### PR TITLE
Closes #1565 - Add `Index.is_unique`

### DIFF
--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -302,6 +302,7 @@ class Index:
             ),
         )
 
+
 class MultiIndex(Index):
     def __init__(self, values):
         if not (isinstance(values, list) or isinstance(values, tuple)):

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -79,6 +79,21 @@ class Index:
     def shape(self):
         return (self.size,)
 
+    @property
+    def is_unique(self):
+        """
+        Property indicating if all values in the index are unique
+        Returns
+        -------
+            bool - True if all values are unique, False otherwise.
+        """
+        g = GroupBy(self.values)
+        key, ct = g.count()
+        if (ct > 1).any():
+            return False
+        else:
+            return True
+
     @staticmethod
     def factory(index):
         t = type(index)
@@ -286,7 +301,6 @@ class Index:
                 f"{self.dtype} {strings_placeholder} {compressed}",
             ),
         )
-
 
 class MultiIndex(Index):
     def __init__(self, values):

--- a/tests/index_test.py
+++ b/tests/index_test.py
@@ -33,6 +33,13 @@ class IndexTest(ArkoudaTest):
         with self.assertRaises(ValueError):
             idx = ak.MultiIndex([ak.arange(5), ak.arange(3)])
 
+    def test_is_unique(self):
+        i = ak.Index(ak.array([0, 1, 2]))
+        self.assertTrue(i.is_unique)
+
+        i = ak.Index(ak.array([0, 1, 1]))
+        self.assertTrue(i.is_unique is False)
+
     def test_factory(self):
         idx = ak.Index.factory(ak.arange(5))
         self.assertIsInstance(idx, ak.Index)


### PR DESCRIPTION
Closes #1565 

Adds `ak.Index.is_unique`. Returns `True` if all values of the Index are unique, otherwise returns `False`.

Adds testing for `ak.Index.is_unique`.

Once this and PR #1168 are merged, we can update the renaming workflow for indexes to only update a specific value if the Index object is unique.