### PR TITLE
810 fix strings.get lengths

### DIFF
--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import cast, List, Sequence, Optional, Union
+from typing import cast, List, Sequence, Union
 import numpy as np # type: ignore
 import itertools
 from typeguard import typechecked
@@ -11,9 +11,8 @@ from arkouda.pdarraycreation import zeros, zeros_like, arange
 from arkouda.dtypes import resolve_scalar_dtype, str_scalars
 from arkouda.dtypes import int64 as akint64
 from arkouda.sorting import argsort
-from arkouda.pdarraysetops import concatenate, in1d
 from arkouda.logger import getArkoudaLogger
-from arkouda.infoclass import information, pretty_print_information
+from arkouda.infoclass import information
 
 __all__ = ['Categorical']
 

--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import cast, List, Sequence, Union
+from typing import cast, List, Optional, Sequence, Union
 import numpy as np # type: ignore
 import itertools
 from typeguard import typechecked

--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -8,7 +8,8 @@ from arkouda.logger import getArkoudaLogger
 from arkouda.message import RequestMessage, MessageFormat, ReplyMessage, \
      MessageType
 
-__all__ = [ "connect", "disconnect", "shutdown", "get_config", "get_mem_used", "__version__", "ruok"]
+__all__ = [ "connect", "disconnect", "shutdown", "get_config", "get_mem_used", 
+           "__version__", "ruok"]
 
 # Try to read the version from the file located at ../VERSION
 VERSIONFILE = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 
@@ -508,14 +509,16 @@ def shutdown() -> None:
 def generic_msg(cmd : str, args : Union[str,bytes]=None, send_bytes : bool=False, 
                 recv_bytes : bool=False) -> Union[str, bytes]:
     """
-    Sends the binary or string message to the arkouda_server and returns 
-    the response sent by the server which is either a success confirmation
-    or error message
+    Sends a binary or string message composed of a command and corresponding 
+    arguments to the arkouda_server, returning the response sent by the server.
 
     Parameters
     ----------
-    message : Union[str, bytes]
-        The message to be sent in the form of a string or bytes array
+    cmd : str
+        The server-side command to be executed
+    args : Union[str,bytes]
+        A space-delimited list of command arguments or a byte array, the latter
+        of which is for creating an Arkouda array
     send_bytes : bool
         Indicates if the message to be sent is binary, defaults to False
     recv_bypes : bool
@@ -533,6 +536,12 @@ def generic_msg(cmd : str, args : Union[str,bytes]=None, send_bytes : bool=False
     RuntimeError
         Raised if the client is not connected to the server or if
         there is a server-side error thrown
+        
+    Notes
+    -----
+    If the server response is a string, the string corresponds to a success  
+    confirmation, warn message, or error message. A response of type bytes 
+    corresponds to an Arkouda array output as a numpy array.
     """
     global socket, pspStr, connected, verbose
 
@@ -617,7 +626,7 @@ def _no_op() -> str:
     RuntimeError
         Raised if there is a server-side error in executing noop request
     """
-    return cast(str,generic_msg("noop"))
+    return cast(str,generic_msg(cmd="noop"))
   
 def ruok() -> str:
     """
