### PR TITLE
Closes #1399: Removing version check from `ak.util.register`

### DIFF
--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -67,12 +67,7 @@ def register(a, name):
     Register an arkouda object with a user-specified name. Backwards compatible
     with earlier arkouda versions.
     """
-    if pd.to_datetime(__version__.lstrip('v')) >= pd.to_datetime('2021.04.14'):
-        # New versions register in-place and don't need callback
-        cb = identity
-    else:
-        # Older versions return a new object that loses higher-level dtypes and must be re-converted
-        cb = get_callback(a)
+    cb = identity
     if type(a) in {Datetime, Timedelta, BitVector, IPv4}:
         # These classes wrap a pdarray, so two names must be updated
         a = a.register(name)


### PR DESCRIPTION
This PR (closes #1399):

The datetime parse in `ak,util.register()` was checking if the current arkouda version was `>= '2021.04.14'` and doing one process if True, and another if False in support of previous versions. This is likely a leftover of when `ak.util` was separate from the main codebase as the current arkouda version will never be less than or equal to `'2021.04.14'` in the current release, `'2022.05.09'` 

Removing this check will allow the `register` method to function properly, but we should look into either updating to be fully generic or removing this method entirely and splitting it's special case into `pdarray.register` if necessary.