### PR TITLE
Closes #1331 - Parquet alignment with HDF5

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -1247,8 +1247,8 @@ class DataFrame(UserDict):
                  file_format=file_format)
 
     @classmethod
-    def load_table(cls, prefix_path):
-        return cls(load_all(prefix_path))
+    def load_table(cls, prefix_path, file_format='INFER'):
+        return cls(load_all(prefix_path, file_format=file_format))
 
     def argsort(self, key, ascending=True):
         """

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1085,23 +1085,29 @@ class pdarray:
         and the number of output files is less than the number of locales or a
         dataset with the same name already exists, a ``RuntimeError`` will result.
 
+        Previously all files saved in Parquet format were saved with a ``.parquet`` file extension.
+        This will require you to use load as if you saved the file with the extension. Try this if
+        an older file is not being found.
+
+        Any file extension can be used. The file I/O does not rely on the extension to determine the file format.
+
         Examples
         --------
-        >>> a = ak.arange(0, 100, 1)
-        >>> a.save('arkouda_range', dataset='array')
-        >>> a.save('arkouda_range_parquet', dataset='array', file_format='Parquet')
+        >>> a = ak.arange(25)
 
-        Array is saved in numLocales files with names like ``tmp/arkouda_range_LOCALE0``
+        >>> # Saving without an extension
+        >>> a.save('path/prefix', dataset='array')
+        Saves the array to numLocales HDF5 files with the name ``cwd/path/name_prefix_LOCALE####``
 
-        The array can be read back in as follows
+        >>> # Saving with an extension (HDF5)
+        >>> a.save('path/prefix.h5', dataset='array')
+        Saves the array to numLocales HDF5 files with the name ``cwd/path/name_prefix_LOCALE####.h5`` where
+        #### is replaced by each locale number
 
-        >>> b = ak.read('arkouda_range', dataset='array')
-        >>> (a == b).all()
-        True
-
-        >>> c = ak.read_parquet('arkouda_range_parquet*')
-        >>> (c == b).all()
-        True
+        >>> # Saving with an extension (Parquet)
+        >>> a.save('path/prefix.parquet', dataset='array', file_format='Parquet')
+        Saves the array in numLocales Parquet files with the name ``cwd/path/name_prefix_LOCALE####.parquet`` where
+        #### is replaced by each locale number
         """
         if mode.lower() in ['a', 'app', 'append']:
             m = 1

--- a/pydoc/usage/IO.rst
+++ b/pydoc/usage/IO.rst
@@ -28,34 +28,43 @@ Large Datasets
 
 .. _data-preprocessing-label:
 
+Supported File Formats
+----------------------
+
+* HDF5
+    * Default File Format
+* Parquet
+    * Optional
+    * Requires `pyarrow`
+
 Data Preprocessing
 ------------------
 
-Arkouda is designed to work primarily with columnar data spread across multiple files of non-uniform size. All disk-based I/O uses the HDF5 file format and associates each column of data with an HDF5 dataset present at the root level of all files.
+Arkouda is designed to work primarily with columnar data spread across multiple files of non-uniform size. All disk-based I/O uses HDF5 or Parquet file format and associates each column of data with an HDF5/Parquet dataset present at the root level of all files.
 
 Files are processed in parallel with one file per locale. While HDF5 has an MPI layer for concurrent reading and writing of a single file from multiple nodes, arkouda does not yet support this functionality.
 
-Because most data does not come in HDF5 format, the arkouda developers use arkouda in conjunction with several data preprocessing pipelines. While each dataset requires a unique conversion strategy, all preprocessing should:
+Because most data does not come in HDF5/Parquet format, the arkouda developers use arkouda in conjunction with several data preprocessing pipelines. While each dataset requires a unique conversion strategy, all preprocessing should:
 
 * Transpose row-based formats (e.g. CSV) to columns and output each column as an HDF5 dataset
 * NOT aggregate input files too aggressively, but keep them separate to enable parallel I/O (hundreds or thousands of files is appropriate, in our experience)
 * Convert text to numeric types where possible
 
-Much of this preprocessing can be accomplished with the Pandas ``read*`` functions for ingest and the ``h5py`` module for output. See `this example`_ for ideas.
+Much of this preprocessing can be accomplished with the Pandas ``read*`` functions for ingest and the ``h5py`` or ``pyarrow`` module for output. See `this example`_ for ideas.
 
 .. _this example: https://github.com/reuster986/hdflow
 
-Reading HDF5 data from disk
+Reading data from disk
 ---------------------------
 
-.. autofunction:: arkouda.read_hdf
+.. autofunction:: arkouda.read
 
 For convenience, multiple datasets can be read in to create a dictionary of pdarrays.
 
 .. autofunction:: arkouda.read_all
 
 
-HDF5 files can be queried via the server for dataset names and sizes.
+HDF5/Parquet files can be queried via the server for dataset names and sizes.
 
 .. autofunction:: arkouda.get_datasets
 
@@ -64,7 +73,7 @@ HDF5 files can be queried via the server for dataset names and sizes.
 Persisting ``pdarray`` data to disk
 -----------------------------------
 
