### PR TITLE
Resolves #1317 and #1318: Fix `uint64` pdarray ops and `String != ''` bug

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -2151,20 +2151,20 @@ def rotl(x, rot) -> pdarray:
 
     Parameters
     ----------
-    x : pdarray(int64) or integer
+    x : pdarray(int64/uint64) or integer
         Value(s) to rotate left.
-    rot : pdarray(int64) or integer
+    rot : pdarray(int64/uint64) or integer
         Amount(s) to rotate by.
 
     Returns
     -------
-    rotated : pdarray(int64)
+    rotated : pdarray(int64/uint64)
         The rotated elements of x.
 
     Raises
     ------
     TypeError
-        If input array is not int64
+        If input array is not int64 or uint64
     
     Examples
     --------
@@ -2172,12 +2172,12 @@ def rotl(x, rot) -> pdarray:
     >>> ak.rotl(A, A)
     array([0, 2, 8, 24, 64, 160, 384, 896, 2048, 4608])
     """
-    if isinstance(x, pdarray) and x.dtype == akint64:
-        if (isinstance(rot, pdarray) and rot.dtype == akint64) or isSupportedInt(rot):
+    if isinstance(x, pdarray) and (x.dtype == akint64 or x.dtype == akuint64):
+        if (isinstance(rot, pdarray) and (rot.dtype == akint64 or rot.dtype == akuint64)) or isSupportedInt(rot):
             return x._binop(rot, "<<<")
         else:
             raise TypeError("Rotations only supported on integers")
-    elif isSupportedInt(x) and isinstance(rot, pdarray) and rot.dtype == akint64:
+    elif isSupportedInt(x) and isinstance(rot, pdarray) and (rot.dtype == akint64 or rot.dtype == akuint64):
         return rot._r_binop(x, "<<<")
     else:
         raise TypeError("Rotations only supported on integers")
@@ -2188,20 +2188,20 @@ def rotr(x, rot) -> pdarray:
 
     Parameters
     ----------
-    x : pdarray(int64) or integer
+    x : pdarray(int64/uint64) or integer
         Value(s) to rotate left.
-    rot : pdarray(int64) or integer
+    rot : pdarray(int64/uint64) or integer
         Amount(s) to rotate by.
 
     Returns
     -------
-    rotated : pdarray(int64)
+    rotated : pdarray(int64/uint64)
         The rotated elements of x.
 
     Raises
     ------
     TypeError
-        If input array is not int64
+        If input array is not int64 or uint64
     
     Examples
     --------
@@ -2209,12 +2209,12 @@ def rotr(x, rot) -> pdarray:
     >>> ak.rotr(1024 * A, A)
     array([0, 512, 512, 384, 256, 160, 96, 56, 32, 18])
     """
-    if isinstance(x, pdarray) and x.dtype == akint64:
-        if (isinstance(rot, pdarray) and rot.dtype == akint64) or isSupportedInt(rot):
+    if isinstance(x, pdarray) and (x.dtype == akint64 or x.dtype == akuint64):
+        if (isinstance(rot, pdarray) and (rot.dtype == akint64 or rot.dtype == akuint64)) or isSupportedInt(rot):
             return x._binop(rot, ">>>")
         else:
             raise TypeError("Rotations only supported on integers")
-    elif isSupportedInt(x) and isinstance(rot, pdarray) and rot.dtype == akint64:
+    elif isSupportedInt(x) and isinstance(rot, pdarray) and (rot.dtype == akint64 or rot.dtype == akuint64):
         return rot._r_binop(x, ">>>")
     else:
         raise TypeError("Rotations only supported on integers")

--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -233,6 +233,19 @@ module EfuncMsg
                         overMemLimit(numBytes(uint) * e.size);
                         st.addEntry(rname, new shared SymEntry(+ scan e.a));
                     }
