### PR TITLE
Initial Multi-dim ArrayView

### DIFF
--- a/arkouda/__init__.py
+++ b/arkouda/__init__.py
@@ -2,6 +2,7 @@ from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
 
+from arkouda.array_view import *
 from arkouda.client import *
 from arkouda.client_dtypes import *
 from arkouda.dtypes import *

--- a/arkouda/alignment.py
+++ b/arkouda/alignment.py
@@ -1,4 +1,4 @@
-import numpy as np
+import numpy as np  # type: ignore
 
 from arkouda.strings import Strings
 from arkouda.pdarrayclass import pdarray, is_sorted

--- a/arkouda/array_view.py
+++ b/arkouda/array_view.py
@@ -1,0 +1,224 @@
+from arkouda.pdarrayclass import pdarray, parse_single_value, create_pdarray
+from arkouda.pdarraycreation import array, arange
+from arkouda.numeric import cumprod
+import numpy as np  # type: ignore
+from arkouda.client import generic_msg
+from arkouda.dtypes import translate_np_dtype, resolve_scalar_dtype
+from enum import Enum
+import json
+
+OrderType = Enum('OrderType', ['ROW_MAJOR', 'COLUMN_MAJOR'])
+
+
+class ArrayView:
+    def __init__(self, base: pdarray, shape, order='row_major'):
+        self.objtype = type(self).__name__
+        self.shape = array(shape)
+        if not isinstance(self.shape, pdarray):
+            raise TypeError(f"Shape cannot be type {type(self.shape)}")
+        if base.size != self.shape.prod():
+            raise ValueError(f"cannot reshape array of size {base.size} into shape {self.shape}")
+        self.base = base
+        self.size = base.size
+        self.ndim = self.shape.size
+        if order.upper() in {'C', 'ROW_MAJOR'}:
+            self.order = OrderType.ROW_MAJOR
+        elif order.upper() in {'F', 'COLUMN_MAJOR'}:
+            self.order = OrderType.COLUMN_MAJOR
+        else:
+            raise ValueError(f"cannot traverse with order={order}")
+        # cache _reverse_shape which is reversed if we're row_major
+        self._reverse_shape = self.shape if self.order is OrderType.COLUMN_MAJOR else self.shape[::-1]
+        if self.shape.min() == 0:
+            # avoid divide by 0 if any of the dimensions are 0
+            self._dim_prod = array([0] * self.shape.size)
+        else:
+            # cache dim_prod to avoid recalculation, reverse if row_major
+            self._dim_prod = cumprod(self.shape)//self.shape if self.order is OrderType.COLUMN_MAJOR else cumprod(self._reverse_shape)//self._reverse_shape
+
+    def __len__(self):
+        return self.size
+
+    def __repr__(self):
+        from arkouda.client import pdarrayIterThresh
+        if self.size <= pdarrayIterThresh:
+            return self.to_ndarray().__repr__()
+        else:
+            vals = [f"'{self.base[i]}'" for i in range(3)]
+            vals.append('... ')
+            vals.extend([f"'{self.base[i]}'" for i in range(self.size-3, self.size)])
+        return f"array([{', '.join(vals)}]), shape {self.shape}"
+
+    def __str__(self):
+        from arkouda.client import pdarrayIterThresh
+        if self.size <= pdarrayIterThresh:
+            return self.to_ndarray().__str__()
+        else:
+            vals = [f"'{self.base[i]}'" for i in range(3)]
+            vals.append('... ')
+            vals.extend([f"'{self.base[i]}'" for i in range(self.size-3, self.size)])
+        return f"[{', '.join(vals)}], shape {self.shape}"
+
+    def __getitem__(self, key):
+        if isinstance(key, int) or isinstance(key, slice):
+            key = [key]
+        elif isinstance(key, tuple):
+            key = list(key)
+        if len(key) > self.ndim:
+            raise IndexError(f"too many indices for array: array is {self.ndim}-dimensional, but {len(key)} were indexed")
+        if len(key) < self.ndim:
+            # append self.ndim-len(key) many ':'s to fill in the missing dimensions
+            for i in range(self.ndim - len(key)):
+                key.append(slice(None, None, None))
+        try:
+            # attempt to convert to a pdarray (allows for view[0,2,1] instead of view[ak.array([0,2,1])]
+            # but pass on RuntimeError to allow things like view[0,:,[True,False,True]] to be correctly handled
+            key = array(key)
+        except:  # bare except is bad practice but we want to pass on any errors/warnings
+            pass
+        if isinstance(key, pdarray):
+            kind, _ = translate_np_dtype(key.dtype)
+            if kind != "int":
+                raise TypeError(f"unsupported pdarray index type {key.dtype}")
+            # Interpret negative key as offset from end of array
+            key = array([key[i] + self.shape[i] if key[i] < 0 else key[i] for i in range(key.size)])
+            # Capture the indices which are still out of bounds
+            out_of_bounds = (key < 0) | (self.shape <= key)
+            if out_of_bounds.any():
+                out = arange(key.size)[out_of_bounds][0]
+                raise IndexError(f"index {key[out]} is out of bounds for axis {out} with size {self.shape[out]}")
+            coords = key if self.order is OrderType.COLUMN_MAJOR else key[::-1]
+            repMsg = generic_msg(cmd="arrayViewIntIndex", args="{} {} {}".format(self.base.name, self._dim_prod.name, coords.name))
+            fields = repMsg.split()
+            return parse_single_value(' '.join(fields[1:]))
+        else:
+            indices = []
+            reshape_dim_list = []
+            index_dim_list = []
+            key = key if self.order is OrderType.COLUMN_MAJOR else key[::-1]
+            for i in range(len(key)):
+                x = key[i]
+                if np.isscalar(x) and resolve_scalar_dtype(x) == 'int64':
+                    orig_key = x
+                    if x < 0:
+                        # Interpret negative key as offset from end of array
+                        x += self._reverse_shape[i]
+                    if 0 <= x < self._reverse_shape[i]:
+                        indices.append('int')
+                        # have to cast to int because JSON doesn't recognize numpy dtypes
+                        indices.append(json.dumps(int(x)))
+                        index_dim_list.append(1)
+                    else:
+                        raise IndexError(f"index {orig_key} is out of bounds for axis {i} with size {self._reverse_shape[i]}")
+                elif isinstance(x, slice):
+                    (start, stop, stride) = x.indices(self._reverse_shape[i])
+                    indices.append('slice')
+                    indices.append(json.dumps((start, stop, stride)))
+                    slice_size = len(range(*(start, stop, stride)))
+                    index_dim_list.append(slice_size)
+                    reshape_dim_list.append(slice_size)
+                elif isinstance(x, pdarray) or isinstance(x, list):
+                    raise TypeError(f"Advanced indexing is not yet supported {x} ({type(x)})")
+                    # x = array(x)
+                    # kind, _ = translate_np_dtype(x.dtype)
+                    # if kind not in ("bool", "int"):
+                    #     raise TypeError("unsupported pdarray index type {}".format(x.dtype))
+                    # if kind == "bool" and dim != x.size:
+                    #     raise ValueError("size mismatch {} {}".format(dim, x.size))
+                    # indices.append('pdarray')
+                    # indices.append(x.name)
+                    # index_dim_list.append(x.size)
+                    # reshape_dim_list.append(x.size)
+                    # arrays.append(x)
+                else:
+                    raise TypeError(f"Unhandled key type: {x} ({type(x)})")
+            index_dim = array(index_dim_list)
+            repMsg = generic_msg(cmd="arrayViewMixedIndex", args="{} {} {} {} {}".format(self.base.name,
+                                                                                         index_dim.name,
+                                                                                         self.ndim,
+                                                                                         self._dim_prod.name,
+                                                                                         json.dumps(indices)))
+            reshape_dim = reshape_dim_list if self.order is OrderType.COLUMN_MAJOR else reshape_dim_list[::-1]
+            return create_pdarray(repMsg).reshape(reshape_dim, order=self.order.name)
+
+    def __setitem__(self, key, value):
+        if isinstance(key, int) or isinstance(key, slice):
+            key = [key]
+        elif isinstance(key, tuple):
+            key = list(key)
+        if len(key) > self.ndim:
+            raise IndexError(f"too many indices for array: array is {self.ndim}-dimensional, but {len(key)} were indexed")
+        if len(key) < self.ndim:
+            # append self.ndim-len(key) many ':'s to fill in the missing dimensions
+            for i in range(self.ndim - len(key)):
+                key.append(slice(None, None, None))
+        try:
+            # attempt to convert to a pdarray (allows for view[0,2,1] instead of view[ak.array([0,2,1])]
+            # but pass on RuntimeError to allow things like view[0,:,[True,False,True]] to be correctly handled
+            key = array(key)
+        except:  # bare except is bad practice but we want to pass on any errors/warnings
+            pass
+        if isinstance(key, pdarray):
+            kind, _ = translate_np_dtype(key.dtype)
+            if kind != "int":
+                raise TypeError(f"unsupported pdarray index type {key.dtype}")
+            # Interpret negative key as offset from end of array
+            key = array([key[i] + self.shape[i] if key[i] < 0 else key[i] for i in range(key.size)])
+            # Capture the indices which are still out of bounds
+            out_of_bounds = (key < 0) | (self.shape <= key)
+            if out_of_bounds.any():
+                out = arange(key.size)[out_of_bounds][0]
+                raise IndexError(f"index {key[out]} is out of bounds for axis {out} with size {self.shape[out]}")
+            coords = key if self.order is OrderType.COLUMN_MAJOR else key[::-1]
+            generic_msg(cmd="arrayViewIntIndexAssign", args="{} {} {} {} {}".format(self.base.name,
+                                                                                    self.base.dtype.name,
+                                                                                    self._dim_prod.name,
+                                                                                    coords.name,
+                                                                                    self.base.format_other(value)))
+        else:
+            raise TypeError(f"Setting via slicing and advanced indexing is not yet supported")
+
+    def to_ndarray(self) -> np.ndarray:
+        """
+        Convert the ArrayView to a np.ndarray, transferring array data from the
+        Arkouda server to client-side Python. Note: if the ArrayView size exceeds
+        client.maxTransferBytes, a RuntimeError is raised.
+
+        Returns
+        -------
+        np.ndarray
+            A numpy ndarray with the same attributes and data as the ArrayView
+
+        Raises
+        ------
+        RuntimeError
+            Raised if there is a server-side error thrown, if the ArrayView size
+            exceeds the built-in client.maxTransferBytes size limit, or if the bytes
+            received does not match expected number of bytes
+        Notes
+        -----
+        The number of bytes in the array cannot exceed ``client.maxTransferBytes``,
+        otherwise a ``RuntimeError`` will be raised. This is to protect the user
+        from overflowing the memory of the system on which the Python client
+        is running, under the assumption that the server is running on a
+        distributed system with much more memory than the client. The user
+        may override this limit by setting client.maxTransferBytes to a larger
+        value, but proceed with caution.
+
+        See Also
+        --------
+        array
+
+        Examples
+        --------
+        >>> a = ak.arange(0, 6, 1).reshape(2,3)
+        >>> a.to_ndarray()
+        array([[0, 1, 2],
+               [3, 4, 5]])
+        >>> type(a.to_ndarray())
+        numpy.ndarray
+        """
+        if self.order is OrderType.ROW_MAJOR:
+            return self.base.to_ndarray().reshape(self.shape.to_ndarray())
+        else:
+            return self.base.to_ndarray().reshape(self.shape.to_ndarray(), order='F')

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -884,7 +884,7 @@ class pdarray:
 
         Parameters
         ----------
