### PR TITLE
Recommend Chapel 1.24.1 and use it for CI testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.23.0
+      image: chapel/chapel:1.24.1
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
@@ -31,7 +31,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.23.0
+      image: chapel/chapel:1.24.1
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
@@ -48,7 +48,7 @@ jobs:
   #    matrix:
   #      python-version: ['3.7', '3.8', '3.9', '3.x']
   #  container:
-  #    image: chapel/chapel:1.23.0
+  #    image: chapel/chapel:1.24.1
   #  steps:
   #  - uses: actions/checkout@v2
   #  - name: Set up Python ${{ matrix.python-version }}
@@ -82,7 +82,7 @@ jobs:
     env:
       CHPL_RT_NUM_THREADS_PER_LOCALE: ${{matrix.threads}}
     container:
-      image: chapel/${{matrix.image}}:1.23.0
+      image: chapel/${{matrix.image}}:1.24.1
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
@@ -114,7 +114,7 @@ jobs:
       matrix:
         image: [chapel, chapel-gasnet-smp]
     container:
-      image: chapel/${{matrix.image}}:1.23.0
+      image: chapel/${{matrix.image}}:1.24.1
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/Makefile
+++ b/Makefile
@@ -99,14 +99,14 @@ check-deps: $(CHECK_DEPS)
 
 CHPL_MINOR := $(shell $(CHPL) --version | sed -n "s/chpl version 1\.\([0-9]*\).*/\1/p")
 CHPL_VERSION_OK := $(shell test $(CHPL_MINOR) -ge 22 && echo yes)
-CHPL_VERSION_WARN := $(shell test $(CHPL_MINOR) -le 22 && echo yes)
+CHPL_VERSION_WARN := $(shell test $(CHPL_MINOR) -le 23 && echo yes)
 .PHONY: check-chpl
 check-chpl:
 ifneq ($(CHPL_VERSION_OK),yes)
 	$(error Chapel 1.22.0 or newer is required)
 endif
 ifeq ($(CHPL_VERSION_WARN),yes)
-	$(warning Chapel 1.23.0 or newer is recommended)
+	$(warning Chapel 1.24.1 or newer is recommended)
 endif
 
 CHPL_VERSION_122 := $(shell test $(CHPL_MINOR) -eq 22 && echo yes)

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This yielded a >20TB dataframe in Arkouda.
 
 <a id="prereq-reqs"></a>
 ### Requirements: <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
- * requires chapel 1.23.0
+ * requires chapel 1.24.1
  * requires zeromq version >= 4.2.5, tested with 4.2.5 and 4.3.1
  * requires hdf5 
  * requires python 3.7 or greater
@@ -154,7 +154,7 @@ Option 2: Build Chapel from source
 
 ```bash
 # build chapel in the user home directory with these settings...
-export CHPL_HOME=~/chapel/chapel-1.23.0
+export CHPL_HOME=~/chapel/chapel-1.24.1
 source $CHPL_HOME/util/setchplenv.bash
 export CHPL_COMM=gasnet
 export CHPL_COMM_SUBSTRATE=smp
@@ -210,9 +210,9 @@ sudo apt-get update
 sudo apt-get install gcc g++ m4 perl python python-dev python-setuptools bash make mawk git pkg-config
 
 # Download latest Chapel release, explode archive, and navigate to source root directory
-wget https://github.com/chapel-lang/chapel/releases/download/1.23.0/chapel-1.23.0.tar.gz
-tar xvf chapel-1.23.0.tar.gz
-cd chapel-1.23.0/
+wget https://github.com/chapel-lang/chapel/releases/download/1.24.1/chapel-1.24.1.tar.gz
+tar xvf chapel-1.24.1.tar.gz
+cd chapel-1.24.1/
 
 # Set CHPL_HOME
 export CHPL_HOME=$PWD

--- a/pydoc/setup/prerequisites.rst
+++ b/pydoc/setup/prerequisites.rst
@@ -7,7 +7,7 @@ Prerequisites
 *******************
 Chapel
 *******************
-(version 1.23.0 or greater)
+(version 1.24.1 or greater)
 
 The arkouda server application is written in Chapel_, a productive and performant parallel programming language. In order to use arkouda, you must first `download the current version of Chapel`_ and build it according to the instructions_ for your platform(s). Below are tips for building Chapel to support arkouda.
 


### PR DESCRIPTION
Chapel 1.24.x contains a number of performance optimizations,
particularly on InfiniBand systems. For more information see
https://chapel-lang.org/releaseNotes/1.24/03a-perf-ib.pdf

Change the documentation to require 1.24.1, but only recommend it in the
Makefile instead of making it an error. Arkouda should continue to work
with Chapel 1.23 so existing users don't necessarily have to upgrade,
but I would recommend it for the performance gains.