### PR TITLE
Tune int in1d threshold

### DIFF
--- a/benchmarks/in1d.py
+++ b/benchmarks/in1d.py
@@ -5,10 +5,10 @@ import arkouda as ak
 
 TYPES = ('int64', 'uint64')
 
-# Must be less than src/In1dMsg.chpl:mbound, which defaults to 2**25
-MEDIUM = 2**25 - 1
-# Must be greater than mbound
-LARGE = 2**25 + 1
+# Tied to src/In1d.chpl:threshold, which defaults to 2**23
+THRESHOLD = 2**23
+MEDIUM = THRESHOLD - 1
+LARGE = THRESHOLD + 1
 
 def time_ak_in1d(N_per_locale, trials, dtype):
     print(f">>> arkouda {dtype} in1d")

--- a/src/In1d.chpl
+++ b/src/In1d.chpl
@@ -8,7 +8,7 @@ module In1d
     use Reflection;
 
     /* Threshold for choosing between in1d implementation strategies */
-    private config const threshold = 2**25;
+    private config const threshold = 2**23;
 
     /* For each value in the first array, check membership in the second array.
 


### PR DESCRIPTION
Tune the threshold for selecting in1d implementations. Even with recent
optimizations, the threshold for selecting between the set and sort
based strategies is a little too high. Drop from `2**25` down to
`2**23`, which is pretty good on 16-node-cs-hdr, 16-node-xc, and
512-node-xc. The ideal threshold depends on core count, node count, and
network bandwidth, but I think this will work well in practice. For some
configs `2**24` may be a little better, but we I'd prefer to stick lower
since we know the sort based methods scales well, it just has high
startup overhead.

Part of #970