### PR TITLE
Add BitOps use to BinOp.chpl file

### DIFF
--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -7,6 +7,7 @@ module BinOp
   use MultiTypeSymEntry;
   use Logging;
   use Message;
+  use BitOps;
 
   private config const logLevel = ServerConfig.logLevel;
   const omLogger = new Logger(logLevel);


### PR DESCRIPTION
BinOp.chpl was previously only getting access to BitOps
through OperatorMsg, which meant that any module that
included BinOp would need to also include BiOps, so I
have added an include for BitOps, which allows modularity.