### PR TITLE
Closes #1154: dtype parameter for `ak.array`

### DIFF
--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -105,15 +105,18 @@ def from_series(series : pd.Series,
                       'float64, int64, string, datetime64[ns], and timedelta64[ns]').format(dt))
     return array(n_array)
 
-def array(a : Union[pdarray,np.ndarray, Iterable]) -> Union[pdarray, Strings]:
+
+def array(a: Union[pdarray, np.ndarray, Iterable], dtype: Union[np.dtype, type, str] = None) -> Union[pdarray, Strings]:
     """
     Convert a Python or Numpy Iterable to a pdarray or Strings object, sending 
     the corresponding data to the arkouda server. 
 
     Parameters
     ----------
-    a : Union[pdarray, np.ndarray]
+    a: Union[pdarray, np.ndarray]
         Rank-1 array of a supported dtype
+    dtype: np.dtype, type, or str
+        The target dtype to cast values to
 
     Returns
     -------
@@ -163,9 +166,10 @@ def array(a : Union[pdarray,np.ndarray, Iterable]) -> Union[pdarray, Strings]:
     >>> type(strings)
     <class 'arkouda.strings.Strings'>  
     """
+    from arkouda.numeric import cast as akcast
     # If a is already a pdarray, do nothing
     if isinstance(a, pdarray):
-        return a
+        return a if dtype is None else akcast(a, dtype)
     from arkouda.client import maxTransferBytes
     # If a is not already a numpy.ndarray, convert it
     if not isinstance(a, np.ndarray):
@@ -190,7 +194,8 @@ def array(a : Union[pdarray,np.ndarray, Iterable]) -> Union[pdarray, Strings]:
         args = f"{encoded_np.dtype.name} {encoded_np.size} seg_string={True}"
         rep_msg = generic_msg(cmd='array', args=args, payload=_array_memview(encoded_np), send_binary=True)
         parts = cast(str, rep_msg).split('+', maxsplit=3)
-        return Strings.from_parts(parts[0], parts[1])
+        return Strings.from_parts(parts[0], parts[1]) if dtype is None \
+            else akcast(Strings.from_parts(parts[0], parts[1]), dtype)
 
     # If not strings, then check that dtype is supported in arkouda
     if a.dtype.name not in DTypes:
@@ -207,7 +212,7 @@ def array(a : Union[pdarray,np.ndarray, Iterable]) -> Union[pdarray, Strings]:
     aview = _array_memview(a)
     args = f"{a.dtype.name} {size} seg_strings={False}"
     rep_msg = generic_msg(cmd='array', args=args, payload=aview, send_binary=True)
-    return create_pdarray(rep_msg)
+    return create_pdarray(rep_msg) if dtype is None else akcast(create_pdarray(rep_msg), dtype)
 
 
 def _array_memview(a) -> memoryview:
@@ -520,13 +525,15 @@ def arange(*args, **kwargs) -> pdarray:
 
     Parameters
     ----------
-    start : int_scalars, optional
+    start: int_scalars, optional
         Starting value (inclusive)
-    stop : int_scalars
+    stop: int_scalars
         Stopping value (exclusive)
-    stride : int_scalars, optional
+    stride: int_scalars, optional
         The difference between consecutive elements, the default stride is 1,
-        if stride is specified then start must also be specified. 
+        if stride is specified then start must also be specified.
+    dtype: np.dtype, type, or str
+        The target dtype to cast values to
 
     Returns
     -------
@@ -564,7 +571,7 @@ def arange(*args, **kwargs) -> pdarray:
     >>> ak.arange(-5, -10, -1)
     array([-5, -6, -7, -8, -9])
     """
-    from arkouda.numeric import cast
+    from arkouda.numeric import cast as akcast
     # if one arg is given then arg is stop
     if len(args) == 1:
         start = 0
@@ -593,7 +600,7 @@ def arange(*args, **kwargs) -> pdarray:
         if stride < 0:
             stop = stop + 2
         repMsg = generic_msg(cmd='arange', args="{} {} {}".format(start, stop, stride))
-        return create_pdarray(repMsg) if dtype == int64 else cast(create_pdarray(repMsg), dtype)
+        return create_pdarray(repMsg) if dtype == int64 else akcast(create_pdarray(repMsg), dtype)
     else:
         raise TypeError(f"start,stop,stride must be type int, np.int64, or np.uint64 {start} {stop} {stride}")
 

--- a/tests/pdarray_creation_test.py
+++ b/tests/pdarray_creation_test.py
@@ -29,7 +29,12 @@ class PdarrayCreationTest(ArkoudaTest):
         pda =  ak.array(deque(range(5)))
         self.assertIsInstance(pda, ak.pdarray)
         self.assertEqual(5, len(pda))
-        self.assertEqual(int, pda.dtype)         
+        self.assertEqual(int, pda.dtype)
+
+        pda = ak.array([f'{i}' for i in range(10)], dtype=ak.int64)
+        self.assertIsInstance(pda, ak.pdarray)
+        self.assertEqual(10, len(pda))
+        self.assertEqual(int, pda.dtype)
 
         with self.assertRaises(RuntimeError) as cm:          
             ak.array({range(0,100)})


### PR DESCRIPTION
- Adds a `dtype` parameter to `ak.array` to mimic `np.array`
```python
In [4]: np.array([0,1,2,3,4], dtype=np.uint64)
Out[4]: array([0, 1, 2, 3, 4], dtype=uint64)

In [5]: ak.array([0,1,2,3,4], dtype=ak.uint64)
Out[5]: array([0 1 2 3 4])

In [6]: ak.array([0,1,2,3,4], dtype=ak.uint64).dtype
Out[6]: dtype('uint64')

In [7]: ak.array([f'{i}' for i in range(10)], dtype=ak.int64)
Out[7]: array([0 1 2 3 4 5 6 7 8 9])
```