### PR TITLE
Closes #1126 dtypes and util to arkouda

### DIFF
--- a/arkouda/__init__.py
+++ b/arkouda/__init__.py
@@ -3,6 +3,7 @@ __version__ = get_versions()['version']
 del get_versions
 
 from arkouda.client import *
+from arkouda.client_dtypes import *
 from arkouda.dtypes import *
 from arkouda.pdarrayclass import *
 from arkouda.sorting import *

--- a/arkouda/client_dtypes.py
+++ b/arkouda/client_dtypes.py
@@ -1,0 +1,515 @@
+import numpy as np  # type: ignore
+from ipaddress import ip_address as _ip_address
+from functools import partial
+
+from arkouda.pdarrayclass import pdarray
+from arkouda.dtypes import isSupportedInt
+from arkouda.dtypes import int64 as akint64
+from arkouda.strings import Strings
+from arkouda.pdarraycreation import zeros, arange
+from arkouda.groupbyclass import GroupBy, broadcast
+from arkouda.numeric import where
+
+
+def BitVectorizer(width=64, reverse=False):
+    """
+    Make a callback (i.e. function) that can be called on an
+    array to create a BitVector.
+
+    Parameters
+    ----------
+    width : int
+        The number of bit fields in the vector
+    reverse : bool
+        If True, display bits from least significant (left) to most
+        significant (right). By default, the most significant bit
+        is the left-most bit.
+
+    Returns
+    -------
+    bitvectorizer : callable
+        A function that takes an array and returns a BitVector instance
+    """
+
+    return partial(BitVector, width=width, reverse=reverse)
+
+
+class BitVector(pdarray):
+    """
+    Represent integers as bit vectors, e.g. a set of flags.
+
+    Parameters
+    ----------
+    values : pdarray, int64
+        The integers to represent as bit vectors
+    width : int
+        The number of bit fields in the vector
+    reverse : bool
+        If True, display bits from least significant (left) to most
+        significant (right). By default, the most significant bit
+        is the left-most bit.
+
+    Returns
+    -------
+    bitvectors : BitVector
+        The array of binary vectors
+
+    Notes
+    -----
+    This class is a thin wrapper around pdarray that mostly affects
+    how values are displayed to the user. Operators and methods will
+    typically treat this class like an int64 pdarray.
+    """
+
+    conserves = frozenset(('+', '-', '|', '&', '^', '>>', '<<'))
+
+    def __init__(self, values, width=64, reverse=False):
+        if type(values) != pdarray or values.dtype != akint64:
+            raise TypeError("Argument must be int64 pdarray")
+        self.width = width
+        self.reverse = reverse
+        self.values = values
+        super().__init__(self.values.name, self.values.dtype.name, self.values.size, self.values.ndim,
+                         self.values.shape, self.values.itemsize)
+
+    def format(self, x):
+        """
+        Format a single binary vector as a string.
+        """
+        # Start with a fixed-width, zero-padded binary value,
+        # and replace 0/1 with ./| for better visibility
+        fmt = '{{:0{}b}}'.format(self.width).format(x).replace('0', '.').replace('1', '|')
+        if self.reverse:
+            return fmt[::-1]
+        else:
+            return fmt
+
+    def __str__(self):
+        from arkouda.client import pdarrayIterThresh
+        if self.size <= pdarrayIterThresh:
+            vals = [self.format(self.values[i]) for i in range(self.size)]
+        else:
+            vals = [self.format(self.values[i]) for i in range(3)]
+            vals.append('...')
+            vals.extend([self.format(self.values[i]) for i in range(self.size-3, self.size)])
+        # Print values as a single, aligned column for easier viewing
+        # Also show "width" and "reverse" parameters
+        spaces = ' '*(len(self.__class__.__name__)+1)
+        return "{}([{}],\n{}width={}, reverse={})".format(self.__class__.__name__,
+                                                          ',\n{} '.format(spaces).join(vals),
+                                                          spaces,
+                                                          self.width,
+                                                          self.reverse)
+
+    def __repr__(self):
+        return self.__str__()
+
+    def to_ndarray(self):
+        '''
+        Export data to a numpy array of string-formatted bit vectors.
+        '''
+        return np.array([self.format(x) for x in self.values.to_ndarray()])
+
+    def _cast(self, values):
+        return self.__class__(values, width=self.width, reverse=self.reverse)
+
+    def __getitem__(self, key):
+        if isSupportedInt(key):
+            # Return single value as a formatted string
+            return self.format(self.values[key])
+        else:
+            # Forward all other indexing ops to integer array
+            return self._cast(self.values[key])
+
+    def __setitem__(self, key, value):
+        if isinstance(value, self.__class__):
+            # Set a slice or selection of values directly
+            self.values[key] = value.values
+        elif isSupportedInt(key) and isSupportedInt(value):
+            # Set a single value
+            self.values[key] = value
+        else:
+            return NotImplemented
+
+    def _binop(self, other, op):
+        # Based on other type, select which data to pass
+        # to _binop of pdarray
+        if isSupportedInt(other):
+            otherdata = other
+        elif isinstance(other, self.__class__):
+            otherdata = other.values
+        elif isinstance(other, pdarray) and other.dtype == akint64:
+            otherdata = other
+        else:
+            return NotImplemented
+        # Some operators return a BitVector, but others don't
+        if op in self.conserves:
+            # These ops are defined as a class attribute
+            return self._cast(self.values._binop(otherdata, op))
+        else:
+            return self.values._binop(otherdata, op)
+
+    def _r_binop(self, other, op):
+        # Cases where left operand is BitVector are handled above by _binop
+        # Only two cases to handle here: scalar int and int64 pdarray
+        if isSupportedInt(other):
+            if op in self.conserves:
+                return self._cast(self.values._r_binop(other, op))
+            else:
+                return self.values._r_binop(other, op)
+        elif (isinstance(other, pdarray) and other.dtype == akint64):
+            # Some operators return a BitVector, but others don't
+            if op in self.conserves:
+                return self._cast(other._binop(self.values, op))
+            else:
+                return other._binop(self.values, op)
+        else:
+            return NotImplemented
+
+    def opeq(self, other, op):
+        # Based on other type, select data to pass to pdarray opeq
+        if isSupportedInt(other):
+            otherdata = other
+        elif isinstance(other, self.__class__):
+            otherdata = other.values
+        elif isinstance(other, pdarray) and other.dtype == akint64:
+            otherdata = other
+        else:
+            return NotImplemented
+        self.values.opeq(otherdata, op)
+
+
+class Fields(BitVector):
+    """
+    An integer-backed representation of a set of named binary fields, e.g. flags.
+
+    Parameters
+    ----------
+    values : pdarray(int64) or Strings
+        The array of field values. If int64, the values are used as-is for the
+        binary representation of fields. If Strings, the values are converted
+        to binary according to the mapping defined by the names and MSB_left
+        arguments.
+    names : str or sequence of str
+        The names of the fields, in order. A string will be treated as a list
+        of single-character field names. Multi-character field names are allowed,
+        but must be passed as a list or tuple and user must specify a separator.
+    MSB_left : bool
+        Controls how field names are mapped to binary values. If True (default),
+        the left-most field name corresponds to the most significant bit in the
+        binary representation. If False, the left-most field name corresponds to
+        the least significant bit.
+    pad : str
+        Character to display when field is not present. Use empty string if no
+        padding is desired.
+    separator : str
+        Substring that separates fields. Used to parse input values (if ak.Strings)
+        and to display output.
+    show_int : bool
+        If True (default), display the integer value of the binary fields in output.
+
+    Returns
+    -------
+    fields : Fields
+        The array of field values
+
+    Notes
+    -----
+    This class is a thin wrapper around pdarray that mostly affects
+    how values are displayed to the user. Operators and methods will
+    typically treat this class like an int64 pdarray.
+    """
+
+    def __init__(self, values, names, MSB_left=True, pad='-', separator='', show_int=True):
+        ### Argument validation
+        # Normalize names, which can be string or sequence
+        self.names = tuple(names)
+        if len(self.names) > 63:
+            raise ValueError("Cannot represent more than 63 fields")
+        # Ensure no duplicate names
+        if len(self.names) != len(set(self.names)):
+            raise ValueError("Field names must be unique")
+        # Ensure no empty names
+        if any(name == '' for name in self.names):
+            raise ValueError("Names cannot be empty strings")
+        # If separator is non-empty, it cannot be a field name
+        if (separator != '') and (separator in self.names):
+            raise ValueError("Separator cannot be a field name")
+        # Field names can have multiple characters, but if so, there must be a separator
+        self.namewidth = max(len(n) for n in self.names)
+        if (self.namewidth > 1) and (separator == ''):
+            raise ValueError(f"A non-empty separator must be specified when field names have more than one character")
+        if len(pad) > 1:
+            raise ValueError(f"Pad must be single character or empty string")
+
+        self.padchar = pad
+        # string to display when a field is not set
+        self.pad = self.namewidth * self.padchar
+        # separator to display between fields
+        self.separator = separator
+        width = len(self.names)
+        # whether the left-most field name corresponds to the most significant bit
+        self.MSB_left = MSB_left
+        if self.MSB_left:
+            self.shifts = range(width - 1, -1, -1)
+        else:
+            self.shifts = range(width)
+        # whether to display the integer value of the field bit vector
+        self.show_int = show_int
+        # values arg can be either int64 or Strings. If Strings, convert to binary
+        if isinstance(values, Strings):
+            values = self._convert_strings(values)
+        super().__init__(values, width=width, reverse=not MSB_left)
+
+    def _convert_strings(self, s):
+        '''
+        Convert string field names to binary vectors.
+        '''
+        # Initialize to zero
+        values = zeros(s.size, dtype=akint64)
+        if self.separator == '':
+            # When separator is empty, field names are guaranteed to be single characters
+            for name, shift in zip(self.names, self.shifts):
+                # Check if name exists in each string
+                bit = s.contains(name)
+                values = values | where(bit, 1 << shift, 0)
+        else:
+            # When separator is non-empty, split on it
+            sf, segs = s.flatten(self.separator, return_segments=True)
+            # Create a grouping to map split fields back to originating string
+            orig = broadcast(segs, arange(segs.size), sf.size)
+            g = GroupBy(orig)
+            for name, shift in zip(self.names, self.shifts):
+                # Check if name matches one of the split fields from originating string
+                bit = g.any(sf == name)[1]
+                values = values | where(bit, 1 << shift, 0)
+        return values
+
+    def _parse_scalar(self, s):
+        '''
+        Convert a string of named fields to a binary value.
+        '''
+        val = 0
+        if self.separator == '':
+            # Arg validation guarantees single-character field names if here
+            for name, shift in zip(self.names, self.shifts):
+                if name in s:
+                    val |= (1 << shift)
+        else:
+            fields = s.split(self.separator)
+            for name, shift in zip(self.names, self.shifts):
+                if name in fields:
+                    val |= (1 << shift)
+        return val
+
+    def format(self, x):
+        '''
+        Format a single binary value as a string of named fields.
+        '''
+        # Start with a fixed-width, zero-padded binary value,
+        # and replace 0/1 with ./| for better visibility
+        s = ''
+        for i, shift in enumerate(self.shifts):
+            bitset = ((x >> shift) & 1) == 1
+            if bitset:
+                s += '{{:^{}s}}'.format(self.namewidth).format(self.names[i])
+            else:
+                s += self.pad
+            s += self.separator
+        if self.show_int:
+            s += ' ({:n})'.format(x)
+        return s
+
+    def __setitem__(self, key, value):
+        if isinstance(value, str):
+            v = self._parse_scalar(value)
+            return super().__setitem__(key, v)
+        else:
+            return super().__setitem__(key, value)
+
+    def _cast(self, values):
+        return self.__class__(values, self.names, MSB_left=self.MSB_left, pad=self.padchar, separator=self.separator,
+                              show_int=self.show_int)
+
+    def _binop(self, other, op):
+        if isinstance(other, str):
+            o = self._parse_scalar(other)
+            return super()._binop(o, op)
+        else:
+            return super()._binop(other, op)
+
+    def _r_binop(self, other, op):
+        if isinstance(other, str):
+            o = self._parse_scalar(other)
+            return super()._r_binop(o, op)
+        else:
+            return super()._r_binop(other, op)
+
+    def opeq(self, other, op):
+        if isinstance(other, str):
+            o = self._parse_scalar(other)
+            return super().opeq(o, op)
+        else:
+            return super().opeq(other, op)
+
+
+def ip_address(values):
+    '''
+    Takes an int64 pdarray (or IPv4 object) and returns an IPv4 object.
+
+    Parameters
+    ----------
+    values : pdarray, int64 or IPv4
+        The integer IP addresses or IPv4 object.
+
+    Returns
+    -------
+    IPv4
+        The same IP addresses
+
+    Notes
+    -----
+    This helper is intended to help future proof changes made to
+    accomodate IPv6 and to prevent errors if a user inadvertently
+    casts a IPv4 instead of a int64 pdarray.
+    '''
+
+    if type(values) == IPv4:
+        return values
+
+    try:
+        return IPv4(values)
+    except TypeError:
+        pass
+
+    raise TypeError('%r must be either an int64 pdarray or IPv4')
+
+
+class IPv4(pdarray):
+    '''
+    Represent integers as IPv4 addresses.
+
+    Parameters
+    ----------
+    values : pdarray, int64
+        The integer IP addresses
+
+    Returns
+    -------
+    IPv4
+        The same IP addresses
+
+    Notes
+    -----
+    This class is a thin wrapper around pdarray that mostly affects
+    how values are displayed to the user. Operators and methods will
+    typically treat this class like an int64 pdarray.
+    '''
+
+    def __init__(self, values):
+        if type(values) != pdarray or values.dtype != akint64:
+            raise TypeError("Argument must be int64 pdarray")
+        self.values = values
+        super().__init__(self.values.name, self.values.dtype.name, self.values.size, self.values.ndim, self.values.shape, self.values.itemsize)
+
+    def format(self, x):
+        '''
+        Format a single integer IP address as a string.
+        '''
+        if not isSupportedInt(x):
+            raise TypeError("Argument must be an integer scalar")
+        return str(_ip_address(int(x)))
+
+    def normalize(self, x):
+        '''
+        Take in an IP address as a string, integer, or IPAddress object,
+        and convert it to an integer.
+        '''
+        if not isSupportedInt(x):
+            x = int(_ip_address(x))
+        if x < 0:
+            raise ValueError("Not an IP address: {}".format(_ip_address(x)))
+        return x
+
+    def _is_supported_scalar(self, x):
+        try:
+            return True, self.normalize(x)
+        except:
+            return False, None
+
+    def __str__(self):
+        from arkouda.client import pdarrayIterThresh
+        if self.size <= pdarrayIterThresh:
+            vals = [self.format(self.values[i]) for i in range(self.size)]
+        else:
+            vals = [self.format(self.values[i]) for i in range(3)]
+            vals.append('...')
+            vals.extend([self.format(self.values[i]) for i in range(self.size-3, self.size)])
+        # Display values as single, aligned column for ease of viewing
+        spaces = ' '*(len(self.__class__.__name__)+1)
+        return "{}([{}],\n{})".format(self.__class__.__name__,
+                                                          ',\n{} '.format(spaces).join(vals),
+                                                          spaces)
+
+    def __repr__(self):
+        return self.__str__()
+
+    def to_ndarray(self):
+        '''
+        Export array as a numpy array of integers.
+        '''
+        return np.array([self.format(x) for x in self.values.to_ndarray()])
+
+    def __getitem__(self, key):
+        if isSupportedInt(key):
+            # Display single item as string
+            return self.format(self.values[key])
+        else:
+            # Forward other accesses to pdarray class
+            return self.__class__(self.values[key])
+
+    def __setitem__(self, key, value):
+        # If scalar, convert to integer and set
+        isscalar, scalarval = self._is_supported_scalar(value)
+        if isscalar:
+            self.values[key] = scalarval
+        elif isinstance(value, self.__class__):
+            self.values[key] = value.values
+        else:
+            return NotImplemented
+
+    def _binop(self, other, op):
+        # Based on other type, select data to pass to pdarray _binop
+        isscalar, scalarval = self._is_supported_scalar(other)
+        if isscalar:
+            otherdata = scalarval
+        elif isinstance(other, self.__class__):
+            otherdata = other.values
+        elif isinstance(other, pdarray) and other.dtype == akint64:
+            otherdata = other
+        else:
+            return NotImplemented
+        return self.values._binop(otherdata, op)
+
+    def _r_binop(self, other, op):
+        # _binop handles everything except left types: scalar and pdarray int64
+        isscalar, scalarval = self._is_supported_scalar(other)
+        if isscalar:
+            return self.values._r_binop(scalarval, op)
+        elif (isinstance(other, pdarray) and other.dtype == akint64):
+            return other._binop(self.values, op)
+        else:
+            return NotImplemented
+
+    def opeq(self, other, op):
+        # Based on other type, select data to pass to pdarray opeq
+        isscalar, scalarval = self._is_supported_scalar(other)
+        if isscalar:
+            otherdata = scalarval
+        elif isinstance(other, self.__class__):
+            otherdata = other.values
+        elif isinstance(other, pdarray) and other.dtype == akint64:
+            otherdata = other
+        else:
+            return NotImplemented
+        self.values.opeq(otherdata, op)

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -19,7 +19,6 @@ from arkouda.sorting import argsort, coargsort
 from arkouda.numeric import where
 from arkouda.client import maxTransferBytes
 from arkouda.row import Row
