### PR TITLE
Catch all Parquet errors and report them to the client

### DIFF
--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -165,7 +165,7 @@ int cpp_getStringColumnNumBytes(const char* filename, const char* colname, void*
       }
       return size;
     }
-    return ARROWUNDEFINED;
+    return ARROWERROR;
   } catch (const std::exception& e) {
     *errMsg = strdup(e.what());
     return ARROWERROR;
@@ -277,7 +277,7 @@ int cpp_readColumnByName(const char* filename, void* chpl_arr, const char* colna
       }
       return 0;
     }
-    return ARROWUNDEFINED;
+    return ARROWERROR;
   } catch (const std::exception& e) {
     *errMsg = strdup(e.what());
     return ARROWERROR;

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -108,8 +108,13 @@ int cpp_getType(const char* filename, const char* colname, char** errMsg) {
       return ARROWFLOAT;
     else if(myType->id() == arrow::Type::DOUBLE)
       return ARROWDOUBLE;
-    else // TODO: error type not supported
-      return ARROWUNDEFINED;
+    else {
+      std::string fname(filename);
+      std::string dname(colname);
+      std::string msg = "Unsupported type on column: " + dname + " in " + filename; 
+      *errMsg = strdup(msg.c_str());
+      return ARROWERROR;
+    }
   } catch (const std::exception& e) {
     *errMsg = strdup(e.what());
     return ARROWERROR;

--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -22,7 +22,6 @@ extern "C" {
 #define ARROWDOUBLE 7
 #define ARROWTIMESTAMP ARROWINT64
 #define ARROWSTRING 6
-#define ARROWUNDEFINED -1
 #define ARROWERROR -1
 
   // Each C++ function contains the actual implementation of the

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -32,7 +32,6 @@ module ParquetMsg {
   extern var ARROWUINT64: c_int;
   extern var ARROWBOOLEAN: c_int;
   extern var ARROWSTRING: c_int;
-  extern var ARROWUNDEFINED: c_int;
   extern var ARROWFLOAT: c_int;
   extern var ARROWDOUBLE: c_int;
   extern var ARROWERROR: c_int;
@@ -192,11 +191,16 @@ module ParquetMsg {
     else if arrType == ARROWSTRING then return ArrowTypes.stringArr;
     else if arrType == ARROWDOUBLE then return ArrowTypes.double;
     else if arrType == ARROWFLOAT then return ArrowTypes.float;
-    // TODO: throw here
+    throw getErrorWithContext(
+                  msg="Unrecognized Parquet data type",
+                  getLineNumber(),
+                  getRoutineName(),
+                  getModuleName(),
+                  errorClass="ParquetError");
     return ArrowTypes.notimplemented;
   }
 
-  proc toCDtype(dtype: string) {
+  proc toCDtype(dtype: string) throws {
     select dtype {
       when 'int64' {
         return ARROWINT64;
@@ -207,8 +211,13 @@ module ParquetMsg {
       } when 'float64' {
         return ARROWDOUBLE;
       } otherwise {
-        // TODO: make this throw so we can catch it
-        return ARROWUNDEFINED;
+         throw getErrorWithContext(
+                msg="Trying to convert unrecognized dtype to Parquet type",
+                getLineNumber(),
+                getRoutineName(),
+                getModuleName(),
+                errorClass="ParquetError");
+        return ARROWERROR;
       }
     }
   }


### PR DESCRIPTION
In the initial Parquet error handling code, the only errors that
were being reported were errors that came from status codes of
calls to the Parquet API, but all errors in the C++ code went
unhandled and would result in a server crash.

This PR wraps all the C++ functions in a try/catch to catch all
errors to be reported back to the client rather than crashing the
server. This approach seems to align with the philosophy of
"The server should never crash, errors should just be reported to
the client".

Additionally, a bug was identified with throwing errors in `forall`
loops within a function, which would cause a try/catch wrapping
the throwing function to not catch the resulting `TaskErrors` error
throw, but a workaround for that is to wrap `forall` loops in a
try/catch which just throws the error, which then allows the
overarching try/catch to catch and report the error, where previously
it would crash the server.

Related issue: https://github.com/chapel-lang/chapel/issues/19378
Closes: https://github.com/Bears-R-Us/arkouda/issues/1158