### PR TITLE
Remove out of date comment about poor sort performance on IB

### DIFF
--- a/pydoc/usage/argsort.rst
+++ b/pydoc/usage/argsort.rst
@@ -4,8 +4,6 @@
 Sorting
 ************
 
-Note: The sorting algorithm in arkouda is currently optimized for a Cray interconnect with a high message rate. For now, sorting runs slowly on Infiniband because of the lower message rate, but upcoming changes to the Chapel runtime involving message buffering should greatly improve sorting speed.
-
 .. autofunction:: arkouda.argsort
 
 .. autofunction:: arkouda.coargsort


### PR DESCRIPTION
Sort performance was significantly improved with Aggregation, which
especially benefited InfiniBand. Performance on EDR/HDR IB is now ahead
of Aries so the comment is no longer accurate.