### PR TITLE
Closes #910: Add regex support to `Strings.flatten`:

### DIFF
--- a/benchmarks/flatten.py
+++ b/benchmarks/flatten.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+import time
+import argparse
+import arkouda as ak
+
+
+def time_flatten(N, trials):
+    print(">>> arkouda flatten")
+    cfg = ak.get_config()
+    print("numLocales = {}, N = {:,}".format(cfg["numLocales"], N))
+
+    thirds = [ak.cast(ak.arange(i, N*3, 3), 'str') for i in range(3)]
+    thickrange = thirds[0].stick(thirds[1], delimiter='_').stick(thirds[2], delimiter='_')
+    nbytes = thickrange.bytes.size * thickrange.bytes.itemsize
+
+    non_regex_times = []
+    regex_literal_times = []
+    regex_pattern_times = []
+    for i in range(trials):
+        start = time.time()
+        non_regex = thickrange.flatten('_')
+        end = time.time()
+        non_regex_times.append(end - start)
+
+        start = time.time()
+        regex_literal = thickrange.flatten('_', regex=True)
+        end = time.time()
+        regex_literal_times.append(end - start)
+
+        start = time.time()
+        regex_pattern = thickrange.flatten('_+', regex=True)
+        end = time.time()
+        regex_pattern_times.append(end - start)
+
+    avg_non_regex = sum(non_regex_times) / trials
+    avg_regex_literal = sum(regex_literal_times) / trials
+    avg_regex_pattern = sum(regex_pattern_times) / trials
+
+    answer = ak.array(['{}'.format(i) for i in range(N*3)])
+    assert (non_regex == answer).all()
+    assert (regex_literal == answer).all()
+    assert (regex_pattern == answer).all()
+
+    print("non-regex flatten with literal delimiter Average time = {:.4f} sec".format(avg_non_regex))
+    print("regex flatten with literal delimiter Average time = {:.4f} sec".format(avg_regex_literal))
+    print("regex flatten with pattern delimiter Average time = {:.4f} sec".format(avg_regex_pattern))
+
+    print("non-regex flatten with literal delimiter Average rate = {:.4f} GiB/sec".format(nbytes/2**30/avg_non_regex))
+    print("regex flatten with literal delimiter Average rate = {:.4f} GiB/sec".format(nbytes/2**30/avg_regex_literal))
+    print("regex flatten with pattern delimiter Average rate = {:.4f} GiB/sec".format(nbytes/2**30/avg_regex_pattern))
+
+
+def check_correctness():
+    N = 10**4
+
+    thirds = [ak.cast(ak.arange(i, N*3, 3), 'str') for i in range(3)]
+    thickrange = thirds[0].stick(thirds[1], delimiter='_').stick(thirds[2], delimiter='_')
+
+    answer = ak.array(['{}'.format(i) for i in range(N*3)])
+    assert (thickrange.flatten('_') == answer).all()
+    assert (thickrange.flatten('_', regex=True) == answer).all()
+    assert (thickrange.flatten('_+', regex=True) == answer).all()
+
+
+def create_parser():
+    parser = argparse.ArgumentParser(description="Measure the performance of regex and non-regex flatten on Strings.")
+    parser.add_argument('hostname', help='Hostname of arkouda server')
+    parser.add_argument('port', type=int, help='Port of arkouda server')
+    parser.add_argument('-n', '--size', type=int, default=10**6, help='Problem size: Number of Strings to flatten')
+    parser.add_argument('-t', '--trials', type=int, default=1, help='Number of times to run the benchmark')
+    parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
+    return parser
+
+
+if __name__ == "__main__":
+    import sys
+    parser = create_parser()
+    args = parser.parse_args()
+    ak.verbose = False
+    ak.connect(args.hostname, args.port)
+
+    if args.correctness_only:
+        check_correctness()
+        sys.exit(0)
+
+    print("array size = {:,}".format(args.size))
+    print("number of trials = ", args.trials)
+    time_flatten(args.size, args.trials)
+    sys.exit(0)

