### PR TITLE
Closes #1267 - unexpected results with GroupBy() when 2nd element is string array

### DIFF
--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -105,6 +105,14 @@ class GroupBy:
 
     def __init__(self, keys: groupable,
                  assume_sorted: bool = False, hash_strings: bool = True) -> None:
+        # Type Checks required because @typechecked was removed for causing other issues
+        # This prevents non-bool values that can be evaluated to true (ie non-empty arrays)
+        # from causing unexpected results. Experienced when forgetting to wrap multiple key arrays in [].
+        # See Issue #1267
+        if not isinstance(assume_sorted, bool):
+            raise TypeError("assume_sorted must be of type bool.")
+        if not isinstance(hash_strings, bool):
+            raise TypeError("hash_strings must be of type bool.")
         from arkouda.categorical import Categorical
         self.logger = getArkoudaLogger(name=self.__class__.__name__)
         self.assume_sorted = assume_sorted

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -219,6 +219,9 @@ class GroupByTest(ArkoudaTest):
         d = make_arrays()
         akdf = {k:ak.array(v) for k, v in d.items()}        
         gb = ak.GroupBy([akdf['keys'], akdf['keys2']])
+
+        with self.assertRaises(TypeError) as cm:
+            ak.GroupBy(ak.arange(4), ak.arange(4))
         
         with self.assertRaises(TypeError) as cm:
             ak.GroupBy(self.bvalues)


### PR DESCRIPTION
This PR (closes #1267):

Spoke with @pierce314159 and the `@typechecked` was removed from the `GroupBy.__init__()` because it was causing issues documented in #858. 

The issue we are currently seeing is that when brackets are not supplied for the first parameter when using multiple key arrays, if the 2nd array was not empty, it evaluates to True for the `assume_sorted` param. In order to prevent this, an `isinstance(assume_sorted, bool)` and `isinistance(hash_strings, bool)` check have been added to enforce these parameters being of type bool.

A test case has been added to `test_error_handling` to ensure this update is functioning.

Example:
```python
In [3]: a = ak.array([0, 1, 2, 1])
   ...: b = ak.array(['a', 'b', 'a', 'b'])

In [4]: ak.GroupBy(a,b)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-4-572f015f0e78> in <module>
----> 1 ak.GroupBy(a,b)

~/Documents/git/arkouda/arkouda/groupbyclass.py in __init__(self, keys, assume_sorted, hash_strings)
    111         # See Issue #1267
    112         if not isinstance(assume_sorted, bool):
--> 113             raise TypeError("assume_sorted must be of type bool.")
    114         if not isinstance(hash_strings, bool):
    115             raise TypeError("hash_strings must be of type bool.")

TypeError: assume_sorted must be of type bool.
```