### PR TITLE
Add optional support for 2 dimensional arrays

### DIFF
--- a/ServerModules.cfg
+++ b/ServerModules.cfg
@@ -23,6 +23,7 @@ BroadcastMsg
 FlattenMsg
 HDF5Msg
 ParquetMsg
+Arr2DMsg
 
 # Add additional modules located in
 # the Arkouda src/ directory below

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -205,6 +205,8 @@ class pdarray:
             if self.size != other.size:
                 raise ValueError("size mismatch {} {}".format(self.size,other.size))
             cmd = "binopvv"
+            if self.ndim != 1:
+                cmd += "2d"
             args= "{} {} {}".format(op, self.name, other.name)
             repMsg = generic_msg(cmd=cmd,args=args)
             return create_pdarray(repMsg)

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -457,6 +457,9 @@ class pdarray:
                 # Interpret negative key as offset from end of array
                 key += self.size
             if (key >= 0 and key < self.size):
+                if self.ndim == 2:
+                    repMsg = generic_msg(cmd="[int2d]", args=f"{self.name} {key}")
+                    return create_pdarray(repMsg)
                 repMsg = generic_msg(cmd="[int]", args="{} {}".format(self.name, key))
                 fields = repMsg.split()
                 # value = fields[2]

--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -829,12 +829,51 @@ def random_strings_lognormal(logmean : numeric_scalars, logstd : numeric_scalars
                  seed))
     return Strings.from_return_msg(cast(str, repMsg))
 
-# We cannot pass the binary data back for this function since it is optional
-# on the server side, which means that it's signature must be identical to
-# the regular Arkouda message. Could possibly add a second map that was like
-# "arrayCreationMap" or something that handled signatures of that type.
 def array2D(val, m, n) -> Union[pdarray, Strings]:
     """
+    Generate a 2D pdarray that is of size `m x n` and initialized to the
+    value `val`.
+
+    Parameters
+    ----------
+    val : numeric_and_bool_scalars
+        The value to initialize all elements of the 2D array to
+    m :  int_scalars
+        The `m` dimension of the array to create
+    n : int_scalars
+        The `n` dimension of the array to create
+    Returns
+    -------
+    pdarray
+        A pdarray instance stored on arkouda server
+        
+    Raises
+    ------
+    TypeError
+        Raised if a is not a pdarray, np.ndarray, or Python Iterable such as a
+        list, array, tuple, or deque
+
+    See Also
+    --------
+    ak.array
+
+    Notes
+    -----
+    We cannot pass the binary data back for this function since it is optional
+    on the server side, which means that its signature must be identical to 
+    the regular Arkouda message. Could possibly add a second map that was like
+    "arrayCreationMap" or something that handled signatures of that type.    
+
+    Examples
+    --------
+    >>> ak.array2D(5, 2, 2)
+    array([[5, 5],
+           [5, 5]])
+    
+    >>> ak.array2D(True, 3, 3)
+    array([[True, True, True],
+           [True, True, True],
+           [True, True, True]])
     """
     args = ""
     from arkouda.client import maxTransferBytes
@@ -851,6 +890,50 @@ def array2D(val, m, n) -> Union[pdarray, Strings]:
 
 def randint2D(low : numeric_scalars, high : numeric_scalars, 
               m : int_scalars, n : int_scalars, dtype=int64, seed : int_scalars=None) -> pdarray:
+    """
+    Generate a 2 dimensional pdarray of randomized int, float, or bool values in a 
+    specified range bounded by the low and high parameters.
+
+    Parameters
+    ----------
+    low : numeric_scalars
+        The low value (inclusive) of the range
+    high : numeric_scalars
+        The high value (exclusive for int, inclusive for float) of the range
+    m :  int_scalars
+        The `m` dimension of the array to create
+    n : int_scalars
+        The `n` dimension of the array to create
+    dtype : Union[int64, float64, bool]
+        The dtype of the array
+    seed : int_scalars
+        Index for where to pull the first returned value
+        
+
+    Returns
+    -------
+    pdarray
+        Values drawn uniformly from the specified range having the desired dtype
+        
+    Raises
+    ------
+    TypeError
+        Raised if dtype.name not in DTypes, size is not an int, low or high is
+        not an int or float, or seed is not an int
+    ValueError
+        Raised if size < 0 or if high < low
+
+    Notes
+    -----
+    Calling randint with dtype=float64 will result in uniform non-integral
+    floating point values.
+
+    Examples
+    --------
+    >>> ak.randint2D(0, 10, 2, 2)
+    array([[3, 6],
+           [8, 4]])
+    """
     if high < low:
         raise ValueError("size must be > 0 and high > low")
     dtype = akdtype(dtype) # normalize dtype

