### PR TITLE
Closes #1584 - Use the non-deprecated methods `util`

### DIFF
--- a/FILEIO.md
+++ b/FILEIO.md
@@ -35,10 +35,11 @@ Each file can contain multiple datasets. Groups are not currently used.
       4) Attribute: `Format`
       5) Data
 
-`Rank`: `int` representing the number of dimensions in the dataset. This should be stored as the rank of the *unflattened* data, even when storing as a flattened array.
+`Rank`: `int` 
+   Integer representing the number of dimensions in the dataset. This should be stored as the rank of the *unflattened* data, even when storing as a flattened array.
 
-`Shape`: `int array` storing the size of each dimension. The array should be of length equal to the `Rank`.
+`Shape`: `int array` Integer array storing the size of each dimension. The array should be of length equal to the `Rank`.
 
-`ObjType`: `b'ArrayView'` Indicates the object type. This is used when loading data to return the correct object type.
+`ObjType`: `b'ArrayView'` Byte string indicating the object type. This is used when loading data to return the correct object type.
 
 `Format`: `int` Integer that is mapped to `flat` and `multi`. `flat==0` and `multi==1`. This indicates the formatting of the data within the HDF5 dataset.

--- a/FILEIO.md
+++ b/FILEIO.md
@@ -8,7 +8,7 @@
    1. [Multidimensional Objects](#multidim)
 
 ## Supported File Types
-Arkouda currently supports 2 file types (listed below). When storing data, the way the data is stored may vary. This file will detail out the "schema" each file type is expected to follow. If your file does not follow the detailed "schema", please try utilization of our `import`/`export` tools. *Please Note: utilization of these tools is dependent on the size of the data because they only run on the client.*
+Arkouda currently supports 2 file types (listed below). When storing data, the way the data is stored may vary. This file will detail out the "schema" each file type is expected to follow. If your file does not follow the detailed "schema", please try using our `import`/`export` tools. *Please Note: The functionality of these tools is dependent on the size of the data because they only run on the client.*
 
 - HDF5
 - Parquet
@@ -21,7 +21,7 @@ Arkouda currently supports 2 file types (listed below). When storing data, the w
       1) Attributes
       2) Data
 
-Each file can contain multiple datasets. Groups are not currently utilized.
+Each file can contain multiple datasets. Groups are not currently used.
 
 ### Multidimensional Objects
 

--- a/FILEIO.md
+++ b/FILEIO.md
@@ -1,0 +1,44 @@
+# Arkouda File Support
+
+*Please Note: This file is being developed in conjunction with updates to our file I/O system. Information is being omitted until updates on each section are completed to avoid confusion.*
+
+## Table of Contents
+1. [File Types](#filetypes)
+2. [HDF5](#hdf)
+   1. [Multidimensional Objects](#multidim)
+
+## Supported File Types
+Arkouda currently supports 2 file types (listed below). When storing data, the way the data is stored may vary. This file will detail out the "schema" each file type is expected to follow. If your file does not follow the detailed "schema", please try utilization of our `import`/`export` tools. *Please Note: utilization of these tools is dependent on the size of the data because they only run on the client.*
+
+- HDF5
+- Parquet
+
+## HDF5
+
+**Simplified Structure**
+1) File
+   1) Dataset
+      1) Attributes
+      2) Data
+
+Each file can contain multiple datasets. Groups are not currently utilized.
+
+### Multidimensional Objects
+
+*Please Note: `import`/`export` functionality is not currently supported for multidimensional objects.*
+
+1) File
+   1) Dataset 
+      1) Attribute: `Rank`
+      2) Attribute: `Shape`
+      3) Attribute: `ObjType`
+      4) Attribute: `Format`
+      5) Data
+
+`Rank`: `int` representing the number of dimensions in the dataset. This should be stored as the rank of the *unflattened* data, even when storing as a flattened array.
+
+`Shape`: `int array` storing the size of each dimension. The array should be of length equal to the `Rank`.
+
+`ObjType`: `b'ArrayView'` Indicates the object type. This is used when loading data to return the correct object type.
+
+`Format`: `int` Integer that is mapped to `flat` and `multi`. `flat==0` and `multi==1`. This indicates the formatting of the data within the HDF5 dataset.

--- a/ServerModules.cfg
+++ b/ServerModules.cfg
@@ -25,6 +25,7 @@ BroadcastMsg
 FlattenMsg
 HDF5Msg
 ParquetMsg
+HDF5_MultiDim
 
 # Add additional modules located outside
 # of the Arkouda src/ directory below.

--- a/ServerModules.cfg
+++ b/ServerModules.cfg
@@ -25,7 +25,7 @@ BroadcastMsg
 FlattenMsg
 HDF5Msg
 ParquetMsg
-HDF5_MultiDim
+HDF5MultiDim
 
 # Add additional modules located outside
 # of the Arkouda src/ directory below.

