### PR TITLE
Add UsedModules.cfg to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ test/IOSpeedTestMsg.good
 test/NanSpeedTest.good
 test/StringArgsortSpeedTest.good
 test/file_LOCALE0000
+UsedModules.cfg


### PR DESCRIPTION
The UsedModules.cfg file, which is generated from --saveUsedModules
was not being ignored by git, and I don't think we would ever want
a UsedModules.cfg pushed into the repo, so moving it into the
gitignore will resolve any annoyance from having to selectively not
include that file.