### PR TITLE
Speed up gasnet unit tests by only using 1 thread per locale

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -118,7 +118,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: [chapel, chapel-gasnet-smp]
+        include:
+          - image: chapel
+            threads: 2
+          - image: chapel-gasnet-smp
+            threads: 1
+    env:
+      CHPL_RT_NUM_THREADS_PER_LOCALE: ${{matrix.threads}}
     container:
       image: chapel/${{matrix.image}}:1.25.1
     steps:


### PR DESCRIPTION
Similar to #742, but for the chapel unit tests instead of the arkouda
pytests. At the time that PR was done the chapel unit tests were fast so
I didn't bother making this change, but they are currently the slowest
part of CI testing. This brings the gasnet unit tests down from 38 to 28
minutes and overall CI testing takes ~30 minutes.

Part of #388