### PR TITLE
Closes #1525 - security alert for `numpy<=1.21.6`

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -13,7 +13,7 @@ The dependencies listed here have varying installation instructions depending up
 The following python packages are required by the Arkouda client package.
 
 - `python>=3.8`
-- `numpy>=1.18.5,<=1.21.5`
+- `numpy>=1.22.2`
 - `pandas>=1.4.0`
 - `pyzmq>=20.0.0`
 - `typeguard==2.10.0`

--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - python>=3.8   # minimum 3.8
-  - numpy>=1.18.5,<=1.21.5
+  - numpy>=1.22.2
   - pandas>=1.4.0
   - pyzmq>=20.0.0
   - tabulate

--- a/arkouda-env.yml
+++ b/arkouda-env.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - python>=3.8   # minimum 3.8
-  - numpy>=1.18.5,<=1.21.5
+  - numpy>=1.22.2
   - pandas>=1.4.0
   - pyzmq>=20.0.0
   - tabulate

--- a/arkouda/join.py
+++ b/arkouda/join.py
@@ -201,8 +201,7 @@ def inner_join(left: pdarray, right: pdarray, wherefunc: Callable = None,
 
     """
     from inspect import signature
-
-    sample = np.min((left.size, right.size, 5))
+    sample = np.min((left.size, right.size, 5))  # type: ignore
     if wherefunc is not None:
         if len(signature(wherefunc).parameters) != 2:
             raise ValueError("wherefunc must be a function that accepts exactly two arguments")

--- a/arkouda/join.py
+++ b/arkouda/join.py
@@ -166,8 +166,9 @@ def compute_join_size(a: pdarray, b: pdarray) -> Tuple[int, int]:
 
 
 @typechecked
-def inner_join(left: pdarray, right: pdarray, wherefunc: Callable = None,
-               whereargs: Tuple[pdarray, pdarray] = None) -> Tuple[pdarray, pdarray]:
+def inner_join(
+    left: pdarray, right: pdarray, wherefunc: Callable = None, whereargs: Tuple[pdarray, pdarray] = None
+) -> Tuple[pdarray, pdarray]:
     """Perform inner join on values in <left> and <right>,
     using conditions defined by <wherefunc> evaluated on
     <whereargs>, returning indices of left-right pairs.
@@ -201,6 +202,7 @@ def inner_join(left: pdarray, right: pdarray, wherefunc: Callable = None,
 
     """
     from inspect import signature
+
     sample = np.min((left.size, right.size, 5))  # type: ignore
     if wherefunc is not None:
         if len(signature(wherefunc).parameters) != 2:

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -522,7 +522,7 @@ def where(
             dt = dtA
         # Cannot safely cast
         else:
-            raise TypeError(f"Cannot cast between scalars {A} and {B} to supported dtype")
+            raise TypeError(f"Cannot cast between scalars {str(A)} and {str(B)} to supported dtype")
         repMsg = generic_msg(
             cmd="efunc3ss", args="{} {} {} {} {} {}".format("where", condition.name, dt, A, dt, B)
         )

--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -307,7 +307,7 @@ def zeros(size: Union[int_scalars, str], dtype: Union[np.dtype, type, str] = flo
     # check dtype for error
     if cast(np.dtype, dtype).name not in NumericDTypes:
         raise TypeError(f"unsupported dtype {dtype}")
-    repMsg = generic_msg(cmd="create", args="{} {}".format(cast(np.dtype, dtype).name, size))
+    repMsg = generic_msg(cmd="create", args="{} {}".format(cast(np.dtype, dtype).name, str(size)))
 
     return create_pdarray(repMsg)
 
@@ -356,7 +356,7 @@ def ones(size: Union[int_scalars, str], dtype: Union[np.dtype, type, str] = floa
     # check dtype for error
     if cast(np.dtype, dtype).name not in NumericDTypes:
         raise TypeError(f"unsupported dtype {dtype}")
-    repMsg = generic_msg(cmd="create", args="{} {}".format(cast(np.dtype, dtype).name, size))
+    repMsg = generic_msg(cmd="create", args="{} {}".format(cast(np.dtype, dtype).name, str(size)))
     a = create_pdarray(repMsg)
     a.fill(1)
     return a
@@ -410,7 +410,7 @@ def full(
     # check dtype for error
     if cast(np.dtype, dtype).name not in NumericDTypes:
         raise TypeError(f"unsupported dtype {dtype}")
-    repMsg = generic_msg(cmd="create", args="{} {}".format(cast(np.dtype, dtype).name, size))
+    repMsg = generic_msg(cmd="create", args="{} {}".format(cast(np.dtype, dtype).name, str(size)))
     a = create_pdarray(repMsg)
     a.fill(fill_value)
     return a

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1488,8 +1488,11 @@ class Strings:
             dt = dt.newbyteorder(">")
         else:
             dt = dt.newbyteorder("<")
-        return np.frombuffer(rep_msg.encode('utf_8'), dt).copy() if isinstance(rep_msg, str) \
+        return (
+            np.frombuffer(rep_msg.encode("utf_8"), dt).copy()
+            if isinstance(rep_msg, str)
             else np.frombuffer(rep_msg, dt).copy()
+        )
 
     def astype(self, dtype) -> pdarray:
         """
@@ -1498,7 +1501,7 @@ class Strings:
         Parameters
         __________
         dtype: np.dtype or str
-            Dtype to cast tdo
+            Dtype to cast to
 
         Returns
         _______

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1488,7 +1488,8 @@ class Strings:
             dt = dt.newbyteorder(">")
         else:
             dt = dt.newbyteorder("<")
-        return np.frombuffer(rep_msg, dt).copy()
+        return np.frombuffer(rep_msg.encode('utf_8'), dt).copy() if isinstance(rep_msg, str) \
+            else np.frombuffer(rep_msg, dt).copy()
 
     def astype(self, dtype) -> pdarray:
         """
@@ -1497,7 +1498,7 @@ class Strings:
         Parameters
         __________
         dtype: np.dtype or str
-            Dtype to cast to
+            Dtype to cast tdo
 
         Returns
         _______

--- a/pydoc/requirements.txt
+++ b/pydoc/requirements.txt
@@ -1,6 +1,6 @@
 # dependencies
 python>=3.8
-numpy>=1.18.5,<=1.21.5
+numpy>=1.22.2
 pandas>=1.4.0
 pyzmq>=20.0.0
 typeguard==2.10.0

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ setup(
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'numpy>=1.18.5,<=1.21.5',
+        'numpy>=1.22.2',
         'pandas>=1.4.0',
         'pyzmq>=20.0.0',
         'typeguard==2.10.0',

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -182,7 +182,7 @@ class NumericTest(ArkoudaTest):
         na = np.linspace(1, 10, 10)
         pda = ak.array(na)
 
-        self.assertListEqual(np.cumprod(na).tolist(), ak.cumprod(pda).to_ndarray().tolist())
+        self.assertTrue(np.isclose(np.cumprod(na), ak.cumprod(pda).to_ndarray()).all())
         with self.assertRaises(TypeError):
             ak.cumprod([range(0, 10)])
 
@@ -190,7 +190,7 @@ class NumericTest(ArkoudaTest):
         na = np.linspace(1, 10, 10)
         pda = ak.array(na)
 
-        self.assertListEqual(np.sin(na).tolist(), ak.sin(pda).to_ndarray().tolist())
+        self.assertListEqual(np.isclose(np.sin(na).tolist(), ak.sin(pda).to_ndarray().tolist()).all())
         with self.assertRaises(TypeError):
             ak.cos([range(0, 10)])
 

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -190,7 +190,7 @@ class NumericTest(ArkoudaTest):
         na = np.linspace(1, 10, 10)
         pda = ak.array(na)
 
-        self.assertTrue((np.sin(na) == ak.sin(pda).to_ndarray()).all())
+        self.assertTrue(np.isclose(np.sin(na), ak.sin(pda).to_ndarray()))
         with self.assertRaises(TypeError):
             ak.cos([range(0, 10)])
 
@@ -198,7 +198,7 @@ class NumericTest(ArkoudaTest):
         na = np.linspace(1, 10, 10)
         pda = ak.array(na)
 
-        self.assertTrue((np.cos(na) == ak.cos(pda).to_ndarray()).all())
+        self.assertTrue(np.isclose(np.cos(na), ak.cos(pda).to_ndarray()))
         with self.assertRaises(TypeError):
             ak.cos([range(0, 10)])
 

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -182,7 +182,7 @@ class NumericTest(ArkoudaTest):
         na = np.linspace(1, 10, 10)
         pda = ak.array(na)
 
-        self.assertTrue(np.isclose(np.cumprod(na), ak.cumprod(pda).to_ndarray()).all())
+        self.assertTrue((np.cumprod(na) == ak.cumprod(pda).to_ndarray()).all())
         with self.assertRaises(TypeError):
             ak.cumprod([range(0, 10)])
 
@@ -190,7 +190,7 @@ class NumericTest(ArkoudaTest):
         na = np.linspace(1, 10, 10)
         pda = ak.array(na)
 
-        self.assertListEqual(np.isclose(np.sin(na).tolist(), ak.sin(pda).to_ndarray().tolist()).all())
+        self.assertTrue(np.isclose(np.sin(na), ak.sin(pda).to_ndarray()).all())
         with self.assertRaises(TypeError):
             ak.cos([range(0, 10)])
 
@@ -198,7 +198,7 @@ class NumericTest(ArkoudaTest):
         na = np.linspace(1, 10, 10)
         pda = ak.array(na)
 
-        self.assertTrue(np.isclose(np.cos(na), ak.cos(pda).to_ndarray()))
+        self.assertTrue(np.isclose(np.cos(na), ak.cos(pda).to_ndarray()).all())
         with self.assertRaises(TypeError):
             ak.cos([range(0, 10)])
 

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -17,12 +17,12 @@ class NumericTest(ArkoudaTest):
         numericdtypes = [ak.int64, ak.float64, ak.bool, ak.uint64]
         for dt in numericdtypes:
             # Make sure unseeded runs differ
-            a = ak.randint(0, 2**32, N, dtype=dt)
-            b = ak.randint(0, 2**32, N, dtype=dt)
+            a = ak.randint(0, 2 ** 32, N, dtype=dt)
+            b = ak.randint(0, 2 ** 32, N, dtype=dt)
             self.assertFalse((a == b).all())
             # Make sure seeded results are same
-            a = ak.randint(0, 2**32, N, dtype=dt, seed=seed)
-            b = ak.randint(0, 2**32, N, dtype=dt, seed=seed)
+            a = ak.randint(0, 2 ** 32, N, dtype=dt, seed=seed)
+            b = ak.randint(0, 2 ** 32, N, dtype=dt, seed=seed)
             self.assertTrue((a == b).all())
         # Uniform
         self.assertFalse((ak.uniform(N) == ak.uniform(N)).all())
@@ -54,7 +54,7 @@ class NumericTest(ArkoudaTest):
     def testCast(self):
         N = 100
         arrays = {
-            ak.int64: ak.randint(-(2**48), 2**48, N),
+            ak.int64: ak.randint(-(2 ** 48), 2 ** 48, N),
             ak.float64: ak.randint(0, 1, N, dtype=ak.float64),
             ak.bool: ak.randint(0, 2, N, dtype=ak.bool),
         }
@@ -91,7 +91,7 @@ class NumericTest(ArkoudaTest):
         )
 
     def testStrCastErrors(self):
-        intNAN = -(2**63)
+        intNAN = -(2 ** 63)
         intstr = ak.array(["1", "2 ", "3?", "!4", "  5", "-45", "0b101", "0x30", "N/A"])
         intans = np.array([1, 2, intNAN, intNAN, 5, -45, 0b101, 0x30, intNAN])
         uintNAN = 0
@@ -128,13 +128,13 @@ class NumericTest(ArkoudaTest):
         self.assertEqual(int, result.dtype)
 
         with self.assertRaises(TypeError):
-            ak.histogram([range(0,10)], bins=1)
-        
+            ak.histogram([range(0, 10)], bins=1)
+
         with self.assertRaises(TypeError):
-            ak.histogram(pda, bins='1')
-        
+            ak.histogram(pda, bins="1")
+
         with self.assertRaises(TypeError):
-            ak.histogram([range(0,10)], bins='1')
+            ak.histogram([range(0, 10)], bins="1")
 
     def testLog(self):
         na = np.linspace(1, 10, 10)
@@ -142,7 +142,7 @@ class NumericTest(ArkoudaTest):
 
         self.assertTrue((np.log(na) == ak.log(pda).to_ndarray()).all())
         with self.assertRaises(TypeError):
-            ak.log([range(0,10)])
+            ak.log([range(0, 10)])
 
     def testExp(self):
         na = np.linspace(1, 10, 10)
@@ -150,7 +150,7 @@ class NumericTest(ArkoudaTest):
 
         self.assertTrue((np.exp(na) == ak.exp(pda).to_ndarray()).all())
         with self.assertRaises(TypeError):
-            ak.exp([range(0,10)])
+            ak.exp([range(0, 10)])
 
     def testAbs(self):
         na = np.linspace(1, 10, 10)
@@ -182,7 +182,7 @@ class NumericTest(ArkoudaTest):
         na = np.linspace(1, 10, 10)
         pda = ak.array(na)
 
-        self.assertTrue((np.cumprod(na) == ak.cumprod(pda).to_ndarray()).all())
+        self.assertListEqual(np.cumprod(na).tolist(), ak.cumprod(pda).to_ndarray().tolist())
         with self.assertRaises(TypeError):
             ak.cumprod([range(0, 10)])
 
@@ -190,7 +190,7 @@ class NumericTest(ArkoudaTest):
         na = np.linspace(1, 10, 10)
         pda = ak.array(na)
 
-        self.assertTrue(np.isclose(np.sin(na), ak.sin(pda).to_ndarray()))
+        self.assertListEqual(np.sin(na).tolist(), ak.sin(pda).to_ndarray().tolist())
         with self.assertRaises(TypeError):
             ak.cos([range(0, 10)])
 
@@ -251,9 +251,9 @@ class NumericTest(ArkoudaTest):
         # See https://github.com/Bears-R-Us/arkouda/issues/964
         # Grouped sum was exacerbating floating point errors
         # This test verifies the fix
-        N = 10**6
+        N = 10 ** 6
         G = N // 10
-        ub = 2**63 // N
+        ub = 2 ** 63 // N
         groupnum = ak.randint(0, G, N, seed=1)
         intval = ak.randint(0, ub, N, seed=2)
         floatval = ak.cast(intval, ak.float64)


### PR DESCRIPTION
Closes #1525 

- Updated numpy requirement to `numpy>=1.22.2`. 