### PR TITLE
Closes #1611 - DataFrame Register and Attach Functionality

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -1809,7 +1809,6 @@ class DataFrame(UserDict):
 
         return DataFrame(df_def, index=self.index)
 
-
     def corr(self) -> DataFrame:
         """
         Return new DataFrame with pairwise correlation of columns

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -4,6 +4,7 @@ from warnings import warn
 
 import numpy as np  # type: ignore
 
+from arkouda import objtypedec
 from arkouda.client import generic_msg
 from arkouda.dtypes import bool as akbool
 from arkouda.dtypes import int64 as akint64
@@ -75,6 +76,7 @@ def _aggregator(func):
     return update_doc
 
 
+@objtypedec
 class SegArray:
     def __init__(self, segments, values, copy=False, lengths=None, grouping=None):
         """
@@ -163,6 +165,10 @@ class SegArray:
                 )
         else:
             self.grouping = grouping
+
+    @property
+    def objtype(self):
+        return self.objtype
 
     @property
     def segments(self):

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -1178,6 +1178,19 @@ module SegmentedMsg {
       smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
       return new MsgTuple(repMsg, MsgType.NORMAL);
   }
+
+  proc stringsToJSONMsg(cmd: string, name: string, st: borrowed SymTab): MsgTuple throws {
+    var strings = getSegString(name, st);
+    var size = strings.size;
+    var rtn: [0..#size] string;
+
+    for i in 0..#size {
+      rtn[i] = strings[i];
+    }
+
+    var repMsg = "%jt".format(rtn);
+    return new MsgTuple(repMsg, MsgType.NORMAL);
+  }
   
   use CommandMap;
   registerFunction("segmentLengths", segmentLengthsMsg, getModuleName());
@@ -1200,5 +1213,6 @@ module SegmentedMsg {
   registerFunction("segArr-getSegments", getSASegmentsMsg, getModuleName());
   registerFunction("segArr-getValues", getSAValuesMsg, getModuleName());
   registerFunction("segStr-assemble", assembleStringsMsg, getModuleName());
+  registerFunction("stringsToJSON", stringsToJSONMsg, getModuleName());
   registerBinaryFunction("segStr-tondarray", segStrTondarrayMsg, getModuleName());
 }

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -1184,7 +1184,7 @@ module SegmentedMsg {
     var size = strings.size;
     var rtn: [0..#size] string;
 
-    for i in 0..#size {
+    forall i in 0..#size {
       rtn[i] = strings[i];
     }
 

--- a/tests/registration_test.py
+++ b/tests/registration_test.py
@@ -635,6 +635,38 @@ class RegistrationTest(ArkoudaTest):
         self.assertFalse(groupC.is_registered())
         self.assertFalse(groupL.is_registered())
 
+    def test_dataframe_register(self):
+        # Create DataFrame
+        username = ak.array(["Alice", "Bob", "Alice", "Carol", "Bob", "Alice"])
+        userid = ak.array([111, 222, 111, 333, 222, 111])
+        item = ak.array([0, 0, 1, 1, 2, 0])
+        day = ak.array([5, 5, 6, 5, 6, 6])
+        amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
+        index = ak.Index.factory(ak.array(["One", "Two", "Three", "Four", "Five", "Six"]))
+        df = ak.DataFrame(
+            {"userName": username, "userID": userid, "item": item, "day": day, "amount": amount},
+            index
+        )
+
+        # Register DataFrame with name 'DataFrame_test'
+        df.register("DataFrame_test")
+        self.assertTrue(df.is_registered())
+
+        # Attach registered DataFrame 'DataFrame_test' into variable dfa and assert the original and
+        # attached versions of the DataFrame are equal
+        dfa = ak.DataFrame.attach("DataFrame_test")
+        self.assertTrue(df.to_pandas().equals(dfa.to_pandas()))
+
+        # Unregister a single component of the DataFrame to assert a warning is raised when not all
+        # expected components of the DataFrame are registered
+        ak.pdarrayclass.unregister_pdarray_by_name("df_index_DataFrame_test_key")
+        with self.assertWarns(UserWarning):
+            df.is_registered()
+
+        # Unregister the DataFrame and assert that it has been unregistered completely
+        df.unregister()
+        self.assertFalse(df.is_registered())
+
 
 def cleanup():
     ak.clear()

--- a/tests/registration_test.py
+++ b/tests/registration_test.py
@@ -644,8 +644,7 @@ class RegistrationTest(ArkoudaTest):
         amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
         index = ak.Index.factory(ak.array(["One", "Two", "Three", "Four", "Five", "Six"]))
         df = ak.DataFrame(
-            {"userName": username, "userID": userid, "item": item, "day": day, "amount": amount},
-            index
+            {"userName": username, "userID": userid, "item": item, "day": day, "amount": amount}, index
         )
 
         # Register DataFrame with name 'DataFrame_test'


### PR DESCRIPTION
This PR closes #1611 

Adds the basic `register` and `attach` capabilities to DataFrame:
`register(name)`
`attach(name)`
`unregister()`
`is_registered()`
`unregister_dataframe_by_name(name)`

Also adds `.objtype` property to `SegArray` to support using the objtype to distinguish between potential column types in the DataFrame to ensure proper rebuilding.

Most of this should be fairly straight forward, the only little "trick" that I had to do was in the attach function. In order to preserve the order of columns within the DataFrame I register the `dataframe.columns` property with the DataFrame and use that list to create a dictionary with the proper keys and empty values. The values are then parsed through the names of the registered column data and assigned to their respective location in the dictionary. This prevents index misalignment issues and allows the original DataFrame and newly attached DataFrame to evaluate to equal.