### PR TITLE
Closes #1161: Update `make test-chapel` to run unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -429,7 +429,10 @@ $(eval $(call create_help_target,test-help,TEST_HELP_TEXT))
 test: test-python
 
 .PHONY: test-chapel
-test-chapel: $(TEST_TARGETS)
+.SILENT:
+test-chapel:
+	@echo $(shell python3 $(MODULE_GENERATION_SCRIPT) $(ARKOUDA_CONFIG_FILE));
+	start_test $(TEST_SOURCE_DIR)
 
 .PHONY: test-all
 test-all: test-python test-chapel


### PR DESCRIPTION
This PR (Closes #1161):
- Updates `make test-chapel` to run unit tests in addition to compiling them
- This now runs the same commands the CI uses i.e.
```bash
python3 src/serverModuleGen.py ServerModules.cfg
start_test test
```
NOTE:
I'm not the best with `make`, so please feel free to suggest a different approach. I got this working using `.SILENT:` but that feels like overkill. I think we really just need `no-print-directory`, but I'm not sure how to get that to work. Without the silent, `make` will exclaim everytime it switches into the test directory and that interupts the compile statement

Tagging @mhmerrill, @bmcdonald3, and @ronawho as they are better with `make` than me