### PR TITLE
Fixes #1384: Change `df['index']` to `df.index` in `Dataframe`

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -134,7 +134,7 @@ class GroupBy(AggregateOps):
             data = self.gb.broadcast(x.values, permute=permute)
         else:
             data = self.gb.broadcast(x, permute=permute)
-        return Series(data=data, index=self.df['index'])
+        return Series(data=data, index=self.df.index)
 
 
 @groupby_operators


### PR DESCRIPTION
I *think* this is the last instance of accessing index as a column in the codebase.

Fixes #1384