### PR TITLE
Closes #1118 move segarray/dataframe from akutil

### DIFF
--- a/arkouda/__init__.py
+++ b/arkouda/__init__.py
@@ -17,4 +17,7 @@ from arkouda.categorical import *
 from arkouda.logger import *
 from arkouda.timeclass import *
 from arkouda.infoclass import *
+from arkouda.segarray import *
+from arkouda.dataframe import *
+from arkouda.row import *
 

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import UserDict
 from warnings import warn
-import pandas as pd
+import pandas as pd  # type: ignore
 import random
 
 from arkouda.segarray import SegArray
@@ -54,7 +54,6 @@ class DataFrame(UserDict):
     Create an empty DataFrame and add a column of data:
 
     >>> import arkouda as ak
-    >>> import pandas as pd
     >>> import numpy as np
     >>> df = ak.DataFrame()
     >>> df['a'] = ak.array([1,2,3])

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -1,13 +1,8 @@
 from __future__ import annotations
 
-from datetime import datetime
-from ipaddress import ip_address
 from collections import UserDict
-from tabulate import tabulate
 from warnings import warn
-import akutil as aku
 import pandas as pd
-import numpy as np
 import random
 
 from arkouda.segarray import SegArray
@@ -16,28 +11,38 @@ from arkouda.categorical import Categorical
 from arkouda.strings import Strings
 from arkouda.pdarraycreation import arange, array
 from arkouda.groupbyclass import GroupBy
-from arkouda.pdarraysetops import concatenate
+from arkouda.pdarraysetops import concatenate, unique, intersect1d, in1d
+from arkouda.pdarrayIO import save_all
+from arkouda.dtypes import int64 as akint64
+from arkouda.dtypes import float64 as akfloat64
+from arkouda.sorting import argsort, coargsort
+from arkouda.numeric import where
+from arkouda.client import maxTransferBytes
+from arkouda.row import Row
 
 # This is necessary for displaying DataFrames with BitVector columns,
 # because pandas _html_repr automatically truncates the number of displayed bits
 pd.set_option('display.max_colwidth', 64)
 
 __all__ = [
-        "DataFrame",
-        "sorted",
-        "intersect",
-        "invert_permutation",
-        "intx",
-    ]
+    "DataFrame",
+    "sorted",
+    "intersect",
+    "invert_permutation",
+    "intx",
+]
+
 
 def groupby_operators(cls):
-        for name in [ 'all','any','argmax','argmin','max','mean','min','nunique','prod','sum','OR', 'AND', 'XOR' ] :
-            setattr(cls,name, cls._make_aggop(name))
-        return cls
+    for name in ['all', 'any', 'argmax', 'argmin', 'max', 'mean', 'min', 'nunique', 'prod', 'sum', 'OR', 'AND', 'XOR']:
+        setattr(cls, name, cls._make_aggop(name))
+    return cls
+
 
 """
 DataFrame structure based on Arkouda arrays.
 """
+
 
 class DataFrame(UserDict):
     """
@@ -49,10 +54,9 @@ class DataFrame(UserDict):
     Create an empty DataFrame and add a column of data:
 
     >>> import arkouda as ak
-    >>> import akutil as aku
     >>> import pandas as pd
     >>> import numpy as np
-    >>> df = aku.DataFrame()
+    >>> df = ak.DataFrame()
     >>> df['a'] = ak.array([1,2,3])
 
     Create a new DataFrame using a dictionary of data:
@@ -62,7 +66,7 @@ class DataFrame(UserDict):
     >>> item = ak.array([0, 0, 1, 1, 2, 0])
     >>> day = ak.array([5, 5, 6, 5, 6, 6])
     >>> amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
-    >>> df = aku.DataFrame({'userName': userName, 'userID': userID,
+    >>> df = ak.DataFrame({'userName': userName, 'userID': userID,
     >>>            'item': item, 'day': day, 'amount': amount})
     >>> df
     DataFrame(['userName', 'userID', 'item', 'day', 'amount'] [6 rows : 224 B])
@@ -213,7 +217,7 @@ class DataFrame(UserDict):
             row = array([key])
             for k in self.data.keys():
                 result[k] = (UserDict.__getitem__(self, k)[row])[0]
-            return aku.Row(result)
+            return Row(result)
 
         # Select a single column using a string
         elif isinstance(key, str):
@@ -228,7 +232,7 @@ class DataFrame(UserDict):
             s = key
             for k in self._columns:
                 data[k] = UserDict.__getitem__(self, k)[s.start:s.stop:s.step]
-                # result._columns.append(k)
+            # result._columns.append(k)
             # result._empty = False
             return DataFrame(initialdata=data)
 
@@ -248,8 +252,8 @@ class DataFrame(UserDict):
             for k in self.data.keys():
                 if isinstance(self.data[k], Strings):
                     raise ValueError("This DataFrame has a column of type ak.Strings;"
-                    " so this DataFrame is immutable. This feature could change"
-                    " if arkouda supports mutable Strings in the future.")
+                                     " so this DataFrame is immutable. This feature could change"
+                                     " if arkouda supports mutable Strings in the future.")
             if self._empty:
                 raise ValueError("Initial data must be dict of arkouda arrays.")
             elif not isinstance(value, (dict, UserDict)):
@@ -257,7 +261,7 @@ class DataFrame(UserDict):
             elif key >= self._size:
                 raise KeyError("The row index is out of range.")
             else:
-                for k,v in value.items():
+                for k, v in value.items():
                     if k == 'index':
                         continue
                     self[k][key] = v
@@ -270,7 +274,7 @@ class DataFrame(UserDict):
                 raise ValueError("Expected size {} but received size {}.".format(self.size, value.size))
             else:
                 self._empty = False
-                UserDict.__setitem__(self,key,value)
+                UserDict.__setitem__(self, key, value)
                 # Update the index values
                 if key not in self._columns:
                     self._columns.append(key)
@@ -316,16 +320,16 @@ class DataFrame(UserDict):
         # Get units that make the most sense.
         if self._bytes < 1024:
             mem = self.memory_usage(unit='B')
-        elif self._bytes < 1024**2:
+        elif self._bytes < 1024 ** 2:
             mem = self.memory_usage(unit='KB')
-        elif self._bytes < 1024**3:
+        elif self._bytes < 1024 ** 3:
             mem = self.memory_usage(unit='MB')
         else:
             mem = self.memory_usage(unit='GB')
         rows = " rows"
         if self._size == 1:
             rows = " row"
-        return 'DataFrame(['+keystr+'], {:,}'.format(self._size)+rows+', '+str(mem)+')'
+        return 'DataFrame([' + keystr + '], {:,}'.format(self._size) + rows + ', ' + str(mem) + ')'
 
     def _get_head_tail(self):
         if self._empty:
@@ -333,7 +337,7 @@ class DataFrame(UserDict):
         self.update_size()
         maxrows = pd.get_option('display.max_rows')
         if self._size <= maxrows:
-            newdf = aku.DataFrame()
+            newdf = DataFrame()
             for col in self._columns:
                 if isinstance(self[col], Categorical):
                     newdf[col] = self[col].categories[self[col].codes]
@@ -341,8 +345,8 @@ class DataFrame(UserDict):
                     newdf[col] = self[col]
             return newdf.to_pandas(retain_index=True)
         # Being 1 above the threshold caises the PANDAS formatter to split the data frame vertically
-        idx = array(list(range(maxrows//2+1)) + list(range(self._size - (maxrows//2), self._size)))
-        newdf = aku.DataFrame()
+        idx = array(list(range(maxrows // 2 + 1)) + list(range(self._size - (maxrows // 2), self._size)))
+        newdf = DataFrame()
         for col in self._columns[1:]:
             if isinstance(self[col], Categorical):
                 newdf[col] = self[col].categories[self[col].codes[idx]]
@@ -352,7 +356,7 @@ class DataFrame(UserDict):
         return newdf.to_pandas(retain_index=True)
 
     def _shape_str(self):
-        return "{} rows x {} columns".format(self.size,self._ncols() )
+        return "{} rows x {} columns".format(self.size, self._ncols())
 
     def __repr__(self):
         """
@@ -467,7 +471,7 @@ class DataFrame(UserDict):
                 dtypes.append(str(val.dtype))
             elif isinstance(val, Strings):
                 dtypes.append('str')
-        res = aku.Row({key: dtype for key, dtype in zip(keys, dtypes)})
+        res = Row({key: dtype for key, dtype in zip(keys, dtypes)})
         return res
 
     @property
@@ -509,3 +513,717 @@ class DataFrame(UserDict):
             self.data['index'] = arange(0, self._size)
         else:
             self.data['index'] = arange(size)
