### PR TITLE
Adding parallel wrapper script for start_test (Chapel based unit testing).

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -125,4 +125,4 @@ jobs:
         echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" > Makefile.paths
     - name: Run unit tests
       run: |
-        start_test test
+        python3 util/test/parallel_start_test.py -d test --threads 4

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ dep/*-install/
 dep/build/
 *.pyc
 ak-server-info
+test/IOSpeedTest.good
+test/IOSpeedTestMsg.good
+test/NanSpeedTest.good
+test/StringArgsortSpeedTest.good
+test/file_LOCALE0000

--- a/util/test/parallel_start_test.py
+++ b/util/test/parallel_start_test.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+"""
+Usage: time python3 util/test/parallel_start_test.py -d `pwd`/test
+"""
+import optparse
+import os
+import os.path
+import subprocess
+import sys
+
+SLOTS = 4
+
+
+def process_dir(test_dir):
+    """
+    Process a directory containing Chapel unit tests
+
+    Parameters
+    ----------
+    test_dir : Directory containing Chapel unit-test files
+
+    Returns
+    -------
+    filtered view of files that are viable unit test files
+    """
+    utests = []
+    skips = []
+    if os.path.isdir(test_dir):
+        for item in [i for i in os.listdir(test_dir)]:
+            if item.lower().endswith("chpl") and "test" in item.lower():
+                utests.append(item)
+            elif item.lower().endswith(".notest"):
+                skips.append(item[:-7] + ".chpl")  # Set up removals
+            else:
+                pass
+        return filter(lambda v: v not in skips, utests)
+    elif test_dir.lower().endswith(".chpl") and "test" in test_dir.lower():  # file case
+        utests.append(test_dir)
+        return utests
+    else:
+        raise Exception(f"Unknown Chapel unit tests file: {test_dir}")
+
+
+def subprocess_start_test(fn):
+    print(f"Calling subprocess on {fn}")
+    cmd = ["start_test", fn]
+    return subprocess.run(capture_output=True, args=cmd)
+
+
+def successful_completed_process(p: subprocess.CompletedProcess):
+    try:
+        p.check_returncode()
+        return True
+    except subprocess.CalledProcessError:
+        # print(f"{p.stderr}")
+        return False
+
+
+def parallel_test(unit_tests):
+    import queue
+    import threading
+    q = queue.Queue()
+
+    results = {}  # used to store the results
+    for test in unit_tests:
+        q.put(test)
+
+    def worker():
+        while True:
+            unit_test = q.get()
+            if unit_test is None:  # EOF?
+                q.task_done()
+                return
+            sp = subprocess_start_test(unit_test)
+            if not successful_completed_process(sp):
+                fn = sp.args[-1]
+                results[fn] = "failed"
+            q.task_done()
+
+    threads = [threading.Thread(target=worker) for _i in range(SLOTS)]
+    for thread in threads:
+        thread.start()
+        q.put(None)  # Sentinel value for each thread to know we're done
+
+    q.join()
+    return results
+
+
+if __name__ == "__main__":
+    parser = optparse.OptionParser()
+    parser.add_option("-f", "--file",
+                      dest="filename",
+                      help="Run single test file",
+                      metavar="FILE")
+    parser.add_option("-d", "--dir",
+                      dest="dir",
+                      help="Directory to look for test files")
+    parser.add_option("-t", "--threads",
+                      dest="num_threads",
+                      help="Number of worker threads, default 4")
+
+    (options, args) = parser.parse_args()
+    if options.num_threads:
+        SLOTS = int(options.num_threads)
+
+    if options.dir and options.filename:
+        raise Exception("Please specify only one of -f/--file or -d/--dir, not both")
+
+    if options.dir or options.filename:
+        tests = process_dir(options.dir if options.dir else options.filename)
+        if options.dir: tests = [f"{options.dir}/{t}" for t in tests]  # Set up relative path to Unit tests
+        print(f"Number of unit tests: {len(tests)}")
+        print(f"Number of threads: {SLOTS}")
+        print("Starting...")
+        test_results = parallel_test(tests)
+        print("Done")
+        if len(test_results) > 0:
+            print(f"{'-' * 40}")
+            [print(f"Test {k} {v}") for k, v in test_results.items()]
+            sys.exit(1)
+    else:
+        raise Exception("Please specify one of the options -f/--file or -d/--dir")

--- a/util/test/parallel_start_test.py
+++ b/util/test/parallel_start_test.py
@@ -69,7 +69,7 @@ def parallel_test(unit_tests):
     def worker():
         while True:
             unit_test = q.get()
-            if unit_test is None:  # EOF?
+            if unit_test is None:  # Reached Sentinel value, we're done
                 q.task_done()
                 return
             sp = subprocess_start_test(unit_test)


### PR DESCRIPTION
I usually run Chapel's `start_test` utility to build and run the server side, Chapel-based unit tests.  (Note: I believe `make test-chapel` only compiles the tests, it does not run and compare output to the `.good` files.)

Typical runs take about 18-20 minutes since they run one at a time.  This wrapper python-script runs these tests in parallel using a configurable number of worker threads.  Using a default of 4 threads it takes about 5 minutes.

It also updates the CI workflow to use the wrapper where appropriate as well as updates the `.gitignore` file to ignore speed-test `.good` files which get auto-generated when running those tests.