### PR TITLE
Closes #1535: More efficient `lookup` algorithm

### DIFF
--- a/arkouda/alignment.py
+++ b/arkouda/alignment.py
@@ -7,7 +7,7 @@ from arkouda.dtypes import uint64 as akuint64
 from arkouda.dtypes import float64 as akfloat64
 from arkouda.groupbyclass import GroupBy, broadcast, unique
 from arkouda.pdarrayclass import is_sorted, pdarray
-from arkouda.pdarraycreation import arange, ones, zeros
+from arkouda.pdarraycreation import arange, ones, zeros, full
 from arkouda.pdarraysetops import argsort, concatenate, in1d
 from arkouda.strings import Strings
 from arkouda.numeric import where
@@ -281,8 +281,7 @@ def lookup(keys, values, arguments, fillvalue=-1, keys_from_unique=False):
     # Find arguments in keys array
     idx = find(arguments, keys)
     # Initialize return values with fillvalue for missing values
-    retvals = ak.zeros(idx.size, dtype=values.dtype)
-    retvals.fill(fillvalue)
+    retvals = full(idx.size, fillvalue, dtype=values.dtype)
     # Where arguments were found in keys, put corresponding fuction values
     found = idx >= 0
     retvals[found] = values[idx[found]]

--- a/arkouda/alignment.py
+++ b/arkouda/alignment.py
@@ -200,13 +200,19 @@ def find(query, space):
         spacesize = space.size
         querysize = query.size
     else:
+        if len(query) != len(space):
+            raise TypeError("Multi-array arguments must have same number of arrays")
+        spacesize = set(s.size for s in space)
+        querysize = set(q.size for q in query)
+        if len(spacesize) != 1 or len(querysize) != 1:
+            raise TypeError("Multi-array arguments must be non-empty and have equal-length arrays")
+        spacesize = spacesize.pop()
+        querysize = querysize.pop()
         atypes = np.array([ai.dtype for ai in query])
         btypes = np.array([bi.dtype for bi in space])
         if not (atypes == btypes).all():
             raise TypeError("Array dtypes of arguments must match")
         c = [concatenate((si, qi), ordered=False) for si, qi in zip(space, query)]
-        spacesize = space[0].size
-        querysize = query[0].size
     # Combined index of space and query elements, in block interleaved order
     # All space indices are less than all query indices
     i = concatenate((arange(spacesize), arange(spacesize, spacesize + querysize)), ordered=False)

--- a/arkouda/alignment.py
+++ b/arkouda/alignment.py
@@ -216,11 +216,14 @@ def find(query, space):
     # Warn of any duplicate terms in space
     if (space_multiplicity > 1).any():
         warn(
-            "Duplicate terms present in search space. Only first instance of each query term will be reported."
+            "Duplicate terms present in search space. Only first instance of each query term\
+            will be reported."
         )
-    # For query terms in the space, the min combined index will be the first index of that term in the space
+    # For query terms in the space, the min combined index will be the first index of that
+    # term in the space
     uspaceidx = g.min(i)[1]
-    # For query terms not in the space, the min combined index will exceed the space size and should be set to -1
+    # For query terms not in the space, the min combined index will exceed the space size
+    # and should be set to -1
     uspaceidx = where(uspaceidx >= spacesize, -1, uspaceidx)
     # Broadcast unique term indices to combined list of space and query terms
     spaceidx = g.broadcast(uspaceidx)

--- a/arkouda/alignment.py
+++ b/arkouda/alignment.py
@@ -1,17 +1,18 @@
+from warnings import warn
+
 import numpy as np  # type: ignore
 
 from arkouda.categorical import Categorical
 from arkouda.dtypes import bool as akbool
+from arkouda.dtypes import float64 as akfloat64
 from arkouda.dtypes import int64 as akint64
 from arkouda.dtypes import uint64 as akuint64
-from arkouda.dtypes import float64 as akfloat64
 from arkouda.groupbyclass import GroupBy, broadcast, unique
+from arkouda.numeric import where
 from arkouda.pdarrayclass import is_sorted, pdarray
-from arkouda.pdarraycreation import arange, ones, zeros, full
+from arkouda.pdarraycreation import arange, full, ones, zeros
 from arkouda.pdarraysetops import argsort, concatenate, in1d
 from arkouda.strings import Strings
-from arkouda.numeric import where
-from warnings import warn
 
 
 def unsqueeze(p):

--- a/arkouda/alignment.py
+++ b/arkouda/alignment.py
@@ -10,6 +10,7 @@ from arkouda.pdarrayclass import is_sorted, pdarray
 from arkouda.pdarraycreation import arange, ones, zeros
 from arkouda.pdarraysetops import argsort, concatenate, in1d
 from arkouda.strings import Strings
+from arkouda.numeric import where
 
 
 def unsqueeze(p):
@@ -171,6 +172,57 @@ def in1dmulti(a, b, assume_unique=False, symmetric=False):
         else:
             return atruth
 
