### PR TITLE
Add a --saveUsedModules flag to save modules used in a server run

### DIFF
--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -488,7 +488,7 @@ module ArgSortMsg
 
     proc registerMe() {
       use CommandMap;
-      registerFunction("argsort", argsortMsg);
-      registerFunction("coargsort", coargsortMsg);
+      registerFunction("argsort", argsortMsg, getModuleName());
+      registerFunction("coargsort", coargsortMsg, getModuleName());
     }
 }

--- a/src/ArraySetopsMsg.chpl
+++ b/src/ArraySetopsMsg.chpl
@@ -240,9 +240,9 @@ module ArraySetopsMsg
     
     proc registerMe() {
       use CommandMap;
-      registerFunction("intersect1d", intersect1dMsg);
-      registerFunction("setdiff1d", setdiff1dMsg);
-      registerFunction("setxor1d", setxor1dMsg);
-      registerFunction("union1d", union1dMsg);
+      registerFunction("intersect1d", intersect1dMsg, getModuleName());
+      registerFunction("setdiff1d", setdiff1dMsg, getModuleName());
+      registerFunction("setxor1d", setxor1dMsg, getModuleName());
+      registerFunction("union1d", union1dMsg, getModuleName());
     }
 }

--- a/src/BroadcastMsg.chpl
+++ b/src/BroadcastMsg.chpl
@@ -113,6 +113,6 @@ module BroadcastMsg {
 
   proc registerMe() {
     use CommandMap;
-    registerFunction("broadcast", broadcastMsg);
+    registerFunction("broadcast", broadcastMsg, getModuleName());
   }
 }

--- a/src/CastMsg.chpl
+++ b/src/CastMsg.chpl
@@ -217,6 +217,6 @@ module CastMsg {
 
   proc registerMe() {
     use CommandMap;
-    registerFunction("cast", castMsg);
+    registerFunction("cast", castMsg, getModuleName());
   }
 }

