### PR TITLE
Closes #1417: Limit multi-locale CI testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -109,30 +109,21 @@ jobs:
       run: |
         make check
     - name: Arkouda unit tests
+      if: matrix.image != 'chapel-gasnet-smp'
       env:
         ARKOUDA_PYTEST_OPTIONS: "--durations=0 --durations-min=5.0"
       run: |
         make test-python
     - name: Arkouda benchmark --correctness-only
+      if: matrix.image != 'chapel-gasnet-smp'
       run: |
         ./benchmarks/run_benchmarks.py --correctness-only
-        if [ "${{matrix.image}}" != "chapel-gasnet-smp" ]; then
-          ./benchmarks/run_benchmarks.py --size=100 --gen-graphs
-        fi
+        ./benchmarks/run_benchmarks.py --size=100 --gen-graphs
 
   chapel_unit_tests_linux:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - image: chapel
-            threads: 2
-          - image: chapel-gasnet-smp
-            threads: 1
-    env:
-      CHPL_RT_NUM_THREADS_PER_LOCALE: ${{matrix.threads}}
     container:
-      image: chapel/${{matrix.image}}:1.25.1
+      image: chapel/chapel:1.25.1
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies


### PR DESCRIPTION
The gasnet correctness testing is now taking over an hour. Back in
January this was down to 30 minutes, which felt reasonable but an hour
is too much and limits our ability to get new code in. For now, limit
multi-locale testing to `make check` and rely on nightly testing to run
the full test suite.

I didn't want to remove all multi-locale testing since I think there's
value in some checks with the different distributions and aggregation
being used, but the full test suite just takes too long at the moment.

Part of #388
Closes #1417