### PR TITLE
763 improve performance of tohdf msg with strings v2

### DIFF
--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -1485,7 +1485,7 @@ module GenSymIO {
                      var segmentsList : list(int);
 
                      (valuesList, segmentsList) = sliceToValuesAndSegments(A.localSlice(locDom));
-
+                     charArrayList.extend(A.localSlice(locDom));
                      /*
                       * If (1) this locale (idx) contains one string/string segment and (2) ends 
                       * with the null uint(8) char, check to see if the trailingSliceIndex from 
@@ -1510,7 +1510,7 @@ module GenSymIO {
                                      }
                                  } 
                                  gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),   
-                                        'APPENDING WITHtrailingValuesList %t and singleStringTrailingSlice: %t for locale %i'.format(
+                                        'APPENDING WITH trailingValuesList %t and singleStringTrailingSlice: %t for locale %i'.format(
                                         trailingValuesList,singleStringTrailingSlice,here.id));
                              }
                              gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),   
@@ -1521,7 +1521,7 @@ module GenSymIO {
                              charArrayList.insert(0,singleStringTrailingSlice);
                          }
                      }
-                      
+
                      /*
                       * Account for the special case where the following is true about the
                       * current locale (idx):
@@ -1544,13 +1544,14 @@ module GenSymIO {
                              segmentsArrayList.clear();
                          }
                      }
-                      gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),   
+                     segmentsArrayList = generateSegmentsList(charArrayList);
+                     gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),   
                                'final valuesList: %t for %i'.format(valuesList,here.id));
-                      gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                     gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                'final charArrayList %t for %i'.format(charArrayList,here.id));
-                      gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                     gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                'final segmentsList %t for %i'.format(segmentsList,here.id));
-                      gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                     gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                'final segmentsArrayList %t for %i'.format(segmentsArrayList,here.id));
  
                       // Write the finalized valuesList and segmentsList to the hdf5 group

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -1919,11 +1919,11 @@ module GenSymIO {
             var lastSeg = -1;
 
             /*
-             * If the first locale (locale 0), the first segment is at char 0
-             * and the last segment starts after the first null uint(8) char.
-             * Otherwise, find the first occurrence of the null uint(8) char 
-             * and the firstSeg is the next non-null char. The lastSeg is the 
-             * final segsArray element.
+             * If the first locale (locale 0), the first segment is retrieved
+             * via segsArray.front(), corresponding to 0. Otherwise, find the 
+             * first occurrence of the null uint(8) char and the firstSeg is the 
+             * next non-null char. The lastSeg in all cases is the final segsArray 
+             * element retrieved via segsArray.back()
              */
             if idx == 0 {
                 firstSeg = segsArray.front();

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -1444,9 +1444,9 @@ module GenSymIO {
                      charArrayList = new list(adjustCharArrayForTrailingSlice(charArrayList));
                      segmentsArrayList.pop();
                      gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),   
-                               'valuesList: %t for locale %i'.format(valuesList,idx));  
+                               'REMOVED TRAILING VALUES FROM valuesList: %t for locale %i'.format(valuesList,idx));  
                      gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                               'charArray: %t for locale %i'.format(charArray,idx));
