### PR TITLE
Disable cache remote

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ endif
 CHPL_FLAGS += -smemTrack=true
 CHPL_FLAGS += -lhdf5 -lhdf5_hl -lzmq
 
+# We have seen segfaults with cache remote at some node counts
+CHPL_FLAGS += --no-cache-remote
+
 # add-path: Append custom paths for non-system software.
 # Note: Darwin `ld` only supports `-rpath <path>`, not `-rpath=<paths>`.
 define add-path


### PR DESCRIPTION
With 1.24.1 we have seen segfaults on XC at some node counts. Disable
the cache until we have time to diagnose and fix the issue (assuming
there's a cache remote bug, we won't re-enable until 1.25.) We might be
able to only disable for XC, but until we know what the core issue is I
want to play it safe and disable everywhere.

Note that cache remote doesn't benefit Arkouda most since most things
are aggregated and bulk messages bypass the cache. The only thing that
benefits from the cache is scans at scale, but even that is minor so I
don't think we're giving much up by disabling it.