@@ -636,7 +645,7 @@ def ruok() -> str:
         both of the latter cases
     """
     try:
-        res = cast(str,generic_msg('ruok'))
+        res = cast(str,generic_msg(cmd='ruok'))
         if res == 'imok':
             return 'imok'
         else:

--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -289,7 +289,7 @@ class GroupBy:
                                     self.segments.name,
                                     operator,
                                     skipna)
-        repMsg = generic_msg(cmd,args)
+        repMsg = generic_msg(cmd=cmd,args=args)
         self.logger.debug(repMsg)
         if operator.startswith('arg'):
             return (self.unique_keys, 

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import itertools
-from typing import cast, Tuple, List, Union
+from typing import cast, Tuple, List, Optional, Union
 from typeguard import typechecked
 from arkouda.client import generic_msg
 from arkouda.pdarrayclass import pdarray, create_pdarray, parse_single_value, \

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
 import itertools
-from typing import cast, Optional, Tuple, List, Union
+from typing import cast, Tuple, List, Union
 from typeguard import typechecked
 from arkouda.client import generic_msg
-from arkouda.pdarrayclass import pdarray, create_pdarray, parse_single_value, unregister_pdarray_by_name, RegistrationError
+from arkouda.pdarrayclass import pdarray, create_pdarray, parse_single_value, \
+     unregister_pdarray_by_name, RegistrationError
 from arkouda.logger import getArkoudaLogger
 import numpy as np # type: ignore
 from arkouda.dtypes import npstr, int_scalars, str_scalars
 from arkouda.dtypes import NUMBER_FORMAT_STRINGS, resolve_scalar_dtype, \
      translate_np_dtype
 import json
-from arkouda.infoclass import information, pretty_print_information
+from arkouda.infoclass import information
 
 __all__ = ['Strings']
 
@@ -228,7 +229,7 @@ class Strings:
                                                          self.offsets.name,
                                                          self.bytes.name,
                                                          key.name)
-            repMsg = generic_msg(cmd,args)
+            repMsg = generic_msg(cmd=cmd,args=args)
             offsets, values = repMsg.split('+')
             return Strings(offsets, values)
         else:
@@ -248,9 +249,10 @@ class Strings:
         RuntimeError
             Raised if there is a server-side error thrown
         """
-        msg = "segmentLengths {} {} {}".\
+        cmd = "segmentLengths"
+        args = "{} {} {}".\
                         format(self.objtype, self.offsets.name, self.bytes.name)
-        return create_pdarray(generic_msg(msg))
+        return create_pdarray(generic_msg(cmd=cmd,args=args))
 
     @typechecked
     def contains(self, substr : Union[bytes,str_scalars]) -> pdarray:
@@ -631,7 +633,7 @@ class Strings:
                             other.bytes.name,
                             NUMBER_FORMAT_STRINGS['bool'].format(toLeft),
                             json.dumps([delimiter]))
-        repMsg = generic_msg(cmd,args)
+        repMsg = generic_msg(cmd=cmd,args=args)
         return Strings(*cast(str,repMsg).split('+'))
 
     def __add__(self, other : Strings) -> Strings:
@@ -737,7 +739,7 @@ class Strings:
         cmd = "segmentedGroup"
         args = "{} {} {}".\
                            format(self.objtype, self.offsets.name, self.bytes.name)
-        return create_pdarray(generic_msg(cmd,args))
+        return create_pdarray(generic_msg(cmd=cmd,args=args))
 
     def to_ndarray(self) -> np.ndarray:
         """

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -102,8 +102,16 @@ class ClientTest(ArkoudaTest):
         :return: None
         :raise: AssertionError if return message is not 'noop'
         '''   
-        noop = ak.client._no_op()
-        self.assertEqual('noop', noop)
+        self.assertEqual('noop', ak.client._no_op())
+        
+    def test_ruok(self):
+        '''
+        Tests the ak.client.ruok method
+        
+        :return: None
+        :raise: AssertionError if return message is not 'imok'
+        '''
+        self.assertEqual('imok', ak.client.ruok())
         
     def test_client_configuration(self):
         '''

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -515,6 +515,11 @@ class StringTest(ArkoudaTest):
         flatrange = thickrange.flatten(', ')
         self.assertTrue((ak.cast(flatrange, 'int64') == ak.arange(99)).all())
         
+    def test_get_lengths(self):
+        s1 = ak.array(['one', 'two', 'three', 'four', 'five'])
+        lengths = s1.get_lengths()
+        self.assertTrue((ak.array([3,3,5,4,4]) == lengths).all())
+
     def test_concatenate(self):
         s1 = self._get_strings('string',51)
         s2 = self._get_strings('string-two', 51)


### PR DESCRIPTION
This PR addresses the following:

1. Fixes #810 
2. Adds corresponding unit test for Strings.get_lengths()
3. Standardizes generic_msg invocation to generic_msg(cmd=cmd,args=args)
4. Updates client.generic_msg pydoc comments for cmd and args params
5. cleans up some import statements
6. Adds client.ruok() test case 