### PR TITLE
Closes #1514: Remove trailing comma from 1 tuples in array creation message

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1636,6 +1636,10 @@ def create_pdarray(repMsg: str) -> pdarray:
         mydtype = fields[2]
         size = int(fields[3])
         ndim = int(fields[4])
+
+        # remove comma from 1 tuple with trailing comma
+        if fields[5][len(fields[5])-2] == ',':
+            fields[5] = fields[5].replace(',', '')
         shape = [int(el) for el in fields[5][1:-1].split(",")]
         itemsize = int(fields[6])
     except Exception as e:


### PR DESCRIPTION
In https://github.com/chapel-lang/chapel/pull/19713, trailing commas
were added to 1 tuples and array creation was splitting on commas,
which caused a problem with the new comma. This PR removes the trailing
comma in the case of a 1-tuple for array creation.

Closes #1514 