### PR TITLE
Closes #1031: Remove non-regex substring search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ endif
 
 .PHONY: check-deps
 ifndef ARKOUDA_SKIP_CHECK_DEPS
-CHECK_DEPS = check-chpl check-zmq check-hdf5 $(OPTIONAL_CHECKS)
+CHECK_DEPS = check-chpl check-zmq check-hdf5 check-re2 $(OPTIONAL_CHECKS)
 endif
 check-deps: $(CHECK_DEPS)
 
@@ -178,6 +178,13 @@ check-zmq: $(ZMQ_CHECK)
 HDF5_CHECK = $(DEP_INSTALL_DIR)/checkHDF5.chpl
 check-hdf5: $(HDF5_CHECK)
 	@echo "Checking for HDF5"
+	$(CHPL) $(CHPL_FLAGS) $< -o $(DEP_INSTALL_DIR)/$@
+	$(DEP_INSTALL_DIR)/$@ -nl 1
+	@rm -f $(DEP_INSTALL_DIR)/$@ $(DEP_INSTALL_DIR)/$@_real
+
+RE2_CHECK = $(DEP_INSTALL_DIR)/checkRE2.chpl
+check-re2: $(RE2_CHECK)
+	@echo "Checking for RE2"
 	$(CHPL) $(CHPL_FLAGS) $< -o $(DEP_INSTALL_DIR)/$@
 	$(DEP_INSTALL_DIR)/$@ -nl 1
 	@rm -f $(DEP_INSTALL_DIR)/$@ $(DEP_INSTALL_DIR)/$@_real

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ export CHPL_COMM_SUBSTRATE=smp
 export CHPL_TARGET_CPU=native
 export GASNET_QUIET=Y
 export CHPL_RT_OVERSUBSCRIBED=yes
+export CHPL_RE2=bundled
 cd $CHPL_HOME
 make
 
@@ -236,6 +237,7 @@ export CHPL_COMM_SUBSTRATE=smp
 export CHPL_TARGET_CPU=native
 export GASNET_QUIET=Y
 export CHPL_RT_OVERSUBSCRIBED=yes
+export CHPL_RE2=bundled
 cd $CHPL_HOME
 make
 

