### PR TITLE
Closes #1699 - `ConcatenateMsg.chpl` to JSON Message Arguments

### DIFF
--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -324,8 +324,13 @@ def concatenate(
             return arrays[0]
 
     repMsg = generic_msg(
-        cmd="concatenate", args="{} {} {} {}".format(len(arrays), objtype, mode, " ".join(names))
-    )
+        cmd="concatenate",
+        args={
+            "nstr": len(arrays),
+            "objType": objtype,
+            "mode": mode,
+            "names": names,
+        })
     if objtype == "pdarray":
         return callback(create_pdarray(cast(str, repMsg)))
     elif objtype == "str":

--- a/src/ConcatenateMsg.chpl
+++ b/src/ConcatenateMsg.chpl
@@ -32,10 +32,9 @@ module ConcatenateMsg
         var mode = msgArgs.getValueOf("mode");
         var n = msgArgs.get("nstr").getIntValue(); // number of arrays to sort
         var names = msgArgs.get("names").getList(n);
-        const low = names.domain.low;
         
         cmLogger.debug(getModuleName(),getRoutineName(), getLineNumber(), 
-              "number of arrays: %i low: %t names: %t".format(n,low,names));
+              "number of arrays: %i names: %t".format(n,names));
 
         // Check that fields contains the stated number of arrays
         if (n != names.size) { 

--- a/src/ConcatenateMsg.chpl
+++ b/src/ConcatenateMsg.chpl
@@ -27,14 +27,15 @@ module ConcatenateMsg
     proc concatenateMsg(cmd: string, payload: string, st: borrowed SymTab) : MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string;
-        var (nstr, objtype, mode, rest) = payload.splitMsgToTuple(4);
-        var n = try! nstr:int; // number of arrays to sort
-        var fields = rest.split();
-        const low = fields.domain.low;
-        var names = fields[low..];
+        var msgArgs = parseMessageArgs(payload, 4);
+        var objtype = msgArgs.getValueOf("objType");
+        var mode = msgArgs.getValueOf("mode");
+        var n = msgArgs.get("nstr").getIntValue(); // number of arrays to sort
+        var names = msgArgs.get("names").getList(n);
+        const low = names.domain.low;
         
         cmLogger.debug(getModuleName(),getRoutineName(), getLineNumber(), 
-              "number of arrays: %i fields: %t low: %t names: %t".format(n,fields,low,names));
+              "number of arrays: %i low: %t names: %t".format(n,low,names));
 
         // Check that fields contains the stated number of arrays
         if (n != names.size) { 


### PR DESCRIPTION
Closes #1699 
Part of #1616 

Updated `concatenate` to use the JSON message arguments instead of string arguments.