### PR TITLE
Make the array values in groupby and aggregate benchmarks consistent

### DIFF
--- a/benchmarks/aggregate.py
+++ b/benchmarks/aggregate.py
@@ -8,7 +8,7 @@ BOOLOPS = ('any', 'all')
 def generate_arrays(N, seed):
     # Sort keys so that aggregations will not have to permute values
     # We just want to measure aggregation time, not gather
-    keys = ak.sort(ak.randint(0, N//8, N, seed=seed))
+    keys = ak.sort(ak.randint(0, 2**32, N, seed=seed))
     if seed is not None: seed += 1
     intvals = ak.randint(0, 2**16, N, seed=seed)
     boolvals = (intvals % 2) == 0

--- a/benchmarks/groupby.py
+++ b/benchmarks/groupby.py
@@ -11,7 +11,7 @@ def generate_arrays(N, numArrays, dtype, seed):
     arrays = []
     for i in range(numArrays):
         if dtype == 'int64' or (i % 2 == 0 and dtype == 'mixed'):
-            a = ak.randint(0, N//8, N//numArrays, seed=seed)
+            a = ak.randint(0, 2**32, N//numArrays, seed=seed)
             arrays.append(a)
             totalbytes += a.size * a.itemsize
         else:


### PR DESCRIPTION
Previously, the values in the array were based on the array size, which
meant that larger values were used as the array size grew. Some
algorithms in Arkouda like radixsort are based on the number of bits
used so when we transitioned from something like 32-bit to 33-bit values
an extra round of radixsort would be required.

This gave us the false impression that there was a regression at certain
problem sizes when in reality it was about the array values not the
array size. To avoid this confusion just use 32-bit values for all
problem sizes. This matches what we do in all the benchmarks.

Resolves #793