### PR TITLE
#1101 Use `computeOnSegments` for casting strings to numeric

### DIFF
--- a/src/Cast.chpl
+++ b/src/Cast.chpl
@@ -1,0 +1,153 @@
+module Cast {
+  use MultiTypeSymbolTable;
+  use MultiTypeSymEntry;
+  use Reflection;
+  use SegmentedArray;
+  use ServerErrors;
+  use Logging;
+  use CommAggregation;
+  use ServerConfig;
+  
+  private config const logLevel = ServerConfig.logLevel;
+  const castLogger = new Logger(logLevel);
+  
+  proc castGenSymEntry(gse: borrowed GenSymEntry, st: borrowed SymTab, type fromType, 
+                                             type toType): string throws {
+    const before = toSymEntry(gse, fromType);
+    const name = st.nextName();
+    var after = st.addEntry(name, before.size, toType);
+    try {
+      after.a = before.a : toType;
+    } catch e: IllegalArgumentError {
+      var errorMsg = "bad value in cast from %s to %s".format(fromType:string, 
+                                                       toType:string);
+      castLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);   
+      return "Error: %s".format(errorMsg);
+    }
+
+    var returnMsg = "created " + st.attrib(name);
+    castLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),returnMsg);
+    return returnMsg;
+  }
+
+  proc castGenSymEntryToString(gse: borrowed GenSymEntry, st: borrowed SymTab, 
+                                                       type fromType): string throws {
+    const before = toSymEntry(gse, fromType);
+    const oname = st.nextName();
+    var segments = st.addEntry(oname, before.size, int);
+    var strings: [before.aD] string;
+    if fromType == real {
+      try {
+          forall (s, v) in zip(strings, before.a) {
+              s = "%.17r".format(v);
+          }
+      } catch e {
+          var errorMsg = "could not convert float64 value to decimal representation";
+          castLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);   
+          return "Error: %s".format(errorMsg);
+      }
+    } else {
+      try {
+          strings = [s in before.a] s : string;
+      } catch e: IllegalArgumentError {
+          var errorMsg = "bad value in cast from %s to string".format(fromType:string);
+          castLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);   
+          return "Error: %s".format(errorMsg);
+      }
+    }
+    const byteLengths = [s in strings] s.numBytes + 1;
+    // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+    overMemLimit(numBytes(uint(8)) * byteLengths.size);
+    segments.a = (+ scan byteLengths) - byteLengths;
+    const totBytes = + reduce byteLengths;
+    const vname = st.nextName();
+    var values = st.addEntry(vname, totBytes, uint(8));
+    ref va = values.a;
+    forall (o, s) in zip(segments.a, strings) with (var agg = newDstAggregator(uint(8))) {
+      for (i, b) in zip(0.., s.bytes()) {
+        agg.copy(va[o+i], b);
+      }
+    }
+
+    var returnMsg ="created " + st.attrib(oname) + "+created " + st.attrib(vname);
+    castLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),returnMsg);
+    return returnMsg;
+  }
+
+  enum ErrorMode {
+    strict,
+    ignore,
+    return_validity,
+  }
+
+  inline proc stringToNumericStrict(values, rng, type toType): toType throws {
+    if toType == bool {
+      return interpretAsString(values, rng).toLower() : toType;
+    } else {
+      return interpretAsString(values, rng) : toType;
+    }
+  }
+
+  inline proc stringToNumericIgnore(values, rng, type toType): toType {
+    var num: toType;
+    try {
+      num = stringToNumericStrict(values, rng, toType);
+    } catch {
+      if toType == real {
+        num = Math.NAN;
+      } else if toType == int {
+        // Use pandas.NaT, i.e. -2**63, as NaN for int
+        num = min(int);
+      }
+      // Other types remain zero on error
+    }
+    return num;
+  }
+
+  inline proc stringToNumericReturnValidity(values, rng, type toType): (toType, bool) {
+    var num: toType;
+    var valid = true;
+    try {
+      num = stringToNumericStrict(values, rng, toType);
+    } catch {
+      if toType == real {
+        num = Math.NAN;
+      } else if toType == int {
+        // Use pandas.NaT, i.e. -2**63, as NaN for int
+        num = min(int);
+      }
+      // Other types remain zero on error
+      valid = false;
+    }
+    return (num, valid);
+  }
+
+  
+  proc castStringToSymEntry(s: SegString, st: borrowed SymTab, type toType, errors: ErrorMode): string throws {
+      use SegmentedComputation;
+      ref oa = s.offsets.a;
+      ref va = s.values.a;
+      const name = st.nextName();
+      var entry = st.addEntry(name, s.size, toType);
+      var returnMsg = "created " + st.attrib(name);
+      select errors {
+        when ErrorMode.strict {
+          entry.a = computeOnSegments(oa, va, SegFunction.StringToNumericStrict, toType);
+        }
+        when ErrorMode.ignore {
+          entry.a = computeOnSegments(oa, va, SegFunction.StringToNumericIgnore, toType);
+        }
+        when ErrorMode.return_validity {
+          var valWithFlag: [entry.aD] (toType, bool) = computeOnSegments(oa, va, SegFunction.StringToNumericReturnValidity, (toType, bool));
+          const vname = st.nextName();
+          var valid = st.addEntry(vname, s.size, bool);
+          forall (n, v, vf) in zip(entry.a, valid.a, valWithFlag) {
+            (n, v) = vf;
+          }
+          returnMsg += "+created " + st.attrib(vname);
+        }
+      }
+      castLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),returnMsg);
+      return returnMsg;
+  }
+}

