### PR TITLE
Closes #1197 & #1245 `SegArray` Set Operations

### DIFF
--- a/ServerModules.cfg
+++ b/ServerModules.cfg
@@ -5,6 +5,7 @@ ArraySetopsMsg
 KExtremeMsg
 ArgSortMsg
 SegmentedMsg
+SegArraySetopsMsg
 OperatorMsg
 RandMsg
 IndexingMsg

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -808,14 +808,14 @@ class SegArray:
 
     def intersect(self, other: SegArray, assume_unique: bool = False):
         """
-        Compute the intersection this SegArray with other.
+        Compute the intersection of this SegArray with other.
 
         Parameters
         ----------
         other : SegArray
             Second SegArray to use in intersection calucation
         assume_unique : bool
-            If True, the segmenst of each SegArray are both assumed to be unique, which can speed up the calculation.
+            If True, the segments of each SegArray are both assumed to be unique, which can speed up the calculation.
             Default is False.
 
         Returns
@@ -843,9 +843,9 @@ class SegArray:
             Second SegArray to use in union calucation
         """
         if self.size != other.size:
-            raise ValueError("SegArrays must have same number of segments to compute intersection.")
+            raise ValueError("SegArrays must have same number of segments to compute union.")
         if self.dtype != other.dtype:
-            raise TypeError("SegArrays must have the same dtype to compute intersection")
+            raise TypeError("SegArrays must have the same dtype to compute union")
 
         repMsg = t_cast(str, generic_msg(cmd="segarr_setops",
                                        args=f"union {self.segments.name} {self.values.name} {self.values.size} {other.segments.name} {other.values.name} {other.values.size}"))
@@ -859,16 +859,16 @@ class SegArray:
         Parameters
         ----------
         other : SegArray
-            Second SegArray to use in intersection calucation
+            Second SegArray to use in difference calucation
         assume_unique : bool
-            If True, the segmenst of each SegArray are both assumed to be unique, which can speed up the calculation.
+            If True, the segments of each SegArray are both assumed to be unique, which can speed up the calculation.
             Default is False.
         """
 
         if self.size != other.size:
-            raise ValueError("SegArrays must have same number of segments to compute intersection.")
+            raise ValueError("SegArrays must have same number of segments to compute difference.")
         if self.dtype != other.dtype:
-            raise TypeError("SegArrays must have the same dtype to compute intersection")
+            raise TypeError("SegArrays must have the same dtype to compute difference")
 
         repMsg = t_cast(str, generic_msg(cmd="segarr_setops",
                                        args=f"setdiff {self.segments.name} {self.values.name} {self.values.size} {other.segments.name} {other.values.name} {other.values.size} {assume_unique}"))
@@ -882,15 +882,15 @@ class SegArray:
         Parameters
         ----------
         other : SegArray
-            Second SegArray to use in intersection calucation
+            Second SegArray to use in xor calucation
         assume_unique : bool
-            If True, the segmenst of each SegArray are both assumed to be unique, which can speed up the calculation.
+            If True, the segments of each SegArray are both assumed to be unique, which can speed up the calculation.
             Default is False.
         """
         if self.size != other.size:
-            raise ValueError("SegArrays must have same number of segments to compute intersection.")
+            raise ValueError("SegArrays must have same number of segments to compute XOR.")
         if self.dtype != other.dtype:
-            raise TypeError("SegArrays must have the same dtype to compute intersection")
+            raise TypeError("SegArrays must have the same dtype to compute XOR")
 
         repMsg = t_cast(str, generic_msg(cmd="segarr_setops",
                                        args=f"setxor {self.segments.name} {self.values.name} {self.values.size} {other.segments.name} {other.values.name} {other.values.size} {assume_unique}"))

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
-
-from typing import cast
-
+from typing import cast as t_cast
 from arkouda.client import generic_msg
 from arkouda.pdarrayclass import pdarray, is_sorted, create_pdarray
 from arkouda.numeric import cumsum
@@ -830,10 +828,10 @@ class SegArray:
         if self.dtype != other.dtype:
             raise TypeError("SegArrays must have the same dtype to compute intersection")
 
