### PR TITLE
Issue #1049: Adds capability to print server commands from the client.

### DIFF
--- a/src/CommandMap.chpl
+++ b/src/CommandMap.chpl
@@ -4,19 +4,59 @@ module CommandMap {
   use Message;
   use MultiTypeSymbolTable;
 
-  // This is a dummy function to get the signature of the Arkouda
-  // server FCF. Ideally, the `func()` function would be able to
-  // construct the FCF type, but there is no way to generate a
-  // FCF that throws using `func()` today.
+  /**
+   * This is a dummy function to get the signature of the Arkouda
+   * server FCF. Ideally, the `func()` function would be able to
+   * construct the FCF type, but there is no way to generate a
+   * FCF that throws using `func()` today.
+   */
   proc akMsgSign(a: string, b: string, c: borrowed SymTab): MsgTuple throws {
     var rep = new MsgTuple("dummy-msg", MsgType.NORMAL);
     return rep;
   }
 
+  /**
+   * Just like akMsgSign, but Messages which have a binary return
+   * require a different signature
+   */
+  proc akBinMsgSign(a: string, b: string, c: borrowed SymTab): bytes throws {
+    var nb = b"\x00";
+    return nb;
+  }
+
   var f = akMsgSign;
+  var b = akBinMsgSign;
+
   var commandMap: map(string, f.type);
-  
+  var commandMapBinary: map(string, b.type);
+
+  /**
+   * Register command->function in the CommandMap
+   * This binds a server command to its corresponding function matching the standard
+   * function signature & MsgTuple return type
+   */
   proc registerFunction(cmd: string, fcf: f.type) {
     commandMap.add(cmd, fcf);
   }
+
+  /**
+   * Register command->function in the CommandMap for Binary returning functions
+   * This binds a server command to its corresponding function matching the standard
+   * function signature but returning "bytes"
+   */
+  proc registerBinaryFunction(cmd: string, fcf: b.type) {
+    commandMapBinary.add(cmd, fcf);
+  }
+
+  /**
+   * Dump the combined contents of the command maps as a single json encoded string
+   */
+  proc dumpCommandMap(): string throws {
+    var cm1:string = "%jt".format(commandMap);
+    var cm2:string = "%jt".format(commandMapBinary);
+    // Join these two together
+    var idx_close = cm1.rfind("}"):int;
+    return cm1(0..idx_close-1) + ", " + cm2(1..cm2.size-1);
+  }
+
 }

--- a/src/CommandMap.chpl
+++ b/src/CommandMap.chpl
@@ -24,8 +24,8 @@ module CommandMap {
     return nb;
   }
 
-  var f = akMsgSign;
-  var b = akBinMsgSign;
+  private var f = akMsgSign;
+  private var b = akBinMsgSign;
 
   var commandMap: map(string, f.type);
   var commandMapBinary: map(string, b.type);

--- a/src/MsgProcessing.chpl
+++ b/src/MsgProcessing.chpl
@@ -15,14 +15,6 @@ module MsgProcessing
     use ServerErrorStrings;
 
     use AryUtil;
-
-    // "Backbone modules" included in every build
-    import RandMsg;
-    RandMsg.registerMe();
-    import IndexingMsg;
-    IndexingMsg.registerMe();
-    import OperatorMsg;
-    OperatorMsg.registerMe();
     
     private config const logLevel = ServerConfig.logLevel;
     const mpLogger = new Logger(logLevel);
@@ -181,6 +173,23 @@ module MsgProcessing
         }
     }
     
+    /**
+     *
+     *
+     */
+    proc getCommandMapMsg(cmd: string, payload: string, st: borrowed SymTab) throws {
+        // We can ignore the args, we just need it to match the CommandMap call signature
+        import CommandMap;
+        try {
+            const json:string = CommandMap.dumpCommandMap();
+            return new MsgTuple(CommandMap.dumpCommandMap():string, MsgType.NORMAL);
+        } catch {
+            var errorMsg = "Error converting CommandMap to JSON";
+            mpLogger.error(getModuleName(), getRoutineName(), getLineNumber(), errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+        }
+    }
+
     /* 
     Response to __str__ method in python str convert array data to string 
 

--- a/src/MsgProcessing.chpl
+++ b/src/MsgProcessing.chpl
@@ -174,8 +174,22 @@ module MsgProcessing
     }
     
     /**
+     * Generate the mapping of server command to function as JSON
+     * encoded string.
      *
+     * The args are IGNORED. They are only here to match the CommandMap
+     * standard function signature, similar to other procs.
      *
+     * :arg cmd: Ignored
+     * :type cmd: string 
+     *
+     * :arg payload: Ignored
+     * :type payload: string
+     *
+     * :arg st: Ignored
+     * :type st: borrowed SymTab 
+     *
+     * :returns: MsgTuple containing JSON formatted string of cmd -> function mapping
      */
     proc getCommandMapMsg(cmd: string, payload: string, st: borrowed SymTab) throws {
         // We can ignore the args, we just need it to match the CommandMap call signature

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -931,5 +931,6 @@ module SegmentedMsg {
     registerFunction("segmentedIn1d", segIn1dMsg);
     registerFunction("randomStrings", randomStringsMsg);
     registerFunction("segStr-assemble", assembleStringsMsg);
+    registerBinaryFunction("segStr-tondarray", segStrTondarrayMsg);
   }
 }

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -302,7 +302,6 @@ module ServerConfig
     proc appendToConfigStr(key:string, val:string) {
       var idx_close = cfgStr.rfind("}"):int;
       var tmp_json = cfgStr(0..idx_close-1);
-      writeln("tmp_json: ", tmp_json);
       cfgStr = tmp_json + "," + Q + key + QCQ + val + Q + "}";
     }
 }

