### PR TITLE
Closes #1290 Add segarray setops to documentation.

### DIFF
--- a/pydoc/usage/segarray.rst
+++ b/pydoc/usage/segarray.rst
@@ -65,3 +65,22 @@ Append & Prepend
 Deduplication
 ----------
 .. autofunction:: arkouda.SegArray.remove_repeats
+
+SegArray SetOps
+===============
+
+Union
+-----
+.. autofunction:: arkouda.SegArray.union
+
+Intersect
+---------
+.. autofunction:: arkouda.SegArray.intersect
+
+Set Difference
+--------------
+.. autofunction:: arkouda.SegArray.setdiff
+
+Symmetric Difference
+--------------------
+.. autofunction:: arkouda.SegArray.setxor


### PR DESCRIPTION
This PR (closes #1290):

Adds the segarray setops to the `pydoc/usage/segarray.rst`. This adds the functions to the documentation on github pages.