### PR TITLE
Rename Errors to ServerErrors

### DIFF
--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -26,7 +26,7 @@ module ArgSortMsg
     use RadixSortLSD;
     use SegmentedArray;
     use Reflection;
-    use Errors;
+    use ServerErrors;
     use Logging;
     use Message;
 

--- a/src/ArraySetopsMsg.chpl
+++ b/src/ArraySetopsMsg.chpl
@@ -21,7 +21,7 @@ module ArraySetopsMsg
     use Indexing;
     use RadixSortLSD;
     use Reflection;
-    use Errors;
+    use ServerErrors;
     use Logging;
     use Message;
 

--- a/src/BroadcastMsg.chpl
+++ b/src/BroadcastMsg.chpl
@@ -1,7 +1,7 @@
 module BroadcastMsg {
   use MultiTypeSymbolTable;
   use MultiTypeSymEntry;
-  use Errors;
+  use ServerErrors;
   use Reflection;
   use Broadcast;
   use ServerConfig;

--- a/src/CastMsg.chpl
+++ b/src/CastMsg.chpl
@@ -3,7 +3,7 @@ module CastMsg {
   use MultiTypeSymEntry;
   use Reflection;
   use SegmentedArray;
-  use Errors;
+  use ServerErrors;
   use Logging;
   use Message;
   use SysError;

--- a/src/ConcatenateMsg.chpl
+++ b/src/ConcatenateMsg.chpl
@@ -5,7 +5,7 @@ module ConcatenateMsg
     use Time only;
     use Math only;
     use Reflection;
-    use Errors;
+    use ServerErrors;
     use Logging;
     use Message;
     

--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -6,7 +6,7 @@ module EfuncMsg
     use Time only;
     use Math only;
     use Reflection;
-    use Errors;
+    use ServerErrors;
     use Logging;
     use Message;
     use MultiTypeSymbolTable;

--- a/src/FindSegmentsMsg.chpl
+++ b/src/FindSegmentsMsg.chpl
@@ -5,7 +5,7 @@ module FindSegmentsMsg
     use Time only;
     use Math only;
     use Reflection;
-    use Errors;
+    use ServerErrors;
     use Logging;
     use Message;
     

--- a/src/Flatten.chpl
+++ b/src/Flatten.chpl
@@ -1,6 +1,6 @@
 module Flatten {
   use SegmentedArray;
-  use Errors;
+  use ServerErrors;
   use SymArrayDmap;
   use CommAggregation;
   use Reflection;

--- a/src/FlattenMsg.chpl
+++ b/src/FlattenMsg.chpl
@@ -1,7 +1,7 @@
 module FlattenMsg {
   use MultiTypeSymbolTable;
   use MultiTypeSymEntry;
-  use Errors;
+  use ServerErrors;
   use Reflection;
   use Flatten;
   use ServerConfig;

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -15,7 +15,7 @@ module GenSymIO {
     use Map;
     use PrivateDist;
     use Reflection;
-    use Errors;
+    use ServerErrors;
     use Logging;
     use Message;
     use ServerConfig;

--- a/src/HistogramMsg.chpl
+++ b/src/HistogramMsg.chpl
@@ -3,7 +3,7 @@ module HistogramMsg
     use ServerConfig;
 
     use Reflection;
-    use Errors;
+    use ServerErrors;
     use Logging;
     use Message;
     

--- a/src/In1dMsg.chpl
+++ b/src/In1dMsg.chpl
@@ -4,7 +4,7 @@ module In1dMsg
     use ServerConfig;
 
     use Reflection;
-    use Errors;
+    use ServerErrors;
     use Logging;
     use Message;
     

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -4,7 +4,7 @@ module IndexingMsg
     use ServerErrorStrings;
 
     use Reflection;
-    use Errors;
+    use ServerErrors;
     use Logging;
     use Message;
 

--- a/src/JoinEqWithDTMsg.chpl
+++ b/src/JoinEqWithDTMsg.chpl
@@ -6,7 +6,7 @@ module JoinEqWithDTMsg
     use Math only;
     use Sort only;
     use Reflection;
-    use Errors;
+    use ServerErrors;
     use Logging;
     use Message;
     use PrivateDist;

--- a/src/KExtremeMsg.chpl
+++ b/src/KExtremeMsg.chpl
@@ -9,7 +9,7 @@ module KExtremeMsg
     use Time only;
     use Math only;
     use Reflection;
-    use Errors;
+    use ServerErrors;
     use Logging;
     use Message;
 

--- a/src/Logging.chpl
+++ b/src/Logging.chpl
@@ -3,7 +3,7 @@ module Logging {
     use IO;
     use DateTime;
     use Reflection;
-    use Errors;
+    use ServerErrors;
 
     /*
      * The LogLevel enum is used to provide a strongly-typed means of

--- a/src/Message.chpl
+++ b/src/Message.chpl
@@ -1,7 +1,7 @@
 module Message {
     use IO;
     use Reflection;
-    use Errors;
+    use ServerErrors;
 
     enum MsgType {NORMAL,WARNING,ERROR}
     enum MsgFormat {STRING,BINARY}

--- a/src/MsgProcessing.chpl
+++ b/src/MsgProcessing.chpl
@@ -6,7 +6,7 @@ module MsgProcessing
     use Time only;
     use Math only;
     use Reflection;
-    use Errors;
+    use ServerErrors;
     use Logging;
     use Message;
     

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -3,7 +3,7 @@ module MultiTypeSymbolTable
     use ServerConfig;
     use ServerErrorStrings;
     use Reflection;
-    use Errors;
+    use ServerErrors;
     use Logging;
     
     use MultiTypeSymEntry;

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -6,7 +6,7 @@ module OperatorMsg
     use Time;
     use Math;
     use Reflection;
-    use Errors;
+    use ServerErrors;
 
     use MultiTypeSymbolTable;
     use MultiTypeSymEntry;

--- a/src/RandArray.chpl
+++ b/src/RandArray.chpl
@@ -1,6 +1,6 @@
 module RandArray {
   use Reflection;
-  use Errors;
+  use ServerErrors;
   use Logging;
   use Random;
   use SegmentedArray;

--- a/src/RandMsg.chpl
+++ b/src/RandMsg.chpl
@@ -5,7 +5,7 @@ module RandMsg
     use Time only;
     use Math only;
     use Reflection;
-    use Errors;
+    use ServerErrors;
     use Logging;
     use Message;
     use RandArray;

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -11,7 +11,7 @@ module ReductionMsg
     use MultiTypeSymEntry;
     use ServerErrorStrings;
     use Reflection;
-    use Errors;
+    use ServerErrors;
     use Logging;
     use Message;
 

--- a/src/RegistrationMsg.chpl
+++ b/src/RegistrationMsg.chpl
@@ -5,7 +5,7 @@ module RegistrationMsg
     use Time only;
     use Math only;
     use Reflection;
-    use Errors;
+    use ServerErrors;
     use Logging;
     use Message;
 

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -15,7 +15,7 @@ module SegmentedArray {
   use Time only Timer, getCurrentTime;
   use Reflection;
   use Logging;
-  use Errors;
+  use ServerErrors;
 
   private config const logLevel = ServerConfig.logLevel;
   const saLogger = new Logger(logLevel);

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -1,6 +1,6 @@
 module SegmentedMsg {
   use Reflection;
-  use Errors;
+  use ServerErrors;
   use Logging;
   use Message;
   use SegmentedArray;

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -10,7 +10,7 @@ module ServerConfig
 
     use ServerErrorStrings;
     use Reflection;
-    use Errors;
+    use ServerErrors;
     use Logging;
 
     /*

--- a/src/ServerErrors.chpl
+++ b/src/ServerErrors.chpl
@@ -1,4 +1,4 @@
-module Errors {
+module ServerErrors {
 
     use SysError;
     private use IO; // for string.format

--- a/src/SipHash.chpl
+++ b/src/SipHash.chpl
@@ -3,7 +3,7 @@ module SipHash {
   private use AryUtil;
   private use CPtr;
   use ServerConfig;
-  use Errors;
+  use ServerErrors;
   use Reflection;
   use Logging;
   

--- a/src/SortMsg.chpl
+++ b/src/SortMsg.chpl
@@ -6,7 +6,7 @@ module SortMsg
     use Math only;
     use Sort only;
     use Reflection;
-    use Errors;
+    use ServerErrors;
     use MultiTypeSymbolTable;
     use MultiTypeSymEntry;
     use ServerErrorStrings;

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -15,7 +15,7 @@ module UniqueMsg
     use Time only;
     use Math only;
     use Reflection;
-    use Errors;
+    use ServerErrors;
     use Logging;
     use Message;
 

--- a/src/deprecated/PerLocaleReduction.chpl
+++ b/src/deprecated/PerLocaleReduction.chpl
@@ -11,7 +11,7 @@ module PerLocaleReduction {
     use ServerErrorStrings;
     use ServerConfig;
     use Reflection;
-    use Errors;
+    use ServerErrors;
 
     use AryUtil;
     use PrivateDist;


### PR DESCRIPTION
Over on the main Chapel repository, we've moved a few modules around as part of module stabilization (see https://github.com/chapel-lang/chapel/pull/18028). As part of that we've added an included-by-default internal module called Errors. However, Arkouda was using a top-level module called Errors so that led to problems. This PR renames the Arkouda one to ServerErrors. This name was chosen to be symmetric with ServerErrorStrings.

(Longer term I think it would be reasonable for Arkouda to consist of an Arkouda module and then submodules beneath that, including in different files. The module system should support having a submodule named Errors along with the toplevel (internal) one - the naming conflict here is specific to top-level modules).