### PR TITLE
Closes #1588: Fix `resolve_scalar_dtype(x) == "int64" or "uint64"` bug

### DIFF
--- a/arkouda/array_view.py
+++ b/arkouda/array_view.py
@@ -160,7 +160,7 @@ class ArrayView:
             key = key if self.order is OrderType.COLUMN_MAJOR else key[::-1]
             for i in range(len(key)):
                 x = key[i]
-                if np.isscalar(x) and (resolve_scalar_dtype(x) == "int64" or "uint64"):
+                if np.isscalar(x) and (resolve_scalar_dtype(x) in ["int64", "uint64"]):
                     orig_key = x
                     if x < 0:
                         # Interpret negative key as offset from end of array

--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -471,7 +471,7 @@ class Categorical:
         return self._binop(other, "!=")
 
     def __getitem__(self, key) -> Categorical:
-        if np.isscalar(key) and resolve_scalar_dtype(key) == "int64":
+        if np.isscalar(key) and (resolve_scalar_dtype(key) in ["int64", "uint64"]):
             return self.categories[self.codes[key]]
         else:
             # Don't reset categories because they might have been user-defined

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -544,7 +544,7 @@ class pdarray:
 
     # overload a[] to treat like list
     def __getitem__(self, key):
-        if np.isscalar(key) and (resolve_scalar_dtype(key) == "int64" or "uint64"):
+        if np.isscalar(key) and (resolve_scalar_dtype(key) in ["int64", "uint64"]):
             orig_key = key
             if key < 0:
                 # Interpret negative key as offset from end of array
@@ -579,7 +579,7 @@ class pdarray:
             raise TypeError(f"Unhandled key type: {key} ({type(key)})")
 
     def __setitem__(self, key, value):
-        if np.isscalar(key) and (resolve_scalar_dtype(key) == "int64" or "uint64"):
+        if np.isscalar(key) and (resolve_scalar_dtype(key) in ["int64", "uint64"]):
             orig_key = key
             if key < 0:
                 # Interpret negative key as offset from end of array

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -274,7 +274,7 @@ class Strings:
         return self._binop(cast(Strings, other), "!=")
 
     def __getitem__(self, key):
-        if np.isscalar(key) and (resolve_scalar_dtype(key) == "int64" or "uint64"):
+        if np.isscalar(key) and (resolve_scalar_dtype(key) in ["int64", "uint64"]):
             orig_key = key
             if key < 0:
                 # Interpret negative key as offset from end of array


### PR DESCRIPTION
This PR (Closes #1588):
- Updates occurrences of `resolve_scalar_dtype(x) == "int64" or "uint64"` (which is always True) to be `resolve_scalar_dtype(x) in ("int64", "uint64")`
- Adds support for `uint` keys for `Categorical.__getitem__(key)`