+                    when "cumprod" {
+                        // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+                        overMemLimit(numBytes(uint) * e.size);
+                        st.addEntry(rname, new shared SymEntry(* scan e.a));
+                    }
+                    when "sin" {
+                        var a = st.addEntry(rname, e.size, real);
+                        a.a = Math.sin(e.a);
+                    }
+                    when "cos" {
+                        var a = st.addEntry(rname, e.size, real);
+                        a.a = Math.cos(e.a);
+                    }
                     when "parity" {
                         var a = st.addEntry(rname, e.size, uint);
                         a.a = parity(e.a);

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -1163,7 +1163,7 @@ module SegmentedArray {
     if testStr.numBytes == 0 {
       // Comparing against the empty string is a quick check for zero length
       const lengths = ss.getLengths() - 1;
-      return (lengths == 0);
+      return if function == SegFunction.StringCompareLiteralEq then (lengths == 0) else (lengths != 0);
     }
     return computeOnSegments(ss.offsets.a, ss.values.a, function, bool, testStr);
   }


### PR DESCRIPTION
This PR (resolves #1317 and resolves #1318):
- Fixes `String != ''` bug
- Updates type checking to allow `uint` compatibility with `rotr`, `rotl`, `cumprod`, `sin`, and `cos`

Reproducer for `String != ''`:
```python
>>> s = ak.array(['hello', '', '', '', ''])
>>> s != ''
array([True False False False False])
>>> s == ''
array([False True True True True])
>>> s != 'hello'
array([False True True True True])
>>> s == 'hello'
array([True False False False False])
```

Reproducer for pdarray ops:
```python
>>> i = ak.arange(10)
>>> u = ak.arange(10, dtype=ak.uint64)

>>> i.rotr(3)
array([0 2305843009213693952 4611686018427387904 6917529027641081856 -9223372036854775808 -6917529027641081856 -4611686018427387904 -2305843009213693952 1 2305843009213693953])

>>> u.rotr(3)
array([0 2305843009213693952 4611686018427387904 6917529027641081856 9223372036854775808 11529215046068469760 13835058055282163712 16140901064495857664 1 2305843009213693953])

>>> i.rotl(3)
array([0 8 16 24 32 40 48 56 64 72])
>>> u.rotl(3)
array([0 8 16 24 32 40 48 56 64 72])

>>> ak.rotr(i,u)
array([0 -9223372036854775808 -9223372036854775808 6917529027641081856 4611686018427387904 2882303761517117440 1729382256910270464 1008806316530991104 576460752303423488 324259173170675712])

>>> ak.rotr(u,i)
array([0 9223372036854775808 9223372036854775808 6917529027641081856 4611686018427387904 2882303761517117440 1729382256910270464 1008806316530991104 576460752303423488 324259173170675712])

>>> ak.rotl(i,u)
array([0 2 8 24 64 160 384 896 2048 4608])

>>> ak.rotl(u,i)
array([0 2 8 24 64 160 384 896 2048 4608])

>>> ak.rotl(u,i).dtype
dtype('uint64')

>>> ak.cumprod(i)
array([0 0 0 0 0 0 0 0 0 0])

>>> ak.cumprod(u)
array([0 0 0 0 0 0 0 0 0 0])

>>> ak.sin(i)
array([0 0.8414709848078965 0.90929742682568171 0.14112000805986721 -0.7568024953079282 -0.95892427466313845 -0.27941549819892586 0.65698659871878906 0.98935824662338179 0.41211848524175659])

>>> ak.sin(u)
array([0 0.8414709848078965 0.90929742682568171 0.14112000805986721 -0.7568024953079282 -0.95892427466313845 -0.27941549819892586 0.65698659871878906 0.98935824662338179 0.41211848524175659])

>>> ak.cos(i)
array([1 0.54030230586813977 -0.41614683654714241 -0.98999249660044542 -0.65364362086361194 0.28366218546322625 0.96017028665036597 0.7539022543433046 -0.14550003380861354 -0.91113026188467694])

>>> ak.cos(u)
array([1 0.54030230586813977 -0.41614683654714241 -0.98999249660044542 -0.65364362086361194 0.28366218546322625 0.96017028665036597 0.7539022543433046 -0.14550003380861354 -0.91113026188467694])
```