### PR TITLE
Use swap operator in radix sort instead of assignment operator

### DIFF
--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -154,7 +154,7 @@ module RadixSortLSD
             // copy back to temp for next iteration
             // Only do this if there are more digits left
             if !last {
-              temp = a;
+              temp <=> a;
             }
         } // for rshift
     }//proc radixSortLSDCore


### PR DESCRIPTION
This PR switches an assignment operator to use the swap operator
instead. The swap operator is a simple pointer swap, whereas the
assignment operator is a deep copy, so nearly all of the time
from that assignment is saved, but it is admittedly not the
bottleneck, so only modest performance improvements should be
expected.

Results on 16-node-cs-hdr:
|              | master          | this pr
| ------------ | --------------- | -------
| argsort perf | 11.1145 GiB/sec | 11.9066 GiB/sec

Closes https://github.com/Bears-R-Us/arkouda/issues/1446