--- a/src/CommandMap.chpl
+++ b/src/CommandMap.chpl
@@ -29,6 +29,9 @@ module CommandMap {
 
   var commandMap: map(string, f.type);
   var commandMapBinary: map(string, b.type);
+  var moduleMap: map(string, string);
+  use Set;
+  var usedModules: set(string);
 
   /**
    * Register command->function in the CommandMap
@@ -39,6 +42,19 @@ module CommandMap {
     commandMap.add(cmd, fcf);
   }
 
+  proc registerFunction(cmd: string, fcf: f.type, modName: string) {
+    commandMap.add(cmd, fcf);
+    moduleMap.add(cmd, modName);
+  }
+
+  proc writeUsedModules() {
+    use IO;
+    var newCfgFile = try! open("UsedModules.cfg", iomode.cw);
+    var chnl = try! newCfgFile.writer();
+    for mod in usedModules do
+      try! chnl.write(mod + '\n');
+  }
+
   /**
    * Register command->function in the CommandMap for Binary returning functions
    * This binds a server command to its corresponding function matching the standard
@@ -46,6 +62,11 @@ module CommandMap {
    */
   proc registerBinaryFunction(cmd: string, fcf: b.type) {
     commandMapBinary.add(cmd, fcf);
+  }
+
+  proc registerBinaryFunction(cmd: string, fcf: b.type, modName: string) {
+    commandMapBinary.add(cmd, fcf);
+    moduleMap.add(cmd, modName);
   }
 
   /**

--- a/src/ConcatenateMsg.chpl
+++ b/src/ConcatenateMsg.chpl
@@ -329,6 +329,6 @@ module ConcatenateMsg
 
     proc registerMe() {
       use CommandMap;
-      registerFunction("concatenate", concatenateMsg);
+      registerFunction("concatenate", concatenateMsg, getModuleName());
     }
 }

--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -694,10 +694,10 @@ module EfuncMsg
 
     proc registerMe() {
       use CommandMap;
-      registerFunction("efunc", efuncMsg);
-      registerFunction("efunc3vv", efunc3vvMsg);
-      registerFunction("efunc3vs", efunc3vsMsg);
-      registerFunction("efunc3sv", efunc3svMsg);
-      registerFunction("efunc3ss", efunc3ssMsg);
+      registerFunction("efunc", efuncMsg, getModuleName());
+      registerFunction("efunc3vv", efunc3vvMsg, getModuleName());
+      registerFunction("efunc3vs", efunc3vsMsg, getModuleName());
+      registerFunction("efunc3sv", efunc3svMsg, getModuleName());
+      registerFunction("efunc3ss", efunc3ssMsg, getModuleName());
     }
 }

--- a/src/FindSegmentsMsg.chpl
+++ b/src/FindSegmentsMsg.chpl
@@ -207,6 +207,6 @@ module FindSegmentsMsg
 
     proc registerMe() {
       use CommandMap;
-      registerFunction("findSegments", findSegmentsMsg);
+      registerFunction("findSegments", findSegmentsMsg, getModuleName());
     }
 }

--- a/src/FlattenMsg.chpl
+++ b/src/FlattenMsg.chpl
@@ -96,7 +96,7 @@ module FlattenMsg {
   
   proc registerMe() {
     use CommandMap;
-    registerFunction("segmentedFlatten", segFlattenMsg);
-    registerFunction("segmentedSplit", segmentedSplitMsg);
+    registerFunction("segmentedFlatten", segFlattenMsg, getModuleName());
+    registerFunction("segmentedSplit", segmentedSplitMsg, getModuleName());
   }
 }

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -2185,9 +2185,9 @@ module HDF5Msg {
 
     proc registerMe() {
         use CommandMap;
-        registerFunction("lshdf", lshdfMsg);
-        registerFunction("readAllHdf", readAllHdfMsg);
-        registerFunction("tohdf", tohdfMsg);
+        registerFunction("lshdf", lshdfMsg, getModuleName());
+        registerFunction("readAllHdf", readAllHdfMsg, getModuleName());
+        registerFunction("tohdf", tohdfMsg, getModuleName());
     }
 
 }

--- a/src/HistogramMsg.chpl
+++ b/src/HistogramMsg.chpl
@@ -80,6 +80,6 @@ module HistogramMsg
 
     proc registerMe() {
       use CommandMap;
-      registerFunction("histogram", histogramMsg);
+      registerFunction("histogram", histogramMsg, getModuleName());
     }
 }

--- a/src/In1dMsg.chpl
+++ b/src/In1dMsg.chpl
@@ -94,6 +94,6 @@ module In1dMsg
 
     proc registerMe() {
       use CommandMap;
-      registerFunction("in1d", in1dMsg);
+      registerFunction("in1d", in1dMsg, getModuleName());
     }
 }

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -723,13 +723,13 @@ module IndexingMsg
     
     proc registerMe() {
       use CommandMap;
-      registerFunction("[int]", intIndexMsg);
-      registerFunction("[slice]", sliceIndexMsg);
-      registerFunction("[pdarray]", pdarrayIndexMsg);
-      registerFunction("[int]=val", setIntIndexToValueMsg);
-      registerFunction("[pdarray]=val", setPdarrayIndexToValueMsg);
-      registerFunction("[pdarray]=pdarray", setPdarrayIndexToPdarrayMsg);
-      registerFunction("[slice]=val", setSliceIndexToValueMsg);
-      registerFunction("[slice]=pdarray", setSliceIndexToPdarrayMsg);
+      registerFunction("[int]", intIndexMsg, getModuleName());
+      registerFunction("[slice]", sliceIndexMsg, getModuleName());
+      registerFunction("[pdarray]", pdarrayIndexMsg, getModuleName());
+      registerFunction("[int]=val", setIntIndexToValueMsg, getModuleName());
+      registerFunction("[pdarray]=val", setPdarrayIndexToValueMsg, getModuleName());
+      registerFunction("[pdarray]=pdarray", setPdarrayIndexToPdarrayMsg, getModuleName());
+      registerFunction("[slice]=val", setSliceIndexToValueMsg, getModuleName());
+      registerFunction("[slice]=pdarray", setSliceIndexToPdarrayMsg, getModuleName());
     }
 }

--- a/src/JoinEqWithDTMsg.chpl
+++ b/src/JoinEqWithDTMsg.chpl
@@ -372,6 +372,6 @@ module JoinEqWithDTMsg
 
     proc registerMe() {
       use CommandMap;
-      registerFunction("joinEqWithDT", joinEqWithDTMsg);
+      registerFunction("joinEqWithDT", joinEqWithDTMsg, getModuleName());
     }
 }// end module JoinEqWithDTMsg

--- a/src/KExtremeMsg.chpl
+++ b/src/KExtremeMsg.chpl
@@ -154,7 +154,7 @@ module KExtremeMsg
 
     proc registerMe() {
       use CommandMap;
-      registerFunction("mink", minkMsg);
-      registerFunction("maxk", maxkMsg);
+      registerFunction("mink", minkMsg, getModuleName());
+      registerFunction("maxk", maxkMsg, getModuleName());
     }
 }

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -1358,10 +1358,10 @@ module OperatorMsg
 
     proc registerMe() {
       use CommandMap;
-      registerFunction("binopvv", binopvvMsg);
-      registerFunction("binopvs", binopvsMsg);
-      registerFunction("binopsv", binopsvMsg);
-      registerFunction("opeqvv", opeqvvMsg);
-      registerFunction("opeqvs", opeqvsMsg);
+      registerFunction("binopvv", binopvvMsg, getModuleName());
+      registerFunction("binopvs", binopvsMsg, getModuleName());
+      registerFunction("binopsv", binopsvMsg, getModuleName());
+      registerFunction("opeqvv", opeqvvMsg, getModuleName());
+      registerFunction("opeqvs", opeqvsMsg, getModuleName());
     }
 }

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -392,8 +392,8 @@ module ParquetMsg {
 
   proc registerMe() {
     use CommandMap;
-    registerFunction("readAllParquet", readAllParquetMsg);
-    registerFunction("writeParquet", toparquetMsg);
+    registerFunction("readAllParquet", readAllParquetMsg, getModuleName());
+    registerFunction("writeParquet", toparquetMsg, getModuleName());
     ServerConfig.appendToConfigStr("ARROW_VERSION", getVersionInfo());
   }
 

--- a/src/RandMsg.chpl
+++ b/src/RandMsg.chpl
@@ -123,7 +123,7 @@ module RandMsg
     
     proc registerMe() {
       use CommandMap;
-      registerFunction("randint", randintMsg);
-      registerFunction("randomNormal", randomNormalMsg);
+      registerFunction("randint", randintMsg, getModuleName());
+      registerFunction("randomNormal", randomNormalMsg, getModuleName());
     }
 }

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -1027,9 +1027,9 @@ module ReductionMsg
 
     proc registerMe() {
       use CommandMap;
-      registerFunction("segmentedReduction", segmentedReductionMsg);
-      registerFunction("reduction", reductionMsg);
-      registerFunction("countReduction", countReductionMsg);
+      registerFunction("segmentedReduction", segmentedReductionMsg, getModuleName());
+      registerFunction("reduction", reductionMsg, getModuleName());
+      registerFunction("countReduction", countReductionMsg, getModuleName());
     }
 
 }

--- a/src/RegistrationMsg.chpl
+++ b/src/RegistrationMsg.chpl
@@ -138,8 +138,8 @@ module RegistrationMsg
 
     proc registerMe() {
       use CommandMap;
-      registerFunction("register", registerMsg);
-      registerFunction("attach", attachMsg);
-      registerFunction("unregister", unregisterMsg);
+      registerFunction("register", registerMsg, getModuleName());
+      registerFunction("attach", attachMsg, getModuleName());
+      registerFunction("unregister", unregisterMsg, getModuleName());
     }
 }

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -917,20 +917,20 @@ module SegmentedMsg {
   
   proc registerMe() {
     use CommandMap;
-    registerFunction("segmentLengths", segmentLengthsMsg);
-    registerFunction("segmentedHash", segmentedHashMsg);
-    registerFunction("segmentedSearch", segmentedSearchMsg);
-    registerFunction("segmentedFindLoc", segmentedFindLocMsg);
-    registerFunction("segmentedFindAll", segmentedFindAllMsg);
-    registerFunction("segmentedPeel", segmentedPeelMsg);
-    registerFunction("segmentedSub", segmentedSubMsg);
-    registerFunction("segmentedIndex", segmentedIndexMsg);
-    registerFunction("segmentedBinopvv", segBinopvvMsg);
-    registerFunction("segmentedBinopvs", segBinopvsMsg);
-    registerFunction("segmentedGroup", segGroupMsg);
-    registerFunction("segmentedIn1d", segIn1dMsg);
-    registerFunction("randomStrings", randomStringsMsg);
-    registerFunction("segStr-assemble", assembleStringsMsg);
-    registerBinaryFunction("segStr-tondarray", segStrTondarrayMsg);
+    registerFunction("segmentLengths", segmentLengthsMsg, getModuleName());
+    registerFunction("segmentedHash", segmentedHashMsg, getModuleName());
+    registerFunction("segmentedSearch", segmentedSearchMsg, getModuleName());
+    registerFunction("segmentedFindLoc", segmentedFindLocMsg, getModuleName());
+    registerFunction("segmentedFindAll", segmentedFindAllMsg, getModuleName());
+    registerFunction("segmentedPeel", segmentedPeelMsg, getModuleName());
+    registerFunction("segmentedSub", segmentedSubMsg, getModuleName());
+    registerFunction("segmentedIndex", segmentedIndexMsg, getModuleName());
+    registerFunction("segmentedBinopvv", segBinopvvMsg, getModuleName());
+    registerFunction("segmentedBinopvs", segBinopvsMsg, getModuleName());
+    registerFunction("segmentedGroup", segGroupMsg, getModuleName());
+    registerFunction("segmentedIn1d", segIn1dMsg, getModuleName());
+    registerFunction("randomStrings", randomStringsMsg, getModuleName());
+    registerFunction("segStr-assemble", assembleStringsMsg, getModuleName());
+    registerBinaryFunction("segStr-tondarray", segStrTondarrayMsg, getModuleName());
   }
 }

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -62,6 +62,8 @@ module ServerConfig
     */
     config param regexMaxCaptures = 20;
 
+    config const saveUsedModules : bool = false;
+
     private config const lLevel = ServerConfig.logLevel;
     const scLogger = new Logger(lLevel);
    

--- a/src/SortMsg.chpl
+++ b/src/SortMsg.chpl
@@ -106,6 +106,6 @@ module SortMsg
 
     proc registerMe() {
       use CommandMap;
-      registerFunction("sort", sortMsg);
+      registerFunction("sort", sortMsg, getModuleName());
     }
 }// end module SortMsg

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -228,7 +228,7 @@ module UniqueMsg
 
     proc registerMe() {
       use CommandMap;
-      registerFunction("unique", uniqueMsg);
-      registerFunction("value_counts", value_countsMsg);
+      registerFunction("unique", uniqueMsg, getModuleName());
+      registerFunction("value_counts", value_countsMsg, getModuleName());
     }
 }