+                               'REMOVED TRAILING VALUES FROM charArrayList: %t for locale %i'.format(charArrayList,idx));
                       
                  } else {
                      valuesList.append(NULL_STRINGS_VALUE);    

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -1324,7 +1324,7 @@ module GenSymIO {
                  * the last locale in the Arkouda cluster If so, all of the chars 
                  * from the next locale (idx+1) are shuffled to the current locale (idx).
                  */
-                var leadingSlice: [1..leadingSliceIndices[idx+1]] uint(8);
+                var leadingSlice: [1..leadingSliceIndices[idx+1] - 1] uint(8);
 
                 if leadingSliceIndices[idx+1] > -1 || isLastLocale(idx+1) {
                     on Locales[idx+1] {
@@ -1336,7 +1336,9 @@ module GenSymIO {
                         
                         var localeArray = A.localSlice(locDom);
                         var leadingSliceIndex = leadingSliceIndices[here.id];
-                        leadingSlice = localeArray[1..leadingSliceIndex];                        
+                        var localStart = locDom.first;
+                        var localLeadingSliceIndex = localStart + leadingSliceIndex - 2;
+                        leadingSlice = localeArray[localStart..localLeadingSliceIndex];                        
                         gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                         "leadingSlice: %t for locale %i".format(
                                                  leadingSlice,here.id));                             
@@ -1395,7 +1397,10 @@ module GenSymIO {
                       */
                      (valuesList, segmentsList) = 
                                          adjustForLeadingSlice(leadingSliceIndex, charList);
-                     var adjCharArray = adjustArrayForLeadingSlice(leadingSliceIndex, 
+                     var localStart = locDom.first;
+                     var localLeadingSliceIndex = localStart + leadingSliceIndex - 1;
+
+                     var adjCharArray = adjustArrayForLeadingSlice(localLeadingSliceIndex, 
                                          A.localSlice(locDom));
                      gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),   
                                'valuesList: %t'.format(valuesList));    
@@ -1529,7 +1534,10 @@ module GenSymIO {
                       if !endsWithCompleteString(idx-1) {
                           (valuesList, segmentsList) = 
                                              adjustForLeadingSlice(leadingSliceIndex, charList);
-                          var adjCharArray = adjustArrayForLeadingSlice(leadingSliceIndex, 
+                          var localStart = locDom.first;
+                          var localLeadingSliceIndex = localStart + leadingSliceIndex - 1;
+
+                          var adjCharArray = adjustArrayForLeadingSlice(localLeadingSliceIndex, 
                                          A.localSlice(locDom));
                           gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),   
                                'valuesList: %t'.format(valuesList));    
@@ -2184,7 +2192,7 @@ module GenSymIO {
         t1.clear();
         t1.start();       
 
-        var adjCharArray = charArray[sliceIndex..charArray.size]; 
+        var adjCharArray = charArray[sliceIndex..charArray.size-1]; 
 
         t1.stop();  
         var elapsed = t1.elapsed();
@@ -2237,7 +2245,7 @@ module GenSymIO {
         t1.clear();
         t1.start();  
         
-        var adjCharArray = charArray[1..sliceIndex]; 
+        var adjCharArray = charArray[1..sliceIndex-1]; 
 
         t1.stop();  
         var elapsed = t1.elapsed();

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -1351,7 +1351,7 @@ module GenSymIO {
                       * Since the leading slice was used to complete the last string in
                       * the previous locale (idx-1), slice those chars from the charList
                       */
-                     charList = new list(adjustForLeftShuffle(shuffleLeftIndex,charList,idx));    
+                     charList = new list(adjustForLeftShuffle(shuffleLeftIndex,charList));    
 
                      gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                             'adjusted locale %i for left shuffle to %i'.format(idx,idx-1)); 
@@ -1370,7 +1370,7 @@ module GenSymIO {
                   */
                  if shuffleRightIndex > -1 && isSingleString[idx+1] {
                      charList = new list(adjustForRightShuffle(
-                                                  shuffleRightIndex,charList,idx));
+                                                  shuffleRightIndex,charList));
                      gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                         'adjusted locale %i for right shuffle to locale %i'.format(
                                         idx,idx+1));
@@ -1479,7 +1479,7 @@ module GenSymIO {
                           var localStart = locDom.first;
                           var localLeadingSliceIndex = localStart + shuffleLeftIndex;
                           var leadingCharArray = adjustCharArrayForLeadingSlice(localLeadingSliceIndex, 
-                                         A.localSlice(locDom),locDom.last,idx);
+                                         A.localSlice(locDom),locDom.last);
                           charList = new list(leadingCharArray);  
                           gsLogger.info(getModuleName(),getRoutineName(),getLineNumber(),
                                   'adjusted locale %i for left shuffle to locale %i'.format(
@@ -2004,7 +2004,7 @@ module GenSymIO {
      * slicing leading chars that compose a string started in the previous locale and 
      * returning a new char array.
      */
-    private proc adjustCharArrayForLeadingSlice(sliceIndex, charArray, last, idx) throws { 
+    private proc adjustCharArrayForLeadingSlice(sliceIndex, charArray, last) throws { 
         return charArray[sliceIndex..last]; 
     }    
 
@@ -2013,7 +2013,7 @@ module GenSymIO {
      * to the previous locale by returning a slice containing chars from the shuffleLeftIndex
      * to the end of the charList.
      */
-    private proc adjustForLeftShuffle(shuffleLeftIndex: int, charList, idx: int) throws {
+    private proc adjustForLeftShuffle(shuffleLeftIndex: int, charList) throws {
         return charList[shuffleLeftIndex..charList.size-1];
     }
 
@@ -2023,7 +2023,7 @@ module GenSymIO {
      * the rightShuffleIndex. 
      */
     private proc adjustForRightShuffle(shuffleRightIndex: int, 
-                                               charsList: list(uint(8)), idx : int) throws {        
+                                               charsList: list(uint(8))) throws {        
         return charsList[0..shuffleRightIndex];
     }
 

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -1266,35 +1266,14 @@ module GenSymIO {
                         on Locales[idx-1] {
                             const locDom = A.localSubdomain();
                             var localeArray = A.localSlice(locDom);
-
-                            var t1 = new Time.Timer();
-                            t1.clear();
-                            t1.start(); 
-
                             rightShuffleSlice = localeArray[shuffleRightIndex..localeArray.size-1];
-
-                            t1.stop();  
-                            var elapsed = t1.elapsed();
-                            gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                "Time to generate chars slice shuffled right FROM %i TO locale %i: %.17r".format(
-                                           here.id,idx,elapsed));  
                         }      
-                  
-                        var t1 = new Time.Timer();
-                        t1.clear();
-                        t1.start(); 
-                        
+                                          
                         /* 
                          * Prepend the current locale charsList with the chars shuffled right from 
                          * the previous locale
                          */
                         charList.insert(0,rightShuffleSlice);
-
-                        t1.stop();  
-                        var elapsed = t1.elapsed(); 
-                        gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                            "Time to insert chars shuffled right TO locale %i FROM %i: %.17r".format(
-                                           idx,idx-1,elapsed));  
                     }
                 }
 
@@ -1313,29 +1292,14 @@ module GenSymIO {
                 if shuffleLeftIndices[idx+1] > -1 || isLastLocale(idx+1) {
                     on Locales[idx+1] {
                         const locDom = A.localSubdomain();
-                        var t1 = new Time.Timer();
-                        t1.clear();
-                        t1.start(); 
                         
                         var localeArray = A.localSlice(locDom);
                         var shuffleLeftIndex = shuffleLeftIndices[here.id];
                         var localStart = locDom.first;
                         var localLeadingSliceIndex = localStart + shuffleLeftIndex -2;
+
                         shuffleLeftSlice = localeArray[localStart..localLeadingSliceIndex];    
-                        t1.stop();  
-                        var elapsed = t1.elapsed();
-                        gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                            "Time to generate left shuffle slice FROM locale %i to complete last string IN locale %i: %.17r".format(
-                                                   here.id,idx,elapsed));                     
-                        t1 = new Time.Timer();
-                        t1.clear();
-                        t1.start(); 
                         charList.extend(shuffleLeftSlice);  
-                        t1.stop();  
-                        elapsed = t1.elapsed();
-                        gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                            "Time to extend charList with left shuffle slice to complete last string FOR locale %i: %.17r".format(
-                                                   idx,elapsed)); 
                     }
                 }
 
@@ -1412,17 +1376,7 @@ module GenSymIO {
                       * not contain chars from a string started in the previous locale (idx-1). 
                       * Accordingly, initialize with the current locale slice.
                       */
-                     var t1 = new Time.Timer();
-                     t1.clear();
-                     t1.start(); 
-
                      charList = new list(A.localSlice(locDom));
-
-                     t1.stop();  
-                     var elapsed = t1.elapsed();
-                     gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                            "Time to initialize char list FOR locale %i: %.17r".format(
-                                                   idx,elapsed)); 
 
                      /*
                       * If (1) this locale (idx) contains one string/string segment and (2) ends 
@@ -1439,27 +1393,10 @@ module GenSymIO {
                              on Locales[idx-1] {
                                  const locDom = A.localSubdomain();  
                                  var localeArray = A.localSlice(locDom);
-
-                                 var t1 = new Time.Timer();
-                                 t1.clear();
-                                 t1.start(); 
-                                 shuffleRightSlice = localeArray[shuffleRightIndex..localeArray.size-1];
-                                 t1.stop();  
-                                 var elapsed = t1.elapsed();
-                                 gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                     "Time to generate chars shuffled right to locale %i FROM %i: %.17r".format(
-                                                   idx,idx-1,elapsed)); 
+                                 shuffleRightSlice = localeArray[shuffleRightIndex..localeArray.size-1]; 
                              }
 
-                             var t1 = new Time.Timer();
-                             t1.clear();
-                             t1.start(); 
                              charList.insert(0,shuffleRightSlice);
-                             t1.stop();
-                             var elapsed = t1.elapsed();
-                             gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                     "Time to insert chars shuffled right TO locale %i FROM %i: %.17r".format(
-                                                   idx,idx-1,elapsed)); 
                          }
                      }
 
@@ -1507,9 +1444,6 @@ module GenSymIO {
                           var localLeadingSliceIndex = localStart + shuffleLeftIndex;
                           var leadingCharArray = adjustCharArrayForLeadingSlice(localLeadingSliceIndex, 
                                          A.localSlice(locDom),locDom.last,idx);
-                          var t1 = new Time.Timer();
-                          t1.clear();
-                          t1.start(); 
                           charList.extend(leadingCharArray);  
                       } else {
                           charList.extend(A.localSlice(locDom));
@@ -1675,17 +1609,10 @@ module GenSymIO {
      */
     proc generateFilenames(prefix : string, extension : string, A) : [] string throws { 
         // Generate the filenames based upon the number of targetLocales.
-        var t1 = new Time.Timer();
-        t1.clear();
-        t1.start(); 
         var filenames: [0..#A.targetLocales().size] string;
         for i in 0..#A.targetLocales().size {
             filenames[i] = generateFilename(prefix, extension, i);
-        }
-        t1.stop();  
-        var elapsed = t1.elapsed();
-        gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                  "Time to generateFilenames: %.17r".format(elapsed));    
+        }   
         return filenames;
     }
 
@@ -1709,11 +1636,6 @@ module GenSymIO {
                                             A, group: string) throws {
       // if appending, make sure number of files hasn't changed and all are present
       var warnFlag: bool;
-
-      // initialize timer
-      var t1 = new Time.Timer();
-      t1.clear();
-      t1.start();
       
       /*
        * Generate a list of matching filenames to test against. If in 
@@ -1806,11 +1728,7 @@ module GenSymIO {
                                     routineName=getRoutineName(), 
                                     moduleName=getModuleName(), 
                                     errorClass='IllegalArgumentError');
-        }  
-        t1.stop();  
-        var elapsed = t1.elapsed();
-        gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                             "Time to process file names: %.17r".format(elapsed));        
+        }      
         return warnFlag;
     }
 
@@ -1823,11 +1741,6 @@ module GenSymIO {
     proc processFilenames(filenames: [] string, matchingFilenames: [] string, mode: int, A) throws {
       // if appending, make sure number of files hasn't changed and all are present
       var warnFlag: bool;
-
-      // initialize timer
-      var t1 = new Time.Timer();
-      t1.clear();
-      t1.start();
 
       if (mode == APPEND) {
           var allexist = true;
@@ -1911,10 +1824,6 @@ module GenSymIO {
                                      moduleName=getModuleName(), 
                                      errorClass='IllegalArgumentError');            
         }    
-        t1.stop();  
-        var elapsed = t1.elapsed();
-        gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                       "Time to process file names: %.17r".format(elapsed));        
 
         return warnFlag;
     }
@@ -1938,10 +1847,6 @@ module GenSymIO {
     private proc generateStringsMetadata(idx : int, shuffleLeftIndices, 
                        shuffleRightIndices, isSingleString, endsWithCompleteString, 
                        charArraySize, A, SA) throws {
-        // initialize timer
-        var t1 = new Time.Timer();
-        t1.clear();
-        t1.start();
         on Locales[idx] {
             //Retrieve the chars and segs local slices (portions of arrays on this locale)
             const locDom = A.localSubdomain();
@@ -2050,11 +1955,6 @@ module GenSymIO {
                 shuffleRightIndices[idx] = -1;
             }
         }
-        t1.stop();  
-        var elapsed = t1.elapsed();
-
-        try! gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                  "Time to generateStringsMetadata for locale %i: %.17r".format(idx,elapsed)); 
     }
     
     /*
@@ -2062,18 +1962,8 @@ module GenSymIO {
      * slicing leading chars that compose a string started in the previous locale and 
      * returning a new char array.
      */
-    private proc adjustCharArrayForLeadingSlice(sliceIndex, charArray, last, idx) throws {
-        // initialize timer
-        var t1 = new Time.Timer();
-        t1.clear();
-        t1.start();    
-        var adjCharArray = charArray[sliceIndex..last]; 
-        t1.stop();  
-        var elapsed = t1.elapsed();
-        gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                 "Time to generate array with leading chars sliced for locale %i: %.17r".format(
-                                    idx,elapsed)); 
-        return adjCharArray;
+    private proc adjustCharArrayForLeadingSlice(sliceIndex, charArray, last, idx) throws { 
+        return charArray[sliceIndex..last]; 
     }    
 
     /*
@@ -2082,18 +1972,7 @@ module GenSymIO {
      * to the end of the charList.
      */
     private proc adjustForLeftShuffle(shuffleLeftIndex: int, charList, idx: int) throws {
-        // initialize timer
-        var t1 = new Time.Timer();
-        t1.clear();
-        t1.start();
-
-        var adjCharList = charList[shuffleLeftIndex..charList.size-1];
-        t1.stop();
-        var elapsed = t1.elapsed();
-        gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                "Time to slice chars FROM locale %i shuffled left to locale %i: %.17r".format(
-                             elapsed,idx,idx-1));
-        return adjCharList;
+        return charList[shuffleLeftIndex..charList.size-1];
     }
 
     /* 
@@ -2102,28 +1981,14 @@ module GenSymIO {
      * the rightShuffleIndex. 
      */
     private proc adjustForRightShuffle(shuffleRightIndex: int, 
-                                               charsList: list(uint(8)), idx : int) throws {
-        var t1 = new Time.Timer();
-        t1.clear();
-        t1.start();  
-        
-        var newCharsList = charsList[0..shuffleRightIndex];
- 
-        t1.stop();  
-        var elapsed = t1.elapsed();
-        gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                   "Time to slice chars FROM locale %i shuffled right TO locale %i: %.17r".format(
-                        idx,idx+1,elapsed)); 
-        return newCharsList;
+                                               charsList: list(uint(8)), idx : int) throws {        
+        return charsList[0..shuffleRightIndex];
     }
 
     private proc generateFinalSegmentsList(charList : list(uint(8)), idx: int) throws {
         var segments: list(int);
         segments.append(0);
 
-        var t1 = new Time.Timer();
-        t1.clear();
-        t1.start(); 
         for (value, i) in zip(charList, 0..charList.size-1) do {
             /*
              * If the char is the null uint(8) char, check to see if it is the 
@@ -2136,10 +2001,6 @@ module GenSymIO {
             }
         }
         
-        t1.stop();  
-        var elapsed = t1.elapsed();
-        gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                   "Time to generate segmentsList FOR locale %i: %.17r".format(idx,elapsed)); 
         return segments;
     }
 
@@ -2180,9 +2041,14 @@ module GenSymIO {
     private proc writeStringsToHdf(fileId: int, idx: int, group: string, 
                               valuesList: list(uint(8)), segmentsList: list(int)) throws {
         // initialize timer
-        var t1 = new Time.Timer();
-        t1.clear();
-        t1.start();
+        var t1: Time.Timer;
+        var elapsed: real(64);
+        if logLevel == LogLevel.DEBUG {
+            t1 = new Time.Timer();
+            t1.clear();
+            t1.start();
+        }
+
         H5LTmake_dataset_WAR(fileId, '/%s/values'.format(group).c_str(), 1,
                      c_ptrTo([valuesList.size:uint(64)]), getHDF5Type(uint(8)),
                             c_ptrTo(valuesList.toArray()));
@@ -2190,9 +2056,11 @@ module GenSymIO {
         H5LTmake_dataset_WAR(fileId, '/%s/segments'.format(group).c_str(), 1,
                      c_ptrTo([segmentsList.size:uint(64)]),getHDF5Type(int),
                            c_ptrTo(segmentsList.toArray()));
-                           
-        t1.stop();  
-        var elapsed = t1.elapsed();
+
+        if logLevel == LogLevel.DEBUG {           
+            t1.stop();  
+            var elapsed = t1.elapsed();
+        }
         gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                   "Time for writing Strings to hdf5 file %t on locale %i: %.17r".format(
                        fileId,idx,elapsed));        

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -2081,7 +2081,6 @@ module GenSymIO {
                               valuesList: list(uint(8)), segmentsList: list(int)) throws {
         // initialize timer
         var t1: Time.Timer;
-        var elapsed: real(64);
         if logLevel == LogLevel.DEBUG {
             t1 = new Time.Timer();
             t1.clear();
@@ -2098,12 +2097,10 @@ module GenSymIO {
 
         if logLevel == LogLevel.DEBUG {           
             t1.stop();  
-            var elapsed = t1.elapsed();
+            gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                  "Time for writing Strings to hdf5 file on locale %i: %.17r".format(
+                       idx,t1.elapsed()));        
         }
-        gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                  "Time for writing Strings to hdf5 file %t on locale %i: %.17r".format(
-                       fileId,idx,elapsed));        
-
     }
     
     /*

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -1939,7 +1939,7 @@ module GenSymIO {
             /*
              * Normalize the first and last seg elements (make them zero-based) by
              * subtracting the char domain first index element. 
-'            */
+             */
             var normalize = 0;
             if idx > 0 {
                 normalize = locDom.first;

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -1325,7 +1325,7 @@ module GenSymIO {
                  * the last locale in the Arkouda cluster If so, all of the chars 
                  * from the next locale (idx+1) are shuffled to the current locale (idx).
                  */
-                var leadingSlice: [1..leadingSliceIndices[idx+1] - 1] uint(8);
+                var leadingSlice: [0..leadingSliceIndices[idx+1]] uint(8);
 
                 if leadingSliceIndices[idx+1] > -1 || isLastLocale(idx+1) {
                     on Locales[idx+1] {
@@ -1338,7 +1338,11 @@ module GenSymIO {
                         var localeArray = A.localSlice(locDom);
                         var leadingSliceIndex = leadingSliceIndices[here.id];
                         var localStart = locDom.first;
-                        var localLeadingSliceIndex = localStart + leadingSliceIndex - 2;
+                        var localLeadingSliceIndex = localStart + leadingSliceIndex;
+                        gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                               'leadingSliceIndex %i localStart %i localLeadlingSliceIndex %i for locale %i'.format(
+                               leadingSliceIndex,localStart,localLeadingSliceIndex,here.id));
+
                         leadingSlice = localeArray[localStart..localLeadingSliceIndex];                        
                         gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                         "leadingSlice: %t for locale %i".format(
@@ -1401,13 +1405,17 @@ module GenSymIO {
                      (valuesList, segmentsList) = 
                                          adjustForLeadingSlice(leadingSliceIndex, charList);
                      var localStart = locDom.first;
-                     var localLeadingSliceIndex = localStart + leadingSliceIndex - 1;
-
+                     var localLeadingSliceIndex = localStart + leadingSliceIndex;
+                     gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                               'leadingSliceIndex %i localStart %i localLeadlingSliceIndex %i'.format(leadingSliceIndex,localStart,localLeadingSliceIndex));
                      var adjCharArray = adjustArrayForLeadingSlice(localLeadingSliceIndex, 
-                                         A.localSlice(locDom));
+                                         A.localSlice(locDom),locDom.last);
                      gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),   
-                               'valuesList: %t and adjCharArray %t for locale %i '.format(
-                               valuesList,adjCharArray,here.id));    
+                               'valuesList: %t for locale %i '.format(
+                               valuesList,here.id));    
+                     gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                               'adjCharArray %t for locale %i '.format(adjCharArray,here.id));
+
                      charArrayList.extend(adjCharArray);
                  } else {
                      valuesList = charList;
@@ -1426,23 +1434,29 @@ module GenSymIO {
                      var sliceIndex = segmentsList.last();
                      (valuesList, segmentsList) = 
                                           adjustForTrailingSlice(sliceIndex, valuesList);  
-                     var charArray = adjustCharArrayForTrailingSlice(segmentsArrayList, 
-                                         charArrayList);
+                     charArrayList = new list(adjustCharArrayForTrailingSlice(charArrayList));
                      segmentsArrayList.pop();
                      gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),   
-                               'valuesList: %t charArray: %t for locale %i'.format(
-                               valuesList,charArray,idx));                
+                               'valuesList: %t for locale %i'.format(valuesList,idx));  
+                     gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                               'charArray: %t for locale %i'.format(charArray,idx));
+                      
                  } else {
                      valuesList.append(NULL_STRINGS_VALUE);    
                      charArrayList.append(NULL_STRINGS_VALUE);        
                  }
 
                  gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),   
-                               'final valuesList: %t and final charArrayList %t for %i'.format(
-                               valuesList, charArrayList,here.id));  
+                               'final valuesList: %t for %i'.format(valuesList,here.id)); 
+                 gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                               'finalcharArrayList %t for %i'.format(charArrayList,here.id));
+ 
                  gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),   
