### PR TITLE
Closes #1302 - .yml files for setup of user and developer conda environment

### DIFF
--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -24,5 +24,5 @@ dependencies:
   - pip:
     - typeguard==2.10.0
     # Developer dependencies
-    - mypy==0.931
+    - mypy>=0.931
   

--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -1,0 +1,28 @@
+name: arkouda-env-dev
+channels:
+  - conda-forge
+dependencies:
+  - python>=3.7   # minimum 3.7
+  - numpy>=1.16.5,<=1.21.5
+  - pandas>=1.1.0
+  - pyzmq>=20.0.0
+  - tabulate
+  - pyfiglet
+  - versioneer
+  - matplotlib
+  - h5py
+  - pip
+  # Developer dependencies
+  - pexpect
+  - pytest
+  - pytest-env
+  - Sphinx
+  - sphinx-argparse
+  - sphinx-autoapi
+  - typed-ast
+  
+  - pip:
+    - typeguard==2.10.0
+    # Developer dependencies
+    - mypy==0.931
+  

--- a/arkouda-env.yml
+++ b/arkouda-env.yml
@@ -1,0 +1,16 @@
+name: arkouda-env
+channels:
+  - conda-forge
+dependencies:
+  - python>=3.7   # minimum 3.7
+  - numpy>=1.16.5,<=1.21.5
+  - pandas>=1.1.0
+  - pyzmq>=20.0.0
+  - tabulate
+  - pyfiglet
+  - versioneer
+  - matplotlib
+  - h5py
+  - pip
+  - pip:
+    - typeguard==2.10.0


### PR DESCRIPTION
This ticket (closes #1302):

Added two yaml files, one for standard configuration and one for developer configuration of conda environments. The packages included were the ones listed in `setup.py`.

These files successfully generated conda environments in testing that were able to run arkouda without errors, but we should find a way to test these in a completely clean environment without other previous installations or existing packages.