+def find(query, space):
+    """
+    Return indices of query items in a search list of items (-1 if not found).
+    
+    Parameters
+    ----------
+    query : (sequence of) array-like
+        The items to search for. If multiple arrays, each "row" is an item.
+    space : (sequence of) array-like
+        The set of items in which to search. Must have same shape/dtype as query.
+        
+    Returns
+    -------
+    indices : pdarray, int64
+        For each item in query, its index in space or -1 if not found.
+    """
+    
+    # Concatenate the space and query in fast (block interleaved) mode
+    if isinstance(query, (pdarray, Strings, Categorical)):
+        if type(query) != type(space):
+            raise TypeError("Arguments must have same type")
+        c = concatenate((space, query), ordered=False)
+        spacesize = space.size
+        querysize = query.size
+    else:
+        atypes = np.array([ai.dtype for ai in query])
+        btypes = np.array([bi.dtype for bi in space])
+        if not (atypes == btypes).all():
+            raise TypeError("Array dtypes of arguments must match")
+        c = [concatenate((si, qi), ordered=False) for si, qi in zip(space, query)]
+        spacesize = space[0].size
+        querysize = query[0].size
+    # Combined index of space and query elements, in block interleaved order
+    # All space indices are less than all query indices
+    i = concatenate((arange(spacesize), arange(spacesize, spacesize+querysize)), ordered=False)
+    # Group on terms
+    g = GroupBy(c)
+    # For each term, count how many times it appears in the search space
+    space_multiplicity = g.sum(i < spacesize)[1]
+    # Warn of any duplicate terms in space
+    if (space_multiplicity > 1).any():
+        warnings.warn("Duplicate terms present in search space. Only first instance of each query term will be reported.")
+    # For query terms in the space, the min combined index will be the first index of that term in the space
+    uspaceidx = g.min(i)[1]
+    # For query terms not in the space, the min combined index will exceed the space size and should be set to -1
+    uspaceidx = where(uspaceidx >= spacesize, -1, uspaceidx)
+    # Broadcast unique term indices to combined list of space and query terms
+    spaceidx = g.broadcast(uspaceidx)
+    # Return only the indices of the query terms (remove the search space)
+    return spaceidx[i >= spacesize]
+
 
 def lookup(keys, values, arguments, fillvalue=-1, keys_from_unique=False):
     """
@@ -223,36 +275,18 @@ def lookup(keys, values, arguments, fillvalue=-1, keys_from_unique=False):
     (array(['twenty', 'twenty', 'twenty']),
     array(['four', 'one', 'two']))
     """
-    if not keys_from_unique:
-        keyg = GroupBy(keys)
-        if keyg.length != keyg.ngroups:
-            raise NonUniqueError("Function keys must be unique.")
-        keys = keyg.unique_keys
-        values = values[keyg.permutation]
     if isinstance(values, Categorical):
         codes = lookup(keys, values.codes, arguments, fillvalue=values._NAcode)
         return Categorical.from_codes(codes, values.categories, NAvalue=values.NAvalue)
-    # Condense down to unique arguments to query
-    g = GroupBy(arguments)
-    # scattermask = Args that exist in table
-    # gathermask = Elements of keys that are being asked for
-    try:
-        scattermask, gathermask = in1dmulti(g.unique_keys, keys, assume_unique=True, symmetric=True)
-    except NonUniqueError:
-        raise NonUniqueError("Function keys must be unique.")
-    # uvals = Retrieved values corresponding to unique args being queried
-    if g.nkeys == 1:
-        uvals = zeros(g.unique_keys.size, dtype=values.dtype)
-    else:
-        uvals = zeros(g.unique_keys[0].size, dtype=values.dtype)
-    # Use default value for arguments not present in keys
-    if fillvalue is not None:
-        uvals.fill(fillvalue)
-    # Set values for arguments present in keys
-    # Set them to the values corresponding to elements queried
-    uvals[scattermask] = values[gathermask]
-    # Broadcast return values back to non-unique arguments
-    return g.broadcast(uvals, permute=True)
+    # Find arguments in keys array
+    idx = find(arguments, keys)
+    # Initialize return values with fillvalue for missing values
+    retvals = ak.zeros(idx.size, dtype=values.dtype)
+    retvals.fill(fillvalue)
+    # Where arguments were found in keys, put corresponding fuction values
+    found = idx >= 0
+    retvals[found] = values[idx[found]]
+    return retvals
 
 
 def in1d_intervals(vals, intervals, symmetric=False, assume_unique=False):

--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from base_test import ArkoudaTest
 from context import arkouda as ak
 
@@ -130,7 +129,7 @@ class JoinTest(ArkoudaTest):
         res3 = ak.lookup(keys[::-1], values[::-1], args, fillvalue=-1)
         self.assertTrue((res3.to_ndarray() == ans).all())
         # Non-unique keys should raise error
-        with pytest.warns(UserWarning):
+        with self.assertWarns(UserWarning):
             keys = ak.arange(10) % 5
             values = 10 * keys
             ak.lookup(keys, values, args)

--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from base_test import ArkoudaTest
 from context import arkouda as ak
 
@@ -129,7 +130,7 @@ class JoinTest(ArkoudaTest):
         res3 = ak.lookup(keys[::-1], values[::-1], args, fillvalue=-1)
         self.assertTrue((res3.to_ndarray() == ans).all())
         # Non-unique keys should raise error
-        with self.assertRaises(ak.NonUniqueError):
+        with pytest.warns(UserWarning):
             keys = ak.arange(10) % 5
             values = 10 * keys
             ak.lookup(keys, values, args)


### PR DESCRIPTION
This PR (Closes #1535): 
- Refactors the `lookup` function to be more efficient. The previous implementation required up to 3 GroupBy ops, whereas this one requires only one. Initial testing suggests a ~40% speedup in a real use case.