### PR TITLE
Add append mode for Parquet file writing

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1144,17 +1144,19 @@ class pdarray:
         >>> (a == b).all()
         True
         """
-        if mode.lower() in 'truncate':
+        if mode.lower() in 'append':
+            m = 1
+        elif mode.lower() in 'truncate':
             m = 0
-        else: # TODO: add support for the append mode
-            raise ValueError("Currently only the 'truncate' mode is supported")
+        else:
+            raise ValueError("Allowed modes are 'truncate' and 'append'")
         
         try:
             json_array = json.dumps([prefix_path])
         except Exception as e:
             raise ValueError(e)
-        return cast(str, generic_msg(cmd="writeParquet", args="{} {} {} {} {}".\
-                                     format(self.name, dataset, json_array, self.dtype,
+        return cast(str, generic_msg(cmd="writeParquet", args="{} {} {} {} {} {}".\
+                                     format(self.name, dataset, m, json_array, self.dtype,
                                             compressed)))
     
     @typechecked

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1421,7 +1421,7 @@ class Strings:
         if mode.lower() in 'truncate':
             m = 0
         else:
-            raise ValueError("Allowed modes are 'truncate'")
+            raise ValueError("Allowed modes are 'truncate', append not yet supported on strings")
 
         try:
             json_array = json.dumps([prefix_path])
@@ -1429,7 +1429,7 @@ class Strings:
             raise ValueError(e)
 
         cmd = "writeParquet"
-        args = f"{self.entry.name} {dataset} {json_array} str {compressed}"
+        args = f"{self.entry.name} {dataset} {m} {json_array} str {compressed}"
         return cast(str, generic_msg(cmd, args))
         
     def is_registered(self) -> np.bool_:

--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -67,6 +67,15 @@ extern "C" {
                                bool compressed, char** errMsg);
   int cpp_createEmptyParquetFile(const char* filename, const char* dsetname, int64_t dtype,
                                  bool compressed, char** errMsg);
+  
+  int c_appendColumnToParquet(const char* filename, void* chpl_arr,
+                              const char* dsetname, int64_t numelems,
+                              int64_t dtype, bool compressed,
+                              char** errMsg);
+  int cpp_appendColumnToParquet(const char* filename, void* chpl_arr,
+                                const char* dsetname, int64_t numelems,
+                                int64_t dtype, bool compressed,
+                                char** errMsg);
     
   const char* c_getVersionInfo(void);
   const char* cpp_getVersionInfo(void);


### PR DESCRIPTION
This PR adds append mode for all dtypes in Parquet besides
strings. Since Parquet does not support any method of appending
columns to a file, all values are read from the file before
appending the column and rewriting out the entire file. Due to
this, as well as using the higher level `ReadTable` and
`WriteTable` functions instead of `ReadBatch` and `WriteBatch`,
the performance of writing Parquet files using append mode is
significantly worse than writing a completely new Parquet file.

Some additional limitations with the Parquet implementation
require that columns appended to an existing match the number
of rows of other columns and that the dataset name is not
duplicated in the file (in other words, this only allows you
to add a new column to the file, not add values to an existing
column).

command                     | exec time 1 node | exec time 8 nodes |
--------------------------- | ----------------:| -----------------:|
truncate (default)          | 0.0967 s         | 0.072 s           |
append with 1 existing col  | 0.42 s	       | 0.106 s           |
append with 2 existing cols | 0.59 s           | 0.110 s           |