### PR TITLE
Closes #1420 - /converter PEP8 Formatting

### DIFF
--- a/converter/csv2hdf.py
+++ b/converter/csv2hdf.py
@@ -1,31 +1,60 @@
 #!/usr/bin/env python3
 
-import os, sys
+import os
+import sys
+
 
 def import_local(path):
     if not os.path.exists(path):
         raise ImportError(f"{path} not found")
     importdir, filename = os.path.split(path)
     importname, ext = os.path.splitext(filename)
-    if ext != '.py':
+    if ext != ".py":
         raise ImportError(f"{path} must be a .py file")
     sys.path.append(importdir)
     return f"from {importname} import OPTIONS as CUSTOM"
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     import hdflow
     from multiprocessing import cpu_count
     import argparse
-    parser = argparse.ArgumentParser(description='Convert CSV files with numeric data to HDF5 files in parallel.')
-    parser.add_argument('--outdir', default='.', help='Output directory for HDF5 files (Default: current directory)')
-    parser.add_argument('--jobs', type=int, default=cpu_count(), help='Number of worker processes to use (Default: all available cores)')
-    parser.add_argument('--extension', default='.hdf', help='Output file extension (Default: .hdf)')
-    parser.add_argument('--format', required=True, help=f'Name of netflow format defined in --formats-file argument')
-    parser.add_argument('--formats-file', required=True, help=f'Python file specifying read_csv options, e.g. column names and dtypes')
-    parser.add_argument('filenames', nargs='+', help='Input files to convert')
+
+    parser = argparse.ArgumentParser(
+        description="Convert CSV files with numeric data to HDF5 files in parallel."
+    )
+    parser.add_argument(
+        "--outdir",
+        default=".",
+        help="Output directory for HDF5 files (Default: current directory)",
+    )
+    parser.add_argument(
+        "--jobs",
+        type=int,
+        default=cpu_count(),
+        help="Number of worker processes to use (Default: all available cores)",
+    )
+    parser.add_argument(
+        "--extension", default=".hdf", help="Output file extension (Default: .hdf)"
+    )
+    parser.add_argument(
+        "--format",
+        required=True,
+        help="Name of netflow format defined in --formats-file argument",
+    )
+    parser.add_argument(
+        "--formats-file",
+        required=True,
+        help="Python file specifying read_csv options, e.g. column names and dtypes",
+    )
+    parser.add_argument("filenames", nargs="+", help="Input files to convert")
 
     args = parser.parse_args()
     exec(import_local(args.formats_file))
     if args.format not in CUSTOM:
-        raise ValueError(f"Netflow format not found. Detected formats: {set(CUSTOM.keys())}")
-    hdflow.convert_files(args.filenames, args.outdir, args.extension, CUSTOM[args.format], args.jobs)
+        raise ValueError(
+            f"Netflow format not found. Detected formats: {set(CUSTOM.keys())}"
+        )
+    hdflow.convert_files(
+        args.filenames, args.outdir, args.extension, CUSTOM[args.format], args.jobs
+    )

--- a/converter/csv2hdf.py
+++ b/converter/csv2hdf.py
@@ -16,9 +16,10 @@ def import_local(path):
 
 
 if __name__ == "__main__":
-    import hdflow
-    from multiprocessing import cpu_count
     import argparse
+    from multiprocessing import cpu_count
+
+    import hdflow
 
     parser = argparse.ArgumentParser(
         description="Convert CSV files with numeric data to HDF5 files in parallel."

--- a/converter/csv2hdf.py
+++ b/converter/csv2hdf.py
@@ -34,9 +34,7 @@ if __name__ == "__main__":
         default=cpu_count(),
         help="Number of worker processes to use (Default: all available cores)",
     )
