### PR TITLE
Closes #1448 - `util.py` cleanup

### DIFF
--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -22,7 +22,9 @@ from arkouda.util import concatenate, convert_if_categorical, get_callback, regi
 
 class Index:
     @typechecked
-    def __init__(self, values: Union[List, pdarray, Strings, pd.Index, "Index"], name: Optional[str] = None):
+    def __init__(
+        self, values: Union[List, pdarray, Strings, pd.Index, "Index"], name: Optional[str] = None
+    ):
         if isinstance(values, Index):
             self.values = values.values
             self.size = values.size

--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -208,7 +208,7 @@ def invert_permutation(perm):
 def most_common(g, values):
     warn(
         "This function is deprecated and will be removed in a later version of Arkouda."
-        " Use ak.GroupBy.most_common(values) instead.",
+        " Use arkouda.GroupBy.most_common(values) instead.",
         DeprecationWarning,
     )
 
@@ -221,7 +221,7 @@ def arkouda_to_numpy(A: pdarray, tmp_dir: str = "") -> np.ndarray:
     """
     warn(
         "This function is deprecated and will be removed in a later version of Arkouda."
-        " Use ak.pdarray.to_ndarray instead.",
+        " Use arkouda.pdarray.to_ndarray instead.",
         DeprecationWarning,
     )
 

--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -12,7 +12,7 @@ from arkouda.client_dtypes import BitVector, BitVectorizer, IPv4
 from arkouda.groupbyclass import GroupBy, broadcast
 from arkouda.infoclass import list_symbol_table
 from arkouda.pdarrayclass import RegistrationError, create_pdarray, pdarray
-from arkouda.pdarraycreation import arange, array
+from arkouda.pdarraycreation import arange
 from arkouda.pdarrayIO import read
 from arkouda.pdarraysetops import unique
 from arkouda.segarray import SegArray
@@ -208,7 +208,7 @@ def invert_permutation(perm):
 def most_common(g, values):
     warn(
         "This function is deprecated and will be removed in a later version of Arkouda."
-        " Use <GroupBy>.most_common(values) instead.",
+        " Use ak.GroupBy.most_common(values) instead.",
         DeprecationWarning,
     )
 
@@ -221,7 +221,7 @@ def arkouda_to_numpy(A: pdarray, tmp_dir: str = "") -> np.ndarray:
     """
     warn(
         "This function is deprecated and will be removed in a later version of Arkouda."
-        " Use x.to_ndarray() instead.",
+        " Use ak.pdarray.to_ndarray instead.",
         DeprecationWarning,
     )
 

--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -263,7 +263,7 @@ def numpy_to_arkouda(
     B = read(f"{tmp_dir}/{rng}.hdf5", "arr")
     os.remove(f"{tmp_dir}/{rng}.hdf5")
 
-    return array(B)
+    return B
 
 
 def convert_if_categorical(values):

--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -39,7 +39,7 @@ def get_callback(x):
 def concatenate(items, ordered=True):
     warn(
         "This function is deprecated and will be removed in a later version of Arkouda."
-        " Use ak.util.generic_concat(items, ordered) instead.",
+        " Use arkouda.util.generic_concat(items, ordered) instead.",
         DeprecationWarning,
     )
 

--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -43,7 +43,7 @@ def concatenate(items, ordered=True):
         DeprecationWarning,
     )
 
-    return generic_concat(items, ordered=True)
+    return generic_concat(items, ordered=ordered)
 
 
 def generic_concat(items, ordered=True):


### PR DESCRIPTION
This PR (closes #1448) 

The purpose of this issue was to cleanup, deprecate, and organize the methods in `util.py` where possible.

The only major change was moving the `most_common()` method into `GroupBy` and temporarily aliasing to the new location with a deprecation warning. The rest of the changes were small, mostly deprecation warnings, and a few places where logic was adjusted to update it to current capabilities.