### PR TITLE
847 Uncaught Chapel Logging Error

### DIFF
--- a/src/Logging.chpl
+++ b/src/Logging.chpl
@@ -38,39 +38,65 @@ module Logging {
         proc init() {}
         
         proc debug(moduleName, routineName, lineNumber, msg: string) throws {
-            if level == LogLevel.DEBUG  {
-                writeln(generateLogMessage(moduleName, routineName, lineNumber, 
+            try {
+                if level == LogLevel.DEBUG  {
+                    writeln(generateLogMessage(moduleName, routineName, lineNumber, 
                                             msg, "DEBUG"));
-                stdout.flush();
+                    stdout.flush();
+                }
+            } catch (e: Error) {
+                writeln(generateErrorMsg(moduleName, routineName, lineNumber, e));
             }
         }
         
         proc info(moduleName, routineName, lineNumber, msg: string) throws {
-            if infoLevels.contains(level) {
-                writeln(generateLogMessage(moduleName, routineName, lineNumber, 
+            try {
+                if infoLevels.contains(level) {
+                    writeln(generateLogMessage(moduleName, routineName, lineNumber, 
                                             msg, "INFO"));
-                stdout.flush();
+                    stdout.flush();
+                }
+            } catch (e: Error) {
+                writeln(generateErrorMsg(moduleName, routineName, lineNumber, e));
             }
         }
         
         proc warn(moduleName, routineName, lineNumber, msg: string) throws {
-            if warnLevels.contains(level) {
-                writeln(generateLogMessage(moduleName, routineName, lineNumber, 
+            try {
+                if warnLevels.contains(level) {
+                    writeln(generateLogMessage(moduleName, routineName, lineNumber, 
                                             msg, "WARN"));
-                stdout.flush();
+                    stdout.flush();
+                }
+            } catch (e: Error) {
+                writeln(generateErrorMsg(moduleName, routineName, lineNumber, e));
             }
         }
         
         proc critical(moduleName, routineName, lineNumber, msg: string) throws {
-            writeln(generateLogMessage(moduleName, routineName, lineNumber, 
+            try {
+                writeln(generateLogMessage(moduleName, routineName, lineNumber, 
                                             msg, "CRITICAL"));
-            stdout.flush();
+                stdout.flush();
+            } catch (e: Error) {
+                writeln(generateErrorMsg(moduleName, routineName, lineNumber, e));
+            }            
         }
         
         proc error(moduleName, routineName, lineNumber, msg: string) throws {
-            writeln(generateLogMessage(moduleName, routineName, lineNumber, 
+            try {
+                writeln(generateLogMessage(moduleName, routineName, lineNumber, 
                                             msg, "ERROR"));
-            stdout.flush();
+                stdout.flush();
+            } catch (e: Error) {
+                writeln(generateErrorMsg(moduleName, routineName, lineNumber, e));
+            }
+        }
+        
+        proc generateErrorMsg(moduleName: string, routineName, lineNumber, 
+                           error) throws {
+            return "Error in logging message for %s %s %i: %t".format(
+                    moduleName, routineName, lineNumber, error.message());                
         }
         
         proc generateLogMessage(moduleName: string, routineName, lineNumber, 

--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -158,7 +158,7 @@ proc main() {
 
     :arg repMsg: either a string or bytes to be sent
     */
-    proc sendRepMsg(repMsg: ?t) where t==string || t==bytes {
+    proc sendRepMsg(repMsg: ?t) throws where t==string || t==bytes {
         repCount += 1;
         if trace {
           if t==bytes {


### PR DESCRIPTION
This PR addresses #847 by the following:

1. Added throws clause to arkouda_server.sendRepMsg to push uncaught errors up to the top of the call stack in arkouda_server.main
2. Added try/catch block around Logging.generateLogMessage to catch errors in message generation and write out a lower-risk error message within the catch block