-        repMsg = cast(str, generic_msg(cmd="segarr_setops",
+        repMsg = t_cast(str, generic_msg(cmd="segarr_setops",
                                        args=f"intersect {self.segments.name} {self.values.name} {self.values.size} {other.segments.name} {other.values.name} {other.values.size} {assume_unique}"))
         rep_ele = repMsg.split("+")
-        return SegArray(cast(pdarray, create_pdarray(rep_ele[0])), cast(pdarray, create_pdarray(rep_ele[1])))
+        return SegArray(t_cast(pdarray, create_pdarray(rep_ele[0])), t_cast(pdarray, create_pdarray(rep_ele[1])))
 
     def union(self, other: SegArray):
         """
@@ -849,10 +847,10 @@ class SegArray:
         if self.dtype != other.dtype:
             raise TypeError("SegArrays must have the same dtype to compute intersection")
 
-        repMsg = cast(str, generic_msg(cmd="segarr_setops",
+        repMsg = t_cast(str, generic_msg(cmd="segarr_setops",
                                        args=f"union {self.segments.name} {self.values.name} {self.values.size} {other.segments.name} {other.values.name} {other.values.size}"))
         rep_ele = repMsg.split("+")
-        return SegArray(cast(pdarray, create_pdarray(rep_ele[0])), cast(pdarray, create_pdarray(rep_ele[1])))
+        return SegArray(t_cast(pdarray, create_pdarray(rep_ele[0])), t_cast(pdarray, create_pdarray(rep_ele[1])))
 
     def difference(self, other: SegArray, assume_unique: bool = False):
         """
@@ -872,10 +870,10 @@ class SegArray:
         if self.dtype != other.dtype:
             raise TypeError("SegArrays must have the same dtype to compute intersection")
 
-        repMsg = cast(str, generic_msg(cmd="segarr_setops",
+        repMsg = t_cast(str, generic_msg(cmd="segarr_setops",
                                        args=f"setdiff {self.segments.name} {self.values.name} {self.values.size} {other.segments.name} {other.values.name} {other.values.size} {assume_unique}"))
         rep_ele = repMsg.split("+")
-        return SegArray(cast(pdarray, create_pdarray(rep_ele[0])), cast(pdarray, create_pdarray(rep_ele[1])))
+        return SegArray(t_cast(pdarray, create_pdarray(rep_ele[0])), t_cast(pdarray, create_pdarray(rep_ele[1])))
 
     def xor(self, other: SegArray, assume_unique: bool = False):
         """
@@ -894,10 +892,10 @@ class SegArray:
         if self.dtype != other.dtype:
             raise TypeError("SegArrays must have the same dtype to compute intersection")
 
-        repMsg = cast(str, generic_msg(cmd="segarr_setops",
+        repMsg = t_cast(str, generic_msg(cmd="segarr_setops",
                                        args=f"setxor {self.segments.name} {self.values.name} {self.values.size} {other.segments.name} {other.values.name} {other.values.size} {assume_unique}"))
         rep_ele = repMsg.split("+")
-        return SegArray(cast(pdarray, create_pdarray(rep_ele[0])), cast(pdarray, create_pdarray(rep_ele[1])))
+        return SegArray(t_cast(pdarray, create_pdarray(rep_ele[0])), t_cast(pdarray, create_pdarray(rep_ele[1])))
 
 
 

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -7,7 +7,7 @@ from arkouda.dtypes import int64 as akint64
 from arkouda.dtypes import bool as akbool
 from arkouda.dtypes import str_
 from arkouda.pdarraycreation import zeros, ones, array, arange
-from arkouda.pdarraysetops import concatenate, unique, intersect1d
+from arkouda.pdarraysetops import concatenate, unique, intersect1d, setdiff1d, setxor1d, union1d
 from arkouda.groupbyclass import GroupBy, broadcast
 from arkouda.pdarrayIO import load
 
@@ -806,7 +806,7 @@ class SegArray:
         return cls(segments, values)
 
     @classmethod
-    def intersection(cls, a, b):
+    def set_intx(cls, a, b):
         """
         Compute the intersection of 2 segmented arrays.
 
@@ -837,6 +837,86 @@ class SegArray:
             intx_segments[i] = 0 if i == 0 else (intx_vals[i - 1].size + intx_segments[i - 1])
 
         return SegArray(intx_segments, concatenate(intx_vals))
+
+    @classmethod
+    def set_union(cls, a, b):
+        """
+        Compute the union of 2 SegArrays
+
+        When computing the union on axis 0, segments, the segments from a and b will be returned as on SegArray.
+        When computing the union on axis 1, columns, the segments from b will be appended to segments in a.
+
+        Parameters
+        ----------
+        a : SegArray
+            First SegArray to use in intersection calculation
+        b : SegArray
+            Seconds SegArray to use in intersection calucation
+        """
+        if not (isinstance(a, SegArray) and isinstance(b, SegArray)):
+            raise TypeError("SegArray Intersections can only be computed on 2 SegArray objects.")
+        if a.size != b.size:
+            raise ValueError("SegArrays must have same number of 'rows' to compute intersection.")
+        if a.dtype != b.dtype:
+            raise TypeError("SegArrays must have the same dtype to compute intersection")
+
+        intx_vals = []
+        intx_segments = zeros(a.size, akint64)
+
+        for i in range(a.size):
+            intx_vals.append(union1d(a[i], b[i]))
+            intx_segments[i] = 0 if i == 0 else (intx_vals[i - 1].size + intx_segments[i - 1])
+
+        return SegArray(intx_segments, concatenate(intx_vals))
+
+    @classmethod
+    def set_difference(cls, a, b):
+        """
+        Compute the difference SegArrays
+
+        Parameters
+        ----------
+        a : SegArray
+            First SegArray to use in intersection calculation
+        b : SegArray
+            Seconds SegArray to use in intersection calucation
+        """
+
+        if not (isinstance(a, SegArray) and isinstance(b, SegArray)):
+            raise TypeError("SegArray Intersections can only be computed on 2 SegArray objects.")
+        if a.size != b.size:
+            raise ValueError("SegArrays must have same number of 'rows' to compute intersection.")
+        if a.dtype != b.dtype:
+            raise TypeError("SegArrays must have the same dtype to compute intersection")
+
+        intx_vals = []
+        intx_segments = zeros(a.size, akint64)
+
+        for i in range(a.size):
+            intx_vals.append(setdiff1d(a[i], b[i]))
+            intx_segments[i] = 0 if i == 0 else (intx_vals[i - 1].size + intx_segments[i - 1])
+
+        return SegArray(intx_segments, concatenate(intx_vals))
+
+    @classmethod
+    def set_xor(cls, a, b):
+        if not (isinstance(a, SegArray) and isinstance(b, SegArray)):
+            raise TypeError("SegArray Intersections can only be computed on 2 SegArray objects.")
+        if a.size != b.size:
+            raise ValueError("SegArrays must have same number of 'rows' to compute intersection.")
+        if a.dtype != b.dtype:
+            raise TypeError("SegArrays must have the same dtype to compute intersection")
+
+        intx_vals = []
+        intx_segments = zeros(a.size, akint64)
+
+        for i in range(a.size):
+            intx_vals.append(setxor1d(a[i], b[i]))
+            intx_segments[i] = 0 if i == 0 else (intx_vals[i - 1].size + intx_segments[i - 1])
+
+        return SegArray(intx_segments, concatenate(intx_vals))
+
+
 
 # Register/Attach functionality has been removed until it is added for GroupBy.
 # Please refer to ticket #1122 (https://github.com/Bears-R-Us/arkouda/issues/1122 for updates

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -10,7 +10,7 @@ from arkouda.dtypes import int64 as akint64
 from arkouda.dtypes import bool as akbool
 from arkouda.dtypes import str_
 from arkouda.pdarraycreation import zeros, ones, array, arange
-from arkouda.pdarraysetops import concatenate, intersect1d, setdiff1d, setxor1d, union1d
+from arkouda.pdarraysetops import concatenate
 from arkouda.groupbyclass import GroupBy, broadcast
 from arkouda.pdarrayIO import load
 
@@ -123,7 +123,7 @@ class SegArray:
         self._non_empty_count = self._non_empty.sum()
 
         if grouping is None:
-            if self.size == 0:
+            if self.size == 0 or self._non_empty_count == 0:
                 self.grouping = GroupBy(zeros(0, dtype=akint64))
             else:
                 # Treat each sub-array as a group, for grouped aggregations

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -7,7 +7,7 @@ from arkouda.dtypes import int64 as akint64
 from arkouda.dtypes import bool as akbool
 from arkouda.dtypes import str_
 from arkouda.pdarraycreation import zeros, ones, array, arange
-from arkouda.pdarraysetops import concatenate, unique, intersect1d, setdiff1d, setxor1d, union1d
+from arkouda.pdarraysetops import concatenate, intersect1d, setdiff1d, setxor1d, union1d
 from arkouda.groupbyclass import GroupBy, broadcast
 from arkouda.pdarrayIO import load
 
@@ -823,20 +823,14 @@ class SegArray:
         """
 
         if not (isinstance(a, SegArray) and isinstance(b, SegArray)):
-            raise TypeError("SegArray Intersections can only be computed on 2 SegArray objects.")
+            raise TypeError("SegArray setops require both objects to be SegArrays.")
         if a.size != b.size:
-            raise ValueError("SegArrays must have same number of 'rows' to compute intersection.")
+            raise ValueError("SegArrays must have same number of segments to compute intersection.")
         if a.dtype != b.dtype:
             raise TypeError("SegArrays must have the same dtype to compute intersection")
 
-        intx_vals = []
-        intx_segments = zeros(a.size, akint64)
-
-        for i in range(a.size):
-            intx_vals.append(intersect1d(a[i], b[i]))
-            intx_segments[i] = 0 if i == 0 else (intx_vals[i - 1].size + intx_segments[i - 1])
-
-        return SegArray(intx_segments, concatenate(intx_vals))
+        segs, vals = intersect1d((a.segments, a.values), (b.segments, b.values))
+        return SegArray(segs, vals)
 
     @classmethod
     def set_union(cls, a, b):
@@ -854,20 +848,14 @@ class SegArray:
             Seconds SegArray to use in union calucation
         """
         if not (isinstance(a, SegArray) and isinstance(b, SegArray)):
-            raise TypeError("SegArray Intersections can only be computed on 2 SegArray objects.")
+            raise TypeError("SegArray setops require both objects to be SegArrays.")
         if a.size != b.size:
-            raise ValueError("SegArrays must have same number of 'rows' to compute intersection.")
+            raise ValueError("SegArrays must have same number of segments to compute intersection.")
         if a.dtype != b.dtype:
             raise TypeError("SegArrays must have the same dtype to compute intersection")
 
-        intx_vals = []
-        intx_segments = zeros(a.size, akint64)
-
-        for i in range(a.size):
-            intx_vals.append(union1d(a[i], b[i]))
-            intx_segments[i] = 0 if i == 0 else (intx_vals[i - 1].size + intx_segments[i - 1])
-
-        return SegArray(intx_segments, concatenate(intx_vals))
+        segs, vals = union1d((a.segments, a.values), (b.segments, b.values))
+        return SegArray(segs, vals)
 
     @classmethod
     def set_difference(cls, a, b):
@@ -883,20 +871,14 @@ class SegArray:
         """
 
         if not (isinstance(a, SegArray) and isinstance(b, SegArray)):
-            raise TypeError("SegArray Intersections can only be computed on 2 SegArray objects.")
+            raise TypeError("SegArray setops require both objects to be SegArrays.")
         if a.size != b.size:
-            raise ValueError("SegArrays must have same number of 'rows' to compute intersection.")
+            raise ValueError("SegArrays must have same number of segments to compute intersection.")
         if a.dtype != b.dtype:
             raise TypeError("SegArrays must have the same dtype to compute intersection")
 
-        intx_vals = []
-        intx_segments = zeros(a.size, akint64)
-
-        for i in range(a.size):
-            intx_vals.append(setdiff1d(a[i], b[i]))
-            intx_segments[i] = 0 if i == 0 else (intx_vals[i - 1].size + intx_segments[i - 1])
-
-        return SegArray(intx_segments, concatenate(intx_vals))
+        segs, vals = setdiff1d((a.segments, a.values), (b.segments, b.values))
+        return SegArray(segs, vals)
 
     @classmethod
     def set_xor(cls, a, b):
@@ -911,20 +893,14 @@ class SegArray:
             Seconds SegArray to use in xor calucation
         """
         if not (isinstance(a, SegArray) and isinstance(b, SegArray)):
-            raise TypeError("SegArray Intersections can only be computed on 2 SegArray objects.")
+            raise TypeError("SegArray setops require both objects to be SegArrays.")
         if a.size != b.size:
-            raise ValueError("SegArrays must have same number of 'rows' to compute intersection.")
+            raise ValueError("SegArrays must have same number of segments to compute intersection.")
         if a.dtype != b.dtype:
             raise TypeError("SegArrays must have the same dtype to compute intersection")
 
-        intx_vals = []
-        intx_segments = zeros(a.size, akint64)
-
-        for i in range(a.size):
-            intx_vals.append(setxor1d(a[i], b[i]))
-            intx_segments[i] = 0 if i == 0 else (intx_vals[i - 1].size + intx_segments[i - 1])
-
-        return SegArray(intx_segments, concatenate(intx_vals))
+        segs, vals = setxor1d((a.segments, a.values), (b.segments, b.values))
+        return SegArray(segs, vals)
 
 
 

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -250,7 +250,9 @@ class SegArray:
         if isSupportedInt(i):
             start = self.segments[i]
             end = self.segments[i] + self.lengths[i]
-            return self.values[start:end].to_ndarray()
+            # TODO - this should be returning pdarray. Will this require updates. Currently, most tests fail with this
+            # return self.values[start:end].to_ndarray()
+            return self.values[start:end]
         elif (isinstance(i, pdarray) and (i.dtype == akint64 or i.dtype == akbool)) or isinstance(i, slice):
             starts = self.segments[i]
             ends = starts + self.lengths[i]

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -849,9 +849,9 @@ class SegArray:
         Parameters
         ----------
         a : SegArray
-            First SegArray to use in intersection calculation
+            First SegArray to use in union calculation
         b : SegArray
-            Seconds SegArray to use in intersection calucation
+            Seconds SegArray to use in union calucation
         """
         if not (isinstance(a, SegArray) and isinstance(b, SegArray)):
             raise TypeError("SegArray Intersections can only be computed on 2 SegArray objects.")
@@ -877,9 +877,9 @@ class SegArray:
         Parameters
         ----------
         a : SegArray
-            First SegArray to use in intersection calculation
+            First SegArray to use in difference calculation
         b : SegArray
-            Seconds SegArray to use in intersection calucation
+            Seconds SegArray to use in difference calucation
         """
 
         if not (isinstance(a, SegArray) and isinstance(b, SegArray)):
@@ -900,6 +900,16 @@ class SegArray:
 
     @classmethod
     def set_xor(cls, a, b):
+        """
+        Compute the symmetric difference SegArrays
+
+        Parameters
+        ----------
+        a : SegArray
+            First SegArray to use in xor calculation
+        b : SegArray
+            Seconds SegArray to use in xor calucation
+        """
         if not (isinstance(a, SegArray) and isinstance(b, SegArray)):
             raise TypeError("SegArray Intersections can only be computed on 2 SegArray objects.")
         if a.size != b.size:

--- a/benchmarks/segarray_setops.py
+++ b/benchmarks/segarray_setops.py
@@ -4,7 +4,7 @@ import time, argparse
 import numpy as np
 import arkouda as ak
 
-OPS = ('intersect', 'union', 'xor', 'difference')
+OPS = ('intersect', 'union', 'difference', 'xor')
 TYPES = ('int64', 'uint64')
 
 

--- a/benchmarks/segarray_setops.py
+++ b/benchmarks/segarray_setops.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+
+import time, argparse
+import numpy as np
+import arkouda as ak
+
+OPS = ('intersect', 'union', 'xor', 'difference')
+TYPES = ('int64', 'uint64')
+
+
+def time_ak_setops(N_per_locale, trials, dtype, seed):
+    print(">>> arkouda segarray {} setops".format(dtype))
+    cfg = ak.get_config()
+    N = N_per_locale * cfg["numLocales"]
+    print("numLocales = {}, N = {:,}".format(cfg["numLocales"], N))
+    if dtype == 'int64':
+        a = ak.randint(0, 2 ** 32, N, seed=seed)
+        b = ak.randint(0, 2 ** 32, N, seed=seed)
+        seg_a = ak.SegArray(ak.array([0, len(a)]), ak.array(a+b))
+        c = ak.randint(0, 2 ** 32, N, seed=seed)
+        d = ak.randint(0, 2 ** 32, N, seed=seed)
+        seg_b = ak.SegArray(ak.array([0, len(c)]), ak.array(c + d))
+    elif dtype == 'uint64':
+        a = ak.randint(0, 2 ** 32, N, seed=seed, dtype=ak.uint64)
+        b = ak.randint(0, 2 ** 32, N, seed=seed, dtype=ak.uint64)
+        seg_a = ak.SegArray(ak.array([0, len(a)]), ak.array(a+b))
+        c = ak.randint(0, 2 ** 32, N, seed=seed, dtype=ak.uint64)
+        d = ak.randint(0, 2 ** 32, N, seed=seed, dtype=ak.uint64)
+        seg_b = ak.SegArray(ak.array([0, len(c)]), ak.array(c+d))
+
+    timings = {op: [] for op in OPS}
+    results = {}
+    for i in range(trials):
+        for op in timings.keys():
+            fxn = getattr(seg_a, op)
+            start = time.time()
+            r = fxn(seg_b)
+            end = time.time()
+            timings[op].append(end - start)
+            results[op] = r
+    tavg = {op: sum(t) / trials for op, t in timings.items()}
+
+    for op, t in tavg.items():
+        print("  {} Average time = {:.4f} sec".format(op, t))
+        # bytes_per_sec = (a.size * a.itemsize * 2) / t
+        # print("  {} Average rate = {:.2f} GiB/sec".format(op, bytes_per_sec / 2 ** 30))
+
+
+def check_correctness(dtype, seed):
+    N = 10**4
+    if seed is not None:
+        np.random.seed(seed)
+    if dtype == 'int64':
+        a = np.random.randint(0, 2**32, N)
+        b = np.random.randint(0, 2**32, N)
+    if dtype == 'uint64':
+        a = np.random.randint(0, 2**32, N, dtype=ak.uint64)
+        b = np.random.randint(0, 2**32, N, dtype=ak.uint64)
+
+    for op in OPS:
+        npa = a
+        npb = b
+        aka = ak.array(a)
+        akb = ak.array(b)
+        fxn = getattr(np, op)
+        npr = fxn(npa, npb)
+        fxn = getattr(ak, op)
+        akr = fxn(aka, akb)
+        np.isclose(npr, akr.to_ndarray())
+
+
+def create_parser():
+    parser = argparse.ArgumentParser(description="Run the setops benchmarks: intersect1d, union1d, setdiff1d, setxor1d")
+    parser.add_argument('hostname', help='Hostname of arkouda server')
+    parser.add_argument('port', type=int, help='Port of arkouda server')
+    parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: length of arrays A and B')
+    parser.add_argument('-t', '--trials', type=int, default=1, help='Number of times to run the benchmark')
+    parser.add_argument('-d', '--dtype', default='int64', help='Dtype of array ({})'.format(', '.join(TYPES)))
+    parser.add_argument('--numpy', default=False, action='store_true', help='Run the same operation in NumPy to compare performance.')
+    parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
+    parser.add_argument('-s', '--seed', default=None, type=int, help='Value to initialize random number generator')
+    return parser
+
+
+if __name__ == "__main__":
+    import sys
+
+    parser = create_parser()
+    args = parser.parse_args()
+    if args.dtype not in TYPES:
+        raise ValueError("Dtype must be {}, not {}".format('/'.join(TYPES), args.dtype))
+
+    ak.verbose = False
+    ak.connect(args.hostname, args.port)
+
+    if args.correctness_only:
+        for dtype in TYPES:
+            check_correctness(dtype, args.seed)
+        sys.exit(0)
+
+    print("array size = {:,}".format(args.size))
+    print("number of trials = ", args.trials)
+    time_ak_setops(args.size, args.trials, args.dtype, args.seed)
+    # if args.numpy:
+    #     time_np_setops(args.size, args.trials, args.dtype, args.seed)
+    #     print("Verifying agreement between arkouda and NumPy on small problem... ", end="")
+    #     check_correctness(args.dtype, args.seed)
+    #     print("CORRECT")
+
+    sys.exit(0)

--- a/benchmarks/segarray_setops.py
+++ b/benchmarks/segarray_setops.py
@@ -47,7 +47,7 @@ def time_ak_setops(N_per_locale, trials, dtype, seed):
 
 
 def check_correctness(dtype):
-    N = 10
+    N = 10**4
     if dtype == 'int64':
         a = np.random.randint(0, 2 ** 32, N)
         b = np.random.randint(0, 2 ** 32, N)
@@ -81,7 +81,7 @@ def create_parser():
     parser = argparse.ArgumentParser(description="Run the setops benchmarks: intersect1d, union1d, setdiff1d, setxor1d")
     parser.add_argument('hostname', help='Hostname of arkouda server')
     parser.add_argument('port', type=int, help='Port of arkouda server')
-    parser.add_argument('-n', '--size', type=int, default=10, help='Problem size: length of arrays A and B')
+    parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: length of arrays A and B')
     parser.add_argument('-t', '--trials', type=int, default=1, help='Number of times to run the benchmark')
     parser.add_argument('-d', '--dtype', default='int64', help='Dtype of array ({})'.format(', '.join(TYPES)))
     parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')

--- a/benchmarks/segarray_setops.py
+++ b/benchmarks/segarray_setops.py
@@ -74,7 +74,7 @@ def check_correctness(dtype):
 
         assert (op_result.size == seg_a.size)
         assert (np.array_equal(op_result[0].to_ndarray(), np_result_1))
-        # np.isclose(np_result_2, op_result[1])
+        assert (np.array_equal(op_result[1].to_ndarray(), np_result_2))
 
 
 def create_parser():

--- a/benchmarks/segarray_setops.py
+++ b/benchmarks/segarray_setops.py
@@ -16,17 +16,17 @@ def time_ak_setops(N_per_locale, trials, dtype, seed):
     if dtype == 'int64':
         a = ak.randint(0, 2 ** 32, N, seed=seed)
         b = ak.randint(0, 2 ** 32, N, seed=seed)
-        seg_a = ak.SegArray(ak.array([0, len(a)]), ak.array(a+b))
+        seg_a = ak.SegArray(ak.array([0, len(a)]), ak.concatenate([a, b]))
         c = ak.randint(0, 2 ** 32, N, seed=seed)
         d = ak.randint(0, 2 ** 32, N, seed=seed)
-        seg_b = ak.SegArray(ak.array([0, len(c)]), ak.array(c + d))
+        seg_b = ak.SegArray(ak.array([0, len(c)]), ak.concatenate([c, d]))
     elif dtype == 'uint64':
         a = ak.randint(0, 2 ** 32, N, seed=seed, dtype=ak.uint64)
         b = ak.randint(0, 2 ** 32, N, seed=seed, dtype=ak.uint64)
-        seg_a = ak.SegArray(ak.array([0, len(a)]), ak.array(a+b))
+        seg_a = ak.SegArray(ak.array([0, len(a)]), ak.concatenate[[a, b]])
         c = ak.randint(0, 2 ** 32, N, seed=seed, dtype=ak.uint64)
         d = ak.randint(0, 2 ** 32, N, seed=seed, dtype=ak.uint64)
-        seg_b = ak.SegArray(ak.array([0, len(c)]), ak.array(c+d))
+        seg_b = ak.SegArray(ak.array([0, len(c)]), ak.concatenate([c, d]))
 
     timings = {op: [] for op in OPS}
     results = {}
@@ -46,37 +46,44 @@ def time_ak_setops(N_per_locale, trials, dtype, seed):
         # print("  {} Average rate = {:.2f} GiB/sec".format(op, bytes_per_sec / 2 ** 30))
 
 
-def check_correctness(dtype, seed):
-    N = 10**4
-    if seed is not None:
-        np.random.seed(seed)
+def check_correctness(dtype):
+    N = 10
     if dtype == 'int64':
-        a = np.random.randint(0, 2**32, N)
-        b = np.random.randint(0, 2**32, N)
-    if dtype == 'uint64':
-        a = np.random.randint(0, 2**32, N, dtype=ak.uint64)
-        b = np.random.randint(0, 2**32, N, dtype=ak.uint64)
+        a = np.random.randint(0, 2 ** 32, N)
+        b = np.random.randint(0, 2 ** 32, N)
+        seg_a = ak.SegArray(ak.array([0, len(a)]), ak.array(np.concatenate([a, b])))
+        c = np.random.randint(0, 2 ** 32, N)
+        d = np.random.randint(0, 2 ** 32, N)
+        seg_b = ak.SegArray(ak.array([0, len(c)]), ak.array(np.concatenate([c, d])))
+    elif dtype == 'uint64':
+        a = np.random.randint(0, 2 ** 32, N, dtype=ak.uint64)
+        b = np.random.randint(0, 2 ** 32, N, dtype=ak.uint64)
+        seg_a = ak.SegArray(ak.array([0, len(a)]), ak.array(np.concatenate([a, b])))
+        c = np.random.randint(0, 2 ** 32, N, dtype=ak.uint64)
+        d = np.random.randint(0, 2 ** 32, N, dtype=ak.uint64)
+        seg_b = ak.SegArray(ak.array([0, len(c)]), ak.array(np.concatenate([c, d])))
+
+    np_to_seg = {'intersect': 'intersect1d', 'union': 'union1d', 'xor': 'setxor1d', 'difference': 'setdiff1d'}
 
     for op in OPS:
-        npa = a
-        npb = b
-        aka = ak.array(a)
-        akb = ak.array(b)
-        fxn = getattr(np, op)
-        npr = fxn(npa, npb)
-        fxn = getattr(ak, op)
-        akr = fxn(aka, akb)
-        np.isclose(npr, akr.to_ndarray())
+        fxn = getattr(np, np_to_seg[op])
+        np_result_1 = fxn(a, c)
+        np_result_2 = fxn(b, d)
+        fxn = getattr(seg_a, op)
+        op_result = fxn(seg_b)
+
+        assert (op_result.size == seg_a.size)
+        assert (np.array_equal(op_result[0].to_ndarray(), np_result_1))
+        # np.isclose(np_result_2, op_result[1])
 
 
 def create_parser():
     parser = argparse.ArgumentParser(description="Run the setops benchmarks: intersect1d, union1d, setdiff1d, setxor1d")
     parser.add_argument('hostname', help='Hostname of arkouda server')
     parser.add_argument('port', type=int, help='Port of arkouda server')
-    parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: length of arrays A and B')
+    parser.add_argument('-n', '--size', type=int, default=10, help='Problem size: length of arrays A and B')
     parser.add_argument('-t', '--trials', type=int, default=1, help='Number of times to run the benchmark')
     parser.add_argument('-d', '--dtype', default='int64', help='Dtype of array ({})'.format(', '.join(TYPES)))
-    parser.add_argument('--numpy', default=False, action='store_true', help='Run the same operation in NumPy to compare performance.')
     parser.add_argument('--correctness-only', default=False, action='store_true', help='Only check correctness, not performance.')
     parser.add_argument('-s', '--seed', default=None, type=int, help='Value to initialize random number generator')
     return parser
@@ -90,21 +97,16 @@ if __name__ == "__main__":
     if args.dtype not in TYPES:
         raise ValueError("Dtype must be {}, not {}".format('/'.join(TYPES), args.dtype))
 
-    ak.verbose = False
+    ak.verbose = True
     ak.connect(args.hostname, args.port)
 
     if args.correctness_only:
         for dtype in TYPES:
-            check_correctness(dtype, args.seed)
+            check_correctness(dtype)
         sys.exit(0)
 
     print("array size = {:,}".format(args.size))
     print("number of trials = ", args.trials)
     time_ak_setops(args.size, args.trials, args.dtype, args.seed)
-    # if args.numpy:
-    #     time_np_setops(args.size, args.trials, args.dtype, args.seed)
-    #     print("Verifying agreement between arkouda and NumPy on small problem... ", end="")
-    #     check_correctness(args.dtype, args.seed)
-    #     print("CORRECT")
 
     sys.exit(0)

--- a/src/SegArraySetops.chpl
+++ b/src/SegArraySetops.chpl
@@ -23,8 +23,8 @@ module SegArraySetops {
         agg.copy(ul, l1);
       }
       else{
-        var slice1: [{0..#l1}] t = values1.a[s1..#l1];
-        var slice2: [{0..#l2}] t = values2.a[s2..#l2];
+        var slice1: [makeDistDom(l1)] t = values1.a[s1..#l1];
+        var slice2: [makeDistDom(l2)] t = values2.a[s2..#l2];
         var u = union1d(slice1, slice2);
         agg.copy(ul, u.size);
       }
@@ -47,8 +47,8 @@ module SegArraySetops {
           agg.copy(union_vals[i+us], u.ptr[i]);
         }
       } else {
-        var slice1: [{0..#l1}] t = values1.a[s1..#l1];
-        var slice2: [{0..#l2}] t = values2.a[s2..#l2];
+        var slice1: [makeDistDom(l1)] t = values1.a[s1..#l1];
+        var slice2: [makeDistDom(l2)] t = values2.a[s2..#l2];
         var u = new lowLevelLocalizingSlice(union1d(slice1, slice2), 0..#ul);
         for i in (0..#ul){
           agg.copy(union_vals[i+us], u.ptr[i]);
@@ -69,8 +69,8 @@ module SegArraySetops {
       if (l1 == 0 || l2 == 0) {
         agg.copy(il, 0);
       } else {
-        var slice1: [{0..#l1}] t = values1.a[s1..#l1];
-        var slice2: [{0..#l2}] t = values2.a[s2..#l2];
+        var slice1: [makeDistDom(l1)] t = values1.a[s1..#l1];
+        var slice2: [makeDistDom(l2)] t = values2.a[s2..#l2];
         var intx = intersect1d(slice1, slice2, isUnique);
         agg.copy(il, intx.size);
       }
@@ -83,8 +83,8 @@ module SegArraySetops {
     forall (idx, s1, l1, s2, l2, is, il) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_segs, intx_lens) with (var agg = newDstAggregator(t)){
       // TODO - update to use lowLevelLocalizingSlice 
       if (il > 0){
-        var slice1: [{0..#l1}] t = values1.a[s1..#l1];
-        var slice2: [{0..#l2}] t = values2.a[s2..#l2];
+        var slice1: [makeDistDom(l1)] t = values1.a[s1..#l1];
+        var slice2: [makeDistDom(l2)] t = values2.a[s2..#l2];
         var intx = new lowLevelLocalizingSlice(intersect1d(slice1, slice2, isUnique), 0..#il);
         for i in (0..#il){
             agg.copy(intx_vals[i+is], intx.ptr[i]);
@@ -108,8 +108,8 @@ module SegArraySetops {
         agg.copy(xl, l1);
       }
       else {
-        var slice1: [{0..#l1}] t = values1.a[s1..#l1];
-        var slice2: [{0..#l2}] t = values2.a[s2..#l2];
+        var slice1: [makeDistDom(l1)] t = values1.a[s1..#l1];
+        var slice2: [makeDistDom(l2)] t = values2.a[s2..#l2];
         var xor = setxor1d(slice1, slice2, isUnique);
         agg.copy(xl, xor.size);
       }
@@ -132,8 +132,8 @@ module SegArraySetops {
           agg.copy(xor_vals[i+xs], xor.ptr[i]);
         }
       } else {
-        var slice1: [{0..#l1}] t = values1.a[s1..#l1];
-        var slice2: [{0..#l2}] t = values2.a[s2..#l2];
+        var slice1: [makeDistDom(l1)] t = values1.a[s1..#l1];
+        var slice2: [makeDistDom(l2)] t = values2.a[s2..#l2];
         var xor = new lowLevelLocalizingSlice(setxor1d(slice1, slice2, isUnique), 0..#xl);
         for i in (0..#xl){
           agg.copy(xor_vals[i+xs], xor.ptr[i]);
@@ -154,8 +154,8 @@ module SegArraySetops {
       if (l1 == 0 || l2 == 0){
         agg.copy(dl, l1);
       } else {
-        var slice1: [{0..#l1}] t = values1.a[s1..#l1];
-        var slice2: [{0..#l2}] t = values2.a[s2..#l2];
+        var slice1: [makeDistDom(l1)] t = values1.a[s1..#l1];
+        var slice2: [makeDistDom(l2)] t = values2.a[s2..#l2];
         var d = setdiff1d(slice1, slice2, isUnique);
         agg.copy(dl, d.size);
       }
@@ -173,8 +173,8 @@ module SegArraySetops {
           agg.copy(diff_vals[i + ds], d.ptr[i]);
         }
       } else {
-        var slice1: [{0..#l1}] t = values1.a[s1..#l1];
-        var slice2: [{0..#l2}] t = values2.a[s2..#l2];
+        var slice1: [makeDistDom(l1)] t = values1.a[s1..#l1];
+        var slice2: [makeDistDom(l2)] t = values2.a[s2..#l2];
         var d = new lowLevelLocalizingSlice(setdiff1d(slice1, slice2, isUnique), 0..#dl);
         for i in (0..#dl){
           agg.copy(diff_vals[i+ds], d.ptr[i]);

--- a/src/SegArraySetops.chpl
+++ b/src/SegArraySetops.chpl
@@ -23,7 +23,9 @@ module SegArraySetops {
         agg.copy(ul, l1);
       }
       else{
-        var u = union1d(values1.a[s1..#l1], values2.a[s2..#l2]);
+        var slice1: [{0..#l1}] t = values1.a[s1..#l1];
+        var slice2: [{0..#l2}] t = values2.a[s2..#l2];
+        var u = union1d(slice1, slice2);
         agg.copy(ul, u.size);
       }
     }
@@ -45,7 +47,9 @@ module SegArraySetops {
           agg.copy(union_vals[i+us], u.ptr[i]);
         }
       } else {
-        var u = new lowLevelLocalizingSlice(union1d(values1.a[s1..#l1], values2.a[s2..#l2]), 0..#ul);
+        var slice1: [{0..#l1}] t = values1.a[s1..#l1];
+        var slice2: [{0..#l2}] t = values2.a[s2..#l2];
+        var u = new lowLevelLocalizingSlice(union1d(slice1, slice2), 0..#ul);
         for i in (0..#ul){
           agg.copy(union_vals[i+us], u.ptr[i]);
         }
@@ -65,7 +69,9 @@ module SegArraySetops {
       if (l1 == 0 || l2 == 0) {
         agg.copy(il, 0);
       } else {
-        var intx = intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+        var slice1: [{0..#l1}] t = values1.a[s1..#l1];
+        var slice2: [{0..#l2}] t = values2.a[s2..#l2];
+        var intx = intersect1d(slice1, slice2, isUnique);
         agg.copy(il, intx.size);
       }
     }
@@ -77,7 +83,9 @@ module SegArraySetops {
     forall (idx, s1, l1, s2, l2, is, il) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_segs, intx_lens) with (var agg = newDstAggregator(t)){
       // TODO - update to use lowLevelLocalizingSlice 
       if (il > 0){
-        var intx = new lowLevelLocalizingSlice(intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique), 0..#il);
+        var slice1: [{0..#l1}] t = values1.a[s1..#l1];
+        var slice2: [{0..#l2}] t = values2.a[s2..#l2];
+        var intx = new lowLevelLocalizingSlice(intersect1d(slice1, slice2, isUnique), 0..#il);
         for i in (0..#il){
             agg.copy(intx_vals[i+is], intx.ptr[i]);
         }
@@ -100,7 +108,9 @@ module SegArraySetops {
         agg.copy(xl, l1);
       }
       else {
-        var xor = setxor1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+        var slice1: [{0..#l1}] t = values1.a[s1..#l1];
+        var slice2: [{0..#l2}] t = values2.a[s2..#l2];
+        var xor = setxor1d(slice1, slice2, isUnique);
         agg.copy(xl, xor.size);
       }
     }
@@ -122,7 +132,9 @@ module SegArraySetops {
           agg.copy(xor_vals[i+xs], xor.ptr[i]);
         }
       } else {
-        var xor = new lowLevelLocalizingSlice(setxor1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique), 0..#xl);
+        var slice1: [{0..#l1}] t = values1.a[s1..#l1];
+        var slice2: [{0..#l2}] t = values2.a[s2..#l2];
+        var xor = new lowLevelLocalizingSlice(setxor1d(slice1, slice2, isUnique), 0..#xl);
         for i in (0..#xl){
           agg.copy(xor_vals[i+xs], xor.ptr[i]);
         }
@@ -142,7 +154,9 @@ module SegArraySetops {
       if (l1 == 0 || l2 == 0){
         agg.copy(dl, l1);
       } else {
-        var d = setdiff1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+        var slice1: [{0..#l1}] t = values1.a[s1..#l1];
+        var slice2: [{0..#l2}] t = values2.a[s2..#l2];
+        var d = setdiff1d(slice1, slice2, isUnique);
         agg.copy(dl, d.size);
       }
     }
@@ -159,7 +173,9 @@ module SegArraySetops {
           agg.copy(diff_vals[i + ds], d.ptr[i]);
         }
       } else {
-        var d = new lowLevelLocalizingSlice(setdiff1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique), 0..#dl);
+        var slice1: [{0..#l1}] t = values1.a[s1..#l1];
+        var slice2: [{0..#l2}] t = values2.a[s2..#l2];
+        var d = new lowLevelLocalizingSlice(setdiff1d(slice1, slice2, isUnique), 0..#dl);
         for i in (0..#dl){
           agg.copy(diff_vals[i+ds], d.ptr[i]);
         }

--- a/src/SegArraySetops.chpl
+++ b/src/SegArraySetops.chpl
@@ -5,6 +5,11 @@ module SegArraySetops {
   use AryUtil;
   use MultiTypeSymEntry;
 
+  use Logging;
+
+  private config const logLevel = ServerConfig.logLevel;
+  const segLogger = new Logger(logLevel);
+
   proc union_sa(segments1: borrowed SymEntry(int), values1: borrowed SymEntry(?t), lens1: [] int, segments2: borrowed SymEntry(int), values2: borrowed SymEntry(t), lens2: [] int) throws {
     var union_lens: [segments1.aD] int;
 

--- a/src/SegArraySetops.chpl
+++ b/src/SegArraySetops.chpl
@@ -1,0 +1,146 @@
+module SegArraySetops {
+  use ServerConfig;
+  use ArraySetops;
+  use CommAggregation;
+  use AryUtil;
+  use MultiTypeSymEntry;
+
+  proc union_sa(segments1: borrowed SymEntry(int), values1: borrowed SymEntry(?t), lens1: [] int, segments2: borrowed SymEntry(int), values2: borrowed SymEntry(t), lens2: [] int) throws {
+    var union_lens: [segments1.aD] int;
+
+    // Compute lengths of the segments resulting from each union
+    forall (idx, s1, l1, s2, l2, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, union_lens) with (var agg = newDstAggregator(int)){
+      // TODO - update to use lowLevelLocalizingSlice 
+      if (l1 == 0) {
+        agg.copy(ul, l2);
+      }
+      else if (l2 == 0) {
+        agg.copy(ul, l1);
+      }
+      else{
+        var u = union1d(values1.a[s1..#l1], values2.a[s2..#l2]);
+        agg.copy(ul, u.size);
+      }
+    }
+
+    const union_segs = (+ scan union_lens) - union_lens;
+    var union_vals = makeDistArray((+ reduce union_lens), t);
+
+    // Compute the union and add values to the corresponding indexes in values
+    forall (idx, s1, l1, s2, l2, us, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, union_segs, union_lens) with (var agg = newDstAggregator(t)){
+      // TODO - update to use lowLevelLocalizingSlice 
+      if (l1 == 0){
+        var u = new lowLevelLocalizingSlice(values2.a, s2..#l2);
+        for i in (0..#l2) {
+          agg.copy(union_vals[i+us], u.ptr[i]);
+        }
+      } else if (l2 == 0) {
+        var u = new lowLevelLocalizingSlice(values1.a, s1..#l1);
+        for i in (0..#l1) {
+          agg.copy(union_vals[i+us], u.ptr[i]);
+        }
+      } else {
+        var u = new lowLevelLocalizingSlice(union1d(values1.a[s1..#l1], values2.a[s2..#l2]), 0..#ul);
+        for i in (0..#ul){
+          agg.copy(union_vals[i+us], u.ptr[i]);
+        }
+      }
+    }
+
+    return (union_segs, union_vals);
+  }
+
+  proc intersect(segments1: borrowed SymEntry(int), values1: borrowed SymEntry(?t), lens1: [] int, segments2: borrowed SymEntry(int), values2: borrowed SymEntry(t), lens2: [] int, isUnique: bool) throws {
+    var intx_lens: [segments1.aD] int;
+
+    // Compute lengths of the segments resulting from each union
+    forall (idx, s1, l1, s2, l2, il) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_lens) with (var agg = newDstAggregator(int)){
+      // TODO - update to use lowLevelLocalizingSlice 
+      // if either segment is empty, intersection is empty
+      if (l1 == 0 || l2 == 0) {
+        agg.copy(il, 0);
+      } else {
+        var intx = intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+        agg.copy(il, intx.size);
+      }
+    }
+
+    const intx_segs = (+ scan intx_lens) - intx_lens;
+    var intx_vals = makeDistArray((+ reduce intx_lens), t);
+
+    // Compute the intersection and add values to the corresponding indexes in values
+    forall (idx, s1, l1, s2, l2, is, il) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_segs, intx_lens) with (var agg = newDstAggregator(t)){
+      // TODO - update to use lowLevelLocalizingSlice 
+      if (il > 0){
+        var intx = new lowLevelLocalizingSlice(intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique), 0..#il);
+        for i in (0..#il){
+            agg.copy(intx_vals[i+is], intx.ptr[i]);
+        }
+      }
+    }
+
+    return (intx_segs, intx_vals);
+  }
+
+  proc setxor(segments1: borrowed SymEntry(int), values1: borrowed SymEntry(?t), lens1: [] int, segments2: borrowed SymEntry(int), values2: borrowed SymEntry(t), lens2: [] int, isUnique: bool) throws {
+    var xor_lens: [segments1.aD] int;
+
+    // Compute lengths of the segments resulting from each union
+    forall (idx, s1, l1, s2, l2, xl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, xor_lens) with (var agg = newDstAggregator(int)){
+      // TODO - update to use lowLevelLocalizingSlice 
+      var xor = setxor1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+      agg.copy(xl, xor.size);
+    }
+
+    const xor_segs = (+ scan xor_lens) - xor_lens;
+    var xor_vals = makeDistArray((+ reduce xor_lens), t);
+
+    // Compute the setxor and add values to the corresponding indexes in values
+    forall (idx, s1, l1, s2, l2, xs, xl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, xor_segs, xor_lens) with (var agg = newDstAggregator(t)){
+      // TODO - update to use lowLevelLocalizingSlice 
+      var xor = new lowLevelLocalizingSlice(setxor1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique), 0..#xl);
+      for i in (0..#xl){
+        agg.copy(xor_vals[i+xs], xor.ptr[i]);
+      }
+    }
+
+    return (xor_segs, xor_vals);
+  }
+
+  proc setdiff(segments1: borrowed SymEntry(int), values1: borrowed SymEntry(?t), lens1: [] int, segments2: borrowed SymEntry(int), values2: borrowed SymEntry(t), lens2: [] int, isUnique: bool) throws {
+    var diff_lens: [segments1.aD] int;
+
+    // Compute lengths of the segments resulting from each union
+    forall (idx, s1, l1, s2, l2, dl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, diff_lens) with (var agg = newDstAggregator(int)){
+      // TODO - update to use lowLevelLocalizingSlice 
+      if (l1 == 0 || l2 == 0){
+        agg.copy(dl, l1);
+      } else {
+        var d = setdiff1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+        agg.copy(dl, d.size);
+      }
+    }
+
+    const diff_segs = (+ scan diff_lens) - diff_lens;
+    var diff_vals = makeDistArray((+ reduce diff_lens), t);
+
+    // Compute the difference and add values to the corresponding indexes in values
+    forall (idx, s1, l1, s2, l2, ds, dl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, diff_segs, diff_lens) with (var agg = newDstAggregator(t)){
+      // TODO - update to use lowLevelLocalizingSlice 
+      if (l1 == 0 || l2 == 0){
+        var d = new lowLevelLocalizingSlice(values1.a, s1..#l1);
+        for i in (0..#l1) {
+          agg.copy(diff_vals[i + ds], d.ptr[i]);
+        }
+      } else {
+        var d = new lowLevelLocalizingSlice(setdiff1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique), 0..#dl);
+        for i in (0..#dl){
+          agg.copy(diff_vals[i+ds], d.ptr[i]);
+        }
+      }
+    }
+
+    return (diff_segs, diff_vals);
+  }
+    
+}

--- a/src/SegArraySetopsMsg.chpl
+++ b/src/SegArraySetopsMsg.chpl
@@ -1,0 +1,168 @@
+module SegArraySetopsMsg {
+    use ServerConfig;
+
+    use Time only;
+    use Math only;
+    use Reflection only;
+
+    use MultiTypeSymbolTable;
+    use MultiTypeSymEntry;
+    use SegmentedArray;
+    use ServerErrorStrings;
+
+    use SegArraySetops;
+    use Indexing;
+    use RadixSortLSD;
+    use Reflection;
+    use ServerErrors;
+    use Logging;
+    use Message;
+
+    private config const logLevel = ServerConfig.logLevel;
+    const segLogger = new Logger(logLevel);
+
+    proc setopsMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+        param pn = Reflection.getRoutineName();
+        var repMsg: string; // response message
+        // split request into fields
+        var (sub_command, seg1_name, vals1_name, s1_str, seg2_name, vals2_name, s2_str, assume_unique) = payload.splitMsgToTuple(8);
+        var isUnique = if assume_unique != "" then stringtobool(assume_unique) else false;
+
+        var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(seg1_name, st);
+        var gEnt2: borrowed GenSymEntry = getGenericTypedArrayEntry(vals1_name, st);
+        var gEnt3: borrowed GenSymEntry = getGenericTypedArrayEntry(seg2_name, st);
+        var gEnt4: borrowed GenSymEntry = getGenericTypedArrayEntry(vals2_name, st);
+
+        // verify that expected integer values can be cast
+        var size1: int;
+        var size2: int;
+        try{
+            size1 = s1_str: int;
+            size2 = s2_str: int;
+        }
+        catch {
+            var errorMsg = "size1 or size2 could not be interpreted as an int size1: %s, size2: %s)".format(s1_str, s2_str);
+            segLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            throw new owned IllegalArgumentError(errorMsg);
+        }
+
+        var segments1 = toSymEntry(gEnt,int);
+        var segments2 = toSymEntry(gEnt3,int);
+
+        // set segment lengths
+        var lens1: [segments1.aD] int;
+        var lens2: [segments2.aD] int;
+        var high = segments1.aD.high;
+        forall (i, s1, l1, s2, l2) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2){
+            if i == high {
+                l1 = size1 - s1;
+                l2 = size2 - s2;
+            }
+            else{
+                l1 = segments1.a[i+1] - s1;
+                l2 = segments2.a[i+1] - s2;
+            }
+        }
+        var m1: int = max reduce lens1;
+        var m2: int = max reduce lens2;
+
+        // perform memory exhaustion check using the size of the largest segment present
+        var itemsize = if gEnt2.dtype == DType.UInt64 then numBytes(uint) else numBytes(int);
+        var sortMem1 = radixSortLSD_memEst(m1, itemsize);
+        var sortMem2 = radixSortLSD_memEst(m2, itemsize);
+        var union_maxMem = max(sortMem1, sortMem2);
+        overMemLimit(union_maxMem);
+
+        var s_name = st.nextName();
+        var v_name = st.nextName();
+
+        select(gEnt2.dtype, gEnt4.dtype){
+        when(DType.Int64, DType.Int64){
+            var values1 = toSymEntry(gEnt2,int);
+            var values2 = toSymEntry(gEnt4,int);
+            select(sub_command){
+            when("union"){
+                var (segments, values) = union_sa(segments1, values1, lens1, segments2, values2, lens2);
+                st.addEntry(s_name, new shared SymEntry(segments));
+                st.addEntry(v_name, new shared SymEntry(values));
+            }
+            when("intersect"){
+                var (segments, values) = intersect(segments1, values1, lens1, segments2, values2, lens2, isUnique);
+                st.addEntry(s_name, new shared SymEntry(segments));
+                st.addEntry(v_name, new shared SymEntry(values));
+            }
+            when("setdiff"){
+                var (segments, values) = setdiff(segments1, values1, lens1, segments2, values2, lens2, isUnique);
+                st.addEntry(s_name, new shared SymEntry(segments));
+                st.addEntry(v_name, new shared SymEntry(values));
+            }
+            when("setxor"){
+                var (segments, values) = setxor(segments1, values1, lens1, segments2, values2, lens2, isUnique);
+                st.addEntry(s_name, new shared SymEntry(segments));
+                st.addEntry(v_name, new shared SymEntry(values));
+            }
+            otherwise {
+                var errorMsg = notImplementedError("setops1d_multi", sub_command);
+                segLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                   
+                return new MsgTuple(errorMsg, MsgType.ERROR);              
+            }
+            }
+        }
+        when(DType.UInt64, DType.UInt64){
+            var values1 = toSymEntry(gEnt2,uint);
+            var values2 = toSymEntry(gEnt4,uint);
+            select(sub_command){
+            when("union"){
+                var (segments, values) = union_sa(segments1, values1, lens1, segments2, values2, lens2);
+                st.addEntry(s_name, new shared SymEntry(segments));
+                st.addEntry(v_name, new shared SymEntry(values));
+            }
+            when("intersect"){
+                var (segments, values) = intersect(segments1, values1, lens1, segments2, values2, lens2, isUnique);
+                st.addEntry(s_name, new shared SymEntry(segments));
+                st.addEntry(v_name, new shared SymEntry(values));
+            }
+            when("setdiff"){
+                var (segments, values) = setdiff(segments1, values1, lens1, segments2, values2, lens2, isUnique);
+                st.addEntry(s_name, new shared SymEntry(segments));
+                st.addEntry(v_name, new shared SymEntry(values));
+            }
+            when("setxor"){
+                var (segments, values) = setxor(segments1, values1, lens1, segments2, values2, lens2, isUnique);
+                st.addEntry(s_name, new shared SymEntry(segments));
+                st.addEntry(v_name, new shared SymEntry(values));
+            }
+            otherwise {
+                var errorMsg = notImplementedError("segarr_setops", sub_command);
+                segLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                   
+                return new MsgTuple(errorMsg, MsgType.ERROR);              
+            }
+            }
+        }
+        otherwise {
+            var errorMsg = notImplementedError("segarr_setops", gEnt2.dtype);
+            segLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                   
+            return new MsgTuple(errorMsg, MsgType.ERROR);              
+        }
+        }
+        repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
+        segLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+        return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+
+    proc stringtobool(str: string): bool throws {
+        if str == "True" then return true;
+        else if str == "False" then return false;
+        throw getErrorWithContext(
+            msg="message: assume_unique must be of type bool",
+            lineNumber=getLineNumber(),
+            routineName=getRoutineName(),
+            moduleName=getModuleName(),
+            errorClass="ErrorWithContext");
+    }
+
+    proc registerMe() {
+        use CommandMap;
+        registerFunction("segarr_setops", setopsMsg, getModuleName());
+    }
+}

--- a/src/Unique.chpl
+++ b/src/Unique.chpl
@@ -477,7 +477,7 @@ module Unique
     
     proc uniqueFromSorted(sorted: [?aD] ?eltType, param needCounts = true) throws {
         var truth: [aD] bool;
-        truth[aD.low] = true;
+        truth[0] = true;
         [(t, s, i) in zip(truth, sorted, aD)] if i > aD.low { t = (sorted[i-1] != s); }
         var allUnique: int = + reduce truth;
         if (allUnique == aD.size) {

--- a/src/Unique.chpl
+++ b/src/Unique.chpl
@@ -477,7 +477,7 @@ module Unique
     
     proc uniqueFromSorted(sorted: [?aD] ?eltType, param needCounts = true) throws {
         var truth: [aD] bool;
-        truth[0] = true;
+        truth[aD.low] = true;
         [(t, s, i) in zip(truth, sorted, aD)] if i > aD.low { t = (sorted[i-1] != s); }
         var allUnique: int = + reduce truth;
         if (allUnique == aD.size) {

--- a/tests/segarray_test.py
+++ b/tests/segarray_test.py
@@ -468,7 +468,7 @@ class SegArrayTest(ArkoudaTest):
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + b))
         segarr_2 = ak.SegArray(ak.array([0, len(c)]), ak.array(c + d))
 
-        intx = ak.SegArray.set_intx(segarr, segarr_2)
+        intx = segarr.intersect(segarr_2)
 
         self.assertEqual(intx.size, 2)
         self.assertListEqual(intx[0].to_ndarray().tolist(), [1, 2, 4])
@@ -476,7 +476,7 @@ class SegArrayTest(ArkoudaTest):
 
         #test with empty Segments
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
-        intx = ak.SegArray.set_intx(segarr, segarr_2)
+        intx = segarr.intersect(segarr_2)
         self.assertListEqual(intx.lengths.to_ndarray().tolist(), [3, 0])
         self.assertListEqual(intx[0].to_ndarray().tolist(), [1, 2, 4])
         self.assertListEqual(intx[1].to_ndarray().tolist(), [])
@@ -491,14 +491,14 @@ class SegArrayTest(ArkoudaTest):
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + b))
         segarr_2 = ak.SegArray(ak.array([0, len(c)]), ak.array(c + d))
 
-        un = ak.SegArray.set_union(segarr, segarr_2)
+        un = segarr.union(segarr_2)
         self.assertEqual(un.size, 2)
         self.assertListEqual(un[0].to_ndarray().tolist(), [1, 2, 3, 4, 5])
         self.assertListEqual(un[1].to_ndarray().tolist(), [6, 7, 8])
 
         #test with empty segments
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
-        un = ak.SegArray.set_union(segarr, segarr_2)
+        un = segarr.union(segarr_2)
         self.assertListEqual(un.lengths.to_ndarray().tolist(), [5, 1])
         self.assertListEqual(un[0].to_ndarray().tolist(), [1, 2, 3, 4, 5])
         self.assertListEqual(un[1].to_ndarray().tolist(), [8])
@@ -512,14 +512,14 @@ class SegArrayTest(ArkoudaTest):
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + b))
         segarr_2 = ak.SegArray(ak.array([0, len(c)]), ak.array(c + d))
 
-        diff = ak.SegArray.set_difference(segarr, segarr_2)
+        diff = segarr.difference(segarr_2)
         self.assertEqual(diff.size, 2)
         self.assertListEqual(diff[0].to_ndarray().tolist(), [3, 5])
         self.assertListEqual(diff[1].to_ndarray().tolist(), [6, 7])
 
         # test with empty segments
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
-        diff = ak.SegArray.set_difference(segarr, segarr_2)
+        diff = segarr.difference(segarr_2)
         self.assertListEqual(diff.lengths.to_ndarray().tolist(), [2, 0])
         self.assertListEqual(diff[0].to_ndarray().tolist(), [3, 5])
         self.assertListEqual(diff[1].to_ndarray().tolist(), [])
@@ -532,7 +532,7 @@ class SegArrayTest(ArkoudaTest):
 
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + b))
         segarr_2 = ak.SegArray(ak.array([0, len(c)]), ak.array(c + d))
-        diff = segarr.set_xor(segarr, segarr_2)
+        diff = segarr.xor(segarr_2)
 
         self.assertEqual(diff.size, 2)
         self.assertListEqual(diff[0].to_ndarray().tolist(), [3, 4])
@@ -540,7 +540,7 @@ class SegArrayTest(ArkoudaTest):
 
         #test with empty segment
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
-        diff = ak.SegArray.set_xor(segarr, segarr_2)
+        diff = segarr.xor(segarr_2)
         self.assertListEqual(diff.lengths.to_ndarray().tolist(), [2, 3])
         self.assertListEqual(diff[0].to_ndarray().tolist(), [3, 4])
         self.assertListEqual(diff[1].to_ndarray().tolist(), [8, 12, 13])

--- a/tests/segarray_test.py
+++ b/tests/segarray_test.py
@@ -532,15 +532,15 @@ class SegArrayTest(ArkoudaTest):
 
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + b))
         segarr_2 = ak.SegArray(ak.array([0, len(c)]), ak.array(c + d))
-        diff = segarr.xor(segarr_2)
+        xor = segarr.xor(segarr_2)
 
-        self.assertEqual(diff.size, 2)
-        self.assertListEqual(diff[0].to_ndarray().tolist(), [3, 4])
-        self.assertListEqual(diff[1].to_ndarray().tolist(), [6, 7, 12, 13])
+        self.assertEqual(xor.size, 2)
+        self.assertListEqual(xor[0].to_ndarray().tolist(), [3, 4])
+        self.assertListEqual(xor[1].to_ndarray().tolist(), [6, 7, 12, 13])
 
         #test with empty segment
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
-        diff = segarr.xor(segarr_2)
-        self.assertListEqual(diff.lengths.to_ndarray().tolist(), [2, 3])
-        self.assertListEqual(diff[0].to_ndarray().tolist(), [3, 4])
-        self.assertListEqual(diff[1].to_ndarray().tolist(), [8, 12, 13])
+        xor = segarr.xor(segarr_2)
+        self.assertListEqual(xor.lengths.to_ndarray().tolist(), [2, 3])
+        self.assertListEqual(xor[0].to_ndarray().tolist(), [3, 4])
+        self.assertListEqual(xor[1].to_ndarray().tolist(), [8, 12, 13])

--- a/tests/segarray_test.py
+++ b/tests/segarray_test.py
@@ -459,3 +459,13 @@ class SegArrayTest(ArkoudaTest):
         self.assertListEqual(dedup[2].tolist(), [])
         self.assertListEqual(dedup[3].tolist(), list(set(b)))
         self.assertListEqual(dedup[4].tolist(), [])
+
+    def test_intersection(self):
+        a = [1, 2, 3, 4, 5]
+        b = [6, 7, 8]
+        c = [1, 2, 4]
+        d = [8]
+        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + b))
+        segarr_2 = ak.SegArray(ak.array([0, len(c)]), ak.array(c + d))
+
+        print(ak.SegArray.intersection(segarr, segarr_2))

--- a/tests/segarray_test.py
+++ b/tests/segarray_test.py
@@ -84,8 +84,8 @@ class SegArrayTest(ArkoudaTest):
         segments2 = ak.array([0, 1])
         segarr2 = ak.SegArray(segments2, flat2)
         concated = ak.SegArray.concat([segarr, segarr2], axis=1)
-        self.assertListEqual(concated[0].tolist(), [10, 11, 12, 13, 14, 15, 10])
-        self.assertListEqual(concated[1].tolist(), [20])
+        self.assertListEqual(concated[0].to_ndarray().tolist(), [10, 11, 12, 13, 14, 15, 10])
+        self.assertListEqual(concated[1].to_ndarray().tolist(), [20])
 
         with self.assertRaises(ValueError):
             concated = ak.SegArray.concat([segarr, segarr_2], ordered=False)
@@ -363,15 +363,15 @@ class SegArrayTest(ArkoudaTest):
         segarr = ak.SegArray(segs, flat)
         appended = segarr.append(segarr2)
         self.assertEqual(appended.segments.size, 5)
-        self.assertListEqual(appended[3].tolist(), [10])
-        self.assertListEqual(appended[4].tolist(), [20])
+        self.assertListEqual(appended[3].to_ndarray().tolist(), [10])
+        self.assertListEqual(appended[4].to_ndarray().tolist(), [20])
 
         flat = ak.array(a)
         segs = ak.array([0, len(a)])
         segarr = ak.SegArray(segs, flat)
         concated = segarr.append(segarr2, axis=1)
-        self.assertListEqual(concated[0].tolist(), [1, 2, 10])
-        self.assertListEqual(concated[1].tolist(), [20])
+        self.assertListEqual(concated[0].to_ndarray().tolist(), [1, 2, 10])
+        self.assertListEqual(concated[1].to_ndarray().tolist(), [20])
 
     def test_single_append(self):
         a = [10, 11, 12, 13, 14, 15]
@@ -417,14 +417,14 @@ class SegArrayTest(ArkoudaTest):
         segs = ak.array([0, len(a), len(a) + len(b)])
         segarr = ak.SegArray(segs, flat)
         appended = segarr.append_single(99)
-        self.assertListEqual(appended[0].tolist(), a + [99])
-        self.assertListEqual(appended[1].tolist(), b + [99])
-        self.assertListEqual(appended[2].tolist(), [99])
+        self.assertListEqual(appended[0].to_ndarray().tolist(), a + [99])
+        self.assertListEqual(appended[1].to_ndarray().tolist(), b + [99])
+        self.assertListEqual(appended[2].to_ndarray().tolist(), [99])
 
         appended = segarr.prepend_single(99)
-        self.assertListEqual(appended[0].tolist(), [99] + a)
-        self.assertListEqual(appended[1].tolist(), [99] + b)
-        self.assertListEqual(appended[2].tolist(), [99])
+        self.assertListEqual(appended[0].to_ndarray().tolist(), [99] + a)
+        self.assertListEqual(appended[1].to_ndarray().tolist(), [99] + b)
+        self.assertListEqual(appended[2].to_ndarray().tolist(), [99])
 
     def test_remove_repeats(self):
         a = [1, 1, 1, 2, 3]
@@ -445,20 +445,20 @@ class SegArrayTest(ArkoudaTest):
         dedup = segarr.remove_repeats()
         print(dedup.lengths)
         self.assertListEqual(dedup.lengths.to_ndarray().tolist(), [3, 0, 3, 0])
-        self.assertListEqual(dedup[0].tolist(), list(set(a)))
-        self.assertListEqual(dedup[1].tolist(), [])
-        self.assertListEqual(dedup[2].tolist(), list(set(b)))
-        self.assertListEqual(dedup[3].tolist(), [])
+        self.assertListEqual(dedup[0].to_ndarray().tolist(), list(set(a)))
+        self.assertListEqual(dedup[1].to_ndarray().tolist(), [])
+        self.assertListEqual(dedup[2].to_ndarray().tolist(), list(set(b)))
+        self.assertListEqual(dedup[3].to_ndarray().tolist(), [])
 
         segments = ak.array([0, len(a), len(a), len(a), len(a)+len(b)])
         segarr = ak.SegArray(segments, flat)
         dedup = segarr.remove_repeats()
         self.assertListEqual(dedup.lengths.to_ndarray().tolist(), [3, 0, 0, 3, 0])
-        self.assertListEqual(dedup[0].tolist(), list(set(a)))
-        self.assertListEqual(dedup[1].tolist(), [])
-        self.assertListEqual(dedup[2].tolist(), [])
-        self.assertListEqual(dedup[3].tolist(), list(set(b)))
-        self.assertListEqual(dedup[4].tolist(), [])
+        self.assertListEqual(dedup[0].to_ndarray().tolist(), list(set(a)))
+        self.assertListEqual(dedup[1].to_ndarray().tolist(), [])
+        self.assertListEqual(dedup[2].to_ndarray().tolist(), [])
+        self.assertListEqual(dedup[3].to_ndarray().tolist(), list(set(b)))
+        self.assertListEqual(dedup[4].to_ndarray().tolist(), [])
 
     def test_intersection(self):
         a = [1, 2, 3, 4, 5]
@@ -473,6 +473,13 @@ class SegArrayTest(ArkoudaTest):
         self.assertEqual(intx.size, 2)
         self.assertListEqual(intx[0].to_ndarray().tolist(), [1, 2, 4])
         self.assertListEqual(intx[1].to_ndarray().tolist(), [8])
+
+        #test with empty Segments
+        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
+        intx = ak.SegArray.set_intx(segarr, segarr_2)
+        self.assertListEqual(intx.lengths.to_ndarray().tolist(), [3, 0])
+        self.assertListEqual(intx[0].to_ndarray().tolist(), [1, 2, 4])
+        self.assertListEqual(intx[1].to_ndarray().tolist(), [])
 
 
     def test_union(self):
@@ -489,6 +496,13 @@ class SegArrayTest(ArkoudaTest):
         self.assertListEqual(un[0].to_ndarray().tolist(), [1, 2, 3, 4, 5])
         self.assertListEqual(un[1].to_ndarray().tolist(), [6, 7, 8])
 
+        #test with empty segments
+        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
+        un = ak.SegArray.set_union(segarr, segarr_2)
+        self.assertListEqual(un.lengths.to_ndarray().tolist(), [5, 1])
+        self.assertListEqual(un[0].to_ndarray().tolist(), [1, 2, 3, 4, 5])
+        self.assertListEqual(un[1].to_ndarray().tolist(), [8])
+
     def test_difference(self):
         a = [1, 2, 3, 4, 5]
         b = [6, 7, 8]
@@ -503,6 +517,13 @@ class SegArrayTest(ArkoudaTest):
         self.assertListEqual(diff[0].to_ndarray().tolist(), [3, 5])
         self.assertListEqual(diff[1].to_ndarray().tolist(), [6, 7])
 
+        # test with empty segments
+        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
+        diff = ak.SegArray.set_difference(segarr, segarr_2)
+        self.assertListEqual(diff.lengths.to_ndarray().tolist(), [2, 0])
+        self.assertListEqual(diff[0].to_ndarray().tolist(), [3, 5])
+        self.assertListEqual(diff[1].to_ndarray().tolist(), [])
+
     def test_xor(self):
         a = [1, 2, 3]
         b = [6, 7, 8]
@@ -512,7 +533,14 @@ class SegArrayTest(ArkoudaTest):
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + b))
         segarr_2 = ak.SegArray(ak.array([0, len(c)]), ak.array(c + d))
         diff = segarr.set_xor(segarr, segarr_2)
-        print(diff)
+
         self.assertEqual(diff.size, 2)
         self.assertListEqual(diff[0].to_ndarray().tolist(), [3, 4])
         self.assertListEqual(diff[1].to_ndarray().tolist(), [6, 7, 12, 13])
+
+        #test with empty segment
+        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
+        diff = ak.SegArray.set_xor(segarr, segarr_2)
+        self.assertListEqual(diff.lengths.to_ndarray().tolist(), [2, 3])
+        self.assertListEqual(diff[0].to_ndarray().tolist(), [3, 4])
+        self.assertListEqual(diff[1].to_ndarray().tolist(), [8, 12, 13])


### PR DESCRIPTION
This PR (closes #1197 and closes #1245):

Adds the requests set operation functionality to `SegArray`. The following are implemented:
- `intersect()` computes the intersection
- `union()` computes the union
- `difference()` computes the difference 
- `xor()` computes the symmetric difference.

Maintaining this as a draft until benchmarks are added for the method used.

Unit tests have been added to `tests/segarray_test.py` to validate functionality. The tests also cover validation when segments are empty.