### PR TITLE
Closes #1128 series/index into arkouda

### DIFF
--- a/arkouda/__init__.py
+++ b/arkouda/__init__.py
@@ -21,4 +21,6 @@ from arkouda.infoclass import *
 from arkouda.segarray import *
 from arkouda.dataframe import *
 from arkouda.row import *
+from arkouda.index import *
+from arkouda.series import *
 

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -10,7 +10,7 @@ from arkouda.pdarrayclass import pdarray
 from arkouda.categorical import Categorical
 from arkouda.strings import Strings
 from arkouda.pdarraycreation import arange, array
-from arkouda.groupbyclass import GroupBy
+from arkouda.groupbyclass import GroupBy as akGroupBy
 from arkouda.pdarraysetops import concatenate, unique, intersect1d, in1d
 from arkouda.pdarrayIO import save_all
 from arkouda.dtypes import int64 as akint64
@@ -20,6 +20,7 @@ from arkouda.numeric import where
 from arkouda.client import maxTransferBytes
 from arkouda.row import Row
 from arkouda.alignment import in1dmulti
+from arkouda.series import Series
 
 # This is necessary for displaying DataFrames with BitVector columns,
 # because pandas _html_repr automatically truncates the number of displayed bits
@@ -38,6 +39,46 @@ def groupby_operators(cls):
     for name in ['all', 'any', 'argmax', 'argmin', 'max', 'mean', 'min', 'nunique', 'prod', 'sum', 'OR', 'AND', 'XOR']:
         setattr(cls, name, cls._make_aggop(name))
     return cls
