### PR TITLE
Closes #1376: Add `Datetime` and `Timedelta` attributes

### DIFF
--- a/ServerModules.cfg
+++ b/ServerModules.cfg
@@ -24,6 +24,7 @@ CastMsg
 BroadcastMsg
 FlattenMsg
 StatsMsg
+TimeClassMsg
 HDF5Msg
 ParquetMsg
 HDF5MultiDim

--- a/arkouda/timeclass.py
+++ b/arkouda/timeclass.py
@@ -421,22 +421,21 @@ class Datetime(_AbstractBaseTime):
         if self._is_populated:
             return
         # lazy initialize all attributes in one server call
-        args = {"values": self.values.name}
-        attributes_dict = json.loads(generic_msg(cmd="dateTimeAttributes", args=args))
-        self._ns = create_pdarray(attributes_dict["nanosecond"])
-        self._us = create_pdarray(attributes_dict["microsecond"])
-        self._ms = create_pdarray(attributes_dict["millisecond"])
-        self._s = create_pdarray(attributes_dict["second"])
-        self._min = create_pdarray(attributes_dict["minute"])
-        self._hour = create_pdarray(attributes_dict["hour"])
-        self._day = create_pdarray(attributes_dict["day"])
-        self._month = create_pdarray(attributes_dict["month"])
-        self._year = create_pdarray(attributes_dict["year"])
-        self._iso_year = create_pdarray(attributes_dict["isoYear"])
-        self._day_of_week = create_pdarray(attributes_dict["dayOfWeek"])
-        self._week_of_year = create_pdarray(attributes_dict["weekOfYear"])
-        self._day_of_year = create_pdarray(attributes_dict["dayOfYear"])
-        self._is_leap_year = create_pdarray(attributes_dict["isLeapYear"])
+        attribute_dict = json.loads(generic_msg(cmd="dateTimeAttributes", args={"values": self.values}))
+        self._ns = create_pdarray(attribute_dict["nanosecond"])
+        self._us = create_pdarray(attribute_dict["microsecond"])
+        self._ms = create_pdarray(attribute_dict["millisecond"])
+        self._s = create_pdarray(attribute_dict["second"])
+        self._min = create_pdarray(attribute_dict["minute"])
+        self._hour = create_pdarray(attribute_dict["hour"])
+        self._day = create_pdarray(attribute_dict["day"])
+        self._month = create_pdarray(attribute_dict["month"])
+        self._year = create_pdarray(attribute_dict["year"])
+        self._iso_year = create_pdarray(attribute_dict["isoYear"])
+        self._day_of_week = create_pdarray(attribute_dict["dayOfWeek"])
+        self._week_of_year = create_pdarray(attribute_dict["weekOfYear"])
+        self._day_of_year = create_pdarray(attribute_dict["dayOfYear"])
+        self._is_leap_year = create_pdarray(attribute_dict["isLeapYear"])
         self._date = self.floor("d")
         self._is_populated = True
 
@@ -615,15 +614,14 @@ class Timedelta(_AbstractBaseTime):
         if self._is_populated:
             return
         # lazy initialize all attributes in one server call
-        args = {"values": self.values.name}
-        attributes_dict = json.loads(generic_msg(cmd="timeDeltaAttributes", args=args))
-        self._ns = create_pdarray(attributes_dict["nanosecond"])
-        self._us = create_pdarray(attributes_dict["microsecond"])
-        self._ms = create_pdarray(attributes_dict["millisecond"])
-        self._s = create_pdarray(attributes_dict["second"])
-        self._m = create_pdarray(attributes_dict["minute"])
-        self._h = create_pdarray(attributes_dict["hour"])
-        self._d = create_pdarray(attributes_dict["day"])
+        attribute_dict = json.loads(generic_msg(cmd="timeDeltaAttributes", args={"values": self.values}))
+        self._ns = create_pdarray(attribute_dict["nanosecond"])
+        self._us = create_pdarray(attribute_dict["microsecond"])
+        self._ms = create_pdarray(attribute_dict["millisecond"])
+        self._s = create_pdarray(attribute_dict["second"])
+        self._m = create_pdarray(attribute_dict["minute"])
+        self._h = create_pdarray(attribute_dict["hour"])
+        self._d = create_pdarray(attribute_dict["day"])
         self._nanoseconds = self._ns
         self._microseconds = self._ms * 1000 + self._us
         self._seconds = self._h * 3600 + self._m * 60 + self._s