--- a/dep/checkRE2.chpl
+++ b/dep/checkRE2.chpl
@@ -1,0 +1,14 @@
+use Version;
+
+proc main() {
+  if chplVersion < createVersion(1,25) {
+    use Regexp;
+    var myRegex = compile("a+");
+  }
+  else {
+    use Regex;
+    var myRegex = compile("a+");
+  }
+  writeln("Chapel correctly made with RE2 support\n");
+  return 0;
+}

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -711,12 +711,9 @@ module SegmentedArray {
       :arg pattern: regex pattern to be applied to strings in SegString
       :type pattern: string
 
-      :arg mode: mode of search being performed (contains, startsWith, endsWith, match)
-      :type mode: SearchMode enum
-
       :returns: [domain] bool where index i indicates whether the regular expression, pattern, matched string i of the SegString
     */
-    proc substringSearchRegex(const pattern: string) throws {
+    proc substringSearch(const pattern: string) throws {
       var hits: [offsets.aD] bool = false;  // the answer
       checkCompile(pattern);
 
@@ -727,68 +724,6 @@ module SegmentedArray {
       forall (o, l, h) in zip(oa, lengths, hits) with (var myRegex = _unsafeCompileRegex(pattern)) {
         // regexp.search searches the receiving string for matches at any offset
         h = myRegex.search(interpretAsString(va, o..#l, borrow=true)).matched;
-      }
-      return hits;
-    }
-    
-    proc substringSearch(const substr: string, mode: SearchMode, regex: bool = false) throws {
-      if regex {
-        return substringSearchRegex(substr);
-      }
-      var hits: [offsets.aD] bool;  // the answer
-      if (size == 0) || (substr.size == 0) {
-        return hits;
-      }
-      var t = new Timer();
-
-      if logLevel == LogLevel.DEBUG {
-           saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                "Checking bytes of substr"); 
-           t.start();
-      }
-      const truth = findSubstringInBytes(substr);
-      const D = truth.domain;
-      if logLevel == LogLevel.DEBUG {
-            t.stop(); 
-            saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                  "took %t seconds\nTranslating to segments...".format(t.elapsed())); 
-            t.clear(); 
-            t.start();
-      }
-      // Need to ignore segment(s) at the end of the array that are too short to contain substr
-      const tail = + reduce (offsets.a > D.high);
-      // oD is the right-truncated domain representing segments that are candidates for containing substr
-      var oD: subdomain(offsets.aD) = offsets.aD[offsets.aD.low..#(offsets.size - tail)];
-      if logLevel == LogLevel.DEBUG {
-             t.stop(); 
-             saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                   "took %t seconds\ndetermining answer...".format(t.elapsed())); 
-             t.clear(); 
-             t.start();
-      }
-      ref oa = offsets.a;
-      if mode == SearchMode.contains {
-        // Determine whether each segment contains a hit
-        // Do this by taking the difference in the cumulative number of hits at the end vs the beginning of the segment  
-        // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
-        overMemLimit(numBytes(int) * truth.size);
-        // Cumulative number of hits up to (and excluding) this point
-        var numHits = (+ scan truth) - truth;
-        hits[oD.interior(-(oD.size-1))] = (numHits[oa[oD.interior(oD.size-1)]] - numHits[oa[oD.interior(-(oD.size-1))]]) > 0;
-        hits[oD.high] = (numHits[D.high] + truth[D.high] - numHits[oa[oD.high]]) > 0;
-      } else if mode == SearchMode.startsWith {
-        // First position of segment must be a hit
-        hits[oD] = truth[oa[oD]];
-      } else if mode == SearchMode.endsWith {
-        // Position where substr aligns with end of segment must be a hit
-        // -1 for null byte
-        hits[oD.interior(-(oD.size-1))] = truth[oa[oD.interior(oD.size-1)] - substr.numBytes - 1];
-        hits[oD.high] = truth[D.high-1];
-      }
-      if logLevel == LogLevel.DEBUG {
-          t.stop(); 
-          saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                   "took %t seconds".format(t.elapsed()));
       }
       return hits;
     }
@@ -1138,9 +1073,6 @@ module SegmentedArray {
   }
 
 
-  enum SearchMode { contains, startsWith, endsWith, match }
-  class UnknownSearchMode: Error {}
-  
   /* Test for equality between two same-length arrays of strings. Returns
      a boolean vector of the same length. */
   operator ==(lss:SegString, rss:SegString) throws {

--- a/test/UnitTestSubstringSearch.chpl
+++ b/test/UnitTestSubstringSearch.chpl
@@ -20,15 +20,15 @@ proc make_strings(substr, n, minLen, maxLen, characters, mode, st) {
   forall (p, rn, o, l) in zip(present, r, segs, lengths) {
     if p {
       var i: int;
-      if mode == SearchMode.contains {
+      if mode == 'contains' {
         if l == nb {
           i = 0;
         } else {
           i = rn % (l - nb);
         }
-      } else if mode == SearchMode.startsWith {
+      } else if mode == 'startsWith' {
         i = 0;
-      } else if mode == SearchMode.endsWith {
+      } else if mode == 'endsWith' {
         i = l - nb;
       }
       vals[{(o+i)..#nb}] = sbytes;
@@ -39,7 +39,7 @@ proc make_strings(substr, n, minLen, maxLen, characters, mode, st) {
   return (present, strings2);
 }
 
-proc test_search(substr:string, n:int, minLen:int, maxLen:int, characters:charSet = charSet.Uppercase, mode: SearchMode = SearchMode.contains) throws {
+proc test_search(substr:string, n:int, minLen:int, maxLen:int, characters:charSet = charSet.Uppercase, mode = 'contains') throws {
   var st = new owned SymTab();
   var d: Diags;
   writeln("Generating random strings..."); stdout.flush();
@@ -48,11 +48,17 @@ proc test_search(substr:string, n:int, minLen:int, maxLen:int, characters:charSe
   d.stop("make_strings");
   writeln("Searching for substring..."); stdout.flush();
   d.start();
-  var truth = strings.substringSearch(substr, mode);
+  var regexSubstr = substr;
+  if mode == 'startsWith' {
+    regexSubstr = '^'+substr;
+  } else if mode == 'endsWith' {
+    regexSubstr = substr+'$';
+  } 
+  var truth = strings.substringSearch(regexSubstr);
   d.stop("substringSearch");
   var nFound = + reduce truth;
   if DEBUG && (nFound > 0) {
-    writeln("Found %t strings containing %s".format(nFound, substr)); stdout.flush();
+    writeln("Found %t strings containing %s".format(nFound, regexSubstr)); stdout.flush();
     var (mSegs, mVals) = strings[truth];
     var matches = getSegString(mSegs, mVals, st);
     matches.show(5);
@@ -104,7 +110,7 @@ proc test_search(substr:string, n:int, minLen:int, maxLen:int, characters:charSe
 }
 
 proc main() {
-  for mode in (SearchMode.contains, SearchMode.startsWith, SearchMode.endsWith) {
+  for mode in ('contains', 'startsWith', 'endsWith') {
     writeln("\n", mode);
     try! test_search(SUBSTRING, N, MINLEN, MAXLEN, mode=mode);
   }

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -394,7 +394,8 @@ class StringTest(ArkoudaTest):
         g = self._get_ak_gremlins()
         run_test_ends_with(g.gremlins_strings, g.gremlins_test_strings, ' ')
         run_test_ends_with(g.gremlins_strings, g.gremlins_test_strings, '"')
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
+            # updated to raise ValueError since regex doesn't currently support patterns matching empty string
             self.assertFalse(run_test_ends_with(g.gremlins_strings,
                                             g.gremlins_test_strings, ''))
     


### PR DESCRIPTION
Closes #1031:
Decreases size and complexity of substring search code by escaping non-regex patterns instead of doing specialized methods. Early benchmarking suggests this may be faster as well

NOTE: this would require users to compile chapel with regex support in order to use the substring search methods. I think that is reasonable especially if the resulting methods are faster