### PR TITLE
Closes #1363: ak.Series with only values and more robust typechecking

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -324,7 +324,7 @@ class DataFrame(UserDict):
         if key not in self.columns:
             raise AttributeError(f'Attribute {key} not found')
         # Should this be cached?
-        return Series(data=self[key], index=self.index)
+        return Series(data=self[key], index=self.index.index)
 
     def __dir__(self):
         return dir(DataFrame) + self.columns

--- a/tests/registration_test.py
+++ b/tests/registration_test.py
@@ -442,7 +442,7 @@ class RegistrationTest(ArkoudaTest):
 
     def test_series_register_attach(self):
         ar_tuple = (ak.arange(5), ak.arange(5))
-        s = ak.Series(ar_tuple=ar_tuple)
+        s = ak.Series(ar_tuple)
 
         # At this time, there is no unregister() in Series. Register one piece to check partial registration
         s.values.register("seriesTest_values")

--- a/tests/series_test.py
+++ b/tests/series_test.py
@@ -7,12 +7,42 @@ import pandas as pd
 class SeriesTest(ArkoudaTest):
 
     def test_series_creation(self):
-        ar_tuple = (ak.arange(3), ak.array(['A', 'B', 'C']))
-        s = ak.Series(ar_tuple=ar_tuple)
+        # Use positional arguments
+        ar_tuple = ak.arange(3), ak.arange(3)
+        s = ak.Series(ar_tuple)
+        self.assertIsInstance(s, ak.Series)
+
+        ar_tuple = ak.array(['A', 'B', 'C']), ak.arange(3)
+        s = ak.Series(ar_tuple)
+        self.assertIsInstance(s, ak.Series)
+
+        # Both data and index are supplied
+        v = ak.array(['A', 'B', 'C'])
+        i = ak.arange(3)
+        s = ak.Series(data=v, index=i)
 
         self.assertIsInstance(s, ak.Series)
         self.assertIsInstance(s.index, ak.Index)
 
+        # Just data is supplied
+        s = ak.Series(data=v)
+        self.assertIsInstance(s, ak.Series)
+        self.assertIsInstance(s.index, ak.Index)
+
+        # Just index is supplied (keyword argument)
+        with self.assertRaises(TypeError):
+            s = ak.Series(index=i)
+
+        # Just data is supplied (positional argument)
+        s = ak.Series(ak.array(['A', 'B', 'C']))
+        self.assertIsInstance(s, ak.Series)
+
+        # Just index is supplied (ar_tuple argument)
+        ar_tuple = (ak.arange(3),)
+        with self.assertRaises(TypeError):
+            s = ak.Series(ar_tuple)
+
+        # No arguments are supplied
         with self.assertRaises(TypeError):
             s = ak.Series()
 
@@ -20,8 +50,9 @@ class SeriesTest(ArkoudaTest):
             s = ak.Series(data=ak.arange(3), index=ak.arange(6))
 
     def test_lookup(self):
-        ar_tuple = (ak.arange(3), ak.array(['A', 'B', 'C']))
-        s = ak.Series(ar_tuple=ar_tuple)
+        v = ak.array(['A', 'B', 'C'])
+        i = ak.arange(3)
+        s = ak.Series(data=v, index=i)
 
         l = s.locate(1)
         self.assertIsInstance(l, ak.Series)
@@ -36,8 +67,9 @@ class SeriesTest(ArkoudaTest):
         self.assertEqual(l.values[1], 'C')
 
     def test_shape(self):
-        ar_tuple = (ak.arange(3), ak.array(['A', 'B', 'C']))
-        s = ak.Series(ar_tuple=ar_tuple)
+        v = ak.array(['A', 'B', 'C'])
+        i = ak.arange(3)
+        s = ak.Series(data=v, index=i)
 
         l, = s.shape
         self.assertEqual(l, 3)
@@ -46,9 +78,11 @@ class SeriesTest(ArkoudaTest):
         ar_tuple = (ak.arange(3), ak.arange(3))
         ar_tuple_add = (ak.arange(3, 6, 1), ak.arange(3, 6, 1))
 
-        s = ak.Series(ar_tuple=ar_tuple)
+        i = ak.arange(3)
+        v = ak.arange(3, 6, 1)
+        s = ak.Series(data=i, index=i)
 
-        s_add = ak.Series(ar_tuple=ar_tuple_add)
+        s_add = ak.Series(data=v, index=v)
 
         added = s.add(s_add)
 
@@ -59,32 +93,36 @@ class SeriesTest(ArkoudaTest):
             self.assertIn(i, val_list)
 
     def test_topn(self):
-        ar_tuple = (ak.arange(3), ak.arange(3))
-        s = ak.Series(ar_tuple=ar_tuple)
+        v = ak.arange(3)
+        i = ak.arange(3)
+        s = ak.Series(data=v, index=i)
 
         top = s.topn(2)
         self.assertListEqual(top.index.to_pandas().tolist(), [2, 1])
         self.assertListEqual(top.values.to_ndarray().tolist(), [2, 1])
 
     def test_sort_idx(self):
