### PR TITLE
Get Parquet string reading offsets in C++ function

### DIFF
--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -39,8 +39,10 @@ extern "C" {
                            const char* colname, int64_t numElems, int64_t batchSize,
                            char** errMsg);
 
-  int cpp_getStringColumnNumBytes(const char* filename, const char* colname, char** errMsg);
-  int c_getStringColumnNumBytes(const char* filename, const char* colname, char** errMsg);
+  int cpp_getStringColumnNumBytes(const char* filename, const char* colname,
+                                  void* chpl_offsets, char** errMsg);
+  int c_getStringColumnNumBytes(const char* filename, const char* colname,
+                                void* chpl_offsets, char** errMsg);
 
   int c_getType(const char* filename, const char* colname, char** errMsg);
   int cpp_getType(const char* filename, const char* colname, char** errMsg);

--- a/test/UnitTestParquetCpp.chpl
+++ b/test/UnitTestParquetCpp.chpl
@@ -163,7 +163,7 @@ proc testGetDsets(filename) {
 
 proc testReadStrings(filename, dsetname) {
   extern proc c_readColumnByName(filename, chpl_arr, colNum, numElems, batchSize,  errMsg): int;
-  extern proc c_getStringColumnNumBytes(filename, colname, errMsg): int;
+  extern proc c_getStringColumnNumBytes(filename, colname, offsets, errMsg): int;
   extern proc c_getNumRows(chpl_str, err): int;
 
   extern proc c_free_string(a);
@@ -174,8 +174,9 @@ proc testReadStrings(filename, dsetname) {
   }
 
   var size = c_getNumRows(filename, c_ptrTo(errMsg));
+  var offsets: [0..#size] int;
   
-  var byteSize = c_getStringColumnNumBytes(filename, dsetname, c_ptrTo(errMsg));
+  var byteSize = c_getStringColumnNumBytes(filename, dsetname, c_ptrTo(offsets[0]), c_ptrTo(errMsg));
   if byteSize < 0 {
     var chplMsg;
     try! chplMsg = createStringWithNewBuffer(errMsg, strlen(errMsg));


### PR DESCRIPTION
Previously, Parquet string files that had been read in were
calculating their offset arrays with the `segmentedCalcOffsets`
function from `GenSymIO.chpl`, but that function is not optimized
and was resulting in large amounts of communication, meaning that
performance decreased as more nodes were added.

This PR switches the computation of the offsets array to happen
at the point where the byte sizes are determined from the file,
resulting in much better scaling.

Here are some performance numbers calculated on a CS using
50 files of 1 million uniformly distributed string elements:

nodes | master  | this branch |
----- | ------: | ----------: |
1     | 2.366 s | 0.3248 s    |
2     | minutes | 0.2899 s    |
4     | minutes | 0.2625 s    |
8     | minutes | 0.2135 s    |