### PR TITLE
Add a flag to get_datasets and ls_hdf for Parquet files

### DIFF
--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -14,7 +14,7 @@ ARKOUDA_HDF5_FILE_METADATA_GROUP = "_arkouda_metadata"
 
 
 @typechecked
-def ls_hdf(filename : str) -> List[str]:
+def ls_hdf(filename : str, is_parquet=False) -> List[str]:
     """
     This function calls the h5ls utility on a filename visible to the
     arkouda server.
@@ -23,6 +23,8 @@ def ls_hdf(filename : str) -> List[str]:
     ----------
     filename : str
         The name of the file to pass to h5ls
+    is_parquet : bool
+        Is filename a Parquet file; false by default
 
     Returns
     -------
@@ -41,7 +43,11 @@ def ls_hdf(filename : str) -> List[str]:
     if not (filename and filename.strip()):
         raise ValueError("filename cannot be an empty string")
 
-    return json.loads(cast(str,generic_msg(cmd="lshdf", args="{}".format(json.dumps([filename])))))
+    if is_parquet:
+        cmd = 'lspq'
+    else:
+        cmd = 'lshdf'
+    return json.loads(cast(str,generic_msg(cmd=cmd, args="{}".format(json.dumps([filename])))))
 
 @typechecked
 def read_hdf(dsetName : str, filenames : Union[str,List[str]],
@@ -379,14 +385,16 @@ def load(path_prefix : str, dataset : str='array', calc_string_offsets:bool = Fa
             
 
 @typechecked
-def get_datasets(filename : str) -> List[str]:
+def get_datasets(filename : str, is_parquet=False) -> List[str]:
     """
     Get the names of datasets in an HDF5 file.
 
     Parameters
     ----------
     filename : str
-        Name of an HDF5 file visible to the arkouda server
+        Name of an HDF5/Parquet file visible to the arkouda server
+    is_parquet : bool
+        Is filename a Parquet file; false by default
 
     Returns
     -------
