### PR TITLE
Closes #848: Limit Length of File Lines Logged

### DIFF
--- a/src/FileIO.chpl
+++ b/src/FileIO.chpl
@@ -329,7 +329,10 @@ module FileIO {
       try {
         filelist = jsonToPdArray(jsonfiles, nfiles);
       } catch {
-        var errorMsg = "Could not decode json filenames via tempfile (%i files: %s)".format(nfiles, jsonfiles);
+        // limit length of file names to 2000 chars
+        var n: int = 1000;
+        var files: string = if jsonfiles.size > 2*n then jsonfiles[0..#n]+'...'+jsonfiles[jsonfiles.size-n..#n] else jsonfiles;
+        var errorMsg = "Could not decode json filenames via tempfile (%i files: %s)".format(nfiles, files);
         return new MsgTuple(errorMsg, MsgType.ERROR);
       }
       

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -1836,8 +1836,11 @@ module HDF5Msg {
         try {
             dsetlist = jsonToPdArray(jsondsets, ndsets);
         } catch {
+            // limit length of dataset names to 2000 chars
+            var n: int = 1000;
+            var dsets: string = if jsondsets.size > 2*n then jsondsets[0..#n]+'...'+jsondsets[jsondsets.size-n..#n] else jsondsets;
             var errorMsg = "Could not decode json dataset names via tempfile (%i files: %s)".format(
-                                               ndsets, jsondsets);
+                                                ndsets, dsets);
             h5Logger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
             return new MsgTuple(errorMsg, MsgType.ERROR);
         }
@@ -1845,7 +1848,10 @@ module HDF5Msg {
         try {
             filelist = jsonToPdArray(jsonfiles, nfiles);
         } catch {
-            var errorMsg = "Could not decode json filenames via tempfile (%i files: %s)".format(nfiles, jsonfiles);
+            // limit length of file names to 2000 chars
+            var n: int = 1000;
+            var files: string = if jsonfiles.size > 2*n then jsonfiles[0..#n]+'...'+jsonfiles[jsonfiles.size-n..#n] else jsonfiles;
+            var errorMsg = "Could not decode json filenames via tempfile (%i files: %s)".format(nfiles, files);
             h5Logger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
             return new MsgTuple(errorMsg, MsgType.ERROR);
         }

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -559,8 +559,11 @@ module ParquetMsg {
     try {
         dsetlist = jsonToPdArray(jsondsets, ndsets);
     } catch {
+        // limit length of dataset names to 2000 chars
+        var n: int = 1000;
+        var dsets: string = if jsondsets.size > 2*n then jsondsets[0..#n]+'...'+jsondsets[jsondsets.size-n..#n] else jsondsets;
         var errorMsg = "Could not decode json dataset names via tempfile (%i files: %s)".format(
-                                            1, jsondsets);
+                                            ndsets, dsets);
         pqLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
         return new MsgTuple(errorMsg, MsgType.ERROR);
     }
@@ -568,7 +571,10 @@ module ParquetMsg {
     try {
         filelist = jsonToPdArray(jsonfiles, nfiles);
     } catch {
-        var errorMsg = "Could not decode json filenames via tempfile (%i files: %s)".format(nfiles, jsonfiles);
+        // limit length of file names to 2000 chars
+        var n: int = 1000;
+        var files: string = if jsonfiles.size > 2*n then jsonfiles[0..#n]+'...'+jsonfiles[jsonfiles.size-n..#n] else jsonfiles;
+        var errorMsg = "Could not decode json filenames via tempfile (%i files: %s)".format(nfiles, files);
         pqLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
         return new MsgTuple(errorMsg, MsgType.ERROR);
     }
@@ -896,7 +902,10 @@ module ParquetMsg {
     try {
       filelist = jsonToPdArray(jsonfiles, nfiles);
     } catch {
-      var errorMsg = "Could not decode json filenames via tempfile (%i files: %s)".format(nfiles, jsonfiles);
+      // limit length of file names to 2000 chars
+      var n: int = 1000;
+      var files: string = if jsonfiles.size > 2*n then jsonfiles[0..#n]+'...'+jsonfiles[jsonfiles.size-n..#n] else jsonfiles;
+      var errorMsg = "Could not decode json filenames via tempfile (%i files: %s)".format(nfiles, files);
       pqLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
       return new MsgTuple(errorMsg, MsgType.ERROR);
     }


### PR DESCRIPTION
This PR (Closes #848):
- Adds limit to length of file/dset names logged

I had no idea what n should be. I made it 1000 characters (so lengths > 2000 are truncated) because that seemed reasonable to me. I'm certainly open to suggestions for different values

If I could get @Ethan-DeBandi99's help testing that this works as intended, that would be awesome!