### PR TITLE
Closes #852 by adding hdf5 and zmq to mypy and docs CI actions.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: |
-        apt-get update && apt-get install -y python3-pip
+        apt-get update && apt-get install -y python3-pip libhdf5-dev hdf5-tools libzmq3-dev
         python3 -m pip install types-pkg_resources
         python3 -m pip install -e .[dev]
     - name: Arkouda mypy
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: |
-        apt-get update && apt-get install -y python3-pip
+        apt-get update && apt-get install -y python3-pip libhdf5-dev hdf5-tools libzmq3-dev
         python3 -m pip install -e .[dev]
     - name: Arkouda make doc
       run: |

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: |
-        apt-get update && apt-get install -y python3-pip rsync
+        apt-get update && apt-get install -y python3-pip rsync libhdf5-dev hdf5-tools libzmq3-dev
         python3 -m pip install -e .[dev]
     - name: Arkouda make doc
       run: |


### PR DESCRIPTION
Closes #852 by adding hdf5 and zmq to mypy and docs CI actions.

Note: I have no idea why this suddenly broke, but here are examples of the failure and fix running in github actions:

FAIL: https://github.com/glitch/arkouda/actions/runs/961367325
FIX:  https://github.com/glitch/arkouda/actions/runs/961563976