### PR TITLE
Closes #1713 - `HDF5Msg.chpl` & `ParquetMsg.chpl` JSON Message Arguments

### DIFF
--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -282,22 +282,19 @@ class Index:
         else:
             raise ValueError("Supported file formats are 'HDF5' and 'Parquet'")
 
-        """
-        If offsets are provided, add to the json_array as the offsets will be used to
-        retrieve the array elements from the hdf5 files.
-        """
-        try:
-            json_array = json.dumps([prefix_path])
-        except Exception as e:
-            raise ValueError(e)
-        strings_placeholder = False
-
         return typecast(
             str,
             generic_msg(
                 cmd=cmd,
-                args=f"{self.values.name} {dataset} {m} {json_array} "
-                f"{self.dtype} {strings_placeholder} {compressed}",
+                args={
+                    "values": self.values,
+                    "dset": dataset,
+                    "mode": m,
+                    "prefix": prefix_path,
+                    "dtype": self.dtype,
+                    "save_offsets": False, # this is only used by strings
+                    "compressed": compressed,
+                }
             ),
         )
 

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -1,4 +1,3 @@
-import json
 from typing import List, Optional, Union
 from typing import cast as typecast
 

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -292,9 +292,9 @@ class Index:
                     "mode": m,
                     "prefix": prefix_path,
                     "dtype": self.dtype,
-                    "save_offsets": False, # this is only used by strings
+                    "save_offsets": False,  # this is only used by strings
                     "compressed": compressed,
-                }
+                },
             ),
         )
 

--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -63,7 +63,9 @@ def ls(filename: str) -> List[str]:
         raise ValueError("filename cannot be an empty string")
 
     cmd = "lsany"
