### PR TITLE
Closes #1218 extend pdarray setops to work for multiple arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ test/NanSpeedTest.good
 test/StringArgsortSpeedTest.good
 test/file_LOCALE0000
 UsedModules.cfg
+.DS_Store

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -276,8 +276,8 @@ def concatenate(arrays: Sequence[Union[pdarray, Strings, 'Categorical']],  # typ
 
 # (A1 | A2) Set Union: elements are in one or the other or both
 @typechecked
-def union1d(pda1: Union[pdarray, List[pdarray], tuple], pda2: Union[pdarray,
-            List[pdarray], tuple]) -> Union[pdarray, tuple, str]:
+def union1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, pdarray]], pda2: Union[pdarray,
+            List[pdarray], Tuple[pdarray, pdarray]]) -> Union[pdarray, Tuple[pdarray, pdarray], str]:
     """
     Find the union of two arrays.
 
@@ -358,8 +358,8 @@ def union1d(pda1: Union[pdarray, List[pdarray], tuple], pda2: Union[pdarray,
 
 # (A1 & A2) Set Intersection: elements have to be in both arrays
 @typechecked
-def intersect1d(pda1: Union[pdarray, List[pdarray], tuple], pda2: Union[pdarray,
-                List[pdarray], tuple], assume_unique: bool = False) -> Union[pdarray, tuple, str]:
+def intersect1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, pdarray]], pda2: Union[pdarray,
+                List[pdarray], Tuple[pdarray, pdarray]], assume_unique: bool = False) -> Union[pdarray, Tuple[pdarray, pdarray], str]:
     """
     Find the intersection of two arrays.
 
