### PR TITLE
 Closes #1519: Add strip method to Strings

### DIFF
--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -526,6 +526,51 @@ class Strings:
         )
 
     @typechecked
+    def strip(self, chars: Optional[Union[bytes, str_scalars]] = "") -> Strings:
+        """
+        Returns a new Strings object with all leading and trailing occurrences of characters contained
+        in chars removed. The chars argument is a string specifying the set of characters to be removed.
+        If omitted, the chars argument defaults to removing whitespace. The chars argument is not a
+        prefix or suffix; rather, all combinations of its values are stripped.
+
+        Parameters
+        ----------
+        chars : the set of characters to be removed
+
+        Returns
+        -------
+        Strings
+            Strings object with the leading and trailing characters matching the set of characters in
+            the chars argument removed
+
+        Raises
+        ------
+        RuntimeError
+            Raised if there is a server-side error thrown
+
+        Examples
+        --------
+        >>> strings = ak.array(['Strings ', '  StringS  ', 'StringS   '])
+        >>> s = strings.strip()
+        >>> s
+        array(['Strings', 'StringS', 'StringS'])
+
+        >>> strings = ak.array(['Strings 1', '1 StringS  ', '  1StringS  12 '])
+        >>> s = strings.strip(' 12')
+        >>> s
+        array(['Strings', 'StringS', 'StringS'])
+        """
+        # The following "if" block is a hack to get around the limitation of sending arguments where
+        # the first character of the argument is a space. Ordinarily, this would result in the space not
+        # being part of the argument.
+        # TODO - Remove this "if" block when we go to JSON for message passing.
+        if isinstance(chars, bytes):
+            chars = chars.decode()
+        args = "{} {} {}".format(self.objtype, self.entry.name, chars,)
+        rep_msg = generic_msg(cmd="segmentedStrip", args=args)
+        return Strings.from_return_msg(cast(str, rep_msg))
+
+    @typechecked
     def cached_regex_patterns(self) -> List:
         """
         Returns the regex patterns for which Match objects have been cached

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -560,10 +560,6 @@ class Strings:
         >>> s
         array(['Strings', 'StringS', 'StringS'])
         """
-        # The following "if" block is a hack to get around the limitation of sending arguments where
-        # the first character of the argument is a space. Ordinarily, this would result in the space not
-        # being part of the argument.
-        # TODO - Remove this "if" block when we go to JSON for message passing.
         if isinstance(chars, bytes):
             chars = chars.decode()
         args = "{} {} {}".format(self.objtype, self.entry.name, chars,)

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -476,6 +476,31 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
+  proc segmentedStripMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    var pn = Reflection.getRoutineName();
+    var repMsg: string;
+
+    var (objtype, name, chars) = payload.splitMsgToTuple(" ", 3);
+
+    // check to make sure symbols defined
+    st.checkTable(name);
+
+    select (objtype) {
+      when ("str") {
+        var strings = getSegString(name, st);
+        var (off, val) = strings.strip(chars);
+        var retString = getSegString(off, val, st);
+        repMsg = "created " + st.attrib(retString.name) + "+created bytes.size %t".format(retString.nBytes);
+        return new MsgTuple(repMsg, MsgType.NORMAL);
+      }
+      otherwise {
+          var errorMsg = notImplementedError(pn, "%s".format(objtype));
+          smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+          return new MsgTuple(errorMsg, MsgType.ERROR);
+      }
+    }
+  }
+
   proc createPeelSymEntries(lo, lv, ro, rv, st: borrowed SymTab) throws {
     var leftEntry = getSegString(lo, lv, st);
     var rightEntry = getSegString(ro, rv, st);
@@ -1005,6 +1030,7 @@ module SegmentedMsg {
     registerFunction("segmentedFindAll", segmentedFindAllMsg, getModuleName());
     registerFunction("segmentedPeel", segmentedPeelMsg, getModuleName());
     registerFunction("segmentedSub", segmentedSubMsg, getModuleName());
+    registerFunction("segmentedStrip", segmentedStripMsg, getModuleName());
     registerFunction("segmentedIndex", segmentedIndexMsg, getModuleName());
     registerFunction("segmentedBinopvv", segBinopvvMsg, getModuleName());
     registerFunction("segmentedBinopvs", segBinopvsMsg, getModuleName());

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -540,6 +540,42 @@ class StringTest(ArkoudaTest):
         lengths = s1.get_lengths()
         self.assertTrue((ak.array([3, 3, 5, 4, 4]) == lengths).all())
 
+    def test_strip(self):
+        s = ak.array([" Jim1", "John1   ", "Steve1 2"])
+        strip = s.strip(" 12")
+        expected = ak.array(["Jim", "John", "Steve"])
+        self.assertListEqual(strip.to_ndarray().tolist(), expected.to_ndarray().tolist())
+
+        s = ak.array([" Jim1", "John1   ", "Steve1 2"])
+        strip = s.strip("12 ")
+        expected = ak.array(["Jim", "John", "Steve"])
+        self.assertListEqual(strip.to_ndarray().tolist(), expected.to_ndarray().tolist())
+
+        s = ak.array([" Jim1", "John1   ", "Steve1 2"])
+        strip = s.strip("1 2")
+        expected = ak.array(["Jim", "John", "Steve"])
+        self.assertListEqual(strip.to_ndarray().tolist(), expected.to_ndarray().tolist())
+
+        s = ak.array([" Jim", "John 1", "Steve1 2  "])
+        strip = s.strip()
+        expected = ak.array(["Jim", "John 1", "Steve1 2"])
+        self.assertListEqual(strip.to_ndarray().tolist(), expected.to_ndarray().tolist())
+
+        s = ak.array(['\nStrings ', ' \n StringS \r', 'bbabStringS \r\t '])
+        strip = s.strip()
+        expected = ak.array(["Strings", "StringS", "bbabStringS"])
+        self.assertListEqual(strip.to_ndarray().tolist(), expected.to_ndarray().tolist())
+
+        s = ak.array(["abcStringsbac", "cabStringScc", "bbabStringS abc"])
+        strip = s.strip('abc')
+        expected = ak.array(["Strings", "StringS", "StringS "])
+        self.assertListEqual(strip.to_ndarray().tolist(), expected.to_ndarray().tolist())
+
+        s = ak.array(['\nStrings ', ' \n StringS \r', ' \t   StringS \r\t '])
+        strip = s.strip()
+        expected = ak.array(["Strings", "StringS", "StringS"])
+        self.assertListEqual(strip.to_ndarray().tolist(), expected.to_ndarray().tolist())
+
     def test_case_change(self):
         mixed = ak.array([f"StrINgS {i}" for i in range(10)])
 
@@ -570,7 +606,7 @@ class StringTest(ArkoudaTest):
         istitle = lmut.is_title()
         expected = ak.arange(40) >= 30
         self.assertListEqual(istitle.to_ndarray().tolist(), expected.to_ndarray().tolist())
-        
+
     def test_concatenate(self):
         s1 = self._get_strings("string", 51)
         s2 = self._get_strings("string-two", 51)


### PR DESCRIPTION
 This PR (Closes #1519):

- Add ability to strip leading and trailing characters from original Strings
	- If a set of characters is provided, it is used as a list of leading and trailing characters to remove
	- If no set of characters is provided, the leading and trailing characters default to spaces