### PR TITLE
Closes #1685 - Update `list.extend` to `list.append` in `MetricsMsg.chpl`

### DIFF
--- a/src/MetricsMsg.chpl
+++ b/src/MetricsMsg.chpl
@@ -91,7 +91,7 @@ module MetricsMsg {
         proc getPerUserNumRequestsPerCommandForAllUsersMetrics() {
             var metrics = new list(owned UserMetric?);
             for userName in this.users.getUserNames() {
-                metrics.extend(this.getPerUserNumRequestsPerCommandMetrics(userName));
+                metrics.append(this.getPerUserNumRequestsPerCommandMetrics(userName));
             }
 
             return metrics;
@@ -191,10 +191,10 @@ module MetricsMsg {
     proc exportAllMetrics() throws {        
         var metrics = new list(owned Metric?);
 
-        metrics.extend(getNumRequestMetrics());
-        metrics.extend(getResponseTimeMetrics());
-        metrics.extend(getSystemMetrics());
-        metrics.extend(getServerMetrics());
+        metrics.append(getNumRequestMetrics());
+        metrics.append(getResponseTimeMetrics());
+        metrics.append(getSystemMetrics());
+        metrics.append(getServerMetrics());
 
         for userMetric in getAllUserRequestMetrics() {
             metrics.append(userMetric: owned Metric);


### PR DESCRIPTION
Closes #1685 

Updates `list.extend` (which has been deprecated) to use `list.append` (recommended replacement by chapel) in `MetricMsg.chpl`. 

This prevents deprecation warnings when running `make`