### PR TITLE
Closes #1109: Scale `substring_search.py` and `flatten.py` benchmarks with `numLocales`

### DIFF
--- a/benchmarks/flatten.py
+++ b/benchmarks/flatten.py
@@ -5,9 +5,10 @@ import argparse
 import arkouda as ak
 
 
-def time_flatten(N, trials):
+def time_flatten(N_per_locale, trials):
     print(">>> arkouda flatten")
     cfg = ak.get_config()
+    N = N_per_locale * cfg["numLocales"]
     print("numLocales = {}, N = {:,}".format(cfg["numLocales"], N))
 
     thirds = [ak.cast(ak.arange(i, N*3, 3), 'str') for i in range(3)]
@@ -67,7 +68,7 @@ def create_parser():
     parser = argparse.ArgumentParser(description="Measure the performance of regex and non-regex flatten on Strings.")
     parser.add_argument('hostname', help='Hostname of arkouda server')
     parser.add_argument('port', type=int, help='Port of arkouda server')
-    parser.add_argument('-n', '--size', type=int, default=10**6, help='Problem size: Number of Strings to flatten')
+    parser.add_argument('-n', '--size', type=int, default=10**5, help='Problem size: Number of Strings to flatten')
     parser.add_argument('-t', '--trials', type=int, default=1, help='Number of times to run the benchmark')
     parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
     return parser

--- a/benchmarks/in1d.py
+++ b/benchmarks/in1d.py
@@ -10,10 +10,10 @@ MEDIUM = 2**25 - 1
 # Must be greater than mbound
 LARGE = 2**25 + 1
 
-def time_ak_in1d(size, trials, dtype):
+def time_ak_in1d(N_per_locale, trials, dtype):
     print(f">>> arkouda {dtype} in1d")
     cfg = ak.get_config()
-    N = size * cfg["numLocales"]
+    N = N_per_locale * cfg["numLocales"]
     a = ak.arange(N) % LARGE
     if dtype == 'uint64':
         a = ak.cast(a, ak.uint64)

--- a/benchmarks/substring_search.py
+++ b/benchmarks/substring_search.py
@@ -5,9 +5,10 @@ import argparse
 import arkouda as ak
 
 
-def time_substring_search(N, trials, seed):
+def time_substring_search(N_per_locale, trials, seed):
     print(">>> arkouda substring search")
     cfg = ak.get_config()
+    N = N_per_locale * cfg["numLocales"]
     print("numLocales = {}, N = {:,}".format(cfg["numLocales"], N))
 
     start = ak.random_strings_uniform(minlen=1, maxlen=8, size=N, seed=seed)


### PR DESCRIPTION
This PR (closes #1109):
- Corrects oversight which kept the `substring_search.py` and `flatten.py` benchmarks from scaling with `numLocales` (as the other benchmarks do)
- Changes the `size` variable to `N_per_locale` in `str-in1d.py` to be consistent with other benchmarks
- Changes the default problem size for flatten from `10**6` to `10**5`