### PR TITLE
Update compatibility to numpy - 1.21.5

### DIFF
--- a/arkouda/dtypes.py
+++ b/arkouda/dtypes.py
@@ -19,22 +19,23 @@ NUMBER_FORMAT_STRINGS = {'bool': '{}',
                          'np.float64': 'f'}
 
 dtype = np.dtype
-bool = np.dtype(np.bool)
+bool = np.dtype(bool)
 int64 = np.dtype(np.int64)
 float64 = np.dtype(np.float64)
 uint8 = np.dtype(np.uint8)
 str_ = np.dtype(np.str_)
-npstr = np.dtype(np.str)
+npstr = np.dtype(str)
 
 # Union aliases used for static and runtime type checking
-bool_scalars = Union[builtins.bool,np.bool]
+bool_scalars = Union[builtins.bool, np.bool_]
 float_scalars = Union[float,np.float64]
 int_scalars = Union[int,np.int64]
-numeric_scalars = Union[float,np.float64,int,np.int64]
-numpy_scalars = Union[np.float64,np.int64,np.bool,np.uint8,np.str,np.str_]
-str_scalars = Union[str, np.str, np.str_]
+numeric_scalars = Union[float,np.float64,int,np.int64,np.uint8]
+numeric_and_bool_scalars = Union[bool_scalars, numeric_scalars]
+numpy_scalars = Union[np.float64,np.int64,np.bool_,np.uint8,np.str_]
+str_scalars = Union[str, np.str_]
 all_scalars = Union[float,np.float64,int,np.int64,
-                                  builtins.bool,np.bool,str,np.str,np.str_]
+                                  builtins.bool,np.bool_,str,np.str_]
 
 '''
 The DType enum defines the supported Arkouda data types in string form.
@@ -78,8 +79,8 @@ SeriesDTypes = {'string' : np.str_,
                  "<class 'numpy.int64'>" : np.int64,                
                  'float64' : np.float64,
                  "<class 'numpy.float64'>" : np.float64,                   
-                 'bool' : np.bool,
-                 "<class 'bool'>" : np.bool,
+                 'bool' : bool,
+                 "<class 'bool'>" : bool,
                  'datetime64[ns]' : np.int64,
                  'timedelta64[ns]' : np.int64
                 }
@@ -140,7 +141,7 @@ def resolve_scalar_dtype(val : object) -> str: # type: ignore
     """
     # Python bool or np.bool
     if isinstance(val, builtins.bool) or (hasattr(val, 'dtype') \
-                                and cast(np.bool,val).dtype.kind == 'b'):
+                                and cast(np.bool_,val).dtype.kind == 'b'):
         return 'bool'
     # Python int or np.int* or np.uint*
     elif isinstance(val, int) or (hasattr(val, 'dtype') and \
@@ -148,13 +149,13 @@ def resolve_scalar_dtype(val : object) -> str: # type: ignore
         return 'int64'
     # Python float or np.float*
     elif isinstance(val, float) or (hasattr(val, 'dtype') and \
-                                    cast(np.float, val).dtype.kind == 'f'):
+                                    cast(np.float_, val).dtype.kind == 'f'):
         return 'float64'
-    elif isinstance(val, builtins.str) or isinstance(val, np.str):
+    elif isinstance(val, builtins.str) or isinstance(val, np.str_):
         return 'str'
     # Other numpy dtype
     elif hasattr(val, 'dtype'):
-        return cast(np.dtype, val).dtype.name
+        return cast(np.dtype, val).name
     # Other python type
     else:
         return builtins.str(type(val))

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -442,10 +442,10 @@ def where(condition : pdarray, A : Union[numeric_scalars, pdarray],
             dt = dtA
         # If the dtypes are different, try casting one direction then the other
         elif dtB in DTypes and np.can_cast(A, dtB):
-            A = np.dtype(dtB).type(A)
+            A = np.dtype(dtB).type(A)  # type: ignore
             dt = dtB
         elif dtA in DTypes and np.can_cast(B, dtA):
-            B = np.dtype(dtA).type(B)
+            B = np.dtype(dtA).type(B)  # type: ignore
             dt = dtA
         # Cannot safely cast
         else:

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -6,7 +6,7 @@ import numpy as np # type: ignore
 from arkouda.client import generic_msg
 from arkouda.dtypes import dtype, DTypes, resolve_scalar_dtype, \
      translate_np_dtype, NUMBER_FORMAT_STRINGS, \
-     int_scalars, numeric_scalars, numpy_scalars, get_server_byteorder
+     int_scalars, numeric_scalars, numeric_and_bool_scalars, numpy_scalars, get_server_byteorder
 from arkouda.dtypes import int64 as akint64
 from arkouda.dtypes import str_ as akstr_
 from arkouda.dtypes import bool as npbool
@@ -136,7 +136,7 @@ class pdarray:
         from arkouda.client import pdarrayIterThresh
         return generic_msg(cmd='repr',args='{} {}'.format(self.name,pdarrayIterThresh))
 
-    def format_other(self, other : object) -> np.dtype:
+    def format_other(self, other : object) -> str:
         """
         Attempt to cast scalar other to the element dtype of this pdarray,
         and print the resulting value to a string (e.g. for sending to a
@@ -149,7 +149,7 @@ class pdarray:
             
         Returns
         -------
-        np.dtype corresponding to the other parameter
+        string representation of np.dtype corresponding to the other parameter
         
         Raises
         ------
@@ -627,7 +627,7 @@ class pdarray:
         """
         return is_sorted(self)
 
-    def sum(self) -> numpy_scalars:
+    def sum(self) -> numeric_and_bool_scalars:
         """
         Return the sum of all elements in the array.
         """
@@ -1302,7 +1302,7 @@ def create_pdarray(repMsg : str) -> pdarray:
         raise ValueError(e)
     logger.debug(("created Chapel array with name: {} dtype: {} size: {} ndim: {} shape: {} " +
                   "itemsize: {}").format(name, mydtype, size, ndim, shape, itemsize))
-    return pdarray(name, mydtype, size, ndim, shape, itemsize)
+    return pdarray(name, dtype(mydtype), size, ndim, shape, itemsize)
 
 def clear() -> None:
     """
@@ -1567,7 +1567,7 @@ def mean(pda : pdarray) -> np.float64:
     RuntimeError
         Raised if there's a server-side error thrown
     """
-    return pda.sum() / pda.size
+    return np.float64(pda.sum()) / pda.size
 
 @typechecked
 def var(pda : pdarray, ddof : int_scalars=0) -> np.float64:

--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -1,3 +1,4 @@
+import builtins
 import itertools
 import numpy as np # type: ignore
 import pandas as pd # type: ignore
@@ -217,7 +218,7 @@ def _array_memview(a) -> memoryview:
         return memoryview(a)
 
 
-def zeros(size : int_scalars, dtype : type=np.float64) -> pdarray:
+def zeros(size : int_scalars, dtype=float64) -> pdarray:
     """
     Create a pdarray filled with zeros.
 
@@ -266,7 +267,7 @@ def zeros(size : int_scalars, dtype : type=np.float64) -> pdarray:
     
     return create_pdarray(repMsg)
 
-def ones(size : int_scalars, dtype : type=float64) -> pdarray:
+def ones(size : int_scalars, dtype=float64) -> pdarray:
     """
     Create a pdarray filled with ones.
 

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -142,13 +142,14 @@ def in1d(pda1 : Union[pdarray,Strings,'Categorical'], pda2 : Union[pdarray,Strin
     array([False, True])
     """
     from arkouda.categorical import Categorical as Categorical_
+    from arkouda.dtypes import bool as ak_bool
     if isinstance(pda1, pdarray) or isinstance(pda1, Strings) or isinstance (pda1, Categorical_):
         # While isinstance(thing, type) can be called on a tuple of types, this causes an issue with mypy for unknown reasons.
         if pda1.size == 0:
-            return  zeros(0, dtype=bool)
+            return  zeros(0, dtype=ak_bool)
     if isinstance(pda2, pdarray) or isinstance(pda2, Strings) or isinstance(pda2, Categorical_):
         if pda2.size == 0:
-            return  zeros(pda1.size, dtype=bool)
+            return  zeros(pda1.size, dtype=ak_bool)
     if hasattr(pda1, 'categories'):
         return cast(Categorical_,pda1).in1d(pda2)
     elif isinstance(pda1, pdarray) and isinstance(pda2, pdarray):
@@ -216,7 +217,8 @@ def concatenate(arrays : Sequence[Union[pdarray,Strings,'Categorical']], #type: 
 
     """
     from arkouda.categorical import Categorical as Categorical_
-    size = 0
+    from arkouda.dtypes import int_scalars
+    size:int_scalars = 0
     objtype = None
     dtype = None
     names = []

--- a/arkouda/sorting.py
+++ b/arkouda/sorting.py
@@ -5,7 +5,7 @@ from arkouda.client import generic_msg
 from arkouda.pdarrayclass import pdarray, create_pdarray
 from arkouda.pdarraycreation import zeros
 from arkouda.strings import Strings
-from arkouda.dtypes import int64, float64
+from arkouda.dtypes import int64, float64, int_scalars
 from enum import Enum
 
 numeric_dtypes = {float64,int64}
@@ -114,7 +114,7 @@ def coargsort(arrays: Sequence[Union[Strings, pdarray, 'Categorical']], algorith
     """
     from arkouda.categorical import Categorical
     check_type(argname='coargsort', value=arrays, expected_type=Sequence[Union[pdarray, Strings, Categorical]])
-    size = -1
+    size:int_scalars = -1
     anames = []
     atypes = []
     for a in arrays:

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1281,8 +1281,9 @@ class Strings:
         """
         from arkouda.client import maxTransferBytes
         # Total number of bytes in the array data
-        my_sz, my_dt = (self.size, arkouda.dtypes.int64) if comp == "offsets" else (self.nbytes, arkouda.dtypes.uint8)
-        array_bytes = my_sz * my_dt.itemsize
+        # my_sz, my_dt = (self.size, arkouda.dtypes.int64) if comp == "offsets" else (self.nbytes, arkouda.dtypes.uint8)
+        # array_bytes = my_sz * my_dt.itemsize
+        array_bytes = self.size * arkouda.dtypes.int64.itemsize if comp == "offsets" else self.nbytes * arkouda.dtypes.uint8.itemsize
 
         # Guard against overflowing client memory
         if array_bytes > maxTransferBytes:
@@ -1297,7 +1298,7 @@ class Strings:
 
         # The server sends us native-endian bytes so we need to account for that.
         # Since bytes are immutable, we need to copy the np array to be mutable
-        dt = np.dtype(np.int64) if comp == "offsets" else np.dtype(np.uint8)
+        dt:np.dtype = np.dtype(np.int64) if comp == "offsets" else np.dtype(np.uint8)
         if arkouda.dtypes.get_server_byteorder() == 'big':
             dt = dt.newbyteorder('>')
         else:

--- a/arkouda/timeclass.py
+++ b/arkouda/timeclass.py
@@ -109,7 +109,7 @@ class _AbstractBaseTime(pdarray):
         else:
             raise TypeError("Unsupported type: {}".format(type(array)))
         # Now that self._data is correct, init self with same metadata
-        super().__init__(self._data.name, self._data.dtype.name, self._data.size, self._data.ndim, self._data.shape, self._data.itemsize)
+        super().__init__(self._data.name, self._data.dtype, self._data.size, self._data.ndim, self._data.shape, self._data.itemsize)
 
     @classmethod
     def _get_callback(cls, other, op):

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ setup(
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'numpy>=1.16.5,<=1.19.5',
+        'numpy>=1.16.5,<1.21.0',
         'pandas>=1.1.0',
         'pyzmq>=20.0.0,<=22.2.1',
         'typeguard==2.10.0',
@@ -150,7 +150,7 @@ setup(
     extras_require={  # Optional
         'dev': ['h5py','pexpect', 'pytest', 
                 'pytest-env','Sphinx', 'sphinx-argparse', 
-                'sphinx-autoapi', 'mypy'],
+                'sphinx-autoapi', 'mypy>=0.931', 'typed-ast'],
     },
     # replace original install command with version that also builds
     # chapel and the arkouda server.

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ setup(
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'numpy>=1.16.5,<1.21.0',
+        'numpy>=1.16.5,<=1.21.5',
         'pandas>=1.1.0',
         'pyzmq>=20.0.0,<=22.2.1',
         'typeguard==2.10.0',

--- a/tests/dtypes_tests.py
+++ b/tests/dtypes_tests.py
@@ -16,11 +16,13 @@ class DtypesTest(ArkoudaTest):
         :return: None
         :raise: AssertionError if 1.. test cases fail
         '''
