### PR TITLE
Add explicit `in` intent to SymTab.addEntry(_, entry)

### DIFF
--- a/MultiTypeSymbolTable.chpl
+++ b/MultiTypeSymbolTable.chpl
@@ -64,7 +64,7 @@ module MultiTypeSymbolTable
         :arg entry: Generic Sym Entry to convert
         :type entry: GenSymEntry
         */
-        proc addEntry(name: string, entry: shared GenSymEntry) {
+        proc addEntry(name: string, in entry: shared GenSymEntry) {
             if (tD.contains(name))
             {
                 if (v) {writeln("redefined symbol ",name);try! stdout.flush();}


### PR DESCRIPTION
Address changes from chapel-lang/chapel#13447 wherein generic managed classes were changed from default intent `in` to `const ref`.