### PR TITLE
Closes #950: Smarter `ak.Categorical.to_ndarray()`

### DIFF
--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -146,8 +146,13 @@ class Categorical:
         may override this limit by setting ak.maxTransferBytes to a larger
         value, but proceed with caution.
         """
-        idx = self.categories.to_ndarray()
-        valcodes = self.codes.to_ndarray()
+        if self.categories.size > self.codes.size:
+            newcat = self.reset_categories()
+            idx = newcat.categories.to_ndarray()
+            valcodes = newcat.codes.to_ndarray()
+        else:
+            idx = self.categories.to_ndarray()
+            valcodes = self.codes.to_ndarray()
         return idx[valcodes]
 
     def __iter__(self):


### PR DESCRIPTION
Closes #950 : 
- Calls `reset_categories()` when `categories.size > codes.size` in `Categorical.to_ndarray()`

I verified locally with that the example from the issue (repeated below) that `Categorical.to_ndarray()` is much faster after the changes suggested by reuster
```python
categories = ak.random_strings_uniform(5, 10, 10**6)
codes = ak.randint(0, 10**6, 10**8)
cat = ak.Categorical.from_codes(codes, categories)
mycat = cat[:10].to_ndarray()
```