### PR TITLE
Closes #1105 - Remove Assertion test from Error Message

### DIFF
--- a/tests/categorical_test.py
+++ b/tests/categorical_test.py
@@ -38,8 +38,6 @@ class CategoricalTest(ArkoudaTest):
         
         with self.assertRaises(ValueError) as cm:
             ak.Categorical(ak.arange(0,5,10))
-        self.assertEqual('Categorical: inputs other than Strings not yet supported', 
-                         cm.exception.args[0])        
         
     def testCategoricalFromCodesAndCategories(self):
         codes = ak.array([7,5,9,8,2,1,4,0,3,6])
@@ -144,8 +142,6 @@ class CategoricalTest(ArkoudaTest):
 
         with self.assertRaises(TypeError) as cm:
             ak.in1d(catOne, ak.randint(0,5,5))
-        self.assertEqual(('type of argument "test" must be one of (Strings, Categorical); got ' + 
-                          'arkouda.pdarrayclass.pdarray instead'), cm.exception.args[0])    
        
     def testConcatenate(self):
         catOne = self._getCategorical('string',51)

--- a/tests/extrema_test.py
+++ b/tests/extrema_test.py
@@ -76,23 +76,15 @@ class MinKTest(ArkoudaTest):
 
         with self.assertRaises(TypeError) as cm:
             ak.mink(list(range(0,10)), 1)
-        self.assertEqual('type of argument "pda" must be arkouda.pdarrayclass.pdarray; got list instead', 
-                         cm.exception.args[0])  
 
         with self.assertRaises(TypeError) as cm:
             ak.mink(testArray, '1')
-        self.assertEqual('type of argument "k" must be one of (int, int64, uint64); got str instead', 
-                         cm.exception.args[0])  
             
         with self.assertRaises(ValueError) as cm:
             ak.mink(testArray, -1)
-        self.assertEqual("k must be 1 or greater", 
-                         cm.exception.args[0])   
         
         with self.assertRaises(ValueError) as cm:
             ak.mink(ak.array([]), 1)
-        self.assertEqual("must be a non-empty pdarray of type int or float", 
-                         cm.exception.args[0])   
 
 class MaxKTest(ArkoudaTest):
     def test_maxk(self):
@@ -109,23 +101,15 @@ class MaxKTest(ArkoudaTest):
 
         with self.assertRaises(TypeError) as cm:
             ak.maxk(list(range(0,10)), 1)
-        self.assertEqual('type of argument "pda" must be arkouda.pdarrayclass.pdarray; got list instead', 
-                         cm.exception.args[0])  
 
         with self.assertRaises(TypeError) as cm:
             ak.maxk(testArray, '1')
-        self.assertEqual('type of argument "k" must be one of (int, int64, uint64); got str instead', 
-                         cm.exception.args[0])  
             
         with self.assertRaises(ValueError) as cm:
             ak.maxk(testArray, -1)
-        self.assertEqual("k must be 1 or greater", 
-                         cm.exception.args[0])   
         
         with self.assertRaises(ValueError) as cm:
             ak.maxk(ak.array([]), 1)
-        self.assertEqual("must be a non-empty pdarray of type int or float", 
-                         cm.exception.args[0])   
 
 class ArgMinKTest(ArkoudaTest):
     def test_argmink(self):
@@ -142,23 +126,15 @@ class ArgMinKTest(ArkoudaTest):
 
         with self.assertRaises(TypeError) as cm:
             ak.argmink(list(range(0,10)), 1)
-        self.assertEqual('type of argument "pda" must be arkouda.pdarrayclass.pdarray; got list instead', 
-                         cm.exception.args[0])  
 
         with self.assertRaises(TypeError) as cm:
             ak.argmink(testArray, '1')
-        self.assertEqual('type of argument "k" must be one of (int, int64, uint64); got str instead', 
-                         cm.exception.args[0])  
             
         with self.assertRaises(ValueError) as cm:
             ak.argmink(testArray, -1)
-        self.assertEqual("k must be 1 or greater", 
-                         cm.exception.args[0])   
         
         with self.assertRaises(ValueError) as cm:
             ak.argmink(ak.array([]), 1)
-        self.assertEqual("must be a non-empty pdarray of type int or float", 
-                         cm.exception.args[0])   
 
 class ArgMaxKTest(ArkoudaTest):
     def test_argmaxk(self):
@@ -175,20 +151,12 @@ class ArgMaxKTest(ArkoudaTest):
 
         with self.assertRaises(TypeError) as cm:
             ak.argmaxk(list(range(0,10)), 1)
