### PR TITLE
Closes #1705 - `EfuncMsg.chpl` JSON Message Arguments

### DIFF
--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -146,7 +146,13 @@ def abs(pda: pdarray) -> pdarray:
     >>> ak.abs(ak.linspace(-5,-1,5))
     array([5, 4, 3, 2, 1])
     """
-    repMsg = generic_msg(cmd="efunc", args="{} {}".format("abs", pda.name))
+    repMsg = generic_msg(
+        cmd="efunc",
+        args={
+            "func": "abs",
+            "array": pda,
+        },
+    )
     return create_pdarray(type_cast(str, repMsg))
 
 
@@ -187,7 +193,13 @@ def log(pda: pdarray) -> pdarray:
     >>> ak.log(A) / np.log(2)
     array([0, 3.3219280948873626, 6.6438561897747253])
     """
-    repMsg = generic_msg(cmd="efunc", args="{} {}".format("log", pda.name))
+    repMsg = generic_msg(
+        cmd="efunc",
+        args={
+            "func": "log",
+            "array": pda,
+        },
+    )
     return create_pdarray(type_cast(str, repMsg))
 
 
@@ -238,7 +250,13 @@ def exp(pda: pdarray) -> pdarray:
     array([11.84010843172504, 46.454368507659211, 5.5571769623557188,
            33.494295836924771, 13.478894913238722])
     """
-    repMsg = generic_msg(cmd="efunc", args="{} {}".format("exp", pda.name))
+    repMsg = generic_msg(
+        cmd="efunc",
+        args={
+            "func": "exp",
+            "array": pda,
+        },
+    )
     return create_pdarray(type_cast(str, repMsg))
 
 
@@ -277,7 +295,13 @@ def cumsum(pda: pdarray) -> pdarray:
     >>> ak.cumsum(ak.randint(0, 1, 5, dtype=ak.bool))
     array([0, 1, 1, 2, 3])
     """
-    repMsg = generic_msg(cmd="efunc", args="{} {}".format("cumsum", pda.name))
+    repMsg = generic_msg(
+        cmd="efunc",
+        args={
+            "func": "cumsum",
+            "array": pda,
+        },
+    )
     return create_pdarray(type_cast(str, repMsg))
 
 
@@ -313,7 +337,13 @@ def cumprod(pda: pdarray) -> pdarray:
     array([1.5728783400481925, 7.0472855509390593, 33.78523998586553,
            134.05309592737584, 450.21589865655358])
     """
-    repMsg = generic_msg(cmd="efunc", args="{} {}".format("cumprod", pda.name))
+    repMsg = generic_msg(
+        cmd="efunc",
+        args={
+            "func": "cumprod",
+            "array": pda,
+        },
+    )
     return create_pdarray(type_cast(str, repMsg))
 
 
@@ -337,7 +367,13 @@ def sin(pda: pdarray) -> pdarray:
     TypeError
         Raised if the parameter is not a pdarray
     """
-    repMsg = generic_msg(cmd="efunc", args="{} {}".format("sin", pda.name))
+    repMsg = generic_msg(
+        cmd="efunc",
+        args={
+            "func": "sin",
+            "array": pda,
+        },
+    )
     return create_pdarray(type_cast(str, repMsg))
 
 
@@ -361,8 +397,17 @@ def cos(pda: pdarray) -> pdarray:
     TypeError
         Raised if the parameter is not a pdarray
     """
-    repMsg = type_cast(str, generic_msg(cmd="efunc", args="{} {}".format("cos", pda.name)))
-    return create_pdarray(type_cast(str, repMsg))
+    repMsg = type_cast(
+        str,
+        generic_msg(
+            cmd="efunc",
+            args={
+                "func": "cos",
+                "array": pda,
+            },
+        ),
+    )
+    return create_pdarray(repMsg)
 
 
 @typechecked
@@ -406,16 +451,21 @@ def hash(pda: pdarray, full: bool = True) -> Union[Tuple[pdarray, pdarray], pdar
     fixed key for the hash, which makes it possible for an
     adversary with control over input to engineer collisions.
     """
+    repMsg = type_cast(
+        str,
+        generic_msg(
+            cmd="efunc",
+            args={
+                "func": "hash128" if full else "hash64",
+                "array": pda,
+            },
+        ),
+    )
     if full:
-        subcmd = "hash128"
+        a, b = repMsg.split("+")
+        return create_pdarray(a), create_pdarray(b)
     else:
-        subcmd = "hash64"
-    repMsg = type_cast(str, generic_msg(cmd="efunc", args="{} {}".format(subcmd, pda.name)))
-    if full:
-        a, b = type_cast(str, repMsg).split("+")
-        return create_pdarray(type_cast(str, a)), create_pdarray(type_cast(str, b))
-    else:
-        return create_pdarray(type_cast(str, repMsg))
+        return create_pdarray(repMsg)
 
 
 @typechecked
