### PR TITLE
Closes #1386 - Generic `unregister_by_name()` method

### DIFF
--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -301,6 +301,18 @@ def attach(name: str, dtype: str = "infer"):
 
 
 def unregister_by_name(name: str, dtype: str = "infer"):
+    """
+    Unregisters all components of a given registered object's name
+
+    Parameters
+    ----------
+    name : str
+        Name of the object to be unregistered
+    dtype : str
+        Name of the type of object being unregistered. If no type is given, we will attempt
+        to identify the type based on registered symbols
+        Supported types are: pdarray, strings, categorical, segarray, and series
+    """
     repMsg = cast(str, generic_msg(cmd="genericUnregisterByName", args=f"{dtype}+{name}"))
 
     return repMsg

--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -298,3 +298,9 @@ def attach(name: str, dtype: str = "infer"):
             return Strings.from_return_msg(repMsg)
         else:
             return create_pdarray(repMsg)
+
+
+def unregister_by_name(name: str, dtype: str = "infer"):
+    repMsg = cast(str, generic_msg(cmd="genericUnregisterByName", args=f"{dtype}+{name}"))
+
+    return repMsg

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,7 +1,9 @@
+import numpy as np
 from base_test import ArkoudaTest
 from context import arkouda as ak
 
-from arkouda.util import attach
+from arkouda import list_registry
+from arkouda.util import attach, unregister_by_name
 
 
 class utilTest(ArkoudaTest):
@@ -79,3 +81,60 @@ class utilTest(ArkoudaTest):
         self.assertListEqual(s2_attach.values.to_ndarray().tolist(), s2.values.to_ndarray().tolist())
         s2Eq = s2_attach.index == s2.index
         self.assertTrue(all(s2Eq.to_ndarray()))
+
+    def test_unregister_by_name(self):
+        # Register the four supported object types
+        # pdarray
+        pda = ak.arange(10)
+        pda.register("pdaUnregisterTest")
+        self.assertTrue(pda.is_registered())
+
+        # Strings
+        s1 = ak.array(["123", "abc", "def"])
+        s1.register("stringsUnregisterTest")
+        self.assertTrue(s1.is_registered())
+
+        # Categorical
+        s2 = ak.array(["abc", "123", "abc"])
+        cat = ak.Categorical(s2)
+        cat.register("catUnregisterTest")
+        self.assertTrue(cat.is_registered())
+
+        # Series
+        # Single Index
+        s3 = ak.Series(
+            index=ak.array(np.random.randint(0, 20, 10)), data=ak.array(np.random.randint(0, 20, 10))
+        )
+        s3.register("seriesSingleTest")
+        self.assertTrue(s3.is_registered())
+
+        multiInd = []
+        for x in range(3):
+            multiInd.append(ak.array(np.random.randint(0, 20, 10)))
+        s4 = ak.Series(index=multiInd, data=ak.array(np.random.randint(0, 20, 10)))
+        s4.register("seriesMultiTest")
+        registry = list_registry()
+        # Series.is_registered() does not support multiIndex
+        self.assertTrue("seriesMultiTest_value" in registry)
+        self.assertTrue("seriesMultiTest_key_0" in registry)
+        self.assertTrue("seriesMultiTest_key_1" in registry)
+        self.assertTrue("seriesMultiTest_key_2" in registry)
+
+        unregister_by_name("pdaUnregisterTest")
+        self.assertFalse(pda.is_registered())
+
+        unregister_by_name("stringsUnregisterTest")
+        self.assertFalse(s1.is_registered())
+
+        unregister_by_name("catUnregisterTest")
+        self.assertFalse(cat.is_registered())
+
+        unregister_by_name("seriesSingleTest")
+        self.assertFalse(s3.is_registered())
+
+        unregister_by_name("seriesMultiTest")
+        registry = list_registry()
+        self.assertFalse("seriesMultiTest_value" in registry)
+        self.assertFalse("seriesMultiTest_key_0" in registry)
+        self.assertFalse("seriesMultiTest_key_1" in registry)
+        self.assertFalse("seriesMultiTest_key_2" in registry)


### PR DESCRIPTION
This PR closes #1386 

This pr adds a generic variation of the `unregister_by_name` method found in various classes. This method supports all of the same types as the generic attach, `Strings`, `pdarray`, `Categorical`, `SegArray`, and `Series`

A test case is added to verify functionality of the method for each of the supported types