-        self.assertEqual('type of argument "pda" must be arkouda.pdarrayclass.pdarray; got list instead', 
-                         cm.exception.args[0])  
         
         with self.assertRaises(TypeError) as cm:
             ak.argmaxk(testArray, '1')
-        self.assertEqual('type of argument "k" must be one of (int, int64, uint64); got str instead', 
-                         cm.exception.args[0])  
             
         with self.assertRaises(ValueError) as cm:
             ak.argmaxk(testArray, -1)
-        self.assertEqual("k must be 1 or greater", 
-                         cm.exception.args[0])      
         
         with self.assertRaises(ValueError) as cm:
             ak.argmaxk(ak.array([]), 1)
-        self.assertEqual("must be a non-empty pdarray of type int or float", 
-                         cm.exception.args[0])           

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -220,69 +220,43 @@ class GroupByTest(ArkoudaTest):
         gb = ak.GroupBy([akdf['keys'], akdf['keys2']])
         
         with self.assertRaises(TypeError) as cm:
-            ak.GroupBy(self.bvalues)  
-        self.assertEqual('GroupBy only supports pdarrays with a dtype int64', 
-                         cm.exception.args[0])    
+            ak.GroupBy(self.bvalues)
         
         with self.assertRaises(TypeError) as cm:
-            ak.GroupBy(self.fvalues)  
-        self.assertEqual('GroupBy only supports pdarrays with a dtype int64', 
-                         cm.exception.args[0])              
+            ak.GroupBy(self.fvalues)
 
         with self.assertRaises(TypeError) as cm:
             gb.broadcast([])
-        self.assertEqual('type of argument "values" must be arkouda.pdarrayclass.pdarray; got list instead', 
-                         cm.exception.args[0])  
         
         with self.assertRaises(TypeError) as cm:
             self.igb.nunique(ak.randint(0,1,10,dtype=bool))
-        self.assertEqual('nunique unsupported for this dtype', 
-                         cm.exception.args[0])  
 
         with self.assertRaises(TypeError) as cm:
             self.igb.nunique(ak.randint(0,1,10,dtype=float64))
-        self.assertEqual('nunique unsupported for this dtype', 
-                         cm.exception.args[0])  
         
         with self.assertRaises(TypeError) as cm:
             self.igb.any(ak.randint(0,1,10,dtype=float64))
-        self.assertEqual('any is only supported for pdarrays of dtype bool', 
-                         cm.exception.args[0])  
 
         with self.assertRaises(TypeError) as cm:
             self.igb.any(ak.randint(0,1,10,dtype=int64))
-        self.assertEqual('any is only supported for pdarrays of dtype bool', 
-                         cm.exception.args[0])  
         
         with self.assertRaises(TypeError) as cm:
             self.igb.all(ak.randint(0,1,10,dtype=float64))
-        self.assertEqual('all is only supported for pdarrays of dtype bool', 
-                         cm.exception.args[0])  
 
         with self.assertRaises(TypeError) as cm:
             self.igb.all(ak.randint(0,1,10,dtype=int64))
-        self.assertEqual('all is only supported for pdarrays of dtype bool', 
-                         cm.exception.args[0])  
         
         with self.assertRaises(TypeError) as cm:
             self.igb.min(ak.randint(0,1,10,dtype=bool))
-        self.assertEqual('min is only supported for pdarrays of dtype float64 and int64', 
-                         cm.exception.args[0])  
 
         with self.assertRaises(TypeError) as cm:
             self.igb.max(ak.randint(0,1,10,dtype=bool))
-        self.assertEqual('max is only supported for pdarrays of dtype float64 and int64', 
-                         cm.exception.args[0])  
         
         with self.assertRaises(TypeError) as cm:
             self.igb.argmin(ak.randint(0,1,10,dtype=bool))
-        self.assertEqual('argmin is only supported for pdarrays of dtype float64 and int64', 
-                         cm.exception.args[0])  
 
         with self.assertRaises(TypeError) as cm:
             self.igb.argmax(ak.randint(0,1,10,dtype=bool))
-        self.assertEqual('argmax is only supported for pdarrays of dtype float64 and int64', 
-                         cm.exception.args[0])
 
     def test_aggregate_strings(self):
         s = ak.array(['a', 'b', 'a', 'b', 'c'])

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -181,7 +181,6 @@ class IOTest(ArkoudaTest):
 
         with self.assertRaises(RuntimeError) as cm:        
             ak.ls_hdf('{}/not-a-file_LOCALE0000'.format(IOTest.io_test_dir))
