### PR TITLE
Update Arkouda to work with CTypes

### DIFF
--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -6,7 +6,7 @@ module ArgSortMsg
 {
     use ServerConfig;
     
-    use CPtr;
+    use CTypes;
 
     use Time only;
     use Math only;

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -1,6 +1,6 @@
 module AryUtil
 {
-    use CPtr;
+    use CTypes;
     use Random;
     use Reflection;
     use Logging;
@@ -137,7 +137,7 @@ module AryUtil
 
         proc init(A: [] ?t, region: range(?)) {
             use CommPrimitives;
-            use SysCTypes;
+            use CTypes;
 
             this.t = t;
             if region.isEmpty() {
@@ -161,7 +161,7 @@ module AryUtil
                     // alloc+bulk GET and return owned c_ptr
                     this.ptr = c_malloc(t, region.size);
                     this.isOwned = true;
-                    const byteSize = region.size:size_t * c_sizeof(t);
+                    const byteSize = region.size:c_size_t * c_sizeof(t);
                     GET(ptr, startLocale, getAddr(start), byteSize);
                 }
             } else {

--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -1,6 +1,5 @@
 module CommAggregation {
-  use SysCTypes;
-  use CPtr;
+  use CTypes;
   use ServerConfig;
   use UnorderedCopy;
   use CommPrimitives;
@@ -341,7 +340,7 @@ module CommAggregation {
         assert(lArr.domain.low == 0);
         assert(lArr.locale.id == here.id);
       }
-      const byte_size = size:size_t * c_sizeof(elemType);
+      const byte_size = size:c_size_t * c_sizeof(elemType);
       CommPrimitives.PUT(c_ptrTo(lArr[0]), loc, data, byte_size);
     }
 
@@ -349,7 +348,7 @@ module CommAggregation {
       if boundsChecking {
         assert(size <= this.size);
       }
-      const byte_size = size:size_t * c_sizeof(elemType);
+      const byte_size = size:c_size_t * c_sizeof(elemType);
       CommPrimitives.PUT(lArr, loc, data, byte_size);
     }
 
@@ -360,7 +359,7 @@ module CommAggregation {
         assert(lArr.domain.low == 0);
         assert(lArr.locale.id == here.id);
       }
-      const byte_size = size:size_t * c_sizeof(elemType);
+      const byte_size = size:c_size_t * c_sizeof(elemType);
       CommPrimitives.GET(c_ptrTo(lArr[0]), loc, data, byte_size);
     }
 

--- a/src/CommPrimitives.chpl
+++ b/src/CommPrimitives.chpl
@@ -1,5 +1,5 @@
 module CommPrimitives {
-  use CPtr;
+  use CTypes;
 
   inline proc getAddr(const ref p): c_ptr(p.type) {
     // TODO can this use c_ptrTo?

--- a/src/Flatten.chpl
+++ b/src/Flatten.chpl
@@ -8,7 +8,7 @@ module Flatten {
   use CommAggregation;
   use Reflection;
   use ArkoudaRegexCompat;
-  use CPtr;
+  use CTypes;
   use SegmentedArray only checkCompile, _unsafeCompileRegex;
 
   config const NULL_STRINGS_VALUE = 0:uint(8);

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -1,7 +1,6 @@
 module GenSymIO {
     use IO;
-    use CPtr;
-    use SysCTypes;
+    use CTypes;
     use Path;
     use MultiTypeSymbolTable;
     use MultiTypeSymEntry;

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -1,5 +1,5 @@
 module HDF5Msg {
-    use CPtr;
+    use CTypes;
     use FileSystem;
     use HDF5;
     use IO;
@@ -8,7 +8,6 @@ module HDF5Msg {
     use PrivateDist;
     use Reflection;
     use Set;
-    use SysCTypes;
     use Time only;
 
     use CommAggregation;
@@ -130,7 +129,7 @@ module HDF5Msg {
     }
 
     private extern proc c_get_HDF5_obj_type(loc_id:C_HDF5.hid_t, name:c_string, obj_type:c_ptr(C_HDF5.H5O_type_t)):C_HDF5.herr_t;
-    private extern proc c_strlen(s:c_ptr(c_char)):size_t;
+    private extern proc c_strlen(s:c_ptr(c_char)):c_size_t;
     private extern proc c_incrementCounter(data:c_void_ptr);
     private extern proc c_append_HDF5_fieldname(data:c_void_ptr, name:c_string);
 
@@ -480,7 +479,7 @@ module HDF5Msg {
      *  as well as the total length of the array. 
      */
     proc get_subdoms(filenames: [?FD] string, dsetName: string) throws {
-        use SysCTypes;
+        use CTypes;
 
         var lengths: [FD] int;
         var skips = new set(string); // Case where there is no data in the file for this dsetName

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -1,5 +1,5 @@
 module ParquetMsg {
-  use SysCTypes, CPtr, IO;
+  use CTypes, IO;
   use ServerErrors, ServerConfig;
   use FileIO;
   use FileSystem;

--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -18,7 +18,7 @@ module RadixSortLSD
     use AryUtil;
     use CommAggregation;
     use IO;
-    use CPtr;
+    use CTypes;
     use Reflection;
     use Logging;
     use ServerConfig;

--- a/src/SegStringSort.chpl
+++ b/src/SegStringSort.chpl
@@ -3,7 +3,7 @@ module SegStringSort {
   use Sort;
   use Time;
   use IO;
-  use CPtr;
+  use CTypes;
   use CommAggregation;
   use PrivateDist;
   use Reflection;

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -1,6 +1,6 @@
 module SegmentedArray {
   use AryUtil;
-  use CPtr;
+  use CTypes;
   use MultiTypeSymbolTable;
   use MultiTypeSymEntry;
   use CommAggregation;

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -1,5 +1,5 @@
 module SegmentedMsg {
-  use CPtr;
+  use CTypes;
   use Reflection;
   use ServerErrors;
   use Logging;

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -6,7 +6,7 @@ module ServerConfig
     use SymArrayDmap only makeDistDom;
 
     public use IO;
-    private use SysCTypes;
+    private use CTypes;
 
     use ServerErrorStrings;
     use Reflection;
@@ -68,7 +68,7 @@ module ServerConfig
     const scLogger = new Logger(lLevel);
    
     proc createConfig() {
-        use SysCTypes;
+        use CTypes;
 
         class LocaleConfig {
             const id: int;

--- a/src/SipHash.chpl
+++ b/src/SipHash.chpl
@@ -1,7 +1,6 @@
 module SipHash {
   private use AryUtil;
-  private use CPtr;
-  private use SysCTypes;
+  private use CTypes;
   use ServerConfig;
   use ServerErrors;
   use Reflection;

--- a/src/compat/lt-126/CTypes.chpl
+++ b/src/compat/lt-126/CTypes.chpl
@@ -1,0 +1,10 @@
+// In Chapel 1.26, various C types from 'SysCTypes', 'SysBasic' and
+// 'CPtr' are being brought together into a single module, 'CTypes'.
+// This compatibility module brings the pieces that Arkouda relies
+// upon together so that it can use the new organization yet still
+// be compiled with older compilers.
+
+public use SysCTypes;
+public use CPtr;
+
+type c_size_t = size_t;


### PR DESCRIPTION
In Chapel 1.26, various C types from 'SysCTypes', 'SysBasic' and
'CPtr' are being brought together into a single (new) module,
'CTypes'.  In this PR, I'm adding a new user-level 'CTypes'
compatibility module that assembles the pieces that Arkouda relies
upon together so that it can use the new names and organization yet
still be compiled with older compilers.
