### PR TITLE
Closes #1622 - Value mismatches with numpy in operations test

### DIFF
--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -13,6 +13,21 @@ module BinOp
   const omLogger = new Logger(logLevel);
 
   /*
+  Helper function to ensure that floor division cases are handled in accordance with numpy
+  */
+  proc floorDivisionHelper(numerator: ?t, denom: ?t2): real {
+    if (numerator == 0 && denom == 0) || (isinf(numerator) && denom > 0){
+      return NAN;
+    }
+    else if (numerator > 0 && denom == -INFINITY) || (numerator < 0 && denom == INFINITY){
+      return -1:real;
+    }
+    else {
+      return floor(numerator/denom);
+    }
+  }
+
+  /*
   Generic function to execute a binary operation on pdarray entries 
   in the symbol table
 
@@ -283,7 +298,7 @@ module BinOp
             ref ea = e.a;
             ref la = l.a;
             ref ra = r.a;
-            [(ei,li,ri) in zip(ea,la,ra)] ei = if ri != 0 then floor(li/ri) else NAN;
+            [(ei,li,ri) in zip(ea,la,ra)] ei = floorDivisionHelper(li, ri);
           }
           when "**" { 
             e.a= l.a**r.a;
@@ -601,7 +616,7 @@ module BinOp
           when "//" { // floordiv
             ref ea = e.a;
             ref la = l.a;
-            [(ei,li) in zip(ea,la)] ei = if val != 0 then floor(li/val) else NAN;
+            [(ei,li) in zip(ea,la)] ei = floorDivisionHelper(li, val);
           }
           when "**" { 
             e.a= l.a**val;
@@ -921,7 +936,7 @@ module BinOp
           when "//" { // floordiv
             ref ea = e.a;
             ref ra = r.a;
-            [(ei,ri) in zip(ea,ra)] ei = if ri != 0 then floor(val:real/ri) else INFINITY;
+            [(ei,ri) in zip(ea,ra)] ei = floorDivisionHelper(val:real, ri);
           }
           when "**" { 
             e.a= val**r.a;

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -329,7 +329,7 @@ module BinOp
             ref ea = e.a;
             ref la = l.a;
             ref ra = r.a;
-            [(ei,li,ri) in zip(ea,la,ra)] ei = if ri != 0 then floor(li/ri) else NAN;
+            [(ei,li,ri) in zip(ea,la,ra)] ei = floorDivisionHelper(li, ri);//if ri != 0 then floor(li/ri) else NAN;
           }
           when "**" { 
             e.a= l.a:real**r.a:real;
@@ -646,7 +646,7 @@ module BinOp
           when "//" { // floordiv
             ref ea = e.a;
             ref la = l.a;
-            [(ei,li) in zip(ea,la)] ei = if val != 0 then floor(li/val) else NAN;
+            [(ei,li) in zip(ea,la)] ei = floorDivisionHelper(li, val);//if val != 0 then floor(li/val) else NAN;
           }
           when "**" { 
             e.a= l.a: real**val: real;
@@ -966,7 +966,7 @@ module BinOp
           when "//" { // floordiv
             ref ea = e.a;
             ref ra = r.a;
-            [(ei,ri) in zip(ea,ra)] ei = if ri != 0 then floor(val:real/ri) else NAN;
+            [(ei,ri) in zip(ea,ra)] ei = floorDivisionHelper(val:real, ri);
           }
           when "**" { 
             e.a= val:real**r.a:real;

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -921,7 +921,7 @@ module BinOp
           when "//" { // floordiv
             ref ea = e.a;
             ref ra = r.a;
-            [(ei,ri) in zip(ea,ra)] ei = if ri != 0 then floor(val:real/ri) else NAN;
+            [(ei,ri) in zip(ea,ra)] ei = if ri != 0 then floor(val:real/ri) else INFINITY;
           }
           when "**" { 
             e.a= val**r.a;

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -329,7 +329,7 @@ module BinOp
             ref ea = e.a;
             ref la = l.a;
             ref ra = r.a;
-            [(ei,li,ri) in zip(ea,la,ra)] ei = floorDivisionHelper(li, ri);//if ri != 0 then floor(li/ri) else NAN;
+            [(ei,li,ri) in zip(ea,la,ra)] ei = floorDivisionHelper(li, ri);
           }
           when "**" { 
             e.a= l.a:real**r.a:real;
@@ -646,7 +646,7 @@ module BinOp
           when "//" { // floordiv
             ref ea = e.a;
             ref la = l.a;
-            [(ei,li) in zip(ea,la)] ei = floorDivisionHelper(li, val);//if val != 0 then floor(li/val) else NAN;
+            [(ei,li) in zip(ea,la)] ei = floorDivisionHelper(li, val);
           }
           when "**" { 
             e.a= l.a: real**val: real;

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -16,7 +16,7 @@ module BinOp
   Helper function to ensure that floor division cases are handled in accordance with numpy
   */
   proc floorDivisionHelper(numerator: ?t, denom: ?t2): real {
-    if (numerator == 0 && denom == 0) || (isinf(numerator) && denom > 0){
+    if (numerator == 0 && denom == 0) || (isinf(numerator) && (denom != 0 || isinf(denom))){
       return NAN;
     }
     else if (numerator > 0 && denom == -INFINITY) || (numerator < 0 && denom == INFINITY){

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -424,8 +424,7 @@ class OperatorsTest(ArkoudaTest):
         self.assertEqual(type(bitvector_akuconcat), ak.BitVector)
         self.assertListEqual(ak.BitVector(pda_concat).to_list(), bitvector_akuconcat.to_list())
 
-    # currently skipped, needs to be renamed to test_floor_div_edge_cases in order to run
-    def floor_div_edge_cases(self):
+    def test_floor_div_edge_cases(self):
         scalar_edge_cases = [-np.inf, -7.0, -0.0, np.nan, 0.0, 7.0, np.inf]
         np_edge_cases = np.array(scalar_edge_cases)
         ak_edge_cases = ak.array(np_edge_cases)


### PR DESCRIPTION
Closes #1622 

Corrects the mismatch between numpy and arkouda values. This updates the return of division by zero to be `INFINITY` (in arkouda) which returns and treated as `inf` in numpy.

Output Before Updates
```
# ops implemented by arkouda but not numpy: 4
int64(array) >> uint64(array)  ->  [0 0 0 0 0 0 0 0 0 0]
int64(array) << uint64(array)  ->  [0 2 8 24 64 160 384 896 2048 4608]
uint64(array) >> int64(array)  ->  [0 0 0 0 0 0 0 0 0 0]
uint64(array) << int64(array)  ->  [0 2 8 24 64 160 384 896 2048 4608]
# ops implemented by both: 569
  Matching results:         564 / 569
  Arkouda execution errors: 0 / 569

  Dtype mismatches:         0 / 569

  Value mismatches:         5 / 569
int64(scalar) // float64(array): np: [inf 22. 11.  7.  5.  4.  3.  3.  2.  2.]
ak: [nan 22. 11.  7.  5.  4.  3.  3.  2.  2.]
uint64(scalar) // float64(array): np: [inf 22. 11.  7.  5.  4.  3.  3.  2.  2.]
ak: [nan 22. 11.  7.  5.  4.  3.  3.  2.  2.]
float64(scalar) // int64(array): np: [inf  3.  1.  1.  0.  0.  0.  0.  0.  0.]
ak: [nan  3.  1.  1.  0.  0.  0.  0.  0.  0.]
float64(scalar) // float64(array): np: [inf 14.  7.  4.  3.  2.  2.  2.  1.  1.]
ak: [nan 14.  7.  4.  3.  2.  2.  2.  1.  1.]
bool(scalar) // float64(array): np: [inf  4.  2.  1.  1.  0.  0.  0.  0.  0.]
ak: [nan  4.  2.  1.  1.  0.  0.  0.  0.  0.]
```

Output After Updates:
```
# ops implemented by arkouda but not numpy: 4
int64(array) >> uint64(array)  ->  [0 0 0 0 0 0 0 0 0 0]
int64(array) << uint64(array)  ->  [0 2 8 24 64 160 384 896 2048 4608]
uint64(array) >> int64(array)  ->  [0 0 0 0 0 0 0 0 0 0]
uint64(array) << int64(array)  ->  [0 2 8 24 64 160 384 896 2048 4608]
# ops implemented by both: 564
  Matching results:         564 / 564
  Arkouda execution errors: 0 / 564

  Dtype mismatches:         0 / 564

  Value mismatches:         0 / 564
```