### PR TITLE
Fixes #825: GroupBy.nunique() fails on Categorical.from_codes()

### DIFF
--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -224,10 +224,9 @@ class GroupBy:
         repMsg = generic_msg(cmd=cmd, args=args)
         self.logger.debug(repMsg)
         return self.unique_keys, create_pdarray(repMsg)
-    
-    @typechecked
+
     def aggregate(self, values: pdarray, operator: str, skipna: bool=True) \
-                    -> Tuple[Union[pdarray, Strings, List[Union[pdarray, Strings]]], pdarray]:
+            -> Tuple[Union[pdarray, Strings, 'Categorical', List[Union[pdarray, Strings]]], pdarray]:  # type: ignore
         '''
         Using the permutation stored in the GroupBy instance, group another 
         array of values and apply a reduction to each group's values. 
@@ -298,7 +297,7 @@ class GroupBy:
             return self.unique_keys, create_pdarray(repMsg)
 
     def sum(self, values : pdarray, skipna : bool=True) \
-                         -> Tuple[Union[pdarray,List[Union[pdarray,Strings]]],pdarray]:
+                         -> Tuple[Union[pdarray, Strings, 'Categorical', List[Union[pdarray,Strings]]],pdarray]:
         """
         Using the permutation stored in the GroupBy instance, group 
         another array of values and sum each group's values. 
@@ -344,7 +343,7 @@ class GroupBy:
         return self.aggregate(values, "sum", skipna)
     
     def prod(self, values : pdarray, skipna : bool=True) \
-                    -> Tuple[Union[pdarray,List[Union[pdarray,Strings]]],pdarray]:
+                    -> Tuple[Union[pdarray, Strings, 'Categorical', List[Union[pdarray,Strings]]],pdarray]:
         """
         Using the permutation stored in the GroupBy instance, group
         another array of values and compute the product of each group's 
@@ -393,7 +392,7 @@ class GroupBy:
         return self.aggregate(values, "prod", skipna)
     
     def mean(self, values : pdarray, skipna : bool=True) \
-                    -> Tuple[Union[pdarray,List[Union[pdarray,Strings]]],pdarray]:
+                    -> Tuple[Union[pdarray, Strings, 'Categorical', List[Union[pdarray,Strings]]],pdarray]:
         """
         Using the permutation stored in the GroupBy instance, group 
         another array of values and compute the mean of each group's 
@@ -440,7 +439,7 @@ class GroupBy:
         return self.aggregate(values, "mean", skipna)
     
     def min(self, values : pdarray, skipna : bool=True) \
-                    -> Tuple[Union[pdarray,List[Union[pdarray,Strings]]],pdarray]:
+                    -> Tuple[Union[pdarray, Strings, 'Categorical', List[Union[pdarray,Strings]]],pdarray]:
         """
         Using the permutation stored in the GroupBy instance, group 
         another array of values and return the minimum of each group's 
@@ -488,7 +487,7 @@ class GroupBy:
         return self.aggregate(values, "min", skipna)
     
     def max(self, values : pdarray, skipna : bool=True) \
-                    -> Tuple[Union[pdarray,List[Union[pdarray,Strings]]],pdarray]:
+                    -> Tuple[Union[pdarray, Strings, 'Categorical', List[Union[pdarray,Strings]]],pdarray]:
         """
         Using the permutation stored in the GroupBy instance, group
         another array of values and return the maximum of each 
@@ -536,7 +535,7 @@ class GroupBy:
         return self.aggregate(values, "max", skipna)
     
     def argmin(self, values : pdarray) \
-                    -> Tuple[Union[pdarray,List[Union[pdarray,Strings]]],pdarray]:
+                    -> Tuple[Union[pdarray, Strings, 'Categorical', List[Union[pdarray,Strings]]],pdarray]:
         """
         Using the permutation stored in the GroupBy instance, group   
         another array of values and return the location of the first 
@@ -589,7 +588,7 @@ class GroupBy:
         return self.aggregate(values, "argmin")
     
     def argmax(self, values : pdarray)\
-                    -> Tuple[Union[pdarray,List[Union[pdarray,Strings]]],pdarray]:
+                    -> Tuple[Union[pdarray, Strings, 'Categorical', List[Union[pdarray,Strings]]],pdarray]:
         """
         Using the permutation stored in the GroupBy instance, group   
         another array of values and return the location of the first 
@@ -640,7 +639,7 @@ class GroupBy:
         return self.aggregate(values, "argmax")
     
     def nunique(self, values : pdarray) \
-                    -> Tuple[Union[pdarray,List[Union[pdarray,Strings]]],pdarray]:
+                    -> Tuple[Union[pdarray, Strings, 'Categorical', List[Union[pdarray,Strings]]],pdarray]:
         """
         Using the permutation stored in the GroupBy instance, group another
         array of values and return the number of unique values in each group. 
@@ -691,7 +690,7 @@ class GroupBy:
         return self.aggregate(values, "nunique")
     
     def any(self, values : pdarray) \
-                    -> Tuple[Union[pdarray,List[Union[pdarray,Strings]]],pdarray]:
+                    -> Tuple[Union[pdarray, Strings, 'Categorical', List[Union[pdarray,Strings]]],pdarray]:
         """
         Using the permutation stored in the GroupBy instance, group another 
         array of values and perform an "or" reduction on each group. 
@@ -722,7 +721,7 @@ class GroupBy:
         return self.aggregate(values, "any")
 
     def all(self, values : pdarray) \
-                    -> Tuple[Union[pdarray,List[Union[pdarray,Strings]]],pdarray]:
+                    -> Tuple[Union[pdarray, Strings, 'Categorical', List[Union[pdarray,Strings]]],pdarray]:
         """
         Using the permutation stored in the GroupBy instance, group  
         another array of values and perform an "and" reduction on 
@@ -757,7 +756,7 @@ class GroupBy:
         return self.aggregate(values, "all")
 
     def OR(self, values : pdarray) \
-                    -> Tuple[Union[pdarray,List[Union[pdarray,Strings]]],pdarray]:
+                    -> Tuple[Union[pdarray, Strings, 'Categorical', List[Union[pdarray,Strings]]],pdarray]:
         """
         Bitwise OR of values in each segment.
         
@@ -794,7 +793,7 @@ class GroupBy:
         return self.aggregate(values, "or")
 
     def AND(self, values : pdarray) \
-                    -> Tuple[Union[pdarray,List[Union[pdarray,Strings]]],pdarray]:
+                    -> Tuple[Union[pdarray, Strings, 'Categorical', List[Union[pdarray,Strings]]],pdarray]:
         """
         Bitwise AND of values in each segment.
         
@@ -831,7 +830,7 @@ class GroupBy:
         return self.aggregate(values, "and")
 
     def XOR(self, values : pdarray) \
-                    -> Tuple[Union[pdarray,List[Union[pdarray,Strings]]],pdarray]:
+                    -> Tuple[Union[pdarray, Strings, 'Categorical', List[Union[pdarray,Strings]]],pdarray]:
         """
         Bitwise XOR of values in each segment.
         

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -294,3 +294,20 @@ class GroupByTest(ArkoudaTest):
         actual = {label: value for (label, value) in zip(labels.to_ndarray(), values.to_ndarray())}
 
         self.assertDictEqual(expected, actual)
+
+    def test_cat_from_codes(self):
+        cat1 = ak.Categorical(ak.array(['a', 'b', 'a', 'b', 'c']))
+        cat2 = ak.Categorical.from_codes(codes=ak.array([0, 1, 0, 1, 2]), categories=ak.array(['a', 'b', 'c']))
+        i = ak.arange(cat1.size)
+
+        expected = {'a': 2, 'b': 2, 'c': 1}
+
+        cat1_group = ak.GroupBy(cat1)
+        cat1_labels, cat1_values = cat1_group.nunique(i)
+        cat1_actual = {label: value for (label, value) in zip(cat1_labels.to_ndarray(), cat1_values.to_ndarray())}
+        self.assertDictEqual(expected, cat1_actual)
+
+        cat2_group = ak.GroupBy(cat2)
+        cat2_labels, cat2_values = cat2_group.nunique(i)
+        cat2_actual = {label: value for (label, value) in zip(cat2_labels.to_ndarray(), cat2_values.to_ndarray())}
+        self.assertDictEqual(expected, cat2_actual)


### PR DESCRIPTION
This PR (#825):
- Adds test for `Groupby.nunique(Categorical.from_codes())`
- Turns off type checking for `aggregate` in a similar way to what is done for `argsort` in `sorting.py`