### PR TITLE
Add BitOps #943

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -15,7 +15,8 @@ from arkouda.infoclass import list_registry, information, pretty_print_informati
 import builtins
 
 __all__ = ["pdarray", "clear", "any", "all", "is_sorted", "sum", "prod", "min", "max", "argmin",
-           "argmax", "mean", "var", "std", "mink", "maxk", "argmink", "argmaxk", "attach_pdarray",
+           "argmax", "mean", "var", "std", "mink", "maxk", "argmink", "argmaxk", "popcount",
+           "parity", "clz", "ctz", "attach_pdarray",
            "unregister_pdarray_by_name", "RegistrationError"]
 
 logger = getArkoudaLogger(name='pdarrayclass')    
@@ -802,6 +803,17 @@ class pdarray:
         """
         return argmaxk(self,k)
 
+    def popcount(self) -> pdarray:
+        return popcount(self)
+
+    def parity(self) -> pdarray:
+        return parity(self)
+
+    def clz(self) -> pdarray:
+        return clz(self)
+
+    def ctz(self) -> pdarray:
+        return ctz(self)
     
     def to_ndarray(self) -> np.ndarray:
         """
@@ -1770,6 +1782,130 @@ def argmaxk(pda : pdarray, k : int_scalars) -> pdarray:
         raise ValueError("must be a non-empty pdarray of type int or float")
 
     repMsg = generic_msg(cmd="maxk", args="{} {} {}".format(pda.name, k, True))
+    return create_pdarray(repMsg)
+
+def popcount(pda: pdarray) -> pdarray:
+    """
+    Find the population (number of bits set) for each integer in an array.
+
+    Parameters
+    ----------
+    pda : pdarray, int64
+        Input array (must be integral).
+
+    Returns
+    -------
+    population : pdarray
+        The number of bits set (1) in each element
+
+    Raises
+    ------
+    TypeError
+        If input array is not int64
+    
+    Examples
+    --------
+    >>> A = ak.arange(10)
+    >>> ak.popcount(A)
+    array([0, 1, 1, 2, 1, 2, 2, 3, 1, 2])
+    """
+    if pda.dtype != akint64:
+        raise TypeError("BitOps only supported on int64 arrays")
+    repMsg = generic_msg(cmd="efunc", args="{} {}".format("popcount", pda.name))
+    return create_pdarray(repMsg)
+
+def parity(pda: pdarray) -> pdarray:
+    """
+    Find the bit parity (XOR of all bits) for each integer in an array.
+
+    Parameters
+    ----------
+    pda : pdarray, int64
+        Input array (must be integral).
+
+    Returns
+    -------
+    parity : pdarray
+        The parity of each element: 0 if even number of bits set, 1 if odd.
+
+    Raises
+    ------
+    TypeError
+        If input array is not int64
+    
+    Examples
+    --------
+    >>> A = ak.arange(10)
+    >>> ak.parity(A)
+    array([0, 1, 1, 0, 1, 0, 0, 1, 1, 0])
+    """
+    if pda.dtype != akint64:
+        raise TypeError("BitOps only supported on int64 arrays")
+    repMsg = generic_msg(cmd="efunc", args="{} {}".format("parity", pda.name))
+    return create_pdarray(repMsg)
+
+def clz(pda: pdarray) -> pdarray:
+    """
+    Count leading zeros for each integer in an array.
+
+    Parameters
+    ----------
+    pda : pdarray, int64
+        Input array (must be integral).
+
+    Returns
+    -------
+    lz : pdarray
+        The number of leading zeros of each element.
+
+    Raises
+    ------
+    TypeError
+        If input array is not int64
+    
+    Examples
+    --------
+    >>> A = ak.arange(10)
+    >>> ak.clz(A)
+    array([64, 63, 62, 62, 61, 61, 61, 61, 60, 60])
+    """
+    if pda.dtype != akint64:
+        raise TypeError("BitOps only supported on int64 arrays")
+    repMsg = generic_msg(cmd="efunc", args="{} {}".format("clz", pda.name))
+    return create_pdarray(repMsg)
+
+def ctz(pda: pdarray) -> pdarray:
+    """
+    Count trailing zeros for each integer in an array.
+
+    Parameters
+    ----------
+    pda : pdarray, int64
+        Input array (must be integral).
+
+    Returns
+    -------
+    lz : pdarray
+        The number of trailing zeros of each element.
+
+    Notes
+    -----
+    ctz(0) is defined to be zero.
+
+    Raises
+    ------
+    TypeError
+        If input array is not int64
+    
+    Examples
+    --------
+    >>> A = ak.arange(10)
+    >>> ak.ctz(A)
+    array([0, 0, 1, 0, 2, 0, 1, 0, 3, 0])
+    """
+    if pda.dtype != akint64:
+        raise TypeError("BitOps only supported on int64 arrays")
+    repMsg = generic_msg(cmd="efunc", args="{} {}".format("ctz", pda.name))
     return create_pdarray(repMsg)
 
 @typechecked

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -804,15 +804,27 @@ class pdarray:
         return argmaxk(self,k)
 
     def popcount(self) -> pdarray:
