### PR TITLE
Closes #1174 ak.randint() fails for ranges greater than 2**63

### DIFF
--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -689,6 +689,9 @@ def randint(low : numeric_scalars, high : numeric_scalars,
     Calling randint with dtype=float64 will result in uniform non-integral
     floating point values.
 
+    Ranges >= 2**64 in size is undefined behavior because
+    it exceeds the maximum value that can be stored on the server (uint64)
+
     Examples
     --------
     >>> ak.randint(0, 10, 5)

--- a/src/RandArray.chpl
+++ b/src/RandArray.chpl
@@ -23,7 +23,7 @@ module RandArray {
       }
       const a2 = a:uint;
       if (aMax > aMin) {
-        const modulus = (aMax - aMin):uint;
+        const modulus = aMax:uint - aMin:uint;
         a = (a2 % modulus):t + aMin:t;
       }
   }

--- a/src/RandArray.chpl
+++ b/src/RandArray.chpl
@@ -21,14 +21,10 @@ module RandArray {
         var seed = (seedStr:int) + here.id;
         fillRandom(a, seed);
       }
-      [ai in a] if (ai < 0) { ai = -ai; }
+      const a2 = a:uint;
       if (aMax > aMin) {
-        const modulus = aMax - aMin;
-        if modulus > 0 {
-          [x in a] x = ((x % modulus) + aMin):t;
-        } else {
-          [x in a] x = (x + aMin):t;
-        }       
+        const modulus = (aMax - aMin):uint;
+        a = (a2 % modulus):t + aMin:t;
       }
   }
 

--- a/src/RandArray.chpl
+++ b/src/RandArray.chpl
@@ -24,7 +24,11 @@ module RandArray {
       [ai in a] if (ai < 0) { ai = -ai; }
       if (aMax > aMin) {
         const modulus = aMax - aMin;
-        [x in a] x = ((x % modulus) + aMin):t;
+        if modulus > 0 {
+          [x in a] x = ((x % modulus) + aMin):t;
+        } else {
+          [x in a] x = (x + aMin):t;
+        }       
       }
   }
 

--- a/tests/pdarray_creation_test.py
+++ b/tests/pdarray_creation_test.py
@@ -124,6 +124,11 @@ class PdarrayCreationTest(ArkoudaTest):
         self.assertEqual(ak.bool, test_array.dtype)
         
         test_ndarray = test_array.to_ndarray()
+
+        # test resolution of modulus overflow - issue #1174
+        test_array = ak.randint(-(2**63), 2**63-1, 10)
+        to_validate = np.full(10, -(2**63))
+        self.assertFalse((test_array.to_ndarray() == to_validate).all())
         
         for value in test_ndarray:
             self.assertTrue(value in [True,False])

--- a/tests/pdarray_creation_test.py
+++ b/tests/pdarray_creation_test.py
@@ -159,7 +159,8 @@ class PdarrayCreationTest(ArkoudaTest):
 
     def test_randint_with_seed(self):
         values = ak.randint(1, 5, 10, seed=2)
-        self.assertTrue((ak.array([4, 3, 1, 3, 4, 4, 2, 4, 3, 2]) == values).all())
+        print(values)
+        self.assertTrue((ak.array([4, 3, 1, 3, 2, 4, 4, 2, 3, 4]) == values).all())
 
         values = ak.randint(1, 5, 10, dtype=ak.float64, seed=2)
         self.assertTrue((ak.array([2.9160772326374946, 4.353429832157099, 4.5392023718621486, 
@@ -450,19 +451,16 @@ class PdarrayCreationTest(ArkoudaTest):
     def test_random_strings_uniform_with_seed(self):
         pda = ak.random_strings_uniform(minlen=1, maxlen=5, seed=1, size=10)
  
-        self.assertTrue((ak.array(['TVKJ', 'EWAB', 'CO', 'HFMD', 'U', 'MMGT', 
-                        'N', 'WOQN', 'HZ', 'VSX']) == pda).all())
+        self.assertTrue((ak.array(['TV', 'JTEW', 'BOCO', 'HF', 'D', 'UDMM', 'T', 'NK', 'OQNP', 'ZXV']) == pda).all())
         
         pda = ak.random_strings_uniform(minlen=np.int64(1), maxlen=np.int64(5), seed=np.int64(1), 
                                         size=np.int64(10))
- 
-        self.assertTrue((ak.array(['TVKJ', 'EWAB', 'CO', 'HFMD', 'U', 'MMGT', 
-                        'N', 'WOQN', 'HZ', 'VSX']) == pda).all())
+
+        self.assertTrue((ak.array(['TV', 'JTEW', 'BOCO', 'HF', 'D', 'UDMM', 'T', 'NK', 'OQNP', 'ZXV']) == pda).all())
         
         pda = ak.random_strings_uniform(minlen=1, maxlen=5, seed=1, size=10,
                                         characters='printable')
-        self.assertTrue((ak.array(['+5"f', '-P]3', '4k', '~HFF', 'F', '`,IE', 
-                        'Y', 'jkBa', '9(', '5oZ']) == pda).all())
+        self.assertTrue((ak.array(['+5', 'fp-P', '3Q4k', '~H', 'F', 'F=`,', 'E', 'YD', 'kBa\'', '(t5']) == pda).all())
 
     def test_random_strings_lognormal(self):
         pda = ak.random_strings_lognormal(2, 0.25, 100, characters='printable')

--- a/tests/pdarray_creation_test.py
+++ b/tests/pdarray_creation_test.py
@@ -159,7 +159,7 @@ class PdarrayCreationTest(ArkoudaTest):
 
     def test_randint_with_seed(self):
         values = ak.randint(1, 5, 10, seed=2)
-        print(values)
+
         self.assertTrue((ak.array([4, 3, 1, 3, 2, 4, 4, 2, 3, 4]) == values).all())
 
         values = ak.randint(1, 5, 10, dtype=ak.float64, seed=2)


### PR DESCRIPTION
This PR (closes #1174):

- Updates `fillInt()` in `arkouda/src/RandArray.chpl` to use an unsigned `modulus`. This allows us to use the full 64 bits and prevent the overflow seen in #1174
- Added unit test to validate functionality to `tests/pd_array_creation_test.py`.


<details>
  <summary>Process:</summary>

The 2 factors that came into play here:
-  The way we converted `a` to unsigned (the code below does an absolute value), essentially zeroes out the signed bit, so we lose one bit of range
```chapel
[ai in a] if (ai < 0) { ai = -ai; }
```
- `modulus` being stored as a signed 64 bit resulted in overflows, so for the example in the issue
```
modulus = aMax - aMin = (2**63-1) - (-(2**63)) = 2**64-1
```

Our proposed solution converts both of these to unsigned
```chapel
const a2 = a:uint;
if (aMax > aMin) {
  const modulus = (aMax - aMin):uint;
  a = (a2 % modulus):t + aMin:t;
}
```
</details>

NOTE:
- We are converting the signed ints to unsigned differently, so randint with a seed will provide different results before and after this PR. Unfortunately, this means anywhere `randint()` is called using seed, we will see different results.
- We are creating a uint copy of `a` where the original code was in place. We might be able to avoid this if we don't define `a` as a `const`, but the it's not clear if this is better since the compiler is able to do optimizations with const