### PR TITLE
Fixes #1387: Boolean comparison binops

### DIFF
--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -59,6 +59,18 @@ module BinOp
           when "!=" {
             e.a = l.a != r.a;
           }
+          when "<" {
+            e.a = l.a:int < r.a:int;
+          }
+          when ">" {
+            e.a = l.a:int > r.a:int;
+          }
+          when "<=" {
+            e.a = l.a:int <= r.a:int;
+          }
+          when ">=" {
+            e.a = l.a:int >= r.a:int;
+          }
           otherwise {
             var errorMsg = notImplementedError(pn,l.dtype,op,r.dtype);
             omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
@@ -70,7 +82,35 @@ module BinOp
       // type is bool and `l` and `r` are not both boolean, so this does
       // not need to be specialized for each case.
       else {
-        select op {
+        if ((l.etype == real && r.etype == bool) || (l.etype == bool && r.etype == real)) {
+          select op {
+            when "<" {
+              e.a = l.a:real < r.a:real;
+            }
+            when ">" {
+              e.a = l.a:real > r.a:real;
+            }
+            when "<=" {
+              e.a = l.a:real <= r.a:real;
+            }
+            when ">=" {
+              e.a = l.a:real >= r.a:real;
+            }
+            when "==" {
+              e.a = l.a:real == r.a:real;
+            }
+            when "!=" {
+              e.a = l.a:real != r.a:real;
+            }
+            otherwise {
+              var errorMsg = notImplementedError(pn,l.dtype,op,r.dtype);
+              omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+              return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+          }
+        }
+        else {
+          select op {
             when "<" {
               e.a = l.a < r.a;
             }
@@ -95,6 +135,7 @@ module BinOp
               return new MsgTuple(errorMsg, MsgType.ERROR); 
             }
           }
+        }
       }
       var repMsg = "created %s".format(st.attrib(rname));
       return new MsgTuple(repMsg, MsgType.NORMAL);
@@ -324,6 +365,18 @@ module BinOp
           when "!=" {
             e.a = l.a != val;
           }
+          when "<" {
+            e.a = l.a:int < val:int;
+          }
+          when ">" {
+            e.a = l.a:int > val:int;
+          }
+          when "<=" {
+            e.a = l.a:int <= val:int;
+          }
+          when ">=" {
+            e.a = l.a:int >= val:int;
+          }
           otherwise {
             var errorMsg = notImplementedError(pn,l.dtype,op,dtype);
             omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
@@ -335,7 +388,35 @@ module BinOp
       // type is bool and `l` and `r` are not both boolean, so this does
       // not need to be specialized for each case.
       else {
-        select op {
+        if ((l.etype == real && val.type == bool) || (l.etype == bool && val.type == real)) {
+          select op {
+            when "<" {
+              e.a = l.a:real < val:real;
+            }
+            when ">" {
+              e.a = l.a:real > val:real;
+            }
+            when "<=" {
+              e.a = l.a:real <= val:real;
+            }
+            when ">=" {
+              e.a = l.a:real >= val:real;
+            }
+            when "==" {
+              e.a = l.a:real == val:real;
+            }
+            when "!=" {
+              e.a = l.a:real != val:real;
+            }
+            otherwise {
+              var errorMsg = notImplementedError(pn,l.dtype,op,dtype);
+              omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+              return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+          }
+        }
+        else {
+          select op {
             when "<" {
               e.a = l.a < val;
             }
@@ -360,6 +441,7 @@ module BinOp
               return new MsgTuple(errorMsg, MsgType.ERROR); 
             }
           }
+        }
       }
       var repMsg = "created %s".format(st.attrib(rname));
       return new MsgTuple(repMsg, MsgType.NORMAL);
@@ -570,6 +652,18 @@ module BinOp
           when "!=" {
             e.a = val != r.a;
           }
+          when "<" {
+            e.a = val:int < r.a:int;
+          }
+          when ">" {
+            e.a = val:int > r.a:int;
+          }
+          when "<=" {
+            e.a = val:int <= r.a:int;
+          }
+          when ">=" {
+            e.a = val:int >= r.a:int;
+          }
           otherwise {
             var errorMsg = notImplementedError(pn,dtype,op,r.dtype);
             omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
@@ -581,7 +675,35 @@ module BinOp
       // type is bool and `l` and `r` are not both boolean, so this does
       // not need to be specialized for each case.
       else {
-        select op {
+        if ((r.etype == real && val.type == bool) || (r.etype == bool && val.type == real)) {
+          select op {
+            when "<" {
+              e.a = val:real < r.a:real;
+            }
+            when ">" {
+              e.a = val:real > r.a:real;
+            }
+            when "<=" {
+              e.a = val:real <= r.a:real;
+            }
+            when ">=" {
+              e.a = val:real >= r.a:real;
+            }
+            when "==" {
+              e.a = val:real == r.a:real;
+            }
+            when "!=" {
+              e.a = val:real != r.a:real;
+            }
+            otherwise {
+              var errorMsg = notImplementedError(pn,dtype,op,r.dtype);
+              omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+              return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+          }
+        }
+        else {
+          select op {
             when "<" {
               e.a = val < r.a;
             }
@@ -606,6 +728,7 @@ module BinOp
               return new MsgTuple(errorMsg, MsgType.ERROR); 
             }
           }
+        }
       }
       var repMsg = "created %s".format(st.attrib(rname));
       return new MsgTuple(repMsg, MsgType.NORMAL);

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -390,7 +390,6 @@ module OperatorMsg
           when (DType.Bool, DType.Float64) {
             var l = toSymEntry(left,bool);
             var val = try! value:real;
-            // Can't add boolOps.contains because chpl doesn't support bool < float
             if boolOps.contains(op) {
               var e = st.addEntry(rname, l.size, bool);
               return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
@@ -401,7 +400,6 @@ module OperatorMsg
           when (DType.Float64, DType.Bool) {
             var l = toSymEntry(left,real);
             var val = try! value.toLower():bool;
-            // Can't add boolOps.contains because chpl doesn't support bool < float
             if boolOps.contains(op) {
               var e = st.addEntry(rname, l.size, bool);
               return doBinOpvs(l, val, e, op, dtype, rname, pn, st);

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -99,6 +99,28 @@ module OperatorMsg
             var e = st.addEntry(rname, l.size, real);
             return doBinOpvv(l, r, e, op, rname, pn, st);
           }
+          when (DType.UInt64, DType.Float64) {
+            var l = toSymEntry(left,uint);
+            var r = toSymEntry(right,real);
+            // Only two possible resultant types are `bool` and `real`
+            // for this case
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, l.size, bool);
+              return doBinOpvv(l, r, e, op, rname, pn, st);
+            }
+            var e = st.addEntry(rname, l.size, real);
+            return doBinOpvv(l, r, e, op, rname, pn, st);
+          }
+          when (DType.Float64, DType.UInt64) {
+            var l = toSymEntry(left,real);
+            var r = toSymEntry(right,uint);
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, l.size, bool);
+              return doBinOpvv(l, r, e, op, rname, pn, st);
+            }
+            var e = st.addEntry(rname, l.size, real);
+            return doBinOpvv(l, r, e, op, rname, pn, st);
+          }
           when (DType.Float64, DType.Float64) {
             var l = toSymEntry(left,real);
             var r = toSymEntry(right,real);
@@ -120,25 +142,55 @@ module OperatorMsg
           when (DType.Bool, DType.Int64) {
             var l = toSymEntry(left,bool);
             var r = toSymEntry(right,int);
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, l.size, bool);
+              return doBinOpvv(l, r, e, op, rname, pn, st);
+            }
             var e = st.addEntry(rname, l.size, int);
             return doBinOpvv(l, r, e, op, rname, pn, st);
           }
           when (DType.Int64, DType.Bool) {
             var l = toSymEntry(left,int);
             var r = toSymEntry(right,bool);
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, l.size, bool);
+              return doBinOpvv(l, r, e, op, rname, pn, st);
+            }
             var e = st.addEntry(rname, l.size, int);
             return doBinOpvv(l, r, e, op, rname, pn, st);
           }
           when (DType.Bool, DType.Float64) {
             var l = toSymEntry(left,bool);
             var r = toSymEntry(right,real);
+            // Can't add boolOps.contains because chpl doesn't support bool < float
             var e = st.addEntry(rname, l.size, real);
             return doBinOpvv(l, r, e, op, rname, pn, st);
           }
           when (DType.Float64, DType.Bool) {
             var l = toSymEntry(left,real);
             var r = toSymEntry(right,bool);
+            // Can't add boolOps.contains because chpl doesn't support float < bool
             var e = st.addEntry(rname, l.size, real);
+            return doBinOpvv(l, r, e, op, rname, pn, st);
+          }
+          when (DType.Bool, DType.UInt64) {
+            var l = toSymEntry(left,bool);
+            var r = toSymEntry(right,uint);
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, l.size, bool);
+              return doBinOpvv(l, r, e, op, rname, pn, st);
+            }
+            var e = st.addEntry(rname, l.size, uint);
+            return doBinOpvv(l, r, e, op, rname, pn, st);
+          }
+          when (DType.UInt64, DType.Bool) {
+            var l = toSymEntry(left,uint);
+            var r = toSymEntry(right,bool);
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, l.size, bool);
+              return doBinOpvv(l, r, e, op, rname, pn, st);
+            }
+            var e = st.addEntry(rname, l.size, uint);
             return doBinOpvv(l, r, e, op, rname, pn, st);
           }
           when (DType.UInt64, DType.UInt64) {
@@ -269,6 +321,28 @@ module OperatorMsg
             var e = st.addEntry(rname, l.size, real);
             return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
           }