-Arkouda supports saving pdarrays to HDF5 files. Unfortunately, arkouda does not yet support writing to a single HDF5 file from multiple locales and must create one output file per locale.
+Arkouda supports saving pdarrays to HDF5/Parquet files. Unfortunately, arkouda does not yet support writing to a single HDF5 file from multiple locales and must create one output file per locale.
 
 .. autofunction:: arkouda.pdarray.save
 
@@ -78,3 +87,14 @@ These functions allow loading ``pdarray`` data persisted with ``save()`` and ``s
 
 .. autofunction:: arkouda.load_all
 
+Persisting ``DataFrame`` data to disk
+-------------------------------------
+Arkouda supports saving ``DataFrame`` objects to HDF5/Parquet files. This is done by creating a dictionary that maps the column name to the pdarray containing the column data. The column names are treated as datasets in the file.
+
+.. autofunction:: arkouda.DataFrame.save_table
+
+Loading persisted DataFrame data from disk
+-------------------------------------------
+This functionality allows the columns be loaded as datasets, which creates a mapping of column names to column data. This structure is supported by the ``DataFrame`` constructor and is used to reconstruct the ``DataFrame``
+
+.. autofunction:: arkouda.DataFrame.load_table

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -305,14 +305,24 @@ module ParquetMsg {
                                         dsetname, numelems,
                                         dtype, compressed,
                                         errMsg): int;
-    var filenames: [0..#A.targetLocales().size] string;
+    // var filenames: [0..#A.targetLocales().size] string;
     var dtypeRep = toCDtype(dtype);
-    for i in 0..#A.targetLocales().size {
-      var suffix = '%04i'.format(i): string;
-      filenames[i] = filename + "_LOCALE" + suffix + ".parquet";
-    }
+    // for i in 0..#A.targetLocales().size {
+    //   var suffix = '%04i'.format(i): string;
+    //   filenames[i] = filename + "_LOCALE" + suffix + ".parquet";
+    // }
     
-    var matchingFilenames = glob("%s_LOCALE*%s".format(filename, ".parquet"));
+    // var matchingFilenames = glob("%s_LOCALE*%s".format(filename, ".parquet"));
+    var prefix: string;
+    var extension: string;
+  
+    (prefix, extension) = getFileMetadata(filename);
+
+    // Generate the filenames based upon the number of targetLocales.
+    var filenames = generateFilenames(prefix, extension, A.targetLocales().size);
+
+    //Generate a list of matching filenames to test against. 
+    var matchingFilenames = getMatchingFilenames(prefix, extension);
 
     var warnFlag = processParquetFilenames(filenames, matchingFilenames, mode);
 
@@ -368,13 +378,24 @@ module ParquetMsg {
     ref ss = segString;
     var A = ss.offsets.a;
 
-    var filenames: [0..#A.targetLocales().size] string;
-    for i in 0..#A.targetLocales().size {
-      var suffix = '%04i'.format(i): string;
-      filenames[i] = filename + "_LOCALE" + suffix + ".parquet";
-    }
+    // var filenames: [0..#A.targetLocales().size] string;
+    // for i in 0..#A.targetLocales().size {
+    //   var suffix = '%04i'.format(i): string;
+    //   filenames[i] = filename + "_LOCALE" + suffix + ".parquet";
+    // }
     
-    var matchingFilenames = glob("%s_LOCALE*%s".format(filename, ".parquet"));
+    // var matchingFilenames = glob("%s_LOCALE*%s".format(filename, ".parquet"));
+
+    var prefix: string;
+    var extension: string;
+  
+    (prefix, extension) = getFileMetadata(filename);
+
+    // Generate the filenames based upon the number of targetLocales.
+    var filenames = generateFilenames(prefix, extension, A.targetLocales().size);
+
+    //Generate a list of matching filenames to test against. 
+    var matchingFilenames = getMatchingFilenames(prefix, extension);
 
     var warnFlag = processParquetFilenames(filenames, matchingFilenames, mode);
 

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -345,6 +345,7 @@ class DataFrameTest(ArkoudaTest):
     def test_coargsort(self):
         df = build_ak_df()
 
+
         p = df.coargsort(keys=['userID', 'amount'])
         self.assertListEqual(p.to_ndarray().tolist(), [0, 5, 2, 1, 4, 3])
 
@@ -458,7 +459,7 @@ class DataFrameTest(ArkoudaTest):
         os.mkdir(f"{os.getcwd()}/save_table_test")
         akdf.save_table(f"{os.getcwd()}/save_table_test/testName", file_format='Parquet')
 
-        ak_loaded = ak.DataFrame.load_table(f"{os.getcwd()}/save_table_test/testName.parquet")
+        ak_loaded = ak.DataFrame.load_table(f"{os.getcwd()}/save_table_test/testName")
         self.assertTrue(validation_df.equals(ak_loaded.to_pandas()))
 
         # Commenting the read into pandas out because it requires optional libraries


### PR DESCRIPTION
Closes #1331

- Updates load functionality to support `file_format='INFER'`. 
- Updates saving files as `Parquet` to not automatically add the file extension.
- `Parquet` save/load should now function the same as `HDF5`. The file extension is now optional and can be added by the user.
- Updated `IO.rst` and docstrings to reflect current I/O functionality for `HDF5` and `Parquet`.