### PR TITLE
Closes #1133 and #1210: Support indexing with uint64

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -464,7 +464,7 @@ class pdarray:
 
     # overload a[] to treat like list
     def __getitem__(self, key):
-        if np.isscalar(key) and resolve_scalar_dtype(key) == 'int64':
+        if np.isscalar(key) and (resolve_scalar_dtype(key) == 'int64' or 'uint64'):
             orig_key = key
             if key < 0:
                 # Interpret negative key as offset from end of array
@@ -483,7 +483,7 @@ class pdarray:
             return create_pdarray(repMsg);
         if isinstance(key, pdarray):
             kind, _ = translate_np_dtype(key.dtype)
-            if kind not in ("bool", "int"):
+            if kind not in ("bool", "int", "uint"):
                 raise TypeError("unsupported pdarray index type {}".format(key.dtype))
             if kind == "bool" and self.size != key.size:
                 raise ValueError("size mismatch {} {}".format(self.size,key.size))
@@ -493,7 +493,7 @@ class pdarray:
             raise TypeError("Unhandled key type: {} ({})".format(key, type(key)))
 
     def __setitem__(self, key, value):
-        if np.isscalar(key) and resolve_scalar_dtype(key) == 'int64':
+        if np.isscalar(key) and (resolve_scalar_dtype(key) == 'int64' or 'uint64'):
             orig_key = key
             if key < 0:
                 # Interpret negative key as offset from end of array

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -263,7 +263,7 @@ class Strings:
         return self._binop(cast(Strings, other), "!=")
 
     def __getitem__(self, key):
-        if np.isscalar(key) and resolve_scalar_dtype(key) == 'int64':
+        if np.isscalar(key) and (resolve_scalar_dtype(key) == 'int64' or 'uint64'):
             orig_key = key
             if key < 0:
                 # Interpret negative key as offset from end of array
@@ -294,7 +294,7 @@ class Strings:
             return Strings.from_return_msg(repMsg)
         elif isinstance(key, pdarray):
             kind, _ = translate_np_dtype(key.dtype)
-            if kind not in ("bool", "int"):
+            if kind not in ("bool", "int", "uint"):
                 raise TypeError("unsupported pdarray index type {}".format(key.dtype))
             if kind == "bool" and self.size != key.size:
                 raise ValueError("size mismatch {} {}".format(self.size,key.size))

--- a/pytest.ini
+++ b/pytest.ini
@@ -13,6 +13,7 @@ testpaths =
     tests/dtypes_tests.py
     tests/groupby_test.py
     tests/index_test.py
+    tests/indexing_test.py
     tests/nan_test.py
     tests/io_test.py
     tests/io_util_test.py

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -272,11 +272,17 @@ module IndexingMsg
             when (DType.Float64, DType.Int64) {
                 return ivInt64Helper(real);
             }
+            when (DType.Float64, DType.UInt64) {
+                return ivUInt64Helper(real);
+            }
             when (DType.Float64, DType.Bool) {
                 return ivBoolHelper(real);
             }
             when (DType.Bool, DType.Int64) {
                 return ivInt64Helper(bool);
+            }
+            when (DType.Bool, DType.UInt64) {
+                return ivUInt64Helper(bool);
             }
             when (DType.Bool, DType.Bool) {
                 return ivBoolHelper(bool);
@@ -310,6 +316,11 @@ module IndexingMsg
                  var val = try! value:int;
                  e.a[idx] = val;
              }
+             when (DType.Int64, DType.UInt64) {
+                 var e = toSymEntry(gEnt,int);
+                 var val = try! value:uint;
+                 e.a[idx] = val:int;
+             }
              when (DType.Int64, DType.Float64) {
                  var e = toSymEntry(gEnt,int);
                  var val = try! value:real;
@@ -322,10 +333,37 @@ module IndexingMsg
                  var val = try! value:bool;
                  e.a[idx] = val:int;
              }
