### PR TITLE
Bulk append values in Parquet and switch some places to int64

### DIFF
--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -38,10 +38,10 @@ extern "C" {
                            const char* colname, int64_t numElems, int64_t startIdx,
                            int64_t batchSize, char** errMsg);
 
-  int cpp_getStringColumnNumBytes(const char* filename, const char* colname,
-                                  void* chpl_offsets, int64_t numElems, int64_t startIdx, char** errMsg);
-  int c_getStringColumnNumBytes(const char* filename, const char* colname,
-                                void* chpl_offsets, int64_t numElems, int64_t startIdx, char** errMsg);
+  int64_t cpp_getStringColumnNumBytes(const char* filename, const char* colname,
+                                      void* chpl_offsets, int64_t numElems, int64_t startIdx, char** errMsg);
+  int64_t c_getStringColumnNumBytes(const char* filename, const char* colname,
+                                    void* chpl_offsets, int64_t numElems, int64_t startIdx, char** errMsg);
 
   int c_getType(const char* filename, const char* colname, char** errMsg);
   int cpp_getType(const char* filename, const char* colname, char** errMsg);


### PR DESCRIPTION
This PR updates the Parquet append function to switch from
adding values one at a time to instead bulk add all of the
values. Additionally, there were some places in the C++/C code
that should have been `int64_t` instead of plain `int`, and those
have been updated here.

Performance with 10m int elems on 8 nodes of a Cray CS:
version     | 1 existing column | 2 existing columns |
----------- | ----------------: | -----------------: |
master      | 0.327 s           | 0.460 s            |
this branch | 0.270 s           | 0.368 s            |