+
+
+@groupby_operators
+class GroupBy:
+    """A DataFrame that has been grouped by a subset of columns"""
+
+    def __init__(self, gb, df):
+        self.gb = gb
+        self.df = df
+        for attr in ['nkeys', 'size', 'permutation', 'unique_keys', 'segments']:
+            setattr(self, attr, getattr(gb, attr))
+
+    @classmethod
+    def _make_aggop(cls, opname):
+        def aggop(self, colname):
+            return Series(self.gb.aggregate(self.df.data[colname], opname))
+
+        return aggop
+
+    def count(self):
+        return Series(self.gb.count())
+
+    def broadcast(self, x, permute=True):
+        """Fill each group’s segment with a constant value.
+
+        Parameters
+        ----------
+
+        x :  Either a Series or a pdarray
+
+        Returns
+        -------
+        A aku.Series with the Index of the original frame and the values of the broadcast.
+        """
+
+        if isinstance(x, Series):
+            data = self.gb.broadcast(x.values, permute=permute)
+        else:
+            data = self.gb.broadcast(x, permute=permute)
+        return Series(data=data, index=self.df['index'])
 
 
 """
@@ -489,14 +530,14 @@ class DataFrame(UserDict):
         if len(subset) == 1:
             if not subset[0] in self.data:
                 raise KeyError("{} is not a column in the DataFrame.".format(subset[0]))
-            _ = GroupBy(self.data[subset[0]])
+            _ = akGroupBy(self.data[subset[0]])
 
         else:
             for col in subset:
                 if col not in self.data:
                     raise KeyError("{} is not a column in the DataFrame.".format(subset[0]))
 
-            _ = GroupBy([self.data[col] for col in subset])
+            _ = akGroupBy([self.data[col] for col in subset])
 
         if keep == 'last':
             _segment_ends = concatenate([_.segments[1:] - 1, array([_.permutation.size - 1])])
@@ -849,12 +890,9 @@ class DataFrame(UserDict):
             cols = self.data[keys[0]]
         else:
             cols = [self.data[col] for col in keys]
-        gb = GroupBy(cols)
+        gb = akGroupBy(cols)
         if use_series:
-            # TODO - remove the error and implement once series is configured
-            #	gb = GroupBy(gb, self)
-            raise NotImplementedError("akutil GroupBy functionality using series has not yet been implemented in "
-                                      "Arkouda. For updates, please visit https://github.com/Bears-R-Us/arkouda/issues/1128")
+            gb = GroupBy(gb, self)
         return gb
 
     def memory_usage(self, unit='GB'):
@@ -1294,7 +1332,7 @@ def intersect(a, b, positions=True, unique=False):
             hash1 = concatenate([hash_a01, hash_b01])
 
             # Group by the unique hashes
-            gb = GroupBy([hash0, hash1])
+            gb = akGroupBy([hash0, hash1])
             val, cnt = gb.count()
 
             # Hash counts, in groupby order
@@ -1317,8 +1355,8 @@ def intersect(a, b, positions=True, unique=False):
 
         # a and b may have duplicate entries, so get the unique hash values
         else:
-            gba = GroupBy([hash_a00, hash_a01])
-            gbb = GroupBy([hash_b00, hash_b01])
+            gba = akGroupBy([hash_a00, hash_a01])
+            gbb = akGroupBy([hash_b00, hash_b01])
 
             # Take the unique keys as the hash we'll work with
             a0, a1 = gba.unique_keys
@@ -1327,7 +1365,7 @@ def intersect(a, b, positions=True, unique=False):
             hash1 = concatenate([a1, b1])
 
             # Group by the unique hashes
-            gb = GroupBy([hash0, hash1])
+            gb = akGroupBy([hash0, hash1])
             val, cnt = gb.count()
 
             # Hash counts, in groupby order

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -1,0 +1,203 @@
+import pandas as pd  # type: ignore
+
+from arkouda.pdarrayclass import pdarray
+from arkouda.pdarraycreation import arange, ones
+from arkouda.pdarraysetops import argsort, in1d, unique
+from arkouda.sorting import coargsort
+from arkouda.dtypes import int64, float64, bool
+from arkouda.series import Series
+from arkouda.util import register, convert_if_categorical, concatenate, get_callback
+from arkouda.groupbyclass import GroupBy
+from arkouda.alignment import in1dmulti
+
+class Index:
+    def __init__(self,index):
+        self.index = index
+        self.size = index.size
+
+    def __getitem__(self,key):
+        if type(key) == Series:
+            key = key.values
+        return Index(self.index[key])
+
+    def __repr__(self):
+        return repr(self.index)
+
+    def __len__(self):
+        return len(self.index)
+
+    def __eq__(self,v):
+        return self.index == v
+
+    @staticmethod
+    def factory(index):
+        t = type(index)
+        if isinstance(index, Index):
+            return index
+        elif t != list and t != tuple:
+            return Index(index)
+        else:
+            return MultiIndex(index)
+
+    def to_pandas(self):
+        val = convert_if_categorical(self.index)
+        return val.to_ndarray()
+
+    def set_dtype(self, dtype):
+        """Change the data type of the index
+
+        Currently only aku.ip_address and ak.array are supported.
+        """
+        new_idx = dtype(self.index)
+        self.index = new_idx
+        return self
+
+    def register(self, label):
+        register(self.index, "{}_key".format(label))
+        return 1
+
+    def to_dict(self, label):
+        data = {}
+        if label is None:
+            label = "idx"
+        elif type(label) == list:
+            label = label[0]
+        data[label] = self.index
+        return data
+
+    def _check_types(self, other):
+        if type(self) != type(other):
+            raise TypeError("Index Types must match")
+
+    def _merge(self, other):
+        self._check_types(other)
+
+        callback = get_callback(self.index)
+        idx = concatenate([self.index, other.index], ordered=False)
+        return Index(callback(unique(idx)))
+
+    def _merge_all(self, array):
+        idx = self.index
+        callback = get_callback(idx)
+
+        for other in array:
+            self._check_types(other)
+            idx = concatenate([idx, other.index], ordered=False)
+
+        return Index(callback(unique(idx)))
+
+    def _check_aligned(self, other):
+        self._check_types(other)
+        l = len(self)
+        return len(other) == l and (self == other.index).sum() == l
+
+    def argsort(self, ascending=True):
+        if not ascending:
+            if isinstance(self.index, pdarray) and self.index.dtype in (int64, float64):
+                i = argsort(-self.index)
+            else:
+                i = argsort(self.index)[arange(self.index.size - 1, -1, -1)]
+        else:
+            i = argsort(self.index)
+        return i
+
+    def concat(self, other):
+        self._check_types(other)
+
+        idx = concatenate([self.index, other.index], ordered=True)
+        return Index(idx)
+
+    def lookup(self, key):
+        if not isinstance(key, pdarray):
+            raise TypeError("Lookup must be on an arkouda array")
+
+        return in1d(self.index, key)
+
+
+class MultiIndex(Index):
+    def __init__(self,index):
+        if not(isinstance(index,list) or isinstance(index,tuple)):
+            raise TypeError("MultiIndex shuold be an iterable")
+        self.index = index
+        first = True
+        for col in self.index:
+            if first:
+                self.size = col.size
+            else:
+                if col.size != self.size:
+                    raise ValueError("All columns in MultiIndex must have same length")
+        self.levels = len(self.index)
+
+    def __getitem__(self,key):
+        if type(key) == Series:
+            key = key.values
+        return MultiIndex([ i[key] for i in self.index])
+
+    def __len__(self):
+        return len(self.index[0])
+
+    def __eq__(self,v):
+        if type(v) != list and type(v) != tuple:
+            raise TypeError("Cannot compare MultiIndex to a scalar")
+        retval = ones(len(self), dtype=bool)
+        for a,b in zip(self.index, v):
+            retval &= (a == b)
+        return retval
+
+    def to_pandas(self):
+        idx = [convert_if_categorical(i) for i in self.index]
+        mi = [i.to_ndarray() for i in idx]
+        return pd.Series(index=mi, dtype='float64').index
+
+    def set_dtype(self, dtype):
+        """Change the data type of the index
+
+        Currently only aku.ip_address and ak.array are supported.
+        """
+        new_idx = [dtype(i) for i in self.index]
+        self.index = new_idx
+        return self
+
+    def register(self, label):
+        for i, arr in enumerate(self.index):
+            register(arr, "{}_key_{}".format(label, i))
+        return len(self.index)
+
+    def to_dict(self, labels):
+        data = {}
+        if labels is None:
+            labels = ["idx_{}".format(i) for i in range(len(self.index))]
+        for i, value in enumerate(self.index):
+            data[labels[i]] = value
+        return data
+
+    def _merge(self, other):
+        self._check_types(other)
+        idx = [concatenate([ix1, ix2], ordered=False) for ix1, ix2 in zip(self.index, other.index)]
+        return MultiIndex(GroupBy(idx).unique_keys)
+
+    def _merge_all(self, array):
+        idx = self.index
+
+        for other in array:
+            self._check_types(other)
+            idx = [concatenate([ix1, ix2], ordered=False) for ix1, ix2 in zip(idx, other.index)]
+
+        return MultiIndex(GroupBy(idx).unique_keys)
+
+    def argsort(self, ascending=True):
+        i = coargsort(self.index)
+        if not ascending:
+            i = i[arange(self.size - 1, -1, -1)]
+        return i
+
+    def concat(self, other):
+        self._check_types(other)
+        idx = [concatenate([ix1, ix2], ordered=True) for ix1, ix2 in zip(self.index, other.index)]
+        return MultiIndex(idx)
+
+    def lookup(self, key):
+        if type(key) != list and type(key) != tuple:
+            raise TypeError("MultiIndex lookup failure")
+
+        return in1dmulti(self.index, key)

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -5,7 +5,6 @@ from arkouda.pdarraycreation import arange, ones
 from arkouda.pdarraysetops import argsort, in1d, unique
 from arkouda.sorting import coargsort
 from arkouda.dtypes import int64, float64, bool
-from arkouda.series import Series
 from arkouda.util import register, convert_if_categorical, concatenate, get_callback
 from arkouda.groupbyclass import GroupBy
 from arkouda.alignment import in1dmulti
@@ -16,6 +15,7 @@ class Index:
         self.size = index.size
 
     def __getitem__(self,key):
+        from arkouda.series import Series
         if type(key) == Series:
             key = key.values
         return Index(self.index[key])
@@ -123,12 +123,14 @@ class MultiIndex(Index):
         for col in self.index:
             if first:
                 self.size = col.size
+                first = False
             else:
                 if col.size != self.size:
                     raise ValueError("All columns in MultiIndex must have same length")
         self.levels = len(self.index)
 
     def __getitem__(self,key):
+        from arkouda.series import Series
         if type(key) == Series:
             key = key.values
         return MultiIndex([ i[key] for i in self.index])

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -117,7 +117,7 @@ class Index:
 class MultiIndex(Index):
     def __init__(self,index):
         if not(isinstance(index,list) or isinstance(index,tuple)):
-            raise TypeError("MultiIndex shuold be an iterable")
+            raise TypeError("MultiIndex should be an iterable")
         self.index = index
         first = True
         for col in self.index:

--- a/arkouda/series.py
+++ b/arkouda/series.py
@@ -1,0 +1,439 @@
+from arkouda.pdarrayclass import pdarray, argmaxk, attach_pdarray
+from arkouda.pdarraycreation import arange, array
+from arkouda.pdarraysetops import argsort, concatenate
+from arkouda.index import Index
+from arkouda.groupbyclass import GroupBy
+from arkouda.dtypes import int64, float64
+from arkouda.numeric import value_counts
+from arkouda.util import convert_if_categorical, register
+from arkouda.alignment import lookup
+from arkouda.dataframe import DataFrame
+
+from pandas._config import get_option
+import pandas as pd  # type: ignore
+import numpy as np  # type: ignore
+
+__all__ = [
+    "Series",
+    ]
+
+import operator
+
+
+def natural_binary_operators(cls):
+    for name, op in {
+        '__add__': operator.add,
+        '__sub__': operator.sub,
+        '__mul__': operator.mul,
+        '__truediv__': operator.truediv,
+        '__floordiv__': operator.floordiv,
+        '__and__': operator.and_,
+        '__or__': operator.or_,
+        '__xor__': operator.xor,
+        '__eq__': operator.eq,
+        '__ge__': operator.ge,
+        '__gt__': operator.gt,
+        '__le__': operator.le,
+        '__lshift__': operator.lshift,
+        '__lt__': operator.lt,
+        '__mod__': operator.mod,
+        '__ne__': operator.ne,
+        '__rshift__': operator.rshift,
+    }.items():
+        setattr(cls, name, cls._make_binop(op))
+
+    return cls
+
+
+def unary_operators(cls):
+    for name, op in {
+        '__invert__': operator.invert,
+        '__neg__': operator.neg,
+    }.items():
+        setattr(cls, name, cls._make_unaryop(op))
+
+    return cls
+
+
+def aggregation_operators(cls):
+    for name in ['max', 'min', 'mean', 'sum', 'std', 'argmax', 'argmin', 'prod']:
+        setattr(cls,name, cls._make_aggop(name))
+    return cls
+
+
+@unary_operators
+@aggregation_operators
+@natural_binary_operators
+class Series:
+    """
+    One-dimensional arkouda array with axis labels.
+
+    Parameters
+    ----------
+    ar_tuple : 2-tuple of arkouda arrays with the first being the grouping key(s) and the
+             second being the value. The grouping key(s) will be the index of the series.
+
+    """
+
+    def __init__(self, ar_tuple=None, data=None, index=None):
+        if ar_tuple is not None:
+            self.index = Index.factory(ar_tuple[0])
+            self.values = ar_tuple[1]
+        elif data is None:
+            raise TypeError("ar_tuple and data cannot both be null")
+
+        else:
+            if not isinstance(data, pdarray):
+                data = array(data)
+            self.values = data
+
+            if index is None:
+                index = arange(data.size)
+            self.index = Index.factory(index)
+        if self.index.size != self.values.size:
+            raise ValueError("Index and data must have same length")
+        self.size = self.index.size
+
+    def __len__(self):
+        return self.values.size
+
+    def __repr__(self):
+        """
+        Return ascii-formatted version of the series.
+        """
+
+        if len(self) == 0:
+            return 'Series([ -- ][ 0 values : 0 B])'
+
+        maxrows = pd.get_option('display.max_rows')
+        if len(self) <= maxrows:
+            prt = self.to_pandas()
+            length_str = ""
+        else:
+            prt = pd.concat([self.head(maxrows // 2 + 2).to_pandas(),
+                             self.tail(maxrows // 2).to_pandas()])
+            length_str = "\nLength {}".format(len(self))
+        return prt.to_string(
+            dtype=prt.dtype,
+            min_rows=get_option("display.min_rows"),
+            max_rows=maxrows,
+            length=False,
+        ) + length_str
+
+    def __getitem__(self, key):
+        if type(key) == Series:
+            # @TODO align the series indexes
+            key = key.values
+        return Series((self.index[key], self.values[key]))
+
+    def locate(self, key):
+        """Lookup values by index label
+
+        The input can be a scalar, a list of scalers, or a list of lists (if the series has a MultiIndex).
+        As a special case, if a Series is used as the key, the series labels are preserved with its values
+        use as the key.
+
+        Keys will be turned into arkouda arrays as needed.
+
+        Returns
+        -------
+
+        A Series containing the values corresponding to the key.
+        """
+        t = type(key)
+        if isinstance(key, Series):
+            # special case, keep the index values of the Series, and lookup the values
+            labels = key.index
+            key = key.values
+            v = lookup(self.index.index, self.values, key)
+            return Series((labels, v))
+        elif isinstance(key, pdarray):
+            idx = self.index.lookup(key)
+        elif t == list or t == tuple:
+            key0 = key[0]
+            if isinstance(key0, list) or isinstance(key0, tuple):
+                # nested list. check if already arkouda arrays
+                if not isinstance(key0[0], pdarray):
+                    # convert list of lists to list of pdarrays
+                    key = [array(a) for a in np.array(key).T.copy()]
+
+            elif not isinstance(key0, pdarray):
+                # a list of scalers, convert into arkouda array
+                key = array(key)
+            # else already list if arkouda array, use as is
+            idx = self.index.lookup(key)
+        else:
+            # scalar value
+            idx = self.index == key
+        return Series((self.index[idx], self.values[idx]))
+
+    @classmethod
+    def _make_binop(cls, operator):
+        def binop(self, other):
+            if type(other) == Series:
+                if self.index._check_aligned(other.index):
+                    return cls((self.index, operator(self.values, other.values)))
+                else:
+                    idx = self.index._merge(other.index).index
+                    a = lookup(self.index.index, self.values, idx, fillvalue=0)
+                    b = lookup(other.index.index, other.values, idx, fillvalue=0)
+                    return cls((idx, operator(a, b)))
+            else:
+                return cls((self.index, operator(self.values, other)))
+
+        return binop
+
+    @classmethod
+    def _make_unaryop(cls, operator):
+        def unaryop(self):
+            return cls((self.index, operator(self.values)))
+
+        return unaryop
+
+    @classmethod
+    def _make_aggop(cls, name):
+        def aggop(self):
+            return getattr(self.values, name)()
+
+        return aggop
+
+    def add(self, b):
+
+        index = self.index.concat(b.index).index
+
+        values = concatenate([self.values, b.values], ordered=False)
+        return Series(GroupBy(index).sum(values))
+
+    def topn(self, n=10):
+        """ Return the top values of the series
+
+        Parameters
+        ----------
+        n: Number of values to return
+
+        Returns
+        -------
+        A new Series with the top values
+        """
+        k = self.index
+        v = self.values
+
+        idx = argmaxk(v, n)
+        idx = idx[-1:-n - 1:-1]
+
+        return Series((k[idx], v[idx]))
+
+    def sort_index(self, ascending=True):
+        """ Sort the series by its index
+
+        Returns
+        -------
+        A new Series sorted.
+        """
+
+        idx = self.index.argsort(ascending=ascending)
+        return Series((self.index[idx], self.values[idx]))
+
+    def sort_values(self, ascending=True):
+        """ Sort the series numerically
+
+        Returns
+        -------
+        A new Series sorted smallest to largest
+        """
+
+        if not ascending:
+            if isinstance(self.values, pdarray) and self.values.dtype in (int64, float64):
+                # For numeric values, negation reverses sort order
+                idx = argsort(-self.values)
+            else:
+                # For non-numeric values, need the descending arange because reverse slicing not supported
+                idx = argsort(self.values)[arange(self.values.size - 1, -1, -1)]
+        else:
+            idx = argsort(self.values)
+        return Series((self.index[idx], self.values[idx]))
+
+    def tail(self, n=10):
+        """Return the last n values of the series"""
+
+        idx_series = (self.index[-n:])
+        return Series((idx_series, self.values[-n:]))
+
+    def head(self, n=10):
+        """Return the first n values of the series"""
+
+        idx_series = (self.index[0:n])
+        return Series((idx_series, self.values[0:n]))
+
+    def to_pandas(self):
+        """Convert the series to a local PANDAS series"""
+
+        idx = self.index.to_pandas()
+        val = convert_if_categorical(self.values)
+        return pd.Series(val.to_ndarray(), index=idx)
+
+    def value_counts(self, sort=True):
+        """Return a Series containing counts of unique values.
+
+        The resulting object will be in descending order so that the
+        first element is the most frequently-occurring element.
+
+        Parameters
+        ----------
+
+        sort : Boolean. Whether or not to sort the results.  Default is true.
+        """
+
+        s = Series(value_counts(self.values))
+        if sort:
+            s = s.sort_values(ascending=False)
+        return s
+
+    def register(self, label):
+        """Register the series with arkouda
+
+                Parameters
+                ----------
+                label : Arkouda name used for the series
+
+                Returns
+                -------
+                Numer of keys
+                """
+
+        retval = self.index.register(label)
+        register(self.values, "{}_value".format(label))
+        return retval
+
+    @staticmethod
+    def attach(label, nkeys=1):
+        """Retrieve a series registered with arkouda
+
+        Parameters
+        ----------
+        label: name used to register the series
+        nkeys: number of keys, if a multi-index was registerd
+        """
+        v = attach_pdarray(label + "_value")
+
+        if nkeys == 1:
+            k = attach_pdarray(label + "_key")
+        else:
+            k = [attach_pdarray("{}_key_{}".format(label, i)) for i in range(nkeys)]
+
+        return Series((k, v))
+
+    @staticmethod
+    def _all_aligned(array):
+        """Is an array of Series indexed aligned?"""
+
+        itor = iter(array)
+        a1 = next(itor).index
+        for a2 in itor:
+            if a1._check_aligned(a2.index) == False:
+                return False
+        return True
+
+    @staticmethod
+    def concat(arrays, axis=0, index_labels=None, value_labels=None):
+        """Concatenate in arkouda a list of arkouda Series or grouped arkouda arrays horizontally or vertically.
+
+                If a list of grouped arkouda arrays is passed they are converted to a series. Each grouping is a 2-tuple
+                with the first item being the key(s) and the second being the value.
+
+                If horizontal, each series or grouping must have the same length and the same index. The index of the series is
+                converted to a column in the dataframe.  If it is a multi-index,each level is converted to a column.
+
+                Parameters
+                ----------
+                arrays:  The list of series/groupings to concat.
+                axis  :  Whether or not to do a verticle (axis=0) or horizontal (axis=1) concatenation
+                index_labels:  column names(s) to label the index.
+                value_labels:  column names to label values of each series.
+
+                Returns
+                -------
+                axis=0: an arkouda series.
+                axis=1: an arkouda dataframe.
+                """
+
+        if len(arrays) == 0:
+            raise IndexError("Array length must be non-zero")
+
+        if type(next(iter(arrays))) == tuple:
+            arrays = [Series(i) for i in arrays]
+
+        if axis == 1:
+            # Horizontal concat
+            if value_labels == None:
+                value_labels = ["val_{}".format(i) for i in range(len(arrays))]
+
+            if Series._all_aligned(arrays):
+
+                data = next(iter(arrays)).index.to_dict(index_labels)
+
+                for col, label in zip(arrays, value_labels):
+                    data[str(label)] = col.values
+
+            else:
+                aitor = iter(arrays)
+                idx = next(aitor).index;
+                idx = idx._merge_all([i.index for i in aitor])
+
+                data = idx.to_dict(index_labels)
+
+                for col, label in zip(arrays, value_labels):
+                    data[str(label)] = lookup(col.index.index, col.values, idx.index, fillvalue=0)
+
+            retval = DataFrame(data)
+        else:
+            # Verticle concat
+            idx = arrays[0].index
+            v = arrays[0].values
+            for other in arrays[1:]:
+                idx = idx.concat(other.index)
+                v = concatenate([v, other.values], ordered=True)
+            retval = Series((idx, v))
+
+        return retval
+
+    @staticmethod
+    def pdconcat(arrays, axis=0, labels=None):
+        """Concatenate a list of arkouda Series or grouped arkouda arrays, returning a PANDAS object.
+
+        If a list of grouped arkouda arrays is passed they are converted to a series. Each grouping is a 2-tuple
+        with the first item being the key(s) and the second being the value.
+
+        If horizontal, each series or grouping must have the same length and the same index. The index of the series is
+        converted to a column in the dataframe.  If it is a multi-index,each level is converted to a column.
+
+        Parameters
+        ----------
+        arrays:  The list of series/groupings to concat.
+        axis  :  Whether or not to do a verticle (axis=0) or horizontal (axis=1) concatenation
+        labels:  names to give the columns of the data frame.
+
+        Returns
+        -------
+        axis=0: a local PANDAS series
+        axis=1: a local PANDAS dataframe
+        """
+        if len(arrays) == 0:
+            raise IndexError("Array length must be non-zero")
+
+        if type(arrays[0]) == tuple:
+            arrays = [Series(i) for i in arrays]
+
+        if axis == 1:
+            idx = arrays[0].index.to_pandas()
+
+            cols = []
+            for col in arrays:
+                cols.append(pd.Series(col.values.to_ndarray(), index=idx))
+            retval = pd.concat(cols, axis=1)
+            if labels is not None:
+                retval.columns = labels
+        else:
+            retval = pd.concat([s.to_pandas() for s in arrays])
+
+        return retval

--- a/arkouda/series.py
+++ b/arkouda/series.py
@@ -9,7 +9,7 @@ from arkouda.util import convert_if_categorical, register
 from arkouda.alignment import lookup
 from arkouda.dataframe import DataFrame
 
-from pandas._config import get_option
+from pandas._config import get_option # type: ignore
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
 

--- a/arkouda/series.py
+++ b/arkouda/series.py
@@ -7,7 +7,6 @@ from arkouda.dtypes import int64, float64
 from arkouda.numeric import value_counts
 from arkouda.util import convert_if_categorical, register
 from arkouda.alignment import lookup
-from arkouda.dataframe import DataFrame
 
 from pandas._config import get_option # type: ignore
 import pandas as pd  # type: ignore
@@ -356,6 +355,7 @@ class Series:
                 axis=0: an arkouda series.
                 axis=1: an arkouda dataframe.
                 """
