### PR TITLE
Closes 1691 - Update `CastMsg.chpl` to use JSON Message Arguments

### DIFF
--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -107,8 +107,15 @@ def cast(
 
     dt = _as_dtype(dt)
     cmd = "cast"
-    args = "{} {} {} {}".format(name, objtype, dt.name, errors.name)
-    repMsg = generic_msg(cmd=cmd, args=args)
+    repMsg = generic_msg(
+        cmd=cmd,
+        args={
+            "name": name,
+            "objType": objtype,
+            "targetDtype": dt.name,
+            "opt": errors.name,
+        },
+    )
     if dt.name.startswith("str"):
         return Strings.from_parts(*(type_cast(str, repMsg).split("+")))
     else:

--- a/src/CastMsg.chpl
+++ b/src/CastMsg.chpl
@@ -15,9 +15,12 @@ module CastMsg {
   const castLogger = new Logger(logLevel);
 
   proc castMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
-    use ServerConfig; // for string.splitMsgToTuple
     param pn = Reflection.getRoutineName();
-    var (name, objtype, targetDtype, opt) = payload.splitMsgToTuple(4);
+    var msgArgs = parseMessageArgs(payload, 4);
+    var name = msgArgs.getValueOf("name");
+    var objtype = msgArgs.getValueOf("objType");
+    var targetDtype = msgArgs.getValueOf("targetDtype");
+    var opt = msgArgs.getValueOf("opt");
     castLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
           "name: %s obgtype: %t targetDtype: %t opt: %t".format(
                                                  name,objtype,targetDtype,opt));


### PR DESCRIPTION
Closes #1691 

Updates `cast` message processing to use JSON message arguments in place of string arguments.