### PR TITLE
Closes #1039 Update peel/stick to use aggregation

### DIFF
--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -762,15 +762,15 @@ module SegmentedArray {
       var leftVals = makeDistArray((+ reduce leftLengths), uint(8));
       var rightVals = makeDistArray((+ reduce rightLengths), uint(8));
       // Fill left values
-      forall (srcStart, dstStart, len) in zip(oa, leftOffsets, leftLengths) {
+      forall (srcStart, dstStart, len) in zip(oa, leftOffsets, leftLengths) with (var agg = newDstAggregator(uint(8))) {
         for i in 0..#(len-1) {
-          unorderedCopy(leftVals[dstStart+i], va[srcStart+i]);
+          agg.copy(leftVals[dstStart+i], va[srcStart+i]);
         }
       }
       // Fill right values
-      forall (srcStart, dstStart, len) in zip(rightStart, rightOffsets, rightLengths) {
+      forall (srcStart, dstStart, len) in zip(rightStart, rightOffsets, rightLengths) with (var agg = newDstAggregator(uint(8))) {
         for i in 0..#(len-1) {
-          unorderedCopy(rightVals[dstStart+i], va[srcStart+i]);
+          agg.copy(rightVals[dstStart+i], va[srcStart+i]);
         }
       }
       return (leftOffsets, leftVals, rightOffsets, rightVals);
@@ -883,15 +883,15 @@ module SegmentedArray {
       var rightVals = makeDistArray((+ reduce rightLengths), uint(8));
       ref va = values.a;
       // Fill left values
-      forall (srcStart, dstStart, len) in zip(oa, leftOffsets, leftLengths) {
+      forall (srcStart, dstStart, len) in zip(oa, leftOffsets, leftLengths) with (var agg = newDstAggregator(uint(8))) {
         for i in 0..#(len-1) {
-          unorderedCopy(leftVals[dstStart+i], va[srcStart+i]);
+          agg.copy(leftVals[dstStart+i], va[srcStart+i]);
         }
       }
       // Fill right values
-      forall (srcStart, dstStart, len) in zip(rightStart, rightOffsets, rightLengths) {
+      forall (srcStart, dstStart, len) in zip(rightStart, rightOffsets, rightLengths) with (var agg = newDstAggregator(uint(8))) {
         for i in 0..#(len-1) {
-          unorderedCopy(rightVals[dstStart+i], va[srcStart+i]);
+          agg.copy(rightVals[dstStart+i], va[srcStart+i]);
         }
       }
       return (leftOffsets, leftVals, rightOffsets, rightVals);
@@ -920,33 +920,33 @@ module SegmentedArray {
       // Copy in the left and right-hand values, separated by the delimiter
       ref va1 = values.a;
       ref va2 = other.values.a;
-      forall (o1, o2, no, l1, l2) in zip(offsets.a, other.offsets.a, newOffsets, leftLen, rightLen) {
+      forall (o1, o2, no, l1, l2) in zip(offsets.a, other.offsets.a, newOffsets, leftLen, rightLen) with (var agg = newDstAggregator(uint(8))) {
         var pos = no;
         // Left side
         if right {
           for i in 0..#l1 {
-            unorderedCopy(newVals[pos+i], va1[o1+i]);
+            agg.copy(newVals[pos+i], va1[o1+i]);
           }
           pos += l1;
         } else {
           for i in 0..#l2 {
-            unorderedCopy(newVals[pos+i], va2[o2+i]);
+            agg.copy(newVals[pos+i], va2[o2+i]);
           }
           pos += l2;
         }
         // Delimiter
         for (i, b) in zip(0..#delim.numBytes, delim.chpl_bytes()) {
-          unorderedCopy(newVals[pos+i], b);
+          agg.copy(newVals[pos+i], b);
         }
         pos += delim.numBytes;
         // Right side
         if right {
           for i in 0..#l2 {
-            unorderedCopy(newVals[pos+i], va2[o2+i]);
+            agg.copy(newVals[pos+i], va2[o2+i]);
           }
         } else {
           for i in 0..#l1 {
-            unorderedCopy(newVals[pos+i], va1[o1+i]);
+            agg.copy(newVals[pos+i], va1[o1+i]);
           }
         }
       }

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -763,14 +763,16 @@ module SegmentedArray {
       var rightVals = makeDistArray((+ reduce rightLengths), uint(8));
       // Fill left values
       forall (srcStart, dstStart, len) in zip(oa, leftOffsets, leftLengths) with (var agg = newDstAggregator(uint(8))) {
+        var localIdx = new lowLevelLocalizingSlice(va, srcStart..#(len-1));
         for i in 0..#(len-1) {
-          agg.copy(leftVals[dstStart+i], va[srcStart+i]);
+          agg.copy(leftVals[dstStart+i], localIdx.ptr[i]);
         }
       }
       // Fill right values
       forall (srcStart, dstStart, len) in zip(rightStart, rightOffsets, rightLengths) with (var agg = newDstAggregator(uint(8))) {
+        var localIdx = new lowLevelLocalizingSlice(va, srcStart..#(len-1));
         for i in 0..#(len-1) {
-          agg.copy(rightVals[dstStart+i], va[srcStart+i]);
+          agg.copy(rightVals[dstStart+i], localIdx.ptr[i]);
         }
       }
       return (leftOffsets, leftVals, rightOffsets, rightVals);
@@ -884,14 +886,16 @@ module SegmentedArray {
       ref va = values.a;
       // Fill left values
       forall (srcStart, dstStart, len) in zip(oa, leftOffsets, leftLengths) with (var agg = newDstAggregator(uint(8))) {
+        var localIdx = new lowLevelLocalizingSlice(va, srcStart..#(len-1));
         for i in 0..#(len-1) {
-          agg.copy(leftVals[dstStart+i], va[srcStart+i]);
+          agg.copy(leftVals[dstStart+i], localIdx.ptr[i]);
         }
       }
       // Fill right values
       forall (srcStart, dstStart, len) in zip(rightStart, rightOffsets, rightLengths) with (var agg = newDstAggregator(uint(8))) {
+        var localIdx = new lowLevelLocalizingSlice(va, srcStart..#(len-1));
         for i in 0..#(len-1) {
-          agg.copy(rightVals[dstStart+i], va[srcStart+i]);
+          agg.copy(rightVals[dstStart+i], localIdx.ptr[i]);
         }
       }
       return (leftOffsets, leftVals, rightOffsets, rightVals);
@@ -924,13 +928,15 @@ module SegmentedArray {
         var pos = no;
         // Left side
         if right {
+          var localIdx = new lowLevelLocalizingSlice(va1, o1..#l1);
           for i in 0..#l1 {
-            agg.copy(newVals[pos+i], va1[o1+i]);
+            agg.copy(newVals[pos+i], localIdx.ptr[i]);
           }
           pos += l1;
         } else {
+          var localIdx = new lowLevelLocalizingSlice(va2, o2..#l2);
           for i in 0..#l2 {
-            agg.copy(newVals[pos+i], va2[o2+i]);
+            agg.copy(newVals[pos+i], localIdx.ptr[i]);
           }
           pos += l2;
         }
@@ -941,12 +947,14 @@ module SegmentedArray {
         pos += delim.numBytes;
         // Right side
         if right {
+          var localIdx = new lowLevelLocalizingSlice(va2, o2..#l2);
           for i in 0..#l2 {
-            agg.copy(newVals[pos+i], va2[o2+i]);
+            agg.copy(newVals[pos+i], localIdx.ptr[i]);
           }
         } else {
+          var localIdx = new lowLevelLocalizingSlice(va1, o1..#l1);
           for i in 0..#l1 {
-            agg.copy(newVals[pos+i], va1[o1+i]);
+            agg.copy(newVals[pos+i], localIdx.ptr[i]);
           }
         }
       }


### PR DESCRIPTION
This PR (closes #1039):

Updates peel/stick functionality to use aggregation in place of `unorderedCopy`.