### PR TITLE
Update strings object to match new save function convention

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1019,9 +1019,9 @@ class pdarray:
             By default, truncate (overwrite) output files, if they exist.
             If 'append', attempt to create new dataset in existing files.
         compressed : bool
-            Arkouda only supports writing with compression on Parquet files.
-            Default is False, but, if True, will write Parquet file with Snappy
-            compression and RLE encoding.
+            Defaults to False. When True, files will be written with Snappy compression
+            and RLE bit packing. This is currently only supported on Parquet files and will
+            not impact the generated files when writing HDF5 files.
         file_format : str {'HDF5', 'Parquet'}
             By default, saved files will be written to the HDF5 file format. If
             'Parquet', the files will be written to the Parquet file format. This
@@ -1098,9 +1098,11 @@ class pdarray:
             json_array = json.dumps([prefix_path])
         except Exception as e:
             raise ValueError(e)
-        return cast(str, generic_msg(cmd=cmd, args="{} {} {} {} {} {}".\
+        strings_placeholder = False
+        
+        return cast(str, generic_msg(cmd=cmd, args="{} {} {} {} {} {} {}".\
                            format(self.name, dataset, m, json_array, self.dtype,
-                                  compressed)))
+                                  strings_placeholder, compressed)))
 
     @typechecked
     def save_parquet(self, prefix_path : str, dataset : str='array', mode : str='truncate',
@@ -1166,7 +1168,8 @@ class pdarray:
         >>> (a == b).all()
         True
         """
-        return self.save(prefix_path, dataset, mode, compressed, file_format='Parquet')
+        return self.save(prefix_path=prefix_path, dataset=dataset, mode=mode,
+                         compressed=compressed, file_format='Parquet')
 
     @typechecked
     def save_hdf(self, prefix_path : str, dataset : str='array', mode : str='truncate') -> str:
@@ -1231,7 +1234,8 @@ class pdarray:
         >>> (a == b).all()
         True
         """
-        return self.save(prefix_path, dataset, mode, compressed=False, file_format='HDF5')
+        return self.save(prefix_path=prefix_path, dataset=dataset, mode=mode,
+                         compressed=False, file_format='HDF5')
     
     @typechecked
     def register(self, user_defined_name: str) -> pdarray:

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -2126,7 +2126,7 @@ module HDF5Msg {
     }
 
     proc tohdfMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
-        var (arrayName, dsetName, modeStr, jsonfile, dataType, segsName, writeOffsetsFlag, pqPlaceholder)= payload.splitMsgToTuple(8);
+        var (arrayName, dsetName, modeStr, jsonfile, dataType, writeOffsetsFlag, pqPlaceholder)= payload.splitMsgToTuple(7);
         var mode = try! modeStr: int;
         var filename: string;
         var entry = st.lookup(arrayName);

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -659,7 +659,7 @@ module ParquetMsg {
   }
   
   proc toparquetMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
-    var (arrayName, dsetname, modeStr, jsonfile, dataType, isCompressed)= payload.splitMsgToTuple(6);
+    var (arrayName, dsetname, modeStr, jsonfile, dataType, hdfPlaceholder, isCompressed)= payload.splitMsgToTuple(7);
     var mode = try! modeStr: int;
     var filename: string;
     var entry = st.lookup(arrayName);


### PR DESCRIPTION
In #1293, the `pdarray.save()` method was updated with a `file_format`
keyword that allowed specification of Parquet or HDF5 files to make
the API simpler to use. In that PR, strings were overlooked and had
not been updated to match this new API design.

This PR updates the `strings.save()` function to use a `file_format`
keyword argument like the other PR and also adds `save_hdf` and
`save_parquet` wrappers around that function.

Additionally documentation has been updated and a discrepency between
the HDF5 strings/pdarray `tohdf` command arguments was cleaned up. An
unused argument was removed and the strings and pdarray message
arguments now send the same number of arguments (7) to the server,
whereas they used to send differing numbers (6 for pdarrays and 8
for strings).

Closes https://github.com/Bears-R-Us/arkouda/issues/1306