--- a/benchmarks/graph_infra/arkouda.graph
+++ b/benchmarks/graph_infra/arkouda.graph
@@ -94,6 +94,12 @@ files: substring_search.dat, substring_search.dat, substring_search.dat
 graphtitle: Substring Search Performance
 ylabel: Performance (GiB/s)
 
+perfkeys: non-regex flatten with literal delimiter Average rate =, regex flatten with literal delimiter Average rate =, regex flatten with pattern delimiter Average rate =
+graphkeys: non-regex flatten with literal delimiter GiB/s, regex flatten with literal delimiter GiB/s, regex flatten with pattern delimiter GiB/s
+files: flatten.dat, flatten.dat, flatten.dat
+graphtitle: Flatten Performance
+ylabel: Performance (GiB/s)
+
 perfkeys: Average rate =
 graphkeys: Noop ops/s
 files: noop.dat

--- a/benchmarks/graph_infra/flatten.perfkeys
+++ b/benchmarks/graph_infra/flatten.perfkeys
@@ -1,0 +1,6 @@
+non-regex flatten with literal delimiter Average time =
+non-regex flatten with literal delimiter Average rate =
+regex flatten with literal delimiter Average time =
+regex flatten with literal delimiter Average rate =
+regex flatten with pattern delimiter Average time =
+regex flatten with pattern delimiter Average rate =

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -22,7 +22,7 @@ logging.basicConfig(level=logging.INFO)
 BENCHMARKS = ['stream', 'argsort', 'coargsort', 'groupby', 'aggregate', 'gather', 'scatter',
               'reduce', 'scan', 'noop', 'setops', 'array_create',
               'array_transfer', 'IO', 'str-argsort', 'str-coargsort',
-              'str-groupby', 'str-gather', 'substring_search']
+              'str-groupby', 'str-gather', 'substring_search', 'flatten']
 
 def get_chpl_util_dir():
     """ Get the Chapel directory that contains graph generation utilities. """

