### PR TITLE
Sort-based in1d for Strings

### DIFF
--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -870,6 +870,8 @@ module SegmentedArray {
     return truth;
   }
 
+  private config const in1dAssocSortThreshold = 10**4;
+
   /* Test array of strings for membership in another array (set) of strings. Returns
      a boolean vector the same size as the first array. */
   proc in1d(mainStr: SegString, testStr: SegString, invert=false) throws where useHash {
@@ -888,40 +890,75 @@ module SegmentedArray {
         saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
                                                 "%t seconds".format(t.elapsed())); 
         t.clear();
+    }
+
+    if testStr.size <= in1dAssocSortThreshold {
+      if logLevel == LogLevel.DEBUG {
         saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
-                                           "Making associative domains for test set on each locale");
+                       "Making associative domains for test set on each locale");
         t.start();
-    }
-    // On each locale, make an associative domain with the hashes of the second array
-    // parSafe=false because we are adding in serial and it's faster
-    var localTestHashes: [PrivateSpace] domain(2*uint(64), parSafe=false);
-    coforall loc in Locales {
-      on loc {
-        // Local hashes of second array
-        ref mySet = localTestHashes[here.id];
-        mySet.requestCapacity(testStr.size);
-        const testHashes = testStr.hash();
-        for h in testHashes {
-          mySet += h;
-        }
-        /* // Check membership of hashes in this locale's chunk of the array */
-        /* [i in truth.localSubdomain()] truth[i] = mySet.contains(hashes[i]); */
       }
-    }
-    if logLevel == LogLevel.DEBUG {
-      t.stop(); 
-      saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                             "%t seconds".format(t.elapsed())); 
-      t.clear();
-      saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),      
-                                             "Testing membership"); 
-      t.start();
-    }
-    [i in truth.domain] truth[i] = localTestHashes[here.id].contains(hashes[i]);
-    if logLevel == LogLevel.DEBUG {
+      // On each locale, make an associative domain with the hashes of the second array
+      // parSafe=false because we are adding in serial and it's faster
+      var localTestHashes: [PrivateSpace] domain(2*uint(64), parSafe=false);
+      coforall loc in Locales {
+        on loc {
+          // Local hashes of second array
+          ref mySet = localTestHashes[here.id];
+          mySet.requestCapacity(testStr.size);
+          const testHashes = testStr.hash();
+          for h in testHashes {
+            mySet += h;
+          }
+          /* // Check membership of hashes in this locale's chunk of the array */
+          /* [i in truth.localSubdomain()] truth[i] = mySet.contains(hashes[i]); */
+        }
+      }
+      if logLevel == LogLevel.DEBUG {
         t.stop(); 
         saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                             "%t seconds".format(t.elapsed()));
+                       "%t seconds".format(t.elapsed())); 
+        t.clear();
+        saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),      
+                       "Testing membership"); 
+        t.start();
+      }
+      [i in truth.domain] truth[i] = localTestHashes[here.id].contains(hashes[i]);
+      if logLevel == LogLevel.DEBUG {
+        t.stop(); 
+        saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                       "%t seconds".format(t.elapsed()));
+      }
+    } else {
+      const testHashes = testStr.hash();
+      // Unique the hashes of each array, preserving reverse index for main
+      (umain, cmain, revIdx) = uniqueSortWithInverse(hashes);
+      utest = uniqueSort(testHashes);
+      // Concat unique hashes
+      var combinedDom = makeDistDom(umain.size + utest.size);
+      var combined: [combinedDom] 2*uint(64);
+      combined[combinedDom.interior(-umain.size)] = umain;
+      combined[combinedDom.interior(utest.size)] = utest;
+      // Sort
+      var iv = radixSortLSD_ranks(combined);
+      var sorted: [combinedDom] 2*uint(64);
+      forall (i, s) in zip(iv, sorted) with (var agg = newSrcAggregator(2*uint(64))) {
+        agg.copy(s, combined[i]);
+      }
+      // Find duplicates
+      // Dupe parallels unique hashes of mainStr and is true when value is in testStr
+      var dupe: [combinedDom] bool = false;
+      forall (sortedIdx, origIdx, s) in zip(combinedDom, iv, sorted) with (var agg = newDstAggregator(bool)){
+        // When next hash is same as current, string exists in both arrays
+        if i < combinedDom.high && (s == sorted[sortedIdx+1]){
+          // Use the iv to scatter back to pre-sorted order
+          agg.copy(dupe[origIdx], true);
+        }
+      }
+      // Use revIdx to broadcast dupe to original non-unique domain
+      forall (t, ri) in zip(truth, revIdx) with (var agg = newSrcAggregator(bool)) {
+        agg.copy(t, dupe[ri]);
+      }
     }
     return truth;
   }

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -127,7 +127,7 @@ module ServerConfig
     Get the physical memory available on this locale
     */ 
     proc getPhysicalMemHere() {
-        use MemDiagnostics;
+        use Memory.Diagnostics;
         return here.physicalMemory();
     }
 
@@ -135,7 +135,7 @@ module ServerConfig
     Get the memory used on this locale
     */
     proc getMemUsed() {
-        use MemDiagnostics;
+        use Memory.Diagnostics;
         return memoryUsed();
     }
 

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -127,7 +127,7 @@ module ServerConfig
     Get the physical memory available on this locale
     */ 
     proc getPhysicalMemHere() {
-        use Memory.Diagnostics;
+        use MemDiagnostics;
         return here.physicalMemory();
     }
 
