### PR TITLE
Closes #1631 - Message Arg Generation Using Dispatch Table

### DIFF
--- a/arkouda/message.py
+++ b/arkouda/message.py
@@ -115,7 +115,7 @@ class ParameterObject:
         -------
         ParameterObject
         """
-        dtypes = set([p.dtype for p in val])
+        dtypes = set([p.dtype if hasattr(p, "dtype") else type(p).__name__ for p in val])
         if len(dtypes) > 1:
             t_str = ", ".join(dtypes)
             raise TypeError(f"List values must be of the same type. Found {t_str}")

--- a/arkouda/message.py
+++ b/arkouda/message.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from enum import Enum
 from typing import Dict
-from typeguard import typechecked
 
-import json
+from typeguard import typechecked
 
 
 class ObjectType(Enum):
@@ -61,11 +61,39 @@ class ParameterObject:
     @staticmethod
     @typechecked
     def _build_pdarray_param(key: str, val) -> ParameterObject:
+        """
+        Create a ParameterObject from a pdarray value
+
+        Parameters
+        ----------
+        key : str
+            key from the dictionary object
+        val
+            pdarray object ot load from the symbol table
+
+        Returns
+        -------
+        ParameterObject
+        """
         return ParameterObject(key, ObjectType.PDARRAY, str(val.dtype), val.name)
 
     @staticmethod
     @typechecked
     def _build_strings_param(key: str, val) -> ParameterObject:
+        """
+        Create a ParameterObject from a Strings value
+
+        Parameters
+        ----------
+        key : str
+            key from the dictionary object
+        val
+            Strings object ot load from the symbol table
+
+        Returns
+        -------
+        ParameterObject
+        """
         # empty string if name of String obj is none
         name = val.name if val.name else ""
         return ParameterObject(key, ObjectType.STRINGS, "str", name)
@@ -73,6 +101,20 @@ class ParameterObject:
     @staticmethod
     @typechecked
     def _build_list_param(key: str, val: list) -> ParameterObject:
+        """
+        Create a ParameterObject from a list
+
+        Parameters
+        ----------
+        key : str
+            key from the dictionary object
+        val : list
+            list object to format as string
+
+        Returns
+        -------
+        ParameterObject
+        """
         dtypes = set([p.dtype for p in val])
         if len(dtypes) > 1:
             t_str = ", ".join(dtypes)
@@ -82,13 +124,35 @@ class ParameterObject:
     @staticmethod
     @typechecked
     def _build_gen_param(key: str, val) -> ParameterObject:
+        """
+        Create a ParameterObject from a single value
+
+        Parameters
+        ----------
+        key : str
+            key from the dictionary object
+        val
+            singular value to use. This could be str, int, float, etc
+
+        Returns
+        -------
+        ParameterObject
+        """
         v = val if isinstance(val, str) else str(val)
         return ParameterObject(key, ObjectType.VALUE, type(val).__name__, v)
 
     @staticmethod
     def generate_dispatch() -> Dict:
+        """
+        Builds and returns the dispatch table used to build parameter object.
+
+        Returns
+        -------
+        Dictionary - mapping the parameter type to the build function
+        """
         from arkouda.pdarrayclass import pdarray
         from arkouda.strings import Strings
+
         return {
             pdarray.__name__: ParameterObject._build_pdarray_param,
             Strings.__name__: ParameterObject._build_strings_param,
@@ -97,11 +161,26 @@ class ParameterObject:
 
     @staticmethod
     def factory(key: str, val) -> ParameterObject:
+        """
+        Factory method used to build ParameterObject given a key value pair
+
+        Parameters
+        ----------
+        key : str
+            key from the dictionary object
+        val
+            the value corresponding to the provided key from the dictionary
+
+        Returns
+        --------
+        ParameterObject - The parameter object formatted to be parsed by the chapel server
+        """
         dispatch = ParameterObject.generate_dispatch()
         if (f := dispatch.get(type(val).__name__)) is not None:
             return f(key, val)
         else:
             return ParameterObject._build_gen_param(key, val)
+
 
 """
 The MessageFormat enum provides controlled vocabulary for the message


### PR DESCRIPTION
Closes #1631 

This PR updates the `if/else` logic to generate the appropriate `ParameterObject` based on the type to use a dispatch table. This is for better performance down the road when more object formats are moved to the server.

- Adds `factory()` static method to `ParameterObject` to pass a `key, val` pair and return the appropriate `ParameterObject`. This is using the dispatch table.
- Updates the `_json_args_to_str()` to call `ParameterObject.factory(key, val)` instead of running the logic itself.