### PR TITLE
Fix allocated buffer size for akVersion

### DIFF
--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -1714,7 +1714,7 @@ module HDF5Msg {
                             C_HDF5.H5P_DEFAULT);
 
         // For the value, we need to build a ptr to a char[]; c_string doesn't work because it is a const char*        
-        var akVersion = c_calloc(c_char, arkoudaVersion.size);
+        var akVersion = c_calloc(c_char, arkoudaVersion.size+1);
         for (c, i) in zip(arkoudaVersion.codepoints(), 0..<arkoudaVersion.size) {
             akVersion[i] = c:c_char;
         }


### PR DESCRIPTION
When calculating the Arkouda version when writing an HDF5 file,
the buffer size was 1 too low, which meant there was a bad memory
access going when setting the last value to 0 to ensure null
termination.

Closes https://github.com/Bears-R-Us/arkouda/issues/1426