### PR TITLE
Refactor cut-and-paste code in histogramMsg

### DIFF
--- a/MsgProcessing.chpl
+++ b/MsgProcessing.chpl
@@ -165,51 +165,32 @@ module MsgProcessing
         var gEnt: borrowed GenSymEntry = st.lookup(name);
         if (gEnt == nil) {return unknownSymbolError("histogram",name);}
 
+        proc histogramHelper(type t) {
+          var e = toSymEntry(gEnt,t);
+          var aMin = min reduce e.a;
+          var aMax = max reduce e.a;
+          var binWidth:real = (aMax - aMin):real / bins:real;
+          if v {try! writeln("binWidth %r ".format(binWidth)); try! stdout.flush();}
+          var hD = makeDistDom(bins);
+          var atomicHist: [hD] atomic int;
+          // count into atomic histogram
+          forall v in e.a {
+            var vBin = ((v - aMin) / binWidth):int;
+            if v == aMax {vBin = bins-1;}
+            //if (v_bin < 0) | (v_bin > (bins-1)) {try! writeln("OOB");try! stdout.flush();}
+            atomicHist[vBin].add(1);
+          }
+          var hist = makeDistArray(bins,int);
+          // copy from atomic histogram to normal histogram
+          [(e,ae) in zip(hist, atomicHist)] e = ae.read();
+          if v {try! writeln("hist =",hist); try! stdout.flush();}
+
+          st.addEntry(rname, new shared SymEntry(hist));
+        }
+
         select (gEnt.dtype) {
-            when (DType.Int64) {
-                var e = toSymEntry(gEnt,int);
-                var aMin = min reduce e.a;
-                var aMax = max reduce e.a;
-                var binWidth:real = (aMax - aMin):real / bins:real;
-                if v {try! writeln("binWidth %r ".format(binWidth)); try! stdout.flush();}
-                var hD = makeDistDom(bins);
-                var atomicHist: [hD] atomic int;
-                // count into atomic histogram
-                forall v in e.a {
-                    var vBin = ((v - aMin) / binWidth):int;
-                    if v == aMax {vBin = bins-1;}
-                    //if (v_bin < 0) | (v_bin > (bins-1)) {try! writeln("OOB");try! stdout.flush();}
-                    atomicHist[vBin].add(1);
-                }
-                var hist = makeDistArray(bins,int);
-                // copy from atomic histogram to normal histogram
-                [(e,ae) in zip(hist, atomicHist)] e = ae.read();
-                if v {try! writeln("hist =",hist); try! stdout.flush();}
-                
-                st.addEntry(rname, new shared SymEntry(hist));
-            }
-            when (DType.Float64) {
-                var e = toSymEntry(gEnt,real);
-                var aMin = min reduce e.a;
-                var aMax = max reduce e.a;
-                var binWidth:real = (aMax - aMin):real / bins:real;
-                if v {try! writeln("binWidth %r ".format(binWidth)); try! stdout.flush();}
-                var hD = makeDistDom(bins);
-                var atomicHist: [hD] atomic int;
-                // count into atomic histogram
-                forall v in e.a {
-                    var vBin = ((v - aMin) / binWidth):int;
-                    if v == aMax {vBin = bins-1;}
-                    //if (v_bin < 0) | (v_bin > (bins-1)) {try! writeln("OOB");try! stdout.flush();}
-                    atomicHist[vBin].add(1);
-                }
-                var hist = makeDistArray(bins,int);
-                // copy from atomic histogram to normal histogram
-                [(e,ae) in zip(hist, atomicHist)] e = ae.read();
-                if v {try! writeln("hist =",hist); try! stdout.flush();}
-                
-                st.addEntry(rname, new shared SymEntry(hist));
-            }
+            when (DType.Int64) do histogramHelper(int);
+            when (DType.Float64) do histogramHelper(real);
             otherwise {return notImplementedError("histogram",gEnt.dtype);}
         }
         


### PR DESCRIPTION
This does a refactor of the histogram code to avoid code duplications
with minor variations in the datatype.  The approach I took was to
write a nested procedure (to avoid having to pass arguments because
I'm lazy) that only takes a single 'type' argument which is used to
do the casting.