### PR TITLE
Closes #1643: `Covariance` and `Correlation`

### DIFF
--- a/ServerModules.cfg
+++ b/ServerModules.cfg
@@ -23,6 +23,7 @@ RegistrationMsg
 CastMsg
 BroadcastMsg
 FlattenMsg
+StatsMsg
 HDF5Msg
 ParquetMsg
 HDF5MultiDim

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -1832,11 +1832,10 @@ class DataFrame(UserDict):
                 d = Categorical(d)
             return d if isinstance(d, pdarray) else d.codes
 
-        numeric_cols = [numeric_help(self[c]) for c in self.columns]
         args = {
             "size": len(self.columns),
             "columns": self.columns,
-            "data_names": [col.name for col in numeric_cols],
+            "data_names": [numeric_help(self[c]) for c in self.columns],
         }
 
         ret_dict = json.loads(generic_msg(cmd="corrMatrix", args=args))

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -1826,23 +1826,20 @@ class DataFrame(UserDict):
 
         Attempts to convert to numeric values where possible for inclusion in the matrix.
         """
-        # TODO converting Strings to Categorical goes out of scope, i don't love registering it
-        unregister_names: List = []
 
         def numeric_help(d):
             if isinstance(d, Strings):
-                d = Categorical(d).register(f"keep_{len(unregister_names)}")
-                unregister_names.append(d.name)
+                d = Categorical(d)
             return d if isinstance(d, pdarray) else d.codes
 
+        numeric_cols = [numeric_help(self[c]) for c in self.columns]
         args = {
             "size": len(self.columns),
             "columns": self.columns,
-            "data_names": [numeric_help(self[c]).name for c in self.columns],
+            "data_names": [col.name for col in numeric_cols],
         }
 
         ret_dict = json.loads(generic_msg(cmd="corrMatrix", args=args))
-        [Categorical.unregister_categorical_by_name(name) for name in unregister_names]
         return DataFrame({c: create_pdarray(ret_dict[c]) for c in self.columns})
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -36,6 +36,7 @@ testpaths =
     tests/series_test.py
     tests/setops_test.py
     tests/sort_test.py
+    tests/stats_test.py
     tests/string_test.py
     tests/summarization_test.py
     tests/util_test.py

--- a/src/Message.chpl
+++ b/src/Message.chpl
@@ -182,7 +182,7 @@ module Message {
         :size: int: number of values in the list
         Note - not yet able to handle list of pdarray or SegString names
         */
-        proc getList(size: int) {
+        proc getList(size: int) throws {
             if this.objType != ObjectType.LIST {
                 throw new owned ErrorWithContext("Parameter with key, %s, is not a list.".format(this.key),
                                     getLineNumber(),

--- a/src/Stats.chpl
+++ b/src/Stats.chpl
@@ -9,7 +9,7 @@ module Stats {
         return (+ reduce ((ar:real - mean(ar)) ** 2)) / (aD.size - ddof):real;
     }
 
-    proc std(ar: [?aD] ?t1, ddof: int): real throws {
+    proc std(ar: [?aD] ?t, ddof: int): real throws {
         return sqrt(variance(ar, ddof));
     }
 

--- a/src/Stats.chpl
+++ b/src/Stats.chpl
@@ -1,0 +1,23 @@
+module Stats {
+    use AryUtil;
+
+    proc mean(ar1: [?aD1] ?t): real throws {
+        return (+ reduce ar1:real) / aD1.size:real;
+    }
+
+    proc variance(ar1: [?aD1] ?t, ddof: int): real throws {
+        return (+ reduce ((ar1:real - mean(ar1)) ** 2)) / (aD1.size - ddof):real;
+    }
+
+    proc std(ar1: [?aD1] ?t, ddof: int): real throws {
+        return sqrt(variance(ar1, ddof));
+    }
+
+    proc cov(ar1: [?aD1] ?t, ar2: [?aD2] ?t2): real throws {
+        return (+ reduce ((ar1:real - mean(ar1)) * (ar2:real - mean(ar2)))) / (aD1.size - 1):real;
+    }
+
+    proc corr(ar1: [?aD1] ?t, ar2: [?aD2] ?t2): real throws {
+        return cov(ar1, ar2) / (std(ar1, 1) * std(ar2, 1));
+    }
+}

--- a/src/Stats.chpl
+++ b/src/Stats.chpl
@@ -1,23 +1,23 @@
 module Stats {
     use AryUtil;
 
-    proc mean(ar1: [?aD1] ?t): real throws {
-        return (+ reduce ar1:real) / aD1.size:real;
+    proc mean(ar: [?aD] ?t): real throws {
+        return (+ reduce ar:real) / aD.size:real;
     }
 
-    proc variance(ar1: [?aD1] ?t, ddof: int): real throws {
-        return (+ reduce ((ar1:real - mean(ar1)) ** 2)) / (aD1.size - ddof):real;
+    proc variance(ar: [?aD] ?t, ddof: int): real throws {
+        return (+ reduce ((ar:real - mean(ar)) ** 2)) / (aD.size - ddof):real;
     }
 
-    proc std(ar1: [?aD1] ?t, ddof: int): real throws {
-        return sqrt(variance(ar1, ddof));
+    proc std(ar: [?aD] ?t1, ddof: int): real throws {
+        return sqrt(variance(ar, ddof));
     }
 
-    proc cov(ar1: [?aD1] ?t, ar2: [?aD2] ?t2): real throws {
+    proc cov(ar1: [?aD1] ?t1, ar2: [?aD2] ?t2): real throws {
         return (+ reduce ((ar1:real - mean(ar1)) * (ar2:real - mean(ar2)))) / (aD1.size - 1):real;
     }
 
-    proc corr(ar1: [?aD1] ?t, ar2: [?aD2] ?t2): real throws {
+    proc corr(ar1: [?aD1] ?t1, ar2: [?aD2] ?t2): real throws {
         return cov(ar1, ar2) / (std(ar1, 1) * std(ar2, 1));
     }
 }

--- a/src/StatsMsg.chpl
+++ b/src/StatsMsg.chpl
@@ -286,8 +286,6 @@ module StatsMsg {
         var dataNames = args.get("data_names").getList(size);
 
         var corrDict = new map(keyType=string, valType=string);
-        // TODO CORRELATION MATRIX IS SYMMETRIC, WE CAN USE THAT!
-        // would this be easy to do with a 2D chapel matrix?
         for (col, d1, i) in zip(columns, dataNames, 0..) {
             var corrPdarray = makeDistArray(size, real);
             var d1gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(d1, st);

--- a/src/StatsMsg.chpl
+++ b/src/StatsMsg.chpl
@@ -1,0 +1,316 @@
+module StatsMsg {
+    use ServerConfig;
+
+    use Reflection;
+    use ServerErrors;
+    use Logging;
+    use Message;
+    use MultiTypeSymbolTable;
+    use MultiTypeSymEntry;
+    use ServerErrorStrings;
+    use Stats;
+
+    use Map;
+
+    private config const logLevel = ServerConfig.logLevel;
+    const sLogger = new Logger(logLevel);
+
+    proc meanMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+        param pn = Reflection.getRoutineName();
+        var repMsg: string;
+        var args = parseMessageArgs(payload, 1);
+
+        var x: borrowed GenSymEntry = getGenericTypedArrayEntry(args.getValueOf("x"), st);
+
+        select (x.dtype) {
+            when (DType.Int64) {
+                repMsg = "float64 %.17r".format(mean(toSymEntry(x,int).a));
+            }
+            when (DType.Float64) {
+                repMsg = "float64 %.17r".format(mean(toSymEntry(x,real).a));
+            }
+            when (DType.Bool) {
+                repMsg = "float64 %.17r".format(mean(toSymEntry(x,bool).a));
+            }
+            when (DType.UInt64) {
+                repMsg = "float64 %.17r".format(mean(toSymEntry(x,uint).a));
+            }
+            otherwise {
+                var errorMsg = unrecognizedTypeError(pn, dtype2str(x.dtype));
+                sLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+        }
+        sLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+        return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+
+    proc varMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+        param pn = Reflection.getRoutineName();
+        var repMsg: string;
+        var args = parseMessageArgs(payload, 2);
+
+        var ddof = args.get("ddof").getIntValue();
+        var x: borrowed GenSymEntry = getGenericTypedArrayEntry(args.getValueOf("x"), st);
+
+        select (x.dtype) {
+            when (DType.Int64) {
+                repMsg = "float64 %.17r".format(variance(toSymEntry(x,int).a, ddof));
+            }
+            when (DType.Float64) {
+                repMsg = "float64 %.17r".format(variance(toSymEntry(x,real).a, ddof));
+            }
+            when (DType.Bool) {
+                repMsg = "float64 %.17r".format(variance(toSymEntry(x,bool).a, ddof));
+            }
+            when (DType.UInt64) {
+                repMsg = "float64 %.17r".format(variance(toSymEntry(x,uint).a, ddof));
+            }
+            otherwise {
+                var errorMsg = unrecognizedTypeError(pn, dtype2str(x.dtype));
+                sLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+        }
+        sLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+        return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+
+    proc stdMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+        param pn = Reflection.getRoutineName();
+        var repMsg: string;
+        var args = parseMessageArgs(payload, 2);
+
+        var ddof = args.get("ddof").getIntValue();
+        var x: borrowed GenSymEntry = getGenericTypedArrayEntry(args.getValueOf("x"), st);
+
+        select (x.dtype) {
+            when (DType.Int64) {
+                repMsg = "float64 %.17r".format(std(toSymEntry(x,int).a, ddof));
+            }
+            when (DType.Float64) {
+                repMsg = "float64 %.17r".format(std(toSymEntry(x,real).a, ddof));
+            }
+            when (DType.Bool) {
+                repMsg = "float64 %.17r".format(std(toSymEntry(x,bool).a, ddof));
+            }
+            when (DType.UInt64) {
+                repMsg = "float64 %.17r".format(std(toSymEntry(x,uint).a, ddof));
+            }
+            otherwise {
+                var errorMsg = unrecognizedTypeError(pn, dtype2str(x.dtype));
+                sLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+        }
+        sLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+        return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+
+    proc covMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+        param pn = Reflection.getRoutineName();
+        var repMsg: string;
+        var args = parseMessageArgs(payload, 2);
+
+        var x: borrowed GenSymEntry = getGenericTypedArrayEntry(args.getValueOf("x"), st);
+        var y: borrowed GenSymEntry = getGenericTypedArrayEntry(args.getValueOf("y"), st);
+
+        select (x.dtype, y.dtype) {
+            when (DType.Int64, DType.Int64) {
+                var eX = toSymEntry(x,int);
+                var eY = toSymEntry(y,int);
+                repMsg = "float64 %.17r".format(cov(eX.a, eY.a));
+            }
+            when (DType.Int64, DType.Float64) {
+                var eX = toSymEntry(x,int);
+                var eY = toSymEntry(y,real);
+                repMsg = "float64 %.17r".format(cov(eX.a, eY.a));
+            }
+            when (DType.Int64, DType.Bool) {
+                var eX = toSymEntry(x,int);
+                var eY = toSymEntry(y,bool);
+                repMsg = "float64 %.17r".format(cov(eX.a, eY.a));
+            }
+            when (DType.Int64, DType.UInt64) {
+                var eX = toSymEntry(x,int);
+                var eY = toSymEntry(y,uint);
+                repMsg = "float64 %.17r".format(cov(eX.a, eY.a));
+            }
+            when (DType.Float64, DType.Float64) {
+                var eX = toSymEntry(x,real);
+                var eY = toSymEntry(y,real);
+                repMsg = "float64 %.17r".format(cov(eX.a, eY.a));
+            }
+            when (DType.Float64, DType.Int64) {
+                var eX = toSymEntry(x,real);
+                var eY = toSymEntry(y,int);
+                repMsg = "float64 %.17r".format(cov(eX.a, eY.a));
+            }
+            when (DType.Float64, DType.Bool) {
+                var eX = toSymEntry(x,real);
+                var eY = toSymEntry(y,bool);
+                repMsg = "float64 %.17r".format(cov(eX.a, eY.a));
+            }
+            when (DType.Float64, DType.UInt64) {
+                var eX = toSymEntry(x,real);
+                var eY = toSymEntry(y,uint);
+                repMsg = "float64 %.17r".format(cov(eX.a, eY.a));
+            }
+            when (DType.Bool, DType.Bool) {
+                var eX = toSymEntry(x,bool);
+                var eY = toSymEntry(y,bool);
+                repMsg = "float64 %.17r".format(cov(eX.a, eY.a));
+            }
+            when (DType.Bool, DType.Float64) {
+                var eX = toSymEntry(x,bool);
+                var eY = toSymEntry(y,real);
+                repMsg = "float64 %.17r".format(cov(eX.a, eY.a));
+            }
+            when (DType.Bool, DType.Int64) {
+                var eX = toSymEntry(x,bool);
+                var eY = toSymEntry(y,int);
+                repMsg = "float64 %.17r".format(cov(eX.a, eY.a));
+            }
+            when (DType.Bool, DType.UInt64) {
+                var eX = toSymEntry(x,bool);
+                var eY = toSymEntry(y,uint);
+                repMsg = "float64 %.17r".format(cov(eX.a, eY.a));
+            }
+            when (DType.UInt64, DType.UInt64) {
+                var eX = toSymEntry(x,uint);
+                var eY = toSymEntry(y,uint);
+                repMsg = "float64 %.17r".format(cov(eX.a, eY.a));
+            }
+            when (DType.UInt64, DType.Int64) {
+                var eX = toSymEntry(x,uint);
+                var eY = toSymEntry(y,int);
+                repMsg = "float64 %.17r".format(cov(eX.a, eY.a));
+            }
+            when (DType.UInt64, DType.Float64) {
+                var eX = toSymEntry(x,uint);
+                var eY = toSymEntry(y,real);
+                repMsg = "float64 %.17r".format(cov(eX.a, eY.a));
+            }
+            when (DType.UInt64, DType.Bool) {
+                var eX = toSymEntry(x,uint);
+                var eY = toSymEntry(y,bool);
+                repMsg = "float64 %.17r".format(cov(eX.a, eY.a));
+            }
+            otherwise {
+                var errorMsg = unrecognizedTypeError(pn, "(%s,%s)".format(dtype2str(x.dtype),dtype2str(y.dtype)));
+                sLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+        }
+        sLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+        return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+
+    proc corrMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+        param pn = Reflection.getRoutineName();
+        var args = parseMessageArgs(payload, 2);
+
+        var x: borrowed GenSymEntry = getGenericTypedArrayEntry(args.getValueOf("x"), st);
+        var y: borrowed GenSymEntry = getGenericTypedArrayEntry(args.getValueOf("y"), st);
+
+        var repMsg: string = "float64 %.17r".format(corrHelper(x, y));
+        sLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+        return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+
+    proc corrHelper(x: borrowed GenSymEntry, y: borrowed GenSymEntry): real throws {
+        param pn = Reflection.getRoutineName();
+        select (x.dtype, y.dtype) {
+            when (DType.Int64, DType.Int64) {
+                return corr(toSymEntry(x,int).a, toSymEntry(y,int).a);
+            }
+            when (DType.Int64, DType.Float64) {
+                return corr(toSymEntry(x,int).a, toSymEntry(y,real).a);
+            }
+            when (DType.Int64, DType.Bool) {
+                return corr(toSymEntry(x,int).a, toSymEntry(y,bool).a);
+            }
+            when (DType.Int64, DType.UInt64) {
+                return corr(toSymEntry(x,int).a, toSymEntry(y,uint).a);
+            }
+            when (DType.Float64, DType.Float64) {
+                return corr(toSymEntry(x,real).a, toSymEntry(y,real).a);
+            }
+            when (DType.Float64, DType.Int64) {
+                return corr(toSymEntry(x,real).a, toSymEntry(y,int).a);
+            }
+            when (DType.Float64, DType.Bool) {
+                return corr(toSymEntry(x,real).a, toSymEntry(y,bool).a);
+            }
+            when (DType.Float64, DType.UInt64) {
+                return corr(toSymEntry(x,real).a, toSymEntry(y,uint).a);
+            }
+            when (DType.Bool, DType.Bool) {
+                return corr(toSymEntry(x,bool).a, toSymEntry(y,bool).a);
+            }
+            when (DType.Bool, DType.Float64) {
+                return corr(toSymEntry(x,bool).a, toSymEntry(y,real).a);
+            }
+            when (DType.Bool, DType.Int64) {
+                return corr(toSymEntry(x,bool).a, toSymEntry(y,int).a);
+            }
+            when (DType.Bool, DType.UInt64) {
+                return corr(toSymEntry(x,bool).a, toSymEntry(y,uint).a);
+            }
+            when (DType.UInt64, DType.UInt64) {
+                return corr(toSymEntry(x,uint).a, toSymEntry(y,uint).a);
+            }
+            when (DType.UInt64, DType.Int64) {
+                return corr(toSymEntry(x,uint).a, toSymEntry(y,int).a);
+            }
+            when (DType.UInt64, DType.Float64) {
+                return corr(toSymEntry(x,uint).a, toSymEntry(y,real).a);
+            }
+            when (DType.UInt64, DType.Bool) {
+                return corr(toSymEntry(x,uint).a, toSymEntry(y,bool).a);
+            }
+            otherwise {
+                var errorMsg = unrecognizedTypeError(pn, "(%s,%s)".format(dtype2str(x.dtype),dtype2str(y.dtype)));
+                sLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                throw new owned IllegalArgumentError(errorMsg);
+            }
+        }
+    }
+
+    proc corrMatrixMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+        param pn = Reflection.getRoutineName();
+        var args = parseMessageArgs(payload, 3);
+
+        var size = args.get("size").getIntValue();
+        var columns = args.get("columns").getList(size);
+        var dataNames = args.get("data_names").getList(size);
+
+        var corrDict = new map(keyType=string, valType=string);
+        // TODO CORRELATION MATRIX IS SYMMETRIC, WE CAN USE THAT!
+        // would this be easy to do with a 2D chapel matrix?
+        for (col, d1, i) in zip(columns, dataNames, 0..) {
+            var corrPdarray = makeDistArray(size, real);
+            var d1gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(d1, st);
+            forall (d2, j) in zip(dataNames, 0..) {
+                var d2gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(d2, st);
+                corrPdarray[j] = corrHelper(d1gEnt, d2gEnt);
+            }
+            var retname = st.nextName();
+            st.addEntry(retname, new shared SymEntry(corrPdarray));
+            corrDict.add(col, "created %s".format(st.attrib(retname)));
+        }
+        var repMsg: string = "%jt".format(corrDict);
+
+        sLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+        return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+
+
+    use CommandMap;
+    registerFunction("mean", meanMsg, getModuleName());
+    registerFunction("var", varMsg, getModuleName());
+    registerFunction("std", stdMsg, getModuleName());
+    registerFunction("cov", covMsg, getModuleName());
+    registerFunction("corr",  corrMsg, getModuleName());
+    registerFunction("corrMatrix",  corrMatrixMsg, getModuleName());
+}

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -117,7 +117,7 @@ class DataFrameTest(ArkoudaTest):
         self.assertTrue(isinstance(df.day, ak.Series))
         self.assertTrue(isinstance(df.amount, ak.Series))
         for col in ("userName", "userID", "item", "day", "amount"):
-            self.assertTrue(isinstance(df["userName"], (ak.pdarray, ak.Strings, ak.Categorical)))
+            self.assertTrue(isinstance(df[col], (ak.pdarray, ak.Strings, ak.Categorical)))
         self.assertTrue(isinstance(df[["userName", "amount"]], ak.DataFrame))
         self.assertTrue(isinstance(df[("userID", "item", "day")], ak.DataFrame))
         self.assertTrue(isinstance(df.index, ak.Index))

--- a/tests/stats_test.py
+++ b/tests/stats_test.py
@@ -8,15 +8,20 @@ class StatsTest(ArkoudaTest):
     def setUp(self):
         ArkoudaTest.setUp(self)
         self.x = ak.arange(10, 20)
-        self.pdx = pd.Series(np.arange(10, 20))
+        self.npx = np.arange(10, 20)
+        self.pdx = pd.Series(self.npx)
         self.y = ak.array([2, 1, 4, 5, 8, 12, 18, 25, 96, 48])
-        self.pdy = pd.Series(np.array([2, 1, 4, 5, 8, 12, 18, 25, 96, 48]))
+        self.npy = np.array([2, 1, 4, 5, 8, 12, 18, 25, 96, 48])
+        self.pdy = pd.Series(self.npy)
         self.u = ak.cast(self.y, ak.uint64)
-        self.pdu = pd.Series(np.array([2, 1, 4, 5, 8, 12, 18, 25, 96, 48], dtype=np.uint64))
+        self.npu = np.array([2, 1, 4, 5, 8, 12, 18, 25, 96, 48], dtype=np.uint64)
+        self.pdu = pd.Series(self.npu)
         self.b = ak.arange(10) % 2 == 0
-        self.pdb = pd.Series(np.arange(10) % 2 == 0)
+        self.npb = np.arange(10) % 2 == 0
+        self.pdb = pd.Series(self.npb)
         self.f = ak.array([i**2 for i in range(10)], dtype=ak.float64)
-        self.pdf = pd.Series(np.array([i**2 for i in range(10)], dtype=np.float64))
+        self.npf = np.array([i**2 for i in range(10)], dtype=np.float64)
+        self.pdf = pd.Series(self.npf)
         self.s = ak.array([f"string {i}" for i in range(10)])
         self.c = ak.Categorical(self.s)
 
@@ -29,6 +34,12 @@ class StatsTest(ArkoudaTest):
 
     def test_var(self):
         # Note the numpy and pandas var/std differ, we follow numpy by default
+        self.assertEqual(self.x.var(), self.npx.var())
+        self.assertAlmostEqual(self.y.var(), self.npy.var())
+        self.assertAlmostEqual(self.u.var(), self.npu.var())
+        self.assertEqual(self.b.var(), self.npb.var())
+        self.assertEqual(self.f.var(), self.npf.var())
+
         # The pandas version requires ddof = 1
         self.assertEqual(self.x.var(ddof=1), self.pdx.var())
         self.assertAlmostEqual(self.y.var(ddof=1), self.pdy.var())
@@ -38,6 +49,12 @@ class StatsTest(ArkoudaTest):
 
     def test_std(self):
         # Note the numpy and pandas var/std differ, we follow numpy by default
+        self.assertEqual(self.x.std(), self.npx.std())
+        self.assertAlmostEqual(self.y.std(), self.npy.std())
+        self.assertAlmostEqual(self.u.std(), self.npu.std())
+        self.assertEqual(self.b.std(), self.npb.std())
+        self.assertEqual(self.f.std(), self.npf.std())
+
         # The pandas version requires ddof = 1
         self.assertEqual(self.x.std(ddof=1), self.pdx.std())
         self.assertEqual(self.y.std(ddof=1), self.pdy.std())
@@ -102,7 +119,7 @@ class StatsTest(ArkoudaTest):
         # is there a better way to compare to pandas dataframe when the index doesn't match
         [self.assertTrue(np.allclose(ak_df[c].to_list(), pd_df[c].to_list())) for c in ak_df.columns]
 
-        # verify this doesn't error
+        # verify this doesn't have scoping issues with numeric conversion
         ak.DataFrame(
             {"x": self.x, "y": self.y, "u": self.u, "b": self.b, "f": self.f, "s": self.s, "c": self.c}
         ).corr()

--- a/tests/stats_test.py
+++ b/tests/stats_test.py
@@ -1,0 +1,108 @@
+import numpy as np
+import pandas as pd
+from base_test import ArkoudaTest
+from context import arkouda as ak
+
+
+class StatsTest(ArkoudaTest):
+    def setUp(self):
+        ArkoudaTest.setUp(self)
+        self.x = ak.arange(10, 20)
+        self.pdx = pd.Series(np.arange(10, 20))
+        self.y = ak.array([2, 1, 4, 5, 8, 12, 18, 25, 96, 48])
+        self.pdy = pd.Series(np.array([2, 1, 4, 5, 8, 12, 18, 25, 96, 48]))
+        self.u = ak.cast(self.y, ak.uint64)
+        self.pdu = pd.Series(np.array([2, 1, 4, 5, 8, 12, 18, 25, 96, 48], dtype=np.uint64))
+        self.b = ak.arange(10) % 2 == 0
+        self.pdb = pd.Series(np.arange(10) % 2 == 0)
+        self.f = ak.array([i**2 for i in range(10)], dtype=ak.float64)
+        self.pdf = pd.Series(np.array([i**2 for i in range(10)], dtype=np.float64))
+        self.s = ak.array([f"string {i}" for i in range(10)])
+        self.c = ak.Categorical(self.s)
+
+    def test_mean(self):
+        self.assertEqual(self.x.mean(), self.pdx.mean())
+        self.assertEqual(self.y.mean(), self.pdy.mean())
+        self.assertEqual(self.u.mean(), self.pdu.mean())
+        self.assertEqual(self.b.mean(), self.pdb.mean())
+        self.assertEqual(self.f.mean(), self.pdf.mean())
+
+    def test_var(self):
+        # Note the numpy and pandas var/std differ, we follow numpy by default
+        # The pandas version requires ddof = 1
+        self.assertEqual(self.x.var(ddof=1), self.pdx.var())
+        self.assertAlmostEqual(self.y.var(ddof=1), self.pdy.var())
+        self.assertAlmostEqual(self.u.var(ddof=1), self.pdu.var())
+        self.assertEqual(self.b.var(ddof=1), self.pdb.var())
+        self.assertEqual(self.f.var(ddof=1), self.pdf.var())
+
+    def test_std(self):
+        # Note the numpy and pandas var/std differ, we follow numpy by default
+        # The pandas version requires ddof = 1
+        self.assertEqual(self.x.std(ddof=1), self.pdx.std())
+        self.assertEqual(self.y.std(ddof=1), self.pdy.std())
+        self.assertEqual(self.u.std(ddof=1), self.pdu.std())
+        self.assertEqual(self.b.std(ddof=1), self.pdb.std())
+        self.assertEqual(self.f.std(ddof=1), self.pdf.std())
+
+    def test_cov(self):
+        # test that variations are equivalent
+        self.assertAlmostEqual(self.x.cov(self.y), self.pdx.cov(self.pdy))
+        self.assertAlmostEqual(self.x.cov(self.y), self.y.cov(self.x))
+        self.assertAlmostEqual(self.x.cov(self.y), ak.cov(self.x, self.y))
+        self.assertAlmostEqual(self.x.cov(self.y), ak.cov(self.y, self.x))
+
+        # test int with other types
+        self.assertAlmostEqual(self.x.cov(self.u), self.pdx.cov(self.pdu))
+        self.assertEqual(self.x.cov(self.b), self.pdx.cov(self.pdb))
+        self.assertEqual(self.x.cov(self.f), self.pdx.cov(self.pdf))
+
+        # test bool with other types
+        self.assertEqual(self.b.cov(self.b), self.pdb.cov(self.pdb))
+        self.assertAlmostEqual(self.b.cov(self.u), self.pdb.cov(self.pdu))
+        self.assertEqual(self.b.cov(self.f), self.pdb.cov(self.pdf))
+
+        # test float with other types
+        self.assertEqual(self.f.cov(self.f), self.pdf.cov(self.pdf))
+        self.assertAlmostEqual(self.f.cov(self.u), self.pdf.cov(self.pdu))
+
+        # test uint with self (other cases covered above)
+        self.assertAlmostEqual(self.u.cov(self.u), self.pdu.cov(self.pdu))
+
+    def test_corr(self):
+        # test that variations are equivalent
+        self.assertAlmostEqual(self.x.corr(self.y), self.pdx.corr(self.pdy))
+        self.assertAlmostEqual(self.x.corr(self.y), self.y.corr(self.x))
+        self.assertAlmostEqual(self.x.corr(self.y), ak.corr(self.x, self.y))
+        self.assertAlmostEqual(self.x.corr(self.y), ak.corr(self.y, self.x))
+
+        # test int with other types
+        self.assertAlmostEqual(self.x.corr(self.u), self.pdx.corr(self.pdu))
+        self.assertEqual(self.x.corr(self.b), self.pdx.corr(self.pdb))
+        self.assertAlmostEqual(self.x.corr(self.f), self.pdx.corr(self.pdf))
+
+        # test bool with other types
+        self.assertEqual(self.b.corr(self.b), self.pdb.corr(self.pdb))
+        self.assertAlmostEqual(self.b.corr(self.u), self.pdb.corr(self.pdu))
+        self.assertEqual(self.b.corr(self.f), self.pdb.corr(self.pdf))
+
+        # test float with other types
+        self.assertEqual(self.f.corr(self.f), self.pdf.corr(self.pdf))
+        self.assertAlmostEqual(self.f.corr(self.u), self.pdf.corr(self.pdu))
+
+        # test uint with self (other cases covered above)
+        self.assertAlmostEqual(self.u.corr(self.u), self.pdu.corr(self.pdu))
+
+    def test_corr_matrix(self):
+        ak_df = ak.DataFrame({"x": self.x, "y": self.y, "u": self.u, "b": self.b, "f": self.f}).corr()
+        pd_df = pd.DataFrame(
+            {"x": self.pdx, "y": self.pdy, "u": self.pdu, "b": self.pdb, "f": self.pdf}
+        ).corr()
+
+        # is there a better way to compare to pandas dataframe when the index doesn't match
+        [self.assertTrue(np.allclose(ak_df[c].to_list(), pd_df[c].to_list())) for c in ak_df.columns]
+
+        # verify this doesn't error
+        ak.DataFrame(
+            {"x": self.x, "y": self.y, "u": self.u, "b": self.b, "f": self.f, "s": self.s, "c": self.c}
+        ).corr()


### PR DESCRIPTION
This PR (Closes https://github.com/Bears-R-Us/arkouda/issues/1643):
- Adds covariance `ak.cov(pda1, pda2)`, correlation for pdarrays `ak.corr(pda1, pda2)`, and correlation matrix for dataframes `df.corr()`
- Moves `mean`, `var`, `std` to server
- Adds testing for these functions and their type combos
- Utilizes the new JSON message arguments infrastructure