### PR TITLE
GroupBy defaults to global vs. per-locale

### DIFF
--- a/arkouda.py
+++ b/arkouda.py
@@ -897,7 +897,7 @@ class GroupBy:
     Reductions = frozenset(['sum', 'prod', 'mean',
                             'min', 'max', 'argmin', 'argmax',
                             'nunique', 'any', 'all'])
-    def __init__(self, keys, per_locale=True):
+    def __init__(self, keys, per_locale=False):
         '''Group <keys> by value, usually in preparation for grouping
         and aggregating the values of another array via the
         .aggregate() method. Return a GroupBy object that stores the


### PR DESCRIPTION
Given recent changes in the groupby-optimization branch, the default GroupBy strategy should be to do a global sort, rather than a per-locale sort.