### PR TITLE
Refactor binary operator function with doBinOp function

### DIFF
--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -1,5 +1,5 @@
 
-module Operators
+module BinOp
 {
   use ServerConfig;
   

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -37,10 +37,10 @@ module BinOp
   :throws: `UndefinedSymbolError(name)`
   */
   proc doBinOpvv(l, r, e, op: string, rname, pn, st) throws {
-    // Since we know that the result type is a boolean, we know
-    // that it either (1) is an operation between bools or (2) uses
-    // one of the boolean operators from the `boolOps` set above
     if e.etype == bool {
+      // Since we know that the result type is a boolean, we know
+      // that it either (1) is an operation between bools or (2) uses
+      // a boolean operator (<, <=, etc.)
       if l.etype == bool && r.etype == bool {
         select op {
           when "|" {

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -8,6 +8,7 @@ module OperatorMsg
     use BitOps;
     use Reflection;
     use ServerErrors;
+    use Operators;
 
     use MultiTypeSymbolTable;
     use MultiTypeSymEntry;
@@ -66,15 +67,15 @@ module OperatorMsg
             
             if boolOps.contains(op) {
               var e = st.addEntry(rname, l.size, bool);
-              return doBinOp(l, r, e, op, rname, pn, st);
+              return doBinOpvv(l, r, e, op, rname, pn, st);
             } else if op == "/" {
               // True division is the only case in this int, int case
               // that results in a `real` symbol table entry.
               var e = st.addEntry(rname, l.size, real);
-              return doBinOp(l, r, e, op, rname, pn, st);
+              return doBinOpvv(l, r, e, op, rname, pn, st);
             }
             var e = st.addEntry(rname, l.size, int);
-            return doBinOp(l, r, e, op, rname, pn, st);
+            return doBinOpvv(l, r, e, op, rname, pn, st);
           }
           when (DType.Int64, DType.Float64) {
             var l = toSymEntry(left,int);
@@ -83,30 +84,30 @@ module OperatorMsg
             // for this case
             if boolOps.contains(op) {
               var e = st.addEntry(rname, l.size, bool);
-              return doBinOp(l, r, e, op, rname, pn, st);
+              return doBinOpvv(l, r, e, op, rname, pn, st);
             }
             var e = st.addEntry(rname, l.size, real);
-            return doBinOp(l, r, e, op, rname, pn, st);
+            return doBinOpvv(l, r, e, op, rname, pn, st);
           }
           when (DType.Float64, DType.Int64) {
             var l = toSymEntry(left,real);
             var r = toSymEntry(right,int);
             if boolOps.contains(op) {
               var e = st.addEntry(rname, l.size, bool);
-              return doBinOp(l, r, e, op, rname, pn, st);
+              return doBinOpvv(l, r, e, op, rname, pn, st);
             }
             var e = st.addEntry(rname, l.size, real);
-            return doBinOp(l, r, e, op, rname, pn, st);
+            return doBinOpvv(l, r, e, op, rname, pn, st);
           }
           when (DType.Float64, DType.Float64) {
             var l = toSymEntry(left,real);
             var r = toSymEntry(right,real);
             if boolOps.contains(op) {
               var e = st.addEntry(rname, l.size, bool);
-              return doBinOp(l, r, e, op, rname, pn, st);
+              return doBinOpvv(l, r, e, op, rname, pn, st);
             }
             var e = st.addEntry(rname, l.size, real);
-            return doBinOp(l, r, e, op, rname, pn, st);
+            return doBinOpvv(l, r, e, op, rname, pn, st);
           }
           // For cases where a boolean operand is involved, the only
           // possible resultant type is `bool`
@@ -114,251 +115,34 @@ module OperatorMsg
             var l = toSymEntry(left,bool);
             var r = toSymEntry(right,bool);
             var e = st.addEntry(rname, l.size, bool);
-            return doBinOp(l, r, e, op, rname, pn, st);
+            return doBinOpvv(l, r, e, op, rname, pn, st);
           }
           when (DType.Bool, DType.Int64) {
             var l = toSymEntry(left,bool);
             var r = toSymEntry(right,int);
             var e = st.addEntry(rname, l.size, int);
-            return doBinOp(l, r, e, op, rname, pn, st);
+            return doBinOpvv(l, r, e, op, rname, pn, st);
           }
           when (DType.Int64, DType.Bool) {
             var l = toSymEntry(left,int);
             var r = toSymEntry(right,bool);
             var e = st.addEntry(rname, l.size, int);
-            return doBinOp(l, r, e, op, rname, pn, st);
+            return doBinOpvv(l, r, e, op, rname, pn, st);
           }
           when (DType.Bool, DType.Float64) {
             var l = toSymEntry(left,bool);
             var r = toSymEntry(right,real);
             var e = st.addEntry(rname, l.size, real);
-            return doBinOp(l, r, e, op, rname, pn, st);
+            return doBinOpvv(l, r, e, op, rname, pn, st);
           }
           when (DType.Float64, DType.Bool) {
             var l = toSymEntry(left,real);
             var r = toSymEntry(right,bool);
             var e = st.addEntry(rname, l.size, real);
-            return doBinOp(l, r, e, op, rname, pn, st);
+            return doBinOpvv(l, r, e, op, rname, pn, st);
           }
         }
         return new MsgTuple("Bin op not supported", MsgType.NORMAL);
-    }
-
-    proc doBinOp(l, r, e, op, rname, pn, st) throws {
-      // Since we know that the result type is a boolean, we know
-      // that it either (1) is an operation between bools or (2) uses
-      // one of the boolean operators from the `boolOps` set above
-      if e.etype == bool {
-        if l.etype == bool && r.etype == bool {
-          select op {
-            when "|" {
-              e.a = l.a | r.a;
-            }
-            when "&" {
-              e.a = l.a & r.a;
-            }
-            when "^" {
-              e.a = l.a ^ r.a;
-            }
-            when "==" {
-              e.a = l.a == r.a;
-            }
-            when "!=" {
-              e.a = l.a != r.a;
-            }
-            otherwise {
-              var errorMsg = notImplementedError(pn,l.dtype,op,r.dtype);
-              omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-              return new MsgTuple(errorMsg, MsgType.ERROR);
-            }
-          }
-        }
-        // All types support the same binary operations when the resultant
-        // type is bool and `l` and `r` are not both boolean, so this does
-        // not need to be specialized for each case.
-        else {
-          select op {
-              when "<" {
-                e.a = l.a < r.a;
-              }
-              when ">" {
-                e.a = l.a > r.a;
-              }
-              when "<=" {
-                e.a = l.a <= r.a;
-              }
-              when ">=" {
-                e.a = l.a >= r.a;
-              }
-              when "==" {
-                e.a = l.a == r.a;
-              }
-              when "!=" {
-                e.a = l.a != r.a;
-              }
-              otherwise {
-                var errorMsg = notImplementedError(pn,l.dtype,op,r.dtype);
-                omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                              
-                return new MsgTuple(errorMsg, MsgType.ERROR); 
-              }
-            }
-        }
-        var repMsg = "created %s".format(st.attrib(rname));
-        return new MsgTuple(repMsg, MsgType.NORMAL);
-      }
-      // Since we know that both `l` and `r` are of type `int` and that
-      // the resultant type is not bool (checked in first `if`), we know
-      // what operations are supported based on the resultant type
-      else if l.etype == int && r.etype == int {
-        if e.etype == int {
-          select op {
-            when "+" {
-              e.a = l.a + r.a;
-            }
-            when "-" {
-              e.a = l.a - r.a;
-            }
-            when "*" {
-              e.a = l.a * r.a;
-            }
-            when "//" { // floordiv
-              ref ea = e.a;
-              ref la = l.a;
-              ref ra = r.a;
-              [(ei,li,ri) in zip(ea,la,ra)] ei = if ri != 0 then li/ri else 0;
-            }
-            when "%" { // modulo
-              ref ea = e.a;
-              ref la = l.a;
-              ref ra = r.a;
-              [(ei,li,ri) in zip(ea,la,ra)] ei = if ri != 0 then li%ri else 0;
-            }
-            when "<<" {
-              e.a = l.a << r.a;
-            }                    
-            when ">>" {
-              e.a = l.a >> r.a;
-            }
-            when "<<<" {
-              e.a = rotl(l.a, r.a);
-            }
-            when ">>>" {
-              e.a = rotr(l.a, r.a);
-            }
-            when "&" {
-              e.a = l.a & r.a;
-            }                    
-            when "|" {
-              e.a = l.a | r.a;
-            }                    
-            when "^" {
-              e.a = l.a ^ r.a;
-            }
-            when "**" { 
-              if || reduce (r.a<0){
-                //instead of error, could we paste the below code but of type float?
-                var errorMsg = "Attempt to exponentiate base of type Int64 to negative exponent";
-                omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);  
-                return new MsgTuple(errorMsg, MsgType.ERROR);                                
-              }
-              e.a= l.a**r.a;
-            }     
-            otherwise {
-              var errorMsg = notImplementedError(pn,l.dtype,op,r.dtype);
-              omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                              
-              return new MsgTuple(errorMsg, MsgType.ERROR); 
-            }
-          }
-        } else if e.etype == real {
-          select op {
-            // True division is the only integer type that would result in a
-            // resultant type of `real`
-            when "/" {
-              e.a = l.a:real / r.a:real;
-            }
-            otherwise {
-              var errorMsg = notImplementedError(pn,l.dtype,op,r.dtype);
-              omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                              
-              return new MsgTuple(errorMsg, MsgType.ERROR); 
-            }
-            
-          }
-        }
-        var repMsg = "created %s".format(st.attrib(rname));
-        return new MsgTuple(repMsg, MsgType.NORMAL);
-      }
-      // If either RHS or LHS type is real, the same operations are supported and the
-      // result will always be a `real`, so all 3 of these cases can be shared.
-      else if ((l.etype == real && r.etype == real) || (l.etype == int && r.etype == real)
-                 || (l.etype == real && r.etype == int)) {
-        select op {
-          when "+" {
-            e.a = l.a + r.a;
-          }
-          when "-" {
-            e.a = l.a - r.a;
-          }
-          when "*" {
-            e.a = l.a * r.a;
-          }
-          when "/" { // truediv
-            e.a = l.a / r.a;
-          } 
-          when "//" { // floordiv
-            ref ea = e.a;
-            ref la = l.a;
-            ref ra = r.a;
-            [(ei,li,ri) in zip(ea,la,ra)] ei = if ri != 0 then floor(li/ri) else NAN;
-          }
-          when "**" { 
-            e.a= l.a**r.a;
-          }
-        }
-        var repMsg = "created %s".format(st.attrib(rname));
-        return new MsgTuple(repMsg, MsgType.NORMAL);
-      } else if ((l.etype == int && r.etype == bool) || (l.etype == bool && r.etype == int)) {
-        select op {
-          when "+" {
-            // Since we don't know which of `l` or `r` is the int and which is the `bool`,
-            // we can just cast both to int, which will be a noop for the vector that is
-            // already `int`
-            e.a = l.a:int + r.a:int;
-          }
-          when "-" {
-            e.a = l.a:int - r.a:int;
-          }
-          when "*" {
-            e.a = l.a:int * r.a:int;
-          }
-          otherwise {
-            var errorMsg = notImplementedError(pn,l.dtype,op,r.dtype);
-            omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-            return new MsgTuple(errorMsg, MsgType.ERROR);
-          }
-        }
-        var repMsg = "created %s".format(st.attrib(rname));
-        return new MsgTuple(repMsg, MsgType.NORMAL);
-      } else if ((l.etype == real && r.etype == bool) || (l.etype == bool && r.etype == real)) {
-        select op {
-          when "+" {
-            e.a = l.a:real + r.a:real;
-          }
-          when "-" {
-            e.a = l.a:real - r.a:real;
-          }
-          when "*" {
-            e.a = l.a:real * r.a:real;
-          }
-          otherwise {
-            var errorMsg = notImplementedError(pn,l.dtype,op,r.dtype);
-            omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-            return new MsgTuple(errorMsg, MsgType.ERROR);
-          }
-        }
-        var repMsg = "created %s".format(st.attrib(rname));
-        return new MsgTuple(repMsg, MsgType.NORMAL);
-      }
-      return new MsgTuple("Bin op not supported", MsgType.NORMAL);
     }
     
     /*

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -8,7 +8,7 @@ module OperatorMsg
     use BitOps;
     use Reflection;
     use ServerErrors;
-    use Operators;
+    use BinOp;
 
     use MultiTypeSymbolTable;
     use MultiTypeSymEntry;

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -48,10 +48,7 @@ module OperatorMsg
                                           cmd,op,st.attrib(aname),st.attrib(bname)));
 
         use Set;
-        // could have supported ops for the different types and
-        // then we would just need to check if they are supported
-        // before calling doBinOp? This would allow us to get around
-        // the selection on dtypes maybe?
+
         var boolOps: set(string);
         boolOps.add("<");
         boolOps.add("<=");
@@ -60,10 +57,6 @@ module OperatorMsg
         boolOps.add("==");
         boolOps.add("!=");
 
-        // switching this to an if/else could enable us to
-        // share more code and not have as much duplication
-        // since all that is different is the casting to a
-        // symEntry type
         select (left.dtype, right.dtype) {
           when (DType.Int64, DType.Int64) {
             var l = toSymEntry(left,int);
@@ -169,8 +162,6 @@ module OperatorMsg
             }
           }
         } else {
-          // could combine this and above case by just checking on types
-          // to see if we can do it? Like for `<`, don't do it for bools
           select op {
               when "<" {
                 e.a = l.a < r.a;

--- a/src/Operators.chpl
+++ b/src/Operators.chpl
@@ -1,0 +1,255 @@
+
+module Operators
+{
+  use ServerConfig;
+  
+  use MultiTypeSymbolTable;
+  use MultiTypeSymEntry;
+  use Logging;
+  use Message;
+
+  private config const logLevel = ServerConfig.logLevel;
+  const omLogger = new Logger(logLevel);
+
+  /*
+  Generic function to execute a binary operation on pdarray entries 
+  in the symbol table
+
+  :arg l: symbol table entry of the LHS operand
+
+  :arg r: symbol table entry of the RHS operand
+
+  :arg e: symbol table entry to store result of operation
+
+  :arg op: string representation of binary operation to execute
+  :type op: string
+
+  :arg rname: name of the `e` in the symbol table
+  :type rname: string
+
+  :arg pn: routine name of callsite function
+  :type pn: string
+
+  :arg st: SymTab to act on
+  :type st: borrowed SymTab 
+
+  :returns: (MsgTuple) 
+  :throws: `UndefinedSymbolError(name)`
+  */
+  proc doBinOpvv(l, r, e, op: string, rname, pn, st) throws {
+    // Since we know that the result type is a boolean, we know
+    // that it either (1) is an operation between bools or (2) uses
+    // one of the boolean operators from the `boolOps` set above
+    if e.etype == bool {
+      if l.etype == bool && r.etype == bool {
+        select op {
+          when "|" {
+            e.a = l.a | r.a;
+          }
+          when "&" {
+            e.a = l.a & r.a;
+          }
+          when "^" {
+            e.a = l.a ^ r.a;
+          }
+          when "==" {
+            e.a = l.a == r.a;
+          }
+          when "!=" {
+            e.a = l.a != r.a;
+          }
+          otherwise {
+            var errorMsg = notImplementedError(pn,l.dtype,op,r.dtype);
+            omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+          }
+        }
+      }
+      // All types support the same binary operations when the resultant
+      // type is bool and `l` and `r` are not both boolean, so this does
+      // not need to be specialized for each case.
+      else {
+        select op {
+            when "<" {
+              e.a = l.a < r.a;
+            }
+            when ">" {
+              e.a = l.a > r.a;
+            }
+            when "<=" {
+              e.a = l.a <= r.a;
+            }
+            when ">=" {
+              e.a = l.a >= r.a;
+            }
+            when "==" {
+              e.a = l.a == r.a;
+            }
+            when "!=" {
+              e.a = l.a != r.a;
+            }
+            otherwise {
+              var errorMsg = notImplementedError(pn,l.dtype,op,r.dtype);
+              omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                              
+              return new MsgTuple(errorMsg, MsgType.ERROR); 
+            }
+          }
+      }
+      var repMsg = "created %s".format(st.attrib(rname));
+      return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+    // Since we know that both `l` and `r` are of type `int` and that
+    // the resultant type is not bool (checked in first `if`), we know
+    // what operations are supported based on the resultant type
+    else if l.etype == int && r.etype == int {
+      if e.etype == int {
+        select op {
+          when "+" {
+            e.a = l.a + r.a;
+          }
+          when "-" {
+            e.a = l.a - r.a;
+          }
+          when "*" {
+            e.a = l.a * r.a;
+          }
+          when "//" { // floordiv
+            ref ea = e.a;
+            ref la = l.a;
+            ref ra = r.a;
+            [(ei,li,ri) in zip(ea,la,ra)] ei = if ri != 0 then li/ri else 0;
+          }
+          when "%" { // modulo
+            ref ea = e.a;
+            ref la = l.a;
+            ref ra = r.a;
+            [(ei,li,ri) in zip(ea,la,ra)] ei = if ri != 0 then li%ri else 0;
+          }
+          when "<<" {
+            e.a = l.a << r.a;
+          }                    
+          when ">>" {
+            e.a = l.a >> r.a;
+          }
+          when "<<<" {
+            e.a = rotl(l.a, r.a);
+          }
+          when ">>>" {
+            e.a = rotr(l.a, r.a);
+          }
+          when "&" {
+            e.a = l.a & r.a;
+          }                    
+          when "|" {
+            e.a = l.a | r.a;
+          }                    
+          when "^" {
+            e.a = l.a ^ r.a;
+          }
+          when "**" { 
+            if || reduce (r.a<0){
+              //instead of error, could we paste the below code but of type float?
+              var errorMsg = "Attempt to exponentiate base of type Int64 to negative exponent";
+              omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);  
+              return new MsgTuple(errorMsg, MsgType.ERROR);                                
+            }
+            e.a= l.a**r.a;
+          }     
+          otherwise {
+            var errorMsg = notImplementedError(pn,l.dtype,op,r.dtype);
+            omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                              
+            return new MsgTuple(errorMsg, MsgType.ERROR); 
+          }
+        }
+      } else if e.etype == real {
+        select op {
+          // True division is the only integer type that would result in a
+          // resultant type of `real`
+          when "/" {
+            e.a = l.a:real / r.a:real;
+          }
+          otherwise {
+            var errorMsg = notImplementedError(pn,l.dtype,op,r.dtype);
+            omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                              
+            return new MsgTuple(errorMsg, MsgType.ERROR); 
+          }
+            
+        }
+      }
+      var repMsg = "created %s".format(st.attrib(rname));
+      return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+    // If either RHS or LHS type is real, the same operations are supported and the
+    // result will always be a `real`, so all 3 of these cases can be shared.
+    else if ((l.etype == real && r.etype == real) || (l.etype == int && r.etype == real)
+             || (l.etype == real && r.etype == int)) {
+      select op {
+          when "+" {
+            e.a = l.a + r.a;
+          }
+          when "-" {
+            e.a = l.a - r.a;
+          }
+          when "*" {
+            e.a = l.a * r.a;
+          }
+          when "/" { // truediv
+            e.a = l.a / r.a;
+          } 
+          when "//" { // floordiv
+            ref ea = e.a;
+            ref la = l.a;
+            ref ra = r.a;
+            [(ei,li,ri) in zip(ea,la,ra)] ei = if ri != 0 then floor(li/ri) else NAN;
+          }
+          when "**" { 
+            e.a= l.a**r.a;
+          }
+        }
+      var repMsg = "created %s".format(st.attrib(rname));
+      return new MsgTuple(repMsg, MsgType.NORMAL);
+    } else if ((l.etype == int && r.etype == bool) || (l.etype == bool && r.etype == int)) {
+      select op {
+          when "+" {
+            // Since we don't know which of `l` or `r` is the int and which is the `bool`,
+            // we can just cast both to int, which will be a noop for the vector that is
+            // already `int`
+            e.a = l.a:int + r.a:int;
+          }
+          when "-" {
+            e.a = l.a:int - r.a:int;
+          }
+          when "*" {
+            e.a = l.a:int * r.a:int;
+          }
+          otherwise {
+            var errorMsg = notImplementedError(pn,l.dtype,op,r.dtype);
+            omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+          }
+        }
+      var repMsg = "created %s".format(st.attrib(rname));
+      return new MsgTuple(repMsg, MsgType.NORMAL);
+    } else if ((l.etype == real && r.etype == bool) || (l.etype == bool && r.etype == real)) {
+      select op {
+          when "+" {
+            e.a = l.a:real + r.a:real;
+          }
+          when "-" {
+            e.a = l.a:real - r.a:real;
+          }
+          when "*" {
+            e.a = l.a:real * r.a:real;
+          }
+          otherwise {
+            var errorMsg = notImplementedError(pn,l.dtype,op,r.dtype);
+            omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+          }
+        }
+      var repMsg = "created %s".format(st.attrib(rname));
+      return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+    return new MsgTuple("Bin op not supported", MsgType.NORMAL);
+  }
+}


### PR DESCRIPTION
As a stepping stone to adding 2D array support, this PR refactors the `binopvvMsg()` function by creating a generic `doBinOp()` function that can accept additional types of symbol table entries beyond just the default `symEntry`. This allows easily stamping out types that are not desired and additionally allows optionally adding new entries, such as a 2D entry, to share this binary operations code, but still be only included optionally.

Additionally, the `binopvvMsg()` function is 453 lines today, but this PR brings that number down to 309 lines, and that is now split between 2 functions. 

This change may slightly increase the difficulty of understanding/reading the `binopvvMsg()` code due to the additional layer of abstraction, but I believe that this type of refactoring is needed to allow additional symbol table entry types to optionally share code with the existing Arkouda server code.

Resolves https://github.com/Bears-R-Us/arkouda/issues/1045