-from arkouda.util import concatenate as util_concatenate
 
 # This is necessary for displaying DataFrames with BitVector columns,
 # because pandas _html_repr automatically truncates the number of displayed bits
@@ -629,6 +628,7 @@ class DataFrame(UserDict):
                 self
                     Appending occurs in-place, but result is returned for compatibility.
                 """
+        from arkouda.util import concatenate as util_concatenate
 
         # Do nothing if the other dataframe is empty
         if other.empty:
@@ -665,6 +665,11 @@ class DataFrame(UserDict):
 
     @classmethod
     def concat(cls, items, ordered=True):
+        """
+        Essentially an append, but diffenent formatting
+        """
+        from arkouda.util import concatenate as util_concatenate
+
         if len(items) == 0:
             return cls()
         first = True

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -19,6 +19,7 @@ from arkouda.sorting import argsort, coargsort
 from arkouda.numeric import where
 from arkouda.client import maxTransferBytes
 from arkouda.row import Row
+from arkouda.util import concatenate as util_concatenate
 
 # This is necessary for displaying DataFrames with BitVector columns,
 # because pandas _html_repr automatically truncates the number of displayed bits
@@ -605,13 +606,87 @@ class DataFrame(UserDict):
         return self
 
     def append(self, other, ordered=True):
-        # TODO - remove error and define function once akutil/util.py moved to arkouda
-        raise NotImplementedError("Append functionality is not yet available for dataframes in arkouda. For updates, please visit https://github.com/Bears-R-Us/arkouda/issues/1126")
+        """
+                Concatenate data from 'other' onto the end of this DataFrame, in place.
+
+                Explicitly, use the arkouda concatenate function to append the data
+                from each column in other to the end of self. This operation is done
+                in place, in the sense that the underlying pdarrays are updated from
+                the result of the arkouda concatenate function, rather than returning
+                a new DataFrame object containing the result.
+
+                Parameters
+                ----------
+                other : DataFrame
+                    The DataFrame object whose data will be appended to this DataFrame.
+                ordered: bool
+                    If False, allow rows to be interleaved for better performance (but
+                    data within a row remains together). By default, append all rows
+                    to the end, in input order.
+
+                Returns
+                -------
+                self
+                    Appending occurs in-place, but result is returned for compatibility.
+                """
+
+        # Do nothing if the other dataframe is empty
+        if other.empty:
+            return self
+
+        # Check all the columns to make sure they can be concatenated
+        self.update_size()
+
+        keyset = set(self.keys())
+        keylist = list(self.keys())
+
+        # Allow for starting with an empty dataframe
+        if self.empty:
+            self = other.copy()
+        # Keys don't match
+        elif keyset != set(other.keys()):
+            raise KeyError(f"Key mismatch; keys must be identical in both DataFrames.")
+        # Keys do match
+        else:
+            tmp_data = {}
+            for key in keylist:
+                try:
+                    tmp_data[key] = util_concatenate([self[key], other[key]], ordered=ordered)
+                except TypeError as e:
+                    raise TypeError("Incompatible types for column {}: {} vs {}".format(key, type(self[key]),
+                                                                                        type(other[key]))) from e
+            self.data = tmp_data
+
+        # Clean up
+        self.reset_index()
+        self.update_size()
+        self._empty = False
+        return self
 
     @classmethod
     def concat(cls, items, ordered=True):
-        # TODO - remove error and define function once akutil/util.py moved to arkouda
-        raise NotImplementedError("Append functionality is not yet available for dataframes in arkouda. For updates, please visit https://github.com/Bears-R-Us/arkouda/issues/1126")
+        if len(items) == 0:
+            return cls()
+        first = True
+        for df in items:
+            # Allow for an empty dataframe
+            if df.empty or set(df.keys()) == {'index'}:
+                continue
+            if first:
+                columnset = set(df.keys())
+                columnlist = df._columns
+                first = False
+            else:
+                if set(df.keys()) != columnset:
+                    raise KeyError("Cannot concatenate DataFrames with mismatched columns")
+        # if here, columns match
+        ret = cls()
+        for col in columnlist:
+            try:
+                ret[col] = util_concatenate([df[col] for df in items], ordered=ordered)
+            except TypeError as e:
+                raise TypeError("Incompatible types for column {}".format(col))
+        return ret
 
     def head(self, n=5):
         """

