### PR TITLE
Part of Issue #940: Simplify Regex Substring Search Methods

### DIFF
--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -748,6 +748,8 @@ class Strings:
             matcher = self._get_matcher(substr, create=False)
             if matcher is not None:
                 return matcher.get_match(MatchType.MATCH, self).matched()
+            else:
+                return self.contains('^' + substr, regex=True)
         cmd = "segmentedEfunc"
         args = "{} {} {} {} {} {} {}".format("startswith",
                                              self.objtype,

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -196,11 +196,6 @@ module SegmentedMsg {
                       truth.a = strings.substringSearch(val, SearchMode.endsWith, regex);
                       repMsg = "created "+st.attrib(rname);
                   }
-                  when "match" {
-                      var truth = st.addEntry(rname, strings.size, bool);
-                      truth.a = strings.substringSearch(val, SearchMode.match, regex);
-                      repMsg = "created "+st.attrib(rname);
-                  }
                   otherwise {
                       var errorMsg = notImplementedError(pn, "subcmd: %s, (%s, %s)".format(
                                   subcmd, objtype, valtype));


### PR DESCRIPTION
Part of Issue #940: Simplify regex substring search methods to only use Regex.search

- Reroutes `startswith` to return `self.contains('^' + substr, regex=True)` when regex is true and no matcher object has been created 
  - Note we already do this for `endswith`, returning`self.contains(substr + '$', regex=True)`
- Simplifies `substringSearchRegex` by only using `Regex.search` 
- Removes chapel code referencing `match` searchmode as this was removed in #958 