### PR TITLE
#1728 Fix nunique

### DIFF
--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -1606,32 +1606,9 @@ class GroupBy:
 
     def most_common(self, values):
         """
-        Find the most common value for each segment of a GroupBy object. This method only supports
-        array-like GroupBy key types.
-
-        Parameters
-        ----------
-        values : array-like
-            Values in which to find most common based on the GroupBy's segment indexes.
-            values.size must equal GroupBy.keys[0].size
-
-        Returns
-        -------
-        most_common_values : array-like
-            The most common value for each segment of the GroupBy
+        (Deprecated) See `GroupBy.mode()`.
         """
-        # Give each key an integer index
-        keyidx = self.broadcast(arange(self.unique_keys[0].size), permute=True)
-        # Annex values and group by (key, val)
-        bykeyval = GroupBy([keyidx, values])
-        # Count number of records for each (key, val)
-        (ki, uval), count = bykeyval.count()
-        # Group out value
-        bykey = GroupBy(ki, assume_sorted=True)
-        # Find the index of the most frequent value for each key
-        _, topidx = bykey.argmax(count)
-        # Gather the most frequent values
-        return uval[topidx]
+        return self.mode(values)
 
 
 def broadcast(

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -472,11 +472,11 @@ class GroupByTest(ArkoudaTest):
             self.assertListEqual(a, r)
 
     def test_nunique_ordering_bug(self):
-        keys = ak.array(['1' for _ in range(8)] + ['2' for _ in range(3)])
+        keys = ak.array(["1" for _ in range(8)] + ["2" for _ in range(3)])
         vals = ak.array([str(i) for i in range(8)] + [str(i) for i in range(3)])
         g = ak.GroupBy(keys)
         unique_keys, nuniq = g.nunique(vals)
-        expected_unique_keys = ['2', '1']
+        expected_unique_keys = ["2", "1"]
         expected_nuniq = [3, 8]
         self.assertListEqual(expected_unique_keys, unique_keys.to_list())
         self.assertListEqual(expected_nuniq, nuniq.to_list())

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -471,6 +471,16 @@ class GroupByTest(ArkoudaTest):
         for a, r in zip(ans, res2[1].to_list()):
             self.assertListEqual(a, r)
 
+    def test_nunique_ordering_bug(self):
+        keys = ak.array(['1' for _ in range(8)] + ['2' for _ in range(3)])
+        vals = ak.array([str(i) for i in range(8)] + [str(i) for i in range(3)])
+        g = ak.GroupBy(keys)
+        unique_keys, nuniq = g.nunique(vals)
+        expected_unique_keys = ['2', '1']
+        expected_nuniq = [3, 8]
+        self.assertListEqual(expected_unique_keys, unique_keys.to_list())
+        self.assertListEqual(expected_nuniq, nuniq.to_list())
+
 
 def to_tuple_dict(labels, values):
     # transforms labels from list of arrays into a list of tuples by index and builds a dictionary


### PR DESCRIPTION
Closes #1728 

- Fixes logic of `GroupBy.nunique()`, which relied on the old sorting behavior of multi-level GroupBy that has since changed.
- Adds a unit test for the ordering bug fix
- Deprecates `GroupBy.most_common()` and makes it an alias to `GroupBy.mode()`