--- a/arkouda/timeclass.py
+++ b/arkouda/timeclass.py
@@ -138,6 +138,7 @@ class _AbstractBaseTime(pdarray):
             self.values.itemsize,
         )
         self._data = self.values
+        self._is_populated = False
 
     @classmethod
     def _get_callback(cls, other, op):
@@ -416,25 +417,6 @@ class Datetime(_AbstractBaseTime):
     supported_with_pdarray = frozenset(())  # type: ignore
     supported_with_r_pdarray = frozenset(())  # type: ignore
 
-    def __init__(self, pda, unit=_BASE_UNIT):
-        super().__init__(pda, unit=unit)
-        self._ns = None
-        self._us = None
-        self._ms = None
-        self._s = None
-        self._min = None
-        self._hour = None
-        self._day = None
-        self._month = None
-        self._year = None
-        self._iso_year = None
-        self._day_of_year = None
-        self._day_of_week = None
-        self._week_of_year = None
-        self._is_leap_year = None
-        self._date = None
-        self._is_populated = False
-
     def _ensure_components(self):
         if self._is_populated:
             return
@@ -455,7 +437,7 @@ class Datetime(_AbstractBaseTime):
         self._week_of_year = create_pdarray(attributes_dict["weekOfYear"])
         self._day_of_year = create_pdarray(attributes_dict["dayOfYear"])
         self._is_leap_year = create_pdarray(attributes_dict["isLeapYear"])
-        self._date = self.floor('d')
+        self._date = self.floor("d")
         self._is_populated = True
 
     @property
@@ -628,20 +610,6 @@ class Timedelta(_AbstractBaseTime):
     supported_opeq = frozenset(("+=", "-=", "%="))
     supported_with_pdarray = frozenset(("*", "//"))
     supported_with_r_pdarray = frozenset(("*"))
-
-    def __init__(self, pda, unit=_BASE_UNIT):
-        super().__init__(pda, unit=unit)
-        self._ms = None
-        self._s = None
-        self._m = None
-        self._h = None
-        self._d = None
-        self._nanoseconds = None
-        self._microseconds = None
-        self._seconds = None
-        self._days = None
-        self._total_seconds = None
-        self._is_populated = False
 
     def _ensure_components(self):
         if self._is_populated:

