### PR TITLE
Closes #1280 - `groupable` support for multiarray setops

### DIFF
--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -8,8 +8,9 @@ from arkouda.sorting import argsort
 from arkouda.strings import Strings
 from arkouda.logger import getArkoudaLogger
 from arkouda.dtypes import uint64 as akuint64
+from arkouda.dtypes import int64 as akint64
 from arkouda.dtypes import bool as akbool
-from arkouda.groupbyclass import GroupBy, groupable
+from arkouda.groupbyclass import GroupBy, groupable, groupable_element_type
 
 Categorical = ForwardRef('Categorical')
 
@@ -275,8 +276,9 @@ def concatenate(arrays: Sequence[Union[pdarray, Strings, 'Categorical', ]],  # t
         raise TypeError('arrays must be an array of pdarray or Strings objects')
 
 
-def multiarray_setop_validation(pda1: Union[List[pdarray], Tuple[pdarray, ...]],
-                                pda2: Union[List[pdarray], Tuple[pdarray, ...]]):
+def multiarray_setop_validation(pda1: Sequence[groupable_element_type],
+                                pda2: Sequence[groupable_element_type]):
+    from arkouda.categorical import Categorical as Categorical_
     if len(pda1) != len(pda2):
         raise ValueError("multi-array setops require same number of arrays in arguments.")
     size1 = set([x.size for x in pda1])
@@ -285,15 +287,15 @@ def multiarray_setop_validation(pda1: Union[List[pdarray], Tuple[pdarray, ...]],
     size2 = set([x.size for x in pda2])
     if len(size2) > 1:
         raise ValueError("multi-array setops require arrays in pda2 be the same size.")
-    atypes = [x.dtype for x in pda1]
-    btypes = [x.dtype for x in pda2]
+    atypes = [akint64 if isinstance(x, Categorical_) else x.dtype for x in pda1]
+    btypes = [akint64 if isinstance(x, Categorical_) else x.dtype for x in pda2]
     if not atypes == btypes:
         raise TypeError("Array dtypes of arguments must match")
 
 # (A1 | A2) Set Union: elements are in one or the other or both
 @typechecked
-def union1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, ...]],
-            pda2: Union[pdarray, List[pdarray], Tuple[pdarray, ...]]) -> \
+def union1d(pda1: Union[pdarray, Sequence[groupable_element_type]],
+            pda2: Union[pdarray, Sequence[groupable_element_type]]) -> \
         Union[pdarray, groupable]:
     """
     Find the union of two arrays/List of Arrays.
@@ -303,14 +305,14 @@ def union1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, ...]],
 
     Parameters
     ----------
-    pda1 : pdarray/List
-        Input array/List of input arrays
+    pda1 : pdarray/Sequence[pdarray, Strings, Categorical]
+        Input array/Sequence of groupable objectsx
     pda2 : pdarray/List
-        Input array/List of input arrays
+        Input array/sequence of groupable objects
 
     Returns
     -------
-    pdarray/List
+    pdarray/groupable
         Unique, sorted union of the input arrays.
         
     Raises
@@ -357,7 +359,7 @@ def union1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, ...]],
         return cast(pdarray,
                     unique(cast(pdarray,
                                 concatenate((unique(pda1), unique(pda2)), ordered=False))))  # type: ignore
-    elif (isinstance(pda1, list) or isinstance(pda1, tuple)) and (isinstance(pda2, list) or isinstance(pda2, tuple)):
+    elif isinstance(pda1, Sequence) and isinstance(pda2, Sequence):#(isinstance(pda1, list) or isinstance(pda1, tuple)) and (isinstance(pda2, list) or isinstance(pda2, tuple)):
         multiarray_setop_validation(pda1, pda2)
         ag = GroupBy(pda1)
         ua = ag.unique_keys
@@ -374,8 +376,8 @@ def union1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, ...]],
 
 # (A1 & A2) Set Intersection: elements have to be in both arrays
 @typechecked
-def intersect1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, ...]],
-                pda2: Union[pdarray, List[pdarray], Tuple[pdarray, ...]],
+def intersect1d(pda1: Union[pdarray, Sequence[groupable_element_type]],
+                pda2: Union[pdarray, Sequence[groupable_element_type]],
                 assume_unique: bool = False) -> Union[pdarray, groupable]:
     """
     Find the intersection of two arrays.
@@ -384,17 +386,17 @@ def intersect1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, ...]],
 
     Parameters
     ----------
-    pda1 : pdarray/List
-        Input array/List of input arrays
+    pda1 : pdarray/Sequence[pdarray, Strings, Categorical]
+        Input array/Sequence of groupable objectsx
     pda2 : pdarray/List
