### PR TITLE
Unify HDF5 and Parquet ls calls into a single function

### DIFF
--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -7,13 +7,13 @@ from arkouda.pdarrayclass import pdarray, create_pdarray
 from arkouda.strings import Strings
 from arkouda.categorical import Categorical
 
-__all__ = ["ls_any", "read_hdf", "read_all", "load", "get_datasets",
+__all__ = ["ls", "read_hdf", "read_all", "load", "get_datasets",
            "load_all", "save_all", "read_parquet"]
 
 ARKOUDA_HDF5_FILE_METADATA_GROUP = "_arkouda_metadata"
 
 @typechecked
-def ls_any(filename : str) -> List[str]:
+def ls(filename : str) -> List[str]:
     """
     This function calls the h5ls utility on a HDF5 file visible to the
     arkouda server or calls a function that imitates the result of h5ls
@@ -90,7 +90,7 @@ def read_hdf(dsetName : str, filenames : Union[str,List[str]],
 
     See Also
     --------
-    get_datasets, ls_any, read_all, load, save
+    get_datasets, ls, read_all, load, save
 
     Notes
     -----
@@ -157,7 +157,7 @@ def read_parquet(filenames : Union[str, List[str]],
 
     See Also
     --------
-    read_hdf, get_datasets, ls_any, read_all, load, save
+    read_hdf, get_datasets, ls, read_all, load, save
 
     Notes
     -----
@@ -171,12 +171,12 @@ def read_parquet(filenames : Union[str, List[str]],
     if isinstance(filenames, str):
         filenames = [filenames]
     if datasets is None:
-        datasets = get_datasets_allow_errors(filenames, True) if allow_errors else get_datasets(filenames[0], True)
+        datasets = get_datasets_allow_errors(filenames) if allow_errors else get_datasets(filenames[0])
     if isinstance(datasets, str):
         datasets = [datasets]
 
     nonexistent = set(datasets) - \
-        (set(get_datasets_allow_errors(filenames, True)) if allow_errors else set(get_datasets(filenames[0], True)))
+        (set(get_datasets_allow_errors(filenames)) if allow_errors else set(get_datasets(filenames[0])))
     if len(nonexistent) > 0:
         raise ValueError("Dataset(s) not found: {}".format(nonexistent))
 
@@ -267,7 +267,7 @@ def read_all(filenames : Union[str, List[str]],
 
     See Also
     --------
-    read_hdf, get_datasets, ls_any
+    read_hdf, get_datasets, ls
 
     Notes
     -----
@@ -414,9 +414,9 @@ def get_datasets(filename : str) -> List[str]:
 
     See Also
     --------
-    ls_any
+    ls
     """
-    datasets = ls_any(filename)
+    datasets = ls(filename)
     # We can skip/remove the _arkouda_metadata group since it is an internal only construct
     if ARKOUDA_HDF5_FILE_METADATA_GROUP in datasets:
         datasets.remove(ARKOUDA_HDF5_FILE_METADATA_GROUP)
@@ -449,7 +449,7 @@ def get_datasets_allow_errors(filenames: List[str]) -> List[str]:
 
     See Also
     --------
-    get_datasets, ls_any
+    get_datasets, ls
     """
     datasets = []
     for filename in filenames:

--- a/pydoc/usage/IO.rst
+++ b/pydoc/usage/IO.rst
@@ -59,7 +59,7 @@ HDF5 files can be queried via the server for dataset names and sizes.
 
 .. autofunction:: arkouda.get_datasets
 
-.. autofunction:: arkouda.ls_hdf
+.. autofunction:: arkouda.ls_any
 
 Persisting ``pdarray`` data to disk
 -----------------------------------

--- a/src/CommandMap.chpl
+++ b/src/CommandMap.chpl
@@ -80,4 +80,15 @@ module CommandMap {
     return cm1(0..idx_close-1) + ", " + cm2(1..cm2.size-1);
   }
 
+  proc executeCommand(cmd: string, args, st) throws {
+    var repTuple: MsgTuple;
+    if commandMap.contains(cmd) {
+      usedModules.add(moduleMap[cmd]);
+      repTuple = commandMap.getBorrowed(cmd)(cmd, args, st);
+    } else {
+      repTuple = new MsgTuple("Unrecognized command: %s".format(cmd), MsgType.ERROR);
+    }
+    return repTuple;
+  }
+
 }

--- a/src/FileIO.chpl
+++ b/src/FileIO.chpl
@@ -228,6 +228,25 @@ module FileIO {
         return new MsgTuple(errorMsg, MsgType.ERROR);                                    
       }
 
+      // If the filename represents a glob pattern, retrieve the locale 0 filename
+      if isGlobPattern(filename) {
+        // Attempt to interpret filename as a glob expression and ls the first result
+        var tmp = glob(filename);
+
+        if tmp.size <= 0 {
+          var errorMsg = "Cannot retrieve filename from glob expression %s, check file name or format".format(filename);
+          return new MsgTuple(errorMsg, MsgType.ERROR);
+        }
+            
+        // Set filename to globbed filename corresponding to locale 0
+        filename = tmp[tmp.domain.first];
+      }
+
+      if !exists(filename) {
+        var errorMsg = "File %s does not exist in a location accessible to Arkouda".format(filename);
+        return new MsgTuple(errorMsg,MsgType.ERROR);
+      } 
+
       select getFileType(filename) {
         when FileType.HDF5 {
           return executeCommand("lshdf", payload, st);

--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -142,6 +142,7 @@ proc main() {
         registerFunction("getmemused", getmemusedMsg);
         registerFunction("getCmdMap", getCommandMapMsg);
         registerFunction("clear", clearMsg);
+        registerFunction("lsany", lsAnyMsg);
 
         // For a few specialized cmds we're going to add dummy functions, so they
         // get added to the client listing of available commands. They will be

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -167,7 +167,7 @@ class IOTest(ArkoudaTest):
     def testLsHdf(self):
         '''
         Creates 1..n files depending upon the number of arkouda_server locales, invokes the 
-        ls_any method on an explicit file name reads the files and confirms the expected 
+        ls method on an explicit file name reads the files and confirms the expected 
         message was returned.
 
         :return: None
@@ -175,23 +175,23 @@ class IOTest(ArkoudaTest):
         '''
         self._create_file(columns=self.dict_single_column, 
                           prefix_path='{}/iotest_single_column'.format(IOTest.io_test_dir))
-        message = ak.ls_any('{}/iotest_single_column_LOCALE0000'.format(IOTest.io_test_dir))
+        message = ak.ls('{}/iotest_single_column_LOCALE0000'.format(IOTest.io_test_dir))
         self.assertIn('int_tens_pdarray', message)
         
 
         with self.assertRaises(RuntimeError) as cm:        
-            ak.ls_any('{}/not-a-file_LOCALE0000'.format(IOTest.io_test_dir))
+            ak.ls('{}/not-a-file_LOCALE0000'.format(IOTest.io_test_dir))
 
     def testLsHdfEmpty(self):
         # Test filename empty/whitespace-only condition
         with self.assertRaises(ValueError):
-            ak.ls_any("")
+            ak.ls("")
         
         with self.assertRaises(ValueError):
-            ak.ls_any("   ")
+            ak.ls("   ")
         
         with self.assertRaises(ValueError):
-            ak.ls_any(" \n\r\t  ")
+            ak.ls(" \n\r\t  ")
 
     def testReadHdf(self):
         ''' DEPRECATED - all client calls route to `readAllHdf`

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -167,7 +167,7 @@ class IOTest(ArkoudaTest):
     def testLsHdf(self):
         '''
         Creates 1..n files depending upon the number of arkouda_server locales, invokes the 
-        ls_hdf method on an explicit file name reads the files and confirms the expected 
+        ls_any method on an explicit file name reads the files and confirms the expected 
         message was returned.
 
         :return: None
@@ -175,23 +175,23 @@ class IOTest(ArkoudaTest):
         '''
         self._create_file(columns=self.dict_single_column, 
                           prefix_path='{}/iotest_single_column'.format(IOTest.io_test_dir))
-        message = ak.ls_hdf('{}/iotest_single_column_LOCALE0000'.format(IOTest.io_test_dir))
+        message = ak.ls_any('{}/iotest_single_column_LOCALE0000'.format(IOTest.io_test_dir))
         self.assertIn('int_tens_pdarray', message)
         
 
         with self.assertRaises(RuntimeError) as cm:        
-            ak.ls_hdf('{}/not-a-file_LOCALE0000'.format(IOTest.io_test_dir))
+            ak.ls_any('{}/not-a-file_LOCALE0000'.format(IOTest.io_test_dir))
 
     def testLsHdfEmpty(self):
         # Test filename empty/whitespace-only condition
         with self.assertRaises(ValueError):
-            ak.ls_hdf("")
+            ak.ls_any("")
         
         with self.assertRaises(ValueError):
-            ak.ls_hdf("   ")
+            ak.ls_any("   ")
         
         with self.assertRaises(ValueError):
-            ak.ls_hdf(" \n\r\t  ")
+            ak.ls_any(" \n\r\t  ")
 
     def testReadHdf(self):
         ''' DEPRECATED - all client calls route to `readAllHdf`

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -69,7 +69,7 @@ def get_datasets_test(dtype):
         
     ak_arr.save_parquet("pq_testdset", "TEST_DSET")
 
-    dsets = ak.get_datasets("pq_testdset*", True)
+    dsets = ak.get_datasets("pq_testdset*")
     
     for f in glob.glob('pq_test*'):
         os.remove(f)
@@ -187,7 +187,7 @@ class ParquetTest(ArkoudaTest):
                     'c_last_review_date']
         for basename, ans in zip(filenames, (columns1, columns1, columns2)):
             filename = os.path.join(datadir, basename)
-            columns = ak.get_datasets(filename, is_parquet=True)
+            columns = ak.get_datasets(filename)
             self.assertListEqual(columns, ans)
             # Merely test that read succeeds, do not check output
             if "delta_byte_array.parquet" not in filename:

--- a/tests/read_write_tests.py
+++ b/tests/read_write_tests.py
@@ -11,7 +11,7 @@ if len(sys.argv) < 4:
     sys.exit()
 ak.connect(sys.argv[1], sys.argv[2])
 onefile = sys.argv[3]
-print(ak.ls_any(onefile))
+print(ak.ls(onefile))
 allfiles = sys.argv[3:]
 print(f"srcIP = ak.read_hdf('srcIP', {onefile})")
 srcIP = ak.read_hdf('srcIP', onefile)

--- a/tests/read_write_tests.py
+++ b/tests/read_write_tests.py
@@ -11,7 +11,7 @@ if len(sys.argv) < 4:
     sys.exit()
 ak.connect(sys.argv[1], sys.argv[2])
 onefile = sys.argv[3]
-print(ak.ls_hdf(onefile))
+print(ak.ls_any(onefile))
 allfiles = sys.argv[3:]
 print(f"srcIP = ak.read_hdf('srcIP', {onefile})")
 srcIP = ak.read_hdf('srcIP', onefile)


### PR DESCRIPTION
This PR moves the `ls_hdf()` function, which accepts an
`is_parquet` argument to a generic `ls()` function. This
allows the user to call `ak.ls(filename)` on either a
Parquet or HDF5 file without having to specify its type.

This is done by having a generic command that is sent to the
server and then allowing the server to differentiate between
the two different file types and calling the correct server
function.

While we would like to get here with all of the IO code, this
function seemed like a good starting point since both functions
have the same arguments (just the filename) and it is a
relatively simple function. Discussion on the naming and how we
would like to handle the differentiating of the file types would
be appreciated.

Closes: https://github.com/Bears-R-Us/arkouda/issues/1234