### PR TITLE
 Closes #909 Add regex support to `Strings` search methods and `peel`:

### DIFF
--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -12,6 +12,7 @@ from arkouda.dtypes import npstr, int_scalars, str_scalars
 from arkouda.dtypes import NUMBER_FORMAT_STRINGS, resolve_scalar_dtype, \
      translate_np_dtype
 import json
+import re
 from arkouda.infoclass import information
 
 __all__ = ['Strings']
@@ -142,7 +143,7 @@ class Strings:
             encapsulating the results of the requested binop      
 
         Raises
-    -   -----
+        -----
         ValueError
             Raised if (1) the op is not in the self.BinOps set, or (2) if the
             sizes of this and the other instance don't match, or (3) the other
@@ -255,14 +256,17 @@ class Strings:
         return create_pdarray(generic_msg(cmd=cmd,args=args))
 
     @typechecked
-    def contains(self, substr : Union[bytes,str_scalars]) -> pdarray:
+    def contains(self, substr: Union[bytes, str_scalars], regex: bool = False) -> pdarray:
         """
         Check whether each element contains the given substring.
 
         Parameters
         ----------
-        substr : str_scalars
+        substr: str_scalars
             The substring in the form of string or byte array to search for
+        regex: bool
+            Indicates whether substr is a regular expression
+            Note: only handles regular expressions supported by re2 (does not support lookaheads/lookbehinds)
 
         Returns
         -------
@@ -273,6 +277,8 @@ class Strings:
         ------
         TypeError
             Raised if the substr parameter is not bytes or str_scalars
+        ValueError
+            Rasied if substr is not a valid regex
         RuntimeError
             Raised if there is a server-side error thrown
 
@@ -282,32 +288,43 @@ class Strings:
         
         Examples
         --------
-        >>> strings = ak.array(['string {}'.format(i) for i in range(1,6)])
+        >>> strings = ak.array(['{} string {}'.format(i, i) for i in range(1, 6)])
         >>> strings
-        array(['string 1', 'string 2', 'string 3', 'string 4', 'string 5'])
+        array(['1 string 1', '2 string 2', '3 string 3', '4 string 4', '5 string 5'])
         >>> strings.contains('string')
+        array([True, True, True, True, True])
+        >>> strings.contains('string \\d', regex=True)
         array([True, True, True, True, True])
         """
         if isinstance(substr, bytes):
             substr = substr.decode()
+        if regex:
+            try:
+                re.compile(substr)
+            except Exception as e:
+                raise ValueError(e)
         cmd = "segmentedEfunc"
-        args = "{} {} {} {} {} {}".format("contains",
-                                                        self.objtype,
-                                                        self.offsets.name,
-                                                        self.bytes.name,
-                                                        "str",
-                                                        json.dumps([substr]))
-        return create_pdarray(generic_msg(cmd=cmd,args=args))
+        args = "{} {} {} {} {} {} {}".format("contains",
+                                             self.objtype,
+                                             self.offsets.name,
+                                             self.bytes.name,
+                                             "str",
+                                             regex,
+                                             json.dumps([substr]))
+        return create_pdarray(generic_msg(cmd=cmd, args=args))
 
     @typechecked
-    def startswith(self, substr : Union[bytes,str_scalars]) -> pdarray:
+    def startswith(self, substr: Union[bytes, str_scalars], regex: bool = False) -> pdarray:
         """
         Check whether each element starts with the given substring.
 
         Parameters
         ----------
-        substr : Union[bytes,str_scalars]
+        substr: Union[bytes, str_scalars]
             The prefix to search for
+        regex: bool
+            Indicates whether substr is a regular expression
+            Note: only handles regular expressions supported by re2 (does not support lookaheads/lookbehinds)
 
         Returns
         -------
@@ -318,6 +335,8 @@ class Strings:
         ------
         TypeError
             Raised if the substr parameter is not a bytes ior str_scalars
+        ValueError
+            Rasied if substr is not a valid regex
         RuntimeError
             Raised if there is a server-side error thrown
 
@@ -327,32 +346,46 @@ class Strings:
         
         Examples
         --------
-        >>> strings = ak.array(['string {}'.format(i) for i in range(1,6)])
-        >>> strings
+        >>> strings_end = ak.array(['string {}'.format(i) for i in range(1, 6)])
+        >>> strings_end
         array(['string 1', 'string 2', 'string 3', 'string 4', 'string 5'])
-        >>> strings.startswith('string')
+        >>> strings_end.startswith('string')
+        array([True, True, True, True, True])
+        >>> strings_start = ak.array(['{} string'.format(i) for i in range(1,6)])
+        >>> strings_start
+        array(['1 string', '2 string', '3 string', '4 string', '5 string'])
+        >>> strings_start.startswith('\\d str', regex = True)
         array([True, True, True, True, True])
         """
         if isinstance(substr, bytes):
             substr = substr.decode()
