### PR TITLE
Adjust source files to be compatible with changes I made to the Math module

### DIFF
--- a/src/Cast.chpl
+++ b/src/Cast.chpl
@@ -94,7 +94,7 @@ module Cast {
       num = stringToNumericStrict(values, rng, toType);
     } catch {
       if toType == real {
-        num = Math.NAN;
+        num = NAN;
       } else if toType == int {
         // Use pandas.NaT, i.e. -2**63, as NaN for int
         num = min(int);
@@ -111,7 +111,7 @@ module Cast {
       num = stringToNumericStrict(values, rng, toType);
     } catch {
       if toType == real {
-        num = Math.NAN;
+        num = NAN;
       } else if toType == int {
         // Use pandas.NaT, i.e. -2**63, as NaN for int
         num = min(int);

--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -55,15 +55,15 @@ module EfuncMsg
                 {
                     when "abs" {
                         var a = st.addEntry(rname, e.size, real);
-                        a.a = Math.abs(e.a);                      
+                        a.a = abs(e.a);
                     }
                     when "log" {
                         var a = st.addEntry(rname, e.size, real);
-                        a.a = Math.log(e.a);
+                        a.a = log(e.a);
                     }
                     when "exp" {
                         var a = st.addEntry(rname, e.size, real);
-                        a.a = Math.exp(e.a);
+                        a.a = exp(e.a);
                     }
                     when "cumsum" {
                         // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
@@ -77,11 +77,11 @@ module EfuncMsg
                     }
                     when "sin" {
                         var a = st.addEntry(rname, e.size, real);
-                        a.a = Math.sin(e.a);
+                        a.a = sin(e.a);
                     }
                     when "cos" {
                         var a = st.addEntry(rname, e.size, real);
-                        a.a = Math.cos(e.a);
+                        a.a = cos(e.a);
                     }
                     when "hash64" {
                         overMemLimit(numBytes(int) * e.size);
@@ -131,15 +131,15 @@ module EfuncMsg
                 {
                     when "abs" {
                         var a = st.addEntry(rname, e.size, real);
-                        a.a = Math.abs(e.a);
+                        a.a = abs(e.a);
                     }
                     when "log" {
                         var a = st.addEntry(rname, e.size, real);
-                        a.a = Math.log(e.a);
+                        a.a = log(e.a);
                     }
                     when "exp" {
                         var a = st.addEntry(rname, e.size, real);
-                        a.a = Math.exp(e.a);
+                        a.a = exp(e.a);
                     }
                     when "cumsum" {
                         // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
@@ -153,11 +153,11 @@ module EfuncMsg
                     }
                     when "sin" {
                         var a = st.addEntry(rname, e.size, real);
-                        a.a = Math.sin(e.a);
+                        a.a = sin(e.a);
                     }
                     when "cos" {
                         var a = st.addEntry(rname, e.size, real);
-                        a.a = Math.cos(e.a);
+                        a.a = cos(e.a);
                     }
                     when "isnan" {
                         var a = st.addEntry(rname, e.size, bool);
@@ -240,11 +240,11 @@ module EfuncMsg
                     }
                     when "sin" {
                         var a = st.addEntry(rname, e.size, real);
-                        a.a = Math.sin(e.a);
+                        a.a = sin(e.a);
                     }
                     when "cos" {
                         var a = st.addEntry(rname, e.size, real);
-                        a.a = Math.cos(e.a);
+                        a.a = cos(e.a);
                     }
                     when "parity" {
                         var a = st.addEntry(rname, e.size, uint);
@@ -271,11 +271,11 @@ module EfuncMsg
                     }
                     when "log" {
                         var a = st.addEntry(rname, e.size, real);
-                        a.a = Math.log(e.a);
+                        a.a = log(e.a);
                     }
                     when "exp" {
                         var a = st.addEntry(rname, e.size, real);
-                        a.a = Math.exp(e.a);
+                        a.a = exp(e.a);
                     }
                     otherwise {
                         var errorMsg = notImplementedError(pn,efunc,gEnt.dtype);

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -629,14 +629,14 @@ module ReductionMsg
           if isnan(v) {
             m = 1.0;
           } else {
-            m = Math.abs(v) + z:real;
+            m = abs(v) + z:real;
           }
         }
       } else {
-        magnitudes = Math.abs(values) + isZero:real;
+        magnitudes = abs(values) + isZero:real;
       }
-      var logs = Math.log(magnitudes);
-      var negatives = (Math.sgn(values) == -1);
+      var logs = log(magnitudes);
+      var negatives = (sgn(values) == -1);
       forall (r, v, n, z) in zip(res,
                                  segSum(logs, segments),
                                  segSum(negatives, segments),
@@ -647,7 +647,7 @@ module ReductionMsg
           // if n is even, product is positive; if odd, negative
           var sign = -2*(n%2) + 1;
           // v = the sum of log-magnitudes; must be exponentiated and signed
-          r = sign * Math.exp(v);
+          r = sign * exp(v);
         }
       }
       return res;

--- a/test/TestBase.chpl
+++ b/test/TestBase.chpl
@@ -11,7 +11,7 @@ public use MultiTypeSymbolTable;
 public use SymArrayDmap;
 public use SegmentedArray;
 public use RandArray;
-public use AryUtil;
+public use AryUtil as AryUtil;
 
 
 // Diag helpers (timers, comm diags, etc.)


### PR DESCRIPTION
The Chapel team is in the process of splitting the Math standard library into a
portion that continues to be included by default and one that will require a
`use` or `import` statement going forward.  To maintain compatibility with both
the previous releases and main/the upcoming release, update these files to no
longer use explicit naming to access the symbols in that module (since the ones
that are being included by default are no longer in the module named "Math" but
are instead in a new module named "AutoMath" that won't exist for previous
releases)

While here, I also updated test/TestBase.chpl to fix the issue test/UnitTestSort.chpl
was encountering with latest Chapel main.  That test was complaining it could not
find AryUtil, because the 1.27 pre-release has changed our handling of `public use`
to no longer bring in the name of the module in addition to the symbols it contains,
unless an `as` clause is used.  Add an `as` clause so that the name is now
brought in again.  (see https://github.com/chapel-lang/chapel/pull/19306#issuecomment-1122425356
for how the scoping rules are expected to change in the upcoming 1.27 release)