### PR TITLE
Fix quoting when getting vars from the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -437,7 +437,7 @@ $(TEST_TARGETS): $(TEST_BINARY_DIR)/$(TEST_BINARY_SIGIL)%: $(TEST_SOURCE_DIR)/%.
 	$(CHPL) $(TEST_CHPL_FLAGS) -M $(ARKOUDA_SOURCE_DIR) $(ARKOUDA_COMPAT_MODULES) $< -o $@
 
 print-%:
-	@echo "$($*)"
+	$(info $($*)) @true
 
 test-python: 
 	python3 -m pytest $(ARKOUDA_PYTEST_OPTIONS) -c pytest.ini


### PR DESCRIPTION
The makefile supports an arbitrary `print-%` command that will print
whatever makefile variable you want. This is used by the chapel unit
tests to get the value of `$CHPL_FLAGS`. Previously, we just `echo`d,
but the shell interprets/removes quotes causing issues for things like:
`CHPL_FLAGS="--ccflags=\"-Wno-expansion-to-defined -Wno-nullability-completeness\""`

Fix that here by using the Makefile `info` command instead of `@echo`