### PR TITLE
Fix get_mem_used test for multi-locale testing

### DIFF
--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -89,7 +89,8 @@ class ClientTest(ArkoudaTest):
                 expected or the call to ak.client.get_mem_used() fails 
         '''  
         try:
-            a = ak.ones(1024*1024)
+            config = ak.client.get_config()
+            a = ak.ones(1024*1024 * config['numLocales'])
             mem_used = ak.client.get_mem_used()
         except Exception as e:
             raise AssertionError(e)


### PR DESCRIPTION
#935 added a mem tracking threshold, which required updating the
get_mem_used test to allocate something over that threshold. I just
allocated a fixed amount, but forgot to scale it by the number of
locales so this was failing for 9+ locales when the size-per-locale
dropped under the threshold. Add the scaling by numLocales here.