### PR TITLE
Closes #1165 drop on axis

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -407,20 +407,16 @@ class DataFrame(UserDict):
         last_idx = -1
         # sort to ensure we go in ascending order.
         keys.sort()
-        for i, k in enumerate(keys):
+        for k in keys:
             if not isinstance(k, int):
                 raise TypeError("Index keys must be integers.")
-            pda = self.index[(last_idx+1):k:1]
-            if pda.size > 0:
-                idx_list.append(pda)
+            idx_list.append(self.index[(last_idx+1):k])
             last_idx = k
 
-        pda = self.index[(last_idx+1):]
-        if pda.size > 0:
-            idx_list.append(pda)
+        idx_list.append(self.index[(last_idx+1):])
 
         idx_to_keep = concatenate(idx_list)
-        for key, val in self.items():
+        for key in self.keys():
             # using the UserDict.__setitem__ here because we know all the columns are being reset to the same size.
             # This avoids the size checks we would do when only setting a single column
             UserDict.__setitem__(self, key, self[key][idx_to_keep])
@@ -433,8 +429,8 @@ class DataFrame(UserDict):
         ----------
         keys : str, int or list
             The labels to be dropped on the given axis
-        axis : int
-            The axis on which to drop from. 0 - drop rows, 1 - drop columns
+        axis : int or str
+            The axis on which to drop from. 0/'index' - drop rows, 1/'columns' - drop columns
 
         Examples
         ----------
@@ -450,10 +446,10 @@ class DataFrame(UserDict):
         if isinstance(keys, str) or isinstance(keys, int):
             keys = [keys]
 
-        if axis == 0:
+        if axis == 0 or axis == 'index':
             #drop a row
             self._drop_row(keys)
-        elif axis == 1:
+        elif axis == 1 or axis == 'columns':
             #drop column
             self._drop_column(keys)
         else:

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -409,7 +409,7 @@ class DataFrame(UserDict):
         keys.sort()
         for i, k in enumerate(keys):
             if not isinstance(k, int):
-                raise ValueError("Index keys must be integers.")
+                raise TypeError("Index keys must be integers.")
             pda = self.index[(last_idx+1):k:1]
             if pda.size > 0:
                 idx_list.append(pda)
@@ -435,6 +435,16 @@ class DataFrame(UserDict):
             The labels to be dropped on the given axis
         axis : int
             The axis on which to drop from. 0 - drop rows, 1 - drop columns
