### PR TITLE
Revert "Closes #1479 - Pandas Cast Warning"

### DIFF
--- a/arkouda/timeclass.py
+++ b/arkouda/timeclass.py
@@ -1,11 +1,10 @@
 import datetime
 from typing import Union
-from warnings import warn
 
 import numpy as np  # type: ignore
 from pandas import Series  # type: ignore
-from pandas import Timestamp  # type: ignore
 from pandas import Timedelta as pdTimedelta  # type: ignore
+from pandas import Timestamp  # type: ignore
 from pandas import date_range as pd_date_range  # type: ignore
 from pandas import timedelta_range as pd_timedelta_range  # type: ignore
 from pandas import to_datetime, to_timedelta  # type: ignore
@@ -540,7 +539,6 @@ def date_range(
     normalize=False,
     name=None,
     closed=None,
-    inclusive="both",
     **kwargs,
 ):
     """Creates a fixed frequency Datetime range. Alias for
@@ -570,9 +568,6 @@ def date_range(
     closed : {None, 'left', 'right'}, optional
         Make the interval closed with respect to the given frequency to
         the 'left', 'right', or both sides (None, the default).
-        *Deprecated*
-    inclusive : {"both", "neither", "left", "right"}, default "both"
-        Include boundaries. Whether to set each bound as closed or open.
     **kwargs
         For compatibility. Has no effect on the result.
 
@@ -591,15 +586,7 @@ def date_range(
     <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases>`__.
 
     """
-    if closed is not None:
-        warn(
-            "closed has been deprecated. Please use the inclusive parameter instead.", DeprecationWarning
-        )
-        inclusive = closed
-
-    return Datetime(
-        pd_date_range(start, end, periods, freq, tz, normalize, name, inclusive=inclusive, **kwargs)
-    )
+    return Datetime(pd_date_range(start, end, periods, freq, tz, normalize, name, closed, **kwargs))
 
 
 def timedelta_range(start=None, end=None, periods=None, freq=None, name=None, closed=None, **kwargs):

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -293,10 +293,10 @@ class DatetimeTest(ArkoudaTest):
             "W": ("weeks", "w", "week"),
             "D": ("days", "d", "day"),
             "h": ("hours", "H", "hr", "hrs"),
-            "m": ("minutes", "minute", "min", "m"),
-            "ms": ("milliseconds", "millisecond", "milli", "ms", "l"),
-            "us": ("microseconds", "microsecond", "micro", "us", "u"),
-            "ns": ("nanoseconds", "nanosecond", "nano", "ns", "n"),
+            "T": ("minutes", "minute", "min", "m"),
+            "L": ("milliseconds", "millisecond", "milli", "ms", "l"),
+            "U": ("microseconds", "microsecond", "micro", "us", "u"),
+            "N": ("nanoseconds", "nanosecond", "nano", "ns", "n"),
         }
         for pdunit, aliases in unitmap.items():
             # check_equal(pdunit, pdunit)


### PR DESCRIPTION
Reverts Bears-R-Us/arkouda#1485

after the merge of 1485 i got a bunch of test failures on my mac.
I reinstalled the arkouda package, rebuilt the server, and reran the tests...

```
platform darwin -- Python 3.8.13, pytest-7.1.1, pluggy-1.0.0

...

plugins: typeguard-2.10.0, env-0.6.2
collected 406 items                                                                

tests/array_view_test.py .........                                           [  2%]
tests/bitops_test.py .......                                                 [  3%]
tests/categorical_test.py ..................                                 [  8%]
tests/check.py ...................                                           [ 13%]
tests/client_test.py ..........                                              [ 15%]
tests/coargsort_test.py .......                                              [ 17%]
tests/compare_test.py ...............                                        [ 20%]
tests/dataframe_test.py ..........................                           [ 27%]
tests/datetime_test.py FFFFFFFFFFFFF                                         [ 30%]
tests/dtypes_tests.py ...........                                            [ 33%]
tests/groupby_test.py ..................                                     [ 37%]
tests/index_test.py ..........                                               [ 40%]
tests/indexing_test.py .....                                                 [ 41%]
tests/nan_test.py .                                                          [ 41%]
tests/import_export_test.py ....                                             [ 42%]
tests/io_test.py ..........................                                  [ 49%]
tests/io_util_test.py ...                                                    [ 49%]
tests/join_test.py ..........                                                [ 52%]
tests/logger_test.py .......                                                 [ 53%]
tests/message_test.py ....                                                   [ 54%]
tests/numeric_test.py ...............                                        [ 58%]
tests/operator_tests.py ..............                                       [ 62%]
tests/pdarray_creation_test.py .......................                       [ 67%]
tests/regex_test.py ...........                                              [ 70%]
tests/registration_test.py ......................                            [ 75%]
tests/security_test.py ....                                                  [ 76%]
tests/segarray_test.py .................                                     [ 81%]
tests/series_test.py ...........                                             [ 83%]
tests/setops_test.py ...........                                             [ 86%]
tests/sort_test.py ....                                                      [ 87%]
tests/string_test.py .....................                                   [ 92%]
tests/where_test.py ..........                                               [ 95%]
tests/extrema_test.py ..........                                             [ 97%]
tests/parquet_test.py s.........                                             [100%]

===================================== FAILURES =====================================
______________________________ DatetimeTest.test_ceil ______________________________

...

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================= short test summary info ==============================
FAILED tests/datetime_test.py::DatetimeTest::test_ceil - TypeError: _generate_ran...
FAILED tests/datetime_test.py::DatetimeTest::test_creation - TypeError: _generate...
FAILED tests/datetime_test.py::DatetimeTest::test_floor - TypeError: _generate_ra...
FAILED tests/datetime_test.py::DatetimeTest::test_groupby - TypeError: _generate_...
FAILED tests/datetime_test.py::DatetimeTest::test_noop_creation - TypeError: _gen...
FAILED tests/datetime_test.py::DatetimeTest::test_op_types - TypeError: _generate...
FAILED tests/datetime_test.py::DatetimeTest::test_plus_minus - TypeError: _genera...
FAILED tests/datetime_test.py::DatetimeTest::test_reductions - TypeError: _genera...
FAILED tests/datetime_test.py::DatetimeTest::test_round - TypeError: _generate_ra...
FAILED tests/datetime_test.py::DatetimeTest::test_roundtrip - TypeError: _generat...
FAILED tests/datetime_test.py::DatetimeTest::test_scalars - TypeError: _generate_...
FAILED tests/datetime_test.py::DatetimeTest::test_timedel_std - TypeError: _gener...
FAILED tests/datetime_test.py::DatetimeTest::test_units - TypeError: _generate_ra...
======== 13 failed, 392 passed, 1 skipped, 62 warnings in 83.19s (0:01:23) =========
```