### PR TITLE
Add compatibility shim for `Array.targetlocales`

### DIFF
--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -63,6 +63,20 @@ module AryUtil
         }
         return sorted;
     }
+
+    /*
+     * targetLocales compatibility wrapper. The parenthesis were dropped for
+     * chpl 1.26. Use the paren-less version if it's available, but drop back
+     * to paren version for older versions.
+     */
+    inline proc targetLocales(A: []) {
+        use Reflection;
+        if canResolveMethod(A, "targetLocales") {
+            return A.targetLocales;
+        } else {
+            return A.targetLocales();
+        }
+    }
     
     /*
       Returns stats on a given array in form (int,int,real,real,real).

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -11,6 +11,7 @@ module HDF5Msg {
     use SysCTypes;
     use Time only;
 
+    use AryUtil;
     use CommAggregation;
     use FileIO;
     use GenSymIO;
@@ -531,13 +532,13 @@ module HDF5Msg {
         where (MyDmap == Dmap.blockDist || MyDmap == Dmap.defaultRectangular)
     {
             h5Logger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                    "entry.a.targetLocales() = %t".format(A.targetLocales()));
+                    "entry.a.targetLocales = %t".format(targetLocales(A)));
             h5Logger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                     "Filedomains: %t".format(filedomains));
             h5Logger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                     "skips: %t".format(skips));
 
-            coforall loc in A.targetLocales() do on loc {
+            coforall loc in targetLocales(A) do on loc {
                 // Create local copies of args
                 var locFiles = filenames;
                 var locFiledoms = filedomains;
@@ -649,7 +650,7 @@ module HDF5Msg {
         (prefix,extension) = getFileMetadata(filename);
  
         // Generate the filenames based upon the number of targetLocales.
-        var filenames = generateFilenames(prefix, extension, A.targetLocales().size);
+        var filenames = generateFilenames(prefix, extension, targetLocales(A).size);
         
         // Generate a list of matching filenames to test against. 
         var matchingFilenames = getMatchingFilenames(prefix, extension);
@@ -697,7 +698,7 @@ module HDF5Msg {
         t1.clear();
         t1.start();
 
-        coforall (loc, idx) in zip(A.targetLocales(), filenames.domain) 
+        coforall (loc, idx) in zip(targetLocales(A), filenames.domain) 
              with (ref shuffleLeftIndices, ref shuffleRightIndices, 
                    ref isSingleString, ref endsWithCompleteString, ref charArraySize) do on loc {
              generateStringsMetadata(idx, shuffleLeftIndices, shuffleRightIndices, 
@@ -715,7 +716,7 @@ module HDF5Msg {
          * locale (2) prepare char and segment lists to be written (3) write each
          * list as a Chapel array to the open hdf5 file and (4) close the hdf5 file
          */
