### PR TITLE
Closes #1545: Add portability testing to older chpl versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{matrix.python-version}}
     - name: Install dependencies
       run: |
         apt-get update && apt-get install -y -V ca-certificates lsb-release wget
@@ -86,9 +86,33 @@ jobs:
       run: |
         make
         python3 -m pip install -e .[dev]
-    - name: Arkouda make check
+    - name: Arkouda unit tests
       run: |
-        make check
+        make test-python
+
+  arkouda_chpl_portability:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        chpl-version: ['1.25.1', '1.26.0', '1.27.0']
+    container:
+      image: chapel/chapel:${{matrix.chpl-version}}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+        apt-get update && apt-get install -y -V ca-certificates lsb-release wget
+        wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+        apt-get install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+        apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip libarrow-dev libparquet-dev
+        echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" > Makefile.paths
+    - name: Check chpl version
+      run: |
+        chpl --version
+    - name: Build/Install Arkouda
+      run: |
+        make
+        python3 -m pip install -e .[dev]
     - name: Arkouda unit tests
       run: |
         make test-python


### PR DESCRIPTION
Add portability testing for chpl 1.25/1.26. The documentation currently
"requires" 1.27, but we expect older versions to continue to work. Add
some testing to lock in that the versions we expect to work continue to
do so. I think we're planning to drop support for 1.25 soon, but wanted
to start with it for now.

Closes #1545