### PR TITLE
Add handling of errors in Parquet code and minor clean up 

### DIFF
--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -5,6 +5,47 @@
 #include <arrow/io/api.h>
 #include <parquet/arrow/reader.h>
 #include <parquet/arrow/writer.h>
+#include <parquet/column_reader.h>
+
+/*
+  Arrow Error Helpers
+  -------------------
+  Arrow provides PARQUETASSIGNORTHROW and other similar macros
+  to help with error handling, but since we are doing something
+  unique (passing back the error message to Chapel to be displayed),
+  these helpers are similar to the provided macros but matching our
+  functionality. 
+*/
+
+// The `ARROWRESULT_OK` macro should be used when trying to
+// assign the result of an Arrow/Parquet function to a value that can
+// potentially throw an error, so the argument `cmd` is the Arrow
+// command to execute and `res` is the desired variable to store the
+// result
+#define ARROWRESULT_OK(cmd, res)                                \
+  {                                                             \
+    auto result = cmd;                                          \
+    if(!result.ok()) {                                          \
+      *errMsg = strdup(result.status().message().c_str());      \
+      return -1;                                                \
+    }                                                           \
+    res = result.ValueOrDie();                                  \
+  }
+
+// The `ARROWSTATUS_OK` macro should be used when calling an
+// Arrow/Parquet function that returns a status. The `cmd`
+// argument should be the Arrow function to execute.
+#define ARROWSTATUS_OK(cmd)                     \
+  if(!check_status_ok(cmd, errMsg))             \
+    return -1;
+
+bool check_status_ok(arrow::Status status, char** errMsg) {
+  if(!status.ok()) {
+    *errMsg = strdup(status.message().c_str());
+    return false;
+  }
+  return true;
+}
 
 /*
  C++ functions
@@ -15,37 +56,40 @@
  C++ functions must return types that are C compatible.
 */
 
-int cpp_getNumRows(const char* filename) {
+int cpp_getNumRows(const char* filename, char** errMsg) {
   std::shared_ptr<arrow::io::ReadableFile> infile;
-  PARQUET_ASSIGN_OR_THROW(
-      infile,
-      arrow::io::ReadableFile::Open(filename,
-                                    arrow::default_memory_pool()));
+  ARROWRESULT_OK(arrow::io::ReadableFile::Open(filename, arrow::default_memory_pool()),
+                 infile);
 
   std::unique_ptr<parquet::arrow::FileReader> reader;
-  PARQUET_THROW_NOT_OK(
-    parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &reader));
+  ARROWSTATUS_OK(parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &reader));
+  
   return reader -> parquet_reader() -> metadata() -> num_rows();
 }
 
-int cpp_getType(const char* filename, const char* colname) {
+int cpp_getType(const char* filename, const char* colname, char** errMsg) {
   std::shared_ptr<arrow::io::ReadableFile> infile;
-  PARQUET_ASSIGN_OR_THROW(
-      infile,
-      arrow::io::ReadableFile::Open(filename,
-                                    arrow::default_memory_pool()));
+  ARROWRESULT_OK(arrow::io::ReadableFile::Open(filename, arrow::default_memory_pool()),
+                 infile);
 
   std::unique_ptr<parquet::arrow::FileReader> reader;
-  PARQUET_THROW_NOT_OK(
-      parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &reader));
+  ARROWSTATUS_OK(parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &reader));
 
   std::shared_ptr<arrow::Schema> sc;
   std::shared_ptr<arrow::Schema>* out = &sc;
-  PARQUET_THROW_NOT_OK(reader->GetSchema(out));
+  ARROWSTATUS_OK(reader->GetSchema(out));
 
   int idx = sc -> GetFieldIndex(colname);
-  if(idx == -1) // TODO: error colname not in schema
-    idx = 0;
+  // Since this doesn't actually throw a Parquet error, we have to generate
+  // our own error message for this case
+  if(idx == -1) {
+    std::string fname(filename);
+    std::string dname(colname);
+    std::string msg = "Dataset: " + dname + " does not exist in file: " + filename; 
+    *errMsg = strdup(msg.c_str());
+    // TODO: revisit this -1, is this what we want?
+    return -1;
+  }
   auto myType = sc -> field(idx) -> type();
 
   if(myType == arrow::int64())
