### PR TITLE
Add support for passing server args to runClient/run_benchmarks.py

### DIFF
--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -91,8 +91,9 @@ def create_parser():
     # TODO support alias for a larger default N
     #parser.add_argument('--large', default=False, action='store_true', help='Run a larger problem size')
 
-    parser.add_argument('-nl', '--num-locales', default=get_arkouda_numlocales(), help='Number of locales to use for the server')
+    parser.add_argument('-nl', '--num-locales', '--numLocales', default=get_arkouda_numlocales(), help='Number of locales to use for the server')
     parser.add_argument('-sp', '--server-port', default='5555', help='Port number to use for the server')
+    parser.add_argument('--server-args', action='append' , help='Additional server arguments')
     parser.add_argument('--numtrials', default=1, type=int, help='Number of trials to run')
     parser.add_argument('benchmarks', nargs='*', help='Basename of benchmarks to run with extension stripped')
     parser.add_argument('--gen-graphs', default=False, action='store_true', help='Generate graphs, requires $CHPL_HOME')
@@ -115,7 +116,7 @@ def main():
     if args.gen_graphs:
         os.makedirs(config_dat_dir, exist_ok=True)
 
-    start_arkouda_server(args.num_locales, port=args.server_port)
+    start_arkouda_server(args.num_locales, port=args.server_port, server_args=args.server_args)
 
     args.benchmarks = args.benchmarks or BENCHMARKS
     for benchmark in args.benchmarks:

--- a/util/test/runClient
+++ b/util/test/runClient
@@ -19,12 +19,13 @@ from util import *;
 
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('clients', type=argparse.FileType('r'), help='The arkouda client program(s) to run', nargs='+')
-parser.add_argument('-nl', '--numLocales', type=int, help='Number of locales')
+parser.add_argument('-nl', '--num-locales', '--numLocales', default=get_arkouda_numlocales(), help='Number of locales to use for the server')
+parser.add_argument('-sp', '--server-port', default='5555', help='Port number to use for the server')
+parser.add_argument('--server-args', action='append' , help='Additional server arguments')
 
 args, client_args = parser.parse_known_args()
-numlocales = args.numLocales or get_arkouda_numlocales()
 
-start_arkouda_server(numlocales)
+start_arkouda_server(args.num_locales, port=args.server_port, server_args=args.server_args)
 ret = 0
 for client in args.clients:
       cmd_string = '{} {}'.format(client.name, ' '.join(client_args)).strip()

--- a/util/test/util.py
+++ b/util/test/util.py
@@ -159,14 +159,13 @@ def kill_server(server_process):
             logging.warn('Attempting dirty server shutdown')
             server_process.kill()
 
-def start_arkouda_server(numlocales, verbose=False, log=False, port=5555, host=None):
+def start_arkouda_server(numlocales, trace=False, port=5555, host=None):
     """
     Start the Arkouda server and wait for it to start running. Connection info
     is written to `get_arkouda_server_info_file()`.
     
     :param int numlocals: the number of arkouda_server locales
-    :param bool verbose: indicates whether to start the arkouda_server in verbose mode
-    :param bool log: indicates whether to start arkouda_server with logging enabled
+    :param bool trace: indicates whether to start the arkouda_server with tracing
     :param int port: the desired arkouda_server port, defaults to 5555
     :param str host: the desired arkouda_server host, defaults to None
     :return: tuple containing server host, port, and process
@@ -177,7 +176,7 @@ def start_arkouda_server(numlocales, verbose=False, log=False, port=5555, host=N
         os.remove(connection_file)
     
     cmd = [get_arkouda_server(),
-           '--trace={}'.format('true' if log else 'false'),
+           '--trace={}'.format('true' if trace else 'false'),
            '--serverConnectionInfo={}'.format(connection_file),
            '-nl {}'.format(numlocales), '--ServerPort={}'.format(port)]
 

--- a/util/test/util.py
+++ b/util/test/util.py
@@ -159,7 +159,7 @@ def kill_server(server_process):
             logging.warn('Attempting dirty server shutdown')
             server_process.kill()
 
-def start_arkouda_server(numlocales, trace=False, port=5555, host=None):
+def start_arkouda_server(numlocales, trace=False, port=5555, host=None, server_args=None):
     """
     Start the Arkouda server and wait for it to start running. Connection info
     is written to `get_arkouda_server_info_file()`.
@@ -168,6 +168,7 @@ def start_arkouda_server(numlocales, trace=False, port=5555, host=None):
     :param bool trace: indicates whether to start the arkouda_server with tracing
     :param int port: the desired arkouda_server port, defaults to 5555
     :param str host: the desired arkouda_server host, defaults to None
+    :param list server_args: additional arguments to pass to the server
     :return: tuple containing server host, port, and process
     :rtype: ServerInfo(host, port, process)
     """
@@ -179,6 +180,8 @@ def start_arkouda_server(numlocales, trace=False, port=5555, host=None):
            '--trace={}'.format('true' if trace else 'false'),
            '--serverConnectionInfo={}'.format(connection_file),
            '-nl {}'.format(numlocales), '--ServerPort={}'.format(port)]
+    if server_args:
+        cmd += server_args
 
     logging.info('Starting "{}"'.format(cmd))
     process = subprocess.Popen(cmd, stdout=subprocess.DEVNULL)


### PR DESCRIPTION
Add `--server-args` argument to `runClient`/`run_benchmarks.py`. This allows
passing arbitrary options to the server. While here, unify some of the options
for these scripts (support both version of num locales, add port to runClient)
and  change `start_arkouda_server` `log`/`verbose` args to `trace`. The actual
server options were replaced in #650/#760, so just update the start server
wrapper args to reflect the name change.


Example usage:

```
./benchmarks/run_benchmarks.py argsort --server-args=--CommAggregation.dstBuffSize=256 --server-args=--CommAggregation.srcBuffSize=12
./util/test/runClient tests/check.py --server-args=--walltime=5:00
```

Resolves #1006