### PR TITLE
Closes #1618 - Nested JSON Message Argument Support

### DIFF
--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -25,7 +25,6 @@ __all__ = [
     "get_server_commands",
     "print_server_commands",
     "ruok",
-    "_json_args_to_str",
 ]
 
 # stuff for zmq connection
@@ -572,8 +571,6 @@ def _json_args_to_str(json_obj: Dict) -> Tuple[int, str]:
     for key, val in json_obj.items():
         if not isinstance(key, str):
             raise TypeError(f"Argument keys are required to be str. Found {type(key)}")
-        # if isinstance(val, dict):
-        #     raise TypeError("Nested JSON is not currently supported for server messages.")
 
         param = ParameterObject.factory(key, val)
         j.append(json.dumps(param.dict))

--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -25,6 +25,7 @@ __all__ = [
     "get_server_commands",
     "print_server_commands",
     "ruok",
+    "_json_args_to_str",
 ]
 
 # stuff for zmq connection
@@ -571,8 +572,8 @@ def _json_args_to_str(json_obj: Dict) -> Tuple[int, str]:
     for key, val in json_obj.items():
         if not isinstance(key, str):
             raise TypeError(f"Argument keys are required to be str. Found {type(key)}")
-        if isinstance(val, dict):
-            raise TypeError("Nested JSON is not currently supported for server messages.")
+        # if isinstance(val, dict):
+        #     raise TypeError("Nested JSON is not currently supported for server messages.")
 
         param = ParameterObject.factory(key, val)
         j.append(json.dumps(param.dict))

--- a/arkouda/message.py
+++ b/arkouda/message.py
@@ -137,7 +137,7 @@ class ParameterObject:
     def _build_dict_param(key: str, val: Dict) -> ParameterObject:
         j = []
         for k, v in val.items():
-            if not isinstance(key, str):
+            if not isinstance(k, str):
                 raise TypeError(f"Argument keys are required to be str. Found {type(key)}")
             param = ParameterObject.factory(k, v)
             j.append(json.dumps(param.dict))

--- a/arkouda/message.py
+++ b/arkouda/message.py
@@ -138,7 +138,7 @@ class ParameterObject:
         j = []
         for k, v in val.items():
             if not isinstance(k, str):
-                raise TypeError(f"Argument keys are required to be str. Found {type(key)}")
+                raise TypeError(f"Argument keys are required to be str. Found {type(k)}")
             param = ParameterObject.factory(k, v)
             j.append(json.dumps(param.dict))
         return ParameterObject(key, ObjectType.DICT, str(dict.__name__), json.dumps(j))

--- a/arkouda/message.py
+++ b/arkouda/message.py
@@ -17,6 +17,7 @@ class ObjectType(Enum):
     PDARRAY = "PDARRAY"
     STRINGS = "SEGSTRING"
     LIST = "LIST"
+    DICT = "DICT"
     VALUE = "VALUE"
 
     def __str__(self) -> str:
@@ -133,6 +134,17 @@ class ParameterObject:
 
     @staticmethod
     @typechecked