-        self.assertIn('is not an HDF5 file', cm.exception.args[0])
 
     def testLsHdfEmpty(self):
         # Test filename empty/whitespace-only condition
@@ -217,15 +216,12 @@ class IOTest(ArkoudaTest):
         with self.assertRaises(RuntimeError) as cm:
             ak.read_hdf(dsetName='in_tens_pdarray', 
                     filenames=['{}/iotest_single_column_LOCALE0000'.format(IOTest.io_test_dir),
-                               '{}/iotest_single_column_dupe_LOCALE0000'.format(IOTest.io_test_dir)])       
-        self.assertTrue('Dataset in_tens_pdarray not found in file' in  
-                         cm.exception.args[0])
+                               '{}/iotest_single_column_dupe_LOCALE0000'.format(IOTest.io_test_dir)])
         
         with self.assertRaises(RuntimeError) as cm:
             ak.read_hdf(dsetName='int_tens_pdarray', 
                     filenames=['{}/iotest_single_colum_LOCALE0000'.format(IOTest.io_test_dir),
-                               '{}/iotest_single_colum_dupe_LOCALE0000'.format(IOTest.io_test_dir)])       
-        self.assertTrue('iotest_single_colum_LOCALE0000 not found' in  cm.exception.args[0])
+                               '{}/iotest_single_colum_dupe_LOCALE0000'.format(IOTest.io_test_dir)])
 
     def testReadHdfWithGlob(self):
         ''' DEPRECATED - all client calls route to `readAllHdf`
@@ -356,15 +352,12 @@ class IOTest(ArkoudaTest):
         # Test load with invalid prefix
         with self.assertRaises(RuntimeError) as cm:
             ak.load(path_prefix='{}/iotest_dict_column'.format(IOTest.io_test_dir), 
-                                    dataset='int_tens_pdarray')  
-        self.assertIn('either corresponds to files inaccessible to Arkouda or files of an invalid format', cm.exception.args[0].args[0])
+                                    dataset='int_tens_pdarray')
 
         # Test load with invalid file
         with self.assertRaises(RuntimeError) as cm:
             ak.load(path_prefix='{}/not-a-file'.format(IOTest.io_test_dir), 
-                                    dataset='int_tens_pdarray') 
-        cm.exception.args[0]
-        self.assertIn('is not an HDF5 file', cm.exception.args[0].args[0])
+                                    dataset='int_tens_pdarray')
         
     def testLoadAll(self):   
         self._create_file(columns=self.dict_columns, 
@@ -382,8 +375,7 @@ class IOTest(ArkoudaTest):
             
         # Test load with invalid file
         with self.assertRaises(RuntimeError) as cm:
-            ak.load_all(path_prefix='{}/not-a-file'.format(IOTest.io_test_dir)) 
-        self.assertIn('Could not open on or more files with the file prefix', cm.exception.args[0])      
+            ak.load_all(path_prefix='{}/not-a-file'.format(IOTest.io_test_dir))
     
     def testGetDataSets(self):
         '''
@@ -404,7 +396,6 @@ class IOTest(ArkoudaTest):
         # Test load_all with invalid filename
         with self.assertRaises(RuntimeError) as cm:            
             ak.get_datasets('{}/iotest_dict_columns_LOCALE000'.format(IOTest.io_test_dir))
-        self.assertIn('does not exist in a location accessible to Arkouda', cm.exception.args[0])
 
     def testSaveStringsDataset(self):
         # Create, save, and load Strings dataset

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -72,18 +72,12 @@ class NumericTest(ArkoudaTest):
         
         with self.assertRaises(TypeError) as cm:
             ak.histogram([range(0,10)], bins=1)
-        self.assertEqual('type of argument "pda" must be arkouda.pdarrayclass.pdarray; got list instead', 
-                        cm.exception.args[0])  
         
         with self.assertRaises(TypeError) as cm:
             ak.histogram(pda, bins='1')
-        self.assertEqual('type of argument "bins" must be one of (int, int64, uint64); got str instead', 
-                        cm.exception.args[0])  
         
         with self.assertRaises(TypeError) as cm:
             ak.histogram([range(0,10)], bins='1')
-        self.assertEqual('type of argument "pda" must be arkouda.pdarrayclass.pdarray; got list instead', 
-                        cm.exception.args[0])  
     
     def testLog(self):
         na = np.linspace(1,10,10)
