### PR TITLE
Update GenSymIO.chpl to use new spelling of `subprocess.exitCode`.

### DIFF
--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -259,8 +259,14 @@ module GenSymIO {
 
             sub.wait();
 
-            exitCode = sub.exit_status;
-            
+            // Use new-style exitCode if available --
+            // https://github.com/chapel-lang/chapel/pull/18352
+            if hasField(sub.type, "exitCode") {
+                exitCode = sub.exitCode;
+            } else {
+                exitCode = sub.exit_status;
+            }
+
             var f = open(tmpfile, iomode.r);
             defer {  // This will ensure we try to close f when we exit the proc scope.
                 ensureClose(f);


### PR DESCRIPTION
`subprocess.exit_status` is being deprecated in 1.25 in favor of `exitCode`.

Check for the existence of the `subprocess.exitCode` field, and use it if it
is available. If not, continue using `subprocess.exit_status`. This way it
will work in 1.24 and in 1.25 forward.