### PR TITLE
Avoid using pyzmq 22.3.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -125,4 +125,4 @@ jobs:
         echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" > Makefile.paths
     - name: Run unit tests
       run: |
-        python3 util/test/parallel_start_test.py -d test --threads 4
+        start_test test

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ setup(
     install_requires=[
         'numpy>=1.16.5,<=1.19.5',
         'pandas>=1.1.0',
-        'pyzmq>=20.0.0',
+        'pyzmq>=20.0.0,<=22.2.1',
         'typeguard==2.10.0',
         'pyfiglet',
         'versioneer'


### PR DESCRIPTION
Since pyzmq 22.3.0 was released we've been seeing testing failures for
registration_test.py due to unknown symbol errors (this is typically due
to a double free or early free of the symbol table entry.)

Until we have time to dig into this, pin to older pyzmq versions to see
if this resolves the nightly testing failures.

See #924 for details

While here, go back to using `start_test` for standalone Chapel CI tests
so that the error messages are visible when something goes wrong. The
config that runs the python tests is the slowest one anyways, so I don't
think having Chapel tests run slower will increase total CI time.