### PR TITLE
Optimize the number of copies for client-server array transfers

### DIFF
--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -295,8 +295,8 @@ def _start_tunnel(addr : str, tunnel_server : str) -> Tuple[str,object]:
     except Exception as e:
         raise ConnectionError(e)
 
-def _send_string_message(cmd : str, recv_bytes : bool=False, 
-                                   args : str=None) -> Union[str, bytes]:
+def _send_string_message(cmd : str, recv_binary : bool=False,
+                         args : str=None) -> Union[str, bytes]:
     """
     Generates a RequestMessage encapsulating command and requesting
     user information, sends it to the Arkouda server, and returns 
@@ -306,16 +306,15 @@ def _send_string_message(cmd : str, recv_bytes : bool=False,
     ----------
     cmd : str
         The name of the command to be executed by the Arkouda server
-    recv_bytes : bool, defaults to False
-        A boolean indicating whether the return message will be in bytes
-        as opposed to a string
+    recv_binary : bool, defaults to False
+        Indicates if the return message will be a string or binary data
     args : str
         A delimited string containing 1..n command arguments
 
     Returns
     -------
     Union[str,bytes]
-        The response string or byte array sent back from the Arkouda server
+        The response string or binary data sent back from the Arkouda server
         
     Raises
     ------
@@ -327,21 +326,18 @@ def _send_string_message(cmd : str, recv_bytes : bool=False,
         expected fields       
     """
     message = RequestMessage(user=username, token=token, cmd=cmd, 
-                          format=MessageFormat.STRING, args=cast(str,args))
+                          format=MessageFormat.STRING, args=args)
 
     logger.debug('sending message {}'.format(message))
 
     socket.send_string(json.dumps(message.asdict()))
 
-    if recv_bytes:
-        return_message = socket.recv()
-
-        # raise errors or warnings sent back from the server
-        if return_message.startswith(b"Error:"): 
-            raise RuntimeError(return_message.decode())
-        elif return_message.startswith(b"Warning:"): 
-            warnings.warn(return_message.decode())
-        return return_message
+    if recv_binary:
+        binary_return_message = socket.recv()
+        # raise errors sent back from the server
+        if binary_return_message.startswith(b"Error:"): \
+                                   raise RuntimeError(binary_return_message.decode())
+        return binary_return_message
     else:
         raw_message = socket.recv_string()
         try:
@@ -359,8 +355,9 @@ def _send_string_message(cmd : str, recv_bytes : bool=False,
             raise ValueError('Return message is not valid JSON: {}'.\
                              format(raw_message))
 
-def _send_binary_message(cmd : str, payload : bytes, recv_bytes : bool=False,
-                                            args : str=None) -> Union[str, bytes]:
+
+def _send_binary_message(cmd : str, payload : bytes, recv_binary : bool=False,
+                         args : str=None) -> Union[str, bytes]:
     """
     Generates a RequestMessage encapsulating command and requesting user information,
     information prepends the binary payload, sends the binary request to the Arkouda 
@@ -371,18 +368,17 @@ def _send_binary_message(cmd : str, payload : bytes, recv_bytes : bool=False,
     cmd : str
         The name of the command to be executed by the Arkouda server    
     payload : bytes
-        The bytes to be converted to a pdarray, Strings, or Categorical object
-        on the Arkouda server
-    recv_bytes : bool, defaults to False
-        A boolean indicating whether the return message will be in bytes
-        as opposed to a string
+        The binary data to be converted to a pdarray, Strings, or Categorical
+        object on the Arkouda server
+    recv_binary : bool, defaults to False
+        Indicates if the return message will be a string or binary data
     args : str
         A delimited string containing 1..n command arguments
 
     Returns
     -------
     Union[str,bytes]
-        The response string or byte array sent back from the Arkouda server
+        The response string or binary data sent back from the Arkouda server
 
     Raises
     ------
@@ -394,20 +390,18 @@ def _send_binary_message(cmd : str, payload : bytes, recv_bytes : bool=False,
         expected fields
     """
     message = RequestMessage(user=username, token=token, cmd=cmd, 
-                                format=MessageFormat.BINARY, args=cast(str,args))
+                                format=MessageFormat.BINARY, args=args)
 
     logger.debug('sending message {}'.format(message))
 
     socket.send('{}BINARY_PAYLOAD'.\
                 format(json.dumps(message.asdict())).encode() + payload)
 
-    if recv_bytes:
-        binary_return_message = cast(bytes, socket.recv())
-        # raise errors or warnings sent back from the server
+    if recv_binary:
+        binary_return_message = socket.recv()
+        # raise errors sent back from the server
         if binary_return_message.startswith(b"Error:"): \
                                    raise RuntimeError(binary_return_message.decode())
-        elif binary_return_message.startswith(b"Warning:"): \
-                                        warnings.warn(binary_return_message.decode())
         return binary_return_message
     else:
         raw_message = socket.recv_string()
@@ -496,8 +490,8 @@ def shutdown() -> None:
     connected = False
     serverConfig = None
 
