### PR TITLE
1379 Fixes `df.col`

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -359,7 +359,7 @@ class DataFrame(UserDict):
             return DataFrame(initialdata=result, index=key)
 
         # Select rows or columns using a list
-        if isinstance(key, list):
+        if isinstance(key, (list, tuple)):
             result = DataFrame()
             if len(key) <= 0:
                 return result

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -322,9 +322,9 @@ class DataFrame(UserDict):
     def __getattr__(self, key):
         # print("key =", key)
         if key not in self.columns:
-            raise AttributeError(f'Attribute f{key} not found')
+            raise AttributeError(f'Attribute {key} not found')
         # Should this be cached?
-        return Series(data=self[key], index=self['index'])
+        return Series(data=self[key], index=self.index)
 
     def __dir__(self):
         return dir(DataFrame) + self.columns

--- a/arkouda/series.py
+++ b/arkouda/series.py
@@ -9,6 +9,7 @@ from arkouda.util import get_callback
 from arkouda.util import convert_if_categorical, register
 from arkouda.alignment import lookup
 from arkouda.categorical import Categorical
+from arkouda.strings import Strings
 from arkouda.accessor import CachedAccessor, DatetimeAccessor, StringAccessor
 
 from pandas._config import get_option # type: ignore
@@ -86,7 +87,7 @@ class Series:
             raise TypeError("ar_tuple and data cannot both be null")
 
         else:
-            if not isinstance(data, pdarray) and not isinstance(data, Categorical):
+            if not isinstance(data, (pdarray, Strings, Categorical)):
                 data = array(data)
             self.values = data
 

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -105,6 +105,19 @@ class DataFrameTest(ArkoudaTest):
         self.assertEqual(len(row), 1)
         self.assertTrue(ref_df[ref_df['userName'] == 'Carol'].equals(row.to_pandas(retain_index=True)))
 
+    def test_column_indexing(self):
+        df = build_ak_df()
+        self.assertTrue(isinstance(df.userName, ak.Series))
+        self.assertTrue(isinstance(df.userID, ak.Series))
+        self.assertTrue(isinstance(df.item, ak.Series))
+        self.assertTrue(isinstance(df.day, ak.Series))
+        self.assertTrue(isinstance(df.amount, ak.Series))
+        for col in ('userName', 'userID', 'item', 'day', 'amount'):
+            self.assertTrue(isinstance(df['userName'], (ak.pdarray, ak.Strings, ak.Categorical)))
+        self.assertTrue(isinstance(df[['userName', 'amount']], ak.DataFrame))
+        self.assertTrue(isinstance(df[('userID', 'item', 'day')], ak.DataFrame))
+        self.assertTrue(isinstance(df.index, ak.Index))
+
     def test_dtype_prop(self):
         str_arr = ak.array(["".join(random.choices(string.ascii_letters + string.digits, k=5)) for _ in range(3)])
         df_dict = {


### PR DESCRIPTION
Closes #1379 

This PR updates the `df.col` syntax to work correctly and adds a test for column indexing. 

The test exposed two more issues, which this PR fixes:
- Can now make Series from Strings, as well as pdarray and Categorical
- Can now index a DataFrame with tuple of column names as well as list