### PR TITLE
Add a ChplConfig compatibility module for < 1.26

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,6 +261,10 @@ ifeq ($(shell expr $(CHPL_MINOR) \>= 25),1)
 else
 	ARKOUDA_COMPAT_MODULES += -M $(ARKOUDA_SOURCE_DIR)/compat/lt-125
 endif
+ifeq ($(shell expr $(CHPL_MINOR) \>= 26),1)
+else
+	ARKOUDA_COMPAT_MODULES += -M $(ARKOUDA_SOURCE_DIR)/compat/lt-126
+endif
 
 MODULE_GENERATION_SCRIPT=$(ARKOUDA_SOURCE_DIR)/serverModuleGen.py
 # This is the main compilation statement section

--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -4,6 +4,7 @@ module CommAggregation {
   use ServerConfig;
   use UnorderedCopy;
   use CommPrimitives;
+  use ChplConfig;
 
   // TODO should tune these values at startup
   param defaultBuffSize = if CHPL_COMM == "ugni" then 4096 else 8096;

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -197,6 +197,8 @@ module SegmentedArray {
     /* Gather strings by index. Returns arrays for the segment offsets
        and bytes of the gathered strings.*/
     proc this(iv: [?D] int) throws {
+      use ChplConfig;
+      
       // Early return for zero-length result
       if (D.size == 0) {
         return (makeDistArray(0, int), makeDistArray(0, uint(8)));

--- a/src/SymArrayDmap.chpl
+++ b/src/SymArrayDmap.chpl
@@ -1,6 +1,8 @@
 
 module SymArrayDmap
 {
+    use ChplConfig;
+
     /*
      Available domain maps. Cyclic isn't regularly tested and may not work.
      */

--- a/src/compat/lt-126/ChplConfig.chpl
+++ b/src/compat/lt-126/ChplConfig.chpl
@@ -1,0 +1,4 @@
+// This exists merely to provide compatibility with the new module
+// name in 1.26.0.  The module provides the old ChapelEnv settings
+// which had previously been auto-used, so there's no need for it to
+// do anything special here.


### PR DESCRIPTION
In Chapel 1.26, we're replacing auto-available module `ChapelEnv` with
must-be-used/imported `ChplConfig` and references to `CHPL_*` start
generating warnings as a result on the main Chapel development branch.
This PR updates the sources to use `ChplConfig` to avoid these warnings
while providing a(n empty) compatibility module for past releases of Chapel.

Resolves #1076.
