### PR TITLE
Issue #838: Fixing peel segfault when long delimiter

### DIFF
--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -528,7 +528,7 @@ module SegmentedArray {
         if oa[i] > D.high {
           // When the last string(s) is/are shorter than the substr
           hasEnough = false;
-        } else if i == high {
+        } else if ((i == high) || (oa[i+1] > D.high)) {
           hasEnough = ((+ reduce truth) - numHits[oa[i]]) >= times;
         } else {
           hasEnough = (numHits[oa[i+1]] - numHits[oa[i]]) >= times;

--- a/test/UnitTestPeelStick.chpl
+++ b/test/UnitTestPeelStick.chpl
@@ -1,12 +1,17 @@
 use TestBase;
+use UnitTest;
 
 use SegmentedMsg;
+use List;
 
 config const N: int = 1_000;
 config const MINLEN: int = 6;
 config const MAXLEN: int = 30;
 config const SUBSTRING: string = "hi";
 config const DEBUG = false;
+const nb_str:string = b"\x00".decode(); // create null_byte string
+const nb_byt:bytes = b"\x00"; // create null_byte
+
 
 proc make_strings(substr, n, minLen, maxLen, characters, st) {
   const nb = substr.numBytes;
@@ -166,8 +171,127 @@ proc testMessageLayer(substr, n, minLen, maxLen) throws {
   writeln("Round trip successful? >>> %t <<<".format(success));
 }
 
+/**
+ * Test case when the delimiter is longer than the last string item
+ * See Issue #838
+ */
+proc testPeelLongDelimiter(test: borrowed Test) throws {
+
+  const d = "----------"; // 10 dashes for delimiter
+  var s = nb_str.join("abc%sxyz".format(d), "small%sdog".format(d), "blue%shat".format(d), "last") + nb_str;
+  test.assertTrue(59 == s.size);
+
+  var st = new owned SymTab();
+  var strings = makeSegArrayFromString(s, st);
+
+  ///////////////////////////// 
+  // First test: peel from the left
+  var (leftOffsets, leftVals, rightOffsets, rightVals) = strings.peel(d, 1, false, false, true); // from left
+  compareArrays(test, [0, 4, 10, 15], leftOffsets);
+  compareArrays(test, "abc\x00small\x00blue\x00\x00".encode().bytes(), leftVals);
+  compareArrays(test, [0, 4, 8, 12], rightOffsets);
+  compareArrays(test, "xyz\x00dog\x00hat\x00last\x00".encode().bytes(), rightVals);
+
+  ///////////////////////////// 
+  // Second test: peel from the right
+  var (leftOffsetsR, leftValsR, rightOffsetsR, rightValsR) = strings.peel(d, 1, false, false, false); // from right
+  test.assertTrue(4 == leftOffsetsR.size && 4 == rightOffsetsR.size);
+  compareArrays(test, [0, 4, 10, 15], leftOffsetsR, "First from right test, leftOffsetsR:", false);
+  compareArrays(test, "abc\x00small\x00blue\x00last\x00".encode().bytes(), leftValsR, "First fromRight test, leftValsR:", false);
+  compareArrays(test, [0, 4, 8, 12], rightOffsetsR, "First fromRight test, rightOffsetsR:", false);
+  compareArrays(test, "xyz\x00dog\x00hat\x00\x00".encode().bytes(), rightValsR, "First fromRight test, rightValsR:", false);
+
+  ///////////////////////////// 
+  // Run one more with a different size array, from Left
+  // Note: reusing parts here causes some overflow issues, so use new vars as appropriate
+  s = nb_str.join("abc%sxyz".format(d), "small%sdog".format(d), "last") + nb_str;
+  test.assertTrue(41 == s.size);
+  strings = makeSegArrayFromString(s, st);
+  var (leftOffsets2, leftVals2, rightOffsets2, rightVals2) = strings.peel(d, 1, false, false, true); // from left
+  compareArrays(test, [0, 4, 10], leftOffsets2, "fromLeft, leftOffsets2:", false);
+  compareArrays(test, "abc\x00small\x00\x00".encode().bytes(), leftVals2, "fromLeft, leftVals2:", false);
+  compareArrays(test, [0, 4, 8], rightOffsets2, "fromLeft, rightOffsets2:", false);
+  compareArrays(test, "xyz\x00dog\x00last\x00".encode().bytes(), rightVals2, "fromLeft, rightVals2:", false);
+  
+  ///////////////////////////// 
+  // Fourth test: peel from the Right
+  var (leftOffsets2R, leftVals2R, rightOffsets2R, rightVals2R) = strings.peel(d, 1, false, false, false); // from right
+  compareArrays(test, [0, 4, 10], leftOffsets2R, "fromLeft, leftOffsets2R:", false);
+  compareArrays(test, "abc\x00small\x00last\x00".encode().bytes(), leftVals2R, "fromLeft, leftVals2R:", false);
+  compareArrays(test, [0, 4, 8], rightOffsets2R, "fromLeft, rightOffsets2R:", false);
+  compareArrays(test, "xyz\x00dog\x00\x00".encode().bytes(), rightVals2R, "fromLeft, rightVals2R:", false);
+}
+
+proc testPeelIncludeDelimiter(test: borrowed Test) throws {
+  const d = "----------"; // 10 dashes for delimiter
+  var s = nb_str.join("abc%sxyz".format(d), "small%sdog".format(d), "blue%shat".format(d), "last") + nb_str;
+  test.assertTrue(59 == s.size);
+
+  var st = new owned SymTab();
+  var strings = makeSegArrayFromString(s, st);
+
+  ///////////////////////////// 
+  // First test: peel from the left
+  var (leftOffsets, leftVals, rightOffsets, rightVals) = strings.peel(d, 1, true, false, true); // from left
+  compareArrays(test, [0, 14, 30, 45], leftOffsets, "fromLeft::leftOffsets:", false);
+  compareArrays(test, "abc----------\x00small----------\x00blue----------\x00\x00".encode().bytes(), leftVals, "fromLeft::leftVals:", false);
+  compareArrays(test, [0, 4, 8, 12], rightOffsets, "fromLeft::rightOffsets:", false);
+  compareArrays(test, "xyz\x00dog\x00hat\x00last\x00".encode().bytes(), rightVals, "fromLeft::rightVals:", false);
+   
+  ///////////////////////////// 
+  // Second test: peel from the right
+  var (leftOffsetsR, leftValsR, rightOffsetsR, rightValsR) = strings.peel(d, 1, true, false, false); // from Right
+  compareArrays(test, [0, 4, 10, 15], leftOffsetsR, "fromRight::leftOffsetsR:", false);
+  compareArrays(test, "abc\x00small\x00blue\x00last\x00".encode().bytes(), leftValsR, "fromRight::leftValsR:", false);
+  compareArrays(test, [0, 14, 28, 42], rightOffsetsR, "fromRight::rightOffsetsR:", false);
+  compareArrays(test, "----------xyz\x00----------dog\x00----------hat\x00\x00".encode().bytes(), rightValsR, "fromRight::rightValsR:", false);
+}
+
+proc compareArrays(test: borrowed Test, expected, actual, msg:string="", debug:bool = false) {
+  for (ex, ac) in zip(expected, actual) {
+    if(debug) {
+      writeln("msg:", msg, " expected:", ex, " - actual:", ac);
+    }
+    test.assertTrue(ex == ac);
+  }
+}
+
+/**
+ * Internal test utility to make a SegString object from a string.
+ * The string should be a concatenation of strings split by null bytes.
+ */
+proc makeSegArrayFromString(s:string, st) throws {
+  // build offsets from null byte positions
+  var offset_list = new list(int);
+  var bytes_list = new list(uint(8));
+  offset_list.append(0); // first string starts at zero
+  const length = s.size;
+  for (i, b) in zip(0.., s.encode().items()){
+    if (nb_byt == b && (i+1) != length) {
+      offset_list.append(i+1);
+    }
+    bytes_list.append(b.toByte());
+  }
+  if (bytes_list.last() != nb_byt.toByte()) {
+    bytes_list.append(nb_byt.toByte());
+  }
+
+  var offsetName = st.nextName();
+  var offsetEntry = new shared SymEntry(offset_list.toArray());
+  st.addEntry(offsetName, offsetEntry);
+
+  var valName = st.nextName();
+  var valEntry = new shared SymEntry(bytes_list.toArray());
+  st.addEntry(valName, valEntry);
+  
+  return new shared SegString(offsetEntry, offsetName, valEntry, valName, st);
+}
+
 proc main() {
+  var t = new Test();
   try! testPeel(SUBSTRING, N, MINLEN, MAXLEN);
   try! testMessageLayer(SUBSTRING, N, MINLEN, MAXLEN);
+  try! testPeelLongDelimiter(t);
+  try! testPeelIncludeDelimiter(t);
 }
   

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -481,6 +481,26 @@ class StringTest(ArkoudaTest):
         self.assertListEqual(expected_a, a.bytes.to_ndarray().tolist())
         self.assertListEqual(expected_b, b.bytes.to_ndarray().tolist())
 
+    def test_peel_delimiter_length_issue(self):
+        # See Issue 838
+        d = "-" * 25 # 25 dashes as delimiter
+        series = pd.Series([f"abc{d}xyz", f"small{d}dog", f"blue{d}hat", "last"])
+        pda = ak.from_series(series)
+        a, b = pda.peel(d)
+        aa = a.to_ndarray().tolist()
+        bb = b.to_ndarray().tolist()
+        self.assertListEqual(["abc", "small", "blue", ""], aa)
+        self.assertListEqual(["xyz", "dog", "hat", "last"], bb)
+
+        # Try a slight permutation since we were able to get both versions to fail at one point
+        series = pd.Series([f"abc{d}xyz", f"small{d}dog", "last"])
+        pda = ak.from_series(series)
+        a, b = pda.peel(d)
+        aa = a.to_ndarray().tolist()
+        bb = b.to_ndarray().tolist()
+        self.assertListEqual(["abc", "small", ""], aa)
+        self.assertListEqual(["xyz", "dog", "last"], bb)
+
     def test_stick(self):
         run_test_stick(self.strings, self.test_strings, self.base_words, 
                        self.delim, 100)


### PR DESCRIPTION
Issue #838: The peel operation may segFault when the delimiter is sufficiently longer than the last string.

This looked to be caused by an out of bounds index operation when determining if the string `hasEnough` to peel.  The fix was made by adjusting the bounds checking conditional statements.

A number of unit tests both server-side (in chapel) and client side (in python) were added to verify correctness.