### PR TITLE
Closes #860 by updating gh-pages workflow to use chapel container v.1.24.1

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository == 'Bears-R-Us/arkouda'
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.23.0
+      image: chapel/chapel:1.24.1
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies


### PR DESCRIPTION
Closes Issue #860 by updating gh-pages workflow to use chapel container v.1.24.1

This fixes the gh-pages `docs` workflow target.