### PR TITLE
Closes #1681 - `SegArray.__init__` to Server

### DIFF
--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -144,11 +144,14 @@ class SegArray:
         self._segments = None  # cache - use .segments to access/set
         self._valsize = None  # cache - use .valsize to access/set
         """
-        Note - if lengths is provided, it will need to be sent to the server in the future (or deprecated).
-        Since no computation is currently done on the server, we will not be sending lengths right now
+        Note - if lengths is provided, it will need to be sent to the
+        server in the future (or deprecated).
+        Since no computation is currently done on the server,
+        we will not be sending lengths right now
         """
         self._lengths = lengths  # cache - use .lengths to access/set. If passed, do not recompute
-        # the following is to maintain support for lengths being passed in (since not currently passed to server)
+        # the following is to maintain support for lengths being passed in
+        # (since not currently passed to server)
         if self._lengths is not None:
             self._non_empty = lengths > 0
             self._non_empty_count = self._non_empty.sum()

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -7,7 +7,6 @@ module SegmentedArray {
     use Reflection;
     use Logging;
     use ServerErrors;
-    use List;
 
     private config const logLevel = ServerConfig.logLevel;
     const saLogger = new Logger(logLevel);

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -47,10 +47,6 @@ module SegmentedArray {
         var size: int;
         var nBytes: int;
 
-        var lengths;
-        var non_empty;
-        var non_empty_count: int;
-
         proc init(entryName:string, entry:borrowed SegArraySymEntry, type eType) {
             name = entryName;
             composite = entry;
@@ -59,15 +55,6 @@ module SegmentedArray {
             
             size = segments.size;
             nBytes = values.size;
-
-            // Format the same as in Segmented string getLengths, but leave here so that we don't recompute each time we need
-            var lenHelp = new list(segments.a[1..]);
-            lenHelp.append(values.size);
-
-            lengths = lenHelp.toArray();
-
-            non_empty = lengths > 0;
-            non_empty_count = + reduce non_empty:int;
 
             // Note - groupby remaining client side because groupby does not have server side object
         }

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -173,6 +173,96 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
+  proc getSALengthsMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    var repMsg: string = "";
+    var msgArgs = parseMessageArgs(payload, 1);
+    var name = msgArgs.getValueOf("name"): string;
+    var entry = st.tab.getBorrowed(name);
+    var compEntry: CompositeSymEntry = toCompositeSymEntry(entry);
+    var lenName = st.nextName();
+    select compEntry.dtype {
+      when (DType.Int64) {
+        var segArr = getSegArray(name, st, int);
+        st.addEntry(lenName, new shared SymEntry(segArr.getLengths()));
+        repMsg = "created " + st.attrib(lenName);
+      }
+      when (DType.UInt64) {
+        var segArr = getSegArray(name, st, uint);
+        st.addEntry(lenName, new shared SymEntry(segArr.getLengths()));
+        repMsg = "created " + st.attrib(lenName);
+      }
+      when (DType.Float64) {
+        var segArr = getSegArray(name, st, real);
+        st.addEntry(lenName, new shared SymEntry(segArr.getLengths()));
+        repMsg = "created " + st.attrib(lenName);
+      }
+      when (DType.Bool) {
+        var segArr = getSegArray(name, st, bool);
+        st.addEntry(lenName, new shared SymEntry(segArr.getLengths()));
+        repMsg = "created " + st.attrib(lenName);
+      }
+      when (DType.UInt8){
+        var segArr = getSegArray(name, st, uint(8));
+        st.addEntry(lenName, new shared SymEntry(segArr.getLengths()));
+        repMsg = "created " + st.attrib(lenName);
+      }
+      otherwise {
+        throw new owned ErrorWithContext("Values array has unsupported dtype %s".format(compEntry.dtype:string),
+                                      getLineNumber(),
+                                      getRoutineName(),
+                                      getModuleName(),
+                                      "TypeError");
+      }
+    }
+    smLogger.debug(getModuleName(), getRoutineName(), getLineNumber(), repMsg);
+    return new MsgTuple(repMsg, MsgType.NORMAL);
+  }
+
+  proc getSANonEmptyMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    var repMsg: string = "";
+    var msgArgs = parseMessageArgs(payload, 1);
+    var name = msgArgs.getValueOf("name"): string;
+    var entry = st.tab.getBorrowed(name);
+    var compEntry: CompositeSymEntry = toCompositeSymEntry(entry);
+    var neName = st.nextName();
+    select compEntry.dtype {
+      when (DType.Int64) {
+        var segArr = getSegArray(name, st, int);
+        st.addEntry(neName, new shared SymEntry(segArr.getNonEmpty()));
+        repMsg = "created " + st.attrib(neName) + "+" + segArr.getNonEmptyCount():string;
+      }
+      when (DType.UInt64) {
+        var segArr = getSegArray(name, st, uint);
+        st.addEntry(neName, new shared SymEntry(segArr.getNonEmpty()));
+        repMsg = "created " + st.attrib(neName) + "+" + segArr.getNonEmptyCount():string;
+      }
+      when (DType.Float64) {
+        var segArr = getSegArray(name, st, real);
+        st.addEntry(neName, new shared SymEntry(segArr.getNonEmpty()));
+        repMsg = "created " + st.attrib(neName) + "+" + segArr.getNonEmptyCount():string;
+      }
+      when (DType.Bool) {
+        var segArr = getSegArray(name, st, bool);
+        st.addEntry(neName, new shared SymEntry(segArr.getNonEmpty()));
+        repMsg = "created " + st.attrib(neName) + "+" + segArr.getNonEmptyCount():string;
+      }
+      when (DType.UInt8){
+        var segArr = getSegArray(name, st, uint(8));
+        st.addEntry(neName, new shared SymEntry(segArr.getNonEmpty()));
+        repMsg = "created " + st.attrib(neName) + "+" + segArr.getNonEmptyCount():string;
+      }
+      otherwise {
+        throw new owned ErrorWithContext("Values array has unsupported dtype %s".format(compEntry.dtype:string),
+                                      getLineNumber(),
+                                      getRoutineName(),
+                                      getModuleName(),
+                                      "TypeError");
+      }
+    }
+    smLogger.debug(getModuleName(), getRoutineName(), getLineNumber(), repMsg);
+    return new MsgTuple(repMsg, MsgType.NORMAL);
+  }
+
 
   /**
    * Procedure for assembling disjoint Strings-object / SegString parts
@@ -1212,6 +1302,8 @@ module SegmentedMsg {
   registerFunction("segArr-assemble", assembleSegArrayMsg, getModuleName());
   registerFunction("segArr-getSegments", getSASegmentsMsg, getModuleName());
   registerFunction("segArr-getValues", getSAValuesMsg, getModuleName());
+  registerFunction("segArr-getLengths", getSALengthsMsg, getModuleName());
+  registerFunction("segArr-getNonEmpty", getSANonEmptyMsg, getModuleName());
   registerFunction("segStr-assemble", assembleStringsMsg, getModuleName());
   registerFunction("stringsToJSON", stringsToJSONMsg, getModuleName());
   registerBinaryFunction("segStr-tondarray", segStrTondarrayMsg, getModuleName());

--- a/tests/segarray_test.py
+++ b/tests/segarray_test.py
@@ -14,7 +14,7 @@ class SegArrayTest(ArkoudaTest):
         segarr = ak.SegArray(segments, akflat)
 
         self.assertIsInstance(segarr, ak.SegArray)
-        self.assertListEqual(segarr._get_lengths().to_list(), [6, 2, 4])
+        self.assertListEqual(segarr.lengths.to_list(), [6, 2, 4])
         self.assertEqual(segarr.__str__(), f"SegArray([\n{a}\n{b}\n{c}\n])".replace(",", ""))
         self.assertEqual(segarr.__getitem__(1).__str__(), str(b).replace(",", ""))
         self.assertEqual(


### PR DESCRIPTION
Closes #1681 

This PR moves the remaining `init` functionality for SegArray to the server. This includes creating messages to access these values from the server. `non_empty`, `non_empty_count` and `lengths` have been moved to the server. `grouping` was not moved because `GroupBy` objects are not server side. In the future, we may want to move GroupBy to the server and update this since most of the functionality is there with the `UniqueMsg`. In the future, we may need to move the `getLengths`, `getNonEmpty` and `getNonEmptyCount` function logic to compute properties in the init in chapel in order to prevent recomputing the values unnecessarily. 

Currently, if a `lengths` is passed to the init in python, it is used and computes `_non_empty` and `_non_empty_count` from it. A few questions here for moving forward (since this is an iteration and should not impact anything negatively at this point).
@pierce314159, @joshmarshall1, @mhmerrill, @reuster986 - if you have any thoughts, they would be greatly appreciated.
1) Should we pass the `name` of the `lengths` pdarray to the server and add the `SymEntry` as part of the `SegArraySymEntry`? 
2) Should we deprecate the `lengths` parameter in python and just recompute in the `init` on the server? (This would be my suggestion). The recompute should be minimal and this way we do not have a `SymEntry` always hanging around taking up space.