### PR TITLE
Remove workarounds for Chapel 1.23 and earlier

### DIFF
--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -143,7 +143,7 @@ module ServerConfig
     Get the physical memory available on this locale
     */ 
     proc getPhysicalMemHere() {
-        use MemDiagnostics;
+        use Memory.Diagnostics;
         return here.physicalMemory();
     }
 
@@ -163,7 +163,7 @@ module ServerConfig
     Get the memory used on this locale
     */
     proc getMemUsed() {
-        use MemDiagnostics;
+        use Memory.Diagnostics;
         return memoryUsed();
     }
 

--- a/src/compat/ge-124/MemDiagnostics.chpl
+++ b/src/compat/ge-124/MemDiagnostics.chpl
@@ -1,5 +1,0 @@
-// Wrapper for the Memory.Diagnostics standard module in versions >= 1.24
-module MemDiagnostics {
-  public use Memory.Diagnostics;
-}
-

--- a/src/compat/lt-124/MemDiagnostics.chpl
+++ b/src/compat/lt-124/MemDiagnostics.chpl
@@ -1,5 +1,0 @@
-// Wrapper for the Memory standard module in versions < 1.24
-module MemDiagnostics {
-  public use Memory;
-}
-


### PR DESCRIPTION
Arkouda currently supports 1.24+, so remove older workarounds. While
here, reorder some Makefile flags so Chapel flags are together and -l
options come after -I/-L options.