@@ -135,7 +135,7 @@ module ServerConfig
     Get the memory used on this locale
     */
     proc getMemUsed() {
-        use Memory.Diagnostics;
+        use MemDiagnostics;
         return memoryUsed();
     }
 

--- a/src/Unique.chpl
+++ b/src/Unique.chpl
@@ -427,10 +427,10 @@ module Unique
 
     :returns: ([] int, [] int)
     */
-    proc uniqueSort(a: [?aD] int, param needCounts = true) {
+    proc uniqueSort(a: [?aD] ?eltType, param needCounts = true) {
         if (aD.size == 0) {
             try! uLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"zero size");
-            var u = makeDistArray(0, int);
+            var u = makeDistArray(0, eltType);
             if (needCounts) {
                 var c = makeDistArray(0, int);
                 return (u,c);
@@ -439,7 +439,7 @@ module Unique
             }
         } 
 
-        var sorted: [aD] int;
+        var sorted: [aD] eltType;
         if (AryUtil.isSorted(a)) {
             sorted = a; 
         }
@@ -456,23 +456,23 @@ module Unique
         }
     }
 
-    proc uniqueSortWithInverse(a: [?aD] int) {
+    proc uniqueSortWithInverse(a: [?aD] ?eltType) {
         if (aD.size == 0) {
             try! uLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"zero size");
-            var u = makeDistArray(0, int);
+            var u = makeDistArray(0, eltType);
             var c = makeDistArray(0, int);
             var inv = makeDistArray(0, int);
             return (u, c, inv);
         }
         var perm: [aD] int;
-        var sorted: [aD] int;
+        var sorted: [aD] eltType;
         if (AryUtil.isSorted(a)) {
             [(i, p) in zip(aD, perm)] p = i;
             sorted = a; 
         }
         else {
             perm = radixSortLSD_ranks(a);
-            forall (p, s) in zip(perm, sorted) with (var agg = newSrcAggregator(int)) {
+            forall (p, s) in zip(perm, sorted) with (var agg = newSrcAggregator(eltType)) {
                 agg.copy(s, a[p]);
             }
         }
@@ -491,7 +491,7 @@ module Unique
         return (u, c, inv);
     }
     
-    proc uniqueFromSorted(sorted: [?aD] int, param needCounts = true) {
+    proc uniqueFromSorted(sorted: [?aD] ?eltType, param needCounts = true) {
         var truth: [aD] bool;
         truth[0] = true;
         [(t, s, i) in zip(truth, sorted, aD)] if i > aD.low { t = (sorted[i-1] != s); }
@@ -499,7 +499,7 @@ module Unique
         if (allUnique == aD.size) {
            try!  uLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                     "early out already unique");
-            var u = makeDistArray(aD.size, int);
+            var u = makeDistArray(aD.size, eltType);
             u = sorted; // array is already unique
             if (needCounts) {
                 var c = makeDistArray(aD.size, int);
@@ -516,7 +516,7 @@ module Unique
         try! uLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"pop = %t".format(pop));
 
         var segs = makeDistArray(pop, int);
-        var ukeys = makeDistArray(pop, int);
+        var ukeys = makeDistArray(pop, eltType);
         
         // segment position... 1-based needs to be converted to 0-based because of inclusive-scan
         // where ever a segment break (true value) is... that index is a segment start index
@@ -528,7 +528,10 @@ module Unique
         }
         // pull out the first key in each segment as a unique key
         // unique keys guaranteed to be sorted because keys are sorted
-        [i in segs.domain] ukeys[i] = sorted[segs[i]];
+        forall (i, uk, seg) in zip(segs.domain, ukeys, segs) with (var agg = newSrcAggregator(eltType)) {
+          agg.copy(uk, sorted[seg]);
+        }
+        // [i in segs.domain] ukeys[i] = sorted[segs[i]];
 
         if (needCounts) {
             var counts = makeDistArray(pop, int);

--- a/test/UnitTestIn1d.chpl
+++ b/test/UnitTestIn1d.chpl
@@ -99,7 +99,11 @@ prototype module UnitTestIn1d
         d.start();
         // returns a boolean vector
         var truth = in1d(str1, str2);
-        d.stop("in1d");
+        d.stop("in1d (associative domain)");
+        d.start();
+        var truth2 = in1d(str1, str2, forceSort=true);
+        d.stop("in1d (sort-based)");
+        writeln("Results of both strategies match? >>> ", && reduce (truth == truth2), " <<<");
         if printExpected then writeln("<<< #str1[i] in str2 = ", + reduce truth, " (expected ", expected, ")");try! stdout.flush();
         if thorough {
           var res: [truth.domain] bool;

--- a/test/UnitTestIn1d.good
+++ b/test/UnitTestIn1d.good
@@ -2,3 +2,4 @@
 >>> in1dSort
 Results of both strategies match? >>> true <<<
 >>> in1d
+Results of both strategies match? >>> true <<<


### PR DESCRIPTION
Closes #731 

This PR adds a case to in1d with Strings that uses a sort-based strategy when the second "test" array is large. This should improve scaling on distributed systems. 

The threshold for when this case is activated can be controlled at the command line with `--SegmentedArray.in1dAssocSortThreshold`. The current default is `10**6`, which was chosen by a cursory exploration with a multi-locale build on a laptop. In the future, we should probably benchmark this operation.

The test for correctness of this functionality is in `test/UnitTestIn1d.chpl`, which forces the computation via both the associative and sort-based strategies and then ensures the results agree.