### PR TITLE
Update tests and benchmarks correctness tests for uint and add uint docs

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1890,7 +1890,7 @@ def popcount(pda: pdarray) -> pdarray:
 
     Parameters
     ----------
-    pda : pdarray, int64
+    pda : pdarray, int64, uint64
         Input array (must be integral).
 
     Returns
@@ -1901,7 +1901,7 @@ def popcount(pda: pdarray) -> pdarray:
     Raises
     ------
     TypeError
-        If input array is not int64
+        If input array is not int64 or uint64
     
     Examples
     --------
@@ -1920,7 +1920,7 @@ def parity(pda: pdarray) -> pdarray:
 
     Parameters
     ----------
-    pda : pdarray, int64
+    pda : pdarray, int64, uint64
         Input array (must be integral).
 
     Returns
@@ -1931,7 +1931,7 @@ def parity(pda: pdarray) -> pdarray:
     Raises
     ------
     TypeError
-        If input array is not int64
+        If input array is not int64 or uint64
     
     Examples
     --------
@@ -1950,7 +1950,7 @@ def clz(pda: pdarray) -> pdarray:
 
     Parameters
     ----------
-    pda : pdarray, int64
+    pda : pdarray, int64, uint64
         Input array (must be integral).
 
     Returns
@@ -1961,7 +1961,7 @@ def clz(pda: pdarray) -> pdarray:
     Raises
     ------
     TypeError
-        If input array is not int64
+        If input array is not int64 or uint64
     
     Examples
     --------
@@ -1980,7 +1980,7 @@ def ctz(pda: pdarray) -> pdarray:
 
     Parameters
     ----------
-    pda : pdarray, int64
+    pda : pdarray, int64, uint64
         Input array (must be integral).
 
     Returns
@@ -1995,7 +1995,7 @@ def ctz(pda: pdarray) -> pdarray:
     Raises
     ------
     TypeError
-        If input array is not int64
+        If input array is not int64 or uint64
     
     Examples
     --------

--- a/benchmarks/IO.py
+++ b/benchmarks/IO.py
@@ -5,7 +5,7 @@ import arkouda as ak
 import os
 from glob import glob
 
-TYPES = ('int64', 'float64')
+TYPES = ('int64', 'float64', 'uint64',)
 
 def time_ak_write(N_per_locale, numfiles, trials, dtype, path, seed, parquet):
     print(">>> arkouda {} write".format(dtype))
@@ -16,6 +16,8 @@ def time_ak_write(N_per_locale, numfiles, trials, dtype, path, seed, parquet):
         a = ak.randint(0, 2**32, N, seed=seed)
     elif dtype == 'float64':
         a = ak.randint(0, 1, N, dtype=ak.float64, seed=seed)
+    elif dtype == 'uint64':
+        a = ak.randint(0, 2**32, N, dtype=ak.uint64, seed=seed)
     
     writetimes = []
     for i in range(trials):
@@ -57,8 +59,6 @@ def remove_files(path):
 
 def check_correctness(dtype, path, seed, parquet, multifile=False):
     N = 10**4
-    a = []
-    b = []
     if dtype == 'int64':
         a = ak.randint(0, 2**32, N, seed=seed)
         if multifile:
@@ -67,11 +67,17 @@ def check_correctness(dtype, path, seed, parquet, multifile=False):
         a = ak.randint(0, 1, N, dtype=ak.float64, seed=seed)
         if multifile:
             b = ak.randint(0, 1, N, dtype=ak.float64, seed=seed)
+    elif dtype == 'uint64':
+        a = ak.randint(0, 1, N, dtype=ak.uint64, seed=seed)
+        if multifile:
+            b = ak.randint(0, 1, N, dtype=ak.uint64, seed=seed)
 
     a.save(f"{path}{1}") if not parquet else a.save_parquet(f"{path}{1}")
     if multifile:
         b.save(f"{path}{2}") if not parquet else b.save_parquet(f"{path}{2}")
+
     c = ak.read_all(path+'*') if not parquet else ak.read_parquet(path+'*')
+    
     for f in glob(path+"*"):
         os.remove(f)
     if not multifile:

--- a/benchmarks/array_create.py
+++ b/benchmarks/array_create.py
@@ -5,7 +5,7 @@ import numpy as np
 import arkouda as ak
 
 OPS = ('zeros', 'ones', 'randint')
