### PR TITLE
Remove duplicate import in arkouda/categorical.py #809

### DIFF
--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -11,7 +11,6 @@ from arkouda.pdarraycreation import zeros, zeros_like, arange
 from arkouda.dtypes import resolve_scalar_dtype, str_scalars
 from arkouda.dtypes import int64 as akint64
 from arkouda.sorting import argsort
-from arkouda.pdarraysetops import concatenate, in1d
 from arkouda.logger import getArkoudaLogger
 from arkouda.infoclass import information, pretty_print_information
 


### PR DESCRIPTION
Fixed duplicate module import in categorical.py as recommended.  Verified that no other duplicate imports were present.

Closes #809 