### PR TITLE
Use --interleave-memory if it's available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,14 @@ ifdef ARKOUDA_HDF5_PATH
 $(eval $(call add-path,$(ARKOUDA_HDF5_PATH)))
 endif
 
+# For configs that use a fixed heap, but still have first-touch semantics
+# (gasnet-ibv-large) interleave large allocations to reduce the performance hit
+# from getting progressively worse NUMA affinity due to memory reuse.
+CHPL_HELP := $(shell $(CHPL) --devel --help)
+ifneq (,$(findstring interleave-memory,$(CHPL_HELP)))
+CHPL_FLAGS += --interleave-memory
+endif
+
 .PHONY: install-deps
 install-deps: install-zmq install-hdf5
 


### PR DESCRIPTION
chapel-lang/chapel#18350 added an `--interleave-memory` feature to
reduce the performance hit incurred by a commit that reduced memory
fragmentation under configurations like gasnet-ibv. If the chapel
compiler/build supports the option, automatically use it for the Arkouda
build. This improves performance for gasnet-ibv segment large (the
default) by interleaving memory allocations to avoid getting
progressively worse NUMA affinity the longer the arkouda server has been
running.

See chapel-lang/chapel#18286 for more details