### PR TITLE
re-add sort distributions benchmark

### DIFF
--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -23,7 +23,7 @@ BENCHMARKS = [
     'stream', 'argsort', 'coargsort', 'groupby', 'aggregate', 'gather',
     'scatter', 'reduce', 'in1d', 'scan', 'noop', 'setops', 'array_create',
     'array_transfer', 'IO', 'str-argsort', 'str-coargsort', 'str-groupby',
-    'str-gather', 'str-in1d', 'substring_search', 'flatten',
+    'str-gather', 'str-in1d', 'substring_search', 'flatten', 'sort-cases',
 ]
 
 if os.getenv('ARKOUDA_SERVER_PARQUET_SUPPORT'):


### PR DESCRIPTION
@ronawho [pointed out](https://github.com/Bears-R-Us/arkouda/pull/977#issuecomment-1011424357) that the `sort-cases.py` benchmark accidentally got dropped from the list, so this PR adds it back in.