### PR TITLE
Closes #1670: Remove `in-place` from `DataFrame.drop` docstring

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -680,7 +680,7 @@ class DataFrame(UserDict):
         inplace: bool = False,
     ) -> Union[None, DataFrame]:
         """
-        Drop column/s or row/s from the dataframe, in-place.
+        Drop column/s or row/s from the dataframe.
 
         Parameters
         ----------


### PR DESCRIPTION
Removes `in-place` from `DataFrame.drop` docstring (Closes #1670)