### PR TITLE
Make regex calls compatible with chapel 1.26

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,15 +258,20 @@ endif
 ARKOUDA_SOURCES = $(shell find $(ARKOUDA_SOURCE_DIR)/ -type f -name '*.chpl')
 ARKOUDA_MAIN_SOURCE := $(ARKOUDA_SOURCE_DIR)/$(ARKOUDA_MAIN_MODULE).chpl
 
-
-ifeq ($(shell expr $(CHPL_MINOR) \>= 25),1)
-	ARKOUDA_COMPAT_MODULES += -M $(ARKOUDA_SOURCE_DIR)/compat/ge-125
-else
+ifeq ($(shell expr $(CHPL_MINOR) \< 25),1)
 	ARKOUDA_COMPAT_MODULES += -M $(ARKOUDA_SOURCE_DIR)/compat/lt-125
 endif
-ifeq ($(shell expr $(CHPL_MINOR) \>= 26),1)
-else
+
+ifeq ($(shell expr $(CHPL_MINOR) \= 25),1)
+	ARKOUDA_COMPAT_MODULES += -M $(ARKOUDA_SOURCE_DIR)/compat/e-125
+endif
+
+ifeq ($(shell expr $(CHPL_MINOR) \< 26),1)
 	ARKOUDA_COMPAT_MODULES += -M $(ARKOUDA_SOURCE_DIR)/compat/lt-126
+endif
+
+ifeq ($(shell expr $(CHPL_MINOR) \>= 26),1)
+	ARKOUDA_COMPAT_MODULES += -M $(ARKOUDA_SOURCE_DIR)/compat/ge-126
 endif
 
 MODULE_GENERATION_SCRIPT=$(ARKOUDA_SOURCE_DIR)/serverModuleGen.py

