### PR TITLE
Closes #1381: Adding `is_registered()` to Series and Index

### DIFF
--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -1,4 +1,5 @@
 import pandas as pd  # type: ignore
+from typing import Optional
 
 from arkouda.pdarrayclass import pdarray
 from arkouda.pdarraycreation import arange, ones
@@ -8,11 +9,13 @@ from arkouda.dtypes import int64, float64, bool
 from arkouda.util import register, convert_if_categorical, concatenate, get_callback
 from arkouda.groupbyclass import unique, GroupBy
 from arkouda.alignment import in1dmulti
+from arkouda.infoclass import list_registry
 
 class Index:
     def __init__(self, index):
         self.index = index
         self.size = index.size
+        self.name: Optional[str] = None
 
     def __getitem__(self,key):
         from arkouda.series import Series
@@ -27,7 +30,7 @@ class Index:
         return len(self.index)
 
     def __eq__(self,v):
-        return self.index == v
+        return self.index == v.index
 
     @staticmethod
     def factory(index):
@@ -54,7 +57,24 @@ class Index:
 
     def register(self, label):
         register(self.index, "{}_key".format(label))
+        self.name = label
         return 1
+
+    def is_registered(self):
+        """
+        Return True if the object is contained in the registry
+
+        Returns
+        -------
+        bool
+            Indicates if the object is contained in the registry
+
+        Raises
+        ------
+        RuntimeError
+            Raised if there's a server-side error thrown
+        """
+        return f"{self.name}_key" in list_registry()
 
     def to_dict(self, label):
         data = {}

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -30,7 +30,9 @@ class Index:
         return len(self.index)
 
     def __eq__(self,v):
-        return self.index == v.index
+        if isinstance(v, Index):
+            return self.index == v.index
+        return self.index == v
 
     @staticmethod
     def factory(index):

--- a/arkouda/series.py
+++ b/arkouda/series.py
@@ -15,6 +15,7 @@ from arkouda.accessor import CachedAccessor, DatetimeAccessor, StringAccessor
 from pandas._config import get_option # type: ignore
 import pandas as pd  # type: ignore
 import numpy as np  # type: ignore
+from warnings import warn
 
 __all__ = [
     "Series",
@@ -382,6 +383,28 @@ class Series:
             k = [attach_pdarray("{}_key_{}".format(label, i)) for i in range(nkeys)]
 
         return Series((k, v))
+
+    def is_registered(self):
+        """
+        Checks if all components of the Series object are registered
+
+        Returns
+        -------
+        bool
+            True if all components are registered, false if not
+
+        See Also
+        --------
+        register, unregister, attach
+        """
+
+        # Series contains 2 parts - index and values
+        regParts = [self.index.is_registered(), self.values.is_registered()]
+
+        if any(regParts) and not all(regParts):
+            warn(f"Series expected {len(regParts)} components to be registered, but only located {sum(regParts)}")
+
+        return all(regParts)
 
     @staticmethod
     def _all_aligned(array):

--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -67,12 +67,7 @@ def register(a, name):
     Register an arkouda object with a user-specified name. Backwards compatible
     with earlier arkouda versions.
     """
-    if pd.to_datetime(__version__.lstrip('v')) >= pd.to_datetime('2021.04.14'):
-        # New versions register in-place and don't need callback
-        cb = identity
-    else:
-        # Older versions return a new object that loses higher-level dtypes and must be re-converted
-        cb = get_callback(a)
+    cb = identity
     if type(a) in {Datetime, Timedelta, BitVector, IPv4}:
         # These classes wrap a pdarray, so two names must be updated
         a = a.register(name)

--- a/tests/registration_test.py
+++ b/tests/registration_test.py
@@ -1,5 +1,7 @@
 import pytest
 import json
+
+from arkouda import Series
 from context import arkouda as ak
 from base_test import ArkoudaTest
 from arkouda.pdarrayclass import RegistrationError, unregister_pdarray_by_name
@@ -437,6 +439,27 @@ class RegistrationTest(ArkoudaTest):
         b = None  # Force out of scope
         with self.assertRaises(RuntimeError):
             str(a)
+
+    def test_series_register_attach(self):
+        ar_tuple = (ak.arange(5), ak.arange(5))
+        s = ak.Series(ar_tuple=ar_tuple)
+
+        # At this time, there is no unregister() in Series. Register one piece to check partial registration
+        s.values.register("seriesTest_values")
+        with self.assertWarns(UserWarning):
+            s.is_registered()
+        # Unregister values pdarray
+        s.values.unregister()
+
+        self.assertFalse(s.is_registered())
+
+        s.register("seriesTest")
+        self.assertTrue(s.is_registered())
+
+        s2 = Series.attach("seriesTest")
+        self.assertListEqual(s2.values.to_ndarray().tolist(), s.values.to_ndarray().tolist())
+        sEq = s2.index == s.index
+        self.assertTrue(all(sEq.to_ndarray()))
 
     def test_strings_groupby_attach(self):
         s = ak.array(["abc", "123", "abc"])


### PR DESCRIPTION
This ticket (closes #1381):

This PR adds the `is_registered` method to `Series` and `Index`, as well as a test for the `register` and `attach` functionality with `Series`, but it should be noted that neither `Series` nor `Index` have an `unregister` method