### PR TITLE
Closes #1339 - Dataframe index set incorrectly on logical indexing

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -635,7 +635,7 @@ class DataFrame(UserDict):
             self._index = value
         elif isinstance(value, pdarray):
             self._index = Index(value)
-        elif isinstance(value, list) or isinstance(tuple):
+        elif isinstance(value, list):
             self._index = Index(array(value))
         else:
             raise TypeError(f"DataFrame Index can only be constructed from type ak.Index, pdarray or list."

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -263,28 +263,15 @@ class DataFrame(UserDict):
                 return result
             if len({type(x) for x in key}) > 1:
                 raise TypeError("Invalid selector: too many types in list.")
-            if type(key[0]) == int:
-                rows = array(key)
-                for k in self.data.keys():
-                    result.data[k] = UserDict.__getitem__(self, k)[rows]
-                    result._columns.append(k)
-                result._empty = False
-                result._set_index(key)
-                return result
-            elif type(key[0]) == str:
+            if type(key[0]) == str:
                 for k in key:
                     result.data[k] = UserDict.__getitem__(self, k)
                     result._columns.append(k)
                 result._empty = False
                 return result
-            elif type(key[0]) == bool:
-                rows = arange(len(key))[key]
-                for k in self.data.keys():
-                    result.data[k] = UserDict.__getitem__(self, k)[rows]
-                    result._columns.append(k)
-                result._empty = False
-                result._set_index(key)
-                return result
+            else:
+                raise TypeError("DataFrames only support lists for column indexing. "
+                                "All list entries must be of type str.")
 
         # Select a single row using an integer
         if isinstance(key, int):

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -204,7 +204,7 @@ class DataFrameTest(ArkoudaTest):
     def test_reset_index(self):
         df = build_ak_df()
 
-        slice_df = df[[1, 3, 5]]
+        slice_df = df[ak.array([1, 3, 5])]
         self.assertTrue((slice_df.index == ak.array([1, 3, 5])).all())
         slice_df.reset_index()
         self.assertTrue((slice_df.index == ak.array([0, 1, 2])).all())
@@ -326,7 +326,7 @@ class DataFrameTest(ArkoudaTest):
         test_df = pd.DataFrame(data, columns=['userName', 'userID', 'item', 'day', 'amount'])
         self.assertTrue(pddf.equals(test_df))
 
-        slice_df = df[[1, 3, 5]]
+        slice_df = df[ak.array([1, 3, 5])]
         pddf = slice_df.to_pandas(retain_index=True)
         self.assertEqual(pddf.index.tolist(), [1, 3, 5])
 

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -97,6 +97,14 @@ class DataFrameTest(ArkoudaTest):
         self.assertEqual(len(df), 6)
         self.assertTrue(ref_df.equals(df.to_pandas()))
 
+    def test_boolean_indexing(self):
+        df = build_ak_df()
+        ref_df = build_pd_df()
+        row = df[df['userName'] == 'Carol']
+
+        self.assertEqual(len(row), 1)
+        self.assertTrue(ref_df[ref_df['userName'] == 'Carol'].equals(row.to_pandas(retain_index=True)))
+
     def test_dtype_prop(self):
         str_arr = ak.array(["".join(random.choices(string.ascii_letters + string.digits, k=5)) for _ in range(3)])
         df_dict = {


### PR DESCRIPTION
Close #1339 

- Updates index handling to identify `pdarrays` with `dtype=bool`. In this case, the index key is updated to `key=arange(key.size)[key]`.
- Updates index handling to identify `lists` of `bools`. In this case, the index key is updated `rows = arange(len(key))[key]` and then processed the same as an integer list.
- Adds testing for boolean indexing to ensure proper functionality