+          when (DType.UInt64, DType.Float64) {
+            var l = toSymEntry(left,uint);
+            var val = try! value:real;
+            // Only two possible resultant types are `bool` and `real`
+            // for this case
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, l.size, bool);
+              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+            }
+            var e = st.addEntry(rname, l.size, real);
+            return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+          }
+          when (DType.Float64, DType.UInt64) {
+            var l = toSymEntry(left,real);
+            var val = try! value:uint;
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, l.size, bool);
+              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+            }
+            var e = st.addEntry(rname, l.size, real);
+            return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+          }
           when (DType.Float64, DType.Float64) {
             var l = toSymEntry(left,real);
             var val = try! value:real;
@@ -290,25 +364,55 @@ module OperatorMsg
           when (DType.Bool, DType.Int64) {
             var l = toSymEntry(left,bool);
             var val = try! value:int;
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, l.size, bool);
+              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+            }
             var e = st.addEntry(rname, l.size, int);
             return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
           }
           when (DType.Int64, DType.Bool) {
             var l = toSymEntry(left,int);
             var val = try! value.toLower():bool;
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, l.size, bool);
+              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+            }
             var e = st.addEntry(rname, l.size, int);
             return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
           }
           when (DType.Bool, DType.Float64) {
             var l = toSymEntry(left,bool);
             var val = try! value:real;
+            // Can't add boolOps.contains because chpl doesn't support bool < float
             var e = st.addEntry(rname, l.size, real);
             return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
           }
           when (DType.Float64, DType.Bool) {
             var l = toSymEntry(left,real);
             var val = try! value.toLower():bool;
+            // Can't add boolOps.contains because chpl doesn't support bool < float
             var e = st.addEntry(rname, l.size, real);
+            return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+          }
+          when (DType.Bool, DType.UInt64) {
+            var l = toSymEntry(left,bool);
+            var val = try! value:uint;
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, l.size, bool);
+              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+            }
+            var e = st.addEntry(rname, l.size, uint);
+            return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+          }
+          when (DType.UInt64, DType.Bool) {
+            var l = toSymEntry(left,uint);
+            var val = try! value.toLower():bool;
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, l.size, bool);
+              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+            }
+            var e = st.addEntry(rname, l.size, uint);
             return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
           }
           when (DType.UInt64, DType.UInt64) {
@@ -427,6 +531,28 @@ module OperatorMsg
             var e = st.addEntry(rname, r.size, real);
             return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
           }
