### PR TITLE
Further reduce the number of copies for client-server array transfers

### DIFF
--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -220,10 +220,8 @@ proc main() {
          * string encapsulating user, token, cmd, message format and args from the 
          * remaining payload.
          */
-        var (rawRequest, payload) = reqMsgRaw.splitMsgToTuple(b"BINARY_PAYLOAD",2);
-        if reqMsgRaw.endsWith(b"BINARY_PAYLOAD") {
-          payload = socket.recv(bytes);
-        }
+        var (rawRequest, _) = reqMsgRaw.splitMsgToTuple(b"BINARY_PAYLOAD",2);
+        var payload = if reqMsgRaw.endsWith(b"BINARY_PAYLOAD") then socket.recv(bytes) else b"";
         var user, token, cmd: string;
 
         // parse requests, execute requests, format responses


### PR DESCRIPTION
Eliminate a copy for `ak.array()` by ensuring that copy elision fires
when recv'ing the binary payload.

Here's the performance impact for 16-node-xc:

| config | to_ndarray | ak.array   |
| ------ | ---------: | ---------: |
| before |  715 MiB/s |  705 MiB/s |
| after  |  715 MiB/s |  750 MiB/s |

Part of #794