--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -16,6 +16,7 @@ from arkouda.client import get_config, get_mem_used
 from arkouda.groupbyclass import GroupBy, broadcast, coargsort
 from arkouda.infoclass import information, AllSymbols
 from arkouda.categorical import Categorical
+from arkouda.dataframe import DataFrame
 
 identity = lambda x: x
 
@@ -102,9 +103,8 @@ def register_all(data, prefix, overwrite=True):
                 att[ksan].unregister()
     if isinstance(data, dict):
         return {k:register(v, f'{prefix}{sanitize(k)}') for k, v in data.items()}
-    #TODO - once DataFrame is available uncomment the next 2 lines (PR #1139)
-    # elif isinstance(data, aku.DataFrame):
-    #    return aku.DataFrame({k:register(v, f'{prefix}{sanitize(k)}') for k, v in data.items()})
+    elif isinstance(data, DataFrame):
+        return DataFrame({k:register(v, f'{prefix}{sanitize(k)}') for k, v in data.items()})
     elif isinstance(data, list):
         return [register(v, f'{prefix}{i}') for i, v in enumerate(data)]
     elif isinstance(data, tuple):

--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -1,7 +1,7 @@
 import pandas as pd  # type: ignore
 import re
 import numpy as np  # type: ignore
-import h5py
+import h5py #type: ignore
 import os
 
 from arkouda import __version__

