### PR TITLE
Fix Parquet unit test version number test when Arrow version < 5

### DIFF
--- a/test/UnitTestParquetCpp.chpl
+++ b/test/UnitTestParquetCpp.chpl
@@ -122,9 +122,13 @@ proc testVersionInfo() {
   }
   var ret;
   try! ret = createStringWithNewBuffer(cVersionString);
-  if ret[0]: int >= 5 {
+  try {
+    // Ensure that version number can be cast to int
+    // Not checking version number for compatability
+    var vMajor = ret[0]:int;
     return 0;
-  } else {
+  } catch {
+    writeln("FAILED: c_getVersionInfo with ", ret);
     return 1;
   }
 }


### PR DESCRIPTION
Previously, the Parquet unit test was checking if the Arrow version
was greater than 5, but 5 is not a requirement, so I am removing
that check and instead just ensuring that the version major can be
cast to an integer value.