### PR TITLE
Add initial support for writing string Parquet files

### DIFF
--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1380,6 +1380,58 @@ class Strings:
         args = f"{self.entry.name} {dataset} {m} {json_array} {self.dtype} {self.entry.name} {save_offsets}"
         return cast(str, generic_msg(cmd, args))
 
+    def save_parquet(self, prefix_path : str, dataset : str='strings_array', 
+                     mode : str='truncate', compressed : bool = False) -> str:
+        """
+        Save the Strings object to Parquet. The result is a collection of Parquet files,
+        one file per locale of the arkouda server, where each filename starts
+        with prefix_path. Each locale saves its chunk of the Strings array to its
+        corresponding file.
+
+        Parameters
+        ----------
+        prefix_path : str
+            Directory and filename prefix that all output files share
+        dataset : str
+            The name of the Strings dataset to be written, defaults to strings_array
+        mode : str {'truncate'}
+            By default, truncate (overwrite) output files, if they exist.
+            Append is not supported for Parquet writing.
+        compressed : bool
+            Defaults to False. When True, files will be written with Snappy compression
+            and RLE bit packing.
+
+        Returns
+        -------
+        String message indicating result of save operation
+
+        Raises
+        ------
+        ValueError 
+            Raised if the lengths of columns and values differ, or the mode is 
+            neither 'truncate' nor 'append'
+        TypeError
+            Raised if prefix_path, dataset, or mode is not a str
+
+        See Also
+        --------
+        strings.save()
+        pdarray.save_parquet()
+        """
+        if mode.lower() in 'truncate':
+            m = 0
+        else:
+            raise ValueError("Allowed modes are 'truncate'")
+
+        try:
+            json_array = json.dumps([prefix_path])
+        except Exception as e:
+            raise ValueError(e)
+
+        cmd = "writeParquet"
+        args = f"{self.entry.name} {dataset} {json_array} str {compressed}"
+        return cast(str, generic_msg(cmd, args))
+        
     def is_registered(self) -> np.bool_:
         """
         Return True iff the object is contained in the registry

--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -53,6 +53,20 @@ extern "C" {
   int c_writeColumnToParquet(const char* filename, void* chpl_arr,
                              int64_t colnum, const char* dsetname, int64_t numelems,
                              int64_t rowGroupSize, int64_t dtype, bool compressed, char** errMsg);
+
+  int c_writeStrColumnToParquet(const char* filename, void* chpl_arr, void* chpl_offsets,
+                                const char* dsetname, int64_t numelems,
+                                int64_t rowGroupSize, int64_t dtype, bool compressed,
+                                char** errMsg);
+  int cpp_writeStrColumnToParquet(const char* filename, void* chpl_arr, void* chpl_offsets,
+                                  const char* dsetname, int64_t numelems,
+                                  int64_t rowGroupSize, int64_t dtype, bool compressed,
+                                  char** errMsg);
+  
+  int c_createEmptyParquetFile(const char* filename, const char* dsetname, int64_t dtype,
+                               bool compressed, char** errMsg);
+  int cpp_createEmptyParquetFile(const char* filename, const char* dsetname, int64_t dtype,
+                                 bool compressed, char** errMsg);
     
   const char* c_getVersionInfo(void);
   const char* cpp_getVersionInfo(void);

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -4,7 +4,7 @@ from base_test import ArkoudaTest
 import numpy as np
 import pytest
 
-TYPES = ('int64', 'uint64', 'bool', 'float64')
+TYPES = ('int64', 'uint64', 'bool', 'float64', 'str')
 SIZE = 100
 NUMFILES = 5
 verbose = True
@@ -18,7 +18,9 @@ def read_write_test(dtype):
         ak_arr = ak.randint(0, 1, SIZE, dtype=ak.bool)
     elif dtype =='float64':
         ak_arr = ak.randint(0, 2**32, SIZE, dtype=ak.float64)
-        
+    elif dtype == 'str':
+        ak_arr = ak.random_strings_uniform(1, 10, SIZE)
+
     ak_arr.save_parquet("pq_testcorrect", "my-dset")
     pq_arr = ak.read_parquet("pq_testcorrect*", "my-dset")
     
@@ -37,7 +39,9 @@ def read_write_multi_test(dtype):
     elif dtype =='bool':
         elems = ak.randint(0, 1, adjusted_size, dtype=ak.bool)
     elif dtype =='float64':
-        elems = ak.randint(0, 2**32, SIZE, dtype=ak.float64)
+        elems = ak.randint(0, 2**32, adjusted_size, dtype=ak.float64)
+    elif dtype == 'str':
+        elems = ak.random_strings_uniform(1, 10, adjusted_size)
         
     per_arr = int(adjusted_size/NUMFILES)
     for i in range(NUMFILES):
@@ -60,6 +64,8 @@ def get_datasets_test(dtype):
         ak_arr = ak.randint(0, 1, 10, dtype=ak.bool)
     elif dtype =='float64':
         ak_arr = ak.randint(0, 2**32, SIZE, dtype=ak.float64)
+    elif dtype == 'str':
+        ak_arr = ak.random_strings_uniform(1, 10, SIZE)
         
     ak_arr.save_parquet("pq_testdset", "TEST_DSET")
 
@@ -105,6 +111,8 @@ class ParquetTest(ArkoudaTest):
                 val = True
             elif dtype == 'float64':
                 val = np.finfo(np.float64).max
+            elif dtype == 'str':
+                val = 'max'
             a = ak.array([val])
             a.save_parquet("pq_test", 'test-dset')
             ak_res = ak.read_parquet("pq_test*", 'test-dset')


### PR DESCRIPTION
This PR adds a `save_parquet()` function to the `strings` object,
allowing Arkouda strings to be written to Parquet files. The Chapel
code is based on the HDF5 aggregators function.

Parquet string reading does not allow saving the offsets array today,
nor are you able to load in the offsets array like you can with HDF5,
but I don't think that is as big of a performance bottleneck for
Parquet reading as it is for HDF5 reading.