### PR TITLE
Closes #1697, `BroadcastMsg.chpl` JSON Message Arguments

### DIFF
--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -1183,10 +1183,16 @@ class GroupBy:
         if values.size != self.segments.size:
             raise ValueError("Must have one value per segment")
         cmd = "broadcast"
-        args = "{} {} {} {} {}".format(
-            self.permutation.name, self.segments.name, values.name, permute, self.length
+        repMsg = generic_msg(
+            cmd=cmd,
+            args={
+                "permName": self.permutation.name,
+                "segName": self.segments.name,
+                "valName": values.name,
+                "permute": permute,
+                "size": self.length,
+            },
         )
-        repMsg = generic_msg(cmd=cmd, args=args)
         return create_pdarray(repMsg)
 
     @staticmethod
@@ -1692,6 +1698,14 @@ def broadcast(
     if size < 1:
         raise ValueError("result size must be greater than zero")
     cmd = "broadcast"
-    args = "{} {} {} {} {}".format(pname, segments.name, values.name, permute, size)
-    repMsg = generic_msg(cmd=cmd, args=args)
+    repMsg = generic_msg(
+        cmd=cmd,
+        args={
+            "permName": pname,
+            "segName": segments.name,
+            "valName": values.name,
+            "permute": permute,
+            "size": size,
+        },
+    )
     return create_pdarray(repMsg)

--- a/src/BroadcastMsg.chpl
+++ b/src/BroadcastMsg.chpl
@@ -36,7 +36,7 @@ module BroadcastMsg {
     const rname = st.nextName();
     // This operation has two modes: one uses a permutation to reorder the answer,
     // while the other does not
-    const usePerm: bool = msgArgs.getValueOf("permute").toLower() == 'true';
+    const usePerm: bool = msgArgs.get("permute").getBoolValue();
     if usePerm {
       // If using a permutation, the array must be int64 and same size as the size parameter
       const gp = getGenericTypedArrayEntry(msgArgs.getValueOf("permName"), st);

--- a/src/Message.chpl
+++ b/src/Message.chpl
@@ -142,7 +142,7 @@ module Message {
         */
         proc getBoolValue(): bool throws {
             try {
-                return this.val:bool;
+                return this.val.toLower():bool;
             }
             catch {
                 throw new owned ErrorWithContext("Parameter cannot be cast as bool. Attempting to cast %s as type bool failed".format(this.val),


### PR DESCRIPTION
Closes #1697 

Updates `broadcast` message parsing to use JSON message arguments.