### PR TITLE
Closes #1190 Index for Indexing DataFrame

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -297,8 +297,8 @@ class DataFrame(UserDict):
             rtn_data = {}
             s = key
             for k in self._columns:
-                rtn_data[k] = UserDict.__getitem__(self, k)[s.start:s.stop:s.step]
-            return DataFrame(initialdata=rtn_data, index=list(range(self.size)[s.start:s.stop:s.step]))
+                rtn_data[k] = UserDict.__getitem__(self, k)[s]
+            return DataFrame(initialdata=rtn_data, index=arange(self.size)[s])
         else:
             raise IndexError("Invalid selector: unknown error.")
 

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -148,10 +148,6 @@ class DataFrame(UserDict):
             self._columns = initialdata._columns
             if index == None:
                 self.index = initialdata.index
-            elif isinstance(index, Index):
-                self.index = index
-            elif isinstance(index, pd.Index):
-                self.index = index.values.tolist()
             else:
                 self.index = index
             self.data = initialdata.data
@@ -167,10 +163,6 @@ class DataFrame(UserDict):
 
             if index == None:
                 self.index = initialdata.index.values.tolist()
-            elif isinstance(index, Index):
-                self.index = index
-            elif isinstance(index, pd.Index):
-                self.index = index.values.tolist()
             else:
                 self.index = index
             self.data = {}
@@ -236,10 +228,6 @@ class DataFrame(UserDict):
             # creating a new one.
             if self.index is None:
                 self.index = arange(0, self._size, 1)
-            elif isinstance(index, Index):
-                self.index = index
-            elif isinstance(index, pd.Index):
-                self.index = index.values.tolist()
             else:
                 self.index = index
 

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -21,6 +21,7 @@ from arkouda.client import maxTransferBytes
 from arkouda.row import Row
 from arkouda.alignment import in1dmulti
 from arkouda.series import Series
+from arkouda.index import Index
 
 # This is necessary for displaying DataFrames with BitVector columns,
 # because pandas _html_repr automatically truncates the number of displayed bits
@@ -154,10 +155,10 @@ class DataFrame(UserDict):
             self._bytes = 0
             self._empty = initialdata.empty
             # ak.DataFrame stores index as a column, it needs to be added before columns from the pd.DataFrame
-            self._columns = ['index'] + initialdata.columns.tolist()
-            # Add index values as data
-            self.data = {'index': array(initialdata.index.values.tolist())}
+            self._columns = initialdata.columns.tolist()
 
+            self.index = Index(initialdata.index.values.tolist())
+            self.data = {}
             # convert the lists defining each column into a pdarray
             # pd.DataFrame.values is stored as rows, we need lists to be columns
             for key, val in initialdata.to_dict('list').items():
@@ -173,8 +174,8 @@ class DataFrame(UserDict):
         self._empty = True
 
         # Initial attempts to keep an order on the columns
-        self._columns = ['index']
-        self.data['index'] = None
+        self._columns = []
+        self.index = None
 
         # Add data to the DataFrame if there is any
         if initialdata is not None:
@@ -220,7 +221,8 @@ class DataFrame(UserDict):
             # If the index column was passed in, use that instead of
             # creating a new one.
             if self.data['index'] is None:
-                self.data['index'] = arange(0, self._size, 1)
+                # self.data['index'] = arange(0, self._size, 1)
+                self.index = Index(arange(0, self._size, 1))
 
             self.update_size()
 

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -148,9 +148,9 @@ class DataFrame(UserDict):
             self._columns = initialdata._columns
             if index == None:
                 self.index = initialdata.index
-            elif isinstance(Index, index):
+            elif isinstance(index, Index):
                 self.index = index
-            elif isinstance(pd.Index, index):
+            elif isinstance(index, pd.Index):
                 self.index = Index(index.values.tolist())
             else:
                 self.index = Index(index)
@@ -167,9 +167,9 @@ class DataFrame(UserDict):
 
             if index == None:
                 self.index = Index(initialdata.index.values.tolist())
-            elif isinstance(Index, index):
+            elif isinstance(index, Index):
                 self.index = index
