### PR TITLE
#1095 benchmarks for str ops with good vs poor locality

### DIFF
--- a/benchmarks/graph_infra/arkouda-string.graph
+++ b/benchmarks/graph_infra/arkouda-string.graph
@@ -27,3 +27,27 @@ graphkeys: Medium GiB/s, Large GiB/s
 files: str-in1d.dat, str-in1d.dat
 graphtitle: String in1d Performance
 ylabel: Performance (GiB/s)
+
+perfkeys: Hashing good locality Average rate =, Hashing poor locality Average rate =
+graphkeys: Good Locality, Poor Locality
+files: str-locality.dat, str-locality.dat
+graphtitle: String Hashing Performance
+ylabel: Performance (GiB/s)
+
+perfkeys: Regex searching good locality Average rate =, Regex searching poor locality Average rate =
+graphkeys: Good Locality, Poor Locality
+files: str-locality.dat, str-locality.dat
+graphtitle: String Regex Search Performance
+ylabel: Performance (GiB/s)
+
+perfkeys: Casting good locality Average rate =, Casting poor locality Average rate =
+graphkeys: Good Locality, Poor Locality
+files: str-locality.dat, str-locality.dat
+graphtitle: String cast-to-float Performance
+ylabel: Performance (GiB/s)
+
+perfkeys: Comparing to scalar good locality Average rate =, Comparing to scalar poor locality Average rate =
+graphkeys: Good Locality, Poor Locality
+files: str-locality.dat, str-locality.dat
+graphtitle: String compare-vs-scalar Performance
+ylabel: Performance (GiB/s)

--- a/benchmarks/graph_infra/str-locality.perfkeys
+++ b/benchmarks/graph_infra/str-locality.perfkeys
@@ -1,0 +1,16 @@
+Hashing good locality Average time =
+Hashing good locality Average rate =
+Hashing poor locality Average time =
+Hashing poor locality Average rate =
+Regex searching good locality Average time =
+Regex searching good locality Average rate =
+Regex searching poor locality Average time =
+Regex searching poor locality Average rate =
+Casting good locality Average time =
+Casting good locality Average rate =
+Casting poor locality Average time =
+Casting poor locality Average rate =
+Comparing to scalar good locality Average time =
+Comparing to scalar good locality Average rate =
+Comparing to scalar poor locality Average time =
+Comparing to scalar poor locality Average rate =

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -24,7 +24,7 @@ BENCHMARKS = [
     'scatter', 'reduce', 'in1d', 'scan', 'noop', 'setops', 'array_create',
     'array_transfer', 'IO', 'str-argsort', 'str-coargsort', 'str-groupby',
     'str-gather', 'str-in1d', 'substring_search', 'flatten', 'sort-cases',
-    'multiIO'
+    'multiIO', 'str-locality'
 ]
 
 if os.getenv('ARKOUDA_SERVER_PARQUET_SUPPORT'):

--- a/benchmarks/str-locality.py
+++ b/benchmarks/str-locality.py
@@ -19,7 +19,7 @@ def time_all_ops(N, trials, seed, correctnessOnly):
     if correctnessOnly:
         N = 10**4
     else:
-        print(">>> arkouda substring search")
+        print(">>> arkouda string locality tests")
         print("numLocales = {}, N = {:,}".format(cfg["numLocales"], N))
     random_strings, sorted_strings, perm = generate_data(N, seed)
     nbytes = random_strings.nbytes

--- a/benchmarks/str-locality.py
+++ b/benchmarks/str-locality.py
@@ -73,7 +73,7 @@ def create_parser():
     parser = argparse.ArgumentParser(description="Measure the performance of various string operations on strings with good locality (random) and poor locality (sorted).")
     parser.add_argument('hostname', help='Hostname of arkouda server')
     parser.add_argument('port', type=int, help='Port of arkouda server')
-    parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: Number of Strings to search')
+    parser.add_argument('-n', '--size', type=int, default=10**7, help='Problem size: Number of Strings to search')
     parser.add_argument('-t', '--trials', type=int, default=1, help='Number of times to run the benchmark')
     parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
     parser.add_argument('-s', '--seed', default=None, type=int, help='Value to initialize random number generator')

--- a/benchmarks/str-locality.py
+++ b/benchmarks/str-locality.py
@@ -14,13 +14,14 @@ def generate_data(N, seed):
     sorted_strings = random_strings[perm]
     return random_strings, sorted_strings, perm
 
-def time_all_ops(N, trials, seed, correctnessOnly):
-    cfg = ak.get_config()
+def time_all_ops(N_per_locale, trials, seed, correctnessOnly):
     if correctnessOnly:
         N = 10**4
     else:
         print(">>> arkouda string locality tests")
