### PR TITLE
Apply 'try!' to cast operator to support chapel-1.20.0-alpha-2019-07-10

### DIFF
--- a/MultiTypeSymEntry.chpl
+++ b/MultiTypeSymEntry.chpl
@@ -78,7 +78,7 @@ module MultiTypeSymEntry
     /* cast the symbol entry of the right type and return it
        blah too much type inference still for my taste */
     inline proc toSymEntry(gse: borrowed GenSymEntry, type etype) {
-        return gse: SymEntry(etype);
+        return try! gse: borrowed SymEntry(etype);
     }
 
     /* 1.18 version print out localSubdomains */


### PR DESCRIPTION
@mhmerrill: This is a change I've been applying to recent versions of arkouda to get it compiling with our master branch for the past month or two.  It's a big hammer in that I'm asking the program to halt (via `try!` if the cast fails rather than catching the error and trying to be smarter / more elegant about it).

The other thing I had to do was to throw `--instantiate-max 2048` on the `chpl` command line.  I'm not sure whether that's something you've been doing as well that I've forgotten about, or if something has changed on master to require this.  We seem to be making lots and lots of copies of the `isArray()` routine which run afoul of the current default maximum number of instantiations (256), and I'm not sure whether it's because they're all necessary or a sign that something's not quite right.