--- a/arkouda/array_view.py
+++ b/arkouda/array_view.py
@@ -314,7 +314,7 @@ class ArrayView:
 
     def save(self, filepath: str, dset: str, mode: str = "truncate", storage: str = "Flat"):
         """
-        Save the current ArrayView object to hdf5
+        Save the current ArrayView object to hdf5 file
 
         Parameters
         ----------

--- a/arkouda/array_view.py
+++ b/arkouda/array_view.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from enum import Enum
 
@@ -9,6 +11,7 @@ from arkouda.numeric import cast as akcast
 from arkouda.numeric import cumprod, where
 from arkouda.pdarrayclass import create_pdarray, parse_single_value, pdarray
 from arkouda.pdarraycreation import arange, array, ones, zeros
+from arkouda.pdarrayIO import read_hdf5_multi_dim, write_hdf5_multi_dim
 from arkouda.pdarraysetops import concatenate
 
 OrderType = Enum("OrderType", ["ROW_MAJOR", "COLUMN_MAJOR"])
@@ -308,3 +311,51 @@ class ArrayView:
             return self.base.to_ndarray().reshape(self.shape.to_ndarray())
         else:
             return self.base.to_ndarray().reshape(self.shape.to_ndarray(), order="F")
+
+    def save(self, filepath: str, dset: str, mode: str = "truncate", storage: str = "Flat"):
+        """
+        Save the current ArrayView object to hdf5
+
+        Parameters
+        ----------
+        filepath: str
+            Path to the file to write the dataset to
+        dset: str
+            Name of the dataset to write
+        mode: str (truncate | append)
+            Default: truncate
+            Mode to write the dataset in. Truncate will overwrite any existing files.
+            Append will add the dataset to an existing file.
+        storage: str (Flat | Multi)
+            Default: Flat
+            Method to use when storing the dataset.
+            Flat - flatten the multi-dimensional object into a 1-D array of values
+            Multi - Store the object in the multidimensional presentation.
+
+        See Also
+        --------
+        ak.ArrayView.load
+        """
+        write_hdf5_multi_dim(self, filepath, dset, mode=mode, storage=storage)
+
+    @staticmethod
+    def load(filepath: str, dset: str) -> ArrayView:
+        """
+        Read a multi-dimensional dataset from an HDF5 file into an ArrayView object
+
+        Parameters
+        ----------
+        file_path: str
+            path to the file to read from
+        dset: str
+            name of the dataset to read
+
+        Returns
+        -------
+        ArrayView object representing the data read from file
+
+        See Also
+        --------
+        ak.ArrayView.save
+        """
+        return read_hdf5_multi_dim(filepath, dset)

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -1137,7 +1137,7 @@ class DataFrame(UserDict):
         self
             Appending occurs in-place, but result is returned for compatibility.
         """
-        from arkouda.util import concatenate as util_concatenate
+        from arkouda.util import generic_concat as util_concatenate
 
         # Do nothing if the other dataframe is empty
         if other.empty:
@@ -1178,7 +1178,7 @@ class DataFrame(UserDict):
         """
         Essentially an append, but diffenent formatting
         """
-        from arkouda.util import concatenate as util_concatenate
+        from arkouda.util import generic_concat as util_concatenate
 
         if len(items) == 0:
             return cls()
@@ -1220,7 +1220,7 @@ class DataFrame(UserDict):
 
         Returns
         -------
-        akutil.DataFrame
+        ak.DataFrame
             The first `n` rows of the DataFrame.
 
         See Also
@@ -1245,12 +1245,12 @@ class DataFrame(UserDict):
 
         Returns
         -------
-        akutil.DataFrame
+        ak.DataFrame
             The last `n` rows of the DataFrame.
 
         See Also
         --------
-        akutil.dataframe.head
+        ak.dataframe.head
         """
 
         self.update_size()
@@ -1269,7 +1269,7 @@ class DataFrame(UserDict):
 
         Returns
         -------
-        akutil.DataFrame
+        ak.DataFrame
             The sampled `n` rows of the DataFrame.
         """
         self.update_size()
@@ -1285,12 +1285,12 @@ class DataFrame(UserDict):
         ----------
         keys : string or list
             An (ordered) list of column names or a single string to group by.
-        use_series : If True, returns an akutil.GroupBy oject. Otherwise an arkouda GroupBy object
+        use_series : If True, returns a GroupBy object. Otherwise, an arkouda GroupBy object
 
         Returns
         -------
         GroupBy
-            Either an akutil GroupBy or an arkouda GroupBy object.
+            Either a GroupBy or an arkouda GroupBy object.
 
         See Also
         --------
@@ -1814,7 +1814,7 @@ def sorted(df, column=False):
 
     Parameters
     ----------
-    df : akutil.dataframe.DataFrame
+    df : ak.dataframe.DataFrame
         The DataFrame to sort.
 
     column : str
@@ -1822,7 +1822,7 @@ def sorted(df, column=False):
 
     Returns
     -------
-    akutil.dataframe.DataFrame
+    ak.dataframe.DataFrame
         A sorted copy of the original DataFrame.
     """
 

--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -822,6 +822,7 @@ def read_hdf5_multi_dim(file_path: str, dset: str) -> arkouda.array_view.ArrayVi
         - This is an initial implementation and updates will be coming soon
         - dset currently only reading a single dataset is supported
         - file_path will need to support list[str] and str for glob
+        - Currently, order is always assumed to be row major
     """
     rep_msg = cast(str, generic_msg(cmd="readhdf_multi", args=f"{file_path} {dset}",))
 

