### PR TITLE
Closes #1505 & #1506

### DIFF
--- a/arkouda/series.py
+++ b/arkouda/series.py
@@ -111,7 +111,7 @@ class Series:
     def __init__(
         self,
         data: Union[Tuple, List, groupable_element_type],
-        index: Optional[Union[pdarray, Strings, Tuple, List]] = None,
+        index: Optional[Union[pdarray, Strings, Tuple, List, Index]] = None,
     ):
         # TODO: Allow index to be an Index when index.py is updated
         if isinstance(data, (tuple, list)) and len(data) == 2:

--- a/arkouda/series.py
+++ b/arkouda/series.py
@@ -116,7 +116,7 @@ class Series:
         # TODO: Allow index to be an Index when index.py is updated
         if isinstance(data, (tuple, list)) and len(data) == 2:
             # handles the previous `ar_tuple` case
-            if not isinstance(data[0], (pdarray, Strings)):
+            if not isinstance(data[0], (pdarray, Strings, List, Tuple)):
                 raise TypeError("indices must be a pdarray or Strings")
             if not isinstance(data[1], (pdarray, Strings, Categorical)):
                 raise TypeError("values must be a pdarray, Strings, or Categorical")

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -515,3 +515,7 @@ class DataFrameTest(ArkoudaTest):
         test_df = df.isin(other_df)
         self.assertListEqual(test_df["col_A"].to_ndarray().tolist(), [True, True])
         self.assertListEqual(test_df["col_B"].to_ndarray().tolist(), [False, False])
+
+    def test_multiindex_compat(self):
+        df = ak.DataFrame({'a': ak.arange(10), 'b': ak.arange(10), 'c': ak.arange(10)})
+        df.groupby(['a', 'b']).sum('c')

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -517,5 +517,6 @@ class DataFrameTest(ArkoudaTest):
         self.assertListEqual(test_df["col_B"].to_ndarray().tolist(), [False, False])
 
     def test_multiindex_compat(self):
+        # Added for testing Issue #1505
         df = ak.DataFrame({'a': ak.arange(10), 'b': ak.arange(10), 'c': ak.arange(10)})
         df.groupby(['a', 'b']).sum('c')

--- a/tests/series_test.py
+++ b/tests/series_test.py
@@ -191,3 +191,9 @@ class SeriesTest(ArkoudaTest):
 
         ref_df = pd.DataFrame({0: [0, 1, 2, 3, 4], 1: [5, 6, 7, 8, 9]})
         self.assertTrue((ref_df == df).all().all())
+
+    def test_index_as_index_compat(self):
+        # added to validate functionality for issue #1506
+        df = ak.DataFrame({'a': ak.arange(10), 'b': ak.arange(10), 'c': ak.arange(10)})
+        g = df.groupby(['a', 'b'])
+        g.broadcast(g.sum('c'))


### PR DESCRIPTION
Closes #1505 
Closes #1506 

Submitting single PR to resolve both issues because modifications are related.

- Adds `List` and `Tuple` to the allowed types for the compatibility of tuples being supplied. This will now allow for Multi-Index objects.
- Adds `Index` as and allowed type for `index` parameter to series.
- Adds testing (test cases provided by @reuster986) to ensure continued functionality. 