### PR TITLE
Fix `computeOnSegments` when there's more locales than strings

### DIFF
--- a/src/SegmentedComputation.chpl
+++ b/src/SegmentedComputation.chpl
@@ -50,7 +50,7 @@ module SegmentedComputation {
     coforall loc in Locales {
       on loc {
         const myFirstSegIdx = startSegInds[loc.id];
-        const myNumSegs = numSegs[loc.id];
+        const myNumSegs = max(0, numSegs[loc.id]);
         const mySegInds = {myFirstSegIdx..#myNumSegs};
         // Segment offsets whose bytes are owned by loc
         // Lengths of segments whose bytes are owned by loc


### PR DESCRIPTION
Many tests were failing in nightly 16 locale testing after #1060. This
was caused by trying to hash fewer strings than there were locales. The
empty locales should be a no-op, but ended up trying to do a count with
a negative value, which isn't supported on ranges without a high bound.
Fix that by just making the number of segments 0 if it was negative.

Alternatively we could skip further computation if the size is 0, but
that adds an extra level of indentation, which didn't seem worthwhile.
The operations will be no-ops anyways so it shouldn't matter.

Resolves #1093