+          when (DType.UInt64, DType.Float64) {
+            var val = try! value:uint;
+            var r = toSymEntry(right,real);
+            // Only two possible resultant types are `bool` and `real`
+            // for this case
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, r.size, bool);
+              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+            }
+            var e = st.addEntry(rname, r.size, real);
+            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          }
+          when (DType.Float64, DType.UInt64) {
+            var val = try! value:real;
+            var r = toSymEntry(right,uint);
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, r.size, bool);
+              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+            }
+            var e = st.addEntry(rname, r.size, real);
+            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          }
           when (DType.Float64, DType.Float64) {
             var val = try! value:real;
             var r = toSymEntry(right,real);
@@ -448,25 +574,55 @@ module OperatorMsg
           when (DType.Bool, DType.Int64) {
             var val = try! value.toLower():bool;
             var r = toSymEntry(right,int);
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, r.size, bool);
+              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+            }
             var e = st.addEntry(rname, r.size, int);
             return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
           }
           when (DType.Int64, DType.Bool) {
             var val = try! value:int;
             var r = toSymEntry(right,bool);
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, r.size, bool);
+              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+            }
             var e = st.addEntry(rname, r.size, int);
             return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
           }
           when (DType.Bool, DType.Float64) {
             var val = try! value.toLower():bool;
             var r = toSymEntry(right,real);
+            // Can't add boolOps.contains because chpl doesn't support bool < float
             var e = st.addEntry(rname, r.size, real);
             return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
           }
           when (DType.Float64, DType.Bool) {
             var val = try! value:real;
             var r = toSymEntry(right,bool);
+            // Can't add boolOps.contains because chpl doesn't support bool < float
             var e = st.addEntry(rname, r.size, real);
+            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          }
+          when (DType.Bool, DType.UInt64) {
+            var val = try! value.toLower():bool;
+            var r = toSymEntry(right,uint);
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, r.size, bool);
+              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+            }
+            var e = st.addEntry(rname, r.size, uint);
+            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          }
+          when (DType.UInt64, DType.Bool) {
+            var val = try! value:uint;
+            var r = toSymEntry(right,bool);
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, r.size, bool);
+              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+            }
+            var e = st.addEntry(rname, r.size, uint);
             return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
           }
           when (DType.UInt64, DType.UInt64) {

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -21,17 +21,17 @@ module OperatorMsg
     const omLogger = new Logger(logLevel);
     
     /*
-    Parse and respond to binopvv message.
-    vv == vector op vector
+      Parse and respond to binopvv message.
+      vv == vector op vector
 
-    :arg reqMsg: request containing (cmd,op,aname,bname,rname)
-    :type reqMsg: string 
+      :arg reqMsg: request containing (cmd,op,aname,bname,rname)
+      :type reqMsg: string 
 
-    :arg st: SymTab to act on
-    :type st: borrowed SymTab 
+      :arg st: SymTab to act on
+      :type st: borrowed SymTab 
 
-    :returns: (MsgTuple) 
-    :throws: `UndefinedSymbolError(name)`
+      :returns: (MsgTuple) 
+      :throws: `UndefinedSymbolError(name)`
     */
     proc binopvvMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {       
         param pn = Reflection.getRoutineName();
@@ -162,14 +162,20 @@ module OperatorMsg
           when (DType.Bool, DType.Float64) {
             var l = toSymEntry(left,bool);
             var r = toSymEntry(right,real);
-            // Can't add boolOps.contains because chpl doesn't support bool < float
+           if boolOps.contains(op) {
+              var e = st.addEntry(rname, l.size, bool);
+              return doBinOpvv(l, r, e, op, rname, pn, st);
+            }
             var e = st.addEntry(rname, l.size, real);
             return doBinOpvv(l, r, e, op, rname, pn, st);
           }
           when (DType.Float64, DType.Bool) {
             var l = toSymEntry(left,real);
             var r = toSymEntry(right,bool);
-            // Can't add boolOps.contains because chpl doesn't support float < bool
+           if boolOps.contains(op) {
+              var e = st.addEntry(rname, l.size, bool);
+              return doBinOpvv(l, r, e, op, rname, pn, st);
+            }
             var e = st.addEntry(rname, l.size, real);
             return doBinOpvv(l, r, e, op, rname, pn, st);
           }
@@ -243,17 +249,17 @@ module OperatorMsg
     }
     
     /*
-    Parse and respond to binopvs message.
-    vs == vector op scalar
+      Parse and respond to binopvs message.
+      vs == vector op scalar
 
-    :arg reqMsg: request containing (cmd,op,aname,dtype,value)
-    :type reqMsg: string 
+      :arg reqMsg: request containing (cmd,op,aname,dtype,value)
+      :type reqMsg: string 
 
-    :arg st: SymTab to act on
-    :type st: borrowed SymTab 
+      :arg st: SymTab to act on
+      :type st: borrowed SymTab 
 
-    :returns: (MsgTuple) 
-    :throws: `UndefinedSymbolError(name)`
+      :returns: (MsgTuple) 
+      :throws: `UndefinedSymbolError(name)`
     */
     proc binopvsMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
@@ -385,6 +391,10 @@ module OperatorMsg
             var l = toSymEntry(left,bool);
             var val = try! value:real;
             // Can't add boolOps.contains because chpl doesn't support bool < float
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, l.size, bool);
+              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+            }
             var e = st.addEntry(rname, l.size, real);
             return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
           }
