### PR TITLE
Closes #1676: Fixes `Strings.to_ndarray` for empty `Strings`

### DIFF
--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1525,7 +1525,7 @@ class Strings:
         # Compute lengths, discounting null terminators
         lengths = np.diff(npoffsets) - 1
         # Numpy dtype is based on max string length
-        dt = f"<U{lengths.max()}"
+        dt = f"<U{lengths.max() if len(lengths) > 0 else 1}"
         res = np.empty(self.size, dtype=dt)
         # Form a string from each segment and store in numpy array
         for i, (o, l) in enumerate(zip(npoffsets, lengths)):


### PR DESCRIPTION
This PR (Fixes #1676):
- Fixes `to_ndarray` for empty `Strings`
- Reenables `findall` tests for regex

```python
# np
>>> np.array([],str)
array([], dtype='<U1')

# ak
>>> s = ak.array(['soon_to_be_empty']).findall('0')
>>> s
array([])

>>> type(s)
arkouda.strings.Strings

>>> s.to_ndarray()
array([], dtype='<U1')
```