### PR TITLE
Add uint operator support and refactor binopvs and binopsv

### DIFF
--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -174,9 +174,44 @@ module BinOp
             var errorMsg = notImplementedError(pn,l.dtype,op,r.dtype);
             omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                              
             return new MsgTuple(errorMsg, MsgType.ERROR); 
-          }
-            
+          }   
         }
+      }
+      var repMsg = "created %s".format(st.attrib(rname));
+      return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+    else if (e.etype == int && r.etype == uint) ||
+            (e.etype == uint && r.etype == int) {
+      select op {
+        when ">>" {
+          e.a = l.a >> r.a;
+        }
+        when "<<" {
+          e.a = l.a << r.a;
+        }
+        when ">>>" {
+          e.a = rotr(l.a, r.a);
+        }
+        when "<<<" {
+          e.a = rotl(l.a, r.a);
+        }
+      }
+      var repMsg = "created %s".format(st.attrib(rname));
+      return new MsgTuple(repMsg, MsgType.NORMAL);
+    } else if (l.etype == uint && r.etype == int) ||
+              (l.etype == int && r.etype == uint) {
+      select op {
+        when "+" {
+          e.a = l.a:real + r.a:real;
+        }
+        when "-" {
+          e.a = l.a:real - r.a:real;
+        }
+        otherwise {
+          var errorMsg = notImplementedError(pn,l.dtype,op,r.dtype);
+          omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                              
+          return new MsgTuple(errorMsg, MsgType.ERROR); 
+        }   
       }
       var repMsg = "created %s".format(st.attrib(rname));
       return new MsgTuple(repMsg, MsgType.NORMAL);

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -104,7 +104,7 @@ module BinOp
     // what operations are supported based on the resultant type
     else if (l.etype == int && r.etype == int) ||
             (l.etype == uint && r.etype == uint)  {
-      if e.etype == int {
+      if e.etype == int || e.etype == uint {
         select op {
           when "+" {
             e.a = l.a + r.a;
@@ -357,8 +357,9 @@ module BinOp
     // Since we know that both `l` and `r` are of type `int` and that
     // the resultant type is not bool (checked in first `if`), we know
     // what operations are supported based on the resultant type
-    else if l.etype == int && val.type == int {
-      if e.etype == int {
+    else if (l.etype == int && val.type == int) ||
+            (l.etype == uint && val.type == uint) {
+      if e.etype == int || e.etype == uint {
         select op {
           when "+" {
             e.a = l.a + val;
@@ -423,6 +424,42 @@ module BinOp
           }
             
         }
+      }
+      var repMsg = "created %s".format(st.attrib(rname));
+      return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+    else if (e.etype == int && val.type == uint) ||
+            (e.etype == uint && val.type == int) {
+      select op {
+        when ">>" {
+          e.a = l.a >> val;
+        }
+        when "<<" {
+          e.a = l.a << val;
+        }
+        when ">>>" {
+          e.a = rotr(l.a, val);
+        }
+        when "<<<" {
+          e.a = rotl(l.a, val);
+        }
+      }
+      var repMsg = "created %s".format(st.attrib(rname));
+      return new MsgTuple(repMsg, MsgType.NORMAL);
+    } else if (l.etype == uint && val.type == int) ||
+              (l.etype == int && val.type == uint) {
+      select op {
+        when "+" {
+          e.a = l.a:real + val:real;
+        }
+        when "-" {
+          e.a = l.a:real - val:real;
+        }
+        otherwise {
+          var errorMsg = notImplementedError(pn,l.dtype,op,dtype);
+          omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                              
+          return new MsgTuple(errorMsg, MsgType.ERROR); 
+        }   
       }
       var repMsg = "created %s".format(st.attrib(rname));
       return new MsgTuple(repMsg, MsgType.NORMAL);
@@ -567,8 +604,9 @@ module BinOp
     // Since we know that both `l` and `r` are of type `int` and that
     // the resultant type is not bool (checked in first `if`), we know
     // what operations are supported based on the resultant type
-    else if r.etype == int && val.type == int {
-      if e.etype == int {
+    else if (r.etype == int && val.type == int) ||
+            (r.etype == uint && val.type == uint) {
+      if e.etype == int || e.etype == uint {
         select op {
           when "+" {
             e.a = val + r.a;
@@ -638,6 +676,41 @@ module BinOp
           }
             
         }
+      }
+      var repMsg = "created %s".format(st.attrib(rname));
+      return new MsgTuple(repMsg, MsgType.NORMAL);
+    } else if (e.etype == int && r.etype == uint) ||
+              (e.etype == uint && r.etype == int) {
+      select op {
+        when ">>" {
+          e.a = val >> r.a;
+        }
+        when "<<" {
+          e.a = val << r.a;
+        }
+        when ">>>" {
+          e.a = rotr(val, r.a);
+        }
+        when "<<<" {
+          e.a = rotl(val, r.a);
+        }
+      }
+      var repMsg = "created %s".format(st.attrib(rname));
+      return new MsgTuple(repMsg, MsgType.NORMAL);
+    } else if (val.type == uint && r.etype == int) ||
+              (val.type == int && r.etype == uint) {
+      select op {
+        when "+" {
+          e.a = val:real + r.a:real;
+        }
+        when "-" {
+          e.a = val:real - r.a:real;
+        }
+        otherwise {
+          var errorMsg = notImplementedError(pn,dtype,op,r.dtype);
+          omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                              
+          return new MsgTuple(errorMsg, MsgType.ERROR); 
+        }   
       }
       var repMsg = "created %s".format(st.attrib(rname));
       return new MsgTuple(repMsg, MsgType.NORMAL);

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -195,6 +195,11 @@ module BinOp
         when "<<<" {
           e.a = rotl(l.a, r.a);
         }
+        otherwise {
+          var errorMsg = notImplementedError(pn,l.dtype,op,r.dtype);
+          omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+          return new MsgTuple(errorMsg, MsgType.ERROR);
+        }
       }
       var repMsg = "created %s".format(st.attrib(rname));
       return new MsgTuple(repMsg, MsgType.NORMAL);
@@ -241,6 +246,11 @@ module BinOp
           }
           when "**" { 
             e.a= l.a**r.a;
+          }
+          otherwise {
+            var errorMsg = notImplementedError(pn,l.dtype,op,r.dtype);
+            omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
           }
         }
       var repMsg = "created %s".format(st.attrib(rname));
@@ -443,6 +453,11 @@ module BinOp
         when "<<<" {
           e.a = rotl(l.a, val);
         }
+        otherwise {
+          var errorMsg = notImplementedError(pn,l.dtype,op,dtype);
+          omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+          return new MsgTuple(errorMsg, MsgType.ERROR);
+        }
       }
       var repMsg = "created %s".format(st.attrib(rname));
       return new MsgTuple(repMsg, MsgType.NORMAL);
@@ -488,6 +503,11 @@ module BinOp
           }
           when "**" { 
             e.a= l.a**val;
+          }
+          otherwise {
+            var errorMsg = notImplementedError(pn,l.dtype,op,dtype);
+            omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
           }
         }
       var repMsg = "created %s".format(st.attrib(rname));
@@ -694,6 +714,11 @@ module BinOp
         when "<<<" {
           e.a = rotl(val, r.a);
         }
+        otherwise {
+          var errorMsg = notImplementedError(pn,dtype,op,r.dtype);
+          omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+          return new MsgTuple(errorMsg, MsgType.ERROR);
+        }
       }
       var repMsg = "created %s".format(st.attrib(rname));
       return new MsgTuple(repMsg, MsgType.NORMAL);
@@ -721,7 +746,7 @@ module BinOp
              || (r.etype == real && val.type == int)) {
       select op {
           when "+" {
-            e.a = val + val;
+            e.a = val + r.a;
           }
           when "-" {
             e.a = val - r.a;
@@ -739,6 +764,11 @@ module BinOp
           }
           when "**" { 
             e.a= val**r.a;
+          }
+          otherwise {
+            var errorMsg = notImplementedError(pn,dtype,op,r.dtype);
+            omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
           }
         }
       var repMsg = "created %s".format(st.attrib(rname));

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -442,39 +442,28 @@ module BinOp
             (e.etype == uint && val.type == int) {
       select op {
         when ">>" {
-          e.a = l.a >> val;
+          e.a = l.a >> val:l.etype;
         }
         when "<<" {
-          e.a = l.a << val;
+          e.a = l.a << val:l.etype;
         }
         when ">>>" {
-          e.a = rotr(l.a, val);
+          e.a = rotr(l.a, val:l.etype);
         }
         when "<<<" {
-          e.a = rotl(l.a, val);
+          e.a = rotl(l.a, val:l.etype);
+        }
+        when "+" {
+          e.a = l.a + val:l.etype;
+        }
+        when "-" {
+          e.a = l.a - val:l.etype;
         }
         otherwise {
           var errorMsg = notImplementedError(pn,l.dtype,op,dtype);
           omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
           return new MsgTuple(errorMsg, MsgType.ERROR);
         }
-      }
-      var repMsg = "created %s".format(st.attrib(rname));
-      return new MsgTuple(repMsg, MsgType.NORMAL);
-    } else if (l.etype == uint && val.type == int) ||
-              (l.etype == int && val.type == uint) {
-      select op {
-        when "+" {
-          e.a = l.a:real + val:real;
-        }
-        when "-" {
-          e.a = l.a:real - val:real;
-        }
-        otherwise {
-          var errorMsg = notImplementedError(pn,l.dtype,op,dtype);
-          omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                              
-          return new MsgTuple(errorMsg, MsgType.ERROR); 
-        }   
       }
       var repMsg = "created %s".format(st.attrib(rname));
       return new MsgTuple(repMsg, MsgType.NORMAL);
@@ -554,7 +543,7 @@ module BinOp
       var repMsg = "created %s".format(st.attrib(rname));
       return new MsgTuple(repMsg, MsgType.NORMAL);
     }
-    var errorMsg = notImplementedError(pn,l.dtype,op,dtype);
+    var errorMsg = unrecognizedTypeError(pn, "("+dtype2str(l.dtype)+","+dtype2str(dtype)+")");
     omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
     return new MsgTuple(errorMsg, MsgType.ERROR);
   }
@@ -699,43 +688,31 @@ module BinOp
       }
       var repMsg = "created %s".format(st.attrib(rname));
       return new MsgTuple(repMsg, MsgType.NORMAL);
-    } else if (e.etype == int && r.etype == uint) ||
-              (e.etype == uint && r.etype == int) {
+    } else if (val.type == int && r.etype == uint) {
       select op {
         when ">>" {
-          e.a = val >> r.a;
+          e.a = val:uint >> r.a:uint;
         }
         when "<<" {
-          e.a = val << r.a;
+          e.a = val:uint << r.a:uint;
         }
         when ">>>" {
-          e.a = rotr(val, r.a);
+          e.a = rotr(val:uint, r.a:uint);
         }
         when "<<<" {
-          e.a = rotl(val, r.a);
+          e.a = rotl(val:uint, r.a:uint);
+        }
+        when "+" {
+          e.a = val:uint + r.a:uint;
+        }
+        when "-" {
+          e.a = val:uint - r.a:uint;
         }
         otherwise {
           var errorMsg = notImplementedError(pn,dtype,op,r.dtype);
           omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
           return new MsgTuple(errorMsg, MsgType.ERROR);
         }
-      }
-      var repMsg = "created %s".format(st.attrib(rname));
-      return new MsgTuple(repMsg, MsgType.NORMAL);
-    } else if (val.type == uint && r.etype == int) ||
-              (val.type == int && r.etype == uint) {
-      select op {
-        when "+" {
-          e.a = val:real + r.a:real;
-        }
-        when "-" {
-          e.a = val:real - r.a:real;
-        }
-        otherwise {
-          var errorMsg = notImplementedError(pn,dtype,op,r.dtype);
-          omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                              
-          return new MsgTuple(errorMsg, MsgType.ERROR); 
-        }   
       }
       var repMsg = "created %s".format(st.attrib(rname));
       return new MsgTuple(repMsg, MsgType.NORMAL);
@@ -815,7 +792,7 @@ module BinOp
       var repMsg = "created %s".format(st.attrib(rname));
       return new MsgTuple(repMsg, MsgType.NORMAL);
     }
-    var errorMsg = notImplementedError(pn,dtype,op,r.dtype);
+    var errorMsg = unrecognizedTypeError(pn, "("+dtype2str(dtype)+","+dtype2str(r.dtype)+")");
     omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
     return new MsgTuple(errorMsg, MsgType.ERROR);
   }

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -38,16 +38,6 @@ module BinOp
   :throws: `UndefinedSymbolError(name)`
   */
   proc doBinOpvv(l, r, e, op: string, rname, pn, st) throws {
-    if e.etype == uint {
-      select op {
-        when "+" {
-          e.a = l.a + r.a;
-        }
-      }
-      var repMsg = "created %s".format(st.attrib(rname));
-      return new MsgTuple(repMsg, MsgType.NORMAL);
-    }
-    
     if e.etype == bool {
       // Since we know that the result type is a boolean, we know
       // that it either (1) is an operation between bools or (2) uses
@@ -112,7 +102,8 @@ module BinOp
     // Since we know that both `l` and `r` are of type `int` and that
     // the resultant type is not bool (checked in first `if`), we know
     // what operations are supported based on the resultant type
-    else if l.etype == int && r.etype == int {
+    else if (l.etype == int && r.etype == int) ||
+            (l.etype == uint && r.etype == uint)  {
       if e.etype == int {
         select op {
           when "+" {

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -471,6 +471,8 @@ module BinOp
       var repMsg = "created %s".format(st.attrib(rname));
       return new MsgTuple(repMsg, MsgType.NORMAL);
     }
-    return new MsgTuple("Bin op not supported", MsgType.NORMAL);
+    var errorMsg = notImplementedError(pn,l.dtype,op,dtype);
+    omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+    return new MsgTuple(errorMsg, MsgType.ERROR);
   }
 }

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -475,4 +475,219 @@ module BinOp
     omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
     return new MsgTuple(errorMsg, MsgType.ERROR);
   }
+
+  proc doBinOpsv(val, r, e, op: string, dtype, rname, pn, st) throws {
+    if e.etype == bool {
+      // Since we know that the result type is a boolean, we know
+      // that it either (1) is an operation between bools or (2) uses
+      // a boolean operator (<, <=, etc.)
+      if r.etype == bool && val.type == bool {
+        select op {
+          when "|" {
+            e.a = val | r.a;
+          }
+          when "&" {
+            e.a = val & r.a;
+          }
+          when "^" {
+            e.a = val ^ r.a;
+          }
+          when "==" {
+            e.a = val == r.a;
+          }
+          when "!=" {
+            e.a = val != r.a;
+          }
+          otherwise {
+            var errorMsg = notImplementedError(pn,dtype,op,r.dtype);
+            omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+          }
+        }
+      }
+      // All types support the same binary operations when the resultant
+      // type is bool and `l` and `r` are not both boolean, so this does
+      // not need to be specialized for each case.
+      else {
+        select op {
+            when "<" {
+              e.a = val < r.a;
+            }
+            when ">" {
+              e.a = val > r.a;
+            }
+            when "<=" {
+              e.a = val <= r.a;
+            }
+            when ">=" {
+              e.a = val >= r.a;
+            }
+            when "==" {
+              e.a = val == r.a;
+            }
+            when "!=" {
+              e.a = val != r.a;
+            }
+            otherwise {
+              var errorMsg = notImplementedError(pn,dtype,op,r.dtype);
+              omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                              
+              return new MsgTuple(errorMsg, MsgType.ERROR); 
+            }
+          }
+      }
+      var repMsg = "created %s".format(st.attrib(rname));
+      return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+    // Since we know that both `l` and `r` are of type `int` and that
+    // the resultant type is not bool (checked in first `if`), we know
+    // what operations are supported based on the resultant type
+    else if r.etype == int && val.type == int {
+      if e.etype == int {
+        select op {
+          when "+" {
+            e.a = val + r.a;
+          }
+          when "-" {
+            e.a = val - r.a;
+          }
+          when "*" {
+            e.a = val * r.a;
+          }
+          when "//" { // floordiv
+            ref ea = e.a;
+            ref ra = r.a;
+            [(ei,ri) in zip(ea,ra)] ei = if ri != 0 then val/ri else 0;
+          }
+          when "%" { // modulo
+            ref ea = e.a;
+            ref ra = r.a;
+            [(ei,ri) in zip(ea,ra)] ei = if ri != 0 then val%ri else 0;
+          }
+          when "<<" {
+            e.a = val << r.a;
+          }                    
+          when ">>" {
+            e.a = val >> r.a;
+          }
+          when "<<<" {
+            e.a = rotl(val, r.a);
+          }
+          when ">>>" {
+            e.a = rotr(val, r.a);
+          }
+          when "&" {
+            e.a = val & r.a;
+          }                    
+          when "|" {
+            e.a = val | r.a;
+          }                    
+          when "^" {
+            e.a = val ^ r.a;
+          }
+          when "**" {
+            if || reduce (r.a<0){
+              var errorMsg = "Attempt to exponentiate base of type Int64 to negative exponent";
+              omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+              return new MsgTuple(errorMsg, MsgType.ERROR); 
+            }
+            e.a= val**r.a;
+          }     
+          otherwise {
+            var errorMsg = notImplementedError(pn,dtype,op,r.dtype);
+            omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                              
+            return new MsgTuple(errorMsg, MsgType.ERROR); 
+          }
+        }
+      } else if e.etype == real {
+        select op {
+          // True division is the only integer type that would result in a
+          // resultant type of `real`
+          when "/" {
+            e.a = val:real / r.a:real;
+          }
+          otherwise {
+            var errorMsg = notImplementedError(pn,dtype,op,r.dtype);
+            omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                              
+            return new MsgTuple(errorMsg, MsgType.ERROR); 
+          }
+            
+        }
+      }
+      var repMsg = "created %s".format(st.attrib(rname));
+      return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+    // If either RHS or LHS type is real, the same operations are supported and the
+    // result will always be a `real`, so all 3 of these cases can be shared.
+    else if ((r.etype == real && val.type == real) || (r.etype == int && val.type == real)
+             || (r.etype == real && val.type == int)) {
+      select op {
+          when "+" {
+            e.a = val + val;
+          }
+          when "-" {
+            e.a = val - r.a;
+          }
+          when "*" {
+            e.a = val * r.a;
+          }
+          when "/" { // truediv
+            e.a = val:real / r.a:real;
+          } 
+          when "//" { // floordiv
+            ref ea = e.a;
+            ref ra = r.a;
+            [(ei,ri) in zip(ea,ra)] ei = if ri != 0 then floor(val:real/ri) else NAN;
+          }
+          when "**" { 
+            e.a= val**r.a;
+          }
+        }
+      var repMsg = "created %s".format(st.attrib(rname));
+      return new MsgTuple(repMsg, MsgType.NORMAL);
+    } else if ((r.etype == int && val.type == bool) || (r.etype == bool && val.type == int)) {
+      select op {
+          when "+" {
+            // Since we don't know which of `l` or `r` is the int and which is the `bool`,
+            // we can just cast both to int, which will be a noop for the vector that is
+            // already `int`
+            e.a = val:int + r.a:int;
+          }
+          when "-" {
+            e.a = val:int - r.a:int;
+          }
+          when "*" {
+            e.a = val:int * r.a:int;
+          }
+          otherwise {
+            var errorMsg = notImplementedError(pn,dtype,op,r.dtype);
+            omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+          }
+        }
+      var repMsg = "created %s".format(st.attrib(rname));
+      return new MsgTuple(repMsg, MsgType.NORMAL);
+    } else if ((r.etype == real && val.type == bool) || (r.etype == bool && val.type == real)) {
+      select op {
+          when "+" {
+            e.a = val:real + r.a:real;
+          }
+          when "-" {
+            e.a = val:real - r.a:real;
+          }
+          when "*" {
+            e.a = val:real * r.a:real;
+          }
+          otherwise {
+            var errorMsg = notImplementedError(pn,dtype,op,r.dtype);
+            omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+          }
+        }
+      var repMsg = "created %s".format(st.attrib(rname));
+      return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+    var errorMsg = notImplementedError(pn,dtype,op,r.dtype);
+    omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+    return new MsgTuple(errorMsg, MsgType.ERROR);
+  }
 }

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -314,8 +314,45 @@ module OperatorMsg
           when (DType.UInt64, DType.UInt64) {
             var l = toSymEntry(left,uint);
             var val = try! value:uint;
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, l.size, bool);
+              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+            }
             var e = st.addEntry(rname, l.size, uint);
             return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+          }
+          when (DType.UInt64, DType.Int64) {
+            var l = toSymEntry(left,uint);
+            var val = try! value:int;
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, l.size, bool);
+              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+            }
+            // + and - both result in real outputs to match NumPy
+            if op == "+" || op == "-" {
+              var e = st.addEntry(rname, l.size, real);
+              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+            } else {
+              // isn't + or -, so we can use LHS to determine type
+              var e = st.addEntry(rname, l.size, uint);
+              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+            }
+          }
+          when (DType.Int64, DType.UInt64) {
+            var l = toSymEntry(left,int);
+            var val = try! value:uint;
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, l.size, bool);
+              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+            }
+            if op == "+" || op == "-" {
+              var e = st.addEntry(rname, l.size, real);
+              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+            } else {
+              // isn't + or -, so we can use LHS to determine type
+              var e = st.addEntry(rname, l.size, int);
+              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+            }
           }
         }
         var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
