### PR TITLE
Closes #1397 - `_get_head_tail_server()` replace `_get_head_tail()`

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -609,7 +609,7 @@ class DataFrame(UserDict):
         Return ascii-formatted version of the dataframe.
         """
 
-        prt = self._get_head_tail()
+        prt = self._get_head_tail_server()
         with pd.option_context("display.show_dimensions", False):
             retval = prt.__repr__()
         retval += " (" + self._shape_str() + ")"
@@ -619,7 +619,7 @@ class DataFrame(UserDict):
         """
         Return html-formatted version of the dataframe.
         """
-        prt = self._get_head_tail()
+        prt = self._get_head_tail_server()
 
         with pd.option_context("display.show_dimensions", False):
             retval = prt._repr_html_()


### PR DESCRIPTION
Closes #1397

Now that we have been benchmarking `_get_head_tail_server()` for some time and are seeing that it is consistently quicker than the `_get_head_tail()` method we were using, we have updated `__repr__` and `_repr_html_` to call `_get_head_tail_server()`.

Performance charts can be found [HERE](https://chapel-lang.org/perf/arkouda/16-node-xc/?startdate=2022/05/04&enddate=2022/08/01&graphs=dataframedisplayperformance)