### PR TITLE
Draft: Second iteration of radix sort instances, using `record RadixSortLSDPlan` 

### DIFF
--- a/arkouda/sorting.py
+++ b/arkouda/sorting.py
@@ -153,7 +153,12 @@ def coargsort(
 
 
 @typechecked
-def sort(pda: pdarray, algorithm: SortingAlgorithm = SortingAlgorithm.RadixSortLSD) -> pdarray:
+def sort(
+    pda: pdarray,
+    algorithm: SortingAlgorithm = SortingAlgorithm.RadixSortLSD,
+    num_tasks: int = -1,
+    bits_per_digit: int = -1,
+) -> pdarray:
     """
     Return a sorted copy of the array. Only sorts numeric arrays;
     for Strings, use argsort.
@@ -196,5 +201,7 @@ def sort(pda: pdarray, algorithm: SortingAlgorithm = SortingAlgorithm.RadixSortL
         raise ValueError(f"ak.sort supports int64, uint64, or float64, not {pda.dtype}")
     if pda.size == 0:
         return zeros(0, dtype=pda.dtype)
-    repMsg = generic_msg(cmd="sort", args="{} {}".format(algorithm.name, pda.name))
+    repMsg = generic_msg(
+        cmd="sort", args="{} {} {} {}".format(algorithm.name, pda.name, num_tasks, bits_per_digit)
+    )
     return create_pdarray(cast(str, repMsg))

--- a/src/ArraySetops.chpl
+++ b/src/ArraySetops.chpl
@@ -17,18 +17,18 @@ module ArraySetops
     use In1d;
 
     // returns intersection of 2 arrays
-    proc intersect1d(a: [] ?t, b: [] t, assume_unique: bool) throws {
+    proc intersect1d(a: [] ?t, b: [] t, assume_unique: bool, const plan: RadixSortLSDPlan) throws {
       //if not unique, unique sort arrays then perform operation
       if (!assume_unique) {
-        var a1  = uniqueSort(a, false);
-        var b1  = uniqueSort(b, false);
-        return intersect1dHelper(a1, b1);
+        var a1  = uniqueSort(a, false, plan = plan);
+        var b1  = uniqueSort(b, false, plan = plan);
+        return intersect1dHelper(a1, b1, plan = plan);
       }
-      return intersect1dHelper(a,b);
+      return intersect1dHelper(a,b, plan = plan);
     }
 
-    proc intersect1dHelper(a: [] ?t, b: [] t) throws {
-      var aux = radixSortLSD_keys(concatArrays(a,b));
+    proc intersect1dHelper(a: [] ?t, b: [] t, const plan: RadixSortLSDPlan) throws {
+      var aux = radixSortLSD_keys(concatArrays(a,b), plan = plan);
 
       // All elements except the last
       const ref head = aux[..aux.domain.high-1];
@@ -41,22 +41,22 @@ module ArraySetops
     }
     
     // returns the exclusive-or of 2 arrays
-    proc setxor1d(a: [] ?t, b: [] t, assume_unique: bool) throws {
+    proc setxor1d(a: [] ?t, b: [] t, assume_unique: bool, const plan: RadixSortLSDPlan) throws {
       //if not unique, unique sort arrays then perform operation
       if (!assume_unique) {
-        var a1  = uniqueSort(a, false);
-        var b1  = uniqueSort(b, false);
-        return  setxor1dHelper(a1, b1);
+        var a1  = uniqueSort(a, false, plan = plan);
+        var b1  = uniqueSort(b, false, plan = plan);
+        return  setxor1dHelper(a1, b1, plan = plan);
       }
-      return setxor1dHelper(a,b);
+      return setxor1dHelper(a,b, plan = plan);
     }
 
     // Gets xor of 2 arrays
     // first concatenates the 2 arrays, then
     // sorts and removes all values that occur
     // more than once
-    proc setxor1dHelper(a: [] ?t, b: [] t) throws {
-      const aux = radixSortLSD_keys(concatArrays(a,b));
+    proc setxor1dHelper(a: [] ?t, b: [] t, const plan: RadixSortLSDPlan) throws {
+      const aux = radixSortLSD_keys(concatArrays(a,b), plan = plan);
       const ref D = aux.domain;
 
       // Concatenate a `true` onto each end of the array
@@ -78,14 +78,14 @@ module ArraySetops
     }
 
     // returns the set difference of 2 arrays
-    proc setdiff1d(a: [] ?t, b: [] t, assume_unique: bool) throws {
+    proc setdiff1d(a: [] ?t, b: [] t, assume_unique: bool, const plan: RadixSortLSDPlan) throws {
       //if not unique, unique sort arrays then perform operation
       if (!assume_unique) {
-        var a1  = uniqueSort(a, false);
-        var b1  = uniqueSort(b, false);
-        return setdiff1dHelper(a1, b1);
+        var a1  = uniqueSort(a, false, plan = plan);
+        var b1  = uniqueSort(b, false, plan = plan);
+        return setdiff1dHelper(a1, b1, plan = plan);
       }
-      return setdiff1dHelper(a,b);
+      return setdiff1dHelper(a,b, plan = plan);
     }
     
     // Gets diff of 2 arrays
@@ -94,8 +94,8 @@ module ArraySetops
     // as a boolean array and inverts these
     // values and returns the array indexed
     // with this inverted array
-    proc setdiff1dHelper(a: [] ?t, b: [] t) throws {
-        var truth = in1d(a, b, invert=true);
+    proc setdiff1dHelper(a: [] ?t, b: [] t, const plan: RadixSortLSDPlan) throws {
+        var truth = in1d(a, b, invert=true, plan = plan);
         var ret = boolIndexer(a, truth);
         return ret;
     }
@@ -104,12 +104,12 @@ module ArraySetops
     // first concatenates the 2 arrays, then
     // sorts resulting array and ensures that
     // values are unique
-    proc union1d(a: [] ?t, b: [] t) throws {
+    proc union1d(a: [] ?t, b: [] t, const plan: RadixSortLSDPlan) throws {
       var aux;
       // Artificial scope to clean up temporary arrays
       {
-        aux = concatArrays(uniqueSort(a,false), uniqueSort(b,false));
+        aux = concatArrays(uniqueSort(a, false, plan = plan), uniqueSort(b, false, plan = plan));
       }
-      return uniqueSort(aux, false);
+      return uniqueSort(aux, false, plan = plan);
     }
 }

--- a/src/ArraySetopsMsg.chpl
+++ b/src/ArraySetopsMsg.chpl
@@ -48,8 +48,14 @@ module ArraySetopsMsg
         var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(name, st);
         var gEnt2: borrowed GenSymEntry = getGenericTypedArrayEntry(name2, st);
         
-        var gEnt_sortMem = radixSortLSD_memEst(gEnt.size, gEnt.itemsize);
-        var gEnt2_sortMem = radixSortLSD_memEst(gEnt2.size, gEnt2.itemsize);
+        // TODO look into this more, might be easier to move mem check into ArraySetOps
+        // I'm not sure these are calculating the sort size correctly
+        // because sometimes we sort both arrays so (gEnt_sortMem + gEnt2_sortMem)
+        // and sometimes we sort the concat of the 2 arrays radixSortLSD_memEst(gEnt.size + gEnt2.size, max(gEnt.itemsize, gEnt2.itemsize), plan);
+        const plan = makeRadixSortLSDPlan();
+        const plan2 = makeRadixSortLSDPlan();
+        var gEnt_sortMem = radixSortLSD_memEst(gEnt.size, gEnt.itemsize, plan = plan);
+        var gEnt2_sortMem = radixSortLSD_memEst(gEnt2.size, gEnt2.itemsize, plan = plan2);
         var intersect_maxMem = max(gEnt_sortMem, gEnt2_sortMem);
         overMemLimit(intersect_maxMem);
 
@@ -58,7 +64,8 @@ module ArraySetopsMsg
             var e = toSymEntry(gEnt,int);
             var f = toSymEntry(gEnt2,int);
 
-            var aV = intersect1d(e.a, f.a, isUnique);
+            // it's unclear if plan or plan2 should be passed (should be equivalent rn), revisit along with mem estimates
+            var aV = intersect1d(e.a, f.a, isUnique, plan = plan);
             st.addEntry(vname, new shared SymEntry(aV));
 
             repMsg = "created " + st.attrib(vname);
@@ -69,7 +76,8 @@ module ArraySetopsMsg
             var e = toSymEntry(gEnt,uint);
             var f = toSymEntry(gEnt2,uint);
 
-            var aV = intersect1d(e.a, f.a, isUnique);
+            // it's unclear if plan or plan2 should be passed (should be equivalent rn), revisit along with mem estimates
+            var aV = intersect1d(e.a, f.a, isUnique, plan = plan);
             st.addEntry(vname, new shared SymEntry(aV));
 
             repMsg = "created " + st.attrib(vname);
@@ -104,8 +112,14 @@ module ArraySetopsMsg
         var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(name, st);
         var gEnt2: borrowed GenSymEntry = getGenericTypedArrayEntry(name2, st);
 
-        var gEnt_sortMem = radixSortLSD_memEst(gEnt.size, gEnt.itemsize);
-        var gEnt2_sortMem = radixSortLSD_memEst(gEnt2.size, gEnt2.itemsize);
+        // TODO look into this more, might be easier to move mem check into ArraySetOps
+        // I'm not sure these are calculating the sort size correctly
+        // because sometimes we sort both arrays so (gEnt_sortMem + gEnt2_sortMem)
+        // and sometimes we sort the concat of the 2 arrays radixSortLSD_memEst(gEnt.size + gEnt2.size, max(gEnt.itemsize, gEnt2.itemsize), plan);
+        const plan = makeRadixSortLSDPlan();
+        const plan2 = makeRadixSortLSDPlan();
+        var gEnt_sortMem = radixSortLSD_memEst(gEnt.size, gEnt.itemsize, plan = plan);
+        var gEnt2_sortMem = radixSortLSD_memEst(gEnt2.size, gEnt2.itemsize, plan = plan2);
         var xor_maxMem = max(gEnt_sortMem, gEnt2_sortMem);
         overMemLimit(xor_maxMem);
 
@@ -114,7 +128,8 @@ module ArraySetopsMsg
              var e = toSymEntry(gEnt,int);
              var f = toSymEntry(gEnt2,int);
              
-             var aV = setxor1d(e.a, f.a, isUnique);
+            // it's unclear if plan or plan2 should be passed (should be equivalent rn), revisit along with mem estimates
+             var aV = setxor1d(e.a, f.a, isUnique, plan = plan);
              st.addEntry(vname, new shared SymEntry(aV));
 
              repMsg = "created " + st.attrib(vname);
@@ -125,7 +140,8 @@ module ArraySetopsMsg
              var e = toSymEntry(gEnt,uint);
              var f = toSymEntry(gEnt2,uint);
              
-             var aV = setxor1d(e.a, f.a, isUnique);
+            // it's unclear if plan or plan2 should be passed (should be equivalent rn), revisit along with mem estimates
+             var aV = setxor1d(e.a, f.a, isUnique, plan = plan);
              st.addEntry(vname, new shared SymEntry(aV));
 
              repMsg = "created " + st.attrib(vname);
@@ -160,8 +176,14 @@ module ArraySetopsMsg
         var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(name, st);
         var gEnt2: borrowed GenSymEntry = getGenericTypedArrayEntry(name2, st);
 
-        var gEnt_sortMem = radixSortLSD_memEst(gEnt.size, gEnt.itemsize);
-        var gEnt2_sortMem = radixSortLSD_memEst(gEnt2.size, gEnt2.itemsize);
+        // TODO look into this more, might be easier to move mem check into ArraySetOps
+        // I'm not sure these are calculating the sort size correctly
+        // because sometimes we sort both arrays so (gEnt_sortMem + gEnt2_sortMem)
+        // and sometimes we sort the concat of the 2 arrays radixSortLSD_memEst(gEnt.size + gEnt2.size, max(gEnt.itemsize, gEnt2.itemsize), plan);
+        const plan = makeRadixSortLSDPlan();
+        const plan2 = makeRadixSortLSDPlan();
+        var gEnt_sortMem = radixSortLSD_memEst(gEnt.size, gEnt.itemsize, plan = plan);
+        var gEnt2_sortMem = radixSortLSD_memEst(gEnt2.size, gEnt2.itemsize, plan = plan2);
         var diff_maxMem = max(gEnt_sortMem, gEnt2_sortMem);
         overMemLimit(diff_maxMem);
 
@@ -170,7 +192,8 @@ module ArraySetopsMsg
              var e = toSymEntry(gEnt,int);
              var f = toSymEntry(gEnt2, int);
              
-             var aV = setdiff1d(e.a, f.a, isUnique);
+            // it's unclear if plan or plan2 should be passed (should be equivalent rn), revisit along with mem estimates
+             var aV = setdiff1d(e.a, f.a, isUnique, plan = plan);
              st.addEntry(vname, new shared SymEntry(aV));
 
              var repMsg = "created " + st.attrib(vname);
@@ -181,7 +204,8 @@ module ArraySetopsMsg
              var e = toSymEntry(gEnt,uint);
              var f = toSymEntry(gEnt2, uint);
              
-             var aV = setdiff1d(e.a, f.a, isUnique);
+            // it's unclear if plan or plan2 should be passed (should be equivalent rn), revisit along with mem estimates
+             var aV = setdiff1d(e.a, f.a, isUnique, plan = plan);
              st.addEntry(vname, new shared SymEntry(aV));
 
              var repMsg = "created " + st.attrib(vname);
@@ -214,9 +238,15 @@ module ArraySetopsMsg
 
       var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(name, st);
       var gEnt2: borrowed GenSymEntry = getGenericTypedArrayEntry(name2, st);
-      
-      var gEnt_sortMem = radixSortLSD_memEst(gEnt.size, gEnt.itemsize);
-      var gEnt2_sortMem = radixSortLSD_memEst(gEnt2.size, gEnt2.itemsize);
+
+      // TODO look into this more, might be easier to move mem check into ArraySetOps
+      // I'm not sure these are calculating the sort size correctly
+      // because sometimes we sort both arrays so (gEnt_sortMem + gEnt2_sortMem)
+      // and sometimes we sort the concat of the 2 arrays radixSortLSD_memEst(gEnt.size + gEnt2.size, max(gEnt.itemsize, gEnt2.itemsize), plan);
+      const plan = makeRadixSortLSDPlan();
+      const plan2 = makeRadixSortLSDPlan();
+      var gEnt_sortMem = radixSortLSD_memEst(gEnt.size, gEnt.itemsize, plan = plan);
+      var gEnt2_sortMem = radixSortLSD_memEst(gEnt2.size, gEnt2.itemsize, plan = plan2);
       var union_maxMem = max(gEnt_sortMem, gEnt2_sortMem);
       overMemLimit(union_maxMem);
 
@@ -225,7 +255,8 @@ module ArraySetopsMsg
            var e = toSymEntry(gEnt,int);
            var f = toSymEntry(gEnt2,int);
 
-           var aV = union1d(e.a, f.a);
+          // it's unclear if plan or plan2 should be passed (should be equivalent rn), revisit along with mem estimates
+           var aV = union1d(e.a, f.a, plan = plan);
            st.addEntry(vname, new shared SymEntry(aV));
 
            var repMsg = "created " + st.attrib(vname);
@@ -236,7 +267,8 @@ module ArraySetopsMsg
            var e = toSymEntry(gEnt,uint);
            var f = toSymEntry(gEnt2,uint);
 
-           var aV = union1d(e.a, f.a);
+          // it's unclear if plan or plan2 should be passed (should be equivalent rn), revisit along with mem estimates
+           var aV = union1d(e.a, f.a, plan = plan);
            st.addEntry(vname, new shared SymEntry(aV));
 
            var repMsg = "created " + st.attrib(vname);

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -1,6 +1,7 @@
 module AryUtil
 {
     use CTypes;
+    use RadixSortLSD;
     use Random;
     use Reflection;
     use Logging;
@@ -327,7 +328,8 @@ module AryUtil
     proc mergeNumericArrays(param numDigits, size, totalDigits, bitWidths, negs, names, st) throws {
       // check mem limit for merged array and sort on merged array
       const itemsize = numDigits * bitsPerDigit / 8;
-      overMemLimit(size*itemsize + radixSortLSD_memEst(size, itemsize));
+      const plan = makeRadixSortLSDPlan();
+      overMemLimit(size*itemsize + radixSortLSD_memEst(size, itemsize, plan = plan));
 
       var ivname = st.nextName();
       var merged = makeDistArray(size, numDigits*uint(bitsPerDigit));

--- a/src/In1dMsg.chpl
+++ b/src/In1dMsg.chpl
@@ -4,6 +4,7 @@ module In1dMsg
     use ServerConfig;
 
     use Reflection;
+    use RadixSortLSD;
     use ServerErrors;
     use Logging;
     use Message;
@@ -49,19 +50,23 @@ module In1dMsg
                         "cmd: %s pdarray1: %s pdarray2: %s invert: %t new pdarray name: %t".format(
                                    cmd,st.attrib(name),st.attrib(sname),invert,rname));
 
+        const plan = makeRadixSortLSDPlan();
+        // check and throw if over memory limit
+        overMemLimit(radixSortLSD_memEst(gAr1.size + gAr2.size, gAr1.itemsize, plan = plan));
+
         select (gAr1.dtype, gAr2.dtype) {
             when (DType.Int64, DType.Int64) {
                 var ar1 = toSymEntry(gAr1,int);
                 var ar2 = toSymEntry(gAr2,int);
 
-                var truth = in1d(ar1.a, ar2.a, invert);
+                var truth = in1d(ar1.a, ar2.a, invert, plan = plan);
                 st.addEntry(rname, new shared SymEntry(truth));
             }
             when (DType.UInt64, DType.UInt64) {
                 var ar1 = toSymEntry(gAr1,uint);
                 var ar2 = toSymEntry(gAr2,uint);
 
-                var truth = in1d(ar1.a, ar2.a, invert);
+                var truth = in1d(ar1.a, ar2.a, invert, plan = plan);
                 st.addEntry(rname, new shared SymEntry(truth));
             }
             otherwise {

--- a/src/Merge.chpl
+++ b/src/Merge.chpl
@@ -1,7 +1,7 @@
 module Merge {
   use IO;
   use SegmentedArray;
-  use RadixSortLSD only numTasks, calcBlock;
+  use RadixSortLSD only numTasks, calcBlock, RadixSortLSDPlan;
   use Reflection;
   use ServerConfig;
   use Logging;
@@ -33,10 +33,12 @@ module Merge {
   }
 
   //const numTasks = RadixSortLSD.numTasks;
-  inline proc findStart(loc, task, s: SegString) throws {
+  inline proc findStart(loc, task, s: SegString, const plan: RadixSortLSDPlan) throws {
       ref va = s.values.a;
       const lD = va.localSubdomain();
-      const tD = RadixSortLSD.calcBlock(task, lD.low, lD.high);
+      // check and throw if over memory limit
+      overMemLimit(radixSortLSD_memEst(lD.size, s.values.itemsize, plan = plan));
+      const tD = RadixSortLSD.calcBlock(task, lD.low, lD.high, plan = plan);
       const i = tD.low;
       ref oa = s.offsets.a;
       if && reduce (oa < i) {

--- a/src/SegStringSort.chpl
+++ b/src/SegStringSort.chpl
@@ -176,6 +176,7 @@ module SegStringSort {
   }
   
   proc radixSortLSD_raw(const ref offsets: [?aD] int, const ref lengths: [aD] int, const ref values: [] uint(8), const ref inds: [aD] int, const pivot: int): [aD] int throws {
+    // TODO why do we ahve this extra version of radixSortLSD? Can this be covered by the regular one?
     const numBuckets = 2**16;
     type state = (uint(8), uint(8), int, int, int);
     inline proc copyDigit(ref k: state, const off: int, const len: int, const rank: int, const right: int, ref agg) {

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -9,6 +9,7 @@ module SegmentedMsg {
   use ServerConfig;
   use MultiTypeSymbolTable;
   use MultiTypeSymEntry;
+  use RadixSortLSD;
   use RandArray;
   use IO;
   use Map;
@@ -967,7 +968,10 @@ module SegmentedMsg {
               var mainStr = getSegString(mainName, st);
               var testStr = getSegString(testName, st);
               var e = st.addEntry(rname, mainStr.size, bool);
-              e.a = in1d(mainStr, testStr, invert);
+              const plan = makeRadixSortLSDPlan();
+              // check and throw if over memory limit
+              overMemLimit(radixSortLSD_memEst(mainStr.size + testStr.size, mainStr.values.itemsize, plan = plan));
+              e.a = in1d(mainStr, testStr, invert, plan = plan);
           }
           otherwise {
               var errorMsg = unrecognizedTypeError(pn, "("+mainObjtype+", "+testObjtype+")");

--- a/src/SortMsg.chpl
+++ b/src/SortMsg.chpl
@@ -30,7 +30,7 @@ module SortMsg
     proc sortMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
       param pn = Reflection.getRoutineName();
       var repMsg: string; // response message
-      var (algoName, name) = payload.splitMsgToTuple(2);
+      var (algoName, name, numTasksStr, bitsPerDigitStr) = payload.splitMsgToTuple(4);
       var algorithm: SortingAlgorithm = defaultSortAlgorithm;
       if algoName != "" {
         try {
@@ -45,6 +45,9 @@ module SortMsg
                                     );
         }
       }
+      var nt = try! numTasksStr:int;
+      var bpd = try! bitsPerDigitStr:int;
+
       // get next symbol name
       var sortedName = st.nextName();
 
@@ -65,7 +68,10 @@ module SortMsg
             return b;
           }
           when SortingAlgorithm.RadixSortLSD {
-            return radixSortLSD_keys(a);
+            var numTasks = if nt != -1 then nt else here.maxTaskPar;
+            var bitsPerDigit = if bpd != -1 then bpd else RSLSD_bitsPerDigit;
+
+            return radixSortLSD_keys(a, numTasks = numTasks, bitsPerDigit = bitsPerDigit);
           }
           otherwise {
             throw getErrorWithContext(

--- a/src/Unique.chpl
+++ b/src/Unique.chpl
@@ -42,7 +42,7 @@ module Unique
 
     :returns: ([] int, [] int)
     */
-    proc uniqueSort(a: [?aD] ?eltType, param needCounts = true) throws {
+    proc uniqueSort(a: [?aD] ?eltType, param needCounts = true, const plan: RadixSortLSDPlan) throws {
         if (aD.size == 0) {
             try! uLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"zero size");
             var u = makeDistArray(0, eltType);
@@ -54,11 +54,11 @@ module Unique
             }
         } 
 
-        var sorted = radixSortLSD_keys(a);
+        var sorted = radixSortLSD_keys(a, plan = plan);
         return uniqueFromSorted(sorted, needCounts);
     }
 
-    proc uniqueSortWithInverse(a: [?aD] ?eltType) throws {
+    proc uniqueSortWithInverse(a: [?aD] ?eltType, const plan: RadixSortLSDPlan) throws {
         if (aD.size == 0) {
             try! uLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"zero size");
             var u = makeDistArray(0, eltType);
@@ -68,7 +68,7 @@ module Unique
         }
         var sorted: [aD] eltType;
         var perm: [aD] int;
-        forall (s, p, sp) in zip(sorted, perm, radixSortLSD(a)) {
+        forall (s, p, sp) in zip(sorted, perm, radixSortLSD(a, plan = plan)) {
           (s, p) = sp;
         }
         var (u, c) = uniqueFromSorted(sorted);
@@ -152,7 +152,7 @@ module Unique
         }
     }
 
-    proc uniqueGroup(str: SegString, returnInverse = false) throws {
+    proc uniqueGroup(str: SegString, returnInverse = false, const plan: RadixSortLSDPlan) throws {
         if (str.size == 0) {
             uLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"zero size");
             var uo = makeDistArray(0, int);
@@ -174,7 +174,7 @@ module Unique
         if SegmentedArrayUseHash {
           var hashes = str.siphash();
           var sorted: [aD] 2*uint;
-          forall (s, p, sp) in zip(sorted, perm, radixSortLSD(hashes)) {
+          forall (s, p, sp) in zip(sorted, perm, radixSortLSD(hashes, plan = plan)) {
             (s, p) = sp;
           }
           truth[0] = true;

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -174,9 +174,9 @@ module UniqueMsg
       }
       proc helper(itemsize, type t, keys: [?D] t) throws {
         // Sort the keys
-        var sortMem = radixSortLSD_memEst(keys.size, itemsize);
-        overMemLimit(sortMem);
-        var kr = radixSortLSD(keys);
+        const plan = makeRadixSortLSDPlan();
+        overMemLimit(radixSortLSD_memEst(keys.size, itemsize, plan = plan));
+        var kr = radixSortLSD(keys, plan = plan);
         // Unpack the permutation and sorted keys
         // var perm: [kr.domain] int;
         var permutation = new shared SymEntry(kr.size, int);

--- a/test/StringGatherSpeedTest.chpl
+++ b/test/StringGatherSpeedTest.chpl
@@ -14,7 +14,8 @@ proc testPermute(n:int, meanLen: numeric) {
   var strings = getSegString(segs, vals, st);
   var rint: [segs.domain] int;
   fillInt(rint, 0, max(int));
-  var perm = radixSortLSD_ranks(rint);
+  const plan = makeRadixSortLSDPlan();
+  var perm = radixSortLSD_ranks(rint, plan = plan);
   d.start();
   var (psegs, pvals) = strings[perm];
   d.stop(printTime=false);

--- a/test/UnitTestGroupby.chpl
+++ b/test/UnitTestGroupby.chpl
@@ -6,6 +6,7 @@ prototype module UnitTestGroupby
   use FindSegmentsMsg;
   use ReductionMsg;
   use RandMsg;
+  use RadixSortLSD;
   use IndexingMsg;
     
   config const LEN:int;
@@ -76,8 +77,9 @@ prototype module UnitTestGroupby
     var d: Diags;
     if (STRATEGY == "default") {
       writeln("argsortDefault");
+      const plan = makeRadixSortLSDPlan();
       d.start();
-      iv = argsortDefault(keys.a);
+      iv = argsortDefault(keys.a, plan = plan);
       d.stop("argsortDefault");
     } else {
       halt("Unrecognized STRATEGY: ", STRATEGY);

--- a/test/UnitTestIn1d.chpl
+++ b/test/UnitTestIn1d.chpl
@@ -3,6 +3,7 @@ prototype module UnitTestIn1d
     use TestBase;
     
     use Random;
+    use RadixSortLSD;
 
     use In1d;
     
@@ -81,8 +82,9 @@ prototype module UnitTestIn1d
         if printExpected then writeln("<<< #a[i] in b = ", + reduce truth, " (expected ", expected, ")");try! stdout.flush();
 
         writeln(">>> in1dSort");
+        const plan = makeRadixSortLSDPlan();
         d.start();
-        var truth2 = in1dSort(a, b);
+        var truth2 = in1dSort(a, b, plan = plan);
         d.stop("in1dSort");
         if printExpected then writeln("<<< #a[i] in b = ", + reduce truth2, " (expected ", expected, ")");try! stdout.flush();
 
@@ -100,8 +102,9 @@ prototype module UnitTestIn1d
         // returns a boolean vector
         var truth = in1dAr2PerLocAssoc(str1.siphash(), str2.siphash());
         d.stop("in1d (associative domain)");
+        const plan = makeRadixSortLSDPlan();
         d.start();
-        var truth2 = in1dSort(str1.siphash(), str2.siphash());
+        var truth2 = in1dSort(str1.siphash(), str2.siphash(), plan = plan);
         d.stop("in1d (sort-based)");
         writeln("Results of both strategies match? >>> ", && reduce (truth == truth2), " <<<");
         if printExpected then writeln("<<< #str1[i] in str2 = ", + reduce truth, " (expected ", expected, ")");try! stdout.flush();

--- a/test/UnitTestSort.chpl
+++ b/test/UnitTestSort.chpl
@@ -54,16 +54,17 @@ prototype module UnitTestSort
   /* Main sort testing routine */
 
   proc testSort(A:[?D], type elemType, nElems, sortDesc) {
+    const plan = makeRadixSortLSDPlan();
     if testKeys {
       startDiag();
-      var sortedA = radixSortLSD_keys(A, checkSorted=false);
+      var sortedA = radixSortLSD_keys(A, checkSorted=false, plan = plan);
       endDiag("radixSortLSD_keys", elemType, nElems, sortDesc);
       if printArrays { writeln(A); writeln(sortedA); }
       if verify { assert(AryUtil.isSorted(sortedA)); }
     }
     if testRanks {
       startDiag();
-      var rankSortedA = radixSortLSD_ranks(A, checkSorted=false);
+      var rankSortedA = radixSortLSD_ranks(A, checkSorted=false, plan = plan);
       endDiag("radixSortLSD_ranks", elemType, nElems, sortDesc);
       if verify {
         var sortedA: [D] elemType;
@@ -200,8 +201,9 @@ prototype module UnitTestSort
     A = B:perfElemType;
 
     if perfWarmup {
-      if testKeys then radixSortLSD_keys(A, checkSorted=false);
-      if testRanks then radixSortLSD_ranks(A, checkSorted=false);
+      const plan = makeRadixSortLSDPlan();
+      if testKeys then radixSortLSD_keys(A, checkSorted=false, plan = plan);
+      if testRanks then radixSortLSD_ranks(A, checkSorted=false, plan = plan);
     }
 
     for 1..perfTrials {

--- a/test/UnitTestUnique.chpl
+++ b/test/UnitTestUnique.chpl
@@ -1,9 +1,8 @@
 prototype module UnitTestUnique
 {
     use TestBase;
-
+    use RadixSortLSD;
     use Unique;
-    
     use Random;
 
 
@@ -88,8 +87,9 @@ prototype module UnitTestUnique
         writeln(">>> uniqueSort");
         var d: Diags;
 
+        const plan = makeRadixSortLSDPlan();
         d.start();
-        var (aV1,aC1) = uniqueSort(a);
+        var (aV1,aC1) = uniqueSort(a, plan = plan);
         d.stop("uniqueSort");
 
         //printAry("aV1 = ",aV1);
@@ -108,7 +108,7 @@ prototype module UnitTestUnique
         }
         writeln("all values present? >>> ", && reduce present, " <<<"); try! stdout.flush();
         writeln("testing return_inverse...");
-        var (aV2, aC2, inv) = uniqueSortWithInverse(a);
+        var (aV2, aC2, inv) = uniqueSortWithInverse(a, plan = plan);
         writeln("values and counts match? >>> ", (&& reduce (aV2 == aV1)) && (&& reduce (aC2 == aC1)), " <<<" );
         var a2: [aDom] int;
         forall (x, idx) in zip(a2, inv) {
@@ -123,8 +123,9 @@ prototype module UnitTestUnique
         
         writeln(">>> uniqueGroup");
         var d: Diags;
+        const plan = makeRadixSortLSDPlan();
         d.start();
-        var (uo1, uv1, c1, inv1) = uniqueGroup(str);
+        var (uo1, uv1, c1, inv1) = uniqueGroup(str, plan = plan);
         d.stop("uniqueGroup");
 
         // var uStr1 = strFromArrays(uo1, uv1, st);
@@ -134,7 +135,7 @@ prototype module UnitTestUnique
         //writeln("uStr1.size = ",uStr1.size);
         //writeln("totalCounts = ",+ reduce c1); try! stdout.flush();
         writeln("testing return_inverse...");
-        var (uo2, uv2, c2, inv2) = uniqueGroup(str, returnInverse=true);
+        var (uo2, uv2, c2, inv2) = uniqueGroup(str, returnInverse=true, plan = plan);
         // var uStr2 = strFromArrays(uo2, uv2, st);
         var uStr2 = getSegString(uo2, uv2, st);
         writeln("offsets, values, and counts match? >>> ", (&& reduce (uo2 == uo1)) && (&& reduce (uv2 == uv1)) && (&& reduce (c2 == c1)), " <<<" );

--- a/test/untested/UnitTestMerge.chpl
+++ b/test/untested/UnitTestMerge.chpl
@@ -7,7 +7,8 @@ use Random;
 proc testBinarySearch(size, trials) {
   var a = makeDistArray(size, int);
   fillRandom(a);
-  var b = radixSortLSD_keys(a);
+  const plan = makeRadixSortLSDPlan();
+  var b = radixSortLSD_keys(a, plan = plan);
   var R = new RandomStream(int);
   const fixed = [min(int), b[0], b[size-1], max(int)];
   const ans = [0, 0, size-1, size];


### PR DESCRIPTION
Part of #1338
Very basic iteration, all we do here is wrap the parameters for `RadixSortCore` into a record and pass them in

I think eventually we want to allocate the arrays `a` and `temp` and store them in `RadixSortLSDPlan` as well. I'm not sure how this will affect performance because right now, i'm passing `plan` in as a `const` and I don't we'll be able to do that then since those arrays will be changing

I think once i figure out the above, we'll build some sort of map so we can cache `RadixSortLSDPlan`s. That way if we request one with the same configuration as an existing one, we can reuse the existing one. This'll save us the cost of allocating and deallocating arrays for repetitive sorts with the same configuration. Though we'll prob want to cap this somehow to avoid too much memory being used by the cache

Once again, `ak.sort` is my guinea pig function
```python
>>> a = ak.randint(1, 15, 10)
>>> a
array([13 11 4 5 6 11 4 8 8 6])

>>> ak.sort(a)
array([4 4 5 6 6 8 8 11 11 13])

>>> ak.sort(a, bits_per_digit=4)
array([4 4 5 6 6 8 8 11 11 13])

>>> ak.sort(a, num_tasks=22, bits_per_digit=4)
array([4 4 5 6 6 8 8 11 11 13])
```