+        '''
+        Find the population (number of bits set) in each element. See `ak.popcount`.
+        '''
         return popcount(self)
 
     def parity(self) -> pdarray:
+        '''
+        Find the parity (XOR of all bits) in each element. See `ak.parity`.
+        '''
         return parity(self)
 
     def clz(self) -> pdarray:
+        '''
+        Count the number of leading zeros in each element. See `ak.clz`.
+        '''
         return clz(self)
 
     def ctz(self) -> pdarray:
+        '''
+        Count the number of trailing zeros in each element. See `ak.ctz`.
+        '''
         return ctz(self)
     
     def to_ndarray(self) -> np.ndarray:

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1960,18 +1960,13 @@ def rotl(x, rot) -> pdarray:
     >>> ak.rotl(A, A)
     array([0, 2, 8, 24, 64, 160, 384, 896, 2048, 4608])
     """
-    if isinstance(x, pdarray):
-        if x.dtype != akint64:
-            raise TypeError("Rotations only supported on integers")
+    if isinstance(x, pdarray) and x.dtype == akint64:
         if (isinstance(rot, pdarray) and rot.dtype == akint64) or isSupportedInt(rot):
             return x._binop(rot, "<<<")
         else:
             raise TypeError("Rotations only supported on integers")
-    elif isSupportedInt(x):
-        if isinstance(rot, pdarray) and rot.dtype == akint64:
-            return rot._r_binop(x, "<<<")
-        else:
-            raise TypeError("Rotations only supported on integers")
+    elif isSupportedInt(x) and isinstance(rot, pdarray) and rot.dtype == akint64:
+        return rot._r_binop(x, "<<<")
     else:
         raise TypeError("Rotations only supported on integers")
 
@@ -2002,18 +1997,13 @@ def rotr(x, rot) -> pdarray:
     >>> ak.rotr(1024 * A, A)
     array([0, 512, 512, 384, 256, 160, 96, 56, 32, 18])
     """
-    if isinstance(x, pdarray):
-        if x.dtype != akint64:
-            raise TypeError("Rotations only supported on integers")
+    if isinstance(x, pdarray) and x.dtype == akint64:
         if (isinstance(rot, pdarray) and rot.dtype == akint64) or isSupportedInt(rot):
             return x._binop(rot, ">>>")
         else:
             raise TypeError("Rotations only supported on integers")
-    elif isSupportedInt(x):
-        if isinstance(rot, pdarray) and rot.dtype == akint64:
-            return rot._r_binop(x, ">>>")
-        else:
-            raise TypeError("Rotations only supported on integers")
+    elif isSupportedInt(x) and isinstance(rot, pdarray) and rot.dtype == akint64:
+        return rot._r_binop(x, ">>>")
     else:
         raise TypeError("Rotations only supported on integers")
 

