### PR TITLE
Add line to pass Arrow float to Chapel side

### DIFF
--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -183,6 +183,7 @@ module ParquetMsg {
     else if arrType == ARROWBOOLEAN then return ArrowTypes.boolean;
     else if arrType == ARROWSTRING then return ArrowTypes.stringArr;
     else if arrType == ARROWDOUBLE then return ArrowTypes.double;
+    else if arrType == ARROWFLOAT then return ArrowTypes.float;
     // TODO: throw here
     return ArrowTypes.notimplemented;
   }


### PR DESCRIPTION
This PR adds a check for the Arrow float type on the Chapel side,
which was left out previously, allowing float data types to be
read with `ak.read_parquet()`. With this addition, the file
`alltypes_plain.parquet` from the Apache website now runs through
`ak.read_parquet()` without fail.