### PR TITLE
Closes #822 : Adds save to hdf5 functionality for Categorical

### DIFF
--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 from typing import cast, List, Optional, Sequence, Union, Dict
-import numpy as np # type: ignore
+import numpy as np  # type: ignore
 import itertools
 from typeguard import typechecked
+from arkouda.client import generic_msg
 from arkouda.strings import Strings
 from arkouda.pdarrayclass import pdarray, RegistrationError, unregister_pdarray_by_name
 from arkouda.groupbyclass import GroupBy, broadcast
 from arkouda.pdarraysetops import in1d, unique, concatenate
-from arkouda.pdarraycreation import zeros, zeros_like, arange
+from arkouda.pdarraycreation import zeros_like, arange
 from arkouda.dtypes import resolve_scalar_dtype, str_scalars, int_scalars
 from arkouda.dtypes import int64 as akint64
 from arkouda.sorting import argsort
@@ -15,6 +16,7 @@ from arkouda.logger import getArkoudaLogger
 from arkouda.infoclass import information, list_registry
 
 __all__ = ['Categorical']
+
 
 class Categorical:
     """
@@ -186,7 +188,7 @@ class Categorical:
             encapsulating the results of the requested binop      
 
         Raises
-    -   -----
+        -----
         ValueError
             Raised if (1) the op is not in the self.BinOps set, or (2) if the
             sizes of this and the other instance don't match
@@ -558,6 +560,63 @@ class Categorical:
                                   ordered=ordered)
             newvals = wherediditgo[oldvals]
             return Categorical.from_codes(newvals, newidx)
+
+    @typechecked
+    def save(self, prefix_path: str, dataset: str = 'categorical_array', mode: str = 'truncate') -> str:
+        """
+        Save the Categorical object to HDF5. The result is a collection of HDF5 files,
+        one file per locale of the arkouda server, where each filename starts
+        with prefix_path and dataset. Each locale saves its chunk of the Strings array to its
+        corresponding file.
+
+        Parameters
+        ----------
+        prefix_path : str
+            Directory and filename prefix that all output files share
+        dataset : str
+            Name of the dataset to create in HDF5 files (must not already exist)
+        mode : str {'truncate' | 'append'}
+            By default, truncate (overwrite) output files, if they exist.
+            If 'append', create a new Categorical dataset within existing files.
+
+        Returns
+        -------
+        String message indicating result of save operation
+
+        Raises
+        ------
+        ValueError
+            Raised if the lengths of columns and values differ, or the mode is
+            neither 'truncate' nor 'append'
+        TypeError
+            Raised if prefix_path, dataset, or mode is not a str
+
+        See Also
+        --------
+        pdarrayIO.save
+
+        Notes
+        -----
+        Important implementation notes: (1) Strings state is saved as two datasets
+        within an hdf5 group: one for the string characters and one for the
+        segments corresponding to the start of each string, (2) the hdf5 group is named
+        via the dataset parameter.
+        """
+        if mode.lower() not in ["append", "truncate"]:
+            raise ValueError("Allowed modes are 'truncate' and 'append'")
+
+        result = []
+        comp_dict = {k: v for k, v in self._get_components_dict().items() if v is not None}
+
+        if self.RequiredPieces.issubset(comp_dict.keys()):
+            # Honor the first mode but switch to append for all others since each following comp may wipe out the file
+            first = True
+            for k, v in comp_dict.items():
+                result.append(v.save(prefix_path + "/" + dataset, dataset=k, mode=(mode if first else "append")))
+                first = False
+        else:
+            raise Exception("The required pieces of `categories` and `codes` were not populated on this Categorical")
+        return ";".join(result)
 
     @typechecked()
     def register(self, user_defined_name: str) -> Categorical:

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -809,7 +809,7 @@ class Strings:
 
         Returns
         -------
-        None
+        String message indicating result of save operation
 
         Raises
         ------
@@ -841,9 +841,9 @@ class Strings:
             json_array = json.dumps([prefix_path])
         except Exception as e:
             raise ValueError(e)
-        
+
         return cast(str, generic_msg(cmd="tohdf", args="{} {} {} {} {} {}".\
-                           format(self.bytes.name, dataset, m, json_array, 
+                           format(self.bytes.name, dataset, m, json_array,
                                   self.dtype, self.offsets.name)))
         
 

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -1173,7 +1173,7 @@ module GenSymIO {
         return {low..high by stride};
     }
 
-    proc tohdfMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {               
+    proc tohdfMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
         var (arrayName, dsetName, modeStr, jsonfile, 
                                       dataType, segsName) = payload.splitMsgToTuple(6);
 
@@ -1186,7 +1186,7 @@ module GenSymIO {
         } catch {
             var errorMsg = "Could not decode json filenames via tempfile " +
                                                     "(%i files: %s)".format(1, jsonfile);
-            gsLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);            
+            gsLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
             return new MsgTuple(errorMsg, MsgType.ERROR);
         }
 
@@ -1212,12 +1212,12 @@ module GenSymIO {
                      * uint8 arrays such as Strings out to external systems.
                      */
                     var e = toSymEntry(entry, uint(8));
-                    var segsEntry = st.lookup(segsName);                   
+                    var segsEntry = st.lookup(segsName);
                     var s_e = toSymEntry(segsEntry, int);
                     warnFlag = write1DDistStrings(filename, mode, dsetName, e.a, DType.UInt8,s_e.a);
                 } otherwise {
                     var errorMsg = unrecognizedTypeError("tohdf", dtype2str(entry.dtype));
-                    gsLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);            
+                    gsLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
                     return new MsgTuple(errorMsg, MsgType.ERROR);
                 }
             }


### PR DESCRIPTION
Closes #822 Support writing `ak.Categorical` to HDF5

This PR implements a `save` function for `Categorical` in the same vein as `pdarray` and `Strings` save implementations.
The saved HDF5 file(s) can be read back in using the standard `ak.read_all` call and passing to either `Categorical` constructor (`init` or `from_codes`) using the python dictionary unpacking operator/idiom (`**foo_dict`)

i.e.
```python
cat.save("/path/to/dir", dataset="my_categorical")
parts = ak.read_all(filenames="/path/to/dir/my_categorical_LOCALE0000")

# Option 1
cat_from_init = ak.Categorical(None, **parts)

# Option 2
cat _from_codes = ak.Categorical.from_codes(**parts)
```

Note: The standard `save` (`tohdfMsg`) impl adds the `LOCAL####` part to the files.  This follows the Strings implementation.