### PR TITLE
Closes #1382: Adding `Series` support to generic attach

### DIFF
--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -273,7 +273,7 @@ class MultiIndex(Index):
         return len(self.index[0])
 
     def __eq__(self, v):
-        if type(v) != list and type(v) != tuple:
+        if not isinstance(v, (list, tuple, MultiIndex)):
             raise TypeError("Cannot compare MultiIndex to a scalar")
         retval = ones(len(self), dtype=akbool)
         if isinstance(v, MultiIndex):

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -276,8 +276,11 @@ class MultiIndex(Index):
         if type(v) != list and type(v) != tuple:
             raise TypeError("Cannot compare MultiIndex to a scalar")
         retval = ones(len(self), dtype=akbool)
+        if isinstance(v, MultiIndex):
+            v = v.index
         for a, b in zip(self.index, v):
             retval &= a == b
+
         return retval
 
     def to_pandas(self):

--- a/arkouda/series.py
+++ b/arkouda/series.py
@@ -111,7 +111,7 @@ class Series:
     def __init__(
         self,
         data: Union[Tuple, List, groupable_element_type],
-        index: Optional[Union[pdarray, Strings]] = None,
+        index: Optional[Union[pdarray, Strings, Tuple, List]] = None,
     ):
         # TODO: Allow index to be an Index when index.py is updated
         if isinstance(data, (tuple, list)) and len(data) == 2:
@@ -484,7 +484,7 @@ class Series:
             for i in range(2, len(parts)):
                 ind.append(create_pdarray(parts[i]))
 
-        return Series((ind, vals))
+        return Series(data=vals, index=ind)
 
     @staticmethod
     def _all_aligned(array):

--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -4,10 +4,10 @@ from typing import Mapping, Union, cast
 
 import h5py  # type: ignore
 import numpy as np  # type: ignore
-
 from arkouda import SegArray
 from arkouda.categorical import Categorical
 from arkouda.client import generic_msg, get_config, get_mem_used
+from arkouda import Strings, SegArray
 from arkouda.client_dtypes import BitVector, BitVectorizer, IPv4
 from arkouda.groupbyclass import GroupBy, broadcast
 from arkouda.infoclass import AllSymbols, information
@@ -281,6 +281,10 @@ def attach(name: str, dtype: str = "infer"):
         return Categorical.from_return_msg(repMsg)
     elif repMsg.split("+")[0] == "segarray":
         return SegArray.from_return_msg(repMsg)
+    elif repMsg.split("+")[0] == "series":
+        from arkouda.series import Series
+
+        return Series.from_return_msg(repMsg)
     else:
         dtype = repMsg.split()[2]
 

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -6,7 +6,7 @@ module MultiTypeSymbolTable
     use Reflection;
     use ServerErrors;
     use Logging;
-    use Regex;
+    use ArkoudaRegexCompat;
     
     use MultiTypeSymEntry;
     use Map;

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -484,13 +484,12 @@ module MultiTypeSymbolTable
         proc findAll(pattern: string): [] string throws {
             var regex = compile(pattern);
             var infoStr = "";
-            for name in tab {
+            forall name in tab.keysToArray() with (+ reduce infoStr) {
                 if name.match(regex) {
                     infoStr += name + "+";
                 }
             }
-            infoStr = infoStr.strip("+");
-            return infoStr.split("+");
+            return infoStr.strip("+").split("+");
         }
     }
 

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -6,6 +6,7 @@ module MultiTypeSymbolTable
     use Reflection;
     use ServerErrors;
     use Logging;
+    use Regex;
     
     use MultiTypeSymEntry;
     use Map;
@@ -469,6 +470,27 @@ module MultiTypeSymbolTable
             } else {
                 return false;
             }
+        }
+
+        /*
+        Attempts to find all sym entries that match the provided regex string, then 
+        returns a string array of matching names
+
+        :arg pattern: regex string to search for
+        :type pattern: string
+
+        :returns: string array containing matching entry names
+        */
+        proc findAll(pattern: string): [] string throws {
+            var regex = compile(pattern);
+            var infoStr = "";
+            for name in tab {
+                if name.match(regex) {
+                    infoStr += name + "+";
+                }
+            }
+            infoStr = infoStr.strip("+");
+            return infoStr.split("+");
         }
     }
 

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -63,9 +63,8 @@ class utilTest(ArkoudaTest):
 
     def test_series_attach(self):
         index_tuple = (ak.arange(5), ak.arange(5, 10))
-        ar_tuple = (index_tuple, ak.arange(0, 10, 2))
-        s = ak.Series(ar_tuple=ar_tuple)  # MultiIndex Series
-        s2 = ak.Series(ar_tuple=(ak.arange(5), ak.arange(5)))  # Single Index Series
+        s = ak.Series(data=ak.arange(0, 10, 2), index=index_tuple)  # MultiIndex Series
+        s2 = ak.Series(data=ak.arange(5), index=ak.arange(5))  # Single Index Series
 
         s.register("series_test")
         s2.register("series_2_test")

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -60,3 +60,23 @@ class utilTest(ArkoudaTest):
         attached_typed = attach("segTest", "SegArray")
         self.assertTrue((segarr == attached_typed).all())
         self.assertIsInstance(attached_typed, ak.SegArray)
+
+    def test_series_attach(self):
+        index_tuple = (ak.arange(5), ak.arange(5, 10))
+        ar_tuple = (index_tuple, ak.arange(0, 10, 2))
+        s = ak.Series(ar_tuple=ar_tuple)  # MultiIndex Series
+        s2 = ak.Series(ar_tuple=(ak.arange(5), ak.arange(5)))  # Single Index Series
+
+        s.register("series_test")
+        s2.register("series_2_test")
+
+        s_attach = ak.util.attach("series_test")
+        s2_attach = ak.util.attach("series_2_test")
+
+        self.assertListEqual(s_attach.values.to_ndarray().tolist(), s.values.to_ndarray().tolist())
+        sEq = s_attach.index == s.index
+        self.assertTrue(all(sEq.to_ndarray()))
+
+        self.assertListEqual(s2_attach.values.to_ndarray().tolist(), s2.values.to_ndarray().tolist())
+        s2Eq = s2_attach.index == s2.index
+        self.assertTrue(all(s2Eq.to_ndarray()))


### PR DESCRIPTION
This PR (closes #1382):

This is waiting on PR #1441 to be merged due to file conflicts. Once merged, I'll update this PR to work with @jeichert60's changes.

This PR adds Chapel logic for determining if a given name represents a `Series` as well as adding logic to the symbol table that allows for a regex string to be passed and returns a list of all matching names contained in the table. This method, `findAll`, serves the purpose of finding all `<name>_key_<n>` names that that are associated with a `MultiIndex`. This method also opens the door for `GroupBy` support to be added in the future.

On the Python side, I added the `from_return_msg` method to `Series` which will create a `Series` object based on the returned message string from the generic attach method