### PR TITLE
Hotfix for Issue #858- Removes @typechecked over aggregate

### DIFF
--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -229,7 +229,6 @@ class GroupBy:
         self.logger.debug(repMsg)
         return self.unique_keys, create_pdarray(repMsg)
     
-    @typechecked
     def aggregate(self, values: groupable, operator: str, skipna: bool=True) \
                     -> Tuple[groupable, pdarray]:
         '''
@@ -753,7 +752,7 @@ class GroupBy:
         """
         if values.dtype != bool:
             raise TypeError('any is only supported for pdarrays of dtype bool')
-        return self.aggregate(values, "any")
+        return self.aggregate(values, "any")  # type: ignore
 
     def all(self, values : pdarray) \
                     -> Tuple[Union[pdarray,List[Union[pdarray,Strings]]],pdarray]:
@@ -788,7 +787,7 @@ class GroupBy:
         if values.dtype != bool:
             raise TypeError('all is only supported for pdarrays of dtype bool')
 
-        return self.aggregate(values, "all")
+        return self.aggregate(values, "all")  # type: ignore
 
     def OR(self, values : pdarray) \
                     -> Tuple[Union[pdarray,List[Union[pdarray,Strings]]],pdarray]:
@@ -825,7 +824,7 @@ class GroupBy:
         if values.dtype != int64:
             raise TypeError('OR is only supported for pdarrays of dtype int64')
 
-        return self.aggregate(values, "or")
+        return self.aggregate(values, "or")  # type: ignore
 
     def AND(self, values : pdarray) \
                     -> Tuple[Union[pdarray,List[Union[pdarray,Strings]]],pdarray]:
@@ -862,7 +861,7 @@ class GroupBy:
         if values.dtype != int64:
             raise TypeError('AND is only supported for pdarrays of dtype int64')
 
-        return self.aggregate(values, "and")
+        return self.aggregate(values, "and")  # type: ignore
 
     def XOR(self, values : pdarray) \
                     -> Tuple[Union[pdarray,List[Union[pdarray,Strings]]],pdarray]:
@@ -899,7 +898,7 @@ class GroupBy:
         if values.dtype != int64:
             raise TypeError('XOR is only supported for pdarrays of dtype int64')
 
-        return self.aggregate(values, "xor")
+        return self.aggregate(values, "xor")  # type: ignore
 
     @typechecked
     def broadcast(self, values : pdarray, permute : bool=True) -> pdarray:

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -334,6 +334,11 @@ class GroupByTest(ArkoudaTest):
                 k, n = g.nunique(val)
                 self.assertTrue((n == expected).all())
 
+    def test_type_failure_multilevel_groupby_aggregate(self):
+        # just checking no error occurs with hotfix for Issue 858
+        keys = [ak.randint(0, 10, 100), ak.randint(0, 10, 100)]
+        g = ak.GroupBy(keys)
+        g.min(ak.randint(0, 10, 100))
 
 def to_tuple_dict(labels, values):
     # transforms labels from list of arrays into a list of tuples by index and builds a dictionary


### PR DESCRIPTION
Issue #858:
Certainly not a permanent fix but should be enough to remove the 'Categorical' typechecking block for users for the time being

This PR removes `typechecked` over aggregate and adds `# type: ignore` for all aggregate calls. This is intended to be a quick fix to avoid interrupting user workflows while we look into handling `Categorical` typechecking in `Groupby`.