--- a/src/Flatten.chpl
+++ b/src/Flatten.chpl
@@ -72,11 +72,11 @@ module Flatten {
       for m in myRegex.matches(interpretAsBytes(origVals, off..#len, borrow=true)) {
         var match = m[0];  // v1.24.x -> reMatch, v1.25.x -> regexMatch
         // set writeToVal to false for matches (except the last character of the match because we will write a null byte)
-        for k in (off + match.offset:int)..#(match.size - 1) {
+        for k in (off + match.byteOffset:int)..#(match.numBytes - 1) {
           writeAgg.copy(writeToVal[k], false);
         }
         // is writeToVal[(off + match.offset:int)..#(match.size - 1)] = false more efficient or for loop with aggregator?
-        nbAgg.copy(nullByteLocations[off + match.offset:int + (match.size - 1)], true);
+        nbAgg.copy(nullByteLocations[off + match.byteOffset:int + (match.numBytes - 1)], true);
         matchessize += 1;
       }
       if off != 0 {
@@ -175,10 +175,10 @@ module Flatten {
       for m in myRegex.matches(interpretAsBytes(origVals, off..#len, borrow=true)) {
         var match = m[0];  // v1.24.x -> reMatch, v1.25.x -> regexMatch
         // set writeToVal to false for matches (except the last character of the match because we will write a null byte)
-        for k in (off + match.offset:int)..#(match.size - 1) {
+        for k in (off + match.byteOffset:int)..#(match.numBytes - 1) {
           writeAgg.copy(writeToVal[k], false);
         }
-        nbAgg.copy(nullByteLocations[off + match.offset:int + (match.size - 1)], true);
+        nbAgg.copy(nullByteLocations[off + match.byteOffset:int + (match.numBytes - 1)], true);
         matchessize += 1;
         if matchessize == maxsplit { break; }
       }

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -459,19 +459,19 @@ module SegmentedArray {
                                                                                var fullMatchBoolAgg = newDstAggregator(bool),
                                                                                var numMatchAgg = newDstAggregator(int)) {
         var matchessize = 0;
-        for m in myRegex.matches(interpretAsString(origVals, off..#len, borrow=true), captures=regexMaxCaptures) {
+        for m in myRegex.matches(interpretAsString(origVals, off..#len, borrow=true), regexMaxCaptures) {
           var match = m[0]; // v1.24.x -> reMatch, v1.25.x -> regexMatch
           var group = m[groupNum];
-          if group.offset != -1 {
-            lenAgg.copy(sparseLens[off + group.offset:int], group.size);
-            startPosAgg.copy(sparseStarts[off + group.offset:int], group.offset:int);
-            startBoolAgg.copy(matchStartBool[off + group.offset:int], true);
+          if group.byteOffset != -1 {
+            lenAgg.copy(sparseLens[off + group.byteOffset:int], group.numBytes);
+            startPosAgg.copy(sparseStarts[off + group.byteOffset:int], group.byteOffset:int);
+            startBoolAgg.copy(matchStartBool[off + group.byteOffset:int], true);
             matchessize += 1;
             searchBoolAgg.copy(searchBools[i], true);
-            if match.offset == 0 {
+            if match.byteOffset == 0 {
               matchBoolAgg.copy(matchBools[i], true);
             }
-            if match.size == len-1 {
+            if match.numBytes == len-1 {
               fullMatchBoolAgg.copy(fullMatchBools[i], true);
             }
           }
@@ -609,12 +609,12 @@ module SegmentedArray {
         var replLen = 0;
         for m in myRegex.matches(interpretAsString(origVals, off..#len, borrow=true)) {
           var match = m[0];  // v1.24.x -> reMatch, v1.25.x -> regexMatch
-          for k in (off + match.offset:int)..#match.size {
+          for k in (off + match.byteOffset:int)..#match.numBytes {
             nonMatchAgg.copy(nonMatch[k], false);
           }
-          startAgg.copy(matchStartBool[off + match.offset:int], true);
+          startAgg.copy(matchStartBool[off + match.byteOffset:int], true);
           replacementCounter += 1;
-          replLen += match.size;
+          replLen += match.numBytes;
           if replacementCounter == count { break; }
         }
         numReplAgg.copy(numReplacements[i], replacementCounter);
@@ -731,13 +731,13 @@ module SegmentedArray {
           // The string can be peeled; figure out where to split
           var match_index: int = if left then (times - 1) else (matches.size - times);
           var match = matches[match_index][0]; // v1.24.x -> reMatch, v1.25.x -> regexMatch
-          var j: int = o + match.offset: int;
+          var j: int = o + match.byteOffset: int;
           // j is now the start of the correct delimiter
           // tweak leftEnd and rightStart based on includeDelimiter
           if includeDelimiter {
             if left {
-              leftEnd[i] = j + match.size - 1;
-              rightStart[i] = j + match.size;
+              leftEnd[i] = j + match.numBytes - 1;
+              rightStart[i] = j + match.numBytes;
             }
             else {
               leftEnd[i] = j - 1;
@@ -746,7 +746,7 @@ module SegmentedArray {
           }
           else {
             leftEnd[i] = j - 1;
-            rightStart[i] = j + match.size;
+            rightStart[i] = j + match.numBytes;
           }
         }
       }

--- a/src/compat/e-125/ArkoudaRegexCompat.chpl
+++ b/src/compat/e-125/ArkoudaRegexCompat.chpl
@@ -1,0 +1,10 @@
+module ArkoudaRegexCompat {
+    // Chapel v1.25
+    public use Regex;
+    proc regexMatch.numBytes {
+      return this.size;
+    }
+    proc regexMatch.byteOffset {
+      return this.offset;
+    }
+}

--- a/src/compat/ge-126/ArkoudaRegexCompat.chpl
+++ b/src/compat/ge-126/ArkoudaRegexCompat.chpl
@@ -1,4 +1,4 @@
 module ArkoudaRegexCompat {
-    // Chapel v1.25.0 and later
+    // Chapel v1.26 or newer
     public use Regex;
 }

--- a/src/compat/lt-125/ArkoudaRegexCompat.chpl
+++ b/src/compat/lt-125/ArkoudaRegexCompat.chpl
@@ -1,4 +1,10 @@
 module ArkoudaRegexCompat {
-    // Chapel v1.24.x and prior
+    // Chapel v1.24 and prior
     public use Regexp;
+    proc reMatch.numBytes {
+      return this.size;
+    }
+    proc reMatch.byteOffset {
+      return this.offset;
+    }
 }


### PR DESCRIPTION
Update regular expressions to be compatible with chapel 1.26:
- Stop using a named arg for the `matches` iterator since `captures` was
  renamed to `numCaptures` in [chapel-lang/chapel#19077]().
- Switch `regexMatch.{offset,size}` to `regexMatch.{byteOffset,numBytes}`.
  See [chapel-lang/chapel#19076]() for motivation on the change. Update the
  compatibility shims to keep this working with older versions as well.

With this, Arkouda builds cleanly with Chapel 1.24, 1.25, and 1.26

Resolves #1215