### PR TITLE
Closes #1390: Missing Parquet skip in test

### DIFF
--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -449,7 +449,7 @@ class DataFrameTest(ArkoudaTest):
         df_copy.__setitem__('userID', ak.array([1, 2, 1, 3, 2, 1]))
         self.assertEqual(df.__repr__(), df_copy.__repr__())
 
-    #@pytest.mark.skipif(not os.getenv('ARKOUDA_SERVER_PARQUET_SUPPORT'), reason="No parquet support")
+    @pytest.mark.skipif(not os.getenv('ARKOUDA_SERVER_PARQUET_SUPPORT'), reason="No parquet support")
     def test_save_table(self):
         i = list(range(3))
         c1 = [9, 7, 17]

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -316,6 +316,7 @@ class IOTest(ArkoudaTest):
                               file_format='HDF5')
         self.assertIsNotNone(dataset, "Expected dataset to be populated")
 
+    @pytest.mark.skipif(not os.getenv('ARKOUDA_SERVER_PARQUET_SUPPORT'), reason="No parquet support")
     def testLoad(self):
         '''
         Creates 1..n files depending upon the number of arkouda_server locales with three columns 
@@ -388,7 +389,8 @@ class IOTest(ArkoudaTest):
             ak.load(path_prefix='{}/not-a-file'.format(IOTest.io_test_dir), 
                                     dataset='int_tens_pdarray')
         
-    def testLoadAll(self):   
+    @pytest.mark.skipif(not os.getenv('ARKOUDA_SERVER_PARQUET_SUPPORT'), reason="No parquet support")
+    def testLoadAll(self):
         self._create_file(columns=self.dict_columns,
                           prefix_path='{}/iotest_dict_columns'.format(IOTest.io_test_dir))
 


### PR DESCRIPTION
This PR (Closes #1390) adds missing pytest parquet skip for:
- `test_save_table` in `dataframe_test.py`
- `testLoad` and `testLoadAll` in `io_test.py`