-TYPES = ('int64', 'float64')
+TYPES = ('int64', 'float64', 'uint64')
 
 def create_ak_array(N, op, dtype, seed):
     if op == 'zeros': 
@@ -28,6 +28,8 @@ def create_np_array(N, op, dtype, seed):
             a = np.random.randint(1, N, N)
         elif dtype == 'float64':
             a = np.random.random(N) + 0.5
+        elif dtype == 'uint64':
+            a = np.random.randint(1, N, N, 'uint64')
     return a
 
 def time_ak_array_create(N_per_locale, trials, dtype, random, seed):

--- a/benchmarks/in1d.py
+++ b/benchmarks/in1d.py
@@ -3,20 +3,26 @@
 import time, argparse
 import arkouda as ak
 
+TYPES = ('int64', 'uint64')
+
 # Must be less than src/In1dMsg.chpl:mbound, which defaults to 2**25
 MEDIUM = 2**25 - 1
 # Must be greater than mbound
 LARGE = 2**25 + 1
 
-def time_ak_in1d(size, trials):
-    print(">>> arkouda int64 in1d")
+def time_ak_in1d(size, trials, dtype):
+    print(f">>> arkouda {dtype} in1d")
     cfg = ak.get_config()
     N = size * cfg["numLocales"]
     a = ak.arange(N) % LARGE
+    if dtype == 'uint64':
+        a = ak.cast(a, ak.uint64)
 
     for regime, bsize in zip(('Medium', 'Large'), (MEDIUM, LARGE)):
         print("{} regime: numLocales = {}  a.size = {:,}  b.size = {:,}".format(regime, cfg["numLocales"], N, bsize))
         b = ak.arange(bsize)
