### PR TITLE
Closes #1241: Use `computeOnSegments` for `substringSearch`

### DIFF
--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -636,6 +636,8 @@ module SegmentedArray {
       :returns: [domain] bool where index i indicates whether the regular expression, pattern, matched string i of the SegString
     */
     proc substringSearch(const pattern: string) throws {
+      // We need to check that pattern compiles once to avoid server crash from !try in _unsafecompile
+      checkCompile(pattern);
       return computeOnSegments(offsets.a, values.a, SegFunction.StringSearch, bool, pattern);
     }
 
@@ -1127,8 +1129,8 @@ module SegmentedArray {
     return try! compile(pattern);
   }
 
-  inline proc stringSearch(values, rng, pattern) throws {
-    return checkCompile(pattern).search(interpretAsString(values, rng, borrow=true)).matched;
+  inline proc stringSearch(values, rng, myRegex) throws {
+    return myRegex.search(interpretAsString(values, rng, borrow=true)).matched;
   }
 
   /* Test array of strings for membership in another array (set) of strings. Returns

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -406,29 +406,6 @@ module SegmentedArray {
     }
 
     /*
-      Returns Regexp.compile if pattern can be compiled without an error
-    */
-    proc checkCompile(const pattern: ?t) throws where t == bytes || t == string {
-      try {
-        return compile(pattern);
-      }
-      catch {
-        var errorMsg = "re2 could not compile pattern: %s)".format(pattern);
-        saLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-        throw new owned IllegalArgumentError(errorMsg);
-      }
-    }
-
-    proc _unsafeCompileRegex(const pattern: ?t) where t == bytes || t == string {
-      // This is a private function and should not be called to compile pattern. Use checkCompile instead
-
-      // This proc is a workaound to allow declaring regexps using a with clause in forall loops
-      // since using declarations with throws are illegal
-      // It is only called after checkCompile so the try! will not result in a server crash
-      return try! compile(pattern);
-    }
-
-    /*
       Given a SegString, finds pattern matches and returns pdarrays containing the number, start postitions, and lengths of matches
       :arg pattern: The regex pattern used to find matches
       :type pattern: string
@@ -659,18 +636,7 @@ module SegmentedArray {
       :returns: [domain] bool where index i indicates whether the regular expression, pattern, matched string i of the SegString
     */
     proc substringSearch(const pattern: string) throws {
-      var hits: [offsets.aD] bool = false;  // the answer
-      checkCompile(pattern);
-
-      ref oa = offsets.a;
-      ref va = values.a;
-      var lengths = getLengths();
-
-      forall (o, l, h) in zip(oa, lengths, hits) with (var myRegex = _unsafeCompileRegex(pattern)) {
-        // regexp.search searches the receiving string for matches at any offset
-        h = myRegex.search(interpretAsString(va, o..#l, borrow=true)).matched;
-      }
-      return hits;
+      return computeOnSegments(offsets.a, values.a, SegFunction.StringSearch, bool, pattern);
     }
 
     /*
@@ -1136,6 +1102,33 @@ module SegmentedArray {
       return (lengths == 0);
     }
     return computeOnSegments(ss.offsets.a, ss.values.a, function, bool, testStr);
+  }
+
+  /*
+    Returns Regexp.compile if pattern can be compiled without an error
+  */
+  proc checkCompile(const pattern: ?t) throws where t == bytes || t == string {
+    try {
+      return compile(pattern);
+    }
+    catch {
+      var errorMsg = "re2 could not compile pattern: %s".format(pattern);
+      saLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+      throw new owned IllegalArgumentError(errorMsg);
+    }
+  }
+
+  proc _unsafeCompileRegex(const pattern: ?t) where t == bytes || t == string {
+    // This is a private function and should not be called to compile pattern. Use checkCompile instead
+
+    // This proc is a workaound to allow declaring regexps using a with clause in forall loops
+    // since using declarations with throws are illegal
+    // It is only called after checkCompile so the try! will not result in a server crash
+    return try! compile(pattern);
+  }
+
+  inline proc stringSearch(values, rng, pattern) throws {
+    return checkCompile(pattern).search(interpretAsString(values, rng, borrow=true)).matched;
   }
 
   /* Test array of strings for membership in another array (set) of strings. Returns

--- a/src/SegmentedComputation.chpl
+++ b/src/SegmentedComputation.chpl
@@ -44,6 +44,7 @@ module SegmentedComputation {
     StringToNumericReturnValidity,
     StringCompareLiteralEq,
     StringCompareLiteralNeq,
+    StringSearch,
   }
   
   proc computeOnSegments(segments: [?D] int, values: [?vD] ?t, param function: SegFunction, type retType, const strArg: string = "") throws {
@@ -89,6 +90,9 @@ module SegmentedComputation {
               }
               when SegFunction.StringCompareLiteralNeq {
                 agg.copy(res[i], stringCompareLiteralNeq(values, start..#len, strArg));
+              }
+              when SegFunction.StringSearch {
+                agg.copy(res[i], stringSearch(values, start..#len, strArg));
               }
               otherwise {
                 compilerError("Unrecognized segmented function");

--- a/src/SegmentedComputation.chpl
+++ b/src/SegmentedComputation.chpl
@@ -71,31 +71,34 @@ module SegmentedComputation {
         }
         try {
           // Apply function to bytes of each owned segment, aggregating return value to res
-          forall (start, len, i) in zip(mySegs, myLens, mySegInds) with (var agg = newDstAggregator(retType)) {
-            select function {
-              when SegFunction.SipHash128 {
-                agg.copy(res[i], sipHash128(values, start..#len));
-              }
-              when SegFunction.StringToNumericStrict {
-                agg.copy(res[i], stringToNumericStrict(values, start..#len, retType));
-              }
-              when SegFunction.StringToNumericIgnore {
-                agg.copy(res[i], stringToNumericIgnore(values, start..#len, retType));
-              }
-              when SegFunction.StringToNumericReturnValidity {
-                agg.copy(res[i], stringToNumericReturnValidity(values, start..#len, retType[0]));
-              }
-              when SegFunction.StringCompareLiteralEq {
-                agg.copy(res[i], stringCompareLiteralEq(values, start..#len, strArg));
-              }
-              when SegFunction.StringCompareLiteralNeq {
-                agg.copy(res[i], stringCompareLiteralNeq(values, start..#len, strArg));
-              }
-              when SegFunction.StringSearch {
-                agg.copy(res[i], stringSearch(values, start..#len, strArg));
-              }
-              otherwise {
-                compilerError("Unrecognized segmented function");
+          if function == SegFunction.StringSearch {
+            forall (start, len, i) in zip(mySegs, myLens, mySegInds) with (var agg = newDstAggregator(retType), var myRegex = _unsafeCompileRegex(strArg)) {
+              agg.copy(res[i], stringSearch(values, start..#len, myRegex));
+            }
+          } else {
+            forall (start, len, i) in zip(mySegs, myLens, mySegInds) with (var agg = newDstAggregator(retType)) {
+              select function {
+                when SegFunction.SipHash128 {
+                  agg.copy(res[i], sipHash128(values, start..#len));
+                }
+                when SegFunction.StringToNumericStrict {
+                  agg.copy(res[i], stringToNumericStrict(values, start..#len, retType));
+                }
+                when SegFunction.StringToNumericIgnore {
+                  agg.copy(res[i], stringToNumericIgnore(values, start..#len, retType));
+                }
+                when SegFunction.StringToNumericReturnValidity {
+                  agg.copy(res[i], stringToNumericReturnValidity(values, start..#len, retType[0]));
+                }
+                when SegFunction.StringCompareLiteralEq {
+                  agg.copy(res[i], stringCompareLiteralEq(values, start..#len, strArg));
+                }
+                when SegFunction.StringCompareLiteralNeq {
+                  agg.copy(res[i], stringCompareLiteralNeq(values, start..#len, strArg));
+                }
+                otherwise {
+                  compilerError("Unrecognized segmented function");
+                }
               }
             }
           }


### PR DESCRIPTION
This PR (Closes #1241):
- Updates `substringSearch` to use `computeOnSegments`

Edit: The NOTE should be resolved thanks to ronawho's suggestion

<details>
  <summary>NOTE: </summary>

The way I've done this recompiles the regex pattern each iteration instead of (I believe) once per task using `with`
```Chapel
forall ... with (var myRegex = _unsafeCompileRegex(pattern))
```
I'm not sure if this is better or worse/if there's a better way to do this. Feedback on this would be appreciated
</details>