--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -242,6 +242,8 @@ proc main() {
     which stops the arkouda_server listener thread and closes socket.
     */
     proc shutdown(user: string) {
+        if saveUsedModules then
+          writeUsedModules();
         shutdownServer = true;
         repCount += 1;
         socket.send(serialize(msg="shutdown server (%i req)".format(repCount), 
@@ -358,8 +360,12 @@ proc main() {
                 }
                 otherwise { // Look up in CommandMap or Binary CommandMap
                     if commandMap.contains(cmd) {
+                        if moduleMap.contains(cmd) then
+                          usedModules.add(moduleMap[cmd]);
                         repTuple = commandMap.getBorrowed(cmd)(cmd, args, st);
                     } else if commandMapBinary.contains(cmd) { // Binary response commands require different handling
+                        if moduleMap.contains(cmd) then
+                          usedModules.add(moduleMap[cmd]);
                         var binaryRepMsg = commandMapBinary.getBorrowed(cmd)(cmd, args, st);
                         sendRepMsg(binaryRepMsg);
                     } else {


### PR DESCRIPTION
This PR adds a --saveUsedModules flag that prints the name of all
modules that had a mesasge function called in a UsedModules.cfg file
that can be reused to speed up the next build. The function is called
upon `ak.shutdown()`.

To use this flag on a benchmark, it can be run:
`./benchmarks/run-benchmarks.py IO --server-args='--saveUsedModules`.
To use this flag on an interactive run of the Arkouda server, run:
`./arkouda_server --saveUsedModules`.

Resolves #1064 