### PR TITLE
Fix server crash when reading string columns from multiple locales

### DIFF
--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -157,7 +157,6 @@ int64_t cpp_getStringColumnNumBytes(const char* filename, const char* colname, v
         int16_t definition_level;
         parquet::ByteArrayReader* ba_reader =
           static_cast<parquet::ByteArrayReader*>(column_reader.get());
-        ba_reader -> Skip(startIdx);
 
         int64_t numRead = 0;
         while (ba_reader->HasNext() && numRead < numElems) {
@@ -264,23 +263,17 @@ int cpp_readColumnByName(const char* filename, void* chpl_arr, const char* colna
         parquet::ByteArrayReader* reader =
           static_cast<parquet::ByteArrayReader*>(column_reader.get());
 
-        while (reader->HasNext() && i < numElems) {
+        while (reader->HasNext()) {
           parquet::ByteArray value;
           (void)reader->ReadBatch(1, &definition_level, nullptr, &value, &values_read);
           // if values_read is 0, that means that it was a null value
           if(values_read > 0) {
             for(int j = 0; j < value.len; j++) {
-              if(startIdx < 1 && i < numElems) {
-                chpl_ptr[i] = value.ptr[j];
-                i++;
-              } else {
-                startIdx--;
-              }
+              chpl_ptr[i] = value.ptr[j];
+              i++;
             }
           }
-          if(startIdx < 1 && i < numElems)
-            i++; // skip one space so the strings are null terminated with a 0
-          startIdx--;
+          i++; // skip one space so the strings are null terminated with a 0
         }
       } else if(ty == ARROWFLOAT) {
         auto chpl_ptr = (double*)chpl_arr;

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -134,27 +134,26 @@ module ParquetMsg {
   proc readStrFilesByName(A: [] ?t, filenames: [] string, sizes: [] int, dsetname: string, ty) throws {
     extern proc c_readColumnByName(filename, chpl_arr, colNum, numElems, startIdx, batchSize, errMsg): int;
     var (subdoms, length) = getSubdomains(sizes);
-    var fileOffsets = (+ scan sizes) - sizes;
     
     coforall loc in A.targetLocales() do on loc {
       var locFiles = filenames;
       var locFiledoms = subdoms;
-      var locOffsets = fileOffsets;
 
       try {
-        forall (off, filedom, filename) in zip(locOffsets, locFiledoms, locFiles) {
+        forall (filedom, filename) in zip(locFiledoms, locFiles) {
           for locdom in A.localSubdomains() {
             const intersection = domain_intersection(locdom, filedom);
-            var startByte = intersection.low - filedom.low;
 
             if intersection.size > 0 {
               var pqErr = new parquetErrorMsg();
+              var col: [filedom] t;
 
-              if c_readColumnByName(filename.localize().c_str(), c_ptrTo(A[intersection.low]),
-                                    dsetname.localize().c_str(), intersection.size, startByte,
+              if c_readColumnByName(filename.localize().c_str(), c_ptrTo(col),
+                                    dsetname.localize().c_str(), intersection.size, 0,
                                     batchSize, c_ptrTo(pqErr.errMsg)) == ARROWERROR {
                 pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
               }
+              A[filedom] = col;
             }
           }
         }
@@ -166,22 +165,21 @@ module ParquetMsg {
 
   proc calcSizesAndOffset(offsets: [] ?t, filenames: [] string, sizes: [] int, dsetname: string) throws {
     var (subdoms, length) = getSubdomains(sizes);
-    var fileOffsets = (+ scan sizes) - sizes;
 
     var byteSizes: [filenames.domain] int;
 
-    coforall loc in offsets.targetLocales() with (+ reduce byteSizes) do on loc {
+    coforall loc in offsets.targetLocales() do on loc {
       var locFiles = filenames;
       var locFiledoms = subdoms;
-      var locOffsets = fileOffsets;
       
       try {
-        forall (i, off, filedom, filename) in zip(sizes.domain, locOffsets, locFiledoms, locFiles) {
+        forall (i, filedom, filename) in zip(sizes.domain, locFiledoms, locFiles) {
           for locdom in offsets.localSubdomains() {
             const intersection = domain_intersection(locdom, filedom);
             if intersection.size > 0 {
-              byteSizes[i] = getStrColSize(filename, dsetname, offsets, intersection.size,
-                                           intersection.low, intersection.low - off);
+              var col: [filedom] t;
+              byteSizes[i] = getStrColSize(filename, dsetname, col);
+              offsets[filedom] = col;
             }
           }
         }
@@ -192,14 +190,14 @@ module ParquetMsg {
     return byteSizes;
   }
 
-  proc getStrColSize(filename: string, dsetname: string, offsets: [] int, numElems: int, chplStartIdx: int, cStartIdx: int) throws {
+  proc getStrColSize(filename: string, dsetname: string, offsets: [] int) throws {
     extern proc c_getStringColumnNumBytes(filename, colname, offsets, numElems, startIdx, errMsg): int;
     var pqErr = new parquetErrorMsg();
 
     var byteSize = c_getStringColumnNumBytes(filename.localize().c_str(),
                                              dsetname.localize().c_str(),
-                                             c_ptrTo(offsets[chplStartIdx]),
-                                             numElems, cStartIdx,
+                                             c_ptrTo(offsets),
+                                             offsets.size, 0,
                                              c_ptrTo(pqErr.errMsg));
     
     if byteSize == ARROWERROR then


### PR DESCRIPTION
There was a bug caught with the Parquet string reading where
reading a string column from a single file that was shared between
multiple locales was causing a crash. I believe this was caused by
a segfault in the C++ code where the buffer allocated on the
Chapel size was too small due to incorrectly handling null bytes.
This PR simplifies the string reading Parquet code to avoid this
type of problem.

This partially reverts an optimization made in https://github.com/Bears-R-Us/arkouda/pull/1204, so we expect that
performance will take a minor hit.

Closes https://github.com/Bears-R-Us/arkouda/issues/1261