### PR TITLE
Fix early return in lowLevelLocalizingSlice init

### DIFF
--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -119,6 +119,8 @@ module AryUtil
 
             this.t = t;
             if region.isEmpty() {
+                this.ptr = c_nil;
+                this.isOwned = false;
                 return;
             }
             ref start = A[region.low];


### PR DESCRIPTION
Previously, when the `lowLevelLocalizingSlice` took an empty region, we
just returned from the initializer and I was expecting the compiler to
insert the default field init. However, the compiler does not do that,
which leaves the fields uninitialized. This leaves them with random
values, which was causing issues where the record had a random address
and isOwned value, which caused us to try and free a random address in
deinit. Here just manually init the fields to work around this.

I opened chapel-lang/chapel#18524 upstream to request an error message