### PR TITLE
Closes #842 adding empty string check for ls_hdf

### DIFF
--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -23,7 +23,15 @@ def ls_hdf(filename : str) -> str:
     -------
     str
         The string output of `h5ls <filename>` from the server
+
+    Raises
+    ------
+    ValueError
+        Raised if filename is empty or contains only whitespace
     """
+    if not (filename and filename.strip()):
+        raise ValueError("filename cannot be an empty string")
+
     return cast(str,generic_msg(cmd="lshdf", args="{}".format(json.dumps([filename]))))
 
 @typechecked

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -199,6 +199,9 @@ module GenSymIO {
         var filename: string;
         try {
             filename = jsonToPdArray(jsonfile, 1)[0];
+            if filename.isEmpty() {
+                throw new Error("filename was empty");  // will be caught by catch block
+            }
         } catch {
             var errorMsg = "Could not decode json filenames via tempfile (%i files: %s)".format(
                                      1, jsonfile);                                     

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -172,6 +172,17 @@ class IOTest(ArkoudaTest):
         message = ak.ls_hdf('{}/iotest_single_column_LOCALE0000'.format(IOTest.io_test_dir))
         self.assertIn('int_tens_pdarray         Dataset', message)
 
+    def testLsHdfEmpty(self):
+        # Test filename empty/whitespace-only condition
+        with self.assertRaises(ValueError) as cm:
+            ak.ls_hdf("")
+        
+        with self.assertRaises(ValueError) as cm:
+            ak.ls_hdf("   ")
+        
+        with self.assertRaises(ValueError) as cm:
+            ak.ls_hdf(" \n\r\t  ")
+
     def testReadHdf(self):
         '''
         Creates 2..n files depending upon the number of arkouda_server locales with two


### PR DESCRIPTION
Closes #842 adding empty string check for ls_hdf

Check occurs on both client & server side code.
Unit test added for python tests.