-        shape : int or tuple of ints
+        shape : int, tuple of ints, or pdarray
             The new shape should be compatible with the original shape.
         order : str {'row_major' | 'C' | 'column_major' | 'F'}
             Read the elements of the pdarray in this index order
@@ -901,7 +901,7 @@ class pdarray:
         # For example, a.reshape(10, 11) is equivalent to a.reshape((10, 11))
         if len(shape) == 1:
             shape = shape[0]
-        else:
+        elif not isinstance(shape, pdarray):
             shape = [i for i in shape]
         return ArrayView(base=self, shape=shape, order=order)
 

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import cast, List, Sequence
+from typing import cast, List, Sequence, Tuple
 from typeguard import typechecked
 import json
 import numpy as np # type: ignore
@@ -481,7 +481,7 @@ class pdarray:
             (start,stop,stride) = key.indices(self.size)
             logger.debug('start: {} stop: {} stride: {}'.format(start,stop,stride))
             repMsg = generic_msg(cmd="[slice]", args="{} {} {} {}".format(self.name, start, stop, stride))
-            return create_pdarray(repMsg);
+            return create_pdarray(repMsg)
         if isinstance(key, pdarray):
             kind, _ = translate_np_dtype(key.dtype)
             if kind not in ("bool", "int", "uint"):