--- a/src/CastMsg.chpl
+++ b/src/CastMsg.chpl
@@ -127,7 +127,7 @@ module CastMsg {
           const errors = opt.toLower() : ErrorMode;
           select targetDtype {
               when "int64" {
-                return new MsgTuple(castStringToSymEntry(strings, st, int, errors), MsgType.NORMAL);
+                  return new MsgTuple(castStringToSymEntry(strings, st, int, errors), MsgType.NORMAL);
               }
               when "uint8" {
                   return new MsgTuple(castStringToSymEntry(strings, st, uint(8), errors), MsgType.NORMAL);

--- a/src/CastMsg.chpl
+++ b/src/CastMsg.chpl
@@ -9,7 +9,7 @@ module CastMsg {
   use SysError;
   use ServerErrorStrings;
   use ServerConfig;
-  use CommAggregation;
+  use Cast;
 
   private config const logLevel = ServerConfig.logLevel;
   const castLogger = new Logger(logLevel);
@@ -124,21 +124,22 @@ module CastMsg {
       }
       when "str" {
           const strings = getSegString(name, st);
+          const errors = opt.toLower() : ErrorMode;
           select targetDtype {
               when "int64" {
-                  return new MsgTuple(castStringToSymEntry(strings, st, int), MsgType.NORMAL);
+                return new MsgTuple(castStringToSymEntry(strings, st, int, errors), MsgType.NORMAL);
               }
               when "uint8" {
-                  return new MsgTuple(castStringToSymEntry(strings, st, uint(8)), MsgType.NORMAL);
+                  return new MsgTuple(castStringToSymEntry(strings, st, uint(8), errors), MsgType.NORMAL);
               }
               when "uint64" {
-                  return new MsgTuple(castStringToSymEntry(strings, st, uint), MsgType.NORMAL);
+                  return new MsgTuple(castStringToSymEntry(strings, st, uint, errors), MsgType.NORMAL);
               }
               when "float64" {
-                  return new MsgTuple(castStringToSymEntry(strings, st, real), MsgType.NORMAL);
+                  return new MsgTuple(castStringToSymEntry(strings, st, real, errors), MsgType.NORMAL);
               }
               when "bool" {
-                  return new MsgTuple(castStringToSymEntry(strings, st, bool), MsgType.NORMAL);
+                  return new MsgTuple(castStringToSymEntry(strings, st, bool, errors), MsgType.NORMAL);
               }
               otherwise {
                  var errorMsg = notImplementedError(pn,"str",":",targetDtype);
@@ -153,99 +154,6 @@ module CastMsg {
         return new MsgTuple(errorMsg, MsgType.ERROR);
       }
     }
-  }
-
-  proc castGenSymEntry(gse: borrowed GenSymEntry, st: borrowed SymTab, type fromType, 
-                                             type toType): string throws {
-    const before = toSymEntry(gse, fromType);
-    const name = st.nextName();
-    var after = st.addEntry(name, before.size, toType);
-    try {
-      after.a = before.a : toType;
-    } catch e: IllegalArgumentError {
-      var errorMsg = "bad value in cast from %s to %s".format(fromType:string, 
-                                                       toType:string);
-      castLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);   
-      return "Error: %s".format(errorMsg);
-    }
-
-    var returnMsg = "created " + st.attrib(name);
-    castLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),returnMsg);
-    return returnMsg;
-  }
-
-  proc castGenSymEntryToString(gse: borrowed GenSymEntry, st: borrowed SymTab, 
-                                                       type fromType): string throws {
-    const before = toSymEntry(gse, fromType);
-    const oname = st.nextName();
-    var segments = st.addEntry(oname, before.size, int);
-    var strings: [before.aD] string;
-    if fromType == real {
-      try {
-          forall (s, v) in zip(strings, before.a) {
-              s = "%.17r".format(v);
-          }
-      } catch e {
-          var errorMsg = "could not convert float64 value to decimal representation";
-          castLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);   
-          return "Error: %s".format(errorMsg);
-      }
-    } else {
-      try {
-          strings = [s in before.a] s : string;
-      } catch e: IllegalArgumentError {
-          var errorMsg = "bad value in cast from %s to string".format(fromType:string);
-          castLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);   
-          return "Error: %s".format(errorMsg);
-      }
-    }
-    const byteLengths = [s in strings] s.numBytes + 1;
-    // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
-    overMemLimit(numBytes(uint(8)) * byteLengths.size);
-    segments.a = (+ scan byteLengths) - byteLengths;
-    const totBytes = + reduce byteLengths;
-    const vname = st.nextName();
-    var values = st.addEntry(vname, totBytes, uint(8));
-    ref va = values.a;
-    forall (o, s) in zip(segments.a, strings) with (var agg = newDstAggregator(uint(8))) {
-      for (i, b) in zip(0.., s.bytes()) {
-        agg.copy(va[o+i], b);
-      }
-    }
-
-    var returnMsg ="created " + st.attrib(oname) + "+created " + st.attrib(vname);
-    castLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),returnMsg);
-    return returnMsg;
-  }
-
-  proc castStringToSymEntry(s: SegString, st: borrowed SymTab, type toType): string throws {
-      ref oa = s.offsets.a;
-      ref va = s.values.a;
-      const name = st.nextName();
-      var entry = st.addEntry(name, s.size, toType);
-    
-      const highInd = s.offsets.aD.high;
-      try {
-          forall (i, o, e) in zip(s.offsets.aD, s.offsets.a, entry.a) {
-              const start = o;
-              var end: int;
-
-              if (i == highInd) {
-              end = s.nBytes - 1;
-              } else {
-                   end = oa[i+1] - 1;
-              }
-              e = interpretAsString(va, start..end) : toType;
-          }
-      } catch e: IllegalArgumentError {
-          var errorMsg = "bad value in cast from string to %s".format(toType:string);
-          castLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);   
-          return "Error: %s".format(errorMsg);
-      }
-
-      var returnMsg = "created " + st.attrib(name);
-      castLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),returnMsg);
-      return returnMsg;
   }
 
   proc registerMe() {

--- a/src/SegmentedComputation.chpl
+++ b/src/SegmentedComputation.chpl
@@ -3,6 +3,7 @@ module SegmentedComputation {
   use SipHash;
   use ServerErrors;
   private use Cast;
+  use Reflection;
 
   proc computeSegmentOwnership(segments: [?D] int, vD) {
     const low = vD.low;

--- a/src/SegmentedComputation.chpl
+++ b/src/SegmentedComputation.chpl
@@ -1,6 +1,8 @@
 module SegmentedComputation {
   use CommAggregation;
   use SipHash;
+  use ServerErrors;
+  private use Cast;
 
   proc computeSegmentOwnership(segments: [?D] int, vD) {
     const low = vD.low;
@@ -36,9 +38,13 @@ module SegmentedComputation {
 
   enum SegFunction {
     SipHash128,
+    StringToNumericStrict,
+    StringToNumericIgnore,
+    StringToNumericReturnValidity,
   }
   
   proc computeOnSegments(segments: [?D] int, values: [?vD] ?t, param function: SegFunction, type retType) throws {
+    // type retType = if (function == SegFunction.StringToNumericReturnValidity) then (outType, bool) else outType;
     var res: [D] retType;
     if (D.size == 0) {
       return res;
@@ -59,16 +65,33 @@ module SegmentedComputation {
           agg.copy(mySegs[i], segments[i]);
           agg.copy(myLens[i], lengths[i]);
         }
-        // Apply function to bytes of each owned segment, aggregating return value to res
-        forall (start, len, i) in zip(mySegs, myLens, mySegInds) with (var agg = newDstAggregator(retType)) {
-          select function {
-            when SegFunction.SipHash128 {
-              agg.copy(res[i], sipHash128(values, start..#len));
-            }
-            otherwise {
-              compilerError("Unrecognized segmented function");
+        try {
+          // Apply function to bytes of each owned segment, aggregating return value to res
+          forall (start, len, i) in zip(mySegs, myLens, mySegInds) with (var agg = newDstAggregator(retType)) {
+            select function {
+              when SegFunction.SipHash128 {
+                agg.copy(res[i], sipHash128(values, start..#len));
+              }
+              when SegFunction.StringToNumericStrict {
+                agg.copy(res[i], stringToNumericStrict(values, start..#len, retType));
+              }
+              when SegFunction.StringToNumericIgnore {
+                agg.copy(res[i], stringToNumericIgnore(values, start..#len, retType));
+              }
+              when SegFunction.StringToNumericReturnValidity {
+                agg.copy(res[i], stringToNumericReturnValidity(values, start..#len, retType[0]));
+              }
+              otherwise {
+                compilerError("Unrecognized segmented function");
+              }
             }
           }
+        } catch {
+          throw new owned ErrorWithContext("Error computing %s on string or segment".format(function:string),
+                                           getLineNumber(),
+                                           getRoutineName(),
+                                           getModuleName(),
+                                           "IllegalArgumentError");
         }
       }
     }


### PR DESCRIPTION
This is part of #1101 and should improve performance of casting string arrays to numeric values when the locality of the string bytes is poor.

Performance is tracked in one of the benchmarks added in #1106 , but I have not yet been able to run this at a significant scale to verify the expected improvement.

While here, also add more robust error handling to str-to-num casts. It now supports three modes:
- strict (default): raise an exception if any value cannot be converted
- ignore: never raise an exception, bad inputs result in a dtype-dependent default/nan value
- return_validity: same result as 'ignore', but also return a bool array showing where the conversion succeeded.

I am not wild about adding another `Enum` for the error handling mode, because it feels rather annoying as a user. Can anyone think of a better way?