### PR TITLE
Change ak.read_parquet to read all supported datasets by default

### DIFF
--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -178,7 +178,7 @@ def read_parquet(filenames : Union[str, List[str]],
         datasets = [datasets]
 
     nonexistent = set(datasets) - \
-        (set(get_datasets_allow_errors(filenames)) if allow_errors else set(get_datasets(filenames[0])))
+        (set(get_datasets_allow_errors(filenames, True)) if allow_errors else set(get_datasets(filenames[0], True)))
     if len(nonexistent) > 0:
         raise ValueError("Dataset(s) not found: {}".format(nonexistent))
 

--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -177,6 +177,11 @@ def read_parquet(filenames : Union[str, List[str]],
     if isinstance(datasets, str):
         datasets = [datasets]
 
+    nonexistent = set(datasets) - \
+        (set(get_datasets_allow_errors(filenames)) if allow_errors else set(get_datasets(filenames[0])))
+    if len(nonexistent) > 0:
+        raise ValueError("Dataset(s) not found: {}".format(nonexistent))
+
     rep_msg = generic_msg(cmd="readAllParquet", args=
                           f"{strictTypes} {len(datasets)} {len(filenames)} {allow_errors} {json.dumps(datasets)} | {json.dumps(filenames)}")
     rep = json.loads(rep_msg)  # See GenSymIO._buildReadAllHdfMsgJson for json structure
@@ -429,6 +434,8 @@ def get_datasets_allow_errors(filenames: List[str], is_parquet=False) -> List[st
     ----------
     filenames : List[str]
         A list of HDF5 files visible to the arkouda server
+    is_parquet : bool
+        Is filename a Parquet file; false by default
 
     Returns
     -------

--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -117,7 +117,7 @@ def read_hdf(dsetName : str, filenames : Union[str,List[str]],
                          calc_string_offsets=calc_string_offsets))
 
 def read_parquet(filenames : Union[str, List[str]],
-                 dsetname : Union[str, List[str]]  = 'array',
+                 datasets : Union[str, List[str]]=None,
                  strictTypes: bool=True, allow_errors:bool = False)\
              -> Union[pdarray, Strings, Mapping[str,Union[pdarray,Strings]]]:
     """
@@ -128,9 +128,9 @@ def read_parquet(filenames : Union[str, List[str]],
     ----------
     filenames : list or str
         Either a list of filenames or shell expression
-    dsetName : str
-        The name of the dataset (must be the same across all files).
-        Defaults to 'array'.
+    datasets : str
+        The names of datasets to be read (must be the same across all files).
+        Defaults to all supported columns.
     strictTypes: bool
         If True (default), require all dtypes in all files to have the
         same precision and sign. If False, allow dtypes of different
@@ -172,11 +172,13 @@ def read_parquet(filenames : Union[str, List[str]],
     """
     if isinstance(filenames, str):
         filenames = [filenames]
-    if isinstance(dsetname, str):
-        dsetname = [dsetname]
+    if datasets is None:
+        datasets = get_datasets_allow_errors(filenames, True) if allow_errors else get_datasets(filenames[0], True)
+    if isinstance(datasets, str):
+        datasets = [datasets]
 
     rep_msg = generic_msg(cmd="readAllParquet", args=
-                          f"{strictTypes} {len(dsetname)} {len(filenames)} {allow_errors} {json.dumps(dsetname)} | {json.dumps(filenames)}")
+                          f"{strictTypes} {len(datasets)} {len(filenames)} {allow_errors} {json.dumps(datasets)} | {json.dumps(filenames)}")
     rep = json.loads(rep_msg)  # See GenSymIO._buildReadAllHdfMsgJson for json structure
     items = rep["items"] if "items" in rep else []
     file_errors = rep["file_errors"] if "file_errors" in rep else []
@@ -418,7 +420,7 @@ def get_datasets(filename : str, is_parquet=False) -> List[str]:
     return datasets
 
 @typechecked
-def get_datasets_allow_errors(filenames: List[str]) -> List[str]:
+def get_datasets_allow_errors(filenames: List[str], is_parquet=False) -> List[str]:
     """
     Get the names of datasets in an HDF5 file
     Allow file read errors until success
@@ -447,7 +449,7 @@ def get_datasets_allow_errors(filenames: List[str]) -> List[str]:
     datasets = []
     for filename in filenames:
         try:
-            datasets = get_datasets(filename)
+            datasets = get_datasets(filename, is_parquet)
             break
         except RuntimeError:
             pass

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -74,10 +74,10 @@ class ParquetTest(ArkoudaTest):
         ak_arr = ak.randint(0, 2**32, SIZE)
         ak_arr.save_parquet("pq_test", "test-dset-name")
         
-        with self.assertRaises(RuntimeError) as cm:
+        with self.assertRaises(ValueError) as cm:
             ak.read_parquet("pq_test*", "wrong-dset-name")
 
-        with self.assertRaises(RuntimeError) as cm:
+        with self.assertRaises(ValueError) as cm:
             ak.read_parquet("pq_test*", ['test-dset-name', 'wrong-dset-name'])
 
         for f in glob.glob("pq_test*"):


### PR DESCRIPTION
Previously, `read_parquet()` was defaulting to reading a dataset
called `array`. This PR updates the client-side code to get all
datasets if the user does not provide any datasets and then pass
those to the server to be read.

Related issue: https://github.com/Bears-R-Us/arkouda/issues/985