### PR TITLE
Closes #1088 - Remove "legacy_placeholder" from String.get_lengths()

### DIFF
--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -321,7 +321,7 @@ class Strings:
             Raised if there is a server-side error thrown
         """
         cmd = "segmentLengths"
-        args = "{} {} {}".format(self.objtype, self.entry.name, "legacy_placeholder")
+        args = "{} {}".format(self.objtype, self.entry.name)
         return create_pdarray(generic_msg(cmd=cmd,args=args))
 
     @typechecked

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -130,15 +130,15 @@ module SegmentedMsg {
   proc segmentLengthsMsg(cmd: string, payload: string, 
                                           st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
-    var (objtype, name, legacy_placeholder) = payload.splitMsgToTuple(3);
+    var (objtype, name) = payload.splitMsgToTuple(2);
 
     // check to make sure symbols defined
     st.checkTable(name);
     
     var rname = st.nextName();
     smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-            "cmd: %s objtype: %t name: %t legacy_placeholder: %t".format(
-                   cmd,objtype,name,"legacy_placeholder"));
+            "cmd: %s objtype: %t name: %t".format(
+                   cmd,objtype,name));
 
     select objtype {
       when "str" {


### PR DESCRIPTION
This PR (closes #1088):

- Removed legacy_placeholder from String.get_lengths() and SegmentedMsg.segmentLengthMsg().

