### PR TITLE
Stop importing arkouda in util/test/util.py

### DIFF
--- a/util/test/util.py
+++ b/util/test/util.py
@@ -23,8 +23,6 @@ import time
 
 from collections import namedtuple
 
-from context import arkouda
-
 util_dir = os.path.dirname(os.path.realpath(__file__))
 
 ##################


### PR DESCRIPTION
We don't need it since 0814c49