@@ -92,8 +86,6 @@ class NumericTest(ArkoudaTest):
         self.assertTrue((np.log(na) == ak.log(pda).to_ndarray()).all())
         with self.assertRaises(TypeError) as cm:
             ak.log([range(0,10)])
-        self.assertEqual('type of argument "pda" must be arkouda.pdarrayclass.pdarray; got list instead', 
-                        cm.exception.args[0])  
         
     def testExp(self):
         na = np.linspace(1,10,10)
@@ -102,8 +94,6 @@ class NumericTest(ArkoudaTest):
         self.assertTrue((np.exp(na) == ak.exp(pda).to_ndarray()).all())
         with self.assertRaises(TypeError) as cm:
             ak.exp([range(0,10)])
-        self.assertEqual('type of argument "pda" must be arkouda.pdarrayclass.pdarray; got list instead', 
-                        cm.exception.args[0])  
         
     def testAbs(self):
         na = np.linspace(1,10,10)
@@ -115,8 +105,6 @@ class NumericTest(ArkoudaTest):
         
         with self.assertRaises(TypeError) as cm:
             ak.abs([range(0,10)])
-        self.assertEqual('type of argument "pda" must be arkouda.pdarrayclass.pdarray; got list instead', 
-                        cm.exception.args[0])  
 
     def testCumSum(self):
         na = np.linspace(1,10,10)
@@ -132,8 +120,6 @@ class NumericTest(ArkoudaTest):
         
         with self.assertRaises(TypeError) as cm:
             ak.cumsum([range(0,10)])
-        self.assertEqual('type of argument "pda" must be arkouda.pdarrayclass.pdarray; got list instead', 
-                        cm.exception.args[0])  
         
     def testCumProd(self):
         na = np.linspace(1,10,10)
@@ -142,8 +128,6 @@ class NumericTest(ArkoudaTest):
         self.assertTrue((np.cumprod(na) == ak.cumprod(pda).to_ndarray()).all())
         with self.assertRaises(TypeError) as cm:
             ak.cumprod([range(0,10)])
-        self.assertEqual('type of argument "pda" must be arkouda.pdarrayclass.pdarray; got list instead', 
-                        cm.exception.args[0])  
         
     def testSin(self):
         na = np.linspace(1,10,10)
@@ -152,8 +136,6 @@ class NumericTest(ArkoudaTest):
         self.assertTrue((np.sin(na) == ak.sin(pda).to_ndarray()).all())
         with self.assertRaises(TypeError) as cm:
             ak.cos([range(0,10)])
-        self.assertEqual('type of argument "pda" must be arkouda.pdarrayclass.pdarray; got list instead', 
-                        cm.exception.args[0])  
         
     def testCos(self):
         na = np.linspace(1,10,10)
@@ -162,8 +144,6 @@ class NumericTest(ArkoudaTest):
         self.assertTrue((np.cos(na) == ak.cos(pda).to_ndarray()).all())    
         with self.assertRaises(TypeError) as cm:
             ak.cos([range(0,10)])
-        self.assertEqual('type of argument "pda" must be arkouda.pdarrayclass.pdarray; got list instead', 
-                        cm.exception.args[0])
 
     def testHash(self):
         h1, h2 = ak.hash(ak.arange(10))
@@ -188,14 +168,10 @@ class NumericTest(ArkoudaTest):
         
         pda = ak.linspace(1,10,10)
         with self.assertRaises(RuntimeError) as cm:
-            ak.value_counts(pda) 
-        self.assertEqual('Error: unique: float64 not implemented', 
-                        cm.exception.args[0])    
+            ak.value_counts(pda)
 
         with self.assertRaises(TypeError) as cm:  
-            ak.value_counts([0]) 
-        self.assertEqual('type of argument "pda" must be arkouda.pdarrayclass.pdarray; got list instead', 
-                        cm.exception.args[0])   
+            ak.value_counts([0])
 
     def test_isnan(self):
         """

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -276,28 +276,18 @@ class OperatorsTest(ArkoudaTest):
         # Test ak,histogram against unsupported dtype
         #with self.assertRaises(ValueError) as cm:
         #    ak.histogram((ak.randint(0, 1, 100, dtype=ak.bool)))
-        #self.assertEqual('Error: histogramMsg: bool not implemented', 
-        #                 cm.exception.args[0])
             
         with self.assertRaises(RuntimeError) as cm:
             ak.concatenate([ak.array([True]),ak.array([True])]).is_sorted()
-        self.assertEqual('Error: reductionMsg: is_sorted bool not implemented', 
-                         cm.exception.args[0])
         
         with self.assertRaises(TypeError):
             ak.ones(100).any([0])
             
         with self.assertRaises(TypeError) as cm:
             ak.unique(list(range(0,10)))
-        self.assertEqual('must be pdarray, Strings, or Categorical {}', 
-                         cm.exception.args[0])
         
         with self.assertRaises(RuntimeError) as cm:
             ak.concatenate([ak.ones(100),ak.array([True])])
-
-        self.assertEqual('Error: concatenateMsg: Incompatible arguments: ' +
-                         'Expected float64 dtype but got bool dtype', 
-                         cm.exception.args[0])
 
     def test_str_repr(self):
         """

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -62,7 +62,6 @@ class ParquetTest(ArkoudaTest):
         
         with self.assertRaises(RuntimeError) as cm:
             ak.read_parquet("pq_test*", "wrong-dset-name")
