### PR TITLE
Unify various file reading functions into a single read function

### DIFF
--- a/akutil/akutil/read.py
+++ b/akutil/akutil/read.py
@@ -2,7 +2,7 @@ import arkouda as ak
 import akutil as aku
 
 def _read_chunk(files, start, end, filterfunc=None, **kwargs):
-    chunk = ak.read_all(files[start:min((end, len(files)))], **kwargs)
+    chunk = ak.read(files[start:min((end, len(files)))], **kwargs)
     # Single datasets will get squeezed into a pdarray, so stuff back into a dict
     if type(chunk) != dict:
         if 'datasets' in kwargs:
@@ -57,7 +57,7 @@ def read_checkpointed(files, filterfunc=None, prior_data=None, prefix=None,
         A mapping of column name to function that will be called on that column
         after it is read. If a column is not present, no error is raised.
     kwargs
-        Passed to ak.read_all()
+        Passed to ak.read()
 
     Returns
     -------

--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -270,7 +270,7 @@ def get_datasets(filename : str) -> List[str]:
         datasets.remove(ARKOUDA_HDF5_FILE_METADATA_GROUP)
     return datasets
 
-def get_filetype(filename: Union[str, list[str]]) -> str:
+def get_filetype(filenames: Union[str, List[str]]) -> str:
     """
     Get the type of a file accessible to the server. Supported
     file types and possible return strings are 'HDF5' and 'Parquet'.
@@ -294,8 +294,8 @@ def get_filetype(filename: Union[str, list[str]]) -> str:
     --------
     read
     """
-    if isinstance(filename, list):
-        fname = filename[0]
+    if isinstance(filenames, list):
+        fname = filenames[0]
     if not (fname and fname.strip()):
         raise ValueError("filename cannot be an empty string")
 

--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -148,7 +148,7 @@ def read(filenames : Union[str, List[str]],
         cmd = 'readany'
     if iterative == True: # iterative calls to server readhdf
         return {dset: read(filenames, dset, strictTypes=strictTypes, allow_errors=allow_errors, iterative=False,
-                           calc_string_offsets=calc_string_offsets) for dset in datasets}
+                           calc_string_offsets=calc_string_offsets)[dset] for dset in datasets}
     else:
         rep_msg = generic_msg(cmd=cmd, args=
         f"{strictTypes} {len(datasets)} {len(filenames)} {allow_errors} {calc_string_offsets} {json.dumps(datasets)} | {json.dumps(filenames)}"
@@ -187,7 +187,7 @@ def read(filenames : Union[str, List[str]],
             raise RuntimeError("No items were returned")
 
 @typechecked
-def load(path_prefix : str, dataset : str='array', calc_string_offsets:bool = False) -> Union[pdarray,Strings]:
+def load(path_prefix : str, dataset : str='array', calc_string_offsets:bool = False) -> Union[pdarray, Strings, Mapping[str,Union[pdarray,Strings]]]:
     """
     Load a pdarray previously saved with ``pdarray.save()``.
 
@@ -299,7 +299,7 @@ def get_filetype(filename: Union[str, list[str]]) -> str:
     if not (fname and fname.strip()):
         raise ValueError("filename cannot be an empty string")
 
-    return generic_msg(cmd="getfiletype", args="{}".format(json.dumps([fname])))
+    return cast(str, generic_msg(cmd="getfiletype", args="{}".format(json.dumps([fname]))))
 
 @typechecked
 def get_datasets_allow_errors(filenames: List[str]) -> List[str]:

--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -219,7 +219,7 @@ def load(path_prefix : str, dataset : str='array', calc_string_offsets:bool = Fa
 
     See Also
     --------
-    save, load_all, read, read
+    save, load_all, read
     """
     prefix, extension = os.path.splitext(path_prefix)
     globstr = "{}_LOCALE*{}".format(prefix, extension)
@@ -369,7 +369,7 @@ def load_all(path_prefix: str) -> Mapping[str, Union[pdarray, Strings, Categoric
 
     See Also
     --------
-    save_all, load, read, read
+    save_all, load, read
     """
     prefix, extension = os.path.splitext(path_prefix)
     firstname = "{}_LOCALE0000{}".format(prefix, extension)

--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -7,8 +7,8 @@ from arkouda.pdarrayclass import pdarray, create_pdarray
 from arkouda.strings import Strings
 from arkouda.categorical import Categorical
 
-__all__ = ["ls", "read_hdf", "read_all", "load", "get_datasets",
-           "load_all", "save_all", "read_parquet"]
+__all__ = ["ls", "read", "load", "get_datasets",
+           "load_all", "save_all",  "get_filetype"]
 
 ARKOUDA_HDF5_FILE_METADATA_GROUP = "_arkouda_metadata"
 
@@ -44,183 +44,16 @@ def ls(filename : str) -> List[str]:
     cmd = 'lsany'
     return json.loads(cast(str,generic_msg(cmd=cmd, args="{}".format(json.dumps([filename])))))
 
-@typechecked
-def read_hdf(dsetName : str, filenames : Union[str,List[str]],
-             strictTypes: bool=True, allow_errors:bool = False, calc_string_offsets:bool = False) \
-          -> Union[pdarray, Strings]:
+def read(filenames : Union[str, List[str]],
+         datasets: Optional[Union[str, List[str]]] = None,
+         iterative: bool = False,
+         strictTypes: bool = True,
+         allow_errors: bool = False,
+         calc_string_offsets = False,
+         file_format: str = 'infer')\
+         -> Union[pdarray, Strings, Mapping[str,Union[pdarray,Strings]]]:
     """
-    Read a single dataset from multiple HDF5 files into an Arkouda
-    pdarray or Strings object.
-
-    Parameters
-    ----------
-    dsetName : str
-        The name of the dataset (must be the same across all files)
-    filenames : list or str
-        Either a list of filenames or shell expression
-    strictTypes: bool
-        If True (default), require all dtypes in all files to have the
-        same precision and sign. If False, allow dtypes of different
-        precision and sign across different files. For example, if one 
-        file contains a uint32 dataset and another contains an int64
-        dataset, the contents of both will be read into an int64 pdarray.
-    allow_errors: bool
-        Default False, if True will allow files with read errors to be skipped
-        instead of failing.  A warning will be included in the return containing
-        the total number of files skipped due to failure and up to 10 filenames.
-    calc_string_offsets: bool
-        Default False, if True this will tell the server to calculate the
-        offsets/segments array on the server versus loading them from HDF5 files.
-        In the future this option may be set to True as the default.
-
-    Returns
-    -------
-    Union[pdarray,Strings] 
-        A pdarray or Strings instance pointing to the server-side data
-
-    Raises
-    ------
-    TypeError 
-        Raised if dsetName is not a str or if filenames is neither a string
-        nor a list of strings
-    ValueError 
-        Raised if all datasets are not present in all hdf5 files  
-    RuntimeError
-        Raised if one or more of the specified files cannot be opened  
-
-    See Also
-    --------
-    get_datasets, ls, read_all, load, save
-
-    Notes
-    -----
-    If filenames is a string, it is interpreted as a shell expression
-    (a single filename is a valid expression, so it will work) and is
-    expanded with glob to read all matching files. Use ``get_datasets`` to
-    show the names of datasets in HDF5 files.
-
-    If dsetName is not present in all files, a TypeError is raised.
-    """
-    if isinstance(filenames, str):
-        filenames = [filenames]
-    # rep_msg = generic_msg("readhdf {} {:n} {}".format(dsetName, len(filenames), json.dumps(filenames)))
-    # # This is a hack to detect a string return type
-    # # In the future, we should put the number and type into the return message
-    # if '+' in rep_msg:
-    #     return Strings(*rep_msg.split('+'))
-    # else:
-    #     return create_pdarray(rep_msg)
-    return cast(Union[pdarray, Strings],
-                read_all(filenames, datasets=dsetName, strictTypes=strictTypes, allow_errors=allow_errors,
-                         calc_string_offsets=calc_string_offsets))
-
-def read_parquet(filenames : Union[str, List[str]],
-                 datasets : Union[str, List[str]]=None,
-                 strictTypes: bool=True, allow_errors:bool = False)\
-             -> Union[pdarray, Strings, Mapping[str,Union[pdarray,Strings]]]:
-    """
-    Read a single dataset from multiple Parquet files into an Arkouda
-    pdarray object.
-
-    Parameters
-    ----------
-    filenames : list or str
-        Either a list of filenames or shell expression
-    datasets : str
-        The names of datasets to be read (must be the same across all files).
-        Defaults to all supported columns.
-    strictTypes: bool
-        If True (default), require all dtypes in all files to have the
-        same precision and sign. If False, allow dtypes of different
-        precision and sign across different files. For example, if one 
-        file contains a uint32 dataset and another contains an int64
-        dataset, the contents of both will be read into an int64 pdarray.
-    allow_errors: bool
-        Default False, if True will allow files with read errors to be skipped
-        instead of failing.  A warning will be included in the return containing
-        the total number of files skipped due to failure and up to 10 filenames.
-
-    Returns
-    -------
-    pdarray
-        A pdarray instance pointing to the server-side data
-
-    Raises
-    ------
-    TypeError 
-        Raised if dsetName is not a str or if filenames is neither a string
-        nor a list of strings
-    ValueError 
-        Raised if all datasets are not present in all parquet files  
-    RuntimeError
-        Raised if one or more of the specified files cannot be opened  
-
-    See Also
-    --------
-    read_hdf, get_datasets, ls, read_all, load, save
-
-    Notes
-    -----
-    If filenames is a string, it is interpreted as a shell expression
-    (a single filename is a valid expression, so it will work) and is
-    expanded with glob to read all matching files. Use ``get_datasets`` to
-    show the names of datasets in Parquet files.
-
-    If dsetName is not present in all files, a TypeError is raised.
-    """
-    if isinstance(filenames, str):
-        filenames = [filenames]
-    if datasets is None:
-        datasets = get_datasets_allow_errors(filenames) if allow_errors else get_datasets(filenames[0])
-    if isinstance(datasets, str):
-        datasets = [datasets]
-
-    nonexistent = set(datasets) - \
-        (set(get_datasets_allow_errors(filenames)) if allow_errors else set(get_datasets(filenames[0])))
-    if len(nonexistent) > 0:
-        raise ValueError("Dataset(s) not found: {}".format(nonexistent))
-
-    rep_msg = generic_msg(cmd="readAllParquet", args=
-                          f"{strictTypes} {len(datasets)} {len(filenames)} {allow_errors} {json.dumps(datasets)} | {json.dumps(filenames)}")
-    rep = json.loads(rep_msg)  # See GenSymIO._buildReadAllHdfMsgJson for json structure
-    items = rep["items"] if "items" in rep else []
-    file_errors = rep["file_errors"] if "file_errors" in rep else []
-
-    # We have a couple possible return conditions
-    # 1. We have multiple items returned i.e. multi pdarrays
-    # 2. We have a single pdarray
-    # TODO: add support for a string objects in Parquet
-    if len(items) > 1: #  DataSets condition
-        d: Dict[str, Union[pdarray, Strings]] = {}
-        for item in items:
-            if "seg_string" == item["arkouda_type"]:
-                d[item["dataset_name"]] = Strings.from_return_msg(item["created"])
-            elif "pdarray" == item["arkouda_type"]:
-                d[item["dataset_name"]] = create_pdarray(item["created"])
-            else:
-                raise TypeError(f"Unknown arkouda type:{item['arkouda_type']}")
-        return d
-
-    elif len(items) == 1:
-        item = items[0]
-        if "pdarray" == item["arkouda_type"]:
-            return create_pdarray(item["created"])
-        elif "seg_string" == item["arkouda_type"]:
-            return Strings.from_return_msg(item["created"])
-        else:
-            raise TypeError(f"Unknown arkouda type:{item['arkouda_type']}")
-    else:
-        raise RuntimeError("No items were returned")
-
-def read_all(filenames : Union[str, List[str]],
-             datasets: Optional[Union[str, List[str]]] = None,
-             iterative: bool = False,
-             strictTypes: bool = True,
-             allow_errors: bool = False,
-             calc_string_offsets = False)\
-             -> Union[pdarray, Strings, Mapping[str,Union[pdarray,Strings]]]:
-    """
-    Read datasets from HDF5 files.
+    Read datasets from HDF5 or Parquet files.
 
     Parameters
     ----------
@@ -245,6 +78,11 @@ def read_all(filenames : Union[str, List[str]],
         Default False, if True this will tell the server to calculate the
         offsets/segments array on the server versus loading them from HDF5 files.
         In the future this option may be set to True as the default.
+    file_format: str
+        Default 'infer', if 'HDF5' or 'Parquet' (case insensitive), the file
+        type checking will be skipped and will execute expecting all files in
+        filenames to be of the specified type. Otherwise, will infer filetype
+        based off of first file in filenames, expanded if a glob expression.
 
     Returns
     -------
@@ -267,7 +105,7 @@ def read_all(filenames : Union[str, List[str]],
 
     See Also
     --------
-    read_hdf, get_datasets, ls
+    read, get_datasets, ls
 
     Notes
     -----
@@ -297,13 +135,24 @@ def read_all(filenames : Union[str, List[str]],
             (set(get_datasets_allow_errors(filenames)) if allow_errors else set(get_datasets(filenames[0])))
         if len(nonexistent) > 0:
             raise ValueError("Dataset(s) not found: {}".format(nonexistent))
+
+    file_format = file_format.lower()
+    if file_format == 'infer':
+        cmd = 'readany'
+    elif file_format == 'hdf5':
+        cmd = 'readAllHdf'
+    elif file_format == 'parquet':
+        cmd = 'readAllParquet'
+    else:
+        warnings.warn(f"Unrecognized file format string: {file_format}. Inferring file type")
+        cmd = 'readany'
     if iterative == True: # iterative calls to server readhdf
-        return {dset: read_hdf(dset, filenames, strictTypes=strictTypes, allow_errors=allow_errors,
-                               calc_string_offsets=calc_string_offsets) for dset in datasets}
-    else:  # single call to server readAllHdf
-        rep_msg = generic_msg(cmd="readAllHdf", args=
+        return {dset: read(filenames, dset, strictTypes=strictTypes, allow_errors=allow_errors, iterative=False,
+                           calc_string_offsets=calc_string_offsets) for dset in datasets}
+    else:
+        rep_msg = generic_msg(cmd=cmd, args=
         f"{strictTypes} {len(datasets)} {len(filenames)} {allow_errors} {calc_string_offsets} {json.dumps(datasets)} | {json.dumps(filenames)}"
-                              )
+                          )
         rep = json.loads(rep_msg)  # See GenSymIO._buildReadAllHdfMsgJson for json structure
         items = rep["items"] if "items" in rep else []
         file_errors = rep["file_errors"] if "file_errors" in rep else []
@@ -336,7 +185,6 @@ def read_all(filenames : Union[str, List[str]],
                 raise TypeError(f"Unknown arkouda type:{item['arkouda_type']}")
         else:
             raise RuntimeError("No items were returned")
-
 
 @typechecked
 def load(path_prefix : str, dataset : str='array', calc_string_offsets:bool = False) -> Union[pdarray,Strings]:
@@ -371,13 +219,13 @@ def load(path_prefix : str, dataset : str='array', calc_string_offsets:bool = Fa
 
     See Also
     --------
-    save, load_all, read_hdf, read_all
+    save, load_all, read, read
     """
     prefix, extension = os.path.splitext(path_prefix)
     globstr = "{}_LOCALE*{}".format(prefix, extension)
 
     try:
-        return read_hdf(dataset, globstr, calc_string_offsets=calc_string_offsets)
+        return read(globstr, dataset, calc_string_offsets=calc_string_offsets)
     except RuntimeError as re:
         if 'does not exist' in str(re):
             raise ValueError('There are no files corresponding to the ' +
@@ -422,6 +270,37 @@ def get_datasets(filename : str) -> List[str]:
         datasets.remove(ARKOUDA_HDF5_FILE_METADATA_GROUP)
     return datasets
 
+def get_filetype(filename: Union[str, list[str]]) -> str:
+    """
+    Get the type of a file accessible to the server. Supported
+    file types and possible return strings are 'HDF5' and 'Parquet'.
+
+    Parameters
+    ----------
+    filenames : Union[str, List[str]]
+        A file or list of files visible to the arkouda server
+
+    Returns
+    -------
+    str
+        Type of the file returned as a string, either 'HDF5' or 'Parquet'
+
+    Raises
+    ------
+    ValueError
+        Raised if filename is empty or contains only whitespace
+
+    See Also
+    --------
+    read
+    """
+    if isinstance(filename, list):
+        fname = filename[0]
+    if not (fname and fname.strip()):
+        raise ValueError("filename cannot be an empty string")
+
+    return generic_msg(cmd="getfiletype", args="{}".format(json.dumps([fname])))
+
 @typechecked
 def get_datasets_allow_errors(filenames: List[str]) -> List[str]:
     """
@@ -432,8 +311,6 @@ def get_datasets_allow_errors(filenames: List[str]) -> List[str]:
     ----------
     filenames : List[str]
         A list of HDF5 files visible to the arkouda server
-    is_parquet : bool
-        Is filename a Parquet file; false by default
 
     Returns
     -------
@@ -492,7 +369,7 @@ def load_all(path_prefix: str) -> Mapping[str, Union[pdarray, Strings, Categoric
 
     See Also
     --------
-    save_all, load, read_hdf, read_all
+    save_all, load, read, read
     """
     prefix, extension = os.path.splitext(path_prefix)
     firstname = "{}_LOCALE0000{}".format(prefix, extension)

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1036,7 +1036,7 @@ class pdarray:
 
         See Also
         --------
-        save_all, load, read_hdf, read_all
+        save_all, load, read
 
         Notes
         -----
@@ -1119,7 +1119,7 @@ class pdarray:
 
         See Also
         --------
-        save, save_all, load, read_hdf, read_all
+        save, save_all, load, read
 
         Notes
         -----
@@ -1141,7 +1141,7 @@ class pdarray:
 
         The array can be read back in as follows
 
-        >>> b = ak.read_parquet('arkouda_range')
+        >>> b = ak.read('arkouda_range')
         >>> (a == b).all()
         True
         """

--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -12,7 +12,7 @@ from arkouda.pdarrayclass import attach_pdarray, pdarray, create_pdarray
 from arkouda.pdarraysetops import concatenate as pdarrayconcatenate
 from arkouda.pdarraycreation import arange
 from arkouda.pdarraysetops import unique
-from arkouda.pdarrayIO import read_hdf
+from arkouda.pdarrayIO import read
 from arkouda.client import get_config, get_mem_used, generic_msg
 from arkouda.groupbyclass import GroupBy, broadcast, coargsort
 from arkouda.infoclass import information, AllSymbols

--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -3,6 +3,7 @@ import re
 import numpy as np  # type: ignore
 import h5py #type: ignore
 import os
+from typing import Union, Mapping
 
 from arkouda import __version__
 from arkouda.client_dtypes import BitVector, BitVectorizer, IPv4
@@ -16,6 +17,7 @@ from arkouda.client import get_config, get_mem_used
 from arkouda.groupbyclass import GroupBy, broadcast, coargsort
 from arkouda.infoclass import information, AllSymbols
 from arkouda.categorical import Categorical
+from arkouda.strings import Strings
 
 identity = lambda x: x
 
@@ -254,7 +256,7 @@ def arkouda_to_numpy(A: pdarray, tmp_dir: str='') -> np.ndarray:
     return B
 
 
-def numpy_to_arkouda(A: np.ndarray, tmp_dir: str = '') -> pdarray:
+def numpy_to_arkouda(A: np.ndarray, tmp_dir: str = '') -> Union[pdarray, Strings, Mapping[str, Union[pdarray, Strings]]]:
     """
     Convert from numpy to arkouda using disk rather than sockets.
     """

--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -11,7 +11,7 @@ from arkouda.pdarrayclass import attach_pdarray, pdarray
 from arkouda.pdarraysetops import concatenate as pdarrayconcatenate
 from arkouda.pdarraycreation import arange
 from arkouda.pdarraysetops import unique
-from arkouda.pdarrayIO import read_hdf
+from arkouda.pdarrayIO import read
 from arkouda.client import get_config, get_mem_used
 from arkouda.groupbyclass import GroupBy, broadcast, coargsort
 from arkouda.infoclass import information, AllSymbols
@@ -264,7 +264,7 @@ def numpy_to_arkouda(A: np.ndarray, tmp_dir: str = '') -> pdarray:
         arr = f.create_dataset('arr', (A.shape[0],), dtype='int64')
         arr[:] = A[:]
 
-    B = read_hdf('arr', f'{tmp_dir}/{rng}.hdf5')
+    B = read(f'{tmp_dir}/{rng}.hdf5', 'arr')
     os.remove(f'{tmp_dir}/{rng}.hdf5')
 
     return B

--- a/benchmarks/IO.py
+++ b/benchmarks/IO.py
@@ -49,7 +49,7 @@ def time_ak_read(N_per_locale, numfiles, trials, dtype, path, seed, parquet):
     readtimes = []
     for i in range(trials):
         start = time.time()
-        a = ak.read_all(path+'*') if not parquet else ak.read_parquet(path+'*')
+        a = ak.read(path+'*')
         end = time.time()
         readtimes.append(end - start)
     avgread = sum(readtimes) / trials
@@ -82,7 +82,7 @@ def check_correctness(dtype, path, seed, parquet, multifile=False):
     if multifile:
         b.save(f"{path}{2}") if not parquet else b.save_parquet(f"{path}{2}")
 
-    c = ak.read_all(path+'*') if not parquet else ak.read_parquet(path+'*')
+    c = ak.read(path+'*')
     
     for f in glob(path+"*"):
         os.remove(f)

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -483,7 +483,7 @@ module ParquetMsg {
   proc readAllParquetMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
     var repMsg: string;
     // May need a more robust delimiter then " | "
-    var (strictFlag, ndsetsStr, nfilesStr, allowErrorsFlag, arraysStr) = payload.splitMsgToTuple(5);
+    var (strictFlag, ndsetsStr, nfilesStr, allowErrorsFlag, hdfArgPlaceholder, arraysStr) = payload.splitMsgToTuple(6);
     var strictTypes: bool = true;
     if (strictFlag.toLower().strip() == "false") {
       strictTypes = false;

--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -143,6 +143,8 @@ proc main() {
         registerFunction("getCmdMap", getCommandMapMsg);
         registerFunction("clear", clearMsg);
         registerFunction("lsany", lsAnyMsg);
+        registerFunction("readany", readAnyMsg);
+        registerFunction("getfiletype", getFileTypeMsg);
 
         // For a few specialized cmds we're going to add dummy functions, so they
         // get added to the client listing of available commands. They will be

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -208,20 +208,20 @@ class IOTest(ArkoudaTest):
         self._create_file(columns=self.dict_single_column, 
                           prefix_path='{}/iotest_single_column_dupe'.format(IOTest.io_test_dir))
         
-        dataset = ak.read_hdf(dsetName='int_tens_pdarray', 
-                    filenames=['{}/iotest_single_column_LOCALE0000'.format(IOTest.io_test_dir),
-                               '{}/iotest_single_column_dupe_LOCALE0000'.format(IOTest.io_test_dir)])
+        dataset = ak.read(filenames=['{}/iotest_single_column_LOCALE0000'.format(IOTest.io_test_dir),
+                                     '{}/iotest_single_column_dupe_LOCALE0000'.format(IOTest.io_test_dir)],
+                          datasets='int_tens_pdarray')
         self.assertIsNotNone(dataset)
 
         with self.assertRaises(RuntimeError) as cm:
-            ak.read_hdf(dsetName='in_tens_pdarray', 
-                    filenames=['{}/iotest_single_column_LOCALE0000'.format(IOTest.io_test_dir),
-                               '{}/iotest_single_column_dupe_LOCALE0000'.format(IOTest.io_test_dir)])
+            ak.read(filenames=['{}/iotest_single_column_LOCALE0000'.format(IOTest.io_test_dir),
+                               '{}/iotest_single_column_dupe_LOCALE0000'.format(IOTest.io_test_dir)],
+                    datasets='in_tens_pdarray', )
         
         with self.assertRaises(RuntimeError) as cm:
-            ak.read_hdf(dsetName='int_tens_pdarray', 
-                    filenames=['{}/iotest_single_colum_LOCALE0000'.format(IOTest.io_test_dir),
-                               '{}/iotest_single_colum_dupe_LOCALE0000'.format(IOTest.io_test_dir)])
+            ak.read(filenames=['{}/iotest_single_colum_LOCALE0000'.format(IOTest.io_test_dir),
+                               '{}/iotest_single_colum_dupe_LOCALE0000'.format(IOTest.io_test_dir)],
+                    datasets='int_tens_pdarray', )
 
     def testReadHdfWithGlob(self):
         ''' DEPRECATED - all client calls route to `readAllHdf`
@@ -238,8 +238,8 @@ class IOTest(ArkoudaTest):
         self._create_file(columns=self.dict_single_column, 
                           prefix_path='{}/iotest_single_column_dupe'.format(IOTest.io_test_dir))
         
-        dataset = ak.read_hdf(dsetName='int_tens_pdarray', 
-                    filenames='{}/iotest_single_column*'.format(IOTest.io_test_dir))
+        dataset = ak.read(filenames='{}/iotest_single_column*'.format(IOTest.io_test_dir),
+                          datasets='int_tens_pdarray', )
         self.assertEqual(self.int_tens_pdarray.all(), dataset.all())
 
     def testReadAll(self):
@@ -254,7 +254,7 @@ class IOTest(ArkoudaTest):
         self._create_file(columns=self.dict_columns, 
                           prefix_path='{}/iotest_dict_columns'.format(IOTest.io_test_dir))
         
-        dataset = ak.read_all(filenames=['{}/iotest_dict_columns_LOCALE0000'.format(IOTest.io_test_dir)])
+        dataset = ak.read(filenames=['{}/iotest_dict_columns_LOCALE0000'.format(IOTest.io_test_dir)])
         self.assertEqual(4, len(list(dataset.keys())))     
         
     def testReadAllWithGlob(self):
@@ -270,7 +270,7 @@ class IOTest(ArkoudaTest):
         self._create_file(columns=self.dict_columns, 
                           prefix_path='{}/iotest_dict_columns'.format(IOTest.io_test_dir))
          
-        retrieved_columns = ak.read_all(filenames='{}/iotest_dict_columns*'.format(IOTest.io_test_dir))
+        retrieved_columns = ak.read(filenames='{}/iotest_dict_columns*'.format(IOTest.io_test_dir))
 
         itp = self.list_columns[0].to_ndarray()
         itp.sort()
@@ -298,21 +298,22 @@ class IOTest(ArkoudaTest):
                           prefix_path=f'{IOTest.io_test_dir}/iotest_single_column_dupe')
 
         # Make sure we can read ok
-        dataset = ak.read_all(filenames=[f'{IOTest.io_test_dir}/iotest_single_column_LOCALE0000',
-                                         f'{IOTest.io_test_dir}/iotest_single_column_dupe_LOCALE0000'])
+        dataset = ak.read(filenames=[f'{IOTest.io_test_dir}/iotest_single_column_LOCALE0000',
+                                     f'{IOTest.io_test_dir}/iotest_single_column_dupe_LOCALE0000'])
         self.assertIsNotNone(dataset, "Expected dataset to be populated")
 
         # Change the name of the first file we try to raise an error due to file missing.
         with self.assertRaises(RuntimeError):
-            dataset = ak.read_all(filenames=[f'{IOTest.io_test_dir}/iotest_MISSING_single_column_LOCALE0000',
-                                             f'{IOTest.io_test_dir}/iotest_single_column_dupe_LOCALE0000'])
+            dataset = ak.read(filenames=[f'{IOTest.io_test_dir}/iotest_MISSING_single_column_LOCALE0000',
+                                         f'{IOTest.io_test_dir}/iotest_single_column_dupe_LOCALE0000'])
 
         # Run the same test with missing file, but this time with the warning flag for read_all
         with pytest.warns(RuntimeWarning, match=r"There were .* errors reading files on the server.*"):
-            dataset = ak.read_all(filenames=[f'{IOTest.io_test_dir}/iotest_MISSING_single_column_LOCALE0000',
+            dataset = ak.read(filenames=[f'{IOTest.io_test_dir}/iotest_MISSING_single_column_LOCALE0000',
                                          f'{IOTest.io_test_dir}/iotest_single_column_dupe_LOCALE0000'],
                               strictTypes=False,
-                              allow_errors=True)
+                              allow_errors=True,
+                              file_format='HDF5')
         self.assertIsNotNone(dataset, "Expected dataset to be populated")
 
     def testLoad(self):
@@ -411,25 +412,25 @@ class IOTest(ArkoudaTest):
         self.assertTrue((strings == r_strings).all())
 
         # Read a part of a saved Strings dataset from one hdf5 file
-        r_strings_subset = ak.read_all(filenames='{}/strings-test_LOCALE0000'.\
+        r_strings_subset = ak.read(filenames='{}/strings-test_LOCALE0000'.\
                                     format(IOTest.io_test_dir))
         self.assertIsNotNone(r_strings_subset)
         self.assertTrue(isinstance(r_strings_subset[0], str))    
-        self.assertIsNotNone(ak.read_hdf(filenames='{}/strings-test_LOCALE0000'.\
-                            format(IOTest.io_test_dir), dsetName='strings/values'))
-        self.assertIsNotNone(ak.read_hdf(filenames='{}/strings-test_LOCALE0000'.\
-                            format(IOTest.io_test_dir), dsetName='strings/segments'))
+        self.assertIsNotNone(ak.read(filenames='{}/strings-test_LOCALE0000'.\
+                            format(IOTest.io_test_dir), datasets='strings/values'))
+        self.assertIsNotNone(ak.read(filenames='{}/strings-test_LOCALE0000'.\
+                            format(IOTest.io_test_dir), datasets='strings/segments'))
 
 
         # Repeat the test using the calc_string_offsets=True option to have server calculate offsets array
-        r_strings_subset = ak.read_all(filenames=f'{IOTest.io_test_dir}/strings-test_LOCALE0000',
+        r_strings_subset = ak.read(filenames=f'{IOTest.io_test_dir}/strings-test_LOCALE0000',
                                        calc_string_offsets=True)
         self.assertIsNotNone(r_strings_subset)
         self.assertTrue(isinstance(r_strings_subset[0], str))
-        self.assertIsNotNone(ak.read_hdf(filenames=f'{IOTest.io_test_dir}/strings-test_LOCALE0000',
-                                         dsetName='strings/values', calc_string_offsets=True))
-        self.assertIsNotNone(ak.read_hdf(filenames=f'{IOTest.io_test_dir}/strings-test_LOCALE0000',
-                                         dsetName='strings/segments', calc_string_offsets=True))
+        self.assertIsNotNone(ak.read(filenames=f'{IOTest.io_test_dir}/strings-test_LOCALE0000',
+                                         datasets='strings/values', calc_string_offsets=True))
+        self.assertIsNotNone(ak.read(filenames=f'{IOTest.io_test_dir}/strings-test_LOCALE0000',
+                                         datasets='strings/segments', calc_string_offsets=True))
 
     def testStringsWithoutOffsets(self):
         """
@@ -545,9 +546,9 @@ class IOTest(ArkoudaTest):
                 fdata = np.arange(i*N, (i+1)*N, dtype=ft)
                 f.create_dataset('floats', data=fdata)
         with self.assertRaises(RuntimeError):
-            ak.read_all(prefix+'*')
+            ak.read(prefix+'*')
 
-        a = ak.read_all(prefix+'*', strictTypes=False)
+        a = ak.read(prefix+'*', strictTypes=False)
         self.assertTrue((a['integers'] == ak.arange(len(inttypes)*N)).all())
         self.assertTrue(np.allclose(a['floats'].to_ndarray(), np.arange(len(floattypes)*N, dtype=np.float64)))
     
@@ -615,7 +616,7 @@ class IOTest(ArkoudaTest):
         my_arrays = {'foo"0"': ak.arange(100), 'bar"': ak.arange(100)}
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
             ak.save_all(my_arrays, f"{tmp_dirname}/bad_dataset_names")
-            ak.read_all(f"{tmp_dirname}/bad_dataset_names*")
+            ak.read(f"{tmp_dirname}/bad_dataset_names*")
 
     def testInternalVersions(self):
         """

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -22,7 +22,7 @@ def read_write_test(dtype):
         ak_arr = ak.random_strings_uniform(1, 10, SIZE)
 
     ak_arr.save_parquet("pq_testcorrect", "my-dset")
-    pq_arr = ak.read_parquet("pq_testcorrect*", "my-dset")
+    pq_arr = ak.read("pq_testcorrect*", "my-dset")
     
     for f in glob.glob('pq_test*'):
         os.remove(f)
@@ -48,7 +48,7 @@ def read_write_multi_test(dtype):
         test_arrs.append(elems[(i*per_arr):(i*per_arr)+per_arr])
         test_arrs[i].save_parquet(f"pq_test{i:04d}", "test-dset")
 
-    pq_arr = ak.read_parquet("pq_test*", "test-dset")
+    pq_arr = ak.read("pq_test*", "test-dset")
     
     for f in glob.glob('pq_test*'):
         os.remove(f)
@@ -93,7 +93,7 @@ def append_test():
     for key in ak_dict:
         ak_dict[key].save_parquet("pq_testcorrect", key, mode='append')
 
-    ak_vals = ak.read_parquet("pq_testcorrect*")
+    ak_vals = ak.read("pq_testcorrect*")
     
     for f in glob.glob('pq_test*'):
         os.remove(f)
@@ -116,11 +116,11 @@ class ParquetTest(ArkoudaTest):
         ak_arr = ak.randint(0, 2**32, SIZE)
         ak_arr.save_parquet("pq_test", "test-dset-name")
         
-        with self.assertRaises(ValueError) as cm:
-            ak.read_parquet("pq_test*", "wrong-dset-name")
+        with self.assertRaises(RuntimeError) as cm:
+            ak.read("pq_test*", "wrong-dset-name")
 
         with self.assertRaises(ValueError) as cm:
-            ak.read_parquet("pq_test*", ['test-dset-name', 'wrong-dset-name'])
+            ak.read("pq_test*", ['test-dset-name', 'wrong-dset-name'])
 
         for f in glob.glob("pq_test*"):
             os.remove(f)
@@ -139,7 +139,7 @@ class ParquetTest(ArkoudaTest):
                 val = 'max'
             a = ak.array([val])
             a.save_parquet("pq_test", 'test-dset')
-            ak_res = ak.read_parquet("pq_test*", 'test-dset')
+            ak_res = ak.read("pq_test*", 'test-dset')
             self.assertTrue(ak_res[0] == val)
 
             for f in glob.glob('pq_test*'):
@@ -165,7 +165,7 @@ class ParquetTest(ArkoudaTest):
         expected = ak.array(['first-string', '', 'string2', '', 'third', '', ''])
 
         filename = os.path.join(datadir, basename)
-        res = ak.read_parquet(filename)
+        res = ak.read(filename)
 
         self.assertTrue((expected == res).all())
             
@@ -201,9 +201,9 @@ class ParquetTest(ArkoudaTest):
             self.assertListEqual(columns, ans)
             # Merely test that read succeeds, do not check output
             if "delta_byte_array.parquet" not in filename:
-                data = ak.read_parquet(filename, datasets=columns)
+                data = ak.read(filename, datasets=columns)
             else:
                 # Since delta encoding is not supported, the columns in
                 # this file should raise an error and not crash the server
                 with self.assertRaises(RuntimeError) as cm:
-                    data = ak.read_parquet(filename, datasets=columns)
+                    data = ak.read(filename, datasets=columns)

--- a/tests/read_all_tests.py
+++ b/tests/read_all_tests.py
@@ -29,18 +29,18 @@ class ReadAllTest(ArkoudaTest):
         allfiles = glob(cwd+'/../converter/netflow_day-*.hdf')
         print(allfiles)
         start = time.time()
-        dictionary1 = ak.read_all(allfiles, iterative=True)
+        dictionary1 = ak.read(allfiles, iterative=True)
         end = time.time()
         t1 = end - start
-        print("read_all(iterative=True) seconds: %.3f" % (t1))
+        print("read(iterative=True) seconds: %.3f" % (t1))
         for key, value in dictionary1.items():
             print(key,type(value),value,len(value))
 
         start = time.time()
-        dictionary2 = ak.read_all(allfiles)
+        dictionary2 = ak.read(allfiles)
         end = time.time()
         t2 = end - start
-        print("read_all() seconds: %.3f" % (t2))
+        print("read() seconds: %.3f" % (t2))
         for key, value in dictionary2.items():
             print(key,type(value),value,len(value))
         
@@ -56,18 +56,18 @@ if __name__ == '__main__':
         allfiles = sys.argv[3:]
 
     start = time.time()
-    dictionary1 = ak.read_all(allfiles, iterative=True)
+    dictionary1 = ak.read(allfiles, iterative=True)
     end = time.time()
     t1 = end - start
-    print("read_all(iterative=True) seconds: %.3f" % (t1))
+    print("read(iterative=True) seconds: %.3f" % (t1))
     for key, value in dictionary1.items():
         print(key,type(value),value,len(value))
 
     start = time.time()
-    dictionary2 = ak.read_all(allfiles)
+    dictionary2 = ak.read(allfiles)
     end = time.time()
     t2 = end - start
-    print("read_all() seconds: %.3f" % (t2))
+    print("read() seconds: %.3f" % (t2))
     for key, value in dictionary2.items():
         print(key,type(value),value,len(value))
 

--- a/tests/read_write_tests.py
+++ b/tests/read_write_tests.py
@@ -13,8 +13,8 @@ ak.connect(sys.argv[1], sys.argv[2])
 onefile = sys.argv[3]
 print(ak.ls(onefile))
 allfiles = sys.argv[3:]
-print(f"srcIP = ak.read_hdf('srcIP', {onefile})")
-srcIP = ak.read_hdf('srcIP', onefile)
+print(f"srcIP = ak.read({onefile},'srcIP')")
+srcIP = ak.read(onefile, 'srcIP')
 print(f"srcIP.save({saveone}, 'srcIP')")
 srcIP.save(saveone, 'srcIP')
 print(f"srcIP2 = ak.load({saveone}, 'srcIP')")
@@ -22,8 +22,8 @@ srcIP2 = ak.load(saveone, 'srcIP')
 assert (srcIP == srcIP2).all()
 del srcIP
 del srcIP2
-print(f"df = ak.read_all(['srcPort', 'proto', 'packets'], {allfiles})")
-df = ak.read_all(['srcPort', 'proto', 'packets'], allfiles)
+print(f"df = ak.read(['srcPort', 'proto', 'packets'], {allfiles})")
+df = ak.read(['srcPort', 'proto', 'packets'], allfiles)
 print(f"ak.save_all(df, {saveall})")
 ak.save_all(df, saveall)
 print(f"newdf = ak.load_all({saveall})")


### PR DESCRIPTION
This PR takes `read_hdf()`, `read_all()`, and `read_parquet()` and
combines them into a single `read()` function. This new function is
identical to the old `read_all()` function with the exception of the
`file_format` keyword argument. This defaults to `"infer"`, which
means that the server will determine the type of the file and it does
not need to be specified by the user.

This file type inference changes certain error checking behaviors
(e.g., if you have an error in one of your filenames, this will behave
differently that before with `allow_errors=True`). To still allow the
old functionality, the `file_format` keyword argument can be explicitly
set to either `HDF5` or `Parquet` (case insensitive), and it will
behave as before.

Additionally, an `ak.get_filetype()` function has been added that will
return the type of a file, or the type of the first file in a glob
expression.

Part of https://github.com/Bears-R-Us/arkouda/issues/1242