### PR TITLE
Issue #917: Change `substring_search` benchmark problem size to `10**6`

### DIFF
--- a/benchmarks/substring_search.py
+++ b/benchmarks/substring_search.py
@@ -73,7 +73,7 @@ def create_parser():
     parser = argparse.ArgumentParser(description="Measure the performance of regex and non-regex substring searches.")
     parser.add_argument('hostname', help='Hostname of arkouda server')
     parser.add_argument('port', type=int, help='Port of arkouda server')
-    parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: Number of Strings to search')
+    parser.add_argument('-n', '--size', type=int, default=10**6, help='Problem size: Number of Strings to search')
     parser.add_argument('-t', '--trials', type=int, default=1, help='Number of times to run the benchmark')
     parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
     parser.add_argument('-s', '--seed', default=None, type=int, help='Value to initialize random number generator')


### PR DESCRIPTION
Intermediate step for Issue #917:
- Changes default problem size for `substring_search` benchmark from `10**8` to `10**6` to prevent time out in nightly performance runs while we investigate the performance bottleneck