### PR TITLE
1406 Fix bug in ak.lookup

### DIFF
--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -105,6 +105,27 @@ class JoinTest(ArkoudaTest):
         with self.assertRaises(ValueError):
             l, r = ak.join.inner_join(left, right, wherefunc=ak.intersect1d, whereargs=(ak.arange(10), ak.arange(5)))
 
+    def test_lookup(self):
+        keys = ak.arange(5)
+        values = 10*keys
+        args = ak.array([5, 3, 1, 4, 2, 3, 1, 0])
+        ans = np.array([-1, 30, 10, 40, 20, 30, 10, 0])
+        # Simple lookup with int keys
+        # Also test shortcut for unique-ordered keys
+        res = ak.lookup(keys, values, args, fillvalue=-1, keys_from_unique=True)
+        self.assertTrue((res.to_ndarray() == ans).all())
+        # Compound lookup with (str, int) keys
+        res2 = ak.lookup((ak.cast(keys, ak.str_), keys), values, (ak.cast(args, ak.str_), args), fillvalue=-1)
+        self.assertTrue((res2.to_ndarray() == ans).all())
+        # Keys not in uniqued order
+        res3 = ak.lookup(keys[::-1], values[::-1], args, fillvalue=-1)
+        self.assertTrue((res3.to_ndarray() == ans).all())
+        # Non-unique keys should raise error
+        with self.assertRaises(ak.NonUniqueError):
+            keys = ak.arange(10) % 5
+            values = 10 * keys
+            ak.lookup(keys, values, args)
+
     def test_error_handling(self):
         """
         Tests error TypeError and ValueError handling


### PR DESCRIPTION
Closes #1406 

Previously, the `ak.lookup()` function, which treats key-value pairs as a function to be applied over args, implicitly assumed that the user-supplied keys were in the order output by `ak.unique()` and `ak.GroupBy()`. This is the most common usage, but it is not inherent to the semantics of the function, and when a user (legitimately) supplied keys that were unique but unordered, `ak.lookup()` would return the wrong answer. 

This PR fixes that behavior by performing `ak.GroupBy(keys)` to ensure the anticipated ordering. Because this can be an expensive step, it also adds a `keys_from_unique` keyword arg as a shortcut for when keys come from unique/GroupBy.

This PR also adds a unit test for `ak.lookup` in the `join_test.py` file (because lookup is a special case of a join).