-def generic_msg(cmd : str, args : Union[str,bytes]=None, send_bytes : bool=False, 
-                recv_bytes : bool=False) -> Union[str, bytes]:
+def generic_msg(cmd : str, args : str=None, payload : bytes=None, send_binary : bool=False,
+                recv_binary : bool=False) -> Union[str, bytes]:
     """
     Sends a binary or string message composed of a command and corresponding 
     arguments to the arkouda_server, returning the response sent by the server.
@@ -506,13 +500,14 @@ def generic_msg(cmd : str, args : Union[str,bytes]=None, send_bytes : bool=False
     ----------
     cmd : str
         The server-side command to be executed
-    args : Union[str,bytes]
-        A space-delimited list of command arguments or a byte array, the latter
-        of which is for creating an Arkouda array
-    send_bytes : bool
-        Indicates if the message to be sent is binary, defaults to False
-    recv_bytes : bool
-        Indicates if the return message will be binary, default to False
+    args : str
+        A space-delimited list of command arguments
+    payload : bytes
+        The payload when sending binary data
+    send_binary : bool
+        Indicates if the message to be sent is a string or binary
+    recv_binary : bool
+        Indicates if the return message will be a string or binary
 
     Returns
     -------
@@ -539,14 +534,14 @@ def generic_msg(cmd : str, args : Union[str,bytes]=None, send_bytes : bool=False
         raise RuntimeError("client is not connected to a server")
     
     try:
-        if send_bytes:
-            return _send_binary_message(cmd=cmd, 
-                                            payload=cast(bytes,args), 
-                                            recv_bytes=recv_bytes)         
+        if send_binary:
+            assert payload is not None
+            return _send_binary_message(cmd=cmd, payload=payload,
+                                        recv_binary=recv_binary, args=args)
         else:
-            return _send_string_message(cmd=cmd, args=cast(str,args), 
-                                            recv_bytes=recv_bytes)
-                
+            assert payload is None
+            return _send_string_message(cmd=cmd, args=args, recv_binary=recv_binary)
+
     except KeyboardInterrupt as e:
         # if the user interrupts during command execution, the socket gets out 
         # of sync reset the socket before raising the interrupt exception
@@ -575,7 +570,7 @@ def get_config() -> Mapping[str, Union[str, int, float]]:
     """
 
     if serverConfig is None:
-        raise RuntimeError('Not connected to a server')
+        raise RuntimeError("client is not connected to a server")
 
     return serverConfig
 

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -850,20 +850,24 @@ class pdarray:
         if arraybytes > maxTransferBytes:
             raise RuntimeError(('Array exceeds allowed size for transfer. Increase ' +
                                'client.maxTransferBytes to allow'))
-        # The reply from the server will be a bytes object
-        rep_msg = generic_msg(cmd="tondarray", args="{}".format(self.name), recv_binary=True)
+        # The reply from the server will be binary data
+        data = cast(memoryview,generic_msg(cmd="tondarray", args="{}".format(self.name), recv_binary=True))
         # Make sure the received data has the expected length
-        if len(rep_msg) != self.size*self.dtype.itemsize:
+        if len(data) != self.size*self.dtype.itemsize:
             raise RuntimeError("Expected {} bytes but received {}".\
-                               format(self.size*self.dtype.itemsize, len(rep_msg)))
-        # The server sends us native-endian bytes so we need to account for that.
-        # Since bytes are immutable, we need to copy the np array to be mutable
+                               format(self.size*self.dtype.itemsize, len(data)))
+        # The server sends us native-endian data so we need to account for
+        # that. If the view is readonly, copy so the np array is mutable
         dt = np.dtype(self.dtype)
         if get_server_byteorder() == 'big':
             dt = dt.newbyteorder('>')
         else:
             dt = dt.newbyteorder('<')