-                               'final segmentsList: %t and final segmentsArrayList %t for %i'.format(
-                               segmentsList, segmentsArrayList,here.id));                                  
+                               'final segmentsList: %t for %i'.format(
+                               segmentsList,here.id));
+                 gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                               'final segmentsArrayList %t for %i'.format(segmentsArrayList,here.id));
+                                  
                  // Write the finalized valuesList and segmentsList to the hdf5 group
                  writeStringsToHdf(myFileID, group, valuesList, segmentsList);
              } else {
@@ -1524,8 +1538,14 @@ module GenSymIO {
                          }
                      }
                       gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),   
-                               'final valuesList: %t and final charArrayList %t for %i'.format(
-                               valuesList, charArrayList,here.id)); 
+                               'final valuesList: %t for %i'.format(valuesList,here.id));
+                      gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                               'final charArrayList %t for %i'.format(charArrayList,here.id));
+                      gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                               'final segmentsList %t for %i'.format(segmentsList,here.id));
+                      gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                               'final segmentsArrayList %t for %i'.format(segmentsArrayList,here.id));
+ 
                       // Write the finalized valuesList and segmentsList to the hdf5 group
                       writeStringsToHdf(myFileID, group, valuesList, segmentsList);
                   } else {
@@ -1552,24 +1572,29 @@ module GenSymIO {
                           (valuesList, segmentsList) = 
                                              adjustForLeadingSlice(leadingSliceIndex, charList);
                           var localStart = locDom.first;
-                          var localLeadingSliceIndex = localStart + leadingSliceIndex - 1;
+                          var localLeadingSliceIndex = localStart + leadingSliceIndex;
+                          gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                               'leadingSliceIndex %i localStart %i localLeadlingSliceIndex %i'.format(leadingSliceIndex,localStart,localLeadingSliceIndex));
 
                           var leadingCharArray = adjustArrayForLeadingSlice(localLeadingSliceIndex, 
-                                         A.localSlice(locDom));
+                                         A.localSlice(locDom),locDom.last);
                           gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),   
