### PR TITLE
Closes #1428- Parquet as Dependency

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,6 @@ on: [push, pull_request]
 
 env:
   ARKOUDA_QUICK_COMPILE: true
-  ARKOUDA_SERVER_PARQUET_SUPPORT: true
 
 jobs:
   lint:

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -36,7 +36,8 @@ Most folks install anaconda and link to these libraries through Makefile.paths i
 setup you can set them explicitly via:
   - ARKOUDA_ZMQ_PATH : Path to ZMQ library
   - ARKOUDA_HDF5_PATH : Path to HDF5 library
-  - ARKOUDA_ARROW_PATH : Path to Arrow library (needed only when building with Parquet support; see "Building with Parquet" below)
+  - ARKOUDA_ARROW_PATH : Path to Arrow library 
+  - LD_LIBRARY_PATH : Path to environment `lib` directory.
   - ARKOUDA_SKIP_CHECK_DEPS : Setting this will skip the automated checks for dependencies (i.e. ZMQ, HDF5). This is
     useful for developers doing repeated Arkouda builds since they should have already verified the deps have been set up.
 
@@ -64,6 +65,3 @@ Also see the python tests [README](tests/README.md) for more information on Pyth
   - ARKOUDA_KEY_FILE : Client env var for keyfile when using ssh tunnel
   - ARKOUDA_PASSWORD : Client env var for password when using ssh tunnel
   - ARKOUDA_LOG_LEVEL : Client env var to control client side Logging Level
-
-## Building with Parquet
-  - ARKOUDA_SERVER_PARQUET_SUPPORT : Env var to control if the server is built with Parquet support; if set, Parquet will be built, regardless of value

--- a/Makefile
+++ b/Makefile
@@ -68,14 +68,12 @@ endif
 
 CHPL_FLAGS += -lhdf5 -lhdf5_hl -lzmq
 
-ifdef ARKOUDA_SERVER_PARQUET_SUPPORT
-  CHPL_FLAGS += -lparquet -larrow
-  OPTIONAL_CHECKS += check-arrow
-  ARROW_FILE_NAME += $(ARKOUDA_SOURCE_DIR)/ArrowFunctions
-  ARROW_CPP += $(ARROW_FILE_NAME).cpp
-  ARROW_H += $(ARROW_FILE_NAME).h
-  ARROW_O += $(ARROW_FILE_NAME).o
-endif
+CHPL_FLAGS += -lparquet -larrow
+OPTIONAL_CHECKS += check-arrow
+ARROW_FILE_NAME += $(ARKOUDA_SOURCE_DIR)/ArrowFunctions
+ARROW_CPP += $(ARROW_FILE_NAME).cpp
+ARROW_H += $(ARROW_FILE_NAME).h
+ARROW_O += $(ARROW_FILE_NAME).o
 
 
 .PHONY: install-deps

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -1290,7 +1290,8 @@ class DataFrame(UserDict):
     def load_table(cls, prefix_path, file_format='INFER'):
         prefix, extension = os.path.splitext(prefix_path)
         first_file = "{}_LOCALE0000{}".format(prefix, extension)
-        filetype = get_filetype(first_file)
+        filetype = get_filetype(first_file) if file_format.lower() == "infer" else file_format
+
         # columns load backwards
         df = cls(load_all(prefix_path, file_format=filetype))
         if filetype == "HDF5":

--- a/pydoc/usage/IO.rst
+++ b/pydoc/usage/IO.rst
@@ -34,7 +34,6 @@ Supported File Formats
 * HDF5
     * Default File Format
 * Parquet
-    * Optional
     * Requires `pyarrow`
 
 Data Preprocessing

--- a/src/serverModuleGen.py
+++ b/src/serverModuleGen.py
@@ -17,15 +17,7 @@ def generateServerIncludes(config_filename, reg_filename):
     serverfile = open(reg_filename, "w")
     serverfile.write("proc doRegister() {\n")
     for mod in getModules(config_filename):
-        if mod.strip() == "ParquetMsg" and "ARKOUDA_SERVER_PARQUET_SUPPORT" not in os.environ:
-            print(
-                "**WARNING**: ParquetMsg module declared in ServerModules.cfg but "
-                "ARKOUDA_SERVER_PARQUET_SUPPORT is not set.",
-                file=sys.stderr,
-            )
-            print("**WARNING**: ParquetMsg module will NOT be built.", file=sys.stderr)
-        else:
-            serverfile.write(f"  import {mod};\n  {mod}.registerMe();\n")
+        serverfile.write(f"  import {mod};\n  {mod}.registerMe();\n")
 
     serverfile.write("}\n")
 

