### PR TITLE
Categorical equality bug fix

### DIFF
--- a/tests/categorical_test.py
+++ b/tests/categorical_test.py
@@ -76,6 +76,12 @@ class CategoricalTest(ArkoudaTest):
         
         self.assertTrue((cat == catDupe).all())
         self.assertTrue((cat != catNonDupe).all())
+
+        c1 = ak.Categorical(ak.array(['a', 'b', 'c', 'a', 'b']))
+        c2 = ak.Categorical(ak.array(['a', 'x', 'c', 'y', 'b']))
+        res = (c1 == c2)
+        ans = ak.array([True, False, True, False, True])
+        self.assertTrue((res == ans).all())
         
     def testBinop(self):
         cat = self._getCategorical()


### PR DESCRIPTION
Closes #789 

This PR fixes a bug in `Categorical == Categorical` which would give incorrect output when the categories differed. In this PR, that case is correctly handled, and the unit tests have been extended to cover it.