### PR TITLE
In1d benchmark

### DIFF
--- a/benchmarks/graph_infra/arkouda-string.graph
+++ b/benchmarks/graph_infra/arkouda-string.graph
@@ -21,3 +21,9 @@ graphkeys: Gather GiB/s
 files: str-gather.dat
 graphtitle: String Gather Performance
 ylabel: Performance (GiB/s)
+
+perfkeys: Medium average rate =, Large average rate =
+graphkeys: Medium GiB/s, Large GiB/s
+files: str-in1d.dat, str-in1d.dat
+graphtitle: String in1d Performance
+ylabel: Performance (GiB/s)

--- a/benchmarks/graph_infra/arkouda.graph
+++ b/benchmarks/graph_infra/arkouda.graph
@@ -64,6 +64,12 @@ files: reduce.dat, reduce.dat, reduce.dat, reduce.dat
 graphtitle: Reduce Performance
 ylabel: Performance (GiB/s)
 
+perfkeys: Medium average rate =, Large average rate =
+graphkeys: Medium GiB/s, Large GiB/s
+files: in1d.dat, in1d.dat
+graphtitle: in1d Performance
+ylabel: Performance (GiB/s)
+
 perfkeys: intersect1d Average rate =, union1d Average rate =, setxor1d Average rate =, setdiff1d Average rate =
 graphkeys: Intersect GiB/s, Union GiB/s, Xor GiB/s, Diff GiB/s
 files: setops.dat, setops.dat, setops.dat, setops.dat

--- a/benchmarks/graph_infra/in1d.perfkeys
+++ b/benchmarks/graph_infra/in1d.perfkeys
@@ -1,0 +1,4 @@
+Medium average time =
+Medium average rate =
+Large average time =
+Large average rate =

--- a/benchmarks/graph_infra/str-in1d.perfkeys
+++ b/benchmarks/graph_infra/str-in1d.perfkeys
@@ -1,0 +1,4 @@
+Medium average time =
+Medium average rate =
+Large average time =
+Large average rate =

--- a/benchmarks/str-in1d.py
+++ b/benchmarks/str-in1d.py
@@ -11,7 +11,7 @@ LARGE = 10**6 + 1
 MAXSTRLEN = 5
 
 def time_ak_in1d(size, trials):
-    print(">>> arkouda int64 in1d")
+    print(">>> arkouda string in1d")
     cfg = ak.get_config()
     N = size * cfg["numLocales"]
     a = ak.random_strings_uniform(1, MAXSTRLEN, N)

--- a/benchmarks/str-in1d.py
+++ b/benchmarks/str-in1d.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3                                                         
+
+import time, argparse
+import arkouda as ak
+
+# Must be less than src/SegmentedArray.chpl:in1dAssocSortThreshold, which defaults to 10**6
+MEDIUM = 10**6 - 1
+# Must be greater than mbound
+LARGE = 10**6 + 1
+# Controls how many unique values are possible
+MAXSTRLEN = 5
+
+def time_ak_in1d(size, trials):
+    print(">>> arkouda int64 in1d")
+    cfg = ak.get_config()
+    N = size * cfg["numLocales"]
+    a = ak.random_strings_uniform(1, MAXSTRLEN, N)
+
+    for regime, bsize in zip(('Medium', 'Large'), (MEDIUM, LARGE)):
+        print("{} regime: numLocales = {}  a.size = {:,}  b.size = {:,}".format(regime, cfg["numLocales"], N, bsize))
+        b = ak.random_strings_uniform(1, MAXSTRLEN, bsize)
+        timings = []
+        for _ in range(trials):
+            start = time.time()
+            c = ak.in1d(a, b)
+            end = time.time()
+            timings.append(end - start)
+        tavg = sum(timings) / trials
+        print("{} average time = {:.4f} sec".format(regime, tavg))
+        bytes_per_sec = (a.size * 8 + a.nbytes + b.size * 8 + b.nbytes) / tavg
+        print("{} average rate = {:.2f} GiB/sec".format(regime, bytes_per_sec/2**30))
+
+def check_correctness():
+    asize = 10**4
+    bsize = 10**3
+    a = ak.array([str(i) for i in range(asize)])
+    b = ak.array([str(i) for i in range(bsize)])
+    c = ak.in1d(a, b)
+    assert c.sum() == bsize, "Incorrect result"
+
+def create_parser():
+    parser = argparse.ArgumentParser(description="Measure the performance of in1d with strings: c = ak.in1d(a, b)")
+    parser.add_argument('hostname', help='Hostname of arkouda server')
+    parser.add_argument('port', type=int, help='Port of arkouda server')
+    parser.add_argument('-n', '--size', type=int, default=10**7, help='Problem size: length of array a')
+    parser.add_argument('-t', '--trials', type=int, default=3, help='Number of times to run the benchmark')
+    parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
+    return parser
+    
+if __name__ == "__main__":
+    import sys
+    parser = create_parser()
+    args = parser.parse_args()
+    ak.verbose = False
+    ak.connect(args.hostname, args.port)
+
+    if args.correctness_only:
+        check_correctness()
+        sys.exit(0)
+    
+    print("problem size per node = {:,}".format(args.size))
+    print("number of trials = ", args.trials)
+    time_ak_in1d(args.size, args.trials)    
+    sys.exit(0)


### PR DESCRIPTION
Will close #968 

This PR implements benchmarks for `in1d` on the four subproblems described in #968 . The hard-coded size of the second argument to `in1d` is necessarily `2**25` (to access the largest regime), so the effective problem size has a large lower bound, regardless of the `--size` option. On my laptop, the benchmarks run fine in single-locale mode, but run out of memory in multi-locale mode. @ronawho will this be a problem for the benchmark systems?