### PR TITLE
Closes #1268, Strings object name initialization

### DIFF
--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -168,11 +168,11 @@ class Strings:
             self.nbytes = bytes_size  # This is a deficiency of server GenSymEntry right now
             self.ndim = self.entry.ndim
             self.shape = self.entry.shape
+            self.name: Optional[str] = self.entry.name
         except Exception as e:
             raise ValueError(e)   
 
         self.dtype = npstr
-        self.name:Optional[str] = None
         self._regex_dict: Dict = dict()
         self.logger = getArkoudaLogger(name=__class__.__name__) # type: ignore
 


### PR DESCRIPTION
This PR (closes #1268):

Moving the name initialization into the try block and setting it to the passed pdarray's name value allows for a generic reference to the name of the object regardless of if the object is a Strings object or pdarray.

Existing references to the Strings object entry.name value will still function, i.e. the name of Strings object 's' can now be accessed through `s.name` or `s.entry.name`. Both of these methods will return the same value.

This solves the issue of using the newly created generic attach method still requiring knowledge of if the array is a pdarray or Strings object in order to get the name of the Strings object correctly, instead of "None", when attaching to an element. 

Example: 
```python
import arkouda as ak

ak.connect()

a = ak.arange(5)
s = ak.array(["abc","123","def"])

a_name = a.name
#Originally, this would set s_name = None
s_name = s.name

```
