### PR TITLE
Optimize calculation of Parquet column byte sizes for string reads

### DIFF
--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -126,6 +126,7 @@ int cpp_getStringColumnNumBytes(const char* filename, const char* colname, void*
   try {
     int64_t ty = cpp_getType(filename, colname, errMsg);
     auto offsets = (int64_t*)chpl_offsets;
+    int64_t byteSize = 0;
 
     if(ty == ARROWSTRING) {
       std::unique_ptr<parquet::ParquetFileReader> parquet_reader =
@@ -162,10 +163,11 @@ int cpp_getStringColumnNumBytes(const char* filename, const char* colname, void*
           parquet::ByteArray value;
           (void)ba_reader->ReadBatch(1, nullptr, nullptr, &value, &values_read);
           offsets[i++] = value.len + 1;
+          byteSize += value.len + 1;
           numRead += values_read;
         }
       }
-      return 0;
+      return byteSize;
     }
     return ARROWERROR;
   } catch (const std::exception& e) {


### PR DESCRIPTION
In the initial implementation of the Parquet string reading code,
the byteSizes were being calculated based on a reduction of the
offsets array of the elements corresponding to a given files domain.
This caused a lot of unnecessary communication and had a simple
solution of just swtiching to a `with + reduce byteSizes` in the
coforall and changing the C++ code to return the number of bytes
that was read for it's individual portion.

Here are some performance runs collected on 16 locales of a Cray CS
reading in 50, 10m element string files:
version | execution time |
------- | -------------: |
master  | 0.2652 s       |
this PR | 0.2119 s       |