### PR TITLE
Only read necessary elements in Chapel array for Parquet

### DIFF
--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -32,16 +32,16 @@ extern "C" {
   int64_t cpp_getNumRows(const char*, char** errMsg);
 
   int c_readColumnByName(const char* filename, void* chpl_arr,
-                         const char* colname, int64_t numElems, int64_t batchSize,
-                         char** errMsg);
+                         const char* colname, int64_t numElems, int64_t startIdx,
+                         int64_t batchSize, char** errMsg);
   int cpp_readColumnByName(const char* filename, void* chpl_arr,
-                           const char* colname, int64_t numElems, int64_t batchSize,
-                           char** errMsg);
+                           const char* colname, int64_t numElems, int64_t startIdx,
+                           int64_t batchSize, char** errMsg);
 
   int cpp_getStringColumnNumBytes(const char* filename, const char* colname,
-                                  void* chpl_offsets, char** errMsg);
+                                  void* chpl_offsets, int64_t numElems, int64_t startIdx, char** errMsg);
   int c_getStringColumnNumBytes(const char* filename, const char* colname,
-                                void* chpl_offsets, char** errMsg);
+                                void* chpl_offsets, int64_t numElems, int64_t startIdx, char** errMsg);
 
   int c_getType(const char* filename, const char* colname, char** errMsg);
   int cpp_getType(const char* filename, const char* colname, char** errMsg);


### PR DESCRIPTION
Previously, Parquet was having each node read the entire file of
any file that had an intersection with its local domain into a
temporary array and then assigning that local array to the
distributed array, which was resulting in extra communication
as well as keeping around a copy of the entire file, which would
mean that memory footprints on each node were much higher than
they needed to be.

This PR switches that to instead read directly into the local
portion of the distributed array and only the necessary number
of elements, skipping to the offset location of each file.

Here are some performance numbers collected on a 16-node-cs-hdr
using the `parquetIO` benchmark:

locales | master      | this branch
------- | ----------- | -----------
1       | 3.11 GiB/s  | 3.44 GiB/s
4       | 11.67 GiB/s | 14.02 GiB/s
8       | 22.43 GiB/s | 27.42 GiB/s
16      | 40.05 GiB/s | 49.27 GiB/s

String reading:
locales | master     | this branch
------- | ---------- | -----------
1       | 1.10 GiB/s | 1.66 GiB/s
4       | 1.09 GiB/s | 1.30 GiB/s
8       | 0.90 GiB/s | 1.22 GiB/s
16      | 0.88 GiB/s | 0.93 GiB/s