### PR TITLE
speed up expandKeys

### DIFF
--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -939,14 +939,9 @@ module ReductionMsg
     /* } */
 
     proc expandKeys(kD, segments: [?sD] int): [kD] int {
-      var keys: [kD] int;
-      forall (s, i) in zip(segments, sD) {
-	if (i < sD.high) {
-	  keys[s..segments[i+1]-1] = i;
-	} else {
-	  keys[s..kD.high] = i;
-	}
-      }
+      var truth: [kD] bool;
+      [i in segments] unorderedCopy(truth[i], true);
+      var keys = (+ scan truth) - 1;
       return keys;
     }
 


### PR DESCRIPTION
To test, build UnitTestGroupby.chpl and run
```bash
test-bin/UnitTestGroupby -nl <num_locales> --LEN=1_000_000 --NVALS=4_000_000_000 --NKEYS=4_000_000_000 --OPERATOR=nunique
```