@@ -56,57 +100,58 @@ int cpp_getType(const char* filename, const char* colname) {
     return ARROWUNDEFINED;
 }
 
-void cpp_readColumnByName(const char* filename, void* chpl_arr, const char* colname, int numElems) {
+#define COPYTOCHAPEL(arrowtype, chunk)                                      \
+  auto int_arr = std::static_pointer_cast<arrow::arrowtype>(chunk); \
+  for(int i = 0; i < numElems; i++) \
+    chpl_ptr[i] = int_arr->Value(i);
+
+int cpp_readColumnByName(const char* filename, void* chpl_arr, const char* colname, int numElems, char** errMsg) {
   auto chpl_ptr = (int64_t*)chpl_arr;
 
   std::shared_ptr<arrow::io::ReadableFile> infile;
-  PARQUET_ASSIGN_OR_THROW(
-      infile,
-      arrow::io::ReadableFile::Open(filename,
-                                    arrow::default_memory_pool()));
+  ARROWRESULT_OK(arrow::io::ReadableFile::Open(filename,arrow::default_memory_pool()),
+                 infile);
 
   std::unique_ptr<parquet::arrow::FileReader> reader;
-  PARQUET_THROW_NOT_OK(
-      parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &reader));
+  ARROWSTATUS_OK(parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &reader));
+
   std::shared_ptr<arrow::ChunkedArray> array;
 
   std::shared_ptr<arrow::Schema> sc;
   std::shared_ptr<arrow::Schema>* out = &sc;
-  PARQUET_THROW_NOT_OK(reader->GetSchema(out));
+  ARROWSTATUS_OK(reader->GetSchema(out));
 
-  auto idx = sc -> GetFieldIndex(colname);
+  if(!reader->ReadColumn(sc -> GetFieldIndex(colname), &array).ok()) {
+    std::string fname(filename);
+    std::string dname(colname);
+    std::string msg = "Dataset: " + dname + " does not exist in file: " + filename; 
+    *errMsg = strdup(msg.c_str());
+    // TODO: revisit this -1, is this what we want?
+    return -1;
+  }
 
-  // TODO: error: schema does not contain dsetname
-  if(idx == -1)
-    idx = 0;
-
-  PARQUET_THROW_NOT_OK(reader->ReadColumn(idx, &array));
-
-  int ty = cpp_getType(filename, colname);
+  int ty = cpp_getType(filename, colname, errMsg);
   std::shared_ptr<arrow::Array> regular = array->chunk(0);
 
   if(ty == ARROWINT64) {
-    auto int_arr = std::static_pointer_cast<arrow::Int64Array>(regular);
-
-    for(int i = 0; i < numElems; i++)
-      chpl_ptr[i] = int_arr->Value(i);
+    COPYTOCHAPEL(Int64Array, regular);
   } else if(ty == ARROWINT32) {
-      auto int_arr = std::static_pointer_cast<arrow::Int32Array>(regular);
-
-      for(int i = 0; i < numElems; i++)
-        chpl_ptr[i] = int_arr->Value(i);
+    COPYTOCHAPEL(Int32Array, regular);
   }
+  return 0;
 }
 