-        coforall (loc, idx) in zip(A.targetLocales(), filenames.domain) with 
+        coforall (loc, idx) in zip(targetLocales(A), filenames.domain) with 
                         (ref shuffleLeftIndices, ref shuffleRightIndices, 
                                                             ref charArraySize) do on loc {
                         
@@ -1073,7 +1074,7 @@ module HDF5Msg {
  
         // Generate the filenames based upon the number of targetLocales.
         // The segments array allocation determines where the bytes/values get written
-        var filenames = generateFilenames(prefix, extension, entry.offsetsEntry.a.targetLocales().size);
+        var filenames = generateFilenames(prefix, extension, targetLocales(entry.offsetsEntry.a).size);
         
         // Generate a list of matching filenames to test against. 
         var matchingFilenames = getMatchingFilenames(prefix, extension);
@@ -1088,7 +1089,7 @@ module HDF5Msg {
         const lastOffset = A[A.domain.high];
         const lastValIdx = ss.values.aD.high;
         // For each locale gather the string bytes corresponding to the offsets in its local domain
-        coforall (loc, idx) in zip(A.targetLocales(), filenames.domain) with (ref ss) do on loc {
+        coforall (loc, idx) in zip(targetLocales(A), filenames.domain) with (ref ss) do on loc {
             /*
              * Generate metadata such as file name, file id, and dataset name
              * for each file to be written
@@ -1124,7 +1125,7 @@ module HDF5Msg {
             }
 
             /*
-             * A.targetLocales() may return all locales depending on your domain distribution
+             * A.targetLocales may return all locales depending on your domain distribution
              * However, if your array size is less then all all locales then some will be empty,
              * so we need to handle empty local domains.
              */
@@ -1195,7 +1196,7 @@ module HDF5Msg {
         (prefix,extension) = getFileMetadata(filename);
 
         // Generate the filenames based upon the number of targetLocales.
-        var filenames = generateFilenames(prefix, extension, A.targetLocales().size);
+        var filenames = generateFilenames(prefix, extension, targetLocales(A).size);
 
         //Generate a list of matching filenames to test against. 
         var matchingFilenames = getMatchingFilenames(prefix, extension);
@@ -1207,7 +1208,7 @@ module HDF5Msg {
          * locale (2) prepare pdarray(s) to be written (3) write pdarray(s) to open
          * hdf5 file and (4) close the hdf5 file
          */
-        coforall (loc, idx) in zip(A.targetLocales(), filenames.domain) do on loc {
+        coforall (loc, idx) in zip(targetLocales(A), filenames.domain) do on loc {
             const myFilename = filenames[idx];
 
             h5Logger.debug(getModuleName(),getRoutineName(),getLineNumber(),
@@ -1369,7 +1370,7 @@ module HDF5Msg {
               warnFlag = false;
           }
 
-          coforall loc in A.targetLocales() do on loc {
+          coforall loc in targetLocales(A) do on loc {
               var file_id: C_HDF5.hid_t;
 
               h5Logger.debug(getModuleName(),getRoutineName(),getLineNumber(),

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -93,7 +93,7 @@ module ParquetMsg {
     extern proc c_readColumnByName(filename, chpl_arr, colNum, numElems, batchSize, errMsg): int;
     var (subdoms, length) = getSubdomains(sizes);
     
-    coforall loc in A.targetLocales() do on loc {
+    coforall loc in targetLocales(A) do on loc {
       var locFiles = filenames;
       var locFiledoms = subdoms;
       forall (filedom, filename) in zip(locFiledoms, locFiles) {
@@ -146,9 +146,9 @@ module ParquetMsg {
     extern proc c_writeColumnToParquet(filename, chpl_arr, colnum,
                                        dsetname, numelems, rowGroupSize,
                                        dtype, errMsg): int;
-    var filenames: [0..#A.targetLocales().size] string;
+    var filenames: [0..#targetLocales(A).size] string;
     var dtypeRep = if dtype == "int64" then 1 else 2;
-    for i in 0..#A.targetLocales().size {
+    for i in 0..#targetLocales(A).size {
       var suffix = '%04i'.format(i): string;
       filenames[i] = filename + "_LOCALE" + suffix + ".parquet";
     }
@@ -156,7 +156,7 @@ module ParquetMsg {
 
     var warnFlag = processParquetFilenames(filenames, matchingFilenames);
     
-    coforall (loc, idx) in zip(A.targetLocales(), filenames.domain) do on loc {
+    coforall (loc, idx) in zip(targetLocales(A), filenames.domain) do on loc {
         var pqErr = new parquetErrorMsg();
         const myFilename = filenames[idx];
 

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -459,7 +459,7 @@ module SegmentedArray {
                                                                                var fullMatchBoolAgg = newDstAggregator(bool),
                                                                                var numMatchAgg = newDstAggregator(int)) {
         var matchessize = 0;
-        for m in myRegex.matches(interpretAsString(origVals, off..#len, borrow=true), captures=regexMaxCaptures) {
+        for m in myRegex.matches(interpretAsString(origVals, off..#len, borrow=true), regexMaxCaptures) {
           var match = m[0]; // v1.24.x -> reMatch, v1.25.x -> regexMatch
           var group = m[groupNum];
           if group.offset != -1 {


### PR DESCRIPTION
`Array.targetLocales()` was changed to `Array.targetLocales` (dropped
paren) in chapel-lang/chapel#18930. Add a `targetLocales(Array)` wrapper
to select between the two methods to be compatible with either one.

While here,  make regex `matches` call compatible with chapel 1.26. For
the `matches` iterator, `captures` was renamed to `numCaptures` in
chapel-lang/chapel#19077. Adjust here to stop using the named argument
to be compatible with either name.

Resolves #1102