### PR TITLE
Add support for reading timestamps in Parquet files

### DIFF
--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -84,10 +84,12 @@ int cpp_getType(const char* filename, const char* colname, char** errMsg) {
   }
   auto myType = sc -> field(idx) -> type();
 
-  if(myType == arrow::int64())
+  if(myType->id() == arrow::Type::INT64)
     return ARROWINT64;
-  else if(myType == arrow::int32())
+  else if(myType->id() == arrow::Type::INT32)
     return ARROWINT32;
+  else if(myType->id() == arrow::Type::TIMESTAMP)
+    return ARROWTIMESTAMP;
   else // TODO: error type not supported
     return ARROWUNDEFINED;
 }

--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -10,9 +10,10 @@
 #include <parquet/column_reader.h>
 extern "C" {
 #endif
-  
+
 #define ARROWINT64 0
 #define ARROWINT32 1
+#define ARROWTIMESTAMP ARROWINT64
 #define ARROWUNDEFINED -1
 #define ARROWERROR -1
 


### PR DESCRIPTION
This PR adds checking for the `timestamp` Arrow type in a Parquet column and treats it as an `int64`, which is its underlying physical type. Also, the type checking for `int64` and `int32` are updated to check against the type enum rather than a type instance.

Resolves https://github.com/Bears-R-Us/arkouda/issues/1026