@@ -447,8 +447,8 @@ def intersect1d(pda1: Union[pdarray, List[pdarray], tuple], pda2: Union[pdarray,
 
 # (A1 - A2) Set Difference: elements have to be in first array but not second
 @typechecked
-def setdiff1d(pda1: Union[pdarray, List[pdarray], tuple], pda2: Union[pdarray, List[pdarray], tuple],
-              assume_unique: bool = False) -> Union[pdarray, tuple, str]:
+def setdiff1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, pdarray]], pda2: Union[pdarray, List[pdarray], Tuple[pdarray, pdarray]],
+              assume_unique: bool = False) -> Union[pdarray, Tuple[pdarray, pdarray], str]:
     """
     Find the set difference of two arrays.
 
@@ -533,8 +533,8 @@ def setdiff1d(pda1: Union[pdarray, List[pdarray], tuple], pda2: Union[pdarray, L
 
 # (A1 ^ A2) Set Symmetric Difference: elements are not in the intersection
 @typechecked
-def setxor1d(pda1: Union[pdarray, List[pdarray], tuple], pda2: Union[pdarray, List[pdarray], tuple],
-              assume_unique: bool = False) -> Union[pdarray, tuple, str]:
+def setxor1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, pdarray]], pda2: Union[pdarray, List[pdarray], Tuple[pdarray, pdarray]],
+              assume_unique: bool = False) -> Union[pdarray, Tuple[pdarray, pdarray], str]:
     """
     Find the set exclusive-or (symmetric difference) of two arrays.
 

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -351,7 +351,8 @@ def union1d(pda1: Union[pdarray, List[pdarray], tuple], pda2: Union[pdarray,
         if pda1[0].size != pda2[0].size:
             raise ValueError("Multiple array support for 1d operation requires the same number of array segments to be present in both objects.")
         # the segment arrays are always going to be dtype int. The values will support int64 and uint64
-        repMsg = generic_msg(cmd="union1d_multi", args=f"{pda1[0].name} {pda1[1].name} {pda1[1].size} {pda2[0].name} {pda2[1].name} {pda2[1].size}")
+        repMsg = cast(str, generic_msg(cmd="union1d_multi",
+                                       args=f"{pda1[0].name} {pda1[1].name} {pda1[1].size} {pda2[0].name} {pda2[1].name} {pda2[1].size}"))
         rep_ele = repMsg.split("+")
         return cast(pdarray, create_pdarray(rep_ele[0])), cast(pdarray, create_pdarray(rep_ele[1]))
 
@@ -439,8 +440,8 @@ def intersect1d(pda1: Union[pdarray, List[pdarray], tuple], pda2: Union[pdarray,
         if pda1[0].size != pda2[0].size:
             raise ValueError("Multiple array support for 1d operation requires the same number of array segments to be present in both objects.")
         # the segment arrays are always going to be dtype int. The values will support int64 and uint64
-        repMsg = generic_msg(cmd="intersect1d_multi",
-                             args=f"{pda1[0].name} {pda1[1].name} {pda1[1].size} {pda2[0].name} {pda2[1].name} {pda2[1].size} {assume_unique}")
+        repMsg = cast(str, generic_msg(cmd="intersect1d_multi",
+                             args=f"{pda1[0].name} {pda1[1].name} {pda1[1].size} {pda2[0].name} {pda2[1].name} {pda2[1].size} {assume_unique}"))
         rep_ele = repMsg.split("+")
         return cast(pdarray, create_pdarray(rep_ele[0])), cast(pdarray, create_pdarray(rep_ele[1]))
 
@@ -525,8 +526,8 @@ def setdiff1d(pda1: Union[pdarray, List[pdarray], tuple], pda2: Union[pdarray, L
         if pda1[0].size != pda2[0].size:
             raise ValueError("Multiple array support for 1d operation requires the same number of array segments to be present in both objects.")
         # the segment arrays are always going to be dtype int. The values will support int64 and uint64
-        repMsg = generic_msg(cmd="setdiff1d_multi",
-                             args=f"{pda1[0].name} {pda1[1].name} {pda1[1].size} {pda2[0].name} {pda2[1].name} {pda2[1].size} {assume_unique}")
+        repMsg = cast(str, generic_msg(cmd="setdiff1d_multi",
+                             args=f"{pda1[0].name} {pda1[1].name} {pda1[1].size} {pda2[0].name} {pda2[1].name} {pda2[1].size} {assume_unique}"))
         rep_ele = repMsg.split("+")
         return cast(pdarray, create_pdarray(rep_ele[0])), cast(pdarray, create_pdarray(rep_ele[1]))
 
@@ -609,7 +610,7 @@ def setxor1d(pda1: Union[pdarray, List[pdarray], tuple], pda2: Union[pdarray, Li
         if pda1[0].size != pda2[0].size:
             raise ValueError("Multiple array support for 1d operation requires the same number of array segments to be present in both objects.")
         # the segment arrays are always going to be dtype int. The values will support int64 and uint64
-        repMsg = generic_msg(cmd="setxor1d_multi",
-                             args=f"{pda1[0].name} {pda1[1].name} {pda1[1].size} {pda2[0].name} {pda2[1].name} {pda2[1].size} {assume_unique}")
+        repMsg = cast(str, generic_msg(cmd="setxor1d_multi",
+                             args=f"{pda1[0].name} {pda1[1].name} {pda1[1].size} {pda2[0].name} {pda2[1].name} {pda2[1].size} {assume_unique}"))
         rep_ele = repMsg.split("+")
         return cast(pdarray, create_pdarray(rep_ele[0])), cast(pdarray, create_pdarray(rep_ele[1]))

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -344,15 +344,14 @@ def union1d(pda1: Union[pdarray, List[pdarray], tuple], pda2: Union[pdarray,
             repMsg = generic_msg(cmd="union1d", args="{} {}".
                                  format(pda1.name, pda2.name))
             return cast(pdarray, create_pdarray(repMsg))
+        return cast(pdarray,
+                    unique(cast(pdarray,
+                                concatenate((unique(pda1), unique(pda2)), ordered=False))))  # type: ignore
     else:
         # the segment arrays are always going to be dtype int. The values will support int64 and uint64
         repMsg = generic_msg(cmd="union1d_multi", args=f"{pda1[0].name} {pda1[1].name} {pda1[1].size} {pda2[0].name} {pda2[1].name} {pda2[1].size}")
         rep_ele = repMsg.split("+")
         return cast(pdarray, create_pdarray(rep_ele[0])), cast(pdarray, create_pdarray(rep_ele[1]))
-
-    return cast(pdarray,
-                unique(cast(pdarray,
-                            concatenate((unique(pda1), unique(pda2)), ordered=False))))  # type: ignore
 
 
 # (A1 & A2) Set Intersection: elements have to be in both arrays

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -330,7 +330,7 @@ def union1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, pdarray]], pda2: 
     >>> b_segs = ak.array([0, 1])
     >>> b_vals = ak.array([5, 6, 7, 8])
     >>> ak.union1d([a_segs, a_vals], [b_segs, b_vals])
-    (array([0 4]), array([0 1 2 3 4 5 6 7 8]))
+    (array([0 4]), array([0 1 2 5 3 4 6 7 8]))
     """
     if isinstance(pda1, pdarray) or isinstance(pda2, pdarray):
         if not (isinstance(pda1, pdarray) and isinstance(pda2, pdarray)):
@@ -503,7 +503,7 @@ def setdiff1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, pdarray]], pda2
     >>> b_segs = ak.array([0, 2])
     >>> b_vals = ak.array([1, 3, 4])
     >>> ak.setdiff1d((a_segs, a_vals), (b_segs, b_vals))
-    (array([0 2]), array([0 2 5]))
+    (array([0 2]), array([0 2 3 5]))
     """
     if isinstance(pda1, pdarray) or isinstance(pda2, pdarray):
         if not (isinstance(pda1, pdarray) and isinstance(pda2, pdarray)):

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -339,7 +339,6 @@ def union1d(pda1: Union[pdarray, List[pdarray], tuple], pda2: Union[pdarray,
             return pda2  # union is pda2
         if pda2.size == 0:
             return pda1  # union is pda1
-        # TODO - update to handle uint
         if (pda1.dtype == int and pda2.dtype == int) or (pda1.dtype == akuint64 and pda2.dtype == akuint64):
             repMsg = generic_msg(cmd="union1d", args="{} {}".
                                  format(pda1.name, pda2.name))
@@ -424,7 +423,7 @@ def intersect1d(pda1: Union[pdarray, List[pdarray], tuple], pda2: Union[pdarray,
             return pda2  # nothing in the intersection
         if (pda1.dtype == int and pda2.dtype == int) or \
                 (pda1.dtype == akuint64 and pda2.dtype == akuint64):
-            repMsg = generic_msg(cmd="intersect1d", args="{} {} {}". \
+            repMsg = generic_msg(cmd="intersect1d", args="{} {} {}".
                                  format(pda1.name, pda2.name, assume_unique))
             return create_pdarray(cast(str, repMsg))
         if not assume_unique:
@@ -515,7 +514,7 @@ def setdiff1d(pda1: Union[pdarray, List[pdarray], tuple], pda2: Union[pdarray, L
             return pda1  # subtracting nothing return orig pdarray
         if (pda1.dtype == int and pda2.dtype == int) or \
                 (pda1.dtype == akuint64 and pda2.dtype == akuint64):
-            repMsg = generic_msg(cmd="setdiff1d", args="{} {} {}". \
+            repMsg = generic_msg(cmd="setdiff1d", args="{} {} {}".
                                  format(pda1.name, pda2.name, assume_unique))
             return create_pdarray(cast(str, repMsg))
         if not assume_unique:
@@ -595,7 +594,7 @@ def setxor1d(pda1: Union[pdarray, List[pdarray], tuple], pda2: Union[pdarray, Li
             return pda1  # return other pdarray if pda2 is empty
         if (pda1.dtype == int and pda2.dtype == int) or \
                 (pda1.dtype == akuint64 and pda2.dtype == akuint64):
-            repMsg = generic_msg(cmd="setxor1d", args="{} {} {}". \
+            repMsg = generic_msg(cmd="setxor1d", args="{} {} {}".
                                  format(pda1.name, pda2.name, assume_unique))
             return create_pdarray(cast(str, repMsg))
         if not assume_unique:

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -330,7 +330,7 @@ def union1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, pdarray]], pda2: 
     >>> b_segs = ak.array([0, 1])
     >>> b_vals = ak.array([5, 6, 7, 8])
     >>> ak.union1d([a_segs, a_vals], [b_segs, b_vals])
-    (array([0, 4]), array([0, 1, 2, 3, 4, 5, 6, 7, 8]))
+    (array([0 4]), array([0 1 2 3 4 5 6 7 8]))
     """
     if isinstance(pda1, pdarray) or isinstance(pda2, pdarray):
         if not (isinstance(pda1, pdarray) and isinstance(pda2, pdarray)):
@@ -412,7 +412,7 @@ def intersect1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, pdarray]], pd
     >>> b_segs = ak.array([0, 1])
     >>> b_vals = ak.array([1, 3, 4, 5])
     >>> ak.intersect1d([a_segs, a_vals], [b_segs, b_vals])
-    (array([0, 1]), array([1, 3, 4))
+    (array([0 1]), array([1 3 4))
     """
     if isinstance(pda1, pdarray) or isinstance(pda2, pdarray):
         if not (isinstance(pda1, pdarray) and isinstance(pda2, pdarray)):
@@ -503,7 +503,7 @@ def setdiff1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, pdarray]], pda2
     >>> b_segs = ak.array([0, 2])
     >>> b_vals = ak.array([1, 3, 4])
     >>> ak.setdiff1d((a_segs, a_vals), (b_segs, b_vals))
-    (array([0, 2]), array(0, 2, 5))
+    (array([0 2]), array([0 2 5]))
     """
     if isinstance(pda1, pdarray) or isinstance(pda2, pdarray):
         if not (isinstance(pda1, pdarray) and isinstance(pda2, pdarray)):
@@ -583,7 +583,7 @@ def setxor1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, pdarray]], pda2:
     >>> b_vals = ak.array([2, 3, 5, 7, 5, 6, 9])
     >>> b_segs = ak.array([0, 5])
     >>> ak.setxor1d((a_segs, a_vals), (b_segs, b_vals))
-    (array([0, 4]), array([1, 4, 5, 7, 1, 3, 9]))
+    (array([0 4]), array([1 4 5 7 1 3 9]))
     """
     if isinstance(pda1, pdarray) or isinstance(pda2, pdarray):
         if not (isinstance(pda1, pdarray) and isinstance(pda2, pdarray)):

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -350,8 +350,8 @@ def union1d(pda1: Union[pdarray, List[pdarray], tuple], pda2: Union[pdarray,
         if pda1[0].size != pda2[0].size:
             raise ValueError("Multiple array support for 1d operation requires the same number of array segments to be present in both objects.")
         # the segment arrays are always going to be dtype int. The values will support int64 and uint64
-        repMsg = cast(str, generic_msg(cmd="union1d_multi",
-                                       args=f"{pda1[0].name} {pda1[1].name} {pda1[1].size} {pda2[0].name} {pda2[1].name} {pda2[1].size}"))
+        repMsg = cast(str, generic_msg(cmd="setops1d_multi",
+                                       args=f"union {pda1[0].name} {pda1[1].name} {pda1[1].size} {pda2[0].name} {pda2[1].name} {pda2[1].size}"))
         rep_ele = repMsg.split("+")
         return cast(pdarray, create_pdarray(rep_ele[0])), cast(pdarray, create_pdarray(rep_ele[1]))
 
@@ -439,8 +439,8 @@ def intersect1d(pda1: Union[pdarray, List[pdarray], tuple], pda2: Union[pdarray,
         if pda1[0].size != pda2[0].size:
             raise ValueError("Multiple array support for 1d operation requires the same number of array segments to be present in both objects.")
         # the segment arrays are always going to be dtype int. The values will support int64 and uint64
-        repMsg = cast(str, generic_msg(cmd="intersect1d_multi",
-                             args=f"{pda1[0].name} {pda1[1].name} {pda1[1].size} {pda2[0].name} {pda2[1].name} {pda2[1].size} {assume_unique}"))
+        repMsg = cast(str, generic_msg(cmd="setops1d_multi",
+                             args=f"intersect {pda1[0].name} {pda1[1].name} {pda1[1].size} {pda2[0].name} {pda2[1].name} {pda2[1].size} {assume_unique}"))
         rep_ele = repMsg.split("+")
         return cast(pdarray, create_pdarray(rep_ele[0])), cast(pdarray, create_pdarray(rep_ele[1]))
 
@@ -525,8 +525,8 @@ def setdiff1d(pda1: Union[pdarray, List[pdarray], tuple], pda2: Union[pdarray, L
         if pda1[0].size != pda2[0].size:
             raise ValueError("Multiple array support for 1d operation requires the same number of array segments to be present in both objects.")
         # the segment arrays are always going to be dtype int. The values will support int64 and uint64
-        repMsg = cast(str, generic_msg(cmd="setdiff1d_multi",
-                             args=f"{pda1[0].name} {pda1[1].name} {pda1[1].size} {pda2[0].name} {pda2[1].name} {pda2[1].size} {assume_unique}"))
+        repMsg = cast(str, generic_msg(cmd="setops1d_multi",
+                             args=f"setdiff {pda1[0].name} {pda1[1].name} {pda1[1].size} {pda2[0].name} {pda2[1].name} {pda2[1].size} {assume_unique}"))
         rep_ele = repMsg.split("+")
         return cast(pdarray, create_pdarray(rep_ele[0])), cast(pdarray, create_pdarray(rep_ele[1]))
 
@@ -609,7 +609,7 @@ def setxor1d(pda1: Union[pdarray, List[pdarray], tuple], pda2: Union[pdarray, Li
         if pda1[0].size != pda2[0].size:
             raise ValueError("Multiple array support for 1d operation requires the same number of array segments to be present in both objects.")
         # the segment arrays are always going to be dtype int. The values will support int64 and uint64
-        repMsg = cast(str, generic_msg(cmd="setxor1d_multi",
-                             args=f"{pda1[0].name} {pda1[1].name} {pda1[1].size} {pda2[0].name} {pda2[1].name} {pda2[1].size} {assume_unique}"))
+        repMsg = cast(str, generic_msg(cmd="setops1d_multi",
+                             args=f"setxor {pda1[0].name} {pda1[1].name} {pda1[1].size} {pda2[0].name} {pda2[1].name} {pda2[1].size} {assume_unique}"))
         rep_ele = repMsg.split("+")
         return cast(pdarray, create_pdarray(rep_ele[0])), cast(pdarray, create_pdarray(rep_ele[1]))

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -348,6 +348,8 @@ def union1d(pda1: Union[pdarray, List[pdarray], tuple], pda2: Union[pdarray,
                     unique(cast(pdarray,
                                 concatenate((unique(pda1), unique(pda2)), ordered=False))))  # type: ignore
     else:
+        if pda1[0].size != pda2[0].size:
+            raise ValueError("Multiple array support for 1d operation requires the same number of array segments to be present in both objects.")
         # the segment arrays are always going to be dtype int. The values will support int64 and uint64
         repMsg = generic_msg(cmd="union1d_multi", args=f"{pda1[0].name} {pda1[1].name} {pda1[1].size} {pda2[0].name} {pda2[1].name} {pda2[1].size}")
         rep_ele = repMsg.split("+")
@@ -434,6 +436,8 @@ def intersect1d(pda1: Union[pdarray, List[pdarray], tuple], pda2: Union[pdarray,
         int1d = aux[:-1][mask]
         return int1d
     else:
+        if pda1[0].size != pda2[0].size:
+            raise ValueError("Multiple array support for 1d operation requires the same number of array segments to be present in both objects.")
         # the segment arrays are always going to be dtype int. The values will support int64 and uint64
         repMsg = generic_msg(cmd="intersect1d_multi",
                              args=f"{pda1[0].name} {pda1[1].name} {pda1[1].size} {pda2[0].name} {pda2[1].name} {pda2[1].size} {assume_unique}")
@@ -518,6 +522,8 @@ def setdiff1d(pda1: Union[pdarray, List[pdarray], tuple], pda2: Union[pdarray, L
             pda2 = cast(pdarray, unique(pda2))
         return pda1[in1d(pda1, pda2, invert=True)]
     else:
+        if pda1[0].size != pda2[0].size:
+            raise ValueError("Multiple array support for 1d operation requires the same number of array segments to be present in both objects.")
         # the segment arrays are always going to be dtype int. The values will support int64 and uint64
         repMsg = generic_msg(cmd="setdiff1d_multi",
                              args=f"{pda1[0].name} {pda1[1].name} {pda1[1].size} {pda2[0].name} {pda2[1].name} {pda2[1].size} {assume_unique}")
@@ -600,6 +606,8 @@ def setxor1d(pda1: Union[pdarray, List[pdarray], tuple], pda2: Union[pdarray, Li
         flag = concatenate((array([True]), aux[1:] != aux[:-1], array([True])))
         return aux[flag[1:] & flag[:-1]]
     else:
+        if pda1[0].size != pda2[0].size:
+            raise ValueError("Multiple array support for 1d operation requires the same number of array segments to be present in both objects.")
         # the segment arrays are always going to be dtype int. The values will support int64 and uint64
         repMsg = generic_msg(cmd="setxor1d_multi",
                              args=f"{pda1[0].name} {pda1[1].name} {pda1[1].size} {pda2[0].name} {pda2[1].name} {pda2[1].size} {assume_unique}")

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -325,10 +325,6 @@ def union1d(pda1: Union[pdarray, List[pdarray], tuple], pda2: Union[pdarray,
     (array(0, 3), array([-2, -1, 0, 1, 2])
 
     Multiple pdarrays flattened
-    a = [0, 1, 2]
-        b = [3, 4]
-        c = [5]
-        d = [6, 7, 8]
     >>> a_segs = ak.array([0, 3])
     >>> a_vals = ak.array([0, 1, 2, 3, 4])
     >>> b_segs = ak.array([0, 1])

--- a/src/ArraySetops.chpl
+++ b/src/ArraySetops.chpl
@@ -56,12 +56,12 @@ module ArraySetops
       const intx_segs = (+ scan intx_lens) - intx_lens;
       var intx_vals = makeDistArray((+ reduce intx_lens), t);
 
-      // Compute the union and add values to the corresponding indexes in values
+      // Compute the intersection and add values to the corresponding indexes in values
       forall (i, s1, l1, s2, l2, is, il) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_segs, intx_lens) with (var agg = newDstAggregator(t)){
         // TODO - update to use lowLevelLocalizingSlice 
-        var intx = intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+        var intx = new lowLevelLocalizingSlice(intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique), 0..#il);
         for i in (0..#il){
-          agg.copy(intx_vals[i+is], intx[i]);
+          agg.copy(intx_vals[i+is], intx.ptr[i]);
         }
       }
 
@@ -118,12 +118,12 @@ module ArraySetops
       const xor_segs = (+ scan xor_lens) - xor_lens;
       var xor_vals = makeDistArray((+ reduce xor_lens), t);
 
-      // Compute the union and add values to the corresponding indexes in values
+      // Compute the setxor and add values to the corresponding indexes in values
       forall (i, s1, l1, s2, l2, xs, xl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, xor_segs, xor_lens) with (var agg = newDstAggregator(t)){
         // TODO - update to use lowLevelLocalizingSlice 
-        var xor = setxor1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+        var xor = new lowLevelLocalizingSlice(setxor1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique), 0..#xl);
         for i in (0..#xl){
-          agg.copy(xor_vals[i+xs], xor[i]);
+          agg.copy(xor_vals[i+xs], xor.ptr[i]);
         }
       }
 
@@ -166,12 +166,12 @@ module ArraySetops
       const diff_segs = (+ scan diff_lens) - diff_lens;
       var diff_vals = makeDistArray((+ reduce diff_lens), t);
 
-      // Compute the union and add values to the corresponding indexes in values
+      // Compute the difference and add values to the corresponding indexes in values
       forall (i, s1, l1, s2, l2, ds, dl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, diff_segs, diff_lens) with (var agg = newDstAggregator(t)){
         // TODO - update to use lowLevelLocalizingSlice 
-        var d = setdiff1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+        var d = new lowLevelLocalizingSlice(setdiff1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique), 0..#dl);
         for i in (0..#dl){
-          agg.copy(diff_vals[i+ds], d[i]);
+          agg.copy(diff_vals[i+ds], d.ptr[i]);
         }
       }
 
@@ -207,9 +207,9 @@ module ArraySetops
       // Compute the union and add values to the corresponding indexes in values
       forall (i, s1, l1, s2, l2, us, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, union_segs, union_lens) with (var agg = newDstAggregator(t)){
         // TODO - update to use lowLevelLocalizingSlice 
-        var u = union1d(values1.a[s1..#l1], values2.a[s2..#l2]);
+        var u = new lowLevelLocalizingSlice(union1d(values1.a[s1..#l1], values2.a[s2..#l2]), 0..#ul);
         for i in (0..#ul){
-          agg.copy(union_vals[i+us], u[i]);
+          agg.copy(union_vals[i+us], u.ptr[i]);
         }
       }
 

--- a/src/ArraySetops.chpl
+++ b/src/ArraySetops.chpl
@@ -9,12 +9,15 @@ module ArraySetops
     use ServerConfig;
 
     use SymArrayDmap;
+    use MultiTypeSymEntry;
 
     use RadixSortLSD;
     use Unique;
     use Indexing;
     use AryUtil;
     use In1d;
+
+    use CommAggregation;
 
     // returns intersection of 2 arrays
     proc intersect1d(a: [] ?t, b: [] t, assume_unique: bool) throws {
@@ -38,6 +41,31 @@ module ArraySetops
       const mask = head == tail;
 
       return boolIndexer(head, mask);
+    }
+
+    proc intersect1d_multi(segments1: borrowed SymEntry(int), values1: borrowed SymEntry(?t), lens1: [] int, segments2: borrowed SymEntry(int), values2: borrowed SymEntry(t), lens2: [] int, isUnique: bool) throws {
+      var intx_lens: [segments1.aD] int;
+
+      // Compute lengths of the segments resulting from each union
+      forall (i, s1, l1, s2, l2, il) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_lens) with (var agg = newDstAggregator(int)){
+        // TODO - update to use lowLevelLocalizingSlice 
+        var intx = intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+        agg.copy(il, intx.size);
+      }
+
+      const intx_segs = (+ scan intx_lens) - intx_lens;
+      var intx_vals = makeDistArray((+ reduce intx_lens), t);
+
+      // Compute the union and add values to the corresponding indexes in values
+      forall (i, s1, l1, s2, l2, is, il) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_segs, intx_lens) with (var agg = newDstAggregator(t)){
+        // TODO - update to use lowLevelLocalizingSlice 
+        var intx = intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+        for i in (0..#il){
+          agg.copy(intx_vals[i+is], intx[i]);
+        }
+      }
+
+      return (intx_segs, intx_vals);
     }
     
     // returns the exclusive-or of 2 arrays
@@ -77,6 +105,31 @@ module ArraySetops
       return ret;
     }
 
+    proc setxor1d_multi(segments1: borrowed SymEntry(int), values1: borrowed SymEntry(?t), lens1: [] int, segments2: borrowed SymEntry(int), values2: borrowed SymEntry(t), lens2: [] int, isUnique: bool) throws {
+      var xor_lens: [segments1.aD] int;
+
+      // Compute lengths of the segments resulting from each union
+      forall (i, s1, l1, s2, l2, xl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, xor_lens) with (var agg = newDstAggregator(int)){
+        // TODO - update to use lowLevelLocalizingSlice 
+        var xor = setxor1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+        agg.copy(xl, xor.size);
+      }
+
+      const xor_segs = (+ scan xor_lens) - xor_lens;
+      var xor_vals = makeDistArray((+ reduce xor_lens), t);
+
+      // Compute the union and add values to the corresponding indexes in values
+      forall (i, s1, l1, s2, l2, xs, xl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, xor_segs, xor_lens) with (var agg = newDstAggregator(t)){
+        // TODO - update to use lowLevelLocalizingSlice 
+        var xor = setxor1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+        for i in (0..#xl){
+          agg.copy(xor_vals[i+xs], xor[i]);
+        }
+      }
+
+      return (xor_segs, xor_vals);
+    }
+
     // returns the set difference of 2 arrays
     proc setdiff1d(a: [] ?t, b: [] t, assume_unique: bool) throws {
       //if not unique, unique sort arrays then perform operation
@@ -99,6 +152,31 @@ module ArraySetops
         var ret = boolIndexer(a, truth);
         return ret;
     }
+
+    proc setdiff1d_multi(segments1: borrowed SymEntry(int), values1: borrowed SymEntry(?t), lens1: [] int, segments2: borrowed SymEntry(int), values2: borrowed SymEntry(t), lens2: [] int, isUnique: bool) throws {
+      var diff_lens: [segments1.aD] int;
+
+      // Compute lengths of the segments resulting from each union
+      forall (i, s1, l1, s2, l2, dl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, diff_lens) with (var agg = newDstAggregator(int)){
+        // TODO - update to use lowLevelLocalizingSlice 
+        var d = setdiff1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+        agg.copy(dl, d.size);
+      }
+
+      const diff_segs = (+ scan diff_lens) - diff_lens;
+      var diff_vals = makeDistArray((+ reduce diff_lens), t);
+
+      // Compute the union and add values to the corresponding indexes in values
+      forall (i, s1, l1, s2, l2, ds, dl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, diff_segs, diff_lens) with (var agg = newDstAggregator(t)){
+        // TODO - update to use lowLevelLocalizingSlice 
+        var d = setdiff1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+        for i in (0..#dl){
+          agg.copy(diff_vals[i+ds], d[i]);
+        }
+      }
+
+      return (diff_segs, diff_vals);
+    }
     
     // Gets union of 2 arrays
     // first concatenates the 2 arrays, then
@@ -111,5 +189,30 @@ module ArraySetops
         aux = concatArrays(uniqueSort(a,false), uniqueSort(b,false));
       }
       return uniqueSort(aux, false);
+    }
+
+    proc union1d_multi(segments1: borrowed SymEntry(int), values1: borrowed SymEntry(?t), lens1: [] int, segments2: borrowed SymEntry(int), values2: borrowed SymEntry(t), lens2: [] int) throws {
+      var union_lens: [segments1.aD] int;
+
+      // Compute lengths of the segments resulting from each union
+      forall (i, s1, l1, s2, l2, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, union_lens) with (var agg = newDstAggregator(int)){
+        // TODO - update to use lowLevelLocalizingSlice 
+        var u = union1d(values1.a[s1..#l1], values2.a[s2..#l2]);
+        agg.copy(ul, u.size);
+      }
+
+      const union_segs = (+ scan union_lens) - union_lens;
+      var union_vals = makeDistArray((+ reduce union_lens), t);
+
+      // Compute the union and add values to the corresponding indexes in values
+      forall (i, s1, l1, s2, l2, us, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, union_segs, union_lens) with (var agg = newDstAggregator(t)){
+        // TODO - update to use lowLevelLocalizingSlice 
+        var u = union1d(values1.a[s1..#l1], values2.a[s2..#l2]);
+        for i in (0..#ul){
+          agg.copy(union_vals[i+us], u[i]);
+        }
+      }
+
+      return (union_segs, union_vals);
     }
 }

--- a/src/ArraySetopsMsg.chpl
+++ b/src/ArraySetopsMsg.chpl
@@ -317,37 +317,21 @@ module ArraySetopsMsg
               var (segments, values) = union1d_multi(segments1, values1, lens1, segments2, values2, lens2);
               st.addEntry(s_name, new shared SymEntry(segments));
               st.addEntry(v_name, new shared SymEntry(values));
-
-              repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
-              asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-              return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             when("intersect"){
               var (segments, values) = intersect1d_multi(segments1, values1, lens1, segments2, values2, lens2, isUnique);
               st.addEntry(s_name, new shared SymEntry(segments));
               st.addEntry(v_name, new shared SymEntry(values));
-
-              repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
-              asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-              return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             when("setdiff"){
               var (segments, values) = setdiff1d_multi(segments1, values1, lens1, segments2, values2, lens2, isUnique);
               st.addEntry(s_name, new shared SymEntry(segments));
               st.addEntry(v_name, new shared SymEntry(values));
-
-              repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
-              asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-              return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             when("setxor"){
               var (segments, values) = setxor1d_multi(segments1, values1, lens1, segments2, values2, lens2, isUnique);
               st.addEntry(s_name, new shared SymEntry(segments));
               st.addEntry(v_name, new shared SymEntry(values));
-
-              repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
-              asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-              return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             otherwise {
               var errorMsg = notImplementedError("setops1d_multi", sub_command);
@@ -364,37 +348,21 @@ module ArraySetopsMsg
               var (segments, values) = union1d_multi(segments1, values1, lens1, segments2, values2, lens2);
               st.addEntry(s_name, new shared SymEntry(segments));
               st.addEntry(v_name, new shared SymEntry(values));
-
-              repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
-              asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-              return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             when("intersect"){
               var (segments, values) = intersect1d_multi(segments1, values1, lens1, segments2, values2, lens2, isUnique);
               st.addEntry(s_name, new shared SymEntry(segments));
               st.addEntry(v_name, new shared SymEntry(values));
-
-              repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
-              asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-              return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             when("setdiff"){
               var (segments, values) = setdiff1d_multi(segments1, values1, lens1, segments2, values2, lens2, isUnique);
               st.addEntry(s_name, new shared SymEntry(segments));
               st.addEntry(v_name, new shared SymEntry(values));
-
-              repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
-              asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-              return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             when("setxor"){
               var (segments, values) = setxor1d_multi(segments1, values1, lens1, segments2, values2, lens2, isUnique);
               st.addEntry(s_name, new shared SymEntry(segments));
               st.addEntry(v_name, new shared SymEntry(values));
-
-              repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
-              asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-              return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             otherwise {
               var errorMsg = notImplementedError("setops1d_multi", sub_command);
@@ -409,6 +377,9 @@ module ArraySetopsMsg
           return new MsgTuple(errorMsg, MsgType.ERROR);              
         }
       }
+      repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
+      asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+      return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 
     proc stringtobool(str: string): bool throws {

--- a/src/ArraySetopsMsg.chpl
+++ b/src/ArraySetopsMsg.chpl
@@ -18,7 +18,6 @@ module ArraySetopsMsg
     use ServerErrorStrings;
 
     use ArraySetops;
-    use Unique;
     use Indexing;
     use RadixSortLSD;
     use Reflection;

--- a/src/ArraySetopsMsg.chpl
+++ b/src/ArraySetopsMsg.chpl
@@ -86,6 +86,143 @@ module ArraySetopsMsg
         }
     }
 
+    proc intersect1d_multiMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+      param pn = Reflection.getRoutineName();
+      var repMsg: string; // response message
+      // split request into fields
+      var (seg1_name, vals1_name, s1_str, seg2_name, vals2_name, s2_str, assume_unique) = payload.splitMsgToTuple(7);
+      var isUnique = stringtobool(assume_unique);
+
+      var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(seg1_name, st);
+      var gEnt2: borrowed GenSymEntry = getGenericTypedArrayEntry(vals1_name, st);
+      var gEnt3: borrowed GenSymEntry = getGenericTypedArrayEntry(seg2_name, st);
+      var gEnt4: borrowed GenSymEntry = getGenericTypedArrayEntry(vals2_name, st);
+
+      // verify that expected integer values can be cast
+      var size1: int;
+      var size2: int;
+      try{
+        size1 = s1_str: int;
+        size2 = s2_str: int;
+      }
+      catch {
+        var errorMsg = "Count could not be interpretted as an int1: %s, int2: %s)".format(s1_str, s2_str);
+        asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+        throw new owned IllegalArgumentError(errorMsg);
+      }
+
+      var segments1 = toSymEntry(gEnt,int);
+      var segments2 = toSymEntry(gEnt3,int);
+
+      // set segment lengths
+      var lens1: [segments1.aD] int;
+      var lens2: [segments2.aD] int;
+      var high = segments1.aD.high;
+      var low = segments1.aD.low;
+      var m1: int;
+      var m2: int;
+      for (i, s1, l1, s2, l2) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2){
+        if i == high {
+          l1 = size1 - s1;
+          l2 = size2 - s2;
+        }
+        else{
+          l1 = segments1.a[i+1] - s1;
+          l2 = segments2.a[i+1] - s2;
+        }
+        // Set the max segment length for memory check
+        if (i == low || m1 < l1) {
+          m1 = l1;
+        }
+        if (i == low || m2 < l2) {
+          m2 = l2;
+        }
+      }
+      
+      // perform memory exhaustion check using the size of the largest segment present
+      var itemsize = if gEnt2.dtype == DType.UInt64 then numBytes(uint) else numBytes(int);
+      var sortMem1 = radixSortLSD_memEst(m1, itemsize);
+      var sortMem2 = radixSortLSD_memEst(m2, itemsize);
+      var intx_maxMem = max(sortMem1, sortMem2);
+      overMemLimit(intx_maxMem);
+
+      select(gEnt2.dtype, gEnt4.dtype) {
+        when (DType.Int64, DType.Int64) {
+          var values1 = toSymEntry(gEnt2, int);
+          var values2 = toSymEntry(gEnt4, int);
+
+          var intx_lens: [segments1.aD] int;
+
+          // Compute lengths of the segments resulting from each union
+          forall (i, s1, l1, s2, l2, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_lens) with (var agg = newSrcAggregator(int)){
+            // TODO - update to use lowLevelLocalizingSlice 
+            var u = intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+            agg.copy(ul, u.size);
+          }
+
+          const intx_segs = (+ scan intx_lens) - intx_lens;
+          var intx_vals = makeDistArray((+ reduce intx_lens), int);
+
+          // Compute the union and add values to the corresponding indexes in values
+          forall (i, s1, l1, s2, l2, us, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_segs, intx_lens) with (var agg = newSrcAggregator(int)){
+            // TODO - update to use lowLevelLocalizingSlice 
+            var intx = intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+            for i in (0..#ul){
+              agg.copy(intx_vals[i+us], intx[i]);
+            }
+          }
+
+          var s_name = st.nextName();
+          st.addEntry(s_name, new shared SymEntry(intx_segs));
+          var v_name = st.nextName();
+          st.addEntry(v_name, new shared SymEntry(intx_vals));
+
+          repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
+          asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+          return new MsgTuple(repMsg, MsgType.NORMAL);
+        }
+        when (DType.UInt64, DType.UInt64) {
+          var values1 = toSymEntry(gEnt2, uint);
+          var values2 = toSymEntry(gEnt4, uint);
+
+          var intx_lens: [segments1.aD] int;
+
+          // Compute lengths of the segments resulting from each union
+          forall (i, s1, l1, s2, l2, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_lens) with (var agg = newSrcAggregator(int)){
+            // TODO - update to use lowLevelLocalizingSlice 
+            var u = intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+            agg.copy(ul, u.size);
+          }
+
+          const intx_segs = (+ scan intx_lens) - intx_lens;
+          var intx_vals = makeDistArray((+ reduce intx_lens), uint);
+
+          // Compute the union and add values to the corresponding indexes in values
+          forall (i, s1, l1, s2, l2, us, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_segs, intx_lens) with (var agg = newSrcAggregator(uint)){
+            // TODO - update to use lowLevelLocalizingSlice 
+            var intx = intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+            for i in (0..#ul){
+              agg.copy(intx_vals[i+us], intx[i]);
+            }
+          }
+
+          var s_name = st.nextName();
+          st.addEntry(s_name, new shared SymEntry(intx_segs));
+          var v_name = st.nextName();
+          st.addEntry(v_name, new shared SymEntry(intx_vals));
+
+          repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
+          asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+          return new MsgTuple(repMsg, MsgType.NORMAL);
+        }
+        otherwise {
+            var errorMsg = notImplementedError("intersect1d_multi",gEnt.dtype);
+            asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+          }
+      }
+    }
+
     /*
     Parse, execute, and respond to a setxor1d message
     :arg reqMsg: request containing (cmd,name,name2,assume_unique)
@@ -403,6 +540,7 @@ module ArraySetopsMsg
     proc registerMe() {
       use CommandMap;
       registerFunction("intersect1d", intersect1dMsg, getModuleName());
+      registerFunction("intersect1d_multi", intersect1d_multiMsg, getModuleName());
       registerFunction("setdiff1d", setdiff1dMsg, getModuleName());
       registerFunction("setxor1d", setxor1dMsg, getModuleName());
       registerFunction("union1d", union1dMsg, getModuleName());

--- a/src/ArraySetopsMsg.chpl
+++ b/src/ArraySetopsMsg.chpl
@@ -85,143 +85,6 @@ module ArraySetopsMsg
         }
     }
 
-    proc intersect1d_multiMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
-      param pn = Reflection.getRoutineName();
-      var repMsg: string; // response message
-      // split request into fields
-      var (seg1_name, vals1_name, s1_str, seg2_name, vals2_name, s2_str, assume_unique) = payload.splitMsgToTuple(7);
-      var isUnique = stringtobool(assume_unique);
-
-      var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(seg1_name, st);
-      var gEnt2: borrowed GenSymEntry = getGenericTypedArrayEntry(vals1_name, st);
-      var gEnt3: borrowed GenSymEntry = getGenericTypedArrayEntry(seg2_name, st);
-      var gEnt4: borrowed GenSymEntry = getGenericTypedArrayEntry(vals2_name, st);
-
-      // verify that expected integer values can be cast
-      var size1: int;
-      var size2: int;
-      try{
-        size1 = s1_str: int;
-        size2 = s2_str: int;
-      }
-      catch {
-        var errorMsg = "Count could not be interpreted as an int1: %s, int2: %s)".format(s1_str, s2_str);
-        asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-        throw new owned IllegalArgumentError(errorMsg);
-      }
-
-      var segments1 = toSymEntry(gEnt,int);
-      var segments2 = toSymEntry(gEnt3,int);
-
-      // set segment lengths
-      var lens1: [segments1.aD] int;
-      var lens2: [segments2.aD] int;
-      var high = segments1.aD.high;
-      var low = segments1.aD.low;
-      var m1: int;
-      var m2: int;
-      for (i, s1, l1, s2, l2) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2){
-        if i == high {
-          l1 = size1 - s1;
-          l2 = size2 - s2;
-        }
-        else{
-          l1 = segments1.a[i+1] - s1;
-          l2 = segments2.a[i+1] - s2;
-        }
-        // Set the max segment length for memory check
-        if (i == low || m1 < l1) {
-          m1 = l1;
-        }
-        if (i == low || m2 < l2) {
-          m2 = l2;
-        }
-      }
-      
-      // perform memory exhaustion check using the size of the largest segment present
-      var itemsize = if gEnt2.dtype == DType.UInt64 then numBytes(uint) else numBytes(int);
-      var sortMem1 = radixSortLSD_memEst(m1, itemsize);
-      var sortMem2 = radixSortLSD_memEst(m2, itemsize);
-      var intx_maxMem = max(sortMem1, sortMem2);
-      overMemLimit(intx_maxMem);
-
-      select(gEnt2.dtype, gEnt4.dtype) {
-        when (DType.Int64, DType.Int64) {
-          var values1 = toSymEntry(gEnt2, int);
-          var values2 = toSymEntry(gEnt4, int);
-
-          var intx_lens: [segments1.aD] int;
-
-          // Compute lengths of the segments resulting from each union
-          forall (i, s1, l1, s2, l2, il) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_lens) with (var agg = newDstAggregator(int)){
-            // TODO - update to use lowLevelLocalizingSlice 
-            var intx = intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
-            agg.copy(il, intx.size);
-          }
-
-          const intx_segs = (+ scan intx_lens) - intx_lens;
-          var intx_vals = makeDistArray((+ reduce intx_lens), int);
-
-          // Compute the union and add values to the corresponding indexes in values
-          forall (i, s1, l1, s2, l2, is, il) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_segs, intx_lens) with (var agg = newDstAggregator(int)){
-            // TODO - update to use lowLevelLocalizingSlice 
-            var intx = intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
-            for i in (0..#il){
-              agg.copy(intx_vals[i+is], intx[i]);
-            }
-          }
-
-          var s_name = st.nextName();
-          st.addEntry(s_name, new shared SymEntry(intx_segs));
-          var v_name = st.nextName();
-          st.addEntry(v_name, new shared SymEntry(intx_vals));
-
-          repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
-          asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-          return new MsgTuple(repMsg, MsgType.NORMAL);
-        }
-        when (DType.UInt64, DType.UInt64) {
-          var values1 = toSymEntry(gEnt2, uint);
-          var values2 = toSymEntry(gEnt4, uint);
-
-          var intx_lens: [segments1.aD] int;
-
-          // Compute lengths of the segments resulting from each union
-          forall (i, s1, l1, s2, l2, il) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_lens) with (var agg = newDstAggregator(int)){
-            // TODO - update to use lowLevelLocalizingSlice 
-            var intx = intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
-            agg.copy(il, intx.size);
-          }
-
-          const intx_segs = (+ scan intx_lens) - intx_lens;
-          var intx_vals = makeDistArray((+ reduce intx_lens), uint);
-
-          // Compute the union and add values to the corresponding indexes in values
-          forall (i, s1, l1, s2, l2, is, il) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_segs, intx_lens) with (var agg = newDstAggregator(uint)){
-            // TODO - update to use lowLevelLocalizingSlice 
-            var intx = intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
-            for i in (0..#il){
-              agg.copy(intx_vals[i+is], intx[i]);
-            }
-          }
-
-          var s_name = st.nextName();
-          st.addEntry(s_name, new shared SymEntry(intx_segs));
-          var v_name = st.nextName();
-          st.addEntry(v_name, new shared SymEntry(intx_vals));
-
-          repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
-          asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-          return new MsgTuple(repMsg, MsgType.NORMAL);
-        }
-        otherwise {
-          var errorMsg = notImplementedError("intersect1d_multi",gEnt.dtype);
-          asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
-          return new MsgTuple(errorMsg, MsgType.ERROR);
-        }
-      }
-    }
-
     /*
     Parse, execute, and respond to a setxor1d message
     :arg reqMsg: request containing (cmd,name,name2,assume_unique)
@@ -276,143 +139,6 @@ module ArraySetopsMsg
                return new MsgTuple(errorMsg, MsgType.ERROR);
            }
         }
-    }
-
-    proc setxor1d_multiMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
-      param pn = Reflection.getRoutineName();
-      var repMsg: string; // response message
-      // split request into fields
-      var (seg1_name, vals1_name, s1_str, seg2_name, vals2_name, s2_str, assume_unique) = payload.splitMsgToTuple(7);
-      var isUnique = stringtobool(assume_unique);
-
-      var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(seg1_name, st);
-      var gEnt2: borrowed GenSymEntry = getGenericTypedArrayEntry(vals1_name, st);
-      var gEnt3: borrowed GenSymEntry = getGenericTypedArrayEntry(seg2_name, st);
-      var gEnt4: borrowed GenSymEntry = getGenericTypedArrayEntry(vals2_name, st);
-
-      // verify that expected integer values can be cast
-      var size1: int;
-      var size2: int;
-      try{
-        size1 = s1_str: int;
-        size2 = s2_str: int;
-      }
-      catch {
-        var errorMsg = "Count could not be interpreted as an int1: %s, int2: %s)".format(s1_str, s2_str);
-        asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-        throw new owned IllegalArgumentError(errorMsg);
-      }
-
-      var segments1 = toSymEntry(gEnt,int);
-      var segments2 = toSymEntry(gEnt3,int);
-
-      // set segment lengths
-      var lens1: [segments1.aD] int;
-      var lens2: [segments2.aD] int;
-      var high = segments1.aD.high;
-      var low = segments1.aD.low;
-      var m1: int;
-      var m2: int;
-      for (i, s1, l1, s2, l2) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2){
-        if i == high {
-          l1 = size1 - s1;
-          l2 = size2 - s2;
-        }
-        else{
-          l1 = segments1.a[i+1] - s1;
-          l2 = segments2.a[i+1] - s2;
-        }
-        // Set the max segment length for memory check
-        if (i == low || m1 < l1) {
-          m1 = l1;
-        }
-        if (i == low || m2 < l2) {
-          m2 = l2;
-        }
-      }
-      
-      // perform memory exhaustion check using the size of the largest segment present
-      var itemsize = if gEnt2.dtype == DType.UInt64 then numBytes(uint) else numBytes(int);
-      var sortMem1 = radixSortLSD_memEst(m1, itemsize);
-      var sortMem2 = radixSortLSD_memEst(m2, itemsize);
-      var xor_maxMem = max(sortMem1, sortMem2);
-      overMemLimit(xor_maxMem);
-
-      select(gEnt2.dtype, gEnt4.dtype) {
-        when (DType.Int64, DType.Int64) {
-          var values1 = toSymEntry(gEnt2, int);
-          var values2 = toSymEntry(gEnt4, int);
-
-          var xor_lens: [segments1.aD] int;
-
-          // Compute lengths of the segments resulting from each union
-          forall (i, s1, l1, s2, l2, xl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, xor_lens) with (var agg = newDstAggregator(int)){
-            // TODO - update to use lowLevelLocalizingSlice 
-            var xor = setxor1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
-            agg.copy(xl, xor.size);
-          }
-
-          const xor_segs = (+ scan xor_lens) - xor_lens;
-          var xor_vals = makeDistArray((+ reduce xor_lens), int);
-
-          // Compute the union and add values to the corresponding indexes in values
-          forall (i, s1, l1, s2, l2, xs, xl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, xor_segs, xor_lens) with (var agg = newDstAggregator(int)){
-            // TODO - update to use lowLevelLocalizingSlice 
-            var xor = setxor1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
-            for i in (0..#xl){
-              agg.copy(xor_vals[i+xs], xor[i]);
-            }
-          }
-
-          var s_name = st.nextName();
-          st.addEntry(s_name, new shared SymEntry(xor_segs));
-          var v_name = st.nextName();
-          st.addEntry(v_name, new shared SymEntry(xor_vals));
-
-          repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
-          asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-          return new MsgTuple(repMsg, MsgType.NORMAL);
-        }
-        when (DType.UInt64, DType.UInt64) {
-          var values1 = toSymEntry(gEnt2, uint);
-          var values2 = toSymEntry(gEnt4, uint);
-
-          var xor_lens: [segments1.aD] int;
-
-          // Compute lengths of the segments resulting from each union
-          forall (i, s1, l1, s2, l2, xl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, xor_lens) with (var agg = newDstAggregator(int)){
-            // TODO - update to use lowLevelLocalizingSlice 
-            var xor = setxor1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
-            agg.copy(xl, xor.size);
-          }
-
-          const xor_segs = (+ scan xor_lens) - xor_lens;
-          var xor_vals = makeDistArray((+ reduce xor_lens), uint);
-
-          // Compute the union and add values to the corresponding indexes in values
-          forall (i, s1, l1, s2, l2, xs, xl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, xor_segs, xor_lens) with (var agg = newDstAggregator(uint)){
-            // TODO - update to use lowLevelLocalizingSlice 
-            var xor = setxor1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
-            for i in (0..#xl){
-              agg.copy(xor_vals[i+xs], xor[i]);
-            }
-          }
-
-          var s_name = st.nextName();
-          st.addEntry(s_name, new shared SymEntry(xor_segs));
-          var v_name = st.nextName();
-          st.addEntry(v_name, new shared SymEntry(xor_vals));
-
-          repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
-          asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-          return new MsgTuple(repMsg, MsgType.NORMAL);
-        }
-        otherwise {
-          var errorMsg = notImplementedError("setxor_multi",gEnt.dtype);
-          asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
-          return new MsgTuple(errorMsg, MsgType.ERROR);
-        }
-      }
     }
 
     /*
@@ -471,143 +197,6 @@ module ArraySetopsMsg
         }
     }
 
-    proc setdiff1d_multiMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
-      param pn = Reflection.getRoutineName();
-      var repMsg: string; // response message
-      // split request into fields
-      var (seg1_name, vals1_name, s1_str, seg2_name, vals2_name, s2_str, assume_unique) = payload.splitMsgToTuple(7);
-      var isUnique = stringtobool(assume_unique);
-
-      var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(seg1_name, st);
-      var gEnt2: borrowed GenSymEntry = getGenericTypedArrayEntry(vals1_name, st);
-      var gEnt3: borrowed GenSymEntry = getGenericTypedArrayEntry(seg2_name, st);
-      var gEnt4: borrowed GenSymEntry = getGenericTypedArrayEntry(vals2_name, st);
-
-      // verify that expected integer values can be cast
-      var size1: int;
-      var size2: int;
-      try{
-        size1 = s1_str: int;
-        size2 = s2_str: int;
-      }
-      catch {
-        var errorMsg = "Count could not be interpreted as an int1: %s, int2: %s)".format(s1_str, s2_str);
-        asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-        throw new owned IllegalArgumentError(errorMsg);
-      }
-
-      var segments1 = toSymEntry(gEnt,int);
-      var segments2 = toSymEntry(gEnt3,int);
-
-      // set segment lengths
-      var lens1: [segments1.aD] int;
-      var lens2: [segments2.aD] int;
-      var high = segments1.aD.high;
-      var low = segments1.aD.low;
-      var m1: int;
-      var m2: int;
-      for (i, s1, l1, s2, l2) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2){
-        if i == high {
-          l1 = size1 - s1;
-          l2 = size2 - s2;
-        }
-        else{
-          l1 = segments1.a[i+1] - s1;
-          l2 = segments2.a[i+1] - s2;
-        }
-        // Set the max segment length for memory check
-        if (i == low || m1 < l1) {
-          m1 = l1;
-        }
-        if (i == low || m2 < l2) {
-          m2 = l2;
-        }
-      }
-      
-      // perform memory exhaustion check using the size of the largest segment present
-      var itemsize = if gEnt2.dtype == DType.UInt64 then numBytes(uint) else numBytes(int);
-      var sortMem1 = radixSortLSD_memEst(m1, itemsize);
-      var sortMem2 = radixSortLSD_memEst(m2, itemsize);
-      var diff_maxMem = max(sortMem1, sortMem2);
-      overMemLimit(diff_maxMem);
-
-      select(gEnt2.dtype, gEnt4.dtype) {
-        when (DType.Int64, DType.Int64) {
-          var values1 = toSymEntry(gEnt2, int);
-          var values2 = toSymEntry(gEnt4, int);
-
-          var diff_lens: [segments1.aD] int;
-
-          // Compute lengths of the segments resulting from each union
-          forall (i, s1, l1, s2, l2, dl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, diff_lens) with (var agg = newDstAggregator(int)){
-            // TODO - update to use lowLevelLocalizingSlice 
-            var d = setdiff1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
-            agg.copy(dl, d.size);
-          }
-
-          const diff_segs = (+ scan diff_lens) - diff_lens;
-          var diff_vals = makeDistArray((+ reduce diff_lens), int);
-
-          // Compute the union and add values to the corresponding indexes in values
-          forall (i, s1, l1, s2, l2, ds, dl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, diff_segs, diff_lens) with (var agg = newDstAggregator(int)){
-            // TODO - update to use lowLevelLocalizingSlice 
-            var d = setdiff1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
-            for i in (0..#dl){
-              agg.copy(diff_vals[i+ds], d[i]);
-            }
-          }
-
-          var s_name = st.nextName();
-          st.addEntry(s_name, new shared SymEntry(diff_segs));
-          var v_name = st.nextName();
-          st.addEntry(v_name, new shared SymEntry(diff_vals));
-
-          repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
-          asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-          return new MsgTuple(repMsg, MsgType.NORMAL);
-        }
-        when (DType.UInt64, DType.UInt64) {
-          var values1 = toSymEntry(gEnt2, uint);
-          var values2 = toSymEntry(gEnt4, uint);
-
-          var diff_lens: [segments1.aD] int;
-
-          // Compute lengths of the segments resulting from each union
-          forall (i, s1, l1, s2, l2, dl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, diff_lens) with (var agg = newDstAggregator(int)){
-            // TODO - update to use lowLevelLocalizingSlice 
-            var d = setdiff1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
-            agg.copy(dl, d.size);
-          }
-
-          const diff_segs = (+ scan diff_lens) - diff_lens;
-          var diff_vals = makeDistArray((+ reduce diff_lens), uint);
-
-          // Compute the union and add values to the corresponding indexes in values
-          forall (i, s1, l1, s2, l2, ds, dl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, diff_segs, diff_lens) with (var agg = newDstAggregator(uint)){
-            // TODO - update to use lowLevelLocalizingSlice 
-            var d = setdiff1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
-            for i in (0..#dl){
-              agg.copy(diff_vals[i+ds], d[i]);
-            }
-          }
-
-          var s_name = st.nextName();
-          st.addEntry(s_name, new shared SymEntry(diff_segs));
-          var v_name = st.nextName();
-          st.addEntry(v_name, new shared SymEntry(diff_vals));
-
-          repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
-          asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-          return new MsgTuple(repMsg, MsgType.NORMAL);
-        }
-        otherwise {
-          var errorMsg = notImplementedError("setdiff1d_multi",gEnt.dtype);
-          asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
-          return new MsgTuple(errorMsg, MsgType.ERROR);
-        }
-      }
-    }
-
     /*
     Parse, execute, and respond to a union1d message
     :arg reqMsg: request containing (cmd,name,name2,assume_unique)
@@ -663,11 +252,12 @@ module ArraySetopsMsg
       }
     }
 
-    proc union1d_multiMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc setops1d_multiMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
       param pn = Reflection.getRoutineName();
       var repMsg: string; // response message
         // split request into fields
-      var (seg1_name, vals1_name, s1_str, seg2_name, vals2_name, s2_str) = payload.splitMsgToTuple(6);
+      var (sub_command, seg1_name, vals1_name, s1_str, seg2_name, vals2_name, s2_str, assume_unique) = payload.splitMsgToTuple(8);
+      var isUnique = if assume_unique != "" then stringtobool(assume_unique) else false;
 
       var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(seg1_name, st);
       var gEnt2: borrowed GenSymEntry = getGenericTypedArrayEntry(vals1_name, st);
@@ -682,7 +272,7 @@ module ArraySetopsMsg
         size2 = s2_str: int;
       }
       catch {
-        var errorMsg = "Count could not be interpreted as an int1: %s, int2: %s)".format(s1_str, s2_str);
+        var errorMsg = "size1 or size2 could not be interpreted as an int size1: %s, size2: %s)".format(s1_str, s2_str);
         asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
         throw new owned IllegalArgumentError(errorMsg);
       }
@@ -695,9 +285,7 @@ module ArraySetopsMsg
       var lens2: [segments2.aD] int;
       var high = segments1.aD.high;
       var low = segments1.aD.low;
-      var m1: int;
-      var m2: int;
-      for (i, s1, l1, s2, l2) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2){
+      forall (i, s1, l1, s2, l2) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2){
         if i == high {
           l1 = size1 - s1;
           l2 = size2 - s2;
@@ -706,15 +294,10 @@ module ArraySetopsMsg
           l1 = segments1.a[i+1] - s1;
           l2 = segments2.a[i+1] - s2;
         }
-        // Set the max segment length for memory check
-        if (i == low || m1 < l1) {
-          m1 = l1;
-        }
-        if (i == low || m2 < l2) {
-          m2 = l2;
-        }
       }
-      
+      var m1: int = max reduce lens1;
+      var m2: int = max reduce lens2;
+
       // perform memory exhaustion check using the size of the largest segment present
       var itemsize = if gEnt2.dtype == DType.UInt64 then numBytes(uint) else numBytes(int);
       var sortMem1 = radixSortLSD_memEst(m1, itemsize);
@@ -722,80 +305,109 @@ module ArraySetopsMsg
       var union_maxMem = max(sortMem1, sortMem2);
       overMemLimit(union_maxMem);
 
-      select(gEnt2.dtype, gEnt4.dtype) {
-        when (DType.Int64, DType.Int64) {
-          var values1 = toSymEntry(gEnt2, int);
-          var values2 = toSymEntry(gEnt4, int);
+      var s_name = st.nextName();
+      var v_name = st.nextName();
 
-          var union_lens: [segments1.aD] int;
+      select(gEnt2.dtype, gEnt4.dtype){
+        when(DType.Int64, DType.Int64){
+          var values1 = toSymEntry(gEnt2,int);
+          var values2 = toSymEntry(gEnt4,int);
+          select(sub_command){
+            when("union"){
+              var (segments, values) = union1d_multi(segments1, values1, lens1, segments2, values2, lens2);
+              st.addEntry(s_name, new shared SymEntry(segments));
+              st.addEntry(v_name, new shared SymEntry(values));
 
-          // Compute lengths of the segments resulting from each union
-          forall (i, s1, l1, s2, l2, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, union_lens) with (var agg = newDstAggregator(int)){
-            // TODO - update to use lowLevelLocalizingSlice 
-            var u = union1d(values1.a[s1..#l1], values2.a[s2..#l2]);
-            agg.copy(ul, u.size);
-          }
+              repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
+              asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            when("intersect"){
+              var (segments, values) = intersect1d_multi(segments1, values1, lens1, segments2, values2, lens2, isUnique);
+              st.addEntry(s_name, new shared SymEntry(segments));
+              st.addEntry(v_name, new shared SymEntry(values));
 
-          const union_segs = (+ scan union_lens) - union_lens;
-          var union_vals = makeDistArray((+ reduce union_lens), int);
+              repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
+              asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            when("setdiff"){
+              var (segments, values) = setdiff1d_multi(segments1, values1, lens1, segments2, values2, lens2, isUnique);
+              st.addEntry(s_name, new shared SymEntry(segments));
+              st.addEntry(v_name, new shared SymEntry(values));
 
-          // Compute the union and add values to the corresponding indexes in values
-          forall (i, s1, l1, s2, l2, us, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, union_segs, union_lens) with (var agg = newDstAggregator(int)){
-            // TODO - update to use lowLevelLocalizingSlice 
-            var u = union1d(values1.a[s1..#l1], values2.a[s2..#l2]);
-            for i in (0..#ul){
-              agg.copy(union_vals[i+us], u[i]);
+              repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
+              asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            when("setxor"){
+              var (segments, values) = setxor1d_multi(segments1, values1, lens1, segments2, values2, lens2, isUnique);
+              st.addEntry(s_name, new shared SymEntry(segments));
+              st.addEntry(v_name, new shared SymEntry(values));
+
+              repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
+              asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            otherwise {
+              var errorMsg = notImplementedError("setops1d_multi", sub_command);
+              asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                   
+              return new MsgTuple(errorMsg, MsgType.ERROR);              
             }
           }
-
-          var s_name = st.nextName();
-          st.addEntry(s_name, new shared SymEntry(union_segs));
-          var v_name = st.nextName();
-          st.addEntry(v_name, new shared SymEntry(union_vals));
-
-          repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
-          asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-          return new MsgTuple(repMsg, MsgType.NORMAL);
         }
-        when (DType.UInt64, DType.UInt64) {
-          var values1 = toSymEntry(gEnt2, uint);
-          var values2 = toSymEntry(gEnt4, uint);
+        when(DType.UInt64, DType.UInt64){
+          var values1 = toSymEntry(gEnt2,uint);
+          var values2 = toSymEntry(gEnt4,uint);
+          select(sub_command){
+            when("union"){
+              var (segments, values) = union1d_multi(segments1, values1, lens1, segments2, values2, lens2);
+              st.addEntry(s_name, new shared SymEntry(segments));
+              st.addEntry(v_name, new shared SymEntry(values));
 
-          var union_lens: [segments1.aD] int;
+              repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
+              asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            when("intersect"){
+              var (segments, values) = intersect1d_multi(segments1, values1, lens1, segments2, values2, lens2, isUnique);
+              st.addEntry(s_name, new shared SymEntry(segments));
+              st.addEntry(v_name, new shared SymEntry(values));
 
-          // Compute lengths of the segments resulting from each union
-          forall (i, s1, l1, s2, l2, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, union_lens) with (var agg = newDstAggregator(int)){
-            // TODO - update to use lowLevelLocalizingSlice 
-            var u = union1d(values1.a[s1..#l1], values2.a[s2..#l2]);
-            agg.copy(ul, u.size);
-          }
+              repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
+              asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            when("setdiff"){
+              var (segments, values) = setdiff1d_multi(segments1, values1, lens1, segments2, values2, lens2, isUnique);
+              st.addEntry(s_name, new shared SymEntry(segments));
+              st.addEntry(v_name, new shared SymEntry(values));
 
-          const union_segs = (+ scan union_lens) - union_lens;
-          var union_vals = makeDistArray((+ reduce union_lens), uint);
+              repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
+              asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            when("setxor"){
+              var (segments, values) = setxor1d_multi(segments1, values1, lens1, segments2, values2, lens2, isUnique);
+              st.addEntry(s_name, new shared SymEntry(segments));
+              st.addEntry(v_name, new shared SymEntry(values));
 
-          // Compute the union and add values to the corresponding indexes in values
-          forall (i, s1, l1, s2, l2, us, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, union_segs, union_lens) with (var agg = newDstAggregator(uint)){
-            // TODO - update to use lowLevelLocalizingSlice 
-            var u = union1d(values1.a[s1..#l1], values2.a[s2..#l2]);
-            for i in (0..#ul){
-              agg.copy(union_vals[i+us], u[i]);
+              repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
+              asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            otherwise {
+              var errorMsg = notImplementedError("setops1d_multi", sub_command);
+              asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                   
+              return new MsgTuple(errorMsg, MsgType.ERROR);              
             }
           }
-
-          var s_name = st.nextName();
-          st.addEntry(s_name, new shared SymEntry(union_segs));
-          var v_name = st.nextName();
-          st.addEntry(v_name, new shared SymEntry(union_vals));
-
-          repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
-          asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-          return new MsgTuple(repMsg, MsgType.NORMAL);
         }
         otherwise {
-             var errorMsg = notImplementedError("union1d_multi",gEnt.dtype);
-             asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                   
-             return new MsgTuple(errorMsg, MsgType.ERROR);              
-         }
+          var errorMsg = notImplementedError("setops1d_multi", gEnt2.dtype);
+          asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                   
+          return new MsgTuple(errorMsg, MsgType.ERROR);              
+        }
       }
     }
 
@@ -813,12 +425,9 @@ module ArraySetopsMsg
     proc registerMe() {
       use CommandMap;
       registerFunction("intersect1d", intersect1dMsg, getModuleName());
-      registerFunction("intersect1d_multi", intersect1d_multiMsg, getModuleName());
       registerFunction("setdiff1d", setdiff1dMsg, getModuleName());
-      registerFunction("setdiff1d_multi", setdiff1d_multiMsg, getModuleName());
       registerFunction("setxor1d", setxor1dMsg, getModuleName());
-      registerFunction("setxor1d_multi", setxor1d_multiMsg, getModuleName());
       registerFunction("union1d", union1dMsg, getModuleName());
-      registerFunction("union1d_multi", union1d_multiMsg, getModuleName());
+      registerFunction("setops1d_multi", setops1d_multiMsg, getModuleName());
     }
 }

--- a/src/ArraySetopsMsg.chpl
+++ b/src/ArraySetopsMsg.chpl
@@ -153,7 +153,7 @@ module ArraySetopsMsg
           var intx_lens: [segments1.aD] int;
 
           // Compute lengths of the segments resulting from each union
-          forall (i, s1, l1, s2, l2, il) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_lens) with (var agg = newSrcAggregator(int)){
+          forall (i, s1, l1, s2, l2, il) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_lens) with (var agg = newDstAggregator(int)){
             // TODO - update to use lowLevelLocalizingSlice 
             var intx = intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
             agg.copy(il, intx.size);
@@ -163,7 +163,7 @@ module ArraySetopsMsg
           var intx_vals = makeDistArray((+ reduce intx_lens), int);
 
           // Compute the union and add values to the corresponding indexes in values
-          forall (i, s1, l1, s2, l2, is, il) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_segs, intx_lens) with (var agg = newSrcAggregator(int)){
+          forall (i, s1, l1, s2, l2, is, il) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_segs, intx_lens) with (var agg = newDstAggregator(int)){
             // TODO - update to use lowLevelLocalizingSlice 
             var intx = intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
             for i in (0..#il){
@@ -187,7 +187,7 @@ module ArraySetopsMsg
           var intx_lens: [segments1.aD] int;
 
           // Compute lengths of the segments resulting from each union
-          forall (i, s1, l1, s2, l2, il) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_lens) with (var agg = newSrcAggregator(int)){
+          forall (i, s1, l1, s2, l2, il) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_lens) with (var agg = newDstAggregator(int)){
             // TODO - update to use lowLevelLocalizingSlice 
             var intx = intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
             agg.copy(il, intx.size);
@@ -197,7 +197,7 @@ module ArraySetopsMsg
           var intx_vals = makeDistArray((+ reduce intx_lens), uint);
 
           // Compute the union and add values to the corresponding indexes in values
-          forall (i, s1, l1, s2, l2, is, il) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_segs, intx_lens) with (var agg = newSrcAggregator(uint)){
+          forall (i, s1, l1, s2, l2, is, il) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_segs, intx_lens) with (var agg = newDstAggregator(uint)){
             // TODO - update to use lowLevelLocalizingSlice 
             var intx = intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
             for i in (0..#il){
@@ -346,7 +346,7 @@ module ArraySetopsMsg
           var xor_lens: [segments1.aD] int;
 
           // Compute lengths of the segments resulting from each union
-          forall (i, s1, l1, s2, l2, xl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, xor_lens) with (var agg = newSrcAggregator(int)){
+          forall (i, s1, l1, s2, l2, xl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, xor_lens) with (var agg = newDstAggregator(int)){
             // TODO - update to use lowLevelLocalizingSlice 
             var xor = setxor1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
             agg.copy(xl, xor.size);
@@ -356,7 +356,7 @@ module ArraySetopsMsg
           var xor_vals = makeDistArray((+ reduce xor_lens), int);
 
           // Compute the union and add values to the corresponding indexes in values
-          forall (i, s1, l1, s2, l2, xs, xl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, xor_segs, xor_lens) with (var agg = newSrcAggregator(int)){
+          forall (i, s1, l1, s2, l2, xs, xl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, xor_segs, xor_lens) with (var agg = newDstAggregator(int)){
             // TODO - update to use lowLevelLocalizingSlice 
             var xor = setxor1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
             for i in (0..#xl){
@@ -380,7 +380,7 @@ module ArraySetopsMsg
           var xor_lens: [segments1.aD] int;
 
           // Compute lengths of the segments resulting from each union
-          forall (i, s1, l1, s2, l2, xl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, xor_lens) with (var agg = newSrcAggregator(int)){
+          forall (i, s1, l1, s2, l2, xl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, xor_lens) with (var agg = newDstAggregator(int)){
             // TODO - update to use lowLevelLocalizingSlice 
             var xor = setxor1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
             agg.copy(xl, xor.size);
@@ -390,7 +390,7 @@ module ArraySetopsMsg
           var xor_vals = makeDistArray((+ reduce xor_lens), uint);
 
           // Compute the union and add values to the corresponding indexes in values
-          forall (i, s1, l1, s2, l2, xs, xl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, xor_segs, xor_lens) with (var agg = newSrcAggregator(uint)){
+          forall (i, s1, l1, s2, l2, xs, xl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, xor_segs, xor_lens) with (var agg = newDstAggregator(uint)){
             // TODO - update to use lowLevelLocalizingSlice 
             var xor = setxor1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
             for i in (0..#xl){
@@ -539,7 +539,7 @@ module ArraySetopsMsg
           var diff_lens: [segments1.aD] int;
 
           // Compute lengths of the segments resulting from each union
-          forall (i, s1, l1, s2, l2, dl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, diff_lens) with (var agg = newSrcAggregator(int)){
+          forall (i, s1, l1, s2, l2, dl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, diff_lens) with (var agg = newDstAggregator(int)){
             // TODO - update to use lowLevelLocalizingSlice 
             var d = setdiff1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
             agg.copy(dl, d.size);
@@ -549,7 +549,7 @@ module ArraySetopsMsg
           var diff_vals = makeDistArray((+ reduce diff_lens), int);
 
           // Compute the union and add values to the corresponding indexes in values
-          forall (i, s1, l1, s2, l2, ds, dl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, diff_segs, diff_lens) with (var agg = newSrcAggregator(int)){
+          forall (i, s1, l1, s2, l2, ds, dl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, diff_segs, diff_lens) with (var agg = newDstAggregator(int)){
             // TODO - update to use lowLevelLocalizingSlice 
             var d = setdiff1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
             for i in (0..#dl){
@@ -573,7 +573,7 @@ module ArraySetopsMsg
           var diff_lens: [segments1.aD] int;
 
           // Compute lengths of the segments resulting from each union
-          forall (i, s1, l1, s2, l2, dl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, diff_lens) with (var agg = newSrcAggregator(int)){
+          forall (i, s1, l1, s2, l2, dl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, diff_lens) with (var agg = newDstAggregator(int)){
             // TODO - update to use lowLevelLocalizingSlice 
             var d = setdiff1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
             agg.copy(dl, d.size);
@@ -583,7 +583,7 @@ module ArraySetopsMsg
           var diff_vals = makeDistArray((+ reduce diff_lens), uint);
 
           // Compute the union and add values to the corresponding indexes in values
-          forall (i, s1, l1, s2, l2, ds, dl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, diff_segs, diff_lens) with (var agg = newSrcAggregator(uint)){
+          forall (i, s1, l1, s2, l2, ds, dl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, diff_segs, diff_lens) with (var agg = newDstAggregator(uint)){
             // TODO - update to use lowLevelLocalizingSlice 
             var d = setdiff1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
             for i in (0..#dl){
@@ -730,7 +730,7 @@ module ArraySetopsMsg
           var union_lens: [segments1.aD] int;
 
           // Compute lengths of the segments resulting from each union
-          forall (i, s1, l1, s2, l2, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, union_lens) with (var agg = newSrcAggregator(int)){
+          forall (i, s1, l1, s2, l2, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, union_lens) with (var agg = newDstAggregator(int)){
             // TODO - update to use lowLevelLocalizingSlice 
             var u = union1d(values1.a[s1..#l1], values2.a[s2..#l2]);
             agg.copy(ul, u.size);
@@ -740,7 +740,7 @@ module ArraySetopsMsg
           var union_vals = makeDistArray((+ reduce union_lens), int);
 
           // Compute the union and add values to the corresponding indexes in values
-          forall (i, s1, l1, s2, l2, us, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, union_segs, union_lens) with (var agg = newSrcAggregator(int)){
+          forall (i, s1, l1, s2, l2, us, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, union_segs, union_lens) with (var agg = newDstAggregator(int)){
             // TODO - update to use lowLevelLocalizingSlice 
             var u = union1d(values1.a[s1..#l1], values2.a[s2..#l2]);
             for i in (0..#ul){
@@ -764,7 +764,7 @@ module ArraySetopsMsg
           var union_lens: [segments1.aD] int;
 
           // Compute lengths of the segments resulting from each union
-          forall (i, s1, l1, s2, l2, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, union_lens) with (var agg = newSrcAggregator(int)){
+          forall (i, s1, l1, s2, l2, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, union_lens) with (var agg = newDstAggregator(int)){
             // TODO - update to use lowLevelLocalizingSlice 
             var u = union1d(values1.a[s1..#l1], values2.a[s2..#l2]);
             agg.copy(ul, u.size);
@@ -774,7 +774,7 @@ module ArraySetopsMsg
           var union_vals = makeDistArray((+ reduce union_lens), uint);
 
           // Compute the union and add values to the corresponding indexes in values
-          forall (i, s1, l1, s2, l2, us, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, union_segs, union_lens) with (var agg = newSrcAggregator(uint)){
+          forall (i, s1, l1, s2, l2, us, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, union_segs, union_lens) with (var agg = newDstAggregator(uint)){
             // TODO - update to use lowLevelLocalizingSlice 
             var u = union1d(values1.a[s1..#l1], values2.a[s2..#l2]);
             for i in (0..#ul){

--- a/src/ArraySetopsMsg.chpl
+++ b/src/ArraySetopsMsg.chpl
@@ -279,6 +279,143 @@ module ArraySetopsMsg
         }
     }
 
+    proc setxor1d_multiMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+      param pn = Reflection.getRoutineName();
+      var repMsg: string; // response message
+      // split request into fields
+      var (seg1_name, vals1_name, s1_str, seg2_name, vals2_name, s2_str, assume_unique) = payload.splitMsgToTuple(7);
+      var isUnique = stringtobool(assume_unique);
+
+      var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(seg1_name, st);
+      var gEnt2: borrowed GenSymEntry = getGenericTypedArrayEntry(vals1_name, st);
+      var gEnt3: borrowed GenSymEntry = getGenericTypedArrayEntry(seg2_name, st);
+      var gEnt4: borrowed GenSymEntry = getGenericTypedArrayEntry(vals2_name, st);
+
+      // verify that expected integer values can be cast
+      var size1: int;
+      var size2: int;
+      try{
+        size1 = s1_str: int;
+        size2 = s2_str: int;
+      }
+      catch {
+        var errorMsg = "Count could not be interpretted as an int1: %s, int2: %s)".format(s1_str, s2_str);
+        asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+        throw new owned IllegalArgumentError(errorMsg);
+      }
+
+      var segments1 = toSymEntry(gEnt,int);
+      var segments2 = toSymEntry(gEnt3,int);
+
+      // set segment lengths
+      var lens1: [segments1.aD] int;
+      var lens2: [segments2.aD] int;
+      var high = segments1.aD.high;
+      var low = segments1.aD.low;
+      var m1: int;
+      var m2: int;
+      for (i, s1, l1, s2, l2) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2){
+        if i == high {
+          l1 = size1 - s1;
+          l2 = size2 - s2;
+        }
+        else{
+          l1 = segments1.a[i+1] - s1;
+          l2 = segments2.a[i+1] - s2;
+        }
+        // Set the max segment length for memory check
+        if (i == low || m1 < l1) {
+          m1 = l1;
+        }
+        if (i == low || m2 < l2) {
+          m2 = l2;
+        }
+      }
+      
+      // perform memory exhaustion check using the size of the largest segment present
+      var itemsize = if gEnt2.dtype == DType.UInt64 then numBytes(uint) else numBytes(int);
+      var sortMem1 = radixSortLSD_memEst(m1, itemsize);
+      var sortMem2 = radixSortLSD_memEst(m2, itemsize);
+      var xor_maxMem = max(sortMem1, sortMem2);
+      overMemLimit(xor_maxMem);
+
+      select(gEnt2.dtype, gEnt4.dtype) {
+        when (DType.Int64, DType.Int64) {
+          var values1 = toSymEntry(gEnt2, int);
+          var values2 = toSymEntry(gEnt4, int);
+
+          var xor_lens: [segments1.aD] int;
+
+          // Compute lengths of the segments resulting from each union
+          forall (i, s1, l1, s2, l2, xl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, xor_lens) with (var agg = newSrcAggregator(int)){
+            // TODO - update to use lowLevelLocalizingSlice 
+            var xor = setxor1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+            agg.copy(xl, xor.size);
+          }
+
+          const xor_segs = (+ scan xor_lens) - xor_lens;
+          var xor_vals = makeDistArray((+ reduce xor_lens), int);
+
+          // Compute the union and add values to the corresponding indexes in values
+          forall (i, s1, l1, s2, l2, xs, xl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, xor_segs, xor_lens) with (var agg = newSrcAggregator(int)){
+            // TODO - update to use lowLevelLocalizingSlice 
+            var xor = setxor1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+            for i in (0..#xl){
+              agg.copy(xor_vals[i+xs], xor[i]);
+            }
+          }
+
+          var s_name = st.nextName();
+          st.addEntry(s_name, new shared SymEntry(xor_segs));
+          var v_name = st.nextName();
+          st.addEntry(v_name, new shared SymEntry(xor_vals));
+
+          repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
+          asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+          return new MsgTuple(repMsg, MsgType.NORMAL);
+        }
+        when (DType.UInt64, DType.UInt64) {
+          var values1 = toSymEntry(gEnt2, uint);
+          var values2 = toSymEntry(gEnt4, uint);
+
+          var xor_lens: [segments1.aD] int;
+
+          // Compute lengths of the segments resulting from each union
+          forall (i, s1, l1, s2, l2, xl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, xor_lens) with (var agg = newSrcAggregator(int)){
+            // TODO - update to use lowLevelLocalizingSlice 
+            var xor = setxor1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+            agg.copy(xl, xor.size);
+          }
+
+          const xor_segs = (+ scan xor_lens) - xor_lens;
+          var xor_vals = makeDistArray((+ reduce xor_lens), uint);
+
+          // Compute the union and add values to the corresponding indexes in values
+          forall (i, s1, l1, s2, l2, xs, xl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, xor_segs, xor_lens) with (var agg = newSrcAggregator(uint)){
+            // TODO - update to use lowLevelLocalizingSlice 
+            var xor = setxor1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+            for i in (0..#xl){
+              agg.copy(xor_vals[i+xs], xor[i]);
+            }
+          }
+
+          var s_name = st.nextName();
+          st.addEntry(s_name, new shared SymEntry(xor_segs));
+          var v_name = st.nextName();
+          st.addEntry(v_name, new shared SymEntry(xor_vals));
+
+          repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
+          asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+          return new MsgTuple(repMsg, MsgType.NORMAL);
+        }
+        otherwise {
+          var errorMsg = notImplementedError("setxor_multi",gEnt.dtype);
+          asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
+          return new MsgTuple(errorMsg, MsgType.ERROR);
+        }
+      }
+    }
+
     /*
     Parse, execute, and respond to a setdiff1d message
     :arg reqMsg: request containing (cmd,name,name2,assume_unique)
@@ -439,7 +576,7 @@ module ArraySetopsMsg
           // Compute lengths of the segments resulting from each union
           forall (i, s1, l1, s2, l2, dl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, diff_lens) with (var agg = newSrcAggregator(int)){
             // TODO - update to use lowLevelLocalizingSlice 
-            var d = intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+            var d = setdiff1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
             agg.copy(dl, d.size);
           }
 
@@ -465,7 +602,7 @@ module ArraySetopsMsg
           return new MsgTuple(repMsg, MsgType.NORMAL);
         }
         otherwise {
-          var errorMsg = notImplementedError("intersect1d_multi",gEnt.dtype);
+          var errorMsg = notImplementedError("setdiff1d_multi",gEnt.dtype);
           asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
           return new MsgTuple(errorMsg, MsgType.ERROR);
         }
@@ -656,7 +793,7 @@ module ArraySetopsMsg
           return new MsgTuple(repMsg, MsgType.NORMAL);
         }
         otherwise {
-             var errorMsg = notImplementedError("newUnion1d",gEnt.dtype);
+             var errorMsg = notImplementedError("union1d_multi",gEnt.dtype);
              asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                   
              return new MsgTuple(errorMsg, MsgType.ERROR);              
          }
@@ -681,6 +818,7 @@ module ArraySetopsMsg
       registerFunction("setdiff1d", setdiff1dMsg, getModuleName());
       registerFunction("setdiff1d_multi", setdiff1d_multiMsg, getModuleName());
       registerFunction("setxor1d", setxor1dMsg, getModuleName());
+      registerFunction("setxor1d_multi", setxor1d_multiMsg, getModuleName());
       registerFunction("union1d", union1dMsg, getModuleName());
       registerFunction("union1d_multi", union1d_multiMsg, getModuleName());
     }

--- a/src/ArraySetopsMsg.chpl
+++ b/src/ArraySetopsMsg.chpl
@@ -154,21 +154,21 @@ module ArraySetopsMsg
           var intx_lens: [segments1.aD] int;
 
           // Compute lengths of the segments resulting from each union
-          forall (i, s1, l1, s2, l2, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_lens) with (var agg = newSrcAggregator(int)){
+          forall (i, s1, l1, s2, l2, il) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_lens) with (var agg = newSrcAggregator(int)){
             // TODO - update to use lowLevelLocalizingSlice 
-            var u = intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
-            agg.copy(ul, u.size);
+            var intx = intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+            agg.copy(il, intx.size);
           }
 
           const intx_segs = (+ scan intx_lens) - intx_lens;
           var intx_vals = makeDistArray((+ reduce intx_lens), int);
 
           // Compute the union and add values to the corresponding indexes in values
-          forall (i, s1, l1, s2, l2, us, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_segs, intx_lens) with (var agg = newSrcAggregator(int)){
+          forall (i, s1, l1, s2, l2, is, il) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_segs, intx_lens) with (var agg = newSrcAggregator(int)){
             // TODO - update to use lowLevelLocalizingSlice 
             var intx = intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
-            for i in (0..#ul){
-              agg.copy(intx_vals[i+us], intx[i]);
+            for i in (0..#il){
+              agg.copy(intx_vals[i+is], intx[i]);
             }
           }
 
@@ -188,21 +188,21 @@ module ArraySetopsMsg
           var intx_lens: [segments1.aD] int;
 
           // Compute lengths of the segments resulting from each union
-          forall (i, s1, l1, s2, l2, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_lens) with (var agg = newSrcAggregator(int)){
+          forall (i, s1, l1, s2, l2, il) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_lens) with (var agg = newSrcAggregator(int)){
             // TODO - update to use lowLevelLocalizingSlice 
-            var u = intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
-            agg.copy(ul, u.size);
+            var intx = intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+            agg.copy(il, intx.size);
           }
 
           const intx_segs = (+ scan intx_lens) - intx_lens;
           var intx_vals = makeDistArray((+ reduce intx_lens), uint);
 
           // Compute the union and add values to the corresponding indexes in values
-          forall (i, s1, l1, s2, l2, us, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_segs, intx_lens) with (var agg = newSrcAggregator(uint)){
+          forall (i, s1, l1, s2, l2, is, il) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, intx_segs, intx_lens) with (var agg = newSrcAggregator(uint)){
             // TODO - update to use lowLevelLocalizingSlice 
             var intx = intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
-            for i in (0..#ul){
-              agg.copy(intx_vals[i+us], intx[i]);
+            for i in (0..#il){
+              agg.copy(intx_vals[i+is], intx[i]);
             }
           }
 
@@ -216,10 +216,10 @@ module ArraySetopsMsg
           return new MsgTuple(repMsg, MsgType.NORMAL);
         }
         otherwise {
-            var errorMsg = notImplementedError("intersect1d_multi",gEnt.dtype);
-            asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
-            return new MsgTuple(errorMsg, MsgType.ERROR);
-          }
+          var errorMsg = notImplementedError("intersect1d_multi",gEnt.dtype);
+          asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
+          return new MsgTuple(errorMsg, MsgType.ERROR);
+        }
       }
     }
 
@@ -333,6 +333,143 @@ module ArraySetopsMsg
                return new MsgTuple(errorMsg, MsgType.ERROR);           
            }
         }
+    }
+
+    proc setdiff1d_multiMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+      param pn = Reflection.getRoutineName();
+      var repMsg: string; // response message
+      // split request into fields
+      var (seg1_name, vals1_name, s1_str, seg2_name, vals2_name, s2_str, assume_unique) = payload.splitMsgToTuple(7);
+      var isUnique = stringtobool(assume_unique);
+
+      var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(seg1_name, st);
+      var gEnt2: borrowed GenSymEntry = getGenericTypedArrayEntry(vals1_name, st);
+      var gEnt3: borrowed GenSymEntry = getGenericTypedArrayEntry(seg2_name, st);
+      var gEnt4: borrowed GenSymEntry = getGenericTypedArrayEntry(vals2_name, st);
+
+      // verify that expected integer values can be cast
+      var size1: int;
+      var size2: int;
+      try{
+        size1 = s1_str: int;
+        size2 = s2_str: int;
+      }
+      catch {
+        var errorMsg = "Count could not be interpretted as an int1: %s, int2: %s)".format(s1_str, s2_str);
+        asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+        throw new owned IllegalArgumentError(errorMsg);
+      }
+
+      var segments1 = toSymEntry(gEnt,int);
+      var segments2 = toSymEntry(gEnt3,int);
+
+      // set segment lengths
+      var lens1: [segments1.aD] int;
+      var lens2: [segments2.aD] int;
+      var high = segments1.aD.high;
+      var low = segments1.aD.low;
+      var m1: int;
+      var m2: int;
+      for (i, s1, l1, s2, l2) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2){
+        if i == high {
+          l1 = size1 - s1;
+          l2 = size2 - s2;
+        }
+        else{
+          l1 = segments1.a[i+1] - s1;
+          l2 = segments2.a[i+1] - s2;
+        }
+        // Set the max segment length for memory check
+        if (i == low || m1 < l1) {
+          m1 = l1;
+        }
+        if (i == low || m2 < l2) {
+          m2 = l2;
+        }
+      }
+      
+      // perform memory exhaustion check using the size of the largest segment present
+      var itemsize = if gEnt2.dtype == DType.UInt64 then numBytes(uint) else numBytes(int);
+      var sortMem1 = radixSortLSD_memEst(m1, itemsize);
+      var sortMem2 = radixSortLSD_memEst(m2, itemsize);
+      var diff_maxMem = max(sortMem1, sortMem2);
+      overMemLimit(diff_maxMem);
+
+      select(gEnt2.dtype, gEnt4.dtype) {
+        when (DType.Int64, DType.Int64) {
+          var values1 = toSymEntry(gEnt2, int);
+          var values2 = toSymEntry(gEnt4, int);
+
+          var diff_lens: [segments1.aD] int;
+
+          // Compute lengths of the segments resulting from each union
+          forall (i, s1, l1, s2, l2, dl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, diff_lens) with (var agg = newSrcAggregator(int)){
+            // TODO - update to use lowLevelLocalizingSlice 
+            var d = setdiff1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+            agg.copy(dl, d.size);
+          }
+
+          const diff_segs = (+ scan diff_lens) - diff_lens;
+          var diff_vals = makeDistArray((+ reduce diff_lens), int);
+
+          // Compute the union and add values to the corresponding indexes in values
+          forall (i, s1, l1, s2, l2, ds, dl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, diff_segs, diff_lens) with (var agg = newSrcAggregator(int)){
+            // TODO - update to use lowLevelLocalizingSlice 
+            var d = setdiff1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+            for i in (0..#dl){
+              agg.copy(diff_vals[i+ds], d[i]);
+            }
+          }
+
+          var s_name = st.nextName();
+          st.addEntry(s_name, new shared SymEntry(diff_segs));
+          var v_name = st.nextName();
+          st.addEntry(v_name, new shared SymEntry(diff_vals));
+
+          repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
+          asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+          return new MsgTuple(repMsg, MsgType.NORMAL);
+        }
+        when (DType.UInt64, DType.UInt64) {
+          var values1 = toSymEntry(gEnt2, uint);
+          var values2 = toSymEntry(gEnt4, uint);
+
+          var diff_lens: [segments1.aD] int;
+
+          // Compute lengths of the segments resulting from each union
+          forall (i, s1, l1, s2, l2, dl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, diff_lens) with (var agg = newSrcAggregator(int)){
+            // TODO - update to use lowLevelLocalizingSlice 
+            var d = intersect1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+            agg.copy(dl, d.size);
+          }
+
+          const diff_segs = (+ scan diff_lens) - diff_lens;
+          var diff_vals = makeDistArray((+ reduce diff_lens), uint);
+
+          // Compute the union and add values to the corresponding indexes in values
+          forall (i, s1, l1, s2, l2, ds, dl) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, diff_segs, diff_lens) with (var agg = newSrcAggregator(uint)){
+            // TODO - update to use lowLevelLocalizingSlice 
+            var d = setdiff1d(values1.a[s1..#l1], values2.a[s2..#l2], isUnique);
+            for i in (0..#dl){
+              agg.copy(diff_vals[i+ds], d[i]);
+            }
+          }
+
+          var s_name = st.nextName();
+          st.addEntry(s_name, new shared SymEntry(diff_segs));
+          var v_name = st.nextName();
+          st.addEntry(v_name, new shared SymEntry(diff_vals));
+
+          repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
+          asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+          return new MsgTuple(repMsg, MsgType.NORMAL);
+        }
+        otherwise {
+          var errorMsg = notImplementedError("intersect1d_multi",gEnt.dtype);
+          asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
+          return new MsgTuple(errorMsg, MsgType.ERROR);
+        }
+      }
     }
 
     /*
@@ -542,6 +679,7 @@ module ArraySetopsMsg
       registerFunction("intersect1d", intersect1dMsg, getModuleName());
       registerFunction("intersect1d_multi", intersect1d_multiMsg, getModuleName());
       registerFunction("setdiff1d", setdiff1dMsg, getModuleName());
+      registerFunction("setdiff1d_multi", setdiff1d_multiMsg, getModuleName());
       registerFunction("setxor1d", setxor1dMsg, getModuleName());
       registerFunction("union1d", union1dMsg, getModuleName());
       registerFunction("union1d_multi", union1d_multiMsg, getModuleName());

--- a/src/ArraySetopsMsg.chpl
+++ b/src/ArraySetopsMsg.chpl
@@ -18,12 +18,14 @@ module ArraySetopsMsg
     use ServerErrorStrings;
 
     use ArraySetops;
+    use Unique;
     use Indexing;
     use RadixSortLSD;
     use Reflection;
     use ServerErrors;
     use Logging;
     use Message;
+    use CommAggregation;
 
     private config const logLevel = ServerConfig.logLevel;
     const asLogger = new Logger(logLevel);
@@ -251,6 +253,142 @@ module ArraySetopsMsg
       }
     }
 
+    proc union1d_multiMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+      param pn = Reflection.getRoutineName();
+      var repMsg: string; // response message
+        // split request into fields
+      var (seg1_name, vals1_name, s1_str, seg2_name, vals2_name, s2_str) = payload.splitMsgToTuple(6);
+
+      var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(seg1_name, st);
+      var gEnt2: borrowed GenSymEntry = getGenericTypedArrayEntry(vals1_name, st);
+      var gEnt3: borrowed GenSymEntry = getGenericTypedArrayEntry(seg2_name, st);
+      var gEnt4: borrowed GenSymEntry = getGenericTypedArrayEntry(vals2_name, st);
+
+      // verify that expected integer values can be cast
+      var size1: int;
+      var size2: int;
+      try{
+        size1 = s1_str: int;
+        size2 = s2_str: int;
+      }
+      catch {
+        var errorMsg = "Count could not be interpretted as an int1: %s, int2: %s)".format(s1_str, s2_str);
+        asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+        throw new owned IllegalArgumentError(errorMsg);
+      }
+
+      var segments1 = toSymEntry(gEnt,int);
+      var segments2 = toSymEntry(gEnt3,int);
+
+      // set segment lengths
+      var lens1: [segments1.aD] int;
+      var lens2: [segments2.aD] int;
+      var high = segments1.aD.high;
+      var low = segments1.aD.low;
+      var m1: int;
+      var m2: int;
+      for (i, s1, l1, s2, l2) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2){
+        if i == high {
+          l1 = size1 - s1;
+          l2 = size2 - s2;
+        }
+        else{
+          l1 = segments1.a[i+1] - s1;
+          l2 = segments2.a[i+1] - s2;
+        }
+        // Set the max segment length for memory check
+        if (i == low || m1 < l1) {
+          m1 = l1;
+        }
+        if (i == low || m2 < l2) {
+          m2 = l2;
+        }
+      }
+      
+      // perform memory exhaustion check using the size of the largest segment present
+      var itemsize = if gEnt2.dtype == DType.UInt64 then numBytes(uint) else numBytes(int);
+      var sortMem1 = radixSortLSD_memEst(m1, itemsize);
+      var sortMem2 = radixSortLSD_memEst(m2, itemsize);
+      var union_maxMem = max(sortMem1, sortMem2);
+      overMemLimit(union_maxMem);
+
+      select(gEnt2.dtype, gEnt4.dtype) {
+        when (DType.Int64, DType.Int64) {
+          var values1 = toSymEntry(gEnt2, int);
+          var values2 = toSymEntry(gEnt4, int);
+
+          var union_lens: [segments1.aD] int;
+
+          // Compute lengths of the segments resulting from each union
+          forall (i, s1, l1, s2, l2, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, union_lens) with (var agg = newSrcAggregator(int)){
+            // TODO - update to use lowLevelLocalizingSlice 
+            var u = union1d(values1.a[s1..#l1], values2.a[s2..#l2]);
+            agg.copy(ul, u.size);
+          }
+
+          const union_segs = (+ scan union_lens) - union_lens;
+          var union_vals = makeDistArray((+ reduce union_lens), int);
+
+          // Compute the union and add values to the corresponding indexes in values
+          forall (i, s1, l1, s2, l2, us, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, union_segs, union_lens) with (var agg = newSrcAggregator(int)){
+            // TODO - update to use lowLevelLocalizingSlice 
+            var u = union1d(values1.a[s1..#l1], values2.a[s2..#l2]);
+            for i in (0..#ul){
+              agg.copy(union_vals[i+us], u[i]);
+            }
+          }
+
+          var s_name = st.nextName();
+          st.addEntry(s_name, new shared SymEntry(union_segs));
+          var v_name = st.nextName();
+          st.addEntry(v_name, new shared SymEntry(union_vals));
+
+          repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
+          asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+          return new MsgTuple(repMsg, MsgType.NORMAL);
+        }
+        when (DType.UInt64, DType.UInt64) {
+          var values1 = toSymEntry(gEnt2, uint);
+          var values2 = toSymEntry(gEnt4, uint);
+
+          var union_lens: [segments1.aD] int;
+
+          // Compute lengths of the segments resulting from each union
+          forall (i, s1, l1, s2, l2, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, union_lens) with (var agg = newSrcAggregator(int)){
+            // TODO - update to use lowLevelLocalizingSlice 
+            var u = union1d(values1.a[s1..#l1], values2.a[s2..#l2]);
+            agg.copy(ul, u.size);
+          }
+
+          const union_segs = (+ scan union_lens) - union_lens;
+          var union_vals = makeDistArray((+ reduce union_lens), uint);
+
+          // Compute the union and add values to the corresponding indexes in values
+          forall (i, s1, l1, s2, l2, us, ul) in zip(segments1.aD, segments1.a, lens1, segments2.a, lens2, union_segs, union_lens) with (var agg = newSrcAggregator(uint)){
+            // TODO - update to use lowLevelLocalizingSlice 
+            var u = union1d(values1.a[s1..#l1], values2.a[s2..#l2]);
+            for i in (0..#ul){
+              agg.copy(union_vals[i+us], u[i]);
+            }
+          }
+
+          var s_name = st.nextName();
+          st.addEntry(s_name, new shared SymEntry(union_segs));
+          var v_name = st.nextName();
+          st.addEntry(v_name, new shared SymEntry(union_vals));
+
+          repMsg = "created " + st.attrib(s_name) + "+created " + st.attrib(v_name);
+          asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+          return new MsgTuple(repMsg, MsgType.NORMAL);
+        }
+        otherwise {
+             var errorMsg = notImplementedError("newUnion1d",gEnt.dtype);
+             asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                   
+             return new MsgTuple(errorMsg, MsgType.ERROR);              
+         }
+      }
+    }
+
     proc stringtobool(str: string): bool throws {
         if str == "True" then return true;
         else if str == "False" then return false;
@@ -268,5 +406,6 @@ module ArraySetopsMsg
       registerFunction("setdiff1d", setdiff1dMsg, getModuleName());
       registerFunction("setxor1d", setxor1dMsg, getModuleName());
       registerFunction("union1d", union1dMsg, getModuleName());
+      registerFunction("union1d_multi", union1d_multiMsg, getModuleName());
     }
 }

--- a/src/ArraySetopsMsg.chpl
+++ b/src/ArraySetopsMsg.chpl
@@ -105,7 +105,7 @@ module ArraySetopsMsg
         size2 = s2_str: int;
       }
       catch {
-        var errorMsg = "Count could not be interpretted as an int1: %s, int2: %s)".format(s1_str, s2_str);
+        var errorMsg = "Count could not be interpreted as an int1: %s, int2: %s)".format(s1_str, s2_str);
         asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
         throw new owned IllegalArgumentError(errorMsg);
       }
@@ -298,7 +298,7 @@ module ArraySetopsMsg
         size2 = s2_str: int;
       }
       catch {
-        var errorMsg = "Count could not be interpretted as an int1: %s, int2: %s)".format(s1_str, s2_str);
+        var errorMsg = "Count could not be interpreted as an int1: %s, int2: %s)".format(s1_str, s2_str);
         asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
         throw new owned IllegalArgumentError(errorMsg);
       }
@@ -682,7 +682,7 @@ module ArraySetopsMsg
         size2 = s2_str: int;
       }
       catch {
-        var errorMsg = "Count could not be interpretted as an int1: %s, int2: %s)".format(s1_str, s2_str);
+        var errorMsg = "Count could not be interpreted as an int1: %s, int2: %s)".format(s1_str, s2_str);
         asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
         throw new owned IllegalArgumentError(errorMsg);
       }

--- a/src/ArraySetopsMsg.chpl
+++ b/src/ArraySetopsMsg.chpl
@@ -491,7 +491,7 @@ module ArraySetopsMsg
         size2 = s2_str: int;
       }
       catch {
-        var errorMsg = "Count could not be interpretted as an int1: %s, int2: %s)".format(s1_str, s2_str);
+        var errorMsg = "Count could not be interpreted as an int1: %s, int2: %s)".format(s1_str, s2_str);
         asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
         throw new owned IllegalArgumentError(errorMsg);
       }

--- a/src/Unique.chpl
+++ b/src/Unique.chpl
@@ -477,7 +477,7 @@ module Unique
     
     proc uniqueFromSorted(sorted: [?aD] ?eltType, param needCounts = true) throws {
         var truth: [aD] bool;
-        truth[0] = true;
+        truth[aD.low] = true;
         [(t, s, i) in zip(truth, sorted, aD)] if i > aD.low { t = (sorted[i-1] != s); }
         var allUnique: int = + reduce truth;
         if (allUnique == aD.size) {

--- a/tests/setops_test.py
+++ b/tests/setops_test.py
@@ -107,7 +107,18 @@ class SetOpsTest(ArkoudaTest):
         with self.assertRaises(RuntimeError) as cm:
             ak.setdiff1d(ak.array([True, False, True]), ak.array([True, True]))
         with self.assertRaises(TypeError):
-            ak.setdiff1d([-1, 0, 1], [-2, 0, 2])     
+            ak.setdiff1d([-1, 0, 1], [-2, 0, 2])
+
+    def testSetdiff1d_multi(self):
+        a = [0, 1, 2]
+        b = [3, 4, 5]
+        c = [1]
+        d = [3, 4]
+
+        segs, vals = ak.setdiff1d((ak.array([0, len(a)]), ak.array(a + b)),
+                                    (ak.array([0, len(c)]), ak.array(c + d)))
+        print(segs)
+        print(vals)
         
     def testIntersectId(self):
         pdaOne = ak.array([1, 3, 4, 3])

--- a/tests/setops_test.py
+++ b/tests/setops_test.py
@@ -92,7 +92,30 @@ class SetOpsTest(ArkoudaTest):
         with self.assertRaises(RuntimeError) as cm:
             ak.setxor1d(ak.array([True, False, True]), ak.array([True, True]))
         with self.assertRaises(TypeError):
-            ak.setxor1d([-1, 0, 1], [-2, 0, 2])     
+            ak.setxor1d([-1, 0, 1], [-2, 0, 2])
+
+    def testSetxor1d_multi(self):
+        a = [1, 2, 3, 2, 4]
+        b = [1, 3, 6]
+        c = [2, 3, 5, 7, 5]
+        d = [6, 9]
+
+        segs, vals = ak.setxor1d((ak.array([0, len(a)]), ak.array(a + b)),
+                                  (ak.array([0, len(c)]), ak.array(c + d)))
+        self.assertIsInstance(segs, ak.pdarray)
+        self.assertIsInstance(vals, ak.pdarray)
+
+        self.assertListEqual(segs.to_ndarray().tolist(), [0, 4])
+        self.assertListEqual(vals.to_ndarray().tolist(), [1, 4, 5, 7, 1, 3, 9])
+
+        segs, vals = ak.setxor1d((ak.array([0, len(a)]), ak.array(a + b, dtype=ak.int64)),
+                                  (ak.array([0, len(c)]), ak.array(c + d, dtype=ak.int64)))
+        self.assertIsInstance(segs, ak.pdarray)
+        self.assertIsInstance(vals, ak.pdarray)
+
+        self.assertListEqual(segs.to_ndarray().tolist(), [0, 4])
+        self.assertListEqual(vals.to_ndarray().tolist(), [1, 4, 5, 7, 1, 3, 9])
+
         
     def testSetdiff1d(self):
         pdaOne = ak.array([1, 2, 3, 2, 4, 1])
@@ -117,8 +140,20 @@ class SetOpsTest(ArkoudaTest):
 
         segs, vals = ak.setdiff1d((ak.array([0, len(a)]), ak.array(a + b)),
                                     (ak.array([0, len(c)]), ak.array(c + d)))
-        print(segs)
-        print(vals)
+        self.assertIsInstance(segs, ak.pdarray)
+        self.assertIsInstance(vals, ak.pdarray)
+
+        self.assertListEqual(segs.to_ndarray().tolist(), [0, 2])
+        self.assertListEqual(vals.to_ndarray().tolist(), [0, 2, 5])
+
+        segs, vals = ak.setdiff1d((ak.array([0, len(a)]), ak.array(a + b, dtype=ak.int64)),
+                                    (ak.array([0, len(c)]), ak.array(c + d, dtype=ak.int64)))
+        self.assertIsInstance(segs, ak.pdarray)
+        self.assertIsInstance(vals, ak.pdarray)
+
+        self.assertListEqual(segs.to_ndarray().tolist(), [0, 2])
+        self.assertListEqual(vals.to_ndarray().tolist(), [0, 2, 5])
+
         
     def testIntersectId(self):
         pdaOne = ak.array([1, 3, 4, 3])

--- a/tests/setops_test.py
+++ b/tests/setops_test.py
@@ -135,7 +135,27 @@ class SetOpsTest(ArkoudaTest):
         with self.assertRaises(RuntimeError) as cm:
             ak.union1d(ak.array([True, True, True]), ak.array([True,False,True]))
         with self.assertRaises(TypeError):
-            ak.union1d([-1, 0, 1], [-2, 0, 2])     
+            ak.union1d([-1, 0, 1], [-2, 0, 2])
+
+    def testUnion1d_multi(self):
+        a = [0, 1, 2]
+        b = [3, 4]
+        c = [5]
+        d = [6, 7, 8]
+
+        segs, vals = ak.union1d((ak.array([0, len(a)]), ak.array(a + b)), (ak.array([0, len(c)]), ak.array(c + d)))
+        self.assertIsInstance(segs, ak.pdarray)
+        self.assertIsInstance(vals, ak.pdarray)
+
+        self.assertListEqual(segs.to_ndarray().tolist(), [0, 4])
+        self.assertListEqual(vals.to_ndarray().tolist(), [0, 1, 2, 5, 3, 4, 6, 7, 8])
+
+        segs, vals = ak.union1d((ak.array([0, len(a)]), ak.array(a + b, dtype=ak.int64)), (ak.array([0, len(c)]), ak.array(c + d, dtype=ak.int64)))
+        self.assertIsInstance(segs, ak.pdarray)
+        self.assertIsInstance(vals, ak.pdarray)
+
+        self.assertListEqual(segs.to_ndarray().tolist(), [0, 4])
+        self.assertListEqual(vals.to_ndarray().tolist(), [0, 1, 2, 5, 3, 4, 6, 7, 8])
 
     def testIn1d(self): 
         pdaOne = ak.array([-1, 0, 1, 3])

--- a/tests/setops_test.py
+++ b/tests/setops_test.py
@@ -108,8 +108,8 @@ class SetOpsTest(ArkoudaTest):
         self.assertListEqual(segs.to_ndarray().tolist(), [0, 4])
         self.assertListEqual(vals.to_ndarray().tolist(), [1, 4, 5, 7, 1, 3, 9])
 
-        segs, vals = ak.setxor1d((ak.array([0, len(a)]), ak.array(a + b, dtype=ak.int64)),
-                                  (ak.array([0, len(c)]), ak.array(c + d, dtype=ak.int64)))
+        segs, vals = ak.setxor1d((ak.array([0, len(a)]), ak.array(a + b, dtype=ak.uint64)),
+                                  (ak.array([0, len(c)]), ak.array(c + d, dtype=ak.uint64)))
         self.assertIsInstance(segs, ak.pdarray)
         self.assertIsInstance(vals, ak.pdarray)
 
@@ -153,8 +153,8 @@ class SetOpsTest(ArkoudaTest):
         self.assertListEqual(segs.to_ndarray().tolist(), [0, 2])
         self.assertListEqual(vals.to_ndarray().tolist(), [0, 2, 5])
 
-        segs, vals = ak.setdiff1d((ak.array([0, len(a)]), ak.array(a + b, dtype=ak.int64)),
-                                    (ak.array([0, len(c)]), ak.array(c + d, dtype=ak.int64)))
+        segs, vals = ak.setdiff1d((ak.array([0, len(a)]), ak.array(a + b, dtype=ak.uint64)),
+                                    (ak.array([0, len(c)]), ak.array(c + d, dtype=ak.uint64)))
         self.assertIsInstance(segs, ak.pdarray)
         self.assertIsInstance(vals, ak.pdarray)
 
@@ -197,8 +197,8 @@ class SetOpsTest(ArkoudaTest):
         self.assertListEqual(segs.to_ndarray().tolist(), [0, 1])
         self.assertListEqual(vals.to_ndarray().tolist(), [1, 3, 4])
 
-        segs, vals = ak.intersect1d((ak.array([0, len(a)]), ak.array(a + b, dtype=ak.int64)),
-                                (ak.array([0, len(c)]), ak.array(c + d, dtype=ak.int64)))
+        segs, vals = ak.intersect1d((ak.array([0, len(a)]), ak.array(a + b, dtype=ak.uint64)),
+                                (ak.array([0, len(c)]), ak.array(c + d, dtype=ak.uint64)))
         self.assertIsInstance(segs, ak.pdarray)
         self.assertIsInstance(vals, ak.pdarray)
 
@@ -239,8 +239,8 @@ class SetOpsTest(ArkoudaTest):
         self.assertListEqual(segs.to_ndarray().tolist(), [0, 4])
         self.assertListEqual(vals.to_ndarray().tolist(), [0, 1, 2, 5, 3, 4, 6, 7, 8])
 
-        segs, vals = ak.union1d((ak.array([0, len(a)]), ak.array(a + b, dtype=ak.int64)),
-                                (ak.array([0, len(c)]), ak.array(c + d, dtype=ak.int64)))
+        segs, vals = ak.union1d((ak.array([0, len(a)]), ak.array(a + b, dtype=ak.uint64)),
+                                (ak.array([0, len(c)]), ak.array(c + d, dtype=ak.uint64)))
         self.assertIsInstance(segs, ak.pdarray)
         self.assertIsInstance(vals, ak.pdarray)
 

--- a/tests/setops_test.py
+++ b/tests/setops_test.py
@@ -116,6 +116,13 @@ class SetOpsTest(ArkoudaTest):
         self.assertListEqual(segs.to_ndarray().tolist(), [0, 4])
         self.assertListEqual(vals.to_ndarray().tolist(), [1, 4, 5, 7, 1, 3, 9])
 
+        a = [0, 1, 2]
+        b = [3, 4, 5]
+        c = [0, 1]
+        with self.assertRaises(ValueError):
+            segs, vals = ak.setxor1d((ak.array([0, len(a)]), ak.array(a + b)),
+                                     (ak.array([0]), ak.array(c)))
+
         
     def testSetdiff1d(self):
         pdaOne = ak.array([1, 2, 3, 2, 4, 1])
@@ -154,6 +161,13 @@ class SetOpsTest(ArkoudaTest):
         self.assertListEqual(segs.to_ndarray().tolist(), [0, 2])
         self.assertListEqual(vals.to_ndarray().tolist(), [0, 2, 5])
 
+        a = [0, 1, 2]
+        b = [3, 4, 5]
+        c = [0, 1]
+        with self.assertRaises(ValueError):
+            segs, vals = ak.setxor1d((ak.array([0, len(a)]), ak.array(a + b)),
+                                     (ak.array([0]), ak.array(c)))
+
         
     def testIntersectId(self):
         pdaOne = ak.array([1, 3, 4, 3])
@@ -190,6 +204,13 @@ class SetOpsTest(ArkoudaTest):
 
         self.assertListEqual(segs.to_ndarray().tolist(), [0, 1])
         self.assertListEqual(vals.to_ndarray().tolist(), [1, 3, 4])
+
+        a = [0, 1, 2]
+        b = [3, 4, 5]
+        c = [0, 1]
+        with self.assertRaises(ValueError):
+            segs, vals = ak.setxor1d((ak.array([0, len(a)]), ak.array(a + b)),
+                                     (ak.array([0]), ak.array(c)))
         
     def testUnion1d(self):
         pdaOne = ak.array([-1, 0, 1])
@@ -225,6 +246,13 @@ class SetOpsTest(ArkoudaTest):
 
         self.assertListEqual(segs.to_ndarray().tolist(), [0, 4])
         self.assertListEqual(vals.to_ndarray().tolist(), [0, 1, 2, 5, 3, 4, 6, 7, 8])
+
+        a = [0, 1, 2]
+        b = [3, 4, 5]
+        c = [0, 1]
+        with self.assertRaises(ValueError):
+            segs, vals = ak.setxor1d((ak.array([0, len(a)]), ak.array(a + b)),
+                                     (ak.array([0]), ak.array(c)))
 
     def testIn1d(self): 
         pdaOne = ak.array([-1, 0, 1, 3])

--- a/tests/setops_test.py
+++ b/tests/setops_test.py
@@ -121,7 +121,29 @@ class SetOpsTest(ArkoudaTest):
         with self.assertRaises(RuntimeError) as cm:
             ak.intersect1d(ak.array([True, False, True]), ak.array([True, True]))
         with self.assertRaises(TypeError):
-            ak.intersect1d([-1, 0, 1], [-2, 0, 2])     
+            ak.intersect1d([-1, 0, 1], [-2, 0, 2])
+
+    def testIntersect1d_multi(self):
+        a = [0, 1, 2]
+        b = [3, 4]
+        c = [1]
+        d = [3, 4, 5]
+
+        segs, vals = ak.intersect1d((ak.array([0, len(a)]), ak.array(a + b)),
+                                    (ak.array([0, len(c)]), ak.array(c + d)))
+        self.assertIsInstance(segs, ak.pdarray)
+        self.assertIsInstance(vals, ak.pdarray)
+
+        self.assertListEqual(segs.to_ndarray().tolist(), [0, 1])
+        self.assertListEqual(vals.to_ndarray().tolist(), [1, 3, 4])
+
+        segs, vals = ak.intersect1d((ak.array([0, len(a)]), ak.array(a + b, dtype=ak.int64)),
+                                (ak.array([0, len(c)]), ak.array(c + d, dtype=ak.int64)))
+        self.assertIsInstance(segs, ak.pdarray)
+        self.assertIsInstance(vals, ak.pdarray)
+
+        self.assertListEqual(segs.to_ndarray().tolist(), [0, 1])
+        self.assertListEqual(vals.to_ndarray().tolist(), [1, 3, 4])
         
     def testUnion1d(self):
         pdaOne = ak.array([-1, 0, 1])
@@ -150,7 +172,8 @@ class SetOpsTest(ArkoudaTest):
         self.assertListEqual(segs.to_ndarray().tolist(), [0, 4])
         self.assertListEqual(vals.to_ndarray().tolist(), [0, 1, 2, 5, 3, 4, 6, 7, 8])
 
-        segs, vals = ak.union1d((ak.array([0, len(a)]), ak.array(a + b, dtype=ak.int64)), (ak.array([0, len(c)]), ak.array(c + d, dtype=ak.int64)))
+        segs, vals = ak.union1d((ak.array([0, len(a)]), ak.array(a + b, dtype=ak.int64)),
+                                (ak.array([0, len(c)]), ak.array(c + d, dtype=ak.int64)))
         self.assertIsInstance(segs, ak.pdarray)
         self.assertIsInstance(vals, ak.pdarray)
 


### PR DESCRIPTION
This PR (closes #1218):

In order to support set operations for `SegArray` objects efficiently, the set operations for `pdarray` have been updated to support computation on multiple 'flattened' arrays.  The set operations supported are:
- union
- interset
- difference
- symmetric difference

The functionality has been added to the 1d set operations for `pdarray`. The client side code has been updated to detect if the call is being made on 2 `pdarray` objects or 2 iterables (tuple/list) of `pdarray` objects. The iterables should have to objects within: a segments/offsets pdarray and a values pdarray. 

```python
# example of iterables accepted by set operation 1d functions
(segements, values)
# OR
[segments, values]
```

Messages have been added to the server to process the multiple array case.
- `union1d_multi`
- `intersect1d_multi`
- `setdiff1d_multi`
- `setxor1d_multi`
These new processing messages parse out the request message and separate the segments so each can be processed. @pierce314159 mentioned it may be more efficient to utilize `lowLevelLocalizingSlice()`, but this requires other existing utilized functionality to be updated to utilize pointers instead of the pdarray. I included `TODO` tags where this would be utilized if we would like to do it in the future.

In order to configure union1d to function properly, `uniqueFromSorted()` needed to be updated to set the initial truth value at the lowest index on the domain passed instead of always using 0. 

Testing has been added on the client to validate int64 and uint64 functionality as well as error handling.

```python
# Example of flattening multiple arrays
a = [0, 1, 2]
b = [3, 4, 5]
c = [6, 7, 8]
d = [9, 10, 11]
m1_segs = ak.array([0, len(a)])
m1_vals = ak.array(a+b)
m2_segs = ak.array([0, len(c)])
m2_vals = ak.array(c+d)

# Example of union to see how values passed/ returned. Return is always tuple
# Can be passed as tuple
(segments, values) = ak.union1d((m1_segs, m1_vals), (m2_segs, m2_vals))
# OR list
(segments, values) = ak.union1d([m1_segs, m1_vals], [m2_segs, m2_vals])

segments
array([0, 6])

values
array([0, 1, 2, 6, 7, 8, 3, 4, 5, 9, 10, 11])

# Return equates to the arrays
[0, 1, 2, 6, 7, 8]
[3, 4, 5, 9, 10, 11]
```

This PR is required for updates requested in PR #1213. 