--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -125,11 +125,10 @@ proc main() {
 
     /**
      * Register our server commands in the CommandMap
-     * There are 4 general types
+     * There are 3 general types
      * 1. Standard, required commands which adhere to the standard Message signature
      * 2. Specialized, required commands which do not adhere to the standard Message signature
-     * 3. "Backbone"/default modules we have deemed should be included in every build
-     * 4. "Optional" modules which are included at compilation time via ServerModules.cfg
+     * 3. "Optional" modules which are included at compilation time via ServerModules.cfg
      */
     proc registerServerCommands() {
         registerBinaryFunction("tondarray", tondarrayMsg);
@@ -146,8 +145,9 @@ proc main() {
         registerFunction("getCmdMap", getCommandMapMsg);
         registerFunction("clear", clearMsg);
 
-        // For a few specialized cmds we're going to add dummy functions,
-        // they will be intercepted in the cmd processing select statement
+        // For a few specialized cmds we're going to add dummy functions, so they
+        // get added to the client listing of available commands. They will be
+        // intercepted in the cmd processing select statement and processed specially
         registerFunction("array", akMsgSign);
         registerFunction("connect", akMsgSign);
         registerFunction("disconnect", akMsgSign);
@@ -155,13 +155,7 @@ proc main() {
         registerFunction("ruok", akMsgSign);
         registerFunction("shutdown", akMsgSign);
 
-        // Now Register our "default" collections included in every build
-        import RandMsg, IndexingMsg, OperatorMsg;
-        RandMsg.registerMe();
-        IndexingMsg.registerMe();
-        OperatorMsg.registerMe();
-
-        // Now add the dynamic versions implemented via ServerRegistration.chpl & ServerModules.cfg
+        // Add the dynamic Modules/cmds implemented via ServerRegistration.chpl & ServerModules.cfg
         doRegister();
     }
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -136,7 +136,7 @@ class ClientTest(ArkoudaTest):
         Tests the ak.client.get_server_commands() method contains an expected
         sample of commands.
         '''
-        expected_cmds = ["connect", "array", "create", "tondarray", "info", "str", "binopvv"]
+        expected_cmds = ["connect", "array", "create", "tondarray", "info", "str"]
         cmds = ak.client.get_server_commands()
         for cmd in expected_cmds:
             self.assertTrue(cmd in cmds)

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -130,3 +130,13 @@ class ClientTest(ArkoudaTest):
         self.assertEqual(100, ak.client.pdarrayIterThresh)
         self.assertEqual(1073741824, ak.client.maxTransferBytes)
         self.assertFalse(ak.client.verbose)
+
+    def test_client_get_server_commands(self):
+        '''
+        Tests the ak.client.get_server_commands() method contains an expected
+        sample of commands.
+        '''
+        expected_cmds = ["connect", "array", "create", "tondarray", "info", "str", "binopvv"]
+        cmds = ak.client.get_server_commands()
+        for cmd in expected_cmds:
+            self.assertTrue(cmd in cmds)


### PR DESCRIPTION
Issue #1049: Adds capability to print server commands from the client.
This also restructures the command processing loop in arkouda_server and
adds extra capability to the CommandMap module.

See notes in ticket but in general
- 2 client functions were added
  - `get_server_commands` returns dictionary/map which is really a dump of the server-side CommandMap
  - `print_server_commands` pretty-print version of the get_server_commands key-set
- 1 command added to server to return contents of commandMap -> `getCmdMap`

A couple of caveats
- I tried to centralize the cmd registration to a single proc in the `arkouda_server` module main / startup area.
- Some commands exist outside of the command map for a couple of different reasons (i.e. `connect`, `shutdown`, etc.) For the specialized ones I added the dummy/fake msg signature defined in CommandMap itself and changed the cmd processing section to process those special cmds first.  This seemed to be the easiest, cleanest way to get them listed in the server commands.
- I added a second command map for functions which do binary returns because they don't fit in the original function signature (they return bytes instead of MsgTuple) so they need to be handled slightly differently.

Overall I think this tightened up the cmd processing section nicely as well as centralized where commands get added.