### PR TITLE
Closes #1614 - Corrects `DataFrame` Index Error on `.append()`

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -1166,7 +1166,7 @@ class DataFrame(UserDict):
             self.data = tmp_data
 
         # Clean up
-        self.reset_index()
+        self.reset_index(inplace=True)
         self.update_size()
         self._empty = False
         return self

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -276,7 +276,7 @@ class DataFrameTest(ArkoudaTest):
         self.assertTrue(ref_df.equals(df.to_pandas()))
 
         idx = np.arange(8)
-        self.assertListEqual(idx.tolist(), df.index.index.to_ndarray().tolist())
+        self.assertListEqual(idx.tolist(), df.index.index.to_list())
 
         df_keyerror = build_ak_keyerror()
         with self.assertRaises(KeyError):

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -5,6 +5,7 @@ import string
 from shutil import rmtree
 
 import pandas as pd  # type: ignore
+import numpy as np # type: ignore
 from base_test import ArkoudaTest
 from context import arkouda as ak
 
@@ -273,6 +274,9 @@ class DataFrameTest(ArkoudaTest):
 
         # dataframe equality returns series with bool result for each row.
         self.assertTrue(ref_df.equals(df.to_pandas()))
+
+        idx = np.arange(8)
+        self.assertListEqual(idx.tolist(), df.index.index.to_ndarray().tolist())
 
         df_keyerror = build_ak_keyerror()
         with self.assertRaises(KeyError):


### PR DESCRIPTION
Closes #1614

Updates the `.reset_index()` call to `.reset_index(inplace=True)`. This results in the index being updated in-place and the resulting object having the appropriate index.