### PR TITLE
Fix append Parquet test when running with more than 10 locales

### DIFF
--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -371,6 +371,13 @@ module ParquetMsg {
         dims[0] = locDom.size: int;
 
         if (locDom.isEmpty() || locDom.size <= 0) {
+          if mode == APPEND then
+            throw getErrorWithContext(
+                 msg="Parquet columns must each have the same length: " + myFilename,
+                 lineNumber=getLineNumber(), 
+                 routineName=getRoutineName(), 
+                 moduleName=getModuleName(), 
+                 errorClass='WriteModeError');
           createEmptyParquetFile(myFilename, dsetName, ARROWSTRING, compressed);
         } else {
           var localOffsets = A[locDom];

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -78,7 +78,7 @@ def get_datasets_test(dtype):
 
 def append_test():
     # use small size to cut down on execution time
-    append_size = 10
+    append_size = 32
 
     base_dset = ak.randint(0, 2**32, append_size)
     ak_dict = {}


### PR DESCRIPTION
The Parquet unit test was only writing with 10 elements, which
meant that when running with greater than 10 nodes, there would
be some files that weren't created or were only created with
string files. This PR adds an error when trying to append an
empty column with Parquet strings and also bumps the unit test
size so it works with greater node counts.

Closes: https://github.com/Bears-R-Us/arkouda/issues/1238