### PR TITLE
Closes #1371 - Setting mypy back to >=0.931

### DIFF
--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -29,6 +29,6 @@ dependencies:
   
   - pip:
     # Developer dependencies
-    - mypy==0.931
+    - mypy>=0.931
     - typeguard==2.10.0
   

--- a/setup.py
+++ b/setup.py
@@ -157,7 +157,7 @@ setup(
     extras_require={  # Optional
         'dev': ['pexpect', 'pytest', 'pytest-env',
                 'Sphinx', 'sphinx-argparse', 'sphinx-autoapi',
-                'mypy==0.931', 'typed-ast', 'flake8'],
+                'mypy>=0.931', 'typed-ast', 'flake8'],
     },
     # replace original install command with version that also builds
     # chapel and the arkouda server.


### PR DESCRIPTION
This PR closes #1371 

Setting the mypy version to `mypy>=0.931` in the developer environment .yml file and the `setup.py` which were both set to `mypy==0.931` in #1433 until we could debug the issues I was seeing with later versions.