### PR TITLE
Add a get_null_indices function for Parquet files

### DIFF
--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -7,8 +7,8 @@ from arkouda.pdarrayclass import pdarray, create_pdarray
 from arkouda.strings import Strings
 from arkouda.categorical import Categorical
 
-__all__ = ["ls", "read", "load", "get_datasets",
-           "load_all", "save_all",  "get_filetype"]
+__all__ = ["ls", "read", "load", "get_datasets", "load_all",
+           "save_all",  "get_filetype", "get_null_indices"]
 
 ARKOUDA_HDF5_FILE_METADATA_GROUP = "_arkouda_metadata"
 
@@ -186,6 +186,67 @@ def read(filenames : Union[str, List[str]],
         else:
             raise RuntimeError("No items were returned")
 
+@typechecked
+def get_null_indices(filenames, datasets) -> Union[pdarray, Mapping[str,pdarray]]:
+    """
+    Get null indices of a string column in a Parquet file.
+
+    Parameters
+    ----------
+    filenames : list or str
+        Either a list of filenames or shell expression
+    datasets : list or str or None
+        (List of) name(s) of dataset(s) to read. Each dataset must be a string
+        column. There is no default value for this funciton, the datasets to be
+        read must be specified.
+
+    Returns
+    -------
+    For a single dataset returns an Arkouda pdarray and for multiple datasets 
+    returns a dictionary of Arkouda pdarrays
+        Dictionary of {datasetName: pdarray}
+
+    Raises
+    ------
+    RuntimeError
+        Raised if one or more of the specified files cannot be opened.
+    TypeError
+        Raised if we receive an unknown arkouda_type returned from the server
+
+    See Also
+    --------
+    get_datasets, ls
+    """
+    if isinstance(filenames, str):
+        filenames = [filenames]
+    if isinstance(datasets, str):
+        datasets = [datasets]
+    rep_msg = generic_msg(cmd="getnullparquet", args=
+        f"{len(datasets)} {len(filenames)} {json.dumps(datasets)} | {json.dumps(filenames)}")
+    rep = json.loads(rep_msg)  # See GenSymIO._buildReadAllHdfMsgJson for json structure
+    items = rep["items"] if "items" in rep else []
+    file_errors = rep["file_errors"] if "file_errors" in rep else []
+
+    # We have a couple possible return conditions
+    # 1. We have multiple items returned i.e. multi pdarrays
+    # 2. We have a single pdarray
+    if len(items) > 1: #  DataSets condition
+        d: Dict[str, pdarray] = {}
+        for item in items:
+            if "pdarray" == item["arkouda_type"]:
+                d[item["dataset_name"]] = create_pdarray(item["created"])
+            else:
+                raise TypeError(f"Unknown arkouda type:{item['arkouda_type']}")
+        return d
+    elif len(items) == 1:
+        item = items[0]
+        if "pdarray" == item["arkouda_type"]:
+            return create_pdarray(item["created"])
+        else:
+            raise TypeError(f"Unknown arkouda type:{item['arkouda_type']}")
+    else:
+        raise RuntimeError("No items were returned")
+        
 @typechecked
 def load(path_prefix : str, dataset : str='array', calc_string_offsets:bool = False) -> Union[pdarray, Strings, Mapping[str,Union[pdarray,Strings]]]:
     """

--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -42,6 +42,9 @@ extern "C" {
                                       void* chpl_offsets, int64_t numElems, int64_t startIdx, char** errMsg);
   int64_t c_getStringColumnNumBytes(const char* filename, const char* colname,
                                     void* chpl_offsets, int64_t numElems, int64_t startIdx, char** errMsg);
+  
+  int64_t c_getStringColumnNullIndices(const char* filename, const char* colname, void* chpl_nulls, char** errMsg);
+  int64_t cpp_getStringColumnNullIndices(const char* filename, const char* colname, void* chpl_nulls, char** errMsg);
 
   int c_getType(const char* filename, const char* colname, char** errMsg);
   int cpp_getType(const char* filename, const char* colname, char** errMsg);

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -168,6 +168,16 @@ class ParquetTest(ArkoudaTest):
         res = ak.read(filename)
 
         self.assertTrue((expected == res).all())
+
+    def test_null_indices(self):
+        datadir = 'resources/parquet-testing'
+        basename = 'null-strings.parquet'
+        expected = ak.array([0, 1, 0, 1, 0, 1, 1])
+
+        filename = os.path.join(datadir, basename)
+        res = ak.get_null_indices(filename, datasets='col1')
+
+        self.assertTrue((expected == res).all())
             
     @pytest.mark.optional_parquet
     def test_against_standard_files(self):


### PR DESCRIPTION
This PR adds support for an `ak.get_null_indices()` function that
accepts a list of Parquet filenames and a list of datasets and will
return a pdarray representing the null indices of that column. This
currently only works with String Parquet columns.

In the returned array, 0 represents a non-null value and 1 represents
a null index.

Closes https://github.com/Bears-R-Us/arkouda/issues/1298