### PR TITLE
Closes #612 - Upgrade to Python 3.8

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.x']
+        python-version: ['3.8', '3.9', '3.10', '3.x']
     container:
       image: chapel/chapel:1.25.1
     steps:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,7 +29,7 @@ This guide will walk you through the environment configuration for Arkouda to op
  * cmake >= 3.11.0
  * zeromq version >= 4.2.5, tested with 4.2.5 and 4.3.1
  * hdf5 
- * python 3.7 or greater
+ * python 3.8 or greater
  * numpy
  * typeguard for runtime type checking
  * pandas for testing and conversion utils

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ For detailed prerequisite information and installation guides, please review [IN
 * cmake >= 3.11.0
 * zeromq version >= 4.2.5, tested with 4.2.5 and 4.3.1
 * hdf5 
-* python 3.7 or greater
+* python 3.8 or greater
 * numpy
 * typeguard for runtime type checking
 * pandas for testing and conversion utils

--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python>=3.7   # minimum 3.7
+  - python>=3.8   # minimum 3.8
   - numpy>=1.16.5,<=1.21.5
   - pandas>=1.1.0
   - pyzmq>=20.0.0

--- a/arkouda-env.yml
+++ b/arkouda-env.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - -defaults
 dependencies:
-  - python>=3.7   # minimum 3.7
+  - python>=3.8   # minimum 3.8
   - numpy>=1.16.5,<=1.21.5
   - pandas>=1.1.0
   - pyzmq>=20.0.0

--- a/pydoc/requirements.txt
+++ b/pydoc/requirements.txt
@@ -1,5 +1,5 @@
 # dependencies
-python>=3.7
+python>=3.8
 numpy>=1.16.5,<=1.21.5
 pandas>=1.1.0
 pyzmq>=20.0.0

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
         # These classifiers are *not* checked by 'pip install'. See instead
         # 'python_requires' below.
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 
     # This field adds keywords for your project which will appear on the
@@ -122,7 +122,7 @@ setup(
     # and refuse to install the project if the version does not match. If you
     # do not support Python 2, you can simplify this to '>=3.5' or similar, see
     # https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
-    python_requires='>=3.7',
+    python_requires='>=3.8',
 
     # This field lists other packages that your project depends on to run.
     # Any package you put here will be installed by pip when your project is


### PR DESCRIPTION
Closes #612 

- Updates references to minimum supported Python version to be `3.8`.
- Updates CI.yml to remove 3.7 testing and add 3.10 testing.

This PR is required for PR #1485.