### PR TITLE
Closes #1573: Remove python script generation for Chapel unit tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -173,5 +173,4 @@ jobs:
         echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" > Makefile.paths
     - name: Run unit tests
       run: |
-        python3 src/serverModuleGen.py ServerModules.cfg
         start_test test

--- a/Makefile
+++ b/Makefile
@@ -427,7 +427,6 @@ test: test-python
 .PHONY: test-chapel
 .SILENT:
 test-chapel:
-	@echo $(shell python3 $(MODULE_GENERATION_SCRIPT) $(ARKOUDA_CONFIG_FILE));
 	start_test $(TEST_SOURCE_DIR)
 
 .PHONY: test-all

--- a/src/CommandMap.chpl
+++ b/src/CommandMap.chpl
@@ -1,5 +1,4 @@
 module CommandMap {
-  use ServerRegistration;
   use Map;
   use Message;
   use MultiTypeSymbolTable;


### PR DESCRIPTION
`CommandMap.chpl` for some reason had a `use ServerRegistration`
that I believe was added by accident and that was making the
Chapel unit tests need the `ServerRegistration` script to be
generated. This PR removes that unnecessary `use` and takes out
the python script call from the CI and Chapel unit tests.

Closes https://github.com/Bears-R-Us/arkouda/issues/1573