### PR TITLE
Chapel 1.20 Prep: Update `addEntry()` to use `in` intent for `entry`

### DIFF
--- a/MultiTypeSymbolTable.chpl
+++ b/MultiTypeSymbolTable.chpl
@@ -64,7 +64,7 @@ module MultiTypeSymbolTable
         :arg entry: Generic Sym Entry to convert
         :type entry: GenSymEntry
         */
-        proc addEntry(name: string, entry: shared GenSymEntry) {
+        proc addEntry(name: string, in entry: shared GenSymEntry) {
             if (tD.contains(name))
             {
                 if (v) {writeln("redefined symbol ",name);try! stdout.flush();}


### PR DESCRIPTION
[Note: this change works with Chapel 1.19 as well]

In Chapel 1.20, `shared` and `owned` types will have `const ref`
intent by default in order to avoid unnecessary (in most cases) accidental
ownership transfers or reference count bumps.  In Chapel 1.19, these
types had `in` intent by default which resulted in other challenges
and surprises, which is why the language change is occurring.

Here, I've inserted an explicit `in` intent for the `entry` argument
in `addEntry()` to preserve the historic behavior and avoid an error
message that otherwise comes up in Chapel 1.20:

  error: value from coercion passed to const ref formal 'x'

The coercion that this is referring to relates to the passing of
`new shared SymEntry()` to a formal of type `const ref GenSymEntry`
due to it being a subclass.  There is some question as to whether a
non-lvalue instance of a subclass _should_ be able to be passed to a 
`const ref` formal of the parent class type like this since intuitively, it
seems like it should "just work."   But unfortunately, this is not supported
in Chapel at present (see issue https://github.com/chapel-lang/chapel/issues/8489
where the general consensus seems to be that we should support this
behavior, but that it will require some effort).

(Aside: My emacs was having trouble with linefeeds in this file and
seemed to auto-identify it as a DOS file for some reason...  I'm
not fully convinced that I haven't made things worse.  If DOS isn't
intended, it might be worthwhile to run dos2unix across all the
`*.chpl` files in a separate commit).