--- a/test/COMPOPTS
+++ b/test/COMPOPTS
@@ -22,7 +22,7 @@ CONFIG_FILE="${SRC_DIR}/ServerConfig.chpl"
 CONFIG_OPTS="${CONFIG_FILE} -strace=false -sarkoudaVersion=\"\\\"TEST_VERSION_STRING\\\"\""
 TEST_OPTS="-sprintTimes=false -sprintDiags=false -sprintDiagsSum=false"
 
-if [[ $ARKOUDA_SERVER_PARQUET_SUPPORT && ! -f $SRC_DIR/ArrowFunctions.o ]]; then
+if [[ ! -f $SRC_DIR/ArrowFunctions.o ]]; then
   make -C ${ARKOUDA_HOME} compile-arrow-cpp > /dev/null 2> /dev/null
 fi
 

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -474,7 +474,6 @@ class DataFrameTest(ArkoudaTest):
         df_copy.__setitem__('userID', ak.array([1, 2, 1, 3, 2, 1]))
         self.assertEqual(df.__repr__(), df_copy.__repr__())
 
-    @pytest.mark.skipif(not os.getenv('ARKOUDA_SERVER_PARQUET_SUPPORT'), reason="No parquet support")
     def test_save_table(self):
         d = f"{os.getcwd()}/save_table_test"
         i = list(range(3))

--- a/tests/import_export_test.py
+++ b/tests/import_export_test.py
@@ -75,7 +75,6 @@ class DataFrameTest(ArkoudaTest):
         # clean up test files
         rmtree(f_base)
 
-    @pytest.mark.skipif(not os.getenv('ARKOUDA_SERVER_PARQUET_SUPPORT'), reason="No parquet support")
     def test_import_parquet(self):
         locales = self.get_locale_count()
         f_base = f"{os.getcwd()}/import_export_test"
@@ -92,7 +91,6 @@ class DataFrameTest(ArkoudaTest):
         # clean up test files
         rmtree(f_base)
 
-    @pytest.mark.skipif(not os.getenv('ARKOUDA_SERVER_PARQUET_SUPPORT'), reason="No parquet support")
     def test_export_parquet(self):
         f_base = f"{os.getcwd()}/import_export_test"
         # make directory to save to so pandas read works

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -316,7 +316,6 @@ class IOTest(ArkoudaTest):
                               file_format='HDF5')
         self.assertIsNotNone(dataset, "Expected dataset to be populated")
 
-    @pytest.mark.skipif(not os.getenv('ARKOUDA_SERVER_PARQUET_SUPPORT'), reason="No parquet support")
     def testLoad(self):
         '''
         Creates 1..n files depending upon the number of arkouda_server locales with three columns 
@@ -388,8 +387,7 @@ class IOTest(ArkoudaTest):
         with self.assertRaises(RuntimeError) as cm:
             ak.load(path_prefix='{}/not-a-file'.format(IOTest.io_test_dir), 
                                     dataset='int_tens_pdarray')
-        
-    @pytest.mark.skipif(not os.getenv('ARKOUDA_SERVER_PARQUET_SUPPORT'), reason="No parquet support")
+
     def testLoadAll(self):
         self._create_file(columns=self.dict_columns,
                           prefix_path='{}/iotest_dict_columns'.format(IOTest.io_test_dir))

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -120,7 +120,6 @@ def empty_append_test(dtype):
 
     return ak_arr, pq_arr
 
-@pytest.mark.skipif(not os.getenv('ARKOUDA_SERVER_PARQUET_SUPPORT'), reason="No parquet support")
 class ParquetTest(ArkoudaTest):
     def test_parquet(self):
         for dtype in TYPES:
@@ -203,7 +202,7 @@ class ParquetTest(ArkoudaTest):
         for dtype in TYPES:
             (ak_arr, pq_arr) = empty_append_test(dtype)
             self.assertTrue((ak_arr ==  pq_arr).all())
-            
+
     @pytest.mark.optional_parquet
     def test_against_standard_files(self):
         datadir = 'resources/parquet-testing'


### PR DESCRIPTION
Closes #1428 

Updates files to require Parquet. 

- Removes `ARKOUDA_SERVER_PARQUET_SUPPORT` environment variable
- Updates testing to remove `pytest.skipif` when `ARKOUDA_SERVER_PARQUET_SUPPORT` does not exist
- Removes code handling removing parquet or not building when `ARKOUDA_SERVER_PARQUET_SUPPORT` is not set