### PR TITLE
Closes #1591 - add `client_dtype_test` to `pytest.ini`

### DIFF
--- a/arkouda/client_dtypes.py
+++ b/arkouda/client_dtypes.py
@@ -236,7 +236,7 @@ class Fields(BitVector):
         # Argument validation
         # Normalize names, which can be string or sequence
         self.names = tuple(names)
-        self.name = None # This is needed to silence warnings of missing name during failed creation
+        self.name = None  # This is needed to silence warnings of missing name during failed creation
         if len(self.names) > 63:
             raise ValueError("Cannot represent more than 63 fields")
         # Ensure no duplicate names
@@ -436,7 +436,7 @@ class IPv4(pdarray):
 
     def __init__(self, values):
         if not isinstance(values, pdarray) or values.dtype not in intTypes:
-            self.name = None # This is needed to silence warnings of missing name during failed creation
+            self.name = None  # This is needed to silence warnings of missing name during failed creation
             raise TypeError("Argument must be int64 pdarray")
         # Casting always creates a copy with new server-side name,
         # which will avoid unknown symbol errors

--- a/arkouda/client_dtypes.py
+++ b/arkouda/client_dtypes.py
@@ -68,6 +68,7 @@ class BitVector(pdarray):
 
     def __init__(self, values, width=64, reverse=False):
         if not isinstance(values, pdarray) or values.dtype not in intTypes:
+            self.name = None  # This is needed to silence warnings of missing name during failed creation
             raise TypeError("Argument must be integer pdarray")
         self.width = width
         self.reverse = reverse
@@ -235,6 +236,7 @@ class Fields(BitVector):
         # Argument validation
         # Normalize names, which can be string or sequence
         self.names = tuple(names)
+        self.name = None # This is needed to silence warnings of missing name during failed creation
         if len(self.names) > 63:
             raise ValueError("Cannot represent more than 63 fields")
         # Ensure no duplicate names
@@ -434,6 +436,7 @@ class IPv4(pdarray):
 
     def __init__(self, values):
         if not isinstance(values, pdarray) or values.dtype not in intTypes:
+            self.name = None # This is needed to silence warnings of missing name during failed creation
             raise TypeError("Argument must be int64 pdarray")
         # Casting always creates a copy with new server-side name,
         # which will avoid unknown symbol errors
@@ -582,11 +585,11 @@ def is_ipv4(ip: Union[pdarray, IPv4], ip2: Optional[pdarray] = None) -> pdarray:
         raise RuntimeError("When supplying a value for ip2, ip and ip2 must be the same size.")
 
     if ip2 is not None:
-        ans = ip < 2 ** 32
+        ans = ip < 2**32
         ans2 = ip2 == 0
         return ans & ans2
     else:
-        return ip < 2 ** 32
+        return ip < 2**32
 
 
 @typechecked
@@ -618,8 +621,8 @@ def is_ipv6(ip: Union[pdarray, IPv4], ip2: Optional[pdarray] = None) -> pdarray:
         raise RuntimeError("When supplying a value for ip2, ip and ip2 must be the same size.")
 
     if ip2 is not None:
-        ans = ip >= 2 ** 32
+        ans = ip >= 2**32
         ans2 = ip2 != 0
         return ans | ans2
     else:
-        return ip >= 2 ** 32
+        return ip >= 2**32

--- a/pytest.ini
+++ b/pytest.ini
@@ -37,6 +37,7 @@ testpaths =
     tests/setops_test.py
     tests/sort_test.py
     tests/string_test.py
+    tests/summarization_test.py
     tests/util_test.py
     tests/where_test.py
 norecursedirs = .git dist build *egg* tests/deprecated/*

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,24 +7,27 @@ testpaths =
     tests/bitops_test.py
     tests/categorical_test.py
     tests/check.py
+    tests/client_dtypes_test.py
     tests/client_test.py
     tests/coargsort_test.py
     tests/compare_test.py
     tests/dataframe_test.py
     tests/datetime_test.py
     tests/dtypes_tests.py
+    tests/extrema_test.py
     tests/groupby_test.py
+    tests/import_export_test.py
     tests/index_test.py
     tests/indexing_test.py
-    tests/nan_test.py
-    tests/import_export_test.py
     tests/io_test.py
     tests/io_util_test.py
     tests/join_test.py
     tests/logger_test.py
     tests/message_test.py
+    tests/nan_test.py
     tests/numeric_test.py
     tests/operator_tests.py
+    tests/parquet_test.py
     tests/pdarray_creation_test.py
     tests/regex_test.py
     tests/registration_test.py
@@ -34,9 +37,8 @@ testpaths =
     tests/setops_test.py
     tests/sort_test.py
     tests/string_test.py
+    tests/util_test.py
     tests/where_test.py
-    tests/extrema_test.py
-    tests/parquet_test.py
 norecursedirs = .git dist build *egg* tests/deprecated/*
 python_functions = test*
 env =

--- a/tests/client_dtypes_test.py
+++ b/tests/client_dtypes_test.py
@@ -155,7 +155,7 @@ class ClientDTypeTests(ArkoudaTest):
         self.assertListEqual(ans.to_ndarray().tolist(), [i < 5 for i in range(10)])
 
         with self.assertRaises(TypeError):
-            ak.is_ipv6(ak.array(x))
+            ak.is_ipv6(ak.array(x, ak.float64))
 
         with self.assertRaises(RuntimeError):
             ak.is_ipv6(ak.cast(ak.array(x), ak.int64), ak.cast(ak.arange(2), ak.int64))

--- a/tests/client_dtypes_test.py
+++ b/tests/client_dtypes_test.py
@@ -151,7 +151,7 @@ class ClientDTypeTests(ArkoudaTest):
         self.assertListEqual(ans.to_ndarray().tolist(), [True] * 100)
 
         x = [random.getrandbits(64) if i < 5 else random.getrandbits(32) for i in range(10)]
-        ans = ak.is_ipv6(ak.cast(ak.array(x), ak.int64))
+        ans = ak.is_ipv6(ak.array(x, ak.uint64))
         self.assertListEqual(ans.to_ndarray().tolist(), [i < 5 for i in range(10)])
 
         with self.assertRaises(TypeError):


### PR DESCRIPTION
Closes #1591 

Updates the `test_is_ipv6` to use proper types.

Adds `self.name = None` in order to silence warnings during testing when the objects cannot be created.

Adds `client_dtypes_test` to `pytest.ini`. Reordered tests so that the order matches the order of the files so it is easier to locate things.