### PR TITLE
Closes #911: Implement `find_locations` and `findall` on regexes for `Strings`

### DIFF
--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import itertools
-from typing import cast, Tuple, List, Optional, Union
+from typing import cast, Tuple, List, Optional, Union, Dict
 from typeguard import typechecked
 from arkouda.client import generic_msg
 from arkouda.pdarrayclass import pdarray, create_pdarray, parse_single_value, \
@@ -13,7 +13,7 @@ from arkouda.dtypes import NUMBER_FORMAT_STRINGS, resolve_scalar_dtype, \
      translate_np_dtype
 import json
 import re
-from arkouda.infoclass import information
+from arkouda.infoclass import information, list_symbol_table
 
 __all__ = ['Strings']
 
@@ -39,6 +39,10 @@ class Strings:
         The sizes of each dimension of the array
     dtype : dtype
         The dtype is ak.str
+    regex_dict: Dict[str, Tuple[pdarray, pdarray, pdarray]]
+        Dictionary storing information on matches (cache of Strings.find(pattern))
+        Keys - regex patterns
+        Values - tuples of pdarrays (numMatches, matchStarts, matchLens)
     logger : ArkoudaLogger
         Used for all logging operations
         
@@ -102,6 +106,7 @@ class Strings:
 
         self.dtype = npstr
         self.name:Optional[str] = None
+        self.regex_dict: Dict = dict()
         self.logger = getArkoudaLogger(name=__class__.__name__) # type: ignore
 
     def __iter__(self):
@@ -254,6 +259,146 @@ class Strings:
         args = "{} {} {}".\
                         format(self.objtype, self.offsets.name, self.bytes.name)
         return create_pdarray(generic_msg(cmd=cmd,args=args))
