### PR TITLE
WIP / Draft 786 seg string entry

### DIFF
--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -153,7 +153,7 @@ class GroupBy:
         keytypes = []
         effectiveKeys = self.nkeys
         for k in mykeys:
-            if isinstance(k, Strings):
+            if isinstance(k, Strings):  # TODO fix Strings to perform as a single entity
                 if self.hash_strings:
                     h1, h2 = k.hash()
                     keyobjs.extend([h1,h2])
@@ -162,8 +162,8 @@ class GroupBy:
                     effectiveKeys += 1
                 else:
                     keyobjs.append(k)
-                    keynames.append('{}+{}'.format(k.offsets.name, 
-                                                   k.bytes.name))
+                    keynames.append('{}+{}'.format(k.entry.name,
+                                                   "legacy_placeholder"))
                     keytypes.append(k.objtype)
             # for Categorical
             elif hasattr(k, 'codes'):

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -57,7 +57,7 @@ def cast(pda : Union[pdarray, Strings], dt: Union[np.dtype,str]) -> Union[pdarra
         name = pda.name
         objtype = "pdarray"
     elif isinstance(pda, Strings):
-        name = '+'.join((pda.offsets.name, pda.bytes.name))
+        name = pda.entry.name
         objtype = "str"    
     # typechecked decorator guarantees no other case
 
@@ -67,7 +67,7 @@ def cast(pda : Union[pdarray, Strings], dt: Union[np.dtype,str]) -> Union[pdarra
     args= "{} {} {} {}".format(name, objtype, dt.name, opt)
     repMsg = generic_msg(cmd=cmd,args=args)
     if dt.name.startswith("str"):
-        return Strings(*(type_cast(str,repMsg).split("+")))
+        return Strings.from_parts(*(type_cast(str,repMsg).split("+")))
     else:
         return create_pdarray(type_cast(str,repMsg))
 

--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -163,12 +163,12 @@ def read_all(filenames : Union[str,List[str]],
             d : Dict[str,Union[pdarray,Strings]] = dict()
             for dset, rm in zip(datasets, rep_msgs):
                 if('+' in cast(str,rm)): #String
-                    d[dset]=Strings(*cast(str,rm).split('+'))
+                    d[dset]=Strings.from_parts(*cast(str,rm).split('+'))
                 else:
                     d[dset]=create_pdarray(cast(str,rm))
             return d
         elif '+' in rep_msg:
-            return Strings(*cast(str,rep_msg).split('+'))
+            return Strings.from_parts(*cast(str,rep_msg).split('+'))
         else:
             return create_pdarray(cast(str,rep_msg))
 

--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -168,6 +168,7 @@ def read_all(filenames : Union[str,List[str]],
                     d[dset]=create_pdarray(cast(str,rm))
             return d
         elif '+' in rep_msg:
+            rep_msg = cast(str, rep_msg)
             return Strings.from_return_msg(rep_msg)
         else:
             return create_pdarray(cast(str,rep_msg))

--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -168,7 +168,7 @@ def read_all(filenames : Union[str,List[str]],
                     d[dset]=create_pdarray(cast(str,rm))
             return d
         elif '+' in rep_msg:
-            return Strings.from_parts(*cast(str,rep_msg).split('+'))
+            return Strings.from_return_msg(rep_msg)
         else:
             return create_pdarray(cast(str,rep_msg))
 

--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -195,7 +195,6 @@ def array(a : Union[pdarray,np.ndarray, Iterable]) -> Union[pdarray, Strings]:
                 values[o+i] = b
         # Recurse to create pdarrays for offsets and values, then return Strings object
         return Strings.from_parts(cast(pdarray, array(offsets)), cast(pdarray, array(values)))
-        # return Strings(cast(pdarray, array(offsets)), cast(pdarray, array(values)))
     # If not strings, then check that dtype is supported in arkouda
     if a.dtype.name not in DTypes:
         raise RuntimeError("Unhandled dtype {}".format(a.dtype))
@@ -821,7 +820,6 @@ def random_strings_lognormal(logmean : numeric_scalars, logstd : numeric_scalars
                  NUMBER_FORMAT_STRINGS['float64'].format(logmean),
                  NUMBER_FORMAT_STRINGS['float64'].format(logstd),
                  seed))
-    # return Strings(*(cast(str,repMsg).split('+')))
     left, right = cast(str, repMsg).split('+')
     bytesSize:int_scalars = int(right.split()[-1])
     return Strings(create_pdarray(left), bytesSize)

--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -194,7 +194,8 @@ def array(a : Union[pdarray,np.ndarray, Iterable]) -> Union[pdarray, Strings]:
             for i, b in enumerate(s):
                 values[o+i] = b
         # Recurse to create pdarrays for offsets and values, then return Strings object
-        return Strings(cast(pdarray, array(offsets)), cast(pdarray, array(values)))
+        return Strings.from_parts(cast(pdarray, array(offsets)), cast(pdarray, array(values)))
+        # return Strings(cast(pdarray, array(offsets)), cast(pdarray, array(values)))
     # If not strings, then check that dtype is supported in arkouda
     if a.dtype.name not in DTypes:
         raise RuntimeError("Unhandled dtype {}".format(a.dtype))
@@ -754,7 +755,10 @@ def random_strings_uniform(minlen : int_scalars, maxlen : int_scalars,
                  NUMBER_FORMAT_STRINGS['int64'].format(minlen),
                  NUMBER_FORMAT_STRINGS['int64'].format(maxlen),
                  seed))
-    return Strings(*(cast(str,repMsg).split('+')))
+    left, right = cast(str, repMsg).split('+')
+    bytesSize:int_scalars = int(right.split()[-1])
+    return Strings(create_pdarray(left), bytesSize)
+    # return Strings(*(cast(str,repMsg).split('+')))
 
 @typechecked
 def random_strings_lognormal(logmean : numeric_scalars, logstd : numeric_scalars, 
@@ -820,4 +824,7 @@ def random_strings_lognormal(logmean : numeric_scalars, logstd : numeric_scalars
                  NUMBER_FORMAT_STRINGS['float64'].format(logmean),
                  NUMBER_FORMAT_STRINGS['float64'].format(logstd),
                  seed))
-    return Strings(*(cast(str,repMsg).split('+')))
+    # return Strings(*(cast(str,repMsg).split('+')))
+    left, right = cast(str, repMsg).split('+')
+    bytesSize:int_scalars = int(right.split()[-1])
+    return Strings(create_pdarray(left), bytesSize)

--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -755,10 +755,7 @@ def random_strings_uniform(minlen : int_scalars, maxlen : int_scalars,
                  NUMBER_FORMAT_STRINGS['int64'].format(minlen),
                  NUMBER_FORMAT_STRINGS['int64'].format(maxlen),
                  seed))
-    left, right = cast(str, repMsg).split('+')
-    bytesSize:int_scalars = int(right.split()[-1])
-    return Strings(create_pdarray(left), bytesSize)
-    # return Strings(*(cast(str,repMsg).split('+')))
+    return Strings.from_return_msg(cast(str, repMsg))
 
 @typechecked
 def random_strings_lognormal(logmean : numeric_scalars, logstd : numeric_scalars, 

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -240,8 +240,8 @@ def concatenate(arrays : Sequence[Union[pdarray,Strings,'Categorical']], #type: 
                 raise ValueError("All pdarrays must have same dtype")
             names.append(cast(pdarray,a).name)
         elif objtype == "str":
-            names.append('{}+{}'.format(cast(Strings,a).offsets.name, 
-                                                   cast(Strings,a).bytes.name))
+            names.append('{}+{}'.format(cast(Strings, a).entry.name,
+                                                   cast(Strings, a).entry.name))
         else:
             raise NotImplementedError(("concatenate not implemented " +
                                     "for object type {}".format(objtype)))
@@ -257,7 +257,8 @@ def concatenate(arrays : Sequence[Union[pdarray,Strings,'Categorical']], #type: 
     if objtype == "pdarray":
         return create_pdarray(cast(str,repMsg))
     elif objtype == "str":
-        return Strings(*(cast(str,repMsg).split('+')))
+        # ConcatenateMsg returns created attrib(name)+created nbytes=123
+        return Strings.from_return_msg(cast(str, repMsg))
     else:
         raise TypeError('arrays must be an array of pdarray or Strings objects')
 

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -74,15 +74,15 @@ def unique(pda : Union[pdarray,Strings,'Categorical'], # type: ignore
         else:
             return create_pdarray(cast(str,repMsg))
     elif isinstance(pda, Strings):
-        name = '{}+{}'.format(pda.offsets.name, pda.bytes.name)
+        name = '{}+{}'.format(pda.entry.name, pda.entry.name)
         repMsg = cast(str,generic_msg(cmd="unique", args="{} {} {}".\
                              format(pda.objtype, name, return_counts)))
         vc = repMsg.split('+')
         logger.debug(vc)
         if return_counts:
-            return Strings(vc[0], vc[1]), create_pdarray(cast(str,vc[2]))
+            return Strings.from_return_msg("+".join(vc[0:2])), create_pdarray(cast(str,vc[2]))
         else:
-            return Strings(vc[0], vc[1])
+            return Strings.from_return_msg(repMsg)
     else:
         raise TypeError("must be pdarray, Strings, or Categorical {}")
 

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -151,11 +151,11 @@ def in1d(pda1 : Union[pdarray,Strings,'Categorical'], pda2 : Union[pdarray,Strin
     elif isinstance(pda1, Strings) and isinstance(pda2, Strings):
         repMsg = generic_msg(cmd="segmentedIn1d", args="{} {} {} {} {} {} {}".\
                                     format(pda1.objtype,
-                                    pda1.offsets.name,
-                                    pda1.bytes.name,
+                                    pda1.entry.name,
+                                    "legacy_placeholder",
                                     pda2.objtype,
-                                    pda2.offsets.name,
-                                    pda2.bytes.name,
+                                    pda2.entry.name,
+                                    "legacy_placeholder",
                                     invert))
         return create_pdarray(cast(str,repMsg))
     else:

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -74,7 +74,7 @@ def unique(pda : Union[pdarray,Strings,'Categorical'], # type: ignore
         else:
             return create_pdarray(cast(str,repMsg))
     elif isinstance(pda, Strings):
-        name = '{}+{}'.format(pda.entry.name, pda.entry.name)
+        name = '{}+{}'.format(pda.entry.name, "legacy_placeholder")
         repMsg = cast(str,generic_msg(cmd="unique", args="{} {} {}".\
                              format(pda.objtype, name, return_counts)))
         vc = repMsg.split('+')
@@ -240,8 +240,7 @@ def concatenate(arrays : Sequence[Union[pdarray,Strings,'Categorical']], #type: 
                 raise ValueError("All pdarrays must have same dtype")
             names.append(cast(pdarray,a).name)
         elif objtype == "str":
-            names.append('{}+{}'.format(cast(Strings, a).entry.name,
-                                                   cast(Strings, a).entry.name))
+            names.append('{}+{}'.format(cast(Strings, a).entry.name, "legacy_placeholder"))
         else:
             raise NotImplementedError(("concatenate not implemented " +
                                     "for object type {}".format(objtype)))

--- a/arkouda/sorting.py
+++ b/arkouda/sorting.py
@@ -54,7 +54,7 @@ def argsort(pda : Union[pdarray,Strings,'Categorical']) -> pdarray: # type: igno
     if pda.size == 0:
         return zeros(0, dtype=int64)
     if isinstance(pda, Strings):
-        name = '{}+{}'.format(pda.entry.name, pda.entry.name)
+        name = '{}+{}'.format(pda.entry.name, "legacy_placeholder")
     else:
         name = pda.name
     repMsg = generic_msg(cmd="argsort", args="{} {}".format(pda.objtype, name))

--- a/arkouda/sorting.py
+++ b/arkouda/sorting.py
@@ -112,7 +112,7 @@ def coargsort(arrays : Sequence[Union[Strings,pdarray]]) -> pdarray:
     atypes = []
     for a in arrays:
         if isinstance(a, Strings):
-            anames.append('{}+{}'.format(a.offsets.name, a.bytes.name))
+            anames.append('{}+{}'.format(a.entry.name, "legacy_placeholder"))
             atypes.append(a.objtype)
         elif isinstance(a, pdarray):
             anames.append(a.name)

--- a/arkouda/sorting.py
+++ b/arkouda/sorting.py
@@ -54,7 +54,7 @@ def argsort(pda : Union[pdarray,Strings,'Categorical']) -> pdarray: # type: igno
     if pda.size == 0:
         return zeros(0, dtype=int64)
     if isinstance(pda, Strings):
-        name = '{}+{}'.format(pda.offsets.name, pda.bytes.name)
+        name = '{}+{}'.format(pda.entry.name, pda.entry.name)
     else:
         name = pda.name
     repMsg = generic_msg(cmd="argsort", args="{} {}".format(pda.objtype, name))

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -52,7 +52,7 @@ class Strings:
     objtype = "str"
 
     @staticmethod
-    def from_parts(offset_attrib : Union[pdarray,str], bytes_attrib : Union[pdarray,str]) -> pdarray:
+    def from_parts(offset_attrib : Union[pdarray,str], bytes_attrib : Union[pdarray,str]) -> Strings:
         if not isinstance(offset_attrib, pdarray):
             try:
                 offset_attrib = create_pdarray(offset_attrib)
@@ -69,6 +69,11 @@ class Strings:
         response = generic_msg(cmd=cmd, args=args)
         return Strings(create_pdarray(response), bytes_attrib.size)
         
+    @staticmethod
+    def from_return_msg(rep_msg:str) -> Strings:
+        left, right = cast(str, rep_msg).split('+')
+        bytes_size: int_scalars = int(right.split()[-1])
+        return Strings(create_pdarray(left), bytes_size)
 
     def __init__(self, strings_pdarray:pdarray, bytes_size:int_scalars) -> None:
         """
@@ -220,8 +225,7 @@ class Strings:
                                                   stop,
                                                   stride)
             repMsg = generic_msg(cmd=cmd, args=args)
-            offsets, values = repMsg.split('+')
-            return Strings(offsets, values);
+            return Strings.from_return_msg(repMsg)
         elif isinstance(key, pdarray):
             kind, _ = translate_np_dtype(key.dtype)
             if kind not in ("bool", "int"):
@@ -235,8 +239,7 @@ class Strings:
                                                          "legacy_placeholder",
                                                          key.name)
             repMsg = generic_msg(cmd=cmd,args=args)
-            offsets, values = repMsg.split('+')
-            return Strings(offsets, values)
+            return Strings.from_return_msg(repMsg)
         else:
             raise TypeError("unsupported pdarray index type {}".format(key.__class__.__name__))
 

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -174,7 +174,7 @@ class Strings:
             args = "{} {} {} {} {} {} {}".format(op,
                                                  self.objtype,
                                                  self.entry.name,
-                                                 self.entry.name,
+                                                 "legacy_placeholder",
                                                  other.objtype,
                                                  other.entry.name,
                                                  other.entry.name)
@@ -183,7 +183,7 @@ class Strings:
             args = "{} {} {} {} {} {}".format(op,
                                                               self.objtype,
                                                               self.entry.name,
-                                                              self.entry.name,
+                                                              "legacy_placeholder",
                                                               self.objtype,
                                                               json.dumps([other]))
         else:
@@ -208,7 +208,7 @@ class Strings:
                 args = " {} {} {} {} {}".format('intIndex',
                                                 self.objtype,
                                                 self.entry.name,
-                                                self.entry.name,
+                                                "legacy_placeholder",
                                                 key)
                 repMsg = generic_msg(cmd=cmd,args=args)
                 _, value = repMsg.split(maxsplit=1)
@@ -261,8 +261,7 @@ class Strings:
             Raised if there is a server-side error thrown
         """
         cmd = "segmentLengths"
-        args = "{} {} {}".\
-                        format(self.objtype, self.offsets.name, self.bytes.name)
+        args = "{} {} {}".format(self.objtype, self.entry.name, "legacy_placeholder")
         return create_pdarray(generic_msg(cmd=cmd,args=args))
 
     @typechecked
@@ -305,7 +304,7 @@ class Strings:
         args = "{} {} {} {} {} {}".format("contains",
                                                         self.objtype,
                                                         self.entry.name,
-                                                        self.entry.name,
+                                                        "legacy_placeholder",
                                                         "str",
                                                         json.dumps([substr]))
         return create_pdarray(generic_msg(cmd=cmd,args=args))
@@ -350,7 +349,7 @@ class Strings:
         args = "{} {} {} {} {} {}".format("startswith",
                                                         self.objtype,
                                                         self.entry.name,
-                                                        self.entry.name,
+                                                        "legacy_placeholder",
                                                         "str",
                                                         json.dumps([substr]))
         return create_pdarray(generic_msg(cmd=cmd,args=args))
@@ -395,7 +394,7 @@ class Strings:
         args = "{} {} {} {} {} {}".format("endswith",
                                           self.objtype,
                                           self.entry.name,
-                                          self.entry.name,
+                                          "legacy_placeholder",
                                           "str",
                                           json.dumps([substr]))
         return create_pdarray(generic_msg(cmd=cmd,args=args))
@@ -434,7 +433,7 @@ class Strings:
         """
         cmd = "segmentedFlatten"
         args = "{}+{} {} {} {}".format(self.entry.name,
-                                       self.entry.name,
+                                       "legacy_placeholder",
                                        self.objtype,
                                        return_segments,
                                        json.dumps([delimiter]))
@@ -517,7 +516,7 @@ class Strings:
         args = "{} {} {} {} {} {} {} {} {} {}".format("peel",
                             self.objtype,
                             self.entry.name,
-                            self.entry.name,
+                            "legacy_placeholder",
                             "str",
                             NUMBER_FORMAT_STRINGS['int64'].format(times),
                             NUMBER_FORMAT_STRINGS['bool'].format(includeDelimiter),
@@ -638,10 +637,10 @@ class Strings:
                             format("stick",
                             self.objtype,
                             self.entry.name,
-                            self.entry.name,
+                            "legacy_placeholder",
                             other.objtype,
                             other.entry.name,
-                            other.entry.name,
+                            "legacy_placeholder",
                             NUMBER_FORMAT_STRINGS['bool'].format(toLeft),
                             json.dumps([delimiter]))
         rep_msg = generic_msg(cmd=cmd,args=args)
@@ -712,8 +711,7 @@ class Strings:
         """
         # TODO fix this to return a single pdarray of hashes
         cmd = "segmentedHash"
-        args = "{} {} {}".format(self.objtype, self.entry.name, 
-                                              self.entry.name)
+        args = "{} {} {}".format(self.objtype, self.entry.name, "legacy_placeholder")
         repMsg = generic_msg(cmd=cmd,args=args)
         h1, h2 = cast(str,repMsg).split('+')
         return create_pdarray(h1), create_pdarray(h2)
@@ -749,8 +747,7 @@ class Strings:
             creating the pdarray encapsulating the return message
         """
         cmd = "segmentedGroup"
-        args = "{} {} {}".\
-                           format(self.objtype, self.entry.name, self.entry.name)
+        args = "{} {} {}".format(self.objtype, self.entry.name, "legacy_placeholder")
         return create_pdarray(generic_msg(cmd=cmd,args=args))
 
     def to_ndarray(self) -> np.ndarray:

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -441,10 +441,9 @@ class Strings:
         repMsg = cast(str,generic_msg(cmd=cmd,args=args))
         if return_segments:
             arrays = repMsg.split('+', maxsplit=2)
-            return Strings(arrays[0], arrays[1]), create_pdarray(arrays[2])
+            return Strings.from_return_msg("+".join(arrays[0:2])), create_pdarray(arrays[2])
         else:
-            arrays = repMsg.split('+', maxsplit=1)
-            return Strings(arrays[0], arrays[1])
+            return Strings.from_return_msg(repMsg)
     
     @typechecked
     def peel(self, delimiter : Union[bytes,str_scalars], times : int_scalars=1, 
@@ -644,8 +643,8 @@ class Strings:
                             other.entry.name,
                             NUMBER_FORMAT_STRINGS['bool'].format(toLeft),
                             json.dumps([delimiter]))
-        repMsg = generic_msg(cmd=cmd,args=args)
-        return Strings(*cast(str,repMsg).split('+'))
+        rep_msg = generic_msg(cmd=cmd,args=args)
+        return Strings.from_return_msg(cast(str, rep_msg))
 
     def __add__(self, other : Strings) -> Strings:
         return self.stick(other)

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -526,9 +526,10 @@ class Strings:
                             json.dumps([delimiter]))
         repMsg = generic_msg(cmd=cmd,args=args)
         arrays = cast(str,repMsg).split('+', maxsplit=3)
-        leftStr = Strings(arrays[0], arrays[1])
-        rightStr = Strings(arrays[2], arrays[3])
-        return leftStr, rightStr
+        # first two created are left Strings, last two are right strings
+        left_str = Strings.from_return_msg("+".join(arrays[0:2]))
+        right_str = Strings.from_return_msg("+".join(arrays[2:4]))
+        return left_str, right_str
 
     def rpeel(self, delimiter : Union[bytes,str_scalars], times : int_scalars=1, 
               includeDelimiter : bool=False, keepPartial : bool=False):

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -68,9 +68,9 @@ class Strings:
             except Exception as e:
                 raise RuntimeError(e)
         # Now we have two pdarray objects
-        args = f"{offset_attrib.name} {bytes_attrib.name}"
+        args = f"{offset_attrib.name} {bytes_attrib.name}" # type: ignore
         response = generic_msg(cmd=CMD_ASSEMBLE, args=args)
-        return Strings(create_pdarray(response), bytes_attrib.size)
+        return Strings(create_pdarray(response), bytes_attrib.size) # type: ignore
         
     @staticmethod
     def from_return_msg(rep_msg:str) -> Strings:
@@ -710,6 +710,7 @@ class Strings:
         to about 10**15), the probability of a collision between two 128-bit hash
         values is negligible.
         """
+        # TODO fix this to return a single pdarray of hashes
         cmd = "segmentedHash"
         args = "{} {} {}".format(self.objtype, self.entry.name, 
                                               self.entry.name)
@@ -980,8 +981,7 @@ class Strings:
         -------
         None
         """
-        self.offsets.pretty_print_info()
-        self.bytes.pretty_print_info()
+        self.entry.pretty_print_info()
 
     @typechecked
     def register(self, user_defined_name: str) -> Strings:
@@ -1086,7 +1086,7 @@ class Strings:
         Registered names/Strings objects in the server are immune to deletion
         until they are unregistered.
         """
-        rep_msg = generic_msg(cmd="attach", args="{}".format(user_defined_name))
+        rep_msg:str = cast(str, generic_msg(cmd="attach", args="{}".format(user_defined_name)))
         s = Strings.from_return_msg(rep_msg)
         s.name = user_defined_name
         return s

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -936,11 +936,7 @@ class Strings:
         RuntimeError
             Raised if there's a server-side error thrown
         """
-        parts_registered = [np.bool_(self.offsets.is_registered()), self.bytes.is_registered()]
-        if np.any(parts_registered) and not np.all(parts_registered):  # test for error
-            raise RegistrationError(f"Not all registerable components of Strings {self.name} are registered.")
-
-        return np.bool_(np.any(parts_registered))
+        return np.bool_(self.entry.is_registered())
 
     def _list_component_names(self) -> List[str]:
         """
@@ -955,7 +951,7 @@ class Strings:
         List[str]
             List of all component names
         """
-        return list(itertools.chain.from_iterable([self.offsets._list_component_names(), self.bytes._list_component_names()]))
+        return list(itertools.chain.from_iterable([self.entry._list_component_names()]))
 
     def info(self) -> str:
         """
@@ -1026,8 +1022,7 @@ class Strings:
         Registered names/Strings objects in the server are immune to deletion
         until they are unregistered.
         """
-        self.offsets.register(f"{user_defined_name}.offsets")
-        self.bytes.register(f"{user_defined_name}.bytes")
+        self.entry.register(user_defined_name)
         self.name = user_defined_name
         return self
 
@@ -1057,8 +1052,7 @@ class Strings:
         Registered names/Strings objects in the server are immune to deletion until
         they are unregistered.
         """
-        self.offsets.unregister()
-        self.bytes.unregister()
+        self.entry.unregister()
         self.name = None
 
     @staticmethod
@@ -1092,8 +1086,8 @@ class Strings:
         Registered names/Strings objects in the server are immune to deletion
         until they are unregistered.
         """
-        s = Strings(pdarray.attach(f"{user_defined_name}.offsets"),
-                    pdarray.attach(f"{user_defined_name}.bytes"))
+        rep_msg = generic_msg(cmd="attach", args="{}".format(user_defined_name))
+        s = Strings.from_return_msg(rep_msg)
         s.name = user_defined_name
         return s
 
@@ -1112,5 +1106,4 @@ class Strings:
         --------
         register, unregister, attach, is_registered
         """
-        unregister_pdarray_by_name(f"{user_defined_name}.bytes")
-        unregister_pdarray_by_name(f"{user_defined_name}.offsets")
+        unregister_pdarray_by_name(user_defined_name)

--- a/benchmarks/argsort.py
+++ b/benchmarks/argsort.py
@@ -19,7 +19,7 @@ def time_ak_argsort(N_per_locale, trials, dtype, seed):
         nbytes = a.size * a.itemsize
     elif dtype == 'str':
         a = ak.random_strings_uniform(1, 16, N, seed=seed)
-        nbytes = (a.bytes.size * a.bytes.itemsize)
+        nbytes = a.nbytes * a.entry.itemsize
      
     timings = []
     for i in range(trials):

--- a/benchmarks/coargsort.py
+++ b/benchmarks/coargsort.py
@@ -24,7 +24,7 @@ def time_ak_coargsort(N_per_locale, trials, dtype, seed):
             nbytes = sum(a.size * a.itemsize for a in arrs)
         elif dtype == 'str':
             arrs = [ak.random_strings_uniform(1, 16, N//numArrays, seed=s) for s in seeds]
-            nbytes = sum(a.bytes.size * a.bytes.itemsize for a in arrs)
+            nbytes = sum(a.nbytes * a.entry.itemsize for a in arrs)
 
         timings = []
         for i in range(trials):

--- a/benchmarks/gather.py
+++ b/benchmarks/gather.py
@@ -41,8 +41,8 @@ def time_ak_gather(isize, vsize, trials, dtype, random, seed):
 
     print("Average time = {:.4f} sec".format(tavg))
     if dtype == 'str':
-        offsets_transferred = 3 * c.offsets.size * c.offsets.itemsize
-        bytes_transferred = (c.offsets.size * c.offsets.itemsize) + (2 * c.bytes.size)
+        offsets_transferred = 3 * c.size * 8
+        bytes_transferred = (c.size * 8) + (2 * c.nbytes)
         bytes_per_sec = (offsets_transferred + bytes_transferred) / tavg
     else:
         bytes_per_sec = (c.size * c.itemsize * 3) / tavg

--- a/benchmarks/groupby.py
+++ b/benchmarks/groupby.py
@@ -17,7 +17,7 @@ def generate_arrays(N, numArrays, dtype, seed):
         else:
             a = ak.random_strings_uniform(1, 16, N//numArrays, seed=seed)
             arrays.append(a)
-            totalbytes += (a.bytes.size * a.bytes.itemsize)
+            totalbytes += (a.nbytes * a.entry.itemsize)
         if seed is not None:
             seed += 1
     if numArrays == 1:

--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -286,8 +286,9 @@ module ArgSortMsg
       for (i, j) in zip(names.domain.low..names.domain.high by -1,
                         types.domain.low..types.domain.high by -1) {
         if (types[j] == "str") {
-          var (myNames1,myNames2) = names[i].splitMsgToTuple('+', 2);
-          var strings = getSegString(myNames1, myNames2, st);
+          // TODO remove legacy_placeholder
+          var (myNames1, legacy_placeholder) = names[i].splitMsgToTuple('+', 2);
+          var strings = getSegString(myNames1, st);
           iv.a = incrementalArgSort(strings, iv.a);
         } else {
           var g: borrowed GenSymEntry = st.lookup(names[i]);
@@ -349,8 +350,9 @@ module ArgSortMsg
             }
           }
           when "str" {
-            var (names1, names2) = name.splitMsgToTuple('+', 2);
-            var strings = getSegString(names1, names2, st);
+            // TODO remove legacy_placeholder
+            var (names1, legacy_placeholder) = name.splitMsgToTuple('+', 2);
+            var strings = getSegString(names1, st);
             // check and throw if over memory limit
             overMemLimit((8 * strings.size * 8)
                          + (2 * here.maxTaskPar * numLocales * 2**16 * 8));

--- a/src/CastMsg.chpl
+++ b/src/CastMsg.chpl
@@ -93,8 +93,7 @@ module CastMsg {
         }
       }
       when "str" {
-          const (segName, valName) = name.splitMsgToTuple("+", 2);
-          const strings = getSegString(segName, valName, st);
+          const strings = getSegString(name, st);
           select targetDtype {
               when "int64" {
                   return new MsgTuple(castStringToSymEntry(strings, st, int), MsgType.NORMAL);
@@ -120,7 +119,7 @@ module CastMsg {
         castLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                      
         return new MsgTuple(errorMsg, MsgType.ERROR);
       }
-      }
+    }
   }
 
   proc castGenSymEntry(gse: borrowed GenSymEntry, st: borrowed SymTab, type fromType, 

--- a/src/ConcatenateMsg.chpl
+++ b/src/ConcatenateMsg.chpl
@@ -121,9 +121,9 @@ module ConcatenateMsg
                    * but it also causes an out of bounds array index due to the 
                    * way the low and high of the empty domain are computed. 
                    */
-                  // TODO: Fix this for strings as single entity
                   if (objtype == "str") && (mynumsegs > 0) {
-                    const e = toSymEntry(g, int);
+                    const stringEntry = toSegStringSymEntry(g);
+                    const e = stringEntry.offsetsEntry;
                     const firstSeg = e.a[e.aD.localSubdomain().low];
                     var mybytes: int;
                     /* If this locale contains the last segment, we cannot use the

--- a/src/FindSegmentsMsg.chpl
+++ b/src/FindSegmentsMsg.chpl
@@ -132,10 +132,11 @@ module FindSegmentsMsg
           [(u, s, i) in zip(ukeylocs, permKey, paD)] if ((i > paD.low) && (permKey[i-1] != s))  { u = true; }
         }
         when "str" {
-          var (myNames1,myNames2) = name.splitMsgToTuple('+', 2);
+          // TODO remvove legacy_placeholder
+          var (myNames1,legacy_placeholder) = name.splitMsgToTuple('+', 2);
           fsLogger.info(getModuleName(),getRoutineName(),getLineNumber(),
-                              "findSegmentsMessage myNames1: {} myNames2: {}".format(myNames1,myNames2));
-          var str = getSegString(myNames1, myNames2, st);
+                              "findSegmentsMessage myNames1: {} legacy_placeholder: {}".format(myNames1,legacy_placeholder));
+          var str = getSegString(myNames1, st);
           var (permOffsets, permVals) = str[pa];
           const ref D = permOffsets.domain;
           var permLengths: [D] int;

--- a/src/FlattenMsg.chpl
+++ b/src/FlattenMsg.chpl
@@ -27,8 +27,7 @@ module FlattenMsg {
         const strings = getSegString(stringsName, st);
         var (off, val, segs) = strings.flatten(delim, returnSegs);
         var stringsObj = getSegString(off, val, st);
-        // TODO remove second created after legacy_placeholder removal.
-        repMsg = "created %s+created %s".format(st.attrib(stringsObj.name), st.attrib(stringsObj.name));
+        repMsg = "created %s+created bytes.size %t".format(st.attrib(stringsObj.name), stringsObj.nBytes);
         if returnSegs {
           const optName: string = st.nextName();
           st.addEntry(optName, new shared SymEntry(segs));

--- a/src/FlattenMsg.chpl
+++ b/src/FlattenMsg.chpl
@@ -23,14 +23,14 @@ module FlattenMsg {
       when "str" {
         const rSegName = st.nextName();
         const rValName = st.nextName();
-        const optName: string = if returnSegs then st.nextName() else "";
-        var (segName, valName) = name.splitMsgToTuple('+', 2);
-        const strings = getSegString(segName, valName, st);
+        var (stringsName, legacy_placeholder) = name.splitMsgToTuple('+', 2);
+        const strings = getSegString(stringsName, st);
         var (off, val, segs) = strings.flatten(delim, returnSegs);
-        st.addEntry(rSegName, new shared SymEntry(off));
-        st.addEntry(rValName, new shared SymEntry(val));
-        repMsg = "created %s+created %s".format(st.attrib(rSegName), st.attrib(rValName));
+        var stringsObj = getSegString(off, val, st);
+        // TODO remove second created after legacy_placeholder removal.
+        repMsg = "created %s+created %s".format(st.attrib(stringsObj.name), st.attrib(stringsObj.name));
         if returnSegs {
+          const optName: string = st.nextName();
           st.addEntry(optName, new shared SymEntry(segs));
           repMsg += "+created %s".format(st.attrib(optName));
         }

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -576,11 +576,11 @@ module GenSymIO {
                     fixupSegBoundaries(entrySeg.a, segSubdoms, subdoms);
                     var entryVal = new shared SymEntry(len, uint(8));
                     read_files_into_distributed_array(entryVal.a, subdoms, filenames, dsetName + "/" + SEGARRAY_VALUE_NAME);
-                    var segName = st.nextName();
-                    st.addEntry(segName, entrySeg);
-                    var valName = st.nextName();
-                    st.addEntry(valName, entryVal);
-                    rnames = rnames + "created " + st.attrib(segName) + " +created " + st.attrib(valName) + " , ";
+                    var stringsEntry = new shared SegStringSymEntry(entrySeg, entryVal, string);
+                    var stringsName = st.nextName();
+                    st.addEntry(stringsName, stringsEntry);
+                    // TODO remove legacy_placeholder second entry below.  Also think about possible improvements to manual SegStringSymEntry above
+                    rnames = rnames + "created " + st.attrib(stringsName) + " +created " + st.attrib(stringsName) + " , ";
                 }
                 when (false, C_HDF5.H5T_INTEGER) {
                     var entryInt = new shared SymEntry(len, int);
@@ -1081,12 +1081,17 @@ module GenSymIO {
                     /*
                      * Look up the values and segments arrays, both of which are needed to write
                      * uint8 arrays such as Strings out to external systems.
+                     * UPDATE: with SegStringSymEntry, it's now encapsulated, also UInt8 is a #legacy_placeholder
+                     *         The type is now DType.Strings so this should be unreachable
                      */
-                    var e = toSymEntry(entry, uint(8));
-                    var segsEntry = st.lookup(segsName);                   
-                    var s_e = toSymEntry(segsEntry, int);
-                    warnFlag = write1DDistStrings(filename, mode, dsetName, e.a, DType.UInt8,s_e.a);
-                } otherwise {
+                    var segString:SegStringSymEntry = toSegStringSymEntry(entry);
+                    warnFlag = write1DDistStrings(filename, mode, dsetName, segString.bytesEntry.a, DType.UInt8, segString.offsetsEntry.a);
+                }
+                when DType.Strings {
+                    var segString:SegStringSymEntry = toSegStringSymEntry(entry);
+                    warnFlag = write1DDistStrings(filename, mode, dsetName, segString.bytesEntry.a, DType.UInt8, segString.offsetsEntry.a);
+                }
+                 otherwise {
                     var errorMsg = unrecognizedTypeError("tohdf", dtype2str(entry.dtype));
                     gsLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);            
                     return new MsgTuple(errorMsg, MsgType.ERROR);

--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -22,6 +22,10 @@ module MultiTypeSymEntry
         return gse.toSymEntry(etype);
     }
 
+    // inline proc toSegStringSymEntry(gse: borrowed GenSymEntry) {
+    //     return gse.toSegStringSymEntry();
+    // }
+
     /* This is a dummy class to avoid having to talk about specific
        instantiations of SymEntry. */
     class GenSymEntry
@@ -51,6 +55,10 @@ module MultiTypeSymEntry
         inline proc toSymEntry(type etype) {
             return try! this :borrowed SymEntry(etype);
         }
+
+        // inline proc toSegStringSymEntry(type etype) {
+        //     return try! this :borrowed SegStringSymEntry(etype);
+        // }
 
         /* 
         Formats and returns data in this entry up to the specified threshold. 
@@ -199,4 +207,24 @@ module MultiTypeSymEntry
         }
     }
 
+    class SegStringSymEntry : GenSymEntry {
+        type etype = string;
+
+        var offsetsEntry: borrowed SymEntry(int);
+        var bytesEntry: borrowed SymEntry(uint(8));
+
+        proc init(offsetsSymEntry: borrowed SymEntry, bytesSymEntry: borrowed SymEntry, type etype) {
+            super.init(string);
+            this.offsetsEntry = offsetsSymEntry;
+            this.bytesEntry = bytesSymEntry;
+        }
+
+        proc init(type etype, len: int = 0) {
+            super.init(etype);
+        }
+
+        proc init(gen: borrowed GenSymEntry){
+            super.init(string);
+        }
+    }
 }

--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -22,9 +22,9 @@ module MultiTypeSymEntry
         return gse.toSymEntry(etype);
     }
 
-    // inline proc toSegStringSymEntry(gse: borrowed GenSymEntry) {
-    //     return gse.toSegStringSymEntry();
-    // }
+    inline proc toSegStringSymEntry(gse: borrowed GenSymEntry) {
+        return try! gse: borrowed SegStringSymEntry(string);
+    }
 
     /* This is a dummy class to avoid having to talk about specific
        instantiations of SymEntry. */
@@ -55,10 +55,6 @@ module MultiTypeSymEntry
         inline proc toSymEntry(type etype) {
             return try! this :borrowed SymEntry(etype);
         }
-
-        // inline proc toSegStringSymEntry(type etype) {
-        //     return try! this :borrowed SegStringSymEntry(etype);
-        // }
 
         /* 
         Formats and returns data in this entry up to the specified threshold. 
@@ -218,13 +214,6 @@ module MultiTypeSymEntry
             this.offsetsEntry = offsetsSymEntry;
             this.bytesEntry = bytesSymEntry;
         }
-
-        proc init(type etype, len: int = 0) {
-            super.init(etype);
-        }
-
-        proc init(gen: borrowed GenSymEntry){
-            super.init(string);
-        }
     }
+
 }

--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -3,6 +3,7 @@ module MultiTypeSymEntry
 {
     use ServerConfig;
     use Logging;
+    use Reflection;
 
     public use NumPyDType;
 
@@ -10,6 +11,9 @@ module MultiTypeSymEntry
 
     use AryUtil;
     
+    private config const logLevel = ServerConfig.logLevel;
+    const genLogger = new Logger(logLevel);
+
     /* Casts a GenSymEntry to the specified type and returns it.
        
        :arg gse: generic sym entry
@@ -76,6 +80,7 @@ module MultiTypeSymEntry
             :returns: s (string) containing the array data
         */
         proc __str__(thresh:int=1, prefix:string="", suffix:string="", baseFormat:string=""): string throws {
+            genLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "__str__ invoked");
             var s = "DType: %s, itemsize: %t, size: %t".format(this.dtype, this.itemsize, this.size);
             return prefix + s + suffix;
         }
@@ -206,10 +211,10 @@ module MultiTypeSymEntry
     class SegStringSymEntry : GenSymEntry {
         type etype = string;
 
-        var offsetsEntry: borrowed SymEntry(int);
-        var bytesEntry: borrowed SymEntry(uint(8));
+        var offsetsEntry: shared SymEntry(int);
+        var bytesEntry: shared SymEntry(uint(8));
 
-        proc init(offsetsSymEntry: borrowed SymEntry, bytesSymEntry: borrowed SymEntry, type etype) {
+        proc init(offsetsSymEntry: shared SymEntry, bytesSymEntry: shared SymEntry, type etype) {
             super.init(string);
             this.offsetsEntry = offsetsSymEntry;
             this.bytesEntry = bytesSymEntry;

--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -208,6 +208,19 @@ module MultiTypeSymEntry
         }
     }
 
+    /**
+     * Factory method for creating a typed SymEntry and checking mem limits
+     * :arg len: the number of elements to allocate
+     * :type len: int
+     * 
+     * :arg t: the element type
+     * :type t: type
+    */
+    proc createTypedSymEntry(len: int, type t) throws {
+        if t == bool {overMemLimit(len);} else {overMemLimit(len*numBytes(t));}
+        return new shared SymEntry(len, t);
+    }
+
     class SegStringSymEntry : GenSymEntry {
         type etype = string;
 

--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -213,6 +213,10 @@ module MultiTypeSymEntry
             super.init(string);
             this.offsetsEntry = offsetsSymEntry;
             this.bytesEntry = bytesSymEntry;
+            this.size = this.offsetsEntry.size;
+            this.ndim = this.offsetsEntry.ndim;
+            this.shape = this.offsetsEntry.shape;
+            this.itemsize = this.bytesEntry.itemsize;
         }
     }
 

--- a/src/NumPyDType.chpl
+++ b/src/NumPyDType.chpl
@@ -3,7 +3,7 @@ module NumPyDType
 {
     /* In chapel the types int and real defalut to int(64) and real(64).
        We also need other types like float32, int32, etc */
-    enum DType {Int64, Float64, Bool, UInt8, UNDEF}; 
+    enum DType {Int64, Float64, Bool, UInt8, UNDEF, Strings}; 
 
     /* 
     Take a chapel type and returns the matching DType 
@@ -17,6 +17,7 @@ module NumPyDType
       if (etype == real) {return DType.Float64;}
       if (etype == bool) {return DType.Bool;}
       if (etype == uint(8)) {return DType.UInt8;}
+      if (etype == string) {return DType.Strings;}
       return DType.UNDEF; // undefined type
     }
 
@@ -47,6 +48,7 @@ module NumPyDType
         if dstr == "float64" {return DType.Float64;}        
         if dstr == "bool" {return DType.Bool;}
         if dstr == "uint8" {return DType.UInt8;}
+        if dstr == "string" {return DType.Strings;}
         return DType.UNDEF;
     }
     
@@ -62,6 +64,7 @@ module NumPyDType
         if dtype == DType.Float64 {return "float64";}        
         if dtype == DType.Bool {return "bool";}
         if dtype == DType.UInt8 {return "uint8";}
+        if dtype == DType.Strings {return "string";}
         return "UNDEF";
     }
 

--- a/src/NumPyDType.chpl
+++ b/src/NumPyDType.chpl
@@ -48,7 +48,7 @@ module NumPyDType
         if dstr == "float64" {return DType.Float64;}        
         if dstr == "bool" {return DType.Bool;}
         if dstr == "uint8" {return DType.UInt8;}
-        if dstr == "string" {return DType.Strings;}
+        if dstr == "str" {return DType.Strings;}
         return DType.UNDEF;
     }
     
@@ -64,7 +64,7 @@ module NumPyDType
         if dtype == DType.Float64 {return "float64";}        
         if dtype == DType.Bool {return "bool";}
         if dtype == DType.UInt8 {return "uint8";}
-        if dtype == DType.Strings {return "string";}
+        if dtype == DType.Strings {return "str";}
         return "UNDEF";
     }
 

--- a/src/RegistrationMsg.chpl
+++ b/src/RegistrationMsg.chpl
@@ -12,6 +12,7 @@ module RegistrationMsg
     use MultiTypeSymbolTable;
     use MultiTypeSymEntry;
     use ServerErrorStrings;
+    use SegmentedArray;
 
     private config const logLevel = ServerConfig.logLevel;
     const regLogger = new Logger(logLevel);
@@ -86,9 +87,24 @@ module RegistrationMsg
             return new MsgTuple(errorMsg, MsgType.ERROR); 
         } else {
             repMsg = "created %s".format(attrib);
+            if (isStringAttrib(attrib)) {
+                var s = getSegString(name, st);
+                repMsg += "+created bytes.size %t".format(s.nBytes);
+            }
             regLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
             return new MsgTuple(repMsg, MsgType.NORMAL); 
         }
+    }
+
+    /*
+     * Determine if the attributes belong to a SegString
+     * :arg attrs: attributes from SymTab
+     * :type attrs: string
+     * :returns: bool
+     */
+    proc isStringAttrib(attrs:string):bool throws {
+        var parts = attrs.split();
+        return parts.size >=6 && "str" == parts[1];
     }
 
     /* 

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -31,9 +31,9 @@ module SegmentedArray {
    */
   proc getSegString(offsetName: string, valName: string, 
                                           st: borrowed SymTab): owned SegString throws {
-      var offsetEntry = st.lookup(offsetName);
-      var valEntry = st.lookup(valName);
-      return new owned SegString(offsetEntry, offsetName, valEntry, valName, st);
+      var combined_name = offsetName + "+" + valName;
+      var combined_entry:GenSymEntry = st.lookup(combined_name);
+      return new owned SegString(combined_entry);
   }
 
   /*
@@ -51,7 +51,11 @@ module SegmentedArray {
       var valEntry = new shared SymEntry(values);
       st.addEntry(valName, valEntry);
 
-      return new SegString(offsetEntry, offsetName, valEntry, valName, st);
+      var combined_name = offsetName + "+" + valName;
+      var combined_entry = new shared SegStringSymEntry(offsetEntry, valEntry, string);
+      st.addEntry(combined_name, combined_entry);
+      return new SegString(combined_entry);
+      // return new SegString(offsetEntry, offsetName, valEntry, valName);
   }
 
   /**
@@ -100,12 +104,22 @@ module SegmentedArray {
      */ 
     var nBytes: int;
 
+    proc init(gse: borrowed GenSymEntry) {
+        var foo:SegStringSymEntry = gse: SegStringSymEntry(string);
+        offsets = foo.offsetsEntry: unmanaged SymEntry(int);
+        values = foo.bytesEntry: unmanaged SymEntry(uint(8));
+        // var foo = gse:unmanaged SegStringSymEntry(string);
+        // var foo:SegStringSymEntry = gse: unmanaged SegStringSymEntry;
+        // var foo = toSegStringSymEntry(gse, string): unmanaged SegStringSymEntry(string);
+        // init(foo.offsetsEntry, "", foo.bytesEntry, "");
+    }
+
     /* 
      * This method should not be called directly. Instead, call one of the
      * getSegString factory methods.
      */
     proc init(offsetEntry: borrowed GenSymEntry, segsName: string, 
-                   valEntry: borrowed GenSymEntry, valName: string, st: borrowed SymTab) {
+                   valEntry: borrowed GenSymEntry, valName: string) {
       offsetName = segsName;
       //Must be unmanaged because borrowed throws a lifetime error
       offsets = toSymEntry(offsetEntry, int): unmanaged SymEntry(int);

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -25,17 +25,6 @@ module SegmentedArray {
   
   class OutOfBoundsError: Error {}
 
-  /* 
-   * This version of the getSegString method is the most common and is only used 
-   * when the names of the segments (offsets) and values SymEntries are known.
-   */
-  proc getSegString(offsetName: string, valName: string, 
-                                          st: borrowed SymTab): owned SegString throws {
-      /* TEMPORARY: until the messaging layer / client side gets updated */
-      var combined_name = offsetName + "+" + valName;
-      return getSegString(combined_name, st);
-  }
-
   proc getSegString(name: string, st: borrowed SymTab): owned SegString throws {
       return new owned SegString(name, st.lookup(name));
   }

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -34,11 +34,20 @@ module SegmentedArray {
    * inputs, generates the SymEntry objects for each and passes the
    * offset and value SymTab lookup names to the alternate init method
    */
-  proc getSegString(segments: [] int, values: [] uint(8), 
-                                          st: borrowed SymTab): owned SegString throws {
-      var offsetEntry = new shared SymEntry(segments);
-      var valEntry = new shared SymEntry(values);
-      var stringsEntry = new shared SegStringSymEntry(offsetEntry, valEntry, string);
+  proc getSegString(segments: [] int, values: [] uint(8), st: borrowed SymTab): owned SegString throws {
+      var offsetsEntry = new shared SymEntry(segments);
+      var valuesEntry = new shared SymEntry(values);
+      return assembleSegStringFromParts(offsetsEntry, valuesEntry, st);
+  }
+
+  proc assembleSegStringFromParts(offsets:GenSymEntry, values:GenSymEntry, st:borrowed SymTab): owned SegString throws {
+      var offs = toSymEntry(offsets, int);
+      var vals = toSymEntry(values, uint(8));
+      return assembleSegStringFromParts(offs, vals, st);
+  }
+
+  proc assembleSegStringFromParts(offsets:SymEntry, values:SymEntry, st:borrowed SymTab): owned SegString throws {
+      var stringsEntry = new shared SegStringSymEntry(offsets, values, string);
       var name = st.nextName();
       st.addEntry(name, stringsEntry);
       return getSegString(name, st);
@@ -87,6 +96,7 @@ module SegmentedArray {
      * getSegString factory methods.
      */
     proc init(entryName:string, gse:borrowed GenSymEntry) {
+        name = entryName;
         composite = toSegStringSymEntry(gse);
         offsets = composite.offsetsEntry: unmanaged SymEntry(int);
         values = composite.bytesEntry: unmanaged SymEntry(uint(8));

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -575,7 +575,7 @@ module SegmentedMsg {
                         strings = getSegString(newOffsets, newVals, st);
                     }
                     // TODO remove second created entry after legacy_placeholder removal
-                    repMsg = "created %s+created %s".format(st.attrib(strings.name), st.attrib(strings.name));
+                    repMsg = "created %s+created bytes.size %t".format(st.attrib(strings.name), strings.nBytes);
                     smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
                 }
                 otherwise {

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -205,6 +205,7 @@ module SegmentedMsg {
   proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
+    // 'peel str id_8 id_8 str 1 True True True ["t"]'
     var (subcmd, objtype, name, legacy_placeholder, valtype, valStr,
          idStr, kpStr, lStr, jsonStr) = payload.splitMsgToTuple(10);
 
@@ -268,10 +269,13 @@ module SegmentedMsg {
               return new MsgTuple(errorMsg, MsgType.ERROR);                            
               }
           }
-          repMsg = "created %s+created %s+created %s+created %s".format(st.attrib(leftName),
-                                                                        st.attrib(leftName + "legacy_placeholder"),
+          // TODO: Make SegString nil-able and then we don't have to play the game of names here.
+          var myLeft = getSegString(leftName, st);
+          var urRight = getSegString(rightName, st);
+          repMsg = "created %s+created bytes.size %t+created %s+created bytes.size %t".format(st.attrib(leftName),
+                                                                        myLeft.nBytes,
                                                                         st.attrib(rightName),
-                                                                        st.attrib(rightName + "legacy_placeholder"));
+                                                                        urRight.nBytes);
         }
         otherwise {
             var errorMsg = notImplementedError(pn, 

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -411,8 +411,7 @@ module SegmentedMsg {
             var (newSegs, newVals) = strings[slice];
             // Store the resulting offsets and bytes arrays
             var newStringsObj = getSegString(newSegs, newVals, st);
-            // TODO after legacy_placeholder removal, drop second created piece
-            var repMsg = "created " + st.attrib(newStringsObj.name) + " +created " + st.attrib(newStringsObj.name);
+            var repMsg = "created " + st.attrib(newStringsObj.name) + "+created bytes.size %t".format(newStringsObj.nBytes);
             smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg); 
             return new MsgTuple(repMsg, MsgType.NORMAL);
         }
@@ -444,6 +443,7 @@ module SegmentedMsg {
     st.checkTable(args[1]);  // TODO update positional args below after removing legacy_placeholder
 
     var newStringsName = "";
+    var nBytes = 0;
     
     smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                                   "objtype:%s".format(objtype));
@@ -460,12 +460,14 @@ module SegmentedMsg {
                         var (newSegs, newVals) = strings[iv.a];
                         var newStringsObj = getSegString(newSegs, newVals, st);
                         newStringsName = newStringsObj.name;
+                        nBytes = newStringsObj.nBytes;
                     }
                     when DType.Bool {
                         var iv = toSymEntry(gIV, bool);
                         var (newSegs, newVals) = strings[iv.a];
                         var newStringsObj = getSegString(newSegs, newVals, st);
                         newStringsName = newStringsObj.name;
+                        nBytes = newStringsObj.nBytes;
                     }
                     otherwise {
                         var errorMsg = "("+objtype+","+dtype2str(gIV.dtype)+")";
@@ -486,8 +488,8 @@ module SegmentedMsg {
             return new MsgTuple(notImplementedError(pn, objtype), MsgType.ERROR);
         }
     }
-    // TODO remove second created objet after legacy_placeholder removal 
-    var repMsg = "created " + st.attrib(newStringsName) + "+created " + st.attrib(newStringsName);
+    var repMsg = "created " + st.attrib(newStringsName) + "+created bytes.size %t".format(nBytes);
+
     smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
 
     return new MsgTuple(repMsg, MsgType.NORMAL);

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -33,6 +33,7 @@ module SegmentedMsg {
     var segString = assembleSegStringFromParts(offsets, values, st);
     smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "created segString.name: %s".format(segString.name));
     // clean up the parts since we only want a single encapsulated "Strings" entry
+    // Although the client may do this when the objects go out of scope.
     // st.deleteEntry(offsetsName);
     // st.deleteEntry(valuesName);
 
@@ -57,7 +58,7 @@ module SegmentedMsg {
               overMemLimit(8*len + 16*len + (maxLen + minLen)*len);
               var (segs, vals) = newRandStringsUniformLength(len, minLen, maxLen, charset, seedStr);
               var strings = getSegString(segs, vals, st);
-              repMsg = 'created ' + st.attrib(strings.name) + '+created legacy_placeholder';
+              repMsg = 'created ' + st.attrib(strings.name) + '+created bytes.size %t'.format(strings.nBytes);
           }
           when "lognormal" {
               var logMean = arg1str:real;
@@ -66,7 +67,7 @@ module SegmentedMsg {
               overMemLimit(8*len + 16*len + exp(logMean + (logStd**2)/2):int*len);
               var (segs, vals) = newRandStringsLogNormalLength(len, logMean, logStd, charset, seedStr);
               var strings = getSegString(segs, vals, st);
-              repMsg = 'created ' + st.attrib(strings.name) + '+created legacy_placeholder';
+              repMsg = 'created ' + st.attrib(strings.name) + '+created bytes.size %t'.format(strings.nBytes);
           }
           otherwise { 
               var errorMsg = notImplementedError(pn, dist);      
@@ -344,12 +345,14 @@ module SegmentedMsg {
       var pn = Reflection.getRoutineName();
 
       // check to make sure symbols defined
+      var strName = args[1];
+      smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "strName: %s".format(strName));
       st.checkTable(args[1]); // TODO move to single name
       
       select objtype {
           when "str" {
               // Make a temporary strings array
-              var strings = getSegString(args[1], st);
+              var strings = getSegString(strName, st);
               // Parse the index
               var idx = args[3]:int;
               // TO DO: in the future, we will force the client to handle this

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -139,7 +139,7 @@ module SegmentedMsg {
       return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+  proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
     var (subcmd, objtype, name, legacy_placeholder, valtype, valStr,
@@ -413,7 +413,7 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
     // check to make sure symbols defined
     st.checkTable(args[1]);  // TODO update positional args below after removing legacy_placeholder
 
-    var newStringsName = st.nextName();
+    var newStringsName = "";
     
     smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                                   "objtype:%s".format(objtype));
@@ -429,11 +429,13 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
                         var iv = toSymEntry(gIV, int);
                         var (newSegs, newVals) = strings[iv.a];
                         var newStringsObj = getSegString(newSegs, newVals, st);
+                        newStringsName = newStringsObj.name;
                     }
                     when DType.Bool {
                         var iv = toSymEntry(gIV, bool);
                         var (newSegs, newVals) = strings[iv.a];
                         var newStringsObj = getSegString(newSegs, newVals, st);
+                        newStringsName = newStringsObj.name;
                     }
                     otherwise {
                         var errorMsg = "("+objtype+","+dtype2str(gIV.dtype)+")";

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -21,11 +21,7 @@ module SegmentedMsg {
           = payload.splitMsgToTuple(6);
       var len = lenStr: int;
       var charset = str2CharSet(charsetStr);
-      var segName = st.nextName();
-      var valName = st.nextName();
       var repMsg: string;
-      smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-             "dist: %s segName: %t valName: %t".format(dist.toLower(),segName,valName));
       select dist.toLower() {
           when "uniform" {
               var minLen = arg1str:int;
@@ -33,11 +29,8 @@ module SegmentedMsg {
               // Lengths + 2*segs + 2*vals (copied to SymTab)
               overMemLimit(8*len + 16*len + (maxLen + minLen)*len);
               var (segs, vals) = newRandStringsUniformLength(len, minLen, maxLen, charset, seedStr);
-              var segEntry = new shared SymEntry(segs);
-              var valEntry = new shared SymEntry(vals);
-              st.addEntry(segName, segEntry);
-              st.addEntry(valName, valEntry);
-              repMsg = 'created ' + st.attrib(segName) + '+created ' + st.attrib(valName);
+              var strings = getSegString(segs, vals, st);
+              repMsg = 'created ' + st.attrib(strings.name) + '+created legacy_placeholder';
           }
           when "lognormal" {
               var logMean = arg1str:real;
@@ -45,11 +38,8 @@ module SegmentedMsg {
               // Lengths + 2*segs + 2*vals (copied to SymTab)
               overMemLimit(8*len + 16*len + exp(logMean + (logStd**2)/2):int*len);
               var (segs, vals) = newRandStringsLogNormalLength(len, logMean, logStd, charset, seedStr);
-              var segEntry = new shared SymEntry(segs);
-              var valEntry = new shared SymEntry(vals);
-              st.addEntry(segName, segEntry);
-              st.addEntry(valName, valEntry);
-              repMsg = 'created ' + st.attrib(segName) + '+created ' + st.attrib(valName);
+              var strings = getSegString(segs, vals, st);
+              repMsg = 'created ' + st.attrib(strings.name) + '+created legacy_placeholder';
           }
           otherwise { 
               var errorMsg = notImplementedError(pn, dist);      
@@ -65,20 +55,19 @@ module SegmentedMsg {
   proc segmentLengthsMsg(cmd: string, payload: string, 
                                           st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
-    var (objtype, segName, valName) = payload.splitMsgToTuple(3);
+    var (objtype, name, legacy_placeholder) = payload.splitMsgToTuple(3);
 
     // check to make sure symbols defined
-    st.checkTable(segName);
-    st.checkTable(valName);
+    st.checkTable(name);
     
     var rname = st.nextName();
     smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-            "cmd: %s objtype: %t segName: %t valName: %t".format(
-                   cmd,objtype,segName,valName));
+            "cmd: %s objtype: %t name: %t legacy_placeholder: %t".format(
+                   cmd,objtype,name,"legacy_placeholder"));
 
     select objtype {
       when "str" {
-        var strings = getSegString(segName, valName, st);
+        var strings = getSegString(name, st);
         var lengths = st.addEntry(rname, strings.size, int);
         // Do not include the null terminator in the length
         lengths.a = strings.getLengths() - 1;
@@ -98,12 +87,11 @@ module SegmentedMsg {
   proc segmentedEfuncMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
       var pn = Reflection.getRoutineName();
       var repMsg: string;
-      var (subcmd, objtype, segName, valName, valtype, valStr) = 
+      var (subcmd, objtype, name, legacy_placeholder, valtype, valStr) = 
                                               payload.splitMsgToTuple(6);
 
       // check to make sure symbols defined
-      st.checkTable(segName);
-      st.checkTable(valName);
+      st.checkTable(name);
 
       var json = jsonToPdArray(valStr, 1);
       var val = json[json.domain.low];
@@ -115,7 +103,7 @@ module SegmentedMsg {
     
         select (objtype, valtype) {
           when ("str", "str") {
-            var strings = getSegString(segName, valName, st);
+            var strings = getSegString(name, st);
             select subcmd {
                 when "contains" {
                 var truth = st.addEntry(rname, strings.size, bool);
@@ -154,12 +142,11 @@ module SegmentedMsg {
 proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    var (subcmd, objtype, segName, valName, valtype, valStr,
+    var (subcmd, objtype, name, legacy_placeholder, valtype, valStr,
          idStr, kpStr, lStr, jsonStr) = payload.splitMsgToTuple(10);
 
     // check to make sure symbols defined
-    st.checkTable(segName);
-    st.checkTable(valName);
+    st.checkTable(name);
 
     smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                          "cmd: %s subcmd: %s objtype: %t valtype: %t".format(
@@ -167,7 +154,7 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
 
     select (objtype, valtype) {
     when ("str", "str") {
-      var strings = getSegString(segName, valName, st);
+      var strings = getSegString(name, st);
       select subcmd {
         when "peel" {
           var times = valStr:int;
@@ -176,59 +163,41 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
           var left = (lStr.toLower() == "true");
           var json = jsonToPdArray(jsonStr, 1);
           var val = json[json.domain.low];
-          var loname = st.nextName();
-          var lvname = st.nextName();
-          var roname = st.nextName();
-          var rvname = st.nextName();
+          var leftName = "";
+          var rightName = "";
           select (includeDelimiter, keepPartial, left) {
           when (false, false, false) {
             var (lo, lv, ro, rv) = strings.peel(val, times, false, false, false);
-            st.addEntry(loname, new shared SymEntry(lo));
-            st.addEntry(lvname, new shared SymEntry(lv));
-            st.addEntry(roname, new shared SymEntry(ro));
-            st.addEntry(rvname, new shared SymEntry(rv));
+            leftName = getSegString(lo, lv, st).name;
+            rightName = getSegString(ro, rv, st).name;
           } when (false, false, true) {
             var (lo, lv, ro, rv) = strings.peel(val, times, false, false, true);
-            st.addEntry(loname, new shared SymEntry(lo));
-            st.addEntry(lvname, new shared SymEntry(lv));
-            st.addEntry(roname, new shared SymEntry(ro));
-            st.addEntry(rvname, new shared SymEntry(rv));
+            leftName = getSegString(lo, lv, st).name;
+            rightName = getSegString(ro, rv, st).name;
           } when (false, true, false) {
             var (lo, lv, ro, rv) = strings.peel(val, times, false, true, false);
-            st.addEntry(loname, new shared SymEntry(lo));
-            st.addEntry(lvname, new shared SymEntry(lv));
-            st.addEntry(roname, new shared SymEntry(ro));
-            st.addEntry(rvname, new shared SymEntry(rv));
+            leftName = getSegString(lo, lv, st).name;
+            rightName = getSegString(ro, rv, st).name;
           } when (false, true, true) {
             var (lo, lv, ro, rv) = strings.peel(val, times, false, true, true);
-            st.addEntry(loname, new shared SymEntry(lo));
-            st.addEntry(lvname, new shared SymEntry(lv));
-            st.addEntry(roname, new shared SymEntry(ro));
-            st.addEntry(rvname, new shared SymEntry(rv));
+            leftName = getSegString(lo, lv, st).name;
+            rightName = getSegString(ro, rv, st).name;
           } when (true, false, false) {
             var (lo, lv, ro, rv) = strings.peel(val, times, true, false, false);
-            st.addEntry(loname, new shared SymEntry(lo));
-            st.addEntry(lvname, new shared SymEntry(lv));
-            st.addEntry(roname, new shared SymEntry(ro));
-            st.addEntry(rvname, new shared SymEntry(rv));
+            leftName = getSegString(lo, lv, st).name;
+            rightName = getSegString(ro, rv, st).name;
           } when (true, false, true) {
             var (lo, lv, ro, rv) = strings.peel(val, times, true, false, true);
-            st.addEntry(loname, new shared SymEntry(lo));
-            st.addEntry(lvname, new shared SymEntry(lv));
-            st.addEntry(roname, new shared SymEntry(ro));
-            st.addEntry(rvname, new shared SymEntry(rv));
+            leftName = getSegString(lo, lv, st).name;
+            rightName = getSegString(ro, rv, st).name;
           } when (true, true, false) {
             var (lo, lv, ro, rv) = strings.peel(val, times, true, true, false);
-            st.addEntry(loname, new shared SymEntry(lo));
-            st.addEntry(lvname, new shared SymEntry(lv));
-            st.addEntry(roname, new shared SymEntry(ro));
-            st.addEntry(rvname, new shared SymEntry(rv));
+            leftName = getSegString(lo, lv, st).name;
+            rightName = getSegString(ro, rv, st).name;
           } when (true, true, true) {
             var (lo, lv, ro, rv) = strings.peel(val, times, true, true, true);
-            st.addEntry(loname, new shared SymEntry(lo));
-            st.addEntry(lvname, new shared SymEntry(lv));
-            st.addEntry(roname, new shared SymEntry(ro));
-            st.addEntry(rvname, new shared SymEntry(rv));
+            leftName = getSegString(lo, lv, st).name;
+            rightName = getSegString(ro, rv, st).name;
           } otherwise {
               var errorMsg = notImplementedError(pn, 
                                "subcmd: %s, (%s, %s)".format(subcmd, objtype, valtype));
@@ -236,10 +205,10 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
               return new MsgTuple(errorMsg, MsgType.ERROR);                            
               }
           }
-          repMsg = "created %s+created %s+created %s+created %s".format(st.attrib(loname),
-                                                                        st.attrib(lvname),
-                                                                        st.attrib(roname),
-                                                                        st.attrib(rvname));
+          repMsg = "created %s+created %s+created %s+created %s".format(st.attrib(leftName),
+                                                                        st.attrib(leftName + "legacy_placeholder"),
+                                                                        st.attrib(rightName),
+                                                                        st.attrib(rightName + "legacy_placeholder"));
         }
         otherwise {
             var errorMsg = notImplementedError(pn, 
@@ -263,15 +232,14 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
   proc segmentedHashMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    var (objtype, segName, valName) = payload.splitMsgToTuple(3);
+    var (objtype, name, legacy_placeholder) = payload.splitMsgToTuple(3);
 
     // check to make sure symbols defined
-    st.checkTable(segName);
-    st.checkTable(valName);
+    st.checkTable(name);
 
     select objtype {
         when "str" {
-            var strings = getSegString(segName, valName, st);
+            var strings = getSegString(name, st);
             var hashes = strings.hash();
             var name1 = st.nextName();
             var hash1 = st.addEntry(name1, hashes.size, int);
@@ -349,13 +317,12 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
       var pn = Reflection.getRoutineName();
 
       // check to make sure symbols defined
-      st.checkTable(args[1]);
-      st.checkTable(args[2]);
+      st.checkTable(args[1]); // TODO move to single name
       
       select objtype {
           when "str" {
               // Make a temporary strings array
-              var strings = getSegString(args[1], args[2], st);
+              var strings = getSegString(args[1], st);
               // Parse the index
               var idx = args[3]:int;
               // TO DO: in the future, we will force the client to handle this
@@ -390,15 +357,14 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
     var pn = Reflection.getRoutineName();
 
     // check to make sure symbols defined
-    st.checkTable(args[1]);
-    st.checkTable(args[2]);
+    st.checkTable(args[1]); //TODO remove legacy_placeholder and bump indices below
 
     select objtype {
         when "str" {
             // Make a temporary string array
-            var strings = getSegString(args[1], args[2], st);
+            var strings = getSegString(args[1], st);
 
-            // Parse the slice parameters
+            // Parse the slice parameters TODO bump this indicies after legacy_placeholder removal
             var start = args[3]:int;
             var stop = args[4]:int;
             var stride = args[5]:int;
@@ -411,17 +377,12 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
             }
             // TO DO: in the future, we will force the client to handle this
             var slice: range(stridable=true) = convertPythonSliceToChapel(start, stop, stride);
-            var newSegName = st.nextName();
-            var newValName = st.nextName();
             // Compute the slice
             var (newSegs, newVals) = strings[slice];
             // Store the resulting offsets and bytes arrays
-            var newSegsEntry = new shared SymEntry(newSegs);
-            var newValsEntry = new shared SymEntry(newVals);
-            st.addEntry(newSegName, newSegsEntry);
-            st.addEntry(newValName, newValsEntry);
-        
-            var repMsg = "created " + st.attrib(newSegName) + " +created " + st.attrib(newValName);
+            var newStringsObj = getSegString(newSegs, newVals, st);
+            // TODO after legacy_placeholder removal, drop second created piece
+            var repMsg = "created " + st.attrib(newStringsObj.name) + " +created " + st.attrib(newStringsObj.name);
             smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg); 
             return new MsgTuple(repMsg, MsgType.NORMAL);
         }
@@ -450,18 +411,16 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
     var pn = Reflection.getRoutineName();
 
     // check to make sure symbols defined
-    st.checkTable(args[1]);
-    st.checkTable(args[2]);
+    st.checkTable(args[1]);  // TODO update positional args below after removing legacy_placeholder
 
-    var newSegName = st.nextName();
-    var newValName = st.nextName();
+    var newStringsName = st.nextName();
     
     smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                                   "objtype:%s".format(objtype));
     
     select objtype {
         when "str" {
-            var strings = getSegString(args[1], args[2], st);
+            var strings = getSegString(args[1], st);
             var iname = args[3];
             var gIV: borrowed GenSymEntry = st.lookup(iname);
             try {
@@ -469,18 +428,12 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
                     when DType.Int64 {
                         var iv = toSymEntry(gIV, int);
                         var (newSegs, newVals) = strings[iv.a];
-                        var newSegsEntry = new shared SymEntry(newSegs);
-                        var newValsEntry = new shared SymEntry(newVals);
-                        st.addEntry(newSegName, newSegsEntry);
-                        st.addEntry(newValName, newValsEntry);
+                        var newStringsObj = getSegString(newSegs, newVals, st);
                     }
                     when DType.Bool {
                         var iv = toSymEntry(gIV, bool);
                         var (newSegs, newVals) = strings[iv.a];
-                        var newSegsEntry = new shared SymEntry(newSegs);
-                        var newValsEntry = new shared SymEntry(newVals);
-                        st.addEntry(newSegName, newSegsEntry);
-                        st.addEntry(newValName, newValsEntry);
+                        var newStringsObj = getSegString(newSegs, newVals, st);
                     }
                     otherwise {
                         var errorMsg = "("+objtype+","+dtype2str(gIV.dtype)+")";
@@ -501,7 +454,8 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
             return new MsgTuple(notImplementedError(pn, objtype), MsgType.ERROR);
         }
     }
-    var repMsg = "created " + st.attrib(newSegName) + "+created " + st.attrib(newValName);
+    // TODO remove second created objet after legacy_placeholder removal 
+    var repMsg = "created " + st.attrib(newStringsName) + "+created " + st.attrib(newStringsName);
     smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
 
     return new MsgTuple(repMsg, MsgType.NORMAL);
@@ -512,21 +466,19 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
     var repMsg: string;
     var (op,
          // Type and attrib names of left segmented array
-         ltype, lsegName, lvalName,
+         ltype, leftName, left_legacy_placeholder,
          // Type and attrib names of right segmented array
-         rtype, rsegName, rvalName, leftStr, jsonStr)
+         rtype, rightName, right_legacy_placeholder, leftStr, jsonStr)
            = payload.splitMsgToTuple(9);
 
     // check to make sure symbols defined
-    st.checkTable(lsegName);
-    st.checkTable(lvalName);
-    st.checkTable(rsegName);
-    st.checkTable(rvalName);
+    st.checkTable(leftName);
+    st.checkTable(rightName);
 
     select (ltype, rtype) {
         when ("str", "str") {
-            var lstrings = getSegString(lsegName, lvalName, st);
-            var rstrings = getSegString(rsegName, rvalName, st);
+            var lstrings = getSegString(leftName, st);
+            var rstrings = getSegString(rightName, st);
 
             select op {
                 when "==" {
@@ -545,18 +497,16 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
                     var left = (leftStr.toLower() != "false");
                     var json = jsonToPdArray(jsonStr, 1);
                     const delim = json[json.domain.low];
-                    var oname = st.nextName();
-                    var vname = st.nextName();
+                    var strings:SegString;
                     if left {
                         var (newOffsets, newVals) = lstrings.stick(rstrings, delim, false);
-                        st.addEntry(oname, new shared SymEntry(newOffsets));
-                        st.addEntry(vname, new shared SymEntry(newVals));
+                        strings = getSegString(newOffsets, newVals, st);
                     } else {
                         var (newOffsets, newVals) = lstrings.stick(rstrings, delim, true);
-                        st.addEntry(oname, new shared SymEntry(newOffsets));
-                        st.addEntry(vname, new shared SymEntry(newVals));
+                        strings = getSegString(newOffsets, newVals, st);
                     }
-                    repMsg = "created %s+created %s".format(st.attrib(oname), st.attrib(vname));
+                    // TODO remove second created entry after legacy_placeholder removal
+                    repMsg = "created %s+created %s".format(st.attrib(strings.name), st.attrib(strings.name));
                     smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
                 }
                 otherwise {
@@ -579,12 +529,11 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
   proc segBinopvsMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
       var pn = Reflection.getRoutineName();
       var repMsg: string;
-      var (op, objtype, segName, valName, valtype, encodedVal)
+      var (op, objtype, name, legacy_placeholder, valtype, encodedVal)
           = payload.splitMsgToTuple(6);
 
       // check to make sure symbols defined
-      st.checkTable(segName);
-      st.checkTable(valName);
+      st.checkTable(name);
 
       var json = jsonToPdArray(encodedVal, 1);
       var value = json[json.domain.low];
@@ -592,7 +541,7 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
 
       select (objtype, valtype) {
           when ("str", "str") {
-              var strings = getSegString(segName, valName, st);
+              var strings = getSegString(name, st);
               select op {
                   when "==" {
                       var e = st.addEntry(rname, strings.size, bool);
@@ -624,14 +573,12 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
   proc segIn1dMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
       var pn = Reflection.getRoutineName();
       var repMsg: string;
-      var (mainObjtype, mainSegName, mainValName, testObjtype, testSegName,
-         testValName, invertStr) = payload.splitMsgToTuple(7);
+      var (mainObjtype, mainName, main_legacy_placeholder, testObjtype, testName,
+         test_legacy_placeholder, invertStr) = payload.splitMsgToTuple(7);
 
       // check to make sure symbols defined
-      st.checkTable(mainSegName);
-      st.checkTable(mainValName);
-      st.checkTable(testSegName);
-      st.checkTable(testValName);
+      st.checkTable(mainName);
+      st.checkTable(testName);
 
       var invert: bool;
       if invertStr == "True" {invert = true;
@@ -646,8 +593,8 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
  
       select (mainObjtype, testObjtype) {
           when ("str", "str") {
-              var mainStr = getSegString(mainSegName, mainValName, st);
-              var testStr = getSegString(testSegName, testValName, st);
+              var mainStr = getSegString(mainName, st);
+              var testStr = getSegString(testName, st);
               var e = st.addEntry(rname, mainStr.size, bool);
               if invert {
                   e.a = !in1d(mainStr, testStr);
@@ -669,16 +616,15 @@ proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTup
 
   proc segGroupMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
       var pn = Reflection.getRoutineName();
-      var (objtype, segName, valName) = payload.splitMsgToTuple(3);
+      var (objtype, name, legacy_placeholder) = payload.splitMsgToTuple(3);
 
       // check to make sure symbols defined
-      st.checkTable(segName);
-      st.checkTable(valName);
+      st.checkTable(name);
       
       var rname = st.nextName();
       select (objtype) {
           when "str" {
-              var strings = getSegString(segName, valName, st);
+              var strings = getSegString(name, st);
               var iv = st.addEntry(rname, strings.size, int);
               iv.a = strings.argGroup();
           }

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -121,10 +121,9 @@ module UniqueMsg
             return new MsgTuple(repMsg, MsgType.NORMAL);
           }
           when "str" {
-              var offsetName = st.nextName();
-              var valueName = st.nextName();
-              var (names1,names2) = name.splitMsgToTuple('+', 2);
-              var str = getSegString(names1, names2, st);
+              // TODO remove legacy_placeholder
+              var (names1, legacy_placeholder) = name.splitMsgToTuple('+', 2);
+              var str = getSegString(names1, st);
 
               /*
                * The upper limit here is the similar to argsort/radixSortLSD_keys, but with 
@@ -133,10 +132,9 @@ module UniqueMsg
               overMemLimit((8 * str.size * 8)
                          + (2 * here.maxTaskPar * numLocales * 2**16 * 8));
               var (uo, uv, c, inv) = uniqueGroup(str);
-              st.addEntry(offsetName, new shared SymEntry(uo));
-              st.addEntry(valueName, new shared SymEntry(uv));
-
-              repMsg = "created " + st.attrib(offsetName) + " +created " + st.attrib(valueName);
+              var myStr = getSegString(uo, uv, st);
+              // TODO remove second, legacy call to st.attrib(myStr.name)
+              repMsg = "created " + st.attrib(myStr.name) + " +created " + st.attrib(myStr.name);
 
               if returnCounts {
                   var countName = st.nextName();

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -134,7 +134,7 @@ module UniqueMsg
               var (uo, uv, c, inv) = uniqueGroup(str);
               var myStr = getSegString(uo, uv, st);
               // TODO remove second, legacy call to st.attrib(myStr.name)
-              repMsg = "created " + st.attrib(myStr.name) + " +created " + st.attrib(myStr.name);
+              repMsg = "created %s+created bytes.size %t".format(st.attrib(myStr.name), myStr.nBytes);
 
               if returnCounts {
                   var countName = st.nextName();

--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -303,7 +303,8 @@ proc main() {
                 when "setdiff1d"         {repTuple = setdiff1dMsg(cmd, args, st);}
                 when "setxor1d"          {repTuple = setxor1dMsg(cmd, args, st);}
                 when "union1d"           {repTuple = union1dMsg(cmd, args, st);}
-                when "assembleStrings"   {repTuple = assembleStringsMsg(cmd, args, st);}
+                when "segStr-assemble"   {repTuple = assembleStringsMsg(cmd, args, st);}
+                when "segStr-tondarray"  {binaryRepMsg = segStrTondarrayMsg(cmd, args, st);}
                 when "segmentLengths"    {repTuple = segmentLengthsMsg(cmd, args, st);}
                 when "segmentedHash"     {repTuple = segmentedHashMsg(cmd, args, st);}
                 when "segmentedEfunc"    {repTuple = segmentedEfuncMsg(cmd, args, st);}

--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -303,6 +303,7 @@ proc main() {
                 when "setdiff1d"         {repTuple = setdiff1dMsg(cmd, args, st);}
                 when "setxor1d"          {repTuple = setxor1dMsg(cmd, args, st);}
                 when "union1d"           {repTuple = union1dMsg(cmd, args, st);}
+                when "assembleStrings"   {repTuple = assembleStringsMsg(cmd, args, st);}
                 when "segmentLengths"    {repTuple = segmentLengthsMsg(cmd, args, st);}
                 when "segmentedHash"     {repTuple = segmentedHashMsg(cmd, args, st);}
                 when "segmentedEfunc"    {repTuple = segmentedEfuncMsg(cmd, args, st);}

--- a/test/UnitTestConcatenate.chpl
+++ b/test/UnitTestConcatenate.chpl
@@ -18,27 +18,16 @@ proc addStrings(n:int, minLen:int, maxLen:int, st: borrowed SymTab) {
 proc testConcat(n:int, minLen:int, maxLen:int) {
   var d: Diags;
   var st = new owned SymTab();
-  var (s1, v1) = newRandStringsUniformLength(n, minLen, maxLen);
-  var (s2, v2) = newRandStringsUniformLength(n, minLen, maxLen);
-  var s1Name = st.nextName();
-  var s1e = st.addEntry(s1Name, s1.size, int);
-  s1e.a = s1;
-  var v1Name = st.nextName();
-  var v1e = st.addEntry(v1Name, v1.size, uint(8));
-  v1e.a = v1;
-  var str1 = getSegString(s1Name, v1Name, st);
-  writeSegString("Str 1, %i elem, %i bytes".format(str1.size, str1.nBytes), str1);
-  var s2Name = st.nextName();
-  var s2e = st.addEntry(s2Name, s2.size, int);
-  s2e.a = s2;
-  var v2Name = st.nextName();
-  var v2e = st.addEntry(v2Name, v2.size, uint(8));
-  v2e.a = v2;
-  var str2 = getSegString(s2Name, v2Name, st);
 
+  var (s1, v1) = newRandStringsUniformLength(n, minLen, maxLen);
+  var str1:SegString = getSegString(s1, v1, st);
+  writeSegString("Str 1, %i elem, %i bytes".format(str1.size, str1.nBytes), str1);
+  
+  var (s2, v2) = newRandStringsUniformLength(n, minLen, maxLen);
+  var str2 = getSegString(s2, v2, st);
   writeSegString("\nStr 2, %i elem, %i bytes".format(str2.size, str2.nBytes), str2);
 
-  var reqMsg = "2 str append %s+%s %s+%s".format(s1Name, v1Name, s2Name, v2Name);
+  var reqMsg = "2 str append %s+%s %s+%s".format(str1.name, "legacy_placeholder", str2.name, "legacy_placeholder");
   writeReq(reqMsg);
   d.start();
   var repMsg = concatenateMsg(cmd="concatenate", payload=reqMsg, st).msg;
@@ -46,8 +35,7 @@ proc testConcat(n:int, minLen:int, maxLen:int) {
   writeRep(repMsg);
   var (resSegAttribStr, resValAttribStr) = repMsg.splitMsgToTuple('+', 2);
   var resSegAttrib = parseName(resSegAttribStr);
-  var resValName = parseName(resValAttribStr);
-  var resStr = getSegString(resSegAttrib, resValName, st);
+  var resStr = getSegString(resSegAttrib, st);
   writeSegString("\nResult, %i elem, %i bytes".format(resStr.size, resStr.nBytes), resStr);
 
   var correct = true;
@@ -59,7 +47,7 @@ proc testConcat(n:int, minLen:int, maxLen:int) {
 
   // Test interleave mode
   
-  reqMsg = "2 str interleave %s+%s %s+%s".format(s1Name, v1Name, s2Name, v2Name);
+  reqMsg = "2 str interleave %s+%s %s+%s".format(str1.name, "legacy_placeholder", str2.name, "legacy_placeholder");
   writeReq(reqMsg);
   d.start();
   repMsg = concatenateMsg(cmd="concatenate", payload=reqMsg, st).msg;
@@ -67,8 +55,7 @@ proc testConcat(n:int, minLen:int, maxLen:int) {
   writeRep(repMsg);
   (resSegAttribStr, resValAttribStr) = repMsg.splitMsgToTuple('+', 2);
   resSegAttrib = parseName(resSegAttribStr);
-  resValName = parseName(resValAttribStr);
-  resStr = getSegString(resSegAttrib, resValName, st);
+  resStr = getSegString(resSegAttrib, st);
   writeSegString("\nResult, %i elem, %i bytes".format(resStr.size, resStr.nBytes), resStr);
   correct = true;
   // All offsets should be monotonically increasing.

--- a/test/UnitTestPeelStick.chpl
+++ b/test/UnitTestPeelStick.chpl
@@ -12,17 +12,7 @@ proc make_strings(substr, n, minLen, maxLen, characters, st) {
   const nb = substr.numBytes;
   const sbytes: [0..#nb] uint(8) = for b in substr.chpl_bytes() do b;
   var (segs, vals) = newRandStringsUniformLength(n, minLen, maxLen, characters);
-    
-  var offsetName = st.nextName();
-  var offsetEntry = new shared SymEntry(segs);
-  st.addEntry(offsetName, offsetEntry);
-
-  var valName = st.nextName();
-  var valEntry = new shared SymEntry(vals);
-  st.addEntry(valName, valEntry);
-
-  var strings = new owned SegString(offsetEntry, offsetName, valEntry, valName, st);
-  
+  var strings = getSegString(segs, vals, st);
   var lengths = strings.getLengths() - 1;
   var r: [segs.domain] int;
   fillInt(r, 0, 100);
@@ -47,15 +37,8 @@ proc make_strings(substr, n, minLen, maxLen, characters, st) {
       }
     }
   }
-  offsetName = st.nextName();
-  offsetEntry = new shared SymEntry(segs);
-  st.addEntry(offsetName, offsetEntry);
-
-  valName = st.nextName();
-  valEntry = new shared SymEntry(vals);
-  st.addEntry(valName, valEntry);
-
-  var strings2 = new shared SegString(offsetEntry, offsetName, valEntry, valName, st);
+  
+  var strings2 = getSegString(segs, vals, st): shared SegString;
   return (splits, strings2);
 }
 

--- a/test/UnitTestPeelStick.chpl
+++ b/test/UnitTestPeelStick.chpl
@@ -128,16 +128,14 @@ proc testMessageLayer(substr, n, minLen, maxLen) throws {
   d.start();
   var (answer, strings) = make_strings(substr, n, minLen, maxLen, charSet.Uppercase, st);
   d.stop("make_strings");
-  var reqMsg = "peel str %s str 1 True True True %jt".format(strings.name, [substr]);
+  var reqMsg = "peel str %s legacy_placeholder str 1 True True True %jt".format(strings.name, [substr]);
   writeReq(reqMsg);
   var repMsg = segmentedPeelMsg(cmd="segmentedPeel", payload=reqMsg, st).msg;
   writeRep(repMsg);
   var (loAttribs,lvAttribs,roAttribs,rvAttribs) = repMsg.splitMsgToTuple('+', 4);
   var loname = parseName(loAttribs);
-  var lvname = parseName(lvAttribs);
   var roname = parseName(roAttribs);
-  var rvname = parseName(rvAttribs);
-  reqMsg = "stick str %s %s str %s %s False %jt".format(loname, lvname, roname, rvname, [""]);
+  reqMsg = "stick str %s %s str %s %s False %jt".format(loname, "legacy_placeholder", roname, "legacy_placeholder", [""]);
   writeReq(reqMsg);
   repMsg = segBinopvvMsg(cmd="segBinopvv", payload=reqMsg, st).msg;
   writeRep(repMsg);

--- a/test/UnitTestPeelStick.chpl
+++ b/test/UnitTestPeelStick.chpl
@@ -128,7 +128,7 @@ proc testMessageLayer(substr, n, minLen, maxLen) throws {
   d.start();
   var (answer, strings) = make_strings(substr, n, minLen, maxLen, charSet.Uppercase, st);
   d.stop("make_strings");
-  var reqMsg = "peel str %s %s str 1 True True True %jt".format(strings.offsetName, strings.valueName, [substr]);
+  var reqMsg = "peel str %s str 1 True True True %jt".format(strings.name, [substr]);
   writeReq(reqMsg);
   var repMsg = segmentedPeelMsg(cmd="segmentedPeel", payload=reqMsg, st).msg;
   writeRep(repMsg);

--- a/test/UnitTestPeelStick.chpl
+++ b/test/UnitTestPeelStick.chpl
@@ -141,10 +141,10 @@ proc testMessageLayer(substr, n, minLen, maxLen) throws {
   writeReq(reqMsg);
   repMsg = segBinopvvMsg(cmd="segBinopvv", payload=reqMsg, st).msg;
   writeRep(repMsg);
-  var (rtoAttribs,rtvAttribs) = repMsg.splitMsgToTuple('+', 2);
+  //TODO remove legacy_placeholder
+  var (rtoAttribs,legacy_placeholder) = repMsg.splitMsgToTuple('+', 2);
   var rtoname = parseName(rtoAttribs);
-  var rtvname = parseName(rtvAttribs);
-  var roundTrip = getSegString(rtoname, rtvname, st);
+  var roundTrip = getSegString(rtoname, st);
   var success = && reduce (strings == roundTrip);
   writeln("Round trip successful? >>> %t <<<".format(success));
 }

--- a/test/UnitTestSubstringSearch.chpl
+++ b/test/UnitTestSubstringSearch.chpl
@@ -10,17 +10,7 @@ proc make_strings(substr, n, minLen, maxLen, characters, mode, st) {
   const nb = substr.numBytes;
   const sbytes: [0..#nb] uint(8) = for b in substr.chpl_bytes() do b;
   var (segs, vals) = newRandStringsUniformLength(n, minLen, maxLen, characters);
-  
-  var offsetName = st.nextName();
-  var offsetEntry = new shared SymEntry(segs);
-  st.addEntry(offsetName, offsetEntry);
-
-  var valName = st.nextName();
-  var valEntry = new shared SymEntry(vals);
-  st.addEntry(valName, valEntry);
-
-  var strings = new owned SegString(offsetEntry, offsetName, valEntry, valName, st);
-
+  var strings = getSegString(segs, vals, st);
   var lengths = strings.getLengths() - 1;
   var r: [segs.domain] int;
   fillInt(r, 0, 100);
@@ -45,15 +35,7 @@ proc make_strings(substr, n, minLen, maxLen, characters, mode, st) {
     }
   }
   
-  offsetName = st.nextName();
-  offsetEntry = new shared SymEntry(segs);
-  st.addEntry(offsetName, offsetEntry);
-
-  valName = st.nextName();
-  valEntry = new shared SymEntry(vals);
-  st.addEntry(valName, valEntry);
-
-  var strings2 = new shared SegString(offsetEntry, offsetName, valEntry, valName, st);
+  var strings2 = getSegString(segs, vals, st): shared SegString;
   return (present, strings2);
 }
 

--- a/tests/registration_test.py
+++ b/tests/registration_test.py
@@ -290,23 +290,16 @@ class RegistrationTest(ArkoudaTest):
         # Initial registration should set name
         keep = ak.random_strings_uniform(1, 10, UNIQUE, characters='printable')
         self.assertTrue(keep.register("keep_me").name == "keep_me")
-        self.assertTrue(keep.offsets.name == "keep_me.offsets")
-        self.assertTrue(keep.bytes.name == "keep_me.bytes")
-
         self.assertTrue(keep.is_registered(), "Expected Strings object to be registered")
 
         # Register a second time to confirm name change
         self.assertTrue(keep.register("kept").name == "kept")
-        self.assertTrue(keep.offsets.name == "kept.offsets")
-        self.assertTrue(keep.bytes.name == "kept.bytes")
         self.assertTrue(keep.is_registered(), "Object should be registered with updated name")
 
         # Add an item to discard, confirm our registered item remains and discarded item is gone
         discard = ak.random_strings_uniform(1, 10, UNIQUE, characters='printable')
         ak.clear()
         self.assertTrue(keep.name == "kept")
-        self.assertTrue(keep.offsets.name == "kept.offsets")
-        self.assertTrue(keep.bytes.name == "kept.bytes")
         with self.assertRaises(RuntimeError, msg="discard was not registered and should be discarded"):
             str(discard)
 
@@ -344,12 +337,6 @@ class RegistrationTest(ArkoudaTest):
 
         keep.unregister()
         self.assertFalse(keep.is_registered())
-
-        # Now mess with one of the internal pieces to test is_registered() logic
-        self.assertTrue(keep.register("uut").is_registered(), "Re-register keep as uut")
-        ak.unregister_pdarray_by_name("uut.bytes")
-        with self.assertRaises(RegistrationError, msg="Expected RegistrationError on mis-matched pieces"):
-            keep.is_registered()
 
         ak.clear()
 

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -471,15 +471,15 @@ class StringTest(ArkoudaTest):
         # Convert Pandas series of strings into a byte array where each string is terminated by a null byte.
         # This mimics what should be stored server-side in the strings.bytes pdarray
         expected_series_dec = convert_to_ord(series.to_list())
-        actual_dec = pda.bytes.to_ndarray().tolist()
+        actual_dec = pda._comp_to_ndarray("values").tolist() #pda.bytes.to_ndarray().tolist()
         self.assertListEqual(expected_series_dec, actual_dec)
 
         # Now perform the peel and verify
         a, b = pda.peel(":")
         expected_a = convert_to_ord(["k1", "k2", "k3", ""])
         expected_b = convert_to_ord(["v1", "v2", "v3", "no_colon"])
-        self.assertListEqual(expected_a, a.bytes.to_ndarray().tolist())
-        self.assertListEqual(expected_b, b.bytes.to_ndarray().tolist())
+        self.assertListEqual(expected_a, a._comp_to_ndarray("values").tolist())
+        self.assertListEqual(expected_b, b._comp_to_ndarray("values").tolist())
 
     def test_stick(self):
         run_test_stick(self.strings, self.test_strings, self.base_words, 


### PR DESCRIPTION
### WIP (Work in Progress / Draft PR, please Do Not Merge)

Issue #786 
This is to get a feel for converting a Strings object into a single server-side composite object instead of having the client manage separate pdarrays.

This implementation is meant to be the start of an incremental, iterative approach instead of a complete redesign... meaning that it is likely to evolve as we start to understand its limitations or expand to a more comprehensive approach as we consider/include other complex objects.

### UPDATE:
This is now a fully-working implementation.  I am beginning to write up details of it on the wiki here: https://github.com/Bears-R-Us/arkouda/wiki/SegStringSymEntry-to-encapsulate-Strings-as-single-entity

Status: All aspects of the CI-workflow are passing.

### Future work:
Stream-line the message passing components.  I put _legacy_placeholder_ values for the various message args which previously represented the values/bytes SymEntry component of the Strings construct.  Also we need a better way of passing back meta-data about the new SegStringSymEntry from the server to the client.  It has an additional value that regular SymEntry doesn't have.

If we're going to follow this kind of pattern for other complex objects like Categoricals, we'll face the same problem, how to pass-back the additional meta-data values (i.e. we pass back something like 6 values now, but will need space for more; the SymTab.attrib proc doesn't really handle this).