### PR TITLE
Fix doc generation for RadixSortLSD

### DIFF
--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -40,6 +40,7 @@ module RadixSortLSD
       const intkey = ptrToULL.deref();
       return (intkey >> rshift);
     }
+    pragma "no doc" // Bug: chapel-lang/chapel#14250
     /*
     extern {
       static inline unsigned long long shiftDouble(double key, long long rshift) {


### PR DESCRIPTION
`chpldoc` fails to generate documentation due to misinterpretation of a commented-out block of code as a document comment on the next function. Add pragma to have chpldoc ignore the comment until it is properly fixed.