### PR TITLE
Make `shiftDouble` static to avoid C warning

### DIFF
--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -35,7 +35,7 @@ module RadixSortLSD
     }
 
     extern {
-      unsigned long long shiftDouble(double key, long long rshift) {
+      static unsigned long long shiftDouble(double key, long long rshift) {
 	// Reinterpret the bits of key as an unsigned 64-bit int (u long long)
 	// Unsigned because we want to left-extend with zeros
 	unsigned long long intkey = * (unsigned long long *) &key;


### PR DESCRIPTION
With sufficiently strict C warnings, the declaration of `shiftDouble()`
as written can generate a warning like:

```
./RadixSortLSD.chpl:38:26: error: no previous prototype for function
      'shiftDouble' [-Werror,-Wmissing-prototypes]
            unsigned long long shiftDouble(double key, long long rshift) {
```

This PR changes it to a static function to squash the warning.  @mppf
points out that it might also be appropriate to make it `static
inline` but I have not done that here.