### PR TITLE
Remove extra copy of entire file for Parquet reading

### DIFF
--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -194,6 +194,9 @@ int cpp_readColumnByName(const char* filename, void* chpl_arr, const char* colna
       reader->Skip(startIdx);
 
       while (reader->HasNext() && i < numElems) {
+        // Only read up to numElems, not over
+        if((numElems - i) < batchSize)
+          batchSize = numElems - i;
         (void)reader->ReadBatch(batchSize, nullptr, nullptr, &chpl_ptr[i], &values_read);
         i+=values_read;
       }
@@ -205,6 +208,8 @@ int cpp_readColumnByName(const char* filename, void* chpl_arr, const char* colna
 
       int32_t* tmpArr = (int32_t*)malloc(batchSize * sizeof(int32_t));
       while (reader->HasNext() && i < numElems) {
+        if((numElems - i) < batchSize)
+          batchSize = numElems - i;
         // Can't read directly into chpl_ptr because it is int64
         (void)reader->ReadBatch(batchSize, nullptr, nullptr, tmpArr, &values_read);
         for (int64_t j = 0; j < values_read; j++)
@@ -218,7 +223,9 @@ int cpp_readColumnByName(const char* filename, void* chpl_arr, const char* colna
         static_cast<parquet::BoolReader*>(column_reader.get());
       reader->Skip(startIdx);
 
-      while (reader->HasNext()) {
+      while (reader->HasNext() && i < numElems) {
+        if((numElems - i) < batchSize)
+          batchSize = numElems - i;
         (void)reader->ReadBatch(batchSize, nullptr, nullptr, &chpl_ptr[i], &values_read);
         i+=values_read;
       }
@@ -245,6 +252,8 @@ int cpp_readColumnByName(const char* filename, void* chpl_arr, const char* colna
 
       float* tmpArr = (float*)malloc(batchSize * sizeof(float));
       while (reader->HasNext() && i < numElems) {
+        if((numElems - i) < batchSize)
+          batchSize = numElems - i;
         // Can't read directly into chpl_ptr because it is a double
         (void)reader->ReadBatch(batchSize, nullptr, nullptr, tmpArr, &values_read);
         for (int64_t j = 0; j < values_read; j++)
@@ -259,6 +268,8 @@ int cpp_readColumnByName(const char* filename, void* chpl_arr, const char* colna
       reader->Skip(startIdx);
 
       while (reader->HasNext() && i < numElems) {
+        if((numElems - i) < batchSize)
+          batchSize = numElems - i;
         (void)reader->ReadBatch(batchSize, nullptr, nullptr, &chpl_ptr[i], &values_read);
         i+=values_read;
       }

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -106,7 +106,7 @@ int cpp_getType(const char* filename, const char* colname, char** errMsg) {
     return ARROWUNDEFINED;
 }
 
-int cpp_getStringColumnNumBytes(const char* filename, const char* colname, void* chpl_offsets, char** errMsg) {
+int cpp_getStringColumnNumBytes(const char* filename, const char* colname, void* chpl_offsets, int64_t numElems, int64_t startIdx, char** errMsg) {
   int64_t ty = cpp_getType(filename, colname, errMsg);
   auto offsets = (int64_t*)chpl_offsets;
 
@@ -139,12 +139,15 @@ int cpp_getStringColumnNumBytes(const char* filename, const char* colname, void*
       column_reader = row_group_reader->Column(idx);
       parquet::ByteArrayReader* ba_reader =
           static_cast<parquet::ByteArrayReader*>(column_reader.get());
+      ba_reader -> Skip(startIdx);
 
-      while (ba_reader->HasNext()) {
+      int64_t numRead = 0;
+      while (ba_reader->HasNext() && numRead < numElems) {
         parquet::ByteArray value;
         (void)ba_reader->ReadBatch(1, nullptr, nullptr, &value, &values_read);
         size += value.len + 1; // add 1 to account for zero that will be added in Chapel array
         offsets[i++] = value.len + 1;
+        numRead += values_read;
       }
     }
     return size;
@@ -152,7 +155,7 @@ int cpp_getStringColumnNumBytes(const char* filename, const char* colname, void*
   return ARROWUNDEFINED;
 }
 
-int cpp_readColumnByName(const char* filename, void* chpl_arr, const char* colname, int64_t numElems, int64_t batchSize, char** errMsg) {
+int cpp_readColumnByName(const char* filename, void* chpl_arr, const char* colname, int64_t numElems, int64_t startIdx, int64_t batchSize, char** errMsg) {
   int64_t ty = cpp_getType(filename, colname, errMsg);
   
   std::unique_ptr<parquet::ParquetFileReader> parquet_reader =
@@ -188,8 +191,9 @@ int cpp_readColumnByName(const char* filename, void* chpl_arr, const char* colna
       auto chpl_ptr = (int64_t*)chpl_arr;
       parquet::Int64Reader* reader =
         static_cast<parquet::Int64Reader*>(column_reader.get());
+      reader->Skip(startIdx);
 
-      while (reader->HasNext()) {
+      while (reader->HasNext() && i < numElems) {
         (void)reader->ReadBatch(batchSize, nullptr, nullptr, &chpl_ptr[i], &values_read);
         i+=values_read;
       }
@@ -197,9 +201,10 @@ int cpp_readColumnByName(const char* filename, void* chpl_arr, const char* colna
       auto chpl_ptr = (int64_t*)chpl_arr;
       parquet::Int32Reader* reader =
         static_cast<parquet::Int32Reader*>(column_reader.get());
+      reader->Skip(startIdx);
 
       int32_t* tmpArr = (int32_t*)malloc(batchSize * sizeof(int32_t));
-      while (reader->HasNext()) {
+      while (reader->HasNext() && i < numElems) {
         // Can't read directly into chpl_ptr because it is int64
         (void)reader->ReadBatch(batchSize, nullptr, nullptr, tmpArr, &values_read);
         for (int64_t j = 0; j < values_read; j++)
@@ -211,6 +216,7 @@ int cpp_readColumnByName(const char* filename, void* chpl_arr, const char* colna
       auto chpl_ptr = (bool*)chpl_arr;
       parquet::BoolReader* reader =
         static_cast<parquet::BoolReader*>(column_reader.get());
+      reader->Skip(startIdx);
 
       while (reader->HasNext()) {
         (void)reader->ReadBatch(batchSize, nullptr, nullptr, &chpl_ptr[i], &values_read);
@@ -218,12 +224,13 @@ int cpp_readColumnByName(const char* filename, void* chpl_arr, const char* colna
       }
     } else if(ty == ARROWSTRING) {
       auto chpl_ptr = (unsigned char*)chpl_arr;
-      parquet::ByteArrayReader* ba_reader =
+      parquet::ByteArrayReader* reader =
         static_cast<parquet::ByteArrayReader*>(column_reader.get());
+      reader->Skip(startIdx);
 
-      while (ba_reader->HasNext()) {
+      while (reader->HasNext() && i < numElems) {
         parquet::ByteArray value;
-        (void)ba_reader->ReadBatch(1, nullptr, nullptr, &value, &values_read);
+        (void)reader->ReadBatch(1, nullptr, nullptr, &value, &values_read);
         for(int j = 0; j < value.len; j++) {
           chpl_ptr[i] = value.ptr[j];
           i++;
@@ -234,9 +241,10 @@ int cpp_readColumnByName(const char* filename, void* chpl_arr, const char* colna
       auto chpl_ptr = (double*)chpl_arr;
       parquet::FloatReader* reader =
         static_cast<parquet::FloatReader*>(column_reader.get());
+      reader->Skip(startIdx);
 
       float* tmpArr = (float*)malloc(batchSize * sizeof(float));
-      while (reader->HasNext()) {
+      while (reader->HasNext() && i < numElems) {
         // Can't read directly into chpl_ptr because it is a double
         (void)reader->ReadBatch(batchSize, nullptr, nullptr, tmpArr, &values_read);
         for (int64_t j = 0; j < values_read; j++)
@@ -248,8 +256,9 @@ int cpp_readColumnByName(const char* filename, void* chpl_arr, const char* colna
       auto chpl_ptr = (double*)chpl_arr;
       parquet::DoubleReader* reader =
         static_cast<parquet::DoubleReader*>(column_reader.get());
+      reader->Skip(startIdx);
 
-      while (reader->HasNext()) {
+      while (reader->HasNext() && i < numElems) {
         (void)reader->ReadBatch(batchSize, nullptr, nullptr, &chpl_ptr[i], &values_read);
         i+=values_read;
       }
@@ -405,8 +414,8 @@ extern "C" {
     return cpp_getNumRows(chpl_str, errMsg);
   }
 
-  int c_readColumnByName(const char* filename, void* chpl_arr, const char* colname, int64_t numElems, int64_t batchSize, char** errMsg) {
-    return cpp_readColumnByName(filename, chpl_arr, colname, numElems, batchSize, errMsg);
+  int c_readColumnByName(const char* filename, void* chpl_arr, const char* colname, int64_t numElems, int64_t startIdx, int64_t batchSize, char** errMsg) {
+    return cpp_readColumnByName(filename, chpl_arr, colname, numElems, startIdx, batchSize, errMsg);
   }
 
   int c_getType(const char* filename, const char* colname, char** errMsg) {
@@ -422,8 +431,8 @@ extern "C" {
                                     errMsg);
   }
 
-  int c_getStringColumnNumBytes(const char* filename, const char* colname, void* chpl_offsets, char** errMsg) {
-    return cpp_getStringColumnNumBytes(filename, colname, chpl_offsets, errMsg);
+  int c_getStringColumnNumBytes(const char* filename, const char* colname, void* chpl_offsets, int64_t numElems, int64_t startIdx, char** errMsg) {
+    return cpp_getStringColumnNumBytes(filename, colname, chpl_offsets, numElems, startIdx, errMsg);
   }
 
   const char* c_getVersionInfo(void) {

--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -33,16 +33,16 @@ extern "C" {
   int64_t cpp_getNumRows(const char*, char** errMsg);
 
   int c_readColumnByName(const char* filename, void* chpl_arr,
-                         const char* colname, int64_t numElems, int64_t batchSize,
-                         char** errMsg);
+                         const char* colname, int64_t numElems, int64_t startIdx,
+                         int64_t batchSize, char** errMsg);
   int cpp_readColumnByName(const char* filename, void* chpl_arr,
-                           const char* colname, int64_t numElems, int64_t batchSize,
-                           char** errMsg);
+                           const char* colname, int64_t numElems, int64_t startIdx,
+                           int64_t batchSize, char** errMsg);
 
   int cpp_getStringColumnNumBytes(const char* filename, const char* colname,
-                                  void* chpl_offsets, char** errMsg);
+                                  void* chpl_offsets, int64_t numElems, int64_t startIdx, char** errMsg);
   int c_getStringColumnNumBytes(const char* filename, const char* colname,
-                                void* chpl_offsets, char** errMsg);
+                                void* chpl_offsets, int64_t numElems, int64_t startIdx, char** errMsg);
 
   int c_getType(const char* filename, const char* colname, char** errMsg);
   int cpp_getType(const char* filename, const char* colname, char** errMsg);

--- a/test/UnitTestParquetCpp.chpl
+++ b/test/UnitTestParquetCpp.chpl
@@ -3,7 +3,7 @@ use UnitTest;
 use TestBase;
 
 proc testReadWrite(filename: c_string, dsetname: c_string, size: int) {
-  extern proc c_readColumnByName(filename, chpl_arr, colNum, numElems, batchSize, errMsg): int;
+  extern proc c_readColumnByName(filename, chpl_arr, colNum, numElems, startIdx, batchSize, errMsg): int;
   extern proc c_writeColumnToParquet(filename, chpl_arr, colnum,
                                      dsetname, numelems, rowGroupSize, compressed,
                                      dtype, errMsg): int;
@@ -26,7 +26,7 @@ proc testReadWrite(filename: c_string, dsetname: c_string, size: int) {
 
   var b: [0..#size] int;
 
-  if(c_readColumnByName(filename, c_ptrTo(b), dsetname, size, 10000, c_ptrTo(errMsg)) < 0) {
+  if(c_readColumnByName(filename, c_ptrTo(b), dsetname, size, 0, 10000, c_ptrTo(errMsg)) < 0) {
     var chplMsg;
     try! chplMsg = createStringWithNewBuffer(errMsg, strlen(errMsg));
     writeln(chplMsg);
@@ -41,7 +41,7 @@ proc testReadWrite(filename: c_string, dsetname: c_string, size: int) {
 }
 
 proc testInt32Read() {
-  extern proc c_readColumnByName(filename, chpl_arr, colNum, numElems, batchSize, errMsg): int;
+  extern proc c_readColumnByName(filename, chpl_arr, colNum, numElems, startIdx, batchSize, errMsg): int;
   extern proc c_free_string(a);
   extern proc strlen(a): int;
   var errMsg: c_ptr(uint(8));
@@ -54,7 +54,7 @@ proc testInt32Read() {
   for i in 0..#50 do expected[i] = i;
   
   if(c_readColumnByName("resources/int32.parquet".c_str(), c_ptrTo(a),
-                        "array".c_str(), 50, 1, c_ptrTo(errMsg)) < 0) {
+                        "array".c_str(), 50, 0, 1, c_ptrTo(errMsg)) < 0) {
     var chplMsg;
     try! chplMsg = createStringWithNewBuffer(errMsg, strlen(errMsg));
     writeln(chplMsg);
@@ -162,7 +162,7 @@ proc testGetDsets(filename) {
 }
 
 proc testReadStrings(filename, dsetname) {
-  extern proc c_readColumnByName(filename, chpl_arr, colNum, numElems, batchSize,  errMsg): int;
+  extern proc c_readColumnByName(filename, chpl_arr, colNum, numElems, startIdx, batchSize,  errMsg): int;
   extern proc c_getStringColumnNumBytes(filename, colname, offsets, errMsg): int;
   extern proc c_getNumRows(chpl_str, err): int;
 
@@ -185,7 +185,7 @@ proc testReadStrings(filename, dsetname) {
 
   var a: [0..#byteSize] uint(8);
 
-  if(c_readColumnByName(filename, c_ptrTo(a), dsetname, 3, 1, c_ptrTo(errMsg)) < 0) {
+  if(c_readColumnByName(filename, c_ptrTo(a), dsetname, 3, 0, 1, c_ptrTo(errMsg)) < 0) {
     var chplMsg;
     try! chplMsg = createStringWithNewBuffer(errMsg, strlen(errMsg));
     writeln(chplMsg);


### PR DESCRIPTION
Previously, Parquet was having each node read the entire file of
any file that had an intersection with its local domain into a
temporary array and then assigning that local array to the
distributed array, which was resulting in extra communication
as well as keeping around a copy of the entire file, which would
mean that memory footprints on each node were much higher than
they needed to be.

This PR switches that to instead read directly into the local
portion of the distributed array and only the necessary number
of elements, skipping to the offset location of each file.

Here are some performance numbers collected on a 16-node-cs-hdr
using the `parquetIO` benchmark:

locales | master | this branch
-- | -- | --
1 | 2.18 GiB/s | 2.34 GiB/s
2 | 4.04 GiB/s | 4.71 GiB/s
4 | 7.45 GiB/s | 8.80 GiB/s
8 | 14.62 GiB/s | 16.67 GiB/s
16 | 27.67 GiB/s | 32.50 GiB/s

String reading: 
locales | master | this branch
-- | -- | --
1 | 1.34 GiB/s | 2.53 GiB/s
2 | 1.61 GiB/s | 2.77 GiB/s
4 | 1.75 GiB/s | 2.97 GiB/s
8 | 1.85 GiB/s | 2.71 GiB/s
16 | 1.86 GiB/s | 3.01 GiB/s