### PR TITLE
Closes #971 by escaping double quotes in dataset names

### DIFF
--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -279,12 +279,13 @@ module GenSymIO {
             repMsg = "[";  // Manual json building Chapel <= 1.24.1
             var first = true;
             for i in items {
+                i = i.replace(Q, ESCAPED_QUOTES, -1);
                 if first {
                     first = false;
                 } else {
                     repMsg += ",";
                 }
-                repMsg += '"' + i + '"';
+                repMsg += Q + i + Q;
             }
             repMsg += "]";
         } catch e : Error {
@@ -686,6 +687,7 @@ module GenSymIO {
         var items: list(string);
         for rname in rnames {
             var (dsetName, akType, id) = rname;
+            dsetName = dsetName.replace(Q, ESCAPED_QUOTES, -1); // sanitize dsetName with respect to double quotes
             var item = "{" + Q + "dataset_name"+ QCQ + dsetName + Q +
                        "," + Q + "arkouda_type" + QCQ + akType + Q;
             select (akType) {

--- a/src/Message.chpl
+++ b/src/Message.chpl
@@ -71,5 +71,7 @@ module Message {
      * String constants for use in constructing JSON formatted messages
      */
     const Q = '"'; // Double Quote, escaping quotes often throws off syntax highlighting.
-    const QCQ = Q + ":" + Q; // `":"` -> useful for closing and opening quotes for named json k,v pairs 
+    const QCQ = Q + ":" + Q; // `":"` -> useful for closing and opening quotes for named json k,v pairs
+    const BSLASH = '\\';
+    const ESCAPED_QUOTES = BSLASH + Q;
 }

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -590,6 +590,13 @@ class IOTest(ArkoudaTest):
             a2 = ak.load(f"{tmp_dirname}/small_numeric", dataset="a1")
             self.assertEqual(str(a1), str(a2))
 
+    def testHdfUnsanitizedNames(self):
+        # Test when quotes are part of the dataset name
+        my_arrays = {'foo"0"': ak.arange(100), 'bar"': ak.arange(100)}
+        with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
+            ak.save_all(my_arrays, f"{tmp_dirname}/bad_dataset_names")
+            ak.read_all(f"{tmp_dirname}/bad_dataset_names*")
+
     def testInternalVersions(self):
         """
         Test loading internal arkouda hdf5 structuring by loading v0 and v1 files.


### PR DESCRIPTION
Closes #971 by escaping double quotes in dataset names
for lshdfMsg and readAllHdfMsg/_buildReadAllHdfMsgJson