--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -5,6 +5,7 @@ module EfuncMsg
     
     use Time only;
     use Math only;
+    use BitOps;
     use Reflection;
     use ServerErrors;
     use Logging;
@@ -100,6 +101,22 @@ module EfuncMsg
                         // Put first array's attrib in repMsg and let common
                         // code append second array's attrib
                         repMsg += "created " + st.attrib(rname2) + "+";
+                    }
+                    when "popcount" {
+                        var a = st.addEntry(rname, e.size, int);
+                        a.a = popcount(e.a);
+                    }
+                    when "parity" {
+                        var a = st.addEntry(rname, e.size, int);
+                        a.a = parity(e.a);
+                    }
+                    when "clz" {
+                        var a = st.addEntry(rname, e.size, int);
+                        a.a = clz(e.a);
+                    }
+                    when "ctz" {
+                        var a = st.addEntry(rname, e.size, int);
+                        a.a = ctz(e.a);
                     }
                     otherwise {
                         var errorMsg = notImplementedError(pn,efunc,gEnt.dtype);

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -5,6 +5,7 @@ module OperatorMsg
 
     use Time;
     use Math;
+    use BitOps;
     use Reflection;
     use ServerErrors;
 
@@ -123,7 +124,15 @@ module OperatorMsg
                     when ">>" {
                         var e = st.addEntry(rname, l.size, int);
                         e.a = l.a >> r.a;
-                    }                    
+                    }
+                    when "<<<" {
+                        var e = st.addEntry(rname, l.size, int);
+                        e.a = rotl(l.a, r.a);
+                    }
+                    when ">>>" {
+                        var e = st.addEntry(rname, l.size, int);
+                        e.a = rotr(l.a, r.a);
+                    }
                     when "&" {
                         var e = st.addEntry(rname, l.size, int);
                         e.a = l.a & r.a;
@@ -571,6 +580,14 @@ module OperatorMsg
                         var e = st.addEntry(rname, l.size, int);
                         e.a = l.a >> val;
                     }
