### PR TITLE
Fix Makefile error due to missing Makefile.paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 # Makefile for Arkouda
 ARKOUDA_MAIN_MODULE := arkouda_server
 
+.PHONY: default
+default: $(ARKOUDA_MAIN_MODULE)
+
 CHPL := chpl
 CHPL_FLAGS += --print-passes
 CHPL_FLAGS += --ccflags="-Wno-incompatible-pointer-types" --cache-remote --instantiate-max 1024 --fast
@@ -12,18 +15,22 @@ CHPL_FLAGS += -I$(1)/include -L$(1)/lib --ldflags="-Wl,-rpath=$(1)/lib"
 endef
 # Usage: $(eval $(call add-path,/home/user/anaconda3/envs/arkouda))
 #                               ^ no space after comma
--include Makefile.paths # Add entries here.
+-include Makefile.paths # Add entries to this file.
 
 # System Environment
 ifdef LD_RUN_PATH
 CHPL_FLAGS += --ldflags="-Wl,-rpath=$(LD_RUN_PATH)"
 endif
 
-.PHONY: all clean
+.PHONY: all
 all: $(ARKOUDA_MAIN_MODULE)
 
-$(ARKOUDA_MAIN_MODULE): $(shell find src/ -type f -name '*.chpl') Makefile #Makefile.*
+Makefile.paths:
+	touch $@
+
+$(ARKOUDA_MAIN_MODULE): $(shell find src/ -type f -name '*.chpl') Makefile Makefile.paths
 	$(CHPL) $(CHPL_FLAGS) src/$(ARKOUDA_MAIN_MODULE).chpl
 
+.PHONY: clean
 clean:
 	$(RM) $(ARKOUDA_MAIN_MODULE) $(ARKOUDA_MAIN_MODULE)_real


### PR DESCRIPTION
This PR fixes the previous issue in #79 (Makefile error caused by missing Makefile.paths). The solution is to create / touch Makefile.paths if it doesn't already exist. The user is then free to modify that file and it won't be reported as dirty due to .gitignore as I have originally intended.