-        self.assertIn("wrong-dset-name does not exist in file", cm.exception.args[0])
 
         for f in glob.glob("pq_test*"):
             os.remove(f)

--- a/tests/pdarray_creation_test.py
+++ b/tests/pdarray_creation_test.py
@@ -32,24 +32,16 @@ class PdarrayCreationTest(ArkoudaTest):
         self.assertEqual(int, pda.dtype)         
 
         with self.assertRaises(RuntimeError) as cm:          
-            ak.array({range(0,100)})         
-        self.assertEqual("Only rank-1 pdarrays or ndarrays supported", 
-                         cm.exception.args[0])  
+            ak.array({range(0,100)})
         
         with self.assertRaises(RuntimeError) as cm:          
-            ak.array(np.array([[0,1],[0,1]]))         
-        self.assertEqual("Only rank-1 pdarrays or ndarrays supported", 
-                         cm.exception.args[0])  
+            ak.array(np.array([[0,1],[0,1]]))
 
         with self.assertRaises(RuntimeError) as cm:          
-            ak.array('not an iterable')          
-        self.assertEqual("Only rank-1 pdarrays or ndarrays supported", 
-                         cm.exception.args[0]) 
+            ak.array('not an iterable')
         
         with self.assertRaises(TypeError) as cm:          
-            ak.array(list(list(0)))          
-        self.assertEqual("'int' object is not iterable", 
-                         cm.exception.args[0])       
+            ak.array(list(list(0)))
 
     def test_arange(self):
         self.assertTrue((ak.array([0, 1, 2, 3, 4]) == ak.arange(0, 5, 1)).all())
@@ -106,18 +98,12 @@ class PdarrayCreationTest(ArkoudaTest):
 
         with self.assertRaises(ValueError) as cm:
             ak.randint(low=0, high=1, size=-1, dtype=ak.float64)
-        self.assertEqual("size must be > 0 and high > low", 
-                         cm.exception.args[0])    
  
         with self.assertRaises(ValueError) as cm:
-            ak.randint(low=1, high=0, size=1, dtype=ak.float64)  
-        self.assertEqual("size must be > 0 and high > low", 
-                         cm.exception.args[0])             
+            ak.randint(low=1, high=0, size=1, dtype=ak.float64)
 
         with self.assertRaises(TypeError) as cm:              
             ak.randint(0,1,'1000')
-        self.assertEqual('type of argument "size" must be one of (int, int64, uint64); got str instead', 
-                         cm.exception.args[0])    
 
         with self.assertRaises(TypeError):              
             ak.randint('0',1,1000)
@@ -223,13 +209,9 @@ class PdarrayCreationTest(ArkoudaTest):
         
         with self.assertRaises(TypeError) as cm:
             ak.ones(5, dtype=ak.uint8)
-        self.assertEqual('unsupported dtype uint8', 
-                         cm.exception.args[0])  
                     
         with self.assertRaises(TypeError) as cm:
             ak.ones(5, dtype=str)
-        self.assertEqual('unsupported dtype <U0', 
-                         cm.exception.args[0])     
         
     def test_ones_like(self):      
         intOnes = ak.ones(5, dtype=ak.int64)
@@ -287,18 +269,12 @@ class PdarrayCreationTest(ArkoudaTest):
         
         with self.assertRaises(TypeError) as cm:        
             ak.linspace(0,'100', 1000)
-        self.assertEqual(('both start and stop must be an int, np.int64, float, or np.float64'), 
-                         cm.exception.args[0])  
         
         with self.assertRaises(TypeError) as cm:        
             ak.linspace('0',100, 1000)
