### PR TITLE
Closes #1550 - Removing Chapel unit tests from CI to improve build time

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -157,20 +157,3 @@ jobs:
       run: |
         ./benchmarks/run_benchmarks.py --correctness-only
         ./benchmarks/run_benchmarks.py --size=100 --gen-graphs
-
-  chapel_unit_tests_linux:
-    runs-on: ubuntu-latest
-    container:
-      image: chapel/chapel:1.27.0
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: |
-        apt-get update && apt-get install -y -V ca-certificates lsb-release wget
-        wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-        apt-get install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-        apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip libarrow-dev libparquet-dev
-        echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" > Makefile.paths
-    - name: Run unit tests
-      run: |
-        start_test test


### PR DESCRIPTION
This PR closes #1550 

I verified major components tested in the Chapel unit tests are covered by python tests. This PR doesn't remove any Chapel tests, so they can still be ran locally for testing. This PR only removes the tests from the CI process to improve build times.