### PR TITLE
Enable UI and API client mode

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -65,3 +65,4 @@ Also see the python tests [README](tests/README.md) for more information on Pyth
   - ARKOUDA_KEY_FILE : Client env var for keyfile when using ssh tunnel
   - ARKOUDA_PASSWORD : Client env var for password when using ssh tunnel
   - ARKOUDA_LOG_LEVEL : Client env var to control client side Logging Level
+  - ARKOUDA_CLIENT_MODE: Client env var controlling client mode (UI or API), where UI mode displays the Arkouda client splash message. 

--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -74,7 +74,7 @@ class ClientMode(Enum):
 
 
 # Get ClientMode, defaulting to UI
-mode = ClientMode(os.getenv('ARKOUDA_CLIENT_MODE', 'UI'))
+mode = ClientMode(os.getenv('ARKOUDA_CLIENT_MODE', 'UI').upper())
 
 # Print splash message if in UI mode
 if mode == ClientMode.UI:

--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -1,6 +1,7 @@
 import json
 import os
 import warnings
+from enum import Enum
 from typing import Dict, Mapping, Optional, Tuple, Union, cast
 
 import pyfiglet  # type: ignore
@@ -49,9 +50,36 @@ regexMaxCaptures: int = -1
 logger = getArkoudaLogger(name="Arkouda Client")
 clientLogger = getArkoudaLogger(name="Arkouda User Logger", logFormat="%(message)s")
 
-# Print splash message
-print("{}".format(pyfiglet.figlet_format("Arkouda")))
-print(f"Client Version: {__version__}")  # type: ignore
+
+class ClientMode(Enum):
+    """
+    The ClientMode enum provides controlled vocabulary indicating whether the
+    Arkouda client is in UI mode or API mode. If in API mode, it is assumed the
+    Arkouda client is being used via an API call instead of a Python shell or notebook.
+    """
+    UI = 'UI'
+    API = 'API'
+
+    def __str__(self) -> str:
+        """
+        Overridden method returns value.
+        """
+        return self.value
+
+    def __repr__(self) -> str:
+        """
+        Overridden method returns value.
+        """
+        return self.value
+
+
+# Get ClientMode, defaulting to UI
+mode = ClientMode(os.getenv('ARKOUDA_CLIENT_MODE', 'UI'))
+
+# Print splash message if in UI mode
+if mode == ClientMode.UI:
+    print("{}".format(pyfiglet.figlet_format("Arkouda")))
+    print(f"Client Version: {__version__}")  # type: ignore
 
 
 # reset settings to default values


### PR DESCRIPTION
This PR addresses issue #1729 via the following:

1. ClientMode enum--UI or API mode
2. logic to retrieve ClientMode value from env variable, defaulting to UI
3. logic to display pyfiglet banner if ClientMode is UI (again, the default), suppress if in API mode, which I have a use case for as described in #1729 