-void cpp_writeColumnToParquet(const char* filename, void* chpl_arr,
-                              int colnum, const char* dsetname, int numelems,
-                              int rowGroupSize) {
+int cpp_writeColumnToParquet(const char* filename, void* chpl_arr,
+                             int colnum, const char* dsetname, int numelems,
+                             int rowGroupSize, char** errMsg) {
   auto chpl_ptr = (int64_t*)chpl_arr;
   arrow::Int64Builder i64builder;
-  for(int i = 0; i < numelems; i++)
-    PARQUET_THROW_NOT_OK(i64builder.AppendValues({chpl_ptr[i]}));
+  arrow::Status status;
+  for(int i = 0; i < numelems; i++) {
+    ARROWSTATUS_OK(i64builder.AppendValues({chpl_ptr[i]}));
+  }
   std::shared_ptr<arrow::Array> i64array;
-  PARQUET_THROW_NOT_OK(i64builder.Finish(&i64array));
+  ARROWSTATUS_OK(i64builder.Finish(&i64array));
 
   std::shared_ptr<arrow::Schema> schema = arrow::schema(
                  {arrow::field(dsetname, arrow::int64())});
@@ -114,12 +159,11 @@ void cpp_writeColumnToParquet(const char* filename, void* chpl_arr,
   auto table = arrow::Table::Make(schema, {i64array});
 
   std::shared_ptr<arrow::io::FileOutputStream> outfile;
-  PARQUET_ASSIGN_OR_THROW(
-      outfile,
-      arrow::io::FileOutputStream::Open(filename));
+  ARROWRESULT_OK(arrow::io::FileOutputStream::Open(filename),
+                 outfile);
 
-  PARQUET_THROW_NOT_OK(
-      parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), outfile, rowGroupSize));
+  ARROWSTATUS_OK(parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), outfile, rowGroupSize));
+  return 0;
 }
 
 const char* cpp_getVersionInfo(void) {
@@ -141,23 +185,23 @@ void cpp_free_string(void* ptr) {
 */
 
 extern "C" {
-  int c_getNumRows(const char* chpl_str) {
-    return cpp_getNumRows(chpl_str);
+  int c_getNumRows(const char* chpl_str, char** errMsg) {
+    return cpp_getNumRows(chpl_str, errMsg);
   }
 
-  void c_readColumnByName(const char* filename, void* chpl_arr, const char* colname, int numElems) {
-    cpp_readColumnByName(filename, chpl_arr, colname, numElems);
+  int c_readColumnByName(const char* filename, void* chpl_arr, const char* colname, int numElems, char** errMsg) {
+    return cpp_readColumnByName(filename, chpl_arr, colname, numElems, errMsg);
   }
 
-  int c_getType(const char* filename, const char* colname) {
-    return cpp_getType(filename, colname);
+  int c_getType(const char* filename, const char* colname, char** errMsg) {
+    return cpp_getType(filename, colname, errMsg);
   }
 
-  void c_writeColumnToParquet(const char* filename, void* chpl_arr,
-                              int colnum, const char* dsetname, int numelems,
-                              int rowGroupSize) {
-    cpp_writeColumnToParquet(filename, chpl_arr, colnum, dsetname,
-                             numelems, rowGroupSize);
+  int c_writeColumnToParquet(const char* filename, void* chpl_arr,
+                             int colnum, const char* dsetname, int numelems,
+                             int rowGroupSize, char** errMsg) {
+    return cpp_writeColumnToParquet(filename, chpl_arr, colnum, dsetname,
+                                    numelems, rowGroupSize, errMsg);
   }
 
   const char* c_getVersionInfo(void) {

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -27,7 +27,7 @@
     auto result = cmd;                                          \
     if(!result.ok()) {                                          \
       *errMsg = strdup(result.status().message().c_str());      \
-      return -1;                                                \
+      return ARROWERROR;                                        \
     }                                                           \
     res = result.ValueOrDie();                                  \
   }
@@ -37,7 +37,7 @@
 // argument should be the Arrow function to execute.
 #define ARROWSTATUS_OK(cmd)                     \
   if(!check_status_ok(cmd, errMsg))             \
-    return -1;
+    return ARROWERROR;
 
 bool check_status_ok(arrow::Status status, char** errMsg) {
   if(!status.ok()) {
@@ -87,8 +87,7 @@ int cpp_getType(const char* filename, const char* colname, char** errMsg) {
     std::string dname(colname);
     std::string msg = "Dataset: " + dname + " does not exist in file: " + filename; 
     *errMsg = strdup(msg.c_str());
-    // TODO: revisit this -1, is this what we want?
-    return -1;
+    return ARROWERROR;
   }
   auto myType = sc -> field(idx) -> type();
 
@@ -126,8 +125,7 @@ int cpp_readColumnByName(const char* filename, void* chpl_arr, const char* colna
     std::string dname(colname);
     std::string msg = "Dataset: " + dname + " does not exist in file: " + filename; 
     *errMsg = strdup(msg.c_str());
-    // TODO: revisit this -1, is this what we want?
-    return -1;
+    return ARROWERROR;
   }
 
   int ty = cpp_getType(filename, colname, errMsg);

--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -6,6 +6,7 @@ extern "C" {
   #define ARROWINT64 0
   #define ARROWINT32 1
   #define ARROWUNDEFINED -1
+  #define ARROWERROR -1
 
   // Each C++ function contains the actual implementation of the
   // functionality, and there is a corresponding C function that

--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -11,23 +11,25 @@ extern "C" {
   // functionality, and there is a corresponding C function that
   // Chapel can call into through C interoperability, since there
   // is no C++ interoperability supported in Chapel today.
-  int c_getNumRows(const char*);
-  int cpp_getNumRows(const char*);
+  int c_getNumRows(const char*, char** errMsg);
+  int cpp_getNumRows(const char*, char** errMsg);
 
-  void c_readColumnByName(const char* filename, void* chpl_arr,
-                          const char* colname, int numElems);
-  void cpp_readColumnByName(const char* filename, void* chpl_arr,
-                            const char* colname, int numElems);
+  int c_readColumnByName(const char* filename, void* chpl_arr,
+                         const char* colname, int numElems,
+                         char** errMsg);
+  int cpp_readColumnByName(const char* filename, void* chpl_arr,
+                           const char* colname, int numElems,
+                           char** errMsg);
 
-  int c_getType(const char* filename, const char* colname);
-  int cpp_getType(const char* filename, const char* colname);
+  int c_getType(const char* filename, const char* colname, char** errMsg);
+  int cpp_getType(const char* filename, const char* colname, char** errMsg);
 
-  void cpp_writeColumnToParquet(const char* filename, void* chpl_arr,
+  int cpp_writeColumnToParquet(const char* filename, void* chpl_arr,
                                int colnum, const char* dsetname, int numelems,
-                               int rowGroupSize);
-  void c_writeColumnToParquet(const char* filename, void* chpl_arr,
+                               int rowGroupSize, char** errMsg);
+  int c_writeColumnToParquet(const char* filename, void* chpl_arr,
                              int colnum, const char* dsetname, int numelems,
-                             int rowGroupSize);;
+                             int rowGroupSize, char** errMsg);
     
   const char* c_getVersionInfo(void);
   const char* cpp_getVersionInfo(void);

--- a/src/Parquet.chpl
+++ b/src/Parquet.chpl
@@ -13,6 +13,7 @@ module Parquet {
   extern var ARROWINT64: c_int;
   extern var ARROWINT32: c_int;
   extern var ARROWUNDEFINED: c_int;
+  extern var ARROWERROR: c_int;
 
   enum ArrowTypes { int64, int32, notimplemented };
 
@@ -90,7 +91,7 @@ module Parquet {
             var col: [filedom] int;
             if c_readColumnByName(filename.localize().c_str(), c_ptrTo(col),
                                   dsetname.localize().c_str(), filedom.size,
-                                  c_ptrTo(pqErr.errMsg)) < 0 {
+                                  c_ptrTo(pqErr.errMsg)) == ARROWERROR {
               pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
             }
             A[filedom] = col;
@@ -106,7 +107,7 @@ module Parquet {
     
     var size = c_getNumRows(filename.localize().c_str(),
                             c_ptrTo(pqErr.errMsg));
-    if size == -1 {
+    if size == ARROWERROR {
       pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
     }
     return size;
@@ -118,7 +119,7 @@ module Parquet {
     var arrType = c_getType(filename.localize().c_str(),
                             colname.localize().c_str(),
                             c_ptrTo(pqErr.errMsg));
-    if arrType < 0 {
+    if arrType == ARROWERROR {
       pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
     }
     
@@ -148,7 +149,7 @@ module Parquet {
         var locArr = A[locDom];
         if c_writeColumnToParquet(myFilename.localize().c_str(), c_ptrTo(locArr), 0,
                                   dsetname.localize().c_str(), locDom.size, rowGroupSize,
-                                  c_ptrTo(pqErr.errMsg)) < 0 {
+                                  c_ptrTo(pqErr.errMsg)) == ARROWERROR {
           pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
         }
       }

--- a/src/Parquet.chpl
+++ b/src/Parquet.chpl
@@ -30,8 +30,12 @@ module Parquet {
 
     proc parquetError(lineNumber, routineName, moduleName) throws {
       extern proc strlen(a): int;
-      var err;
-      try! err = createStringWithNewBuffer(errMsg, strlen(errMsg));
+      var err: string;
+      try {
+        err = createStringWithNewBuffer(errMsg, strlen(errMsg));
+      } catch e {
+        err = "Error converting Parquet error message to Chapel string";
+      }
       throw getErrorWithContext(
                      msg=err,
                      lineNumber,
@@ -49,8 +53,13 @@ module Parquet {
     defer {
       c_free_string(cVersionString: c_void_ptr);
     }
-    var ret = try! createStringWithNewBuffer(cVersionString,
-                                             strlen(cVersionString));
+    var ret: string;
+    try {
+      ret = createStringWithNewBuffer(cVersionString,
+                                strlen(cVersionString));
+    } catch e {
+      ret = "Error converting Arrow version message to Chapel string";
+    }
     return ret;
   }
   

--- a/src/Parquet.chpl
+++ b/src/Parquet.chpl
@@ -32,7 +32,6 @@ module Parquet {
       extern proc strlen(a): int;
       var err;
       try! err = createStringWithNewBuffer(errMsg, strlen(errMsg));
-      // free error message before throw since it can't be used again
       throw getErrorWithContext(
                      msg=err,
                      lineNumber,

--- a/src/Parquet.chpl
+++ b/src/Parquet.chpl
@@ -1,6 +1,8 @@
 module Parquet {
   use SysCTypes, CPtr, IO;
   use ServerErrors, ServerConfig;
+  // Use reflection for error information
+  use Reflection;
   if hasParquetSupport {
     require "ArrowFunctions.h";
     require "ArrowFunctions.o";
@@ -13,6 +15,31 @@ module Parquet {
   extern var ARROWUNDEFINED: c_int;
 
   enum ArrowTypes { int64, int32, notimplemented };
+
+  record parquetErrorMsg {
+    var errMsg: c_ptr(uint(8));
+    proc init() {
+      errMsg = c_nil;
+    }
+    
+    proc deinit() {
+      extern proc c_free_string(ptr);
+      c_free_string(errMsg);
+    }
+
+    proc parquetError(lineNumber, routineName, moduleName) throws {
+      extern proc strlen(a): int;
+      var err;
+      try! err = createStringWithNewBuffer(errMsg, strlen(errMsg));
+      // free error message before throw since it can't be used again
+      throw getErrorWithContext(
+                     msg=err,
+                     lineNumber,
+                     routineName,
+                     moduleName,
+                     errorClass="ParquetError");
+    }
+  }
   
   proc getVersionInfo() {
     extern proc c_getVersionInfo(): c_string;
@@ -48,11 +75,12 @@ module Parquet {
     return {low..high by stride};
   }
   
-  proc readFilesByName(A, filenames: [] string, sizes: [] int, dsetname: string) {
-    extern proc c_readColumnByName(filename, chpl_arr, colNum, numElems);
+  proc readFilesByName(A, filenames: [] string, sizes: [] int, dsetname: string) throws {
+    extern proc c_readColumnByName(filename, chpl_arr, colNum, numElems, errMsg): int;
     var (subdoms, length) = getSubdomains(sizes);
 
     coforall loc in A.targetLocales() do on loc {
+      var pqErr = new parquetErrorMsg();
       var locFiles = filenames;
       var locFiledoms = subdoms;
       for (filedom, filename) in zip(locFiledoms, locFiles) {
@@ -60,8 +88,11 @@ module Parquet {
           const intersection = domain_intersection(locdom, filedom);
           if intersection.size > 0 {
             var col: [filedom] int;
-            // TODO: errors
-            c_readColumnByName(filename.localize().c_str(), c_ptrTo(col), dsetname.localize().c_str(), filedom.size);
+            if c_readColumnByName(filename.localize().c_str(), c_ptrTo(col),
+                                  dsetname.localize().c_str(), filedom.size,
+                                  c_ptrTo(pqErr.errMsg)) < 0 {
+              pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
+            }
             A[filedom] = col;
           }
         }
@@ -69,16 +100,28 @@ module Parquet {
     }
   }
 
-  proc getArrSize(filename: string) {
-    extern proc c_getNumRows(chpl_str): int;
-    var size = c_getNumRows(filename.localize().c_str());
+  proc getArrSize(filename: string) throws {
+    extern proc c_getNumRows(chpl_str, errMsg): int;
+    var pqErr = new parquetErrorMsg();
+    
+    var size = c_getNumRows(filename.localize().c_str(),
+                            c_ptrTo(pqErr.errMsg));
+    if size == -1 {
+      pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
+    }
     return size;
   }
 
-  proc getArrType(filename: string, colname: string) {
-    extern proc c_getType(filename, colname): c_int;
+  proc getArrType(filename: string, colname: string) throws {
+    extern proc c_getType(filename, colname, errMsg): c_int;
+    var pqErr = new parquetErrorMsg();
     var arrType = c_getType(filename.localize().c_str(),
-                            colname.localize().c_str());
+                            colname.localize().c_str(),
+                            c_ptrTo(pqErr.errMsg));
+    if arrType < 0 {
+      pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
+    }
+    
     if arrType == ARROWINT64 then return ArrowTypes.int64;
     else if arrType == ARROWINT32 then return ArrowTypes.int32;
     return ArrowTypes.notimplemented;
@@ -86,24 +129,44 @@ module Parquet {
 
   proc writeDistArrayToParquet(A, filename, dsetname, rowGroupSize) throws {
     extern proc c_writeColumnToParquet(filename, chpl_arr, colnum,
-                                     dsetname, numelems, rowGroupSize);
+                                       dsetname, numelems, rowGroupSize,
+                                       errMsg): int;
     var filenames: [0..#A.targetLocales().size] string;
     for i in 0..#A.targetLocales().size {
       var suffix = '%04i'.format(i): string;
       filenames[i] = filename + "_LOCALE" + suffix + ".parquet";
     }
+    var matchingFilenames = glob("%s_LOCALE*%s".format(filename, ".parquet"));
 
+    var warnFlag = processParquetFilenames(filenames, matchingFilenames);
+    
     coforall (loc, idx) in zip(A.targetLocales(), filenames.domain) do on loc {
+        var pqErr = new parquetErrorMsg();
         const myFilename = filenames[idx];
 
         var locDom = A.localSubdomain();
         var locArr = A[locDom];
-        c_writeColumnToParquet(myFilename.localize().c_str(), c_ptrTo(locArr), 0, dsetname.localize().c_str(), locDom.size, rowGroupSize);
+        if c_writeColumnToParquet(myFilename.localize().c_str(), c_ptrTo(locArr), 0,
+                                  dsetname.localize().c_str(), locDom.size, rowGroupSize,
+                                  c_ptrTo(pqErr.errMsg)) < 0 {
+          pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
+        }
       }
+    return warnFlag;
+  }
+      
+
+  proc processParquetFilenames(filenames: [] string, matchingFilenames: [] string) throws {
+    var warnFlag: bool;
+    if matchingFilenames.size > 0 {
+      warnFlag = true;
+    } else {
+      warnFlag = false;
+    }
+    return warnFlag;
   }
 
   proc write1DDistArrayParquet(filename: string, dsetname, A) throws {
-    writeDistArrayToParquet(A, filename, dsetname, ROWGROUPS);
-    return false;
+    return writeDistArrayToParquet(A, filename, dsetname, ROWGROUPS);
   }
 }

--- a/test/UnitTestParquetCpp.chpl
+++ b/test/UnitTestParquetCpp.chpl
@@ -3,16 +3,34 @@ use UnitTest;
 use TestBase;
 
 proc testReadWrite(filename: c_string, dsetname: c_string, size: int) {
-  extern proc c_readColumnByName(filename, chpl_arr, colNum, numElems);
+  extern proc c_readColumnByName(filename, chpl_arr, colNum, numElems, errMsg): int;
   extern proc c_writeColumnToParquet(filename, chpl_arr, colnum,
-                                     dsetname, numelems, rowGroupSize);
+                                     dsetname, numelems, rowGroupSize,
+                                     errMsg): int;
+  extern proc c_free_string(a);
+  extern proc strlen(a): int;
+  var errMsg: c_ptr(uint(8));
+  defer {
+    c_free_string(errMsg);
+  }
+  var causeError = "asdasdasd":c_string;
+  
   var a: [0..#size] int;
   for i in 0..#size do a[i] = i;
-  c_writeColumnToParquet(filename, c_ptrTo(a), 0, dsetname, size, 10000);
+  if c_writeColumnToParquet(filename, c_ptrTo(a), 0, dsetname, size, 10000, errMsg) < 0 {
+    var chplMsg;
+    try! chplMsg = createStringWithNewBuffer(errMsg, strlen(errMsg));
+    writeln(chplMsg);
+  }
 
   var b: [0..#size] int;
-  
-  c_readColumnByName(filename, c_ptrTo(b), dsetname, size);
+
+  if(c_readColumnByName(filename, c_ptrTo(b), dsetname, size, c_ptrTo(errMsg)) < 0) {
+    var chplMsg;
+    try! chplMsg = createStringWithNewBuffer(errMsg, strlen(errMsg));
+    writeln(chplMsg);
+  }
+    
   if a.equals(b) {
     return 0;
   } else {
@@ -22,25 +40,45 @@ proc testReadWrite(filename: c_string, dsetname: c_string, size: int) {
 }
 
 proc testGetNumRows(filename: c_string, expectedSize: int) {
-  extern proc c_getNumRows(chpl_str): int;
-  var size = c_getNumRows(filename);
+  extern proc c_getNumRows(chpl_str, err): int;
+  extern proc c_free_string(a);
+  extern proc strlen(a): int;
+  var errMsg: c_ptr(uint(8));
+  defer {
+    c_free_string(errMsg);
+  }
+  var causeError = "asdasdasd":c_string;
+  var size = c_getNumRows(filename, c_ptrTo(errMsg));
   if size == expectedSize {
     return 0;
   } else {
+    var chplMsg;
+    try! chplMsg = createStringWithNewBuffer(errMsg, strlen(errMsg));
+    writeln(chplMsg);
     writeln("FAILED: c_getNumRows");
     return 1;
   }
 }
 
 proc testGetType(filename: c_string, dsetname: c_string) {
-  extern proc c_getType(filename, colname): c_int;
-  var arrowType = c_getType(filename, dsetname);
+  extern proc c_getType(filename, colname, errMsg): c_int;
+  extern proc c_free_string(a);
+  extern proc strlen(a): int;
+  var errMsg: c_ptr(uint(8));
+  defer {
+    c_free_string(errMsg);
+  }
+  var causeError = "asdasdasd":c_string;
+  var arrowType = c_getType(filename, dsetname, c_ptrTo(errMsg));
 
   // a positive value corresponds to an arrow type
   // -1 corresponds to unsupported type
   if arrowType >= 0 {
     return 0;
   } else {
+    var chplMsg;
+    try! chplMsg = createStringWithNewBuffer(errMsg, strlen(errMsg));
+    writeln(chplMsg);
     writeln("FAILED: c_getType with ", arrowType);
     return 1;
   }

--- a/test/UnitTestParquetCpp.chpl
+++ b/test/UnitTestParquetCpp.chpl
@@ -13,7 +13,7 @@ proc testReadWrite(filename: c_string, dsetname: c_string, size: int) {
   defer {
     c_free_string(errMsg);
   }
-  var causeError = "asdasdasd":c_string;
+  var causeError = "cause-error":c_string;
   
   var a: [0..#size] int;
   for i in 0..#size do a[i] = i;

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -34,3 +34,15 @@ class ParquetTest(ArkoudaTest):
 
         for f in glob.glob('pq_test*'):
             os.remove(f)
+
+    def test_wrong_dset_name(self):
+        ak_arr = ak.randint(0, 2**32, SIZE)
+        ak_arr.save_parquet("pq_test", "test-dset-name")
+        
+        with self.assertRaises(RuntimeError) as cm:
+            ak.read_parquet("pq_test*", "wrong-dset-name")
+        self.assertIn("wrong-dset-name does not exist in file", cm.exception.args[0])
+
+        for f in glob.glob("pq_test*"):
+            os.remove(f)
+        


### PR DESCRIPTION
With the initial Parquet work in https://github.com/Bears-R-Us/arkouda/pull/967, all errors in the C++ code are unhandled and cause the server to crash. This PR adds in Parquet error handling by catching the errors in the C++ code and passing the messages back to the Chapel code so helpful error messages can be passed back to the client. Also, some macros were added in the C++ code to help clean up some of the boilerplate code.