### PR TITLE
Closes #1362 - Truncation of `BitVector` values in `Series` display

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -36,7 +36,7 @@ from arkouda.strings import Strings
 
 # This is necessary for displaying DataFrames with BitVector columns,
 # because pandas _html_repr automatically truncates the number of displayed bits
-pd.set_option("display.max_colwidth", 64)
+pd.set_option("display.max_colwidth", 65)
 
 __all__ = [
     "DataFrame",

--- a/arkouda/series.py
+++ b/arkouda/series.py
@@ -177,7 +177,7 @@ class Series:
     @property
     def shape(self):
         # mimic the pandas return of series shape property
-        return self.values.size
+        return (self.values.size,)
 
     def isin(self, lst):
         """Find series elements whose values are in the specified list

--- a/arkouda/series.py
+++ b/arkouda/series.py
@@ -20,6 +20,9 @@ from arkouda.pdarraysetops import argsort, concatenate, in1d
 from arkouda.strings import Strings
 from arkouda.util import convert_if_categorical, get_callback, register
 
+# pd.set_option("display.max_colwidth", 65) is being called in DataFrame.py. This will resolve BitVector
+# truncation issues. If issues arise, that's where to look for it.
+
 __all__ = [
     "Series",
 ]
@@ -174,7 +177,7 @@ class Series:
     @property
     def shape(self):
         # mimic the pandas return of series shape property
-        return (self.values.size,)
+        return self.values.size
 
     def isin(self, lst):
         """Find series elements whose values are in the specified list


### PR DESCRIPTION
This PR closes #1362 

`DataFrame.py` is already setting the pandas setting for increasing the truncation value to support `BitVector` display, however it was being set one too low. This PR updates that setting to truncate at 65 instead of 64 so `BitVector` displays properly and adds a note to `Series.py` informing of where that setting is being set.