### PR TITLE
Make some minor optimizations to RadixSortLSD

### DIFF
--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -186,7 +186,7 @@ module RadixSortLSD
                                    "locid: %t task: %t tD: %t".format(loc.id,task,tD));
                         // count digits in this task's part of the array
                         for i in tD {
-                            const key = comparator.key(temp[i]);
+                            const key = comparator.key(temp.localAccess[i]);
                             var bucket = getDigit(key, rshift, last, negs); // calc bucket from key
                             taskBucketCounts[bucket] += 1;
                         }
@@ -233,11 +233,12 @@ module RadixSortLSD
                         {
                             var aggregator = newDstAggregator(t);
                             for i in tD {
-                                const key = comparator.key(temp[i]);
+                                const ref tempi = temp.localAccess[i];
+                                const key = comparator.key(tempi);
                                 var bucket = getDigit(key, rshift, last, negs); // calc bucket from key
                                 var pos = taskBucketPos[bucket];
                                 taskBucketPos[bucket] += 1;
-                                aggregator.copy(a[pos], temp[i]);
+                                aggregator.copy(a[pos], tempi);
                             }
                             aggregator.flush();
                         }

--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -164,7 +164,6 @@ module RadixSortLSD
         // create a global count array to scan
         var gD = newBlockDom({0..#(numLocales * numTasks * numBuckets)});
         var globalCounts: [gD] int;
-        var globalStarts: [gD] int;
         
         // loop over digits
         for rshift in {0..#nBits by bitsPerDigit} {
@@ -203,8 +202,8 @@ module RadixSortLSD
             }//coforall loc
             
             // scan globalCounts to get bucket ends on each locale/task
-            globalStarts = + scan globalCounts;
-            globalStarts = globalStarts - globalCounts;
+            var globalStarts = + scan globalCounts;
+            globalStarts -= globalCounts;
             
             if vv {printAry("globalCounts =",globalCounts);try! stdout.flush();}
             if vv {printAry("globalStarts =",globalStarts);try! stdout.flush();}


### PR DESCRIPTION
While cleaning up the sort implementation in #1099 I saw a few minor
optimization opportunities. They won't have a major impact, but given
the importance of sort it seemed worthwhile.

Specifically this:
- Avoids an extra copy for sort. Part of 1099 added an extra copy
  between the input array and the temp array. Remove that here by
  switching the order the arrays are used so we end up PUT'ing sorted
  results into the input/return array instead of the temp one.
- Eliminates a copy for the scan on globalStarts in sort. Today scan
  always creates a new array and returns it. By assigning the result of
  a scan into an existing array we were just adding an array copy and
  not eliminating an allocation. Switch to just assigning into a new
  variable, which will steal the returned buffer and avoid the initial
  allocation for globalStarts and the assignment to it during scans.
  Longer term, we have discussed having a way to provide the output
  array for scans, but there's no timeframe for that.
- Uses `localAccess` for some array accesses in sort. `localAccess` is a
  minor optimization that avoids some locality checks when array
  accesses are local. The performance benefit is small, but not trivial
  and given the importance of sort it seemed worthwhile.

Resolves #1119