+        if regex:
+            try:
+                re.compile(substr)
+            except Exception as e:
+                raise ValueError(e)
         cmd = "segmentedEfunc"
-        args = "{} {} {} {} {} {}".format("startswith",
-                                                        self.objtype,
-                                                        self.offsets.name,
-                                                        self.bytes.name,
-                                                        "str",
-                                                        json.dumps([substr]))
-        return create_pdarray(generic_msg(cmd=cmd,args=args))
+        args = "{} {} {} {} {} {} {}".format("startswith",
+                                             self.objtype,
+                                             self.offsets.name,
+                                             self.bytes.name,
+                                             "str",
+                                             regex,
+                                             json.dumps([substr]))
+        return create_pdarray(generic_msg(cmd=cmd, args=args))
 
     @typechecked
-    def endswith(self, substr : Union[bytes,str_scalars]) -> pdarray:
+    def endswith(self, substr: Union[bytes, str_scalars], regex: bool = False) -> pdarray:
         """
         Check whether each element ends with the given substring.
 
         Parameters
         ----------
-        substr : Union[bytes,str_scalars]
+        substr: Union[bytes, str_scalars]
             The suffix to search for
+        regex: bool
+            Indicates whether substr is a regular expression
+            Note: only handles regular expressions supported by re2 (does not support lookaheads/lookbehinds)
 
         Returns
         -------
@@ -363,6 +396,8 @@ class Strings:
         ------
         TypeError
             Raised if the substr parameter is not bytes or str_scalars
+        ValueError
+            Rasied if substr is not a valid regex
         RuntimeError
             Raised if there is a server-side error thrown
 
@@ -372,22 +407,89 @@ class Strings:
         
         Examples
         --------
-        >>> strings = ak.array(['{} string'.format(i) for i in range(1,6)])
-        >>> strings
+        >>> strings_start = ak.array(['{} string'.format(i) for i in range(1,6)])
+        >>> strings_start
         array(['1 string', '2 string', '3 string', '4 string', '5 string'])
-        >>> strings.endswith('ing')
+        >>> strings_start.endswith('ing')
+        array([True, True, True, True, True])
+        >>> strings_end = ak.array(['string {}'.format(i) for i in range(1, 6)])
+        >>> strings_end
+        array(['string 1', 'string 2', 'string 3', 'string 4', 'string 5'])
+        >>> strings_end.endswith('ing \\d', regex = True)
         array([True, True, True, True, True])
         """
         if isinstance(substr, bytes):
             substr = substr.decode()
+        if regex:
+            try:
+                re.compile(substr)
+            except Exception as e:
+                raise ValueError(e)
         cmd = "segmentedEfunc"
