### PR TITLE
Closes #1703 - `DataFrameIndexingMsg.chpl` JSON Message Arguments

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -577,7 +577,11 @@ class DataFrame(UserDict):
             str,
             generic_msg(
                 cmd="dataframe_idx",
-                args="{} {} {}".format(len(msg_list), idx.name, json.dumps(msg_list)),
+                args={
+                    "size": len(msg_list),
+                    "idx_name": idx.name,
+                    "columns": msg_list,
+                },
             ),
         )
         msgList = json.loads(repMsg)


### PR DESCRIPTION
Closes #1703 
Part of #1616 

Updates `dataframe_idx` to use JSON message arguments instead of string arguments.