### PR TITLE
Optimize small and medium int in1d operations

### DIFF
--- a/benchmarks/in1d.py
+++ b/benchmarks/in1d.py
@@ -42,8 +42,8 @@ def create_parser():
     parser = argparse.ArgumentParser(description="Measure the performance of in1d: c = ak.in1d(a, b)")
     parser.add_argument('hostname', help='Hostname of arkouda server')
     parser.add_argument('port', type=int, help='Port of arkouda server')
-    parser.add_argument('-n', '--size', type=int, default=10**7, help='Problem size: length of array a')
-    parser.add_argument('-t', '--trials', type=int, default=1, help='Number of times to run the benchmark')
+    parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: length of array a')
+    parser.add_argument('-t', '--trials', type=int, default=3, help='Number of times to run the benchmark')
     parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
     return parser
     

--- a/src/ArraySetops.chpl
+++ b/src/ArraySetops.chpl
@@ -15,12 +15,6 @@ module ArraySetops
     use Indexing;
     use In1d;
 
-
-    /*
-    Small bound const. Brute force in1d implementation recommended.
-    */
-    private config const sBound = 2**4; 
-
     /*
     Medium bound const. Per locale associative domain in1d implementation recommended.
     */
@@ -108,8 +102,7 @@ module ArraySetops
         var truth = makeDistArray(a.size, bool);
 
         // based on size of array, determine which method to use 