--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -821,7 +821,7 @@ def read_hdf5_multi_dim(file_path: str, dset: str) -> ArrayView:
         - dset currently only reading a single dataset is supported
         - file_path will need to support list[str] and str for glob
     """
-    rep_msg = generic_msg(cmd="readhdf_multi", args=f"{file_path} {dset}",)
+    rep_msg = cast(str, generic_msg(cmd="readhdf_multi", args=f"{file_path} {dset}",))
 
     objs = rep_msg.split("+")
 

--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Mapping, Optional, Union, cast
 import pandas as pd  # type: ignore
 from typeguard import typechecked
 
+from arkouda.array_view import ArrayView
 from arkouda.categorical import Categorical
 from arkouda.client import generic_msg
 from arkouda.pdarrayclass import create_pdarray, pdarray
@@ -23,6 +24,8 @@ __all__ = [
     "get_null_indices",
     "import_data",
     "export",
+    "read_hdf5_multi_dim",
+    "write_hdf5_multi_dim",
 ]
 
 ARKOUDA_HDF5_FILE_METADATA_GROUP = "_arkouda_metadata"
@@ -789,3 +792,139 @@ def export(
 
     if return_obj:
         return df
+
+
+@typechecked
+def read_hdf5_multi_dim(file_path: str, dset: str) -> ArrayView:
+    """
+    Read a multi-dimensional object from an HDF5 file
+
+    Parameters
+    ----------
+    file_path: str
+        path to the file to read from
+    dset: str
+        name of the dataset to read
+
+    Returns
+    -------
+    ArrayView object representing the data read from file
+
+    See Also
+    --------
+    ak.write_hdf5_multi_dim
+
+    Notes
+    -----
+        - Error handling done on server to prevent multiple server calls
+        - This is an initial implementation and updates will be coming soon
+        - dset currently only reading a single dataset is supported
+        - file_path will need to support list[str] and str for glob
+    """
+    rep_msg = generic_msg(cmd="readhdf_multi", args=f"{file_path} {dset}",)
+
+    objs = rep_msg.split("+")
+
+    shape = create_pdarray(objs[0])
+    flat = create_pdarray(objs[1])
+
+    arr = ArrayView(flat, shape)
+    return arr
+
+
+@typechecked
+def _storage_str_to_int(method: str) -> int:
+    """
+    Convert string to integer representing the storage method
+
+    Parameters
+    ----------
+    method: str (flat | multi)
+        The string representation of the storage format to be converted to integer
+
+    Returns
+    -------
+    int representing the storage method
+
+    Raises
+    ------
+    ValueError
+        - If mode is not 'flat' or 'multi'
+    """
+    if method.lower() == "flat":
+        return 0
+    elif method.lower() == "multi":
+        return 1
+    else:
+        raise ValueError(f"Storage method expected to be 'flat' or 'multi'. Got {method}.")
+
+
+@typechecked
+def _mode_str_to_int(mode: str) -> int:
+    """
+    Convert string to integer representing the mode to write
+
+    Parameters
+    ----------
+    mode: str (truncate | append)
+        The string representation of the write mode to be converted to integer
+
+    Returns
+    -------
+    int representing the mode
+
+    Raises
+    ------
+    ValueError
+        - If mode is not 'truncate' or 'append'
+    """
+    if mode.lower() == "truncate":
+        return 0
+    elif mode.lower() == "append":
+        return 1
+    else:
+        raise ValueError(f"Write Mode expected to be 'truncate' or 'append'. Got {mode}.")
+
+
+@typechecked
+def write_hdf5_multi_dim(
+    obj: ArrayView, file_path: str, dset: str, mode: str = "truncate", storage: str = "Flat"
+):
+    """
+    Write a multi-dimensional ArrayView object to an HDF5 file
+
+    Parameters
+    ----------
+    obj: ArrayView
+        The object that will be written to the file
+    file_path: str
+        Path to the file to write the dataset to
+    dset: str
+        Name of the dataset to write
+    mode: str (truncate | append)
+        Default: truncate
+        Mode to write the dataset in. Truncate will overwrite any existing files.
+        Append will add the dataset to an existing file.
+    storage: str (Flat | Multi)
+        Default: Flat
+        Method to use when storing the dataset.
+        Flat - flatten the multi-dimensional object into a 1-D array of values
+        Multi - Store the object in the multidimensional presentation.
+
+    See Also
+    --------
+    ak.read_hdf5_multi_dim
+
+    Notes
+    -----
+    - If a file does not exist, it will be created regardless of the mode value
+    - This function is currently standalone functionality for multi-dimensional datasets
+    - Error handling done on server to prevent multiple server calls
+    """
+    # error handling is done in the conversion functions
+    storage_int = _storage_str_to_int(storage)
+    mode_int = _mode_str_to_int(mode)
+    generic_msg(
+        cmd="writehdf_multi",
+        args=f"{obj.base.name} {obj.shape.name} {obj.order} {file_path} {dset} {mode_int} {storage_int}",
+    )

--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -824,7 +824,13 @@ def read_hdf5_multi_dim(file_path: str, dset: str) -> arkouda.array_view.ArrayVi
         - file_path will need to support list[str] and str for glob
         - Currently, order is always assumed to be row major
     """
-    rep_msg = cast(str, generic_msg(cmd="readhdf_multi", args=f"{file_path} {dset}",))
+    rep_msg = cast(
+        str,
+        generic_msg(
+            cmd="readhdf_multi",
+            args=f"{file_path} {dset}",
+        ),
+    )
 
     objs = rep_msg.split("+")
 

