### PR TITLE
Closes #1324 - `load_all()` use `file_format`

### DIFF
--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -122,7 +122,6 @@ def read(filenames : Union[str, List[str]],
     and read all of them. Use ``get_datasets`` to show the names of datasets
     to HDF5 files.
     """
-    print(filenames)
     if isinstance(filenames, str):
         filenames = [filenames]
     if datasets is None:

--- a/src/FileIO.chpl
+++ b/src/FileIO.chpl
@@ -291,7 +291,8 @@ module FileIO {
         // Set filename to globbed filename corresponding to locale 0
         filename = tmp[tmp.domain.first];
       }
-
+      fioLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                      "FILENAME: %s".format(filename));
       if !exists(filename) {
         var errorMsg = "File %s does not exist in a location accessible to Arkouda".format(filename);
         return new MsgTuple(errorMsg,MsgType.ERROR);

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -325,20 +325,20 @@ class IOTest(ArkoudaTest):
         :return: None
         :raise: AssertionError if the input and returned datasets (pdarrays) don't match
         '''
-        self._create_file(columns=self.dict_columns, 
-                          prefix_path='{}/iotest_dict_columns'.format(IOTest.io_test_dir)) 
-        result_array_tens = ak.load(path_prefix='{}/iotest_dict_columns'.format(IOTest.io_test_dir), 
+        self._create_file(columns=self.dict_columns,
+                          prefix_path='{}/iotest_dict_columns'.format(IOTest.io_test_dir))
+        result_array_tens = ak.load(path_prefix='{}/iotest_dict_columns'.format(IOTest.io_test_dir),
                                     dataset='int_tens_pdarray')
-        result_array_hundreds = ak.load(path_prefix='{}/iotest_dict_columns'.format(IOTest.io_test_dir), 
+        result_array_hundreds = ak.load(path_prefix='{}/iotest_dict_columns'.format(IOTest.io_test_dir),
                                         dataset='int_hundreds_pdarray')
-        result_array_floats = ak.load(path_prefix='{}/iotest_dict_columns'.format(IOTest.io_test_dir), 
+        result_array_floats = ak.load(path_prefix='{}/iotest_dict_columns'.format(IOTest.io_test_dir),
                                      dataset='float_pdarray')
-        result_array_bools = ak.load(path_prefix='{}/iotest_dict_columns'.format(IOTest.io_test_dir), 
+        result_array_bools = ak.load(path_prefix='{}/iotest_dict_columns'.format(IOTest.io_test_dir),
                                      dataset='bool_pdarray')
-        
+
         ratens = result_array_tens.to_ndarray()
         ratens.sort()
-        
+
         rahundreds = result_array_hundreds.to_ndarray()
         rahundreds.sort()
 
@@ -347,6 +347,34 @@ class IOTest(ArkoudaTest):
 
         self.assertTrue((self.int_tens_ndarray == ratens).all())
         self.assertTrue((self.int_hundreds_ndarray  == rahundreds).all())
+        self.assertTrue((self.float_ndarray == rafloats).all())
+        self.assertEqual(len(self.bool_pdarray), len(result_array_bools))
+
+        # test load_all with file_format parameter usage
+        ak.save_all(columns=self.dict_columns, file_format='Parquet',
+                    prefix_path='{}/iotest_dict_columns_parquet'.format(IOTest.io_test_dir))
+        result_array_tens = ak.load(path_prefix='{}/iotest_dict_columns_parquet'.format(IOTest.io_test_dir),
+                                    dataset='int_tens_pdarray',
+                                    file_format='Parquet')
+        result_array_hundreds = ak.load(path_prefix='{}/iotest_dict_columns_parquet'.format(IOTest.io_test_dir),
+                                        dataset='int_hundreds_pdarray',
+                                        file_format='Parquet')
+        result_array_floats = ak.load(path_prefix='{}/iotest_dict_columns_parquet'.format(IOTest.io_test_dir),
+                                      dataset='float_pdarray',
+                                      file_format='Parquet')
+        result_array_bools = ak.load(path_prefix='{}/iotest_dict_columns_parquet'.format(IOTest.io_test_dir),
+                                     dataset='bool_pdarray',
+                                     file_format='Parquet')
+        ratens = result_array_tens.to_ndarray()
+        ratens.sort()
+
+        rahundreds = result_array_hundreds.to_ndarray()
+        rahundreds.sort()
+
+        rafloats = result_array_floats.to_ndarray()
+        rafloats.sort()
+        self.assertTrue((self.int_tens_ndarray == ratens).all())
+        self.assertTrue((self.int_hundreds_ndarray == rahundreds).all())
         self.assertTrue((self.float_ndarray == rafloats).all())
         self.assertEqual(len(self.bool_pdarray), len(result_array_bools))
         
@@ -361,23 +389,33 @@ class IOTest(ArkoudaTest):
                                     dataset='int_tens_pdarray')
         
     def testLoadAll(self):   
-        self._create_file(columns=self.dict_columns, 
-                          prefix_path='{}/iotest_dict_columns'.format(IOTest.io_test_dir)) 
-        
+        self._create_file(columns=self.dict_columns,
+                          prefix_path='{}/iotest_dict_columns'.format(IOTest.io_test_dir))
+
         results = ak.load_all(path_prefix='{}/iotest_dict_columns'.format(IOTest.io_test_dir))
         self.assertTrue('bool_pdarray' in results)
         self.assertTrue('float_pdarray' in results)
         self.assertTrue('int_tens_pdarray' in results)
         self.assertTrue('int_hundreds_pdarray' in results)
-        
-        # Test load_all with invalid prefix
+
+        #test load_all with file_format parameter usage
+        ak.save_all(columns=self.dict_columns, file_format='Parquet',
+                    prefix_path='{}/iotest_dict_columns_parquet'.format(IOTest.io_test_dir))
+        results = ak.load_all(file_format='Parquet',
+                              path_prefix='{}/iotest_dict_columns_parquet'.format(IOTest.io_test_dir))
+        self.assertTrue('bool_pdarray' in results)
+        self.assertTrue('float_pdarray' in results)
+        self.assertTrue('int_tens_pdarray' in results)
+        self.assertTrue('int_hundreds_pdarray' in results)
+
+        # # Test load_all with invalid prefix
         with self.assertRaises(ValueError):
-            ak.load_all(path_prefix='{}/iotest_dict_column'.format(IOTest.io_test_dir))       
-            
+            ak.load_all(path_prefix='{}/iotest_dict_column'.format(IOTest.io_test_dir))
+
         # Test load with invalid file
         with self.assertRaises(RuntimeError) as cm:
             ak.load_all(path_prefix='{}/not-a-file'.format(IOTest.io_test_dir))
-    
+
     def testGetDataSets(self):
         '''
         Creates 1..n files depending upon the number of arkouda_server locales containing three 


### PR DESCRIPTION
Closes #1324 

- Updates `ak.load()` and `ak.load_all()` to make use of the `file_format` parameter that has been added for save methhods.
- Adds testing for `ak.load()` and `ak.load_all()` functionality with `file_format` parameter to `tests/io_test.py`.

The code here is configured to work around some of the inconsistencies raised in #1328. Because Parquet files always have `.parquet` extension, but HDF5 has more flexibility the code is configured to add the extension for parquet and continue using `os.path.splitext()` for HDF5 files.