### PR TITLE
Closes #1531 and #1605: Update tests to use `assertListEqual` and add `.to_list` methods

### DIFF
--- a/arkouda/array_view.py
+++ b/arkouda/array_view.py
@@ -296,7 +296,8 @@ class ArrayView:
 
         See Also
         --------
-        array
+        array()
+        to_list()
 
         Examples
         --------
@@ -311,6 +312,48 @@ class ArrayView:
             return self.base.to_ndarray().reshape(self.shape.to_ndarray())
         else:
             return self.base.to_ndarray().reshape(self.shape.to_ndarray(), order="F")
+
+    def to_list(self) -> list:
+        """
+        Convert the ArrayView to a list, transferring array data from the
+        Arkouda server to client-side Python. Note: if the ArrayView size exceeds
+        client.maxTransferBytes, a RuntimeError is raised.
+
+        Returns
+        -------
+        list
+            A list with the same data as the ArrayView
+
+        Raises
+        ------
+        RuntimeError
+            Raised if there is a server-side error thrown, if the ArrayView size
+            exceeds the built-in client.maxTransferBytes size limit, or if the bytes
+            received does not match expected number of bytes
+
+        Notes
+        -----
+        The number of bytes in the array cannot exceed ``client.maxTransferBytes``,
+        otherwise a ``RuntimeError`` will be raised. This is to protect the user
+        from overflowing the memory of the system on which the Python client
+        is running, under the assumption that the server is running on a
+        distributed system with much more memory than the client. The user
+        may override this limit by setting client.maxTransferBytes to a larger
+        value, but proceed with caution.
+
+        See Also
+        --------
+        to_ndarray()
+
+        Examples
+        --------
+        >>> a = ak.arange(6).reshape(2,3)
+        >>> a.to_list()
+        [[0, 1, 2], [3, 4, 5]]
+        >>> type(a.to_list())
+        list
+        """
+        return self.to_ndarray().tolist()
 
     def save(self, filepath: str, dset: str, mode: str = "truncate", storage: str = "Flat"):
         """

--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -361,6 +361,31 @@ class Categorical:
             valcodes = self.codes.to_ndarray()
         return idx[valcodes]
 
+    def to_list(self) -> List:
+        """
+        Convert the Categorical to a list, transferring data from
+        the arkouda server to Python. This conversion discards category
+        information and produces a list of strings. If the arrays
+        exceeds a built-in size limit, a RuntimeError is raised.
+
+        Returns
+        -------
+        list
+            A list of strings corresponding to the values in
+            this Categorical
+
+        Notes
+        -----
+        The number of bytes in the Categorical cannot exceed ``arkouda.maxTransferBytes``,
+        otherwise a ``RuntimeError`` will be raised. This is to protect the user
+        from overflowing the memory of the system on which the Python client
+        is running, under the assumption that the server is running on a
+        distributed system with much more memory than the client. The user
+        may override this limit by setting ak.maxTransferBytes to a larger
+        value, but proceed with caution.
+        """
+        return self.to_ndarray().tolist()
+
     def __iter__(self):
         raise NotImplementedError(
             "Categorical does not support iteration. To force data transfer from server, use to_ndarray"

--- a/arkouda/client_dtypes.py
+++ b/arkouda/client_dtypes.py
@@ -122,6 +122,12 @@ class BitVector(pdarray):
         """
         return np.array([self.format(x) for x in self.values.to_ndarray()])
 
+    def to_list(self):
+        """
+        Export data to a list of string-formatted bit vectors.
+        """
+        return self.to_ndarray().tolist()
+
     def _cast(self, values):
         return self.__class__(values, width=self.width, reverse=self.reverse)
 
@@ -498,6 +504,12 @@ class IPv4(pdarray):
         Export array as a numpy array of integers.
         """
         return np.array([self.format(x) for x in self.values.to_ndarray()])
+
+    def to_list(self):
+        """
+        Export array as a list of integers.
+        """
+        return self.to_ndarray().tolist()
 
     def __getitem__(self, key):
         if isSupportedInt(key):

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -1402,9 +1402,7 @@ class DataFrame(UserDict):
             try:
                 # in order for proper pandas functionality, SegArrays must be seen as 1d
                 # and therefore need to be converted to list
-                pandas_data[key] = (
-                    val.to_ndarray() if not isinstance(val, SegArray) else val.to_ndarray().tolist()
-                )
+                pandas_data[key] = val.to_ndarray() if not isinstance(val, SegArray) else val.to_list()
             except TypeError:
                 raise IndexError("Bad index type or format.")
 

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -108,6 +108,9 @@ class Index:
         val = convert_if_categorical(self.values)
         return val.to_ndarray()
 
+    def to_list(self):
+        return self.to_ndarray().tolist()
+
     def set_dtype(self, dtype):
         """Change the data type of the index
 

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1046,7 +1046,8 @@ class pdarray:
 
         See Also
         --------
-        array
+        array()
+        to_list()
 
         Examples
         --------
@@ -1088,6 +1089,48 @@ class pdarray:
             return np.frombuffer(data, dt).copy()
         else:
             return np.frombuffer(data, dt)
+
+    def to_list(self) -> List:
+        """
+        Convert the array to a list, transferring array data from the
+        Arkouda server to client-side Python. Note: if the pdarray size exceeds
+        client.maxTransferBytes, a RuntimeError is raised.
+
+        Returns
+        -------
+        list
+            A list with the same data as the pdarray
+
+        Raises
+        ------
+        RuntimeError
+            Raised if there is a server-side error thrown, if the pdarray size
+            exceeds the built-in client.maxTransferBytes size limit, or if the bytes
+            received does not match expected number of bytes
+        Notes
+        -----
+        The number of bytes in the array cannot exceed ``client.maxTransferBytes``,
+        otherwise a ``RuntimeError`` will be raised. This is to protect the user
+        from overflowing the memory of the system on which the Python client
+        is running, under the assumption that the server is running on a
+        distributed system with much more memory than the client. The user
+        may override this limit by setting client.maxTransferBytes to a larger
+        value, but proceed with caution.
+
+        See Also
+        --------
+        to_ndarray()
+
+        Examples
+        --------
+        >>> a = ak.arange(0, 5, 1)
+        >>> a.to_list()
+        [0, 1, 2, 3, 4]
+
+        >>> type(a.to_list())
+        list
+        """
+        return self.to_ndarray().tolist()
 
     def to_cuda(self):
         """

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -676,7 +676,8 @@ class SegArray:
 
         See Also
         --------
-        array
+        array()
+        to_list()
 
         Examples
         --------
@@ -692,6 +693,30 @@ class SegArray:
         if self.size > 0:
             arr.append(ndvals[ndsegs[-1] :])
         return np.array(arr, dtype=object)
+
+    def to_list(self):
+        """
+        Convert the segarray into a list containing sub-arrays
+
+        Returns
+        -------
+        list
+            A list with the same sub-arrays (also list) as this segarray
+
+        See Also
+        --------
+        to_ndarray()
+
+        Examples
+        --------
+        >>> segarr = ak.SegArray(ak.array([0, 4, 7]), ak.arange(12))
+        >>> segarr.to_list()
+        [[0, 1, 2, 3], [4, 5, 6], [7, 8, 9, 10, 11]]
+        >>> type(segarr.to_list())
+        list
+        """
+        # TODO this may need to change once #1600 has been worked
+        return [arr.tolist() for arr in self.to_ndarray()]
 
     def sum(self, x=None):
         if x is None:

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -715,7 +715,6 @@ class SegArray:
         >>> type(segarr.to_list())
         list
         """
-        # TODO this may need to change once #1600 has been worked
         return [arr.tolist() for arr in self.to_ndarray()]
 
     def sum(self, x=None):

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1510,7 +1510,8 @@ class Strings:
 
         See Also
         --------
-        array
+        array()
+        to_list()
 
         Examples
         --------
@@ -1533,6 +1534,41 @@ class Strings:
         for i, (o, l) in enumerate(zip(npoffsets, lengths)):
             res[i] = np.str_("".join(chr(b) for b in npvalues[o : o + l]))
         return res
+
+    def to_list(self) -> list:
+        """
+        Convert the SegString to a list, transferring data from the
+        arkouda server to Python. If the SegString exceeds a built-in size limit,
+        a RuntimeError is raised.
+
+        Returns
+        -------
+        list
+            A list with the same strings as this SegString
+
+        Notes
+        -----
+        The number of bytes in the array cannot exceed ``arkouda.maxTransferBytes``,
+        otherwise a ``RuntimeError`` will be raised. This is to protect the user
+        from overflowing the memory of the system on which the Python client
+        is running, under the assumption that the server is running on a
+        distributed system with much more memory than the client. The user
+        may override this limit by setting ak.maxTransferBytes to a larger
+        value, but proceed with caution.
+
+        See Also
+        --------
+        to_ndarray()
+
+        Examples
+        --------
+        >>> a = ak.array(["hello", "my", "world"])
+        >>> a.to_list()
+        ['hello', 'my', 'world']
+        >>> type(a.to_list())
+        list
+        """
+        return self.to_ndarray().tolist()
 
     def _comp_to_ndarray(self, comp: str) -> np.ndarray:
         """

--- a/arkouda/timeclass.py
+++ b/arkouda/timeclass.py
@@ -211,6 +211,10 @@ class _AbstractBaseTime(pdarray):
             dtype="{}64[ns]".format(self.__class__.__name__.lower()),
         )
 
+    def to_list(self):
+        __doc__ = super().to_list().__doc__  # noqa
+        return self.to_ndarray().tolist()
+
     def __str__(self):
         from arkouda.client import pdarrayIterThresh
 

--- a/tests/alignment_tests.py
+++ b/tests/alignment_tests.py
@@ -14,21 +14,21 @@ class DataFrameTest(ArkoudaTest):
         upper_bound = ak.array(ub)
         vals = ak.array(v)
         interval_idxs = ak.search_intervals(vals, (lower_bound, upper_bound))
-        self.assertListEqual(expected_result, interval_idxs.to_ndarray().tolist())
+        self.assertListEqual(expected_result, interval_idxs.to_list())
 
         # test uint64
         lower_bound = ak.array(lb, dtype=ak.uint64)
         upper_bound = ak.array(ub, dtype=ak.uint64)
         vals = ak.array(v, dtype=ak.uint64)
         interval_idxs = ak.search_intervals(vals, (lower_bound, upper_bound))
-        self.assertListEqual(expected_result, interval_idxs.to_ndarray().tolist())
+        self.assertListEqual(expected_result, interval_idxs.to_list())
 
         # test uint64
         lower_bound = ak.array(lb, dtype=ak.float64)
         upper_bound = ak.array(ub, dtype=ak.float64)
         vals = ak.array(v, dtype=ak.float64)
         interval_idxs = ak.search_intervals(vals, (lower_bound, upper_bound))
-        self.assertListEqual(expected_result, interval_idxs.to_ndarray().tolist())
+        self.assertListEqual(expected_result, interval_idxs.to_list())
 
     def test_multi_array_search_interval(self):
         # Added for Issue #1548
@@ -36,24 +36,18 @@ class DataFrameTest(ArkoudaTest):
         ends = (ak.array([5, 15, 25]), ak.array([5, 15, 25]))
         vals = (ak.array([3, 13, 23]), ak.array([23, 13, 3]))
         ans = [-1, 1, -1]
-        self.assertListEqual(ans, ak.search_intervals(vals, (starts, ends)).to_ndarray().tolist())
-        self.assertListEqual(
-            ans, ak.interval_lookup((starts, ends), ak.arange(3), vals).to_ndarray().tolist()
-        )
+        self.assertListEqual(ans, ak.search_intervals(vals, (starts, ends)).to_list())
+        self.assertListEqual(ans, ak.interval_lookup((starts, ends), ak.arange(3), vals).to_list())
 
         vals = (ak.array([23, 13, 3]), ak.array([23, 13, 3]))
         ans = [2, 1, 0]
-        self.assertListEqual(ans, ak.search_intervals(vals, (starts, ends)).to_ndarray().tolist())
-        self.assertListEqual(
-            ans, ak.interval_lookup((starts, ends), ak.arange(3), vals).to_ndarray().tolist()
-        )
+        self.assertListEqual(ans, ak.search_intervals(vals, (starts, ends)).to_list())
+        self.assertListEqual(ans, ak.interval_lookup((starts, ends), ak.arange(3), vals).to_list())
 
         vals = (ak.array([23, 13, 33]), ak.array([23, 13, 3]))
         ans = [2, 1, -1]
-        self.assertListEqual(ans, ak.search_intervals(vals, (starts, ends)).to_ndarray().tolist())
-        self.assertListEqual(
-            ans, ak.interval_lookup((starts, ends), ak.arange(3), vals).to_ndarray().tolist()
-        )
+        self.assertListEqual(ans, ak.search_intervals(vals, (starts, ends)).to_list())
+        self.assertListEqual(ans, ak.interval_lookup((starts, ends), ak.arange(3), vals).to_list())
 
     def test_search_interval_nonunique(self):
         expected_result = [2, 5, 2, 1, 3, 1, 4, -1, -1]
@@ -66,21 +60,21 @@ class DataFrameTest(ArkoudaTest):
         upper_bound = ak.array(ub)
         vals = ak.array(v)
         interval_idxs = ak.search_intervals(vals, (lower_bound, upper_bound))
-        self.assertListEqual(expected_result, interval_idxs.to_ndarray().tolist())
+        self.assertListEqual(expected_result, interval_idxs.to_list())
 
         # test uint64
         lower_bound = ak.array(lb, dtype=ak.uint64)
         upper_bound = ak.array(ub, dtype=ak.uint64)
         vals = ak.array(v, dtype=ak.uint64)
         interval_idxs = ak.search_intervals(vals, (lower_bound, upper_bound))
-        self.assertListEqual(expected_result, interval_idxs.to_ndarray().tolist())
+        self.assertListEqual(expected_result, interval_idxs.to_list())
 
         # test uint64
         lower_bound = ak.array(lb, dtype=ak.float64)
         upper_bound = ak.array(ub, dtype=ak.float64)
         vals = ak.array(v, dtype=ak.float64)
         interval_idxs = ak.search_intervals(vals, (lower_bound, upper_bound))
-        self.assertListEqual(expected_result, interval_idxs.to_ndarray().tolist())
+        self.assertListEqual(expected_result, interval_idxs.to_list())
 
     def test_error_handling(self):
         lb = [0, 10, 20, 30, 40, 50]

--- a/tests/alignment_tests.py
+++ b/tests/alignment_tests.py
@@ -147,6 +147,6 @@ class DataFrameTest(ArkoudaTest):
         first_answer = [-1, -1, 0, 0, -1, 0, 2, 0, -1, 0, 0, 3, -1]
         smallest_answer = [-1, -1, 0, 2, -1, 2, 2, 1, -1, 0, 0, 3, -1]
         first_result = ak.search_intervals(values, intervals)
-        self.assertListEqual(first_result.to_ndarray().tolist(), first_answer)
+        self.assertListEqual(first_result.to_list(), first_answer)
         smallest_result = ak.search_intervals(values, intervals, tiebreak=tiebreak_smallest)
-        self.assertListEqual(smallest_result.to_ndarray().tolist(), smallest_answer)
+        self.assertListEqual(smallest_result.to_list(), smallest_answer)

--- a/tests/array_view_test.py
+++ b/tests/array_view_test.py
@@ -9,16 +9,16 @@ class ArrayViewTest(ArkoudaTest):
     def test_mulitdimensional_array_creation(self):
         n = np.array([[0, 0], [0, 1], [1, 1]])
         a = ak.array([[0, 0], [0, 1], [1, 1]])
-        self.assertListEqual(n.tolist(), a.to_ndarray().tolist())
+        self.assertListEqual(n.tolist(), a.to_list())
         n = np.arange(27).reshape((3, 3, 3))
         a = ak.arange(27).reshape((3, 3, 3))
-        self.assertListEqual(n.tolist(), a.to_ndarray().tolist())
+        self.assertListEqual(n.tolist(), a.to_list())
         n = np.arange(27).reshape(3, 3, 3)
         a = ak.arange(27).reshape(3, 3, 3)
-        self.assertListEqual(n.tolist(), a.to_ndarray().tolist())
+        self.assertListEqual(n.tolist(), a.to_list())
         n = np.arange(27, dtype=np.uint64).reshape(3, 3, 3)
         a = ak.arange(27, dtype=ak.uint64).reshape(3, 3, 3)
-        self.assertListEqual(n.tolist(), a.to_ndarray().tolist())
+        self.assertListEqual(n.tolist(), a.to_list())
 
     def test_arrayview_int_indexing(self):
         nd = np.arange(9).reshape(3, 3)
@@ -78,16 +78,16 @@ class ArrayViewTest(ArkoudaTest):
         a = ak.arange(30).reshape(5, 3, 2)
 
         n_bool_list = n[True, True, True].tolist()
-        a_bool_list = a[True, True, True].to_ndarray().tolist()
+        a_bool_list = a[True, True, True].to_list()
         self.assertListEqual(n_bool_list, a_bool_list)
         n_bool_list = n[False, True, True].tolist()
-        a_bool_list = a[False, True, True].to_ndarray().tolist()
+        a_bool_list = a[False, True, True].to_list()
         self.assertListEqual(n_bool_list, a_bool_list)
         n_bool_list = n[True, False, True].tolist()
-        a_bool_list = a[True, False, True].to_ndarray().tolist()
+        a_bool_list = a[True, False, True].to_list()
         self.assertListEqual(n_bool_list, a_bool_list)
         n_bool_list = n[True, True, False].tolist()
-        a_bool_list = a[True, True, False].to_ndarray().tolist()
+        a_bool_list = a[True, True, False].to_list()
         self.assertListEqual(n_bool_list, a_bool_list)
 
     def test_set_bool_pdarray(self):
@@ -96,16 +96,16 @@ class ArrayViewTest(ArkoudaTest):
 
         n[True, True, True] = 9
         a[True, True, True] = 9
-        self.assertListEqual(n.tolist(), a.to_ndarray().tolist())
+        self.assertListEqual(n.tolist(), a.to_list())
         n[False, True, True] = 5
         a[False, True, True] = 5
-        self.assertListEqual(n.tolist(), a.to_ndarray().tolist())
+        self.assertListEqual(n.tolist(), a.to_list())
         n[True, False, True] = 6
         a[True, False, True] = 6
-        self.assertListEqual(n.tolist(), a.to_ndarray().tolist())
+        self.assertListEqual(n.tolist(), a.to_list())
         n[True, True, False] = 13
         a[True, True, False] = 13
-        self.assertListEqual(n.tolist(), a.to_ndarray().tolist())
+        self.assertListEqual(n.tolist(), a.to_list())
 
     def test_reshape_order(self):
         # Keep 'C'/'F' (C/Fortran) order to be consistent with numpy
@@ -136,55 +136,55 @@ class ArrayViewTest(ArkoudaTest):
         n = np.arange(10).reshape(2, 5)
         a = ak.arange(10).reshape(2, 5)
 
-        self.assertListEqual(list(n.shape), a.shape.to_ndarray().tolist())
+        self.assertListEqual(list(n.shape), a.shape.to_list())
         # n.tolist() = [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]
-        self.assertListEqual(n.tolist(), a.to_ndarray().tolist())
+        self.assertListEqual(n.tolist(), a.to_list())
         self.assertEqual(n.__str__(), a.__str__())
 
         self.assertEqual(n[1, 3], a[1, 3])
         self.assertEqual(n[1, -1], a[1, -1])
 
-        self.assertListEqual(n[0].tolist(), a[0].to_ndarray().tolist())
+        self.assertListEqual(n[0].tolist(), a[0].to_list())
         self.assertEqual(n[0][2], a[0][2])
 
         n = np.array([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]])
         a = ak.array([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]])
         # n[0, 1:7:2].tolist() = [1, 3, 5]
-        self.assertListEqual(n[0, 1:7:2].tolist(), a[0, 1:7:2].to_ndarray().tolist())
+        self.assertListEqual(n[0, 1:7:2].tolist(), a[0, 1:7:2].to_list())
         # n[0, -2:10].tolist() = [8, 9]
-        self.assertListEqual(n[0, -2:10].tolist(), a[0, -2:10].to_ndarray().tolist())
+        self.assertListEqual(n[0, -2:10].tolist(), a[0, -2:10].to_list())
         # n[0, -3:3:-1].tolist() = [7, 6, 5, 4]
-        self.assertListEqual(n[0, -3:3:-1].tolist(), a[0, -3:3:-1].to_ndarray().tolist())
+        self.assertListEqual(n[0, -3:3:-1].tolist(), a[0, -3:3:-1].to_list())
         # n[0, 5:].tolist() = [5, 6, 7, 8, 9]
-        self.assertListEqual(n[0, 5:].tolist(), a[0, 5:].to_ndarray().tolist())
+        self.assertListEqual(n[0, 5:].tolist(), a[0, 5:].to_list())
 
         n = np.array([[[1], [2], [3]], [[4], [5], [6]]])
         a = ak.array([[[1], [2], [3]], [[4], [5], [6]]])
         # list(n.shape) = [2, 3, 1]
-        self.assertListEqual(list(n.shape), a.shape.to_ndarray().tolist())
+        self.assertListEqual(list(n.shape), a.shape.to_list())
         # n.tolist() = [[[1], [2], [3]], [[4], [5], [6]]]
-        self.assertListEqual(n.tolist(), a.to_ndarray().tolist())
+        self.assertListEqual(n.tolist(), a.to_list())
         self.assertEqual(n.__str__(), a.__str__())
 
         # n[1:2].tolist() = [[[4], [5], [6]]]
-        self.assertListEqual(n[1:2].tolist(), a[1:2].to_ndarray().tolist())
+        self.assertListEqual(n[1:2].tolist(), a[1:2].to_list())
 
     def test_slicing(self):
         a = ak.arange(30).reshape(2, 3, 5)
         n = np.arange(30).reshape(2, 3, 5)
-        self.assertListEqual(n.tolist(), a.to_ndarray().tolist())
+        self.assertListEqual(n.tolist(), a.to_list())
 
         # n[:, ::-1, 1:5:2].tolist() = [[[11, 13], [6, 8], [1, 3]], [[26, 28], [21, 23], [16, 18]]]
-        self.assertListEqual(n[:, ::-1, 1:5:2].tolist(), a[:, ::-1, 1:5:2].to_ndarray().tolist())
+        self.assertListEqual(n[:, ::-1, 1:5:2].tolist(), a[:, ::-1, 1:5:2].to_list())
 
         # n[:, 5:8, 1:5:2].tolist() = [[], []]
-        self.assertListEqual(n[:, 5:8, 1:5:2].tolist(), a[:, 5:8, 1:5:2].to_ndarray().tolist())
+        self.assertListEqual(n[:, 5:8, 1:5:2].tolist(), a[:, 5:8, 1:5:2].to_list())
         # n[:, 5:8, 1:5:2][1].tolist() = []
-        self.assertListEqual(n[:, 5:8, 1:5:2][1].tolist(), a[:, 5:8, 1:5:2][1].to_ndarray().tolist())
+        self.assertListEqual(n[:, 5:8, 1:5:2][1].tolist(), a[:, 5:8, 1:5:2][1].to_list())
 
         a = ak.arange(30).reshape(2, 3, 5, order="F")
         n = np.arange(30).reshape(2, 3, 5, order="F")
-        self.assertListEqual(n.tolist(), a.to_ndarray().tolist())
+        self.assertListEqual(n.tolist(), a.to_list())
 
         # n[:, ::-1, 1:5:2].tolist() = [[10, 22], [8, 20], [6, 18]]
-        self.assertListEqual(n[:, ::-1, 1:5:2].tolist(), a[:, ::-1, 1:5:2].to_ndarray().tolist())
+        self.assertListEqual(n[:, ::-1, 1:5:2].tolist(), a[:, ::-1, 1:5:2].to_list())

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -47,9 +47,7 @@ class ArkoudaTest(unittest.TestCase):
                 ArkoudaTest.server, _, _ = start_arkouda_server(numlocales=nl, port=ArkoudaTest.port)
                 print(
                     "Started arkouda_server in TEST_CLASS mode with "
-                    "host: {} port: {} locales: {}".format(
-                        ArkoudaTest.server, ArkoudaTest.port, nl
-                    )
+                    "host: {} port: {} locales: {}".format(ArkoudaTest.server, ArkoudaTest.port, nl)
                 )
             except Exception as e:
                 raise RuntimeError(

--- a/tests/bitops_test.py
+++ b/tests/bitops_test.py
@@ -13,71 +13,69 @@ class BitOpsTest(ArkoudaTest):
     def test_popcount(self):
         # Method invocation
         # Toy input
-        ans = ak.array([0, 1, 1, 2, 1, 2, 2, 3, 1, 2])
-        self.assertListEqual(self.a.popcount().to_ndarray().tolist(), ans.to_ndarray().tolist())
+        ans = [0, 1, 1, 2, 1, 2, 2, 3, 1, 2]
+        self.assertListEqual(self.a.popcount().to_ndarray().tolist(), ans)
 
         # Test uint case
-        ans = ak.cast(ans, ak.uint64)
+        ans = ak.array(ans, ak.uint64)
         self.assertListEqual(self.b.popcount().to_ndarray().tolist(), ans.to_ndarray().tolist())
 
         # Function invocation
         # Edge case input
-        ans = ak.array([1, 64, 63])
-        self.assertListEqual(
-            ak.popcount(self.edgeCases).to_ndarray().tolist(), ans.to_ndarray().tolist()
-        )
+        ans = [1, 64, 63]
+        self.assertListEqual(ak.popcount(self.edgeCases).to_ndarray().tolist(), ans)
 
         # Test uint case
-        ans = ak.cast(ans, ak.uint64)
+        ans = ak.array(ans, ak.uint64)
         self.assertListEqual(
             ak.popcount(self.edgeCasesUint).to_ndarray().tolist(), ans.to_ndarray().tolist()
         )
 
     def test_parity(self):
-        ans = ak.array([0, 1, 1, 0, 1, 0, 0, 1, 1, 0])
-        self.assertListEqual(self.a.parity().to_ndarray().tolist(), ans.to_ndarray().tolist())
+        ans = [0, 1, 1, 0, 1, 0, 0, 1, 1, 0]
+        self.assertListEqual(self.a.parity().to_ndarray().tolist(), ans)
 
         # Test uint case
-        ans = ak.cast(ans, ak.uint64)
+        ans = ak.array(ans, ak.uint64)
         self.assertListEqual(self.b.parity().to_ndarray().tolist(), ans.to_ndarray().tolist())
 
-        ans = ak.array([1, 0, 1])
-        self.assertListEqual(ak.parity(self.edgeCases).to_ndarray().tolist(), ans.to_ndarray().tolist())
+        ans = [1, 0, 1]
+        self.assertListEqual(ak.parity(self.edgeCases).to_ndarray().tolist(), ans)
 
         # Test uint case
-        ans = ak.cast(ans, ak.uint64)
+        ans = ak.array(ans, ak.uint64)
         self.assertListEqual(
             ak.parity(self.edgeCasesUint).to_ndarray().tolist(), ans.to_ndarray().tolist()
         )
 
     def test_clz(self):
-        ans = ak.array([64, 63, 62, 62, 61, 61, 61, 61, 60, 60])
-        self.assertListEqual(self.a.clz().to_ndarray().tolist(), ans.to_ndarray().tolist())
+        ans = [64, 63, 62, 62, 61, 61, 61, 61, 60, 60]
+        self.assertListEqual(self.a.clz().to_ndarray().tolist(), ans)
 
         # Test uint case
-        ans = ak.cast(ans, ak.uint64)
+        ans = ak.array(ans, ak.uint64)
         self.assertListEqual(self.b.clz().to_ndarray().tolist(), ans.to_ndarray().tolist())
 
-        ans = ak.array([0, 0, 1])
-        self.assertListEqual(ak.clz(self.edgeCases).to_ndarray().tolist(), ans.to_ndarray().tolist())
+        ans = [0, 0, 1]
+        self.assertListEqual(ak.clz(self.edgeCases).to_ndarray().tolist(), ans)
 
         # Test uint case
-        ans = ak.cast(ans, ak.uint64)
+        ans = ak.array(ans, ak.uint64)
         self.assertListEqual(ak.clz(self.edgeCasesUint).to_ndarray().tolist(), ans.to_ndarray().tolist())
 
     def test_ctz(self):
-        ans = ak.array([0, 0, 1, 0, 2, 0, 1, 0, 3, 0])
-        self.assertListEqual(self.a.ctz().to_ndarray().tolist(), ans.to_ndarray().tolist())
+        ans = [0, 0, 1, 0, 2, 0, 1, 0, 3, 0]
+        self.assertListEqual(self.a.ctz().to_ndarray().tolist(), ans)
 
         # Test uint case
-        ans = ak.cast(ans, ak.uint64)
+        ans = ak.array(ans, ak.uint64)
         self.assertListEqual(self.b.ctz().to_ndarray().tolist(), ans.to_ndarray().tolist())
 
-        ans = ak.array([63, 0, 0])
-        self.assertListEqual(ak.ctz(self.edgeCases).to_ndarray().tolist(), ans.to_ndarray().tolist())
+        ans = [63, 0, 0]
+        self.assertListEqual(ak.ctz(self.edgeCases).to_ndarray().tolist(), ans)
 
         # Test uint case
-        ans = ak.cast(ans, ak.uint64)
+        ans = ak.array(ans, ak.uint64)
         self.assertListEqual(ak.ctz(self.edgeCasesUint).to_ndarray().tolist(), ans.to_ndarray().tolist())
 
     def test_dtypes(self):
@@ -96,8 +94,7 @@ class BitOpsTest(ArkoudaTest):
         self.assertListEqual(rotated.to_ndarray().tolist(), shifted.to_ndarray().tolist())
 
         r = ak.rotl(self.edgeCases, 1)
-        ans = ak.array([1, -1, -2])
-        self.assertListEqual(r.to_ndarray().tolist(), ans.to_ndarray().tolist())
+        self.assertListEqual(r.to_ndarray().tolist(), [1, -1, -2])
 
         # vector <<< vector
         rotated = self.a.rotl(self.a)
@@ -106,13 +103,12 @@ class BitOpsTest(ArkoudaTest):
         self.assertListEqual(rotated.to_ndarray().tolist(), shifted.to_ndarray().tolist())
 
         r = ak.rotl(self.edgeCases, ak.array([1, 1, 1]))
-        ans = ak.array([1, -1, -2])
-        self.assertListEqual(r.to_ndarray().tolist(), ans.to_ndarray().tolist())
+        self.assertListEqual(r.to_ndarray().tolist(), [1, -1, -2])
 
         # scalar <<< vector
         rotated = ak.rotl(-(2**63), self.a)
-        ans = ak.array([-(2**63), 1, 2, 4, 8, 16, 32, 64, 128, 256])
-        self.assertListEqual(rotated.to_ndarray().tolist(), ans.to_ndarray().tolist())
+        ans = [-(2**63), 1, 2, 4, 8, 16, 32, 64, 128, 256]
+        self.assertListEqual(rotated.to_ndarray().tolist(), ans)
 
     def test_rotr(self):
         # vector <<< scalar
@@ -122,8 +118,7 @@ class BitOpsTest(ArkoudaTest):
         self.assertListEqual(rotated.to_ndarray().tolist(), shifted.to_ndarray().tolist())
 
         r = ak.rotr(self.edgeCases, 1)
-        ans = ak.array([2**62, -1, -(2**62) - 1])
-        self.assertListEqual(r.to_ndarray().tolist(), ans.to_ndarray().tolist())
+        self.assertListEqual(r.to_ndarray().tolist(), [2**62, -1, -(2**62) - 1])
 
         # vector <<< vector
         rotated = (1024 * self.a).rotr(self.a)
@@ -132,12 +127,9 @@ class BitOpsTest(ArkoudaTest):
         self.assertListEqual(rotated.to_ndarray().tolist(), shifted.to_ndarray().tolist())
 
         r = ak.rotr(self.edgeCases, ak.array([1, 1, 1]))
-        ans = ak.array([2**62, -1, -(2**62) - 1])
-        self.assertListEqual(r.to_ndarray().tolist(), ans.to_ndarray().tolist())
+        self.assertListEqual(r.to_ndarray().tolist(), [2**62, -1, -(2**62) - 1])
 
         # scalar <<< vector
         rotated = ak.rotr(1, self.a)
-        ans = ak.array(
-            [1, -(2**63), 2**62, 2**61, 2**60, 2**59, 2**58, 2**57, 2**56, 2**55]
-        )
-        self.assertListEqual(rotated.to_ndarray().tolist(), ans.to_ndarray().tolist())
+        ans = [1, -(2**63), 2**62, 2**61, 2**60, 2**59, 2**58, 2**57, 2**56, 2**55]
+        self.assertListEqual(rotated.to_ndarray().tolist(), ans)

--- a/tests/bitops_test.py
+++ b/tests/bitops_test.py
@@ -1,5 +1,6 @@
 from base_test import ArkoudaTest
 from context import arkouda as ak
+import numpy as np
 
 
 class BitOpsTest(ArkoudaTest):
@@ -17,8 +18,8 @@ class BitOpsTest(ArkoudaTest):
         self.assertListEqual(self.a.popcount().to_list(), ans)
 
         # Test uint case
-        ans = ak.array(ans, ak.uint64)
-        self.assertListEqual(self.b.popcount().to_list(), ans.to_list())
+        ans = np.array(ans, ak.uint64)
+        self.assertListEqual(self.b.popcount().to_list(), ans.tolist())
 
         # Function invocation
         # Edge case input
@@ -26,53 +27,53 @@ class BitOpsTest(ArkoudaTest):
         self.assertListEqual(ak.popcount(self.edgeCases).to_list(), ans)
 
         # Test uint case
-        ans = ak.array(ans, ak.uint64)
-        self.assertListEqual(ak.popcount(self.edgeCasesUint).to_list(), ans.to_list())
+        ans = np.array(ans, ak.uint64)
+        self.assertListEqual(ak.popcount(self.edgeCasesUint).to_list(), ans.tolist())
 
     def test_parity(self):
         ans = [0, 1, 1, 0, 1, 0, 0, 1, 1, 0]
         self.assertListEqual(self.a.parity().to_list(), ans)
 
         # Test uint case
-        ans = ak.array(ans, ak.uint64)
-        self.assertListEqual(self.b.parity().to_list(), ans.to_list())
+        ans = np.array(ans, ak.uint64)
+        self.assertListEqual(self.b.parity().to_list(), ans.tolist())
 
         ans = [1, 0, 1]
         self.assertListEqual(ak.parity(self.edgeCases).to_list(), ans)
 
         # Test uint case
-        ans = ak.array(ans, ak.uint64)
-        self.assertListEqual(ak.parity(self.edgeCasesUint).to_list(), ans.to_list())
+        ans = np.array(ans, ak.uint64)
+        self.assertListEqual(ak.parity(self.edgeCasesUint).to_list(), ans.tolist())
 
     def test_clz(self):
         ans = [64, 63, 62, 62, 61, 61, 61, 61, 60, 60]
         self.assertListEqual(self.a.clz().to_list(), ans)
 
         # Test uint case
-        ans = ak.array(ans, ak.uint64)
-        self.assertListEqual(self.b.clz().to_list(), ans.to_list())
+        ans = np.array(ans, ak.uint64)
+        self.assertListEqual(self.b.clz().to_list(), ans.tolist())
 
         ans = [0, 0, 1]
         self.assertListEqual(ak.clz(self.edgeCases).to_list(), ans)
 
         # Test uint case
-        ans = ak.array(ans, ak.uint64)
-        self.assertListEqual(ak.clz(self.edgeCasesUint).to_list(), ans.to_list())
+        ans = np.array(ans, ak.uint64)
+        self.assertListEqual(ak.clz(self.edgeCasesUint).to_list(), ans.tolist())
 
     def test_ctz(self):
         ans = [0, 0, 1, 0, 2, 0, 1, 0, 3, 0]
         self.assertListEqual(self.a.ctz().to_list(), ans)
 
         # Test uint case
-        ans = ak.array(ans, ak.uint64)
-        self.assertListEqual(self.b.ctz().to_list(), ans.to_list())
+        ans = np.array(ans, ak.uint64)
+        self.assertListEqual(self.b.ctz().to_list(), ans.tolist())
 
         ans = [63, 0, 0]
         self.assertListEqual(ak.ctz(self.edgeCases).to_list(), ans)
 
         # Test uint case
-        ans = ak.array(ans, ak.uint64)
-        self.assertListEqual(ak.ctz(self.edgeCasesUint).to_list(), ans.to_list())
+        ans = np.array(ans, ak.uint64)
+        self.assertListEqual(ak.ctz(self.edgeCasesUint).to_list(), ans.tolist())
 
     def test_dtypes(self):
         f = ak.zeros(10, dtype=ak.float64)

--- a/tests/bitops_test.py
+++ b/tests/bitops_test.py
@@ -13,82 +13,72 @@ class BitOpsTest(ArkoudaTest):
     def test_popcount(self):
         # Method invocation
         # Toy input
-        p = self.a.popcount()
         ans = ak.array([0, 1, 1, 2, 1, 2, 2, 3, 1, 2])
-        self.assertTrue((p == ans).all())
+        self.assertListEqual(self.a.popcount().to_ndarray().tolist(), ans.to_ndarray().tolist())
 
         # Test uint case
-        p = self.b.popcount()
         ans = ak.cast(ans, ak.uint64)
-        self.assertTrue((p == ans).all())
+        self.assertListEqual(self.b.popcount().to_ndarray().tolist(), ans.to_ndarray().tolist())
 
         # Function invocation
         # Edge case input
-        p = ak.popcount(self.edgeCases)
         ans = ak.array([1, 64, 63])
-        self.assertTrue((p == ans).all())
+        self.assertListEqual(
+            ak.popcount(self.edgeCases).to_ndarray().tolist(), ans.to_ndarray().tolist()
+        )
 
         # Test uint case
-        p = ak.popcount(self.edgeCasesUint)
         ans = ak.cast(ans, ak.uint64)
-        self.assertTrue((p == ans).all())
+        self.assertListEqual(
+            ak.popcount(self.edgeCasesUint).to_ndarray().tolist(), ans.to_ndarray().tolist()
+        )
 
     def test_parity(self):
-        p = self.a.parity()
         ans = ak.array([0, 1, 1, 0, 1, 0, 0, 1, 1, 0])
-        self.assertTrue((p == ans).all())
+        self.assertListEqual(self.a.parity().to_ndarray().tolist(), ans.to_ndarray().tolist())
 
         # Test uint case
-        p = self.b.parity()
         ans = ak.cast(ans, ak.uint64)
-        self.assertTrue((p == ans).all())
+        self.assertListEqual(self.b.parity().to_ndarray().tolist(), ans.to_ndarray().tolist())
 
-        p = ak.parity(self.edgeCases)
         ans = ak.array([1, 0, 1])
-        self.assertTrue((p == ans).all())
+        self.assertListEqual(ak.parity(self.edgeCases).to_ndarray().tolist(), ans.to_ndarray().tolist())
 
         # Test uint case
-        p = ak.parity(self.edgeCasesUint)
         ans = ak.cast(ans, ak.uint64)
-        self.assertTrue((p == ans).all())
+        self.assertListEqual(
+            ak.parity(self.edgeCasesUint).to_ndarray().tolist(), ans.to_ndarray().tolist()
+        )
 
     def test_clz(self):
-        p = self.a.clz()
         ans = ak.array([64, 63, 62, 62, 61, 61, 61, 61, 60, 60])
-        self.assertTrue((p == ans).all())
+        self.assertListEqual(self.a.clz().to_ndarray().tolist(), ans.to_ndarray().tolist())
 
         # Test uint case
-        p = self.b.clz()
         ans = ak.cast(ans, ak.uint64)
-        self.assertTrue((p == ans).all())
+        self.assertListEqual(self.b.clz().to_ndarray().tolist(), ans.to_ndarray().tolist())
 
-        p = ak.clz(self.edgeCases)
         ans = ak.array([0, 0, 1])
-        self.assertTrue((p == ans).all())
+        self.assertListEqual(ak.clz(self.edgeCases).to_ndarray().tolist(), ans.to_ndarray().tolist())
 
         # Test uint case
-        p = ak.clz(self.edgeCasesUint)
         ans = ak.cast(ans, ak.uint64)
-        self.assertTrue((p == ans).all())
+        self.assertListEqual(ak.clz(self.edgeCasesUint).to_ndarray().tolist(), ans.to_ndarray().tolist())
 
     def test_ctz(self):
-        p = self.a.ctz()
         ans = ak.array([0, 0, 1, 0, 2, 0, 1, 0, 3, 0])
-        self.assertTrue((p == ans).all())
+        self.assertListEqual(self.a.ctz().to_ndarray().tolist(), ans.to_ndarray().tolist())
 
         # Test uint case
-        p = self.b.ctz()
         ans = ak.cast(ans, ak.uint64)
-        self.assertTrue((p == ans).all())
+        self.assertListEqual(self.b.ctz().to_ndarray().tolist(), ans.to_ndarray().tolist())
 
-        p = ak.ctz(self.edgeCases)
         ans = ak.array([63, 0, 0])
-        self.assertTrue((p == ans).all())
+        self.assertListEqual(ak.ctz(self.edgeCases).to_ndarray().tolist(), ans.to_ndarray().tolist())
 
         # Test uint case
-        p = ak.ctz(self.edgeCasesUint)
         ans = ak.cast(ans, ak.uint64)
-        self.assertTrue((p == ans).all())
+        self.assertListEqual(ak.ctz(self.edgeCasesUint).to_ndarray().tolist(), ans.to_ndarray().tolist())
 
     def test_dtypes(self):
         f = ak.zeros(10, dtype=ak.float64)
@@ -103,51 +93,51 @@ class BitOpsTest(ArkoudaTest):
         rotated = self.a.rotl(5)
         shifted = self.a << 5
         # No wraparound, so these should be equal
-        self.assertTrue((rotated == shifted).all())
+        self.assertListEqual(rotated.to_ndarray().tolist(), shifted.to_ndarray().tolist())
 
         r = ak.rotl(self.edgeCases, 1)
         ans = ak.array([1, -1, -2])
-        self.assertTrue((r == ans).all())
+        self.assertListEqual(r.to_ndarray().tolist(), ans.to_ndarray().tolist())
 
         # vector <<< vector
         rotated = self.a.rotl(self.a)
         shifted = self.a << self.a
         # No wraparound, so these should be equal
-        self.assertTrue((rotated == shifted).all())
+        self.assertListEqual(rotated.to_ndarray().tolist(), shifted.to_ndarray().tolist())
 
         r = ak.rotl(self.edgeCases, ak.array([1, 1, 1]))
         ans = ak.array([1, -1, -2])
-        self.assertTrue((r == ans).all())
+        self.assertListEqual(r.to_ndarray().tolist(), ans.to_ndarray().tolist())
 
         # scalar <<< vector
         rotated = ak.rotl(-(2**63), self.a)
         ans = ak.array([-(2**63), 1, 2, 4, 8, 16, 32, 64, 128, 256])
-        self.assertTrue((rotated == ans).all())
+        self.assertListEqual(rotated.to_ndarray().tolist(), ans.to_ndarray().tolist())
 
     def test_rotr(self):
         # vector <<< scalar
         rotated = (1024 * self.a).rotr(5)
         shifted = (1024 * self.a) >> 5
         # No wraparound, so these should be equal
-        self.assertTrue((rotated == shifted).all())
+        self.assertListEqual(rotated.to_ndarray().tolist(), shifted.to_ndarray().tolist())
 
         r = ak.rotr(self.edgeCases, 1)
         ans = ak.array([2**62, -1, -(2**62) - 1])
-        self.assertTrue((r == ans).all())
+        self.assertListEqual(r.to_ndarray().tolist(), ans.to_ndarray().tolist())
 
         # vector <<< vector
         rotated = (1024 * self.a).rotr(self.a)
         shifted = (1024 * self.a) >> self.a
         # No wraparound, so these should be equal
-        self.assertTrue((rotated == shifted).all())
+        self.assertListEqual(rotated.to_ndarray().tolist(), shifted.to_ndarray().tolist())
 
         r = ak.rotr(self.edgeCases, ak.array([1, 1, 1]))
         ans = ak.array([2**62, -1, -(2**62) - 1])
-        self.assertTrue((r == ans).all())
+        self.assertListEqual(r.to_ndarray().tolist(), ans.to_ndarray().tolist())
 
         # scalar <<< vector
         rotated = ak.rotr(1, self.a)
         ans = ak.array(
             [1, -(2**63), 2**62, 2**61, 2**60, 2**59, 2**58, 2**57, 2**56, 2**55]
         )
-        self.assertTrue((rotated == ans).all())
+        self.assertListEqual(rotated.to_ndarray().tolist(), ans.to_ndarray().tolist())

--- a/tests/bitops_test.py
+++ b/tests/bitops_test.py
@@ -14,69 +14,65 @@ class BitOpsTest(ArkoudaTest):
         # Method invocation
         # Toy input
         ans = [0, 1, 1, 2, 1, 2, 2, 3, 1, 2]
-        self.assertListEqual(self.a.popcount().to_ndarray().tolist(), ans)
+        self.assertListEqual(self.a.popcount().to_list(), ans)
 
         # Test uint case
         ans = ak.array(ans, ak.uint64)
-        self.assertListEqual(self.b.popcount().to_ndarray().tolist(), ans.to_ndarray().tolist())
+        self.assertListEqual(self.b.popcount().to_list(), ans.to_list())
 
         # Function invocation
         # Edge case input
         ans = [1, 64, 63]
-        self.assertListEqual(ak.popcount(self.edgeCases).to_ndarray().tolist(), ans)
+        self.assertListEqual(ak.popcount(self.edgeCases).to_list(), ans)
 
         # Test uint case
         ans = ak.array(ans, ak.uint64)
-        self.assertListEqual(
-            ak.popcount(self.edgeCasesUint).to_ndarray().tolist(), ans.to_ndarray().tolist()
-        )
+        self.assertListEqual(ak.popcount(self.edgeCasesUint).to_list(), ans.to_list())
 
     def test_parity(self):
         ans = [0, 1, 1, 0, 1, 0, 0, 1, 1, 0]
-        self.assertListEqual(self.a.parity().to_ndarray().tolist(), ans)
+        self.assertListEqual(self.a.parity().to_list(), ans)
 
         # Test uint case
         ans = ak.array(ans, ak.uint64)
-        self.assertListEqual(self.b.parity().to_ndarray().tolist(), ans.to_ndarray().tolist())
+        self.assertListEqual(self.b.parity().to_list(), ans.to_list())
 
         ans = [1, 0, 1]
-        self.assertListEqual(ak.parity(self.edgeCases).to_ndarray().tolist(), ans)
+        self.assertListEqual(ak.parity(self.edgeCases).to_list(), ans)
 
         # Test uint case
         ans = ak.array(ans, ak.uint64)
-        self.assertListEqual(
-            ak.parity(self.edgeCasesUint).to_ndarray().tolist(), ans.to_ndarray().tolist()
-        )
+        self.assertListEqual(ak.parity(self.edgeCasesUint).to_list(), ans.to_list())
 
     def test_clz(self):
         ans = [64, 63, 62, 62, 61, 61, 61, 61, 60, 60]
-        self.assertListEqual(self.a.clz().to_ndarray().tolist(), ans)
+        self.assertListEqual(self.a.clz().to_list(), ans)
 
         # Test uint case
         ans = ak.array(ans, ak.uint64)
-        self.assertListEqual(self.b.clz().to_ndarray().tolist(), ans.to_ndarray().tolist())
+        self.assertListEqual(self.b.clz().to_list(), ans.to_list())
 
         ans = [0, 0, 1]
-        self.assertListEqual(ak.clz(self.edgeCases).to_ndarray().tolist(), ans)
+        self.assertListEqual(ak.clz(self.edgeCases).to_list(), ans)
 
         # Test uint case
         ans = ak.array(ans, ak.uint64)
-        self.assertListEqual(ak.clz(self.edgeCasesUint).to_ndarray().tolist(), ans.to_ndarray().tolist())
+        self.assertListEqual(ak.clz(self.edgeCasesUint).to_list(), ans.to_list())
 
     def test_ctz(self):
         ans = [0, 0, 1, 0, 2, 0, 1, 0, 3, 0]
-        self.assertListEqual(self.a.ctz().to_ndarray().tolist(), ans)
+        self.assertListEqual(self.a.ctz().to_list(), ans)
 
         # Test uint case
         ans = ak.array(ans, ak.uint64)
-        self.assertListEqual(self.b.ctz().to_ndarray().tolist(), ans.to_ndarray().tolist())
+        self.assertListEqual(self.b.ctz().to_list(), ans.to_list())
 
         ans = [63, 0, 0]
-        self.assertListEqual(ak.ctz(self.edgeCases).to_ndarray().tolist(), ans)
+        self.assertListEqual(ak.ctz(self.edgeCases).to_list(), ans)
 
         # Test uint case
         ans = ak.array(ans, ak.uint64)
-        self.assertListEqual(ak.ctz(self.edgeCasesUint).to_ndarray().tolist(), ans.to_ndarray().tolist())
+        self.assertListEqual(ak.ctz(self.edgeCasesUint).to_list(), ans.to_list())
 
     def test_dtypes(self):
         f = ak.zeros(10, dtype=ak.float64)
@@ -91,45 +87,45 @@ class BitOpsTest(ArkoudaTest):
         rotated = self.a.rotl(5)
         shifted = self.a << 5
         # No wraparound, so these should be equal
-        self.assertListEqual(rotated.to_ndarray().tolist(), shifted.to_ndarray().tolist())
+        self.assertListEqual(rotated.to_list(), shifted.to_list())
 
         r = ak.rotl(self.edgeCases, 1)
-        self.assertListEqual(r.to_ndarray().tolist(), [1, -1, -2])
+        self.assertListEqual(r.to_list(), [1, -1, -2])
 
         # vector <<< vector
         rotated = self.a.rotl(self.a)
         shifted = self.a << self.a
         # No wraparound, so these should be equal
-        self.assertListEqual(rotated.to_ndarray().tolist(), shifted.to_ndarray().tolist())
+        self.assertListEqual(rotated.to_list(), shifted.to_list())
 
         r = ak.rotl(self.edgeCases, ak.array([1, 1, 1]))
-        self.assertListEqual(r.to_ndarray().tolist(), [1, -1, -2])
+        self.assertListEqual(r.to_list(), [1, -1, -2])
 
         # scalar <<< vector
         rotated = ak.rotl(-(2**63), self.a)
         ans = [-(2**63), 1, 2, 4, 8, 16, 32, 64, 128, 256]
-        self.assertListEqual(rotated.to_ndarray().tolist(), ans)
+        self.assertListEqual(rotated.to_list(), ans)
 
     def test_rotr(self):
         # vector <<< scalar
         rotated = (1024 * self.a).rotr(5)
         shifted = (1024 * self.a) >> 5
         # No wraparound, so these should be equal
-        self.assertListEqual(rotated.to_ndarray().tolist(), shifted.to_ndarray().tolist())
+        self.assertListEqual(rotated.to_list(), shifted.to_list())
 
         r = ak.rotr(self.edgeCases, 1)
-        self.assertListEqual(r.to_ndarray().tolist(), [2**62, -1, -(2**62) - 1])
+        self.assertListEqual(r.to_list(), [2**62, -1, -(2**62) - 1])
 
         # vector <<< vector
         rotated = (1024 * self.a).rotr(self.a)
         shifted = (1024 * self.a) >> self.a
         # No wraparound, so these should be equal
-        self.assertListEqual(rotated.to_ndarray().tolist(), shifted.to_ndarray().tolist())
+        self.assertListEqual(rotated.to_list(), shifted.to_list())
 
         r = ak.rotr(self.edgeCases, ak.array([1, 1, 1]))
-        self.assertListEqual(r.to_ndarray().tolist(), [2**62, -1, -(2**62) - 1])
+        self.assertListEqual(r.to_list(), [2**62, -1, -(2**62) - 1])
 
         # scalar <<< vector
         rotated = ak.rotr(1, self.a)
         ans = [1, -(2**63), 2**62, 2**61, 2**60, 2**59, 2**58, 2**57, 2**56, 2**55]
-        self.assertListEqual(rotated.to_ndarray().tolist(), ans)
+        self.assertListEqual(rotated.to_list(), ans)

--- a/tests/categorical_test.py
+++ b/tests/categorical_test.py
@@ -42,31 +42,27 @@ class CategoricalTest(ArkoudaTest):
         cat = self._getCategorical()
 
         self.assertListEqual(
-            ak.array([7, 5, 9, 8, 2, 1, 4, 0, 3, 6]).to_ndarray().tolist(),
+            [7, 5, 9, 8, 2, 1, 4, 0, 3, 6],
             cat.codes.to_ndarray().tolist(),
         )
         self.assertListEqual(
-            ak.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).to_ndarray().tolist(),
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
             cat.segments.to_ndarray().tolist(),
         )
         self.assertListEqual(
-            ak.array(
-                [
-                    "string 8",
-                    "string 6",
-                    "string 5",
-                    "string 9",
-                    "string 7",
-                    "string 2",
-                    "string 10",
-                    "string 1",
-                    "string 4",
-                    "string 3",
-                    "N/A",
-                ]
-            )
-            .to_ndarray()
-            .tolist(),
+            [
+                "string 8",
+                "string 6",
+                "string 5",
+                "string 9",
+                "string 7",
+                "string 2",
+                "string 10",
+                "string 1",
+                "string 4",
+                "string 3",
+                "N/A",
+            ],
             cat.categories.to_ndarray().tolist(),
         )
         self.assertEqual(10, cat.size)
@@ -113,9 +109,7 @@ class CategoricalTest(ArkoudaTest):
 
     def testGroup(self):
         group = self._getRandomizedCategorical().group()
-        self.assertListEqual(
-            ak.array([2, 5, 9, 6, 1, 3, 7, 0, 4, 8]).to_ndarray().tolist(), group.to_ndarray().tolist()
-        )
+        self.assertListEqual([2, 5, 9, 6, 1, 3, 7, 0, 4, 8], group.to_ndarray().tolist())
 
     def testUnique(self):
         cat = self._getRandomizedCategorical()
@@ -156,8 +150,7 @@ class CategoricalTest(ArkoudaTest):
         c1 = ak.Categorical(ak.array(["a", "b", "c", "a", "b"]))
         c2 = ak.Categorical(ak.array(["a", "x", "c", "y", "b"]))
         res = c1 == c2
-        ans = ak.array([True, False, True, False, True])
-        self.assertListEqual(res.to_ndarray().tolist(), ans.to_ndarray().tolist())
+        self.assertListEqual(res.to_ndarray().tolist(), [True, False, True, False, True])
 
     def testBinop(self):
         cat = self._getCategorical()
@@ -212,12 +205,10 @@ class CategoricalTest(ArkoudaTest):
         catOne = ak.Categorical(stringsOne)
         catTwo = ak.Categorical(stringsTwo)
 
-        answer = ak.array([x < 2 for x in vals])
+        answer = [x < 2 for x in vals]
 
-        self.assertListEqual(answer.to_ndarray().tolist(), ak.in1d(catOne, catTwo).to_ndarray().tolist())
-        self.assertListEqual(
-            answer.to_ndarray().tolist(), ak.in1d(catOne, stringsTwo).to_ndarray().tolist()
-        )
+        self.assertListEqual(answer, ak.in1d(catOne, catTwo).to_ndarray().tolist())
+        self.assertListEqual(answer, ak.in1d(catOne, stringsTwo).to_ndarray().tolist())
 
         with self.assertRaises(TypeError):
             ak.in1d(catOne, ak.randint(0, 5, 5))
@@ -402,8 +393,7 @@ class CategoricalTest(ArkoudaTest):
         values = ak.Categorical(ak.array(["A", "B", "C"]))
         args = ak.array([3, 2, 1, 0])
         ret = ak.lookup(keys, values, args)
-        expected = ["C", "B", "A", "N/A"]
-        self.assertListEqual(ret.to_ndarray().tolist(), expected)
+        self.assertListEqual(ret.to_ndarray().tolist(), ["C", "B", "A", "N/A"])
 
     def tearDown(self):
         super(CategoricalTest, self).tearDown()

--- a/tests/categorical_test.py
+++ b/tests/categorical_test.py
@@ -115,9 +115,9 @@ class CategoricalTest(ArkoudaTest):
         cat = self._getRandomizedCategorical()
 
         self.assertListEqual(
-            ak.Categorical(ak.array(["non-string", "string3", "string1", "non-string2", "string"]))
-            .to_ndarray()
-            .tolist(),
+            ak.Categorical(
+                ak.array(["non-string", "string3", "string1", "non-string2", "string"])
+            ).to_list(),
             cat.unique().to_list(),
         )
 

--- a/tests/categorical_test.py
+++ b/tests/categorical_test.py
@@ -43,11 +43,11 @@ class CategoricalTest(ArkoudaTest):
 
         self.assertListEqual(
             [7, 5, 9, 8, 2, 1, 4, 0, 3, 6],
-            cat.codes.to_ndarray().tolist(),
+            cat.codes.to_list(),
         )
         self.assertListEqual(
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-            cat.segments.to_ndarray().tolist(),
+            cat.segments.to_list(),
         )
         self.assertListEqual(
             [
@@ -63,7 +63,7 @@ class CategoricalTest(ArkoudaTest):
                 "string 3",
                 "N/A",
             ],
-            cat.categories.to_ndarray().tolist(),
+            cat.categories.to_list(),
         )
         self.assertEqual(10, cat.size)
         self.assertEqual("Categorical", cat.objtype)
@@ -92,8 +92,8 @@ class CategoricalTest(ArkoudaTest):
         )
 
         cat = ak.Categorical.from_codes(codes, categories)
-        self.assertListEqual(codes.to_ndarray().tolist(), cat.codes.to_ndarray().tolist())
-        self.assertListEqual(categories.to_ndarray().tolist(), cat.categories.to_ndarray().tolist())
+        self.assertListEqual(codes.to_list(), cat.codes.to_list())
+        self.assertListEqual(categories.to_list(), cat.categories.to_list())
 
     def testContains(self):
         cat = self._getCategorical()
@@ -109,7 +109,7 @@ class CategoricalTest(ArkoudaTest):
 
     def testGroup(self):
         group = self._getRandomizedCategorical().group()
-        self.assertListEqual([2, 5, 9, 6, 1, 3, 7, 0, 4, 8], group.to_ndarray().tolist())
+        self.assertListEqual([2, 5, 9, 6, 1, 3, 7, 0, 4, 8], group.to_list())
 
     def testUnique(self):
         cat = self._getRandomizedCategorical()
@@ -118,7 +118,7 @@ class CategoricalTest(ArkoudaTest):
             ak.Categorical(ak.array(["non-string", "string3", "string1", "non-string2", "string"]))
             .to_ndarray()
             .tolist(),
-            cat.unique().to_ndarray().tolist(),
+            cat.unique().to_list(),
         )
 
     def testToNdarray(self):
@@ -137,20 +137,20 @@ class CategoricalTest(ArkoudaTest):
                 "non-string",
             ]
         )
-        self.assertListEqual(cat.to_ndarray().tolist(), ndcat.tolist())
+        self.assertListEqual(cat.to_list(), ndcat.tolist())
 
     def testEquality(self):
         cat = self._getCategorical()
         catDupe = self._getCategorical()
         catNonDupe = self._getRandomizedCategorical()
 
-        self.assertListEqual(cat.to_ndarray().tolist(), catDupe.to_ndarray().tolist())
+        self.assertListEqual(cat.to_list(), catDupe.to_list())
         self.assertFalse((cat == catNonDupe).any())
 
         c1 = ak.Categorical(ak.array(["a", "b", "c", "a", "b"]))
         c2 = ak.Categorical(ak.array(["a", "x", "c", "y", "b"]))
         res = c1 == c2
-        self.assertListEqual(res.to_ndarray().tolist(), [True, False, True, False, True])
+        self.assertListEqual(res.to_list(), [True, False, True, False, True])
 
     def testBinop(self):
         cat = self._getCategorical()
@@ -161,33 +161,33 @@ class CategoricalTest(ArkoudaTest):
         self.assertTrue(cat._binop(catNonDupe, "!=").all())
 
         self.assertListEqual(
-            ak.ones(10, dtype=bool).to_ndarray().tolist(),
-            cat._binop(catDupe, "==").to_ndarray().tolist(),
+            ak.ones(10, dtype=bool).to_list(),
+            cat._binop(catDupe, "==").to_list(),
         )
 
         self.assertListEqual(
-            ak.zeros(10, dtype=bool).to_ndarray().tolist(),
-            cat._binop(catDupe, "!=").to_ndarray().tolist(),
+            ak.zeros(10, dtype=bool).to_list(),
+            cat._binop(catDupe, "!=").to_list(),
         )
 
         self.assertListEqual(
-            (ak.arange(10) == 0).to_ndarray().tolist(),
-            cat._binop("string 1", "==").to_ndarray().tolist(),
+            (ak.arange(10) == 0).to_list(),
+            cat._binop("string 1", "==").to_list(),
         )
 
         self.assertListEqual(
-            (ak.arange(10) == 0).to_ndarray().tolist(),
-            cat._binop(np.str_("string 1"), "==").to_ndarray().tolist(),
+            (ak.arange(10) == 0).to_list(),
+            cat._binop(np.str_("string 1"), "==").to_list(),
         )
 
         self.assertListEqual(
-            (ak.arange(10) != 0).to_ndarray().tolist(),
-            cat._binop("string 1", "!=").to_ndarray().tolist(),
+            (ak.arange(10) != 0).to_list(),
+            cat._binop("string 1", "!=").to_list(),
         )
 
         self.assertListEqual(
-            (ak.arange(10) != 0).to_ndarray().tolist(),
-            cat._binop(np.str_("string 1"), "!=").to_ndarray().tolist(),
+            (ak.arange(10) != 0).to_list(),
+            cat._binop(np.str_("string 1"), "!=").to_list(),
         )
 
         with self.assertRaises(NotImplementedError):
@@ -207,8 +207,8 @@ class CategoricalTest(ArkoudaTest):
 
         answer = [x < 2 for x in vals]
 
-        self.assertListEqual(answer, ak.in1d(catOne, catTwo).to_ndarray().tolist())
-        self.assertListEqual(answer, ak.in1d(catOne, stringsTwo).to_ndarray().tolist())
+        self.assertListEqual(answer, ak.in1d(catOne, catTwo).to_list())
+        self.assertListEqual(answer, ak.in1d(catOne, stringsTwo).to_list())
 
         with self.assertRaises(TypeError):
             ak.in1d(catOne, ak.randint(0, 5, 5))
@@ -246,13 +246,11 @@ class CategoricalTest(ArkoudaTest):
         # Ordered concatenation
         s12ord = ak.concatenate([s1, s2], ordered=True)
         c12ord = ak.concatenate([c1, c2], ordered=True)
-        self.assertListEqual(ak.Categorical(s12ord).to_ndarray().tolist(), c12ord.to_ndarray().tolist())
+        self.assertListEqual(ak.Categorical(s12ord).to_list(), c12ord.to_list())
         # Unordered (but still deterministic) concatenation
         s12unord = ak.concatenate([s1, s2], ordered=False)
         c12unord = ak.concatenate([c1, c2], ordered=False)
-        self.assertListEqual(
-            ak.Categorical(s12unord).to_ndarray().tolist(), c12unord.to_ndarray().tolist()
-        )
+        self.assertListEqual(ak.Categorical(s12unord).to_list(), c12unord.to_list())
 
         # Tiny concatenation
         # Used to fail when length of array was less than numLocales
@@ -261,7 +259,7 @@ class CategoricalTest(ArkoudaTest):
         b = ak.Categorical(ak.array(["b"]))
         c = ak.concatenate((a, b), ordered=False)
         ans = ak.Categorical(ak.array(["a", "b"]))
-        self.assertListEqual(c.to_ndarray().tolist(), ans.to_ndarray().tolist())
+        self.assertListEqual(c.to_list(), ans.to_list())
 
     def testSaveAndLoadCategorical(self):
         """
@@ -301,7 +299,7 @@ class CategoricalTest(ArkoudaTest):
 
             # Note assertCountEqual asserts a and b have the same elements
             # in the same amount regardless of order
-            self.assertCountEqual(cat_from_hdf.categories.to_ndarray().tolist(), expected_categories)
+            self.assertCountEqual(cat_from_hdf.categories.to_list(), expected_categories)
 
             # Asserting the optional components and sizes are correct
             # for both constructors should be sufficient
@@ -319,20 +317,14 @@ class CategoricalTest(ArkoudaTest):
         s12 = s[1:3]
         cat = ak.Categorical(s)
         cat12 = cat[1:3]
-        self.assertListEqual(
-            ak.in1d(s, s12).to_ndarray().tolist(), ak.in1d(cat, cat12).to_ndarray().tolist()
-        )
-        self.assertSetEqual(
-            set(ak.unique(s12).to_ndarray().tolist()), set(ak.unique(cat12).to_ndarray().tolist())
-        )
+        self.assertListEqual(ak.in1d(s, s12).to_list(), ak.in1d(cat, cat12).to_list())
+        self.assertSetEqual(set(ak.unique(s12).to_list()), set(ak.unique(cat12).to_list()))
 
         cat_from_codes = ak.Categorical.from_codes(ak.array([1, 2]), s)
-        self.assertListEqual(
-            ak.in1d(s, s12).to_ndarray().tolist(), ak.in1d(cat, cat_from_codes).to_ndarray().tolist()
-        )
+        self.assertListEqual(ak.in1d(s, s12).to_list(), ak.in1d(cat, cat_from_codes).to_list())
         self.assertSetEqual(
-            set(ak.unique(s12).to_ndarray().tolist()),
-            set(ak.unique(cat_from_codes).to_ndarray().tolist()),
+            set(ak.unique(s12).to_list()),
+            set(ak.unique(cat_from_codes).to_list()),
         )
 
     def testSaveAndLoadCategoricalMulti(self):
@@ -353,20 +345,16 @@ class CategoricalTest(ArkoudaTest):
             self.assertEqual(len(x.items()), 4)
             # Note assertCountEqual asserts a and b have the same
             # elements in the same amount regardless of order
-            self.assertCountEqual(
-                x["cat1"].categories.to_ndarray().tolist(), c1.categories.to_ndarray().tolist()
-            )
-            self.assertCountEqual(
-                x["cat2"].categories.to_ndarray().tolist(), c2.categories.to_ndarray().tolist()
-            )
-            self.assertCountEqual(x["pda1"].to_ndarray().tolist(), pda1.to_ndarray().tolist())
-            self.assertCountEqual(x["strings1"].to_ndarray().tolist(), strings1.to_ndarray().tolist())
+            self.assertCountEqual(x["cat1"].categories.to_list(), c1.categories.to_list())
+            self.assertCountEqual(x["cat2"].categories.to_list(), c2.categories.to_list())
+            self.assertCountEqual(x["pda1"].to_list(), pda1.to_list())
+            self.assertCountEqual(x["strings1"].to_list(), strings1.to_list())
 
     def testNA(self):
         s = ak.array(["A", "B", "C", "B", "C"])
         # NAval present in categories
         c = ak.Categorical(s, NAvalue="C")
-        self.assertListEqual(c.isna().to_ndarray().tolist(), [False, False, True, False, True])
+        self.assertListEqual(c.isna().to_list(), [False, False, True, False, True])
         self.assertEqual(c.NAvalue, "C")
         # Test that NAval survives registration
         c.register("my_categorical")
@@ -382,7 +370,7 @@ class CategoricalTest(ArkoudaTest):
         c1 = ak.Categorical(ak.array(["A", "B", "C"]))
         c2 = ak.Categorical(ak.array(["B", "C", "D"]))
         c3, c4 = ak.Categorical.standardize_categories([c1, c2])
-        self.assertListEqual(c3.categories.to_ndarray().tolist(), c4.categories.to_ndarray().tolist())
+        self.assertListEqual(c3.categories.to_list(), c4.categories.to_list())
         self.assertTrue(not c3.isna().any())
         self.assertTrue(not c4.isna().any())
         self.assertEqual(c3.categories.size, c1.categories.size + 1)
@@ -393,7 +381,7 @@ class CategoricalTest(ArkoudaTest):
         values = ak.Categorical(ak.array(["A", "B", "C"]))
         args = ak.array([3, 2, 1, 0])
         ret = ak.lookup(keys, values, args)
-        self.assertListEqual(ret.to_ndarray().tolist(), ["C", "B", "A", "N/A"])
+        self.assertListEqual(ret.to_list(), ["C", "B", "A", "N/A"])
 
     def tearDown(self):
         super(CategoricalTest, self).tearDown()

--- a/tests/check.py
+++ b/tests/check.py
@@ -20,7 +20,7 @@ def check_bool(N):
     a = ak.arange(N)
     b = ak.ones(N)
     try:
-        c = a and b
+        a and b
     except ValueError:
         correct = True
     except:

--- a/tests/client_dtypes_test.py
+++ b/tests/client_dtypes_test.py
@@ -19,14 +19,14 @@ class ClientDTypeTests(ArkoudaTest):
         arr = ak.arange(4)
         bv = ak.BitVector(arr, width=3)
         self.assertIsInstance(bv, client_dtypes.BitVector)
-        self.assertListEqual(bv.to_ndarray().tolist(), ["...", "..|", ".|.", ".||"])
+        self.assertListEqual(bv.to_list(), ["...", "..|", ".|.", ".||"])
         self.assertEqual(bv.dtype, ak.bitType)
 
         # Test reversed
         arr = ak.arange(4, dtype=ak.uint64)  # Also test with uint64 input
         bv = ak.BitVector(arr, width=3, reverse=True)
         self.assertIsInstance(bv, client_dtypes.BitVector)
-        self.assertListEqual(bv.to_ndarray().tolist(), ["...", "|..", ".|.", "||."])
+        self.assertListEqual(bv.to_list(), ["...", "|..", ".|.", "||."])
         self.assertEqual(bv.dtype, ak.bitType)
 
         # test use of vectorizer function
@@ -34,7 +34,7 @@ class ClientDTypeTests(ArkoudaTest):
         bvectorizer = ak.BitVectorizer(3)
         bv = bvectorizer(arr)
         self.assertIsInstance(bv, client_dtypes.BitVector)
-        self.assertListEqual(bv.to_ndarray().tolist(), ["...", "..|", ".|.", ".||"])
+        self.assertListEqual(bv.to_list(), ["...", "..|", ".|.", ".||"])
         self.assertEqual(bv.dtype, ak.bitType)
 
         # fail on argument types
@@ -49,7 +49,7 @@ class ClientDTypeTests(ArkoudaTest):
         names = ["8", "4", "2", "1"]
         f = ak.Fields(values, names)
         self.assertIsInstance(f, ak.Fields)
-        self.assertListEqual(f.to_ndarray().tolist(), ["---- (0)", "---1 (1)", "--2- (2)", "--21 (3)"])
+        self.assertListEqual(f.to_list(), ["---- (0)", "---1 (1)", "--2- (2)", "--21 (3)"])
         self.assertEqual(f.dtype, ak.bitType)
 
         # Named fields with reversed bit order
@@ -63,7 +63,7 @@ class ClientDTypeTests(ArkoudaTest):
             "----//----//----//Bit4// (8)",
             "----//----//Bit3//Bit4// (12)",
         ]
-        self.assertListEqual(f.to_ndarray().tolist(), expected)
+        self.assertListEqual(f.to_list(), expected)
 
         values = ak.arange(8, dtype=ak.uint64)
         names = [f"Bit{x}" for x in range(65)]
@@ -94,7 +94,7 @@ class ClientDTypeTests(ArkoudaTest):
         ipv4 = ak.IPv4(ip_list)
 
         self.assertIsInstance(ipv4, ak.IPv4)
-        self.assertListEqual(ipv4.to_ndarray().tolist(), ["192.168.1.1"])
+        self.assertListEqual(ipv4.to_list(), ["192.168.1.1"])
         self.assertEqual(ipv4.dtype, ak.bitType)
 
         # Test handling of uint64 input
@@ -102,7 +102,7 @@ class ClientDTypeTests(ArkoudaTest):
         ipv4 = ak.IPv4(ip_list)
 
         self.assertIsInstance(ipv4, ak.IPv4)
-        self.assertListEqual(ipv4.to_ndarray().tolist(), ["192.168.1.1"])
+        self.assertListEqual(ipv4.to_list(), ["192.168.1.1"])
         self.assertEqual(ipv4.dtype, ak.bitType)
 
         with self.assertRaises(TypeError):
@@ -113,7 +113,7 @@ class ClientDTypeTests(ArkoudaTest):
         # Test handling of python dotted-quad input
         ipv4 = ak.ip_address(["192.168.1.1"])
         self.assertIsInstance(ipv4, ak.IPv4)
-        self.assertListEqual(ipv4.to_ndarray().tolist(), ["192.168.1.1"])
+        self.assertListEqual(ipv4.to_list(), ["192.168.1.1"])
         self.assertEqual(ipv4.dtype, ak.bitType)
 
     def test_ipv4_normalization(self):
@@ -126,14 +126,14 @@ class ClientDTypeTests(ArkoudaTest):
         x = [random.getrandbits(32) for i in range(100)]
 
         ans = ak.is_ipv4(ak.array(x, dtype=ak.uint64))
-        self.assertListEqual(ans.to_ndarray().tolist(), [True] * 100)
+        self.assertListEqual(ans.to_list(), [True] * 100)
 
         ipv4 = ak.IPv4(ak.array(x))
-        self.assertListEqual(ak.is_ipv4(ipv4).to_ndarray().tolist(), [True] * 100)
+        self.assertListEqual(ak.is_ipv4(ipv4).to_list(), [True] * 100)
 
         x = [random.getrandbits(64) if i < 5 else random.getrandbits(32) for i in range(10)]
         ans = ak.is_ipv4(ak.array(x, ak.uint64))
-        self.assertListEqual(ans.to_ndarray().tolist(), [i >= 5 for i in range(10)])
+        self.assertListEqual(ans.to_list(), [i >= 5 for i in range(10)])
 
         with self.assertRaises(TypeError):
             ak.is_ipv4(ak.array(x, ak.float64))
@@ -146,11 +146,11 @@ class ClientDTypeTests(ArkoudaTest):
         low = ak.array([i & (2**64 - 1) for i in x], dtype=ak.uint64)
         high = ak.array([i >> 64 for i in x], dtype=ak.uint64)
 
-        self.assertListEqual(ak.is_ipv6(high, low).to_ndarray().tolist(), [True] * 100)
+        self.assertListEqual(ak.is_ipv6(high, low).to_list(), [True] * 100)
 
         x = [random.getrandbits(64) if i < 5 else random.getrandbits(32) for i in range(10)]
         ans = ak.is_ipv6(ak.array(x, ak.uint64))
-        self.assertListEqual(ans.to_ndarray().tolist(), [i < 5 for i in range(10)])
+        self.assertListEqual(ans.to_list(), [i < 5 for i in range(10)])
 
         with self.assertRaises(TypeError):
             ak.is_ipv6(ak.array(x, ak.float64))

--- a/tests/client_dtypes_test.py
+++ b/tests/client_dtypes_test.py
@@ -20,14 +20,14 @@ class ClientDTypeTests(ArkoudaTest):
         bv = ak.BitVector(arr, width=3)
         self.assertIsInstance(bv, client_dtypes.BitVector)
         self.assertListEqual(bv.to_ndarray().tolist(), ["...", "..|", ".|.", ".||"])
-        self.assertTrue(bv.dtype == ak.bitType)
+        self.assertEqual(bv.dtype, ak.bitType)
 
         # Test reversed
         arr = ak.arange(4, dtype=ak.uint64)  # Also test with uint64 input
         bv = ak.BitVector(arr, width=3, reverse=True)
         self.assertIsInstance(bv, client_dtypes.BitVector)
         self.assertListEqual(bv.to_ndarray().tolist(), ["...", "|..", ".|.", "||."])
-        self.assertTrue(bv.dtype == ak.bitType)
+        self.assertEqual(bv.dtype, ak.bitType)
 
         # test use of vectorizer function
         arr = ak.arange(4)
@@ -35,7 +35,7 @@ class ClientDTypeTests(ArkoudaTest):
         bv = bvectorizer(arr)
         self.assertIsInstance(bv, client_dtypes.BitVector)
         self.assertListEqual(bv.to_ndarray().tolist(), ["...", "..|", ".|.", ".||"])
-        self.assertTrue(bv.dtype == ak.bitType)
+        self.assertEqual(bv.dtype, ak.bitType)
 
         # fail on argument types
         with self.assertRaises(TypeError):
@@ -50,7 +50,7 @@ class ClientDTypeTests(ArkoudaTest):
         f = ak.Fields(values, names)
         self.assertIsInstance(f, ak.Fields)
         self.assertListEqual(f.to_ndarray().tolist(), ["---- (0)", "---1 (1)", "--2- (2)", "--21 (3)"])
-        self.assertTrue(f.dtype == ak.bitType)
+        self.assertEqual(f.dtype, ak.bitType)
 
         # Named fields with reversed bit order
         values = ak.array([0, 1, 5, 8, 12])
@@ -95,7 +95,7 @@ class ClientDTypeTests(ArkoudaTest):
 
         self.assertIsInstance(ipv4, ak.IPv4)
         self.assertListEqual(ipv4.to_ndarray().tolist(), ["192.168.1.1"])
-        self.assertTrue(ipv4.dtype == ak.bitType)
+        self.assertEqual(ipv4.dtype, ak.bitType)
 
         # Test handling of uint64 input
         ip_list = ak.array([3232235777], dtype=ak.uint64)
@@ -103,7 +103,7 @@ class ClientDTypeTests(ArkoudaTest):
 
         self.assertIsInstance(ipv4, ak.IPv4)
         self.assertListEqual(ipv4.to_ndarray().tolist(), ["192.168.1.1"])
-        self.assertTrue(ipv4.dtype == ak.bitType)
+        self.assertEqual(ipv4.dtype, ak.bitType)
 
         with self.assertRaises(TypeError):
             ipv4 = ak.IPv4("3232235777")
@@ -114,7 +114,7 @@ class ClientDTypeTests(ArkoudaTest):
         ipv4 = ak.ip_address(["192.168.1.1"])
         self.assertIsInstance(ipv4, ak.IPv4)
         self.assertListEqual(ipv4.to_ndarray().tolist(), ["192.168.1.1"])
-        self.assertTrue(ipv4.dtype == ak.bitType)
+        self.assertEqual(ipv4.dtype, ak.bitType)
 
     def test_ipv4_normalization(self):
         ip_list = ak.array([3232235777])
@@ -126,7 +126,7 @@ class ClientDTypeTests(ArkoudaTest):
         x = [random.getrandbits(32) for i in range(100)]
 
         ans = ak.is_ipv4(ak.array(x, dtype=ak.uint64))
-        self.assertListEqual(ans.to_ndarray().tolist(), [True]*100)
+        self.assertListEqual(ans.to_ndarray().tolist(), [True] * 100)
 
         ipv4 = ak.IPv4(ak.array(x))
         ans = ak.is_ipv4(ipv4)
@@ -144,7 +144,7 @@ class ClientDTypeTests(ArkoudaTest):
 
     def test_is_ipv6(self):
         x = [random.getrandbits(128) for i in range(100)]
-        low = ak.array([i & (2 ** 64 - 1) for i in x], dtype=ak.uint64)
+        low = ak.array([i & (2**64 - 1) for i in x], dtype=ak.uint64)
         high = ak.array([i >> 64 for i in x], dtype=ak.uint64)
 
         ans = ak.is_ipv6(high, low)

--- a/tests/client_dtypes_test.py
+++ b/tests/client_dtypes_test.py
@@ -129,8 +129,7 @@ class ClientDTypeTests(ArkoudaTest):
         self.assertListEqual(ans.to_ndarray().tolist(), [True] * 100)
 
         ipv4 = ak.IPv4(ak.array(x))
-        ans = ak.is_ipv4(ipv4)
-        self.assertListEqual(ans.to_ndarray().tolist(), [True] * 100)
+        self.assertListEqual(ak.is_ipv4(ipv4).to_ndarray().tolist(), [True] * 100)
 
         x = [random.getrandbits(64) if i < 5 else random.getrandbits(32) for i in range(10)]
         ans = ak.is_ipv4(ak.array(x, ak.uint64))
@@ -147,8 +146,7 @@ class ClientDTypeTests(ArkoudaTest):
         low = ak.array([i & (2**64 - 1) for i in x], dtype=ak.uint64)
         high = ak.array([i >> 64 for i in x], dtype=ak.uint64)
 
-        ans = ak.is_ipv6(high, low)
-        self.assertListEqual(ans.to_ndarray().tolist(), [True] * 100)
+        self.assertListEqual(ak.is_ipv6(high, low).to_ndarray().tolist(), [True] * 100)
 
         x = [random.getrandbits(64) if i < 5 else random.getrandbits(32) for i in range(10)]
         ans = ak.is_ipv6(ak.array(x, ak.uint64))

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -136,7 +136,6 @@ class ClientTest(ArkoudaTest):
         Tests the ak.client.get_server_commands() method contains an expected
         sample of commands.
         """
-        expected_cmds = ["connect", "array", "create", "tondarray", "info", "str"]
         cmds = ak.client.get_server_commands()
-        for cmd in expected_cmds:
+        for cmd in ["connect", "array", "create", "tondarray", "info", "str"]:
             self.assertTrue(cmd in cmds)

--- a/tests/coargsort_test.py
+++ b/tests/coargsort_test.py
@@ -167,28 +167,24 @@ class CoargsortTest(ArkoudaTest):
         )
         for algo in ak.SortingAlgorithm:
             str_perm = ak.coargsort([string], algo)
-            str_sorted = string[str_perm].to_ndarray()
+            str_sorted = string[str_perm].to_list()
 
             # coargsort on categorical
             cat_perm = ak.coargsort([cat], algo)
-            cat_sorted = cat[cat_perm].to_ndarray()
-            self.assertListEqual(str_sorted.tolist(), cat_sorted.tolist())
+            self.assertListEqual(str_sorted, cat[cat_perm].to_list())
 
             # coargsort on categorical.from_codes
             # coargsort sorts using codes, the order isn't guaranteed, only grouping
             from_codes_perm = ak.coargsort([cat_from_codes], algo)
-            from_codes_sorted = cat_from_codes[from_codes_perm].to_ndarray()
-            self.assertListEqual(["a", "a", "b", "b", "c"], from_codes_sorted.tolist())
+            self.assertListEqual(["a", "a", "b", "b", "c"], cat_from_codes[from_codes_perm].to_list())
 
             # coargsort on 2 categoricals (one from_codes)
             cat_perm = ak.coargsort([cat, cat_from_codes], algo)
-            cat_sorted = cat[cat_perm].to_ndarray()
-            self.assertListEqual(str_sorted.tolist(), cat_sorted.tolist())
+            self.assertListEqual(str_sorted, cat[cat_perm].to_list())
 
             # coargsort on mixed strings and categoricals
             mixed_perm = ak.coargsort([cat, string, cat_from_codes], algo)
-            mixed_sorted = cat_from_codes[mixed_perm].to_ndarray()
-            self.assertListEqual(str_sorted.tolist(), mixed_sorted.tolist())
+            self.assertListEqual(str_sorted, cat_from_codes[mixed_perm].to_list())
 
 
 def create_parser():

--- a/tests/coargsort_test.py
+++ b/tests/coargsort_test.py
@@ -172,23 +172,23 @@ class CoargsortTest(ArkoudaTest):
             # coargsort on categorical
             cat_perm = ak.coargsort([cat], algo)
             cat_sorted = cat[cat_perm].to_ndarray()
-            self.assertTrue((str_sorted == cat_sorted).all())
+            self.assertListEqual(str_sorted.tolist(), cat_sorted.tolist())
 
             # coargsort on categorical.from_codes
             # coargsort sorts using codes, the order isn't guaranteed, only grouping
             from_codes_perm = ak.coargsort([cat_from_codes], algo)
             from_codes_sorted = cat_from_codes[from_codes_perm].to_ndarray()
-            self.assertTrue((["a", "a", "b", "b", "c"] == from_codes_sorted).all())
+            self.assertListEqual(["a", "a", "b", "b", "c"], from_codes_sorted.tolist())
 
             # coargsort on 2 categoricals (one from_codes)
             cat_perm = ak.coargsort([cat, cat_from_codes], algo)
             cat_sorted = cat[cat_perm].to_ndarray()
-            self.assertTrue((str_sorted == cat_sorted).all())
+            self.assertListEqual(str_sorted.tolist(), cat_sorted.tolist())
 
             # coargsort on mixed strings and categoricals
             mixed_perm = ak.coargsort([cat, string, cat_from_codes], algo)
             mixed_sorted = cat_from_codes[mixed_perm].to_ndarray()
-            self.assertTrue((str_sorted == mixed_sorted).all())
+            self.assertListEqual(str_sorted.tolist(), mixed_sorted.tolist())
 
 
 def create_parser():

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -216,14 +216,14 @@ class DataFrameTest(ArkoudaTest):
         df = build_ak_df()
 
         slice_df = df[ak.array([1, 3, 5])]
-        self.assertListEqual(slice_df.index.to_ndarray().tolist(), [1, 3, 5])
+        self.assertListEqual(slice_df.index.to_list(), [1, 3, 5])
 
         df_reset = slice_df.reset_index()
-        self.assertListEqual(df_reset.index.to_ndarray().tolist(), [0, 1, 2])
-        self.assertListEqual(slice_df.index.to_ndarray().tolist(), [1, 3, 5])
+        self.assertListEqual(df_reset.index.to_list(), [0, 1, 2])
+        self.assertListEqual(slice_df.index.to_list(), [1, 3, 5])
 
         slice_df.reset_index(inplace=True)
-        self.assertListEqual(slice_df.index.to_ndarray().tolist(), [0, 1, 2])
+        self.assertListEqual(slice_df.index.to_list(), [0, 1, 2])
 
     def test_rename(self):
         df = build_ak_df()
@@ -256,12 +256,12 @@ class DataFrameTest(ArkoudaTest):
 
         # Test out of Place - index
         df_rename = df.rename(rename_idx)
-        self.assertListEqual(df_rename.index.values.to_ndarray().tolist(), conf)
-        self.assertListEqual(df.index.values.to_ndarray().tolist(), list(range(6)))
+        self.assertListEqual(df_rename.index.values.to_list(), conf)
+        self.assertListEqual(df.index.values.to_list(), list(range(6)))
 
         # Test in place - index
         df.rename(index=rename_idx, inplace=True)
-        self.assertListEqual(df.index.values.to_ndarray().tolist(), conf)
+        self.assertListEqual(df.index.values.to_list(), conf)
 
     def test_append(self):
         df = build_ak_df()
@@ -322,16 +322,16 @@ class DataFrameTest(ArkoudaTest):
 
         gb = df.GroupBy("userName")
         keys, count = gb.count()
-        self.assertTrue(keys.to_ndarray().tolist(), ["Alice", "Carol", "Bob"])
-        self.assertListEqual(count.to_ndarray().tolist(), [3, 1, 2])
-        self.assertListEqual(gb.permutation.to_ndarray().tolist(), [0, 2, 5, 3, 1, 4])
+        self.assertTrue(keys.to_list(), ["Alice", "Carol", "Bob"])
+        self.assertListEqual(count.to_list(), [3, 1, 2])
+        self.assertListEqual(gb.permutation.to_list(), [0, 2, 5, 3, 1, 4])
 
         gb = df.GroupBy(["userName", "userID"])
         keys, count = gb.count()
         self.assertEqual(len(keys), 2)
-        self.assertListEqual(keys[0].to_ndarray().tolist(), ["Carol", "Alice", "Bob"])
-        self.assertTrue(keys[1].to_ndarray().tolist(), [111, 333, 222])
-        self.assertTrue(count.to_ndarray().tolist(), [3, 1, 2])
+        self.assertListEqual(keys[0].to_list(), ["Carol", "Alice", "Bob"])
+        self.assertTrue(keys[1].to_list(), [111, 333, 222])
+        self.assertTrue(count.to_list(), [3, 1, 2])
 
     def test_gb_series(self):
         username = ak.array(["Alice", "Bob", "Alice", "Carol", "Bob", "Alice"])
@@ -347,8 +347,8 @@ class DataFrameTest(ArkoudaTest):
 
         c = gb.count()
         self.assertIsInstance(c, ak.Series)
-        self.assertListEqual(c.index.to_ndarray().tolist(), ["Alice", "Carol", "Bob"])
-        self.assertListEqual(c.values.to_ndarray().tolist(), [3, 1, 2])
+        self.assertListEqual(c.index.to_list(), ["Alice", "Carol", "Bob"])
+        self.assertListEqual(c.values.to_list(), [3, 1, 2])
 
     def test_to_pandas(self):
         df = build_ak_df()
@@ -367,19 +367,19 @@ class DataFrameTest(ArkoudaTest):
         df = build_ak_df()
 
         p = df.argsort(key="userName")
-        self.assertListEqual(p.to_ndarray().tolist(), [0, 2, 5, 1, 4, 3])
+        self.assertListEqual(p.to_list(), [0, 2, 5, 1, 4, 3])
 
         p = df.argsort(key="userName", ascending=False)
-        self.assertListEqual(p.to_ndarray().tolist(), [3, 4, 1, 5, 2, 0])
+        self.assertListEqual(p.to_list(), [3, 4, 1, 5, 2, 0])
 
     def test_coargsort(self):
         df = build_ak_df()
 
         p = df.coargsort(keys=["userID", "amount"])
-        self.assertListEqual(p.to_ndarray().tolist(), [0, 5, 2, 1, 4, 3])
+        self.assertListEqual(p.to_list(), [0, 5, 2, 1, 4, 3])
 
         p = df.coargsort(keys=["userID", "amount"], ascending=False)
-        self.assertListEqual(p.to_ndarray().tolist(), [3, 4, 1, 2, 5, 0])
+        self.assertListEqual(p.to_list(), [3, 4, 1, 2, 5, 0])
 
     def test_sort_values(self):
         userid = [111, 222, 111, 333, 222, 111]
@@ -418,7 +418,7 @@ class DataFrameTest(ArkoudaTest):
         df_2 = ak.DataFrame({"user_name": username, "user_id": userid})
 
         rows = ak.intx(df_1, df_2)
-        self.assertListEqual(rows.to_ndarray().tolist(), [False, True, False, False, True, False])
+        self.assertListEqual(rows.to_list(), [False, True, False, False, True, False])
 
         df_3 = ak.DataFrame({"user_name": username, "user_number": userid})
         with self.assertRaises(ValueError):
@@ -510,26 +510,26 @@ class DataFrameTest(ArkoudaTest):
 
         # test against pdarray
         test_df = df.isin(ak.array([0, 1]))
-        self.assertListEqual(test_df["col_A"].to_ndarray().tolist(), [False, False])
-        self.assertListEqual(test_df["col_B"].to_ndarray().tolist(), [True, False])
+        self.assertListEqual(test_df["col_A"].to_list(), [False, False])
+        self.assertListEqual(test_df["col_B"].to_list(), [True, False])
 
         # Test against dict
         test_df = df.isin({"col_A": ak.array([0, 3])})
-        self.assertListEqual(test_df["col_A"].to_ndarray().tolist(), [False, True])
-        self.assertListEqual(test_df["col_B"].to_ndarray().tolist(), [False, False])
+        self.assertListEqual(test_df["col_A"].to_list(), [False, True])
+        self.assertListEqual(test_df["col_B"].to_list(), [False, False])
 
         # test against series
         i = ak.Index(ak.arange(2))
         s = ak.Series(data=ak.array([3, 9]), index=i.index)
         test_df = df.isin(s)
-        self.assertListEqual(test_df["col_A"].to_ndarray().tolist(), [False, False])
-        self.assertListEqual(test_df["col_B"].to_ndarray().tolist(), [False, True])
+        self.assertListEqual(test_df["col_A"].to_list(), [False, False])
+        self.assertListEqual(test_df["col_B"].to_list(), [False, True])
 
         # test against another dataframe
         other_df = ak.DataFrame({"col_A": ak.array([7, 3]), "col_C": ak.array([0, 9])})
         test_df = df.isin(other_df)
-        self.assertListEqual(test_df["col_A"].to_ndarray().tolist(), [True, True])
-        self.assertListEqual(test_df["col_B"].to_ndarray().tolist(), [False, False])
+        self.assertListEqual(test_df["col_A"].to_list(), [True, True])
+        self.assertListEqual(test_df["col_B"].to_list(), [False, False])
 
     def test_multiindex_compat(self):
         # Added for testing Issue #1505

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -216,22 +216,14 @@ class DataFrameTest(ArkoudaTest):
         df = build_ak_df()
 
         slice_df = df[ak.array([1, 3, 5])]
-        self.assertListEqual(
-            slice_df.index.to_ndarray().tolist(), ak.array([1, 3, 5]).to_ndarray().tolist()
-        )
+        self.assertListEqual(slice_df.index.to_ndarray().tolist(), [1, 3, 5])
 
         df_reset = slice_df.reset_index()
-        self.assertListEqual(
-            df_reset.index.to_ndarray().tolist(), ak.array([0, 1, 2]).to_ndarray().tolist()
-        )
-        self.assertListEqual(
-            slice_df.index.to_ndarray().tolist(), ak.array([1, 3, 5]).to_ndarray().tolist()
-        )
+        self.assertListEqual(df_reset.index.to_ndarray().tolist(), [0, 1, 2])
+        self.assertListEqual(slice_df.index.to_ndarray().tolist(), [1, 3, 5])
 
         slice_df.reset_index(inplace=True)
-        self.assertListEqual(
-            slice_df.index.to_ndarray().tolist(), ak.array([0, 1, 2]).to_ndarray().tolist()
-        )
+        self.assertListEqual(slice_df.index.to_ndarray().tolist(), [0, 1, 2])
 
     def test_rename(self):
         df = build_ak_df()

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -216,14 +216,22 @@ class DataFrameTest(ArkoudaTest):
         df = build_ak_df()
 
         slice_df = df[ak.array([1, 3, 5])]
-        self.assertTrue((slice_df.index == ak.array([1, 3, 5])).all())
+        self.assertListEqual(
+            slice_df.index.to_ndarray().tolist(), ak.array([1, 3, 5]).to_ndarray().tolist()
+        )
 
         df_reset = slice_df.reset_index()
-        self.assertTrue((df_reset.index == ak.array([0, 1, 2])).all())
-        self.assertTrue((slice_df.index == ak.array([1, 3, 5])).all())
+        self.assertListEqual(
+            df_reset.index.to_ndarray().tolist(), ak.array([0, 1, 2]).to_ndarray().tolist()
+        )
+        self.assertListEqual(
+            slice_df.index.to_ndarray().tolist(), ak.array([1, 3, 5]).to_ndarray().tolist()
+        )
 
         slice_df.reset_index(inplace=True)
-        self.assertTrue((slice_df.index == ak.array([0, 1, 2])).all())
+        self.assertListEqual(
+            slice_df.index.to_ndarray().tolist(), ak.array([0, 1, 2]).to_ndarray().tolist()
+        )
 
     def test_rename(self):
         df = build_ak_df()
@@ -248,8 +256,8 @@ class DataFrameTest(ArkoudaTest):
         self.assertNotIn("userName", df.columns)
         self.assertNotIn("userID", df.columns)
 
-        #prep for index renaming
-        rename_idx = {1:17, 2:93}
+        # prep for index renaming
+        rename_idx = {1: 17, 2: 93}
         conf = list(range(6))
         conf[1] = 17
         conf[2] = 93
@@ -347,7 +355,7 @@ class DataFrameTest(ArkoudaTest):
 
         c = gb.count()
         self.assertIsInstance(c, ak.Series)
-        self.assertListEqual(c.index.to_ndarray().tolist(), ['Alice', 'Carol', 'Bob'])
+        self.assertListEqual(c.index.to_ndarray().tolist(), ["Alice", "Carol", "Bob"])
         self.assertListEqual(c.values.to_ndarray().tolist(), [3, 1, 2])
 
     def test_to_pandas(self):
@@ -493,12 +501,12 @@ class DataFrameTest(ArkoudaTest):
 
         # test save with index true
         akdf.save(f"{d}/testName_with_index.pq", file_format="Parquet", index=True)
-        self.assertTrue(len(glob.glob(f"{d}/testName_with_index*.pq")) == ak.get_config()["numLocales"])
+        self.assertEqual(len(glob.glob(f"{d}/testName_with_index*.pq")), ak.get_config()["numLocales"])
 
         # Test for df having seg array col
         df = ak.DataFrame({"a": ak.arange(10), "b": ak.SegArray(ak.arange(10), ak.arange(10))})
         df.save(f"{d}/seg_test.h5")
-        self.assertTrue(len(glob.glob(f"{d}/seg_test*.h5")) == ak.get_config()["numLocales"])
+        self.assertEqual(len(glob.glob(f"{d}/seg_test*.h5")), ak.get_config()["numLocales"])
         ak_loaded = ak.DataFrame.load(f"{d}/seg_test.h5")
         self.assertTrue(df.to_pandas().equals(ak_loaded.to_pandas()))
 
@@ -533,5 +541,5 @@ class DataFrameTest(ArkoudaTest):
 
     def test_multiindex_compat(self):
         # Added for testing Issue #1505
-        df = ak.DataFrame({'a': ak.arange(10), 'b': ak.arange(10), 'c': ak.arange(10)})
-        df.groupby(['a', 'b']).sum('c')
+        df = ak.DataFrame({"a": ak.arange(10), "b": ak.arange(10), "c": ak.arange(10)})
+        df.groupby(["a", "b"]).sum("c")

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -5,6 +5,7 @@ import arkouda as ak
 import pandas as pd
 import logging
 
+
 def build_op_table():
     ALL_OPS = ak.pdarray.BinOps - set(("<<<", ">>>"))
     table = {}
@@ -25,6 +26,7 @@ def build_op_table():
 
 
 class DatetimeTest(ArkoudaTest):
+    # Leave these comparisons as ( == ).all() instead of assertListEqual, to test the datetime comparison ops
     def setUp(self):
         ArkoudaTest.setUp(self)
         self.dtvec1 = ak.date_range(start="2021-01-01 12:00:00", periods=100, freq="s")

--- a/tests/deprecated/IOtest.py
+++ b/tests/deprecated/IOtest.py
@@ -3,13 +3,13 @@
 import sys, time, argparse
 import arkouda as ak
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     ak.verbose = False
     parser = argparse.ArgumentParser()
-    parser.add_argument('--server', default=None)
-    parser.add_argument('--port', default=None)
-    parser.add_argument('dsetName')
-    parser.add_argument('filenames', nargs='+')
+    parser.add_argument("--server", default=None)
+    parser.add_argument("--port", default=None)
+    parser.add_argument("dsetName")
+    parser.add_argument("filenames", nargs="+")
 
     args = parser.parse_args()
     if args.server is not None:
@@ -28,18 +28,18 @@ if __name__ == '__main__':
     end = time.time()
     t = end - start
     print(a)
-    print(f'{t:.2f} seconds ({8*a.size/t:.2e} bytes/sec)')
+    print(f"{t:.2f} seconds ({8*a.size/t:.2e} bytes/sec)")
     print("Testing bad filename...")
-    badfilename = args.filenames[0] + '-should-not-exist-5473219431'
+    badfilename = args.filenames[0] + "-should-not-exist-5473219431"
     try:
         ak.read_hdf(args.dsetName, args.filenames + [badfilename])
     except RuntimeError as e:
         print(e)
     print("Testing bad dsetName...")
     try:
-        ak.read_hdf(args.dsetName+'-not-a-dset', args.filenames)
+        ak.read_hdf(args.dsetName + "-not-a-dset", args.filenames)
     except RuntimeError as e:
         print(e)
-        
+
     ak.shutdown()
     sys.exit()

--- a/tests/deprecated/ak_add_sub.py
+++ b/tests/deprecated/ak_add_sub.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3                                                         
+#!/usr/bin/env python3
 
 import importlib
 import numpy as np
@@ -15,14 +15,13 @@ else:
     ak.connect()
 
 N = 10**9
-a = ak.ones(N,dtype='int64')
-b = ak.ones(N,dtype='int64')
-print(a,b)
+a = ak.ones(N, dtype="int64")
+b = ak.ones(N, dtype="int64")
+print(a, b)
 
-c = a+b
-d = a-b
+c = a + b
+d = a - b
 print(c)
 print(d)
 
 ak.shutdown()
-

--- a/tests/deprecated/ak_test.py
+++ b/tests/deprecated/ak_test.py
@@ -19,7 +19,7 @@ b = np.linspace(10, 20, 10)
 c = ak.array(b)
 d = a + c
 e = d.to_ndarray()
-    
+
 a = ak.ones(10)
 a[::2] = 0
 print(a)
@@ -29,135 +29,135 @@ b = ak.zeros(5)
 a[1::2] = b
 print(a)
 
-a = ak.zeros(10) # float64
-b = ak.arange(0,10,1) # int64
-a[:] = b # cast b to float64
-print(b,b.dtype)
-print(a,a.dtype)
+a = ak.zeros(10)  # float64
+b = ak.arange(0, 10, 1)  # int64
+a[:] = b  # cast b to float64
+print(b, b.dtype)
+print(a, a.dtype)
 
-a = ak.randint(0,2,10,dtype=ak.bool)
+a = ak.randint(0, 2, 10, dtype=ak.bool)
 a[1] = True
 a[2] = True
 print(a)
 
-a = ak.ones(10,dtype=ak.int64)
-iv = ak.arange(0,10,1)[::2]
+a = ak.ones(10, dtype=ak.int64)
+iv = ak.arange(0, 10, 1)[::2]
 a[iv] = 10
 print(a)
 
 a = ak.ones(10)
-iv = ak.arange(0,10,1)[::2]
+iv = ak.arange(0, 10, 1)[::2]
 a[iv] = 10.0
 print(a)
 
-a = ak.ones(10,dtype=ak.bool)
-iv = ak.arange(0,10,1)[::2]
+a = ak.ones(10, dtype=ak.bool)
+iv = ak.arange(0, 10, 1)[::2]
 a[iv] = False
 print(a)
 
-a = ak.ones(10,dtype=ak.bool)
-iv = ak.arange(0,5,1)
-b = ak.zeros(iv.size,dtype=ak.bool)
+a = ak.ones(10, dtype=ak.bool)
+iv = ak.arange(0, 5, 1)
+b = ak.zeros(iv.size, dtype=ak.bool)
 a[iv] = b
 print(a)
 
-a = ak.randint(10,20,10)
+a = ak.randint(10, 20, 10)
 print(a)
-iv = ak.randint(0,10,5)
+iv = ak.randint(0, 10, 5)
 print(iv)
-b = ak.zeros(iv.size,dtype=ak.int64)
+b = ak.zeros(iv.size, dtype=ak.int64)
 a[iv] = b
 print(a)
 
 ak.verbose = False
-a = ak.randint(10,30,40)
+a = ak.randint(10, 30, 40)
 vc = ak.value_counts(a)
-print(vc[0].size,vc[0])
-print(vc[1].size,vc[1])
+print(vc[0].size, vc[0])
+print(vc[1].size, vc[1])
 
 ak.verbose = False
 
-a = ak.arange(0,10,1)
-b = a[a<5]
-a = ak.linspace(0,9,10)
-b = a[a<5]
+a = ak.arange(0, 10, 1)
+b = a[a < 5]
+a = ak.linspace(0, 9, 10)
+b = a[a < 5]
 print(b)
 
 ak.verbose = True
 ak.pdarrayIterThresh = 1000
-a = ak.arange(0,10,1)
+a = ak.arange(0, 10, 1)
 print(list(a))
 
 ak.verbose = False
-a = ak.randint(10,30,40)
+a = ak.randint(10, 30, 40)
 u = ak.unique(a)
-h = ak.histogram(a,bins=20)
+h = ak.histogram(a, bins=20)
 print(a)
-print(h.size,h)
-print(u.size,u)
+print(h.size, h)
+print(u.size, u)
 
 ak.verbose = False
-a = ak.randint(10,30,50)
-h = ak.histogram(a,bins=20)
+a = ak.randint(10, 30, 50)
+h = ak.histogram(a, bins=20)
 print(a)
 print(h)
 
 ak.verbose = False
-a = ak.randint(0,2,50,dtype=ak.bool)
+a = ak.randint(0, 2, 50, dtype=ak.bool)
 print(a)
 print(a.sum())
 
 ak.verbose = False
-a = ak.linspace(101,102,100)
-h = ak.histogram(a,bins=50)
+a = ak.linspace(101, 102, 100)
+h = ak.histogram(a, bins=50)
 print(h)
 
 ak.verbose = False
-a = ak.arange(0,100,1)
-h = ak.histogram(a,bins=10)
+a = ak.arange(0, 100, 1)
+h = ak.histogram(a, bins=10)
 print(h)
 
 ak.verbose = False
-a = ak.arange(0,99,1)
-b = a[::10] # take every tenth one
-b = b[::-1] # reverse b
+a = ak.arange(0, 99, 1)
+b = a[::10]  # take every tenth one
+b = b[::-1]  # reverse b
 print(a)
 print(b)
-c = ak.in1d(a,b) # put out truth vector
+c = ak.in1d(a, b)  # put out truth vector
 print(c)
-print(a[c]) # compress out false values
+print(a[c])  # compress out false values
 
 ak.verbose = False
-a = np.ones(10,dtype=np.bool)
-b = np.arange(0,10,1)
+a = np.ones(10, dtype=np.bool)
+b = np.arange(0, 10, 1)
 
-np.sum(a),np.cumsum(a),np.sum(b<4),b[b<4],b<5
+np.sum(a), np.cumsum(a), np.sum(b < 4), b[b < 4], b < 5
 
 ak.verbose = False
 # currently... ak pdarray to np array
-a = ak.linspace(0,9,10)
+a = ak.linspace(0, 9, 10)
 b = np.array(list(a))
-print(a,a.dtype,b,b.dtype)
+print(a, a.dtype, b, b.dtype)
 
-a = ak.arange(0,10,1)
+a = ak.arange(0, 10, 1)
 b = np.array(list(a))
-print(a,a.dtype,b,b.dtype)
+print(a, a.dtype, b, b.dtype)
 
-a = ak.ones(10,dtype=ak.bool)
+a = ak.ones(10, dtype=ak.bool)
 b = np.array(list(a))
-print(a,a.dtype,b,b.dtype)
+print(a, a.dtype, b, b.dtype)
 
 ak.verbose = False
 
-b = np.linspace(1,10,10)
-a = np.arange(1,11,1)
-print(b/a)
+b = np.linspace(1, 10, 10)
+a = np.arange(1, 11, 1)
+print(b / a)
 
 ak.verbose = False
 
-#a = np.ones(10000,dtype=np.int64)
-a = np.linspace(0,99,100)
-#a = np.arange(0,100,1)
+# a = np.ones(10000,dtype=np.int64)
+a = np.linspace(0, 99, 100)
+# a = np.arange(0,100,1)
 print(a)
 
 ak.verbose = False
@@ -169,34 +169,34 @@ print(a)
 print(type(a), a.dtype, a.size, a.ndim, a.shape, a.itemsize)
 
 ak.verbose = False
-a = ak.arange(0,100,1)
+a = ak.arange(0, 100, 1)
 
 ak.verbose = False
 print(a)
 
 ak.verbose = False
 
-b = ak.linspace(0,99,100)
+b = ak.linspace(0, 99, 100)
 print(b.__repr__())
 
 ak.verbose = False
-b = ak.linspace(0,9,10)
-a = ak.arange(0,10,1)
+b = ak.linspace(0, 9, 10)
+a = ak.arange(0, 10, 1)
 print(a.name, a.size, a.dtype, a)
 print(b.name, b.size, b.dtype, b)
-print(ak.info(a+b))
+print(ak.info(a + b))
 
 
 ak.verbose = False
 
-c = ak.arange(0,10,1)
+c = ak.arange(0, 10, 1)
 print(ak.info(c))
 print(c.name, c.dtype, c.size, c.ndim, c.shape, c.itemsize)
 print(c)
 
 ak.verbose = False
 
-print(5+c + 5)
+print(5 + c + 5)
 
 c = np.array([10, 11, 12, 13, 14, 15, 16, 17, 18, 19])
 c = np.array([10, 11, 12, 13, 14, 15, 16, 17, 18, 19.1])
@@ -204,23 +204,23 @@ print(c.__repr__(), c.dtype.__str__(), c.dtype.__repr__())
 
 ak.verbose = False
 a = np.ones(9)
-b = np.arange(1,10,1)
-print(a.dtype,b.dtype)
+b = np.arange(1, 10, 1)
+print(a.dtype, b.dtype)
 c = ak.ones(9)
-d = ak.arange(1,10,1)
-print(c.dtype,d.dtype)
-y = a/b
-z = c/d
-print("truediv  \nnp out:",y,"\nak out:",z)
-print(y[5],z[5],y[5] ==z[5])
-y = a//b
-z = c//d
-print("floordiv \nnp out:",y,"\nak out:",z)
-print(y[5],z[5],y[5] ==z[5])
+d = ak.arange(1, 10, 1)
+print(c.dtype, d.dtype)
+y = a / b
+z = c / d
+print("truediv  \nnp out:", y, "\nak out:", z)
+print(y[5], z[5], y[5] == z[5])
+y = a // b
+z = c // d
+print("floordiv \nnp out:", y, "\nak out:", z)
+print(y[5], z[5], y[5] == z[5])
 
 ak.verbose = False
 
-c = ak.arange(1,10,1)
+c = ak.arange(1, 10, 1)
 c //= c
 print(c)
 c += c
@@ -230,65 +230,65 @@ print(c)
 
 ak.verbose = False
 
-a = np.ones(9,dtype=np.int64)
+a = np.ones(9, dtype=np.int64)
 b = np.ones_like(a)
 print(b)
 
 ak.verbose = False
 
-a = ak.ones(9,dtype=ak.int64)
+a = ak.ones(9, dtype=ak.int64)
 b = ak.ones_like(a)
 print(b)
 
 ak.verbose = False
 
-a = ak.arange(0,10,1)
-b = np.arange(0,10,1)
+a = ak.arange(0, 10, 1)
+b = np.arange(0, 10, 1)
 
 print(a[5] == b[5])
 
 ak.verbose = False
 
-a = ak.arange(0,10,1)
-b = np.arange(0,10,1)
+a = ak.arange(0, 10, 1)
+b = np.arange(0, 10, 1)
 
 a[5] = 10.2
 print(a[5])
 
 ak.verbose = False
 
-a = ak.arange(0,10,1)
-b = np.arange(0,10,1)
-#print((a[:]),b[:])
-#print(a[1:-1:2],b[1:-1:2])
-#print(a[0:10:2],b[0:10:2])
-print(a[4:20:-1],b[4:20:-1])
-print(a[:1:-1],b[:1:-1])
+a = ak.arange(0, 10, 1)
+b = np.arange(0, 10, 1)
+# print((a[:]),b[:])
+# print(a[1:-1:2],b[1:-1:2])
+# print(a[0:10:2],b[0:10:2])
+print(a[4:20:-1], b[4:20:-1])
+print(a[:1:-1], b[:1:-1])
 
 ak.verbose = False
-d = ak.arange(1,10,1)
-#d.type.__class__,d.name,d.isnative,np.int64.__class__,bool
+d = ak.arange(1, 10, 1)
+# d.type.__class__,d.name,d.isnative,np.int64.__class__,bool
 ak.info(d)
-#dir(d)
+# dir(d)
 
 ak.verbose = False
 
-a = ak.ones(10,dtype=ak.bool)
+a = ak.ones(10, dtype=ak.bool)
 print(a[1])
 
 ak.verbose = False
 
-a = ak.zeros(10,dtype=ak.bool)
+a = ak.zeros(10, dtype=ak.bool)
 print(a[1])
 
 ak.verbose = False
-a = ak.ones(10,dtype=ak.bool)
+a = ak.ones(10, dtype=ak.bool)
 a[4] = False
 a[1] = False
 print(a)
 print(a[::2])
 print(a[1])
-a = ak.ones(10,dtype=ak.int64)
+a = ak.ones(10, dtype=ak.int64)
 a[4] = False
 a[1] = False
 print(a)
@@ -303,121 +303,121 @@ print(a[1])
 
 ak.verbose = False
 
-a = ak.arange(0,10,1)
+a = ak.arange(0, 10, 1)
 b = list(a)
 print(b)
 
-a = a<5
+a = a < 5
 b = list(a)
 print(b)
 
 ak.verbose = False
-a = ak.linspace(1,10,10)
+a = ak.linspace(1, 10, 10)
 print(ak.abs(a))
 print(ak.log(a))
 print(ak.exp(a))
 a.fill(math.e)
 print(ak.log(a))
 
-type(bool),type(np.bool),type(ak.bool),type(True)
+type(bool), type(np.bool), type(ak.bool), type(True)
 
 ak.verbose = False
-a = ak.linspace(0,9,10)
-print(a,ak.any(a),ak.all(a),ak.all(ak.ones(10,dtype=ak.float64)))
-b = a<5
-print(b,ak.any(b),ak.all(b),ak.all(ak.ones(10,dtype=ak.bool)))
-c = ak.arange(0,10,1)
-print(c,ak.any(c),ak.all(c),ak.all(ak.ones(10,dtype=ak.int64)))
-print(a.any(),a.all(),b.any(),b.all())
+a = ak.linspace(0, 9, 10)
+print(a, ak.any(a), ak.all(a), ak.all(ak.ones(10, dtype=ak.float64)))
+b = a < 5
+print(b, ak.any(b), ak.all(b), ak.all(ak.ones(10, dtype=ak.bool)))
+c = ak.arange(0, 10, 1)
+print(c, ak.any(c), ak.all(c), ak.all(ak.ones(10, dtype=ak.int64)))
+print(a.any(), a.all(), b.any(), b.all())
 
 ak.verbose = False
-a = ak.linspace(0,9,10)
+a = ak.linspace(0, 9, 10)
 ak.sum(a)
-b = np.linspace(0,9,10)
-print(ak.sum(a) == np.sum(b),ak.sum(a),np.sum(b),a.sum(),b.sum())
+b = np.linspace(0, 9, 10)
+print(ak.sum(a) == np.sum(b), ak.sum(a), np.sum(b), a.sum(), b.sum())
 
 ak.verbose = False
-a = ak.linspace(1,10,10)
-b = np.linspace(1,10,10)
-print(ak.prod(a) == np.prod(b),ak.prod(a),np.prod(b),a.prod(),b.prod())
+a = ak.linspace(1, 10, 10)
+b = np.linspace(1, 10, 10)
+print(ak.prod(a) == np.prod(b), ak.prod(a), np.prod(b), a.prod(), b.prod())
 
 ak.verbose = False
 
-a = np.arange(0,20,1)
-b = a<10
-print(b,np.sum(b),b.sum(),np.prod(b),b.prod(),np.cumsum(b),np.cumprod(b))
+a = np.arange(0, 20, 1)
+b = a < 10
+print(b, np.sum(b), b.sum(), np.prod(b), b.prod(), np.cumsum(b), np.cumprod(b))
 print()
-b = a<5
-print(b,np.sum(b),b.sum(),np.prod(b),b.prod(),np.cumsum(b),np.cumprod(b))
+b = a < 5
+print(b, np.sum(b), b.sum(), np.prod(b), b.prod(), np.cumsum(b), np.cumprod(b))
 print()
-a = ak.arange(0,20,1)
-b = a<10
-print(b,ak.sum(b),b.sum(),ak.prod(b),b.prod(),ak.cumsum(b),ak.cumprod(b))
-b = a<5
-print(b,ak.sum(b),b.sum(),ak.prod(b),b.prod(),ak.cumsum(b),ak.cumprod(b))
+a = ak.arange(0, 20, 1)
+b = a < 10
+print(b, ak.sum(b), b.sum(), ak.prod(b), b.prod(), ak.cumsum(b), ak.cumprod(b))
+b = a < 5
+print(b, ak.sum(b), b.sum(), ak.prod(b), b.prod(), ak.cumsum(b), ak.cumprod(b))
 
 ak.verbose = False
-a = ak.arange(0,10,1)
+a = ak.arange(0, 10, 1)
 iv = a[::-1]
-print(a,iv,a[iv])
+print(a, iv, a[iv])
 
 ak.verbose = False
-a = ak.arange(0,10,1)
+a = ak.arange(0, 10, 1)
 iv = a[::-1]
-print(a,iv,a[iv])
+print(a, iv, a[iv])
 
 ak.verbose = False
-a = ak.linspace(0,9,10)
-iv = ak.arange(0,10,1)
+a = ak.linspace(0, 9, 10)
+iv = ak.arange(0, 10, 1)
 iv = iv[::-1]
-print(a,iv,a[iv])
+print(a, iv, a[iv])
 
 ak.verbose = False
-a = np.arange(0,10,1)
+a = np.arange(0, 10, 1)
 iv = a[::-1]
-print(a,iv,a[iv])
+print(a, iv, a[iv])
 
 ak.verbose = False
-a = ak.arange(0,10,1)
-b = a<20
-print(a,b,a[b])
+a = ak.arange(0, 10, 1)
+b = a < 20
+print(a, b, a[b])
 
 ak.verbose = False
-a = ak.arange(0,10,1)
-b = a<5
-print(a,b,a[b])
+a = ak.arange(0, 10, 1)
+b = a < 5
+print(a, b, a[b])
 
 ak.verbose = False
-a = ak.arange(0,10,1)
-b = a<0
-print(a,b,a[b])
+a = ak.arange(0, 10, 1)
+b = a < 0
+print(a, b, a[b])
 
 ak.verbose = False
-a = ak.linspace(0,9,10)
-b = a<5
-print(a,b,a[b])
+a = ak.linspace(0, 9, 10)
+b = a < 5
+print(a, b, a[b])
 
 ak.verbose = False
-N = 2**23 # 2**23 * 8 == 64MiB
-A = ak.linspace(0,N-1,N)
-B = ak.linspace(0,N-1,N)
+N = 2**23  # 2**23 * 8 == 64MiB
+A = ak.linspace(0, N - 1, N)
+B = ak.linspace(0, N - 1, N)
 
-C = A+B
-print(ak.info(C),C)
+C = A + B
+print(ak.info(C), C)
 
 # turn off verbose messages from arkouda package
 ak.verbose = False
 # set pdarrayIterThresh to 0 to only print the first 3 and last 3 of pdarray
 ak.pdarrayIterThresh = 0
-a = ak.linspace(0,9,10)
-b = a<5
+a = ak.linspace(0, 9, 10)
+b = a < 5
 print(a)
 print(b)
 print(a[b])
 print(a)
 
-a = np.linspace(0,9,10)
-b = a<5
+a = np.linspace(0, 9, 10)
+b = a < 5
 print(a)
 print(b)
 print(a[b])
@@ -426,19 +426,18 @@ print(a)
 ak.verbose = False
 ak.pdarrayIterThresh = 0
 
-a = ak.ones(10,ak.int64)
-b = a | 0xff
-print(a, b, a^b, b>>a, b<<1|1, 0xf & b, 0xaa ^ b, b ^ 0xff)
-print(-a,~(~a))
+a = ak.ones(10, ak.int64)
+b = a | 0xFF
+print(a, b, a ^ b, b >> a, b << 1 | 1, 0xF & b, 0xAA ^ b, b ^ 0xFF)
+print(-a, ~(~a))
 
-a = ak.ones(10,dtype=ak.int64)
-b = ~ak.zeros(10,dtype=ak.int64)
+a = ak.ones(10, dtype=ak.int64)
+b = ~ak.zeros(10, dtype=ak.int64)
 print(~a, -b)
 
-a = np.ones(10,dtype=np.int64)
-b = ~np.zeros(10,dtype=np.int64)
+a = np.ones(10, dtype=np.int64)
+b = ~np.zeros(10, dtype=np.int64)
 print(~a, -b)
 
 
 ak.shutdown()
-

--- a/tests/deprecated/groupby_performance.py
+++ b/tests/deprecated/groupby_performance.py
@@ -2,26 +2,32 @@ from context import arkouda as ak
 import numpy as np
 from time import time
 from base_test import ArkoudaTest
-OPERATORS = ['sum', 'min', 'nunique']
 
-def generate_arrays(length, nkeys, nvals, dtype='int64'):
+OPERATORS = ["sum", "min", "nunique"]
+
+
+def generate_arrays(length, nkeys, nvals, dtype="int64"):
     keys = ak.randint(0, nkeys, length)
-    if dtype == 'int64':
+    if dtype == "int64":
         vals = ak.randint(0, nvals, length)
-    elif dtype == 'bool':
-        vals = ak.zeros(length, dtype='bool')
-        for i in np.random.randint(0, length, nkeys//2):
+    elif dtype == "bool":
+        vals = ak.zeros(length, dtype="bool")
+        for i in np.random.randint(0, length, nkeys // 2):
             vals[i] = True
     else:
         vals = ak.linspace(-1, 1, length)
     return keys, vals
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     import sys
+
     if len(sys.argv) != 7:
-        print(f"Usage: {sys.argv[0]} <server> <port> <strategy (0=global, 1=perLocale)> <length> <num_keys> <num_vals>")
+        print(
+            f"Usage: {sys.argv[0]} <server> <port> <strategy (0=global, 1=perLocale)> <length> <num_keys> <num_vals>"
+        )
         sys.exit()
-    per_locale = (sys.argv[3] == '1')
+    per_locale = sys.argv[3] == "1"
     print("per_locale = ", per_locale)
     length = int(sys.argv[4])
     print("length     = ", length)

--- a/tests/dtypes_tests.py
+++ b/tests/dtypes_tests.py
@@ -150,20 +150,38 @@ class DtypesTest(ArkoudaTest):
 
     def test_scalars(self):
         self.assertEqual("typing.Union[bool, numpy.bool_]", str(ak.bool_scalars))
-        self.assertEqual('typing.Union[float, numpy.float64]', str(ak.float_scalars))
-        self.assertEqual(('typing.Union[int, numpy.int8, numpy.int16, numpy.int32, numpy.int64, ' +
-                         'numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64]'), str(ak.int_scalars))
-        self.assertEqual(('typing.Union[float, numpy.float64, int, numpy.int8, numpy.int16, numpy.int32, ' +
-                         'numpy.int64, numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64]'), 
-                         str(ak.numeric_scalars))
-        self.assertEqual('typing.Union[str, numpy.str_]', str(ak.str_scalars))
-        self.assertEqual(('typing.Union[numpy.float64, numpy.int8, numpy.int16, numpy.int32, ' +
-                         'numpy.int64, numpy.bool_, numpy.str_, numpy.uint8, numpy.uint16, numpy.uint32, ' +
-                         'numpy.uint64]'), 
-                         str(ak.numpy_scalars))
-        self.assertEqual(('typing.Union[bool, numpy.bool_, float, numpy.float64, int, numpy.int8, ' +
-                         'numpy.int16, numpy.int32, numpy.int64, numpy.uint8, numpy.uint16, numpy.uint32,' +
-                         ' numpy.uint64, numpy.str_, str]'),str(ak.all_scalars))
+        self.assertEqual("typing.Union[float, numpy.float64]", str(ak.float_scalars))
+        self.assertEqual(
+            (
+                "typing.Union[int, numpy.int8, numpy.int16, numpy.int32, numpy.int64, "
+                + "numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64]"
+            ),
+            str(ak.int_scalars),
+        )
+        self.assertEqual(
+            (
+                "typing.Union[float, numpy.float64, int, numpy.int8, numpy.int16, numpy.int32, "
+                + "numpy.int64, numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64]"
+            ),
+            str(ak.numeric_scalars),
+        )
+        self.assertEqual("typing.Union[str, numpy.str_]", str(ak.str_scalars))
+        self.assertEqual(
+            (
+                "typing.Union[numpy.float64, numpy.int8, numpy.int16, numpy.int32, "
+                + "numpy.int64, numpy.bool_, numpy.str_, numpy.uint8, numpy.uint16, numpy.uint32, "
+                + "numpy.uint64]"
+            ),
+            str(ak.numpy_scalars),
+        )
+        self.assertEqual(
+            (
+                "typing.Union[bool, numpy.bool_, float, numpy.float64, int, numpy.int8, "
+                + "numpy.int16, numpy.int32, numpy.int64, numpy.uint8, numpy.uint16, numpy.uint32,"
+                + " numpy.uint64, numpy.str_, str]"
+            ),
+            str(ak.all_scalars),
+        )
 
     def test_number_format_strings(self):
         self.assertEqual("{}", dtypes.NUMBER_FORMAT_STRINGS["bool"])

--- a/tests/extrema_test.py
+++ b/tests/extrema_test.py
@@ -87,7 +87,7 @@ class MinKTest(ArkoudaTest):
             ak.mink(list(range(0, 10)), 1)
 
         with self.assertRaises(TypeError):
-            ak.mink(testArray, '1')
+            ak.mink(testArray, "1")
 
         with self.assertRaises(ValueError):
             ak.mink(testArray, -1)
@@ -110,11 +110,11 @@ class MaxKTest(ArkoudaTest):
         testArray = ak.randint(0, 100, 100)
 
         with self.assertRaises(TypeError):
-            ak.maxk(list(range(0,10)), 1)
+            ak.maxk(list(range(0, 10)), 1)
 
         with self.assertRaises(TypeError):
-            ak.maxk(testArray, '1')
-            
+            ak.maxk(testArray, "1")
+
         with self.assertRaises(ValueError):
             ak.maxk(testArray, -1)
 
@@ -136,10 +136,10 @@ class ArgMinKTest(ArkoudaTest):
         testArray = ak.randint(0, 100, 100)
 
         with self.assertRaises(TypeError):
-            ak.argmink(list(range(0,10)), 1)
+            ak.argmink(list(range(0, 10)), 1)
 
         with self.assertRaises(TypeError):
-            ak.argmink(testArray, '1')
+            ak.argmink(testArray, "1")
 
         with self.assertRaises(ValueError):
             ak.argmink(testArray, -1)
@@ -162,10 +162,10 @@ class ArgMaxKTest(ArkoudaTest):
         testArray = ak.randint(0, 100, 100)
 
         with self.assertRaises(TypeError):
-            ak.argmaxk(list(range(0,10)), 1)
+            ak.argmaxk(list(range(0, 10)), 1)
 
         with self.assertRaises(TypeError):
-            ak.argmaxk(testArray, '1')
+            ak.argmaxk(testArray, "1")
 
         with self.assertRaises(ValueError):
             ak.argmaxk(testArray, -1)
@@ -173,14 +173,16 @@ class ArgMaxKTest(ArkoudaTest):
         with self.assertRaises(ValueError):
             ak.argmaxk(ak.array([]), 1)
 
+
 class ArgMinTest(ArkoudaTest):
     def test_argmin(self):
         np_arr = np.array([False, False, True, True, False])
         ak_arr = ak.array(np_arr)
-        self.assertTrue(np_arr.argmin() == ak_arr.argmin())
+        self.assertEqual(np_arr.argmin(), ak_arr.argmin())
+
 
 class ArgMaxTest(ArkoudaTest):
     def test_argmax(self):
         np_arr = np.array([False, False, True, True, False])
         ak_arr = ak.array(np_arr)
-        self.assertTrue(np_arr.argmax() == ak_arr.argmax())
+        self.assertEqual(np_arr.argmax(), ak_arr.argmax())

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -171,12 +171,12 @@ class GroupByTest(ArkoudaTest):
         x = ak.array([True, True, False, True, False, False])
         g = ak.GroupBy(x)
         keys, locs = g.argmin(b)
-        self.assertListEqual(keys.to_ndarray().tolist(), [False, True])
-        self.assertListEqual(locs.to_ndarray().tolist(), [4, 1])
+        self.assertListEqual(keys.to_list(), [False, True])
+        self.assertListEqual(locs.to_list(), [4, 1])
 
         keys, locs = g.argmax(b)
-        self.assertListEqual(keys.to_ndarray().tolist(), [False, True])
-        self.assertListEqual(locs.to_ndarray().tolist(), [2, 0])
+        self.assertListEqual(keys.to_list(), [False, True])
+        self.assertListEqual(locs.to_list(), [2, 0])
 
     def test_boolean_arrays(self):
         a = ak.array([True, False, True, True, False])
@@ -185,32 +185,28 @@ class GroupByTest(ArkoudaTest):
         k, ct = g.count()
 
         self.assertEqual(ct[1], true_ct)
-        self.assertListEqual(k.to_ndarray().tolist(), [False, True])
+        self.assertListEqual(k.to_list(), [False, True])
 
         # This test was added since we added the size method for issue #1353
         k, ct = g.size()
 
         self.assertEqual(ct[1], true_ct)
-        self.assertListEqual(k.to_ndarray().tolist(), [False, True])
+        self.assertListEqual(k.to_list(), [False, True])
 
         b = ak.array([False, False, True, False, False])
         g = ak.GroupBy([a, b])
         k, ct = g.count()
-        self.assertListEqual(ct.to_ndarray().tolist(), [2, 2, 1])
-        self.assertListEqual(k[0].to_ndarray().tolist(), [False, True, True])
-        self.assertListEqual(k[1].to_ndarray().tolist(), [False, False, True])
+        self.assertListEqual(ct.to_list(), [2, 2, 1])
+        self.assertListEqual(k[0].to_list(), [False, True, True])
+        self.assertListEqual(k[1].to_list(), [False, False, True])
 
     def test_bitwise_aggregations(self):
         revs = ak.arange(self.igb.length) % 2
+        self.assertListEqual(self.igb.OR(revs)[1].to_list(), self.igb.max(revs)[1].to_list())
+        self.assertListEqual(self.igb.AND(revs)[1].to_list(), self.igb.min(revs)[1].to_list())
         self.assertListEqual(
-            self.igb.OR(revs)[1].to_ndarray().tolist(), self.igb.max(revs)[1].to_ndarray().tolist()
-        )
-        self.assertListEqual(
-            self.igb.AND(revs)[1].to_ndarray().tolist(), self.igb.min(revs)[1].to_ndarray().tolist()
-        )
-        self.assertListEqual(
-            self.igb.XOR(revs)[1].to_ndarray().tolist(),
-            (self.igb.sum(revs)[1] % 2).to_ndarray().tolist(),
+            self.igb.XOR(revs)[1].to_list(),
+            (self.igb.sum(revs)[1] % 2).to_list(),
         )
 
     def test_standalone_broadcast(self):
@@ -227,86 +223,86 @@ class GroupByTest(ArkoudaTest):
     def test_broadcast_ints(self):
         keys, counts = self.igb.count()
 
-        self.assertListEqual([1, 4, 2, 1, 2], counts.to_ndarray().tolist())
-        self.assertListEqual([1, 2, 3, 4, 5], keys.to_ndarray().tolist())
+        self.assertListEqual([1, 4, 2, 1, 2], counts.to_list())
+        self.assertListEqual([1, 2, 3, 4, 5], keys.to_list())
 
         results = self.igb.broadcast(1 * (counts > 2), permute=False)
-        self.assertListEqual([0, 1, 1, 1, 1, 0, 0, 0, 0, 0], results.to_ndarray().tolist())
+        self.assertListEqual([0, 1, 1, 1, 1, 0, 0, 0, 0, 0], results.to_list())
 
         results = self.igb.broadcast(1 * (counts == 2), permute=False)
-        self.assertListEqual([0, 0, 0, 0, 0, 1, 1, 0, 1, 1], results.to_ndarray().tolist())
+        self.assertListEqual([0, 0, 0, 0, 0, 1, 1, 0, 1, 1], results.to_list())
 
         results = self.igb.broadcast(1 * (counts < 4), permute=False)
-        self.assertListEqual([1, 0, 0, 0, 0, 1, 1, 1, 1, 1], results.to_ndarray().tolist())
+        self.assertListEqual([1, 0, 0, 0, 0, 1, 1, 1, 1, 1], results.to_list())
 
         results = self.igb.broadcast(1 * (counts > 2))
-        self.assertListEqual([0, 0, 0, 1, 1, 1, 0, 0, 1, 0], results.to_ndarray().tolist())
+        self.assertListEqual([0, 0, 0, 1, 1, 1, 0, 0, 1, 0], results.to_list())
 
         results = self.igb.broadcast(1 * (counts == 2))
-        self.assertListEqual([0, 0, 1, 0, 0, 0, 1, 1, 0, 1], results.to_ndarray().tolist())
+        self.assertListEqual([0, 0, 1, 0, 0, 0, 1, 1, 0, 1], results.to_list())
 
         results = self.igb.broadcast(1 * (counts < 4))
-        self.assertListEqual([1, 1, 1, 0, 0, 0, 1, 1, 0, 1], results.to_ndarray().tolist())
+        self.assertListEqual([1, 1, 1, 0, 0, 0, 1, 1, 0, 1], results.to_list())
 
     def test_broadcast_uints(self):
         keys, counts = self.ugb.count()
-        self.assertListEqual([1, 4, 2, 1, 2], counts.to_ndarray().tolist())
-        self.assertListEqual([1, 2, 3, 4, 5], keys.to_ndarray().tolist())
+        self.assertListEqual([1, 4, 2, 1, 2], counts.to_list())
+        self.assertListEqual([1, 2, 3, 4, 5], keys.to_list())
 
         u_results = self.ugb.broadcast(1 * (counts > 2))
         i_results = self.igb.broadcast(1 * (counts > 2))
-        self.assertListEqual(i_results.to_ndarray().tolist(), u_results.to_ndarray().tolist())
+        self.assertListEqual(i_results.to_list(), u_results.to_list())
 
         u_results = self.ugb.broadcast(1 * (counts == 2))
         i_results = self.igb.broadcast(1 * (counts == 2))
-        self.assertListEqual(i_results.to_ndarray().tolist(), u_results.to_ndarray().tolist())
+        self.assertListEqual(i_results.to_list(), u_results.to_list())
 
         u_results = self.ugb.broadcast(1 * (counts < 4))
         i_results = self.igb.broadcast(1 * (counts < 4))
-        self.assertListEqual(i_results.to_ndarray().tolist(), u_results.to_ndarray().tolist())
+        self.assertListEqual(i_results.to_list(), u_results.to_list())
 
         # test uint Groupby.broadcast with and without permute
         u_results = self.ugb.broadcast(ak.array([1, 2, 6, 8, 9], dtype=ak.uint64), permute=False)
         i_results = self.igb.broadcast(ak.array([1, 2, 6, 8, 9], dtype=ak.uint64), permute=False)
-        self.assertListEqual(i_results.to_ndarray().tolist(), u_results.to_ndarray().tolist())
+        self.assertListEqual(i_results.to_list(), u_results.to_list())
         u_results = self.ugb.broadcast(ak.array([1, 2, 6, 8, 9], dtype=ak.uint64))
         i_results = self.igb.broadcast(ak.array([1, 2, 6, 8, 9], dtype=ak.uint64))
-        self.assertListEqual(i_results.to_ndarray().tolist(), u_results.to_ndarray().tolist())
+        self.assertListEqual(i_results.to_list(), u_results.to_list())
 
         # test uint broadcast
         u_results = ak.broadcast(ak.array([0]), ak.array([1], dtype=ak.uint64), 1)
         i_results = ak.broadcast(ak.array([0]), ak.array([1]), 1)
-        self.assertListEqual(i_results.to_ndarray().tolist(), u_results.to_ndarray().tolist())
+        self.assertListEqual(i_results.to_list(), u_results.to_list())
 
     def test_broadcast_booleans(self):
         keys, counts = self.igb.count()
 
-        self.assertListEqual([1, 4, 2, 1, 2], counts.to_ndarray().tolist())
-        self.assertListEqual([1, 2, 3, 4, 5], keys.to_ndarray().tolist())
+        self.assertListEqual([1, 4, 2, 1, 2], counts.to_list())
+        self.assertListEqual([1, 2, 3, 4, 5], keys.to_list())
 
         results = self.igb.broadcast(counts > 2, permute=False)
-        self.assertListEqual([0, 1, 1, 1, 1, 0, 0, 0, 0, 0], results.to_ndarray().tolist())
+        self.assertListEqual([0, 1, 1, 1, 1, 0, 0, 0, 0, 0], results.to_list())
 
         results = self.igb.broadcast(counts == 2, permute=False)
-        self.assertListEqual([0, 0, 0, 0, 0, 1, 1, 0, 1, 1], results.to_ndarray().tolist())
+        self.assertListEqual([0, 0, 0, 0, 0, 1, 1, 0, 1, 1], results.to_list())
 
         results = self.igb.broadcast(counts < 4, permute=False)
-        self.assertListEqual([1, 0, 0, 0, 0, 1, 1, 1, 1, 1], results.to_ndarray().tolist())
+        self.assertListEqual([1, 0, 0, 0, 0, 1, 1, 1, 1, 1], results.to_list())
 
         results = self.igb.broadcast(counts > 2)
-        self.assertListEqual([0, 0, 0, 1, 1, 1, 0, 0, 1, 0], results.to_ndarray().tolist())
+        self.assertListEqual([0, 0, 0, 1, 1, 1, 0, 0, 1, 0], results.to_list())
 
         results = self.igb.broadcast(counts == 2)
-        self.assertListEqual([0, 0, 1, 0, 0, 0, 1, 1, 0, 1], results.to_ndarray().tolist())
+        self.assertListEqual([0, 0, 1, 0, 0, 0, 1, 1, 0, 1], results.to_list())
 
         results = self.igb.broadcast(counts < 4)
-        self.assertListEqual([1, 1, 1, 0, 0, 0, 1, 1, 0, 1], results.to_ndarray().tolist())
+        self.assertListEqual([1, 1, 1, 0, 0, 0, 1, 1, 0, 1], results.to_list())
 
     def test_count(self):
         keys, counts = self.igb.count()
 
-        self.assertListEqual([1, 2, 3, 4, 5], keys.to_ndarray().tolist())
-        self.assertListEqual([1, 4, 2, 1, 2], counts.to_ndarray().tolist())
+        self.assertListEqual([1, 2, 3, 4, 5], keys.to_list())
+        self.assertListEqual([1, 4, 2, 1, 2], counts.to_list())
 
     def test_groupby_reduction_type(self):
         self.assertEqual("any", str(GroupByReductionType.ANY))
@@ -403,7 +399,7 @@ class GroupByTest(ArkoudaTest):
             g = ak.GroupBy(key)
             for val in keys:
                 k, n = g.nunique(val)
-                self.assertListEqual(n.to_ndarray().tolist(), [1, 1, 1])
+                self.assertListEqual(n.to_list(), [1, 1, 1])
 
     def test_type_failure_multilevel_groupby_aggregate(self):
         # just checking no error occurs with hotfix for Issue 858
@@ -420,8 +416,8 @@ class GroupByTest(ArkoudaTest):
         u_keys, u_group_sums = gu.sum(u)
         i_keys, i_group_sums = gi.sum(i)
 
-        self.assertListEqual(u_keys.to_ndarray().tolist(), i_keys.to_ndarray().tolist())
-        self.assertListEqual(u_group_sums.to_ndarray().tolist(), i_group_sums.to_ndarray().tolist())
+        self.assertListEqual(u_keys.to_list(), i_keys.to_list())
+        self.assertListEqual(u_group_sums.to_list(), i_group_sums.to_list())
 
         # verify the multidim unsigned version doesnt break
         multi_gu = ak.GroupBy([u, u])
@@ -432,10 +428,8 @@ class GroupByTest(ArkoudaTest):
         g = ak.GroupBy(labels)
         u_unique_keys, u_group_nunique = g.nunique(u_data)
         i_unique_keys, i_group_nunique = g.nunique(i_data)
-        self.assertListEqual(u_unique_keys.to_ndarray().tolist(), i_unique_keys.to_ndarray().tolist())
-        self.assertListEqual(
-            u_group_nunique.to_ndarray().tolist(), i_group_nunique.to_ndarray().tolist()
-        )
+        self.assertListEqual(u_unique_keys.to_list(), i_unique_keys.to_list())
+        self.assertListEqual(u_group_nunique.to_list(), i_group_nunique.to_list())
 
     def test_zero_length_groupby(self):
         """

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -227,43 +227,31 @@ class GroupByTest(ArkoudaTest):
     def test_broadcast_ints(self):
         keys, counts = self.igb.count()
 
-        self.assertListEqual(np.array([1, 4, 2, 1, 2]).tolist(), counts.to_ndarray().tolist())
-        self.assertListEqual(np.array([1, 2, 3, 4, 5]).tolist(), keys.to_ndarray().tolist())
+        self.assertListEqual([1, 4, 2, 1, 2], counts.to_ndarray().tolist())
+        self.assertListEqual([1, 2, 3, 4, 5], keys.to_ndarray().tolist())
 
         results = self.igb.broadcast(1 * (counts > 2), permute=False)
-        self.assertListEqual(
-            np.array([0, 1, 1, 1, 1, 0, 0, 0, 0, 0]).tolist(), results.to_ndarray().tolist()
-        )
+        self.assertListEqual([0, 1, 1, 1, 1, 0, 0, 0, 0, 0], results.to_ndarray().tolist())
 
         results = self.igb.broadcast(1 * (counts == 2), permute=False)
-        self.assertListEqual(
-            np.array([0, 0, 0, 0, 0, 1, 1, 0, 1, 1]).tolist(), results.to_ndarray().tolist()
-        )
+        self.assertListEqual([0, 0, 0, 0, 0, 1, 1, 0, 1, 1], results.to_ndarray().tolist())
 
         results = self.igb.broadcast(1 * (counts < 4), permute=False)
-        self.assertListEqual(
-            np.array([1, 0, 0, 0, 0, 1, 1, 1, 1, 1]).tolist(), results.to_ndarray().tolist()
-        )
+        self.assertListEqual([1, 0, 0, 0, 0, 1, 1, 1, 1, 1], results.to_ndarray().tolist())
 
         results = self.igb.broadcast(1 * (counts > 2))
-        self.assertListEqual(
-            np.array([0, 0, 0, 1, 1, 1, 0, 0, 1, 0]).tolist(), results.to_ndarray().tolist()
-        )
+        self.assertListEqual([0, 0, 0, 1, 1, 1, 0, 0, 1, 0], results.to_ndarray().tolist())
 
         results = self.igb.broadcast(1 * (counts == 2))
-        self.assertListEqual(
-            np.array([0, 0, 1, 0, 0, 0, 1, 1, 0, 1]).tolist(), results.to_ndarray().tolist()
-        )
+        self.assertListEqual([0, 0, 1, 0, 0, 0, 1, 1, 0, 1], results.to_ndarray().tolist())
 
         results = self.igb.broadcast(1 * (counts < 4))
-        self.assertListEqual(
-            np.array([1, 1, 1, 0, 0, 0, 1, 1, 0, 1]).tolist(), results.to_ndarray().tolist()
-        )
+        self.assertListEqual([1, 1, 1, 0, 0, 0, 1, 1, 0, 1], results.to_ndarray().tolist())
 
     def test_broadcast_uints(self):
         keys, counts = self.ugb.count()
-        self.assertListEqual(np.array([1, 4, 2, 1, 2]).tolist(), counts.to_ndarray().tolist())
-        self.assertListEqual(np.array([1, 2, 3, 4, 5]).tolist(), keys.to_ndarray().tolist())
+        self.assertListEqual([1, 4, 2, 1, 2], counts.to_ndarray().tolist())
+        self.assertListEqual([1, 2, 3, 4, 5], keys.to_ndarray().tolist())
 
         u_results = self.ugb.broadcast(1 * (counts > 2))
         i_results = self.igb.broadcast(1 * (counts > 2))
@@ -293,44 +281,32 @@ class GroupByTest(ArkoudaTest):
     def test_broadcast_booleans(self):
         keys, counts = self.igb.count()
 
-        self.assertListEqual(np.array([1, 4, 2, 1, 2]).tolist(), counts.to_ndarray().tolist())
-        self.assertListEqual(np.array([1, 2, 3, 4, 5]).tolist(), keys.to_ndarray().tolist())
+        self.assertListEqual([1, 4, 2, 1, 2], counts.to_ndarray().tolist())
+        self.assertListEqual([1, 2, 3, 4, 5], keys.to_ndarray().tolist())
 
         results = self.igb.broadcast(counts > 2, permute=False)
-        self.assertListEqual(
-            np.array([0, 1, 1, 1, 1, 0, 0, 0, 0, 0]).tolist(), results.to_ndarray().tolist()
-        )
+        self.assertListEqual([0, 1, 1, 1, 1, 0, 0, 0, 0, 0], results.to_ndarray().tolist())
 
         results = self.igb.broadcast(counts == 2, permute=False)
-        self.assertListEqual(
-            np.array([0, 0, 0, 0, 0, 1, 1, 0, 1, 1]).tolist(), results.to_ndarray().tolist()
-        )
+        self.assertListEqual([0, 0, 0, 0, 0, 1, 1, 0, 1, 1], results.to_ndarray().tolist())
 
         results = self.igb.broadcast(counts < 4, permute=False)
-        self.assertListEqual(
-            np.array([1, 0, 0, 0, 0, 1, 1, 1, 1, 1]).tolist(), results.to_ndarray().tolist()
-        )
+        self.assertListEqual([1, 0, 0, 0, 0, 1, 1, 1, 1, 1], results.to_ndarray().tolist())
 
         results = self.igb.broadcast(counts > 2)
-        self.assertListEqual(
-            np.array([0, 0, 0, 1, 1, 1, 0, 0, 1, 0]).tolist(), results.to_ndarray().tolist()
-        )
+        self.assertListEqual([0, 0, 0, 1, 1, 1, 0, 0, 1, 0], results.to_ndarray().tolist())
 
         results = self.igb.broadcast(counts == 2)
-        self.assertListEqual(
-            np.array([0, 0, 1, 0, 0, 0, 1, 1, 0, 1]).tolist(), results.to_ndarray().tolist()
-        )
+        self.assertListEqual([0, 0, 1, 0, 0, 0, 1, 1, 0, 1], results.to_ndarray().tolist())
 
         results = self.igb.broadcast(counts < 4)
-        self.assertListEqual(
-            np.array([1, 1, 1, 0, 0, 0, 1, 1, 0, 1]).tolist(), results.to_ndarray().tolist()
-        )
+        self.assertListEqual([1, 1, 1, 0, 0, 0, 1, 1, 0, 1], results.to_ndarray().tolist())
 
     def test_count(self):
         keys, counts = self.igb.count()
 
-        self.assertListEqual(np.array([1, 2, 3, 4, 5]).tolist(), keys.to_ndarray().tolist())
-        self.assertListEqual(np.array([1, 4, 2, 1, 2]).tolist(), counts.to_ndarray().tolist())
+        self.assertListEqual([1, 2, 3, 4, 5], keys.to_ndarray().tolist())
+        self.assertListEqual([1, 4, 2, 1, 2], counts.to_ndarray().tolist())
 
     def test_groupby_reduction_type(self):
         self.assertEqual("any", str(GroupByReductionType.ANY))
@@ -387,10 +363,8 @@ class GroupByTest(ArkoudaTest):
         grouping = ak.GroupBy(s)
         labels, values = grouping.nunique(i)
 
-        expected = {"a": 2, "b": 2, "c": 1}
         actual = {label: value for (label, value) in zip(labels.to_ndarray(), values.to_ndarray())}
-
-        self.assertDictEqual(expected, actual)
+        self.assertDictEqual({"a": 2, "b": 2, "c": 1}, actual)
 
     def test_multi_level_categorical(self):
         string = ak.array(["a", "b", "a", "b", "c"])
@@ -423,14 +397,13 @@ class GroupByTest(ArkoudaTest):
         string = ak.array(["a", "b", "a", "b", "c"])
         cat = ak.Categorical(string)
         i = ak.array([5, 3, 5, 3, 1])
-        expected = ak.array([1, 1, 1])
         # Try GroupBy.nunique with every combination of types, including mixed
         keys = (string, cat, i, (string, cat, i))
         for key in keys:
             g = ak.GroupBy(key)
             for val in keys:
                 k, n = g.nunique(val)
-                self.assertListEqual(n.to_ndarray().tolist(), expected.to_ndarray().tolist())
+                self.assertListEqual(n.to_ndarray().tolist(), [1, 1, 1])
 
     def test_type_failure_multilevel_groupby_aggregate(self):
         # just checking no error occurs with hotfix for Issue 858

--- a/tests/import_export_test.py
+++ b/tests/import_export_test.py
@@ -4,7 +4,6 @@ from shutil import rmtree
 
 import numpy as np
 import pandas as pd
-import pytest
 from base_test import ArkoudaTest
 from context import arkouda as ak
 
@@ -38,19 +37,19 @@ class DataFrameTest(ArkoudaTest):
         pddf = self.build_pandas_dataframe()
         pddf.to_hdf(f"{f_base}/table.h5", "dataframe", format="Table", mode="w")
         akdf = ak.import_data(f"{f_base}/table.h5", write_file=f"{f_base}/ak_table.h5")
-        self.assertTrue(len(glob.glob(f"{f_base}/ak_table_*.h5")) == locales)
+        self.assertEqual(len(glob.glob(f"{f_base}/ak_table_*.h5")), locales)
         self.assertTrue(pddf.equals(akdf.to_pandas()))
 
         pddf.to_hdf(
             f"{f_base}/table_columns.h5", "dataframe", format="Table", data_columns=True, mode="w"
         )
         akdf = ak.import_data(f"{f_base}/table_columns.h5", write_file=f"{f_base}/ak_table_columns.h5")
-        self.assertTrue(len(glob.glob(f"{f_base}/ak_table_columns_*.h5")) == locales)
+        self.assertEqual(len(glob.glob(f"{f_base}/ak_table_columns_*.h5")), locales)
         self.assertTrue(pddf.equals(akdf.to_pandas()))
 
         pddf.to_hdf(f"{f_base}/fixed.h5", "dataframe", format="fixed", data_columns=True, mode="w")
         akdf = ak.import_data(f"{f_base}/fixed.h5", write_file=f"{f_base}/ak_fixed.h5")
-        self.assertTrue(len(glob.glob(f"{f_base}/ak_fixed_*.h5")) == locales)
+        self.assertEqual(len(glob.glob(f"{f_base}/ak_fixed_*.h5")), locales)
         self.assertTrue(pddf.equals(akdf.to_pandas()))
 
         with self.assertRaises(FileNotFoundError):
@@ -71,7 +70,7 @@ class DataFrameTest(ArkoudaTest):
         akdf.save(f"{f_base}/ak_write")
 
         pddf = ak.export(f"{f_base}/ak_write", write_file=f"{f_base}/pd_from_ak.h5", index=True)
-        self.assertTrue(len(glob.glob(f"{f_base}/pd_from_ak.h5")) == 1)
+        self.assertEqual(len(glob.glob(f"{f_base}/pd_from_ak.h5")), 1)
         self.assertTrue(pddf.equals(akdf.to_pandas()))
 
         with self.assertRaises(RuntimeError):
@@ -90,7 +89,7 @@ class DataFrameTest(ArkoudaTest):
         pddf = self.build_pandas_dataframe()
         pddf.to_parquet(f"{f_base}/table.parquet")
         akdf = ak.import_data(f"{f_base}/table.parquet", write_file=f"{f_base}/ak_table.parquet")
-        self.assertTrue(len(glob.glob(f"{f_base}/ak_table_*.parquet")) == locales)
+        self.assertEqual(len(glob.glob(f"{f_base}/ak_table_*.parquet")), locales)
         self.assertTrue(pddf.equals(akdf.to_pandas()))
 
         # clean up test files
@@ -108,7 +107,7 @@ class DataFrameTest(ArkoudaTest):
 
         pddf = ak.export(f"{f_base}/ak_write", write_file=f"{f_base}/pd_from_ak.parquet", index=True)
         print(pddf)
-        self.assertTrue(len(glob.glob(f"{f_base}/pd_from_ak.parquet")) == 1)
+        self.assertEqual(len(glob.glob(f"{f_base}/pd_from_ak.parquet")), 1)
         self.assertTrue(pddf.equals(akdf.to_pandas()))
 
         with self.assertRaises(RuntimeError):

--- a/tests/index_test.py
+++ b/tests/index_test.py
@@ -107,7 +107,7 @@ class IndexTest(ArkoudaTest):
 
         idx = ak.Index(ak.arange(5))
         idx.save(f"{d}/idx_file.h5")
-        self.assertTrue(len(glob.glob(f"{d}/idx_file_*.h5")) == locale_count)
+        self.assertEqual(len(glob.glob(f"{d}/idx_file_*.h5")), locale_count)
 
         # clean up test files
         rmtree(d)

--- a/tests/index_test.py
+++ b/tests/index_test.py
@@ -12,7 +12,7 @@ class IndexTest(ArkoudaTest):
 
         self.assertIsInstance(idx, ak.Index)
         self.assertEqual(idx.size, 5)
-        self.assertListEqual(idx.to_ndarray().tolist(), [i for i in range(5)])
+        self.assertListEqual(idx.to_list(), [i for i in range(5)])
 
     def test_multiindex_creation(self):
         # test list generation
@@ -50,12 +50,12 @@ class IndexTest(ArkoudaTest):
     def test_argsort(self):
         idx = ak.Index.factory(ak.arange(5))
         i = idx.argsort(False)
-        self.assertListEqual(i.to_ndarray().tolist(), [4, 3, 2, 1, 0])
+        self.assertListEqual(i.to_list(), [4, 3, 2, 1, 0])
 
         idx = ak.Index(ak.array([1, 0, 4, 2, 5, 3]))
         i = idx.argsort()
         # values should be the indexes in the array of idx
-        self.assertListEqual(i.to_ndarray().tolist(), [1, 0, 3, 5, 2, 4])
+        self.assertListEqual(i.to_list(), [1, 0, 3, 5, 2, 4])
 
     def test_concat(self):
         idx_1 = ak.Index.factory(ak.arange(5))
@@ -63,20 +63,20 @@ class IndexTest(ArkoudaTest):
         idx_2 = ak.Index(ak.array([2, 4, 1, 3, 0]))
 
         idx_full = idx_1.concat(idx_2)
-        self.assertListEqual(idx_full.to_ndarray().tolist(), [0, 1, 2, 3, 4, 2, 4, 1, 3, 0])
+        self.assertListEqual(idx_full.to_list(), [0, 1, 2, 3, 4, 2, 4, 1, 3, 0])
 
     def test_lookup(self):
         idx = ak.Index.factory(ak.arange(5))
         lk = idx.lookup(ak.array([0, 4]))
-        self.assertListEqual(lk.to_ndarray().tolist(), [True, False, False, False, True])
+        self.assertListEqual(lk.to_list(), [True, False, False, False, True])
 
     def test_multi_argsort(self):
         idx = ak.Index.factory([ak.arange(5), ak.arange(5)])
         s = idx.argsort(False)
-        self.assertListEqual(s.to_ndarray().tolist(), [4, 3, 2, 1, 0])
+        self.assertListEqual(s.to_list(), [4, 3, 2, 1, 0])
 
         s = idx.argsort()
-        self.assertListEqual(s.to_ndarray().tolist(), [i for i in range(5)])
+        self.assertListEqual(s.to_list(), [i for i in range(5)])
 
     def test_multi_concat(self):
         idx = ak.Index.factory([ak.arange(5), ak.arange(5)])
@@ -97,7 +97,7 @@ class IndexTest(ArkoudaTest):
         lk = ak.array([0, 3, 2])
 
         result = idx.lookup([lk, lk])
-        self.assertListEqual(result.to_ndarray().tolist(), [True, False, True, True, False])
+        self.assertListEqual(result.to_list(), [True, False, True, True, False])
 
     def test_save(self):
         locale_count = ak.get_config()["numLocales"]

--- a/tests/indexing_test.py
+++ b/tests/indexing_test.py
@@ -22,20 +22,16 @@ class IndexingTest(ArkoudaTest):
         # for every pda in array_dict test indexing with uint array and uint scalar
         for pda in self.array_dict.values():
             self.assertEqual(pda[np.uint(2)], pda[2])
-            self.assertListEqual(
-                pda[self.ukeys].to_ndarray().tolist(), pda[self.ikeys].to_ndarray().tolist()
-            )
+            self.assertListEqual(pda[self.ukeys].to_list(), pda[self.ikeys].to_list())
 
     def test_strings_uint_indexing(self):
         # test Strings array indexing with uint array and uint scalar
         self.assertEqual(self.s[np.uint(2)], self.s[2])
-        self.assertListEqual(
-            self.s[self.ukeys].to_ndarray().tolist(), self.s[self.ikeys].to_ndarray().tolist()
-        )
+        self.assertListEqual(self.s[self.ukeys].to_list(), self.s[self.ikeys].to_list())
 
     def test_uint_bool_indexing(self):
         # test uint array with bool indexing
-        self.assertListEqual(self.u[self.b].to_ndarray().tolist(), self.i[self.b].to_ndarray().tolist())
+        self.assertListEqual(self.u[self.b].to_list(), self.i[self.b].to_list())
 
     def test_set_uint(self):
         # for every pda in array_dict test __setitem__ indexing with uint array and uint scalar
@@ -46,23 +42,15 @@ class IndexingTest(ArkoudaTest):
 
             # set [slice] = scalar/pdarray
             pda[:10] = np.uint(-2)
-            self.assertListEqual(
-                pda[self.ukeys].to_ndarray().tolist(), pda[self.ikeys].to_ndarray().tolist()
-            )
+            self.assertListEqual(pda[self.ukeys].to_list(), pda[self.ikeys].to_list())
             pda[:10] = ak.cast(ak.arange(10), t)
-            self.assertListEqual(
-                pda[self.ukeys].to_ndarray().tolist(), pda[self.ikeys].to_ndarray().tolist()
-            )
+            self.assertListEqual(pda[self.ukeys].to_list(), pda[self.ikeys].to_list())
 
             # set [pdarray] = scalar/pdarray with uint key pdarray
             pda[ak.arange(10, dtype=ak.uint64)] = np.uint(3)
-            self.assertListEqual(
-                pda[self.ukeys].to_ndarray().tolist(), pda[self.ikeys].to_ndarray().tolist()
-            )
+            self.assertListEqual(pda[self.ukeys].to_list(), pda[self.ikeys].to_list())
             pda[ak.arange(10, dtype=ak.uint64)] = ak.cast(ak.arange(10), t)
-            self.assertListEqual(
-                pda[self.ukeys].to_ndarray().tolist(), pda[self.ikeys].to_ndarray().tolist()
-            )
+            self.assertListEqual(pda[self.ukeys].to_list(), pda[self.ikeys].to_list())
 
     def test_indexing_with_uint(self):
         # verify reproducer from #1210 no longer fails

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -119,9 +119,9 @@ class IOTest(ArkoudaTest):
         rifp.sort()
 
         self.assertEqual(4, len(retrieved_columns))
-        self.assertTrue((itp == ritp).all())
-        self.assertTrue((ihp == rihp).all())
-        self.assertTrue((ifp == rifp).all())
+        self.assertListEqual(itp.tolist(), ritp.tolist())
+        self.assertListEqual(ihp.tolist(), rihp.tolist())
+        self.assertListEqual(ifp.tolist(), rifp.tolist())
         self.assertEqual(len(self.dict_columns["bool_pdarray"]), len(retrieved_columns["bool_pdarray"]))
         self.assertEqual(4, len(ak.get_datasets("{}/iotest_dict_LOCALE0000".format(IOTest.io_test_dir))))
 
@@ -155,9 +155,9 @@ class IOTest(ArkoudaTest):
         rfp.sort()
 
         self.assertEqual(4, len(retrieved_columns))
-        self.assertTrue((itp == ritp).all())
-        self.assertTrue((ihp == rihp).all())
-        self.assertTrue((fp == rfp).all())
+        self.assertListEqual(itp.tolist(), ritp.tolist())
+        self.assertListEqual(ihp.tolist(), rihp.tolist())
+        self.assertListEqual(fp.tolist(), rfp.tolist())
         self.assertEqual(len(self.list_columns[3]), len(retrieved_columns["bool_pdarray"]))
         self.assertEqual(4, len(ak.get_datasets("{}/iotest_list_LOCALE0000".format(IOTest.io_test_dir))))
 
@@ -308,9 +308,9 @@ class IOTest(ArkoudaTest):
         rfp.sort()
 
         self.assertEqual(4, len(list(retrieved_columns.keys())))
-        self.assertTrue((itp == ritp).all())
-        self.assertTrue((ihp == rihp).all())
-        self.assertTrue((fp == rfp).all())
+        self.assertListEqual(itp.tolist(), ritp.tolist())
+        self.assertListEqual(ihp.tolist(), rihp.tolist())
+        self.assertListEqual(fp.tolist(), rfp.tolist())
         self.assertEqual(len(self.bool_pdarray), len(retrieved_columns["bool_pdarray"]))
 
     def testReadAllWithErrorAndWarn(self):
@@ -388,9 +388,9 @@ class IOTest(ArkoudaTest):
         rafloats = result_array_floats.to_ndarray()
         rafloats.sort()
 
-        self.assertTrue((self.int_tens_ndarray == ratens).all())
-        self.assertTrue((self.int_hundreds_ndarray == rahundreds).all())
-        self.assertTrue((self.float_ndarray == rafloats).all())
+        self.assertListEqual(self.int_tens_ndarray.tolist(), ratens.tolist())
+        self.assertListEqual(self.int_hundreds_ndarray.tolist(), rahundreds.tolist())
+        self.assertListEqual(self.float_ndarray.tolist(), rafloats.tolist())
         self.assertEqual(len(self.bool_pdarray), len(result_array_bools))
 
         # test load_all with file_format parameter usage
@@ -427,9 +427,9 @@ class IOTest(ArkoudaTest):
 
         rafloats = result_array_floats.to_ndarray()
         rafloats.sort()
-        self.assertTrue((self.int_tens_ndarray == ratens).all())
-        self.assertTrue((self.int_hundreds_ndarray == rahundreds).all())
-        self.assertTrue((self.float_ndarray == rafloats).all())
+        self.assertListEqual(self.int_tens_ndarray.tolist(), ratens.tolist())
+        self.assertListEqual(self.int_hundreds_ndarray.tolist(), rahundreds.tolist())
+        self.assertListEqual(self.float_ndarray.tolist(), rafloats.tolist())
         self.assertEqual(len(self.bool_pdarray), len(result_array_bools))
 
         # Test load with invalid prefix
@@ -508,7 +508,7 @@ class IOTest(ArkoudaTest):
         strings.sort()
         r_strings = r_strings_array.to_ndarray()
         r_strings.sort()
-        self.assertTrue((strings == r_strings).all())
+        self.assertListEqual(strings.tolist(), r_strings.tolist())
 
         # Read a part of a saved Strings dataset from one hdf5 file
         r_strings_subset = ak.read(filenames="{}/strings-test_LOCALE0000".format(IOTest.io_test_dir))
@@ -566,7 +566,7 @@ class IOTest(ArkoudaTest):
         strings.sort()
         r_strings = r_strings_array.to_ndarray()
         r_strings.sort()
-        self.assertTrue((strings == r_strings).all())
+        self.assertListEqual(strings.tolist(), r_strings.tolist())
 
     def testSaveLongStringsDataset(self):
         # Create, save, and load Strings dataset
@@ -583,7 +583,7 @@ class IOTest(ArkoudaTest):
         r_strings = ak.load("{}/strings-test".format(IOTest.io_test_dir), dataset="strings").to_ndarray()
         r_strings.sort()
 
-        self.assertTrue((n_strings == r_strings).all())
+        self.assertListEqual(n_strings.tolist(), r_strings.tolist())
 
     def testSaveMixedStringsDataset(self):
         strings_array = ak.array(["string {}".format(num) for num in list(range(0, 25))])
@@ -595,15 +595,18 @@ class IOTest(ArkoudaTest):
         )
         r_mixed = ak.load_all("{}/multi-type-test".format(IOTest.io_test_dir))
 
-        self.assertTrue((strings_array.to_ndarray().sort() == r_mixed["m_strings"].to_ndarray().sort()))
+        self.assertListEqual(
+            np.sort(strings_array.to_ndarray()).tolist(),
+            np.sort(r_mixed["m_strings"].to_ndarray()).tolist(),
+        )
         self.assertIsNotNone(r_mixed["m_floats"])
         self.assertIsNotNone(r_mixed["m_ints"])
 
         r_floats = ak.sort(ak.load("{}/multi-type-test".format(IOTest.io_test_dir), dataset="m_floats"))
-        self.assertTrue((m_floats == r_floats).all())
+        self.assertListEqual(m_floats.to_ndarray().tolist(), r_floats.to_ndarray().tolist())
 
         r_ints = ak.sort(ak.load("{}/multi-type-test".format(IOTest.io_test_dir), dataset="m_ints"))
-        self.assertTrue((m_ints == r_ints).all())
+        self.assertListEqual(m_ints.to_ndarray().tolist(), r_ints.to_ndarray().tolist())
 
         strings = strings_array.to_ndarray()
         strings.sort()
@@ -612,7 +615,7 @@ class IOTest(ArkoudaTest):
         ).to_ndarray()
         r_strings.sort()
 
-        self.assertTrue((strings == r_strings).all())
+        self.assertListEqual(strings.tolist(), r_strings.tolist())
 
     def testAppendStringsDataset(self):
         strings_array = ak.array(["string {}".format(num) for num in list(range(0, 25))])
@@ -625,7 +628,7 @@ class IOTest(ArkoudaTest):
         r_strings_dupe = ak.load(
             "{}/append-strings-test".format(IOTest.io_test_dir), dataset="strings-dupe"
         )
-        self.assertTrue((r_strings == r_strings_dupe).all())
+        self.assertListEqual(r_strings.to_ndarray().tolist(), r_strings_dupe.to_ndarray().tolist())
 
     def testAppendMixedStringsDataset(self):
         strings_array = ak.array(["string {}".format(num) for num in list(range(0, 25))])
@@ -648,15 +651,15 @@ class IOTest(ArkoudaTest):
         r_ints = ak.sort(
             ak.load("{}/append-multi-type-test".format(IOTest.io_test_dir), dataset="m_ints")
         )
-        self.assertTrue((m_floats == r_floats).all())
-        self.assertTrue((m_ints == r_ints).all())
+        self.assertListEqual(m_floats.to_ndarray().tolist(), r_floats.to_ndarray().tolist())
+        self.assertListEqual(m_ints.to_ndarray().tolist(), r_ints.to_ndarray().tolist())
 
         strings = strings_array.to_ndarray()
         strings.sort()
         r_strings = r_mixed["m_strings"].to_ndarray()
         r_strings.sort()
 
-        self.assertTrue((strings == r_strings).all())
+        self.assertListEqual(strings.tolist(), r_strings.tolist())
 
     def testStrictTypes(self):
         N = 100
@@ -673,7 +676,9 @@ class IOTest(ArkoudaTest):
             ak.read(prefix + "*")
 
         a = ak.read(prefix + "*", strictTypes=False)
-        self.assertTrue((a["integers"] == ak.arange(len(inttypes) * N)).all())
+        self.assertListEqual(
+            a["integers"].to_ndarray().tolist(), ak.arange(len(inttypes) * N).to_ndarray().tolist()
+        )
         self.assertTrue(
             np.allclose(a["floats"].to_ndarray(), np.arange(len(floattypes) * N, dtype=np.float64))
         )
@@ -682,12 +687,12 @@ class IOTest(ArkoudaTest):
         ones = ak.ones(10)
         n_ones = ones.to_ndarray()
         new_ones = ak.array(n_ones)
-        self.assertTrue((ones.to_ndarray() == new_ones.to_ndarray()).all())
+        self.assertListEqual(ones.to_ndarray().tolist(), new_ones.to_ndarray().tolist())
 
         empty_ones = ak.ones(0)
         n_empty_ones = empty_ones.to_ndarray()
         new_empty_ones = ak.array(n_empty_ones)
-        self.assertTrue((empty_ones.to_ndarray() == new_empty_ones.to_ndarray()).all())
+        self.assertListEqual(empty_ones.to_ndarray().tolist(), new_empty_ones.to_ndarray().tolist())
 
     def testSmallArrayToHDF5(self):
         a1 = ak.array([1])
@@ -728,7 +733,7 @@ class IOTest(ArkoudaTest):
             pda2 = ak.load(f"{tmp_dirname}/small_numeric", dataset="pda1")
             self.assertEqual(str(pda1), str(pda2))
             self.assertEqual(18446744073709551500, pda2[0])
-            self.assertTrue((pda2.to_ndarray() == npa1).all())
+            self.assertListEqual(pda2.to_ndarray().tolist(), npa1.tolist())
 
     def testUint64ToFromArray(self):
         """
@@ -739,7 +744,7 @@ class IOTest(ArkoudaTest):
         )
         pda1 = ak.array(npa1)
         self.assertEqual(18446744073709551500, pda1[0])
-        self.assertTrue((pda1.to_ndarray() == npa1).all())
+        self.assertListEqual(pda1.to_ndarray().tolist(), npa1.tolist())
 
     def testHdfUnsanitizedNames(self):
         # Test when quotes are part of the dataset name
@@ -772,9 +777,11 @@ class IOTest(ArkoudaTest):
     def test_multi_dim_rdwr(self):
         arr = ak.ArrayView(ak.arange(27), ak.array([3, 3, 3]))
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
-            ak.write_hdf5_multi_dim(arr, tmp_dirname+"/multi_dim_test", 'MultiDimObj', mode="append", storage="flat")
+            ak.write_hdf5_multi_dim(
+                arr, tmp_dirname + "/multi_dim_test", "MultiDimObj", mode="append", storage="flat"
+            )
             # load data back
-            read_arr = ak.read_hdf5_multi_dim(tmp_dirname+"/multi_dim_test", "MultiDimObj")
+            read_arr = ak.read_hdf5_multi_dim(tmp_dirname + "/multi_dim_test", "MultiDimObj")
             self.assertTrue(np.array_equal(arr.to_ndarray(), read_arr.to_ndarray()))
 
     def tearDown(self):

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -676,9 +676,7 @@ class IOTest(ArkoudaTest):
             ak.read(prefix + "*")
 
         a = ak.read(prefix + "*", strictTypes=False)
-        self.assertListEqual(
-            a["integers"].to_ndarray().tolist(), ak.arange(len(inttypes) * N).to_ndarray().tolist()
-        )
+        self.assertListEqual(a["integers"].to_ndarray().tolist(), np.arange(len(inttypes) * N).tolist())
         self.assertTrue(
             np.allclose(a["floats"].to_ndarray(), np.arange(len(floattypes) * N, dtype=np.float64))
         )

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -603,10 +603,10 @@ class IOTest(ArkoudaTest):
         self.assertIsNotNone(r_mixed["m_ints"])
 
         r_floats = ak.sort(ak.load("{}/multi-type-test".format(IOTest.io_test_dir), dataset="m_floats"))
-        self.assertListEqual(m_floats.to_ndarray().tolist(), r_floats.to_ndarray().tolist())
+        self.assertListEqual(m_floats.to_list(), r_floats.to_list())
 
         r_ints = ak.sort(ak.load("{}/multi-type-test".format(IOTest.io_test_dir), dataset="m_ints"))
-        self.assertListEqual(m_ints.to_ndarray().tolist(), r_ints.to_ndarray().tolist())
+        self.assertListEqual(m_ints.to_list(), r_ints.to_list())
 
         strings = strings_array.to_ndarray()
         strings.sort()
@@ -628,7 +628,7 @@ class IOTest(ArkoudaTest):
         r_strings_dupe = ak.load(
             "{}/append-strings-test".format(IOTest.io_test_dir), dataset="strings-dupe"
         )
-        self.assertListEqual(r_strings.to_ndarray().tolist(), r_strings_dupe.to_ndarray().tolist())
+        self.assertListEqual(r_strings.to_list(), r_strings_dupe.to_list())
 
     def testAppendMixedStringsDataset(self):
         strings_array = ak.array(["string {}".format(num) for num in list(range(0, 25))])
@@ -651,8 +651,8 @@ class IOTest(ArkoudaTest):
         r_ints = ak.sort(
             ak.load("{}/append-multi-type-test".format(IOTest.io_test_dir), dataset="m_ints")
         )
-        self.assertListEqual(m_floats.to_ndarray().tolist(), r_floats.to_ndarray().tolist())
-        self.assertListEqual(m_ints.to_ndarray().tolist(), r_ints.to_ndarray().tolist())
+        self.assertListEqual(m_floats.to_list(), r_floats.to_list())
+        self.assertListEqual(m_ints.to_list(), r_ints.to_list())
 
         strings = strings_array.to_ndarray()
         strings.sort()
@@ -676,7 +676,7 @@ class IOTest(ArkoudaTest):
             ak.read(prefix + "*")
 
         a = ak.read(prefix + "*", strictTypes=False)
-        self.assertListEqual(a["integers"].to_ndarray().tolist(), np.arange(len(inttypes) * N).tolist())
+        self.assertListEqual(a["integers"].to_list(), np.arange(len(inttypes) * N).tolist())
         self.assertTrue(
             np.allclose(a["floats"].to_ndarray(), np.arange(len(floattypes) * N, dtype=np.float64))
         )
@@ -685,12 +685,12 @@ class IOTest(ArkoudaTest):
         ones = ak.ones(10)
         n_ones = ones.to_ndarray()
         new_ones = ak.array(n_ones)
-        self.assertListEqual(ones.to_ndarray().tolist(), new_ones.to_ndarray().tolist())
+        self.assertListEqual(ones.to_list(), new_ones.to_list())
 
         empty_ones = ak.ones(0)
         n_empty_ones = empty_ones.to_ndarray()
         new_empty_ones = ak.array(n_empty_ones)
-        self.assertListEqual(empty_ones.to_ndarray().tolist(), new_empty_ones.to_ndarray().tolist())
+        self.assertListEqual(empty_ones.to_list(), new_empty_ones.to_list())
 
     def testSmallArrayToHDF5(self):
         a1 = ak.array([1])
@@ -731,7 +731,7 @@ class IOTest(ArkoudaTest):
             pda2 = ak.load(f"{tmp_dirname}/small_numeric", dataset="pda1")
             self.assertEqual(str(pda1), str(pda2))
             self.assertEqual(18446744073709551500, pda2[0])
-            self.assertListEqual(pda2.to_ndarray().tolist(), npa1.tolist())
+            self.assertListEqual(pda2.to_list(), npa1.tolist())
 
     def testUint64ToFromArray(self):
         """
@@ -742,7 +742,7 @@ class IOTest(ArkoudaTest):
         )
         pda1 = ak.array(npa1)
         self.assertEqual(18446744073709551500, pda1[0])
-        self.assertListEqual(pda1.to_ndarray().tolist(), npa1.tolist())
+        self.assertListEqual(pda1.to_list(), npa1.tolist())
 
     def testHdfUnsanitizedNames(self):
         # Test when quotes are part of the dataset name

--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -82,8 +82,8 @@ class JoinTest(ArkoudaTest):
         end = ak.array([10, 20, 30])
 
         segs, ranges = ak.join.gen_ranges(start, end)
-        self.assertListEqual(segs.to_ndarray().tolist(), [0, 10, 20])
-        self.assertListEqual(ranges.to_ndarray().tolist(), list(range(30)))
+        self.assertListEqual(segs.to_list(), [0, 10, 20])
+        self.assertListEqual(ranges.to_list(), list(range(30)))
 
         with self.assertRaises(ValueError):
             segs, ranges = ak.join.gen_ranges(ak.array([11, 12, 41]), end)
@@ -93,7 +93,7 @@ class JoinTest(ArkoudaTest):
         right = ak.array([0, 5, 3, 3, 4, 6, 7, 9, 8, 1])
 
         l, r = ak.join.inner_join(left, right)
-        self.assertListEqual(left[l].to_ndarray().tolist(), right[r].to_ndarray().tolist())
+        self.assertListEqual(left[l].to_list(), right[r].to_list())
 
         with self.assertRaises(ValueError):
             l, r = ak.join.inner_join(left, right, wherefunc=ak.unique)
@@ -119,15 +119,15 @@ class JoinTest(ArkoudaTest):
         # Simple lookup with int keys
         # Also test shortcut for unique-ordered keys
         res = ak.lookup(keys, values, args, fillvalue=-1)
-        self.assertListEqual(res.to_ndarray().tolist(), ans)
+        self.assertListEqual(res.to_list(), ans)
         # Compound lookup with (str, int) keys
         res2 = ak.lookup(
             (ak.cast(keys, ak.str_), keys), values, (ak.cast(args, ak.str_), args), fillvalue=-1
         )
-        self.assertListEqual(res2.to_ndarray().tolist(), ans)
+        self.assertListEqual(res2.to_list(), ans)
         # Keys not in uniqued order
         res3 = ak.lookup(keys[::-1], values[::-1], args, fillvalue=-1)
-        self.assertListEqual(res3.to_ndarray().tolist(), ans)
+        self.assertListEqual(res3.to_list(), ans)
         # Non-unique keys should raise error
         with self.assertWarns(UserWarning):
             keys = ak.arange(10) % 5

--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -93,7 +93,7 @@ class JoinTest(ArkoudaTest):
         right = ak.array([0, 5, 3, 3, 4, 6, 7, 9, 8, 1])
 
         l, r = ak.join.inner_join(left, right)
-        self.assertTrue((left[l] == right[r]).all())
+        self.assertListEqual(left[l].to_ndarray().tolist(), right[r].to_ndarray().tolist())
 
         with self.assertRaises(ValueError):
             l, r = ak.join.inner_join(left, right, wherefunc=ak.unique)
@@ -119,15 +119,15 @@ class JoinTest(ArkoudaTest):
         # Simple lookup with int keys
         # Also test shortcut for unique-ordered keys
         res = ak.lookup(keys, values, args, fillvalue=-1)
-        self.assertTrue((res.to_ndarray() == ans).all())
+        self.assertListEqual(res.to_ndarray().tolist(), ans.tolist())
         # Compound lookup with (str, int) keys
         res2 = ak.lookup(
             (ak.cast(keys, ak.str_), keys), values, (ak.cast(args, ak.str_), args), fillvalue=-1
         )
-        self.assertTrue((res2.to_ndarray() == ans).all())
+        self.assertListEqual(res2.to_ndarray().tolist(), ans.tolist())
         # Keys not in uniqued order
         res3 = ak.lookup(keys[::-1], values[::-1], args, fillvalue=-1)
-        self.assertTrue((res3.to_ndarray() == ans).all())
+        self.assertListEqual(res3.to_ndarray().tolist(), ans.tolist())
         # Non-unique keys should raise error
         with self.assertWarns(UserWarning):
             keys = ak.arange(10) % 5

--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -115,19 +115,19 @@ class JoinTest(ArkoudaTest):
         keys = ak.arange(5)
         values = 10 * keys
         args = ak.array([5, 3, 1, 4, 2, 3, 1, 0])
-        ans = np.array([-1, 30, 10, 40, 20, 30, 10, 0])
+        ans = [-1, 30, 10, 40, 20, 30, 10, 0]
         # Simple lookup with int keys
         # Also test shortcut for unique-ordered keys
         res = ak.lookup(keys, values, args, fillvalue=-1)
-        self.assertListEqual(res.to_ndarray().tolist(), ans.tolist())
+        self.assertListEqual(res.to_ndarray().tolist(), ans)
         # Compound lookup with (str, int) keys
         res2 = ak.lookup(
             (ak.cast(keys, ak.str_), keys), values, (ak.cast(args, ak.str_), args), fillvalue=-1
         )
-        self.assertListEqual(res2.to_ndarray().tolist(), ans.tolist())
+        self.assertListEqual(res2.to_ndarray().tolist(), ans)
         # Keys not in uniqued order
         res3 = ak.lookup(keys[::-1], values[::-1], args, fillvalue=-1)
-        self.assertListEqual(res3.to_ndarray().tolist(), ans.tolist())
+        self.assertListEqual(res3.to_ndarray().tolist(), ans)
         # Non-unique keys should raise error
         with self.assertWarns(UserWarning):
             keys = ak.arange(10) % 5

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -85,12 +85,12 @@ class NumericTest(ArkoudaTest):
                     )
 
         self.assertListEqual(
-            ak.array([1, 2, 3, 4, 5]).to_ndarray().tolist(),
+            [1, 2, 3, 4, 5],
             ak.cast(ak.linspace(1, 5, 5), dt=ak.int64).to_ndarray().tolist(),
         )
         self.assertEqual(ak.cast(ak.arange(0, 5), dt=ak.float64).dtype, ak.float64)
         self.assertListEqual(
-            ak.array([False, True, True, True, True]).to_ndarray().tolist(),
+            [False, True, True, True, True],
             ak.cast(ak.linspace(0, 4, 5), dt=ak.bool).to_ndarray().tolist(),
         )
 
@@ -165,7 +165,7 @@ class NumericTest(ArkoudaTest):
             ak.arange(5, 1, -1).to_ndarray().tolist(), ak.abs(ak.arange(-5, -1)).to_ndarray().tolist()
         )
         self.assertListEqual(
-            ak.array([5, 4, 3, 2, 1]).to_ndarray().tolist(),
+            [5, 4, 3, 2, 1],
             ak.abs(ak.linspace(-5, -1, 5)).to_ndarray().tolist(),
         )
 
@@ -250,8 +250,7 @@ class NumericTest(ArkoudaTest):
         ark_s_float64 = ak.array(npa)
         ark_isna_float64 = ak.isnan(ark_s_float64)
         actual = ark_isna_float64.to_ndarray()
-        expected = np.isnan(npa)
-        self.assertTrue(np.array_equal(expected, actual))
+        self.assertTrue(np.array_equal(np.isnan(npa), actual))
 
         # Currently we can't make an int64 array with a NaN in it so verify that we throw an Exception
         ark_s_int64 = ak.array(np.array([1, 2, 3, 4], dtype="int64"))

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -23,34 +23,34 @@ class NumericTest(ArkoudaTest):
             # Make sure seeded results are same
             a = ak.randint(0, 2**32, N, dtype=dt, seed=seed)
             b = ak.randint(0, 2**32, N, dtype=dt, seed=seed)
-            self.assertListEqual(a.to_ndarray().tolist(), b.to_ndarray().tolist())
+            self.assertListEqual(a.to_list(), b.to_list())
         # Uniform
         self.assertFalse((ak.uniform(N) == ak.uniform(N)).all())
         self.assertListEqual(
-            ak.uniform(N, seed=seed).to_ndarray().tolist(),
-            ak.uniform(N, seed=seed).to_ndarray().tolist(),
+            ak.uniform(N, seed=seed).to_list(),
+            ak.uniform(N, seed=seed).to_list(),
         )
         # Standard Normal
         self.assertFalse((ak.standard_normal(N) == ak.standard_normal(N)).all())
         self.assertListEqual(
-            ak.standard_normal(N, seed=seed).to_ndarray().tolist(),
-            ak.standard_normal(N, seed=seed).to_ndarray().tolist(),
+            ak.standard_normal(N, seed=seed).to_list(),
+            ak.standard_normal(N, seed=seed).to_list(),
         )
         # Strings (uniformly distributed length)
         self.assertFalse(
             (ak.random_strings_uniform(1, 10, N) == ak.random_strings_uniform(1, 10, N)).all()
         )
         self.assertListEqual(
-            ak.random_strings_uniform(1, 10, N, seed=seed).to_ndarray().tolist(),
-            ak.random_strings_uniform(1, 10, N, seed=seed).to_ndarray().tolist(),
+            ak.random_strings_uniform(1, 10, N, seed=seed).to_list(),
+            ak.random_strings_uniform(1, 10, N, seed=seed).to_list(),
         )
         # Strings (log-normally distributed length)
         self.assertFalse(
             (ak.random_strings_lognormal(2, 1, N) == ak.random_strings_lognormal(2, 1, N)).all()
         )
         self.assertListEqual(
-            ak.random_strings_lognormal(2, 1, N, seed=seed).to_ndarray().tolist(),
-            ak.random_strings_lognormal(2, 1, N, seed=seed).to_ndarray().tolist(),
+            ak.random_strings_lognormal(2, 1, N, seed=seed).to_list(),
+            ak.random_strings_lognormal(2, 1, N, seed=seed).to_list(),
         )
 
     def testCast(self):
@@ -86,12 +86,12 @@ class NumericTest(ArkoudaTest):
 
         self.assertListEqual(
             [1, 2, 3, 4, 5],
-            ak.cast(ak.linspace(1, 5, 5), dt=ak.int64).to_ndarray().tolist(),
+            ak.cast(ak.linspace(1, 5, 5), dt=ak.int64).to_list(),
         )
         self.assertEqual(ak.cast(ak.arange(0, 5), dt=ak.float64).dtype, ak.float64)
         self.assertListEqual(
             [False, True, True, True, True],
-            ak.cast(ak.linspace(0, 4, 5), dt=ak.bool).to_ndarray().tolist(),
+            ak.cast(ak.linspace(0, 4, 5), dt=ak.bool).to_list(),
         )
 
     def testStrCastErrors(self):
@@ -119,7 +119,7 @@ class NumericTest(ArkoudaTest):
             res = ak.cast(arg, dt, errors=ak.ErrorMode.ignore)
             self.assertTrue(np.allclose(ans, res.to_ndarray(), equal_nan=True))
             res, valid = ak.cast(arg, dt, errors=ak.ErrorMode.return_validity)
-            self.assertListEqual(valid.to_ndarray().tolist(), validans.to_ndarray().tolist())
+            self.assertListEqual(valid.to_list(), validans.to_list())
             self.assertTrue(np.allclose(ans, res.to_ndarray(), equal_nan=True))
 
     def testHistogram(self):
@@ -161,12 +161,10 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
 
         self.assertTrue(np.allclose(np.abs(na), ak.abs(pda).to_ndarray()))
-        self.assertListEqual(
-            ak.arange(5, 1, -1).to_ndarray().tolist(), ak.abs(ak.arange(-5, -1)).to_ndarray().tolist()
-        )
+        self.assertListEqual(ak.arange(5, 1, -1).to_list(), ak.abs(ak.arange(-5, -1)).to_list())
         self.assertListEqual(
             [5, 4, 3, 2, 1],
-            ak.abs(ak.linspace(-5, -1, 5)).to_ndarray().tolist(),
+            ak.abs(ak.linspace(-5, -1, 5)).to_list(),
         )
 
         with self.assertRaises(TypeError):
@@ -215,12 +213,12 @@ class NumericTest(ArkoudaTest):
         h1, h2 = ak.hash(ak.arange(10))
         rev = ak.arange(9, -1, -1)
         h3, h4 = ak.hash(rev)
-        self.assertListEqual(h1.to_ndarray().tolist(), h3[rev].to_ndarray().tolist())
-        self.assertListEqual(h2.to_ndarray().tolist(), h4[rev].to_ndarray().tolist())
+        self.assertListEqual(h1.to_list(), h3[rev].to_list())
+        self.assertListEqual(h2.to_list(), h4[rev].to_list())
 
         h1 = ak.hash(ak.arange(10), full=False)
         h3 = ak.hash(rev, full=False)
-        self.assertListEqual(h1.to_ndarray().tolist(), h3[rev].to_ndarray().tolist())
+        self.assertListEqual(h1.to_list(), h3[rev].to_list())
 
         h = ak.hash(ak.linspace(0, 10, 10))
         self.assertEqual(h[0].dtype, ak.uint64)

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -17,44 +17,46 @@ class NumericTest(ArkoudaTest):
         numericdtypes = [ak.int64, ak.float64, ak.bool, ak.uint64]
         for dt in numericdtypes:
             # Make sure unseeded runs differ
-            a = ak.randint(0, 2 ** 32, N, dtype=dt)
-            b = ak.randint(0, 2 ** 32, N, dtype=dt)
+            a = ak.randint(0, 2**32, N, dtype=dt)
+            b = ak.randint(0, 2**32, N, dtype=dt)
             self.assertFalse((a == b).all())
             # Make sure seeded results are same
-            a = ak.randint(0, 2 ** 32, N, dtype=dt, seed=seed)
-            b = ak.randint(0, 2 ** 32, N, dtype=dt, seed=seed)
-            self.assertTrue((a == b).all())
+            a = ak.randint(0, 2**32, N, dtype=dt, seed=seed)
+            b = ak.randint(0, 2**32, N, dtype=dt, seed=seed)
+            self.assertListEqual(a.to_ndarray().tolist(), b.to_ndarray().tolist())
         # Uniform
         self.assertFalse((ak.uniform(N) == ak.uniform(N)).all())
-        self.assertTrue((ak.uniform(N, seed=seed) == ak.uniform(N, seed=seed)).all())
+        self.assertListEqual(
+            ak.uniform(N, seed=seed).to_ndarray().tolist(),
+            ak.uniform(N, seed=seed).to_ndarray().tolist(),
+        )
         # Standard Normal
         self.assertFalse((ak.standard_normal(N) == ak.standard_normal(N)).all())
-        self.assertTrue((ak.standard_normal(N, seed=seed) == ak.standard_normal(N, seed=seed)).all())
+        self.assertListEqual(
+            ak.standard_normal(N, seed=seed).to_ndarray().tolist(),
+            ak.standard_normal(N, seed=seed).to_ndarray().tolist(),
+        )
         # Strings (uniformly distributed length)
         self.assertFalse(
             (ak.random_strings_uniform(1, 10, N) == ak.random_strings_uniform(1, 10, N)).all()
         )
-        self.assertTrue(
-            (
-                ak.random_strings_uniform(1, 10, N, seed=seed)
-                == ak.random_strings_uniform(1, 10, N, seed=seed)
-            ).all()
+        self.assertListEqual(
+            ak.random_strings_uniform(1, 10, N, seed=seed).to_ndarray().tolist(),
+            ak.random_strings_uniform(1, 10, N, seed=seed).to_ndarray().tolist(),
         )
         # Strings (log-normally distributed length)
         self.assertFalse(
             (ak.random_strings_lognormal(2, 1, N) == ak.random_strings_lognormal(2, 1, N)).all()
         )
-        self.assertTrue(
-            (
-                ak.random_strings_lognormal(2, 1, N, seed=seed)
-                == ak.random_strings_lognormal(2, 1, N, seed=seed)
-            ).all()
+        self.assertListEqual(
+            ak.random_strings_lognormal(2, 1, N, seed=seed).to_ndarray().tolist(),
+            ak.random_strings_lognormal(2, 1, N, seed=seed).to_ndarray().tolist(),
         )
 
     def testCast(self):
         N = 100
         arrays = {
-            ak.int64: ak.randint(-(2 ** 48), 2 ** 48, N),
+            ak.int64: ak.randint(-(2**48), 2**48, N),
             ak.float64: ak.randint(0, 1, N, dtype=ak.float64),
             ak.bool: ak.randint(0, 2, N, dtype=ak.bool),
         }
@@ -82,16 +84,18 @@ class NumericTest(ArkoudaTest):
                         (orig == roundtrip).all(), f"{t1}: {orig[:5]}, {t2}: {roundtrip[:5]}"
                     )
 
-        self.assertTrue((ak.array([1, 2, 3, 4, 5]) == ak.cast(ak.linspace(1, 5, 5), dt=ak.int64)).all())
+        self.assertListEqual(
+            ak.array([1, 2, 3, 4, 5]).to_ndarray().tolist(),
+            ak.cast(ak.linspace(1, 5, 5), dt=ak.int64).to_ndarray().tolist(),
+        )
         self.assertEqual(ak.cast(ak.arange(0, 5), dt=ak.float64).dtype, ak.float64)
-        self.assertTrue(
-            (
-                ak.array([False, True, True, True, True]) == ak.cast(ak.linspace(0, 4, 5), dt=ak.bool)
-            ).all()
+        self.assertListEqual(
+            ak.array([False, True, True, True, True]).to_ndarray().tolist(),
+            ak.cast(ak.linspace(0, 4, 5), dt=ak.bool).to_ndarray().tolist(),
         )
 
     def testStrCastErrors(self):
-        intNAN = -(2 ** 63)
+        intNAN = -(2**63)
         intstr = ak.array(["1", "2 ", "3?", "!4", "  5", "-45", "0b101", "0x30", "N/A"])
         intans = np.array([1, 2, intNAN, intNAN, 5, -45, 0b101, 0x30, intNAN])
         uintNAN = 0
@@ -115,7 +119,7 @@ class NumericTest(ArkoudaTest):
             res = ak.cast(arg, dt, errors=ak.ErrorMode.ignore)
             self.assertTrue(np.allclose(ans, res.to_ndarray(), equal_nan=True))
             res, valid = ak.cast(arg, dt, errors=ak.ErrorMode.return_validity)
-            self.assertTrue((valid == validans).all())
+            self.assertListEqual(valid.to_ndarray().tolist(), validans.to_ndarray().tolist())
             self.assertTrue(np.allclose(ans, res.to_ndarray(), equal_nan=True))
 
     def testHistogram(self):
@@ -157,8 +161,13 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
 
         self.assertTrue(np.allclose(np.abs(na), ak.abs(pda).to_ndarray()))
-        self.assertTrue((ak.arange(5, 1, -1) == ak.abs(ak.arange(-5, -1))).all())
-        self.assertTrue((ak.array([5, 4, 3, 2, 1]) == ak.abs(ak.linspace(-5, -1, 5))).all())
+        self.assertListEqual(
+            ak.arange(5, 1, -1).to_ndarray().tolist(), ak.abs(ak.arange(-5, -1)).to_ndarray().tolist()
+        )
+        self.assertListEqual(
+            ak.array([5, 4, 3, 2, 1]).to_ndarray().tolist(),
+            ak.abs(ak.linspace(-5, -1, 5)).to_ndarray().tolist(),
+        )
 
         with self.assertRaises(TypeError):
             ak.abs([range(0, 10)])
@@ -206,14 +215,16 @@ class NumericTest(ArkoudaTest):
         h1, h2 = ak.hash(ak.arange(10))
         rev = ak.arange(9, -1, -1)
         h3, h4 = ak.hash(rev)
-        self.assertTrue((h1 == h3[rev]).all() and (h2 == h4[rev]).all())
+        self.assertListEqual(h1.to_ndarray().tolist(), h3[rev].to_ndarray().tolist())
+        self.assertListEqual(h2.to_ndarray().tolist(), h4[rev].to_ndarray().tolist())
 
         h1 = ak.hash(ak.arange(10), full=False)
         h3 = ak.hash(rev, full=False)
-        self.assertTrue((h1 == h3[rev]).all())
+        self.assertListEqual(h1.to_ndarray().tolist(), h3[rev].to_ndarray().tolist())
 
         h = ak.hash(ak.linspace(0, 10, 10))
-        self.assertTrue((h[0].dtype == ak.uint64) and (h[1].dtype == ak.uint64))
+        self.assertEqual(h[0].dtype, ak.uint64)
+        self.assertEqual(h[1].dtype, ak.uint64)
 
     def testValueCounts(self):
         pda = ak.ones(100, dtype=ak.int64)
@@ -251,9 +262,9 @@ class NumericTest(ArkoudaTest):
         # See https://github.com/Bears-R-Us/arkouda/issues/964
         # Grouped sum was exacerbating floating point errors
         # This test verifies the fix
-        N = 10 ** 6
+        N = 10**6
         G = N // 10
-        ub = 2 ** 63 // N
+        ub = 2**63 // N
         groupnum = ak.randint(0, G, N, seed=1)
         intval = ak.randint(0, ub, N, seed=2)
         floatval = ak.cast(intval, ak.float64)

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -264,20 +264,33 @@ class OperatorsTest(ArkoudaTest):
         pdaOne = ak.arange(1, 4)
         pdaTwo = ak.arange(4, 7)
 
-        self.assertTrue((ak.array([1, 2, 3, 4, 5, 6]) == ak.concatenate([pdaOne, pdaTwo])).all())
-        self.assertTrue((ak.array([4, 5, 6, 1, 2, 3]) == ak.concatenate([pdaTwo, pdaOne])).all())
+        self.assertListEqual(
+            ak.array([1, 2, 3, 4, 5, 6]).to_ndarray().tolist(),
+            ak.concatenate([pdaOne, pdaTwo]).to_ndarray().tolist(),
+        )
+        self.assertListEqual(
+            ak.array([4, 5, 6, 1, 2, 3]).to_ndarray().tolist(),
+            ak.concatenate([pdaTwo, pdaOne]).to_ndarray().tolist(),
+        )
 
         pdaOne = ak.linspace(start=1, stop=3, length=3)
         pdaTwo = ak.linspace(start=4, stop=6, length=3)
 
-        self.assertTrue((ak.array([1, 2, 3, 4, 5, 6]) == ak.concatenate([pdaOne, pdaTwo])).all())
-        self.assertTrue((ak.array([4, 5, 6, 1, 2, 3]) == ak.concatenate([pdaTwo, pdaOne])).all())
+        self.assertListEqual(
+            ak.array([1, 2, 3, 4, 5, 6]).to_ndarray().tolist(),
+            ak.concatenate([pdaOne, pdaTwo]).to_ndarray().tolist(),
+        )
+        self.assertListEqual(
+            ak.array([4, 5, 6, 1, 2, 3]).to_ndarray().tolist(),
+            ak.concatenate([pdaTwo, pdaOne]).to_ndarray().tolist(),
+        )
 
         pdaOne = ak.array([True, False, True])
         pdaTwo = ak.array([False, True, True])
 
-        self.assertTrue(
-            (ak.array([True, False, True, False, True, True]) == ak.concatenate([pdaOne, pdaTwo])).all()
+        self.assertListEqual(
+            ak.array([True, False, True, False, True, True]).to_ndarray().tolist(),
+            ak.concatenate([pdaOne, pdaTwo]).to_ndarray().tolist(),
         )
 
     def test_concatenate_type_preservation(self):
@@ -400,7 +413,7 @@ class OperatorsTest(ArkoudaTest):
         # with self.assertRaises(ValueError) as cm:
         #    ak.histogram((ak.randint(0, 1, 100, dtype=ak.bool)))
         with self.assertRaises(RuntimeError) as cm:
-            ak.concatenate([ak.array([True]),ak.array([True])]).is_sorted()
+            ak.concatenate([ak.array([True]), ak.array([True])]).is_sorted()
 
         with self.assertRaises(TypeError):
             ak.ones(100).any([0])

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -265,11 +265,11 @@ class OperatorsTest(ArkoudaTest):
         pdaTwo = ak.arange(4, 7)
 
         self.assertListEqual(
-            ak.array([1, 2, 3, 4, 5, 6]).to_ndarray().tolist(),
+            [1, 2, 3, 4, 5, 6],
             ak.concatenate([pdaOne, pdaTwo]).to_ndarray().tolist(),
         )
         self.assertListEqual(
-            ak.array([4, 5, 6, 1, 2, 3]).to_ndarray().tolist(),
+            [4, 5, 6, 1, 2, 3],
             ak.concatenate([pdaTwo, pdaOne]).to_ndarray().tolist(),
         )
 
@@ -277,11 +277,11 @@ class OperatorsTest(ArkoudaTest):
         pdaTwo = ak.linspace(start=4, stop=6, length=3)
 
         self.assertListEqual(
-            ak.array([1, 2, 3, 4, 5, 6]).to_ndarray().tolist(),
+            [1, 2, 3, 4, 5, 6],
             ak.concatenate([pdaOne, pdaTwo]).to_ndarray().tolist(),
         )
         self.assertListEqual(
-            ak.array([4, 5, 6, 1, 2, 3]).to_ndarray().tolist(),
+            [4, 5, 6, 1, 2, 3],
             ak.concatenate([pdaTwo, pdaOne]).to_ndarray().tolist(),
         )
 
@@ -289,7 +289,7 @@ class OperatorsTest(ArkoudaTest):
         pdaTwo = ak.array([False, True, True])
 
         self.assertListEqual(
-            ak.array([True, False, True, False, True, True]).to_ndarray().tolist(),
+            [True, False, True, False, True, True],
             ak.concatenate([pdaOne, pdaTwo]).to_ndarray().tolist(),
         )
 

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -266,11 +266,11 @@ class OperatorsTest(ArkoudaTest):
 
         self.assertListEqual(
             [1, 2, 3, 4, 5, 6],
-            ak.concatenate([pdaOne, pdaTwo]).to_ndarray().tolist(),
+            ak.concatenate([pdaOne, pdaTwo]).to_list(),
         )
         self.assertListEqual(
             [4, 5, 6, 1, 2, 3],
-            ak.concatenate([pdaTwo, pdaOne]).to_ndarray().tolist(),
+            ak.concatenate([pdaTwo, pdaOne]).to_list(),
         )
 
         pdaOne = ak.linspace(start=1, stop=3, length=3)
@@ -278,11 +278,11 @@ class OperatorsTest(ArkoudaTest):
 
         self.assertListEqual(
             [1, 2, 3, 4, 5, 6],
-            ak.concatenate([pdaOne, pdaTwo]).to_ndarray().tolist(),
+            ak.concatenate([pdaOne, pdaTwo]).to_list(),
         )
         self.assertListEqual(
             [4, 5, 6, 1, 2, 3],
-            ak.concatenate([pdaTwo, pdaOne]).to_ndarray().tolist(),
+            ak.concatenate([pdaTwo, pdaOne]).to_list(),
         )
 
         pdaOne = ak.array([True, False, True])
@@ -290,7 +290,7 @@ class OperatorsTest(ArkoudaTest):
 
         self.assertListEqual(
             [True, False, True, False, True, True],
-            ak.concatenate([pdaOne, pdaTwo]).to_ndarray().tolist(),
+            ak.concatenate([pdaOne, pdaTwo]).to_list(),
         )
 
     def test_concatenate_type_preservation(self):
@@ -306,14 +306,10 @@ class OperatorsTest(ArkoudaTest):
         ipv4_two = ak.IPv4(pda_two)
         ipv4_concat = ak.concatenate([ipv4_one, ipv4_two])
         self.assertEqual(type(ipv4_concat), ak.IPv4)
-        self.assertListEqual(
-            ak.IPv4(pda_concat).to_ndarray().tolist(), ipv4_concat.to_ndarray().tolist()
-        )
+        self.assertListEqual(ak.IPv4(pda_concat).to_list(), ipv4_concat.to_list())
         # test single and empty
         self.assertEqual(type(ak.concatenate([ipv4_one])), ak.IPv4)
-        self.assertListEqual(
-            ak.IPv4(pda_one).to_ndarray().tolist(), ak.concatenate([ipv4_one]).to_ndarray().tolist()
-        )
+        self.assertListEqual(ak.IPv4(pda_one).to_list(), ak.concatenate([ipv4_one]).to_list())
         self.assertEqual(type(ak.concatenate([ak.IPv4(ak.array([], dtype=ak.int64))])), ak.IPv4)
 
         # Datetime test
@@ -321,14 +317,12 @@ class OperatorsTest(ArkoudaTest):
         datetime_two = ak.Datetime(pda_two)
         datetime_concat = ak.concatenate([datetime_one, datetime_two])
         self.assertEqual(type(datetime_concat), ak.Datetime)
-        self.assertListEqual(
-            ak.Datetime(pda_concat).to_ndarray().tolist(), datetime_concat.to_ndarray().tolist()
-        )
+        self.assertListEqual(ak.Datetime(pda_concat).to_list(), datetime_concat.to_list())
         # test single and empty
         self.assertEqual(type(ak.concatenate([datetime_one])), ak.Datetime)
         self.assertListEqual(
-            ak.Datetime(pda_one).to_ndarray().tolist(),
-            ak.concatenate([datetime_one]).to_ndarray().tolist(),
+            ak.Datetime(pda_one).to_list(),
+            ak.concatenate([datetime_one]).to_list(),
         )
         self.assertEqual(type(ak.concatenate([ak.Datetime(ak.array([], dtype=ak.int64))])), ak.Datetime)
 
@@ -337,14 +331,12 @@ class OperatorsTest(ArkoudaTest):
         timedelta_two = ak.Timedelta(pda_two)
         timedelta_concat = ak.concatenate([timedelta_one, timedelta_two])
         self.assertEqual(type(timedelta_concat), ak.Timedelta)
-        self.assertListEqual(
-            ak.Timedelta(pda_concat).to_ndarray().tolist(), timedelta_concat.to_ndarray().tolist()
-        )
+        self.assertListEqual(ak.Timedelta(pda_concat).to_list(), timedelta_concat.to_list())
         # test single and empty
         self.assertEqual(type(ak.concatenate([timedelta_one])), ak.Timedelta)
         self.assertListEqual(
-            ak.Timedelta(pda_one).to_ndarray().tolist(),
-            ak.concatenate([timedelta_one]).to_ndarray().tolist(),
+            ak.Timedelta(pda_one).to_list(),
+            ak.concatenate([timedelta_one]).to_list(),
         )
         self.assertEqual(
             type(ak.concatenate([ak.Timedelta(ak.array([], dtype=ak.int64))])), ak.Timedelta
@@ -355,14 +347,12 @@ class OperatorsTest(ArkoudaTest):
         bitvector_two = ak.BitVector(pda_two)
         bitvector_concat = ak.concatenate([bitvector_one, bitvector_two])
         self.assertEqual(type(bitvector_concat), ak.BitVector)
-        self.assertListEqual(
-            ak.BitVector(pda_concat).to_ndarray().tolist(), bitvector_concat.to_ndarray().tolist()
-        )
+        self.assertListEqual(ak.BitVector(pda_concat).to_list(), bitvector_concat.to_list())
         # test single and empty
         self.assertEqual(type(ak.concatenate([bitvector_one])), ak.BitVector)
         self.assertListEqual(
-            ak.BitVector(pda_one).to_ndarray().tolist(),
-            ak.concatenate([bitvector_one]).to_ndarray().tolist(),
+            ak.BitVector(pda_one).to_list(),
+            ak.concatenate([bitvector_one]).to_list(),
         )
         self.assertEqual(
             type(ak.concatenate([ak.BitVector(ak.array([], dtype=ak.int64))])), ak.BitVector
@@ -375,27 +365,19 @@ class OperatorsTest(ArkoudaTest):
         # verify ak.util.concatenate still works
         ipv4_akuconcat = akuconcat([ipv4_one, ipv4_two])
         self.assertEqual(type(ipv4_akuconcat), ak.IPv4)
-        self.assertListEqual(
-            ak.IPv4(pda_concat).to_ndarray().tolist(), ipv4_akuconcat.to_ndarray().tolist()
-        )
+        self.assertListEqual(ak.IPv4(pda_concat).to_list(), ipv4_akuconcat.to_list())
 
         datetime_akuconcat = akuconcat([datetime_one, datetime_two])
         self.assertEqual(type(datetime_akuconcat), ak.Datetime)
-        self.assertListEqual(
-            ak.Datetime(pda_concat).to_ndarray().tolist(), datetime_akuconcat.to_ndarray().tolist()
-        )
+        self.assertListEqual(ak.Datetime(pda_concat).to_list(), datetime_akuconcat.to_list())
 
         timedelta_akuconcat = akuconcat([timedelta_one, timedelta_two])
         self.assertEqual(type(timedelta_akuconcat), ak.Timedelta)
-        self.assertListEqual(
-            ak.Timedelta(pda_concat).to_ndarray().tolist(), timedelta_akuconcat.to_ndarray().tolist()
-        )
+        self.assertListEqual(ak.Timedelta(pda_concat).to_list(), timedelta_akuconcat.to_list())
 
         bitvector_akuconcat = akuconcat([bitvector_one, bitvector_two])
         self.assertEqual(type(bitvector_akuconcat), ak.BitVector)
-        self.assertListEqual(
-            ak.BitVector(pda_concat).to_ndarray().tolist(), bitvector_akuconcat.to_ndarray().tolist()
-        )
+        self.assertListEqual(ak.BitVector(pda_concat).to_list(), bitvector_akuconcat.to_list())
 
     def testAllOperators(self):
         run_tests(verbose)

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -132,12 +132,12 @@ class ParquetTest(ArkoudaTest):
     def test_parquet(self):
         for dtype in TYPES:
             (ak_arr, pq_arr) = read_write_test(dtype)
-            self.assertListEqual(ak_arr.to_ndarray().tolist(), pq_arr.to_ndarray().tolist())
+            self.assertListEqual(ak_arr.to_list(), pq_arr.to_list())
 
     def test_multi_file(self):
         for dtype in TYPES:
             (ak_arr, pq_arr) = read_write_multi_test(dtype)
-            self.assertListEqual(ak_arr.to_ndarray().tolist(), pq_arr.to_ndarray().tolist())
+            self.assertListEqual(ak_arr.to_list(), pq_arr.to_list())
 
     def test_wrong_dset_name(self):
         ak_arr = ak.randint(0, 2**32, SIZE)
@@ -184,7 +184,7 @@ class ParquetTest(ArkoudaTest):
         ak_vals, ak_dict = append_test()
 
         for key in ak_dict:
-            self.assertListEqual(ak_vals[key].to_ndarray().tolist(), ak_dict[key].to_ndarray().tolist())
+            self.assertListEqual(ak_vals[key].to_list(), ak_dict[key].to_list())
 
     def test_null_strings(self):
         datadir = "resources/parquet-testing"
@@ -194,7 +194,7 @@ class ParquetTest(ArkoudaTest):
         filename = os.path.join(datadir, basename)
         res = ak.read(filename)
 
-        self.assertListEqual(expected, res.to_ndarray().tolist())
+        self.assertListEqual(expected, res.to_list())
 
     def test_null_indices(self):
         datadir = "resources/parquet-testing"
@@ -203,13 +203,13 @@ class ParquetTest(ArkoudaTest):
         filename = os.path.join(datadir, basename)
         res = ak.get_null_indices(filename, datasets="col1")
 
-        self.assertListEqual([0, 1, 0, 1, 0, 1, 1], res.to_ndarray().tolist())
+        self.assertListEqual([0, 1, 0, 1, 0, 1, 1], res.to_list())
 
     def test_append_empty(self):
         for dtype in TYPES:
             (ak_arr, pq_arr) = empty_append_test(dtype)
 
-            self.assertListEqual(ak_arr.to_ndarray().tolist(), pq_arr.to_ndarray().tolist())
+            self.assertListEqual(ak_arr.to_list(), pq_arr.to_list())
 
     @pytest.mark.optional_parquet
     def test_against_standard_files(self):

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -189,22 +189,21 @@ class ParquetTest(ArkoudaTest):
     def test_null_strings(self):
         datadir = "resources/parquet-testing"
         basename = "null-strings.parquet"
-        expected = ak.array(["first-string", "", "string2", "", "third", "", ""])
+        expected = ["first-string", "", "string2", "", "third", "", ""]
 
         filename = os.path.join(datadir, basename)
         res = ak.read(filename)
 
-        self.assertListEqual(expected.to_ndarray().tolist(), res.to_ndarray().tolist())
+        self.assertListEqual(expected, res.to_ndarray().tolist())
 
     def test_null_indices(self):
         datadir = "resources/parquet-testing"
         basename = "null-strings.parquet"
-        expected = ak.array([0, 1, 0, 1, 0, 1, 1])
 
         filename = os.path.join(datadir, basename)
         res = ak.get_null_indices(filename, datasets="col1")
 
-        self.assertListEqual(expected.to_ndarray().tolist(), res.to_ndarray().tolist())
+        self.assertListEqual([0, 1, 0, 1, 0, 1, 1], res.to_ndarray().tolist())
 
     def test_append_empty(self):
         for dtype in TYPES:

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -132,12 +132,12 @@ class ParquetTest(ArkoudaTest):
     def test_parquet(self):
         for dtype in TYPES:
             (ak_arr, pq_arr) = read_write_test(dtype)
-            self.assertTrue((ak_arr == pq_arr).all())
+            self.assertListEqual(ak_arr.to_ndarray().tolist(), pq_arr.to_ndarray().tolist())
 
     def test_multi_file(self):
         for dtype in TYPES:
             (ak_arr, pq_arr) = read_write_multi_test(dtype)
-            self.assertTrue((ak_arr == pq_arr).all())
+            self.assertListEqual(ak_arr.to_ndarray().tolist(), pq_arr.to_ndarray().tolist())
 
     def test_wrong_dset_name(self):
         ak_arr = ak.randint(0, 2**32, SIZE)
@@ -167,7 +167,7 @@ class ParquetTest(ArkoudaTest):
             a = ak.array([val])
             a.save_parquet("pq_test", "test-dset")
             ak_res = ak.read("pq_test*", "test-dset")
-            self.assertTrue(ak_res[0] == val)
+            self.assertEqual(ak_res[0], val)
 
             for f in glob.glob("pq_test*"):
                 os.remove(f)
@@ -175,7 +175,7 @@ class ParquetTest(ArkoudaTest):
     def test_get_datasets(self):
         for dtype in TYPES:
             dsets = get_datasets_test(dtype)
-            self.assertTrue(["TEST_DSET"] == dsets)
+            self.assertEqual(["TEST_DSET"], dsets)
 
         for f in glob.glob("pq_test*"):
             os.remove(f)
@@ -184,7 +184,7 @@ class ParquetTest(ArkoudaTest):
         ak_vals, ak_dict = append_test()
 
         for key in ak_dict:
-            self.assertTrue((ak_vals[key] == ak_dict[key]).all())
+            self.assertListEqual(ak_vals[key].to_ndarray().tolist(), ak_dict[key].to_ndarray().tolist())
 
     def test_null_strings(self):
         datadir = "resources/parquet-testing"
@@ -194,7 +194,7 @@ class ParquetTest(ArkoudaTest):
         filename = os.path.join(datadir, basename)
         res = ak.read(filename)
 
-        self.assertTrue((expected == res).all())
+        self.assertListEqual(expected.to_ndarray().tolist(), res.to_ndarray().tolist())
 
     def test_null_indices(self):
         datadir = "resources/parquet-testing"
@@ -204,13 +204,13 @@ class ParquetTest(ArkoudaTest):
         filename = os.path.join(datadir, basename)
         res = ak.get_null_indices(filename, datasets="col1")
 
-        self.assertTrue((expected == res).all())
+        self.assertListEqual(expected.to_ndarray().tolist(), res.to_ndarray().tolist())
 
     def test_append_empty(self):
         for dtype in TYPES:
             (ak_arr, pq_arr) = empty_append_test(dtype)
-            
-            self.assertTrue((ak_arr == pq_arr).all())
+
+            self.assertListEqual(ak_arr.to_ndarray().tolist(), pq_arr.to_ndarray().tolist())
 
     @pytest.mark.optional_parquet
     def test_against_standard_files(self):

--- a/tests/pdarray_creation_test.py
+++ b/tests/pdarray_creation_test.py
@@ -50,26 +50,26 @@ class PdarrayCreationTest(ArkoudaTest):
             ak.array(list(list(0)))
 
     def test_arange(self):
-        self.assertListEqual([0, 1, 2, 3, 4], ak.arange(0, 5, 1).to_ndarray().tolist())
-        self.assertListEqual([5, 4, 3, 2, 1], ak.arange(5, 0, -1).to_ndarray().tolist())
+        self.assertListEqual([0, 1, 2, 3, 4], ak.arange(0, 5, 1).to_list())
+        self.assertListEqual([5, 4, 3, 2, 1], ak.arange(5, 0, -1).to_list())
         self.assertListEqual(
             [-5, -6, -7, -8, -9],
-            ak.arange(-5, -10, -1).to_ndarray().tolist(),
+            ak.arange(-5, -10, -1).to_list(),
         )
-        self.assertListEqual([0, 2, 4, 6, 8], ak.arange(0, 10, 2).to_ndarray().tolist())
+        self.assertListEqual([0, 2, 4, 6, 8], ak.arange(0, 10, 2).to_list())
 
     def test_arange_dtype(self):
         # test dtype works with optional start/stride
         uint_stop = ak.arange(3, dtype=ak.uint64)
-        self.assertListEqual([0, 1, 2], uint_stop.to_ndarray().tolist())
+        self.assertListEqual([0, 1, 2], uint_stop.to_list())
         self.assertEqual(ak.uint64, uint_stop.dtype)
 
         uint_start_stop = ak.arange(3, 7, dtype=ak.uint64)
-        self.assertListEqual([3, 4, 5, 6], uint_start_stop.to_ndarray().tolist())
+        self.assertListEqual([3, 4, 5, 6], uint_start_stop.to_list())
         self.assertEqual(ak.uint64, uint_start_stop.dtype)
 
         uint_start_stop_stride = ak.arange(3, 7, 2, dtype=ak.uint64)
-        self.assertListEqual([3, 5], uint_start_stop_stride.to_ndarray().tolist())
+        self.assertListEqual([3, 5], uint_start_stop_stride.to_list())
         self.assertEqual(ak.uint64, uint_start_stop_stride.dtype)
 
         # test uint64 handles negatives correctly
@@ -77,25 +77,25 @@ class PdarrayCreationTest(ArkoudaTest):
         ak_arange_uint = ak.arange(-5, -10, -1, dtype=ak.uint64)
         # np_arange_uint = array([18446744073709551611, 18446744073709551610, 18446744073709551609,
         #        18446744073709551608, 18446744073709551607], dtype=uint64)
-        self.assertListEqual(np_arange_uint.tolist(), ak_arange_uint.to_ndarray().tolist())
+        self.assertListEqual(np_arange_uint.tolist(), ak_arange_uint.to_list())
         self.assertEqual(ak.uint64, ak_arange_uint.dtype)
 
         # test correct conversion to float64
         np_arange_float = np.arange(-5, -10, -1, dtype=np.float64)
         ak_arange_float = ak.arange(-5, -10, -1, dtype=ak.float64)
         # array([-5., -6., -7., -8., -9.])
-        self.assertListEqual(np_arange_float.tolist(), ak_arange_float.to_ndarray().tolist())
+        self.assertListEqual(np_arange_float.tolist(), ak_arange_float.to_list())
         self.assertEqual(ak.float64, ak_arange_float.dtype)
 
         # test correct conversion to bool
         expected_bool = [False, True, True, True, True]
         ak_arange_bool = ak.arange(0, 10, 2, dtype=ak.bool)
-        self.assertListEqual(expected_bool, ak_arange_bool.to_ndarray().tolist())
+        self.assertListEqual(expected_bool, ak_arange_bool.to_list())
         self.assertEqual(ak.bool, ak_arange_bool.dtype)
 
         # test uint64 input works
         uint_input = ak.arange(3, dtype=ak.uint64)
-        self.assertListEqual([0, 1, 2], uint_input.to_ndarray().tolist())
+        self.assertListEqual([0, 1, 2], uint_input.to_list())
         self.assertEqual(ak.uint64, uint_input.dtype)
 
         # test int_scalars covers uint8, uint16, uint32
@@ -171,7 +171,7 @@ class PdarrayCreationTest(ArkoudaTest):
     def test_randint_with_seed(self):
         values = ak.randint(1, 5, 10, seed=2)
 
-        self.assertListEqual([4, 3, 1, 3, 2, 4, 4, 2, 3, 4], values.to_ndarray().tolist())
+        self.assertListEqual([4, 3, 1, 3, 2, 4, 4, 2, 3, 4], values.to_list())
 
         values = ak.randint(1, 5, 10, dtype=ak.float64, seed=2)
         self.assertListEqual(
@@ -187,19 +187,19 @@ class PdarrayCreationTest(ArkoudaTest):
                 4.5939589352472314,
                 4.0337935981006172,
             ],
-            values.to_ndarray().tolist(),
+            values.to_list(),
         )
 
         values = ak.randint(1, 5, 10, dtype=ak.bool, seed=2)
         self.assertListEqual(
             [False, True, True, True, True, False, True, True, True, True],
-            values.to_ndarray().tolist(),
+            values.to_list(),
         )
 
         values = ak.randint(1, 5, 10, dtype=bool, seed=2)
         self.assertListEqual(
             [False, True, True, True, True, False, True, True, True, True],
-            values.to_ndarray().tolist(),
+            values.to_list(),
         )
 
         # Test that int_scalars covers uint8, uint16, uint32
@@ -219,13 +219,13 @@ class PdarrayCreationTest(ArkoudaTest):
         uArray = ak.uniform(size=3, low=0, high=5, seed=0)
         self.assertListEqual(
             [0.30013431967121934, 0.47383036230759112, 1.0441791878997098],
-            uArray.to_ndarray().tolist(),
+            uArray.to_list(),
         )
 
         uArray = ak.uniform(size=np.int64(3), low=np.int64(0), high=np.int64(5), seed=np.int64(0))
         self.assertListEqual(
             [0.30013431967121934, 0.47383036230759112, 1.0441791878997098],
-            uArray.to_ndarray().tolist(),
+            uArray.to_list(),
         )
 
         with self.assertRaises(TypeError):
@@ -452,7 +452,7 @@ class PdarrayCreationTest(ArkoudaTest):
         npda = pda.to_ndarray()
         pda = ak.standard_normal(np.int64(100), np.int64(1))
 
-        self.assertListEqual(npda.tolist(), pda.to_ndarray().tolist())
+        self.assertListEqual(npda.tolist(), pda.to_list())
 
         with self.assertRaises(TypeError):
             ak.standard_normal("100")
@@ -512,7 +512,7 @@ class PdarrayCreationTest(ArkoudaTest):
 
         self.assertListEqual(
             ["VW", "JEXI", "EBBX", "HG", "S", "WOVK", "U", "WL", "JCSD", "DSN"],
-            pda.to_ndarray().tolist(),
+            pda.to_list(),
         )
 
         pda = ak.random_strings_uniform(
@@ -521,13 +521,13 @@ class PdarrayCreationTest(ArkoudaTest):
 
         self.assertListEqual(
             ["VW", "JEXI", "EBBX", "HG", "S", "WOVK", "U", "WL", "JCSD", "DSN"],
-            pda.to_ndarray().tolist(),
+            pda.to_list(),
         )
 
         pda = ak.random_strings_uniform(minlen=1, maxlen=5, seed=1, size=10, characters="printable")
         self.assertListEqual(
             ["eL", "6<OD", "o-GO", " l", "m", "PV y", "f", "}.", "b3Yc", "Kw,"],
-            pda.to_ndarray().tolist(),
+            pda.to_list(),
         )
 
         # Test that int_scalars covers uint8, uint16, uint32
@@ -613,7 +613,7 @@ class PdarrayCreationTest(ArkoudaTest):
                 "QHQETTEZ",
                 "DJBPWJV",
             ],
-            pda.to_ndarray().tolist(),
+            pda.to_list(),
         )
 
         pda = ak.random_strings_lognormal(float(2), np.float64(0.25), np.int64(10), seed=1)
@@ -630,7 +630,7 @@ class PdarrayCreationTest(ArkoudaTest):
                 "QHQETTEZ",
                 "DJBPWJV",
             ],
-            pda.to_ndarray().tolist(),
+            pda.to_list(),
         )
 
         pda = ak.random_strings_lognormal(2, 0.25, 10, seed=1, characters="printable")
@@ -647,7 +647,7 @@ class PdarrayCreationTest(ArkoudaTest):
                 "0!u~e$Lm",
                 "9Q{TtHq",
             ],
-            pda.to_ndarray().tolist(),
+            pda.to_list(),
         )
 
         pda = ak.random_strings_lognormal(
@@ -666,7 +666,7 @@ class PdarrayCreationTest(ArkoudaTest):
                 "0!u~e$Lm",
                 "9Q{TtHq",
             ],
-            pda.to_ndarray().tolist(),
+            pda.to_list(),
         )
 
     def test_mulitdimensional_array_creation(self):

--- a/tests/pdarray_creation_test.py
+++ b/tests/pdarray_creation_test.py
@@ -50,40 +50,26 @@ class PdarrayCreationTest(ArkoudaTest):
             ak.array(list(list(0)))
 
     def test_arange(self):
+        self.assertListEqual([0, 1, 2, 3, 4], ak.arange(0, 5, 1).to_ndarray().tolist())
+        self.assertListEqual([5, 4, 3, 2, 1], ak.arange(5, 0, -1).to_ndarray().tolist())
         self.assertListEqual(
-            ak.array([0, 1, 2, 3, 4]).to_ndarray().tolist(), ak.arange(0, 5, 1).to_ndarray().tolist()
-        )
-        self.assertListEqual(
-            ak.array([5, 4, 3, 2, 1]).to_ndarray().tolist(), ak.arange(5, 0, -1).to_ndarray().tolist()
-        )
-        self.assertListEqual(
-            ak.array([-5, -6, -7, -8, -9]).to_ndarray().tolist(),
+            [-5, -6, -7, -8, -9],
             ak.arange(-5, -10, -1).to_ndarray().tolist(),
         )
-        self.assertListEqual(
-            ak.array([0, 2, 4, 6, 8]).to_ndarray().tolist(), ak.arange(0, 10, 2).to_ndarray().tolist()
-        )
+        self.assertListEqual([0, 2, 4, 6, 8], ak.arange(0, 10, 2).to_ndarray().tolist())
 
     def test_arange_dtype(self):
         # test dtype works with optional start/stride
-        expected_stop = ak.array([0, 1, 2])
         uint_stop = ak.arange(3, dtype=ak.uint64)
-        self.assertListEqual(expected_stop.to_ndarray().tolist(), uint_stop.to_ndarray().tolist())
+        self.assertListEqual([0, 1, 2], uint_stop.to_ndarray().tolist())
         self.assertEqual(ak.uint64, uint_stop.dtype)
 
-        expected_start_stop = ak.array([3, 4, 5, 6])
         uint_start_stop = ak.arange(3, 7, dtype=ak.uint64)
-        self.assertListEqual(
-            expected_start_stop.to_ndarray().tolist(), uint_start_stop.to_ndarray().tolist()
-        )
+        self.assertListEqual([3, 4, 5, 6], uint_start_stop.to_ndarray().tolist())
         self.assertEqual(ak.uint64, uint_start_stop.dtype)
 
-        expected_start_stop_stride = ak.array([3, 5])
         uint_start_stop_stride = ak.arange(3, 7, 2, dtype=ak.uint64)
-        self.assertListEqual(
-            expected_start_stop_stride.to_ndarray().tolist(),
-            uint_start_stop_stride.to_ndarray().tolist(),
-        )
+        self.assertListEqual([3, 5], uint_start_stop_stride.to_ndarray().tolist())
         self.assertEqual(ak.uint64, uint_start_stop_stride.dtype)
 
         # test uint64 handles negatives correctly
@@ -102,15 +88,14 @@ class PdarrayCreationTest(ArkoudaTest):
         self.assertEqual(ak.float64, ak_arange_float.dtype)
 
         # test correct conversion to bool
-        expected_bool = ak.array([False, True, True, True, True])
+        expected_bool = [False, True, True, True, True]
         ak_arange_bool = ak.arange(0, 10, 2, dtype=ak.bool)
-        self.assertListEqual(expected_bool.to_ndarray().tolist(), ak_arange_bool.to_ndarray().tolist())
+        self.assertListEqual(expected_bool, ak_arange_bool.to_ndarray().tolist())
         self.assertEqual(ak.bool, ak_arange_bool.dtype)
 
         # test uint64 input works
-        expected = ak.array([0, 1, 2])
         uint_input = ak.arange(3, dtype=ak.uint64)
-        self.assertListEqual(expected.to_ndarray().tolist(), uint_input.to_ndarray().tolist())
+        self.assertListEqual([0, 1, 2], uint_input.to_ndarray().tolist())
         self.assertEqual(ak.uint64, uint_input.dtype)
 
         # test int_scalars covers uint8, uint16, uint32
@@ -186,44 +171,34 @@ class PdarrayCreationTest(ArkoudaTest):
     def test_randint_with_seed(self):
         values = ak.randint(1, 5, 10, seed=2)
 
-        self.assertListEqual(
-            ak.array([4, 3, 1, 3, 2, 4, 4, 2, 3, 4]).to_ndarray().tolist(), values.to_ndarray().tolist()
-        )
+        self.assertListEqual([4, 3, 1, 3, 2, 4, 4, 2, 3, 4], values.to_ndarray().tolist())
 
         values = ak.randint(1, 5, 10, dtype=ak.float64, seed=2)
         self.assertListEqual(
-            ak.array(
-                [
-                    2.9160772326374946,
-                    4.353429832157099,
-                    4.5392023718621486,
-                    4.4019932101126606,
-                    3.3745324569952304,
-                    1.1642002901528308,
-                    4.4714086874555292,
-                    3.7098921109084522,
-                    4.5939589352472314,
-                    4.0337935981006172,
-                ]
-            )
-            .to_ndarray()
-            .tolist(),
+            [
+                2.9160772326374946,
+                4.353429832157099,
+                4.5392023718621486,
+                4.4019932101126606,
+                3.3745324569952304,
+                1.1642002901528308,
+                4.4714086874555292,
+                3.7098921109084522,
+                4.5939589352472314,
+                4.0337935981006172,
+            ],
             values.to_ndarray().tolist(),
         )
 
         values = ak.randint(1, 5, 10, dtype=ak.bool, seed=2)
         self.assertListEqual(
-            ak.array([False, True, True, True, True, False, True, True, True, True])
-            .to_ndarray()
-            .tolist(),
+            [False, True, True, True, True, False, True, True, True, True],
             values.to_ndarray().tolist(),
         )
 
         values = ak.randint(1, 5, 10, dtype=bool, seed=2)
         self.assertListEqual(
-            ak.array([False, True, True, True, True, False, True, True, True, True])
-            .to_ndarray()
-            .tolist(),
+            [False, True, True, True, True, False, True, True, True, True],
             values.to_ndarray().tolist(),
         )
 
@@ -243,17 +218,13 @@ class PdarrayCreationTest(ArkoudaTest):
 
         uArray = ak.uniform(size=3, low=0, high=5, seed=0)
         self.assertListEqual(
-            ak.array([0.30013431967121934, 0.47383036230759112, 1.0441791878997098])
-            .to_ndarray()
-            .tolist(),
+            [0.30013431967121934, 0.47383036230759112, 1.0441791878997098],
             uArray.to_ndarray().tolist(),
         )
 
         uArray = ak.uniform(size=np.int64(3), low=np.int64(0), high=np.int64(5), seed=np.int64(0))
         self.assertListEqual(
-            ak.array([0.30013431967121934, 0.47383036230759112, 1.0441791878997098])
-            .to_ndarray()
-            .tolist(),
+            [0.30013431967121934, 0.47383036230759112, 1.0441791878997098],
             uArray.to_ndarray().tolist(),
         )
 
@@ -540,9 +511,7 @@ class PdarrayCreationTest(ArkoudaTest):
         pda = ak.random_strings_uniform(minlen=1, maxlen=5, seed=1, size=10)
 
         self.assertListEqual(
-            ak.array(["VW", "JEXI", "EBBX", "HG", "S", "WOVK", "U", "WL", "JCSD", "DSN"])
-            .to_ndarray()
-            .tolist(),
+            ["VW", "JEXI", "EBBX", "HG", "S", "WOVK", "U", "WL", "JCSD", "DSN"],
             pda.to_ndarray().tolist(),
         )
 
@@ -551,17 +520,13 @@ class PdarrayCreationTest(ArkoudaTest):
         )
 
         self.assertListEqual(
-            ak.array(["VW", "JEXI", "EBBX", "HG", "S", "WOVK", "U", "WL", "JCSD", "DSN"])
-            .to_ndarray()
-            .tolist(),
+            ["VW", "JEXI", "EBBX", "HG", "S", "WOVK", "U", "WL", "JCSD", "DSN"],
             pda.to_ndarray().tolist(),
         )
 
         pda = ak.random_strings_uniform(minlen=1, maxlen=5, seed=1, size=10, characters="printable")
         self.assertListEqual(
-            ak.array(["eL", "6<OD", "o-GO", " l", "m", "PV y", "f", "}.", "b3Yc", "Kw,"])
-            .to_ndarray()
-            .tolist(),
+            ["eL", "6<OD", "o-GO", " l", "m", "PV y", "f", "}.", "b3Yc", "Kw,"],
             pda.to_ndarray().tolist(),
         )
 
@@ -635,92 +600,72 @@ class PdarrayCreationTest(ArkoudaTest):
 
     def test_random_strings_lognormal_with_seed(self):
         pda = ak.random_strings_lognormal(2, 0.25, 10, seed=1)
-
         self.assertListEqual(
-            ak.array(
-                [
-                    "VWHJEX",
-                    "BEBBXJHGM",
-                    "RWOVKBUR",
-                    "LNJCSDXD",
-                    "NKEDQC",
-                    "GIBAFPAVWF",
-                    "IJIFHGDHKA",
-                    "VUDYRA",
-                    "QHQETTEZ",
-                    "DJBPWJV",
-                ]
-            )
-            .to_ndarray()
-            .tolist(),
+            [
+                "VWHJEX",
+                "BEBBXJHGM",
+                "RWOVKBUR",
+                "LNJCSDXD",
+                "NKEDQC",
+                "GIBAFPAVWF",
+                "IJIFHGDHKA",
+                "VUDYRA",
+                "QHQETTEZ",
+                "DJBPWJV",
+            ],
             pda.to_ndarray().tolist(),
         )
 
         pda = ak.random_strings_lognormal(float(2), np.float64(0.25), np.int64(10), seed=1)
-
         self.assertListEqual(
-            ak.array(
-                [
-                    "VWHJEX",
-                    "BEBBXJHGM",
-                    "RWOVKBUR",
-                    "LNJCSDXD",
-                    "NKEDQC",
-                    "GIBAFPAVWF",
-                    "IJIFHGDHKA",
-                    "VUDYRA",
-                    "QHQETTEZ",
-                    "DJBPWJV",
-                ]
-            )
-            .to_ndarray()
-            .tolist(),
+            [
+                "VWHJEX",
+                "BEBBXJHGM",
+                "RWOVKBUR",
+                "LNJCSDXD",
+                "NKEDQC",
+                "GIBAFPAVWF",
+                "IJIFHGDHKA",
+                "VUDYRA",
+                "QHQETTEZ",
+                "DJBPWJV",
+            ],
             pda.to_ndarray().tolist(),
         )
 
         pda = ak.random_strings_lognormal(2, 0.25, 10, seed=1, characters="printable")
-
         self.assertListEqual(
-            ak.array(
-                [
-                    "eL96<O",
-                    ")o-GOe lR",
-                    ")PV yHf(",
-                    "._b3Yc&K",
-                    ",7Wjef",
-                    "R{lQs_g]5T",
-                    "E[2dk\\2a9J",
-                    "I*VknZ",
-                    "0!u~e$Lm",
-                    "9Q{TtHq",
-                ]
-            )
-            .to_ndarray()
-            .tolist(),
+            [
+                "eL96<O",
+                ")o-GOe lR",
+                ")PV yHf(",
+                "._b3Yc&K",
+                ",7Wjef",
+                "R{lQs_g]5T",
+                "E[2dk\\2a9J",
+                "I*VknZ",
+                "0!u~e$Lm",
+                "9Q{TtHq",
+            ],
             pda.to_ndarray().tolist(),
         )
 
         pda = ak.random_strings_lognormal(
             np.int64(2), np.float64(0.25), np.int64(10), seed=1, characters="printable"
         )
-
         self.assertListEqual(
-            ak.array(
-                [
-                    "eL96<O",
-                    ")o-GOe lR",
-                    ")PV yHf(",
-                    "._b3Yc&K",
-                    ",7Wjef",
-                    "R{lQs_g]5T",
-                    "E[2dk\\2a9J",
-                    "I*VknZ",
-                    "0!u~e$Lm",
-                    "9Q{TtHq",
-                ]
-            )
-            .to_ndarray()
-            .tolist(),
+            [
+                "eL96<O",
+                ")o-GOe lR",
+                ")PV yHf(",
+                "._b3Yc&K",
+                ",7Wjef",
+                "R{lQs_g]5T",
+                "E[2dk\\2a9J",
+                "I*VknZ",
+                "0!u~e$Lm",
+                "9Q{TtHq",
+            ],
             pda.to_ndarray().tolist(),
         )
 

--- a/tests/pdarray_creation_test.py
+++ b/tests/pdarray_creation_test.py
@@ -50,10 +50,19 @@ class PdarrayCreationTest(ArkoudaTest):
             ak.array(list(list(0)))
 
     def test_arange(self):
-        self.assertTrue((ak.array([0, 1, 2, 3, 4]) == ak.arange(0, 5, 1)).all())
-        self.assertTrue((ak.array([5, 4, 3, 2, 1]) == ak.arange(5, 0, -1)).all())
-        self.assertTrue((ak.array([-5, -6, -7, -8, -9]) == ak.arange(-5, -10, -1)).all())
-        self.assertTrue((ak.array([0, 2, 4, 6, 8]) == ak.arange(0, 10, 2)).all())
+        self.assertListEqual(
+            ak.array([0, 1, 2, 3, 4]).to_ndarray().tolist(), ak.arange(0, 5, 1).to_ndarray().tolist()
+        )
+        self.assertListEqual(
+            ak.array([5, 4, 3, 2, 1]).to_ndarray().tolist(), ak.arange(5, 0, -1).to_ndarray().tolist()
+        )
+        self.assertListEqual(
+            ak.array([-5, -6, -7, -8, -9]).to_ndarray().tolist(),
+            ak.arange(-5, -10, -1).to_ndarray().tolist(),
+        )
+        self.assertListEqual(
+            ak.array([0, 2, 4, 6, 8]).to_ndarray().tolist(), ak.arange(0, 10, 2).to_ndarray().tolist()
+        )
 
     def test_arange_dtype(self):
         # test dtype works with optional start/stride
@@ -162,14 +171,14 @@ class PdarrayCreationTest(ArkoudaTest):
         with self.assertRaises(ValueError):
             ak.randint(low=1, high=0, size=1, dtype=ak.float64)
 
-        with self.assertRaises(TypeError):              
-            ak.randint(0,1,'1000')
+        with self.assertRaises(TypeError):
+            ak.randint(0, 1, "1000")
 
-        with self.assertRaises(TypeError):              
-            ak.randint('0',1,1000)
-        
-        with self.assertRaises(TypeError):              
-            ak.randint(0,'1',1000)
+        with self.assertRaises(TypeError):
+            ak.randint("0", 1, 1000)
+
+        with self.assertRaises(TypeError):
+            ak.randint(0, "1", 1000)
 
         # Test that int_scalars covers uint8, uint16, uint32
         ak.randint(low=np.uint8(1), high=np.uint16(100), size=np.uint32(100))
@@ -177,37 +186,45 @@ class PdarrayCreationTest(ArkoudaTest):
     def test_randint_with_seed(self):
         values = ak.randint(1, 5, 10, seed=2)
 
-        self.assertTrue((ak.array([4, 3, 1, 3, 2, 4, 4, 2, 3, 4]) == values).all())
+        self.assertListEqual(
+            ak.array([4, 3, 1, 3, 2, 4, 4, 2, 3, 4]).to_ndarray().tolist(), values.to_ndarray().tolist()
+        )
 
         values = ak.randint(1, 5, 10, dtype=ak.float64, seed=2)
-        self.assertTrue(
-            (
-                ak.array(
-                    [
-                        2.9160772326374946,
-                        4.353429832157099,
-                        4.5392023718621486,
-                        4.4019932101126606,
-                        3.3745324569952304,
-                        1.1642002901528308,
-                        4.4714086874555292,
-                        3.7098921109084522,
-                        4.5939589352472314,
-                        4.0337935981006172,
-                    ]
-                )
-                == values
-            ).all()
+        self.assertListEqual(
+            ak.array(
+                [
+                    2.9160772326374946,
+                    4.353429832157099,
+                    4.5392023718621486,
+                    4.4019932101126606,
+                    3.3745324569952304,
+                    1.1642002901528308,
+                    4.4714086874555292,
+                    3.7098921109084522,
+                    4.5939589352472314,
+                    4.0337935981006172,
+                ]
+            )
+            .to_ndarray()
+            .tolist(),
+            values.to_ndarray().tolist(),
         )
 
         values = ak.randint(1, 5, 10, dtype=ak.bool, seed=2)
-        self.assertTrue(
-            (ak.array([False, True, True, True, True, False, True, True, True, True]) == values).all()
+        self.assertListEqual(
+            ak.array([False, True, True, True, True, False, True, True, True, True])
+            .to_ndarray()
+            .tolist(),
+            values.to_ndarray().tolist(),
         )
 
         values = ak.randint(1, 5, 10, dtype=bool, seed=2)
-        self.assertTrue(
-            (ak.array([False, True, True, True, True, False, True, True, True, True]) == values).all()
+        self.assertListEqual(
+            ak.array([False, True, True, True, True, False, True, True, True, True])
+            .to_ndarray()
+            .tolist(),
+            values.to_ndarray().tolist(),
         )
 
         # Test that int_scalars covers uint8, uint16, uint32
@@ -225,13 +242,19 @@ class PdarrayCreationTest(ArkoudaTest):
         self.assertEqual([3], testArray.shape)
 
         uArray = ak.uniform(size=3, low=0, high=5, seed=0)
-        self.assertTrue(
-            (ak.array([0.30013431967121934, 0.47383036230759112, 1.0441791878997098]) == uArray).all()
+        self.assertListEqual(
+            ak.array([0.30013431967121934, 0.47383036230759112, 1.0441791878997098])
+            .to_ndarray()
+            .tolist(),
+            uArray.to_ndarray().tolist(),
         )
 
         uArray = ak.uniform(size=np.int64(3), low=np.int64(0), high=np.int64(5), seed=np.int64(0))
-        self.assertTrue(
-            (ak.array([0.30013431967121934, 0.47383036230759112, 1.0441791878997098]) == uArray).all()
+        self.assertListEqual(
+            ak.array([0.30013431967121934, 0.47383036230759112, 1.0441791878997098])
+            .to_ndarray()
+            .tolist(),
+            uArray.to_ndarray().tolist(),
         )
 
         with self.assertRaises(TypeError):
@@ -241,7 +264,7 @@ class PdarrayCreationTest(ArkoudaTest):
             ak.uniform(low=0, high="5", size=100)
 
         with self.assertRaises(TypeError):
-            ak.uniform(low=0, high=5, size='100')
+            ak.uniform(low=0, high=5, size="100")
 
         # Test that int_scalars covers uint8, uint16, uint32
         ak.uniform(low=np.uint8(0), high=5, size=np.uint32(100))
@@ -270,14 +293,14 @@ class PdarrayCreationTest(ArkoudaTest):
             ak.zeros(5, dtype=ak.uint8)
 
         with self.assertRaises(TypeError):
-            ak.zeros(5, dtype=str)      
+            ak.zeros(5, dtype=str)
 
         # Test that int_scalars covers uint8, uint16, uint32
         ak.zeros(np.uint8(5), dtype=ak.int64)
         ak.zeros(np.uint16(5), dtype=ak.int64)
         ak.zeros(np.uint32(5), dtype=ak.int64)
-            
-    def test_ones(self):   
+
+    def test_ones(self):
         intOnes = ak.ones(5, dtype=int)
         self.assertIsInstance(intOnes, ak.pdarray)
         self.assertEqual(int, intOnes.dtype)
@@ -310,8 +333,8 @@ class PdarrayCreationTest(ArkoudaTest):
         ak.ones(np.uint8(5), dtype=ak.int64)
         ak.ones(np.uint16(5), dtype=ak.int64)
         ak.ones(np.uint32(5), dtype=ak.int64)
-        
-    def test_ones_like(self):      
+
+    def test_ones_like(self):
         intOnes = ak.ones(5, dtype=ak.int64)
         intOnesLike = ak.ones_like(intOnes)
 
@@ -424,20 +447,20 @@ class PdarrayCreationTest(ArkoudaTest):
         pda = ak.linspace(start=float(5.0), stop=float(0.0), length=np.int64(6))
         self.assertEqual(5.0000, pda[0])
         self.assertEqual(0.0000, pda[5])
-        
-        with self.assertRaises(TypeError):        
-            ak.linspace(0,'100', 1000)
 
-        with self.assertRaises(TypeError):        
-            ak.linspace('0',100, 1000)
+        with self.assertRaises(TypeError):
+            ak.linspace(0, "100", 1000)
 
-        with self.assertRaises(TypeError):          
-            ak.linspace(0,100,'1000')           
+        with self.assertRaises(TypeError):
+            ak.linspace("0", 100, 1000)
+
+        with self.assertRaises(TypeError):
+            ak.linspace(0, 100, "1000")
 
         # Test that int_scalars covers uint8, uint16, uint32
-        ak.linspace(np.uint8(0),np.uint16(100),np.uint32(1000))
-        ak.linspace(np.uint32(0),np.uint16(100),np.uint8(1000))
-        ak.linspace(np.uint16(0),np.uint8(100),np.uint8(1000))
+        ak.linspace(np.uint8(0), np.uint16(100), np.uint32(1000))
+        ak.linspace(np.uint32(0), np.uint16(100), np.uint8(1000))
+        ak.linspace(np.uint16(0), np.uint8(100), np.uint8(1000))
 
     def test_standard_normal(self):
         pda = ak.standard_normal(100)
@@ -457,19 +480,19 @@ class PdarrayCreationTest(ArkoudaTest):
 
         npda = pda.to_ndarray()
         pda = ak.standard_normal(np.int64(100), np.int64(1))
-        
-        self.assertTrue((npda ==  pda.to_ndarray()).all())
 
-        with self.assertRaises(TypeError):          
-            ak.standard_normal('100')          
-   
-        with self.assertRaises(TypeError):          
-            ak.standard_normal(100.0)          
+        self.assertListEqual(npda.tolist(), pda.to_ndarray().tolist())
 
-        with self.assertRaises(ValueError):          
+        with self.assertRaises(TypeError):
+            ak.standard_normal("100")
+
+        with self.assertRaises(TypeError):
+            ak.standard_normal(100.0)
+
+        with self.assertRaises(ValueError):
             ak.standard_normal(-1)
 
-        # Test that int_scalars covers uint8, uint16, uint32 
+        # Test that int_scalars covers uint8, uint16, uint32
         ak.standard_normal(np.uint8(100))
         ak.standard_normal(np.uint16(100))
         ak.standard_normal(np.uint32(100))
@@ -503,39 +526,53 @@ class PdarrayCreationTest(ArkoudaTest):
 
         with self.assertRaises(ValueError):
             ak.random_strings_uniform(maxlen=5, minlen=5, size=10)
-        
-        with self.assertRaises(TypeError):          
-            ak.random_strings_uniform(minlen='1', maxlen=5, size=10)          
 
-        with self.assertRaises(TypeError):          
-            ak.random_strings_uniform( minlen=1, maxlen='5', size=10)
+        with self.assertRaises(TypeError):
+            ak.random_strings_uniform(minlen="1", maxlen=5, size=10)
 
-        with self.assertRaises(TypeError):          
-            ak.random_strings_uniform(minlen=1, maxlen=5, size='10')          
+        with self.assertRaises(TypeError):
+            ak.random_strings_uniform(minlen=1, maxlen="5", size=10)
 
+        with self.assertRaises(TypeError):
+            ak.random_strings_uniform(minlen=1, maxlen=5, size="10")
 
     def test_random_strings_uniform_with_seed(self):
         pda = ak.random_strings_uniform(minlen=1, maxlen=5, seed=1, size=10)
 
-        self.assertTrue(
-            (ak.array(["VW", "JEXI", "EBBX", "HG", "S", "WOVK", "U", "WL", "JCSD", "DSN"]) == pda).all()
+        self.assertListEqual(
+            ak.array(["VW", "JEXI", "EBBX", "HG", "S", "WOVK", "U", "WL", "JCSD", "DSN"])
+            .to_ndarray()
+            .tolist(),
+            pda.to_ndarray().tolist(),
         )
 
         pda = ak.random_strings_uniform(
             minlen=np.int64(1), maxlen=np.int64(5), seed=np.int64(1), size=np.int64(10)
         )
 
-        self.assertTrue(
-            (ak.array(["VW", "JEXI", "EBBX", "HG", "S", "WOVK", "U", "WL", "JCSD", "DSN"]) == pda).all()
+        self.assertListEqual(
+            ak.array(["VW", "JEXI", "EBBX", "HG", "S", "WOVK", "U", "WL", "JCSD", "DSN"])
+            .to_ndarray()
+            .tolist(),
+            pda.to_ndarray().tolist(),
         )
 
         pda = ak.random_strings_uniform(minlen=1, maxlen=5, seed=1, size=10, characters="printable")
-        self.assertTrue(
-            (ak.array(["eL", "6<OD", "o-GO", " l", "m", "PV y", "f", "}.", "b3Yc", "Kw,"]) == pda).all()
+        self.assertListEqual(
+            ak.array(["eL", "6<OD", "o-GO", " l", "m", "PV y", "f", "}.", "b3Yc", "Kw,"])
+            .to_ndarray()
+            .tolist(),
+            pda.to_ndarray().tolist(),
         )
 
         # Test that int_scalars covers uint8, uint16, uint32
-        pda = ak.random_strings_uniform(minlen=np.uint8(1), maxlen=np.uint32(5), seed=np.uint16(1), size=np.uint8(10), characters='printable')
+        pda = ak.random_strings_uniform(
+            minlen=np.uint8(1),
+            maxlen=np.uint32(5),
+            seed=np.uint16(1),
+            size=np.uint8(10),
+            characters="printable",
+        )
 
     def test_random_strings_lognormal(self):
         pda = ak.random_strings_lognormal(2, 0.25, 100, characters="printable")
@@ -583,108 +620,108 @@ class PdarrayCreationTest(ArkoudaTest):
         self.assertIsInstance(pda, ak.Strings)
         self.assertEqual(100, len(pda))
         self.assertEqual(str, pda.dtype)
-        
-        with self.assertRaises(TypeError):          
-            ak.random_strings_lognormal('2', 0.25, 100)
-      
-        with self.assertRaises(TypeError):          
-            ak.random_strings_lognormal(2, 0.25, '100')          
 
-        with self.assertRaises(TypeError):          
+        with self.assertRaises(TypeError):
+            ak.random_strings_lognormal("2", 0.25, 100)
+
+        with self.assertRaises(TypeError):
+            ak.random_strings_lognormal(2, 0.25, "100")
+
+        with self.assertRaises(TypeError):
             ak.random_strings_lognormal(2, 0.25, 100, 1000000)
 
-        # Test that int_scalars covers uint8, uint16, uint32 
+        # Test that int_scalars covers uint8, uint16, uint32
         ak.random_strings_lognormal(np.uint8(2), 0.25, np.uint16(100))
 
     def test_random_strings_lognormal_with_seed(self):
         pda = ak.random_strings_lognormal(2, 0.25, 10, seed=1)
 
-        self.assertTrue(
-            (
-                ak.array(
-                    [
-                        "VWHJEX",
-                        "BEBBXJHGM",
-                        "RWOVKBUR",
-                        "LNJCSDXD",
-                        "NKEDQC",
-                        "GIBAFPAVWF",
-                        "IJIFHGDHKA",
-                        "VUDYRA",
-                        "QHQETTEZ",
-                        "DJBPWJV",
-                    ]
-                )
-                == pda
-            ).all()
+        self.assertListEqual(
+            ak.array(
+                [
+                    "VWHJEX",
+                    "BEBBXJHGM",
+                    "RWOVKBUR",
+                    "LNJCSDXD",
+                    "NKEDQC",
+                    "GIBAFPAVWF",
+                    "IJIFHGDHKA",
+                    "VUDYRA",
+                    "QHQETTEZ",
+                    "DJBPWJV",
+                ]
+            )
+            .to_ndarray()
+            .tolist(),
+            pda.to_ndarray().tolist(),
         )
 
         pda = ak.random_strings_lognormal(float(2), np.float64(0.25), np.int64(10), seed=1)
 
-        self.assertTrue(
-            (
-                ak.array(
-                    [
-                        "VWHJEX",
-                        "BEBBXJHGM",
-                        "RWOVKBUR",
-                        "LNJCSDXD",
-                        "NKEDQC",
-                        "GIBAFPAVWF",
-                        "IJIFHGDHKA",
-                        "VUDYRA",
-                        "QHQETTEZ",
-                        "DJBPWJV",
-                    ]
-                )
-                == pda
-            ).all()
+        self.assertListEqual(
+            ak.array(
+                [
+                    "VWHJEX",
+                    "BEBBXJHGM",
+                    "RWOVKBUR",
+                    "LNJCSDXD",
+                    "NKEDQC",
+                    "GIBAFPAVWF",
+                    "IJIFHGDHKA",
+                    "VUDYRA",
+                    "QHQETTEZ",
+                    "DJBPWJV",
+                ]
+            )
+            .to_ndarray()
+            .tolist(),
+            pda.to_ndarray().tolist(),
         )
 
         pda = ak.random_strings_lognormal(2, 0.25, 10, seed=1, characters="printable")
 
-        self.assertTrue(
-            (
-                ak.array(
-                    [
-                        "eL96<O",
-                        ")o-GOe lR",
-                        ")PV yHf(",
-                        "._b3Yc&K",
-                        ",7Wjef",
-                        "R{lQs_g]5T",
-                        "E[2dk\\2a9J",
-                        "I*VknZ",
-                        "0!u~e$Lm",
-                        "9Q{TtHq",
-                    ]
-                )
-                == pda
-            ).all()
+        self.assertListEqual(
+            ak.array(
+                [
+                    "eL96<O",
+                    ")o-GOe lR",
+                    ")PV yHf(",
+                    "._b3Yc&K",
+                    ",7Wjef",
+                    "R{lQs_g]5T",
+                    "E[2dk\\2a9J",
+                    "I*VknZ",
+                    "0!u~e$Lm",
+                    "9Q{TtHq",
+                ]
+            )
+            .to_ndarray()
+            .tolist(),
+            pda.to_ndarray().tolist(),
         )
 
         pda = ak.random_strings_lognormal(
             np.int64(2), np.float64(0.25), np.int64(10), seed=1, characters="printable"
         )
 
-        self.assertTrue(
-            (
-                ak.array(
-                    [
-                        "eL96<O",
-                        ")o-GOe lR",
-                        ")PV yHf(",
-                        "._b3Yc&K",
-                        ",7Wjef",
-                        "R{lQs_g]5T",
-                        "E[2dk\\2a9J",
-                        "I*VknZ",
-                        "0!u~e$Lm",
-                        "9Q{TtHq",
-                    ]
-                )
-                == pda
-            ).all()
+        self.assertListEqual(
+            ak.array(
+                [
+                    "eL96<O",
+                    ")o-GOe lR",
+                    ")PV yHf(",
+                    "._b3Yc&K",
+                    ",7Wjef",
+                    "R{lQs_g]5T",
+                    "E[2dk\\2a9J",
+                    "I*VknZ",
+                    "0!u~e$Lm",
+                    "9Q{TtHq",
+                ]
+            )
+            .to_ndarray()
+            .tolist(),
+            pda.to_ndarray().tolist(),
         )
 
     def test_mulitdimensional_array_creation(self):
@@ -771,15 +808,15 @@ class PdarrayCreationTest(ArkoudaTest):
 
         ones.fill(2)
         self.assertTrue((2 == ones.to_ndarray()).all())
-        
-        ones.fill(np.int64(2))  
-        self.assertTrue((np.int64(2) == ones.to_ndarray()).all())     
-        
-        ones.fill(float(2))  
-        self.assertTrue((float(2) == ones.to_ndarray()).all())  
-        
-        ones.fill(np.float64(2))  
-        self.assertTrue((np.float64(2) == ones.to_ndarray()).all()) 
+
+        ones.fill(np.int64(2))
+        self.assertTrue((np.int64(2) == ones.to_ndarray()).all())
+
+        ones.fill(float(2))
+        self.assertTrue((float(2) == ones.to_ndarray()).all())
+
+        ones.fill(np.float64(2))
+        self.assertTrue((np.float64(2) == ones.to_ndarray()).all())
 
         # Test that int_scalars covers uint8, uint16, uint32
         ones.fill(np.uint8(2))

--- a/tests/regex_test.py
+++ b/tests/regex_test.py
@@ -51,33 +51,23 @@ class RegexTest(ArkoudaTest):
         re_match = [re.match(pattern, strings[i]) for i in range(strings.size)]
         re_fullmatch = [re.fullmatch(pattern, strings[i]) for i in range(strings.size)]
 
-        self.assertListEqual(
-            ak_search.matched().to_ndarray().tolist(), [m is not None for m in re_search]
-        )
-        self.assertListEqual(ak_match.matched().to_ndarray().tolist(), [m is not None for m in re_match])
-        self.assertListEqual(
-            ak_fullmatch.matched().to_ndarray().tolist(), [m is not None for m in re_fullmatch]
-        )
+        self.assertListEqual(ak_search.matched().to_list(), [m is not None for m in re_search])
+        self.assertListEqual(ak_match.matched().to_list(), [m is not None for m in re_match])
+        self.assertListEqual(ak_fullmatch.matched().to_list(), [m is not None for m in re_fullmatch])
 
         self.assertListEqual(
-            ak_search.start().to_ndarray().tolist(), [m.start() for m in re_search if m is not None]
+            ak_search.start().to_list(), [m.start() for m in re_search if m is not None]
         )
+        self.assertListEqual(ak_match.start().to_list(), [m.start() for m in re_match if m is not None])
         self.assertListEqual(
-            ak_match.start().to_ndarray().tolist(), [m.start() for m in re_match if m is not None]
-        )
-        self.assertListEqual(
-            ak_fullmatch.start().to_ndarray().tolist(),
+            ak_fullmatch.start().to_list(),
             [m.start() for m in re_fullmatch if m is not None],
         )
 
+        self.assertListEqual(ak_search.end().to_list(), [m.end() for m in re_search if m is not None])
+        self.assertListEqual(ak_match.end().to_list(), [m.end() for m in re_match if m is not None])
         self.assertListEqual(
-            ak_search.end().to_ndarray().tolist(), [m.end() for m in re_search if m is not None]
-        )
-        self.assertListEqual(
-            ak_match.end().to_ndarray().tolist(), [m.end() for m in re_match if m is not None]
-        )
-        self.assertListEqual(
-            ak_fullmatch.end().to_ndarray().tolist(), [m.end() for m in re_fullmatch if m is not None]
+            ak_fullmatch.end().to_list(), [m.end() for m in re_fullmatch if m is not None]
         )
 
         self.assertEqual(ak_search.match_type(), "SEARCH")
@@ -88,27 +78,27 @@ class RegexTest(ArkoudaTest):
         match_matches, match_origins = ak_match.find_matches(return_match_origins=True)
         fullmatch_matches, fullmatch_origins = ak_fullmatch.find_matches(return_match_origins=True)
         self.assertListEqual(
-            search_matches.to_ndarray().tolist(),
+            search_matches.to_list(),
             [m.string[m.start() : m.end()] for m in re_search if m is not None],
         )
         self.assertListEqual(
-            search_origins.to_ndarray().tolist(),
+            search_origins.to_list(),
             [i for i in range(len(re_search)) if re_search[i] is not None],
         )
         self.assertListEqual(
-            match_matches.to_ndarray().tolist(),
+            match_matches.to_list(),
             [m.string[m.start() : m.end()] for m in re_match if m is not None],
         )
         self.assertListEqual(
-            match_origins.to_ndarray().tolist(),
+            match_origins.to_list(),
             [i for i in range(len(re_match)) if re_match[i] is not None],
         )
         self.assertListEqual(
-            fullmatch_matches.to_ndarray().tolist(),
+            fullmatch_matches.to_list(),
             [m.string[m.start() : m.end()] for m in re_fullmatch if m is not None],
         )
         self.assertListEqual(
-            fullmatch_origins.to_ndarray().tolist(),
+            fullmatch_origins.to_list(),
             [i for i in range(len(re_fullmatch)) if re_fullmatch[i] is not None],
         )
 
@@ -119,20 +109,20 @@ class RegexTest(ArkoudaTest):
         ak_captures = tug_of_war.search("(\\w+) (\\w+)")
         re_captures = [re.search("(\\w+) (\\w+)", tug_of_war[i]) for i in range(tug_of_war.size)]
         self.assertListEqual(
-            ak_captures.group().to_ndarray().tolist(), [m.group() for m in re_captures if m is not None]
+            ak_captures.group().to_list(), [m.group() for m in re_captures if m is not None]
         )
         self.assertListEqual(
-            ak_captures.group(1).to_ndarray().tolist(),
+            ak_captures.group(1).to_list(),
             [m.group(1) for m in re_captures if m is not None],
         )
         self.assertListEqual(
-            ak_captures.group(2).to_ndarray().tolist(),
+            ak_captures.group(2).to_list(),
             [m.group(2) for m in re_captures if m is not None],
         )
 
         group, group_origins = ak_captures.group(1, return_group_origins=True)
         self.assertListEqual(
-            group_origins.to_ndarray().tolist(),
+            group_origins.to_list(),
             [i for i in range(len(re_captures)) if re_captures[i] is not None],
         )
 
@@ -155,8 +145,8 @@ class RegexTest(ArkoudaTest):
         re_sub = [re.sub(pattern, repl, strings[i], count) for i in range(strings.size)]
         re_sub_counts = [re.subn(pattern, repl, strings[i], count)[1] for i in range(strings.size)]
         ak_sub, ak_sub_counts = strings.subn(pattern, repl, count)
-        self.assertListEqual(re_sub, ak_sub.to_ndarray().tolist())
-        self.assertListEqual(re_sub_counts, ak_sub_counts.to_ndarray().tolist())
+        self.assertListEqual(re_sub, ak_sub.to_list())
+        self.assertListEqual(re_sub_counts, ak_sub_counts.to_list())
 
         # test long repl
         repl = "---------"
@@ -164,8 +154,8 @@ class RegexTest(ArkoudaTest):
         re_sub = [re.sub(pattern, repl, strings[i], count) for i in range(strings.size)]
         re_sub_counts = [re.subn(pattern, repl, strings[i], count)[1] for i in range(strings.size)]
         ak_sub, ak_sub_counts = strings.subn(pattern, repl, count)
-        self.assertListEqual(re_sub, ak_sub.to_ndarray().tolist())
-        self.assertListEqual(re_sub_counts, ak_sub_counts.to_ndarray().tolist())
+        self.assertListEqual(re_sub, ak_sub.to_list())
+        self.assertListEqual(re_sub_counts, ak_sub_counts.to_list())
 
     def test_split(self):
         strings = ak.array(
@@ -181,7 +171,7 @@ class RegexTest(ArkoudaTest):
                 if i == strings.size - 1
                 else split[split_map[i] : split_map[i + 1]]
             )
-            self.assertListEqual(re_split, ak_split.to_ndarray().tolist())
+            self.assertListEqual(re_split, ak_split.to_list())
 
     def test_regex_contains(self):
         digit_strings = ak.array(["{} string {}".format(i, i) for i in range(1, 6)])
@@ -214,37 +204,37 @@ class RegexTest(ArkoudaTest):
         strings = ak.array(["{} string {}".format(i, i) for i in range(1, 6)])
 
         actual_num_matches, actual_starts, actual_lens = strings.find_locations("\\d")
-        self.assertListEqual([2, 2, 2, 2, 2], actual_num_matches.to_ndarray().tolist())
-        self.assertListEqual([0, 9, 0, 9, 0, 9, 0, 9, 0, 9], actual_starts.to_ndarray().tolist())
-        self.assertListEqual([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], actual_lens.to_ndarray().tolist())
+        self.assertListEqual([2, 2, 2, 2, 2], actual_num_matches.to_list())
+        self.assertListEqual([0, 9, 0, 9, 0, 9, 0, 9, 0, 9], actual_starts.to_list())
+        self.assertListEqual([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], actual_lens.to_list())
 
         actual_num_matches, actual_starts, actual_lens = strings.find_locations("string \\d")
-        self.assertListEqual([1, 1, 1, 1, 1], actual_num_matches.to_ndarray().tolist())
-        self.assertListEqual([2, 2, 2, 2, 2], actual_starts.to_ndarray().tolist())
-        self.assertListEqual([8, 8, 8, 8, 8], actual_lens.to_ndarray().tolist())
+        self.assertListEqual([1, 1, 1, 1, 1], actual_num_matches.to_list())
+        self.assertListEqual([2, 2, 2, 2, 2], actual_starts.to_list())
+        self.assertListEqual([8, 8, 8, 8, 8], actual_lens.to_list())
 
     def test_regex_findall(self):
         strings = ak.array(["{} string {}".format(i, i) for i in range(1, 6)])
         expected_matches = ["1", "1", "2", "2", "3", "3", "4", "4", "5", "5"]
         expected_match_origins = [0, 0, 1, 1, 2, 2, 3, 3, 4, 4]
         actual_matches, actual_match_origins = strings.findall("\\d", return_match_origins=True)
-        self.assertListEqual(expected_matches, actual_matches.to_ndarray().tolist())
-        self.assertListEqual(expected_match_origins, actual_match_origins.to_ndarray().tolist())
+        self.assertListEqual(expected_matches, actual_matches.to_list())
+        self.assertListEqual(expected_match_origins, actual_match_origins.to_list())
         actual_matches = strings.findall("\\d")
-        self.assertListEqual(expected_matches, actual_matches.to_ndarray().tolist())
+        self.assertListEqual(expected_matches, actual_matches.to_list())
 
         expected_matches = ["string 1", "string 2", "string 3", "string 4", "string 5"]
         expected_match_origins = [0, 1, 2, 3, 4]
         actual_matches, actual_match_origins = strings.findall("string \\d", return_match_origins=True)
-        self.assertListEqual(expected_matches, actual_matches.to_ndarray().tolist())
-        self.assertListEqual(expected_match_origins, actual_match_origins.to_ndarray().tolist())
+        self.assertListEqual(expected_matches, actual_matches.to_list())
+        self.assertListEqual(expected_match_origins, actual_match_origins.to_list())
 
         under = ak.array(["", "____", "_1_2", "3___4___", "5"])
         expected_matches = ["____", "_", "_", "___", "___"]
         expected_match_origins = [1, 2, 2, 3, 3]
         actual_matches, actual_match_origins = under.findall("_+", return_match_origins=True)
-        self.assertListEqual(expected_matches, actual_matches.to_ndarray().tolist())
-        self.assertListEqual(expected_match_origins, actual_match_origins.to_ndarray().tolist())
+        self.assertListEqual(expected_matches, actual_matches.to_list())
+        self.assertListEqual(expected_match_origins, actual_match_origins.to_list())
 
     def test_regex_peel(self):
         orig = ak.array(["a.b", "c.d", "e.f.g"])
@@ -254,43 +244,43 @@ class RegexTest(ArkoudaTest):
         o_left, o_right = orig.peel(".")
         d_left, d_right = digit.peel("\\d", regex=True)
         u_left, u_right = under.peel("_+", regex=True)
-        self.assertListEqual(["a", "c", "e"], o_left.to_ndarray().tolist())
-        self.assertListEqual(["a", "c", "e"], d_left.to_ndarray().tolist())
-        self.assertListEqual(["a", "c", "e"], u_left.to_ndarray().tolist())
-        self.assertListEqual(["b", "d", "f.g"], o_right.to_ndarray().tolist())
-        self.assertListEqual(["b", "d", "f2g"], d_right.to_ndarray().tolist())
-        self.assertListEqual(["b", "d", "f____g"], u_right.to_ndarray().tolist())
+        self.assertListEqual(["a", "c", "e"], o_left.to_list())
+        self.assertListEqual(["a", "c", "e"], d_left.to_list())
+        self.assertListEqual(["a", "c", "e"], u_left.to_list())
+        self.assertListEqual(["b", "d", "f.g"], o_right.to_list())
+        self.assertListEqual(["b", "d", "f2g"], d_right.to_list())
+        self.assertListEqual(["b", "d", "f____g"], u_right.to_list())
 
         o_left, o_right = orig.peel(".", includeDelimiter=True)
         d_left, d_right = digit.peel("\\d", includeDelimiter=True, regex=True)
         u_left, u_right = under.peel("_+", includeDelimiter=True, regex=True)
-        self.assertListEqual(["a.", "c.", "e."], o_left.to_ndarray().tolist())
-        self.assertListEqual(["a1", "c1", "e1"], d_left.to_ndarray().tolist())
-        self.assertListEqual(["a_", "c___", "e__"], u_left.to_ndarray().tolist())
-        self.assertListEqual(["b", "d", "f.g"], o_right.to_ndarray().tolist())
-        self.assertListEqual(["b", "d", "f2g"], d_right.to_ndarray().tolist())
-        self.assertListEqual(["b", "d", "f____g"], u_right.to_ndarray().tolist())
+        self.assertListEqual(["a.", "c.", "e."], o_left.to_list())
+        self.assertListEqual(["a1", "c1", "e1"], d_left.to_list())
+        self.assertListEqual(["a_", "c___", "e__"], u_left.to_list())
+        self.assertListEqual(["b", "d", "f.g"], o_right.to_list())
+        self.assertListEqual(["b", "d", "f2g"], d_right.to_list())
+        self.assertListEqual(["b", "d", "f____g"], u_right.to_list())
 
         o_left, o_right = orig.peel(".", times=2, keepPartial=True)
         d_left, d_right = digit.peel("\\d", times=2, keepPartial=True, regex=True)
         u_left, u_right = under.peel("_+", times=2, keepPartial=True, regex=True)
-        self.assertListEqual(["a.b", "c.d", "e.f"], o_left.to_ndarray().tolist())
-        self.assertListEqual(["a1b", "c1d", "e1f"], d_left.to_ndarray().tolist())
-        self.assertListEqual(["a_b", "c___d", "e__f"], u_left.to_ndarray().tolist())
-        self.assertListEqual(["", "", "g"], o_right.to_ndarray().tolist())
-        self.assertListEqual(["", "", "g"], d_right.to_ndarray().tolist())
-        self.assertListEqual(["", "", "g"], u_right.to_ndarray().tolist())
+        self.assertListEqual(["a.b", "c.d", "e.f"], o_left.to_list())
+        self.assertListEqual(["a1b", "c1d", "e1f"], d_left.to_list())
+        self.assertListEqual(["a_b", "c___d", "e__f"], u_left.to_list())
+        self.assertListEqual(["", "", "g"], o_right.to_list())
+        self.assertListEqual(["", "", "g"], d_right.to_list())
+        self.assertListEqual(["", "", "g"], u_right.to_list())
 
         # rpeel / fromRight: digit is testing fromRight and under is testing rpeel
         o_left, o_right = orig.peel(".", times=2, includeDelimiter=True, fromRight=True)
         d_left, d_right = digit.peel("\\d", times=2, includeDelimiter=True, fromRight=True, regex=True)
         u_left, u_right = under.rpeel("_+", times=2, includeDelimiter=True, regex=True)
-        self.assertListEqual(["a.b", "c.d", "e"], o_left.to_ndarray().tolist())
-        self.assertListEqual(["a1b", "c1d", "e"], d_left.to_ndarray().tolist())
-        self.assertListEqual(["a_b", "c___d", "e"], u_left.to_ndarray().tolist())
-        self.assertListEqual(["", "", ".f.g"], o_right.to_ndarray().tolist())
-        self.assertListEqual(["", "", "1f2g"], d_right.to_ndarray().tolist())
-        self.assertListEqual(["", "", "__f____g"], u_right.to_ndarray().tolist())
+        self.assertListEqual(["a.b", "c.d", "e"], o_left.to_list())
+        self.assertListEqual(["a1b", "c1d", "e"], d_left.to_list())
+        self.assertListEqual(["a_b", "c___d", "e"], u_left.to_list())
+        self.assertListEqual(["", "", ".f.g"], o_right.to_list())
+        self.assertListEqual(["", "", "1f2g"], d_right.to_list())
+        self.assertListEqual(["", "", "__f____g"], u_right.to_list())
 
     def test_regex_flatten(self):
         orig = ak.array(["one|two", "three|four|five", "six", "seven|eight|nine|ten|", "eleven"])
@@ -319,13 +309,13 @@ class RegexTest(ArkoudaTest):
         digit_flat, digit_map = digit.flatten("\\d", return_segments=True, regex=True)
         under_flat, under_map = under.flatten("_+", return_segments=True, regex=True)
 
-        self.assertListEqual(answer_flat, orig_flat.to_ndarray().tolist())
-        self.assertListEqual(answer_flat, digit_flat.to_ndarray().tolist())
-        self.assertListEqual(answer_flat, under_flat.to_ndarray().tolist())
+        self.assertListEqual(answer_flat, orig_flat.to_list())
+        self.assertListEqual(answer_flat, digit_flat.to_list())
+        self.assertListEqual(answer_flat, under_flat.to_list())
 
-        self.assertListEqual(answer_map, orig_map.to_ndarray().tolist())
-        self.assertListEqual(answer_map, digit_map.to_ndarray().tolist())
-        self.assertListEqual(answer_map, under_map.to_ndarray().tolist())
+        self.assertListEqual(answer_map, orig_map.to_list())
+        self.assertListEqual(answer_map, digit_map.to_list())
+        self.assertListEqual(answer_map, under_map.to_list())
 
         # empty string, start with delim, end with delim, and only delim cases
         orig = ak.array(["", "|", "|1|2", "3|4|", "5"])
@@ -337,8 +327,8 @@ class RegexTest(ArkoudaTest):
         orig_flat, orig_map = orig.flatten("|", return_segments=True)
         regex_flat, regex_map = regex.flatten("_+", return_segments=True, regex=True)
 
-        self.assertListEqual(answer_flat, orig_flat.to_ndarray().tolist())
-        self.assertListEqual(answer_flat, regex_flat.to_ndarray().tolist())
+        self.assertListEqual(answer_flat, orig_flat.to_list())
+        self.assertListEqual(answer_flat, regex_flat.to_list())
 
-        self.assertListEqual(answer_map, orig_map.to_ndarray().tolist())
-        self.assertListEqual(answer_map, regex_map.to_ndarray().tolist())
+        self.assertListEqual(answer_map, orig_map.to_list())
+        self.assertListEqual(answer_map, regex_map.to_list())

--- a/tests/regex_test.py
+++ b/tests/regex_test.py
@@ -213,21 +213,15 @@ class RegexTest(ArkoudaTest):
     def test_regex_find_locations(self):
         strings = ak.array(["{} string {}".format(i, i) for i in range(1, 6)])
 
-        expected_num_matches = [2, 2, 2, 2, 2]
-        expected_starts = [0, 9, 0, 9, 0, 9, 0, 9, 0, 9]
-        expected_lens = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
         actual_num_matches, actual_starts, actual_lens = strings.find_locations("\\d")
-        self.assertListEqual(expected_num_matches, actual_num_matches.to_ndarray().tolist())
-        self.assertListEqual(expected_starts, actual_starts.to_ndarray().tolist())
-        self.assertListEqual(expected_lens, actual_lens.to_ndarray().tolist())
+        self.assertListEqual([2, 2, 2, 2, 2], actual_num_matches.to_ndarray().tolist())
+        self.assertListEqual([0, 9, 0, 9, 0, 9, 0, 9, 0, 9], actual_starts.to_ndarray().tolist())
+        self.assertListEqual([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], actual_lens.to_ndarray().tolist())
 
-        expected_num_matches = [1, 1, 1, 1, 1]
-        expected_starts = [2, 2, 2, 2, 2]
-        expected_lens = [8, 8, 8, 8, 8]
         actual_num_matches, actual_starts, actual_lens = strings.find_locations("string \\d")
-        self.assertListEqual(expected_num_matches, actual_num_matches.to_ndarray().tolist())
-        self.assertListEqual(expected_starts, actual_starts.to_ndarray().tolist())
-        self.assertListEqual(expected_lens, actual_lens.to_ndarray().tolist())
+        self.assertListEqual([1, 1, 1, 1, 1], actual_num_matches.to_ndarray().tolist())
+        self.assertListEqual([2, 2, 2, 2, 2], actual_starts.to_ndarray().tolist())
+        self.assertListEqual([8, 8, 8, 8, 8], actual_lens.to_ndarray().tolist())
 
     def test_regex_findall(self):
         strings = ak.array(["{} string {}".format(i, i) for i in range(1, 6)])

--- a/tests/registration_test.py
+++ b/tests/registration_test.py
@@ -30,7 +30,7 @@ class RegistrationTest(ArkoudaTest):
 
         self.assertEqual("test_int64_a", self.a_array.name, "Expect name to change inplace")
         self.assertTrue(self.a_array is ar_array, "These should be the same object")
-        self.assertListEqual(self.a_array.to_ndarray().tolist(), ar_array.to_ndarray().tolist())
+        self.assertListEqual(self.a_array.to_list(), ar_array.to_list())
         ak.clear()
         # Both ar_array and self.a_array point to the same object, so both should still be usable.
         str(ar_array)
@@ -110,14 +110,14 @@ class RegistrationTest(ArkoudaTest):
         aar_array = ak.attach_pdarray("test_int64_a")
 
         self.assertEqual(ar_array.name, aar_array.name)
-        self.assertListEqual(ar_array.to_ndarray().tolist(), aar_array.to_ndarray().tolist())
+        self.assertListEqual(ar_array.to_list(), aar_array.to_list())
 
         ak.disconnect()
         ak.connect(server=ArkoudaTest.server, port=ArkoudaTest.port)
         aar_array = ak.attach_pdarray("test_int64_a")
 
         self.assertEqual(ar_array.name, aar_array.name)
-        self.assertListEqual(ar_array.to_ndarray().tolist(), aar_array.to_ndarray().tolist())
+        self.assertListEqual(ar_array.to_list(), aar_array.to_list())
 
         ar_array.unregister()
         ak.clear()
@@ -151,7 +151,7 @@ class RegistrationTest(ArkoudaTest):
         twos_array.fill(2)
 
         g_twos_array = self.a_array + self.b_array
-        self.assertListEqual(twos_array.to_ndarray().tolist(), g_twos_array.to_ndarray().tolist())
+        self.assertListEqual(twos_array.to_list(), g_twos_array.to_list())
 
         ak.clear()  # This should remove self.b_array and g_twos_array
 
@@ -173,7 +173,7 @@ class RegistrationTest(ArkoudaTest):
             self.a_array + self.b_array
 
         g_twos_array = ar_array + aar_array
-        self.assertListEqual(twos_array.to_ndarray().tolist(), g_twos_array.to_ndarray().tolist())
+        self.assertListEqual(twos_array.to_list(), g_twos_array.to_list())
 
     def test_register_info(self):
         """
@@ -509,7 +509,7 @@ class RegistrationTest(ArkoudaTest):
         self.assertTrue(s.is_registered())
 
         s2 = Series.attach("seriesTest")
-        self.assertListEqual(s2.values.to_ndarray().tolist(), s.values.to_ndarray().tolist())
+        self.assertListEqual(s2.values.to_list(), s.values.to_list())
         sEq = s2.index == s.index
         self.assertTrue(all(sEq.to_ndarray()))
 
@@ -520,16 +520,10 @@ class RegistrationTest(ArkoudaTest):
         sAttach = ak.GroupBy.attach("stringsTest")
 
         # Verify the attached GroupBy's components equal the original components
-        self.assertListEqual(sGroup.keys.to_ndarray().tolist(), sAttach.keys.to_ndarray().tolist())
-        self.assertListEqual(
-            sGroup.permutation.to_ndarray().tolist(), sAttach.permutation.to_ndarray().tolist()
-        )
-        self.assertListEqual(
-            sGroup.segments.to_ndarray().tolist(), sAttach.segments.to_ndarray().tolist()
-        )
-        self.assertListEqual(
-            sGroup.unique_keys.to_ndarray().tolist(), sAttach.unique_keys.to_ndarray().tolist()
-        )
+        self.assertListEqual(sGroup.keys.to_list(), sAttach.keys.to_list())
+        self.assertListEqual(sGroup.permutation.to_list(), sAttach.permutation.to_list())
+        self.assertListEqual(sGroup.segments.to_list(), sAttach.segments.to_list())
+        self.assertListEqual(sGroup.unique_keys.to_list(), sAttach.unique_keys.to_list())
 
         self.assertIsInstance(sAttach.keys, ak.Strings)
         self.assertIsInstance(sAttach.permutation, ak.pdarray)
@@ -543,16 +537,10 @@ class RegistrationTest(ArkoudaTest):
         aAttach = ak.GroupBy.attach("pdarray_test")
 
         # Verify the attached GroupBy's components equal the original components
-        self.assertListEqual(aGroup.keys.to_ndarray().tolist(), aAttach.keys.to_ndarray().tolist())
-        self.assertListEqual(
-            aGroup.permutation.to_ndarray().tolist(), aAttach.permutation.to_ndarray().tolist()
-        )
-        self.assertListEqual(
-            aGroup.segments.to_ndarray().tolist(), aAttach.segments.to_ndarray().tolist()
-        )
-        self.assertListEqual(
-            aGroup.unique_keys.to_ndarray().tolist(), aAttach.unique_keys.to_ndarray().tolist()
-        )
+        self.assertListEqual(aGroup.keys.to_list(), aAttach.keys.to_list())
+        self.assertListEqual(aGroup.permutation.to_list(), aAttach.permutation.to_list())
+        self.assertListEqual(aGroup.segments.to_list(), aAttach.segments.to_list())
+        self.assertListEqual(aGroup.unique_keys.to_list(), aAttach.unique_keys.to_list())
 
         self.assertIsInstance(aAttach.keys, ak.pdarray)
         self.assertIsInstance(aAttach.permutation, ak.pdarray)
@@ -567,16 +555,10 @@ class RegistrationTest(ArkoudaTest):
         catAttach = ak.GroupBy.attach("categorical_test")
 
         # Verify the attached GroupBy's components equal the original components
-        self.assertListEqual(catGroup.keys.to_ndarray().tolist(), catAttach.keys.to_ndarray().tolist())
-        self.assertListEqual(
-            catGroup.permutation.to_ndarray().tolist(), catAttach.permutation.to_ndarray().tolist()
-        )
-        self.assertListEqual(
-            catGroup.segments.to_ndarray().tolist(), catAttach.segments.to_ndarray().tolist()
-        )
-        self.assertListEqual(
-            catGroup.unique_keys.to_ndarray().tolist(), catAttach.unique_keys.to_ndarray().tolist()
-        )
+        self.assertListEqual(catGroup.keys.to_list(), catAttach.keys.to_list())
+        self.assertListEqual(catGroup.permutation.to_list(), catAttach.permutation.to_list())
+        self.assertListEqual(catGroup.segments.to_list(), catAttach.segments.to_list())
+        self.assertListEqual(catGroup.unique_keys.to_list(), catAttach.unique_keys.to_list())
 
         self.assertIsInstance(catAttach.keys, ak.Categorical)
         self.assertIsInstance(catAttach.permutation, ak.pdarray)
@@ -594,30 +576,14 @@ class RegistrationTest(ArkoudaTest):
 
         # Verify the attached GroupBy's components equal the original components for each key
         # in the sequence
-        self.assertListEqual(
-            group.keys[0].to_ndarray().tolist(), seqAttach.keys[0].to_ndarray().tolist()
-        )
-        self.assertListEqual(
-            group.keys[1].to_ndarray().tolist(), seqAttach.keys[1].to_ndarray().tolist()
-        )
-        self.assertListEqual(
-            group.keys[2].to_ndarray().tolist(), seqAttach.keys[2].to_ndarray().tolist()
-        )
-        self.assertListEqual(
-            group.unique_keys[0].to_ndarray().tolist(), seqAttach.unique_keys[0].to_ndarray().tolist()
-        )
-        self.assertListEqual(
-            group.unique_keys[1].to_ndarray().tolist(), seqAttach.unique_keys[1].to_ndarray().tolist()
-        )
-        self.assertListEqual(
-            group.unique_keys[2].to_ndarray().tolist(), seqAttach.unique_keys[2].to_ndarray().tolist()
-        )
-        self.assertListEqual(
-            group.permutation.to_ndarray().tolist(), seqAttach.permutation.to_ndarray().tolist()
-        )
-        self.assertListEqual(
-            group.segments.to_ndarray().tolist(), seqAttach.segments.to_ndarray().tolist()
-        )
+        self.assertListEqual(group.keys[0].to_list(), seqAttach.keys[0].to_list())
+        self.assertListEqual(group.keys[1].to_list(), seqAttach.keys[1].to_list())
+        self.assertListEqual(group.keys[2].to_list(), seqAttach.keys[2].to_list())
+        self.assertListEqual(group.unique_keys[0].to_list(), seqAttach.unique_keys[0].to_list())
+        self.assertListEqual(group.unique_keys[1].to_list(), seqAttach.unique_keys[1].to_list())
+        self.assertListEqual(group.unique_keys[2].to_list(), seqAttach.unique_keys[2].to_list())
+        self.assertListEqual(group.permutation.to_list(), seqAttach.permutation.to_list())
+        self.assertListEqual(group.segments.to_list(), seqAttach.segments.to_list())
 
         # Verify the attached GroupBy preserved the type of each key
         self.assertIsInstance(seqAttach.keys[0], ak.pdarray)

--- a/tests/registration_test.py
+++ b/tests/registration_test.py
@@ -30,7 +30,7 @@ class RegistrationTest(ArkoudaTest):
 
         self.assertEqual("test_int64_a", self.a_array.name, "Expect name to change inplace")
         self.assertTrue(self.a_array is ar_array, "These should be the same object")
-        self.assertTrue((self.a_array.to_ndarray() == ar_array.to_ndarray()).all())
+        self.assertListEqual(self.a_array.to_ndarray().tolist(), ar_array.to_ndarray().tolist())
         ak.clear()
         # Both ar_array and self.a_array point to the same object, so both should still be usable.
         str(ar_array)
@@ -110,14 +110,14 @@ class RegistrationTest(ArkoudaTest):
         aar_array = ak.attach_pdarray("test_int64_a")
 
         self.assertEqual(ar_array.name, aar_array.name)
-        self.assertTrue((ar_array.to_ndarray() == aar_array.to_ndarray()).all())
+        self.assertListEqual(ar_array.to_ndarray().tolist(), aar_array.to_ndarray().tolist())
 
         ak.disconnect()
         ak.connect(server=ArkoudaTest.server, port=ArkoudaTest.port)
         aar_array = ak.attach_pdarray("test_int64_a")
 
         self.assertEqual(ar_array.name, aar_array.name)
-        self.assertTrue((ar_array.to_ndarray() == aar_array.to_ndarray()).all())
+        self.assertListEqual(ar_array.to_ndarray().tolist(), aar_array.to_ndarray().tolist())
 
         ar_array.unregister()
         ak.clear()
@@ -151,7 +151,7 @@ class RegistrationTest(ArkoudaTest):
         twos_array.fill(2)
 
         g_twos_array = self.a_array + self.b_array
-        self.assertTrue((twos_array.to_ndarray() == g_twos_array.to_ndarray()).all())
+        self.assertListEqual(twos_array.to_ndarray().tolist(), g_twos_array.to_ndarray().tolist())
 
         ak.clear()  # This should remove self.b_array and g_twos_array
 
@@ -173,7 +173,7 @@ class RegistrationTest(ArkoudaTest):
             self.a_array + self.b_array
 
         g_twos_array = ar_array + aar_array
-        self.assertTrue((twos_array.to_ndarray() == g_twos_array.to_ndarray()).all())
+        self.assertListEqual(twos_array.to_ndarray().tolist(), g_twos_array.to_ndarray().tolist())
 
     def test_register_info(self):
         """
@@ -226,11 +226,11 @@ class RegistrationTest(ArkoudaTest):
             msg="info(AllSymbols) should have more objects than info(RegisteredSymbols) before clear()",
         )
         ak.clear()
-        self.assertTrue(
-            len(json.loads(ak.information(ak.AllSymbols)))
-            == len(json.loads(ak.information(ak.RegisteredSymbols))),
+        self.assertEqual(
+            len(json.loads(ak.information(ak.AllSymbols))),
+            len(json.loads(ak.information(ak.RegisteredSymbols))),
             msg="info(AllSymbols) and info(RegisteredSymbols) should have same num of objects "
-                "after clear()",
+            "after clear()",
         )
 
         # After unregister(), the registered field should be set to false for AllSymbol and
@@ -337,17 +337,17 @@ class RegistrationTest(ArkoudaTest):
         cleanup()
         # Initial registration should set name
         keep = ak.random_strings_uniform(1, 10, UNIQUE, characters="printable")
-        self.assertTrue(keep.register("keep_me").name == "keep_me")
+        self.assertEqual(keep.register("keep_me").name, "keep_me")
         self.assertTrue(keep.is_registered(), "Expected Strings object to be registered")
 
         # Register a second time to confirm name change
-        self.assertTrue(keep.register("kept").name == "kept")
+        self.assertEqual(keep.register("kept").name, "kept")
         self.assertTrue(keep.is_registered(), "Object should be registered with updated name")
 
         # Add an item to discard, confirm our registered item remains and discarded item is gone
         discard = ak.random_strings_uniform(1, 10, UNIQUE, characters="printable")
         ak.clear()
-        self.assertTrue(keep.name == "kept")
+        self.assertEqual(keep.name, "kept")
         with self.assertRaises(RuntimeError, msg="discard was not registered and should be discarded"):
             str(discard)
 
@@ -431,7 +431,8 @@ class RegistrationTest(ArkoudaTest):
         self.assertTrue(c.is_registered(), "test_me categorical should be registered after attach")
         c.unregister()
         self.assertFalse(c.is_registered(), "test_me should be unregistered")
-        self.assertTrue(c.register("another_name").name == "another_name" and c.is_registered())
+        self.assertEqual(c.register("another_name").name, "another_name")
+        self.assertTrue(c.is_registered())
 
         # Test static unregister_by_name
         ak.Categorical.unregister_categorical_by_name("another_name")
@@ -462,7 +463,8 @@ class RegistrationTest(ArkoudaTest):
         self.assertTrue(cat.is_registered(), "test_me categorical should be registered after attach")
         cat.unregister()
         self.assertFalse(cat.is_registered(), "test_me should be unregistered")
-        self.assertTrue(cat.register("another_name").name == "another_name" and cat.is_registered())
+        self.assertEqual(cat.register("another_name").name, "another_name")
+        self.assertTrue(cat.is_registered())
 
         # Test static unregister_by_name
         ak.Categorical.unregister_categorical_by_name("another_name")

--- a/tests/segarray_test.py
+++ b/tests/segarray_test.py
@@ -14,7 +14,7 @@ class SegArrayTest(ArkoudaTest):
         segarr = ak.SegArray(segments, akflat)
 
         self.assertIsInstance(segarr, ak.SegArray)
-        self.assertListEqual(segarr._get_lengths().to_ndarray().tolist(), [6, 2, 4])
+        self.assertListEqual(segarr._get_lengths().to_list(), [6, 2, 4])
         self.assertEqual(segarr.__str__(), f"SegArray([\n{a}\n{b}\n{c}\n])".replace(",", ""))
         self.assertEqual(segarr.__getitem__(1).__str__(), str(b).replace(",", ""))
         self.assertEqual(
@@ -41,21 +41,21 @@ class SegArrayTest(ArkoudaTest):
         segs = ak.array([0, 0, len(b)])
         segarr = ak.SegArray(segs, flat)
         self.assertIsInstance(segarr, ak.SegArray)
-        self.assertListEqual(segarr.lengths.to_ndarray().tolist(), [0, 3, 1])
+        self.assertListEqual(segarr.lengths.to_list(), [0, 3, 1])
 
         # test empty as middle element
         flat = ak.array(a + c)
         segs = ak.array([0, len(a), len(a)])
         segarr = ak.SegArray(segs, flat)
         self.assertIsInstance(segarr, ak.SegArray)
-        self.assertListEqual(segarr.lengths.to_ndarray().tolist(), [2, 0, 1])
+        self.assertListEqual(segarr.lengths.to_list(), [2, 0, 1])
 
         # test empty as last
         flat = ak.array(a + b + c)
         segs = ak.array([0, len(a), len(a) + len(b), len(a) + len(b) + len(c)])
         segarr = ak.SegArray(segs, flat)
         self.assertIsInstance(segarr, ak.SegArray)
-        self.assertListEqual(segarr.lengths.to_ndarray().tolist(), [2, 3, 1, 0])
+        self.assertListEqual(segarr.lengths.to_list(), [2, 3, 1, 0])
 
     def test_concat(self):
         a = [10, 11, 12, 13, 14, 15]
@@ -137,18 +137,18 @@ class SegArrayTest(ArkoudaTest):
 
         suffix, origin = segarr.get_suffixes(1)
         self.assertTrue(origin.all())
-        self.assertListEqual(suffix[0].to_ndarray().tolist(), [15, 21, 33])
+        self.assertListEqual(suffix[0].to_list(), [15, 21, 33])
 
         suffix, origin = segarr.get_suffixes(2)
-        self.assertListEqual(suffix[0].to_ndarray().tolist(), [14, 32])
-        self.assertListEqual(suffix[1].to_ndarray().tolist(), [15, 33])
+        self.assertListEqual(suffix[0].to_list(), [14, 32])
+        self.assertListEqual(suffix[1].to_list(), [15, 33])
         self.assertTrue(origin[0])
         self.assertFalse(origin[1])
         self.assertTrue(origin[2])
 
         suffix, origin = segarr.get_suffixes(2, proper=False)
-        self.assertListEqual(suffix[0].to_ndarray().tolist(), [14, 20, 32])
-        self.assertListEqual(suffix[1].to_ndarray().tolist(), [15, 21, 33])
+        self.assertListEqual(suffix[0].to_list(), [14, 20, 32])
+        self.assertListEqual(suffix[1].to_list(), [15, 21, 33])
         self.assertTrue(origin.all())
 
         # Test with empty segment
@@ -156,8 +156,8 @@ class SegArrayTest(ArkoudaTest):
         segs = ak.array([0, len(a), len(a)])
         segarr = ak.SegArray(segs, flat)
         suffix, origin = segarr.get_suffixes(1)
-        self.assertListEqual(suffix[0].to_ndarray().tolist(), [15, 21])
-        self.assertListEqual(origin.to_ndarray().tolist(), [True, False, True])
+        self.assertListEqual(suffix[0].to_list(), [15, 21])
+        self.assertListEqual(origin.to_list(), [True, False, True])
 
     def test_prefixes(self):
         a = [10, 11, 12, 13, 14, 15]
@@ -171,19 +171,19 @@ class SegArrayTest(ArkoudaTest):
         segarr = ak.SegArray(segments, akflat)
         prefix, origin = segarr.get_prefixes(1)
 
-        self.assertListEqual(prefix[0].to_ndarray().tolist(), [10, 20, 30])
+        self.assertListEqual(prefix[0].to_list(), [10, 20, 30])
         self.assertTrue(origin.all())
 
         prefix, origin = segarr.get_prefixes(2)
-        self.assertListEqual(prefix[0].to_ndarray().tolist(), [10, 30])
-        self.assertListEqual(prefix[1].to_ndarray().tolist(), [11, 31])
+        self.assertListEqual(prefix[0].to_list(), [10, 30])
+        self.assertListEqual(prefix[1].to_list(), [11, 31])
         self.assertTrue(origin[0])
         self.assertFalse(origin[1])
         self.assertTrue(origin[2])
 
         prefix, origin = segarr.get_prefixes(2, proper=False)
-        self.assertListEqual(prefix[0].to_ndarray().tolist(), [10, 20, 30])
-        self.assertListEqual(prefix[1].to_ndarray().tolist(), [11, 21, 31])
+        self.assertListEqual(prefix[0].to_list(), [10, 20, 30])
+        self.assertListEqual(prefix[1].to_list(), [11, 21, 31])
         self.assertTrue(origin.all())
 
         # Test with empty segment
@@ -191,8 +191,8 @@ class SegArrayTest(ArkoudaTest):
         segs = ak.array([0, len(a), len(a)])
         segarr = ak.SegArray(segs, flat)
         prefix, origin = segarr.get_prefixes(1)
-        self.assertListEqual(prefix[0].to_ndarray().tolist(), [10, 20])
-        self.assertListEqual(origin.to_ndarray().tolist(), [True, False, True])
+        self.assertListEqual(prefix[0].to_list(), [10, 20])
+        self.assertListEqual(origin.to_list(), [True, False, True])
 
     def test_ngram(self):
         a = [10, 11, 12, 13, 14, 15]
@@ -205,26 +205,26 @@ class SegArrayTest(ArkoudaTest):
 
         segarr = ak.SegArray(segments, akflat)
         ngram, origin = segarr.get_ngrams(2)
-        self.assertListEqual(ngram[0].to_ndarray().tolist(), [10, 11, 12, 13, 14, 20, 30, 31, 32])
-        self.assertListEqual(ngram[1].to_ndarray().tolist(), [11, 12, 13, 14, 15, 21, 31, 32, 33])
-        self.assertListEqual(origin.to_ndarray().tolist(), [0, 0, 0, 0, 0, 1, 2, 2, 2])
+        self.assertListEqual(ngram[0].to_list(), [10, 11, 12, 13, 14, 20, 30, 31, 32])
+        self.assertListEqual(ngram[1].to_list(), [11, 12, 13, 14, 15, 21, 31, 32, 33])
+        self.assertListEqual(origin.to_list(), [0, 0, 0, 0, 0, 1, 2, 2, 2])
 
         ngram, origin = segarr.get_ngrams(5)
-        self.assertListEqual(ngram[0].to_ndarray().tolist(), [10, 11])
-        self.assertListEqual(ngram[1].to_ndarray().tolist(), [11, 12])
-        self.assertListEqual(ngram[2].to_ndarray().tolist(), [12, 13])
-        self.assertListEqual(ngram[3].to_ndarray().tolist(), [13, 14])
-        self.assertListEqual(ngram[4].to_ndarray().tolist(), [14, 15])
-        self.assertListEqual(origin.to_ndarray().tolist(), [0, 0])
+        self.assertListEqual(ngram[0].to_list(), [10, 11])
+        self.assertListEqual(ngram[1].to_list(), [11, 12])
+        self.assertListEqual(ngram[2].to_list(), [12, 13])
+        self.assertListEqual(ngram[3].to_list(), [13, 14])
+        self.assertListEqual(ngram[4].to_list(), [14, 15])
+        self.assertListEqual(origin.to_list(), [0, 0])
 
         # Test with empty segment
         flat = ak.array(a + b)
         segs = ak.array([0, len(a), len(a)])
         segarr = ak.SegArray(segs, flat)
         ngram, origin = segarr.get_ngrams(2)
-        self.assertListEqual(ngram[0].to_ndarray().tolist(), [10, 11, 12, 13, 14, 20])
-        self.assertListEqual(ngram[1].to_ndarray().tolist(), [11, 12, 13, 14, 15, 21])
-        self.assertListEqual(origin.to_ndarray().tolist(), [0, 0, 0, 0, 0, 2])
+        self.assertListEqual(ngram[0].to_list(), [10, 11, 12, 13, 14, 20])
+        self.assertListEqual(ngram[1].to_list(), [11, 12, 13, 14, 15, 21])
+        self.assertListEqual(origin.to_list(), [0, 0, 0, 0, 0, 2])
 
         with self.assertRaises(ValueError):
             ngram, origin = segarr.get_ngrams(7)
@@ -241,19 +241,19 @@ class SegArrayTest(ArkoudaTest):
         segarr = ak.SegArray(segments, akflat)
 
         res, origins = segarr.get_jth(1)
-        self.assertListEqual(res.to_ndarray().tolist(), [11, 21, 31])
+        self.assertListEqual(res.to_list(), [11, 21, 31])
         res, origins = segarr.get_jth(5)
-        self.assertListEqual(res.to_ndarray().tolist(), [15, 0, 0])
+        self.assertListEqual(res.to_list(), [15, 0, 0])
         res, origins = segarr.get_jth(5, compressed=True)
-        self.assertListEqual(res.to_ndarray().tolist(), [15])
+        self.assertListEqual(res.to_list(), [15])
 
         # Test with empty segment
         flat = ak.array(a + b)
         segs = ak.array([0, len(a), len(a)])
         segarr = ak.SegArray(segs, flat)
         res, origin = segarr.get_jth(2)
-        self.assertListEqual(res.to_ndarray().tolist(), [12, 0, 0])
-        self.assertListEqual(origin.to_ndarray().tolist(), [True, False, False])
+        self.assertListEqual(res.to_list(), [12, 0, 0])
+        self.assertListEqual(origin.to_list(), [True, False, False])
 
     def test_set_jth(self):
         """
@@ -302,17 +302,17 @@ class SegArrayTest(ArkoudaTest):
         segarr = ak.SegArray(segments, akflat)
 
         elem, origin = segarr.get_length_n(2)
-        self.assertListEqual(elem[0].to_ndarray().tolist(), [20])
-        self.assertListEqual(elem[1].to_ndarray().tolist(), [21])
+        self.assertListEqual(elem[0].to_list(), [20])
+        self.assertListEqual(elem[1].to_list(), [21])
 
         # Test with empty segment
         flat = ak.array(a + b)
         segs = ak.array([0, len(a), len(a)])
         segarr = ak.SegArray(segs, flat)
         elem, origin = segarr.get_length_n(2)
-        self.assertListEqual(elem[0].to_ndarray().tolist(), [20])
-        self.assertListEqual(elem[1].to_ndarray().tolist(), [21])
-        self.assertListEqual(origin.to_ndarray().tolist(), [False, False, True])
+        self.assertListEqual(elem[0].to_list(), [20])
+        self.assertListEqual(elem[1].to_list(), [21])
+        self.assertListEqual(origin.to_list(), [False, False, True])
 
     def test_append(self):
         a = [10, 11, 12, 13, 14, 15]
@@ -368,7 +368,7 @@ class SegArrayTest(ArkoudaTest):
         segarr2 = ak.SegArray(segments2, flat2)
         appended = segarr.append(segarr2, axis=1)
 
-        self.assertListEqual(appended.lengths.to_ndarray().tolist(), [3, 3])
+        self.assertListEqual(appended.lengths.to_list(), [3, 3])
         self.assertListEqual(appended[0].tolist(), [1, 2, 10])
         self.assertListEqual(appended[1].tolist(), [3, 4, 20])
 
@@ -401,7 +401,7 @@ class SegArrayTest(ArkoudaTest):
         to_append = ak.array([99, 98, 97])
 
         appended = segarr.append_single(to_append)
-        self.assertListEqual(appended.lengths.to_ndarray().tolist(), [7, 3, 5])
+        self.assertListEqual(appended.lengths.to_list(), [7, 3, 5])
         self.assertListEqual(appended[0].tolist(), a + [99])
         self.assertListEqual(appended[1].tolist(), b + [98])
         self.assertListEqual(appended[2].tolist(), c + [97])
@@ -416,13 +416,13 @@ class SegArrayTest(ArkoudaTest):
 
         to_append = 99
         appended = segarr.append_single(to_append)
-        self.assertListEqual(appended.lengths.to_ndarray().tolist(), [7, 3, 5])
+        self.assertListEqual(appended.lengths.to_list(), [7, 3, 5])
         self.assertListEqual(appended[0].tolist(), a + [99])
         self.assertListEqual(appended[1].tolist(), b + [99])
         self.assertListEqual(appended[2].tolist(), c + [99])
 
         appended = segarr.prepend_single(to_append)
-        self.assertListEqual(appended.lengths.to_ndarray().tolist(), [7, 3, 5])
+        self.assertListEqual(appended.lengths.to_list(), [7, 3, 5])
         self.assertListEqual(appended[0].tolist(), [99] + a)
         self.assertListEqual(appended[1].tolist(), [99] + b)
         self.assertListEqual(appended[2].tolist(), [99] + c)
@@ -450,7 +450,7 @@ class SegArrayTest(ArkoudaTest):
 
         segarr = ak.SegArray(segments, flat)
         dedup = segarr.remove_repeats()
-        self.assertListEqual(dedup.lengths.to_ndarray().tolist(), [3, 3])
+        self.assertListEqual(dedup.lengths.to_list(), [3, 3])
         self.assertListEqual(dedup[0].tolist(), list(set(a)))
         self.assertListEqual(dedup[1].tolist(), list(set(b)))
 
@@ -459,7 +459,7 @@ class SegArrayTest(ArkoudaTest):
         segarr = ak.SegArray(segments, flat)
         dedup = segarr.remove_repeats()
         print(dedup.lengths)
-        self.assertListEqual(dedup.lengths.to_ndarray().tolist(), [3, 0, 3, 0])
+        self.assertListEqual(dedup.lengths.to_list(), [3, 0, 3, 0])
         self.assertListEqual(dedup[0].tolist(), list(set(a)))
         self.assertListEqual(dedup[1].tolist(), [])
         self.assertListEqual(dedup[2].tolist(), list(set(b)))
@@ -468,7 +468,7 @@ class SegArrayTest(ArkoudaTest):
         segments = ak.array([0, len(a), len(a), len(a), len(a) + len(b)])
         segarr = ak.SegArray(segments, flat)
         dedup = segarr.remove_repeats()
-        self.assertListEqual(dedup.lengths.to_ndarray().tolist(), [3, 0, 0, 3, 0])
+        self.assertListEqual(dedup.lengths.to_list(), [3, 0, 0, 3, 0])
         self.assertListEqual(dedup[0].tolist(), list(set(a)))
         self.assertListEqual(dedup[1].tolist(), [])
         self.assertListEqual(dedup[2].tolist(), [])
@@ -492,14 +492,14 @@ class SegArrayTest(ArkoudaTest):
         # test with empty Segments
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
         intx = segarr.intersect(segarr_2)
-        self.assertListEqual(intx.lengths.to_ndarray().tolist(), [3, 0])
+        self.assertListEqual(intx.lengths.to_list(), [3, 0])
         self.assertListEqual(intx[0].tolist(), [1, 2, 4])
         self.assertListEqual(intx[1].tolist(), [])
 
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + c))
         segarr_2 = ak.SegArray(ak.array([0, len(d)]), ak.array(d + c))
         intx = segarr.intersect(segarr_2)
-        self.assertListEqual(intx.lengths.to_ndarray().tolist(), [0, 3])
+        self.assertListEqual(intx.lengths.to_list(), [0, 3])
         self.assertListEqual(intx[0].tolist(), [])
         self.assertListEqual(intx[1].tolist(), [1, 2, 4])
 
@@ -520,14 +520,14 @@ class SegArrayTest(ArkoudaTest):
         # test with empty segments
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
         un = segarr.union(segarr_2)
-        self.assertListEqual(un.lengths.to_ndarray().tolist(), [5, 1])
+        self.assertListEqual(un.lengths.to_list(), [5, 1])
         self.assertListEqual(un[0].tolist(), [1, 2, 3, 4, 5])
         self.assertListEqual(un[1].tolist(), [8])
 
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
         segarr_2 = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
         un = segarr.union(segarr_2)
-        self.assertListEqual(un.lengths.to_ndarray().tolist(), [5, 0])
+        self.assertListEqual(un.lengths.to_list(), [5, 0])
         self.assertListEqual(un[0].tolist(), [1, 2, 3, 4, 5])
         self.assertListEqual(un[1].tolist(), [])
 
@@ -548,14 +548,14 @@ class SegArrayTest(ArkoudaTest):
         # test with empty segments
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
         diff = segarr.setdiff(segarr_2)
-        self.assertListEqual(diff.lengths.to_ndarray().tolist(), [2, 0])
+        self.assertListEqual(diff.lengths.to_list(), [2, 0])
         self.assertListEqual(diff[0].tolist(), [3, 5])
         self.assertListEqual(diff[1].tolist(), [])
 
         segarr = ak.SegArray(ak.array([0, len(a), len(a)]), ak.array(a + a))
         segarr_2 = ak.SegArray(ak.array([0, len(c), len(c + c)]), ak.array(c + c + c))
         diff = segarr_2.setdiff(segarr)
-        self.assertListEqual(diff.lengths.to_ndarray().tolist(), [0, 3, 0])
+        self.assertListEqual(diff.lengths.to_list(), [0, 3, 0])
         self.assertListEqual(diff[0].tolist(), [])
         self.assertListEqual(diff[1].tolist(), [1, 2, 4])
         self.assertListEqual(diff[2].tolist(), [])
@@ -577,14 +577,14 @@ class SegArrayTest(ArkoudaTest):
         # test with empty segment
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
         xor = segarr.setxor(segarr_2)
-        self.assertListEqual(xor.lengths.to_ndarray().tolist(), [2, 3])
+        self.assertListEqual(xor.lengths.to_list(), [2, 3])
         self.assertListEqual(xor[0].tolist(), [3, 4])
         self.assertListEqual(xor[1].tolist(), [8, 12, 13])
 
         segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + a))
         segarr_2 = ak.SegArray(ak.array([0, len(a)]), ak.array(a + c))
         xor = segarr.setxor(segarr_2)
-        self.assertListEqual(xor.lengths.to_ndarray().tolist(), [0, 2])
+        self.assertListEqual(xor.lengths.to_list(), [0, 2])
         self.assertListEqual(xor[0].tolist(), [])
         self.assertListEqual(xor[1].tolist(), [3, 4])
 
@@ -599,13 +599,9 @@ class SegArrayTest(ArkoudaTest):
         segarr_2 = ak.SegArray.attach("segarrtest")
 
         self.assertEqual(segarr.size, segarr_2.size)
-        self.assertListEqual(
-            segarr.lengths.to_ndarray().tolist(), segarr_2.lengths.to_ndarray().tolist()
-        )
-        self.assertListEqual(
-            segarr.segments.to_ndarray().tolist(), segarr_2.segments.to_ndarray().tolist()
-        )
-        self.assertListEqual(segarr.values.to_ndarray().tolist(), segarr_2.values.to_ndarray().tolist())
+        self.assertListEqual(segarr.lengths.to_list(), segarr_2.lengths.to_list())
+        self.assertListEqual(segarr.segments.to_list(), segarr_2.segments.to_list())
+        self.assertListEqual(segarr.values.to_list(), segarr_2.values.to_list())
 
         # Verify is_registered
         self.assertTrue(segarr.is_registered())

--- a/tests/segarray_test.py
+++ b/tests/segarray_test.py
@@ -14,9 +14,7 @@ class SegArrayTest(ArkoudaTest):
         segarr = ak.SegArray(segments, akflat)
 
         self.assertIsInstance(segarr, ak.SegArray)
-        self.assertListEqual(
-            segarr._get_lengths().to_ndarray().tolist(), ak.array([6, 2, 4]).to_ndarray().tolist()
-        )
+        self.assertListEqual(segarr._get_lengths().to_ndarray().tolist(), [6, 2, 4])
         self.assertEqual(segarr.__str__(), f"SegArray([\n{a}\n{b}\n{c}\n])".replace(",", ""))
         self.assertEqual(segarr.__getitem__(1).__str__(), str(b).replace(",", ""))
         self.assertEqual(
@@ -139,24 +137,18 @@ class SegArrayTest(ArkoudaTest):
 
         suffix, origin = segarr.get_suffixes(1)
         self.assertTrue(origin.all())
-        self.assertListEqual(
-            suffix[0].to_ndarray().tolist(), ak.array([15, 21, 33]).to_ndarray().tolist()
-        )
+        self.assertListEqual(suffix[0].to_ndarray().tolist(), [15, 21, 33])
 
         suffix, origin = segarr.get_suffixes(2)
-        self.assertListEqual(suffix[0].to_ndarray().tolist(), ak.array([14, 32]).to_ndarray().tolist())
-        self.assertListEqual(suffix[1].to_ndarray().tolist(), ak.array([15, 33]).to_ndarray().tolist())
+        self.assertListEqual(suffix[0].to_ndarray().tolist(), [14, 32])
+        self.assertListEqual(suffix[1].to_ndarray().tolist(), [15, 33])
         self.assertTrue(origin[0])
         self.assertFalse(origin[1])
         self.assertTrue(origin[2])
 
         suffix, origin = segarr.get_suffixes(2, proper=False)
-        self.assertListEqual(
-            suffix[0].to_ndarray().tolist(), ak.array([14, 20, 32]).to_ndarray().tolist()
-        )
-        self.assertListEqual(
-            suffix[1].to_ndarray().tolist(), ak.array([15, 21, 33]).to_ndarray().tolist()
-        )
+        self.assertListEqual(suffix[0].to_ndarray().tolist(), [14, 20, 32])
+        self.assertListEqual(suffix[1].to_ndarray().tolist(), [15, 21, 33])
         self.assertTrue(origin.all())
 
         # Test with empty segment
@@ -179,25 +171,19 @@ class SegArrayTest(ArkoudaTest):
         segarr = ak.SegArray(segments, akflat)
         prefix, origin = segarr.get_prefixes(1)
 
-        self.assertListEqual(
-            prefix[0].to_ndarray().tolist(), ak.array([10, 20, 30]).to_ndarray().tolist()
-        )
+        self.assertListEqual(prefix[0].to_ndarray().tolist(), [10, 20, 30])
         self.assertTrue(origin.all())
 
         prefix, origin = segarr.get_prefixes(2)
-        self.assertListEqual(prefix[0].to_ndarray().tolist(), ak.array([10, 30]).to_ndarray().tolist())
-        self.assertListEqual(prefix[1].to_ndarray().tolist(), ak.array([11, 31]).to_ndarray().tolist())
+        self.assertListEqual(prefix[0].to_ndarray().tolist(), [10, 30])
+        self.assertListEqual(prefix[1].to_ndarray().tolist(), [11, 31])
         self.assertTrue(origin[0])
         self.assertFalse(origin[1])
         self.assertTrue(origin[2])
 
         prefix, origin = segarr.get_prefixes(2, proper=False)
-        self.assertListEqual(
-            prefix[0].to_ndarray().tolist(), ak.array([10, 20, 30]).to_ndarray().tolist()
-        )
-        self.assertListEqual(
-            prefix[1].to_ndarray().tolist(), ak.array([11, 21, 31]).to_ndarray().tolist()
-        )
+        self.assertListEqual(prefix[0].to_ndarray().tolist(), [10, 20, 30])
+        self.assertListEqual(prefix[1].to_ndarray().tolist(), [11, 21, 31])
         self.assertTrue(origin.all())
 
         # Test with empty segment
@@ -219,25 +205,17 @@ class SegArrayTest(ArkoudaTest):
 
         segarr = ak.SegArray(segments, akflat)
         ngram, origin = segarr.get_ngrams(2)
-        self.assertListEqual(
-            ngram[0].to_ndarray().tolist(),
-            ak.array([10, 11, 12, 13, 14, 20, 30, 31, 32]).to_ndarray().tolist(),
-        )
-        self.assertListEqual(
-            ngram[1].to_ndarray().tolist(),
-            ak.array([11, 12, 13, 14, 15, 21, 31, 32, 33]).to_ndarray().tolist(),
-        )
-        self.assertListEqual(
-            origin.to_ndarray().tolist(), ak.array([0, 0, 0, 0, 0, 1, 2, 2, 2]).to_ndarray().tolist()
-        )
+        self.assertListEqual(ngram[0].to_ndarray().tolist(), [10, 11, 12, 13, 14, 20, 30, 31, 32])
+        self.assertListEqual(ngram[1].to_ndarray().tolist(), [11, 12, 13, 14, 15, 21, 31, 32, 33])
+        self.assertListEqual(origin.to_ndarray().tolist(), [0, 0, 0, 0, 0, 1, 2, 2, 2])
 
         ngram, origin = segarr.get_ngrams(5)
-        self.assertListEqual(ngram[0].to_ndarray().tolist(), ak.array([10, 11]).to_ndarray().tolist())
-        self.assertListEqual(ngram[1].to_ndarray().tolist(), ak.array([11, 12]).to_ndarray().tolist())
-        self.assertListEqual(ngram[2].to_ndarray().tolist(), ak.array([12, 13]).to_ndarray().tolist())
-        self.assertListEqual(ngram[3].to_ndarray().tolist(), ak.array([13, 14]).to_ndarray().tolist())
-        self.assertListEqual(ngram[4].to_ndarray().tolist(), ak.array([14, 15]).to_ndarray().tolist())
-        self.assertListEqual(origin.to_ndarray().tolist(), ak.array([0, 0]).to_ndarray().tolist())
+        self.assertListEqual(ngram[0].to_ndarray().tolist(), [10, 11])
+        self.assertListEqual(ngram[1].to_ndarray().tolist(), [11, 12])
+        self.assertListEqual(ngram[2].to_ndarray().tolist(), [12, 13])
+        self.assertListEqual(ngram[3].to_ndarray().tolist(), [13, 14])
+        self.assertListEqual(ngram[4].to_ndarray().tolist(), [14, 15])
+        self.assertListEqual(origin.to_ndarray().tolist(), [0, 0])
 
         # Test with empty segment
         flat = ak.array(a + b)
@@ -263,11 +241,11 @@ class SegArrayTest(ArkoudaTest):
         segarr = ak.SegArray(segments, akflat)
 
         res, origins = segarr.get_jth(1)
-        self.assertListEqual(res.to_ndarray().tolist(), ak.array([11, 21, 31]).to_ndarray().tolist())
+        self.assertListEqual(res.to_ndarray().tolist(), [11, 21, 31])
         res, origins = segarr.get_jth(5)
-        self.assertListEqual(res.to_ndarray().tolist(), ak.array([15, 0, 0]).to_ndarray().tolist())
+        self.assertListEqual(res.to_ndarray().tolist(), [15, 0, 0])
         res, origins = segarr.get_jth(5, compressed=True)
-        self.assertListEqual(res.to_ndarray().tolist(), ak.array([15]).to_ndarray().tolist())
+        self.assertListEqual(res.to_ndarray().tolist(), [15])
 
         # Test with empty segment
         flat = ak.array(a + b)
@@ -324,8 +302,8 @@ class SegArrayTest(ArkoudaTest):
         segarr = ak.SegArray(segments, akflat)
 
         elem, origin = segarr.get_length_n(2)
-        self.assertListEqual(elem[0].to_ndarray().tolist(), ak.array([20]).to_ndarray().tolist())
-        self.assertListEqual(elem[1].to_ndarray().tolist(), ak.array([21]).to_ndarray().tolist())
+        self.assertListEqual(elem[0].to_ndarray().tolist(), [20])
+        self.assertListEqual(elem[1].to_ndarray().tolist(), [21])
 
         # Test with empty segment
         flat = ak.array(a + b)

--- a/tests/segarray_test.py
+++ b/tests/segarray_test.py
@@ -14,7 +14,9 @@ class SegArrayTest(ArkoudaTest):
         segarr = ak.SegArray(segments, akflat)
 
         self.assertIsInstance(segarr, ak.SegArray)
-        self.assertTrue((segarr._get_lengths() == ak.array([6, 2, 4])).all())
+        self.assertListEqual(
+            segarr._get_lengths().to_ndarray().tolist(), ak.array([6, 2, 4]).to_ndarray().tolist()
+        )
         self.assertEqual(segarr.__str__(), f"SegArray([\n{a}\n{b}\n{c}\n])".replace(",", ""))
         self.assertEqual(segarr.__getitem__(1).__str__(), str(b).replace(",", ""))
         self.assertEqual(
@@ -137,18 +139,24 @@ class SegArrayTest(ArkoudaTest):
 
         suffix, origin = segarr.get_suffixes(1)
         self.assertTrue(origin.all())
-        self.assertTrue((suffix[0] == ak.array([15, 21, 33])).all())
+        self.assertListEqual(
+            suffix[0].to_ndarray().tolist(), ak.array([15, 21, 33]).to_ndarray().tolist()
+        )
 
         suffix, origin = segarr.get_suffixes(2)
-        self.assertTrue((suffix[0] == ak.array([14, 32])).all())
-        self.assertTrue((suffix[1] == ak.array([15, 33])).all())
+        self.assertListEqual(suffix[0].to_ndarray().tolist(), ak.array([14, 32]).to_ndarray().tolist())
+        self.assertListEqual(suffix[1].to_ndarray().tolist(), ak.array([15, 33]).to_ndarray().tolist())
         self.assertTrue(origin[0])
         self.assertFalse(origin[1])
         self.assertTrue(origin[2])
 
         suffix, origin = segarr.get_suffixes(2, proper=False)
-        self.assertTrue((suffix[0] == ak.array([14, 20, 32])).all())
-        self.assertTrue((suffix[1] == ak.array([15, 21, 33])).all())
+        self.assertListEqual(
+            suffix[0].to_ndarray().tolist(), ak.array([14, 20, 32]).to_ndarray().tolist()
+        )
+        self.assertListEqual(
+            suffix[1].to_ndarray().tolist(), ak.array([15, 21, 33]).to_ndarray().tolist()
+        )
         self.assertTrue(origin.all())
 
         # Test with empty segment
@@ -171,19 +179,25 @@ class SegArrayTest(ArkoudaTest):
         segarr = ak.SegArray(segments, akflat)
         prefix, origin = segarr.get_prefixes(1)
 
-        self.assertTrue((prefix[0] == ak.array([10, 20, 30])).all())
+        self.assertListEqual(
+            prefix[0].to_ndarray().tolist(), ak.array([10, 20, 30]).to_ndarray().tolist()
+        )
         self.assertTrue(origin.all())
 
         prefix, origin = segarr.get_prefixes(2)
-        self.assertTrue((prefix[0] == ak.array([10, 30])).all())
-        self.assertTrue((prefix[1] == ak.array([11, 31])).all())
+        self.assertListEqual(prefix[0].to_ndarray().tolist(), ak.array([10, 30]).to_ndarray().tolist())
+        self.assertListEqual(prefix[1].to_ndarray().tolist(), ak.array([11, 31]).to_ndarray().tolist())
         self.assertTrue(origin[0])
         self.assertFalse(origin[1])
         self.assertTrue(origin[2])
 
         prefix, origin = segarr.get_prefixes(2, proper=False)
-        self.assertTrue((prefix[0] == ak.array([10, 20, 30])).all())
-        self.assertTrue((prefix[1] == ak.array([11, 21, 31])).all())
+        self.assertListEqual(
+            prefix[0].to_ndarray().tolist(), ak.array([10, 20, 30]).to_ndarray().tolist()
+        )
+        self.assertListEqual(
+            prefix[1].to_ndarray().tolist(), ak.array([11, 21, 31]).to_ndarray().tolist()
+        )
         self.assertTrue(origin.all())
 
         # Test with empty segment
@@ -205,17 +219,25 @@ class SegArrayTest(ArkoudaTest):
 
         segarr = ak.SegArray(segments, akflat)
         ngram, origin = segarr.get_ngrams(2)
-        self.assertTrue((ngram[0] == ak.array([10, 11, 12, 13, 14, 20, 30, 31, 32])).all())
-        self.assertTrue((ngram[1] == ak.array([11, 12, 13, 14, 15, 21, 31, 32, 33])).all())
-        self.assertTrue((origin == ak.array([0, 0, 0, 0, 0, 1, 2, 2, 2])).all())
+        self.assertListEqual(
+            ngram[0].to_ndarray().tolist(),
+            ak.array([10, 11, 12, 13, 14, 20, 30, 31, 32]).to_ndarray().tolist(),
+        )
+        self.assertListEqual(
+            ngram[1].to_ndarray().tolist(),
+            ak.array([11, 12, 13, 14, 15, 21, 31, 32, 33]).to_ndarray().tolist(),
+        )
+        self.assertListEqual(
+            origin.to_ndarray().tolist(), ak.array([0, 0, 0, 0, 0, 1, 2, 2, 2]).to_ndarray().tolist()
+        )
 
         ngram, origin = segarr.get_ngrams(5)
-        self.assertTrue((ngram[0] == ak.array([10, 11])).all())
-        self.assertTrue((ngram[1] == ak.array([11, 12])).all())
-        self.assertTrue((ngram[2] == ak.array([12, 13])).all())
-        self.assertTrue((ngram[3] == ak.array([13, 14])).all())
-        self.assertTrue((ngram[4] == ak.array([14, 15])).all())
-        self.assertTrue((origin == ak.array([0, 0])).all())
+        self.assertListEqual(ngram[0].to_ndarray().tolist(), ak.array([10, 11]).to_ndarray().tolist())
+        self.assertListEqual(ngram[1].to_ndarray().tolist(), ak.array([11, 12]).to_ndarray().tolist())
+        self.assertListEqual(ngram[2].to_ndarray().tolist(), ak.array([12, 13]).to_ndarray().tolist())
+        self.assertListEqual(ngram[3].to_ndarray().tolist(), ak.array([13, 14]).to_ndarray().tolist())
+        self.assertListEqual(ngram[4].to_ndarray().tolist(), ak.array([14, 15]).to_ndarray().tolist())
+        self.assertListEqual(origin.to_ndarray().tolist(), ak.array([0, 0]).to_ndarray().tolist())
 
         # Test with empty segment
         flat = ak.array(a + b)
@@ -241,11 +263,11 @@ class SegArrayTest(ArkoudaTest):
         segarr = ak.SegArray(segments, akflat)
 
         res, origins = segarr.get_jth(1)
-        self.assertTrue((res == ak.array([11, 21, 31])).all())
+        self.assertListEqual(res.to_ndarray().tolist(), ak.array([11, 21, 31]).to_ndarray().tolist())
         res, origins = segarr.get_jth(5)
-        self.assertTrue((res == ak.array([15, 0, 0])).all())
+        self.assertListEqual(res.to_ndarray().tolist(), ak.array([15, 0, 0]).to_ndarray().tolist())
         res, origins = segarr.get_jth(5, compressed=True)
-        self.assertTrue((res == ak.array([15])).all())
+        self.assertListEqual(res.to_ndarray().tolist(), ak.array([15]).to_ndarray().tolist())
 
         # Test with empty segment
         flat = ak.array(a + b)
@@ -302,8 +324,8 @@ class SegArrayTest(ArkoudaTest):
         segarr = ak.SegArray(segments, akflat)
 
         elem, origin = segarr.get_length_n(2)
-        self.assertTrue((elem[0] == ak.array([20])).all())
-        self.assertTrue((elem[1] == ak.array([21])).all())
+        self.assertListEqual(elem[0].to_ndarray().tolist(), ak.array([20]).to_ndarray().tolist())
+        self.assertListEqual(elem[1].to_ndarray().tolist(), ak.array([21]).to_ndarray().tolist())
 
         # Test with empty segment
         flat = ak.array(a + b)

--- a/tests/series_test.py
+++ b/tests/series_test.py
@@ -85,7 +85,7 @@ class SeriesTest(ArkoudaTest):
         added = s.add(s_add)
 
         idx_list = added.index.to_pandas().tolist()
-        val_list = added.values.to_ndarray().tolist()
+        val_list = added.values.to_list()
         for i in range(6):
             self.assertIn(i, idx_list)
             self.assertIn(i, val_list)
@@ -97,7 +97,7 @@ class SeriesTest(ArkoudaTest):
 
         top = s.topn(2)
         self.assertListEqual(top.index.to_pandas().tolist(), [2, 1])
-        self.assertListEqual(top.values.to_ndarray().tolist(), [2, 1])
+        self.assertListEqual(top.values.to_list(), [2, 1])
 
     def test_sort_idx(self):
         v = ak.arange(5)
@@ -106,7 +106,7 @@ class SeriesTest(ArkoudaTest):
 
         sorted = s.sort_index()
         self.assertListEqual(sorted.index.to_pandas().tolist(), [i for i in range(5)])
-        self.assertListEqual(sorted.values.to_ndarray().tolist(), [3, 1, 4, 0, 2])
+        self.assertListEqual(sorted.values.to_list(), [3, 1, 4, 0, 2])
 
     def test_sort_value(self):
         v = ak.array([3, 1, 4, 0, 2])
@@ -115,7 +115,7 @@ class SeriesTest(ArkoudaTest):
 
         sorted = s.sort_values()
         self.assertListEqual(sorted.index.to_pandas().tolist(), [3, 1, 4, 0, 2])
-        self.assertListEqual(sorted.values.to_ndarray().tolist(), [i for i in range(5)])
+        self.assertListEqual(sorted.values.to_list(), [i for i in range(5)])
 
     def test_head_tail(self):
         v = ak.arange(5)
@@ -124,11 +124,11 @@ class SeriesTest(ArkoudaTest):
 
         head = s.head(2)
         self.assertListEqual(head.index.to_pandas().tolist(), [0, 1])
-        self.assertListEqual(head.values.to_ndarray().tolist(), [0, 1])
+        self.assertListEqual(head.values.to_list(), [0, 1])
 
         tail = s.tail(3)
         self.assertListEqual(tail.index.to_pandas().tolist(), [2, 3, 4])
-        self.assertListEqual(tail.values.to_ndarray().tolist(), [2, 3, 4])
+        self.assertListEqual(tail.values.to_list(), [2, 3, 4])
 
     def test_value_counts(self):
         v = ak.array([0, 0, 1, 2, 2])
@@ -137,11 +137,11 @@ class SeriesTest(ArkoudaTest):
 
         c = s.value_counts()
         self.assertListEqual(c.index.to_pandas().tolist(), [0, 2, 1])
-        self.assertListEqual(c.values.to_ndarray().tolist(), [2, 2, 1])
+        self.assertListEqual(c.values.to_list(), [2, 2, 1])
 
         c = s.value_counts(sort=True)
         self.assertListEqual(c.index.to_pandas().tolist(), [0, 2, 1])
-        self.assertListEqual(c.values.to_ndarray().tolist(), [2, 2, 1])
+        self.assertListEqual(c.values.to_list(), [2, 2, 1])
 
     def test_concat(self):
         v = ak.arange(5)
@@ -154,7 +154,7 @@ class SeriesTest(ArkoudaTest):
 
         c = ak.Series.concat([s, s2])
         self.assertListEqual(c.index.to_pandas().tolist(), [i for i in range(11)])
-        self.assertListEqual(c.values.to_ndarray().tolist(), [i for i in range(11)])
+        self.assertListEqual(c.values.to_list(), [i for i in range(11)])
 
         df = ak.Series.concat([s, s2], axis=1)
         self.assertIsInstance(df, ak.DataFrame)

--- a/tests/series_test.py
+++ b/tests/series_test.py
@@ -10,12 +10,12 @@ class SeriesTest(ArkoudaTest):
         s = ak.Series(ar_tuple)
         self.assertIsInstance(s, ak.Series)
 
-        ar_tuple = ak.array(['A', 'B', 'C']), ak.arange(3)
+        ar_tuple = ak.array(["A", "B", "C"]), ak.arange(3)
         s = ak.Series(ar_tuple)
         self.assertIsInstance(s, ak.Series)
 
         # Both data and index are supplied
-        v = ak.array(['A', 'B', 'C'])
+        v = ak.array(["A", "B", "C"])
         i = ak.arange(3)
         s = ak.Series(data=v, index=i)
 
@@ -32,7 +32,7 @@ class SeriesTest(ArkoudaTest):
             s = ak.Series(index=i)
 
         # Just data is supplied (positional argument)
-        s = ak.Series(ak.array(['A', 'B', 'C']))
+        s = ak.Series(ak.array(["A", "B", "C"]))
         self.assertIsInstance(s, ak.Series)
 
         # Just index is supplied (ar_tuple argument)
@@ -48,7 +48,7 @@ class SeriesTest(ArkoudaTest):
             s = ak.Series(data=ak.arange(3), index=ak.arange(6))
 
     def test_lookup(self):
-        v = ak.array(['A', 'B', 'C'])
+        v = ak.array(["A", "B", "C"])
         i = ak.arange(3)
         s = ak.Series(data=v, index=i)
 
@@ -65,7 +65,7 @@ class SeriesTest(ArkoudaTest):
         self.assertEqual(lk.values[1], "C")
 
     def test_shape(self):
-        v = ak.array(['A', 'B', 'C'])
+        v = ak.array(["A", "B", "C"])
         i = ak.arange(3)
         s = ak.Series(data=v, index=i)
 
@@ -194,6 +194,6 @@ class SeriesTest(ArkoudaTest):
 
     def test_index_as_index_compat(self):
         # added to validate functionality for issue #1506
-        df = ak.DataFrame({'a': ak.arange(10), 'b': ak.arange(10), 'c': ak.arange(10)})
-        g = df.groupby(['a', 'b'])
-        g.broadcast(g.sum('c'))
+        df = ak.DataFrame({"a": ak.arange(10), "b": ak.arange(10), "c": ak.arange(10)})
+        g = df.groupby(["a", "b"])
+        g.broadcast(g.sum("c"))

--- a/tests/setops_test.py
+++ b/tests/setops_test.py
@@ -92,7 +92,7 @@ class SetOpsTest(ArkoudaTest):
         pdaOne = ak.array([1, 2, 3, 2, 4])
         pdaTwo = ak.array([2, 3, 5, 7, 5])
 
-        self.assertListEqual([1, 4, 5, 7], ak.setxor1d(pdaOne, pdaTwo).to_ndarray().tolist())
+        self.assertListEqual([1, 4, 5, 7], ak.setxor1d(pdaOne, pdaTwo).to_list())
 
         with self.assertRaises(TypeError):
             ak.setxor1d(ak.array([-1.0, 0.0, 1.0]), ak.array([-2.0, 0.0, 2.0]))
@@ -117,13 +117,13 @@ class SetOpsTest(ArkoudaTest):
 
         # Testing
         t = ak.setxor1d([a1, a2], [b1, b2])
-        self.assertListEqual(t[0].to_ndarray().tolist(), npr0)
-        self.assertListEqual(t[1].to_ndarray().tolist(), npr1)
+        self.assertListEqual(t[0].to_list(), npr0)
+        self.assertListEqual(t[1].to_list(), npr1)
 
         # Testing tuple input
         t = ak.setxor1d((a1, a2), (b1, b2))
-        self.assertListEqual(t[0].to_ndarray().tolist(), npr0)
-        self.assertListEqual(t[1].to_ndarray().tolist(), npr1)
+        self.assertListEqual(t[0].to_list(), npr0)
+        self.assertListEqual(t[1].to_list(), npr1)
 
         # Test for strings
         a = ["abc", "def"]
@@ -135,8 +135,8 @@ class SetOpsTest(ArkoudaTest):
         b1 = ak.array(c)
         b2 = ak.array(d)
         t = ak.setxor1d([a1, a2], [b1, b2])
-        self.assertListEqual(["abc", "abc"], t[0].to_ndarray().tolist())
-        self.assertListEqual(["000", "123"], t[1].to_ndarray().tolist())
+        self.assertListEqual(["abc", "abc"], t[0].to_list())
+        self.assertListEqual(["000", "123"], t[1].to_list())
 
         # Test for Categorical
         cat_a1 = ak.Categorical(a1)
@@ -144,14 +144,14 @@ class SetOpsTest(ArkoudaTest):
         cat_b1 = ak.Categorical(b1)
         cat_b2 = ak.Categorical(b2)
         t = ak.setxor1d([cat_a1, cat_a2], [cat_b1, cat_b2])
-        self.assertListEqual(["abc", "abc"], t[0].to_ndarray().tolist())
-        self.assertListEqual(["000", "123"], t[1].to_ndarray().tolist())
+        self.assertListEqual(["abc", "abc"], t[0].to_list())
+        self.assertListEqual(["000", "123"], t[1].to_list())
 
     def testSetdiff1d(self):
         pdaOne = ak.array([1, 2, 3, 2, 4, 1])
         pdaTwo = ak.array([3, 4, 5, 6])
 
-        self.assertListEqual([1, 2], ak.setdiff1d(pdaOne, pdaTwo).to_ndarray().tolist())
+        self.assertListEqual([1, 2], ak.setdiff1d(pdaOne, pdaTwo).to_list())
 
         with self.assertRaises(TypeError):
             ak.setdiff1d(ak.array([-1.0, 0.0, 1.0]), ak.array([-2.0, 0.0, 2.0]))
@@ -175,8 +175,8 @@ class SetOpsTest(ArkoudaTest):
         npr0, npr1 = map(list, zip(*lr))
 
         t = ak.setdiff1d([a1, a2], [b1, b2])
-        self.assertListEqual(t[0].to_ndarray().tolist(), npr0)
-        self.assertListEqual(t[1].to_ndarray().tolist(), npr1)
+        self.assertListEqual(t[0].to_list(), npr0)
+        self.assertListEqual(t[1].to_list(), npr1)
 
         # Test for strings
         a = ["abc", "def"]
@@ -188,8 +188,8 @@ class SetOpsTest(ArkoudaTest):
         b1 = ak.array(c)
         b2 = ak.array(d)
         t = ak.setdiff1d([a1, a2], [b1, b2])
-        self.assertListEqual(["abc"], t[0].to_ndarray().tolist())
-        self.assertListEqual(["123"], t[1].to_ndarray().tolist())
+        self.assertListEqual(["abc"], t[0].to_list())
+        self.assertListEqual(["123"], t[1].to_list())
 
         # Test for Categorical
         cat_a1 = ak.Categorical(a1)
@@ -197,13 +197,13 @@ class SetOpsTest(ArkoudaTest):
         cat_b1 = ak.Categorical(b1)
         cat_b2 = ak.Categorical(b2)
         t = ak.setdiff1d([cat_a1, cat_a2], [cat_b1, cat_b2])
-        self.assertListEqual(["abc"], t[0].to_ndarray().tolist())
-        self.assertListEqual(["123"], t[1].to_ndarray().tolist())
+        self.assertListEqual(["abc"], t[0].to_list())
+        self.assertListEqual(["123"], t[1].to_list())
 
     def testIntersect1d(self):
         pdaOne = ak.array([1, 3, 4, 3])
         pdaTwo = ak.array([3, 1, 2, 1])
-        self.assertListEqual([1, 3], ak.intersect1d(pdaOne, pdaTwo).to_ndarray().tolist())
+        self.assertListEqual([1, 3], ak.intersect1d(pdaOne, pdaTwo).to_list())
 
         with self.assertRaises(TypeError):
             ak.intersect1d(ak.array([-1.0, 0.0, 1.0]), ak.array([-2.0, 0.0, 2.0]))
@@ -227,8 +227,8 @@ class SetOpsTest(ArkoudaTest):
         npr0, npr1 = map(list, zip(*lr))
 
         t = ak.intersect1d([a1, a2], [b1, b2])
-        self.assertListEqual(t[0].to_ndarray().tolist(), npr0)
-        self.assertListEqual(t[1].to_ndarray().tolist(), npr1)
+        self.assertListEqual(t[0].to_list(), npr0)
+        self.assertListEqual(t[1].to_list(), npr1)
 
         # Test for strings
         a = ["abc", "def"]
@@ -240,8 +240,8 @@ class SetOpsTest(ArkoudaTest):
         b1 = ak.array(c)
         b2 = ak.array(d)
         t = ak.intersect1d([a1, a2], [b1, b2])
-        self.assertListEqual(["def"], t[0].to_ndarray().tolist())
-        self.assertListEqual(["456"], t[1].to_ndarray().tolist())
+        self.assertListEqual(["def"], t[0].to_list())
+        self.assertListEqual(["456"], t[1].to_list())
 
         # Test for Categorical
         cat_a1 = ak.Categorical(a1)
@@ -249,13 +249,13 @@ class SetOpsTest(ArkoudaTest):
         cat_b1 = ak.Categorical(b1)
         cat_b2 = ak.Categorical(b2)
         t = ak.intersect1d([cat_a1, cat_a2], [cat_b1, cat_b2])
-        self.assertListEqual(["def"], t[0].to_ndarray().tolist())
-        self.assertListEqual(["456"], t[1].to_ndarray().tolist())
+        self.assertListEqual(["def"], t[0].to_list())
+        self.assertListEqual(["456"], t[1].to_list())
 
     def testUnion1d(self):
         pdaOne = ak.array([-1, 0, 1])
         pdaTwo = ak.array([-2, 0, 2])
-        self.assertListEqual([-2, -1, 0, 1, 2], ak.union1d(pdaOne, pdaTwo).to_ndarray().tolist())
+        self.assertListEqual([-2, -1, 0, 1, 2], ak.union1d(pdaOne, pdaTwo).to_list())
 
         with self.assertRaises(TypeError):
             ak.union1d(ak.array([-1.0, 0.0, 1.0]), ak.array([-2.0, 0.0, 2.0]))
@@ -278,8 +278,8 @@ class SetOpsTest(ArkoudaTest):
         lr = list(sorted(la.union(lb)))
         npr0, npr1 = map(list, zip(*lr))
         t = ak.union1d([a1, a2], [b1, b2])
-        self.assertListEqual(t[0].to_ndarray().tolist(), npr0)
-        self.assertListEqual(t[1].to_ndarray().tolist(), npr1)
+        self.assertListEqual(t[0].to_list(), npr0)
+        self.assertListEqual(t[1].to_list(), npr1)
 
         # Test for Strings
         a = ["abc", "def"]
@@ -291,8 +291,8 @@ class SetOpsTest(ArkoudaTest):
         b1 = ak.array(c)
         b2 = ak.array(d)
         t = ak.union1d([a1, a2], [b1, b2])
-        self.assertListEqual(["def", "xyz", "abc"], t[0].to_ndarray().tolist())
-        self.assertListEqual(["456", "0", "123"], t[1].to_ndarray().tolist())
+        self.assertListEqual(["def", "xyz", "abc"], t[0].to_list())
+        self.assertListEqual(["456", "0", "123"], t[1].to_list())
 
         # Test for Categorical
         cat_a1 = ak.Categorical(a1)
@@ -300,14 +300,14 @@ class SetOpsTest(ArkoudaTest):
         cat_b1 = ak.Categorical(b1)
         cat_b2 = ak.Categorical(b2)
         t = ak.union1d([cat_a1, cat_a2], [cat_b1, cat_b2])
-        self.assertListEqual(["abc", "xyz", "def"], t[0].to_ndarray().tolist())
-        self.assertListEqual(["123", "0", "456"], t[1].to_ndarray().tolist())
+        self.assertListEqual(["abc", "xyz", "def"], t[0].to_list())
+        self.assertListEqual(["123", "0", "456"], t[1].to_list())
 
     def testIn1d(self):
         pdaOne = ak.array([-1, 0, 1, 3])
         pdaTwo = ak.array([-1, 2, 2, 3])
         self.assertListEqual(
-            ak.in1d(pdaOne, pdaTwo).to_ndarray().tolist(),
+            ak.in1d(pdaOne, pdaTwo).to_list(),
             [True, False, False, True],
         )
 
@@ -316,9 +316,7 @@ class SetOpsTest(ArkoudaTest):
         stringsOne = ak.array(["String {}".format(i) for i in vals])
         stringsTwo = ak.array(["String {}".format(i) for i in valsTwo])
 
-        self.assertListEqual(
-            [x < 2 for x in vals], ak.in1d(stringsOne, stringsTwo).to_ndarray().tolist()
-        )
+        self.assertListEqual([x < 2 for x in vals], ak.in1d(stringsOne, stringsTwo).to_list())
 
     def test_multiarray_validation(self):
         x = [ak.arange(3), ak.arange(3), ak.arange(3)]

--- a/tests/setops_test.py
+++ b/tests/setops_test.py
@@ -93,7 +93,9 @@ class SetOpsTest(ArkoudaTest):
         pdaTwo = ak.array([2, 3, 5, 7, 5])
         expected = ak.array([1, 4, 5, 7])
 
-        self.assertTrue((expected == ak.setxor1d(pdaOne, pdaTwo)).all())
+        self.assertListEqual(
+            expected.to_ndarray().tolist(), ak.setxor1d(pdaOne, pdaTwo).to_ndarray().tolist()
+        )
 
         with self.assertRaises(TypeError):
             ak.setxor1d(ak.array([-1.0, 0.0, 1.0]), ak.array([-2.0, 0.0, 2.0]))
@@ -153,7 +155,9 @@ class SetOpsTest(ArkoudaTest):
         pdaTwo = ak.array([3, 4, 5, 6])
         expected = ak.array([1, 2])
 
-        self.assertTrue((expected == ak.setdiff1d(pdaOne, pdaTwo)).all())
+        self.assertListEqual(
+            expected.to_ndarray().tolist(), ak.setdiff1d(pdaOne, pdaTwo).to_ndarray().tolist()
+        )
 
         with self.assertRaises(TypeError):
             ak.setdiff1d(ak.array([-1.0, 0.0, 1.0]), ak.array([-2.0, 0.0, 2.0]))
@@ -206,7 +210,9 @@ class SetOpsTest(ArkoudaTest):
         pdaOne = ak.array([1, 3, 4, 3])
         pdaTwo = ak.array([3, 1, 2, 1])
         expected = ak.array([1, 3])
-        self.assertTrue((expected == ak.intersect1d(pdaOne, pdaTwo)).all())
+        self.assertListEqual(
+            expected.to_ndarray().tolist(), ak.intersect1d(pdaOne, pdaTwo).to_ndarray().tolist()
+        )
 
         with self.assertRaises(TypeError):
             ak.intersect1d(ak.array([-1.0, 0.0, 1.0]), ak.array([-2.0, 0.0, 2.0]))
@@ -259,7 +265,9 @@ class SetOpsTest(ArkoudaTest):
         pdaOne = ak.array([-1, 0, 1])
         pdaTwo = ak.array([-2, 0, 2])
         expected = ak.array([-2, -1, 0, 1, 2])
-        self.assertTrue((expected == ak.union1d(pdaOne, pdaTwo)).all())
+        self.assertListEqual(
+            expected.to_ndarray().tolist(), ak.union1d(pdaOne, pdaTwo).to_ndarray().tolist()
+        )
 
         with self.assertRaises(TypeError):
             ak.union1d(ak.array([-1.0, 0.0, 1.0]), ak.array([-2.0, 0.0, 2.0]))
@@ -310,7 +318,10 @@ class SetOpsTest(ArkoudaTest):
     def testIn1d(self):
         pdaOne = ak.array([-1, 0, 1, 3])
         pdaTwo = ak.array([-1, 2, 2, 3])
-        self.assertTrue((ak.in1d(pdaOne, pdaTwo) == ak.array([True, False, False, True])).all())
+        self.assertListEqual(
+            ak.in1d(pdaOne, pdaTwo).to_ndarray().tolist(),
+            ak.array([True, False, False, True]).to_ndarray().tolist(),
+        )
 
         vals = [i % 3 for i in range(10)]
         valsTwo = [i % 2 for i in range(10)]
@@ -318,7 +329,9 @@ class SetOpsTest(ArkoudaTest):
         stringsTwo = ak.array(["String {}".format(i) for i in valsTwo])
 
         answer = ak.array([x < 2 for x in vals])
-        self.assertTrue((answer == ak.in1d(stringsOne, stringsTwo)).all())
+        self.assertListEqual(
+            answer.to_ndarray().tolist(), ak.in1d(stringsOne, stringsTwo).to_ndarray().tolist()
+        )
 
     def test_multiarray_validation(self):
         x = [ak.arange(3), ak.arange(3), ak.arange(3)]

--- a/tests/setops_test.py
+++ b/tests/setops_test.py
@@ -91,11 +91,8 @@ class SetOpsTest(ArkoudaTest):
     def testSetxor1d(self):
         pdaOne = ak.array([1, 2, 3, 2, 4])
         pdaTwo = ak.array([2, 3, 5, 7, 5])
-        expected = ak.array([1, 4, 5, 7])
 
-        self.assertListEqual(
-            expected.to_ndarray().tolist(), ak.setxor1d(pdaOne, pdaTwo).to_ndarray().tolist()
-        )
+        self.assertListEqual([1, 4, 5, 7], ak.setxor1d(pdaOne, pdaTwo).to_ndarray().tolist())
 
         with self.assertRaises(TypeError):
             ak.setxor1d(ak.array([-1.0, 0.0, 1.0]), ak.array([-2.0, 0.0, 2.0]))
@@ -153,11 +150,8 @@ class SetOpsTest(ArkoudaTest):
     def testSetdiff1d(self):
         pdaOne = ak.array([1, 2, 3, 2, 4, 1])
         pdaTwo = ak.array([3, 4, 5, 6])
-        expected = ak.array([1, 2])
 
-        self.assertListEqual(
-            expected.to_ndarray().tolist(), ak.setdiff1d(pdaOne, pdaTwo).to_ndarray().tolist()
-        )
+        self.assertListEqual([1, 2], ak.setdiff1d(pdaOne, pdaTwo).to_ndarray().tolist())
 
         with self.assertRaises(TypeError):
             ak.setdiff1d(ak.array([-1.0, 0.0, 1.0]), ak.array([-2.0, 0.0, 2.0]))
@@ -209,10 +203,7 @@ class SetOpsTest(ArkoudaTest):
     def testIntersect1d(self):
         pdaOne = ak.array([1, 3, 4, 3])
         pdaTwo = ak.array([3, 1, 2, 1])
-        expected = ak.array([1, 3])
-        self.assertListEqual(
-            expected.to_ndarray().tolist(), ak.intersect1d(pdaOne, pdaTwo).to_ndarray().tolist()
-        )
+        self.assertListEqual([1, 3], ak.intersect1d(pdaOne, pdaTwo).to_ndarray().tolist())
 
         with self.assertRaises(TypeError):
             ak.intersect1d(ak.array([-1.0, 0.0, 1.0]), ak.array([-2.0, 0.0, 2.0]))
@@ -264,10 +255,7 @@ class SetOpsTest(ArkoudaTest):
     def testUnion1d(self):
         pdaOne = ak.array([-1, 0, 1])
         pdaTwo = ak.array([-2, 0, 2])
-        expected = ak.array([-2, -1, 0, 1, 2])
-        self.assertListEqual(
-            expected.to_ndarray().tolist(), ak.union1d(pdaOne, pdaTwo).to_ndarray().tolist()
-        )
+        self.assertListEqual([-2, -1, 0, 1, 2], ak.union1d(pdaOne, pdaTwo).to_ndarray().tolist())
 
         with self.assertRaises(TypeError):
             ak.union1d(ak.array([-1.0, 0.0, 1.0]), ak.array([-2.0, 0.0, 2.0]))
@@ -320,7 +308,7 @@ class SetOpsTest(ArkoudaTest):
         pdaTwo = ak.array([-1, 2, 2, 3])
         self.assertListEqual(
             ak.in1d(pdaOne, pdaTwo).to_ndarray().tolist(),
-            ak.array([True, False, False, True]).to_ndarray().tolist(),
+            [True, False, False, True],
         )
 
         vals = [i % 3 for i in range(10)]
@@ -328,9 +316,8 @@ class SetOpsTest(ArkoudaTest):
         stringsOne = ak.array(["String {}".format(i) for i in vals])
         stringsTwo = ak.array(["String {}".format(i) for i in valsTwo])
 
-        answer = ak.array([x < 2 for x in vals])
         self.assertListEqual(
-            answer.to_ndarray().tolist(), ak.in1d(stringsOne, stringsTwo).to_ndarray().tolist()
+            [x < 2 for x in vals], ak.in1d(stringsOne, stringsTwo).to_ndarray().tolist()
         )
 
     def test_multiarray_validation(self):

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -526,74 +526,47 @@ class StringTest(ArkoudaTest):
     def test_flatten(self):
         orig = ak.array(["one|two", "three|four|five", "six"])
         flat, mapping = orig.flatten("|", return_segments=True)
-        ans = ak.array(["one", "two", "three", "four", "five", "six"])
-        ans2 = ak.array([0, 2, 5])
-        self.assertListEqual(flat.to_ndarray().tolist(), ans.to_ndarray().tolist())
-        self.assertListEqual(mapping.to_ndarray().tolist(), ans2.to_ndarray().tolist())
+        self.assertListEqual(flat.to_ndarray().tolist(), ["one", "two", "three", "four", "five", "six"])
+        self.assertListEqual(mapping.to_ndarray().tolist(), [0, 2, 5])
         thirds = [ak.cast(ak.arange(i, 99, 3), "str") for i in range(3)]
         thickrange = thirds[0].stick(thirds[1], delimiter=", ").stick(thirds[2], delimiter=", ")
         flatrange = thickrange.flatten(", ")
-        self.assertListEqual(
-            ak.cast(flatrange, "int64").to_ndarray().tolist(), ak.arange(99).to_ndarray().tolist()
-        )
+        self.assertListEqual(ak.cast(flatrange, "int64").to_ndarray().tolist(), np.arange(99).tolist())
 
     def test_get_lengths(self):
         s1 = ak.array(["one", "two", "three", "four", "five"])
         lengths = s1.get_lengths()
-        self.assertListEqual(
-            ak.array([3, 3, 5, 4, 4]).to_ndarray().tolist(), lengths.to_ndarray().tolist()
-        )
+        self.assertListEqual([3, 3, 5, 4, 4], lengths.to_ndarray().tolist())
 
     def test_strip(self):
         s = ak.array([" Jim1", "John1   ", "Steve1 2"])
-        strip = s.strip(" 12")
-        expected = ak.array(["Jim", "John", "Steve"])
-        self.assertListEqual(strip.to_ndarray().tolist(), expected.to_ndarray().tolist())
-
-        s = ak.array([" Jim1", "John1   ", "Steve1 2"])
-        strip = s.strip("12 ")
-        expected = ak.array(["Jim", "John", "Steve"])
-        self.assertListEqual(strip.to_ndarray().tolist(), expected.to_ndarray().tolist())
-
-        s = ak.array([" Jim1", "John1   ", "Steve1 2"])
-        strip = s.strip("1 2")
-        expected = ak.array(["Jim", "John", "Steve"])
-        self.assertListEqual(strip.to_ndarray().tolist(), expected.to_ndarray().tolist())
+        self.assertListEqual(s.strip(" 12").to_ndarray().tolist(), ["Jim", "John", "Steve"])
+        self.assertListEqual(s.strip("12 ").to_ndarray().tolist(), ["Jim", "John", "Steve"])
+        self.assertListEqual(s.strip("1 2").to_ndarray().tolist(), ["Jim", "John", "Steve"])
 
         s = ak.array([" Jim", "John 1", "Steve1 2  "])
-        strip = s.strip()
-        expected = ak.array(["Jim", "John 1", "Steve1 2"])
-        self.assertListEqual(strip.to_ndarray().tolist(), expected.to_ndarray().tolist())
+        self.assertListEqual(s.strip().to_ndarray().tolist(), ["Jim", "John 1", "Steve1 2"])
 
-        s = ak.array(['\nStrings ', ' \n StringS \r', 'bbabStringS \r\t '])
-        strip = s.strip()
-        expected = ak.array(["Strings", "StringS", "bbabStringS"])
-        self.assertListEqual(strip.to_ndarray().tolist(), expected.to_ndarray().tolist())
+        s = ak.array(["\nStrings ", " \n StringS \r", "bbabStringS \r\t "])
+        self.assertListEqual(s.strip().to_ndarray().tolist(), ["Strings", "StringS", "bbabStringS"])
 
         s = ak.array(["abcStringsbac", "cabStringScc", "bbabStringS abc"])
-        strip = s.strip('abc')
-        expected = ak.array(["Strings", "StringS", "StringS "])
-        self.assertListEqual(strip.to_ndarray().tolist(), expected.to_ndarray().tolist())
+        self.assertListEqual(s.strip("abc").to_ndarray().tolist(), ["Strings", "StringS", "StringS "])
 
-        s = ak.array(['\nStrings ', ' \n StringS \r', ' \t   StringS \r\t '])
-        strip = s.strip()
-        expected = ak.array(["Strings", "StringS", "StringS"])
-        self.assertListEqual(strip.to_ndarray().tolist(), expected.to_ndarray().tolist())
+        s = ak.array(["\nStrings ", " \n StringS \r", " \t   StringS \r\t "])
+        self.assertListEqual(s.strip().to_ndarray().tolist(), ["Strings", "StringS", "StringS"])
 
     def test_case_change(self):
         mixed = ak.array([f"StrINgS {i}" for i in range(10)])
 
         lower = mixed.to_lower()
-        expected = ak.array([f"strings {i}" for i in range(10)])
-        self.assertListEqual(lower.to_ndarray().tolist(), expected.to_ndarray().tolist())
+        self.assertListEqual(lower.to_ndarray().tolist(), [f"strings {i}" for i in range(10)])
 
         upper = mixed.to_upper()
-        expected = ak.array([f"STRINGS {i}" for i in range(10)])
-        self.assertListEqual(upper.to_ndarray().tolist(), expected.to_ndarray().tolist())
+        self.assertListEqual(upper.to_ndarray().tolist(), [f"STRINGS {i}" for i in range(10)])
 
         title = mixed.to_title()
-        expected = ak.array([f"Strings {i}" for i in range(10)])
-        self.assertListEqual(title.to_ndarray().tolist(), expected.to_ndarray().tolist())
+        self.assertListEqual(title.to_ndarray().tolist(), [f"Strings {i}" for i in range(10)])
 
         # first 10 all lower, second 10 mixed case (not lower, upper, or title), third 10 all upper,
         # last 10 all title
@@ -625,24 +598,22 @@ class StringTest(ArkoudaTest):
 
         s1 = self._get_strings("string", 6)
         s2 = self._get_strings("string-two", 6)
-        expectedResult = ak.array(
-            [
-                "string 1",
-                "string 2",
-                "string 3",
-                "string 4",
-                "string 5",
-                "string-two 1",
-                "string-two 2",
-                "string-two 3",
-                "string-two 4",
-                "string-two 5",
-            ]
-        )
+        expected_result = [
+            "string 1",
+            "string 2",
+            "string 3",
+            "string 4",
+            "string 5",
+            "string-two 1",
+            "string-two 2",
+            "string-two 3",
+            "string-two 4",
+            "string-two 5",
+        ]
 
         # Ordered concatenation
         s12ord = ak.concatenate([s1, s2], ordered=True)
-        self.assertListEqual(expectedResult.to_ndarray().tolist(), s12ord.to_ndarray().tolist())
+        self.assertListEqual(expected_result, s12ord.to_ndarray().tolist())
         # Unordered (but still deterministic) concatenation
         # TODO: the unordered concatenation test is disabled per #710 #721
         # s12unord = ak.concatenate([s1, s2], ordered=False)

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -528,17 +528,21 @@ class StringTest(ArkoudaTest):
         flat, mapping = orig.flatten("|", return_segments=True)
         ans = ak.array(["one", "two", "three", "four", "five", "six"])
         ans2 = ak.array([0, 2, 5])
-        self.assertTrue((flat == ans).all())
-        self.assertTrue((mapping == ans2).all())
+        self.assertListEqual(flat.to_ndarray().tolist(), ans.to_ndarray().tolist())
+        self.assertListEqual(mapping.to_ndarray().tolist(), ans2.to_ndarray().tolist())
         thirds = [ak.cast(ak.arange(i, 99, 3), "str") for i in range(3)]
         thickrange = thirds[0].stick(thirds[1], delimiter=", ").stick(thirds[2], delimiter=", ")
         flatrange = thickrange.flatten(", ")
-        self.assertTrue((ak.cast(flatrange, "int64") == ak.arange(99)).all())
+        self.assertListEqual(
+            ak.cast(flatrange, "int64").to_ndarray().tolist(), ak.arange(99).to_ndarray().tolist()
+        )
 
     def test_get_lengths(self):
         s1 = ak.array(["one", "two", "three", "four", "five"])
         lengths = s1.get_lengths()
-        self.assertTrue((ak.array([3, 3, 5, 4, 4]) == lengths).all())
+        self.assertListEqual(
+            ak.array([3, 3, 5, 4, 4]).to_ndarray().tolist(), lengths.to_ndarray().tolist()
+        )
 
     def test_strip(self):
         s = ak.array([" Jim1", "John1   ", "Steve1 2"])
@@ -638,7 +642,7 @@ class StringTest(ArkoudaTest):
 
         # Ordered concatenation
         s12ord = ak.concatenate([s1, s2], ordered=True)
-        self.assertTrue((expectedResult == s12ord).all())
+        self.assertListEqual(expectedResult.to_ndarray().tolist(), s12ord.to_ndarray().tolist())
         # Unordered (but still deterministic) concatenation
         # TODO: the unordered concatenation test is disabled per #710 #721
         # s12unord = ak.concatenate([s1, s2], ordered=False)

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -17,16 +17,16 @@ class utilTest(ArkoudaTest):
         b_attached = attach(b.name)
         b_typed_attach = attach(b.name, "pdarray")
 
-        self.assertTrue((a == a_attached).all())
+        self.assertListEqual(a.to_ndarray().tolist(), a_attached.to_ndarray().tolist())
         self.assertIsInstance(a_attached, ak.Strings)
 
-        self.assertTrue((a == a_typed_attach).all())
+        self.assertListEqual(a.to_ndarray().tolist(), a_typed_attach.to_ndarray().tolist())
         self.assertIsInstance(a_typed_attach, ak.Strings)
 
-        self.assertTrue((b == b_attached).all())
+        self.assertListEqual(b.to_ndarray().tolist(), b_attached.to_ndarray().tolist())
         self.assertIsInstance(b_attached, ak.pdarray)
 
-        self.assertTrue((b == b_typed_attach).all())
+        self.assertListEqual(b.to_ndarray().tolist(), b_typed_attach.to_ndarray().tolist())
         self.assertIsInstance(b_typed_attach, ak.pdarray)
 
     def test_categorical_attach(self):
@@ -37,11 +37,11 @@ class utilTest(ArkoudaTest):
         cat.register("catTest")
 
         attached = attach("catTest")
-        self.assertTrue((cat == attached).all())
+        self.assertListEqual(cat.to_ndarray().tolist(), attached.to_ndarray().tolist())
         self.assertIsInstance(attached, ak.Categorical)
 
         attached_typed = attach("catTest", "Categorical")
-        self.assertTrue((cat == attached_typed).all())
+        self.assertListEqual(cat.to_ndarray().tolist(), attached_typed.to_ndarray().tolist())
         self.assertIsInstance(attached_typed, ak.Categorical)
 
     def test_segArray_attach(self):
@@ -56,11 +56,11 @@ class utilTest(ArkoudaTest):
         segarr.register("segTest")
 
         attached = attach("segTest")
-        self.assertTrue((segarr == attached).all())
+        self.assertListEqual(segarr.to_ndarray().tolist(), attached.to_ndarray().tolist())
         self.assertIsInstance(attached, ak.SegArray)
 
         attached_typed = attach("segTest", "SegArray")
-        self.assertTrue((segarr == attached_typed).all())
+        self.assertListEqual(segarr.to_ndarray().tolist(), attached_typed.to_ndarray().tolist())
         self.assertIsInstance(attached_typed, ak.SegArray)
 
     def test_series_attach(self):

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -17,16 +17,16 @@ class utilTest(ArkoudaTest):
         b_attached = attach(b.name)
         b_typed_attach = attach(b.name, "pdarray")
 
-        self.assertListEqual(a.to_ndarray().tolist(), a_attached.to_ndarray().tolist())
+        self.assertListEqual(a.to_list(), a_attached.to_list())
         self.assertIsInstance(a_attached, ak.Strings)
 
-        self.assertListEqual(a.to_ndarray().tolist(), a_typed_attach.to_ndarray().tolist())
+        self.assertListEqual(a.to_list(), a_typed_attach.to_list())
         self.assertIsInstance(a_typed_attach, ak.Strings)
 
-        self.assertListEqual(b.to_ndarray().tolist(), b_attached.to_ndarray().tolist())
+        self.assertListEqual(b.to_list(), b_attached.to_list())
         self.assertIsInstance(b_attached, ak.pdarray)
 
-        self.assertListEqual(b.to_ndarray().tolist(), b_typed_attach.to_ndarray().tolist())
+        self.assertListEqual(b.to_list(), b_typed_attach.to_list())
         self.assertIsInstance(b_typed_attach, ak.pdarray)
 
     def test_categorical_attach(self):
@@ -37,11 +37,11 @@ class utilTest(ArkoudaTest):
         cat.register("catTest")
 
         attached = attach("catTest")
-        self.assertListEqual(cat.to_ndarray().tolist(), attached.to_ndarray().tolist())
+        self.assertListEqual(cat.to_list(), attached.to_list())
         self.assertIsInstance(attached, ak.Categorical)
 
         attached_typed = attach("catTest", "Categorical")
-        self.assertListEqual(cat.to_ndarray().tolist(), attached_typed.to_ndarray().tolist())
+        self.assertListEqual(cat.to_list(), attached_typed.to_list())
         self.assertIsInstance(attached_typed, ak.Categorical)
 
     def test_segArray_attach(self):
@@ -56,17 +56,11 @@ class utilTest(ArkoudaTest):
         segarr.register("segTest")
 
         attached = attach("segTest")
-        # TODO segarray.to_ndarray() currently returns a list tracked by Issue#1600
-        # potentially return below instead:
-        # self.assertListEqual(segarr.to_ndarray().tolist(), attached.to_ndarray().tolist())
-        self.assertTrue((segarr == attached).all())
+        self.assertListEqual(segarr.to_list(), attached.to_list())
         self.assertIsInstance(attached, ak.SegArray)
 
         attached_typed = attach("segTest", "SegArray")
-        # TODO segarray.to_ndarray() currently returns a list tracked by Issue#1600
-        # potentially return below instead:
-        # self.assertListEqual(segarr.to_ndarray().tolist(), attached_typed.to_ndarray().tolist())
-        self.assertTrue((segarr == attached_typed).all())
+        self.assertListEqual(segarr.to_list(), attached_typed.to_list())
         self.assertIsInstance(attached_typed, ak.SegArray)
 
     def test_series_attach(self):
@@ -80,11 +74,11 @@ class utilTest(ArkoudaTest):
         s_attach = ak.util.attach("series_test")
         s2_attach = ak.util.attach("series_2_test")
 
-        self.assertListEqual(s_attach.values.to_ndarray().tolist(), s.values.to_ndarray().tolist())
+        self.assertListEqual(s_attach.values.to_list(), s.values.to_list())
         sEq = s_attach.index == s.index
         self.assertTrue(all(sEq.to_ndarray()))
 
-        self.assertListEqual(s2_attach.values.to_ndarray().tolist(), s2.values.to_ndarray().tolist())
+        self.assertListEqual(s2_attach.values.to_list(), s2.values.to_list())
         s2Eq = s2_attach.index == s2.index
         self.assertTrue(all(s2Eq.to_ndarray()))
 

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -56,11 +56,17 @@ class utilTest(ArkoudaTest):
         segarr.register("segTest")
 
         attached = attach("segTest")
-        self.assertListEqual(segarr.to_ndarray().tolist(), attached.to_ndarray().tolist())
+        # TODO segarray.to_ndarray() currently returns a list tracked by Issue#1600
+        # potentially return below instead:
+        # self.assertListEqual(segarr.to_ndarray().tolist(), attached.to_ndarray().tolist())
+        self.assertTrue((segarr == attached).all())
         self.assertIsInstance(attached, ak.SegArray)
 
         attached_typed = attach("segTest", "SegArray")
-        self.assertListEqual(segarr.to_ndarray().tolist(), attached_typed.to_ndarray().tolist())
+        # TODO segarray.to_ndarray() currently returns a list tracked by Issue#1600
+        # potentially return below instead:
+        # self.assertListEqual(segarr.to_ndarray().tolist(), attached_typed.to_ndarray().tolist())
+        self.assertTrue((segarr == attached_typed).all())
         self.assertIsInstance(attached_typed, ak.SegArray)
 
     def test_series_attach(self):

--- a/tests/where_test.py
+++ b/tests/where_test.py
@@ -68,11 +68,13 @@ class WhereTest(ArkoudaTest):
 
         cond = n1 < 5
         result = np.where(cond, n1, n2)
-        self.assertTrue((np.array([1, 2, 3, 4, 1, 1, 1, 1, 1]) == result).all())
+        self.assertListEqual(np.array([1, 2, 3, 4, 1, 1, 1, 1, 1]).tolist(), result.tolist())
 
         cond = a1 < 5
         result = ak.where(cond, a1, a2)
-        self.assertTrue((ak.array([1, 2, 3, 4, 1, 1, 1, 1, 1]) == result).all())
+        self.assertListEqual(
+            ak.array([1, 2, 3, 4, 1, 1, 1, 1, 1]).to_ndarray().tolist(), result.to_ndarray().tolist()
+        )
 
     def test_greater_than_where_clause(self):
         n1 = np.arange(1, 10)
@@ -82,11 +84,13 @@ class WhereTest(ArkoudaTest):
 
         cond = n1 > 5
         result = np.where(cond, n1, n2)
-        self.assertTrue((np.array([1, 1, 1, 1, 1, 6, 7, 8, 9]) == result).all())
+        self.assertListEqual(np.array([1, 1, 1, 1, 1, 6, 7, 8, 9]).tolist(), result.tolist())
 
         cond = a1 > 5
         result = ak.where(cond, a1, a2)
-        self.assertTrue((ak.array([1, 1, 1, 1, 1, 6, 7, 8, 9]) == result).all())
+        self.assertListEqual(
+            ak.array([1, 1, 1, 1, 1, 6, 7, 8, 9]).to_ndarray().tolist(), result.to_ndarray().tolist()
+        )
 
     def test_greater_than_where_clause_with_scalars(self):
         n1 = np.arange(1, 10)
@@ -94,17 +98,21 @@ class WhereTest(ArkoudaTest):
 
         condN = n1 > 5
         result = np.where(condN, n1, 1)
-        self.assertTrue((np.array([1, 1, 1, 1, 1, 6, 7, 8, 9]) == result).all())
+        self.assertListEqual(np.array([1, 1, 1, 1, 1, 6, 7, 8, 9]).tolist(), result.tolist())
 
         condA = a1 > 5
         result = ak.where(condA, a1, 1)
-        self.assertTrue((ak.array([1, 1, 1, 1, 1, 6, 7, 8, 9]) == result).all())
+        self.assertListEqual(
+            ak.array([1, 1, 1, 1, 1, 6, 7, 8, 9]).to_ndarray().tolist(), result.to_ndarray().tolist()
+        )
 
         result = np.where(condN, 1, n1)
-        self.assertTrue((np.array([1, 2, 3, 4, 5, 1, 1, 1, 1]) == result).all())
+        self.assertListEqual(np.array([1, 2, 3, 4, 5, 1, 1, 1, 1]).tolist(), result.tolist())
 
         result = ak.where(condA, 1, a1)
-        self.assertTrue((ak.array([1, 2, 3, 4, 5, 1, 1, 1, 1]) == result).all())
+        self.assertListEqual(
+            ak.array([1, 2, 3, 4, 5, 1, 1, 1, 1]).to_ndarray().tolist(), result.to_ndarray().tolist()
+        )
 
     def test_not_equal_where_clause(self):
         n1 = np.arange(1, 10)
@@ -114,11 +122,13 @@ class WhereTest(ArkoudaTest):
 
         cond = n1 != 5
         result = np.where(cond, n1, n2)
-        self.assertTrue((np.array([1, 2, 3, 4, 1, 6, 7, 8, 9]) == result).all())
+        self.assertListEqual(np.array([1, 2, 3, 4, 1, 6, 7, 8, 9]).tolist(), result.tolist())
 
         cond = a1 != 5
         result = ak.where(cond, a1, a2)
-        self.assertTrue((ak.array([1, 2, 3, 4, 1, 6, 7, 8, 9]) == result).all())
+        self.assertListEqual(
+            ak.array([1, 2, 3, 4, 1, 6, 7, 8, 9]).to_ndarray().tolist(), result.to_ndarray().tolist()
+        )
 
     def test_equals_where_clause(self):
         n1 = np.arange(1, 10)
@@ -128,11 +138,13 @@ class WhereTest(ArkoudaTest):
 
         cond = n1 == 5
         result = np.where(cond, n1, n2)
-        self.assertTrue((np.array([1, 1, 1, 1, 5, 1, 1, 1, 1]) == result).all())
+        self.assertListEqual(np.array([1, 1, 1, 1, 5, 1, 1, 1, 1]).tolist(), result.tolist())
 
         cond = a1 == 5
         result = ak.where(cond, a1, a2)
-        self.assertTrue((ak.array([1, 1, 1, 1, 5, 1, 1, 1, 1]) == result).all())
+        self.assertListEqual(
+            ak.array([1, 1, 1, 1, 5, 1, 1, 1, 1]).to_ndarray().tolist(), result.to_ndarray().tolist()
+        )
 
     def test_where_filter(self):
         n1 = np.arange(1, 10)
@@ -140,8 +152,8 @@ class WhereTest(ArkoudaTest):
         n2 = np.arange(6, 10)
         a2 = ak.array(n2)
 
-        self.assertTrue((n2 == n1[n1 > 5]).all())
-        self.assertTrue((a2 == a1[a1 > 5]).all())
+        self.assertListEqual(n2.tolist(), n1[n1 > 5].tolist())
+        self.assertListEqual(a2.to_ndarray().tolist(), a1[a1 > 5].to_ndarray().tolist())
 
     def test_multiple_where_clauses(self):
         n1 = np.arange(1, 10)
@@ -151,8 +163,9 @@ class WhereTest(ArkoudaTest):
 
         cond = n1 > 2, n1 < 8
         result = np.where(cond, n1, n2)
-        self.assertTrue(
-            (np.array([[1, 1, 3, 4, 5, 6, 7, 8, 9], [1, 2, 3, 4, 5, 6, 7, 1, 1]]) == result).all()
+        self.assertListEqual(
+            np.array([[1, 1, 3, 4, 5, 6, 7, 8, 9], [1, 2, 3, 4, 5, 6, 7, 1, 1]]).tolist(),
+            result.tolist(),
         )
         # Arkouda does not support multiple where clauses
         cond = a1 > 5, a1 < 8
@@ -164,6 +177,6 @@ class WhereTest(ArkoudaTest):
         for dt in (ak.int64, ak.uint64, ak.float64, ak.bool):
             a = ak.ones(10, dtype=dt)
             b = ak.ones(10, dtype=dt)
-            self.assertTrue((ak.where(cond, a, b) == a).all())
-            self.assertTrue((ak.where(cond, 1, b) == a).all())
-            self.assertTrue((ak.where(cond, a, 1) == a).all())
+            self.assertListEqual(ak.where(cond, a, b).to_ndarray().tolist(), a.to_ndarray().tolist())
+            self.assertListEqual(ak.where(cond, 1, b).to_ndarray().tolist(), a.to_ndarray().tolist())
+            self.assertListEqual(ak.where(cond, a, 1).to_ndarray().tolist(), a.to_ndarray().tolist())

--- a/tests/where_test.py
+++ b/tests/where_test.py
@@ -68,13 +68,11 @@ class WhereTest(ArkoudaTest):
 
         cond = n1 < 5
         result = np.where(cond, n1, n2)
-        self.assertListEqual(np.array([1, 2, 3, 4, 1, 1, 1, 1, 1]).tolist(), result.tolist())
+        self.assertListEqual([1, 2, 3, 4, 1, 1, 1, 1, 1], result.tolist())
 
         cond = a1 < 5
         result = ak.where(cond, a1, a2)
-        self.assertListEqual(
-            ak.array([1, 2, 3, 4, 1, 1, 1, 1, 1]).to_ndarray().tolist(), result.to_ndarray().tolist()
-        )
+        self.assertListEqual([1, 2, 3, 4, 1, 1, 1, 1, 1], result.to_ndarray().tolist())
 
     def test_greater_than_where_clause(self):
         n1 = np.arange(1, 10)
@@ -84,13 +82,11 @@ class WhereTest(ArkoudaTest):
 
         cond = n1 > 5
         result = np.where(cond, n1, n2)
-        self.assertListEqual(np.array([1, 1, 1, 1, 1, 6, 7, 8, 9]).tolist(), result.tolist())
+        self.assertListEqual([1, 1, 1, 1, 1, 6, 7, 8, 9], result.tolist())
 
         cond = a1 > 5
         result = ak.where(cond, a1, a2)
-        self.assertListEqual(
-            ak.array([1, 1, 1, 1, 1, 6, 7, 8, 9]).to_ndarray().tolist(), result.to_ndarray().tolist()
-        )
+        self.assertListEqual([1, 1, 1, 1, 1, 6, 7, 8, 9], result.to_ndarray().tolist())
 
     def test_greater_than_where_clause_with_scalars(self):
         n1 = np.arange(1, 10)
@@ -98,21 +94,17 @@ class WhereTest(ArkoudaTest):
 
         condN = n1 > 5
         result = np.where(condN, n1, 1)
-        self.assertListEqual(np.array([1, 1, 1, 1, 1, 6, 7, 8, 9]).tolist(), result.tolist())
+        self.assertListEqual([1, 1, 1, 1, 1, 6, 7, 8, 9], result.tolist())
 
         condA = a1 > 5
         result = ak.where(condA, a1, 1)
-        self.assertListEqual(
-            ak.array([1, 1, 1, 1, 1, 6, 7, 8, 9]).to_ndarray().tolist(), result.to_ndarray().tolist()
-        )
+        self.assertListEqual([1, 1, 1, 1, 1, 6, 7, 8, 9], result.to_ndarray().tolist())
 
         result = np.where(condN, 1, n1)
-        self.assertListEqual(np.array([1, 2, 3, 4, 5, 1, 1, 1, 1]).tolist(), result.tolist())
+        self.assertListEqual([1, 2, 3, 4, 5, 1, 1, 1, 1], result.tolist())
 
         result = ak.where(condA, 1, a1)
-        self.assertListEqual(
-            ak.array([1, 2, 3, 4, 5, 1, 1, 1, 1]).to_ndarray().tolist(), result.to_ndarray().tolist()
-        )
+        self.assertListEqual([1, 2, 3, 4, 5, 1, 1, 1, 1], result.to_ndarray().tolist())
 
     def test_not_equal_where_clause(self):
         n1 = np.arange(1, 10)
@@ -122,13 +114,11 @@ class WhereTest(ArkoudaTest):
 
         cond = n1 != 5
         result = np.where(cond, n1, n2)
-        self.assertListEqual(np.array([1, 2, 3, 4, 1, 6, 7, 8, 9]).tolist(), result.tolist())
+        self.assertListEqual([1, 2, 3, 4, 1, 6, 7, 8, 9], result.tolist())
 
         cond = a1 != 5
         result = ak.where(cond, a1, a2)
-        self.assertListEqual(
-            ak.array([1, 2, 3, 4, 1, 6, 7, 8, 9]).to_ndarray().tolist(), result.to_ndarray().tolist()
-        )
+        self.assertListEqual([1, 2, 3, 4, 1, 6, 7, 8, 9], result.to_ndarray().tolist())
 
     def test_equals_where_clause(self):
         n1 = np.arange(1, 10)
@@ -138,13 +128,11 @@ class WhereTest(ArkoudaTest):
 
         cond = n1 == 5
         result = np.where(cond, n1, n2)
-        self.assertListEqual(np.array([1, 1, 1, 1, 5, 1, 1, 1, 1]).tolist(), result.tolist())
+        self.assertListEqual([1, 1, 1, 1, 5, 1, 1, 1, 1], result.tolist())
 
         cond = a1 == 5
         result = ak.where(cond, a1, a2)
-        self.assertListEqual(
-            ak.array([1, 1, 1, 1, 5, 1, 1, 1, 1]).to_ndarray().tolist(), result.to_ndarray().tolist()
-        )
+        self.assertListEqual([1, 1, 1, 1, 5, 1, 1, 1, 1], result.to_ndarray().tolist())
 
     def test_where_filter(self):
         n1 = np.arange(1, 10)

--- a/tests/where_test.py
+++ b/tests/where_test.py
@@ -72,7 +72,7 @@ class WhereTest(ArkoudaTest):
 
         cond = a1 < 5
         result = ak.where(cond, a1, a2)
-        self.assertListEqual([1, 2, 3, 4, 1, 1, 1, 1, 1], result.to_ndarray().tolist())
+        self.assertListEqual([1, 2, 3, 4, 1, 1, 1, 1, 1], result.to_list())
 
     def test_greater_than_where_clause(self):
         n1 = np.arange(1, 10)
@@ -86,7 +86,7 @@ class WhereTest(ArkoudaTest):
 
         cond = a1 > 5
         result = ak.where(cond, a1, a2)
-        self.assertListEqual([1, 1, 1, 1, 1, 6, 7, 8, 9], result.to_ndarray().tolist())
+        self.assertListEqual([1, 1, 1, 1, 1, 6, 7, 8, 9], result.to_list())
 
     def test_greater_than_where_clause_with_scalars(self):
         n1 = np.arange(1, 10)
@@ -98,13 +98,13 @@ class WhereTest(ArkoudaTest):
 
         condA = a1 > 5
         result = ak.where(condA, a1, 1)
-        self.assertListEqual([1, 1, 1, 1, 1, 6, 7, 8, 9], result.to_ndarray().tolist())
+        self.assertListEqual([1, 1, 1, 1, 1, 6, 7, 8, 9], result.to_list())
 
         result = np.where(condN, 1, n1)
         self.assertListEqual([1, 2, 3, 4, 5, 1, 1, 1, 1], result.tolist())
 
         result = ak.where(condA, 1, a1)
-        self.assertListEqual([1, 2, 3, 4, 5, 1, 1, 1, 1], result.to_ndarray().tolist())
+        self.assertListEqual([1, 2, 3, 4, 5, 1, 1, 1, 1], result.to_list())
 
     def test_not_equal_where_clause(self):
         n1 = np.arange(1, 10)
@@ -118,7 +118,7 @@ class WhereTest(ArkoudaTest):
 
         cond = a1 != 5
         result = ak.where(cond, a1, a2)
-        self.assertListEqual([1, 2, 3, 4, 1, 6, 7, 8, 9], result.to_ndarray().tolist())
+        self.assertListEqual([1, 2, 3, 4, 1, 6, 7, 8, 9], result.to_list())
 
     def test_equals_where_clause(self):
         n1 = np.arange(1, 10)
@@ -132,7 +132,7 @@ class WhereTest(ArkoudaTest):
 
         cond = a1 == 5
         result = ak.where(cond, a1, a2)
-        self.assertListEqual([1, 1, 1, 1, 5, 1, 1, 1, 1], result.to_ndarray().tolist())
+        self.assertListEqual([1, 1, 1, 1, 5, 1, 1, 1, 1], result.to_list())
 
     def test_where_filter(self):
         n1 = np.arange(1, 10)
@@ -141,7 +141,7 @@ class WhereTest(ArkoudaTest):
         a2 = ak.array(n2)
 
         self.assertListEqual(n2.tolist(), n1[n1 > 5].tolist())
-        self.assertListEqual(a2.to_ndarray().tolist(), a1[a1 > 5].to_ndarray().tolist())
+        self.assertListEqual(a2.to_list(), a1[a1 > 5].to_list())
 
     def test_multiple_where_clauses(self):
         n1 = np.arange(1, 10)
@@ -165,6 +165,6 @@ class WhereTest(ArkoudaTest):
         for dt in (ak.int64, ak.uint64, ak.float64, ak.bool):
             a = ak.ones(10, dtype=dt)
             b = ak.ones(10, dtype=dt)
-            self.assertListEqual(ak.where(cond, a, b).to_ndarray().tolist(), a.to_ndarray().tolist())
-            self.assertListEqual(ak.where(cond, 1, b).to_ndarray().tolist(), a.to_ndarray().tolist())
-            self.assertListEqual(ak.where(cond, a, 1).to_ndarray().tolist(), a.to_ndarray().tolist())
+            self.assertListEqual(ak.where(cond, a, b).to_list(), a.to_list())
+            self.assertListEqual(ak.where(cond, 1, b).to_list(), a.to_list())
+            self.assertListEqual(ak.where(cond, a, 1).to_list(), a.to_list())


### PR DESCRIPTION
This PR (Closes #1531 and Closes #1605):
- Updates tests to use `assertListEqual` instead of `assertTrue(( == ).all())` to give more info in debugging (see issue for example)
- Adds `to_list` method to arkouda objects which have a `to_ndarray` method and updates tests to use it