-        print("numLocales = {}, N = {:,}".format(cfg["numLocales"], N))
+        nl = ak.get_config()["numLocales"]
+        N = nl * N_per_locale
+        print("numLocales = {}, N = {:,}".format(nl, N))
     random_strings, sorted_strings, perm = generate_data(N, seed)
     nbytes = random_strings.nbytes
 

--- a/benchmarks/str-locality.py
+++ b/benchmarks/str-locality.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+import time
+import argparse
+import arkouda as ak
+
+def generate_data(N, seed):
+    prefix = ak.random_strings_uniform(minlen=1, maxlen=16, size=N, seed=seed, characters='numeric')
+    if seed is not None:
+        seed += 1
+    suffix = ak.random_strings_uniform(minlen=1, maxlen=16, size=N, seed=seed, characters='numeric')
+    random_strings = prefix.stick(suffix, delimiter='.')
+    perm = ak.argsort(random_strings.get_lengths())
+    sorted_strings = random_strings[perm]
+    return random_strings, sorted_strings, perm
+
+def time_all_ops(N, trials, seed, correctnessOnly):
+    cfg = ak.get_config()
+    if correctnessOnly:
+        N = 10**4
+    else:
+        print(">>> arkouda substring search")
+        print("numLocales = {}, N = {:,}".format(cfg["numLocales"], N))
+    random_strings, sorted_strings, perm = generate_data(N, seed)
+    nbytes = random_strings.nbytes
+
+    def time_op(op, name):
+        random_times = []
+        sorted_times = []
+        for i in range(trials):
+            start = time.time()
+            random_ans = op(random_strings)
+            end = time.time()
+            random_times.append(end - start)
+            start = time.time()
+            sorted_ans = op(sorted_strings)
+            end = time.time()
+            sorted_times.append(end - start)
+        if not correctnessOnly:
+            avg = sum(random_times) / trials
+            rate = nbytes / 2**30 / avg
+            print("{} good locality Average time = {:.4f} sec".format(name, avg))
+            print("{} good locality Average rate = {:.4f} GiB/sec".format(name, rate))
+            avg = sum(sorted_times) / trials
+            rate = nbytes / 2**30 / avg
+            print("{} poor locality Average time = {:.4f} sec".format(name, avg))
+            print("{} poor locality Average rate = {:.4f} GiB/sec".format(name, rate))
+        return random_ans, sorted_ans
+
+    # Hash
+    op = lambda x: x.hash()
+    ans1, ans2 = time_op(op, 'Hashing')
+    for i in range(2):
+        assert (ans1[i][perm] == ans2[i]).all()
+
+    # Substring search
+    op = lambda x: x.contains(r'\d{3,5}\.\d{5,8}', regex=True)
+    ans1, ans2 = time_op(op, "Regex searching")
+    assert (ans1[perm] == ans2).all()
+
+    # Cast
+    op = lambda x: ak.cast(x, ak.float64)
+    ans1, ans2 = time_op(op, "Casting")
+    assert (ans1[perm] == ans2).all()
+
+    # Scalar compare
+    op = lambda x: (x == "5.5")
+    ans1, ans2 = time_op(op, "Comparing to scalar")
+    assert (ans1[perm] == ans2).all()
+
+def create_parser():
+    parser = argparse.ArgumentParser(description="Measure the performance of various string operations on strings with good locality (random) and poor locality (sorted).")
+    parser.add_argument('hostname', help='Hostname of arkouda server')
+    parser.add_argument('port', type=int, help='Port of arkouda server')
+    parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: Number of Strings to search')
+    parser.add_argument('-t', '--trials', type=int, default=1, help='Number of times to run the benchmark')
+    parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
+    parser.add_argument('-s', '--seed', default=None, type=int, help='Value to initialize random number generator')
+    return parser
+
+
+if __name__ == "__main__":
+    import sys
+    parser = create_parser()
+    args = parser.parse_args()
+    ak.verbose = False
+    ak.connect(args.hostname, args.port)
+
+    if not args.correctness_only:
+        print("array size = {:,}".format(args.size))
+        print("number of trials = ", args.trials)
+    time_all_ops(args.size, args.trials, args.seed, args.correctness_only)
+    sys.exit(0)


### PR DESCRIPTION
Closes #1095 

This PR adds one benchmark script that generates 4 benchmark plots, each of which compare performance of an operation on strings with good locality vs. strings with poor locality. The operations are:
- `strings.hash()`
- `strings.substring_search()`
- `ak.cast(strings, ak.float64)`
- `strings == literal`

I did not measure the performance of sorting the lengths and permuting the generated strings because those operations are already measured by the `argsort` and `str-gather` benchmarks. However, it would be easy to capture these measurements if desired.