### PR TITLE
Resolves #1311: `ak.array` dtype bug for python lists

### DIFF
--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -176,7 +176,7 @@ def array(a: Union[pdarray, np.ndarray, Iterable], dtype: Union[np.dtype, type, 
     # If a is not already a numpy.ndarray, convert it
     if not isinstance(a, np.ndarray):
         try:
-            a = np.array(a)
+            a = np.array(a, dtype=dtype)
         except:
             raise TypeError(('a must be a pdarray, np.ndarray, or convertible to' +
                             ' a numpy array'))


### PR DESCRIPTION
This PR (resolves #1311):
Adds in the missing `dtype` param for python lists. The `dtype` param in `ak.array` was not passed along when converting a python list to a numpy list

The reproducer with this change:
```python
>>> orig_list = [2**64-1, 2**63, 6]
>>> orig_list
[18446744073709551615, 9223372036854775808, 6]

>>> np_array = np.array(orig_list, dtype='<u8')
>>> np_array
array([18446744073709551615,  9223372036854775808,                    6],
      dtype=uint64)

>>> from_list = ak.array(orig_list, dtype='uint64')
>>> from_list
array([18446744073709551615 9223372036854775808 6])

>>> from_np = ak.array(np_array)
>>> from_np
array([18446744073709551615 9223372036854775808 6])

>>> assert all(from_list.to_ndarray()==from_np.to_ndarray())
```