### PR TITLE
Closes #1527 - Add `is_ipv4()` and `is_ipv6()` for ipaddresses

### DIFF
--- a/tests/client_dtypes_test.py
+++ b/tests/client_dtypes_test.py
@@ -1,3 +1,5 @@
+import random
+
 from base_test import ArkoudaTest
 from context import arkouda as ak
 
@@ -119,3 +121,41 @@ class ClientDTypeTests(ArkoudaTest):
         ipv4 = ak.IPv4(ip_list)
         ip_as_int = ipv4.normalize("192.168.1.1")
         self.assertEqual(3232235777, ip_as_int)
+
+    def test_is_ipv4(self):
+        x = [random.getrandbits(32) for i in range(100)]
+
+        ans = ak.is_ipv4(ak.cast(ak.array(x), ak.int64))
+        self.assertListEqual(ans.to_ndarray().tolist(), [True for i in range(100)])
+
+        ipv4 = ak.IPv4(ak.array(x))
+        ans = ak.is_ipv4(ipv4)
+        self.assertListEqual(ans.to_ndarray().tolist(), [True for i in range(100)])
+
+        x = [random.getrandbits(64) if i < 5 else random.getrandbits(32) for i in range(10)]
+        ans = ak.is_ipv4(ak.cast(ak.array(x), ak.int64))
+        self.assertListEqual(ans.to_ndarray().tolist(), [False if i < 5 else True for i in range(10)])
+
+        with self.assertRaises(TypeError):
+            ak.is_ipv4(ak.array(x))
+
+        with self.assertRaises(RuntimeError):
+            ak.is_ipv4(ak.cast(ak.array(x), ak.int64), ak.cast(ak.arange(2), ak.int64))
+
+    def test_is_ipv6(self):
+        x = [random.getrandbits(128) for i in range(100)]
+        low = ak.cast(ak.array([i & (2 ** 64 - 1) for i in x]), ak.int64)
+        high = ak.cast(ak.array([i >> 64 for i in x]), ak.int64)
+
+        ans = ak.is_ipv6(high, low)
+        self.assertListEqual(ans.to_ndarray().tolist(), [True for i in range(100)])
+
+        x = [random.getrandbits(64) if i < 5 else random.getrandbits(32) for i in range(10)]
+        ans = ak.is_ipv6(ak.cast(ak.array(x), ak.int64))
+        self.assertListEqual(ans.to_ndarray().tolist(), [True if i < 5 else False for i in range(10)])
+
+        with self.assertRaises(TypeError):
+            ak.is_ipv6(ak.array(x))
+
+        with self.assertRaises(RuntimeError):
+            ak.is_ipv6(ak.cast(ak.array(x), ak.int64), ak.cast(ak.arange(2), ak.int64))

--- a/tests/client_dtypes_test.py
+++ b/tests/client_dtypes_test.py
@@ -125,34 +125,34 @@ class ClientDTypeTests(ArkoudaTest):
     def test_is_ipv4(self):
         x = [random.getrandbits(32) for i in range(100)]
 
-        ans = ak.is_ipv4(ak.cast(ak.array(x), ak.int64))
-        self.assertListEqual(ans.to_ndarray().tolist(), [True for i in range(100)])
+        ans = ak.is_ipv4(ak.array(x, dtype=ak.uint64))
+        self.assertListEqual(ans.to_ndarray().tolist(), [True]*100)
 
         ipv4 = ak.IPv4(ak.array(x))
         ans = ak.is_ipv4(ipv4)
-        self.assertListEqual(ans.to_ndarray().tolist(), [True for i in range(100)])
+        self.assertListEqual(ans.to_ndarray().tolist(), [True] * 100)
 
         x = [random.getrandbits(64) if i < 5 else random.getrandbits(32) for i in range(10)]
-        ans = ak.is_ipv4(ak.cast(ak.array(x), ak.int64))
-        self.assertListEqual(ans.to_ndarray().tolist(), [False if i < 5 else True for i in range(10)])
+        ans = ak.is_ipv4(ak.array(x, ak.uint64))
+        self.assertListEqual(ans.to_ndarray().tolist(), [i >= 5 for i in range(10)])
 
         with self.assertRaises(TypeError):
             ak.is_ipv4(ak.array(x))
 
         with self.assertRaises(RuntimeError):
-            ak.is_ipv4(ak.cast(ak.array(x), ak.int64), ak.cast(ak.arange(2), ak.int64))
+            ak.is_ipv4(ak.array(x, dtype=ak.uint64), ak.arange(2, dtype=ak.uint64))
 
     def test_is_ipv6(self):
         x = [random.getrandbits(128) for i in range(100)]
-        low = ak.cast(ak.array([i & (2 ** 64 - 1) for i in x]), ak.int64)
-        high = ak.cast(ak.array([i >> 64 for i in x]), ak.int64)
+        low = ak.array([i & (2 ** 64 - 1) for i in x], dtype=ak.uint64)
+        high = ak.array([i >> 64 for i in x], dtype=ak.uint64)
 
         ans = ak.is_ipv6(high, low)
-        self.assertListEqual(ans.to_ndarray().tolist(), [True for i in range(100)])
+        self.assertListEqual(ans.to_ndarray().tolist(), [True] * 100)
 
         x = [random.getrandbits(64) if i < 5 else random.getrandbits(32) for i in range(10)]
         ans = ak.is_ipv6(ak.cast(ak.array(x), ak.int64))
-        self.assertListEqual(ans.to_ndarray().tolist(), [True if i < 5 else False for i in range(10)])
+        self.assertListEqual(ans.to_ndarray().tolist(), [i < 5 for i in range(10)])
 
         with self.assertRaises(TypeError):
             ak.is_ipv6(ak.array(x))


### PR DESCRIPTION
Closes #1527

Adds `is_ipv4` and `is_ipv6` functionality returning a bool array indicating which values are the respective type.

The methods were added as top level functions to allow for calls via `ak.is_ipv4()` and `ak.is_ipv6()`. 

Each function requires at least 1 parameter, but allows for 2 to support mixed data sets being passed in. 

I am not sure if we want to support more than just `int64`, especially since we now have expanded scalar support. If we want to expand to additional types rather than just `ak.int64`, that can be done.