@@ -486,22 +536,36 @@ def where(
         raise TypeError("both A and B must be an int, np.int64, float, np.float64, or pdarray")
     if isinstance(A, pdarray) and isinstance(B, pdarray):
         repMsg = generic_msg(
-            cmd="efunc3vv", args="{} {} {} {}".format("where", condition.name, A.name, B.name)
+            cmd="efunc3vv",
+            args={
+                "func": "where",
+                "condition": condition,
+                "a": A,
+                "b": B,
+            },
         )
     # For scalars, try to convert it to the array's dtype
     elif isinstance(A, pdarray) and np.isscalar(B):
         repMsg = generic_msg(
             cmd="efunc3vs",
-            args="{} {} {} {} {}".format(
-                "where", condition.name, A.name, A.dtype.name, A.format_other(B)
-            ),
+            args={
+                "func": "where",
+                "condition": condition,
+                "a": A,
+                "dtype": A.dtype.name,
+                "scalar": A.format_other(B),
+            },
         )
     elif isinstance(B, pdarray) and np.isscalar(A):
         repMsg = generic_msg(
             cmd="efunc3sv",
-            args="{} {} {} {} {}".format(
-                "where", condition.name, B.dtype.name, B.format_other(A), B.name
-            ),
+            args={
+                "func": "where",
+                "condition": condition,
+                "dtype": B.dtype.name,
+                "scalar": B.format_other(A),
+                "b": B,
+            },
         )
     elif np.isscalar(A) and np.isscalar(B):
         # Scalars must share a common dtype (or be cast)
@@ -524,7 +588,14 @@ def where(
         else:
             raise TypeError(f"Cannot cast between scalars {str(A)} and {str(B)} to supported dtype")
         repMsg = generic_msg(
-            cmd="efunc3ss", args="{} {} {} {} {} {}".format("where", condition.name, dt, A, dt, B)
+            cmd="efunc3ss",
+            args={
+                "func": "where",
+                "condition": condition,
+                "dtype": dt,
+                "a": A,
+                "b": B,
+            },
         )
     return create_pdarray(type_cast(str, repMsg))
 
@@ -652,5 +723,11 @@ def isnan(pda: pdarray) -> pdarray:
     RuntimeError
         if the underlying pdarray is not float-based
     """
-    rep_msg = generic_msg(cmd="efunc", args=f"isnan {pda.name}")
+    rep_msg = generic_msg(
+        cmd="efunc",
+        args={
+            "func": "isnan",
+            "array": pda,
+        },
+    )
     return create_pdarray(type_cast(str, rep_msg))

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -2400,7 +2400,13 @@ def popcount(pda: pdarray) -> pdarray:
     """
     if pda.dtype not in [akint64, akuint64]:
         raise TypeError("BitOps only supported on int64 and uint64 arrays")
-    repMsg = generic_msg(cmd="efunc", args="{} {}".format("popcount", pda.name))
+    repMsg = generic_msg(
+        cmd="efunc",
+        args={
+            "func": "popcount",
+            "array": pda,
+        },
+    )
     return create_pdarray(repMsg)
 
 
@@ -2431,7 +2437,13 @@ def parity(pda: pdarray) -> pdarray:
     """
     if pda.dtype not in [akint64, akuint64]:
         raise TypeError("BitOps only supported on int64 and uint64 arrays")
-    repMsg = generic_msg(cmd="efunc", args="{} {}".format("parity", pda.name))
+    repMsg = generic_msg(
+        cmd="efunc",
+        args={
+            "func": "parity",
+            "array": pda,
+        },
+    )
     return create_pdarray(repMsg)
 
 
@@ -2462,7 +2474,13 @@ def clz(pda: pdarray) -> pdarray:
     """
     if pda.dtype not in [akint64, akuint64]:
         raise TypeError("BitOps only supported on int64 and uint64 arrays")
-    repMsg = generic_msg(cmd="efunc", args="{} {}".format("clz", pda.name))
+    repMsg = generic_msg(
+        cmd="efunc",
+        args={
+            "func": "clz",
+            "array": pda,
+        },
+    )
     return create_pdarray(repMsg)
 
 
@@ -2497,7 +2515,13 @@ def ctz(pda: pdarray) -> pdarray:
     """
     if pda.dtype not in [akint64, akuint64]:
         raise TypeError("BitOps only supported on int64 and uint64 arrays")
-    repMsg = generic_msg(cmd="efunc", args="{} {}".format("ctz", pda.name))
+    repMsg = generic_msg(
+        cmd="efunc",
+        args={
+            "func": "ctz",
+            "array": pda,
+        },
+    )
     return create_pdarray(repMsg)
 
 

--- a/src/Message.chpl
+++ b/src/Message.chpl
@@ -142,7 +142,7 @@ module Message {
         */
         proc getBoolValue(): bool throws {
             try {
-                return this.val:bool;
+                return this.val.toLower():bool;
             }
             catch {
                 throw new owned ErrorWithContext("Parameter cannot be cast as bool. Attempting to cast %s as type bool failed".format(this.val),


### PR DESCRIPTION
Closes #1705 
Part of #1616 

Updates `efunc` (and variations) to use JSON message arguments in place of strings.