### PR TITLE
Closes #692: Add support for multi-level GroupBy with Categorical

### DIFF
--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -56,7 +56,7 @@ class GroupBy:
 
     Parameters
     ----------
-    keys : (list of) pdarray, int64 or Strings
+    keys : (list of) pdarray, int64, Strings, or Categorical
         The array to group by value, or if list, the column arrays to group by row
     assume_sorted : bool
         If True, assume keys is already sorted (Default: False)
@@ -69,7 +69,7 @@ class GroupBy:
         The length of the array(s), i.e. number of rows
     permutation : pdarray
         The permutation that sorts the keys array(s) by value (row)
-    unique_keys : (list of) pdarray or Strings
+    unique_keys : (list of) pdarray, Strings, or Categorical
         The unique values of the keys array(s), in grouped order
     segments : pdarray
         The start index of each group in the grouped array(s)
@@ -86,14 +86,14 @@ class GroupBy:
 
     Notes
     -----
-    Only accepts pdarrays of int64 dtype or Strings.
+    Only accepts (list of) pdarrays of int64 dtype, Strings, or Categorical.
 
     """
     Reductions = GROUPBY_REDUCTION_TYPES
 
-    def __init__(self, keys : Union[pdarray,Strings,'Categorical', 
-                                    List[Union[pdarray,np.int64,Strings]]], 
-                assume_sorted : bool=False, hash_strings : bool=True) -> None:
+    def __init__(self, keys: Union[pdarray, Strings, 'Categorical',
+                                   List[Union[pdarray, np.int64, Strings, 'Categorical']]],
+                 assume_sorted: bool = False, hash_strings: bool = True) -> None:
         from arkouda.categorical import Categorical
         self.logger = getArkoudaLogger(name=self.__class__.__name__)
         self.assume_sorted = assume_sorted

--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -163,6 +163,11 @@ module ArgSortMsg
             thisSize = g.size;
             hasStr = true;
           }
+          when "category" {
+            // passed only Categorical.codes.name to be sorted on
+            var g = st.lookup(name);
+            thisSize = g.size;
+          }
           otherwise {
               var errorMsg = unrecognizedTypeError(pn, objtype);
               asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);  

--- a/tests/coargsort_test.py
+++ b/tests/coargsort_test.py
@@ -139,7 +139,37 @@ class CoargsortTest(ArkoudaTest):
             ak.coargsort([ones, short_ones])
             
         with self.assertRaises(TypeError):
-            ak.coargsort([list(range(0,10)), [0]])       
+            ak.coargsort([list(range(0,10)), [0]])
+
+    def test_coargsort_categorical(self):
+        string = ak.array(['a', 'b', 'a', 'b', 'c'])
+        cat = ak.Categorical(string)
+        cat_from_codes = ak.Categorical.from_codes(codes=ak.array([0, 1, 0, 1, 2]),
+                                                   categories=ak.array(['a', 'b', 'c']))
+        str_perm = ak.coargsort([string])
+        str_sorted = string[str_perm].to_ndarray()
+
+        # coargsort on categorical
+        cat_perm = ak.coargsort([cat])
+        cat_sorted = cat[cat_perm].to_ndarray()
+        self.assertTrue((str_sorted == cat_sorted).all())
+
+        # coargsort on categorical.from_codes
+        # coargsort sorts using codes, the order isn't guaranteed, only grouping
+        from_codes_perm = ak.coargsort([cat_from_codes])
+        from_codes_sorted = cat_from_codes[from_codes_perm].to_ndarray()
+        self.assertTrue((['a', 'a', 'b', 'b', 'c'] == from_codes_sorted).all())
+
+        # coargsort on 2 categoricals (one from_codes)
+        cat_perm = ak.coargsort([cat, cat_from_codes])
+        cat_sorted = cat[cat_perm].to_ndarray()
+        self.assertTrue((str_sorted == cat_sorted).all())
+
+        # coargsort on mixed strings and categoricals
+        mixed_perm = ak.coargsort([cat, string, cat_from_codes])
+        mixed_sorted = cat_from_codes[mixed_perm].to_ndarray()
+        self.assertTrue((str_sorted == mixed_sorted).all())
+
 
 def create_parser():
     parser = argparse.ArgumentParser(description="Check coargsort correctness.")

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -282,7 +282,7 @@ class GroupByTest(ArkoudaTest):
         with self.assertRaises(TypeError) as cm:
             self.igb.argmax(ak.randint(0,1,10,dtype=bool))
         self.assertEqual('argmax is only supported for pdarrays of dtype float64 and int64', 
-                         cm.exception.args[0])  
+                         cm.exception.args[0])
 
     def test_aggregate_strings(self):
         s = ak.array(['a', 'b', 'a', 'b', 'c'])
@@ -294,3 +294,36 @@ class GroupByTest(ArkoudaTest):
         actual = {label: value for (label, value) in zip(labels.to_ndarray(), values.to_ndarray())}
 
         self.assertDictEqual(expected, actual)
+
+    def test_multi_level_categorical(self):
+        string = ak.array(['a', 'b', 'a', 'b', 'c'])
+        cat = ak.Categorical(string)
+        cat_from_codes = ak.Categorical.from_codes(codes=ak.array([0, 1, 0, 1, 2]),
+                                                   categories=ak.array(['a', 'b', 'c']))
+        i = ak.arange(string.size)
+        expected = {('a', 'a'): 2, ('b', 'b'): 2, ('c', 'c'): 1}
+
+        # list of 2 strings
+        str_grouping = ak.GroupBy([string, string])
+        str_labels, str_values = str_grouping.nunique(i)
+        str_dict = to_tuple_dict(str_labels, str_values)
+        self.assertDictEqual(expected, str_dict)
+
+        # list of 2 cats (one from_codes)
+        cat_grouping = ak.GroupBy([cat, cat_from_codes])
+        cat_labels, cat_values = cat_grouping.nunique(i)
+        cat_dict = to_tuple_dict(cat_labels, cat_values)
+        self.assertDictEqual(expected, cat_dict)
+
+        # One cat (from_codes) and one string
+        mixed_grouping = ak.GroupBy([cat_from_codes, string])
+        mixed_labels, mixed_values = mixed_grouping.nunique(i)
+        mixed_dict = to_tuple_dict(mixed_labels, mixed_values)
+        self.assertDictEqual(expected, mixed_dict)
+
+
+def to_tuple_dict(labels, values):
+    # transforms labels from list of arrays into a list of tuples by index and builds a dictionary
+    # labels: [array(['b', 'a', 'c']), array(['b', 'a', 'c'])] -> [('b', 'b'), ('a', 'a'), ('c', 'c')]
+    return {label: value for (label, value) in
+            zip([index_tuple for index_tuple in zip(*[pda.to_ndarray() for pda in labels])], values.to_ndarray())}


### PR DESCRIPTION
This PR (Closes #692):
- Updates coargsort to sort Categoricals by their `Categorical.codes` component (this guarantees grouping but not sorting, the same standard for Strings)
- Adds test for GroupBy with multiple Categoricals and test for coargsort with multiple Categoricals

Note:
Because Categoricals are sorted according to their codes, two seemingly equivalent categoricals can be "sorted" by coargsort differently. I'm not convinced this is the functionality we want, so feel free to weigh in 

```python
>>> cat1 = ak.Categorical.from_codes(codes=ak.array([0, 1, 0, 1, 2]), categories=ak.array(['a', 'b', 'c']))
>>> cat2 = ak.Categorical.from_codes(codes=ak.array([1, 0, 1, 0, 2]), categories=ak.array(['b', 'a', 'c']))
>>> cat1
array(['a', 'b', 'a', 'b', 'c'])
>>> cat2
array(['a', 'b', 'a', 'b', 'c'])
>>> cat1[ak.coargsort([cat1])]
array(['a', 'a', 'b', 'b', 'c'])
>>> cat2[ak.coargsort([cat2])]
array(['b', 'b', 'a', 'a', 'c'])
```