### PR TITLE
Closes #1273 akutil.plotting to arkouda

### DIFF
--- a/arkouda/__init__.py
+++ b/arkouda/__init__.py
@@ -23,4 +23,5 @@ from arkouda.dataframe import *
 from arkouda.row import *
 from arkouda.index import *
 from arkouda.series import *
+from arkouda.plotting import *
 

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -165,6 +165,23 @@ def log(pda : pdarray) -> pdarray:
     return create_pdarray(type_cast(str,repMsg))
 
 @typechecked
+def log10(x: pdarray) -> pdarray:
+    """
+    compute the log of a pdarray and perform a basechange
+
+    Parameters
+    __________
+    x : pdarray
+        array to compute on
+
+    Returns
+    _______
+    pdarray contain values of the base 10 log
+    """
+    basechange = float(np.log10(np.exp(1)))
+    return basechange*log(x)
+
+@typechecked
 def exp(pda : pdarray) -> pdarray:
     """
     Return the element-wise exponential of the array.

--- a/arkouda/plotting.py
+++ b/arkouda/plotting.py
@@ -9,6 +9,37 @@ def log10(x):
     return basechange*log(x)
 
 def plot_dist(b, h, log=True, xlabel=None, newfig=True):
+    """
+    Plot the distribution and cumulative distribution of histogram Data
+
+    Parameters
+    ----------
+    b : np.ndarray
+        Bin edges
+    h : np.ndarray
+        Histogram data
+    log : bool
+        use log to scale y
+    xlabel: str
+        Label for the x axis of the graph
+    newfig: bool
+        Generate a new figure or not
+
+    Notes
+    -----
+    This function does not return or display the plot. A user must have matplotlib imported in addition to arkouda to
+    display plots. This could be updated to return the object or have a flag to show the resulting plots.
+    See Examples Below.
+
+    Examples
+    --------
+    >>> import arkouda as ak
+    >>> from matplotlib import pyplot as plt
+    >>> b, h = ak.histogram(ak.arange(10), 3)
+    >>> ak.plot_dist(b, h)
+    >>> # to show the plot
+    >>> plt.show()
+    """
     if newfig:
         plt.figure(figsize=(12, 5))
     plt.subplot(1, 2, 1)

--- a/arkouda/plotting.py
+++ b/arkouda/plotting.py
@@ -36,7 +36,7 @@ def plot_dist(b, h, log=True, xlabel=None, newfig=True):
     >>> import arkouda as ak
     >>> from matplotlib import pyplot as plt
     >>> b, h = ak.histogram(ak.arange(10), 3)
-    >>> ak.plot_dist(b, h)
+    >>> ak.plot_dist(b, h.to_ndarray())
     >>> # to show the plot
     >>> plt.show()
     """

--- a/arkouda/plotting.py
+++ b/arkouda/plotting.py
@@ -1,5 +1,5 @@
-import numpy as np
-from matplotlib import pyplot as plt
+import numpy as np  # type: ignore
+from matplotlib import pyplot as plt  # type: ignore
 
 from arkouda.numeric import log
 

--- a/arkouda/plotting.py
+++ b/arkouda/plotting.py
@@ -9,37 +9,6 @@ def log10(x):
     return basechange*log(x)
 
 def plot_dist(b, h, log=True, xlabel=None, newfig=True):
-    """
-    Plot the distribution and cumulative distribution of histogram Data
-
-    Parameters
-    ----------
-    b : np.ndarray
-        Bin edges
-    h : np.ndarray
-        Histogram data
-    log : bool
-        use log to scale y
-    xlabel: str
-        Label for the x axis of the graph
-    newfig: bool
-        Generate a new figure or not
-
-    Notes
-    -----
-    This function does not return or display the plot. A user must have matplotlib imported in addition to arkouda to
-    display plots. This could be updated to return the object or have a flag to show the resulting plots.
-    See Examples Below.
-
-    Examples
-    --------
-    >>> import arkouda as ak
-    >>> from matplotlib import pyplot as plt
-    >>> b, h = ak.histogram(ak.arange(10), 3)
-    >>> ak.plot_dist(b, h)
-    >>> # to show the plot
-    >>> plt.show()
-    """
     if newfig:
         plt.figure(figsize=(12, 5))
     plt.subplot(1, 2, 1)

