### PR TITLE
Issue #914 : Disabling testSmallStringArrayToHDF5 from unit tests.

### DIFF
--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -2,7 +2,7 @@ import os, shutil, glob
 import tempfile
 
 import numpy as np
-from pytest import warns
+import pytest
 from typing import List, Mapping, Union
 from base_test import ArkoudaTest
 from context import arkouda as ak
@@ -312,7 +312,7 @@ class IOTest(ArkoudaTest):
                                              f'{IOTest.io_test_dir}/iotest_single_column_dupe_LOCALE0000'])
 
         # Run the same test with missing file, but this time with the warning flag for read_all
-        with warns(RuntimeWarning, match=r"There were .* errors reading files on the server.*"):
+        with pytest.warns(RuntimeWarning, match=r"There were .* errors reading files on the server.*"):
             dataset = ak.read_all(filenames=[f'{IOTest.io_test_dir}/iotest_MISSING_single_column_LOCALE0000',
                                          f'{IOTest.io_test_dir}/iotest_single_column_dupe_LOCALE0000'],
                               strictTypes=False,
@@ -579,6 +579,9 @@ class IOTest(ArkoudaTest):
             a2 = ak.load(f"{tmp_dirname}/small_numeric", dataset="a1")
             self.assertEqual(str(a1), str(a2))
 
+    # This currently breaks on 4 or greater locales.  Since it is such a rare corner case
+    # we are going to remove it for now.
+    @pytest.mark.skip(reason="Breaks nightly testing and this is an extremely rare corner case.")
     def testSmallStringArrayToHDF5(self):
         a1 = ak.array(["ab", "cd"])
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:


### PR DESCRIPTION
This is causing issues with nightly benchmarking and represents a
very rare corner case on a tiny amout of data. We already know this
section of code requires and overhaul so we feel comfortable in
disabling it for now.