### PR TITLE
Temporary Fix for #959: Server hangs when `Regex.matches` has a `pattern` which matches the empty string

### DIFF
--- a/arkouda/matcher.py
+++ b/arkouda/matcher.py
@@ -20,6 +20,9 @@ class Matcher:
             re.compile(self.pattern)
         except Exception as e:
             raise ValueError(e)
+        if re.search(self.pattern, ''):
+            # TODO remove once changes from chapel issue #18639 are in arkouda
+            raise ValueError("regex operations with a pattern that matches the empty string are not currently supported")
         self.parent_bytes_name = parent_bytes_name
         self.parent_offsets_name = parent_offsets_name
         self.num_matches: pdarray
@@ -94,8 +97,6 @@ class Matcher:
         Split string by the occurrences of pattern. If maxsplit is nonzero, at most maxsplit splits occur
         """
         from arkouda.strings import Strings
-        if re.search(self.pattern, ''):
-            raise ValueError("Cannot split with a pattern that matches the empty string")
         cmd = "segmentedSplit"
         args = "{} {} {} {} {} {}".format(self.objtype,
                                           self.parent_offsets_name,
@@ -141,8 +142,6 @@ class Matcher:
         If return_num_subs is True, return the number of substitutions that occurred
         """
         from arkouda.strings import Strings
-        if re.search(self.pattern, ''):
-            raise ValueError("Cannot sub with a pattern that matches the empty string")
         cmd = "segmentedSub"
         args = "{} {} {} {} {} {} {}".format(self.objtype,
                                              self.parent_offsets_name,

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -877,6 +877,9 @@ class Strings:
                 re.compile(delimiter)
             except Exception as e:
                 raise ValueError(e)
+            if re.search(delimiter, ''):
+                # TODO remove once changes from chapel issue #18639 are in arkouda
+                raise ValueError("regex operations with a pattern that matches the empty string are not currently supported")
         if times < 1:
             raise ValueError("times must be >= 1")
         cmd = "segmentedPeel"

--- a/tests/regex_test.py
+++ b/tests/regex_test.py
@@ -5,6 +5,37 @@ import re
 
 class RegexTest(ArkoudaTest):
 
+    def test_empty_string_patterns(self):
+        # For issue #959:
+        # verify ValueError is raised when methods which use Regex.matches have a pattern which matches the empty string
+        # TODO remove/change test once changes from chapel issue #18639 are in arkouda
+        s = ak.array(['one'])
+        for pattern in ['', '|', '^', '$']:
+            with self.assertRaises(ValueError):
+                s.search(pattern)
+            with self.assertRaises(ValueError):
+                s.match(pattern)
+            with self.assertRaises(ValueError):
+                s.fullmatch(pattern)
+            with self.assertRaises(ValueError):
+                s.split(pattern)
+            with self.assertRaises(ValueError):
+                s.sub(pattern, 'repl')
+            with self.assertRaises(ValueError):
+                s.findall(pattern)
+            with self.assertRaises(ValueError):
+                s.find_locations(pattern)
+            with self.assertRaises(ValueError):
+                s.contains(pattern, regex=True)
+            with self.assertRaises(ValueError):
+                s.startswith(pattern, regex=True)
+            with self.assertRaises(ValueError):
+                s.endswith(pattern, regex=True)
+            with self.assertRaises(ValueError):
+                s.peel(pattern, regex=True)
+            with self.assertRaises(ValueError):
+                s.flatten(pattern, regex=True)
+
     def test_match_objects(self):
         strings = ak.array(['', '____', '_1_2____', '3___4___', '5', '__6__', '___7', '__8___9____10____11'])
         pattern = '_+'


### PR DESCRIPTION
Temporary Fix for #959 :
- Until changes from chapel-lang/chapel#18639 are in arkouda,
- Raise `ValueError` when methods that use `Regex.matches` have a `pattern` which matches the empty string

