### PR TITLE
Closes #1260 - GroupBy w/ Booleans

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -10,6 +10,7 @@ from arkouda.dtypes import dtype, DTypes, resolve_scalar_dtype, \
 from arkouda.dtypes import int64 as akint64
 from arkouda.dtypes import uint64 as akuint64
 from arkouda.dtypes import str_ as akstr_
+from arkouda.dtypes import bool as akbool
 from arkouda.dtypes import bool as npbool
 from arkouda.dtypes import isSupportedInt
 from arkouda.logger import getArkoudaLogger
@@ -1307,10 +1308,15 @@ class pdarray:
         API: this method must be defined by all groupable arrays, and it
         must return a list of arrays that can be (co)argsorted.
         '''
-        if self.dtype not in (akint64, akuint64):
-            raise TypeError("Grouping numeric data is only supported on integral types.")
+        if self.dtype == akbool:
+            from arkouda.numeric import cast as akcast
+            return [akcast(self, akint64)]
+        elif self.dtype in (akint64, akuint64):
+            return [self]
+        else:
+            raise TypeError("Grouping is only supported on numeric data (integral types) and bools.")
         # Integral pdarrays are their own grouping keys
-        return [self]
+
 
 #end pdarray class def
     

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1312,10 +1312,10 @@ class pdarray:
             from arkouda.numeric import cast as akcast
             return [akcast(self, akint64)]
         elif self.dtype in (akint64, akuint64):
+            # Integral pdarrays are their own grouping keys
             return [self]
         else:
             raise TypeError("Grouping is only supported on numeric data (integral types) and bools.")
-        # Integral pdarrays are their own grouping keys
 
 
 #end pdarray class def

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -237,9 +237,6 @@ class GroupByTest(ArkoudaTest):
         gb = ak.GroupBy([akdf['keys'], akdf['keys2']])
         
         with self.assertRaises(TypeError) as cm:
-            ak.GroupBy(self.bvalues)
-        
-        with self.assertRaises(TypeError) as cm:
             ak.GroupBy(self.fvalues)
 
         with self.assertRaises(TypeError) as cm:
@@ -262,7 +259,7 @@ class GroupByTest(ArkoudaTest):
 
         with self.assertRaises(TypeError) as cm:
             self.igb.all(ak.randint(0,1,10,dtype=int64))
-        
+
         with self.assertRaises(TypeError) as cm:
             self.igb.min(ak.randint(0,1,10,dtype=bool))
 

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -149,6 +149,22 @@ class GroupByTest(ArkoudaTest):
         '''
         self.assertEqual(0, run_test(2, verbose))
 
+    def test_boolean_arrays(self):
+        a = ak.array([True, False, True, True, False])
+        true_ct = a.sum()
+        g = ak.GroupBy(a)
+        k, ct = g.count()
+
+        self.assertEqual(ct[1], true_ct)
+        self.assertListEqual(k.to_ndarray().tolist(), [False, True])
+
+        b = ak.array([False, False, True, False, False])
+        g = ak.GroupBy([a, b])
+        k, ct = g.count()
+        self.assertListEqual(ct.to_ndarray().tolist(), [2, 2, 1])
+        self.assertListEqual(k[0].to_ndarray().tolist(), [False, True, True])
+        self.assertListEqual(k[1].to_ndarray().tolist(), [False, False, True])
+
     def test_bitwise_aggregations(self):
         revs = ak.arange(self.igb.size) % 2
         self.assertTrue((self.igb.OR(revs)[1] == self.igb.max(revs)[1]).all())


### PR DESCRIPTION
This PR (closes #1260):

Adds support for Booleans to `ak.GroupBy`. This is done by updating the `pdarrayclass._get_grouping_keys()` method to handle boolean arrays. The arrays are cast to `ak.int64` arrays using `ak.cast`, which allows all other functionality to be used as if we are dealing with integers.

```python
a = ak.array([True, False, True, True, False])
b = ak.array([False, False, True, False, False])

ga = ak.GroupBy(a)
ga.count()
(array([False True]), array([2 3]))

g = ak.GroupBy([a, b])
g.count()
([array([False True True]), array([False False True])], array([2 2 1]))
```