### PR TITLE
Closes #1455 pep8 formatting `tests`

### DIFF
--- a/tests/array_view_test.py
+++ b/tests/array_view_test.py
@@ -1,11 +1,11 @@
+from itertools import product
+
 import numpy as np
 from base_test import ArkoudaTest
 from context import arkouda as ak
-from itertools import product
 
 
 class ArrayViewTest(ArkoudaTest):
-
     def test_mulitdimensional_array_creation(self):
         n = np.array([[0, 0], [0, 1], [1, 1]])
         a = ak.array([[0, 0], [0, 1], [1, 1]])
@@ -110,9 +110,9 @@ class ArrayViewTest(ArkoudaTest):
     def test_reshape_order(self):
         # Keep 'C'/'F' (C/Fortran) order to be consistent with numpy
         # But also accept more descriptive 'row_major' and 'column_major'
-        nd = np.arange(30).reshape((5, 3, 2), order='C')
-        ak_C = ak.arange(30).reshape((5, 3, 2), order='C')
-        ak_row = ak.arange(30).reshape((5, 3, 2), order='row_major')
+        nd = np.arange(30).reshape((5, 3, 2), order="C")
+        ak_C = ak.arange(30).reshape((5, 3, 2), order="C")
+        ak_row = ak.arange(30).reshape((5, 3, 2), order="row_major")
 
         nd_ind = [nd[i, j, k] for (i, j, k) in product(range(5), range(3), range(2))]
         C_order = [ak_C[i, j, k] for (i, j, k) in product(range(5), range(3), range(2))]
@@ -120,9 +120,9 @@ class ArrayViewTest(ArkoudaTest):
         self.assertListEqual(nd_ind, C_order)
         self.assertListEqual(nd_ind, row_order)
 
-        nd = np.arange(30).reshape((5, 3, 2), order='F')
-        ak_F = ak.arange(30).reshape((5, 3, 2), order='F')
-        ak_column = ak.arange(30).reshape((5, 3, 2), order='column_major')
+        nd = np.arange(30).reshape((5, 3, 2), order="F")
+        ak_F = ak.arange(30).reshape((5, 3, 2), order="F")
+        ak_column = ak.arange(30).reshape((5, 3, 2), order="column_major")
 
         nd_ind = [nd[i, j, k] for (i, j, k) in product(range(5), range(3), range(2))]
         F_order = [ak_F[i, j, k] for (i, j, k) in product(range(5), range(3), range(2))]
@@ -158,8 +158,8 @@ class ArrayViewTest(ArkoudaTest):
         # n[0, 5:].tolist() = [5, 6, 7, 8, 9]
         self.assertListEqual(n[0, 5:].tolist(), a[0, 5:].to_ndarray().tolist())
 
-        n = np.array([[[1],[2],[3]], [[4],[5],[6]]])
-        a = ak.array([[[1],[2],[3]], [[4],[5],[6]]])
+        n = np.array([[[1], [2], [3]], [[4], [5], [6]]])
+        a = ak.array([[[1], [2], [3]], [[4], [5], [6]]])
         # list(n.shape) = [2, 3, 1]
         self.assertListEqual(list(n.shape), a.shape.to_ndarray().tolist())
         # n.tolist() = [[[1], [2], [3]], [[4], [5], [6]]]
@@ -182,10 +182,9 @@ class ArrayViewTest(ArkoudaTest):
         # n[:, 5:8, 1:5:2][1].tolist() = []
         self.assertListEqual(n[:, 5:8, 1:5:2][1].tolist(), a[:, 5:8, 1:5:2][1].to_ndarray().tolist())
 
-        a = ak.arange(30).reshape(2, 3, 5, order='F')
-        n = np.arange(30).reshape(2, 3, 5, order='F')
+        a = ak.arange(30).reshape(2, 3, 5, order="F")
+        n = np.arange(30).reshape(2, 3, 5, order="F")
         self.assertListEqual(n.tolist(), a.to_ndarray().tolist())
 
         # n[:, ::-1, 1:5:2].tolist() = [[10, 22], [8, 20], [6, 18]]
         self.assertListEqual(n[:, ::-1, 1:5:2].tolist(), a[:, ::-1, 1:5:2].to_ndarray().tolist())
-

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -1,69 +1,89 @@
-import unittest, os
-from context import arkouda as ak
-from util.test.util import get_arkouda_numlocales, start_arkouda_server, \
-     stop_arkouda_server, TestRunningMode
 import importlib
+import os
+import unittest
 
-'''
-ArkoudaTest defines the base Arkouda test logic for starting up the arkouda_server at the 
+from context import arkouda as ak
+
+from util.test.util import (
+    TestRunningMode,
+    get_arkouda_numlocales,
+    start_arkouda_server,
+    stop_arkouda_server,
+)
+
+"""
+ArkoudaTest defines the base Arkouda test logic for starting up the arkouda_server at the
 launch of a unittest TestCase and shutting down the arkouda_server at the completion of
 the unittest TestCase.
 
-Note: each Arkouda TestCase class extends ArkoudaTest and encompasses 1..n test methods, the 
+Note: each Arkouda TestCase class extends ArkoudaTest and encompasses 1..n test methods, the
 names of which match the pattern 'test*' (e.g., ArkoudaTest.test_arkouda_server).
-'''
+"""
+
+
 class ArkoudaTest(unittest.TestCase):
 
-    verbose = True if os.getenv('ARKOUDA_VERBOSE') == 'True' else False
-    port = int(os.getenv('ARKOUDA_SERVER_PORT', 5555))
-    server = os.getenv('ARKOUDA_SERVER_HOST', 'localhost')
-    test_running_mode = TestRunningMode(os.getenv('ARKOUDA_RUNNING_MODE','GLOBAL_SERVER'))
-    timeout = int(os.getenv('ARKOUDA_CLIENT_TIMEOUT', 5))
+    verbose = True if os.getenv("ARKOUDA_VERBOSE") == "True" else False
+    port = int(os.getenv("ARKOUDA_SERVER_PORT", 5555))
+    server = os.getenv("ARKOUDA_SERVER_HOST", "localhost")
+    test_running_mode = TestRunningMode(os.getenv("ARKOUDA_RUNNING_MODE", "GLOBAL_SERVER"))
+    timeout = int(os.getenv("ARKOUDA_CLIENT_TIMEOUT", 5))
 
     @classmethod
     def setUpClass(cls):
-        '''
-        If in full stack mode, configures and starts the arkouda_server process and sets the 
+        """
+        If in full stack mode, configures and starts the arkouda_server process and sets the
         ArkoudaTest.server class attribute, noop in client mode.
-        
+
         :return: None
-        :raise: EnvironmentError if 1..n required test libraries are missing, RuntimeError 
+        :raise: EnvironmentError if 1..n required test libraries are missing, RuntimeError
                 if there is an error in configuring or starting arkouda_server
-        '''
-        if not importlib.util.find_spec('pytest') or not importlib.util.find_spec('pytest_env'):
-            raise EnvironmentError('pytest and pytest-env must be installed')
+        """
+        if not importlib.util.find_spec("pytest") or not importlib.util.find_spec("pytest_env"):
+            raise EnvironmentError("pytest and pytest-env must be installed")
         if TestRunningMode.CLASS_SERVER == ArkoudaTest.test_running_mode:
-            try: 
+            try:
                 nl = get_arkouda_numlocales()
                 ArkoudaTest.server, _, _ = start_arkouda_server(numlocales=nl, port=ArkoudaTest.port)
-                print('Started arkouda_server in TEST_CLASS mode with host: {} port: {} locales: {}'.\
-                      format(ArkoudaTest.server, ArkoudaTest.port, nl))
+                print(
+                    "Started arkouda_server in TEST_CLASS mode with "
+                    "host: {} port: {} locales: {}".format(
+                        ArkoudaTest.server, ArkoudaTest.port, nl
+                    )
+                )
             except Exception as e:
-                raise RuntimeError('in configuring or starting the arkouda_server: {}, check ' +
-                         'environment and/or arkouda_server installation', e)
+                raise RuntimeError(
+                    "in configuring or starting the arkouda_server: {}, check "
+                    + "environment and/or arkouda_server installation",
+                    e,
+                )
         else:
-            print('in client stack test mode with host: {} port: {}'.format(ArkoudaTest.server, ArkoudaTest.port))
-        
+            print(
+                "in client stack test mode with host: {} port: {}".format(
+                    ArkoudaTest.server, ArkoudaTest.port
+                )
+            )
 
     def setUp(self):
-        '''
+        """
         Connects an Arkouda client for each test case
-        
+
         :return: None
         :raise: ConnectionError if exception is raised in connecting to arkouda_server
-        '''
+        """
         try:
-            ak.client.connect(server=ArkoudaTest.server, port=ArkoudaTest.port, 
-                              timeout=ArkoudaTest.timeout)
+            ak.client.connect(
+                server=ArkoudaTest.server, port=ArkoudaTest.port, timeout=ArkoudaTest.timeout
+            )
         except Exception as e:
             raise ConnectionError(e)
-    
+
     def tearDown(self):
-        '''
+        """
         Disconnects the client connection for each test case
         :return: None
         :raise: ConnectionError if exception is raised in connecting to arkouda_server
-        '''
+        """
         try:
             ak.client.disconnect()
         except Exception as e:
@@ -71,12 +91,12 @@ class ArkoudaTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        '''
+        """
         Shuts down the arkouda_server started in the setUpClass method if test is run
         in full stack mode, noop if in client stack mode.
 
         :return: None
-        '''
+        """
         if TestRunningMode.CLASS_SERVER == ArkoudaTest.test_running_mode:
             try:
                 stop_arkouda_server()

--- a/tests/bitops_test.py
+++ b/tests/bitops_test.py
@@ -1,5 +1,6 @@
-from context import arkouda as ak
 from base_test import ArkoudaTest
+from context import arkouda as ak
+
 
 class BitOpsTest(ArkoudaTest):
     def setUp(self):
@@ -7,9 +8,8 @@ class BitOpsTest(ArkoudaTest):
         self.a = ak.arange(10)
         self.b = ak.cast(self.a, ak.uint64)
         self.edgeCases = ak.array([-(2**63), -1, 2**63 - 1])
-        self.edgeCasesUint = ak.cast(ak.array([-(2**63), -1, 2**63 - 1]), \
-                                     ak.uint64)
-    
+        self.edgeCasesUint = ak.cast(ak.array([-(2**63), -1, 2**63 - 1]), ak.uint64)
+
     def test_popcount(self):
         # Method invocation
         # Toy input
@@ -21,7 +21,7 @@ class BitOpsTest(ArkoudaTest):
         p = self.b.popcount()
         ans = ak.cast(ans, ak.uint64)
         self.assertTrue((p == ans).all())
-        
+
         # Function invocation
         # Edge case input
         p = ak.popcount(self.edgeCases)
@@ -92,10 +92,10 @@ class BitOpsTest(ArkoudaTest):
 
     def test_dtypes(self):
         f = ak.zeros(10, dtype=ak.float64)
-        with self.assertRaises(TypeError) as cm:
+        with self.assertRaises(TypeError):
             f.popcount()
-        b = ak.zeros(10, dtype=ak.bool)
-        with self.assertRaises(TypeError) as cm:
+
+        with self.assertRaises(TypeError):
             ak.popcount(f)
 
     def test_rotl(self):
@@ -126,8 +126,8 @@ class BitOpsTest(ArkoudaTest):
 
     def test_rotr(self):
         # vector <<< scalar
-        rotated = (1024*self.a).rotr(5)
-        shifted = (1024*self.a) >> 5
+        rotated = (1024 * self.a).rotr(5)
+        shifted = (1024 * self.a) >> 5
         # No wraparound, so these should be equal
         self.assertTrue((rotated == shifted).all())
 
@@ -136,8 +136,8 @@ class BitOpsTest(ArkoudaTest):
         self.assertTrue((r == ans).all())
 
         # vector <<< vector
-        rotated = (1024*self.a).rotr(self.a)
-        shifted = (1024*self.a) >> self.a
+        rotated = (1024 * self.a).rotr(self.a)
+        shifted = (1024 * self.a) >> self.a
         # No wraparound, so these should be equal
         self.assertTrue((rotated == shifted).all())
 
@@ -147,7 +147,7 @@ class BitOpsTest(ArkoudaTest):
 
         # scalar <<< vector
         rotated = ak.rotr(1, self.a)
-        ans = ak.array([1, -(2**63), 2**62, 2**61, 2**60, 2**59, 2**58, 2**57, 2**56, 2**55])
+        ans = ak.array(
+            [1, -(2**63), 2**62, 2**61, 2**60, 2**59, 2**58, 2**57, 2**56, 2**55]
+        )
         self.assertTrue((rotated == ans).all())
-
-                    

--- a/tests/categorical_test.py
+++ b/tests/categorical_test.py
@@ -1,175 +1,257 @@
-import numpy as np
 import glob
-import shutil
 import os
+import shutil
 import tempfile
-from arkouda import io_util
-from context import arkouda as ak
+
+import numpy as np
 from base_test import ArkoudaTest
-from arkouda import pdarrayIO
+from context import arkouda as ak
+
+from arkouda import io_util, pdarrayIO
 
 
 class CategoricalTest(ArkoudaTest):
-
     @classmethod
     def setUpClass(cls):
         super(CategoricalTest, cls).setUpClass()
-        CategoricalTest.cat_test_base_tmp = '{}/categorical_test'.format(os.getcwd())
-        io_util.get_directory(CategoricalTest.cat_test_base_tmp )
-    
-    def _getCategorical(self, prefix : str='string', size : int=11) -> ak.Categorical:
-        return ak.Categorical(ak.array(['{} {}'.format(prefix,i) for i in range(1,size)]))
-    
+        CategoricalTest.cat_test_base_tmp = "{}/categorical_test".format(os.getcwd())
+        io_util.get_directory(CategoricalTest.cat_test_base_tmp)
+
+    def _getCategorical(self, prefix: str = "string", size: int = 11) -> ak.Categorical:
+        return ak.Categorical(ak.array(["{} {}".format(prefix, i) for i in range(1, size)]))
+
     def _getRandomizedCategorical(self) -> ak.Categorical:
-        return ak.Categorical(ak.array(['string', 'string1', 'non-string', 'non-string2', 
-                                        'string', 'non-string', 'string3','non-string2', 
-                                        'string', 'non-string']))
-    
+        return ak.Categorical(
+            ak.array(
+                [
+                    "string",
+                    "string1",
+                    "non-string",
+                    "non-string2",
+                    "string",
+                    "non-string",
+                    "string3",
+                    "non-string2",
+                    "string",
+                    "non-string",
+                ]
+            )
+        )
+
     def testBaseCategorical(self):
         cat = self._getCategorical()
 
-        self.assertTrue((ak.array([7,5,9,8,2,1,4,0,3,6]) == cat.codes).all())
-        self.assertTrue((ak.array([0,1,2,3,4,5,6,7,8,9]) == cat.segments).all())
-        self.assertTrue((ak.array(['string 8', 'string 6', 'string 5', 'string 9', 
-                                    'string 7', 'string 2', 'string 10', 'string 1', 
-                                    'string 4', 'string 3', 'N/A']) == cat.categories).all())
-        self.assertEqual(10,cat.size)
-        self.assertEqual('category',cat.objtype)
-        
-        with self.assertRaises(ValueError) as cm:
-            ak.Categorical(ak.arange(0,5,10))
-        
+        self.assertTrue((ak.array([7, 5, 9, 8, 2, 1, 4, 0, 3, 6]) == cat.codes).all())
+        self.assertTrue((ak.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) == cat.segments).all())
+        self.assertTrue(
+            (
+                ak.array(
+                    [
+                        "string 8",
+                        "string 6",
+                        "string 5",
+                        "string 9",
+                        "string 7",
+                        "string 2",
+                        "string 10",
+                        "string 1",
+                        "string 4",
+                        "string 3",
+                        "N/A",
+                    ]
+                )
+                == cat.categories
+            ).all()
+        )
+        self.assertEqual(10, cat.size)
+        self.assertEqual("category", cat.objtype)
+
+        with self.assertRaises(ValueError):
+            ak.Categorical(ak.arange(0, 5, 10))
+
     def testCategoricalFromCodesAndCategories(self):
-        codes = ak.array([7,5,9,8,2,1,4,0,3,6])
-        categories = ak.unique(ak.array(['string 8', 'string 6', 'string 5', 'string 9', 
-                                    'string 7', 'string 2', 'string 10', 'string 1', 
-                                    'string 4', 'string 3', 'N/A']))
-        
+        codes = ak.array([7, 5, 9, 8, 2, 1, 4, 0, 3, 6])
+        categories = ak.unique(
+            ak.array(
+                [
+                    "string 8",
+                    "string 6",
+                    "string 5",
+                    "string 9",
+                    "string 7",
+                    "string 2",
+                    "string 10",
+                    "string 1",
+                    "string 4",
+                    "string 3",
+                    "N/A",
+                ]
+            )
+        )
+
         cat = ak.Categorical.from_codes(codes, categories)
         self.assertTrue((codes == cat.codes).all())
         self.assertTrue((categories == cat.categories).all())
-        
+
     def testContains(self):
         cat = self._getCategorical()
-        self.assertTrue(cat.contains('string').all())
-        
+        self.assertTrue(cat.contains("string").all())
+
     def testEndsWith(self):
         cat = self._getCategorical()
-        self.assertTrue(cat.endswith('1').any())
-        
+        self.assertTrue(cat.endswith("1").any())
+
     def testStartsWith(self):
         cat = self._getCategorical()
-        self.assertTrue(cat.startswith('string').all())
-        
+        self.assertTrue(cat.startswith("string").all())
+
     def testGroup(self):
         group = self._getRandomizedCategorical().group()
-        self.assertTrue((ak.array([2,5,9,6,1,3,7,0,4,8]) == group).all())
-        
+        self.assertTrue((ak.array([2, 5, 9, 6, 1, 3, 7, 0, 4, 8]) == group).all())
+
     def testUnique(self):
         cat = self._getRandomizedCategorical()
-        
-        self.assertTrue((ak.Categorical(ak.array(['non-string', 'string3', 'string1', 
-                                        'non-string2', 'string'])).to_ndarray() 
-                                                  == cat.unique().to_ndarray()).all())  
-        
+
+        self.assertTrue(
+            (
+                ak.Categorical(
+                    ak.array(["non-string", "string3", "string1", "non-string2", "string"])
+                ).to_ndarray()
+                == cat.unique().to_ndarray()
+            ).all()
+        )
+
     def testToNdarray(self):
         cat = self._getRandomizedCategorical()
-        ndcat = np.array(['string', 'string1', 'non-string', 'non-string2', 
-                            'string', 'non-string', 'string3','non-string2', 
-                            'string', 'non-string'])
+        ndcat = np.array(
+            [
+                "string",
+                "string1",
+                "non-string",
+                "non-string2",
+                "string",
+                "non-string",
+                "string3",
+                "non-string2",
+                "string",
+                "non-string",
+            ]
+        )
         self.assertTrue((cat.to_ndarray() == ndcat).all())
-        
+
     def testEquality(self):
         cat = self._getCategorical()
         catDupe = self._getCategorical()
         catNonDupe = self._getRandomizedCategorical()
-        
+
         self.assertTrue((cat == catDupe).all())
         self.assertTrue((cat != catNonDupe).all())
 
-        c1 = ak.Categorical(ak.array(['a', 'b', 'c', 'a', 'b']))
-        c2 = ak.Categorical(ak.array(['a', 'x', 'c', 'y', 'b']))
-        res = (c1 == c2)
+        c1 = ak.Categorical(ak.array(["a", "b", "c", "a", "b"]))
+        c2 = ak.Categorical(ak.array(["a", "x", "c", "y", "b"]))
+        res = c1 == c2
         ans = ak.array([True, False, True, False, True])
         self.assertTrue((res == ans).all())
-        
+
     def testBinop(self):
         cat = self._getCategorical()
         catDupe = self._getCategorical()
         catNonDupe = self._getRandomizedCategorical()
 
-        
-        self.assertTrue((cat._binop(catDupe,'==')).all())
-        self.assertTrue((cat._binop(catNonDupe,'!=')).all())
-        
-        self.assertTrue((ak.array([True,True,True,True,True,True,True,
-                                   True,True,True]) == cat._binop(catDupe,'==')).all())
-        
-        self.assertTrue((ak.array([False,False,False,False,False,False,
-                                   False,False,False,False]) == cat._binop(catDupe,'!=')).all())
+        self.assertTrue((cat._binop(catDupe, "==")).all())
+        self.assertTrue((cat._binop(catNonDupe, "!=")).all())
 
-        self.assertTrue((ak.array([True,False,False,False,False,False,
-                                   False,False,False,False]) == 
-                                   cat._binop('string 1', '==')).all())
-        self.assertTrue((ak.array([True,False,False,False,False,False,
-                                   False,False,False,False]) == 
-                                   cat._binop(np.str_('string 1'), '==')).all())
-        
-        self.assertTrue((ak.array([False,True,True,True,True,True,True,True,True,True]) ==
-                   cat._binop('string 1', '!=')).all())
-        self.assertTrue((ak.array([False,True,True,True,True,True,True,True,True,True]) ==
-                   cat._binop(np.str_('string 1'), '!=')).all())
-        
+        self.assertTrue(
+            (
+                ak.array([True, True, True, True, True, True, True, True, True, True])
+                == cat._binop(catDupe, "==")
+            ).all()
+        )
+
+        self.assertTrue(
+            (
+                ak.array([False, False, False, False, False, False, False, False, False, False])
+                == cat._binop(catDupe, "!=")
+            ).all()
+        )
+
+        self.assertTrue(
+            (
+                ak.array([True, False, False, False, False, False, False, False, False, False])
+                == cat._binop("string 1", "==")
+            ).all()
+        )
+        self.assertTrue(
+            (
+                ak.array([True, False, False, False, False, False, False, False, False, False])
+                == cat._binop(np.str_("string 1"), "==")
+            ).all()
+        )
+
+        self.assertTrue(
+            (
+                ak.array([False, True, True, True, True, True, True, True, True, True])
+                == cat._binop("string 1", "!=")
+            ).all()
+        )
+        self.assertTrue(
+            (
+                ak.array([False, True, True, True, True, True, True, True, True, True])
+                == cat._binop(np.str_("string 1"), "!=")
+            ).all()
+        )
+
         with self.assertRaises(NotImplementedError):
-            cat._binop('string 1', '===')
-        
-        with self.assertRaises(TypeError) as cm:
-            cat._binop(1, '==')
+            cat._binop("string 1", "===")
+
+        with self.assertRaises(TypeError):
+            cat._binop(1, "==")
 
     def testIn1d(self):
         vals = [i % 3 for i in range(10)]
         valsTwo = [i % 2 for i in range(10)]
 
-        stringsOne = ak.array(['String {}'.format(i) for i in vals])
-        stringsTwo = ak.array(['String {}'.format(i) for i in valsTwo])
+        stringsOne = ak.array(["String {}".format(i) for i in vals])
+        stringsTwo = ak.array(["String {}".format(i) for i in valsTwo])
         catOne = ak.Categorical(stringsOne)
         catTwo = ak.Categorical(stringsTwo)
 
         answer = ak.array([x < 2 for x in vals])
 
-        self.assertTrue((answer == ak.in1d(catOne,catTwo)).all())
-        self.assertTrue((answer == ak.in1d(catOne,stringsTwo)).all())
+        self.assertTrue((answer == ak.in1d(catOne, catTwo)).all())
+        self.assertTrue((answer == ak.in1d(catOne, stringsTwo)).all())
 
-        with self.assertRaises(TypeError) as cm:
-            ak.in1d(catOne, ak.randint(0,5,5))
-       
+        with self.assertRaises(TypeError):
+            ak.in1d(catOne, ak.randint(0, 5, 5))
+
     def testConcatenate(self):
-        catOne = self._getCategorical('string',51)
-        catTwo = self._getCategorical('string-two', 51)
-        
+        catOne = self._getCategorical("string", 51)
+        catTwo = self._getCategorical("string-two", 51)
+
         resultCat = catOne.concatenate([catTwo])
-        self.assertEqual('category', resultCat.objtype)
+        self.assertEqual("category", resultCat.objtype)
         self.assertIsInstance(resultCat, ak.Categorical)
-        self.assertEqual(100,resultCat.size)
+        self.assertEqual(100, resultCat.size)
 
         # Since Categorical.concatenate uses Categorical.from_codes method, confirm
         # that both permutation and segments are None
         self.assertFalse(resultCat.permutation)
         self.assertFalse(resultCat.segments)
-        
-        resultCat = ak.concatenate([catOne,catOne], ordered=False)
-        self.assertEqual('category', resultCat.objtype)
+
+        resultCat = ak.concatenate([catOne, catOne], ordered=False)
+        self.assertEqual("category", resultCat.objtype)
         self.assertIsInstance(resultCat, ak.Categorical)
-        self.assertEqual(100,resultCat.size)
+        self.assertEqual(100, resultCat.size)
 
         # Since Categorical.concatenate uses Categorical.from_codes method, confirm
         # that both permutation and segments are None
         self.assertFalse(resultCat.permutation)
         self.assertFalse(resultCat.segments)
-        
-        # Concatenate two Categoricals with different categories, and test result against original strings
-        s1 = ak.array(['abc', 'de', 'abc', 'fghi', 'de'])
-        s2 = ak.array(['jkl', 'mno', 'fghi', 'abc', 'fghi', 'mno'])
+
+        # Concatenate two Categoricals with different categories,
+        # and test result against original strings
+        s1 = ak.array(["abc", "de", "abc", "fghi", "de"])
+        s2 = ak.array(["jkl", "mno", "fghi", "abc", "fghi", "mno"])
         c1 = ak.Categorical(s1)
         c2 = ak.Categorical(s2)
         # Ordered concatenation
@@ -184,12 +266,12 @@ class CategoricalTest(ArkoudaTest):
         # Tiny concatenation
         # Used to fail when length of array was less than numLocales
         # CI uses 2 locales, so try with length-1 arrays
-        a = ak.Categorical(ak.array(['a']))
-        b = ak.Categorical(ak.array(['b']))
+        a = ak.Categorical(ak.array(["a"]))
+        b = ak.Categorical(ak.array(["b"]))
         c = ak.concatenate((a, b), ordered=False)
-        ans = ak.Categorical(ak.array(['a', 'b']))
+        ans = ak.Categorical(ak.array(["a", "b"]))
         self.assertTrue((c == ans).all())
-        
+
     def testSaveAndLoadCategorical(self):
         """
         Test to save categorical to hdf5 and read it back successfully
@@ -206,12 +288,17 @@ class CategoricalTest(ArkoudaTest):
             cat.save(f"{tmp_dirname}/cat-save-test", dataset=dset_name)
 
             import h5py
+
             f = h5py.File(tmp_dirname + "/cat-save-test_LOCALE0000", mode="r")
             keys = set(f.keys())
-            if pdarrayIO.ARKOUDA_HDF5_FILE_METADATA_GROUP in keys:  # Ignore the metadata group if it exists
+            if (
+                pdarrayIO.ARKOUDA_HDF5_FILE_METADATA_GROUP in keys
+            ):  # Ignore the metadata group if it exists
                 keys.remove(pdarrayIO.ARKOUDA_HDF5_FILE_METADATA_GROUP)
             self.assertEqual(len(keys), 5, "Expected 5 keys")
-            self.assertSetEqual(set(f"categorical_array.{k}" for k in cat._get_components_dict().keys()), keys)
+            self.assertSetEqual(
+                set(f"categorical_array.{k}" for k in cat._get_components_dict().keys()), keys
+            )
             f.close()
 
             # Now try to read them back with load_all
@@ -219,36 +306,49 @@ class CategoricalTest(ArkoudaTest):
             self.assertTrue(dset_name in x)
             cat_from_hdf = x[dset_name]
 
-            expected_categories = [f"string {i}" for i in range(1, num_elems)] + ['N/A']
+            expected_categories = [f"string {i}" for i in range(1, num_elems)] + ["N/A"]
 
-            # Note assertCountEqual asserts a and b have the same elements in the same amount regardless of order
-            self.assertCountEqual(cat_from_hdf.categories.to_ndarray().tolist(), expected_categories)
+            # Note assertCountEqual asserts a and b have the same elements
+            # in the same amount regardless of order
+            self.assertCountEqual(cat_from_hdf.categories.to_ndarray().tolist(),
+                                  expected_categories)
 
-            # Asserting the optional components and sizes are correct for both constructors should be sufficient
+            # Asserting the optional components and sizes are correct
+            # for both constructors should be sufficient
             self.assertTrue(cat_from_hdf.segments is not None)
             self.assertTrue(cat_from_hdf.permutation is not None)
             print(f"==> cat_from_hdf.size:{cat_from_hdf.size}")
-            self.assertTrue(cat_from_hdf.size == num_elems-1)
+            self.assertTrue(cat_from_hdf.size == num_elems - 1)
 
     def test_unused_categories_logic(self):
         """
-        Test that Categoricals built from_codes and from slices that have unused categories behave correctly
+        Test that Categoricals built from_codes and from slices
+        that have unused categories behave correctly
         """
         s = ak.array([str(i) for i in range(10)])
         s12 = s[1:3]
         cat = ak.Categorical(s)
         cat12 = cat[1:3]
-        self.assertListEqual(ak.in1d(s, s12).to_ndarray().tolist(), ak.in1d(cat, cat12).to_ndarray().tolist())
-        self.assertSetEqual(set(ak.unique(s12).to_ndarray().tolist()), set(ak.unique(cat12).to_ndarray().tolist()))
+        self.assertListEqual(
+            ak.in1d(s, s12).to_ndarray().tolist(), ak.in1d(cat, cat12).to_ndarray().tolist()
+        )
+        self.assertSetEqual(
+            set(ak.unique(s12).to_ndarray().tolist()), set(ak.unique(cat12).to_ndarray().tolist())
+        )
 
         cat_from_codes = ak.Categorical.from_codes(ak.array([1, 2]), s)
-        self.assertListEqual(ak.in1d(s, s12).to_ndarray().tolist(), ak.in1d(cat, cat_from_codes).to_ndarray().tolist())
-        self.assertSetEqual(set(ak.unique(s12).to_ndarray().tolist()), set(ak.unique(cat_from_codes).to_ndarray().tolist()))
-
+        self.assertListEqual(
+            ak.in1d(s, s12).to_ndarray().tolist(), ak.in1d(cat, cat_from_codes).to_ndarray().tolist()
+        )
+        self.assertSetEqual(
+            set(ak.unique(s12).to_ndarray().tolist()),
+            set(ak.unique(cat_from_codes).to_ndarray().tolist()),
+        )
 
     def testSaveAndLoadCategoricalMulti(self):
         """
-        Test to build a pseudo dataframe with multiple categoricals, pdarrays, strings objects and successfully
+        Test to build a pseudo dataframe with multiple
+        categoricals, pdarrays, strings objects and successfully
         write/read it from HDF5
         """
         c1 = self._getCategorical(prefix="c1", size=51)
@@ -257,58 +357,58 @@ class CategoricalTest(ArkoudaTest):
         strings1 = ak.random_strings_uniform(9, 10, 52)
 
         with tempfile.TemporaryDirectory(dir=CategoricalTest.cat_test_base_tmp) as tmp_dirname:
-            df = {
-                "cat1": c1,
-                "cat2": c2,
-                "pda1": pda1,
-                "strings1": strings1
-            }
+            df = {"cat1": c1, "cat2": c2, "pda1": pda1, "strings1": strings1}
             ak.save_all(df, f"{tmp_dirname}/cat-save-test")
             x = ak.load_all(path_prefix=f"{tmp_dirname}/cat-save-test")
             self.assertTrue(len(x.items()) == 4)
-            # Note assertCountEqual asserts a and b have the same elements in the same amount regardless of order
-            self.assertCountEqual(x["cat1"].categories.to_ndarray().tolist(), c1.categories.to_ndarray().tolist())
-            self.assertCountEqual(x["cat2"].categories.to_ndarray().tolist(), c2.categories.to_ndarray().tolist())
+            # Note assertCountEqual asserts a and b have the same
+            # elements in the same amount regardless of order
+            self.assertCountEqual(
+                x["cat1"].categories.to_ndarray().tolist(), c1.categories.to_ndarray().tolist()
+            )
+            self.assertCountEqual(
+                x["cat2"].categories.to_ndarray().tolist(), c2.categories.to_ndarray().tolist()
+            )
             self.assertCountEqual(x["pda1"].to_ndarray().tolist(), pda1.to_ndarray().tolist())
             self.assertCountEqual(x["strings1"].to_ndarray().tolist(), strings1.to_ndarray().tolist())
 
     def testNA(self):
-        s = ak.array(['A', 'B', 'C', 'B', 'C'])
+        s = ak.array(["A", "B", "C", "B", "C"])
         # NAval present in categories
-        c = ak.Categorical(s, NAvalue='C')
+        c = ak.Categorical(s, NAvalue="C")
         self.assertListEqual(c.isna().to_ndarray().tolist(), [False, False, True, False, True])
-        self.assertTrue(c.NAvalue == 'C')
+        self.assertTrue(c.NAvalue == "C")
         # Test that NAval survives registration
-        c.register('my_categorical')
-        c2 = ak.Categorical.attach('my_categorical')
-        self.assertTrue(c2.NAvalue == 'C')
+        c.register("my_categorical")
+        c2 = ak.Categorical.attach("my_categorical")
+        self.assertTrue(c2.NAvalue == "C")
 
         # default NAval not present in categories
         c = ak.Categorical(s)
         self.assertTrue(not c.isna().any())
-        self.assertTrue(c.NAvalue == 'N/A')
+        self.assertTrue(c.NAvalue == "N/A")
 
     def testStandardizeCategories(self):
-        c1 = ak.Categorical(ak.array(['A', 'B', 'C']))
-        c2 = ak.Categorical(ak.array(['B', 'C', 'D']))
+        c1 = ak.Categorical(ak.array(["A", "B", "C"]))
+        c2 = ak.Categorical(ak.array(["B", "C", "D"]))
         c3, c4 = ak.Categorical.standardize_categories([c1, c2])
         self.assertTrue((c3.categories == c4.categories).all())
         self.assertTrue(not c3.isna().any())
         self.assertTrue(not c4.isna().any())
-        self.assertTrue(c3.categories.size == c1.categories.size+1)
-        self.assertTrue(c4.categories.size == c2.categories.size+1)
+        self.assertTrue(c3.categories.size == c1.categories.size + 1)
+        self.assertTrue(c4.categories.size == c2.categories.size + 1)
 
     def testLookup(self):
         keys = ak.array([1, 2, 3])
-        values = ak.Categorical(ak.array(['A', 'B', 'C']))
+        values = ak.Categorical(ak.array(["A", "B", "C"]))
         args = ak.array([3, 2, 1, 0])
         ret = ak.lookup(keys, values, args)
-        expected = ['C', 'B', 'A', 'N/A']
+        expected = ["C", "B", "A", "N/A"]
         self.assertListEqual(ret.to_ndarray().tolist(), expected)
-        
+
     def tearDown(self):
         super(CategoricalTest, self).tearDown()
-        for f in glob.glob('{}/*'.format(CategoricalTest.cat_test_base_tmp)):
+        for f in glob.glob("{}/*".format(CategoricalTest.cat_test_base_tmp)):
             os.remove(f)
 
     @classmethod

--- a/tests/check.py
+++ b/tests/check.py
@@ -1,21 +1,20 @@
-#!/usr/bin/env python3                                                         
+#!/usr/bin/env python3
 
-import importlib
-import numpy as np
-import math
-import gc
 import sys
 
-from context import arkouda as ak
+import numpy as np
 from base_test import ArkoudaTest
+from context import arkouda as ak
 
 N = 1_000_000
 errors = False
 
+
 def pass_fail(f):
     global errors
     errors = errors or not f
-    return ("Passed" if f else "Failed")
+    return "Passed" if f else "Failed"
+
 
 def check_bool(N):
     a = ak.arange(N)
@@ -30,6 +29,7 @@ def check_bool(N):
     correct = correct and (d and 5)
     return pass_fail(correct)
 
+
 def check_arange(N):
     # create np version
     a = np.arange(N)
@@ -40,6 +40,7 @@ def check_arange(N):
     # print(type(c),c)
     return pass_fail(c.all())
 
+
 def check_linspace(N):
     # create np version
     a = np.linspace(10, 20, N)
@@ -48,6 +49,7 @@ def check_linspace(N):
     # print(a,b)
     f = np.allclose(a, b.to_ndarray())
     return pass_fail(f)
+
 
 def check_ones(N):
     # create np version
@@ -59,6 +61,7 @@ def check_ones(N):
     # print(type(c),c)
     return pass_fail(c.all())
 
+
 def check_zeros(N):
     # create np version
     a = np.zeros(N)
@@ -68,6 +71,7 @@ def check_zeros(N):
     c = a == b.to_ndarray()
     # print(type(c),c)
     return pass_fail(c.all())
+
 
 def check_argsort(N):
     # create np version
@@ -85,6 +89,7 @@ def check_argsort(N):
     # print(type(c),c)
     return pass_fail(c.all())
 
+
 def check_coargsort(N):
     # create np version
     a = np.arange(N)
@@ -101,6 +106,7 @@ def check_coargsort(N):
     # print(type(c),c)
     return pass_fail(c.all())
 
+
 def check_sort(N):
     # create np version
     a = np.arange(N)
@@ -115,6 +121,7 @@ def check_sort(N):
     # print(type(c),c)
     return pass_fail(c.all())
 
+
 def check_get_slice(N):
     # create np version
     a = np.ones(N)
@@ -125,6 +132,7 @@ def check_get_slice(N):
     # print(a,b)
     c = a == b.to_ndarray()
     return pass_fail(c.all())
+
 
 def check_set_slice_value(N):
     # create np version
@@ -137,6 +145,7 @@ def check_set_slice_value(N):
     c = a == b.to_ndarray()
     return pass_fail(c.all())
 
+
 def check_set_slice(N):
     # create np version
     a = np.ones(N)
@@ -148,169 +157,180 @@ def check_set_slice(N):
     c = a == b.to_ndarray()
     return pass_fail(c.all())
 
+
 def check_get_bool_iv(N):
     # create np version
     a = np.arange(N)
-    a = a[a < N//2]
+    a = a[a < N // 2]
     # create ak version
     b = ak.arange(N)
-    b = b[b < N//2]
+    b = b[b < N // 2]
     # print(a,b)
     c = a == b.to_ndarray()
     # print(type(c),c)
     return pass_fail(c.all())
+
 
 def check_set_bool_iv_value(N):
     # create np version
     a = np.arange(N)
-    a[a < N//2] = -1
+    a[a < N // 2] = -1
     # create ak version
     b = ak.arange(N)
-    b[b < N//2] = -1
+    b[b < N // 2] = -1
     # print(a,b)
     c = a == b.to_ndarray()
     # print(type(c),c)
     return pass_fail(c.all())
+
 
 def check_set_bool_iv(N):
     # create np version
     a = np.arange(N)
-    a[a < N//2] = a[:N//2] * -1
+    a[a < N // 2] = a[: N // 2] * -1
     # create ak version
     b = ak.arange(N)
-    b[b < N//2] = b[:N//2] * -1
+    b[b < N // 2] = b[: N // 2] * -1
     # print(a,b)
     c = a == b.to_ndarray()
     # print(type(c),c)
     return pass_fail(c.all())
 
+
 def check_get_integer_iv(N):
     # create np version
     a = np.arange(N)
-    iv = np.arange(N//2)
+    iv = np.arange(N // 2)
     a = a[iv]
     # create ak version
     b = ak.arange(N)
-    iv = ak.arange(N//2)
+    iv = ak.arange(N // 2)
     b = b[iv]
     # print(a,b)
     c = a == b.to_ndarray()
     # print(type(c),c)
     return pass_fail(c.all())
 
+
 def check_set_integer_iv_value(N):
     # create np version
     a = np.arange(N)
-    iv = np.arange(N//2)
+    iv = np.arange(N // 2)
     a[iv] = -1
     # create ak version
     b = ak.arange(N)
-    iv = ak.arange(N//2)
+    iv = ak.arange(N // 2)
     b[iv] = -1
     # print(a,b)
     c = a == b.to_ndarray()
     # print(type(c),c)
     return pass_fail(c.all())
 
+
 def check_set_integer_iv(N):
     # create np version
     a = np.arange(N)
-    iv = np.arange(N//2)
-    a[iv] = iv*10
+    iv = np.arange(N // 2)
+    a[iv] = iv * 10
     # create ak version
     b = ak.arange(N)
-    iv = ak.arange(N//2)
-    b[iv] = iv*10
+    iv = ak.arange(N // 2)
+    b[iv] = iv * 10
     # print(a,b)
     c = a == b.to_ndarray()
     # print(type(c),c)
     return pass_fail(c.all())
 
+
 def check_get_integer_idx(N):
     # create np version
     a = np.arange(N)
-    v1 = a[N//2]
+    v1 = a[N // 2]
     # create ak version
     b = ak.arange(N)
-    v2 = b[N//2]
+    v2 = b[N // 2]
     return pass_fail(v1 == v2) and pass_fail(a[-1] == b[-1])
+
 
 def check_set_integer_idx(N):
     # create np version
     a = np.arange(N)
-    a[N//2] = -1
+    a[N // 2] = -1
     a[-1] = -1
-    v1 = a[N//2]
+    v1 = a[N // 2]
     # create ak version
     b = ak.arange(N)
-    b[N//2] = -1
+    b[N // 2] = -1
     b[-1] = -1
-    v2 = b[N//2]
+    v2 = b[N // 2]
     return pass_fail(v1 == v2) and pass_fail(a[-1] == b[-1])
 
-'''
+
+"""
 Encapsulates test cases that invoke the run_tests method.
-'''
+"""
+
+
 class CheckTest(ArkoudaTest):
-    
     def testBool(self):
         self.assertTrue(check_bool(N))
-    
+
     def testArange(self):
         self.assertTrue(check_arange(N))
-        
+
     def testLinspace(self):
         self.assertTrue(check_linspace(N))
-        
+
     def testOnes(self):
         self.assertTrue(check_ones(N))
-        
+
     def testZeros(self):
         self.assertTrue(check_zeros(N))
-        
+
     def testArgsort(self):
         self.assertTrue(check_argsort(N))
-        
+
     def testCoargsort(self):
         self.assertTrue(check_coargsort(N))
-        
+
     def testSort(self):
         self.assertTrue(check_sort(N))
-        
+
     def testGetSlice(self):
         self.assertTrue(check_get_slice(N))
-        
+
     def testSetSliceValue(self):
         self.assertTrue(check_set_slice_value(N))
-        
+
     def testSetSlice(self):
         self.assertTrue(check_set_slice(N))
-        
+
     def testGetBoolIv(self):
         self.assertTrue(check_get_bool_iv(N))
-        
+
     def testGetBoolIvValue(self):
         self.assertTrue(check_set_bool_iv_value(N))
-        
+
     def testSetBoolIv(self):
         self.assertTrue(check_set_bool_iv(N))
-        
+
     def testGetIntegerIv(self):
         self.assertTrue(check_get_integer_iv(N))
-        
+
     def testSetIntegerIvValue(self):
         self.assertTrue(check_set_integer_iv_value(N))
-        
+
     def testSetIntegerIv(self):
         self.assertTrue(check_set_integer_iv(N))
-        
+
     def testGetIntegerIdx(self):
         self.assertTrue(check_get_integer_idx(N))
-        
+
     def testSetIntegerIdx(self):
         self.assertTrue(check_set_integer_idx(N))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     N = 1_000_000
     print(">>> Sanity checks on the arkouda_server")
 
@@ -343,4 +363,3 @@ if __name__ == '__main__':
 
     ak.disconnect()
     sys.exit(errors)
-    

--- a/tests/client_dtypes_test.py
+++ b/tests/client_dtypes_test.py
@@ -1,13 +1,15 @@
-import numpy as np
-from context import arkouda as ak
-from arkouda import client_dtypes
 from base_test import ArkoudaTest
+from context import arkouda as ak
+
+from arkouda import client_dtypes
 
 
 class ClientDTypeTests(ArkoudaTest):
     """
-    Note: BitVector operations are not tested here because the class is only a wrapper on a pdarray to display as such.
-    The class does not actually store values as bit-values, it only converts to a bit representation for display.
+    Note: BitVector operations are not tested here because the class is
+    only a wrapper on a pdarray to display as such.
+    The class does not actually store values as bit-values,
+    it only converts to a bit representation for display.
     Thus, pdarray testing covers these operations.
     """
 
@@ -15,25 +17,25 @@ class ClientDTypeTests(ArkoudaTest):
         arr = ak.arange(4)
         bv = ak.BitVector(arr, width=3)
         self.assertIsInstance(bv, client_dtypes.BitVector)
-        self.assertListEqual(bv.to_ndarray().tolist(), ['...', '..|', '.|.', '.||'])
+        self.assertListEqual(bv.to_ndarray().tolist(), ["...", "..|", ".|.", ".||"])
         self.assertTrue(bv.dtype == ak.bitType)
 
         # Test reversed
         arr = ak.arange(4, dtype=ak.uint64)  # Also test with uint64 input
         bv = ak.BitVector(arr, width=3, reverse=True)
         self.assertIsInstance(bv, client_dtypes.BitVector)
-        self.assertListEqual(bv.to_ndarray().tolist(), ['...', '|..', '.|.', '||.'])
+        self.assertListEqual(bv.to_ndarray().tolist(), ["...", "|..", ".|.", "||."])
         self.assertTrue(bv.dtype == ak.bitType)
 
-        #test use of vectorizer function
+        # test use of vectorizer function
         arr = ak.arange(4)
         bvectorizer = ak.BitVectorizer(3)
         bv = bvectorizer(arr)
         self.assertIsInstance(bv, client_dtypes.BitVector)
-        self.assertListEqual(bv.to_ndarray().tolist(), ['...', '..|', '.|.', '.||'])
+        self.assertListEqual(bv.to_ndarray().tolist(), ["...", "..|", ".|.", ".||"])
         self.assertTrue(bv.dtype == ak.bitType)
 
-        #fail on argument types
+        # fail on argument types
         with self.assertRaises(TypeError):
             bv = ak.BitVector(17, width=4)
         arr = ak.array([1.1, 8.3])
@@ -42,47 +44,47 @@ class ClientDTypeTests(ArkoudaTest):
 
     def test_Field_creation(self):
         values = ak.arange(4)
-        names = ['8', '4', '2', '1']
+        names = ["8", "4", "2", "1"]
         f = ak.Fields(values, names)
         self.assertIsInstance(f, ak.Fields)
-        self.assertListEqual(f.to_ndarray().tolist(), ['---- (0)', '---1 (1)', '--2- (2)', '--21 (3)'])
+        self.assertListEqual(f.to_ndarray().tolist(), ["---- (0)", "---1 (1)", "--2- (2)", "--21 (3)"])
         self.assertTrue(f.dtype == ak.bitType)
 
-        #Named fields with reversed bit order
+        # Named fields with reversed bit order
         values = ak.array([0, 1, 5, 8, 12])
-        names = ['Bit1', 'Bit2', 'Bit3', 'Bit4']
-        f = ak.Fields(values, names, MSB_left=False, separator='//')
+        names = ["Bit1", "Bit2", "Bit3", "Bit4"]
+        f = ak.Fields(values, names, MSB_left=False, separator="//")
         expected = [
-            '----//----//----//----// (0)',
-            'Bit1//----//----//----// (1)',
-            'Bit1//----//Bit3//----// (5)',
-            '----//----//----//Bit4// (8)',
-            '----//----//Bit3//Bit4// (12)'
+            "----//----//----//----// (0)",
+            "Bit1//----//----//----// (1)",
+            "Bit1//----//Bit3//----// (5)",
+            "----//----//----//Bit4// (8)",
+            "----//----//Bit3//Bit4// (12)",
         ]
         self.assertListEqual(f.to_ndarray().tolist(), expected)
 
         values = ak.arange(8, dtype=ak.uint64)
-        names = [f'Bit{x}' for x in range(65)]
+        names = [f"Bit{x}" for x in range(65)]
         with self.assertRaises(ValueError):
             f = ak.Fields(values, names)
 
-        names = ['t', 't']
+        names = ["t", "t"]
         with self.assertRaises(ValueError):
             f = ak.Fields(values, names)
 
-        names = ['t', '']
+        names = ["t", ""]
         with self.assertRaises(ValueError):
             f = ak.Fields(values, names)
 
-        names = ['abc', '123']
+        names = ["abc", "123"]
         with self.assertRaises(ValueError):
-            f = ak.Fields(values, names, separator='abc')
+            f = ak.Fields(values, names, separator="abc")
 
         with self.assertRaises(ValueError):
             f = ak.Fields(values, names)
 
         with self.assertRaises(ValueError):
-            f = ak.Fields(values, names, pad='|!~', separator='//')
+            f = ak.Fields(values, names, pad="|!~", separator="//")
 
     def test_ipv4_creation(self):
         # Test handling of int64 input
@@ -90,30 +92,30 @@ class ClientDTypeTests(ArkoudaTest):
         ipv4 = ak.IPv4(ip_list)
 
         self.assertIsInstance(ipv4, ak.IPv4)
-        self.assertListEqual(ipv4.to_ndarray().tolist(), ['192.168.1.1'])
+        self.assertListEqual(ipv4.to_ndarray().tolist(), ["192.168.1.1"])
         self.assertTrue(ipv4.dtype == ak.bitType)
-        
+
         # Test handling of uint64 input
         ip_list = ak.array([3232235777], dtype=ak.uint64)
         ipv4 = ak.IPv4(ip_list)
 
         self.assertIsInstance(ipv4, ak.IPv4)
-        self.assertListEqual(ipv4.to_ndarray().tolist(), ['192.168.1.1'])
+        self.assertListEqual(ipv4.to_ndarray().tolist(), ["192.168.1.1"])
         self.assertTrue(ipv4.dtype == ak.bitType)
 
         with self.assertRaises(TypeError):
-            ipv4 = ak.IPv4('3232235777')
+            ipv4 = ak.IPv4("3232235777")
         with self.assertRaises(TypeError):
             ipv4 = ak.IPv4(ak.array([3232235777.177]))
 
         # Test handling of python dotted-quad input
-        ipv4 = ak.ip_address(['192.168.1.1'])
+        ipv4 = ak.ip_address(["192.168.1.1"])
         self.assertIsInstance(ipv4, ak.IPv4)
-        self.assertListEqual(ipv4.to_ndarray().tolist(), ['192.168.1.1'])
+        self.assertListEqual(ipv4.to_ndarray().tolist(), ["192.168.1.1"])
         self.assertTrue(ipv4.dtype == ak.bitType)
 
     def test_ipv4_normalization(self):
         ip_list = ak.array([3232235777])
         ipv4 = ak.IPv4(ip_list)
-        ip_as_int = ipv4.normalize('192.168.1.1')
+        ip_as_int = ipv4.normalize("192.168.1.1")
         self.assertEqual(3232235777, ip_as_int)

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1,125 +1,125 @@
 from base_test import ArkoudaTest
 from context import arkouda as ak
 
-'''
+"""
 Tests basic Arkouda client functionality
-'''
+"""
 from util.test.util import start_arkouda_server
+
+
 class ClientTest(ArkoudaTest):
-    
     def test_client_connected(self):
-        '''
+        """
         Tests the following methods:
         ak.client.connected()
         ak.client.disconnect()
         ak.client.connect()
-        
+
         :return: None
         :raise: AssertionError if an assert* method returns incorrect value or
                 if there is a error in connecting or disconnecting from  the
                 Arkouda server
-        '''
+        """
         self.assertTrue(ak.client.connected)
         try:
             ak.disconnect()
         except Exception as e:
             raise AssertionError(e)
-   
+
         self.assertFalse(ak.client.connected)
         try:
             ak.connect(server=ArkoudaTest.server, port=ArkoudaTest.port)
         except Exception as e:
             raise AssertionError(e)
         self.assertTrue(ak.client.connected)
-        
+
     def test_disconnect_on_disconnected_client(self):
-        '''
+        """
         Tests the ak.disconnect() method invoked on a client that is already
         disconnect to ensure there is no error
-        '''
+        """
         ak.disconnect()
         self.assertFalse(ak.client.connected)
         ak.disconnect()
         ak.connect(server=ArkoudaTest.server, port=ArkoudaTest.port)
-        
+
     def test_shutdown(self):
-        '''
+        """
         Tests the ak.shutdown() method
-        '''
+        """
         ak.shutdown()
         start_arkouda_server(numlocales=1)
-        
+
     def test_client_get_config(self):
-        '''
+        """
         Tests the ak.client.get_config() method
-        
+
         :return: None
-        :raise: AssertionError if one or more Config values are not as expected 
-                or the call to ak.client.get_config() fails 
-        '''
+        :raise: AssertionError if one or more Config values are not as expected
+                or the call to ak.client.get_config() fails
+        """
         try:
             config = ak.client.get_config()
         except Exception as e:
             raise AssertionError(e)
-        self.assertEqual(ArkoudaTest.port, config['ServerPort'])
-        self.assertTrue('arkoudaVersion' in config)
-        self.assertTrue('INFO', config['logLevel'])
-        
-    def test_client_context(self):   
-        '''
+        self.assertEqual(ArkoudaTest.port, config["ServerPort"])
+        self.assertTrue("arkoudaVersion" in config)
+        self.assertTrue("INFO", config["logLevel"])
+
+    def test_client_context(self):
+        """
         Tests the ak.client.context method
-        
+
         :return: None
-        :raise: AssertionError if one or more context values are not as expected 
-                or the call to ak.client.context fails 
-        '''      
-        try: 
+        :raise: AssertionError if one or more context values are not as expected
+                or the call to ak.client.context fails
+        """
+        try:
             context = ak.client.context
         except Exception as e:
             raise AssertionError(e)
         self.assertTrue(context)
         self.assertFalse(context.closed)
-        
+
     def test_get_mem_used(self):
-        '''
+        """
         Tests the ak.client.get_mem_used method
-        
+
         :return: None
-        :raise: AssertionError if one or more ak.get_mem_used values are not as 
-                expected or the call to ak.client.get_mem_used() fails 
-        '''  
+        :raise: AssertionError if one or more ak.get_mem_used values are not as
+                expected or the call to ak.client.get_mem_used() fails
+        """
         try:
             config = ak.client.get_config()
-            a = ak.ones(1024*1024 * config['numLocales'])
+            a = ak.ones(1024 * 1024 * config["numLocales"])
             mem_used = ak.client.get_mem_used()
         except Exception as e:
             raise AssertionError(e)
         self.assertTrue(mem_used > 0)
-        
-        
+
     def test_no_op(self):
-        '''
+        """
         Tests the ak.client._no_op method
-        
+
         :return: None
         :raise: AssertionError if return message is not 'noop'
-        '''   
-        self.assertEqual('noop', ak.client._no_op())
-        
+        """
+        self.assertEqual("noop", ak.client._no_op())
+
     def test_ruok(self):
-        '''
+        """
         Tests the ak.client.ruok method
-        
+
         :return: None
         :raise: AssertionError if return message is not 'imok'
-        '''
-        self.assertEqual('imok', ak.client.ruok())
-        
+        """
+        self.assertEqual("imok", ak.client.ruok())
+
     def test_client_configuration(self):
-        '''
+        """
         Tests the ak.client.set_defaults() method as well as set/get
         parrayIterThresh, maxTransferBytes, and verbose config params.
-        '''
+        """
         ak.client.pdarrayIterThresh = 50
         ak.client.maxTransferBytes = 1048576000
         ak.client.verbose = True
@@ -132,10 +132,10 @@ class ClientTest(ArkoudaTest):
         self.assertFalse(ak.client.verbose)
 
     def test_client_get_server_commands(self):
-        '''
+        """
         Tests the ak.client.get_server_commands() method contains an expected
         sample of commands.
-        '''
+        """
         expected_cmds = ["connect", "array", "create", "tondarray", "info", "str"]
         cmds = ak.client.get_server_commands()
         for cmd in expected_cmds:

--- a/tests/coargsort_test.py
+++ b/tests/coargsort_test.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
-import time, argparse
-import numpy as np
-from context import arkouda as ak 
+import argparse
+
 from base_test import ArkoudaTest
+from context import arkouda as ak
+
 
 def check_integral(N, algo, dtype):
     z = ak.zeros(N, dtype=dtype)
@@ -32,7 +33,6 @@ def check_integral(N, algo, dtype):
     perm = ak.coargsort([z, z, z, d2], algo)
     assert ak.is_sorted(d2[perm])
 
-
     a4 = ak.randint(0, 2**32, N)
     b4 = ak.randint(0, 2**32, N)
     n4 = ak.randint(-(2**31), 2**31, N)
@@ -49,11 +49,9 @@ def check_integral(N, algo, dtype):
     perm = ak.coargsort([b4, a4], algo)
     assert ak.is_sorted(b4[perm])
 
-
     a8 = ak.randint(0, 2**64, N)
     b8 = ak.randint(0, 2**64, N)
     n8 = ak.randint(-(2**63), 2**64, N)
- 
 
     perm = ak.coargsort([a8], algo)
     assert ak.is_sorted(a8[perm])
@@ -70,6 +68,7 @@ def check_integral(N, algo, dtype):
     for p in all_perm:
         perm = ak.coargsort(p, algo)
         assert ak.is_sorted(p[0][perm])
+
 
 def check_float(N, algo):
     a = ak.randint(0, 1, N, dtype=ak.float64)
@@ -91,6 +90,7 @@ def check_float(N, algo):
     perm = ak.coargsort([z, n], algo)
     assert ak.is_sorted(n[perm])
 
+
 def check_int_uint_float(N, algo):
     f = ak.randint(0, 2**63, N, dtype=ak.float64)
     u = ak.randint(0, 2**63, N, dtype=ak.uint64)
@@ -105,10 +105,12 @@ def check_int_uint_float(N, algo):
     perm = ak.coargsort([i, f, u], algo)
     assert ak.is_sorted(i[perm])
 
+
 def check_large(N, algo):
-    l = [ak.randint(0, 2**63, N) for _ in range(10)]
-    perm = ak.coargsort(l, algo)
-    assert ak.is_sorted(l[0][perm])
+    lg = [ak.randint(0, 2**63, N) for _ in range(10)]
+    perm = ak.coargsort(lg, algo)
+    assert ak.is_sorted(lg[0][perm])
+
 
 def check_coargsort(N_per_locale):
     print(">>> arkouda coargsort")
@@ -123,8 +125,8 @@ def check_coargsort(N_per_locale):
         check_int_uint_float(N, algo)
         check_large(N, algo)
 
-class CoargsortTest(ArkoudaTest):
 
+class CoargsortTest(ArkoudaTest):
     def test_int(self):
         for algo in ak.SortingAlgorithm:
             check_integral(10**3, algo, ak.int64)
@@ -144,7 +146,7 @@ class CoargsortTest(ArkoudaTest):
     def test_large(self):
         for algo in ak.SortingAlgorithm:
             check_large(10**3, algo)
-        
+
     def test_error_handling(self):
         ones = ak.ones(100)
         short_ones = ak.ones(10)
@@ -155,13 +157,14 @@ class CoargsortTest(ArkoudaTest):
 
         for algo in ak.SortingAlgorithm:
             with self.assertRaises(TypeError):
-                ak.coargsort([list(range(0,10)), [0]], algo)
+                ak.coargsort([list(range(0, 10)), [0]], algo)
 
     def test_coargsort_categorical(self):
-        string = ak.array(['a', 'b', 'a', 'b', 'c'])
+        string = ak.array(["a", "b", "a", "b", "c"])
         cat = ak.Categorical(string)
-        cat_from_codes = ak.Categorical.from_codes(codes=ak.array([0, 1, 0, 1, 2]),
-                                                   categories=ak.array(['a', 'b', 'c']))
+        cat_from_codes = ak.Categorical.from_codes(
+            codes=ak.array([0, 1, 0, 1, 2]), categories=ak.array(["a", "b", "c"])
+        )
         for algo in ak.SortingAlgorithm:
             str_perm = ak.coargsort([string], algo)
             str_sorted = string[str_perm].to_ndarray()
@@ -175,7 +178,7 @@ class CoargsortTest(ArkoudaTest):
             # coargsort sorts using codes, the order isn't guaranteed, only grouping
             from_codes_perm = ak.coargsort([cat_from_codes], algo)
             from_codes_sorted = cat_from_codes[from_codes_perm].to_ndarray()
-            self.assertTrue((['a', 'a', 'b', 'b', 'c'] == from_codes_sorted).all())
+            self.assertTrue((["a", "a", "b", "b", "c"] == from_codes_sorted).all())
 
             # coargsort on 2 categoricals (one from_codes)
             cat_perm = ak.coargsort([cat, cat_from_codes], algo)
@@ -190,13 +193,17 @@ class CoargsortTest(ArkoudaTest):
 
 def create_parser():
     parser = argparse.ArgumentParser(description="Check coargsort correctness.")
-    parser.add_argument('hostname', help='Hostname of arkouda server')
-    parser.add_argument('port', type=int, help='Port of arkouda server')
-    parser.add_argument('-n', '--size', type=int, default=10**3, help='Problem size: length of array to argsort')
+    parser.add_argument("hostname", help="Hostname of arkouda server")
+    parser.add_argument("port", type=int, help="Port of arkouda server")
+    parser.add_argument(
+        "-n", "--size", type=int, default=10**3, help="Problem size: length of array to argsort"
+    )
     return parser
+
 
 if __name__ == "__main__":
     import sys
+
     parser = create_parser()
     args = parser.parse_args()
     ak.verbose = False

--- a/tests/compare_test.py
+++ b/tests/compare_test.py
@@ -1,16 +1,17 @@
 import numpy as np
-from context import arkouda as ak
 from base_test import ArkoudaTest
+from context import arkouda as ak
 
 N = 1_000_000
 
-'''
-The CompareTest class encapsulates unit tests that compare the results of analogous  
-method invocations against Numpy ndarrays and Arkouda pdarrays to ensure equivalent 
+"""
+The CompareTest class encapsulates unit tests that compare the results of analogous
+method invocations against Numpy ndarrays and Arkouda pdarrays to ensure equivalent
 results are generated.
-'''
-class CompareTest(ArkoudaTest):
+"""
 
+
+class CompareTest(ArkoudaTest):
     def test_compare_arange(self):
         # create np version
         nArange = np.arange(N)
@@ -93,83 +94,83 @@ class CompareTest(ArkoudaTest):
     def test_compare_get_bool_iv(self):
         # create np version
         a = np.arange(N)
-        a = a[a < N//2]
+        a = a[a < N // 2]
         # create ak version
         b = ak.arange(N)
-        b = b[b < N//2]
+        b = b[b < N // 2]
         self.assertEqual(a.all(), b.to_ndarray().all())
 
     def test_compare_set_bool_iv_value(self):
         # create np version
         a = np.arange(N)
-        a[a < N//2] = -1
+        a[a < N // 2] = -1
         # create ak version
         b = ak.arange(N)
-        b[b < N//2] = -1
+        b[b < N // 2] = -1
         self.assertEqual(a.all(), b.to_ndarray().all())
 
     def check_set_bool_iv(self):
         # create np version
         a = np.arange(N)
-        a[a < N//2] = a[:N//2] * -1
+        a[a < N // 2] = a[: N // 2] * -1
         # create ak version
         b = ak.arange(N)
-        b[b < N//2] = b[:N//2] * -1
+        b[b < N // 2] = b[: N // 2] * -1
         self.assertEqual(a.all(), b.to_ndarray().all())
-       
+
     def check_get_integer_iv(self):
         # create np version
         a = np.arange(N)
-        iv = np.arange(N//2)
+        iv = np.arange(N // 2)
         a = a[iv]
         # create ak version
         b = ak.arange(N)
-        iv = ak.arange(N//2)
+        iv = ak.arange(N // 2)
         b = b[iv]
         self.assertEqual(a.all(), b.to_ndarray().all())
 
     def test_compare_set_integer_iv_val(self):
         # create np version
         a = np.arange(N)
-        iv = np.arange(N//2)
+        iv = np.arange(N // 2)
         a[iv] = -1
         # create ak version
         b = ak.arange(N)
-        iv = ak.arange(N//2)
+        iv = ak.arange(N // 2)
         b[iv] = -1
         self.assertEqual(a.all(), b.to_ndarray().all())
 
     def test_compare_set_integer_iv(self):
         # create np version
         a = np.arange(N)
-        iv = np.arange(N//2)
-        a[iv] = iv*10
+        iv = np.arange(N // 2)
+        a[iv] = iv * 10
         # create ak version
         b = ak.arange(N)
-        iv = ak.arange(N//2)
-        b[iv] = iv*10
+        iv = ak.arange(N // 2)
+        b[iv] = iv * 10
         self.assertEqual(a.all(), b.to_ndarray().all())
 
     def test_compare_get_integer_idx(self):
         # create np version
         a = np.arange(N)
-        v1 = a[N//2]
+        v1 = a[N // 2]
         # create ak version
         b = ak.arange(N)
-        v2 = b[N//2]
+        v2 = b[N // 2]
         self.assertEqual(v1, v2)
         self.assertEqual(a[-1], b[-1])
 
     def test_compare_set_integer_idx(self):
         # create np version
         a = np.arange(N)
-        a[N//2] = -1
+        a[N // 2] = -1
         a[-1] = -1
-        v1 = a[N//2]
+        v1 = a[N // 2]
         # create ak version
         b = ak.arange(N)
-        b[N//2] = -1
+        b[N // 2] = -1
         b[-1] = -1
-        v2 = b[N//2]
+        v2 = b[N // 2]
         self.assertEqual(v1, v2)
         self.assertEqual(a[-1], b[-1])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,15 @@
 import os
+
 import pytest
-from util.test.util import get_arkouda_numlocales, start_arkouda_server, \
-     TestRunningMode
+
+from util.test.util import TestRunningMode, get_arkouda_numlocales, start_arkouda_server
+
 
 def pytest_addoption(parser):
     parser.addoption(
         "--optional-parquet", action="store_true", default=False, help="run optional parquet tests"
     )
+
 
 def pytest_collection_modifyitems(config, items):
     if config.getoption("--optional-parquet"):
@@ -17,20 +20,28 @@ def pytest_collection_modifyitems(config, items):
         if "optional_parquet" in item.keywords:
             item.add_marker(skip_parquet)
 
+
 def pytest_configure(config):
     config.addinivalue_line("markers", "optional_parquet: mark test as slow to run")
-    port = int(os.getenv('ARKOUDA_SERVER_PORT', 5555))
-    server = os.getenv('ARKOUDA_SERVER_HOST', 'localhost')
-    test_server_mode = TestRunningMode(os.getenv('ARKOUDA_RUNNING_MODE','GLOBAL_SERVER'))
-    
+    port = int(os.getenv("ARKOUDA_SERVER_PORT", 5555))
+    server = os.getenv("ARKOUDA_SERVER_HOST", "localhost")
+    test_server_mode = TestRunningMode(os.getenv("ARKOUDA_RUNNING_MODE", "GLOBAL_SERVER"))
+
     if TestRunningMode.GLOBAL_SERVER == test_server_mode:
-        try: 
+        try:
             nl = get_arkouda_numlocales()
             server, _, _ = start_arkouda_server(numlocales=nl, port=port)
-            print(('Started arkouda_server in GLOBAL_SERVER running mode host: {} ' +
-                  'port: {} locales: {}').format(server, port, nl))
+            print(
+                (
+                    "Started arkouda_server in GLOBAL_SERVER running mode host: {} "
+                    + "port: {} locales: {}"
+                ).format(server, port, nl)
+            )
         except Exception as e:
-            raise RuntimeError('in configuring or starting the arkouda_server: {}, check ' +
-                     'environment and/or arkouda_server installation', e)
+            raise RuntimeError(
+                "in configuring or starting the arkouda_server: {}, check "
+                + "environment and/or arkouda_server installation",
+                e,
+            )
     else:
-        print('in client stack test mode with host: {} port: {}'.format(server, port))
+        print("in client stack test mode with host: {} port: {}".format(server, port))

--- a/tests/context.py
+++ b/tests/context.py
@@ -1,5 +1,6 @@
 import os
 import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 import arkouda
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -337,33 +337,17 @@ class DataFrameTest(ArkoudaTest):
         self.assertListEqual(c.values.to_ndarray().tolist(), [3, 1, 2])
 
     def test_to_pandas(self):
-        username = ak.array(["Alice", "Bob", "Alice", "Carol", "Bob", "Alice"])
-        userid = ak.array([111, 222, 111, 333, 222, 111])
-        item = ak.array([0, 0, 1, 1, 2, 0])
-        day = ak.array([5, 5, 6, 5, 6, 6])
-        amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
-        df = ak.DataFrame(
-            {"userName": username, "userID": userid, "item": item, "day": day, "amount": amount}
-        )
+        df = build_ak_df()
+        pd_df = build_pd_df()
 
-        pddf = df.to_pandas()
-        data = [
-            ["Alice", 111, 0, 5, 0.5],
-            ["Bob", 222, 0, 5, 0.6],
-            ["Alice", 111, 1, 6, 1.1],
-            ["Carol", 333, 1, 5, 1.2],
-            ["Bob", 222, 2, 6, 4.3],
-            ["Alice", 111, 0, 6, 0.6],
-        ]
-        test_df = pd.DataFrame(data, columns=["userName", "userID", "item", "day", "amount"])
-        self.assertTrue(pddf.equals(test_df))
+        self.assertTrue(pd_df.equals(df.to_pandas()))
 
         slice_df = df[ak.array([1, 3, 5])]
-        pddf = slice_df.to_pandas(retain_index=True)
-        self.assertEqual(pddf.index.tolist(), [1, 3, 5])
+        pd_df = slice_df.to_pandas(retain_index=True)
+        self.assertEqual(pd_df.index.tolist(), [1, 3, 5])
 
-        pddf = slice_df.to_pandas()
-        self.assertEqual(pddf.index.tolist(), [0, 1, 2])
+        pd_df = slice_df.to_pandas()
+        self.assertEqual(pd_df.index.tolist(), [0, 1, 2])
 
     def test_argsort(self):
         df = build_ak_df()

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -1,87 +1,91 @@
-import pandas as pd  # type: ignore
+import glob
+import os
 import random
 import string
-
-import os, glob
 from shutil import rmtree
-import pytest
 
+import pandas as pd  # type: ignore
+import pytest
 from base_test import ArkoudaTest
 from context import arkouda as ak
 
 
 def build_ak_df():
-    username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+    username = ak.array(["Alice", "Bob", "Alice", "Carol", "Bob", "Alice"])
     userid = ak.array([111, 222, 111, 333, 222, 111])
     item = ak.array([0, 0, 1, 1, 2, 0])
     day = ak.array([5, 5, 6, 5, 6, 6])
     amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
-    return ak.DataFrame({'userName': username, 'userID': userid,
-                         'item': item, 'day': day, 'amount': amount})
+    return ak.DataFrame(
+        {"userName": username, "userID": userid, "item": item, "day": day, "amount": amount}
+    )
 
 
 def build_ak_df_duplicates():
-    username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+    username = ak.array(["Alice", "Bob", "Alice", "Carol", "Bob", "Alice"])
     userid = ak.array([111, 222, 111, 333, 222, 111])
     item = ak.array([0, 1, 0, 2, 1, 0])
     day = ak.array([5, 5, 5, 5, 5, 5])
-    return ak.DataFrame({'userName': username, 'userID': userid,
-                         'item': item, 'day': day})
+    return ak.DataFrame({"userName": username, "userID": userid, "item": item, "day": day})
 
 
 def build_ak_append():
-    username = ak.array(['John', 'Carol'])
+    username = ak.array(["John", "Carol"])
     userid = ak.array([444, 333])
     item = ak.array([0, 2])
     day = ak.array([1, 2])
     amount = ak.array([0.5, 5.1])
-    return ak.DataFrame({'userName': username, 'userID': userid,
-                         'item': item, 'day': day, 'amount': amount})
+    return ak.DataFrame(
+        {"userName": username, "userID": userid, "item": item, "day": day, "amount": amount}
+    )
 
 
 def build_ak_keyerror():
     userid = ak.array([444, 333])
     item = ak.array([0, 2])
-    return ak.DataFrame({'user_id': userid, 'item': item})
+    return ak.DataFrame({"user_id": userid, "item": item})
 
 
 def build_ak_typeerror():
     username = ak.array([111, 222, 111, 333, 222, 111])
-    userid = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+    userid = ak.array(["Alice", "Bob", "Alice", "Carol", "Bob", "Alice"])
     item = ak.array([0, 0, 1, 1, 2, 0])
     day = ak.array([5, 5, 6, 5, 6, 6])
     amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
-    return ak.DataFrame({'userName': username, 'userID': userid,
-                         'item': item, 'day': day, 'amount': amount})
+    return ak.DataFrame(
+        {"userName": username, "userID": userid, "item": item, "day": day, "amount": amount}
+    )
 
 
 def build_pd_df():
-    username = ['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice']
+    username = ["Alice", "Bob", "Alice", "Carol", "Bob", "Alice"]
     userid = [111, 222, 111, 333, 222, 111]
     item = [0, 0, 1, 1, 2, 0]
     day = [5, 5, 6, 5, 6, 6]
     amount = [0.5, 0.6, 1.1, 1.2, 4.3, 0.6]
-    return pd.DataFrame({'userName': username, 'userID': userid,
-                         'item': item, 'day': day, 'amount': amount})
+    return pd.DataFrame(
+        {"userName": username, "userID": userid, "item": item, "day": day, "amount": amount}
+    )
 
 
 def build_pd_df_duplicates():
-    username = ['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice']
+    username = ["Alice", "Bob", "Alice", "Carol", "Bob", "Alice"]
     userid = [111, 222, 111, 333, 222, 111]
     item = [0, 1, 0, 2, 1, 0]
     day = [5, 5, 5, 5, 5, 5]
-    return pd.DataFrame({'userName': username, 'userID': userid,
-                         'item': item, 'day': day})
+    return pd.DataFrame({"userName": username, "userID": userid, "item": item, "day": day})
 
 
 def build_pd_df_append():
-    username = ['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice', 'John', 'Carol']
+    username = ["Alice", "Bob", "Alice", "Carol", "Bob", "Alice", "John", "Carol"]
     userid = [111, 222, 111, 333, 222, 111, 444, 333]
     item = [0, 0, 1, 1, 2, 0, 0, 2]
     day = [5, 5, 6, 5, 6, 6, 1, 2]
     amount = [0.5, 0.6, 1.1, 1.2, 4.3, 0.6, 0.5, 5.1]
-    return pd.DataFrame({'userName': username, 'userID': userid,
-                         'item': item, 'day': day, 'amount': amount})
+    return pd.DataFrame(
+        {"userName": username, "userID": userid, "item": item, "day": day, "amount": amount}
+    )
+
 
 class DataFrameTest(ArkoudaTest):
     def test_dataframe_creation(self):
@@ -100,10 +104,10 @@ class DataFrameTest(ArkoudaTest):
     def test_boolean_indexing(self):
         df = build_ak_df()
         ref_df = build_pd_df()
-        row = df[df['userName'] == 'Carol']
+        row = df[df["userName"] == "Carol"]
 
         self.assertEqual(len(row), 1)
-        self.assertTrue(ref_df[ref_df['userName'] == 'Carol'].equals(row.to_pandas(retain_index=True)))
+        self.assertTrue(ref_df[ref_df["userName"] == "Carol"].equals(row.to_pandas(retain_index=True)))
 
     def test_column_indexing(self):
         df = build_ak_df()
@@ -112,46 +116,36 @@ class DataFrameTest(ArkoudaTest):
         self.assertTrue(isinstance(df.item, ak.Series))
         self.assertTrue(isinstance(df.day, ak.Series))
         self.assertTrue(isinstance(df.amount, ak.Series))
-        for col in ('userName', 'userID', 'item', 'day', 'amount'):
-            self.assertTrue(isinstance(df['userName'], (ak.pdarray, ak.Strings, ak.Categorical)))
-        self.assertTrue(isinstance(df[['userName', 'amount']], ak.DataFrame))
-        self.assertTrue(isinstance(df[('userID', 'item', 'day')], ak.DataFrame))
+        for col in ("userName", "userID", "item", "day", "amount"):
+            self.assertTrue(isinstance(df["userName"], (ak.pdarray, ak.Strings, ak.Categorical)))
+        self.assertTrue(isinstance(df[["userName", "amount"]], ak.DataFrame))
+        self.assertTrue(isinstance(df[("userID", "item", "day")], ak.DataFrame))
         self.assertTrue(isinstance(df.index, ak.Index))
 
     def test_dtype_prop(self):
-        str_arr = ak.array(["".join(random.choices(string.ascii_letters + string.digits, k=5)) for _ in range(3)])
+        str_arr = ak.array(
+            ["".join(random.choices(string.ascii_letters + string.digits, k=5)) for _ in range(3)]
+        )
         df_dict = {
             "i": ak.arange(3),
             "c_1": ak.arange(3, 6, 1),
             "c_2": ak.arange(6, 9, 1),
             "c_3": str_arr,
             "c_4": ak.Categorical(str_arr),
-            "c_5": ak.SegArray(ak.array([0, 9, 14]), ak.arange(20))
+            "c_5": ak.SegArray(ak.array([0, 9, 14]), ak.arange(20)),
         }
         akdf = ak.DataFrame(df_dict)
         self.assertEqual(len(akdf.columns), len(akdf.dtypes))
 
-    def test_to_pandas(self):
-        df = build_ak_df()
-        pd_df = build_pd_df()
-
-        self.assertTrue(pd_df.equals(df.to_pandas()))
-
-        slice_df = df[[1, 3, 5]]
-        pd_df = slice_df.to_pandas(retain_index=True)
-        self.assertEqual(pd_df.index.tolist(), [1, 3, 5])
-
-        pd_df = slice_df.to_pandas()
-        self.assertEqual(pd_df.index.tolist(), [0, 1, 2])
-
     def test_from_pandas(self):
-        username = ['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice', 'John', 'Carol']
+        username = ["Alice", "Bob", "Alice", "Carol", "Bob", "Alice", "John", "Carol"]
         userid = [111, 222, 111, 333, 222, 111, 444, 333]
         item = [0, 0, 1, 1, 2, 0, 0, 2]
         day = [5, 5, 6, 5, 6, 6, 1, 2]
         amount = [0.5, 0.6, 1.1, 1.2, 4.3, 0.6, 0.5, 5.1]
-        ref_df = pd.DataFrame({'userName': username, 'userID': userid,
-                               'item': item, 'day': day, 'amount': amount})
+        ref_df = pd.DataFrame(
+            {"userName": username, "userID": userid, "item": item, "day": day, "amount": amount}
+        )
 
         df = ak.DataFrame(ref_df)
 
@@ -159,7 +153,6 @@ class DataFrameTest(ArkoudaTest):
 
         df = ak.DataFrame.from_pandas(ref_df)
         self.assertTrue(((ref_df == df.to_pandas()).all()).all())
-
 
     def test_drop(self):
         # create an arkouda df.
@@ -173,13 +166,13 @@ class DataFrameTest(ArkoudaTest):
         pddf_drop.reset_index(drop=True, inplace=True)
         self.assertTrue(pddf_drop.equals(df_drop.to_pandas()))
 
-        df_drop = df.drop('userName', axis=1)
-        pddf_drop = pd_df.drop(labels=['userName'], axis=1)
+        df_drop = df.drop("userName", axis=1)
+        pddf_drop = pd_df.drop(labels=["userName"], axis=1)
         self.assertTrue(pddf_drop.equals(df_drop.to_pandas()))
 
         # Test dropping columns
-        df.drop('userName', axis=1, inplace=True)
-        pd_df.drop(labels=['userName'], axis=1, inplace=True)
+        df.drop("userName", axis=1, inplace=True)
+        pd_df.drop(labels=["userName"], axis=1, inplace=True)
 
         self.assertTrue(((df.to_pandas() == pd_df).all()).all())
 
@@ -193,11 +186,11 @@ class DataFrameTest(ArkoudaTest):
 
         # verify that index keys must be ints
         with self.assertRaises(TypeError):
-            df.drop('index')
+            df.drop("index")
 
         # verify axis can only be 0 or 1
         with self.assertRaises(ValueError):
-            df.drop('amount', 15)
+            df.drop("amount", 15)
 
     def test_drop_duplicates(self):
         df = build_ak_df_duplicates()
@@ -208,8 +201,8 @@ class DataFrameTest(ArkoudaTest):
         # pandas retains original indexes when dropping dups, need to reset to line up with arkouda
         dedup_pd.reset_index(drop=True, inplace=True)
 
-        dedup_test = dedup.to_pandas().sort_values('userName').reset_index(drop=True)
-        dedup_pd_test = dedup_pd.sort_values('userName').reset_index(drop=True)
+        dedup_test = dedup.to_pandas().sort_values("userName").reset_index(drop=True)
+        dedup_pd_test = dedup_pd.sort_values("userName").reset_index(drop=True)
 
         self.assertTrue(dedup_test.equals(dedup_pd_test))
 
@@ -236,26 +229,25 @@ class DataFrameTest(ArkoudaTest):
     def test_rename(self):
         df = build_ak_df()
 
-        rename = {'userName': 'name_col', 'userID': 'user_id'}
+        rename = {"userName": "name_col", "userID": "user_id"}
 
-        #Test out of Place
+        # Test out of Place
         df_rename = df.rename(rename)
         self.assertIn("user_id", df_rename.columns)
         self.assertIn("name_col", df_rename.columns)
-        self.assertNotIn('userName', df_rename.columns)
-        self.assertNotIn('userID', df_rename.columns)
+        self.assertNotIn("userName", df_rename.columns)
+        self.assertNotIn("userID", df_rename.columns)
         self.assertIn("userID", df.columns)
         self.assertIn("userName", df.columns)
-        self.assertNotIn('user_id', df.columns)
-        self.assertNotIn('name_col', df.columns)
-
+        self.assertNotIn("user_id", df.columns)
+        self.assertNotIn("name_col", df.columns)
 
         # Test in place
         df.rename(rename, inplace=True)
         self.assertIn("user_id", df.columns)
         self.assertIn("name_col", df.columns)
-        self.assertNotIn('userName', df.columns)
-        self.assertNotIn('userID', df.columns)
+        self.assertNotIn("userName", df.columns)
+        self.assertNotIn("userID", df.columns)
 
     def test_append(self):
         df = build_ak_df()
@@ -314,54 +306,56 @@ class DataFrameTest(ArkoudaTest):
     def test_groupby_standard(self):
         df = build_ak_df()
 
-        gb = df.GroupBy('userName')
+        gb = df.GroupBy("userName")
         keys, count = gb.count()
-        self.assertTrue(keys.to_ndarray().tolist(), ['Alice', 'Carol', 'Bob'])
+        self.assertTrue(keys.to_ndarray().tolist(), ["Alice", "Carol", "Bob"])
         self.assertListEqual(count.to_ndarray().tolist(), [3, 1, 2])
         self.assertListEqual(gb.permutation.to_ndarray().tolist(), [0, 2, 5, 3, 1, 4])
 
-        gb = df.GroupBy(['userName', 'userID'])
+        gb = df.GroupBy(["userName", "userID"])
         keys, count = gb.count()
         self.assertEqual(len(keys), 2)
-        self.assertListEqual(keys[0].to_ndarray().tolist(), ['Carol', 'Alice', 'Bob'])
+        self.assertListEqual(keys[0].to_ndarray().tolist(), ["Carol", "Alice", "Bob"])
         self.assertTrue(keys[1].to_ndarray().tolist(), [111, 333, 222])
         self.assertTrue(count.to_ndarray().tolist(), [3, 1, 2])
 
     def test_gb_series(self):
-        username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+        username = ak.array(["Alice", "Bob", "Alice", "Carol", "Bob", "Alice"])
         userid = ak.array([111, 222, 111, 333, 222, 111])
         item = ak.array([0, 0, 1, 1, 2, 0])
         day = ak.array([5, 5, 6, 5, 6, 6])
         amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
-        df = ak.DataFrame({'userName': username, 'userID': userid,
-                           'item': item, 'day': day, 'amount': amount})
+        df = ak.DataFrame(
+            {"userName": username, "userID": userid, "item": item, "day": day, "amount": amount}
+        )
 
-        gb = df.GroupBy('userName', use_series=True)
+        gb = df.GroupBy("userName", use_series=True)
 
         c = gb.count()
         self.assertIsInstance(c, ak.Series)
-        self.assertListEqual(c.index.to_pandas().tolist(), ['Alice', 'Carol', 'Bob'])
+        self.assertListEqual(c.index.to_pandas().tolist(), ["Alice", "Carol", "Bob"])
         self.assertListEqual(c.values.to_ndarray().tolist(), [3, 1, 2])
 
     def test_to_pandas(self):
-        username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+        username = ak.array(["Alice", "Bob", "Alice", "Carol", "Bob", "Alice"])
         userid = ak.array([111, 222, 111, 333, 222, 111])
         item = ak.array([0, 0, 1, 1, 2, 0])
         day = ak.array([5, 5, 6, 5, 6, 6])
         amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
-        df = ak.DataFrame({'userName': username, 'userID': userid,
-                           'item': item, 'day': day, 'amount': amount})
+        df = ak.DataFrame(
+            {"userName": username, "userID": userid, "item": item, "day": day, "amount": amount}
+        )
 
         pddf = df.to_pandas()
         data = [
-            ['Alice', 111, 0, 5, 0.5],
-            ['Bob', 222, 0, 5, 0.6],
-            ['Alice', 111, 1, 6, 1.1],
-            ['Carol', 333, 1, 5, 1.2],
-            ['Bob', 222, 2, 6, 4.3],
-            ['Alice', 111, 0, 6, 0.6]
+            ["Alice", 111, 0, 5, 0.5],
+            ["Bob", 222, 0, 5, 0.6],
+            ["Alice", 111, 1, 6, 1.1],
+            ["Carol", 333, 1, 5, 1.2],
+            ["Bob", 222, 2, 6, 4.3],
+            ["Alice", 111, 0, 6, 0.6],
         ]
-        test_df = pd.DataFrame(data, columns=['userName', 'userID', 'item', 'day', 'amount'])
+        test_df = pd.DataFrame(data, columns=["userName", "userID", "item", "day", "amount"])
         self.assertTrue(pddf.equals(test_df))
 
         slice_df = df[ak.array([1, 3, 5])]
@@ -374,20 +368,19 @@ class DataFrameTest(ArkoudaTest):
     def test_argsort(self):
         df = build_ak_df()
 
-        p = df.argsort(key='userName')
+        p = df.argsort(key="userName")
         self.assertListEqual(p.to_ndarray().tolist(), [0, 2, 5, 1, 4, 3])
 
-        p = df.argsort(key='userName', ascending=False)
+        p = df.argsort(key="userName", ascending=False)
         self.assertListEqual(p.to_ndarray().tolist(), [3, 4, 1, 5, 2, 0])
 
     def test_coargsort(self):
         df = build_ak_df()
 
-
-        p = df.coargsort(keys=['userID', 'amount'])
+        p = df.coargsort(keys=["userID", "amount"])
         self.assertListEqual(p.to_ndarray().tolist(), [0, 5, 2, 1, 4, 3])
 
-        p = df.coargsort(keys=['userID', 'amount'], ascending=False)
+        p = df.coargsort(keys=["userID", "amount"], ascending=False)
         self.assertListEqual(p.to_ndarray().tolist(), [3, 4, 1, 2, 5, 0])
 
     def test_sort_values(self):
@@ -397,39 +390,39 @@ class DataFrameTest(ArkoudaTest):
         # sort userid to build dataframes to reference
         userid.sort()
 
-        df = ak.DataFrame({'userID': userid_ak})
+        df = ak.DataFrame({"userID": userid_ak})
         ord = df.sort_values()
-        self.assertTrue(ord.to_pandas().equals(pd.DataFrame(data=userid, columns=['userID'])))
+        self.assertTrue(ord.to_pandas().equals(pd.DataFrame(data=userid, columns=["userID"])))
         ord = df.sort_values(ascending=False)
         userid.reverse()
-        self.assertTrue(ord.to_pandas().equals(pd.DataFrame(data=userid, columns=['userID'])))
+        self.assertTrue(ord.to_pandas().equals(pd.DataFrame(data=userid, columns=["userID"])))
 
         df = build_ak_df()
-        ord = df.sort_values(by='userID')
+        ord = df.sort_values(by="userID")
         ref_df = build_pd_df()
-        ref_df = ref_df.sort_values(by='userID').reset_index(drop=True)
+        ref_df = ref_df.sort_values(by="userID").reset_index(drop=True)
         self.assertTrue(ref_df.equals(ord.to_pandas()))
 
-        ord = df.sort_values(by=['userID', 'day'])
-        ref_df = ref_df.sort_values(by=['userID', 'day']).reset_index(drop=True)
+        ord = df.sort_values(by=["userID", "day"])
+        ref_df = ref_df.sort_values(by=["userID", "day"]).reset_index(drop=True)
         self.assertTrue(ref_df.equals(ord.to_pandas()))
 
         with self.assertRaises(TypeError):
             df.sort_values(by=1)
 
     def test_intx(self):
-        username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+        username = ak.array(["Alice", "Bob", "Alice", "Carol", "Bob", "Alice"])
         userid = ak.array([111, 222, 111, 333, 222, 111])
-        df_1 = ak.DataFrame({'user_name': username, 'user_id': userid})
+        df_1 = ak.DataFrame({"user_name": username, "user_id": userid})
 
-        username = ak.array(['Bob', 'Alice'])
+        username = ak.array(["Bob", "Alice"])
         userid = ak.array([222, 445])
-        df_2 = ak.DataFrame({'user_name': username, 'user_id': userid})
+        df_2 = ak.DataFrame({"user_name": username, "user_id": userid})
 
         rows = ak.intx(df_1, df_2)
         self.assertListEqual(rows.to_ndarray().tolist(), [False, True, False, False, True, False])
 
-        df_3 = ak.DataFrame({'user_name': username, 'user_number': userid})
+        df_3 = ak.DataFrame({"user_name": username, "user_number": userid})
         with self.assertRaises(ValueError):
             rows = ak.intx(df_1, df_3)
 
@@ -437,21 +430,21 @@ class DataFrameTest(ArkoudaTest):
         df = build_ak_df()
         ref_df = build_pd_df()
 
-        ord = df.sort_values(by='userID')
+        ord = df.sort_values(by="userID")
         perm_list = [0, 3, 1, 5, 4, 2]
         default_perm = ak.array(perm_list)
         ord.apply_permutation(default_perm)
 
-        ord_ref = ref_df.sort_values(by='userID').reset_index(drop=True)
+        ord_ref = ref_df.sort_values(by="userID").reset_index(drop=True)
         ord_ref = ord_ref.reindex(perm_list).reset_index(drop=True)
         self.assertTrue(ord_ref.equals(ord.to_pandas()))
 
     def test_filter_by_range(self):
         userid = ak.array([111, 222, 111, 333, 222, 111])
         amount = ak.array([0, 1, 1, 2, 3, 15])
-        df = ak.DataFrame({'userID': userid, 'amount': amount})
+        df = ak.DataFrame({"userID": userid, "amount": amount})
 
-        filtered = df.filter_by_range(keys=['userID'], low=1, high=2)
+        filtered = df.filter_by_range(keys=["userID"], low=1, high=2)
         self.assertFalse(filtered[0])
         self.assertTrue(filtered[1])
         self.assertFalse(filtered[2])
@@ -460,18 +453,18 @@ class DataFrameTest(ArkoudaTest):
         self.assertFalse(filtered[5])
 
     def test_copy(self):
-        username = ak.array(['Alice', 'Bob', 'Alice', 'Carol', 'Bob', 'Alice'])
+        username = ak.array(["Alice", "Bob", "Alice", "Carol", "Bob", "Alice"])
         userid = ak.array([111, 222, 111, 333, 222, 111])
-        df = ak.DataFrame({'userName': username, 'userID': userid})
+        df = ak.DataFrame({"userName": username, "userID": userid})
 
         df_copy = df.copy(deep=True)
         self.assertEqual(df.__repr__(), df_copy.__repr__())
 
-        df_copy.__setitem__('userID', ak.array([1, 2, 1, 3, 2, 1]))
+        df_copy.__setitem__("userID", ak.array([1, 2, 1, 3, 2, 1]))
         self.assertNotEqual(df.__repr__(), df_copy.__repr__())
 
         df_copy = df.copy(deep=False)
-        df_copy.__setitem__('userID', ak.array([1, 2, 1, 3, 2, 1]))
+        df_copy.__setitem__("userID", ak.array([1, 2, 1, 3, 2, 1]))
         self.assertEqual(df.__repr__(), df_copy.__repr__())
 
     def test_save_table(self):
@@ -479,30 +472,28 @@ class DataFrameTest(ArkoudaTest):
         i = list(range(3))
         c1 = [9, 7, 17]
         c2 = [2, 4, 6]
-        df_dict = {
-            "i": ak.array(i),
-            "c_1": ak.array(c1),
-            "c_2": ak.array(c2)
-        }
+        df_dict = {"i": ak.array(i), "c_1": ak.array(c1), "c_2": ak.array(c2)}
 
         akdf = ak.DataFrame(df_dict)
 
-        validation_df = pd.DataFrame({
-            "i": i,
-            "c_1": c1,
-            "c_2": c2,
-        })
+        validation_df = pd.DataFrame(
+            {
+                "i": i,
+                "c_1": c1,
+                "c_2": c2,
+            }
+        )
 
         # make directory to save to so pandas read works
         os.mkdir(d)
-        akdf.save_table(f"{d}/testName", file_format='Parquet')
+        akdf.save_table(f"{d}/testName", file_format="Parquet")
 
         ak_loaded = ak.DataFrame.load_table(f"{d}/testName")
         self.assertTrue(validation_df.equals(ak_loaded.to_pandas()))
 
         # test save with index true
-        akdf.save_table(f"{d}/testName_with_index.pq", file_format='Parquet', index=True)
-        self.assertTrue(len(glob.glob(f"{d}/testName_with_index*.pq")) == ak.get_config()['numLocales'])
+        akdf.save_table(f"{d}/testName_with_index.pq", file_format="Parquet", index=True)
+        self.assertTrue(len(glob.glob(f"{d}/testName_with_index*.pq")) == ak.get_config()["numLocales"])
 
         # Commenting the read into pandas out because it requires optional libraries
         # pddf = pd.read_parquet("save_table_test", engine='pyarrow')
@@ -512,31 +503,27 @@ class DataFrameTest(ArkoudaTest):
         rmtree("save_table_test/")
 
     def test_isin(self):
-        df = ak.DataFrame({
-            'col_A': ak.array([7, 3]),
-            'col_B': ak.array([1, 9])
-        })
+        df = ak.DataFrame({"col_A": ak.array([7, 3]), "col_B": ak.array([1, 9])})
 
         # test against pdarray
         test_df = df.isin(ak.array([0, 1]))
-        self.assertListEqual(test_df['col_A'].to_ndarray().tolist(), [False, False])
-        self.assertListEqual(test_df['col_B'].to_ndarray().tolist(), [True, False])
+        self.assertListEqual(test_df["col_A"].to_ndarray().tolist(), [False, False])
+        self.assertListEqual(test_df["col_B"].to_ndarray().tolist(), [True, False])
 
         # Test against dict
-        test_df = df.isin({'col_A': ak.array([0, 3])})
-        self.assertListEqual(test_df['col_A'].to_ndarray().tolist(), [False, True])
-        self.assertListEqual(test_df['col_B'].to_ndarray().tolist(), [False, False])
+        test_df = df.isin({"col_A": ak.array([0, 3])})
+        self.assertListEqual(test_df["col_A"].to_ndarray().tolist(), [False, True])
+        self.assertListEqual(test_df["col_B"].to_ndarray().tolist(), [False, False])
 
         # test against series
         i = ak.Index(ak.arange(2))
         s = ak.Series(data=ak.array([3, 9]), index=i.index)
         test_df = df.isin(s)
-        self.assertListEqual(test_df['col_A'].to_ndarray().tolist(), [False, False])
-        self.assertListEqual(test_df['col_B'].to_ndarray().tolist(), [False, True])
+        self.assertListEqual(test_df["col_A"].to_ndarray().tolist(), [False, False])
+        self.assertListEqual(test_df["col_B"].to_ndarray().tolist(), [False, True])
 
         # test against another dataframe
-        other_df = ak.DataFrame({'col_A': ak.array([7, 3]), 'col_C': ak.array([0, 9])})
+        other_df = ak.DataFrame({"col_A": ak.array([7, 3]), "col_C": ak.array([0, 9])})
         test_df = df.isin(other_df)
-        self.assertListEqual(test_df['col_A'].to_ndarray().tolist(), [True, True])
-        self.assertListEqual(test_df['col_B'].to_ndarray().tolist(), [False, False])
-
+        self.assertListEqual(test_df["col_A"].to_ndarray().tolist(), [True, True])
+        self.assertListEqual(test_df["col_B"].to_ndarray().tolist(), [False, False])

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -1,8 +1,10 @@
-from base_test import ArkoudaTest
-import arkouda as ak
-import pandas as pd
-import numpy as np
 import logging
+
+import pandas as pd
+from base_test import ArkoudaTest
+
+import arkouda as ak
+
 
 def build_op_table():
     ALL_OPS = ak.pdarray.BinOps - set(("<<<", ">>>"))
@@ -10,40 +12,44 @@ def build_op_table():
     for op in ALL_OPS:
         for firstclass in (ak.Datetime, ak.Timedelta):
             for secondclass in (ak.Datetime, ak.Timedelta, ak.pdarray):
-                is_supported = op in getattr(firstclass, 'supported_with_{}'.format(secondclass.__name__.lower()))
+                is_supported = op in getattr(
+                    firstclass, "supported_with_{}".format(secondclass.__name__.lower())
+                )
                 return_type = firstclass._get_callback(secondclass.__name__, op)
                 if return_type is ak.timeclass._identity:
                     return_type = ak.pdarray
-                r_is_supported = op in getattr(firstclass, 'supported_with_r_{}'.format(secondclass.__name__.lower()))
+                r_is_supported = op in getattr(
+                    firstclass, "supported_with_r_{}".format(secondclass.__name__.lower())
+                )
                 table[(firstclass, op, secondclass)] = (is_supported, r_is_supported, return_type)
     return table
-        
+
+
 class DatetimeTest(ArkoudaTest):
-        
     def setUp(self):
         ArkoudaTest.setUp(self)
-        self.dtvec1 = ak.date_range(start='2021-01-01 12:00:00', periods=100, freq='s')
-        self.dtvec2 = ak.Datetime(pd.date_range('2021-01-01 12:00:00', periods=100, freq='s'))
-        self.dtscalar = pd.Timestamp('2021-01-01 12:00:00')
-        self.tdvec1 = ak.timedelta_range(start='1 second', end='1 second', periods=100)
-        self.tdvec2 = ak.Timedelta(ak.ones(100, dtype=ak.int64), unit='s')
-        self.onesecond = pd.Timedelta(1, unit='s')
+        self.dtvec1 = ak.date_range(start="2021-01-01 12:00:00", periods=100, freq="s")
+        self.dtvec2 = ak.Datetime(pd.date_range("2021-01-01 12:00:00", periods=100, freq="s"))
+        self.dtscalar = pd.Timestamp("2021-01-01 12:00:00")
+        self.tdvec1 = ak.timedelta_range(start="1 second", end="1 second", periods=100)
+        self.tdvec2 = ak.Timedelta(ak.ones(100, dtype=ak.int64), unit="s")
+        self.onesecond = pd.Timedelta(1, unit="s")
 
     def test_creation(self):
         self.assertTrue((self.dtvec1 == self.dtvec2).all())
         self.assertTrue((self.tdvec1 == self.tdvec2).all())
-    
+
     def test_noop_creation(self):
         self.assertTrue((ak.Datetime(self.dtvec1) == self.dtvec1).all())
         self.assertTrue((ak.Timedelta(self.tdvec1) == self.tdvec1).all())
-    
+
     def test_roundtrip(self):
         d = ak.Datetime(self.dtvec1.to_ndarray())
         self.assertTrue((d == self.dtvec1).all())
 
     def test_plus_minus(self):
         # Datetime + Datetime not supported
-        with self.assertRaises(TypeError) as cm:
+        with self.assertRaises(TypeError):
             self.dtvec1 + self.dtvec2
         # Datetime slice -> Datetime
         leading = self.dtvec1[1:]
@@ -55,7 +61,7 @@ class DatetimeTest(ArkoudaTest):
         self.assertTrue((diff == self.onesecond).all())
         # Datetime - DatetimeScalar -> Timedelta
         diff = self.dtvec1 - self.dtscalar
-        trange = ak.timedelta_range(start=0, periods=100, freq='s')
+        trange = ak.timedelta_range(start=0, periods=100, freq="s")
         self.assertTrue(isinstance(diff, ak.Timedelta))
         self.assertTrue((diff == trange).all())
         # DatetimeScalar - Datetime -> Timedelta
@@ -63,11 +69,11 @@ class DatetimeTest(ArkoudaTest):
         self.assertTrue(isinstance(diff, ak.Timedelta))
         self.assertTrue((diff == (-trange)).all())
         # Datetime + TimedeltaScalar -> Datetime
-        t = (trailing + self.onesecond)
+        t = trailing + self.onesecond
         self.assertTrue(isinstance(t, ak.Datetime))
         self.assertTrue((t == leading).all())
         # TimedeltaScalar + Datetime -> Datetime
-        t = (self.onesecond + trailing)
+        t = self.onesecond + trailing
         self.assertTrue(isinstance(t, ak.Datetime))
         self.assertTrue((t == leading).all())
         # Datetime - TimedeltaScalar -> Datetime
@@ -75,47 +81,47 @@ class DatetimeTest(ArkoudaTest):
         self.assertTrue(isinstance(t, ak.Datetime))
         self.assertTrue((t == trailing).all())
         # Datetime + Timedelta -> Datetime
-        t = (trailing + self.tdvec1[1:])
+        t = trailing + self.tdvec1[1:]
         self.assertTrue(isinstance(t, ak.Datetime))
         self.assertTrue((t == leading).all())
         # Timedelta + Datetime -> Datetime
-        t = (self.tdvec1[1:] + trailing)
+        t = self.tdvec1[1:] + trailing
         self.assertTrue(isinstance(t, ak.Datetime))
         self.assertTrue((t == leading).all())
         # Datetime - Timedelat -> Datetime
-        t = (leading - self.tdvec1[1:])
+        t = leading - self.tdvec1[1:]
         self.assertTrue(isinstance(t, ak.Datetime))
         # Timedelta + Timedelta -> Timedelta
         t = self.tdvec1 + self.tdvec1
         self.assertTrue(isinstance(t, ak.Timedelta))
-        self.assertTrue((t == ak.Timedelta(2*ak.ones(100, dtype=ak.int64), unit='s')).all())
+        self.assertTrue((t == ak.Timedelta(2 * ak.ones(100, dtype=ak.int64), unit="s")).all())
         # Timedelta + TimedeltaScalar -> Timedelta
         t = self.tdvec1 + self.onesecond
         self.assertTrue(isinstance(t, ak.Timedelta))
-        self.assertTrue((t == ak.Timedelta(2*ak.ones(100, dtype=ak.int64), unit='s')).all())
+        self.assertTrue((t == ak.Timedelta(2 * ak.ones(100, dtype=ak.int64), unit="s")).all())
         # Timedelta - Timedelta -> Timedelta
         t = self.tdvec1 - self.tdvec1
         self.assertTrue(isinstance(t, ak.Timedelta))
-        self.assertTrue((t == ak.Timedelta(ak.zeros(100, dtype=ak.int64), unit='s')).all())
+        self.assertTrue((t == ak.Timedelta(ak.zeros(100, dtype=ak.int64), unit="s")).all())
         # Timedelta - TimedeltaScalar -> Timedelta
         t = self.tdvec1 - self.onesecond
         self.assertTrue(isinstance(t, ak.Timedelta))
-        self.assertTrue((t == ak.Timedelta(ak.zeros(100, dtype=ak.int64), unit='s')).all())
+        self.assertTrue((t == ak.Timedelta(ak.zeros(100, dtype=ak.int64), unit="s")).all())
 
     def test_op_types(self):
-        vectors = {ak.Datetime: self.dtvec1,
-                   ak.Timedelta: self.tdvec1,
-                   ak.pdarray: ak.arange(100)}
-        pdvectors = {ak.Datetime: pd.to_datetime(self.dtvec1.to_ndarray()),
-                     ak.Timedelta: pd.to_timedelta(self.tdvec1.to_ndarray()),
-                     ak.pdarray: pd.Series(ak.arange(100).to_ndarray())}
-        scalars = {ak.Datetime: self.dtscalar,
-                   ak.Timedelta: self.onesecond,
-                   ak.pdarray: 5}
-        metrics = {'ak_supported': 0,
-                   'ak_not_supported': 0,
-                   'ak_yes_pd_no':0}
-        for (firstclass, op, secondclass), (is_supported, r_is_supported, return_type) in build_op_table().items():
+        vectors = {ak.Datetime: self.dtvec1, ak.Timedelta: self.tdvec1, ak.pdarray: ak.arange(100)}
+        pdvectors = {
+            ak.Datetime: pd.to_datetime(self.dtvec1.to_ndarray()),
+            ak.Timedelta: pd.to_timedelta(self.tdvec1.to_ndarray()),
+            ak.pdarray: pd.Series(ak.arange(100).to_ndarray()),
+        }
+        scalars = {ak.Datetime: self.dtscalar, ak.Timedelta: self.onesecond, ak.pdarray: 5}
+        metrics = {"ak_supported": 0, "ak_not_supported": 0, "ak_yes_pd_no": 0}
+        for (firstclass, op, secondclass), (
+            is_supported,
+            r_is_supported,
+            return_type,
+        ) in build_op_table().items():
             fcvec = vectors[firstclass]
             pdfcvec = pdvectors[firstclass]
             fcsca = scalars[firstclass]
@@ -127,28 +133,36 @@ class DatetimeTest(ArkoudaTest):
                     eval("fcvec {} scvec".format(op))
                 with self.assertRaises(TypeError):
                     eval("fcvec {} scsca".format(op))
-                metrics['ak_not_supported'] += 1
+                metrics["ak_not_supported"] += 1
             else:
                 compareflag = True
                 ret = eval("fcvec {} scvec".format(op))
                 self.assertTrue(isinstance(ret, return_type))
-                metrics['ak_supported'] += 1
+                metrics["ak_supported"] += 1
                 try:
                     pdret = eval("pdfcvec {} pdscvec".format(op))
                 except TypeError:
-                    logging.getLogger().info("Pandas does not support {} {} {}".format(firstclass.__name__, op, secondclass.__name__))
-                    metrics['ak_yes_pd_no'] += 1
+                    logging.getLogger().info(
+                        "Pandas does not support {} {} {}".format(
+                            firstclass.__name__, op, secondclass.__name__
+                        )
+                    )
+                    metrics["ak_yes_pd_no"] += 1
                     compareflag = False
                 if compareflag:
                     # Arkouda currently does not handle NaT, so replace with zero
-                    if pdret.dtype.kind == 'm':
+                    if pdret.dtype.kind == "m":
                         pdret = pd.Series(pdret).fillna(pd.Timedelta(seconds=0))
                     else:
                         pdret = pd.Series(pdret).fillna(pd.Timestamp(0))
                     try:
                         self.assertTrue((pdret.values == ret.to_ndarray()).all())
                     except AssertionError as e:
-                        logging.getLogger().error("arkouda vs pandas discrepancy in {} {} {}:\n {} {}".format(firstclass.__name__, op, secondclass.__name__, ret, pdret))
+                        logging.getLogger().error(
+                            "arkouda vs pandas discrepancy in {} {} {}:\n {} {}".format(
+                                firstclass.__name__, op, secondclass.__name__, ret, pdret
+                            )
+                        )
                         raise e
 
                 compareflag = True
@@ -157,7 +171,11 @@ class DatetimeTest(ArkoudaTest):
                 try:
                     pdret = eval("pdfcvec {} scsca".format(op))
                 except TypeError:
-                    logging.getLogger().info("Pandas does not support {} {} {}".format(firstclass.__name__, op, secondclass.__name__))
+                    logging.getLogger().info(
+                        "Pandas does not support {} {} {}".format(
+                            firstclass.__name__, op, secondclass.__name__
+                        )
+                    )
                     compareflag = False
                 if compareflag:
                     self.assertTrue((pd.Series(pdret).values == ret.to_ndarray()).all())
@@ -165,46 +183,51 @@ class DatetimeTest(ArkoudaTest):
             if not r_is_supported:
                 with self.assertRaises(TypeError):
                     eval("scsca {} fcvec".format(op))
-                metrics['ak_not_supported'] += 1
+                metrics["ak_not_supported"] += 1
             else:
                 try:
                     ret = eval("scsca {} fcvec".format(op))
                 except Exception as e:
                     raise TypeError("{} scalar {} {}".format(secondclass, op, firstclass)) from e
                 self.assertTrue(isinstance(ret, return_type))
-                metrics['ak_supported'] += 1
+                metrics["ak_supported"] += 1
                 compareflag = True
                 try:
                     pdret = eval("scsca {} pdfcvec".format(op))
                 except TypeError:
-                    logging.getLogger().info("Pandas does not support {}(scalar) {} {}".format(secondclass.__name__, op, firstclass.__name__))
-                    metrics['ak_yes_pd_no'] += 1
+                    logging.getLogger().info(
+                        "Pandas does not support {}(scalar) {} {}".format(
+                            secondclass.__name__, op, firstclass.__name__
+                        )
+                    )
+                    metrics["ak_yes_pd_no"] += 1
                     compareflag = False
                 if compareflag:
                     try:
                         self.assertTrue((pd.Series(pdret).values == ret.to_ndarray()).all())
                     except AttributeError:
-                        logging.getLogger().error("Unexpected pandas return: {}(scalar) {} {} -> {}: {}".format(secondclass, op, firstclass, type(pdret), pdret))
+                        logging.getLogger().error(
+                            "Unexpected pandas return: {}(scalar) {} {} -> {}: {}".format(
+                                secondclass, op, firstclass, type(pdret), pdret
+                            )
+                        )
         logging.getLogger().info("{}".format(metrics.items()))
 
     def test_floor(self):
-        onemin = pd.Timedelta(1, unit='min')
-        floor = self.dtvec1.floor('m')
-        floor2 = self.dtvec1.to_pandas().floor('min')
+        floor = self.dtvec1.floor("m")
+        floor2 = self.dtvec1.to_pandas().floor("min")
         self.assertTrue(isinstance(floor, ak.Datetime))
         self.assertTrue((floor.to_pandas() == floor2).all())
 
     def test_ceil(self):
-        onemin = pd.Timedelta(1, unit='min')
-        ceil = self.dtvec1.ceil('m')
-        ceil2 = self.dtvec1.to_pandas().ceil('min')
+        ceil = self.dtvec1.ceil("m")
+        ceil2 = self.dtvec1.to_pandas().ceil("min")
         self.assertTrue(isinstance(ceil, ak.Datetime))
         self.assertTrue((ceil.to_pandas() == ceil2).all())
 
     def test_round(self):
-        onemin = pd.Timedelta(1, unit='min')
-        rd = self.dtvec1.round('m')
-        rd2 = self.dtvec1.to_pandas().round('min')
+        rd = self.dtvec1.round("m")
+        rd2 = self.dtvec1.to_pandas().round("min")
         self.assertTrue(isinstance(rd, ak.Datetime))
         try:
             self.assertTrue((rd.to_pandas() == rd2).all())
@@ -222,29 +245,30 @@ class DatetimeTest(ArkoudaTest):
         self.assertEqual(self.dtvec1.min(), self.dtvec1[0])
         self.assertEqual(self.dtvec1.max(), self.dtvec1[-1])
         self.assertEqual(self.dtvec1.argmin(), 0)
-        self.assertEqual(self.dtvec1.argmax(), self.dtvec1.size-1)
+        self.assertEqual(self.dtvec1.argmax(), self.dtvec1.size - 1)
         with self.assertRaises(TypeError):
             self.dtvec1.sum()
         self.assertEqual(self.tdvec1.min(), self.onesecond)
         self.assertEqual(self.tdvec1.max(), self.onesecond)
         self.assertEqual(self.tdvec1.argmin(), 0)
         self.assertEqual(self.tdvec1.argmax(), 0)
-        self.assertEqual(self.tdvec1.sum(), pd.Timedelta(self.tdvec1.size, unit='s'))
+        self.assertEqual(self.tdvec1.sum(), pd.Timedelta(self.tdvec1.size, unit="s"))
         self.assertTrue(((-self.tdvec1).abs() == self.tdvec1).all())
 
     def test_timedel_std(self):
-        # pandas std uses unbiased estimator by default, in order to compare we set ddof=1 for arkouda std
-        ak_timedel_std = ak.Timedelta(ak.array([123, 456, 789]), unit='s').std(ddof=1)
-        pd_timedel_std = pd.to_timedelta([123, 456, 789], unit='s').std()
+        # pandas std uses unbiased estimator by default, in order to compare we set
+        # ddof=1 for arkouda std
+        ak_timedel_std = ak.Timedelta(ak.array([123, 456, 789]), unit="s").std(ddof=1)
+        pd_timedel_std = pd.to_timedelta([123, 456, 789], unit="s").std()
 
         self.assertEqual(ak_timedel_std, pd_timedel_std)
 
     def test_scalars(self):
-        self.assertTrue((self.dtscalar <= self.dtvec1).all()) # pandas.Timestamp
-        self.assertTrue((self.dtscalar.to_pydatetime() <= self.dtvec1).all()) # datetime.datetime
+        self.assertTrue((self.dtscalar <= self.dtvec1).all())  # pandas.Timestamp
+        self.assertTrue((self.dtscalar.to_pydatetime() <= self.dtvec1).all())  # datetime.datetime
         # self.assertTrue((self.dtscalar.to_numpy() <= self.dtvec1).all()) # numpy.datetime64
-        self.assertTrue((self.onesecond == self.tdvec1).all()) # pandas.Timedelta
-        self.assertTrue((self.onesecond.to_pytimedelta() == self.tdvec1).all()) # datetime.timedelta
+        self.assertTrue((self.onesecond == self.tdvec1).all())  # pandas.Timedelta
+        self.assertTrue((self.onesecond.to_pytimedelta() == self.tdvec1).all())  # datetime.timedelta
         # self.assertTrue((self.onesecond.to_numpy() == self.tdvec1).all()) # numpy.timedelta64
 
     def test_units(self):
@@ -254,23 +278,28 @@ class DatetimeTest(ArkoudaTest):
             try:
                 self.assertEqual(pdval, akval)
             except AssertionError:
-                logging.getLogger().error("pandas {} ({}) != arkouda {} ({})".format(pdunit, pdval, akunit, akval))
+                logging.getLogger().error(
+                    "pandas {} ({}) != arkouda {} ({})".format(pdunit, pdval, akunit, akval)
+                )
             pdval = pd.Timedelta(1, unit=pdunit)
             akval = ak.Timedelta(ak.ones(10, dtype=ak.int64), unit=akunit)[0]
             try:
                 self.assertEqual(pdval, akval)
             except AssertionError:
-                logging.getLogger().error("pandas {} ({}) != arkouda {} ({})".format(pdunit, pdval, akunit, akval))
+                logging.getLogger().error(
+                    "pandas {} ({}) != arkouda {} ({})".format(pdunit, pdval, akunit, akval)
+                )
 
-        unitmap = {'W': ('weeks', 'w', 'week'),
-                   'D': ('days', 'd', 'day'),
-                   'h': ('hours', 'H', 'hr', 'hrs'),
-                   'T': ('minutes', 'minute', 'min', 'm'),
-                   'L': ('milliseconds', 'millisecond', 'milli', 'ms', 'l'),
-                   'U': ('microseconds', 'microsecond', 'micro', 'us', 'u'),
-                   'N': ('nanoseconds', 'nanosecond', 'nano', 'ns', 'n')}
+        unitmap = {
+            "W": ("weeks", "w", "week"),
+            "D": ("days", "d", "day"),
+            "h": ("hours", "H", "hr", "hrs"),
+            "T": ("minutes", "minute", "min", "m"),
+            "L": ("milliseconds", "millisecond", "milli", "ms", "l"),
+            "U": ("microseconds", "microsecond", "micro", "us", "u"),
+            "N": ("nanoseconds", "nanosecond", "nano", "ns", "n"),
+        }
         for pdunit, aliases in unitmap.items():
-            #check_equal(pdunit, pdunit)
-            for akunit in (pdunit,)+aliases:
+            # check_equal(pdunit, pdunit)
+            for akunit in (pdunit,) + aliases:
                 check_equal(pdunit, akunit)
-                

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -1,10 +1,9 @@
-import logging
-
-import pandas as pd
 from base_test import ArkoudaTest
 
 import arkouda as ak
 
+import pandas as pd
+import logging
 
 def build_op_table():
     ALL_OPS = ak.pdarray.BinOps - set(("<<<", ">>>"))

--- a/tests/dtypes_tests.py
+++ b/tests/dtypes_tests.py
@@ -1,21 +1,23 @@
 import numpy as np
-from context import arkouda as ak
-from arkouda import dtypes
 from base_test import ArkoudaTest
+from context import arkouda as ak
 
-'''
+from arkouda import dtypes
+
+"""
 DtypesTest encapsulates arkouda dtypes module methods
-'''
-class DtypesTest(ArkoudaTest):
+"""
 
+
+class DtypesTest(ArkoudaTest):
     def test_check_np_dtype(self):
-      
-        '''
-        Tests dtypes.check_np_dtype method 
-        
+
+        """
+        Tests dtypes.check_np_dtype method
+
         :return: None
         :raise: AssertionError if 1.. test cases fail
-        '''
+        """
         dtypes.check_np_dtype(np.dtype(np.bool_))
         dtypes.check_np_dtype(np.dtype(bool))
         dtypes.check_np_dtype(np.dtype(np.int64))
@@ -28,134 +30,147 @@ class DtypesTest(ArkoudaTest):
         with self.assertRaises(TypeError):
             dtypes.check_np_dtype(np.dtype(np.int16))
         with self.assertRaises(TypeError):
-            dtypes.check_np_dtype('np.str')
+            dtypes.check_np_dtype("np.str")
 
     def test_translate_np_dtype(self):
-        '''
+        """
         Tests dtypes.translate_np_dtype method
-        
+
         :return: None
         :raise: AssertionError if 1.. test cases fail
-        '''
+        """
         d_tuple = dtypes.translate_np_dtype(np.dtype(np.bool_))
         self.assertEqual(1, d_tuple[1])
-        self.assertEqual('bool', d_tuple[0])
+        self.assertEqual("bool", d_tuple[0])
         d_tuple = dtypes.translate_np_dtype(np.dtype(bool))
         self.assertEqual(1, d_tuple[1])
-        self.assertEqual('bool', d_tuple[0])
+        self.assertEqual("bool", d_tuple[0])
         d_tuple = dtypes.translate_np_dtype(np.dtype(np.int64))
         self.assertEqual(8, d_tuple[1])
-        self.assertEqual('int', d_tuple[0])
+        self.assertEqual("int", d_tuple[0])
         d_tuple = dtypes.translate_np_dtype(np.dtype(np.float64))
         self.assertEqual(8, d_tuple[1])
-        self.assertEqual('float', d_tuple[0])
+        self.assertEqual("float", d_tuple[0])
         d_tuple = dtypes.translate_np_dtype(np.dtype(np.uint8))
         self.assertEqual(1, d_tuple[1])
-        self.assertEqual('uint',d_tuple[0])
+        self.assertEqual("uint", d_tuple[0])
         d_tuple = dtypes.translate_np_dtype(np.dtype(np.str_))
         self.assertEqual(0, d_tuple[1])
-        self.assertEqual('str', d_tuple[0])
+        self.assertEqual("str", d_tuple[0])
         d_tuple = dtypes.translate_np_dtype(np.dtype(str))
         self.assertEqual(0, d_tuple[1])
-        self.assertEqual('str', d_tuple[0])
+        self.assertEqual("str", d_tuple[0])
 
         with self.assertRaises(TypeError):
             dtypes.check_np_dtype(np.dtype(np.int16))
         with self.assertRaises(TypeError):
-            dtypes.translate_np_dtype('np.str')
-            
+            dtypes.translate_np_dtype("np.str")
+
     def test_resolve_scalar_dtype(self):
-        '''
+        """
         Tests dtypes.resolve_scalar_dtype method
-        
+
         :return: None
         :raise: AssertionError if 1.. test cases fail
-        '''
-        self.assertEqual('bool', dtypes.resolve_scalar_dtype(True))
-        self.assertEqual('int64', dtypes.resolve_scalar_dtype(1))
-        self.assertEqual('float64', dtypes.resolve_scalar_dtype(float(0.0)))
-        self.assertEqual('str', dtypes.resolve_scalar_dtype('test'))
-        self.assertEqual('int64', dtypes.resolve_scalar_dtype(np.int64(1))) 
+        """
+        self.assertEqual("bool", dtypes.resolve_scalar_dtype(True))
+        self.assertEqual("int64", dtypes.resolve_scalar_dtype(1))
+        self.assertEqual("float64", dtypes.resolve_scalar_dtype(float(0.0)))
+        self.assertEqual("str", dtypes.resolve_scalar_dtype("test"))
+        self.assertEqual("int64", dtypes.resolve_scalar_dtype(np.int64(1)))
         self.assertEqual("<class 'list'>", dtypes.resolve_scalar_dtype([1]))
-        
+
     def test_pdarrays_datatypes(self):
-        self.assertEqual(dtypes.dtype('float64'), ak.ones(10).dtype)
-        self.assertEqual(dtypes.dtype('str'), 
-                         ak.array(['string {}'.format(i) for i in range(0,10)]).dtype)
+        self.assertEqual(dtypes.dtype("float64"), ak.ones(10).dtype)
+        self.assertEqual(
+            dtypes.dtype("str"), ak.array(["string {}".format(i) for i in range(0, 10)]).dtype
+        )
 
     def test_isSupportedInt(self):
-        '''
+        """
         Tests for both True and False scenarios of the isSupportedInt method.
-        '''
+        """
         self.assertTrue(dtypes.isSupportedInt(1))
         self.assertTrue(dtypes.isSupportedInt(np.int64(1)))
         self.assertTrue(dtypes.isSupportedInt(np.int64(1.0)))
         self.assertFalse(dtypes.isSupportedInt(1.0))
-        self.assertFalse(dtypes.isSupportedInt('1'))
-        self.assertFalse(dtypes.isSupportedInt('1.0'))
-        
+        self.assertFalse(dtypes.isSupportedInt("1"))
+        self.assertFalse(dtypes.isSupportedInt("1.0"))
+
     def test_isSupportedFloat(self):
-        '''
+        """
         Tests for both True and False scenarios of the isSupportedFloat method.
-        '''
+        """
         self.assertTrue(dtypes.isSupportedFloat(1.0))
         self.assertTrue(dtypes.isSupportedFloat(float(1)))
         self.assertTrue(dtypes.isSupportedFloat(np.float64(1.0)))
         self.assertTrue(dtypes.isSupportedFloat(np.float64(1)))
         self.assertFalse(dtypes.isSupportedFloat(np.int64(1.0)))
         self.assertFalse(dtypes.isSupportedFloat(int(1.0)))
-        self.assertFalse(dtypes.isSupportedFloat('1'))
-        self.assertFalse(dtypes.isSupportedFloat('1.0'))
-        
+        self.assertFalse(dtypes.isSupportedFloat("1"))
+        self.assertFalse(dtypes.isSupportedFloat("1.0"))
+
     def test_DtypeEnum(self):
-        '''
+        """
         Tests for DTypeEnum, ak.DTypes, and ak.ARKOUDA_SUPPORTED_DTYPES
-        '''
-        self.assertEqual('bool', str(dtypes.DType.BOOL))
-        self.assertEqual('float', str(dtypes.DType.FLOAT))
-        self.assertEqual('float64', str(dtypes.DType.FLOAT64))
-        self.assertEqual('int', str(dtypes.DType.INT))
-        self.assertEqual('int64', str(dtypes.DType.INT64))
-        self.assertEqual('str', str(dtypes.DType.STR))
-        self.assertEqual('uint8', str(dtypes.DType.UINT8))
-        self.assertEqual(frozenset({'float','float64', 'bool', 'uint8', 
-                                    'int','int64', 'str', 'uint64'}), ak.DTypes)
-        self.assertEqual(frozenset({'float','float64', 'bool', 'uint8', 
-                                    'int','int64', 'str', 'uint64'}), ak.ARKOUDA_SUPPORTED_DTYPES)
-        
+        """
+        self.assertEqual("bool", str(dtypes.DType.BOOL))
+        self.assertEqual("float", str(dtypes.DType.FLOAT))
+        self.assertEqual("float64", str(dtypes.DType.FLOAT64))
+        self.assertEqual("int", str(dtypes.DType.INT))
+        self.assertEqual("int64", str(dtypes.DType.INT64))
+        self.assertEqual("str", str(dtypes.DType.STR))
+        self.assertEqual("uint8", str(dtypes.DType.UINT8))
+        self.assertEqual(
+            frozenset({"float", "float64", "bool", "uint8", "int", "int64", "str", "uint64"}), ak.DTypes
+        )
+        self.assertEqual(
+            frozenset({"float", "float64", "bool", "uint8", "int", "int64", "str", "uint64"}),
+            ak.ARKOUDA_SUPPORTED_DTYPES,
+        )
+
     def test_NumericDTypes(self):
-        self.assertEqual(frozenset(['bool', 'float', 'float64','int','int64', 'uint64']), 
-                         dtypes.NumericDTypes)
-        
+        self.assertEqual(
+            frozenset(["bool", "float", "float64", "int", "int64", "uint64"]), dtypes.NumericDTypes
+        )
+
     def test_SeriesDTypes(self):
-        self.assertEqual(np.str_, dtypes.SeriesDTypes['string'])
+        self.assertEqual(np.str_, dtypes.SeriesDTypes["string"])
         self.assertEqual(np.str_, dtypes.SeriesDTypes["<class 'str'>"])
-        self.assertEqual(np.int64, dtypes.SeriesDTypes['int64'])
+        self.assertEqual(np.int64, dtypes.SeriesDTypes["int64"])
         self.assertEqual(np.int64, dtypes.SeriesDTypes["<class 'numpy.int64'>"])
-        self.assertEqual(np.float64, dtypes.SeriesDTypes['float64'])
+        self.assertEqual(np.float64, dtypes.SeriesDTypes["float64"])
         self.assertEqual(np.float64, dtypes.SeriesDTypes["<class 'numpy.float64'>"])
-        self.assertEqual(np.bool_, dtypes.SeriesDTypes['bool'])
-        self.assertEqual(np.dtype(bool), dtypes.SeriesDTypes['bool'])
+        self.assertEqual(np.bool_, dtypes.SeriesDTypes["bool"])
+        self.assertEqual(np.dtype(bool), dtypes.SeriesDTypes["bool"])
         self.assertEqual(np.bool_, dtypes.SeriesDTypes["<class 'bool'>"])
         self.assertEqual(np.dtype(bool), dtypes.SeriesDTypes["<class 'bool'>"])
-        self.assertEqual(np.int64, dtypes.SeriesDTypes['datetime64[ns]'])
-        self.assertEqual(np.int64, dtypes.SeriesDTypes['timedelta64[ns]'])
+        self.assertEqual(np.int64, dtypes.SeriesDTypes["datetime64[ns]"])
+        self.assertEqual(np.int64, dtypes.SeriesDTypes["timedelta64[ns]"])
 
     def test_scalars(self):
         self.assertEqual("typing.Union[bool, numpy.bool_]", str(ak.bool_scalars))
-        self.assertEqual('typing.Union[float, numpy.float64]', str(ak.float_scalars))
-        self.assertEqual('typing.Union[int, numpy.int64, numpy.uint64]', str(ak.int_scalars))
-        self.assertEqual('typing.Union[float, numpy.float64, int, numpy.int64, numpy.uint8, numpy.uint64]', 
-                         str(ak.numeric_scalars))
-        self.assertEqual('typing.Union[str, numpy.str_]', str(ak.str_scalars))
-        self.assertEqual('typing.Union[numpy.float64, numpy.int64, numpy.bool_, numpy.uint8, numpy.str_, numpy.uint64]', 
-                         str(ak.numpy_scalars))
-        self.assertEqual('typing.Union[float, numpy.float64, int, numpy.int64, numpy.uint64, bool, numpy.bool_, str, numpy.str_]', 
-                         str(ak.all_scalars))
-        
+        self.assertEqual("typing.Union[float, numpy.float64]", str(ak.float_scalars))
+        self.assertEqual("typing.Union[int, numpy.int64, numpy.uint64]", str(ak.int_scalars))
+        self.assertEqual(
+            "typing.Union[float, numpy.float64, int, numpy.int64, numpy.uint8, numpy.uint64]",
+            str(ak.numeric_scalars),
+        )
+        self.assertEqual("typing.Union[str, numpy.str_]", str(ak.str_scalars))
+        self.assertEqual(
+            "typing.Union[numpy.float64, numpy.int64, numpy.bool_, numpy.uint8, "
+            "numpy.str_, numpy.uint64]",
+            str(ak.numpy_scalars),
+        )
+        self.assertEqual(
+            "typing.Union[float, numpy.float64, int, numpy.int64, numpy.uint64, bool, "
+            "numpy.bool_, str, numpy.str_]",
+            str(ak.all_scalars),
+        )
+
     def test_number_format_strings(self):
-        self.assertEqual('{}', dtypes.NUMBER_FORMAT_STRINGS['bool'])
-        self.assertEqual('{:n}', dtypes.NUMBER_FORMAT_STRINGS['int64'])
-        self.assertEqual('{:.17f}', dtypes.NUMBER_FORMAT_STRINGS['float64'])
-        self.assertEqual('f', dtypes.NUMBER_FORMAT_STRINGS['np.float64'])
-        self.assertEqual('{:n}', dtypes.NUMBER_FORMAT_STRINGS['uint8'])
+        self.assertEqual("{}", dtypes.NUMBER_FORMAT_STRINGS["bool"])
+        self.assertEqual("{:n}", dtypes.NUMBER_FORMAT_STRINGS["int64"])
+        self.assertEqual("{:.17f}", dtypes.NUMBER_FORMAT_STRINGS["float64"])
+        self.assertEqual("f", dtypes.NUMBER_FORMAT_STRINGS["np.float64"])
+        self.assertEqual("{:n}", dtypes.NUMBER_FORMAT_STRINGS["uint8"])

--- a/tests/extrema_test.py
+++ b/tests/extrema_test.py
@@ -1,162 +1,174 @@
 import numpy as np
-from context import arkouda as ak
 from base_test import ArkoudaTest
+from context import arkouda as ak
 
 SIZE = 10
 K = 5
+
 
 def make_array():
     a = ak.randint(0, SIZE, SIZE)
     return a
 
+
 def compare_results(akres, sortedres) -> int:
-    '''
+    """
     Compares the numpy and arkouda arrays via the numpy.allclose method with the
     default relative and absolute tolerances, returning 0 if the arrays are similar
     element-wise within the tolerances, 1 if they are dissimilar.element
-    
+
     :return: 0 (identical) or 1 (dissimilar)
     :rtype: int
-    '''
+    """
     akres = akres.to_ndarray()
-    
+
     if not np.array_equal(akres, sortedres):
         akres = ak.array(akres)
         sortedres = ak.array(sortedres)
-        innp = sortedres[ak.in1d(ak.array(sortedres), ak.array(akres), True)] # values in np array, but not ak array
-        inak = akres[ak.in1d(ak.array(akres), ak.array(sortedres), True)] # values in ak array, not not np array
+        innp = sortedres[
+            ak.in1d(ak.array(sortedres), ak.array(akres), True)
+        ]  # values in np array, but not ak array
+        inak = akres[
+            ak.in1d(ak.array(akres), ak.array(sortedres), True)
+        ]  # values in ak array, not not np array
         print(f"(values in np but not ak: {innp}) (values in ak but not np: {inak})")
         return 1
     return 0
 
+
 def run_test(runMin=True, isInd=True, verbose=True):
-    '''
+    """
     The run_test method runs execution of the mink reduction
     on a randomized array.
-    :return: 
-    '''
+    :return:
+    """
     aka = make_array()
-    
+
     failures = 0
     try:
         if not isInd:
             if runMin:
                 akres = ak.mink(aka, K)
-                npres = np.sort(aka.to_ndarray())[:K] # first K elements from sorted array
+                npres = np.sort(aka.to_ndarray())[:K]  # first K elements from sorted array
             else:
                 akres = ak.maxk(aka, K)
-                npres = np.sort(aka.to_ndarray())[-K:] # last K elements from sorted array
+                npres = np.sort(aka.to_ndarray())[-K:]  # last K elements from sorted array
         else:
             if runMin:
                 akres = aka[ak.argmink(aka, K)]
-                npres = np.sort(aka.to_ndarray())[:K] # first K elements from sorted array
+                npres = np.sort(aka.to_ndarray())[:K]  # first K elements from sorted array
             else:
                 akres = aka[ak.argmaxk(aka, K)]
-                npres = np.sort(aka.to_ndarray())[-K:] # last K elements from sorted array
+                npres = np.sort(aka.to_ndarray())[-K:]  # last K elements from sorted array
     except RuntimeError as E:
-        if verbose: print("Arkouda error: ", E)
+        if verbose:
+            print("Arkouda error: ", E)
         return 1
 
     failures += compare_results(akres, npres)
-    
+
     return failures
+
 
 class MinKTest(ArkoudaTest):
     def test_mink(self):
-        '''
+        """
         Executes run_test and asserts whether there are any errors
-        
+
         :return: None
         :raise: AssertionError if there are any errors encountered in run_test for set operations
-        '''
+        """
         self.assertEqual(0, run_test())
-        
+
     def test_error_handling(self):
         testArray = ak.randint(0, 100, 100)
 
-        with self.assertRaises(TypeError) as cm:
-            ak.mink(list(range(0,10)), 1)
+        with self.assertRaises(TypeError):
+            ak.mink(list(range(0, 10)), 1)
 
-        with self.assertRaises(TypeError) as cm:
-            ak.mink(testArray, '1')
-            
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(TypeError):
+            ak.mink(testArray, "1")
+
+        with self.assertRaises(ValueError):
             ak.mink(testArray, -1)
-        
-        with self.assertRaises(ValueError) as cm:
+
+        with self.assertRaises(ValueError):
             ak.mink(ak.array([]), 1)
+
 
 class MaxKTest(ArkoudaTest):
     def test_maxk(self):
-        '''
+        """
         Executes run_test and asserts whether there are any errors
-        
+
         :return: None
         :raise: AssertionError if there are any errors encountered in run_test for set operations
-        '''
+        """
         self.assertEqual(0, run_test(runMin=False))
-        
+
     def test_error_handling(self):
         testArray = ak.randint(0, 100, 100)
 
-        with self.assertRaises(TypeError) as cm:
-            ak.maxk(list(range(0,10)), 1)
+        with self.assertRaises(TypeError):
+            ak.maxk(list(range(0, 10)), 1)
 
-        with self.assertRaises(TypeError) as cm:
-            ak.maxk(testArray, '1')
-            
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(TypeError):
+            ak.maxk(testArray, "1")
+
+        with self.assertRaises(ValueError):
             ak.maxk(testArray, -1)
-        
-        with self.assertRaises(ValueError) as cm:
+
+        with self.assertRaises(ValueError):
             ak.maxk(ak.array([]), 1)
+
 
 class ArgMinKTest(ArkoudaTest):
     def test_argmink(self):
-        '''
+        """
         Executes run_test and asserts whether there are any errors
-        
+
         :return: None
         :raise: AssertionError if there are any errors encountered in run_test for set operations
-        '''
+        """
         self.assertEqual(0, run_test(isInd=True))
-        
+
     def test_error_handling(self):
         testArray = ak.randint(0, 100, 100)
 
-        with self.assertRaises(TypeError) as cm:
-            ak.argmink(list(range(0,10)), 1)
+        with self.assertRaises(TypeError):
+            ak.argmink(list(range(0, 10)), 1)
 
-        with self.assertRaises(TypeError) as cm:
-            ak.argmink(testArray, '1')
-            
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(TypeError):
+            ak.argmink(testArray, "1")
+
+        with self.assertRaises(ValueError):
             ak.argmink(testArray, -1)
-        
-        with self.assertRaises(ValueError) as cm:
+
+        with self.assertRaises(ValueError):
             ak.argmink(ak.array([]), 1)
+
 
 class ArgMaxKTest(ArkoudaTest):
     def test_argmaxk(self):
-        '''
+        """
         Executes run_test and asserts whether there are any errors
-        
+
         :return: None
         :raise: AssertionError if there are any errors encountered in run_test for set operations
-        '''
+        """
         self.assertEqual(0, run_test(runMin=False, isInd=True))
-    
+
     def test_error_handling(self):
         testArray = ak.randint(0, 100, 100)
 
-        with self.assertRaises(TypeError) as cm:
-            ak.argmaxk(list(range(0,10)), 1)
-        
-        with self.assertRaises(TypeError) as cm:
-            ak.argmaxk(testArray, '1')
-            
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(TypeError):
+            ak.argmaxk(list(range(0, 10)), 1)
+
+        with self.assertRaises(TypeError):
+            ak.argmaxk(testArray, "1")
+
+        with self.assertRaises(ValueError):
             ak.argmaxk(testArray, -1)
-        
-        with self.assertRaises(ValueError) as cm:
+
+        with self.assertRaises(ValueError):
             ak.argmaxk(ak.array([]), 1)

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -1,56 +1,59 @@
 import numpy as np
 import pandas as pd
-
-from context import arkouda as ak
-from arkouda.dtypes import float64, int64
 from base_test import ArkoudaTest
+from context import arkouda as ak
+
+from arkouda.dtypes import float64, int64
 from arkouda.groupbyclass import GroupByReductionType
 
 SIZE = 100
 GROUPS = 8
 verbose = True
 
-def groupby_to_arrays(df : pd.DataFrame, kname, vname, op, levels):
+
+def groupby_to_arrays(df: pd.DataFrame, kname, vname, op, levels):
     g = df.groupby(kname)[vname]
-    agg = g.aggregate(op.replace('arg', 'idx'))
-    if op == 'prod':
+    agg = g.aggregate(op.replace("arg", "idx"))
+    if op == "prod":
         # There appears to be a bug in pandas where it sometimes
         # reports the product of a segment as NaN when it should be 0
         agg[agg.isna()] = 0
-    if levels==1:
+    if levels == 1:
         keys = agg.index.values
     else:
         keys = tuple(zip(*(agg.index.values)))
     return keys, agg.values
 
+
 def make_arrays():
     keys = np.random.randint(0, GROUPS, SIZE, dtype=np.uint64)
     keys2 = np.random.randint(0, GROUPS, SIZE)
-    i = np.random.randint(0, SIZE//GROUPS, SIZE)
-    u = np.random.randint(0, SIZE//GROUPS, SIZE, dtype=np.uint64)
-    f = np.random.randn(SIZE) # normally dist random numbers
+    i = np.random.randint(0, SIZE // GROUPS, SIZE)
+    u = np.random.randint(0, SIZE // GROUPS, SIZE, dtype=np.uint64)
+    f = np.random.randn(SIZE)  # normally dist random numbers
     b = (i % 2) == 0
-    d = {'keys':keys, 'keys2':keys2, 'int64':i, 'uint64':u, 'float64':f, 'bool':b}
+    d = {"keys": keys, "keys2": keys2, "int64": i, "uint64": u, "float64": f, "bool": b}
 
     return d
-  
+
+
 def compare_keys(pdkeys, akkeys, levels, pdvals, akvals) -> int:
-    '''
+    """
     Compares the numpy and arkouda arrays via the numpy.allclose method with the
     default relative and absolute tolerances, returning 0 if the arrays are similar
     element-wise within the tolerances, 1 if they are dissimilar.element
-    
+
     :return: 0 (identical) or 1 (dissimilar)
     :rtype: int
-    '''
+    """
     if levels == 1:
         akkeys = akkeys.to_ndarray()
         if not np.allclose(pdkeys, akkeys):
             print("Different keys")
             return 1
     else:
-        for l in range(levels):
-            if not np.allclose(pdkeys[l], akkeys[l].to_ndarray()):
+        for lvl in range(levels):
+            if not np.allclose(pdkeys[lvl], akkeys[lvl].to_ndarray()):
                 print("Different keys")
                 return 1
     if not np.allclose(pdvals, akvals):
@@ -58,98 +61,109 @@ def compare_keys(pdkeys, akkeys, levels, pdvals, akvals) -> int:
         return 1
     return 0
 
+
 def run_test(levels, verbose=False):
-    '''
+    """
     The run_test method enables execution of ak.GroupBy and ak.GroupBy.Reductions
-    on a randomized set of arrays on the specified number of levels. 
-    
+    on a randomized set of arrays on the specified number of levels.
+
     Note: the current set of valid levels is {1,2}
-    :return: 
-    '''
+    :return:
+    """
     d = make_arrays()
     df = pd.DataFrame(d)
-    akdf = {k:ak.array(v) for k, v in d.items()}
+    akdf = {k: ak.array(v) for k, v in d.items()}
 
     if levels == 1:
-        akg = ak.GroupBy(akdf['keys'])
-        keyname = 'keys'
+        akg = ak.GroupBy(akdf["keys"])
+        keyname = "keys"
     elif levels == 2:
-        akg = ak.GroupBy([akdf['keys'], akdf['keys2']])
-        keyname = ['keys', 'keys2']
+        akg = ak.GroupBy([akdf["keys"], akdf["keys2"]])
+        keyname = ["keys", "keys2"]
     tests = 0
     failures = 0
     not_impl = 0
-    if verbose: print(f"Doing .count()")
+    if verbose:
+        print("Doing .count()")
     tests += 1
-    pdkeys, pdvals = groupby_to_arrays(df, keyname, 'int64', 'count', levels)
+    pdkeys, pdvals = groupby_to_arrays(df, keyname, "int64", "count", levels)
     akkeys, akvals = akg.count()
     akvals = akvals.to_ndarray()
     failures += compare_keys(pdkeys, akkeys, levels, pdvals, akvals)
-    for vname in ('int64', 'uint64', 'float64', 'bool'):
+    for vname in ("int64", "uint64", "float64", "bool"):
         for op in ak.GroupBy.Reductions:
-            if verbose: print(f"\nDoing aggregate({vname}, {op})")
+            if verbose:
+                print(f"\nDoing aggregate({vname}, {op})")
             tests += 1
             do_check = True
             try:
                 pdkeys, pdvals = groupby_to_arrays(df, keyname, vname, op, levels)
-            except Exception as E:
-                if verbose: print("Pandas does not implement")
+            except Exception:
+                if verbose:
+                    print("Pandas does not implement")
                 do_check = False
             try:
                 akkeys, akvals = akg.aggregate(akdf[vname], op)
                 akvals = akvals.to_ndarray()
             except Exception as E:
-                if verbose: print("Arkouda error: ", E)
+                if verbose:
+                    print("Arkouda error: ", E)
                 not_impl += 1
                 do_check = False
                 continue
             if not do_check:
                 continue
-            if op.startswith('arg'):
+            if op.startswith("arg"):
                 pdextrema = df[vname][pdvals]
                 akextrema = akdf[vname][ak.array(akvals)].to_ndarray()
                 if not np.allclose(pdextrema, akextrema):
-                    print(f"Different argmin/argmax: Arkouda failed to find an extremum")
+                    print("Different argmin/argmax: Arkouda failed to find an extremum")
                     print("pd: ", pdextrema)
                     print("ak: ", akextrema)
                     failures += 1
             else:
                 failures += compare_keys(pdkeys, akkeys, levels, pdvals, akvals)
-    print(f"{tests - failures - not_impl} / {tests - not_impl} passed, {failures} errors, {not_impl} not implemented")
+    print(
+        f"{tests - failures - not_impl} / {tests - not_impl} passed, "
+        f"{failures} errors, {not_impl} not implemented"
+    )
     return failures
 
-'''
-The GroupByTest class encapsulates specific calls to the run_test method within a Python unittest.TestCase object,
-which enables integration into a pytest test harness.
-'''
-class GroupByTest(ArkoudaTest): 
 
+"""
+The GroupByTest class encapsulates specific calls to the run_test
+method within a Python unittest.TestCase object,
+which enables integration into a pytest test harness.
+"""
+
+
+class GroupByTest(ArkoudaTest):
     def setUp(self):
         ArkoudaTest.setUp(self)
-        
-        self.bvalues = ak.randint(0,1,10,dtype=bool)
-        self.fvalues = ak.randint(0,1,10,dtype=float)
+
+        self.bvalues = ak.randint(0, 1, 10, dtype=bool)
+        self.fvalues = ak.randint(0, 1, 10, dtype=float)
         self.ivalues = ak.array([4, 1, 3, 2, 2, 2, 5, 5, 2, 3])
         self.uvalues = ak.cast(self.ivalues, ak.uint64)
         self.igb = ak.GroupBy(self.ivalues)
         self.ugb = ak.GroupBy(self.uvalues)
 
     def test_groupby_on_one_level(self):
-        '''
+        """
         Executes run_test with levels=1 and asserts whether there are any errors
-        
+
         :return: None
         :raise: AssertionError if there are any errors encountered in run_test with levels = 1
-        '''
+        """
         self.assertEqual(0, run_test(1, verbose))
 
     def test_groupby_on_two_levels(self):
-        '''
+        """
         Executes run_test with levels=1 and asserts whether there are any errors
-        
+
         :return: None
         :raise: AssertionError if there are any errors encountered in run_test with levels = 2
-        '''
+        """
         self.assertEqual(0, run_test(2, verbose))
 
     def test_boolean_arrays(self):
@@ -173,18 +187,18 @@ class GroupByTest(ArkoudaTest):
         self.assertTrue((self.igb.OR(revs)[1] == self.igb.max(revs)[1]).all())
         self.assertTrue((self.igb.AND(revs)[1] == self.igb.min(revs)[1]).all())
         self.assertTrue((self.igb.XOR(revs)[1] == (self.igb.sum(revs)[1] % 2)).all())
-        
+
     def test_standalone_broadcast(self):
-        segs = ak.arange(10)**2
+        segs = ak.arange(10) ** 2
         vals = ak.arange(10)
         size = 100
-        check = ((2*vals + 1)*vals).sum()
+        check = ((2 * vals + 1) * vals).sum()
         self.assertTrue(ak.broadcast(segs, vals, size=size).sum() == check)
         perm = ak.arange(99, -1, -1)
         bcast = ak.broadcast(segs, vals, permutation=perm)
         self.assertTrue(bcast.sum() == check)
         self.assertTrue((bcast[:-1] >= bcast[1:]).all())
-        
+
     def test_broadcast_ints(self):
         keys, counts = self.igb.count()
 
@@ -262,88 +276,87 @@ class GroupByTest(ArkoudaTest):
 
         results = self.igb.broadcast(counts < 4)
         self.assertTrue((np.array([1, 1, 1, 0, 0, 0, 1, 1, 0, 1]) == results.to_ndarray()).all())
-        
+
     def test_count(self):
         keys, counts = self.igb.count()
-        
-        self.assertTrue((np.array([1,2,3,4,5]) == keys.to_ndarray()).all())
-        self.assertTrue((np.array([1,4,2,1,2]) == counts.to_ndarray()).all())
-        
-        
+
+        self.assertTrue((np.array([1, 2, 3, 4, 5]) == keys.to_ndarray()).all())
+        self.assertTrue((np.array([1, 4, 2, 1, 2]) == counts.to_ndarray()).all())
+
     def test_groupby_reduction_type(self):
-        self.assertEqual('any', str(GroupByReductionType.ANY)) 
-        self.assertEqual('all', str(GroupByReductionType.ALL))         
-        self.assertEqual(GroupByReductionType.ANY, GroupByReductionType('any'))
-        
+        self.assertEqual("any", str(GroupByReductionType.ANY))
+        self.assertEqual("all", str(GroupByReductionType.ALL))
+        self.assertEqual(GroupByReductionType.ANY, GroupByReductionType("any"))
+
         with self.assertRaises(ValueError):
-            GroupByReductionType('an')
-        
+            GroupByReductionType("an")
+
         self.assertIsInstance(ak.GROUPBY_REDUCTION_TYPES, frozenset)
-        self.assertTrue('any' in ak.GROUPBY_REDUCTION_TYPES)
-        
-        
+        self.assertTrue("any" in ak.GROUPBY_REDUCTION_TYPES)
+
     def test_error_handling(self):
         d = make_arrays()
-        akdf = {k:ak.array(v) for k, v in d.items()}        
-        gb = ak.GroupBy([akdf['keys'], akdf['keys2']])
+        akdf = {k: ak.array(v) for k, v in d.items()}
+        gb = ak.GroupBy([akdf["keys"], akdf["keys2"]])
 
-        with self.assertRaises(TypeError) as cm:
+        with self.assertRaises(TypeError):
             ak.GroupBy(ak.arange(4), ak.arange(4))
-        
-        with self.assertRaises(TypeError) as cm:
+
+        with self.assertRaises(TypeError):
             ak.GroupBy(self.fvalues)
 
-        with self.assertRaises(TypeError) as cm:
+        with self.assertRaises(TypeError):
             gb.broadcast([])
-        
-        with self.assertRaises(TypeError) as cm:
-            self.igb.nunique(ak.randint(0,1,10,dtype=bool))
 
-        with self.assertRaises(TypeError) as cm:
-            self.igb.nunique(ak.randint(0,1,10,dtype=float64))
-        
-        with self.assertRaises(TypeError) as cm:
-            self.igb.any(ak.randint(0,1,10,dtype=float64))
+        with self.assertRaises(TypeError):
+            self.igb.nunique(ak.randint(0, 1, 10, dtype=bool))
 
-        with self.assertRaises(TypeError) as cm:
-            self.igb.any(ak.randint(0,1,10,dtype=int64))
-        
-        with self.assertRaises(TypeError) as cm:
-            self.igb.all(ak.randint(0,1,10,dtype=float64))
+        with self.assertRaises(TypeError):
+            self.igb.nunique(ak.randint(0, 1, 10, dtype=float64))
 
-        with self.assertRaises(TypeError) as cm:
-            self.igb.all(ak.randint(0,1,10,dtype=int64))
+        with self.assertRaises(TypeError):
+            self.igb.any(ak.randint(0, 1, 10, dtype=float64))
 
-        with self.assertRaises(TypeError) as cm:
-            self.igb.min(ak.randint(0,1,10,dtype=bool))
+        with self.assertRaises(TypeError):
+            self.igb.any(ak.randint(0, 1, 10, dtype=int64))
 
-        with self.assertRaises(TypeError) as cm:
-            self.igb.max(ak.randint(0,1,10,dtype=bool))
-        
-        with self.assertRaises(TypeError) as cm:
-            self.igb.argmin(ak.randint(0,1,10,dtype=bool))
+        with self.assertRaises(TypeError):
+            self.igb.all(ak.randint(0, 1, 10, dtype=float64))
 
-        with self.assertRaises(TypeError) as cm:
-            self.igb.argmax(ak.randint(0,1,10,dtype=bool))
+        with self.assertRaises(TypeError):
+            self.igb.all(ak.randint(0, 1, 10, dtype=int64))
+
+        with self.assertRaises(TypeError):
+            self.igb.min(ak.randint(0, 1, 10, dtype=bool))
+
+        with self.assertRaises(TypeError):
+            self.igb.max(ak.randint(0, 1, 10, dtype=bool))
+
+        with self.assertRaises(TypeError):
+            self.igb.argmin(ak.randint(0, 1, 10, dtype=bool))
+
+        with self.assertRaises(TypeError):
+            self.igb.argmax(ak.randint(0, 1, 10, dtype=bool))
 
     def test_aggregate_strings(self):
-        s = ak.array(['a', 'b', 'a', 'b', 'c'])
+        s = ak.array(["a", "b", "a", "b", "c"])
         i = ak.arange(s.size)
         grouping = ak.GroupBy(s)
         labels, values = grouping.nunique(i)
 
-        expected = {'a': 2, 'b': 2, 'c': 1}
+        expected = {"a": 2, "b": 2, "c": 1}
         actual = {label: value for (label, value) in zip(labels.to_ndarray(), values.to_ndarray())}
 
         self.assertDictEqual(expected, actual)
 
     def test_multi_level_categorical(self):
-        string = ak.array(['a', 'b', 'a', 'b', 'c'])
+        string = ak.array(["a", "b", "a", "b", "c"])
         cat = ak.Categorical(string)
-        cat_from_codes = ak.Categorical.from_codes(codes=ak.array([0, 1, 0, 1, 2]),
-                                                   categories=ak.array(['a', 'b', 'c']))
+        cat_from_codes = ak.Categorical.from_codes(
+            codes=ak.array([0, 1, 0, 1, 2]), categories=ak.array(["a", "b", "c"])
+        )
         i = ak.arange(string.size)
-        expected = {('a', 'a'): 2, ('b', 'b'): 2, ('c', 'c'): 1}
+        expected = {("a", "a"): 2, ("b", "b"): 2, ("c", "c"): 1}
 
         # list of 2 strings
         str_grouping = ak.GroupBy([string, string])
@@ -364,7 +377,7 @@ class GroupByTest(ArkoudaTest):
         self.assertDictEqual(expected, mixed_dict)
 
     def test_nunique_types(self):
-        string = ak.array(['a', 'b', 'a', 'b', 'c'])
+        string = ak.array(["a", "b", "a", "b", "c"])
         cat = ak.Categorical(string)
         i = ak.array([5, 3, 5, 3, 1])
         expected = ak.array([1, 1, 1])
@@ -404,7 +417,9 @@ class GroupByTest(ArkoudaTest):
         u_unique_keys, u_group_nunique = g.nunique(u_data)
         i_unique_keys, i_group_nunique = g.nunique(i_data)
         self.assertListEqual(u_unique_keys.to_ndarray().tolist(), i_unique_keys.to_ndarray().tolist())
-        self.assertListEqual(u_group_nunique.to_ndarray().tolist(), i_group_nunique.to_ndarray().tolist())
+        self.assertListEqual(
+            u_group_nunique.to_ndarray().tolist(), i_group_nunique.to_ndarray().tolist()
+        )
 
     def test_zero_length_groupby(self):
         """
@@ -417,5 +432,10 @@ class GroupByTest(ArkoudaTest):
 def to_tuple_dict(labels, values):
     # transforms labels from list of arrays into a list of tuples by index and builds a dictionary
     # labels: [array(['b', 'a', 'c']), array(['b', 'a', 'c'])] -> [('b', 'b'), ('a', 'a'), ('c', 'c')]
-    return {label: value for (label, value) in
-            zip([index_tuple for index_tuple in zip(*[pda.to_ndarray() for pda in labels])], values.to_ndarray())}
+    return {
+        label: value
+        for (label, value) in zip(
+            [index_tuple for index_tuple in zip(*[pda.to_ndarray() for pda in labels])],
+            values.to_ndarray(),
+        )
+    }

--- a/tests/import_export_test.py
+++ b/tests/import_export_test.py
@@ -1,21 +1,24 @@
-import numpy as np
-import pandas as pd
+import glob
 import os
 from shutil import rmtree
-import glob
 
+import numpy as np
+import pandas as pd
 import pytest
-
 from base_test import ArkoudaTest
 from context import arkouda as ak
 
+
 class DataFrameTest(ArkoudaTest):
     def build_pandas_dataframe(self):
-        df = pd.DataFrame(data={
-            'Random_A': np.random.randint(0, 5, 5),
-            'Random_B': np.random.randint(0, 5, 5),
-            'Random_C': np.random.randint(0, 5, 5)
-        }, index=np.arange(5))
+        df = pd.DataFrame(
+            data={
+                "Random_A": np.random.randint(0, 5, 5),
+                "Random_B": np.random.randint(0, 5, 5),
+                "Random_C": np.random.randint(0, 5, 5),
+            },
+            index=np.arange(5),
+        )
         return df
 
     def build_arkouda_dataframe(self):
@@ -23,7 +26,7 @@ class DataFrameTest(ArkoudaTest):
         return ak.DataFrame(pddf)
 
     def get_locale_count(self):
-        return ak.get_config()['numLocales']
+        return ak.get_config()["numLocales"]
 
     def test_import_hdf(self):
         locales = self.get_locale_count()
@@ -38,7 +41,9 @@ class DataFrameTest(ArkoudaTest):
         self.assertTrue(len(glob.glob(f"{f_base}/ak_table_*.h5")) == locales)
         self.assertTrue(pddf.equals(akdf.to_pandas()))
 
-        pddf.to_hdf(f"{f_base}/table_columns.h5", "dataframe", format="Table", data_columns=True, mode="w")
+        pddf.to_hdf(
+            f"{f_base}/table_columns.h5", "dataframe", format="Table", data_columns=True, mode="w"
+        )
         akdf = ak.import_data(f"{f_base}/table_columns.h5", write_file=f"{f_base}/ak_table_columns.h5")
         self.assertTrue(len(glob.glob(f"{f_base}/ak_table_columns_*.h5")) == locales)
         self.assertTrue(pddf.equals(akdf.to_pandas()))

--- a/tests/index_test.py
+++ b/tests/index_test.py
@@ -1,10 +1,12 @@
-from base_test import ArkoudaTest
-from context import arkouda as ak
-import os, glob
+import glob
+import os
 from shutil import rmtree
 
-class IndexTest(ArkoudaTest):
+from base_test import ArkoudaTest
+from context import arkouda as ak
 
+
+class IndexTest(ArkoudaTest):
     def test_index_creation(self):
         idx = ak.Index(ak.arange(5))
 
@@ -13,13 +15,13 @@ class IndexTest(ArkoudaTest):
         self.assertListEqual(idx.to_pandas().tolist(), [i for i in range(5)])
 
     def test_multiindex_creation(self):
-        #test list generation
+        # test list generation
         idx = ak.MultiIndex([ak.arange(5), ak.arange(5)])
         self.assertIsInstance(idx, ak.MultiIndex)
         self.assertEqual(idx.levels, 2)
         self.assertEqual(idx.size, 5)
 
-        #test tuple generation
+        # test tuple generation
         idx = ak.MultiIndex((ak.arange(5), ak.arange(5)))
         self.assertIsInstance(idx, ak.MultiIndex)
         self.assertEqual(idx.levels, 2)
@@ -45,7 +47,7 @@ class IndexTest(ArkoudaTest):
 
         idx = ak.Index(ak.array([1, 0, 4, 2, 5, 3]))
         i = idx.argsort()
-        #values should be the indexes in the array of idx
+        # values should be the indexes in the array of idx
         self.assertListEqual(i.to_ndarray().tolist(), [1, 0, 3, 5, 2, 4])
 
     def test_concat(self):
@@ -58,8 +60,8 @@ class IndexTest(ArkoudaTest):
 
     def test_lookup(self):
         idx = ak.Index.factory(ak.arange(5))
-        l = idx.lookup(ak.array([0, 4]))
-        self.assertListEqual(l.to_ndarray().tolist(), [True, False, False, False, True])
+        lk = idx.lookup(ak.array([0, 4]))
+        self.assertListEqual(lk.to_ndarray().tolist(), [True, False, False, False, True])
 
     def test_multi_argsort(self):
         idx = ak.Index.factory([ak.arange(5), ak.arange(5)])
@@ -77,18 +79,21 @@ class IndexTest(ArkoudaTest):
 
         idx_2 = ak.Index.factory([ak.arange(5), ak.arange(5)])
         idx_full = idx.concat(idx_2)
-        self.assertListEqual(idx_full.to_pandas().tolist(), [(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (0, 0), (1, 1), (2, 2), (3, 3), (4, 4)])
+        self.assertListEqual(
+            idx_full.to_pandas().tolist(),
+            [(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (0, 0), (1, 1), (2, 2), (3, 3), (4, 4)],
+        )
 
     def test_multi_lookup(self):
         idx = ak.Index.factory([ak.arange(5), ak.arange(5)])
 
-        l = ak.array([0, 3, 2])
+        lk = ak.array([0, 3, 2])
 
-        result = idx.lookup([l, l])
+        result = idx.lookup([lk, lk])
         self.assertListEqual(result.to_ndarray().tolist(), [True, False, True, True, False])
 
     def test_save(self):
-        locale_count = ak.get_config()['numLocales']
+        locale_count = ak.get_config()["numLocales"]
         d = f"{os.getcwd()}/save_index_test"
         # make directory to save to so pandas read works
         os.mkdir(d)

--- a/tests/indexing_test.py
+++ b/tests/indexing_test.py
@@ -1,12 +1,11 @@
 import numpy as np
-from context import arkouda as ak
 from base_test import ArkoudaTest
+from context import arkouda as ak
 
 SIZE = 100
 
 
 class IndexingTest(ArkoudaTest):
-
     def setUp(self):
         ArkoudaTest.setUp(self)
 
@@ -17,18 +16,22 @@ class IndexingTest(ArkoudaTest):
         self.f = ak.array(np.random.randn(SIZE))  # normally dist random numbers
         self.b = (self.i % 2) == 0
         self.s = ak.cast(self.i, str)
-        self.array_dict = {'int64': self.i, 'uint64': self.u, 'float64': self.f, 'bool': self.b}
+        self.array_dict = {"int64": self.i, "uint64": self.u, "float64": self.f, "bool": self.b}
 
     def test_pdarray_uint_indexing(self):
         # for every pda in array_dict test indexing with uint array and uint scalar
         for pda in self.array_dict.values():
             self.assertEqual(pda[np.uint(2)], pda[2])
-            self.assertListEqual(pda[self.ukeys].to_ndarray().tolist(), pda[self.ikeys].to_ndarray().tolist())
+            self.assertListEqual(
+                pda[self.ukeys].to_ndarray().tolist(), pda[self.ikeys].to_ndarray().tolist()
+            )
 
     def test_strings_uint_indexing(self):
         # test Strings array indexing with uint array and uint scalar
         self.assertEqual(self.s[np.uint(2)], self.s[2])
-        self.assertListEqual(self.s[self.ukeys].to_ndarray().tolist(), self.s[self.ikeys].to_ndarray().tolist())
+        self.assertListEqual(
+            self.s[self.ukeys].to_ndarray().tolist(), self.s[self.ikeys].to_ndarray().tolist()
+        )
 
     def test_uint_bool_indexing(self):
         # test uint array with bool indexing
@@ -43,15 +46,23 @@ class IndexingTest(ArkoudaTest):
 
             # set [slice] = scalar/pdarray
             pda[:10] = np.uint(-2)
-            self.assertListEqual(pda[self.ukeys].to_ndarray().tolist(), pda[self.ikeys].to_ndarray().tolist())
+            self.assertListEqual(
+                pda[self.ukeys].to_ndarray().tolist(), pda[self.ikeys].to_ndarray().tolist()
+            )
             pda[:10] = ak.cast(ak.arange(10), t)
-            self.assertListEqual(pda[self.ukeys].to_ndarray().tolist(), pda[self.ikeys].to_ndarray().tolist())
+            self.assertListEqual(
+                pda[self.ukeys].to_ndarray().tolist(), pda[self.ikeys].to_ndarray().tolist()
+            )
 
             # set [pdarray] = scalar/pdarray with uint key pdarray
             pda[ak.arange(10, dtype=ak.uint64)] = np.uint(3)
-            self.assertListEqual(pda[self.ukeys].to_ndarray().tolist(), pda[self.ikeys].to_ndarray().tolist())
+            self.assertListEqual(
+                pda[self.ukeys].to_ndarray().tolist(), pda[self.ikeys].to_ndarray().tolist()
+            )
             pda[ak.arange(10, dtype=ak.uint64)] = ak.cast(ak.arange(10), t)
-            self.assertListEqual(pda[self.ukeys].to_ndarray().tolist(), pda[self.ikeys].to_ndarray().tolist())
+            self.assertListEqual(
+                pda[self.ukeys].to_ndarray().tolist(), pda[self.ikeys].to_ndarray().tolist()
+            )
 
     def test_indexing_with_uint(self):
         # verify reproducer from #1210 no longer fails

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -1,340 +1,383 @@
-import os, shutil, glob
+import glob
+import os
+import shutil
 import tempfile
+from typing import List, Mapping, Union
 
+import h5py
 import numpy as np
 import pytest
-from typing import List, Mapping, Union
 from base_test import ArkoudaTest
 from context import arkouda as ak
+
 from arkouda import io_util
-import h5py
 
-'''
+"""
 Tests writing Arkouda pdarrays to and reading from files
-'''
-class IOTest(ArkoudaTest):
+"""
 
+
+class IOTest(ArkoudaTest):
     @classmethod
     def setUpClass(cls):
         super(IOTest, cls).setUpClass()
-        IOTest.io_test_dir = '{}/io_test'.format(os.getcwd())
+        IOTest.io_test_dir = "{}/io_test".format(os.getcwd())
         io_util.get_directory(IOTest.io_test_dir)
 
     def setUp(self):
         ArkoudaTest.setUp(self)
-        self.int_tens_pdarray = ak.array(np.random.randint(-100,100,1000))
+        self.int_tens_pdarray = ak.array(np.random.randint(-100, 100, 1000))
         self.int_tens_ndarray = self.int_tens_pdarray.to_ndarray()
         self.int_tens_ndarray.sort()
-        self.int_tens_pdarray_dupe = ak.array(np.random.randint(-100,100,1000))
+        self.int_tens_pdarray_dupe = ak.array(np.random.randint(-100, 100, 1000))
 
-        self.int_hundreds_pdarray = ak.array(np.random.randint(-1000,1000,1000))
+        self.int_hundreds_pdarray = ak.array(np.random.randint(-1000, 1000, 1000))
         self.int_hundreds_ndarray = self.int_hundreds_pdarray.to_ndarray()
         self.int_hundreds_ndarray.sort()
-        self.int_hundreds_pdarray_dupe = ak.array(np.random.randint(-1000,1000,1000))
+        self.int_hundreds_pdarray_dupe = ak.array(np.random.randint(-1000, 1000, 1000))
 
-        self.float_pdarray = ak.array(np.random.uniform(-100,100,1000))  
-        self.float_ndarray = self.float_pdarray.to_ndarray() 
+        self.float_pdarray = ak.array(np.random.uniform(-100, 100, 1000))
+        self.float_ndarray = self.float_pdarray.to_ndarray()
         self.float_ndarray.sort()
-        self.float_pdarray_dupe = ak.array(np.random.uniform(-100,100,1000))   
+        self.float_pdarray_dupe = ak.array(np.random.uniform(-100, 100, 1000))
 
         self.bool_pdarray = ak.randint(0, 1, 1000, dtype=ak.bool)
-        self.bool_pdarray_dupe = ak.randint(0, 1, 1000, dtype=ak.bool)     
-   
-        self.dict_columns =  {
-           'int_tens_pdarray' : self.int_tens_pdarray,
-           'int_hundreds_pdarray' : self.int_hundreds_pdarray,
-           'float_pdarray' : self.float_pdarray,
-           'bool_pdarray' : self.bool_pdarray
+        self.bool_pdarray_dupe = ak.randint(0, 1, 1000, dtype=ak.bool)
+
+        self.dict_columns = {
+            "int_tens_pdarray": self.int_tens_pdarray,
+            "int_hundreds_pdarray": self.int_hundreds_pdarray,
+            "float_pdarray": self.float_pdarray,
+            "bool_pdarray": self.bool_pdarray,
         }
-        
-        self.dict_columns_dupe =  {
-           'int_tens_pdarray' : self.int_tens_pdarray_dupe,
-           'int_hundreds_pdarray' : self.int_hundreds_pdarray_dupe,
-           'float_pdarray' : self.float_pdarray_dupe,
-           'bool_pdarray' : self.bool_pdarray_dupe
+
+        self.dict_columns_dupe = {
+            "int_tens_pdarray": self.int_tens_pdarray_dupe,
+            "int_hundreds_pdarray": self.int_hundreds_pdarray_dupe,
+            "float_pdarray": self.float_pdarray_dupe,
+            "bool_pdarray": self.bool_pdarray_dupe,
         }
-        
-        self.dict_single_column = {
-           'int_tens_pdarray' : self.int_tens_pdarray
-        }
-        
+
+        self.dict_single_column = {"int_tens_pdarray": self.int_tens_pdarray}
+
         self.list_columns = [
-          self.int_tens_pdarray,
-          self.int_hundreds_pdarray,
-          self.float_pdarray,
-          self.bool_pdarray
+            self.int_tens_pdarray,
+            self.int_hundreds_pdarray,
+            self.float_pdarray,
+            self.bool_pdarray,
         ]
-        
-        self.names =  [
-          'int_tens_pdarray',
-          'int_hundreds_pdarray',
-          'float_pdarray',
-          'bool_pdarray'
-        ]
-        
-        with open('{}/not-a-file_LOCALE0000'.format(IOTest.io_test_dir), 'w'):
+
+        self.names = ["int_tens_pdarray", "int_hundreds_pdarray", "float_pdarray", "bool_pdarray"]
+
+        with open("{}/not-a-file_LOCALE0000".format(IOTest.io_test_dir), "w"):
             pass
 
-    def _create_file(self, prefix_path : str, columns : Union[Mapping[str,ak.array]], 
-                                           names : List[str]=None) -> None:
-        '''
+    def _create_file(
+        self, prefix_path: str, columns: Union[Mapping[str, ak.array]], names: List[str] = None
+    ) -> None:
+        """
         Creates an hdf5 file with dataset(s) from the specified columns and path prefix
-        via the ak.save_all method. If columns is a List, then the names list is used 
+        via the ak.save_all method. If columns is a List, then the names list is used
         to create the datasets
-        
+
         :return: None
         :raise: ValueError if the names list is None when columns is a list
-        '''       
+        """
         if isinstance(columns, dict):
             ak.save_all(columns=columns, prefix_path=prefix_path)
         else:
             if not names:
-                raise ValueError('the names list must be not None if columns is a list')
+                raise ValueError("the names list must be not None if columns is a list")
             ak.save_all(columns=columns, prefix_path=prefix_path, names=names)
-    
-    def testSaveAllLoadAllWithDict(self): 
 
-        '''
-        Creates 2..n files from an input columns dict depending upon the number of 
-        arkouda_server locales, retrieves all datasets and correspoding pdarrays, 
+    def testSaveAllLoadAllWithDict(self):
+
+        """
+        Creates 2..n files from an input columns dict depending upon the number of
+        arkouda_server locales, retrieves all datasets and correspoding pdarrays,
         and confirms they match inputs
-        
+
         :return: None
         :raise: AssertionError if the input and returned datasets and pdarrays don't match
-        '''
-        self._create_file(columns=self.dict_columns, 
-                          prefix_path='{}/iotest_dict'.format(IOTest.io_test_dir))
-        retrieved_columns = ak.load_all('{}/iotest_dict'.format(IOTest.io_test_dir))
+        """
+        self._create_file(
+            columns=self.dict_columns, prefix_path="{}/iotest_dict".format(IOTest.io_test_dir)
+        )
+        retrieved_columns = ak.load_all("{}/iotest_dict".format(IOTest.io_test_dir))
 
-        itp = self.dict_columns['int_tens_pdarray'].to_ndarray()
-        ritp = retrieved_columns['int_tens_pdarray'].to_ndarray()
+        itp = self.dict_columns["int_tens_pdarray"].to_ndarray()
+        ritp = retrieved_columns["int_tens_pdarray"].to_ndarray()
         itp.sort()
         ritp.sort()
-        ihp = self.dict_columns['int_hundreds_pdarray'].to_ndarray()
-        rihp = retrieved_columns['int_hundreds_pdarray'].to_ndarray()
+        ihp = self.dict_columns["int_hundreds_pdarray"].to_ndarray()
+        rihp = retrieved_columns["int_hundreds_pdarray"].to_ndarray()
         ihp.sort()
         rihp.sort()
-        ifp = self.dict_columns['float_pdarray'].to_ndarray()
-        rifp = retrieved_columns['float_pdarray'].to_ndarray()
+        ifp = self.dict_columns["float_pdarray"].to_ndarray()
+        rifp = retrieved_columns["float_pdarray"].to_ndarray()
         ifp.sort()
         rifp.sort()
 
         self.assertEqual(4, len(retrieved_columns))
         self.assertTrue((itp == ritp).all())
         self.assertTrue((ihp == rihp).all())
-        self.assertTrue((ifp == rifp).all())    
-        self.assertEqual(len(self.dict_columns['bool_pdarray']),  
-                         len(retrieved_columns['bool_pdarray']))    
-        self.assertEqual(4, 
-                         len(ak.get_datasets('{}/iotest_dict_LOCALE0000'.format(IOTest.io_test_dir))))
-        
+        self.assertTrue((ifp == rifp).all())
+        self.assertEqual(len(self.dict_columns["bool_pdarray"]), len(retrieved_columns["bool_pdarray"]))
+        self.assertEqual(4, len(ak.get_datasets("{}/iotest_dict_LOCALE0000".format(IOTest.io_test_dir))))
+
     def testSaveAllLoadAllWithList(self):
-        '''
-        Creates 2..n files from an input columns and names list depending upon the number of 
-        arkouda_server locales, retrieves all datasets and correspoding pdarrays, and confirms 
+        """
+        Creates 2..n files from an input columns and names list depending upon the number of
+        arkouda_server locales, retrieves all datasets and correspoding pdarrays, and confirms
         they match inputs
-        
+
         :return: None
         :raise: AssertionError if the input and returned datasets and pdarrays don't match
-        '''
-        self._create_file(columns=self.list_columns, 
-                          prefix_path='{}/iotest_list'.format(IOTest.io_test_dir), 
-                          names=self.names)
-        retrieved_columns = ak.load_all(path_prefix='{}/iotest_list'.format(IOTest.io_test_dir))
+        """
+        self._create_file(
+            columns=self.list_columns,
+            prefix_path="{}/iotest_list".format(IOTest.io_test_dir),
+            names=self.names,
+        )
+        retrieved_columns = ak.load_all(path_prefix="{}/iotest_list".format(IOTest.io_test_dir))
 
         itp = self.list_columns[0].to_ndarray()
         itp.sort()
-        ritp = retrieved_columns['int_tens_pdarray'].to_ndarray()
+        ritp = retrieved_columns["int_tens_pdarray"].to_ndarray()
         ritp.sort()
         ihp = self.list_columns[1].to_ndarray()
         ihp.sort()
-        rihp = retrieved_columns['int_hundreds_pdarray'].to_ndarray()
+        rihp = retrieved_columns["int_hundreds_pdarray"].to_ndarray()
         rihp.sort()
         fp = self.list_columns[2].to_ndarray()
         fp.sort()
-        rfp = retrieved_columns['float_pdarray'].to_ndarray()
+        rfp = retrieved_columns["float_pdarray"].to_ndarray()
         rfp.sort()
 
         self.assertEqual(4, len(retrieved_columns))
         self.assertTrue((itp == ritp).all())
         self.assertTrue((ihp == rihp).all())
-        self.assertTrue((fp == rfp).all())      
-        self.assertEqual(len(self.list_columns[3]), 
-                         len(retrieved_columns['bool_pdarray']))    
-        self.assertEqual(4, 
-                      len(ak.get_datasets('{}/iotest_list_LOCALE0000'.format(IOTest.io_test_dir))))
-    
+        self.assertTrue((fp == rfp).all())
+        self.assertEqual(len(self.list_columns[3]), len(retrieved_columns["bool_pdarray"]))
+        self.assertEqual(4, len(ak.get_datasets("{}/iotest_list_LOCALE0000".format(IOTest.io_test_dir))))
+
     def testLsHdf(self):
-        '''
-        Creates 1..n files depending upon the number of arkouda_server locales, invokes the 
-        ls method on an explicit file name reads the files and confirms the expected 
+        """
+        Creates 1..n files depending upon the number of arkouda_server locales, invokes the
+        ls method on an explicit file name reads the files and confirms the expected
         message was returned.
 
         :return: None
         :raise: AssertionError if the h5ls output does not match expected value
-        '''
-        self._create_file(columns=self.dict_single_column, 
-                          prefix_path='{}/iotest_single_column'.format(IOTest.io_test_dir))
-        message = ak.ls('{}/iotest_single_column_LOCALE0000'.format(IOTest.io_test_dir))
-        self.assertIn('int_tens_pdarray', message)
-        
+        """
+        self._create_file(
+            columns=self.dict_single_column,
+            prefix_path="{}/iotest_single_column".format(IOTest.io_test_dir),
+        )
+        message = ak.ls("{}/iotest_single_column_LOCALE0000".format(IOTest.io_test_dir))
+        self.assertIn("int_tens_pdarray", message)
 
-        with self.assertRaises(RuntimeError) as cm:        
-            ak.ls('{}/not-a-file_LOCALE0000'.format(IOTest.io_test_dir))
+        with self.assertRaises(RuntimeError):
+            ak.ls("{}/not-a-file_LOCALE0000".format(IOTest.io_test_dir))
 
     def testLsHdfEmpty(self):
         # Test filename empty/whitespace-only condition
         with self.assertRaises(ValueError):
             ak.ls("")
-        
+
         with self.assertRaises(ValueError):
             ak.ls("   ")
-        
+
         with self.assertRaises(ValueError):
             ak.ls(" \n\r\t  ")
 
     def testReadHdf(self):
-        ''' DEPRECATED - all client calls route to `readAllHdf`
+        """DEPRECATED - all client calls route to `readAllHdf`
         Creates 2..n files depending upon the number of arkouda_server locales with two
         files each containing different-named datasets with the same pdarrays, reads the files
-        with an explicit list of file names to the read_hdf method, and confirms the dataset 
+        with an explicit list of file names to the read_hdf method, and confirms the dataset
         was returned correctly.
 
         :return: None
         :raise: AssertionError if the input and returned datasets don't match
-        '''
-        self._create_file(columns=self.dict_single_column, 
-                          prefix_path='{}/iotest_single_column'.format(IOTest.io_test_dir))
-        self._create_file(columns=self.dict_single_column, 
-                          prefix_path='{}/iotest_single_column_dupe'.format(IOTest.io_test_dir))
-        
-        dataset = ak.read(filenames=['{}/iotest_single_column_LOCALE0000'.format(IOTest.io_test_dir),
-                                     '{}/iotest_single_column_dupe_LOCALE0000'.format(IOTest.io_test_dir)],
-                          datasets='int_tens_pdarray')
+        """
+        self._create_file(
+            columns=self.dict_single_column,
+            prefix_path="{}/iotest_single_column".format(IOTest.io_test_dir),
+        )
+        self._create_file(
+            columns=self.dict_single_column,
+            prefix_path="{}/iotest_single_column_dupe".format(IOTest.io_test_dir),
+        )
+
+        dataset = ak.read(
+            filenames=[
+                "{}/iotest_single_column_LOCALE0000".format(IOTest.io_test_dir),
+                "{}/iotest_single_column_dupe_LOCALE0000".format(IOTest.io_test_dir),
+            ],
+            datasets="int_tens_pdarray",
+        )
         self.assertIsNotNone(dataset)
 
-        with self.assertRaises(RuntimeError) as cm:
-            ak.read(filenames=['{}/iotest_single_column_LOCALE0000'.format(IOTest.io_test_dir),
-                               '{}/iotest_single_column_dupe_LOCALE0000'.format(IOTest.io_test_dir)],
-                    datasets='in_tens_pdarray', )
-        
-        with self.assertRaises(RuntimeError) as cm:
-            ak.read(filenames=['{}/iotest_single_colum_LOCALE0000'.format(IOTest.io_test_dir),
-                               '{}/iotest_single_colum_dupe_LOCALE0000'.format(IOTest.io_test_dir)],
-                    datasets='int_tens_pdarray', )
+        with self.assertRaises(RuntimeError):
+            ak.read(
+                filenames=[
+                    "{}/iotest_single_column_LOCALE0000".format(IOTest.io_test_dir),
+                    "{}/iotest_single_column_dupe_LOCALE0000".format(IOTest.io_test_dir),
+                ],
+                datasets="in_tens_pdarray",
+            )
+
+        with self.assertRaises(RuntimeError):
+            ak.read(
+                filenames=[
+                    "{}/iotest_single_colum_LOCALE0000".format(IOTest.io_test_dir),
+                    "{}/iotest_single_colum_dupe_LOCALE0000".format(IOTest.io_test_dir),
+                ],
+                datasets="int_tens_pdarray",
+            )
 
     def testReadHdfWithGlob(self):
-        ''' DEPRECATED - all client calls route to `readAllHdf`
+        """DEPRECATED - all client calls route to `readAllHdf`
         Creates 2..n files depending upon the number of arkouda_server locales with two
         files each containing different-named datasets with the same pdarrays, reads the files
-        with the glob feature of the read_hdf method, and confirms the datasets and embedded 
+        with the glob feature of the read_hdf method, and confirms the datasets and embedded
         pdarrays match the input dataset and pdarrays
 
         :return: None
         :raise: AssertionError if the input and returned datasets don't match
-        '''
-        self._create_file(columns=self.dict_single_column, 
-                          prefix_path='{}/iotest_single_column'.format(IOTest.io_test_dir))
-        self._create_file(columns=self.dict_single_column, 
-                          prefix_path='{}/iotest_single_column_dupe'.format(IOTest.io_test_dir))
-        
-        dataset = ak.read(filenames='{}/iotest_single_column*'.format(IOTest.io_test_dir),
-                          datasets='int_tens_pdarray', )
+        """
+        self._create_file(
+            columns=self.dict_single_column,
+            prefix_path="{}/iotest_single_column".format(IOTest.io_test_dir),
+        )
+        self._create_file(
+            columns=self.dict_single_column,
+            prefix_path="{}/iotest_single_column_dupe".format(IOTest.io_test_dir),
+        )
+
+        dataset = ak.read(
+            filenames="{}/iotest_single_column*".format(IOTest.io_test_dir),
+            datasets="int_tens_pdarray",
+        )
         self.assertEqual(self.int_tens_pdarray.all(), dataset.all())
 
     def testReadAll(self):
-        '''
+        """
         Creates 2..n files depending upon the number of arkouda_server locales, reads the files
-        with an explicit list of file names to the read_all method, and confirms the datasets 
+        with an explicit list of file names to the read_all method, and confirms the datasets
         and embedded pdarrays match the input dataset and pdarrays
 
         :return: None
         :raise: AssertionError if the input and returned datasets don't match
-        '''
-        self._create_file(columns=self.dict_columns, 
-                          prefix_path='{}/iotest_dict_columns'.format(IOTest.io_test_dir))
-        
-        dataset = ak.read(filenames=['{}/iotest_dict_columns_LOCALE0000'.format(IOTest.io_test_dir)])
-        self.assertEqual(4, len(list(dataset.keys())))     
-        
+        """
+        self._create_file(
+            columns=self.dict_columns, prefix_path="{}/iotest_dict_columns".format(IOTest.io_test_dir)
+        )
+
+        dataset = ak.read(filenames=["{}/iotest_dict_columns_LOCALE0000".format(IOTest.io_test_dir)])
+        self.assertEqual(4, len(list(dataset.keys())))
+
     def testReadAllWithGlob(self):
-        '''
+        """
         Creates 2..n files depending upon the number of arkouda_server locales with two
         files each containing different-named datasets with the same pdarrays, reads the files
-        with the glob feature of the read_all method, and confirms the datasets and embedded 
+        with the glob feature of the read_all method, and confirms the datasets and embedded
         pdarrays match the input dataset and pdarrays
 
         :return: None
         :raise: AssertionError if the input and returned datasets don't match
-        '''
-        self._create_file(columns=self.dict_columns, 
-                          prefix_path='{}/iotest_dict_columns'.format(IOTest.io_test_dir))
-         
-        retrieved_columns = ak.read(filenames='{}/iotest_dict_columns*'.format(IOTest.io_test_dir))
+        """
+        self._create_file(
+            columns=self.dict_columns, prefix_path="{}/iotest_dict_columns".format(IOTest.io_test_dir)
+        )
+
+        retrieved_columns = ak.read(filenames="{}/iotest_dict_columns*".format(IOTest.io_test_dir))
 
         itp = self.list_columns[0].to_ndarray()
         itp.sort()
-        ritp = retrieved_columns['int_tens_pdarray'].to_ndarray()
+        ritp = retrieved_columns["int_tens_pdarray"].to_ndarray()
         ritp.sort()
         ihp = self.list_columns[1].to_ndarray()
         ihp.sort()
-        rihp = retrieved_columns['int_hundreds_pdarray'].to_ndarray()
+        rihp = retrieved_columns["int_hundreds_pdarray"].to_ndarray()
         rihp.sort()
         fp = self.list_columns[2].to_ndarray()
         fp.sort()
-        rfp = retrieved_columns['float_pdarray'].to_ndarray()
+        rfp = retrieved_columns["float_pdarray"].to_ndarray()
         rfp.sort()
 
-        self.assertEqual(4, len(list(retrieved_columns.keys())))  
+        self.assertEqual(4, len(list(retrieved_columns.keys())))
         self.assertTrue((itp == ritp).all())
         self.assertTrue((ihp == rihp).all())
         self.assertTrue((fp == rfp).all())
-        self.assertEqual(len(self.bool_pdarray), len(retrieved_columns['bool_pdarray']))
+        self.assertEqual(len(self.bool_pdarray), len(retrieved_columns["bool_pdarray"]))
 
     def testReadAllWithErrorAndWarn(self):
-        self._create_file(columns=self.dict_single_column,
-                          prefix_path=f'{IOTest.io_test_dir}/iotest_single_column')
-        self._create_file(columns=self.dict_single_column,
-                          prefix_path=f'{IOTest.io_test_dir}/iotest_single_column_dupe')
+        self._create_file(
+            columns=self.dict_single_column, prefix_path=f"{IOTest.io_test_dir}/iotest_single_column"
+        )
+        self._create_file(
+            columns=self.dict_single_column,
+            prefix_path=f"{IOTest.io_test_dir}/iotest_single_column_dupe",
+        )
 
         # Make sure we can read ok
-        dataset = ak.read(filenames=[f'{IOTest.io_test_dir}/iotest_single_column_LOCALE0000',
-                                     f'{IOTest.io_test_dir}/iotest_single_column_dupe_LOCALE0000'])
+        dataset = ak.read(
+            filenames=[
+                f"{IOTest.io_test_dir}/iotest_single_column_LOCALE0000",
+                f"{IOTest.io_test_dir}/iotest_single_column_dupe_LOCALE0000",
+            ]
+        )
         self.assertIsNotNone(dataset, "Expected dataset to be populated")
 
         # Change the name of the first file we try to raise an error due to file missing.
         with self.assertRaises(RuntimeError):
-            dataset = ak.read(filenames=[f'{IOTest.io_test_dir}/iotest_MISSING_single_column_LOCALE0000',
-                                         f'{IOTest.io_test_dir}/iotest_single_column_dupe_LOCALE0000'])
+            dataset = ak.read(
+                filenames=[
+                    f"{IOTest.io_test_dir}/iotest_MISSING_single_column_LOCALE0000",
+                    f"{IOTest.io_test_dir}/iotest_single_column_dupe_LOCALE0000",
+                ]
+            )
 
         # Run the same test with missing file, but this time with the warning flag for read_all
         with pytest.warns(RuntimeWarning, match=r"There were .* errors reading files on the server.*"):
-            dataset = ak.read(filenames=[f'{IOTest.io_test_dir}/iotest_MISSING_single_column_LOCALE0000',
-                                         f'{IOTest.io_test_dir}/iotest_single_column_dupe_LOCALE0000'],
-                              strictTypes=False,
-                              allow_errors=True,
-                              file_format='HDF5')
+            dataset = ak.read(
+                filenames=[
+                    f"{IOTest.io_test_dir}/iotest_MISSING_single_column_LOCALE0000",
+                    f"{IOTest.io_test_dir}/iotest_single_column_dupe_LOCALE0000",
+                ],
+                strictTypes=False,
+                allow_errors=True,
+                file_format="HDF5",
+            )
         self.assertIsNotNone(dataset, "Expected dataset to be populated")
 
     def testLoad(self):
-        '''
-        Creates 1..n files depending upon the number of arkouda_server locales with three columns 
-        AKA datasets, loads each corresponding dataset and confirms each corresponding pdarray 
+        """
+        Creates 1..n files depending upon the number of arkouda_server locales with three columns
+        AKA datasets, loads each corresponding dataset and confirms each corresponding pdarray
         equals the input pdarray.
-        
+
         :return: None
         :raise: AssertionError if the input and returned datasets (pdarrays) don't match
-        '''
-        self._create_file(columns=self.dict_columns,
-                          prefix_path='{}/iotest_dict_columns'.format(IOTest.io_test_dir))
-        result_array_tens = ak.load(path_prefix='{}/iotest_dict_columns'.format(IOTest.io_test_dir),
-                                    dataset='int_tens_pdarray')
-        result_array_hundreds = ak.load(path_prefix='{}/iotest_dict_columns'.format(IOTest.io_test_dir),
-                                        dataset='int_hundreds_pdarray')
-        result_array_floats = ak.load(path_prefix='{}/iotest_dict_columns'.format(IOTest.io_test_dir),
-                                     dataset='float_pdarray')
-        result_array_bools = ak.load(path_prefix='{}/iotest_dict_columns'.format(IOTest.io_test_dir),
-                                     dataset='bool_pdarray')
+        """
+        self._create_file(
+            columns=self.dict_columns, prefix_path="{}/iotest_dict_columns".format(IOTest.io_test_dir)
+        )
+        result_array_tens = ak.load(
+            path_prefix="{}/iotest_dict_columns".format(IOTest.io_test_dir), dataset="int_tens_pdarray"
+        )
+        result_array_hundreds = ak.load(
+            path_prefix="{}/iotest_dict_columns".format(IOTest.io_test_dir),
+            dataset="int_hundreds_pdarray",
+        )
+        result_array_floats = ak.load(
+            path_prefix="{}/iotest_dict_columns".format(IOTest.io_test_dir), dataset="float_pdarray"
+        )
+        result_array_bools = ak.load(
+            path_prefix="{}/iotest_dict_columns".format(IOTest.io_test_dir), dataset="bool_pdarray"
+        )
 
         ratens = result_array_tens.to_ndarray()
         ratens.sort()
@@ -346,25 +389,36 @@ class IOTest(ArkoudaTest):
         rafloats.sort()
 
         self.assertTrue((self.int_tens_ndarray == ratens).all())
-        self.assertTrue((self.int_hundreds_ndarray  == rahundreds).all())
+        self.assertTrue((self.int_hundreds_ndarray == rahundreds).all())
         self.assertTrue((self.float_ndarray == rafloats).all())
         self.assertEqual(len(self.bool_pdarray), len(result_array_bools))
 
         # test load_all with file_format parameter usage
-        ak.save_all(columns=self.dict_columns, file_format='Parquet',
-                    prefix_path='{}/iotest_dict_columns_parquet'.format(IOTest.io_test_dir))
-        result_array_tens = ak.load(path_prefix='{}/iotest_dict_columns_parquet'.format(IOTest.io_test_dir),
-                                    dataset='int_tens_pdarray',
-                                    file_format='Parquet')
-        result_array_hundreds = ak.load(path_prefix='{}/iotest_dict_columns_parquet'.format(IOTest.io_test_dir),
-                                        dataset='int_hundreds_pdarray',
-                                        file_format='Parquet')
-        result_array_floats = ak.load(path_prefix='{}/iotest_dict_columns_parquet'.format(IOTest.io_test_dir),
-                                      dataset='float_pdarray',
-                                      file_format='Parquet')
-        result_array_bools = ak.load(path_prefix='{}/iotest_dict_columns_parquet'.format(IOTest.io_test_dir),
-                                     dataset='bool_pdarray',
-                                     file_format='Parquet')
+        ak.save_all(
+            columns=self.dict_columns,
+            file_format="Parquet",
+            prefix_path="{}/iotest_dict_columns_parquet".format(IOTest.io_test_dir),
+        )
+        result_array_tens = ak.load(
+            path_prefix="{}/iotest_dict_columns_parquet".format(IOTest.io_test_dir),
+            dataset="int_tens_pdarray",
+            file_format="Parquet",
+        )
+        result_array_hundreds = ak.load(
+            path_prefix="{}/iotest_dict_columns_parquet".format(IOTest.io_test_dir),
+            dataset="int_hundreds_pdarray",
+            file_format="Parquet",
+        )
+        result_array_floats = ak.load(
+            path_prefix="{}/iotest_dict_columns_parquet".format(IOTest.io_test_dir),
+            dataset="float_pdarray",
+            file_format="Parquet",
+        )
+        result_array_bools = ak.load(
+            path_prefix="{}/iotest_dict_columns_parquet".format(IOTest.io_test_dir),
+            dataset="bool_pdarray",
+            file_format="Parquet",
+        )
         ratens = result_array_tens.to_ndarray()
         ratens.sort()
 
@@ -377,71 +431,78 @@ class IOTest(ArkoudaTest):
         self.assertTrue((self.int_hundreds_ndarray == rahundreds).all())
         self.assertTrue((self.float_ndarray == rafloats).all())
         self.assertEqual(len(self.bool_pdarray), len(result_array_bools))
-        
+
         # Test load with invalid prefix
-        with self.assertRaises(RuntimeError) as cm:
-            ak.load(path_prefix='{}/iotest_dict_column'.format(IOTest.io_test_dir), 
-                                    dataset='int_tens_pdarray')
+        with self.assertRaises(RuntimeError):
+            ak.load(
+                path_prefix="{}/iotest_dict_column".format(IOTest.io_test_dir),
+                dataset="int_tens_pdarray",
+            )
 
         # Test load with invalid file
-        with self.assertRaises(RuntimeError) as cm:
-            ak.load(path_prefix='{}/not-a-file'.format(IOTest.io_test_dir), 
-                                    dataset='int_tens_pdarray')
+        with self.assertRaises(RuntimeError):
+            ak.load(path_prefix="{}/not-a-file".format(IOTest.io_test_dir), dataset="int_tens_pdarray")
 
     def testLoadAll(self):
-        self._create_file(columns=self.dict_columns,
-                          prefix_path='{}/iotest_dict_columns'.format(IOTest.io_test_dir))
+        self._create_file(
+            columns=self.dict_columns, prefix_path="{}/iotest_dict_columns".format(IOTest.io_test_dir)
+        )
 
-        results = ak.load_all(path_prefix='{}/iotest_dict_columns'.format(IOTest.io_test_dir))
-        self.assertTrue('bool_pdarray' in results)
-        self.assertTrue('float_pdarray' in results)
-        self.assertTrue('int_tens_pdarray' in results)
-        self.assertTrue('int_hundreds_pdarray' in results)
+        results = ak.load_all(path_prefix="{}/iotest_dict_columns".format(IOTest.io_test_dir))
+        self.assertTrue("bool_pdarray" in results)
+        self.assertTrue("float_pdarray" in results)
+        self.assertTrue("int_tens_pdarray" in results)
+        self.assertTrue("int_hundreds_pdarray" in results)
 
-        #test load_all with file_format parameter usage
-        ak.save_all(columns=self.dict_columns, file_format='Parquet',
-                    prefix_path='{}/iotest_dict_columns_parquet'.format(IOTest.io_test_dir))
-        results = ak.load_all(file_format='Parquet',
-                              path_prefix='{}/iotest_dict_columns_parquet'.format(IOTest.io_test_dir))
-        self.assertTrue('bool_pdarray' in results)
-        self.assertTrue('float_pdarray' in results)
-        self.assertTrue('int_tens_pdarray' in results)
-        self.assertTrue('int_hundreds_pdarray' in results)
+        # test load_all with file_format parameter usage
+        ak.save_all(
+            columns=self.dict_columns,
+            file_format="Parquet",
+            prefix_path="{}/iotest_dict_columns_parquet".format(IOTest.io_test_dir),
+        )
+        results = ak.load_all(
+            file_format="Parquet",
+            path_prefix="{}/iotest_dict_columns_parquet".format(IOTest.io_test_dir),
+        )
+        self.assertTrue("bool_pdarray" in results)
+        self.assertTrue("float_pdarray" in results)
+        self.assertTrue("int_tens_pdarray" in results)
+        self.assertTrue("int_hundreds_pdarray" in results)
 
         # # Test load_all with invalid prefix
         with self.assertRaises(ValueError):
-            ak.load_all(path_prefix='{}/iotest_dict_column'.format(IOTest.io_test_dir))
+            ak.load_all(path_prefix="{}/iotest_dict_column".format(IOTest.io_test_dir))
 
         # Test load with invalid file
-        with self.assertRaises(RuntimeError) as cm:
-            ak.load_all(path_prefix='{}/not-a-file'.format(IOTest.io_test_dir))
+        with self.assertRaises(RuntimeError):
+            ak.load_all(path_prefix="{}/not-a-file".format(IOTest.io_test_dir))
 
     def testGetDataSets(self):
-        '''
-        Creates 1..n files depending upon the number of arkouda_server locales containing three 
+        """
+        Creates 1..n files depending upon the number of arkouda_server locales containing three
         datasets and confirms the expected number of datasets along with the dataset names
-        
+
         :return: None
         :raise: AssertionError if the input and returned dataset names don't match
-        '''
-        self._create_file(columns=self.dict_columns, 
-                          prefix_path='{}/iotest_dict_columns'.format(IOTest.io_test_dir))     
-        datasets = ak.get_datasets('{}/iotest_dict_columns_LOCALE0000'.format(IOTest.io_test_dir))
+        """
+        self._create_file(
+            columns=self.dict_columns, prefix_path="{}/iotest_dict_columns".format(IOTest.io_test_dir)
+        )
+        datasets = ak.get_datasets("{}/iotest_dict_columns_LOCALE0000".format(IOTest.io_test_dir))
 
-        self.assertEqual(4, len(datasets)) 
+        self.assertEqual(4, len(datasets))
         for dataset in datasets:
             self.assertIn(dataset, self.names)
 
         # Test load_all with invalid filename
-        with self.assertRaises(RuntimeError) as cm:            
-            ak.get_datasets('{}/iotest_dict_columns_LOCALE000'.format(IOTest.io_test_dir))
+        with self.assertRaises(RuntimeError):
+            ak.get_datasets("{}/iotest_dict_columns_LOCALE000".format(IOTest.io_test_dir))
 
     def testSaveStringsDataset(self):
         # Create, save, and load Strings dataset
-        strings_array = ak.array(['testing string{}'.format(num) for num in list(range(0,25))])
-        strings_array.save('{}/strings-test'.format(IOTest.io_test_dir), dataset='strings')
-        r_strings_array = ak.load('{}/strings-test'.format(IOTest.io_test_dir), 
-                                  dataset='strings')
+        strings_array = ak.array(["testing string{}".format(num) for num in list(range(0, 25))])
+        strings_array.save("{}/strings-test".format(IOTest.io_test_dir), dataset="strings")
+        r_strings_array = ak.load("{}/strings-test".format(IOTest.io_test_dir), dataset="strings")
 
         strings = strings_array.to_ndarray()
         strings.sort()
@@ -450,152 +511,179 @@ class IOTest(ArkoudaTest):
         self.assertTrue((strings == r_strings).all())
 
         # Read a part of a saved Strings dataset from one hdf5 file
-        r_strings_subset = ak.read(filenames='{}/strings-test_LOCALE0000'.\
-                                    format(IOTest.io_test_dir))
-        self.assertIsNotNone(r_strings_subset)
-        self.assertTrue(isinstance(r_strings_subset[0], str))    
-        self.assertIsNotNone(ak.read(filenames='{}/strings-test_LOCALE0000'.\
-                            format(IOTest.io_test_dir), datasets='strings/values'))
-        self.assertIsNotNone(ak.read(filenames='{}/strings-test_LOCALE0000'.\
-                            format(IOTest.io_test_dir), datasets='strings/segments'))
-
-
-        # Repeat the test using the calc_string_offsets=True option to have server calculate offsets array
-        r_strings_subset = ak.read(filenames=f'{IOTest.io_test_dir}/strings-test_LOCALE0000',
-                                       calc_string_offsets=True)
+        r_strings_subset = ak.read(filenames="{}/strings-test_LOCALE0000".format(IOTest.io_test_dir))
         self.assertIsNotNone(r_strings_subset)
         self.assertTrue(isinstance(r_strings_subset[0], str))
-        self.assertIsNotNone(ak.read(filenames=f'{IOTest.io_test_dir}/strings-test_LOCALE0000',
-                                         datasets='strings/values', calc_string_offsets=True))
-        self.assertIsNotNone(ak.read(filenames=f'{IOTest.io_test_dir}/strings-test_LOCALE0000',
-                                         datasets='strings/segments', calc_string_offsets=True))
+        self.assertIsNotNone(
+            ak.read(
+                filenames="{}/strings-test_LOCALE0000".format(IOTest.io_test_dir),
+                datasets="strings/values",
+            )
+        )
+        self.assertIsNotNone(
+            ak.read(
+                filenames="{}/strings-test_LOCALE0000".format(IOTest.io_test_dir),
+                datasets="strings/segments",
+            )
+        )
+
+        # Repeat the test using the calc_string_offsets=True option to
+        # have server calculate offsets array
+        r_strings_subset = ak.read(
+            filenames=f"{IOTest.io_test_dir}/strings-test_LOCALE0000", calc_string_offsets=True
+        )
+        self.assertIsNotNone(r_strings_subset)
+        self.assertTrue(isinstance(r_strings_subset[0], str))
+        self.assertIsNotNone(
+            ak.read(
+                filenames=f"{IOTest.io_test_dir}/strings-test_LOCALE0000",
+                datasets="strings/values",
+                calc_string_offsets=True,
+            )
+        )
+        self.assertIsNotNone(
+            ak.read(
+                filenames=f"{IOTest.io_test_dir}/strings-test_LOCALE0000",
+                datasets="strings/segments",
+                calc_string_offsets=True,
+            )
+        )
 
     def testStringsWithoutOffsets(self):
         """
         This tests both saving & reading a strings array without saving and reading the offsets to HDF5.
-        Instead the offsets array will be derived from the values/bytes area by looking for null-byte terminator strings
+        Instead the offsets array will be derived from the values/bytes area by looking for null-byte
+        terminator strings
         """
-        strings_array = ak.array(['testing string{}'.format(num) for num in list(range(0, 25))])
-        strings_array.save('{}/strings-test'.format(IOTest.io_test_dir), dataset='strings', save_offsets=False)
-        r_strings_array = ak.load('{}/strings-test'.format(IOTest.io_test_dir),
-                                  dataset='strings', calc_string_offsets=True)
+        strings_array = ak.array(["testing string{}".format(num) for num in list(range(0, 25))])
+        strings_array.save(
+            "{}/strings-test".format(IOTest.io_test_dir), dataset="strings", save_offsets=False
+        )
+        r_strings_array = ak.load(
+            "{}/strings-test".format(IOTest.io_test_dir), dataset="strings", calc_string_offsets=True
+        )
         strings = strings_array.to_ndarray()
         strings.sort()
         r_strings = r_strings_array.to_ndarray()
         r_strings.sort()
         self.assertTrue((strings == r_strings).all())
 
-     
     def testSaveLongStringsDataset(self):
         # Create, save, and load Strings dataset
-        strings = ak.array(['testing a longer string{} to be written, loaded and appended'.\
-                                  format(num) for num in list(range(0,26))])
-        strings.save('{}/strings-test'.format(IOTest.io_test_dir), dataset='strings')
+        strings = ak.array(
+            [
+                "testing a longer string{} to be written, loaded and appended".format(num)
+                for num in list(range(0, 26))
+            ]
+        )
+        strings.save("{}/strings-test".format(IOTest.io_test_dir), dataset="strings")
 
         n_strings = strings.to_ndarray()
         n_strings.sort()
-        r_strings = ak.load('{}/strings-test'.format(IOTest.io_test_dir), 
-                                  dataset='strings').to_ndarray()
+        r_strings = ak.load("{}/strings-test".format(IOTest.io_test_dir), dataset="strings").to_ndarray()
         r_strings.sort()
 
-        self.assertTrue((n_strings == r_strings).all())       
+        self.assertTrue((n_strings == r_strings).all())
 
     def testSaveMixedStringsDataset(self):
-        strings_array = ak.array(['string {}'.format(num) for num in list(range(0,25))])
-        m_floats =  ak.array([x / 10.0 for x in range(0, 10)])      
+        strings_array = ak.array(["string {}".format(num) for num in list(range(0, 25))])
+        m_floats = ak.array([x / 10.0 for x in range(0, 10)])
         m_ints = ak.array(list(range(0, 10)))
-        ak.save_all({'m_strings': strings_array,
-                     'm_floats' : m_floats,
-                     'm_ints' : m_ints}, 
-                     '{}/multi-type-test'.format(IOTest.io_test_dir))
-        r_mixed = ak.load_all('{}/multi-type-test'.format(IOTest.io_test_dir))
+        ak.save_all(
+            {"m_strings": strings_array, "m_floats": m_floats, "m_ints": m_ints},
+            "{}/multi-type-test".format(IOTest.io_test_dir),
+        )
+        r_mixed = ak.load_all("{}/multi-type-test".format(IOTest.io_test_dir))
 
-        self.assertTrue((strings_array.to_ndarray().sort() == \
-                                           r_mixed['m_strings'].to_ndarray().sort()))
-        self.assertIsNotNone(r_mixed['m_floats'])
-        self.assertIsNotNone(r_mixed['m_ints'])
+        self.assertTrue((strings_array.to_ndarray().sort() == r_mixed["m_strings"].to_ndarray().sort()))
+        self.assertIsNotNone(r_mixed["m_floats"])
+        self.assertIsNotNone(r_mixed["m_ints"])
 
-        r_floats = ak.sort(ak.load('{}/multi-type-test'.format(IOTest.io_test_dir), 
-                           dataset='m_floats'))
+        r_floats = ak.sort(ak.load("{}/multi-type-test".format(IOTest.io_test_dir), dataset="m_floats"))
         self.assertTrue((m_floats == r_floats).all())
 
-        r_ints = ak.sort(ak.load('{}/multi-type-test'.format(IOTest.io_test_dir), 
-                           dataset='m_ints'))
+        r_ints = ak.sort(ak.load("{}/multi-type-test".format(IOTest.io_test_dir), dataset="m_ints"))
         self.assertTrue((m_ints == r_ints).all())
-        
+
         strings = strings_array.to_ndarray()
         strings.sort()
-        r_strings = ak.load('{}/multi-type-test'.format(IOTest.io_test_dir), 
-                            dataset='m_strings').to_ndarray()
+        r_strings = ak.load(
+            "{}/multi-type-test".format(IOTest.io_test_dir), dataset="m_strings"
+        ).to_ndarray()
         r_strings.sort()
 
         self.assertTrue((strings == r_strings).all())
 
     def testAppendStringsDataset(self):
-        strings_array = ak.array(['string {}'.format(num) for num in list(range(0,25))])
-        strings_array.save('{}/append-strings-test'.format(IOTest.io_test_dir), 
-                           dataset='strings')
-        strings_array.save('{}/append-strings-test'.format(IOTest.io_test_dir), 
-                           dataset='strings-dupe', mode='append')
+        strings_array = ak.array(["string {}".format(num) for num in list(range(0, 25))])
+        strings_array.save("{}/append-strings-test".format(IOTest.io_test_dir), dataset="strings")
+        strings_array.save(
+            "{}/append-strings-test".format(IOTest.io_test_dir), dataset="strings-dupe", mode="append"
+        )
 
-        r_strings = ak.load('{}/append-strings-test'.format(IOTest.io_test_dir), 
-                                 dataset='strings')
-        r_strings_dupe = ak.load('{}/append-strings-test'.format(IOTest.io_test_dir), 
-                                 dataset='strings-dupe')  
+        r_strings = ak.load("{}/append-strings-test".format(IOTest.io_test_dir), dataset="strings")
+        r_strings_dupe = ak.load(
+            "{}/append-strings-test".format(IOTest.io_test_dir), dataset="strings-dupe"
+        )
         self.assertTrue((r_strings == r_strings_dupe).all())
 
     def testAppendMixedStringsDataset(self):
-        strings_array = ak.array(['string {}'.format(num) for num in list(range(0,25))])
-        strings_array.save('{}/append-multi-type-test'.format(IOTest.io_test_dir), 
-                           dataset='m_strings') 
-        m_floats =  ak.array([x / 10.0 for x in range(0, 10)])      
+        strings_array = ak.array(["string {}".format(num) for num in list(range(0, 25))])
+        strings_array.save("{}/append-multi-type-test".format(IOTest.io_test_dir), dataset="m_strings")
+        m_floats = ak.array([x / 10.0 for x in range(0, 10)])
         m_ints = ak.array(list(range(0, 10)))
-        ak.save_all({'m_floats' : m_floats,
-                     'm_ints' : m_ints}, 
-                     '{}/append-multi-type-test'.format(IOTest.io_test_dir), mode='append')
-        r_mixed = ak.load_all('{}/append-multi-type-test'.format(IOTest.io_test_dir))
-        
-        self.assertIsNotNone(r_mixed['m_floats'])
-        self.assertIsNotNone(r_mixed['m_ints'])
- 
-        r_floats = ak.sort(ak.load('{}/append-multi-type-test'.format(IOTest.io_test_dir), 
-                                   dataset='m_floats'))
-        r_ints = ak.sort(ak.load('{}/append-multi-type-test'.format(IOTest.io_test_dir), 
-                                 dataset='m_ints'))
+        ak.save_all(
+            {"m_floats": m_floats, "m_ints": m_ints},
+            "{}/append-multi-type-test".format(IOTest.io_test_dir),
+            mode="append",
+        )
+        r_mixed = ak.load_all("{}/append-multi-type-test".format(IOTest.io_test_dir))
+
+        self.assertIsNotNone(r_mixed["m_floats"])
+        self.assertIsNotNone(r_mixed["m_ints"])
+
+        r_floats = ak.sort(
+            ak.load("{}/append-multi-type-test".format(IOTest.io_test_dir), dataset="m_floats")
+        )
+        r_ints = ak.sort(
+            ak.load("{}/append-multi-type-test".format(IOTest.io_test_dir), dataset="m_ints")
+        )
         self.assertTrue((m_floats == r_floats).all())
         self.assertTrue((m_ints == r_ints).all())
-        
+
         strings = strings_array.to_ndarray()
         strings.sort()
-        r_strings = r_mixed['m_strings'].to_ndarray()
+        r_strings = r_mixed["m_strings"].to_ndarray()
         r_strings.sort()
 
-        self.assertTrue((strings  == r_strings).all())
+        self.assertTrue((strings == r_strings).all())
 
     def testStrictTypes(self):
         N = 100
-        prefix = '{}/strict-type-test'.format(IOTest.io_test_dir)
+        prefix = "{}/strict-type-test".format(IOTest.io_test_dir)
         inttypes = [np.uint32, np.int64, np.uint16, np.int16]
         floattypes = [np.float32, np.float64, np.float32, np.float64]
         for i, (it, ft) in enumerate(zip(inttypes, floattypes)):
-            with h5py.File('{}-{}'.format(prefix, i), 'w') as f:
-                idata = np.arange(i*N, (i+1)*N, dtype=it)
-                f.create_dataset('integers', data=idata)
-                fdata = np.arange(i*N, (i+1)*N, dtype=ft)
-                f.create_dataset('floats', data=fdata)
+            with h5py.File("{}-{}".format(prefix, i), "w") as f:
+                idata = np.arange(i * N, (i + 1) * N, dtype=it)
+                f.create_dataset("integers", data=idata)
+                fdata = np.arange(i * N, (i + 1) * N, dtype=ft)
+                f.create_dataset("floats", data=fdata)
         with self.assertRaises(RuntimeError):
-            ak.read(prefix+'*')
+            ak.read(prefix + "*")
 
-        a = ak.read(prefix+'*', strictTypes=False)
-        self.assertTrue((a['integers'] == ak.arange(len(inttypes)*N)).all())
-        self.assertTrue(np.allclose(a['floats'].to_ndarray(), np.arange(len(floattypes)*N, dtype=np.float64)))
-    
+        a = ak.read(prefix + "*", strictTypes=False)
+        self.assertTrue((a["integers"] == ak.arange(len(inttypes) * N)).all())
+        self.assertTrue(
+            np.allclose(a["floats"].to_ndarray(), np.arange(len(floattypes) * N, dtype=np.float64))
+        )
+
     def testTo_ndarray(self):
         ones = ak.ones(10)
         n_ones = ones.to_ndarray()
         new_ones = ak.array(n_ones)
         self.assertTrue((ones.to_ndarray() == new_ones.to_ndarray()).all())
-        
+
         empty_ones = ak.ones(0)
         n_empty_ones = empty_ones.to_ndarray()
         new_empty_ones = ak.array(n_empty_ones)
@@ -630,7 +718,9 @@ class IOTest(ArkoudaTest):
         """
         Test our ability to read/write uint64 to HDF5
         """
-        npa1 = np.array([18446744073709551500, 18446744073709551501, 18446744073709551502], dtype=np.uint64)
+        npa1 = np.array(
+            [18446744073709551500, 18446744073709551501, 18446744073709551502], dtype=np.uint64
+        )
         pda1 = ak.array(npa1)
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
             pda1.save(f"{tmp_dirname}/small_numeric", dataset="pda1")
@@ -644,7 +734,9 @@ class IOTest(ArkoudaTest):
         """
         Test conversion to and from numpy array / pdarray using unsigned 64bit integer (uint64)
         """
-        npa1 = np.array([18446744073709551500, 18446744073709551501, 18446744073709551502], dtype=np.uint64)
+        npa1 = np.array(
+            [18446744073709551500, 18446744073709551501, 18446744073709551502], dtype=np.uint64
+        )
         pda1 = ak.array(npa1)
         self.assertEqual(18446744073709551500, pda1[0])
         self.assertTrue((pda1.to_ndarray() == npa1).all())
@@ -679,7 +771,7 @@ class IOTest(ArkoudaTest):
 
     def tearDown(self):
         super(IOTest, self).tearDown()
-        for f in glob.glob('{}/*'.format(IOTest.io_test_dir)):
+        for f in glob.glob("{}/*".format(IOTest.io_test_dir)):
             os.remove(f)
 
     @classmethod

--- a/tests/io_util_test.py
+++ b/tests/io_util_test.py
@@ -1,15 +1,17 @@
-import os, shutil
+import os
+import shutil
 from pathlib import Path
-from context import arkouda as ak
-from arkouda import io_util
+
 from base_test import ArkoudaTest
 
-class IOUtilTest(ArkoudaTest):
+from arkouda import io_util
 
+
+class IOUtilTest(ArkoudaTest):
     @classmethod
     def setUpClass(cls):
         super(IOUtilTest, cls).setUpClass()
-        IOUtilTest.io_test_dir = '{}/io_util_test/'.format(os.getcwd())
+        IOUtilTest.io_test_dir = "{}/io_util_test/".format(os.getcwd())
         io_util.get_directory(IOUtilTest.io_test_dir)
 
     def testGetDirectory(self):
@@ -20,22 +22,26 @@ class IOUtilTest(ArkoudaTest):
         self.assertTrue(os.path.exists(IOUtilTest.io_test_dir))
 
     def testWriteLineToFile(self):
-        io_util.write_line_to_file(path='{}/testfile.txt'.format(IOUtilTest.io_test_dir),
-                                       line='localhost:5555,9ty4h6olr4')
-        self.assertTrue(os.path.exists('{}/testfile.txt'.format(IOUtilTest.io_test_dir)))
-        Path.unlink(Path('{}/testfile.txt'.format(IOUtilTest.io_test_dir)))
+        io_util.write_line_to_file(
+            path="{}/testfile.txt".format(IOUtilTest.io_test_dir), line="localhost:5555,9ty4h6olr4"
+        )
+        self.assertTrue(os.path.exists("{}/testfile.txt".format(IOUtilTest.io_test_dir)))
+        Path.unlink(Path("{}/testfile.txt".format(IOUtilTest.io_test_dir)))
 
     def testDelimitedFileToDict(self):
-        io_util.write_line_to_file(path='{}/testfile.txt'.format(IOUtilTest.io_test_dir),
-                                       line='localhost:5555,9ty4h6olr4')
-        io_util.write_line_to_file(path='{}/testfile.txt'.format(IOUtilTest.io_test_dir),
-                                       line='127.0.0.1:5556,6ky3i91l17')
-        values = io_util.delimited_file_to_dict(path='{}/testfile.txt'.format(IOUtilTest.io_test_dir),
-                                delimiter=',')
+        io_util.write_line_to_file(
+            path="{}/testfile.txt".format(IOUtilTest.io_test_dir), line="localhost:5555,9ty4h6olr4"
+        )
+        io_util.write_line_to_file(
+            path="{}/testfile.txt".format(IOUtilTest.io_test_dir), line="127.0.0.1:5556,6ky3i91l17"
+        )
+        values = io_util.delimited_file_to_dict(
+            path="{}/testfile.txt".format(IOUtilTest.io_test_dir), delimiter=","
+        )
         self.assertTrue(values)
-        self.assertEqual('9ty4h6olr4', values['localhost:5555'])
-        self.assertEqual('6ky3i91l17', values['127.0.0.1:5556'])
-        Path.unlink(Path('{}/testfile.txt'.format(IOUtilTest.io_test_dir)))
+        self.assertEqual("9ty4h6olr4", values["localhost:5555"])
+        self.assertEqual("6ky3i91l17", values["127.0.0.1:5556"])
+        Path.unlink(Path("{}/testfile.txt".format(IOUtilTest.io_test_dir)))
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -1,77 +1,79 @@
 import numpy as np
-
 from base_test import ArkoudaTest
 from context import arkouda as ak
 
-'''
+"""
 Encapsulates a variety of arkouda join_on_eq_with_dt test cases.
-'''
-class JoinTest(ArkoudaTest):
+"""
 
+
+class JoinTest(ArkoudaTest):
     def setUp(self):
         ArkoudaTest.setUp(self)
         self.N = 1000
-        self.a1 = ak.ones(self.N,dtype=np.int64)
-        self.a2 = ak.arange(0,self.N,1)
+        self.a1 = ak.ones(self.N, dtype=np.int64)
+        self.a2 = ak.arange(0, self.N, 1)
         self.t1 = self.a1
         self.t2 = self.a1 * 10
         self.dt = 10
         ak.verbose = False
 
     def test_join_on_eq_with_true_dt(self):
-        I,J = ak.join_on_eq_with_dt(self.a2,self.a1,self.t1,self.t2,self.dt,"true_dt")
-        nl = ak.get_config()['numLocales']
-        self.assertEqual(self.N//nl, I.size)
-        self.assertEqual(self.N//nl, J.size)
-               
+        I, J = ak.join_on_eq_with_dt(self.a2, self.a1, self.t1, self.t2, self.dt, "true_dt")
+        nl = ak.get_config()["numLocales"]
+        self.assertEqual(self.N // nl, I.size)
+        self.assertEqual(self.N // nl, J.size)
+
     def test_join_on_eq_with_true_dt_with_result_limit(self):
-        nl = ak.get_config()['numLocales']
+        nl = ak.get_config()["numLocales"]
         lim = (self.N + nl) * self.N
         res_size = self.N * self.N
-        I,J = ak.join_on_eq_with_dt(self.a1,self.a1,self.a1,self.a1,self.dt,"true_dt",result_limit=lim)
+        I, J = ak.join_on_eq_with_dt(
+            self.a1, self.a1, self.a1, self.a1, self.dt, "true_dt", result_limit=lim
+        )
         self.assertEqual(res_size, I.size)
         self.assertEqual(res_size, J.size)
 
     def test_join_on_eq_with_abs_dt(self):
-        I,J = ak.join_on_eq_with_dt(self.a2,self.a1,self.t1,self.t2,self.dt,"abs_dt")
-        nl = ak.get_config()['numLocales']
-        self.assertEqual(self.N//nl, I.size)
-        self.assertEqual(self.N//nl, J.size)
+        I, J = ak.join_on_eq_with_dt(self.a2, self.a1, self.t1, self.t2, self.dt, "abs_dt")
+        nl = ak.get_config()["numLocales"]
+        self.assertEqual(self.N // nl, I.size)
+        self.assertEqual(self.N // nl, J.size)
 
     def test_join_on_eq_with_pos_dt(self):
-        I,J = ak.join_on_eq_with_dt(self.a2,self.a1,self.t1,self.t2,self.dt,"pos_dt")
-        nl = ak.get_config()['numLocales']
-        self.assertEqual(self.N//nl, I.size)
-        self.assertEqual(self.N//nl, J.size)
+        I, J = ak.join_on_eq_with_dt(self.a2, self.a1, self.t1, self.t2, self.dt, "pos_dt")
+        nl = ak.get_config()["numLocales"]
+        self.assertEqual(self.N // nl, I.size)
+        self.assertEqual(self.N // nl, J.size)
 
     def test_join_on_eq_with_abs_dt_outside_window(self):
-        '''
-        Should get 0 answers because N^2 matches but 0 within dt window 
-        '''
+        """
+        Should get 0 answers because N^2 matches but 0 within dt window
+        """
         dt = 8
-        I,J = ak.join_on_eq_with_dt(self.a1,self.a1,self.t1,self.t1*10,dt,"abs_dt")
+        I, J = ak.join_on_eq_with_dt(self.a1, self.a1, self.t1, self.t1 * 10, dt, "abs_dt")
         self.assertEqual(0, I.size)
         self.assertEqual(0, J.size)
 
-        I,J = ak.join_on_eq_with_dt(self.a2,self.a1,self.t1,self.t2,dt,"abs_dt")
+        I, J = ak.join_on_eq_with_dt(self.a2, self.a1, self.t1, self.t2, dt, "abs_dt")
         self.assertEqual(0, I.size)
         self.assertEqual(0, J.size)
 
     def test_join_on_eq_with_pos_dt_outside_window(self):
-        '''
+        """
         Should get 0 answers because N matches but 0 within dt window
-        '''
+        """
         dt = 8
-        I,J = ak.join_on_eq_with_dt(self.a2,self.a1,self.t1,self.t2,dt,"pos_dt")
+        I, J = ak.join_on_eq_with_dt(self.a2, self.a1, self.t1, self.t2, dt, "pos_dt")
         self.assertEqual(0, I.size)
         self.assertEqual(0, J.size)
-        
+
         dt = np.int64(8)
-        I,J = ak.join_on_eq_with_dt(self.a2,self.a1,self.t1,self.t2,dt,"pos_dt")
+        I, J = ak.join_on_eq_with_dt(self.a2, self.a1, self.t1, self.t2, dt, "pos_dt")
         self.assertEqual(0, I.size)
         self.assertEqual(0, J.size)
-        
-        I,J = ak.join_on_eq_with_dt(self.a2,self.a1,self.t1,self.t2,dt,"pos_dt", int(0))
+
+        I, J = ak.join_on_eq_with_dt(self.a2, self.a1, self.t1, self.t2, dt, "pos_dt", int(0))
         self.assertEqual(0, I.size)
         self.assertEqual(0, J.size)
 
@@ -100,14 +102,18 @@ class JoinTest(ArkoudaTest):
             l, r = ak.join.inner_join(left, right, wherefunc=ak.intersect1d)
 
         with self.assertRaises(ValueError):
-            l, r = ak.join.inner_join(left, right, wherefunc=ak.intersect1d, whereargs=(ak.arange(5), ak.arange(10)))
+            l, r = ak.join.inner_join(
+                left, right, wherefunc=ak.intersect1d, whereargs=(ak.arange(5), ak.arange(10))
+            )
 
         with self.assertRaises(ValueError):
-            l, r = ak.join.inner_join(left, right, wherefunc=ak.intersect1d, whereargs=(ak.arange(10), ak.arange(5)))
+            l, r = ak.join.inner_join(
+                left, right, wherefunc=ak.intersect1d, whereargs=(ak.arange(10), ak.arange(5))
+            )
 
     def test_lookup(self):
         keys = ak.arange(5)
-        values = 10*keys
+        values = 10 * keys
         args = ak.array([5, 3, 1, 4, 2, 3, 1, 0])
         ans = np.array([-1, 30, 10, 40, 20, 30, 10, 0])
         # Simple lookup with int keys
@@ -115,7 +121,9 @@ class JoinTest(ArkoudaTest):
         res = ak.lookup(keys, values, args, fillvalue=-1, keys_from_unique=True)
         self.assertTrue((res.to_ndarray() == ans).all())
         # Compound lookup with (str, int) keys
-        res2 = ak.lookup((ak.cast(keys, ak.str_), keys), values, (ak.cast(args, ak.str_), args), fillvalue=-1)
+        res2 = ak.lookup(
+            (ak.cast(keys, ak.str_), keys), values, (ak.cast(args, ak.str_), args), fillvalue=-1
+        )
         self.assertTrue((res2.to_ndarray() == ans).all())
         # Keys not in uniqued order
         res3 = ak.lookup(keys[::-1], values[::-1], args, fillvalue=-1)
@@ -131,21 +139,16 @@ class JoinTest(ArkoudaTest):
         Tests error TypeError and ValueError handling
         """
         with self.assertRaises(TypeError):
-            ak.join_on_eq_with_dt([list(range(0,11))],
-                                  self.a1,self.t1,self.t2,8,"pos_dt")
+            ak.join_on_eq_with_dt([list(range(0, 11))], self.a1, self.t1, self.t2, 8, "pos_dt")
         with self.assertRaises(TypeError):
-            ak.join_on_eq_with_dt([self.a1, list(range(0,11))],
-                                  self.t1,self.t2,8,"pos_dt")
+            ak.join_on_eq_with_dt([self.a1, list(range(0, 11))], self.t1, self.t2, 8, "pos_dt")
         with self.assertRaises(TypeError):
-            ak.join_on_eq_with_dt([self.a1, self.a1, list(range(0,11))],
-                                  self.t2,8,"pos_dt")
+            ak.join_on_eq_with_dt([self.a1, self.a1, list(range(0, 11))], self.t2, 8, "pos_dt")
         with self.assertRaises(TypeError):
-            ak.join_on_eq_with_dt([self.a1, self.a1, self.t1,
-                                  list(range(0,11))],8,"pos_dt")
+            ak.join_on_eq_with_dt([self.a1, self.a1, self.t1, list(range(0, 11))], 8, "pos_dt")
         with self.assertRaises(TypeError):
-            ak.join_on_eq_with_dt(self.a1,
-                                  self.a1,self.t1,self.t2,'8',"pos_dt")
+            ak.join_on_eq_with_dt(self.a1, self.a1, self.t1, self.t2, "8", "pos_dt")
         with self.assertRaises(ValueError):
-            ak.join_on_eq_with_dt(self.a1,self.a1,self.t1,self.t1*10,8,"ab_dt")
+            ak.join_on_eq_with_dt(self.a1, self.a1, self.t1, self.t1 * 10, 8, "ab_dt")
         with self.assertRaises(ValueError):
-            ak.join_on_eq_with_dt(self.a1,self.a1,self.t1,self.t1*10,8,"abs_dt",-1)            
+            ak.join_on_eq_with_dt(self.a1, self.a1, self.t1, self.t1 * 10, 8, "abs_dt", -1)

--- a/tests/logger_test.py
+++ b/tests/logger_test.py
@@ -1,101 +1,100 @@
-import os, unittest
-from context import arkouda
-import arkouda as ak
-from arkouda.logger import LogLevel, getArkoudaLogger, getArkoudaClientLogger
-from logging import StreamHandler, DEBUG, INFO, WARN, \
-     FileHandler
+import os
+import unittest
+from logging import DEBUG, INFO, WARN, FileHandler, StreamHandler
 
-'''
+import arkouda as ak
+from arkouda.logger import LogLevel, getArkoudaClientLogger, getArkoudaLogger
+
+"""
 Tests Arkouda logging functionality
-'''
+"""
+
+
 class LoggerTest(unittest.TestCase):
-    
     def testLogLevel(self):
-        self.assertEqual('DEBUG', LogLevel.DEBUG.value) 
-        self.assertEqual('INFO', LogLevel.INFO.value) 
-        self.assertEqual('WARN', LogLevel.WARN.value)  
-        self.assertEqual('CRITICAL', LogLevel.CRITICAL.value)
-        self.assertEqual('ERROR', LogLevel.ERROR.value)   
-        
-        self.assertEqual(LogLevel.DEBUG,LogLevel('DEBUG'))    
-        self.assertEqual(LogLevel.INFO,LogLevel('INFO'))  
-        self.assertEqual(LogLevel.WARN,LogLevel('WARN')) 
-        self.assertEqual(LogLevel.CRITICAL,LogLevel('CRITICAL')) 
-        self.assertEqual(LogLevel.ERROR,LogLevel('ERROR')) 
-        
-    def testArkoudaLogger(self): 
+        self.assertEqual("DEBUG", LogLevel.DEBUG.value)
+        self.assertEqual("INFO", LogLevel.INFO.value)
+        self.assertEqual("WARN", LogLevel.WARN.value)
+        self.assertEqual("CRITICAL", LogLevel.CRITICAL.value)
+        self.assertEqual("ERROR", LogLevel.ERROR.value)
+
+        self.assertEqual(LogLevel.DEBUG, LogLevel("DEBUG"))
+        self.assertEqual(LogLevel.INFO, LogLevel("INFO"))
+        self.assertEqual(LogLevel.WARN, LogLevel("WARN"))
+        self.assertEqual(LogLevel.CRITICAL, LogLevel("CRITICAL"))
+        self.assertEqual(LogLevel.ERROR, LogLevel("ERROR"))
+
+    def testArkoudaLogger(self):
         handler = StreamHandler()
-        handler.name = 'streaming'   
-        logger = getArkoudaLogger(name=self.__class__.__name__, 
-                                  handlers=[handler])
+        handler.name = "streaming"
+        logger = getArkoudaLogger(name=self.__class__.__name__, handlers=[handler])
         self.assertEqual(DEBUG, logger.level)
-        self.assertEqual('LoggerTest', logger.name)
-        self.assertIsNotNone(logger.getHandler('streaming'))
-        logger.debug('debug message')
-        
+        self.assertEqual("LoggerTest", logger.name)
+        self.assertIsNotNone(logger.getHandler("streaming"))
+        logger.debug("debug message")
+
     def testArkoudaClientLogger(self):
-        logger = getArkoudaClientLogger(name='ClientLogger')
+        logger = getArkoudaClientLogger(name="ClientLogger")
         self.assertEqual(DEBUG, logger.level)
-        self.assertEqual('ClientLogger', logger.name)
-        logger.debug('debug message')      
-        self.assertIsNotNone(logger.getHandler('console-handler'))
+        self.assertEqual("ClientLogger", logger.name)
+        logger.debug("debug message")
+        self.assertIsNotNone(logger.getHandler("console-handler"))
         with self.assertRaises(ValueError):
-            logger.getHandler('console-handlers')
-        
-    def testUpdateArkoudaLoggerLogLevel(self):  
-        logger = getArkoudaLogger(name='UpdateLogger')
+            logger.getHandler("console-handlers")
+
+    def testUpdateArkoudaLoggerLogLevel(self):
+        logger = getArkoudaLogger(name="UpdateLogger")
         self.assertEqual(DEBUG, logger.level)
-        logger.debug('debug before level change')
+        logger.debug("debug before level change")
         logger.changeLogLevel(LogLevel.WARN)
         self.assertEqual(WARN, logger.handlers[0].level)
-        logger.debug('debug after level change')
-        
+        logger.debug("debug after level change")
+
         handlerOne = StreamHandler()
-        handlerOne.name = 'handler-one'
+        handlerOne.name = "handler-one"
         handlerOne.setLevel(DEBUG)
-        handlerTwo = FileHandler(filename='output.txt')
-        handlerTwo.name = 'handler-two'
+        handlerTwo = FileHandler(filename="output.txt")
+        handlerTwo.name = "handler-two"
         handlerTwo.setLevel(INFO)
-        logger = getArkoudaLogger(name='UpdateLogger', 
-                                  handlers=[handlerOne,handlerTwo])
-        logger.changeLogLevel(level=LogLevel.WARN, handlerNames=['handler-one'])
-        self.assertEqual(WARN,handlerOne.level)
+        logger = getArkoudaLogger(name="UpdateLogger", handlers=[handlerOne, handlerTwo])
+        logger.changeLogLevel(level=LogLevel.WARN, handlerNames=["handler-one"])
+        self.assertEqual(WARN, handlerOne.level)
         self.assertEqual(INFO, handlerTwo.level)
 
     def testVerbosityControls(self):
-        logger = getArkoudaLogger(name='VerboseLogger', logLevel=LogLevel('INFO'))
+        logger = getArkoudaLogger(name="VerboseLogger", logLevel=LogLevel("INFO"))
 
-        self.assertEqual(INFO, logger.getHandler('console-handler').level)
-        logger.debug('non-working debug message')     
-        logger.enableVerbose()  
-        self.assertEqual(DEBUG, logger.getHandler('console-handler').level)
-        logger.debug('working debug message')     
-        logger.disableVerbose() 
-        self.assertEqual(INFO, logger.getHandler('console-handler').level)
-        logger.debug('next non-working debug message') 
-        
-    def testEnableDisableVerbose(self):  
-        loggerOne = getArkoudaLogger(name='loggerOne',logLevel=LogLevel.INFO)
-        loggerTwo = getArkoudaLogger('loggerTwo', logLevel=LogLevel.INFO)
-        
-        loggerOne.debug('loggerOne before enableVerbose')
-        loggerTwo.debug('loggerTwo before enableVerbose')
+        self.assertEqual(INFO, logger.getHandler("console-handler").level)
+        logger.debug("non-working debug message")
+        logger.enableVerbose()
+        self.assertEqual(DEBUG, logger.getHandler("console-handler").level)
+        logger.debug("working debug message")
+        logger.disableVerbose()
+        self.assertEqual(INFO, logger.getHandler("console-handler").level)
+        logger.debug("next non-working debug message")
+
+    def testEnableDisableVerbose(self):
+        loggerOne = getArkoudaLogger(name="loggerOne", logLevel=LogLevel.INFO)
+        loggerTwo = getArkoudaLogger("loggerTwo", logLevel=LogLevel.INFO)
+
+        loggerOne.debug("loggerOne before enableVerbose")
+        loggerTwo.debug("loggerTwo before enableVerbose")
         ak.enableVerbose()
-        loggerOne.debug('loggerOne after enableVerbose')
-        loggerTwo.debug('loggerTwo after enableVerbose')     
+        loggerOne.debug("loggerOne after enableVerbose")
+        loggerTwo.debug("loggerTwo after enableVerbose")
         ak.disableVerbose()
-        loggerOne.debug('loggerOne after disableVerbose')
-        loggerTwo.debug('loggerTwo after disableVerbose')  
-        
+        loggerOne.debug("loggerOne after disableVerbose")
+        loggerTwo.debug("loggerTwo after disableVerbose")
+
     def testErrorHandling(self):
-        logger = getArkoudaLogger(name='VerboseLogger', logLevel=LogLevel('INFO'))
+        logger = getArkoudaLogger(name="VerboseLogger", logLevel=LogLevel("INFO"))
 
         with self.assertRaises(ValueError):
-            logger.getHandler('not-a-handler')
-            
+            logger.getHandler("not-a-handler")
+
         with self.assertRaises(TypeError):
-            logger.disableVerbose(logLevel='INFO')
-    
+            logger.disableVerbose(logLevel="INFO")
+
     @classmethod
     def tearDownClass(cls):
-        os.remove('output.txt')            
+        os.remove("output.txt")

--- a/tests/message_test.py
+++ b/tests/message_test.py
@@ -1,90 +1,100 @@
-import unittest, json
-from context import arkouda
-from arkouda.message import RequestMessage, MessageFormat, ReplyMessage, \
-     MessageType
+import json
+import unittest
+
+from arkouda.message import MessageFormat, MessageType, ReplyMessage, RequestMessage
+
 
 class MessageTest(unittest.TestCase):
-
     def testMessageFormat(self):
-        self.assertEqual(MessageFormat.BINARY, MessageFormat('BINARY'))
-        self.assertEqual(MessageFormat.STRING, MessageFormat('STRING'))
-        self.assertEqual('BINARY', str(MessageFormat.BINARY))
-        self.assertEqual('STRING', str(MessageFormat.STRING))
-        self.assertEqual('BINARY', repr(MessageFormat.BINARY))
-        self.assertEqual('STRING', repr(MessageFormat.STRING))
-        
-        with self.assertRaises(ValueError):
-            MessageFormat('STR')        
-        
-    def testMessageType(self):
-        self.assertEqual(MessageType.NORMAL, MessageType('NORMAL'))
-        self.assertEqual(MessageType.WARNING, MessageType('WARNING'))
-        self.assertEqual(MessageType.ERROR, MessageType('ERROR'))
-       
-        self.assertEqual('NORMAL', str(MessageType.NORMAL))
-        self.assertEqual('WARNING', str(MessageType.WARNING))
-        self.assertEqual('ERROR', str(MessageType.ERROR))
-        self.assertEqual('NORMAL', repr(MessageType.NORMAL))
-        self.assertEqual('WARNING', repr(MessageType.WARNING))
-        self.assertEqual('ERROR', repr(MessageType.ERROR))
-        
-        with self.assertRaises(ValueError):
-            MessageType('STANDARD')
-      
-    def testRequestMessage(self):
-        msg = RequestMessage(user='user1', token='token', cmd='connect', 
-                      format=MessageFormat.STRING)
-        msgDupe = RequestMessage(user='user1', token='token', cmd='connect', 
-                      format=MessageFormat.STRING)
-        msgNonDupe = RequestMessage(user='user1', token='token', cmd='connect', 
-                      format=MessageFormat.BINARY)
-        
-        self.assertEqual('user1', msg.user)
-        self.assertEqual('token', msg.token)
-        self.assertEqual('connect', msg.cmd)
-        self.assertEqual(MessageFormat.STRING, msg.format)
-        
-        self.assertEqual(msg,msgDupe)
-        self.assertNotEqual(msg, msgNonDupe)
-        
-        self.assertEqual("RequestMessage(user='user1', token='token', cmd='connect', format=STRING, args=None)", 
-                         str(msg))
-        
-        self.assertEqual("RequestMessage(user='user1', token='token', cmd='connect', format=STRING, args=None)", 
-                         repr(msg))
+        self.assertEqual(MessageFormat.BINARY, MessageFormat("BINARY"))
+        self.assertEqual(MessageFormat.STRING, MessageFormat("STRING"))
+        self.assertEqual("BINARY", str(MessageFormat.BINARY))
+        self.assertEqual("STRING", str(MessageFormat.STRING))
+        self.assertEqual("BINARY", repr(MessageFormat.BINARY))
+        self.assertEqual("STRING", repr(MessageFormat.STRING))
 
-        self.assertEqual('{"user": "user1", "token": "token", "cmd": "connect", "format": "STRING", "args": ""}',
-                        json.dumps(msg.asdict()))
-        
-        self.assertFalse(self.assertRaises(Exception,json.loads(json.dumps(msg.asdict()))))
-        
-        minMsg = RequestMessage(user='user1', cmd='connect')
-        
-        self.assertEqual("RequestMessage(user='user1', token=None, cmd='connect', format=STRING, args=None)", 
-                         str(minMsg))
-        
-        self.assertEqual("RequestMessage(user='user1', token=None, cmd='connect', format=STRING, args=None)", 
-                         repr(minMsg))
-        self.assertEqual('{"user": "user1", "token": "", "cmd": "connect", "format": "STRING", "args": ""}',
-                        json.dumps(minMsg.asdict()))
-        
-    def testReplyMessage(self):
-        msg = ReplyMessage(msg='normal result',msgType=MessageType.NORMAL, user='user')
-        msgDupe = ReplyMessage(msg='normal result',msgType=MessageType.NORMAL, user='user')
-        msgNonDupe = ReplyMessage(msg='normal result 2',msgType=MessageType.NORMAL, user='user')
-        
-        self.assertEqual(msg,msgDupe)
+        with self.assertRaises(ValueError):
+            MessageFormat("STR")
+
+    def testMessageType(self):
+        self.assertEqual(MessageType.NORMAL, MessageType("NORMAL"))
+        self.assertEqual(MessageType.WARNING, MessageType("WARNING"))
+        self.assertEqual(MessageType.ERROR, MessageType("ERROR"))
+
+        self.assertEqual("NORMAL", str(MessageType.NORMAL))
+        self.assertEqual("WARNING", str(MessageType.WARNING))
+        self.assertEqual("ERROR", str(MessageType.ERROR))
+        self.assertEqual("NORMAL", repr(MessageType.NORMAL))
+        self.assertEqual("WARNING", repr(MessageType.WARNING))
+        self.assertEqual("ERROR", repr(MessageType.ERROR))
+
+        with self.assertRaises(ValueError):
+            MessageType("STANDARD")
+
+    def testRequestMessage(self):
+        msg = RequestMessage(user="user1", token="token", cmd="connect", format=MessageFormat.STRING)
+        msgDupe = RequestMessage(user="user1", token="token", cmd="connect", format=MessageFormat.STRING)
+        msgNonDupe = RequestMessage(
+            user="user1", token="token", cmd="connect", format=MessageFormat.BINARY
+        )
+
+        self.assertEqual("user1", msg.user)
+        self.assertEqual("token", msg.token)
+        self.assertEqual("connect", msg.cmd)
+        self.assertEqual(MessageFormat.STRING, msg.format)
+
+        self.assertEqual(msg, msgDupe)
         self.assertNotEqual(msg, msgNonDupe)
-        
+
+        self.assertEqual(
+            "RequestMessage(user='user1', token='token', cmd='connect', format=STRING, args=None)",
+            str(msg),
+        )
+
+        self.assertEqual(
+            "RequestMessage(user='user1', token='token', cmd='connect', format=STRING, args=None)",
+            repr(msg),
+        )
+
+        self.assertEqual(
+            '{"user": "user1", "token": "token", "cmd": "connect", "format": "STRING", "args": ""}',
+            json.dumps(msg.asdict()),
+        )
+
+        self.assertFalse(self.assertRaises(Exception, json.loads(json.dumps(msg.asdict()))))
+
+        minMsg = RequestMessage(user="user1", cmd="connect")
+
+        self.assertEqual(
+            "RequestMessage(user='user1', token=None, cmd='connect', format=STRING, args=None)",
+            str(minMsg),
+        )
+
+        self.assertEqual(
+            "RequestMessage(user='user1', token=None, cmd='connect', format=STRING, args=None)",
+            repr(minMsg),
+        )
+        self.assertEqual(
+            '{"user": "user1", "token": "", "cmd": "connect", "format": "STRING", "args": ""}',
+            json.dumps(minMsg.asdict()),
+        )
+
+    def testReplyMessage(self):
+        msg = ReplyMessage(msg="normal result", msgType=MessageType.NORMAL, user="user")
+        msgDupe = ReplyMessage(msg="normal result", msgType=MessageType.NORMAL, user="user")
+        msgNonDupe = ReplyMessage(msg="normal result 2", msgType=MessageType.NORMAL, user="user")
+
+        self.assertEqual(msg, msgDupe)
+        self.assertNotEqual(msg, msgNonDupe)
+
         self.assertEqual("ReplyMessage(msg='normal result', msgType=NORMAL, user='user')", str(msg))
         self.assertEqual("ReplyMessage(msg='normal result', msgType=NORMAL, user='user')", repr(msg))
-        
-        newMsg = ReplyMessage.fromdict({ 'msg' : 'normal result', 'msgType': 'NORMAL', 'user': 'user'})
-        self.assertEqual(msg,newMsg)    
-        
+
+        newMsg = ReplyMessage.fromdict({"msg": "normal result", "msgType": "NORMAL", "user": "user"})
+        self.assertEqual(msg, newMsg)
+
         self.assertEqual("ReplyMessage(msg='normal result', msgType=NORMAL, user='user')", str(newMsg))
-        self.assertEqual("ReplyMessage(msg='normal result', msgType=NORMAL, user='user')", repr(newMsg))    
-        
+        self.assertEqual("ReplyMessage(msg='normal result', msgType=NORMAL, user='user')", repr(newMsg))
+
         with self.assertRaises(ValueError):
-            ReplyMessage.fromdict({ 'msg' : 'normal result', 'msgType': 'NORMAL'})
-    
+            ReplyMessage.fromdict({"msg": "normal result", "msgType": "NORMAL"})

--- a/tests/nan_test.py
+++ b/tests/nan_test.py
@@ -1,42 +1,44 @@
 import numpy as np
 import pandas as pd
-from context import arkouda as ak
 from base_test import ArkoudaTest
-import unittest
+from context import arkouda as ak
 
 SIZE = 1000
 GROUPS = 32
 verbose = True
 
-OPS = frozenset(['mean', 'min', 'max', 'sum', 'prod'])
+OPS = frozenset(["mean", "min", "max", "sum", "prod"])
 
-def groupby_to_arrays(df : pd.DataFrame, kname, vname, op):
+
+def groupby_to_arrays(df: pd.DataFrame, kname, vname, op):
     g = df.groupby(kname)[vname]
-    agg = g.aggregate(op.replace('arg', 'idx'))
+    agg = g.aggregate(op.replace("arg", "idx"))
     keys = agg.index.values
     return keys, agg.values
+
 
 def make_arrays():
     keys = np.random.randint(0, GROUPS, SIZE)
     f = np.random.randn(SIZE)
-    #f.fill(5)
+    # f.fill(5)
 
     for i in range(SIZE):
-        if np.random.rand() < .2:
+        if np.random.rand() < 0.2:
             f[i] = np.nan
-    d = {'keys':keys, 'float64':f}
+    d = {"keys": keys, "float64": f}
 
     return d
 
+
 def compare_keys(pdkeys, akkeys, pdvals, akvals) -> int:
-    '''
+    """
     Compares the numpy and arkouda arrays via the numpy.allclose method with the
     default relative and absolute tolerances, returning 0 if the arrays are similar
     element-wise within the tolerances, 1 if they are dissimilar.element
-    
+
     :return: 0 (identical) or 1 (dissimilar)
     :rtype: int
-    '''
+    """
     akkeys = akkeys.to_ndarray()
 
     if not np.allclose(pdkeys, akkeys):
@@ -50,27 +52,27 @@ def compare_keys(pdkeys, akkeys, pdvals, akvals) -> int:
 
 
 def run_test(verbose=True):
-    '''
-    The run_test method enables execution of ak.GroupBy and ak.GroupBy.Reductions 
+    """
+    The run_test method enables execution of ak.GroupBy and ak.GroupBy.Reductions
     for mean, min, max, and sum
-    on a randomized set of arrays including nan values. 
+    on a randomized set of arrays including nan values.
 
-    :return: 
-    '''
+    :return:
+    """
 
     d = make_arrays()
     df = pd.DataFrame(d)
-    akdf = {k:ak.array(v) for k, v in d.items()}
+    akdf = {k: ak.array(v) for k, v in d.items()}
 
-    akg = ak.GroupBy(akdf['keys'])
-    keyname = 'keys'
+    akg = ak.GroupBy(akdf["keys"])
+    keyname = "keys"
 
     tests = 0
     failures = 0
     not_impl = 0
 
     tests += 1
-    pdkeys, pdvals = groupby_to_arrays(df, keyname, 'float64', 'count')
+    pdkeys, pdvals = groupby_to_arrays(df, keyname, "float64", "count")
     akkeys, akvals = akg.count()
     akvals = akvals.to_ndarray()
 
@@ -79,15 +81,17 @@ def run_test(verbose=True):
 
         do_check = True
         try:
-            pdkeys, pdvals = groupby_to_arrays(df, keyname, 'float64', op)
-        except Exception as E:
-            if verbose: print("Pandas does not implement")
+            pdkeys, pdvals = groupby_to_arrays(df, keyname, "float64", op)
+        except Exception:
+            if verbose:
+                print("Pandas does not implement")
             do_check = False
         try:
-            akkeys, akvals = akg.aggregate(akdf['float64'], op, True)
+            akkeys, akvals = akg.aggregate(akdf["float64"], op, True)
             akvals = akvals.to_ndarray()
         except RuntimeError as E:
-            if verbose: print("Arkouda error: ", E)
+            if verbose:
+                print("Arkouda error: ", E)
             not_impl += 1
             do_check = False
             continue
@@ -96,17 +100,18 @@ def run_test(verbose=True):
 
         for i in range(pdvals.size):
             if np.isnan(pdvals[i]):
-                pdvals[i] = 0.0 # clear out any nans to match ak implementation
+                pdvals[i] = 0.0  # clear out any nans to match ak implementation
         failures += compare_keys(pdkeys, akkeys, pdvals, akvals)
 
     return failures
 
+
 class NanTest(ArkoudaTest):
     def test_nan(self):
-        '''
+        """
         Executes run_test and asserts whether there are any errors
-        
+
         :return: None
         :raise: AssertionError if there are any errors encountered in run_test with nan values
-        '''
+        """
         self.assertEqual(0, run_test())

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -1,14 +1,16 @@
 import numpy as np
-from context import arkouda as ak
-from arkouda.dtypes import npstr
 from base_test import ArkoudaTest
+from context import arkouda as ak
+
+from arkouda.dtypes import npstr
 
 """
 Encapsulates unit tests for the numeric module with the exception
 of the where method, which is in the where_test module
 """
-class NumericTest(ArkoudaTest):
 
+
+class NumericTest(ArkoudaTest):
     def testSeededRNG(self):
         N = 100
         seed = 8675309
@@ -29,26 +31,46 @@ class NumericTest(ArkoudaTest):
         self.assertFalse((ak.standard_normal(N) == ak.standard_normal(N)).all())
         self.assertTrue((ak.standard_normal(N, seed=seed) == ak.standard_normal(N, seed=seed)).all())
         # Strings (uniformly distributed length)
-        self.assertFalse((ak.random_strings_uniform(1, 10, N) == ak.random_strings_uniform(1, 10, N)).all())
-        self.assertTrue((ak.random_strings_uniform(1, 10, N, seed=seed) == ak.random_strings_uniform(1, 10, N, seed=seed)).all())
+        self.assertFalse(
+            (ak.random_strings_uniform(1, 10, N) == ak.random_strings_uniform(1, 10, N)).all()
+        )
+        self.assertTrue(
+            (
+                ak.random_strings_uniform(1, 10, N, seed=seed)
+                == ak.random_strings_uniform(1, 10, N, seed=seed)
+            ).all()
+        )
         # Strings (log-normally distributed length)
-        self.assertFalse((ak.random_strings_lognormal(2, 1, N) == ak.random_strings_lognormal(2, 1, N)).all())
-        self.assertTrue((ak.random_strings_lognormal(2, 1, N, seed=seed) == ak.random_strings_lognormal(2, 1, N, seed=seed)).all())
-            
+        self.assertFalse(
+            (ak.random_strings_lognormal(2, 1, N) == ak.random_strings_lognormal(2, 1, N)).all()
+        )
+        self.assertTrue(
+            (
+                ak.random_strings_lognormal(2, 1, N, seed=seed)
+                == ak.random_strings_lognormal(2, 1, N, seed=seed)
+            ).all()
+        )
+
     def testCast(self):
         N = 100
-        arrays = {ak.int64: ak.randint(-(2**48), 2**48, N),
-                  ak.float64: ak.randint(0, 1, N, dtype=ak.float64),
-                  ak.bool: ak.randint(0, 2, N, dtype=ak.bool)}
-        roundtripable = set(((ak.bool, ak.bool),
-                         (ak.int64, ak.int64),
-                         (ak.int64, ak.float64),
-                         (ak.int64, npstr),
-                         (ak.float64, ak.float64),
-                         (ak.float64, npstr),
-                         (ak.uint8, ak.int64),
-                         (ak.uint8, ak.float64),
-                         (ak.uint8, npstr)))
+        arrays = {
+            ak.int64: ak.randint(-(2**48), 2**48, N),
+            ak.float64: ak.randint(0, 1, N, dtype=ak.float64),
+            ak.bool: ak.randint(0, 2, N, dtype=ak.bool),
+        }
+        roundtripable = set(
+            (
+                (ak.bool, ak.bool),
+                (ak.int64, ak.int64),
+                (ak.int64, ak.float64),
+                (ak.int64, npstr),
+                (ak.float64, ak.float64),
+                (ak.float64, npstr),
+                (ak.uint8, ak.int64),
+                (ak.uint8, ak.float64),
+                (ak.uint8, npstr),
+            )
+        )
         for t1, orig in arrays.items():
             for t2 in ak.DTypes:
                 t2 = ak.dtype(t2)
@@ -56,11 +78,17 @@ class NumericTest(ArkoudaTest):
                 self.assertEqual(orig.size, other.size)
                 if (t1, t2) in roundtripable:
                     roundtrip = ak.cast(other, t1)
-                    self.assertTrue((orig == roundtrip).all(), f"{t1}: {orig[:5]}, {t2}: {roundtrip[:5]}")
-                    
-        self.assertTrue((ak.array([1, 2, 3, 4, 5]) == ak.cast(ak.linspace(1,5,5), dt=ak.int64)).all())
-        self.assertEqual(ak.cast(ak.arange(0,5), dt=ak.float64).dtype, ak.float64)
-        self.assertTrue((ak.array([False, True, True, True, True]) == ak.cast(ak.linspace(0,4,5), dt=ak.bool)).all())
+                    self.assertTrue(
+                        (orig == roundtrip).all(), f"{t1}: {orig[:5]}, {t2}: {roundtrip[:5]}"
+                    )
+
+        self.assertTrue((ak.array([1, 2, 3, 4, 5]) == ak.cast(ak.linspace(1, 5, 5), dt=ak.int64)).all())
+        self.assertEqual(ak.cast(ak.arange(0, 5), dt=ak.float64).dtype, ak.float64)
+        self.assertTrue(
+            (
+                ak.array([False, True, True, True, True]) == ak.cast(ak.linspace(0, 4, 5), dt=ak.bool)
+            ).all()
+        )
 
     def testStrCastErrors(self):
         intNAN = -(2**63)
@@ -71,104 +99,108 @@ class NumericTest(ArkoudaTest):
         uintans = np.array([1, 2, uintNAN, uintNAN, 5, 45, 0b101, 0x30, uintNAN])
         floatstr = ak.array(["1.1", "2.2 ", "3?.3", "4.!4", "  5.5", "6.6e-6", "78.91E+4", "6", "N/A"])
         floatans = np.array([1.1, 2.2, np.nan, np.nan, 5.5, 6.6e-6, 78.91e4, 6.0, np.nan])
-        boolstr = ak.array(["True", "False ", "Neither", "N/A", "  True", "true", "false", "TRUE", "NOTTRUE"])
+        boolstr = ak.array(
+            ["True", "False ", "Neither", "N/A", "  True", "true", "false", "TRUE", "NOTTRUE"]
+        )
         boolans = np.array([True, False, False, False, True, True, False, True, False])
         validans = ak.array([True, True, False, False, True, True, True, True, False])
-        for dt, arg, ans in [(ak.int64, intstr, intans),
-                             (ak.uint64, uintstr, uintans),
-                             (ak.float64, floatstr, floatans),
-                             (ak.bool, boolstr, boolans)]:
-            with self.assertRaises(RuntimeError) as cm:
+        for dt, arg, ans in [
+            (ak.int64, intstr, intans),
+            (ak.uint64, uintstr, uintans),
+            (ak.float64, floatstr, floatans),
+            (ak.bool, boolstr, boolans),
+        ]:
+            with self.assertRaises(RuntimeError):
                 ak.cast(arg, dt, errors=ak.ErrorMode.strict)
             res = ak.cast(arg, dt, errors=ak.ErrorMode.ignore)
             self.assertTrue(np.allclose(ans, res.to_ndarray(), equal_nan=True))
             res, valid = ak.cast(arg, dt, errors=ak.ErrorMode.return_validity)
             self.assertTrue((valid == validans).all())
             self.assertTrue(np.allclose(ans, res.to_ndarray(), equal_nan=True))
-    
+
     def testHistogram(self):
-        pda = ak.randint(10,30,40)
+        pda = ak.randint(10, 30, 40)
         bins, result = ak.histogram(pda, bins=20)
 
         self.assertIsInstance(result, ak.pdarray)
         self.assertEqual(20, len(bins))
         self.assertEqual(20, len(result))
         self.assertEqual(int, result.dtype)
-        
-        with self.assertRaises(TypeError) as cm:
-            ak.histogram([range(0,10)], bins=1)
-        
-        with self.assertRaises(TypeError) as cm:
-            ak.histogram(pda, bins='1')
-        
-        with self.assertRaises(TypeError) as cm:
-            ak.histogram([range(0,10)], bins='1')
-    
+
+        with self.assertRaises(TypeError):
+            ak.histogram([range(0, 10)], bins=1)
+
+        with self.assertRaises(TypeError):
+            ak.histogram(pda, bins="1")
+
+        with self.assertRaises(TypeError):
+            ak.histogram([range(0, 10)], bins="1")
+
     def testLog(self):
-        na = np.linspace(1,10,10)
+        na = np.linspace(1, 10, 10)
         pda = ak.array(na)
 
         self.assertTrue((np.log(na) == ak.log(pda).to_ndarray()).all())
-        with self.assertRaises(TypeError) as cm:
-            ak.log([range(0,10)])
-        
+        with self.assertRaises(TypeError):
+            ak.log([range(0, 10)])
+
     def testExp(self):
-        na = np.linspace(1,10,10)
+        na = np.linspace(1, 10, 10)
         pda = ak.array(na)
 
         self.assertTrue((np.exp(na) == ak.exp(pda).to_ndarray()).all())
-        with self.assertRaises(TypeError) as cm:
-            ak.exp([range(0,10)])
-        
+        with self.assertRaises(TypeError):
+            ak.exp([range(0, 10)])
+
     def testAbs(self):
-        na = np.linspace(1,10,10)
+        na = np.linspace(1, 10, 10)
         pda = ak.array(na)
 
         self.assertTrue((np.abs(na) == ak.abs(pda).to_ndarray()).all())
-        self.assertTrue((ak.arange(5,1,-1) == ak.abs(ak.arange(-5,-1))).all())
-        self.assertTrue((ak.array([5,4,3,2,1]) == ak.abs(ak.linspace(-5,-1,5))).all())
-        
-        with self.assertRaises(TypeError) as cm:
-            ak.abs([range(0,10)])
+        self.assertTrue((ak.arange(5, 1, -1) == ak.abs(ak.arange(-5, -1))).all())
+        self.assertTrue((ak.array([5, 4, 3, 2, 1]) == ak.abs(ak.linspace(-5, -1, 5))).all())
+
+        with self.assertRaises(TypeError):
+            ak.abs([range(0, 10)])
 
     def testCumSum(self):
-        na = np.linspace(1,10,10)
+        na = np.linspace(1, 10, 10)
         pda = ak.array(na)
 
         self.assertTrue((np.cumsum(na) == ak.cumsum(pda).to_ndarray()).all())
 
         # Test uint case
-        na = np.linspace(1,10,10, 'uint64')
+        na = np.linspace(1, 10, 10, "uint64")
         pda = ak.cast(pda, ak.uint64)
-        
+
         self.assertTrue((np.cumsum(na) == ak.cumsum(pda).to_ndarray()).all())
-        
-        with self.assertRaises(TypeError) as cm:
-            ak.cumsum([range(0,10)])
-        
+
+        with self.assertRaises(TypeError):
+            ak.cumsum([range(0, 10)])
+
     def testCumProd(self):
-        na = np.linspace(1,10,10)
+        na = np.linspace(1, 10, 10)
         pda = ak.array(na)
 
         self.assertTrue((np.cumprod(na) == ak.cumprod(pda).to_ndarray()).all())
-        with self.assertRaises(TypeError) as cm:
-            ak.cumprod([range(0,10)])
-        
+        with self.assertRaises(TypeError):
+            ak.cumprod([range(0, 10)])
+
     def testSin(self):
-        na = np.linspace(1,10,10)
+        na = np.linspace(1, 10, 10)
         pda = ak.array(na)
-    
+
         self.assertTrue((np.sin(na) == ak.sin(pda).to_ndarray()).all())
-        with self.assertRaises(TypeError) as cm:
-            ak.cos([range(0,10)])
-        
+        with self.assertRaises(TypeError):
+            ak.cos([range(0, 10)])
+
     def testCos(self):
-        na = np.linspace(1,10,10)
+        na = np.linspace(1, 10, 10)
         pda = ak.array(na)
-  
-        self.assertTrue((np.cos(na) == ak.cos(pda).to_ndarray()).all())    
-        with self.assertRaises(TypeError) as cm:
-            ak.cos([range(0,10)])
+
+        self.assertTrue((np.cos(na) == ak.cos(pda).to_ndarray()).all())
+        with self.assertRaises(TypeError):
+            ak.cos([range(0, 10)])
 
     def testHash(self):
         h1, h2 = ak.hash(ak.arange(10))
@@ -182,25 +214,25 @@ class NumericTest(ArkoudaTest):
 
         h = ak.hash(ak.linspace(0, 10, 10))
         self.assertTrue((h[0].dtype == ak.uint64) and (h[1].dtype == ak.uint64))
-        
-        
+
     def testValueCounts(self):
         pda = ak.ones(100, dtype=ak.int64)
         result = ak.value_counts(pda)
 
         self.assertEqual(ak.array([1]), result[0])
         self.assertEqual(ak.array([100]), result[1])
-        
-        pda = ak.linspace(1,10,10)
-        with self.assertRaises(TypeError) as cm:
+
+        pda = ak.linspace(1, 10, 10)
+        with self.assertRaises(TypeError):
             ak.value_counts(pda)
 
-        with self.assertRaises(TypeError) as cm:  
+        with self.assertRaises(TypeError):
             ak.value_counts([0])
 
     def test_isnan(self):
         """
-        Test efunc `isnan`; it returns a pdarray of element-wise T/F values for whether it is NaN (not a number)
+        Test efunc `isnan`; it returns a pdarray of element-wise T/F values for whether it is NaN
+        (not a number)
         Currently we only support float based arrays since numpy doesn't support NaN in int-based arrays
         """
         npa = np.array([1, 2, None, 3, 4], dtype="float64")
@@ -228,5 +260,5 @@ class NumericTest(ArkoudaTest):
         g = ak.GroupBy(groupnum)
         _, intmean = g.mean(intval)
         _, floatmean = g.mean(floatval)
-        ak_mse = ak.mean((intmean - floatmean)**2)
+        ak_mse = ak.mean((intmean - floatmean) ** 2)
         self.assertTrue(np.isclose(ak_mse, 0.0))

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -1,30 +1,34 @@
-import numpy as np
 import warnings
 from itertools import product
+
+import numpy as np
 from base_test import ArkoudaTest
 from context import arkouda as ak
+
 SIZE = 10
 verbose = ArkoudaTest.verbose
 
+
 def run_tests(verbose):
     # ignore numpy warnings like divide by 0
-    np.seterr(all='ignore')
+    np.seterr(all="ignore")
     global pdarrays
-    pdarrays = {'int64': ak.arange(0, SIZE, 1),
-                'uint64': ak.array(np.arange(0, SIZE, 1, dtype=np.uint64)),
-                'float64': ak.linspace(0, 2, SIZE),
-                'bool': (ak.arange(0, SIZE, 1) % 2) == 0}
+    pdarrays = {
+        "int64": ak.arange(0, SIZE, 1),
+        "uint64": ak.array(np.arange(0, SIZE, 1, dtype=np.uint64)),
+        "float64": ak.linspace(0, 2, SIZE),
+        "bool": (ak.arange(0, SIZE, 1) % 2) == 0,
+    }
     global ndarrays
-    ndarrays = {'int64': np.arange(0, SIZE, 1),
-                'uint64': np.arange(0, SIZE, 1, dtype=np.uint64),
-                'float64': np.linspace(0, 2, SIZE),
-                'bool': (np.arange(0, SIZE, 1) % 2) == 0}
+    ndarrays = {
+        "int64": np.arange(0, SIZE, 1),
+        "uint64": np.arange(0, SIZE, 1, dtype=np.uint64),
+        "float64": np.linspace(0, 2, SIZE),
+        "bool": (np.arange(0, SIZE, 1) % 2) == 0,
+    }
     global scalars
-    #scalars = {k: v[SIZE//2] for k, v in ndarrays.items()}
-    scalars = {'int64': 5,
-               'uint64': np.uint64(5),
-               'float64': 3.14159,
-               'bool': True}
+    # scalars = {k: v[SIZE//2] for k, v in ndarrays.items()}
+    scalars = {"int64": 5, "uint64": np.uint64(5), "float64": 3.14159, "bool": True}
     dtypes = pdarrays.keys()
     if verbose:
         print("Operators: ", ak.pdarray.BinOps)
@@ -40,121 +44,139 @@ def run_tests(verbose):
             print(k, ": ", v)
 
     def do_op(lt, rt, ls, rs, isarkouda, oper):
-        evalstr = ''
+        evalstr = ""
         if ls:
             evalstr += 'scalars["{}"]'.format(lt)
         else:
-            evalstr += '{}["{}"]'.format(('ndarrays', 'pdarrays')[isarkouda], lt)
-        evalstr += ' {} '.format(oper)
+            evalstr += '{}["{}"]'.format(("ndarrays", "pdarrays")[isarkouda], lt)
+        evalstr += " {} ".format(oper)
         if rs:
             evalstr += 'scalars["{}"]'.format(rt)
         else:
-            evalstr += '{}["{}"]'.format(('ndarrays', 'pdarrays')[isarkouda], rt)
-        #print(evalstr)
+            evalstr += '{}["{}"]'.format(("ndarrays", "pdarrays")[isarkouda], rt)
+        # print(evalstr)
         res = eval(evalstr)
         return res
 
-    results = {'neither_implement': [],   # (expression, ak_error)
-               'arkouda_minus_numpy': [], # (expression, ak_result, error_on_exec?)
-               'numpy_minus_arkouda': [], # (expression, ak_result, error_on_exec?)
-               'both_implement': []}      # (expression, ak_result, error_on_exec?, dtype_mismatch?, value_mismatch?)
+    results = {
+        "neither_implement": [],  # (expression, ak_error)
+        "arkouda_minus_numpy": [],  # (expression, ak_result, error_on_exec?)
+        "numpy_minus_arkouda": [],  # (expression, ak_result, error_on_exec?)
+        "both_implement": [],
+    }  # (expression, ak_result, error_on_exec?, dtype_mismatch?, value_mismatch?)
     tests = 0
     for ltype, rtype, op in product(dtypes, dtypes, ak.pdarray.BinOps):
         if op in ("<<<", ">>>"):
             continue
         for lscalar, rscalar in ((False, False), (False, True), (True, False)):
             tests += 1
-            expression = "{}({}) {} {}({})".format(ltype, ('array', 'scalar')[lscalar], op, rtype, ('array', 'scalar')[rscalar])
+            expression = "{}({}) {} {}({})".format(
+                ltype, ("array", "scalar")[lscalar], op, rtype, ("array", "scalar")[rscalar]
+            )
             try:
                 npres = do_op(ltype, rtype, lscalar, rscalar, False, op)
-            except TypeError: # numpy doesn't implement operation
+            except TypeError:  # numpy doesn't implement operation
                 try:
                     akres = do_op(ltype, rtype, lscalar, rscalar, True, op)
                 except RuntimeError as e:
-                    if 'not implemented' or 'unrecognized type' in str(e):  # neither numpy nor arkouda implement
-                        results['neither_implement'].append((expression, str(e)))
-                    else: # arkouda implements with error, np does not implement
-                        results['arkouda_minus_numpy'].append((expression, str(e), True))
+                    if "not implemented" or "unrecognized type" in str(
+                        e
+                    ):  # neither numpy nor arkouda implement
+                        results["neither_implement"].append((expression, str(e)))
+                    else:  # arkouda implements with error, np does not implement
+                        results["arkouda_minus_numpy"].append((expression, str(e), True))
                     continue
                 # arkouda implements but not numpy
-                results['arkouda_minus_numpy'].append((expression, str(akres), False))
+                results["arkouda_minus_numpy"].append((expression, str(akres), False))
                 continue
             try:
                 akres = do_op(ltype, rtype, lscalar, rscalar, True, op)
             except RuntimeError as e:
-                if 'not implemented' or 'unrecognized type' in str(e):  # numpy implements but not arkouda
-                    results['numpy_minus_arkouda'].append((expression, str(e), True))
-                else: # both implement, but arkouda errors
-                    results['both_implement'].append((expression, str(e), True, False, False))
+                if "not implemented" or "unrecognized type" in str(
+                    e
+                ):  # numpy implements but not arkouda
+                    results["numpy_minus_arkouda"].append((expression, str(e), True))
+                else:  # both implement, but arkouda errors
+                    results["both_implement"].append((expression, str(e), True, False, False))
                 continue
             # both numpy and arkouda execute without error
             try:
                 akrestype = akres.dtype
-            except Exception as e:
-                warnings.warn("Cannot detect return dtype of ak result: {} (np result: {})".format(akres, npres))
-                results['both_implement'].append((expression, str(akres), False, True, False))
+            except Exception:
+                warnings.warn(
+                    "Cannot detect return dtype of ak result: {} (np result: {})".format(akres, npres)
+                )
+                results["both_implement"].append((expression, str(akres), False, True, False))
                 continue
 
             if akrestype != npres.dtype:
                 restypes = "{}(np) vs. {}(ak)".format(npres.dtype, akrestype)
-                #warnings.warn("dtype mismatch: {} = {}".format(expression, restypes))
-                results['both_implement'].append((expression, restypes, False, True, False))
+                # warnings.warn("dtype mismatch: {} = {}".format(expression, restypes))
+                results["both_implement"].append((expression, restypes, False, True, False))
                 continue
             try:
                 akasnp = akres.to_ndarray()
-            except Exception as e:
+            except Exception:
                 warnings.warn("Could not convert to ndarray: {}".format(akres))
-                results['both_implement'].append((expression, str(akres), True, False, False))
+                results["both_implement"].append((expression, str(akres), True, False, False))
                 continue
             if not np.allclose(akasnp, npres, equal_nan=True):
                 res = "np: {}\nak: {}".format(npres, akasnp)
                 # warnings.warn("result mismatch: {} =\n{}".format(expression, res))
-                results['both_implement'].append((expression, res, False, False, True))
+                results["both_implement"].append((expression, res, False, False, True))
             # Finally, both numpy and arkouda agree on result
-            results['both_implement'].append((expression, "", False, False, False))
+            results["both_implement"].append((expression, "", False, False, False))
 
-    print("# ops not implemented by numpy or arkouda: {}".format(len(results['neither_implement'])))
+    print("# ops not implemented by numpy or arkouda: {}".format(len(results["neither_implement"])))
     if verbose:
-        for expression, err in results['neither_implement']:
+        for expression, err in results["neither_implement"]:
             print(expression)
-    print("# ops implemented by numpy but not arkouda: {}".format(len(results['numpy_minus_arkouda'])))
+    print("# ops implemented by numpy but not arkouda: {}".format(len(results["numpy_minus_arkouda"])))
     if verbose:
-        for expression, err, flag in results['numpy_minus_arkouda']:
+        for expression, err, flag in results["numpy_minus_arkouda"]:
             print(expression)
-    print("# ops implemented by arkouda but not numpy: {}".format(len(results['arkouda_minus_numpy'])))
+    print("# ops implemented by arkouda but not numpy: {}".format(len(results["arkouda_minus_numpy"])))
     if verbose:
-        for expression, res, flag in results['arkouda_minus_numpy']:
+        for expression, res, flag in results["arkouda_minus_numpy"]:
             print(expression, " -> ", res)
-    nboth = len(results['both_implement'])
+    nboth = len(results["both_implement"])
     print("# ops implemented by both: {}".format(nboth))
     matches = 0
     execerrors = []
     dtypeerrors = []
     valueerrors = []
-    for (expression, res, ex, dt, val) in results['both_implement']:
+    for (expression, res, ex, dt, val) in results["both_implement"]:
         matches += not any((ex, dt, val))
-        if ex: execerrors.append((expression, res))
-        if dt: dtypeerrors.append((expression, res))
-        if val: valueerrors.append((expression, res))
+        if ex:
+            execerrors.append((expression, res))
+        if dt:
+            dtypeerrors.append((expression, res))
+        if val:
+            valueerrors.append((expression, res))
     print("  Matching results:         {} / {}".format(matches, nboth))
     print("  Arkouda execution errors: {} / {}".format(len(execerrors), nboth))
-    if verbose: print('\n'.join(map(': '.join, execerrors)))
+    if verbose:
+        print("\n".join(map(": ".join, execerrors)))
     print("  Dtype mismatches:         {} / {}".format(len(dtypeerrors), nboth))
-    if verbose: print('\n'.join(map(': '.join, dtypeerrors)))
+    if verbose:
+        print("\n".join(map(": ".join, dtypeerrors)))
     print("  Value mismatches:         {} / {}".format(len(valueerrors), nboth))
-    if verbose: print('\n'.join(map(': '.join, valueerrors)))
+    if verbose:
+        print("\n".join(map(": ".join, valueerrors)))
     return matches == nboth
 
-'''
-Encapsulates test cases that invoke the run_tests method.
-'''
-class OperatorsTest(ArkoudaTest):
 
+"""
+Encapsulates test cases that invoke the run_tests method.
+"""
+
+
+class OperatorsTest(ArkoudaTest):
     def testPdArrayAddInt(self):
         aArray = ak.ones(100)
         addArray = aArray + 1
         self.assertIsInstance(addArray, ak.pdarrayclass.pdarray)
-        self.assertEqual(np.float64(2),addArray[0])
+        self.assertEqual(np.float64(2), addArray[0])
 
         addArray = 1 + aArray
         self.assertIsInstance(addArray, ak.pdarrayclass.pdarray)
@@ -172,98 +194,96 @@ class OperatorsTest(ArkoudaTest):
 
     def testPdArraySubtractInt(self):
         aArray = ak.ones(100)
-        subArray =  aArray - 2
+        subArray = aArray - 2
         self.assertIsInstance(subArray, ak.pdarrayclass.pdarray)
         self.assertEqual(np.float64(-1), subArray[0])
 
-        subArray =  2 - aArray
+        subArray = 2 - aArray
         self.assertIsInstance(subArray, ak.pdarrayclass.pdarray)
         self.assertEqual(np.float64(1), subArray[0])
 
     def testPdArraySubtractNumpyInt(self):
         aArray = ak.ones(100)
-        subArray =  aArray - np.int64(2)
+        subArray = aArray - np.int64(2)
         self.assertIsInstance(subArray, ak.pdarrayclass.pdarray)
         self.assertEqual(np.float64(-1), subArray[0])
 
-        subArray =  np.int64(2) - aArray
+        subArray = np.int64(2) - aArray
         self.assertIsInstance(subArray, ak.pdarrayclass.pdarray)
         self.assertEqual(np.float64(1), subArray[0])
 
     def testPdArrayMultInt(self):
         aArray = ak.ones(100)
-        mArray =  aArray*5
+        mArray = aArray * 5
         self.assertIsInstance(mArray, ak.pdarrayclass.pdarray)
         self.assertEqual(np.float64(5), mArray[0])
 
-        mArray =  5*aArray
+        mArray = 5 * aArray
         self.assertIsInstance(mArray, ak.pdarrayclass.pdarray)
         self.assertEqual(np.float64(5), mArray[0])
 
     def testPdArrayMultNumpyInt(self):
         aArray = ak.ones(100)
-        mArray =  aArray*np.int64(5)
+        mArray = aArray * np.int64(5)
         self.assertIsInstance(mArray, ak.pdarrayclass.pdarray)
         self.assertEqual(np.float64(5), mArray[0])
 
-        mArray =  np.int64(5)*aArray
+        mArray = np.int64(5) * aArray
         self.assertIsInstance(mArray, ak.pdarrayclass.pdarray)
         self.assertEqual(np.float64(5), mArray[0])
 
     def testPdArrayDivideInt(self):
         aArray = ak.ones(100)
-        dArray =  aArray*15/3
+        dArray = aArray * 15 / 3
         self.assertIsInstance(dArray, ak.pdarrayclass.pdarray)
         self.assertEqual(np.float64(5), dArray[0])
 
-        dArray =  15*aArray/3
+        dArray = 15 * aArray / 3
         self.assertIsInstance(dArray, ak.pdarrayclass.pdarray)
         self.assertEqual(np.float64(5), dArray[0])
 
     def testPdArrayDivideNumpyInt(self):
         aArray = ak.ones(100)
-        dArray =  aArray*np.int64(15)/3
+        dArray = aArray * np.int64(15) / 3
         self.assertIsInstance(dArray, ak.pdarrayclass.pdarray)
         self.assertEqual(np.float64(5), dArray[0])
 
-        dArray =  np.int64(15)*aArray/3
+        dArray = np.int64(15) * aArray / 3
         self.assertIsInstance(dArray, ak.pdarrayclass.pdarray)
         self.assertEqual(np.float64(5), dArray[0])
-        
+
     def testPdArrayConcatenation(self):
         onesOne = ak.randint(0, 100, 100)
         onesTwo = ak.randint(0, 100, 100)
-        
-        result = ak.concatenate([onesOne,onesTwo])
+
+        result = ak.concatenate([onesOne, onesTwo])
         self.assertEqual(200, len(result))
-        self.assertEqual(np.int64,result.dtype)
+        self.assertEqual(np.int64, result.dtype)
 
     def testConcatenate(self):
-        pdaOne = ak.arange(1,4)
-        pdaTwo = ak.arange(4,7)  
-        
-        self.assertTrue((ak.array([1,2,3,4,5,6])
-                              == ak.concatenate([pdaOne,pdaTwo])).all())
-        self.assertTrue((ak.array([4,5,6,1,2,3])
-                              == ak.concatenate([pdaTwo,pdaOne])).all())
-        
-        pdaOne = ak.linspace(start=1,stop=3,length=3)
-        pdaTwo = ak.linspace(start=4,stop=6,length=3)        
-        
-        self.assertTrue((ak.array([1,2,3,4,5,6])
-                              == ak.concatenate([pdaOne,pdaTwo])).all())
-        self.assertTrue((ak.array([4,5,6,1,2,3])
-                              == ak.concatenate([pdaTwo,pdaOne])).all())
+        pdaOne = ak.arange(1, 4)
+        pdaTwo = ak.arange(4, 7)
 
-        pdaOne = ak.array([True,False,True])
-        pdaTwo = ak.array([False,True,True])
-       
-        self.assertTrue((ak.array([True, False, True, False, True, True]) == 
-                ak.concatenate([pdaOne,pdaTwo])).all())
+        self.assertTrue((ak.array([1, 2, 3, 4, 5, 6]) == ak.concatenate([pdaOne, pdaTwo])).all())
+        self.assertTrue((ak.array([4, 5, 6, 1, 2, 3]) == ak.concatenate([pdaTwo, pdaOne])).all())
+
+        pdaOne = ak.linspace(start=1, stop=3, length=3)
+        pdaTwo = ak.linspace(start=4, stop=6, length=3)
+
+        self.assertTrue((ak.array([1, 2, 3, 4, 5, 6]) == ak.concatenate([pdaOne, pdaTwo])).all())
+        self.assertTrue((ak.array([4, 5, 6, 1, 2, 3]) == ak.concatenate([pdaTwo, pdaOne])).all())
+
+        pdaOne = ak.array([True, False, True])
+        pdaTwo = ak.array([False, True, True])
+
+        self.assertTrue(
+            (ak.array([True, False, True, False, True, True]) == ak.concatenate([pdaOne, pdaTwo])).all()
+        )
 
     def test_concatenate_type_preservation(self):
         # Test that concatenate preserves special pdarray types (IPv4, Datetime, BitVector, ...)
         from arkouda.util import concatenate as akuconcat
+
         pda_one = ak.arange(1, 4)
         pda_two = ak.arange(4, 7)
         pda_concat = ak.concatenate([pda_one, pda_two])
@@ -273,10 +293,14 @@ class OperatorsTest(ArkoudaTest):
         ipv4_two = ak.IPv4(pda_two)
         ipv4_concat = ak.concatenate([ipv4_one, ipv4_two])
         self.assertEqual(type(ipv4_concat), ak.IPv4)
-        self.assertListEqual(ak.IPv4(pda_concat).to_ndarray().tolist(), ipv4_concat.to_ndarray().tolist())
+        self.assertListEqual(
+            ak.IPv4(pda_concat).to_ndarray().tolist(), ipv4_concat.to_ndarray().tolist()
+        )
         # test single and empty
         self.assertEqual(type(ak.concatenate([ipv4_one])), ak.IPv4)
-        self.assertListEqual(ak.IPv4(pda_one).to_ndarray().tolist(), ak.concatenate([ipv4_one]).to_ndarray().tolist())
+        self.assertListEqual(
+            ak.IPv4(pda_one).to_ndarray().tolist(), ak.concatenate([ipv4_one]).to_ndarray().tolist()
+        )
         self.assertEqual(type(ak.concatenate([ak.IPv4(ak.array([], dtype=ak.int64))])), ak.IPv4)
 
         # Datetime test
@@ -284,10 +308,15 @@ class OperatorsTest(ArkoudaTest):
         datetime_two = ak.Datetime(pda_two)
         datetime_concat = ak.concatenate([datetime_one, datetime_two])
         self.assertEqual(type(datetime_concat), ak.Datetime)
-        self.assertListEqual(ak.Datetime(pda_concat).to_ndarray().tolist(), datetime_concat.to_ndarray().tolist())
+        self.assertListEqual(
+            ak.Datetime(pda_concat).to_ndarray().tolist(), datetime_concat.to_ndarray().tolist()
+        )
         # test single and empty
         self.assertEqual(type(ak.concatenate([datetime_one])), ak.Datetime)
-        self.assertListEqual(ak.Datetime(pda_one).to_ndarray().tolist(), ak.concatenate([datetime_one]).to_ndarray().tolist())
+        self.assertListEqual(
+            ak.Datetime(pda_one).to_ndarray().tolist(),
+            ak.concatenate([datetime_one]).to_ndarray().tolist(),
+        )
         self.assertEqual(type(ak.concatenate([ak.Datetime(ak.array([], dtype=ak.int64))])), ak.Datetime)
 
         # Timedelta test
@@ -295,22 +324,36 @@ class OperatorsTest(ArkoudaTest):
         timedelta_two = ak.Timedelta(pda_two)
         timedelta_concat = ak.concatenate([timedelta_one, timedelta_two])
         self.assertEqual(type(timedelta_concat), ak.Timedelta)
-        self.assertListEqual(ak.Timedelta(pda_concat).to_ndarray().tolist(), timedelta_concat.to_ndarray().tolist())
+        self.assertListEqual(
+            ak.Timedelta(pda_concat).to_ndarray().tolist(), timedelta_concat.to_ndarray().tolist()
+        )
         # test single and empty
         self.assertEqual(type(ak.concatenate([timedelta_one])), ak.Timedelta)
-        self.assertListEqual(ak.Timedelta(pda_one).to_ndarray().tolist(), ak.concatenate([timedelta_one]).to_ndarray().tolist())
-        self.assertEqual(type(ak.concatenate([ak.Timedelta(ak.array([], dtype=ak.int64))])), ak.Timedelta)
+        self.assertListEqual(
+            ak.Timedelta(pda_one).to_ndarray().tolist(),
+            ak.concatenate([timedelta_one]).to_ndarray().tolist(),
+        )
+        self.assertEqual(
+            type(ak.concatenate([ak.Timedelta(ak.array([], dtype=ak.int64))])), ak.Timedelta
+        )
 
         # BitVector test
         bitvector_one = ak.BitVector(pda_one)
         bitvector_two = ak.BitVector(pda_two)
         bitvector_concat = ak.concatenate([bitvector_one, bitvector_two])
         self.assertEqual(type(bitvector_concat), ak.BitVector)
-        self.assertListEqual(ak.BitVector(pda_concat).to_ndarray().tolist(), bitvector_concat.to_ndarray().tolist())
+        self.assertListEqual(
+            ak.BitVector(pda_concat).to_ndarray().tolist(), bitvector_concat.to_ndarray().tolist()
+        )
         # test single and empty
         self.assertEqual(type(ak.concatenate([bitvector_one])), ak.BitVector)
-        self.assertListEqual(ak.BitVector(pda_one).to_ndarray().tolist(), ak.concatenate([bitvector_one]).to_ndarray().tolist())
-        self.assertEqual(type(ak.concatenate([ak.BitVector(ak.array([], dtype=ak.int64))])), ak.BitVector)
+        self.assertListEqual(
+            ak.BitVector(pda_one).to_ndarray().tolist(),
+            ak.concatenate([bitvector_one]).to_ndarray().tolist(),
+        )
+        self.assertEqual(
+            type(ak.concatenate([ak.BitVector(ak.array([], dtype=ak.int64))])), ak.BitVector
+        )
 
         # Test failure with mixed types
         with self.assertRaises(TypeError):
@@ -319,47 +362,55 @@ class OperatorsTest(ArkoudaTest):
         # verify ak.util.concatenate still works
         ipv4_akuconcat = akuconcat([ipv4_one, ipv4_two])
         self.assertEqual(type(ipv4_akuconcat), ak.IPv4)
-        self.assertListEqual(ak.IPv4(pda_concat).to_ndarray().tolist(), ipv4_akuconcat.to_ndarray().tolist())
+        self.assertListEqual(
+            ak.IPv4(pda_concat).to_ndarray().tolist(), ipv4_akuconcat.to_ndarray().tolist()
+        )
 
         datetime_akuconcat = akuconcat([datetime_one, datetime_two])
         self.assertEqual(type(datetime_akuconcat), ak.Datetime)
-        self.assertListEqual(ak.Datetime(pda_concat).to_ndarray().tolist(), datetime_akuconcat.to_ndarray().tolist())
+        self.assertListEqual(
+            ak.Datetime(pda_concat).to_ndarray().tolist(), datetime_akuconcat.to_ndarray().tolist()
+        )
 
         timedelta_akuconcat = akuconcat([timedelta_one, timedelta_two])
         self.assertEqual(type(timedelta_akuconcat), ak.Timedelta)
-        self.assertListEqual(ak.Timedelta(pda_concat).to_ndarray().tolist(), timedelta_akuconcat.to_ndarray().tolist())
+        self.assertListEqual(
+            ak.Timedelta(pda_concat).to_ndarray().tolist(), timedelta_akuconcat.to_ndarray().tolist()
+        )
 
         bitvector_akuconcat = akuconcat([bitvector_one, bitvector_two])
         self.assertEqual(type(bitvector_akuconcat), ak.BitVector)
-        self.assertListEqual(ak.BitVector(pda_concat).to_ndarray().tolist(), bitvector_akuconcat.to_ndarray().tolist())
+        self.assertListEqual(
+            ak.BitVector(pda_concat).to_ndarray().tolist(), bitvector_akuconcat.to_ndarray().tolist()
+        )
 
     def testAllOperators(self):
         run_tests(verbose)
-        
+
     def testErrorHandling(self):
-        # Test NotImplmentedError that prevents pddarray iteration       
+        # Test NotImplmentedError that prevents pddarray iteration
         with self.assertRaises(NotImplementedError):
             iter(ak.ones(100))
-            
-        # Test NotImplmentedError that prevents Strings iteration       
+
+        # Test NotImplmentedError that prevents Strings iteration
         with self.assertRaises(NotImplementedError):
-            iter(ak.array(['String {}'.format(i) for i in range(0,10)]))
-        
+            iter(ak.array(["String {}".format(i) for i in range(0, 10)]))
+
         # Test ak,histogram against unsupported dtype
-        #with self.assertRaises(ValueError) as cm:
+        # with self.assertRaises(ValueError) as cm:
         #    ak.histogram((ak.randint(0, 1, 100, dtype=ak.bool)))
-            
-        with self.assertRaises(RuntimeError) as cm:
-            ak.concatenate([ak.array([True]),ak.array([True])]).is_sorted()
-        
+
+        with self.assertRaises(RuntimeError):
+            ak.concatenate([ak.array([True]), ak.array([True])]).is_sorted()
+
         with self.assertRaises(TypeError):
             ak.ones(100).any([0])
-            
-        with self.assertRaises(AttributeError) as cm:
-            ak.unique(list(range(0,10)))
-        
-        with self.assertRaises(ValueError) as cm:
-            ak.concatenate([ak.ones(100),ak.array([True])])
+
+        with self.assertRaises(AttributeError):
+            ak.unique(list(range(0, 10)))
+
+        with self.assertRaises(RuntimeError):
+            ak.concatenate([ak.ones(100), ak.array([True])])
 
     def test_str_repr(self):
         """
@@ -371,28 +422,42 @@ class OperatorsTest(ArkoudaTest):
         self.assertEqual("[1 2 3]", ak.array([1, 2, 3]).__str__())
         self.assertEqual("[1 2 3 ... 17 18 19]", ak.arange(1, 20).__str__())
         self.assertEqual("[1.100000e+00 2.300000e+00 5.000000e+00]", ak.array([1.1, 2.3, 5]).__str__())
-        self.assertEqual("[0.000000e+00 5.263158e-01 1.052632e+00 ... 8.947368e+00 9.473684e+00 1.000000e+01]",
-                         ak.linspace(0, 10, 20).__str__())
+        self.assertEqual(
+            "[0.000000e+00 5.263158e-01 1.052632e+00 ... 8.947368e+00 9.473684e+00 1.000000e+01]",
+            ak.linspace(0, 10, 20).__str__(),
+        )
         self.assertEqual("[False False False]", ak.isnan(ak.array([1.1, 2.3, 5])).__str__())
-        self.assertEqual("[False False False ... False False False]", ak.isnan(ak.linspace(0, 10, 20)).__str__())
+        self.assertEqual(
+            "[False False False ... False False False]", ak.isnan(ak.linspace(0, 10, 20)).__str__()
+        )
 
         # Test __repr__()
         self.assertEqual("array([1 2 3])", ak.array([1, 2, 3]).__repr__())
         self.assertEqual("array([1 2 3 ... 17 18 19])", ak.arange(1, 20).__repr__())
-        self.assertEqual("array([1.1000000000000001 2.2999999999999998 5])", ak.array([1.1, 2.3, 5]).__repr__())
-        self.assertEqual("array([0 0.52631578947368418 1.0526315789473684 ... 8.9473684210526319 9.473684210526315 10])",
-                         ak.linspace(0, 10, 20).__repr__())
+        self.assertEqual(
+            "array([1.1000000000000001 2.2999999999999998 5])", ak.array([1.1, 2.3, 5]).__repr__()
+        )
+        self.assertEqual(
+            "array([0 0.52631578947368418 1.0526315789473684 ... "
+            "8.9473684210526319 9.473684210526315 10])",
+            ak.linspace(0, 10, 20).__repr__(),
+        )
         self.assertEqual("array([False False False])", ak.isnan(ak.array([1.1, 2.3, 5])).__repr__())
-        self.assertEqual("array([False False False ... False False False])", ak.isnan(ak.linspace(0, 10, 20)).__repr__())
-        ak.client.pdarrayIterThresh = ak.client.pdarrayIterThreshDefVal  # Don't forget to set this back for other tests.
+        self.assertEqual(
+            "array([False False False ... False False False])",
+            ak.isnan(ak.linspace(0, 10, 20)).__repr__(),
+        )
+        ak.client.pdarrayIterThresh = (
+            ak.client.pdarrayIterThreshDefVal
+        )  # Don't forget to set this back for other tests.
 
 
-
-if __name__ == '__main__':
-    '''
+if __name__ == "__main__":
+    """
     Enables invocation of operator tests outside of pytest test harness
-    '''
+    """
     import sys
+
     if len(sys.argv) not in (3, 4):
         print(f"Usage: {sys.argv[0]} <server_name> <port> [<verbose>=(0|1)]")
     verbose = False

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -399,9 +399,8 @@ class OperatorsTest(ArkoudaTest):
         # Test ak,histogram against unsupported dtype
         # with self.assertRaises(ValueError) as cm:
         #    ak.histogram((ak.randint(0, 1, 100, dtype=ak.bool)))
-
-        with self.assertRaises(RuntimeError):
-            ak.concatenate([ak.array([True]), ak.array([True])]).is_sorted()
+        with self.assertRaises(ValueError) as cm:
+            ak.concatenate([ak.array([True]),ak.array([True])]).is_sorted()
 
         with self.assertRaises(TypeError):
             ak.ones(100).any([0])

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -408,7 +408,7 @@ class OperatorsTest(ArkoudaTest):
         with self.assertRaises(AttributeError):
             ak.unique(list(range(0, 10)))
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             ak.concatenate([ak.ones(100), ak.array([True])])
 
     def test_str_repr(self):

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -399,7 +399,7 @@ class OperatorsTest(ArkoudaTest):
         # Test ak,histogram against unsupported dtype
         # with self.assertRaises(ValueError) as cm:
         #    ak.histogram((ak.randint(0, 1, 100, dtype=ak.bool)))
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(RuntimeError) as cm:
             ak.concatenate([ak.array([True]),ak.array([True])]).is_sorted()
 
         with self.assertRaises(TypeError):

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -1,80 +1,86 @@
-import glob, os
-from context import arkouda as ak
-from base_test import ArkoudaTest
+import glob
+import os
+
 import numpy as np
 import pytest
+from base_test import ArkoudaTest
+from context import arkouda as ak
 
-TYPES = ('int64', 'uint64', 'bool', 'float64', 'str')
+TYPES = ("int64", "uint64", "bool", "float64", "str")
 SIZE = 100
 NUMFILES = 5
 verbose = True
 
+
 def read_write_test(dtype):
-    if dtype == 'int64':
+    if dtype == "int64":
         ak_arr = ak.randint(0, 2**32, SIZE)
-    elif dtype =='uint64':
+    elif dtype == "uint64":
         ak_arr = ak.randint(0, 2**32, SIZE, dtype=ak.uint64)
-    elif dtype =='bool':
+    elif dtype == "bool":
         ak_arr = ak.randint(0, 1, SIZE, dtype=ak.bool)
-    elif dtype =='float64':
+    elif dtype == "float64":
         ak_arr = ak.randint(0, 2**32, SIZE, dtype=ak.float64)
-    elif dtype == 'str':
+    elif dtype == "str":
         ak_arr = ak.random_strings_uniform(1, 10, SIZE)
 
     ak_arr.save_parquet("pq_testcorrect", "my-dset")
     pq_arr = ak.read("pq_testcorrect*", "my-dset")
-    
-    for f in glob.glob('pq_test*'):
+
+    for f in glob.glob("pq_test*"):
         os.remove(f)
 
     return ak_arr, pq_arr
 
+
 def read_write_multi_test(dtype):
-    adjusted_size = int(SIZE/NUMFILES)*NUMFILES
+    adjusted_size = int(SIZE / NUMFILES) * NUMFILES
     test_arrs = []
-    if dtype == 'int64':
+    if dtype == "int64":
         elems = ak.randint(0, 2**32, adjusted_size)
-    elif dtype == 'uint64':
+    elif dtype == "uint64":
         elems = ak.randint(0, 2**32, adjusted_size, dtype=ak.uint64)
-    elif dtype =='bool':
+    elif dtype == "bool":
         elems = ak.randint(0, 1, adjusted_size, dtype=ak.bool)
-    elif dtype =='float64':
+    elif dtype == "float64":
         elems = ak.randint(0, 2**32, adjusted_size, dtype=ak.float64)
-    elif dtype == 'str':
+    elif dtype == "str":
         elems = ak.random_strings_uniform(1, 10, adjusted_size)
-        
-    per_arr = int(adjusted_size/NUMFILES)
+
+    per_arr = int(adjusted_size / NUMFILES)
     for i in range(NUMFILES):
-        test_arrs.append(elems[(i*per_arr):(i*per_arr)+per_arr])
+        test_arrs.append(elems[(i * per_arr) : (i * per_arr) + per_arr])
         test_arrs[i].save_parquet(f"pq_test{i:04d}", "test-dset")
 
     pq_arr = ak.read("pq_test*", "test-dset")
-    
-    for f in glob.glob('pq_test*'):
+
+    for f in glob.glob("pq_test*"):
         os.remove(f)
 
     return elems, pq_arr
 
+
 def get_datasets_test(dtype):
-    if dtype == 'int64':
+    if dtype == "int64":
         ak_arr = ak.randint(0, 2**32, 10)
-    elif dtype =='uint64':
+    elif dtype == "uint64":
         ak_arr = ak.randint(0, 2**32, 10, dtype=ak.uint64)
-    elif dtype =='bool':
+    elif dtype == "bool":
         ak_arr = ak.randint(0, 1, 10, dtype=ak.bool)
-    elif dtype =='float64':
+    elif dtype == "float64":
         ak_arr = ak.randint(0, 2**32, SIZE, dtype=ak.float64)
-    elif dtype == 'str':
+    elif dtype == "str":
         ak_arr = ak.random_strings_uniform(1, 10, SIZE)
-        
+
     ak_arr.save_parquet("pq_testdset", "TEST_DSET")
 
     dsets = ak.get_datasets("pq_testdset*")
-    
-    for f in glob.glob('pq_test*'):
+
+    for f in glob.glob("pq_test*"):
         os.remove(f)
 
     return dsets
+
 
 def append_test():
     # use small size to cut down on execution time
@@ -82,86 +88,88 @@ def append_test():
 
     base_dset = ak.randint(0, 2**32, append_size)
     ak_dict = {}
-    ak_dict['uint-dset'] = ak.randint(0, 2**32, append_size, dtype=ak.uint64)
-    ak_dict['bool-dset'] = ak.randint(0, 1, append_size, dtype=ak.bool)
-    ak_dict['float-dset'] = ak.randint(0, 2**32, append_size, dtype=ak.float64)
-    ak_dict['int-dset'] = ak.randint(0, 2**32, append_size)
-    ak_dict['str-dset'] = ak.random_strings_uniform(1, 10, append_size)
+    ak_dict["uint-dset"] = ak.randint(0, 2**32, append_size, dtype=ak.uint64)
+    ak_dict["bool-dset"] = ak.randint(0, 1, append_size, dtype=ak.bool)
+    ak_dict["float-dset"] = ak.randint(0, 2**32, append_size, dtype=ak.float64)
+    ak_dict["int-dset"] = ak.randint(0, 2**32, append_size)
+    ak_dict["str-dset"] = ak.random_strings_uniform(1, 10, append_size)
 
     base_dset.save_parquet("pq_testcorrect", "base-dset")
 
     for key in ak_dict:
-        ak_dict[key].save_parquet("pq_testcorrect", key, mode='append')
+        ak_dict[key].save_parquet("pq_testcorrect", key, mode="append")
 
     ak_vals = ak.read("pq_testcorrect*")
-    
-    for f in glob.glob('pq_test*'):
+
+    for f in glob.glob("pq_test*"):
         os.remove(f)
 
     return ak_vals, ak_dict
 
+
 def empty_append_test(dtype):
-    if dtype == 'int64':
+    if dtype == "int64":
         ak_arr = ak.randint(0, 2**32, SIZE)
-    elif dtype =='uint64':
+    elif dtype == "uint64":
         ak_arr = ak.randint(0, 2**32, SIZE, dtype=ak.uint64)
-    elif dtype =='bool':
+    elif dtype == "bool":
         ak_arr = ak.randint(0, 1, SIZE, dtype=ak.bool)
-    elif dtype =='float64':
+    elif dtype == "float64":
         ak_arr = ak.randint(0, 2**32, SIZE, dtype=ak.float64)
-    elif dtype == 'str':
+    elif dtype == "str":
         ak_arr = ak.random_strings_uniform(1, 10, SIZE)
 
-    ak_arr.save("pq_testcorrect", "my-dset", mode='append', file_format='parquet')
+    ak_arr.save("pq_testcorrect", "my-dset", mode="append", file_format="parquet")
     pq_arr = ak.read("pq_testcorrect*", "my-dset")
-    
-    for f in glob.glob('pq_test*'):
+
+    for f in glob.glob("pq_test*"):
         os.remove(f)
 
     return ak_arr, pq_arr
+
 
 class ParquetTest(ArkoudaTest):
     def test_parquet(self):
         for dtype in TYPES:
             (ak_arr, pq_arr) = read_write_test(dtype)
-            self.assertTrue((ak_arr ==  pq_arr).all())
+            self.assertTrue((ak_arr == pq_arr).all())
 
     def test_multi_file(self):
         for dtype in TYPES:
             (ak_arr, pq_arr) = read_write_multi_test(dtype)
-            self.assertTrue((ak_arr ==  pq_arr).all())
+            self.assertTrue((ak_arr == pq_arr).all())
 
     def test_wrong_dset_name(self):
         ak_arr = ak.randint(0, 2**32, SIZE)
         ak_arr.save_parquet("pq_test", "test-dset-name")
-        
-        with self.assertRaises(RuntimeError) as cm:
+
+        with self.assertRaises(RuntimeError):
             ak.read("pq_test*", "wrong-dset-name")
 
-        with self.assertRaises(ValueError) as cm:
-            ak.read("pq_test*", ['test-dset-name', 'wrong-dset-name'])
+        with self.assertRaises(ValueError):
+            ak.read("pq_test*", ["test-dset-name", "wrong-dset-name"])
 
         for f in glob.glob("pq_test*"):
             os.remove(f)
 
     def test_max_read_write(self):
         for dtype in TYPES:
-            if dtype == 'int64':
+            if dtype == "int64":
                 val = np.iinfo(np.int64).max
-            elif dtype == 'uint64':
+            elif dtype == "uint64":
                 val = np.iinfo(np.uint64).max
-            elif dtype == 'bool':
+            elif dtype == "bool":
                 val = True
-            elif dtype == 'float64':
+            elif dtype == "float64":
                 val = np.finfo(np.float64).max
-            elif dtype == 'str':
-                val = 'max'
+            elif dtype == "str":
+                val = "max"
             a = ak.array([val])
-            a.save_parquet("pq_test", 'test-dset')
-            ak_res = ak.read("pq_test*", 'test-dset')
+            a.save_parquet("pq_test", "test-dset")
+            ak_res = ak.read("pq_test*", "test-dset")
             self.assertTrue(ak_res[0] == val)
 
-            for f in glob.glob('pq_test*'):
+            for f in glob.glob("pq_test*"):
                 os.remove(f)
 
     def test_get_datasets(self):
@@ -169,7 +177,7 @@ class ParquetTest(ArkoudaTest):
             dsets = get_datasets_test(dtype)
             self.assertTrue(["TEST_DSET"] == dsets)
 
-        for f in glob.glob('pq_test*'):
+        for f in glob.glob("pq_test*"):
             os.remove(f)
 
     def test_append(self):
@@ -179,9 +187,9 @@ class ParquetTest(ArkoudaTest):
             self.assertTrue((ak_vals[key] == ak_dict[key]).all())
 
     def test_null_strings(self):
-        datadir = 'resources/parquet-testing'
-        basename = 'null-strings.parquet'
-        expected = ak.array(['first-string', '', 'string2', '', 'third', '', ''])
+        datadir = "resources/parquet-testing"
+        basename = "null-strings.parquet"
+        expected = ak.array(["first-string", "", "string2", "", "third", "", ""])
 
         filename = os.path.join(datadir, basename)
         res = ak.read(filename)
@@ -189,46 +197,53 @@ class ParquetTest(ArkoudaTest):
         self.assertTrue((expected == res).all())
 
     def test_null_indices(self):
-        datadir = 'resources/parquet-testing'
-        basename = 'null-strings.parquet'
+        datadir = "resources/parquet-testing"
+        basename = "null-strings.parquet"
         expected = ak.array([0, 1, 0, 1, 0, 1, 1])
 
         filename = os.path.join(datadir, basename)
-        res = ak.get_null_indices(filename, datasets='col1')
+        res = ak.get_null_indices(filename, datasets="col1")
 
         self.assertTrue((expected == res).all())
 
     def test_append_empty(self):
         for dtype in TYPES:
             (ak_arr, pq_arr) = empty_append_test(dtype)
-            self.assertTrue((ak_arr ==  pq_arr).all())
+            
+            self.assertTrue((ak_arr == pq_arr).all())
 
     @pytest.mark.optional_parquet
     def test_against_standard_files(self):
-        datadir = 'resources/parquet-testing'
-        filenames = ['alltypes_plain.parquet',
-                     'alltypes_plain.snappy.parquet',
-                     'delta_byte_array.parquet']
-        columns1 = ['id',
-                    'bool_col',
-                    'tinyint_col',
-                    'smallint_col',
-                    'int_col',
-                    'bigint_col',
-                    'float_col',
-                    'double_col',
-                    'date_string_col',
-                    'string_col',
-                    'timestamp_col']
-        columns2 = ['c_customer_id',
-                    'c_salutation',
-                    'c_first_name',
-                    'c_last_name',
-                    'c_preferred_cust_flag',
-                    'c_birth_country',
-                    'c_login',
-                    'c_email_address',
-                    'c_last_review_date']
+        datadir = "resources/parquet-testing"
+        filenames = [
+            "alltypes_plain.parquet",
+            "alltypes_plain.snappy.parquet",
+            "delta_byte_array.parquet",
+        ]
+        columns1 = [
+            "id",
+            "bool_col",
+            "tinyint_col",
+            "smallint_col",
+            "int_col",
+            "bigint_col",
+            "float_col",
+            "double_col",
+            "date_string_col",
+            "string_col",
+            "timestamp_col",
+        ]
+        columns2 = [
+            "c_customer_id",
+            "c_salutation",
+            "c_first_name",
+            "c_last_name",
+            "c_preferred_cust_flag",
+            "c_birth_country",
+            "c_login",
+            "c_email_address",
+            "c_last_review_date",
+        ]
         for basename, ans in zip(filenames, (columns1, columns1, columns2)):
             filename = os.path.join(datadir, basename)
             columns = ak.get_datasets(filename)
@@ -239,5 +254,5 @@ class ParquetTest(ArkoudaTest):
             else:
                 # Since delta encoding is not supported, the columns in
                 # this file should raise an error and not crash the server
-                with self.assertRaises(RuntimeError) as cm:
+                with self.assertRaises(RuntimeError):
                     data = ak.read(filename, datasets=columns)

--- a/tests/pdarray_creation_test.py
+++ b/tests/pdarray_creation_test.py
@@ -1,50 +1,52 @@
-import numpy as np
-import pandas as pd
 import datetime as dt
 from collections import deque
+
+import numpy as np
+import pandas as pd
 from base_test import ArkoudaTest
 from context import arkouda as ak
 
-'''
+"""
 Encapsulates test cases for pdarray creation methods
-'''
+"""
+
+
 class PdarrayCreationTest(ArkoudaTest):
- 
     def testArrayCreation(self):
         pda = ak.array(np.ones(100))
         self.assertIsInstance(pda, ak.pdarray)
         self.assertEqual(100, len(pda))
         self.assertEqual(float, pda.dtype)
-        
-        pda =  ak.array(list(range(0,100)))
+
+        pda = ak.array(list(range(0, 100)))
         self.assertIsInstance(pda, ak.pdarray)
         self.assertEqual(100, len(pda))
-        self.assertEqual(int, pda.dtype)        
+        self.assertEqual(int, pda.dtype)
 
-        pda =  ak.array((range(5)))
+        pda = ak.array((range(5)))
         self.assertIsInstance(pda, ak.pdarray)
-        self.assertEqual(5, len(pda))
-        self.assertEqual(int, pda.dtype) 
-        
-        pda =  ak.array(deque(range(5)))
         self.assertEqual(5, len(pda))
         self.assertEqual(int, pda.dtype)
 
-        pda = ak.array([f'{i}' for i in range(10)], dtype=ak.int64)
+        pda = ak.array(deque(range(5)))
+        self.assertEqual(5, len(pda))
+        self.assertEqual(int, pda.dtype)
+
+        pda = ak.array([f"{i}" for i in range(10)], dtype=ak.int64)
         self.assertIsInstance(pda, ak.pdarray)
         self.assertEqual(10, len(pda))
         self.assertEqual(int, pda.dtype)
 
-        av = ak.array(np.array([[0,1],[0,1]]))
+        av = ak.array(np.array([[0, 1], [0, 1]]))
         self.assertIsInstance(av, ak.ArrayView)
 
-        with self.assertRaises(TypeError) as cm:
-            ak.array({range(0,100)})
+        with self.assertRaises(TypeError):
+            ak.array({range(0, 100)})
 
-        with self.assertRaises(TypeError) as cm:
-            ak.array('not an iterable')
-        
-        with self.assertRaises(TypeError) as cm:          
+        with self.assertRaises(TypeError):
+            ak.array("not an iterable")
+
+        with self.assertRaises(TypeError):
             ak.array(list(list(0)))
 
     def test_arange(self):
@@ -62,12 +64,17 @@ class PdarrayCreationTest(ArkoudaTest):
 
         expected_start_stop = ak.array([3, 4, 5, 6])
         uint_start_stop = ak.arange(3, 7, dtype=ak.uint64)
-        self.assertListEqual(expected_start_stop.to_ndarray().tolist(), uint_start_stop.to_ndarray().tolist())
+        self.assertListEqual(
+            expected_start_stop.to_ndarray().tolist(), uint_start_stop.to_ndarray().tolist()
+        )
         self.assertEqual(ak.uint64, uint_start_stop.dtype)
 
         expected_start_stop_stride = ak.array([3, 5])
         uint_start_stop_stride = ak.arange(3, 7, 2, dtype=ak.uint64)
-        self.assertListEqual(expected_start_stop_stride.to_ndarray().tolist(), uint_start_stop_stride.to_ndarray().tolist())
+        self.assertListEqual(
+            expected_start_stop_stride.to_ndarray().tolist(),
+            uint_start_stop_stride.to_ndarray().tolist(),
+        )
         self.assertEqual(ak.uint64, uint_start_stop_stride.dtype)
 
         # test uint64 handles negatives correctly
@@ -103,63 +110,63 @@ class PdarrayCreationTest(ArkoudaTest):
         self.assertEqual(5, len(testArray))
         self.assertEqual(ak.int64, testArray.dtype)
         self.assertEqual([5], testArray.shape)
-        
+
         testArray = ak.randint(np.int64(0), np.int64(10), np.int64(5))
         self.assertIsInstance(testArray, ak.pdarray)
         self.assertEqual(5, len(testArray))
         self.assertEqual(ak.int64, testArray.dtype)
         self.assertEqual([5], testArray.shape)
-        
+
         testArray = ak.randint(np.float64(0), np.float64(10), np.int64(5))
         self.assertIsInstance(testArray, ak.pdarray)
         self.assertEqual(5, len(testArray))
         self.assertEqual(ak.int64, testArray.dtype)
         self.assertEqual([5], testArray.shape)
-        
+
         test_ndarray = testArray.to_ndarray()
-        
+
         for value in test_ndarray:
             self.assertTrue(0 <= value <= 10)
 
         test_array = ak.randint(0, 1, 3, dtype=ak.float64)
         self.assertEqual(ak.float64, test_array.dtype)
-        
+
         test_array = ak.randint(0, 1, 5, dtype=ak.bool)
         self.assertEqual(ak.bool, test_array.dtype)
-        
+
         test_ndarray = test_array.to_ndarray()
 
         # test resolution of modulus overflow - issue #1174
-        test_array = ak.randint(-(2**63), 2**63-1, 10)
+        test_array = ak.randint(-(2**63), 2**63 - 1, 10)
         to_validate = np.full(10, -(2**63))
         self.assertFalse((test_array.to_ndarray() == to_validate).all())
-        
+
         for value in test_ndarray:
-            self.assertTrue(value in [True,False])
-           
+            self.assertTrue(value in [True, False])
+
         with self.assertRaises(TypeError):
             ak.randint(low=5)
-            
+
         with self.assertRaises(TypeError):
             ak.randint(high=5)
 
-        with self.assertRaises(TypeError):            
+        with self.assertRaises(TypeError):
             ak.randint()
 
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(ValueError):
             ak.randint(low=0, high=1, size=-1, dtype=ak.float64)
- 
-        with self.assertRaises(ValueError) as cm:
+
+        with self.assertRaises(ValueError):
             ak.randint(low=1, high=0, size=1, dtype=ak.float64)
 
-        with self.assertRaises(TypeError) as cm:              
-            ak.randint(0,1,'1000')
+        with self.assertRaises(TypeError):
+            ak.randint(0, 1, "1000")
 
-        with self.assertRaises(TypeError):              
-            ak.randint('0',1,1000)
-        
-        with self.assertRaises(TypeError):              
-            ak.randint(0,'1',1000)
+        with self.assertRaises(TypeError):
+            ak.randint("0", 1, 1000)
+
+        with self.assertRaises(TypeError):
+            ak.randint(0, "1", 1000)
 
     def test_randint_with_seed(self):
         values = ak.randint(1, 5, 10, seed=2)
@@ -167,119 +174,137 @@ class PdarrayCreationTest(ArkoudaTest):
         self.assertTrue((ak.array([4, 3, 1, 3, 2, 4, 4, 2, 3, 4]) == values).all())
 
         values = ak.randint(1, 5, 10, dtype=ak.float64, seed=2)
-        self.assertTrue((ak.array([2.9160772326374946, 4.353429832157099, 4.5392023718621486, 
-                                   4.4019932101126606, 3.3745324569952304, 1.1642002901528308, 
-                                   4.4714086874555292, 3.7098921109084522, 4.5939589352472314, 
-                                   4.0337935981006172]) == values).all())
-    
+        self.assertTrue(
+            (
+                ak.array(
+                    [
+                        2.9160772326374946,
+                        4.353429832157099,
+                        4.5392023718621486,
+                        4.4019932101126606,
+                        3.3745324569952304,
+                        1.1642002901528308,
+                        4.4714086874555292,
+                        3.7098921109084522,
+                        4.5939589352472314,
+                        4.0337935981006172,
+                    ]
+                )
+                == values
+            ).all()
+        )
+
         values = ak.randint(1, 5, 10, dtype=ak.bool, seed=2)
-        self.assertTrue((ak.array([False, True, True, True, True, False, True, True, 
-                                   True, True]) == values).all())
-        
+        self.assertTrue(
+            (ak.array([False, True, True, True, True, False, True, True, True, True]) == values).all()
+        )
+
         values = ak.randint(1, 5, 10, dtype=bool, seed=2)
-        self.assertTrue((ak.array([False, True, True, True, True, False, True, True, 
-                                   True, True]) == values).all())
+        self.assertTrue(
+            (ak.array([False, True, True, True, True, False, True, True, True, True]) == values).all()
+        )
 
     def test_uniform(self):
         testArray = ak.uniform(3)
         self.assertIsInstance(testArray, ak.pdarray)
         self.assertEqual(ak.float64, testArray.dtype)
         self.assertEqual([3], testArray.shape)
-        
+
         testArray = ak.uniform(np.int64(3))
         self.assertIsInstance(testArray, ak.pdarray)
         self.assertEqual(ak.float64, testArray.dtype)
         self.assertEqual([3], testArray.shape)
 
+        uArray = ak.uniform(size=3, low=0, high=5, seed=0)
+        self.assertTrue(
+            (ak.array([0.30013431967121934, 0.47383036230759112, 1.0441791878997098]) == uArray).all()
+        )
 
-        uArray = ak.uniform(size=3,low=0,high=5,seed=0)
-        self.assertTrue((ak.array([0.30013431967121934, 0.47383036230759112, 1.0441791878997098])
-                        == uArray).all())
-        
-        uArray = ak.uniform(size=np.int64(3),low=np.int64(0),high=np.int64(5),seed=np.int64(0))
-        self.assertTrue((ak.array([0.30013431967121934, 0.47383036230759112, 1.0441791878997098])
-                        == uArray).all())
-    
-        with self.assertRaises(TypeError):
-            ak.uniform(low='0', high=5, size=100)
+        uArray = ak.uniform(size=np.int64(3), low=np.int64(0), high=np.int64(5), seed=np.int64(0))
+        self.assertTrue(
+            (ak.array([0.30013431967121934, 0.47383036230759112, 1.0441791878997098]) == uArray).all()
+        )
 
         with self.assertRaises(TypeError):
-            ak.uniform(low=0, high='5', size=100)
+            ak.uniform(low="0", high=5, size=100)
 
         with self.assertRaises(TypeError):
-            ak.uniform(low=0, high=5, size='100')
- 
+            ak.uniform(low=0, high="5", size=100)
+
+        with self.assertRaises(TypeError):
+            ak.uniform(low=0, high=5, size="100")
+
     def test_zeros(self):
         intZeros = ak.zeros(5, dtype=ak.int64)
         self.assertIsInstance(intZeros, ak.pdarray)
-        self.assertEqual(ak.int64,intZeros.dtype)
+        self.assertEqual(ak.int64, intZeros.dtype)
 
         floatZeros = ak.zeros(5, dtype=float)
-        self.assertEqual(float,floatZeros.dtype)
+        self.assertEqual(float, floatZeros.dtype)
 
         floatZeros = ak.zeros(5, dtype=ak.float64)
-        self.assertEqual(ak.float64,floatZeros.dtype)
+        self.assertEqual(ak.float64, floatZeros.dtype)
 
         boolZeros = ak.zeros(5, dtype=bool)
-        self.assertEqual(bool,boolZeros.dtype)
+        self.assertEqual(bool, boolZeros.dtype)
 
         boolZeros = ak.zeros(5, dtype=ak.bool)
-        self.assertEqual(ak.bool,boolZeros.dtype)
-        
-        zeros  = ak.zeros('5')
+        self.assertEqual(ak.bool, boolZeros.dtype)
+
+        zeros = ak.zeros("5")
         self.assertEqual(5, len(zeros))
 
         with self.assertRaises(TypeError):
             ak.zeros(5, dtype=ak.uint8)
-            
+
         with self.assertRaises(TypeError):
-            ak.zeros(5, dtype=str)        
-            
-    def test_ones(self):   
+            ak.zeros(5, dtype=str)
+
+    def test_ones(self):
         intOnes = ak.ones(5, dtype=int)
         self.assertIsInstance(intOnes, ak.pdarray)
-        self.assertEqual(int,intOnes.dtype)
-       
+        self.assertEqual(int, intOnes.dtype)
+
         intOnes = ak.ones(5, dtype=ak.int64)
-        self.assertEqual(ak.int64,intOnes.dtype)
+        self.assertEqual(ak.int64, intOnes.dtype)
 
         floatOnes = ak.ones(5, dtype=float)
-        self.assertEqual(float,floatOnes.dtype)
-        
+        self.assertEqual(float, floatOnes.dtype)
+
         floatOnes = ak.ones(5, dtype=ak.float64)
-        self.assertEqual(ak.float64,floatOnes.dtype)
+        self.assertEqual(ak.float64, floatOnes.dtype)
 
         boolOnes = ak.ones(5, dtype=bool)
-        self.assertEqual(bool,boolOnes.dtype)
-        
-        boolOnes = ak.ones(5, dtype=ak.bool)
-        self.assertEqual(ak.bool,boolOnes.dtype)
+        self.assertEqual(bool, boolOnes.dtype)
 
-        ones = ak.ones('5')
+        boolOnes = ak.ones(5, dtype=ak.bool)
+        self.assertEqual(ak.bool, boolOnes.dtype)
+
+        ones = ak.ones("5")
         self.assertEqual(5, len(ones))
-        
-        with self.assertRaises(TypeError) as cm:
+
+        with self.assertRaises(TypeError):
             ak.ones(5, dtype=ak.uint8)
-                    
-        with self.assertRaises(TypeError) as cm:
+
+        with self.assertRaises(TypeError):
             ak.ones(5, dtype=str)
-        
-    def test_ones_like(self):      
+
+    def test_ones_like(self):
         intOnes = ak.ones(5, dtype=ak.int64)
         intOnesLike = ak.ones_like(intOnes)
 
         self.assertIsInstance(intOnesLike, ak.pdarray)
-        self.assertEqual(ak.int64,intOnesLike.dtype)
-        
+        self.assertEqual(ak.int64, intOnesLike.dtype)
+
         floatOnes = ak.ones(5, dtype=ak.float64)
         floatOnesLike = ak.ones_like(floatOnes)
-        
-        self.assertEqual(ak.float64,floatOnesLike.dtype)
-        
+
+        self.assertEqual(ak.float64, floatOnesLike.dtype)
+
         boolOnes = ak.ones(5, dtype=ak.bool)
         boolOnesLike = ak.ones_like(boolOnes)
-        
-        self.assertEqual(ak.bool,boolOnesLike.dtype)
+
+        self.assertEqual(ak.bool, boolOnesLike.dtype)
 
     def test_full(self):
         int_full = ak.full(5, 5, dtype=int)
@@ -310,13 +335,13 @@ class PdarrayCreationTest(ArkoudaTest):
         self.assertEqual(ak.bool, bool_full.dtype)
         self.assertEqual(bool_full[0], False)
 
-        string_len_full = ak.full('5', 5)
+        string_len_full = ak.full("5", 5)
         self.assertEqual(5, len(string_len_full))
 
-        with self.assertRaises(TypeError) as cm:
+        with self.assertRaises(TypeError):
             ak.full(5, 1, dtype=ak.uint8)
 
-        with self.assertRaises(TypeError) as cm:
+        with self.assertRaises(TypeError):
             ak.full(5, 8, dtype=str)
 
     def test_full_like(self):
@@ -341,76 +366,75 @@ class PdarrayCreationTest(ArkoudaTest):
         intZerosLike = ak.zeros_like(intZeros)
 
         self.assertIsInstance(intZerosLike, ak.pdarray)
-        self.assertEqual(ak.int64,intZerosLike.dtype)
-        
+        self.assertEqual(ak.int64, intZerosLike.dtype)
+
         floatZeros = ak.ones(5, dtype=ak.float64)
         floatZerosLike = ak.ones_like(floatZeros)
-        
-        self.assertEqual(ak.float64,floatZerosLike.dtype)
-        
+
+        self.assertEqual(ak.float64, floatZerosLike.dtype)
+
         boolZeros = ak.ones(5, dtype=ak.bool)
         boolZerosLike = ak.ones_like(boolZeros)
-        
-        self.assertEqual(ak.bool,boolZerosLike.dtype)        
+
+        self.assertEqual(ak.bool, boolZerosLike.dtype)
 
     def test_linspace(self):
-        pda = ak.linspace(0, 100, 1000)  
+        pda = ak.linspace(0, 100, 1000)
         self.assertEqual(1000, len(pda))
         self.assertEqual(float, pda.dtype)
         self.assertIsInstance(pda, ak.pdarray)
-        
-        pda = ak.linspace(0.0, 100.0, 150)  
-            
+
+        pda = ak.linspace(0.0, 100.0, 150)
+
         pda = ak.linspace(start=5, stop=0, length=6)
         self.assertEqual(5.0000, pda[0])
         self.assertEqual(0.0000, pda[5])
-        
+
         pda = ak.linspace(start=5.0, stop=0.0, length=6)
         self.assertEqual(5.0000, pda[0])
         self.assertEqual(0.0000, pda[5])
-        
+
         pda = ak.linspace(start=float(5.0), stop=float(0.0), length=np.int64(6))
         self.assertEqual(5.0000, pda[0])
         self.assertEqual(0.0000, pda[5])
-        
-        with self.assertRaises(TypeError) as cm:        
-            ak.linspace(0,'100', 1000)
-        
-        with self.assertRaises(TypeError) as cm:        
-            ak.linspace('0',100, 1000)
 
-        with self.assertRaises(TypeError) as cm:          
-            ak.linspace(0,100,'1000')
+        with self.assertRaises(TypeError):
+            ak.linspace(0, "100", 1000)
+
+        with self.assertRaises(TypeError):
+            ak.linspace("0", 100, 1000)
+
+        with self.assertRaises(TypeError):
+            ak.linspace(0, 100, "1000")
 
     def test_standard_normal(self):
         pda = ak.standard_normal(100)
         self.assertIsInstance(pda, ak.pdarray)
-        self.assertEqual(100,len(pda))
-        self.assertEqual(float,pda.dtype)
-        
+        self.assertEqual(100, len(pda))
+        self.assertEqual(float, pda.dtype)
+
         pda = ak.standard_normal(np.int64(100))
         self.assertIsInstance(pda, ak.pdarray)
-        self.assertEqual(100,len(pda))
-        self.assertEqual(float,pda.dtype)
-        
+        self.assertEqual(100, len(pda))
+        self.assertEqual(float, pda.dtype)
+
         pda = ak.standard_normal(np.int64(100), np.int64(1))
         self.assertIsInstance(pda, ak.pdarray)
-        self.assertEqual(100,len(pda))
-        self.assertEqual(float,pda.dtype)
-        
+        self.assertEqual(100, len(pda))
+        self.assertEqual(float, pda.dtype)
+
         npda = pda.to_ndarray()
         pda = ak.standard_normal(np.int64(100), np.int64(1))
-        
-        self.assertTrue((npda ==  pda.to_ndarray()).all())
-        
 
-        with self.assertRaises(TypeError) as cm:          
-            ak.standard_normal('100')
-   
-        with self.assertRaises(TypeError) as cm:          
+        self.assertTrue((npda == pda.to_ndarray()).all())
+
+        with self.assertRaises(TypeError):
+            ak.standard_normal("100")
+
+        with self.assertRaises(TypeError):
             ak.standard_normal(100.0)
-    
-        with self.assertRaises(ValueError) as cm:          
+
+        with self.assertRaises(ValueError):
             ak.standard_normal(-1)
 
     def test_random_strings_uniform(self):
@@ -423,7 +447,7 @@ class PdarrayCreationTest(ArkoudaTest):
         for string in nda:
             self.assertTrue(len(string) >= 1 and len(string) <= 5)
             self.assertTrue(string.isupper())
-            
+
         pda = ak.random_strings_uniform(minlen=np.int64(1), maxlen=np.int64(5), size=np.int64(100))
         nda = pda.to_ndarray()
 
@@ -433,215 +457,302 @@ class PdarrayCreationTest(ArkoudaTest):
         for string in nda:
             self.assertTrue(len(string) >= 1 and len(string) <= 5)
             self.assertTrue(string.isupper())
-        
-        with self.assertRaises(ValueError) as cm:          
-            ak.random_strings_uniform(maxlen=1,minlen=5, size=100)
-        
-        with self.assertRaises(ValueError) as cm:          
-            ak.random_strings_uniform(maxlen=5,minlen=1, size=-1)
 
-        with self.assertRaises(ValueError) as cm:          
+        with self.assertRaises(ValueError):
+            ak.random_strings_uniform(maxlen=1, minlen=5, size=100)
+
+        with self.assertRaises(ValueError):
+            ak.random_strings_uniform(maxlen=5, minlen=1, size=-1)
+
+        with self.assertRaises(ValueError):
             ak.random_strings_uniform(maxlen=5, minlen=5, size=10)
-        
-        with self.assertRaises(TypeError) as cm:          
-            ak.random_strings_uniform(minlen='1', maxlen=5, size=10)
-        
-        with self.assertRaises(TypeError) as cm:          
-            ak.random_strings_uniform( minlen=1, maxlen='5', size=10)
-        
-        with self.assertRaises(TypeError) as cm:          
-            ak.random_strings_uniform(minlen=1, maxlen=5, size='10')
+
+        with self.assertRaises(TypeError):
+            ak.random_strings_uniform(minlen="1", maxlen=5, size=10)
+
+        with self.assertRaises(TypeError):
+            ak.random_strings_uniform(minlen=1, maxlen="5", size=10)
+
+        with self.assertRaises(TypeError):
+            ak.random_strings_uniform(minlen=1, maxlen=5, size="10")
 
     def test_random_strings_uniform_with_seed(self):
         pda = ak.random_strings_uniform(minlen=1, maxlen=5, seed=1, size=10)
- 
-        self.assertTrue((ak.array(['TV', 'JTEW', 'BOCO', 'HF', 'D', 'UDMM', 'T', 'NK', 'OQNP', 'ZXV']) == pda).all())
-        
-        pda = ak.random_strings_uniform(minlen=np.int64(1), maxlen=np.int64(5), seed=np.int64(1), 
-                                        size=np.int64(10))
 
-        self.assertTrue((ak.array(['TV', 'JTEW', 'BOCO', 'HF', 'D', 'UDMM', 'T', 'NK', 'OQNP', 'ZXV']) == pda).all())
-        
-        pda = ak.random_strings_uniform(minlen=1, maxlen=5, seed=1, size=10,
-                                        characters='printable')
-        self.assertTrue((ak.array(['+5', 'fp-P', '3Q4k', '~H', 'F', 'F=`,', 'E', 'YD', 'kBa\'', '(t5']) == pda).all())
+        self.assertTrue(
+            (ak.array(["TV", "JTEW", "BOCO", "HF", "D", "UDMM", "T", "NK", "OQNP", "ZXV"]) == pda).all()
+        )
+
+        pda = ak.random_strings_uniform(
+            minlen=np.int64(1), maxlen=np.int64(5), seed=np.int64(1), size=np.int64(10)
+        )
+
+        self.assertTrue(
+            (ak.array(["TV", "JTEW", "BOCO", "HF", "D", "UDMM", "T", "NK", "OQNP", "ZXV"]) == pda).all()
+        )
+
+        pda = ak.random_strings_uniform(minlen=1, maxlen=5, seed=1, size=10, characters="printable")
+        self.assertTrue(
+            (ak.array(["+5", "fp-P", "3Q4k", "~H", "F", "F=`,", "E", "YD", "kBa'", "(t5"]) == pda).all()
+        )
 
     def test_random_strings_lognormal(self):
-        pda = ak.random_strings_lognormal(2, 0.25, 100, characters='printable')
-        self.assertIsInstance(pda,ak.Strings)
+        pda = ak.random_strings_lognormal(2, 0.25, 100, characters="printable")
+        self.assertIsInstance(pda, ak.Strings)
         self.assertEqual(100, len(pda))
         self.assertEqual(str, pda.dtype)
-        
-        pda = ak.random_strings_lognormal(np.int64(2), 0.25, np.int64(100), characters='printable')
-        self.assertIsInstance(pda,ak.Strings)
+
+        pda = ak.random_strings_lognormal(np.int64(2), 0.25, np.int64(100), characters="printable")
+        self.assertIsInstance(pda, ak.Strings)
         self.assertEqual(100, len(pda))
         self.assertEqual(str, pda.dtype)
-        
-        pda = ak.random_strings_lognormal(np.int64(2), float(0.25), np.int64(100), characters='printable')
-        self.assertIsInstance(pda,ak.Strings)
+
+        pda = ak.random_strings_lognormal(
+            np.int64(2), float(0.25), np.int64(100), characters="printable"
+        )
+        self.assertIsInstance(pda, ak.Strings)
         self.assertEqual(100, len(pda))
         self.assertEqual(str, pda.dtype)
-        
-        pda = ak.random_strings_lognormal(logmean=np.int64(2), logstd=0.25, size=np.int64(100), characters='printable', 
-                                          seed=np.int64(0))
-        self.assertIsInstance(pda,ak.Strings)
+
+        pda = ak.random_strings_lognormal(
+            logmean=np.int64(2),
+            logstd=0.25,
+            size=np.int64(100),
+            characters="printable",
+            seed=np.int64(0),
+        )
+        self.assertIsInstance(pda, ak.Strings)
         self.assertEqual(100, len(pda))
         self.assertEqual(str, pda.dtype)
-        
-        pda = ak.random_strings_lognormal(logmean=np.float64(2), logstd=np.float64(0.25), size=np.int64(100), characters='printable', 
-                                          seed=np.int64(0))
-        self.assertIsInstance(pda,ak.Strings)
+
+        pda = ak.random_strings_lognormal(
+            logmean=np.float64(2),
+            logstd=np.float64(0.25),
+            size=np.int64(100),
+            characters="printable",
+            seed=np.int64(0),
+        )
+        self.assertIsInstance(pda, ak.Strings)
         self.assertEqual(100, len(pda))
         self.assertEqual(str, pda.dtype)
-        
-        pda = ak.random_strings_lognormal(np.float64(2), np.float64(0.25), np.int64(100), 
-                                          characters='printable', seed=np.int64(0))
-        self.assertIsInstance(pda,ak.Strings)
+
+        pda = ak.random_strings_lognormal(
+            np.float64(2), np.float64(0.25), np.int64(100), characters="printable", seed=np.int64(0)
+        )
+        self.assertIsInstance(pda, ak.Strings)
         self.assertEqual(100, len(pda))
         self.assertEqual(str, pda.dtype)
-        
-        with self.assertRaises(TypeError) as cm:          
-            ak.random_strings_lognormal('2', 0.25, 100)
-                
-        with self.assertRaises(TypeError) as cm:          
-            ak.random_strings_lognormal(2, 0.25, '100')
-        
-        with self.assertRaises(TypeError) as cm:          
+
+        with self.assertRaises(TypeError):
+            ak.random_strings_lognormal("2", 0.25, 100)
+
+        with self.assertRaises(TypeError):
+            ak.random_strings_lognormal(2, 0.25, "100")
+
+        with self.assertRaises(TypeError):
             ak.random_strings_lognormal(2, 0.25, 100, 1000000)
-        
+
     def test_random_strings_lognormal_with_seed(self):
         pda = ak.random_strings_lognormal(2, 0.25, 10, seed=1)
-        
-        self.assertTrue((ak.array(['TVKJTE', 'ABOCORHFM', 'LUDMMGTB', 'KWOQNPHZ', 
-                                   'VSXRRL', 'AKOZOEEWTB', 'GOSVGEJNOW', 'BFWSIO', 
-                                   'MRIEJUSA', 'OLUKRJK'])
-                        == pda).all())   
-        
+
+        self.assertTrue(
+            (
+                ak.array(
+                    [
+                        "TVKJTE",
+                        "ABOCORHFM",
+                        "LUDMMGTB",
+                        "KWOQNPHZ",
+                        "VSXRRL",
+                        "AKOZOEEWTB",
+                        "GOSVGEJNOW",
+                        "BFWSIO",
+                        "MRIEJUSA",
+                        "OLUKRJK",
+                    ]
+                )
+                == pda
+            ).all()
+        )
+
         pda = ak.random_strings_lognormal(float(2), np.float64(0.25), np.int64(10), seed=1)
-        
-        self.assertTrue((ak.array(['TVKJTE', 'ABOCORHFM', 'LUDMMGTB', 'KWOQNPHZ', 
-                                   'VSXRRL', 'AKOZOEEWTB', 'GOSVGEJNOW', 'BFWSIO', 
-                                   'MRIEJUSA', 'OLUKRJK'])
-                        == pda).all())          
 
-        pda = ak.random_strings_lognormal(2, 0.25, 10, seed=1, characters='printable')
+        self.assertTrue(
+            (
+                ak.array(
+                    [
+                        "TVKJTE",
+                        "ABOCORHFM",
+                        "LUDMMGTB",
+                        "KWOQNPHZ",
+                        "VSXRRL",
+                        "AKOZOEEWTB",
+                        "GOSVGEJNOW",
+                        "BFWSIO",
+                        "MRIEJUSA",
+                        "OLUKRJK",
+                    ]
+                )
+                == pda
+            ).all()
+        )
 
-        self.assertTrue((ak.array(['+5"fp-', ']3Q4kC~HF', '=F=`,IE!', "DjkBa'9(", '5oZ1)=', 
-                                   'T^.1@6aj";', '8b2$IX!Y7.', 'x|Y!eQ', '>1\\>2,on', '&#W":C3'])
-                        == pda).all())   
-        
-        pda = ak.random_strings_lognormal(np.int64(2), np.float64(0.25), np.int64(10), seed=1, characters='printable')
+        pda = ak.random_strings_lognormal(2, 0.25, 10, seed=1, characters="printable")
 
-        self.assertTrue((ak.array(['+5"fp-', ']3Q4kC~HF', '=F=`,IE!', "DjkBa'9(", '5oZ1)=', 
-                                   'T^.1@6aj";', '8b2$IX!Y7.', 'x|Y!eQ', '>1\\>2,on', '&#W":C3'])
-                        == pda).all())      
-    
+        self.assertTrue(
+            (
+                ak.array(
+                    [
+                        '+5"fp-',
+                        "]3Q4kC~HF",
+                        "=F=`,IE!",
+                        "DjkBa'9(",
+                        "5oZ1)=",
+                        'T^.1@6aj";',
+                        "8b2$IX!Y7.",
+                        "x|Y!eQ",
+                        ">1\\>2,on",
+                        '&#W":C3',
+                    ]
+                )
+                == pda
+            ).all()
+        )
+
+        pda = ak.random_strings_lognormal(
+            np.int64(2), np.float64(0.25), np.int64(10), seed=1, characters="printable"
+        )
+
+        self.assertTrue(
+            (
+                ak.array(
+                    [
+                        '+5"fp-',
+                        "]3Q4kC~HF",
+                        "=F=`,IE!",
+                        "DjkBa'9(",
+                        "5oZ1)=",
+                        'T^.1@6aj";',
+                        "8b2$IX!Y7.",
+                        "x|Y!eQ",
+                        ">1\\>2,on",
+                        '&#W":C3',
+                    ]
+                )
+                == pda
+            ).all()
+        )
+
     def test_mulitdimensional_array_creation(self):
-        av = ak.array([[0,0],[0,1],[1,1]])
+        av = ak.array([[0, 0], [0, 1], [1, 1]])
         self.assertIsInstance(av, ak.ArrayView)
 
     def test_from_series(self):
-        strings = ak.from_series(pd.Series(['a', 'b', 'c', 'd', 'e'], dtype="string"))
-        
+        strings = ak.from_series(pd.Series(["a", "b", "c", "d", "e"], dtype="string"))
+
         self.assertIsInstance(strings, ak.Strings)
         self.assertEqual(5, len(strings))
 
-        objects = ak.from_series(pd.Series(['a', 'b', 'c', 'd', 'e']), dtype=str)
-        
+        objects = ak.from_series(pd.Series(["a", "b", "c", "d", "e"]), dtype=str)
+
         self.assertIsInstance(objects, ak.Strings)
         self.assertEqual(str, objects.dtype)
-        
-        objects = ak.from_series(pd.Series(['a', 'b', 'c', 'd', 'e']))
-        
+
+        objects = ak.from_series(pd.Series(["a", "b", "c", "d", "e"]))
+
         self.assertIsInstance(objects, ak.Strings)
-        self.assertEqual(str, objects.dtype)       
+        self.assertEqual(str, objects.dtype)
 
-        p_array = ak.from_series(pd.Series(np.random.randint(0,10,10)))
+        p_array = ak.from_series(pd.Series(np.random.randint(0, 10, 10)))
 
-        self.assertIsInstance(p_array,ak.pdarray)
+        self.assertIsInstance(p_array, ak.pdarray)
         self.assertEqual(np.int64, p_array.dtype)
-    
-        p_i_objects_array = ak.from_series(pd.Series(np.random.randint(0,10,10), 
-                                                   dtype='object'), dtype=np.int64)
 
-        self.assertIsInstance(p_i_objects_array,ak.pdarray)
+        p_i_objects_array = ak.from_series(
+            pd.Series(np.random.randint(0, 10, 10), dtype="object"), dtype=np.int64
+        )
+
+        self.assertIsInstance(p_i_objects_array, ak.pdarray)
         self.assertEqual(np.int64, p_i_objects_array.dtype)
-        
-        p_array = ak.from_series(pd.Series(np.random.uniform(low=0.0,high=1.0,size=10)))
 
-        self.assertIsInstance(p_array,ak.pdarray)
-        self.assertEqual(np.float64, p_array.dtype)    
-        
-        p_f_objects_array = ak.from_series(pd.Series(np.random.uniform(low=0.0,high=1.0,size=10), 
-                                           dtype='object'), dtype=np.float64)
+        p_array = ak.from_series(pd.Series(np.random.uniform(low=0.0, high=1.0, size=10)))
 
-        self.assertIsInstance(p_f_objects_array,ak.pdarray)
-        self.assertEqual(np.float64, p_f_objects_array.dtype)  
-        
-        p_array = ak.from_series(pd.Series(np.random.choice([True, False],size=10)))
+        self.assertIsInstance(p_array, ak.pdarray)
+        self.assertEqual(np.float64, p_array.dtype)
 
-        self.assertIsInstance(p_array,ak.pdarray)
-        self.assertEqual(bool, p_array.dtype)       
-        
-        p_b_objects_array = ak.from_series(pd.Series(np.random.choice([True, False],size=10), 
-                                            dtype='object'), dtype=bool)
+        p_f_objects_array = ak.from_series(
+            pd.Series(np.random.uniform(low=0.0, high=1.0, size=10), dtype="object"), dtype=np.float64
+        )
 
-        self.assertIsInstance( p_b_objects_array,ak.pdarray)
-        self.assertEqual(bool, p_b_objects_array.dtype)     
+        self.assertIsInstance(p_f_objects_array, ak.pdarray)
+        self.assertEqual(np.float64, p_f_objects_array.dtype)
 
-        p_array = ak.from_series(pd.Series([dt.datetime(2016,1,1,0,0,1)]))
-        
-        self.assertIsInstance(p_array,ak.pdarray)
-        self.assertEqual(np.int64, p_array.dtype)   
+        p_array = ak.from_series(pd.Series(np.random.choice([True, False], size=10)))
 
-        p_array = ak.from_series(pd.Series([np.datetime64('2018-01-01')]))
-        
-        self.assertIsInstance(p_array,ak.pdarray)
-        self.assertEqual(np.int64, p_array.dtype)   
-        
-        p_array = ak.from_series(pd.Series(pd.to_datetime(['1/1/2018', 
-                                    np.datetime64('2018-01-01'), dt.datetime(2018, 1, 1)])))
-        
-        self.assertIsInstance(p_array,ak.pdarray)
-        self.assertEqual(np.int64, p_array.dtype)  
-  
-        with self.assertRaises(TypeError) as cm:          
+        self.assertIsInstance(p_array, ak.pdarray)
+        self.assertEqual(bool, p_array.dtype)
+
+        p_b_objects_array = ak.from_series(
+            pd.Series(np.random.choice([True, False], size=10), dtype="object"), dtype=bool
+        )
+
+        self.assertIsInstance(p_b_objects_array, ak.pdarray)
+        self.assertEqual(bool, p_b_objects_array.dtype)
+
+        p_array = ak.from_series(pd.Series([dt.datetime(2016, 1, 1, 0, 0, 1)]))
+
+        self.assertIsInstance(p_array, ak.pdarray)
+        self.assertEqual(np.int64, p_array.dtype)
+
+        p_array = ak.from_series(pd.Series([np.datetime64("2018-01-01")]))
+
+        self.assertIsInstance(p_array, ak.pdarray)
+        self.assertEqual(np.int64, p_array.dtype)
+
+        p_array = ak.from_series(
+            pd.Series(pd.to_datetime(["1/1/2018", np.datetime64("2018-01-01"), dt.datetime(2018, 1, 1)]))
+        )
+
+        self.assertIsInstance(p_array, ak.pdarray)
+        self.assertEqual(np.int64, p_array.dtype)
+
+        with self.assertRaises(TypeError):
             ak.from_series(np.ones(100))
 
-        with self.assertRaises(ValueError) as cm:          
-            ak.from_series(pd.Series(np.random.randint(0,10,10), dtype=np.int8))
-        
+        with self.assertRaises(ValueError):
+            ak.from_series(pd.Series(np.random.randint(0, 10, 10), dtype=np.int8))
+
     def test_fill(self):
         ones = ak.ones(100)
 
         ones.fill(2)
         self.assertTrue((2 == ones.to_ndarray()).all())
-        
-        ones.fill(np.int64(2))  
-        self.assertTrue((np.int64(2) == ones.to_ndarray()).all())     
-        
-        ones.fill(float(2))  
-        self.assertTrue((float(2) == ones.to_ndarray()).all())  
-        
-        ones.fill(np.float64(2))  
-        self.assertTrue((np.float64(2) == ones.to_ndarray()).all())  
+
+        ones.fill(np.int64(2))
+        self.assertTrue((np.int64(2) == ones.to_ndarray()).all())
+
+        ones.fill(float(2))
+        self.assertTrue((float(2) == ones.to_ndarray()).all())
+
+        ones.fill(np.float64(2))
+        self.assertTrue((np.float64(2) == ones.to_ndarray()).all())
 
     def test_endian(self):
         N = 100
 
         a = np.random.randint(1, N, N)
         aka = ak.array(a)
-        npa = aka.to_ndarray();
+        npa = aka.to_ndarray()
         self.assertTrue(np.allclose(a, npa))
 
         a = a.newbyteorder().byteswap()
         aka = ak.array(a)
-        npa = aka.to_ndarray();
+        npa = aka.to_ndarray()
         self.assertTrue(np.allclose(a, npa))
 
         a = a.newbyteorder().byteswap()
         aka = ak.array(a)
-        npa = aka.to_ndarray();
+        npa = aka.to_ndarray()
         self.assertTrue(np.allclose(a, npa))
 
     def test_clobber(self):
@@ -663,9 +774,9 @@ class PdarrayCreationTest(ArkoudaTest):
             self.assertTrue(np.all(npa == i))
 
             a += 1
-            self.assertTrue(np.all(a == i+1))
+            self.assertTrue(np.all(a == i + 1))
             self.assertTrue(np.all(npa == i))
 
             npa += 1
-            self.assertTrue(np.all(a == i+1))
-            self.assertTrue(np.all(npa == i+1))
+            self.assertTrue(np.all(a == i + 1))
+            self.assertTrue(np.all(npa == i + 1))

--- a/tests/read_all_tests.py
+++ b/tests/read_all_tests.py
@@ -2,31 +2,33 @@
 # test data located at  https://csr.lanl.gov/data/netflow.html
 # field names located at https://csr.lanl.gov/data/2017.html
 
-from context import arkouda as ak
-import sys, os, h5py, time
+import os
+import sys
+import time
 from glob import glob
+
 from base_test import ArkoudaTest
+from context import arkouda as ak
 
 
 class ReadAllTest(ArkoudaTest):
-
     def setUp(self):
-      
-        '''
+
+        """
         Invokes the parent setUp method to start the arkouda_server and also
         sets the test_data_url used to lookup test files.sets
-        
+
         :return: None
         :raise: AssertionError if the TEST_DATA_URL has not been set
-        '''
+        """
         ArkoudaTest.setUp(self)
-        self.test_data_url = os.getenv('TEST_DATA_URL')
-        assert self.test_data_url, 'The TEST_DATA_URL env variable must be set'
+        self.test_data_url = os.getenv("TEST_DATA_URL")
+        assert self.test_data_url, "The TEST_DATA_URL env variable must be set"
 
     def testReadAll(self):
-        ak.verbose = False    #client verbose Flag
+        ak.verbose = False  # client verbose Flag
         cwd = os.getcwd()
-        allfiles = glob(cwd+'/../converter/netflow_day-*.hdf')
+        allfiles = glob(cwd + "/../converter/netflow_day-*.hdf")
         print(allfiles)
         start = time.time()
         dictionary1 = ak.read(allfiles, iterative=True)
@@ -34,7 +36,7 @@ class ReadAllTest(ArkoudaTest):
         t1 = end - start
         print("read(iterative=True) seconds: %.3f" % (t1))
         for key, value in dictionary1.items():
-            print(key,type(value),value,len(value))
+            print(key, type(value), value, len(value))
 
         start = time.time()
         dictionary2 = ak.read(allfiles)
@@ -42,16 +44,17 @@ class ReadAllTest(ArkoudaTest):
         t2 = end - start
         print("read() seconds: %.3f" % (t2))
         for key, value in dictionary2.items():
-            print(key,type(value),value,len(value))
-        
-if __name__ == '__main__':        
+            print(key, type(value), value, len(value))
+
+
+if __name__ == "__main__":
     if len(sys.argv) < 3:
         print("Usage: {} <hostname> <port> <HDF5_filenames>".format(sys.argv[0]))
         sys.exit()
     ak.connect(sys.argv[1], sys.argv[2])
-    ak.verbose = False    #client verbose Flag
+    ak.verbose = False  # client verbose Flag
     cwd = os.getcwd()
-    allfiles = glob(cwd+'/../converter/netflow_day-*.hdf')
+    allfiles = glob(cwd + "/../converter/netflow_day-*.hdf")
     if len(sys.argv) > 3:
         allfiles = sys.argv[3:]
 
@@ -61,7 +64,7 @@ if __name__ == '__main__':
     t1 = end - start
     print("read(iterative=True) seconds: %.3f" % (t1))
     for key, value in dictionary1.items():
-        print(key,type(value),value,len(value))
+        print(key, type(value), value, len(value))
 
     start = time.time()
     dictionary2 = ak.read(allfiles)
@@ -69,6 +72,6 @@ if __name__ == '__main__':
     t2 = end - start
     print("read() seconds: %.3f" % (t2))
     for key, value in dictionary2.items():
-        print(key,type(value),value,len(value))
+        print(key, type(value), value, len(value))
 
     ak.disconnect()

--- a/tests/read_write_tests.py
+++ b/tests/read_write_tests.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 
-import arkouda as ak
-import sys, os
+import os
+import sys
 
-saveone = '/tmp/ak_save.hdf'
-saveall = '/tmp/ak_save_all.hdf'
+import arkouda as ak
+
+saveone = "/tmp/ak_save.hdf"
+saveall = "/tmp/ak_save_all.hdf"
 
 if len(sys.argv) < 4:
     print("Usage: {} <hostname> <port> <HDF5_filenames>".format(sys.argv[0]))
@@ -14,20 +16,20 @@ onefile = sys.argv[3]
 print(ak.ls(onefile))
 allfiles = sys.argv[3:]
 print(f"srcIP = ak.read({onefile},'srcIP')")
-srcIP = ak.read(onefile, 'srcIP')
+srcIP = ak.read(onefile, "srcIP")
 print(f"srcIP.save({saveone}, 'srcIP')")
-srcIP.save(saveone, 'srcIP')
+srcIP.save(saveone, "srcIP")
 print(f"srcIP2 = ak.load({saveone}, 'srcIP')")
-srcIP2 = ak.load(saveone, 'srcIP')
+srcIP2 = ak.load(saveone, "srcIP")
 assert (srcIP == srcIP2).all()
 del srcIP
 del srcIP2
 print(f"df = ak.read(['srcPort', 'proto', 'packets'], {allfiles})")
-df = ak.read(['srcPort', 'proto', 'packets'], allfiles)
+df = ak.read(["srcPort", "proto", "packets"], allfiles)
 print(f"ak.save_all(df, {saveall})")
 ak.save_all(df, saveall)
 print(f"newdf = ak.load_all({saveall})")
 newdf = ak.load_all(saveall)
 print(newdf)
-os.system('rm -rf /tmp/ak_save*')
+os.system("rm -rf /tmp/ak_save*")
 ak.disconnect()

--- a/tests/regex_test.py
+++ b/tests/regex_test.py
@@ -1,16 +1,17 @@
-from context import arkouda as ak
-from base_test import ArkoudaTest
 import re
+
+from base_test import ArkoudaTest
+from context import arkouda as ak
 
 
 class RegexTest(ArkoudaTest):
-
     def test_empty_string_patterns(self):
         # For issue #959:
-        # verify ValueError is raised when methods which use Regex.matches have a pattern which matches the empty string
+        # verify ValueError is raised when methods which use Regex.matches
+        # have a pattern which matches the empty string
         # TODO remove/change test once changes from chapel issue #18639 are in arkouda
-        s = ak.array(['one'])
-        for pattern in ['', '|', '^', '$']:
+        s = ak.array(["one"])
+        for pattern in ["", "|", "^", "$"]:
             with self.assertRaises(ValueError):
                 s.search(pattern)
             with self.assertRaises(ValueError):
@@ -20,7 +21,7 @@ class RegexTest(ArkoudaTest):
             with self.assertRaises(ValueError):
                 s.split(pattern)
             with self.assertRaises(ValueError):
-                s.sub(pattern, 'repl')
+                s.sub(pattern, "repl")
             with self.assertRaises(ValueError):
                 s.findall(pattern)
             with self.assertRaises(ValueError):
@@ -37,8 +38,10 @@ class RegexTest(ArkoudaTest):
                 s.flatten(pattern, regex=True)
 
     def test_match_objects(self):
-        strings = ak.array(['', '____', '_1_2____', '3___4___', '5', '__6__', '___7', '__8___9____10____11'])
-        pattern = '_+'
+        strings = ak.array(
+            ["", "____", "_1_2____", "3___4___", "5", "__6__", "___7", "__8___9____10____11"]
+        )
+        pattern = "_+"
 
         ak_search = strings.search(pattern)
         ak_match = strings.match(pattern)
@@ -48,58 +51,90 @@ class RegexTest(ArkoudaTest):
         re_match = [re.match(pattern, strings[i]) for i in range(strings.size)]
         re_fullmatch = [re.fullmatch(pattern, strings[i]) for i in range(strings.size)]
 
-        self.assertListEqual(ak_search.matched().to_ndarray().tolist(), [m is not None for m in re_search])
+        self.assertListEqual(
+            ak_search.matched().to_ndarray().tolist(), [m is not None for m in re_search]
+        )
         self.assertListEqual(ak_match.matched().to_ndarray().tolist(), [m is not None for m in re_match])
-        self.assertListEqual(ak_fullmatch.matched().to_ndarray().tolist(), [m is not None for m in re_fullmatch])
+        self.assertListEqual(
+            ak_fullmatch.matched().to_ndarray().tolist(), [m is not None for m in re_fullmatch]
+        )
 
-        self.assertListEqual(ak_search.start().to_ndarray().tolist(),
-                             [m.start() for m in re_search if m is not None])
-        self.assertListEqual(ak_match.start().to_ndarray().tolist(),
-                             [m.start() for m in re_match if m is not None])
-        self.assertListEqual(ak_fullmatch.start().to_ndarray().tolist(),
-                             [m.start() for m in re_fullmatch if m is not None])
+        self.assertListEqual(
+            ak_search.start().to_ndarray().tolist(), [m.start() for m in re_search if m is not None]
+        )
+        self.assertListEqual(
+            ak_match.start().to_ndarray().tolist(), [m.start() for m in re_match if m is not None]
+        )
+        self.assertListEqual(
+            ak_fullmatch.start().to_ndarray().tolist(),
+            [m.start() for m in re_fullmatch if m is not None],
+        )
 
-        self.assertListEqual(ak_search.end().to_ndarray().tolist(),
-                             [m.end() for m in re_search if m is not None])
-        self.assertListEqual(ak_match.end().to_ndarray().tolist(),
-                             [m.end() for m in re_match if m is not None])
-        self.assertListEqual(ak_fullmatch.end().to_ndarray().tolist(),
-                             [m.end() for m in re_fullmatch if m is not None])
+        self.assertListEqual(
+            ak_search.end().to_ndarray().tolist(), [m.end() for m in re_search if m is not None]
+        )
+        self.assertListEqual(
+            ak_match.end().to_ndarray().tolist(), [m.end() for m in re_match if m is not None]
+        )
+        self.assertListEqual(
+            ak_fullmatch.end().to_ndarray().tolist(), [m.end() for m in re_fullmatch if m is not None]
+        )
 
-        self.assertEqual(ak_search.match_type(), 'SEARCH')
-        self.assertEqual(ak_match.match_type(), 'MATCH')
-        self.assertEqual(ak_fullmatch.match_type(), 'FULLMATCH')
+        self.assertEqual(ak_search.match_type(), "SEARCH")
+        self.assertEqual(ak_match.match_type(), "MATCH")
+        self.assertEqual(ak_fullmatch.match_type(), "FULLMATCH")
 
         search_matches, search_origins = ak_search.find_matches(return_match_origins=True)
         match_matches, match_origins = ak_match.find_matches(return_match_origins=True)
         fullmatch_matches, fullmatch_origins = ak_fullmatch.find_matches(return_match_origins=True)
-        self.assertListEqual(search_matches.to_ndarray().tolist(),
-                             [m.string[m.start():m.end()] for m in re_search if m is not None])
-        self.assertListEqual(search_origins.to_ndarray().tolist(),
-                             [i for i in range(len(re_search)) if re_search[i] is not None])
-        self.assertListEqual(match_matches.to_ndarray().tolist(),
-                             [m.string[m.start():m.end()] for m in re_match if m is not None])
-        self.assertListEqual(match_origins.to_ndarray().tolist(),
-                             [i for i in range(len(re_match)) if re_match[i] is not None])
-        self.assertListEqual(fullmatch_matches.to_ndarray().tolist(),
-                             [m.string[m.start():m.end()] for m in re_fullmatch if m is not None])
-        self.assertListEqual(fullmatch_origins.to_ndarray().tolist(),
-                             [i for i in range(len(re_fullmatch)) if re_fullmatch[i] is not None])
+        self.assertListEqual(
+            search_matches.to_ndarray().tolist(),
+            [m.string[m.start() : m.end()] for m in re_search if m is not None],
+        )
+        self.assertListEqual(
+            search_origins.to_ndarray().tolist(),
+            [i for i in range(len(re_search)) if re_search[i] is not None],
+        )
+        self.assertListEqual(
+            match_matches.to_ndarray().tolist(),
+            [m.string[m.start() : m.end()] for m in re_match if m is not None],
+        )
+        self.assertListEqual(
+            match_origins.to_ndarray().tolist(),
+            [i for i in range(len(re_match)) if re_match[i] is not None],
+        )
+        self.assertListEqual(
+            fullmatch_matches.to_ndarray().tolist(),
+            [m.string[m.start() : m.end()] for m in re_fullmatch if m is not None],
+        )
+        self.assertListEqual(
+            fullmatch_origins.to_ndarray().tolist(),
+            [i for i in range(len(re_fullmatch)) if re_fullmatch[i] is not None],
+        )
 
         # Capture Groups
-        tug_of_war = ak.array(["Isaac Newton, physicist", '<--calculus-->', 'Gottfried Leibniz, mathematician'])
+        tug_of_war = ak.array(
+            ["Isaac Newton, physicist", "<--calculus-->", "Gottfried Leibniz, mathematician"]
+        )
         ak_captures = tug_of_war.search("(\\w+) (\\w+)")
         re_captures = [re.search("(\\w+) (\\w+)", tug_of_war[i]) for i in range(tug_of_war.size)]
-        self.assertListEqual(ak_captures.group().to_ndarray().tolist(),
-                             [m.group() for m in re_captures if m is not None])
-        self.assertListEqual(ak_captures.group(1).to_ndarray().tolist(),
-                             [m.group(1) for m in re_captures if m is not None])
-        self.assertListEqual(ak_captures.group(2).to_ndarray().tolist(),
-                             [m.group(2) for m in re_captures if m is not None])
+        self.assertListEqual(
+            ak_captures.group().to_ndarray().tolist(), [m.group() for m in re_captures if m is not None]
+        )
+        self.assertListEqual(
+            ak_captures.group(1).to_ndarray().tolist(),
+            [m.group(1) for m in re_captures if m is not None],
+        )
+        self.assertListEqual(
+            ak_captures.group(2).to_ndarray().tolist(),
+            [m.group(2) for m in re_captures if m is not None],
+        )
 
         group, group_origins = ak_captures.group(1, return_group_origins=True)
-        self.assertListEqual(group_origins.to_ndarray().tolist(),
-                             [i for i in range(len(re_captures)) if re_captures[i] is not None])
+        self.assertListEqual(
+            group_origins.to_ndarray().tolist(),
+            [i for i in range(len(re_captures)) if re_captures[i] is not None],
+        )
 
         with self.assertRaises(ValueError):
             ak_captures.group(-1)
@@ -107,13 +142,15 @@ class RegexTest(ArkoudaTest):
             ak_captures.group(40)
 
         # verify fluid programming with Match object doesn't raise a RuntimeError
-        ak.array(['1_2___', '____', '3', '__4___5____6___7', '']).search('_+').find_matches()
+        ak.array(["1_2___", "____", "3", "__4___5____6___7", ""]).search("_+").find_matches()
 
     def test_sub(self):
-        strings = ak.array(['', '____', '_1_2____', '3___4___', '5', '__6__', '___7', '__8___9____10____11'])
-        pattern = '_+'
+        strings = ak.array(
+            ["", "____", "_1_2____", "3___4___", "5", "__6__", "___7", "__8___9____10____11"]
+        )
+        pattern = "_+"
         # test short repl
-        repl = '-'
+        repl = "-"
         count = 3
         re_sub = [re.sub(pattern, repl, strings[i], count) for i in range(strings.size)]
         re_sub_counts = [re.subn(pattern, repl, strings[i], count)[1] for i in range(strings.size)]
@@ -122,7 +159,7 @@ class RegexTest(ArkoudaTest):
         self.assertListEqual(re_sub_counts, ak_sub_counts.to_ndarray().tolist())
 
         # test long repl
-        repl = '---------'
+        repl = "---------"
         count = 3
         re_sub = [re.sub(pattern, repl, strings[i], count) for i in range(strings.size)]
         re_sub_counts = [re.subn(pattern, repl, strings[i], count)[1] for i in range(strings.size)]
@@ -131,49 +168,55 @@ class RegexTest(ArkoudaTest):
         self.assertListEqual(re_sub_counts, ak_sub_counts.to_ndarray().tolist())
 
     def test_split(self):
-        strings = ak.array(['', '____', '_1_2____', '3___4___', '5', '__6__', '___7', '__8___9____10____11'])
-        pattern = '_+'
+        strings = ak.array(
+            ["", "____", "_1_2____", "3___4___", "5", "__6__", "___7", "__8___9____10____11"]
+        )
+        pattern = "_+"
         maxsplit = 3
         split, split_map = strings.split(pattern, maxsplit, return_segments=True)
         for i in range(strings.size):
             re_split = re.split(pattern, strings[i], maxsplit)
-            ak_split = split[split_map[i]:] if i == strings.size-1 else split[split_map[i]:split_map[i+1]]
+            ak_split = (
+                split[split_map[i] :]
+                if i == strings.size - 1
+                else split[split_map[i] : split_map[i + 1]]
+            )
             self.assertListEqual(re_split, ak_split.to_ndarray().tolist())
 
     def test_regex_contains(self):
-        digit_strings = ak.array(['{} string {}'.format(i, i) for i in range(1, 6)])
-        self.assertTrue(digit_strings.contains('\\d str', regex=True).all())
-        self.assertTrue(digit_strings.contains('ing \\d', regex=True).all())
+        digit_strings = ak.array(["{} string {}".format(i, i) for i in range(1, 6)])
+        self.assertTrue(digit_strings.contains("\\d str", regex=True).all())
+        self.assertTrue(digit_strings.contains("ing \\d", regex=True).all())
 
-        aaa_strings = ak.array(['{} string {}'.format('a'*i, 'a'*i) for i in range(1, 6)])
-        self.assertTrue(aaa_strings.contains('a+ str', regex=True).all())
-        self.assertTrue(aaa_strings.contains('ing a+', regex=True).all())
+        aaa_strings = ak.array(["{} string {}".format("a" * i, "a" * i) for i in range(1, 6)])
+        self.assertTrue(aaa_strings.contains("a+ str", regex=True).all())
+        self.assertTrue(aaa_strings.contains("ing a+", regex=True).all())
 
     def test_regex_startswith(self):
-        digit_strings = ak.array(['{} string {}'.format(i, i) for i in range(1, 6)])
-        self.assertTrue(digit_strings.startswith('\\d str', regex=True).all())
-        self.assertFalse(digit_strings.startswith('ing \\d', regex=True).any())
+        digit_strings = ak.array(["{} string {}".format(i, i) for i in range(1, 6)])
+        self.assertTrue(digit_strings.startswith("\\d str", regex=True).all())
+        self.assertFalse(digit_strings.startswith("ing \\d", regex=True).any())
 
-        aaa_strings = ak.array(['{} string {}'.format('a'*i, 'a'*i) for i in range(1, 6)])
-        self.assertTrue(aaa_strings.startswith('a+ str', regex=True).all())
-        self.assertFalse(aaa_strings.startswith('ing a+', regex=True).any())
+        aaa_strings = ak.array(["{} string {}".format("a" * i, "a" * i) for i in range(1, 6)])
+        self.assertTrue(aaa_strings.startswith("a+ str", regex=True).all())
+        self.assertFalse(aaa_strings.startswith("ing a+", regex=True).any())
 
     def test_regex_endswith(self):
-        digit_strings = ak.array(['{} string {}'.format(i, i) for i in range(1, 6)])
-        self.assertTrue(digit_strings.endswith('ing \\d', regex=True).all())
-        self.assertFalse(digit_strings.endswith('\\d str', regex=True).any())
+        digit_strings = ak.array(["{} string {}".format(i, i) for i in range(1, 6)])
+        self.assertTrue(digit_strings.endswith("ing \\d", regex=True).all())
+        self.assertFalse(digit_strings.endswith("\\d str", regex=True).any())
 
-        aaa_strings = ak.array(['{} string {}'.format('a'*i, 'a'*i) for i in range(1, 6)])
-        self.assertTrue(aaa_strings.endswith('ing a+', regex=True).all())
-        self.assertFalse(aaa_strings.endswith('a+ str', regex=True).any())
+        aaa_strings = ak.array(["{} string {}".format("a" * i, "a" * i) for i in range(1, 6)])
+        self.assertTrue(aaa_strings.endswith("ing a+", regex=True).all())
+        self.assertFalse(aaa_strings.endswith("a+ str", regex=True).any())
 
     def test_regex_find_locations(self):
-        strings = ak.array(['{} string {}'.format(i, i) for i in range(1, 6)])
+        strings = ak.array(["{} string {}".format(i, i) for i in range(1, 6)])
 
         expected_num_matches = [2, 2, 2, 2, 2]
         expected_starts = [0, 9, 0, 9, 0, 9, 0, 9, 0, 9]
         expected_lens = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
-        actual_num_matches, actual_starts, actual_lens = strings.find_locations('\\d')
+        actual_num_matches, actual_starts, actual_lens = strings.find_locations("\\d")
         self.assertListEqual(expected_num_matches, actual_num_matches.to_ndarray().tolist())
         self.assertListEqual(expected_starts, actual_starts.to_ndarray().tolist())
         self.assertListEqual(expected_lens, actual_lens.to_ndarray().tolist())
@@ -181,91 +224,106 @@ class RegexTest(ArkoudaTest):
         expected_num_matches = [1, 1, 1, 1, 1]
         expected_starts = [2, 2, 2, 2, 2]
         expected_lens = [8, 8, 8, 8, 8]
-        actual_num_matches, actual_starts, actual_lens = strings.find_locations('string \\d')
+        actual_num_matches, actual_starts, actual_lens = strings.find_locations("string \\d")
         self.assertListEqual(expected_num_matches, actual_num_matches.to_ndarray().tolist())
         self.assertListEqual(expected_starts, actual_starts.to_ndarray().tolist())
         self.assertListEqual(expected_lens, actual_lens.to_ndarray().tolist())
 
     def test_regex_findall(self):
-        strings = ak.array(['{} string {}'.format(i, i) for i in range(1, 6)])
-        expected_matches = ['1', '1', '2', '2', '3', '3', '4', '4', '5', '5']
+        strings = ak.array(["{} string {}".format(i, i) for i in range(1, 6)])
+        expected_matches = ["1", "1", "2", "2", "3", "3", "4", "4", "5", "5"]
         expected_match_origins = [0, 0, 1, 1, 2, 2, 3, 3, 4, 4]
-        actual_matches, actual_match_origins = strings.findall('\\d', return_match_origins=True)
+        actual_matches, actual_match_origins = strings.findall("\\d", return_match_origins=True)
         self.assertListEqual(expected_matches, actual_matches.to_ndarray().tolist())
         self.assertListEqual(expected_match_origins, actual_match_origins.to_ndarray().tolist())
-        actual_matches = strings.findall('\\d')
+        actual_matches = strings.findall("\\d")
         self.assertListEqual(expected_matches, actual_matches.to_ndarray().tolist())
 
-        expected_matches = ['string 1', 'string 2', 'string 3', 'string 4', 'string 5']
+        expected_matches = ["string 1", "string 2", "string 3", "string 4", "string 5"]
         expected_match_origins = [0, 1, 2, 3, 4]
-        actual_matches, actual_match_origins = strings.findall('string \\d', return_match_origins=True)
+        actual_matches, actual_match_origins = strings.findall("string \\d", return_match_origins=True)
         self.assertListEqual(expected_matches, actual_matches.to_ndarray().tolist())
         self.assertListEqual(expected_match_origins, actual_match_origins.to_ndarray().tolist())
 
-        under = ak.array(['', '____', '_1_2', '3___4___', '5'])
-        expected_matches = ['____', '_', '_', '___', '___']
+        under = ak.array(["", "____", "_1_2", "3___4___", "5"])
+        expected_matches = ["____", "_", "_", "___", "___"]
         expected_match_origins = [1, 2, 2, 3, 3]
-        actual_matches, actual_match_origins = under.findall('_+', return_match_origins=True)
+        actual_matches, actual_match_origins = under.findall("_+", return_match_origins=True)
         self.assertListEqual(expected_matches, actual_matches.to_ndarray().tolist())
         self.assertListEqual(expected_match_origins, actual_match_origins.to_ndarray().tolist())
 
     def test_regex_peel(self):
-        orig = ak.array(['a.b', 'c.d', 'e.f.g'])
-        digit = ak.array(['a1b', 'c1d', 'e1f2g'])
-        under = ak.array(['a_b', 'c___d', 'e__f____g'])
+        orig = ak.array(["a.b", "c.d", "e.f.g"])
+        digit = ak.array(["a1b", "c1d", "e1f2g"])
+        under = ak.array(["a_b", "c___d", "e__f____g"])
 
-        o_left, o_right = orig.peel('.')
-        d_left, d_right = digit.peel('\\d', regex=True)
-        u_left, u_right = under.peel('_+', regex=True)
-        self.assertListEqual(['a', 'c', 'e'], o_left.to_ndarray().tolist())
-        self.assertListEqual(['a', 'c', 'e'], d_left.to_ndarray().tolist())
-        self.assertListEqual(['a', 'c', 'e'], u_left.to_ndarray().tolist())
-        self.assertListEqual(['b', 'd', 'f.g'], o_right.to_ndarray().tolist())
-        self.assertListEqual(['b', 'd', 'f2g'], d_right.to_ndarray().tolist())
-        self.assertListEqual(['b', 'd', 'f____g'], u_right.to_ndarray().tolist())
+        o_left, o_right = orig.peel(".")
+        d_left, d_right = digit.peel("\\d", regex=True)
+        u_left, u_right = under.peel("_+", regex=True)
+        self.assertListEqual(["a", "c", "e"], o_left.to_ndarray().tolist())
+        self.assertListEqual(["a", "c", "e"], d_left.to_ndarray().tolist())
+        self.assertListEqual(["a", "c", "e"], u_left.to_ndarray().tolist())
+        self.assertListEqual(["b", "d", "f.g"], o_right.to_ndarray().tolist())
+        self.assertListEqual(["b", "d", "f2g"], d_right.to_ndarray().tolist())
+        self.assertListEqual(["b", "d", "f____g"], u_right.to_ndarray().tolist())
 
-        o_left, o_right = orig.peel('.', includeDelimiter=True)
-        d_left, d_right = digit.peel('\\d', includeDelimiter=True, regex=True)
-        u_left, u_right = under.peel('_+', includeDelimiter=True, regex=True)
-        self.assertListEqual(['a.', 'c.', 'e.'], o_left.to_ndarray().tolist())
-        self.assertListEqual(['a1', 'c1', 'e1'], d_left.to_ndarray().tolist())
-        self.assertListEqual(['a_', 'c___', 'e__'], u_left.to_ndarray().tolist())
-        self.assertListEqual(['b', 'd', 'f.g'], o_right.to_ndarray().tolist())
-        self.assertListEqual(['b', 'd', 'f2g'], d_right.to_ndarray().tolist())
-        self.assertListEqual(['b', 'd', 'f____g'], u_right.to_ndarray().tolist())
+        o_left, o_right = orig.peel(".", includeDelimiter=True)
+        d_left, d_right = digit.peel("\\d", includeDelimiter=True, regex=True)
+        u_left, u_right = under.peel("_+", includeDelimiter=True, regex=True)
+        self.assertListEqual(["a.", "c.", "e."], o_left.to_ndarray().tolist())
+        self.assertListEqual(["a1", "c1", "e1"], d_left.to_ndarray().tolist())
+        self.assertListEqual(["a_", "c___", "e__"], u_left.to_ndarray().tolist())
+        self.assertListEqual(["b", "d", "f.g"], o_right.to_ndarray().tolist())
+        self.assertListEqual(["b", "d", "f2g"], d_right.to_ndarray().tolist())
+        self.assertListEqual(["b", "d", "f____g"], u_right.to_ndarray().tolist())
 
-        o_left, o_right = orig.peel('.', times=2, keepPartial=True)
-        d_left, d_right = digit.peel('\\d', times=2, keepPartial=True, regex=True)
-        u_left, u_right = under.peel('_+', times=2, keepPartial=True, regex=True)
-        self.assertListEqual(['a.b', 'c.d', 'e.f'], o_left.to_ndarray().tolist())
-        self.assertListEqual(['a1b', 'c1d', 'e1f'], d_left.to_ndarray().tolist())
-        self.assertListEqual(['a_b', 'c___d', 'e__f'], u_left.to_ndarray().tolist())
-        self.assertListEqual(['', '', 'g'], o_right.to_ndarray().tolist())
-        self.assertListEqual(['', '', 'g'], d_right.to_ndarray().tolist())
-        self.assertListEqual(['', '', 'g'], u_right.to_ndarray().tolist())
+        o_left, o_right = orig.peel(".", times=2, keepPartial=True)
+        d_left, d_right = digit.peel("\\d", times=2, keepPartial=True, regex=True)
+        u_left, u_right = under.peel("_+", times=2, keepPartial=True, regex=True)
+        self.assertListEqual(["a.b", "c.d", "e.f"], o_left.to_ndarray().tolist())
+        self.assertListEqual(["a1b", "c1d", "e1f"], d_left.to_ndarray().tolist())
+        self.assertListEqual(["a_b", "c___d", "e__f"], u_left.to_ndarray().tolist())
+        self.assertListEqual(["", "", "g"], o_right.to_ndarray().tolist())
+        self.assertListEqual(["", "", "g"], d_right.to_ndarray().tolist())
+        self.assertListEqual(["", "", "g"], u_right.to_ndarray().tolist())
 
         # rpeel / fromRight: digit is testing fromRight and under is testing rpeel
-        o_left, o_right = orig.peel('.', times=2, includeDelimiter=True, fromRight=True)
-        d_left, d_right = digit.peel('\\d', times=2, includeDelimiter=True, fromRight=True, regex=True)
-        u_left, u_right = under.rpeel('_+', times=2, includeDelimiter=True, regex=True)
-        self.assertListEqual(['a.b', 'c.d', 'e'], o_left.to_ndarray().tolist())
-        self.assertListEqual(['a1b', 'c1d', 'e'], d_left.to_ndarray().tolist())
-        self.assertListEqual(['a_b', 'c___d', 'e'], u_left.to_ndarray().tolist())
-        self.assertListEqual(['', '', '.f.g'], o_right.to_ndarray().tolist())
-        self.assertListEqual(['', '', '1f2g'], d_right.to_ndarray().tolist())
-        self.assertListEqual(['', '', '__f____g'], u_right.to_ndarray().tolist())
+        o_left, o_right = orig.peel(".", times=2, includeDelimiter=True, fromRight=True)
+        d_left, d_right = digit.peel("\\d", times=2, includeDelimiter=True, fromRight=True, regex=True)
+        u_left, u_right = under.rpeel("_+", times=2, includeDelimiter=True, regex=True)
+        self.assertListEqual(["a.b", "c.d", "e"], o_left.to_ndarray().tolist())
+        self.assertListEqual(["a1b", "c1d", "e"], d_left.to_ndarray().tolist())
+        self.assertListEqual(["a_b", "c___d", "e"], u_left.to_ndarray().tolist())
+        self.assertListEqual(["", "", ".f.g"], o_right.to_ndarray().tolist())
+        self.assertListEqual(["", "", "1f2g"], d_right.to_ndarray().tolist())
+        self.assertListEqual(["", "", "__f____g"], u_right.to_ndarray().tolist())
 
     def test_regex_flatten(self):
-        orig = ak.array(['one|two', 'three|four|five', 'six', 'seven|eight|nine|ten|', 'eleven'])
-        digit = ak.array(['one1two', 'three2four3five', 'six', 'seven4eight5nine6ten7', 'eleven'])
-        under = ak.array(['one_two', 'three_four__five', 'six', 'seven_____eight__nine____ten_', 'eleven'])
+        orig = ak.array(["one|two", "three|four|five", "six", "seven|eight|nine|ten|", "eleven"])
+        digit = ak.array(["one1two", "three2four3five", "six", "seven4eight5nine6ten7", "eleven"])
+        under = ak.array(
+            ["one_two", "three_four__five", "six", "seven_____eight__nine____ten_", "eleven"]
+        )
 
-        answer_flat = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten', '', 'eleven']
+        answer_flat = [
+            "one",
+            "two",
+            "three",
+            "four",
+            "five",
+            "six",
+            "seven",
+            "eight",
+            "nine",
+            "ten",
+            "",
+            "eleven",
+        ]
         answer_map = [0, 2, 5, 6, 11]
 
-        orig_flat, orig_map = orig.flatten('|', return_segments=True)
-        digit_flat, digit_map = digit.flatten('\\d', return_segments=True, regex=True)
-        under_flat, under_map = under.flatten('_+', return_segments=True, regex=True)
+        orig_flat, orig_map = orig.flatten("|", return_segments=True)
+        digit_flat, digit_map = digit.flatten("\\d", return_segments=True, regex=True)
+        under_flat, under_map = under.flatten("_+", return_segments=True, regex=True)
 
         self.assertListEqual(answer_flat, orig_flat.to_ndarray().tolist())
         self.assertListEqual(answer_flat, digit_flat.to_ndarray().tolist())
@@ -276,14 +334,14 @@ class RegexTest(ArkoudaTest):
         self.assertListEqual(answer_map, under_map.to_ndarray().tolist())
 
         # empty string, start with delim, end with delim, and only delim cases
-        orig = ak.array(['', '|', '|1|2', '3|4|', '5'])
-        regex = ak.array(['', '____', '_1_2', '3___4___', '5'])
+        orig = ak.array(["", "|", "|1|2", "3|4|", "5"])
+        regex = ak.array(["", "____", "_1_2", "3___4___", "5"])
 
-        answer_flat = ['', '', '', '', '1', '2', '3', '4', '', '5']
+        answer_flat = ["", "", "", "", "1", "2", "3", "4", "", "5"]
         answer_map = [0, 1, 3, 6, 9]
 
-        orig_flat, orig_map = orig.flatten('|', return_segments=True)
-        regex_flat, regex_map = regex.flatten('_+', return_segments=True, regex=True)
+        orig_flat, orig_map = orig.flatten("|", return_segments=True)
+        regex_flat, regex_map = regex.flatten("_+", return_segments=True, regex=True)
 
         self.assertListEqual(answer_flat, orig_flat.to_ndarray().tolist())
         self.assertListEqual(answer_flat, regex_flat.to_ndarray().tolist())

--- a/tests/registration_test.py
+++ b/tests/registration_test.py
@@ -1,9 +1,10 @@
-import pytest
 import json
 
-from arkouda import Series
-from context import arkouda as ak
+import pytest
 from base_test import ArkoudaTest
+from context import arkouda as ak
+
+from arkouda import Series
 from arkouda.pdarrayclass import RegistrationError, unregister_pdarray_by_name
 
 N = 100
@@ -11,24 +12,23 @@ UNIQUE = N // 4
 
 
 class RegistrationTest(ArkoudaTest):
-
     def setUp(self):
         ArkoudaTest.setUp(self)
         self.a_array = ak.ones(10, dtype=ak.int64)
         self.b_array = ak.ones(10, dtype=ak.int64)
 
     def test_register(self):
-        '''
+        """
         Tests the following:
 
         1. register invocation
         2. pdarray.name matches register name
         3. original and registered pdarray are equal
         4. method invocation on a cleared, registered array succeeds
-        '''
-        ar_array = self.a_array.register('test_int64_a')
+        """
+        ar_array = self.a_array.register("test_int64_a")
 
-        self.assertEqual('test_int64_a', self.a_array.name, "Expect name to change inplace")
+        self.assertEqual("test_int64_a", self.a_array.name, "Expect name to change inplace")
         self.assertTrue(self.a_array is ar_array, "These should be the same object")
         self.assertTrue((self.a_array.to_ndarray() == ar_array.to_ndarray()).all())
         ak.clear()
@@ -63,25 +63,29 @@ class RegistrationTest(ArkoudaTest):
 
         a = ak.ones(3, dtype=ak.int64)
 
-        with self.assertRaises(TypeError, msg="register() should raise TypeError when user_defined_name is not a str"):
+        with self.assertRaises(
+            TypeError, msg="register() should raise TypeError when user_defined_name is not a str"
+        ):
             a.register(7)
-        with self.assertRaises(TypeError, msg="attach() should raise TypeError when user_defined_name is not a str"):
+        with self.assertRaises(
+            TypeError, msg="attach() should raise TypeError when user_defined_name is not a str"
+        ):
             a.attach(7)
 
         ak.clear()
 
     def test_unregister(self):
-        '''
+        """
         Tests the following:
 
         1. unregister invocation
         2. method invocation on a cleared, unregistered array raises RuntimeError
-        '''
-        ar_array = self.a_array.register('test_int64_a')
+        """
+        ar_array = self.a_array.register("test_int64_a")
 
-        self.assertEqual('[1 1 1 1 1 1 1 1 1 1]', str(ar_array))
+        self.assertEqual("[1 1 1 1 1 1 1 1 1 1]", str(ar_array))
         ar_array.unregister()
-        self.assertEqual('[1 1 1 1 1 1 1 1 1 1]', str(ar_array))
+        self.assertEqual("[1 1 1 1 1 1 1 1 1 1]", str(ar_array))
 
         ak.clear()
 
@@ -92,7 +96,7 @@ class RegistrationTest(ArkoudaTest):
             repr(ar_array)
 
     def test_attach(self):
-        '''
+        """
         Tests the following:
 
         1. Attaching to a registered pdarray
@@ -101,21 +105,19 @@ class RegistrationTest(ArkoudaTest):
            unregister of registered pdarray and invocation of
            ak.clear()
         4. method invocation on cleared attached array raises RuntimeError
-        '''
-        ar_array = self.a_array.register('test_int64_a')
-        aar_array = ak.attach_pdarray('test_int64_a')
+        """
+        ar_array = self.a_array.register("test_int64_a")
+        aar_array = ak.attach_pdarray("test_int64_a")
 
         self.assertEqual(ar_array.name, aar_array.name)
-        self.assertTrue((ar_array.to_ndarray() ==
-                         aar_array.to_ndarray()).all())
+        self.assertTrue((ar_array.to_ndarray() == aar_array.to_ndarray()).all())
 
         ak.disconnect()
         ak.connect(server=ArkoudaTest.server, port=ArkoudaTest.port)
-        aar_array = ak.attach_pdarray('test_int64_a')
+        aar_array = ak.attach_pdarray("test_int64_a")
 
         self.assertEqual(ar_array.name, aar_array.name)
-        self.assertTrue((ar_array.to_ndarray() ==
-                         aar_array.to_ndarray()).all())
+        self.assertTrue((ar_array.to_ndarray() == aar_array.to_ndarray()).all())
 
         ar_array.unregister()
         ak.clear()
@@ -127,35 +129,40 @@ class RegistrationTest(ArkoudaTest):
             repr(aar_array)
 
     def test_clear(self):
-        '''
+        """
         Tests the following:
 
         1. clear() removes server-side pdarrays that are unregistered
         2. Registered pdarrays remain after ak.clear()
         3. All cleared pdarrays throw RuntimeError upon method invocation
         4. Method invocation on registered arrays succeeds after ak.clear()
-        '''
-        ar_array = self.a_array.register('test_int64_a')
-        aar_array = self.a_array.register('test_int64_aa')
+        """
+        ar_array = self.a_array.register("test_int64_a")
+        aar_array = self.a_array.register("test_int64_aa")
 
-        self.assertTrue(ar_array is aar_array,
-                        msg="With inplace modification, these should be the same")
-        self.assertEqual(ar_array.name, "test_int64_aa",
-                         msg="ar_array.name should be updated with inplace modification")
+        self.assertTrue(ar_array is aar_array, msg="With inplace modification, these should be the same")
+        self.assertEqual(
+            ar_array.name,
+            "test_int64_aa",
+            msg="ar_array.name should be updated with inplace modification",
+        )
 
-        twos_array = ak.ones(10, dtype=ak.int64).register('twos_array')
+        twos_array = ak.ones(10, dtype=ak.int64).register("twos_array")
         twos_array.fill(2)
 
         g_twos_array = self.a_array + self.b_array
-        self.assertTrue((twos_array.to_ndarray() ==
-                         g_twos_array.to_ndarray()).all())
+        self.assertTrue((twos_array.to_ndarray() == g_twos_array.to_ndarray()).all())
 
         ak.clear()  # This should remove self.b_array and g_twos_array
 
-        with self.assertRaises(RuntimeError, msg="g_twos_array should have been cleared because it wasn't registered"):
+        with self.assertRaises(
+            RuntimeError, msg="g_twos_array should have been cleared because it wasn't registered"
+        ):
             str(g_twos_array)
 
-        with self.assertRaises(RuntimeError, msg="self.b_array should have been cleared because it wasn't registered"):
+        with self.assertRaises(
+            RuntimeError, msg="self.b_array should have been cleared because it wasn't registered"
+        ):
             str(self.b_array)
 
         # Assert these exist by invoking them and not receiving an exception
@@ -166,11 +173,10 @@ class RegistrationTest(ArkoudaTest):
             self.a_array + self.b_array
 
         g_twos_array = ar_array + aar_array
-        self.assertTrue((twos_array.to_ndarray() ==
-                         g_twos_array.to_ndarray()).all())
+        self.assertTrue((twos_array.to_ndarray() == g_twos_array.to_ndarray()).all())
 
     def test_register_info(self):
-        '''
+        """
         Tests the following:
 
         1. json.loads(info(AllSymbols)) is an empty list when the symbol table is empty
@@ -180,55 +186,81 @@ class RegistrationTest(ArkoudaTest):
         5. info(ak.AllSymbols) contains both registered and non-registered objects
         6. info(ak.RegisteredSymbols) only contains registered objects
         7. info raises RunTimeError when called on objects not found in symbol table
-        '''
+        """
         # Cleanup symbol table from previous tests
         cleanup()
 
-        self.assertFalse(json.loads(ak.information(ak.AllSymbols)),
-                         msg='info(AllSymbols) should be empty list')
-        self.assertFalse(json.loads(ak.information(ak.RegisteredSymbols)),
-                         msg='info(RegisteredSymbols) should be empty list')
+        self.assertFalse(
+            json.loads(ak.information(ak.AllSymbols)), msg="info(AllSymbols) should be empty list"
+        )
+        self.assertFalse(
+            json.loads(ak.information(ak.RegisteredSymbols)),
+            msg="info(RegisteredSymbols) should be empty list",
+        )
 
         my_pdarray = ak.ones(10, dtype=ak.int64)
-        self.assertFalse(json.loads(my_pdarray.info())[0]['registered'],
-                         msg='my_array should be in all symbols but not be registered')
+        self.assertFalse(
+            json.loads(my_pdarray.info())[0]["registered"],
+            msg="my_array should be in all symbols but not be registered",
+        )
 
         # After register(), the registered field should be set to true for all info calls
-        my_pdarray.register('keep_me')
-        self.assertTrue(json.loads(ak.information('keep_me'))[0]['registered'],
-                        msg='keep_me array not found or not registered')
-        self.assertTrue(any([sym['registered'] for sym in json.loads(ak.information(ak.AllSymbols))]),
-                        msg='No registered objects were found in symbol table')
-        self.assertTrue(any([sym['registered'] for sym in json.loads(ak.information(ak.RegisteredSymbols))]),
-                        msg='No registered objects were found in registry')
+        my_pdarray.register("keep_me")
+        self.assertTrue(
+            json.loads(ak.information("keep_me"))[0]["registered"],
+            msg="keep_me array not found or not registered",
+        )
+        self.assertTrue(
+            any([sym["registered"] for sym in json.loads(ak.information(ak.AllSymbols))]),
+            msg="No registered objects were found in symbol table",
+        )
+        self.assertTrue(
+            any([sym["registered"] for sym in json.loads(ak.information(ak.RegisteredSymbols))]),
+            msg="No registered objects were found in registry",
+        )
 
         not_registered_array = ak.ones(10, dtype=ak.int64)
         self.assertTrue(
-            len(json.loads(ak.information(ak.AllSymbols))) > len(json.loads(ak.information(ak.RegisteredSymbols))),
-            msg='info(AllSymbols) should have more objects than info(RegisteredSymbols) before clear()')
+            len(json.loads(ak.information(ak.AllSymbols)))
+            > len(json.loads(ak.information(ak.RegisteredSymbols))),
+            msg="info(AllSymbols) should have more objects than info(RegisteredSymbols) before clear()",
+        )
         ak.clear()
         self.assertTrue(
-            len(json.loads(ak.information(ak.AllSymbols))) == len(json.loads(ak.information(ak.RegisteredSymbols))),
-            msg='info(AllSymbols) and info(RegisteredSymbols) should have same num of objects after clear()')
+            len(json.loads(ak.information(ak.AllSymbols)))
+            == len(json.loads(ak.information(ak.RegisteredSymbols))),
+            msg="info(AllSymbols) and info(RegisteredSymbols) should have same num of objects "
+                "after clear()",
+        )
 
-        # After unregister(), the registered field should be set to false for AllSymbol and object name info calls
+        # After unregister(), the registered field should be set to false for AllSymbol and
+        # object name info calls
         # RegisteredSymbols info calls should return ak.EmptyRegistry
         my_pdarray.unregister()
-        self.assertFalse(any([obj['registered'] for obj in json.loads(my_pdarray.info())]),
-                         msg='info(my_array) registered field should be false after unregister()')
-        self.assertFalse(all([obj['registered'] for obj in json.loads(ak.information(ak.AllSymbols))]),
-                         msg='info(AllSymbols) should contain unregistered objects')
-        self.assertFalse(json.loads(ak.information(ak.RegisteredSymbols)),
-                         msg='info(RegisteredSymbols) empty list failed after unregister()')
+        self.assertFalse(
+            any([obj["registered"] for obj in json.loads(my_pdarray.info())]),
+            msg="info(my_array) registered field should be false after unregister()",
+        )
+        self.assertFalse(
+            all([obj["registered"] for obj in json.loads(ak.information(ak.AllSymbols))]),
+            msg="info(AllSymbols) should contain unregistered objects",
+        )
+        self.assertFalse(
+            json.loads(ak.information(ak.RegisteredSymbols)),
+            msg="info(RegisteredSymbols) empty list failed after unregister()",
+        )
 
         ak.clear()
         # RuntimeError when calling info on an object not in the symbol table
         with self.assertRaises(RuntimeError, msg="RuntimeError for info on object not in symbol table"):
-            ak.information('keep_me')
-        self.assertFalse(json.loads(ak.information(ak.AllSymbols)),
-                         msg='info(AllSymbols) should be empty list')
-        self.assertFalse(json.loads(ak.information(ak.RegisteredSymbols)),
-                         msg='info(RegisteredSymbols) should be empty list')
+            ak.information("keep_me")
+        self.assertFalse(
+            json.loads(ak.information(ak.AllSymbols)), msg="info(AllSymbols) should be empty list"
+        )
+        self.assertFalse(
+            json.loads(ak.information(ak.RegisteredSymbols)),
+            msg="info(RegisteredSymbols) should be empty list",
+        )
         cleanup()
 
     def test_in_place_info(self):
@@ -237,25 +269,37 @@ class RegistrationTest(ArkoudaTest):
         """
         cleanup()
         my_pda = ak.ones(10, ak.int64)
-        self.assertFalse(any([sym['registered'] for sym in json.loads(my_pda.info())]),
-                         msg='no components of my_pda should be registered before register call')
-        my_pda.register('my_pda')
-        self.assertTrue(all([sym['registered'] for sym in json.loads(my_pda.info())]),
-                        msg='all components of my_pda should be registered after register call')
+        self.assertFalse(
+            any([sym["registered"] for sym in json.loads(my_pda.info())]),
+            msg="no components of my_pda should be registered before register call",
+        )
+        my_pda.register("my_pda")
+        self.assertTrue(
+            all([sym["registered"] for sym in json.loads(my_pda.info())]),
+            msg="all components of my_pda should be registered after register call",
+        )
 
-        my_str = ak.random_strings_uniform(1, 10, UNIQUE, characters='printable')
-        self.assertFalse(any([sym['registered'] for sym in json.loads(my_str.info())]),
-                         msg='no components of my_str should be registered before register call')
-        my_str.register('my_str')
-        self.assertTrue(all([sym['registered'] for sym in json.loads(my_str.info())]),
-                        msg='all components of my_str should be registered after register call')
+        my_str = ak.random_strings_uniform(1, 10, UNIQUE, characters="printable")
+        self.assertFalse(
+            any([sym["registered"] for sym in json.loads(my_str.info())]),
+            msg="no components of my_str should be registered before register call",
+        )
+        my_str.register("my_str")
+        self.assertTrue(
+            all([sym["registered"] for sym in json.loads(my_str.info())]),
+            msg="all components of my_str should be registered after register call",
+        )
 
         my_cat = ak.Categorical(ak.array([f"my_cat {i}" for i in range(1, 11)]))
-        self.assertFalse(any([sym['registered'] for sym in json.loads(my_cat.info())]),
-                         msg='no components of my_cat should be registered before register call')
-        my_cat.register('my_cat')
-        self.assertTrue(all([sym['registered'] for sym in json.loads(my_cat.info())]),
-                        msg='all components of my_cat should be registered after register call')
+        self.assertFalse(
+            any([sym["registered"] for sym in json.loads(my_cat.info())]),
+            msg="no components of my_cat should be registered before register call",
+        )
+        my_cat.register("my_cat")
+        self.assertTrue(
+            all([sym["registered"] for sym in json.loads(my_cat.info())]),
+            msg="all components of my_cat should be registered after register call",
+        )
         cleanup()
 
     def test_is_registered(self):
@@ -266,7 +310,7 @@ class RegistrationTest(ArkoudaTest):
         a = ak.ones(10, dtype=ak.int64)
         self.assertFalse(a.is_registered())
 
-        a.register('keep')
+        a.register("keep")
         self.assertTrue(a.is_registered())
 
         a.unregister()
@@ -285,14 +329,14 @@ class RegistrationTest(ArkoudaTest):
         # list_registry() should return an empty list which is implicitly False
         self.assertFalse(ak.list_registry())
 
-        a.register('keep')
-        self.assertTrue('keep' in ak.list_registry())
+        a.register("keep")
+        self.assertTrue("keep" in ak.list_registry())
         cleanup()
 
     def test_string_registration_suite(self):
         cleanup()
         # Initial registration should set name
-        keep = ak.random_strings_uniform(1, 10, UNIQUE, characters='printable')
+        keep = ak.random_strings_uniform(1, 10, UNIQUE, characters="printable")
         self.assertTrue(keep.register("keep_me").name == "keep_me")
         self.assertTrue(keep.is_registered(), "Expected Strings object to be registered")
 
@@ -301,7 +345,7 @@ class RegistrationTest(ArkoudaTest):
         self.assertTrue(keep.is_registered(), "Object should be registered with updated name")
 
         # Add an item to discard, confirm our registered item remains and discarded item is gone
-        discard = ak.random_strings_uniform(1, 10, UNIQUE, characters='printable')
+        discard = ak.random_strings_uniform(1, 10, UNIQUE, characters="printable")
         ak.clear()
         self.assertTrue(keep.name == "kept")
         with self.assertRaises(RuntimeError, msg="discard was not registered and should be discarded"):
@@ -316,7 +360,7 @@ class RegistrationTest(ArkoudaTest):
             str(keep)  # should cause RuntimeError
 
         # Test attach functionality
-        s1 = ak.random_strings_uniform(1, 10, UNIQUE, characters='printable')
+        s1 = ak.random_strings_uniform(1, 10, UNIQUE, characters="printable")
         self.assertTrue(s1.register("uut").is_registered(), "uut should be registered")
         s1 = None
         self.assertTrue(s1 is None, "Reference should be cleared")
@@ -333,10 +377,10 @@ class RegistrationTest(ArkoudaTest):
         """
         Tests the Strings.is_registered() function
         """
-        keep = ak.random_strings_uniform(1, 10, UNIQUE, characters='printable')
+        keep = ak.random_strings_uniform(1, 10, UNIQUE, characters="printable")
         self.assertFalse(keep.is_registered())
 
-        keep.register('keep_me')
+        keep.register("keep_me")
         self.assertTrue(keep.is_registered())
 
         keep.unregister()
@@ -357,19 +401,19 @@ class RegistrationTest(ArkoudaTest):
         b = ak.ones(3, dtype=ak.int64)
 
         # registered objects are not deleted from symbol table
-        a.register('keep')
-        self.assertEqual(ak.client.generic_msg(cmd='delete', args=a.name),
-                         f'registered symbol, {a.name}, not deleted')
+        a.register("keep")
+        self.assertEqual(
+            ak.client.generic_msg(cmd="delete", args=a.name), f"registered symbol, {a.name}, not deleted"
+        )
         self.assertTrue(a.name in ak.list_symbol_table())
 
         # non-registered objects are deleted from symbol table
-        self.assertEqual(ak.client.generic_msg(cmd='delete', args=b.name),
-                         'deleted ' + b.name)
+        self.assertEqual(ak.client.generic_msg(cmd="delete", args=b.name), "deleted " + b.name)
         self.assertTrue(b.name not in ak.list_symbol_table())
 
         # RuntimeError when calling delete on an object not in the symbol table
         with self.assertRaises(RuntimeError):
-            ak.client.generic_msg(cmd='delete', args='not_in_table')
+            ak.client.generic_msg(cmd="delete", args="not_in_table")
 
     def test_categorical_registration_suite(self):
         """
@@ -378,7 +422,9 @@ class RegistrationTest(ArkoudaTest):
         cleanup()  # Make sure we start with a clean registry
         c = ak.Categorical(ak.array([f"my_cat {i}" for i in range(1, 11)]))
         self.assertFalse(c.is_registered(), "test_me should be unregistered")
-        self.assertTrue(c.register("test_me").is_registered(), "test_me categorical should be registered")
+        self.assertTrue(
+            c.register("test_me").is_registered(), "test_me categorical should be registered"
+        )
         c = None  # Should trigger destructor, but survive server deletion because it is registered
         self.assertTrue(c is None, "The reference to `c` should be None")
         c = ak.Categorical.attach("test_me")
@@ -403,11 +449,13 @@ class RegistrationTest(ArkoudaTest):
         for Categorical made using .from_codes
         """
         cleanup()  # Make sure we start with a clean registry
-        categories = ak.array(['a', 'b', 'c'])
+        categories = ak.array(["a", "b", "c"])
         codes = ak.array([0, 1, 0, 2, 1])
         cat = ak.Categorical.from_codes(codes, categories)
         self.assertFalse(cat.is_registered(), "test_me should be unregistered")
-        self.assertTrue(cat.register("test_me").is_registered(), "test_me categorical should be registered")
+        self.assertTrue(
+            cat.register("test_me").is_registered(), "test_me categorical should be registered"
+        )
         cat = None  # Should trigger destructor, but survive server deletion because it is registered
         self.assertTrue(cat is None, "The reference to `c` should be None")
         cat = ak.Categorical.attach("test_me")
@@ -428,8 +476,9 @@ class RegistrationTest(ArkoudaTest):
 
     def test_attach_weak_binding(self):
         """
-        Ultimately pdarrayclass issues delete calls to the server when a bound object goes out of scope, if you bind
-        to a server object more than once and one of those goes out of scope it affects all other references to it.
+        Ultimately pdarrayclass issues delete calls to the server when a bound object goes out of scope,
+        if you bind to a server object more than once and one of those goes out of scope it affects
+        all other references to it.
         """
         cleanup()
         a = ak.ones(3, dtype=ak.int64).register("a_reg")
@@ -444,7 +493,8 @@ class RegistrationTest(ArkoudaTest):
         ar_tuple = (ak.arange(5), ak.arange(5))
         s = ak.Series(ar_tuple)
 
-        # At this time, there is no unregister() in Series. Register one piece to check partial registration
+        # At this time, there is no unregister() in Series. Register one piece to check partial
+        # registration
         s.values.register("seriesTest_values")
         with self.assertWarns(UserWarning):
             s.is_registered()
@@ -469,9 +519,15 @@ class RegistrationTest(ArkoudaTest):
 
         # Verify the attached GroupBy's components equal the original components
         self.assertListEqual(sGroup.keys.to_ndarray().tolist(), sAttach.keys.to_ndarray().tolist())
-        self.assertListEqual(sGroup.permutation.to_ndarray().tolist(), sAttach.permutation.to_ndarray().tolist())
-        self.assertListEqual(sGroup.segments.to_ndarray().tolist(), sAttach.segments.to_ndarray().tolist())
-        self.assertListEqual(sGroup.unique_keys.to_ndarray().tolist(), sAttach.unique_keys.to_ndarray().tolist())
+        self.assertListEqual(
+            sGroup.permutation.to_ndarray().tolist(), sAttach.permutation.to_ndarray().tolist()
+        )
+        self.assertListEqual(
+            sGroup.segments.to_ndarray().tolist(), sAttach.segments.to_ndarray().tolist()
+        )
+        self.assertListEqual(
+            sGroup.unique_keys.to_ndarray().tolist(), sAttach.unique_keys.to_ndarray().tolist()
+        )
 
         self.assertIsInstance(sAttach.keys, ak.Strings)
         self.assertIsInstance(sAttach.permutation, ak.pdarray)
@@ -486,9 +542,15 @@ class RegistrationTest(ArkoudaTest):
 
         # Verify the attached GroupBy's components equal the original components
         self.assertListEqual(aGroup.keys.to_ndarray().tolist(), aAttach.keys.to_ndarray().tolist())
-        self.assertListEqual(aGroup.permutation.to_ndarray().tolist(), aAttach.permutation.to_ndarray().tolist())
-        self.assertListEqual(aGroup.segments.to_ndarray().tolist(), aAttach.segments.to_ndarray().tolist())
-        self.assertListEqual(aGroup.unique_keys.to_ndarray().tolist(), aAttach.unique_keys.to_ndarray().tolist())
+        self.assertListEqual(
+            aGroup.permutation.to_ndarray().tolist(), aAttach.permutation.to_ndarray().tolist()
+        )
+        self.assertListEqual(
+            aGroup.segments.to_ndarray().tolist(), aAttach.segments.to_ndarray().tolist()
+        )
+        self.assertListEqual(
+            aGroup.unique_keys.to_ndarray().tolist(), aAttach.unique_keys.to_ndarray().tolist()
+        )
 
         self.assertIsInstance(aAttach.keys, ak.pdarray)
         self.assertIsInstance(aAttach.permutation, ak.pdarray)
@@ -504,9 +566,15 @@ class RegistrationTest(ArkoudaTest):
 
         # Verify the attached GroupBy's components equal the original components
         self.assertListEqual(catGroup.keys.to_ndarray().tolist(), catAttach.keys.to_ndarray().tolist())
-        self.assertListEqual(catGroup.permutation.to_ndarray().tolist(), catAttach.permutation.to_ndarray().tolist())
-        self.assertListEqual(catGroup.segments.to_ndarray().tolist(), catAttach.segments.to_ndarray().tolist())
-        self.assertListEqual(catGroup.unique_keys.to_ndarray().tolist(), catAttach.unique_keys.to_ndarray().tolist())
+        self.assertListEqual(
+            catGroup.permutation.to_ndarray().tolist(), catAttach.permutation.to_ndarray().tolist()
+        )
+        self.assertListEqual(
+            catGroup.segments.to_ndarray().tolist(), catAttach.segments.to_ndarray().tolist()
+        )
+        self.assertListEqual(
+            catGroup.unique_keys.to_ndarray().tolist(), catAttach.unique_keys.to_ndarray().tolist()
+        )
 
         self.assertIsInstance(catAttach.keys, ak.Categorical)
         self.assertIsInstance(catAttach.permutation, ak.pdarray)
@@ -517,20 +585,37 @@ class RegistrationTest(ArkoudaTest):
         a = ak.randint(0, 10, 11)
         b = ak.array(["The", "ants", "go", "marching", "one", "by", "one", ",", "hurrah", ",", "hurrah"])
         c = ak.Categorical(b)
-        l = [a, b, c]
-        group = ak.GroupBy(l)
+        lx = [a, b, c]
+        group = ak.GroupBy(lx)
         group.register("sequenceTest")
         seqAttach = ak.GroupBy.attach("sequenceTest")
 
-        # Verify the attached GroupBy's components equal the original components for each key in the sequence
-        self.assertListEqual(group.keys[0].to_ndarray().tolist(), seqAttach.keys[0].to_ndarray().tolist())
-        self.assertListEqual(group.keys[1].to_ndarray().tolist(), seqAttach.keys[1].to_ndarray().tolist())
-        self.assertListEqual(group.keys[2].to_ndarray().tolist(), seqAttach.keys[2].to_ndarray().tolist())
-        self.assertListEqual(group.unique_keys[0].to_ndarray().tolist(), seqAttach.unique_keys[0].to_ndarray().tolist())
-        self.assertListEqual(group.unique_keys[1].to_ndarray().tolist(), seqAttach.unique_keys[1].to_ndarray().tolist())
-        self.assertListEqual(group.unique_keys[2].to_ndarray().tolist(), seqAttach.unique_keys[2].to_ndarray().tolist())
-        self.assertListEqual(group.permutation.to_ndarray().tolist(), seqAttach.permutation.to_ndarray().tolist())
-        self.assertListEqual(group.segments.to_ndarray().tolist(), seqAttach.segments.to_ndarray().tolist())
+        # Verify the attached GroupBy's components equal the original components for each key
+        # in the sequence
+        self.assertListEqual(
+            group.keys[0].to_ndarray().tolist(), seqAttach.keys[0].to_ndarray().tolist()
+        )
+        self.assertListEqual(
+            group.keys[1].to_ndarray().tolist(), seqAttach.keys[1].to_ndarray().tolist()
+        )
+        self.assertListEqual(
+            group.keys[2].to_ndarray().tolist(), seqAttach.keys[2].to_ndarray().tolist()
+        )
+        self.assertListEqual(
+            group.unique_keys[0].to_ndarray().tolist(), seqAttach.unique_keys[0].to_ndarray().tolist()
+        )
+        self.assertListEqual(
+            group.unique_keys[1].to_ndarray().tolist(), seqAttach.unique_keys[1].to_ndarray().tolist()
+        )
+        self.assertListEqual(
+            group.unique_keys[2].to_ndarray().tolist(), seqAttach.unique_keys[2].to_ndarray().tolist()
+        )
+        self.assertListEqual(
+            group.permutation.to_ndarray().tolist(), seqAttach.permutation.to_ndarray().tolist()
+        )
+        self.assertListEqual(
+            group.segments.to_ndarray().tolist(), seqAttach.segments.to_ndarray().tolist()
+        )
 
         # Verify the attached GroupBy preserved the type of each key
         self.assertIsInstance(seqAttach.keys[0], ak.pdarray)
@@ -549,7 +634,9 @@ class RegistrationTest(ArkoudaTest):
 
         # New variable declarations for sequence
         seqA = ak.randint(0, 10, 11)
-        seqB = ak.array(["The", "ants", "go", "marching", "one", "by", "one", ",", "hurrah", ",", "hurrah"])
+        seqB = ak.array(
+            ["The", "ants", "go", "marching", "one", "by", "one", ",", "hurrah", ",", "hurrah"]
+        )
         seqC = ak.Categorical(seqB)
         seq = [seqA, seqB, seqC]
         groupA = ak.GroupBy(a)

--- a/tests/security_test.py
+++ b/tests/security_test.py
@@ -1,26 +1,29 @@
 import platform
 from os.path import expanduser
+
 from base_test import ArkoudaTest
-from context import arkouda
+
 from arkouda import security
 
-'''
+"""
 Tests Arkouda client-side security functionality
-'''
-class SecurityTest(ArkoudaTest):
+"""
 
+
+class SecurityTest(ArkoudaTest):
     def testGenerateToken(self):
         self.assertEqual(32, len(security.generate_token(32)))
         self.assertEqual(16, len(security.generate_token(16)))
 
-    def testGetHome(self):        
-        self.assertEqual(expanduser('~'), security.get_home_directory())
+    def testGetHome(self):
+        self.assertEqual(expanduser("~"), security.get_home_directory())
 
     def testGetUsername(self):
-        self.assertTrue(security.get_username() in security.username_tokenizer \
-                   [platform.system()](security.get_home_directory()))
+        self.assertTrue(
+            security.get_username()
+            in security.username_tokenizer[platform.system()](security.get_home_directory())
+        )
 
     def testGetArkoudaDirectory(self):
         ak_directory = security.get_arkouda_client_directory()
-        self.assertEqual('{}/.arkouda'.format(security.get_home_directory()), 
-                         str(ak_directory))
+        self.assertEqual("{}/.arkouda".format(security.get_home_directory()), str(ak_directory))

--- a/tests/segarray_test.py
+++ b/tests/segarray_test.py
@@ -1,7 +1,6 @@
-import pandas
-
 from base_test import ArkoudaTest
 from context import arkouda as ak
+
 
 class SegArrayTest(ArkoudaTest):
     def test_creation(self):
@@ -11,23 +10,26 @@ class SegArrayTest(ArkoudaTest):
 
         flat = a + b + c
         akflat = ak.array(flat)
-        segments = ak.array([0, len(a), len(a)+len(b)])
+        segments = ak.array([0, len(a), len(a) + len(b)])
         segarr = ak.SegArray(segments, akflat)
 
         self.assertIsInstance(segarr, ak.SegArray)
         self.assertTrue((segarr._get_lengths() == ak.array([6, 2, 4])).all())
-        self.assertEqual(segarr.__str__(), f'SegArray([\n{a}\n{b}\n{c}\n])'.replace(',', ''))
-        self.assertEqual(segarr.__getitem__(1).__str__(), str(b).replace(',', ''))
-        self.assertEqual(segarr.__getitem__(ak.array([1, 2])).__str__(),
-                         f'SegArray([\n{b}\n{c}\n])'.replace(',', ''))
+        self.assertEqual(segarr.__str__(), f"SegArray([\n{a}\n{b}\n{c}\n])".replace(",", ""))
+        self.assertEqual(segarr.__getitem__(1).__str__(), str(b).replace(",", ""))
+        self.assertEqual(
+            segarr.__getitem__(ak.array([1, 2])).__str__(), f"SegArray([\n{b}\n{c}\n])".replace(",", "")
+        )
         self.assertEqual(segarr.__eq__(ak.array([1])), NotImplemented)
         self.assertTrue(segarr.__eq__(segarr).all())
 
-        multi_pd = ak.SegArray.from_multi_array([ak.array([10, 20, 30]), ak.array([11, 21, 31]), ak.array([12, 22, 32])])
+        multi_pd = ak.SegArray.from_multi_array(
+            [ak.array([10, 20, 30]), ak.array([11, 21, 31]), ak.array([12, 22, 32])]
+        )
         self.assertIsInstance(multi_pd, ak.SegArray)
-        self.assertEqual(multi_pd.__str__(), f'SegArray([\n[10 11 12]\n[20 21 22]\n[30 31 32]\n])')
+        self.assertEqual(multi_pd.__str__(), "SegArray([\n[10 11 12]\n[20 21 22]\n[30 31 32]\n])")
         with self.assertRaises(TypeError):
-            segarr.__getitem__('a')
+            segarr.__getitem__("a")
 
     def test_creation_empty_segment(self):
         a = [10, 11]
@@ -50,7 +52,7 @@ class SegArrayTest(ArkoudaTest):
 
         # test empty as last
         flat = ak.array(a + b + c)
-        segs = ak.array([0, len(a), len(a)+len(b), len(a)+len(b)+len(c)])
+        segs = ak.array([0, len(a), len(a) + len(b), len(a) + len(b) + len(c)])
         segarr = ak.SegArray(segs, flat)
         self.assertIsInstance(segarr, ak.SegArray)
         self.assertListEqual(segarr.lengths.to_ndarray().tolist(), [2, 3, 1, 0])
@@ -68,12 +70,12 @@ class SegArrayTest(ArkoudaTest):
         segarr_2 = ak.SegArray(ak.array([0]), ak.array(c))
 
         concated = ak.SegArray.concat([segarr, segarr_2])
-        self.assertEqual(concated.__str__(), f'SegArray([\n{a}\n{b}\n{c}\n])'.replace(',', ''))
+        self.assertEqual(concated.__str__(), f"SegArray([\n{a}\n{b}\n{c}\n])".replace(",", ""))
 
-        #test concat with empty segments
+        # test concat with empty segments
         empty_segs = ak.SegArray(ak.array([0, 2, 2]), ak.array(b + c))
         concated = ak.SegArray.concat([segarr, empty_segs])
-        self.assertEqual(concated.__str__(), f'SegArray([\n{a}\n{b}\n{b}\n[]\n{c}\n])'.replace(',', ''))
+        self.assertEqual(concated.__str__(), f"SegArray([\n{a}\n{b}\n{b}\n[]\n{c}\n])".replace(",", ""))
 
         flat = ak.array(a)
         segs = ak.array([0, len(a)])
@@ -101,13 +103,24 @@ class SegArrayTest(ArkoudaTest):
         with self.assertRaises(ValueError):
             concated = ak.SegArray.concat([segarr, segarr_2], axis=5)
 
-        multi_pd = ak.SegArray.from_multi_array([ak.array([10, 20, 30]), ak.array([11, 21, 31]), ak.array([12, 22, 32])])
-        multi_pd2 = ak.SegArray.from_multi_array([ak.array([13, 23, 33]), ak.array([14, 24, 34]), ak.array([15, 25, 35])])
+        multi_pd = ak.SegArray.from_multi_array(
+            [ak.array([10, 20, 30]), ak.array([11, 21, 31]), ak.array([12, 22, 32])]
+        )
+        multi_pd2 = ak.SegArray.from_multi_array(
+            [ak.array([13, 23, 33]), ak.array([14, 24, 34]), ak.array([15, 25, 35])]
+        )
         concated = ak.SegArray.concat([multi_pd, multi_pd2], axis=1)
 
-        test = ak.SegArray.from_multi_array([ak.array([10, 20, 30]), ak.array([11, 21, 31]), ak.array([12, 22, 32]),
-                                             ak.array([13, 23, 33]), ak.array([14, 24, 34]), ak.array([15, 25, 35])
-                                             ])
+        test = ak.SegArray.from_multi_array(
+            [
+                ak.array([10, 20, 30]),
+                ak.array([11, 21, 31]),
+                ak.array([12, 22, 32]),
+                ak.array([13, 23, 33]),
+                ak.array([14, 24, 34]),
+                ak.array([15, 25, 35]),
+            ]
+        )
 
         self.assertEqual(concated.__str__(), test.__str__())
 
@@ -118,7 +131,7 @@ class SegArrayTest(ArkoudaTest):
 
         flat = a + b + c
         akflat = ak.array(flat)
-        segments = ak.array([0, len(a), len(a)+len(b)])
+        segments = ak.array([0, len(a), len(a) + len(b)])
 
         segarr = ak.SegArray(segments, akflat)
 
@@ -258,22 +271,24 @@ class SegArrayTest(ArkoudaTest):
         segarr = ak.SegArray(segments, akflat)
 
         segarr.set_jth(0, 1, 99)
-        self.assertEqual(segarr[0].__str__(), f'{a}'.replace(',', '').replace('11', '99'))
+        self.assertEqual(segarr[0].__str__(), f"{a}".replace(",", "").replace("11", "99"))
 
         segarr.set_jth(ak.array([0, 1, 2]), 0, 99)
-        self.assertEqual(segarr[0].__str__(), f'{a}'.replace(',', '').replace('10', '99').replace('11', '99'))
-        self.assertEqual(segarr[1].__str__(), f'{b}'.replace(',', '').replace('20', '99'))
-        self.assertEqual(segarr[2].__str__(), f'{c}'.replace(',', '').replace('30', '99'))
+        self.assertEqual(
+            segarr[0].__str__(), f"{a}".replace(",", "").replace("10", "99").replace("11", "99")
+        )
+        self.assertEqual(segarr[1].__str__(), f"{b}".replace(",", "").replace("20", "99"))
+        self.assertEqual(segarr[2].__str__(), f"{c}".replace(",", "").replace("30", "99"))
 
         with self.assertRaises(ValueError):
             segarr.set_jth(1, 4, 999)
 
-        s = ak.array(['abc', '123'])
+        s = ak.array(["abc", "123"])
         s_segments = ak.array([0])
         segarr = ak.SegArray(s_segments, s)
 
         with self.assertRaises(TypeError):
-            segarr.set_jth(0, 0, 'test')
+            segarr.set_jth(0, 0, "test")
 
     def test_get_length_n(self):
         a = [10, 11, 12, 13, 14, 15]
@@ -359,7 +374,7 @@ class SegArrayTest(ArkoudaTest):
 
         # Test with empty segments
         flat = ak.array(a + b)
-        segs = ak.array([0, len(a), len(a)+len(b)])
+        segs = ak.array([0, len(a), len(a) + len(b)])
         segarr = ak.SegArray(segs, flat)
         appended = segarr.append(segarr2)
         self.assertEqual(appended.segments.size, 5)
@@ -412,7 +427,7 @@ class SegArrayTest(ArkoudaTest):
         self.assertListEqual(appended[1].tolist(), [99] + b)
         self.assertListEqual(appended[2].tolist(), [99] + c)
 
-        #test with empty segment
+        # test with empty segment
         flat = ak.array(a + b)
         segs = ak.array([0, len(a), len(a) + len(b)])
         segarr = ak.SegArray(segs, flat)
@@ -440,7 +455,7 @@ class SegArrayTest(ArkoudaTest):
         self.assertListEqual(dedup[1].tolist(), list(set(b)))
 
         # test with empty segments
-        segments = ak.array([0, len(a), len(a), len(a)+len(b)])
+        segments = ak.array([0, len(a), len(a), len(a) + len(b)])
         segarr = ak.SegArray(segments, flat)
         dedup = segarr.remove_repeats()
         print(dedup.lengths)
@@ -450,7 +465,7 @@ class SegArrayTest(ArkoudaTest):
         self.assertListEqual(dedup[2].tolist(), list(set(b)))
         self.assertListEqual(dedup[3].tolist(), [])
 
-        segments = ak.array([0, len(a), len(a), len(a), len(a)+len(b)])
+        segments = ak.array([0, len(a), len(a), len(a), len(a) + len(b)])
         segarr = ak.SegArray(segments, flat)
         dedup = segarr.remove_repeats()
         self.assertListEqual(dedup.lengths.to_ndarray().tolist(), [3, 0, 0, 3, 0])
@@ -481,8 +496,8 @@ class SegArrayTest(ArkoudaTest):
         self.assertListEqual(intx[0].tolist(), [1, 2, 4])
         self.assertListEqual(intx[1].tolist(), [])
 
-        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a+c))
-        segarr_2 = ak.SegArray(ak.array([0, len(d)]), ak.array(d+c))
+        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + c))
+        segarr_2 = ak.SegArray(ak.array([0, len(d)]), ak.array(d + c))
         intx = segarr.intersect(segarr_2)
         self.assertListEqual(intx.lengths.to_ndarray().tolist(), [0, 3])
         self.assertListEqual(intx[0].tolist(), [])
@@ -537,8 +552,8 @@ class SegArrayTest(ArkoudaTest):
         self.assertListEqual(diff[0].tolist(), [3, 5])
         self.assertListEqual(diff[1].tolist(), [])
 
-        segarr = ak.SegArray(ak.array([0, len(a), len(a)]), ak.array(a+a))
-        segarr_2 = ak.SegArray(ak.array([0, len(c), len(c+c)]), ak.array(c + c + c))
+        segarr = ak.SegArray(ak.array([0, len(a), len(a)]), ak.array(a + a))
+        segarr_2 = ak.SegArray(ak.array([0, len(c), len(c + c)]), ak.array(c + c + c))
         diff = segarr_2.setdiff(segarr)
         self.assertListEqual(diff.lengths.to_ndarray().tolist(), [0, 3, 0])
         self.assertListEqual(diff[0].tolist(), [])
@@ -566,8 +581,8 @@ class SegArrayTest(ArkoudaTest):
         self.assertListEqual(xor[0].tolist(), [3, 4])
         self.assertListEqual(xor[1].tolist(), [8, 12, 13])
 
-        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a+a))
-        segarr_2 = ak.SegArray(ak.array([0, len(a)]), ak.array(a+c))
+        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + a))
+        segarr_2 = ak.SegArray(ak.array([0, len(a)]), ak.array(a + c))
         xor = segarr.setxor(segarr_2)
         self.assertListEqual(xor.lengths.to_ndarray().tolist(), [0, 2])
         self.assertListEqual(xor[0].tolist(), [])
@@ -578,14 +593,18 @@ class SegArrayTest(ArkoudaTest):
         b = [6, 7, 8]
 
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + b))
-        #register the seg array
-        segarr.register('segarrtest')
+        # register the seg array
+        segarr.register("segarrtest")
 
-        segarr_2 = ak.SegArray.attach('segarrtest')
+        segarr_2 = ak.SegArray.attach("segarrtest")
 
         self.assertEqual(segarr.size, segarr_2.size)
-        self.assertListEqual(segarr.lengths.to_ndarray().tolist(), segarr_2.lengths.to_ndarray().tolist())
-        self.assertListEqual(segarr.segments.to_ndarray().tolist(), segarr_2.segments.to_ndarray().tolist())
+        self.assertListEqual(
+            segarr.lengths.to_ndarray().tolist(), segarr_2.lengths.to_ndarray().tolist()
+        )
+        self.assertListEqual(
+            segarr.segments.to_ndarray().tolist(), segarr_2.segments.to_ndarray().tolist()
+        )
         self.assertListEqual(segarr.values.to_ndarray().tolist(), segarr_2.values.to_ndarray().tolist())
 
         # Verify is_registered

--- a/tests/series_test.py
+++ b/tests/series_test.py
@@ -1,11 +1,9 @@
+import pandas as pd
 from base_test import ArkoudaTest
 from context import arkouda as ak
 
-import pandas as pd
-
 
 class SeriesTest(ArkoudaTest):
-
     def test_series_creation(self):
         # Use positional arguments
         ar_tuple = ak.arange(3), ak.arange(3)
@@ -54,24 +52,24 @@ class SeriesTest(ArkoudaTest):
         i = ak.arange(3)
         s = ak.Series(data=v, index=i)
 
-        l = s.locate(1)
-        self.assertIsInstance(l, ak.Series)
-        self.assertEqual(l.index[0], 1)
-        self.assertEqual(l.values[0], 'B')
+        lk = s.locate(1)
+        self.assertIsInstance(lk, ak.Series)
+        self.assertEqual(lk.index[0], 1)
+        self.assertEqual(lk.values[0], "B")
 
-        l = s.locate([0, 2])
-        self.assertIsInstance(l, ak.Series)
-        self.assertEqual(l.index[0], 0)
-        self.assertEqual(l.values[0], 'A')
-        self.assertEqual(l.index[1], 2)
-        self.assertEqual(l.values[1], 'C')
+        lk = s.locate([0, 2])
+        self.assertIsInstance(lk, ak.Series)
+        self.assertEqual(lk.index[0], 0)
+        self.assertEqual(lk.values[0], "A")
+        self.assertEqual(lk.index[1], 2)
+        self.assertEqual(lk.values[1], "C")
 
     def test_shape(self):
         v = ak.array(['A', 'B', 'C'])
         i = ak.arange(3)
         s = ak.Series(data=v, index=i)
 
-        l, = s.shape
+        (l,) = s.shape
         self.assertEqual(l, 3)
 
     def test_add(self):
@@ -161,8 +159,13 @@ class SeriesTest(ArkoudaTest):
         df = ak.Series.concat([s, s2], axis=1)
         self.assertIsInstance(df, ak.DataFrame)
 
-        ref_df = pd.DataFrame({'idx': [i for i in range(11)], 'val_0': [0, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0],
-                               'val_1': [0, 0, 0, 0, 0, 5, 6, 7, 8, 9, 10]})
+        ref_df = pd.DataFrame(
+            {
+                "idx": [i for i in range(11)],
+                "val_0": [0, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0],
+                "val_1": [0, 0, 0, 0, 0, 5, 6, 7, 8, 9, 10],
+            }
+        )
         self.assertTrue(((ref_df == df.to_pandas()).all()).all())
 
     def test_pdconcat(self):
@@ -186,6 +189,5 @@ class SeriesTest(ArkoudaTest):
         df = ak.Series.pdconcat([s, s2], axis=1)
         self.assertIsInstance(df, pd.DataFrame)
 
-        ref_df = pd.DataFrame({0: [0, 1, 2, 3, 4],
-                               1: [5, 6, 7, 8, 9]})
+        ref_df = pd.DataFrame({0: [0, 1, 2, 3, 4], 1: [5, 6, 7, 8, 9]})
         self.assertTrue((ref_df == df).all().all())

--- a/tests/setops_test.py
+++ b/tests/setops_test.py
@@ -1,49 +1,56 @@
 import numpy as np
-from context import arkouda as ak
 from base_test import ArkoudaTest
+from context import arkouda as ak
 
 SIZE = 10
-OPS = frozenset(['intersect1d', 'union1d', 'setxor1d', 'setdiff1d'])
+OPS = frozenset(["intersect1d", "union1d", "setxor1d", "setdiff1d"])
 
-TYPES = ('int64', 'uint64')
+TYPES = ("int64", "uint64")
+
 
 def make_arrays(dtype):
-    if dtype == 'int64':
+    if dtype == "int64":
         a = ak.randint(0, SIZE, SIZE)
-        b = ak.randint(SIZE/2, 2*SIZE, SIZE)
+        b = ak.randint(SIZE / 2, 2 * SIZE, SIZE)
         return a, b
-    elif dtype == 'uint64':
+    elif dtype == "uint64":
         a = ak.randint(0, SIZE, SIZE, dtype=ak.uint64)
-        b = ak.randint(SIZE/2, 2*SIZE, SIZE, dtype=ak.uint64)
+        b = ak.randint(SIZE / 2, 2 * SIZE, SIZE, dtype=ak.uint64)
         return a, b
 
+
 def compare_results(akvals, npvals) -> int:
-    '''
+    """
     Compares the numpy and arkouda arrays via the numpy.allclose method with the
     default relative and absolute tolerances, returning 0 if the arrays are similar
     element-wise within the tolerances, 1 if they are dissimilar.element
-    
+
     :return: 0 (identical) or 1 (dissimilar)
     :rtype: int
-    '''
+    """
     akvals = akvals.to_ndarray()
-    
-    if not np.array_equal(akvals,npvals):
+
+    if not np.array_equal(akvals, npvals):
         akvals = ak.array(akvals)
         npvals = ak.array(npvals)
-        innp = npvals[ak.in1d(ak.array(npvals), ak.array(akvals), True)] # values in np array, but not ak array
-        inak = akvals[ak.in1d(ak.array(akvals), ak.array(npvals), True)] # values in ak array, not not np array
+        innp = npvals[
+            ak.in1d(ak.array(npvals), ak.array(akvals), True)
+        ]  # values in np array, but not ak array
+        inak = akvals[
+            ak.in1d(ak.array(akvals), ak.array(npvals), True)
+        ]  # values in ak array, not not np array
         print(f"(values in np but not ak: {innp}) (values in ak but not np: {inak})")
         return 1
     return 0
 
+
 def run_test(verbose=True):
-    '''
+    """
     The run_test method enables execution of the set operations
     intersect1d, union1d, setxor1d, and setdiff1d
-    on a randomized set of arrays. 
-    :return: 
-    '''
+    on a randomized set of arrays.
+    :return:
+    """
     tests = 0
     failures = 0
     not_impl = 0
@@ -55,41 +62,43 @@ def run_test(verbose=True):
             do_check = True
             try:
                 fxn = getattr(ak, op)
-                akres = fxn(aka,akb)
+                akres = fxn(aka, akb)
                 fxn = getattr(np, op)
                 npres = fxn(aka.to_ndarray(), akb.to_ndarray())
             except RuntimeError as E:
-                if verbose: print("Arkouda error: ", E)
+                if verbose:
+                    print("Arkouda error: ", E)
                 not_impl += 1
                 do_check = False
                 continue
             if not do_check:
                 continue
             failures += compare_results(akres, npres)
-    
+
     return failures
+
 
 class SetOpsTest(ArkoudaTest):
     def test_setops(self):
-        '''
+        """
         Executes run_test and asserts whether there are any errors
-        
+
         :return: None
         :raise: AssertionError if there are any errors encountered in run_test for set operations
-        '''
+        """
         self.assertEqual(0, run_test())
-        
+
     def testSetxor1d(self):
         pdaOne = ak.array([1, 2, 3, 2, 4])
         pdaTwo = ak.array([2, 3, 5, 7, 5])
         expected = ak.array([1, 4, 5, 7])
-        
-        self.assertTrue((expected == ak.setxor1d(pdaOne,pdaTwo)).all())
-        
-        with self.assertRaises(TypeError) as cm:
+
+        self.assertTrue((expected == ak.setxor1d(pdaOne, pdaTwo)).all())
+
+        with self.assertRaises(TypeError):
             ak.setxor1d(ak.array([-1.0, 0.0, 1.0]), ak.array([-2.0, 0.0, 2.0]))
-        
-        with self.assertRaises(RuntimeError) as cm:
+
+        with self.assertRaises(RuntimeError):
             ak.setxor1d(ak.array([True, False, True]), ak.array([True, True]))
 
     def testSetxor1d_Multi(self):
@@ -107,7 +116,7 @@ class SetOpsTest(ArkoudaTest):
         lr = list(sorted(la.symmetric_difference(lb)))
         npr0, npr1 = map(list, zip(*lr))
 
-        #Testing
+        # Testing
         t = ak.setxor1d([a1, a2], [b1, b2])
         self.assertListEqual(t[0].to_ndarray().tolist(), npr0)
         self.assertListEqual(t[1].to_ndarray().tolist(), npr1)
@@ -118,17 +127,17 @@ class SetOpsTest(ArkoudaTest):
         self.assertListEqual(t[1].to_ndarray().tolist(), npr1)
 
         # Test for strings
-        a = ['abc', 'def']
-        b = ['123', '456']
-        c = ['abc', 'def']
-        d = ['000', '456']
+        a = ["abc", "def"]
+        b = ["123", "456"]
+        c = ["abc", "def"]
+        d = ["000", "456"]
         a1 = ak.array(a)
         a2 = ak.array(b)
         b1 = ak.array(c)
         b2 = ak.array(d)
         t = ak.setxor1d([a1, a2], [b1, b2])
-        self.assertListEqual(['abc', 'abc'], t[0].to_ndarray().tolist())
-        self.assertListEqual(['000', '123'], t[1].to_ndarray().tolist())
+        self.assertListEqual(["abc", "abc"], t[0].to_ndarray().tolist())
+        self.assertListEqual(["000", "123"], t[1].to_ndarray().tolist())
 
         # Test for Categorical
         cat_a1 = ak.Categorical(a1)
@@ -136,20 +145,20 @@ class SetOpsTest(ArkoudaTest):
         cat_b1 = ak.Categorical(b1)
         cat_b2 = ak.Categorical(b2)
         t = ak.setxor1d([cat_a1, cat_a2], [cat_b1, cat_b2])
-        self.assertListEqual(['abc', 'abc'], t[0].to_ndarray().tolist())
-        self.assertListEqual(['000', '123'], t[1].to_ndarray().tolist())
-        
+        self.assertListEqual(["abc", "abc"], t[0].to_ndarray().tolist())
+        self.assertListEqual(["000", "123"], t[1].to_ndarray().tolist())
+
     def testSetdiff1d(self):
         pdaOne = ak.array([1, 2, 3, 2, 4, 1])
         pdaTwo = ak.array([3, 4, 5, 6])
-        expected = ak.array([1,2])
-        
-        self.assertTrue((expected == ak.setdiff1d(pdaOne,pdaTwo)).all())
-        
-        with self.assertRaises(TypeError) as cm:
+        expected = ak.array([1, 2])
+
+        self.assertTrue((expected == ak.setdiff1d(pdaOne, pdaTwo)).all())
+
+        with self.assertRaises(TypeError):
             ak.setdiff1d(ak.array([-1.0, 0.0, 1.0]), ak.array([-2.0, 0.0, 2.0]))
-        
-        with self.assertRaises(RuntimeError) as cm:
+
+        with self.assertRaises(RuntimeError):
             ak.setdiff1d(ak.array([True, False, True]), ak.array([True, True]))
 
     def testSetDiff1d_Multi(self):
@@ -172,17 +181,17 @@ class SetOpsTest(ArkoudaTest):
         self.assertListEqual(t[1].to_ndarray().tolist(), npr1)
 
         # Test for strings
-        a = ['abc', 'def']
-        b = ['123', '456']
-        c = ['abc', 'def']
-        d = ['000', '456']
+        a = ["abc", "def"]
+        b = ["123", "456"]
+        c = ["abc", "def"]
+        d = ["000", "456"]
         a1 = ak.array(a)
         a2 = ak.array(b)
         b1 = ak.array(c)
         b2 = ak.array(d)
         t = ak.setdiff1d([a1, a2], [b1, b2])
-        self.assertListEqual(['abc'], t[0].to_ndarray().tolist())
-        self.assertListEqual(['123'], t[1].to_ndarray().tolist())
+        self.assertListEqual(["abc"], t[0].to_ndarray().tolist())
+        self.assertListEqual(["123"], t[1].to_ndarray().tolist())
 
         # Test for Categorical
         cat_a1 = ak.Categorical(a1)
@@ -190,19 +199,19 @@ class SetOpsTest(ArkoudaTest):
         cat_b1 = ak.Categorical(b1)
         cat_b2 = ak.Categorical(b2)
         t = ak.setdiff1d([cat_a1, cat_a2], [cat_b1, cat_b2])
-        self.assertListEqual(['abc'], t[0].to_ndarray().tolist())
-        self.assertListEqual(['123'], t[1].to_ndarray().tolist())
+        self.assertListEqual(["abc"], t[0].to_ndarray().tolist())
+        self.assertListEqual(["123"], t[1].to_ndarray().tolist())
 
     def testIntersect1d(self):
         pdaOne = ak.array([1, 3, 4, 3])
         pdaTwo = ak.array([3, 1, 2, 1])
-        expected = ak.array([1,3])
-        self.assertTrue((expected == ak.intersect1d(pdaOne,pdaTwo)).all())
-        
-        with self.assertRaises(TypeError) as cm:
+        expected = ak.array([1, 3])
+        self.assertTrue((expected == ak.intersect1d(pdaOne, pdaTwo)).all())
+
+        with self.assertRaises(TypeError):
             ak.intersect1d(ak.array([-1.0, 0.0, 1.0]), ak.array([-2.0, 0.0, 2.0]))
-        
-        with self.assertRaises(RuntimeError) as cm:
+
+        with self.assertRaises(RuntimeError):
             ak.intersect1d(ak.array([True, False, True]), ak.array([True, True]))
 
     def testIntersect1d_Multi(self):
@@ -225,37 +234,37 @@ class SetOpsTest(ArkoudaTest):
         self.assertListEqual(t[1].to_ndarray().tolist(), npr1)
 
         # Test for strings
-        a = ['abc', 'def']
-        b = ['123', '456']
-        c = ['abc', 'def']
-        d = ['000', '456']
+        a = ["abc", "def"]
+        b = ["123", "456"]
+        c = ["abc", "def"]
+        d = ["000", "456"]
         a1 = ak.array(a)
         a2 = ak.array(b)
         b1 = ak.array(c)
         b2 = ak.array(d)
         t = ak.intersect1d([a1, a2], [b1, b2])
-        self.assertListEqual(['def'], t[0].to_ndarray().tolist())
-        self.assertListEqual(['456'], t[1].to_ndarray().tolist())
+        self.assertListEqual(["def"], t[0].to_ndarray().tolist())
+        self.assertListEqual(["456"], t[1].to_ndarray().tolist())
 
-        #Test for Categorical
+        # Test for Categorical
         cat_a1 = ak.Categorical(a1)
         cat_a2 = ak.Categorical(a2)
         cat_b1 = ak.Categorical(b1)
         cat_b2 = ak.Categorical(b2)
         t = ak.intersect1d([cat_a1, cat_a2], [cat_b1, cat_b2])
-        self.assertListEqual(['def'], t[0].to_ndarray().tolist())
-        self.assertListEqual(['456'], t[1].to_ndarray().tolist())
+        self.assertListEqual(["def"], t[0].to_ndarray().tolist())
+        self.assertListEqual(["456"], t[1].to_ndarray().tolist())
 
     def testUnion1d(self):
         pdaOne = ak.array([-1, 0, 1])
         pdaTwo = ak.array([-2, 0, 2])
-        expected = ak.array([-2, -1,  0,  1,  2])
-        self.assertTrue((expected == ak.union1d(pdaOne,pdaTwo)).all())
-        
-        with self.assertRaises(TypeError) as cm:
+        expected = ak.array([-2, -1, 0, 1, 2])
+        self.assertTrue((expected == ak.union1d(pdaOne, pdaTwo)).all())
+
+        with self.assertRaises(TypeError):
             ak.union1d(ak.array([-1.0, 0.0, 1.0]), ak.array([-2.0, 0.0, 2.0]))
-        
-        # with self.assertRaises(RuntimeError) as cm:
+
+        # with self.assertRaises(RuntimeError):
         #     ak.union1d(ak.array([True, True, True]), ak.array([True,False,True]))
 
     def testUnion1d_Multi(self):
@@ -277,40 +286,39 @@ class SetOpsTest(ArkoudaTest):
         self.assertListEqual(t[1].to_ndarray().tolist(), npr1)
 
         # Test for Strings
-        a = ['abc', 'def']
-        b = ['123', '456']
-        c = ['xyz']
-        d = ['0']
+        a = ["abc", "def"]
+        b = ["123", "456"]
+        c = ["xyz"]
+        d = ["0"]
         a1 = ak.array(a)
         a2 = ak.array(b)
         b1 = ak.array(c)
         b2 = ak.array(d)
         t = ak.union1d([a1, a2], [b1, b2])
-        self.assertListEqual(['def', 'xyz', 'abc'], t[0].to_ndarray().tolist())
-        self.assertListEqual(['456', '0', '123'], t[1].to_ndarray().tolist())
+        self.assertListEqual(["def", "xyz", "abc"], t[0].to_ndarray().tolist())
+        self.assertListEqual(["456", "0", "123"], t[1].to_ndarray().tolist())
 
-        #Test for Categorical
+        # Test for Categorical
         cat_a1 = ak.Categorical(a1)
         cat_a2 = ak.Categorical(a2)
         cat_b1 = ak.Categorical(b1)
         cat_b2 = ak.Categorical(b2)
         t = ak.union1d([cat_a1, cat_a2], [cat_b1, cat_b2])
-        self.assertListEqual(['abc', 'xyz', 'def'], t[0].to_ndarray().tolist())
-        self.assertListEqual(['123', '0', '456'], t[1].to_ndarray().tolist())
+        self.assertListEqual(["abc", "xyz", "def"], t[0].to_ndarray().tolist())
+        self.assertListEqual(["123", "0", "456"], t[1].to_ndarray().tolist())
 
-    def testIn1d(self): 
+    def testIn1d(self):
         pdaOne = ak.array([-1, 0, 1, 3])
         pdaTwo = ak.array([-1, 2, 2, 3])
-        self.assertTrue((ak.in1d(pdaOne, pdaTwo) == 
-                         ak.array([True, False, False, True])).all())
+        self.assertTrue((ak.in1d(pdaOne, pdaTwo) == ak.array([True, False, False, True])).all())
 
         vals = [i % 3 for i in range(10)]
         valsTwo = [i % 2 for i in range(10)]
-        stringsOne = ak.array(['String {}'.format(i) for i in vals])
-        stringsTwo = ak.array(['String {}'.format(i) for i in valsTwo])
+        stringsOne = ak.array(["String {}".format(i) for i in vals])
+        stringsTwo = ak.array(["String {}".format(i) for i in valsTwo])
 
         answer = ak.array([x < 2 for x in vals])
-        self.assertTrue((answer == ak.in1d(stringsOne,stringsTwo)).all())
+        self.assertTrue((answer == ak.in1d(stringsOne, stringsTwo)).all())
 
     def test_multiarray_validation(self):
         x = [ak.arange(3), ak.arange(3), ak.arange(3)]
@@ -328,5 +336,3 @@ class SetOpsTest(ArkoudaTest):
         x = [ak.arange(3, dtype=ak.uint64), ak.arange(3)]
         with self.assertRaises(TypeError):
             ak.pdarraysetops.multiarray_setop_validation(x, y)
-
-

--- a/tests/sort_test.py
+++ b/tests/sort_test.py
@@ -1,20 +1,20 @@
-from context import arkouda as ak 
 from base_test import ArkoudaTest
+from context import arkouda as ak
 
-
-'''
+"""
 Encapsulates test cases that test sort functionality
-'''
-class SortTest(ArkoudaTest):
+"""
 
+
+class SortTest(ArkoudaTest):
     def testSort(self):
-        pda = ak.randint(0,100,100)
+        pda = ak.randint(0, 100, 100)
         for algo in ak.SortingAlgorithm:
             spda = ak.sort(pda, algo)
             maxIndex = spda.argmax()
             self.assertTrue(maxIndex > 0)
-        
-        pda = ak.randint(0,100,100,dtype=ak.uint64)
+
+        pda = ak.randint(0, 100, 100, dtype=ak.uint64)
         for algo in ak.SortingAlgorithm:
             spda = ak.sort(pda, algo)
             assert ak.is_sorted(spda)
@@ -22,18 +22,18 @@ class SortTest(ArkoudaTest):
     def testBitBoundaryHardcode(self):
 
         # test hardcoded 16/17-bit boundaries with and without negative values
-        a = ak.array([1, -1, 32767]) # 16 bit
-        b = ak.array([1,  0, 32768]) # 16 bit
-        c = ak.array([1, -1, 32768]) # 17 bit
+        a = ak.array([1, -1, 32767])  # 16 bit
+        b = ak.array([1, 0, 32768])  # 16 bit
+        c = ak.array([1, -1, 32768])  # 17 bit
         for algo in ak.SortingAlgorithm:
             assert ak.is_sorted(ak.sort(a, algo))
             assert ak.is_sorted(ak.sort(b, algo))
             assert ak.is_sorted(ak.sort(c, algo))
 
         # test hardcoded 64-bit boundaries with and without negative values
-        d = ak.array([1, -1, 2**63-1])
-        e = ak.array([1,  0, 2**63-1])
-        f = ak.array([1, -2**63, 2**63-1])
+        d = ak.array([1, -1, 2**63 - 1])
+        e = ak.array([1, 0, 2**63 - 1])
+        f = ak.array([1, -(2**63), 2**63 - 1])
         for algo in ak.SortingAlgorithm:
             assert ak.is_sorted(ak.sort(d, algo))
             assert ak.is_sorted(ak.sort(e, algo))
@@ -42,29 +42,29 @@ class SortTest(ArkoudaTest):
     def testBitBoundary(self):
 
         # test 17-bit sort
-        L = -2**15
+        L = -(2**15)
         U = 2**16
         a = ak.randint(L, U, 100)
         for algo in ak.SortingAlgorithm:
             assert ak.is_sorted(ak.sort(a, algo))
 
     def testErrorHandling(self):
-        
+
         # Test RuntimeError from bool NotImplementedError
-        akbools = ak.randint(0, 1, 1000, dtype=ak.bool)   
-        bools = ak.randint(0, 1, 1000, dtype=bool) 
+        akbools = ak.randint(0, 1, 1000, dtype=ak.bool)
+        bools = ak.randint(0, 1, 1000, dtype=bool)
 
         for algo in ak.SortingAlgorithm:
-            with self.assertRaises(ValueError) as cm:
+            with self.assertRaises(ValueError):
                 ak.sort(akbools, algo)
-        
-            with self.assertRaises(ValueError) as cm:
+
+            with self.assertRaises(ValueError):
                 ak.sort(bools, algo)
-        
+
             # Test TypeError from sort attempt on non-pdarray
             with self.assertRaises(TypeError):
-                ak.sort(list(range(0,10)), algo)  
-                
+                ak.sort(list(range(0, 10)), algo)
+
             # Test attempt to sort Strings object, which is unsupported
             with self.assertRaises(TypeError):
-                ak.sort(ak.array(['String {}'.format(i) for i in range(0,10)]), algo)
+                ak.sort(ak.array(["String {}".format(i) for i in range(0, 10)]), algo)

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -1,33 +1,36 @@
+from collections import Counter, namedtuple
 from typing import List, Tuple
+
 import numpy as np
 import pandas as pd
-from collections import Counter
-from context import arkouda as ak
 from base_test import ArkoudaTest
-from collections import namedtuple
+from context import arkouda as ak
 
 ak.verbose = False
 N = 100
-UNIQUE = N//4
+UNIQUE = N // 4
+
 
 def compare_strings(a, b):
     return all(x == y for x, y in zip(a, b))
 
 
-def convert_to_ord(s:List[str]) -> List[int]:
+def convert_to_ord(s: List[str]) -> List[int]:
     return [ord(i) for i in "\x00".join(s)] + [ord("\x00")]
 
 
 errors = False
 
+
 def run_test_argsort(strings, test_strings, cat):
     akperm = ak.argsort(strings)
     aksorted = strings[akperm].to_ndarray()
     npsorted = np.sort(test_strings)
-    assert((aksorted == npsorted).all())
+    assert (aksorted == npsorted).all()
     catperm = ak.argsort(cat)
     catsorted = cat[catperm].to_ndarray()
-    assert((catsorted == npsorted).all())
+    assert (catsorted == npsorted).all()
+
 
 def run_test_unique(strings, test_strings, cat):
     # unique
@@ -35,55 +38,58 @@ def run_test_unique(strings, test_strings, cat):
     catuniq = ak.unique(cat)
     akset = set(akuniq.to_ndarray())
     catset = set(catuniq.to_ndarray())
-    assert(akset == catset)
+    assert akset == catset
     # There should be no duplicates
-    assert(akuniq.size == len(akset))
+    assert akuniq.size == len(akset)
     npset = set(np.unique(test_strings))
     # When converted to a set, should agree with numpy
-    assert(akset == npset)
+    assert akset == npset
     return akset
+
 
 def run_test_index(strings, test_strings, cat, specificInds):
     # int index
-    assert(strings[N//3] == test_strings[N//3])
-    assert(cat[N//3] == test_strings[N//3])
+    assert strings[N // 3] == test_strings[N // 3]
+    assert cat[N // 3] == test_strings[N // 3]
     for i in specificInds:
-        assert(strings[i] == test_strings[i])
-        assert(cat[i] == test_strings[i])
-    
+        assert strings[i] == test_strings[i]
+        assert cat[i] == test_strings[i]
+
+
 def run_test_slice(strings, test_strings, cat):
-    assert(compare_strings(strings[N//4:N//3].to_ndarray(), 
-                           test_strings[N//4:N//3]))
-    assert(compare_strings(cat[N//4:N//3].to_ndarray(), 
-                           test_strings[N//4:N//3]))
-    
+    assert compare_strings(strings[N // 4 : N // 3].to_ndarray(), test_strings[N // 4 : N // 3])
+    assert compare_strings(cat[N // 4 : N // 3].to_ndarray(), test_strings[N // 4 : N // 3])
+
+
 def run_test_pdarray_index(strings, test_strings, cat):
     inds = ak.arange(0, strings.size, 10)
-    assert(compare_strings(strings[inds].to_ndarray(), test_strings[inds.to_ndarray()]))
-    assert(compare_strings(cat[inds].to_ndarray(), test_strings[inds.to_ndarray()]))
+    assert compare_strings(strings[inds].to_ndarray(), test_strings[inds.to_ndarray()])
+    assert compare_strings(cat[inds].to_ndarray(), test_strings[inds.to_ndarray()])
     logical = ak.zeros(strings.size, dtype=ak.bool)
     logical[inds] = True
-    assert(compare_strings(strings[logical].to_ndarray(), test_strings[logical.to_ndarray()]))
+    assert compare_strings(strings[logical].to_ndarray(), test_strings[logical.to_ndarray()])
     # Indexing with a one-element pdarray (int) should return Strings array, not string scalar
-    i = N//2
+    i = N // 2
     singleton = ak.array([i])
     result = strings[singleton]
-    assert(isinstance(result, ak.Strings) and (result.size == 1))
-    assert(result[0] == strings[i])
+    assert isinstance(result, ak.Strings) and (result.size == 1)
+    assert result[0] == strings[i]
     # Logical indexing with all-False array should return empty Strings array
     logicalSingleton = ak.zeros(strings.size, dtype=ak.bool)
     result = strings[logicalSingleton]
-    assert(isinstance(result, ak.Strings) and (result.size == 0))
+    assert isinstance(result, ak.Strings) and (result.size == 0)
     # Logical indexing with a single True should return one-element Strings array, not string scalar
     logicalSingleton[i] = True
     result = strings[logicalSingleton]
-    assert(isinstance(result, ak.Strings) and (result.size == 1))
-    assert(result[0] == strings[i])
-    
+    assert isinstance(result, ak.Strings) and (result.size == 1)
+    assert result[0] == strings[i]
+
+
 def run_comparison_test(strings, test_strings, cat):
-    akinds = (strings == test_strings[N//4])
-    npinds = (test_strings == test_strings[N//4])
-    assert(np.allclose(akinds.to_ndarray(), npinds))
+    akinds = strings == test_strings[N // 4]
+    npinds = test_strings == test_strings[N // 4]
+    assert np.allclose(akinds.to_ndarray(), npinds)
+
 
 def run_test_in1d(strings, cat, base_words):
     more_choices = ak.randint(0, UNIQUE, 100)
@@ -91,69 +97,73 @@ def run_test_in1d(strings, cat, base_words):
     more_words = akwords.to_ndarray()
     matches = ak.in1d(strings, akwords)
     catmatches = ak.in1d(cat, akwords)
-    assert((matches == catmatches).all())
+    assert (matches == catmatches).all()
     # Every word in matches should be in the target set
     for word in strings[matches].to_ndarray():
-        assert(word in more_words)
+        assert word in more_words
     # Exhaustively find all matches to make sure we didn't miss any
     inds = ak.zeros(strings.size, dtype=ak.bool)
     for word in more_words:
-        inds |= (strings == word)
-    assert((inds == matches).all())
+        inds |= strings == word
+    assert (inds == matches).all()
+
 
 def run_test_groupby(strings, cat, akset):
     g = ak.GroupBy(strings)
     gc = ak.GroupBy(cat)
     # Unique keys should be same result as ak.unique
-    assert(akset == set(g.unique_keys.to_ndarray()))
-    assert(akset == set(gc.unique_keys.to_ndarray()))
-    assert((gc.permutation == g.permutation).all())
+    assert akset == set(g.unique_keys.to_ndarray())
+    assert akset == set(gc.unique_keys.to_ndarray())
+    assert (gc.permutation == g.permutation).all()
     permStrings = strings[g.permutation].to_ndarray()
     # Check each group individually
     lengths = np.diff(np.hstack((g.segments.to_ndarray(), np.array([g.size]))))
-    for uk, s, l in zip(g.unique_keys.to_ndarray(),
-                        g.segments.to_ndarray(),
-                        lengths):
+    for uk, s, l in zip(g.unique_keys.to_ndarray(), g.segments.to_ndarray(), lengths):
         # All values in group should equal key
-        assert((permStrings[s:s+l] == uk).all())
+        assert (permStrings[s : s + l] == uk).all()
         # Key should not appear anywhere outside of group
-        assert(not (permStrings[:s] == uk).any())
-        assert(not (permStrings[s+l:] == uk).any())
+        assert not (permStrings[:s] == uk).any()
+        assert not (permStrings[s + l :] == uk).any()
 
 
 def run_test_contains(strings, test_strings, delim):
-    if isinstance(delim,bytes):
+    if isinstance(delim, bytes):
         delim = delim.decode()
     found = strings.contains(delim).to_ndarray()
     npfound = np.array([s.count(delim) > 0 for s in test_strings])
-    assert((found == npfound).all())
+    assert (found == npfound).all()
 
-def run_test_starts_with(strings, test_strings, delim):    
-    if isinstance(delim,bytes):
+
+def run_test_starts_with(strings, test_strings, delim):
+    if isinstance(delim, bytes):
         delim = delim.decode()
     found = strings.startswith(delim).to_ndarray()
     npfound = np.array([s.startswith(delim) for s in test_strings])
-    assert((found == npfound).all())
+    assert (found == npfound).all()
+
 
 def run_test_ends_with(strings, test_strings, delim):
-    if isinstance(delim,bytes):
+    if isinstance(delim, bytes):
         delim = delim.decode()
     found = strings.endswith(delim).to_ndarray()
     npfound = np.array([s.endswith(delim) for s in test_strings])
     if len(found) != len(npfound):
-        raise AttributeError('found and npfound are of different lengths')
-    assert((found == npfound).all())
+        raise AttributeError("found and npfound are of different lengths")
+    assert (found == npfound).all()
+
 
 def run_test_peel(strings, test_strings, delim):
-    if isinstance(delim,bytes):
+    if isinstance(delim, bytes):
         delim = delim.decode()
     import itertools as it
+
     tf = (True, False)
+
     def munge(triple, inc, part):
         ret = []
         for h, s, t in triple:
-            if not part and s == '':
-                ret.append(('', h))
+            if not part and s == "":
+                ret.append(("", h))
             else:
                 if inc:
                     ret.append((h + s, t))
@@ -165,8 +175,8 @@ def run_test_peel(strings, test_strings, delim):
     def rmunge(triple, inc, part):
         ret = []
         for h, s, t in triple:
-            if not part and s == '':
-                ret.append((t, ''))
+            if not part and s == "":
+                ret.append((t, ""))
             else:
                 if inc:
                     ret.append((h, s + t))
@@ -186,41 +196,43 @@ def run_test_peel(strings, test_strings, delim):
         h2, s2, t2 = h.rpartition(delim)
         newt = t2 + s + t
         return h2, s2, newt
-    
-    for times, inc, part in it.product(range(1,4), tf, tf):
+
+    for times, inc, part in it.product(range(1, 4), tf, tf):
         ls, rs = strings.peel(delim, times=times, includeDelimiter=inc, keepPartial=part)
         triples = [s.partition(delim) for s in test_strings]
-        for _ in range(times-1):
+        for _ in range(times - 1):
             triples = [slide(t, delim) for t in triples]
         ltest, rtest = munge(triples, inc, part)
-        assert((ltest == ls.to_ndarray()).all() and (rtest == rs.to_ndarray()).all())
+        assert (ltest == ls.to_ndarray()).all() and (rtest == rs.to_ndarray()).all()
 
-    for times, inc, part in it.product(range(1,4), tf, tf):
+    for times, inc, part in it.product(range(1, 4), tf, tf):
         ls, rs = strings.rpeel(delim, times=times, includeDelimiter=inc, keepPartial=part)
         triples = [s.rpartition(delim) for s in test_strings]
-        for _ in range(times-1):
+        for _ in range(times - 1):
             triples = [rslide(t, delim) for t in triples]
         ltest, rtest = rmunge(triples, inc, part)
-        assert((ltest == ls.to_ndarray()).all() and (rtest == rs.to_ndarray()).all())
+        assert (ltest == ls.to_ndarray()).all() and (rtest == rs.to_ndarray()).all()
+
 
 def run_test_stick(strings, test_strings, base_words, delim, N):
-    if isinstance(delim,bytes):
+    if isinstance(delim, bytes):
         delim = delim.decode()
     test_strings2 = np.random.choice(base_words.to_ndarray(), N, replace=True)
     strings2 = ak.array(test_strings2)
     stuck = strings.stick(strings2, delimiter=delim).to_ndarray()
     tstuck = np.array([delim.join((a, b)) for a, b in zip(test_strings, test_strings2)])
-    assert ((stuck == tstuck).all())
+    assert (stuck == tstuck).all()
     assert ((strings + strings2) == strings.stick(strings2, delimiter="")).all()
 
     lstuck = strings.lstick(strings2, delimiter=delim).to_ndarray()
     tlstuck = np.array([delim.join((b, a)) for a, b in zip(test_strings, test_strings2)])
-    assert ((lstuck == tlstuck).all())
+    assert (lstuck == tlstuck).all()
     assert ((strings2 + strings) == strings.lstick(strings2, delimiter="")).all()
 
-        
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     import sys
+
     if len(sys.argv) > 1:
         ak.connect(server=sys.argv[1], port=sys.argv[2])
     else:
@@ -232,12 +244,12 @@ if __name__ == '__main__':
     # test_strings = np.random.choice(base_words, N, replace=True)
     # strings = ak.array(test_strings)
 
-    base_words1 = ak.random_strings_uniform(1, 10, UNIQUE, characters='printable')
-    base_words2 = ak.random_strings_lognormal(2, 0.25, UNIQUE, characters='printable')
-    gremlins = ak.array(['"', ' ', ''])
+    base_words1 = ak.random_strings_uniform(1, 10, UNIQUE, characters="printable")
+    base_words2 = ak.random_strings_lognormal(2, 0.25, UNIQUE, characters="printable")
+    gremlins = ak.array(['"', " ", ""])
     base_words = ak.concatenate((base_words1, base_words2))
     np_base_words = np.hstack((base_words1.to_ndarray(), base_words2.to_ndarray()))
-    assert(compare_strings(base_words.to_ndarray(), np_base_words))
+    assert compare_strings(base_words.to_ndarray(), np_base_words)
     choices = ak.randint(0, base_words.size, N)
     strings = base_words[choices]
     test_strings = strings.to_ndarray()
@@ -245,15 +257,15 @@ if __name__ == '__main__':
     print("strings =", strings)
     print("categorical =", cat)
     print("Generation and concatenate passed")
-  
+
     # int index
     run_test_index(strings, test_strings, cat, range(-len(gremlins), 0))
     print("int index passed")
-  
+
     # slice
     run_test_slice(strings, test_strings, cat)
     print("slice passed")
-    
+
     # pdarray int index
     run_test_pdarray_index(strings, test_strings, cat)
     print("pdarray int index passed")
@@ -274,7 +286,7 @@ if __name__ == '__main__':
 
     # argsort
     run_test_argsort(strings, test_strings, cat)
-    
+
     # unique
     akset = run_test_unique(strings, test_strings, cat)
 
@@ -283,8 +295,8 @@ if __name__ == '__main__':
     print("groupby passed")
 
     # substring functions
-    x, w = tuple(zip(*Counter(''.join(base_words.to_ndarray())).items()))
-    delim = np.random.choice(x, p=(np.array(w)/sum(w)))
+    x, w = tuple(zip(*Counter("".join(base_words.to_ndarray())).items()))
+    delim = np.random.choice(x, p=(np.array(w) / sum(w)))
 
     # contains
     run_test_contains(strings, test_strings, delim)
@@ -309,14 +321,16 @@ if __name__ == '__main__':
 
 class StringTest(ArkoudaTest):
 
-    Gremlins = namedtuple('Gremlins', 'gremlins_base_words gremlins_strings gremlins_test_strings gremlins_cat')
+    Gremlins = namedtuple(
+        "Gremlins", "gremlins_base_words gremlins_strings gremlins_test_strings gremlins_cat"
+    )
 
     def setUp(self):
         self.maxDiff = None
         ArkoudaTest.setUp(self)
-        base_words1 = ak.random_strings_uniform(1, 10, UNIQUE, characters='printable')
-        base_words2 = ak.random_strings_lognormal(2, 0.25, UNIQUE, characters='printable')
-        gremlins = np.array(['"', ' ', ''])
+        base_words1 = ak.random_strings_uniform(1, 10, UNIQUE, characters="printable")
+        base_words2 = ak.random_strings_lognormal(2, 0.25, UNIQUE, characters="printable")
+        gremlins = np.array(['"', " ", ""])
         self.gremlins = ak.array(gremlins)
         self.base_words = ak.concatenate((base_words1, base_words2))
         self.np_base_words = np.hstack((base_words1.to_ndarray(), base_words2.to_ndarray()))
@@ -324,16 +338,16 @@ class StringTest(ArkoudaTest):
         self.strings = self.base_words[self.choices]
         self.test_strings = self.strings.to_ndarray()
 
-        x, w = tuple(zip(*Counter(''.join(self.base_words.to_ndarray())).items()))
-        self.delim = self._get_delimiter(x,w,gremlins)
+        x, w = tuple(zip(*Counter("".join(self.base_words.to_ndarray())).items()))
+        self.delim = self._get_delimiter(x, w, gremlins)
 
-    def _get_strings(self, prefix : str='string', size : int=11) -> ak.Strings:
-        return ak.array(['{} {}'.format(prefix,i) for i in range(1,size)])
+    def _get_strings(self, prefix: str = "string", size: int = 11) -> ak.Strings:
+        return ak.array(["{} {}".format(prefix, i) for i in range(1, size)])
 
-    def _get_delimiter(self, x : Tuple, w : Tuple, gremlins : np.ndarray) -> str:
-        delim = np.random.choice(x, p=(np.array(w)/sum(w)))
+    def _get_delimiter(self, x: Tuple, w: Tuple, gremlins: np.ndarray) -> str:
+        delim = np.random.choice(x, p=(np.array(w) / sum(w)))
         if delim in gremlins:
-            self._get_delimiter(x,w,gremlins)
+            self._get_delimiter(x, w, gremlins)
         return delim
 
     def _get_ak_gremlins(self):
@@ -354,7 +368,7 @@ class StringTest(ArkoudaTest):
 
     def test_in1d(self):
         run_test_in1d(self.strings, self._get_categorical(), self.base_words)
-                      
+
     def test_unique(self):
         run_test_unique(self.strings, self.test_strings, self._get_categorical())
 
@@ -363,15 +377,17 @@ class StringTest(ArkoudaTest):
         run_test_groupby(self.strings, self._get_categorical(), akset)
 
     def test_index(self):
-        run_test_index(self.strings, self.test_strings, self._get_categorical(),
-                       range(-len(self.gremlins), 0))
+        run_test_index(
+            self.strings, self.test_strings, self._get_categorical(), range(-len(self.gremlins), 0)
+        )
         g = self._get_ak_gremlins()
-        run_test_index(g.gremlins_strings, g.gremlins_test_strings,
-                       g.gremlins_cat, range(-len(self.gremlins), 0))
-        
+        run_test_index(
+            g.gremlins_strings, g.gremlins_test_strings, g.gremlins_cat, range(-len(self.gremlins), 0)
+        )
+
     def test_slice(self):
         run_test_slice(self.strings, self.test_strings, self._get_categorical())
-        
+
     def test_pdarray_index(self):
         run_test_pdarray_index(self.strings, self.test_strings, self._get_categorical())
 
@@ -379,7 +395,7 @@ class StringTest(ArkoudaTest):
         run_test_contains(self.strings, self.test_strings, self.delim)
         run_test_contains(self.strings, self.test_strings, np.str_(self.delim))
         run_test_contains(self.strings, self.test_strings, str.encode(str(self.delim)))
-        
+
     def test_starts_with(self):
         run_test_starts_with(self.strings, self.test_strings, self.delim)
         run_test_starts_with(self.strings, self.test_strings, np.str_(self.delim))
@@ -392,73 +408,72 @@ class StringTest(ArkoudaTest):
 
         # Test gremlins delimiters
         g = self._get_ak_gremlins()
-        run_test_ends_with(g.gremlins_strings, g.gremlins_test_strings, ' ')
+        run_test_ends_with(g.gremlins_strings, g.gremlins_test_strings, " ")
         run_test_ends_with(g.gremlins_strings, g.gremlins_test_strings, '"')
         with self.assertRaises(ValueError):
-            # updated to raise ValueError since regex doesn't currently support patterns matching empty string
-            self.assertFalse(run_test_ends_with(g.gremlins_strings,
-                                            g.gremlins_test_strings, ''))
-    
+            # updated to raise ValueError since regex doesn't currently support patterns
+            # matching empty string
+            self.assertFalse(run_test_ends_with(g.gremlins_strings, g.gremlins_test_strings, ""))
+
     def test_ends_with_delimiter_match(self):
-        strings = ak.array(['string{} '.format(i) for i in range(0,5)])
-        self.assertTrue((strings.endswith(' ').to_ndarray()).all())
-        
-        strings = ak.array(['string{}"'.format(i) for i in range(0,5)])
+        strings = ak.array(["string{} ".format(i) for i in range(0, 5)])
+        self.assertTrue((strings.endswith(" ").to_ndarray()).all())
+
+        strings = ak.array(['string{}"'.format(i) for i in range(0, 5)])
         self.assertTrue((strings.endswith('"').to_ndarray()).all())
 
-        strings = ak.array(['string{}$'.format(i) for i in range(0,5)])
-        self.assertTrue((strings.endswith('$').to_ndarray()).all())   
-        
-        strings = ak.array(['string{}yyz'.format(i) for i in range(0,5)])
-        self.assertTrue((strings.endswith('z').to_ndarray()).all())        
-    
-    def test_error_handling(self):
-        stringsOne = ak.random_strings_uniform(1, 10, UNIQUE, 
-                                            characters='printable')
-        stringsTwo = ak.random_strings_uniform(1, 10, UNIQUE, 
-                                            characters='printable')
+        strings = ak.array(["string{}$".format(i) for i in range(0, 5)])
+        self.assertTrue((strings.endswith("$").to_ndarray()).all())
 
-        with self.assertRaises(TypeError) as cm:
+        strings = ak.array(["string{}yyz".format(i) for i in range(0, 5)])
+        self.assertTrue((strings.endswith("z").to_ndarray()).all())
+
+    def test_error_handling(self):
+        stringsOne = ak.random_strings_uniform(1, 10, UNIQUE, characters="printable")
+        stringsTwo = ak.random_strings_uniform(1, 10, UNIQUE, characters="printable")
+
+        with self.assertRaises(TypeError):
             stringsOne.lstick(stringsTwo, delimiter=1)
-        
-        with self.assertRaises(TypeError) as cm:
+
+        with self.assertRaises(TypeError):
             stringsOne.lstick([1], 1)
-        
-        with self.assertRaises(TypeError) as cm:
+
+        with self.assertRaises(TypeError):
             stringsOne.startswith(1)
-        
-        with self.assertRaises(TypeError) as cm:
+
+        with self.assertRaises(TypeError):
             stringsOne.endswith(1)
-        
-        with self.assertRaises(TypeError) as cm:
+
+        with self.assertRaises(TypeError):
             stringsOne.contains(1)
-        
-        with self.assertRaises(TypeError) as cm:
+
+        with self.assertRaises(TypeError):
             stringsOne.peel(1)
 
-        with self.assertRaises(ValueError) as cm:
-            stringsOne.peel("",-5)
+        with self.assertRaises(ValueError):
+            stringsOne.peel("", -5)
 
     def test_peel(self):
         run_test_peel(self.strings, self.test_strings, self.delim)
         run_test_peel(self.strings, self.test_strings, np.str_(self.delim))
         run_test_peel(self.strings, self.test_strings, str.encode(str(self.delim)))
-        
+
         # Test gremlins delimiters
         g = self._get_ak_gremlins()
         with self.assertRaises(ValueError):
-            run_test_peel(g.gremlins_strings, g.gremlins_test_strings, '')
+            run_test_peel(g.gremlins_strings, g.gremlins_test_strings, "")
         run_test_peel(g.gremlins_strings, g.gremlins_test_strings, '"')
-        run_test_peel(g.gremlins_strings, g.gremlins_test_strings, ' ')
+        run_test_peel(g.gremlins_strings, g.gremlins_test_strings, " ")
 
         # Run a test with a specific set of strings to verify strings.bytes matches expected output
         series = pd.Series(["k1:v1", "k2:v2", "k3:v3", "no_colon"])
         pda = ak.from_series(series, "string")
 
-        # Convert Pandas series of strings into a byte array where each string is terminated by a null byte.
+        # Convert Pandas series of strings into a byte array where each string is terminated
+        # by a null byte.
         # This mimics what should be stored server-side in the strings.bytes pdarray
         expected_series_dec = convert_to_ord(series.to_list())
-        actual_dec = pda._comp_to_ndarray("values").tolist() #pda.bytes.to_ndarray().tolist()
+        actual_dec = pda._comp_to_ndarray("values").tolist()  # pda.bytes.to_ndarray().tolist()
         self.assertListEqual(expected_series_dec, actual_dec)
 
         # Now perform the peel and verify
@@ -470,7 +485,7 @@ class StringTest(ArkoudaTest):
 
     def test_peel_delimiter_length_issue(self):
         # See Issue 838
-        d = "-" * 25 # 25 dashes as delimiter
+        d = "-" * 25  # 25 dashes as delimiter
         series = pd.Series([f"abc{d}xyz", f"small{d}dog", f"blue{d}hat", "last"])
         pda = ak.from_series(series)
         a, b = pda.peel(d)
@@ -489,53 +504,51 @@ class StringTest(ArkoudaTest):
         self.assertListEqual(["xyz", "dog", "last"], bb)
 
     def test_stick(self):
-        run_test_stick(self.strings, self.test_strings, self.base_words, 
-                       self.delim, 100)
-        run_test_stick(self.strings, self.test_strings, self.base_words, 
-                       np.str_(self.delim), 100)
-        run_test_stick(self.strings, self.test_strings, self.base_words, 
-                       str.encode(str(self.delim)), 100)
-        
+        run_test_stick(self.strings, self.test_strings, self.base_words, self.delim, 100)
+        run_test_stick(self.strings, self.test_strings, self.base_words, np.str_(self.delim), 100)
+        run_test_stick(
+            self.strings, self.test_strings, self.base_words, str.encode(str(self.delim)), 100
+        )
+
         # Test gremlins delimiters
         g = self._get_ak_gremlins()
-        run_test_stick(g.gremlins_strings, g.gremlins_test_strings,
-                       g.gremlins_base_words, ' ', 103)
-        run_test_stick(g.gremlins_strings, g.gremlins_test_strings,
-                       g.gremlins_base_words, '', 103)
-        run_test_stick(g.gremlins_strings, g.gremlins_test_strings,
-                       g.gremlins_base_words, '"', 103)
-        
+        run_test_stick(g.gremlins_strings, g.gremlins_test_strings, g.gremlins_base_words, " ", 103)
+        run_test_stick(g.gremlins_strings, g.gremlins_test_strings, g.gremlins_base_words, "", 103)
+        run_test_stick(g.gremlins_strings, g.gremlins_test_strings, g.gremlins_base_words, '"', 103)
+
     def test_str_output(self):
-        strings = ak.array(['string {}'.format(i) for i in range (0,101)])
-        self.assertEqual("['string 0', 'string 1', 'string 2', ... , 'string 98', 'string 99', 'string 100']",
-                         str(strings))
+        strings = ak.array(["string {}".format(i) for i in range(0, 101)])
+        self.assertEqual(
+            "['string 0', 'string 1', 'string 2', ... , 'string 98', 'string 99', 'string 100']",
+            str(strings),
+        )
 
     def test_flatten(self):
-        orig = ak.array(['one|two', 'three|four|five', 'six'])
-        flat, mapping = orig.flatten('|', return_segments=True)
-        ans = ak.array(['one', 'two', 'three', 'four', 'five', 'six'])
+        orig = ak.array(["one|two", "three|four|five", "six"])
+        flat, mapping = orig.flatten("|", return_segments=True)
+        ans = ak.array(["one", "two", "three", "four", "five", "six"])
         ans2 = ak.array([0, 2, 5])
         self.assertTrue((flat == ans).all())
         self.assertTrue((mapping == ans2).all())
-        thirds = [ak.cast(ak.arange(i, 99, 3), 'str') for i in range(3)]
-        thickrange = thirds[0].stick(thirds[1], delimiter=', ').stick(thirds[2], delimiter=', ')
-        flatrange = thickrange.flatten(', ')
-        self.assertTrue((ak.cast(flatrange, 'int64') == ak.arange(99)).all())
-        
+        thirds = [ak.cast(ak.arange(i, 99, 3), "str") for i in range(3)]
+        thickrange = thirds[0].stick(thirds[1], delimiter=", ").stick(thirds[2], delimiter=", ")
+        flatrange = thickrange.flatten(", ")
+        self.assertTrue((ak.cast(flatrange, "int64") == ak.arange(99)).all())
+
     def test_get_lengths(self):
-        s1 = ak.array(['one', 'two', 'three', 'four', 'five'])
+        s1 = ak.array(["one", "two", "three", "four", "five"])
         lengths = s1.get_lengths()
-        self.assertTrue((ak.array([3,3,5,4,4]) == lengths).all())
+        self.assertTrue((ak.array([3, 3, 5, 4, 4]) == lengths).all())
 
     def test_case_change(self):
-        s = ak.array([f'StrINgS {i}' for i in range(10)])
+        s = ak.array([f"StrINgS {i}" for i in range(10)])
 
         lower = s.to_lower()
-        expected = ak.array([f'strings {i}' for i in range(10)])
+        expected = ak.array([f"strings {i}" for i in range(10)])
         self.assertListEqual(lower.to_ndarray().tolist(), expected.to_ndarray().tolist())
 
         upper = s.to_upper()
-        expected = ak.array([f'STRINGS {i}' for i in range(10)])
+        expected = ak.array([f"STRINGS {i}" for i in range(10)])
         self.assertListEqual(upper.to_ndarray().tolist(), expected.to_ndarray().tolist())
 
         # first 10 all lower, middle 10 mixed case (not lower or upper), last 10 all upper
@@ -550,27 +563,37 @@ class StringTest(ArkoudaTest):
         self.assertListEqual(isupper.to_ndarray().tolist(), expected.to_ndarray().tolist())
 
     def test_concatenate(self):
-        s1 = self._get_strings('string',51)
-        s2 = self._get_strings('string-two', 51)
-        
-        resultStrings = ak.concatenate([s1,s2])
-        self.assertIsInstance(resultStrings, ak.Strings)
-        self.assertEqual(100,resultStrings.size)
-        
-        resultStrings = ak.concatenate([s1,s1], ordered=False)
-        self.assertIsInstance(resultStrings, ak.Strings)
-        self.assertEqual(100,resultStrings.size)
+        s1 = self._get_strings("string", 51)
+        s2 = self._get_strings("string-two", 51)
 
+        resultStrings = ak.concatenate([s1, s2])
+        self.assertIsInstance(resultStrings, ak.Strings)
+        self.assertEqual(100, resultStrings.size)
 
-        s1 = self._get_strings('string',6)
-        s2 = self._get_strings('string-two', 6)
-        expectedResult = ak.array(['string 1', 'string 2', 'string 3', 'string 4', 'string 5', 
-                                   'string-two 1', 'string-two 2', 'string-two 3', 'string-two 4', 
-                                   'string-two 5'])
+        resultStrings = ak.concatenate([s1, s1], ordered=False)
+        self.assertIsInstance(resultStrings, ak.Strings)
+        self.assertEqual(100, resultStrings.size)
+
+        s1 = self._get_strings("string", 6)
+        s2 = self._get_strings("string-two", 6)
+        expectedResult = ak.array(
+            [
+                "string 1",
+                "string 2",
+                "string 3",
+                "string 4",
+                "string 5",
+                "string-two 1",
+                "string-two 2",
+                "string-two 3",
+                "string-two 4",
+                "string-two 5",
+            ]
+        )
 
         # Ordered concatenation
         s12ord = ak.concatenate([s1, s2], ordered=True)
         self.assertTrue((expectedResult == s12ord).all())
         # Unordered (but still deterministic) concatenation
         # TODO: the unordered concatenation test is disabled per #710 #721
-        #s12unord = ak.concatenate([s1, s2], ordered=False)
+        # s12unord = ak.concatenate([s1, s2], ordered=False)

--- a/tests/summarization_test.py
+++ b/tests/summarization_test.py
@@ -1,35 +1,36 @@
 import numpy as np
-from context import arkouda as ak
 from base_test import ArkoudaTest
+from context import arkouda as ak
 
 """
 Encapsulates unit tests for the pdarrayclass module that provide
 summarized values via reduction methods
 """
+
+
 class SummarizationTest(ArkoudaTest):
-    
     def setUp(self):
         ArkoudaTest.setUp(self)
-        self.na = np.linspace(1,10,10)
+        self.na = np.linspace(1, 10, 10)
         self.pda = ak.array(self.na)
-    
+
     def testStd(self):
-        self.assertEqual(self.na.std(), self.pda.std())      
-        
+        self.assertEqual(self.na.std(), self.pda.std())
+
     def testMin(self):
-        self.assertEqual(self.na.min(), self.pda.min())   
-    
+        self.assertEqual(self.na.min(), self.pda.min())
+
     def testMax(self):
-        self.assertEqual(self.na.max(), self.pda.max())   
-        
+        self.assertEqual(self.na.max(), self.pda.max())
+
     def testMean(self):
-        self.assertEqual(self.na.mean(), self.pda.mean())   
-        
+        self.assertEqual(self.na.mean(), self.pda.mean())
+
     def testVar(self):
-        self.assertEqual(self.na.var(), self.pda.var())   
+        self.assertEqual(self.na.var(), self.pda.var())
 
     def testAny(self):
-        self.assertEqual(self.na.any(), self.pda.any()) 
-        
+        self.assertEqual(self.na.any(), self.pda.any())
+
     def testAll(self):
-        self.assertEqual(self.na.all(), self.pda.all()) 
+        self.assertEqual(self.na.all(), self.pda.all())

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,10 +1,12 @@
 from base_test import ArkoudaTest
 from context import arkouda as ak
+
 from arkouda.util import attach
+
 
 class utilTest(ArkoudaTest):
     def test_simple_attach(self):
-        a = ak.array(["abc","123","def"])
+        a = ak.array(["abc", "123", "def"])
         b = ak.arange(10)
 
         # Attach the Strings array and the pdarray to new objects
@@ -26,7 +28,9 @@ class utilTest(ArkoudaTest):
         self.assertIsInstance(b_typed_attach, ak.pdarray)
 
     def test_categorical_attach(self):
-        strings = ak.array(["hurrah", ",", "hurrah", ",", "one", "by", "one", "marching", "go", "ants", "the"])
+        strings = ak.array(
+            ["hurrah", ",", "hurrah", ",", "one", "by", "one", "marching", "go", "ants", "the"]
+        )
         cat = ak.Categorical(strings)
         cat.register("catTest")
 

--- a/tests/where_test.py
+++ b/tests/where_test.py
@@ -1,155 +1,164 @@
-import numpy as np
 import warnings
 from itertools import product
-from context import arkouda as ak
+
+import numpy as np
 from base_test import ArkoudaTest
+from context import arkouda as ak
+
 warnings.simplefilter("always", UserWarning)
 SIZE = 10
 
-'''
+"""
 Tests the Arkouda where functionality and compares with analogous Numpy results.
-'''
+"""
+
+
 class WhereTest(ArkoudaTest):
-    
-    def setUp(self): 
+    def setUp(self):
         ArkoudaTest.setUp(self)
-        self.npA = {'int64': np.random.randint(0, 10, SIZE),
-               'float64': np.random.randn(SIZE),
-               'bool': np.random.randint(0, 2, SIZE, dtype='bool')}
+        self.npA = {
+            "int64": np.random.randint(0, 10, SIZE),
+            "float64": np.random.randn(SIZE),
+            "bool": np.random.randint(0, 2, SIZE, dtype="bool"),
+        }
         self.akA = {k: ak.array(v) for k, v in self.npA.items()}
-        self.npB = {'int64': np.random.randint(10, 20, SIZE),
-               'float64': np.random.randn(SIZE)+10,
-               'bool': np.random.randint(0, 2, SIZE, dtype='bool')}
+        self.npB = {
+            "int64": np.random.randint(10, 20, SIZE),
+            "float64": np.random.randn(SIZE) + 10,
+            "bool": np.random.randint(0, 2, SIZE, dtype="bool"),
+        }
         self.akB = {k: ak.array(v) for k, v in self.npB.items()}
-        self.npCond = np.random.randint(0, 2, SIZE, dtype='bool')
+        self.npCond = np.random.randint(0, 2, SIZE, dtype="bool")
         self.akCond = ak.array(self.npCond)
-        self.scA = {'int64': 42, 'float64': 2.71828, 'bool': True}
-        self.scB = {'int64': -1, 'float64': 3.14159, 'bool': False}
-        self.dtypes = set(self.npA.keys()) 
+        self.scA = {"int64": 42, "float64": 2.71828, "bool": True}
+        self.scB = {"int64": -1, "float64": 3.14159, "bool": False}
+        self.dtypes = set(self.npA.keys())
 
     def test_where_equivalence(self):
         failures = 0
         tests = 0
         for dtype in self.dtypes:
-            for (self.ak1, self.ak2), (self.np1, self.np2) in \
-                                       zip(product((self.akA, self.scA), (self.akB, self.scB)),
-                                       product((self.npA, self.scA), (self.npB, self.scB))):
+            for (self.ak1, self.ak2), (self.np1, self.np2) in zip(
+                product((self.akA, self.scA), (self.akB, self.scB)),
+                product((self.npA, self.scA), (self.npB, self.scB)),
+            ):
                 tests += 1
                 akres = ak.where(self.akCond, self.ak1[dtype], self.ak2[dtype]).to_ndarray()
                 npres = np.where(self.npCond, self.np1[dtype], self.np2[dtype])
                 if not np.allclose(akres, npres, equal_nan=True):
                     self.assertWarning(warnings.warn("{} !=\n{}".format(akres, npres)))
                     failures += 1
-        self.assertEqual(0,failures)
-        
+        self.assertEqual(0, failures)
+
     def test_error_handling(self):
-        with self.assertRaises(TypeError) as cm:
-            ak.where([0], ak.linspace(1,10,10), ak.linspace(1,10,10))
-        
-        with self.assertRaises(TypeError) as cm:
-            ak.where(ak.linspace(1,10,10), [0], ak.linspace(1,10,10))
-        
-        with self.assertRaises(TypeError) as cm:
-            ak.where(ak.linspace(1,10,10), ak.linspace(1,10,10), [0])
-        
+        with self.assertRaises(TypeError):
+            ak.where([0], ak.linspace(1, 10, 10), ak.linspace(1, 10, 10))
+
+        with self.assertRaises(TypeError):
+            ak.where(ak.linspace(1, 10, 10), [0], ak.linspace(1, 10, 10))
+
+        with self.assertRaises(TypeError):
+            ak.where(ak.linspace(1, 10, 10), ak.linspace(1, 10, 10), [0])
+
     def test_less_than_where_clause(self):
-        n1 = np.arange(1,10)
-        n2 = np.ones(9, dtype=np.int64) 
+        n1 = np.arange(1, 10)
+        n2 = np.ones(9, dtype=np.int64)
         a1 = ak.array(n1)
-        a2 = ak.array(n2)     
-        
-        cond = n1 < 5 
-        result = np.where(cond,n1,n2)
+        a2 = ak.array(n2)
+
+        cond = n1 < 5
+        result = np.where(cond, n1, n2)
         self.assertTrue((np.array([1, 2, 3, 4, 1, 1, 1, 1, 1]) == result).all())
-     
-        cond = a1 < 5 
-        result = ak.where(cond,a1,a2)
+
+        cond = a1 < 5
+        result = ak.where(cond, a1, a2)
         self.assertTrue((ak.array([1, 2, 3, 4, 1, 1, 1, 1, 1]) == result).all())
-        
+
     def test_greater_than_where_clause(self):
-        n1 = np.arange(1,10)
-        n2 = np.ones(9, dtype=np.int64) 
+        n1 = np.arange(1, 10)
+        n2 = np.ones(9, dtype=np.int64)
         a1 = ak.array(n1)
-        a2 = ak.array(n2)     
-        
-        cond = n1 > 5 
-        result = np.where(cond,n1,n2)
+        a2 = ak.array(n2)
+
+        cond = n1 > 5
+        result = np.where(cond, n1, n2)
         self.assertTrue((np.array([1, 1, 1, 1, 1, 6, 7, 8, 9]) == result).all())
-     
-        cond = a1 > 5 
-        result = ak.where(cond,a1,a2)
+
+        cond = a1 > 5
+        result = ak.where(cond, a1, a2)
         self.assertTrue((ak.array([1, 1, 1, 1, 1, 6, 7, 8, 9]) == result).all())
-        
+
     def test_greater_than_where_clause_with_scalars(self):
-        n1 = np.arange(1,10)
+        n1 = np.arange(1, 10)
         a1 = ak.array(n1)
-        
-        condN = n1 > 5 
-        result = np.where(condN,n1,1)
+
+        condN = n1 > 5
+        result = np.where(condN, n1, 1)
         self.assertTrue((np.array([1, 1, 1, 1, 1, 6, 7, 8, 9]) == result).all())
-     
-        condA = a1 > 5 
-        result = ak.where(condA,a1,1)
+
+        condA = a1 > 5
+        result = ak.where(condA, a1, 1)
         self.assertTrue((ak.array([1, 1, 1, 1, 1, 6, 7, 8, 9]) == result).all())
-        
-        result = np.where(condN,1,n1)
+
+        result = np.where(condN, 1, n1)
         self.assertTrue((np.array([1, 2, 3, 4, 5, 1, 1, 1, 1]) == result).all())
-     
-        result = ak.where(condA,1,a1)
+
+        result = ak.where(condA, 1, a1)
         self.assertTrue((ak.array([1, 2, 3, 4, 5, 1, 1, 1, 1]) == result).all())
-        
+
     def test_not_equal_where_clause(self):
-        n1 = np.arange(1,10)
-        n2 = np.ones(9, dtype=np.int64) 
+        n1 = np.arange(1, 10)
+        n2 = np.ones(9, dtype=np.int64)
         a1 = ak.array(n1)
-        a2 = ak.array(n2)         
+        a2 = ak.array(n2)
 
         cond = n1 != 5
-        result = np.where(cond,n1,n2)
+        result = np.where(cond, n1, n2)
         self.assertTrue((np.array([1, 2, 3, 4, 1, 6, 7, 8, 9]) == result).all())
-         
+
         cond = a1 != 5
-        result = ak.where(cond,a1,a2)
+        result = ak.where(cond, a1, a2)
         self.assertTrue((ak.array([1, 2, 3, 4, 1, 6, 7, 8, 9]) == result).all())
-        
+
     def test_equals_where_clause(self):
-        n1 = np.arange(1,10)
-        n2 = np.ones(9, dtype=np.int64) 
+        n1 = np.arange(1, 10)
+        n2 = np.ones(9, dtype=np.int64)
         a1 = ak.array(n1)
-        a2 = ak.array(n2)         
+        a2 = ak.array(n2)
 
         cond = n1 == 5
-        result = np.where(cond,n1,n2)
+        result = np.where(cond, n1, n2)
         self.assertTrue((np.array([1, 1, 1, 1, 5, 1, 1, 1, 1]) == result).all())
-         
+
         cond = a1 == 5
-        result = ak.where(cond,a1,a2)
+        result = ak.where(cond, a1, a2)
         self.assertTrue((ak.array([1, 1, 1, 1, 5, 1, 1, 1, 1]) == result).all())
-        
+
     def test_where_filter(self):
-        n1 = np.arange(1,10)
-        a1 = ak.array(n1)        
-        n2 = np.arange(6,10)
+        n1 = np.arange(1, 10)
+        a1 = ak.array(n1)
+        n2 = np.arange(6, 10)
         a2 = ak.array(n2)
-        
+
         self.assertTrue((n2 == n1[n1 > 5]).all())
-        self.assertTrue((a2 == a1[a1 > 5]).all())  
+        self.assertTrue((a2 == a1[a1 > 5]).all())
 
     def test_multiple_where_clauses(self):
-        n1 = np.arange(1,10)
-        n2 = np.ones(9, dtype=np.int64) 
+        n1 = np.arange(1, 10)
+        n2 = np.ones(9, dtype=np.int64)
         a1 = ak.array(n1)
-        a2 = ak.array(n2)         
+        a2 = ak.array(n2)
 
-        cond = n1 > 2,n1 < 8
-        result = np.where(cond,n1,n2)
-        self.assertTrue((np.array([[1,1,3,4,5,6,7,8,9],
-                                         [1,2,3,4,5,6,7,1,1]]) == result).all())
-        # Arkouda does not support multiple where clauses  
-        cond = a1 > 5,a1 < 8
+        cond = n1 > 2, n1 < 8
+        result = np.where(cond, n1, n2)
+        self.assertTrue(
+            (np.array([[1, 1, 3, 4, 5, 6, 7, 8, 9], [1, 2, 3, 4, 5, 6, 7, 1, 1]]) == result).all()
+        )
+        # Arkouda does not support multiple where clauses
+        cond = a1 > 5, a1 < 8
         with self.assertRaises(TypeError):
-            ak.where(cond,a1,a2)
-            
+            ak.where(cond, a1, a2)
+
     def test_dtypes(self):
         cond = (ak.arange(10) % 2) == 0
         for dt in (ak.int64, ak.uint64, ak.float64, ak.bool):


### PR DESCRIPTION
Closes #1455 

Formats all the files in `tests` using:
- black
- isort
- flake8

Some flake8 errors are ignored for functionality.