### PR TITLE
Add util/git: `date` and `hash-from-date`

### DIFF
--- a/util/git/README.md
+++ b/util/git/README.md
@@ -1,0 +1,27 @@
+# Git Utils
+
+Git scripts to assist in managing any Git repository.
+
+To use, simply run a script inside any Git repository. Optionally, you can
+install the scripts into `git` by adding this directory to your `PATH`
+environment variable in order to call a script via e.g., `git date`.
+
+
+## git-date
+
+Arguments: `[Branch (HEAD)]`
+
+Output a time point for a commit reference.
+
+## git-hash-from-date
+
+Arguments: `Date [Branch (origin/master)] [Options]`
+
+Output a commit's hash for a time point.
+
+- `Date` must be any format that Git accepts via `--date`. See `git help show`,
+  `PRETTY FORMATS` for valid committer's-date formats.
+
+- `Branch` can be any valid commit reference.
+
+- `Options` are optional flags accepted by `git rev-list`.

--- a/util/git/git-date
+++ b/util/git/git-date
@@ -1,0 +1,1 @@
+git show --no-patch --no-notes --pretty='%cI' $@

--- a/util/git/git-hash-from-date
+++ b/util/git/git-hash-from-date
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -o errexit -o pipefail -o noclobber -o nounset
+
+Branch="origin/master"
+
+min_args=1
+if (( $# < min_args )); then
+    >&2 echo "Usage: git hash-from-date Date [Branch] [Options]"
+    >&2 echo "  Date can be any format"
+    >&2 echo "  Branch can be any commit reference (default: $Branch)"
+    >&2 echo "  Options that are accepted by 'git rev-list'"
+    >&2 echo
+    exit 1
+fi
+Date="$1"
+ObservedRequiredArgs=$min_args
+if (( $# >= 2 )) && ! [[ "$2" =~ '--' ]]; then
+    ((ObservedRequiredArgs++))
+    Branch="$2"
+fi
+shift $ObservedRequiredArgs
+
+git rev-list -1 --before="Date" "$Branch" $@


### PR DESCRIPTION
Add tools to help manage any Git repository. Two scripts are provided along with a README.md.

To "install" these scripts into `git`, simply add the util/git dir to the `PATH` env var.

## git-date
`git-date` is used to simply grab a timestamp for any commit. The time format was chosen so it could be easily copied, but any Git-accepted time format will work. You can override the time format with anything that `git show` will accept (`--format`).
Examples:
```terminal
$ git date
2019-08-20T20:07:37-04:00 # The timestamp of this PR's latest commit.

$ git date origin/master
2019-08-20T19:37:53-04:00

$ git date origin/master --format='%cd'
Tue Aug 20 19:37:53 2019 -0400
```

## git-hash-from-date
`git-hash-from-date` is used to get a commit's hash that is before or on a given timestamp.
Examples:
```terminal
$ git hash-from-date 2019-08-20T19:37:53-04:00
f150e04047022b39773e6fd0035a43e910785899

$ git show origin/master --format='%H'
f150e04047022b39773e6fd0035a43e910785899 # Verification that it works.

$ git hash-from-date 'Tue Aug 20 19:37:53 2019 -0400'
f150e04047022b39773e6fd0035a43e910785899

$ git hash-from-date '0 minutes ago' # First commit *before or on* this relative time point.
f150e04047022b39773e6fd0035a43e910785899
```

The output from `git-date` could be made fancier, but I wanted to avoid complicating things so that the two commands were reversible.
Example:
```terminal
$ git hash-from-date "$(git date d69ec0d)" util-git
d69ec0d9e2e91959bccc06e723e94fd302faa168
```
Note that `util-git` has to be provided as the base Branch to start history traversal from. Otherwise, the default is origin/master (and in this example, I'm using this PR's commits which haven't been committed to origin/master yet). Otherwise, you'll get the origin/master hash, which is technically correct because the timestamp on that commit is *before* the timestamp of this PR.