### PR TITLE
Use gasnet-smp for CI testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: [chapel, chapel-gasnet]
+        image: [chapel, chapel-gasnet-smp]
     container:
       image: chapel/${{matrix.image}}:1.22.0
     steps:
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: [chapel, chapel-gasnet]
+        image: [chapel, chapel-gasnet-smp]
     container:
       image: chapel/${{matrix.image}}:1.22.0
     steps:


### PR DESCRIPTION
Switch gasnet CI testing from gasnet-udp to gasnet-smp. smp uses shared
memory to communicate instead of going through the kernel via udp. This
improves communication speed. This takes gasnet python CI testing from
45 to 35 minutes.

Part of https://github.com/mhmerrill/arkouda/issues/388