### PR TITLE
Uncomment 'use Sort only;' line

### DIFF
--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -22,7 +22,7 @@ module ArgSortMsg
     use UnorderedCopy;
     use UnorderedAtomics;
 
-    //use Sort only;
+    use Sort only;
     use RadixSortLSD;
     
     // thresholds for different sized sorts


### PR DESCRIPTION
In Chapel 1.19 and prior, a top-level module did not require a 'use'
statement if the compiler was already aware of the module, either
through it being named on the command-line, or through another
module 'use'ing it first.  In Chapel 1.20, a top-level module like
'Sort' must be `use`d before it (or its contents) can be referred
to as discussed in https://github.com/chapel-lang/chapel/issues/13523.

This change uncomments the previous `use Sort only;` line which wasn't
strictly necessary in the old world (because other things `use Sort`
in a typical Chapel compilation), but is now.

Note that with this change, Arkouda compiles with the `--legacy-classes`
flag on the upcoming Chapel 1.20.0 release (and that this change won't
break compatibility with 1.19.0, so can be merged anytime).