### PR TITLE
Remove Arkouda's dependencies on LLVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,12 @@ interactive session.
 
 ## Requirements:
  * requires chapel 1.20.0 with the --legacy-classes flag
- * requires llvm version of Chapel parser to support HDF5 I/O
  * requires zeromq version >= 4.2.5, tested with 4.2.5 and 4.3.1
  * requires python 3.6 or greater
 
 ```bash
 #it should be simple to get things going on a mac
 #can't use brew install chapel anymore
-#need to build with export CHPL_LLVM=llvm
 #on my mac build chapel in my home directory with these settings...
 #I don't understand them all but they seem to work
 export CHPL_HOME=~/chapel/chapel-1.20.0
@@ -66,7 +64,6 @@ export GASNET_MASTERIP=127.0.0.1
 # Set these to help with oversubscription...
 export QT_AFFINITY=no
 export CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION=1
-export CHPL_LLVM=llvm
 cd $CHPL_HOME
 make
 # you can also install these other packages with brew

--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -34,6 +34,13 @@ module RadixSortLSD
         return ((key >> rshift) & maskDigit);
     }
 
+    proc shiftDouble(in key: real(64), rshift: int(64)) {
+      const ptrToReal = c_ptrTo(key);
+      const ptrToULL = ptrToReal: c_ptr(int(64));
+      const intkey = ptrToULL.deref();
+      return (intkey >> rshift);
+    }
+    /*
     extern {
       static inline unsigned long long shiftDouble(double key, long long rshift) {
 	// Reinterpret the bits of key as an unsigned 64-bit int (u long long)
@@ -42,6 +49,7 @@ module RadixSortLSD
 	return (intkey >> rshift);
       }
     }
+    */
     
     inline proc getDigit(key: real, rshift: int): int {
       var shiftedKey: uint = shiftDouble(key: c_double, rshift: c_longlong): uint;


### PR DESCRIPTION
HDF5 no longer requires LLVM to build as of Chapel 1.20.0, so remove
that line from the README.  The extern block in RadixSortLSD does need
LLVM, but it seems that routine could be written in Chapel using C interop
features as done here.  So Arkouda shouldn't need LLVM anymore!

This also means that arkouda can be built with a homebrew installation of
Chapel (single locale only... no gasnet support in homebrew yet).

TODO:
- [X] Make sure sort unit tests still pass
- [X] I'm doing a spot-check to make sure I didn't add overhead to the sort time as @mhmerrill requested
- [x] @reuster986 should read the code to be sure nothing got lost in translation (though maybe that's paranoid
- [x] @mhmerrill and/or @reuster986 may want to check timings on a larger run / more stable system than I did