### PR TITLE
Closes #1511 - `make install-deps` inconsistencies

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -111,7 +111,7 @@ make install-arrow
 
 #### Arrow Install Troubleshooting
 
-Arrow should be installed without issue, but in some instances it is possible that the install will not all complete using the Chapel dependencies. If that occurs, install the following packages.
+Arrow should be installed without issue, but in some instances it is possible that the install will not always complete using the Chapel dependencies. If that occurs, install the following packages.
 
 ```
 #using conda to install

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,173 @@
+# Building the Arkouda Server
+
+## Table of Contents
+1. [Getting Started](#start)
+2. [Environment Variables](#env-vars)
+3. [Building the Source](#build-ak-source)
+   1. [Using Environment Installed Dependencies](#env_deps)
+   2. [Installing Dependencies](#install-deps)
+
+<a id="start"></a>
+## Getting Started <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
+ 
+If you have not installed the Arkouda Client and prerequisites, please follow the directions in [INSTALL.md](INSTALL.md) before proceeding with this build.
+
+Download, clone, or fork the [arkouda repo](https://github.com/mhmerrill/arkouda). Further instructions assume that the current directory is the top-level directory of the repo.
+
+<a id="env-vars"></a>
+## Environment Variables <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
+In order to build the server executable, some environment variables need to be configured. For a full list, please refer to [ENVIRONMENT.md](ENVIRONMENT.md).
+
+<a id="build-ak-source"></a>
+## Build the Source <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
+
+<a id="env-deps"></a>
+### Using Environment Installed Dependencies <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
+If your environment requires non-system paths to find dependencies (e.g., if using the ZMQ and HDF5 bundled with [Anaconda]), append each path to a new file `Makefile.paths` like so:
+
+```make
+# Makefile.paths
+
+# Custom Anaconda environment for Arkouda
+$(eval $(call add-path,/home/user/anaconda3/envs/arkouda))
+#                      ^ Note: No space after comma.
+```
+
+It is important to note that the path may vary based on the installation location of Anaconda (or pip if not using Anaconda). Here are some tips to locate the path
+
+```commandline
+# when installing via pip
+%pip show hdf5 | grep Location
+Location: /opt/homebrew/Caskroom/miniforge/base/envs/ak-base/lib/python3.10/site-packages
+
+# when using conda - the first line of return gives the location
+%conda list hdf5
+# packages in environment at /opt/homebrew/Caskroom/miniforge/base/envs/ak-base:
+#
+# Name                    Version                   Build  Channel
+hdf5                      1.12.1          nompi_hf9525e8_104    conda-forge
+```
+
+The `chpl` compiler will be executed with `-I`, `-L` and an `-rpath` to each path.
+
+The minimum cmake version is 3.11.0, which is not supported in older RHEL versions such as CentOS 7; in these cases, cmake must be downloaded, installed, and linked as follows. Note: while any version of cmake >= 3.11.0 should work, we tested exclusively with 3.11.0:
+
+```
+# Export version number of cmake binary to be installed
+export CM_VERSION=3.11.0
+
+# Download cmake
+wget https://github.com/Kitware/CMake/releases/download/v$CM_VERSION/cmake-$CM_VERSION-Linux-x86_64.sh
+
+# Install cmake
+sh /opt/cmake-$CM_VERSION-Linux-x86_64.sh --skip-license --include-subdir
+
+# Link cmake version
+
+export PATH=./cmake-$CM_VERSION-Linux-x86_64/bin:$PATH
+```
+
+`cmake` can also be installed using conda or pip
+```commandline
+conda install cmake>=3.11.0
+
+pip install cmake>=3.11.0
+```
+
+<a id="install-deps"></a>
+### Installing Dependencies<sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
+*Please Note: This step is to only be performed if you are NOT using dependencies from your env. If you attempt to use both there is a potential that version mismatches with cause build failures*. 
+
+This step only needs to be done once. Once dependencies are installed, you will not need to run again. You can installl all dependencies with a single command or install individually for a customized build.
+
+Before installing, ensure the `Makefile.paths` is empty.
+
+#### Dependencies
+
+- ZMQ
+- HDF5
+- Arrow
+
+##### All Dependencies 
+
+`make install-deps`
+
+#### Individual Installs
+
+```
+# Install ZMQ Only
+make install-zmq
+
+# Install HDF5 Only
+make install-hdf5
+
+# Install Arrow Only
+make install-arrow
+```
+
+#### Arrow Install Troubleshooting
+
+Arrow should be installed without issue, but in some instances it is possible that the install will not all complete using the Chapel dependencies. If that occurs, install the following packages.
+
+```
+#using conda to install
+conda install boost-cpp snappy thrift-cpp re2 utf8proc
+
+#using pip
+pip install boost snappy thrift re2 utf8proc
+```
+
+Run the `make` command to build the `arkouda_server` executable.
+```
+make
+```
+
+<a id="build-ak-docs"></a>
+### Building the Arkouda documentation <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
+The Arkouda documentation is [here](https://bears-r-us.github.io/arkouda/).
+
+<details>
+<summary><b>(click to see more)</b></summary>
+
+First ensure that all Python doc dependencies including sphinx and sphinx extensions have been installed as detailed 
+above. _Important: if Chapel was built locally, ```make chpldoc``` must be executed as detailed above to enable 
+generation of the Chapel docs via the chpldoc executable._
+
+Now that all doc generation dependencies for both Python and Chapel have been installed, there are three make targets for 
+generating docs:
+
+```bash
+# make doc-python generates the Python docs only
+make doc-python
+
+# make doc-server generates the Chapel docs only
+make doc-server
+
+# make doc generates both Python and Chapel documentation
+make doc
+```
+
+The Python docs are written out to the arkouda/docs directory while the Chapel docs are exported to the 
+arkouda/docs/server directory.
+
+```
+arkouda/docs/ # Python frontend documentation
+arkouda/docs/server # Chapel backend server documentation 
+```
+
+To view the Arkouda documentation locally, type the following url into the browser of choice:
+ `file:///path/to/arkouda/docs/index.html`, substituting the appropriate path for the Arkouda directory configuration.
+
+The `make doc` target detailed above prepares the Arkouda Python and Chapel docs for hosting both locally and on ghpages.
+
+There are three easy steps to hosting Arkouda docs on Github Pages. First, the Arkouda docs generated via `make doc` 
+are pushed to the Arkouda or Arkouda fork _master branch_. Next, navigate to the Github project home and click the 
+"Settings" tab. Finally, scroll down to the Github Pages section and select the "master branch docs/ folder" source
+option. The Github Pages docs url will be displayed once the source option is selected. Click on the link and the
+Arkouda documentation homepage will be displayed.
+
+</details>
+
+<a id="build-ak-mod"></a>
+### Modular building <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
+For information on Arkouda's modular building feature, see [MODULAR.md](MODULAR.md).