-        Input array/List of input arrays
+        Input array/sequence of groupable objects
     assume_unique : bool
         If True, the input arrays are both assumed to be unique, which
         can speed up the calculation.  Default is False.
 
     Returns
     -------
-    pdarray/List
+    pdarray/groupable
         Sorted 1D array/List of sorted pdarrays of common and unique elements.
 
     Raises
@@ -477,8 +479,8 @@ def intersect1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, ...]],
 
 # (A1 - A2) Set Difference: elements have to be in first array but not second
 @typechecked
-def setdiff1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, ...]],
-              pda2: Union[pdarray, List[pdarray], Tuple[pdarray, ...]],
+def setdiff1d(pda1: Union[pdarray, Sequence[groupable_element_type]],
+              pda2: Union[pdarray, Sequence[groupable_element_type]],
               assume_unique: bool = False) -> Union[pdarray, groupable]:
     """
     Find the set difference of two arrays.
@@ -487,17 +489,17 @@ def setdiff1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, ...]],
 
     Parameters
     ----------
-    pda1 : pdarray/List
-        Input array/List of input arrays
+    pda1 : pdarray/Sequence[pdarray, Strings, Categorical]
+        Input array/Sequence of groupable objectsx
     pda2 : pdarray/List
-        Input array/List of input arrays
+        Input array/sequence of groupable objects
     assume_unique : bool
         If True, the input arrays are both assumed to be unique, which
         can speed up the calculation.  Default is False.
 
     Returns
     -------
-    pdarray/List
+    pdarray/groupable
         Sorted 1D array/List of sorted pdarrays of values in `pda1` that are not in `pda2`.
 
     Raises
@@ -578,8 +580,8 @@ def setdiff1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, ...]],
 
 # (A1 ^ A2) Set Symmetric Difference: elements are not in the intersection
 @typechecked
-def setxor1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, ...]],
-             pda2: Union[pdarray, List[pdarray], Tuple[pdarray, ...]],
+def setxor1d(pda1: Union[pdarray, Sequence[groupable_element_type]],
+             pda2: Union[pdarray, Sequence[groupable_element_type]],
              assume_unique: bool = False) -> Union[pdarray, groupable]:
     """
     Find the set exclusive-or (symmetric difference) of two arrays.
