### PR TITLE
Optimize domain_intersection() when both domains are non-strided

### DIFF
--- a/src/FileIO.chpl
+++ b/src/FileIO.chpl
@@ -179,8 +179,12 @@ module FileIO {
             //TODO: change this to throw
             halt("At least one domain must have stride 1");
         }
-        var stride = max(d1.stride, d2.stride);
-        return {low..high by stride};
+        if !d1.stridable && !d2.stridable {
+            return {low..high};
+        } else {
+            var stride = max(d1.stride, d2.stride);
+            return {low..high by stride};
+        }
     }
 
     proc getFirstEightBytesFromFile(path:string):bytes throws {


### PR DESCRIPTION
As currently written, domain_intersection() will always return a
'stridable' domain because its return expression is of the form
'low..high by stride'.  In Chapel, stridable domains can result in a
performance hit relative to non-stridable ones since they require more
generalized math (since the stride is not known statically).  For
example, an array '[1..n by s] uint(8)' requires a division by 's' in
order to calculate the offset from the array's base pointer.

Here, I'm optimizing the return path so that if neither of the input
domains are stridable, the output domain won't be either.

Note that, for its current uses, I don't expect this to have much of
an impact on the execution time.  In part because (so far as I could
tell), the resulting domain didn't seem to be used to declare arrays
(which is where the highest overheads are), and since the calls are
largely in I/O code, it's likely that the I/O overheads will overwhelm
any benefit from this change.

But, it could still be beneficial in case further uses of the utility
are made in the future.

Finally, note that if this is a simple domain intersection, indexing
one domain by another in Chapel computes a domain intersection.  Thus,
this could be replaced with ``d1[d2]``.  That's a bigger change than I
wanted to take on here, though, so I just took the baby step that
seemed obvious to me.
