### PR TITLE
Fixes #1620: Fix uint and float binops

### DIFF
--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -296,6 +296,37 @@ module BinOp
         }
       var repMsg = "created %s".format(st.attrib(rname));
       return new MsgTuple(repMsg, MsgType.NORMAL);
+    } else if ((l.etype == uint && r.etype == real) || (l.etype == real && r.etype == uint)) {
+      select op {
+          when "+" {
+            e.a = l.a:real + r.a:real;
+          }
+          when "-" {
+            e.a = l.a:real - r.a:real;
+          }
+          when "*" {
+            e.a = l.a:real * r.a:real;
+          }
+          when "/" { // truediv
+            e.a = l.a:real / r.a:real;
+          } 
+          when "//" { // floordiv
+            ref ea = e.a;
+            ref la = l.a;
+            ref ra = r.a;
+            [(ei,li,ri) in zip(ea,la,ra)] ei = if ri != 0 then floor(li/ri) else NAN;
+          }
+          when "**" { 
+            e.a= l.a:real**r.a:real;
+          }
+          otherwise {
+            var errorMsg = notImplementedError(pn,l.dtype,op,r.dtype);
+            omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+          }
+        }
+      var repMsg = "created %s".format(st.attrib(rname));
+      return new MsgTuple(repMsg, MsgType.NORMAL);
     } else if ((l.etype == int && r.etype == bool) || (l.etype == bool && r.etype == int)) {
       select op {
           when "+" {
@@ -574,6 +605,36 @@ module BinOp
           }
           when "**" { 
             e.a= l.a**val;
+          }
+          otherwise {
+            var errorMsg = notImplementedError(pn,l.dtype,op,dtype);
+            omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+          }
+        }
+      var repMsg = "created %s".format(st.attrib(rname));
+      return new MsgTuple(repMsg, MsgType.NORMAL);
+    } else if ((l.etype == uint && val.type == real) || (l.etype == real && val.type == uint)) {
+      select op {
+          when "+" {
+            e.a = l.a: real + val: real;
+          }
+          when "-" {
+            e.a = l.a: real - val: real;
+          }
+          when "*" {
+            e.a = l.a: real * val: real;
+          }
+          when "/" { // truediv
+            e.a = l.a: real / val: real;
+          } 
+          when "//" { // floordiv
+            ref ea = e.a;
+            ref la = l.a;
+            [(ei,li) in zip(ea,la)] ei = if val != 0 then floor(li/val) else NAN;
+          }
+          when "**" { 
+            e.a= l.a: real**val: real;
           }
           otherwise {
             var errorMsg = notImplementedError(pn,l.dtype,op,dtype);
@@ -864,6 +925,36 @@ module BinOp
           }
           when "**" { 
             e.a= val**r.a;
+          }
+          otherwise {
+            var errorMsg = notImplementedError(pn,dtype,op,r.dtype);
+            omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+          }
+        }
+      var repMsg = "created %s".format(st.attrib(rname));
+      return new MsgTuple(repMsg, MsgType.NORMAL);
+    } else if ((r.etype == uint && val.type == real) || (r.etype == real && val.type == uint)) {
+      select op {
+          when "+" {
+            e.a = val:real + r.a:real;
+          }
+          when "-" {
+            e.a = val:real - r.a:real;
+          }
+          when "*" {
+            e.a = val:real * r.a:real;
+          }
+          when "/" { // truediv
+            e.a = val:real / r.a:real;
+          } 
+          when "//" { // floordiv
+            ref ea = e.a;
+            ref ra = r.a;
+            [(ei,ri) in zip(ea,ra)] ei = if ri != 0 then floor(val:real/ri) else NAN;
+          }
+          when "**" { 
+            e.a= val:real**r.a:real;
           }
           otherwise {
             var errorMsg = notImplementedError(pn,dtype,op,r.dtype);

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -280,6 +280,51 @@ class OperatorsTest(ArkoudaTest):
             (ak.array([True, False, True, False, True, True]) == ak.concatenate([pdaOne, pdaTwo])).all()
         )
 
+    def test_float_uint_binops(self):
+        # Test fix for issue #1620
+        ak_uint = ak.array([5], dtype=ak.uint64)
+        np_uint = np.array([5], dtype=np.uint64)
+        scalar_uint = np.uint64(5)
+
+        ak_float = ak.array([3.01], dtype=ak.float64)
+        np_float = np.array([3.01], dtype=np.float_)
+        scalar_float = 3.01
+
+        ak_uints = [ak_uint, scalar_uint]
+        np_uints = [np_uint, scalar_uint]
+        ak_floats = [ak_float, scalar_float]
+        np_floats = [np_float, scalar_float]
+        for aku, akf, npu, npf in zip(ak_uints, ak_floats, np_uints, np_floats):
+            self.assertEqual(ak_uint + akf, np_uint + npf)
+            self.assertEqual(akf + ak_uint, npf + np_uint)
+            self.assertEqual(ak_float + aku, np_float + npu)
+            self.assertEqual(aku + ak_float, npu + np_float)
+
+            self.assertEqual(ak_uint - akf, np_uint - npf)
+            self.assertEqual(akf - ak_uint, npf - np_uint)
+            self.assertEqual(ak_float - aku, np_float - npu)
+            self.assertEqual(aku - ak_float, npu - np_float)
+
+            self.assertEqual(ak_uint * akf, np_uint * npf)
+            self.assertEqual(akf * ak_uint, npf * np_uint)
+            self.assertEqual(ak_float * aku, np_float * npu)
+            self.assertEqual(aku * ak_float, npu * np_float)
+
+            self.assertEqual(ak_uint / akf, np_uint / npf)
+            self.assertEqual(akf / ak_uint, npf / np_uint)
+            self.assertEqual(ak_float / aku, np_float / npu)
+            self.assertEqual(aku / ak_float, npu / np_float)
+
+            self.assertEqual(ak_uint // akf, np_uint // npf)
+            self.assertEqual(akf // ak_uint, npf // np_uint)
+            self.assertEqual(ak_float // aku, np_float // npu)
+            self.assertEqual(aku // ak_float, npu // np_float)
+
+            self.assertEqual(ak_uint ** akf, np_uint ** npf)
+            self.assertEqual(akf ** ak_uint, npf ** np_uint)
+            self.assertEqual(ak_float ** aku, np_float ** npu)
+            self.assertEqual(aku ** ak_float, npu ** np_float)
+
     def test_concatenate_type_preservation(self):
         # Test that concatenate preserves special pdarray types (IPv4, Datetime, BitVector, ...)
         from arkouda.util import generic_concat as akuconcat


### PR DESCRIPTION
This PR (Fixes #1620):
- Adds code in `binopvv`, `binopvs`, and `binopsv` to enable support for `uint` binop `float`
- Adds test of this functionality against numpy

the condensed output of testAllOperators after this PR:
```
# ops not implemented by numpy or arkouda: 114
# ops implemented by numpy but not arkouda: 158
# ops implemented by arkouda but not numpy: 4
# ops implemented by both: 594
  Matching results:         588 / 594
  Arkouda execution errors: 0 / 594
  Dtype mismatches:         0 / 594
  Value mismatches:         6 / 594
int64(scalar) // float64(array): np: [inf 22. 11.  7.  5.  4.  3.  3.  2.  2.]
ak: [nan 22. 11.  7.  5.  4.  3.  3.  2.  2.]
uint64(scalar) // float64(array): np: [inf 22. 11.  7.  5.  4.  3.  3.  2.  2.]
ak: [nan 22. 11.  7.  5.  4.  3.  3.  2.  2.]
float64(scalar) // int64(array): np: [inf  3.  1.  1.  0.  0.  0.  0.  0.  0.]
ak: [nan  3.  1.  1.  0.  0.  0.  0.  0.  0.]
float64(scalar) // uint64(array): np: [inf  3.  1.  1.  0.  0.  0.  0.  0.  0.]
ak: [nan  3.  1.  1.  0.  0.  0.  0.  0.  0.]
float64(scalar) // float64(array): np: [inf 14.  7.  4.  3.  2.  2.  2.  1.  1.]
ak: [nan 14.  7.  4.  3.  2.  2.  2.  1.  1.]
bool(scalar) // float64(array): np: [inf  4.  2.  1.  1.  0.  0.  0.  0.  0.]
ak: [nan  4.  2.  1.  1.  0.  0.  0.  0.  0.]
```

vs before this PR:
```
# ops not implemented by numpy or arkouda: 114
# ops implemented by numpy but not arkouda: 182
# ops implemented by arkouda but not numpy: 4
# ops implemented by both: 569
  Matching results:         564 / 569
  Arkouda execution errors: 0 / 569

  Dtype mismatches:         0 / 569

  Value mismatches:         5 / 569
int64(scalar) // float64(array): np: [inf 22. 11.  7.  5.  4.  3.  3.  2.  2.]
ak: [nan 22. 11.  7.  5.  4.  3.  3.  2.  2.]
uint64(scalar) // float64(array): np: [inf 22. 11.  7.  5.  4.  3.  3.  2.  2.]
ak: [nan 22. 11.  7.  5.  4.  3.  3.  2.  2.]
float64(scalar) // int64(array): np: [inf  3.  1.  1.  0.  0.  0.  0.  0.  0.]
ak: [nan  3.  1.  1.  0.  0.  0.  0.  0.  0.]
float64(scalar) // float64(array): np: [inf 14.  7.  4.  3.  2.  2.  2.  1.  1.]
ak: [nan 14.  7.  4.  3.  2.  2.  2.  1.  1.]
bool(scalar) // float64(array): np: [inf  4.  2.  1.  1.  0.  0.  0.  0.  0.]
ak: [nan  4.  2.  1.  1.  0.  0.  0.  0.  0.]
```

NOTES:
- the value mismatches are surprising because they were not present in #1388. I have opened issue #1622, to investigate these further
- I wrote the test rather quickly so please let me know if there are any mistakes or if there's a better way