--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -1,0 +1,283 @@
+import pandas as pd  # type: ignore
+import re
+import numpy as np  # type: ignore
+import h5py
+import os
+
+from arkouda import __version__
+from arkouda.client_dtypes import BitVector, BitVectorizer, IPv4
+from arkouda.timeclass import Datetime, Timedelta
+from arkouda.pdarrayclass import attach_pdarray, pdarray
+from arkouda.pdarraysetops import concatenate as pdarrayconcatenate
+from arkouda.pdarraycreation import arange
+from arkouda.pdarraysetops import unique
+from arkouda.pdarrayIO import read_hdf
+from arkouda.client import get_config, get_mem_used
+from arkouda.groupbyclass import GroupBy, broadcast, coargsort
+from arkouda.infoclass import information, AllSymbols
+from arkouda.categorical import Categorical
+
+identity = lambda x: x
+
+
+def get_callback(x):
+    if type(x) in {Datetime, Timedelta, IPv4}:
+        return type(x)
+    elif hasattr(x, '_cast'):
+        return x._cast
+    elif type(x) == BitVector:
+        return BitVectorizer(width=x.width, reverse=x.reverse)
+    else:
+        return identity
+
+
+# TODO - moving this into arkouda, function name should probably be changed.
+def concatenate(items, ordered=True):
+    if len(items) > 0:
+        types = set([type(x) for x in items])
+        if len(types) != 1:
+            raise TypeError("Items must all have same type: {}".format(types))
+        t = types.pop()
+        if t == BitVector:
+            widths = set([x.width for x in items])
+            revs = set([x.reverse for x in items])
+            if len(widths) != 1 or len(revs) != 1:
+                raise TypeError("BitVectors must all have same width and direction")
+        callback = get_callback(list(items)[0])
+        if hasattr(t, 'concat'):
+            concat = t.concat
+        else:
+            concat = pdarrayconcatenate
+    else:
+        callback = identity
+        concat = pdarrayconcatenate
+    return callback(concat(items, ordered=ordered))
+
+
+def report_mem(pre=''):
+    cfg = get_config()
+    used = get_mem_used() / (cfg['numLocales']*cfg['physicalMemory'])
+    print(f"{pre} mem use: {get_mem_used()/(1024**4): .2f} TB ({used:.1%})")
+
+
+def register(a, name):
+    """
+    Register an arkouda object with a user-specified name. Backwards compatible
+    with earlier arkouda versions.
+    """
+    if pd.to_datetime(__version__.lstrip('v')) >= pd.to_datetime('2021.04.14'):
+        # New versions register in-place and don't need callback
+        cb = identity
+    else:
+        # Older versions return a new object that loses higher-level dtypes and must be re-converted
+        cb = get_callback(a)
+    if type(a) in {Datetime, Timedelta, BitVector, IPv4}:
+        # These classes wrap a pdarray, so two names must be updated
+        a = a.register(name)
+        # Get the registered name
+        n = a.name
+        # Re-convert object if necessary
+        reg = cb(a)
+        # Assign registered name to wrapper object
+        reg.name = n
+        # Assign same name to underlying pdarray
+        if type(a) in {Datetime, Timedelta}:
+            reg._data.name = n
+        else:
+            reg.values.name = n
+    else:
+        a = a.register(name)
+        reg = cb(a)
+    return reg
+
+
+def register_all(data, prefix, overwrite=True):
+    def sanitize(k):
+        return str(k).replace(' ', '_')
+    if overwrite:
+        att = attach_all(prefix)
+        for k in data:
+            ksan = sanitize(k)
+            if ksan in att:
+                att[ksan].unregister()
+    if isinstance(data, dict):
+        return {k:register(v, f'{prefix}{sanitize(k)}') for k, v in data.items()}
+    #TODO - once DataFrame is available uncomment the next 2 lines (PR #1139)
+    # elif isinstance(data, aku.DataFrame):
+    #    return aku.DataFrame({k:register(v, f'{prefix}{sanitize(k)}') for k, v in data.items()})
+    elif isinstance(data, list):
+        return [register(v, f'{prefix}{i}') for i, v in enumerate(data)]
+    elif isinstance(data, tuple):
+        return tuple([register(v, f'{prefix}{i}') for i, v in enumerate(data)])
+    elif isinstance(data, GroupBy):
+        data.permutation = register(data.permutation, f'{prefix}permutation')
+        data.segments = register(data.segments, f'{prefix}segments')
+        data.unique_keys = register_all(data.unique_keys, f'{prefix}unique_keys_')
+        return data
+    else:
+        raise TypeError(f"Cannot register objects of type {type(data)}")
+
+
+def attach_all(prefix):
+    pat = re.compile(prefix+'\w+')
+    res = pat.findall(information(AllSymbols))
+    return {k[len(prefix):]:attach_pdarray(k) for k in res}
+
+
+def unregister_all(prefix):
+    att = attach_all(prefix)
+    for v in att.values():
+        v.unregister()
+
+
+def enrich_inplace(data, keynames, aggregations, **kwargs):
+    # TO DO: validate reductions and values
+    try:
+        keys = data[keynames]
+    except (KeyError, TypeError):
+        keys = [data[k] for k in keynames]
+    g = GroupBy(keys, **kwargs)
+    for resname, (reduction, values) in aggregations.items():
+        try:
+            values = data[values]
+        except (KeyError, TypeError):
+            pass
+        if reduction == 'count':
+            pergroupval = g.count()[1]
+        else:
+            pergroupval = g.aggregate(values, reduction)[1]
+        data[resname] = g.broadcast(pergroupval, permute=True)
+
+
+def expand(size, segs, vals):
+    """
+    Expand an array with values placed into the indicated segments.
+
+    Parameters
+    ----------
+    size : ak.pdarray
+        The size of the array to be expanded
+    segs : ak.pdarray
+        The indices where the values should be placed
+    vals : ak.pdarray
+        The values to be placed in each segment
+
+    Returns
+    -------
+    pdarray
+        The expanded array.
+
+    Notes
+    -----
+    This function (with different order of arguments) is now in arkouda
+    proper as ak.broadcast. It is retained here for backwards compatibility.
+
+    """
+    return broadcast(segs, vals, size=size)
+
+
+def invert_permutation(perm):
+    """
+    Find the inverse of a permutation array.
+
+    Parameters
+    ----------
+    perm : ak.pdarray
+        The permutation array.
+
+    Returns
+    -------
+    ak.array
+        The inverse of the permutation array.
+
+    """
+    #TODO - look into the comment below
+    # I think this suffers from overflow errors on large arrays.
+    #if perm.sum() != (perm.size * (perm.size -1)) / 2:
+    #    raise ValueError("The indicated permutation is invalid.")
+    if unique(perm).size != perm.size:
+        raise ValueError("The array is not a permutation.")
+    return coargsort([perm, arange(0, perm.size)])
+
+
+def most_common(g, values):
+    """
+    Find the most common value for each key in a GroupBy object.
+
+    Parameters
+    ----------
+    g : ak.GroupBy
+        Grouping of keys
+    values : array-like
+        Values in which to find most common
+
+    Returns
+    -------
+    unique_keys : (list of) arrays
+        Unique key of each group
+    most_common_values : array-like
+        The most common value for each key
+    """
+    # Give each key an integer index
+    keyidx = g.broadcast(arange(g.unique_keys[0].size), permute=True)
+    # Annex values and group by (key, val)
+    bykeyval = GroupBy([keyidx, values])
+    # Count number of records for each (key, val)
+    (ki, uval), count = bykeyval.count()
+    # Group out value
+    bykey = GroupBy(ki, assume_sorted=True)
+    # Find the index of the most frequent value for each key
+    _, topidx = bykey.argmax(count)
+    # Gather the most frequent values
+    return uval[topidx]
+
+
+def arkouda_to_numpy(A: pdarray, tmp_dir: str='') -> np.ndarray:
+    """
+    Convert from arkouda to numpy using disk rather than sockets.
+    """
+    rng = np.random.randint(2**64, dtype=np.uint64)
+    tmp_dir = os.getcwd() if not tmp_dir else tmp_dir
+    A.save(f"{tmp_dir}/{rng}")
+    files = sorted(
+        f"{tmp_dir}/{f}"
+        for f in os.listdir(tmp_dir)
+        if f.startswith(str(rng))
+    )
+
+    B = np.zeros(A.size, dtype=np.int64)
+    i = 0
+    for file in files:
+        with h5py.File(file) as hf:
+            a = hf['array']
+            B[i:i+a.size] = a[:]
+            i += a.size
+        os.remove(file)
+
+    return B
+
+
+def numpy_to_arkouda(A: np.ndarray, tmp_dir: str = '') -> pdarray:
+    """
+    Convert from numpy to arkouda using disk rather than sockets.
+    """
+    rng = np.random.randint(2 ** 64, dtype=np.uint64)
+    tmp_dir = os.getcwd() if not tmp_dir else tmp_dir
+    with h5py.File(f'{tmp_dir}/{rng}.hdf5', 'w') as f:
+        arr = f.create_dataset('arr', (A.shape[0],), dtype='int64')
+        arr[:] = A[:]
+
+    B = read_hdf('arr', f'{tmp_dir}/{rng}.hdf5')
+    os.remove(f'{tmp_dir}/{rng}.hdf5')
+
+    return B
+
+
+def convert_if_categorical(values):
+    """
+    Convert a cetegorical array to strings for display
+    """
+
+    if isinstance(values, Categorical):
+        values = values.categories[values.codes]
+    return values

