### PR TITLE
Closes #1499 - Update Requirements for Pandas

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,0 +1,56 @@
+# Dependency List
+- `python>=3.8`
+- `numpy>=1.18.5,<=1.21.5`
+- `pandas>=1.4.0`
+- `pyzmq>=20.0.0`
+- `typeguard==2.10.0`
+- `tabulate`
+- `pyfiglet`
+- `versioneer`
+- `matplotlib>=3.3.2`
+- `h5py`
+- `pip`
+- `types-tabulate`
+- `tables>=3.7.0`
+- `pyarrow>=1.0.1`
+
+# Developer Specific Dependency List
+- `pexpect`
+- `pytest>=6.0`
+- `pytest-env`
+- `Sphinx`
+- `sphinx-argparse`
+- `sphinx-autoapi`
+- `typed-ast`
+- `mypy>=0.931`
+- `flake8`
+
+# Installing Dependencies
+
+Dependencies can be install using `Anaconda` (Recommended) or `pip`. 
+
+## Using Anaconda
+Arkouda provides 2 files for installing dependencies, one for users and one for developers. 
+
+- Users Enviorment YAML: `arkouda-env.yml`
+- Developer Enviornment YAML: `arkouda-env-dev.yml`
+
+**When running the commands below, replace `<env_name>` with the name you want to give/have given your conda enviroment. Replace `<yaml_file>` with the file appropriate to your interaction with Arkouda.**
+```commandline
+# Creating a new environment with dependencies installed
+conda env create -n <env_name> -f <yaml_file>
+
+# Updating env using the yaml 
+conda env update -n <env_name> -f <yaml_file> --prune 
+#Only use the --prune option if you want to remove packages that are no longer requirements for arkouda.
+```
+
+## Using Pip
+When you `pip install Arkouda`, dependencies should be installed as well. However, dependencies may change during the life-cycle of Arkouda, so here we detail how to update dependencies when using `pip` for package management.
+
+```commandline
+# Update Dependencies
+cd <path_to_arkouda>/arkouda
+pip install --upgrade --upgrade-strategy eager -e .
+```
+ 

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -27,15 +27,15 @@
 
 # Installing Dependencies
 
-Dependencies can be install using `Anaconda` (Recommended) or `pip`. 
+Dependencies can be installed using `Anaconda` (Recommended) or `pip`. 
 
 ## Using Anaconda
 Arkouda provides 2 files for installing dependencies, one for users and one for developers. 
 
-- Users Enviorment YAML: `arkouda-env.yml`
-- Developer Enviornment YAML: `arkouda-env-dev.yml`
+- Users Environment YAML: `arkouda-env.yml`
+- Developer Environment YAML: `arkouda-env-dev.yml`
 
-**When running the commands below, replace `<env_name>` with the name you want to give/have given your conda enviroment. Replace `<yaml_file>` with the file appropriate to your interaction with Arkouda.**
+**When running the commands below, replace `<env_name>` with the name you want to give/have given your conda environment. Replace `<yaml_file>` with the file appropriate to your interaction with Arkouda.**
 ```commandline
 # Creating a new environment with dependencies installed
 conda env create -n <env_name> -f <yaml_file>

--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -4,31 +4,31 @@ channels:
   - defaults
 dependencies:
   - python>=3.8   # minimum 3.8
-  - numpy>=1.16.5,<=1.21.5
-  - pandas>=1.1.0
+  - numpy>=1.18.5,<=1.21.5
+  - pandas>=1.4.0
   - pyzmq>=20.0.0
   - tabulate
   - pyfiglet
   - versioneer
-  - matplotlib
+  - matplotlib>=3.3.2
   - h5py
   - pip
   - types-tabulate
   - pytables>=3.7.0
-  - pyarrow
+  - pyarrow>=1.0.1
 
   # Developer dependencies
   - pexpect
-  - pytest
+  - pytest>=6.0
   - pytest-env
   - Sphinx
   - sphinx-argparse
   - sphinx-autoapi
   - typed-ast
   - flake8
+  - mypy>=0.931
   
   - pip:
     # Developer dependencies
-    - mypy>=0.931
     - typeguard==2.10.0
   

--- a/arkouda-env.yml
+++ b/arkouda-env.yml
@@ -4,19 +4,19 @@ channels:
   - -defaults
 dependencies:
   - python>=3.8   # minimum 3.8
-  - numpy>=1.16.5,<=1.21.5
-  - pandas>=1.1.0
+  - numpy>=1.18.5,<=1.21.5
+  - pandas>=1.4.0
   - pyzmq>=20.0.0
   - typeguard==2.10.0
   - tabulate
   - pyfiglet
   - versioneer
-  - matplotlib
+  - matplotlib>=3.3.2
   - h5py
   - pip
   - types-tabulate
   - pytables>=3.7.0
-  - pyarrow
+  - pyarrow>=1.0.1
 
   - pip:
       - typeguard==2.10.0

--- a/arkouda-env.yml
+++ b/arkouda-env.yml
@@ -7,7 +7,6 @@ dependencies:
   - numpy>=1.18.5,<=1.21.5
   - pandas>=1.4.0
   - pyzmq>=20.0.0
-  - typeguard==2.10.0
   - tabulate
   - pyfiglet
   - versioneer

--- a/pydoc/requirements.txt
+++ b/pydoc/requirements.txt
@@ -1,22 +1,22 @@
 # dependencies
 python>=3.8
-numpy>=1.16.5,<=1.21.5
-pandas>=1.1.0
+numpy>=1.18.5,<=1.21.5
+pandas>=1.4.0
 pyzmq>=20.0.0
 typeguard==2.10.0
 tabulate
 pyfiglet
 versioneer
-matplotlib
+matplotlib>=3.3.2
 h5py
 pip
 types-tabulate
 tables>=3.7.0
-pyarrow
+pyarrow>=1.0.1
 
 # Developer dependencies
 pexpect
-pytest
+pytest>=6.0
 pytest-env
 Sphinx
 sphinx-argparse

--- a/setup.py
+++ b/setup.py
@@ -131,19 +131,19 @@ setup(
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'numpy>=1.16.5,<=1.21.5',
-        'pandas>=1.1.0',
+        'numpy>=1.18.5,<=1.21.5',
+        'pandas>=1.4.0',
         'pyzmq>=20.0.0',
         'typeguard==2.10.0',
         'tabulate',
         'pyfiglet',
         'versioneer',
-        'matplotlib',
+        'matplotlib>=3.3.2',
         'h5py',
         'pip',
         'types-tabulate',
         'tables>=3.7.0',
-        'pyarrow'
+        'pyarrow>=1.0.1'
     ],
 
     # List additional groups of dependencies here (e.g. development
@@ -155,7 +155,7 @@ setup(
     # Similar to `install_requires` above, these must be valid existing
     # projects.
     extras_require={  # Optional
-        'dev': ['pexpect', 'pytest', 'pytest-env',
+        'dev': ['pexpect', 'pytest>=6.0', 'pytest-env',
                 'Sphinx', 'sphinx-argparse', 'sphinx-autoapi',
                 'mypy>=0.931', 'typed-ast', 'flake8'],
     },


### PR DESCRIPTION
Closes #1499

- Updates `setup.py`, `arkouda-env-dev.yml`, `arkouda-env.yml`, and `pydoc/requirements.txt` to include updated dependencies for Pandas. We updated to require `pandas>=1.4.0` which required other minimum versions be updated, namely `numpy>=1.18.5`.
- Adds `REQUIREMENTS.md` file for easy identification of requirements and information on how to install dependencies and update them when they are out of date.