### PR TITLE
Closes #1627 - `sphinx==5.0.2`

### DIFF
--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -21,7 +21,7 @@ dependencies:
   - pexpect
   - pytest>=6.0
   - pytest-env
-  - Sphinx
+  - Sphinx==5.0.2
   - sphinx-argparse
   - sphinx-autoapi
   - typed-ast

--- a/pydoc/requirements.txt
+++ b/pydoc/requirements.txt
@@ -18,7 +18,7 @@ pyarrow>=1.0.1
 pexpect
 pytest>=6.0
 pytest-env
-Sphinx
+Sphinx==5.0.2
 sphinx-argparse
 sphinx-autoapi
 typed-ast

--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,7 @@ setup(
     # projects.
     extras_require={  # Optional
         'dev': ['pexpect', 'pytest>=6.0', 'pytest-env',
-                'Sphinx', 'sphinx-argparse', 'sphinx-autoapi',
+                'Sphinx==5.0.2', 'sphinx-argparse', 'sphinx-autoapi',
                 'mypy>=0.931', 'typed-ast', 'black', 'isort',
                 'flake8'],
     },


### PR DESCRIPTION
Closes #1627 

Sets `Sphinx==5.0.2`. This is being done because `5.1.0` is incompatible with our formatting.