### PR TITLE
Closes #1429 - `pydoc/_ext/ak_sphinx_extensions.py` PEP8 Formatting

### DIFF
--- a/pydoc/_ext/ak_sphinx_extensions.py
+++ b/pydoc/_ext/ak_sphinx_extensions.py
@@ -7,6 +7,7 @@ from typing import List
 from sphinx.application import Sphinx
 from sphinx.directives.code import CodeBlock
 
+
 class SubstitutionCodeBlock(CodeBlock):  # type: ignore
     """
     Similar to CodeBlock but replaces placeholders with variables.
@@ -36,5 +37,5 @@ def setup(app: Sphinx) -> None:
     """
     Add the custom directives to Sphinx.
     """
-    app.add_config_value('substitutions', [], 'html')
-    app.add_directive('substitution-code-block', SubstitutionCodeBlock)
+    app.add_config_value("substitutions", [], "html")
+    app.add_directive("substitution-code-block", SubstitutionCodeBlock)


### PR DESCRIPTION
Closes #1429 

- Formats file to PEP8 via `black`
- Ran `isort`, but no changes resulted because imports were already formatted properly.