### PR TITLE
Fixes #1607: Allow `MultiIndex` to have mixed dtypes

### DIFF
--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -311,13 +311,10 @@ class MultiIndex(Index):
                 # because we are using obj.size/obj.dtype instead of len(obj)/type(obj)
                 # this should be made explict using typechecking
                 self.size = col.size
-                self.dtype = col.dtype
                 first = False
             else:
                 if col.size != self.size:
                     raise ValueError("All columns in MultiIndex must have same length")
-                if col.dtype != self.dtype:
-                    raise ValueError("All columns in MultiIndex must have same dtype")
         self.levels = len(self.values)
 
     def __getitem__(self, key):
@@ -326,6 +323,9 @@ class MultiIndex(Index):
         if type(key) == Series:
             key = key.values
         return MultiIndex([i[key] for i in self.index])
+
+    def __repr__(self):
+        return f"MultiIndex({repr(self.index)})"
 
     def __len__(self):
         return len(self.index[0])


### PR DESCRIPTION
This PR (Fixes #1607):
- Removes `dtype` parameter and associated validation that was introduced in PR #1516. Overrides the `__repr__` of `Index` instead

NOTE:
The `dtype`s shown below are from `Series` and are not accurate since it's possible to have a mix of dtypes in `Series`. This should be investigated further, but I wanted to get this PR up to address the important bug

Output on reproducer for #1607:
```python
>>> df = ak.DataFrame({'a': ak.arange(10, dtype=ak.int64), 'b': ak.arange(10, dtype=ak.uint64)})
>>> df.groupby(['a', 'b']).count()
0  0    1
1  1    1
2  2    1
3  3    1
4  4    1
5  5    1
6  6    1
7  7    1
8  8    1
9  9    1
dtype: int64
```

Output from reproducer for #1512 (to ensure it's still working):
```python
>>> a = ak.array([1,2,3,2,3,4,5,6,5,4,3,2])
>>> b = ak.array([2,3,2,3,4,5,6,5,4,3,2,1])
>>> df = ak.DataFrame({'a':a, 'b':b})
>>> c = df.groupby(['a','b']).count()

# These all threw type or attribute errors before this PR
>>> c.index
MultiIndex((array([1 2 2 3 3 4 4 5 5 6]), array([2 1 3 2 4 3 5 4 6 5])))

>>> c.sort_values()
1  2    1
2  1    1
3  4    1
4  3    1
   5    1
5  4    1
   6    1
6  5    1
2  3    2
3  2    2
dtype: int64

>>> c.sort_index()
1  2    1
2  1    1
   3    2
3  2    2
   4    1
4  3    1
   5    1
5  4    1
   6    1
6  5    1
dtype: int64

>>> c.locate((ak.array([1, 2, 2, 3, 3, 4, 4, 5, 5, 6]), ak.array([2, 1, 3, 2, 4, 3, 5, 4, 6, 5])))
1  2    1
2  1    1
   3    2
3  2    2
   4    1
4  3    1
   5    1
5  4    1
   6    1
6  5    1
dtype: int64
```