### PR TITLE
Closes #839: Explicitly adding missing package for mypy CI job failure.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get update && apt-get install -y python3-pip
+        python3 -m pip install types-pkg_resources
         python3 -m pip install -e .[dev]
     - name: Arkouda mypy
       run: |


### PR DESCRIPTION
See Arkouda Issue #839 
CI workflow failure on the `mypy` job because the CI container has a missing package.
Example: https://github.com/glitch/arkouda/runs/2793977571?check_suite_focus=true
(check the `mypy` failure section and error message)

This updates the CI workflow to add the explicit package installation instruction in the container to solve the issue.

#### Steps to reproduce:
In theory any push / PR done after the initial breakage date (June 08, 2021) should fail for this reason.  I believe the issue is ultimately upstream from the Arkouda project.