### PR TITLE
Remove a pair of flags from the Makefile's `chpl` command-line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ VERBOSE ?= 0
 
 CHPL := chpl
 CHPL_DEBUG_FLAGS += --print-passes
-CHPL_FLAGS += --ccflags="-Wno-incompatible-pointer-types" --cache-remote --instantiate-max 1024 --fast --legacy-classes
+CHPL_FLAGS += --cache-remote --fast --legacy-classes
 CHPL_FLAGS += -lhdf5 -lhdf5_hl -lzmq
 
 # add-path: Append custom paths for non-system software.


### PR DESCRIPTION
Specifically:

* It removes the `--instantiate-max` flag which is no longer required as a workaround now that we're on version 1.20
* I _believe_ the -Wno-incompatible-pointer types should no longer be required, though I'm not positive I know why it was added to begin with...  @mhmerrill, @reuster986, do either of you recall?
