### PR TITLE
Update these operator declarations to use the operator keyword

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,16 +98,17 @@ endif
 check-deps: $(CHECK_DEPS)
 
 CHPL_MINOR := $(shell $(CHPL) --version | sed -n "s/chpl version 1\.\([0-9]*\).*/\1/p")
-CHPL_VERSION_OK := $(shell test $(CHPL_MINOR) -ge 22 && echo yes)
-CHPL_VERSION_WARN := $(shell test $(CHPL_MINOR) -le 23 && echo yes)
+CHPL_VERSION_OK := $(shell test $(CHPL_MINOR) -ge 24 && echo yes)
+CHPL_VERSION_WARN := $(shell test $(CHPL_MINOR) -le 24 && echo yes)
 .PHONY: check-chpl
 check-chpl:
 ifneq ($(CHPL_VERSION_OK),yes)
-	$(error Chapel 1.22.0 or newer is required)
+	$(error Chapel 1.24.0 or newer is required)
 endif
-ifeq ($(CHPL_VERSION_WARN),yes)
-	$(warning Chapel 1.24.1 or newer is recommended)
-endif
+# Re-enable when support more than just one version again
+#ifeq ($(CHPL_VERSION_WARN),yes)
+#	$(warning Chapel 1.24.1 or newer is recommended)
+#endif
 
 CHPL_VERSION_122 := $(shell test $(CHPL_MINOR) -eq 22 && echo yes)
 ifeq ($(CHPL_VERSION_122),yes)

--- a/src/JoinEqWithDTMsg.chpl
+++ b/src/JoinEqWithDTMsg.chpl
@@ -23,10 +23,10 @@ module JoinEqWithDTMsg
     const jeLogger = new Logger(logLevel);
 
     // operator overloads so + reduce and + scan can work on atomic int arrays
-    proc +(x: atomic int, y: atomic int) {
+    operator +(x: atomic int, y: atomic int) {
         return x.read() + y.read();
     }
-    proc +=(X: [?D] int, Y: [D] atomic int) {
+    operator +=(X: [?D] int, Y: [D] atomic int) {
         [i in D] {X[i] += Y[i].read();}
     }
 

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -750,13 +750,13 @@ module SegmentedArray {
   
   /* Test for equality between two same-length arrays of strings. Returns
      a boolean vector of the same length. */
-  operator SegString.==(lss:SegString, rss:SegString) throws {
+  operator ==(lss:SegString, rss:SegString) throws {
     return compare(lss, rss, true);
   }
 
   /* Test for inequality between two same-length arrays of strings. Returns
      a boolean vector of the same length. */
-  operator SegString.!=(lss:SegString, rss:SegString) throws {
+  operator !=(lss:SegString, rss:SegString) throws {
     return compare(lss, rss, false);
   }
 

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -750,13 +750,13 @@ module SegmentedArray {
   
   /* Test for equality between two same-length arrays of strings. Returns
      a boolean vector of the same length. */
-  proc ==(lss:SegString, rss:SegString) throws {
+  operator SegString.==(lss:SegString, rss:SegString) throws {
     return compare(lss, rss, true);
   }
 
   /* Test for inequality between two same-length arrays of strings. Returns
      a boolean vector of the same length. */
-  proc !=(lss:SegString, rss:SegString) throws {
+  operator SegString.!=(lss:SegString, rss:SegString) throws {
     return compare(lss, rss, false);
   }
 
@@ -821,13 +821,13 @@ module SegmentedArray {
 
   /* Test an array of strings for equality against a constant string. Return a boolean
      vector the same size as the array. */
-  proc ==(ss:SegString, testStr: string) {
+  operator ==(ss:SegString, testStr: string) {
     return compare(ss, testStr, true);
   }
   
   /* Test an array of strings for inequality against a constant string. Return a boolean
      vector the same size as the array. */
-  proc !=(ss:SegString, testStr: string) {
+  operator !=(ss:SegString, testStr: string) {
     return compare(ss, testStr, false);
   }
 


### PR DESCRIPTION
Chapel 1.24 added support for declaring operator overloads with a new "operator"
keyword.  This enables operator definitions to be more easily found.
Declarations without the keyword will be deprecated starting in 1.25 (which is a
few months down the road, but I figured it would be good to address avoid the
deprecation warning as soon as possible)

At least two of these could be operator methods.  I'm choosing to avoid doing that right
now for compatibility with 1.24 - there were some bugs with operator methods
remaining by the time of that release that should be resolved on master, or
shortly after a PR I have opened is merged.  In the future, we can choose to
use that functionality

`make default` and `make test` both worked

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>