### PR TITLE
Closes #1433 - Set `mypy==0.931`

### DIFF
--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -24,5 +24,5 @@ dependencies:
   - pip:
     - typeguard==2.10.0
     # Developer dependencies
-    - mypy>=0.931
+    - mypy==0.931
   

--- a/setup.py
+++ b/setup.py
@@ -153,7 +153,7 @@ setup(
     extras_require={  # Optional
         'dev': ['h5py','pexpect', 'pytest', 
                 'pytest-env','Sphinx', 'sphinx-argparse', 
-                'sphinx-autoapi', 'mypy>=0.931', 'typed-ast'],
+                'sphinx-autoapi', 'mypy==0.931', 'typed-ast'],
     },
     # replace original install command with version that also builds
     # chapel and the arkouda server.


### PR DESCRIPTION
Closes #1433 

Updates the mypy dependency to use version `0.931`. This is to avoid issues documented in #1371 until the cause can be identified and resolved.