@@ -877,7 +877,34 @@ class pdarray:
         from arkouda.numeric import cast as akcast
 
         return akcast(self, dtype)
-    
+
+    def reshape(self, *shape, order='row_major'):
+        """
+        Gives a new shape to an array without changing its data.
+
+        Parameters
+        ----------
+        shape : int or tuple of ints
+            The new shape should be compatible with the original shape.
+        order : str {'row_major' | 'C' | 'column_major' | 'F'}
+            Read the elements of the pdarray in this index order
+            By default, read the elements in row_major or C-like order where the last index changes the fastest
+            If 'column_major' or 'F', read the elements in column_major or Fortran-like order where the first index changes the fastest
+
+        Returns
+        -------
+        ArrayView
+            An arrayview object with the data from the array but with the new shape
+        """
+        from arkouda.array_view import ArrayView
+        # allows the elements of the shape parameter to be passed in as separate arguments
+        # For example, a.reshape(10, 11) is equivalent to a.reshape((10, 11))
+        if len(shape) == 1:
+            shape = shape[0]
+        else:
+            shape = [i for i in shape]
+        return ArrayView(base=self, shape=shape, order=order)
+
     def to_ndarray(self) -> np.ndarray:
         """
         Convert the array to a np.ndarray, transferring array data from the

--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -106,8 +106,6 @@ def from_series(series : pd.Series,
                       'float64, int64, string, datetime64[ns], and timedelta64[ns]').format(dt))
     return array(n_array)
 
-
-@typechecked
 def array(a: Union[pdarray, np.ndarray, Iterable], dtype: Union[np.dtype, type, str] = None) -> Union[pdarray, Strings]:
     """
     Convert a Python or Numpy Iterable to a pdarray or Strings object, sending 
