### PR TITLE
Move localizing code from SipHash to a general helper

### DIFF
--- a/test/SipHashSpeedTest.chpl
+++ b/test/SipHashSpeedTest.chpl
@@ -4,6 +4,7 @@ use SipHash;
 
 config const NINPUTS = 100_000;
 config const INPUTSIZE = 64;
+config const SEED = "none";
 
 enum testMode {fixed, variable};
 config const mode = testMode.variable;
@@ -28,7 +29,7 @@ proc testVariableLength(n:int, meanSize:int, type t) {
   var d: Diags;
   const logMean:real = log(meanSize:real)/2;
   const logStd:real = sqrt(2*logMean);
-  var (segs, vals) = newRandStringsLogNormalLength(n, logMean, logStd);
+  var (segs, vals) = newRandStringsLogNormalLength(n, logMean, logStd, seedStr=SEED);
   var tohash: [vals.domain] t = [v in vals] v: t;
   const D = segs.domain;
   var lengths: [D] int;


### PR DESCRIPTION
In #287 SipHash was optimized by localizing segmented string data with a
bulk GET instead of collecting elements one at a time. This moves that
localization logic into a common `lowLevelLocalizingSlice` helper so
that we can use it in an upcoming PR to localize segmented string data
used in the regex implementation.

This also adds a seed argument to SipHashSpeedTest to get the same
arrays from run-to-run. I used this to verify there is no performance
difference from this change.

Part of #917