### PR TITLE
Parallelize Parquet file reading on-node

### DIFF
--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -93,13 +93,13 @@ module ParquetMsg {
     var (subdoms, length) = getSubdomains(sizes);
 
     coforall loc in A.targetLocales() do on loc {
-      var pqErr = new parquetErrorMsg();
       var locFiles = filenames;
       var locFiledoms = subdoms;
-      for (filedom, filename) in zip(locFiledoms, locFiles) {
+      forall (filedom, filename) in zip(locFiledoms, locFiles) {
         for locdom in A.localSubdomains() {
           const intersection = domain_intersection(locdom, filedom);
           if intersection.size > 0 {
+            var pqErr = new parquetErrorMsg();
             var col: [filedom] int;
             if c_readColumnByName(filename.localize().c_str(), c_ptrTo(col),
                                   dsetname.localize().c_str(), filedom.size, batchSize,


### PR DESCRIPTION
This PR turns the `for` loop for reading files into a `forall` loop to parallelize file reading. Since Parquet is thread-safe, we are able to parallelize reads on-node, which can't be done with HDF5. `test_multi_file()` in `tests/parquet_test.py` tests this functionality.

Here are some performance figures collected on 16-node-cs-hdr using 400 .25 GiB files before and after vs HDF5:
| Nodes | HDF5   | Ser Parquet (before) | Par parquet (after) |
| ----: | -----: | ----------: | ----------: |
|  1      |  136.1s   |    126.9s  |        12.8s   |
| 16     |  8.4s  |    17.8s        |         4.0s    |