### PR TITLE
Optimize server conversions for client-server array transfers

### DIFF
--- a/arkouda/dtypes.py
+++ b/arkouda/dtypes.py
@@ -8,14 +8,10 @@ import sys
 __all__ = ["DTypes", "DTypeObjects", "dtype", "bool", "int64", "float64", 
            "uint8", "str_", "check_np_dtype", "translate_np_dtype", 
            "resolve_scalar_dtype", "ARKOUDA_SUPPORTED_DTYPES", "bool_scalars",
-           "float_scalars", "int_scalars", "numeric_scalars", "numpy_scalars", 
-           "str_scalars", "all_scalars", "get_byteorder"]
+           "float_scalars", "int_scalars", "numeric_scalars", "numpy_scalars",
+           "str_scalars", "all_scalars", "get_byteorder",
+           "get_server_byteorder"]
 
-# supported dtypes
-structDtypeCodes = {'int64': 'q',
-                    'float64': 'd',
-                    'bool': '?',
-                    'uint8': 'B'}
 NUMBER_FORMAT_STRINGS = {'bool': '{}',
                          'int64': '{:n}',
                          'float64': '{:.17f}',
@@ -176,3 +172,13 @@ def get_byteorder(dt: np.dtype) -> str:
             raise ValueError("Client byteorder must be 'little' or 'big'")
     else:
         return dt.byteorder
+
+def get_server_byteorder() -> str:
+    """
+    Get the server's byteorder
+    """
+    from arkouda.client import get_config
+    order = get_config()['byteorder']
+    if order not in ('little', 'big'):
+        raise ValueError("Server byteorder must be 'little' or 'big'")
+    return cast('str', order)

--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -3,9 +3,9 @@ import pandas as pd # type: ignore
 from typing import cast, Iterable, Optional, Union
 from typeguard import typechecked
 from arkouda.client import generic_msg
-from arkouda.dtypes import structDtypeCodes, NUMBER_FORMAT_STRINGS, float64, int64, \
+from arkouda.dtypes import NUMBER_FORMAT_STRINGS, float64, int64, \
      DTypes, isSupportedInt, isSupportedNumber, NumericDTypes, SeriesDTypes,\
-    int_scalars, numeric_scalars, get_byteorder
+    int_scalars, numeric_scalars, get_byteorder, get_server_byteorder
 from arkouda.dtypes import dtype as akdtype
 from arkouda.pdarrayclass import pdarray, create_pdarray
 from arkouda.strings import Strings
@@ -203,9 +203,11 @@ def array(a : Union[pdarray,np.ndarray, Iterable]) -> Union[pdarray, Strings]:
         raise RuntimeError(("Array exceeds allowed transfer size. Increase " +
                             "ak.maxTransferBytes to allow"))
     # Pack binary array data into a bytes object with a command header
-    # including the dtype and size. Note that the server expects big-endian so
-    # if we're using litle-endian swap the bytes before sending.
-    if get_byteorder(a.dtype) == '<':
+    # including the dtype and size. If the server has a different byteorder
+    # than our numpy array we need to swap to match since the server expects
+    # native endian bytes
+    if ((get_byteorder(a.dtype) == '<' and get_server_byteorder() == 'big') or
+        (get_byteorder(a.dtype) == '>' and get_server_byteorder() == 'little')):
         abytes = a.byteswap().tobytes()
     else:
         abytes = a.tobytes()

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -94,6 +94,7 @@ module ServerConfig
             const LocaleConfigs: [LocaleSpace] owned LocaleConfig;
             const authenticate: bool;
             const logLevel: LogLevel;
+            const byteorder: string;
         }
         var (Zmajor, Zminor, Zmicro) = ZMQ.version;
         var H5major: c_uint, H5minor: c_uint, H5micro: c_uint;
@@ -111,7 +112,8 @@ module ServerConfig
             distributionType = (makeDistDom(10).type):string,
             LocaleConfigs = [loc in LocaleSpace] new owned LocaleConfig(loc),
             authenticate = authenticate,
-            logLevel = logLevel
+            logLevel = logLevel,
+            byteorder = try! getByteorder()
         );
 
         return cfg;
@@ -136,6 +138,18 @@ module ServerConfig
     proc getPhysicalMemHere() {
         use MemDiagnostics;
         return here.physicalMemory();
+    }
+
+    /*
+    Get the byteorder (endianness) of this locale
+    */
+    proc getByteorder() throws {
+        use IO;
+        var writeVal = 1, readVal = 0;
+        var tmpf = openmem();
+        tmpf.writer(kind=iobig).write(writeVal);
+        tmpf.reader(kind=ionative, start=0).read(readVal);
+        return if writeVal == readVal then "big" else "little";
     }
 
     /*

--- a/tests/dtypes_tests.py
+++ b/tests/dtypes_tests.py
@@ -148,9 +148,3 @@ class DtypesTest(ArkoudaTest):
         self.assertEqual('{:.17f}', dtypes.NUMBER_FORMAT_STRINGS['float64'])
         self.assertEqual('f', dtypes.NUMBER_FORMAT_STRINGS['np.float64'])
         self.assertEqual('{:n}', dtypes.NUMBER_FORMAT_STRINGS['uint8'])
-        
-    def test_structDtypeCodes(self):
-        self.assertEqual('q', dtypes.structDtypeCodes['int64'])
-        self.assertEqual('d', dtypes.structDtypeCodes['float64'])
-        self.assertEqual('?', dtypes.structDtypeCodes['bool'])
-        self.assertEqual('B', dtypes.structDtypeCodes['uint8'])


### PR DESCRIPTION
Improve the performance of `ak.array()` and `pdarray.to_ndarray()` by
optimizing how the server converts between bytes and pdarrays.
Previously, the server would write to and read from a big-endian memory
mapped file to convert between bytes and arrays but this is fairly
slow. Optimize this conversion by directly interpreting the underlying
memory as the type we're converting to. In the `ak.array()` case we
create the local array with `makeArrayFromPtr`, which will create an
array from the existing bytes without any copies. For the `to_ndarray()`
case `makeArrayFromPtr` is also used on some local memory, which is then
reinterpreted as bytes with `createBytesWithOwnedBuffer`.

Here's the performance improvement for 16-node-xc:

| config | to_ndarray | ak.array   |
| ------ | ---------: | ---------: |
| before |   33 MiB/s |   50 MiB/s |
| after  |  410 MiB/s |  175 MiB/s |

Where `ak.array()` is slower because there are more copies compared to
`to_ndarray()` on both the server and client side. Optimizing those
copies out is future work.

Part of #794