-    return json.loads(cast(str, generic_msg(cmd=cmd, args="{}".format(json.dumps([filename])))))
+    return json.loads(cast(str, generic_msg(cmd=cmd, args={
+        "filename": filename,
+    })))
 
 
 def read(
@@ -196,8 +198,15 @@ def read(
     else:
         rep_msg = generic_msg(
             cmd=cmd,
-            args=f"{strictTypes} {len(datasets)} {len(filenames)} {allow_errors} {calc_string_offsets} "
-            f"{json.dumps(datasets)} | {json.dumps(filenames)}",
+            args={
+                "strict_types": strictTypes,
+                "dset_size": len(datasets),
+                "filename_size": len(filenames),
+                "allow_errors": allow_errors,
+                "calc_string_offsets": calc_string_offsets,
+                "dsets": datasets,
+                "filenames": filenames,
+            },
         )
         rep = json.loads(rep_msg)  # See GenSymIO._buildReadAllHdfMsgJson for json structure
         items = rep["items"] if "items" in rep else []
@@ -273,7 +282,12 @@ def get_null_indices(filenames, datasets) -> Union[pdarray, Mapping[str, pdarray
         datasets = [datasets]
     rep_msg = generic_msg(
         cmd="getnullparquet",
-        args=f"{len(datasets)} {len(filenames)} {json.dumps(datasets)} | {json.dumps(filenames)}",
+        args={
+            "dset_size": len(datasets),
+            "filename_size": len(filenames),
+            "dsets": datasets,
+            "filenames": filenames
+        },
     )
     rep = json.loads(rep_msg)  # See GenSymIO._buildReadAllHdfMsgJson for json structure
     items = rep["items"] if "items" in rep else []

--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -63,9 +63,17 @@ def ls(filename: str) -> List[str]:
         raise ValueError("filename cannot be an empty string")
 
     cmd = "lsany"
-    return json.loads(cast(str, generic_msg(cmd=cmd, args={
-        "filename": filename,
-    })))
+    return json.loads(
+        cast(
+            str,
+            generic_msg(
+                cmd=cmd,
+                args={
+                    "filename": filename,
+                },
+            ),
+        )
+    )
 
 
 def read(
@@ -286,7 +294,7 @@ def get_null_indices(filenames, datasets) -> Union[pdarray, Mapping[str, pdarray
             "dset_size": len(datasets),
             "filename_size": len(filenames),
             "dsets": datasets,
-            "filenames": filenames
+            "filenames": filenames,
         },
     )
     rep = json.loads(rep_msg)  # See GenSymIO._buildReadAllHdfMsgJson for json structure
@@ -838,10 +846,7 @@ def read_hdf5_multi_dim(file_path: str, dset: str) -> arkouda.array_view.ArrayVi
         - file_path will need to support list[str] and str for glob
         - Currently, order is always assumed to be row major
     """
-    args = {
-        "filename": file_path,
-        "dset": dset
-    }
+    args = {"filename": file_path, "dset": dset}
     rep_msg = cast(
         str,
         generic_msg(
@@ -962,7 +967,7 @@ def write_hdf5_multi_dim(
         "filename": file_path,
         "dset": dset,
         "mode": mode_int,
-        "method": storage_int
+        "method": storage_int,
     }
 
     generic_msg(

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import builtins
-import json
 from typing import List, Sequence, cast
 
 import numpy as np  # type: ignore

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1316,29 +1316,19 @@ class pdarray:
         else:
             raise ValueError("Supported file formats are 'HDF5' and 'Parquet'")
 
-        """
-        If offsets are provided, add to the json_array as the offsets will be used to
-        retrieve the array elements from the hdf5 files.
-        """
-        try:
-            json_array = json.dumps([prefix_path])
-        except Exception as e:
-            raise ValueError(e)
-        strings_placeholder = False
-
         return cast(
             str,
             generic_msg(
                 cmd=cmd,
-                args="{} {} {} {} {} {} {}".format(
-                    self.name,
-                    dataset,
-                    m,
-                    json_array,
-                    self.dtype,
-                    strings_placeholder,
-                    compressed,
-                ),
+                args={
+                    "values":self,
+                    "dset": dataset,
+                    "mode": m,
+                    "prefix": prefix_path,
+                    "dtype": self.dtype,
+                    "save_offsets": False,  # only used by strings
+                    "compressed": compressed,
+                }
             ),
         )
 

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1321,14 +1321,14 @@ class pdarray:
             generic_msg(
                 cmd=cmd,
                 args={
-                    "values":self,
+                    "values": self,
                     "dset": dataset,
                     "mode": m,
                     "prefix": prefix_path,
                     "dtype": self.dtype,
                     "save_offsets": False,  # only used by strings
                     "compressed": compressed,
-                }
+                },
             ),
         )
 

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1724,11 +1724,6 @@ class Strings:
         else:
             raise ValueError("Allowed modes are 'truncate' and 'append'")
 
-        try:
-            json_array = json.dumps([prefix_path])
-        except Exception as e:
-            raise ValueError(e)
-
         if file_format.lower() == "hdf5":
             cmd = "tohdf"
         elif file_format.lower() == "parquet":

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1736,7 +1736,15 @@ class Strings:
         else:
             raise ValueError("Supported file formats are 'HDF5' and 'Parquet'")
 
-        args = f"{self.entry.name} {dataset} {m} {json_array} {self.dtype} {save_offsets} {compressed}"
+        args = {
+            "values": self.entry,
+            "dset": dataset,
+            "mode": m,
+            "prefix": prefix_path,
+            "dtype": self.dtype,
+            "save_offsets": save_offsets,
+            "compressed": compressed,
+        }
         return cast(str, generic_msg(cmd, args))
 
     def save_parquet(

--- a/src/FileIO.chpl
+++ b/src/FileIO.chpl
@@ -308,18 +308,12 @@ module FileIO {
 
     proc lsAnyMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
       var (jsonfile) = payload.splitMsgToTuple(1);
+      var msgArgs = parseMessageArgs(payload, 1);
       
       // Retrieve filename from payload
-      var filename: string;
-      try {
-        filename = jsonToPdArray(jsonfile, 1)[0];
-        if filename.isEmpty() {
-          throw new IllegalArgumentError("filename was empty");  // will be caught by catch block
-        }
-      } catch {
-        var errorMsg = "Could not decode json filenames via tempfile (%i files: %s)".format(
-                                                                                            1, jsonfile);
-        return new MsgTuple(errorMsg, MsgType.ERROR);                                    
+      var filename: string = msgArgs.getValueOf("filename");
+      if filename.isEmpty() {
+        throw new IllegalArgumentError("filename was empty");  // will be caught by catch block
       }
 
       // If the filename represents a glob pattern, retrieve the locale 0 filename
@@ -359,15 +353,12 @@ module FileIO {
       var (strictFlag, ndsetsStr, nfilesStr, allowErrorsFlag, calcStringOffsetsFlag, arraysStr) = payload.splitMsgToTuple(6);
       var (jsondsets, jsonfiles) = arraysStr.splitMsgToTuple(" | ",2);
 
-      if (!checkCast(nfilesStr, int)) {
-        var errMsg = "Number of files:`%s` could not be cast to an integer".format(nfilesStr);
-        return new MsgTuple(errMsg, MsgType.ERROR);
-      }
-      var nfiles = nfilesStr:int; // Error checked above
+      var msgArgs = parseMessageArgs(payload, 7);
+      var nfiles = msgArgs.get("filename_size").getIntValue();
       var filelist: [0..#nfiles] string;
       
       try {
-        filelist = jsonToPdArray(jsonfiles, nfiles);
+        filelist = msgArgs.get("filenames").getList(nfiles);
       } catch {
         // limit length of file names to 2000 chars
         var n: int = 1000;

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -55,7 +55,9 @@ module HDF5Msg {
         // Retrieve filename from payload
         var filename: string = msgArgs.getValueOf("filename");
         if filename.isEmpty() {
-            throw new IllegalArgumentError("filename was empty");  // will be caught by catch block
+            var errorMsg = "Filename was Empty";
+            h5Logger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
         }
 
         // If the filename represents a glob pattern, retrieve the locale 0 filename
@@ -1777,7 +1779,7 @@ module HDF5Msg {
         var msgArgs = parseMessageArgs(payload, 7);
         var strictTypes: bool = msgArgs.get("strict_types").getBoolValue();
 
-        var allowErrors: bool = msgArgs.get("allow_errors").getBoolValue(); // default if false
+        var allowErrors: bool = msgArgs.get("allow_errors").getBoolValue(); // default is false
         if allowErrors {
             h5Logger.warn(getModuleName(), getRoutineName(), getLineNumber(), "Allowing file read errors");
         }

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -779,7 +779,9 @@ module ParquetMsg {
     // Retrieve filename from payload
     var filename: string = msgArgs.getValueOf("filename");
     if filename.isEmpty() {
-      throw new IllegalArgumentError("filename was empty");  // will be caught by catch block
+      var errorMsg = "Filename was Empty";
+      pqLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+      return new MsgTuple(errorMsg, MsgType.ERROR);
     }
 
     // If the filename represents a glob pattern, retrieve the locale 0 filename

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -530,41 +530,25 @@ module ParquetMsg {
 
   proc readAllParquetMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
     var repMsg: string;
-    // May need a more robust delimiter then " | "
-    var (strictFlag, ndsetsStr, nfilesStr, allowErrorsFlag, hdfArgPlaceholder, arraysStr) = payload.splitMsgToTuple(6);
-    var strictTypes: bool = true;
-    if (strictFlag.toLower().strip() == "false") {
-      strictTypes = false;
-    }
+    var msgArgs = parseMessageArgs(payload, 7);
+    var strictTypes: bool = msgArgs.get("strict_types").getBoolValue();
 
-    var allowErrors: bool = "true" == allowErrorsFlag.toLower(); // default is false
+    var allowErrors: bool = msgArgs.get("allow_errors").getBoolValue(); // default is false
     if allowErrors {
         pqLogger.warn(getModuleName(), getRoutineName(), getLineNumber(), "Allowing file read errors");
     }
-
-    // Test arg casting so we can send error message instead of failing
-    if (!checkCast(ndsetsStr, int)) {
-        var errMsg = "Number of datasets:`%s` could not be cast to an integer".format(ndsetsStr);
-        pqLogger.error(getModuleName(), getRoutineName(), getLineNumber(), errMsg);
-        return new MsgTuple(errMsg, MsgType.ERROR);
-    }
-    if (!checkCast(nfilesStr, int)) {
-      var errMsg = "Number of files:`%s` could not be cast to an integer".format(nfilesStr);
-      pqLogger.error(getModuleName(), getRoutineName(), getLineNumber(), errMsg);
-      return new MsgTuple(errMsg, MsgType.ERROR);
-    }
-
-    var (jsondsets, jsonfiles) = arraysStr.splitMsgToTuple(" | ",2);
-    var ndsets = ndsetsStr:int; // Error checked above
-    var nfiles = nfilesStr:int; // Error checked above
+    
+    var ndsets = msgArgs.get("dset_size").getIntValue();
+    var nfiles = msgArgs.get("filename_size").getIntValue();
     var dsetlist: [0..#ndsets] string;
     var filelist: [0..#nfiles] string;
 
     try {
-        dsetlist = jsonToPdArray(jsondsets, ndsets);
+        dsetlist = msgArgs.get("dsets").getList(ndsets);
     } catch {
         // limit length of dataset names to 2000 chars
         var n: int = 1000;
+        var jsondsets = msgArgs.getValueOf("dsets");
         var dsets: string = if jsondsets.size > 2*n then jsondsets[0..#n]+'...'+jsondsets[jsondsets.size-n..#n] else jsondsets;
         var errorMsg = "Could not decode json dataset names via tempfile (%i files: %s)".format(
                                             ndsets, dsets);
@@ -573,10 +557,11 @@ module ParquetMsg {
     }
 
     try {
-        filelist = jsonToPdArray(jsonfiles, nfiles);
+        filelist = msgArgs.get("filenames").getList(nfiles);
     } catch {
         // limit length of file names to 2000 chars
         var n: int = 1000;
+        var jsonfiles = msgArgs.getValueOf("filenames");
         var files: string = if jsonfiles.size > 2*n then jsonfiles[0..#n]+'...'+jsonfiles[jsonfiles.size-n..#n] else jsonfiles;
         var errorMsg = "Could not decode json filenames via tempfile (%i files: %s)".format(nfiles, files);
         pqLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
@@ -713,10 +698,12 @@ module ParquetMsg {
   }
   
   proc toparquetMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
-    var (arrayName, dsetname, modeStr, jsonfile, dataType, hdfPlaceholder, isCompressed)= payload.splitMsgToTuple(7);
-    var mode = try! modeStr: int;
-    var filename: string;
-    var entry = st.lookup(arrayName);
+    var msgArgs = parseMessageArgs(payload, 7);
+    var mode = msgArgs.get("mode").getIntValue();
+    var filename: string = msgArgs.getValueOf("prefix");
+    var entry = st.lookup(msgArgs.getValueOf("values"));
+    var dsetname = msgArgs.getValueOf("dset");
+    var dataType = msgArgs.getValueOf("dtype");
     
     var entryDtype = DType.UNDEF;
     if (entry.isAssignableTo(SymbolEntryType.TypedArraySymEntry)) {
@@ -728,16 +715,7 @@ module ParquetMsg {
       return new MsgTuple(errorMsg, MsgType.ERROR);
     }
 
-    var compressed = try! isCompressed.toLower():bool;
-
-    try {
-      filename = jsonToPdArray(jsonfile, 1)[0];
-    } catch {
-      var errorMsg = "Could not decode json filenames via tempfile " +
-        "(%i files: %s)".format(1, jsonfile);
-      pqLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-      return new MsgTuple(errorMsg, MsgType.ERROR);
-    }
+    var compressed = msgArgs.get("compressed").getBoolValue();
 
     var warnFlag: bool;
 
@@ -796,19 +774,12 @@ module ParquetMsg {
   proc lspqMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
     // reqMsg: "lshdf [<json_filename>]"
     var repMsg: string;
-    var (jsonfile) = payload.splitMsgToTuple(1);
+    var msgArgs = parseMessageArgs(payload, 1);
 
     // Retrieve filename from payload
-    var filename: string;
-    try {
-      filename = jsonToPdArray(jsonfile, 1)[0];
-      if filename.isEmpty() {
-        throw new IllegalArgumentError("filename was empty");  // will be caught by catch block
-      }
-    } catch {
-      var errorMsg = "Could not decode json filenames via tempfile (%i files: %s)".format(
-                                                                                          1, jsonfile);
-      return new MsgTuple(errorMsg, MsgType.ERROR);                                    
+    var filename: string = msgArgs.getValueOf("filename");
+    if filename.isEmpty() {
+      throw new IllegalArgumentError("filename was empty");  // will be caught by catch block
     }
 
     // If the filename represents a glob pattern, retrieve the locale 0 filename
@@ -858,41 +829,28 @@ module ParquetMsg {
 
   proc nullIndicesMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
     var repMsg: string;
-    // May need a more robust delimiter then " | "
-    var (ndsetsStr, nfilesStr, arraysStr) = payload.splitMsgToTuple(3);
+    var msgArgs = parseMessageArgs(payload, 4);
 
-    // Test arg casting so we can send error message instead of failing
-    if (!checkCast(ndsetsStr, int)) {
-      var errMsg = "Number of datasets:`%s` could not be cast to an integer".format(ndsetsStr);
-      pqLogger.error(getModuleName(), getRoutineName(), getLineNumber(), errMsg);
-      return new MsgTuple(errMsg, MsgType.ERROR);
-    }
-    if (!checkCast(nfilesStr, int)) {
-      var errMsg = "Number of files:`%s` could not be cast to an integer".format(nfilesStr);
-      pqLogger.error(getModuleName(), getRoutineName(), getLineNumber(), errMsg);
-      return new MsgTuple(errMsg, MsgType.ERROR);
-    }
-
-    var (jsondsets, jsonfiles) = arraysStr.splitMsgToTuple(" | ",2);
-    var ndsets = ndsetsStr:int; // Error checked above
-    var nfiles = nfilesStr:int; // Error checked above
+    var ndsets = msgArgs.get("dset_size").getIntValue();
+    var nfiles = msgArgs.get("filename_size").getIntValue();
     var dsetlist: [0..#ndsets] string;
     var filelist: [0..#nfiles] string;
 
     try {
-      dsetlist = jsonToPdArray(jsondsets, ndsets);
+      dsetlist = msgArgs.get("dsets").getList(ndsets);
     } catch {
       var errorMsg = "Could not decode json dataset names via tempfile (%i files: %s)".format(
-                                                                                              1, jsondsets);
+                                                                                              1, msgArgs.getValueOf("dsets"));
       pqLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
       return new MsgTuple(errorMsg, MsgType.ERROR);
     }
 
     try {
-      filelist = jsonToPdArray(jsonfiles, nfiles);
+      filelist = msgArgs.get("filenames").getList(nfiles);
     } catch {
       // limit length of file names to 2000 chars
       var n: int = 1000;
+      var jsonfiles = msgArgs.getValueOf("filenames");
       var files: string = if jsonfiles.size > 2*n then jsonfiles[0..#n]+'...'+jsonfiles[jsonfiles.size-n..#n] else jsonfiles;
       var errorMsg = "Could not decode json filenames via tempfile (%i files: %s)".format(nfiles, files);
       pqLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);


### PR DESCRIPTION
Closes #1713 
Part of #1616 

Updates messages in `HDF5Msg.chpl` and `ParquetMsg.chpl` to use JSON message arguments in place of string arguments. Corresponding client code is also updated.