### PR TITLE
857 improve hdf5 error handling

### DIFF
--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -215,7 +215,7 @@ def load(path_prefix : str, dataset : str='array') -> Union[pdarray,Strings]:
         path_prefix does not correspond to files accessible to Arkouda
     RuntimeError
         Raised if the hdf5 files are present but there is an error in opening
-        on or more of them
+        one or more of them
 
     See Also
     --------
@@ -291,7 +291,7 @@ def load_all(path_prefix : str) -> Mapping[str,Union[pdarray,Strings]]:
         path_prefix does not correspond to files accessible to Arkouda   
     RuntimeError
         Raised if the hdf5 files are present but there is an error in opening
-        on or more of them
+        one or more of them
 
     See Also
     --------

--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -1,6 +1,6 @@
 from typeguard import typechecked
 import json, os
-from typing import cast, List, Mapping, Optional, Union
+from typing import cast, Dict, List, Mapping, Optional, Union
 from arkouda.client import generic_msg
 from arkouda.pdarrayclass import pdarray, create_pdarray
 from arkouda.strings import Strings
@@ -229,8 +229,7 @@ def load(path_prefix : str, dataset : str='array') -> Union[pdarray,Strings]:
     except RuntimeError as re:
         if 'does not exist' in str(re):
             raise ValueError('There are no files corresponding to the ' +
-                                     'path_prefix {} in location accessible to Arkouda'.\
-                                     format(prefix, extension))
+                                'path_prefix {} in location accessible to Arkouda'.format(prefix))
         else:
             raise RuntimeError(re)
             
@@ -313,8 +312,7 @@ def load_all(path_prefix : str) -> Mapping[str,Union[pdarray,Strings]]:
             except RuntimeError as re:
                 if 'does not exist' in str(re):
                     raise ValueError('There are no files corresponding to the ' +
-                                     'path_prefix {} in location accessible to Arkouda'.\
-                                     format(prefix, extension))
+                                     'path_prefix {} in location accessible to Arkouda'.format(prefix))
                 else:
                     raise RuntimeError(re)
         else:

--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -1,6 +1,6 @@
 from typeguard import typechecked
 import json, os
-from typing import cast, Dict, List, Mapping, Optional, Union
+from typing import cast, List, Mapping, Optional, Union
 from arkouda.client import generic_msg
 from arkouda.pdarrayclass import pdarray, create_pdarray
 from arkouda.strings import Strings
@@ -26,8 +26,12 @@ def ls_hdf(filename : str) -> str:
 
     Raises
     ------
+    TypeError
+        Raised if filename is not a str
     ValueError
         Raised if filename is empty or contains only whitespace
+    RuntimeError
+        Raised if error occurs in executing ls on an HDF5 file
     """
     if not (filename and filename.strip()):
         raise ValueError("filename cannot be an empty string")
@@ -66,7 +70,9 @@ def read_hdf(dsetName : str, filenames : Union[str,List[str]],
         Raised if dsetName is not a str or if filenames is neither a string
         nor a list of strings
     ValueError 
-        Raised if all datasets are not present in all hdf5 files    
+        Raised if all datasets are not present in all hdf5 files  
+    RuntimeError
+        Raised if one or more of the specified files cannot be opened  
 
     See Also
     --------
@@ -127,8 +133,11 @@ def read_all(filenames : Union[str,List[str]],
     Raises
     ------
     ValueError 
-        Raised if all datasets are not present in all hdf5 files
-
+        Raised if all datasets are not present in all hdf5 files or if one or 
+        more of the specified files do not exist
+    RuntimeError
+        Raised if one or more of the specified files cannot be opened
+        
     See Also
     --------
     read_hdf, get_datasets, ls_hdf
@@ -200,9 +209,13 @@ def load(path_prefix : str, dataset : str='array') -> Union[pdarray,Strings]:
     Raises
     ------
     TypeError 
-        Raised if dataset is not a str 
+        Raised if either path_prefix or dataset is not a str 
     ValueError 
-        Raised if all datasets are not present in all hdf5 files     
+        Raised if the dataset is not present in all hdf5 files or if the
+        path_prefix does not correspond to files accessible to Arkouda
+    RuntimeError
+        Raised if the hdf5 files are present but there is an error in opening
+        on or more of them
 
     See Also
     --------
@@ -210,7 +223,17 @@ def load(path_prefix : str, dataset : str='array') -> Union[pdarray,Strings]:
     """
     prefix, extension = os.path.splitext(path_prefix)
     globstr = "{}_LOCALE*{}".format(prefix, extension)
