### PR TITLE
Closes #900 : bugfix on groupby with zero length array.

### DIFF
--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -340,6 +340,14 @@ class GroupByTest(ArkoudaTest):
         g = ak.GroupBy(keys)
         g.min(ak.randint(0, 10, 100))
 
+    def test_zero_length_groupby(self):
+        """
+        This tests groupby boundary condition on a zero length pdarray, see Issue #900 for details
+        """
+        g = ak.GroupBy(ak.zeros(0, dtype=ak.int64))
+        str(g.segments)  # passing condition, if this was deleted it will cause the test to fail
+
+
 def to_tuple_dict(labels, values):
     # transforms labels from list of arrays into a list of tuples by index and builds a dictionary
     # labels: [array(['b', 'a', 'c']), array(['b', 'a', 'c'])] -> [('b', 'b'), ('a', 'a'), ('c', 'c')]


### PR DESCRIPTION
Closes #900 : bugfix on groupby with zero length array.
Also fixes indentation issues in findSegmentsMsg.

Note: The actual fix is a single character change on line 107 of FindSegmentsMsg
```
repMsg = "created " + st.attrib(n1) + " +created " + st.attrib(n2);
```

The rest of the changes are purely white-space to fix bad indentation in the proc.