### PR TITLE
Add Arrow versioning to ak.get_config() call

### DIFF
--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -92,6 +92,7 @@ module ServerConfig
             const arkoudaVersion: string;
             const ZMQVersion: string;
             const HDF5Version: string;
+            const arrowVersion: string;
             const serverHostname: string;
             const ServerPort: int;
             const numLocales: int;
@@ -108,10 +109,28 @@ module ServerConfig
         var (Zmajor, Zminor, Zmicro) = ZMQ.version;
         var H5major: c_uint, H5minor: c_uint, H5micro: c_uint;
         H5get_libversion(H5major, H5minor, H5micro);
+
+        var arrowVNum: string;
+        if hasParquetSupport {
+          use SysCTypes, CPtr;
+          extern proc c_getVersionInfo(): c_string;
+          extern proc strlen(str): c_int;
+          extern proc c_free_string(ptr);
+          var cVersionString = c_getVersionInfo();
+          defer {
+            c_free_string(cVersionString: c_void_ptr);
+          }
+          arrowVNum = try! createStringWithNewBuffer(cVersionString,
+                                                     strlen(cVersionString));
+        } else {
+          arrowVNum = "Not built";
+        }
+        
         const cfg = new owned Config(
             arkoudaVersion = (ServerConfig.arkoudaVersion:string),
             ZMQVersion = try! "%i.%i.%i".format(Zmajor, Zminor, Zmicro),
             HDF5Version = try! "%i.%i.%i".format(H5major, H5minor, H5micro),
+            arrowVersion = arrowVNum,
             serverHostname = serverHostname,
             ServerPort = ServerPort,
             numLocales = numLocales,

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -110,7 +110,7 @@ module ServerConfig
         var H5major: c_uint, H5minor: c_uint, H5micro: c_uint;
         H5get_libversion(H5major, H5minor, H5micro);
 
-        var arrowVNum: string;
+        var arrowVNum = "Unsupported";
         if hasParquetSupport {
           use SysCTypes, CPtr;
           extern proc c_getVersionInfo(): c_string;
@@ -122,8 +122,6 @@ module ServerConfig
           }
           arrowVNum = try! createStringWithNewBuffer(cVersionString,
                                                      strlen(cVersionString));
-        } else {
-          arrowVNum = "Not built";
         }
         
         const cfg = new owned Config(


### PR DESCRIPTION
This PR adds the Arrow version to calls to `ak.get_config()` to allow users to see the version of Arrow their server has been built with. It is a bit unfortunate, but due to the circular dependency that would be created by importing the `Parquet` module into the `ServerConfig` module, we can't import the call to get the version info from the Parquet module and need to copy and paste that code into the `ServerConfig` file. 

One other idea I had was splitting that single function call into it's own module that didn't need to include `ServerConfig`, something like `ArrowVersion`, but I think I prefer just copying the code since it is relatively short in this case,  but am open to taking that approach if others prefer (or have better ideas).