### PR TITLE
Optimize sorting calls when both keys and ranks are needed

### DIFF
--- a/src/In1d.chpl
+++ b/src/In1d.chpl
@@ -74,10 +74,10 @@ module In1d
         /* ar[{u1.size..#u2.size}] = u2; */
         ar[D.interior(u2.size)] = u2;
         // Sort unique arrays together to find duplicates
-        var order = radixSortLSD_ranks(ar);
         var sar: [D] int;
-        forall (s, o) in zip(sar, order) with (var agg = newSrcAggregator(int)) {
-            agg.copy(s, ar[o]);
+        var order: [D] int;
+        forall (s, o, so) in zip(sar, order, radixSortLSD(ar)) {
+          (s, o) = so;
         }
         // Duplicates correspond to values in both arrays
         var flag: [D] bool;

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -7,7 +7,7 @@ module SegmentedArray {
   use UnorderedCopy;
   use SipHash;
   use SegStringSort;
-  use RadixSortLSD only radixSortLSD_ranks;
+  use RadixSortLSD;
   use PrivateDist;
   use ServerConfig;
   use Unique;
@@ -1271,10 +1271,10 @@ module SegmentedArray {
       combined[combinedDom.interior(-umain.size)] = umain;
       combined[combinedDom.interior(utest.size)] = utest;
       // Sort
-      var iv = radixSortLSD_ranks(combined);
       var sorted: [combinedDom] 2*uint(64);
-      forall (i, s) in zip(iv, sorted) with (var agg = newSrcAggregator(2*uint(64))) {
-        agg.copy(s, combined[i]);
+      var iv: [combinedDom] int;
+      forall (s, i, si) in zip(sorted, iv, radixSortLSD(combined)) {
+        (s, i) = si;
       }
       // Find duplicates
       // Dupe parallels unique hashes of mainStr and is true when value is in testStr


### PR DESCRIPTION
Previously, code that needed both the sorted keys and the ranks was
doing a rank sort and then gathering to sort the keys. Sorting the keys
is already done as part of the main radixSort code, so call the new
version that returns both the keys and values and then split that into 2
arrays. In some cases it would be pretty easy to just use the combined
array, but I wasn't sure if that was worthwhile.

This also removes some explicit `isSorted` checks since the sort code
will already do that check and removes an unused `assumeSorted` from
`uniqueGroup`

On 16-node-cs-hdr I see large int in1d go from 4.8 to 5.4 GiB/s and
setdiff go from 3.6 to 4.1 GiB/s. I expect some improvements for codes
using the other areas that were optimized.

Resolves #1062
Part of #970