### PR TITLE
Update additional files to avoid using SysCTypes, CPtr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,14 +174,14 @@ endif
 ZMQ_CHECK = $(DEP_INSTALL_DIR)/checkZMQ.chpl
 check-zmq: $(ZMQ_CHECK)
 	@echo "Checking for ZMQ"
-	$(CHPL) $(CHPL_FLAGS) $< -o $(DEP_INSTALL_DIR)/$@
+	$(CHPL) $(CHPL_FLAGS) $(ARKOUDA_COMPAT_MODULES) $< -o $(DEP_INSTALL_DIR)/$@
 	$(DEP_INSTALL_DIR)/$@ -nl 1
 	@rm -f $(DEP_INSTALL_DIR)/$@ $(DEP_INSTALL_DIR)/$@_real
 
 HDF5_CHECK = $(DEP_INSTALL_DIR)/checkHDF5.chpl
 check-hdf5: $(HDF5_CHECK)
 	@echo "Checking for HDF5"
-	$(CHPL) $(CHPL_FLAGS) $< -o $(DEP_INSTALL_DIR)/$@
+	$(CHPL) $(CHPL_FLAGS) $(ARKOUDA_COMPAT_MODULES) $< -o $(DEP_INSTALL_DIR)/$@
 	$(DEP_INSTALL_DIR)/$@ -nl 1
 	@rm -f $(DEP_INSTALL_DIR)/$@ $(DEP_INSTALL_DIR)/$@_real
 
@@ -198,7 +198,7 @@ check-re2: $(RE2_CHECK)
 ARROW_CHECK = $(DEP_INSTALL_DIR)/checkArrow.chpl
 check-arrow: $(ARROW_CHECK) $(ARROW_O)
 	@echo "Checking for Arrow"
-	$(CHPL) $(CHPL_FLAGS) $< $(ARROW_M) -M $(ARKOUDA_SOURCE_DIR) -o $(DEP_INSTALL_DIR)/$@
+	$(CHPL) $(CHPL_FLAGS) $(ARKOUDA_COMPAT_MODULES) $< $(ARROW_M) -M $(ARKOUDA_SOURCE_DIR) -o $(DEP_INSTALL_DIR)/$@
 	$(DEP_INSTALL_DIR)/$@ -nl 1
 	@rm -f $(DEP_INSTALL_DIR)/$@ $(DEP_INSTALL_DIR)/$@_real
 

--- a/dep/checkArrow.chpl
+++ b/dep/checkArrow.chpl
@@ -1,4 +1,4 @@
-use SysCTypes, CPtr, IO;
+use CTypes, IO;
 
 require "../src/ArrowFunctions.h";
 require "../src/ArrowFunctions.o";

--- a/dep/checkHDF5.chpl
+++ b/dep/checkHDF5.chpl
@@ -1,4 +1,4 @@
-use HDF5, SysCTypes;
+use HDF5, CTypes;
 
 proc main() {
   var H5major: c_uint, H5minor: c_uint, H5micro: c_uint;

--- a/test/UnitTestParquetCpp.chpl
+++ b/test/UnitTestParquetCpp.chpl
@@ -1,4 +1,4 @@
-use ParquetMsg, SysCTypes, CPtr, FileSystem;
+use ParquetMsg, CTypes, FileSystem;
 use UnitTest;
 use TestBase;
 

--- a/toys/fftw-mpi.chpl
+++ b/toys/fftw-mpi.chpl
@@ -56,7 +56,7 @@
 // require MPI here. 
 use MPI;
 use FFTW;
-use SysCTypes;
+use CTypes;
 require "fftw3-mpi.h";
 
 // Allow the user to define the number of threads used by FFTW.


### PR DESCRIPTION
This is a follow-up to PR #1185 which updated Arkouda to use with
the new 'CTypes' module introduced in Chapel 1.26.  Specifically,
I'd overlooked that other files still relied on SysCTypes and CPtr,
such as those used for the check-* rules in the make process.

Here, I'm updating those files to also use the new 'CTypes' modules
and updating the Makefile to add the ARKOUDA_COMPAT_MODULES
module search path to their compilations as well.  This seems like a
reasonable change in that (as I understand it) the point of the
check-* rules is to see whether the main compilation will work, so
making the 'chpl' command lines more similar seems like it's only
making the check that much better (?).

This work was motivated by the fact that I removed the deprecated
modules on `main` in preparing for this month's Chapel 1.27 and
broke several of our nightly test configurations trying to use Chapel's
`main` branch as a result.