-    parser.add_argument(
-        "--extension", default=".hdf", help="Output file extension (Default: .hdf)"
-    )
+    parser.add_argument("--extension", default=".hdf", help="Output file extension (Default: .hdf)")
     parser.add_argument(
         "--format",
         required=True,
@@ -52,9 +50,5 @@ if __name__ == "__main__":
     args = parser.parse_args()
     exec(import_local(args.formats_file))
     if args.format not in CUSTOM:
-        raise ValueError(
-            f"Netflow format not found. Detected formats: {set(CUSTOM.keys())}"
-        )
-    hdflow.convert_files(
-        args.filenames, args.outdir, args.extension, CUSTOM[args.format], args.jobs
-    )
+        raise ValueError(f"Netflow format not found. Detected formats: {set(CUSTOM.keys())}")
+    hdflow.convert_files(args.filenames, args.outdir, args.extension, CUSTOM[args.format], args.jobs)

--- a/converter/hdflow.py
+++ b/converter/hdflow.py
@@ -6,21 +6,27 @@ from itertools import repeat
 from tqdm import tqdm
 import multiprocessing as mp
 
+
 def _normalize_dtype(col, dtype):
-    if dtype == np.str_ or dtype == str or (isinstance(dtype, str) and dtype in 'strings'):
-        normdtype = np.dtype('str')
+    if (
+        dtype == np.str_
+        or dtype == str
+        or (isinstance(dtype, str) and dtype in "strings")
+    ):
+        normdtype = np.dtype("str")
     elif dtype is not None:
         # data = col.astype(dtype).values
         if callable(dtype):
             normdtype = dtype().dtype
     # Convert datetime64 to int64, but save original dtype for round-trip conversion
-    elif col.dtype.kind == 'M':
+    elif col.dtype.kind == "M":
         # data = col.astype(np.int64).values
         normdtype = col.dtype
     else:
         # data = col.values
         normdtype = col.dtype
     return normdtype
+
 
 def pack_strings(column):
     lengths = column.apply(len).values
@@ -29,50 +35,64 @@ def pack_strings(column):
     packed = np.zeros(shape=(totalbytes,), dtype=np.uint8)
     for (o, s) in zip(offsets, column.values):
         for i, b in enumerate(s.encode()):
-            packed[o+i] = b
+            packed[o + i] = b
     return packed, offsets
 
+
 def _cast_values(col, dtype):
-    if dtype == np.str_ or dtype == str or (isinstance(dtype, str) and dtype in 'strings'):
+    if (
+        dtype == np.str_
+        or dtype == str
+        or (isinstance(dtype, str) and dtype in "strings")
+    ):
         data = pack_strings(col)
     elif dtype is not None:
         data = col.astype(dtype).values
-    elif col.dtype.kind == 'M':
+    elif col.dtype.kind == "M":
         data = col.astype(np.int64).values
     else:
         data = col.values
     return data
 
+
 def write_strings(f, group, packed, offsets):
     g = f.create_group(group)
     g.attrs["segmented_string"] = np.bool(True)
-    g.create_dataset('values', data=packed)
-    g.create_dataset('segments', data=offsets)
+    g.create_dataset("values", data=packed)
+    g.create_dataset("segments", data=offsets)
 
-def col2dset(name, col, f, dtype=None, compression='gzip'):
-    '''Write a pandas Series <col> to dataset <name> in HDF5 file <f>.
+
+def col2dset(name, col, f, dtype=None, compression="gzip"):
+    """Write a pandas Series <col> to dataset <name> in HDF5 file <f>.
     Optionally, specify a dtype to convert to before writing. Compression
-    with gzip is also supported.'''
+    with gzip is also supported."""
     normdtype = _normalize_dtype(col, dtype)
     data = _cast_values(col, dtype)
     try:
-        if normdtype == np.dtype('str'):
+        if normdtype == np.dtype("str"):
             packed, offsets = data
             write_strings(f, name, packed, offsets)
         else:
             dset = f.create_dataset(name, data=data, compression=compression)
             # Store the normalized dtype for conversion back to a pd.Series
-            dset.attrs['dtype'] = np.string_(normdtype.str)
+            dset.attrs["dtype"] = np.string_(normdtype.str)
     except TypeError:
         print(f"Column {col}")
 
 
-def df2hdf(filename, df, dtypes={}, compression='gzip'):
-    '''Write a pandas DataFrame <df> to a HDF5 file <filename>. Optionally,
-    specify dtypes for converting the columns and a compression to use.'''
-    with h5py.File(filename, 'w') as f:
+def df2hdf(filename, df, dtypes={}, compression="gzip"):
+    """Write a pandas DataFrame <df> to a HDF5 file <filename>. Optionally,
+    specify dtypes for converting the columns and a compression to use."""
+    with h5py.File(filename, "w") as f:
         for colname in df.columns:
-            col2dset(colname, df[colname], f, dtype=dtypes.get(colname, None), compression=compression)
+            col2dset(
+                colname,
+                df[colname],
+                f,
+                dtype=dtypes.get(colname, None),
+                compression=compression,
+            )
+
 
 def convert_file(args):
     filename, outdir, extension, options = args
@@ -83,20 +103,21 @@ def convert_file(args):
         print(e)
         return
     newname = os.path.splitext(os.path.basename(filename))[0] + extension
-    df2hdf(os.path.join(outdir, newname), df, options.get('dtype', {}))
+    df2hdf(os.path.join(outdir, newname), df, options.get("dtype", {}))
+
 
 def _get_valid_columns(filename, options):
-    #print(filename)
-    #print(options)
+    # print(filename)
+    # print(options)
     try:
-        #**options causing error
+        # **options causing error
         df = pd.read_csv(filename, nrows=1000, **options)
     except Exception as e:
-        print(f"Error reading sample DataFrame: ",e)
-        #print(e)
+        print(f"Error reading sample DataFrame: {e}")
+        # print(e)
     validcols = []
     for i, col in enumerate(df.columns):
-        userdtype = options.get('dtype', {}).get(col, None)
+        userdtype = options.get("dtype", {}).get(col, None)
         normdtype = _normalize_dtype(df[col], userdtype)
         data = _cast_values(df[col], userdtype)
         try:
@@ -104,12 +125,15 @@ def _get_valid_columns(filename, options):
                 h5py.h5t.py_create(data.dtype, logical=True)
             validcols.append(i)
         except TypeError:
-            print(f'Ignoring column {col} because dtype "{df[col].values.dtype}" has no HDF5 equivalent.')
+            print(
+                f'Ignoring column {col} because dtype "{df[col].values.dtype}" has no HDF5 equivalent.'
+            )
     print("Columns to be extracted:")
     print(df[df.columns[validcols]].info())
-    used = options.get('usecols', list(range(df.shape[1])))
+    used = options.get("usecols", list(range(df.shape[1])))
     new_usecols = [used[v] for v in validcols]
     return new_usecols
+
 
 def convert_files(filenames, outdir, extension, options, nprocs):
     if not os.path.isdir(outdir) or not os.access(outdir, os.W_OK):
@@ -117,14 +141,16 @@ def convert_files(filenames, outdir, extension, options, nprocs):
     usecols = _get_valid_columns(filenames[0], options)
     if len(usecols) == 0:
         raise TypeError("No columns found with HDF5-compatible dtype")
-    options['usecols'] = usecols
+    options["usecols"] = usecols
     arglist = zip(filenames, repeat(outdir), repeat(extension), repeat(options))
     nprocs = min((nprocs, len(filenames)))
     if nprocs <= 1:
         _ = list(tqdm(map(convert_file, arglist), total=len(filenames)))
     else:
         with mp.Pool(nprocs) as pool:
-            _ = list(tqdm(pool.imap_unordered(convert_file, arglist), total=len(filenames)))
+            _ = list(
+                tqdm(pool.imap_unordered(convert_file, arglist), total=len(filenames))
+            )
 
 
 def read_hdf(filenames):
@@ -132,6 +158,7 @@ def read_hdf(filenames):
     for fname, ind in tqdm(zip(filenames, offsets), total=len(filenames)):
         _hdf_insert(fname, df, ind)
     return df
+
 
 def _hdf_alloc(filenames):
     if len(filenames) == 0:
@@ -152,13 +179,16 @@ def _hdf_alloc(filenames):
     # Last entry is total length; remove it so it won't be used as offset
     total = offsets.pop()
     # Allocate uninitialized memory for concatenated columns
-    columns = {col:pd.Series(np.empty(shape=(total,), dtype=dtypes[col])) for col in dtypes}
+    columns = {
+        col: pd.Series(np.empty(shape=(total,), dtype=dtypes[col])) for col in dtypes
+    }
     return pd.DataFrame(columns), offsets, lengths
 
-def _get_column_metadata(filename, dtype_attr='dtype'):
+
+def _get_column_metadata(filename, dtype_attr="dtype"):
     dtypes = {}
     length = -1
-    with h5py.File(filename, 'r') as f:
+    with h5py.File(filename, "r") as f:
         # Use HDF5 dataset names as column names
         for colname in f.keys():
             dset = f[colname]
@@ -169,14 +199,17 @@ def _get_column_metadata(filename, dtype_attr='dtype'):
             if length == -1:
                 length = dset.shape[0]
             else:
-                assert length == dset.shape[0], f"Columns of unequal length in {filename}"
+                assert (
+                    length == dset.shape[0]
+                ), f"Columns of unequal length in {filename}"
     return dtypes, length
 
+
 def _hdf_insert(filename, df, index):
-    with h5py.File(filename, 'r') as f:
+    with h5py.File(filename, "r") as f:
         # _hdf_alloc has already guaranteed that file has correct column names
         for colname in f.keys():
             dset = f[colname]
             size = dset.shape[0]
             # Read the dataset directly into the uninitialized column
-            df[colname].values[index:index+size] = dset[:]
+            df[colname].values[index : index + size] = dset[:]

--- a/converter/hdflow.py
+++ b/converter/hdflow.py
@@ -8,11 +8,7 @@ import multiprocessing as mp
 
 
 def _normalize_dtype(col, dtype):
-    if (
-        dtype == np.str_
-        or dtype == str
-        or (isinstance(dtype, str) and dtype in "strings")
-    ):
+    if dtype == np.str_ or dtype == str or (isinstance(dtype, str) and dtype in "strings"):
         normdtype = np.dtype("str")
     elif dtype is not None:
         # data = col.astype(dtype).values
@@ -40,11 +36,7 @@ def pack_strings(column):
 
 
 def _cast_values(col, dtype):
-    if (
-        dtype == np.str_
-        or dtype == str
-        or (isinstance(dtype, str) and dtype in "strings")
-    ):
+    if dtype == np.str_ or dtype == str or (isinstance(dtype, str) and dtype in "strings"):
         data = pack_strings(col)
     elif dtype is not None:
         data = col.astype(dtype).values
@@ -148,9 +140,7 @@ def convert_files(filenames, outdir, extension, options, nprocs):
         _ = list(tqdm(map(convert_file, arglist), total=len(filenames)))
     else:
         with mp.Pool(nprocs) as pool:
-            _ = list(
-                tqdm(pool.imap_unordered(convert_file, arglist), total=len(filenames))
-            )
+            _ = list(tqdm(pool.imap_unordered(convert_file, arglist), total=len(filenames)))
 
 
 def read_hdf(filenames):
@@ -179,9 +169,7 @@ def _hdf_alloc(filenames):
     # Last entry is total length; remove it so it won't be used as offset
     total = offsets.pop()
     # Allocate uninitialized memory for concatenated columns
-    columns = {
-        col: pd.Series(np.empty(shape=(total,), dtype=dtypes[col])) for col in dtypes
-    }
+    columns = {col: pd.Series(np.empty(shape=(total,), dtype=dtypes[col])) for col in dtypes}
     return pd.DataFrame(columns), offsets, lengths
 
 
@@ -199,9 +187,7 @@ def _get_column_metadata(filename, dtype_attr="dtype"):
             if length == -1:
                 length = dset.shape[0]
             else:
-                assert (
-                    length == dset.shape[0]
-                ), f"Columns of unequal length in {filename}"
+                assert length == dset.shape[0], f"Columns of unequal length in {filename}"
     return dtypes, length
 
 

--- a/converter/hdflow.py
+++ b/converter/hdflow.py
@@ -1,10 +1,11 @@
-import pandas as pd
-import numpy as np
-import h5py
+import multiprocessing as mp
 import os
 from itertools import repeat
+
+import h5py
+import numpy as np
+import pandas as pd
 from tqdm import tqdm
-import multiprocessing as mp
 
 
 def _normalize_dtype(col, dtype):

--- a/converter/lanl_format.py
+++ b/converter/lanl_format.py
@@ -1,5 +1,6 @@
-import numpy as np
 import re
+
+import numpy as np
 
 splitter = re.compile(r"([a-zA-Z]*)(\d*)")
 

--- a/converter/lanl_format.py
+++ b/converter/lanl_format.py
@@ -52,6 +52,4 @@ lanl_options = {
 }
 
 
-OPTIONS = {
-    "lanl": lanl_options
-}
+OPTIONS = {"lanl": lanl_options}

--- a/converter/lanl_format.py
+++ b/converter/lanl_format.py
@@ -1,33 +1,57 @@
 import numpy as np
 import re
 
-splitter = re.compile(r'([a-zA-Z]*)(\d*)')
+splitter = re.compile(r"([a-zA-Z]*)(\d*)")
+
 
 def numerify(s):
     name, num = splitter.match(s).groups()
-    prefix = hash(name) & 0xffff
-    if num == '':
+    prefix = hash(name) & 0xFFFF
+    if num == "":
         postfix = 0
     else:
         postfix = int(num)
     return np.int64((prefix << 20) ^ postfix)
 
+
 def deport(s):
-    return np.int64(s.lstrip('Port'))
-
-lanl_options = {'delimiter': ',',
-                'header':None,
-                'names':['start', 'duration', 'srcIP', 'dstIP', 'proto',
-                         'srcPort', 'dstPort', 'srcPkts', 'dstPkts',
-                         'srcBytes', 'dstBytes'],
-                'converters': {# 'srcIP': numerify, 'dstIP': numerify,
-                               'srcPort': deport, 'dstPort': deport},
-                'dtype': {'srcIP': np.str_, 'dstIP': np.str_,
-                          'start': np.int64, 'duration': np.int64,
-                          'proto': np.int64, 'srcPkts': np.int64,
-                          'dstPkts': np.int64, 'srcBytes': np.float64,
-                          'dstBytes': np.float64}}
+    return np.int64(s.lstrip("Port"))
 
 
-OPTIONS = {}
-OPTIONS['lanl'] = lanl_options
+lanl_options = {
+    "delimiter": ",",
+    "header": None,
+    "names": [
+        "start",
+        "duration",
+        "srcIP",
+        "dstIP",
+        "proto",
+        "srcPort",
+        "dstPort",
+        "srcPkts",
+        "dstPkts",
+        "srcBytes",
+        "dstBytes",
+    ],
+    "converters": {  # 'srcIP': numerify, 'dstIP': numerify,
+        "srcPort": deport,
+        "dstPort": deport,
+    },
+    "dtype": {
+        "srcIP": np.str_,
+        "dstIP": np.str_,
+        "start": np.int64,
+        "duration": np.int64,
+        "proto": np.int64,
+        "srcPkts": np.int64,
+        "dstPkts": np.int64,
+        "srcBytes": np.float64,
+        "dstBytes": np.float64,
+    },
+}
+
+
+OPTIONS = {
+    "lanl": lanl_options
+}


### PR DESCRIPTION
Closes #1420

Updates the Python files in `/converter` to adhere to PEP8 formatting. 
Ran `isort`

*NOTE*
If we decide to leave the `max_line_length` setting at 88 for `flake8`, `converter/hdlfow.py` will need to have 2 lines updated before merging this. See #1412.