### PR TITLE
Do scans on arrays of bools directly

### DIFF
--- a/IndexingMsg.chpl
+++ b/IndexingMsg.chpl
@@ -128,8 +128,7 @@ module IndexingMsg
             when (DType.Int64, DType.Bool) {
                 var e = toSymEntry(gX,int);
                 var truth = toSymEntry(gIV,bool);
-                var itruth: [truth.aD] int = truth.a:int; // make a copy of bools as ints blah!
-                var iv: [truth.aD] int = (+ scan itruth);
+                var iv: [truth.aD] int = (+ scan truth.a);
                 var pop = iv[iv.size-1];
                 if v {writeln("pop = ",pop,"last-scan = ",iv[iv.size-1]);try! stdout.flush();}
                 var a = makeDistArray(pop, int);
@@ -150,8 +149,7 @@ module IndexingMsg
             when (DType.Float64, DType.Bool) {
                 var e = toSymEntry(gX,real);
                 var truth = toSymEntry(gIV,bool);
-                var itruth: [truth.aD] int = truth.a:int; // make a copy of bools as ints blah!
-                var iv: [truth.aD] int = (+ scan itruth);
+                var iv: [truth.aD] int = (+ scan truth.a);
                 var pop = iv[iv.size-1];
                 if v {writeln("pop = ",pop,"last-scan = ",iv[iv.size-1]);try! stdout.flush();}
                 var a = makeDistArray(pop, real);
@@ -172,8 +170,7 @@ module IndexingMsg
             when (DType.Bool, DType.Bool) {
                 var e = toSymEntry(gX,bool);
                 var truth = toSymEntry(gIV,bool);
-                var itruth: [truth.aD] int = truth.a:int; // make a copy of bools as ints blah! to get around scan issue
-                var iv: [truth.aD] int = (+ scan itruth);
+                var iv: [truth.aD] int = (+ scan truth.a);
                 var pop = iv[iv.size-1];
                 if v {writeln("pop = ",pop,"last-scan = ",iv[iv.size-1]);try! stdout.flush();}
                 var a = makeDistArray(pop, bool);


### PR DESCRIPTION
I could've sworn I tried this when we first ran into issue #13, but while working on making scan of expressions like `A:int` parallel and wrestling with some unexpected gotchas there, I ended up going back to simply scanning the array of bools without a cast and found that it worked.  Hence this PR which gets rid of the temporary arrays of ints.

Note that while I think this resolves issue #13, I don't mean to suggest that scans of expressions like `A:int` shouldn't also work and result in parallel execution.  I'll continue to work that over in chapel-lang/chapel/issues/12707

Resolves #13.