### PR TITLE
Optimize client conversions for client-server array transfers

### DIFF
--- a/arkouda/dtypes.py
+++ b/arkouda/dtypes.py
@@ -3,12 +3,13 @@ from enum import Enum
 import numpy as np # type: ignore
 from typeguard import typechecked
 import builtins
+import sys
 
 __all__ = ["DTypes", "DTypeObjects", "dtype", "bool", "int64", "float64", 
            "uint8", "str_", "check_np_dtype", "translate_np_dtype", 
            "resolve_scalar_dtype", "ARKOUDA_SUPPORTED_DTYPES", "bool_scalars",
            "float_scalars", "int_scalars", "numeric_scalars", "numpy_scalars", 
-           "str_scalars", "all_scalars"]
+           "str_scalars", "all_scalars", "get_byteorder"]
 
 # supported dtypes
 structDtypeCodes = {'int64': 'q',
@@ -161,3 +162,17 @@ def resolve_scalar_dtype(val : object) -> str: # type: ignore
     # Other python type
     else:
         return builtins.str(type(val))
+
+def get_byteorder(dt: np.dtype) -> str:
+    """
+    Get a concrete byteorder (turns '=' into '<' or '>')
+    """
+    if dt.byteorder == '=':
+        if sys.byteorder == 'little':
+            return '<'
+        elif sys.byteorder == 'big':
+            return '>'
+        else:
+            raise ValueError("Client byteorder must be 'little' or 'big'")
+    else:
+        return dt.byteorder

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -856,10 +856,11 @@ class pdarray:
         if len(rep_msg) != self.size*self.dtype.itemsize:
             raise RuntimeError("Expected {} bytes but received {}".\
                                format(self.size*self.dtype.itemsize, len(rep_msg)))
-        # Use struct to interpret bytes as a big-endian numeric array
-        fmt = '>{:n}{}'.format(self.size, structDtypeCodes[self.dtype.name])
-        # Return a numpy ndarray
-        return np.array(struct.unpack(fmt, rep_msg)) # type: ignore
+        # The server sends us big-endian bytes so we need to account for that.
+        # Since bytes are immutable, we need to copy the np array to be mutable
+        dt = np.dtype(self.dtype)
+        dt = dt.newbyteorder('>')
+        return np.frombuffer(rep_msg, dt).copy()
 
     def to_cuda(self):
         """

--- a/tests/pdarray_creation_test.py
+++ b/tests/pdarray_creation_test.py
@@ -574,3 +574,21 @@ class PdarrayCreationTest(ArkoudaTest):
         
         ones.fill(np.float64(2))  
         self.assertTrue((np.float64(2) == ones.to_ndarray()).all())  
+
+    def test_endian(self):
+        N = 100
+
+        a = np.random.randint(1, N, N)
+        aka = ak.array(a)
+        npa = aka.to_ndarray();
+        self.assertTrue(np.allclose(a, npa))
+
+        a = a.newbyteorder().byteswap()
+        aka = ak.array(a)
+        npa = aka.to_ndarray();
+        self.assertTrue(np.allclose(a, npa))
+
+        a = a.newbyteorder().byteswap()
+        aka = ak.array(a)
+        npa = aka.to_ndarray();
+        self.assertTrue(np.allclose(a, npa))


### PR DESCRIPTION
Improve the performance of `ak.array()` and `pdarray.to_ndarray()` by
optimizing how the client converts between bytes and numpy arrays. This
switches from `struct.{pack,unpack}` to `numpy.{tobytes,frombuffer}`
which has a non-trivial performance improvement. We have to be more
careful about endianness now, but the conversions are still pretty
straightforward. Note that the server currently always uses big-endian
for these conversions though a future optimization will look to use
native endianness.

Currently, the client code is still making some extra copies. In the
`to_ndarray()` case we need a copy because the underlying `bytes` buffer
is immutable, which makes the numpy array immutable so things that
modify the array in place like `numpy.array.sort()` would fail without
the copy. We should be able to optimize this by looking at the zmq frame
directly, but this will be future work. On the `ak.array()` side I think
`tobytes` copies, and I wonder if we can use `memoryview` here instead.
That too will be left for future work.

Here's the performance improvement for 16-node-xc:

| config | to_ndarray | ak.array   |
| ------ | ---------: | ---------: |
| before | 20.5 MiB/s | 23.5 MiB/s |
| after  | 32.5 MiB/s | 50.0 MiB/s |

While the rate increases don't look too large the time difference shows
the improvement a little better.

| config | to_ndarray | ak.array   |
| ------ | ---------: | ---------: |
| before | 36.6s      | 31.2s      |
| after  | 23.6s      | 15.2s      |

Next steps will be to optimize the server side conversions more, which
should shave another 10-15 seconds off these operations which will give
more respectable rates.

Part of #794