### PR TITLE
Closes #1470 -  `ak.Index` Updates

### DIFF
--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -1,8 +1,8 @@
 import json
-from typing import List, Union, Optional, SupportsInt
+from typeguard import typechecked
+from typing import List, Union, Optional
 from typing import cast as typecast
 
-import numpy as np
 import pandas as pd  # type: ignore
 
 from arkouda import Strings
@@ -21,13 +21,13 @@ from arkouda.util import concatenate, convert_if_categorical, get_callback, regi
 
 
 class Index:
+    @typechecked
     def __init__(self, values: Union[List, pdarray, Strings, pd.Index, "Index"], name: Optional[str] = None):
         if isinstance(values, Index):
-            # Typing added here for MyPy
-            self.values: Union[pdarray, Strings] = values.values
-            self.size: SupportsInt = values.size
-            self.dtype: np.dtype = values.dtype
-            self.name: Optional[str] = name if name else values.name
+            self.values = values.values
+            self.size = values.size
+            self.dtype = values.dtype
+            self.name = name if name else values.name
             return
         elif isinstance(values, pd.Index):
             self.values = array(values.values)

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -332,8 +332,7 @@ class DataFrameTest(ArkoudaTest):
 
         c = gb.count()
         self.assertIsInstance(c, ak.Series)
-        self.assertListEqual(c.index.to_pandas().tolist(), ["Alice", "Carol", "Bob"])
-        self.assertListEqual(c.values.to_ndarray().tolist(), [3, 1, 2])
+        self.assertListEqual(c.index.to_ndarray().tolist(), ['Alice', 'Carol', 'Bob'])
 
     def test_to_pandas(self):
         df = build_ak_df()

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -333,6 +333,7 @@ class DataFrameTest(ArkoudaTest):
         c = gb.count()
         self.assertIsInstance(c, ak.Series)
         self.assertListEqual(c.index.to_ndarray().tolist(), ['Alice', 'Carol', 'Bob'])
+        self.assertListEqual(c.values.to_ndarray().tolist(), [3, 1, 2])
 
     def test_to_pandas(self):
         df = build_ak_df()

--- a/tests/index_test.py
+++ b/tests/index_test.py
@@ -12,7 +12,7 @@ class IndexTest(ArkoudaTest):
 
         self.assertIsInstance(idx, ak.Index)
         self.assertEqual(idx.size, 5)
-        self.assertListEqual(idx.to_pandas().tolist(), [i for i in range(5)])
+        self.assertListEqual(idx.to_ndarray().tolist(), [i for i in range(5)])
 
     def test_multiindex_creation(self):
         # test list generation
@@ -56,7 +56,7 @@ class IndexTest(ArkoudaTest):
         idx_2 = ak.Index(ak.array([2, 4, 1, 3, 0]))
 
         idx_full = idx_1.concat(idx_2)
-        self.assertListEqual(idx_full.to_pandas().tolist(), [0, 1, 2, 3, 4, 2, 4, 1, 3, 0])
+        self.assertListEqual(idx_full.to_ndarray().tolist(), [0, 1, 2, 3, 4, 2, 4, 1, 3, 0])
 
     def test_lookup(self):
         idx = ak.Index.factory(ak.arange(5))


### PR DESCRIPTION
Closes #1470 

General updates made to existing `ak.Index` functionality to bring into line with Pandas, but without interrupting existing workflows.

- Updates `__init__` to better handle input that is not pdarray
  - Allows for: pdarray, String, List, pandas.Index, and ak.Index object to be passed in
  - Optional name parameter that can be passed to set the index name
  - Updated properties to align with pandas. Calling `ak.Index.index` will still return the underlying pdarray/Strings object and is functionally equivalent to calling `ak.Index.values`
  - Updates underlying pdarray accesses to call `self.values` 
- `__getitem__` updated to return an `ak.Index` object when passing in multiple values. Passing single indexes for access returns the value at that index.
- `__repr__` Updated to display similar to pandas
- Added `ak.Index.shape` property
- `to_pandas` updated to return `pd.Index` object
- Added `to_ndarray` to return the underlying `pdarray` converted to `ndarray`. This is more in line with other arkouda objects.
- Updates testing to access correct values in accordance with updates.