### PR TITLE
Force HDF5 110 API for HDF5 1.10.x and 1.12.x support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ default: $(DEFAULT_TARGET)
 VERBOSE ?= 0
 
 CHPL := chpl
+
+# We need to make the HDF5 API use the 1.10.x version for compatibility between 1.10 and 1.12
+CHPL_FLAGS += --ccflags="-DH5_USE_110_API"
+
 CHPL_DEBUG_FLAGS += --print-passes
 ifdef ARKOUDA_DEVELOPER
 CHPL_FLAGS += --ccflags="-O1"
@@ -248,6 +252,7 @@ else
 	ARKOUDA_COMPAT_MODULES += -M $(ARKOUDA_SOURCE_DIR)/compat/lt-125
 endif
 
+# This is the main compilation statement section
 $(ARKOUDA_MAIN_MODULE): check-deps $(ARROW_O) $(ARKOUDA_SOURCES) $(ARKOUDA_MAKEFILES)
 	$(CHPL) $(CHPL_DEBUG_FLAGS) $(PRINT_PASSES_FLAGS) $(REGEX_MAX_CAPTURES_FLAG) $(OPTIONAL_SERVER_FLAGS) $(CHPL_FLAGS_WITH_VERSION) $(ARKOUDA_MAIN_SOURCE) $(ARKOUDA_COMPAT_MODULES) -o $@
 

--- a/src/c_helpers/help_h5ls.c
+++ b/src/c_helpers/help_h5ls.c
@@ -12,7 +12,8 @@ herr_t c_get_HDF5_obj_type(hid_t loc_id, const char *name, H5O_type_t *obj_type)
 {
     herr_t status;
     H5O_info_t info_t;
-    status = H5Oget_info_by_name1(loc_id, name, &info_t, H5P_DEFAULT);
+    H5O_info_t* info_t_ptr = &info_t;
+    status = H5Oget_info_by_name(loc_id, name, info_t_ptr, H5P_DEFAULT);
     *obj_type = info_t.type;
     return status;
 }


### PR DESCRIPTION
Closes #975 and #979
Forces HDF5 API version 110 so we can be compatible with both 1.10.x and 1.12.x versions of HDF5.  Updates help_h5ls.c to use H5 110 API