### PR TITLE
Closes #1230 - Updated `mode.lower() in 'append' / 'truncate'`

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1062,9 +1062,9 @@ class pdarray:
         >>> (a == b).all()
         True
         """
-        if mode.lower() in 'append':
+        if mode.lower() in ['a', 'app', 'append']:
             m = 1
-        elif mode.lower() in 'truncate':
+        elif mode.lower() in ['t', 'trunc', 'truncate']:
             m = 0
         else:
             raise ValueError("Allowed modes are 'truncate' and 'append'")

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1486,9 +1486,9 @@ class Strings:
         segments corresponding to the start of each string, (2) the hdf5 group is named 
         via the dataset parameter. 
         """       
-        if mode.lower() in 'append':
+        if mode.lower() in ['a', 'app', 'append']:
             m = 1
-        elif mode.lower() in 'truncate':
+        elif mode.lower() in ['t', 'trunc', 'truncate']:
             m = 0
         else:
             raise ValueError("Allowed modes are 'truncate' and 'append'")


### PR DESCRIPTION
This ticket (closes #1230 ):

Based on the suggestion in #1230 I updated the logic for saving hdf5 files in `Strings.py` and `pdarrayclass.py` to eliminate the possibility of accidental append or truncation based on passing a single letter instead of the full word. I opted to use the suggestion including ` if mode.lower() in ['a', 'app', 'append'] ` as it will allow anyone used to using 'a' or 't' instead of 'append' and 'truncate' to continue using that without issue.