### PR TITLE
Closes #990: Logic error in Categorical.in1d and other methods

### DIFF
--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -85,11 +85,12 @@ class Categorical:
         self.ndim = self.codes.ndim
         self.shape = self.codes.shape
         self.name : Optional[str] = None
+        self.uses_all_categories = kwargs['uses_all_categories'] if 'uses_all_categories' in kwargs else True
 
     @classmethod
     @typechecked
-    def from_codes(cls, codes : pdarray, categories : Strings, 
-                          permutation=None, segments=None) -> Categorical:
+    def from_codes(cls, codes: pdarray, categories: Strings,
+                   permutation=None, segments=None, uses_all_categories=False) -> Categorical:
         """
         Make a Categorical from codes and categories arrays. If codes and 
         categories have already been pre-computed, this constructor saves 
@@ -121,7 +122,7 @@ class Categorical:
         if codes.dtype != akint64:
             raise TypeError("Codes must be pdarray of int64")
         return cls(None, codes=codes, categories=categories, 
-                            permutation=permutation, segments=segments)
+                   permutation=permutation, segments=segments, uses_all_categories=uses_all_categories)
 
     def to_ndarray(self) -> np.ndarray:
         """
@@ -301,8 +302,8 @@ class Categorical:
         g = GroupBy(self.codes)
         idx = self.categories[g.unique_keys]
         newvals = g.broadcast(arange(idx.size), permute=True)
-        return Categorical.from_codes(newvals, idx, permutation=g.permutation, 
-                                      segments=g.segments)
+        return Categorical.from_codes(newvals, idx, permutation=g.permutation,
+                                      segments=g.segments, uses_all_categories=True)
 
     @typechecked
     def contains(self, substr : str) -> pdarray:
@@ -450,18 +451,19 @@ class Categorical:
         >>> ak.in1d(cat,catTwo)
         array([False, False, False, False, False])
         """
-        reset_cat = self.reset_categories()
+        reset_cat = self if self.uses_all_categories else self.reset_categories()
         if isinstance(test, Categorical):
-            categoriesisin = in1d(reset_cat.categories, test.reset_categories().categories)
+            reset_test = test if test.uses_all_categories else test.reset_categories()
+            categoriesisin = in1d(reset_cat.categories, reset_test.categories)
         else:
             categoriesisin = in1d(reset_cat.categories, test)
         return categoriesisin[reset_cat.codes]
 
     def unique(self) -> Categorical:
         #__doc__ = unique.__doc__
-        reset_cat = self.reset_categories()
-        return Categorical.from_codes(arange(reset_cat.categories.size),
-                                      reset_cat.categories)
+        reset_cat = self if self.uses_all_categories else self.reset_categories()
+        return Categorical.from_codes(arange(reset_cat.categories.size), reset_cat.categories,
+                                      uses_all_categories=reset_cat.uses_all_categories)
 
     def group(self) -> pdarray:
         """

--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -283,7 +283,7 @@ class Categorical:
         if np.isscalar(key) and resolve_scalar_dtype(key) == 'int64':
             return self.categories[self.codes[key]]
         else:
-            return Categorical.from_codes(self.codes[key], self.categories)
+            return Categorical.from_codes(self.codes[key], self.categories).reset_categories()
 
     def reset_categories(self) -> Categorical:
         """
@@ -450,16 +450,18 @@ class Categorical:
         >>> ak.in1d(cat,catTwo)
         array([False, False, False, False, False])
         """
-        if isinstance(test,Categorical):
-            categoriesisin = in1d(self.categories, test.categories)
+        reset_cat = self.reset_categories()
+        if isinstance(test, Categorical):
+            categoriesisin = in1d(reset_cat.categories, test.reset_categories().categories)
         else:
-            categoriesisin = in1d(self.categories, test)
-        return categoriesisin[self.codes]
+            categoriesisin = in1d(reset_cat.categories, test)
+        return categoriesisin[reset_cat.codes]
 
     def unique(self) -> Categorical:
         #__doc__ = unique.__doc__
-        return Categorical.from_codes(arange(self.categories.size), 
-                                      self.categories)
+        reset_cat = self.reset_categories()
+        return Categorical.from_codes(arange(reset_cat.categories.size),
+                                      reset_cat.categories)
 
     def group(self) -> pdarray:
         """

--- a/tests/categorical_test.py
+++ b/tests/categorical_test.py
@@ -234,6 +234,22 @@ class CategoricalTest(ArkoudaTest):
             print(f"==> cat_from_hdf.size:{cat_from_hdf.size}")
             self.assertTrue(cat_from_hdf.size == num_elems-1)
 
+    def test_unused_categories_logic(self):
+        """
+        Test that Categoricals built from_codes and from slices that have unused categories behave correctly
+        """
+        s = ak.array([str(i) for i in range(10)])
+        s12 = s[1:3]
+        cat = ak.Categorical(s)
+        cat12 = cat[1:3]
+        self.assertListEqual(ak.in1d(s, s12).to_ndarray().tolist(), ak.in1d(cat, cat12).to_ndarray().tolist())
+        self.assertSetEqual(set(ak.unique(s12).to_ndarray().tolist()), set(ak.unique(cat12).to_ndarray().tolist()))
+
+        cat_from_codes = ak.Categorical.from_codes(ak.array([1, 2]), s)
+        self.assertListEqual(ak.in1d(s, s12).to_ndarray().tolist(), ak.in1d(cat, cat_from_codes).to_ndarray().tolist())
+        self.assertSetEqual(set(ak.unique(s12).to_ndarray().tolist()), set(ak.unique(cat_from_codes).to_ndarray().tolist()))
+
+
     def testSaveAndLoadCategoricalMulti(self):
         """
         Test to build a pseudo dataframe with multiple categoricals, pdarrays, strings objects and successfully


### PR DESCRIPTION
This PR (Closes #990):
- Resets categories for `Categoricals` built from slices
- Resets categories for `Categorical.unique` and `Categorical.in1d`

Example:

set up (same for before and after):
```python
s = ak.array([str(i) for i in range(10)])
cat = ak.Categorical(s)
cat_slice = cat[1:3]
cat_from_codes = ak.Categorical.from_codes(ak.array([1, 2]), s)
```

before PR:
```python
# unused categories present for slices
>>> cat_slice.categories
array(['6', '0', '5', '4', '9', '2', '7', '8', '1', '3'])

# user specified categories remain unchanged
>>> cat_from_codes.categories
array(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'])

# in1d returns incorrect result
>>> ak.in1d(cat, cat_slice)
array([True True True True True True True True True True])
>>> cat.in1d(cat_from_codes)
array([True True True True True True True True True True])

# unique returns incorrect result
>>> cat_slice.unique()
array(['6', '0', '5', '4', '9', '2', '7', '8', '1', '3'])
>>> ak.unique(cat_from_codes)
array(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'])
```
after PR:
```python
# unused categories removed for slices
>>> cat_slice.categories
array(['1', '2'])

# user specified categories remain unchanged (but still operate logically)
>>> cat_from_codes.categories
array(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'])

# in1d returns expected result
>>> ak.in1d(cat, cat_slice)
array([False True True False False False False False False False])
>>> cat.in1d(cat_from_codes)
array([False True True False False False False False False False])

# unique returns expected result
>>> cat_slice.unique()
array(['2', '1'])
>>> ak.unique(cat_from_codes)
array(['1', '2'])
```