@@ -589,17 +591,17 @@ def setxor1d(pda1: Union[pdarray, List[pdarray], Tuple[pdarray, ...]],
 
     Parameters
     ----------
-    pda1 : pdarray/List
-        Input array.
+    pda1 : pdarray/Sequence[pdarray, Strings, Categorical]
+        Input array/Sequence of groupable objectsx
     pda2 : pdarray/List
-        Input array.
+        Input array/sequence of groupable objects
     assume_unique : bool
         If True, the input arrays are both assumed to be unique, which
         can speed up the calculation.  Default is False.
 
     Returns
     -------
-    pdarray/List
+    pdarray/groupable
         Sorted 1D array/List of sorted pdarrays of unique values that are in only one of the input
         arrays.
 

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -306,7 +306,7 @@ def union1d(pda1: Union[pdarray, Sequence[groupable_element_type]],
     Parameters
     ----------
     pda1 : pdarray/Sequence[pdarray, Strings, Categorical]
-        Input array/Sequence of groupable objectsx
+        Input array/Sequence of groupable objects
     pda2 : pdarray/List
         Input array/sequence of groupable objects
 
@@ -359,7 +359,7 @@ def union1d(pda1: Union[pdarray, Sequence[groupable_element_type]],
         return cast(pdarray,
                     unique(cast(pdarray,
                                 concatenate((unique(pda1), unique(pda2)), ordered=False))))  # type: ignore
-    elif isinstance(pda1, Sequence) and isinstance(pda2, Sequence):#(isinstance(pda1, list) or isinstance(pda1, tuple)) and (isinstance(pda2, list) or isinstance(pda2, tuple)):
+    elif isinstance(pda1, Sequence) and isinstance(pda2, Sequence):
         multiarray_setop_validation(pda1, pda2)
         ag = GroupBy(pda1)
         ua = ag.unique_keys
@@ -387,7 +387,7 @@ def intersect1d(pda1: Union[pdarray, Sequence[groupable_element_type]],
     Parameters
     ----------
     pda1 : pdarray/Sequence[pdarray, Strings, Categorical]
-        Input array/Sequence of groupable objectsx
+        Input array/Sequence of groupable objects
     pda2 : pdarray/List
         Input array/sequence of groupable objects
     assume_unique : bool
@@ -490,7 +490,7 @@ def setdiff1d(pda1: Union[pdarray, Sequence[groupable_element_type]],
     Parameters
     ----------
     pda1 : pdarray/Sequence[pdarray, Strings, Categorical]
-        Input array/Sequence of groupable objectsx
+        Input array/Sequence of groupable objects
     pda2 : pdarray/List
         Input array/sequence of groupable objects
     assume_unique : bool
@@ -592,7 +592,7 @@ def setxor1d(pda1: Union[pdarray, Sequence[groupable_element_type]],
     Parameters
     ----------
     pda1 : pdarray/Sequence[pdarray, Strings, Categorical]
-        Input array/Sequence of groupable objectsx
+        Input array/Sequence of groupable objects
     pda2 : pdarray/List
         Input array/sequence of groupable objects
     assume_unique : bool

--- a/tests/setops_test.py
+++ b/tests/setops_test.py
@@ -91,10 +91,9 @@ class SetOpsTest(ArkoudaTest):
         
         with self.assertRaises(RuntimeError) as cm:
             ak.setxor1d(ak.array([True, False, True]), ak.array([True, True]))
-        with self.assertRaises(TypeError):
-            ak.setxor1d([-1, 0, 1], [-2, 0, 2])
 
     def testSetxor1d_Multi(self):
+        # Test Numeric pdarray
         a = [1, 2, 3, 4, 5]
         b = [1, 5, 2, 3, 4]
         c = [1, 3, 2, 5, 4]
@@ -117,6 +116,28 @@ class SetOpsTest(ArkoudaTest):
         t = ak.setxor1d((a1, a2), (b1, b2))
         self.assertListEqual(t[0].to_ndarray().tolist(), npr0)
         self.assertListEqual(t[1].to_ndarray().tolist(), npr1)
+
+        # Test for strings
+        a = ['abc', 'def']
+        b = ['123', '456']
+        c = ['abc', 'def']
+        d = ['000', '456']
+        a1 = ak.array(a)
+        a2 = ak.array(b)
+        b1 = ak.array(c)
+        b2 = ak.array(d)
+        t = ak.setxor1d([a1, a2], [b1, b2])
+        self.assertListEqual(['abc', 'abc'], t[0].to_ndarray().tolist())
+        self.assertListEqual(['000', '123'], t[1].to_ndarray().tolist())
+
+        # Test for Categorical
+        cat_a1 = ak.Categorical(a1)
+        cat_a2 = ak.Categorical(a2)
+        cat_b1 = ak.Categorical(b1)
+        cat_b2 = ak.Categorical(b2)
+        t = ak.setxor1d([cat_a1, cat_a2], [cat_b1, cat_b2])
+        self.assertListEqual(['abc', 'abc'], t[0].to_ndarray().tolist())
+        self.assertListEqual(['000', '123'], t[1].to_ndarray().tolist())
         
     def testSetdiff1d(self):
         pdaOne = ak.array([1, 2, 3, 2, 4, 1])
@@ -130,10 +151,9 @@ class SetOpsTest(ArkoudaTest):
         
         with self.assertRaises(RuntimeError) as cm:
             ak.setdiff1d(ak.array([True, False, True]), ak.array([True, True]))
-        with self.assertRaises(TypeError):
-            ak.setdiff1d([-1, 0, 1], [-2, 0, 2])
 
     def testSetDiff1d_Multi(self):
+        # Test for numeric pdarray
         a = [1, 2, 3, 4, 5]
         b = [1, 5, 2, 3, 4]
         c = [1, 3, 2, 5, 4]
@@ -151,6 +171,28 @@ class SetOpsTest(ArkoudaTest):
         self.assertListEqual(t[0].to_ndarray().tolist(), npr0)
         self.assertListEqual(t[1].to_ndarray().tolist(), npr1)
 
+        # Test for strings
+        a = ['abc', 'def']
+        b = ['123', '456']
+        c = ['abc', 'def']
+        d = ['000', '456']
+        a1 = ak.array(a)
+        a2 = ak.array(b)
+        b1 = ak.array(c)
+        b2 = ak.array(d)
+        t = ak.setdiff1d([a1, a2], [b1, b2])
+        self.assertListEqual(['abc'], t[0].to_ndarray().tolist())
+        self.assertListEqual(['123'], t[1].to_ndarray().tolist())
+
+        # Test for Categorical
+        cat_a1 = ak.Categorical(a1)
+        cat_a2 = ak.Categorical(a2)
+        cat_b1 = ak.Categorical(b1)
+        cat_b2 = ak.Categorical(b2)
+        t = ak.setdiff1d([cat_a1, cat_a2], [cat_b1, cat_b2])
+        self.assertListEqual(['abc'], t[0].to_ndarray().tolist())
+        self.assertListEqual(['123'], t[1].to_ndarray().tolist())
+
     def testIntersect1d(self):
         pdaOne = ak.array([1, 3, 4, 3])
         pdaTwo = ak.array([3, 1, 2, 1])
@@ -162,10 +204,9 @@ class SetOpsTest(ArkoudaTest):
         
         with self.assertRaises(RuntimeError) as cm:
             ak.intersect1d(ak.array([True, False, True]), ak.array([True, True]))
-        with self.assertRaises(TypeError):
-            ak.intersect1d([-1, 0, 1], [-2, 0, 2])
 
     def testIntersect1d_Multi(self):
+        # Test for numeric
         a = [1, 2, 3, 4, 5]
         b = [1, 5, 2, 3, 4]
         c = [1, 3, 2, 5, 4]
@@ -183,6 +224,28 @@ class SetOpsTest(ArkoudaTest):
         self.assertListEqual(t[0].to_ndarray().tolist(), npr0)
         self.assertListEqual(t[1].to_ndarray().tolist(), npr1)
 
+        # Test for strings
+        a = ['abc', 'def']
+        b = ['123', '456']
+        c = ['abc', 'def']
+        d = ['000', '456']
+        a1 = ak.array(a)
+        a2 = ak.array(b)
+        b1 = ak.array(c)
+        b2 = ak.array(d)
+        t = ak.intersect1d([a1, a2], [b1, b2])
+        self.assertListEqual(['def'], t[0].to_ndarray().tolist())
+        self.assertListEqual(['456'], t[1].to_ndarray().tolist())
+
+        #Test for Categorical
+        cat_a1 = ak.Categorical(a1)
+        cat_a2 = ak.Categorical(a2)
+        cat_b1 = ak.Categorical(b1)
+        cat_b2 = ak.Categorical(b2)
+        t = ak.intersect1d([cat_a1, cat_a2], [cat_b1, cat_b2])
+        self.assertListEqual(['def'], t[0].to_ndarray().tolist())
+        self.assertListEqual(['456'], t[1].to_ndarray().tolist())
+
     def testUnion1d(self):
         pdaOne = ak.array([-1, 0, 1])
         pdaTwo = ak.array([-2, 0, 2])
@@ -194,10 +257,9 @@ class SetOpsTest(ArkoudaTest):
         
         with self.assertRaises(RuntimeError) as cm:
             ak.union1d(ak.array([True, True, True]), ak.array([True,False,True]))
-        with self.assertRaises(TypeError):
-            ak.union1d([-1, 0, 1], [-2, 0, 2])
 
     def testUnion1d_Multi(self):
+        # test for numeric
         a = [1, 2, 3, 4, 5]
         b = [1, 5, 2, 3, 4]
         c = [1, 3, 2, 5, 4]
@@ -213,6 +275,28 @@ class SetOpsTest(ArkoudaTest):
         t = ak.union1d([a1, a2], [b1, b2])
         self.assertListEqual(t[0].to_ndarray().tolist(), npr0)
         self.assertListEqual(t[1].to_ndarray().tolist(), npr1)
+
+        # Test for Strings
+        a = ['abc', 'def']
+        b = ['123', '456']
+        c = ['xyz']
+        d = ['0']
+        a1 = ak.array(a)
+        a2 = ak.array(b)
+        b1 = ak.array(c)
+        b2 = ak.array(d)
+        t = ak.union1d([a1, a2], [b1, b2])
+        self.assertListEqual(['abc', 'xyz', 'def'], t[0].to_ndarray().tolist())
+        self.assertListEqual(['123', '0', '456'], t[1].to_ndarray().tolist())
+
+        #Test for Categorical
+        cat_a1 = ak.Categorical(a1)
+        cat_a2 = ak.Categorical(a2)
+        cat_b1 = ak.Categorical(b1)
+        cat_b2 = ak.Categorical(b2)
+        t = ak.union1d([cat_a1, cat_a2], [cat_b1, cat_b2])
+        self.assertListEqual(['abc', 'xyz', 'def'], t[0].to_ndarray().tolist())
+        self.assertListEqual(['123', '0', '456'], t[1].to_ndarray().tolist())
 
     def testIn1d(self): 
         pdaOne = ak.array([-1, 0, 1, 3])


### PR DESCRIPTION
This PR (closes #1280):

Initially the plan was to update this to `Union[List[groupable], Tuple[groupable]]`. However, this would essentially then allow sequences of sequences. I updated the typing to replace `Union[List[pdarray], Tuple[pdarray, ...]]` with `Sequence[groupable_element_type]`. This allows us to maintain the existing functionality and expand multi-array set operations to function on Lists/Tuples of `pdarrays`, `Strings`, and `Categoricals`.

The `tests/setops_test.py` has been updated to add testing to the multiarray setops for the additional types now supported. 

The docstrings have been updated to reflect the changes.