-        dtypes.check_np_dtype(np.dtype(np.bool))
+        dtypes.check_np_dtype(np.dtype(np.bool_))
+        dtypes.check_np_dtype(np.dtype(bool))
         dtypes.check_np_dtype(np.dtype(np.int64))
         dtypes.check_np_dtype(np.dtype(np.float64))
         dtypes.check_np_dtype(np.dtype(np.uint8))
-        dtypes.check_np_dtype(np.dtype(np.str))
+        dtypes.check_np_dtype(np.dtype(np.str_))
+        dtypes.check_np_dtype(np.dtype(str))
 
         with self.assertRaises(TypeError):
             dtypes.check_np_dtype(np.dtype(np.int16))
@@ -34,21 +36,27 @@ class DtypesTest(ArkoudaTest):
         :return: None
         :raise: AssertionError if 1.. test cases fail
         '''
-        d_tuple = dtypes.translate_np_dtype(np.dtype(np.bool))
+        d_tuple = dtypes.translate_np_dtype(np.dtype(np.bool_))
+        self.assertEqual(1, d_tuple[1])
+        self.assertEqual('bool', d_tuple[0])
+        d_tuple = dtypes.translate_np_dtype(np.dtype(bool))
         self.assertEqual(1, d_tuple[1])
         self.assertEqual('bool', d_tuple[0])
         d_tuple = dtypes.translate_np_dtype(np.dtype(np.int64))
         self.assertEqual(8, d_tuple[1])
-        self.assertEqual('int', d_tuple[0])  
+        self.assertEqual('int', d_tuple[0])
         d_tuple = dtypes.translate_np_dtype(np.dtype(np.float64))
         self.assertEqual(8, d_tuple[1])
-        self.assertEqual('float', d_tuple[0])        
+        self.assertEqual('float', d_tuple[0])
         d_tuple = dtypes.translate_np_dtype(np.dtype(np.uint8))
         self.assertEqual(1, d_tuple[1])
-        self.assertEqual('uint',d_tuple[0])    
-        d_tuple = dtypes.translate_np_dtype(np.dtype(np.str))
+        self.assertEqual('uint',d_tuple[0])
+        d_tuple = dtypes.translate_np_dtype(np.dtype(np.str_))
         self.assertEqual(0, d_tuple[1])
-        self.assertEqual('str', d_tuple[0])   
+        self.assertEqual('str', d_tuple[0])
+        d_tuple = dtypes.translate_np_dtype(np.dtype(str))
+        self.assertEqual(0, d_tuple[1])
+        self.assertEqual('str', d_tuple[0])
 
         with self.assertRaises(TypeError):
             dtypes.check_np_dtype(np.dtype(np.int16))
@@ -120,26 +128,28 @@ class DtypesTest(ArkoudaTest):
         
     def test_SeriesDTypes(self):
         self.assertEqual(np.str_, dtypes.SeriesDTypes['string'])
-        self.assertEqual(np.str_, dtypes. SeriesDTypes["<class 'str'>"])
-        self.assertEqual(np.int64, dtypes. SeriesDTypes['int64'])
-        self.assertEqual(np.int64, dtypes. SeriesDTypes["<class 'numpy.int64'>"])
-        self.assertEqual(np.float64, dtypes. SeriesDTypes['float64'])
-        self.assertEqual(np.float64, dtypes. SeriesDTypes["<class 'numpy.float64'>"])
-        self.assertEqual(np.bool, dtypes. SeriesDTypes['bool'])
-        self.assertEqual(np.bool, dtypes. SeriesDTypes["<class 'bool'>"])
-        self.assertEqual(np.int64, dtypes. SeriesDTypes['datetime64[ns]'])
-        self.assertEqual(np.int64, dtypes. SeriesDTypes['timedelta64[ns]'])
+        self.assertEqual(np.str_, dtypes.SeriesDTypes["<class 'str'>"])
+        self.assertEqual(np.int64, dtypes.SeriesDTypes['int64'])
+        self.assertEqual(np.int64, dtypes.SeriesDTypes["<class 'numpy.int64'>"])
+        self.assertEqual(np.float64, dtypes.SeriesDTypes['float64'])
+        self.assertEqual(np.float64, dtypes.SeriesDTypes["<class 'numpy.float64'>"])
+        self.assertEqual(np.bool_, dtypes.SeriesDTypes['bool'])
+        self.assertEqual(np.dtype(bool), dtypes.SeriesDTypes['bool'])
+        self.assertEqual(np.bool_, dtypes.SeriesDTypes["<class 'bool'>"])
+        self.assertEqual(np.dtype(bool), dtypes.SeriesDTypes["<class 'bool'>"])
+        self.assertEqual(np.int64, dtypes.SeriesDTypes['datetime64[ns]'])
+        self.assertEqual(np.int64, dtypes.SeriesDTypes['timedelta64[ns]'])
 
     def test_scalars(self):
-        self.assertEqual("<class 'bool'>", str(ak.bool_scalars))
+        self.assertEqual("typing.Union[bool, numpy.bool_]", str(ak.bool_scalars))
         self.assertEqual('typing.Union[float, numpy.float64]', str(ak.float_scalars))
         self.assertEqual('typing.Union[int, numpy.int64]', str(ak.int_scalars))
-        self.assertEqual('typing.Union[float, numpy.float64, int, numpy.int64]', 
+        self.assertEqual('typing.Union[float, numpy.float64, int, numpy.int64, numpy.uint8]', 
                          str(ak.numeric_scalars))
         self.assertEqual('typing.Union[str, numpy.str_]', str(ak.str_scalars))
-        self.assertEqual('typing.Union[numpy.float64, numpy.int64, bool, numpy.uint8, str, numpy.str_]', 
+        self.assertEqual('typing.Union[numpy.float64, numpy.int64, numpy.bool_, numpy.uint8, numpy.str_]', 
                          str(ak.numpy_scalars))
-        self.assertEqual('typing.Union[float, numpy.float64, int, numpy.int64, bool, str, numpy.str_]', 
+        self.assertEqual('typing.Union[float, numpy.float64, int, numpy.int64, bool, numpy.bool_, str, numpy.str_]', 
                          str(ak.all_scalars))
         
     def test_number_format_strings(self):

--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -71,7 +71,7 @@ class JoinTest(ArkoudaTest):
         self.assertEqual(0, I.size)
         self.assertEqual(0, J.size)
         
-        I,J = ak.join_on_eq_with_dt(self.a2,self.a1,self.t1,self.t2,dt,"pos_dt", np.int(0))
+        I,J = ak.join_on_eq_with_dt(self.a2,self.a1,self.t1,self.t2,dt,"pos_dt", int(0))
         self.assertEqual(0, I.size)
         self.assertEqual(0, J.size)
         

--- a/tests/pdarray_creation_test.py
+++ b/tests/pdarray_creation_test.py
@@ -281,7 +281,7 @@ class PdarrayCreationTest(ArkoudaTest):
         self.assertEqual(5.0000, pda[0])
         self.assertEqual(0.0000, pda[5])
         
-        pda = ak.linspace(start=np.float(5.0), stop=np.float(0.0), length=np.int64(6))
+        pda = ak.linspace(start=float(5.0), stop=float(0.0), length=np.int64(6))
         self.assertEqual(5.0000, pda[0])
         self.assertEqual(0.0000, pda[5])
         
@@ -416,7 +416,7 @@ class PdarrayCreationTest(ArkoudaTest):
         self.assertEqual(100, len(pda))
         self.assertEqual(str, pda.dtype)
         
-        pda = ak.random_strings_lognormal(np.int64(2), np.float(0.25), np.int64(100), characters='printable')
+        pda = ak.random_strings_lognormal(np.int64(2), float(0.25), np.int64(100), characters='printable')
         self.assertIsInstance(pda,ak.Strings)
         self.assertEqual(100, len(pda))
         self.assertEqual(str, pda.dtype)
@@ -494,15 +494,15 @@ class PdarrayCreationTest(ArkoudaTest):
         self.assertIsInstance(strings, ak.Strings)
         self.assertEqual(5, len(strings))
 
-        objects = ak.from_series(pd.Series(['a', 'b', 'c', 'd', 'e']), dtype=np.str)
+        objects = ak.from_series(pd.Series(['a', 'b', 'c', 'd', 'e']), dtype=str)
         
         self.assertIsInstance(objects, ak.Strings)
-        self.assertEqual(np.str, objects.dtype)
+        self.assertEqual(str, objects.dtype)
         
         objects = ak.from_series(pd.Series(['a', 'b', 'c', 'd', 'e']))
         
         self.assertIsInstance(objects, ak.Strings)
-        self.assertEqual(np.str, objects.dtype)       
+        self.assertEqual(str, objects.dtype)       
 
         p_array = ak.from_series(pd.Series(np.random.randint(0,10,10)))
 
@@ -532,7 +532,7 @@ class PdarrayCreationTest(ArkoudaTest):
         self.assertEqual(bool, p_array.dtype)       
         
         p_b_objects_array = ak.from_series(pd.Series(np.random.choice([True, False],size=10), 
-                                            dtype='object'), dtype=np.bool)
+                                            dtype='object'), dtype=bool)
 
         self.assertIsInstance( p_b_objects_array,ak.pdarray)
         self.assertEqual(bool, p_b_objects_array.dtype)     
@@ -574,7 +574,7 @@ class PdarrayCreationTest(ArkoudaTest):
         ones.fill(np.int64(2))  
         self.assertTrue((np.int64(2) == ones.to_ndarray()).all())     
         
-        ones.fill(np.float(2))  
+        ones.fill(float(2))  
         self.assertTrue((float(2) == ones.to_ndarray()).all())  
         
         ones.fill(np.float64(2))  


### PR DESCRIPTION
Issue #670 - This updates the compatibility for numpy to a max of version 1.21.5.

`mypy` and `pytest` unit testing pass for the following numpy verisons (I tested locally as well as with the github CI runner, you can check the logs under `arkouda_tests_linux -> Build/Install Arkouda to verify which version of numpy was installed)

- 1.19.2 (https://github.com/glitch/arkouda/actions/runs/1719532839)
- 1.20.3 (https://github.com/glitch/arkouda/actions/runs/1718965418)
- 1.21.5 (https://github.com/glitch/arkouda/actions/runs/1719181717)

Note: The latest version of numpy at this time is 1.22.0 but it dropped Python 3.7.x support so I stopped with the latest 3.7.x line available in `conda` which was 1.21.5

In short the main thing which happened was deprecation warnings were added to things like `np.bool` in later versions on numpy.  The documentations said it was really just a stand in for `builtins.bool` etc.  I made updates for each of the specific items which were deprecated to use the recommended type.

Also updated was the version of `mypy` to 0.931 along with its dependency `typed-ast`.

You may need to update your local environment to the new versions of dependencies, but they should all be available with either `pip` or `conda`.