+        from arkouda.dataframe import DataFrame
 
         if len(arrays) == 0:
             raise IndexError("Array length must be non-zero")

--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -16,7 +16,6 @@ from arkouda.client import get_config, get_mem_used
 from arkouda.groupbyclass import GroupBy, broadcast, coargsort
 from arkouda.infoclass import information, AllSymbols
 from arkouda.categorical import Categorical
-from arkouda.dataframe import DataFrame
 
 identity = lambda x: x
 
@@ -93,6 +92,7 @@ def register(a, name):
 
 
 def register_all(data, prefix, overwrite=True):
+    from arkouda.dataframe import DataFrame
     def sanitize(k):
         return str(k).replace(' ', '_')
     if overwrite:

--- a/pydoc/usage/Index.rst
+++ b/pydoc/usage/Index.rst
@@ -1,0 +1,35 @@
+***********
+Indexs in Arkouda
+***********
+
+Like Pandas, Arkouda supports ``Indexes``. The purpose and intended functionality remains the same in Arkouda, but are configured to be based on ``arkouda.pdarrays``.
+
+.. autoclass:: arkouda.Index
+
+Additionally, ``Multi-Indexes`` are supported for indexes with multiple keys.
+
+..autoclass:: arkouda.MultiIndex
+
+Features
+==========
+``Index`` support the majority of functionality offered by ``pandas.Index``.
+
+Change Dtype
+----------
+.. autofunction:: arkouda.Index.set_dtype
+.. autofunction:: arkouda.MultiIndex.set_dtype
+
+ArgSort
+----------
+.. autofunction:: arkouda.Index.argsort
+.. autofunction:: arkouda.MultiIndex.argsort
+
+Lookup
+----------
+.. autofunction:: arkouda.Index.lookup
+.. autofunction:: arkouda.MultiIndex.lookup
+
+Concat
+----------
+.. autofunction:: arkouda.Index.concat
+.. autofunction:: arkouda.MultiIndex.concat

