### PR TITLE
Optimize `myLocaleSpace` assignment in aggregators

### DIFF
--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -6,7 +6,7 @@ module CommAggregation {
   use CommPrimitives;
 
   // TODO should tune these values at startup
-  param defaultBuffSize = if CHPL_COMM == "ugni" then 4096 else 8096;
+  param defaultBuffSize = if CHPL_COMM == "ugni" then 4096 else 8192;
   private config const yieldFrequency = getEnvInt("ARKOUDA_SERVER_AGGREGATION_YIELD_FREQUENCY", 1024);
   private config const dstBuffSize = getEnvInt("ARKOUDA_SERVER_AGGREGATION_DST_BUFF_SIZE", defaultBuffSize);
   private config const srcBuffSize = getEnvInt("ARKOUDA_SERVER_AGGREGATION_SRC_BUFF_SIZE", defaultBuffSize);
@@ -39,7 +39,7 @@ module CommAggregation {
     type elemType;
     type aggType = (c_ptr(elemType), elemType);
     const bufferSize = dstBuffSize;
-    const myLocaleSpace = LocaleSpace;
+    const myLocaleSpace = 0..<numLocales;
     var opsUntilYield = yieldFrequency;
     var lBuffers: c_ptr(c_ptr(aggType));
     var rBuffers: [myLocaleSpace] remoteBuffer(aggType);
@@ -151,7 +151,7 @@ module CommAggregation {
     type elemType;
     type aggType = c_ptr(elemType);
     const bufferSize = srcBuffSize;
-    const myLocaleSpace = LocaleSpace;
+    const myLocaleSpace = 0..<numLocales;
     var opsUntilYield = yieldFrequency;
     var dstAddrs: c_ptr(c_ptr(aggType));
     var lSrcAddrs: c_ptr(c_ptr(aggType));


### PR DESCRIPTION
Change `myLocaleSpace = LocaleSpace` to `myLocaleSpace = 0..<numLocales`
to eliminate communication when creating aggregators. `LocaleSpace`
lives on locale 0, so there was some communication to copy it. Using
`numLocales` eliminates that because `numLocales` is just an `int` that
is replicated at program startup. This eliminates a many-to-one GET that
may have a minor performance benefit, particularly at scale.

While here, also change the non-ugni default buffer size from `8096` to
`8192`. I meant for this to be a power of two in #732 but either made a
typo or a think-o.

I expect some minor performance benefits from these changes on
InfiniBand system.

Resolves #1081