### PR TITLE
Closes #1711 - `FlattenMsg.chpl` JSON Message Arguments

### DIFF
--- a/arkouda/matcher.py
+++ b/arkouda/matcher.py
@@ -113,10 +113,19 @@ class Matcher:
         if re.search(self.pattern, ""):
             raise ValueError("Cannot split or flatten with a pattern that matches the empty string")
         cmd = "segmentedSplit"
-        args = "{} {} {} {} {}".format(
-            self.objtype, self.parent_entry_name, maxsplit, return_segments, json.dumps([self.pattern])
+        repMsg = cast(
+            str,
+            generic_msg(
+                cmd=cmd,
+                args={
+                    "parent_name": self.parent_entry_name,
+                    "objtype": self.objtype,
+                    "max": maxsplit,
+                    "return_segs": return_segments,
+                    "pattern": [self.pattern],
+                },
+            ),
         )
-        repMsg = cast(str, generic_msg(cmd=cmd, args=args))
         if return_segments:
             arrays = repMsg.split("+", maxsplit=2)
             return Strings.from_return_msg("+".join(arrays[0:2])), create_pdarray(arrays[2])

--- a/arkouda/matcher.py
+++ b/arkouda/matcher.py
@@ -122,7 +122,7 @@ class Matcher:
                     "objtype": self.objtype,
                     "max": maxsplit,
                     "return_segs": return_segments,
-                    "pattern": [self.pattern],
+                    "pattern": self.pattern,
                 },
             ),
         )

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1121,10 +1121,19 @@ class Strings:
             return self.split(delimiter, return_segments=return_segments)
         else:
             cmd = "segmentedFlatten"
-            args = "{} {} {} {} {}".format(
-                self.entry.name, self.objtype, return_segments, regex, json.dumps([delimiter])
+            repMsg = cast(
+                str,
+                generic_msg(
+                    cmd=cmd,
+                    args={
+                        "values": self.entry,
+                        "objtype": self.objtype,
+                        "return_segs": return_segments,
+                        "regex": regex,
+                        "delim": [delimiter],
+                    },
+                ),
             )
-            repMsg = cast(str, generic_msg(cmd=cmd, args=args))
             if return_segments:
                 arrays = repMsg.split("+", maxsplit=2)
                 return Strings.from_return_msg("+".join(arrays[0:2])), create_pdarray(arrays[2])

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1130,7 +1130,7 @@ class Strings:
                         "objtype": self.objtype,
                         "return_segs": return_segments,
                         "regex": regex,
-                        "delim": [delimiter],
+                        "delim": delimiter,
                     },
                 ),
             )

--- a/src/FlattenMsg.chpl
+++ b/src/FlattenMsg.chpl
@@ -17,8 +17,7 @@ module FlattenMsg {
     const objtype = msgArgs.getValueOf("objtype");
     const returnSegs: bool = msgArgs.get("return_segs").getBoolValue();
     const regex: bool = msgArgs.get("regex").getBoolValue();
-    const arr = msgArgs.get("delim").getList(1);
-    const delim: string = arr[arr.domain.low];
+    const delim: string = msgArgs.getValueOf("delim");
     var repMsg: string;
     select objtype {
       when "str" {
@@ -59,8 +58,7 @@ module FlattenMsg {
     // check to make sure symbols defined
     st.checkTable(name);
 
-    const json = msgArgs.get("pattern").getList(1);
-    const pattern: string = json[json.domain.low];
+    const pattern: string = msgArgs.getValueOf("pattern");
 
     fmLogger.debug(getModuleName(), getRoutineName(), getLineNumber(),
                    "cmd: %s objtype: %t".format(cmd, objtype));


### PR DESCRIPTION
Closes #1711 
Part of #1616 

Updates `segmentedFlatten` and `segmentedSplit` messages to use JSON message arguments.