### PR TITLE
Closes #1315 make DataFrame.dtypes handle missing cases better

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -593,6 +593,12 @@ class DataFrame(UserDict):
                 dtypes.append(str(val.dtype))
             elif isinstance(val, Strings):
                 dtypes.append('str')
+            elif isinstance(val, Categorical):
+                dtypes.append('Categorical')
+            elif isinstance(val, SegArray):
+                dtypes.append('SegArray')
+            else:
+               raise TypeError(f"Unsupported type encountered for ak.DataFrame, {type(val)}")
         res = Row({key: dtype for key, dtype in zip(keys, dtypes)})
         return res
 

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -598,7 +598,7 @@ class DataFrame(UserDict):
             elif isinstance(val, SegArray):
                 dtypes.append('SegArray')
             else:
-               raise TypeError(f"Unsupported type encountered for ak.DataFrame, {type(val)}")
+                raise TypeError(f"Unsupported type encountered for ak.DataFrame, {type(val)}")
         res = Row({key: dtype for key, dtype in zip(keys, dtypes)})
         return res
 

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -1,4 +1,6 @@
 import pandas as pd  # type: ignore
+import random
+import string
 
 from base_test import ArkoudaTest
 from context import arkouda as ak
@@ -90,6 +92,19 @@ class DataFrameTest(ArkoudaTest):
         self.assertIsInstance(df, ak.DataFrame)
         self.assertEqual(len(df), 6)
         self.assertTrue(ref_df.equals(df.to_pandas()))
+
+    def test_dtype_prop(self):
+        str_arr = ak.array(["".join(random.choices(string.ascii_letters + string.digits, k=5)) for _ in range(3)])
+        df_dict = {
+            "i": ak.arange(3),
+            "c_1": ak.arange(3, 6, 1),
+            "c_2": ak.arange(6, 9, 1),
+            "c_3": str_arr,
+            "c_4": ak.Categorical(str_arr),
+            "c_5": ak.SegArray(ak.array([0, 9, 14]), ak.arange(20))
+        }
+        akdf = ak.DataFrame(df_dict)
+        self.assertEqual(len(akdf.columns), len(akdf.dtypes))
 
     def test_to_pandas(self):
         df = build_ak_df()


### PR DESCRIPTION
This PR (closes #1315):

- Adds cases to `ak.DataFrame.dtypes` property computation to add values for `Categorical` and `SegArray`.
- Adds error message if a type that is not `Strings`, `pdarray`, `Categorical`, or `SegArray` is detected.
- Adds testing to validate that `ak.DataFrame.dtypes` contains the same number of elements as there are columns in the DataFrame