### PR TITLE
Add support for optionally reading and writing Parquet files

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 env:
   ARKOUDA_QUICK_COMPILE: true
+  ARKOUDA_SERVER_PARQUET_SUPPORT: true
 
 jobs:
   lint:
@@ -89,7 +90,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: |
-        apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip
+        apt-get update && apt-get install -y -V ca-certificates lsb-release wget
+        wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+        apt-get install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+        apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip libarrow-dev libparquet-dev
         echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" > Makefile.paths
     - name: Build/Install Arkouda
       run: |
@@ -121,7 +125,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: |
-        apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip
+        apt-get update && apt-get install -y -V ca-certificates lsb-release wget
+        wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+        apt-get install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+        apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip libarrow-dev libparquet-dev
         echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" > Makefile.paths
     - name: Run unit tests
       run: |

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,12 @@ endif
 # add-path: Append custom paths for non-system software.
 # Note: Darwin `ld` only supports `-rpath <path>`, not `-rpath=<paths>`.
 define add-path
-CHPL_FLAGS += -I$(1)/include -L$(1)/lib --ldflags="-Wl,-rpath,$(1)/lib"
+ifneq ("$(wildcard $(1)/lib64)","")
+  INCLUDE_FLAGS += -I$(1)/include -L$(1)/lib64
+  CHPL_FLAGS    += -I$(1)/include -L$(1)/lib64 --ldflags="-Wl,-rpath,$(1)/lib64"
+endif
+INCLUDE_FLAGS += -I$(1)/include -L$(1)/lib
+CHPL_FLAGS    += -I$(1)/include -L$(1)/lib --ldflags="-Wl,-rpath,$(1)/lib"
 endef
 # Usage: $(eval $(call add-path,/home/user/anaconda3/envs/arkouda))
 #                               ^ no space after comma
@@ -49,11 +54,25 @@ endif
 ifdef ARKOUDA_HDF5_PATH
 $(eval $(call add-path,$(ARKOUDA_HDF5_PATH)))
 endif
+ifdef ARKOUDA_ARROW_PATH
+$(eval $(call add-path,$(ARKOUDA_ARROW_PATH)))
+endif
 
 CHPL_FLAGS += -lhdf5 -lhdf5_hl -lzmq
 
+ifdef ARKOUDA_SERVER_PARQUET_SUPPORT
+  CHPL_FLAGS += -lparquet -larrow
+  OPTIONAL_CHECKS += check-arrow
+  OPTIONAL_SERVER_FLAGS += -shasParquetSupport
+  ARROW_FILE_NAME += $(ARKOUDA_SOURCE_DIR)/ArrowFunctions
+  ARROW_CPP += $(ARROW_FILE_NAME).cpp
+  ARROW_H += $(ARROW_FILE_NAME).h
+  ARROW_O += $(ARROW_FILE_NAME).o
+endif
+
+
 .PHONY: install-deps
-install-deps: install-zmq install-hdf5
+install-deps: install-zmq install-hdf5 install-arrow
 
 DEP_DIR := dep
 DEP_INSTALL_DIR := $(ARKOUDA_PROJECT_DIR)/$(DEP_DIR)
@@ -88,6 +107,20 @@ install-hdf5:
 	rm -rf $(HDF5_BUILD_DIR)
 	echo '$$(eval $$(call add-path,$(HDF5_INSTALL_DIR)))' >> Makefile.paths
 
+ARROW_VER := 6.0.0
+ARROW_NAME_VER := apache-arrow-$(ARROW_VER)
+ARROW_FULL_NAME_VER := arrow-apache-arrow-$(ARROW_VER)
+ARROW_BUILD_DIR := $(DEP_BUILD_DIR)/$(ARROW_FULL_NAME_VER)
+ARROW_INSTALL_DIR := $(DEP_INSTALL_DIR)/arrow-install
+ARROW_LINK := https://github.com/apache/arrow/archive/refs/tags/$(ARROW_NAME_VER).tar.gz
+install-arrow:
+	@echo "Installing Apache Arrow/Parquet"
+	rm -rf $(ARROW_BUILD_DIR) $(ARROW_INSTALL_DIR)
+	mkdir -p $(DEP_INSTALL_DIR) $(DEP_BUILD_DIR)
+	cd $(DEP_BUILD_DIR) && curl -sL $(ARROW_LINK) | tar xz
+	cd $(ARROW_BUILD_DIR)/cpp && cmake -DCMAKE_INSTALL_PREFIX=$(ARROW_INSTALL_DIR) -DCMAKE_BUILD_TYPE=Release -DARROW_PARQUET=ON $(ARROW_OPTIONS) . && make && make install
+	rm -rf $(ARROW_BUILD_DIR)
+	echo '$$(eval $$(call add-path,$(ARROW_INSTALL_DIR)))' >> Makefile.paths
 
 # System Environment
 ifdef LD_RUN_PATH
@@ -105,9 +138,16 @@ endif
 
 .PHONY: check-deps
 ifndef ARKOUDA_SKIP_CHECK_DEPS
-CHECK_DEPS = check-chpl check-zmq check-hdf5
+CHECK_DEPS = check-chpl check-zmq check-hdf5 $(OPTIONAL_CHECKS)
 endif
 check-deps: $(CHECK_DEPS)
+
+.PHONY: compile-arrow-cpp
+compile-arrow-cpp: $(ARROW_CPP) $(ARROW_H)
+	$(CXX) -O3 -std=c++11 -c $(ARROW_CPP) -o $(ARROW_O) $(INCLUDE_FLAGS)
+
+$(ARROW_O): $(ARROW_CPP) $(ARROW_H)
+	make compile-arrow-cpp
 
 CHPL_MINOR := $(shell $(CHPL) --version | sed -n "s/chpl version 1\.\([0-9]*\).*/\1/p")
 CHPL_VERSION_OK := $(shell test $(CHPL_MINOR) -ge 24 && echo yes)
@@ -132,6 +172,13 @@ HDF5_CHECK = $(DEP_INSTALL_DIR)/checkHDF5.chpl
 check-hdf5: $(HDF5_CHECK)
 	@echo "Checking for HDF5"
 	$(CHPL) $(CHPL_FLAGS) $< -o $(DEP_INSTALL_DIR)/$@
+	$(DEP_INSTALL_DIR)/$@ -nl 1
+	@rm -f $(DEP_INSTALL_DIR)/$@ $(DEP_INSTALL_DIR)/$@_real
+
+ARROW_CHECK = $(DEP_INSTALL_DIR)/checkArrow.chpl
+check-arrow: $(ARROW_CHECK) $(ARROW_O)
+	@echo "Checking for Arrow"
+	$(CHPL) $(CHPL_FLAGS) $< $(ARROW_M) -M $(ARKOUDA_SOURCE_DIR) -o $(DEP_INSTALL_DIR)/$@ -shasParquetSupport
 	$(DEP_INSTALL_DIR)/$@ -nl 1
 	@rm -f $(DEP_INSTALL_DIR)/$@ $(DEP_INSTALL_DIR)/$@_real
 