-        ar_tuple = (ak.array([3, 1, 4, 0, 2]), ak.arange(5))
-        s = ak.Series(ar_tuple=ar_tuple)
+        v = ak.arange(5)
+        i = ak.array([3, 1, 4, 0, 2])
+        s = ak.Series(data=v, index=i)
 
         sorted = s.sort_index()
         self.assertListEqual(sorted.index.to_pandas().tolist(), [i for i in range(5)])
         self.assertListEqual(sorted.values.to_ndarray().tolist(), [3, 1, 4, 0, 2])
 
     def test_sort_value(self):
-        ar_tuple = (ak.arange(5), ak.array([3, 1, 4, 0, 2]))
-        s = ak.Series(ar_tuple=ar_tuple)
+        v = ak.array([3, 1, 4, 0, 2])
+        i = ak.arange(5)
+        s = ak.Series(data=v, index=i)
 
         sorted = s.sort_values()
         self.assertListEqual(sorted.index.to_pandas().tolist(), [3, 1, 4, 0, 2])
         self.assertListEqual(sorted.values.to_ndarray().tolist(), [i for i in range(5)])
 
     def test_head_tail(self):
-        ar_tuple = (ak.arange(5), ak.arange(5))
-        s = ak.Series(ar_tuple=ar_tuple)
+        v = ak.arange(5)
+        i = ak.arange(5)
+        s = ak.Series(data=v, index=i)
 
         head = s.head(2)
         self.assertListEqual(head.index.to_pandas().tolist(), [0, 1])
@@ -95,8 +133,9 @@ class SeriesTest(ArkoudaTest):
         self.assertListEqual(tail.values.to_ndarray().tolist(), [2, 3, 4])
 
     def test_value_counts(self):
-        ar_tuple = (ak.arange(5), ak.array([0, 0, 1, 2, 2]))
-        s = ak.Series(ar_tuple=ar_tuple)
+        v = ak.array([0, 0, 1, 2, 2])
+        i = ak.arange(5)
+        s = ak.Series(data=v, index=i)
 
         c = s.value_counts()
         self.assertListEqual(c.index.to_pandas().tolist(), [0, 2, 1])
@@ -107,11 +146,13 @@ class SeriesTest(ArkoudaTest):
         self.assertListEqual(c.values.to_ndarray().tolist(), [2, 2, 1])
 
     def test_concat(self):
-        ar_tuple = (ak.arange(5), ak.arange(5))
-        s = ak.Series(ar_tuple=ar_tuple)
+        v = ak.arange(5)
+        i = ak.arange(5)
+        s = ak.Series(data=v, index=i)
 
-        ar_tuple_2 = (ak.arange(5, 11, 1), ak.arange(5, 11, 1))
-        s2 = ak.Series(ar_tuple_2)
+        v = ak.arange(5, 11, 1)
+        i = ak.arange(5, 11, 1)
+        s2 = ak.Series(data=v, index=i)
 
         c = ak.Series.concat([s, s2])
         self.assertListEqual(c.index.to_pandas().tolist(), [i for i in range(11)])
@@ -125,19 +166,22 @@ class SeriesTest(ArkoudaTest):
         self.assertTrue(((ref_df == df.to_pandas()).all()).all())
 
     def test_pdconcat(self):
-        ar_tuple = (ak.arange(5), ak.arange(5))
-        s = ak.Series(ar_tuple=ar_tuple)
+        v = ak.arange(5)
+        i = ak.arange(5)
+        s = ak.Series(data=v, index=i)
 
-        ar_tuple_2 = (ak.arange(5, 11, 1), ak.arange(5, 11, 1))
-        s2 = ak.Series(ar_tuple_2)
+        v = ak.arange(5, 11, 1)
+        i = ak.arange(5, 11, 1)
+        s2 = ak.Series(data=v, index=i)
 
         c = ak.Series.pdconcat([s, s2])
         self.assertIsInstance(c, pd.Series)
         self.assertListEqual(c.index.tolist(), [i for i in range(11)])
         self.assertListEqual(c.values.tolist(), [i for i in range(11)])
 
-        ar_tuple_2 = (ak.arange(5, 10, 1), ak.arange(5, 10, 1))
-        s2 = ak.Series(ar_tuple_2)
+        v = ak.arange(5, 10, 1)
+        i = ak.arange(5, 10, 1)
+        s2 = ak.Series(data=v, index=i)
 
         df = ak.Series.pdconcat([s, s2], axis=1)
         self.assertIsInstance(df, pd.DataFrame)


### PR DESCRIPTION
This PR (closes #1363):

- Deprecates the `ar_tuple` parameter inside of the `__init__` method.
- Adjusts the tests to use the other 2 parameters `(index, data)` when instantiating.