@@ -447,8 +484,45 @@ module OperatorMsg
           when (DType.UInt64, DType.UInt64) {
             var val = try! value:uint;
             var r = toSymEntry(right,uint);
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, r.size, bool);
+              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+            }
             var e = st.addEntry(rname, r.size, uint);
             return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          }
+          when (DType.UInt64, DType.Int64) {
+            var val = try! value:uint;
+            var r = toSymEntry(right,int);
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, r.size, bool);
+              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+            }
+            // + and - both result in real outputs to match NumPy
+            if op == "+" || op == "-" {
+              var e = st.addEntry(rname, r.size, real);
+              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+            } else {
+              // isn't + or -, so we can use LHS to determine type
+              var e = st.addEntry(rname, r.size, uint);
+              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+            }
+          }
+          when (DType.Int64, DType.UInt64) {
+            var val = try! value:int;
+            var r = toSymEntry(right,uint);
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, r.size, bool);
+              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+            }
+            if op == "+" || op == "-" {
+              var e = st.addEntry(rname, r.size, real);
+              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+            } else {
+              // isn't + or -, so we can use LHS to determine type
+              var e = st.addEntry(rname, r.size, int);
+              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+            }
           }
         }
         var errorMsg = notImplementedError(pn,dtype,op,right.dtype);

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -328,15 +328,9 @@ module OperatorMsg
               var e = st.addEntry(rname, l.size, bool);
               return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
             }
