### PR TITLE
Closes #1684 - `ArgSortMsg.chpl` & `UniqueMsg.chpl` JSON Message Arguments

### DIFF
--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -111,13 +111,13 @@ def unique(
     effectiveKeys = len(grouping_keys)
     repMsg = generic_msg(
         cmd="unique",
-        args="{} {} {:n} {} {}".format(
-            return_groups,
-            assume_sorted,
-            effectiveKeys,
-            " ".join(keynames),
-            " ".join(keytypes),
-        ),
+        args={
+            "returnGroupStr": return_groups,
+            "assumeSortedStr": assume_sorted,
+            "nstr": effectiveKeys,
+            "keynames": keynames,
+            "keytypes": keytypes,
+        },
     )
     if return_groups:
         parts = cast(str, repMsg).split("+")

--- a/arkouda/sorting.py
+++ b/arkouda/sorting.py
@@ -63,12 +63,11 @@ def argsort(
         return cast(Categorical, pda).argsort()
     if pda.size == 0 and hasattr(pda, "dtype"):
         return zeros(0, dtype=pda.dtype)
-    args = {
+    repMsg = generic_msg(cmd="argsort", args={
         "name": pda.entry.name if isinstance(pda, Strings) else pda.name,
         "algoName": algorithm.name,
         "objType": pda.objtype,
-    }
-    repMsg = generic_msg(cmd="argsort", args=args)
+    })
     return create_pdarray(cast(str, repMsg))
 
 
@@ -149,16 +148,15 @@ def coargsort(
             raise ValueError("All pdarrays, Strings, or Categoricals must be of the same size")
     if size == 0:
         return zeros(0, dtype=arrays[0].dtype)
-    args = {
-        "algoName": algorithm.name,
-        "nstr": len(arrays),
-        "arr_names": anames,
-        "arr_types": atypes,
-    }
 
     repMsg = generic_msg(
         cmd="coargsort",
-        args=args,
+        args={
+            "algoName": algorithm.name,
+            "nstr": len(arrays),
+            "arr_names": anames,
+            "arr_types": atypes,
+        },
     )
     return create_pdarray(cast(str, repMsg))
 

--- a/arkouda/sorting.py
+++ b/arkouda/sorting.py
@@ -63,8 +63,12 @@ def argsort(
         return cast(Categorical, pda).argsort()
     if pda.size == 0 and hasattr(pda, "dtype"):
         return zeros(0, dtype=pda.dtype)
-    name = pda.entry.name if isinstance(pda, Strings) else pda.name
-    repMsg = generic_msg(cmd="argsort", args="{} {} {}".format(algorithm.name, pda.objtype, name))
+    args = {
+        "name": pda.entry.name if isinstance(pda, Strings) else pda.name,
+        "algoName": algorithm.name,
+        "objType": pda.objtype,
+    }
+    repMsg = generic_msg(cmd="argsort", args=args)
     return create_pdarray(cast(str, repMsg))
 
 
@@ -145,9 +149,16 @@ def coargsort(
             raise ValueError("All pdarrays, Strings, or Categoricals must be of the same size")
     if size == 0:
         return zeros(0, dtype=arrays[0].dtype)
+    args = {
+        "algoName": algorithm.name,
+        "nstr": len(arrays),
+        "arr_names": anames,
+        "arr_types": atypes,
+    }
+
     repMsg = generic_msg(
         cmd="coargsort",
-        args="{} {:n} {} {}".format(algorithm.name, len(arrays), " ".join(anames), " ".join(atypes)),
+        args=args,
     )
     return create_pdarray(cast(str, repMsg))
 

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -140,10 +140,10 @@ module AryUtil
      *
      * :returns: (length, hasStr, names, objtypes)
      */
-    proc validateArraysSameLength(n:int, fields:[] string, st: borrowed SymTab) throws {
+    proc validateArraysSameLength(n:int, names:[] string, types: [] string, st: borrowed SymTab) throws {
       // Check that fields contains the stated number of arrays
-      if (fields.size != 2*n) { 
-          var errorMsg = "Expected %i arrays but got %i".format(n, fields.size/2 - 1);
+      if (names.size != n) { 
+          var errorMsg = "Expected %i arrays but got %i".format(n, names.size);
           auLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
           throw new owned ErrorWithContext(errorMsg,
                                            getLineNumber(),
@@ -151,9 +151,15 @@ module AryUtil
                                            getModuleName(),
                                            "ArgumentError");
       }
-      const low = fields.domain.low;
-      var names = fields[low..#n];
-      var types = fields[low+n..#n];
+      if (types.size != n) { 
+          var errorMsg = "Expected %i types but got %i".format(n, types.size);
+          auLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+          throw new owned ErrorWithContext(errorMsg,
+                                           getLineNumber(),
+                                           getRoutineName(),
+                                           getModuleName(),
+                                           "ArgumentError");
+      }
       /* var arrays: [0..#n] borrowed GenSymEntry; */
       var size: int;
       // Check that all arrays exist in the symbol table and have the same size


### PR DESCRIPTION
Closes #1684 
Part of #1616 

- Converts `ArgSortMsg.chpl` to use JSON message arguments instead of string.
    - `cmd="argSortMsg"`
    - `cmd="coargSortMsg"`
- Converts `UniqueMsg.chpl` to use JSON message arguments instead of string
    - `cmd="unique"`
- Updates `AryUtil.validateArraysSameLength` to take in list of array name and array types instead of a single string list. This is more readable and allows these components to be parsed separately instead of separating from a single component.
- Updates calling code in the client to use JSON formatted arguments.

On the surface, functionality remains the same, this is purely under the hood mechanics for cleaner organization of message arguments.