### PR TITLE
Recommend Chapel 1.26.0 and use it for CI testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.25.1
+      image: chapel/chapel:1.26.0
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
@@ -32,7 +32,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.25.1
+      image: chapel/chapel:1.26.0
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
@@ -47,7 +47,7 @@ jobs:
   flake8:
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.25.1
+      image: chapel/chapel:1.26.0
     steps:
       - uses: actions/checkout@v2
       - name: Install Dependencies
@@ -65,7 +65,7 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.x']
     container:
-      image: chapel/chapel:1.25.1
+      image: chapel/chapel:1.26.0
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -105,7 +105,7 @@ jobs:
     env:
       CHPL_RT_NUM_THREADS_PER_LOCALE: ${{matrix.threads}}
     container:
-      image: chapel/${{matrix.image}}:1.25.1
+      image: chapel/${{matrix.image}}:1.26.0
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
@@ -137,7 +137,7 @@ jobs:
   chapel_unit_tests_linux:
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.25.1
+      image: chapel/chapel:1.26.0
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository == 'Bears-R-Us/arkouda'
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.25.1
+      image: chapel/chapel:1.26.0
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -54,8 +54,6 @@ sudo apt-get update
 sudo apt-get install gcc g++ m4 perl python3 python3-pip python3-venv python3-dev bash make mawk git pkg-config cmake llvm-12-dev llvm-12 llvm-12-tools clang-12 libclang-12-dev libclang-cpp12-dev libedit-dev
 
 # Download latest Chapel release, explode archive, and navigate to source root directory
-# Chapel 1.26.0 is recommended, but 1.25.1 is still supported.
-# To use Chapel 1.25.1, replace '1.26.0' in the following three commands with '1.25.1'
 wget https://github.com/chapel-lang/chapel/releases/download/1.26.0/chapel-1.26.0.tar.gz
 tar xvf chapel-1.26.0.tar.gz
 cd chapel-1.26.0/
@@ -254,7 +252,7 @@ pip install -e .[dev]
 
 ```bash
 # build chapel in the user home directory with these settings...
-export CHPL_HOME=~/chapel/chapel-1.25.1
+export CHPL_HOME=~/chapel/chapel-1.26.0
 source $CHPL_HOME/util/setchplenv.bash
 export CHPL_COMM=gasnet
 export CHPL_COMM_SUBSTRATE=smp

--- a/Makefile
+++ b/Makefile
@@ -161,14 +161,14 @@ $(ARROW_O): $(ARROW_CPP) $(ARROW_H)
 
 CHPL_MINOR := $(shell $(CHPL) --version | sed -n "s/chpl version 1\.\([0-9]*\).*/\1/p")
 CHPL_VERSION_OK := $(shell test $(CHPL_MINOR) -ge 24 && echo yes)
-CHPL_VERSION_WARN := $(shell test $(CHPL_MINOR) -le 24 && echo yes)
+CHPL_VERSION_WARN := $(shell test $(CHPL_MINOR) -le 25 && echo yes)
 .PHONY: check-chpl
 check-chpl:
 ifneq ($(CHPL_VERSION_OK),yes)
 	$(error Chapel 1.24.0 or newer is required)
 endif
 ifeq ($(CHPL_VERSION_WARN),yes)
-	$(warning Chapel 1.25.1 or newer is recommended)
+	$(warning Chapel 1.26.0 or newer is recommended)
 endif
 
 ZMQ_CHECK = $(DEP_INSTALL_DIR)/checkZMQ.chpl

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -2,7 +2,7 @@
 
 The dependencies listed here have varying installation instructions depending upon your preferred operating system. Please use in the installation instructions provided in [INSTALL.md](INSTALL.md).
 
-- `Chapel 1.25.1 or later` *(1.26.0 Recommended)*
+- `Chapel 1.26.0 or later`
 - `cmake>=3.11.0`
 - `zeromq>=4.2.5`
 - `hdf5`

--- a/pydoc/setup/prerequisites.rst
+++ b/pydoc/setup/prerequisites.rst
@@ -7,7 +7,7 @@ Prerequisites
 *******************
 Chapel
 *******************
-(version 1.25.1 or greater)
+(version 1.26.0 or greater)
 
 The arkouda server application is written in Chapel_, a productive and performant parallel programming language. In order to use arkouda, you must first `download the current version of Chapel`_ and build it according to the instructions_ for your platform(s). Below are tips for building Chapel to support arkouda.
 


### PR DESCRIPTION
Chapel 1.26 was mostly about new GPU features and better `CHPL_COMM=ofi`
support, neither of which are important to Arkouda currently, which is
largely why I haven't upgraded until now.

Note that this changes the documentation to "require" 1.26.0, but only
recommends it in the Makefile instead of making it an error. Arkouda
should continue to work with Chapel 1.24+ so existing users don't
necessarily have to upgrade, but I think it makes sense to recommend
that users reading the doc should use the latest version.

Note that 1.24 is pretty old at this point and we can probably drop some
support for some older versions, but I'll leave that for others.

Resolves #1543