--- a/pydoc/usage/dataframe.rst
+++ b/pydoc/usage/dataframe.rst
@@ -68,6 +68,14 @@ Rename Columns
 ----------
 .. autofunction:: arkouda.DataFrame.rename
 
+Append
+----------
+.. autofunction:: akrouda.DataFrame.append
+
+Concatenate
+----------
+.. autofunction:: arkouda.DataFrame.concat
+
 Reset Indexes
 ----------
 .. autofunction:: arkouda.DataFrame.reset_index

--- a/tests/client_dtypes_test.py
+++ b/tests/client_dtypes_test.py
@@ -1,0 +1,104 @@
+import numpy as np
+from context import arkouda as ak
+from arkouda import client_dtypes
+from base_test import ArkoudaTest
+
+
+class ClientDTypeTests(ArkoudaTest):
+    """
+    Note: BitVector operations are not tested here because the class is only a wrapper on a pdarray to display as such.
+    The class does not actually store values as bit-values, it only converts to a bit representation for display.
+    Thus, pdarray testing covers these operations.
+    """
+
+    def test_BitVector_creation(self):
+        arr = ak.arange(4)
+        bv = ak.BitVector(arr, width=3)
+        self.assertIsInstance(bv, client_dtypes.BitVector)
+        self.assertListEqual(bv.to_ndarray().tolist(), ['...', '..|', '.|.', '.||'])
+
+        # Test reversed
+        arr = ak.arange(4)
+        bv = ak.BitVector(arr, width=3, reverse=True)
+        self.assertIsInstance(bv, client_dtypes.BitVector)
+        self.assertListEqual(bv.to_ndarray().tolist(), ['...', '|..', '.|.', '||.'])
+
+        #test use of vectorizer function
+        arr = ak.arange(4)
+        bvectorizer = ak.BitVectorizer(3)
+        bv = bvectorizer(arr)
+        self.assertIsInstance(bv, client_dtypes.BitVector)
+        self.assertListEqual(bv.to_ndarray().tolist(), ['...', '..|', '.|.', '.||'])
+
+        #fail on argument types
+        with self.assertRaises(TypeError):
+            bv = ak.BitVector(17, width=4)
+        arr = ak.array([1.1, 8.3])
+        with self.assertRaises(TypeError):
+            bv - ak.BitVector(arr)
+
+    def test_Field_creation(self):
+        values = ak.arange(4)
+        names = ['8', '4', '2', '1']
+        f = ak.Fields(values, names)
+        self.assertIsInstance(f, ak.Fields)
+        self.assertListEqual(f.to_ndarray().tolist(), ['---- (0)', '---1 (1)', '--2- (2)', '--21 (3)'])
+
+        #Named fields with reversed bit order
+        values = ak.array([0, 1, 5, 8, 12])
+        names = ['Bit1', 'Bit2', 'Bit3', 'Bit4']
+        f = ak.Fields(values, names, MSB_left=False, separator='//')
+        expected = [
+            '----//----//----//----// (0)',
+            'Bit1//----//----//----// (1)',
+            'Bit1//----//Bit3//----// (5)',
+            '----//----//----//Bit4// (8)',
+            '----//----//Bit3//Bit4// (12)'
+        ]
+        self.assertListEqual(f.to_ndarray().tolist(), expected)
+
+        values = ak.arange(8)
+        names = [f'Bit{x}' for x in range(65)]
+        with self.assertRaises(ValueError):
+            f = ak.Fields(values, names)
+
+        names = ['t', 't']
+        with self.assertRaises(ValueError):
+            f = ak.Fields(values, names)
+
+        names = ['t', '']
+        with self.assertRaises(ValueError):
+            f = ak.Fields(values, names)
+
+        names = ['abc', '123']
+        with self.assertRaises(ValueError):
+            f = ak.Fields(values, names, separator='abc')
+
+        with self.assertRaises(ValueError):
+            f = ak.Fields(values, names)
+
+        with self.assertRaises(ValueError):
+            f = ak.Fields(values, names, pad='|!~', separator='//')
+
+    def test_ipv4_creation(self):
+        ip_list = ak.array([3232235777])
+        ipv4 = ak.IPv4(ip_list)
+
+        self.assertIsInstance(ipv4, ak.IPv4)
+        self.assertListEqual(ipv4.to_ndarray().tolist(), ['192.168.1.1'])
+
+        with self.assertRaises(TypeError):
+            ipv4 = ak.IPv4('3232235777')
+        with self.assertRaises(TypeError):
+            ipv4 = ak.IPv4(ak.array([3232235777.177]))
+
+        ip_list = ak.array([3232235777])
+        ipv4 = ak.ip_address(ip_list)
+        self.assertIsInstance(ipv4, ak.IPv4)
+        self.assertListEqual(ipv4.to_ndarray().tolist(), ['192.168.1.1'])
+
+    def test_ipv4_normalization(self):
+        ip_list = ak.array([3232235777])
+        ipv4 = ak.IPv4(ip_list)
+        ip_as_int = ipv4.normalize('192.168.1.1')
+        self.assertEqual(3232235777, ip_as_int)

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -1,4 +1,5 @@
 import pandas
