### PR TITLE
Closes #1480 & #1481 - Deprecation Warnings

### DIFF
--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -14,7 +14,7 @@ dependencies:
   - h5py
   - pip
   - types-tabulate
-  - pytables
+  - pytables>=3.7.0
   - pyarrow
 
   # Developer dependencies

--- a/arkouda-env.yml
+++ b/arkouda-env.yml
@@ -15,7 +15,7 @@ dependencies:
   - h5py
   - pip
   - types-tabulate
-  - pytables
+  - pytables>=3.7.0
   - pyarrow
 
   - pip:

--- a/pydoc/requirements.txt
+++ b/pydoc/requirements.txt
@@ -11,7 +11,7 @@ matplotlib
 h5py
 pip
 types-tabulate
-tables
+tables>=3.7.0
 pyarrow
 
 # Developer dependencies

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ setup(
         'h5py',
         'pip',
         'types-tabulate',
-        'tables',
+        'tables>=3.7.0',
         'pyarrow'
     ],
 


### PR DESCRIPTION
Closes #1480 
Closes #1481 

The inclusion of `pytables` (conda) / `tables` (pip) was resulting in several deprecation warnings related to `numpy`. Both the `np.typeDict` deprecation warning and the `np.object` deprecation warning are resolved in when using `pytables==3.7.0`. This version resolves the deprecation warnings. All dependency locations have been updated to require `pytables==3.7.0` or `tables==3.7.0` depending upon the package manager they are for.