### PR TITLE
#1199 - Dynamic versioning for quickstart documentation

### DIFF
--- a/pydoc/_ext/ak_sphinx_extensions.py
+++ b/pydoc/_ext/ak_sphinx_extensions.py
@@ -1,0 +1,40 @@
+"""
+Custom Sphinx extensions.
+"""
+
+from typing import List
+
+from sphinx.application import Sphinx
+from sphinx.directives.code import CodeBlock
+
+class SubstitutionCodeBlock(CodeBlock):  # type: ignore
+    """
+    Similar to CodeBlock but replaces placeholders with variables.
+    """
+
+    def run(self) -> List:
+        """
+        Replace placeholders with given variables.
+        """
+        app = self.state.document.settings.env.app
+        new_content = []
+        self.content = self.content  # type: List[str]
+        existing_content = self.content
+        for item in existing_content:
+            for pair in app.config.substitutions:
+                original, replacement = pair
+                item = item.replace(original, replacement)
+
+            new_content.append(item)
+
+        self.content = new_content
+
+        return list(CodeBlock.run(self))
+
+
+def setup(app: Sphinx) -> None:
+    """
+    Add the custom directives to Sphinx.
+    """
+    app.add_config_value('substitutions', [], 'html')
+    app.add_directive('substitution-code-block', SubstitutionCodeBlock)

--- a/pydoc/conf.py
+++ b/pydoc/conf.py
@@ -12,9 +12,12 @@
 #
 import os
 import sys
+from arkouda import _version
 
 sys.path.insert(0, os.path.abspath('../benchmarks'))
 sys.path.insert(0, os.path.abspath('..'))
+
+sys.path.append('_ext')
 
 # -- Project information -----------------------------------------------------
 
@@ -23,7 +26,7 @@ copyright = '2020, Michael Merrill and William Reus'
 author = 'Michael Merrill and William Reus'
 
 # The full version, including alpha/beta/rc tags
-release = ''
+release = _version.get_versions()["version"]
 
 
 # -- General configuration ---------------------------------------------------
@@ -34,7 +37,8 @@ master_doc = 'index'
 # ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon', 
               'sphinxarg.ext', 'sphinx.ext.githubpages',
-              'sphinx.ext.coverage', 'autoapi.extension'
+              'sphinx.ext.coverage', 'autoapi.extension',
+              'ak_sphinx_extensions'
              ]
 
 # path to directory containing files to autogenerate docs from comments
@@ -60,3 +64,5 @@ html_theme = 'alabaster'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+substitutions = [("|release|", release)]

--- a/pydoc/conf.py
+++ b/pydoc/conf.py
@@ -65,4 +65,5 @@ html_theme = 'alabaster'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+# Add release substitution variable
 substitutions = [("|release|", release)]

--- a/pydoc/setup/quickstart.rst
+++ b/pydoc/setup/quickstart.rst
@@ -12,21 +12,21 @@ In a terminal, run the arkouda server program with one locale
 
 You should see a startup message like
 
-.. code-block:: bash
+.. substitution-code-block:: bash
 
     $ ./arkouda_server -nl 1
     server listening on tcp://<your_machine>.local:5555
-    arkouda server version = vYYYY.MM.DD
+    arkouda server version = |release|
     memory limit = 15461882265
     bytes of memory used = 0
 
 or with authentication turned on 
 
-.. code-block:: bash
+.. substitution-code-block:: bash
 
    $ ./arkouda_server -nl 1 --authenticate
    server listening on tcp://<your_machine>:5555?token=<token_string>
-    arkouda server version = vYYYY.MM.DD
+    arkouda server version = |release|
     memory limit = 15461882265
     bytes of memory used = 0
 


### PR DESCRIPTION
This ticket (closes #1199):

Versioneer doesn't support writing the version to multiple locations, so the workaround for this is to import the `_version.py` file under arkouda into any files that need to access the version. Using the `get_versions()` method from `_version.py` I was able to pull the current version into the documentation's config file.

Sphinx doesn't natively support replacing strings within `code-blocks`, so because the versions in the quickstart guide are within a code-block I found an extension that enables substitution inside `code-blocks` [here](https://stackoverflow.com/questions/44761197/how-to-use-substitution-definitions-with-code-blocks/53267394#53267394?newreg=7a731bc3a74141e9a74d7cd46fcf74fa)

I added the extension under `pydocs/_ext` and setup the substitution variable to make it work. Tested with `make docs` and verified the substitution happened in both instances of the version being displayed as well as in the page title by looking at the output file and hovering over the tab in my browser.

Example output:

``` bash
$ ./arkouda_server -nl 1
server listening on tcp://<your_machine>.local:5555
arkouda server version = v2022.04.15+22.g8027d1f6.dirty
memory limit = 15461882265
bytes of memory used = 0
```