### PR TITLE
Add in1d and setops support for uint pdarrays

### DIFF
--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -7,6 +7,7 @@ from arkouda.pdarraycreation import zeros, zeros_like, array
 from arkouda.sorting import argsort
 from arkouda.strings import Strings
 from arkouda.logger import getArkoudaLogger
+from arkouda.dtypes import uint64 as akuint64
 
 Categorical = ForwardRef('Categorical')
 
@@ -371,7 +372,8 @@ def intersect1d(pda1 : pdarray, pda2 : pdarray,
         return pda1 # nothing in the intersection
     if pda2.size == 0:
         return pda2 # nothing in the intersection
-    if pda1.dtype == int and pda2.dtype == int:
+    if (pda1.dtype == int and pda2.dtype == int) or \
+       (pda1.dtype == akuint64 and pda2.dtype == akuint64):
         repMsg = generic_msg(cmd="intersect1d", args="{} {} {}".\
                              format(pda1.name, pda2.name, assume_unique))
         return create_pdarray(cast(str,repMsg))
@@ -435,7 +437,8 @@ def setdiff1d(pda1 : pdarray, pda2 : pdarray,
         return pda1 # return a zero length pdarray
     if pda2.size == 0:
         return pda1 # subtracting nothing return orig pdarray
-    if pda1.dtype == int and pda2.dtype == int:
+    if (pda1.dtype == int and pda2.dtype == int) or \
+       (pda1.dtype == akuint64 and pda2.dtype == akuint64):
         repMsg = generic_msg(cmd="setdiff1d", args="{} {} {}".\
                             format(pda1.name, pda2.name, assume_unique))
         return create_pdarray(cast(str,repMsg))
@@ -492,7 +495,8 @@ def setxor1d(pda1 : pdarray, pda2 : pdarray,
         return pda2 # return other pdarray if pda1 is empty
     if pda2.size == 0:
         return pda1 # return other pdarray if pda2 is empty
-    if pda1.dtype == int and pda2.dtype == int:
+    if (pda1.dtype == int and pda2.dtype == int) or \
+       (pda1.dtype == akuint64 and pda2.dtype == akuint64):
         repMsg = generic_msg(cmd="setxor1d", args="{} {} {}".\
                              format(pda1.name, pda2.name, assume_unique))
         return create_pdarray(cast(str,repMsg))

--- a/src/ArraySetops.chpl
+++ b/src/ArraySetops.chpl
@@ -21,7 +21,7 @@ module ArraySetops
     private config const mBound = 2**25; 
 
     // returns intersection of 2 arrays
-    proc intersect1d(a: [] int, b: [] int, assume_unique: bool) throws {
+    proc intersect1d(a: [] ?t, b: [] t, assume_unique: bool) throws {
       //if not unique, unique sort arrays then perform operation
       if (!assume_unique) {
         var a1  = uniqueSort(a, false);
@@ -45,7 +45,7 @@ module ArraySetops
     }
     
     // returns the exclusive-or of 2 arrays
-    proc setxor1d(a: [] int, b: [] int, assume_unique: bool) throws {
+    proc setxor1d(a: [] ?t, b: [] t, assume_unique: bool) throws {
       //if not unique, unique sort arrays then perform operation
       if (!assume_unique) {
         var a1  = uniqueSort(a, false);
@@ -82,7 +82,7 @@ module ArraySetops
     }
 
     // returns the set difference of 2 arrays
-    proc setdiff1d(a: [] int, b: [] int, assume_unique: bool) throws {
+    proc setdiff1d(a: [] ?t, b: [] t, assume_unique: bool) throws {
       //if not unique, unique sort arrays then perform operation
       if (!assume_unique) {
         var a1  = uniqueSort(a, false);
@@ -116,7 +116,7 @@ module ArraySetops
     // first concatenates the 2 arrays, then
     // sorts resulting array and ensures that
     // values are unique
-    proc union1d(a: [] int, b: [] int) throws {
+    proc union1d(a: [] ?t, b: [] t) throws {
       var aux;
       // Artificial scope to clean up temporary arrays
       {

--- a/src/ArraySetopsMsg.chpl
+++ b/src/ArraySetopsMsg.chpl
@@ -53,28 +53,34 @@ module ArraySetopsMsg
         var intersect_maxMem = max(gEnt_sortMem, gEnt2_sortMem);
         overMemLimit(intersect_maxMem);
 
-        select(gEnt.dtype) {
-          when (DType.Int64) {
-             if (gEnt.dtype != gEnt2.dtype) {
-                 var errorMsg = notImplementedError("newIntersect1d",gEnt2.dtype);
-                 asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                             
-                 return new MsgTuple(errorMsg, MsgType.ERROR);
-             }
-             var e = toSymEntry(gEnt,int);
-             var f = toSymEntry(gEnt2, int);
-             
-             var aV = intersect1d(e.a, f.a, isUnique);
-             st.addEntry(vname, new shared SymEntry(aV));
+        select(gEnt.dtype, gEnt2.dtype) {
+          when (DType.Int64, DType.Int64) {
+            var e = toSymEntry(gEnt,int);
+            var f = toSymEntry(gEnt2,int);
 
-             repMsg = "created " + st.attrib(vname);
-             asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-             return new MsgTuple(repMsg, MsgType.NORMAL);
-           }
-           otherwise {
-               var errorMsg = notImplementedError("newIntersect1d",gEnt.dtype);
-               asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
-               return new MsgTuple(errorMsg, MsgType.ERROR);
-           }
+            var aV = intersect1d(e.a, f.a, isUnique);
+            st.addEntry(vname, new shared SymEntry(aV));
+
+            repMsg = "created " + st.attrib(vname);
+            asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+            return new MsgTuple(repMsg, MsgType.NORMAL);
+          }
+          when (DType.UInt64, DType.UInt64) {
+            var e = toSymEntry(gEnt,uint);
+            var f = toSymEntry(gEnt2,uint);
+
+            var aV = intersect1d(e.a, f.a, isUnique);
+            st.addEntry(vname, new shared SymEntry(aV));
+
+            repMsg = "created " + st.attrib(vname);
+            asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+            return new MsgTuple(repMsg, MsgType.NORMAL);
+          }
+          otherwise {
+            var errorMsg = notImplementedError("intersect1d",gEnt.dtype);
+            asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+          }
         }
     }
 
@@ -103,15 +109,21 @@ module ArraySetopsMsg
         var xor_maxMem = max(gEnt_sortMem, gEnt2_sortMem);
         overMemLimit(xor_maxMem);
 
-        select(gEnt.dtype) {
-          when (DType.Int64) {
-             if(gEnt.dtype != gEnt2.dtype) {
-                 var errorMsg = notImplementedError("setxor1d",gEnt2.dtype);
-                 asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                 
-                 return new MsgTuple(errorMsg, MsgType.ERROR);
-             }
+        select(gEnt.dtype, gEnt2.dtype) {
+          when (DType.Int64, DType.Int64) {
              var e = toSymEntry(gEnt,int);
-             var f = toSymEntry(gEnt2, int);
+             var f = toSymEntry(gEnt2,int);
+             
+             var aV = setxor1d(e.a, f.a, isUnique);
+             st.addEntry(vname, new shared SymEntry(aV));
+
+             repMsg = "created " + st.attrib(vname);
+             asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+             return new MsgTuple(repMsg, MsgType.NORMAL);
+           }
+           when (DType.UInt64, DType.UInt64) {
+             var e = toSymEntry(gEnt,uint);
+             var f = toSymEntry(gEnt2,uint);
              
              var aV = setxor1d(e.a, f.a, isUnique);
              st.addEntry(vname, new shared SymEntry(aV));
@@ -153,15 +165,21 @@ module ArraySetopsMsg
         var diff_maxMem = max(gEnt_sortMem, gEnt2_sortMem);
         overMemLimit(diff_maxMem);
 
-        select(gEnt.dtype) {
-          when (DType.Int64) {
-             if (gEnt.dtype != gEnt2.dtype) {
-                 var errorMsg = notImplementedError("setdiff1d",gEnt2.dtype);
-                 asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                
-                 return new MsgTuple(errorMsg, MsgType.ERROR);             
-             }
+        select(gEnt.dtype, gEnt2.dtype) {
+          when (DType.Int64, DType.Int64) {
              var e = toSymEntry(gEnt,int);
              var f = toSymEntry(gEnt2, int);
+             
+             var aV = setdiff1d(e.a, f.a, isUnique);
+             st.addEntry(vname, new shared SymEntry(aV));
+
+             var repMsg = "created " + st.attrib(vname);
+             asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+             return new MsgTuple(repMsg, MsgType.NORMAL);
+           }
+           when (DType.UInt64, DType.UInt64) {
+             var e = toSymEntry(gEnt,uint);
+             var f = toSymEntry(gEnt2, uint);
              
              var aV = setdiff1d(e.a, f.a, isUnique);
              st.addEntry(vname, new shared SymEntry(aV));
@@ -202,15 +220,21 @@ module ArraySetopsMsg
       var union_maxMem = max(gEnt_sortMem, gEnt2_sortMem);
       overMemLimit(union_maxMem);
 
-      select(gEnt.dtype) {
-        when (DType.Int64) {
-           if (gEnt.dtype != gEnt2.dtype) {
-               var errorMsg = notImplementedError("newUnion1d",gEnt2.dtype);
-               asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                   
-               return new MsgTuple(errorMsg, MsgType.ERROR);              
-           }
+      select(gEnt.dtype, gEnt2.dtype) {
+        when (DType.Int64, DType.Int64) {
            var e = toSymEntry(gEnt,int);
-           var f = toSymEntry(gEnt2, int);
+           var f = toSymEntry(gEnt2,int);
+
+           var aV = union1d(e.a, f.a);
+           st.addEntry(vname, new shared SymEntry(aV));
+
+           var repMsg = "created " + st.attrib(vname);
+           asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+           return new MsgTuple(repMsg, MsgType.NORMAL);
+         }
+         when (DType.UInt64, DType.UInt64) {
+           var e = toSymEntry(gEnt,uint);
+           var f = toSymEntry(gEnt2,uint);
 
            var aV = union1d(e.a, f.a);
            st.addEntry(vname, new shared SymEntry(aV));

--- a/src/In1d.chpl
+++ b/src/In1d.chpl
@@ -24,12 +24,12 @@ module In1d
     :returns truth: the distributed boolean array containing the result of ar1 being broadcast over ar2
     :type truth: [] bool
     */
-    proc in1dAr2PerLocAssoc(ar1: [?aD1] int, ar2: [?aD2] int) {
+    proc in1dAr2PerLocAssoc(ar1: [?aD1] ?t, ar2: [?aD2] t) {
         var truth: [aD1] bool;
         
         coforall loc in Locales {
             on loc {
-                var ar2Set: domain(int, parSafe=false); // create a set to hold ar2, parSafe modification is OFF
+                var ar2Set: domain(t, parSafe=false); // create a set to hold ar2, parSafe modification is OFF
                 ar2Set.requestCapacity(ar2.size); // request a capacity for the initial set
 
                 for loc in offset(0..<numLocales) {
@@ -59,7 +59,7 @@ module In1d
        :returns truth: the distributed boolean array containing the result of ar1 being broadcast over ar2
        :type truth: [] bool
      */
-    proc in1dSort(ar1: [?aD1] int, ar2: [?aD2] int) throws  {
+    proc in1dSort(ar1: [?aD1] ?t, ar2: [?aD2] t) throws  {
         /* General strategy: unique both arrays, find the intersecting values, 
            then map back to the original domain of ar1.
          */
@@ -68,13 +68,13 @@ module In1d
         var (u2, c2) = uniqueSort(ar2);
         // Concatenate the two unique arrays
         const D = makeDistDom(u1.size + u2.size);
-        var ar: [D] int;
+        var ar: [D] t;
         /* ar[{0..#u1.size}] = u1; */
         ar[D.interior(-u1.size)] = u1;
         /* ar[{u1.size..#u2.size}] = u2; */
         ar[D.interior(u2.size)] = u2;
         // Sort unique arrays together to find duplicates
-        var sar: [D] int;
+        var sar: [D] t;
         var order: [D] int;
         forall (s, o, so) in zip(sar, order, radixSortLSD(ar)) {
           (s, o) = so;

--- a/src/In1dMsg.chpl
+++ b/src/In1dMsg.chpl
@@ -81,6 +81,32 @@ module In1dMsg
                     st.addEntry(rname, new shared SymEntry(truth));
                 }
             }
+            when (DType.UInt64, DType.UInt64) {
+                var ar1 = toSymEntry(gAr1,uint);
+                var ar2 = toSymEntry(gAr2,uint);
+
+                // things to do...
+                // if ar2 is big for some value of big... call unique on ar2 first
+
+                // per locale assoc domain if below medium bound
+                if (ar2.size <= mBound) {
+                    iLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                               "%t <= %t, using Ar2PerLocAssoc".format(ar2.size,mBound));                  
+                    var truth = in1dAr2PerLocAssoc(ar1.a, ar2.a);
+                    if (invert) {truth = !truth;}
+                    
+                    st.addEntry(rname, new shared SymEntry(truth));
+                }
+                // sort-based strategy if above medium bound
+                else {
+                    iLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                          "%t > %t, using sort-based strategy".format(ar2.size, mBound));
+                    var truth = in1dSort(ar1.a, ar2.a);
+                    if (invert) {truth = !truth;}
+
+                    st.addEntry(rname, new shared SymEntry(truth));
+                }
+            }
             otherwise {
                 var errorMsg = notImplementedError(pn,gAr1.dtype,"in",gAr2.dtype);
                 iLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);

--- a/src/Indexing.chpl
+++ b/src/Indexing.chpl
@@ -41,9 +41,9 @@ module Indexing {
         overMemLimit(numBytes(int) * truth.size);
         var iv: [truth.domain] int = (+ scan truth);
         var pop = iv[iv.size-1];
-        var ret = makeDistArray(pop, int);
+        var ret = makeDistArray(pop, t);
 
-        forall (i, eai) in zip(a.domain, a) with (var agg = newDstAggregator(int)) {
+        forall (i, eai) in zip(a.domain, a) with (var agg = newDstAggregator(t)) {
           if (truth[i]) {
             agg.copy(ret[iv[i]-1], eai);
           }

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -73,12 +73,12 @@ module UniqueMsg
                 overMemLimit(radixSortLSD_memEst(gEnt.size, gEnt.itemsize));
         
                 select (gEnt.dtype) {
-                    when (DType.Int64) {
+                  when (DType.Int64) {
                     var e = toSymEntry(gEnt,int);
-                
+
                     /* var eMin:int = min reduce e.a; */
                     /* var eMax:int = max reduce e.a; */
-                
+
                     /* // how many bins in histogram */
                     /* var bins = eMax-eMin+1; */
                     /* umLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
@@ -103,14 +103,22 @@ module UniqueMsg
                     st.addEntry(vname, new shared SymEntry(aV));
                     if returnCounts {
                         st.addEntry(cname, new shared SymEntry(aC));
-                    }                  
+                    }
+                  } when (DType.UInt64) {
+                    var e = toSymEntry(gEnt,uint);
+
+                    var (aV,aC) = uniqueSort(e.a);
+                    st.addEntry(vname, new shared SymEntry(aV));
+                    if returnCounts {
+                        st.addEntry(cname, new shared SymEntry(aC));
+                    }
+                  }
+                  otherwise {
+                      var errorMsg = notImplementedError("unique",gEnt.dtype);
+                      umLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                
+                      return new MsgTuple(errorMsg, MsgType.ERROR);
+                  }
                 }
-                otherwise {
-                    var errorMsg = notImplementedError("unique",gEnt.dtype);
-                    umLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                
-                    return new MsgTuple(errorMsg, MsgType.ERROR);
-                }
-            }
         
             repMsg = "created " + st.attrib(vname);
 

--- a/tests/setops_test.py
+++ b/tests/setops_test.py
@@ -5,10 +5,17 @@ from base_test import ArkoudaTest
 SIZE = 10
 OPS = frozenset(['intersect1d', 'union1d', 'setxor1d', 'setdiff1d'])
 
-def make_arrays():
-    a = ak.randint(0, SIZE, SIZE)
-    b = ak.randint(SIZE/2, 2*SIZE, SIZE)
-    return a, b
+TYPES = ('int64', 'uint64')
+
+def make_arrays(dtype):
+    if dtype == 'int64':
+        a = ak.randint(0, SIZE, SIZE)
+        b = ak.randint(SIZE/2, 2*SIZE, SIZE)
+        return a, b
+    elif dtype == 'uint64':
+        a = ak.randint(0, SIZE, SIZE, dtype=ak.uint64)
+        b = ak.randint(SIZE/2, 2*SIZE, SIZE, dtype=ak.uint64)
+        return a, b
 
 def compare_results(akvals, npvals) -> int:
     '''
@@ -37,28 +44,28 @@ def run_test(verbose=True):
     on a randomized set of arrays. 
     :return: 
     '''
-    aka, akb = make_arrays()
-
     tests = 0
     failures = 0
     not_impl = 0
-    
-    for op in OPS:
-        tests += 1
-        do_check = True
-        try:
-            fxn = getattr(ak, op)
-            akres = fxn(aka,akb)
-            fxn = getattr(np, op)
-            npres = fxn(aka.to_ndarray(), akb.to_ndarray())
-        except RuntimeError as E:
-            if verbose: print("Arkouda error: ", E)
-            not_impl += 1
-            do_check = False
-            continue
-        if not do_check:
-            continue
-        failures += compare_results(akres, npres)
+
+    for dtype in TYPES:
+        aka, akb = make_arrays(dtype)
+        for op in OPS:
+            tests += 1
+            do_check = True
+            try:
+                fxn = getattr(ak, op)
+                akres = fxn(aka,akb)
+                fxn = getattr(np, op)
+                npres = fxn(aka.to_ndarray(), akb.to_ndarray())
+            except RuntimeError as E:
+                if verbose: print("Arkouda error: ", E)
+                not_impl += 1
+                do_check = False
+                continue
+            if not do_check:
+                continue
+            failures += compare_results(akres, npres)
     
     return failures
 


### PR DESCRIPTION
This PR adds support for `in1d`, `setdiff1d`, `setxor1d`,
`union`, `intersect1d`, `concatenate`, and `unique` for 
`uint` pdarrays.

The testing in `tests/setops_test.py` has been extended to
account for the new `uint` support.