@@ -392,6 +402,10 @@ module OperatorMsg
             var l = toSymEntry(left,real);
             var val = try! value.toLower():bool;
             // Can't add boolOps.contains because chpl doesn't support bool < float
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, l.size, bool);
+              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+            }
             var e = st.addEntry(rname, l.size, real);
             return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
           }
@@ -453,17 +467,17 @@ module OperatorMsg
     }
 
     /*
-    Parse and respond to binopsv message.
-    sv == scalar op vector
+      Parse and respond to binopsv message.
+      sv == scalar op vector
 
-    :arg reqMsg: request containing (cmd,op,dtype,value,aname)
-    :type reqMsg: string 
+      :arg reqMsg: request containing (cmd,op,dtype,value,aname)
+      :type reqMsg: string 
 
-    :arg st: SymTab to act on
-    :type st: borrowed SymTab 
+      :arg st: SymTab to act on
+      :type st: borrowed SymTab 
 
-    :returns: (MsgTuple) 
-    :throws: `UndefinedSymbolError(name)`
+      :returns: (MsgTuple) 
+      :throws: `UndefinedSymbolError(name)`
     */
     proc binopsvMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
@@ -594,14 +608,20 @@ module OperatorMsg
           when (DType.Bool, DType.Float64) {
             var val = try! value.toLower():bool;
             var r = toSymEntry(right,real);
-            // Can't add boolOps.contains because chpl doesn't support bool < float
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, r.size, bool);
+              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+            }
             var e = st.addEntry(rname, r.size, real);
             return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
           }
           when (DType.Float64, DType.Bool) {
             var val = try! value:real;
             var r = toSymEntry(right,bool);
-            // Can't add boolOps.contains because chpl doesn't support bool < float
+            if boolOps.contains(op) {
+              var e = st.addEntry(rname, r.size, bool);
+              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+            }
             var e = st.addEntry(rname, r.size, real);
             return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
           }


