### PR TITLE
Fix crash when passing in bad column names to Parquet

### DIFF
--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -77,6 +77,9 @@ class ParquetTest(ArkoudaTest):
         with self.assertRaises(RuntimeError) as cm:
             ak.read_parquet("pq_test*", "wrong-dset-name")
 
+        with self.assertRaises(RuntimeError) as cm:
+            ak.read_parquet("pq_test*", ['test-dset-name', 'wrong-dset-name'])
+
         for f in glob.glob("pq_test*"):
             os.remove(f)
 


### PR DESCRIPTION
When calling `ak.read_parquet()` with a bad column name
that was not the first column was causing the server to
crash. This is because only the first dataset name in the
set of dataset names was being checked, so if dataset
names after the first were bad, they would cause the
server to crash.

This is a remnant of copy-pasting code from the HDF5
layer that I did not totally understand that does not
work identically for Parquet.

Now, each dataset name will be checked and an error
will be returned if the dataset does not exist in the
file, rather than crashing the server.

Additionally, I have removed a bunch of the error handling
code that is HDF5 specific, as none of the Parquet code
throws anything other than a basic `Error`.

Resolves: https://github.com/Bears-R-Us/arkouda/issues/1153