### PR TITLE
Add Parquet support information in env file

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -36,6 +36,7 @@ Most folks install anaconda and link to these libraries through Makefile.paths i
 setup you can set them explicitly via:
   - ARKOUDA_ZMQ_PATH : Path to ZMQ library
   - ARKOUDA_HDF5_PATH : Path to HDF5 library
+  - ARKOUDA_ARROW_PATH : Path to Arrow library (needed only when building with Parquet support; see "Building with Parquet" below)
   - ARKOUDA_SKIP_CHECK_DEPS : Setting this will skip the automated checks for dependencies (i.e. ZMQ, HDF5). This is
     useful for developers doing repeated Arkouda builds since they should have already verified the deps have been set up.
 

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -60,3 +60,6 @@ Also see the python tests [README](tests/README.md) for more information on Pyth
   - ARKOUDA_KEY_FILE : Client env var for keyfile when using ssh tunnel
   - ARKOUDA_PASSWORD : Client env var for password when using ssh tunnel
   - ARKOUDA_LOG_LEVEL : Client env var to control client side Logging Level
+
+## Building with Parquet
+  - ARKOUDA_SERVER_PARQUET_SUPPORT : Env var to control if the server is built with Parquet support; if set, Parquet will be built, regardless of value


### PR DESCRIPTION
This PR adds information on the new ARKOUDA_SERVER_PARQUET_SUPPORT and ARKOUDA_ARROW_PATH environment variables that are used to build with/without Parquet support.