@@ -406,7 +414,7 @@ def get_datasets(filename : str) -> List[str]:
     --------
     ls_hdf
     """
-    datasets = ls_hdf(filename)
+    datasets = ls_hdf(filename, is_parquet)
     # We can skip/remove the _arkouda_metadata group since it is an internal only construct
     if ARKOUDA_HDF5_FILE_METADATA_GROUP in datasets:
         datasets.remove(ARKOUDA_HDF5_FILE_METADATA_GROUP)

--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -43,10 +43,7 @@ def ls_hdf(filename : str, is_parquet=False) -> List[str]:
     if not (filename and filename.strip()):
         raise ValueError("filename cannot be an empty string")
 
-    if is_parquet:
-        cmd = 'lspq'
-    else:
-        cmd = 'lshdf'
+    cmd = 'lshdf' if not is_parquet else 'lspq'
     return json.loads(cast(str,generic_msg(cmd=cmd, args="{}".format(json.dumps([filename])))))
 
 @typechecked

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -231,7 +231,10 @@ int cpp_getDatasetNames(const char* filename, char** dsetResult, char** errMsg) 
   std::string fields = "";
   
   for(int i = 0; i < sc->num_fields(); i++) {
-    fields += (sc->field(i)->name() + " ");
+    if(i != sc->num_fields()-1)
+      fields += (sc->field(i)->name() + ",");
+    else
+      fields += (sc->field(i)->name());
   }
   *dsetResult = strdup(fields.c_str());
   

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -229,12 +229,21 @@ int cpp_getDatasetNames(const char* filename, char** dsetResult, char** errMsg) 
   ARROWSTATUS_OK(reader->GetSchema(out));
 
   std::string fields = "";
-  
+  bool first = true;
+
   for(int i = 0; i < sc->num_fields(); i++) {
-    if(i != sc->num_fields()-1)
-      fields += (sc->field(i)->name() + ",");
-    else
-      fields += (sc->field(i)->name());
+    // only add fields of supported types
+    if(sc->field(i)->type()->id() == arrow::Type::INT64 ||
+       sc->field(i)->type()->id() == arrow::Type::INT32 ||
+       sc->field(i)->type()->id() == arrow::Type::UINT64 ||
+       sc->field(i)->type()->id() == arrow::Type::UINT32 ||
+       sc->field(i)->type()->id() == arrow::Type::TIMESTAMP) {
+      if(!first)
+        fields += (", " + sc->field(i)->name());
+      else
+        fields += (sc->field(i)->name());
+      first = false;
+    }
   }
   *dsetResult = strdup(fields.c_str());
   

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -233,7 +233,6 @@ int cpp_getDatasetNames(const char* filename, char** dsetResult, char** errMsg) 
   for(int i = 0; i < sc->num_fields(); i++) {
     fields += (sc->field(i)->name() + " ");
   }
-  std::cout << fields << std::endl;
   *dsetResult = strdup(fields.c_str());
   
   return 0;

--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -49,6 +49,9 @@ extern "C" {
   const char* c_getVersionInfo(void);
   const char* cpp_getVersionInfo(void);
 
+  int c_getDatasetNames(const char* filename, char** dsetResult, char** errMsg);
+  int cpp_getDatasetNames(const char* filename, char** dsetResult, char** errMsg);
+
   void c_free_string(void* ptr);
   void cpp_free_string(void* ptr);
   

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -277,7 +277,7 @@ module ParquetMsg {
             try {
                 // not using the type for now since it is only implemented for ints
                 // also, since Parquet files have a `numRows` that isn't specifc
-                // to dsetname like for Parquet, we only need to get this once per
+                // to dsetname like for HDF5, we only need to get this once per
                 // file, regardless of how many datasets we are reading
                 sizes[i] = getArrSize(fname);
             } catch e: FileNotFoundError {

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -277,7 +277,7 @@ module ParquetMsg {
             try {
                 // not using the type for now since it is only implemented for ints
                 // also, since Parquet files have a `numRows` that isn't specifc
-                // to dsetname like for HDF5, we only need to get this once per
+                // to dsetname like for Parquet, we only need to get this once per
                 // file, regardless of how many datasets we are reading
                 sizes[i] = getArrSize(fname);
             } catch e: FileNotFoundError {
@@ -454,7 +454,6 @@ module ParquetMsg {
       }
       var sports = c_getDatasetNames(filename.c_str(), c_ptrTo(res), c_ptrTo(pqErr.errMsg));
       try! repMsg = createStringWithNewBuffer(res, strlen(res));
-      writeln(repMsg);
       var items = new list(repMsg.split(",")); // convert to json
 
       // TODO: There is a bug with json formatting of lists in Chapel 1.24.x fixed in 1.25
@@ -473,9 +472,8 @@ module ParquetMsg {
         repMsg += Q + i + Q;
       }
       repMsg += "]";
-      writeln(repMsg);
     } catch e : Error {
-      var errorMsg = "Failed to process HDF5 file %t".format(e.message());
+      var errorMsg = "Failed to process Parquet file %t".format(e.message());
       return new MsgTuple(errorMsg, MsgType.ERROR);
     }
 
@@ -485,8 +483,8 @@ module ParquetMsg {
   proc registerMe() {
     use CommandMap;
     registerFunction("readAllParquet", readAllParquetMsg, getModuleName());
-    registerFunction("lshdf", lspqMsg, getModuleName());
     registerFunction("writeParquet", toparquetMsg, getModuleName());
+    registerFunction("lspq", lspqMsg, getModuleName());
     ServerConfig.appendToConfigStr("ARROW_VERSION", getVersionInfo());
   }
 

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -452,7 +452,10 @@ module ParquetMsg {
         extern proc c_free_string(ptr);
         c_free_string(res);
       }
-      var sports = c_getDatasetNames(filename.c_str(), c_ptrTo(res), c_ptrTo(pqErr.errMsg));
+      if c_getDatasetNames(filename.c_str(), c_ptrTo(res),
+                           c_ptrTo(pqErr.errMsg)) == ARROWERROR {
+        pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
+      }
       try! repMsg = createStringWithNewBuffer(res, strlen(res));
       var items = new list(repMsg.split(",")); // convert to json
 

--- a/test/UnitTestParquetCpp.chpl
+++ b/test/UnitTestParquetCpp.chpl
@@ -143,7 +143,7 @@ proc testGetDsets(filename) {
   var ret;
   try! ret = createStringWithNewBuffer(cDsetString, strlen(cDsetString));
 
-  if st == 0 && ret == "my-dset-name-test " {
+  if st == 0 && ret == "my-dset-name-test" {
     return 0;
   } else if st != 0 {
     var chplMsg;

--- a/test/UnitTestParquetCpp.chpl
+++ b/test/UnitTestParquetCpp.chpl
@@ -6,7 +6,7 @@ proc testReadWrite(filename: c_string, dsetname: c_string, size: int) {
   extern proc c_readColumnByName(filename, chpl_arr, colNum, numElems, batchSize, errMsg): int;
   extern proc c_writeColumnToParquet(filename, chpl_arr, colnum,
                                      dsetname, numelems, rowGroupSize, compressed,
-                                     errMsg): int;
+                                     dtype, errMsg): int;
   extern proc c_free_string(a);
   extern proc strlen(a): int;
   var errMsg: c_ptr(uint(8));
@@ -17,7 +17,8 @@ proc testReadWrite(filename: c_string, dsetname: c_string, size: int) {
   
   var a: [0..#size] int;
   for i in 0..#size do a[i] = i;
-  if c_writeColumnToParquet(filename, c_ptrTo(a), 0, dsetname, size, 10000, false, errMsg) < 0 {
+  
+  if c_writeColumnToParquet(filename, c_ptrTo(a), 0, dsetname, size, 10000, false, 1, errMsg) < 0 {
     var chplMsg;
     try! chplMsg = createStringWithNewBuffer(errMsg, strlen(errMsg));
     writeln(chplMsg);
@@ -128,6 +129,26 @@ proc testVersionInfo() {
   }
 }
 
+proc testGetDsets(filename) {
+  extern proc c_getDatasetNames(f, r, e): int(32);
+  extern proc c_free_string(ptr);
+  extern proc strlen(a): int;
+  var cDsetString: c_ptr(uint(8));
+  var errMsg: c_ptr(uint(8));
+  var st = c_getDatasetNames(filename, cDsetString, errMsg);
+  defer {
+    c_free_string(cDsetString);
+    c_free_string(errMsg);
+  }
+  var ret;
+  try! ret = createStringWithNewBuffer(cDsetString, strlen(cDsetString));
+
+  if ret != "my-dset-name-test" then
+    return 0;
+  else
+    return 1;
+}
+
 proc main() {
   var errors = 0;
 
@@ -140,6 +161,7 @@ proc main() {
   errors += testGetNumRows(filename, size);
   errors += testGetType(filename, dsetname);
   errors += testVersionInfo();
+  errors += testGetDsets(filename);
 
   if errors != 0 then
     writeln(errors, " Parquet tests failed");

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -97,7 +97,7 @@ class ParquetTest(ArkoudaTest):
     def test_get_datasets(self):
         for dtype in TYPES:
             dsets = get_datasets_test(dtype)
-            self.assertTrue("TEST_DSET" in dsets)
+            self.assertTrue(["TEST_DSET"] == dsets)
 
         for f in glob.glob('pq_test*'):
             os.remove(f)

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -42,7 +42,21 @@ def read_write_multi_test(dtype):
         os.remove(f)
 
     return elems, pq_arr
+
+def get_datasets_test(dtype):
+    if dtype == 'int64':
+        ak_arr = ak.randint(0, 2**32, 10)
+    elif dtype =='uint64':
+        ak_arr = ak.randint(0, 2**32, 10, dtype=ak.uint64)
+        
+    ak_arr.save_parquet("pq_testdset", "TEST_DSET")
+
+    dsets = ak.get_datasets("pq_testdset*", True)
     
+    for f in glob.glob('pq_test*'):
+        os.remove(f)
+
+    return dsets
 
 @pytest.mark.skipif(not os.getenv('ARKOUDA_SERVER_PARQUET_SUPPORT'), reason="No parquet support")
 class ParquetTest(ArkoudaTest):
@@ -80,3 +94,10 @@ class ParquetTest(ArkoudaTest):
             for f in glob.glob('pq_test*'):
                 os.remove(f)
 
+    def test_get_datasets(self):
+        for dtype in TYPES:
+            dsets = get_datasets_test(dtype)
+            self.assertTrue("TEST_DSET" in dsets)
+
+        for f in glob.glob('pq_test*'):
+            os.remove(f)


### PR DESCRIPTION
This PR adds an `is_parquet` flag to both the `get_datasets()`
function and the `ls_hdf()` function. This is not ideal since
`ls_hdf` implies HDF5 files, but in the short term before we
have figured out auto-detecting of Parquet files, I think that
this approach makes sense.

In the C++/C side, there was a function added to return a
string of the dataset names separated by a comma of all
datasets that we support the types of today (int, uint,
timestamp). In the Chapel side, there was a `lspqMsg`
added that is very similar to the `lshdfMsg` function,
but with the Parquet calls substituted in. This means
that once we have the auto detecting of Parquet files
figured out, it will be easy to combine the two functions.

Motivating issue: https://github.com/Bears-R-Us/arkouda/issues/985