--- a/src/TimeClassMsg.chpl
+++ b/src/TimeClassMsg.chpl
@@ -44,32 +44,20 @@ module TimeClassMsg {
         var attributesDict = simpleAttributesHelper(valuesEntry.a, st);
 
         const valDom = valuesEntry.aD;
-        // calculate year, month, day from total days
-        // Algorithm from https://stackoverflow.com/questions/7960318/math-to-convert-seconds-since-1970-into-date-and-vice-versa
-        var days: [valDom] int;
-        [(di,vi) in zip(days,valuesEntry.a)] di = floorDivisionHelper(vi, 10**9 * 60 * 60 * 24):int + 719468;
-        var era = days;
-        [i in valDom] if (era[i] < 0) {era[i] -= 146096;}
-        era /= 146097;
-        const doe = days - era * 146097;
-        const yoe = (doe - doe/1460 + doe/36524 - doe/146096) / 365;
-        var year = yoe + era * 400;
-        const doy = doe - (365*yoe + yoe/4 - yoe/100);
-        var month = (5*doy + 2)/153;
-        const day = doy - (153*month+2)/5 + 1;
-        [i in valDom] if (month[i] < 10) {month[i] += 3;} else {month[i] -= 9;}
-        [i in valDom] if (month[i] <= 2) {year[i] += 1;}
-
-        const is_leap_year: [valuesEntry.aD] bool = isLeapYear(year);
-        const dayOfYear: [valuesEntry.aD] int = MONTHOFFSET[is_leap_year * 13 + month - 1] + day;
-        var isoYear: [valuesEntry.aD] int;
-        var weekOfYear: [valuesEntry.aD] int;
-        var dayOfWeek: [valuesEntry.aD] int;
-        forall (y, m, d, iso_y, woy, dow) in zip(year, month, day, isoYear, weekOfYear, dayOfWeek) {
-            var time = new date(y, m, d);
-            (iso_y, woy, dow) = time.isoCalendar();
+        var year: [valDom] int;
+        var month: [valDom] int;
+        var day: [valDom] int;
+        var isoYear: [valDom] int;
+        var weekOfYear: [valDom] int;
+        var dayOfWeek: [valDom] int;
+        forall (v, y, m, d, iso_y, woy, dow) in zip(valuesEntry.a, year, month, day, isoYear, weekOfYear, dayOfWeek) {
+            // convert to seconds and create date
+            var t = date.fromTimestamp(floorDivisionHelper(v, 10**9):int);
+            (y, m, d, (iso_y, woy, dow)) = (t.year, t.month, t.day, t.isoCalendar());
             dow -= 1;
         }
+        const is_leap_year: [valDom] bool = isLeapYear(year);
+        const dayOfYear: [valDom] int = MONTHOFFSET[is_leap_year * 13 + month - 1] + day;
 
         var retname = st.nextName();
         st.addEntry(retname, new shared SymEntry(day));

--- a/src/TimeClassMsg.chpl
+++ b/src/TimeClassMsg.chpl
@@ -1,0 +1,137 @@
+module TimeClassMsg {
+    use ServerConfig;
+
+    use Reflection;
+    use ServerErrors;
+    use Logging;
+    use Message;
+    use MultiTypeSymbolTable;
+    use MultiTypeSymEntry;
+    use ServerErrorStrings;
+    use BinOp;
+
+    use ArkoudaDateTimeCompat;
+    use Map;
+
+    private config const logLevel = ServerConfig.logLevel;
+    const tLogger = new Logger(logLevel);
+
+    // The first 13 entries give the month days elapsed as of the first of month N
+    // (or the total number of days in the year for N=13) in non-leap years.
+    // The remaining 13 entries give the days elapsed in leap years.
+    const MONTHOFFSET = [
+        0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365,
+        0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366
+    ];
+
+    // To get UNITS do (values // (PROD_PREVIOUS_FACTORS)) % CURRENT_FACTOR
+    // for example seconds = (values // (1000*1000*1000)) % 60
+    const FACTORS = [
+        1000,  // nanosecond
+        1000,  // microsecond
+        1000,  // millisecond
+        60,  // second
+        60,  // minute
+        24,  // hour
+        7,  // day
+    ];
+
+    const UNITS = ["nanosecond", "microsecond", "millisecond", "second", "minute", "hour", "day"];
+
+    proc dateTimeAttributesMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+        var values: borrowed GenSymEntry = getGenericTypedArrayEntry(parseMessageArgs(payload, 1).getValueOf("values"), st);
+        var valuesEntry = toSymEntry(values, int);
+        var attributesDict = simpleAttributesHelper(valuesEntry.a, st);
+
+        const valDom = valuesEntry.aD;
+        // calculate year, month, day from total days
+        // Algorithm from https://stackoverflow.com/questions/7960318/math-to-convert-seconds-since-1970-into-date-and-vice-versa
+        var days: [valDom] int;
+        [(di,vi) in zip(days,valuesEntry.a)] di = floorDivisionHelper(vi, 10**9 * 60 * 60 * 24):int + 719468;
+        var era = days;
+        [i in valDom] if (era[i] < 0) {era[i] -= 146096;}
+        era /= 146097;
+        const doe = days - era * 146097;
+        const yoe = (doe - doe/1460 + doe/36524 - doe/146096) / 365;
+        var year = yoe + era * 400;
+        const doy = doe - (365*yoe + yoe/4 - yoe/100);
+        var month = (5*doy + 2)/153;
+        const day = doy - (153*month+2)/5 + 1;
+        [i in valDom] if (month[i] < 10) {month[i] += 3;} else {month[i] -= 9;}
+        [i in valDom] if (month[i] <= 2) {year[i] += 1;}
+
+        const is_leap_year: [valuesEntry.aD] bool = isLeapYear(year);
+        const dayOfYear: [valuesEntry.aD] int = MONTHOFFSET[is_leap_year * 13 + month - 1] + day;
+        var isoYear: [valuesEntry.aD] int;
+        var weekOfYear: [valuesEntry.aD] int;
+        var dayOfWeek: [valuesEntry.aD] int;
+        forall (y, m, d, iso_y, woy, dow) in zip(year, month, day, isoYear, weekOfYear, dayOfWeek) {
+            var time = new date(y, m, d);
+            (iso_y, woy, dow) = time.isoCalendar();
+            dow -= 1;
+        }
+
+        var retname = st.nextName();
+        st.addEntry(retname, new shared SymEntry(day));
+        attributesDict.addOrSet("day", "created %s".format(st.attrib(retname)));
+        retname = st.nextName();
+        st.addEntry(retname, new shared SymEntry(month));
+        attributesDict.add("month", "created %s".format(st.attrib(retname)));
+        retname = st.nextName();
+        st.addEntry(retname, new shared SymEntry(year));
+        attributesDict.add("year", "created %s".format(st.attrib(retname)));
+        retname = st.nextName();
+        st.addEntry(retname, new shared SymEntry(is_leap_year));
+        attributesDict.add("isLeapYear", "created %s".format(st.attrib(retname)));
+        retname = st.nextName();
+        st.addEntry(retname, new shared SymEntry(dayOfYear));
+        attributesDict.add("dayOfYear", "created %s".format(st.attrib(retname)));
+        retname = st.nextName();
+        st.addEntry(retname, new shared SymEntry(isoYear));
+        attributesDict.add("isoYear", "created %s".format(st.attrib(retname)));
+        retname = st.nextName();
+        st.addEntry(retname, new shared SymEntry(weekOfYear));
+        attributesDict.add("weekOfYear", "created %s".format(st.attrib(retname)));
+        retname = st.nextName();
+        st.addEntry(retname, new shared SymEntry(dayOfWeek));
+        attributesDict.add("dayOfWeek", "created %s".format(st.attrib(retname)));
+
+        var repMsg: string = "%jt".format(attributesDict);
+
+        tLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+        return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+
+    proc timeDeltaAttributesMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+        var values: borrowed GenSymEntry = getGenericTypedArrayEntry(parseMessageArgs(payload, 1).getValueOf("values"), st);
+        var repMsg: string = "%jt".format(simpleAttributesHelper(toSymEntry(values, int).a, st));
+
+        tLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+        return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+
+    proc simpleAttributesHelper(values: [?aD] ?t, st: borrowed SymTab): map throws {
+        var attributesDict = new map(keyType=string, valType=string);
+        var denominator = 1;
+        for (u, f) in zip(UNITS, FACTORS) {
+            // handles all the attributes in UNITS
+            // UNIT = (values // PROD_PREVIOUS_FACTORS) % CURRENT_FACTOR
+            var retname = st.nextName();
+            var e = st.addEntry(retname, aD.size, int);
+            if u != "day" {
+                [(ei,vi) in zip(e.a,values)] ei = floorDivisionHelper(vi, denominator):int % f;
+            }
+            else {
+                // "day" is not modded, because it's the last unit
+                [(ei,vi) in zip(e.a,values)] ei = floorDivisionHelper(vi, denominator):int;
+            }
+            attributesDict.add(u, "created %s".format(st.attrib(retname)));
+            denominator *= f;  //denominator is product of previous factors
+        }
+        return attributesDict;
+    }
+
+    use CommandMap;
+    registerFunction("dateTimeAttributes",  dateTimeAttributesMsg, getModuleName());
+    registerFunction("timeDeltaAttributes",  timeDeltaAttributesMsg, getModuleName());
+}

--- a/src/compat/ge-127/ArkoudaDateTimeCompat.chpl
+++ b/src/compat/ge-127/ArkoudaDateTimeCompat.chpl
@@ -1,0 +1,4 @@
+module ArkoudaDateTimeCompat {
+    // Chapel v1.27 or newer
+    public use DateTime;
+}

--- a/src/compat/lt-127/ArkoudaDateTimeCompat.chpl
+++ b/src/compat/lt-127/ArkoudaDateTimeCompat.chpl
@@ -1,0 +1,7 @@
+module ArkoudaDateTimeCompat {
+    // Chapel v1.26
+    public use DateTime;
+    proc date.isoCalendar() {
+      return this.isocalendar();
+    }
+}

--- a/src/compat/lt-127/ArkoudaDateTimeCompat.chpl
+++ b/src/compat/lt-127/ArkoudaDateTimeCompat.chpl
@@ -4,4 +4,8 @@ module ArkoudaDateTimeCompat {
     proc date.isoCalendar() {
       return this.isocalendar();
     }
+
+    proc type date.fromTimestamp(timestamp) {
+      return date.fromtimestamp(timestamp);
+    }
 }


### PR DESCRIPTION
This PR (Closes #1376):
- Attributes/methods for `Datetime`
  - `date`
  - `nanosecond`
  - `microsecond`
  - `second`
  - `minute`
  - `hour`
  - `day`
  - `month`
  - `year`
  - `day_of_week`, `dayofweek`, `weekday`
  - `week`, `weekofyear`
  - `day_of_year`, `dayofyear`
  - `is_leap_year`
  - `isocalendar()`
- Attributes/methods for `Timedelta`
  - `components`
  - `total_seconds`
  - `nanoseconds`
  - `microseconds`
  - `seconds`
  - `days`
- Tests comparing these to their pandas equivalents

NOTE:
`date.isoCalendar()`/`date.fromTimestamp` doesn't exist before chapel 1.27 and `date.isocalendar()`/`date.fromtimestamp` is deprecated in 1.27. Added `ArkoudaDateTimeCompat` to handle this

<details>
  <summary>Example output</summary>

```python
# Timedelta
>>> pd_td = pd.Series(pd.to_timedelta(np.arange(10**12 + 1000, (10**12 + 1010)), unit='us')).dt
>>> ak_td = ak.Timedelta(ak.arange(10**12 + 1000, (10**12 + 1010)), unit='us')
>>> pd_td.components
   days  hours  minutes  seconds  milliseconds  microseconds  nanoseconds
0    11     13       46       40             1             0            0
1    11     13       46       40             1             1            0
2    11     13       46       40             1             2            0
3    11     13       46       40             1             3            0
4    11     13       46       40             1             4            0
5    11     13       46       40             1             5            0
6    11     13       46       40             1             6            0
7    11     13       46       40             1             7            0
8    11     13       46       40             1             8            0
9    11     13       46       40             1             9            0

>>> ak_td.components
   days  hours  minutes  seconds  milliseconds  microseconds  nanoseconds
0    11     13       46       40             1             0            0
1    11     13       46       40             1             1            0
2    11     13       46       40             1             2            0
3    11     13       46       40             1             3            0
4    11     13       46       40             1             4            0
5    11     13       46       40             1             5            0
6    11     13       46       40             1             6            0
7    11     13       46       40             1             7            0
8    11     13       46       40             1             8            0
9    11     13       46       40             1             9            0 (10 rows x 7 columns)

>>> pd_td.total_seconds()
0    1.000000e+06
1    1.000000e+06
2    1.000000e+06
3    1.000000e+06
4    1.000000e+06
5    1.000000e+06
6    1.000000e+06
7    1.000000e+06
8    1.000000e+06
9    1.000000e+06
dtype: float64

>>> ak_td.total_seconds()
array([1000000.001 1000000.0010010001 1000000.0010019999 1000000.001003 1000000.001004 1000000.001005 1000000.001006 1000000.001007 1000000.001008 1000000.001009])

# Datetime
>>> pd_dt = pd.Series(pd.date_range("2000-01-01 12:00:00", periods=100, freq="d")).dt
>>> ak_dt = ak.Datetime(ak.date_range("2000-01-01 12:00:00", periods=100, freq="d"))
>>> pd_dt.isocalendar()
    year  week  day
0   1999    52    6
1   1999    52    7
2   2000     1    1
3   2000     1    2
4   2000     1    3
..   ...   ...  ...
95  2000    14    3
96  2000    14    4
97  2000    14    5
98  2000    14    6
99  2000    14    7

[100 rows x 3 columns]

>>> ak_dt.isocalendar()
    year  week  day
0   1999    52    6
1   1999    52    7
2   2000     1    1
3   2000     1    2
4   2000     1    3
..   ...   ...  ...
95  2000    14    3
96  2000    14    4
97  2000    14    5
98  2000    14    6
99  2000    14    7 (100 rows x 3 columns)

>>> pd_dt.date
0     2000-01-01
1     2000-01-02
2     2000-01-03
3     2000-01-04
4     2000-01-05
         ...
95    2000-04-05
96    2000-04-06
97    2000-04-07
98    2000-04-08
99    2000-04-09
Length: 100, dtype: object

>>> ak_dt.date
Datetime(['2000-01-01 00:00:00',
          '2000-01-02 00:00:00',
          '2000-01-03 00:00:00',
          '2000-01-04 00:00:00',
          ...
          '2000-04-07 00:00:00',
          '2000-04-08 00:00:00',
          '2000-04-09 00:00:00'],
         dtype='datetime64[ns]')

>>> pd_dt.is_leap_year
0     True
1     True
2     True
3     True
4     True
      ...
95    True
96    True
97    True
98    True
99    True
Length: 100, dtype: bool

>>> ak_dt.is_leap_year
array([True True True ... True True True])

>>> pd_dt.hour
0     12
1     12
2     12
3     12
4     12
      ..
95    12
96    12
97    12
98    12
99    12
Length: 100, dtype: int64

>>>  ak_dt.hour
array([12 12 12 ... 12 12 12])

>>> pd_dt.day
0     1
1     2
2     3
3     4
4     5
     ..
95    5
96    6
97    7
98    8
99    9
Length: 100, dtype: int64

>>> ak_dt.day
array([1 2 3 ... 7 8 9])

>>> pd_dt.month
0     1
1     1
2     1
3     1
4     1
     ..
95    4
96    4
97    4
98    4
99    4
Length: 100, dtype: int64

>>> ak_dt.month
array([1 1 1 ... 4 4 4])

>>> pd_dt.year
0     2000
1     2000
2     2000
3     2000
4     2000
      ...
95    2000
96    2000
97    2000
98    2000
99    2000
Length: 100, dtype: int64

>>> ak_dt.year
array([2000 2000 2000 ... 2000 2000 2000])

>>> pd_dt.day_of_week
0     5
1     6
2     0
3     1
4     2
     ..
95    2
96    3
97    4
98    5
99    6
Length: 100, dtype: int64

>>> ak_dt.day_of_week
array([5 6 0 ... 4 5 6])

>>> pd_dt.day_of_year
0       1
1       2
2       3
3       4
4       5
     ...
95     96
96     97
97     98
98     99
99    100
Length: 100, dtype: int64

>>> ak_dt.day_of_year
array([1 2 3 ... 98 99 100])
```
</details>