### PR TITLE
Closes #452 by simulating h5ls using the HDF5 api H5Literate

### DIFF
--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -14,7 +14,7 @@ ARKOUDA_HDF5_FILE_METADATA_GROUP = "_arkouda_metadata"
 
 
 @typechecked
-def ls_hdf(filename : str) -> str:
+def ls_hdf(filename : str) -> List[str]:
     """
     This function calls the h5ls utility on a filename visible to the
     arkouda server.
@@ -41,7 +41,7 @@ def ls_hdf(filename : str) -> str:
     if not (filename and filename.strip()):
         raise ValueError("filename cannot be an empty string")
 
-    return cast(str,generic_msg(cmd="lshdf", args="{}".format(json.dumps([filename]))))
+    return json.loads(cast(str,generic_msg(cmd="lshdf", args="{}".format(json.dumps([filename])))))
 
 @typechecked
 def read_hdf(dsetName : str, filenames : Union[str,List[str]],
@@ -317,8 +317,7 @@ def get_datasets(filename : str) -> List[str]:
     --------
     ls_hdf
     """
-    rep_msg = ls_hdf(filename)
-    datasets = [line.split()[0] for line in rep_msg.splitlines()]
+    datasets = ls_hdf(filename)
     # We can skip/remove the _arkouda_metadata group since it is an internal only construct
     if ARKOUDA_HDF5_FILE_METADATA_GROUP in datasets:
         datasets.remove(ARKOUDA_HDF5_FILE_METADATA_GROUP)

--- a/src/c_helpers/help_h5ls.c
+++ b/src/c_helpers/help_h5ls.c
@@ -1,0 +1,49 @@
+/**
+ * External C functions for simulating h5ls and processing HDF5 API objects/data.
+ * HDF5 API passes void* data objects in between calls which can't be processed
+ * directly in chapel, so you need C functions to handle opaque data objects.
+ */
+#include "c_helpers/help_h5ls.h"
+
+/**
+ * C function to retrieve the HDF5 object type for a given object name
+ */
+herr_t c_get_HDF5_obj_type(hid_t loc_id, const char *name, H5O_type_t *obj_type)
+{
+    herr_t status;
+    H5O_info_t info_t;
+    status = H5Oget_info_by_name(loc_id, name, &info_t, H5P_DEFAULT);
+    *obj_type = info_t.type;
+    return status;
+}
+
+/**
+ * C helper function to increment a counter passed via void*
+ */
+void c_incrementCounter(void *data)
+{
+    int i = *(int *)data;
+    i = i + 1;
+    *(int *)data = i;
+}
+
+/**
+ * C helper function to wrap `strlen`
+ */
+size_t c_strlen(char *s)
+{
+    return strlen(s);
+}
+
+/**
+ * C helper function to append HDF5 fieldnames to a char* passed as void*
+ */
+void c_append_HDF5_fieldname(void *data, const char *name)
+{
+    char *d = (char *)data; // Turn void* data into char*
+    if (strlen(d) > 0)
+    {
+        strcat(d, ",");
+    }
+    strcat(d, name);
+}

--- a/src/c_helpers/help_h5ls.h
+++ b/src/c_helpers/help_h5ls.h
@@ -1,0 +1,27 @@
+/**
+ * Function prototypes for HDF5 helper functions to simulate `h5ls`
+ * These are helper functions to process opaque data objects passed
+ * via void* / c_void_ptr.
+ * See GenSymIO.simulate_h5ls
+ */
+
+#ifndef _AK_H5LS_HELPER_H_
+#define _AK_H5LS_HELPER_H_
+
+#include "hdf5.h"
+#include <string.h>
+
+/* C function to retrieve the HDF5 object type for a given object name */
+herr_t c_get_HDF5_obj_type (hid_t loc_id, const char *name, H5O_type_t *obj_type);
+
+/* C helper function to increment a counter passed via `void*` */
+void c_incrementCounter(void *data);
+
+
+/* C helper function to wrap `strlen` */
+size_t c_strlen(char* s);
+
+/* C helper function to append HDF5 fieldnames to a char* passed as `void*` */
+void c_append_HDF5_fieldname(void *data, const char *name);
+
+#endif

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -176,12 +176,12 @@ class IOTest(ArkoudaTest):
         self._create_file(columns=self.dict_single_column, 
                           prefix_path='{}/iotest_single_column'.format(IOTest.io_test_dir))
         message = ak.ls_hdf('{}/iotest_single_column_LOCALE0000'.format(IOTest.io_test_dir))
-        self.assertIn('int_tens_pdarray         Dataset', message)
+        self.assertIn('int_tens_pdarray', message)
         
 
         with self.assertRaises(RuntimeError) as cm:        
             ak.ls_hdf('{}/not-a-file_LOCALE0000'.format(IOTest.io_test_dir))
-        self.assertIn('check file permissions or format', cm.exception.args[0])
+        self.assertIn('is not an HDF5 file', cm.exception.args[0])
 
     def testLsHdfEmpty(self):
         # Test filename empty/whitespace-only condition


### PR DESCRIPTION
Closes #452 by simulating h5ls using the HDF5 api H5Literate
to list datasets and groups in the top level of an HDF5 file.
This uses helper functions written in C to handle the opaque
c_void_ptr / void* used to pass data between HDF5 iterations.
This generates and returns a json formatted  list of the top
level dataset and group objects.