### PR TITLE
Closes #1155: `ak.cast` doesn't work with numpy dtypes

### DIFF
--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -21,8 +21,9 @@ class ErrorMode(Enum):
     ignore = 'ignore'
     return_validity = 'return_validity'
 
+
 @typechecked
-def cast(pda : Union[pdarray, Strings], dt: Union[np.dtype,str], errors:ErrorMode=ErrorMode.strict) -> Union[Union[pdarray, Strings],Tuple[pdarray, pdarray]]:
+def cast(pda: Union[pdarray, Strings], dt: Union[np.dtype, type, str], errors: ErrorMode = ErrorMode.strict) -> Union[Union[pdarray, Strings], Tuple[pdarray, pdarray]]:
     """
     Cast an array to another dtype.
 
@@ -30,7 +31,7 @@ def cast(pda : Union[pdarray, Strings], dt: Union[np.dtype,str], errors:ErrorMod
     ----------
     pda : pdarray or Strings
         The array of values to cast
-    dtype : np.dtype or str
+    dt : np.dtype, type, or str
         The target dtype to cast values to
     errors : {strict, ignore, return_validity}
         Controls how errors are handled when casting strings to a numeric type


### PR DESCRIPTION
This PR (closes #1155):
- Adds `type` to allowed types for `dt` in the `ak.cast` function signature. This enables the use of np dtypes in addition to ak dtypes. 

```python
>>> ak.cast(ak.array([0,1,2,3,4]), ak.uint64)
array([0 1 2 3 4])

>>> ak.cast(ak.array([0,1,2,3,4]), np.uint64)
array([0 1 2 3 4])

>>> ak.cast(ak.array([0,1,2,3,4]), np.uint64).dtype
dtype('uint64')

>>> ak.cast(ak.array([0,1,2,3,4]), np.float64)
array([0 1 2 3 4])

>>> ak.cast(ak.array([0,1,2,3,4]), np.float64).dtype
dtype('float64')
```
This also enables this functionality for `ak.arange` since this uses `cast` under the hood
```python
>>> ak.arange(5, dtype=np.int64)
array([0 1 2 3 4])
```