### PR TITLE
Closes #848 Limit Length of Logging Lines:

### DIFF
--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -265,8 +265,11 @@ proc main() {
             if (trace) {
               try {
                 if (cmd != "array") {
+                  var n: int = 12;
+                  // if args.size > 2*n, only first n characters and last n characters are logged
+                  var short_args: string = if args.size > 2*n then args[0..#n]+'...'+args[args.size-n..#n] else args;
                   asLogger.info(getModuleName(), getRoutineName(), getLineNumber(),
-                                                     ">>> %t %t".format(cmd, args));
+                                                     ">>> %t %t".format(cmd, short_args));
                 } else {
                   asLogger.info(getModuleName(), getRoutineName(), getLineNumber(),
                                                      ">>> %s [binary data]".format(cmd));


### PR DESCRIPTION
Closes #848 Limit Length of Logging Lines:
- Adds a threshold, `n`, that caps the length of `args` being logged to `2*n`. Whens `args.size > 2*n`, it will be logged as `[first n characters]...[last n characters]`

I had no idea what `n` should be. I made it 12 for no reason in particular other than ease of testing (and it made my example below look nice hahaha). I'm certainly open to suggestions for different values

```python
# client commands:
pd = ak.array([1,2,3])
pd.register('reallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallylongname')

# server logs before PR:
2021-07-28:13:41:35 [arkouda_server] main Line 268 INFO [Chapel] >>> "register" "id_1 reallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallylongname"
...
2021-07-28:13:41:35 [arkouda_server] main Line 268 INFO [Chapel] >>> "repr" "reallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallylongname 100"

# server logs after PR:
2021-07-28:15:30:02 [arkouda_server] main Line 271 INFO [Chapel] >>> "register" "id_1 reallyr...allylongname"
...
2021-07-28:15:30:02 [arkouda_server] main Line 271 INFO [Chapel] >>> "repr" "reallyreally...longname 100"
```