-    return read_hdf(dataset, globstr)
+
+    try:
+        return read_hdf(dataset, globstr)
+    except RuntimeError as re:
+        if 'does not exist' in str(re):
+            raise ValueError('There are no files corresponding to the ' +
+                                     'path_prefix {} in location accessible to Arkouda'.\
+                                     format(prefix, extension))
+        else:
+            raise RuntimeError(re)
+            
 
 @typechecked
 def get_datasets(filename : str) -> List[str]:
@@ -231,6 +254,10 @@ def get_datasets(filename : str) -> List[str]:
     ------
     TypeError
         Raised if filename is not a str
+    ValueError
+        Raised if filename is empty or contains only whitespace
+    RuntimeError
+        Raised if error occurs in executing ls on an HDF5 file
 
     See Also
     --------
@@ -258,8 +285,14 @@ def load_all(path_prefix : str) -> Mapping[str,Union[pdarray,Strings]]:
         
     Raises
     ------
+    TypeError:
+        Raised if path_prefix is not a str
     ValueError 
-        Raised if all datasets are not present in all hdf5 files    
+        Raised if all datasets are not present in all hdf5 files or if the
+        path_prefix does not correspond to files accessible to Arkouda   
+    RuntimeError
+        Raised if the hdf5 files are present but there is an error in opening
+        on or more of them
 
     See Also
     --------
@@ -270,11 +303,23 @@ def load_all(path_prefix : str) -> Mapping[str,Union[pdarray,Strings]]:
     try:
         return {dataset: load(path_prefix, dataset=dataset) \
                                        for dataset in get_datasets(firstname)}
-    except RuntimeError:
+    except RuntimeError as re:
         # enables backwards compatibility with previous naming convention
