### PR TITLE
Capture corner case to prevent server crash for ak.in1d

### DIFF
--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -8,7 +8,7 @@ from arkouda.pdarrayclass import pdarray, RegistrationError, unregister_pdarray_
 from arkouda.groupbyclass import GroupBy, broadcast
 from arkouda.pdarraysetops import in1d, unique, concatenate
 from arkouda.pdarraycreation import zeros, zeros_like, arange
-from arkouda.dtypes import resolve_scalar_dtype, str_scalars
+from arkouda.dtypes import resolve_scalar_dtype, str_scalars, int_scalars
 from arkouda.dtypes import int64 as akint64
 from arkouda.sorting import argsort
 from arkouda.logger import getArkoudaLogger
@@ -78,7 +78,7 @@ class Categorical:
             self.permutation = cast(pdarray, g.permutation)
             self.segments = g.segments
         # Always set these values
-        self.size = self.codes.size
+        self.size: int_scalars = self.codes.size
         self.nlevels = self.categories.size
         self.ndim = self.codes.ndim
         self.shape = self.codes.shape

--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -518,7 +518,7 @@ def generic_msg(cmd : str, args : Union[str,bytes]=None, send_bytes : bool=False
         The message to be sent in the form of a string or bytes array
     send_bytes : bool
         Indicates if the message to be sent is binary, defaults to False
-    recv_bypes : bool
+    recv_bytes : bool
         Indicates if the return message will be binary, default to False
 
     Returns

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -153,7 +153,7 @@ def in1d(pda1 : Union[pdarray,Strings,'Categorical'], pda2 : Union[pdarray,Strin
         repMsg = generic_msg(cmd="in1d", args="{} {} {}".\
                              format(pda1.name, pda2.name, invert))
         return create_pdarray(repMsg)
-    if isinstance(pda1, Strings) and isinstance(pda2, Strings):
+    elif isinstance(pda1, Strings) and isinstance(pda2, Strings):
         repMsg = generic_msg(cmd="segmentedIn1d", args="{} {} {} {} {} {} {}".\
                                     format(pda1.objtype,
                                     pda1.offsets.name,

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -3,7 +3,7 @@ from typing import cast, Optional, Sequence, Tuple, Union, ForwardRef
 from typeguard import typechecked
 from arkouda.client import generic_msg, get_config
 from arkouda.pdarrayclass import pdarray, create_pdarray
-from arkouda.pdarraycreation import zeros_like, array
+from arkouda.pdarraycreation import zeros, zeros_like, array
 from arkouda.sorting import argsort
 from arkouda.strings import Strings
 from arkouda.logger import getArkoudaLogger
@@ -142,11 +142,13 @@ def in1d(pda1 : Union[pdarray,Strings,'Categorical'], pda2 : Union[pdarray,Strin
     array([False, True])
     """
     from arkouda.categorical import Categorical as Categorical_
-    if isinstance(pda2, pdarray) or isinstance(pda2, Strings) or isinstance(pda2, Categorical_):
-        from arkouda.dtypes import int_scalars, structDtypeCodes
-        if pda2.size == 0:  # If pda2 is empty, in1d shouldn't do anything.
-            repMsg = generic_msg(cmd="create", args="int64 0")
+    if isinstance(pda1, pdarray) or isinstance(pda1, Strings) or isinstance(pda1, Categorical_):
+        if pda1.size == 0:
+            repMsg = generic_msg(cmd="create", args="bool 0")
             return  create_pdarray(cast(str,repMsg))
+    if isinstance(pda2, pdarray) or isinstance(pda2, Strings) or isinstance(pda2, Categorical_):
+        if pda2.size == 0:
+            return  zeros(pda1.size, dtype='bool')
     if hasattr(pda1, 'categories'):
         return cast(Categorical_,pda1).in1d(pda2)
     elif isinstance(pda1, pdarray) and isinstance(pda2, pdarray):

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -142,11 +142,12 @@ def in1d(pda1 : Union[pdarray,Strings,'Categorical'], pda2 : Union[pdarray,Strin
     array([False, True])
     """
     from arkouda.categorical import Categorical as Categorical_
-    if isinstance(pda1, (pdarray, Strings, Categorical_)):
+    if isinstance(pda1, pdarray) or isinstance(pda1, Strings) or isinstance (pda1, Categorical_):
+        # While isinstance(thing, type) can be called on a tuple of types, this causes an issue with mypy for unknown reasons.
         if pda1.size == 0:
             repMsg = generic_msg(cmd="create", args="bool 0")
             return  create_pdarray(cast(str,repMsg))
-    if isinstance(pda2, (pdarray, Strings, Categorical_)):
+    if isinstance(pda2, pdarray) or isinstance(pda2, Strings) or isinstance(pda2, Categorical_):
         if pda2.size == 0:
             return  zeros(pda1.size, dtype=bool)
     if hasattr(pda1, 'categories'):

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -145,8 +145,7 @@ def in1d(pda1 : Union[pdarray,Strings,'Categorical'], pda2 : Union[pdarray,Strin
     if isinstance(pda1, pdarray) or isinstance(pda1, Strings) or isinstance (pda1, Categorical_):
         # While isinstance(thing, type) can be called on a tuple of types, this causes an issue with mypy for unknown reasons.
         if pda1.size == 0:
-            repMsg = generic_msg(cmd="create", args="bool 0")
-            return  create_pdarray(cast(str,repMsg))
+            return  zeros(0, dtype=bool)
     if isinstance(pda2, pdarray) or isinstance(pda2, Strings) or isinstance(pda2, Categorical_):
         if pda2.size == 0:
             return  zeros(pda1.size, dtype=bool)

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -148,7 +148,7 @@ def in1d(pda1 : Union[pdarray,Strings,'Categorical'], pda2 : Union[pdarray,Strin
             return  create_pdarray(cast(str,repMsg))
     if isinstance(pda2, (pdarray, Strings, Categorical_)):
         if pda2.size == 0:
-            return  zeros(pda1.size, dtype='bool')
+            return  zeros(pda1.size, dtype=bool)
     if hasattr(pda1, 'categories'):
         return cast(Categorical_,pda1).in1d(pda2)
     elif isinstance(pda1, pdarray) and isinstance(pda2, pdarray):

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -141,6 +141,10 @@ def in1d(pda1 : Union[pdarray,Strings,'Categorical'], pda2 : Union[pdarray,Strin
     >>> ak.in1d(ak.array(['one','two']),ak.array(['two', 'three','four','five']))
     array([False, True])
     """
+    # If the second array is empty, it will crash the server when pda1.size > mBound=2**25
+    # This is because of an issue with the in1dSort process in arkouda/src/In1d.chpl, lines 135-170
+    if pda2.size == 0:
+        return arkouda.pdarraycreation.array([])
     from arkouda.categorical import Categorical as Categorical_
     if hasattr(pda1, 'categories'):
         return cast(Categorical_,pda1).in1d(pda2)

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -142,11 +142,11 @@ def in1d(pda1 : Union[pdarray,Strings,'Categorical'], pda2 : Union[pdarray,Strin
     array([False, True])
     """
     from arkouda.categorical import Categorical as Categorical_
-    if isinstance(pda1, pdarray) or isinstance(pda1, Strings) or isinstance(pda1, Categorical_):
+    if isinstance(pda1, (pdarray, Strings, Categorical_)):
         if pda1.size == 0:
             repMsg = generic_msg(cmd="create", args="bool 0")
             return  create_pdarray(cast(str,repMsg))
-    if isinstance(pda2, pdarray) or isinstance(pda2, Strings) or isinstance(pda2, Categorical_):
+    if isinstance(pda2, (pdarray, Strings, Categorical_)):
         if pda2.size == 0:
             return  zeros(pda1.size, dtype='bool')
     if hasattr(pda1, 'categories'):


### PR DESCRIPTION
Based on an issue discovered with ak.in1d(pd1, pd2), a quick fix is implemented for preventing a server crash.  In1d calls one of three function calls based on array size; when the combined size of both arrays passed mBound (set as 2**25 server-side), the process defined in 'arkouda/src/In1d.chpl' crashes the server when pd2 is an empty array.

While this should resolve the issue, it is still a good idea to look more closely as what is happening on the server that causes the crash.