### PR TITLE
Closes #1121 uint64 hash return

### DIFF
--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -85,18 +85,18 @@ module EfuncMsg
                     }
                     when "hash64" {
                         overMemLimit(numBytes(int) * e.size);
-                        var a = st.addEntry(rname, e.size, int);
+                        var a = st.addEntry(rname, e.size, uint);
                         forall (ai, x) in zip(a.a, e.a) {
-                            ai = sipHash64(x): int(64);
+                            ai = sipHash64(x): uint;
                         }
                     }
                     when "hash128" {
                         overMemLimit(numBytes(int) * e.size * 2);
                         var rname2 = st.nextName();
-                        var a1 = st.addEntry(rname2, e.size, int);
-                        var a2 = st.addEntry(rname, e.size, int);
+                        var a1 = st.addEntry(rname2, e.size, uint);
+                        var a2 = st.addEntry(rname, e.size, uint);
                         forall (a1i, a2i, x) in zip(a1.a, a2.a, e.a) {
-                            (a1i, a2i) = sipHash128(x): (int(64), int(64));
+                            (a1i, a2i) = sipHash128(x): (uint, uint);
                         }
                         // Put first array's attrib in repMsg and let common
                         // code append second array's attrib
@@ -165,18 +165,18 @@ module EfuncMsg
                     }
                     when "hash64" {
                         overMemLimit(numBytes(real) * e.size);
-                        var a = st.addEntry(rname, e.size, int);
+                        var a = st.addEntry(rname, e.size, uint);
                         forall (ai, x) in zip(a.a, e.a) {
-                            ai = sipHash64(x): int(64);
+                            ai = sipHash64(x): uint;
                         }
                     }
                     when "hash128" {
                         overMemLimit(numBytes(real) * e.size * 2);
                         var rname2 = st.nextName();
-                        var a1 = st.addEntry(rname2, e.size, int);
-                        var a2 = st.addEntry(rname, e.size, int);
+                        var a1 = st.addEntry(rname2, e.size, uint);
+                        var a2 = st.addEntry(rname, e.size, uint);
                         forall (a1i, a2i, x) in zip(a1.a, a2.a, e.a) {
-                            (a1i, a2i) = sipHash128(x): (int(64), int(64));
+                            (a1i, a2i) = sipHash128(x): (uint, uint);
                         }
                         // Put first array's attrib in repMsg and let common
                         // code append second array's attrib
@@ -239,7 +239,6 @@ module EfuncMsg
                     }
                     when "hash64" {
                         overMemLimit(numBytes(uint) * e.size);
-                        // TO DO: change all hash return types to uint
                         var a = st.addEntry(rname, e.size, uint);
                         forall (ai, x) in zip(a.a, e.a) {
                             ai = sipHash64(x): uint;
@@ -248,7 +247,6 @@ module EfuncMsg
                     when "hash128" {
                         overMemLimit(numBytes(uint) * e.size * 2);
                         var rname2 = st.nextName();
-                        // TO DO: change all hash return types to uint
                         var a1 = st.addEntry(rname2, e.size, uint);
                         var a2 = st.addEntry(rname, e.size, uint);
                         forall (a1i, a2i, x) in zip(a1.a, a2.a, e.a) {

--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -240,19 +240,19 @@ module EfuncMsg
                     when "hash64" {
                         overMemLimit(numBytes(uint) * e.size);
                         // TO DO: change all hash return types to uint
-                        var a = st.addEntry(rname, e.size, int);
+                        var a = st.addEntry(rname, e.size, uint);
                         forall (ai, x) in zip(a.a, e.a) {
-                            ai = sipHash64(x): int(64);
+                            ai = sipHash64(x): uint;
                         }
                     }
                     when "hash128" {
                         overMemLimit(numBytes(uint) * e.size * 2);
                         var rname2 = st.nextName();
                         // TO DO: change all hash return types to uint
-                        var a1 = st.addEntry(rname2, e.size, int);
-                        var a2 = st.addEntry(rname, e.size, int);
+                        var a1 = st.addEntry(rname2, e.size, uint);
+                        var a2 = st.addEntry(rname, e.size, uint);
                         forall (a1i, a2i, x) in zip(a1.a, a2.a, e.a) {
-                            (a1i, a2i) = sipHash128(x): (int(64), int(64));
+                            (a1i, a2i) = sipHash128(x): (uint, uint);
                         }
                         // Put first array's attrib in repMsg and let common
                         // code append second array's attrib

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -511,11 +511,11 @@ module SegmentedMsg {
             var strings = getSegString(name, st);
             var hashes = strings.hash();
             var name1 = st.nextName();
-            var hash1 = st.addEntry(name1, hashes.size, int);
+            var hash1 = st.addEntry(name1, hashes.size, uint);
             var name2 = st.nextName();
-            var hash2 = st.addEntry(name2, hashes.size, int);
+            var hash2 = st.addEntry(name2, hashes.size, uint);
             forall (h, h1, h2) in zip(hashes, hash1.a, hash2.a) {
-                (h1,h2) = h:(int,int);
+                (h1,h2) = h:(uint,uint);
             }
             var repMsg = "created " + st.attrib(name1) + "+created " + st.attrib(name2);
             smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -180,7 +180,7 @@ class NumericTest(ArkoudaTest):
         self.assertTrue((h1 == h3[rev]).all())
 
         h = ak.hash(ak.linspace(0, 10, 10))
-        self.assertTrue((h[0].dtype == ak.int64) and (h[1].dtype == ak.int64))
+        self.assertTrue((h[0].dtype == ak.uint64) and (h[1].dtype == ak.uint64))
         
         
     def testValueCounts(self):


### PR DESCRIPTION
This PR (closes #1121):

`.hash()` functions have been updated so that chapel is using uint64 for hashes. This results in uint64 returning to the client.

- `hash64` returns a single uint64 
- `hash128` returns (uint64, uint64)