### PR TITLE
Hash arrays #919

### DIFF
--- a/src/SipHash.chpl
+++ b/src/SipHash.chpl
@@ -2,6 +2,7 @@ module SipHash {
   private use CommPrimitives;
   private use AryUtil;
   private use CPtr;
+  private use SysCTypes;
   use ServerConfig;
   use ServerErrors;
   use Reflection;
@@ -55,6 +56,17 @@ module SipHash {
             (p[7]: uint(64) << 56));
   }
 
+  private inline proc XTO64_LE(in x: ?t) {
+    var y: uint(64);
+    if isSubtype(t, c_ptr) {
+      c_memcpy(c_ptrTo(y), x, 8);
+    } else if numBytes(t) == 8 {
+      c_memcpy(c_ptrTo(y), c_ptrTo(x), numBytes(t));
+    } else {
+      compilerError("input must have 64 bit values");
+    }
+    return y;
+  }
 
   private inline proc byte_reverse(b: uint(64)): uint(64) {
     var c: uint(64);
@@ -69,20 +81,32 @@ module SipHash {
     return c;
   }
   
-  proc sipHash64(msg: [] uint(8), D): uint(64) {
+  proc sipHash64(msg: [] ?t, D): uint(64) {
     var (res,_) = computeSipHashLocalized(msg, D, 8);
     return res;
   }
 
-  proc sipHash128(msg: [] uint(8), D): 2*uint(64) {
+  proc sipHash128(msg: [] ?t, D): 2*uint(64) {
     return computeSipHashLocalized(msg, D, 16);
   }
 
-  private proc computeSipHashLocalized(msg: [] uint(8), D, param outlen: int) {
+  /*
+   * Compute hash of a single value
+   */
+  proc sipHash64(in val): uint(64) {
+    var (res,_) = computeSipHash(c_ptrTo(val), 0..#1, 8, 8);
+    return res;
+  }
+  
+  proc sipHash128(in val): 2*uint(64) {
+    return computeSipHash(c_ptrTo(val), 0..#1, 16, 8);
+  }
+  
+  private proc computeSipHashLocalized(msg: [] ?t, D, param outlen: int) {
     if contiguousIndices(msg) {
       ref start = msg[D.low];
       if D.high < D.low {
-        return computeSipHash(c_ptrTo(start), 0..#0, outlen);
+        return computeSipHash(c_ptrTo(start), 0..#0, outlen, numBytes(t));
       }
       ref end = msg[D.high];
       const startLocale = start.locale.id;
@@ -91,22 +115,26 @@ module SipHash {
       const l = D.size;
       if startLocale == endLocale {
         if startLocale == hereLocale {
-          return computeSipHash(c_ptrTo(start), 0..#l, outlen);
+          return computeSipHash(c_ptrTo(start), 0..#l, outlen, numBytes(t));
         } else {
           var a = c_malloc(msg.eltType, l);
-          GET(a, startLocale, getAddr(start), l);
-          var h = computeSipHash(a, 0..#l, outlen);
+          const byteSize = l:size_t * c_sizeof(t);
+          GET(a, startLocale, getAddr(start), byteSize);
+          var h = computeSipHash(a, 0..#l, outlen, numBytes(t));
           c_free(a);
           return h;
         }
       }
     }
-    return computeSipHash(msg, D, outlen);
+    return computeSipHash(msg, D, outlen, numBytes(t));
   }
   
-  private proc computeSipHash(msg, D, param outlen: int) {
+  private proc computeSipHash(msg, D, param outlen: int, param eltBytes: int) {
     if !((outlen == 8) || (outlen == 16)) {
       compilerError("outlen must be 8 or 16");
+    }
+    if !((eltBytes == 1) || (eltBytes == 8)) {
+      compilerError("can only hash (arrays of) 8-bit or 64-bit values");
     }
     var v0 = 0x736f6d6570736575: uint(64);
     var v1 = 0x646f72616e646f6d: uint(64);
@@ -116,11 +144,13 @@ module SipHash {
     const k1 = 0x0f0e0d0c0b0a0908: uint(64);
     var m: uint(64);
     var i: int;
-    const lastPos = D.low + D.size - (D.size % 8);
+    param stride: int = if (eltBytes == 1) then 8 else 1;
+    const lastPos = D.low + D.size - (D.size % stride);
     // const uint8_t *end = in + inlen - (inlen % sizeof(uint64_t));
-    const left: int = D.size & 7;
+    const left: int = D.size & (stride - 1);
     // const int left = inlen & 7;
-    var b: uint(64) = (D.size: uint(64)) << 56;
+    const numBytes = D.size * eltBytes;
+    var b: uint(64) = (numBytes: uint(64)) << 56;
     v3 ^= k1;
     v2 ^= k0;
     v1 ^= k1;
@@ -151,23 +181,41 @@ module SipHash {
         if DEBUG {
             try! {
               shLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                                   "%i v0 %016xu".format(D.size, v0));
+                                                   "%i v0 %016xu".format(numBytes, v0));
               shLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                                   "%i v1 %016xu".format(D.size, v1));
+                                                   "%i v1 %016xu".format(numBytes, v1));
               shLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                                   "%i v2 %016xu".format(D.size, v2));
+                                                   "%i v2 %016xu".format(numBytes, v2));
               shLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                                   "%i v3 %016xu".format(D.size, v3));
+                                                   "%i v3 %016xu".format(numBytes, v3));
             }
         }
     }
 
-    for pos in D.low..lastPos-1 by 8 {
-        if isSubtype(msg.type, c_ptr) {
-          m = U8TO64_LE(msg + pos);
+    for pos in D.low..lastPos-1 by stride {
+      // select (stride, isSubtype(msg.type, c_ptr))
+        if (stride == 8) {
+          if isSubtype(msg.type, c_ptr) {
+            m = U8TO64_LE(msg + pos);
+          } else {
+            m = U8TO64_LE(msg, pos..#stride);
+          }
+        } else if (stride == 1) {
+          if isSubtype(msg.type, c_ptr) {
+            m = XTO64_LE(msg + pos);
+          } else {
+            m = XTO64_LE(msg[pos]);
+          }
         } else {
-          m = U8TO64_LE(msg, pos..#8);
+          // Should never reach here
+          compilerError("can only hash (arrays of) 8-bit or 64-bit values");
         }
+
+        if DEBUG {
+          try! shLogger.debug(getModuleName(), getRoutineName(), getLineNumber(),
+                         "m = %016xu".format(m));
+        }
+
         v3 ^= m;
         TRACE();
         for i in 0..#cROUNDS {
@@ -179,25 +227,25 @@ module SipHash {
 
     if (left == 7) {
         b |= (msg[lastPos+6]: uint(64)) << 48;
-}
+    }
     if (left >= 6) {
         b |= (msg[lastPos+5]: uint(64)) << 40;
     }
     if (left >= 5) {
         b |= (msg[lastPos+4]: uint(64)) << 32;
-}
+    }
     if (left >= 4) {
         b |= (msg[lastPos+3]: uint(64)) << 24;
-}
+    }
     if (left >= 3) {
         b |= (msg[lastPos+2]: uint(64)) << 16;
-}
+    }
     if (left >= 2) {
         b |= (msg[lastPos+1]: uint(64)) << 8;
-}
+    }
     if (left >= 1) {
         b |= (msg[lastPos]: uint(64));
-        }
+    }
 
     v3 ^= b;
 
@@ -221,7 +269,11 @@ module SipHash {
 
     b = v0 ^ v1 ^ v2 ^ v3;
     const res0 = byte_reverse(b);
-
+    if DEBUG {
+      try! shLogger.debug(getModuleName(), getRoutineName(), getLineNumber(),
+                          "b = %016xu".format(b));
+    }
+    
     if (outlen == 8) {
         return (res0, 0:uint(64));
     }
@@ -234,7 +286,10 @@ module SipHash {
     }
     
     b = v0 ^ v1 ^ v2 ^ v3;
-
+    if DEBUG {
+      try! shLogger.debug(getModuleName(), getRoutineName(), getLineNumber(),
+                          "b = %016xu".format(b));
+    }
     return  (res0, byte_reverse(b));
   }
 }

--- a/src/SipHash.chpl
+++ b/src/SipHash.chpl
@@ -59,7 +59,7 @@ module SipHash {
   private inline proc XTO64_LE(in x: ?t) {
     var y: uint(64);
     if isSubtype(t, c_ptr) {
-      c_memcpy(c_ptrTo(y), x, 8);
+      c_memcpy(c_ptrTo(y), x, c_sizeof(t));
     } else if numBytes(t) == 8 {
       c_memcpy(c_ptrTo(y), c_ptrTo(x), numBytes(t));
     } else {
@@ -81,12 +81,16 @@ module SipHash {
     return c;
   }
   
-  proc sipHash64(msg: [] ?t, D): uint(64) {
+  proc sipHash64(msg: [] ?t, D): uint(64) where ((t == uint(8)) ||
+                                                 (t == int(64)) ||
+                                                 (t == real(64))) {
     var (res,_) = computeSipHashLocalized(msg, D, 8);
     return res;
   }
 
-  proc sipHash128(msg: [] ?t, D): 2*uint(64) {
+  proc sipHash128(msg: [] ?t, D): 2*uint(64) where ((t == uint(8)) ||
+                                                    (t == int(64)) ||
+                                                    (t == real(64))) {
     return computeSipHashLocalized(msg, D, 16);
   }
 
@@ -118,7 +122,7 @@ module SipHash {
           return computeSipHash(c_ptrTo(start), 0..#l, outlen, numBytes(t));
         } else {
           var a = c_malloc(msg.eltType, l);
-          const byteSize = l:size_t * c_sizeof(t);
+          const byteSize = l:size_t * numBytes(t);
           GET(a, startLocale, getAddr(start), byteSize);
           var h = computeSipHash(a, 0..#l, outlen, numBytes(t));
           c_free(a);

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -156,7 +156,21 @@ class NumericTest(ArkoudaTest):
         with self.assertRaises(TypeError) as cm:
             ak.cos([range(0,10)])
         self.assertEqual('type of argument "pda" must be arkouda.pdarrayclass.pdarray; got list instead', 
-                        cm.exception.args[0])    
+                        cm.exception.args[0])
+
+    def testHash(self):
+        h1, h2 = ak.hash(ak.arange(10))
+        rev = ak.arange(9, -1, -1)
+        h3, h4 = ak.hash(rev)
+        self.assertTrue((h1 == h3[rev]).all() and (h2 == h4[rev]).all())
+
+        h1 = ak.hash(ak.arange(10), full=False)
+        h3 = ak.hash(rev, full=False)
+        self.assertTrue((h1 == h3[rev]).all())
+
+        h = ak.hash(ak.linspace(0, 10, 10))
+        self.assertTrue((h[0].dtype == ak.int64) and (h[1].dtype == ak.int64))
+        
         
     def testValueCounts(self):
         pda = ak.ones(100, dtype=ak.int64)


### PR DESCRIPTION
## Functionality

This PR addresses the first part of #919 by introducing element-wise hashing for pdarrays. The form

```python
h1, h2 = ak.hash(x)
```

returns an "array" of 128-bit hashes split across 2 pdarrays, whereas the form

```python
h = ak.hash(x, full=False)
```

returns an array of 64-bit hashes. As noted in the function docstring, the 64-bit form is not recommended when the number of unique values in `x` exceeds several million, due to high risk of collisions.

## Tests

`tests/numeric_test.py` contains a test for the API, invoked on `int64` and `float64` pdarrays (hashing `bool` pdarrays is not supported), and `test/UnitTestSipHash.chpl` has been expanded to test the correctness of hashing (arrays of) 64-bit integers, compared against published test vectors for SIPhash.

## Performance

`tests/SipHashSpeedTest.chpl` has been updated to optionally compare performance across the three supported element types, `uint(8)`, `int(64)`, and `real(64)`. Hashing the larger element types is about twice as fast as `uint(8)`, on a per-byte basis, and this difference is consistent on multiple (simulated) locales.

Single-locale performance with `test-bin/SipHashSpeedTest --NINPUTS=10_000_000 --compareTypes`:

| mode | dtype | size (MB) | rate (MB/s) |
| ------- | ------- | ------ | ------ |
| variable-length | uint(8) | 615 | 1691 |
| variable-length | int(64) | 4923 | 3296 |
| variable-length | real(64) | 4919 | 3633 |
| fixed-length | uint(8) | 610 | 2022 |
| fixed-length | int(64) | 4882 | 3759 |
| fixed-length | real(64) | 4882 | 3765 |

Simulated multi-locale performance with `test-bin/SipHashSpeedTest -nl 2 --NINPUTS=1_000_000 --compareTypes` (smaller size due to memory constraints):

| mode | dtype | size (MB) | rate (MB/s) |
| ------- | ------- | ------ | ------ |
| variable-length | uint(8) | 62 | 668 |
| variable-length | int(64) | 488 | 1535 |
| variable-length | real(64) | 490 | 1554 |
| fixed-length | uint(8) | 61 | 686 |
| fixed-length | int(64) | 488 | 1559 |
| fixed-length | real(64) | 488 | 1544 |