-            // + and - both result in real outputs to match NumPy
-            if op == "+" || op == "-" {
-              var e = st.addEntry(rname, l.size, real);
-              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
-            } else {
-              // isn't + or -, so we can use LHS to determine type
-              var e = st.addEntry(rname, l.size, uint);
-              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
-            }
+            // isn't + or -, so we can use LHS to determine type
+            var e = st.addEntry(rname, l.size, uint);
+            return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
           }
           when (DType.Int64, DType.UInt64) {
             var l = toSymEntry(left,int);
@@ -345,17 +339,11 @@ module OperatorMsg
               var e = st.addEntry(rname, l.size, bool);
               return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
             }
-            if op == "+" || op == "-" {
-              var e = st.addEntry(rname, l.size, real);
-              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
-            } else {
-              // isn't + or -, so we can use LHS to determine type
-              var e = st.addEntry(rname, l.size, int);
-              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
-            }
+            var e = st.addEntry(rname, l.size, int);
+            return doBinOpvs(l, val, e, op, dtype, rname, pn, st); 
           }
         }
-        var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
+        var errorMsg = unrecognizedTypeError(pn, "("+dtype2str(left.dtype)+","+dtype2str(dtype)+")");
         omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
         return new MsgTuple(errorMsg, MsgType.ERROR);
     }
