### PR TITLE
Give type to [MultiType]SymEntry's 'aD' field

### DIFF
--- a/MultiTypeSymEntry.chpl
+++ b/MultiTypeSymEntry.chpl
@@ -77,7 +77,7 @@ module MultiTypeSymEntry
     // cast the symbol entry of the right type and return it
     // blah too much type inference still for my taste
     inline proc toSymEntry(gse: borrowed GenSymEntry, type etype) {
-        return gse: SymEntry(etype, makeDistDomType(gse.size));
+        return gse: SymEntry(etype);
     }
 
     // 1.18 version
@@ -116,8 +116,9 @@ module MultiTypeSymEntry
         // etype is different from dtype (chapel vs numpy)
         type etype;
 
-        // aD which is suppose to hold the domain is now a completely generic field
-        var aD;
+        // 'aD' is the distributed domain for 'a' whose value and type
+        // are defined by makeDistDom() to support varying distributions
+        var aD: makeDistDom(size).type;
         var a: [aD] etype;
         
         // this one takes length and element type


### PR DESCRIPTION
This makes the declaration of `SymEntry.aD` more in the style that
Mike originally wanted to write it.  I'm embarrassed I didn't think of
doing this when we were originally discussing it.  The idea is to pass
the actual 'size' in for the computation of `aD`'s type rather than
passing in '0' as a (white lie) placeholder as Mike was doing before.

To see why Chapel requires this, consider the following analogy:

```chapel
proc makeArr(size) {
  var A: [1..size] real;
  return A;
}

var A: makeArr(0).type = makeArr(3);
writeln(A);
```

if we think of 'makeArr(0).type' as only evaluating to A's static
(C-like) type rather than its full Chapel type, then it seems like we
might be able to get away with this.  But in reality, this is
essentially a long-form way of writing the following:

```chapel
var A: [1..0] real = [0.0, 0.0, 0.0];
```

which doesn't make sense because we're declaring a 0-element array and
then trying to assign a 3-element array to it.  So it fails in the same
way and would need to be rewritten as:

```chapel
var A: makeArr(3).type = makeArr(3);
```

or more generally,

```chapel
var A: makeArr(size).type = makeArr(size);
```

The key here is to keep in mind that type definitions in Chapel (the
stuff between the ':' and '=' or ';' that describes a variable) mixes
static (type / param) and dynamic (const / var) information.  For
example, the array's type definition here includes its size and
(implicitly) the identity of its domain.

Similarly, a domain's type definition is composed of values that
characterize its distribution such as the distribution's identity and
defining values (bounding box for Block, startIdx for Cyclic).  Thus,
by setting the type of 'aD' to be 'makeDistDom(0)' we weren't just
saying something about the static (C-like) types of 'aD', but also
something about its distribution and distribution's values.  So, as
with the array example above, if we set the type based on
'makeDistDom(size)' then we get the behavior we'd expect.

If desired, we could also write the declaration as:

```chapel
const aD = makeDistDom(size);
```

which has the same effect of constraining the type of 'aD' to be
'makeDistDom(size).type' without the repetition of code.

The (long-game) rationale for these choices in Chapel is that by
giving the compiler the ability to see that multiple domains or arrays
share a single distribution, it gives it knowledge about the relative
alignment of those data structures, giving it semantic information
about when communication is or is not needed.  Whereas if we don't
link arrays to a specific domain, or domains to a specific
distribution, we compromise that ability.