### PR TITLE
Added support for a comma-delimited list of ServerDaemonTypes #1659

### DIFF
--- a/src/arkouda_server.chpl
+++ b/src/arkouda_server.chpl
@@ -16,10 +16,6 @@ const asLogger = new Logger(logLevel);
  * method on the configured list of ArkoudaServerDaemon objects
  */
 proc main() {
-    asLogger.info(getModuleName(), 
-                  getRoutineName(), 
-                  getLineNumber(),
-                  'Starting Arkouda Server Daemons');
     coforall daemon in getServerDaemons() {
         daemon.run();
     }


### PR DESCRIPTION
Closes  #1659:
This PR enables Arkouda to support 1..n ServerDaemon types via enum-controlled configuration