### PR TITLE
Fix # 786 Adds typing hierarchy regarding SymEntry types to Parquet code.

### DIFF
--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -1443,7 +1443,7 @@ module GenSymIO {
             use Parquet;
             var (arrayName, dsetname,  jsonfile, dataType)= payload.splitMsgToTuple(4);
             var filename: string;
-            var entry = st.lookup(arrayName);
+            var entry = getGenericTypedArrayEntry(arrayName, st);
 
             try {
               filename = jsonToPdArray(jsonfile, 1)[0];


### PR DESCRIPTION
This updates the `toparquetMsg` proc to use the Typing Hierarchy convenience methods to handle SymbolEntryType casting.