### PR TITLE
Cleanup the int in1d implementation

### DIFF
--- a/src/ArraySetops.chpl
+++ b/src/ArraySetops.chpl
@@ -13,6 +13,7 @@ module ArraySetops
     use RadixSortLSD;
     use Unique;
     use Indexing;
+    use AryUtil;
     use In1d;
 
     /*
@@ -32,7 +33,7 @@ module ArraySetops
     }
 
     proc intersect1dHelper(a: [] ?t, b: [] t) throws {
-      var aux = radixSortLSD_keys(concatset(a,b));
+      var aux = radixSortLSD_keys(concatArrays(a,b));
 
       // All elements except the last
       const ref head = aux[..aux.domain.high-1];
@@ -60,7 +61,7 @@ module ArraySetops
     // sorts and removes all values that occur
     // more than once
     proc setxor1dHelper(a: [] ?t, b: [] t) throws {
-      const aux = radixSortLSD_keys(concatset(a,b));
+      const aux = radixSortLSD_keys(concatArrays(a,b));
       const ref D = aux.domain;
 
       // Concatenate a `true` onto each end of the array
@@ -120,7 +121,7 @@ module ArraySetops
       var aux;
       // Artificial scope to clean up temporary arrays
       {
-        aux = concatset(uniqueSort(a,false), uniqueSort(b,false));
+        aux = concatArrays(uniqueSort(a,false), uniqueSort(b,false));
       }
       return uniqueSort(aux, false);
     }

--- a/src/ArraySetops.chpl
+++ b/src/ArraySetops.chpl
@@ -16,11 +16,6 @@ module ArraySetops
     use AryUtil;
     use In1d;
 
-    /*
-    Medium bound const. Per locale associative domain in1d implementation recommended.
-    */
-    private config const mBound = 2**25; 
-
     // returns intersection of 2 arrays
     proc intersect1d(a: [] ?t, b: [] t, assume_unique: bool) throws {
       //if not unique, unique sort arrays then perform operation
@@ -100,16 +95,8 @@ module ArraySetops
     // values and returns the array indexed
     // with this inverted array
     proc setdiff1dHelper(a: [] ?t, b: [] t) throws {
-        var truth = makeDistArray(a.size, bool);
-
-        // based on size of array, determine which method to use 
-        if (b.size <= mBound) then truth = in1dAr2PerLocAssoc(a, b);
-        else truth = in1dSort(a,b);
-        
-        truth = !truth;
-
+        var truth = in1d(a, b, invert=true);
         var ret = boolIndexer(a, truth);
-
         return ret;
     }
     

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -88,6 +88,18 @@ module AryUtil
     }
 
     /*
+       Concatenate 2 arrays and return the result.
+     */
+    proc concatArrays(a: [?aD] ?t, b: [?bD] t) {
+      var ret = makeDistArray((a.size + b.size), t);
+
+      ret[0..#a.size] = a;
+      ret[a.size..#b.size] = b;
+
+      return ret;
+    }
+
+    /*
       Iterate over indices (range/domain) ``ind`` but in an offset manner based
       on the locale id. Can be used to avoid doing communication in lockstep.
     */

--- a/src/In1d.chpl
+++ b/src/In1d.chpl
@@ -7,23 +7,34 @@ module In1d
     use RadixSortLSD;
     use Reflection;
 
-    /* Put ar2 into an associative domain of int, per locale. 
-    Creates truth (boolean array) from the domain of ar1.
-    ar1 and truth are distributed on the same locales.
-    ar2 is copied to a set (associative domain) in each locale.
-    set membership of ar1 to ar2 is checked on each locale by iterating over 
-    the local subdomains of ar1, and populating the local subdomains of truth 
-    with the result of the membership test.
+    /* Threshold for choosing between in1d implementation strategies */
+    private config const threshold = 2**25;
 
-    :arg ar1: array to broadcast in parallel over ar2
-    :type ar1: [] int
-    
-    :arg ar2: array to be broadcast over in parallel
-    :type ar2: [] int
-    
-    :returns truth: the distributed boolean array containing the result of ar1 being broadcast over ar2
-    :type truth: [] bool
-    */
+    /* For each value in the first array, check membership in the second array.
+
+       :arg ar1: array to broadcast in parallel over ar2
+       :type ar1: [] int
+
+       :arg ar2: array to be broadcast over in parallel
+       :type ar2: [] int
+
+       :arg invert: should the result be inverted (not in1d)
+       :type invert: bool
+
+       :returns truth: the distributed boolean array containing the result of ar1 being broadcast over ar2
+       :type truth: [] bool
+     */
+    proc in1d(ar1: [?aD1] ?t, ar2: [?aD2] t, invert: bool = false): [aD1] bool throws {
+        var truth = if ar2.size <= threshold then in1dAr2PerLocAssoc(ar1, ar2)
+                                             else in1dSort(ar1, ar2);
+        if invert then truth = !truth;
+        return truth;
+    }
+
+    /* in1d that uses a per-locale set/associative-domain. Each locale will
+     * localize ar2 and put it in the set, so only appropriate in terms of
+     * size and space when ar2 is "small".
+     */
     proc in1dAr2PerLocAssoc(ar1: [?aD1] ?t, ar2: [?aD2] t) {
         var truth: [aD1] bool;
         
@@ -46,23 +57,12 @@ module In1d
         return truth;
     }
 
-    /* For each value in the first array, check membership in the second array. This 
-       implementation uses a sort, which is best when the second array is large because 
-       it scales well in both time and memory.
-
-       :arg ar1: array to broadcast in parallel over ar2
-       :type ar1: [] int
-    
-       :arg ar2: array to be broadcast over in parallel
-       :type ar2: [] int
-    
-       :returns truth: the distributed boolean array containing the result of ar1 being broadcast over ar2
-       :type truth: [] bool
+    /* in1d that uses a sorting strategy. At a high level it uniques both
+     * arrays, finds the intersecting values, then maps back to the original
+     * domain of ar1. Scales well with time/size, but sort has non-trivial
+     * overhead so typically used when ar2 is "large".
      */
     proc in1dSort(ar1: [?aD1] ?t, ar2: [?aD2] t) throws {
-        /* General strategy: unique both arrays, find the intersecting values, 
-           then map back to the original domain of ar1.
-         */
         // Need the inverse index to map back from unique domain to original domain later
         var (u1, _, inv) = uniqueSortWithInverse(ar1);
         var u2 = uniqueSort(ar2, needCounts=false);

--- a/src/In1d.chpl
+++ b/src/In1d.chpl
@@ -64,8 +64,8 @@ module In1d
            then map back to the original domain of ar1.
          */
         // Need the inverse index to map back from unique domain to original domain later
-        var (u1, c1, inv) = uniqueSortWithInverse(ar1);
-        var (u2, c2) = uniqueSort(ar2);
+        var (u1, _, inv) = uniqueSortWithInverse(ar1);
+        var u2 = uniqueSort(ar2, needCounts=false);
         // Concatenate the two unique arrays
         const ar = concatArrays(u1, u2);
         const D = ar.domain;

--- a/src/In1d.chpl
+++ b/src/In1d.chpl
@@ -73,21 +73,17 @@ module In1d
         var sar: [D] t;
         var order: [D] int;
         forall (s, o, so) in zip(sar, order, radixSortLSD(ar)) {
-          (s, o) = so;
+            (s, o) = so;
         }
         // Duplicates correspond to values in both arrays
         var flag: [D] bool;
-        flag[D.interior(-(D.size-1))] = (sar[D.interior(D.size-1)] == sar[D.interior(-(D.size-1))]);
-        // Get the indices of values from u1 that are also in u2
-        // Because sort is stable, original index of left duplicate will always be in u1
-        var ret: [D] bool;
-        forall (o, f) in zip(order, flag) with (var agg = newDstAggregator(bool)) {
-            agg.copy(ret[o], f);
+        forall i in D[D.low..<D.high] with (var agg = newDstAggregator(bool)) {
+            agg.copy(flag[order[i]], sar[i+1] == sar[i]);
         }
         // Use the inverse index to map from u1 domain to ar1 domain
         var truth: [aD1] bool;
         forall (t, idx) in zip(truth, inv) with (var agg = newSrcAggregator(bool)) {
-            agg.copy(t, ret[idx]);
+            agg.copy(t, flag[idx]);
         }
         return truth;
     }

--- a/src/In1d.chpl
+++ b/src/In1d.chpl
@@ -59,7 +59,7 @@ module In1d
        :returns truth: the distributed boolean array containing the result of ar1 being broadcast over ar2
        :type truth: [] bool
      */
-    proc in1dSort(ar1: [?aD1] ?t, ar2: [?aD2] t) throws  {
+    proc in1dSort(ar1: [?aD1] ?t, ar2: [?aD2] t) throws {
         /* General strategy: unique both arrays, find the intersecting values, 
            then map back to the original domain of ar1.
          */
@@ -67,12 +67,8 @@ module In1d
         var (u1, c1, inv) = uniqueSortWithInverse(ar1);
         var (u2, c2) = uniqueSort(ar2);
         // Concatenate the two unique arrays
-        const D = makeDistDom(u1.size + u2.size);
-        var ar: [D] t;
-        /* ar[{0..#u1.size}] = u1; */
-        ar[D.interior(-u1.size)] = u1;
-        /* ar[{u1.size..#u2.size}] = u2; */
-        ar[D.interior(u2.size)] = u2;
+        const ar = concatArrays(u1, u2);
+        const D = ar.domain;
         // Sort unique arrays together to find duplicates
         var sar: [D] t;
         var order: [D] int;

--- a/src/In1dMsg.chpl
+++ b/src/In1dMsg.chpl
@@ -17,11 +17,6 @@ module In1dMsg
     private config const logLevel = ServerConfig.logLevel;
     const iLogger = new Logger(logLevel);
     
-    /*
-    Medium bound const. Per locale associative domain in1d implementation recommended.
-    */
-    private config const mBound = 2**25; 
-
     /* in1d takes two pdarray and returns a bool pdarray
        with the "in"/contains for each element tested against the second pdarray.
        
@@ -59,53 +54,15 @@ module In1dMsg
                 var ar1 = toSymEntry(gAr1,int);
                 var ar2 = toSymEntry(gAr2,int);
 
-                // things to do...
-                // if ar2 is big for some value of big... call unique on ar2 first
-
-                // per locale assoc domain if below medium bound
-                if (ar2.size <= mBound) {
-                    iLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                               "%t <= %t, using Ar2PerLocAssoc".format(ar2.size,mBound));                  
-                    var truth = in1dAr2PerLocAssoc(ar1.a, ar2.a);
-                    if (invert) {truth = !truth;}
-                    
-                    st.addEntry(rname, new shared SymEntry(truth));
-                }
-                // sort-based strategy if above medium bound
-                else {
-                    iLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                          "%t > %t, using sort-based strategy".format(ar2.size, mBound));
-                    var truth = in1dSort(ar1.a, ar2.a);
-                    if (invert) {truth = !truth;}
-
-                    st.addEntry(rname, new shared SymEntry(truth));
-                }
+                var truth = in1d(ar1.a, ar2.a, invert);
+                st.addEntry(rname, new shared SymEntry(truth));
             }
             when (DType.UInt64, DType.UInt64) {
                 var ar1 = toSymEntry(gAr1,uint);
                 var ar2 = toSymEntry(gAr2,uint);
 
-                // things to do...
-                // if ar2 is big for some value of big... call unique on ar2 first
-
-                // per locale assoc domain if below medium bound
-                if (ar2.size <= mBound) {
-                    iLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                               "%t <= %t, using Ar2PerLocAssoc".format(ar2.size,mBound));                  
-                    var truth = in1dAr2PerLocAssoc(ar1.a, ar2.a);
-                    if (invert) {truth = !truth;}
-                    
-                    st.addEntry(rname, new shared SymEntry(truth));
-                }
-                // sort-based strategy if above medium bound
-                else {
-                    iLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                          "%t > %t, using sort-based strategy".format(ar2.size, mBound));
-                    var truth = in1dSort(ar1.a, ar2.a);
-                    if (invert) {truth = !truth;}
-
-                    st.addEntry(rname, new shared SymEntry(truth));
-                }
+                var truth = in1d(ar1.a, ar2.a, invert);
+                st.addEntry(rname, new shared SymEntry(truth));
             }
             otherwise {
                 var errorMsg = notImplementedError(pn,gAr1.dtype,"in",gAr2.dtype);

--- a/src/Indexing.chpl
+++ b/src/Indexing.chpl
@@ -50,14 +50,4 @@ module Indexing {
         }
         return ret;
     }
-
-    // concatenate 2 distributed arrays and return the result
-    proc concatset(a: [?aD] ?t, b: [?bD] t) {
-      var ret = makeDistArray((a.size + b.size), t);
-      
-      ret[{0..#a.size}] = a;
-      ret[{a.size..#b.size}] = b;
-
-      return ret;
-    }
 }


### PR DESCRIPTION
Make a few implementation cleanups to in1d. There may be a small
performance benefit as well, but most of the time is spent sorting so
nothing major. Cleanups are:
 - Add a helper function to concatenate arrays for `in1dSort`
 - Drop the unused `counts` from `uniqueSort*` in `in1dSort`
 - Simplify the check for duplicates in` in1dSort`
 - Add in1d wrapper to select strategy instead of choosing at each callsite

Part of #970