### PR TITLE
Closes #1546: Recommend Chapel 1.27.0 and use it for CI testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.26.0
+      image: chapel/chapel:1.27.0
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
@@ -32,7 +32,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.26.0
+      image: chapel/chapel:1.27.0
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
@@ -47,7 +47,7 @@ jobs:
   flake8:
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.26.0
+      image: chapel/chapel:1.27.0
     steps:
       - uses: actions/checkout@v2
       - name: Install Dependencies
@@ -65,7 +65,7 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.x']
     container:
-      image: chapel/chapel:1.26.0
+      image: chapel/chapel:1.27.0
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -105,7 +105,7 @@ jobs:
     env:
       CHPL_RT_NUM_THREADS_PER_LOCALE: ${{matrix.threads}}
     container:
-      image: chapel/${{matrix.image}}:1.26.0
+      image: chapel/${{matrix.image}}:1.27.0
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
@@ -137,7 +137,7 @@ jobs:
   chapel_unit_tests_linux:
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.26.0
+      image: chapel/chapel:1.27.0
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository == 'Bears-R-Us/arkouda'
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.26.0
+      image: chapel/chapel:1.27.0
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -54,9 +54,9 @@ sudo apt-get update
 sudo apt-get install gcc g++ m4 perl python3 python3-pip python3-venv python3-dev bash make mawk git pkg-config cmake llvm-12-dev llvm-12 llvm-12-tools clang-12 libclang-12-dev libclang-cpp12-dev libedit-dev
 
 # Download latest Chapel release, explode archive, and navigate to source root directory
-wget https://github.com/chapel-lang/chapel/releases/download/1.26.0/chapel-1.26.0.tar.gz
-tar xvf chapel-1.26.0.tar.gz
-cd chapel-1.26.0/
+wget https://github.com/chapel-lang/chapel/releases/download/1.27.0/chapel-1.27.0.tar.gz
+tar xvf chapel-1.27.0.tar.gz
+cd chapel-1.27.0/
 
 # Set CHPL_HOME
 export CHPL_HOME=$PWD
@@ -161,7 +161,7 @@ for installing Chapel & Arkouda.  We also recommend installing Anaconda for wind
 
 <b>Note:</b> When running `make` to build Chapel while using WSL, pathing issues to library dependencies are common. In most cases, a symlink pointing to the correct location or library will fix these errors.
 
-An example of one of these errors found while using Chapel 1.26.0 and Ubuntu 20.04 LTS with WSL is:
+An example of one of these errors found while using Chapel 1.27.0 and Ubuntu 20.04 LTS with WSL is:
 ```
 ../../../bin/llvm-tblgen: error while loading shared libraries: libtinfow.so.6: cannot open shared object file: No such file or directory
 ````
@@ -252,7 +252,7 @@ pip install -e .[dev]
 
 ```bash
 # build chapel in the user home directory with these settings...
-export CHPL_HOME=~/chapel/chapel-1.26.0
+export CHPL_HOME=~/chapel/chapel-1.27.0
 source $CHPL_HOME/util/setchplenv.bash
 export CHPL_COMM=gasnet
 export CHPL_COMM_SUBSTRATE=smp

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ ifneq ($(CHPL_VERSION_OK),yes)
 	$(error Chapel 1.24.0 or newer is required)
 endif
 ifeq ($(CHPL_VERSION_WARN),yes)
-	$(warning Chapel 1.26.0 or newer is recommended)
+	$(warning Chapel 1.27.0 or newer is recommended)
 endif
 
 ZMQ_CHECK = $(DEP_INSTALL_DIR)/checkZMQ.chpl

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -2,7 +2,7 @@
 
 The dependencies listed here have varying installation instructions depending upon your preferred operating system. Please use in the installation instructions provided in [INSTALL.md](INSTALL.md).
 
-- `Chapel 1.26.0 or later`
+- `Chapel 1.27.0 or later`
 - `cmake>=3.11.0`
 - `zeromq>=4.2.5`
 - `hdf5`

--- a/pydoc/setup/prerequisites.rst
+++ b/pydoc/setup/prerequisites.rst
@@ -7,7 +7,7 @@ Prerequisites
 *******************
 Chapel
 *******************
-(version 1.26.0 or greater)
+(version 1.27.0 or greater)
 
 The arkouda server application is written in Chapel_, a productive and performant parallel programming language. In order to use arkouda, you must first `download the current version of Chapel`_ and build it according to the instructions_ for your platform(s). Below are tips for building Chapel to support arkouda.
 

--- a/test/UnitTestHDF5.chpl
+++ b/test/UnitTestHDF5.chpl
@@ -89,12 +89,12 @@ proc test_readAllHdfMsg(t: borrowed Test) throws {
     // Exercise the basic read functionality with & without offsets and then again using dataset names
     var payload = "false 1 1 false false [\"strings\"] | [\"resources/UnitTestHDF5_withOffsets_LOCALE0000\"]";
     var msg = readAllHdfMsg("readAllHdfMsg", payload, st);
-    t.assertTrue(msg.msg.find("str 5 1 (5) 1+created bytes.size 24") > 0);
+    t.assertTrue(msg.msg.find("str 5 1 (5,) 1+created bytes.size 24") > 0);
 
     // Same test built with calcOffsets true & noOffsets file
     payload = "false 1 1 false true [\"strings\"] | [\"resources/UnitTestHDF5_noOffsets_LOCALE0000\"]";
     msg = readAllHdfMsg("readAllHdfMsg", payload, st);
-    t.assertTrue(msg.msg.find("str 5 1 (5) 1+created bytes.size 24") > 0);
+    t.assertTrue(msg.msg.find("str 5 1 (5,) 1+created bytes.size 24") > 0);
 }
 
 /**


### PR DESCRIPTION
Chapel 1.27 includes scan optimizations and scans are used heavily in
Arkouda so it improves the performance of quite a few operations.

More details about the 1.27 release can be found at:
https://chapel.discourse.group/t/announcing-chapel-1-27-0/13627

Closes https://github.com/Bears-R-Us/arkouda/issues/1546