### PR TITLE
Closes #1536: Switch to using a lowLevelLocalizingSlice for DF indexing message

### DIFF
--- a/src/DataFrameIndexingMsg.chpl
+++ b/src/DataFrameIndexingMsg.chpl
@@ -130,7 +130,11 @@
                     var idxCodeName = dfIdxHelper(idx, code_vals, st, col_name, true);
                     
                     var args: [1..2] string = [categories_name, idxCodeName];
-                    var repTup = segPdarrayIndex("str", args, st);
+                    // When smallIdx is set to true, some localization work will
+                    // be skipped and a localizing slice will instead be done,
+                    // which can perform better by avoiding those overhead costs.
+                    var repTup = segPdarrayIndex("str", args, st, smallIdx=true);
+                    
                     if repTup.msgType == MsgType.ERROR {
                         throw new IllegalArgumentError(repTup.msg);
                     }
@@ -140,7 +144,11 @@
                 when ("Strings") {
                     dfiLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"Element at %i is Strings. Name: %s".format(i, ele_parts[2]));
                     var args: [1..2] string = [ele_parts[2], iname];
-                    var repTup = segPdarrayIndex("str", args, st);
+                    // When smallIdx is set to true, some localization work will
+                    // be skipped and a localizing slice will instead be done,
+                    // which can perform better by avoiding those overhead costs.
+                    var repTup = segPdarrayIndex("str", args, st, smallIdx=true);
+                    
                     if repTup.msgType == MsgType.ERROR {
                         throw new IllegalArgumentError(repTup.msg);
                     }

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -197,7 +197,7 @@ module SegmentedArray {
 
     /* Gather strings by index. Returns arrays for the segment offsets
        and bytes of the gathered strings.*/
-    proc this(iv: [?D] ?t) throws where t == int || t == uint {
+    proc this(iv: [?D] ?t, smallIdx=false) throws where t == int || t == uint {
       use ChplConfig;
       
       // Early return for zero-length result
@@ -247,8 +247,17 @@ module SegmentedArray {
       }
       var gatheredVals = makeDistArray(retBytes, uint(8));
       // Multi-locale requires some extra localization work that is not needed
-      // in CHPL_COMM=none
-      if CHPL_COMM != 'none' {
+      // in CHPL_COMM=none. When smallArr is set to true, a lowLevelLocalizingSlice
+      // will take place that can perform better by avoiding the extra localization
+      // work.
+      if CHPL_COMM != 'none' && smallIdx {
+        forall (go, gl, idx) in zip(gatheredOffsets, gatheredLengths, iv) with (var agg = newDstAggregator(uint(8))) {
+          var slice = new lowLevelLocalizingSlice(values.a, idx:int..#gl);
+          for i in 0..#gl {
+            agg.copy(gatheredVals[go+i], slice.ptr[i]);
+          }
+        }
+      } else if CHPL_COMM != 'none' {
         // Compute the src index for each byte in gatheredVals
         /* For performance, we will do this with a scan, so first we need an array
            with the difference in index between the current and previous byte. For

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -760,7 +760,7 @@ module SegmentedMsg {
   }
 
   proc segPdarrayIndex(objtype: string, args: [] string, 
-                                 st: borrowed SymTab): MsgTuple throws {
+                       st: borrowed SymTab, smallIdx=false): MsgTuple throws {
     var pn = Reflection.getRoutineName();
 
     // check to make sure symbols defined
@@ -781,7 +781,10 @@ module SegmentedMsg {
                 select gIV.dtype {
                     when DType.Int64 {
                         var iv = toSymEntry(gIV, int);
-                        var (newSegs, newVals) = strings[iv.a];
+                        // When smallIdx is set to true, some localization work will
+                        // be skipped and a localizing slice will instead be done,
+                        // which can perform better by avoiding those overhead costs.
+                        var (newSegs, newVals) = strings[iv.a, smallIdx=smallIdx];
                         var newStringsObj = getSegString(newSegs, newVals, st);
                         newStringsName = newStringsObj.name;
                         nBytes = newStringsObj.nBytes;


### PR DESCRIPTION
This PR is a performance improvement for the `_get_head_tail_server`
function. Since we know that the index arrays will be small that
we are using to index in the DataFrameIndexingMsg function, we can
hardcode in that expectation to avoid some overhead that is helpful
only when doing large-array indexing.

To get around this overhead, a `smallIdx` argument was added to
pdarray string indexing by integer arrays indicating that the
indexing array is small and would not benefit from all of the
large array index overhead.

Instead of doing the regular indexing, the `smallIdx` branch will
localize each string using `lowLevelLocalizingSlice` before copying
it into the output array. This performs better than the naive
indexing approach taken when `CHPL_COMM=none` for distributed runs
for arrays over a certain threshold and significantly outperforms
the large array path.

This optimization could be extended to dynamically check the size of
the index array and then determine whether or not we want to do the
indexing optimized for large or small arrays, but pinning down those
thresholds can be difficult and machine-dependent.

Running 50 `_get_head_tail_server` string calls on 8
nodes of a cs-hdr:
String size | This branch | Naive copy | Master
----------- | ----------- | ---------- | ------
5-6         | 0.7960 s    | 0.7883 s   | 1.1169 s
50-51       | 0.8262 s    | 1.0042 s   | 1.2797 s
100-101     | 0.8736 s    | 1.2195 s   | 1.3165 s
200-201     | 0.8778 s    | 1.6184 s   | 1.3511 s
300-301     | 0.9518 s    | 1.9948 s   | 1.4371 s
1000-1001   | 1.363 s     | --         | 1.8706 s
2000-2001   | 1.8799 s    | --         | 2.3605 s

Running `dataframe.py` benchmark on 16 nodes of a cs-hdr:
This branch | Master
----------- | ---------
0.8991 s    | 1.0048 s

Closes: https://github.com/Bears-R-Us/arkouda/issues/1536
Part of: https://github.com/Bears-R-Us/arkouda/issues/1398