### PR TITLE
Closes #1265: Add `to/is_lower` and `to/is_upper` methods to `Strings`

### DIFF
--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -327,6 +327,128 @@ class Strings:
         return create_pdarray(generic_msg(cmd=cmd,args=args))
 
     @typechecked
+    def to_lower(self) -> Strings:
+        """
+        Returns a new Strings with all uppercase characters from the original replaced with their lowercase equivalent
+
+        Returns
+        -------
+        Strings
+            Strings with all uppercase characters from the original replaced with their lowercase equivalent
+
+        Raises
+        ------
+        RuntimeError
+            Raised if there is a server-side error thrown
+
+        See Also
+        --------
+        Strings.to_upper
+
+        Examples
+        --------
+        >>> strings = ak.array([f'StrINgS {i}' for i in range(5)])
+        >>> strings
+        array(['StrINgS 0', 'StrINgS 1', 'StrINgS 2', 'StrINgS 3', 'StrINgS 4'])
+        >>> strings.to_lower()
+        array(['strings 0', 'strings 1', 'strings 2', 'strings 3', 'strings 4'])
+        """
+        rep_msg = generic_msg(cmd="caseChange", args=f"toLower {self.objtype} {self.entry.name}")
+        return Strings.from_return_msg(cast(str, rep_msg))
+
+    @typechecked
+    def to_upper(self) -> Strings:
+        """
+        Returns a new Strings with all lowercase characters from the original replaced with their uppercase equivalent
+
+        Returns
+        -------
+        Strings
+            Strings with all lowercase characters from the original replaced with their uppercase equivalent
+
+        Raises
+        ------
+        RuntimeError
+            Raised if there is a server-side error thrown
+
+        See Also
+        --------
+        Strings.to_lower
+
+        Examples
+        --------
+        >>> strings = ak.array([f'StrINgS {i}' for i in range(5)])
+        >>> strings
+        array(['StrINgS 0', 'StrINgS 1', 'StrINgS 2', 'StrINgS 3', 'StrINgS 4'])
+        >>> strings.to_upper()
+        array(['STRINGS 0', 'STRINGS 1', 'STRINGS 2', 'STRINGS 3', 'STRINGS 4'])
+        """
+        rep_msg = generic_msg(cmd="caseChange", args=f"toUpper {self.objtype} {self.entry.name}")
+        return Strings.from_return_msg(cast(str, rep_msg))
+
+    @typechecked
+    def is_lower(self) -> pdarray:
+        """
+        Returns a boolean pdarray where index i indicates whether string i of the Strings is entirely lowercase
+
+        Returns
+        -------
+        pdarray, bool
+            True for elements that are entirely lowercase, False otherwise
+
+        Raises
+        ------
+        RuntimeError
+            Raised if there is a server-side error thrown
+
+        See Also
+        --------
+        Strings.is_upper
+
+        Examples
+        --------
+        >>> lower = ak.array([f'strings {i}' for i in range(3)])
+        >>> upper = ak.array([f'STRINGS {i}' for i in range(3)])
+        >>> strings = ak.concatenate([lower, upper])
+        >>> strings
+        array(['strings 0', 'strings 1', 'strings 2', 'STRINGS 0', 'STRINGS 1', 'STRINGS 2'])
+        >>> strings.is_lower()
+        array([True True True False False False])
+        """
+        return create_pdarray(generic_msg(cmd="checkChars", args=f"isLower {self.objtype} {self.entry.name}"))
+
+    @typechecked
+    def is_upper(self) -> pdarray:
+        """
+        Returns a boolean pdarray where index i indicates whether string i of the Strings is entirely uppercase
+
+        Returns
+        -------
+        pdarray, bool
+            True for elements that are entirely uppercase, False otherwise
+
+        Raises
+        ------
+        RuntimeError
+            Raised if there is a server-side error thrown
+
+        See Also
+        --------
+        Strings.is_lower
+
+        Examples
+        --------
+        >>> lower = ak.array([f'strings {i}' for i in range(3)])
+        >>> upper = ak.array([f'STRINGS {i}' for i in range(3)])
+        >>> strings = ak.concatenate([lower, upper])
+        >>> strings
+        array(['strings 0', 'strings 1', 'strings 2', 'STRINGS 0', 'STRINGS 1', 'STRINGS 2'])
+        >>> strings.is_upper()
+        array([False False False True True True])
+        """
+        return create_pdarray(generic_msg(cmd="checkChars", args=f"isUpper {self.objtype} {self.entry.name}"))
+
+    @typechecked
     def cached_regex_patterns(self) -> List:
         """
         Returns the regex patterns for which Match objects have been cached

--- a/src/Flatten.chpl
+++ b/src/Flatten.chpl
@@ -14,26 +14,6 @@ module Flatten {
   config const NULL_STRINGS_VALUE = 0:uint(8);
 
   /*
-     Interpret a region of a byte array as bytes. Modeled after interpretAsString
-   */
-  proc interpretAsBytes(bytearray: [?D] uint(8), region: range(?), borrow=false): bytes {
-    var localSlice = new lowLevelLocalizingSlice(bytearray, region);
-    // Byte buffer is null-terminated, so length is region.size - 1
-    try {
-      if localSlice.isOwned {
-        localSlice.isOwned = false;
-        return createBytesWithOwnedBuffer(localSlice.ptr, region.size-1, region.size);
-      } else if borrow {
-        return createBytesWithBorrowedBuffer(localSlice.ptr, region.size-1, region.size);
-      } else {
-        return createBytesWithNewBuffer(localSlice.ptr, region.size-1, region.size);
-      }
-    } catch {
-      return b"<error interpreting uint(8) as bytes>";
-    }
-  }
-
-  /*
     Given a SegString where each string encodes a variable-length sequence delimited by a regex,
     flattenRegex unpacks the sequences into a flat array of individual elements.
     If returnSegs is set to True, a mapping between the original strings and new array elements will be returned

--- a/src/SegmentedComputation.chpl
+++ b/src/SegmentedComputation.chpl
@@ -45,6 +45,8 @@ module SegmentedComputation {
     StringCompareLiteralEq,
     StringCompareLiteralNeq,
     StringSearch,
+    StringIsLower,
+    StringIsUpper,
   }
   
   proc computeOnSegments(segments: [?D] int, values: [?vD] ?t, param function: SegFunction, type retType, const strArg: string = "") throws {
@@ -95,6 +97,12 @@ module SegmentedComputation {
                 }
                 when SegFunction.StringCompareLiteralNeq {
                   agg.copy(res[i], stringCompareLiteralNeq(values, start..#len, strArg));
+                }
+                when SegFunction.StringIsLower {
+                  agg.copy(res[i], stringIsLower(values, start..#len));
+                }
+                when SegFunction.StringIsUpper {
+                  agg.copy(res[i], stringIsUpper(values, start..#len));
                 }
                 otherwise {
                   compilerError("Unrecognized segmented function");

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -159,6 +159,89 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
+  proc caseChangeMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    var pn = Reflection.getRoutineName();
+    var repMsg: string;
+    var (subcmd, objtype, name) = payload.splitMsgToTuple(3);
+
+    // check to make sure symbols defined
+    st.checkTable(name);
+
+    var rname = st.nextName();
+    smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"cmd: %s objtype: %t name: %t".format(cmd,objtype,name));
+
+    select objtype {
+      when "str" {
+        var strings = getSegString(name, st);
+        select subcmd {
+          when "toLower" {
+            var (off, val) = strings.lower();
+            var retString = getSegString(off, val, st);
+            repMsg = "created " + st.attrib(retString.name) + "+created bytes.size %t".format(retString.nBytes);
+          }
+          when "toUpper" {
+            var (off, val) = strings.upper();
+            var retString = getSegString(off, val, st);
+            repMsg = "created " + st.attrib(retString.name) + "+created bytes.size %t".format(retString.nBytes);
+          }
+          otherwise {
+            var errorMsg = notImplementedError(pn, "%s".format(subcmd));
+            smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+          }
+        }
+      }
+      otherwise {
+          var errorMsg = notImplementedError(pn, "%s".format(objtype));
+          smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+          return new MsgTuple(errorMsg, MsgType.ERROR);
+      }
+    }
+    smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+    return new MsgTuple(repMsg, MsgType.NORMAL);
+  }
+
+  proc checkCharsMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    var pn = Reflection.getRoutineName();
+    var repMsg: string;
+    var (subcmd, objtype, name) = payload.splitMsgToTuple(3);
+
+    // check to make sure symbols defined
+    st.checkTable(name);
+
+    var rname = st.nextName();
+    smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"cmd: %s objtype: %t name: %t".format(cmd,objtype,name));
+
+    select objtype {
+      when "str" {
+        var strings = getSegString(name, st);
+        var truth = st.addEntry(rname, strings.size, bool);
+        select subcmd {
+          when "isLower" {
+            truth.a = strings.isLower();
+            repMsg = "created "+st.attrib(rname);
+          }
+          when "isUpper" {
+            truth.a = strings.isUpper();
+            repMsg = "created "+st.attrib(rname);
+          }
+          otherwise {
+            var errorMsg = notImplementedError(pn, "%s".format(subcmd));
+            smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+          }
+        }
+      }
+      otherwise {
+          var errorMsg = notImplementedError(pn, "%s".format(objtype));
+          smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+          return new MsgTuple(errorMsg, MsgType.ERROR);
+      }
+    }
+    smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+    return new MsgTuple(repMsg, MsgType.NORMAL);
+  }
+
   proc segmentedSearchMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
       var pn = Reflection.getRoutineName();
       var repMsg: string;
@@ -919,6 +1002,8 @@ module SegmentedMsg {
   proc registerMe() {
     use CommandMap;
     registerFunction("segmentLengths", segmentLengthsMsg, getModuleName());
+    registerFunction("caseChange", caseChangeMsg, getModuleName());
+    registerFunction("checkChars", checkCharsMsg, getModuleName());
     registerFunction("segmentedHash", segmentedHashMsg, getModuleName());
     registerFunction("segmentedSearch", segmentedSearchMsg, getModuleName());
     registerFunction("segmentedFindLoc", segmentedFindLocMsg, getModuleName());

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -527,6 +527,28 @@ class StringTest(ArkoudaTest):
         lengths = s1.get_lengths()
         self.assertTrue((ak.array([3,3,5,4,4]) == lengths).all())
 
+    def test_case_change(self):
+        s = ak.array([f'StrINgS {i}' for i in range(10)])
+
+        lower = s.to_lower()
+        expected = ak.array([f'strings {i}' for i in range(10)])
+        self.assertListEqual(lower.to_ndarray().tolist(), expected.to_ndarray().tolist())
+
+        upper = s.to_upper()
+        expected = ak.array([f'STRINGS {i}' for i in range(10)])
+        self.assertListEqual(upper.to_ndarray().tolist(), expected.to_ndarray().tolist())
+
+        # first 10 all lower, middle 10 mixed case (not lower or upper), last 10 all upper
+        lu = ak.concatenate([lower, s, upper])
+
+        islower = lu.is_lower()
+        expected = ak.arange(30) < 10
+        self.assertListEqual(islower.to_ndarray().tolist(), expected.to_ndarray().tolist())
+
+        isupper = lu.is_upper()
+        expected = ak.arange(30) >= 20
+        self.assertListEqual(isupper.to_ndarray().tolist(), expected.to_ndarray().tolist())
+
     def test_concatenate(self):
         s1 = self._get_strings('string',51)
         s2 = self._get_strings('string-two', 51)


### PR DESCRIPTION
This PR (Closes #1265):
- Adds `Strings.to_lower()`
  - Returns a new Strings with all uppercase characters from the original replaced with their lowercase equivalent
- Adds `Strings.to_upper()`
  - Returns a new Strings with all lowercase characters from the original replaced with their uppercase equivalent
- Adds `Strings.is_lower()`
  - Returns a boolean pdarray where index `i` indicates whether string `i` of the Strings is entirely lowercase
- Adds `Strings.is_upper()`
  - Returns a boolean pdarray where index `i` indicates whether string `i` of the Strings is entirely uppercase
- Adds a test for the new functionality

NOTES:
- This PR follows the basic outline laid out by @ronawho in the issue and returns a new Strings. I can work on a version that modifies in-place if we want to go in that direction
- `is_lower/upper` takes advantage of `computeOnSegments`, but it seemed more involved for `to_lower/upper`. This is something that should be looked into more
- `interpretAsBytes` is moved from `Flatten.chpl` to `SegmentedArray.chpl`. The function is not changed

Examples:
```python
>>> mixed_case = ak.array([f'StrINgS {i}' for i in range(3)])
>>> mixed_case 
array(['StrINgS 0', 'StrINgS 1', 'StrINgS 2'])

>>> lower = mixed_case.to_lower()
>>> lower
array(['strings 0', 'strings 1', 'strings 2'])

>>> upper = mixed_case.to_upper()
>>> upper
array(['STRINGS 0', 'STRINGS 1', 'STRINGS 2'])

>>> strings = ak.concatenate([lower, mixed_case , upper])
>>> strings
array(['strings 0', 'strings 1', 'strings 2', 'StrINgS 0', 'StrINgS 1', 'StrINgS 2', 'STRINGS 0', 'STRINGS 1', 'STRINGS 2'])

>>> strings.is_lower()
array([True True True False False False False False False])

>>> strings.is_upper()
array([False False False False False False True True True])
```