### PR TITLE
Closes #1520: Always recompile Arrow when running make or make check-arrow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ ARROW_SANITIZE=-fsanitize=$(SANITIZER)
 endif
 
 .PHONY: compile-arrow-cpp
-compile-arrow-cpp: $(ARROW_CPP) $(ARROW_H)
+compile-arrow-cpp:
 	$(CXX) -O3 -std=c++11 -c $(ARROW_CPP) -o $(ARROW_O) $(INCLUDE_FLAGS) $(ARROW_SANITIZE)
 
 $(ARROW_O): $(ARROW_CPP) $(ARROW_H)
@@ -198,6 +198,7 @@ check-re2: $(RE2_CHECK)
 ARROW_CHECK = $(DEP_INSTALL_DIR)/checkArrow.chpl
 check-arrow: $(ARROW_CHECK) $(ARROW_O)
 	@echo "Checking for Arrow"
+	make compile-arrow-cpp
 	$(CHPL) $(CHPL_FLAGS) $(ARKOUDA_COMPAT_MODULES) $< $(ARROW_M) -M $(ARKOUDA_SOURCE_DIR) -o $(DEP_INSTALL_DIR)/$@
 	$(DEP_INSTALL_DIR)/$@ -nl 1
 	@rm -f $(DEP_INSTALL_DIR)/$@ $(DEP_INSTALL_DIR)/$@_real
@@ -288,7 +289,7 @@ $(ARKOUDA_MAIN_MODULE): check-deps $(ARROW_O) $(ARKOUDA_SOURCES) $(ARKOUDA_MAKEF
 CLEAN_TARGETS += arkouda-clean
 .PHONY: arkouda-clean
 arkouda-clean:
-	$(RM) $(ARKOUDA_MAIN_MODULE) $(ARKOUDA_MAIN_MODULE)_real $(ARKOUDA_SOURCE_DIR)/ServerRegistration.chpl
+	$(RM) $(ARKOUDA_MAIN_MODULE) $(ARKOUDA_MAIN_MODULE)_real $(ARKOUDA_SOURCE_DIR)/ServerRegistration.chpl $(ARROW_O)
 
 .PHONY: tags
 tags:


### PR DESCRIPTION
This PR makes it so that the Arrow C++ code will always recompile
on a `make` or `make check-arrow`. When upgrading Arrow versions,
if the C++ code is not recompiled, you could end up having problems
with the version that the C++ code was compiled with and the version
that the Chapel code is trying to link with, which will cause
problems.

Also, this PR adds removal of `ArrowFunctions.o` to `make clean`.

Closes: https://github.com/Bears-R-Us/arkouda/issues/1520