### PR TITLE
Change broadcast default and update docs

### DIFF
--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -73,9 +73,7 @@ class Categorical:
                                  "Strings not yet supported"))
             g = GroupBy(values)
             self.categories = g.unique_keys
-            self.codes = zeros(values.size, dtype=np.int64)
-            self.codes[cast(pdarray, g.permutation)] = \
-                                g.broadcast(arange(self.categories.size))
+            self.codes = g.broadcast(arange(self.categories.size), permute=True)
             self.permutation = cast(pdarray, g.permutation)
             self.segments = g.segments
         # Always set these values
@@ -294,8 +292,7 @@ class Categorical:
         """
         g = GroupBy(self.codes)
         idx = self.categories[g.unique_keys]
-        newvals = zeros(self.codes.size, akint64)
-        newvals[g.permutation] = g.broadcast(arange(idx.size))
+        newvals = g.broadcast(arange(idx.size), permute=True)
         return Categorical.from_codes(newvals, idx, permutation=g.permutation, 
                                       segments=g.segments)
 

--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -867,7 +867,7 @@ class GroupBy:
         return self.aggregate(values, "xor")
 
     @typechecked
-    def broadcast(self, values : pdarray, permute : bool=False) -> pdarray:
+    def broadcast(self, values : pdarray, permute : bool=True) -> pdarray:
         """
         Fill each group's segment with a constant value.
 
@@ -875,6 +875,10 @@ class GroupBy:
         ----------
         values : pdarray
             The values to put in each group's segment
+        permute : bool
+            If True (default), permute broadcast values back to the ordering
+            of the original array on which GroupBy was called. If False, the
+            broadcast values are grouped by value.
 
         Returns
         -------
@@ -896,24 +900,18 @@ class GroupBy:
         this function takes a (dense) column vector and replicates
         each value to the non-zero elements in the corresponding row.
 
-        The returned array is in permuted (grouped) order. To get
-        back to the order of the array on which GroupBy was called,
-        the user must invert the permutation (see below).
-
         Examples
         --------
         >>> a = ak.array([0, 1, 0, 1, 0])
         >>> values = ak.array([3, 5])
         >>> g = ak.GroupBy(a)
-        # Result is in grouped order
+        # By default, result is in original order
         >>> g.broadcast(values)
-        array([3, 3, 3, 5, 5]
-
-        >>> b = ak.zeros_like(a)
-        # Result is in original order
-        >>> b[g.permutation] = g.broadcast(values)
-        >>> b
         array([3, 5, 3, 5, 3])
+        
+        # With permute=False, result is in grouped order
+        >>> g.broadcast(values, permute=False)
+        array([3, 3, 3, 5, 5]
         
         >>> a = ak.randint(1,5,10)
         >>> a
@@ -921,11 +919,11 @@ class GroupBy:
         >>> g = ak.GroupBy(a)
         >>> keys,counts = g.count()
         >>> g.broadcast(counts > 2)
-        array([0, 0, 0, 0, 1, 1, 1, 1, 1, 1])
+        array([True False True True True False True True False False])
         >>> g.broadcast(counts == 3)
-        array([0, 0, 0, 0, 1, 1, 1, 1, 1, 1])
+        array([True False True True True False True True False False])
         >>> g.broadcast(counts < 4)
-        array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+        array([True True True True True True True True True True])
         """
         if values.size != self.segments.size:
             raise ValueError("Must have one value per segment")
@@ -940,6 +938,54 @@ class GroupBy:
 
 def broadcast(segments : pdarray, values : pdarray, size : Union[int,np.int64]=-1,
               permutation : Union[pdarray, None]=None):
+    '''
+    Broadcast a dense column vector to the rows of a sparse matrix or grouped array.
+    
+    Parameters
+    ----------
+    segments : pdarray, int64
+        Offsets of the start of each row in the sparse matrix or grouped array.
+        Must be sorted in ascending order.
+    values : pdarray
+        The values to broadcast, one per row (or group)
+    size : int
+        The total number of nonzeros in the matrix. If permutation is given, this
+        argument is ignored and the size is inferred from the permutation array.
+    permutation : pdarray, int64
+        The permutation to go from the original ordering of nonzeros to the ordering
+        grouped by row. To broadcast values back to the original ordering, this
+        permutation will be inverted. If no permutation is supplied, it is assumed
+        that the original nonzeros were already grouped by row. In this case, the
+        size argument must be given.
+        
+    Returns
+    -------
+    pdarray
+        The broadcast values, one per nonzero
+        
+    Raises
+    ------
+    ValueError
+        - If segments and values are different sizes
+        - If segments are empty
+        - If number of nonzeros (either user-specified or inferred from permutation)
+          is less than one
+        
+    Examples
+    --------
+    # Define a sparse matrix with 3 rows and 7 nonzeros
+    >>> row_starts = ak.array([0, 2, 5])
+    >>> nnz = 7
+    # Broadcast the row number to each nonzero element
+    >>> row_number = ak.arange(3)
+    >>> ak.broadcast(row_starts, row_number, nnz)
+    array([0 0 1 1 1 2 2])
+    
+    # If the original nonzeros were in reverse order...
+    >>> permutation = ak.arange(6, -1, -1)
+    >>> ak.broadcast(row_starts, row_number, permutation=permutation)
+    array([2 2 1 1 1 0 0])
+    '''
     if segments.size != values.size:
         raise ValueError("segments and values arrays must be same size")
     if segments.size == 0:


### PR DESCRIPTION
This PR does two things:
- Changes default for `permute` keyword argument of `GroupBy.broadcast` from `False` to `True`. In personal experience and discussions with users, I have only ever seen it called with `permute=True`. Making this the default would clean up user code and make the behavior more intuitive for new users.
- Updates documentation for `GroupBy.broadcast` and `ak.broadcast` to reflect new default and the fact that we can now broadcast booleans.