### PR TITLE
Fixes bug in Categorical concatenate when length < numLocales

### DIFF
--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import cast, List, Optional, Union
+from typing import cast, List, Sequence, Optional, Union
 import numpy as np # type: ignore
 import itertools
 from typeguard import typechecked
@@ -510,7 +510,7 @@ class Categorical:
 
         Parameters
         ----------
-        others : List[Categorical]
+        others : Sequence[Categorical]
             The Categorical arrays to concatenate and merge with this one
         ordered : bool
             If True (default), the arrays will be appended in the

--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -503,7 +503,7 @@ class Categorical:
         return Categorical.from_codes(newvals, self.categories[idxperm])
     
     @typechecked
-    def concatenate(self, others : List[Categorical], ordered : bool=True) -> Categorical:
+    def concatenate(self, others : Sequence[Categorical], ordered : bool=True) -> Categorical:
         """
         Merge this Categorical with other Categorical objects in the array, 
         concatenating the arrays and synchronizing the categories.

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -217,21 +217,6 @@ def concatenate(arrays : Sequence[Union[pdarray,Strings,'Categorical']], #type: 
         mode = 'append'
     else:
         mode = 'interleave'
-
-    if mode == 'interleave' and isinstance(arrays[0],(Strings,Categorical_)): # type: ignore
-        '''
-        Check if any Strings or Categorical objects have length < numLocales per 
-        #710 and #721 (Strings and Categorical concatenate in interleave mode fails with
-        an array index out of bounds error where 1..n of the Strings/Categoricals objects
-        have a length < numLocales) TODO: remove once #710 and #721 are resolved.
-        '''
-        numLocales = int(get_config()['numLocales'])
-        for arr in arrays:
-            if len(arr) < numLocales:
-                raise RuntimeError(('Strings or Categorical concatenate with ' +
-                'ordered=False currently only supported with lengths >= numLocales. ' +
-                'Please retry with ordered=True'))       
-
     if len(arrays) < 1:
         raise ValueError("concatenate called on empty iterable")
     if len(arrays) == 1:

--- a/tests/categorical_test.py
+++ b/tests/categorical_test.py
@@ -172,7 +172,17 @@ class CategoricalTest(ArkoudaTest):
         c12ord = ak.concatenate([c1, c2], ordered=True)
         self.assertTrue((ak.Categorical(s12ord) == c12ord).all())
         # Unordered (but still deterministic) concatenation
-        # TODO: the unordered concantenation is disabled per #710 #721
-        #s12unord = ak.concatenate([s1, s2], ordered=False)
-        #c12unord = ak.concatenate([c1, c2], ordered=False)
-        #self.assertTrue((ak.Categorical(s12unord) == c12unord).all())
+        s12unord = ak.concatenate([s1, s2], ordered=False)
+        c12unord = ak.concatenate([c1, c2], ordered=False)
+        self.assertTrue((ak.Categorical(s12unord) == c12unord).all())
+
+        # Tiny concatenation
+        # Used to fail when length of array was less than numLocales
+        # CI uses 2 locales, so try with length-1 arrays
+        a = ak.Categorical(ak.array(['a']))
+        b = ak.Categorical(ak.array(['b']))
+        c = ak.concatenate((a, b), ordered=False)
+        ans = ak.Categorical(ak.array(['a', 'b']))
+        self.assertTrue((c == ans).all())
+        
+        


### PR DESCRIPTION
This PR should close #710 , #721 , and #805 by making `ak.concatenate(..., ordered=False)` safe with `Categorical` arrays when the length of an array is less than `numLocales`. I tested manually with `test/UnitTestConcatenate.chpl` in several such configurations, e.g. with `-nl 6 --N=3`. The `categorical_test.py` unit tests also pass with `ARKOUDA_NUMLOCALES=6`.

I also added a block to `categorical_test.py` that concatenates length-1 arrays, which should cover this case in the normal CI using 2 locales, and I re-enabled the test of unordered concatenation that had been disabled in response to #710 and #721.

@ronawho would you mind confirming that this change fixes the errors you are seeing on your systems?