+
+        Examples
+        ----------
+        Drop column
+        >>> df.drop('col_name', axis=1)
+
+        Drop Row
+        >>> df.drop(1)
+        or
+        >>> df.drop(1, axis=0)
         """
 
         if isinstance(keys, str) or isinstance(keys, int):

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -453,7 +453,7 @@ class DataFrame(UserDict):
             #drop column
             self._drop_column(keys)
         else:
-            raise ValueError("axis must be 0 or 1")
+            raise ValueError(f"No axxis named {axis} for object type DataFrame")
 
         # If the dataframe just became empty...
         if len(self._columns) == 1:

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -453,7 +453,7 @@ class DataFrame(UserDict):
             #drop column
             self._drop_column(keys)
         else:
-            raise ValueError(f"No axxis named {axis} for object type DataFrame")
+            raise ValueError(f"No axis named {axis} for object type DataFrame")
 
         # If the dataframe just became empty...
         if len(self._columns) == 1:

--- a/pydoc/usage/dataframe.rst
+++ b/pydoc/usage/dataframe.rst
@@ -34,6 +34,10 @@ Features
 ==========
 ``DataFrames`` support the majority of functionality offered by ``pandas.DataFrame``.
 
+Drop
+---------
+.. autofunction:: arkouda.DataFrame.drop
+
 GroupBy
 ----------
 .. autofunction:: arkouda.DataFrame.groupby

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -1,8 +1,29 @@
-import pandas
-import pandas as pd
+import pandas as pd  # type: ignore
 
 from base_test import ArkoudaTest
 from context import arkouda as ak
+
+def build_ak_df():
+    username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+    userid = ak.array([111, 222, 111, 333, 222, 111])
+    item = ak.array([0, 0, 1, 1, 2, 0])
+    day = ak.array([5, 5, 6, 5, 6, 6])
+    amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
+    df = ak.DataFrame({'userName': username, 'userID': userid,
+                       'item': item, 'day': day, 'amount': amount})
+    return df
+
+
+def build_pd_df():
+    username = ['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice']
+    userid = [111, 222, 111, 333, 222, 111]
+    item = [0, 0, 1, 1, 2, 0]
+    day = [5, 5, 6, 5, 6, 6]
+    amount = [0.5, 0.6, 1.1, 1.2, 4.3, 0.6]
+    df = pd.DataFrame({'userName': username, 'userID': userid,
+                       'item': item, 'day': day, 'amount': amount})
+    return df
+
 
 class DataFrameTest(ArkoudaTest):
     def test_dataframe_creation(self):
@@ -22,18 +43,31 @@ class DataFrameTest(ArkoudaTest):
         self.assertEqual(len(df), 6)
 
     def test_drop(self):
-        username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
-        userid = ak.array([111, 222, 111, 333, 222, 111])
-        item = ak.array([0, 0, 1, 1, 2, 0])
-        day = ak.array([5, 5, 6, 5, 6, 6])
-        amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
-        df = ak.DataFrame({'userName': username, 'userID': userid,
-                           'item': item, 'day': day, 'amount': amount})
-        df.drop('userName')
-        self.assertEquals(df.__str__(), ak.DataFrame({'userID': userid,
-                                           'item': item, 'day': day, 'amount': amount}).__str__())
+        # create an arkouda df.
+        df = build_ak_df()
+        # create pandas df to validate functionality against
+        pd_df = build_pd_df()
 
+        # Test dropping columns
+        df.drop('userName', axis=1)
+        pd_df.drop(labels=['userName'], axis=1, inplace=True)
+
+        self.assertTrue(((df.to_pandas() == pd_df).all()).all())
+
+        # verify that the index cannot be dropped from ak.DataFrame
         with self.assertRaises(KeyError):
+            df.drop('index', axis=1)
+
+        # Test dropping rows
+        df.drop([0, 2, 5])
+        # pandas retains original indexes when dropping rows, need to reset to line up with arkouda
+        pd_df.drop(labels=[0, 2, 5], inplace=True)
+        pd_df.reset_index(drop=True, inplace=True)
+
+        self.assertTrue(((df.to_pandas() == pd_df).all()).all())
+
+        # verify that index keys must be ints
+        with self.assertRaises(TypeError):
             df.drop('index')
 
     def test_drop_duplicates(self):
@@ -253,7 +287,7 @@ class DataFrameTest(ArkoudaTest):
             ['Bob', 222, 2, 6, 4.3],
             ['Alice', 111, 0, 6, 0.6]
         ]
-        test_df = pandas.DataFrame(data, columns=['userName', 'userID', 'item', 'day', 'amount'])
+        test_df = pd.DataFrame(data, columns=['userName', 'userID', 'item', 'day', 'amount'])
         self.assertTrue(pddf.equals(test_df))
 
 

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -70,6 +70,10 @@ class DataFrameTest(ArkoudaTest):
         with self.assertRaises(TypeError):
             df.drop('index')
 
+        #verify axis can only be 0 or 1
+        with self.assertRaises(ValueError):
+            df.drop('amount', 15)
+
     def test_drop_duplicates(self):
         username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
         userid = ak.array([111, 222, 111, 333, 222, 111])


### PR DESCRIPTION
This PR (closes #1165):

Pandas `DataFrame.drop()` utilizes an `axis` parameter to trigger drops on rows or columns. This functionality has been added to Arkouda here.

- `axis` should be 0 or 1. 0 = rows, 1 = columns.
- Tests have been added to: validate column drop using axis param, validate row drop, validate exception cases are caught as expected.
- Documentation has been updated to include `.drop()` for `DataFrame`. 

For testing I added functions to build an `ak.DataFrame` and a `pd.DataFrame`. I only implemented this for drop because there is an existing issue in to handle this for all tests.

This functionality is currently only available in-place at this time. 