### PR TITLE
Start timing array transfer again

### DIFF
--- a/benchmarks/array_transfer.py
+++ b/benchmarks/array_transfer.py
@@ -28,8 +28,8 @@ def time_ak_array_transfer(N, trials, dtype, seed):
         end = time.time()
         to_ndarray_times.append(end - start)
         start = time.time()
-        end = time.time()
         aka = ak.array(npa)
+        end = time.time()
         to_pdarray_times.append(end - start)
         gc.collect()
     avgnd = sum(to_ndarray_times) / trials


### PR DESCRIPTION
In a refactor PR, the array transfer was accidentally moved
outside of the timing code, so this benchmark was not timing
anything.

Closes https://github.com/Bears-R-Us/arkouda/issues/1497