### PR TITLE
Add simple backwards-compatibility for Chapel version 1.18

### DIFF
--- a/Chapel118.chpl
+++ b/Chapel118.chpl
@@ -1,0 +1,29 @@
+//
+// This module is designed to provide some backwards compatibility
+// with Chapel 1.18 for arkouda.
+//
+module Chapel118 {
+  //
+  // TODO: Would be cool / smart if Chapel code could query compiler
+  // version number directly to avoid needing this param and the
+  // last resort overload below...  See Chapel issue #5491.
+  //
+  config param version118 = false;
+
+  // If `version118` is set, forward .contains() on a domain to
+  // .member()
+  //
+  proc _domain.contains(i) where version118 {
+    return this.member(i);
+  }
+
+  //
+  // This is a trick to provide a hint to someone using 1.18 (or
+  // earlier) to throw the -sversion118 flag without breaking 1.19
+  //
+  pragma "last resort"
+  proc _domain.contains(i) {
+    compilerError("Couldn't find <domain>.contains(:"+i.type:string+")\n"+
+                  "Maybe try recompiling with -sversion118?");
+  }
+}

--- a/MultiTypeSymbolTable.chpl
+++ b/MultiTypeSymbolTable.chpl
@@ -5,6 +5,7 @@ module MultiTypeSymbolTable
     use ServerErrorStrings;
     
     use MultiTypeSymEntry;
+    use Chapel118;
 
     // symbol table
     class SymTab


### PR DESCRIPTION
This patch adds a `Chapel118` module that's designed to provide backwards-compatibility for Chapel version 1.18 while systems are transitioning over to Chapel 1.19.  Specifically, it adds an overload of `.contains()` for domains that is enabled when compiling with the `-sversion118` flag.  I don't know that this is necessarily code that should be merged, but since it came up in conversation and was easy to implement, I thought I'd open a pull request for it.  I've also used the line below to tag it to the issue I created such that if/when the pull request is merged, the issue should be closed.

Resolves #2.