### PR TITLE
Improve the performance of client-server array transfers

### DIFF
--- a/benchmarks/array_transfer.py
+++ b/benchmarks/array_transfer.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+import time, argparse
+import numpy as np
+import arkouda as ak
+
+TYPES = ('int64', 'float64')
+
+def time_ak_array_transfer(N, trials, dtype, random, seed):
+    print(">>> arkouda {} array creation".format(dtype))
+    cfg = ak.get_config()
+    print("numLocales = {}, N = {:,}".format(cfg["numLocales"], N))
+
+    a = ak.randint(0, 2**32, N, dtype=dtype, seed=seed)
+    nb = a.size * a.itemsize
+    ak.client.maxTransferBytes = nb
+
+    to_ndarray_times = []
+    to_pdarray_times = []
+    for i in range(trials):
+        start = time.time()
+        npa = a.to_ndarray();
+        end = time.time()
+        to_ndarray_times.append(end - start)
+        start = time.time();
+        aka = ak.array(npa)
+        end = time.time()
+        to_pdarray_times.append(end - start)
+    avgnd = sum(to_ndarray_times) / trials
+    avgpd = sum(to_pdarray_times) / trials
+
+    print("to_ndarray Average time = {:.4f} sec".format(avgnd))
+    print("ak.array Average time = {:.4f} sec".format(avgpd))
+
+    print("to_ndarray Average rate = {:.4f} GiB/sec".format(nb/2**30/avgnd))
+    print("ak.array Average rate = {:.4f} GiB/sec".format(nb/2**30/avgpd))
+
+def check_correctness(dtype, random, seed):
+    N = 10**4
+
+    if seed is not None:
+        np.random.seed(seed)
+    if dtype == 'int64':
+        a = np.random.randint(1, N, N)
+    elif dtype == 'float64':
+        a = np.random.random(N) + 0.5
+
+    aka = ak.array(a)
+    npa = aka.to_ndarray();
+    assert np.allclose(a, npa)
+
+def create_parser():
+    parser = argparse.ArgumentParser(description="Measure the performance of transferring arrays.")
+    parser.add_argument('hostname', help='Hostname of arkouda server')
+    parser.add_argument('port', type=int, help='Port of arkouda server')
+    parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: length of array')
+    parser.add_argument('-t', '--trials', type=int, default=1, help='Number of times to run the benchmark')
+    parser.add_argument('-d', '--dtype', default='int64', help='Dtype of array ({})'.format(', '.join(TYPES)))
+    parser.add_argument('-r', '--randomize', default=False, action='store_true', help='Fill array with random values instead of range (unused)')
+    parser.add_argument('--numpy', default=False, action='store_true', help='Run the same operation in NumPy to compare performance.')
+    parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
+    parser.add_argument('-s', '--seed', default=None, type=int, help='Value to initialize random number generator')
+    return parser
+
+if __name__ == "__main__":
+    import sys
+    parser = create_parser()
+    args = parser.parse_args()
+    if args.dtype not in TYPES:
+        raise ValueError("Dtype must be {}, not {}".format('/'.join(TYPES), args.dtype))
+    ak.verbose = False
+    ak.connect(args.hostname, args.port)
+
+    if args.correctness_only:
+        for dtype in TYPES:
+            check_correctness(dtype, args.randomize, args.seed)
+        sys.exit(0)
+
+    print("array size = {:,}".format(args.size))
+    print("number of trials = ", args.trials)
+    time_ak_array_transfer(args.size, args.trials, args.dtype, args.randomize, args.seed)
+    sys.exit(0)

--- a/benchmarks/graph_infra/arkouda.graph
+++ b/benchmarks/graph_infra/arkouda.graph
@@ -76,6 +76,12 @@ files: array_create.dat, array_create.dat, array_create.dat
 graphtitle: Array Creation Performance
 ylabel: Performance (GiB/s)
 
+perfkeys: to_ndarray Average rate =, ak.array Average rate =
+graphkeys: to_ndarray GiB/s, ak.array GiB/s
+files: array_transfer.dat, array_transfer.dat
+graphtitle: Array Transfer Performance
+ylabel: Performance (GiB/s)
+
 perfkeys: write Average rate =, read Average rate =
 graphkeys: Write GiB/s, Read GiB/s
 files: IO.dat, IO.dat

--- a/benchmarks/graph_infra/array_transfer.perfkeys
+++ b/benchmarks/graph_infra/array_transfer.perfkeys
@@ -1,0 +1,4 @@
+to_ndarray Average time =
+to_ndarray Average rate =
+ak.array Average time =
+ak.array Average rate =

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -20,8 +20,9 @@ from util import *
 logging.basicConfig(level=logging.INFO)
 
 BENCHMARKS = ['stream', 'argsort', 'coargsort', 'groupby', 'aggregate', 'gather', 'scatter',
-              'reduce', 'scan', 'noop', 'setops', 'array_create', 'IO',
-              'str-argsort', 'str-coargsort', 'str-groupby', 'str-gather']
+              'reduce', 'scan', 'noop', 'setops', 'array_create',
+              'array_transfer', 'IO', 'str-argsort', 'str-coargsort',
+              'str-groupby', 'str-gather']
 
 def get_chpl_util_dir():
     """ Get the Chapel directory that contains graph generation utilities. """


### PR DESCRIPTION
Improve the performance of `ak.array()` and `pdarray.to_ndarray()`. This
improves how the arrays are translated to bytes. For pdarray.to_ndarray,
previously we would just read from the distributed pdarray directly, but
this results in lots of fine-grained reads from that distributed array.
Change to copying to a local array, which takes advantage of Chapel's
bulk transfer, and then doing the byte conversion locally. For ak.array
do something similar but write into a local array and then do bulk
transfer to the distributed array.

This also adds a benchmark to track the performance. Note that unlike
most tests that take a per-locale size, this just takes a fixed size
since it ultimately depends on the client to head-node connection.

Here's the performance improvement for 16-node-xc:

| config | to_ndarray | ak.array   |
| ------ | ---------: | ---------: |
| before |  3.9 MiB/s |  4.7 MiB/s |
| after  | 20.5 MiB/s | 23.5 MiB/s |

And for 16-node-cs-hdr:

| config | to_ndarray | ak.array   |
| ------ | ---------: | ---------: |
| before |  2.4 MiB/s |  2.9 MiB/s |
| after  | 29.5 MiB/s | 25.9 MiB/s |

So roughly a ~5x improvement for XC and ~10x for CS.

Part of https://github.com/Bears-R-Us/arkouda/issues/794