### PR TITLE
Fix sorting arrays with values on bitsPerDigit boundaries

### DIFF
--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -30,8 +30,9 @@ module RadixSortLSD
       var aMin = min reduce a;
       var aMax = max reduce a;
       var wPos = if aMax >= 0 then numBits(int) - clz(aMax) else 0;
-      var wNeg = if aMin < 0 then numBits(int) - clz((-aMin)-1) + 1 else 0;
-      const bitWidth = max(wPos, wNeg);
+      var wNeg = if aMin < 0 then numBits(int) - clz((-aMin)-1) else 0;
+      const signBit = if aMin < 0 then 1 else 0;
+      const bitWidth = max(wPos, wNeg) + signBit;
       const negs = aMin < 0;
       return (bitWidth, negs);
     }

--- a/tests/sort_test.py
+++ b/tests/sort_test.py
@@ -12,7 +12,33 @@ class SortTest(ArkoudaTest):
         spda = ak.sort(pda)
         maxIndex = spda.argmax()
         self.assertTrue(maxIndex > 0)
-   
+
+    def testBitBoundaryHardcode(self):
+
+        # test hardcoded 16/17-bit boundaries with and without negative values
+        a = ak.array([1, -1, 32767]) # 16 bit
+        b = ak.array([1,  0, 32768]) # 16 bit
+        c = ak.array([1, -1, 32768]) # 17 bit
+        assert ak.is_sorted(ak.sort(a))
+        assert ak.is_sorted(ak.sort(b))
+        assert ak.is_sorted(ak.sort(c))
+
+        # test hardcoded 64-bit boundaries with and without negative values
+        d = ak.array([1, -1, 2**63-1])
+        e = ak.array([1,  0, 2**63-1])
+        f = ak.array([1, -2**63, 2**63-1])
+        assert ak.is_sorted(ak.sort(d))
+        assert ak.is_sorted(ak.sort(e))
+        assert ak.is_sorted(ak.sort(f))
+
+    def testBitBoundary(self):
+
+        # test 17-bit sort
+        L = -2**15
+        U = 2**16
+        a = ak.randint(L, U, 100)
+        assert ak.is_sorted(ak.sort(a))
+
     def testErrorHandling(self):
         
         # Test RuntimeError from bool NotImplementedError


### PR DESCRIPTION
Fix sorting arrays that contain a positive value that requires a
multiple of `bitsPerDigit` digits and at least one negative value. As an
optimization, the sort code checks how many bits are used so that we can
reduce the number of rounds of radix sort. e.g. if an array only
contains unsigned 16-bit values (`0 - 2**16-1`) we only need 1 round of
radixsort. Similarly, if an array only contains signed 16-bit values
(`-2**15 - 2**15-1`) we still only need 1 round of siphash.

However, there was a bug in the code where we were independently
computing the number of bits needed for positive and negative values.
If you have an array `0 - 2**16-1` you only need 16 bits, but as soon as
we add a negative value the signbit needs to be accounted for, which we
weren't doing before. So for an array with `-2**15 - 2**16-1` values we
were saying only 16 bits were needed even though it actually needs 17.
Fix that here by computing the number of bits needed for positive and
negative values and then if there are any negative values add 1 for the
signbit.

Resolves #937