+        if dtype == 'uint64':
+            b = ak.cast(b, ak.uint64)
         expected_misses = (LARGE - bsize) * (a.size // LARGE) + max((0, (a.size % LARGE) - bsize))
         timings = []
         for _ in range(trials):
@@ -30,11 +36,15 @@ def time_ak_in1d(size, trials):
         bytes_per_sec = (a.size * a.itemsize + b.size * b.itemsize) / tavg
         print("{} average rate = {:.2f} GiB/sec".format(regime, bytes_per_sec/2**30))
 
-def check_correctness():
+def check_correctness(dtype):
     asize = 10**4
     bsize = 10**3
     a = ak.arange(asize)
+    if dtype == 'uint64':
+        a = ak.cast(a, ak.uint64)
     b = ak.arange(bsize)
+    if dtype == 'uint64':
+        b = ak.cast(b, ak.uint64)
     c = ak.in1d(a, b)
     assert c.sum() == bsize, "Incorrect result"
 
@@ -43,6 +53,7 @@ def create_parser():
     parser.add_argument('hostname', help='Hostname of arkouda server')
     parser.add_argument('port', type=int, help='Port of arkouda server')
     parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: length of array a')
+    parser.add_argument('-d', '--dtype', default='int64', help='Dtype of array ({})'.format(', '.join(TYPES)))
     parser.add_argument('-t', '--trials', type=int, default=3, help='Number of times to run the benchmark')
     parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
     return parser
@@ -51,14 +62,17 @@ if __name__ == "__main__":
     import sys
     parser = create_parser()
     args = parser.parse_args()
+    if args.dtype not in TYPES:
+        raise ValueError("Dtype must be {}, not {}".format('/'.join(TYPES), args.dtype))
     ak.verbose = False
     ak.connect(args.hostname, args.port)
 
     if args.correctness_only:
-        check_correctness()
+        for dtype in TYPES:
+            check_correctness(dtype)
         sys.exit(0)
     
     print("problem size per node = {:,}".format(args.size))
     print("number of trials = ", args.trials)
-    time_ak_in1d(args.size, args.trials)    
+    time_ak_in1d(args.size, args.trials, args.dtype)    
     sys.exit(0)

--- a/benchmarks/multiIO.py
+++ b/benchmarks/multiIO.py
@@ -3,7 +3,7 @@
 import argparse
 from IO import *
 
-TYPES = ('int64', 'float64')
+TYPES = ('int64', 'float64', 'uint64',)
 
 def create_parser():
     parser = argparse.ArgumentParser(description="Measure performance of writing and reading a random array from disk.")

--- a/benchmarks/parquetIO.py
+++ b/benchmarks/parquetIO.py
@@ -3,7 +3,7 @@
 import argparse
 from IO import *
 
-TYPES = ('int64',)
+TYPES = ('int64', 'uint64',)
 
 def create_parser():
     parser = argparse.ArgumentParser(description="Measure performance of Parquet reads/writes.")

--- a/benchmarks/parquetMultiIO.py
+++ b/benchmarks/parquetMultiIO.py
@@ -3,7 +3,7 @@
 import argparse
 from multiIO import *
 
-TYPES = ('int64',)
+TYPES = ('int64', 'uint64')
 
 def create_parser():
     parser = argparse.ArgumentParser(description="Measure performance of writing and reading a random array from disk.")

--- a/benchmarks/setops.py
+++ b/benchmarks/setops.py
@@ -5,7 +5,7 @@ import numpy as np
 import arkouda as ak
 
 OPS = ('intersect1d', 'union1d', 'setxor1d', 'setdiff1d')
-TYPES = ('int64',)
+TYPES = ('int64','uint64',)
 
 def time_ak_setops(N_per_locale, trials, dtype, seed):
     print(">>> arkouda {} setops".format(dtype))
@@ -15,6 +15,9 @@ def time_ak_setops(N_per_locale, trials, dtype, seed):
     if dtype == 'int64':
         a = ak.randint(0, 2**32, N, seed=seed)
         b = ak.randint(0, 2**32, N, seed=seed)
+    elif dtype == 'uint64':
+        a = ak.randint(0, 2**32, N, seed=seed, dtype=ak.uint64)
+        b = ak.randint(0, 2**32, N, seed=seed, dtype=ak.uint64)
     
     timings = {op: [] for op in OPS}
     results = {}
@@ -41,6 +44,9 @@ def time_np_setops(N, trials, dtype, seed):
     if dtype == 'int64':
         a = np.random.randint(0, 2**32, N)
         b = np.random.randint(0, 2**32, N)
+    elif dtype == 'uint64':
+        a = np.random.randint(0, 2**32, N, 'uint64')
+        b = np.random.randint(0, 2**32, N, 'uint64')
         
     timings = {op: [] for op in OPS}
     results = {}
@@ -66,6 +72,9 @@ def check_correctness(dtype, seed):
     if dtype == 'int64':
         a = np.random.randint(0, 2**32, N)
         b = np.random.randint(0, 2**32, N)
+    if dtype == 'uint64':
+        a = np.random.randint(0, 2**32, N, dtype=ak.uint64)
+        b = np.random.randint(0, 2**32, N, dtype=ak.uint64)
 
     for op in OPS:
         npa = a

--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -15,6 +15,7 @@ extern "C" {
 #define ARROWINT64 0
 #define ARROWINT32 1
 #define ARROWUINT64 2
+#define ARROWUINT32 3
 #define ARROWTIMESTAMP ARROWINT64
 #define ARROWUNDEFINED -1
 #define ARROWERROR -1

--- a/tests/bitops_test.py
+++ b/tests/bitops_test.py
@@ -5,7 +5,10 @@ class BitOpsTest(ArkoudaTest):
     def setUp(self):
         ArkoudaTest.setUp(self)
         self.a = ak.arange(10)
+        self.b = ak.cast(self.a, ak.uint64)
         self.edgeCases = ak.array([-(2**63), -1, 2**63 - 1])
+        self.edgeCasesUint = ak.cast(ak.array([-(2**63), -1, 2**63 - 1]), \
+                                     ak.uint64)
     
     def test_popcount(self):
         # Method invocation
@@ -13,10 +16,21 @@ class BitOpsTest(ArkoudaTest):
         p = self.a.popcount()
         ans = ak.array([0, 1, 1, 2, 1, 2, 2, 3, 1, 2])
         self.assertTrue((p == ans).all())
+
+        # Test uint case
+        p = self.b.popcount()
+        ans = ak.cast(ans, ak.uint64)
+        self.assertTrue((p == ans).all())
+        
         # Function invocation
         # Edge case input
         p = ak.popcount(self.edgeCases)
         ans = ak.array([1, 64, 63])
+        self.assertTrue((p == ans).all())
+
+        # Test uint case
+        p = ak.popcount(self.edgeCasesUint)
+        ans = ak.cast(ans, ak.uint64)
         self.assertTrue((p == ans).all())
 
     def test_parity(self):
@@ -24,8 +38,18 @@ class BitOpsTest(ArkoudaTest):
         ans = ak.array([0, 1, 1, 0, 1, 0, 0, 1, 1, 0])
         self.assertTrue((p == ans).all())
 
+        # Test uint case
+        p = self.b.parity()
+        ans = ak.cast(ans, ak.uint64)
+        self.assertTrue((p == ans).all())
+
         p = ak.parity(self.edgeCases)
         ans = ak.array([1, 0, 1])
+        self.assertTrue((p == ans).all())
+
+        # Test uint case
+        p = ak.parity(self.edgeCasesUint)
+        ans = ak.cast(ans, ak.uint64)
         self.assertTrue((p == ans).all())
 
     def test_clz(self):
@@ -33,8 +57,18 @@ class BitOpsTest(ArkoudaTest):
         ans = ak.array([64, 63, 62, 62, 61, 61, 61, 61, 60, 60])
         self.assertTrue((p == ans).all())
 
+        # Test uint case
+        p = self.b.clz()
+        ans = ak.cast(ans, ak.uint64)
+        self.assertTrue((p == ans).all())
+
         p = ak.clz(self.edgeCases)
         ans = ak.array([0, 0, 1])
+        self.assertTrue((p == ans).all())
+
+        # Test uint case
+        p = ak.clz(self.edgeCasesUint)
+        ans = ak.cast(ans, ak.uint64)
         self.assertTrue((p == ans).all())
 
     def test_ctz(self):
@@ -42,8 +76,18 @@ class BitOpsTest(ArkoudaTest):
         ans = ak.array([0, 0, 1, 0, 2, 0, 1, 0, 3, 0])
         self.assertTrue((p == ans).all())
 
+        # Test uint case
+        p = self.b.ctz()
+        ans = ak.cast(ans, ak.uint64)
+        self.assertTrue((p == ans).all())
+
         p = ak.ctz(self.edgeCases)
         ans = ak.array([63, 0, 0])
+        self.assertTrue((p == ans).all())
+
+        # Test uint case
+        p = ak.ctz(self.edgeCasesUint)
+        ans = ak.cast(ans, ak.uint64)
         self.assertTrue((p == ans).all())
 
     def test_dtypes(self):

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -12,7 +12,7 @@ class NumericTest(ArkoudaTest):
     def testSeededRNG(self):
         N = 100
         seed = 8675309
-        numericdtypes = [ak.int64, ak.float64, ak.bool]
+        numericdtypes = [ak.int64, ak.float64, ak.bool, ak.uint64]
         for dt in numericdtypes:
             # Make sure unseeded runs differ
             a = ak.randint(0, 2**32, N, dtype=dt)
@@ -123,6 +123,13 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
 
         self.assertTrue((np.cumsum(na) == ak.cumsum(pda).to_ndarray()).all())
+
+        # Test uint case
+        na = np.linspace(1,10,10, 'uint64')
+        pda = ak.cast(pda, ak.uint64)
+        
+        self.assertTrue((np.cumsum(na) == ak.cumsum(pda).to_ndarray()).all())
+        
         with self.assertRaises(TypeError) as cm:
             ak.cumsum([range(0,10)])
         self.assertEqual('type of argument "pda" must be arkouda.pdarrayclass.pdarray; got list instead', 

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -4,36 +4,57 @@ from base_test import ArkoudaTest
 import numpy as np
 import pytest
 
+TYPES = ('int64', 'uint64')
 SIZE = 100
 NUMFILES = 5
 verbose = True
 
+def read_write_test(dtype):
+    if dtype == 'int64':
+        ak_arr = ak.randint(0, 2**32, SIZE)
+    elif dtype =='uint64':
+        ak_arr = ak.randint(0, 2**32, SIZE, dtype=ak.uint64)
+        
+    ak_arr.save_parquet("pq_testcorrect", "my-dset")
+    pq_arr = ak.read_parquet("pq_testcorrect*", "my-dset")
+    
+    for f in glob.glob('pq_test*'):
+        os.remove(f)
+
+    return ak_arr, pq_arr
+
+def read_write_multi_test(dtype):
+    adjusted_size = int(SIZE/NUMFILES)*NUMFILES
+    test_arrs = []
+    if dtype == 'int64':
+        elems = ak.randint(0, 2**32, adjusted_size)
+    elif dtype == 'uint64':
+        elems = ak.randint(0, 2**32, adjusted_size, dtype=ak.uint64)
+        
+    per_arr = int(adjusted_size/NUMFILES)
+    for i in range(NUMFILES):
+        test_arrs.append(elems[(i*per_arr):(i*per_arr)+per_arr])
+        test_arrs[i].save_parquet(f"pq_test{i:04d}", "test-dset")
+
+    pq_arr = ak.read_parquet("pq_test*", "test-dset")
+    
+    for f in glob.glob('pq_test*'):
+        os.remove(f)
+
+    return elems, pq_arr
+    
+
 @pytest.mark.skipif(not os.getenv('ARKOUDA_SERVER_PARQUET_SUPPORT'), reason="No parquet support")
 class ParquetTest(ArkoudaTest):
     def test_parquet(self):
-        ak_arr = ak.randint(0, 2**32, SIZE)
-        ak_arr.save_parquet("pq_testcorrect", "my-dset")
-        pq_arr = ak.read_parquet("pq_testcorrect*", "my-dset")
-        self.assertTrue((ak_arr ==  pq_arr).all())
-        
-        for f in glob.glob('pq_test*'):
-            os.remove(f)
+        for dtype in TYPES:
+            (ak_arr, pq_arr) = read_write_test(dtype)
+            self.assertTrue((ak_arr ==  pq_arr).all())
 
     def test_multi_file(self):
-        adjusted_size = int(SIZE/NUMFILES)*NUMFILES
-        test_arrs = []
-        elems = ak.randint(0, 2**32, adjusted_size)
-        per_arr = int(adjusted_size/NUMFILES)
-        for i in range(NUMFILES):
-            test_arrs.append(elems[(i*per_arr):(i*per_arr)+per_arr])
-            test_arrs[i].save_parquet(f"pq_test{i:04d}", "test-dset")
-
-        pq_arr = ak.read_parquet("pq_test*", "test-dset")
-
-        self.assertTrue((elems == pq_arr).all())
-
-        for f in glob.glob('pq_test*'):
-            os.remove(f)
+        for dtype in TYPES:
+            (ak_arr, pq_arr) = read_write_multi_test(dtype)
+            self.assertTrue((ak_arr ==  pq_arr).all())
 
     def test_wrong_dset_name(self):
         ak_arr = ak.randint(0, 2**32, SIZE)
@@ -45,4 +66,18 @@ class ParquetTest(ArkoudaTest):
 
         for f in glob.glob("pq_test*"):
             os.remove(f)
-        
+
+    def test_max_read_write(self):
+        for dtype in TYPES:
+            if dtype == 'int64':
+                val = np.iinfo(np.int64).max
+            elif dtype == 'uint64':
+                val = np.iinfo(np.uint64).max
+            a = ak.array([val])
+            a.save_parquet("pq_test", 'test-dset')
+            ak_res = ak.read_parquet("pq_test*", 'test-dset')
+            self.assertTrue(ak_res[0] == val)
+
+            for f in glob.glob('pq_test*'):
+                os.remove(f)
+

--- a/tests/sort_test.py
+++ b/tests/sort_test.py
@@ -13,6 +13,11 @@ class SortTest(ArkoudaTest):
             spda = ak.sort(pda, algo)
             maxIndex = spda.argmax()
             self.assertTrue(maxIndex > 0)
+        
+        pda = ak.randint(0,100,100,dtype=ak.uint64)
+        for algo in ak.SortingAlgorithm:
+            spda = ak.sort(pda, algo)
+            assert ak.is_sorted(spda)
 
     def testBitBoundaryHardcode(self):
 


### PR DESCRIPTION
In the rush to get the uint support into Arkouda, the tests/benchmarks/
docs got slightly neglected, so this PR fills in some of those gaps.
All benchmarks with supported options have had their dtypes updated
to reflect uint support and also several unit tests have been updated
to reflect their new uint support, such as the sorting test, bitops
test, setops test, and numeric test.

Also in this PR are minor fixes from the initial uint PR:
* fixing `sorting.py` to return the correct dtype for an empty array
* removing duplicate logic in `ArrowFunctions.cpp` for uint reading