### PR TITLE
Reduce argsort memory footprint

### DIFF
--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -154,103 +154,103 @@ module RadixSortLSD
         try! rsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                        "type = %s nBits = %t".format(t:string,nBits));
         
-        // form (key,rank) vector
-        var kr0: [aD] (t,int) = [(key,rank) in zip(a,aD)] (key,rank);
         var kr1: [aD] (t,int);
-        
-        // create a global count array to scan
-        var gD = newBlockDom({0..#(numLocales * numTasks * numBuckets)});
-        var globalCounts: [gD] int;
-        var globalStarts: [gD] int;
-        
-        // loop over digits
-        for rshift in {0..#nBits by bitsPerDigit} {
-            const last = (rshift + bitsPerDigit) >= nBits;
-            try! rsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                                        "rshift = %t".format(rshift));
-            // count digits
-            coforall loc in Locales {
-                on loc {
-                    coforall task in Tasks {
-                        // bucket domain
-                        var bD = {0..#numBuckets};
-                        // allocate counts
-                        var taskBucketCounts: [bD] int;
-                        // get local domain's indices
-                        var lD = kr0.localSubdomain();
-                        // calc task's indices from local domain's indices
-                        var tD = calcBlock(task, lD.low, lD.high);
-                        try! rsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                   "locid: %t task: %t tD: %t".format(loc.id,task,tD));
-                        // count digits in this task's part of the array
-                        for i in tD {
-                            const (key,_) = kr0[i];
-                            var bucket = getDigit(key, rshift, last, negs); // calc bucket from key
-                            taskBucketCounts[bucket] += 1;
-                        }
-                        // write counts in to global counts in transposed order
-                        var aggregator = newDstAggregator(int);
-                        for bucket in bD {
-                            aggregator.copy(globalCounts[calcGlobalIndex(bucket, loc.id, task)], 
-                                                         taskBucketCounts[bucket]);
-                        }
-                        aggregator.flush();
-                    }//coforall task
-                }//on loc
-            }//coforall loc
+        { // Artificial scope  to lower total memory overhead
+            // form (key,rank) vector
+            var kr0: [aD] (t,int) = [(key,rank) in zip(a,aD)] (key,rank);
             
-            // scan globalCounts to get bucket ends on each locale/task
-            // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
-            overMemLimit(numBytes(int) * globalCounts.size);
-            globalStarts = + scan globalCounts;
-            globalStarts = globalStarts - globalCounts;
+            // create a global count array to scan
+            var gD = newBlockDom({0..#(numLocales * numTasks * numBuckets)});
+            var globalCounts: [gD] int;
+            var globalStarts: [gD] int;
             
-            if vv {printAry("globalCounts =",globalCounts);try! stdout.flush();}
-            if vv {printAry("globalStarts =",globalStarts);try! stdout.flush();}
-            
-            // calc new positions and permute
-            coforall loc in Locales {
-                on loc {
-                    coforall task in Tasks {
-                        // bucket domain
-                        var bD = {0..#numBuckets};
-                        // allocate counts
-                        var taskBucketPos: [bD] int;
-                        // get local domain's indices
-                        var lD = kr0.localSubdomain();
-                        // calc task's indices from local domain's indices
-                        var tD = calcBlock(task, lD.low, lD.high);
-                        // read start pos in to globalStarts back from transposed order
-                        {
-                            var aggregator = newSrcAggregator(int);
-                            for bucket in bD {
-                                aggregator.copy(taskBucketPos[bucket], 
-                                           globalStarts[calcGlobalIndex(bucket, loc.id, task)]);
-                            }
-                            aggregator.flush();
-                        }
-                        // calc new position and put (key,rank) pair there in kr1
-                        {
-                            var aggregator = newDstAggregator((t,int));
+            // loop over digits
+            for rshift in {0..#nBits by bitsPerDigit} {
+                const last = (rshift + bitsPerDigit) >= nBits;
+                try! rsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                                            "rshift = %t".format(rshift));
+                // count digits
+                coforall loc in Locales {
+                    on loc {
+                        coforall task in Tasks {
+                            // bucket domain
+                            var bD = {0..#numBuckets};
+                            // allocate counts
+                            var taskBucketCounts: [bD] int;
+                            // get local domain's indices
+                            var lD = kr0.localSubdomain();
+                            // calc task's indices from local domain's indices
+                            var tD = calcBlock(task, lD.low, lD.high);
+                            try! rsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                       "locid: %t task: %t tD: %t".format(loc.id,task,tD));
+                            // count digits in this task's part of the array
                             for i in tD {
                                 const (key,_) = kr0[i];
                                 var bucket = getDigit(key, rshift, last, negs); // calc bucket from key
-                                var pos = taskBucketPos[bucket];
-                                taskBucketPos[bucket] += 1;
-                                aggregator.copy(kr1[pos], kr0[i]);
+                                taskBucketCounts[bucket] += 1;
+                            }
+                            // write counts in to global counts in transposed order
+                            var aggregator = newDstAggregator(int);
+                            for bucket in bD {
+                                aggregator.copy(globalCounts[calcGlobalIndex(bucket, loc.id, task)], 
+                                                             taskBucketCounts[bucket]);
                             }
                             aggregator.flush();
-                        }
-                    }//coforall task 
-                }//on loc
-            }//coforall loc
-            
-            // copy back to k0 and r0 for next iteration
-            // Only do this if there are more digits left
-            if !last {
-                kr0 = kr1;
-            }
-        } // for rshift
+                        }//coforall task
+                    }//on loc
+                }//coforall loc
+                
+                // scan globalCounts to get bucket ends on each locale/task
+                globalStarts = + scan globalCounts;
+                globalStarts = globalStarts - globalCounts;
+                
+                if vv {printAry("globalCounts =",globalCounts);try! stdout.flush();}
+                if vv {printAry("globalStarts =",globalStarts);try! stdout.flush();}
+                
+                // calc new positions and permute
+                coforall loc in Locales {
+                    on loc {
+                        coforall task in Tasks {
+                            // bucket domain
+                            var bD = {0..#numBuckets};
+                            // allocate counts
+                            var taskBucketPos: [bD] int;
+                            // get local domain's indices
+                            var lD = kr0.localSubdomain();
+                            // calc task's indices from local domain's indices
+                            var tD = calcBlock(task, lD.low, lD.high);
+                            // read start pos in to globalStarts back from transposed order
+                            {
+                                var aggregator = newSrcAggregator(int);
+                                for bucket in bD {
+                                    aggregator.copy(taskBucketPos[bucket], 
+                                               globalStarts[calcGlobalIndex(bucket, loc.id, task)]);
+                                }
+                                aggregator.flush();
+                            }
+                            // calc new position and put (key,rank) pair there in kr1
+                            {
+                                var aggregator = newDstAggregator((t,int));
+                                for i in tD {
+                                    const (key,_) = kr0[i];
+                                    var bucket = getDigit(key, rshift, last, negs); // calc bucket from key
+                                    var pos = taskBucketPos[bucket];
+                                    taskBucketPos[bucket] += 1;
+                                    aggregator.copy(kr1[pos], kr0[i]);
+                                }
+                                aggregator.flush();
+                            }
+                        }//coforall task 
+                    }//on loc
+                }//coforall loc
+                
+                // copy back to k0 and r0 for next iteration
+                // Only do this if there are more digits left
+                if !last {
+                    kr0 = kr1;
+                }
+            } // for rshift
+        } // Ensure everything except kr1 is deleted to lower memory footprint
 
         var ranks: [aD] int = [(key, rank) in kr1] rank;
         return ranks;
@@ -321,8 +321,6 @@ module RadixSortLSD
             }//coforall loc
             
             // scan globalCounts to get bucket ends on each locale/task
-            // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
-            overMemLimit(numBytes(int) * globalCounts.size);
             globalStarts = + scan globalCounts;
             globalStarts = globalStarts - globalCounts;
             
@@ -376,7 +374,7 @@ module RadixSortLSD
     }//proc radixSortLSD_keys
 
     proc radixSortLSD_memEst(size: int, itemsize: int) {
-        return ((4 + 1) * size * itemsize)
+        return (4 * size * itemsize)
                      + (2 * here.maxTaskPar * numLocales * 2**16 * 8);
     }
 }


### PR DESCRIPTION
Reduce the memory overhead of argsort/radixSortLSD_ranks from ~5x to
~4x. The big arrays created are 2 temp arrays with the key and the rank
and a return array with just the rank. Previously all 3 arrays existed
at the same time for a ~5x overhead, but this refactors the code to
destroy one of the temp arrays before creating the return array, which
changes the peak overhead to those 2 temp arrays or a ~4x overhead.

While here remove some internal `overMemLimit` checks on a scan since
it's expected that callsites use radixSortLSD_memEst before calling
argsort and that includes the scan arrays.