-                               'valuesList: %t and leadingCharArray %t for %i'.format(
-                               valuesList,leadingCharArray,here.id)); 
+                               'valuesList: %t for %i'.format(valuesList,here.id));
+                          gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                               'leadingCharArray %t for %i'.format(leadingCharArray,here.id)); 
                           charArrayList.extend(leadingCharArray);  
                       } else {
                           valuesList = charList;
                       }
                       var segmentsArrayList = generateSegmentsList(charArrayList);
                       gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),   
-                               'final valuesList: %t and final charArrayList %t for %i'.format(
-                               valuesList, charArrayList,here.id)); 
+                               'final valuesList: %t for %i'.format(valuesList,here.id));
+                      gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                               'final charArrayList %t for %i'.format(charArrayList,here.id));
                       gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),   
-                               'final segmentsList: %t and final segmentsArrayList %t for %i'.format(
-                               segmentsList, segmentsArrayList,here.id)); 
+                               'final segmentsList: %t for %i'.format(segmentsList,here.id));
+                      gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                               'final segmentsArrayList %t for %i'.format(segmentsArrayList,here.id));
                       // Write the finalized valuesList and segmentsList to the hdf5 group
                       writeStringsToHdf(myFileID, group, valuesList, segmentsList);
                     }
@@ -2209,14 +2234,12 @@ module GenSymIO {
      * previous locale by slicing leading chars that compose a string
      * started in the previous locale and returning a new char array.
      */
-    private proc adjustArrayForLeadingSlice(sliceIndex : int, charArray) throws {
+    private proc adjustArrayForLeadingSlice(sliceIndex : int, charArray, last) throws {
         // initialize timer
         var t1 = new Time.Timer();
         t1.clear();
         t1.start();       
-
-        var adjCharArray = charArray[sliceIndex..charArray.size-1]; 
-
+        var adjCharArray = charArray[sliceIndex..last]; 
         t1.stop();  
         var elapsed = t1.elapsed();
         gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
@@ -2261,25 +2284,25 @@ module GenSymIO {
      * chars composing a string that completes in the next locale,
      * returning a new, correspondin list for the current locale. 
      */
-    private proc adjustCharArrayForTrailingSlice(segmentsList, charsList) throws {
+    private proc adjustCharArrayForTrailingSlice(charsList) throws {
         var t1 = new Time.Timer();
         t1.clear();
         t1.start();  
         
-        var newChars = charsList(0..charsList.size-1);
+        var newChars = charsList[0..charsList.size-1];
  
         t1.stop();  
         var elapsed = t1.elapsed();
         gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                   "Time to adjustArraysForLeadingSlice: %.17r".format(elapsed)); 
+                   "Time to adjustArraysForTrailingSlice: %.17r".format(elapsed)); 
         return newChars;
     }
 
     private proc generateSegmentsList(charList : list(uint(8))) throws {
         var segments: list(int);
-        var i: int = 0;
+        segments.append(0);
 
-        for value in charList(0..charList.size-1) {
+        for (value, i) in zip(charList, 0..charList.size-1) do {
             /*
              * If the char is the null uint(8) char, check to see if it is the 
              * last char. If not, added to the indices. If it is the last char,  
@@ -2289,7 +2312,6 @@ module GenSymIO {
             if value == NULL_STRINGS_VALUE && i < charList.size-1 {
                 segments.append(i+1);
             }
-            i+=1;        
         }
         
         return segments;


### PR DESCRIPTION
This PR addresses #763, containing a second round of Strings.save() optimizations. Specifically, this PR contains changes that do the following:
1. Obviates the need for several list creation and iteration operations by leveraging locale-scoped array slicing
2. Builds up one char list per locale with the corresponding array slices
3. Generates a one segments list per locale once the final locale char list is generated
4. Provides detailed debug messages to detail the slice and shuffle ops needed to prepare for writing to disk
5. Updated and expanded chapel doc comments 

In testing, this set of changes, together with the [first round](https://github.com/Bears-R-Us/arkouda/pull/779), decreases the save runtime of a 10-million length Strings object on a 3-locale smp (one server) Arkouda cluster from 400 seconds down to ~ 10 seconds. 