+import pandas as pd
 
 from base_test import ArkoudaTest
 from context import arkouda as ak
@@ -92,6 +93,67 @@ class DataFrameTest(ArkoudaTest):
         self.assertNotIn('userName', df.__str__())
         self.assertNotIn('userID', df.__str__())
         print(df.__str__())
+
+    def test_append(self):
+        username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+        userid = ak.array([111, 222, 111, 333, 222, 111])
+        item = ak.array([0, 0, 1, 1, 2, 0])
+        day = ak.array([5, 5, 6, 5, 6, 6])
+        amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
+        df = ak.DataFrame({'userName': username, 'userID': userid,
+                           'item': item, 'day': day, 'amount': amount})
+
+        username = ak.array(['John', 'Carol'])
+        userid = ak.array([444, 333])
+        item = ak.array([0, 2])
+        day = ak.array([1, 2])
+        amount = ak.array([0.5, 5.1])
+        df_toappend = ak.DataFrame({'userName': username, 'userID': userid,
+                           'item': item, 'day': day, 'amount': amount})
+
+        df.append(df_toappend)
+
+        username = ['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice', 'John', 'Carol']
+        userid = [111, 222, 111, 333, 222, 111, 444, 333]
+        item = [0, 0, 1, 1, 2, 0, 0, 2]
+        day = [5, 5, 6, 5, 6, 6, 1, 2]
+        amount = [0.5, 0.6, 1.1, 1.2, 4.3, 0.6, 0.5, 5.1]
+        ref_df = pd.DataFrame({'userName': username, 'userID': userid,
+                           'item': item, 'day': day, 'amount': amount})
+
+        #dataframe equality returns series with bool result for each row.
+        self.assertTrue(((ref_df == df.to_pandas()).all()).all())
+
+    def test_concat(self):
+        username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+        userid = ak.array([111, 222, 111, 333, 222, 111])
+        item = ak.array([0, 0, 1, 1, 2, 0])
+        day = ak.array([5, 5, 6, 5, 6, 6])
+        amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
+        df = ak.DataFrame({'userName': username, 'userID': userid,
+                           'item': item, 'day': day, 'amount': amount})
+
+        username = ak.array(['John', 'Carol'])
+        userid = ak.array([444, 333])
+        item = ak.array([0, 2])
+        day = ak.array([1, 2])
+        amount = ak.array([0.5, 5.1])
+        df_toappend = ak.DataFrame({'userName': username, 'userID': userid,
+                                    'item': item, 'day': day, 'amount': amount})
+
+        glued = ak.DataFrame.concat([df, df_toappend])
+
+        username = ['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice', 'John', 'Carol']
+        userid = [111, 222, 111, 333, 222, 111, 444, 333]
+        item = [0, 0, 1, 1, 2, 0, 0, 2]
+        day = [5, 5, 6, 5, 6, 6, 1, 2]
+        amount = [0.5, 0.6, 1.1, 1.2, 4.3, 0.6, 0.5, 5.1]
+        ref_df = pd.DataFrame({'userName': username, 'userID': userid,
+                               'item': item, 'day': day, 'amount': amount})
+
+        # dataframe equality returns series with bool result for each row.
+        self.assertTrue(((ref_df == glued.to_pandas()).all()).all())
+
 
     def test_head(self):
         username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -124,6 +124,22 @@ class DataFrameTest(ArkoudaTest):
         #dataframe equality returns series with bool result for each row.
         self.assertTrue(((ref_df == df.to_pandas()).all()).all())
 
