### PR TITLE
Closes #1086, Generic Attach Method

### DIFF
--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -4,15 +4,15 @@ import numpy as np  # type: ignore
 import h5py #type: ignore
 import os
 
-from arkouda import __version__
+from arkouda import __version__, Strings
 from arkouda.client_dtypes import BitVector, BitVectorizer, IPv4
 from arkouda.timeclass import Datetime, Timedelta
-from arkouda.pdarrayclass import attach_pdarray, pdarray
+from arkouda.pdarrayclass import attach_pdarray, pdarray, create_pdarray
 from arkouda.pdarraysetops import concatenate as pdarrayconcatenate
 from arkouda.pdarraycreation import arange
 from arkouda.pdarraysetops import unique
 from arkouda.pdarrayIO import read_hdf
-from arkouda.client import get_config, get_mem_used
+from arkouda.client import get_config, get_mem_used, generic_msg
 from arkouda.groupbyclass import GroupBy, broadcast, coargsort
 from arkouda.infoclass import information, AllSymbols
 from arkouda.categorical import Categorical
@@ -278,3 +278,15 @@ def convert_if_categorical(values):
     if isinstance(values, Categorical):
         values = values.categories[values.codes]
     return values
+
+
+def attach(name):
+    """
+    Attaches to a known element name without requiring to know if the element is a Strings object or pdarray
+    """
+    repMsg = generic_msg(cmd="attach", args=name)
+    dtype = repMsg.split()[2]
+    if dtype == "str":
+        return Strings.from_return_msg(repMsg)
+    else:
+        return create_pdarray(repMsg)

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,0 +1,17 @@
+from base_test import ArkoudaTest
+from context import arkouda as ak
+from arkouda.util import attach
+
+class utilTest(ArkoudaTest):
+    def test_attach(self):
+        a = ak.array(["abc","123","def"])
+        b = ak.arange(10)
+
+        #Attach the Strings array and the pdarray to new objects
+        a_attached = attach(a.entry.name) #This should be updated after Strings' init of the name property is changed
+        b_attached = attach(b.name)
+
+        self.assertTrue((a == a_attached).all())
+        self.assertIsInstance(a_attached, ak.Strings)
+        self.assertTrue((b == b_attached).all())
+        self.assertIsInstance(b_attached, ak.pdarray)


### PR DESCRIPTION
This PR (closes #1086):

Added the method outlined in the original issue to arkouda/util.py. During testing I found that on creation of a Strings object, .name is always equal to None - created issue #1268 for this. Until that issue is worked, to get the name of a Strings object you have to use `<Strings object>.entry.name`.

Example of the functionality:
```python
import arkouda as ak

ak.connect()

a = ak.arange(5)
a_name = a.name

s = ak.array(["abc","def","123"])
s_name = s.entry.name

ak.diconnect()
ak.connect()

a2 = ak.util.attach(a_name)
s2 = ak.util.attach(s_name)

```
