### PR TITLE
Recommend Chapel 1.25.1 and use it for CI testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.25.0
+      image: chapel/chapel:1.25.1
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
@@ -33,7 +33,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.25.0
+      image: chapel/chapel:1.25.1
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
@@ -51,7 +51,7 @@ jobs:
   #    matrix:
   #      python-version: ['3.7', '3.8', '3.9', '3.x']
   #  container:
-  #    image: chapel/chapel:1.25.0
+  #    image: chapel/chapel:1.25.1
   #  steps:
   #  - uses: actions/checkout@v2
   #  - name: Set up Python ${{ matrix.python-version }}
@@ -85,7 +85,7 @@ jobs:
     env:
       CHPL_RT_NUM_THREADS_PER_LOCALE: ${{matrix.threads}}
     container:
-      image: chapel/${{matrix.image}}:1.25.0
+      image: chapel/${{matrix.image}}:1.25.1
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
@@ -120,7 +120,7 @@ jobs:
       matrix:
         image: [chapel, chapel-gasnet-smp]
     container:
-      image: chapel/${{matrix.image}}:1.25.0
+      image: chapel/${{matrix.image}}:1.25.1
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository == 'Bears-R-Us/arkouda'
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.25.0
+      image: chapel/chapel:1.25.1
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ ifneq ($(CHPL_VERSION_OK),yes)
 	$(error Chapel 1.24.0 or newer is required)
 endif
 ifeq ($(CHPL_VERSION_WARN),yes)
-	$(warning Chapel 1.25.0 or newer is recommended)
+	$(warning Chapel 1.25.1 or newer is recommended)
 endif
 
 ZMQ_CHECK = $(DEP_INSTALL_DIR)/checkZMQ.chpl

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ This yielded a >20TB dataframe in Arkouda.
 
 <a id="prereq-reqs"></a>
 ### Requirements: <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
- * requires chapel 1.25.0
+ * requires chapel 1.25.1
  * requires zeromq version >= 4.2.5, tested with 4.2.5 and 4.3.1
  * requires hdf5 
  * requires python 3.7 or greater
@@ -159,7 +159,7 @@ Option 2: Build Chapel from source
 
 ```bash
 # build chapel in the user home directory with these settings...
-export CHPL_HOME=~/chapel/chapel-1.25.0
+export CHPL_HOME=~/chapel/chapel-1.25.1
 source $CHPL_HOME/util/setchplenv.bash
 export CHPL_COMM=gasnet
 export CHPL_COMM_SUBSTRATE=smp
@@ -220,9 +220,9 @@ sudo apt-get update
 sudo apt-get install gcc g++ m4 perl python python-dev python-setuptools bash make mawk git pkg-config
 
 # Download latest Chapel release, explode archive, and navigate to source root directory
-wget https://github.com/chapel-lang/chapel/releases/download/1.25.0/chapel-1.25.0.tar.gz
-tar xvf chapel-1.25.0.tar.gz
-cd chapel-1.25.0/
+wget https://github.com/chapel-lang/chapel/releases/download/1.25.1/chapel-1.25.1.tar.gz
+tar xvf chapel-1.25.1.tar.gz
+cd chapel-1.25.1/
 
 # Set CHPL_HOME
 export CHPL_HOME=$PWD

--- a/pydoc/setup/prerequisites.rst
+++ b/pydoc/setup/prerequisites.rst
@@ -7,7 +7,7 @@ Prerequisites
 *******************
 Chapel
 *******************
-(version 1.25.0 or greater)
+(version 1.25.1 or greater)
 
 The arkouda server application is written in Chapel_, a productive and performant parallel programming language. In order to use arkouda, you must first `download the current version of Chapel`_ and build it according to the instructions_ for your platform(s). Below are tips for building Chapel to support arkouda.
 


### PR DESCRIPTION
Chapel 1.25.1 includes:
- llvm portability fixes
- memory tracking optimizations that are important for arkouda regexs
- reduction in memory allocations for Chapel regex routines
- bug fix for sporadic failures on XC

This changes the documentation to require 1.25.1, but only recommends it
in the Makefile instead of making it an error. Arkouda should continue
to work with Chapel 1.24 so existing users don't necessarily have to
upgrade, but I would recommend it for the performance gains.