### PR TITLE
Drop in1d down to 1 trial

### DIFF
--- a/benchmarks/in1d.py
+++ b/benchmarks/in1d.py
@@ -43,7 +43,7 @@ def create_parser():
     parser.add_argument('hostname', help='Hostname of arkouda server')
     parser.add_argument('port', type=int, help='Port of arkouda server')
     parser.add_argument('-n', '--size', type=int, default=10**7, help='Problem size: length of array a')
-    parser.add_argument('-t', '--trials', type=int, default=3, help='Number of times to run the benchmark')
+    parser.add_argument('-t', '--trials', type=int, default=1, help='Number of times to run the benchmark')
     parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
     return parser
     


### PR DESCRIPTION
This benchmark is timing out under 16-node-cs-hdr testing (which we just
got running again.) Decrease the number of trials to hopefully avoid the
timeout while we work to tune performance in #970.