### PR TITLE
Switch `SymEntry` to use const domains

### DIFF
--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -183,7 +183,7 @@ module MultiTypeSymEntry
         'aD' is the distributed domain for 'a' whose value and type
         are defined by makeDistDom() to support varying distributions
         */
-        var aD: makeDistDom(size).type;
+        const aD: makeDistDom(size).type;
         var a: [aD] etype;
         
         /*


### PR DESCRIPTION
Arkouda arrays are never resized so there's no reason for the domains to
not be const. Making them const allows Chapel to skip some tracking code
that's used for potential array resizing, so this slightly optimizes
array creation and deletion.

For more information on this optimization see the content starting on
slide 25 of https://chapel-lang.org/releaseNotes/1.23/04-perf-opt.pdf.

Resolves #1083