### PR TITLE
Change Parquet C++ types from int to int64_t and reorganization

### DIFF
--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -1,36 +1,44 @@
+#include <stdint.h>
+
 // Wrap functions in C extern if compiling C++ object file
 #ifdef __cplusplus
+#include <iostream>
+#include <arrow/api.h>
+#include <arrow/io/api.h>
+#include <parquet/arrow/reader.h>
+#include <parquet/arrow/writer.h>
+#include <parquet/column_reader.h>
 extern "C" {
 #endif
-
-  #define ARROWINT64 0
-  #define ARROWINT32 1
-  #define ARROWUNDEFINED -1
-  #define ARROWERROR -1
+  
+#define ARROWINT64 0
+#define ARROWINT32 1
+#define ARROWUNDEFINED -1
+#define ARROWERROR -1
 
   // Each C++ function contains the actual implementation of the
   // functionality, and there is a corresponding C function that
   // Chapel can call into through C interoperability, since there
   // is no C++ interoperability supported in Chapel today.
-  int c_getNumRows(const char*, char** errMsg);
-  int cpp_getNumRows(const char*, char** errMsg);
+  int64_t c_getNumRows(const char*, char** errMsg);
+  int64_t cpp_getNumRows(const char*, char** errMsg);
 
   int c_readColumnByName(const char* filename, void* chpl_arr,
-                         const char* colname, int numElems, int batchSize,
+                         const char* colname, int64_t numElems, int64_t batchSize,
                          char** errMsg);
   int cpp_readColumnByName(const char* filename, void* chpl_arr,
-                           const char* colname, int numElems, int batchSize,
+                           const char* colname, int64_t numElems, int64_t batchSize,
                            char** errMsg);
 
   int c_getType(const char* filename, const char* colname, char** errMsg);
   int cpp_getType(const char* filename, const char* colname, char** errMsg);
 
   int cpp_writeColumnToParquet(const char* filename, void* chpl_arr,
-                               int colnum, const char* dsetname, int numelems,
-                               int rowGroupSize, char** errMsg);
+                               int64_t colnum, const char* dsetname, int64_t numelems,
+                               int64_t rowGroupSize, char** errMsg);
   int c_writeColumnToParquet(const char* filename, void* chpl_arr,
-                             int colnum, const char* dsetname, int numelems,
-                             int rowGroupSize, char** errMsg);
+                             int64_t colnum, const char* dsetname, int64_t numelems,
+                             int64_t rowGroupSize, char** errMsg);
     
   const char* c_getVersionInfo(void);
   const char* cpp_getVersionInfo(void);


### PR DESCRIPTION
In the initial Parquet work, I was naively using `int` for all of my Arrow code, even in places where `int64_t` made more sense. What this means is that, before this PR, the maximum size for a Parquet file that could be read/written was `2^32` elements large. This PR updates those places to be `int64_t` instead of `int` and also moves includes to the header file.