--- a/pydoc/usage/series.rst
+++ b/pydoc/usage/series.rst
@@ -1,0 +1,39 @@
+***********
+Series in Arkouda
+***********
+
+Like Pandas, Arkouda supports ``Series``. The purpose and intended functionality remains the same in Arkouda, but are configured to be based on ``arkouda.pdarrays``.
+
+.. autoclass:: arkouda.Series
+
+Features
+==========
+``Series`` support the majority of functionality offered by ``pandas.Series``.
+
+Lookup
+----------
+.. autofunction:: arkouda.Series.locate
+
+Lookup
+----------
+.. autofunction:: arkouda.Series.locate
+
+Sorting
+----------
+.. autofunction:: arkouda.Series.sort_index
+.. autofunction:: arkouda.Series.sort_values
+
+Head/Tail
+----------
+.. autofunction:: arkouda.Series.topn
+.. autofunction:: arkouda.Series.head
+.. autofunction:: arkouda.Series.tail
+
+Value Counts
+----------
+.. autofunction:: arkouda.Series.value_counts
+
+Pandas Integration
+----------
+.. autofunction:: arkouda.Series.to_pandas
+.. autofunction:: arkouda.Series.pdconcat

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,6 +12,7 @@ testpaths =
     tests/datetime_test.py
     tests/dtypes_tests.py
     tests/groupby_test.py
