### PR TITLE
Closes #1218 Extend `pdarray` setops to work for multiple arrrays

### DIFF
--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -158,7 +158,7 @@ class GroupBy:
             # Most categoricals already store segments and unique keys
             if hasattr(self.keys, 'segments') and cast(Categorical, 
                                                        self.keys).segments is not None:
-                self.unique_keys = cast(Categorical, self.keys).categories
+                self.unique_keys: Any = cast(Categorical, self.keys).categories
                 self.segments = cast(pdarray, cast(Categorical, self.keys).segments)
                 self.ngroups = self.unique_keys.size
                 return

--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -10,8 +10,6 @@ from arkouda.pdarrayclass import pdarray, create_pdarray
 from arkouda.sorting import argsort, coargsort
 from arkouda.strings import Strings
 from arkouda.pdarraycreation import array, zeros, arange
-from arkouda.pdarraysetops import concatenate
-from arkouda.numeric import cumsum
 from arkouda.logger import getArkoudaLogger
 from arkouda.dtypes import int64, uint64
 

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -622,7 +622,7 @@ def setxor1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, ...]],
     array([1, 4, 5, 7])
 
     #Multi-Array Example
-    >>> a = ak.arange(5)
+    >>> a = ak.arange(1, 6)
     >>> b = ak.array([1, 5, 3, 4, 2])
     >>> c = ak.array([1, 4, 3, 2, 5])
     >>> d = ak.array([1, 2, 3, 5, 4])

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -565,8 +565,7 @@ def setdiff1d(pda1: Union[pdarray, List[pdarray]], pda2: Union[pdarray, List[pda
                 raise ValueError("Called with assume_unique=True, but second argument is not unique")
         k, ct = g.count()
         truth = g.broadcast(ct == 1, permute=True)
-        atruth = ag.broadcast(truth[isa], permute=True)
-        return [x[atruth] for x in ua]
+        return [x[truth[isa]] for x in ua]
     else:
         raise TypeError('Both pda1 and pda2 must be pdarray or list')
 
@@ -667,17 +666,7 @@ def setxor1d(pda1: Union[pdarray, List[pdarray]], pda2: Union[pdarray, List[pdar
                 raise ValueError("Called with assume_unique=True, but second argument is not unique")
         k, ct = g.count()
         truth = g.broadcast(ct == 1, permute=True)
-        atruth = ag.broadcast(truth[isa], permute=True)
-        btruth = bg.broadcast(truth[~isa], permute=True)
-        afilter = [x[atruth] for x in pda1]
-        bfilter = [x[btruth] for x in pda2]
-        afg = GroupBy(afilter)
-        afu = afg.unique_keys
-        bfg = GroupBy(bfilter)
-        bfu = bfg.unique_keys
-        cfilter = [concatenate(x, ordered=False) for x in zip(afu, bfu)]
-        gfg = GroupBy(cfilter)
-        kfilter, ctfilter = gfg.count()
-        return kfilter
+        rtn = [x[truth] for x in c]
+        return rtn
     else:
         raise TypeError('Both pda1 and pda2 must be pdarray or list')

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -286,7 +286,7 @@ def multiarray_setop_validation(pda1: List[pdarray], pda2: List[pdarray]):
         raise ValueError("multi-array setops require arrays in pda2 be the same size.")
     atypes = [x.dtype for x in pda1]
     btypes = [x.dtype for x in pda2]
-    if not (atypes == btypes).all():
+    if not atypes == btypes:
         raise TypeError("Array dtypes of arguments must match")
 
 # (A1 | A2) Set Union: elements are in one or the other or both

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -454,7 +454,7 @@ def intersect1d(pda1: Union[pdarray, List[pdarray]], pda2: Union[pdarray, List[p
             ub = bg.unique_keys
         else:
             ua = pda1
-            ub = pda1
+            ub = pda2
 
         # Key for deinterleaving result
         isa = concatenate((ones(ua[0].size, dtype=akbool), zeros(ub[0].size, dtype=akbool)), ordered=False)
@@ -551,7 +551,7 @@ def setdiff1d(pda1: Union[pdarray, List[pdarray]], pda2: Union[pdarray, List[pda
             ub = bg.unique_keys
         else:
             ua = pda1
-            ub = pda1
+            ub = pda2
 
         # Key for deinterleaving result
         isa = concatenate((ones(ua[0].size, dtype=akbool), zeros(ub[0].size, dtype=akbool)), ordered=False)
@@ -652,7 +652,7 @@ def setxor1d(pda1: Union[pdarray, List[pdarray]], pda2: Union[pdarray, List[pdar
             ub = bg.unique_keys
         else:
             ua = pda1
-            ub = pda1
+            ub = pda2
 
         # Key for deinterleaving result
         isa = concatenate((ones(ua[0].size, dtype=akbool), zeros(ub[0].size, dtype=akbool)), ordered=False)

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -294,21 +294,21 @@ def multiarray_setop_validation(pda1: List[pdarray], pda2: List[pdarray]):
 def union1d(pda1: Union[pdarray, List[pdarray]], pda2: Union[pdarray, List[pdarray]]) -> \
         Union[pdarray, List[pdarray]]:
     """
-    Find the union of two arrays.
+    Find the union of two arrays/List of Arrays.
 
     Return the unique, sorted array of values that are in either 
     of the two input arrays.
 
     Parameters
     ----------
-    pda1 : pdarray
-        Input array
-    pda2 : pdarray
-        Input array
+    pda1 : pdarray/List
+        Input array/List of input arrays
+    pda2 : pdarray/List
+        Input array/List of input arrays
 
     Returns
     -------
-    pdarray
+    pdarray/List
         Unique, sorted union of the input arrays.
         
     Raises
@@ -328,8 +328,19 @@ def union1d(pda1: Union[pdarray, List[pdarray]], pda2: Union[pdarray, List[pdarr
 
     Examples
     --------
+    # 1D Example
     >>> ak.union1d(ak.array([-1, 0, 1]), ak.array([-2, 0, 2]))
     array([-2, -1, 0, 1, 2])
+
+    #Multi-Array Example
+    >>> a = ak.arange(5)
+    >>> b = ak.array([1, 5, 3, 4, 2])
+    >>> c = ak.array([1, 4, 3, 2, 5])
+    >>> d = ak.array([1, 2, 3, 5, 4])
+    >>> multia = [a, a, a]
+    >>> multib = [b, c, d]
+    >>> ak.union1d(multia, multib)
+    [array[1, 2, 2, 3, 4, 4, 5, 5], array[1, 2, 5, 3, 2, 4, 4, 5], array[1, 2, 4, 3, 4, 5, 2, 5]]
     """
     if isinstance(pda1, pdarray) and isinstance(pda2, pdarray):
         if pda1.size == 0:
@@ -370,18 +381,18 @@ def intersect1d(pda1: Union[pdarray, List[pdarray]], pda2: Union[pdarray, List[p
 
     Parameters
     ----------
-    pda1 : pdarray
-        Input array
-    pda2 : pdarray
-        Input array
+    pda1 : pdarray/List
+        Input array/List of input arrays
+    pda2 : pdarray/List
+        Input array/List of input arrays
     assume_unique : bool
         If True, the input arrays are both assumed to be unique, which
         can speed up the calculation.  Default is False.
 
     Returns
     -------
-    pdarray
-        Sorted 1D array of common and unique elements.
+    pdarray/List
+        Sorted 1D array/List of sorted pdarrays of common and unique elements.
 
     Raises
     ------
@@ -400,8 +411,19 @@ def intersect1d(pda1: Union[pdarray, List[pdarray]], pda2: Union[pdarray, List[p
 
     Examples
     --------
+    # 1D Example
     >>> ak.intersect1d([1, 3, 4, 3], [3, 1, 2, 1])
     array([1, 3])
+
+    # Multi-Array Example
+    >>> a = ak.arange(5)
+    >>> b = ak.array([1, 5, 3, 4, 2])
+    >>> c = ak.array([1, 4, 3, 2, 5])
+    >>> d = ak.array([1, 2, 3, 5, 4])
+    >>> multia = [a, a, a]
+    >>> multib = [b, c, d]
+    >>> ak.intersect1d(multia, multib)
+    [array([1, 3]), array([1, 3]), array([1, 3])]
     """
     if isinstance(pda1, pdarray) and isinstance(pda2, pdarray):
         if pda1.size == 0:
@@ -460,18 +482,18 @@ def setdiff1d(pda1: Union[pdarray, List[pdarray]], pda2: Union[pdarray, List[pda
 
     Parameters
     ----------
-    pda1 : pdarray
-        Input array.
-    pda2 : pdarray
-        Input comparison array.
+    pda1 : pdarray/List
+        Input array/List of input arrays
+    pda2 : pdarray/List
+        Input array/List of input arrays
     assume_unique : bool
         If True, the input arrays are both assumed to be unique, which
         can speed up the calculation.  Default is False.
 
     Returns
     -------
-    pdarray
-        Sorted 1D array of values in `pda1` that are not in `pda2`.
+    pdarray/List
+        Sorted 1D array/List of sorted pdarrays of values in `pda1` that are not in `pda2`.
 
     Raises
     ------
@@ -494,6 +516,16 @@ def setdiff1d(pda1: Union[pdarray, List[pdarray]], pda2: Union[pdarray, List[pda
     >>> b = ak.array([3, 4, 5, 6])
     >>> ak.setdiff1d(a, b)
     array([1, 2])
+
+    #Multi-Array Example
+    >>> a = ak.arange(5)
+    >>> b = ak.array([1, 5, 3, 4, 2])
+    >>> c = ak.array([1, 4, 3, 2, 5])
+    >>> d = ak.array([1, 2, 3, 5, 4])
+    >>> multia = [a, a, a]
+    >>> multib = [b, c, d]
+    >>> ak.setdiff1d(multia, multib)
+    [array([2, 4, 5]), array([2, 4, 5]), array([2, 4, 5])]
     """
     if isinstance(pda1, pdarray) and isinstance(pda2, pdarray):
         if pda1.size == 0:
@@ -551,9 +583,9 @@ def setxor1d(pda1: Union[pdarray, List[pdarray]], pda2: Union[pdarray, List[pdar
 
     Parameters
     ----------
-    pda1 : pdarray
+    pda1 : pdarray/List
         Input array.
-    pda2 : pdarray
+    pda2 : pdarray/List
         Input array.
     assume_unique : bool
         If True, the input arrays are both assumed to be unique, which
@@ -561,8 +593,8 @@ def setxor1d(pda1: Union[pdarray, List[pdarray]], pda2: Union[pdarray, List[pdar
 
     Returns
     -------
-    pdarray
-        Sorted 1D array of unique values that are in only one of the input
+    pdarray/List
+        Sorted 1D array/List of sorted pdarrays of unique values that are in only one of the input
         arrays.
 
     Raises
@@ -582,6 +614,16 @@ def setxor1d(pda1: Union[pdarray, List[pdarray]], pda2: Union[pdarray, List[pdar
     >>> b = ak.array([2, 3, 5, 7, 5])
     >>> ak.setxor1d(a,b)
     array([1, 4, 5, 7])
+
+    #Multi-Array Example
+    >>> a = ak.arange(5)
+    >>> b = ak.array([1, 5, 3, 4, 2])
+    >>> c = ak.array([1, 4, 3, 2, 5])
+    >>> d = ak.array([1, 2, 3, 5, 4])
+    >>> multia = [a, a, a]
+    >>> multib = [b, c, d]
+    >>> ak.setdiff1d(multia, multib)
+    [array([2, 2, 4, 4, 5, 5]), array([2, 5, 2, 4, 4, 5]), array([2, 4, 5, 4, 2, 5])]
     """
     if isinstance(pda1, pdarray) and isinstance(pda2, pdarray):
         if pda1.size == 0:

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -667,6 +667,7 @@ def setxor1d(pda1: Union[pdarray, List[pdarray]], pda2: Union[pdarray, List[pdar
         k, ct = g.count()
         truth = g.broadcast(ct == 1, permute=True)
         rtn = [x[truth] for x in c]
-        return rtn
+        keys, ct = GroupBy(rtn).count()
+        return keys
     else:
         raise TypeError('Both pda1 and pda2 must be pdarray or list')

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -346,7 +346,6 @@ def union1d(pda1: Union[pdarray, List[pdarray]], pda2: Union[pdarray, List[pdarr
                                 concatenate((unique(pda1), unique(pda2)), ordered=False))))  # type: ignore
     elif isinstance(pda1, list) and isinstance(pda2, list):
         multiarray_setop_validation(pda1, pda2)
-
         ag = GroupBy(pda1)
         ua = ag.unique_keys
         bg = GroupBy(pda2)

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -335,14 +335,14 @@ def union1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, ...]],
     array([-2, -1, 0, 1, 2])
 
     #Multi-Array Example
-    >>> a = ak.arange(5)
+    >>> a = ak.arange(1, 6)
     >>> b = ak.array([1, 5, 3, 4, 2])
     >>> c = ak.array([1, 4, 3, 2, 5])
     >>> d = ak.array([1, 2, 3, 5, 4])
     >>> multia = [a, a, a]
     >>> multib = [b, c, d]
     >>> ak.union1d(multia, multib)
-    [array[1, 2, 2, 3, 4, 4, 5, 5], array[1, 2, 5, 3, 2, 4, 4, 5], array[1, 2, 4, 3, 4, 5, 2, 5]]
+    [array[1, 2, 2, 3, 4, 4, 5, 5], array[1, 2, 5, 3, 2, 4, 4, 5], array[1, 2, 4, 3, 5, 4, 2, 5]]
     """
     if isinstance(pda1, pdarray) and isinstance(pda2, pdarray):
         if pda1.size == 0:
@@ -357,7 +357,7 @@ def union1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, ...]],
         return cast(pdarray,
                     unique(cast(pdarray,
                                 concatenate((unique(pda1), unique(pda2)), ordered=False))))  # type: ignore
-    elif (isinstance(pda1, list) and isinstance(pda2, list)) or (isinstance(pda1, tuple) and isinstance(pda2, tuple)):
+    elif (isinstance(pda1, list) or isinstance(pda1, tuple)) and (isinstance(pda2, list) or isinstance(pda2, tuple)):
         multiarray_setop_validation(pda1, pda2)
         ag = GroupBy(pda1)
         ua = ag.unique_keys
@@ -369,7 +369,7 @@ def union1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, ...]],
         k, ct = g.count()
         return k
     else:
-        raise TypeError('Both pda1 and pda2 must be pdarray or list')
+        raise TypeError(f'Both pda1 and pda2 must be pdarray, List, or Tuple. Received {type(pda1)} and {type(pda2)}')
 
 
 # (A1 & A2) Set Intersection: elements have to be in both arrays
@@ -447,7 +447,7 @@ def intersect1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, ...]],
         mask = aux[1:] == aux[:-1]
         int1d = aux[:-1][mask]
         return int1d
-    elif (isinstance(pda1, list) and isinstance(pda2, list)) or (isinstance(pda1, tuple) and isinstance(pda2, tuple)):
+    elif (isinstance(pda1, list) or isinstance(pda1, tuple)) and (isinstance(pda2, list) or isinstance(pda2, tuple)):
         multiarray_setop_validation(pda1, pda2)
 
         if not assume_unique:
@@ -473,7 +473,7 @@ def intersect1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, ...]],
         in_union = ct == 2
         return [x[in_union] for x in k]
     else:
-        raise TypeError('Both pda1 and pda2 must be pdarray or list')
+        raise TypeError(f'Both pda1 and pda2 must be pdarray, List, or Tuple. Received {type(pda1)} and {type(pda2)}')
 
 # (A1 - A2) Set Difference: elements have to be in first array but not second
 @typechecked
@@ -523,7 +523,7 @@ def setdiff1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, ...]],
     array([1, 2])
 
     #Multi-Array Example
-    >>> a = ak.arange(5)
+    >>> a = ak.arange(1, 6)
     >>> b = ak.array([1, 5, 3, 4, 2])
     >>> c = ak.array([1, 4, 3, 2, 5])
     >>> d = ak.array([1, 2, 3, 5, 4])
@@ -546,7 +546,7 @@ def setdiff1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, ...]],
             pda1 = cast(pdarray, unique(pda1))
             pda2 = cast(pdarray, unique(pda2))
         return pda1[in1d(pda1, pda2, invert=True)]
-    elif (isinstance(pda1, list) and isinstance(pda2, list)) or (isinstance(pda1, tuple) and isinstance(pda2, tuple)):
+    elif (isinstance(pda1, list) or isinstance(pda1, tuple)) and (isinstance(pda2, list) or isinstance(pda2, tuple)):
         multiarray_setop_validation(pda1, pda2)
 
         if not assume_unique:
@@ -573,7 +573,7 @@ def setdiff1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, ...]],
         atruth = truth[isa]
         return [x[atruth] for x in ua]
     else:
-        raise TypeError('Both pda1 and pda2 must be pdarray or list')
+        raise TypeError(f'Both pda1 and pda2 must be pdarray, List, or Tuple. Received {type(pda1)} and {type(pda2)}')
 
 
 # (A1 ^ A2) Set Symmetric Difference: elements are not in the intersection
@@ -628,7 +628,7 @@ def setxor1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, ...]],
     >>> d = ak.array([1, 2, 3, 5, 4])
     >>> multia = [a, a, a]
     >>> multib = [b, c, d]
-    >>> ak.setdiff1d(multia, multib)
+    >>> ak.setxor1d(multia, multib)
     [array([2, 2, 4, 4, 5, 5]), array([2, 5, 2, 4, 4, 5]), array([2, 4, 5, 4, 2, 5])]
     """
     if isinstance(pda1, pdarray) and isinstance(pda2, pdarray):
@@ -649,7 +649,7 @@ def setxor1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, ...]],
         aux = aux[aux_sort_indices]
         flag = concatenate((array([True]), aux[1:] != aux[:-1], array([True])))
         return aux[flag[1:] & flag[:-1]]
-    elif (isinstance(pda1, list) and isinstance(pda2, list)) or (isinstance(pda1, tuple) and isinstance(pda2, tuple)):
+    elif (isinstance(pda1, list) or isinstance(pda1, tuple)) and (isinstance(pda2, list) or isinstance(pda2, tuple)):
         multiarray_setop_validation(pda1, pda2)
 
         if not assume_unique:

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -9,7 +9,7 @@ from arkouda.strings import Strings
 from arkouda.logger import getArkoudaLogger
 from arkouda.dtypes import uint64 as akuint64
 from arkouda.dtypes import bool as akbool
-from arkouda.groupbyclass import GroupBy
+from arkouda.groupbyclass import GroupBy, groupable
 
 Categorical = ForwardRef('Categorical')
 
@@ -292,7 +292,7 @@ def multiarray_setop_validation(pda1: List[pdarray], pda2: List[pdarray]):
 # (A1 | A2) Set Union: elements are in one or the other or both
 @typechecked
 def union1d(pda1: Union[pdarray, List[pdarray]], pda2: Union[pdarray, List[pdarray]]) -> \
-        Union[pdarray, List[pdarray]]:
+        Union[pdarray, groupable]:
     """
     Find the union of two arrays/List of Arrays.
 
@@ -373,7 +373,7 @@ def union1d(pda1: Union[pdarray, List[pdarray]], pda2: Union[pdarray, List[pdarr
 # (A1 & A2) Set Intersection: elements have to be in both arrays
 @typechecked
 def intersect1d(pda1: Union[pdarray, List[pdarray]], pda2: Union[pdarray, List[pdarray]],
-                assume_unique: bool = False) -> Union[pdarray, List[pdarray]]:
+                assume_unique: bool = False) -> Union[pdarray, groupable]:
     """
     Find the intersection of two arrays.
 
@@ -474,7 +474,7 @@ def intersect1d(pda1: Union[pdarray, List[pdarray]], pda2: Union[pdarray, List[p
 # (A1 - A2) Set Difference: elements have to be in first array but not second
 @typechecked
 def setdiff1d(pda1: Union[pdarray, List[pdarray]], pda2: Union[pdarray, List[pdarray]],
-              assume_unique: bool = False) -> Union[pdarray, List[pdarray]]:
+              assume_unique: bool = False) -> Union[pdarray, groupable]:
     """
     Find the set difference of two arrays.
 
@@ -573,7 +573,7 @@ def setdiff1d(pda1: Union[pdarray, List[pdarray]], pda2: Union[pdarray, List[pda
 # (A1 ^ A2) Set Symmetric Difference: elements are not in the intersection
 @typechecked
 def setxor1d(pda1: Union[pdarray, List[pdarray]], pda2: Union[pdarray, List[pdarray]],
-             assume_unique: bool = False) -> Union[pdarray, List[pdarray]]:
+             assume_unique: bool = False) -> Union[pdarray, groupable]:
     """
     Find the set exclusive-or (symmetric difference) of two arrays.
 

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -850,7 +850,7 @@ class SegArray:
             segments[k] = g.segments
             truth = ~self._non_empty | ~other._non_empty
             if truth[-1]:
-                segments[-1] = new_values[g.permutation].size
+                segments[-1] = g.permutation.size
                 truth[-1] = False
             segments[truth] = segments[arange(self.size)[truth] + 1]
             return SegArray(segments, new_values[g.permutation])
@@ -902,7 +902,7 @@ class SegArray:
             segments[k] = g.segments
             truth = ~self._non_empty | ~other._non_empty
             if truth[-1]:
-                segments[-1] = new_values[g.permutation].size
+                segments[-1] = g.permutation.size
                 truth[-1] = False
             segments[truth] = segments[arange(self.size)[truth] + 1]
             return SegArray(segments, new_values[g.permutation])
@@ -954,7 +954,7 @@ class SegArray:
             segments[k] = g.segments
             truth = ~self._non_empty | ~other._non_empty
             if truth[-1]:
-                segments[-1] = new_values[g.permutation].size
+                segments[-1] = g.permutation.size
                 truth[-1] = False
             segments[truth] = segments[arange(self.size)[truth] + 1]
             return SegArray(segments, new_values[g.permutation])
@@ -1006,7 +1006,7 @@ class SegArray:
             segments[k] = g.segments
             truth = ~self._non_empty | ~other._non_empty
             if truth[-1]:
-                segments[-1] = new_values[g.permutation].size
+                segments[-1] = g.permutation.size
                 truth[-1] = False
             segments[truth] = segments[arange(self.size)[truth] + 1]
             return SegArray(segments, new_values[g.permutation])

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -805,37 +805,76 @@ class SegArray:
 
     def intersect_ma(self, other):
         from arkouda.pdarraysetops import intersect1d
-        a_seg_inds = self.grouping.broadcast(arange(self.size))
-        b_seg_inds = other.grouping.broadcast(arange(other.size))
+        a_seg_inds = self.grouping.broadcast(arange(self.size)[self._non_empty])
+        b_seg_inds = other.grouping.broadcast(arange(other.size)[other._non_empty])
         (new_seg_inds, new_values) = intersect1d([a_seg_inds, self.values], [b_seg_inds, other.values])
         g = GroupBy(new_seg_inds)
-        # TODO: Possibly add logic to insert empty segments where intersection is empty
-        return SegArray(g.segments, new_values[g.permutation])
+        if g.segments.size == self.size:
+            return SegArray(g.segments, new_values[g.permutation])
+        else:
+            segments = zeros(self.size, dtype=akint64)
+            k, ct = g.count()
+            segments[k] = g.segments
+            truth = ~self._non_empty | ~other._non_empty
+            segments[-1] = new_values[g.permutation].size if truth[-1] else segments[-1]
+            truth[-1] = False
+            segments[truth] = segments[arange(self.size)[truth] + 1]
+            return SegArray(segments, new_values[g.permutation])
 
     def union_ma(self, other):
         from arkouda.pdarraysetops import union1d
-        a_seg_inds = self.grouping.broadcast(arange(self.size))
-        b_seg_inds = other.grouping.broadcast(arange(other.size))
+
+        a_seg_inds = self.grouping.broadcast(arange(self.size)[self._non_empty])
+        b_seg_inds = other.grouping.broadcast(arange(other.size)[other._non_empty])
         (new_seg_inds, new_values) = union1d([a_seg_inds, self.values], [b_seg_inds, other.values])
         g = GroupBy(new_seg_inds)
-        # TODO: Possibly add logic to insert empty segments where intersection is empty
-        return SegArray(g.segments, new_values[g.permutation])
+        if g.segments.size == self.size:
+            return SegArray(g.segments, new_values[g.permutation])
+        else:
+            segments = zeros(self.size, dtype=akint64)
+            k, ct = g.count()
+            segments[k] = g.segments
+            truth = ~self._non_empty | ~other._non_empty
+            segments[-1] = new_values[g.permutation].size if truth[-1] else segments[-1]
+            truth[-1] = False
+            segments[truth] = segments[arange(self.size)[truth] + 1]
+            return SegArray(segments, new_values[g.permutation])
 
     def setdiff_ma(self, other):
         from arkouda.pdarraysetops import setdiff1d
-        a_seg_inds = self.grouping.broadcast(arange(self.size))
-        b_seg_inds = other.grouping.broadcast(arange(other.size))
+        a_seg_inds = self.grouping.broadcast(arange(self.size)[self._non_empty])
+        b_seg_inds = other.grouping.broadcast(arange(other.size)[other._non_empty])
         (new_seg_inds, new_values) = setdiff1d([a_seg_inds, self.values], [b_seg_inds, other.values])
         g = GroupBy(new_seg_inds)
-        # TODO: Possibly add logic to insert empty segments where intersection is empty
-        return SegArray(g.segments, new_values[g.permutation])
+        if g.segments.size == self.size:
+            return SegArray(g.segments, new_values[g.permutation])
+        else:
+            segments = zeros(self.size, dtype=akint64)
+            k, ct = g.count()
+            segments[k] = g.segments
+            truth = ~self._non_empty | ~other._non_empty
+            segments[-1] = new_values[g.permutation].size if truth[-1] else segments[-1]
+            truth[-1] = False
+            segments[truth] = segments[arange(self.size)[truth] + 1]
+            return SegArray(segments, new_values[g.permutation])
 
     def setxor_ma(self, other):
         from arkouda.pdarraysetops import setxor1d
-        a_seg_inds = self.grouping.broadcast(arange(self.size))
-        b_seg_inds = other.grouping.broadcast(arange(other.size))
+        a_seg_inds = self.grouping.broadcast(arange(self.size)[self._non_empty])
+        b_seg_inds = other.grouping.broadcast(arange(other.size)[other._non_empty])
         (new_seg_inds, new_values) = setxor1d([a_seg_inds, self.values], [b_seg_inds, other.values])
         g = GroupBy(new_seg_inds)
-        # TODO: Possibly add logic to insert empty segments where inter
+        if g.segments.size == self.size:
+            return SegArray(g.segments, new_values[g.permutation])
+        else:
+            segments = zeros(self.size, dtype=akint64)
+            k, ct = g.count()
+            segments[k] = g.segments
+            truth = ~self._non_empty | ~other._non_empty
+            segments[-1] = new_values[g.permutation].size if truth[-1] else segments[-1]
+            truth[-1] = False
+            segments[truth] = segments[arange(self.size)[truth] + 1]
+            return SegArray(segments, new_values[g.permutation])
+
 # Register/Attach functionality has been removed until it is added for GroupBy.
 # Please refer to ticket #1122 (https://github.com/Bears-R-Us/arkouda/issues/1122 for updates

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -803,7 +803,7 @@ class SegArray:
         values = load(prefix_path, dataset=dataset + value_suffix)
         return cls(segments, values)
 
-    def intersect_ma(self, other):
+    def intersect(self, other):
         """
         Computes the intersection of 2 SegArrays.
 
@@ -829,7 +829,7 @@ class SegArray:
         >>> d = [2, 2, 4]
         >>> seg_a = ak.SegArray(ak.array([0, len(a)]), ak.array(a+b))
         >>> seg_b = ak.SegArray(ak.array([0, len(c)]), ak.array(c+d))
-        >>> seg_a.intersect_ma(seg_b)
+        >>> seg_a.intersect(seg_b)
         SegArray([
         [1, 3],
         [4]
@@ -856,7 +856,7 @@ class SegArray:
             segments[truth] = segments[arange(self.size)[truth] + 1]
             return SegArray(segments, new_values[g.permutation])
 
-    def union_ma(self, other):
+    def union(self, other):
         """
         Computes the union of 2 SegArrays.
 
@@ -882,7 +882,7 @@ class SegArray:
         >>> d = [2, 2, 4]
         >>> seg_a = ak.SegArray(ak.array([0, len(a)]), ak.array(a+b))
         >>> seg_b = ak.SegArray(ak.array([0, len(c)]), ak.array(c+d))
-        >>> seg_a.union_ma(seg_b)
+        >>> seg_a.union(seg_b)
         SegArray([
         [1, 2, 3, 4, 5],
         [1, 2, 3, 4, 5]
@@ -909,7 +909,7 @@ class SegArray:
             segments[truth] = segments[arange(self.size)[truth] + 1]
             return SegArray(segments, new_values[g.permutation])
 
-    def setdiff_ma(self, other):
+    def setdiff(self, other):
         """
         Computes the set difference of 2 SegArrays.
 
@@ -935,7 +935,7 @@ class SegArray:
         >>> d = [2, 2, 4]
         >>> seg_a = ak.SegArray(ak.array([0, len(a)]), ak.array(a+b))
         >>> seg_b = ak.SegArray(ak.array([0, len(c)]), ak.array(c+d))
-        >>> seg_a.setdiff_ma(seg_b)
+        >>> seg_a.setdiff(seg_b)
         SegArray([
         [2, 4],
         [1, 3, 5]
@@ -962,7 +962,7 @@ class SegArray:
             segments[truth] = segments[arange(self.size)[truth] + 1]
             return SegArray(segments, new_values[g.permutation])
 
-    def setxor_ma(self, other):
+    def setxor(self, other):
         """
         Computes the symmetric difference of 2 SegArrays.
 
@@ -988,7 +988,7 @@ class SegArray:
         >>> d = [2, 2, 4]
         >>> seg_a = ak.SegArray(ak.array([0, len(a)]), ak.array(a+b))
         >>> seg_b = ak.SegArray(ak.array([0, len(c)]), ak.array(c+d))
-        >>> seg_a.setxor_ma(seg_b)
+        >>> seg_a.setxor(seg_b)
         SegArray([
         [2, 4, 5],
         [1, 3, 5, 2]

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -804,7 +804,25 @@ class SegArray:
         return cls(segments, values)
 
     def intersect_ma(self, other):
+        """
+        Computes the intersection of 2 SegArrays.
+
+        Parameters
+        ----------
+        other : SegArray
+            SegArray to compute against
+
+        Returns
+        -------
+        SegArray
+            Segments are the 1d intersections of the segments of self and other
+
+        See Also
+        --------
+        pdarraysetops.intersect1d
+        """
         from arkouda.pdarraysetops import intersect1d
+
         a_seg_inds = self.grouping.broadcast(arange(self.size)[self._non_empty])
         b_seg_inds = other.grouping.broadcast(arange(other.size)[other._non_empty])
         (new_seg_inds, new_values) = intersect1d([a_seg_inds, self.values], [b_seg_inds, other.values])
@@ -822,6 +840,23 @@ class SegArray:
             return SegArray(segments, new_values[g.permutation])
 
     def union_ma(self, other):
+        """
+        Computes the union of 2 SegArrays.
+
+        Parameters
+        ----------
+        other : SegArray
+            SegArray to compute against
+
+        Returns
+        -------
+        SegArray
+            Segments are the 1d union of the segments of self and other
+
+        See Also
+        --------
+        pdarraysetops.union1d
+        """
         from arkouda.pdarraysetops import union1d
 
         a_seg_inds = self.grouping.broadcast(arange(self.size)[self._non_empty])
@@ -841,7 +876,25 @@ class SegArray:
             return SegArray(segments, new_values[g.permutation])
 
     def setdiff_ma(self, other):
+        """
+        Computes the set difference of 2 SegArrays.
+
+        Parameters
+        ----------
+        other : SegArray
+            SegArray to compute against
+
+        Returns
+        -------
+        SegArray
+            Segments are the 1d set difference of the segments of self and other
+
+        See Also
+        --------
+        pdarraysetops.setdiff1d
+        """
         from arkouda.pdarraysetops import setdiff1d
+
         a_seg_inds = self.grouping.broadcast(arange(self.size)[self._non_empty])
         b_seg_inds = other.grouping.broadcast(arange(other.size)[other._non_empty])
         (new_seg_inds, new_values) = setdiff1d([a_seg_inds, self.values], [b_seg_inds, other.values])
@@ -859,7 +912,25 @@ class SegArray:
             return SegArray(segments, new_values[g.permutation])
 
     def setxor_ma(self, other):
+        """
+        Computes the symmetric difference of 2 SegArrays.
+
+        Parameters
+        ----------
+        other : SegArray
+            SegArray to compute against
+
+        Returns
+        -------
+        SegArray
+            Segments are the 1d symmetric difference of the segments of self and other
+
+        See Also
+        --------
+        pdarraysetops.setxor1d
+        """
         from arkouda.pdarraysetops import setxor1d
+        
         a_seg_inds = self.grouping.broadcast(arange(self.size)[self._non_empty])
         b_seg_inds = other.grouping.broadcast(arange(other.size)[other._non_empty])
         (new_seg_inds, new_values) = setxor1d([a_seg_inds, self.values], [b_seg_inds, other.values])
@@ -871,8 +942,9 @@ class SegArray:
             k, ct = g.count()
             segments[k] = g.segments
             truth = ~self._non_empty | ~other._non_empty
-            segments[-1] = new_values[g.permutation].size if truth[-1] else segments[-1]
-            truth[-1] = False
+            if truth[-1]:
+                segments[-1] = new_values[g.permutation].size
+                truth[-1] = False
             segments[truth] = segments[arange(self.size)[truth] + 1]
             return SegArray(segments, new_values[g.permutation])
 

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -820,6 +820,20 @@ class SegArray:
         See Also
         --------
         pdarraysetops.intersect1d
+
+        Examples
+        --------
+        >>> a = [1, 2, 3, 1, 4]
+        >>> b = [3, 1, 4, 5]
+        >>> c = [1, 3, 3, 5]
+        >>> d = [2, 2, 4]
+        >>> seg_a = ak.SegArray(ak.array([0, len(a)]), ak.array(a+b))
+        >>> seg_b = ak.SegArray(ak.array([0, len(c)]), ak.array(c+d))
+        >>> seg_a.intersect_ma(seg_b)
+        SegArray([
+        [1, 3],
+        [4]
+        ])
         """
         from arkouda.pdarraysetops import intersect1d
 
@@ -827,6 +841,7 @@ class SegArray:
         b_seg_inds = other.grouping.broadcast(arange(other.size)[other._non_empty])
         (new_seg_inds, new_values) = intersect1d([a_seg_inds, self.values], [b_seg_inds, other.values])
         g = GroupBy(new_seg_inds)
+        # This method does not return any empty resulting segments. We need to add these if they are missing.
         if g.segments.size == self.size:
             return SegArray(g.segments, new_values[g.permutation])
         else:
@@ -834,8 +849,9 @@ class SegArray:
             k, ct = g.count()
             segments[k] = g.segments
             truth = ~self._non_empty | ~other._non_empty
-            segments[-1] = new_values[g.permutation].size if truth[-1] else segments[-1]
-            truth[-1] = False
+            if truth[-1]:
+                segments[-1] = new_values[g.permutation].size
+                truth[-1] = False
             segments[truth] = segments[arange(self.size)[truth] + 1]
             return SegArray(segments, new_values[g.permutation])
 
@@ -856,6 +872,20 @@ class SegArray:
         See Also
         --------
         pdarraysetops.union1d
+
+        Examples
+        --------
+        >>> a = [1, 2, 3, 1, 4]
+        >>> b = [3, 1, 4, 5]
+        >>> c = [1, 3, 3, 5]
+        >>> d = [2, 2, 4]
+        >>> seg_a = ak.SegArray(ak.array([0, len(a)]), ak.array(a+b))
+        >>> seg_b = ak.SegArray(ak.array([0, len(c)]), ak.array(c+d))
+        >>> seg_a.union_ma(seg_b)
+        SegArray([
+        [1, 2, 3, 4, 5],
+        [1, 2, 3, 4, 5]
+        ])
         """
         from arkouda.pdarraysetops import union1d
 
@@ -863,6 +893,7 @@ class SegArray:
         b_seg_inds = other.grouping.broadcast(arange(other.size)[other._non_empty])
         (new_seg_inds, new_values) = union1d([a_seg_inds, self.values], [b_seg_inds, other.values])
         g = GroupBy(new_seg_inds)
+        # This method does not return any empty resulting segments. We need to add these if they are missing.
         if g.segments.size == self.size:
             return SegArray(g.segments, new_values[g.permutation])
         else:
@@ -870,8 +901,9 @@ class SegArray:
             k, ct = g.count()
             segments[k] = g.segments
             truth = ~self._non_empty | ~other._non_empty
-            segments[-1] = new_values[g.permutation].size if truth[-1] else segments[-1]
-            truth[-1] = False
+            if truth[-1]:
+                segments[-1] = new_values[g.permutation].size
+                truth[-1] = False
             segments[truth] = segments[arange(self.size)[truth] + 1]
             return SegArray(segments, new_values[g.permutation])
 
@@ -892,6 +924,20 @@ class SegArray:
         See Also
         --------
         pdarraysetops.setdiff1d
+
+        Examples
+        --------
+        >>> a = [1, 2, 3, 1, 4]
+        >>> b = [3, 1, 4, 5]
+        >>> c = [1, 3, 3, 5]
+        >>> d = [2, 2, 4]
+        >>> seg_a = ak.SegArray(ak.array([0, len(a)]), ak.array(a+b))
+        >>> seg_b = ak.SegArray(ak.array([0, len(c)]), ak.array(c+d))
+        >>> seg_a.setdiff_ma(seg_b)
+        SegArray([
+        [2, 4],
+        [1, 3, 5]
+        ])
         """
         from arkouda.pdarraysetops import setdiff1d
 
@@ -899,6 +945,7 @@ class SegArray:
         b_seg_inds = other.grouping.broadcast(arange(other.size)[other._non_empty])
         (new_seg_inds, new_values) = setdiff1d([a_seg_inds, self.values], [b_seg_inds, other.values])
         g = GroupBy(new_seg_inds)
+        # This method does not return any empty resulting segments. We need to add these if they are missing.
         if g.segments.size == self.size:
             return SegArray(g.segments, new_values[g.permutation])
         else:
@@ -906,8 +953,9 @@ class SegArray:
             k, ct = g.count()
             segments[k] = g.segments
             truth = ~self._non_empty | ~other._non_empty
-            segments[-1] = new_values[g.permutation].size if truth[-1] else segments[-1]
-            truth[-1] = False
+            if truth[-1]:
+                segments[-1] = new_values[g.permutation].size
+                truth[-1] = False
             segments[truth] = segments[arange(self.size)[truth] + 1]
             return SegArray(segments, new_values[g.permutation])
 
@@ -928,13 +976,28 @@ class SegArray:
         See Also
         --------
         pdarraysetops.setxor1d
+
+        Examples
+        --------
+        >>> a = [1, 2, 3, 1, 4]
+        >>> b = [3, 1, 4, 5]
+        >>> c = [1, 3, 3, 5]
+        >>> d = [2, 2, 4]
+        >>> seg_a = ak.SegArray(ak.array([0, len(a)]), ak.array(a+b))
+        >>> seg_b = ak.SegArray(ak.array([0, len(c)]), ak.array(c+d))
+        >>> seg_a.setxor_ma(seg_b)
+        SegArray([
+        [2, 4, 5],
+        [1, 3, 5, 2]
+        ])
         """
         from arkouda.pdarraysetops import setxor1d
-        
+
         a_seg_inds = self.grouping.broadcast(arange(self.size)[self._non_empty])
         b_seg_inds = other.grouping.broadcast(arange(other.size)[other._non_empty])
         (new_seg_inds, new_values) = setxor1d([a_seg_inds, self.values], [b_seg_inds, other.values])
         g = GroupBy(new_seg_inds)
+        # This method does not return any empty resulting segments. We need to add these if they are missing.
         if g.segments.size == self.size:
             return SegArray(g.segments, new_values[g.permutation])
         else:

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -120,7 +120,7 @@ class SegArray:
         self._non_empty_count = self._non_empty.sum()
 
         if grouping is None:
-            if self.size == 0:
+            if self.size == 0 or self._non_empty_count == 0:
                 self.grouping = GroupBy(zeros(0, dtype=akint64))
             else:
                 # Treat each sub-array as a group, for grouped aggregations

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -846,9 +846,10 @@ class SegArray:
             return SegArray(g.segments, new_values[g.permutation])
         else:
             segments = zeros(self.size, dtype=akint64)
+            truth = ones(self.size, dtype=akbool)
             k, ct = g.count()
             segments[k] = g.segments
-            truth = ~self._non_empty | ~other._non_empty
+            truth[k] = zeros(k.size, dtype=akbool)
             if truth[-1]:
                 segments[-1] = g.permutation.size
                 truth[-1] = False
@@ -898,9 +899,10 @@ class SegArray:
             return SegArray(g.segments, new_values[g.permutation])
         else:
             segments = zeros(self.size, dtype=akint64)
+            truth = ones(self.size, dtype=akbool)
             k, ct = g.count()
             segments[k] = g.segments
-            truth = ~self._non_empty | ~other._non_empty
+            truth[k] = zeros(k.size, dtype=akbool)
             if truth[-1]:
                 segments[-1] = g.permutation.size
                 truth[-1] = False
@@ -950,9 +952,10 @@ class SegArray:
             return SegArray(g.segments, new_values[g.permutation])
         else:
             segments = zeros(self.size, dtype=akint64)
+            truth = ones(self.size, dtype=akbool)
             k, ct = g.count()
             segments[k] = g.segments
-            truth = ~self._non_empty | ~other._non_empty
+            truth[k] = zeros(k.size, dtype=akbool)
             if truth[-1]:
                 segments[-1] = g.permutation.size
                 truth[-1] = False
@@ -1002,9 +1005,10 @@ class SegArray:
             return SegArray(g.segments, new_values[g.permutation])
         else:
             segments = zeros(self.size, dtype=akint64)
+            truth = ones(self.size, dtype=akbool)
             k, ct = g.count()
             segments[k] = g.segments
-            truth = ~self._non_empty | ~other._non_empty
+            truth[k] = zeros(k.size, dtype=akbool)
             if truth[-1]:
                 segments[-1] = g.permutation.size
                 truth[-1] = False

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -803,5 +803,39 @@ class SegArray:
         values = load(prefix_path, dataset=dataset + value_suffix)
         return cls(segments, values)
 
+    def intersect_ma(self, other):
+        from arkouda.pdarraysetops import intersect1d
+        a_seg_inds = self.grouping.broadcast(arange(self.size))
+        b_seg_inds = other.grouping.broadcast(arange(other.size))
+        (new_seg_inds, new_values) = intersect1d([a_seg_inds, self.values], [b_seg_inds, other.values])
+        g = GroupBy(new_seg_inds)
+        # TODO: Possibly add logic to insert empty segments where intersection is empty
+        return SegArray(g.segments, new_values[g.permutation])
+
+    def union_ma(self, other):
+        from arkouda.pdarraysetops import union1d
+        a_seg_inds = self.grouping.broadcast(arange(self.size))
+        b_seg_inds = other.grouping.broadcast(arange(other.size))
+        (new_seg_inds, new_values) = union1d([a_seg_inds, self.values], [b_seg_inds, other.values])
+        g = GroupBy(new_seg_inds)
+        # TODO: Possibly add logic to insert empty segments where intersection is empty
+        return SegArray(g.segments, new_values[g.permutation])
+
+    def setdiff_ma(self, other):
+        from arkouda.pdarraysetops import setdiff1d
+        a_seg_inds = self.grouping.broadcast(arange(self.size))
+        b_seg_inds = other.grouping.broadcast(arange(other.size))
+        (new_seg_inds, new_values) = setdiff1d([a_seg_inds, self.values], [b_seg_inds, other.values])
+        g = GroupBy(new_seg_inds)
+        # TODO: Possibly add logic to insert empty segments where intersection is empty
+        return SegArray(g.segments, new_values[g.permutation])
+
+    def setxor_ma(self, other):
+        from arkouda.pdarraysetops import setxor1d
+        a_seg_inds = self.grouping.broadcast(arange(self.size))
+        b_seg_inds = other.grouping.broadcast(arange(other.size))
+        (new_seg_inds, new_values) = setxor1d([a_seg_inds, self.values], [b_seg_inds, other.values])
+        g = GroupBy(new_seg_inds)
+        # TODO: Possibly add logic to insert empty segments where inter
 # Register/Attach functionality has been removed until it is added for GroupBy.
 # Please refer to ticket #1122 (https://github.com/Bears-R-Us/arkouda/issues/1122 for updates

--- a/benchmarks/segarray_setops.py
+++ b/benchmarks/segarray_setops.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+import time, argparse
+import numpy as np
+import arkouda as ak
+
+OPS = ('intersect_ma', 'union_ma', 'setdiff_ma', 'setxor_ma')
+TYPES = ('int64', 'uint64',)
+
+
+def time_ak_setops(N_per_locale, trials, dtype, seed):
+    print(">>> arkouda segarray {} setops".format(dtype))
+    cfg = ak.get_config()
+    N = N_per_locale * cfg["numLocales"]
+    print("numLocales = {}, N = {:,}".format(cfg["numLocales"], N))
+    if dtype == 'int64':
+        a = ak.randint(0, 2 ** 32, N, seed=seed)
+        b = ak.randint(0, 2 ** 32, N, seed=seed)
+        seg_a = ak.SegArray(ak.array([0, len(a)]), ak.concatenate([a, b]))
+        c = ak.randint(0, 2 ** 32, N, seed=seed)
+        d = ak.randint(0, 2 ** 32, N, seed=seed)
+        seg_b = ak.SegArray(ak.array([0, len(c)]), ak.concatenate([c, d]))
+    elif dtype == 'uint64':
+        a = ak.randint(0, 2 ** 32, N, seed=seed, dtype=ak.uint64)
+        b = ak.randint(0, 2 ** 32, N, seed=seed, dtype=ak.uint64)
+        seg_a = ak.SegArray(ak.array([0, len(a)]), ak.concatenate[[a, b]])
+        c = ak.randint(0, 2 ** 32, N, seed=seed, dtype=ak.uint64)
+        d = ak.randint(0, 2 ** 32, N, seed=seed, dtype=ak.uint64)
+        seg_b = ak.SegArray(ak.array([0, len(c)]), ak.concatenate([c, d]))
+
+    print(OPS)
+    timings = {op: [] for op in OPS}
+    results = {}
+    for i in range(trials):
+        for op in timings.keys():
+            fxn = getattr(seg_a, op)
+            start = time.time()
+            r = fxn(seg_b)
+            end = time.time()
+            timings[op].append(end - start)
+            results[op] = r
+    tavg = {op: sum(t) / trials for op, t in timings.items()}
+
+    for op, t in tavg.items():
+        print("  {} Average time = {:.4f} sec".format(op, t))
+        # bytes_per_sec = (a.size * a.itemsize * 2) / t
+        # print("  {} Average rate = {:.2f} GiB/sec".format(op, bytes_per_sec / 2 ** 30))
+
+
+def check_correctness(dtype, seed):
+    return
+
+
+def create_parser():
+    parser = argparse.ArgumentParser(description="Run the setops benchmarks: intersect1d, union1d, setdiff1d, setxor1d")
+    parser.add_argument('hostname', help='Hostname of arkouda server')
+    parser.add_argument('port', type=int, help='Port of arkouda server')
+    parser.add_argument('-n', '--size', type=int, default=10, help='Problem size: length of arrays A and B')
+    parser.add_argument('-t', '--trials', type=int, default=1, help='Number of times to run the benchmark')
+    parser.add_argument('-d', '--dtype', default='int64', help='Dtype of array ({})'.format(', '.join(TYPES)))
+    parser.add_argument('--numpy', default=False, action='store_true',
+                        help='Run the same operation in NumPy to compare performance.')
+    parser.add_argument('--correctness-only', default=False, action='store_true',
+                        help='Only check correctness, not performance.')
+    parser.add_argument('-s', '--seed', default=None, type=int, help='Value to initialize random number generator')
+    return parser
+
+
+if __name__ == "__main__":
+    import sys
+
+    parser = create_parser()
+    args = parser.parse_args()
+    if args.dtype not in TYPES:
+        raise ValueError("Dtype must be {}, not {}".format('/'.join(TYPES), args.dtype))
+
+    ak.verbose = False
+    ak.connect(args.hostname, args.port)
+
+    if args.correctness_only:
+        for dtype in TYPES:
+            check_correctness(dtype, args.seed)
+        sys.exit(0)
+
+    print("array size = {:,}".format(args.size))
+    print("number of trials = ", args.trials)
+    time_ak_setops(args.size, args.trials, args.dtype, args.seed)
+    if args.numpy:
+        time_np_setops(args.size, args.trials, args.dtype, args.seed)
+        print("Verifying agreement between arkouda and NumPy on small problem... ", end="")
+        check_correctness(args.dtype, args.seed)
+        print("CORRECT")
+
+    sys.exit(0)

--- a/benchmarks/segarray_setops.py
+++ b/benchmarks/segarray_setops.py
@@ -55,11 +55,9 @@ def create_parser():
     parser = argparse.ArgumentParser(description="Run the setops benchmarks: intersect1d, union1d, setdiff1d, setxor1d")
     parser.add_argument('hostname', help='Hostname of arkouda server')
     parser.add_argument('port', type=int, help='Port of arkouda server')
-    parser.add_argument('-n', '--size', type=int, default=10, help='Problem size: length of arrays A and B')
+    parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: length of arrays A and B')
     parser.add_argument('-t', '--trials', type=int, default=1, help='Number of times to run the benchmark')
     parser.add_argument('-d', '--dtype', default='int64', help='Dtype of array ({})'.format(', '.join(TYPES)))
-    parser.add_argument('--numpy', default=False, action='store_true',
-                        help='Run the same operation in NumPy to compare performance.')
     parser.add_argument('--correctness-only', default=False, action='store_true',
                         help='Only check correctness, not performance.')
     parser.add_argument('-s', '--seed', default=None, type=int, help='Value to initialize random number generator')
@@ -85,10 +83,5 @@ if __name__ == "__main__":
     print("array size = {:,}".format(args.size))
     print("number of trials = ", args.trials)
     time_ak_setops(args.size, args.trials, args.dtype, args.seed)
-    if args.numpy:
-        time_np_setops(args.size, args.trials, args.dtype, args.seed)
-        print("Verifying agreement between arkouda and NumPy on small problem... ", end="")
-        check_correctness(args.dtype, args.seed)
-        print("CORRECT")
 
     sys.exit(0)

--- a/benchmarks/segarray_setops.py
+++ b/benchmarks/segarray_setops.py
@@ -4,7 +4,7 @@ import time, argparse
 import numpy as np
 import arkouda as ak
 
-OPS = ('intersect_ma', 'union_ma', 'setdiff_ma', 'setxor_ma')
+OPS = ('intersect', 'union', 'setdiff', 'setxor')
 TYPES = ('int64', 'uint64',)
 
 
@@ -28,7 +28,6 @@ def time_ak_setops(N_per_locale, trials, dtype, seed):
         d = ak.randint(0, 2 ** 32, N, seed=seed, dtype=ak.uint64)
         seg_b = ak.SegArray(ak.array([0, len(c)]), ak.concatenate([c, d]))
 
-    print(OPS)
     timings = {op: [] for op in OPS}
     results = {}
     for i in range(trials):
@@ -43,10 +42,10 @@ def time_ak_setops(N_per_locale, trials, dtype, seed):
 
     for op, t in tavg.items():
         print("  {} Average time = {:.4f} sec".format(op, t))
-        # bytes_per_sec = (a.size * a.itemsize * 2) / t
-        # print("  {} Average rate = {:.2f} GiB/sec".format(op, bytes_per_sec / 2 ** 30))
+        bytes_per_sec = (a.size * a.itemsize * 2) / t
+        print("  {} Average rate = {:.2f} GiB/sec".format(op, bytes_per_sec / 2 ** 30))
 
-NP_OP_MAP = {'intersect_ma': 'intersect1d', 'union_ma': 'union1d', 'setdiff_ma': 'setdiff1d', 'setxor_ma': 'setxor1d'}
+NP_OP_MAP = {'intersect': 'intersect1d', 'union': 'union1d', 'setdiff': 'setdiff1d', 'setxor': 'setxor1d'}
 
 def check_correctness(dtype, seed):
     N = 10 ** 4

--- a/benchmarks/setops_multiarray.py
+++ b/benchmarks/setops_multiarray.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+import time, argparse
+import numpy as np
+import arkouda as ak
+
+OPS = ('intersect1d', 'union1d', 'setxor1d', 'setdiff1d')
+TYPES = ('int64', 'uint64',)
+
+
+def time_ak_setops(N_per_locale, trials, dtype, seed):
+    print(">>> arkouda {} setops".format(dtype))
+    cfg = ak.get_config()
+    N = N_per_locale * cfg["numLocales"]
+    print("numLocales = {}, N = {:,}".format(cfg["numLocales"], N))
+    if dtype == 'int64':
+        a = ak.randint(0, 2 ** 32, N, seed=seed)
+        b = ak.randint(0, 2 ** 32, N, seed=seed)
+    elif dtype == 'uint64':
+        a = ak.randint(0, 2 ** 32, N, seed=seed, dtype=ak.uint64)
+        b = ak.randint(0, 2 ** 32, N, seed=seed, dtype=ak.uint64)
+
+    timings = {op: [] for op in OPS}
+    results = {}
+    for i in range(trials):
+        for op in timings.keys():
+            fxn = getattr(ak, op)
+            start = time.time()
+            r = fxn(a, b)
+            end = time.time()
+            timings[op].append(end - start)
+            results[op] = r
+    tavg = {op: sum(t) / trials for op, t in timings.items()}
+
+    for op, t in tavg.items():
+        print("  {} Average time = {:.4f} sec".format(op, t))
+        bytes_per_sec = (a.size * a.itemsize * 2) / t
+        print("  {} Average rate = {:.2f} GiB/sec".format(op, bytes_per_sec / 2 ** 30))
+
+
+def check_correctness(dtype, seed):
+    return
+
+
+def create_parser():
+    parser = argparse.ArgumentParser(description="Run the setops benchmarks: intersect1d, union1d, setdiff1d, setxor1d")
+    parser.add_argument('hostname', help='Hostname of arkouda server')
+    parser.add_argument('port', type=int, help='Port of arkouda server')
+    parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: length of arrays A and B')
+    parser.add_argument('-t', '--trials', type=int, default=1, help='Number of times to run the benchmark')
+    parser.add_argument('-d', '--dtype', default='int64', help='Dtype of array ({})'.format(', '.join(TYPES)))
+    parser.add_argument('--numpy', default=False, action='store_true',
+                        help='Run the same operation in NumPy to compare performance.')
+    parser.add_argument('--correctness-only', default=False, action='store_true',
+                        help='Only check correctness, not performance.')
+    parser.add_argument('-s', '--seed', default=None, type=int, help='Value to initialize random number generator')
+    return parser
+
+
+if __name__ == "__main__":
+    import sys
+
+    parser = create_parser()
+    args = parser.parse_args()
+    if args.dtype not in TYPES:
+        raise ValueError("Dtype must be {}, not {}".format('/'.join(TYPES), args.dtype))
+
+    ak.verbose = False
+    ak.connect(args.hostname, args.port)
+
+    if args.correctness_only:
+        for dtype in TYPES:
+            check_correctness(dtype, args.seed)
+        sys.exit(0)
+
+    print("array size = {:,}".format(args.size))
+    print("number of trials = ", args.trials)
+    time_ak_setops(args.size, args.trials, args.dtype, args.seed)
+    if args.numpy:
+        time_np_setops(args.size, args.trials, args.dtype, args.seed)
+        print("Verifying agreement between arkouda and NumPy on small problem... ", end="")
+        check_correctness(args.dtype, args.seed)
+        print("CORRECT")
+
+    sys.exit(0)

--- a/benchmarks/setops_multiarray.py
+++ b/benchmarks/setops_multiarray.py
@@ -72,7 +72,6 @@ def check_correctness(dtype, seed):
             npr1 = []
         fxn = getattr(ak, op)
         akr = fxn(pd_list_a, pd_list_b)
-        print(f"\nNPR0: {npr0}\n\nNPR1: {npr1}\n\nAKR: {akr}\n")
 
         np.isclose(akr[0].to_ndarray(), np.array(npr0))
         np.isclose(akr[1].to_ndarray(), np.array(npr1))
@@ -85,8 +84,6 @@ def create_parser():
     parser.add_argument('-n', '--size', type=int, default=10**8, help='Problem size: length of arrays A and B')
     parser.add_argument('-t', '--trials', type=int, default=1, help='Number of times to run the benchmark')
     parser.add_argument('-d', '--dtype', default='int64', help='Dtype of array ({})'.format(', '.join(TYPES)))
-    parser.add_argument('--numpy', default=False, action='store_true',
-                        help='Run the same operation in NumPy to compare performance.')
     parser.add_argument('--correctness-only', default=False, action='store_true',
                         help='Only check correctness, not performance.')
     parser.add_argument('-s', '--seed', default=None, type=int, help='Value to initialize random number generator')

--- a/tests/segarray_test.py
+++ b/tests/segarray_test.py
@@ -481,6 +481,13 @@ class SegArrayTest(ArkoudaTest):
         self.assertListEqual(intx[0].tolist(), [1, 2, 4])
         self.assertListEqual(intx[1].tolist(), [])
 
+        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a+c))
+        segarr_2 = ak.SegArray(ak.array([0, len(d)]), ak.array(d+c))
+        intx = segarr.intersect_ma(segarr_2)
+        self.assertListEqual(intx.lengths.to_ndarray().tolist(), [0, 3])
+        self.assertListEqual(intx[0].tolist(), [])
+        self.assertListEqual(intx[1].tolist(), [1, 2, 4])
+
     def test_union_ma(self):
         a = [1, 2, 3, 4, 5]
         b = [6, 7, 8]
@@ -501,6 +508,13 @@ class SegArrayTest(ArkoudaTest):
         self.assertListEqual(un.lengths.to_ndarray().tolist(), [5, 1])
         self.assertListEqual(un[0].tolist(), [1, 2, 3, 4, 5])
         self.assertListEqual(un[1].tolist(), [8])
+
+        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
+        segarr_2 = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
+        un = segarr.union_ma(segarr_2)
+        self.assertListEqual(un.lengths.to_ndarray().tolist(), [5, 0])
+        self.assertListEqual(un[0].tolist(), [1, 2, 3, 4, 5])
+        self.assertListEqual(un[1].tolist(), [])
 
     def test_setdiff_ma(self):
         a = [1, 2, 3, 4, 5]
@@ -523,6 +537,14 @@ class SegArrayTest(ArkoudaTest):
         self.assertListEqual(diff[0].tolist(), [3, 5])
         self.assertListEqual(diff[1].tolist(), [])
 
+        segarr = ak.SegArray(ak.array([0, len(a), len(a)]), ak.array(a+a))
+        segarr_2 = ak.SegArray(ak.array([0, len(c), len(c+c)]), ak.array(c + c + c))
+        diff = segarr_2.setdiff_ma(segarr)
+        self.assertListEqual(diff.lengths.to_ndarray().tolist(), [0, 3, 0])
+        self.assertListEqual(diff[0].tolist(), [])
+        self.assertListEqual(diff[1].tolist(), [1, 2, 4])
+        self.assertListEqual(diff[2].tolist(), [])
+
     def test_setxor_ma(self):
         a = [1, 2, 3]
         b = [6, 7, 8]
@@ -543,3 +565,10 @@ class SegArrayTest(ArkoudaTest):
         self.assertListEqual(xor.lengths.to_ndarray().tolist(), [2, 3])
         self.assertListEqual(xor[0].tolist(), [3, 4])
         self.assertListEqual(xor[1].tolist(), [8, 12, 13])
+
+        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a+a))
+        segarr_2 = ak.SegArray(ak.array([0, len(a)]), ak.array(a+c))
+        xor = segarr.setxor_ma(segarr_2)
+        self.assertListEqual(xor.lengths.to_ndarray().tolist(), [0, 2])
+        self.assertListEqual(xor[0].tolist(), [])
+        self.assertListEqual(xor[1].tolist(), [3, 4])

--- a/tests/segarray_test.py
+++ b/tests/segarray_test.py
@@ -460,7 +460,7 @@ class SegArrayTest(ArkoudaTest):
         self.assertListEqual(dedup[3].tolist(), list(set(b)))
         self.assertListEqual(dedup[4].tolist(), [])
 
-    def test_intersection_ma(self):
+    def test_intersection(self):
         a = [1, 2, 3, 4, 5]
         b = [6, 7, 8]
         c = [1, 2, 4]
@@ -468,7 +468,7 @@ class SegArrayTest(ArkoudaTest):
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + b))
         segarr_2 = ak.SegArray(ak.array([0, len(c)]), ak.array(c + d))
 
-        intx = segarr.intersect_ma(segarr_2)
+        intx = segarr.intersect(segarr_2)
 
         self.assertEqual(intx.size, 2)
         self.assertListEqual(intx[0].tolist(), [1, 2, 4])
@@ -476,19 +476,19 @@ class SegArrayTest(ArkoudaTest):
 
         # test with empty Segments
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
-        intx = segarr.intersect_ma(segarr_2)
+        intx = segarr.intersect(segarr_2)
         self.assertListEqual(intx.lengths.to_ndarray().tolist(), [3, 0])
         self.assertListEqual(intx[0].tolist(), [1, 2, 4])
         self.assertListEqual(intx[1].tolist(), [])
 
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a+c))
         segarr_2 = ak.SegArray(ak.array([0, len(d)]), ak.array(d+c))
-        intx = segarr.intersect_ma(segarr_2)
+        intx = segarr.intersect(segarr_2)
         self.assertListEqual(intx.lengths.to_ndarray().tolist(), [0, 3])
         self.assertListEqual(intx[0].tolist(), [])
         self.assertListEqual(intx[1].tolist(), [1, 2, 4])
 
-    def test_union_ma(self):
+    def test_union(self):
         a = [1, 2, 3, 4, 5]
         b = [6, 7, 8]
         c = [1, 2, 4]
@@ -497,26 +497,26 @@ class SegArrayTest(ArkoudaTest):
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + b))
         segarr_2 = ak.SegArray(ak.array([0, len(c)]), ak.array(c + d))
 
-        un = segarr.union_ma(segarr_2)
+        un = segarr.union(segarr_2)
         self.assertEqual(un.size, 2)
         self.assertListEqual(un[0].tolist(), [1, 2, 3, 4, 5])
         self.assertListEqual(un[1].tolist(), [6, 7, 8])
 
         # test with empty segments
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
-        un = segarr.union_ma(segarr_2)
+        un = segarr.union(segarr_2)
         self.assertListEqual(un.lengths.to_ndarray().tolist(), [5, 1])
         self.assertListEqual(un[0].tolist(), [1, 2, 3, 4, 5])
         self.assertListEqual(un[1].tolist(), [8])
 
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
         segarr_2 = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
-        un = segarr.union_ma(segarr_2)
+        un = segarr.union(segarr_2)
         self.assertListEqual(un.lengths.to_ndarray().tolist(), [5, 0])
         self.assertListEqual(un[0].tolist(), [1, 2, 3, 4, 5])
         self.assertListEqual(un[1].tolist(), [])
 
-    def test_setdiff_ma(self):
+    def test_setdiff(self):
         a = [1, 2, 3, 4, 5]
         b = [6, 7, 8]
         c = [1, 2, 4]
@@ -525,27 +525,27 @@ class SegArrayTest(ArkoudaTest):
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + b))
         segarr_2 = ak.SegArray(ak.array([0, len(c)]), ak.array(c + d))
 
-        diff = segarr.setdiff_ma(segarr_2)
+        diff = segarr.setdiff(segarr_2)
         self.assertEqual(diff.size, 2)
         self.assertListEqual(diff[0].tolist(), [3, 5])
         self.assertListEqual(diff[1].tolist(), [6, 7])
 
         # test with empty segments
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
-        diff = segarr.setdiff_ma(segarr_2)
+        diff = segarr.setdiff(segarr_2)
         self.assertListEqual(diff.lengths.to_ndarray().tolist(), [2, 0])
         self.assertListEqual(diff[0].tolist(), [3, 5])
         self.assertListEqual(diff[1].tolist(), [])
 
         segarr = ak.SegArray(ak.array([0, len(a), len(a)]), ak.array(a+a))
         segarr_2 = ak.SegArray(ak.array([0, len(c), len(c+c)]), ak.array(c + c + c))
-        diff = segarr_2.setdiff_ma(segarr)
+        diff = segarr_2.setdiff(segarr)
         self.assertListEqual(diff.lengths.to_ndarray().tolist(), [0, 3, 0])
         self.assertListEqual(diff[0].tolist(), [])
         self.assertListEqual(diff[1].tolist(), [1, 2, 4])
         self.assertListEqual(diff[2].tolist(), [])
 
-    def test_setxor_ma(self):
+    def test_setxor(self):
         a = [1, 2, 3]
         b = [6, 7, 8]
         c = [1, 2, 4]
@@ -553,7 +553,7 @@ class SegArrayTest(ArkoudaTest):
 
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + b))
         segarr_2 = ak.SegArray(ak.array([0, len(c)]), ak.array(c + d))
-        xor = segarr.setxor_ma(segarr_2)
+        xor = segarr.setxor(segarr_2)
 
         self.assertEqual(xor.size, 2)
         self.assertListEqual(xor[0].tolist(), [3, 4])
@@ -561,14 +561,14 @@ class SegArrayTest(ArkoudaTest):
 
         # test with empty segment
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
-        xor = segarr.setxor_ma(segarr_2)
+        xor = segarr.setxor(segarr_2)
         self.assertListEqual(xor.lengths.to_ndarray().tolist(), [2, 3])
         self.assertListEqual(xor[0].tolist(), [3, 4])
         self.assertListEqual(xor[1].tolist(), [8, 12, 13])
 
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a+a))
         segarr_2 = ak.SegArray(ak.array([0, len(a)]), ak.array(a+c))
-        xor = segarr.setxor_ma(segarr_2)
+        xor = segarr.setxor(segarr_2)
         self.assertListEqual(xor.lengths.to_ndarray().tolist(), [0, 2])
         self.assertListEqual(xor[0].tolist(), [])
         self.assertListEqual(xor[1].tolist(), [3, 4])

--- a/tests/segarray_test.py
+++ b/tests/segarray_test.py
@@ -459,3 +459,87 @@ class SegArrayTest(ArkoudaTest):
         self.assertListEqual(dedup[2].tolist(), [])
         self.assertListEqual(dedup[3].tolist(), list(set(b)))
         self.assertListEqual(dedup[4].tolist(), [])
+
+    def test_intersection_ma(self):
+        a = [1, 2, 3, 4, 5]
+        b = [6, 7, 8]
+        c = [1, 2, 4]
+        d = [8]
+        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + b))
+        segarr_2 = ak.SegArray(ak.array([0, len(c)]), ak.array(c + d))
+
+        intx = segarr.intersect_ma(segarr_2)
+
+        self.assertEqual(intx.size, 2)
+        self.assertListEqual(intx[0].tolist(), [1, 2, 4])
+        self.assertListEqual(intx[1].tolist(), [8])
+
+        # test with empty Segments
+        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
+        intx = segarr.intersect_ma(segarr_2)
+        self.assertListEqual(intx.lengths.to_ndarray().tolist(), [3, 0])
+        self.assertListEqual(intx[0].tolist(), [1, 2, 4])
+        self.assertListEqual(intx[1].tolist(), [])
+
+    def test_union_ma(self):
+        a = [1, 2, 3, 4, 5]
+        b = [6, 7, 8]
+        c = [1, 2, 4]
+        d = [8]
+
+        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + b))
+        segarr_2 = ak.SegArray(ak.array([0, len(c)]), ak.array(c + d))
+
+        un = segarr.union_ma(segarr_2)
+        self.assertEqual(un.size, 2)
+        self.assertListEqual(un[0].tolist(), [1, 2, 3, 4, 5])
+        self.assertListEqual(un[1].tolist(), [6, 7, 8])
+
+        # test with empty segments
+        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
+        un = segarr.union_ma(segarr_2)
+        self.assertListEqual(un.lengths.to_ndarray().tolist(), [5, 1])
+        self.assertListEqual(un[0].tolist(), [1, 2, 3, 4, 5])
+        self.assertListEqual(un[1].tolist(), [8])
+
+    def test_setdiff_ma(self):
+        a = [1, 2, 3, 4, 5]
+        b = [6, 7, 8]
+        c = [1, 2, 4]
+        d = [8]
+
+        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + b))
+        segarr_2 = ak.SegArray(ak.array([0, len(c)]), ak.array(c + d))
+
+        diff = segarr.setdiff_ma(segarr_2)
+        self.assertEqual(diff.size, 2)
+        self.assertListEqual(diff[0].tolist(), [3, 5])
+        self.assertListEqual(diff[1].tolist(), [6, 7])
+
+        # test with empty segments
+        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
+        diff = segarr.setdiff_ma(segarr_2)
+        self.assertListEqual(diff.lengths.to_ndarray().tolist(), [2, 0])
+        self.assertListEqual(diff[0].tolist(), [3, 5])
+        self.assertListEqual(diff[1].tolist(), [])
+
+    def test_setxor_ma(self):
+        a = [1, 2, 3]
+        b = [6, 7, 8]
+        c = [1, 2, 4]
+        d = [8, 12, 13]
+
+        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + b))
+        segarr_2 = ak.SegArray(ak.array([0, len(c)]), ak.array(c + d))
+        xor = segarr.setxor_ma(segarr_2)
+
+        self.assertEqual(xor.size, 2)
+        self.assertListEqual(xor[0].tolist(), [3, 4])
+        self.assertListEqual(xor[1].tolist(), [6, 7, 12, 13])
+
+        # test with empty segment
+        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
+        xor = segarr.setxor_ma(segarr_2)
+        self.assertListEqual(xor.lengths.to_ndarray().tolist(), [2, 3])
+        self.assertListEqual(xor[0].tolist(), [3, 4])
+        self.assertListEqual(xor[1].tolist(), [8, 12, 13])

--- a/tests/setops_test.py
+++ b/tests/setops_test.py
@@ -103,10 +103,14 @@ class SetOpsTest(ArkoudaTest):
         b1 = ak.array(b)
         b2 = ak.array(c)
 
+        la = set([(x, y) for x, y in zip(a, a)])
+        lb = set([(x, y) for x, y in zip(b, c)])
+        lr = list(sorted(la.symmetric_difference(lb)))
+        npr0, npr1 = map(list, zip(*lr))
+
         t = ak.setxor1d([a1, a2], [b1, b2])
-        print(t)
-        self.assertListEqual(t[0].to_ndarray().tolist(), [3, 3, 5, 5])
-        self.assertListEqual(t[1].to_ndarray().tolist(), [3, 5, 3, 5])
+        self.assertListEqual(t[0].to_ndarray().tolist(), npr0)
+        self.assertListEqual(t[1].to_ndarray().tolist(), npr1)
         
     def testSetdiff1d(self):
         pdaOne = ak.array([1, 2, 3, 2, 4, 1])
@@ -132,9 +136,14 @@ class SetOpsTest(ArkoudaTest):
         b1 = ak.array(b)
         b2 = ak.array(c)
 
+        la = set([(x, y) for x, y in zip(a, a)])
+        lb = set([(x, y) for x, y in zip(b, c)])
+        lr = list(sorted(la.difference(lb)))
+        npr0, npr1 = map(list, zip(*lr))
+
         t = ak.setdiff1d([a1, a2], [b1, b2])
-        self.assertListEqual(t[0].to_ndarray().tolist(), [3, 5])
-        self.assertListEqual(t[1].to_ndarray().tolist(), [3, 5])
+        self.assertListEqual(t[0].to_ndarray().tolist(), npr0)
+        self.assertListEqual(t[1].to_ndarray().tolist(), npr1)
 
     def testIntersect1d(self):
         pdaOne = ak.array([1, 3, 4, 3])
@@ -159,9 +168,14 @@ class SetOpsTest(ArkoudaTest):
         b1 = ak.array(b)
         b2 = ak.array(c)
 
+        la = set([(x, y) for x, y in zip(a, a)])
+        lb = set([(x, y) for x, y in zip(b, c)])
+        lr = list(sorted(la.intersection(lb)))
+        npr0, npr1 = map(list, zip(*lr))
+
         t = ak.intersect1d([a1, a2], [b1, b2])
-        self.assertListEqual(t[0].to_ndarray().tolist(), [1, 2, 4])
-        self.assertListEqual(t[1].to_ndarray().tolist(), [1, 2, 4])
+        self.assertListEqual(t[0].to_ndarray().tolist(), npr0)
+        self.assertListEqual(t[1].to_ndarray().tolist(), npr1)
 
     def testUnion1d(self):
         pdaOne = ak.array([-1, 0, 1])
@@ -186,9 +200,13 @@ class SetOpsTest(ArkoudaTest):
         b1 = ak.array(b)
         b2 = ak.array(c)
 
+        la = set([(x, y) for x, y in zip(a, a)])
+        lb = set([(x, y) for x, y in zip(b, c)])
+        lr = list(sorted(la.union(lb)))
+        npr0, npr1 = map(list, zip(*lr))
         t = ak.union1d([a1, a2], [b1, b2])
-        self.assertListEqual(t[0].to_ndarray().tolist(), [1, 2, 3, 3, 4, 5, 5])
-        self.assertListEqual(t[1].to_ndarray().tolist(), [1, 2, 3, 5, 4, 3, 5])
+        self.assertListEqual(t[0].to_ndarray().tolist(), npr0)
+        self.assertListEqual(t[1].to_ndarray().tolist(), npr1)
 
     def testIn1d(self): 
         pdaOne = ak.array([-1, 0, 1, 3])

--- a/tests/setops_test.py
+++ b/tests/setops_test.py
@@ -108,7 +108,13 @@ class SetOpsTest(ArkoudaTest):
         lr = list(sorted(la.symmetric_difference(lb)))
         npr0, npr1 = map(list, zip(*lr))
 
+        #Testing
         t = ak.setxor1d([a1, a2], [b1, b2])
+        self.assertListEqual(t[0].to_ndarray().tolist(), npr0)
+        self.assertListEqual(t[1].to_ndarray().tolist(), npr1)
+
+        # Testing tuple input
+        t = ak.setxor1d((a1, a2), (b1, b2))
         self.assertListEqual(t[0].to_ndarray().tolist(), npr0)
         self.assertListEqual(t[1].to_ndarray().tolist(), npr1)
         

--- a/tests/setops_test.py
+++ b/tests/setops_test.py
@@ -92,7 +92,21 @@ class SetOpsTest(ArkoudaTest):
         with self.assertRaises(RuntimeError) as cm:
             ak.setxor1d(ak.array([True, False, True]), ak.array([True, True]))
         with self.assertRaises(TypeError):
-            ak.setxor1d([-1, 0, 1], [-2, 0, 2])     
+            ak.setxor1d([-1, 0, 1], [-2, 0, 2])
+
+    def testSetxor1d_Multi(self):
+        a = [1, 2, 3, 4, 5]
+        b = [1, 5, 2, 3, 4]
+        c = [1, 3, 2, 5, 4]
+        a1 = ak.array(a)
+        a2 = ak.array(a)
+        b1 = ak.array(b)
+        b2 = ak.array(c)
+
+        t = ak.setxor1d([a1, a2], [b1, b2])
+        print(t)
+        self.assertListEqual(t[0].to_ndarray().tolist(), [3, 3, 5, 5])
+        self.assertListEqual(t[1].to_ndarray().tolist(), [3, 5, 3, 5])
         
     def testSetdiff1d(self):
         pdaOne = ak.array([1, 2, 3, 2, 4, 1])
@@ -107,9 +121,22 @@ class SetOpsTest(ArkoudaTest):
         with self.assertRaises(RuntimeError) as cm:
             ak.setdiff1d(ak.array([True, False, True]), ak.array([True, True]))
         with self.assertRaises(TypeError):
-            ak.setdiff1d([-1, 0, 1], [-2, 0, 2])     
-        
-    def testIntersectId(self):
+            ak.setdiff1d([-1, 0, 1], [-2, 0, 2])
+
+    def testSetDiff1d_Multi(self):
+        a = [1, 2, 3, 4, 5]
+        b = [1, 5, 2, 3, 4]
+        c = [1, 3, 2, 5, 4]
+        a1 = ak.array(a)
+        a2 = ak.array(a)
+        b1 = ak.array(b)
+        b2 = ak.array(c)
+
+        t = ak.setdiff1d([a1, a2], [b1, b2])
+        self.assertListEqual(t[0].to_ndarray().tolist(), [3, 5])
+        self.assertListEqual(t[1].to_ndarray().tolist(), [3, 5])
+
+    def testIntersect1d(self):
         pdaOne = ak.array([1, 3, 4, 3])
         pdaTwo = ak.array([3, 1, 2, 1])
         expected = ak.array([1,3])
@@ -121,8 +148,21 @@ class SetOpsTest(ArkoudaTest):
         with self.assertRaises(RuntimeError) as cm:
             ak.intersect1d(ak.array([True, False, True]), ak.array([True, True]))
         with self.assertRaises(TypeError):
-            ak.intersect1d([-1, 0, 1], [-2, 0, 2])     
-        
+            ak.intersect1d([-1, 0, 1], [-2, 0, 2])
+
+    def testIntersect1d_Multi(self):
+        a = [1, 2, 3, 4, 5]
+        b = [1, 5, 2, 3, 4]
+        c = [1, 3, 2, 5, 4]
+        a1 = ak.array(a)
+        a2 = ak.array(a)
+        b1 = ak.array(b)
+        b2 = ak.array(c)
+
+        t = ak.intersect1d([a1, a2], [b1, b2])
+        self.assertListEqual(t[0].to_ndarray().tolist(), [1, 2, 4])
+        self.assertListEqual(t[1].to_ndarray().tolist(), [1, 2, 4])
+
     def testUnion1d(self):
         pdaOne = ak.array([-1, 0, 1])
         pdaTwo = ak.array([-2, 0, 2])
@@ -135,7 +175,20 @@ class SetOpsTest(ArkoudaTest):
         with self.assertRaises(RuntimeError) as cm:
             ak.union1d(ak.array([True, True, True]), ak.array([True,False,True]))
         with self.assertRaises(TypeError):
-            ak.union1d([-1, 0, 1], [-2, 0, 2])     
+            ak.union1d([-1, 0, 1], [-2, 0, 2])
+
+    def testUnion1d_Multi(self):
+        a = [1, 2, 3, 4, 5]
+        b = [1, 5, 2, 3, 4]
+        c = [1, 3, 2, 5, 4]
+        a1 = ak.array(a)
+        a2 = ak.array(a)
+        b1 = ak.array(b)
+        b2 = ak.array(c)
+
+        t = ak.union1d([a1, a2], [b1, b2])
+        self.assertListEqual(t[0].to_ndarray().tolist(), [1, 2, 3, 3, 4, 5, 5])
+        self.assertListEqual(t[1].to_ndarray().tolist(), [1, 2, 3, 5, 4, 3, 5])
 
     def testIn1d(self): 
         pdaOne = ak.array([-1, 0, 1, 3])
@@ -150,3 +203,22 @@ class SetOpsTest(ArkoudaTest):
 
         answer = ak.array([x < 2 for x in vals])
         self.assertTrue((answer == ak.in1d(stringsOne,stringsTwo)).all())
+
+    def test_multiarray_validation(self):
+        x = [ak.arange(3), ak.arange(3), ak.arange(3)]
+        y = [ak.arange(2), ak.arange(2)]
+        with self.assertRaises(ValueError):
+            ak.pdarraysetops.multiarray_setop_validation(x, y)
+
+        x = [ak.arange(3), ak.arange(5)]
+        with self.assertRaises(ValueError):
+            ak.pdarraysetops.multiarray_setop_validation(x, y)
+
+        with self.assertRaises(ValueError):
+            ak.pdarraysetops.multiarray_setop_validation(y, x)
+
+        x = [ak.arange(3, dtype=ak.uint64), ak.arange(3)]
+        with self.assertRaises(TypeError):
+            ak.pdarraysetops.multiarray_setop_validation(x, y)
+
+


### PR DESCRIPTION
This PR (closes #1218):

Adds support for multiple arrays to the existing `pdarray` set operations:
- `union1d`
- `intersect1d`
- `setdiff1d`
- `setxor1d`
*Note - `in1d` multiple array support is defined in `arkouda/alignment.py:in1d_multi(a, b)`. This will need to be moved separately.*

Adds support for set operations to SegArrays:
- `union_ma`
- `intersect_ma`
- `setdiff_ma`
- `setxor_ma`
*Note - the `_ma` suffix is denoting that these are utilizing the multiple array code added to `pdarraysetops.py`. This was added to prevent conflicts if PR #1213 was merged before this PR was submitted. I am suggesting that PR be closed as this is a better solution. If everyone agrees, I will update the naming to remove the `_ma` suffix.*

Only int64 and uint64 are currently supported for these set operations.

Testing for:
- Multiple Array `pdarray` Setops - `tests/setops_test.py` (added `_multi` functions)
- `SegArray` Setops - `tests/segarray_test.py` (added setops tests)

Benchmarks for:
- Multiple Array `pdarray` setops - `benchmarks/setops_multiarray.py`
- `SegArray` Setops - `benchmarks/segarray_setops.py`

The current implementation is all client side. I discussed with @reuster986 and we plan to add an issue to move this to the server in the future.

`pdarray` set operations have been updated to take a single `pdarray` for each element or a `list` of `pdarrays` for each argument. The later triggers the multiple array workflow. This requires  the lists be the same size and for the elements within a list to be equal size.

```python
# Example Multiple Array Setops 
a = [1, 2, 3, 4, 5]
a1 = ak.array(a)
b1 = ak.array([1, 5, 2, 3, 4])
b2 = ak.array([1, 3, 2, 5, 4])

intx = ak.intersect1d([a1, a1], [b1, b2])
intx
[array([1 2 4]), array([1 2 4])]

# Example SegArray Setop
a = [1, 2, 3, 4, 5]
b = [6, 7, 8]
c = [1, 2, 4]
d = [8]
segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + b))
segarr_2 = ak.SegArray(ak.array([0, len(c)]), ak.array(c + d))

intx = segarr.intersect_ma(segarr_2)
SegArray([
[1 2 4]
[8]
])
```