@@ -515,17 +503,11 @@ module OperatorMsg
               var e = st.addEntry(rname, r.size, bool);
               return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
             }
-            if op == "+" || op == "-" {
-              var e = st.addEntry(rname, r.size, real);
-              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
-            } else {
-              // isn't + or -, so we can use LHS to determine type
-              var e = st.addEntry(rname, r.size, int);
-              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
-            }
+            var e = st.addEntry(rname, r.size, uint);
+            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
           }
         }
-        var errorMsg = notImplementedError(pn,dtype,op,right.dtype);
+        var errorMsg = unrecognizedTypeError(pn, "("+dtype2str(dtype)+","+dtype2str(right.dtype)+")");
         omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
         return new MsgTuple(errorMsg, MsgType.ERROR);
     }

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -314,420 +314,109 @@ module OperatorMsg
                  "command = %t op = %t scalar dtype = %t scalar = %t pdarray = %t".format(
                                    cmd,op,dtype2str(dtype),value,st.attrib(aname)));
 
-        select (dtype, right.dtype) {
-            when (DType.Int64, DType.Int64) {
-                var val = try! value:int;
-                var r = toSymEntry(right,int);
-                select op
-                {
-                    when "+" {
-                        var e = st.addEntry(rname, r.size, int);
-                        e.a = val + r.a;
-                    }
-                    when "-" {
-                        var e = st.addEntry(rname, r.size, int);
-                        e.a = val - r.a;
-                    }
-                    when "*" {
-                        var e = st.addEntry(rname, r.size, int);
-                        e.a = val * r.a;
-                    }
-                    when "/" { // truediv
-                        var e = st.addEntry(rname, r.size, real);
-                        e.a =  val:real / r.a:real;
-                    } 
-                    when "//" { // floordiv
-                        var e = st.addEntry(rname, r.size, int);
-                        ref ea = e.a;
-                        ref ra = r.a;
-                        [(ei,ri) in zip(ea,ra)] ei = if ri != 0 then val/ri else 0;
-                    }
-                    when "%" { // modulo
-                        var e = st.addEntry(rname, r.size, int);
-                        ref ea = e.a;
-                        ref ra = r.a;
-                        [(ei,ri) in zip(ea,ra)] ei = if ri != 0 then val%ri else 0;
-                    }
-                    when "<" {
-                        var e = st.addEntry(rname, r.size, bool);
-                        e.a = val < r.a;
-                    }
-                    when ">" {
-                        var e = st.addEntry(rname, r.size, bool);
-                        e.a = val > r.a;
-                    }
-                    when "<=" {
-                        var e = st.addEntry(rname, r.size, bool);
-                        e.a = val <= r.a;
-                    }
-                    when ">=" {
-                        var e = st.addEntry(rname, r.size, bool);
-                        e.a = val >= r.a;
-                    }
-                    when "==" {
-                        var e = st.addEntry(rname, r.size, bool);
-                        e.a = val == r.a;
-                    }
-                    when "!=" {
-                        var e = st.addEntry(rname, r.size, bool);
-                        e.a = val != r.a;
-                    }
-                    when "<<" {
-                        var e = st.addEntry(rname, r.size, int);
-                        e.a = val << r.a;
-                    }
-                    when ">>" {
-                        var e = st.addEntry(rname, r.size, int);
-                        e.a = val >> r.a;
-                    }
-                    when "<<<" {
-                        var e = st.addEntry(rname, r.size, int);
-                        e.a = rotl(val, r.a);
-                    }
-                    when ">>>" {
-                        var e = st.addEntry(rname, r.size, int);
-                        e.a = rotr(val, r.a);
-                    }
-                    when "&" {
-                        var e = st.addEntry(rname, r.size, int);
-                        e.a = val & r.a;
-                    }
-                    when "|" {
-                        var e = st.addEntry(rname, r.size, int);
-                        e.a = val | r.a;
-                    }
-                    when "^" {
-                        var e = st.addEntry(rname, r.size, int);
-                        e.a = val ^ r.a;
-                    }
-                    when "**" { 
-                        if || reduce (r.a<0){
-                            var errorMsg = "Attempt to exponentiate base of type Int64 to negative exponent";
-                            omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                            return new MsgTuple(errorMsg, MsgType.ERROR); 
-                        }
-                        var e = st.addEntry(rname, r.size, int);
-                        e.a= val**r.a;
-                    }
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,dtype,op,right.dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR); 
-                    }
-                }
-            }
-            when (DType.Int64, DType.Float64) {
-                var val = try! value:int;
-                var r = toSymEntry(right,real);
-                select op
-                {
-                    when "+" {
-                        var e = st.addEntry(rname, r.size, real);
-                        e.a = val + r.a;
-                    }
-                    when "-" {
-                        var e = st.addEntry(rname, r.size, real);
-                        e.a = val - r.a;
-                    }
-                    when "*" {
-                        var e = st.addEntry(rname, r.size, real);
-                        e.a = val * r.a;
-                    }
-                    when "/" { // truediv
-                        var e = st.addEntry(rname, r.size, real);
-                        e.a = val:real / r.a;
-                    }
-                    when "//" { // floordiv
-                        var e = st.addEntry(rname, r.size, real);
-                        ref ea = e.a;
-                        ref ra = r.a;
-                        [(ei,ri) in zip(ea,ra)] ei = if ri != 0 then floor(val:real / ri) else NAN;
-                    }
-                    when "<" {
-                        var e = st.addEntry(rname, r.size, bool);
-                        e.a = val < r.a;
-                    }
-                    when ">" {
-                        var e = st.addEntry(rname, r.size, bool);
-                        e.a = val > r.a;
-                    }
-                    when "<=" {
-                        var e = st.addEntry(rname, r.size, bool);
-                        e.a = val <= r.a;
-                    }
-                    when ">=" {
-                        var e = st.addEntry(rname, r.size, bool);
-                        e.a = val >= r.a;
-                    }
-                    when "==" {
-                        var e = st.addEntry(rname, r.size, bool);
-                        e.a = val == r.a;
-                    }
-                    when "!=" {
-                        var e = st.addEntry(rname, r.size, bool);
-                        e.a = val != r.a;
-                    }
-                    when "**" { 
-                        var e = st.addEntry(rname, r.size, real);
-                        e.a= val**r.a;
-                    }
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,dtype,op,right.dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);                     
-                    }
-                }
-            }
-            when (DType.Float64, DType.Int64) {
-                var val = try! value:real;
-                var r = toSymEntry(right,int);
-                select op
-                {
-                    when "+" {
-                        var e = st.addEntry(rname, r.size, real);
-                        e.a = val + r.a;
-                    }
-                    when "-" {
-                        var e = st.addEntry(rname, r.size, real);
-                        e.a = val - r.a;
-                    }
-                    when "*" {
-                        var e = st.addEntry(rname, r.size, real);
-                        e.a = val * r.a;
-                    }
-                    when "/" { // truediv
-                        var e = st.addEntry(rname, r.size, real);
-                        e.a = val / r.a:real;
-                    } 
-                    when "//" { // floordiv
-                        var e = st.addEntry(rname, r.size, real);
-                        ref ea = e.a;
-                        ref ra = r.a;
-                        [(ei,ri) in zip(ea,ra)] ei = if ri != 0 then floor(val / ri:real) else NAN;
-                    }
-                    when "<" {
-                        var e = st.addEntry(rname, r.size, bool);
-                        e.a = val < r.a;
-                    }
-                    when ">" {
-                        var e = st.addEntry(rname, r.size, bool);
-                        e.a = val > r.a;
-                    }
-                    when "<=" {
-                        var e = st.addEntry(rname, r.size, bool);
-                        e.a = val <= r.a;
-                    }
-                    when ">=" {
-                        var e = st.addEntry(rname, r.size, bool);
-                        e.a = val >= r.a;
-                    }
-                    when "==" {
-                        var e = st.addEntry(rname, r.size, bool);
-                        e.a = val == r.a;
-                    }
-                    when "!=" {
-                        var e = st.addEntry(rname, r.size, bool);
-                        e.a = val != r.a;
-                    }
-                    when "**" { 
-                        var e = st.addEntry(rname, r.size, real);
-                        e.a= val**r.a;
-                    }
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,dtype,op,right.dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR); 
-                    }
-                }
-            }
-            when (DType.Float64, DType.Float64) {
-                var val = try! value:real;
-                var r = toSymEntry(right,real);
-                select op
-                {
-                    when "+" {
-                        var e = st.addEntry(rname, r.size, real);
-                        e.a = val + r.a;
-                    }
-                    when "-" {
-                        var e = st.addEntry(rname, r.size, real);
-                        e.a = val - r.a;
-                    }
-                    when "*" {
-                        var e = st.addEntry(rname, r.size, real);
-                        e.a = val * r.a;
-                    }
-                    when "/" { // truediv
-                        var e = st.addEntry(rname, r.size, real);
-                        e.a = val / r.a;
-                    } 
-                    when "//" { // floordiv
-                        var e = st.addEntry(rname, r.size, real);
-                        ref ea = e.a;
-                        ref ra = r.a;
-                        [(ei,ri) in zip(ea,ra)] ei = if ri != 0 then floor(val / ri) else NAN;
-                    }
-                    when "<" {
-                        var e = st.addEntry(rname, r.size, bool);
-                        e.a = val < r.a;
-                    }
-                    when ">" {
-                        var e = st.addEntry(rname, r.size, bool);
-                        e.a = val > r.a;
-                    }
-                    when "<=" {
-                        var e = st.addEntry(rname, r.size, bool);
-                        e.a = val <= r.a;
-                    }
-                    when ">=" {
-                        var e = st.addEntry(rname, r.size, bool);
-                        e.a = val >= r.a;
-                    }
-                    when "==" {
-                        var e = st.addEntry(rname, r.size, bool);
-                        e.a = val == r.a;
-                    }
-                    when "!=" {
-                        var e = st.addEntry(rname, r.size, bool);
-                        e.a = val != r.a;
-                    }
-                    when "**" { 
-                        var e = st.addEntry(rname, r.size, real);
-                        e.a= val**r.a;
-                    }
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,dtype,op,right.dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR); 
-                    }                        
-                }
-            }
-            when (DType.Bool, DType.Bool) {
-                var val = try! value.toLower():bool;
-                var r = toSymEntry(right, bool);
-                select op {
-                    when "|" {
-                        var e = st.addEntry(rname, r.size, bool);
-                         e.a = val | r.a;
-                    }
-                    when "&" {
-                        var e = st.addEntry(rname, r.size, bool);
-                         e.a = val & r.a;
-                    }
-                    when "^" {
-                        var e = st.addEntry(rname, r.size, bool);
-                         e.a = val ^ r.a;
-                    }
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,dtype,op,right.dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR); 
-                    }
-                }
-            }
-            when (DType.Bool, DType.Int64) {
-                var val = try! value.toLower():bool;
-                var r = toSymEntry(right, int);
-                select op {
-                    when "+" {
-                        var e = st.addEntry(rname, r.size, int);
-                        e.a = val:int + r.a;
-                    }
-                    when "-" {
-                        var e = st.addEntry(rname, r.size, int);
-                        e.a = val:int - r.a;
-                    }
-                    when "*" {
-                        var e = st.addEntry(rname, r.size, int);
-                        e.a = val:int * r.a;
-                    }
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,dtype,op,right.dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR); 
-                    }
-                }
-            }
-            when (DType.Int64, DType.Bool) {
-                var val = try! value:int;
-                var r = toSymEntry(right, bool);
-                select op {
-                    when "+" {
-                        var e = st.addEntry(rname, r.size, int);
-                        e.a = val + r.a:int;
-                    }
-                    when "-" {
-                        var e = st.addEntry(rname, r.size, int);
-                        e.a = val - r.a:int;
-                    }
-                    when "*" {
-                        var e = st.addEntry(rname, r.size, int);
-                        e.a = val * r.a:int;
-                    }
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,dtype,op,right.dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR); 
-                    }
-                }
-            }
-            when (DType.Bool, DType.Float64) {
-                var val = try! value.toLower():bool;
-                var r = toSymEntry(right, real);
-                select op {
-                    when "+" {
-                        var e = st.addEntry(rname, r.size, real);
-                        e.a = val:real + r.a;
-                    }
-                    when "-" {
-                        var e = st.addEntry(rname, r.size, real);
-                        e.a = val:real - r.a;
-                    }
-                    when "*" {
-                        var e = st.addEntry(rname, r.size, real);
-                        e.a = val:real * r.a;
-                    }
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,dtype,op,right.dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR); 
-                    }
-                }
-            }
-            when (DType.Float64, DType.Bool) {
-                var val = try! value:real;
-                var r = toSymEntry(right, bool);
-                select op {
-                    when "+" {
-                        var e = st.addEntry(rname, r.size, real);
-                        e.a = val + r.a:real;
-                    }
-                    when "-" {
-                        var e = st.addEntry(rname, r.size, real);
-                        e.a = val - r.a:real;
-                    }
-                    when "*" {
-                        var e = st.addEntry(rname, r.size, real);
-                        e.a = val * r.a:real;
-                    }
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,dtype,op,right.dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR); 
-                    }
-                }
-            }
-            otherwise {
-                var errorMsg = unrecognizedTypeError(pn,
-                                     "("+dtype2str(dtype)+","+dtype2str(right.dtype)+")");
-                omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg, MsgType.ERROR); 
-            }
-        }
+        use Set;
+        // This boolOps set is a filter to determine the output type for the operation.
+        // All operations that involve one of these operations result in a `bool` symbol
+        // table entry.
+        var boolOps: set(string);
+        boolOps.add("<");
+        boolOps.add("<=");
+        boolOps.add(">");
+        boolOps.add(">=");
+        boolOps.add("==");
+        boolOps.add("!=");
         
