### PR TITLE
Optimize byte<->array conversions in to_ndarray

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -856,10 +856,10 @@ class pdarray:
         if len(rep_msg) != self.size*self.dtype.itemsize:
             raise RuntimeError("Expected {} bytes but received {}".\
                                format(self.size*self.dtype.itemsize, len(rep_msg)))
-        # Use struct to interpret bytes as a big-endian numeric array
-        fmt = '>{:n}{}'.format(self.size, structDtypeCodes[self.dtype.name])
-        # Return a numpy ndarray
-        return np.array(struct.unpack(fmt, rep_msg)) # type: ignore
+        dt = np.dtype(self.dtype)
+        dt = dt.newbyteorder('>')
+        mut_rep_msg = bytearray(rep_msg)
+        return np.frombuffer(mut_rep_msg, dt)
 
     def to_cuda(self):
         """

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -857,7 +857,6 @@ class pdarray:
             raise RuntimeError("Expected {} bytes but received {}".\
                                format(self.size*self.dtype.itemsize, len(rep_msg)))
         dt = np.dtype(self.dtype)
-        dt = dt.newbyteorder('>')
         mut_rep_msg = bytearray(rep_msg)
         return np.frombuffer(mut_rep_msg, dt)
 


### PR DESCRIPTION
Optimize the byte->nparray conversion by using `np.frombytes` instead of
`struct.unpack`. Unfortunately, we still have to make a copy because `bytes`
aren't mutable so we have to create a `bytearray` copy. There may be some way
to eliminate this with `memoryview`, but I'm not familiar with that yet.

Then optimize pdarray->byte conversations by directly copying the localized
array's buffer into a bytes type instead of writing to and then reading from a
memory mapped file. Here again there's an extra copy, but we could eliminate
that by using the `makeArrayFromPtr` interface.

Note that this breaks portability when the endianness of the server doesn't
match the client. Previously, everything forced big-endian and now we assume
client and server match. This can probably be addressed by sending the
endianness along with the message and interpreting differently, but I'm not
sure. Because of this breakage I've drafted this for now.

Here are some performance results for to_ndarray on 16-node-xc

| config        | Time  |  Rate     |
| ------------- | ----: | --------: |
| before        | 39.0s |  20 MiB/s |
| np.frombuffer | 23.8s |  32 MiB/s |
| direct-bytes  |  2.1s | 362 MiB/s |