### PR DESCRIPTION
This PR (Fixes #1387):
- Adds the `BoolOps` comparison code for bool array compared with `int`, `uint`, and `float` scalars/arrays
- Adds the code for `float binop uint` and `bool binop uint`
- Adds other comparison functions for bools (ex `bool < bool`) by treating them as `int`

Edit:
@bmcdonald3 gave me a suggestion that fixed my issues with `BoolOps` comparions between `bool` and `float`!!! Thanks Ben!

the condensed output of ` testAllOperators` after this PR:
```
# ops not implemented by numpy or arkouda: 114
# ops implemented by numpy but not arkouda: 182
# ops implemented by arkouda but not numpy: 4
# ops implemented by both: 564
  Matching results:         564 / 564
  Arkouda execution errors: 0 / 564

  Dtype mismatches:         0 / 564

  Value mismatches:         0 / 564
```
vs before this PR
```
# ops not implemented by numpy or arkouda: 114
# ops implemented by numpy but not arkouda: 290
# ops implemented by arkouda but not numpy: 4
# ops implemented by both: 456
  Matching results:         456 / 456
  Arkouda execution errors: 0 / 456

  Dtype mismatches:         0 / 456

  Value mismatches:         0 / 456
```

<details>
  <summary>Full output of testAllOperators</summary>

```
Operators:  frozenset({'-', '%', '<', '|', '<<<', '>=', '*', '+', '**', '<<', '//', '!=', '<=', '^', '>', '&', '/', '==', '>>', '>>>'})
Dtypes:  dict_keys(['int64', 'uint64', 'float64', 'bool'])
pdarrays: 
int64 :  [0 1 2 3 4 5 6 7 8 9]
uint64 :  [0 1 2 3 4 5 6 7 8 9]
float64 :  [0.000000e+00 2.222222e-01 4.444444e-01 6.666667e-01 8.888889e-01 1.111111e+00 1.333333e+00 1.555556e+00 1.777778e+00 2.000000e+00]
bool :  [True False True False True False True False True False]
ndarrays: 
int64 :  [0 1 2 3 4 5 6 7 8 9]
uint64 :  [0 1 2 3 4 5 6 7 8 9]
float64 :  [0.         0.22222222 0.44444444 0.66666667 0.88888889 1.11111111
 1.33333333 1.55555556 1.77777778 2.        ]
bool :  [ True False  True False  True False  True False  True False]
scalars: 
int64 :  5
uint64 :  5
float64 :  3.14159
bool :  True
# ops not implemented by numpy or arkouda: 114
int64(array) | uint64(array)
int64(array) ^ uint64(array)
int64(array) & uint64(array)
int64(array) | float64(array)
int64(array) | float64(scalar)
int64(scalar) | float64(array)
int64(array) << float64(array)
int64(array) << float64(scalar)
int64(scalar) << float64(array)
int64(array) ^ float64(array)
int64(array) ^ float64(scalar)
int64(scalar) ^ float64(array)
int64(array) & float64(array)
int64(array) & float64(scalar)
int64(scalar) & float64(array)
int64(array) >> float64(array)
int64(array) >> float64(scalar)
int64(scalar) >> float64(array)
uint64(array) | int64(array)
uint64(array) ^ int64(array)
uint64(array) & int64(array)
uint64(array) | float64(array)
uint64(array) | float64(scalar)
uint64(scalar) | float64(array)
uint64(array) << float64(array)
uint64(array) << float64(scalar)
uint64(scalar) << float64(array)
uint64(array) ^ float64(array)
uint64(array) ^ float64(scalar)
uint64(scalar) ^ float64(array)
uint64(array) & float64(array)
uint64(array) & float64(scalar)
uint64(scalar) & float64(array)
uint64(array) >> float64(array)
uint64(array) >> float64(scalar)
uint64(scalar) >> float64(array)
float64(array) | int64(array)
float64(array) | int64(scalar)
float64(scalar) | int64(array)
float64(array) << int64(array)
float64(array) << int64(scalar)
float64(scalar) << int64(array)
float64(array) ^ int64(array)
float64(array) ^ int64(scalar)
float64(scalar) ^ int64(array)
float64(array) & int64(array)
float64(array) & int64(scalar)
float64(scalar) & int64(array)
float64(array) >> int64(array)
float64(array) >> int64(scalar)
float64(scalar) >> int64(array)
float64(array) | uint64(array)
float64(array) | uint64(scalar)
float64(scalar) | uint64(array)
float64(array) << uint64(array)
float64(array) << uint64(scalar)
float64(scalar) << uint64(array)
float64(array) ^ uint64(array)
float64(array) ^ uint64(scalar)
float64(scalar) ^ uint64(array)
float64(array) & uint64(array)
float64(array) & uint64(scalar)
float64(scalar) & uint64(array)
float64(array) >> uint64(array)
float64(array) >> uint64(scalar)
float64(scalar) >> uint64(array)
float64(array) | float64(array)
float64(array) | float64(scalar)
float64(scalar) | float64(array)
float64(array) << float64(array)
float64(array) << float64(scalar)
float64(scalar) << float64(array)
float64(array) ^ float64(array)
float64(array) ^ float64(scalar)
float64(scalar) ^ float64(array)
float64(array) & float64(array)
float64(array) & float64(scalar)
float64(scalar) & float64(array)
float64(array) >> float64(array)
float64(array) >> float64(scalar)
float64(scalar) >> float64(array)
float64(array) | bool(array)
float64(array) | bool(scalar)
float64(scalar) | bool(array)
float64(array) << bool(array)
float64(array) << bool(scalar)
float64(scalar) << bool(array)
float64(array) ^ bool(array)
float64(array) ^ bool(scalar)
float64(scalar) ^ bool(array)
float64(array) & bool(array)
float64(array) & bool(scalar)
float64(scalar) & bool(array)
float64(array) >> bool(array)
float64(array) >> bool(scalar)
float64(scalar) >> bool(array)
bool(array) | float64(array)
bool(array) | float64(scalar)
bool(scalar) | float64(array)
bool(array) << float64(array)
bool(array) << float64(scalar)
bool(scalar) << float64(array)
bool(array) ^ float64(array)
bool(array) ^ float64(scalar)
bool(scalar) ^ float64(array)
bool(array) & float64(array)
bool(array) & float64(scalar)
bool(scalar) & float64(array)
bool(array) >> float64(array)
bool(array) >> float64(scalar)
bool(scalar) >> float64(array)
bool(array) - bool(array)
bool(array) - bool(scalar)
bool(scalar) - bool(array)
# ops implemented by numpy but not arkouda: 182
int64(array) % uint64(array)
int64(array) * uint64(array)
int64(array) ** uint64(array)
int64(array) // uint64(array)
int64(array) / uint64(array)
int64(scalar) / uint64(array)
int64(array) % float64(array)
int64(array) % float64(scalar)
int64(scalar) % float64(array)
int64(array) % bool(array)
int64(scalar) % bool(array)
int64(array) | bool(array)
int64(scalar) | bool(array)
int64(array) ** bool(array)
int64(scalar) ** bool(array)
int64(array) << bool(array)
int64(scalar) << bool(array)
int64(array) // bool(array)
int64(scalar) // bool(array)
int64(array) ^ bool(array)
int64(scalar) ^ bool(array)
int64(array) & bool(array)
int64(scalar) & bool(array)
int64(array) / bool(array)
int64(scalar) / bool(array)
int64(array) >> bool(array)
int64(scalar) >> bool(array)
uint64(array) % int64(array)
uint64(array) * int64(array)
uint64(array) ** int64(array)
uint64(array) // int64(array)
uint64(array) / int64(array)
uint64(array) / int64(scalar)
uint64(array) / uint64(array)
uint64(array) / uint64(scalar)
uint64(scalar) / uint64(array)
uint64(array) - float64(array)
uint64(array) - float64(scalar)
uint64(array) % float64(array)
uint64(array) % float64(scalar)
uint64(scalar) % float64(array)
uint64(array) * float64(array)
uint64(array) * float64(scalar)
uint64(array) + float64(array)
uint64(array) + float64(scalar)
uint64(array) ** float64(array)
uint64(array) ** float64(scalar)
uint64(array) // float64(array)
uint64(array) // float64(scalar)
uint64(array) / float64(array)
uint64(array) / float64(scalar)
uint64(array) - bool(array)
uint64(scalar) - bool(array)
uint64(array) % bool(array)
uint64(scalar) % bool(array)
uint64(array) | bool(array)
uint64(scalar) | bool(array)
uint64(array) * bool(array)
uint64(scalar) * bool(array)
uint64(array) + bool(array)
uint64(scalar) + bool(array)
uint64(array) ** bool(array)
uint64(scalar) ** bool(array)
uint64(array) << bool(array)
uint64(scalar) << bool(array)
uint64(array) // bool(array)
uint64(scalar) // bool(array)
uint64(array) ^ bool(array)
uint64(scalar) ^ bool(array)
uint64(array) & bool(array)
uint64(scalar) & bool(array)
uint64(array) / bool(array)
uint64(array) / bool(scalar)
uint64(scalar) / bool(array)
uint64(array) >> bool(array)
uint64(scalar) >> bool(array)
float64(array) % int64(array)
float64(array) % int64(scalar)
float64(scalar) % int64(array)
float64(array) - uint64(array)
float64(scalar) - uint64(array)
float64(array) % uint64(array)
float64(array) % uint64(scalar)
float64(scalar) % uint64(array)
float64(array) * uint64(array)
float64(scalar) * uint64(array)
float64(array) + uint64(array)
float64(scalar) + uint64(array)
float64(array) ** uint64(array)
float64(scalar) ** uint64(array)
float64(array) // uint64(array)
float64(scalar) // uint64(array)
float64(array) / uint64(array)
float64(scalar) / uint64(array)
float64(array) % float64(array)
float64(array) % float64(scalar)
float64(scalar) % float64(array)
float64(array) % bool(array)
float64(array) % bool(scalar)
float64(scalar) % bool(array)
float64(array) ** bool(array)
float64(scalar) ** bool(array)
float64(array) // bool(array)
float64(scalar) // bool(array)
float64(array) / bool(array)
float64(scalar) / bool(array)
bool(array) % int64(array)
bool(array) % int64(scalar)
bool(array) | int64(array)
bool(array) | int64(scalar)
bool(array) ** int64(array)
bool(array) ** int64(scalar)
bool(array) << int64(array)
bool(array) << int64(scalar)
bool(array) // int64(array)
bool(array) // int64(scalar)
bool(array) ^ int64(array)
bool(array) ^ int64(scalar)
bool(array) & int64(array)
bool(array) & int64(scalar)
bool(array) / int64(array)
bool(array) / int64(scalar)
bool(array) >> int64(array)
bool(array) >> int64(scalar)
bool(array) - uint64(array)
bool(array) - uint64(scalar)
bool(array) % uint64(array)
bool(array) % uint64(scalar)
bool(array) | uint64(array)
bool(array) | uint64(scalar)
bool(array) * uint64(array)
bool(array) * uint64(scalar)
bool(array) + uint64(array)
bool(array) + uint64(scalar)
bool(array) ** uint64(array)
bool(array) ** uint64(scalar)
bool(array) << uint64(array)
bool(array) << uint64(scalar)
bool(array) // uint64(array)
bool(array) // uint64(scalar)
bool(array) ^ uint64(array)
bool(array) ^ uint64(scalar)
bool(array) & uint64(array)
bool(array) & uint64(scalar)
bool(array) / uint64(array)
bool(array) / uint64(scalar)
bool(scalar) / uint64(array)
bool(array) >> uint64(array)
bool(array) >> uint64(scalar)
bool(array) % float64(array)
bool(array) % float64(scalar)
bool(scalar) % float64(array)
bool(array) ** float64(array)
bool(array) ** float64(scalar)
bool(array) // float64(array)
bool(array) // float64(scalar)
bool(array) / float64(array)
bool(array) / float64(scalar)
bool(array) % bool(array)
bool(array) % bool(scalar)
bool(scalar) % bool(array)
bool(array) * bool(array)
bool(array) * bool(scalar)
bool(scalar) * bool(array)
bool(array) + bool(array)
bool(array) + bool(scalar)
bool(scalar) + bool(array)
bool(array) ** bool(array)
bool(array) ** bool(scalar)
bool(scalar) ** bool(array)
bool(array) << bool(array)
bool(array) << bool(scalar)
bool(scalar) << bool(array)
bool(array) // bool(array)
bool(array) // bool(scalar)
bool(scalar) // bool(array)
bool(array) / bool(array)
bool(array) / bool(scalar)
bool(scalar) / bool(array)
bool(array) >> bool(array)
bool(array) >> bool(scalar)
bool(scalar) >> bool(array)
# ops implemented by arkouda but not numpy: 4
int64(array) << uint64(array)  ->  [0 2 8 24 64 160 384 896 2048 4608]
int64(array) >> uint64(array)  ->  [0 0 0 0 0 0 0 0 0 0]
uint64(array) << int64(array)  ->  [0 2 8 24 64 160 384 896 2048 4608]
uint64(array) >> int64(array)  ->  [0 0 0 0 0 0 0 0 0 0]
# ops implemented by both: 564
  Matching results:         564 / 564
  Arkouda execution errors: 0 / 564

  Dtype mismatches:         0 / 564

  Value mismatches:         0 / 564
```
</details>

Example:
```python
>>> b = ak.zeros(10, dtype=ak.bool)
>>> i = ak.zeros(10, dtype=ak.int64)
>>> f = ak.zeros(10)
>>> u = ak.zeros(10, dtype = ak.uint64)

>>> b == 0
# array([True True True True True True True True True True])
>>> b == np.int(0)
# array([True True True True True True True True True True])
>>> b == np.uint(0)
# array([True True True True True True True True True True])
>>> b == False
# array([True True True True True True True True True True])
>>> b == np.float(0)
# array([True True True True True True True True True True])
>>> b == i
# array([True True True True True True True True True True])
>>> b == u
# array([True True True True True True True True True True])
>>> b == f
# array([True True True True True True True True True True])
>>> u == f
# array([True True True True True True True True True True])
>>> u == i
# array([True True True True True True True True True True])
>>> i == f
# array([True True True True True True True True True True])
```