@@ -168,6 +166,7 @@ def array(a: Union[pdarray, np.ndarray, Iterable], dtype: Union[np.dtype, type, 
     >>> type(strings)
     <class 'arkouda.strings.Strings'>  
     """
+    # Removed @typechecked to prevent cyclic dependencies with ArrayView
     from arkouda.numeric import cast as akcast
     # If a is already a pdarray, do nothing
     if isinstance(a, pdarray):
@@ -184,7 +183,7 @@ def array(a: Union[pdarray, np.ndarray, Iterable], dtype: Union[np.dtype, type, 
     if a.ndim != 1:
         # TODO add order
         if a.dtype.name in NumericDTypes:
-            flat_a = array(a.flatten())
+            flat_a = array(a.flatten(), dtype=dtype)
             if isinstance(flat_a, pdarray):
                 # break into parts so mypy doesn't think we're calling reshape on a Strings
                 return flat_a.reshape(a.shape)

--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -180,9 +180,16 @@ def array(a: Union[pdarray, np.ndarray, Iterable], dtype: Union[np.dtype, type, 
         except:
             raise TypeError(('a must be a pdarray, np.ndarray, or convertible to' +
                             ' a numpy array'))
-    # Only rank 1 arrays currently supported
+    # Return multi-dimensional arrayview
     if a.ndim != 1:
-        raise RuntimeError("Only rank-1 pdarrays or ndarrays supported")
+        # TODO add order
+        if a.dtype.name in NumericDTypes:
+            flat_a = array(a.flatten())
+            if isinstance(flat_a, pdarray):
+                # break into parts so mypy doesn't think we're calling reshape on a Strings
+                return flat_a.reshape(a.shape)
+        else:
+            raise TypeError('Must be an iterable or have a numeric DType')
     # Check if array of strings
     if 'U' in a.dtype.kind:
         # encode each string and add a null byte terminator

--- a/pydoc/usage.rst
+++ b/pydoc/usage.rst
@@ -18,3 +18,5 @@ Usage
    usage/groupby
    usage/strings
    usage/categorical
+   usage/segarray
+   usage/arrayview

--- a/pydoc/usage/arrayview.rst
+++ b/pydoc/usage/arrayview.rst
@@ -1,0 +1,72 @@
+*********************
+ArrayView in Arkouda
+*********************
+
+.. autoclass:: arkouda.ArrayView
+
+Creation
+========
+ArrayViews can be created using ak.array or pdarray.reshape
+
+.. code-block:: python
+
+    >>> ak.array([[0, 0], [0, 1], [1, 1]])
+    array([[0, 0],
+           [0, 1],
+           [1, 1]])
+
+    >>> ak.arange(30).reshape(5, 2, 3)
+    array([[[ 0,  1,  2],
+            [ 3,  4,  5]],
+
+           [[ 6,  7,  8],
+            [ 9, 10, 11]],
+
+           [[12, 13, 14],
+            [15, 16, 17]],
+
+           [[18, 19, 20],
+            [21, 22, 23]],
+
+           [[24, 25, 26],
+            [27, 28, 29]]])
+
+Indexing
+========
+Arkouda ``ArrayView`` objects support basic indexing
+
+* Indexing with an integer ``pdarray`` (of size ndim) or
+* Indexing with a mix of integers and slices
+
+Mixed indexing by arrays or "advanced indexing" as numpy calls it is not yet supported. numpy behavior with 2+ arrays is different than equivalent slices.
+
+This example shows how indexing by arrays can be a bit different. This is talked about a bit in https://numpy.org/doc/stable/user/basics.indexing.html
+
+.. code-block:: python
+
+   >>> n = np.arange(4).reshape(2,2)
+   # sometimes they line up
+   >>> n[:,:]
+   array([[0, 1],
+          [2, 3]])
+
+   >>> n[:,[0,1]]
+   array([[0, 1],
+          [2, 3]])
+
+   >>> n[[0,1],:]
+   array([[0, 1],
+          [2, 3]])
+   # sometimes they do not
+   >>> n[[0,1],[0,1]]
+   array([0, 3])
+
+With 2+ arrays the functionality switches from the Cartesian product of coordinates to more coordinate-wise.
+
+so ``n[:, :]`` gets indices ``[0,0], [0,1], [1,0], [1,1]`` whereas ``n[[0,1],[0,1]]`` only gets indices ``[0,0], [1,1]``
+
+Iteration
+===========
+Iterating directly over an ``ArrayView`` with ``for x in array_view`` is not supported to discourage transferring all array data from the arkouda server to the Python client. To force this transfer, use the ``to_ndarray`` function to return the ``ArrayView`` as a ``numpy.ndarray``. This transfer will raise an error if it exceeds the byte limit defined in ``arkouda.maxTransferBytes``.
+
+.. autofunction:: arkouda.ArrayView.to_ndarray

--- a/pydoc/usage/pdarray.rst
+++ b/pydoc/usage/pdarray.rst
@@ -57,3 +57,10 @@ Conversion between dtypes is sometimes implicit, as in the following example:
 Explicit conversion is supported via the ``cast`` function.
 
 .. autofunction:: arkouda.cast
+
+Reshape
+=======
+
+Using the ``.reshape`` method, a multi-dimension view of a pdarray will be returned as an ``ArrayView``
+
+.. autofunction:: arkodua.pdarray.reshape

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,7 @@
 filterwarnings =
     ignore:Version mismatch between client .*
 testpaths =
+    tests/array_view_test.py
     tests/bitops_test.py
     tests/categorical_test.py
     tests/check.py

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -52,7 +52,7 @@ module IndexingMsg
         overMemLimit(numBytes(int) * dims.size);
         var offsets = (+ scan dims) - dims;
 
-        for i in 0..#typeCoords.size by 2 {
+        forall i in 0..#typeCoords.size by 2 {
             select typeCoords[i] {
                 when "int" {
                     scaledCoords[offsets[i/2]] = typeCoords[i+1]:int * dimProdEntry.a[i/2];

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -13,8 +13,135 @@ module IndexingMsg
 
     use CommAggregation;
 
+    use FileIO;
+    use List;
+
     private config const logLevel = ServerConfig.logLevel;
     const imLogger = new Logger(logLevel);
+
+    proc jsonToTuple(json: string, type t) throws {
+        var f = opentmp(); defer { ensureClose(f); }
+        var w = f.writer();
+        w.write(json);
+        w.close();
+        var r = f.reader(start=0);
+        var tup: t;
+        r.readf("%jt", tup);
+        r.close();
+        return tup;
+    }
+
+    proc arrayViewMixedIndexMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+        var (pdaName, indexDimName, ndimStr, dimProdName, coords) = payload.splitMsgToTuple(5);
+        var ndim = try! ndimStr:int;
+        imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                                    "%s %s %i %s %s".format(cmd, pdaName, ndim, dimProdName, coords));
+
+        var dimProd: borrowed GenSymEntry = getGenericTypedArrayEntry(dimProdName, st);
+        var dimProdEntry = toSymEntry(dimProd, int);
+
+        var indexDim: borrowed GenSymEntry = getGenericTypedArrayEntry(indexDimName, st);
+        var indexDimEntry = toSymEntry(indexDim, int);
+        ref dims = indexDimEntry.a;
+
+        // String array containing the type of the following value at even indicies then the value ex. ["int", "7", "slice", "(0,5,-1)", "pdarray", "id_4"]
+        var typeCoords: [0..#(ndim*2)] string = jsonToPdArray(coords, ndim*2);
+
+        var scaledCoords: [makeDistDom(+ reduce dims)] int;
+        // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+        overMemLimit(numBytes(int) * dims.size);
+        var offsets = (+ scan dims) - dims;
+
+        for i in 0..#typeCoords.size by 2 {
+            select typeCoords[i] {
+                when "int" {
+                    scaledCoords[offsets[i/2]] = typeCoords[i+1]:int * dimProdEntry.a[i/2];
+                }
+                when "slice" {
+                    var (start, stop, stride) = jsonToTuple(typeCoords[i+1], 3*int);
+                    var slice: range(stridable=true) = convertSlice(start, stop, stride);
+                    var scaled: [0..#slice.size] int = slice * dimProdEntry.a[i/2];
+                    for j in 0..#slice.size {
+                        scaledCoords[offsets[i/2]+j] = scaled[j];
+                    }
+                }
+                // Advanced indexing not yet supported
+                // when "pdarray" {
+                //     // TODO if bool array convert to int array by doing arange(len)[bool_array]
+                //     var arrName: string = typeCoords[i+1];
+                //     var indArr: borrowed GenSymEntry = getGenericTypedArrayEntry(arrName, st);
+                //     var indArrEntry = toSymEntry(indArr, int);
+                //     var scaledArray = indArrEntry.a * dimProdEntry.a[i/2];
+                //     // var localizedArray = new lowLevelLocalizingSlice(scaledArray, offsets[i/2]..#indArrEntry.a.size);
+                //     forall (j, s) in zip(indArrEntry.aD, scaledArray) with (var DstAgg = newDstAggregator(int)) {
+                //         DstAgg.copy(scaledCoords[offsets[i/2]+j], s);
+                //     }
+                // }
+            }
+        }
+
+        // create full index list
+        // get next symbol name
+        var indiciesName = st.nextName();
+        var indicies = st.addEntry(indiciesName, * reduce dims, int);
+
+        imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "rname = %s".format(indiciesName));
+
+        // avoid dividing by 0
+        // if any dim is 0 we return an empty list
+        if & reduce (dims!=0) {
+            // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+            overMemLimit(numBytes(int) * dims.size);
+            var dim_prod = (* scan(dims)) / dims;
+
+            recursiveIndexCalc(0,0,0);
+            proc recursiveIndexCalc(depth: int, ind:int, sum:int) throws {
+                for j in 0..#dims[depth] {
+                    imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "depth = %i".format(depth));
+                    imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "j = %i".format(j));
+                    imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "SUM: sum + scaledCoords[offsets[depth]+j] = %i".format(sum + scaledCoords[offsets[depth]+j]));
+                    imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "IND: ind + j*dim_prod[depth] = %i".format(ind+(j*dim_prod[depth])));
+
+                    if depth == ndim-1 then indicies.a[ind+(j*dim_prod[depth])] = sum+scaledCoords[offsets[depth]+j];
+                    else recursiveIndexCalc(depth+1, ind+(j*dim_prod[depth]), sum+scaledCoords[offsets[depth]+j]);
+                }
+            }
+        }
+
+        return pdarrayIndexMsg(cmd, "%s %s".format(pdaName, indiciesName), st);
+    }
+
+    /* arrayViewIntIndexMsg "av[int_list]" response to __getitem__(int_list) where av is an ArrayView */
+    proc arrayViewIntIndexMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+        var (pdaName, dimProdName, coordsName) = payload.splitMsgToTuple(3);
+        imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "%s %s %s %s".format(cmd, pdaName, dimProdName, coordsName));
+
+        var dimProd: borrowed GenSymEntry = getGenericTypedArrayEntry(dimProdName, st);
+        var dimProdEntry = toSymEntry(dimProd, int);
+        var coords: borrowed GenSymEntry = getGenericTypedArrayEntry(coordsName, st);
+        var coordsEntry = toSymEntry(coords, int);
+
+        // multi-dim to 1D address calculation
+        // (dimProd and coords are reversed on python side to account for row_major vs column_major)
+        var idx: int = + reduce (dimProdEntry.a * coordsEntry.a);
+        return intIndexMsg(cmd, "%s %i".format(pdaName, idx), st);
+    }
+
+    /* arrayViewIntIndexAssignMsg "av[int_list]=value" response to __getitem__(int_list) where av is an ArrayView */
+    proc arrayViewIntIndexAssignMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+        var (pdaName, dtypeStr, dimProdName, coordsName, value) = payload.splitMsgToTuple(5);
+        imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "%s %s %s %s".format(cmd, pdaName, dimProdName, coordsName));
+
+        var dimProd: borrowed GenSymEntry = getGenericTypedArrayEntry(dimProdName, st);
+        var dimProdEntry = toSymEntry(dimProd, int);
+        var coords: borrowed GenSymEntry = getGenericTypedArrayEntry(coordsName, st);
+        var coordsEntry = toSymEntry(coords, int);
+
+        // multi-dim to 1D address calculation
+        // (dimProd and coords are reversed on python side to account for row_major vs column_major)
+        var idx: int = + reduce (dimProdEntry.a * coordsEntry.a);
+        return setIntIndexToValueMsg(cmd, "%s %i %s %s".format(pdaName, idx, dtypeStr, value), st);
+    }
 
     /* intIndex "a[int]" response to __getitem__(int) */
     proc intIndexMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
@@ -66,6 +193,18 @@ module IndexingMsg
          }
     }
 
+    /* convert python slice to chapel slice */
+    proc convertSlice(start: int, stop: int, stride: int): range(stridable=true) {
+        var slice: range(stridable=true);
+        // backwards iteration with negative stride
+        if  (start > stop) & (stride < 0) {slice = (stop+1)..start by stride;}
+        // forward iteration with positive stride
+        else if (start <= stop) & (stride > 0) {slice = start..(stop-1) by stride;}
+        // BAD FORM start < stop and stride is negative
+        else {slice = 1..0;}
+        return slice;
+    }
+
     /* sliceIndex "a[slice]" response to __getitem__(slice) */
     proc sliceIndexMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
@@ -75,15 +214,7 @@ module IndexingMsg
         var start = try! startStr:int;
         var stop = try! stopStr:int;
         var stride = try! strideStr:int;
-        var slice: range(stridable=true);
-
-        // convert python slice to chapel slice
-        // backwards iteration with negative stride
-        if  (start > stop) & (stride < 0) {slice = (stop+1)..start by stride;}
-        // forward iteration with positive stride
-        else if (start <= stop) & (stride > 0) {slice = start..(stop-1) by stride;}
-        // BAD FORM start < stop and stride is negative
-        else {slice = 1..0;}
+        var slice: range(stridable=true) = convertSlice(start, stop, stride);
 
         // get next symbol name
         var rname = st.nextName();
@@ -751,15 +882,7 @@ module IndexingMsg
         var stop = try! stopStr:int;
         var stride = try! strideStr:int;
         var dtype = str2dtype(dtypeStr);
-        var slice: range(stridable=true);
-
-        // convert python slice to chapel slice
-        // backwards iteration with negative stride
-        if  (start > stop) & (stride < 0) {slice = (stop+1)..start by stride;}
-        // forward iteration with positive stride
-        else if (start <= stop) & (stride > 0) {slice = start..(stop-1) by stride;}
-        // BAD FORM start < stop and stride is negative
-        else {slice = 1..0;}
+        var slice: range(stridable=true) = convertSlice(start, stop, stride);
 
         imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                        "%s %s %i %i %i %s %s".format(cmd, name, start, stop, stride, 
@@ -999,6 +1122,9 @@ module IndexingMsg
     
     proc registerMe() {
       use CommandMap;
+      registerFunction("arrayViewIntIndex", arrayViewIntIndexMsg, getModuleName());
+      registerFunction("arrayViewMixedIndex", arrayViewMixedIndexMsg, getModuleName());
+      registerFunction("arrayViewIntIndexAssign", arrayViewIntIndexAssignMsg, getModuleName());
       registerFunction("[int]", intIndexMsg, getModuleName());
       registerFunction("[slice]", sliceIndexMsg, getModuleName());
       registerFunction("[pdarray]", pdarrayIndexMsg, getModuleName());

--- a/tests/array_view_test.py
+++ b/tests/array_view_test.py
@@ -73,6 +73,40 @@ class ArrayViewTest(ArkoudaTest):
         self.assertEqual(uav[uind], unav[nind])
         self.assertEqual(uav[iind], uav[uind])
 
+    def test_get_bool_pdarray(self):
+        n = np.arange(30).reshape(5, 3, 2)
+        a = ak.arange(30).reshape(5, 3, 2)
+
+        n_bool_list = n[True, True, True].tolist()
+        a_bool_list = a[True, True, True].to_ndarray().tolist()
+        self.assertListEqual(n_bool_list, a_bool_list)
+        n_bool_list = n[False, True, True].tolist()
+        a_bool_list = a[False, True, True].to_ndarray().tolist()
+        self.assertListEqual(n_bool_list, a_bool_list)
+        n_bool_list = n[True, False, True].tolist()
+        a_bool_list = a[True, False, True].to_ndarray().tolist()
+        self.assertListEqual(n_bool_list, a_bool_list)
+        n_bool_list = n[True, True, False].tolist()
+        a_bool_list = a[True, True, False].to_ndarray().tolist()
+        self.assertListEqual(n_bool_list, a_bool_list)
+
+    def test_set_bool_pdarray(self):
+        n = np.arange(30).reshape(5, 3, 2)
+        a = ak.arange(30).reshape(5, 3, 2)
+
+        n[True, True, True] = 9
+        a[True, True, True] = 9
+        self.assertListEqual(n.tolist(), a.to_ndarray().tolist())
+        n[False, True, True] = 5
+        a[False, True, True] = 5
+        self.assertListEqual(n.tolist(), a.to_ndarray().tolist())
+        n[True, False, True] = 6
+        a[True, False, True] = 6
+        self.assertListEqual(n.tolist(), a.to_ndarray().tolist())
+        n[True, True, False] = 13
+        a[True, True, False] = 13
+        self.assertListEqual(n.tolist(), a.to_ndarray().tolist())
+
     def test_reshape_order(self):
         # Keep 'C'/'F' (C/Fortran) order to be consistent with numpy
         # But also accept more descriptive 'row_major' and 'column_major'

--- a/tests/array_view_test.py
+++ b/tests/array_view_test.py
@@ -7,17 +7,20 @@ from itertools import product
 class ArrayViewTest(ArkoudaTest):
 
     def test_mulitdimensional_array_creation(self):
-        n1 = np.array([[0, 0], [0, 1], [1, 1]])
-        a1 = ak.array([[0, 0], [0, 1], [1, 1]])
-        self.assertListEqual(n1.tolist(), a1.to_ndarray().tolist())
-        n2 = np.arange(27).reshape((3, 3, 3))
-        a2 = ak.arange(27).reshape((3, 3, 3))
-        self.assertListEqual(n2.tolist(), a2.to_ndarray().tolist())
-        n3 = np.arange(27).reshape(3, 3, 3)
-        a3 = ak.arange(27).reshape(3, 3, 3)
-        self.assertListEqual(n3.tolist(), a3.to_ndarray().tolist())
+        n = np.array([[0, 0], [0, 1], [1, 1]])
+        a = ak.array([[0, 0], [0, 1], [1, 1]])
+        self.assertListEqual(n.tolist(), a.to_ndarray().tolist())
+        n = np.arange(27).reshape((3, 3, 3))
+        a = ak.arange(27).reshape((3, 3, 3))
+        self.assertListEqual(n.tolist(), a.to_ndarray().tolist())
+        n = np.arange(27).reshape(3, 3, 3)
+        a = ak.arange(27).reshape(3, 3, 3)
+        self.assertListEqual(n.tolist(), a.to_ndarray().tolist())
+        n = np.arange(27, dtype=np.uint64).reshape(3, 3, 3)
+        a = ak.arange(27, dtype=ak.uint64).reshape(3, 3, 3)
+        self.assertListEqual(n.tolist(), a.to_ndarray().tolist())
 
-    def testArrayViewIntIndexing(self):
+    def test_arrayview_int_indexing(self):
         nd = np.arange(9).reshape(3, 3)
         pd_reshape = ak.arange(9).reshape(3, 3)
         pd_array = ak.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]])
@@ -41,6 +44,34 @@ class ArrayViewTest(ArkoudaTest):
         with self.assertRaises(ValueError):
             # cannot reshape array of size 9 into shape (4,3)
             ak.arange(9).reshape(4, 3)
+
+    def test_int_list_indexing(self):
+        iav = ak.arange(30).reshape((5, 3, 2))
+        uav = ak.arange(30, dtype=ak.uint64).reshape((5, 3, 2))
+
+        iind = ak.array([3, 0, 1])
+        uind = ak.cast(iind, ak.uint64)
+        self.assertEqual(iav[iind], iav[uind])
+        self.assertEqual(uav[iind], uav[uind])
+
+    def test_set_index(self):
+        inav = np.arange(30).reshape((5, 3, 2))
+        unav = np.arange(30, dtype=np.uint64).reshape((5, 3, 2))
+        iav = ak.arange(30).reshape((5, 3, 2))
+        uav = ak.arange(30, dtype=ak.uint64).reshape((5, 3, 2))
+
+        nind = (3, 0, 1)
+        iind = ak.array(nind)
+        uind = ak.cast(iind, ak.uint64)
+
+        inav[nind] = -9999
+        unav[nind] = -9999
+        iav[uind] = -9999
+        uav[iind] = -9999
+        self.assertEqual(iav[uind], inav[nind])
+        self.assertEqual(iav[iind], iav[uind])
+        self.assertEqual(uav[uind], unav[nind])
+        self.assertEqual(uav[iind], uav[uind])
 
     def test_reshape_order(self):
         # Keep 'C'/'F' (C/Fortran) order to be consistent with numpy

--- a/tests/array_view_test.py
+++ b/tests/array_view_test.py
@@ -1,0 +1,126 @@
+import numpy as np
+from base_test import ArkoudaTest
+from context import arkouda as ak
+from itertools import product
+
+
+class ArrayViewTest(ArkoudaTest):
+
+    def test_mulitdimensional_array_creation(self):
+        n1 = np.array([[0, 0], [0, 1], [1, 1]])
+        a1 = ak.array([[0, 0], [0, 1], [1, 1]])
+        self.assertListEqual(n1.tolist(), a1.to_ndarray().tolist())
+        n2 = np.arange(27).reshape((3, 3, 3))
+        a2 = ak.arange(27).reshape((3, 3, 3))
+        self.assertListEqual(n2.tolist(), a2.to_ndarray().tolist())
+        n3 = np.arange(27).reshape(3, 3, 3)
+        a3 = ak.arange(27).reshape(3, 3, 3)
+        self.assertListEqual(n3.tolist(), a3.to_ndarray().tolist())
+
+    def testArrayViewIntIndexing(self):
+        nd = np.arange(9).reshape(3, 3)
+        pd_reshape = ak.arange(9).reshape(3, 3)
+        pd_array = ak.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]])
+
+        nd_ind = [nd[i, j] for (i, j) in product(range(3), repeat=2)]
+        reshape_ind = [pd_reshape[i, j] for (i, j) in product(range(3), repeat=2)]
+        array_ind = [pd_array[i, j] for (i, j) in product(range(3), repeat=2)]
+        self.assertListEqual(nd_ind, reshape_ind)
+        self.assertListEqual(nd_ind, array_ind)
+
+        with self.assertRaises(IndexError):
+            # index out bounds (>= dimension)
+            # index 3 is out of bounds for axis 0 with size 3
+            pd_reshape[3, 1]
+        with self.assertRaises(IndexError):
+            # index -4 is out of bounds for axis 1 with size 3
+            pd_reshape[2, -4]
+        with self.assertRaises(IndexError):
+            # too many indicies for array: array is 2-dimensional, but 3 were indexed
+            pd_reshape[0, 1, 1]
+        with self.assertRaises(ValueError):
+            # cannot reshape array of size 9 into shape (4,3)
+            ak.arange(9).reshape(4, 3)
+
+    def test_reshape_order(self):
+        # Keep 'C'/'F' (C/Fortran) order to be consistent with numpy
+        # But also accept more descriptive 'row_major' and 'column_major'
+        nd = np.arange(30).reshape((5, 3, 2), order='C')
+        ak_C = ak.arange(30).reshape((5, 3, 2), order='C')
+        ak_row = ak.arange(30).reshape((5, 3, 2), order='row_major')
+
+        nd_ind = [nd[i, j, k] for (i, j, k) in product(range(5), range(3), range(2))]
+        C_order = [ak_C[i, j, k] for (i, j, k) in product(range(5), range(3), range(2))]
+        row_order = [ak_row[i, j, k] for (i, j, k) in product(range(5), range(3), range(2))]
+        self.assertListEqual(nd_ind, C_order)
+        self.assertListEqual(nd_ind, row_order)
+
+        nd = np.arange(30).reshape((5, 3, 2), order='F')
+        ak_F = ak.arange(30).reshape((5, 3, 2), order='F')
+        ak_column = ak.arange(30).reshape((5, 3, 2), order='column_major')
+
+        nd_ind = [nd[i, j, k] for (i, j, k) in product(range(5), range(3), range(2))]
+        F_order = [ak_F[i, j, k] for (i, j, k) in product(range(5), range(3), range(2))]
+        column_order = [ak_column[i, j, k] for (i, j, k) in product(range(5), range(3), range(2))]
+        self.assertListEqual(nd_ind, F_order)
+        self.assertListEqual(nd_ind, column_order)
+
+    def test_basic_indexing(self):
+        # verify functionality is consistent with numpy basic indexing tutorial
+        # https://numpy.org/doc/stable/user/basics.indexing.html
+        n = np.arange(10).reshape(2, 5)
+        a = ak.arange(10).reshape(2, 5)
+
+        self.assertListEqual(list(n.shape), a.shape.to_ndarray().tolist())
+        # n.tolist() = [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]
+        self.assertListEqual(n.tolist(), a.to_ndarray().tolist())
+        self.assertEqual(n.__str__(), a.__str__())
+
+        self.assertEqual(n[1, 3], a[1, 3])
+        self.assertEqual(n[1, -1], a[1, -1])
+
+        self.assertListEqual(n[0].tolist(), a[0].to_ndarray().tolist())
+        self.assertEqual(n[0][2], a[0][2])
+
+        n = np.array([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]])
+        a = ak.array([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]])
+        # n[0, 1:7:2].tolist() = [1, 3, 5]
+        self.assertListEqual(n[0, 1:7:2].tolist(), a[0, 1:7:2].to_ndarray().tolist())
+        # n[0, -2:10].tolist() = [8, 9]
+        self.assertListEqual(n[0, -2:10].tolist(), a[0, -2:10].to_ndarray().tolist())
+        # n[0, -3:3:-1].tolist() = [7, 6, 5, 4]
+        self.assertListEqual(n[0, -3:3:-1].tolist(), a[0, -3:3:-1].to_ndarray().tolist())
+        # n[0, 5:].tolist() = [5, 6, 7, 8, 9]
+        self.assertListEqual(n[0, 5:].tolist(), a[0, 5:].to_ndarray().tolist())
+
+        n = np.array([[[1],[2],[3]], [[4],[5],[6]]])
+        a = ak.array([[[1],[2],[3]], [[4],[5],[6]]])
+        # list(n.shape) = [2, 3, 1]
+        self.assertListEqual(list(n.shape), a.shape.to_ndarray().tolist())
+        # n.tolist() = [[[1], [2], [3]], [[4], [5], [6]]]
+        self.assertListEqual(n.tolist(), a.to_ndarray().tolist())
+        self.assertEqual(n.__str__(), a.__str__())
+
+        # n[1:2].tolist() = [[[4], [5], [6]]]
+        self.assertListEqual(n[1:2].tolist(), a[1:2].to_ndarray().tolist())
+
+    def test_slicing(self):
+        a = ak.arange(30).reshape(2, 3, 5)
+        n = np.arange(30).reshape(2, 3, 5)
+        self.assertListEqual(n.tolist(), a.to_ndarray().tolist())
+
+        # n[:, ::-1, 1:5:2].tolist() = [[[11, 13], [6, 8], [1, 3]], [[26, 28], [21, 23], [16, 18]]]
+        self.assertListEqual(n[:, ::-1, 1:5:2].tolist(), a[:, ::-1, 1:5:2].to_ndarray().tolist())
+
+        # n[:, 5:8, 1:5:2].tolist() = [[], []]
+        self.assertListEqual(n[:, 5:8, 1:5:2].tolist(), a[:, 5:8, 1:5:2].to_ndarray().tolist())
+        # n[:, 5:8, 1:5:2][1].tolist() = []
+        self.assertListEqual(n[:, 5:8, 1:5:2][1].tolist(), a[:, 5:8, 1:5:2][1].to_ndarray().tolist())
+
+        a = ak.arange(30).reshape(2, 3, 5, order='F')
+        n = np.arange(30).reshape(2, 3, 5, order='F')
+        self.assertListEqual(n.tolist(), a.to_ndarray().tolist())
+
+        # n[:, ::-1, 1:5:2].tolist() = [[10, 22], [8, 20], [6, 18]]
+        self.assertListEqual(n[:, ::-1, 1:5:2].tolist(), a[:, ::-1, 1:5:2].to_ndarray().tolist())
+

--- a/tests/pdarray_creation_test.py
+++ b/tests/pdarray_creation_test.py
@@ -27,7 +27,6 @@ class PdarrayCreationTest(ArkoudaTest):
         self.assertEqual(int, pda.dtype) 
         
         pda =  ak.array(deque(range(5)))
-        self.assertIsInstance(pda, ak.pdarray)
         self.assertEqual(5, len(pda))
         self.assertEqual(int, pda.dtype)
 
@@ -36,13 +35,13 @@ class PdarrayCreationTest(ArkoudaTest):
         self.assertEqual(10, len(pda))
         self.assertEqual(int, pda.dtype)
 
-        with self.assertRaises(RuntimeError) as cm:          
-            ak.array({range(0,100)})
-        
-        with self.assertRaises(RuntimeError) as cm:          
-            ak.array(np.array([[0,1],[0,1]]))
+        av = ak.array(np.array([[0,1],[0,1]]))
+        self.assertIsInstance(av, ak.ArrayView)
 
-        with self.assertRaises(RuntimeError) as cm:          
+        with self.assertRaises(TypeError) as cm:
+            ak.array({range(0,100)})
+
+        with self.assertRaises(TypeError) as cm:
             ak.array('not an iterable')
         
         with self.assertRaises(TypeError) as cm:          
@@ -538,9 +537,9 @@ class PdarrayCreationTest(ArkoudaTest):
                         == pda).all())      
     
     def test_mulitdimensional_array_creation(self):
-        with self.assertRaises(RuntimeError) as cm:
-            ak.array([[0,0],[0,1],[1,1]])
-        
+        av = ak.array([[0,0],[0,1],[1,1]])
+        self.assertIsInstance(av, ak.ArrayView)
+
     def test_from_series(self):
         strings = ak.from_series(pd.Series(['a', 'b', 'c', 'd', 'e'], dtype="string"))
         


### PR DESCRIPTION
Part of Issue #1008:
- Introduces `ArrayView`
- Creation using `ak.array` or `pdarray.reshape`
  - `ak.array([[0, 0], [0, 1], [1, 1]])`
  - `ak.arange(27).reshape(3, 3, 3)`
- Handles `row_major`/`C` order and `column_major`/`F`
-  Support integer and slice indexing for `__getitem__`
- Support integer indexing for `__setitem__`
- `__str__` and `__repr__` methods implemented by converting to numpy and calling corresponding methods
- Implements `to_ndarray`
- Adds basic testing following along with [numpy basic indexing tutorial](https://numpy.org/doc/stable/user/basics.indexing.html)

<details>
<summary> Why advanced indexing isn't implemented:</summary>

the reason indexing by arrays or "advanced indexing" as numpy calls it is not yet supported is because numpy behavior with 2+ arrays is different than I expected. I don't *think* it should be too hard to modify the existing code to get the right functionality, but it's been a while since I started working this issue and wanted to go ahead and get out the first iteration.

This example shows how indexing by arrays can be a bit different. This is talked about a bit in https://numpy.org/doc/stable/user/basics.indexing.html

but I expected slice and array to behave the same when their indices matched up, but that's not always the case
```python
>>> n = np.arange(4).reshape(2,2)
# sometimes they line up
>>> n[:,:]
array([[0, 1],
       [2, 3]])

>>> n[:,[0,1]]
array([[0, 1],
       [2, 3]])

>>> n[[0,1],:]
array([[0, 1],
       [2, 3]])
# sometimes they do not
>>> n[[0,1],[0,1]]
array([0, 3])
```
basically when you have 2+ arrays, the functionality switches from the Cartesian product of coordinates to more coordinate-wise.

so `n[:, :]` gets `[0,0], [0,1], [1,0], [1,1]` whereas `n[[0,1],[0,1]]` only gets `[0,0], [1,1]`
</details>
