### PR TITLE
Use `computeOnSegments` for string comparisons

### DIFF
--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -1044,6 +1044,11 @@ module SegmentedArray {
                            moduleName = getModuleName(),
                            errorClass="ArgumentError");
     }
+    if useHash {
+      const lh = lss.hash();
+      const rh = rss.hash();
+      return if polarity then (lh == rh) else (lh != rh);
+    }
     ref oD = lss.offsets.aD;
     // Start by assuming all elements differ, then correct for those that are equal
     // This translates to an initial value of false for == and true for !=

--- a/src/SegmentedComputation.chpl
+++ b/src/SegmentedComputation.chpl
@@ -42,9 +42,11 @@ module SegmentedComputation {
     StringToNumericStrict,
     StringToNumericIgnore,
     StringToNumericReturnValidity,
+    StringCompareLiteralEq,
+    StringCompareLiteralNeq,
   }
   
-  proc computeOnSegments(segments: [?D] int, values: [?vD] ?t, param function: SegFunction, type retType) throws {
+  proc computeOnSegments(segments: [?D] int, values: [?vD] ?t, param function: SegFunction, type retType, const strArg: string = "") throws {
     // type retType = if (function == SegFunction.StringToNumericReturnValidity) then (outType, bool) else outType;
     var res: [D] retType;
     if (D.size == 0) {
@@ -81,6 +83,12 @@ module SegmentedComputation {
               }
               when SegFunction.StringToNumericReturnValidity {
                 agg.copy(res[i], stringToNumericReturnValidity(values, start..#len, retType[0]));
+              }
+              when SegFunction.StringCompareLiteralEq {
+                agg.copy(res[i], stringCompareLiteralEq(values, start..#len, strArg));
+              }
+              when SegFunction.StringCompareLiteralNeq {
+                agg.copy(res[i], stringCompareLiteralNeq(values, start..#len, strArg));
               }
               otherwise {
                 compilerError("Unrecognized segmented function");


### PR DESCRIPTION
This is part of https://github.com/Bears-R-Us/arkouda/issues/1101 and should improve performance of comparing string arrays to string literals or other string arrays when the locality of the string bytes is poor.

Performance is tracked in one of the benchmarks added in https://github.com/Bears-R-Us/arkouda/pull/1106 , but I have not yet tested at scale.

This PR includes the commits in #1107 , which has not yet been merged. My git-fu is poor, so I'm not sure if there is a better way to extend a pending PR or what I should do if/when it gets merged.