+             when (DType.UInt64, DType.Int64) {
+                 var e = toSymEntry(gEnt,uint);
+                 var val = try! value:int;
+                 e.a[idx] = val:uint;
+             }
+             when (DType.UInt64, DType.UInt64) {
+                 var e = toSymEntry(gEnt,uint);
+                 var val = try! value:uint;
+                 e.a[idx] = val;
+             }
+             when (DType.UInt64, DType.Float64) {
+                 var e = toSymEntry(gEnt,uint);
+                 var val = try! value:real;
+                 e.a[idx] = val:uint;
+             }
+             when (DType.UInt64, DType.Bool) {
+                 var e = toSymEntry(gEnt,uint);
+                 value = value.replace("True","true");// chapel to python bool
+                 value = value.replace("False","false");// chapel to python bool
+                 var val = try! value:bool;
+                 e.a[idx] = val:uint;
+             }
              when (DType.Float64, DType.Int64) {
                  var e = toSymEntry(gEnt,real);
                  var val = try! value:int;
                  e.a[idx] = val;
+             }
+             when (DType.Float64, DType.UInt64) {
+                 var e = toSymEntry(gEnt,real);
+                 var val = try! value:uint;
+                 e.a[idx] = val:real;
              }
              when (DType.Float64, DType.Float64) {
                  var e = toSymEntry(gEnt,real);
@@ -344,6 +382,11 @@ module IndexingMsg
              when (DType.Bool, DType.Int64) {
                  var e = toSymEntry(gEnt,bool);
                  var val = try! value:int;
+                 e.a[idx] = val:bool;
+             }
+             when (DType.Bool, DType.UInt64) {
+                 var e = toSymEntry(gEnt,bool);
+                 var val = try! value:uint;
                  e.a[idx] = val:bool;
              }
              when (DType.Bool, DType.Float64) {
@@ -418,6 +461,38 @@ module IndexingMsg
             return new MsgTuple(repMsg, MsgType.NORMAL);
         }
 
+        // scatter indexing by unsigned integer index vector
+        proc ivUInt64Helper(type Xtype, type dtype): MsgTuple throws {
+            var e = toSymEntry(gX,Xtype);
+            var iv = toSymEntry(gIV,uint);
+            var ivMin = min reduce iv.a;
+            var ivMax = max reduce iv.a;
+            if ivMin < 0 {
+                var errorMsg = "Error: %s: OOBindex %i < 0".format(pn,ivMin);
+                imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                return new MsgTuple(errorMsg,MsgType.ERROR);;
+            }
+            if ivMax >= e.size {
+                var errorMsg = "Error: %s: OOBindex %i > %i".format(pn,ivMax,e.size-1);
+                imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                return new MsgTuple(errorMsg,MsgType.ERROR);;   
+            }
+            if isBool(dtype) {
+                value = value.replace("True","true"); // chapel to python bool
+                value = value.replace("False","false"); // chapel to python bool
+            }
+            var val = try! value:dtype;
+            // [i in iv.a] e.a[i] = val;
+            ref iva = iv.a;
+            ref ea = e.a;
+            forall i in iva with (var agg = newDstAggregator(dtype)) {
+              agg.copy(ea[i:int],val);
+            }
+            var repMsg = "%s success".format(pn);
+            imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+            return new MsgTuple(repMsg, MsgType.NORMAL);
+        }
+
         // expansion boolean indexing by bool index vector
         proc ivBoolHelper(type Xtype, type dtype): MsgTuple throws {
             var e = toSymEntry(gX,Xtype);
@@ -451,17 +526,35 @@ module IndexingMsg
             when (DType.Int64, DType.Int64, DType.Int64) {
               return ivInt64Helper(int, int);
             }
+            when (DType.Int64, DType.UInt64, DType.Int64) {
+              return ivUInt64Helper(int, int);
+            }
             when (DType.Int64, DType.Bool, DType.Int64) {
               return ivBoolHelper(int, int);
             }
+            when (DType.UInt64, DType.Int64, DType.UInt64) {
+              return ivInt64Helper(uint, uint);
+            }
+            when (DType.UInt64, DType.UInt64, DType.UInt64) {
+              return ivUInt64Helper(uint, uint);
+            }
+            when (DType.UInt64, DType.Bool, DType.UInt64) {
+              return ivBoolHelper(uint, uint);
+            }
             when (DType.Float64, DType.Int64, DType.Float64) {
               return ivInt64Helper(real, real);
+            }
+            when (DType.Float64, DType.UInt64, DType.Float64) {
+              return ivUInt64Helper(real, real);
             }
             when (DType.Float64, DType.Bool, DType.Float64) {
               return ivBoolHelper(real, real);
             }
             when (DType.Bool, DType.Int64, DType.Bool) {
               return ivInt64Helper(bool, bool);
+            }
+            when (DType.Bool, DType.UInt64, DType.Bool) {
+              return ivUInt64Helper(bool, bool);
             }
             when (DType.Bool, DType.Bool, DType.Bool) {
               return ivBoolHelper(bool, bool);
@@ -530,6 +623,41 @@ module IndexingMsg
             return new MsgTuple(repMsg, MsgType.NORMAL);
         }
 
+        // scatter indexing by unsigned integer index vector
+        proc ivUInt64Helper(type t): MsgTuple throws {
+            // add check to make syre IV and Y are same size
+            if (gIV.size != gY.size) {
+                var errorMsg = "Error: %s: size mismatch %i %i".format(pn,gIV.size,gY.size);
+                imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                return new MsgTuple(errorMsg,MsgType.ERROR);;     
+            }
+            var e = toSymEntry(gX,t);
+            var iv = toSymEntry(gIV,uint);
+            var ivMin = min reduce iv.a;
+            var ivMax = max reduce iv.a;
+            var y = toSymEntry(gY,t);
+            if ivMin < 0 {
+                var errorMsg = "Error: %s: OOBindex %i < 0".format(pn,ivMin);
+                imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg); 
+                return new MsgTuple(errorMsg,MsgType.ERROR);;  
+            }
+            if ivMax >= e.size {
+                var errorMsg = "Error: %s: OOBindex %i > %i".format(pn,ivMax,e.size-1);
+                imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
+                return new MsgTuple(errorMsg,MsgType.ERROR);;
+            }
+            //[(i,v) in zip(iv.a,y.a)] e.a[i] = v;
+            ref iva = iv.a;
+            ref ya = y.a;
+            ref ea = e.a;
+            forall (i,v) in zip(iva,ya) with (var agg = newDstAggregator(t)) {
+              agg.copy(ea[i:int],v);
+            }
+            var repMsg = "%s success".format(pn);
+            imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+            return new MsgTuple(repMsg, MsgType.NORMAL);
+        }
+
         // expansion indexing by a bool index vector
         proc ivBoolHelper(type t): MsgTuple throws {
             // add check to make syre IV and Y are same size
@@ -571,17 +699,35 @@ module IndexingMsg
             when (DType.Int64, DType.Int64, DType.Int64) {
                 return ivInt64Helper(int);
             }
+            when (DType.Int64, DType.UInt64, DType.Int64) {
+                return ivUInt64Helper(int);
+            }
             when (DType.Int64, DType.Bool, DType.Int64) {
                 return ivBoolHelper(int);
             }
+            when (DType.UInt64, DType.Int64, DType.UInt64) {
+                return ivInt64Helper(uint);
+            }
+            when (DType.UInt64, DType.UInt64, DType.UInt64) {
+                return ivUInt64Helper(uint);
+            }
+            when (DType.UInt64, DType.Bool, DType.UInt64) {
+                return ivBoolHelper(uint);
+            }
             when (DType.Float64, DType.Int64, DType.Float64) {
                 return ivInt64Helper(real);
+            }
+            when (DType.Float64, DType.UInt64, DType.Float64) {
+                return ivUInt64Helper(real);
             }
             when (DType.Float64, DType.Bool, DType.Float64) {
                 return  ivBoolHelper(real);
             }
             when (DType.Bool, DType.Int64, DType.Bool) {
                 return ivInt64Helper(bool);
+            }
+            when (DType.Bool, DType.UInt64, DType.Bool) {
+                return ivUInt64Helper(bool);
             }
             when (DType.Bool, DType.Bool, DType.Bool) {
                 return ivBoolHelper(bool);
@@ -627,6 +773,11 @@ module IndexingMsg
                 var val = try! value:int;
                 e.a[slice] = val;
             }
+            when (DType.Int64, DType.UInt64) {
+                var e = toSymEntry(gEnt,int);
+                var val = try! value:uint;
+                e.a[slice] = val:int;
+            }
             when (DType.Int64, DType.Float64) {
                 var e = toSymEntry(gEnt,int);
                 var val = try! value:real;
@@ -639,10 +790,37 @@ module IndexingMsg
                 var val = try! value:bool;
                 e.a[slice] = val:int;
             }
+            when (DType.UInt64, DType.Int64) {
+                var e = toSymEntry(gEnt,uint);
+                var val = try! value:int;
+                e.a[slice] = val:uint;
+            }
+            when (DType.UInt64, DType.UInt64) {
+                var e = toSymEntry(gEnt,uint);
+                var val = try! value:uint;
+                e.a[slice] = val:uint;
+            }
+            when (DType.UInt64, DType.Float64) {
+                var e = toSymEntry(gEnt,uint);
+                var val = try! value:real;
+                e.a[slice] = val:uint;
+            }
+            when (DType.UInt64, DType.Bool) {
+                var e = toSymEntry(gEnt,uint);
+                value = value.replace("True","true");// chapel to python bool
+                value = value.replace("False","false");// chapel to python bool
+                var val = try! value:bool;
+                e.a[slice] = val:uint;
+            }
             when (DType.Float64, DType.Int64) {
                 var e = toSymEntry(gEnt,real);
                 var val = try! value:int;
                 e.a[slice] = val;
+            }
+            when (DType.Float64, DType.UInt64) {
+                var e = toSymEntry(gEnt,real);
+                var val = try! value:uint;
+                e.a[slice] = val:real;
             }
             when (DType.Float64, DType.Float64) {
                 var e = toSymEntry(gEnt,real);
@@ -661,6 +839,11 @@ module IndexingMsg
             when (DType.Bool, DType.Int64) {
                 var e = toSymEntry(gEnt,bool);
                 var val = try! value:int;
+                e.a[slice] = val:bool;
+            }
+            when (DType.Bool, DType.UInt64) {
+                var e = toSymEntry(gEnt,bool);
+                var val = try! value:uint;
                 e.a[slice] = val:bool;
             }
             when (DType.Bool, DType.Float64) {
@@ -726,6 +909,11 @@ module IndexingMsg
                 var y = toSymEntry(gY,int);
                 x.a[slice] = y.a;
             }
+            when (DType.Int64, DType.UInt64) {
+                var x = toSymEntry(gX,int);
+                var y = toSymEntry(gY,uint);
+                x.a[slice] = y.a:int;
+            }
             when (DType.Int64, DType.Float64) {
                 var x = toSymEntry(gX,int);
                 var y = toSymEntry(gY,real);
@@ -736,9 +924,34 @@ module IndexingMsg
                 var y = toSymEntry(gY,bool);
                 x.a[slice] = y.a:int;
             }
+            when (DType.UInt64, DType.Int64) {
+                var x = toSymEntry(gX,uint);
+                var y = toSymEntry(gY,int);
+                x.a[slice] = y.a:uint;
+            }
+            when (DType.UInt64, DType.UInt64) {
+                var x = toSymEntry(gX,uint);
+                var y = toSymEntry(gY,uint);
+                x.a[slice] = y.a:uint;
+            }
+            when (DType.UInt64, DType.Float64) {
+                var x = toSymEntry(gX,uint);
+                var y = toSymEntry(gY,real);
+                x.a[slice] = y.a:uint;
+            }
+            when (DType.UInt64, DType.Bool) {
+                var x = toSymEntry(gX,uint);
+                var y = toSymEntry(gY,bool);
+                x.a[slice] = y.a:uint;
+            }
             when (DType.Float64, DType.Int64) {
                 var x = toSymEntry(gX,real);
                 var y = toSymEntry(gY,int);
+                x.a[slice] = y.a:real;
+            }
+            when (DType.Float64, DType.UInt64) {
+                var x = toSymEntry(gX,real);
+                var y = toSymEntry(gY,uint);
                 x.a[slice] = y.a:real;
             }
             when (DType.Float64, DType.Float64) {
@@ -754,6 +967,11 @@ module IndexingMsg
             when (DType.Bool, DType.Int64) {
                 var x = toSymEntry(gX,bool);
                 var y = toSymEntry(gY,int);
+                x.a[slice] = y.a:bool;
+            }
+            when (DType.Bool, DType.UInt64) {
+                var x = toSymEntry(gX,bool);
+                var y = toSymEntry(gY,uint);
                 x.a[slice] = y.a:bool;
             }
             when (DType.Bool, DType.Float64) {

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -135,18 +135,18 @@ module SegmentedArray {
     }
 
     /* Retrieve one string from the array */
-    proc this(idx: int): string throws {
+    proc this(idx: ?t): string throws where t == int || t == uint {
       if (idx < offsets.aD.low) || (idx > offsets.aD.high) {
         throw new owned OutOfBoundsError();
       }
       // Start index of the string
-      var start = offsets.a[idx];
+      var start = offsets.a[idx:int];
       // Index of last (null) byte in string
       var end: int;
       if (idx == size - 1) {
         end = nBytes - 1;
       } else {
-        end = offsets.a[idx+1] - 1;
+        end = offsets.a[idx:int+1] - 1;
       }
       // Take the slice of the bytearray and "cast" it to a chpl string
       var s = interpretAsString(values.a, start..end);
@@ -197,7 +197,7 @@ module SegmentedArray {
 
     /* Gather strings by index. Returns arrays for the segment offsets
        and bytes of the gathered strings.*/
-    proc this(iv: [?D] int) throws {
+    proc this(iv: [?D] ?t) throws where t == int || t == uint {
       use ChplConfig;
       
       // Early return for zero-length result
@@ -225,9 +225,9 @@ module SegmentedArray {
         if (idx == high) {
           agg.copy(r, values.size);
         } else {
-          agg.copy(r, oa[idx+1]);
+          agg.copy(r, oa[idx:int+1]);
         }
-        agg.copy(l, oa[idx]);
+        agg.copy(l, oa[idx:int]);
       }
       // Lengths of segments including null bytes
       var gatheredLengths: [D] int = right - left;
@@ -282,7 +282,7 @@ module SegmentedArray {
         // Copy string data to gathered result
         forall (go, gl, idx) in zip(gatheredOffsets, gatheredLengths, iv) {
           for pos in 0..#gl {
-            gatheredVals[go+pos] = va[oa[idx]+pos];
+            gatheredVals[go+pos] = va[oa[idx:int]+pos];
           }
         }
       }

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -703,6 +703,13 @@ module SegmentedMsg {
                         newStringsName = newStringsObj.name;
                         nBytes = newStringsObj.nBytes;
                     }
+                    when DType.UInt64 {
+                        var iv = toSymEntry(gIV, uint);
+                        var (newSegs, newVals) = strings[iv.a];
+                        var newStringsObj = getSegString(newSegs, newVals, st);
+                        newStringsName = newStringsObj.name;
+                        nBytes = newStringsObj.nBytes;
+                    } 
                     when DType.Bool {
                         var iv = toSymEntry(gIV, bool);
                         var (newSegs, newVals) = strings[iv.a];

--- a/tests/indexing_test.py
+++ b/tests/indexing_test.py
@@ -1,0 +1,60 @@
+import numpy as np
+from context import arkouda as ak
+from base_test import ArkoudaTest
+
+SIZE = 100
+
+
+class IndexingTest(ArkoudaTest):
+
+    def setUp(self):
+        ArkoudaTest.setUp(self)
+
+        self.ikeys = ak.arange(SIZE)
+        self.ukeys = ak.arange(SIZE, dtype=ak.uint64)
+        self.i = ak.randint(0, SIZE, SIZE)
+        self.u = ak.cast(self.i, ak.uint64)
+        self.f = ak.array(np.random.randn(SIZE))  # normally dist random numbers
+        self.b = (self.i % 2) == 0
+        self.s = ak.cast(self.i, str)
+        self.array_dict = {'int64': self.i, 'uint64': self.u, 'float64': self.f, 'bool': self.b}
+
+    def test_pdarray_uint_indexing(self):
+        # for every pda in array_dict test indexing with uint array and uint scalar
+        for pda in self.array_dict.values():
+            self.assertEqual(pda[np.uint(2)], pda[2])
+            self.assertListEqual(pda[self.ukeys].to_ndarray().tolist(), pda[self.ikeys].to_ndarray().tolist())
+
+    def test_strings_uint_indexing(self):
+        # test Strings array indexing with uint array and uint scalar
+        self.assertEqual(self.s[np.uint(2)], self.s[2])
+        self.assertListEqual(self.s[self.ukeys].to_ndarray().tolist(), self.s[self.ikeys].to_ndarray().tolist())
+
+    def test_uint_bool_indexing(self):
+        # test uint array with bool indexing
+        self.assertListEqual(self.u[self.b].to_ndarray().tolist(), self.i[self.b].to_ndarray().tolist())
+
+    def test_set_uint(self):
+        # for every pda in array_dict test __setitem__ indexing with uint array and uint scalar
+        for t, pda in self.array_dict.items():
+            # set [int] = val with uint key and value
+            pda[np.uint(2)] = np.uint(5)
+            self.assertEqual(pda[np.uint(2)], pda[2])
+
+            # set [slice] = scalar/pdarray
+            pda[:10] = np.uint(-2)
+            self.assertListEqual(pda[self.ukeys].to_ndarray().tolist(), pda[self.ikeys].to_ndarray().tolist())
+            pda[:10] = ak.cast(ak.arange(10), t)
+            self.assertListEqual(pda[self.ukeys].to_ndarray().tolist(), pda[self.ikeys].to_ndarray().tolist())
+
+            # set [pdarray] = scalar/pdarray with uint key pdarray
+            pda[ak.arange(10, dtype=ak.uint64)] = np.uint(3)
+            self.assertListEqual(pda[self.ukeys].to_ndarray().tolist(), pda[self.ikeys].to_ndarray().tolist())
+            pda[ak.arange(10, dtype=ak.uint64)] = ak.cast(ak.arange(10), t)
+            self.assertListEqual(pda[self.ukeys].to_ndarray().tolist(), pda[self.ikeys].to_ndarray().tolist())
+
+    def test_indexing_with_uint(self):
+        # verify reproducer from #1210 no longer fails
+        a = ak.arange(10) * 2
+        b = ak.cast(ak.array([3, 0, 8]), ak.uint64)
+        a[b]


### PR DESCRIPTION
This PR (Closes #1133 and Closes #1210):
- Adds support for indexing pdarrays with uint scalars and uint pdarrays
- Adds support for `__setitem__(uint scalars/pdarrays)` for integer, slice, and pdarray
- Adds support for indexing `Strings` with uint scalars and uint pdarrays
- Adds `indexing_test.py` to test uint indexing functionality

Note: I feel a lot of the `iv*Helper` functions seems like repeated logic that can probably be pulled out. I'll look into that in another PR in the interest of getting this functionality into master ASAP and avoiding too many changes at once