### PR TITLE
Issue 821 ak.read_all option to warn on HDF5 file read errors

### DIFF
--- a/src/Message.chpl
+++ b/src/Message.chpl
@@ -66,4 +66,10 @@ module Message {
        return "%jt".format(new ReplyMsg(msg=msg,msgType=msgType, 
                                                         msgFormat=msgFormat, user=user));
    }
+
+    /*
+     * String constants for use in constructing JSON formatted messages
+     */
+    const Q = '"'; // Double Quote, escaping quotes often throws off syntax highlighting.
+    const QCQ = Q + ":" + Q; // `":"` -> useful for closing and opening quotes for named json k,v pairs 
 }

--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -314,7 +314,10 @@ proc main() {
                 when "segmentedIn1d"     {repTuple = segIn1dMsg(cmd, args, st);}
                 when "segmentedFlatten"  {repTuple = segFlattenMsg(cmd, args, st);}
                 when "lshdf"             {repTuple = lshdfMsg(cmd, args, st);}
+                
+                // DEPRECATED all client paths point to readAllHdfMsg
                 when "readhdf"           {repTuple = readhdfMsg(cmd, args, st);}
+                
                 when "readAllHdf"        {repTuple = readAllHdfMsg(cmd, args, st);}
                 when "tohdf"             {repTuple = tohdfMsg(cmd, args, st);}
                 when "create"            {repTuple = createMsg(cmd, args, st);}

--- a/test/IOSpeedTestMsg.chpl
+++ b/test/IOSpeedTestMsg.chpl
@@ -5,6 +5,19 @@ config const size = 10**4;
 config const write = true;
 config const read = true;
 
+proc parseIdFromReadAllHdfMsgCreated(msg:string, start:int = 0):string {
+  const marker = "created id_";
+  var p:int = msg.find(marker, start..<msg.size):int;
+  if p > -1 {
+    p = p + marker.size;
+    var q:int = msg.find(" ", p..<msg.size):int;
+    if q > -1 {
+      return "id_" + msg.this(p..q-1); // our id number should be [p..q-1]
+    }
+  }
+  return "ERROR";
+}
+
 proc main() {
   var st = new owned SymTab();
   var A = st.addEntry("A", size*numLocales, int);
@@ -25,9 +38,10 @@ proc main() {
   if read {
     d.start();
     var cmd = "readAllHdf";
-    var payload = "True 1 1 [\"array\"] | [\"file_LOCALE*\"]";
+    var payload = "True 1 1 False [\"array\"] | [\"file_LOCALE*\"]";
     var repMsg = readAllHdfMsg(cmd, payload, st).msg;
-    var B = toSymEntry(st.lookup(parseName(repMsg)), int);
+    var id = parseIdFromReadAllHdfMsgCreated(repMsg);
+    var B = toSymEntry(st.lookup(id), int);
     d.stop(printTime=false);
     if printTimes then writeln("read: %.2dr GiB/s (%.2drs)".format(GiB/d.elapsed(), d.elapsed()));
     forall (a, b) in zip (A.a, B.a) do assert(a == b);

--- a/test/untested/UnitTestStringType.chpl
+++ b/test/untested/UnitTestStringType.chpl
@@ -22,6 +22,9 @@ proc parseNames(msg, param k) {
 
 proc main() {
   var st = new owned SymTab();
+
+  // DEPRECATED - All client calls now redirect to readAllHdf
+  // TODO: Move this call to readAllHdf/Msg for this test
   var cmd = "readhdf";
   var reqMsg = "%s %i %jt".format(dsetName, 1, [filename]);
   writeln(">>> ", reqMsg);

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -1,9 +1,6 @@
-import os, shutil, glob, stat
+import os, shutil, glob
 import numpy as np
 from typing import List, Mapping, Union
-
-import pytest
-
 from base_test import ArkoudaTest
 from context import arkouda as ak
 from arkouda import io_util
@@ -306,14 +303,13 @@ class IOTest(ArkoudaTest):
                                          f'{IOTest.io_test_dir}/iotest_single_column_dupe_LOCALE0000'])
         self.assertIsNotNone(dataset, "Expected dataset to be populated")
 
-        # Change the file permissions on a file and assert we can an error
-        os.chmod(f"{IOTest.io_test_dir}/iotest_single_column_LOCALE0000", stat.S_IWUSR)
-        with pytest.raises(RuntimeError):
-            dataset = ak.read_all(filenames=[f'{IOTest.io_test_dir}/iotest_single_column_LOCALE0000',
+        # Change the name of the first file we try to raise an error due to file missing.
+        with self.assertRaises(RuntimeError):
+            dataset = ak.read_all(filenames=[f'{IOTest.io_test_dir}/iotest_MISSING_single_column_LOCALE0000',
                                              f'{IOTest.io_test_dir}/iotest_single_column_dupe_LOCALE0000'])
 
-        # Run the same test of the modified permissions, but this time with the warning flag for read_all
-        dataset = ak.read_all(filenames=[f'{IOTest.io_test_dir}/iotest_single_column_LOCALE0000',
+        # Run the same test with missing file, but this time with the warning flag for read_all
+        dataset = ak.read_all(filenames=[f'{IOTest.io_test_dir}/iotest_MISSING_single_column_LOCALE0000',
                                          f'{IOTest.io_test_dir}/iotest_single_column_dupe_LOCALE0000'],
                               strictTypes=False,
                               allow_errors=True)

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -1,6 +1,9 @@
-import os, shutil, glob
+import os, shutil, glob, stat
 import numpy as np
 from typing import List, Mapping, Union
+
+import pytest
+
 from base_test import ArkoudaTest
 from context import arkouda as ak
 from arkouda import io_util
@@ -192,7 +195,7 @@ class IOTest(ArkoudaTest):
             ak.ls_hdf(" \n\r\t  ")
 
     def testReadHdf(self):
-        '''
+        ''' DEPRECATED - all client calls route to `readAllHdf`
         Creates 2..n files depending upon the number of arkouda_server locales with two
         files each containing different-named datasets with the same pdarrays, reads the files
         with an explicit list of file names to the read_hdf method, and confirms the dataset 
@@ -225,7 +228,7 @@ class IOTest(ArkoudaTest):
         self.assertTrue('iotest_single_colum_LOCALE0000 not found' in  cm.exception.args[0])
 
     def testReadHdfWithGlob(self):
-        '''
+        ''' DEPRECATED - all client calls route to `readAllHdf`
         Creates 2..n files depending upon the number of arkouda_server locales with two
         files each containing different-named datasets with the same pdarrays, reads the files
         with the glob feature of the read_hdf method, and confirms the datasets and embedded 
@@ -291,6 +294,30 @@ class IOTest(ArkoudaTest):
         self.assertTrue((ihp == rihp).all())
         self.assertTrue((fp == rfp).all())
         self.assertEqual(len(self.bool_pdarray), len(retrieved_columns['bool_pdarray']))
+
+    def testReadAllWithErrorAndWarn(self):
+        self._create_file(columns=self.dict_single_column,
+                          prefix_path=f'{IOTest.io_test_dir}/iotest_single_column')
+        self._create_file(columns=self.dict_single_column,
+                          prefix_path=f'{IOTest.io_test_dir}/iotest_single_column_dupe')
+
+        # Make sure we can read ok
+        dataset = ak.read_all(filenames=[f'{IOTest.io_test_dir}/iotest_single_column_LOCALE0000',
+                                         f'{IOTest.io_test_dir}/iotest_single_column_dupe_LOCALE0000'])
+        self.assertIsNotNone(dataset, "Expected dataset to be populated")
+
+        # Change the file permissions on a file and assert we can an error
+        os.chmod(f"{IOTest.io_test_dir}/iotest_single_column_LOCALE0000", stat.S_IWUSR)
+        with pytest.raises(RuntimeError):
+            dataset = ak.read_all(filenames=[f'{IOTest.io_test_dir}/iotest_single_column_LOCALE0000',
+                                             f'{IOTest.io_test_dir}/iotest_single_column_dupe_LOCALE0000'])
+
+        # Run the same test of the modified permissions, but this time with the warning flag for read_all
+        dataset = ak.read_all(filenames=[f'{IOTest.io_test_dir}/iotest_single_column_LOCALE0000',
+                                         f'{IOTest.io_test_dir}/iotest_single_column_dupe_LOCALE0000'],
+                              strictTypes=False,
+                              allow_errors=True)
+        self.assertIsNotNone(dataset, "Expected dataset to be populated")
 
     def testLoad(self):
         '''


### PR DESCRIPTION
Closes Issue #821 

### This PR adds an option to `ak.read_all` to allow file read errors instead of failing the call.

There are two major commits in this PR.

1. The first half adds the option to the cmd message on both the client side and the message processing component on the server side.  This boolean flag `allow_errors` signals to the server that it should not error out if one or more HDF5 file cannot be read due to conditions like file permissions, corruption, missing file, etc.
2. The second major commit changes the _response message_ sent back from the server into a json structure to allow a sample of the file error messages along with the total count of failed files.

*If we don't want to move to the json response message in this PR I can unwind that change, but it means we can't really return the error messages and total file error counts.*

### Additional components of interest

- The `ak.read_all` function also calls the `ls_hdf` component to retrieve the datasets, it was necessary to add another ls_hdf function to the client which was resilient in the face of file read errors.
- `hdfreadMsg` and corresponding functions.  This component was meant to read a single hdf5 file, however it is no longer in the chain of function calls.  The client now redirects to using the read_all component in the single file case.  The server side `readHdfMsg` proc can be removed, so I marked it as DEPRECATED.  (I can add that to this PR if desired or we can complete it in a separate Issue).

### JSON notes
The Chapel string formatting "%jt" construct doesn't really work for the `list` data structure so it was necessary to add a procedure and string constants to produce our own json.  I also tried various json structures and ended up with something I think is pretty succinct and clear.  It is documented in the `GenSymIO._buildReadAllHdfMsgJson` doc string with an example.

