### PR TITLE
Closes #1325 - update documentation for ak.histogram to reflect that bin edges are now returned 

### DIFF
--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -515,7 +515,7 @@ def histogram(pda : pdarray, bins : int_scalars=10) -> Tuple[np.ndarray, pdarray
 
     Returns
     -------
-    (pdarray[float64], Union[pdarray, int64 or float64])
+    (np.ndarray, Union[pdarray, int64 or float64])
         Bin edges and The number of values present in each bin
         
     Raises
@@ -535,8 +535,6 @@ def histogram(pda : pdarray, bins : int_scalars=10) -> Tuple[np.ndarray, pdarray
     Notes
     -----
     The bins are evenly spaced in the interval [pda.min(), pda.max()].
-    Currently, the user must re-compute the bin edges, e.g. with np.linspace 
-    (see below) in order to plot the histogram.
 
     Examples
     --------
@@ -549,7 +547,7 @@ def histogram(pda : pdarray, bins : int_scalars=10) -> Tuple[np.ndarray, pdarray
     >>> b
     array([0., 3., 6.])
 
-    # To plot, use only the left edges, and export the histogram to NumPy
+    # To plot, use only the left edges (now returned), and export the histogram to NumPy
     >>> plt.plot(b, h.to_ndarray())
     """
     if bins < 1:

--- a/pydoc/usage/histogram.rst
+++ b/pydoc/usage/histogram.rst
@@ -65,13 +65,6 @@ Arkouda can compute simple histograms on ``pdarray`` data. Currently, this funct
 
 .. autofunction:: arkouda.histogram
 
-Since the ``histogram`` function currently does not return the bin edges, only the counts, the user can recreate the bin edges (e.g. for plotting) using:
-
-.. code-block:: python
-
-   >>> binEdges = np.linspace(myarray.min(), myarray.max(), nbins + 1)
-
-
 Value Counts
 ============
 


### PR DESCRIPTION
Closes #1325

The documentation has been updated to reflect the changes made to `ak.histrogram` to reflect that it now returns bin edges. The type has been corrected in the docstring for the bin edges return from `pdarray` to `np.ndarray`.

Updates made to
- `arkouda/numeric.py:histogram` docstring
- `pydoc/usage/histogram.rst` 