-        args = "{} {} {} {} {} {}".format("endswith",
-                                          self.objtype,
-                                          self.offsets.name,
-                                          self.bytes.name,
-                                          "str",
-                                          json.dumps([substr]))
-        return create_pdarray(generic_msg(cmd=cmd,args=args))
+        args = "{} {} {} {} {} {} {}".format("endswith",
+                                             self.objtype,
+                                             self.offsets.name,
+                                             self.bytes.name,
+                                             "str",
+                                             regex,
+                                             json.dumps([substr]))
+        return create_pdarray(generic_msg(cmd=cmd, args=args))
+
+    @typechecked
+    def match(self, pattern: Union[bytes, str_scalars]) -> pdarray:
+        """
+        For each element check whether the entire element matches the given regex, pattern.
+
+        Note: only handles regular expressions supported by re2 (does not support lookaheads/lookbehinds)
+
+        Parameters
+        ----------
+        pattern: str_scalars
+            The regex in the form of string or byte array to search for
+
+        Returns
+        -------
+        pdarray, bool
+            True for elements that match pattern, False otherwise
+
+        Raises
+        ------
+        TypeError
+            Raised if the pattern parameter is not bytes or str_scalars
+        ValueError
+            Rasied if pattern is not a valid regex
+        RuntimeError
+            Raised if there is a server-side error thrown
+
+        See Also
+        --------
+        Strings.contains, Strings.startswith, Strings.endswith
+
+        Examples
+        --------
+        >>> strings = ak.array(['{} string {}'.format(i, i) for i in range(1, 6)])
+        >>> strings
+        array(['1 string 1', '2 string 2', '3 string 3', '4 string 4', '5 string 5'])
+        >>> strings.match('\\d string \\d')
+        array([True, True, True, True, True])
+        >>> strings.match('ing \\d')
+        array([False, False, False, False, False])
+        """
+        if isinstance(pattern, bytes):
+            pattern = pattern.decode()
+        try:
+            re.compile(pattern)
+        except Exception as e:
+            raise ValueError(e)
+        cmd = "segmentedEfunc"
+        args = "{} {} {} {} {} {} {}".format("match",
+                                             self.objtype,
+                                             self.offsets.name,
+                                             self.bytes.name,
+                                             "str",
+                                             True,  # regex flag is always True for match
+                                             json.dumps([pattern]))
+        return create_pdarray(generic_msg(cmd=cmd, args=args))
 
     def flatten(self, delimiter : str, return_segments : bool=False) -> Union[Strings,Tuple]:
         """Unpack delimiter-joined substrings into a flat array.

--- a/benchmarks/graph_infra/arkouda.graph
+++ b/benchmarks/graph_infra/arkouda.graph
@@ -88,6 +88,12 @@ files: IO.dat, IO.dat
 graphtitle: IO Performance
 ylabel: Performance (GiB/s)
 
+perfkeys: non-regex with literal substring Average rate =, regex with literal substring Average rate =, regex with pattern Average rate =
+graphkeys: non-regex with literal substring GiB/s, regex with literal substring GiB/s, regex with pattern GiB/s
+files: substring_search.dat, substring_search.dat, substring_search.dat
+graphtitle: Substring Search Performance
+ylabel: Performance (GiB/s)
+
 perfkeys: Average rate =
 graphkeys: Noop ops/s
 files: noop.dat

--- a/benchmarks/graph_infra/substring_search.perfkeys
+++ b/benchmarks/graph_infra/substring_search.perfkeys
@@ -1,0 +1,6 @@
+non-regex with literal substring Average time =
+non-regex with literal substring Average rate =
+regex with literal substring Average time =
+regex with literal substring Average rate =
+regex with pattern Average time =
+regex with pattern Average rate =

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -22,7 +22,7 @@ logging.basicConfig(level=logging.INFO)
 BENCHMARKS = ['stream', 'argsort', 'coargsort', 'groupby', 'aggregate', 'gather', 'scatter',
               'reduce', 'scan', 'noop', 'setops', 'array_create',
               'array_transfer', 'IO', 'str-argsort', 'str-coargsort',
-              'str-groupby', 'str-gather']
+              'str-groupby', 'str-gather', 'substring_search']
 
 def get_chpl_util_dir():
     """ Get the Chapel directory that contains graph generation utilities. """

--- a/benchmarks/substring_search.py
+++ b/benchmarks/substring_search.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+import time
+import argparse
+import arkouda as ak
+
+
+def time_substring_search(N, trials, seed):
+    print(">>> arkouda substring search")
+    cfg = ak.get_config()
+    print("numLocales = {}, N = {:,}".format(cfg["numLocales"], N))
+
+    start = ak.random_strings_uniform(minlen=1, maxlen=8, size=N, seed=seed)
+    end = ak.random_strings_uniform(minlen=1, maxlen=8, size=N, seed=seed)
+    digit_substr = ['{} string {}'.format(i % 10, i % 10) for i in range(0, N)]
+
+    # each string in test_substring contains digit_substr with random strings before and after
+    test_substring = ak.array([s + d + e for s, d, e in zip(start.to_ndarray(), digit_substr, end.to_ndarray())])
+    nbytes = test_substring.bytes.size * test_substring.bytes.itemsize
+
+    non_regex_times = []
+    regex_literal_times = []
+    regex_pattern_times = []
+    for i in range(trials):
+        start = time.time()
+        non_regex = test_substring.contains('string')
+        end = time.time()
+        non_regex_times.append(end - start)
+
+        start = time.time()
+        regex_literal = test_substring.contains('string', regex=True)
+        end = time.time()
+        regex_literal_times.append(end - start)
+
+        start = time.time()
+        regex_pattern = test_substring.contains('\\d string \\d', regex=True)
+        end = time.time()
+        regex_pattern_times.append(end - start)
+
+    avg_non_regex = sum(non_regex_times) / trials
+    avg_regex_literal = sum(regex_literal_times) / trials
+    avg_regex_pattern = sum(regex_pattern_times) / trials
+
+    assert non_regex.all()
+    assert regex_literal.all()
+    assert regex_pattern.all()
+
+    print("non-regex with literal substring Average time = {:.4f} sec".format(avg_non_regex))
+    print("regex with literal substring Average time = {:.4f} sec".format(avg_regex_literal))
+    print("regex with pattern Average time = {:.4f} sec".format(avg_regex_pattern))
+
+    print("non-regex with literal substring Average rate = {:.4f} GiB/sec".format(nbytes/2**30/avg_non_regex))
+    print("regex with literal substring Average rate = {:.4f} GiB/sec".format(nbytes/2**30/avg_regex_literal))
+    print("regex with pattern Average rate = {:.4f} GiB/sec".format(nbytes/2**30/avg_regex_pattern))
+
+
+def check_correctness(seed):
+    N = 10**4
+
+    start = ak.random_strings_uniform(minlen=1, maxlen=8, size=N, seed=seed)
+    end = ak.random_strings_uniform(minlen=1, maxlen=8, size=N, seed=seed)
+    digit_substr = ['{} string {}'.format(i % 10, i % 10) for i in range(0, N)]
+
+    # each string in test_substring contains digit_substr with random strings before and after
+    test_substring = ak.array([s + d + e for s, d, e in zip(start.to_ndarray(), digit_substr, end.to_ndarray())])
+
+    assert test_substring.contains('string').all()
+    assert test_substring.contains('string', regex=True).all()
+    assert test_substring.contains('\\d string \\d', regex=True).all()
+
+
+def create_parser():
+    parser = argparse.ArgumentParser(description="Measure the performance of regex and non-regex substring searches.")
+    parser.add_argument('hostname', help='Hostname of arkouda server')
+    parser.add_argument('port', type=int, help='Port of arkouda server')
+    parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: Number of Strings to search')
+    parser.add_argument('-t', '--trials', type=int, default=1, help='Number of times to run the benchmark')
+    parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
+    parser.add_argument('-s', '--seed', default=None, type=int, help='Value to initialize random number generator')
+    return parser
+
+
+if __name__ == "__main__":
+    import sys
+    parser = create_parser()
+    args = parser.parse_args()
+    ak.verbose = False
+    ak.connect(args.hostname, args.port)
+
+    if args.correctness_only:
+        check_correctness(args.seed)
+        sys.exit(0)
+
+    print("array size = {:,}".format(args.size))
+    print("number of trials = ", args.trials)
+    time_substring_search(args.size, args.trials, args.seed)
+    sys.exit(0)

--- a/pytest.ini
+++ b/pytest.ini
@@ -19,6 +19,7 @@ testpaths =
     tests/numeric_test.py
     tests/operator_tests.py
     tests/pdarray_creation_test.py
+    tests/regex_test.py
     tests/registration_test.py
     tests/security_test.py
     tests/setops_test.py

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -484,17 +484,17 @@ module SegmentedArray {
     }
 
     /*
-    Returns list of bools where index i indicates whether the regular expression, pattern, matched string i of the SegString
+      Returns list of bools where index i indicates whether the regular expression, pattern, matched string i of the SegString
 
-    Note: the regular expression engine used, re2, does not support lookahead/lookbehind
+      Note: the regular expression engine used, re2, does not support lookahead/lookbehind
 
-    :arg pattern: regex pattern to be applied to strings in SegString
-    :type pattern: string
+      :arg pattern: regex pattern to be applied to strings in SegString
+      :type pattern: string
 
-    :arg mode: mode of search being performed (contains, startsWith, endsWith, match)
-    :type mode: SearchMode enum
+      :arg mode: mode of search being performed (contains, startsWith, endsWith, match)
+      :type mode: SearchMode enum
 
-    :returns: [domain] bool where index i indicates whether the regular expression, pattern, matched string i of the SegString
+      :returns: [domain] bool where index i indicates whether the regular expression, pattern, matched string i of the SegString
     */
     proc substringSearchRegex(const pattern: string, mode: SearchMode) throws {
       var hits: [offsets.aD] bool = false;  // the answer
@@ -602,31 +602,31 @@ module SegmentedArray {
     }
 
     /*
-    Peel off one or more fields matching the regular expression, delimiter, from each string (similar
-    to string.partition), returning two new arrays of strings.
-    *Warning*: This function is experimental and not guaranteed to work.
+      Peel off one or more fields matching the regular expression, delimiter, from each string (similar
+      to string.partition), returning two new arrays of strings.
+      *Warning*: This function is experimental and not guaranteed to work.
 
-    Note: the regular expression engine used, re2, does not support lookahead/lookbehind
+      Note: the regular expression engine used, re2, does not support lookahead/lookbehind
 
-    :arg delimter: regex delimter where the split in SegString will occur
-    :type delimter: string
+      :arg delimter: regex delimter where the split in SegString will occur
+      :type delimter: string
 
-    :arg times: The number of times the delimiter is sought, i.e. skip over the first (times-1) delimiters
-    :type times: int
+      :arg times: The number of times the delimiter is sought, i.e. skip over the first (times-1) delimiters
+      :type times: int
 
-    :arg includeDelimiter: If true, append the delimiter to the end of the first return array
-                            By default, it is prepended to the beginning of the second return array.
-    :type includeDelimiter: bool
+      :arg includeDelimiter: If true, append the delimiter to the end of the first return array
+                              By default, it is prepended to the beginning of the second return array.
+      :type includeDelimiter: bool
 
-    :arg keepPartial: If true, a string that does not contain <times> instances of
-                      the delimiter will be returned in the first array. By default,
-                      such strings are returned in the second array.
-    :type keepPartial: bool
+      :arg keepPartial: If true, a string that does not contain <times> instances of
+                        the delimiter will be returned in the first array. By default,
+                        such strings are returned in the second array.
+      :type keepPartial: bool
 
-    :arg left: If true, peel from the left
-    :type left: bool
+      :arg left: If true, peel from the left
+      :type left: bool
 
-    :returns: Components to build 2 SegStrings (leftOffsets, leftVals, rightOffsets, rightVals)
+      :returns: Components to build 2 SegStrings (leftOffsets, leftVals, rightOffsets, rightVals)
     */
     proc peelRegex(const delimiter: string, const times: int, const includeDelimiter: bool, const keepPartial: bool, const left: bool) throws {
       checkCompile(delimiter);
@@ -638,7 +638,7 @@ module SegmentedArray {
       var rightStart: [offsets.aD] int;
 
       forall (o, len, i) in zip(oa, lengths, offsets.aD) with (var myRegex = _unsafeCompileRegex(delimiter)) {
-        var matches = myRegex.matches(interpretAsString(va[o..#(len+1)]));
+        var matches = myRegex.matches(interpretAsString(va[o..#len]));
         if matches.size < times {
           // not enough occurances of delim, the entire string stays together, and the param args
           // determine whether it ends up on the left or right

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -232,12 +232,6 @@ module SegmentedMsg {
                 var (lo, lv, ro, rv) = strings.peel(val, times, true, true, true);
                 createPeelSymEntries(loname, lo, lvname, lv, roname, ro, rvname, rv, st);
               }
-              otherwise {
-                var errorMsg = notImplementedError(pn,
-                                "subcmd: %s, (%s, %s)".format(subcmd, objtype, valtype));
-                smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg, MsgType.ERROR);
-              }
             }
           }
           repMsg = "created %s+created %s+created %s+created %s".format(st.attrib(loname),

--- a/test/UnitTestPeelStick.chpl
+++ b/test/UnitTestPeelStick.chpl
@@ -150,7 +150,8 @@ proc testMessageLayer(substr, n, minLen, maxLen) throws {
   d.start();
   var (answer, strings) = make_strings(substr, n, minLen, maxLen, charSet.Uppercase, st);
   d.stop("make_strings");
-  var reqMsg = "peel str %s %s str 1 True True True %jt".format(strings.offsetName, strings.valueName, [substr]);
+  // The message layer for peel has changed during Issue#894 to include regex bool
+  var reqMsg = "peel str %s %s str 1 True True True False %jt".format(strings.offsetName, strings.valueName, [substr]);
   writeReq(reqMsg);
   var repMsg = segmentedPeelMsg(cmd="segmentedPeel", payload=reqMsg, st).msg;
   writeRep(repMsg);

--- a/tests/regex_test.py
+++ b/tests/regex_test.py
@@ -1,0 +1,91 @@
+from context import arkouda as ak
+from base_test import ArkoudaTest
+
+
+class RegexTest(ArkoudaTest):
+
+    def test_regex_contains(self):
+        digit_strings = ak.array(['{} string {}'.format(i, i) for i in range(1, 6)])
+        self.assertTrue(digit_strings.contains('\\d str', regex=True).all())
+        self.assertTrue(digit_strings.contains('ing \\d', regex=True).all())
+
+        aaa_strings = ak.array(['{} string {}'.format('a'*i, 'a'*i) for i in range(1, 6)])
+        self.assertTrue(aaa_strings.contains('a+ str', regex=True).all())
+        self.assertTrue(aaa_strings.contains('ing a+', regex=True).all())
+
+    def test_regex_startswith(self):
+        digit_strings = ak.array(['{} string {}'.format(i, i) for i in range(1, 6)])
+        self.assertTrue(digit_strings.startswith('\\d str', regex=True).all())
+        self.assertFalse(digit_strings.startswith('ing \\d', regex=True).any())
+
+        aaa_strings = ak.array(['{} string {}'.format('a'*i, 'a'*i) for i in range(1, 6)])
+        self.assertTrue(aaa_strings.startswith('a+ str', regex=True).all())
+        self.assertFalse(aaa_strings.startswith('ing a+', regex=True).any())
+
+    def test_regex_endswith(self):
+        digit_strings = ak.array(['{} string {}'.format(i, i) for i in range(1, 6)])
+        self.assertTrue(digit_strings.endswith('ing \\d', regex=True).all())
+        self.assertFalse(digit_strings.endswith('\\d str', regex=True).any())
+
+        aaa_strings = ak.array(['{} string {}'.format('a'*i, 'a'*i) for i in range(1, 6)])
+        self.assertTrue(aaa_strings.endswith('ing a+', regex=True).all())
+        self.assertFalse(aaa_strings.endswith('a+ str', regex=True).any())
+
+    def test_regex_match(self):
+        digit_strings = ak.array(['{} string {}'.format(i, i) for i in range(1, 6)])
+        self.assertTrue(digit_strings.match('\\d string \\d').all())
+        # the following are false because the regex is not an exact match of any digit_strings
+        self.assertFalse(digit_strings.match('ing \\d').any())
+        self.assertFalse(digit_strings.match('\\d str').any())
+
+        aaa_strings = ak.array(['{} string {}'.format('a'*i, 'a'*i) for i in range(1, 6)])
+        self.assertTrue(aaa_strings.match('a+ string a+').all())
+        # the following are false because the regex is not an exact match of any aaa_strings
+        self.assertFalse(aaa_strings.match('ing a+').any())
+        self.assertFalse(aaa_strings.match('a+ str').any())
+
+    def test_regex_peel(self):
+        orig = ak.array(['a.b', 'c.d', 'e.f.g'])
+        digit = ak.array(['a1b', 'c1d', 'e1f2g'])
+        under = ak.array(['a_b', 'c___d', 'e__f____g'])
+
+        o_left, o_right = orig.peel('.')
+        d_left, d_right = digit.peel('\\d', regex=True)
+        u_left, u_right = under.peel('_+', regex=True)
+        self.assertListEqual(['a', 'c', 'e'], o_left.to_ndarray().tolist())
+        self.assertListEqual(['a', 'c', 'e'], d_left.to_ndarray().tolist())
+        self.assertListEqual(['a', 'c', 'e'], u_left.to_ndarray().tolist())
+        self.assertListEqual(['b', 'd', 'f.g'], o_right.to_ndarray().tolist())
+        self.assertListEqual(['b', 'd', 'f2g'], d_right.to_ndarray().tolist())
+        self.assertListEqual(['b', 'd', 'f____g'], u_right.to_ndarray().tolist())
+
+        o_left, o_right = orig.peel('.', includeDelimiter=True)
+        d_left, d_right = digit.peel('\\d', includeDelimiter=True, regex=True)
+        u_left, u_right = under.peel('_+', includeDelimiter=True, regex=True)
+        self.assertListEqual(['a.', 'c.', 'e.'], o_left.to_ndarray().tolist())
+        self.assertListEqual(['a1', 'c1', 'e1'], d_left.to_ndarray().tolist())
+        self.assertListEqual(['a_', 'c___', 'e__'], u_left.to_ndarray().tolist())
+        self.assertListEqual(['b', 'd', 'f.g'], o_right.to_ndarray().tolist())
+        self.assertListEqual(['b', 'd', 'f2g'], d_right.to_ndarray().tolist())
+        self.assertListEqual(['b', 'd', 'f____g'], u_right.to_ndarray().tolist())
+
+        o_left, o_right = orig.peel('.', times=2, keepPartial=True)
+        d_left, d_right = digit.peel('\\d', times=2, keepPartial=True, regex=True)
+        u_left, u_right = under.peel('_+', times=2, keepPartial=True, regex=True)
+        self.assertListEqual(['a.b', 'c.d', 'e.f'], o_left.to_ndarray().tolist())
+        self.assertListEqual(['a1b', 'c1d', 'e1f'], d_left.to_ndarray().tolist())
+        self.assertListEqual(['a_b', 'c___d', 'e__f'], u_left.to_ndarray().tolist())
+        self.assertListEqual(['', '', 'g'], o_right.to_ndarray().tolist())
+        self.assertListEqual(['', '', 'g'], d_right.to_ndarray().tolist())
+        self.assertListEqual(['', '', 'g'], u_right.to_ndarray().tolist())
+
+        # rpeel / fromRight: digit is testing fromRight and under is testing rpeel
+        o_left, o_right = orig.peel('.', times=2, includeDelimiter=True, fromRight=True)
+        d_left, d_right = digit.peel('\\d', times=2, includeDelimiter=True, fromRight=True, regex=True)
+        u_left, u_right = under.rpeel('_+', times=2, includeDelimiter=True, regex=True)
+        self.assertListEqual(['a.b', 'c.d', 'e'], o_left.to_ndarray().tolist())
+        self.assertListEqual(['a1b', 'c1d', 'e'], d_left.to_ndarray().tolist())
+        self.assertListEqual(['a_b', 'c___d', 'e'], u_left.to_ndarray().tolist())
+        self.assertListEqual(['', '', '.f.g'], o_right.to_ndarray().tolist())
+        self.assertListEqual(['', '', '1f2g'], d_right.to_ndarray().tolist())
+        self.assertListEqual(['', '', '__f____g'], u_right.to_ndarray().tolist())


### PR DESCRIPTION
  Closes #909:
- Adds regex support for `contains`, `startswith`, and `endswith` String search functions
- Implements new `Strings.match(pattern)` function
  - Returns a list of booleans where index `i` is True iff the entire `i`th string matches `pattern`
- Adds regex support for `Strings.peel` function
- Adds tests of regex functionality for `contains`, `startswith`, `endswith`, `match`, and `peel`
- Adds `substring_search.py` benchmark in response to PR feedback

Note:
The regex functionality uses Chapels `regexp` module which is built on google's `re2`. re2 sacrifices some features like lookahead/lookbehind in exchange for ["guarantees that searches complete in linear time with respect to the size of the input and in a fixed amount of stack space"](https://opensource.googleblog.com/2010/03/re2-principled-approach-to-regular.html)

Examples:
Strings search functions and `match`-
```python
>>> strings = ak.array(['{} string {}'.format(i, i) for i in range(1, 6)])
>>> strings
array(['1 string 1', '2 string 2', '3 string 3', '4 string 4', '5 string 5'])

>>> strings.contains('string \\d', regex=True)
array([True, True, True, True, True])

>>> strings.startswith('\\d str', regex = True)
array([True, True, True, True, True])

>>> strings.endswith('ing \\d', regex = True)
array([True, True, True, True, True])

>>> strings.match('\\d string \\d')
array([True, True, True, True, True])
>>> strings.match('ing \\d')
array([False, False, False, False, False])
```
`peel` with regex delimiter-
```python
>>> under = ak.array(['a_b', 'c___d', 'e__f____g'])
>>> u_left, u_right = under.peel('_+', includeDelimiter=True, regex=True)
>>> u_left
array(['a_', 'c___', 'e__'])
>>> u_right 
array(['b', 'd', 'f____g'])
```