+
+    @property
+    def info(self):
+        """
+        Returns a summary string of this dataframe.
+        """
+
+        self.update_size()
+
+        if self._size is None:
+            return 'DataFrame([ -- ][ 0 rows : 0 B])'
+
+        keys = [str(key) for key in list(self.data.keys())]
+        keys = [("'" + key + "'") for key in keys]
+        keystr = ", ".join(keys)
+
+        # first call to memory_usage() initializes self._bytes
+        mem = self.memory_usage()
+
+        # Get units that make the most sense.
+        if self._bytes < 1024:
+            mem = self.memory_usage(unit='B')
+        elif self._bytes < 1024 ** 2:
+            mem = self.memory_usage(unit='KB')
+        elif self._bytes < 1024 ** 3:
+            mem = self.memory_usage(unit='MB')
+        else:
+            mem = self.memory_usage(unit='GB')
+        rows = " rows"
+        if self._size == 1:
+            rows = " row"
+        return 'DataFrame([' + keystr + '], {:,}'.format(self._size) + rows + ', ' + str(mem) + ')'
+
+    def update_size(self):
+        """
+        Computes the number of bytes on the arkouda server.
+        """
+
+        sizes = set()
+        for key, val in self.items():
+            if val is not None:
+                sizes.add(val.size)
+        if len(sizes) > 1:
+            raise ValueError("Size mismatch in DataFrame columns.")
+        if len(sizes) == 0:
+            self._size = None
+        else:
+            self._size = sizes.pop()
+
+    def rename(self, mapper):
+        """
+        Rename columns in-place according to a mapping.
+
+        Parameters
+        ----------
+        mapper : callable or dict-like
+            Function or dictionary mapping existing column names to
+            new column names. Nonexistent names will not raise an
+            error.
+
+        Returns
+        -------
+        self
+            Renaming occurs in-place, but result is also returned,
+            for compatibility.
+        """
+
+        if callable(mapper):
+            # Do not rename index, start at 1
+            for i in range(1, len(self._columns)):
+                oldname = self._columns[i]
+                newname = mapper(oldname)
+                # Only rename if name has changed
+                if newname != oldname:
+                    self._columns[i] = newname
+                    self.data[newname] = self.data[oldname]
+                    del self.data[oldname]
+        elif isinstance(mapper, dict):
+            for oldname, newname in mapper.items():
+                # Only rename if name has changed
+                if newname != oldname:
+                    try:
+                        i = self._columns.index(oldname)
+                        self._columns[i] = newname
+                        self.data[newname] = self.data[oldname]
+                        del self.data[oldname]
+                    except:
+                        pass
+        else:
+            raise TypeError("Argument must be callable or dict-like")
+        return self
+
+    def append(self, other, ordered=True):
+        # TODO - remove error and define function once akutil/util.py moved to arkouda
+        raise NotImplementedError("Append functionality is not yet available for dataframes in arkouda. For updates, please visit https://github.com/Bears-R-Us/arkouda/issues/1126")
+
+    @classmethod
+    def concat(cls, items, ordered=True):
+        # TODO - remove error and define function once akutil/util.py moved to arkouda
+        raise NotImplementedError("Append functionality is not yet available for dataframes in arkouda. For updates, please visit https://github.com/Bears-R-Us/arkouda/issues/1126")
+
+    def head(self, n=5):
+        """
+        Return the first `n` rows.
+
+        This function returns the first `n` rows of the the dataframe. It is
+        useful for quickly verifying data, for example, after sorting or
+        appending rows.
+
+        Parameters
+        ----------
+        n : int
+            Number of rows to select.
+
+        Returns
+        -------
+        akutil.DataFrame
+            The first `n` rows of the DataFrame.
+
+        See Also
+        --------
+        tail
+        """
+
+        return self[:n]
+
+    def tail(self, n=5):
+        """
+        Return the last `n` rows.
+
+        This function returns the last `n` rows for the dataframe. It is
+        useful for quickly testing if your object has the right type of data in
+        it.
+
+        Parameters
+        ----------
+        n : int (default=5)
+            Number of rows to select.
+
+        Returns
+        -------
+        akutil.DataFrame
+            The last `n` rows of the DataFrame.
+
+        See Also
+        --------
+        akutil.dataframe.head
+        """
+
+        self.update_size()
+        if self._size <= n:
+            return self
+        return self[self._size - n:]
+
+    def sample(self, n=5):
+        """
+        Return a random sample of `n` rows.
+
+        Parameters
+        ----------
+        n : int (default=5)
+            Number of rows to return.
+
+        Returns
+        -------
+        akutil.DataFrame
+            The sampled `n` rows of the DataFrame.
+        """
+        self.update_size()
+        if self._size <= n:
+            return self
+        return self[array(random.sample(range(self._size), n))]
+
+    def GroupBy(self, keys, use_series=False):
+        """
+        Group the dataframe by a column or a list of columns.
+
+        Parameters
+        ----------
+        keys : string or list
+            An (ordered) list of column names or a single string to group by.
+        use_series : If True, returns an akutil.GroupBy oject. Otherwise an arkouda GroupBy object
+
+        Returns
+        -------
+        GroupBy
+            Either an akutil GroupBy or an arkouda GroupBy object.
+
+        See Also
+        --------
+        arkouda.GroupBy
+        """
+
+        self.update_size()
+        if isinstance(keys, str):
+            cols = self.data[keys]
+        elif not isinstance(keys, list):
+            raise TypeError("keys must be a colum name or a list of column names")
+        elif len(keys) == 1:
+            cols = self.data[keys[0]]
+        else:
+            cols = [self.data[col] for col in keys]
+        gb = GroupBy(cols)
+        if use_series:
+            # TODO - remove the error and implement once series is configured
+            #	gb = GroupBy(gb, self)
+            raise NotImplementedError("akutil GroupBy functionality using series has not yet been implemented in "
+                                      "Arkouda. For updates, please visit https://github.com/Bears-R-Us/arkouda/issues/1128")
+        return gb
+
+    def memory_usage(self, unit='GB'):
+        """
+        Print the size of this DataFrame.
+
+        Parameters
+        ----------
+        unit : str
+            Unit to return. One of {'KB', 'MB', 'GB'}.
+
+        Returns
+        -------
+        int
+            The number of bytes used by this DataFrame in [unit]s.
+        """
+
+        KB = 1024
+        MB = KB * KB
+        GB = MB * KB
+        self._bytes = 0
+        for key, val in self.items():
+            if isinstance(val, pdarray):
+                self._bytes += (val.dtype).itemsize * val.size
+            elif isinstance(val, Strings):
+                self._bytes += val.nbytes
+        if unit == 'B':
+            return "{:} B".format(int(self._bytes))
+        elif unit == 'MB':
+            return "{:} MB".format(int(self._bytes / MB))
+        elif unit == 'KB':
+            return "{:} KB".format(int(self._bytes / KB))
+        return "{:.2f} GB".format(self._bytes / GB)
+
+    def to_pandas(self, datalimit=maxTransferBytes, retain_index=False):
+        """
+        Send this DataFrame to a pandas DataFrame.
+
+        Parameters
+        ----------
+        datalimit : int (default=arkouda.client.maxTransferBytes)
+            The maximum number size, in megabytes to transfer. The requested
+            DataFrame will be converted to a pandas DataFrame only if the
+            estimated size of the DataFrame does not exceed this value.
+
+        retain_index : book (default=False)
+            Normally, to_pandas() creates a new range index object. If you want
+            to keep the index column, set this to True.
+
+        Returns
+        -------
+        pandas.DataFrame
+            The result of converting this DataFrame to a pandas DataFrame.
+        """
+
+        self.update_size()
+
+        # Estimate how much memory would be required for this DataFrame
+        nbytes = 0
+        for key, val in self.items():
+            if isinstance(val, pdarray):
+                nbytes += (val.dtype).itemsize * self._size
+            elif isinstance(val, Strings):
+                nbytes += val.nbytes
+
+        KB = 1024
+        MB = KB * KB
+        GB = MB * KB
+
+        # Get units that make the most sense.
+        msg = ""
+        if nbytes < KB:
+            msg = "{:,} B".format(nbytes)
+        elif nbytes < MB:
+            msg = "{:,} KB".format(int(nbytes / KB))
+        elif nbytes < GB:
+            msg = "{:,} MB".format(int(nbytes / MB))
+            print(f"This transfer will use " + msg + ".")
+        else:
+            msg = "{:,} GB".format(int(nbytes / GB))
+            print(f"This will transfer " + msg + " from arkouda to pandas.")
+        # If the total memory transfer requires more than `datalimit` per
+        # column, we will warn the user and return.
+        if nbytes > (datalimit * len(self._columns) * MB):
+            msg = f"This operation would transfer more than {datalimit} bytes."
+            warn(msg, UserWarning)
+            return None
+
+        # Proceed with conversion if possible, ignore index column
+        pandas_data = {}
+        for key in self._columns[1:]:
+            val = self[key]
+            try:
+                pandas_data[key] = val.to_ndarray()
+            except TypeError as e:
+                raise IndexError("Bad index type or format.")
+
+        # Return a new dataframe with original indices if requested.
+        if retain_index and 'index' in self:
+            index = self.data['index'].to_ndarray()
+            return pd.DataFrame(data=pandas_data, index=index)
+
+        else:
+            return pd.DataFrame(data=pandas_data)
+
+    def save(self, path, index=False):
+        """
+        Save DataFrame to disk, preserving column names.
+
+        Parameters
+        ----------
+        path : str
+            File path to save data
+        index : bool
+            If True, save the index column. By default, do not save the index.
+
+        Notes
+        -----
+        This method saves one file per locale of the arkouda server. All
+        files are prefixed by the path argument and suffixed by their
+        locale number.
+        """
+        tosave = {k: v for k, v in self.data.items() if (index or k != "index")}
+        save_all(tosave, path)
+
+    def argsort(self, key, ascending=True):
+        """
+        Return the permutation that sorts the dataframe by `key`.
+
+        Parameters
+        ----------
+        key : str
+            The key to sort on.
+
+        Returns
+        -------
+        ak.pdarray
+            The permutation array that sorts the data on `key`.
+        """
+
+        if self._empty:
+            return array([], dtype=akint64)
+        if ascending:
+            return argsort(self[key])
+        else:
+            if isinstance(self[key], pdarray) and self[key].dtype in (akint64, akfloat64):
+                return argsort(-self[key])
+            else:
+                return argsort(self[key])[arange(self.size - 1, -1, -1)]
+
+    def coargsort(self, keys, ascending=True):
+        """
+        Return the permutation that sorts the dataframe by `keys`.
+
+        Parameters
+        ----------
+        keys : list
+            The keys to sort on.
+
+        Returns
+        -------
+        ak.pdarray
+            The permutation array that sorts the data on `keys`.
+        """
+
+        if self._empty:
+            return array([], dtype=akint64)
+        arrays = []
+        for key in keys:
+            arrays.append(self[key])
+        i = coargsort(arrays)
+        if not ascending:
+            i = i[arange(self.size - 1, -1, -1)]
+        return i
+
+    def sort_values(self, by=None, ascending=True):
+        """
+        Sort the DataFrame by one or more columns.
+
+        If no column is specified, all columns are used.
+
+        Parameters
+        ----------
+        key : str or list/tuple of str
+            The name(s) of the column(s) to sort by.
+        ascending : bool
+            Sort values in ascending (default) or descending order.
+
+        See Also
+        --------
+        apply_permutation, sorted
+        """
+
+        if self._empty:
+            return array([], dtype=akint64)
+        if by is None:
+            if len(self._columns) == 2:
+                i = self.argsort(self._columns[1], ascending=ascending)
+            else:
+                i = self.coargsort(self._columns[1:], ascending=ascending)
+        elif isinstance(by, str):
+            i = self.argsort(by, ascending=ascending)
+        elif isinstance(by, (list, tuple)):
+            i = self.coargsort(by, ascending=ascending)
+        else:
+            raise TypeError("Column name(s) must be str or list/tuple of str")
+        return self[i]
+
+    def apply_permutation(self, perm):
+        """
+        Apply a permutation to an entire DataFrame.
+
+        This may be useful if you want to unsort an DataFrame, or even to
+        apply an arbitrary permutation such as the inverse of a sorting
+        permutation.
+
+        Parameters
+        ----------
+        perm : ak.pdarray
+            A permutation array. Should be the same size as the data
+            arrays, and should consist of the integers [0,size-1] in
+            some order. Very minimal testing is done to ensure this
+            is a permutation.
+
+        See Also
+        --------
+        sort
+        """
+
+        if (perm.min() != 0) or (perm.max() != perm.size - 1):
+            raise ValueError("The indicated permutation is invalid.")
+        if unique(perm).size != perm.size:
+            raise ValueError("The indicated permutation is invalid.")
+        for key, val in self.data.items():
+            self[key] = self[key][perm]
+
+    def filter_by_range(self, keys, low=1, high=None):
+        """
+        Find all rows where the value count of the items in a given set of
+        columns (keys) is within the range [low, high].
+
+        To filter by a specific value, set low == high.
+
+        Parameters
+        ----------
+        keys : list or str
+            The names of the columns to group by
+        low : int (default=1)
+            The lowest value count.
+        high : int (default=None)
+            The highest value count, default to unlimited.
+
+        Returns
+        -------
+        pdarray
+            An array of boolean values for qualified rows in this DataFrame.
+
+        See Also
+        --------
+        filter_by_count
+        """
+
+        if isinstance(keys, str):
+            keys = [keys]
+        gb = self.GroupBy(keys, use_series=False)
+        vals, cts = gb.count()
+        if not high:
+            positions = where(cts >= low, 1, 0)
+        else:
+            positions = where(((cts >= low) & (cts <= high)), 1, 0)
+
+        broadcast = gb.broadcast(positions, permute=False)
+        broadcast = (broadcast == 1)
+        return broadcast[invert_permutation(gb.permutation)]
+
+    def copy(self, deep=True):
+        """
+        Make a copy of this object's data.
+
+        When `deep = True` (default), a new object will be created with a copy of
+        the calling object's data. Modifications to the data of the copy will not
+        be reflected in the original object.
+
+
+        When `deep = False` a new object will be created without copying the
+        calling object's data. Any changes to the data of the original object will
+        be reflected in the shallow copy, and vice versa.
+
+        Parameters
+        ----------
+        deep : bool (default=True)
+            When True, return a deep copy. Otherwise, return a shallow copy.
+
+        Returns
+        -------
+        aku.DataFrame
+            A deep or shallow copy according to caller specification.
+        """
+
+        if deep:
+            res = DataFrame()
+            res._size = self._size
+            res._bytes = self._bytes
+            res._empty = self._empty
+            res._columns = self._columns
+
+            for key, val in self.items():
+                res[key] = val[:]
+
+            return res
+        else:
+            return DataFrame(self.data)
+
+    def groupby(self, keys, use_series=True):
+        """Group the dataframe by a column or a list of columns.  Alias for GroupBy
+
+        Parameters
+        ----------
+        keys : a single column name or a list of column names
+        use_series : Change return type to Arkouda Groupby object.
+
+        Returns
+        -------
+        An arkouda Groupby instance
+        """
+
+        return self.GroupBy(keys, use_series)
+
+
+def sorted(df, column=False):
+    """
+    Analogous to other python 'sorted(obj)' functions in that it returns
+    a sorted copy of the DataFrame.
+
+    If no sort key is specified, sort by the first key returned.
+
+    Note: This fails on sorting ak.Strings, as does DataFrame.sort().
+
+    Parameters
+    ----------
+    df : akutil.dataframe.DataFrame
+        The DataFrame to sort.
+
+    column : str
+        The name of the column to sort by.
+
+    Returns
+    -------
+    akutil.dataframe.DataFrame
+        A sorted copy of the original DataFrame.
+    """
+
+    if not isinstance(df, DataFrame):
+        raise TypeError("The sorted operation requires an DataFrame.")
+    result = DataFrame(df.data)
+    result.sort(column)
+    return result
+
+
+def intx(a, b):
+    # TODO - define function once akutil/alignment.py is moved into arkouda
+    raise NotImplementedError("intx functionality from akutil is not yet available in arkouda. For updates, visit https://github.com/Bears-R-Us/arkouda/issues/1127")
+
+
+def intersect(a, b, positions=True, unique=False):
+    """
+    Find the intersection of two arkouda arrays.
+
+    This function can be especially useful when `positions=True` so
+    that the caller gets the indices of values present in both arrays.
+
+    Parameters
+    ----------
+    a : ak.Strings or ak.pdarray
+        An array of strings
+
+    b : ak.Strings or ak.pdarray
+        An array of strings
+
+    positions : bool (default=True)
+        Return tuple of boolean pdarrays that indicate positions in a and b
+        where the values are in the intersection.
+
+    unique : bool (default=False)
+        If the number of distinct values in `a` (and `b`) is equal to the size of
+        `a` (and `b`), there is a more efficient method to compute the intersection.
+
+    Returns
+    -------
+    (ak.pdarray, ak.pdarray)
+        The indices of `a` and `b` where any element occurs at least once in both
+        arrays.
+    """
+
+    # To ensure compatibility with all types of arrays:
+    if (isinstance(a, pdarray) and isinstance(b, pdarray)):
+        intx = intersect1d(a, b)
+        if not positions:
+            return intx
+        else:
+            maska = in1d(a, intx)
+            maskb = in1d(b, intx)
+            return (maska, maskb)
+
+    # It takes more effort to do this with ak.Strings arrays.
+    elif (isinstance(a, Strings) and isinstance(b, Strings)):
+
+        # Hash the two arrays first
+        hash_a00, hash_a01 = a.hash()
+        hash_b00, hash_b01 = b.hash()
+
+        # a and b do not have duplicate entries, so the hashes are distinct
+        if unique:
+            hash0 = concatenate([hash_a00, hash_b00])
+            hash1 = concatenate([hash_a01, hash_b01])
+
+            # Group by the unique hashes
+            gb = GroupBy([hash0, hash1])
+            val, cnt = gb.count()
+
+            # Hash counts, in groupby order
+            counts = gb.broadcast(cnt, permute=False)
+
+            # Same, in original order
+            tmp = counts[:]
+            counts[gb.permutation] = tmp
+            del tmp
+
+            # Masks
+            maska = (counts > 1)[:a.size]
+            maskb = (counts > 1)[a.size:]
+
+            # The intersection for each array of hash values
+            if positions:
+                return (maska, maskb)
+            else:
+                return a[maska]
+
+        # a and b may have duplicate entries, so get the unique hash values
+        else:
+            gba = GroupBy([hash_a00, hash_a01])
+            gbb = GroupBy([hash_b00, hash_b01])
+
+            # Take the unique keys as the hash we'll work with
+            a0, a1 = gba.unique_keys
+            b0, b1 = gbb.unique_keys
+            hash0 = concatenate([a0, b0])
+            hash1 = concatenate([a1, b1])
+
+            # Group by the unique hashes
+            gb = GroupBy([hash0, hash1])
+            val, cnt = gb.count()
+
+            # Hash counts, in groupby order
+            counts = gb.broadcast(cnt, permute=False)
+
+            # Restore the original order
+            tmp = counts[:]
+            counts[gb.permutation] = tmp
+            del tmp
+
+            # Broadcast back up one more level
+            countsa = counts[:a0.size]
+            countsb = counts[a0.size:]
+            counts2a = gba.broadcast(countsa, permute=False)
+            counts2b = gbb.broadcast(countsb, permute=False)
+
+            # Restore the original orders
+            tmp = counts2a[:]
+            counts2a[gba.permutation] = tmp
+            del tmp
+            tmp = counts2b[:]
+            counts2b[gbb.permutation] = tmp
+            del tmp
+
+            # Masks
+            maska = (counts2a > 1)
+            maskb = (counts2b > 1)
+
+            # The intersection for each array of hash values
+            if positions:
+                return (maska, maskb)
+            else:
+                return a[maska]
+
+
+def invert_permutation(perm):
+    """
+    Find the inverse of a permutation array.
+
+    Parameters
+    ----------
+    perm : ak.pdarray
+        The permutation array.
+
+    Returns
+    -------
+    ak.pdarray
+        The inverse of the permutation array.
+    """
+
+    # Test if the array is actually a permutation
+    rng = perm.max() - perm.min()
+    if (unique(perm).size != perm.size) and (perm.size != rng + 1):
+        raise ValueError("The array is not a permutation.")
+    return coargsort([perm, arange(0, perm.size)])

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -875,6 +875,8 @@ class DataFrame(UserDict):
         """
         Return the permutation that sorts the dataframe by `keys`.
 
+        Sorting using Strings may not yield correct results
+
         Parameters
         ----------
         keys : list
@@ -902,9 +904,11 @@ class DataFrame(UserDict):
 
         If no column is specified, all columns are used.
 
+        Note: Fails on sorting ak.Strings when multiple columns being sorted
+
         Parameters
         ----------
-        key : str or list/tuple of str
+        by : str or list/tuple of str
             The name(s) of the column(s) to sort by.
         ascending : bool
             Sort values in ascending (default) or descending order.
@@ -1032,7 +1036,7 @@ class DataFrame(UserDict):
 
             return res
         else:
-            return DataFrame(self.data)
+            return DataFrame(self)
 
     def groupby(self, keys, use_series=True):
         """Group the dataframe by a column or a list of columns.  Alias for GroupBy

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -1,0 +1,511 @@
+from __future__ import annotations
+
+from datetime import datetime
+from ipaddress import ip_address
+from collections import UserDict
+from tabulate import tabulate
+from warnings import warn
+import akutil as aku
+import pandas as pd
+import numpy as np
+import random
+
+from arkouda.segarray import SegArray
+from arkouda.pdarrayclass import pdarray
+from arkouda.categorical import Categorical
+from arkouda.strings import Strings
+from arkouda.pdarraycreation import arange, array
+from arkouda.groupbyclass import GroupBy
+from arkouda.pdarraysetops import concatenate
+
+# This is necessary for displaying DataFrames with BitVector columns,
+# because pandas _html_repr automatically truncates the number of displayed bits
+pd.set_option('display.max_colwidth', 64)
+
+__all__ = [
+        "DataFrame",
+        "sorted",
+        "intersect",
+        "invert_permutation",
+        "intx",
+    ]
+
+def groupby_operators(cls):
+        for name in [ 'all','any','argmax','argmin','max','mean','min','nunique','prod','sum','OR', 'AND', 'XOR' ] :
+            setattr(cls,name, cls._make_aggop(name))
+        return cls
+
+"""
+DataFrame structure based on Arkouda arrays.
+"""
+
+class DataFrame(UserDict):
+    """
+    A DataFrame structure based on arkouda arrays.
+
+    Examples
+    --------
+
+    Create an empty DataFrame and add a column of data:
+
+    >>> import arkouda as ak
+    >>> import akutil as aku
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> df = aku.DataFrame()
+    >>> df['a'] = ak.array([1,2,3])
+
+    Create a new DataFrame using a dictionary of data:
+
+    >>> userName = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+    >>> userID = ak.array([111, 222, 111, 333, 222, 111])
+    >>> item = ak.array([0, 0, 1, 1, 2, 0])
+    >>> day = ak.array([5, 5, 6, 5, 6, 6])
+    >>> amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
+    >>> df = aku.DataFrame({'userName': userName, 'userID': userID,
+    >>>            'item': item, 'day': day, 'amount': amount})
+    >>> df
+    DataFrame(['userName', 'userID', 'item', 'day', 'amount'] [6 rows : 224 B])
+
+    Indexing works slightly differently than with pandas:
+    >>> df[0]
+    {'userName': 'Alice', 'userID': 111, 'item': 0, 'day': 5, 'amount': 0.5}
+    >>> df['userID']
+    array([111, 222, 111, 333, 222, 111])
+    >>> df['userName']
+    array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+    >>> df[[1,5,7]]
+      userName  userID  item  day  amount
+    1      Bob     222     0    5     0.6
+    2    Alice     111     1    6     1.1
+    3    Carol     333     1    5     1.2
+
+    Note that strides are not implemented except for stride = 1.
+    >>> df[1:5:1]
+    DataFrame(['userName', 'userID', 'item', 'day', 'amount'] [4 rows : 148 B])
+    >>> df[ak.array([1,2,3])]
+    DataFrame(['userName', 'userID', 'item', 'day', 'amount'] [3 rows : 112 B])
+    >>> df[['userID', 'day']]
+    DataFrame(['userID', 'day'] [6 rows : 96 B])
+    """
+
+    COLUMN_CLASSES = (pdarray, Strings, Categorical, SegArray)
+
+    def __init__(self, initialdata=None):
+        super().__init__()
+
+        if isinstance(initialdata, DataFrame):
+            # Copy constructor
+            self._size = initialdata._size
+            self._bytes = initialdata._bytes
+            self._empty = initialdata._empty
+            self._columns = initialdata._columns
+            self.data = initialdata.data
+            self.update_size()
+            return
+
+        # Some metadata about this dataframe.
+        self._size = 0
+        self._bytes = 0
+        self._empty = True
+
+        # Initial attempts to keep an order on the columns
+        self._columns = ['index']
+        self.data['index'] = None
+
+        # Add data to the DataFrame if there is any
+        if initialdata is not None:
+            # Used to prevent uneven array length in initialization.
+            sizes = set()
+
+            # Initial data is a dictionary of arkouda arrays
+            if type(initialdata) == dict:
+                for key, val in initialdata.items():
+                    if not isinstance(val, self.COLUMN_CLASSES):
+                        raise ValueError(f"Values must be one of {self.COLUMN_CLASSES}.")
+                    sizes.add(val.size)
+                    if len(sizes) > 1:
+                        raise ValueError("Input arrays must have equal size.")
+                    self._empty = False
+                    UserDict.__setitem__(self, key, val)
+                    # Update the column index
+                    if key != 'index':
+                        self._columns.append(key)
+
+            # Initial data is a list of arkouda arrays
+            elif type(initialdata) == list:
+                # Create string IDs for the columns
+                keys = [str(x) for x in range(len(initialdata))]
+                for key, col in zip(keys, initialdata):
+                    if not isinstance(col, self.COLUMN_CLASSES):
+                        raise ValueError(f"Values must be one of {self.COLUMN_CLASSES}.")
+                    sizes.add(col.size)
+                    if len(sizes) > 1:
+                        raise ValueError("Input arrays must have equal size.")
+                    self._empty = False
+                    UserDict.__setitem__(self, key, col)
+                    # Update the column index
+                    self._columns.append(key)
+
+            # Initial data is invalid.
+            else:
+                raise ValueError(f"Initialize with dict or list of {self.COLUMN_CLASSES}.")
+
+            # Update the dataframe indices and metadata.
+            if len(sizes) > 0:
+                self._size = sizes.pop()
+            # If the index column was passed in, use that instead of
+            # creating a new one.
+            if self.data['index'] is None:
+                self.data['index'] = arange(0, self._size, 1)
+
+            self.update_size()
+
+    def __delitem__(self, key):
+        # This function is a backdoor to messing up the indices and columns.
+        # I needed to reimplement it to prevent bad behavior
+        if key == 'index':
+            raise KeyError('The index column may be reset, but not dropped.')
+        else:
+            UserDict.__delitem__(self, key)
+            self._columns.remove(key)
+
+        # If removing this column emptied the dataframe
+        if len(self._columns) == 1:
+            self.data['index'] = None
+            self._empty = True
+        self.update_size()
+
+    def __getitem__(self, key):
+        # Select rows using an integer pdarray
+        if isinstance(key, pdarray):
+            result = {}
+            for k in self._columns:
+                result[k] = UserDict.__getitem__(self, k)[key]
+            return DataFrame(initialdata=result)
+
+        # Select rows or columns using a list
+        if isinstance(key, list):
+            result = DataFrame()
+            if len(key) <= 0:
+                return result
+            if len({type(x) for x in key}) > 1:
+                raise TypeError("Invalid selector: too many types in list.")
+            if type(key[0]) == int:
+                rows = array(key)
+                for k in self.data.keys():
+                    result.data[k] = UserDict.__getitem__(self, k)[rows]
+                    result._columns.append(k)
+                result._empty = False
+                return result
+            elif type(key[0]) == str:
+                # Grab the index column as well.
+                result.data['index'] = UserDict.__getitem__(self, 'index')
+                for k in key:
+                    result.data[k] = UserDict.__getitem__(self, k)
+                    result._columns.append(k)
+                result._empty = False
+                return result
+
+        # Select a single row using an integer
+        if isinstance(key, int):
+            result = {}
+            row = array([key])
+            for k in self.data.keys():
+                result[k] = (UserDict.__getitem__(self, k)[row])[0]
+            return aku.Row(result)
+
+        # Select a single column using a string
+        elif isinstance(key, str):
+            if key not in self.keys():
+                raise KeyError("Invalid column name '{}'.".format(key))
+            return UserDict.__getitem__(self, key)
+
+        # Select rows using a slice
+        elif isinstance(key, slice):
+            # result = DataFrame()
+            data = {}
+            s = key
+            for k in self._columns:
+                data[k] = UserDict.__getitem__(self, k)[s.start:s.stop:s.step]
+                # result._columns.append(k)
+            # result._empty = False
+            return DataFrame(initialdata=data)
+
+        else:
+            raise IndexError("Invalid selector: unknown error.")
+
+    def __setitem__(self, key, value):
+        self.update_size()
+
+        # If this is the first column added, we must create an index column.
+        add_index = False
+        if self._empty:
+            add_index = True
+
+        # Set a single row in the dataframe using a dict of values
+        if type(key) == int:
+            for k in self.data.keys():
+                if isinstance(self.data[k], Strings):
+                    raise ValueError("This DataFrame has a column of type ak.Strings;"
+                    " so this DataFrame is immutable. This feature could change"
+                    " if arkouda supports mutable Strings in the future.")
+            if self._empty:
+                raise ValueError("Initial data must be dict of arkouda arrays.")
+            elif not isinstance(value, (dict, UserDict)):
+                raise ValueError("Expected dict or Row type.")
+            elif key >= self._size:
+                raise KeyError("The row index is out of range.")
+            else:
+                for k,v in value.items():
+                    if k == 'index':
+                        continue
+                    self[k][key] = v
+
+        # Set a single column in the dataframe using a an arkouda array
+        elif type(key) == str:
+            if not isinstance(value, self.COLUMN_CLASSES):
+                raise ValueError(f"Column must be one of {self.COLUMN_CLASSES}.")
+            elif self._size is not None and self._size != value.size:
+                raise ValueError("Expected size {} but received size {}.".format(self.size, value.size))
+            else:
+                self._empty = False
+                UserDict.__setitem__(self,key,value)
+                # Update the index values
+                if key not in self._columns:
+                    self._columns.append(key)
+
+        # Do nothing and return if there's no valid data
+        else:
+            raise ValueError("No valid data received.")
+
+        # Update the dataframe indices and metadata.
+        if add_index:
+            self.update_size()
+            self.data['index'] = arange(0, self._size, 1)
+
+    def __len__(self):
+        """
+        Return the number of rows
+        """
+        return self.size
+
+    def _ncols(self):
+        """
+        Only count the non-index columns.
+        """
+        return len(list(self.data.keys())) - 1
+
+    def __str__(self):
+        """
+        Returns a summary string of this dataframe.
+        """
+
+        self.update_size()
+
+        if self._empty:
+            return 'DataFrame([ -- ][ 0 rows : 0 B])'
+
+        keys = [str(key) for key in list(self.data.keys())]
+        keys = [("'" + key + "'") for key in keys]
+        keystr = ", ".join(keys)
+
+        # first call to memory_usage() initializes self._bytes
+        mem = self.memory_usage()
+
+        # Get units that make the most sense.
+        if self._bytes < 1024:
+            mem = self.memory_usage(unit='B')
+        elif self._bytes < 1024**2:
+            mem = self.memory_usage(unit='KB')
+        elif self._bytes < 1024**3:
+            mem = self.memory_usage(unit='MB')
+        else:
+            mem = self.memory_usage(unit='GB')
+        rows = " rows"
+        if self._size == 1:
+            rows = " row"
+        return 'DataFrame(['+keystr+'], {:,}'.format(self._size)+rows+', '+str(mem)+')'
+
+    def _get_head_tail(self):
+        if self._empty:
+            return pd.DataFrame()
+        self.update_size()
+        maxrows = pd.get_option('display.max_rows')
+        if self._size <= maxrows:
+            newdf = aku.DataFrame()
+            for col in self._columns:
+                if isinstance(self[col], Categorical):
+                    newdf[col] = self[col].categories[self[col].codes]
+                else:
+                    newdf[col] = self[col]
+            return newdf.to_pandas(retain_index=True)
+        # Being 1 above the threshold caises the PANDAS formatter to split the data frame vertically
+        idx = array(list(range(maxrows//2+1)) + list(range(self._size - (maxrows//2), self._size)))
+        newdf = aku.DataFrame()
+        for col in self._columns[1:]:
+            if isinstance(self[col], Categorical):
+                newdf[col] = self[col].categories[self[col].codes[idx]]
+            else:
+                newdf[col] = self[col][idx]
+        newdf['index'] = self['index'][idx]
+        return newdf.to_pandas(retain_index=True)
+
+    def _shape_str(self):
+        return "{} rows x {} columns".format(self.size,self._ncols() )
+
+    def __repr__(self):
+        """
+        Return ascii-formatted version of the dataframe.
+        """
+
+        prt = self._get_head_tail()
+        with pd.option_context("display.show_dimensions", False):
+            retval = prt.__repr__()
+        retval += self._shape_str()
+        return retval
+
+    def _repr_html_(self):
+        """
+        Return html-formatted version of the dataframe.
+        """
+
+        prt = self._get_head_tail()
+        with pd.option_context("display.show_dimensions", False):
+            retval = prt._repr_html_()
+        retval += "<p>" + self._shape_str() + "</p>"
+        return retval
+
+    def _ipython_key_completions_(self):
+        return self._columns
+
+    def drop(self, keys):
+        """
+        Drop a column or columns from the dataframe, in-place.
+
+        Parameters
+        ----------
+        keys : str or list
+            The column(s) to be dropped.
+        """
+
+        if isinstance(keys, str):
+            keys = [keys]
+        for key in keys:
+            # Do not allow the user to drop the index column
+            if key == 'index':
+                raise KeyError('The index column may be reset, but not dropped.')
+
+            del self[key]
+
+        # If the dataframe just became empty...
+        if len(self._columns) == 1:
+            self.data['index'] = None
+            self._empty = True
+        self.update_size()
+
+    def drop_duplicates(self, subset=None, keep='first'):
+        """
+        Drops duplcated rows and returns resulting DataFrame.
+
+        If a subset of the columns are provided then only one instance of each
+        duplicated row will be returned (keep determines which row).
+
+        Parameters
+        ----------
+        subset : Iterable of column names to use to dedupe.
+        keep : {'first', 'last'}, default 'first'
+            Determines which duplicates (if any) to keep.
+
+        Returns
+        -------
+        DataFrame
+            DataFrame with duplicates removed.
+        """
+        if self._empty:
+            return self
+
+        if not subset:
+            subset = self._columns[1:]
+
+        if len(subset) == 1:
+            if not subset[0] in self.data:
+                raise KeyError("{} is not a column in the DataFrame.".format(subset[0]))
+            _ = GroupBy(self.data[subset[0]])
+
+        else:
+            for col in subset:
+                if not col in self.data:
+                    raise KeyError("{} is not a column in the DataFrame.".format(subset[0]))
+
+            _ = GroupBy([self.data[col] for col in subset])
+
+        if keep == 'last':
+            _segment_ends = concatenate([_.segments[1:] - 1, array([_.permutation.size - 1])])
+            return self[_.permutation[_segment_ends]]
+        else:
+            return self[_.permutation[_.segments]]
+
+    @property
+    def size(self):
+        """
+        Returns the number of bytes on the arkouda server.
+        """
+
+        self.update_size()
+        if self._size == None:
+            return 0
+        return self._size
+
+    @property
+    def dtypes(self):
+        dtypes = []
+        keys = []
+        for key, val in self.items():
+            keys.append(key)
+            if isinstance(val, pdarray):
+                dtypes.append(str(val.dtype))
+            elif isinstance(val, Strings):
+                dtypes.append('str')
+        res = aku.Row({key: dtype for key, dtype in zip(keys, dtypes)})
+        return res
+
+    @property
+    def empty(self):
+        return self._empty
+
+    @property
+    def shape(self):
+        self.update_size()
+        num_cols = len(self._columns) - 1
+        num_rows = self._size
+        return (num_rows, num_cols)
+
+    @property
+    def columns(self):
+        return self._columns
+
+    @property
+    def index(self):
+        return self.data['index']
+
+    def reset_index(self, size=False):
+        """
+        Set the index to an integer range.
+
+        Useful if this dataframe is the result of a slice operation from
+        another dataframe, or if you have permuted the rows and no longer need
+        to keep that ordering on the rows.
+
+        Parameters
+        ----------
+        size : int
+            If size is passed, do not attempt to determine size based on
+            existing column sizes. Assume caller handles consistency correctly.
+        """
+
+        if not size:
+            self.update_size()
+            self.data['index'] = arange(0, self._size)
+        else:
+            self.data['index'] = arange(size)

--- a/arkouda/row.py
+++ b/arkouda/row.py
@@ -1,5 +1,5 @@
 from collections import UserDict
-from tabulate import tabulate
+from tabulate import tabulate  # type: ignore
 
 __all__ = ["Row", ]
 

--- a/arkouda/row.py
+++ b/arkouda/row.py
@@ -1,0 +1,33 @@
+from collections import UserDict
+from tabulate import tabulate
+
+__all__ = ["Row", ]
+
+"""
+Row structure based on UserDict.
+"""
+
+
+class Row(UserDict):
+    """
+    This class is useful for printing and working with individual rows of a
+    of an aku.DataFrame.
+    """
+
+    def __str__(self):
+        """
+        Return ascii-formatted version of the dataframe.
+        """
+
+        return tabulate(self.items(), headers=['keys', 'values'], showindex=False)
+
+    def __repr__(self):
+        return dict(self).__repr__()
+
+    def _repr_html_(self):
+        """
+        Return html-formatted version of the dataframe.
+        """
+
+        headers = ['keys', 'values']
+        return tabulate(self.items(), headers=headers, tablefmt='html', showindex=False)

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -13,40 +13,40 @@ from arkouda.pdarrayIO import load
 
 
 def gen_ranges(starts, ends, stride=1):
-	""" Generate a segmented array of variable-length, contiguous ranges between pairs of start- and end-points.
+    """ Generate a segmented array of variable-length, contiguous ranges between pairs of start- and end-points.
 
-	Parameters
-	----------
-	starts : pdarray, int64
-		The start value of each range
-	ends : pdarray, int64
-		The end value (exclusive) of each range
-	stride: int
-		Difference between successive elements of each range
+    Parameters
+    ----------
+    starts : pdarray, int64
+    The start value of each range
+    ends : pdarray, int64
+    The end value (exclusive) of each range
+    stride: int
+    Difference between successive elements of each range
 
-	Returns
-	-------
-	segments : pdarray, int64
-		The starting index of each range in the resulting array
-	ranges : pdarray, int64
-		The actual ranges, flattened into a single array
-	"""
-	if starts.size != ends.size:
-		raise ValueError("starts and ends must be same length")
-	if starts.size == 0:
-		return zeros(0, dtype=akint64), zeros(0, dtype=akint64)
-	lengths = (ends - starts) // stride
-	segs = cumsum(lengths) - lengths
-	totlen = lengths.sum()
-	slices = ones(totlen, dtype=akint64)
-	diffs = concatenate((array([starts[0]]),
-	                     starts[1:] - starts[:-1] - (lengths[:-1] - 1) * stride))
-	slices[segs] = diffs
-	return segs, cumsum(slices)
+    Returns
+    -------
+    segments : pdarray, int64
+    The starting index of each range in the resulting array
+    ranges : pdarray, int64
+    The actual ranges, flattened into a single array
+    """
+    if starts.size != ends.size:
+        raise ValueError("starts and ends must be same length")
+    if starts.size == 0:
+        return zeros(0, dtype=akint64), zeros(0, dtype=akint64)
+    lengths = (ends - starts) // stride
+    segs = cumsum(lengths) - lengths
+    totlen = lengths.sum()
+    slices = ones(totlen, dtype=akint64)
+    diffs = concatenate((array([starts[0]]),
+                         starts[1:] - starts[:-1] - (lengths[:-1] - 1) * stride))
+    slices[segs] = diffs
+    return segs, cumsum(slices)
 
 
 def _aggregator(func):
-	aggdoc = """
+    aggdoc = """
         Aggregate values over each sub-array.
 
         Parameters
@@ -62,710 +62,730 @@ def _aggregator(func):
         Array of one aggregated value per sub-array.
         """
 
-	def update_doc():
-		func.__doc__ = aggdoc
-		return func
+    def update_doc():
+        func.__doc__ = aggdoc
+        return func
 
-	return update_doc
+    return update_doc
 
 
 class SegArray:
-	def __init__(self, segments, values, copy=False, lengths=None, grouping=None):
-		"""
-		An array of variable-length arrays, also called a skyline array or ragged array.
-
-		Parameters
-		----------
-		segments : pdarray, int64
-			Start index of each sub-array in the flattened values array
-		values : pdarray
-			The flattened values of all sub-arrays
-		copy : bool
-			If True, make a copy of the input arrays; otherwise, just store a reference.
-
-		Returns
-		-------
-		SegArray
-			Data structure representing an array whose elements are variable-length arrays.
-
-		Notes
-		-----
-		Keyword args 'lengths' and 'grouping' are not user-facing. They are used by the
-		attach method.
-		"""
-		if not isinstance(segments, pdarray) or segments.dtype != akint64:
-			raise TypeError("Segments must be int64 pdarray")
-		if not is_sorted(segments) or (unique(segments).size != segments.size):
-			raise ValueError("Segments must be unique and in sorted order")
-		if segments.size > 0:
-			if segments.min() != 0 or segments.max() >= values.size:
-				raise ValueError("Segments must start at zero and be less than values.size")
-		elif values.size > 0:
-			raise ValueError("Cannot have non-empty values with empty segments")
-		if copy:
-			self.segments = segments[:]
-			self.values = values[:]
-		else:
-			self.segments = segments
-			self.values = values
-		self.size = segments.size
-		self.valsize = values.size
-		if lengths is None:
-			self.lengths = self._get_lengths()
-		else:
-			self.lengths = lengths
-		self.dtype = values.dtype
-		if grouping is None:
-			if self.size == 0:
-				self.grouping = GroupBy(zeros(0, dtype=akint64))
-			else:
-				# Treat each sub-array as a group, for grouped aggregations
-				self.grouping = GroupBy(broadcast(self.segments, arange(self.size), self.valsize))
-		else:
-			self.grouping = grouping
-
-	@classmethod
-	def from_multi_array(cls, m):
-		"""
-		Construct a SegArray from a list of columns. This essentially transposes the input,
-		resulting in an array of rows.
-
-		Parameters
-		----------
-		m : list of pdarray
-			List of columns, the rows of which will form the sub-arrays of the output
-
-		Returns
-		-------
-		SegArray
-			Array of rows of input
-		"""
-		if isinstance(m, pdarray):
-			size = m.size
-			n = 1
-			dtype = m.dtype
-		else:
-			s = set(mi.size for mi in m)
-			if len(s) != 1:
-				raise ValueError("All columns must have same length")
-			size = s.pop()
-			n = len(m)
-			d = set(mi.dtype for mi in m)
-			if len(d) != 1:
-				raise ValueError("All columns must have same dtype")
-			dtype = d.pop()
-		newsegs = arange(size) * n
-		newvals = zeros(size * n, dtype=dtype)
-		for j in range(len(m)):
-			newvals[j::len(m)] = m[j]
-		return cls(newsegs, newvals)
-
-	@classmethod
-	def concat(cls, x, axis=0, ordered=True):
-		"""
-		Concatenate a sequence of SegArrays
-
-		Parameters
-		----------
-		x : sequence of SegArray
-			The SegArrays to concatenate
-		axis : 0 or 1
-			Select vertical (0) or horizontal (1) concatenation. If axis=1, all
-			SegArrays must have same size.
-		ordered : bool
-			Must be True. This option is present for compatibility only, because unordered
-			concatenation is not yet supported.
-
-		Returns
-		-------
-		SegArray
-			The input arrays joined into one SegArray
-		"""
-		if not ordered:
-			raise ValueError("Unordered concatenation not yet supported on SegArray; use ordered=True.")
-		if len(x) == 0:
-			raise ValueError("Empty sequence passed to concat")
-		for xi in x:
-			if not isinstance(xi, cls):
-				return NotImplemented
-		if len(set(xi.dtype for xi in x)) != 1:
-			raise ValueError("SegArrays must all have same dtype to concatenate")
-		if axis == 0:
-			ctr = 0
-			segs = []
-			vals = []
-			for xi in x:
-				# Segment offsets need to be raised by length of previous values
-				segs.append(xi.segments + ctr)
-				ctr += xi.valsize
-				# Values can just be concatenated
-				vals.append(xi.values)
-			return cls(concatenate(segs), concatenate(vals))
-		elif axis == 1:
-			sizes = set(xi.size for xi in x)
-			if len(sizes) != 1:
-				raise ValueError("SegArrays must all have same size to concatenate with axis=1")
-			if sizes.pop() == 0:
-				return x[0]
-			dt = list(x)[0].dtype
-			newlens = sum(xi.lengths for xi in x)
-			newsegs = cumsum(newlens) - newlens
-			# Ignore sub-arrays that are empty in all arrays
-			nonzero = concatenate((newsegs[:-1] < newsegs[1:], array([True])))
-			nzsegs = newsegs[nonzero]
-			newvals = zeros(newlens.sum(), dtype=dt)
-			for xi in x:
-				# Set up fromself for a scan, so that it steps up at the start of a segment
-				# from the current array, and steps back down at the end
-				fromself = zeros(newvals.size + 1, dtype=akint64)
-				fromself[nzsegs] += 1
-				nzlens = xi.lengths[nonzero]
-				fromself[nzsegs + nzlens] -= 1
-				fromself = (cumsum(fromself[:-1]) == 1)
-				newvals[fromself] = xi.values
-				nzsegs += nzlens
-			return cls(newsegs, newvals, copy=False)
-		else:
-			raise ValueError("Supported values for axis are 0 (vertical concat) or 1 (horizontal concat)")
-
-	def copy(self):
-		"""
-		Return a deep copy.
-		"""
-		return SegArray(self.segments, self.values, copy=True)
-
-	def _get_lengths(self):
-		if self.size == 0:
-			return zeros(0, dtype=akint64)
-		elif self.size == 1:
-			return array([self.valsize])
-		else:
-			return concatenate((self.segments[1:], array([self.valsize]))) - self.segments
-
-	def __getitem__(self, i):
-		if isSupportedInt(i):
-			start = self.segments[i]
-			end = self.segments[i] + self.lengths[i]
-			return self.values[start:end].to_ndarray()
-		elif (isinstance(i, pdarray) and (i.dtype == akint64 or i.dtype == akbool)) or isinstance(i, slice):
-			starts = self.segments[i]
-			ends = starts + self.lengths[i]
-			newsegs, inds = gen_ranges(starts, ends)
-			return SegArray(newsegs, self.values[inds], copy=True)
-		else:
-			raise TypeError(f'Invalid index type: {type(i)}')
-
-	def __eq__(self, other):
-		if not isinstance(other, SegArray):
-			return NotImplemented
-		eq = zeros(self.size, dtype=akbool)
-		leneq = self.lengths == other.lengths
-		if leneq.sum() > 0:
-			selfcmp = self[leneq]
-			othercmp = other[leneq]
-			intersection = self.all(selfcmp.values == othercmp.values)
-			eq[leneq] = intersection
-		return eq
-
-	def __str__(self):
-		if self.size <= 6:
-			rows = list(range(self.size))
-		else:
-			rows = [0, 1, 2, None, self.size - 3, self.size - 2, self.size - 1]
-		outlines = ['SegArray([']
-		for r in rows:
-			if r is None:
-				outlines.append('...')
-			else:
-				outlines.append(str(self[r]))
-		outlines.append('])')
-		return '\n'.join(outlines)
-
-	def __repr__(self):
-		return self.__str__()
-
-	def get_suffixes(self, n, return_origins=True, proper=True):
-		"""
-		Return the n-long suffix of each sub-array, where possible
-
-		Parameters
-		----------
-		n : int
-			Length of suffix
-		return_origins : bool
-			If True, return a logical index indicating which sub-arrays
-			were long enough to return an n-suffix
-		proper : bool
-			If True, only return proper suffixes, i.e. from sub-arrays
-			that are at least n+1 long. If False, allow the entire
-			sub-array to be returned as a suffix.
-
-		Returns
-		-------
-		suffixes : list of pdarray
-			An n-long list of pdarrays, essentially a table where each row is an n-suffix.
-			The number of rows is the number of True values in the returned mask.
-		origin_indices : pdarray, bool
-			Boolean array that is True where the sub-array was long enough to return
-			an n-suffix, False otherwise.
-		"""
-		if proper:
-			longenough = self.lengths > n
-		else:
-			longenough = self.lengths >= n
-		suffixes = []
-		for i in range(n):
-			ind = (self.segments + self.lengths - (n - i))[longenough]
-			suffixes.append(self.values[ind])
-		if return_origins:
-			return suffixes, longenough
-		else:
-			return suffixes
-
-	def get_prefixes(self, n, return_origins=True, proper=True):
-		"""
-		Return all sub-array prefixes of length n (for sub-arrays that are at least n+1 long)
-
-		Parameters
-		----------
-		n : int
-			Length of suffix
-		return_origins : bool
-			If True, return a logical index indicating which sub-arrays
-			were long enough to return an n-prefix
-		proper : bool
-			If True, only return proper prefixes, i.e. from sub-arrays
-			that are at least n+1 long. If False, allow the entire
-			sub-array to be returned as a prefix.
-
-		Returns
-		-------
-		prefixes : list of pdarray
-			An n-long list of pdarrays, essentially a table where each row is an n-prefix.
-			The number of rows is the number of True values in the returned mask.
-		origin_indices : pdarray, bool
-			Boolean array that is True where the sub-array was long enough to return
-			an n-suffix, False otherwise.
-		"""
-		if proper:
-			longenough = self.lengths > n
-		else:
-			longenough = self.lengths >= n
-		prefixes = []
-		for i in range(n):
-			ind = (self.segments + i)[longenough]
-			prefixes.append(self.values[ind])
-		if return_origins:
-			return prefixes, longenough
-		else:
-			return prefixes
-
-	def get_ngrams(self, n, return_origins=True):
-		"""
-		Return all n-grams from all sub-arrays.
-
-		Parameters
-		----------
-		n : int
-			Length of n-gram
-		return_origins : bool
-			If True, return an int64 array indicating which sub-array
-			each returned n-gram came from.
-
-		Returns
-		-------
-		ngrams : list of pdarray
-			An n-long list of pdarrays, essentially a table where each row is an n-gram.
-		origin_indices : pdarray, int
-			The index of the sub-array from which the corresponding n-gram originated
-		"""
-		if n > self._get_lengths().max():
-			raise ValueError('n must be <= the maximum length of the sub-arrays')
-
-		ngrams = []
-		notsegstart = ones(self.valsize, dtype=akbool)
-		notsegstart[self.segments] = False
-		valid = ones(self.valsize - n + 1, dtype=akbool)
-		for i in range(n):
-			end = self.valsize - n + i + 1
-			ngrams.append(self.values[i:end])
-			if i > 0:
-				valid &= notsegstart[i:end]
-		ngrams = [char[valid] for char in ngrams]
-		if return_origins:
-			origin_indices = self.grouping.broadcast(arange(self.size), permute=True)[:valid.size][valid]
-			return ngrams, origin_indices
-		else:
-			return ngrams
-
-	def _normalize_index(self, j):
-		if not isSupportedInt(j):
-			raise TypeError(f'index must be integer, not {type(j)}')
-		if j >= 0:
-			longenough = self.lengths > j
-		else:
-			j = self.lengths + j
-			longenough = j >= 0
-		return longenough, j
-
-	def get_jth(self, j, return_origins=True, compressed=False, default=0):
-		"""
-		Select the j-th element of each sub-array, where possible.
-
-		Parameters
-		----------
-		j : int
-			The index of the value to get from each sub-array. If j is negative,
-			it counts backwards from the end of each sub-array.
-		return_origins : bool
-			If True, return a logical index indicating where j is in bounds
-		compressed : bool
-			If False, return array is same size as self, with default value
-			where j is out of bounds. If True, the return array only contains
-			values where j is in bounds.
-		default : scalar
-			When compressed=False, the value to return when j is out of bounds
-			for the sub-array
-
-		Returns
-		-------
-		val : pdarray
-			compressed=False: The j-th value of each sub-array where j is in
-			bounds and the default value where j is out of bounds.
-			compressed=True: The j-th values of only the sub-arrays where j is
-			in bounds
-		origin_indices : pdarray, bool
-			A Boolean array that is True where j is in bounds for the sub-array.
-		"""
-		longenough, newj = self._normalize_index(j)
-		ind = (self.segments + newj)[longenough]
-		if compressed:
-			res = self.values[ind]
-		else:
-			res = zeros(self.size, dtype=self.dtype) + default
-			res[longenough] = self.values[ind]
-		if return_origins:
-			return res, longenough
-		else:
-			return res
-
-	def set_jth(self, i, j, v):
-		"""
-		Set the j-th element of each sub-array in a subset.
-
-		Parameters
-		----------
-		i : pdarray, int
-			Indices of sub-arrays to set j-th element
-		j : int
-			Index of value to set in each sub-array. If j is negative, it counts
-			backwards from the end of the sub-array.
-		v : pdarray or scalar
-			The value(s) to set. If v is a pdarray, it must have same length as i.
-
-		Raises
-		-----
-		ValueError
-			If j is out of bounds in any of the sub-arrays specified by i.
-		"""
-		if self.dtype == str_:
-			raise TypeError("String elements are immutable")
-		longenough, newj = self._normalize_index(j)
-		if not longenough[i].all():
-			raise ValueError(f'Not all (i, j) in bounds')
-		ind = (self.segments + newj)[i]
-		self.values[ind] = v
-
-	def get_length_n(self, n, return_origins=True):
-		"""
-		Return all sub-arrays of length n, as a list of columns.
-
-		Parameters
-		----------
-		n : int
-			Length of sub-arrays to select
-		return_origins : bool
-			Return a logical index indicating which sub-arrays are length n
-
-		Returns
-		-------
-		columns : list of pdarray
-			An n-long list of pdarray, where each row is one of the n-long
-			sub-arrays from the SegArray. The number of rows is the number of
-			True values in the returned mask.
-		origin_indices : pdarray, bool
-			Array of bool for each element of the SegArray, True where sub-array
-			has length n.
-		"""
-		mask = self.lengths == n
-		elem = []
-		for i in range(n):
-			ind = (self.segments + self.lengths - (n - i))[mask]
-			elem.append(self.values[ind])
-		if return_origins:
-			return elem, mask
-		else:
-			return elem
-
-	def append(self, other, axis=0):
-		"""
-		Append other to self, either vertically (axis=0, length of resulting SegArray
-		increases), or horizontally (axis=1, each sub-array of other appends to the
-		corresponding sub-array of self).
-
-		Parameters
-		----------
-		other : SegArray
-			Array of sub-arrays to append
-		axis : 0 or 1
-			Whether to append vertically (0) or horizontally (1). If axis=1, other
-			must be same size as self.
-
-		Returns
-		-------
-		SegArray
-			axis=0: New SegArray containing all sub-arrays
-			axis=1: New SegArray of same length, with pairs of sub-arrays concatenated
-		"""
-		if not isinstance(other, SegArray):
-			return NotImplemented
-		if self.dtype != other.dtype:
-			raise TypeError("SegArrays must have same value type to append")
-		return self.__class__.concat((self, other), axis=axis)
-
-	def append_single(self, x, prepend=False):
-		'''
-		Append a single value to each sub-array.
-
-		Parameters
-		----------
-		x : pdarray or scalar
-			Single value to append to each sub-array
-
-		Returns
-		-------
-		SegArray
-			Copy of original SegArray with values from x appended to each sub-array
-		'''
-		if hasattr(x, 'size'):
-			if x.size != self.size:
-				raise ValueError('Argument must be scalar or same size as SegArray')
-			if type(x) != type(self.values) or x.dtype != self.dtype:
-				raise TypeError('Argument type must match value type of SegArray')
-		newlens = self.lengths + 1
-		newsegs = cumsum(newlens) - newlens
-		newvals = zeros(newlens.sum(), dtype=self.dtype)
-		if prepend:
-			lastscatter = newsegs
-		else:
-			lastscatter = newsegs + newlens - 1
-		newvals[lastscatter] = x
-		origscatter = arange(self.valsize) + self.grouping.broadcast(arange(self.size), permute=True)
-		if prepend:
-			origscatter += 1
-		newvals[origscatter] = self.values
-		return SegArray(newsegs, newvals)
-
-	def prepend_single(self, x):
-		return self.append_single(x, prepend=True)
-
-	def remove_repeats(self, return_multiplicity=False):
-		"""
-		Condense sequences of repeated values within a sub-array to a single value.
-
-		Parameters
-		----------
-		return_multiplicity : bool
-			If True, also return the number of times each value was repeated.
-
-		Returns
-		-------
-		norepeats : SegArray
-			Sub-arrays with runs of repeated values replaced with single value
-		multiplicity : SegArray
-			If return_multiplicity=True, this array contains the number of times
-			each value in the returned SegArray was repeated in the original SegArray.
-		"""
-		isrepeat = zeros(self.values.size, dtype=akbool)
-		isrepeat[1:] = self.values[:-1] == self.values[1:]
-		isrepeat[self.segments] = False
-		truepaths = self.values[~isrepeat]
-		nhops = self.grouping.sum(~isrepeat)[1]
-		# truehops = ak.cumsum(~isrepeat)
-		# nhops = ak.concatenate((truehops[self.segments[1:]], ak.array([truehops.sum()+1]))) - truehops[self.segments]
-		truesegs = cumsum(nhops) - nhops
-		norepeats = SegArray(truesegs, truepaths)
-		if return_multiplicity:
-			truehopinds = arange(self.valsize)[~isrepeat]
-			multiplicity = zeros(truepaths.size, dtype=akint64)
-			multiplicity[:-1] = truehopinds[1:] - truehopinds[:-1]
-			multiplicity[-1] = self.valsize - truehopinds[-1]
-			return norepeats, SegArray(truesegs, multiplicity)
-		else:
-			return norepeats
-
-	def to_ndarray(self):
-		ndvals = self.values.to_ndarray()
-		ndsegs = self.segments.to_ndarray()
-		arr = [ndvals[start:end] for start, end in zip(ndsegs, ndsegs[1:])]
-		if self.size > 0:
-			arr.append(ndvals[ndsegs[-1]:])
-		return arr
-
-	def sum(self, x=None):
-		if x is None:
-			x = self.values
-		return self.grouping.sum(x)[1]
-
-	def prod(self, x=None):
-		if x is None:
-			x = self.values
-		return self.grouping.prod(x)[1]
-
-	def min(self, x=None):
-		if x is None:
-			x = self.values
-		return self.grouping.min(x)[1]
-
-	def max(self, x=None):
-		if x is None:
-			x = self.values
-		return self.grouping.max(x)[1]
-
-	def argmin(self, x=None):
-		if x is None:
-			x = self.values
-		return self.grouping.argmin(x)[1]
-
-	def argmax(self, x=None):
-		if x is None:
-			x = self.values
-		return self.grouping.argmax(x)[1]
-
-	def any(self, x=None):
-		if x is None:
-			x = self.values
-		return self.grouping.any(x)[1]
-
-	def all(self, x=None):
-		if x is None:
-			x = self.values
-		return self.grouping.all(x)[1]
-
-	def OR(self, x=None):
-		if x is None:
-			x = self.values
-		return self.grouping.OR(x)[1]
-
-	def AND(self, x=None):
-		if x is None:
-			x = self.values
-		return self.grouping.AND(x)[1]
-
-	def XOR(self, x=None):
-		if x is None:
-			x = self.values
-		return self.grouping.XOR(x)[1]
-
-	def nunique(self, x=None):
-		if x is None:
-			x = self.values
-		return self.grouping.nunique(x)[1]
-
-	def mean(self, x=None):
-		if x is None:
-			x = self.values
-		return self.grouping.mean(x)[1]
-
-	def aggregate(self, op, x=None):
-		if x is None:
-			x = self.values
-		return self.grouping.aggregate(x, op)
-
-	def unique(self, x=None):
-		'''
-		Return sub-arrays of unique values.
-
-		Parameters
-		----------
-		x : pdarray
-			The values to unique, per group. By default, the values of this
-			SegArray's sub-arrays.
-
-		Returns
-		-------
-		SegArray
-			Same number of sub-arrays as original SegArray, but elements in sub-array
-			are unique and in sorted order.
-		'''
-		if x is None:
-			x = self.values
-		keyidx = self.grouping.broadcast(arange(self.size), permute=True)
-		ukey, uval = GroupBy([keyidx, x]).unique_keys
-		g = GroupBy(ukey, assume_sorted=True)
-		_, lengths = g.count()
-		return SegArray(g.segments, uval, grouping=g, lengths=lengths)
-
-	def save(self, prefix_path, dataset='segarray', segment_suffix='_segments', value_suffix='_values',
-	         mode='truncate'):
-		'''
-		Save the SegArray to HDF5. The result is a collection of HDF5 files, one file
-		per locale of the arkouda server, where each filename starts with prefix_path.
-
-		Parameters
-		----------
-		prefix_path : str
-			Directory and filename prefix that all output files will share
-		dataset : str
-			Name prefix for saved data within the HDF5 file
-		segment_suffix : str
-			Suffix to append to dataset name for segments array
-		value_suffix : str
-			Suffix to append to dataset name for values array
-		mode : str {'truncate' | 'append'}
-			By default, truncate (overwrite) output files, if they exist.
-			If 'append', add data as a new column to existing files.
-
-		Returns
-		-------
-		None
-
-		Notes
-		-----
-		Unlike for ak.Strings, SegArray is saved as two datasets in the top level of
-		the HDF5 file, not nested under a group.
-		'''
-		if segment_suffix == value_suffix:
-			raise ValueError("Segment suffix and value suffix must be different")
-		self.segments.save(prefix_path, dataset=dataset + segment_suffix, mode=mode)
-		self.values.save(prefix_path, dataset=dataset + value_suffix, mode='append')
-
-	@classmethod
-	def load(cls, prefix_path, dataset='segarray', segment_suffix='_segments', value_suffix='_values', mode='truncate'):
-		'''
-		Load a saved SegArray from HDF5. All arguments msut match what
-		was supplied to SegArray.save()
-
-		Parameters
-		----------
-		prefix_path : str
-			Directory and filename prefix
-		dataset : str
-			Name prefix for saved data within the HDF5 files
-		segment_suffix : str
-			Suffix to append to dataset name for segments array
-		value_suffix : str
-			Suffix to append to dataset name for values array
-
-		Returns
-		-------
-		SegArray
-		'''
-		if segment_suffix == value_suffix:
-			raise ValueError("Segment suffix and value suffix must be different")
-		segments = load(prefix_path, dataset=dataset + segment_suffix)
-		values = load(prefix_path, dataset=dataset + value_suffix)
-		return cls(segments, values)
+    def __init__(self, segments, values, copy=False, lengths=None, grouping=None):
+        """
+        An array of variable-length arrays, also called a skyline array or ragged array.
+
+        Parameters
+        ----------
+        segments : pdarray, int64
+            Start index of each sub-array in the flattened values array
+        values : pdarray
+            The flattened values of all sub-arrays
+        copy : bool
+            If True, make a copy of the input arrays; otherwise, just store a reference.
+
+        Returns
+        -------
+        SegArray
+            Data structure representing an array whose elements are variable-length arrays.
+
+        Notes
+        -----
+        Keyword args 'lengths' and 'grouping' are not user-facing. They are used by the
+        attach method.
+        """
+        if not isinstance(segments, pdarray) or segments.dtype != akint64:
+            raise TypeError("Segments must be int64 pdarray")
+        if not is_sorted(segments) or (unique(segments).size != segments.size):
+            raise ValueError("Segments must be unique and in sorted order")
+        if segments.size > 0:
+            if segments.min() != 0 or segments.max() >= values.size:
+                raise ValueError("Segments must start at zero and be less than values.size")
+        elif values.size > 0:
+            raise ValueError("Cannot have non-empty values with empty segments")
+        if copy:
+            self.segments = segments[:]
+            self.values = values[:]
+        else:
+            self.segments = segments
+            self.values = values
+        self.size = segments.size
+        self.valsize = values.size
+        if lengths is None:
+            self.lengths = self._get_lengths()
+        else:
+            self.lengths = lengths
+        self.dtype = values.dtype
+        if grouping is None:
+            if self.size == 0:
+                self.grouping = GroupBy(zeros(0, dtype=akint64))
+            else:
+                # Treat each sub-array as a group, for grouped aggregations
+                self.grouping = GroupBy(broadcast(self.segments, arange(self.size), self.valsize))
+        else:
+            self.grouping = grouping
+
+    @classmethod
+    def from_multi_array(cls, m):
+        """
+        Construct a SegArray from a list of columns. This essentially transposes the input,
+        resulting in an array of rows.
+
+        Parameters
+        ----------
+        m : list of pdarray
+            List of columns, the rows of which will form the sub-arrays of the output
+
+        Returns
+        -------
+        SegArray
+            Array of rows of input
+        """
+        if isinstance(m, pdarray):
+            size = m.size
+            n = 1
+            dtype = m.dtype
+        else:
+            s = set(mi.size for mi in m)
+            if len(s) != 1:
+                raise ValueError("All columns must have same length")
+            size = s.pop()
+            n = len(m)
+            d = set(mi.dtype for mi in m)
+            if len(d) != 1:
+                raise ValueError("All columns must have same dtype")
+            dtype = d.pop()
+        newsegs = arange(size) * n
+        newvals = zeros(size * n, dtype=dtype)
+        for j in range(len(m)):
+            newvals[j::len(m)] = m[j]
+        return cls(newsegs, newvals)
+
+    @classmethod
+    def concat(cls, x, axis=0, ordered=True):
+        """
+        Concatenate a sequence of SegArrays
+
+        Parameters
+        ----------
+        x : sequence of SegArray
+            The SegArrays to concatenate
+        axis : 0 or 1
+            Select vertical (0) or horizontal (1) concatenation. If axis=1, all
+            SegArrays must have same size.
+        ordered : bool
+            Must be True. This option is present for compatibility only, because unordered
+            concatenation is not yet supported.
+
+        Returns
+        -------
+        SegArray
+            The input arrays joined into one SegArray
+        """
+        if not ordered:
+            raise ValueError("Unordered concatenation not yet supported on SegArray; use ordered=True.")
+        if len(x) == 0:
+            raise ValueError("Empty sequence passed to concat")
+        for xi in x:
+            if not isinstance(xi, cls):
+                return NotImplemented
+        if len(set(xi.dtype for xi in x)) != 1:
+            raise ValueError("SegArrays must all have same dtype to concatenate")
+        if axis == 0:
+            ctr = 0
+            segs = []
+            vals = []
+            for xi in x:
+                # Segment offsets need to be raised by length of previous values
+                segs.append(xi.segments + ctr)
+                ctr += xi.valsize
+                # Values can just be concatenated
+                vals.append(xi.values)
+            return cls(concatenate(segs), concatenate(vals))
+        elif axis == 1:
+            sizes = set(xi.size for xi in x)
+            if len(sizes) != 1:
+                raise ValueError("SegArrays must all have same size to concatenate with axis=1")
+            if sizes.pop() == 0:
+                return x[0]
+            dt = list(x)[0].dtype
+            newlens = sum(xi.lengths for xi in x)
+            newsegs = cumsum(newlens) - newlens
+            # Ignore sub-arrays that are empty in all arrays
+            nonzero = concatenate((newsegs[:-1] < newsegs[1:], array([True])))
+            nzsegs = newsegs[nonzero]
+            newvals = zeros(newlens.sum(), dtype=dt)
+            for xi in x:
+                # Set up fromself for a scan, so that it steps up at the start of a segment
+                # from the current array, and steps back down at the end
+                fromself = zeros(newvals.size + 1, dtype=akint64)
+                fromself[nzsegs] += 1
+                nzlens = xi.lengths[nonzero]
+                fromself[nzsegs + nzlens] -= 1
+                fromself = (cumsum(fromself[:-1]) == 1)
+                newvals[fromself] = xi.values
+                nzsegs += nzlens
+            return cls(newsegs, newvals, copy=False)
+        else:
+            raise ValueError("Supported values for axis are 0 (vertical concat) or 1 (horizontal concat)")
+
+    def copy(self):
+        """
+        Return a deep copy.
+        """
+        return SegArray(self.segments, self.values, copy=True)
+
+    def _get_lengths(self):
+        if self.size == 0:
+            return zeros(0, dtype=akint64)
+        elif self.size == 1:
+            return array([self.valsize])
+        else:
+            return concatenate((self.segments[1:], array([self.valsize]))) - self.segments
+
+    def __getitem__(self, i):
+        if isSupportedInt(i):
+            start = self.segments[i]
+            end = self.segments[i] + self.lengths[i]
+            return self.values[start:end].to_ndarray()
+        elif (isinstance(i, pdarray) and (i.dtype == akint64 or i.dtype == akbool)) or isinstance(i, slice):
+            starts = self.segments[i]
+            ends = starts + self.lengths[i]
+            newsegs, inds = gen_ranges(starts, ends)
+            return SegArray(newsegs, self.values[inds], copy=True)
+        else:
+            raise TypeError(f'Invalid index type: {type(i)}')
+
+    def __eq__(self, other):
+        if not isinstance(other, SegArray):
+            return NotImplemented
+        eq = zeros(self.size, dtype=akbool)
+        leneq = self.lengths == other.lengths
+        if leneq.sum() > 0:
+            selfcmp = self[leneq]
+            othercmp = other[leneq]
+            intersection = self.all(selfcmp.values == othercmp.values)
+            eq[leneq] = intersection
+        return eq
+
+    def __str__(self):
+        if self.size <= 6:
+            rows = list(range(self.size))
+        else:
+            rows = [0, 1, 2, None, self.size - 3, self.size - 2, self.size - 1]
+        outlines = ['SegArray([']
+        for r in rows:
+            if r is None:
+                outlines.append('...')
+            else:
+                outlines.append(str(self[r]))
+        outlines.append('])')
+        return '\n'.join(outlines)
+
+    def __repr__(self):
+        return self.__str__()
+
+    def get_suffixes(self, n, return_origins=True, proper=True):
+        """
+        Return the n-long suffix of each sub-array, where possible
+
+        Parameters
+        ----------
+        n : int
+            Length of suffix
+        return_origins : bool
+            If True, return a logical index indicating which sub-arrays
+            were long enough to return an n-suffix
+        proper : bool
+            If True, only return proper suffixes, i.e. from sub-arrays
+            that are at least n+1 long. If False, allow the entire
+            sub-array to be returned as a suffix.
+
+        Returns
+        -------
+        suffixes : list of pdarray
+            An n-long list of pdarrays, essentially a table where each row is an n-suffix.
+            The number of rows is the number of True values in the returned mask.
+        origin_indices : pdarray, bool
+            Boolean array that is True where the sub-array was long enough to return
+            an n-suffix, False otherwise.
+        """
+        if proper:
+            longenough = self.lengths > n
+        else:
+            longenough = self.lengths >= n
+        suffixes = []
+        for i in range(n):
+            ind = (self.segments + self.lengths - (n - i))[longenough]
+            suffixes.append(self.values[ind])
+        if return_origins:
+            return suffixes, longenough
+        else:
+            return suffixes
+
+    def get_prefixes(self, n, return_origins=True, proper=True):
+        """
+        Return all sub-array prefixes of length n (for sub-arrays that are at least n+1 long)
+
+        Parameters
+        ----------
+        n : int
+            Length of suffix
+        return_origins : bool
+            If True, return a logical index indicating which sub-arrays
+            were long enough to return an n-prefix
+        proper : bool
+            If True, only return proper prefixes, i.e. from sub-arrays
+            that are at least n+1 long. If False, allow the entire
+            sub-array to be returned as a prefix.
+
+        Returns
+        -------
+        prefixes : list of pdarray
+            An n-long list of pdarrays, essentially a table where each row is an n-prefix.
+            The number of rows is the number of True values in the returned mask.
+        origin_indices : pdarray, bool
+            Boolean array that is True where the sub-array was long enough to return
+            an n-suffix, False otherwise.
+        """
+        if proper:
+            longenough = self.lengths > n
+        else:
+            longenough = self.lengths >= n
+        prefixes = []
+        for i in range(n):
+            ind = (self.segments + i)[longenough]
+            prefixes.append(self.values[ind])
+        if return_origins:
+            return prefixes, longenough
+        else:
+            return prefixes
+
+    def get_ngrams(self, n, return_origins=True):
+        """
+        Return all n-grams from all sub-arrays.
+
+        Parameters
+        ----------
+        n : int
+            Length of n-gram
+        return_origins : bool
+            If True, return an int64 array indicating which sub-array
+            each returned n-gram came from.
+
+        Returns
+        -------
+        ngrams : list of pdarray
+            An n-long list of pdarrays, essentially a table where each row is an n-gram.
+        origin_indices : pdarray, int
+            The index of the sub-array from which the corresponding n-gram originated
+        """
+        if n > self._get_lengths().max():
+            raise ValueError('n must be <= the maximum length of the sub-arrays')
+
+        ngrams = []
+        notsegstart = ones(self.valsize, dtype=akbool)
+        notsegstart[self.segments] = False
+        valid = ones(self.valsize - n + 1, dtype=akbool)
+        for i in range(n):
+            end = self.valsize - n + i + 1
+            ngrams.append(self.values[i:end])
+            if i > 0:
+                valid &= notsegstart[i:end]
+        ngrams = [char[valid] for char in ngrams]
+        if return_origins:
+            origin_indices = self.grouping.broadcast(arange(self.size), permute=True)[:valid.size][valid]
+            return ngrams, origin_indices
+        else:
+            return ngrams
+
+    def _normalize_index(self, j):
+        if not isSupportedInt(j):
+            raise TypeError(f'index must be integer, not {type(j)}')
+        if j >= 0:
+            longenough = self.lengths > j
+        else:
+            j = self.lengths + j
+            longenough = j >= 0
+        return longenough, j
+
+    def get_jth(self, j, return_origins=True, compressed=False, default=0):
+        """
+        Select the j-th element of each sub-array, where possible.
+
+        Parameters
+        ----------
+        j : int
+            The index of the value to get from each sub-array. If j is negative,
+            it counts backwards from the end of each sub-array.
+        return_origins : bool
+            If True, return a logical index indicating where j is in bounds
+        compressed : bool
+            If False, return array is same size as self, with default value
+            where j is out of bounds. If True, the return array only contains
+            values where j is in bounds.
+        default : scalar
+            When compressed=False, the value to return when j is out of bounds
+            for the sub-array
+
+        Returns
+        -------
+        val : pdarray
+            compressed=False: The j-th value of each sub-array where j is in
+            bounds and the default value where j is out of bounds.
+            compressed=True: The j-th values of only the sub-arrays where j is
+            in bounds
+        origin_indices : pdarray, bool
+            A Boolean array that is True where j is in bounds for the sub-array.
+        """
+        longenough, newj = self._normalize_index(j)
+        ind = (self.segments + newj)[longenough]
+        if compressed:
+            res = self.values[ind]
+        else:
+            res = zeros(self.size, dtype=self.dtype) + default
+            res[longenough] = self.values[ind]
+        if return_origins:
+            return res, longenough
+        else:
+            return res
+
+    def set_jth(self, i, j, v):
+        """
+        Set the j-th element of each sub-array in a subset.
+
+        Parameters
+        ----------
+        i : pdarray, int
+            Indices of sub-arrays to set j-th element
+        j : int
+            Index of value to set in each sub-array. If j is negative, it counts
+            backwards from the end of the sub-array.
+        v : pdarray or scalar
+            The value(s) to set. If v is a pdarray, it must have same length as i.
+
+        Raises
+        -----
+        ValueError
+            If j is out of bounds in any of the sub-arrays specified by i.
+        """
+        if self.dtype == str_:
+            raise TypeError("String elements are immutable")
+        longenough, newj = self._normalize_index(j)
+        if not longenough[i].all():
+            raise ValueError(f'Not all (i, j) in bounds')
+        ind = (self.segments + newj)[i]
+        self.values[ind] = v
+
+    def get_length_n(self, n, return_origins=True):
+        """
+        Return all sub-arrays of length n, as a list of columns.
+
+        Parameters
+        ----------
+        n : int
+            Length of sub-arrays to select
+        return_origins : bool
+            Return a logical index indicating which sub-arrays are length n
+
+        Returns
+        -------
+        columns : list of pdarray
+            An n-long list of pdarray, where each row is one of the n-long
+            sub-arrays from the SegArray. The number of rows is the number of
+            True values in the returned mask.
+        origin_indices : pdarray, bool
+            Array of bool for each element of the SegArray, True where sub-array
+            has length n.
+        """
+        mask = self.lengths == n
+        elem = []
+        for i in range(n):
+            ind = (self.segments + self.lengths - (n - i))[mask]
+            elem.append(self.values[ind])
+        if return_origins:
+            return elem, mask
+        else:
+            return elem
+
+    def append(self, other, axis=0):
+        """
+        Append other to self, either vertically (axis=0, length of resulting SegArray
+        increases), or horizontally (axis=1, each sub-array of other appends to the
+        corresponding sub-array of self).
+
+        Parameters
+        ----------
+        other : SegArray
+            Array of sub-arrays to append
+        axis : 0 or 1
+            Whether to append vertically (0) or horizontally (1). If axis=1, other
+            must be same size as self.
+
+        Returns
+        -------
+        SegArray
+            axis=0: New SegArray containing all sub-arrays
+            axis=1: New SegArray of same length, with pairs of sub-arrays concatenated
+        """
+        if not isinstance(other, SegArray):
+            return NotImplemented
+        if self.dtype != other.dtype:
+            raise TypeError("SegArrays must have same value type to append")
+        return self.__class__.concat((self, other), axis=axis)
+
+    def append_single(self, x, prepend=False):
+        '''
+        Append a single value to each sub-array.
+
+        Parameters
+        ----------
+        x : pdarray or scalar
+            Single value to append to each sub-array
+
+        Returns
+        -------
+        SegArray
+            Copy of original SegArray with values from x appended to each sub-array
+        '''
+        if hasattr(x, 'size'):
+            if x.size != self.size:
+                raise ValueError('Argument must be scalar or same size as SegArray')
+            if type(x) != type(self.values) or x.dtype != self.dtype:
+                raise TypeError('Argument type must match value type of SegArray')
+        newlens = self.lengths + 1
+        newsegs = cumsum(newlens) - newlens
+        newvals = zeros(newlens.sum(), dtype=self.dtype)
+        if prepend:
+            lastscatter = newsegs
+        else:
+            lastscatter = newsegs + newlens - 1
+        newvals[lastscatter] = x
+        origscatter = arange(self.valsize) + self.grouping.broadcast(arange(self.size), permute=True)
+        if prepend:
+            origscatter += 1
+        newvals[origscatter] = self.values
+        return SegArray(newsegs, newvals)
+
+    def prepend_single(self, x):
+        return self.append_single(x, prepend=True)
+
+    def remove_repeats(self, return_multiplicity=False):
+        """
+        Condense sequences of repeated values within a sub-array to a single value.
+
+        Parameters
+        ----------
+        return_multiplicity : bool
+            If True, also return the number of times each value was repeated.
+
+        Returns
+        -------
+        norepeats : SegArray
+            Sub-arrays with runs of repeated values replaced with single value
+        multiplicity : SegArray
+            If return_multiplicity=True, this array contains the number of times
+            each value in the returned SegArray was repeated in the original SegArray.
+        """
+        isrepeat = zeros(self.values.size, dtype=akbool)
+        isrepeat[1:] = self.values[:-1] == self.values[1:]
+        isrepeat[self.segments] = False
+        truepaths = self.values[~isrepeat]
+        nhops = self.grouping.sum(~isrepeat)[1]
+        # truehops = ak.cumsum(~isrepeat)
+        # nhops = ak.concatenate((truehops[self.segments[1:]], ak.array([truehops.sum()+1]))) - truehops[self.segments]
+        truesegs = cumsum(nhops) - nhops
+        norepeats = SegArray(truesegs, truepaths)
+        if return_multiplicity:
+            truehopinds = arange(self.valsize)[~isrepeat]
+            multiplicity = zeros(truepaths.size, dtype=akint64)
+            multiplicity[:-1] = truehopinds[1:] - truehopinds[:-1]
+            multiplicity[-1] = self.valsize - truehopinds[-1]
+            return norepeats, SegArray(truesegs, multiplicity)
+        else:
+            return norepeats
+
+    def to_ndarray(self):
+        """
+        Convert the array into a numpy.ndarray containing sub-arrays
+
+        Returns
+        -------
+        np.ndarray
+            A numpy ndarray with the same sub-arrays (also numpy.ndarray) as this array
+
+        See Also
+        --------
+        array
+
+        Examples
+        --------
+        >>> segarr = ak.SegArray(ak.array([0, 4, 7]), ak.arange(12))
+        >>> segarr.to_ndarray()
+        array([[1, 2, 3, 4], [5, 6, 7], [8, 9, 10, 11, 12]])
+        >>> type(segarr.to_ndarray())
+        numpy.ndarray
+        """
+        ndvals = self.values.to_ndarray()
+        ndsegs = self.segments.to_ndarray()
+        arr = [ndvals[start:end] for start, end in zip(ndsegs, ndsegs[1:])]
+        if self.size > 0:
+            arr.append(ndvals[ndsegs[-1]:])
+        return arr
+
+    def sum(self, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.sum(x)[1]
+
+    def prod(self, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.prod(x)[1]
+
+    def min(self, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.min(x)[1]
+
+    def max(self, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.max(x)[1]
+
+    def argmin(self, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.argmin(x)[1]
+
+    def argmax(self, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.argmax(x)[1]
+
+    def any(self, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.any(x)[1]
+
+    def all(self, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.all(x)[1]
+
+    def OR(self, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.OR(x)[1]
+
+    def AND(self, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.AND(x)[1]
+
+    def XOR(self, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.XOR(x)[1]
+
+    def nunique(self, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.nunique(x)[1]
+
+    def mean(self, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.mean(x)[1]
+
+    def aggregate(self, op, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.aggregate(x, op)
+
+    def unique(self, x=None):
+        '''
+        Return sub-arrays of unique values.
+
+        Parameters
+        ----------
+        x : pdarray
+            The values to unique, per group. By default, the values of this
+            SegArray's sub-arrays.
+
+        Returns
+        -------
+        SegArray
+            Same number of sub-arrays as original SegArray, but elements in sub-array
+            are unique and in sorted order.
+        '''
+        if x is None:
+            x = self.values
+        keyidx = self.grouping.broadcast(arange(self.size), permute=True)
+        ukey, uval = GroupBy([keyidx, x]).unique_keys
+        g = GroupBy(ukey, assume_sorted=True)
+        _, lengths = g.count()
+        return SegArray(g.segments, uval, grouping=g, lengths=lengths)
+
+    def save(self, prefix_path, dataset='segarray', segment_suffix='_segments', value_suffix='_values',
+             mode='truncate'):
+        '''
+        Save the SegArray to HDF5. The result is a collection of HDF5 files, one file
+        per locale of the arkouda server, where each filename starts with prefix_path.
+
+        Parameters
+        ----------
+        prefix_path : str
+            Directory and filename prefix that all output files will share
+        dataset : str
+            Name prefix for saved data within the HDF5 file
+        segment_suffix : str
+            Suffix to append to dataset name for segments array
+        value_suffix : str
+            Suffix to append to dataset name for values array
+        mode : str {'truncate' | 'append'}
+            By default, truncate (overwrite) output files, if they exist.
+            If 'append', add data as a new column to existing files.
+
+        Returns
+        -------
+        None
+
+        Notes
+        -----
+        Unlike for ak.Strings, SegArray is saved as two datasets in the top level of
+        the HDF5 file, not nested under a group.
+        '''
+        if segment_suffix == value_suffix:
+            raise ValueError("Segment suffix and value suffix must be different")
+        self.segments.save(prefix_path, dataset=dataset + segment_suffix, mode=mode)
+        self.values.save(prefix_path, dataset=dataset + value_suffix, mode='append')
+
+    @classmethod
+    def load(cls, prefix_path, dataset='segarray', segment_suffix='_segments', value_suffix='_values', mode='truncate'):
+        '''
+        Load a saved SegArray from HDF5. All arguments msut match what
+        was supplied to SegArray.save()
+
+        Parameters
+        ----------
+        prefix_path : str
+            Directory and filename prefix
+        dataset : str
+            Name prefix for saved data within the HDF5 files
+        segment_suffix : str
+            Suffix to append to dataset name for segments array
+        value_suffix : str
+            Suffix to append to dataset name for values array
+
+        Returns
+        -------
+        SegArray
+        '''
+        if segment_suffix == value_suffix:
+            raise ValueError("Segment suffix and value suffix must be different")
+        segments = load(prefix_path, dataset=dataset + segment_suffix)
+        values = load(prefix_path, dataset=dataset + value_suffix)
+        return cls(segments, values)
 
 # Register/Attach functionality has been removed until it is added for GroupBy.
 # Please refer to ticket #1122 (https://github.com/Bears-R-Us/arkouda/issues/1122 for updates

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -1,0 +1,767 @@
+from __future__ import annotations
+
+from arkouda.pdarrayclass import pdarray, is_sorted
+from arkouda.numeric import cumsum
+from arkouda.dtypes import isSupportedInt
+from arkouda.dtypes import int64 as akint64
+from arkouda.dtypes import bool as akbool
+from arkouda.dtypes import str_
+from arkouda.pdarraycreation import zeros, ones, array, arange
+from arkouda.pdarraysetops import concatenate, unique
+from arkouda.groupbyclass import GroupBy, broadcast
+from arkouda.pdarrayIO import load
+
+
+def gen_ranges(starts, ends, stride=1):
+    """ Generate a segmented array of variable-length, contiguous ranges between pairs of start- and end-points.
+
+    Parameters
+    ----------
+    starts : pdarray, int64
+        The start value of each range
+    ends : pdarray, int64
+        The end value (exclusive) of each range
+    stride: int
+        Difference between successive elements of each range
+
+    Returns
+    -------
+    segments : pdarray, int64
+        The starting index of each range in the resulting array
+    ranges : pdarray, int64
+        The actual ranges, flattened into a single array
+    """
+    if starts.size != ends.size:
+        raise ValueError("starts and ends must be same length")
+    if starts.size == 0:
+        return zeros(0, dtype=akint64), zeros(0, dtype=akint64)
+    lengths = (ends - starts) // stride
+    segs = cumsum(lengths) - lengths
+    totlen = lengths.sum()
+    slices = ones(totlen, dtype=akint64)
+    diffs = concatenate((array([starts[0]]),
+                            starts[1:] - starts[:-1] - (lengths[:-1] - 1) * stride))
+    slices[segs] = diffs
+    return segs, cumsum(slices)
+
+
+def _aggregator(func):
+    aggdoc = """
+        Aggregate values over each sub-array.
+
+        Parameters
+        ----------
+        x : pdarray
+        The values to aggregate. By default, the values of the sub-arrays 
+        themselves are used, but the user may supply an array of values
+        corresponding to the flattened values of all sub-arrays.
+
+        Returns
+        -------
+        pdarray
+        Array of one aggregated value per sub-array.
+        """
+
+    def update_doc():
+        func.__doc__ = aggdoc
+        return func
+
+    return update_doc
+
+class SegArray:
+    def __init__(self, segments, values, copy=False, lengths=None, grouping=None):
+        """
+        An array of variable-length arrays, also called a skyline array or ragged array.
+
+        Parameters
+        ----------
+        segments : pdarray, int64
+            Start index of each sub-array in the flattened values array
+        values : pdarray
+            The flattened values of all sub-arrays
+        copy : bool
+            If True, make a copy of the input arrays; otherwise, just store a reference.
+
+        Returns
+        -------
+        SegArray
+            Data structure representing an array whose elements are variable-length arrays.
+
+        Notes
+        -----
+        Keyword args 'lengths' and 'grouping' are not user-facing. They are used by the
+        attach method.
+        """
+        if not isinstance(segments, pdarray) or segments.dtype != akint64:
+            raise TypeError("Segments must be int64 pdarray")
+        if not is_sorted(segments) or (unique(segments).size != segments.size):
+            raise ValueError("Segments must be unique and in sorted order")
+        if segments.size > 0:
+            if segments.min() != 0 or segments.max() >= values.size:
+                raise ValueError("Segments must start at zero and be less than values.size")
+        elif values.size > 0:
+            raise ValueError("Cannot have non-empty values with empty segments")
+        if copy:
+            self.segments = segments[:]
+            self.values = values[:]
+        else:
+            self.segments = segments
+            self.values = values
+        self.size = segments.size
+        self.valsize = values.size
+        if lengths is None:
+            self.lengths = self._get_lengths()
+        else:
+            self.lengths = lengths
+        self.dtype = values.dtype
+        if grouping is None:
+            if self.size == 0:
+                self.grouping = GroupBy(zeros(0, dtype=akint64))
+            else:
+                # Treat each sub-array as a group, for grouped aggregations
+                self.grouping = GroupBy(broadcast(self.segments, arange(self.size), self.valsize))
+        else:
+            self.grouping = grouping
+
+    @classmethod
+    def from_multi_array(cls, m):
+        """
+        Construct a SegArray from a list of columns. This essentially transposes the input,
+        resulting in an array of rows.
+
+        Parameters
+        ----------
+        m : list of pdarray
+            List of columns, the rows of which will form the sub-arrays of the output
+
+        Returns
+        -------
+        SegArray
+            Array of rows of input
+        """
+        if isinstance(m, pdarray):
+            size = m.size
+            n = 1
+            dtype = m.dtype
+        else:
+            s = set(mi.size for mi in m)
+            if len(s) != 1:
+                raise ValueError("All columns must have same length")
+            size = s.pop()
+            n = len(m)
+            d = set(mi.dtype for mi in m)
+            if len(d) != 1:
+                raise ValueError("All columns must have same dtype")
+            dtype = d.pop()
+        newsegs = arange(size) * n
+        newvals = zeros(size * n, dtype=dtype)
+        for j in range(len(m)):
+            newvals[j::len(m)] = m[j]
+        return cls(newsegs, newvals)
+
+    @classmethod
+    def concat(cls, x, axis=0, ordered=True):
+        """
+        Concatenate a sequence of SegArrays
+
+        Parameters
+        ----------
+        x : sequence of SegArray
+            The SegArrays to concatenate
+        axis : 0 or 1
+            Select vertical (0) or horizontal (1) concatenation. If axis=1, all
+            SegArrays must have same size.
+        ordered : bool
+            Must be True. This option is present for compatibility only, because unordered
+            concatenation is not yet supported.
+
+        Returns
+        -------
+        SegArray
+            The input arrays joined into one SegArray
+        """
+        if not ordered:
+            raise ValueError("Unordered concatenation not yet supported on SegArray; use ordered=True.")
+        if len(x) == 0:
+            raise ValueError("Empty sequence passed to concat")
+        for xi in x:
+            if not isinstance(xi, cls):
+                return NotImplemented
+        if len(set(xi.dtype for xi in x)) != 1:
+            raise ValueError("SegArrays must all have same dtype to concatenate")
+        if axis == 0:
+            ctr = 0
+            segs = []
+            vals = []
+            for xi in x:
+                # Segment offsets need to be raised by length of previous values
+                segs.append(xi.segments + ctr)
+                ctr += xi.valsize
+                # Values can just be concatenated
+                vals.append(xi.values)
+            return cls(concatenate(segs), concatenate(vals))
+        elif axis == 1:
+            sizes = set(xi.size for xi in x)
+            if len(sizes) != 1:
+                raise ValueError("SegArrays must all have same size to concatenate with axis=1")
+            if sizes.pop() == 0:
+                return x[0]
+            dt = list(x)[0].dtype
+            newlens = sum(xi.lengths for xi in x)
+            newsegs = cumsum(newlens) - newlens
+            # Ignore sub-arrays that are empty in all arrays
+            nonzero = concatenate((newsegs[:-1] < newsegs[1:], array([True])))
+            nzsegs = newsegs[nonzero]
+            newvals = zeros(newlens.sum(), dtype=dt)
+            for xi in x:
+                # Set up fromself for a scan, so that it steps up at the start of a segment
+                # from the current array, and steps back down at the end
+                fromself = zeros(newvals.size + 1, dtype=akint64)
+                fromself[nzsegs] += 1
+                nzlens = xi.lengths[nonzero]
+                fromself[nzsegs + nzlens] -= 1
+                fromself = (cumsum(fromself[:-1]) == 1)
+                newvals[fromself] = xi.values
+                nzsegs += nzlens
+            return cls(newsegs, newvals, copy=False)
+        else:
+            raise ValueError("Supported values for axis are 0 (vertical concat) or 1 (horizontal concat)")
+
+    def copy(self):
+        """
+        Return a deep copy.
+        """
+        return SegArray(self.segments, self.values, copy=True)
+
+    def _get_lengths(self):
+        if self.size == 0:
+            return zeros(0, dtype=akint64)
+        elif self.size == 1:
+            return array([self.valsize])
+        else:
+            return concatenate((self.segments[1:], array([self.valsize]))) - self.segments
+
+    def __getitem__(self, i):
+        if isSupportedInt(i):
+            start = self.segments[i]
+            end = self.segments[i] + self.lengths[i]
+            return self.values[start:end].to_ndarray()
+        elif (isinstance(i, pdarray) and (i.dtype == akint64 or i.dtype == akbool)) or isinstance(i, slice):
+            starts = self.segments[i]
+            ends = starts + self.lengths[i]
+            newsegs, inds = gen_ranges(starts, ends)
+            return SegArray(newsegs, self.values[inds], copy=True)
+        else:
+            raise TypeError(f'Invalid index type: {type(i)}')
+
+    def __eq__(self, other):
+        if not isinstance(other, SegArray):
+            return NotImplemented
+        eq = zeros(self.size, dtype=akbool)
+        leneq = self.lengths == other.lengths
+        if leneq.sum() > 0:
+            selfcmp = self[leneq]
+            othercmp = other[leneq]
+            intersection = self.all(selfcmp.values == othercmp.values)
+            eq[leneq] = intersection
+        return eq
+
+    def __str__(self):
+        if self.size <= 6:
+            rows = list(range(self.size))
+        else:
+            rows = [0, 1, 2, None, self.size - 3, self.size - 2, self.size - 1]
+        outlines = ['SegArray([']
+        for r in rows:
+            if r is None:
+                outlines.append('...')
+            else:
+                outlines.append(str(self[r]))
+        outlines.append('])')
+        return '\n'.join(outlines)
+
+    def __repr__(self):
+        return self.__str__()
+
+    def get_suffixes(self, n, return_origins=True, proper=True):
+        """
+        Return the n-long suffix of each sub-array, where possible
+
+        Parameters
+        ----------
+        n : int
+            Length of suffix
+        return_origins : bool
+            If True, return a logical index indicating which sub-arrays
+            were long enough to return an n-suffix
+        proper : bool
+            If True, only return proper suffixes, i.e. from sub-arrays
+            that are at least n+1 long. If False, allow the entire
+            sub-array to be returned as a suffix.
+
+        Returns
+        -------
+        suffixes : list of pdarray
+            An n-long list of pdarrays, essentially a table where each row is an n-suffix.
+            The number of rows is the number of True values in the returned mask.
+        origin_indices : pdarray, bool
+            Boolean array that is True where the sub-array was long enough to return
+            an n-suffix, False otherwise.
+        """
+        if proper:
+            longenough = self.lengths > n
+        else:
+            longenough = self.lengths >= n
+        suffixes = []
+        for i in range(n):
+            ind = (self.segments + self.lengths - (n - i))[longenough]
+            suffixes.append(self.values[ind])
+        if return_origins:
+            return suffixes, longenough
+        else:
+            return suffixes
+
+    def get_prefixes(self, n, return_origins=True, proper=True):
+        """
+        Return all sub-array prefixes of length n (for sub-arrays that are at least n+1 long)
+
+        Parameters
+        ----------
+        n : int
+            Length of suffix
+        return_origins : bool
+            If True, return a logical index indicating which sub-arrays
+            were long enough to return an n-prefix
+        proper : bool
+            If True, only return proper prefixes, i.e. from sub-arrays
+            that are at least n+1 long. If False, allow the entire
+            sub-array to be returned as a prefix.
+
+        Returns
+        -------
+        prefixes : list of pdarray
+            An n-long list of pdarrays, essentially a table where each row is an n-prefix.
+            The number of rows is the number of True values in the returned mask.
+        origin_indices : pdarray, bool
+            Boolean array that is True where the sub-array was long enough to return
+            an n-suffix, False otherwise.
+        """
+        if proper:
+            longenough = self.lengths > n
+        else:
+            longenough = self.lengths >= n
+        prefixes = []
+        for i in range(n):
+            ind = (self.segments + i)[longenough]
+            prefixes.append(self.values[ind])
+        if return_origins:
+            return prefixes, longenough
+        else:
+            return prefixes
+
+    def get_ngrams(self, n, return_origins=True):
+        """
+        Return all n-grams from all sub-arrays.
+
+        Parameters
+        ----------
+        n : int
+            Length of n-gram
+        return_origins : bool
+            If True, return an int64 array indicating which sub-array
+            each returned n-gram came from.
+
+        Returns
+        -------
+        ngrams : list of pdarray
+            An n-long list of pdarrays, essentially a table where each row is an n-gram.
+        origin_indices : pdarray, int
+            The index of the sub-array from which the corresponding n-gram originated
+        """
+        ngrams = []
+        notsegstart = ones(self.valsize, dtype=akbool)
+        notsegstart[self.segments] = False
+        valid = ones(self.valsize - n + 1, dtype=akbool)
+        for i in range(n):
+            end = self.valsize - n + i + 1
+            ngrams.append(self.values[i:end])
+            if i > 0:
+                valid &= notsegstart[i:end]
+        ngrams = [char[valid] for char in ngrams]
+        if return_origins:
+            origin_indices = self.grouping.broadcast(arange(self.size), permute=True)[:valid.size][valid]
+            return ngrams, origin_indices
+        else:
+            return ngrams
+
+    def _normalize_index(self, j):
+        if not isSupportedInt(j):
+            raise TypeError(f'index must be integer, not {type(j)}')
+        if j >= 0:
+            longenough = self.lengths > j
+        else:
+            j = self.lengths + j
+            longenough = j >= 0
+        return longenough, j
+
+    def get_jth(self, j, return_origins=True, compressed=False, default=0):
+        """
+        Select the j-th element of each sub-array, where possible.
+
+        Parameters
+        ----------
+        j : int
+            The index of the value to get from each sub-array. If j is negative,
+            it counts backwards from the end of each sub-array.
+        return_origins : bool
+            If True, return a logical index indicating where j is in bounds
+        compressed : bool
+            If False, return array is same size as self, with default value
+            where j is out of bounds. If True, the return array only contains
+            values where j is in bounds.
+        default : scalar
+            When compressed=False, the value to return when j is out of bounds
+            for the sub-array
+
+        Returns
+        -------
+        val : pdarray
+            compressed=False: The j-th value of each sub-array where j is in
+            bounds and the default value where j is out of bounds.
+            compressed=True: The j-th values of only the sub-arrays where j is
+            in bounds
+        origin_indices : pdarray, bool
+            A Boolean array that is True where j is in bounds for the sub-array.
+        """
+        longenough, newj = self._normalize_index(j)
+        ind = (self.segments + newj)[longenough]
+        if compressed:
+            res = self.values[ind]
+        else:
+            res = zeros(self.size, dtype=self.dtype) + default
+            res[longenough] = self.values[ind]
+        if return_origins:
+            return res, longenough
+        else:
+            return res
+
+    def set_jth(self, i, j, v):
+        """
+        Set the j-th element of each sub-array in a subset.
+
+        Parameters
+        ----------
+        i : pdarray, int
+            Indices of sub-arrays to set j-th element
+        j : int
+            Index of value to set in each sub-array. If j is negative, it counts
+            backwards from the end of the sub-array.
+        v : pdarray or scalar
+            The value(s) to set. If v is a pdarray, it must have same length as i.
+
+        Raises
+        -----
+        ValueError
+            If j is out of bounds in any of the sub-arrays specified by i.
+        """
+        if self.dtype == str_:
+            raise TypeError("String elements are immutable")
+        longenough, newj = self._normalize_index(j)
+        if not longenough[i].all():
+            raise ValueError(f'Not all (i, j) in bounds')
+        ind = (self.segments + newj)[i]
+        self.values[ind] = v
+
+    def get_length_n(self, n, return_origins=True):
+        """
+        Return all sub-arrays of length n, as a list of columns.
+
+        Parameters
+        ----------
+        n : int
+            Length of sub-arrays to select
+        return_origins : bool
+            Return a logical index indicating which sub-arrays are length n
+
+        Returns
+        -------
+        columns : list of pdarray
+            An n-long list of pdarray, where each row is one of the n-long
+            sub-arrays from the SegArray. The number of rows is the number of
+            True values in the returned mask.
+        origin_indices : pdarray, bool
+            Array of bool for each element of the SegArray, True where sub-array
+            has length n.
+        """
+        mask = self.lengths == n
+        elem = []
+        for i in range(n):
+            ind = (self.segments + self.lengths - (n - i))[mask]
+            elem.append(self.values[ind])
+        if return_origins:
+            return elem, mask
+        else:
+            return elem
+
+    def append(self, other, axis=0):
+        """
+        Append other to self, either vertically (axis=0, length of resulting SegArray
+        increases), or horizontally (axis=1, each sub-array of other appends to the
+        corresponding sub-array of self).
+
+        Parameters
+        ----------
+        other : SegArray
+            Array of sub-arrays to append
+        axis : 0 or 1
+            Whether to append vertically (0) or horizontally (1). If axis=1, other
+            must be same size as self.
+
+        Returns
+        -------
+        SegArray
+            axis=0: New SegArray containing all sub-arrays
+            axis=1: New SegArray of same length, with pairs of sub-arrays concatenated
+        """
+        if not isinstance(other, SegArray):
+            return NotImplemented
+        if self.dtype != other.dtype:
+            raise TypeError("SegArrays must have same value type to append")
+        return self.__class__.concat((self, other), axis=axis)
+
+    def append_single(self, x, prepend=False):
+        '''
+        Append a single value to each sub-array.
+
+        Parameters
+        ----------
+        x : pdarray or scalar
+            Single value to append to each sub-array
+
+        Returns
+        -------
+        SegArray
+            Copy of original SegArray with values from x appended to each sub-array
+        '''
+        if hasattr(x, 'size'):
+            if x.size != self.size:
+                raise ValueError('Argument must be scalar or same size as SegArray')
+            if type(x) != type(self.values) or x.dtype != self.dtype:
+                raise TypeError('Argument type must match value type of SegArray')
+        newlens = self.lengths + 1
+        newsegs = cumsum(newlens) - newlens
+        newvals = zeros(newlens.sum(), dtype=self.dtype)
+        if prepend:
+            lastscatter = newsegs
+        else:
+            lastscatter = newsegs + newlens - 1
+        newvals[lastscatter] = x
+        origscatter = arange(self.valsize) + self.grouping.broadcast(ak.arange(self.size), permute=True)
+        if prepend:
+            origscatter += 1
+        newvals[origscatter] = self.values
+        return SegArray(newsegs, newvals)
+
+    def prepend_single(self, x):
+        return self.append_single(x, prepend=True)
+
+    def remove_repeats(self, return_multiplicity=False):
+        """
+        Condense sequences of repeated values within a sub-array to a single value.
+
+        Parameters
+        ----------
+        return_multiplicity : bool
+            If True, also return the number of times each value was repeated.
+
+        Returns
+        -------
+        norepeats : SegArray
+            Sub-arrays with runs of repeated values replaced with single value
+        multiplicity : SegArray
+            If return_multiplicity=True, this array contains the number of times
+            each value in the returned SegArray was repeated in the original SegArray.
+        """
+        isrepeat = zeros(self.values.size, dtype=akbool)
+        isrepeat[1:] = self.values[:-1] == self.values[1:]
+        isrepeat[self.segments] = False
+        truepaths = self.values[~isrepeat]
+        nhops = self.grouping.sum(~isrepeat)[1]
+        # truehops = ak.cumsum(~isrepeat)
+        # nhops = ak.concatenate((truehops[self.segments[1:]], ak.array([truehops.sum()+1]))) - truehops[self.segments]
+        truesegs = cumsum(nhops) - nhops
+        norepeats = SegArray(truesegs, truepaths)
+        if return_multiplicity:
+            truehopinds = arange(self.valsize)[~isrepeat]
+            multiplicity = zeros(truepaths.size, dtype=akint64)
+            multiplicity[:-1] = truehopinds[1:] - truehopinds[:-1]
+            multiplicity[-1] = self.valsize - truehopinds[-1]
+            return norepeats, SegArray(truesegs, multiplicity)
+        else:
+            return norepeats
+
+    def to_ndarray(self):
+        ndvals = self.values.to_ndarray()
+        ndsegs = self.segments.to_ndarray()
+        arr = [ndvals[start:end] for start, end in zip(ndsegs, ndsegs[1:])]
+        if self.size > 0:
+            arr.append(ndvals[ndsegs[-1]:])
+        return arr
+
+    def sum(self, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.sum(x)[1]
+
+    def prod(self, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.prod(x)[1]
+
+    def min(self, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.min(x)[1]
+
+    def max(self, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.max(x)[1]
+
+    def argmin(self, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.argmin(x)[1]
+
+    def argmax(self, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.argmax(x)[1]
+
+    def any(self, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.any(x)[1]
+
+    def all(self, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.all(x)[1]
+
+    def OR(self, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.OR(x)[1]
+
+    def AND(self, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.AND(x)[1]
+
+    def XOR(self, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.XOR(x)[1]
+
+    def nunique(self, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.nunique(x)[1]
+
+    def mean(self, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.mean(x)[1]
+
+    def aggregate(self, op, x=None):
+        if x is None:
+            x = self.values
+        return self.grouping.aggregate(x, op)
+
+    def unique(self, x=None):
+        '''
+        Return sub-arrays of unique values.
+
+        Parameters
+        ----------
+        x : pdarray
+            The values to unique, per group. By default, the values of this
+            SegArray's sub-arrays.
+
+        Returns
+        -------
+        SegArray
+            Same number of sub-arrays as original SegArray, but elements in sub-array
+            are unique and in sorted order.
+        '''
+        if x is None:
+            x = self.values
+        keyidx = self.grouping.broadcast(arange(self.size), permute=True)
+        ukey, uval = GroupBy([keyidx, x]).unique_keys
+        g = GroupBy(ukey, assume_sorted=True)
+        _, lengths = g.count()
+        return SegArray(g.segments, uval, grouping=g, lengths=lengths)
+
+    def save(self, prefix_path, dataset='segarray', segment_suffix='_segments', value_suffix='_values',
+             mode='truncate'):
+        '''
+        Save the SegArray to HDF5. The result is a collection of HDF5 files, one file
+        per locale of the arkouda server, where each filename starts with prefix_path.
+
+        Parameters
+        ----------
+        prefix_path : str
+            Directory and filename prefix that all output files will share
+        dataset : str
+            Name prefix for saved data within the HDF5 file
+        segment_suffix : str
+            Suffix to append to dataset name for segments array
+        value_suffix : str
+            Suffix to append to dataset name for values array
+        mode : str {'truncate' | 'append'}
+            By default, truncate (overwrite) output files, if they exist.
+            If 'append', add data as a new column to existing files.
+
+        Returns
+        -------
+        None
+
+        Notes
+        -----
+        Unlike for ak.Strings, SegArray is saved as two datasets in the top level of
+        the HDF5 file, not nested under a group.
+        '''
+        if segment_suffix == value_suffix:
+            raise ValueError("Segment suffix and value suffix must be different")
+        self.segments.save(prefix_path, dataset=dataset + segment_suffix, mode=mode)
+        self.values.save(prefix_path, dataset=dataset + value_suffix, mode='append')
+
+    @classmethod
+    def load(cls, prefix_path, dataset='segarray', segment_suffix='_segments', value_suffix='_values', mode='truncate'):
+        '''
+        Load a saved SegArray from HDF5. All arguments msut match what
+        was supplied to SegArray.save()
+
+        Parameters
+        ----------
+        prefix_path : str
+            Directory and filename prefix
+        dataset : str
+            Name prefix for saved data within the HDF5 files
+        segment_suffix : str
+            Suffix to append to dataset name for segments array
+        value_suffix : str
+            Suffix to append to dataset name for values array
+
+        Returns
+        -------
+        SegArray
+        '''
+        if segment_suffix == value_suffix:
+            raise ValueError("Segment suffix and value suffix must be different")
+        segments = load(prefix_path, dataset=dataset + segment_suffix)
+        values = load(prefix_path, dataset=dataset + value_suffix)
+        return cls(segments, values)
+
+    #Register/Attach functionality has been removed until it is added for GroupBy.
+    # Please refer to ticket #1122 (https://github.com/Bears-R-Us/arkouda/issues/1122 for updates

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -13,40 +13,40 @@ from arkouda.pdarrayIO import load
 
 
 def gen_ranges(starts, ends, stride=1):
-    """ Generate a segmented array of variable-length, contiguous ranges between pairs of start- and end-points.
+	""" Generate a segmented array of variable-length, contiguous ranges between pairs of start- and end-points.
 
-    Parameters
-    ----------
-    starts : pdarray, int64
-        The start value of each range
-    ends : pdarray, int64
-        The end value (exclusive) of each range
-    stride: int
-        Difference between successive elements of each range
+	Parameters
+	----------
+	starts : pdarray, int64
+		The start value of each range
+	ends : pdarray, int64
+		The end value (exclusive) of each range
+	stride: int
+		Difference between successive elements of each range
 
-    Returns
-    -------
-    segments : pdarray, int64
-        The starting index of each range in the resulting array
-    ranges : pdarray, int64
-        The actual ranges, flattened into a single array
-    """
-    if starts.size != ends.size:
-        raise ValueError("starts and ends must be same length")
-    if starts.size == 0:
-        return zeros(0, dtype=akint64), zeros(0, dtype=akint64)
-    lengths = (ends - starts) // stride
-    segs = cumsum(lengths) - lengths
-    totlen = lengths.sum()
-    slices = ones(totlen, dtype=akint64)
-    diffs = concatenate((array([starts[0]]),
-                            starts[1:] - starts[:-1] - (lengths[:-1] - 1) * stride))
-    slices[segs] = diffs
-    return segs, cumsum(slices)
+	Returns
+	-------
+	segments : pdarray, int64
+		The starting index of each range in the resulting array
+	ranges : pdarray, int64
+		The actual ranges, flattened into a single array
+	"""
+	if starts.size != ends.size:
+		raise ValueError("starts and ends must be same length")
+	if starts.size == 0:
+		return zeros(0, dtype=akint64), zeros(0, dtype=akint64)
+	lengths = (ends - starts) // stride
+	segs = cumsum(lengths) - lengths
+	totlen = lengths.sum()
+	slices = ones(totlen, dtype=akint64)
+	diffs = concatenate((array([starts[0]]),
+	                     starts[1:] - starts[:-1] - (lengths[:-1] - 1) * stride))
+	slices[segs] = diffs
+	return segs, cumsum(slices)
 
 
 def _aggregator(func):
-    aggdoc = """
+	aggdoc = """
         Aggregate values over each sub-array.
 
         Parameters
@@ -62,706 +62,707 @@ def _aggregator(func):
         Array of one aggregated value per sub-array.
         """
 
-    def update_doc():
-        func.__doc__ = aggdoc
-        return func
+	def update_doc():
+		func.__doc__ = aggdoc
+		return func
 
-    return update_doc
+	return update_doc
+
 
 class SegArray:
-    def __init__(self, segments, values, copy=False, lengths=None, grouping=None):
-        """
-        An array of variable-length arrays, also called a skyline array or ragged array.
-
-        Parameters
-        ----------
-        segments : pdarray, int64
-            Start index of each sub-array in the flattened values array
-        values : pdarray
-            The flattened values of all sub-arrays
-        copy : bool
-            If True, make a copy of the input arrays; otherwise, just store a reference.
-
-        Returns
-        -------
-        SegArray
-            Data structure representing an array whose elements are variable-length arrays.
-
-        Notes
-        -----
-        Keyword args 'lengths' and 'grouping' are not user-facing. They are used by the
-        attach method.
-        """
-        if not isinstance(segments, pdarray) or segments.dtype != akint64:
-            raise TypeError("Segments must be int64 pdarray")
-        if not is_sorted(segments) or (unique(segments).size != segments.size):
-            raise ValueError("Segments must be unique and in sorted order")
-        if segments.size > 0:
-            if segments.min() != 0 or segments.max() >= values.size:
-                raise ValueError("Segments must start at zero and be less than values.size")
-        elif values.size > 0:
-            raise ValueError("Cannot have non-empty values with empty segments")
-        if copy:
-            self.segments = segments[:]
-            self.values = values[:]
-        else:
-            self.segments = segments
-            self.values = values
-        self.size = segments.size
-        self.valsize = values.size
-        if lengths is None:
-            self.lengths = self._get_lengths()
-        else:
-            self.lengths = lengths
-        self.dtype = values.dtype
-        if grouping is None:
-            if self.size == 0:
-                self.grouping = GroupBy(zeros(0, dtype=akint64))
-            else:
-                # Treat each sub-array as a group, for grouped aggregations
-                self.grouping = GroupBy(broadcast(self.segments, arange(self.size), self.valsize))
-        else:
-            self.grouping = grouping
-
-    @classmethod
-    def from_multi_array(cls, m):
-        """
-        Construct a SegArray from a list of columns. This essentially transposes the input,
-        resulting in an array of rows.
-
-        Parameters
-        ----------
-        m : list of pdarray
-            List of columns, the rows of which will form the sub-arrays of the output
-
-        Returns
-        -------
-        SegArray
-            Array of rows of input
-        """
-        if isinstance(m, pdarray):
-            size = m.size
-            n = 1
-            dtype = m.dtype
-        else:
-            s = set(mi.size for mi in m)
-            if len(s) != 1:
-                raise ValueError("All columns must have same length")
-            size = s.pop()
-            n = len(m)
-            d = set(mi.dtype for mi in m)
-            if len(d) != 1:
-                raise ValueError("All columns must have same dtype")
-            dtype = d.pop()
-        newsegs = arange(size) * n
-        newvals = zeros(size * n, dtype=dtype)
-        for j in range(len(m)):
-            newvals[j::len(m)] = m[j]
-        return cls(newsegs, newvals)
-
-    @classmethod
-    def concat(cls, x, axis=0, ordered=True):
-        """
-        Concatenate a sequence of SegArrays
-
-        Parameters
-        ----------
-        x : sequence of SegArray
-            The SegArrays to concatenate
-        axis : 0 or 1
-            Select vertical (0) or horizontal (1) concatenation. If axis=1, all
-            SegArrays must have same size.
-        ordered : bool
-            Must be True. This option is present for compatibility only, because unordered
-            concatenation is not yet supported.
-
-        Returns
-        -------
-        SegArray
-            The input arrays joined into one SegArray
-        """
-        if not ordered:
-            raise ValueError("Unordered concatenation not yet supported on SegArray; use ordered=True.")
-        if len(x) == 0:
-            raise ValueError("Empty sequence passed to concat")
-        for xi in x:
-            if not isinstance(xi, cls):
-                return NotImplemented
-        if len(set(xi.dtype for xi in x)) != 1:
-            raise ValueError("SegArrays must all have same dtype to concatenate")
-        if axis == 0:
-            ctr = 0
-            segs = []
-            vals = []
-            for xi in x:
-                # Segment offsets need to be raised by length of previous values
-                segs.append(xi.segments + ctr)
-                ctr += xi.valsize
-                # Values can just be concatenated
-                vals.append(xi.values)
-            return cls(concatenate(segs), concatenate(vals))
-        elif axis == 1:
-            sizes = set(xi.size for xi in x)
-            if len(sizes) != 1:
-                raise ValueError("SegArrays must all have same size to concatenate with axis=1")
-            if sizes.pop() == 0:
-                return x[0]
-            dt = list(x)[0].dtype
-            newlens = sum(xi.lengths for xi in x)
-            newsegs = cumsum(newlens) - newlens
-            # Ignore sub-arrays that are empty in all arrays
-            nonzero = concatenate((newsegs[:-1] < newsegs[1:], array([True])))
-            nzsegs = newsegs[nonzero]
-            newvals = zeros(newlens.sum(), dtype=dt)
-            for xi in x:
-                # Set up fromself for a scan, so that it steps up at the start of a segment
-                # from the current array, and steps back down at the end
-                fromself = zeros(newvals.size + 1, dtype=akint64)
-                fromself[nzsegs] += 1
-                nzlens = xi.lengths[nonzero]
-                fromself[nzsegs + nzlens] -= 1
-                fromself = (cumsum(fromself[:-1]) == 1)
-                newvals[fromself] = xi.values
-                nzsegs += nzlens
-            return cls(newsegs, newvals, copy=False)
-        else:
-            raise ValueError("Supported values for axis are 0 (vertical concat) or 1 (horizontal concat)")
-
-    def copy(self):
-        """
-        Return a deep copy.
-        """
-        return SegArray(self.segments, self.values, copy=True)
-
-    def _get_lengths(self):
-        if self.size == 0:
-            return zeros(0, dtype=akint64)
-        elif self.size == 1:
-            return array([self.valsize])
-        else:
-            return concatenate((self.segments[1:], array([self.valsize]))) - self.segments
-
-    def __getitem__(self, i):
-        if isSupportedInt(i):
-            start = self.segments[i]
-            end = self.segments[i] + self.lengths[i]
-            return self.values[start:end].to_ndarray()
-        elif (isinstance(i, pdarray) and (i.dtype == akint64 or i.dtype == akbool)) or isinstance(i, slice):
-            starts = self.segments[i]
-            ends = starts + self.lengths[i]
-            newsegs, inds = gen_ranges(starts, ends)
-            return SegArray(newsegs, self.values[inds], copy=True)
-        else:
-            raise TypeError(f'Invalid index type: {type(i)}')
-
-    def __eq__(self, other):
-        if not isinstance(other, SegArray):
-            return NotImplemented
-        eq = zeros(self.size, dtype=akbool)
-        leneq = self.lengths == other.lengths
-        if leneq.sum() > 0:
-            selfcmp = self[leneq]
-            othercmp = other[leneq]
-            intersection = self.all(selfcmp.values == othercmp.values)
-            eq[leneq] = intersection
-        return eq
-
-    def __str__(self):
-        if self.size <= 6:
-            rows = list(range(self.size))
-        else:
-            rows = [0, 1, 2, None, self.size - 3, self.size - 2, self.size - 1]
-        outlines = ['SegArray([']
-        for r in rows:
-            if r is None:
-                outlines.append('...')
-            else:
-                outlines.append(str(self[r]))
-        outlines.append('])')
-        return '\n'.join(outlines)
-
-    def __repr__(self):
-        return self.__str__()
-
-    def get_suffixes(self, n, return_origins=True, proper=True):
-        """
-        Return the n-long suffix of each sub-array, where possible
-
-        Parameters
-        ----------
-        n : int
-            Length of suffix
-        return_origins : bool
-            If True, return a logical index indicating which sub-arrays
-            were long enough to return an n-suffix
-        proper : bool
-            If True, only return proper suffixes, i.e. from sub-arrays
-            that are at least n+1 long. If False, allow the entire
-            sub-array to be returned as a suffix.
-
-        Returns
-        -------
-        suffixes : list of pdarray
-            An n-long list of pdarrays, essentially a table where each row is an n-suffix.
-            The number of rows is the number of True values in the returned mask.
-        origin_indices : pdarray, bool
-            Boolean array that is True where the sub-array was long enough to return
-            an n-suffix, False otherwise.
-        """
-        if proper:
-            longenough = self.lengths > n
-        else:
-            longenough = self.lengths >= n
-        suffixes = []
-        for i in range(n):
-            ind = (self.segments + self.lengths - (n - i))[longenough]
-            suffixes.append(self.values[ind])
-        if return_origins:
-            return suffixes, longenough
-        else:
-            return suffixes
-
-    def get_prefixes(self, n, return_origins=True, proper=True):
-        """
-        Return all sub-array prefixes of length n (for sub-arrays that are at least n+1 long)
-
-        Parameters
-        ----------
-        n : int
-            Length of suffix
-        return_origins : bool
-            If True, return a logical index indicating which sub-arrays
-            were long enough to return an n-prefix
-        proper : bool
-            If True, only return proper prefixes, i.e. from sub-arrays
-            that are at least n+1 long. If False, allow the entire
-            sub-array to be returned as a prefix.
-
-        Returns
-        -------
-        prefixes : list of pdarray
-            An n-long list of pdarrays, essentially a table where each row is an n-prefix.
-            The number of rows is the number of True values in the returned mask.
-        origin_indices : pdarray, bool
-            Boolean array that is True where the sub-array was long enough to return
-            an n-suffix, False otherwise.
-        """
-        if proper:
-            longenough = self.lengths > n
-        else:
-            longenough = self.lengths >= n
-        prefixes = []
-        for i in range(n):
-            ind = (self.segments + i)[longenough]
-            prefixes.append(self.values[ind])
-        if return_origins:
-            return prefixes, longenough
-        else:
-            return prefixes
-
-    def get_ngrams(self, n, return_origins=True):
-        """
-        Return all n-grams from all sub-arrays.
-
-        Parameters
-        ----------
-        n : int
-            Length of n-gram
-        return_origins : bool
-            If True, return an int64 array indicating which sub-array
-            each returned n-gram came from.
-
-        Returns
-        -------
-        ngrams : list of pdarray
-            An n-long list of pdarrays, essentially a table where each row is an n-gram.
-        origin_indices : pdarray, int
-            The index of the sub-array from which the corresponding n-gram originated
-        """
-        ngrams = []
-        notsegstart = ones(self.valsize, dtype=akbool)
-        notsegstart[self.segments] = False
-        valid = ones(self.valsize - n + 1, dtype=akbool)
-        for i in range(n):
-            end = self.valsize - n + i + 1
-            ngrams.append(self.values[i:end])
-            if i > 0:
-                valid &= notsegstart[i:end]
-        ngrams = [char[valid] for char in ngrams]
-        if return_origins:
-            origin_indices = self.grouping.broadcast(arange(self.size), permute=True)[:valid.size][valid]
-            return ngrams, origin_indices
-        else:
-            return ngrams
-
-    def _normalize_index(self, j):
-        if not isSupportedInt(j):
-            raise TypeError(f'index must be integer, not {type(j)}')
-        if j >= 0:
-            longenough = self.lengths > j
-        else:
-            j = self.lengths + j
-            longenough = j >= 0
-        return longenough, j
-
-    def get_jth(self, j, return_origins=True, compressed=False, default=0):
-        """
-        Select the j-th element of each sub-array, where possible.
-
-        Parameters
-        ----------
-        j : int
-            The index of the value to get from each sub-array. If j is negative,
-            it counts backwards from the end of each sub-array.
-        return_origins : bool
-            If True, return a logical index indicating where j is in bounds
-        compressed : bool
-            If False, return array is same size as self, with default value
-            where j is out of bounds. If True, the return array only contains
-            values where j is in bounds.
-        default : scalar
-            When compressed=False, the value to return when j is out of bounds
-            for the sub-array
-
-        Returns
-        -------
-        val : pdarray
-            compressed=False: The j-th value of each sub-array where j is in
-            bounds and the default value where j is out of bounds.
-            compressed=True: The j-th values of only the sub-arrays where j is
-            in bounds
-        origin_indices : pdarray, bool
-            A Boolean array that is True where j is in bounds for the sub-array.
-        """
-        longenough, newj = self._normalize_index(j)
-        ind = (self.segments + newj)[longenough]
-        if compressed:
-            res = self.values[ind]
-        else:
-            res = zeros(self.size, dtype=self.dtype) + default
-            res[longenough] = self.values[ind]
-        if return_origins:
-            return res, longenough
-        else:
-            return res
-
-    def set_jth(self, i, j, v):
-        """
-        Set the j-th element of each sub-array in a subset.
-
-        Parameters
-        ----------
-        i : pdarray, int
-            Indices of sub-arrays to set j-th element
-        j : int
-            Index of value to set in each sub-array. If j is negative, it counts
-            backwards from the end of the sub-array.
-        v : pdarray or scalar
-            The value(s) to set. If v is a pdarray, it must have same length as i.
-
-        Raises
-        -----
-        ValueError
-            If j is out of bounds in any of the sub-arrays specified by i.
-        """
-        if self.dtype == str_:
-            raise TypeError("String elements are immutable")
-        longenough, newj = self._normalize_index(j)
-        if not longenough[i].all():
-            raise ValueError(f'Not all (i, j) in bounds')
-        ind = (self.segments + newj)[i]
-        self.values[ind] = v
-
-    def get_length_n(self, n, return_origins=True):
-        """
-        Return all sub-arrays of length n, as a list of columns.
-
-        Parameters
-        ----------
-        n : int
-            Length of sub-arrays to select
-        return_origins : bool
-            Return a logical index indicating which sub-arrays are length n
-
-        Returns
-        -------
-        columns : list of pdarray
-            An n-long list of pdarray, where each row is one of the n-long
-            sub-arrays from the SegArray. The number of rows is the number of
-            True values in the returned mask.
-        origin_indices : pdarray, bool
-            Array of bool for each element of the SegArray, True where sub-array
-            has length n.
-        """
-        mask = self.lengths == n
-        elem = []
-        for i in range(n):
-            ind = (self.segments + self.lengths - (n - i))[mask]
-            elem.append(self.values[ind])
-        if return_origins:
-            return elem, mask
-        else:
-            return elem
-
-    def append(self, other, axis=0):
-        """
-        Append other to self, either vertically (axis=0, length of resulting SegArray
-        increases), or horizontally (axis=1, each sub-array of other appends to the
-        corresponding sub-array of self).
-
-        Parameters
-        ----------
-        other : SegArray
-            Array of sub-arrays to append
-        axis : 0 or 1
-            Whether to append vertically (0) or horizontally (1). If axis=1, other
-            must be same size as self.
-
-        Returns
-        -------
-        SegArray
-            axis=0: New SegArray containing all sub-arrays
-            axis=1: New SegArray of same length, with pairs of sub-arrays concatenated
-        """
-        if not isinstance(other, SegArray):
-            return NotImplemented
-        if self.dtype != other.dtype:
-            raise TypeError("SegArrays must have same value type to append")
-        return self.__class__.concat((self, other), axis=axis)
-
-    def append_single(self, x, prepend=False):
-        '''
-        Append a single value to each sub-array.
-
-        Parameters
-        ----------
-        x : pdarray or scalar
-            Single value to append to each sub-array
-
-        Returns
-        -------
-        SegArray
-            Copy of original SegArray with values from x appended to each sub-array
-        '''
-        if hasattr(x, 'size'):
-            if x.size != self.size:
-                raise ValueError('Argument must be scalar or same size as SegArray')
-            if type(x) != type(self.values) or x.dtype != self.dtype:
-                raise TypeError('Argument type must match value type of SegArray')
-        newlens = self.lengths + 1
-        newsegs = cumsum(newlens) - newlens
-        newvals = zeros(newlens.sum(), dtype=self.dtype)
-        if prepend:
-            lastscatter = newsegs
-        else:
-            lastscatter = newsegs + newlens - 1
-        newvals[lastscatter] = x
-        origscatter = arange(self.valsize) + self.grouping.broadcast(ak.arange(self.size), permute=True)
-        if prepend:
-            origscatter += 1
-        newvals[origscatter] = self.values
-        return SegArray(newsegs, newvals)
-
-    def prepend_single(self, x):
-        return self.append_single(x, prepend=True)
-
-    def remove_repeats(self, return_multiplicity=False):
-        """
-        Condense sequences of repeated values within a sub-array to a single value.
-
-        Parameters
-        ----------
-        return_multiplicity : bool
-            If True, also return the number of times each value was repeated.
-
-        Returns
-        -------
-        norepeats : SegArray
-            Sub-arrays with runs of repeated values replaced with single value
-        multiplicity : SegArray
-            If return_multiplicity=True, this array contains the number of times
-            each value in the returned SegArray was repeated in the original SegArray.
-        """
-        isrepeat = zeros(self.values.size, dtype=akbool)
-        isrepeat[1:] = self.values[:-1] == self.values[1:]
-        isrepeat[self.segments] = False
-        truepaths = self.values[~isrepeat]
-        nhops = self.grouping.sum(~isrepeat)[1]
-        # truehops = ak.cumsum(~isrepeat)
-        # nhops = ak.concatenate((truehops[self.segments[1:]], ak.array([truehops.sum()+1]))) - truehops[self.segments]
-        truesegs = cumsum(nhops) - nhops
-        norepeats = SegArray(truesegs, truepaths)
-        if return_multiplicity:
-            truehopinds = arange(self.valsize)[~isrepeat]
-            multiplicity = zeros(truepaths.size, dtype=akint64)
-            multiplicity[:-1] = truehopinds[1:] - truehopinds[:-1]
-            multiplicity[-1] = self.valsize - truehopinds[-1]
-            return norepeats, SegArray(truesegs, multiplicity)
-        else:
-            return norepeats
-
-    def to_ndarray(self):
-        ndvals = self.values.to_ndarray()
-        ndsegs = self.segments.to_ndarray()
-        arr = [ndvals[start:end] for start, end in zip(ndsegs, ndsegs[1:])]
-        if self.size > 0:
-            arr.append(ndvals[ndsegs[-1]:])
-        return arr
-
-    def sum(self, x=None):
-        if x is None:
-            x = self.values
-        return self.grouping.sum(x)[1]
-
-    def prod(self, x=None):
-        if x is None:
-            x = self.values
-        return self.grouping.prod(x)[1]
-
-    def min(self, x=None):
-        if x is None:
-            x = self.values
-        return self.grouping.min(x)[1]
-
-    def max(self, x=None):
-        if x is None:
-            x = self.values
-        return self.grouping.max(x)[1]
-
-    def argmin(self, x=None):
-        if x is None:
-            x = self.values
-        return self.grouping.argmin(x)[1]
-
-    def argmax(self, x=None):
-        if x is None:
-            x = self.values
-        return self.grouping.argmax(x)[1]
-
-    def any(self, x=None):
-        if x is None:
-            x = self.values
-        return self.grouping.any(x)[1]
-
-    def all(self, x=None):
-        if x is None:
-            x = self.values
-        return self.grouping.all(x)[1]
-
-    def OR(self, x=None):
-        if x is None:
-            x = self.values
-        return self.grouping.OR(x)[1]
-
-    def AND(self, x=None):
-        if x is None:
-            x = self.values
-        return self.grouping.AND(x)[1]
-
-    def XOR(self, x=None):
-        if x is None:
-            x = self.values
-        return self.grouping.XOR(x)[1]
-
-    def nunique(self, x=None):
-        if x is None:
-            x = self.values
-        return self.grouping.nunique(x)[1]
-
-    def mean(self, x=None):
-        if x is None:
-            x = self.values
-        return self.grouping.mean(x)[1]
-
-    def aggregate(self, op, x=None):
-        if x is None:
-            x = self.values
-        return self.grouping.aggregate(x, op)
-
-    def unique(self, x=None):
-        '''
-        Return sub-arrays of unique values.
-
-        Parameters
-        ----------
-        x : pdarray
-            The values to unique, per group. By default, the values of this
-            SegArray's sub-arrays.
-
-        Returns
-        -------
-        SegArray
-            Same number of sub-arrays as original SegArray, but elements in sub-array
-            are unique and in sorted order.
-        '''
-        if x is None:
-            x = self.values
-        keyidx = self.grouping.broadcast(arange(self.size), permute=True)
-        ukey, uval = GroupBy([keyidx, x]).unique_keys
-        g = GroupBy(ukey, assume_sorted=True)
-        _, lengths = g.count()
-        return SegArray(g.segments, uval, grouping=g, lengths=lengths)
-
-    def save(self, prefix_path, dataset='segarray', segment_suffix='_segments', value_suffix='_values',
-             mode='truncate'):
-        '''
-        Save the SegArray to HDF5. The result is a collection of HDF5 files, one file
-        per locale of the arkouda server, where each filename starts with prefix_path.
-
-        Parameters
-        ----------
-        prefix_path : str
-            Directory and filename prefix that all output files will share
-        dataset : str
-            Name prefix for saved data within the HDF5 file
-        segment_suffix : str
-            Suffix to append to dataset name for segments array
-        value_suffix : str
-            Suffix to append to dataset name for values array
-        mode : str {'truncate' | 'append'}
-            By default, truncate (overwrite) output files, if they exist.
-            If 'append', add data as a new column to existing files.
-
-        Returns
-        -------
-        None
-
-        Notes
-        -----
-        Unlike for ak.Strings, SegArray is saved as two datasets in the top level of
-        the HDF5 file, not nested under a group.
-        '''
-        if segment_suffix == value_suffix:
-            raise ValueError("Segment suffix and value suffix must be different")
-        self.segments.save(prefix_path, dataset=dataset + segment_suffix, mode=mode)
-        self.values.save(prefix_path, dataset=dataset + value_suffix, mode='append')
-
-    @classmethod
-    def load(cls, prefix_path, dataset='segarray', segment_suffix='_segments', value_suffix='_values', mode='truncate'):
-        '''
-        Load a saved SegArray from HDF5. All arguments msut match what
-        was supplied to SegArray.save()
-
-        Parameters
-        ----------
-        prefix_path : str
-            Directory and filename prefix
-        dataset : str
-            Name prefix for saved data within the HDF5 files
-        segment_suffix : str
-            Suffix to append to dataset name for segments array
-        value_suffix : str
-            Suffix to append to dataset name for values array
-
-        Returns
-        -------
-        SegArray
-        '''
-        if segment_suffix == value_suffix:
-            raise ValueError("Segment suffix and value suffix must be different")
-        segments = load(prefix_path, dataset=dataset + segment_suffix)
-        values = load(prefix_path, dataset=dataset + value_suffix)
-        return cls(segments, values)
-
-    #Register/Attach functionality has been removed until it is added for GroupBy.
-    # Please refer to ticket #1122 (https://github.com/Bears-R-Us/arkouda/issues/1122 for updates
+	def __init__(self, segments, values, copy=False, lengths=None, grouping=None):
+		"""
+		An array of variable-length arrays, also called a skyline array or ragged array.
+
+		Parameters
+		----------
+		segments : pdarray, int64
+			Start index of each sub-array in the flattened values array
+		values : pdarray
+			The flattened values of all sub-arrays
+		copy : bool
+			If True, make a copy of the input arrays; otherwise, just store a reference.
+
+		Returns
+		-------
+		SegArray
+			Data structure representing an array whose elements are variable-length arrays.
+
+		Notes
+		-----
+		Keyword args 'lengths' and 'grouping' are not user-facing. They are used by the
+		attach method.
+		"""
+		if not isinstance(segments, pdarray) or segments.dtype != akint64:
+			raise TypeError("Segments must be int64 pdarray")
+		if not is_sorted(segments) or (unique(segments).size != segments.size):
+			raise ValueError("Segments must be unique and in sorted order")
+		if segments.size > 0:
+			if segments.min() != 0 or segments.max() >= values.size:
+				raise ValueError("Segments must start at zero and be less than values.size")
+		elif values.size > 0:
+			raise ValueError("Cannot have non-empty values with empty segments")
+		if copy:
+			self.segments = segments[:]
+			self.values = values[:]
+		else:
+			self.segments = segments
+			self.values = values
+		self.size = segments.size
+		self.valsize = values.size
+		if lengths is None:
+			self.lengths = self._get_lengths()
+		else:
+			self.lengths = lengths
+		self.dtype = values.dtype
+		if grouping is None:
+			if self.size == 0:
+				self.grouping = GroupBy(zeros(0, dtype=akint64))
+			else:
+				# Treat each sub-array as a group, for grouped aggregations
+				self.grouping = GroupBy(broadcast(self.segments, arange(self.size), self.valsize))
+		else:
+			self.grouping = grouping
+
+	@classmethod
+	def from_multi_array(cls, m):
+		"""
+		Construct a SegArray from a list of columns. This essentially transposes the input,
+		resulting in an array of rows.
+
+		Parameters
+		----------
+		m : list of pdarray
+			List of columns, the rows of which will form the sub-arrays of the output
+
+		Returns
+		-------
+		SegArray
+			Array of rows of input
+		"""
+		if isinstance(m, pdarray):
+			size = m.size
+			n = 1
+			dtype = m.dtype
+		else:
+			s = set(mi.size for mi in m)
+			if len(s) != 1:
+				raise ValueError("All columns must have same length")
+			size = s.pop()
+			n = len(m)
+			d = set(mi.dtype for mi in m)
+			if len(d) != 1:
+				raise ValueError("All columns must have same dtype")
+			dtype = d.pop()
+		newsegs = arange(size) * n
+		newvals = zeros(size * n, dtype=dtype)
+		for j in range(len(m)):
+			newvals[j::len(m)] = m[j]
+		return cls(newsegs, newvals)
+
+	@classmethod
+	def concat(cls, x, axis=0, ordered=True):
+		"""
+		Concatenate a sequence of SegArrays
+
+		Parameters
+		----------
+		x : sequence of SegArray
+			The SegArrays to concatenate
+		axis : 0 or 1
+			Select vertical (0) or horizontal (1) concatenation. If axis=1, all
+			SegArrays must have same size.
+		ordered : bool
+			Must be True. This option is present for compatibility only, because unordered
+			concatenation is not yet supported.
+
+		Returns
+		-------
+		SegArray
+			The input arrays joined into one SegArray
+		"""
+		if not ordered:
+			raise ValueError("Unordered concatenation not yet supported on SegArray; use ordered=True.")
+		if len(x) == 0:
+			raise ValueError("Empty sequence passed to concat")
+		for xi in x:
+			if not isinstance(xi, cls):
+				return NotImplemented
+		if len(set(xi.dtype for xi in x)) != 1:
+			raise ValueError("SegArrays must all have same dtype to concatenate")
+		if axis == 0:
+			ctr = 0
+			segs = []
+			vals = []
+			for xi in x:
+				# Segment offsets need to be raised by length of previous values
+				segs.append(xi.segments + ctr)
+				ctr += xi.valsize
+				# Values can just be concatenated
+				vals.append(xi.values)
+			return cls(concatenate(segs), concatenate(vals))
+		elif axis == 1:
+			sizes = set(xi.size for xi in x)
+			if len(sizes) != 1:
+				raise ValueError("SegArrays must all have same size to concatenate with axis=1")
+			if sizes.pop() == 0:
+				return x[0]
+			dt = list(x)[0].dtype
+			newlens = sum(xi.lengths for xi in x)
+			newsegs = cumsum(newlens) - newlens
+			# Ignore sub-arrays that are empty in all arrays
+			nonzero = concatenate((newsegs[:-1] < newsegs[1:], array([True])))
+			nzsegs = newsegs[nonzero]
+			newvals = zeros(newlens.sum(), dtype=dt)
+			for xi in x:
+				# Set up fromself for a scan, so that it steps up at the start of a segment
+				# from the current array, and steps back down at the end
+				fromself = zeros(newvals.size + 1, dtype=akint64)
+				fromself[nzsegs] += 1
+				nzlens = xi.lengths[nonzero]
+				fromself[nzsegs + nzlens] -= 1
+				fromself = (cumsum(fromself[:-1]) == 1)
+				newvals[fromself] = xi.values
+				nzsegs += nzlens
+			return cls(newsegs, newvals, copy=False)
+		else:
+			raise ValueError("Supported values for axis are 0 (vertical concat) or 1 (horizontal concat)")
+
+	def copy(self):
+		"""
+		Return a deep copy.
+		"""
+		return SegArray(self.segments, self.values, copy=True)
+
+	def _get_lengths(self):
+		if self.size == 0:
+			return zeros(0, dtype=akint64)
+		elif self.size == 1:
+			return array([self.valsize])
+		else:
+			return concatenate((self.segments[1:], array([self.valsize]))) - self.segments
+
+	def __getitem__(self, i):
+		if isSupportedInt(i):
+			start = self.segments[i]
+			end = self.segments[i] + self.lengths[i]
+			return self.values[start:end].to_ndarray()
+		elif (isinstance(i, pdarray) and (i.dtype == akint64 or i.dtype == akbool)) or isinstance(i, slice):
+			starts = self.segments[i]
+			ends = starts + self.lengths[i]
+			newsegs, inds = gen_ranges(starts, ends)
+			return SegArray(newsegs, self.values[inds], copy=True)
+		else:
+			raise TypeError(f'Invalid index type: {type(i)}')
+
+	def __eq__(self, other):
+		if not isinstance(other, SegArray):
+			return NotImplemented
+		eq = zeros(self.size, dtype=akbool)
+		leneq = self.lengths == other.lengths
+		if leneq.sum() > 0:
+			selfcmp = self[leneq]
+			othercmp = other[leneq]
+			intersection = self.all(selfcmp.values == othercmp.values)
+			eq[leneq] = intersection
+		return eq
+
+	def __str__(self):
+		if self.size <= 6:
+			rows = list(range(self.size))
+		else:
+			rows = [0, 1, 2, None, self.size - 3, self.size - 2, self.size - 1]
+		outlines = ['SegArray([']
+		for r in rows:
+			if r is None:
+				outlines.append('...')
+			else:
+				outlines.append(str(self[r]))
+		outlines.append('])')
+		return '\n'.join(outlines)
+
+	def __repr__(self):
+		return self.__str__()
+
+	def get_suffixes(self, n, return_origins=True, proper=True):
+		"""
+		Return the n-long suffix of each sub-array, where possible
+
+		Parameters
+		----------
+		n : int
+			Length of suffix
+		return_origins : bool
+			If True, return a logical index indicating which sub-arrays
+			were long enough to return an n-suffix
+		proper : bool
+			If True, only return proper suffixes, i.e. from sub-arrays
+			that are at least n+1 long. If False, allow the entire
+			sub-array to be returned as a suffix.
+
+		Returns
+		-------
+		suffixes : list of pdarray
+			An n-long list of pdarrays, essentially a table where each row is an n-suffix.
+			The number of rows is the number of True values in the returned mask.
+		origin_indices : pdarray, bool
+			Boolean array that is True where the sub-array was long enough to return
+			an n-suffix, False otherwise.
+		"""
+		if proper:
+			longenough = self.lengths > n
+		else:
+			longenough = self.lengths >= n
+		suffixes = []
+		for i in range(n):
+			ind = (self.segments + self.lengths - (n - i))[longenough]
+			suffixes.append(self.values[ind])
+		if return_origins:
+			return suffixes, longenough
+		else:
+			return suffixes
+
+	def get_prefixes(self, n, return_origins=True, proper=True):
+		"""
+		Return all sub-array prefixes of length n (for sub-arrays that are at least n+1 long)
+
+		Parameters
+		----------
+		n : int
+			Length of suffix
+		return_origins : bool
+			If True, return a logical index indicating which sub-arrays
+			were long enough to return an n-prefix
+		proper : bool
+			If True, only return proper prefixes, i.e. from sub-arrays
+			that are at least n+1 long. If False, allow the entire
+			sub-array to be returned as a prefix.
+
+		Returns
+		-------
+		prefixes : list of pdarray
+			An n-long list of pdarrays, essentially a table where each row is an n-prefix.
+			The number of rows is the number of True values in the returned mask.
+		origin_indices : pdarray, bool
+			Boolean array that is True where the sub-array was long enough to return
+			an n-suffix, False otherwise.
+		"""
+		if proper:
+			longenough = self.lengths > n
+		else:
+			longenough = self.lengths >= n
+		prefixes = []
+		for i in range(n):
+			ind = (self.segments + i)[longenough]
+			prefixes.append(self.values[ind])
+		if return_origins:
+			return prefixes, longenough
+		else:
+			return prefixes
+
+	def get_ngrams(self, n, return_origins=True):
+		"""
+		Return all n-grams from all sub-arrays.
+
+		Parameters
+		----------
+		n : int
+			Length of n-gram
+		return_origins : bool
+			If True, return an int64 array indicating which sub-array
+			each returned n-gram came from.
+
+		Returns
+		-------
+		ngrams : list of pdarray
+			An n-long list of pdarrays, essentially a table where each row is an n-gram.
+		origin_indices : pdarray, int
+			The index of the sub-array from which the corresponding n-gram originated
+		"""
+		ngrams = []
+		notsegstart = ones(self.valsize, dtype=akbool)
+		notsegstart[self.segments] = False
+		valid = ones(self.valsize - n + 1, dtype=akbool)
+		for i in range(n):
+			end = self.valsize - n + i + 1
+			ngrams.append(self.values[i:end])
+			if i > 0:
+				valid &= notsegstart[i:end]
+		ngrams = [char[valid] for char in ngrams]
+		if return_origins:
+			origin_indices = self.grouping.broadcast(arange(self.size), permute=True)[:valid.size][valid]
+			return ngrams, origin_indices
+		else:
+			return ngrams
+
+	def _normalize_index(self, j):
+		if not isSupportedInt(j):
+			raise TypeError(f'index must be integer, not {type(j)}')
+		if j >= 0:
+			longenough = self.lengths > j
+		else:
+			j = self.lengths + j
+			longenough = j >= 0
+		return longenough, j
+
+	def get_jth(self, j, return_origins=True, compressed=False, default=0):
+		"""
+		Select the j-th element of each sub-array, where possible.
+
+		Parameters
+		----------
+		j : int
+			The index of the value to get from each sub-array. If j is negative,
+			it counts backwards from the end of each sub-array.
+		return_origins : bool
+			If True, return a logical index indicating where j is in bounds
+		compressed : bool
+			If False, return array is same size as self, with default value
+			where j is out of bounds. If True, the return array only contains
+			values where j is in bounds.
+		default : scalar
+			When compressed=False, the value to return when j is out of bounds
+			for the sub-array
+
+		Returns
+		-------
+		val : pdarray
+			compressed=False: The j-th value of each sub-array where j is in
+			bounds and the default value where j is out of bounds.
+			compressed=True: The j-th values of only the sub-arrays where j is
+			in bounds
+		origin_indices : pdarray, bool
+			A Boolean array that is True where j is in bounds for the sub-array.
+		"""
+		longenough, newj = self._normalize_index(j)
+		ind = (self.segments + newj)[longenough]
+		if compressed:
+			res = self.values[ind]
+		else:
+			res = zeros(self.size, dtype=self.dtype) + default
+			res[longenough] = self.values[ind]
+		if return_origins:
+			return res, longenough
+		else:
+			return res
+
+	def set_jth(self, i, j, v):
+		"""
+		Set the j-th element of each sub-array in a subset.
+
+		Parameters
+		----------
+		i : pdarray, int
+			Indices of sub-arrays to set j-th element
+		j : int
+			Index of value to set in each sub-array. If j is negative, it counts
+			backwards from the end of the sub-array.
+		v : pdarray or scalar
+			The value(s) to set. If v is a pdarray, it must have same length as i.
+
+		Raises
+		-----
+		ValueError
+			If j is out of bounds in any of the sub-arrays specified by i.
+		"""
+		if self.dtype == str_:
+			raise TypeError("String elements are immutable")
+		longenough, newj = self._normalize_index(j)
+		if not longenough[i].all():
+			raise ValueError(f'Not all (i, j) in bounds')
+		ind = (self.segments + newj)[i]
+		self.values[ind] = v
+
+	def get_length_n(self, n, return_origins=True):
+		"""
+		Return all sub-arrays of length n, as a list of columns.
+
+		Parameters
+		----------
+		n : int
+			Length of sub-arrays to select
+		return_origins : bool
+			Return a logical index indicating which sub-arrays are length n
+
+		Returns
+		-------
+		columns : list of pdarray
+			An n-long list of pdarray, where each row is one of the n-long
+			sub-arrays from the SegArray. The number of rows is the number of
+			True values in the returned mask.
+		origin_indices : pdarray, bool
+			Array of bool for each element of the SegArray, True where sub-array
+			has length n.
+		"""
+		mask = self.lengths == n
+		elem = []
+		for i in range(n):
+			ind = (self.segments + self.lengths - (n - i))[mask]
+			elem.append(self.values[ind])
+		if return_origins:
+			return elem, mask
+		else:
+			return elem
+
+	def append(self, other, axis=0):
+		"""
+		Append other to self, either vertically (axis=0, length of resulting SegArray
+		increases), or horizontally (axis=1, each sub-array of other appends to the
+		corresponding sub-array of self).
+
+		Parameters
+		----------
+		other : SegArray
+			Array of sub-arrays to append
+		axis : 0 or 1
+			Whether to append vertically (0) or horizontally (1). If axis=1, other
+			must be same size as self.
+
+		Returns
+		-------
+		SegArray
+			axis=0: New SegArray containing all sub-arrays
+			axis=1: New SegArray of same length, with pairs of sub-arrays concatenated
+		"""
+		if not isinstance(other, SegArray):
+			return NotImplemented
+		if self.dtype != other.dtype:
+			raise TypeError("SegArrays must have same value type to append")
+		return self.__class__.concat((self, other), axis=axis)
+
+	def append_single(self, x, prepend=False):
+		'''
+		Append a single value to each sub-array.
+
+		Parameters
+		----------
+		x : pdarray or scalar
+			Single value to append to each sub-array
+
+		Returns
+		-------
+		SegArray
+			Copy of original SegArray with values from x appended to each sub-array
+		'''
+		if hasattr(x, 'size'):
+			if x.size != self.size:
+				raise ValueError('Argument must be scalar or same size as SegArray')
+			if type(x) != type(self.values) or x.dtype != self.dtype:
+				raise TypeError('Argument type must match value type of SegArray')
+		newlens = self.lengths + 1
+		newsegs = cumsum(newlens) - newlens
+		newvals = zeros(newlens.sum(), dtype=self.dtype)
+		if prepend:
+			lastscatter = newsegs
+		else:
+			lastscatter = newsegs + newlens - 1
+		newvals[lastscatter] = x
+		origscatter = arange(self.valsize) + self.grouping.broadcast(arange(self.size), permute=True)
+		if prepend:
+			origscatter += 1
+		newvals[origscatter] = self.values
+		return SegArray(newsegs, newvals)
+
+	def prepend_single(self, x):
+		return self.append_single(x, prepend=True)
+
+	def remove_repeats(self, return_multiplicity=False):
+		"""
+		Condense sequences of repeated values within a sub-array to a single value.
+
+		Parameters
+		----------
+		return_multiplicity : bool
+			If True, also return the number of times each value was repeated.
+
+		Returns
+		-------
+		norepeats : SegArray
+			Sub-arrays with runs of repeated values replaced with single value
+		multiplicity : SegArray
+			If return_multiplicity=True, this array contains the number of times
+			each value in the returned SegArray was repeated in the original SegArray.
+		"""
+		isrepeat = zeros(self.values.size, dtype=akbool)
+		isrepeat[1:] = self.values[:-1] == self.values[1:]
+		isrepeat[self.segments] = False
+		truepaths = self.values[~isrepeat]
+		nhops = self.grouping.sum(~isrepeat)[1]
+		# truehops = ak.cumsum(~isrepeat)
+		# nhops = ak.concatenate((truehops[self.segments[1:]], ak.array([truehops.sum()+1]))) - truehops[self.segments]
+		truesegs = cumsum(nhops) - nhops
+		norepeats = SegArray(truesegs, truepaths)
+		if return_multiplicity:
+			truehopinds = arange(self.valsize)[~isrepeat]
+			multiplicity = zeros(truepaths.size, dtype=akint64)
+			multiplicity[:-1] = truehopinds[1:] - truehopinds[:-1]
+			multiplicity[-1] = self.valsize - truehopinds[-1]
+			return norepeats, SegArray(truesegs, multiplicity)
+		else:
+			return norepeats
+
+	def to_ndarray(self):
+		ndvals = self.values.to_ndarray()
+		ndsegs = self.segments.to_ndarray()
+		arr = [ndvals[start:end] for start, end in zip(ndsegs, ndsegs[1:])]
+		if self.size > 0:
+			arr.append(ndvals[ndsegs[-1]:])
+		return arr
+
+	def sum(self, x=None):
+		if x is None:
+			x = self.values
+		return self.grouping.sum(x)[1]
+
+	def prod(self, x=None):
+		if x is None:
+			x = self.values
+		return self.grouping.prod(x)[1]
+
+	def min(self, x=None):
+		if x is None:
+			x = self.values
+		return self.grouping.min(x)[1]
+
+	def max(self, x=None):
+		if x is None:
+			x = self.values
+		return self.grouping.max(x)[1]
+
+	def argmin(self, x=None):
+		if x is None:
+			x = self.values
+		return self.grouping.argmin(x)[1]
+
+	def argmax(self, x=None):
+		if x is None:
+			x = self.values
+		return self.grouping.argmax(x)[1]
+
+	def any(self, x=None):
+		if x is None:
+			x = self.values
+		return self.grouping.any(x)[1]
+
+	def all(self, x=None):
+		if x is None:
+			x = self.values
+		return self.grouping.all(x)[1]
+
+	def OR(self, x=None):
+		if x is None:
+			x = self.values
+		return self.grouping.OR(x)[1]
+
+	def AND(self, x=None):
+		if x is None:
+			x = self.values
+		return self.grouping.AND(x)[1]
+
+	def XOR(self, x=None):
+		if x is None:
+			x = self.values
+		return self.grouping.XOR(x)[1]
+
+	def nunique(self, x=None):
+		if x is None:
+			x = self.values
+		return self.grouping.nunique(x)[1]
+
+	def mean(self, x=None):
+		if x is None:
+			x = self.values
+		return self.grouping.mean(x)[1]
+
+	def aggregate(self, op, x=None):
+		if x is None:
+			x = self.values
+		return self.grouping.aggregate(x, op)
+
+	def unique(self, x=None):
+		'''
+		Return sub-arrays of unique values.
+
+		Parameters
+		----------
+		x : pdarray
+			The values to unique, per group. By default, the values of this
+			SegArray's sub-arrays.
+
+		Returns
+		-------
+		SegArray
+			Same number of sub-arrays as original SegArray, but elements in sub-array
+			are unique and in sorted order.
+		'''
+		if x is None:
+			x = self.values
+		keyidx = self.grouping.broadcast(arange(self.size), permute=True)
+		ukey, uval = GroupBy([keyidx, x]).unique_keys
+		g = GroupBy(ukey, assume_sorted=True)
+		_, lengths = g.count()
+		return SegArray(g.segments, uval, grouping=g, lengths=lengths)
+
+	def save(self, prefix_path, dataset='segarray', segment_suffix='_segments', value_suffix='_values',
+	         mode='truncate'):
+		'''
+		Save the SegArray to HDF5. The result is a collection of HDF5 files, one file
+		per locale of the arkouda server, where each filename starts with prefix_path.
+
+		Parameters
+		----------
+		prefix_path : str
+			Directory and filename prefix that all output files will share
+		dataset : str
+			Name prefix for saved data within the HDF5 file
+		segment_suffix : str
+			Suffix to append to dataset name for segments array
+		value_suffix : str
+			Suffix to append to dataset name for values array
+		mode : str {'truncate' | 'append'}
+			By default, truncate (overwrite) output files, if they exist.
+			If 'append', add data as a new column to existing files.
+
+		Returns
+		-------
+		None
+
+		Notes
+		-----
+		Unlike for ak.Strings, SegArray is saved as two datasets in the top level of
+		the HDF5 file, not nested under a group.
+		'''
+		if segment_suffix == value_suffix:
+			raise ValueError("Segment suffix and value suffix must be different")
+		self.segments.save(prefix_path, dataset=dataset + segment_suffix, mode=mode)
+		self.values.save(prefix_path, dataset=dataset + value_suffix, mode='append')
+
+	@classmethod
+	def load(cls, prefix_path, dataset='segarray', segment_suffix='_segments', value_suffix='_values', mode='truncate'):
+		'''
+		Load a saved SegArray from HDF5. All arguments msut match what
+		was supplied to SegArray.save()
+
+		Parameters
+		----------
+		prefix_path : str
+			Directory and filename prefix
+		dataset : str
+			Name prefix for saved data within the HDF5 files
+		segment_suffix : str
+			Suffix to append to dataset name for segments array
+		value_suffix : str
+			Suffix to append to dataset name for values array
+
+		Returns
+		-------
+		SegArray
+		'''
+		if segment_suffix == value_suffix:
+			raise ValueError("Segment suffix and value suffix must be different")
+		segments = load(prefix_path, dataset=dataset + segment_suffix)
+		values = load(prefix_path, dataset=dataset + value_suffix)
+		return cls(segments, values)
+
+# Register/Attach functionality has been removed until it is added for GroupBy.
+# Please refer to ticket #1122 (https://github.com/Bears-R-Us/arkouda/issues/1122 for updates

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -379,6 +379,9 @@ class SegArray:
 		origin_indices : pdarray, int
 			The index of the sub-array from which the corresponding n-gram originated
 		"""
+		if n > self._get_lengths().max():
+			raise ValueError('n must be <= the maximum length of the sub-arrays')
+
 		ngrams = []
 		notsegstart = ones(self.valsize, dtype=akbool)
 		notsegstart[self.segments] = False

--- a/pydoc/requirements.txt
+++ b/pydoc/requirements.txt
@@ -7,6 +7,7 @@ pexpect
 pytest 
 pytest-env
 pyfiglet
+tabulate
 typeguard
 numpy
 zmq

--- a/pydoc/usage/dataframe.rst
+++ b/pydoc/usage/dataframe.rst
@@ -1,0 +1,78 @@
+***********
+DataFrames in Arkouda
+***********
+
+Like Pandas, Arkouda supports ``DataFrames``. The purpose and intended functionality remains the same in Arkouda, but are configured to be based on ``arkouda.pdarrays``.
+
+.. autoclass:: arkouda.DataFrame
+
+Data Types
+==========
+Currently, ``DataFrames`` support 4 Arkouda data types for supplying columns.
+
+* ``Arkouda.pdarray``
+* ``Arkouda.Strings``
+* ``Arkouda.Categorical``
+* ``Arkouda.SegArray``
+
+Data within the above objects can be of the types below. Please Note - Not all listed types are compatible with every type above.
+
+* ``int64``: 64-bit signed integer
+* ``uint64``: 64-bit unsigned integer
+* ``float64``: IEEE 64-bit floating point number
+* ``bool``: 8-bit boolean value
+* ``str``: Python string
+
+Iteration
+=========
+
+Iterating directly over a ``DataFrame`` with ``for x in df`` is not recommended. Doing so is discouraged because it requires transferring all array data from the arkouda server to the Python client since there is almost always a more array-oriented way to express an iterator-based computation. To force this transfer, use the ``to_pandas`` function to return the ``DataFrame`` as a ``pandas.DataFrame``. This transfer will raise an error if it exceeds the byte limit defined in ``arkouda.maxTransferBytes``.
+
+.. autofunction:: arkouda.DataFrame.to_pandas
+
+Features
+==========
+``DataFrames`` support the majority of functionality offered by ``pandas.DataFrame``.
+
+GroupBy
+----------
+.. autofunction:: arkouda.DataFrame.groupby
+
+Copy
+----------
+.. autofunction:: arkouda.DataFrame.copy
+
+Filter
+----------
+.. autofunction:: arkouda.DataFrame.filter_by_ranges
+
+Permutations
+----------
+.. autofunction:: arkouda.DataFrame.apply_permutation
+
+Sorting
+----------
+.. autofunction:: arkouda.DataFrame.argsort
+
+.. autofunction:: arkouda.DataFrame.coargsort
+
+.. autofunction:: arkouda.DataFrame.sort_values
+
+Tail/Head of Data
+----------
+.. autofunction:: arkouda.DataFrame.tail
+
+.. autofunction:: arkouda.DataFrame.head
+
+Rename Columns
+----------
+.. autofunction:: arkouda.DataFrame.rename
+
+Reset Indexes
+----------
+.. autofunction:: arkouda.DataFrame.reset_index
+
+Deduplication
+----------
+.. autofunction:: arkouda.DataFrame.drop_duplicates
+

--- a/pydoc/usage/segarray.rst
+++ b/pydoc/usage/segarray.rst
@@ -1,0 +1,67 @@
+*********************
+SegArrays in Arkouda
+*********************
+
+In NumPy, arrays containing variable-length sub-arrays are supported as an array containing a single column. Each column contains another ``ndarray`` of some length. Depending on the chosen approach in NumPy, this can result in a loss of functioanlity. In Arkouda, the array containing variable-length sub-arrays is its own class: ``SegArray``
+
+In order to efficiently store arrays with varying row and column dimensions, Arkouda uses a "segmented array" data strucuture:
+
+* ``segments``: An ``int64`` array containing the start index of each sub-array within the flattened values array
+* ``values``: The flattened values of all sub-arrays
+
+
+Performance
+===========
+``SegArray`` objects are currently processed entire on the Arkouda client side. The data structure is reflective of the data structure that will be used for Arkouda server side processing.
+
+Iteration
+===========
+Because ``SegArray`` is currently processing entirely on the Arkouda client side, iteration is natively supported. Thus, ``for row in segarr`` with iterate over each sub-array. Each of these sub-arrays is currently returned as a ``numpy.ndarray``.
+
+Similar to ``Strings``, ``SegArrays`` will be moved to process server side. This will remove the ability to natively iterate to discourage transferring all of the objects data to the client. In order to support this moving forward, ``SegArray`` includes a ``to_ndarray()`` function. It is recommended that this function be used for iteration over ``SegArray`` objects, to prevent issues associated with moving processing server side. For more information on the usage of ``to_ndarray`` with SegArray
+
+.. autofunction:: arkouda.SegArray.to_ndarray
+
+Operation
+===========
+Arkouda ``SegArray`` objects support the following operations:
+
+* Indexing with integer, slice, integer ``pdarray``, and boolean ``pdarray`` (see :ref:`indexing-label`)
+* Comparison (==) Provides an Arkouda ``pdarray`` containing ``bool`` values indicating the equality of each sub-array in the ``SegArray``.
+* :ref:`setops-label`, e.g. ``unique``
+* :ref:`concatenate-label` with other ``SegArrays``. Horizontal and vertical axis supported.
+
+SegArray Specific Methods
+===========
+
+Prefix & Suffix
+-----------
+.. autofunction:: arkouda.SegArray.get_prefixes
+
+.. autofunction:: arkouda.SegArray.get_suffixes
+
+NGrams
+----------
+.. autofunction:: arkouda.SegArray.get_ngrams
+
+Sub-array of Size
+----------
+.. autofunction:: arkouda.SegArray.get_length_n
+
+Access/Set Specific Elements in Sub-Array
+----------
+.. autofunction:: arkouda.SegArray.get_jth
+
+.. autofunction:: arkouda.SegArray.set_jth
+
+Append & Prepend
+----------
+.. autofunction:: arkouda.SegArray.append
+
+.. autofunction:: arkouda.SegArray.append_single
+
+.. autofunction:: arkouda.SegArray.prepend_single
+
+Deduplication
+----------
+.. autofunction:: arkouda.SegArray.remove_repeats

--- a/pytest.ini
+++ b/pytest.ini
@@ -24,6 +24,7 @@ testpaths =
     tests/regex_test.py
     tests/registration_test.py
     tests/security_test.py
+    tests/segarray_test.py
     tests/setops_test.py
     tests/sort_test.py
     tests/string_test.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,6 +8,7 @@ testpaths =
     tests/client_test.py
     tests/coargsort_test.py
     tests/compare_test.py
+    tests/dataframe_test.py
     tests/datetime_test.py
     tests/dtypes_tests.py
     tests/groupby_test.py

--- a/setup.py
+++ b/setup.py
@@ -135,6 +135,7 @@ setup(
         'pandas>=1.1.0',
         'pyzmq>=20.0.0',
         'typeguard==2.10.0',
+        'tabulate',
         'pyfiglet',
         'versioneer'
     ],

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -1,0 +1,274 @@
+import pandas
+
+from base_test import ArkoudaTest
+from context import arkouda as ak
+
+class DataFrameTest(ArkoudaTest):
+    def test_dataframe_creation(self):
+        df = ak.DataFrame()
+        self.assertIsInstance(df, ak.DataFrame)
+
+        username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+        userid = ak.array([111, 222, 111, 333, 222, 111])
+        item = ak.array([0, 0, 1, 1, 2, 0])
+        day = ak.array([5, 5, 6, 5, 6, 6])
+        amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
+        df = ak.DataFrame({'userName': username, 'userID': userid,
+                           'item': item, 'day': day, 'amount': amount})
+        self.assertIsInstance(df, ak.DataFrame)
+        self.assertEqual(df[0], {'index': 0, 'userName': 'Alice', 'userID': 111, 'item': 0, 'day': 5, 'amount': 0.5})
+        self.assertTrue((df['userName'] == ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])).all())
+        self.assertEqual(len(df), 6)
+
+    def test_drop(self):
+        username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+        userid = ak.array([111, 222, 111, 333, 222, 111])
+        item = ak.array([0, 0, 1, 1, 2, 0])
+        day = ak.array([5, 5, 6, 5, 6, 6])
+        amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
+        df = ak.DataFrame({'userName': username, 'userID': userid,
+                           'item': item, 'day': day, 'amount': amount})
+        df.drop('userName')
+        self.assertEquals(df.__str__(), ak.DataFrame({'userID': userid,
+                                           'item': item, 'day': day, 'amount': amount}).__str__())
+
+        with self.assertRaises(KeyError):
+            df.drop('index')
+
+    def test_drop_duplicates(self):
+        username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+        userid = ak.array([111, 222, 111, 333, 222, 111])
+        item = ak.array([0, 1, 0, 2, 1, 0])
+        day = ak.array([5, 5, 5, 5, 5, 5])
+        df = ak.DataFrame({'userName': username, 'userID': userid,
+                           'item': item, 'day': day})
+
+        dedup = df.drop_duplicates()
+
+        username2 = ak.array(['Alice', 'Bob', 'Carol'])
+        userid2 = ak.array([111, 222, 333])
+        item2 = ak.array([0, 1, 2])
+        day2 = ak.array([5, 5, 5])
+        self.assertEquals(dedup.__str__(), ak.DataFrame({'userName': username2, 'userID': userid2,
+                           'item': item2, 'day': day2}).__str__())
+
+    def test_shape(self):
+        username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+        userid = ak.array([111, 222, 111, 333, 222, 111])
+        item = ak.array([0, 1, 0, 2, 1, 0])
+        day = ak.array([5, 5, 5, 5, 5, 5])
+        df = ak.DataFrame({'userName': username, 'userID': userid,
+                           'item': item, 'day': day})
+
+        row, col = df.shape
+        self.assertEqual(row, 6)
+        self.assertEqual(col, 4)
+
+    def test_reset_index(self):
+        username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+        userid = ak.array([111, 222, 111, 333, 222, 111])
+        item = ak.array([0, 1, 0, 2, 1, 0])
+        day = ak.array([5, 5, 5, 5, 5, 5])
+        df = ak.DataFrame({'userName': username, 'userID': userid,
+                           'item': item, 'day': day})
+
+        slice_df = df[[1, 3, 5]]
+        self.assertTrue((slice_df.index == ak.array([1, 3, 5])).all())
+        slice_df.reset_index()
+        self.assertTrue((slice_df.index == ak.array([0, 1, 2])).all())
+
+    def test_rename(self):
+        username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+        userid = ak.array([111, 222, 111, 333, 222, 111])
+        item = ak.array([0, 1, 0, 2, 1, 0])
+        day = ak.array([5, 5, 5, 5, 5, 5])
+        df = ak.DataFrame({'userName': username, 'userID': userid,
+                           'item': item, 'day': day})
+
+        rename = {'userName': 'name_col', 'userID': 'user_id'}
+        df.rename(rename)
+        self.assertIn("user_id", df.__str__())
+        self.assertIn("name_col", df.__str__())
+        self.assertNotIn('userName', df.__str__())
+        self.assertNotIn('userID', df.__str__())
+        print(df.__str__())
+
+    def test_head(self):
+        username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+        userid = ak.array([111, 222, 111, 333, 222, 111])
+        item = ak.array([0, 1, 0, 2, 1, 0])
+        day = ak.array([5, 5, 5, 5, 5, 5])
+        df = ak.DataFrame({'userName': username, 'userID': userid,
+                           'item': item, 'day': day})
+
+        hdf = df.head(3)
+        self.assertEqual(len(hdf), 3)
+        self.assertTrue((hdf.index == ak.array([0, 1, 2])).all())
+
+    def test_tail(self):
+        username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+        userid = ak.array([111, 222, 111, 333, 222, 111])
+        item = ak.array([0, 1, 0, 2, 1, 0])
+        day = ak.array([5, 5, 5, 5, 5, 5])
+        df = ak.DataFrame({'userName': username, 'userID': userid,
+                           'item': item, 'day': day})
+
+        hdf = df.tail(2)
+        self.assertEqual(len(hdf), 2)
+        self.assertTrue((hdf.index == ak.array([4, 5])).all())
+
+    def test_groupby_standard(self):
+        username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+        userid = ak.array([111, 222, 111, 333, 222, 111])
+        item = ak.array([0, 0, 1, 1, 2, 0])
+        day = ak.array([5, 5, 6, 5, 6, 6])
+        amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
+        df = ak.DataFrame({'userName': username, 'userID': userid,
+                           'item': item, 'day': day, 'amount': amount})
+
+        gb = df.GroupBy('userName')
+        keys, count = gb.count()
+        self.assertTrue((keys == ak.array(['Alice', 'Carol', 'Bob'])).all())
+        self.assertTrue((count == ak.array([3, 1, 2])).all())
+
+        gb = df.GroupBy(['userName', 'userID'])
+        keys, count = gb.count()
+        self.assertEqual(len(keys), 2)
+        self.assertTrue((keys[0] == ak.array(['Alice', 'Carol', 'Bob'])).all())
+        self.assertTrue((keys[1] == ak.array([111, 333, 222])).all())
+        self.assertTrue((count == ak.array([3, 1, 2])).all())
+
+        with self.assertRaises(NotImplementedError):
+            gb = df.GroupBy('userName', use_series=True)
+
+    def test_to_pandas(self):
+        username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+        userid = ak.array([111, 222, 111, 333, 222, 111])
+        item = ak.array([0, 0, 1, 1, 2, 0])
+        day = ak.array([5, 5, 6, 5, 6, 6])
+        amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
+        df = ak.DataFrame({'userName': username, 'userID': userid,
+                           'item': item, 'day': day, 'amount': amount})
+
+        pddf = df.to_pandas()
+        data = [
+            ['Alice', 111, 0, 5, 0.5],
+            ['Bob', 222, 0, 5, 0.6],
+            ['Alice', 111, 1, 6, 1.1],
+            ['Carol', 333, 1, 5, 1.2],
+            ['Bob', 222, 2, 6, 4.3],
+            ['Alice', 111, 0, 6, 0.6]
+        ]
+        test_df = pandas.DataFrame(data, columns=['userName', 'userID', 'item', 'day', 'amount'])
+        self.assertTrue(pddf.equals(test_df))
+
+
+        slice_df = df[[1, 3, 5]]
+        pddf = slice_df.to_pandas(retain_index=True)
+        self.assertEqual(pddf.index.tolist(), [1, 3, 5])
+
+        pddf = slice_df.to_pandas()
+        self.assertEqual(pddf.index.tolist(), [0, 1, 2])
+
+    def test_argsort(self):
+        username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+        userid = ak.array([111, 222, 111, 333, 222, 111])
+        item = ak.array([0, 0, 1, 1, 2, 0])
+        day = ak.array([5, 5, 6, 5, 6, 6])
+        amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
+        df = ak.DataFrame({'userName': username, 'userID': userid,
+                           'item': item, 'day': day, 'amount': amount})
+
+        p = df.argsort(key='userName')
+        self.assertTrue((p == ak.array([0, 2, 5, 1, 4, 3])).all())
+
+        p = df.argsort(key='userName', ascending=False)
+        self.assertTrue((p == ak.array([3, 4, 1, 5, 2, 0])).all())
+
+    def test_coargsort(self):
+        username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+        userid = ak.array([111, 222, 111, 333, 222, 111])
+        item = ak.array([0, 0, 1, 1, 2, 0])
+        day = ak.array([5, 5, 6, 5, 6, 6])
+        amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
+        df = ak.DataFrame({'userName': username, 'userID': userid,
+                           'item': item, 'day': day, 'amount': amount})
+
+        p = df.coargsort(keys=['userID', 'amount'])
+        self.assertTrue((p == ak.array([0, 5, 2, 1, 4, 3])).all())
+
+        p = df.coargsort(keys=['userID', 'amount'], ascending=False)
+        self.assertTrue((p == ak.array([3, 4, 1, 2, 5, 0])).all())
+
+    def test_sort_values(self):
+        username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+        userid = ak.array([111, 222, 111, 333, 222, 111])
+        item = ak.array([0, 0, 1, 1, 2, 0])
+        day = ak.array([5, 5, 6, 5, 6, 6])
+        amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
+
+        df = ak.DataFrame({'userID':userid})
+        ord = df.sort_values()
+        self.assertEqual(ord.__repr__(), ak.DataFrame({'userID': ak.array([111, 111, 111, 222, 222, 333])}).__repr__())
+        ord = df.sort_values(ascending=False)
+        self.assertEqual(ord.__repr__(), ak.DataFrame({'userID': ak.array([333, 222, 222, 111, 111, 111])}).__repr__())
+
+        df = ak.DataFrame({'userName': username, 'userID': userid,
+                           'item': item, 'day': day, 'amount': amount})
+        ord = df.sort_values(by='userID')
+        test_un = ak.array(['Alice', 'Alice', 'Alice', 'Bob', 'Bob', 'Carol'])
+        test_uid = ak.array([111, 111, 111, 222, 222, 333])
+        test_i = ak.array([0, 1, 0, 0, 2, 1])
+        test_d = ak.array([5, 6, 6, 5, 6, 5])
+        test_a = ak.array([0.5, 1.1, 0.6, 0.6, 4.3, 1.2])
+        test_df = ak.DataFrame({'userName': test_un, 'userID': test_uid,
+                                'item': test_i, 'day': test_d, 'amount': test_a})
+        self.assertEqual(ord.__repr__(), test_df.__repr__())
+
+        ord = df.sort_values(by=['userID', 'day'])
+        self.assertEqual(ord.__repr__(), test_df.__repr__())
+
+        with self.assertRaises(TypeError):
+            df.sort_values(by=1)
+
+    def test_apply_perm(self):
+        username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+        userid = ak.array([111, 222, 111, 333, 222, 111])
+        item = ak.array([0, 0, 1, 1, 2, 0])
+        day = ak.array([5, 5, 6, 5, 6, 6])
+        amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
+        df = ak.DataFrame({'userName': username, 'userID': userid,
+                           'item': item, 'day': day, 'amount': amount})
+
+        ord = df.sort_values(by='userID')
+        default_perm = ak.array([0, 3, 1, 5, 4, 2])
+        ord.apply_permutation(default_perm)
+        self.assertEqual(ord.__repr__(), df.__repr__())
+
+    def test_filter_by_range(self):
+        userid = ak.array([111, 222, 111, 333, 222, 111])
+        amount = ak.array([0, 1, 1, 2, 3, 15])
+        df = ak.DataFrame({'userID': userid, 'amount': amount})
+
+        filtered = df.filter_by_range(keys=['userID'], low=1, high=2)
+        self.assertFalse(filtered[0])
+        self.assertTrue(filtered[1])
+        self.assertFalse(filtered[2])
+        self.assertTrue(filtered[3])
+        self.assertTrue(filtered[4])
+        self.assertFalse(filtered[5])
+
+    def test_copy(self):
+        username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+        userid = ak.array([111, 222, 111, 333, 222, 111])
+        df = ak.DataFrame({'userName': username, 'userID': userid})
+
+        df_copy = df.copy(deep=True)
+        self.assertEqual(df.__repr__(), df_copy.__repr__())
+
+        df_copy.__setitem__('userID', ak.array([1, 2, 1, 3, 2, 1]))
+        self.assertNotEqual(df.__repr__(), df_copy.__repr__())
+
+        df_copy = df.copy(deep=False)
+        df_copy.__setitem__('userID', ak.array([1, 2, 1, 3, 2, 1]))
+        self.assertEqual(df.__repr__(), df_copy.__repr__())

--- a/tests/segarray_test.py
+++ b/tests/segarray_test.py
@@ -1,0 +1,323 @@
+import pandas
+
+from base_test import ArkoudaTest
+from context import arkouda as ak
+
+class SegArrayTest(ArkoudaTest):
+    def test_creation(self):
+        a = [10, 11, 12, 13, 14, 15]
+        b = [20, 21]
+        c = [30, 31, 32, 33]
+
+        flat = a + b + c
+        akflat = ak.array(flat)
+        segments = ak.array([0, len(a), len(a)+len(b)])
+        segarr = ak.SegArray(segments, akflat)
+
+        self.assertIsInstance(segarr, ak.SegArray)
+        self.assertTrue((segarr._get_lengths() == ak.array([6, 2, 4])).all())
+        self.assertEqual(segarr.__str__(), f'SegArray([\n{a}\n{b}\n{c}\n])'.replace(',', ''))
+        self.assertEqual(segarr.__getitem__(1).__str__(), str(b).replace(',', ''))
+        self.assertEqual(segarr.__getitem__(ak.array([1, 2])).__str__(),
+                         f'SegArray([\n{b}\n{c}\n])'.replace(',', ''))
+        self.assertEqual(segarr.__eq__(ak.array([1])), NotImplemented)
+        self.assertTrue(segarr.__eq__(segarr).all())
+
+        multi_pd = ak.SegArray.from_multi_array([ak.array([10, 20, 30]), ak.array([11, 21, 31]), ak.array([12, 22, 32])])
+        self.assertIsInstance(multi_pd, ak.SegArray)
+        self.assertEqual(multi_pd.__str__(), f'SegArray([\n[10 11 12]\n[20 21 22]\n[30 31 32]\n])')
+        with self.assertRaises(TypeError):
+            segarr.__getitem__('a')
+
+    def test_concat(self):
+        a = [10, 11, 12, 13, 14, 15]
+        b = [20, 21]
+        c = [30, 31, 32, 33]
+
+        flat = a + b
+        akflat = ak.array(flat)
+        segments = ak.array([0, len(a)])
+
+        segarr = ak.SegArray(segments, akflat)
+        segarr_2 = ak.SegArray(ak.array([0]), ak.array(c))
+
+        concated = ak.SegArray.concat([segarr, segarr_2])
+
+        self.assertEqual(concated.__str__(), f'SegArray([\n{a}\n{b}\n{c}\n])'.replace(',', ''))
+
+        with self.assertRaises(ValueError):
+            concated = ak.SegArray.concat([segarr, segarr_2], ordered=False)
+
+        with self.assertRaises(ValueError):
+            concated = ak.SegArray.concat([])
+
+        self.assertEqual(ak.SegArray.concat([ak.array([1, 2])]), NotImplemented)
+
+        with self.assertRaises(ValueError):
+            concated = ak.SegArray.concat([segarr, segarr_2], axis=1)
+
+        with self.assertRaises(ValueError):
+            concated = ak.SegArray.concat([segarr, segarr_2], axis=5)
+
+        multi_pd = ak.SegArray.from_multi_array([ak.array([10, 20, 30]), ak.array([11, 21, 31]), ak.array([12, 22, 32])])
+        multi_pd2 = ak.SegArray.from_multi_array([ak.array([13, 23, 33]), ak.array([14, 24, 34]), ak.array([15, 25, 35])])
+        concated = ak.SegArray.concat([multi_pd, multi_pd2], axis=1)
+
+        test = ak.SegArray.from_multi_array([ak.array([10, 20, 30]), ak.array([11, 21, 31]), ak.array([12, 22, 32]),
+                                             ak.array([13, 23, 33]), ak.array([14, 24, 34]), ak.array([15, 25, 35])
+                                             ])
+
+        self.assertEqual(concated.__str__(), test.__str__())
+
+    def test_suffixes(self):
+        a = [10, 11, 12, 13, 14, 15]
+        b = [20, 21]
+        c = [30, 31, 32, 33]
+
+        flat = a + b + c
+        akflat = ak.array(flat)
+        segments = ak.array([0, len(a), len(a)+len(b)])
+
+        segarr = ak.SegArray(segments, akflat)
+
+        suffix, origin = segarr.get_suffixes(1)
+        self.assertTrue(origin.all())
+        self.assertTrue((suffix[0] == ak.array([15, 21, 33])).all())
+
+        suffix, origin = segarr.get_suffixes(2)
+        self.assertTrue((suffix[0] == ak.array([14, 32])).all())
+        self.assertTrue((suffix[1] == ak.array([15, 33])).all())
+        self.assertTrue(origin[0])
+        self.assertFalse(origin[1])
+        self.assertTrue(origin[2])
+
+        suffix, origin = segarr.get_suffixes(2, proper=False)
+        self.assertTrue((suffix[0] == ak.array([14, 20, 32])).all())
+        self.assertTrue((suffix[1] == ak.array([15, 21, 33])).all())
+        self.assertTrue(origin.all())
+
+    def test_prefixes(self):
+        a = [10, 11, 12, 13, 14, 15]
+        b = [20, 21]
+        c = [30, 31, 32, 33]
+
+        flat = a + b + c
+        akflat = ak.array(flat)
+        segments = ak.array([0, len(a), len(a) + len(b)])
+
+        segarr = ak.SegArray(segments, akflat)
+        prefix, origin = segarr.get_prefixes(1)
+
+        self.assertTrue((prefix[0] == ak.array([10, 20, 30])).all())
+        self.assertTrue(origin.all())
+
+        prefix, origin = segarr.get_prefixes(2)
+        self.assertTrue((prefix[0] == ak.array([10, 30])).all())
+        self.assertTrue((prefix[1] == ak.array([11, 31])).all())
+        self.assertTrue(origin[0])
+        self.assertFalse(origin[1])
+        self.assertTrue(origin[2])
+
+        prefix, origin = segarr.get_prefixes(2, proper=False)
+        self.assertTrue((prefix[0] == ak.array([10, 20, 30])).all())
+        self.assertTrue((prefix[1] == ak.array([11, 21, 31])).all())
+        self.assertTrue(origin.all())
+
+    def test_ngram(self):
+        a = [10, 11, 12, 13, 14, 15]
+        b = [20, 21]
+        c = [30, 31, 32, 33]
+
+        flat = a + b + c
+        akflat = ak.array(flat)
+        segments = ak.array([0, len(a), len(a) + len(b)])
+
+        segarr = ak.SegArray(segments, akflat)
+        ngram, origin = segarr.get_ngrams(2)
+        self.assertTrue((ngram[0] == ak.array([10, 11, 12, 13, 14, 20, 30, 31, 32])).all())
+        self.assertTrue((ngram[1] == ak.array([11, 12, 13, 14, 15, 21, 31, 32, 33])).all())
+        self.assertTrue((origin == ak.array([0, 0, 0, 0, 0, 1, 2, 2, 2])).all())
+
+        ngram, origin = segarr.get_ngrams(5)
+        self.assertTrue((ngram[0] == ak.array([10, 11])).all())
+        self.assertTrue((ngram[1] == ak.array([11, 12])).all())
+        self.assertTrue((ngram[2] == ak.array([12, 13])).all())
+        self.assertTrue((ngram[3] == ak.array([13, 14])).all())
+        self.assertTrue((ngram[4] == ak.array([14, 15])).all())
+        self.assertTrue((origin == ak.array([0, 0])).all())
+
+        with self.assertRaises(ValueError):
+            ngram, origin = segarr.get_ngrams(7)
+
+    def test_get_jth(self):
+        a = [10, 11, 12, 13, 14, 15]
+        b = [20, 21]
+        c = [30, 31, 32, 33]
+
+        flat = a + b + c
+        akflat = ak.array(flat)
+        segments = ak.array([0, len(a), len(a) + len(b)])
+
+        segarr = ak.SegArray(segments, akflat)
+
+        res, origins = segarr.get_jth(1)
+        self.assertTrue((res == ak.array([11, 21, 31])).all())
+        res, origins = segarr.get_jth(5)
+        self.assertTrue((res == ak.array([15, 0, 0])).all())
+        res, origins = segarr.get_jth(5, compressed=True)
+        self.assertTrue((res == ak.array([15])).all())
+        print(res)
+
+    def test_set_jth(self):
+        a = [10, 11, 12, 13, 14, 15]
+        b = [20, 21]
+        c = [30, 31, 32, 33]
+
+        flat = a + b + c
+        akflat = ak.array(flat)
+        segments = ak.array([0, len(a), len(a) + len(b)])
+
+        segarr = ak.SegArray(segments, akflat)
+
+        segarr.set_jth(0, 1, 99)
+        self.assertEqual(segarr[0].__str__(), f'{a}'.replace(',', '').replace('11', '99'))
+
+        segarr.set_jth(ak.array([0, 1, 2]), 0, 99)
+        self.assertEqual(segarr[0].__str__(), f'{a}'.replace(',', '').replace('10', '99').replace('11', '99'))
+        self.assertEqual(segarr[1].__str__(), f'{b}'.replace(',', '').replace('20', '99'))
+        self.assertEqual(segarr[2].__str__(), f'{c}'.replace(',', '').replace('30', '99'))
+
+        with self.assertRaises(ValueError):
+            segarr.set_jth(1, 4, 999)
+
+        s = ak.array(['abc', '123'])
+        s_segments = ak.array([0])
+        segarr = ak.SegArray(s_segments, s)
+
+        with self.assertRaises(TypeError):
+            segarr.set_jth(0, 0, 'test')
+
+    def test_get_length_n(self):
+        a = [10, 11, 12, 13, 14, 15]
+        b = [20, 21]
+        c = [30, 31, 32, 33]
+
+        flat = a + b + c
+        akflat = ak.array(flat)
+        segments = ak.array([0, len(a), len(a) + len(b)])
+
+        segarr = ak.SegArray(segments, akflat)
+
+        elem, origin = segarr.get_length_n(2)
+        self.assertTrue((elem[0] == ak.array([20])).all())
+        self.assertTrue((elem[1] == ak.array([21])).all())
+
+    def test_append(self):
+        a = [10, 11, 12, 13, 14, 15]
+        b = [20, 21]
+        c = [30, 31, 32, 33]
+
+        flat = a + b + c
+        akflat = ak.array(flat)
+        segments = ak.array([0, len(a), len(a) + len(b)])
+
+        segarr = ak.SegArray(segments, akflat)
+
+        self.assertEqual(segarr.append(ak.array([1, 2, 3])), NotImplemented)
+
+        a2 = [0.5, 5.1, 2.3]
+        b2 = [1.1, 0.7]
+        flat2 = ak.array(a2 + b2)
+        segments2 = ak.array([0, len(a2)])
+        float_segarr = ak.SegArray(segments2, flat2)
+
+        with self.assertRaises(TypeError):
+            segarr.append(float_segarr)
+
+        a2 = [1, 2, 3, 4]
+        b2 = [22, 23]
+        flat2 = ak.array(a2 + b2)
+        segments2 = ak.array([0, len(a2)])
+        segarr2 = ak.SegArray(segments2, flat2)
+
+        appended = segarr.append(segarr2)
+        self.assertEqual(appended.segments.size, 5)
+        self.assertListEqual(appended[3].tolist(), [1, 2, 3, 4])
+        self.assertListEqual(appended[4].tolist(), [22, 23])
+
+        a2 = [1, 2]
+        b2 = [3]
+        segments2 = ak.array([0, len(a2)])
+        segarr2 = ak.SegArray(segments2, ak.array(a2 + b2))
+
+        with self.assertRaises(ValueError):
+            appended = segarr.append(segarr2, axis=1)
+
+        a = [1, 2]
+        b = [3, 4]
+        flat = a + b
+        akflat = ak.array(flat)
+        segments = ak.array([0, len(a)])
+        segarr = ak.SegArray(segments, akflat)
+        a2 = [10]
+        b2 = [20]
+        flat2 = ak.array(a2 + b2)
+        segments2 = ak.array([0, 1])
+        segarr2 = ak.SegArray(segments2, flat2)
+        appended = segarr.append(segarr2, axis=1)
+
+        self.assertListEqual(appended.lengths.to_ndarray().tolist(), [3, 3])
+        self.assertListEqual(appended[0].tolist(), [1, 2, 10])
+        self.assertListEqual(appended[1].tolist(), [3, 4, 20])
+
+    def test_single_append(self):
+        a = [10, 11, 12, 13, 14, 15]
+        b = [20, 21]
+        c = [30, 31, 32, 33]
+
+        flat = a + b + c
+        akflat = ak.array(flat)
+        segments = ak.array([0, len(a), len(a) + len(b)])
+
+        segarr = ak.SegArray(segments, akflat)
+        to_append = ak.array([99, 98, 97])
+
+        appended = segarr.append_single(to_append)
+        self.assertListEqual(appended.lengths.to_ndarray().tolist(), [7, 3, 5])
+        self.assertListEqual(appended[0].tolist(), a + [99])
+        self.assertListEqual(appended[1].tolist(), b + [98])
+        self.assertListEqual(appended[2].tolist(), c + [97])
+
+        to_append = ak.array([99, 99])
+        with self.assertRaises(ValueError):
+            appended = segarr.append_single(to_append)
+
+        to_append = ak.array([99.99, 1.1, 2.2])
+        with self.assertRaises(TypeError):
+            appended = segarr.append_single(to_append)
+
+        to_append = 99
+        appended = segarr.append_single(to_append)
+        self.assertListEqual(appended.lengths.to_ndarray().tolist(), [7, 3, 5])
+        self.assertListEqual(appended[0].tolist(), a + [99])
+        self.assertListEqual(appended[1].tolist(), b + [99])
+        self.assertListEqual(appended[2].tolist(), c + [99])
+
+        appended = segarr.prepend_single(to_append)
+        self.assertListEqual(appended.lengths.to_ndarray().tolist(), [7, 3, 5])
+        self.assertListEqual(appended[0].tolist(), [99] + a)
+        self.assertListEqual(appended[1].tolist(), [99] + b)
+        self.assertListEqual(appended[2].tolist(), [99] + c)
+
+    def test_remove_repeats(self):
+        a = [1, 1, 1, 2, 3]
+        b = [10, 11, 11, 12]
+
+        flat = ak.array(a + b)
+        segments = ak.array([0, len(a)])
+
+        segarr = ak.SegArray(segments, flat)
+        dedup = segarr.remove_repeats()
+        self.assertListEqual(dedup.lengths.to_ndarray().tolist(), [3, 3])
+        self.assertListEqual(dedup[0].tolist(), list(set(a)))
+        self.assertListEqual(dedup[1].tolist(), list(set(b)))


### PR DESCRIPTION
This PR (closes #1118 ):

This is the initial move of `akutil/segarry.py` to `arkouda/segarray` and `akutil/dataframe.py` to `arkouda/dataframe.py`.

Some functionality has not yet been implemented in `arkouda/dataframe.py` because it relies on files that not been moved to arkouda yet:

- `akutil/dataframe.py` supported 2 types of GroupBy functionality. One is `arkouda.GroupBy` which has been implemented. The other relies on `akutil/series.py`, which will be implemented once `akutil/series.py` is moved to arkouda. 
- `intx` functionality has not been implemented. This is waiting on `akutil/alignment.py`to be moved over to arkouda
- `append` and `concat` cannot be implemented until `akutil/util.py` is moved to arkouda.

Where functionality is missing, errors and comments have been added for easy recognition.

Testing for `SegArray` objects and `DataFrame` Objects have been added to `tests`. Test files have been added to pytest.ini.

Documentation added for `SegArray` and `DataFrame`. I am not the greatest at conveying my thoughts in documentation, so I would appreciate notes here.

I have made some small modification to docstrings and comments for understanding. Most code has been moved from `akutil` only. No functionality has been altered or reviewed in depth. This PR does not include moving `SegArray` to server-side, that will be handled in a separate issue. I was planning to review everything in akutil when the move is complete.

In some places, SegArray (namely get_ngrams - ln 382 in segarray.py) if a value is supplied for n that is greater than the max length, n empty arrays are returned inside one containing array. I added a check here to raise an error. I think this makes the most sense, but wanted to verify using this as an example. If everyone agrees/or has a better way to handle this, I will add it to the `get_length_n` function as well.