-        return np.frombuffer(rep_msg, dt).copy()
+
+        if data.readonly:
+            return np.frombuffer(data, dt).copy()
+        else:
+            return np.frombuffer(data, dt)
 
     def to_cuda(self):
         """

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -851,7 +851,7 @@ class pdarray:
             raise RuntimeError(('Array exceeds allowed size for transfer. Increase ' +
                                'client.maxTransferBytes to allow'))
         # The reply from the server will be a bytes object
-        rep_msg = generic_msg(cmd="tondarray", args="{}".format(self.name), recv_bytes=True)
+        rep_msg = generic_msg(cmd="tondarray", args="{}".format(self.name), recv_binary=True)
         # Make sure the received data has the expected length
         if len(rep_msg) != self.size*self.dtype.itemsize:
             raise RuntimeError("Expected {} bytes but received {}".\

--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -208,11 +208,11 @@ def array(a : Union[pdarray,np.ndarray, Iterable]) -> Union[pdarray, Strings]:
     # native endian bytes
     if ((get_byteorder(a.dtype) == '<' and get_server_byteorder() == 'big') or
         (get_byteorder(a.dtype) == '>' and get_server_byteorder() == 'little')):
-        abytes = a.byteswap().tobytes()
+        aview = memoryview(a.byteswap())
     else:
-        abytes = a.tobytes()
+        aview = memoryview(a)
     args = "{} {:n} ".  format(a.dtype.name, size)
-    repMsg = generic_msg(cmd='array', args=args, payload=abytes, send_binary=True)
+    repMsg = generic_msg(cmd='array', args=args, payload=aview, send_binary=True)
     return create_pdarray(repMsg)
 
 def zeros(size : int_scalars, dtype : type=np.float64) -> pdarray:

--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -211,8 +211,8 @@ def array(a : Union[pdarray,np.ndarray, Iterable]) -> Union[pdarray, Strings]:
         abytes = a.byteswap().tobytes()
     else:
         abytes = a.tobytes()
-    req_msg = "{} {:n} ".  format(a.dtype.name, size).encode() + abytes
-    repMsg = generic_msg(cmd='array', args=req_msg, send_bytes=True)
+    args = "{} {:n} ".  format(a.dtype.name, size)
+    repMsg = generic_msg(cmd='array', args=args, payload=abytes, send_binary=True)
     return create_pdarray(repMsg)
 
 def zeros(size : int_scalars, dtype : type=np.float64) -> pdarray:

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -54,7 +54,7 @@ module GenSymIO {
             return new MsgTuple(errorMsg, MsgType.ERROR);
         }
 
-        overMemLimit(2*8*size);
+        overMemLimit(2*size);
 
         gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                           "dtype: %t size: %i".format(dtype,size));

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -36,17 +36,17 @@ module GenSymIO {
      * Creates a pdarray server-side and returns the SymTab name used to
      * retrieve the pdarray from the SymTab.
      */
-    proc arrayMsg(cmd: string, payload: bytes, st: borrowed SymTab): MsgTuple throws {
+    proc arrayMsg(cmd: string, args: string, ref data: bytes, st: borrowed SymTab): MsgTuple throws {
         // Set up our return items
         var msgType = MsgType.NORMAL;
         var msg:string = "";
         var rname:string = "";
 
-        var (dtypeBytes, sizeBytes, data) = payload.splitMsgToTuple(b" ", 3);
+        var (dtypeBytes, sizeBytes) = args.splitMsgToTuple(" ", 2);
         var dtype = DType.UNDEF;
         var size:int;
         try {
-            dtype = str2dtype(dtypeBytes.decode());
+            dtype = str2dtype(dtypeBytes);
             size = sizeBytes:int;
         } catch {
             var errorMsg = "Error parsing/decoding either dtypeBytes or size";

--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -294,7 +294,7 @@ proc main() {
 
             select cmd
             {
-                when "array"             {repTuple = arrayMsg(cmd, payload, st);}
+                when "array"             {repTuple = arrayMsg(cmd, args, payload, st);}
                 when "tondarray"         {binaryRepMsg = tondarrayMsg(cmd, args, st);}
                 when "cast"              {repTuple = castMsg(cmd, args, st);}
                 when "mink"              {repTuple = minkMsg(cmd, args, st);}

--- a/tests/pdarray_creation_test.py
+++ b/tests/pdarray_creation_test.py
@@ -592,3 +592,29 @@ class PdarrayCreationTest(ArkoudaTest):
         aka = ak.array(a)
         npa = aka.to_ndarray();
         self.assertTrue(np.allclose(a, npa))
+
+    def test_clobber(self):
+        N = 100
+        narrs = 10
+
+        arrs = [np.random.randint(1, N, N) for _ in range(narrs)]
+        akarrs = [ak.array(arr) for arr in arrs]
+        nparrs = [arr.to_ndarray() for arr in akarrs]
+        for (a, npa) in zip(arrs, nparrs):
+            self.assertTrue(np.allclose(a, npa))
+
+        arrs = [np.full(N, i) for i in range(narrs)]
+        akarrs = [ak.array(arr) for arr in arrs]
+        nparrs = [arr.to_ndarray() for arr in akarrs]
+
+        for (a, npa, i) in zip(arrs, nparrs, range(narrs)):
+            self.assertTrue(np.all(a == i))
+            self.assertTrue(np.all(npa == i))
+
+            a += 1
+            self.assertTrue(np.all(a == i+1))
+            self.assertTrue(np.all(npa == i))
+
+            npa += 1
+            self.assertTrue(np.all(a == i+1))
+            self.assertTrue(np.all(npa == i+1))


### PR DESCRIPTION
Reduce the number of copies for `ak.array()` and `pdarray.to_ndarray()`.
On the client side use non-copying sends/recvs that take/return a
memoryview. For `ak.array` send the binary payload in a separate message
to avoid concatenating (which creates a copy) on the client side and
splitting (which also creates a copy ) on the server side. For
`pdarray.to_ndarray()` on the server side move the binaryRepMsg
declaration to avoid an extra copy that was happening.

Here's the performance impact for 16-node-xc:

| config | to_ndarray | ak.array   |
| ------ | ---------: | ---------: |
| before |  410 MiB/s |  175 MiB/s |
| after  |  715 MiB/s |  705 MiB/s |

Part of #794