### PR TITLE
Closes #1630 - Use `Enum` for `ObjType`

### DIFF
--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -8,7 +8,14 @@ import zmq  # type: ignore
 
 from arkouda import __version__, io_util, security
 from arkouda.logger import getArkoudaLogger
-from arkouda.message import MessageFormat, MessageType, ReplyMessage, RequestMessage, ParameterObject, ObjectType
+from arkouda.message import (
+    MessageFormat,
+    MessageType,
+    ObjectType,
+    ParameterObject,
+    ReplyMessage,
+    RequestMessage,
+)
 
 __all__ = [
     "connect",

--- a/arkouda/message.py
+++ b/arkouda/message.py
@@ -4,6 +4,56 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Dict
 
+
+class ObjectType(Enum):
+    """
+    Class used for assigning object types in the JSON string
+    sent to the server for processing
+    """
+    PDARRAY = "PDARRAY"
+    STRINGS = "SEGSTRING"
+    LIST = "LIST"
+    VALUE = "VALUE"
+
+    def __str__(self) -> str:
+        """
+        Overridden method returns value, which is useful in outputting
+        a MessageType object to JSON.
+        """
+        return self.value
+
+    def __repr__(self) -> str:
+        """
+        Overridden method returns value, which is useful in outputting
+        a MessageType object to JSON.
+        """
+        return self.value
+
+
+class ParameterObject:
+    __slots = ("key", "objType", "dtype", "val")
+
+    key: str
+    objType: MessageFormat
+    dtype: str
+    val: str
+
+    def __init__(self, key, objType, dtype, val):
+        object.__setattr__(self, "key", key)
+        object.__setattr__(self, "objType", objType)
+        object.__setattr__(self, "dtype", dtype)
+        object.__setattr__(self, "val", val)
+
+    @property
+    def dict(self):
+        return {
+            "key": self.key,
+            "objType": str(self.objType),
+            "dtype": self.dtype,
+            "val": self.val,
+        }
+
+
 """
 The MessageFormat enum provides controlled vocabulary for the message
 format which can be either a string or a binary (bytes) object.

--- a/arkouda/message.py
+++ b/arkouda/message.py
@@ -10,6 +10,7 @@ class ObjectType(Enum):
     Class used for assigning object types in the JSON string
     sent to the server for processing
     """
+
     PDARRAY = "PDARRAY"
     STRINGS = "SEGSTRING"
     LIST = "LIST"

--- a/src/Message.chpl
+++ b/src/Message.chpl
@@ -7,6 +7,7 @@ module Message {
 
     enum MsgType {NORMAL,WARNING,ERROR}
     enum MsgFormat {STRING,BINARY}
+    enum ObjectType {PDARRAY, SEGSTRING, LIST, VALUE}
 
     /*
      * Encapsulates the message string and message type.
@@ -48,7 +49,7 @@ module Message {
     record ParameterObj {
         var key: string; // json key value 
         var val: string; // json value
-        var objType: string; // type of the object
+        var objType: ObjectType; // type of the object
         var dtype: string; // type of elements contained in the object
 
         proc init() {}

--- a/src/Message.chpl
+++ b/src/Message.chpl
@@ -157,7 +157,7 @@ module Message {
         * Return the value as the provided type
         */
         proc getValueAsType(type t = string): t throws {
-            if objType != dtype {
+            if objType != ObjectType.VALUE {
                 throw new owned ErrorWithContext("The value provided is not a castable type, please use ParameterObj.getSymEntry for this object.",
                                     getLineNumber(),
                                     getRoutineName(),
@@ -183,7 +183,7 @@ module Message {
         Note - not yet able to handle list of pdarray or SegString names
         */
         proc getList(size: int) {
-            if this.objType != "list" {
+            if this.objType != ObjectType.LIST {
                 throw new owned ErrorWithContext("Parameter with key, %s, is not a list.".format(this.key),
                                     getLineNumber(),
                                     getRoutineName(),


### PR DESCRIPTION
Closes #1630 

- Adds `ObjectType` and `ParameterObject` classes to the client
- Uses `Enum` for `objType` assignment
- Adds `enum ObjectType` to the server
- Updates JSON parsing to create `ParameterObject` and writes to json using the `.dict` property

*Functionally, this does not change the JSON message arguments, but provides a more formal structure that will be easier to maintain*