-        if (b.size <= sBound) then truth = in1dGlobalAr2Bcast(a, b);
-        else if (b.size <= mBound) then truth = in1dAr2PerLocAssoc(a, b);
+        if (b.size <= mBound) then truth = in1dAr2PerLocAssoc(a, b);
         else truth = in1dSort(a,b);
         
         truth = !truth;

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -88,6 +88,16 @@ module AryUtil
     }
 
     /*
+      Iterate over indices (range/domain) ``ind`` but in an offset manner based
+      on the locale id. Can be used to avoid doing communication in lockstep.
+    */
+    iter offset(ind) where isRange(ind) || isDomain(ind) {
+        for i in ind + (ind.size/numLocales * here.id) do {
+            yield i % ind.size + ind.first;
+        }
+    }
+
+    /*
       Determines if the passed array array maps contiguous indices to
       contiguous memory.
 

--- a/src/In1d.chpl
+++ b/src/In1d.chpl
@@ -1,64 +1,11 @@
-
 module In1d
 {
     use ServerConfig;
     use Unique;
+    use AryUtil;
     use CommAggregation;
     use RadixSortLSD;
     use Reflection;
-
-    use Time only;
-    use Math only;
-
-    use PrivateDist;
-    use Logging;
-
-    private config const logLevel = ServerConfig.logLevel;
-    const inLogger = new Logger(logLevel);
-
-    /* Brute force:
-    forward-way reduction per element of ar1 over ar2.
-    Causes every element in ar1 to be broadcast/communicated over ar2.
-    
-    :arg ar1: array to broadcast over ar2
-    :type ar1: [] int
-
-    :arg ar2: array to be broadcast over
-    :type ar2: [] int
-
-    :returns truth: a boolean array containing the result of ar1 being broadcast over ar2
-    :type truth: [] bool
-    */
-    proc in1dGlobalAr1Bcast(ar1: [?aD1] int, ar2: [?aD2] int) {
-
-        var truth: [aD1] bool;
-        
-        [(elt,t) in zip(ar1,truth)] t = | reduce (elt == ar2);
-
-        return truth;
-    }
-
-    /* Brute force:
-    reverse-way serial-or-reduce for each element in ar2 over ar1.
-    Causes every element in ar2 to be broadcast/communicated over ar1.
-    
-    :arg ar1: array to be broadcast over
-    :type ar1: [] int
-
-    :arg ar2: array to broadcast over ar1
-    :type ar2: [] int
-
-    :returns truth: a boolean array containing the result of ar2 being broadcast over ar1
-    :type truth: [] bool
-    */
-    proc in1dGlobalAr2Bcast(ar1: [?aD1] int, ar2: [?aD2] int) {
-
-        var truth: [aD1] bool;
-
-        for elt in ar2 {truth |= (ar1 == elt);}
-        
-        return truth;
-    }
 
     /* Put ar2 into an associative domain of int, per locale. 
     Creates truth (boolean array) from the domain of ar1.
@@ -67,8 +14,6 @@ module In1d
     set membership of ar1 to ar2 is checked on each locale by iterating over 
     the local subdomains of ar1, and populating the local subdomains of truth 
     with the result of the membership test.
-
-    Apply v flag for timing information.
 
     :arg ar1: array to broadcast in parallel over ar2
     :type ar1: [] int
@@ -80,42 +25,24 @@ module In1d
     :type truth: [] bool
     */
     proc in1dAr2PerLocAssoc(ar1: [?aD1] int, ar2: [?aD2] int) {
-
         var truth: [aD1] bool;
-        var timings: [PrivateSpace] [0..#3] real;
         
         coforall loc in Locales {
             on loc {
-
-                var t = new Time.Timer();
-                
-                if logLevel == LogLevel.DEBUG {t.start();}
-
                 var ar2Set: domain(int, parSafe=false); // create a set to hold ar2, parSafe modification is OFF
                 ar2Set.requestCapacity(ar2.size); // request a capacity for the initial set
 
-                if logLevel == LogLevel.DEBUG {t.stop(); timings[here.id][0] = t.elapsed(); t.clear(); t.start();}
-
-                // serially add all elements of ar2 to ar2Set
-                for e in ar2 { ar2Set += e; }
-                // all elements of ar2 have been added to ar2Set so modification done.
-                
-                if logLevel == LogLevel.DEBUG {t.stop(); timings[here.id][1] = t.elapsed(); t.clear(); t.start();}
+                for loc in offset(0..<numLocales) {
+                    var lD = ar2.localSubdomain(Locales[loc]);
+                    var slice = new lowLevelLocalizingSlice(ar2, lD.low..lD.high);
+                    // serially add all elements of ar2 to ar2Set
+                    for i in 0..<lD.size { ar2Set += slice.ptr[i]; }
+                }
 
                 // in parallel check all elements of ar1 to see if ar2Set contains them
                 [i in truth.localSubdomain()] truth[i] = ar2Set.contains(ar1[i]);
-
-                if logLevel == LogLevel.DEBUG {t.stop(); timings[here.id][2] = t.elapsed();}
             }
         }
-
-        try! inLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                     "max create time = %t".format(max reduce [i in PrivateSpace] timings[i][0]));
-        try! inLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                        "max fill time = %t".format(max reduce [i in PrivateSpace] timings[i][1]));
-        try! inLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                  "max membership time = %t".format(max reduce [i in PrivateSpace] timings[i][2]));
-        
         return truth;
     }
 

--- a/src/In1dMsg.chpl
+++ b/src/In1dMsg.chpl
@@ -18,11 +18,6 @@ module In1dMsg
     const iLogger = new Logger(logLevel);
     
     /*
-    Small bound const. Brute force in1d implementation recommended.
-    */
-    private config const sBound = 2**4; 
-
-    /*
     Medium bound const. Per locale associative domain in1d implementation recommended.
     */
     private config const mBound = 2**25; 
@@ -67,17 +62,8 @@ module In1dMsg
                 // things to do...
                 // if ar2 is big for some value of big... call unique on ar2 first
 
-                // brute force if below small bound
-                if (ar2.size <= sBound) {
-                    iLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                           "%t <= %t, using GlobalAr2Bcast".format(ar2.size,sBound));                    
-                    var truth = in1dGlobalAr2Bcast(ar1.a, ar2.a);
-                    if (invert) {truth = !truth;}
-                    
-                    st.addEntry(rname, new shared SymEntry(truth));
-                }
                 // per locale assoc domain if below medium bound
