### PR TITLE
Closes #1642 - `testAllOperators` double counting when mismatch occurs

### DIFF
--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -124,6 +124,7 @@ def run_tests(verbose):
                 res = "np: {}\nak: {}".format(npres, akasnp)
                 # warnings.warn("result mismatch: {} =\n{}".format(expression, res))
                 results["both_implement"].append((expression, res, False, False, True))
+                continue
             # Finally, both numpy and arkouda agree on result
             results["both_implement"].append((expression, "", False, False, False))
 


### PR DESCRIPTION
Closes #1642 

Updates the `run_tests` method to add a `continue` in the `if` block that runs when a mismatch is detected. This prevents the success state from hitting as well (which is what caused the double count). 

### To Test
I reverted the code back to the way it was before PR #1633 was merged. This code resulted in several mismatches and resulted in double counts. I verified that adding the `continue` results in the same number of total cases regardless of the number of mismatches.