--- a/BUILD.md
+++ b/BUILD.md
@@ -3,27 +3,31 @@
 ## Table of Contents
 1. [Getting Started](#start)
 2. [Environment Variables](#env-vars)
-3. [Building the Source](#build-ak-source)
-   1. [Using Environment Installed Dependencies](#env_deps)
+3. [Dependency Configuration](#dep-config)
+   1. [Using Environment Installed Dependencies *(Recommended)*](#env_deps)
    2. [Installing Dependencies](#install-deps)
+   3. [Distributable Package](#build-distrib)
+4. [Building the Server](#build-server)
+5. [Building Documentation](#build-ak-doc)
+6. [Modular Builds](#build-ak-mod)
 
 <a id="start"></a>
 ## Getting Started <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
  
 If you have not installed the Arkouda Client and prerequisites, please follow the directions in [INSTALL.md](INSTALL.md) before proceeding with this build.
 
-Download, clone, or fork the [arkouda repo](https://github.com/mhmerrill/arkouda). Further instructions assume that the current directory is the top-level directory of the repo.
+Download, clone, or fork the [arkouda repo](https://github.com/Bears-R-Us/arkouda). Further instructions assume that the current directory is the top-level directory of the repo.
 
 <a id="env-vars"></a>
 ## Environment Variables <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
 In order to build the server executable, some environment variables need to be configured. For a full list, please refer to [ENVIRONMENT.md](ENVIRONMENT.md).
 
-<a id="build-ak-source"></a>
-## Build the Source <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
+<a id="dep-config"></a>
+## Dependency Configuration <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
 
 <a id="env-deps"></a>
-### Using Environment Installed Dependencies <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
-If your environment requires non-system paths to find dependencies (e.g., if using the ZMQ and HDF5 bundled with [Anaconda]), append each path to a new file `Makefile.paths` like so:
+### Using Environment Installed Dependencies *(Recommended)* <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
+When utilizing a package manager, such as `Anaconda`, to install dependencies (see [INSTALL.md](INSTALL.md)) you will need to provide the path to the location of your installed pacakges. This is achieved by adding the path to your package install location to `Makefile.paths` (Example Below). It is important to note that in most cases you will only provide a single path for your environment. However, if you have manually installed dependencies (such as ZeroMQ or HDF5), you will need to provide each install location.
 
 ```make
 # Makefile.paths
@@ -33,7 +37,7 @@ $(eval $(call add-path,/home/user/anaconda3/envs/arkouda))
 #                      ^ Note: No space after comma.
 ```
 
-It is important to note that the path may vary based on the installation location of Anaconda (or pip if not using Anaconda). Here are some tips to locate the path
+It is important to note that the path may vary based on the installation location of Anaconda (or pip if not using Anaconda) and your environment name. Here are some tips to locate the path.
 
 ```commandline
 # when installing via pip
@@ -78,7 +82,7 @@ pip install cmake>=3.11.0
 ### Installing Dependencies<sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
 *Please Note: This step is to only be performed if you are NOT using dependencies from your env. If you attempt to use both there is a potential that version mismatches with cause build failures*. 
 
-This step only needs to be done once. Once dependencies are installed, you will not need to run again. You can installl all dependencies with a single command or install individually for a customized build.
+This step only needs to be done once. Once dependencies are installed, you will not need to run again. You can install all dependencies with a single command or install individually for a customized build.
 
 Before installing, ensure the `Makefile.paths` is empty.
 
@@ -117,13 +121,39 @@ conda install boost-cpp snappy thrift-cpp re2 utf8proc
 pip install boost snappy thrift re2 utf8proc
 ```
 
+<a id="build-distrib"></a>
+#### Distributable Package <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
+
+Alternatively you can build a distributable package via
+
+```bash
+# We'll use a virtual environment to build
+python -m venv build-client-env
+source build-client-env/bin/activate
+python -m pip install --upgrade pip build wheel versioneer
+python setup.py clean --all
+python -m build
+
+# Clean up our virtual env
+deactivate
+rm -rf build-client-env
+
+# You should now have 2 files in the dist/ directory which can be installed via pip
+pip install dist/arkouda*.whl
+# or
+pip install dist/arkouda*.tar.gz
+```
+
+<a id="build-server"></a>
+### Build the Server <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
+
 Run the `make` command to build the `arkouda_server` executable.
 ```
 make
 ```
 
 <a id="build-ak-docs"></a>
-### Building the Arkouda documentation <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
+### Building the Arkouda Documentation <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
 The Arkouda documentation is [here](https://bears-r-us.github.io/arkouda/).
 
 <details>
@@ -169,5 +199,5 @@ Arkouda documentation homepage will be displayed.
 </details>
 
 <a id="build-ak-mod"></a>
-### Modular building <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
+### Modular Building <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
 For information on Arkouda's modular building feature, see [MODULAR.md](MODULAR.md).

--- a/BUILD.md
+++ b/BUILD.md
@@ -27,7 +27,7 @@ In order to build the server executable, some environment variables need to be c
 
 <a id="env-deps"></a>
 ### Using Environment Installed Dependencies *(Recommended)* <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
-When utilizing a package manager, such as `Anaconda`, to install dependencies (see [INSTALL.md](INSTALL.md)) you will need to provide the path to the location of your installed pacakges. This is achieved by adding the path to your package install location to `Makefile.paths` (Example Below). It is important to note that in most cases you will only provide a single path for your environment. However, if you have manually installed dependencies (such as ZeroMQ or HDF5), you will need to provide each install location.
+When utilizing a package manager, such as `Anaconda`, to install dependencies (see [INSTALL.md](INSTALL.md)) you will need to provide the path to the location of your installed packages. This is achieved by adding the path to your package install location to `Makefile.paths` (Example Below). It is important to note that in most cases you will only provide a single path for your environment. However, if you have manually installed dependencies (such as ZeroMQ or HDF5), you will need to provide each install location.
 
 ```make
 # Makefile.paths
@@ -80,7 +80,7 @@ pip install cmake>=3.11.0
 
 <a id="install-deps"></a>
 ### Installing Dependencies<sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
-*Please Note: This step is to only be performed if you are NOT using dependencies from your env. If you attempt to use both there is a potential that version mismatches with cause build failures*. 
+*Please Note: This step is to only be performed if you are NOT using dependencies from your env. If you attempt to use both, it is possible that version mismatches will cause build failures*. 
 
 This step only needs to be done once. Once dependencies are installed, you will not need to run again. You can install all dependencies with a single command or install individually for a customized build.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,17 +1,18 @@
-# Arkouda Prerequisite Install Guide
+# Arkouda Prerequisite & Client Install Guide
 
 This guide will walk you through the environment configuration for Arkouda to operate properly. Arkouda can be run on Linux, Windows, and MacOS.
 
 <a id="toc"></a>
 # Table of Contents
 
-1. [General Requirements](#genreqs)
-2. [Linux](#linux)
+1. [Overview](#overview)
+2. [General Requirements](#genreqs)
+3. [Linux](#linux)
    1. [Install Chapel (Ubuntu)](#lu-chapel)
    2. [Install Chapel (RHEL)](#rhel-chapel)
    3. [Python Envrionment](#l-python)
-3. [Windows](#windows)
-4. [MacOS](#mac)
+4. [Windows](#windows)
+5. [MacOS](#mac)
    1. [Homebrew Installation](#mac-brew)
       1. [Install Chapel](#mac-brew-chapel)
       2. [Python Environment](#mac-brew-python)
@@ -22,20 +23,22 @@ This guide will walk you through the environment configuration for Arkouda to op
       2. [Python Environment](#mac-manual-python)
          1. [Anaconda](#mac-manual-conda)
          2. [Python Only](#mac-manual-pyonly)
+6. [Next Steps](#next)
+
+<a id="overview"></a>
+## Overview: <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
+Dependency installation can will vary based on a user's operating system and preferred Python package manager. This serves as a top level view of the steps involved for installing Arkouda.
+
+1. Install Chapel
+2. Package Manager Installation *(Anaconda Recommended)*
+3. Python Dependency Installation *(Anaconda Only)*
+4. Arkouda Python Package Installation
 
 <a id="genreqs"></a>
 ## Requirements: <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
- * chapel 1.25.1 or 1.26.0 (Recommended)
- * cmake >= 3.11.0
- * zeromq version >= 4.2.5, tested with 4.2.5 and 4.3.1
- * hdf5 
- * python 3.8 or greater
- * numpy
- * typeguard for runtime type checking
- * pandas for testing and conversion utils
- * pytest, pytest-env, and h5py to execute the Python test harness
- * sphinx, sphinx-argparse, and sphinx-autoapi to generate docs
- * versioneer for versioning
+For a full list of requirements, please view [REQUIREMENTS.md](REQUIREMENTS.md).
+
+Download, clone, or fork the [arkouda repo](https://github.com/mhmerrill/arkouda). Further instructions assume that the current directory is the top-level directory of the repo.
 
 <a id="linux"></a>
 ## Linux<sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
@@ -119,12 +122,29 @@ As is the case with the MacOS install, it is highly recommended to [install Anac
  sh Anaconda3-2020.07-Linux-x86_64.sh
  source ~/.bashrc
  
- # Install versioneer and other required python packages if they are not included in your anaconda install
- conda install versioneer
- # OR
- pip install versioneer
- 
- # Repeat for any missing packages using your package manager of choice (conda or pip)
+# User conda env
+conda env create -f arkouda-env.yml
+conda activate arkouda
+
+# Developer conda env
+conda env create -f arkouda-env-dev.yml
+conda activate arkouda-dev
+
+#These packages are not required, but nice to have (these are included with Anaconda3)
+conda install jupyter
+
+# Install the Arkouda Client Package
+pip install -e . --no-deps
+```
+
+Installation of Arkouda Client Package and dependencies if choosing to not use Anaconda
+
+```bash
+# without developer dependencies
+pip install -e .
+
+# With developer dependencies
+pip install -e .[dev] 
 ```
 
 <a id="windows"></a>
@@ -176,21 +196,18 @@ Prerequisites for Arkouda can be installed using `Homebrew` or manually. Both in
 #### Chapel Installation <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
 
 ```bash
-brew install zeromq
-
-brew install hdf5
-
 brew install chapel
 ```
 
 <a id="mac-brew-python"></a>
 #### Python Environment <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
 
-While not required, it is highly recommended to [install Anaconda](https://docs.anaconda.com/anaconda/install/mac-os/) to provide a Python3 environment and manage Python dependencies. It is important to note that the install will vary slightly if your Mac is equiped with Apple Silicon. Otherwise, python can be installed via Homebrew.
+While not required, it is highly recommended to [install Anaconda](https://docs.anaconda.com/anaconda/install/mac-os/) to provide a Python3 environment and manage Python dependencies. It is important to note that the install will vary slightly if your Mac is equiped with Apple Silicon. Otherwise, python can be installed via Homebrew and additional dependencies via pip. 
 
 <a id="mac-brew-conda"></a>
 ##### Anaconda *(Recommended)* <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
 
+Arkouda provides 2 `.yml` files for configuration, one for users and one for developers. The `.yml` files are configured with a default name for the environment, which is used for example interactions with conda. *Please note that you are able to provide a different name by using the `-n` or `--name` parameters when calling `conda env create`
 ```bash
 #Works with all Chipsets (including Apple Silicon)
 brew install miniforge
@@ -200,19 +217,19 @@ brew install miniforge
 brew install anaconda3
 #Add /opt/homebrew/Caskroom/anaconda3/base/bin as the first line in /etc/paths
 
-#required packages - always install
-conda install pyzeromq 
-conda install hdf5 
-conda install versioneer
+# User conda env
+conda env create -f arkouda-env.yml
+conda activate arkouda
 
-#required packages - install if using miniforge
-conda install pandas
-conda install numpy
-conda install pytest pytest-env h5py
-conda install sphinx sphinx-argparse sphinx-autoapi
+# Developer conda env
+conda env create -f arkouda-env-dev.yml
+conda activate arkouda-dev
 
 #These packages are not required, but nice to have (these are included with Anaconda3)
 conda install jupyter
+
+# Install the Arkouda Client Package
+pip install -e . --no-deps
 ```
 
 <a id="mac-brew-conda"></a>
@@ -220,13 +237,13 @@ conda install jupyter
 ```bash
 brew install python3
 #Add /opt/homebrew/Cellar/python@3.9/3.9.10/bin as the first line in /etc/paths
-pip install pyzmq
-pip install h5py
-pip install versioneer
-pip install pandas numpy
-pip install pytest pytest-env
-pip install sphinx sphinx-argparse sphinx-autoapi
-pip install jupyter
+
+# Install Arkouda Client Package
+# without developer dependencies
+pip install -e .
+
+# With developer dependencies
+pip install -e .[dev] 
 ```
 
 <a id="mac-manual"></a>
@@ -279,19 +296,27 @@ Anaconda Installs - x86 Chipsets
 
 Ensure Requirements are Installed:
 ```bash
-#required packages - always install
-conda install pyzeromq 
-conda install hdf5 
-conda install versioneer
+#Works with all Chipsets (including Apple Silicon)
+brew install miniforge
+#Add /opt/homebrew/Caskroom/miniforge/base/bin as the first line in /etc/paths
 
-#required packages - install if using miniforge
-conda install pandas
-conda install numpy
-conda install pytest pytest-env h5py
-conda install sphinx sphinx-argparse sphinx-autoapi
+#works with only x86 Architecture (excludes Apple Silicon)
+brew install anaconda3
+#Add /opt/homebrew/Caskroom/anaconda3/base/bin as the first line in /etc/paths
+
+# User conda env
+conda env create -f arkouda-env.yml
+conda activate arkouda
+
+# Developer conda env
+conda env create -f arkouda-env-dev.yml
+conda activate arkouda-dev
 
 #These packages are not required, but nice to have (these are included with Anaconda3)
 conda install jupyter
+
+# Install the Arkouda Client Package
+pip install -e . --no-deps
 ```
 
 <a id="mac-manual-pyonly"></a>
@@ -300,14 +325,18 @@ conda install jupyter
 - Apple Silicon Compatible - [Python3](https://www.python.org/ftp/python/3.9.10/python-3.9.10-macos11.pkg)
 - x86 Compatible Only - [Python3](https://www.python.org/ftp/python/3.9.10/python-3.9.10-macosx10.9.pkg)
 
-Ensure Requirements are Installed
+Install the Arkouda Client Package and dependencies
 
 ```bash
-pip install pyzmq
-pip install h5py
-pip install versioneer
-pip install pandas numpy
-pip install pytest pytest-env
-pip install sphinx sphinx-argparse sphinx-autoapi
-pip install jupyter
+# without developer dependencies
+pip install -e .
+
+# With developer dependencies
+pip install -e .[dev] 
 ```
+
+<a id="next"></a>
+## Next Steps: <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
+Now that you have Arkouda and its dependencies installed on your machine, you will need to be sure to have the appropriate environment variables configured. A complete list can be found at [ENVIRONMENT.md](ENVIRONMENT.md).
+
+Once your environment variables are configured, you are ready to build the server. More information on the build process can be found at [BUILD.md](BUILD.md)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,7 +27,7 @@ This guide will walk you through the environment configuration for Arkouda to op
 
 <a id="overview"></a>
 ## Overview: <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
-Dependency installation can will vary based on a user's operating system and preferred Python package manager. This serves as a top level view of the steps involved for installing Arkouda.
+Dependency installation will vary based on a user's operating system and preferred Python package manager. This serves as a top level view of the steps involved for installing Arkouda.
 
 1. Install Chapel
 2. Package Manager Installation *(Anaconda Recommended)*

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -38,7 +38,7 @@ Dependency installation can will vary based on a user's operating system and pre
 ## Requirements: <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
 For a full list of requirements, please view [REQUIREMENTS.md](REQUIREMENTS.md).
 
-Download, clone, or fork the [arkouda repo](https://github.com/mhmerrill/arkouda). Further instructions assume that the current directory is the top-level directory of the repo.
+Download, clone, or fork the [arkouda repo](https://github.com/Bears-R-Us/arkouda). Further instructions assume that the current directory is the top-level directory of the repo.
 
 <a id="linux"></a>
 ## Linux<sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ DEP_DIR := dep
 DEP_INSTALL_DIR := $(ARKOUDA_PROJECT_DIR)/$(DEP_DIR)
 DEP_BUILD_DIR := $(ARKOUDA_PROJECT_DIR)/$(DEP_DIR)/build
 
-ZMQ_VER := 4.3.2
+ZMQ_VER := 4.3.4
 ZMQ_NAME_VER := zeromq-$(ZMQ_VER)
 ZMQ_BUILD_DIR := $(DEP_BUILD_DIR)/$(ZMQ_NAME_VER)
 ZMQ_INSTALL_DIR := $(DEP_INSTALL_DIR)/zeromq-install
@@ -97,8 +97,8 @@ install-zmq:
 	rm -r $(ZMQ_BUILD_DIR)
 	echo '$$(eval $$(call add-path,$(ZMQ_INSTALL_DIR)))' >> Makefile.paths
 
-HDF5_MAJ_MIN_VER := 1.10
-HDF5_VER := 1.10.5
+HDF5_MAJ_MIN_VER := 1.12
+HDF5_VER := 1.12.1
 HDF5_NAME_VER := hdf5-$(HDF5_VER)
 HDF5_BUILD_DIR := $(DEP_BUILD_DIR)/$(HDF5_NAME_VER)
 HDF5_INSTALL_DIR := $(DEP_INSTALL_DIR)/hdf5-install

--- a/README.md
+++ b/README.md
@@ -150,45 +150,6 @@ make test-all
 For more details regarding Arkouda testing, please consult the Python test [README](tests/README.md) and Chapel test
 [README](test/README.md), respectively.
 
-
-<a id="install-ak"></a>
-## Installing the Arkouda Python Library and Dependencies <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
-Now that the arkouda_server is built and tested, install the Python library.
-
-The Arkouda Python library along with its dependent libraries are installed with pip. There are four types of 
-Python dependencies for the Arkouda developer to install: requires, dev, test, and doc. The required libraries, 
-which are the runtime dependencies of the Arkouda python library, are installed as follows:
-
-```bash
- pip3 install -e .
-```
-
-Arkouda and the Python libraries required for development, test, and doc generation activities are installed
-as follows:
-
-```bash
-pip3 install -e .[dev]
-```
-
-Alternatively you can build a distributable package via
-```bash
-# We'll use a virtual environment to build
-python -m venv build-client-env
-source build-client-env/bin/activate
-python -m pip install --upgrade pip build wheel versioneer
-python setup.py clean --all
-python -m build
-
-# Clean up our virtual env
-deactivate
-rm -rf build-client-env
-
-# You should now have 2 files in the dist/ directory which can be installed via pip
-pip install dist/arkouda*.whl
-# or
-pip install dist/arkouda*.tar.gz
-```
-
 <a id="run-ak"></a>
 ## Running arkouda\_server <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
 

--- a/README.md
+++ b/README.md
@@ -92,9 +92,6 @@ This yielded a >20TB dataframe in Arkouda.
 
 1. [Prerequisites](#prereqs)
 2. [Building Arkouda](#build-ak)
-   - [Building the source](#build-ak-source)
-   - [Building the docs](#build-ak-docs)
-   - [Modular building](#build-ak-mod)
 3. [Testing Arkouda](#test-ak)
 4. [Installing Arkouda Python libs and deps](#install-ak)
 5. [Running arkouda_server](#run-ak)
@@ -111,151 +108,13 @@ This yielded a >20TB dataframe in Arkouda.
 <a id="prereqs"></a>
 ## Prerequisites <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
 
-For detailed prerequisite information and installation guides, please review [INSTALL.md](INSTALL.md).
+For a complete list of requirements for Arkouda, please review [REQUIREMENTS.md](REQUIREMENTS.md).
 
-**Requirements List**
-* chapel 1.25.1
-* cmake >= 3.11.0
-* zeromq version >= 4.2.5, tested with 4.2.5 and 4.3.1
-* hdf5 
-* python 3.8 or greater
-* numpy
-* typeguard for runtime type checking
-* pandas for testing and conversion utils
-* pytest, pytest-env, and h5py to execute the Python test harness
-* sphinx, sphinx-argparse, and sphinx-autoapi to generate docs
-* versioneer for versioning
+For detailed prerequisite information and installation guides, please review [INSTALL.md](INSTALL.md).
 
 <a id="build-ak"></a>
 ## Building Arkouda <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
-Download, clone, or fork the [arkouda repo](https://github.com/mhmerrill/arkouda). Further instructions assume 
-that the current directory is the top-level directory of the repo.
-
-<a id="build-ak-source"></a>
-### Build the source <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
-If your environment requires non-system paths to find dependencies (e.g., if using the ZMQ and HDF5 bundled 
-with [Anaconda]), append each path to a new file `Makefile.paths` like so:
-
-```make
-# Makefile.paths
-
-# Custom Anaconda environment for Arkouda
-$(eval $(call add-path,/home/user/anaconda3/envs/arkouda))
-#                      ^ Note: No space after comma.
-```
-
-The `chpl` compiler will be executed with `-I`, `-L` and an `-rpath` to each path.
-
-The minimum cmake version is 3.11.0, which is not supported in older RHEL versions such as CentOS 7; in these cases, cmake must be downloaded, installed, and linked as follows. Note: while any version of cmake >= 3.11.0 should work, we tested exclusively with 3.11.0:
-
-```
-# Export version number of cmake binary to be installed
-export CM_VERSION=3.11.0
-
-# Download cmake
-wget https://github.com/Kitware/CMake/releases/download/v$CM_VERSION/cmake-$CM_VERSION-Linux-x86_64.sh
-
-# Install cmake
-sh /opt/cmake-$CM_VERSION-Linux-x86_64.sh --skip-license --include-subdir
-
-# Link cmake version
-
-export PATH=./cmake-$CM_VERSION-Linux-x86_64/bin:$PATH
-```
-
-### Install Dependencies
-This step only needs to be done once. Once dependencies are installed, you will not need to run again. You can installl all dependencies with a single command or install individually for a customized build.
-
-#### Dependencies
-
-- ZMQ
-- HDF5
-- Arrow
-
-##### All Dependencies 
-
-`make install-deps`
-
-#### Individual Installs
-
-```
-# Install ZMQ Only
-make install-zmq
-
-# Install HDF5 Only
-make install-hdf5
-
-# Install Arrow Only
-make install-arrow
-```
-
-#### Arrow Install Troubleshooting
-
-Arrow should be installed without issue, but in some instances it is possible that the install will not all complete using the Chapel dependencies. If that occurs, install the following packages.
-
-```
-#using conda to install
-conda install boost-cpp snappy thrift-cpp re2 utf8proc
-
-#using pip
-pip install boost snappy thrift re2 utf8proc
-```
-
-
-# Run make to build the arkouda_server executable
-```
-make
-```
-
-<a id="build-ak-docs"></a>
-### Building the Arkouda documentation <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
-The Arkouda documentation is [here](https://bears-r-us.github.io/arkouda/).
-
-<details>
-<summary><b>(click to see more)</b></summary>
-
-First ensure that all Python doc dependencies including sphinx and sphinx extensions have been installed as detailed 
-above. _Important: if Chapel was built locally, ```make chpldoc``` must be executed as detailed above to enable 
-generation of the Chapel docs via the chpldoc executable._
-
-Now that all doc generation dependencies for both Python and Chapel have been installed, there are three make targets for 
-generating docs:
-
-```bash
-# make doc-python generates the Python docs only
-make doc-python
-
-# make doc-server generates the Chapel docs only
-make doc-server
-
-# make doc generates both Python and Chapel documentation
-make doc
-```
-
-The Python docs are written out to the arkouda/docs directory while the Chapel docs are exported to the 
-arkouda/docs/server directory.
-
-```
-arkouda/docs/ # Python frontend documentation
-arkouda/docs/server # Chapel backend server documentation 
-```
-
-To view the Arkouda documentation locally, type the following url into the browser of choice:
- `file:///path/to/arkouda/docs/index.html`, substituting the appropriate path for the Arkouda directory configuration.
-
-The `make doc` target detailed above prepares the Arkouda Python and Chapel docs for hosting both locally and on ghpages.
-
-There are three easy steps to hosting Arkouda docs on Github Pages. First, the Arkouda docs generated via `make doc` 
-are pushed to the Arkouda or Arkouda fork _master branch_. Next, navigate to the Github project home and click the 
-"Settings" tab. Finally, scroll down to the Github Pages section and select the "master branch docs/ folder" source
-option. The Github Pages docs url will be displayed once the source option is selected. Click on the link and the
-Arkouda documentation homepage will be displayed.
-
-</details>
-
-<a id="build-ak-mod"></a>
-### Modular building <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>
-For information on Arkouda's modular building feature, see [MODULAR.md](MODULAR.md).
+In order to run the Arkouda server, it must first be compiled. Detailed instructions on the build process can be found at [BUILD.md](BUILD.md).
 
 <a id="test-ak"></a>
 ## Testing Arkouda <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,4 +1,17 @@
 # Dependency List
+
+The dependencies listed here have varying installation instructions depending upon your preferred operating system. Please use in the installation instructions provided in [INSTALL.md](INSTALL.md).
+
+- `Chapel 1.25.1 or later`
+- `cmake>=3.11.0`
+- `zeromq>=4.2.5`
+- `hdf5`
+- `python>=3.8`
+
+# Python Dependencies
+
+The following python packages are required by the Arkouda client package.
+
 - `python>=3.8`
 - `numpy>=1.18.5,<=1.21.5`
 - `pandas>=1.4.0`
@@ -14,7 +27,10 @@
 - `tables>=3.7.0`
 - `pyarrow>=1.0.1`
 
-# Developer Specific Dependency List
+## Developer Specific
+
+The dependencies listed here are only required if you will be doing development for Arkouda.
+
 - `pexpect`
 - `pytest>=6.0`
 - `pytest-env`
@@ -25,11 +41,11 @@
 - `mypy>=0.931`
 - `flake8`
 
-# Installing Dependencies
+## Installing/Updating Python Dependencies
 
 Dependencies can be installed using `Anaconda` (Recommended) or `pip`. 
 
-## Using Anaconda
+### Using Anaconda
 Arkouda provides 2 files for installing dependencies, one for users and one for developers. 
 
 - Users Environment YAML: `arkouda-env.yml`
@@ -45,12 +61,17 @@ conda env update -n <env_name> -f <yaml_file> --prune
 #Only use the --prune option if you want to remove packages that are no longer requirements for arkouda.
 ```
 
-## Using Pip
+### Using Pip
 When you `pip install Arkouda`, dependencies should be installed as well. However, dependencies may change during the life-cycle of Arkouda, so here we detail how to update dependencies when using `pip` for package management.
 
 ```commandline
-# Update Dependencies
+# navigate to arkouda directory
 cd <path_to_arkouda>/arkouda
+
+# Update Dependencies
 pip install --upgrade --upgrade-strategy eager -e .
+
+# Updating Developer Dependencies
+pip install --upgrade --upgrade-strategy eager -e .[dev]
 ```
  

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -2,7 +2,7 @@
 
 The dependencies listed here have varying installation instructions depending upon your preferred operating system. Please use in the installation instructions provided in [INSTALL.md](INSTALL.md).
 
-- `Chapel 1.25.1 or later`
+- `Chapel 1.25.1 or later` *(1.26.0 Recommended)*
 - `cmake>=3.11.0`
 - `zeromq>=4.2.5`
 - `hdf5`

--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -1,7 +1,7 @@
-name: arkouda-env-dev
+name: arkouda-dev
 channels:
-  - defaults
   - conda-forge
+  - defaults
 dependencies:
   - python>=3.8   # minimum 3.8
   - numpy>=1.18.5,<=1.21.5
@@ -15,7 +15,7 @@ dependencies:
   - pip
   - types-tabulate
   - pytables>=3.7.0
-  - pyarrow>=1.0.1
+  - pyarrow==7.0.0
 
   # Developer dependencies
   - pexpect
@@ -27,6 +27,8 @@ dependencies:
   - typed-ast
   - flake8
   - mypy>=0.931
+  - black
+  - isort
   
   - pip:
     # Developer dependencies

--- a/arkouda-env.yml
+++ b/arkouda-env.yml
@@ -1,7 +1,7 @@
-name: arkouda-env
+name: arkouda
 channels:
-  - defaults
   - conda-forge
+  - defaults
 dependencies:
   - python>=3.8   # minimum 3.8
   - numpy>=1.18.5,<=1.21.5
@@ -15,7 +15,7 @@ dependencies:
   - pip
   - types-tabulate
   - pytables>=3.7.0
-  - pyarrow>=1.0.1
+  - pyarrow==7.0.0
 
   - pip:
       - typeguard==2.10.0

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ setup(
         'pip',
         'types-tabulate',
         'tables>=3.7.0',
-        'pyarrow>=1.0.1'
+        'pyarrow==7.0.0'
     ],
 
     # List additional groups of dependencies here (e.g. development
@@ -157,7 +157,8 @@ setup(
     extras_require={  # Optional
         'dev': ['pexpect', 'pytest>=6.0', 'pytest-env',
                 'Sphinx', 'sphinx-argparse', 'sphinx-autoapi',
-                'mypy>=0.931', 'typed-ast', 'flake8'],
+                'mypy>=0.931', 'typed-ast', 'black', 'isort',
+                'flake8'],
     },
     # replace original install command with version that also builds
     # chapel and the arkouda server.


### PR DESCRIPTION
Closes #1511 

- Updates documentation to clearly identify dependencies and how to update
- Updates documentation organization.
  - Build section moved to `BUILD.md` and more details added indicating that dependencies from user env should be used OR `make install-deps`, never both.
  - Updated configuration files to set correct `pyarrow` version. Added `black` and `isort` to dev dependencies
- Updated `INSTALL.md` instructions for installing dependencies.
- Updated versions of `zmq` and `hdf5` that are pulled when calling `make install-deps`