--- a/src/Flatten.chpl
+++ b/src/Flatten.chpl
@@ -104,8 +104,10 @@ module Flatten {
         if nullByteLocations[origInd] {
           // nullbyte location, copy nullbyte into flattenedVals
           valAgg.copy(flattenedVals[flatValInd], NULL_STRINGS_VALUE);
-          // offset points to position after null byte
-          offAgg.copy(flattenedOffsets[offInd], flatValInd + 1);
+          if origInd != this.values.aD.high {
+            // offset points to position after null byte
+            offAgg.copy(flattenedOffsets[offInd], flatValInd + 1);
+          }
         }
         else {
           // non-match location, copy origVal into flattenedVals

--- a/src/Flatten.chpl
+++ b/src/Flatten.chpl
@@ -6,8 +6,128 @@ module Flatten {
   use SymArrayDmap;
   use CommAggregation;
   use Reflection;
-  
-  proc SegString.flatten(delim: string, returnSegs: bool) throws {
+  use Regexp;
+  use CPtr;
+  use SegmentedArray only checkCompile, _unsafeCompileRegex;
+
+  config const NULL_STRINGS_VALUE = 0:uint(8);
+
+  /*
+    Convert a uint(8) array into bytes. Modeled after SegString.interpretAsString
+  */
+  inline proc interpretAsBytes(bytearray: [?D] uint(8)): bytes {
+    // Byte buffer must be local in order to make a C pointer
+    var localBytes: [{0..#D.size}] uint(8) = bytearray;
+    var cBytes = c_ptrTo(localBytes);
+    // Byte buffer is null-terminated, so length is buffer.size - 1
+    // The contents of the buffer should be copied out because cBytes will go out of scope
+    var b: bytes;
+    try {
+      b = createBytesWithNewBuffer(cBytes, D.size-1, D.size);
+    } catch {
+      b = b"<error interpreting uint(8) as bytes>";
+    }
+    return b;
+  }
+
+  /*
+    Given a SegString where each string encodes a variable-length sequence delimited by a regex,
+    flattenRegex unpacks the sequences into a flat array of individual elements.
+    If returnSegs is set to True, a mapping between the original strings and new array elements will be returned
+
+    Note: the regular expression engine used, re2, does not support lookahead/lookbehind
+
+    :arg delim: regex delimter used to split strings into substrings
+    :type delim: string
+
+    :arg returnSegs: If True, also return mapping of original strings to first substring in return array
+    :type returnSegs: bool
+
+    :returns: Strings – Flattened substrings with delimiters removed and (optional) int64 pdarray – For each original string, the index of first corresponding substring in the return array
+  */
+  proc SegString.flattenRegex(delim: string, returnSegs: bool) throws {
+    checkCompile(delim);
+    ref origOffsets = this.offsets.a;
+    ref origVals = this.values.a;
+    const lengths = this.getLengths();
+
+    overMemLimit((this.offsets.size * numBytes(int)) + (2 * this.values.size * numBytes(int)));
+    var numMatches: [this.offsets.aD] int;
+    var writeToVal: [this.values.aD] bool = true;
+    var nullByteLocations: [this.values.aD] bool = false;
+
+    // since the delim matches are variable length, we don't know what the size of flattenedVals should be until we've found the matches
+    forall (i, off, len) in zip(this.offsets.aD, origOffsets, lengths) with (var myRegex = _unsafeCompileRegex(delim.encode()),
+                                                                             var writeAgg = newDstAggregator(bool),
+                                                                             var nbAgg = newDstAggregator(bool),
+                                                                             var matchAgg = newDstAggregator(int)) {
+      // for each string, find delim matches and set the positions of matches in writeToVal to false (non-matches will be copied to flattenedVals)
+      // mark the locations of null bytes (the positions before original offsets and the last character of matches)
+      var matches = myRegex.matches(interpretAsBytes(origVals[off..#len]));
+      for m in matches {
+        var match: reMatch = m[0];
+        // set writeToVal to false for matches (except the last character of the match because we will write a null byte)
+        for k in (off + match.offset:int)..#(match.size - 1) {
+          writeAgg.copy(writeToVal[k], false);
+        }
+        // is writeToVal[(off + match.offset:int)..#(match.size - 1)] = false more efficient or for loop with aggregator?
+        nbAgg.copy(nullByteLocations[off + match.offset:int + (match.size - 1)], true);
+      }
+      if off != 0 {
+        // the position before an offset is a null byte (except for off == 0)
+        nbAgg.copy(nullByteLocations[off - 1], true);
+      }
+      matchAgg.copy(numMatches[i], matches.size);
+    }
+
+    // writeToVal is true for positions to copy origVals (non-matches) and positions to write a null byte
+    var flattenedVals: [makeDistDom(+ reduce writeToVal)] uint(8);
+    // Each match is replaced with a null byte, so new offsets.size = totalNumMatches + old offsets.size
+    var flattenedOffsets: [makeDistDom((+ reduce numMatches) + this.offsets.size)] int;
+
+    // check there's enough room to create copies for the IndexTransform scans and throw if creating a copy would go over memory limit
+    overMemLimit(2 * numBytes(int) * writeToVal.size);
+    // the IndexTransforms start at 0 and increment after hitting a writeToVal/nullByteLocation condition
+    // we do this because the indexing set for origVals is different from flattenedVals/Offsets (they are different lengths)
+    // when looping over the origVals domain, the IndexTransforms act as a function: origVals.domain -> flattenedVals/Offsets.domain
+    var valsIndexTransform = (+ scan writeToVal) - writeToVal;
+    var offsIndexTransform = (+ scan nullByteLocations) - nullByteLocations + 1;  // the plus one is to leave space for the offset 0 edge case
+
+    forall (origInd, flatValInd, offInd) in zip(this.values.aD, valsIndexTransform, offsIndexTransform) with (var valAgg = newDstAggregator(uint(8)),
+                                                                                                              var offAgg = newDstAggregator(int)) {
+      // writeToVal is true for positions to copy origVals (non-matches) and positions to write a null byte
+      if writeToVal[origInd] {
+        if origInd == 0 {
+          // offset 0 edge case
+          offAgg.copy(flattenedOffsets[0], 0);
+        }
+        if nullByteLocations[origInd] {
+          // nullbyte location, copy nullbyte into flattenedVals
+          valAgg.copy(flattenedVals[flatValInd], NULL_STRINGS_VALUE);
+          // offset points to position after null byte
+          offAgg.copy(flattenedOffsets[offInd], flatValInd + 1);
+        }
+        else {
+          // non-match location, copy origVal into flattenedVals
+          valAgg.copy(flattenedVals[flatValInd], origVals[origInd]);
+        }
+      }
+    }
+
+    // build segments mapping from original Strings to flattenedStrings
+    const segmentsDom = if returnSegs then this.offsets.aD else makeDistDom(0);
+    var segments: [segmentsDom] int;
+    if returnSegs {
+      // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+      overMemLimit(numBytes(int) * numMatches.size);
+      // each match results in a new element (it is replaced with a null byte)
+      // so the mapping is a running sum of all previous replacements plus the curent index
+      segments = (+ scan numMatches) - numMatches + segmentsDom;
+    }
+    return (flattenedOffsets, flattenedVals, segments);
+  }
+
+  proc SegString.flatten(delim: string, returnSegs: bool, regex: bool = false) throws {
     if delim.numBytes == 0 {
       throw new owned ErrorWithContext("Cannot flatten with empty delimiter",
                                        getLineNumber(),
@@ -17,6 +137,10 @@ module Flatten {
     }
     if this.size == 0 {
       return (this.offsets.a, this.values.a, this.offsets.a);
+    }
+    if regex {
+      // we still perform the empty delimeter check above
+      return flattenRegex(delim, returnSegs);
     }
     // delimHits is true immediately following instances of delim, i.e.
     // at the starts of newly created segments

--- a/src/FlattenMsg.chpl
+++ b/src/FlattenMsg.chpl
@@ -14,8 +14,9 @@ module FlattenMsg {
   const fmLogger = new Logger(logLevel);
 
   proc segFlattenMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
-    var (name, objtype, returnSegsStr, delimJson) = payload.splitMsgToTuple(4);
+    var (name, objtype, returnSegsStr, regexStr, delimJson) = payload.splitMsgToTuple(5);
     const returnSegs: bool = returnSegsStr.toLower() == "true";
+    const regex: bool = regexStr.toLower() == "true";
     const arr = jsonToPdArray(delimJson, 1);
     const delim: string = arr[arr.domain.low];
     var repMsg: string;
@@ -26,7 +27,7 @@ module FlattenMsg {
         const optName: string = if returnSegs then st.nextName() else "";
         var (segName, valName) = name.splitMsgToTuple('+', 2);
         const strings = getSegString(segName, valName, st);
-        var (off, val, segs) = strings.flatten(delim, returnSegs);
+        var (off, val, segs) = strings.flatten(delim, returnSegs, regex);
         st.addEntry(rSegName, new shared SymEntry(off));
         st.addEntry(rValName, new shared SymEntry(val));
         repMsg = "created %s+created %s".format(st.attrib(rSegName), st.attrib(rValName));

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -463,7 +463,7 @@ module SegmentedArray {
     /*
     Returns Regexp.compile if pattern can be compiled without an error
     */
-    proc checkCompile(const pattern: string) throws {
+    proc checkCompile(const pattern: ?t) throws where t == bytes || t == string {
       try {
         return compile(pattern);
       }
@@ -474,7 +474,7 @@ module SegmentedArray {
       }
     }
 
-    proc _unsafeCompileRegex(const pattern: string) {
+    proc _unsafeCompileRegex(const pattern: ?t) where t == bytes || t == string {
       // This is a private function and should not be called to compile pattern. Use checkCompile instead
 
       // This proc is a workaound to allow declaring regexps using a with clause in forall loops

--- a/tests/regex_test.py
+++ b/tests/regex_test.py
@@ -89,3 +89,39 @@ class RegexTest(ArkoudaTest):
         self.assertListEqual(['', '', '.f.g'], o_right.to_ndarray().tolist())
         self.assertListEqual(['', '', '1f2g'], d_right.to_ndarray().tolist())
         self.assertListEqual(['', '', '__f____g'], u_right.to_ndarray().tolist())
+
+    def test_regex_flatten(self):
+        orig = ak.array(['one|two', 'three|four|five', 'six', 'seven|eight|nine|ten|', 'eleven'])
+        digit = ak.array(['one1two', 'three2four3five', 'six', 'seven4eight5nine6ten7', 'eleven'])
+        under = ak.array(['one_two', 'three_four__five', 'six', 'seven_____eight__nine____ten_', 'eleven'])
+
+        answer_flat = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten', '', 'eleven']
+        answer_map = [0, 2, 5, 6, 11]
+
+        orig_flat, orig_map = orig.flatten('|', return_segments=True)
+        digit_flat, digit_map = digit.flatten('\\d', return_segments=True, regex=True)
+        under_flat, under_map = under.flatten('_+', return_segments=True, regex=True)
+
+        self.assertListEqual(answer_flat, orig_flat.to_ndarray().tolist())
+        self.assertListEqual(answer_flat, digit_flat.to_ndarray().tolist())
+        self.assertListEqual(answer_flat, under_flat.to_ndarray().tolist())
+
+        self.assertListEqual(answer_map, orig_map.to_ndarray().tolist())
+        self.assertListEqual(answer_map, digit_map.to_ndarray().tolist())
+        self.assertListEqual(answer_map, under_map.to_ndarray().tolist())
+
+        # empty string, start with delim, end with delim, and only delim cases
+        orig = ak.array(['', '|', '|1|2', '3|4|', '5'])
+        regex = ak.array(['', '____', '_1_2', '3___4___', '5'])
+
+        answer_flat = ['', '', '', '', '1', '2', '3', '4', '', '5']
+        answer_map = [0, 1, 3, 6, 9]
+
+        orig_flat, orig_map = orig.flatten('|', return_segments=True)
+        regex_flat, regex_map = regex.flatten('_+', return_segments=True, regex=True)
+
+        self.assertListEqual(answer_flat, orig_flat.to_ndarray().tolist())
+        self.assertListEqual(answer_flat, regex_flat.to_ndarray().tolist())
+
+        self.assertListEqual(answer_map, orig_map.to_ndarray().tolist())
+        self.assertListEqual(answer_map, regex_map.to_ndarray().tolist())


### PR DESCRIPTION
Closes #910:
- Adds regex support for `Strings.flatten` and a test for the regex functionality

Example:
```python
# regex flatten functionality
>>> under = ak.array(['one_two', 'three_____four____five', 'six'])
>>> under_flat, under_map = under.flatten('_+', return_segments=True, regex=True)
>>> under_flat
array(['one', 'two', 'three', 'four', 'five', 'six'])
>>> under_map
array([0, 2, 5])

# compared to existing flatten
>>> orig = ak.array(['one|two', 'three|four|five', 'six'])
>>> flat, map = orig.flatten('|', return_segments=True)
>>> flat
array(['one', 'two', 'three', 'four', 'five', 'six'])
>>> map
array([0, 2, 5])
```