### PR TITLE
Issue #871: Adds caching of `get_config` response

### DIFF
--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1,5 +1,6 @@
 from base_test import ArkoudaTest
 from context import arkouda as ak
+import time
 
 '''
 Tests basic Arkouda client functionality
@@ -64,6 +65,13 @@ class ClientTest(ArkoudaTest):
         self.assertEqual(ArkoudaTest.port, config['ServerPort'])
         self.assertTrue('arkoudaVersion' in config)
         self.assertTrue('INFO', config['logLevel'])
+
+        # Verify caching of get_config
+        tl = config["time_loaded"]
+        self.assertEqual(tl, ak.client.get_config()["time_loaded"])  # Verify caching
+        ak.client._get_config.cache_clear()
+        time.sleep(0.15)
+        self.assertFalse(tl == ak.client.get_config()["time_loaded"])  # Verify clearing of cache and fresh fetch
         
     def test_client_context(self):   
         '''


### PR DESCRIPTION
Issue #871 : Adds caching of `get_config` response by using lru_cache decorator with a ttl enhancement to add time expiration.
The client.connect() also updated to return the config object.

This uses the lru_cache from functools but adds one level of indirection to get_config so we can keep the client function call the same.

If the client gets disconnect and calls connect again, the cache is cleared so we can ensure up to date information from the server.

Note: The connect call now returns the `get_config` dictionary.