### PR TITLE
Rename `SegString.hash()` to `SegString.siphash()`

### DIFF
--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -175,7 +175,7 @@ module ArgSortMsg
     }
 
     proc incrementalArgSort(s: SegString, iv: [?aD] int): [] int throws {
-      var hashes = s.hash();
+      var hashes = s.siphash();
       var newHashes: [aD] 2*uint;
       forall (nh, idx) in zip(newHashes, iv) with (var agg = newSrcAggregator((2*uint))) {
         agg.copy(nh, hashes[idx]);

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -335,7 +335,7 @@ module SegmentedArray {
 
     /* Apply a hash function to all strings. This is useful for grouping
        and set membership. The hash used is SipHash128.*/
-    proc hash() throws {
+    proc siphash() throws {
       return computeOnSegments(offsets.a, values.a, SegFunction.SipHash128, 2*uint(64));
     }
 
@@ -348,7 +348,7 @@ module SegmentedArray {
         // Hash all strings
         saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "Hashing strings"); 
         if logLevel == LogLevel.DEBUG { t.start(); }
-        var hashes = this.hash();
+        var hashes = this.siphash();
 
         if logLevel == LogLevel.DEBUG { 
             t.stop();    
@@ -1113,8 +1113,8 @@ module SegmentedArray {
                            errorClass="ArgumentError");
     }
     if useHash {
-      const lh = lss.hash();
-      const rh = rss.hash();
+      const lh = lss.siphash();
+      const rh = rss.siphash();
       return if polarity then (lh == rh) else (lh != rh);
     }
     ref oD = lss.offsets.aD;
@@ -1263,7 +1263,7 @@ module SegmentedArray {
       var truth: [mainStr.offsets.aD] bool;
       return truth;
     }
-    return in1d(mainStr.hash(), testStr.hash(), invert);
+    return in1d(mainStr.siphash(), testStr.siphash(), invert);
   }
 
   proc concat(s1: [] int, v1: [] uint(8), s2: [] int, v2: [] uint(8)) throws {

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -601,7 +601,7 @@ module SegmentedMsg {
     select objtype {
         when "str" {
             var strings = getSegString(name, st);
-            var hashes = strings.hash();
+            var hashes = strings.siphash();
             var name1 = st.nextName();
             var hash1 = st.addEntry(name1, hashes.size, uint);
             var name2 = st.nextName();

--- a/src/Unique.chpl
+++ b/src/Unique.chpl
@@ -172,7 +172,7 @@ module Unique
         var truth: [aD] bool;
         var perm: [aD] int;
         if SegmentedArrayUseHash {
-          var hashes = str.hash();
+          var hashes = str.siphash();
           var sorted: [aD] 2*uint;
           forall (s, p, sp) in zip(sorted, perm, radixSortLSD(hashes)) {
             (s, p) = sp;

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -271,7 +271,7 @@ module UniqueMsg
           when "str" {
             var (myNames, _) = name.splitMsgToTuple('+', 2);
             var g = getSegString(myNames, st);
-            hashes ^= rotl(g.hash(), i);
+            hashes ^= rotl(g.siphash(), i);
           }
         }
       }

--- a/test/UnitTestIn1d.chpl
+++ b/test/UnitTestIn1d.chpl
@@ -98,10 +98,10 @@ prototype module UnitTestIn1d
         var d: Diags;
         d.start();
         // returns a boolean vector
-        var truth = in1dAr2PerLocAssoc(str1.hash(), str2.hash());
+        var truth = in1dAr2PerLocAssoc(str1.siphash(), str2.siphash());
         d.stop("in1d (associative domain)");
         d.start();
-        var truth2 = in1dSort(str1.hash(), str2.hash());
+        var truth2 = in1dSort(str1.siphash(), str2.siphash());
         d.stop("in1d (sort-based)");
         writeln("Results of both strategies match? >>> ", && reduce (truth == truth2), " <<<");
         if printExpected then writeln("<<< #str1[i] in str2 = ", + reduce truth, " (expected ", expected, ")");try! stdout.flush();


### PR DESCRIPTION
`hash()` is currently a special method in Chapel and we recently added
some extra checking upstream that disallows using the name without the
`override` keyword. We haven't settled on the name `hash()` yet and are
considering special methods with names more unique as to not interfere
with user names, but until that's settled I think it's easiest to just
give the segmented string hash a different name to stay compatible.

Resolves #1555