--- a/arkouda/plotting.py
+++ b/arkouda/plotting.py
@@ -12,8 +12,8 @@ def plot_dist(b, h, log=True, xlabel=None, newfig=True):
     """
     Plot the distribution and cumulative distribution of histogram Data
 
-    Params
-    _______
+    Parameters
+    ----------
     b : np.ndarray
         Bin edges
     h : np.ndarray
@@ -26,13 +26,13 @@ def plot_dist(b, h, log=True, xlabel=None, newfig=True):
         Generate a new figure or not
 
     Notes
-    _______
+    -----
     This function does not return or display the plot. A user must have matplotlib imported in addition to arkouda to
     display plots. This could be updated to return the object or have a flag to show the resulting plots.
     See Examples Below.
 
     Examples
-    _________
+    --------
     >>> import arkouda as ak
     >>> from matplotlib import pyplot as plt
     >>> b, h = ak.histogram(ak.arange(10), 3)

--- a/arkouda/plotting.py
+++ b/arkouda/plotting.py
@@ -1,13 +1,6 @@
 import numpy as np  # type: ignore
 from matplotlib import pyplot as plt  # type: ignore
 
-from arkouda.numeric import log
-
-
-def log10(x):
-    basechange = float(np.log10(np.exp(1)))
-    return basechange*log(x)
-
 def plot_dist(b, h, log=True, xlabel=None, newfig=True):
     """
     Plot the distribution and cumulative distribution of histogram Data

--- a/arkouda/plotting.py
+++ b/arkouda/plotting.py
@@ -9,7 +9,39 @@ def log10(x):
     return basechange*log(x)
 
 def plot_dist(b, h, log=True, xlabel=None, newfig=True):
-    if newfig: plt.figure(figsize=(12, 5))
+    """
+    Plot the distribution and cumulative distribution of histogram Data
+
+    Params
+    _______
+    b : np.ndarray
+        Bin edges
+    h : np.ndarray
+        Histogram data
+    log : bool
+        use log to scale y
+    xlabel: str
+        Label for the x axis of the graph
+    newfig: bool
+        Generate a new figure or not
+
+    Notes
+    _______
+    This function does not return or display the plot. A user must have matplotlib imported in addition to arkouda to
+    display plots. This could be updated to return the object or have a flag to show the resulting plots.
+    See Examples Below.
+
+    Examples
+    _________
+    >>> import arkouda as ak
+    >>> from matplotlib import pyplot as plt
+    >>> b, h = ak.histogram(ak.arange(10), 3)
+    >>> ak.plot_dist(b, h)
+    >>> # to show the plot
+    >>> plt.show()
+    """
+    if newfig:
+        plt.figure(figsize=(12, 5))
     plt.subplot(1, 2, 1)
     plt.plot(b, h, marker='.', linestyle='solid')
     if log:

--- a/arkouda/plotting.py
+++ b/arkouda/plotting.py
@@ -1,0 +1,25 @@
+import numpy as np
+from matplotlib import pyplot as plt
+
+from arkouda.numeric import log
+
+
+def log10(x):
+    basechange = float(np.log10(np.exp(1)))
+    return basechange*log(x)
+
+def plot_dist(b, h, log=True, xlabel=None, newfig=True):
+    if newfig: plt.figure(figsize=(12, 5))
+    plt.subplot(1, 2, 1)
+    plt.plot(b, h, marker='.', linestyle='solid')
+    if log:
+        plt.yscale('log')
+    if xlabel is not None:
+        plt.gca().set_xlabel(xlabel, fontsize=14)
+    plt.gca().set_title('distribution')
+    plt.subplot(1, 2, 2)
+    plt.plot(b, np.cumsum(h)/np.sum(h), marker=None, linestyle='solid')
+    plt.gca().set_ylim((0, 1))
+    plt.gca().set_title('cumulative distribution')
+    if xlabel is not None:
+        plt.gca().set_xlabel(xlabel, fontsize=14)

--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,8 @@ setup(
         'typeguard==2.10.0',
         'tabulate',
         'pyfiglet',
-        'versioneer'
+        'versioneer',
+        'matplotlib'
     ],
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
This PR (closes #1273):

Plotting functionality has been moved to `arkouda/plotting.py`. Because `hist()` was moved to `arkouda/numeric.py` to update `ak.histogram()`, it has been removed from `arkouda/plotting.py`.

I was unsure of the best way to test the plotting. `matplotlib` has functionality to verify the resulting plots ([Documented Here](https://matplotlib.org/3.5.0/devel/testing.html)). This would require saving off and storing an example image though. If anyone has any suggestions on testing the plotting, please let me know.