+        userid = ak.array([444, 333])
+        item = ak.array([0, 2])
+        df_keyerror = ak.DataFrame({'user_id':userid, 'item':item})
+        with self.assertRaises(KeyError):
+            df.append(df_keyerror)
+
+        username = ak.array([111, 222, 111, 333, 222, 111])
+        userid = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+        item = ak.array([0, 0, 1, 1, 2, 0])
+        day = ak.array([5, 5, 6, 5, 6, 6])
+        amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
+        df_typeerror = ak.DataFrame({'userName': username, 'userID': userid,
+                           'item': item, 'day': day, 'amount': amount})
+        with self.assertRaises(TypeError):
+            df.append(df_typeerror)
+
     def test_concat(self):
         username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
         userid = ak.array([111, 222, 111, 333, 222, 111])
@@ -153,6 +169,22 @@ class DataFrameTest(ArkoudaTest):
 
         # dataframe equality returns series with bool result for each row.
         self.assertTrue(((ref_df == glued.to_pandas()).all()).all())
+
+        userid = ak.array([444, 333])
+        item = ak.array([0, 2])
+        df_keyerror = ak.DataFrame({'user_id': userid, 'item': item})
+        with self.assertRaises(KeyError):
+            ak.DataFrame.concat([df, df_keyerror])
+
+        username = ak.array([111, 222, 111, 333, 222, 111])
+        userid = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+        item = ak.array([0, 0, 1, 1, 2, 0])
+        day = ak.array([5, 5, 6, 5, 6, 6])
+        amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
+        df_typeerror = ak.DataFrame({'userName': username, 'userID': userid,
+                                     'item': item, 'day': day, 'amount': amount})
+        with self.assertRaises(TypeError):
+            ak.DataFrame.concat([df, df_typeerror])
 
 
     def test_head(self):


### PR DESCRIPTION
This PR (closes #1126):

- Moved `akutil/dtypes.py` and `akutil/util.py` into `arkouda`
- Added `.append()` and `.concat()` to `ak.DataFrame`
- Unit Tests for `arkouda/client_dtypes.py`. 
- Unit tests added to `tests/dataframe_tests.py` updated with tests for `append()` and `concat()`.
- `ak.DataFrame` documentation updated to include `append()` and `concat()` functionality.

Currently, the dtypes being added are going to remain strictly client-side. This may change in the future, but for now they are being kept in `arkouda/client_dtypes.py` to differentiate them from server-side dtypes.