-        self.assertEqual(('both start and stop must be an int, np.int64, float, or np.float64'), 
-                         cm.exception.args[0])  
 
         with self.assertRaises(TypeError) as cm:          
-            ak.linspace(0,100,'1000')           
-        self.assertEqual('type of argument "length" must be one of (int, int64, uint64); got str instead', 
-                         cm.exception.args[0])            
+            ak.linspace(0,100,'1000')
 
     def test_standard_normal(self):
         pda = ak.standard_normal(100)
@@ -323,19 +299,13 @@ class PdarrayCreationTest(ArkoudaTest):
         
 
         with self.assertRaises(TypeError) as cm:          
-            ak.standard_normal('100')          
-        self.assertEqual('type of argument "size" must be one of (int, int64, uint64); got str instead', 
-                         cm.exception.args[0]) 
+            ak.standard_normal('100')
    
         with self.assertRaises(TypeError) as cm:          
-            ak.standard_normal(100.0)          
-        self.assertEqual('type of argument "size" must be one of (int, int64, uint64); got float instead', 
-                         cm.exception.args[0])   
+            ak.standard_normal(100.0)
     
         with self.assertRaises(ValueError) as cm:          
-            ak.standard_normal(-1)          
-        self.assertEqual("The size parameter must be > 0", 
-                         cm.exception.args[0])  
+            ak.standard_normal(-1)
 
     def test_random_strings_uniform(self):
         pda = ak.random_strings_uniform(minlen=1, maxlen=5, size=100)
@@ -359,34 +329,22 @@ class PdarrayCreationTest(ArkoudaTest):
             self.assertTrue(string.isupper())
         
         with self.assertRaises(ValueError) as cm:          
-            ak.random_strings_uniform(maxlen=1,minlen=5, size=100)          
-        self.assertEqual("Incompatible arguments: minlen < 0, maxlen <= minlen, or size < 0", 
-                         cm.exception.args[0])
+            ak.random_strings_uniform(maxlen=1,minlen=5, size=100)
         
         with self.assertRaises(ValueError) as cm:          
-            ak.random_strings_uniform(maxlen=5,minlen=1, size=-1)          
-        self.assertEqual("Incompatible arguments: minlen < 0, maxlen <= minlen, or size < 0", 
-                         cm.exception.args[0])
+            ak.random_strings_uniform(maxlen=5,minlen=1, size=-1)
 
         with self.assertRaises(ValueError) as cm:          
-            ak.random_strings_uniform(maxlen=5, minlen=5, size=10)          
-        self.assertEqual("Incompatible arguments: minlen < 0, maxlen <= minlen, or size < 0", 
-                         cm.exception.args[0])
+            ak.random_strings_uniform(maxlen=5, minlen=5, size=10)
         
         with self.assertRaises(TypeError) as cm:          
-            ak.random_strings_uniform(minlen='1', maxlen=5, size=10)          
-        self.assertEqual('type of argument "minlen" must be one of (int, int64, uint64); got str instead', 
-                         cm.exception.args[0])  
+            ak.random_strings_uniform(minlen='1', maxlen=5, size=10)
         
         with self.assertRaises(TypeError) as cm:          
-            ak.random_strings_uniform( minlen=1, maxlen='5', size=10)          
-        self.assertEqual('type of argument "maxlen" must be one of (int, int64, uint64); got str instead', 
-                         cm.exception.args[0])     
+            ak.random_strings_uniform( minlen=1, maxlen='5', size=10)
         
         with self.assertRaises(TypeError) as cm:          
-            ak.random_strings_uniform(minlen=1, maxlen=5, size='10')          
-        self.assertEqual('type of argument "size" must be one of (int, int64, uint64); got str instead', 
-                         cm.exception.args[0])              
+            ak.random_strings_uniform(minlen=1, maxlen=5, size='10')
 
     def test_random_strings_uniform_with_seed(self):
         pda = ak.random_strings_uniform(minlen=1, maxlen=5, seed=1, size=10)
@@ -440,19 +398,13 @@ class PdarrayCreationTest(ArkoudaTest):
         self.assertEqual(str, pda.dtype)
         
         with self.assertRaises(TypeError) as cm:          
-            ak.random_strings_lognormal('2', 0.25, 100)          
-        self.assertEqual('both logmean and logstd must be an int, np.int64, float, or np.float64', 
-                         cm.exception.args[0])   
+            ak.random_strings_lognormal('2', 0.25, 100)
                 
         with self.assertRaises(TypeError) as cm:          
