### PR TITLE
Reduce argsort memory overhead

### DIFF
--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -139,14 +139,13 @@ module RadixSortLSD
 
     /* Radix Sort Least Significant Digit
        radix sort a block distributed array
-       returning a permutation vector as a block distributed array */
-    proc radixSortLSD_ranks(a:[?aD] ?t, checkSorted: bool = true): [aD] int throws {
-
+       returning keys and permutation vector as a block distributed array */
+    proc radixSortLSD(a:[?aD] ?t, checkSorted: bool = true): [aD] (t, int) throws {
         // check to see if array is already sorted
         if (checkSorted) {
             if (isSorted(a)) {
-                var ranks: [aD] int = [i in aD] i;
-                return ranks;
+                var keyranks: [aD] (t,int) = [i in aD] (a[i], i);
+                return keyranks;
             }
         }
         
@@ -251,8 +250,23 @@ module RadixSortLSD
                 kr0 = kr1;
             }
         } // for rshift
+        return kr1;
+    }//proc radixSortLSD
 
-        var ranks: [aD] int = [(key, rank) in kr1] rank;
+
+    /* Radix Sort Least Significant Digit
+       radix sort a block distributed array
+       returning a permutation vector as a block distributed array */
+    proc radixSortLSD_ranks(a:[?aD] ?t, checkSorted: bool = true): [aD] int throws {
+        // check to see if array is already sorted
+        if (checkSorted) {
+            if (isSorted(a)) {
+                var ranks: [aD] int = [i in aD] i;
+                return ranks;
+            }
+        }
+
+        var ranks: [aD] int = [(key, rank) in radixSortLSD(a, checkSorted=false)] rank;
         return ranks;
         
     }//proc radixSortLSD_ranks

--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -140,7 +140,7 @@ module RadixSortLSD
     /* Radix Sort Least Significant Digit
        radix sort a block distributed array
        returning keys and permutation vector as a block distributed array */
-    proc radixSortLSD(a:[?aD] ?t, checkSorted: bool = true): [aD] (t, int) throws {
+    proc radixSortLSD(a:[?aD] ?t, checkSorted: bool = true): [aD] (t, int) {
         // check to see if array is already sorted
         if (checkSorted) {
             if (isSorted(a)) {
@@ -199,8 +199,6 @@ module RadixSortLSD
             }//coforall loc
             
             // scan globalCounts to get bucket ends on each locale/task
-            // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
-            overMemLimit(numBytes(int) * globalCounts.size);
             globalStarts = + scan globalCounts;
             globalStarts = globalStarts - globalCounts;
             
@@ -257,7 +255,7 @@ module RadixSortLSD
     /* Radix Sort Least Significant Digit
        radix sort a block distributed array
        returning a permutation vector as a block distributed array */
-    proc radixSortLSD_ranks(a:[?aD] ?t, checkSorted: bool = true): [aD] int throws {
+    proc radixSortLSD_ranks(a:[?aD] ?t, checkSorted: bool = true): [aD] int {
         // check to see if array is already sorted
         if (checkSorted) {
             if (isSorted(a)) {
@@ -275,7 +273,7 @@ module RadixSortLSD
     /* Radix Sort Least Significant Digit
        radix sort a block distributed array
        returning sorted keys as a block distributed array */
-    proc radixSortLSD_keys(a: [?aD] ?t, checkSorted: bool = true): [aD] t throws {
+    proc radixSortLSD_keys(a: [?aD] ?t, checkSorted: bool = true): [aD] t {
 
         // check to see if array is already sorted
         if (checkSorted) {
@@ -335,8 +333,6 @@ module RadixSortLSD
             }//coforall loc
             
             // scan globalCounts to get bucket ends on each locale/task
-            // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
-            overMemLimit(numBytes(int) * globalCounts.size);
             globalStarts = + scan globalCounts;
             globalStarts = globalStarts - globalCounts;
             
@@ -390,8 +386,16 @@ module RadixSortLSD
     }//proc radixSortLSD_keys
 
     proc radixSortLSD_memEst(size: int, itemsize: int) {
-        return ((4 + 1) * size * itemsize)
-                     + (2 * here.maxTaskPar * numLocales * 2**16 * 8);
+        // 2 temp key+ranks arrays + globalStarts/globalClounts
+        return (2 * size * (itemsize + numBytes(int))) +
+               (2 * numLocales * numTasks * numBuckets * numBytes(int));
+    }
+
+    proc radixSortLSD_keys_memEst(size: int, itemsize: int) {
+        // 2 temp key arrays + globalStarts/globalClounts
+        return (2 * size * itemsize) +
+               (2 * numLocales * numTasks * numBuckets * numBytes(int));
+
     }
 }
 

--- a/src/SortMsg.chpl
+++ b/src/SortMsg.chpl
@@ -51,8 +51,7 @@ module SortMsg
       var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(name, st);
 
       // check and throw if over memory limit
-      overMemLimit(((2 + 1) * gEnt.size * gEnt.itemsize)
-                   + (2 * here.maxTaskPar * numLocales * 2**16 * 8));
+      overMemLimit(radixSortLSD_keys_memEst(gEnt.size,  gEnt.itemsize));
  
       sortLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                 "cmd: %s name: %s sortedName: %s dtype: %t".format(

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -24,6 +24,7 @@ module UniqueMsg
     use SegmentedArray;
     use ServerErrorStrings;
 
+    use RadixSortLSD;
     use Unique;
     
     private config const logLevel = ServerConfig.logLevel;
@@ -69,8 +70,7 @@ module UniqueMsg
 
                 // the upper limit here is the same as argsort/radixSortLSD_keys
                 // check and throw if over memory limit
-                overMemLimit(((4 + 1) * gEnt.size * gEnt.itemsize)
-                         + (2 * here.maxTaskPar * numLocales * 2**16 * 8));
+                overMemLimit(radixSortLSD_memEst(gEnt.size, gEnt.itemsize));
         
                 select (gEnt.dtype) {
                     when (DType.Int64) {


### PR DESCRIPTION
Reduce the memory overhead of `argsort`/`radixSortLSD_ranks` from ~5x to
~4x. Previously, `radixSortLSD_ranks` had 3 large arrays in existence at
the same time -- 2 temp key+rank arrays and a return rank array. This
creates a `radixSortLSD` wrapper that returns the key+ranks, and updates
`radixSortLSD_ranks` to call that. This means we only have 1 temp array
when we create the ranks arrays, which reduces the peak memory to the 2
temp key+ranks arrays.

I created `radixSortLSD` instead of just adjusting `radixSortLSD_ranks`
to destroy one of the temp arrays early since we can use it to optimize
in1d, which needs the sorted keys and the ranks, but today does that
inefficiently with a rank sort and gathering values into a sorted array.
See #1062 for more information on this optimization.

Also update `radixSortLSD_memEst` to reflect the reduced memory usage
and use it in additional places that were duplicating the calculation.

Resolves https://github.com/Bears-R-Us/arkouda/issues/1058