### PR TITLE
Update modularization docs to more clearly specify absolute paths

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -41,7 +41,7 @@ setup you can set them explicitly via:
     useful for developers doing repeated Arkouda builds since they should have already verified the deps have been set up.
 
 #### Adding a Module from Outside the Arkouda src Directory
-  - ARKOUDA_SERVER_USER_MODULES : Path or string of paths to modules outside of the Arkouda source directory to be included in the Arkouda build. The module name must also be included in `ServerModules.cfg` for the function to be registered with the server.
+  - ARKOUDA_SERVER_USER_MODULES : Absolute path or string of absolute paths separated by a space to modules outside of the Arkouda source directory to be included in the Arkouda build. The module name must also be included in `ServerModules.cfg` for the function to be registered with the server.
 
 ## Testing
 Also see the python tests [README](tests/README.md) for more information on Python based unit & functional testing.

--- a/MODULAR.md
+++ b/MODULAR.md
@@ -12,7 +12,7 @@ New config files must follow the same format, listing one module name per line w
 
 ### Adding new modules into the build process
 
-Adding a module from outside of the Arkouda `src/` directory requires adding the module name in the `ServerModules.cfg` file, but also requires setting the `ARKOUDA_SERVER_USER_MODULES` environment variable to a string of the full path to the module. If multiple user modules are included, the paths must be separated by a space. For example, Arkouda could be built with a custom module `TestMsg.chpl` by adding `TestMsg` to a line in the `ServerModules.cfg` file and then by running the command `ARKOUDA_SERVER_USER_MODULES='/Users/path/to/TestMsg.chpl' make` in the Arkouda home directory.
+Adding a module from outside of the Arkouda `src/` directory requires adding the module name in the `ServerModules.cfg` file, but also requires setting the `ARKOUDA_SERVER_USER_MODULES` environment variable to a string of the absolute path to the Chapel module. If multiple user modules are included, the paths must be separated by a space. For example, Arkouda could be built with a custom module `TestMsg.chpl` by adding `TestMsg` to a line in the `ServerModules.cfg` file and then by running the command `ARKOUDA_SERVER_USER_MODULES='/Users/path/to/TestMsg.chpl' make` in the Arkouda home directory. Note that for this to work, the absolute path to the `.chpl` file must be specified in the `ARKOUDA_SERVER_USER_MODULES` environment variable.
 
 Additionally, a `registerMe()` function is required in the module in order to make the new functionality visible to the Arkouda server. This function must have the `CommandMap` module in scope and must call `registerFunction()` with the server message string and function name to be called.
 


### PR DESCRIPTION
Upon rereading the existing docs and seeing that they were not
clear to others, I realized that the mention of "absolute path"
was missing from the docs. This PR makes it much more clear
what should be added to the `ARKOUDA_SERVER_USER_MODULES` env
variable.

Resolves https://github.com/Bears-R-Us/arkouda/issues/1057