+    tests/index_test.py
     tests/nan_test.py
     tests/io_test.py
     tests/io_util_test.py
@@ -25,6 +26,7 @@ testpaths =
     tests/registration_test.py
     tests/security_test.py
     tests/segarray_test.py
+    tests/series_test.py
     tests/setops_test.py
     tests/sort_test.py
     tests/string_test.py

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -88,7 +88,7 @@ class DataFrameTest(ArkoudaTest):
         userid2 = ak.array([111, 222, 333])
         item2 = ak.array([0, 1, 2])
         day2 = ak.array([5, 5, 5])
-        self.assertEquals(dedup.__str__(), ak.DataFrame({'userName': username2, 'userID': userid2,
+        self.assertEqual(dedup.__str__(), ak.DataFrame({'userName': username2, 'userID': userid2,
                            'item': item2, 'day': day2}).__str__())
 
     def test_shape(self):

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -270,8 +270,21 @@ class DataFrameTest(ArkoudaTest):
         self.assertTrue((keys[1] == ak.array([111, 333, 222])).all())
         self.assertTrue((count == ak.array([3, 1, 2])).all())
 
-        with self.assertRaises(NotImplementedError):
-            gb = df.GroupBy('userName', use_series=True)
+    def test_gb_series(self):
+        username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+        userid = ak.array([111, 222, 111, 333, 222, 111])
+        item = ak.array([0, 0, 1, 1, 2, 0])
+        day = ak.array([5, 5, 6, 5, 6, 6])
+        amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
+        df = ak.DataFrame({'userName': username, 'userID': userid,
+                           'item': item, 'day': day, 'amount': amount})
+
+        gb = df.GroupBy('userName', use_series=True)
+
+        c = gb.count()
+        self.assertIsInstance(c, ak.Series)
+        self.assertListEqual(c.index.to_pandas().tolist(), ['Alice', 'Carol', 'Bob'])
+        self.assertListEqual(c.values.to_ndarray().tolist(), [3, 1, 2])
 
     def test_to_pandas(self):
         username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])

--- a/tests/index_test.py
+++ b/tests/index_test.py
@@ -1,0 +1,86 @@
+from base_test import ArkoudaTest
+from context import arkouda as ak
+
+class DataFrameTest(ArkoudaTest):
+
+    def test_index_creation(self):
+        idx = ak.Index(ak.arange(5))
+
+        self.assertIsInstance(idx, ak.Index)
+        self.assertEqual(idx.size, 5)
+        self.assertListEqual(idx.to_pandas().tolist(), [i for i in range(5)])
+
+    def test_multiindex_creation(self):
+        #test list generation
+        idx = ak.MultiIndex([ak.arange(5), ak.arange(5)])
+        self.assertIsInstance(idx, ak.MultiIndex)
+        self.assertEqual(idx.levels, 2)
+        self.assertEqual(idx.size, 5)
+
+        #test tuple generation
+        idx = ak.MultiIndex((ak.arange(5), ak.arange(5)))
+        self.assertIsInstance(idx, ak.MultiIndex)
+        self.assertEqual(idx.levels, 2)
+        self.assertEqual(idx.size, 5)
+
+        with self.assertRaises(TypeError):
+            idx = ak.MultiIndex(ak.arange(5))
+
+        with self.assertRaises(ValueError):
+            idx = ak.MultiIndex([ak.arange(5), ak.arange(3)])
+
+    def test_factory(self):
+        idx = ak.Index.factory(ak.arange(5))
+        self.assertIsInstance(idx, ak.Index)
+
+        idx = ak.Index.factory([ak.arange(5), ak.arange(5)])
+        self.assertIsInstance(idx, ak.MultiIndex)
+
+    def test_argsort(self):
+        idx = ak.Index.factory(ak.arange(5))
+        i = idx.argsort(False)
+        self.assertListEqual(i.to_ndarray().tolist(), [4, 3, 2, 1, 0])
+
+        idx = ak.Index(ak.array([1, 0, 4, 2, 5, 3]))
+        i = idx.argsort()
+        #values should be the indexes in the array of idx
+        self.assertListEqual(i.to_ndarray().tolist(), [1, 0, 3, 5, 2, 4])
+
+    def test_concat(self):
+        idx_1 = ak.Index.factory(ak.arange(5))
+
+        idx_2 = ak.Index(ak.array([2, 4, 1, 3, 0]))
+
+        idx_full = idx_1.concat(idx_2)
+        self.assertListEqual(idx_full.to_pandas().tolist(), [0, 1, 2, 3, 4, 2, 4, 1, 3, 0])
+
+    def test_lookup(self):
+        idx = ak.Index.factory(ak.arange(5))
+        l = idx.lookup(ak.array([0, 4]))
+        self.assertListEqual(l.to_ndarray().tolist(), [True, False, False, False, True])
+
+    def test_multi_argsort(self):
+        idx = ak.Index.factory([ak.arange(5), ak.arange(5)])
+        s = idx.argsort(False)
+        self.assertListEqual(s.to_ndarray().tolist(), [4, 3, 2, 1, 0])
+
+        s = idx.argsort()
+        self.assertListEqual(s.to_ndarray().tolist(), [i for i in range(5)])
+
+    def test_multi_concat(self):
+        idx = ak.Index.factory([ak.arange(5), ak.arange(5)])
+        idx_2 = ak.Index.factory(ak.array([0.1, 1.1, 2.2, 3.3, 4.4]))
+        with self.assertRaises(TypeError):
+            idx.concat(idx_2)
+
+        idx_2 = ak.Index.factory([ak.arange(5), ak.arange(5)])
+        idx_full = idx.concat(idx_2)
+        self.assertListEqual(idx_full.to_pandas().tolist(), [(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (0, 0), (1, 1), (2, 2), (3, 3), (4, 4)])
+
+    def test_multi_lookup(self):
+        idx = ak.Index.factory([ak.arange(5), ak.arange(5)])
+
+        l = ak.array([0, 3, 2])
+
+        result = idx.lookup([l, l])
+        self.assertListEqual(result.to_ndarray().tolist(), [True, False, True, True, False])

--- a/tests/index_test.py
+++ b/tests/index_test.py
@@ -1,7 +1,7 @@
 from base_test import ArkoudaTest
 from context import arkouda as ak
 
-class DataFrameTest(ArkoudaTest):
+class IndexTest(ArkoudaTest):
 
     def test_index_creation(self):
         idx = ak.Index(ak.arange(5))

--- a/tests/series_test.py
+++ b/tests/series_test.py
@@ -45,8 +45,11 @@ class SeriesTest(ArkoudaTest):
 
         added = s.add(s_add)
 
-        self.assertListEqual(added.index.to_pandas().tolist(), [i for i in range(6)])
-        self.assertListEqual(added.values.to_ndarray().tolist(), [i for i in range(6)])
+        idx_list = added.index.to_pandas().tolist()
+        val_list = added.values.to_ndarray().tolist()
+        for i in range(6):
+            self.assertIn(i, idx_list)
+            self.assertIn(i, val_list)
 
     def test_topn(self):
         ar_tuple = (ak.arange(3), ak.arange(3))

--- a/tests/series_test.py
+++ b/tests/series_test.py
@@ -1,0 +1,138 @@
+from base_test import ArkoudaTest
+from context import arkouda as ak
+
+import pandas as pd
+
+
+class SeriesTest(ArkoudaTest):
+
+    def test_series_creation(self):
+        ar_tuple = (ak.arange(3), ak.array(['A', 'B', 'C']))
+        s = ak.Series(ar_tuple=ar_tuple)
+
+        self.assertIsInstance(s, ak.Series)
+        self.assertIsInstance(s.index, ak.Index)
+
+        with self.assertRaises(TypeError):
+            s = ak.Series()
+
+        with self.assertRaises(ValueError):
+            s = ak.Series(data=ak.array(['A', 'B', 'C']), index=ak.arange(6))
+
+    def test_lookup(self):
+        ar_tuple = (ak.arange(3), ak.array(['A', 'B', 'C']))
+        s = ak.Series(ar_tuple=ar_tuple)
+
+        l = s.locate(1)
+        self.assertIsInstance(l, ak.Series)
+        self.assertEqual(l.index[0], 1)
+        self.assertEqual(l.values[0], 'B')
+
+        l = s.locate([0, 2])
+        self.assertIsInstance(l, ak.Series)
+        self.assertEqual(l.index[0], 0)
+        self.assertEqual(l.values[0], 'A')
+        self.assertEqual(l.index[1], 2)
+        self.assertEqual(l.values[1], 'C')
+
+    def test_add(self):
+        ar_tuple = (ak.arange(3), ak.arange(3))
+        ar_tuple_add = (ak.arange(3, 6, 1), ak.arange(3, 6, 1))
+
+        s = ak.Series(ar_tuple=ar_tuple)
+
+        s_add = ak.Series(ar_tuple=ar_tuple_add)
+
+        added = s.add(s_add)
+        print(added)
+
+        self.assertListEqual(added.index.to_pandas().tolist(), [i for i in range(6)])
+        self.assertListEqual(added.values.to_ndarray().tolist(), [i for i in range(6)])
+
+    def test_topn(self):
+        ar_tuple = (ak.arange(3), ak.arange(3))
+        s = ak.Series(ar_tuple=ar_tuple)
+
+        top = s.topn(2)
+        self.assertListEqual(top.index.to_pandas().tolist(), [2, 1])
+        self.assertListEqual(top.values.to_ndarray().tolist(), [2, 1])
+
+    def test_sort_idx(self):
+        ar_tuple = (ak.array([3, 1, 4, 0, 2]), ak.arange(5))
+        s = ak.Series(ar_tuple=ar_tuple)
+
+        sorted = s.sort_index()
+        self.assertListEqual(sorted.index.to_pandas().tolist(), [i for i in range(5)])
+        self.assertListEqual(sorted.values.to_ndarray().tolist(), [3, 1, 4, 0, 2])
+
+    def test_sort_value(self):
+        ar_tuple = (ak.arange(5), ak.array([3, 1, 4, 0, 2]))
+        s = ak.Series(ar_tuple=ar_tuple)
+
+        sorted = s.sort_values()
+        self.assertListEqual(sorted.index.to_pandas().tolist(), [3, 1, 4, 0, 2])
+        self.assertListEqual(sorted.values.to_ndarray().tolist(), [i for i in range(5)])
+
+    def test_head_tail(self):
+        ar_tuple = (ak.arange(5), ak.arange(5))
+        s = ak.Series(ar_tuple=ar_tuple)
+
+        head = s.head(2)
+        self.assertListEqual(head.index.to_pandas().tolist(), [0, 1])
+        self.assertListEqual(head.values.to_ndarray().tolist(), [0, 1])
+
+        tail = s.tail(3)
+        self.assertListEqual(tail.index.to_pandas().tolist(), [2, 3, 4])
+        self.assertListEqual(tail.values.to_ndarray().tolist(), [2, 3, 4])
+
+    def test_value_counts(self):
+        ar_tuple = (ak.arange(5), ak.array([0, 0, 1, 2, 2]))
+        s = ak.Series(ar_tuple=ar_tuple)
+
+        c = s.value_counts()
+        self.assertListEqual(c.index.to_pandas().tolist(), [0, 2, 1])
+        self.assertListEqual(c.values.to_ndarray().tolist(), [2, 2, 1])
+
+        c = s.value_counts(sort=True)
+        self.assertListEqual(c.index.to_pandas().tolist(), [0, 2, 1])
+        self.assertListEqual(c.values.to_ndarray().tolist(), [2, 2, 1])
+
+    def test_concat(self):
+        ar_tuple = (ak.arange(5), ak.arange(5))
+        s = ak.Series(ar_tuple=ar_tuple)
+
+        ar_tuple_2 = (ak.arange(5, 11, 1), ak.arange(5, 11, 1))
+        s2 = ak.Series(ar_tuple_2)
+
+        c = ak.Series.concat([s, s2])
+        self.assertListEqual(c.index.to_pandas().tolist(), [i for i in range(11)])
+        self.assertListEqual(c.values.to_ndarray().tolist(), [i for i in range(11)])
+
+        df = ak.Series.concat([s, s2], axis=1)
+        self.assertIsInstance(df, ak.DataFrame)
+
+        ref_df = pd.DataFrame({'idx': [i for i in range(11)], 'val_0': [0, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0],
+                               'val_1': [0, 0, 0, 0, 0, 5, 6, 7, 8, 9, 10]})
+        self.assertTrue(((ref_df == df.to_pandas()).all()).all())
+
+    def test_pdconcat(self):
+        ar_tuple = (ak.arange(5), ak.arange(5))
+        s = ak.Series(ar_tuple=ar_tuple)
+
+        ar_tuple_2 = (ak.arange(5, 11, 1), ak.arange(5, 11, 1))
+        s2 = ak.Series(ar_tuple_2)
+
+        c = ak.Series.pdconcat([s, s2])
+        self.assertIsInstance(c, pd.Series)
+        self.assertListEqual(c.index.tolist(), [i for i in range(11)])
+        self.assertListEqual(c.values.tolist(), [i for i in range(11)])
+
+        ar_tuple_2 = (ak.arange(5, 10, 1), ak.arange(5, 10, 1))
+        s2 = ak.Series(ar_tuple_2)
+
+        df = ak.Series.pdconcat([s, s2], axis=1)
+        self.assertIsInstance(df, pd.DataFrame)
+
+        ref_df = pd.DataFrame({0: [0, 1, 2, 3, 4],
+                               1: [5, 6, 7, 8, 9]})
+        self.assertTrue((ref_df == df).all().all())

--- a/tests/series_test.py
+++ b/tests/series_test.py
@@ -44,7 +44,6 @@ class SeriesTest(ArkoudaTest):
         s_add = ak.Series(ar_tuple=ar_tuple_add)
 
         added = s.add(s_add)
-        print(added)
 
         self.assertListEqual(added.index.to_pandas().tolist(), [i for i in range(6)])
         self.assertListEqual(added.values.to_ndarray().tolist(), [i for i in range(6)])

--- a/tests/series_test.py
+++ b/tests/series_test.py
@@ -17,7 +17,7 @@ class SeriesTest(ArkoudaTest):
             s = ak.Series()
 
         with self.assertRaises(ValueError):
-            s = ak.Series(data=ak.array(['A', 'B', 'C']), index=ak.arange(6))
+            s = ak.Series(data=ak.arange(3), index=ak.arange(6))
 
     def test_lookup(self):
         ar_tuple = (ak.arange(3), ak.array(['A', 'B', 'C']))


### PR DESCRIPTION
This PR (closes #1128):

Adds the following files from `akutil` to `arkouda`.
- `series.py`
- `index.py`

Adds Unit tests for `arkouda/series.py` and `arkouda/index.py`.
Adds Documentation for `arkouda/series.py` and `arkouda/index.py`.

Testing for `arkouda.DataFrame` has been updated to include additional `groupby()` testing with additional case using `Series` that is now in place.

