### PR TITLE
Closes #1229 and #1295 - Updating save checks in parquet/hdf5 msg files to be more efficient

### DIFF
--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -1318,23 +1318,13 @@ module HDF5Msg {
        * meaning that 1..n files will be overwritten.
        */
       if (mode == APPEND) {
-          var allexist = true;
-          var anyexist = false;
-          
-          for f in filenames {
-              var result =  try! exists(f);
-              allexist &= result;
-              if result {
-                  anyexist = true;
-              }
-          }
 
           /*
            * Check to see if any exist. If not, this means the user is attempting to append
            * to 1..n files that don't exist. In this situation, the user is alerted that
            * the dataset must be saved in TRUNCATE mode.
            */
-          if !anyexist {
+          if matchingFilenames.size == 0 {
               throw getErrorWithContext(
                  msg="Cannot append a non-existent file, please save without mode='append'",
                  lineNumber=getLineNumber(), 
@@ -1350,7 +1340,7 @@ module HDF5Msg {
            * a file append is attempted where the number of locales between the file 
            * creates and updates changes.
            */
-          if !allexist || (matchingFilenames.size != filenames.size) {
+          if matchingFilenames.size != filenames.size {
               throw getErrorWithContext(
                    msg="appending to existing files must be done with the same number " +
                       "of locales. Try saving with a different directory or filename prefix?",


### PR DESCRIPTION
This ticket (closes #1229 and closes #1295):

Updated the `processParquetFilenames()` and `processFilenames()` methods to reflect the recommended updates in #1229 . This resulted in the removal of a `for` loop and a few variables that were no longer required in both files. 

In addition, during testing I found that attempting to save in append mode to a non-existing files was throwing the wrong error message and in further debugging, I found the bug to be pre-existing in the codebase. Issue #1295 describes this bug.

With Ethan's assistance we debugged the root cause of the incorrect error and corrected it in this PR. The issue was due to trying to use a non-existant filename to check for the existence of an array within the file before checking if the file itself existed. The solution was to move the file check above the array check so it would error correctly.