### PR TITLE
Closes #1350 - Add `ak.DataFrame.isin`

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -1584,8 +1584,6 @@ class DataFrame(UserDict):
             # create the dataframe with all false
             df_def = {col: zeros(self.size, dtype=akbool) for col in self.columns}
             # identify the indexes in both
-            # rows_self = in1d(self.index.index, values.index.index)
-            # rows_val = in1d(values.index.index, self.index.index)
             rows_self, rows_val = intersect(self.index.index, values.index.index, unique=True)
 
             # used to sort the rows with only the indexes in both

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -1572,10 +1572,9 @@ class DataFrame(UserDict):
         """
         if isinstance(values, pdarray):
             # flatten the DataFrame so single in1d can be used.
-            flat = concatenate(list(self.data.values()))
-            lens = array([self.data[col].size for col in self.columns])
-            segs = concatenate([cumsum(lens) - lens, array([flat.size])])
-            df_def = {col: in1d(flat, values)[segs[i]:segs[i + 1]] for i, col in enumerate(self.columns)}
+            flat_in1d = in1d(concatenate(list(self.data.values())), values)
+            segs = concatenate([array([0]), cumsum(array([self.data[col].size for col in self.columns]))])
+            df_def = {col: flat_in1d[segs[i]:segs[i + 1]] for i, col in enumerate(self.columns)}
         elif isinstance(values, Dict):
             # key is column name, val is the list of values to check
             df_def = {col: (in1d(self.data[col], values[col]) if col in values.keys()
@@ -1585,8 +1584,9 @@ class DataFrame(UserDict):
             # create the dataframe with all false
             df_def = {col: zeros(self.size, dtype=akbool) for col in self.columns}
             # identify the indexes in both
-            rows_self = in1d(self.index.index, values.index.index)
-            rows_val = in1d(values.index.index, self.index.index)
+            # rows_self = in1d(self.index.index, values.index.index)
+            # rows_val = in1d(values.index.index, self.index.index)
+            rows_self, rows_val = intersect(self.index.index, values.index.index, unique=True)
 
             # used to sort the rows with only the indexes in both
             sort_self = self.index[rows_self].argsort()

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -512,3 +512,32 @@ class DataFrameTest(ArkoudaTest):
         # clean up test files
         rmtree("save_table_test/")
 
+    def test_isin(self):
+        df = ak.DataFrame({
+            'col_A': ak.array([7, 3]),
+            'col_B': ak.array([1, 9])
+        })
+
+        # test against pdarray
+        test_df = df.isin(ak.array([0, 1]))
+        self.assertListEqual(test_df['col_A'].to_ndarray().tolist(), [False, False])
+        self.assertListEqual(test_df['col_B'].to_ndarray().tolist(), [True, False])
+
+        # Test against dict
+        test_df = df.isin({'col_A': ak.array([0, 3])})
+        self.assertListEqual(test_df['col_A'].to_ndarray().tolist(), [False, True])
+        self.assertListEqual(test_df['col_B'].to_ndarray().tolist(), [False, False])
+
+        # test against series
+        i = ak.Index(ak.arange(2))
+        s = ak.Series(data=[3, 9], index=i)
+        test_df = df.isin(s)
+        self.assertListEqual(test_df['col_A'].to_ndarray().tolist(), [False, False])
+        self.assertListEqual(test_df['col_B'].to_ndarray().tolist(), [False, True])
+
+        # test against another dataframe
+        other_df = ak.DataFrame({'col_A':ak.array([7, 3]), 'col_C':ak.array([0, 9])})
+        test_df = df.isin(other_df)
+        self.assertListEqual(test_df['col_A'].to_ndarray().tolist(), [True, True])
+        self.assertListEqual(test_df['col_B'].to_ndarray().tolist(), [False, False])
+

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -536,7 +536,7 @@ class DataFrameTest(ArkoudaTest):
         self.assertListEqual(test_df['col_B'].to_ndarray().tolist(), [False, True])
 
         # test against another dataframe
-        other_df = ak.DataFrame({'col_A':ak.array([7, 3]), 'col_C':ak.array([0, 9])})
+        other_df = ak.DataFrame({'col_A': ak.array([7, 3]), 'col_C': ak.array([0, 9])})
         test_df = df.isin(other_df)
         self.assertListEqual(test_df['col_A'].to_ndarray().tolist(), [True, True])
         self.assertListEqual(test_df['col_B'].to_ndarray().tolist(), [False, False])


### PR DESCRIPTION
Closes #1350

- Adds `isin` to DataFrame.
    - Functionality works the same as [pandas.DataFrame.isin](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.isin.html#pandas-dataframe-isin) 
    - Supports `values` being of type pdarray, dict (values of pdarray), Series, and DataFrame
    - Similar to pandas, Series with multi-index are not supported. Arkouda currently raises the same error as pandas in this case.
- Adds testing for `isin` method.

This is currently configured on the client using `==` or `in1d`. This could probably have slightly better performance if it was moved to the server, but I do not think it is necessary at this time. If anyone, disagrees, let me know and I can retool the code to run things server side in a single call.