### PR TITLE
Closes # 1310 - Import akutil updates

### DIFF
--- a/arkouda/__init__.py
+++ b/arkouda/__init__.py
@@ -26,3 +26,4 @@ from arkouda.index import *
 from arkouda.series import *
 from arkouda.alignment import *
 from arkouda.plotting import *
+from arkouda.accessor import *

--- a/arkouda/accessor.py
+++ b/arkouda/accessor.py
@@ -1,0 +1,81 @@
+from arkouda.timeclass import Datetime
+from arkouda.categorical import Categorical
+from arkouda.strings import Strings
+
+
+class CachedAccessor:
+    """
+    Custom property-like object.
+    A descriptor for caching accessors.
+    Parameters
+    ----------
+    name : str
+        Namespace that will be accessed under, e.g. ``df.foo``.
+    accessor : cls
+        Class with the extension methods.
+    Notes
+    -----
+    For accessor, The class's __init__ method assumes that one of
+    ``Series``, ``DataFrame`` or ``Index`` as the
+    single argument ``data``.
+    """
+
+    def __init__(self, name: str, accessor) -> None:
+        self._name = name
+        self._accessor = accessor
+
+    def __get__(self, obj, cls):
+        if obj is None:
+            # we're accessing the attribute of the class, i.e., Dataset.geo
+            return self._accessor
+        accessor_obj = self._accessor(obj)
+        # Replace the property with the accessor object. Inspired by:
+        # https://www.pydanny.com/cached-property.html
+        # We need to use object.__setattr__ because we overwrite __setattr__ on
+        # NDFrame
+        object.__setattr__(obj, self._name, accessor_obj)
+        return accessor_obj
+
+def string_operators(cls):
+        for name in ['contains', 'startswith', 'endswith' ] :
+            setattr(cls,name, cls._make_op(name))
+        return cls
+
+
+def date_operators(cls):
+        for name in ['floor', 'ceil', 'round' ] :
+            setattr(cls,name, cls._make_op(name))
+        return cls
+
+
+class Properties:
+
+    @classmethod
+    def _make_op(cls, name):
+        def accessop(self,*args,**kwargs):
+                from . import Series
+                results = getattr(self.series.values,name)(*args,**kwargs)
+                return Series( data=results, index=self.series.index)
+        return accessop
+
+@date_operators
+class DatetimeAccessor(Properties):
+
+    def __init__(self, series ):
+
+        data = series.values
+        if not isinstance(data, Datetime):
+            raise AttributeError("Can only use .dt accessor with datetimelike values")
+
+        self.series = series
+
+@string_operators
+class StringAccessor(Properties):
+
+    def __init__(self, series ):
+
+        data = series.values
+        if not (isinstance(data, Categorical) or isinstance(data, Strings) ):
+            raise AttributeError("Can only use .str accessor with string like values")
+
+        self.series = series

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -320,7 +320,6 @@ class DataFrame(UserDict):
     def __getattr__(self, key):
         # print("key =", key)
         if key not in self.columns:
-            # return self.__getattribute__(key)
             raise AttributeError(f'Attribute f{key} not found')
         # Should this be cached?
         return Series(data=self[key], index=self['index'])

--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,8 @@ setup(
         'tabulate',
         'pyfiglet',
         'versioneer',
-        'matplotlib'
+        'matplotlib',
+        'tabulate'
     ],
 
     # List additional groups of dependencies here (e.g. development

--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,7 @@ setup(
         'pyfiglet',
         'versioneer',
         'matplotlib',
-        'tabulate'
+        'types-tabulate'
     ],
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
Closes #1310 

- Adds `accessor.py`
- Updates to `dataframe.py` manually configured against current master
- Updates to `series.py` manually configured against current master
- Added code to check if user passes a column named `index`, and if they do, the index `df.index` will be built from that and the index is not added to the columns.

Linking to the diff of the branch posted with the issue for reference: [Akutil Updates Branch](https://github.com/Bears-R-Us/arkouda/compare/dataframe-updates2)

A large majority of the differences displayed are due to whitespace and were omitted.

Please Note: if reviewing the diff, some changes do not completely line up due to the fact that `ak.DataFrame` has been updated to utilize and `Index` object and set the index using a property instead of as a column in the data.