### PR TITLE
Closes #738: Support ak.Timedelta.std()

### DIFF
--- a/arkouda/timeclass.py
+++ b/arkouda/timeclass.py
@@ -466,8 +466,11 @@ class Timedelta(_AbstractBaseTime):
         '''
         return to_timedelta(self.to_ndarray())
 
-    def std(self, ddof : Union[int, np.int64] = 0):
-        return Timedelta(ak_array([np.int64(self._data.std(ddof=ddof))]))
+    def std(self, ddof: Union[int, np.int64] = 0):
+        '''
+        Returns the standard deviation as a pd.Timedelta object
+        '''
+        return self._scalar_callback(self._data.std(ddof=ddof))
 
     def sum(self):
         # Sum as a pd.Timedelta

--- a/arkouda/timeclass.py
+++ b/arkouda/timeclass.py
@@ -5,6 +5,7 @@ from arkouda.pdarraycreation import from_series, array as ak_array
 from arkouda.numeric import cast, abs as akabs
 import numpy as np # type: ignore
 import datetime
+from typing import Union
 
 _BASE_UNIT = 'ns'
 
@@ -464,6 +465,9 @@ class Timedelta(_AbstractBaseTime):
         to_ndarray
         '''
         return to_timedelta(self.to_ndarray())
+
+    def std(self, ddof : Union[int, np.int64] = 0):
+        return Timedelta(ak_array([np.int64(self._data.std(ddof=ddof))]))
 
     def sum(self):
         # Sum as a pd.Timedelta

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -237,7 +237,7 @@ class DatetimeTest(ArkoudaTest):
         ak_timedel_std = ak.Timedelta(ak.array([123, 456, 789]), unit='s').std(ddof=1)
         pd_timedel_std = pd.to_datetime([123, 456, 789], unit='s').std()
 
-        self.assertEqual(ak_timedel_std.to_pandas(), pd_timedel_std)
+        self.assertEqual(ak_timedel_std, pd_timedel_std)
 
     def test_scalars(self):
         self.assertTrue((self.dtscalar <= self.dtvec1).all()) # pandas.Timestamp

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -232,6 +232,13 @@ class DatetimeTest(ArkoudaTest):
         self.assertEqual(self.tdvec1.sum(), pd.Timedelta(self.tdvec1.size, unit='s'))
         self.assertTrue(((-self.tdvec1).abs() == self.tdvec1).all())
 
+    def test_timedel_std(self):
+        # pandas std uses unbiased estimator by default, in order to compare we set ddof=1 for arkouda std
+        ak_timedel_std = ak.Timedelta(ak.array([123, 456, 789]), unit='s').std(ddof=1)
+        pd_timedel_std = pd.to_datetime([123, 456, 789], unit='s').std()
+
+        self.assertEqual(ak_timedel_std.to_pandas(), pd_timedel_std)
+
     def test_scalars(self):
         self.assertTrue((self.dtscalar <= self.dtvec1).all()) # pandas.Timestamp
         self.assertTrue((self.dtscalar.to_pydatetime() <= self.dtvec1).all()) # datetime.datetime


### PR DESCRIPTION
This PR (Closes #738)
- Adds `.std` method to the `Timedelta` class, which calls `pdarrayclass.std` on the internal `_data` pdarray and converts result back to a `Timedelta` object
- Adds a test for this functionality which compares the result to the pandas implementation of standard deviation on time delta objects