+
+    def _refresh_regex_dict(self):
+        """
+        Internal function to recreate regex_dict without any stale pdarrays (that are no longer in the symbol table)
+        """
+        sym_tab = list_symbol_table()
+        self.regex_dict = {key: val for key, val in self.regex_dict.items() if all([pda.name in sym_tab for pda in val])}
+
+    def print_cached_regex_patterns(self):
+        """
+        Prints the regex patterns for which Strings.find(pattern) has been cached
+        """
+        self._refresh_regex_dict()
+        print(self.regex_dict.keys())
+
+    @typechecked
+    def find(self, pattern: Union[bytes, str_scalars]) -> Tuple[pdarray, pdarray, pdarray]:
+        """
+        Finds pattern matches and returns pdarrays containing the number, start postitions, and lengths of matches
+            Note: only handles regular expressions supported by re2 (does not support lookaheads/lookbehinds)
+
+        Parameters
+        ----------
+        pattern: str_scalars
+            The regex pattern used to find matches
+
+        Returns
+        -------
+        pdarray, int64
+            For each original string, the number of pattern matches
+        pdarray, int64
+            The start positons of pattern matches
+        pdarray, int64
+            The lengths of pattern matches
+
+        Raises
+        ------
+        TypeError
+            Raised if the pattern parameter is not bytes or str_scalars
+        ValueError
+            Rasied if pattern is not a valid regex
+        RuntimeError
+            Raised if there is a server-side error thrown
+
+        See Also
+        --------
+        Strings.slice, Strings.match
+
+        Examples
+        --------
+        >>> strings = ak.array(['{} string {}'.format(i, i) for i in range(1, 6)])
+        >>> strings
+        array(['1 string 1', '2 string 2', '3 string 3', '4 string 4', '5 string 5'])
+        >>> num_matches, starts, lens = strings.find('\\d')
+        >>> num_matches
+        array([2, 2, 2, 2, 2])
+        >>> starts
+        array([0, 9, 11, 20, 22, 31, 33, 42, 44, 53])
+        >>> lens
+        array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1]))
+        """
+        if isinstance(pattern, bytes):
+            pattern = pattern.decode()
+        sym_tab = list_symbol_table()
+        if pattern not in self.regex_dict or any([pda.name not in sym_tab for pda in self.regex_dict[pattern]]):
+            # run find if we don't have the result of find(pattern) cached or any of the references have gone stale
+            try:
+                re.compile(pattern)
+            except Exception as e:
+                raise ValueError(e)
+            cmd = "segmentedFind"
+            args = "{} {} {} {}".format(self.objtype,
+                                        self.offsets.name,
+                                        self.bytes.name,
+                                        json.dumps([pattern]))
+            repMsg = cast(str, generic_msg(cmd=cmd, args=args))
+            arrays = repMsg.split('+', maxsplit=2)
+            self.regex_dict[pattern] = (create_pdarray(arrays[0]), create_pdarray(arrays[1]), create_pdarray(arrays[2]))
+        return self.regex_dict[pattern]
+
+    @typechecked
+    def slice(self, pattern: Union[bytes, str_scalars], return_match_origins: bool = False) -> Union[Strings, Tuple]:
+        """
+        Returns the slices of Strings which match pattern
+            Note: only handles regular expressions supported by re2 (does not support lookaheads/lookbehinds)
+
+        Parameters
+        ----------
+        pattern: str_scalars
+            The regex pattern used to find match slices
+        return_match_origins: bool
+            If True, return a pdarray containing the index of the original string each pattern match is from
+
+        Returns
+        -------
+        Strings
+            Strings object containing only pattern matches
+        pdarray, int64 (optional)
+            The index of the original string each pattern match is from
+
+        Raises
+        ------
+        TypeError
+            Raised if the pattern parameter is not bytes or str_scalars
+        ValueError
+            Rasied if pattern is not a valid regex
+        RuntimeError
+            Raised if there is a server-side error thrown
+
+        See Also
+        --------
+        Strings.find, Strings.match
+
+        Examples
+        --------
+        >>> strings = ak.array(['{} string {}'.format(i, i) for i in range(1, 6)])
+        >>> strings
+        array(['1 string 1', '2 string 2', '3 string 3', '4 string 4', '5 string 5'])
+        >>> matches, match_origins = strings.slice('\\d', return_match_origins = True)
+        >>> matches
+        array(['1', '1', '2', '2', '3', '3', '4', '4', '5', '5'])
+        >>> match_origins
+        array([0, 0, 1, 1, 2, 2, 3, 3, 4, 4])
+        """
+        num_matches, starts, lens = self.find(pattern)
+        cmd = "segmentedSlice"
+        args = "{} {} {} {} {} {} {}".format(self.objtype,
+                                             self.offsets.name,
+                                             self.bytes.name,
+                                             num_matches.name,
+                                             starts.name,
+                                             lens.name,
+                                             return_match_origins)
+        repMsg = cast(str, generic_msg(cmd=cmd, args=args))
+        if return_match_origins:
+            arrays = repMsg.split('+', maxsplit=2)
+            return Strings(arrays[0], arrays[1]), create_pdarray(arrays[2])
+        else:
+            arrays = repMsg.split('+', maxsplit=1)
+            return Strings(arrays[0], arrays[1])
 
     @typechecked
     def contains(self, substr: Union[bytes, str_scalars], regex: bool = False) -> pdarray:

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -156,7 +156,7 @@ module SegmentedMsg {
       return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc segmentedFindMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+  proc segmentedFindLocMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
     var (objtype, segName, valName, patternJson) = payload.splitMsgToTuple(4);
@@ -177,7 +177,7 @@ module SegmentedMsg {
         const rStartsName = st.nextName();
         const rLensName = st.nextName();
         var strings = getSegString(segName, valName, st);
-        var (numMatches, matchStarts, matchLens) = strings.findMatches(pattern);
+        var (numMatches, matchStarts, matchLens) = strings.findMatchLocations(pattern);
         st.addEntry(rNumMatchesName, new shared SymEntry(numMatches));
         st.addEntry(rStartsName, new shared SymEntry(matchStarts));
         st.addEntry(rLensName, new shared SymEntry(matchLens));
@@ -195,7 +195,7 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc segmentedSliceMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+  proc segmentedFindAllMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
     var (objtype, segName, valName, numMatchesName, startsName, lensName, returnMatchOrigStr) = payload.splitMsgToTuple(7);
@@ -221,7 +221,7 @@ module SegmentedMsg {
         var starts = st.lookup(startsName): borrowed SymEntry(int);
         var lens = st.lookup(lensName): borrowed SymEntry(int);
 
-        var (off, val, matchOrigins) = strings.sliceMatches(numMatches, starts, lens, returnMatchOrig);
+        var (off, val, matchOrigins) = strings.findAllMatches(numMatches, starts, lens, returnMatchOrig);
         st.addEntry(rSegName, new shared SymEntry(off));
         st.addEntry(rValName, new shared SymEntry(val));
         repMsg = "created %s+created %s".format(st.attrib(rSegName), st.attrib(rValName));

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -156,6 +156,90 @@ module SegmentedMsg {
       return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
+  proc segmentedFindMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    var pn = Reflection.getRoutineName();
+    var repMsg: string;
+    var (objtype, segName, valName, patternJson) = payload.splitMsgToTuple(4);
+
+    // check to make sure symbols defined
+    st.checkTable(segName);
+    st.checkTable(valName);
+
+    const json = jsonToPdArray(patternJson, 1);
+    const pattern: string = json[json.domain.low];
+
+    smLogger.debug(getModuleName(), getRoutineName(), getLineNumber(),
+                   "cmd: %s objtype: %t".format(cmd, objtype));
+
+    select objtype {
+      when "str" {
+        const rNumMatchesName = st.nextName();
+        const rStartsName = st.nextName();
+        const rLensName = st.nextName();
+        var strings = getSegString(segName, valName, st);
+        var (numMatches, matchStarts, matchLens) = strings.findMatches(pattern);
+        st.addEntry(rNumMatchesName, new shared SymEntry(numMatches));
+        st.addEntry(rStartsName, new shared SymEntry(matchStarts));
+        st.addEntry(rLensName, new shared SymEntry(matchLens));
+        repMsg = "created %s+created %s+created %s".format(st.attrib(rNumMatchesName),
+                                                           st.attrib(rStartsName),
+                                                           st.attrib(rLensName));
+      }
+      otherwise {
+        var errorMsg = "%s".format(objtype);
+        smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+        return new MsgTuple(notImplementedError(pn, errorMsg), MsgType.ERROR);
+      }
+    }
+    smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+    return new MsgTuple(repMsg, MsgType.NORMAL);
+  }
+
+  proc segmentedSliceMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    var pn = Reflection.getRoutineName();
+    var repMsg: string;
+    var (objtype, segName, valName, numMatchesName, startsName, lensName, returnMatchOrigStr) = payload.splitMsgToTuple(7);
+    const returnMatchOrig: bool = returnMatchOrigStr.toLower() == "true";
+
+    // check to make sure symbols defined
+    st.checkTable(segName);
+    st.checkTable(valName);
+    st.checkTable(numMatchesName);
+    st.checkTable(startsName);
+    st.checkTable(lensName);
+
+    smLogger.debug(getModuleName(), getRoutineName(), getLineNumber(),
+                   "cmd: %s objtype: %t".format(cmd, objtype));
+
+    select objtype {
+      when "str" {
+        const rSegName = st.nextName();
+        const rValName = st.nextName();
+        const optName: string = if returnMatchOrig then st.nextName() else "";
+        var strings = getSegString(segName, valName, st);
+        var numMatches = st.lookup(numMatchesName): borrowed SymEntry(int);
+        var starts = st.lookup(startsName): borrowed SymEntry(int);
+        var lens = st.lookup(lensName): borrowed SymEntry(int);
+
+        var (off, val, matchOrigins) = strings.sliceMatches(numMatches, starts, lens, returnMatchOrig);
+        st.addEntry(rSegName, new shared SymEntry(off));
+        st.addEntry(rValName, new shared SymEntry(val));
+        repMsg = "created %s+created %s".format(st.attrib(rSegName), st.attrib(rValName));
+        if returnMatchOrig {
+          st.addEntry(optName, new shared SymEntry(matchOrigins));
+          repMsg += "+created %s".format(st.attrib(optName));
+        }
+      }
+      otherwise {
+        var errorMsg = "%s".format(objtype);
+        smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+        return new MsgTuple(notImplementedError(pn, errorMsg), MsgType.ERROR);
+      }
+    }
+    smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+    return new MsgTuple(repMsg, MsgType.NORMAL);
+  }
+
   proc createPeelSymEntries(loname, lo, lvname, lv, roname, ro, rvname, rv, st: borrowed SymTab) throws {
     st.addEntry(loname, new shared SymEntry(lo));
     st.addEntry(lvname, new shared SymEntry(lv));

--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -308,6 +308,8 @@ proc main() {
                 when "segmentLengths"    {repTuple = segmentLengthsMsg(cmd, args, st);}
                 when "segmentedHash"     {repTuple = segmentedHashMsg(cmd, args, st);}
                 when "segmentedEfunc"    {repTuple = segmentedEfuncMsg(cmd, args, st);}
+                when "segmentedFind"     {repTuple = segmentedFindMsg(cmd, args, st);}
+                when "segmentedSlice"    {repTuple = segmentedSliceMsg(cmd, args, st);}
                 when "segmentedPeel"     {repTuple = segmentedPeelMsg(cmd, args, st);}
                 when "segmentedIndex"    {repTuple = segmentedIndexMsg(cmd, args, st);}
                 when "segmentedBinopvv"  {repTuple = segBinopvvMsg(cmd, args, st);}

--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -308,8 +308,8 @@ proc main() {
                 when "segmentLengths"    {repTuple = segmentLengthsMsg(cmd, args, st);}
                 when "segmentedHash"     {repTuple = segmentedHashMsg(cmd, args, st);}
                 when "segmentedEfunc"    {repTuple = segmentedEfuncMsg(cmd, args, st);}
-                when "segmentedFind"     {repTuple = segmentedFindMsg(cmd, args, st);}
-                when "segmentedSlice"    {repTuple = segmentedSliceMsg(cmd, args, st);}
+                when "segmentedFindLoc"  {repTuple = segmentedFindLocMsg(cmd, args, st);}
+                when "segmentedFindAll"  {repTuple = segmentedFindAllMsg(cmd, args, st);}
                 when "segmentedPeel"     {repTuple = segmentedPeelMsg(cmd, args, st);}
                 when "segmentedIndex"    {repTuple = segmentedIndexMsg(cmd, args, st);}
                 when "segmentedBinopvv"  {repTuple = segBinopvvMsg(cmd, args, st);}

--- a/tests/regex_test.py
+++ b/tests/regex_test.py
@@ -44,6 +44,48 @@ class RegexTest(ArkoudaTest):
         self.assertFalse(aaa_strings.match('ing a+').any())
         self.assertFalse(aaa_strings.match('a+ str').any())
 
+    def test_regex_find(self):
+        strings = ak.array(['{} string {}'.format(i, i) for i in range(1, 6)])
+
+        expected_num_matches = [2, 2, 2, 2, 2]
+        expected_starts = [0, 9, 11, 20, 22, 31, 33, 42, 44, 53]
+        expected_lens = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+        actual_num_matches, actual_starts, actual_lens = strings.find('\\d')
+        self.assertListEqual(expected_num_matches, actual_num_matches.to_ndarray().tolist())
+        self.assertListEqual(expected_starts, actual_starts.to_ndarray().tolist())
+        self.assertListEqual(expected_lens, actual_lens.to_ndarray().tolist())
+
+        expected_num_matches = [1, 1, 1, 1, 1]
+        expected_starts = [2, 13, 24, 35, 46]
+        expected_lens = [8, 8, 8, 8, 8]
+        actual_num_matches, actual_starts, actual_lens = strings.find('string \\d')
+        self.assertListEqual(expected_num_matches, actual_num_matches.to_ndarray().tolist())
+        self.assertListEqual(expected_starts, actual_starts.to_ndarray().tolist())
+        self.assertListEqual(expected_lens, actual_lens.to_ndarray().tolist())
+
+    def test_regex_slice(self):
+        strings = ak.array(['{} string {}'.format(i, i) for i in range(1, 6)])
+        expected_matches = ['1', '1', '2', '2', '3', '3', '4', '4', '5', '5']
+        expected_match_origins = [0, 0, 1, 1, 2, 2, 3, 3, 4, 4]
+        actual_matches, actual_match_origins = strings.slice('\\d', return_match_origins=True)
+        self.assertListEqual(expected_matches, actual_matches.to_ndarray().tolist())
+        self.assertListEqual(expected_match_origins, actual_match_origins.to_ndarray().tolist())
+        actual_matches = strings.slice('\\d')
+        self.assertListEqual(expected_matches, actual_matches.to_ndarray().tolist())
+
+        expected_matches = ['string 1', 'string 2', 'string 3', 'string 4', 'string 5']
+        expected_match_origins = [0, 1, 2, 3, 4]
+        actual_matches, actual_match_origins = strings.slice('string \\d', return_match_origins=True)
+        self.assertListEqual(expected_matches, actual_matches.to_ndarray().tolist())
+        self.assertListEqual(expected_match_origins, actual_match_origins.to_ndarray().tolist())
+
+        under = ak.array(['', '____', '_1_2', '3___4___', '5'])
+        expected_matches = ['____', '_', '_', '___', '___']
+        expected_match_origins = [1, 2, 2, 3, 3]
+        actual_matches, actual_match_origins = under.slice('_+', return_match_origins=True)
+        self.assertListEqual(expected_matches, actual_matches.to_ndarray().tolist())
+        self.assertListEqual(expected_match_origins, actual_match_origins.to_ndarray().tolist())
+
     def test_regex_peel(self):
         orig = ak.array(['a.b', 'c.d', 'e.f.g'])
         digit = ak.array(['a1b', 'c1d', 'e1f2g'])

--- a/tests/regex_test.py
+++ b/tests/regex_test.py
@@ -44,13 +44,13 @@ class RegexTest(ArkoudaTest):
         self.assertFalse(aaa_strings.match('ing a+').any())
         self.assertFalse(aaa_strings.match('a+ str').any())
 
-    def test_regex_find(self):
+    def test_regex_find_locations(self):
         strings = ak.array(['{} string {}'.format(i, i) for i in range(1, 6)])
 
         expected_num_matches = [2, 2, 2, 2, 2]
         expected_starts = [0, 9, 11, 20, 22, 31, 33, 42, 44, 53]
         expected_lens = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
-        actual_num_matches, actual_starts, actual_lens = strings.find('\\d')
+        actual_num_matches, actual_starts, actual_lens = strings.find_locations('\\d')
         self.assertListEqual(expected_num_matches, actual_num_matches.to_ndarray().tolist())
         self.assertListEqual(expected_starts, actual_starts.to_ndarray().tolist())
         self.assertListEqual(expected_lens, actual_lens.to_ndarray().tolist())
@@ -58,31 +58,31 @@ class RegexTest(ArkoudaTest):
         expected_num_matches = [1, 1, 1, 1, 1]
         expected_starts = [2, 13, 24, 35, 46]
         expected_lens = [8, 8, 8, 8, 8]
-        actual_num_matches, actual_starts, actual_lens = strings.find('string \\d')
+        actual_num_matches, actual_starts, actual_lens = strings.find_locations('string \\d')
         self.assertListEqual(expected_num_matches, actual_num_matches.to_ndarray().tolist())
         self.assertListEqual(expected_starts, actual_starts.to_ndarray().tolist())
         self.assertListEqual(expected_lens, actual_lens.to_ndarray().tolist())
 
-    def test_regex_slice(self):
+    def test_regex_findall(self):
         strings = ak.array(['{} string {}'.format(i, i) for i in range(1, 6)])
         expected_matches = ['1', '1', '2', '2', '3', '3', '4', '4', '5', '5']
         expected_match_origins = [0, 0, 1, 1, 2, 2, 3, 3, 4, 4]
-        actual_matches, actual_match_origins = strings.slice('\\d', return_match_origins=True)
+        actual_matches, actual_match_origins = strings.findall('\\d', return_match_origins=True)
         self.assertListEqual(expected_matches, actual_matches.to_ndarray().tolist())
         self.assertListEqual(expected_match_origins, actual_match_origins.to_ndarray().tolist())
-        actual_matches = strings.slice('\\d')
+        actual_matches = strings.findall('\\d')
         self.assertListEqual(expected_matches, actual_matches.to_ndarray().tolist())
 
         expected_matches = ['string 1', 'string 2', 'string 3', 'string 4', 'string 5']
         expected_match_origins = [0, 1, 2, 3, 4]
-        actual_matches, actual_match_origins = strings.slice('string \\d', return_match_origins=True)
+        actual_matches, actual_match_origins = strings.findall('string \\d', return_match_origins=True)
         self.assertListEqual(expected_matches, actual_matches.to_ndarray().tolist())
         self.assertListEqual(expected_match_origins, actual_match_origins.to_ndarray().tolist())
 
         under = ak.array(['', '____', '_1_2', '3___4___', '5'])
         expected_matches = ['____', '_', '_', '___', '___']
         expected_match_origins = [1, 2, 2, 3, 3]
-        actual_matches, actual_match_origins = under.slice('_+', return_match_origins=True)
+        actual_matches, actual_match_origins = under.findall('_+', return_match_origins=True)
         self.assertListEqual(expected_matches, actual_matches.to_ndarray().tolist())
         self.assertListEqual(expected_match_origins, actual_match_origins.to_ndarray().tolist())
 


### PR DESCRIPTION
This PR (closes #911):
- Adds `find_locations`/`findall` to `Strings` and unit tests for this functionality. Also caches previous `Strings.find_locations` results
- `find_locations(pattern)` 
  - Finds pattern matches and returns pdarrays containing the number, start postitions, and lengths of matches
  - Results of `find_locations` are cached in `regex_dict`
- `findall(pattern, return_match_origins)`
  - Return all non-overlapping matches of pattern in Strings as a new Strings object. If `return_match_origins` is True, return a pdarray containing the index of the original string each pattern match is from
  - Uses the output of `find_locations`

Example:
```python
>>> strings = ak.array(['', '____', '_1_2', '3___4___', '5'])
>>> strings.find('_+')
(array([0 1 2 2 0]), array([1 6 8 12 16]), array([4 1 1 3 3]))

>>> strings.print_cached_regex_patterns()
dict_keys(['_+'])

>>> strings.slice('_+', return_match_origins=True)
(array(['____', '_', '_', '___', '___']), array([1 2 2 3 3]))

>>> strings.slice('\\d', return_match_origins=True)
(array(['1', '2', '3', '4', '5']), array([2 2 3 3 4]))

>>> strings.print_cached_regex_patterns()
dict_keys(['_+', '\\d'])

>>> strings.register('myStr')
array(['', '____', '_1_2', '3___4___', '5'])

>>> ak.clear()
>>> strings.cached_regex_patterns()
dict_keys([])

>>> strings.slice('\\d')
array(['1', '2', '3', '4', '5'])

>>> strings.print_cached_regex_patterns()
dict_keys(['\\d'])
```