--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -909,7 +909,6 @@ def randint2D(low : numeric_scalars, high : numeric_scalars,
     seed : int_scalars
         Index for where to pull the first returned value
         
-
     Returns
     -------
     pdarray
@@ -933,6 +932,14 @@ def randint2D(low : numeric_scalars, high : numeric_scalars,
     >>> ak.randint2D(0, 10, 2, 2)
     array([[3, 6],
            [8, 4]])
+
+    >>> ak.randint2D(0, 1, 2, 2, dtype=ak.bool)
+    array([[True, True],
+           [False, True]])
+
+    >>> ak.randint2D(0, 1, 2, 2, dtype=ak.float64)
+    array([[0.3793842821625909, 0.97508925511529132],
+           [0.12608488822540775, 0.23591727525338338]])    
     """
     if high < low:
         raise ValueError("size must be > 0 and high > low")
@@ -943,6 +950,6 @@ def randint2D(low : numeric_scalars, high : numeric_scalars,
     lowstr = NUMBER_FORMAT_STRINGS[dtype.name].format(low)
     highstr = NUMBER_FORMAT_STRINGS[dtype.name].format(high)
 
-    repMsg = generic_msg(cmd='randint2d', args='{} {} {} {} {}'.\
-                         format(lowstr, highstr, m, n, seed))
+    repMsg = generic_msg(cmd='randint2d', args='{} {} {} {} {} {}'.\
+                         format(dtype.name, lowstr, highstr, m, n, seed))
     return create_pdarray(repMsg)

--- a/benchmarks/arr2d.py
+++ b/benchmarks/arr2d.py
@@ -1,0 +1,76 @@
+import time, argparse
+import arkouda as ak
+import os
+from glob import glob
+import math
+
+TYPES = ('int64')
+
+def time_binary_op(N_per_locale, trials, dtype, seed):
+    print(">>> arkouda {} binary op".format(dtype))
+    cfg = ak.get_config()
+    N = N_per_locale * cfg["numLocales"]
+    print("numLocales = {}, N = {:,}".format(cfg["numLocales"], N))
+    a = ak.randint(0, 2**32, N)
+    b = ak.randint2D(0,2**32, int(math.sqrt(N)), int(math.sqrt(N)))
+     
+    times1d = []
+    times2d = []
+    for i in range(trials):
+        start = time.time()
+        a + a
+        end = time.time()
+        times1d.append(end - start)
+        start = time.time()
+        b + b
+        end = time.time()
+        times2d.append(end - start)
+    avg1d = sum(times1d) / trials
+    avg2d = sum(times2d) / trials
+
+    print("1d Average time = {:.4f} sec".format(avg1d))
+    print("2d Average time = {:.4f} sec".format(avg2d))
+
+    nb = a.size * a.itemsize
+    print("1d Average rate = {:.2f} GiB/sec".format(nb/2**30/avg1d))
+    print("2d Average rate = {:.2f} GiB/sec".format(nb/2**30/avg2d))
+
+def check_correctness(dtype, path, seed):
+    N = 10**4
+    a = ak.randint(0, 2**32, N, seed=seed)
+
+    a.save_parquet(path)
+    b = ak.read_parquet(path+'*')
+    for f in glob(path + '_LOCALE*'):
+        os.remove(f)
+    assert (a == b).all()
+
+def create_parser():
+    parser = argparse.ArgumentParser(description="Measure performance of writing and reading a random array from disk.")
+    parser.add_argument('hostname', help='Hostname of arkouda server')
+    parser.add_argument('port', type=int, help='Port of arkouda server')
+    parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: length of array to write/read')
+    parser.add_argument('-t', '--trials', type=int, default=1, help='Number of times to run the benchmark')
+    parser.add_argument('-d', '--dtype', default='int64', help='Dtype of array ({})'.format(', '.join(TYPES)))
+    parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
+    parser.add_argument('-s', '--seed', default=None, type=int, help='Value to initialize random number generator')
+    return parser
+
+if __name__ == "__main__":
+    import sys
+    parser = create_parser()
+    args = parser.parse_args()
+    if args.dtype not in TYPES:
+        raise ValueError("Dtype must be {}, not {}".format('/'.join(TYPES), args.dtype))
+    ak.verbose = False
+    ak.connect(args.hostname, args.port)
+
+    #if args.correctness_only:
+    #   for dtype in TYPES:
+    #      check_correctness(dtype, args.seed)
+    # sys.exit(0)
+    
+    print("array size = {:,}".format(args.size))
+    print("number of trials = ", args.trials)
+    time_binary_op(args.size, args.trials, args.dtype, args.seed)
+    sys.exit(0)

--- a/benchmarks/binop2d.py
+++ b/benchmarks/binop2d.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3                                                         
+
+import time, argparse
+import arkouda as ak
+import os
+from glob import glob
+
+TYPES = ('int64')
+
+def time_ak_1d(N_per_locale, trials, dtype, path, seed):
+    print(">>> arkouda {} 1D Binary Operation".format(dtype))
+    cfg = ak.get_config()
+    N = N_per_locale * cfg["numLocales"]
+    print("numLocales = {}, N = {:,}".format(cfg["numLocales"], N))
+    a = ak.randint(0, 2**32, N, seed=seed)
+    b = ak.randint(0, 2**32, N, seed=seed)
+     
+    writetimes = []
+    readtimes = []
+    for i in range(trials):
+        start = time.time()
+        c = a + b
+        end = time.time()
+        readtimes.append(end - start)
+        for f in glob(path+'_LOCALE*'):
+            os.remove(f)
+    avgread = sum(readtimes) / trials
+
+    print("1D Average time = {:.4f} sec".format(avgread))
+
+    nb = a.size * a.itemsize
+    print("1D Average rate = {:.2f} GiB/sec".format(nb/2**30/avgread))
+
+def time_ak_2d(N_per_locale, M_per_locale, trials, dtype, path, seed):
+    print(">>> arkouda {} 2D Binary Operation".format(dtype))
+    cfg = ak.get_config()
+    N = N_per_locale * cfg["numLocales"]
+    M = M_per_locale * cfg["numLocales"]
+    print("numLocales = {}, N = {:,}".format(cfg["numLocales"], N))
+    a = ak.randint2D(0, 2**32, M, N, seed=seed)
+    b = ak.randint2D(0, 2**32, M, N, seed=seed)
+     
+    writetimes = []
+    readtimes = []
+    for i in range(trials):
+        start = time.time()
+        c = a + b
+        end = time.time()
+        readtimes.append(end - start)
+        for f in glob(path+'_LOCALE*'):
+            os.remove(f)
+    avgread = sum(readtimes) / trials
+
+    print("2D Average time = {:.4f} sec".format(avgread))
+
+    nb = a.size * a.itemsize
+    print("2D Average rate = {:.2f} GiB/sec".format(nb/2**30/avgread))
+
+    
+def check_correctness(dtype, path, seed):
+    N = 10**4
+    if dtype == 'int64':
+        a = ak.randint(0, 2**32, N, seed=seed)
+    elif dtype == 'float64':
+        a = ak.randint(0, 1, N, dtype=ak.float64, seed=seed)
+
+    a.save(path)
+    b = ak.load(path)
+    for f in glob(path+"_LOCALE*"):
+        os.remove(f)
+    assert (a == b).all()
+
+def create_parser():
+    parser = argparse.ArgumentParser(description="Measure performance of writing and reading a random array from disk.")
+    parser.add_argument('hostname', help='Hostname of arkouda server')
+    parser.add_argument('port', type=int, help='Port of arkouda server')
+    parser.add_argument('-n', '--size', type=int, default=10**2, help='Problem size: length of array to write/read')
+    parser.add_argument('-m', '--size2', type=int, default=10**2, help='Problem size: length of array to write/read')  
+    parser.add_argument('-t', '--trials', type=int, default=1, help='Number of times to run the benchmark')
+    parser.add_argument('-d', '--dtype', default='int64', help='Dtype of array ({})'.format(', '.join(TYPES)))
+    parser.add_argument('-p', '--path', default=os.getcwd()+'ak-io-test', help='Target path for measuring read/write rates')
+    parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
+    parser.add_argument('-s', '--seed', default=None, type=int, help='Value to initialize random number generator')
+    return parser
+
+if __name__ == "__main__":
+    import sys
+    parser = create_parser()
+    args = parser.parse_args()
+    if args.dtype not in TYPES:
+        raise ValueError("Dtype must be {}, not {}".format('/'.join(TYPES), args.dtype))
+    ak.verbose = False
+    ak.connect(args.hostname, args.port)
+
+    if args.correctness_only:
+        for dtype in TYPES:
+            check_correctness(dtype, args.path, args.seed)
+        sys.exit(0)
+    
+    print("array size = {:,}".format(args.size))
+    print("number of trials = ", args.trials)
+    time_ak_1d(args.size*args.size2, args.trials, args.dtype, args.path, args.seed)
+    time_ak_2d(args.size, args.size2, args.trials, args.dtype, args.path, args.seed)
+    sys.exit(0)

--- a/src/Arr2DMsg.chpl
+++ b/src/Arr2DMsg.chpl
@@ -142,79 +142,79 @@ module Arr2DMsg {
     boolOps.add("!=");
 
     select (left.dtype, right.dtype) {
-    when (DType.Int64, DType.Int64) {
-      var l = left: SymEntry2D(int);
-      var r = right: SymEntry2D(int);
-      if boolOps.contains(op) {
-        var e = st.addEntry2D(rname, l.m, l.n, bool);
+      when (DType.Int64, DType.Int64) {
+        var l = left: SymEntry2D(int);
+        var r = right: SymEntry2D(int);
+        if boolOps.contains(op) {
+          var e = st.addEntry2D(rname, l.m, l.n, bool);
+          return doBinOp(l, r, e, op, rname, pn, st);
+        } else if op == "/" {
+          var e = st.addEntry2D(rname, l.m, l.n, real);
+          return doBinOp(l, r, e, op, rname, pn, st);
+        }
+        var e = st.addEntry2D(rname, l.m, l.n, int);
         return doBinOp(l, r, e, op, rname, pn, st);
-      } else if op == "/" {
+      }
+      when (DType.Int64, DType.Float64) {
+        var l = left: SymEntry2D(int);
+        var r = right: SymEntry2D(real);
+        if boolOps.contains(op) {
+          var e = st.addEntry2D(rname, l.m, l.n, bool);
+          return doBinOp(l, r, e, op, rname, pn, st);
+        }
         var e = st.addEntry2D(rname, l.m, l.n, real);
         return doBinOp(l, r, e, op, rname, pn, st);
       }
-      var e = st.addEntry2D(rname, l.m, l.n, int);
-      return doBinOp(l, r, e, op, rname, pn, st);
-    }
-    when (DType.Int64, DType.Float64) {
-      var l = left: SymEntry2D(int);
-      var r = right: SymEntry2D(real);
-      if boolOps.contains(op) {
+      when (DType.Float64, DType.Int64) {
+        var l = left: SymEntry2D(real);
+        var r = right: SymEntry2D(int);
+        if boolOps.contains(op) {
+          var e = st.addEntry2D(rname, l.m, l.n, bool);
+          return doBinOp(l, r, e, op, rname, pn, st);
+        }
+        var e = st.addEntry2D(rname, l.m, l.n, real);
+        return doBinOp(l, r, e, op, rname, pn, st);
+      }
+      when (DType.Float64, DType.Float64) {
+        var l = left: SymEntry2D(real);
+        var r = right: SymEntry2D(real);
+        if boolOps.contains(op) {
+          var e = st.addEntry2D(rname, l.m, l.n, bool);
+          return doBinOp(l, r, e, op, rname, pn, st);
+        }
+        var e = st.addEntry2D(rname, l.m, l.n, real);
+        return doBinOp(l, r, e, op, rname, pn, st);
+      }
+      when (DType.Bool, DType.Bool) {
+        var l = left: SymEntry2D(bool);
+        var r = right: SymEntry2D(bool);
         var e = st.addEntry2D(rname, l.m, l.n, bool);
         return doBinOp(l, r, e, op, rname, pn, st);
       }
-      var e = st.addEntry2D(rname, l.m, l.n, real);
-      return doBinOp(l, r, e, op, rname, pn, st);
-    }
-    when (DType.Float64, DType.Int64) {
-      var l = left: SymEntry2D(real);
-      var r = right: SymEntry2D(int);
-      if boolOps.contains(op) {
-        var e = st.addEntry2D(rname, l.m, l.n, bool);
+      when (DType.Bool, DType.Int64) {
+        var l = left: SymEntry2D(bool);
+        var r = right: SymEntry2D(int);
+        var e = st.addEntry2D(rname, l.m, l.n, int);
         return doBinOp(l, r, e, op, rname, pn, st);
       }
-      var e = st.addEntry2D(rname, l.m, l.n, real);
-      return doBinOp(l, r, e, op, rname, pn, st);
-    }
-    when (DType.Float64, DType.Float64) {
-      var l = left: SymEntry2D(real);
-      var r = right: SymEntry2D(real);
-      if boolOps.contains(op) {
-        var e = st.addEntry2D(rname, l.m, l.n, bool);
+      when (DType.Int64, DType.Bool) {
+        var l = left: SymEntry2D(int);
+        var r = right: SymEntry2D(bool);
+        var e = st.addEntry2D(rname, l.m, l.n, int);
         return doBinOp(l, r, e, op, rname, pn, st);
       }
-      var e = st.addEntry2D(rname, l.m, l.n, real);
-      return doBinOp(l, r, e, op, rname, pn, st);
-    }
-    when (DType.Bool, DType.Bool) {
-      var l = left: SymEntry2D(bool);
-      var r = right: SymEntry2D(bool);
-      var e = st.addEntry2D(rname, l.m, l.n, bool);
-      return doBinOp(l, r, e, op, rname, pn, st);
-    }
-    when (DType.Bool, DType.Int64) {
-      var l = left: SymEntry2D(bool);
-      var r = right: SymEntry2D(int);
-      var e = st.addEntry2D(rname, l.m, l.n, int);
-      return doBinOp(l, r, e, op, rname, pn, st);
-    }
-    when (DType.Int64, DType.Bool) {
-      var l = left: SymEntry2D(int);
-      var r = right: SymEntry2D(bool);
-      var e = st.addEntry2D(rname, l.m, l.n, int);
-      return doBinOp(l, r, e, op, rname, pn, st);
-    }
-    when (DType.Bool, DType.Float64) {
-      var l = left: SymEntry2D(bool);
-      var r = right: SymEntry2D(real);
-      var e = st.addEntry2D(rname, l.m, l.n, real);
-      return doBinOp(l, r, e, op, rname, pn, st);
-    }
-    when (DType.Float64, DType.Bool) {
-      var l = left: SymEntry2D(real);
-      var r = right: SymEntry2D(bool);
-      var e = st.addEntry2D(rname, l.m, l.n, real);
-      return doBinOp(l, r, e, op, rname, pn, st);
-    }
+      when (DType.Bool, DType.Float64) {
+        var l = left: SymEntry2D(bool);
+        var r = right: SymEntry2D(real);
+        var e = st.addEntry2D(rname, l.m, l.n, real);
+        return doBinOp(l, r, e, op, rname, pn, st);
+      }
+      when (DType.Float64, DType.Bool) {
+        var l = left: SymEntry2D(real);
+        var r = right: SymEntry2D(bool);
+        var e = st.addEntry2D(rname, l.m, l.n, real);
+        return doBinOp(l, r, e, op, rname, pn, st);
+      }
     }
     return new MsgTuple("Bin op not supported", MsgType.NORMAL);
   }
@@ -238,8 +238,7 @@ module Arr2DMsg {
   proc rowIndex2DMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
     param pn = Reflection.getRoutineName();
     var repMsg: string; // response message
-    var (name, rowNumStr)
-      = payload.splitMsgToTuple(2); // split request into fields
+    var (name, rowNumStr) = payload.splitMsgToTuple(2); // split request into fields
     var row = try! rowNumStr:int;
 
     // get next symbol name

--- a/src/Arr2DMsg.chpl
+++ b/src/Arr2DMsg.chpl
@@ -1,0 +1,209 @@
+module Arr2DMsg {
+  use GenSymIO;
+  use SymEntry2D;
+
+  use ServerConfig;
+  use MultiTypeSymbolTable;
+  use MultiTypeSymEntry;
+  use Message;
+  use ServerErrors;
+  use Reflection;
+  use RandArray;
+
+  use OperatorMsg;
+
+  proc array2DMsg(cmd: string, args: string, st: borrowed SymTab): MsgTuple throws {
+    var (dtypeBytes, val, mStr, nStr) = args.splitMsgToTuple(" ", 4);
+    var dtype = DType.UNDEF;
+    var m: int;
+    var n: int;
+    var rname:string = "";
+
+    try {
+      dtype = str2dtype(dtypeBytes);
+      m = mStr: int;
+      n = nStr: int;
+    } catch {
+      var errorMsg = "Error parsing/decoding either dtypeBytes, m, or n";
+      gsLogger.error(getModuleName(), getRoutineName(), getLineNumber(), errorMsg);
+      return new MsgTuple(errorMsg, MsgType.ERROR);
+    }
+
+    overMemLimit(2*m*n);
+
+    if dtype == DType.Int64 {
+      var entry = new shared SymEntry2D(m, n, int);
+      var localA: [{0..#m, 0..#n}] int = val:int;
+      entry.a = localA;
+      rname = st.nextName();
+      st.addEntry(rname, entry);
+    } else if dtype == DType.Float64 {
+      var entry = new shared SymEntry2D(m, n, real);
+      var localA: [{0..#m, 0..#n}] real = val:real;
+      entry.a = localA;
+      rname = st.nextName();
+      st.addEntry(rname, entry);
+    } else if dtype == DType.Bool {
+      var entry = new shared SymEntry2D(m, n, bool);
+      var localA: [{0..#m, 0..#n}] bool = if val == "True" then true else false;
+      entry.a = localA;
+      rname = st.nextName();
+      st.addEntry(rname, entry);
+    }
+
+    var msgType = MsgType.NORMAL;
+    var msg:string = "";
+
+    if (MsgType.ERROR != msgType) {
+      if (msg.isEmpty()) {
+        msg = "created " + st.attrib(rname);
+      }
+      gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),msg);
+    }
+    return new MsgTuple(msg, msgType);
+  }
+
+  proc randint2DMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    param pn = Reflection.getRoutineName();
+    var repMsg: string; // response message
+    // split request into fields
+    var (aMinStr,aMaxStr,mStr,nStr,seed) = payload.splitMsgToTuple(5);
+    var m = mStr:int;
+    var n = nStr:int;
+
+    overMemLimit(8*m*n);
+    var aMin = aMinStr:int;
+    var aMax = aMaxStr:int;
+    var entry = new shared SymEntry2D(m, n, int);
+
+    var localA: [{0..#m, 0..#n}] int;
+    entry.a = localA;
+    var rname = st.nextName();
+    st.addEntry(rname, entry);
+    fillInt(entry.a, aMin, aMax, seed);
+
+    repMsg = "created " + st.attrib(rname);
+    return new MsgTuple(repMsg, MsgType.NORMAL);
+  }
+
+  proc binopvv2DMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    param pn = Reflection.getRoutineName();
+    var repMsg: string; // response message
+
+    // split request into fields
+    var (op, aname, bname) = payload.splitMsgToTuple(3);
+
+    var rname = st.nextName();
+    var left: borrowed GenSymEntry = getGenericTypedArrayEntry(aname, st);
+    var right: borrowed GenSymEntry = getGenericTypedArrayEntry(bname, st);
+
+    use Set;
+    var boolOps: set(string);
+    boolOps.add("<");
+    boolOps.add("<=");
+    boolOps.add(">");
+    boolOps.add(">=");
+    boolOps.add("==");
+    boolOps.add("!=");
+
+    select (left.dtype, right.dtype) {
+    when (DType.Int64, DType.Int64) {
+      var l = left: SymEntry2D(int);
+      var r = right: SymEntry2D(int);
+      if boolOps.contains(op) {
+        var e = st.addEntry2D(rname, l.m, l.n, bool);
+        return doBinOp(l, r, e, op, rname, pn, st);
+      } else if op == "/" {
+        var e = st.addEntry2D(rname, l.m, l.n, real);
+        return doBinOp(l, r, e, op, rname, pn, st);
+      }
+      var e = st.addEntry2D(rname, l.m, l.n, int);
+      return doBinOp(l, r, e, op, rname, pn, st);
+    }
+    when (DType.Int64, DType.Float64) {
+      var l = left: SymEntry2D(int);
+      var r = right: SymEntry2D(real);
+      if boolOps.contains(op) {
+        var e = st.addEntry2D(rname, l.m, l.n, bool);
+        return doBinOp(l, r, e, op, rname, pn, st);
+      }
+      var e = st.addEntry2D(rname, l.m, l.n, real);
+      return doBinOp(l, r, e, op, rname, pn, st);
+    }
+    when (DType.Float64, DType.Int64) {
+      var l = left: SymEntry2D(real);
+      var r = right: SymEntry2D(int);
+      if boolOps.contains(op) {
+        var e = st.addEntry2D(rname, l.m, l.n, bool);
+        return doBinOp(l, r, e, op, rname, pn, st);
+      }
+      var e = st.addEntry2D(rname, l.m, l.n, real);
+      return doBinOp(l, r, e, op, rname, pn, st);
+    }
+    when (DType.Float64, DType.Float64) {
+      var l = left: SymEntry2D(real);
+      var r = right: SymEntry2D(real);
+      if boolOps.contains(op) {
+        var e = st.addEntry2D(rname, l.m, l.n, bool);
+        return doBinOp(l, r, e, op, rname, pn, st);
+      }
+      var e = st.addEntry2D(rname, l.m, l.n, real);
+      return doBinOp(l, r, e, op, rname, pn, st);
+    }
+    when (DType.Bool, DType.Bool) {
+      var l = left: SymEntry2D(bool);
+      var r = right: SymEntry2D(bool);
+      var e = st.addEntry2D(rname, l.m, l.n, bool);
+      return doBinOp(l, r, e, op, rname, pn, st);
+    }
+    when (DType.Bool, DType.Int64) {
+      var l = left: SymEntry2D(bool);
+      var r = right: SymEntry2D(int);
+      var e = st.addEntry2D(rname, l.m, l.n, int);
+      return doBinOp(l, r, e, op, rname, pn, st);
+    }
+    when (DType.Int64, DType.Bool) {
+      var l = left: SymEntry2D(int);
+      var r = right: SymEntry2D(bool);
+      var e = st.addEntry2D(rname, l.m, l.n, int);
+      return doBinOp(l, r, e, op, rname, pn, st);
+    }
+    when (DType.Bool, DType.Float64) {
+      var l = left: SymEntry2D(bool);
+      var r = right: SymEntry2D(real);
+      var e = st.addEntry2D(rname, l.m, l.n, real);
+      return doBinOp(l, r, e, op, rname, pn, st);
+    }
+    when (DType.Float64, DType.Bool) {
+      var l = left: SymEntry2D(real);
+      var r = right: SymEntry2D(bool);
+      var e = st.addEntry2D(rname, l.m, l.n, real);
+      return doBinOp(l, r, e, op, rname, pn, st);
+    }
+    }
+    return new MsgTuple("Bin op not supported", MsgType.NORMAL);
+  }
+
+  proc SymTab.addEntry2D(name: string, m, n, type t): borrowed SymEntry2D(t) throws {
+    if t == bool {overMemLimit(m*n);} else {overMemLimit(m*n*numBytes(t));}
+
+    var entry = new shared SymEntry2D(m, n, t);
+    if (tab.contains(name)) {
+      mtLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                     "redefined symbol: %s ".format(name));
+    } else {
+      mtLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                     "adding symbol: %s ".format(name));
+    }
+
+    tab.addOrSet(name, entry);
+    return (tab.getBorrowed(name):borrowed GenSymEntry): SymEntry2D(t);
+  }
+
+  proc registerMe() {
+    use CommandMap;
+    registerFunction("array2d", array2DMsg);
+    registerFunction("randint2d", randint2DMsg);
+    registerFunction("binopvv2d", binopvv2DMsg);
+  }
+}

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -48,10 +48,7 @@ module OperatorMsg
                                           cmd,op,st.attrib(aname),st.attrib(bname)));
 
         use Set;
-        // could have supported ops for the different types and
-        // then we would just need to check if they are supported
-        // before calling doBinOp? This would allow us to get around
-        // the selection on dtypes maybe?
+
         var boolOps: set(string);
         boolOps.add("<");
         boolOps.add("<=");
@@ -60,10 +57,6 @@ module OperatorMsg
         boolOps.add("==");
         boolOps.add("!=");
 
-        // switching this to an if/else could enable us to
-        // share more code and not have as much duplication
-        // since all that is different is the casting to a
-        // symEntry type
         select (left.dtype, right.dtype) {
           when (DType.Int64, DType.Int64) {
             var l = toSymEntry(left,int);
@@ -169,8 +162,6 @@ module OperatorMsg
             }
           }
         } else {
-          // could combine this and above case by just checking on types
-          // to see if we can do it? Like for `<`, don't do it for bools
           select op {
               when "<" {
                 e.a = l.a < r.a;

--- a/src/SymEntry2D.chpl
+++ b/src/SymEntry2D.chpl
@@ -1,0 +1,83 @@
+module SymEntry2D {
+  use MultiTypeSymEntry;
+  use SymArrayDmap;
+
+  class SymEntry2D : GenSymEntry {
+    type etype;
+
+    var m: int;
+    var n: int;
+    var aD: makeDistDom2D(m,n).type;
+    var a: [aD] etype;
+
+    proc init(m: int, n: int, type etype) {
+      super.init(etype, (m*n));
+      this.etype = etype;
+      this.m = m;
+      this.n = n;
+      this.aD = makeDistDom2D(m, n);
+      this.ndim = 2;
+    }
+
+    proc init(a: [?D] ?etype) {
+      super.init(etype, a.size);
+      this.etype = etype;
+      this.m = D.high[0]+1;
+      this.n = D.high[1]+1;
+      this.aD = D;
+      this.a = a;
+      this.ndim = 2;
+    }
+
+    // TODO: not using threshold, how do we want to print large
+    // 2D arrays?
+    override proc __str__(thresh:int=6, prefix:string = "[", suffix:string = "]", baseFormat:string = "%t"): string throws {
+      var s:string = "";
+
+      for i in 0..#this.m {
+        s += "[";
+        for j in 0..#this.n {
+          s += try! baseFormat.format(this.a[i, j]);
+          if j != n-1 then
+            s += ", ";
+          else if i != m-1 then
+            s +=  "],\n       ";
+        }
+      }
+      s += "]";
+
+      if (bool == this.etype) {
+        s = s.replace("true","True");
+        s = s.replace("false","False");
+      }
+
+      return prefix + s + suffix;
+    }
+  }
+
+  proc makeDistDom2D(m: int, n: int) {
+    select MyDmap {
+        when Dmap.defaultRectangular {
+          return {0..#m, 0..#n};
+        }
+        when Dmap.blockDist {
+          if m > 0 && n > 0 {
+            return {0..#m, 0..#n} dmapped Block(boundingBox={0..#m, 0..#n});
+          }
+          // fix the annoyance about boundingBox being enpty
+          else {return {0..#0, 0..#0} dmapped Block(boundingBox={0..0, 0..0});}
+        }
+        when Dmap.cyclicDist {
+          return {0..#m, 0..#n} dmapped Cyclic(startIdx=0);
+        }
+        otherwise {
+          halt("Unsupported distribution " + MyDmap:string);
+        }
+      }
+  }
+
+  proc makeDistArray2D(m: int, n: int, type etype) {
+    var a: [makeDistDom2D(m, n)] etype;
+    return a;
+  }
+}

--- a/src/SymEntry2D.chpl
+++ b/src/SymEntry2D.chpl
@@ -55,6 +55,10 @@ module SymEntry2D {
     }
   }
 
+  proc toSymEntry2D(e, type etype) {
+    return try! e :borrowed SymEntry2D(etype);
+  }
+
   proc makeDistDom2D(m: int, n: int) {
     select MyDmap {
         when Dmap.defaultRectangular {


### PR DESCRIPTION
This PR adds support for optional 2D arrays in the server. These 2D arrays essentially only support binary operations and random 2D array generation in this PR, but that could be extended to other areas of the codebase as seen fit.

This is able to stay modular by containing everything pertaining to 2D arrays in files separate from the 1D array code. This 2D array support is located in `SymEntry2D.chpl`, which contains the 2D symbol table entry, and `Arr2DMsg.chpl`, which contains all of the 2D array functions.

This PR is based on the binary operations refactor in https://github.com/Bears-R-Us/arkouda/pull/1034 (in other words, the diff for `OperatorMsg.chpl` is identical to that other PR), where the 2D array code is able to share the `doBinOp` function to avoid code duplication while maintaining modularity of the 2D arrays.