### PR TITLE
Closes #1074: Update `operator_test` to account for `uint64`

### DIFF
--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -261,6 +261,8 @@ module BinOp
       var repMsg = "created %s".format(st.attrib(rname));
       return new MsgTuple(repMsg, MsgType.NORMAL);
     }
-    return new MsgTuple("Bin op not supported", MsgType.NORMAL);
+    var errorMsg = notImplementedError(pn,l.dtype,op,r.dtype);
+    omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+    return new MsgTuple(errorMsg, MsgType.ERROR);
   }
 }

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -148,7 +148,9 @@ module OperatorMsg
             return doBinOpvv(l, r, e, op, rname, pn, st);
           }
         }
-        return new MsgTuple("Bin op not supported", MsgType.NORMAL);
+        var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
+        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+        return new MsgTuple(errorMsg, MsgType.ERROR);
     }
     
     /*

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -148,7 +148,7 @@ module OperatorMsg
             return doBinOpvv(l, r, e, op, rname, pn, st);
           }
         }
-        var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
+        var errorMsg = unrecognizedTypeError(pn, "("+dtype2str(left.dtype)+","+dtype2str(right.dtype)+")");
         omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
         return new MsgTuple(errorMsg, MsgType.ERROR);
     }

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -71,7 +71,7 @@ def run_tests(verbose):
                 try:
                     akres = do_op(ltype, rtype, lscalar, rscalar, True, op)
                 except RuntimeError as e:
-                    if 'not implemented' in str(e): # neither numpy nor arkouda implement
+                    if 'not implemented' or 'unrecognized type' in str(e):  # neither numpy nor arkouda implement
                         results['neither_implement'].append((expression, str(e)))
                     else: # arkouda implements with error, np does not implement
                         results['arkouda_minus_numpy'].append((expression, str(e), True))
@@ -82,7 +82,7 @@ def run_tests(verbose):
             try:
                 akres = do_op(ltype, rtype, lscalar, rscalar, True, op)
             except RuntimeError as e:
-                if 'not implemented' in str(e): # numpy implements but not arkouda
+                if 'not implemented' or 'unrecognized type' in str(e):  # numpy implements but not arkouda
                     results['numpy_minus_arkouda'].append((expression, str(e), True))
                 else: # both implement, but arkouda errors
                     results['both_implement'].append((expression, str(e), True, False, False))

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -11,15 +11,18 @@ def run_tests(verbose):
     np.seterr(all='ignore')
     global pdarrays
     pdarrays = {'int64': ak.arange(0, SIZE, 1),
+                'uint64': ak.array(np.arange(0, SIZE, 1, dtype=np.uint64)),
                 'float64': ak.linspace(0, 2, SIZE),
                 'bool': (ak.arange(0, SIZE, 1) % 2) == 0}
     global ndarrays
     ndarrays = {'int64': np.arange(0, SIZE, 1),
+                'uint64': np.arange(0, SIZE, 1, dtype=np.uint64),
                 'float64': np.linspace(0, 2, SIZE),
                 'bool': (np.arange(0, SIZE, 1) % 2) == 0}
     global scalars
     #scalars = {k: v[SIZE//2] for k, v in ndarrays.items()}
     scalars = {'int64': 5,
+               'uint64': np.uint64(5),
                'float64': 3.14159,
                'bool': True}
     dtypes = pdarrays.keys()

--- a/tests/regex_test.py
+++ b/tests/regex_test.py
@@ -214,6 +214,11 @@ class RegexTest(ArkoudaTest):
         digit = ak.array(['a1b', 'c1d', 'e1f2g'])
         under = ak.array(['a_b', 'c___d', 'e__f____g'])
 
+        # register to keep python from garbage collecting causing unknownsymbol in CI
+        orig.register('orig')
+        digit.register('digit')
+        under.register('under')
+
         o_left, o_right = orig.peel('.')
         d_left, d_right = digit.peel('\\d', regex=True)
         u_left, u_right = under.peel('_+', regex=True)
@@ -254,6 +259,11 @@ class RegexTest(ArkoudaTest):
         self.assertListEqual(['', '', '.f.g'], o_right.to_ndarray().tolist())
         self.assertListEqual(['', '', '1f2g'], d_right.to_ndarray().tolist())
         self.assertListEqual(['', '', '__f____g'], u_right.to_ndarray().tolist())
+
+        # cleanup registry
+        orig.unregister()
+        digit.unregister()
+        under.unregister()
 
     def test_regex_flatten(self):
         orig = ak.array(['one|two', 'three|four|five', 'six', 'seven|eight|nine|ten|', 'eleven'])


### PR DESCRIPTION
Closes #1074: Update `operator_test` to account for `uint64`

The output of `testAllOperators` detailing which operations are supported by numpy and us for `uint64` (and others) can be seen below. It's collapsed cause it's kinda a lot

EDIT: Output has been updated with `unrecognized type` check

<details>
  <summary>Output of testAllOperators</summary>

```
Operators:  frozenset({'&', '>>>', '>', '+', '<=', '**', '/', '<<', '%', '*', '//', '>>', '!=', '==', '>=', '|', '<<<', '^', '-', '<'})
Dtypes:  dict_keys(['int64', 'uint64', 'float64', 'bool'])
pdarrays: 
int64 :  [0 1 2 3 4 5 6 7 8 9]
uint64 :  [0 1 2 3 4 5 6 7 8 9]
float64 :  [0.000000e+00 2.222222e-01 4.444444e-01 6.666667e-01 8.888889e-01 1.111111e+00 1.333333e+00 1.555556e+00 1.777778e+00 2.000000e+00]
bool :  [True False True False True False True False True False]
ndarrays: 
int64 :  [0 1 2 3 4 5 6 7 8 9]
uint64 :  [0 1 2 3 4 5 6 7 8 9]
float64 :  [0.         0.22222222 0.44444444 0.66666667 0.88888889 1.11111111
 1.33333333 1.55555556 1.77777778 2.        ]
bool :  [ True False  True False  True False  True False  True False]
scalars: 
int64 :  5
uint64 :  5
float64 :  3.14159
bool :  True
# ops not implemented by numpy or arkouda: 103
int64(array) & uint64(array)
int64(array) << uint64(array)
int64(array) >> uint64(array)
int64(array) | uint64(array)
int64(array) ^ uint64(array)
int64(array) & float64(scalar)
int64(scalar) & float64(array)
int64(array) << float64(scalar)
int64(scalar) << float64(array)
int64(array) >> float64(scalar)
int64(scalar) >> float64(array)
int64(array) | float64(scalar)
int64(scalar) | float64(array)
int64(array) ^ float64(scalar)
int64(scalar) ^ float64(array)
uint64(array) & int64(array)
uint64(array) << int64(array)
uint64(array) >> int64(array)
uint64(array) | int64(array)
uint64(array) ^ int64(array)
uint64(array) & float64(array)
uint64(array) & float64(scalar)
uint64(scalar) & float64(array)
uint64(array) << float64(array)
uint64(array) << float64(scalar)
uint64(scalar) << float64(array)
uint64(array) >> float64(array)
uint64(array) >> float64(scalar)
uint64(scalar) >> float64(array)
uint64(array) | float64(array)
uint64(array) | float64(scalar)
uint64(scalar) | float64(array)
uint64(array) ^ float64(array)
uint64(array) ^ float64(scalar)
uint64(scalar) ^ float64(array)
float64(array) & int64(scalar)
float64(scalar) & int64(array)
float64(array) << int64(scalar)
float64(scalar) << int64(array)
float64(array) >> int64(scalar)
float64(scalar) >> int64(array)
float64(array) | int64(scalar)
float64(scalar) | int64(array)
float64(array) ^ int64(scalar)
float64(scalar) ^ int64(array)
float64(array) & uint64(array)
float64(array) & uint64(scalar)
float64(scalar) & uint64(array)
float64(array) << uint64(array)
float64(array) << uint64(scalar)
float64(scalar) << uint64(array)
float64(array) >> uint64(array)
float64(array) >> uint64(scalar)
float64(scalar) >> uint64(array)
float64(array) | uint64(array)
float64(array) | uint64(scalar)
float64(scalar) | uint64(array)
float64(array) ^ uint64(array)
float64(array) ^ uint64(scalar)
float64(scalar) ^ uint64(array)
float64(array) & float64(scalar)
float64(scalar) & float64(array)
float64(array) << float64(scalar)
float64(scalar) << float64(array)
float64(array) >> float64(scalar)
float64(scalar) >> float64(array)
float64(array) | float64(scalar)
float64(scalar) | float64(array)
float64(array) ^ float64(scalar)
float64(scalar) ^ float64(array)
float64(array) & bool(array)
float64(array) & bool(scalar)
float64(scalar) & bool(array)
float64(array) << bool(array)
float64(array) << bool(scalar)
float64(scalar) << bool(array)
float64(array) >> bool(array)
float64(array) >> bool(scalar)
float64(scalar) >> bool(array)
float64(array) | bool(array)
float64(array) | bool(scalar)
float64(scalar) | bool(array)
float64(array) ^ bool(array)
float64(array) ^ bool(scalar)
float64(scalar) ^ bool(array)
bool(array) & float64(array)
bool(array) & float64(scalar)
bool(scalar) & float64(array)
bool(array) << float64(array)
bool(array) << float64(scalar)
bool(scalar) << float64(array)
bool(array) >> float64(array)
bool(array) >> float64(scalar)
bool(scalar) >> float64(array)
bool(array) | float64(array)
bool(array) | float64(scalar)
bool(scalar) | float64(array)
bool(array) ^ float64(array)
bool(array) ^ float64(scalar)
bool(scalar) ^ float64(array)
bool(array) - bool(array)
bool(array) - bool(scalar)
bool(scalar) - bool(array)
# ops implemented by numpy but not arkouda: 516
int64(array) & uint64(scalar)
int64(scalar) & uint64(array)
int64(array) > uint64(array)
int64(array) > uint64(scalar)
int64(scalar) > uint64(array)
int64(array) + uint64(array)
int64(array) + uint64(scalar)
int64(scalar) + uint64(array)
int64(array) <= uint64(array)
int64(array) <= uint64(scalar)
int64(scalar) <= uint64(array)
int64(array) ** uint64(array)
int64(array) ** uint64(scalar)
int64(scalar) ** uint64(array)
int64(array) / uint64(array)
int64(array) / uint64(scalar)
int64(scalar) / uint64(array)
int64(array) << uint64(scalar)
int64(scalar) << uint64(array)
int64(array) % uint64(array)
int64(array) % uint64(scalar)
int64(scalar) % uint64(array)
int64(array) * uint64(array)
int64(array) * uint64(scalar)
int64(scalar) * uint64(array)
int64(array) // uint64(array)
int64(array) // uint64(scalar)
int64(scalar) // uint64(array)
int64(array) >> uint64(scalar)
int64(scalar) >> uint64(array)
int64(array) != uint64(array)
int64(array) != uint64(scalar)
int64(scalar) != uint64(array)
int64(array) == uint64(array)
int64(array) == uint64(scalar)
int64(scalar) == uint64(array)
int64(array) >= uint64(array)
int64(array) >= uint64(scalar)
int64(scalar) >= uint64(array)
int64(array) | uint64(scalar)
int64(scalar) | uint64(array)
int64(array) ^ uint64(scalar)
int64(scalar) ^ uint64(array)
int64(array) - uint64(array)
int64(array) - uint64(scalar)
int64(scalar) - uint64(array)
int64(array) < uint64(array)
int64(array) < uint64(scalar)
int64(scalar) < uint64(array)
int64(array) % float64(scalar)
int64(scalar) % float64(array)
int64(array) & bool(array)
int64(array) & bool(scalar)
int64(scalar) & bool(array)
int64(array) > bool(array)
int64(array) > bool(scalar)
int64(scalar) > bool(array)
int64(array) <= bool(array)
int64(array) <= bool(scalar)
int64(scalar) <= bool(array)
int64(array) ** bool(array)
int64(array) ** bool(scalar)
int64(scalar) ** bool(array)
int64(array) / bool(array)
int64(array) / bool(scalar)
int64(scalar) / bool(array)
int64(array) << bool(array)
int64(array) << bool(scalar)
int64(scalar) << bool(array)
int64(array) % bool(array)
int64(array) % bool(scalar)
int64(scalar) % bool(array)
int64(array) // bool(array)
int64(array) // bool(scalar)
int64(scalar) // bool(array)
int64(array) >> bool(array)
int64(array) >> bool(scalar)
int64(scalar) >> bool(array)
int64(array) != bool(array)
int64(array) != bool(scalar)
int64(scalar) != bool(array)
int64(array) == bool(array)
int64(array) == bool(scalar)
int64(scalar) == bool(array)
int64(array) >= bool(array)
int64(array) >= bool(scalar)
int64(scalar) >= bool(array)
int64(array) | bool(array)
int64(array) | bool(scalar)
int64(scalar) | bool(array)
int64(array) ^ bool(array)
int64(array) ^ bool(scalar)
int64(scalar) ^ bool(array)
int64(array) < bool(array)
int64(array) < bool(scalar)
int64(scalar) < bool(array)
uint64(array) & int64(scalar)
uint64(scalar) & int64(array)
uint64(array) > int64(array)
uint64(array) > int64(scalar)
uint64(scalar) > int64(array)
uint64(array) + int64(array)
uint64(array) + int64(scalar)
uint64(scalar) + int64(array)
uint64(array) <= int64(array)
uint64(array) <= int64(scalar)
uint64(scalar) <= int64(array)
uint64(array) ** int64(array)
uint64(array) ** int64(scalar)
uint64(scalar) ** int64(array)
uint64(array) / int64(array)
uint64(array) / int64(scalar)
uint64(scalar) / int64(array)
uint64(array) << int64(scalar)
uint64(scalar) << int64(array)
uint64(array) % int64(array)
uint64(array) % int64(scalar)
uint64(scalar) % int64(array)
uint64(array) * int64(array)
uint64(array) * int64(scalar)
uint64(scalar) * int64(array)
uint64(array) // int64(array)
uint64(array) // int64(scalar)
uint64(scalar) // int64(array)
uint64(array) >> int64(scalar)
uint64(scalar) >> int64(array)
uint64(array) != int64(array)
uint64(array) != int64(scalar)
uint64(scalar) != int64(array)
uint64(array) == int64(array)
uint64(array) == int64(scalar)
uint64(scalar) == int64(array)
uint64(array) >= int64(array)
uint64(array) >= int64(scalar)
uint64(scalar) >= int64(array)
uint64(array) | int64(scalar)
uint64(scalar) | int64(array)
uint64(array) ^ int64(scalar)
uint64(scalar) ^ int64(array)
uint64(array) - int64(array)
uint64(array) - int64(scalar)
uint64(scalar) - int64(array)
uint64(array) < int64(array)
uint64(array) < int64(scalar)
uint64(scalar) < int64(array)
uint64(array) & uint64(scalar)
uint64(scalar) & uint64(array)
uint64(array) > uint64(scalar)
uint64(scalar) > uint64(array)
uint64(array) + uint64(scalar)
uint64(scalar) + uint64(array)
uint64(array) <= uint64(scalar)
uint64(scalar) <= uint64(array)
uint64(array) ** uint64(scalar)
uint64(scalar) ** uint64(array)
uint64(array) / uint64(scalar)
uint64(scalar) / uint64(array)
uint64(array) << uint64(scalar)
uint64(scalar) << uint64(array)
uint64(array) % uint64(scalar)
uint64(scalar) % uint64(array)
uint64(array) * uint64(scalar)
uint64(scalar) * uint64(array)
uint64(array) // uint64(scalar)
uint64(scalar) // uint64(array)
uint64(array) >> uint64(scalar)
uint64(scalar) >> uint64(array)
uint64(array) != uint64(scalar)
uint64(scalar) != uint64(array)
uint64(array) == uint64(scalar)
uint64(scalar) == uint64(array)
uint64(array) >= uint64(scalar)
uint64(scalar) >= uint64(array)
uint64(array) | uint64(scalar)
uint64(scalar) | uint64(array)
uint64(array) ^ uint64(scalar)
uint64(scalar) ^ uint64(array)
uint64(array) - uint64(scalar)
uint64(scalar) - uint64(array)
uint64(array) < uint64(scalar)
uint64(scalar) < uint64(array)
uint64(array) > float64(array)
uint64(array) > float64(scalar)
uint64(scalar) > float64(array)
uint64(array) + float64(array)
uint64(array) + float64(scalar)
uint64(scalar) + float64(array)
uint64(array) <= float64(array)
uint64(array) <= float64(scalar)
uint64(scalar) <= float64(array)
uint64(array) ** float64(array)
uint64(array) ** float64(scalar)
uint64(scalar) ** float64(array)
uint64(array) / float64(array)
uint64(array) / float64(scalar)
uint64(scalar) / float64(array)
uint64(array) % float64(array)
uint64(array) % float64(scalar)
uint64(scalar) % float64(array)
uint64(array) * float64(array)
uint64(array) * float64(scalar)
uint64(scalar) * float64(array)
uint64(array) // float64(array)
uint64(array) // float64(scalar)
uint64(scalar) // float64(array)
uint64(array) != float64(array)
uint64(array) != float64(scalar)
uint64(scalar) != float64(array)
uint64(array) == float64(array)
uint64(array) == float64(scalar)
uint64(scalar) == float64(array)
uint64(array) >= float64(array)
uint64(array) >= float64(scalar)
uint64(scalar) >= float64(array)
uint64(array) - float64(array)
uint64(array) - float64(scalar)
uint64(scalar) - float64(array)
uint64(array) < float64(array)
uint64(array) < float64(scalar)
uint64(scalar) < float64(array)
uint64(array) & bool(array)
uint64(array) & bool(scalar)
uint64(scalar) & bool(array)
uint64(array) > bool(array)
uint64(array) > bool(scalar)
uint64(scalar) > bool(array)
uint64(array) + bool(array)
uint64(array) + bool(scalar)
uint64(scalar) + bool(array)
uint64(array) <= bool(array)
uint64(array) <= bool(scalar)
uint64(scalar) <= bool(array)
uint64(array) ** bool(array)
uint64(array) ** bool(scalar)
uint64(scalar) ** bool(array)
uint64(array) / bool(array)
uint64(array) / bool(scalar)
uint64(scalar) / bool(array)
uint64(array) << bool(array)
uint64(array) << bool(scalar)
uint64(scalar) << bool(array)
uint64(array) % bool(array)
uint64(array) % bool(scalar)
uint64(scalar) % bool(array)
uint64(array) * bool(array)
uint64(array) * bool(scalar)
uint64(scalar) * bool(array)
uint64(array) // bool(array)
uint64(array) // bool(scalar)
uint64(scalar) // bool(array)
uint64(array) >> bool(array)
uint64(array) >> bool(scalar)
uint64(scalar) >> bool(array)
uint64(array) != bool(array)
uint64(array) != bool(scalar)
uint64(scalar) != bool(array)
uint64(array) == bool(array)
uint64(array) == bool(scalar)
uint64(scalar) == bool(array)
uint64(array) >= bool(array)
uint64(array) >= bool(scalar)
uint64(scalar) >= bool(array)
uint64(array) | bool(array)
uint64(array) | bool(scalar)
uint64(scalar) | bool(array)
uint64(array) ^ bool(array)
uint64(array) ^ bool(scalar)
uint64(scalar) ^ bool(array)
uint64(array) - bool(array)
uint64(array) - bool(scalar)
uint64(scalar) - bool(array)
uint64(array) < bool(array)
uint64(array) < bool(scalar)
uint64(scalar) < bool(array)
float64(array) % int64(scalar)
float64(scalar) % int64(array)
float64(array) > uint64(array)
float64(array) > uint64(scalar)
float64(scalar) > uint64(array)
float64(array) + uint64(array)
float64(array) + uint64(scalar)
float64(scalar) + uint64(array)
float64(array) <= uint64(array)
float64(array) <= uint64(scalar)
float64(scalar) <= uint64(array)
float64(array) ** uint64(array)
float64(array) ** uint64(scalar)
float64(scalar) ** uint64(array)
float64(array) / uint64(array)
float64(array) / uint64(scalar)
float64(scalar) / uint64(array)
float64(array) % uint64(array)
float64(array) % uint64(scalar)
float64(scalar) % uint64(array)
float64(array) * uint64(array)
float64(array) * uint64(scalar)
float64(scalar) * uint64(array)
float64(array) // uint64(array)
float64(array) // uint64(scalar)
float64(scalar) // uint64(array)
float64(array) != uint64(array)
float64(array) != uint64(scalar)
float64(scalar) != uint64(array)
float64(array) == uint64(array)
float64(array) == uint64(scalar)
float64(scalar) == uint64(array)
float64(array) >= uint64(array)
float64(array) >= uint64(scalar)
float64(scalar) >= uint64(array)
float64(array) - uint64(array)
float64(array) - uint64(scalar)
float64(scalar) - uint64(array)
float64(array) < uint64(array)
float64(array) < uint64(scalar)
float64(scalar) < uint64(array)
float64(array) % float64(scalar)
float64(scalar) % float64(array)
float64(array) > bool(array)
float64(array) > bool(scalar)
float64(scalar) > bool(array)
float64(array) <= bool(array)
float64(array) <= bool(scalar)
float64(scalar) <= bool(array)
float64(array) ** bool(array)
float64(array) ** bool(scalar)
float64(scalar) ** bool(array)
float64(array) / bool(array)
float64(array) / bool(scalar)
float64(scalar) / bool(array)
float64(array) % bool(array)
float64(array) % bool(scalar)
float64(scalar) % bool(array)
float64(array) // bool(array)
float64(array) // bool(scalar)
float64(scalar) // bool(array)
float64(array) != bool(array)
float64(array) != bool(scalar)
float64(scalar) != bool(array)
float64(array) == bool(array)
float64(array) == bool(scalar)
float64(scalar) == bool(array)
float64(array) >= bool(array)
float64(array) >= bool(scalar)
float64(scalar) >= bool(array)
float64(array) < bool(array)
float64(array) < bool(scalar)
float64(scalar) < bool(array)
bool(array) & int64(array)
bool(array) & int64(scalar)
bool(scalar) & int64(array)
bool(array) > int64(array)
bool(array) > int64(scalar)
bool(scalar) > int64(array)
bool(array) <= int64(array)
bool(array) <= int64(scalar)
bool(scalar) <= int64(array)
bool(array) ** int64(array)
bool(array) ** int64(scalar)
bool(scalar) ** int64(array)
bool(array) / int64(array)
bool(array) / int64(scalar)
bool(scalar) / int64(array)
bool(array) << int64(array)
bool(array) << int64(scalar)
bool(scalar) << int64(array)
bool(array) % int64(array)
bool(array) % int64(scalar)
bool(scalar) % int64(array)
bool(array) // int64(array)
bool(array) // int64(scalar)
bool(scalar) // int64(array)
bool(array) >> int64(array)
bool(array) >> int64(scalar)
bool(scalar) >> int64(array)
bool(array) != int64(array)
bool(array) != int64(scalar)
bool(scalar) != int64(array)
bool(array) == int64(array)
bool(array) == int64(scalar)
bool(scalar) == int64(array)
bool(array) >= int64(array)
bool(array) >= int64(scalar)
bool(scalar) >= int64(array)
bool(array) | int64(array)
bool(array) | int64(scalar)
bool(scalar) | int64(array)
bool(array) ^ int64(array)
bool(array) ^ int64(scalar)
bool(scalar) ^ int64(array)
bool(array) < int64(array)
bool(array) < int64(scalar)
bool(scalar) < int64(array)
bool(array) & uint64(array)
bool(array) & uint64(scalar)
bool(scalar) & uint64(array)
bool(array) > uint64(array)
bool(array) > uint64(scalar)
bool(scalar) > uint64(array)
bool(array) + uint64(array)
bool(array) + uint64(scalar)
bool(scalar) + uint64(array)
bool(array) <= uint64(array)
bool(array) <= uint64(scalar)
bool(scalar) <= uint64(array)
bool(array) ** uint64(array)
bool(array) ** uint64(scalar)
bool(scalar) ** uint64(array)
bool(array) / uint64(array)
bool(array) / uint64(scalar)
bool(scalar) / uint64(array)
bool(array) << uint64(array)
bool(array) << uint64(scalar)
bool(scalar) << uint64(array)
bool(array) % uint64(array)
bool(array) % uint64(scalar)
bool(scalar) % uint64(array)
bool(array) * uint64(array)
bool(array) * uint64(scalar)
bool(scalar) * uint64(array)
bool(array) // uint64(array)
bool(array) // uint64(scalar)
bool(scalar) // uint64(array)
bool(array) >> uint64(array)
bool(array) >> uint64(scalar)
bool(scalar) >> uint64(array)
bool(array) != uint64(array)
bool(array) != uint64(scalar)
bool(scalar) != uint64(array)
bool(array) == uint64(array)
bool(array) == uint64(scalar)
bool(scalar) == uint64(array)
bool(array) >= uint64(array)
bool(array) >= uint64(scalar)
bool(scalar) >= uint64(array)
bool(array) | uint64(array)
bool(array) | uint64(scalar)
bool(scalar) | uint64(array)
bool(array) ^ uint64(array)
bool(array) ^ uint64(scalar)
bool(scalar) ^ uint64(array)
bool(array) - uint64(array)
bool(array) - uint64(scalar)
bool(scalar) - uint64(array)
bool(array) < uint64(array)
bool(array) < uint64(scalar)
bool(scalar) < uint64(array)
bool(array) > float64(array)
bool(array) > float64(scalar)
bool(scalar) > float64(array)
bool(array) <= float64(array)
bool(array) <= float64(scalar)
bool(scalar) <= float64(array)
bool(array) ** float64(array)
bool(array) ** float64(scalar)
bool(scalar) ** float64(array)
bool(array) / float64(array)
bool(array) / float64(scalar)
bool(scalar) / float64(array)
bool(array) % float64(array)
bool(array) % float64(scalar)
bool(scalar) % float64(array)
bool(array) // float64(array)
bool(array) // float64(scalar)
bool(scalar) // float64(array)
bool(array) != float64(array)
bool(array) != float64(scalar)
bool(scalar) != float64(array)
bool(array) == float64(array)
bool(array) == float64(scalar)
bool(scalar) == float64(array)
bool(array) >= float64(array)
bool(array) >= float64(scalar)
bool(scalar) >= float64(array)
bool(array) < float64(array)
bool(array) < float64(scalar)
bool(scalar) < float64(array)
bool(array) > bool(array)
bool(array) > bool(scalar)
bool(scalar) > bool(array)
bool(array) + bool(array)
bool(array) + bool(scalar)
bool(scalar) + bool(array)
bool(array) <= bool(array)
bool(array) <= bool(scalar)
bool(scalar) <= bool(array)
bool(array) ** bool(array)
bool(array) ** bool(scalar)
bool(scalar) ** bool(array)
bool(array) / bool(array)
bool(array) / bool(scalar)
bool(scalar) / bool(array)
bool(array) << bool(array)
bool(array) << bool(scalar)
bool(scalar) << bool(array)
bool(array) % bool(array)
bool(array) % bool(scalar)
bool(scalar) % bool(array)
bool(array) * bool(array)
bool(array) * bool(scalar)
bool(scalar) * bool(array)
bool(array) // bool(array)
bool(array) // bool(scalar)
bool(scalar) // bool(array)
bool(array) >> bool(array)
bool(array) >> bool(scalar)
bool(scalar) >> bool(array)
bool(array) != bool(scalar)
bool(scalar) != bool(array)
bool(array) == bool(scalar)
bool(scalar) == bool(array)
bool(array) >= bool(array)
bool(array) >= bool(scalar)
bool(scalar) >= bool(array)
bool(array) < bool(array)
bool(array) < bool(scalar)
bool(scalar) < bool(array)
# ops implemented by arkouda but not numpy: 15
int64(array) & float64(array)  ->  [0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00]
int64(array) << float64(array)  ->  [0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00]
int64(array) >> float64(array)  ->  [0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00]
int64(array) | float64(array)  ->  [0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00]
int64(array) ^ float64(array)  ->  [0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00]
float64(array) & int64(array)  ->  [0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00]
float64(array) << int64(array)  ->  [0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00]
float64(array) >> int64(array)  ->  [0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00]
float64(array) | int64(array)  ->  [0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00]
float64(array) ^ int64(array)  ->  [0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00]
float64(array) & float64(array)  ->  [0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00]
float64(array) << float64(array)  ->  [0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00]
float64(array) >> float64(array)  ->  [0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00]
float64(array) | float64(array)  ->  [0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00]
float64(array) ^ float64(array)  ->  [0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00]
# ops implemented by both: 239
  Matching results:         223 / 239
  Arkouda execution errors: 0 / 239

  Dtype mismatches:         7 / 239
uint64(array) > uint64(array): bool(np) vs. uint64(ak)
uint64(array) <= uint64(array): bool(np) vs. uint64(ak)
uint64(array) / uint64(array): float64(np) vs. uint64(ak)
uint64(array) != uint64(array): bool(np) vs. uint64(ak)
uint64(array) == uint64(array): bool(np) vs. uint64(ak)
uint64(array) >= uint64(array): bool(np) vs. uint64(ak)
uint64(array) < uint64(array): bool(np) vs. uint64(ak)
  Value mismatches:         9 / 239
int64(array) % float64(array): np: [       nan 0.11111111 0.22222222 0.33333333 0.44444444 0.55555556
 0.66666667 0.77777778 0.88888889 1.        ]
ak: [0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
uint64(array) & uint64(array): np: [0 1 2 3 4 5 6 7 8 9]
ak: [0 0 0 0 0 0 0 0 0 0]
uint64(array) ** uint64(array): np: [        1         1         4        27       256      3125     46656
    823543  16777216 387420489]
ak: [0 0 0 0 0 0 0 0 0 0]
uint64(array) << uint64(array): np: [   0    2    8   24   64  160  384  896 2048 4608]
ak: [0 0 0 0 0 0 0 0 0 0]
uint64(array) * uint64(array): np: [ 0  1  4  9 16 25 36 49 64 81]
ak: [0 0 0 0 0 0 0 0 0 0]
uint64(array) // uint64(array): np: [0 1 1 1 1 1 1 1 1 1]
ak: [0 0 0 0 0 0 0 0 0 0]
uint64(array) | uint64(array): np: [0 1 2 3 4 5 6 7 8 9]
ak: [0 0 0 0 0 0 0 0 0 0]
float64(array) % int64(array): np: [       nan 0.22222222 0.44444444 0.66666667 0.88888889 1.11111111
 1.33333333 1.55555556 1.77777778 2.        ]
ak: [0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
float64(array) % float64(array): np: [nan  0.  0.  0.  0.  0.  0.  0.  0.  0.]
ak: [0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
```
</details>

___________________________

Notes:
- We may want to add a `dtype`  field into `arange` at some point, but I figured building the `uint64` array with numpy and using `ak.array` would work for now
- I had to change 
```python
return new MsgTuple("Bin op not supported", MsgType.NORMAL);
```
because `create_pdarray` was struggling trying to interpret it, so I'd like @bmcdonald3 to weigh in on if the `notImplementedError` seems appropriate

Part of #1011 