### PR TITLE
Closes #1351 - make ak.Series.shape work as it does in pandas

### DIFF
--- a/arkouda/series.py
+++ b/arkouda/series.py
@@ -133,6 +133,11 @@ class Series:
     str = CachedAccessor("str", StringAccessor)
     # cat = CachedAccessor("cat", CategoricalAccessor)
 
+    @property
+    def shape(self):
+        # mimic the pandas return of series shape property
+        return (self.values.size,)
+
     def isin(self, lst):
         """Find series elements whose values are in the specified list
 

--- a/tests/series_test.py
+++ b/tests/series_test.py
@@ -35,6 +35,13 @@ class SeriesTest(ArkoudaTest):
         self.assertEqual(l.index[1], 2)
         self.assertEqual(l.values[1], 'C')
 
+    def test_shape(self):
+        ar_tuple = (ak.arange(3), ak.array(['A', 'B', 'C']))
+        s = ak.Series(ar_tuple=ar_tuple)
+
+        l, = s.shape
+        self.assertEqual(l, 3)
+
     def test_add(self):
         ar_tuple = (ak.arange(3), ak.arange(3))
         ar_tuple_add = (ak.arange(3, 6, 1), ak.arange(3, 6, 1))


### PR DESCRIPTION
Closes #1351 

- Adds `shape` property to `ak.Series`
- `shape` is returned as a tuple of the format `(x,)` where x is the length of the Series. 
- Adds testing of `series.shape` output to confirm proper formatting.