### PR TITLE
Add support for writing Parquet files with Snappy/RLE

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1044,7 +1044,8 @@ class pdarray:
                            format(self.name, dataset, m, json_array, self.dtype)))
 
     @typechecked
-    def save_parquet(self, prefix_path : str, dataset : str='array', mode : str='truncate') -> str:
+    def save_parquet(self, prefix_path : str, dataset : str='array', mode : str='truncate',
+                     compressed : bool = False) -> str:
         """
         Save the pdarray to Parquet. The result is a collection of Parquet files,
         one file per locale of the arkouda server, where each filename starts
@@ -1060,6 +1061,8 @@ class pdarray:
         mode : str {'truncate'}
             By default, truncate (overwrite) output files, if they exist.
             Append is currently not supported.
+        compressed : bool
+            By default, write without Snappy compression and RLE encoding.
 
         Returns
         -------
@@ -1114,8 +1117,9 @@ class pdarray:
             json_array = json.dumps([prefix_path])
         except Exception as e:
             raise ValueError(e)
-        return cast(str, generic_msg(cmd="writeParquet", args="{} {} {} {}".\
-                                     format(self.name, dataset, json_array, self.dtype)))
+        return cast(str, generic_msg(cmd="writeParquet", args="{} {} {} {} {}".\
+                                     format(self.name, dataset, json_array, self.dtype,
+                                            compressed)))
     
     @typechecked
     def register(self, user_defined_name: str) -> pdarray:

--- a/benchmarks/parquetIO.py
+++ b/benchmarks/parquetIO.py
@@ -19,6 +19,7 @@ def create_parser():
     parser.add_argument('-r', '--only-read', default=False, action='store_true', help="Only read the files; files will not be removed")
     parser.add_argument('-f', '--only-delete', default=False, action='store_true', help="Only delete files created from writing with this benchmark")
     parser.add_argument('-l', '--files-per-loc', type=int, default=1, help='Number of files to create per locale')
+    parser.add_argument('-c', '--compressed', default=False, action='store_true', help='Write with Snappy compression and RLE encoding')
     return parser
 
 if __name__ == "__main__":
@@ -39,11 +40,11 @@ if __name__ == "__main__":
     print("number of trials = ", args.trials)
 
     if args.only_write:
-        time_ak_write(args.size, args.files_per_loc, args.trials, args.dtype, args.path, args.seed, True)
+        time_ak_write(args.size, args.files_per_loc, args.trials, args.dtype, args.path, args.seed, True, args.compressed)
     elif args.only_read:
         time_ak_read(args.size, args.files_per_loc, args.trials, args.dtype, args.path, args.seed, True)
     else:
-        time_ak_write(args.size, args.files_per_loc, args.trials, args.dtype, args.path, args.seed, True)
+        time_ak_write(args.size, args.files_per_loc, args.trials, args.dtype, args.path, args.seed, True, args.compressed)
         time_ak_read(args.size, args.files_per_loc, args.trials, args.dtype, args.path, args.seed, True)
         remove_files(args.path)
     

--- a/benchmarks/parquetMultiIO.py
+++ b/benchmarks/parquetMultiIO.py
@@ -19,6 +19,7 @@ def create_parser():
     parser.add_argument('-r', '--only-read', default=False, action='store_true', help="Only read the files; files will not be removed")
     parser.add_argument('-f', '--only-delete', default=False, action='store_true', help="Only delete files created from writing with this benchmark")
     parser.add_argument('-l', '--files-per-loc', type=int, default=10, help='Number of files to create per locale')
+    parser.add_argument('-c', '--compressed', default=False, action='store_true', help='Write with Snappy compression and RLE encoding')
     return parser
 
 if __name__ == "__main__":
@@ -39,13 +40,13 @@ if __name__ == "__main__":
     print("number of trials = ", args.trials)
 
     if args.only_write:
-        time_ak_write(args.size, args.files_per_loc, args.trials, args.dtype, args.path, args.seed, True)
+        time_ak_write(args.size, args.files_per_loc, args.trials, args.dtype, args.path, args.seed, True, args.compressed)
     elif args.only_read:
         time_ak_read(args.size, args.files_per_loc, args.trials, args.dtype, args.path, args.seed, True)
     elif args.only_delete:
         remove_files(args.path)
     else:
-        time_ak_write(args.size, args.files_per_loc, args.trials, args.dtype, args.path, args.seed, True)
+        time_ak_write(args.size, args.files_per_loc, args.trials, args.dtype, args.path, args.seed, True, args.compressed)
         time_ak_read(args.size, args.files_per_loc, args.trials, args.dtype, args.path, args.seed, True)
         remove_files(args.path)
     

--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -1,4 +1,5 @@
 #include <stdint.h>
+#include <stdbool.h>
 
 // Wrap functions in C extern if compiling C++ object file
 #ifdef __cplusplus
@@ -39,10 +40,11 @@ extern "C" {
 
   int cpp_writeColumnToParquet(const char* filename, void* chpl_arr,
                                int64_t colnum, const char* dsetname, int64_t numelems,
-                               int64_t rowGroupSize, int64_t dtype, char** errMsg);
+                               int64_t rowGroupSize, int64_t dtype, bool compressed,
+                               char** errMsg);
   int c_writeColumnToParquet(const char* filename, void* chpl_arr,
                              int64_t colnum, const char* dsetname, int64_t numelems,
-                             int64_t rowGroupSize, int64_t dtype, char** errMsg);
+                             int64_t rowGroupSize, int64_t dtype, bool compressed, char** errMsg);
     
   const char* c_getVersionInfo(void);
   const char* cpp_getVersionInfo(void);

--- a/test/UnitTestParquetCpp.chpl
+++ b/test/UnitTestParquetCpp.chpl
@@ -5,7 +5,7 @@ use TestBase;
 proc testReadWrite(filename: c_string, dsetname: c_string, size: int) {
   extern proc c_readColumnByName(filename, chpl_arr, colNum, numElems, batchSize, errMsg): int;
   extern proc c_writeColumnToParquet(filename, chpl_arr, colnum,
-                                     dsetname, numelems, rowGroupSize,
+                                     dsetname, numelems, rowGroupSize, compressed,
                                      errMsg): int;
   extern proc c_free_string(a);
   extern proc strlen(a): int;
@@ -17,7 +17,7 @@ proc testReadWrite(filename: c_string, dsetname: c_string, size: int) {
   
   var a: [0..#size] int;
   for i in 0..#size do a[i] = i;
-  if c_writeColumnToParquet(filename, c_ptrTo(a), 0, dsetname, size, 10000, errMsg) < 0 {
+  if c_writeColumnToParquet(filename, c_ptrTo(a), 0, dsetname, size, 10000, false, errMsg) < 0 {
     var chplMsg;
     try! chplMsg = createStringWithNewBuffer(errMsg, strlen(errMsg));
     writeln(chplMsg);


### PR DESCRIPTION
This PR adds support for writing Parquet with Snappy compression
and RLE/Bit-Packing Hybrid encoding. This can be toggled through
the `compressed` keyword argument on `pdarray.save_parquet()`.

Here are performance numbers collected on a 16-node CS:
Locales	| Current Write	| Snappy/RLE Write
------- | ------------: | ---------------:
1	| 1.00 GiB/s	| 0.36 GiB/s
16	| 7.78 GiB/s	| 5.21 GiB/s

Locales | Current Read | Snappy/RLE Read | Current 400-file Read | Snappy/RLE 400-file Read
------- | -----------: | --------------: | --------------------: | -----------------------:
1       | 1.50 GiB/s   | 0.72 GiB/s      | 8.33 GiB/s            | 8.13 GiB/s
16      | 19.12 GiB/s  | 10.40 GiB/s     | 22.73 GiB/s           | 21.74 GiB/s

So there is a rather large hit for reading/writing a single large file,
but read performance does not take much of a hit for I/O-bound reads,
such as reading in 400 files in parallel.

The current Parquet IO benchmarks continue to write without compression
to allow a more fair comparison against HDF5 and also to maintain
continuity with historical numbers for the benchmarks.

Captured in https://github.com/Bears-R-Us/arkouda/issues/985