+                    when "<<<" {
+                        var e = st.addEntry(rname, l.size, int);
+                        e.a = rotl(l.a, val);
+                    }
+                    when ">>>" {
+                        var e = st.addEntry(rname, l.size, int);
+                        e.a = rotr(l.a, val);
+                    }
                     when "&" {
                         var e = st.addEntry(rname, l.size, int);
                         e.a = l.a & val;
@@ -1008,6 +1025,14 @@ module OperatorMsg
                     when ">>" {
                         var e = st.addEntry(rname, r.size, int);
                         e.a = val >> r.a;
+                    }
+                    when "<<<" {
+                        var e = st.addEntry(rname, r.size, int);
+                        e.a = rotl(val, r.a);
+                    }
+                    when ">>>" {
+                        var e = st.addEntry(rname, r.size, int);
+                        e.a = rotr(val, r.a);
                     }
                     when "&" {
                         var e = st.addEntry(rname, r.size, int);

--- a/tests/bitops_test.py
+++ b/tests/bitops_test.py
@@ -1,0 +1,50 @@
+from context import arkouda as ak
+from base_test import ArkoudaTest
+
+class BitOpsTest(ArkoudaTest):
+    def test_popcount(self):
+        # Method invocation
+        # Toy input
+        p = ak.arange(10).popcount()
+        ans = ak.array([0, 1, 1, 2, 1, 2, 2, 3, 1, 2])
+        self.assertTrue((p == ans).all())
+        # Function invocation
+        # Edge case input
+        p = ak.popcount(ak.array([-(2**63), -1, 2**63 - 1]))
+        ans = ak.array([1, 64, 63])
+        self.assertTrue((p == ans).all())
+
+    def test_parity(self):
+        p = ak.arange(10).parity()
+        ans = ak.array([0, 1, 1, 0, 1, 0, 0, 1, 1, 0])
+        self.assertTrue((p == ans).all())
+
+        p = ak.parity(ak.array([-(2**63), -1, 2**63 - 1]))
+        ans = ak.array([1, 0, 1])
+        self.assertTrue((p == ans).all())
+
+    def test_clz(self):
+        p = ak.arange(10).clz()
+        ans = ak.array([64, 63, 62, 62, 61, 61, 61, 61, 60, 60])
+        self.assertTrue((p == ans).all())
+
+        p = ak.clz(ak.array([-(2**63), -1, 2**63 - 1]))
+        ans = ak.array([0, 0, 1])
+        self.assertTrue((p == ans).all())
+
+    def test_ctz(self):
+        p = ak.arange(10).ctz()
+        ans = ak.array([0, 0, 1, 0, 2, 0, 1, 0, 3, 0])
+        self.assertTrue((p == ans).all())
+
+        p = ak.ctz(ak.array([-(2**63), -1, 2**63 - 1]))
+        ans = ak.array([63, 0, 0])
+        self.assertTrue((p == ans).all())
+
+    def test_dtypes(self):
+        f = ak.zeros(10, dtype=ak.float64)
+        with self.assertRaises(TypeError) as cm:
+            f.popcount()
+        b = ak.zeros(10, dtype=ak.bool)
+        with self.assertRaises(TypeError) as cm:
+            ak.popcount(f)

--- a/tests/bitops_test.py
+++ b/tests/bitops_test.py
@@ -2,42 +2,47 @@ from context import arkouda as ak
 from base_test import ArkoudaTest
 
 class BitOpsTest(ArkoudaTest):
+    def setUp(self):
+        ArkoudaTest.setUp(self)
+        self.a = ak.arange(10)
+        self.edgeCases = ak.array([-(2**63), -1, 2**63 - 1])
+    
     def test_popcount(self):
         # Method invocation
         # Toy input
-        p = ak.arange(10).popcount()
+        p = self.a.popcount()
         ans = ak.array([0, 1, 1, 2, 1, 2, 2, 3, 1, 2])
         self.assertTrue((p == ans).all())
         # Function invocation
         # Edge case input
-        p = ak.popcount(ak.array([-(2**63), -1, 2**63 - 1]))
+        p = ak.popcount(self.edgeCases)
         ans = ak.array([1, 64, 63])
         self.assertTrue((p == ans).all())
 
     def test_parity(self):
-        p = ak.arange(10).parity()
+        p = self.a.parity()
         ans = ak.array([0, 1, 1, 0, 1, 0, 0, 1, 1, 0])
         self.assertTrue((p == ans).all())
 
-        p = ak.parity(ak.array([-(2**63), -1, 2**63 - 1]))
+        p = ak.parity(self.edgeCases)
         ans = ak.array([1, 0, 1])
         self.assertTrue((p == ans).all())
 
     def test_clz(self):
-        p = ak.arange(10).clz()
+        p = self.a.clz()
         ans = ak.array([64, 63, 62, 62, 61, 61, 61, 61, 60, 60])
         self.assertTrue((p == ans).all())
 
-        p = ak.clz(ak.array([-(2**63), -1, 2**63 - 1]))
+        p = ak.clz(self.edgeCases)
         ans = ak.array([0, 0, 1])
         self.assertTrue((p == ans).all())
 
     def test_ctz(self):
-        p = ak.arange(10).ctz()
+        p = self.a.ctz()
         ans = ak.array([0, 0, 1, 0, 2, 0, 1, 0, 3, 0])
         self.assertTrue((p == ans).all())
 
-        p = ak.ctz(ak.array([-(2**63), -1, 2**63 - 1]))
+        p = ak.ctz(self.edgeCases)
         ans = ak.array([63, 0, 0])
         self.assertTrue((p == ans).all())
 
@@ -48,3 +53,57 @@ class BitOpsTest(ArkoudaTest):
         b = ak.zeros(10, dtype=ak.bool)
         with self.assertRaises(TypeError) as cm:
             ak.popcount(f)
+
+    def test_rotl(self):
+        # vector <<< scalar
+        rotated = self.a.rotl(5)
+        shifted = self.a << 5
+        # No wraparound, so these should be equal
+        self.assertTrue((rotated == shifted).all())
+
+        r = ak.rotl(self.edgeCases, 1)
+        ans = ak.array([1, -1, -2])
+        self.assertTrue((r == ans).all())
+
+        # vector <<< vector
+        rotated = self.a.rotl(self.a)
+        shifted = self.a << self.a
+        # No wraparound, so these should be equal
+        self.assertTrue((rotated == shifted).all())
+
+        r = ak.rotl(self.edgeCases, ak.array([1, 1, 1]))
+        ans = ak.array([1, -1, -2])
+        self.assertTrue((r == ans).all())
+
+        # scalar <<< vector
+        rotated = ak.rotl(-(2**63), self.a)
+        ans = ak.array([-(2**63), 1, 2, 4, 8, 16, 32, 64, 128, 256])
+        self.assertTrue((rotated == ans).all())
+
+    def test_rotr(self):
+        # vector <<< scalar
+        rotated = (1024*self.a).rotr(5)
+        shifted = (1024*self.a) >> 5
+        # No wraparound, so these should be equal
+        self.assertTrue((rotated == shifted).all())
+
+        r = ak.rotr(self.edgeCases, 1)
+        ans = ak.array([2**62, -1, -(2**62) - 1])
+        self.assertTrue((r == ans).all())
+
+        # vector <<< vector
+        rotated = (1024*self.a).rotr(self.a)
+        shifted = (1024*self.a) >> self.a
+        # No wraparound, so these should be equal
+        self.assertTrue((rotated == shifted).all())
+
+        r = ak.rotr(self.edgeCases, ak.array([1, 1, 1]))
+        ans = ak.array([2**62, -1, -(2**62) - 1])
+        self.assertTrue((r == ans).all())
+
+        # scalar <<< vector
+        rotated = ak.rotr(1, self.a)
+        ans = ak.array([1, -(2**63), 2**62, 2**61, 2**60, 2**59, 2**58, 2**57, 2**56, 2**55])
+        self.assertTrue((rotated == ans).all())
+
+                    

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -5,7 +5,7 @@ import numpy as np
 import logging
 
 def build_op_table():
-    ALL_OPS = ak.pdarray.BinOps
+    ALL_OPS = ak.pdarray.BinOps - set(("<<<", ">>>"))
     table = {}
     for op in ALL_OPS:
         for firstclass in (ak.Datetime, ak.Timedelta):

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -57,6 +57,8 @@ def run_tests(verbose):
                'both_implement': []}      # (expression, ak_result, error_on_exec?, dtype_mismatch?, value_mismatch?)
     tests = 0
     for ltype, rtype, op in product(dtypes, dtypes, ak.pdarray.BinOps):
+        if op in ("<<<", ">>>"):
+            continue
         for lscalar, rscalar in ((False, False), (False, True), (True, False)):
             tests += 1
             expression = "{}({}) {} {}({})".format(ltype, ('array', 'scalar')[lscalar], op, rtype, ('array', 'scalar')[rscalar])


### PR DESCRIPTION
This PR adds support for the operations in the Chapel `BitOps` package:
- `popcount`
- `parity`
- `clz`
- `ctz`
- `rotl`
- `rotr`

These operations are accessible as both module-level functions (e.g. `ak.popcount(x)`) and methods (e.g. `x.popcount()`). The rotations accept both array and scalar arguments, like other binary operators.

Closes #943 