### PR TITLE
Closes #795: __iter__ for pdarray, Strings, and Categorical

### DIFF
--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -150,7 +150,7 @@ class Categorical:
         return idx[valcodes]
 
     def __iter__(self):
-        return iter(self.to_ndarray())
+        raise NotImplementedError('Categorical does not support iteration. To force data transfer from server, use to_ndarray')
         
     def __len__(self):
         return self.shape[0]

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -443,7 +443,7 @@ class pdarray:
         return self.opeq(other,"**=")
     
     def __iter__(self):
-        raise NotImplementedError('pdarray does not support iteration')
+        raise NotImplementedError('pdarray does not support iteration. To force data transfer from server, use to_ndarray')
 
     # overload a[] to treat like list
     def __getitem__(self, key):

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -103,7 +103,7 @@ class Strings:
         self.logger = getArkoudaLogger(name=__class__.__name__) # type: ignore
 
     def __iter__(self):
-        raise NotImplementedError('Strings does not support iteration')
+        raise NotImplementedError('Strings does not support iteration. To force data transfer from server, use to_ndarray')
 
     def __len__(self) -> int:
         return self.shape[0]

--- a/pydoc/usage/categorical.rst
+++ b/pydoc/usage/categorical.rst
@@ -33,3 +33,10 @@ Arkouda ``Categorical`` objects support all operations that ``Strings`` support,
 * :ref:`setops-label`, e.g. ``unique`` and ``in1d``
 * :ref:`sorting-label`, via ``argsort`` and ``coargsort``
 * :ref:`groupby-label`, both alone and in conjunction with numeric arrays
+
+Iteration
+=========
+
+Iterating directly over a ``Categorical`` with ``for x in categorical`` is not supported to discourage transferring all the ``Categorical`` object's data from the arkouda server to the Python client since there is almost always a more array-oriented way to express an iterator-based computation. To force this transfer, use the ``to_ndarray`` function to return the ``categorical`` as a ``numpy.ndarray``. This transfer will raise an error if it exceeds the byte limit defined in ``arkouda.maxTransferBytes``.
+
+.. autofunction:: arkouda.Categorical.to_ndarray

--- a/pydoc/usage/pdarray.rst
+++ b/pydoc/usage/pdarray.rst
@@ -35,7 +35,10 @@ The ``pdarray`` class supports most Python special methods, including arithmetic
 Iteration
 =========
 
-While it is possible to iterate directly over a ``pdarray`` with ``for x in array``, this is not recommended because it triggers a transfer of all array data from the arkouda server to the Python client as a ``numpy.ndarray``. This transfer will raise an error if it exceeds the byte limit defined in ``arkouda.maxTransferBytes``. There is almost always a more array-oriented way to express an iterator-based computation; see the coming sections for details.
+Iterating directly over a ``pdarray`` with ``for x in array`` is not supported to discourage transferring all array data from the arkouda server to the Python client since there is almost always a more array-oriented way to express an iterator-based computation. To force this transfer, use the ``to_ndarray`` function to return the ``pdarray`` as a ``numpy.ndarray``. This transfer will raise an error if it exceeds the byte limit defined in ``arkouda.maxTransferBytes``.
+
+.. autofunction:: arkouda.pdarray.to_ndarray
+
 
 .. _cast-label:
 

--- a/pydoc/usage/strings.rst
+++ b/pydoc/usage/strings.rst
@@ -14,12 +14,21 @@ Performance
 
 Because strings are a variable-width data type, and because of the way Arkouda represents strings, operations on strings are considerably slower than operations on numeric data. Use numeric data whenever possible. For example, if your raw data contains string data that could be represented numerically, consider setting up a processing pipeline performs the conversion (and stores the result in HDF5 format) on ingest.
 
+.. _string-io-label:
+
 I/O
 ===========
 
 Arrays of strings can be transferred between the Arkouda client and server using the ``arkouda.array`` and ``Strings.to_ndarray`` functions (see :ref:`IO-label`). The former converts a Python list or NumPy ``ndarray`` of strings to an Arkouda ``Strings`` object, whereas the latter converts an Arkouda ``Strings`` object to a NumPy ``ndarray``. As with numeric arrays, if the size of the data exceeds the threshold set by ``arkouda.maxTransferBytes``, the client will raise an exception.
 
 Arkouda currently only supports the HDF5 file format for disk-based I/O. In order to read an array of strings from an HDF5 file, the strings must be stored in an HDF5 ``group`` containing two datasets: ``segments`` (an integer array corresponding to ``offsets`` above) and ``values`` (a ``uint8`` array corresponding to ``bytes`` above). See :ref:`data-preprocessing-label` for more information and guidelines.
+
+Iteration
+=========
+
+Iterating directly over a ``Strings`` with ``for x in string`` is not supported to discourage transferring all the ``Strings`` object's data from the arkouda server to the Python client since there is almost always a more array-oriented way to express an iterator-based computation. To force this transfer, use the ``to_ndarray`` function to return the ``Strings`` as a ``numpy.ndarray``. See :ref:`string-io-label` for more details about using ``to_ndarray`` with ``Strings``
+
+.. autofunction:: arkouda.Strings.to_ndarray
 
 Operations
 ===========


### PR DESCRIPTION
This PR (Closes #795):
- Updates `__iter__` error message to be consistent for `pdarrayclass`, `Strings`, and `Categorical` and refer user to `to_ndarray`
- Adds documentation for `Iteration` in each of these classes explaining why it is not supported