-        repMsg = "created %s".format(st.attrib(rname));
-        omLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-        return new MsgTuple(repMsg, MsgType.NORMAL);
+        select (dtype, right.dtype) {
+          when (DType.Int64, DType.Int64) {
+            var val = try! value:int;
+            var r = toSymEntry(right,int);
+            
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, r.size, bool);
+              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+            } else if op == "/" {
+              // True division is the only case in this int, int case
+              // that results in a `real` symbol table entry.
+              var e = st.addEntry(rname, r.size, real);
+              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+            }
+            var e = st.addEntry(rname, r.size, int);
+            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          }
+          when (DType.Int64, DType.Float64) {
+            var val = try! value:int;
+            var r = toSymEntry(right,real);
+            // Only two possible resultant types are `bool` and `real`
+            // for this case
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, r.size, bool);
+              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+            }
+            var e = st.addEntry(rname, r.size, real);
+            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          }
+          when (DType.Float64, DType.Int64) {
+            var val = try! value:real;
+            var r = toSymEntry(right,int);
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, r.size, bool);
+              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+            }
+            var e = st.addEntry(rname, r.size, real);
+            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          }
+          when (DType.Float64, DType.Float64) {
+            var val = try! value:real;
+            var r = toSymEntry(right,real);
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, r.size, bool);
+              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+            }
+            var e = st.addEntry(rname, r.size, real);
+            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          }
+          // For cases where a boolean operand is involved, the only
+          // possible resultant type is `bool`
+          when (DType.Bool, DType.Bool) {
+            var val = try! value.toLower():bool;
+            var r = toSymEntry(right,bool);
+            var e = st.addEntry(rname, r.size, bool);
+            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          }
+          when (DType.Bool, DType.Int64) {
+            var val = try! value.toLower():bool;
+            var r = toSymEntry(right,int);
+            var e = st.addEntry(rname, r.size, int);
+            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          }
+          when (DType.Int64, DType.Bool) {
+            var val = try! value:int;
+            var r = toSymEntry(right,bool);
+            var e = st.addEntry(rname, r.size, int);
+            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          }
+          when (DType.Bool, DType.Float64) {
+            var val = try! value.toLower():bool;
+            var r = toSymEntry(right,real);
+            var e = st.addEntry(rname, r.size, real);
+            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          }
+          when (DType.Float64, DType.Bool) {
+            var val = try! value:real;
+            var r = toSymEntry(right,bool);
+            var e = st.addEntry(rname, r.size, real);
+            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          }
+          when (DType.UInt64, DType.UInt64) {
+            var val = try! value:uint;
+            var r = toSymEntry(right,uint);
+            var e = st.addEntry(rname, r.size, uint);
+            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          }
+        }
+        var errorMsg = notImplementedError(pn,dtype,op,right.dtype);
+        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+        return new MsgTuple(errorMsg, MsgType.ERROR);
     }
 
     /*

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -144,12 +144,20 @@ module OperatorMsg
           when (DType.UInt64, DType.UInt64) {
             var l = toSymEntry(left,uint);
             var r = toSymEntry(right,uint);
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, l.size, bool);
+              return doBinOpvv(l, r, e, op, rname, pn, st);
+            }
             var e = st.addEntry(rname, l.size, uint);
             return doBinOpvv(l, r, e, op, rname, pn, st);
           }
           when (DType.UInt64, DType.Int64) {
             var l = toSymEntry(left,uint);
             var r = toSymEntry(right,int);
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, l.size, bool);
+              return doBinOpvv(l, r, e, op, rname, pn, st);
+            }
             // + and - both result in real outputs to match NumPy
             if op == "+" || op == "-" {
               var e = st.addEntry(rname, l.size, real);
@@ -163,6 +171,10 @@ module OperatorMsg
           when (DType.Int64, DType.UInt64) {
             var l = toSymEntry(left,int);
             var r = toSymEntry(right,uint);
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, l.size, bool);
+              return doBinOpvv(l, r, e, op, rname, pn, st);
+            }
             if op == "+" || op == "-" {
               var e = st.addEntry(rname, l.size, real);
               return doBinOpvv(l, r, e, op, rname, pn, st);

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -150,14 +150,27 @@ module OperatorMsg
           when (DType.UInt64, DType.Int64) {
             var l = toSymEntry(left,uint);
             var r = toSymEntry(right,int);
-            var e = st.addEntry(rname, l.size, uint);
-            return doBinOpvv(l, r, e, op, rname, pn, st);
+            // + and - both result in real outputs to match NumPy
+            if op == "+" || op == "-" {
+              var e = st.addEntry(rname, l.size, real);
+              return doBinOpvv(l, r, e, op, rname, pn, st);
+            } else {
+              // isn't + or -, so we can use LHS to determine type
+              var e = st.addEntry(rname, l.size, uint);
+              return doBinOpvv(l, r, e, op, rname, pn, st);
+            }
           }
           when (DType.Int64, DType.UInt64) {
             var l = toSymEntry(left,int);
             var r = toSymEntry(right,uint);
-            var e = st.addEntry(rname, l.size, uint);
-            return doBinOpvv(l, r, e, op, rname, pn, st);
+            if op == "+" || op == "-" {
+              var e = st.addEntry(rname, l.size, real);
+              return doBinOpvv(l, r, e, op, rname, pn, st);
+            } else {
+              // isn't + or -, so we can use LHS to determine type
+              var e = st.addEntry(rname, l.size, int);
+              return doBinOpvv(l, r, e, op, rname, pn, st);
+            }
           }
         }
         var errorMsg = unrecognizedTypeError(pn, "("+dtype2str(left.dtype)+","+dtype2str(right.dtype)+")");

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -281,7 +281,9 @@ module OperatorMsg
             return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
           }
         }
-        return new MsgTuple("Bin op not supported", MsgType.NORMAL);
+        var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
+        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+        return new MsgTuple(errorMsg, MsgType.ERROR);
     }
 
     /*

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -147,6 +147,18 @@ module OperatorMsg
             var e = st.addEntry(rname, l.size, uint);
             return doBinOpvv(l, r, e, op, rname, pn, st);
           }
+          when (DType.UInt64, DType.Int64) {
+            var l = toSymEntry(left,uint);
+            var r = toSymEntry(right,int);
+            var e = st.addEntry(rname, l.size, uint);
+            return doBinOpvv(l, r, e, op, rname, pn, st);
+          }
+          when (DType.Int64, DType.UInt64) {
+            var l = toSymEntry(left,int);
+            var r = toSymEntry(right,uint);
+            var e = st.addEntry(rname, l.size, uint);
+            return doBinOpvv(l, r, e, op, rname, pn, st);
+          }
         }
         var errorMsg = unrecognizedTypeError(pn, "("+dtype2str(left.dtype)+","+dtype2str(right.dtype)+")");
         omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);


### PR DESCRIPTION
This PR adds uint operator support for all uint <op> uint
operations and a subset of uint <op> int operations.

Additionally, this PR refactors the existing binopvs and
binopsv code in the same fashion that the binopvv function
was refactored. This allows for less code duplication and
also greater modularity.

Supported operations:
* uint <op> uint
  - all int <op> operations
* uint <op> int
  - +, -, >>, <<, >>>, <<<
  - +, - return `real` arrays to match numpy
  - <<, >>, >>>, <<< return `l.dtype` arrays