@@ -201,8 +248,8 @@ else
 	ARKOUDA_COMPAT_MODULES += -M $(ARKOUDA_SOURCE_DIR)/compat/lt-125
 endif
 
-$(ARKOUDA_MAIN_MODULE): check-deps $(ARKOUDA_SOURCES) $(ARKOUDA_MAKEFILES)
-	$(CHPL) $(CHPL_DEBUG_FLAGS) $(PRINT_PASSES_FLAGS) $(REGEX_MAX_CAPTURES_FLAG) $(CHPL_FLAGS_WITH_VERSION) $(ARKOUDA_MAIN_SOURCE) $(ARKOUDA_COMPAT_MODULES) -o $@
+$(ARKOUDA_MAIN_MODULE): check-deps $(ARROW_O) $(ARKOUDA_SOURCES) $(ARKOUDA_MAKEFILES)
+	$(CHPL) $(CHPL_DEBUG_FLAGS) $(PRINT_PASSES_FLAGS) $(REGEX_MAX_CAPTURES_FLAG) $(OPTIONAL_SERVER_FLAGS) $(CHPL_FLAGS_WITH_VERSION) $(ARKOUDA_MAIN_SOURCE) $(ARKOUDA_COMPAT_MODULES) -o $@
 
 CLEAN_TARGETS += arkouda-clean
 .PHONY: arkouda-clean

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1043,6 +1043,80 @@ class pdarray:
                            format(self.name, dataset, m, json_array, self.dtype)))
 
     @typechecked
