### PR TITLE
Cache the server config string instead of recreating it

### DIFF
--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -125,14 +125,13 @@ module ServerConfig
             regexMaxCaptures = regexMaxCaptures,
             byteorder = try! getByteorder()
         );
+        return try! "%jt".format(cfg);
 
-        return cfg;
     }
-    private const cfg = createConfig();
+    private const cfgStr = createConfig();
 
     proc getConfig(): string {
-        var res: string = try! "%jt".format(cfg);
-        return res;
+        return cfgStr;
     }
 
     proc getEnv(name: string, default=""): string {


### PR DESCRIPTION
Cache the string the server returns for `ak.get_config()` instead of
recomputing it each time. While working on #982 I noticed that the we
were reconstructing the string from the cached config object each time,
but we can just cache the string directly instead.

This makes `ak.get_config()` a little faster and avoids the performance
loss seen in #982 while I continue to dig into the root cause.