### PR TITLE
Closes #1176 doc version num

### DIFF
--- a/pydoc/conf.py
+++ b/pydoc/conf.py
@@ -12,6 +12,7 @@
 #
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath('../benchmarks'))
 sys.path.insert(0, os.path.abspath('..'))
 
@@ -22,7 +23,7 @@ copyright = '2020, Michael Merrill and William Reus'
 author = 'Michael Merrill and William Reus'
 
 # The full version, including alpha/beta/rc tags
-release = '2020.07.07'
+release = ''
 
 
 # -- General configuration ---------------------------------------------------

--- a/pydoc/setup/quickstart.rst
+++ b/pydoc/setup/quickstart.rst
@@ -12,27 +12,23 @@ In a terminal, run the arkouda server program with one locale
 
 You should see a startup message like
 
-.. code-block:: none
+.. code-block:: bash
 
-   $ ./arkouda_server -nl 1
-   arkouda server version = 2020.07.07
-   memory tracking = true
-   initialized the .arkouda directory /Your/PATH/arkouda/.arkouda
-   getMemLimit() = 123695058124
-   bytes of memoryUsed() = 2462
-   server listening on tcp://node01:5555
+    $ ./arkouda_server -nl 1
+    server listening on tcp://<your_machine>.local:5555
+    arkouda server version = vYYYY.MM.DD
+    memory limit = 15461882265
+    bytes of memory used = 0
 
 or with authentication turned on 
 
-.. code-block:: none
+.. code-block:: bash
 
    $ ./arkouda_server -nl 1 --authenticate
-   arkouda server version = 2020.07.07
-   memory tracking = true
-   initialized the .arkouda directory /Your/PATH/arkouda/.arkouda
-   getMemLimit() = 123695058124
-   bytes of memoryUsed() = 2462
-   server listening on tcp://node01:5555?token=vikq8Co2fqv20usbrRnRtFsLr9nNbad
+   server listening on tcp://<your_machine>:5555?token=<token_string>
+    arkouda server version = vYYYY.MM.DD
+    memory limit = 15461882265
+    bytes of memory used = 0
 
 
 The last line is the most important, because it contains the connection url with the hostname and port required for the client to connect to the server.


### PR DESCRIPTION
This PR (closes #1176):

- Updates quickstart guide to show proper output from `./arkouda_server`
- Replaced release with empty string, so that browser tab does not include version.