### PR TITLE
1240 Uint64 compatibility and other improvements to client dtype classes

### DIFF
--- a/arkouda/dtypes.py
+++ b/arkouda/dtypes.py
@@ -6,7 +6,8 @@ import builtins
 import sys
 
 __all__ = ["DTypes", "DTypeObjects", "dtype", "bool", "int64", "float64", 
-           "uint8", "uint64", "str_", "check_np_dtype", "translate_np_dtype", 
+           "uint8", "uint64", "str_", "intTypes", "bitType",
+           "check_np_dtype", "translate_np_dtype", 
            "resolve_scalar_dtype", "ARKOUDA_SUPPORTED_DTYPES", "bool_scalars",
            "float_scalars", "int_scalars", "numeric_scalars", "numpy_scalars",
            "str_scalars", "all_scalars", "get_byteorder",
@@ -27,6 +28,8 @@ uint8 = np.dtype(np.uint8)
 uint64 = np.dtype(np.uint64)
 str_ = np.dtype(np.str_)
 npstr = np.dtype(str)
+intTypes = frozenset((int64, uint64, uint8))
+bitType = uint64
 
 # Union aliases used for static and runtime type checking
 bool_scalars = Union[builtins.bool, np.bool_]

--- a/arkouda/timeclass.py
+++ b/arkouda/timeclass.py
@@ -1,6 +1,6 @@
 from arkouda.pdarrayclass import pdarray
 from pandas import Series, Timestamp, Timedelta as pdTimedelta, date_range as pd_date_range, timedelta_range as pd_timedelta_range, to_datetime, to_timedelta # type: ignore
-from arkouda.dtypes import int64, isSupportedInt
+from arkouda.dtypes import int64, intTypes, isSupportedInt
 from arkouda.pdarraycreation import from_series, array as ak_array
 from arkouda.numeric import cast, abs as akabs
 import numpy as np # type: ignore
@@ -54,7 +54,7 @@ class _Timescalar:
         self.unit = np.datetime_data(scalar.dtype)[0]
         self._factor = _get_factor(self.unit)
         # int64 in nanoseconds
-        self._data = self._factor * scalar.astype('int64')
+        self.value = self._factor * scalar.astype('int64')
     
 
 class _AbstractBaseTime(pdarray):
@@ -70,16 +70,17 @@ class _AbstractBaseTime(pdarray):
         if isinstance(array, Datetime) or isinstance(array, Timedelta):
             self.unit: str = array.unit
             self._factor: int = array._factor
-            self._data: pdarray  = array._data
+            # Make a copy to avoid unknown symbol errors
+            self.values: pdarray = cast(array.values, int64)
         # Convert the input to int64 pdarray of nanoseconds
         elif isinstance(array, pdarray):
-            if array.dtype != int64:
+            if array.dtype not in intTypes:
                 raise TypeError("{} array must have int64 dtype".format(self.__class__.__name__))
             # Already int64 pdarray, just scale
             self.unit = unit
             self._factor = _get_factor(self.unit)
             # This makes a copy of the input array, to leave input unchanged
-            self._data = self._factor * array # Mimics a datetime64[ns] array         
+            self.values = cast(self._factor * array, int64) # Mimics a datetime64[ns] array
         elif hasattr(array, 'dtype'):
             # Handles all pandas and numpy datetime/timedelta arrays
             if array.dtype.kind not in ('M', 'm'):
@@ -91,13 +92,13 @@ class _AbstractBaseTime(pdarray):
                 self.unit = np.datetime_data(array.values.dtype)[0]
                 self._factor = _get_factor(self.unit)
                 # Create pdarray
-                self._data = from_series(array)
+                self.values = from_series(array)
                 # Scale if necessary
                 # This is futureproofing; it will not be used unless pandas
                 # changes its Datetime implementation
                 if self._factor != 1:
                     # Scale inplace because we already created a copy
-                    self._data *= self._factor
+                    self.values *= self._factor
             elif isinstance(array, np.ndarray):
                 # Numpy datetime64 and timedelta64
                 # Force through pandas.Series
@@ -108,8 +109,10 @@ class _AbstractBaseTime(pdarray):
                 self.__init__(array.to_series()) # type: ignore
         else:
             raise TypeError("Unsupported type: {}".format(type(array)))
-        # Now that self._data is correct, init self with same metadata
-        super().__init__(self._data.name, self._data.dtype, self._data.size, self._data.ndim, self._data.shape, self._data.itemsize)
+        # Now that self.values is correct, init self with same metadata
+        super().__init__(self.values.name, self.values.dtype, self.values.size, self.values.ndim, self.values.shape, self.values.itemsize)
+        # Deprecated
+        self._data = self.values
 
     @classmethod
     def _get_callback(cls, other, op):
@@ -130,7 +133,7 @@ class _AbstractBaseTime(pdarray):
             Values rounded down to nearest frequency
         '''
         f = _get_factor(freq)
-        return self.__class__(self._data // f, unit=freq)
+        return self.__class__(self.values // f, unit=freq)
 
     def ceil(self, freq):
         '''Round times up to the nearest integer of a given frequency.
@@ -146,7 +149,7 @@ class _AbstractBaseTime(pdarray):
             Values rounded up to nearest frequency
         '''
         f = _get_factor(freq)
-        return self.__class__((self._data + (f - 1)) // f, unit=freq)
+        return self.__class__((self.values + (f - 1)) // f, unit=freq)
 
     def round(self, freq):
         '''Round times to the nearest integer of a given frequency. Midpoint
@@ -163,7 +166,7 @@ class _AbstractBaseTime(pdarray):
             Values rounded to nearest frequency
         '''
         f = _get_factor(freq)
-        offset = self._data + ((f + 1) // 2)
+        offset = self.values + ((f + 1) // 2)
         rounded = offset // f
         # Halfway values are supposed to round to the nearest even integer
         # Need to figure out which ones ended up odd and fix them
@@ -173,7 +176,7 @@ class _AbstractBaseTime(pdarray):
 
     def to_ndarray(self):
         __doc__ = super().to_ndarray.__doc__
-        return np.array(self._data.to_ndarray(), dtype="{}64[ns]".format(self.__class__.__name__.lower()))
+        return np.array(self.values.to_ndarray(), dtype="{}64[ns]".format(self.__class__.__name__.lower()))
 
     def __str__(self):
         from arkouda.client import pdarrayIterThresh
@@ -201,18 +204,18 @@ class _AbstractBaseTime(pdarray):
                 raise TypeError("{} not supported between {} and Datetime".format(op, self.__class__.__name__))
             otherclass = 'Datetime'
             if self._is_datetime_scalar(other):
-                otherdata = _Timescalar(other)._data
+                otherdata = _Timescalar(other).value
             else:
-                otherdata = other._data
+                otherdata = other.values
         elif isinstance(other, Timedelta) or self._is_timedelta_scalar(other):
             if op not in self.supported_with_timedelta:
                 raise TypeError("{} not supported between {} and Timedelta".format(op, self.__class__.__name__))
             otherclass = 'Timedelta'
             if self._is_timedelta_scalar(other):
-                otherdata = _Timescalar(other)._data
+                otherdata = _Timescalar(other).value
             else:
-                otherdata = other._data
-        elif (isinstance(other, pdarray) and other.dtype == int64) or isSupportedInt(other):
+                otherdata = other.values
+        elif (isinstance(other, pdarray) and other.dtype in intTypes) or isSupportedInt(other):
             if op not in self.supported_with_pdarray:
                 raise TypeError("{} not supported between {} and integer".format(op, self.__class__.__name__))
             otherclass = 'pdarray'
@@ -222,7 +225,7 @@ class _AbstractBaseTime(pdarray):
         # Determines return type (Datetime, Timedelta, or pdarray)
         callback = self._get_callback(otherclass, op)
         # Actual operation evaluates on the underlying int64 data
-        return callback(self._data._binop(otherdata, op))
+        return callback(self.values._binop(otherdata, op))
 
     def _r_binop(self, other, op):
         # Need to do 2 things:
@@ -230,23 +233,23 @@ class _AbstractBaseTime(pdarray):
         #  2) Get other's int64 data to combine with self's data
         
         # First case is pdarray <op> self
-        if (isinstance(other, pdarray) and other.dtype == int64):
+        if (isinstance(other, pdarray) and other.dtype in intTypes):
             if op not in self.supported_with_r_pdarray:
                 raise TypeError("{} not supported between int64 and {}".format(op, self.__class__.__name__))
             callback = self._get_callback('pdarray', op)
-            # Need to use other._binop because self._data._r_binop can only handle scalars
-            return callback(other._binop(self._data, op))
-        # All other cases are scalars, so can use self._data._r_binop
+            # Need to use other._binop because self.values._r_binop can only handle scalars
+            return callback(other._binop(self.values, op))
+        # All other cases are scalars, so can use self.values._r_binop
         elif self._is_datetime_scalar(other):
             if op not in self.supported_with_r_datetime:
                 raise TypeError("{} not supported between scalar datetime and {}".format(op, self.__class__.__name__))
             otherclass = 'Datetime'
-            otherdata = _Timescalar(other)._data
+            otherdata = _Timescalar(other).value
         elif self._is_timedelta_scalar(other):
             if op not in self.supported_with_r_timedelta:
                 raise TypeError("{} not supported between scalar timedelta and {}".format(op, self.__class__.__name__))
             otherclass = 'Timedelta'
-            otherdata = _Timescalar(other)._data
+            otherdata = _Timescalar(other).value
         elif isSupportedInt(other):
             if op not in self.supported_with_r_pdarray:
                 raise TypeError("{} not supported between int64 and {}".format(op, self.__class__.__name__))
@@ -256,7 +259,7 @@ class _AbstractBaseTime(pdarray):
             # If here, type is not handled
             return NotImplemented
         callback = self._get_callback(otherclass, op)
-        return callback(self._data._r_binop(otherdata, op))
+        return callback(self.values._r_binop(otherdata, op))
 
     def opeq(self, other, op):
         if isinstance(other, Timedelta) or self._is_timedelta_scalar(other):
@@ -264,7 +267,7 @@ class _AbstractBaseTime(pdarray):
                 raise TypeError("{} {} Timedelta not supported".format(self.__class__.__name__, op))
             if self._is_timedelta_scalar(other):
                 other = _Timescalar(other)
-            self._data.opeq(other._data, op)
+            self.values.opeq(other.values, op)
         elif isinstance(other, Datetime) or self._is_datetime_scalar(other):
             raise TypeError("{} {} datetime not supported".format(self.__class__.__name__, op))
         else:
@@ -289,43 +292,43 @@ class _AbstractBaseTime(pdarray):
     def __getitem__(self, key):
         if isSupportedInt(key):
             # Single integer index will return a pandas scalar
-            return self._scalar_callback(self._data[key])
+            return self._scalar_callback(self.values[key])
         else:
             # Slice or array index should return same class
-            return self.__class__(self._data[key])
+            return self.__class__(self.values[key])
 
     def __setitem__(self, key, value):
         # RHS can only be vector or scalar of same class
         if isinstance(value, self.__class__):
-            # Value._data is already in nanoseconds, so self._data
+            # Value.values is already in nanoseconds, so self.values
             # can be set directly
-            self._data[key] = value._data
+            self.values[key] = value.values
         elif self._is_supported_scalar(value):
             # _Timescalar takes care of normalization to nanoseconds
             normval = _Timescalar(value)
-            self._data[key] = normval._data
+            self.values[key] = normval.values
         else:
             return NotImplemented
 
     def min(self):
         __doc__ = super().min.__doc__
         # Return type is pandas scalar
-        return self._scalar_callback(self._data.min())
+        return self._scalar_callback(self.values.min())
 
     def max(self):
         __doc__ = super().max.__doc__
         # Return type is pandas scalar
-        return self._scalar_callback(self._data.max())
+        return self._scalar_callback(self.values.max())
 
     def mink(self, k):
         __doc__ = super().mink.__doc__
         # Return type is same class
-        return self.__class__(self._data.mink(k))
+        return self.__class__(self.values.mink(k))
 
     def maxk(self, k):
         __doc__ = super().maxk.__doc__
         # Return type is same class
-        return self.__class__(self._data.maxk(k))
+        return self.__class__(self.values.maxk(k))
 
 class Datetime(_AbstractBaseTime):
     '''Represents a date and/or time.
@@ -356,7 +359,7 @@ class Datetime(_AbstractBaseTime):
 
     Notes
     -----
-    The ``._data`` attribute is always in nanoseconds with int64 dtype.
+    The ``.values`` attribute is always in nanoseconds with int64 dtype.
     '''
     
     supported_with_datetime = frozenset(('==', '!=', '<', '<=', '>', '>=', '-'))
@@ -426,7 +429,7 @@ class Timedelta(_AbstractBaseTime):
 
     Notes
     -----
-    The ``._data`` attribute is always in nanoseconds with int64 dtype.
+    The ``.values`` attribute is always in nanoseconds with int64 dtype.
     '''
     supported_with_datetime = frozenset(('+'))
     supported_with_r_datetime = frozenset(('+', '-', '/', '//', '%'))
@@ -470,16 +473,16 @@ class Timedelta(_AbstractBaseTime):
         '''
         Returns the standard deviation as a pd.Timedelta object
         '''
-        return self._scalar_callback(self._data.std(ddof=ddof))
+        return self._scalar_callback(self.values.std(ddof=ddof))
 
     def sum(self):
         # Sum as a pd.Timedelta
-        return self._scalar_callback(self._data.sum())
+        return self._scalar_callback(self.values.sum())
 
     def abs(self):
         '''Absolute value of time interval.
         '''
-        return self.__class__(cast(akabs(self._data), 'int64'))
+        return self.__class__(cast(akabs(self.values), 'int64'))
     
     
 def date_range(start=None, end=None, periods=None, freq=None,

--- a/arkouda/timeclass.py
+++ b/arkouda/timeclass.py
@@ -266,8 +266,10 @@ class _AbstractBaseTime(pdarray):
             if op not in self.supported_opeq:
                 raise TypeError("{} {} Timedelta not supported".format(self.__class__.__name__, op))
             if self._is_timedelta_scalar(other):
-                other = _Timescalar(other)
-            self.values.opeq(other.values, op)
+                otherdata = _Timescalar(other).value
+            else:
+                otherdata = other.values
+            self.values.opeq(otherdata, op)
         elif isinstance(other, Datetime) or self._is_datetime_scalar(other):
             raise TypeError("{} {} datetime not supported".format(self.__class__.__name__, op))
         else:
@@ -306,7 +308,7 @@ class _AbstractBaseTime(pdarray):
         elif self._is_supported_scalar(value):
             # _Timescalar takes care of normalization to nanoseconds
             normval = _Timescalar(value)
-            self.values[key] = normval.values
+            self.values[key] = normval.value
         else:
             return NotImplemented
 

--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -81,10 +81,7 @@ def register(a, name):
         # Assign registered name to wrapper object
         reg.name = n
         # Assign same name to underlying pdarray
-        if type(a) in {Datetime, Timedelta}:
-            reg._data.name = n
-        else:
-            reg.values.name = n
+        reg.values.name = n
     else:
         a = a.register(name)
         reg = cb(a)

--- a/tests/client_dtypes_test.py
+++ b/tests/client_dtypes_test.py
@@ -16,12 +16,14 @@ class ClientDTypeTests(ArkoudaTest):
         bv = ak.BitVector(arr, width=3)
         self.assertIsInstance(bv, client_dtypes.BitVector)
         self.assertListEqual(bv.to_ndarray().tolist(), ['...', '..|', '.|.', '.||'])
+        self.assertTrue(bv.dtype == ak.bitType)
 
         # Test reversed
-        arr = ak.arange(4)
+        arr = ak.arange(4, dtype=ak.uint64)  # Also test with uint64 input
         bv = ak.BitVector(arr, width=3, reverse=True)
         self.assertIsInstance(bv, client_dtypes.BitVector)
         self.assertListEqual(bv.to_ndarray().tolist(), ['...', '|..', '.|.', '||.'])
+        self.assertTrue(bv.dtype == ak.bitType)
 
         #test use of vectorizer function
         arr = ak.arange(4)
@@ -29,6 +31,7 @@ class ClientDTypeTests(ArkoudaTest):
         bv = bvectorizer(arr)
         self.assertIsInstance(bv, client_dtypes.BitVector)
         self.assertListEqual(bv.to_ndarray().tolist(), ['...', '..|', '.|.', '.||'])
+        self.assertTrue(bv.dtype == ak.bitType)
 
         #fail on argument types
         with self.assertRaises(TypeError):
@@ -43,6 +46,7 @@ class ClientDTypeTests(ArkoudaTest):
         f = ak.Fields(values, names)
         self.assertIsInstance(f, ak.Fields)
         self.assertListEqual(f.to_ndarray().tolist(), ['---- (0)', '---1 (1)', '--2- (2)', '--21 (3)'])
+        self.assertTrue(f.dtype == ak.bitType)
 
         #Named fields with reversed bit order
         values = ak.array([0, 1, 5, 8, 12])
@@ -57,7 +61,7 @@ class ClientDTypeTests(ArkoudaTest):
         ]
         self.assertListEqual(f.to_ndarray().tolist(), expected)
 
-        values = ak.arange(8)
+        values = ak.arange(8, dtype=ak.uint64)
         names = [f'Bit{x}' for x in range(65)]
         with self.assertRaises(ValueError):
             f = ak.Fields(values, names)
@@ -81,21 +85,32 @@ class ClientDTypeTests(ArkoudaTest):
             f = ak.Fields(values, names, pad='|!~', separator='//')
 
     def test_ipv4_creation(self):
-        ip_list = ak.array([3232235777])
+        # Test handling of int64 input
+        ip_list = ak.array([3232235777], dtype=ak.int64)
         ipv4 = ak.IPv4(ip_list)
 
         self.assertIsInstance(ipv4, ak.IPv4)
         self.assertListEqual(ipv4.to_ndarray().tolist(), ['192.168.1.1'])
+        self.assertTrue(ipv4.dtype == ak.bitType)
+        
+        # Test handling of uint64 input
+        ip_list = ak.array([3232235777], dtype=ak.uint64)
+        ipv4 = ak.IPv4(ip_list)
+
+        self.assertIsInstance(ipv4, ak.IPv4)
+        self.assertListEqual(ipv4.to_ndarray().tolist(), ['192.168.1.1'])
+        self.assertTrue(ipv4.dtype == ak.bitType)
 
         with self.assertRaises(TypeError):
             ipv4 = ak.IPv4('3232235777')
         with self.assertRaises(TypeError):
             ipv4 = ak.IPv4(ak.array([3232235777.177]))
 
-        ip_list = ak.array([3232235777])
-        ipv4 = ak.ip_address(ip_list)
+        # Test handling of python dotted-quad input
+        ipv4 = ak.ip_address(['192.168.1.1'])
         self.assertIsInstance(ipv4, ak.IPv4)
         self.assertListEqual(ipv4.to_ndarray().tolist(), ['192.168.1.1'])
+        self.assertTrue(ipv4.dtype == ak.bitType)
 
     def test_ipv4_normalization(self):
         ip_list = ak.array([3232235777])


### PR DESCRIPTION
This PR updates client dtype classes:
- Accept both uint64 and int64 inputs (but convert underlying values to a standard type)
- Make a copy of the input array. Previously, the `__init__` method of, say, `ak.Datetime`, would call `pdarray.__init__` with the same server-side name as the input array, thus creating a logical reference to the input array that python was not tracking. In some cases, I think this was leading to unknown symbol errors when the input array would go out of scope and the name would get deleted from the server, even though the `Datetime` object still had that name.
- Standardize name of underlying values attribute to `.values` across all classes
- Expand `ak.ip_address()` to accept Python lists, so it can function like `ak.array()` for IP addresses.
- Update unit tests accordingly