### PR TITLE
Closes #855 Add mem checks for scans

### DIFF
--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -305,7 +305,7 @@ module ArgSortMsg
       return new MsgTuple(repMsg, MsgType.NORMAL);
     }
     
-    proc argsortDefault(A:[?D] ?t):[D] int {
+    proc argsortDefault(A:[?D] ?t):[D] int throws {
       var t1 = Time.getCurrentTime();
       //var AI = [(a, i) in zip(A, D)] (a, i);
       //Sort.TwoArrayRadixSort.twoArrayRadixSort(AI);

--- a/src/ArraySetops.chpl
+++ b/src/ArraySetops.chpl
@@ -27,7 +27,7 @@ module ArraySetops
     private config const mBound = 2**25; 
 
     // returns intersection of 2 arrays
-    proc intersect1d(a: [] int, b: [] int, assume_unique: bool) {
+    proc intersect1d(a: [] int, b: [] int, assume_unique: bool) throws {
       //if not unique, unique sort arrays then perform operation
       if (!assume_unique) {
         var a1  = uniqueSort(a, false);
@@ -37,7 +37,7 @@ module ArraySetops
       return intersect1dHelper(a,b);
     }
 
-    proc intersect1dHelper(a: [] ?t, b: [] t) {
+    proc intersect1dHelper(a: [] ?t, b: [] t) throws {
       var aux = radixSortLSD_keys(concatset(a,b));
 
       // All elements except the last
@@ -51,7 +51,7 @@ module ArraySetops
     }
     
     // returns the exclusive-or of 2 arrays
-    proc setxor1d(a: [] int, b: [] int, assume_unique: bool) {
+    proc setxor1d(a: [] int, b: [] int, assume_unique: bool) throws {
       //if not unique, unique sort arrays then perform operation
       if (!assume_unique) {
         var a1  = uniqueSort(a, false);
@@ -65,7 +65,7 @@ module ArraySetops
     // first concatenates the 2 arrays, then
     // sorts and removes all values that occur
     // more than once
-    proc setxor1dHelper(a: [] ?t, b: [] t) {
+    proc setxor1dHelper(a: [] ?t, b: [] t) throws {
       const aux = radixSortLSD_keys(concatset(a,b));
       const ref D = aux.domain;
 
@@ -88,7 +88,7 @@ module ArraySetops
     }
 
     // returns the set difference of 2 arrays
-    proc setdiff1d(a: [] int, b: [] int, assume_unique: bool) {
+    proc setdiff1d(a: [] int, b: [] int, assume_unique: bool) throws {
       //if not unique, unique sort arrays then perform operation
       if (!assume_unique) {
         var a1  = uniqueSort(a, false);
@@ -104,7 +104,7 @@ module ArraySetops
     // as a boolean array and inverts these
     // values and returns the array indexed
     // with this inverted array
-    proc setdiff1dHelper(a: [] ?t, b: [] t) {
+    proc setdiff1dHelper(a: [] ?t, b: [] t) throws {
         var truth = makeDistArray(a.size, bool);
 
         // based on size of array, determine which method to use 
@@ -123,7 +123,7 @@ module ArraySetops
     // first concatenates the 2 arrays, then
     // sorts resulting array and ensures that
     // values are unique
-    proc union1d(a: [] int, b: [] int) {
+    proc union1d(a: [] int, b: [] int) throws {
       var aux;
       // Artificial scope to clean up temporary arrays
       {

--- a/src/CastMsg.chpl
+++ b/src/CastMsg.chpl
@@ -168,6 +168,8 @@ module CastMsg {
       }
     }
     const byteLengths = [s in strings] s.numBytes + 1;
+    // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+    overMemLimit(numBytes(uint(8)) * byteLengths.size);
     segments.a = (+ scan byteLengths) - byteLengths;
     const totBytes = + reduce byteLengths;
     const vname = st.nextName();

--- a/src/ConcatenateMsg.chpl
+++ b/src/ConcatenateMsg.chpl
@@ -142,7 +142,12 @@ module ConcatenateMsg
         var blockstarts: [PrivateSpace] int;
         var blockValStarts: [PrivateSpace] int;
         if mode == "interleave" {
+          // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+          overMemLimit(numBytes(int) * blocksizes.size);
           blockstarts = (+ scan blocksizes) - blocksizes;
+
+          // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+          overMemLimit(numBytes(int) * blockValSizes.size);
           blockValStarts = (+ scan blockValSizes) - blockValSizes;
         }
 

--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -64,12 +64,14 @@ module EfuncMsg
                         a.a = Math.exp(e.a);
                     }
                     when "cumsum" {
-                        var a = st.addEntry(rname, e.size, int);
-                        a.a = + scan e.a;
+                        // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+                        overMemLimit(numBytes(int) * e.size);
+                        st.addEntry(rname, new shared SymEntry(+ scan e.a));
                     }
                     when "cumprod" {
-                        var a= st.addEntry(rname, e.size, int);
-                        a.a = * scan e.a;
+                        // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+                        overMemLimit(numBytes(int) * e.size);
+                        st.addEntry(rname, new shared SymEntry(* scan e.a));
                     }
                     when "sin" {
                         var a = st.addEntry(rname, e.size, real);
@@ -103,12 +105,14 @@ module EfuncMsg
                         a.a = Math.exp(e.a);
                     }
                     when "cumsum" {
-                        var a = st.addEntry(rname, e.size, real);
-                        a.a = + scan e.a;
+                        // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+                        overMemLimit(numBytes(real) * e.size);
+                        st.addEntry(rname, new shared SymEntry(+ scan e.a));
                     }
                     when "cumprod" {
-                        var a = st.addEntry(rname, e.size, real);
-                        a.a = * scan e.a;
+                        // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+                        overMemLimit(numBytes(real) * e.size);
+                        st.addEntry(rname, new shared SymEntry(* scan e.a));
                     }
                     when "sin" {
                         var a = st.addEntry(rname, e.size, real);
@@ -135,13 +139,15 @@ module EfuncMsg
                 {
                     when "cumsum" {
                         var ia: [e.aD] int = (e.a:int); // make a copy of bools as ints blah!
-                        var a = st.addEntry(rname, e.size, int);
-                        a.a = + scan ia;
+                        // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+                        overMemLimit(numBytes(int) * ia.size);
+                        st.addEntry(rname, new shared SymEntry(+ scan ia));
                     }
                     when "cumprod" {
                         var ia: [e.aD] int = (e.a:int); // make a copy of bools as ints blah!
-                        var a = st.addEntry(rname, e.size, int);
-                        a.a = * scan ia;
+                        // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+                        overMemLimit(numBytes(int) * ia.size);
+                        st.addEntry(rname, new shared SymEntry(* scan ia));
                     }
                     otherwise {
                         var errorMsg = notImplementedError(pn,efunc,gEnt.dtype);

--- a/src/FindSegmentsMsg.chpl
+++ b/src/FindSegmentsMsg.chpl
@@ -164,6 +164,8 @@ module FindSegmentsMsg
       } // select objtype
         }
     // All keys have been processed, all steps have been found
+        // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+        overMemLimit(numBytes(int) * ukeylocs.size);
         // +scan to compute segment position... 1-based because of inclusive-scan
         var iv: [ukeylocs.domain] int = (+ scan ukeylocs);
         // compute how many segments

--- a/src/Flatten.chpl
+++ b/src/Flatten.chpl
@@ -1,4 +1,6 @@
 module Flatten {
+  use ServerConfig;
+
   use SegmentedArray;
   use ServerErrors;
   use SymArrayDmap;
@@ -40,6 +42,8 @@ module Flatten {
     forall o in this.offsets.a with (var agg = newDstAggregator(bool)) {
       agg.copy(offTruth[o], true);
     }
+    // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+    overMemLimit(numBytes(int) * offTruth.size);
     // Running segment number
     var scanOff = (+ scan offTruth) - offTruth;
     // Copy over the offsets; later we will shrink them if delim is > 1 byte
@@ -87,6 +91,8 @@ module Flatten {
       const boundaryDeriv = (followsDelim:int * (delim.numBytes - 1)) + 1;
       // Next step requires offsets to be translated to new domain, i.e. with
       // delims removed.
+      // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+      overMemLimit(numBytes(int) * followsDelim.size);
       // Number of delims preceding current string
       const delimsBefore = + scan followsDelim;
       // Each delim gets replaced by null byte (length 1)
@@ -97,6 +103,8 @@ module Flatten {
       }
       // Force first derivative to match start of src domain
       srcIdx[valDom.low] = this.values.aD.low;
+      // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+      overMemLimit(numBytes(int) * srcIdx.size);
       // Perform integration to compute gather indices
       srcIdx = (+ scan srcIdx);
       // Now we have dest-local copy of src indices, so gather with a src aggregator

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -766,7 +766,7 @@ module GenSymIO {
         return reply;
     }
 
-    proc fixupSegBoundaries(a: [?D] int, segSubdoms: [?fD] domain(1), valSubdoms: [fD] domain(1)) {
+    proc fixupSegBoundaries(a: [?D] int, segSubdoms: [?fD] domain(1), valSubdoms: [fD] domain(1)) throws {
         var boundaries: [fD] int; // First index of each region that needs to be raised
         var diffs: [fD] int;// Amount each region must be raised over previous region
         forall (i, sd, vd, b) in zip(fD, segSubdoms, valSubdoms, boundaries) {
@@ -781,6 +781,8 @@ module GenSymIO {
         forall (b, d) in zip(boundaries, diffs) with (var agg = newDstAggregator(int)) {
             agg.copy(sparseDiffs[b], d);
         }
+        // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+        overMemLimit(numBytes(int) * sparseDiffs.size);
         // Make plateaus from peaks
         var corrections = + scan sparseDiffs;
         // Raise the segment offsets by the plateaus

--- a/src/In1d.chpl
+++ b/src/In1d.chpl
@@ -132,7 +132,7 @@ module In1d
        :returns truth: the distributed boolean array containing the result of ar1 being broadcast over ar2
        :type truth: [] bool
      */
-    proc in1dSort(ar1: [?aD1] int, ar2: [?aD2] int) {
+    proc in1dSort(ar1: [?aD1] int, ar2: [?aD2] int) throws  {
         /* General strategy: unique both arrays, find the intersecting values, 
            then map back to the original domain of ar1.
          */

--- a/src/Indexing.chpl
+++ b/src/Indexing.chpl
@@ -36,7 +36,9 @@ module Indexing {
     }
 
     // return an array of all values from array a whose index corresponds to a true value in array truth
-    proc boolIndexer(a: [?aD] ?t, truth: [aD] bool) {
+    proc boolIndexer(a: [?aD] ?t, truth: [aD] bool) throws {
+        // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+        overMemLimit(numBytes(int) * truth.size);
         var iv: [truth.domain] int = (+ scan truth);
         var pop = iv[iv.size-1];
         var ret = makeDistArray(pop, int);

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -180,6 +180,8 @@ module IndexingMsg
                 imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg); 
                 return new MsgTuple(repMsg, MsgType.NORMAL);
             }
+            // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+            overMemLimit(numBytes(int) * truth.size);
             var iv: [truth.aD] int = (+ scan truth.a);
             var pop = iv[iv.size-1];
             imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
@@ -480,6 +482,8 @@ module IndexingMsg
             }
             var e = toSymEntry(gX,t);
             var truth = toSymEntry(gIV,bool);
+            // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+            overMemLimit(numBytes(int) * truth.size);
             var iv: [truth.aD] int = (+ scan truth.a);
             var pop = iv[iv.size-1];
             imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 

--- a/src/JoinEqWithDTMsg.chpl
+++ b/src/JoinEqWithDTMsg.chpl
@@ -90,7 +90,7 @@ module JoinEqWithDTMsg
     proc joinEqWithDT(a1: [?a1D] int,
                       seg: [?segD] int,  ukeys: [segD] int, perm: [?a2D] int,
                       t1: [a1D] int, t2: [a2D] int, dt: int, pred: int,
-                      resLimitPerLocale: int) {
+                      resLimitPerLocale: int) throws {
 
         try! jeLogger.info(getModuleName(),getRoutineName(),getLineNumber(),
                                             "resLimitPerLocale = %t".format(resLimitPerLocale));
@@ -179,6 +179,8 @@ module JoinEqWithDTMsg
 
         // +scan for all the local result ends
         // last value should be total results
+        // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+        overMemLimit(numBytes(int) * locNumResults.size);
         var resEnds: [PrivateSpace] int = + scan locNumResults;
         var numResults: int = resEnds[resEnds.domain.high];
 

--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -139,7 +139,7 @@ module RadixSortLSD
     /* Radix Sort Least Significant Digit
        radix sort a block distributed array
        returning a permutation vector as a block distributed array */
-    proc radixSortLSD_ranks(a:[?aD] ?t, checkSorted: bool = true): [aD] int {
+    proc radixSortLSD_ranks(a:[?aD] ?t, checkSorted: bool = true): [aD] int throws {
 
         // check to see if array is already sorted
         if (checkSorted) {
@@ -199,6 +199,8 @@ module RadixSortLSD
             }//coforall loc
             
             // scan globalCounts to get bucket ends on each locale/task
+            // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+            overMemLimit(numBytes(int) * globalCounts.size);
             globalStarts = + scan globalCounts;
             globalStarts = globalStarts - globalCounts;
             
@@ -258,7 +260,7 @@ module RadixSortLSD
     /* Radix Sort Least Significant Digit
        radix sort a block distributed array
        returning sorted keys as a block distributed array */
-    proc radixSortLSD_keys(a: [?aD] ?t, checkSorted: bool = true): [aD] t {
+    proc radixSortLSD_keys(a: [?aD] ?t, checkSorted: bool = true): [aD] t throws {
 
         // check to see if array is already sorted
         if (checkSorted) {
@@ -318,6 +320,8 @@ module RadixSortLSD
             }//coforall loc
             
             // scan globalCounts to get bucket ends on each locale/task
+            // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+            overMemLimit(numBytes(int) * globalCounts.size);
             globalStarts = + scan globalCounts;
             globalStarts = globalStarts - globalCounts;
             

--- a/src/RandArray.chpl
+++ b/src/RandArray.chpl
@@ -128,6 +128,8 @@ module RandArray {
     var lengths = makeDistArray(n, int);
     fillInt(lengths, minLen+1, maxLen+1, seedStr=seedStr);
     const nBytes = + reduce lengths;
+    // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+    overMemLimit(numBytes(int) * lengths.size);
     var segs = (+ scan lengths) - lengths;
     var vals = makeDistArray(nBytes, uint(8));
     var (lb, ub) = charBounds[characters];
@@ -152,6 +154,8 @@ module RandArray {
     ltemp = exp(logMean + logStd*ltemp);
     var lengths:[ltemp.domain] int = [l in ltemp] ceil(l):int;
     const nBytes = + reduce lengths;
+    // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+    overMemLimit(numBytes(int) * lengths.size);
     var segs = (+ scan lengths) - lengths;
     var vals = makeDistArray(nBytes, uint(8));
     var (lb, ub) = charBounds[characters];

--- a/src/SortMsg.chpl
+++ b/src/SortMsg.chpl
@@ -20,7 +20,7 @@ module SortMsg
 
     /* Sort the given pdarray using Radix Sort and
        return sorted keys as a block distributed array */
-    proc sort(a: [?aD] ?t): [aD] t {
+    proc sort(a: [?aD] ?t): [aD] t throws {
       var sorted: [aD] t = radixSortLSD_keys(a);
       return sorted;
     }


### PR DESCRIPTION
Closes #855 Add mem checks for scans:
- Adds `overMemLimit` check before `scan` operations
- Adds `throws` to the function signature of methods with newly added `overMemLimit` checks and to function signatures of any methods which call them
- Rearranges `cumsum` and `cumprod` to avoid unnecessary copies