### PR TITLE
Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+arkouda_server


### PR DESCRIPTION
The .gitignore file is used to have commands line `git status` ignore certain files.  For now, I've just asked it to ignore the arkouda_server binary after it's been built.