### PR TITLE
Quiet deprecation warnings for Chapel 1.27

### DIFF
--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -340,7 +340,7 @@ module AryUtil
 
           const r = 0..#nBits by bitsPerDigit;
           for rshift in r {
-            const myDigit = (r.high - rshift) / bitsPerDigit;
+            const myDigit = (nBits-1 - rshift) / bitsPerDigit;
             const last = myDigit == 0;
             forall (m, a) in zip(merged, A) {
               m[curDigit+myDigit] =  getDigit(a, rshift, last, neg):uint(bitsPerDigit);
@@ -381,7 +381,7 @@ module AryUtil
         /* Do we own the memory? */
         var isOwned: bool = false;
 
-        proc init(A: [] ?t, region: range(?)) {
+        proc init(A: [] ?t, region: range(stridable=false)) {
             use CommPrimitives;
             use CTypes;
 

--- a/src/Logging.chpl
+++ b/src/Logging.chpl
@@ -112,7 +112,7 @@ module Logging {
         }
          
         proc generateDateTimeString() throws {
-            var dts = datetime.today():string;
+            var dts = datetime.now():string;
             var vals = dts.split("T");
             var cd = vals(0);
             var rawCms = vals(1).split(".");

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -485,7 +485,7 @@ module MultiTypeSymbolTable
             var regex = compile(pattern);
             var infoStr = "";
             forall name in tab.keysToArray() with (+ reduce infoStr) {
-                if name.match(regex) {
+                if regex.match(name) {
                     infoStr += name + "+";
                 }
             }

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -156,7 +156,7 @@ module SegmentedArray {
     /* Take a slice of strings from the array. The slice must be a 
        Chapel range, i.e. low..high by stride, not a Python slice.
        Returns arrays for the segment offsets and bytes of the slice.*/
-    proc this(const slice: range(stridable=true)) throws {
+    proc this(const slice: range(stridable=false)) throws {
       if (slice.low < offsets.aD.low) || (slice.high > offsets.aD.high) {
           saLogger.error(getModuleName(),getRoutineName(),getLineNumber(),
           "Array is out of bounds");

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -739,7 +739,7 @@ module SegmentedMsg {
                 return new MsgTuple(errorMsg, MsgType.ERROR);
             }
             // TO DO: in the future, we will force the client to handle this
-            var slice: range(stridable=true) = convertPythonSliceToChapel(start, stop, stride);
+            var slice = convertPythonSliceToChapel(start, stop);
             // Compute the slice
             var (newSegs, newVals) = strings[slice];
             // Store the resulting offsets and bytes arrays
@@ -756,16 +756,12 @@ module SegmentedMsg {
     }
   }
 
-  proc convertPythonSliceToChapel(start:int, stop:int, stride:int=1): range(stridable=true) {
-    var slice: range(stridable=true);
-    // convert python slice to chapel slice
-    // backwards iteration with negative stride
-    if  (start > stop) & (stride < 0) {slice = (stop+1)..start by stride;}
-    // forward iteration with positive stride
-    else if (start <= stop) & (stride > 0) {slice = start..(stop-1) by stride;}
-    // BAD FORM start < stop and stride is negative
-    else {slice = 1..0;}
-    return slice;
+  proc convertPythonSliceToChapel(start:int, stop:int): range(stridable=false) {
+    if (start <= stop) {
+      return start..(stop-1);
+    } else {
+      return 1..0;
+    }
   }
 
   proc segPdarrayIndex(objtype: string, args: [] string, 


### PR DESCRIPTION
As part of Chapel's continued push to library stabilization and Chapel
2.0 there are a few methods that have changed or will change that result
in deprecation warnings for Arkouda. Adjust them here to be compatible
with 1.27 while maintaining compatible with previously supported
versions (currently 1.24)

Individual commits have more details, but the 3 main changes are:
 - Change `datetime.today()` to `datetime.now()`
 - Change `string.match(regex)` to `regex.match(string)`
 - Avoid calling `.low`/`.high` on strided ranges/domains

Part of https://github.com/Bears-R-Us/arkouda/issues/1546