+    def _build_dict_param(key: str, val: Dict) -> ParameterObject:
+        j = []
+        for k, v in val.items():
+            if not isinstance(key, str):
+                raise TypeError(f"Argument keys are required to be str. Found {type(key)}")
+            param = ParameterObject.factory(k, v)
+            j.append(json.dumps(param.dict))
+        return ParameterObject(key, ObjectType.DICT, str(dict.__name__), json.dumps(j))
+
+    @staticmethod
+    @typechecked
     def _build_gen_param(key: str, val) -> ParameterObject:
         """
         Create a ParameterObject from a single value
@@ -167,6 +179,7 @@ class ParameterObject:
             pdarray.__name__: ParameterObject._build_pdarray_param,
             Strings.__name__: ParameterObject._build_strings_param,
             list.__name__: ParameterObject._build_list_param,
+            dict.__name__: ParameterObject._build_dict_param,
         }
 
     @staticmethod

--- a/src/Message.chpl
+++ b/src/Message.chpl
@@ -194,7 +194,13 @@ module Message {
         }
 
         proc getJSON(size: int) throws {
-            // TODO - add error if not right type
+            if this.objType != ObjectType.DICT {
+                throw new owned ErrorWithContext("Parameter with key, %s, is not a JSON obj.".format(this.key),
+                                    getLineNumber(),
+                                    getRoutineName(),
+                                    getModuleName(),
+                                    "TypeError");
+            }
             return parseMessageArgs(this.val, size);
         }
     }

--- a/src/Message.chpl
+++ b/src/Message.chpl
@@ -7,7 +7,7 @@ module Message {
 
     enum MsgType {NORMAL,WARNING,ERROR}
     enum MsgFormat {STRING,BINARY}
-    enum ObjectType {PDARRAY, SEGSTRING, LIST, VALUE}
+    enum ObjectType {PDARRAY, SEGSTRING, LIST, DICT, VALUE}
 
     /*
      * Encapsulates the message string and message type.
@@ -191,6 +191,11 @@ module Message {
                                     "TypeError");
             }
             return jsonToPdArray(this.val, size);
+        }
+
+        proc getJSON(size: int) throws {
+            // TODO - add error if not right type
+            return parseMessageArgs(this.val, size);
         }
     }
 

--- a/tests/message_test.py
+++ b/tests/message_test.py
@@ -161,3 +161,34 @@ class JSONArgs(ArkoudaTest):
             self.assertEqual(p["objType"], "SEGSTRING")
             self.assertEqual(p["dtype"], "str")
             self.assertRegex(p["val"], "^id_\\w{7}_\\d$")
+
+        # test nested json
+        size, args = _json_args_to_str({
+            "json_1": {
+                "param1": 1,
+                "param2": "abc",
+                "param3": [1, 2, 3],
+            }
+        })
+        self.assertEqual(size, 1)
+        j = json.loads(json.loads(args)[0])
+        self.assertEqual(j["key"], "json_1")
+        self.assertEqual(j["objType"], "DICT")
+        self.assertEqual(j["dtype"], "dict")
+        for i, a in enumerate(json.loads(j["val"])):
+            p = json.loads(a)
+            self.assertEqual(p["key"], f"param{i+1}")
+            if i == 0:
+                self.assertEqual(p["objType"], "VALUE")
+                self.assertEqual(p["dtype"], "int")
+                self.assertEqual(p["val"], "1")
+            elif i == 1:
+                self.assertEqual(p["objType"], "VALUE")
+                self.assertEqual(p["dtype"], "str")
+                self.assertEqual(p["val"], "abc")
+            else:
+                self.assertEqual(p["objType"], "LIST")
+                self.assertEqual(p["dtype"], "int")
+                self.assertListEqual(json.loads(p["val"]), ["1", "2", "3"])
+
+


### PR DESCRIPTION
Closes #1618 

Adds support for nested json arguments to the client and server message parsing.

# Example for use
## Python Code
```python
# one layer nested. 'a' contains JSON
x = {
    'a': {
        'test':1,
        'JSON':2
    }
}

rep_msg = ak.generic_msg(
    cmd="<yourCommandHere>", 
    args=x
)
```

## Chapel Code
```chapel
// This is just an example function I used for initial testing to show how to access sub-json
proc nestedTestMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
    // Parse the top level json into message args
    var msgArgs = parseMessageArgs(payload, 1);

    // Access the json formatted string value 
    var json_str = msgArgs.get('a');

    writeln("JSON STRING: %s".format(json_str.getValue()));

    // Parse the sub-json. This requires you provide the number of parameters like lists.
    var sub_json_args = json_str.getJSON(2);

    writeln("SUB JSON KEYS: %jt".format(sub_json_args.keys()));
    return new MsgTuple("JSON Read Success", MsgType.NORMAL);
}
```