### PR TITLE
Optimize Parquet file writing with WriteBatch function

### DIFF
--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -8,6 +8,7 @@
 #include <parquet/arrow/reader.h>
 #include <parquet/arrow/writer.h>
 #include <parquet/column_reader.h>
+#include <parquet/api/writer.h>
 extern "C" {
 #endif
 


### PR DESCRIPTION
This PR changes from using the simple `WriteTable` function provided by the Parquet API to a lower-level `WriteBatch` function that allows greater control of writes. This optimization to Parquet writing in Arkodua is very similar to the reading optimization from https://github.com/Bears-R-Us/arkouda/pull/1014. 

Performance numbers collected on chapcs:
Current | This Branch
-- | --
0.11 GiB/s | 1.09 GiB/s

So we are seeing about a 10x improvement for writing Parquet files on chapcs.