-            ak.random_strings_lognormal(2, 0.25, '100')          
-        self.assertEqual('type of argument "size" must be one of (int, int64, uint64); got str instead', 
-                         cm.exception.args[0])       
+            ak.random_strings_lognormal(2, 0.25, '100')
         
         with self.assertRaises(TypeError) as cm:          
-            ak.random_strings_lognormal(2, 0.25, 100, 1000000)          
-        self.assertEqual('type of argument "characters" must be str; got int instead', 
-                         cm.exception.args[0])  
+            ak.random_strings_lognormal(2, 0.25, 100, 1000000)
         
     def test_random_strings_lognormal_with_seed(self):
         pda = ak.random_strings_lognormal(2, 0.25, 10, seed=1)
@@ -484,9 +436,6 @@ class PdarrayCreationTest(ArkoudaTest):
     def test_mulitdimensional_array_creation(self):
         with self.assertRaises(RuntimeError) as cm:
             ak.array([[0,0],[0,1],[1,1]])
-            
-        self.assertEqual('Only rank-1 pdarrays or ndarrays supported', 
-                         cm.exception.args[0])
         
     def test_from_series(self):
         strings = ak.from_series(pd.Series(['a', 'b', 'c', 'd', 'e'], dtype="string"))
@@ -554,16 +503,10 @@ class PdarrayCreationTest(ArkoudaTest):
         self.assertEqual(np.int64, p_array.dtype)  
   
         with self.assertRaises(TypeError) as cm:          
-            ak.from_series(np.ones(100))        
-        self.assertEqual(('type of argument "series" must be pandas.core.series.Series; ' +
-                         'got numpy.ndarray instead'), 
-                         cm.exception.args[0])    
+            ak.from_series(np.ones(100))
 
         with self.assertRaises(ValueError) as cm:          
-            ak.from_series(pd.Series(np.random.randint(0,10,10), dtype=np.int8))      
-        self.assertEqual(('dtype int8 is unsupported. Supported dtypes are bool, ' +
-                          'float64, int64, string, datetime64[ns], and timedelta64[ns]'), 
-                         cm.exception.args[0])
+            ak.from_series(pd.Series(np.random.randint(0,10,10), dtype=np.int8))
         
     def test_fill(self):
         ones = ak.ones(100)

--- a/tests/setops_test.py
+++ b/tests/setops_test.py
@@ -88,13 +88,9 @@ class SetOpsTest(ArkoudaTest):
         
         with self.assertRaises(RuntimeError) as cm:
             ak.setxor1d(ak.array([-1.0, 0.0, 1.0]), ak.array([-2.0, 0.0, 2.0]))
-        self.assertEqual('Error: unique: float64 not implemented', 
-                         cm.exception.args[0])  
         
         with self.assertRaises(RuntimeError) as cm:
             ak.setxor1d(ak.array([True, False, True]), ak.array([True, True]))
-        self.assertEqual('Error: unique: bool not implemented', 
-                         cm.exception.args[0]) 
         with self.assertRaises(TypeError):
             ak.setxor1d([-1, 0, 1], [-2, 0, 2])     
         
@@ -107,13 +103,9 @@ class SetOpsTest(ArkoudaTest):
         
         with self.assertRaises(RuntimeError) as cm:
             ak.setdiff1d(ak.array([-1.0, 0.0, 1.0]), ak.array([-2.0, 0.0, 2.0]))
-        self.assertEqual('Error: unique: float64 not implemented', 
-                         cm.exception.args[0])  
         
         with self.assertRaises(RuntimeError) as cm:
             ak.setdiff1d(ak.array([True, False, True]), ak.array([True, True]))
-        self.assertEqual('Error: unique: bool not implemented', 
-                         cm.exception.args[0]) 
         with self.assertRaises(TypeError):
             ak.setdiff1d([-1, 0, 1], [-2, 0, 2])     
         
@@ -125,13 +117,9 @@ class SetOpsTest(ArkoudaTest):
         
         with self.assertRaises(RuntimeError) as cm:
             ak.intersect1d(ak.array([-1.0, 0.0, 1.0]), ak.array([-2.0, 0.0, 2.0]))
-        self.assertEqual('Error: unique: float64 not implemented', 
-                         cm.exception.args[0])  
         
         with self.assertRaises(RuntimeError) as cm:
             ak.intersect1d(ak.array([True, False, True]), ak.array([True, True]))
-        self.assertEqual('Error: unique: bool not implemented', 
-                         cm.exception.args[0]) 
         with self.assertRaises(TypeError):
             ak.intersect1d([-1, 0, 1], [-2, 0, 2])     
         
