### PR TITLE
Test to see if 1.26.0 causes OOM Error

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -129,7 +129,7 @@ jobs:
     env:
       CHPL_RT_NUM_THREADS_PER_LOCALE: ${{matrix.threads}}
     container:
-      image: chapel/${{matrix.image}}:1.27.0
+      image: chapel/${{matrix.image}}:1.26.0
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies


### PR DESCRIPTION
This PR is only for testing the CI step that is failing with an OOM error from the docker container.