### PR TITLE
Closes #1012 `.astype()` method

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -854,6 +854,28 @@ class pdarray:
         Rotate bits right by <other>.
         """
         return rotr(self, other)
+
+    def astype(self, dtype) -> pdarray:
+        """
+        Cast values of pdarray to provided dtype
+
+        Parameters
+        __________
+        dtype: np.dtype or str
+            Dtype to cast to
+
+        Returns
+        _______
+        ak.pdarray
+            An arkouda pdarray with values converted to the specified data type
+
+        Notes
+        _____
+        This is essentially shorthand for ak.cast(x, '<dtype>') where x is a pdarray.
+        """
+        from arkouda.numeric import cast as akcast
+
+        return akcast(self, dtype)
     
     def to_ndarray(self) -> np.ndarray:
         """

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1287,6 +1287,28 @@ class Strings:
             dt = dt.newbyteorder('<')
         return np.frombuffer(rep_msg, dt).copy()
 
+    def astype(self, dtype) -> pdarray:
+        """
+        Cast values of Strings object to provided dtype
+
+        Parameters
+        __________
+        dtype: np.dtype or str
+            Dtype to cast to
+
+        Returns
+        _______
+        ak.pdarray
+            An arkouda pdarray with values converted to the specified data type
+
+        Notes
+        _____
+        This is essentially shorthand for ak.cast(x, '<dtype>') where x is a pdarray.
+        """
+        from arkouda.numeric import cast as akcast
+
+        return akcast(self, dtype)
+
     @typechecked
     def save(self, prefix_path : str, dataset : str='strings_array', 
              mode : str='truncate', save_offsets : bool = True) -> str:


### PR DESCRIPTION
This PR (closes #1012):

 - `.astype()` method added for `pdarray`
 - `.astype()` method added for Strings.

Both `.astype()` methods take in a `str` or `np.dtype` (same as `cast()`). These methods serve as an alias for `ak.cast()`. Calling `x.astype('<dtype>')` results in a call to `ak.cast(x, '<dtype>')`.

I did not add testing for this because testing for `ak.cast()` is already in place, and additional testing here would be the same. I can add tests if we would prefer to have testing dedicated to these functions.