-                else if (ar2.size <= mBound) {
+                if (ar2.size <= mBound) {
                     iLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                                "%t <= %t, using Ar2PerLocAssoc".format(ar2.size,mBound));                  
                     var truth = in1dAr2PerLocAssoc(ar1.a, ar2.a);


### PR DESCRIPTION
Previously, int `in1d` had three implementation strategies depending on
the size of the second array. For small arrays (`<= 2**4`) a brute force
reduction was done, for medium arrays (`<= 2**25`) the array was
localized into a set, and for anything larger a more complicated
sorting-based scheme was used. Sorting has a lot of overhead so the
expectation was that the other strategies would be faster for smaller
problem sizes, but this wasn't tuned extensively before.

After adding a benchmark in #969, we discovered that the medium sized set
strategy was very slow in multi-locale configs. This was because the
code was serially gathering each element of the distributed array to add
to each locales private set. We know this fine-grained communication
performs poorly, especially on non Aries networks. Optimize that here by
doing bulk communication with the `lowLevelLocalizingSlice` to gather
the entire localSubdomain from each locale. This results in a single
bulk GET from each remote locale. We do this with an offset iterator so
that you don't have all locales doing a GETs from remote locales in
lockstep, which can overwhelm the network injection rate of a single
node. This was the most efficient strategy I found, and the results for
other schemes I found are in #970.

This significantly improves modest size in1d operations and brought
performance of really small operations close to the brute force scheme.
To close that gap I removed the PrivateDist array used for timers which
had small startup cost and with that the set based strategy is always
faster than the brute force strategy so I just removed the old brute
force method. Almost all (>95%) of the time in the set strategy is
serially adding to the set for non-trivial problem sizes so there's not
much user for the timers anyways now.

Here's some performance figures for various second array sizes on
16-node-cs-hdr before and after (first array size of `10**8`)

| Size      | Before      | Now         |
| --------- | ----------: | ----------: |
| 2**1      | 316.2 GiB/s | 324.7 GiB/s |
| 2**4      |  90.8 GiB/s | 250.1 GiB/s |
| 2**8      | 208.4 GiB/s | 247.3 GiB/s |
| 2**16     |  47.3 GiB/s | 177.3 GiB/s |
| 2**22     |   0.9 GiB/s |   9.4 GiB/s |
| 2**23     |   0.4 GiB/s |   4.8 GiB/s |
| 2**24     |   0.2 GiB/s |   2.5 GiB/s |
| 2**25 - 1 |   0.1 GiB/s |   1.3 GiB/s |
| 2**25 + 1 |   4.2 GiB/s |   4.2 GiB/s |

So overall some large performance benefits, though we'll probably still
want to do some tuning on the threshold between the medium and large
strategy.

Given that the medium size is doing an all gather, I wanted to check
scaling too. Here's some 512-node-xc results:

| Size      | Before      | Now         |
| --------- | ----------: | ----------: |
| 2**25 - 1 |   0.4 GiB/s |   6.4 GiB/s |
| 2**25 + 1 |   4.1 GiB/s |   4.1 GiB/s |

So here we still see improved performance for the set strategy, and in
this case it's actually faster than the sort strategy at the current
threshold.

The main bottleneck in the set strategy is that we're serially adding to
a set and this serialization becomes more apparent on higher core count
machines. It's unlikely that we'll be able to come up with a perfect
simple threshold because it depends on core count and network speed, but
I would still lean towards dropping it to `2**22` or `2**23` or so.

This threshold is also optimization dependent and there's likely more we
can do to optimize both strategies. Chapel should eventually have a
portable and scalable concurrent set which would help with the current
serialization. I haven't looked at tuning the sort-based strategy at all
yet but there is likely room for improvement. In the end, I don't think
we need a prefect threshold and I lean towards lowering the sort
threshold because sort is used for so much else it has well known
performance behavior.

Part of #970