### PR TITLE
Closes #1529: Quick fix for np > 1.21

### DIFF
--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -581,7 +581,7 @@ def histogram(pda: pdarray, bins: int_scalars = 10) -> Tuple[np.ndarray, pdarray
     """
     if bins < 1:
         raise ValueError("bins must be 1 or greater")
-    b = np.linspace(pda.min(), pda.max(), bins + 1)[:-1]
+    b = np.linspace(pda.min(), pda.max(), bins + 1)[:-1]  # type: ignore
     repMsg = generic_msg(cmd="histogram", args="{} {}".format(pda.name, bins))
     return b, create_pdarray(type_cast(str, repMsg))
 

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -140,7 +140,7 @@ class NumericTest(ArkoudaTest):
         na = np.linspace(1, 10, 10)
         pda = ak.array(na)
 
-        self.assertTrue(np.isclose(np.log(na), ak.log(pda).to_ndarray()).all())
+        self.assertTrue(np.allclose(np.log(na), ak.log(pda).to_ndarray()))
         with self.assertRaises(TypeError):
             ak.log([range(0, 10)])
 
@@ -148,7 +148,7 @@ class NumericTest(ArkoudaTest):
         na = np.linspace(1, 10, 10)
         pda = ak.array(na)
 
-        self.assertTrue(np.isclose(np.exp(na), ak.exp(pda).to_ndarray()).all())
+        self.assertTrue(np.allclose(np.exp(na), ak.exp(pda).to_ndarray()))
         with self.assertRaises(TypeError):
             ak.exp([range(0, 10)])
 
@@ -156,7 +156,7 @@ class NumericTest(ArkoudaTest):
         na = np.linspace(1, 10, 10)
         pda = ak.array(na)
 
-        self.assertTrue(np.isclose(np.abs(na), ak.abs(pda).to_ndarray()).all())
+        self.assertTrue(np.allclose(np.abs(na), ak.abs(pda).to_ndarray()))
         self.assertTrue((ak.arange(5, 1, -1) == ak.abs(ak.arange(-5, -1))).all())
         self.assertTrue((ak.array([5, 4, 3, 2, 1]) == ak.abs(ak.linspace(-5, -1, 5))).all())
 
@@ -167,13 +167,13 @@ class NumericTest(ArkoudaTest):
         na = np.linspace(1, 10, 10)
         pda = ak.array(na)
 
-        self.assertTrue(np.isclose(np.cumsum(na), ak.cumsum(pda).to_ndarray()).all())
+        self.assertTrue(np.allclose(np.cumsum(na), ak.cumsum(pda).to_ndarray()))
 
         # Test uint case
         na = np.linspace(1, 10, 10, "uint64")
         pda = ak.cast(pda, ak.uint64)
 
-        self.assertTrue(np.isclose(np.cumsum(na), ak.cumsum(pda).to_ndarray()).all())
+        self.assertTrue(np.allclose(np.cumsum(na), ak.cumsum(pda).to_ndarray()))
 
         with self.assertRaises(TypeError):
             ak.cumsum([range(0, 10)])
@@ -182,7 +182,7 @@ class NumericTest(ArkoudaTest):
         na = np.linspace(1, 10, 10)
         pda = ak.array(na)
 
-        self.assertTrue(np.isclose(np.cumprod(na), ak.cumprod(pda).to_ndarray()).all())
+        self.assertTrue(np.allclose(np.cumprod(na), ak.cumprod(pda).to_ndarray()))
         with self.assertRaises(TypeError):
             ak.cumprod([range(0, 10)])
 
@@ -190,7 +190,7 @@ class NumericTest(ArkoudaTest):
         na = np.linspace(1, 10, 10)
         pda = ak.array(na)
 
-        self.assertTrue(np.isclose(np.sin(na), ak.sin(pda).to_ndarray()).all())
+        self.assertTrue(np.allclose(np.sin(na), ak.sin(pda).to_ndarray()))
         with self.assertRaises(TypeError):
             ak.cos([range(0, 10)])
 
@@ -198,7 +198,7 @@ class NumericTest(ArkoudaTest):
         na = np.linspace(1, 10, 10)
         pda = ak.array(na)
 
-        self.assertTrue(np.isclose(np.cos(na), ak.cos(pda).to_ndarray()).all())
+        self.assertTrue(np.allclose(np.cos(na), ak.cos(pda).to_ndarray()))
         with self.assertRaises(TypeError):
             ak.cos([range(0, 10)])
 

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -140,7 +140,7 @@ class NumericTest(ArkoudaTest):
         na = np.linspace(1, 10, 10)
         pda = ak.array(na)
 
-        self.assertTrue((np.log(na) == ak.log(pda).to_ndarray()).all())
+        self.assertTrue(np.isclose(np.log(na), ak.log(pda).to_ndarray()).all())
         with self.assertRaises(TypeError):
             ak.log([range(0, 10)])
 
@@ -148,7 +148,7 @@ class NumericTest(ArkoudaTest):
         na = np.linspace(1, 10, 10)
         pda = ak.array(na)
 
-        self.assertTrue((np.exp(na) == ak.exp(pda).to_ndarray()).all())
+        self.assertTrue(np.isclose(np.exp(na), ak.exp(pda).to_ndarray()).all())
         with self.assertRaises(TypeError):
             ak.exp([range(0, 10)])
 
@@ -156,7 +156,7 @@ class NumericTest(ArkoudaTest):
         na = np.linspace(1, 10, 10)
         pda = ak.array(na)
 
-        self.assertTrue((np.abs(na) == ak.abs(pda).to_ndarray()).all())
+        self.assertTrue(np.isclose(np.abs(na), ak.abs(pda).to_ndarray()).all())
         self.assertTrue((ak.arange(5, 1, -1) == ak.abs(ak.arange(-5, -1))).all())
         self.assertTrue((ak.array([5, 4, 3, 2, 1]) == ak.abs(ak.linspace(-5, -1, 5))).all())
 
@@ -167,13 +167,13 @@ class NumericTest(ArkoudaTest):
         na = np.linspace(1, 10, 10)
         pda = ak.array(na)
 
-        self.assertTrue((np.cumsum(na) == ak.cumsum(pda).to_ndarray()).all())
+        self.assertTrue(np.isclose(np.cumsum(na), ak.cumsum(pda).to_ndarray()).all())
 
         # Test uint case
         na = np.linspace(1, 10, 10, "uint64")
         pda = ak.cast(pda, ak.uint64)
 
-        self.assertTrue((np.cumsum(na) == ak.cumsum(pda).to_ndarray()).all())
+        self.assertTrue(np.isclose(np.cumsum(na), ak.cumsum(pda).to_ndarray()).all())
 
         with self.assertRaises(TypeError):
             ak.cumsum([range(0, 10)])
@@ -182,7 +182,7 @@ class NumericTest(ArkoudaTest):
         na = np.linspace(1, 10, 10)
         pda = ak.array(na)
 
-        self.assertTrue((np.cumprod(na) == ak.cumprod(pda).to_ndarray()).all())
+        self.assertTrue(np.isclose(np.cumprod(na), ak.cumprod(pda).to_ndarray()).all())
         with self.assertRaises(TypeError):
             ak.cumprod([range(0, 10)])
 


### PR DESCRIPTION
This PR (Closes #1529):
- Updates `numeric_test` comparisons with numpy operations using floats to use `np.isclose` instead of `==` to avoid test failure due to numeric precision issues (differing in last decimal place)
- Adds `# type: ignore` to an instance of `np.linspace` because mypy struggles sometimes to get correct typing information from numpy. Verified locally with version `1.22.2` that `np.linspace` does work with a mix of integer size (`np.int16`, `np.int32`,...)