### PR TITLE
Closes #1725 - `sqrt` and `power` functions on pdarrays

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -2593,13 +2593,13 @@ def rotr(x, rot) -> pdarray:
 
 
 @typechecked
-def power(pda: pdarray, pwr: Union[int, pdarray]) -> pdarray:
+def power(pda: pdarray, pwr: Union[int, float, pdarray]) -> pdarray:
     return pda**pwr
 
 
 @typechecked
 def sqrt(pda: pdarray) -> pdarray:
-    return pda**0.5
+    return power(pda, 0.5)
 
 
 @typechecked

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import builtins
-from typing import List, Sequence, cast
+from typing import List, Sequence, Union, cast
 
 import numpy as np  # type: ignore
 from typeguard import typechecked
@@ -53,6 +53,8 @@ __all__ = [
     "rotr",
     "cov",
     "corr",
+    "sqrt",
+    "power",
     "attach_pdarray",
     "unregister_pdarray_by_name",
     "RegistrationError",
@@ -2588,6 +2590,16 @@ def rotr(x, rot) -> pdarray:
         return rot._r_binop(x, ">>>")
     else:
         raise TypeError("Rotations only supported on integers")
+
+
+@typechecked
+def power(pda: pdarray, pwr: Union[int, pdarray]) -> pdarray:
+    return pda**pwr
+
+
+@typechecked
+def sqrt(pda: pdarray) -> pdarray:
+    return pda**0.5
 
 
 @typechecked

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -454,7 +454,7 @@ class OperatorsTest(ArkoudaTest):
             equality_helper(a_vect // ak_edge_cases, n_vect // np_edge_cases)
 
     def test_pda_sqrt(self):
-        n = np.array([4, 16, -1, 0])
+        n = np.array([4, 16, -1, 0, np.inf])
         a = ak.array(n)
 
         s = ak.sqrt(a)
@@ -479,6 +479,15 @@ class OperatorsTest(ArkoudaTest):
         p = ak.power(a, ak.array([2, 3, 4]))
         ex = np.power(n, [2, 3, 4])
         self.assertListEqual(p.to_list(), ex.tolist())
+
+        n = np.array([-1.0, -3.0])
+        a = ak.array(n)
+
+        p = ak.power(a, 0.5)
+        ex = np.power(n, 0.5)
+        nan = ak.isnan(p)
+        npnan = np.isnan(ex)
+        self.assertListEqual(nan.to_list(), npnan.tolist())
 
     def testAllOperators(self):
         run_tests(verbose)

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -453,6 +453,33 @@ class OperatorsTest(ArkoudaTest):
             equality_helper(ak_edge_cases // a_vect, np_edge_cases // n_vect)
             equality_helper(a_vect // ak_edge_cases, n_vect // np_edge_cases)
 
+    def test_pda_sqrt(self):
+        n = np.array([4, 16, -1, 0])
+        a = ak.array(n)
+
+        s = ak.sqrt(a)
+        ex = np.sqrt(n)
+
+        # id nans
+        nan = ak.isnan(s)
+        npnan = np.isnan(ex)
+        self.assertListEqual(nan.to_list(), npnan.tolist())
+
+        # check results are equal remove nans
+        self.assertListEqual(s[~nan].to_list(), ex[~npnan].tolist())
+
+    def test_pda_power(self):
+        n = np.array([10, 5, 2])
+        a = ak.array(n)
+
+        p = ak.power(a, 2)
+        ex = np.power(n, 2)
+        self.assertListEqual(p.to_list(), ex.tolist())
+
+        p = ak.power(a, ak.array([2, 3, 4]))
+        ex = np.power(n, [2, 3, 4])
+        self.assertListEqual(p.to_list(), ex.tolist())
+
     def testAllOperators(self):
         run_tests(verbose)
 


### PR DESCRIPTION
Closes #1725 

Added `ak.power` and `ak.sqrt` functions. These functions are just aliases for `**` and `**0.5`, respectively. 
Adds testing to ensure arkouda functionality is in alignment with `Numpy`.