### PR TITLE
fix channel order in conda yml file

### DIFF
--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -1,7 +1,7 @@
 name: arkouda-env-dev
 channels:
-  - conda-forge
   - defaults
+  - conda-forge
 dependencies:
   - python>=3.8   # minimum 3.8
   - numpy>=1.16.5,<=1.21.5

--- a/arkouda-env.yml
+++ b/arkouda-env.yml
@@ -1,7 +1,7 @@
 name: arkouda-env
 channels:
+  - defaults
   - conda-forge
-  - -defaults
 dependencies:
   - python>=3.8   # minimum 3.8
   - numpy>=1.16.5,<=1.21.5


### PR DESCRIPTION
closes #1503 

`pyarrow` 7.0.0 from the conda-forge channel does not work for me on my x86_64 mac running catalina os.

flipping the order of the channels installs `pyarrow` 4.0.1 which works... any explanation beyond this is in the issue.
