### PR TITLE
Remove apparent redundant initialization of 'a' field

### DIFF
--- a/MultiTypeSymEntry.chpl
+++ b/MultiTypeSymEntry.chpl
@@ -125,7 +125,7 @@ module MultiTypeSymEntry
             super.init(etype, len);
             this.etype = etype;
             this.aD = makeDistDom(len);
-            this.a = makeDistArray(len, etype);
+            // this.a uses default initialization
         }
 
         // this one takes an array of a type


### PR DESCRIPTION
While looking through this code, I noticed that the initialization of
the 'a' field is essentially duplicating what would happen
automatically for that field, and in a more expensive way (by creating
a temporary distributed array and returning it from a function).
While it's reasonable to assume that this might eventually be
optimized away, I'm fairly certain it wouldn't be today and that
relying on the default initialization will result in better
performance when creating a bunch of SymEntry's (though I didn't
attempt to quantify it).