-            elif isinstance(pd.Index, index):
+            elif isinstance(index, pd.Index):
                 self.index = Index(index.values.tolist())
             else:
                 self.index = Index(index)
@@ -236,9 +236,9 @@ class DataFrame(UserDict):
             # creating a new one.
             if self.index is None:
                 self.index = Index(arange(0, self._size, 1))
-            elif isinstance(Index, index):
+            elif isinstance(index, Index):
                 self.index = index
-            elif isinstance(pd.Index, index):
+            elif isinstance(index, pd.Index):
                 self.index = Index(index.values.tolist())
             else:
                 self.index = Index(index)
@@ -421,6 +421,7 @@ class DataFrame(UserDict):
                     newdf[col] = self[col].categories[self[col].codes]
                 else:
                     newdf[col] = self[col]
+            newdf.index = self.index
             return newdf.to_pandas(retain_index=True)
         # Being 1 above the threshold causes the PANDAS formatter to split the data frame vertically
         idx = array(list(range(maxrows // 2 + 1)) + list(range(self._size - (maxrows // 2), self._size)))
@@ -563,25 +564,26 @@ class DataFrame(UserDict):
             return self
 
         if not subset:
-            subset = self._columns[1:]
+            subset = self._columns
 
         if len(subset) == 1:
             if not subset[0] in self.data:
                 raise KeyError("{} is not a column in the DataFrame.".format(subset[0]))
-            _ = akGroupBy(self.data[subset[0]])
+            gp = akGroupBy(self.data[subset[0]])
 
         else:
             for col in subset:
                 if col not in self.data:
                     raise KeyError("{} is not a column in the DataFrame.".format(subset[0]))
 
-            _ = akGroupBy([self.data[col] for col in subset])
+            gp = akGroupBy([self.data[col] for col in subset])
 
         if keep == 'last':
-            _segment_ends = concatenate([_.segments[1:] - 1, array([_.permutation.size - 1])])
-            return self[_.permutation[_segment_ends]]
+            _segment_ends = concatenate([gp.segments[1:] - 1, array([gp.permutation.size - 1])])
+            return self[gp.permutation[_segment_ends]]
         else:
-            return self[_.permutation[_.segments]]
+            print(gp.permutation[gp.segments])
+            return self[gp.permutation[gp.segments]]
 
     @property
     def size(self):

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -641,13 +641,18 @@ class DataFrame(UserDict):
         size : int
             If size is passed, do not attempt to determine size based on
             existing column sizes. Assume caller handles consistency correctly.
+
+        NOTE
+        ----------
+        Pandas adds a column 'index' to indicate the original index. Arkouda does not currently
+        support this behavior.
         """
 
         if not size:
             self.update_size()
-            self.data['index'] = arange(0, self._size)
+            self.index = Index(arange(0, self._size))
         else:
-            self.data['index'] = arange(size)
+            self.index = Index(arange(size))
 
     @property
     def info(self):

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -570,7 +570,6 @@ class DataFrame(UserDict):
             _segment_ends = concatenate([gp.segments[1:] - 1, array([gp.permutation.size - 1])])
             return self[gp.permutation[_segment_ends]]
         else:
-            print(gp.permutation[gp.segments])
             return self[gp.permutation[gp.segments]]
 
     @property

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -10,7 +10,7 @@ from arkouda.groupbyclass import GroupBy
 from arkouda.alignment import in1dmulti
 
 class Index:
-    def __init__(self,index):
+    def __init__(self, index):
         self.index = index
         self.size = index.size
 


### PR DESCRIPTION
This PR (closes #1190):

Arkouda DataFrames were previously using a column labeled `'index'` for indexing and then artificially providing an `index` property via a function that returned `df.data['index']`. In order to configure this to function more in line with pandas, Arkouda DataFrames have been updated to have a property that uses Arkouda Index objects as the index.

This new configuration prevents the need to filter the columns to avoid pulling out the index. Currently, the functionality of Arkouda Index objects are not fully comparable to pandas.Index. This does not currently impact our functionality, but is noted as it may need to be improved upon in the future.