@@ -143,13 +131,9 @@ class SetOpsTest(ArkoudaTest):
         
         with self.assertRaises(RuntimeError) as cm:
             ak.union1d(ak.array([-1.0, 0.0, 1.0]), ak.array([-2.0, 0.0, 2.0]))
-        self.assertEqual('Error: unique: float64 not implemented', 
-                         cm.exception.args[0])  
         
         with self.assertRaises(RuntimeError) as cm:
             ak.union1d(ak.array([True, True, True]), ak.array([True,False,True]))
-        self.assertEqual('Error: unique: bool not implemented', 
-                         cm.exception.args[0])          
         with self.assertRaises(TypeError):
             ak.union1d([-1, 0, 1], [-2, 0, 2])     
 

--- a/tests/sort_test.py
+++ b/tests/sort_test.py
@@ -57,13 +57,9 @@ class SortTest(ArkoudaTest):
         for algo in ak.SortingAlgorithm:
             with self.assertRaises(ValueError) as cm:
                 ak.sort(akbools, algo)
-            self.assertEqual('ak.sort supports int64, uint64, or float64, not bool',
-                             cm.exception.args[0])
         
             with self.assertRaises(ValueError) as cm:
                 ak.sort(bools, algo)
-            self.assertEqual('ak.sort supports int64, uint64, or float64, not bool',
-                             cm.exception.args[0])        
         
             # Test TypeError from sort attempt on non-pdarray
             with self.assertRaises(TypeError):

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -420,38 +420,24 @@ class StringTest(ArkoudaTest):
 
         with self.assertRaises(TypeError) as cm:
             stringsOne.lstick(stringsTwo, delimiter=1)
-        self.assertEqual('type of argument "delimiter" must be one of (bytes, str, str_); got int instead', 
-                         cm.exception.args[0])
         
         with self.assertRaises(TypeError) as cm:
             stringsOne.lstick([1], 1)
-        self.assertEqual('type of argument "other" must be arkouda.strings.Strings; got list instead', 
-                         cm.exception.args[0])  
         
         with self.assertRaises(TypeError) as cm:
             stringsOne.startswith(1)
-        self.assertEqual('type of argument "substr" must be one of (bytes, str, str_); got int instead', 
-                         cm.exception.args[0])    
         
         with self.assertRaises(TypeError) as cm:
             stringsOne.endswith(1)
-        self.assertEqual('type of argument "substr" must be one of (bytes, str, str_); got int instead', 
-                         cm.exception.args[0])   
         
         with self.assertRaises(TypeError) as cm:
             stringsOne.contains(1)
-        self.assertEqual('type of argument "substr" must be one of (bytes, str, str_); got int instead', 
-                         cm.exception.args[0])  
         
         with self.assertRaises(TypeError) as cm:
             stringsOne.peel(1)
-        self.assertEqual('type of argument "delimiter" must be one of (bytes, str, str_); got int instead', 
-                         cm.exception.args[0])  
 
         with self.assertRaises(ValueError) as cm:
             stringsOne.peel("",-5)
-        self.assertEqual('times must be >= 1', 
-                         cm.exception.args[0])  
 
     def test_peel(self):
         run_test_peel(self.strings, self.test_strings, self.delim)

--- a/tests/where_test.py
+++ b/tests/where_test.py
@@ -45,18 +45,12 @@ class WhereTest(ArkoudaTest):
     def test_error_handling(self):
         with self.assertRaises(TypeError) as cm:
             ak.where([0], ak.linspace(1,10,10), ak.linspace(1,10,10))
-        self.assertEqual(('type of argument "condition" must be arkouda.pdarrayclass.pdarray;' +
-                         ' got list instead'), cm.exception.args[0]) 
         
         with self.assertRaises(TypeError) as cm:
             ak.where(ak.linspace(1,10,10), [0], ak.linspace(1,10,10))
-        self.assertEqual(('both A and B must be an int, np.int64, float, np.float64, or pdarray'), 
-                         cm.exception.args[0]) 
         
         with self.assertRaises(TypeError) as cm:
             ak.where(ak.linspace(1,10,10), ak.linspace(1,10,10), [0])
-        self.assertEqual('both A and B must be an int, np.int64, float, np.float64, or pdarray', 
-                         cm.exception.args[0]) 
         
     def test_less_than_where_clause(self):
         n1 = np.arange(1,10)


### PR DESCRIPTION
This PR (closes #1105):

-Removed Assert tests checking for specific wording within error messages from `tests`