### PR TITLE
Makefile: add-path now supports Darwin `ld`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,9 @@ CHPL_FLAGS += --ccflags="-Wno-incompatible-pointer-types" --cache-remote --insta
 CHPL_FLAGS += -lhdf5 -lhdf5_hl -lzmq
 
 # add-path: Append custom paths for non-system software.
+# Note: Darwin `ld` only supports `-rpath <path>`, not `-rpath=<paths>`.
 define add-path
-CHPL_FLAGS += -I$(1)/include -L$(1)/lib --ldflags="-Wl,-rpath=$(1)/lib"
+CHPL_FLAGS += -I$(1)/include -L$(1)/lib --ldflags="-Wl,-rpath,$(1)/lib"
 endef
 # Usage: $(eval $(call add-path,/home/user/anaconda3/envs/arkouda))
 #                               ^ no space after comma


### PR DESCRIPTION
The MacOS/Darwin linker `ld` is an old BSD version and doesn't support the newer `-rpath=<paths>` syntax used by contemporary linkers. The add-path macro in the Makefile only needs a single path, so this PR changes it to emit `-rpath <path>` instead.

I did not change the rpath emission for `LD_RUN_PATH` because that environment variable is only relevant for not-Darwin (e.g., Linux) systems. I could add some logic to handle the multiple paths from `LD_RUN_PATH`, but it isn't worth the effort since it isn't likely to come up.

I don't have a MacOS. This should work, but @jwcrandall needs to verify the fix.