### PR TITLE
Closes #1613: Remove empty string regex workaround

### DIFF
--- a/arkouda/matcher.py
+++ b/arkouda/matcher.py
@@ -32,12 +32,6 @@ class Matcher:
             re.compile(self.pattern)
         except Exception as e:
             raise ValueError(e)
-        if re.search(self.pattern, ""):
-            # TODO remove once changes from chapel issue #18639 are in arkouda
-            raise ValueError(
-                "regex operations with a pattern that matches the empty string are"
-                "not currently supported"
-            )
         self.parent_entry_name = parent_entry_name
         self.num_matches: pdarray
         self.starts: pdarray
@@ -116,6 +110,8 @@ class Matcher:
         """
         from arkouda.strings import Strings
 
+        if re.search(self.pattern, ""):
+            raise ValueError("Cannot split or flatten with a pattern that matches the empty string")
         cmd = "segmentedSplit"
         args = "{} {} {} {} {}".format(
             self.objtype, self.parent_entry_name, maxsplit, return_segments, json.dumps([self.pattern])

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -580,6 +580,14 @@ class Strings:
         """
         self._regex_dict = dict()
 
+    def _empty_pattern_verification(self, pattern):
+        if pattern == "$" or (pattern == "" and (self == "").any()):  # type: ignore
+            # TODO remove once changes from chapel issue #20431 and #20441 are in arkouda
+            raise ValueError(
+                "regex operations not currently supported with a pattern='$' or pattern='' when "
+                "the empty string is contained in Strings"
+            )
+
     def _get_matcher(self, pattern: Union[bytes, str_scalars], create: bool = True):
         """
         internal function to fetch cached Matcher objects
@@ -592,12 +600,7 @@ class Strings:
             re.compile(pattern)
         except Exception as e:
             raise ValueError(e)
-        if pattern == "$" or (pattern == "" and (self == "").any()):  # type: ignore
-            # TODO remove once changes from chapel issue #20431 and #20441 are in arkouda
-            raise ValueError(
-                "regex operations not currently supported with a pattern=$ or pattern='' when "
-                "the empty string is contained in Strings"
-            )
+        self._empty_pattern_verification(pattern)
         matcher = None
         if pattern in self._regex_dict:
             matcher = self._regex_dict[pattern]
@@ -950,12 +953,7 @@ class Strings:
             substr = substr.decode()
         if not regex:
             substr = re.escape(substr)
-        if substr == "$" or (substr == "" and (self == "").any()):  # type: ignore
-            # TODO remove once changes from chapel issue #20431 and #20441 are in arkouda
-            raise ValueError(
-                "regex operations not currently supported with a pattern=$ or pattern='' when "
-                "the empty string is contained in Strings"
-            )
+        self._empty_pattern_verification(substr)
         matcher = self._get_matcher(substr, create=False)
         if matcher is not None:
             return matcher.get_match(MatchType.SEARCH, self).matched()
@@ -1012,12 +1010,7 @@ class Strings:
             substr = substr.decode()
         if not regex:
             substr = re.escape(substr)
-        if substr == "$" or (substr == "" and (self == "").any()):  # type: ignore
-            # TODO remove once changes from chapel issue #20431 and #20441 are in arkouda
-            raise ValueError(
-                "regex operations not currently supported with a pattern=$ or pattern='' when "
-                "the empty string is contained in Strings"
-            )
+        self._empty_pattern_verification(substr)
         matcher = self._get_matcher(substr, create=False)
         if matcher is not None:
             return matcher.get_match(MatchType.MATCH, self).matched()
@@ -1073,13 +1066,7 @@ class Strings:
             substr = substr.decode()
         if not regex:
             substr = re.escape(substr)
-        if substr == "$":
-            # TODO remove once changes from chapel issue #20431 and #20441 are in arkouda
-            # no need to add "" case because it will be caught in contains
-            raise ValueError(
-                "regex operations not currently supported with a pattern=$ or pattern='' when "
-                "the empty string is contained in Strings"
-            )
+        self._empty_pattern_verification(substr)
         return self.contains(substr + "$", regex=True)
 
     def flatten(

--- a/tests/regex_test.py
+++ b/tests/regex_test.py
@@ -17,7 +17,7 @@ class RegexTest(ArkoudaTest):
                 s2.startswith(pattern, regex=True).to_list(),
                 [re.search("^" + pattern, si) is not None for si in s],
             )
-            if pattern is not "":
+            if pattern != "":
                 self.assertListEqual(
                     s2.endswith(pattern, regex=True).to_list(),
                     [re.search(pattern + "$", si) is not None for si in s],


### PR DESCRIPTION
This PR (Closes #1613):
- Removes the workaround to raise a ValueError for patterns that match the empty string
- Updates `sub` chapel code to correctly handle patterns which match the empty string
- Updates tests for this functionality

There are a few exceptions:
- We don't currently support `pattern="$"` because of [Chapel issue #20431](https://github.com/chapel-lang/chapel/issues/20431)
  - Might be able to come up with a workaround for this
- We don't support `pattern=""` if Strings also contains a `""` because of [Chapel issue #20441](https://github.com/chapel-lang/chapel/issues/20441)
- We don't allow patterns that match the empty string for `peel`, `split`, `flatten`
  - `re.split` and `non-regex flatten` don't work with empty separator, so this lines up
  - `peel` hangs with single character strings and regex which matches the empty string. This needs to be looked into further.