--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import glob
 import json
 import os
@@ -7,7 +9,7 @@ from typing import Dict, List, Mapping, Optional, Union, cast
 import pandas as pd  # type: ignore
 from typeguard import typechecked
 
-from arkouda.array_view import ArrayView
+import arkouda.array_view
 from arkouda.categorical import Categorical
 from arkouda.client import generic_msg
 from arkouda.pdarrayclass import create_pdarray, pdarray
@@ -795,7 +797,7 @@ def export(
 
 
 @typechecked
-def read_hdf5_multi_dim(file_path: str, dset: str) -> ArrayView:
+def read_hdf5_multi_dim(file_path: str, dset: str) -> arkouda.array_view.ArrayView:
     """
     Read a multi-dimensional object from an HDF5 file
 
@@ -828,7 +830,7 @@ def read_hdf5_multi_dim(file_path: str, dset: str) -> ArrayView:
     shape = create_pdarray(objs[0])
     flat = create_pdarray(objs[1])
 
-    arr = ArrayView(flat, shape)
+    arr = arkouda.array_view.ArrayView(flat, shape)
     return arr
 
 
@@ -888,7 +890,11 @@ def _mode_str_to_int(mode: str) -> int:
 
 @typechecked
 def write_hdf5_multi_dim(
-    obj: ArrayView, file_path: str, dset: str, mode: str = "truncate", storage: str = "Flat"
+    obj: arkouda.array_view.ArrayView,
+    file_path: str,
+    dset: str,
+    mode: str = "truncate",
+    storage: str = "Flat",
 ):
     """
     Write a multi-dimensional ArrayView object to an HDF5 file

--- a/src/HDF5MultiDim.chpl
+++ b/src/HDF5MultiDim.chpl
@@ -1,4 +1,4 @@
-module HDF5_MultiDim {
+module HDF5MultiDim {
     use IO;
     use CTypes;
     use Reflection;

--- a/src/HDF5MultiDim.chpl
+++ b/src/HDF5MultiDim.chpl
@@ -79,7 +79,7 @@ module HDF5MultiDim {
 
         var matchingFiles = glob("%s*%s".format(prefix, extension));
 
-        return matchingFiles.size > 0
+        return matchingFiles.size > 0;
     }
 
     /*

--- a/src/HDF5_MultiDim.chpl
+++ b/src/HDF5_MultiDim.chpl
@@ -283,8 +283,6 @@ module HDF5_MultiDim {
             return new MsgTuple(errorMsg, MsgType.ERROR);
         }
 
-        var flat_sym: borrowed GenSymEntry = getGenericTypedArrayEntry(flat_name, st);
-        // var flat = toSymEntry(flat_sym, int);
         var shape_sym: borrowed GenSymEntry = getGenericTypedArrayEntry(shape_name, st);
         var shape = toSymEntry(shape_sym, int);
 

--- a/src/HDF5_MultiDim.chpl
+++ b/src/HDF5_MultiDim.chpl
@@ -150,11 +150,9 @@ module HDF5_MultiDim {
         // check if rank is attr and then get.
         var rank: int;
         if C_HDF5.H5Aexists_by_name(dset_id, ".".c_str(), "Rank", C_HDF5.H5P_DEFAULT) > 0 {
-            writeln("Rank attr Found");
             var rank_id: C_HDF5.hid_t = C_HDF5.H5Aopen_by_name(dset_id, ".".c_str(), "Rank", C_HDF5.H5P_DEFAULT, C_HDF5.H5P_DEFAULT);
             var attr_type: C_HDF5.hid_t = C_HDF5.H5Aget_type(rank_id);
             C_HDF5.H5Aread(rank_id, getHDF5Type(int), c_ptrTo(rank));
-            //writeln(rank);
         }
         else{
             // Return error that file does not have required attrs
@@ -166,7 +164,6 @@ module HDF5_MultiDim {
         // check if shape attr is present and read it
         var shape: [0..#rank] int;
         if C_HDF5.H5Aexists_by_name(dset_id, ".".c_str(), "Shape", C_HDF5.H5P_DEFAULT) > 0 {
-            //writeln("Shape attr Found");
             var shape_id: C_HDF5.hid_t = C_HDF5.H5Aopen_by_name(dset_id, ".".c_str(), "Shape", C_HDF5.H5P_DEFAULT, C_HDF5.H5P_DEFAULT);
             var attr_type: C_HDF5.hid_t = C_HDF5.H5Aget_type(shape_id);
             C_HDF5.H5Aread(shape_id, getHDF5Type(shape.eltType), c_ptrTo(shape));

--- a/src/HDF5_MultiDim.chpl
+++ b/src/HDF5_MultiDim.chpl
@@ -385,7 +385,8 @@ module HDF5_MultiDim {
         C_HDF5.H5Sset_extent_simple(attrSpaceId, 1, c_ptrTo(adim), c_ptrTo(adim));
 
         attr_id = C_HDF5.H5Acreate2(dset_id, "Shape".c_str(), getHDF5Type(shape.a.eltType), attrSpaceId, C_HDF5.H5P_DEFAULT, C_HDF5.H5P_DEFAULT);
-        C_HDF5.H5Awrite(attr_id, getHDF5Type(shape.a.eltType), c_ptrTo(shape.a));
+        var localShape = new lowLevelLocalizingSlice(shape.a, 0..#shape.size);
+        C_HDF5.H5Awrite(attr_id, getHDF5Type(shape.a.eltType), localShape.ptr);
         C_HDF5.H5Aclose(attr_id);
 
 

--- a/src/HDF5_MultiDim.chpl
+++ b/src/HDF5_MultiDim.chpl
@@ -1,0 +1,339 @@
+module HDF5_MultiDim {
+    use IO;
+    use CTypes;
+    use Reflection;
+    use HDF5;
+    use FileIO;
+    use FileSystem;
+
+    use Logging;
+    use ServerConfig;
+    use Message;
+    use MultiTypeSymbolTable;
+    use MultiTypeSymEntry;
+    use CommAggregation;
+    use ServerErrors;
+    use ServerErrorStrings;
+
+    config const TRUNCATE: int = 0;
+    config const APPEND: int = 1;
+
+    private config const logLevel = ServerConfig.logLevel;
+    const h5tLogger = new Logger(logLevel);
+
+    require "c_helpers/help_h5ls.h", "c_helpers/help_h5ls.c";
+
+    private extern proc c_get_HDF5_obj_type(loc_id:C_HDF5.hid_t, name:c_string, obj_type:c_ptr(C_HDF5.H5O_type_t)):C_HDF5.herr_t;
+    private extern proc c_strlen(s:c_ptr(c_char)):c_size_t;
+    private extern proc c_incrementCounter(data:c_void_ptr);
+    private extern proc c_append_HDF5_fieldname(data:c_void_ptr, name:c_string);
+
+    config const FLAT: int = 0;
+    config const MULTI_DIM: int = 1;
+
+    /*
+    * Wrapper to call c function used to count the number of attributes
+    */
+    proc _count_attrs(loc_id:C_HDF5.hid_t, name:c_void_ptr, info:c_void_ptr, data:c_void_ptr){
+        c_incrementCounter(data);
+        return 0;
+    }
+
+    /*
+    * Wrapper to call out to c function to add attribute name to list
+    */
+    proc _list_attributes(loc_id:C_HDF5.hid_t, name:c_void_ptr, info:c_void_ptr, data:c_void_ptr){
+        var obj_name = name:c_string;
+
+        c_append_HDF5_fieldname(data, obj_name);
+
+        return 0;
+    }
+
+    /*
+    * Take a multidimensional array and flatten is to a 1 X (prod of dimensions)
+    */
+    proc _flatten(a: [?D] int, shape: [?sD] int){
+        var dim_prod: [sD] int = (* scan shape) / shape;
+        var flat_size: int = (* reduce shape);
+
+        var flat: [0..#flat_size] int;
+        for loc in D{
+            var idx: int;
+            for i in 0..#loc.size {
+                idx += loc[i] * dim_prod[(dim_prod.size-(i+1))];
+            }
+            flat[idx] = a[loc];
+        }
+
+        return flat;
+    }
+
+    /*
+    Returns a bool indicating if the file provided exists or not 
+    */
+    proc doesFileExists(filename: string): bool throws {
+        var prefix: string;
+        var extension: string;
+        (prefix,extension) = getFileMetadata(filename);
+
+        var matchingFiles = glob("%s*%s".format(prefix, extension));
+
+        if matchingFiles.size > 0 {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /*
+    Determines if the file exists and creates if not.
+    In the event of truncation, remove the file if it already exists
+    */
+    proc prepFile(filename: string, mode: int) throws {
+        var fileExists: bool = doesFileExists(filename);
+
+        if ((!fileExists && mode == APPEND) || mode == TRUNCATE) {
+            if (mode == TRUNCATE && fileExists){
+                remove(filename);
+            }
+            // create the file
+            var file_id: C_HDF5.hid_t = C_HDF5.H5Fcreate(filename.c_str(), C_HDF5.H5F_ACC_TRUNC, C_HDF5.H5P_DEFAULT, C_HDF5.H5P_DEFAULT);
+            defer { // Close file upon exiting scope
+                C_HDF5.H5Fclose(file_id);
+            }
+
+            if file_id < 0 { // Negative file_id means error
+                throw getErrorWithContext(msg="Failure to create/overwrite file, %s".format(filename),
+                                            lineNumber=getLineNumber(), 
+                                            routineName=getRoutineName(), 
+                                            moduleName=getModuleName(), 
+                                            errorClass='FileNotFoundError');
+            }
+
+            // TODO - add the meta data to the file. This is not done yet because current model does not make sense as it is overwritten (or not updated on append)
+        }
+    }
+
+    /*
+    Reads an HDF5 dataset and builds the components as pdarrays
+    The resulting data is always in flattened form (as expected by ArrayView)
+    Adds a pdarray containing the flattened data and a pdarray containing the shape of the object to the symbol table
+    */
+    proc read_hdf_multi_msg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+        // Currently always load flat as row major
+        var (filename, dset_name) = payload.splitMsgToTuple(2);
+
+        var file_id: C_HDF5.hid_t;
+        var dset_id: C_HDF5.hid_t;
+
+        file_id = C_HDF5.H5Fopen(filename.c_str(), C_HDF5.H5F_ACC_RDONLY, C_HDF5.H5P_DEFAULT);
+
+        if file_id < 0 { // HF5open returns negative value on failure
+            C_HDF5.H5Fclose(file_id);
+            var errorMsg = "Failure accessing file %s.".format(filename);
+            h5tLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+        }
+
+        dset_id = C_HDF5.H5Dopen(file_id, dset_name.c_str(), C_HDF5.H5P_DEFAULT);
+        if dset_id < 0 { // HF5open returns negative value on failure
+            C_HDF5.H5Fclose(file_id);
+            var errorMsg = "Failure accessing dataset %s.".format(dset_name);
+            h5tLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);     
+        }
+        
+
+        // check if rank is attr and then get.
+        var rank: int;
+        if C_HDF5.H5Aexists_by_name(dset_id, ".".c_str(), "Rank", C_HDF5.H5P_DEFAULT) > 0 {
+            writeln("Rank attr Found");
+            var rank_id: C_HDF5.hid_t = C_HDF5.H5Aopen_by_name(dset_id, ".".c_str(), "Rank", C_HDF5.H5P_DEFAULT, C_HDF5.H5P_DEFAULT);
+            var attr_type: C_HDF5.hid_t = C_HDF5.H5Aget_type(rank_id);
+            C_HDF5.H5Aread(rank_id, getHDF5Type(int), c_ptrTo(rank));
+            //writeln(rank);
+        }
+        else{
+            // Return error that file does not have required attrs
+            var errorMsg = "Rank Attribute was not located in %s. This attribute is required to process multi-dimensional data.".format(filename);
+            h5tLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+        }
+
+        // check if shape attr is present and read it
+        var shape: [0..#rank] int;
+        if C_HDF5.H5Aexists_by_name(dset_id, ".".c_str(), "Shape", C_HDF5.H5P_DEFAULT) > 0 {
+            //writeln("Shape attr Found");
+            var shape_id: C_HDF5.hid_t = C_HDF5.H5Aopen_by_name(dset_id, ".".c_str(), "Shape", C_HDF5.H5P_DEFAULT, C_HDF5.H5P_DEFAULT);
+            var attr_type: C_HDF5.hid_t = C_HDF5.H5Aget_type(shape_id);
+            C_HDF5.H5Aread(shape_id, getHDF5Type(shape.eltType), c_ptrTo(shape));
+        }
+        else {
+            // Return error that file does not have required attrs
+            var errorMsg = "Shape Attribute was not located in %s. This attribute is required to process multi-dimensional data.".format(filename);
+            h5tLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+        }
+
+        var dset_domain: domain(3) = { // domain cannot init with runtime var. Must be set at compile
+            0..#shape[0],
+            0..#shape[1],
+            0..#shape[2]
+        };
+
+        var data: [dset_domain] int;
+
+        C_HDF5.H5Dread(dset_id, getHDF5Type(data.eltType), C_HDF5.H5S_ALL, C_HDF5.H5S_ALL, C_HDF5.H5P_DEFAULT, c_ptrTo(data));
+
+        var flat = _flatten(data, shape);
+
+        var fname = st.nextName();
+        st.addEntry(fname, new shared SymEntry(flat));
+
+        var sname = st.nextName();
+        st.addEntry(sname, new shared SymEntry(shape));
+
+        // Close the open hdf5 objects
+        C_HDF5.H5Dclose(dset_id);
+        C_HDF5.H5Fclose(file_id);
+
+        var repMsg: string = "created " + st.attrib(sname) + "+created " + st.attrib(fname);
+
+        return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+
+    /*
+    * Takes a multidimensional array obj and writes it into and HDF5 dataset.
+    * Provides the ability to store the data flat or multidimensional.
+    */
+    proc write_hdf_multi_msg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+        var (flat_name, shape_name, order_str, filename, dset_name, mode_str, method_str) = payload.splitMsgToTuple(7);
+        
+        var method: int;
+        try {
+            method = method_str:int;
+        } catch {
+            var errorMsg = "Could not convert method to numeric";
+            h5tLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+        }
+
+        var flat_sym: borrowed GenSymEntry = getGenericTypedArrayEntry(flat_name, st);
+        var flat = toSymEntry(flat_sym, int);
+        var shape_sym: borrowed GenSymEntry = getGenericTypedArrayEntry(shape_name, st);
+        var shape = toSymEntry(shape_sym, int);
+
+        var mode: int;
+        try {
+            mode = mode_str: int;
+        } catch {
+            var errorMsg = "Could not convert mode to numeric";
+            h5tLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+        }
+
+        // create the file if it does not exist or if we are truncating
+        prepFile(filename, mode);
+        var file_id = C_HDF5.H5Fopen(filename.c_str(), C_HDF5.H5F_ACC_RDWR, C_HDF5.H5P_DEFAULT);
+
+        if file_id < 0 { // HF5open returns negative value on failure
+            C_HDF5.H5Fclose(file_id);
+            var errorMsg = "Failure accessing file %s.".format(filename);
+            h5tLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);     
+        }
+
+        // validate that the dataset does not already exist
+        var dset_exists: int = C_HDF5.H5Lexists(file_id, dset_name.c_str(), C_HDF5.H5P_DEFAULT);
+        if dset_exists > 0 {
+            var errorMsg = "A dataset named %s already exists in %s. Overwriting is not currently supported. Please choose another name.".format(dset_name, filename);
+            h5tLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+        }
+        else if dset_exists < -1 {
+            var errorMsg = "Failure validating the status of dataset named %s.".format(dset_name);
+            h5tLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+        }
+        
+        var rank: c_int;
+        select (method) {
+            when (FLAT) { // store data as a flattened single array
+                rank = 1:c_int;
+                var dims: [0..#1] C_HDF5.hsize_t;
+                dims[0] = flat.size:C_HDF5.hsize_t;
+                C_HDF5.H5LTmake_dataset(file_id, dset_name.c_str(), rank, dims, getHDF5Type(flat.a.eltType), c_ptrTo(flat.a));
+            }
+            when (MULTI_DIM) { // store the data as the multi-dimensional object
+                rank = shape.size:c_int;
+                // reshape the data based on the shape passed.
+                var dims: [0..#shape.size] C_HDF5.hsize_t;
+                forall i in 0..#shape.size{
+                    dims[i] = shape.a[i]:C_HDF5.hsize_t;
+                }
+                C_HDF5.H5LTmake_dataset(file_id, dset_name.c_str(), rank, dims, getHDF5Type(flat.a.eltType), c_ptrTo(flat.a));
+            }
+            otherwise {
+                var errorMsg = "Unknown storage method. Expecting 'flat' or 'multi'. Found %s".format(method_str);
+                h5tLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+        }
+
+        //open the created dset so we can add attributes.
+        var dset_id: C_HDF5.hid_t = C_HDF5.H5Dopen(file_id, dset_name.c_str(), C_HDF5.H5P_DEFAULT);
+
+        // Write attributes for the dataset
+        var attrSpaceId: C_HDF5.hid_t = C_HDF5.H5Screate(C_HDF5.H5S_SCALAR);
+        var attr_id: C_HDF5.hid_t;
+
+        var objType: string = "ArrayView";
+        var attrStringType = C_HDF5.H5Tcopy(C_HDF5.H5T_C_S1): C_HDF5.hid_t;
+        C_HDF5.H5Tset_size(attrStringType, objType.size:uint(64) + 1); // ensure space for NULL terminator
+        C_HDF5.H5Tset_strpad(attrStringType, C_HDF5.H5T_STR_NULLTERM);
+        C_HDF5.H5Tset_cset(attrStringType, C_HDF5.H5T_CSET_UTF8);
+        attr_id = C_HDF5.H5Acreate2(dset_id, "ObjType".c_str(), attrStringType, attrSpaceId, C_HDF5.H5P_DEFAULT, C_HDF5.H5P_DEFAULT);
+        var type_chars = c_calloc(c_char, objType.size+1);
+        for (c, i) in zip(objType.codepoints(), 0..<objType.size) {
+            type_chars[i] = c:c_char;
+        }
+        type_chars[objType.size] = 0:c_char; // ensure NULL termination
+        C_HDF5.H5Awrite(attr_id, attrStringType, type_chars);
+        C_HDF5.H5Aclose(attr_id);
+
+        attr_id = C_HDF5.H5Acreate2(dset_id, "Rank".c_str(), getHDF5Type(int), attrSpaceId, C_HDF5.H5P_DEFAULT, C_HDF5.H5P_DEFAULT);
+        C_HDF5.H5Awrite(attr_id, getHDF5Type(int), c_ptrTo(shape.size));
+        C_HDF5.H5Aclose(attr_id);
+
+        attr_id = C_HDF5.H5Acreate2(dset_id, "Format".c_str(), getHDF5Type(int), attrSpaceId, C_HDF5.H5P_DEFAULT, C_HDF5.H5P_DEFAULT);
+        C_HDF5.H5Awrite(attr_id, getHDF5Type(int), c_ptrTo(method));
+        C_HDF5.H5Aclose(attr_id);
+
+        C_HDF5.H5Sclose(attrSpaceId);
+        attrSpaceId= C_HDF5.H5Screate(C_HDF5.H5S_SIMPLE);
+        var adim: [0..#1] C_HDF5.hsize_t = shape.size:C_HDF5.hsize_t;
+        C_HDF5.H5Sset_extent_simple(attrSpaceId, 1, c_ptrTo(adim), c_ptrTo(adim));
+
+        attr_id = C_HDF5.H5Acreate2(dset_id, "Shape".c_str(), getHDF5Type(shape.a.eltType), attrSpaceId, C_HDF5.H5P_DEFAULT, C_HDF5.H5P_DEFAULT);
+        C_HDF5.H5Awrite(attr_id, getHDF5Type(shape.a.eltType), c_ptrTo(shape.a));
+        C_HDF5.H5Aclose(attr_id);
+
+
+        // Close the open hdf5 objects
+        C_HDF5.H5Sclose(attrSpaceId);
+        C_HDF5.H5Dclose(dset_id);
+        C_HDF5.H5Fclose(file_id);
+
+        var repMsg: string = "Dataset written successfully!";
+
+        return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+
+
+    proc registerMe() {
+        use CommandMap;
+        registerFunction("readhdf_multi", read_hdf_multi_msg, getModuleName());
+        registerFunction("writehdf_multi", write_hdf_multi_msg, getModuleName());
+    }
+}

--- a/src/HDF5_MultiDim.chpl
+++ b/src/HDF5_MultiDim.chpl
@@ -284,10 +284,11 @@ module HDF5_MultiDim {
         //open the created dset so we can add attributes.
         var dset_id: C_HDF5.hid_t = C_HDF5.H5Dopen(file_id, dset_name.c_str(), C_HDF5.H5P_DEFAULT);
 
-        // Write attributes for the dataset
+        // Create the attribute space
         var attrSpaceId: C_HDF5.hid_t = C_HDF5.H5Screate(C_HDF5.H5S_SCALAR);
         var attr_id: C_HDF5.hid_t;
 
+        // Create the objectType. This will be important when merging with other read/write functionality.
         var objType: string = "ArrayView";
         var attrStringType = C_HDF5.H5Tcopy(C_HDF5.H5T_C_S1): C_HDF5.hid_t;
         C_HDF5.H5Tset_size(attrStringType, objType.size:uint(64) + 1); // ensure space for NULL terminator
@@ -302,10 +303,12 @@ module HDF5_MultiDim {
         C_HDF5.H5Awrite(attr_id, attrStringType, type_chars);
         C_HDF5.H5Aclose(attr_id);
 
+        // Store the rank of the dataset. Required to read so that shape can be built
         attr_id = C_HDF5.H5Acreate2(dset_id, "Rank".c_str(), getHDF5Type(int), attrSpaceId, C_HDF5.H5P_DEFAULT, C_HDF5.H5P_DEFAULT);
         C_HDF5.H5Awrite(attr_id, getHDF5Type(int), c_ptrTo(shape.size));
         C_HDF5.H5Aclose(attr_id);
 
+        // Indicates if the data is stored as Flat or Mutli-dimensional.
         attr_id = C_HDF5.H5Acreate2(dset_id, "Format".c_str(), getHDF5Type(int), attrSpaceId, C_HDF5.H5P_DEFAULT, C_HDF5.H5P_DEFAULT);
         C_HDF5.H5Awrite(attr_id, getHDF5Type(int), c_ptrTo(method));
         C_HDF5.H5Aclose(attr_id);

--- a/src/HDF5_MultiDim.chpl
+++ b/src/HDF5_MultiDim.chpl
@@ -25,8 +25,6 @@ module HDF5_MultiDim {
 
     require "c_helpers/help_h5ls.h", "c_helpers/help_h5ls.c";
 
-    private extern proc c_get_HDF5_obj_type(loc_id:C_HDF5.hid_t, name:c_string, obj_type:c_ptr(C_HDF5.H5O_type_t)):C_HDF5.herr_t;
-    private extern proc c_strlen(s:c_ptr(c_char)):c_size_t;
     private extern proc c_incrementCounter(data:c_void_ptr);
     private extern proc c_append_HDF5_fieldname(data:c_void_ptr, name:c_string);
 
@@ -60,12 +58,12 @@ module HDF5_MultiDim {
         var flat_size: int = (* reduce shape);
 
         var flat: [0..#flat_size] int;
-        for loc in D{
+        for coords in D{
             var idx: int;
-            for i in 0..#loc.size {
-                idx += loc[i] * dim_prod[(dim_prod.size-(i+1))];
+            for i in 0..#coords.size {
+                idx += coords[i] * dim_prod[(dim_prod.size-(i+1))];
             }
-            flat[idx] = a[loc];
+            flat[idx] = a[coords];
         }
 
         return flat;
@@ -81,11 +79,7 @@ module HDF5_MultiDim {
 
         var matchingFiles = glob("%s*%s".format(prefix, extension));
 
-        if matchingFiles.size > 0 {
-            return true;
-        } else {
-            return false;
-        }
+        return matchingFiles.size > 0
     }
 
     /*

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -769,6 +769,14 @@ class IOTest(ArkoudaTest):
         self.assertEqual(50, v0.size)
         self.assertEqual(50, v1.size)
 
+    def test_multi_dim_rdwr(self):
+        arr = ak.ArrayView(ak.arange(27), ak.array([3, 3, 3]))
+        with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
+            ak.write_hdf5_multi_dim(arr, tmp_dirname+"/multi_dim_test", 'MultiDimObj', mode="append", storage="flat")
+            # load data back
+            read_arr = ak.read_hdf5_multi_dim(tmp_dirname+"/multi_dim_test", "MultiDimObj")
+            self.assertTrue(np.array_equal(arr.to_ndarray(), read_arr.to_ndarray()))
+
     def tearDown(self):
         super(IOTest, self).tearDown()
         for f in glob.glob("{}/*".format(IOTest.io_test_dir)):

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -282,7 +282,7 @@ class OperatorsTest(ArkoudaTest):
 
     def test_concatenate_type_preservation(self):
         # Test that concatenate preserves special pdarray types (IPv4, Datetime, BitVector, ...)
-        from arkouda.util import concatenate as akuconcat
+        from arkouda.util import generic_concat as akuconcat
 
         pda_one = ak.arange(1, 4)
         pda_two = ak.arange(4, 7)


### PR DESCRIPTION
Closes #1584 

Updated references to the old `ak.util.concenate` to reference `ak.util.generic_concat` to prevent deprecation warnings. 