+    def save_parquet(self, prefix_path : str, dataset : str='array', mode : str='truncate') -> str:
+        """
+        Save the pdarray to Parquet. The result is a collection of Parquet files,
+        one file per locale of the arkouda server, where each filename starts
+        with prefix_path. Each locale saves its chunk of the array to its
+        corresponding file.
+
+        Parameters
+        ----------
+        prefix_path : str
+            Directory and filename prefix that all output files share
+        dataset : str
+            Name of the dataset to create in Parquet files (must not already exist)
+        mode : str {'truncate'}
+            By default, truncate (overwrite) output files, if they exist.
+            Append is currently not supported.
+
+        Returns
+        -------
+        string message indicating result of save operation
+
+        Raises
+        ------
+        RuntimeError
+            Raised if a server-side error is thrown saving the pdarray
+        ValueError
+            Raised if there is an error in parsing the prefix path pointing to
+            file write location or if the mode parameter is neither truncate
+            nor append
+        TypeError
+            Raised if any one of the prefix_path, dataset, or mode parameters
+            is not a string
+
+        See Also
+        --------
+        save, save_all, load, read_hdf, read_all
+
+        Notes
+        -----
+        The prefix_path must be visible to the arkouda server and the user must
+        have write permission.
+
+        Output files have names of the form ``<prefix_path>_LOCALE<i>.parquet``, where ``<i>``
+        ranges from 0 to ``numLocales``. If any of the output files already exist and
+        the mode is 'truncate', they will be overwritten. If the mode is 'append'
+        and the number of output files is less than the number of locales or a
+        dataset with the same name already exists, a ``RuntimeError`` will result.
+
+        Examples
+        --------
+        >>> a = ak.arange(0, 100, 1)
+        >>> a.save_parquet('arkouda_range')
+
+        Array is saved in numLocales files with names like ``tmp/arkouda_range_LOCALE0.hdf``
+
+        The array can be read back in as follows
+
+        >>> b = ak.read_parquet('arkouda_range')
+        >>> (a == b).all()
+        True
+        """
+        if mode.lower() in 'truncate':
+            m = 0
+        else: # TODO: add support for the append mode
+            raise ValueError("Currently only the 'truncate' mode is supported")
+        
+        try:
+            json_array = json.dumps([prefix_path])
+        except Exception as e:
+            raise ValueError(e)
+        return cast(str, generic_msg(cmd="writeParquet", args="{} {} {} {}".\
+                                     format(self.name, dataset, json_array, self.dtype)))
+    
+    @typechecked
     def register(self, user_defined_name: str) -> pdarray:
         """
         Register this pdarray with a user defined name in the arkouda server

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1096,7 +1096,7 @@ class pdarray:
         >>> a = ak.arange(0, 100, 1)
         >>> a.save_parquet('arkouda_range')
 
-        Array is saved in numLocales files with names like ``tmp/arkouda_range_LOCALE0.hdf``
+        Array is saved in numLocales files with names like ``tmp/arkouda_range_LOCALE0.parquet``
 
         The array can be read back in as follows
 

--- a/benchmarks/graph_infra/arkouda.graph
+++ b/benchmarks/graph_infra/arkouda.graph
@@ -94,6 +94,12 @@ files: IO.dat, IO.dat
 graphtitle: IO Performance
 ylabel: Performance (GiB/s)
 
+perfkeys: write Average rate =, read Average rate =
+graphkeys: Write GiB/s, Read GiB/s
+files: parquetIO.dat, parquetIO.dat
+graphtitle: Parquet IO Performance
+ylabel: Performance (GiB/s)
+
 perfkeys: non-regex with literal substring Average rate =, regex with literal substring Average rate =, regex with pattern Average rate =
 graphkeys: non-regex with literal substring GiB/s, regex with literal substring GiB/s, regex with pattern GiB/s
 files: substring_search.dat, substring_search.dat, substring_search.dat

--- a/benchmarks/graph_infra/parquetIO.perfkeys
+++ b/benchmarks/graph_infra/parquetIO.perfkeys
@@ -1,0 +1,4 @@
+write Average time =
+write Average rate =
+read Average time =
+read Average rate =

--- a/benchmarks/parquetIO.py
+++ b/benchmarks/parquetIO.py
@@ -20,7 +20,7 @@ def time_ak_write_read(N_per_locale, trials, dtype, path, seed):
         end = time.time()
         writetimes.append(end - start)
         start = time.time()
-        b = ak.read_parquet(path)
+        b = ak.read_parquet(path+'*')
         end = time.time()
         readtimes.append(end - start)
         for f in glob(path + '_LOCALE*'):
@@ -40,7 +40,7 @@ def check_correctness(dtype, path, seed):
     a = ak.randint(0, 2**32, N, seed=seed)
 
     a.save_parquet(path)
-    b = ak.read_parquet(path)
+    b = ak.read_parquet(path+'*')
     for f in glob(path + '_LOCALE*'):
         os.remove(f)
     assert (a == b).all()

--- a/benchmarks/parquetIO.py
+++ b/benchmarks/parquetIO.py
@@ -1,0 +1,77 @@
+import time, argparse
+import arkouda as ak
+import os
+from glob import glob
+
+TYPES = ('int64')
+
+def time_ak_write_read(N_per_locale, trials, dtype, path, seed):
+    print(">>> arkouda {} write/read".format(dtype))
+    cfg = ak.get_config()
+    N = N_per_locale * cfg["numLocales"]
+    print("numLocales = {}, N = {:,}".format(cfg["numLocales"], N))
+    a = ak.randint(0, 2**32, N)
+     
+    writetimes = []
+    readtimes = []
+    for i in range(trials):
+        start = time.time()
+        a.save_parquet(path)
+        end = time.time()
+        writetimes.append(end - start)
+        start = time.time()
+        b = ak.read_parquet(path)
+        end = time.time()
+        readtimes.append(end - start)
+        for f in glob(path + '_LOCALE*'):
+            os.remove(f)
+    avgwrite = sum(writetimes) / trials
+    avgread = sum(readtimes) / trials
+
+    print("write Average time = {:.4f} sec".format(avgwrite))
+    print("read Average time = {:.4f} sec".format(avgread))
+
+    nb = a.size * a.itemsize
+    print("write Average rate = {:.2f} GiB/sec".format(nb/2**30/avgwrite))
+    print("read Average rate = {:.2f} GiB/sec".format(nb/2**30/avgread))
+
+def check_correctness(dtype, path, seed):
+    N = 10**4
+    a = ak.randint(0, 2**32, N, seed=seed)
+
+    a.save_parquet(path)
+    b = ak.read_parquet(path)
+    for f in glob(path + '_LOCALE*'):
+        os.remove(f)
+    assert (a == b).all()
+
+def create_parser():
+    parser = argparse.ArgumentParser(description="Measure performance of writing and reading a random array from disk.")
+    parser.add_argument('hostname', help='Hostname of arkouda server')
+    parser.add_argument('port', type=int, help='Port of arkouda server')
+    parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: length of array to write/read')
+    parser.add_argument('-t', '--trials', type=int, default=1, help='Number of times to run the benchmark')
+    parser.add_argument('-d', '--dtype', default='int64', help='Dtype of array ({})'.format(', '.join(TYPES)))
+    parser.add_argument('-p', '--path', default=os.getcwd()+'/ak-pq-test', help='Target path for measuring read/write rates')
+    parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
+    parser.add_argument('-s', '--seed', default=None, type=int, help='Value to initialize random number generator')
+    return parser
+
+if __name__ == "__main__":
+    import sys
+    parser = create_parser()
+    args = parser.parse_args()
+    if args.dtype not in TYPES:
+        raise ValueError("Dtype must be {}, not {}".format('/'.join(TYPES), args.dtype))
+    ak.verbose = False
+    ak.connect(args.hostname, args.port)
+
+    if args.correctness_only:
+        for dtype in TYPES:
+            check_correctness(dtype, args.path, args.seed)
+        sys.exit(0)
+    
+    print("array size = {:,}".format(args.size))
+    print("number of trials = ", args.trials)
+    time_ak_write_read(args.size, args.trials, args.dtype, args.path, args.seed)
+    sys.exit(0)

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -24,6 +24,9 @@ BENCHMARKS = ['stream', 'argsort', 'coargsort', 'groupby', 'aggregate', 'gather'
               'array_transfer', 'IO', 'str-argsort', 'str-coargsort',
               'str-groupby', 'str-gather', 'substring_search', 'flatten']
 
+if os.getenv('ARKOUDA_SERVER_PARQUET_SUPPORT'):
+    BENCHMARKS.append('parquetIO')
+
 def get_chpl_util_dir():
     """ Get the Chapel directory that contains graph generation utilities. """
     CHPL_HOME = os.getenv('CHPL_HOME')

--- a/dep/checkArrow.chpl
+++ b/dep/checkArrow.chpl
@@ -1,0 +1,7 @@
+use Parquet;
+
+proc main() {
+  var ArrowVersion = getVersionInfo();
+  writeln("Found Arrow version: ", ArrowVersion);
+  return 0;
+}

--- a/pytest.ini
+++ b/pytest.ini
@@ -27,6 +27,7 @@ testpaths =
     tests/string_test.py
     tests/where_test.py
     tests/extrema_test.py
+    tests/parquet_test.py
 norecursedirs = .git dist build *egg* tests/deprecated/*
 python_functions = test*
 env =

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,1 +1,2 @@
 TAGS
+ArrowFunctions.o

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -6,6 +6,15 @@
 #include <parquet/arrow/reader.h>
 #include <parquet/arrow/writer.h>
 
+/*
+ C++ functions
+ -------------
+ These C++ functions are used to call into the Arrow library
+ and are then called to by their corresponding C functions to
+ allow interoperability with Chapel. This means that all of the
+ C++ functions must return types that are C compatible.
+*/
+
 int cpp_getNumRows(const char* filename) {
   std::shared_ptr<arrow::io::ReadableFile> infile;
   PARQUET_ASSIGN_OR_THROW(
@@ -120,6 +129,16 @@ const char* cpp_getVersionInfo(void) {
 void cpp_free_string(void* ptr) {
   free(ptr);
 }
+
+/*
+ C functions
+ -----------
+ These C functions provide no functionality, since the C++
+ Arrow library is being used, they merely call the C++ functions
+ to allow Chapel to call the C++ functions through C interoperability.
+ Each Arrow function must have a corresponding C function if wished
+ to be called by Chapel.
+*/
 
 extern "C" {
   int c_getNumRows(const char* chpl_str) {

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -1,0 +1,151 @@
+#include "ArrowFunctions.h"
+
+#include <iostream>
+#include <arrow/api.h>
+#include <arrow/io/api.h>
+#include <parquet/arrow/reader.h>
+#include <parquet/arrow/writer.h>
+
+int cpp_getNumRows(const char* filename) {
+  std::shared_ptr<arrow::io::ReadableFile> infile;
+  PARQUET_ASSIGN_OR_THROW(
+      infile,
+      arrow::io::ReadableFile::Open(filename,
+                                    arrow::default_memory_pool()));
+
+  std::unique_ptr<parquet::arrow::FileReader> reader;
+  PARQUET_THROW_NOT_OK(
+    parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &reader));
+  return reader -> parquet_reader() -> metadata() -> num_rows();
+}
+
+int cpp_getType(const char* filename, const char* colname) {
+  std::shared_ptr<arrow::io::ReadableFile> infile;
+  PARQUET_ASSIGN_OR_THROW(
+      infile,
+      arrow::io::ReadableFile::Open(filename,
+                                    arrow::default_memory_pool()));
+
+  std::unique_ptr<parquet::arrow::FileReader> reader;
+  PARQUET_THROW_NOT_OK(
+      parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &reader));
+
+  std::shared_ptr<arrow::Schema> sc;
+  std::shared_ptr<arrow::Schema>* out = &sc;
+  PARQUET_THROW_NOT_OK(reader->GetSchema(out));
+
+  int idx = sc -> GetFieldIndex(colname);
+  if(idx == -1) // TODO: error colname not in schema
+    idx = 0;
+  auto myType = sc -> field(idx) -> type();
+
+  if(myType == arrow::int64())
+    return ARROWINT64;
+  else if(myType == arrow::int32())
+    return ARROWINT32;
+  else // TODO: error type not supported
+    return ARROWUNDEFINED;
+}
+
+void cpp_readColumnByName(const char* filename, void* chpl_arr, const char* colname, int numElems) {
+  auto chpl_ptr = (int64_t*)chpl_arr;
+
+  std::shared_ptr<arrow::io::ReadableFile> infile;
+  PARQUET_ASSIGN_OR_THROW(
+      infile,
+      arrow::io::ReadableFile::Open(filename,
+                                    arrow::default_memory_pool()));
+
+  std::unique_ptr<parquet::arrow::FileReader> reader;
+  PARQUET_THROW_NOT_OK(
+      parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &reader));
+  std::shared_ptr<arrow::ChunkedArray> array;
+
+  std::shared_ptr<arrow::Schema> sc;
+  std::shared_ptr<arrow::Schema>* out = &sc;
+  PARQUET_THROW_NOT_OK(reader->GetSchema(out));
+
+  auto idx = sc -> GetFieldIndex(colname);
+
+  // TODO: error: schema does not contain dsetname
+  if(idx == -1)
+    idx = 0;
+
+  PARQUET_THROW_NOT_OK(reader->ReadColumn(idx, &array));
+
+  int ty = cpp_getType(filename, colname);
+  std::shared_ptr<arrow::Array> regular = array->chunk(0);
+
+  if(ty == ARROWINT64) {
+    auto int_arr = std::static_pointer_cast<arrow::Int64Array>(regular);
+
+    for(int i = 0; i < numElems; i++)
+      chpl_ptr[i] = int_arr->Value(i);
+  } else if(ty == ARROWINT32) {
+      auto int_arr = std::static_pointer_cast<arrow::Int32Array>(regular);
+
+      for(int i = 0; i < numElems; i++)
+        chpl_ptr[i] = int_arr->Value(i);
+  }
+}
+
+void cpp_writeColumnToParquet(const char* filename, void* chpl_arr,
+                              int colnum, const char* dsetname, int numelems,
+                              int rowGroupSize) {
+  auto chpl_ptr = (int64_t*)chpl_arr;
+  arrow::Int64Builder i64builder;
+  for(int i = 0; i < numelems; i++)
+    PARQUET_THROW_NOT_OK(i64builder.AppendValues({chpl_ptr[i]}));
+  std::shared_ptr<arrow::Array> i64array;
+  PARQUET_THROW_NOT_OK(i64builder.Finish(&i64array));
+
+  std::shared_ptr<arrow::Schema> schema = arrow::schema(
+                 {arrow::field(dsetname, arrow::int64())});
+
+  auto table = arrow::Table::Make(schema, {i64array});
+
+  std::shared_ptr<arrow::io::FileOutputStream> outfile;
+  PARQUET_ASSIGN_OR_THROW(
+      outfile,
+      arrow::io::FileOutputStream::Open(filename));
+
+  PARQUET_THROW_NOT_OK(
+      parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), outfile, rowGroupSize));
+}
+
+const char* cpp_getVersionInfo(void) {
+  return strdup(arrow::GetBuildInfo().version_string.c_str());
+}
+
+void cpp_free_string(void* ptr) {
+  free(ptr);
+}
+
+extern "C" {
+  int c_getNumRows(const char* chpl_str) {
+    return cpp_getNumRows(chpl_str);
+  }
+
+  void c_readColumnByName(const char* filename, void* chpl_arr, const char* colname, int numElems) {
+    cpp_readColumnByName(filename, chpl_arr, colname, numElems);
+  }
+
+  int c_getType(const char* filename, const char* colname) {
+    return cpp_getType(filename, colname);
+  }
+
+  void c_writeColumnToParquet(const char* filename, void* chpl_arr,
+                              int colnum, const char* dsetname, int numelems,
+                              int rowGroupSize) {
+    cpp_writeColumnToParquet(filename, chpl_arr, colnum, dsetname,
+                             numelems, rowGroupSize);
+  }
+
+  const char* c_getVersionInfo(void) {
+    return cpp_getVersionInfo();
+  }
+
+  void c_free_string(void* ptr) {
+    cpp_free_string(ptr);
+  }
+}

--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -1,3 +1,4 @@
+// Wrap functions in C extern if compiling C++ object file
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -5,7 +6,11 @@ extern "C" {
   #define ARROWINT64 0
   #define ARROWINT32 1
   #define ARROWUNDEFINED -1
-  
+
+  // Each C++ function contains the actual implementation of the
+  // functionality, and there is a corresponding C function that
+  // Chapel can call into through C interoperability, since there
+  // is no C++ interoperability supported in Chapel today.
   int c_getNumRows(const char*);
   int cpp_getNumRows(const char*);
 

--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -1,0 +1,35 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+  #define ARROWINT64 0
+  #define ARROWINT32 1
+  #define ARROWUNDEFINED -1
+  
+  int c_getNumRows(const char*);
+  int cpp_getNumRows(const char*);
+
+  void c_readColumnByName(const char* filename, void* chpl_arr,
+                          const char* colname, int numElems);
+  void cpp_readColumnByName(const char* filename, void* chpl_arr,
+                            const char* colname, int numElems);
+
+  int c_getType(const char* filename, const char* colname);
+  int cpp_getType(const char* filename, const char* colname);
+
+  void cpp_writeColumnToParquet(const char* filename, void* chpl_arr,
+                               int colnum, const char* dsetname, int numelems,
+                               int rowGroupSize);
+  void c_writeColumnToParquet(const char* filename, void* chpl_arr,
+                             int colnum, const char* dsetname, int numelems,
+                             int rowGroupSize);;
+    
+  const char* c_getVersionInfo(void);
+  const char* cpp_getVersionInfo(void);
+
+  void c_free_string(void* ptr);
+  void cpp_free_string(void* ptr);
+  
+#ifdef __cplusplus
+}
+#endif

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -715,7 +715,7 @@ module GenSymIO {
                     gsLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
                     return new MsgTuple(errorMsg, MsgType.ERROR);
                 }
-                var tmp = glob(filelist[0]+"*");
+                var tmp = glob(filelist[0]);
                 gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                       "glob expanded %s to %i files".format(filelist[0], tmp.size));
                 if tmp.size == 0 {

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -736,7 +736,7 @@ module GenSymIO {
             var fileErrorMsg:string = "";
             var sizes: [filedom] int;
             var ty = getArrType(filenames[filedom.low],
-                                dsetlist[dsetdom.low]);;
+                                dsetlist[dsetdom.low]);
             var rnames: list((string, string, string)); // tuple (dsetName, item type, id)
 
             for dsetname in dsetnames do {

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -645,6 +645,168 @@ module GenSymIO {
         return new MsgTuple(repMsg,MsgType.NORMAL);
     }
 
+    proc readAllParquetMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+        if !hasParquetSupport {
+            throw getErrorWithContext(
+                   msg="Arkouda has been built without Parquet support",
+                   lineNumber=getLineNumber(),
+                   routineName=getRoutineName(), 
+                   moduleName=getModuleName(),
+                   errorClass="ParquetBuildError");
+        } else {
+            use Parquet;
+            var repMsg: string;
+            // May need a more robust delimiter then " | "
+            var (strictFlag, ndsetsStr, nfilesStr, allowErrorsFlag, arraysStr) = payload.splitMsgToTuple(5);
+            var strictTypes: bool = true;
+            if (strictFlag.toLower().strip() == "false") {
+              strictTypes = false;
+            }
+
+            var allowErrors: bool = "true" == allowErrorsFlag.toLower(); // default is false
+            if allowErrors {
+                gsLogger.warn(getModuleName(), getRoutineName(), getLineNumber(), "Allowing file read errors");
+            }
+
+            // Test arg casting so we can send error message instead of failing
+            if (!checkCast(ndsetsStr, int)) {
+                var errMsg = "Number of datasets:`%s` could not be cast to an integer".format(ndsetsStr);
+                gsLogger.error(getModuleName(), getRoutineName(), getLineNumber(), errMsg);
+                return new MsgTuple(errMsg, MsgType.ERROR);
+            }
+            if (!checkCast(nfilesStr, int)) {
+              var errMsg = "Number of files:`%s` could not be cast to an integer".format(nfilesStr);
+              gsLogger.error(getModuleName(), getRoutineName(), getLineNumber(), errMsg);
+              return new MsgTuple(errMsg, MsgType.ERROR);
+            }
+
+            var (jsondsets, jsonfiles) = arraysStr.splitMsgToTuple(" | ",2);
+            var ndsets = ndsetsStr:int; // Error checked above
+            var nfiles = nfilesStr:int; // Error checked above
+            var dsetlist: [0..#ndsets] string;
+            var filelist: [0..#nfiles] string;
+
+            try {
+                dsetlist = jsonToPdArray(jsondsets, ndsets);
+            } catch {
+                var errorMsg = "Could not decode json dataset names via tempfile (%i files: %s)".format(
+                                                   1, jsondsets);
+                gsLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+
+            try {
+                filelist = jsonToPdArray(jsonfiles, nfiles);
+            } catch {
+                var errorMsg = "Could not decode json filenames via tempfile (%i files: %s)".format(nfiles, jsonfiles);
+                gsLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+
+            var dsetdom = dsetlist.domain;
+            var filedom = filelist.domain;
+            var dsetnames: [dsetdom] string;
+            var filenames: [filedom] string;
+            dsetnames = dsetlist;
+
+            if filelist.size == 1 {
+                if filelist[0].strip().size == 0 {
+                    var errorMsg = "filelist was empty.";
+                    gsLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                    return new MsgTuple(errorMsg, MsgType.ERROR);
+                }
+                var tmp = glob(filelist[0]+"*");
+                gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                      "glob expanded %s to %i files".format(filelist[0], tmp.size));
+                if tmp.size == 0 {
+                    var errorMsg = "The wildcarded filename %s either corresponds to files inaccessible to Arkouda or files of an invalid format".format(filelist[0]);
+                    gsLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                    return new MsgTuple(errorMsg, MsgType.ERROR);
+                }
+                // Glob returns filenames in weird order. Sort for consistency
+                sort(tmp);
+                filedom = tmp.domain;
+                filenames = tmp;
+            } else {
+                filenames = filelist;
+            }
+
+            var fileErrors: list(string);
+            var fileErrorCount:int = 0;
+            var fileErrorMsg:string = "";
+            var sizes: [filedom] int;
+            var ty = getArrType(filenames[filedom.low],
+                                dsetlist[dsetdom.low]);;
+            var rnames: list((string, string, string)); // tuple (dsetName, item type, id)
+
+            for dsetname in dsetnames do {
+                for (i, fname) in zip(filedom, filenames) {
+                    var hadError = false;
+                    try {
+                        // not using the type for now since it is only implemented for ints
+                        // also, since Parquet files have a `numRows` that isn't specifc
+                        // to dsetname like for HDF5, we only need to get this once per
+                        // file, regardless of how many datasets we are reading
+                        sizes[i] = getArrSize(fname);
+                    } catch e: FileNotFoundError {
+                        fileErrorMsg = "File %s not found".format(fname);
+                        gsLogger.error(getModuleName(),getRoutineName(),getLineNumber(),fileErrorMsg);
+                        hadError = true;
+                        if !allowErrors { return new MsgTuple(fileErrorMsg, MsgType.ERROR); }
+                    } catch e: PermissionError {
+                        fileErrorMsg = "Permission error %s opening %s".format(e.message(),fname);
+                        gsLogger.error(getModuleName(),getRoutineName(),getLineNumber(),fileErrorMsg);
+                        hadError = true;
+                        if !allowErrors { return new MsgTuple(fileErrorMsg, MsgType.ERROR); }
+                    } catch e: DatasetNotFoundError {
+                        fileErrorMsg = "Dataset %s not found in file %s".format(dsetname,fname);
+                        gsLogger.error(getModuleName(),getRoutineName(),getLineNumber(),fileErrorMsg);
+                        hadError = true;
+                        if !allowErrors { return new MsgTuple(fileErrorMsg, MsgType.ERROR); }
+                    } catch e: SegArrayError {
+                        fileErrorMsg = "SegmentedArray error: %s".format(e.message());
+                        gsLogger.error(getModuleName(),getRoutineName(),getLineNumber(),fileErrorMsg);
+                        hadError = true;
+                        if !allowErrors { return new MsgTuple(fileErrorMsg, MsgType.ERROR); }
+                    } catch e : Error {
+                        fileErrorMsg = "Other error in accessing file %s: %s".format(fname,e.message());
+                        gsLogger.error(getModuleName(),getRoutineName(),getLineNumber(),fileErrorMsg);
+                        hadError = true;
+                        if !allowErrors { return new MsgTuple(fileErrorMsg, MsgType.ERROR); }
+                    }
+
+                    // This may need to be adjusted for this all-in-one approach
+                    if hadError {
+                      // Keep running total, but we'll only report back the first 10
+                      if fileErrorCount < 10 {
+                        fileErrors.append(fileErrorMsg.replace("\n", " ").replace("\r", " ").replace("\t", " ").strip());
+                      }
+                      fileErrorCount += 1;
+                    }
+                }
+                // This is handled in the readFilesByName() function
+                var subdoms: [filedom] domain(1);
+                var len: int;
+                var nSeg: int;
+                len = + reduce sizes;
+
+                // Only integer is implemented for now, do nothing if the Parquet
+                // file has a different type
+                if ty == ArrowTypes.int64 || ty == ArrowTypes.int32 {
+                  var entryVal = new shared SymEntry(len, int);
+                  readFilesByName(entryVal.a, filenames, sizes, dsetname);
+                  var valName = st.nextName();
+                  st.addEntry(valName, entryVal);
+                  rnames.append((dsetname, "pdarray", valName));
+                }
+            }
+
+            repMsg = _buildReadAllHdfMsgJson(rnames, false, 0, fileErrors, st);
+            gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+            return new MsgTuple(repMsg,MsgType.NORMAL);
+        }
+    }
+    
     /**
      * Construct json object to be returned from readAllHdfMsg
      * :arg rnames: List of (DataSetName, arkouda_type, id of SymEntry) for items read from HDF5 files
@@ -1237,6 +1399,71 @@ module GenSymIO {
         }
     }
 
+    proc toparquetMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+        if !hasParquetSupport {
+            throw getErrorWithContext(
+                   msg="Arkouda has been built without Parquet support",
+                   lineNumber=getLineNumber(),
+                   routineName=getRoutineName(), 
+                   moduleName=getModuleName(),
+                   errorClass="ParquetBuildError");
+        } else {
+            use Parquet;
+            var (arrayName, dsetname,  jsonfile, dataType)= payload.splitMsgToTuple(4);
+            var filename: string;
+            var entry = st.lookup(arrayName);
+
+            try {
+              filename = jsonToPdArray(jsonfile, 1)[0];
+            } catch {
+              var errorMsg = "Could not decode json filenames via tempfile " +
+                "(%i files: %s)".format(1, jsonfile);
+              gsLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+              return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+
+            var warnFlag: bool;
+
+            try {
+              select entry.dtype {
+                  when DType.Int64 {
+                    var e = toSymEntry(entry, int);
+                    warnFlag = write1DDistArrayParquet(filename, dsetname, e.a);
+                  }
+                  otherwise {
+                    var errorMsg = "Writing Parquet files is only supported for int arrays";
+                    gsLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                    return new MsgTuple(errorMsg, MsgType.ERROR);
+                  }
+                }
+            } catch e: FileNotFoundError {
+              var errorMsg = "Unable to open %s for writing: %s".format(filename,e.message());
+              gsLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+              return new MsgTuple(errorMsg, MsgType.ERROR);
+            } catch e: MismatchedAppendError {
+              var errorMsg = "Mismatched append %s".format(e.message());
+              gsLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+              return new MsgTuple(errorMsg, MsgType.ERROR);
+            } catch e: WriteModeError {
+              var errorMsg = "Write mode error %s".format(e.message());
+              gsLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+              return new MsgTuple(errorMsg, MsgType.ERROR);
+            } catch e: Error {
+              var errorMsg = "problem writing to file %s".format(e);
+              gsLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+              return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+            if warnFlag {
+              var warnMsg = "Warning: possibly overwriting existing files matching filename pattern";
+              return new MsgTuple(warnMsg, MsgType.WARNING);
+            } else {
+              var repMsg = "wrote array to file";
+              gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+        }
+    }
+    
     /*
      * Writes out the two pdarrays composing a Strings object to hdf5.
      */

--- a/src/Parquet.chpl
+++ b/src/Parquet.chpl
@@ -1,0 +1,109 @@
+module Parquet {
+  use SysCTypes, CPtr, IO;
+  use ServerErrors, ServerConfig;
+  if hasParquetSupport {
+    require "ArrowFunctions.h";
+    require "ArrowFunctions.o";
+  }
+
+  private config const ROWGROUPS = 512*1024*1024 / numBytes(int); // 512 mb of int64
+
+  extern var ARROWINT64: c_int;
+  extern var ARROWINT32: c_int;
+  extern var ARROWUNDEFINED: c_int;
+
+  enum ArrowTypes { int64, int32, notimplemented };
+  
+  proc getVersionInfo() {
+    extern proc c_getVersionInfo(): c_string;
+    extern proc strlen(str): c_int;
+    extern proc c_free_string(ptr);
+    var cVersionString = c_getVersionInfo();
+    defer {
+      c_free_string(cVersionString: c_void_ptr);
+    }
+    var ret = try! createStringWithNewBuffer(cVersionString,
+                                             strlen(cVersionString));
+    return ret;
+  }
+  
+  proc getSubdomains(lengths: [?FD] int) {
+    var subdoms: [FD] domain(1);
+    var offset = 0;
+    for i in FD {
+      subdoms[i] = {offset..#lengths[i]};
+      offset += lengths[i];
+    }
+    return (subdoms, (+ reduce lengths));
+  }
+
+  proc domain_intersection(d1: domain(1), d2: domain(1)) {
+    var low = max(d1.low, d2.low);
+    var high = min(d1.high, d2.high);
+    if (d1.stride !=1) && (d2.stride != 1) {
+      //TODO: change this to throw
+      halt("At least one domain must have stride 1");
+    }
+    var stride = max(d1.stride, d2.stride);
+    return {low..high by stride};
+  }
+  
+  proc readFilesByName(A, filenames: [] string, sizes: [] int, dsetname: string) {
+    extern proc c_readColumnByName(filename, chpl_arr, colNum, numElems);
+    var (subdoms, length) = getSubdomains(sizes);
+
+    coforall loc in A.targetLocales() do on loc {
+      var locFiles = filenames;
+      var locFiledoms = subdoms;
+      for (filedom, filename) in zip(locFiledoms, locFiles) {
+        for locdom in A.localSubdomains() {
+          const intersection = domain_intersection(locdom, filedom);
+          if intersection.size > 0 {
+            var col: [filedom] int;
+            // TODO: errors
+            c_readColumnByName(filename.localize().c_str(), c_ptrTo(col), dsetname.localize().c_str(), filedom.size);
+            A[filedom] = col;
+          }
+        }
+      }
+    }
+  }
+
+  proc getArrSize(filename: string) {
+    extern proc c_getNumRows(chpl_str): int;
+    var size = c_getNumRows(filename.localize().c_str());
+    return size;
+  }
+
+  proc getArrType(filename: string, colname: string) {
+    extern proc c_getType(filename, colname): c_int;
+    var arrType = c_getType(filename.localize().c_str(),
+                            colname.localize().c_str());
+    if arrType == ARROWINT64 then return ArrowTypes.int64;
+    else if arrType == ARROWINT32 then return ArrowTypes.int32;
+    return ArrowTypes.notimplemented;
+  }
+
+  proc writeDistArrayToParquet(A, filename, dsetname, rowGroupSize) {
+    extern proc c_writeColumnToParquet(filename, chpl_arr, colnum,
+                                     dsetname, numelems, rowGroupSize);
+    var filenames: [0..#A.targetLocales().size] string;
+    for i in 0..#A.targetLocales().size {
+      var suffix = i: string;
+      filenames[i] = filename + "_LOCALE" + suffix + ".parquet";
+    }
+
+    coforall (loc, idx) in zip(A.targetLocales(), filenames.domain) do on loc {
+        const myFilename = filenames[idx];
+
+        var locDom = A.localSubdomain();
+        var locArr = A[locDom];
+        c_writeColumnToParquet(myFilename.localize().c_str(), c_ptrTo(locArr), 0, dsetname.localize().c_str(), locDom.size, rowGroupSize);
+      }
+  }
+
+  proc write1DDistArrayParquet(filename: string, dsetname, A) {
+    writeDistArrayToParquet(A, filename, dsetname, ROWGROUPS);
+    return false;
+  }
+}

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -62,6 +62,9 @@ module ServerConfig
     */
     config param regexMaxCaptures = 20;
 
+    /* Whether the server was built with parquet support */
+    config param hasParquetSupport = false;
+
     private config const lLevel = ServerConfig.logLevel;
     const scLogger = new Logger(lLevel);
    

--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -321,6 +321,8 @@ proc main() {
                 when "segmentedFlatten"  {repTuple = segFlattenMsg(cmd, args, st);}
                 when "lshdf"             {repTuple = lshdfMsg(cmd, args, st);}
                 when "readAllHdf"        {repTuple = readAllHdfMsg(cmd, args, st);}
+                when "readAllParquet"    {repTuple = readAllParquetMsg(cmd, args, st);}
+                when "writeParquet"      {repTuple = toparquetMsg(cmd, args, st);}
                 when "tohdf"             {repTuple = tohdfMsg(cmd, args, st);}
                 when "create"            {repTuple = createMsg(cmd, args, st);}
                 when "delete"            {repTuple = deleteMsg(cmd, args, st);}

--- a/test/UnitTestParquetCpp.chpl
+++ b/test/UnitTestParquetCpp.chpl
@@ -1,0 +1,80 @@
+use Parquet, SysCTypes, CPtr, FileSystem;
+use UnitTest;
+use TestBase;
+
+proc testReadWrite(filename: c_string, dsetname: c_string, size: int) {
+  extern proc c_readColumnByName(filename, chpl_arr, colNum, numElems);
+  extern proc c_writeColumnToParquet(filename, chpl_arr, colnum,
+                                     dsetname, numelems, rowGroupSize);
+  var a: [0..#size] int;
+  for i in 0..#size do a[i] = i;
+  c_writeColumnToParquet(filename, c_ptrTo(a), 0, dsetname, size, 10000);
+
+  var b: [0..#size] int;
+  
+  c_readColumnByName(filename, c_ptrTo(b), dsetname, size);
+  if a.equals(b) {
+    return 0;
+  } else {
+    writeln("FAILED: read/write");
+    return 1;
+  }
+}
+
+proc testGetNumRows(filename: c_string, expectedSize: int) {
+  extern proc c_getNumRows(chpl_str): int;
+  var size = c_getNumRows(filename);
+  if size == expectedSize {
+    return 0;
+  } else {
+    writeln("FAILED: c_getNumRows");
+    return 1;
+  }
+}
+
+proc testGetType(filename: c_string, dsetname: c_string) {
+  extern proc c_getType(filename, colname): c_int;
+  var arrowType = c_getType(filename, dsetname);
+
+  // a positive value corresponds to an arrow type
+  // -1 corresponds to unsupported type
+  if arrowType >= 0 {
+    return 0;
+  } else {
+    writeln("FAILED: c_getType with ", arrowType);
+    return 1;
+  }
+}
+
+proc testVersionInfo() {
+  extern proc c_getVersionInfo(): c_string;
+  extern proc c_free_string(ptr);
+  var cVersionString = c_getVersionInfo();
+  defer {
+    c_free_string(cVersionString);
+  }
+  var ret;
+  try! ret = createStringWithNewBuffer(cVersionString);
+  if ret[0]: int >= 5 {
+    return 0;
+  } else {
+    return 1;
+  }
+}
+proc main() {
+  var errors = 0;
+
+  const size = 1000;
+  const filename = "myFile.parquet".c_str();
+  const dsetname = "my-dset-name-test".c_str();
+  
+  errors += testReadWrite(filename, dsetname, size);
+  errors += testGetNumRows(filename, size);
+  errors += testGetType(filename, dsetname);
+  errors += testVersionInfo();
+
+  if errors != 0 then
+    writeln(errors, " Parquet tests failed");
+
+  remove("myFile.parquet");
+}

--- a/test/UnitTestParquetCpp.compopts
+++ b/test/UnitTestParquetCpp.compopts
@@ -1,0 +1,1 @@
+-shasParquetSupport

--- a/test/UnitTestParquetCpp.skipif
+++ b/test/UnitTestParquetCpp.skipif
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+if [[ -n $CHPL_HOME ]]; then
+  export PATH="$PATH:$CHPL_HOME/bin/$CHPL_HOST_BIN_SUBDIR"
+fi
+
+PARENT_DIR=$(dirname $(cd $(dirname $0) ; pwd))
+ARKOUDA_HOME=${ARKOUDA_HOME:-$PARENT_DIR}
+
+compile() {
+  make -C ../ compile-arrow-cpp > /dev/null 2> /dev/null
+
+  if [ $? -eq 0 ]; then
+      echo False
+  else
+      echo True
+  fi
+}
+compile

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -7,47 +7,29 @@ SIZE = 50
 NUMFILES = 5
 verbose = True
 
-def compare_values(arr1, arr2):
-    if (arr1 != arr2).all():
-        print("Arrays do not match")
-        return 1
-    return 0
-
-def run_parquet_test(verbose=True):
-    ak_arr = ak.randint(0, 2**32, SIZE)
-    ak_arr.save_parquet("pq_testcorrect", "my-dset")
-    pq_arr = ak.read_parquet("pq_testcorrect*", "my-dset")
-    # get the dset from the dictionary in multi-locale cases
-    for f in glob.glob('pq_test*'):
-        os.remove(f)
-    return compare_values(ak_arr, pq_arr)
-
-def run_parquet_multi_file_test(verbose=True):
-    adjusted_size = int(SIZE/NUMFILES)*NUMFILES
-    failures = 0
-    test_arrs = []
-    for i in range(NUMFILES):
-        test_arrs.append(ak.randint(0, 2**32, int(adjusted_size/NUMFILES)))
-        test_arrs[i].save_parquet("pq_test" + str(i), "test-dset")
-
-    pq_arr = ak.read_parquet("pq_test*", "test-dset")
-    if len(pq_arr) != adjusted_size:
-        print('Size of array read in was', str(len(pq_arr)), 'but should be', adjusted_size)
-        failures += 1
-
-    for i in range(NUMFILES):
-        sz = len(test_arrs[i])
-        failures += compare_values(test_arrs[i], pq_arr[(i*sz):(i*sz)+sz])
-    for f in glob.glob('pq_test*'):
-        os.remove(f)
-    return failures
-
-
-
 @pytest.mark.skipif(not os.getenv('ARKOUDA_SERVER_PARQUET_SUPPORT'), reason="No parquet support")
 class ParquetTest(ArkoudaTest):
     def test_parquet(self):
-        self.assertEqual(run_parquet_test(), 0)
+        ak_arr = ak.randint(0, 2**32, SIZE)
+        ak_arr.save_parquet("pq_testcorrect", "my-dset")
+        pq_arr = ak.read_parquet("pq_testcorrect*", "my-dset")
+        # get the dset from the dictionary in multi-locale cases
+        for f in glob.glob('pq_test*'):
+            os.remove(f)
+            self.assertTrue((ak_arr ==  pq_arr).all())
 
     def test_multi_file(self):
-        self.assertEqual(run_parquet_multi_file_test(), 0)
+        adjusted_size = int(SIZE/NUMFILES)*NUMFILES
+        test_arrs = []
+        for i in range(NUMFILES):
+            test_arrs.append(ak.randint(0, 2**32, int(adjusted_size/NUMFILES)))
+            test_arrs[i].save_parquet("pq_test" + str(i), "test-dset")
+
+        pq_arr = ak.read_parquet("pq_test*", "test-dset")
+        self.assertTrue(len(pq_arr) == adjusted_size)
+
+        for i in range(NUMFILES):
+            sz = len(test_arrs[i])
+            self.assertTrue((test_arrs[i] == pq_arr[(i*sz):(i*sz)+sz]).all())
+        for f in glob.glob('pq_test*'):
+            os.remove(f)

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -8,16 +8,15 @@ NUMFILES = 5
 verbose = True
 
 def compare_values(arr1, arr2):
-    for i in range(len(arr1)):
-        if arr1[i] != arr2[i]:
-            print(arr1[i], 'does not match', arr2[i], 'at index', i)
-            return 1
+    if (arr1 != arr2).all():
+        print("Arrays do not match")
+        return 1
     return 0
 
 def run_parquet_test(verbose=True):
     ak_arr = ak.randint(0, 2**32, SIZE)
     ak_arr.save_parquet("pq_testcorrect", "my-dset")
-    pq_arr = ak.read_parquet("pq_testcorrect", "my-dset")
+    pq_arr = ak.read_parquet("pq_testcorrect*", "my-dset")
     # get the dset from the dictionary in multi-locale cases
     for f in glob.glob('pq_test*'):
         os.remove(f)
@@ -31,7 +30,7 @@ def run_parquet_multi_file_test(verbose=True):
         test_arrs.append(ak.randint(0, 2**32, int(adjusted_size/NUMFILES)))
         test_arrs[i].save_parquet("pq_test" + str(i), "test-dset")
 
-    pq_arr = ak.read_parquet("pq_test", "test-dset")
+    pq_arr = ak.read_parquet("pq_test*", "test-dset")
     if len(pq_arr) != adjusted_size:
         print('Size of array read in was', str(len(pq_arr)), 'but should be', adjusted_size)
         failures += 1

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -1,0 +1,54 @@
+import glob, os
+from context import arkouda as ak
+from base_test import ArkoudaTest
+import pytest
+
+SIZE = 50
+NUMFILES = 5
+verbose = True
+
+def compare_values(arr1, arr2):
+    for i in range(len(arr1)):
+        if arr1[i] != arr2[i]:
+            print(arr1[i], 'does not match', arr2[i], 'at index', i)
+            return 1
+    return 0
+
+def run_parquet_test(verbose=True):
+    ak_arr = ak.randint(0, 2**32, SIZE)
+    ak_arr.save_parquet("pq_testcorrect", "my-dset")
+    pq_arr = ak.read_parquet("pq_testcorrect", "my-dset")
+    # get the dset from the dictionary in multi-locale cases
+    for f in glob.glob('pq_test*'):
+        os.remove(f)
+    return compare_values(ak_arr, pq_arr)
+
+def run_parquet_multi_file_test(verbose=True):
+    adjusted_size = int(SIZE/NUMFILES)*NUMFILES
+    failures = 0
+    test_arrs = []
+    for i in range(NUMFILES):
+        test_arrs.append(ak.randint(0, 2**32, int(adjusted_size/NUMFILES)))
+        test_arrs[i].save_parquet("pq_test" + str(i), "test-dset")
+
+    pq_arr = ak.read_parquet("pq_test", "test-dset")
+    if len(pq_arr) != adjusted_size:
+        print('Size of array read in was', str(len(pq_arr)), 'but should be', adjusted_size)
+        failures += 1
+
+    for i in range(NUMFILES):
+        sz = len(test_arrs[i])
+        failures += compare_values(test_arrs[i], pq_arr[(i*sz):(i*sz)+sz])
+    for f in glob.glob('pq_test*'):
+        os.remove(f)
+    return failures
+
+
+
+@pytest.mark.skipif(not os.getenv('ARKOUDA_SERVER_PARQUET_SUPPORT'), reason="No parquet support")
+class ParquetTest(ArkoudaTest):
+    def test_parquet(self):
+        self.assertEqual(run_parquet_test(), 0)
+
+    def test_multi_file(self):
+        self.assertEqual(run_parquet_multi_file_test(), 0)


### PR DESCRIPTION
This PR adds the ability to read and write int64 Parquet files in Arkouda through a `pdarray.save_parquet()` function and an `ak.read_parquet()` function. These functions behave in much the same way as the `pdarray.save()` and `ak.load()` functions (see docstrings). This is only the initial support, and more dtypes will likely be added as use necessitates.

For reading Parquet files, the Arrow C++ library was chosen due to library completeness and portability. The actual functionality is written in C++, with light C wrappers to allow leveraging of the Chapel C interoperability features, which requires the C++ code to be compiled into an object file prior to calling the functions within Chapel.

On the Chapel side, the functionality is modeled off of the HDF5 code, but currently only supports int64 and int32 Arrow datatypes, which are read into int64 pdarrays.

Performance numbers collected on a single node Cray CS:
Function  | Parquet (GiB/s) | HDF5 (GiB/s)
-- | -- | --
Read | 0.65 | 2.29
Write | 0.11 | 2.81

Potential next steps:
- Better error handling
- Improve performance
- Extend to support more reading of Arrow types to pdarrays
- Extend to support Arkouda Strings
- Support append mode
- Auto detect arrow/parquet support

Parquet as an optional dependency:
Running a `make` with this PR will build Arkouda as normal, without requiring Arrow. Only when the environment variable `ARKOUDA_SERVER_PARQUET_SUPPORT` is set will the Arrow-requiring files be pulled into the build. This functions in much the same way as ZMQ and HDF5, where the path can be specified in `Makefile.paths` and there is a provided `make install-arrow` command to download Arrow from offline and build from source.

Closes https://github.com/Bears-R-Us/arkouda/issues/903