-        firstname = "{}_LOCALE0{}".format(prefix, extension)
-        return {dataset: load(path_prefix, dataset=dataset) \
+        if 'does not exist' in str(re):
+            try: 
+                firstname = "{}_LOCALE0{}".format(prefix, extension)
+                return {dataset: load(path_prefix, dataset=dataset) \
                                        for dataset in get_datasets(firstname)}
+            except RuntimeError as re:
+                if 'does not exist' in str(re):
+                    raise ValueError('There are no files corresponding to the ' +
+                                     'path_prefix {} in location accessible to Arkouda'.\
+                                     format(prefix, extension))
+                else:
+                    raise RuntimeError(re)
+        else:
+            raise RuntimeError('Could not open on or more files with ' +
+                                   'the file prefix {}, check file format or permissions'.format(prefix))
 
 def save_all(columns : Union[Mapping[str,pdarray],List[pdarray]], prefix_path : str, 
              names : List[str]=None, mode : str='truncate') -> None:

--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -426,7 +426,13 @@ proc main() {
             }
         } catch (e: Error) {
             // Generate a ReplyMsg of type ERROR and serialize to a JSON-formatted string
-            sendRepMsg(serialize(msg=unknownError(e.message()),msgType=MsgType.ERROR, 
+            var errorMsg = e.message();
+            
+            if errorMsg.isEmpty() {
+                errorMsg = "unexpected error";
+            }
+
+            sendRepMsg(serialize(msg=errorMsg,msgType=MsgType.ERROR, 
                                                          msgFormat=MsgFormat.STRING, user=user));
             if trace {
                 asLogger.error(getModuleName(), getRoutineName(), getLineNumber(), 

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -68,6 +68,9 @@ class IOTest(ArkoudaTest):
           'float_pdarray',
           'bool_pdarray'
         ]
+        
+        with open('{}/not-a-file_LOCALE0000'.format(IOTest.io_test_dir), 'w'):
+            pass
 
     def _create_file(self, prefix_path : str, columns : Union[Mapping[str,ak.array]], 
                                            names : List[str]=None) -> None:
@@ -171,16 +174,21 @@ class IOTest(ArkoudaTest):
                           prefix_path='{}/iotest_single_column'.format(IOTest.io_test_dir))
         message = ak.ls_hdf('{}/iotest_single_column_LOCALE0000'.format(IOTest.io_test_dir))
         self.assertIn('int_tens_pdarray         Dataset', message)
+        
+
+        with self.assertRaises(RuntimeError) as cm:        
+            ak.ls_hdf('{}/not-a-file_LOCALE0000'.format(IOTest.io_test_dir))
+        self.assertIn('check file permissions or format', cm.exception.args[0])
 
     def testLsHdfEmpty(self):
         # Test filename empty/whitespace-only condition
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(ValueError):
             ak.ls_hdf("")
         
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(ValueError):
             ak.ls_hdf("   ")
         
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(ValueError):
             ak.ls_hdf(" \n\r\t  ")
 
     def testReadHdf(self):
@@ -318,6 +326,38 @@ class IOTest(ArkoudaTest):
         self.assertTrue((self.float_ndarray == rafloats).all())
         self.assertEqual(len(self.bool_pdarray), len(result_array_bools))
         
+        # Test load with invalid prefix
+        with self.assertRaises(RuntimeError) as cm:
+            ak.load(path_prefix='{}/iotest_dict_column'.format(IOTest.io_test_dir), 
+                                    dataset='int_tens_pdarray')  
+        self.assertIn('either corresponds to files inaccessible to Arkouda or files of an invalid format', cm.exception.args[0].args[0])
+
+        # Test load with invalid file
+        with self.assertRaises(RuntimeError) as cm:
+            ak.load(path_prefix='{}/not-a-file'.format(IOTest.io_test_dir), 
+                                    dataset='int_tens_pdarray') 
+        cm.exception.args[0]
+        self.assertIn('is not an HDF5 file', cm.exception.args[0].args[0])
+        
+    def testLoadAll(self):   
+        self._create_file(columns=self.dict_columns, 
+                          prefix_path='{}/iotest_dict_columns'.format(IOTest.io_test_dir)) 
+        
+        results = ak.load_all(path_prefix='{}/iotest_dict_columns'.format(IOTest.io_test_dir))
+        self.assertTrue('bool_pdarray' in results)
+        self.assertTrue('float_pdarray' in results)
+        self.assertTrue('int_tens_pdarray' in results)
+        self.assertTrue('int_hundreds_pdarray' in results)
+        
+        # Test load_all with invalid prefix
+        with self.assertRaises(ValueError):
+            ak.load_all(path_prefix='{}/iotest_dict_column'.format(IOTest.io_test_dir))       
+            
+        # Test load with invalid file
+        with self.assertRaises(RuntimeError) as cm:
+            ak.load_all(path_prefix='{}/not-a-file'.format(IOTest.io_test_dir)) 
+        self.assertIn('Could not open on or more files with the file prefix', cm.exception.args[0])      
+    
     def testGetDataSets(self):
         '''
         Creates 1..n files depending upon the number of arkouda_server locales containing three 
@@ -333,6 +373,11 @@ class IOTest(ArkoudaTest):
         self.assertEqual(4, len(datasets)) 
         for dataset in datasets:
             self.assertIn(dataset, self.names)
+
+        # Test load_all with invalid filename
+        with self.assertRaises(RuntimeError) as cm:            
+            ak.get_datasets('{}/iotest_dict_columns_LOCALE000'.format(IOTest.io_test_dir))
+        self.assertIn('does not exist in a location accessible to Arkouda', cm.exception.args[0])
 
     def testSaveStringsDataset(self):
         # Create, save, and load Strings dataset
@@ -454,9 +499,9 @@ class IOTest(ArkoudaTest):
                 f.create_dataset('integers', data=idata)
                 fdata = np.arange(i*N, (i+1)*N, dtype=ft)
                 f.create_dataset('floats', data=fdata)
-        with self.assertRaises(RuntimeError) as cm:
-            a = ak.read_all(prefix+'*')
-        self.assertTrue('Inconsistent precision or sign' in cm.exception.args[0])
+        with self.assertRaises(RuntimeError):
+            ak.read_all(prefix+'*')
+
         a = ak.read_all(prefix+'*', strictTypes=False)
         self.assertTrue((a['integers'] == ak.arange(len(inttypes)*N)).all())
         self.assertTrue(np.allclose(a['floats'].to_ndarray(), np.arange(len(floattypes)*N, dtype=np.float64)))


### PR DESCRIPTION
This PR addresses #857 by doing the following:

1. Adding Chapel logic to differentiate hdf5 ls and read errors resulting from (1) missing files (2) insufficient file permission(s) and (3) incorrect file format (note: only HDF5 files are currently handled in GenSymIO.chpl)
2. pdarrayIO.py error handling logic to accommodate items 1-3 above
3. Refined to error logging and error handling in GenSymIO.chpl and pdarrayIO.py