### PR TITLE
Optimize string indexing by removing extra interior domain creations

### DIFF
--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -269,10 +269,11 @@ module SegmentedArray {
         srcIdx = 1;
         var diffs: [D] int;
         diffs[D.low] = left[D.low]; // first offset is not affected by scan
-        if (D.size > 1) {
-          // This expression breaks when D.size == 1, resulting in strange behavior
-          // However, this logic is only necessary when D.size > 1 anyway
-          diffs[D.interior(D.size-1)] = left[D.interior(D.size-1)] - (right[D.interior(-(D.size-1))] - 1);
+
+        forall idx in D {
+          if idx!=0 {
+            diffs[idx] = left[idx] - (right[idx-1]-1);
+          }
         }
         // Set srcIdx to diffs at segment boundaries
         forall (go, d) in zip(gatheredOffsets, diffs) with (var agg = newDstAggregator(int)) {


### PR DESCRIPTION
In pdarray indexing previously, there were 3 calls to `interior`
on the domain of the array that was causing overhead from creating
the additional domains from those calls. This PR instead just loops
over the entire domain to avoid needing to create those extra
domains.

This impact is most beneficial for small problem sizes where
creation overheads are more pronounced, but results in a slight
performance improvement for all cases.

String gather benchmark on 16-node-cs-hdr:
master        | this branch   |
------------- | ------------- |
23.20 GiB/sec | 24.74 GiB/sec |