### PR TITLE
Closes #1751 - Include Chapel Version in `get_config`

### DIFF
--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -131,6 +131,7 @@ module ServerConfig
 
         class Config {
             const arkoudaVersion: string;
+            const chplVersion: string;
             const ZMQVersion: string;
             const HDF5Version: string;
             const serverHostname: string;
@@ -153,6 +154,7 @@ module ServerConfig
         
         const cfg = new owned Config(
             arkoudaVersion = (ServerConfig.arkoudaVersion:string),
+            chplVersion = chplVersion,
             ZMQVersion = try! "%i.%i.%i".format(Zmajor, Zminor, Zmicro),
             HDF5Version = try! "%i.%i.%i".format(H5major, H5minor, H5micro),
             serverHostname = serverHostname,


### PR DESCRIPTION
Closes #1751 

Adds the Chapel version under the key `chplVersion` to the result of `ak.get_config()`.

**Example**
```
{'arkoudaVersion': 'v2022.08.30+2.g19a77002.dirty', 'chplVersion': ' 1.27.0', 'ZMQVersion': '4.3.4', 'HDF5Version': '1.12.1', 'serverHostname': 'Ethans-MacBook-Pro.local', 'ServerPort': 5555, 'numLocales': 1, 'numPUs': 10, 'maxTaskPar': 10, 'physicalMemory': 17179869184, 'distributionType': 'domain(1,int(64),false)', 'LocaleConfigs': [{'id': 0, 'name': 'Ethans-MacBook-Pro.local', 'numPUs': 10, 'maxTaskPar': 10, 'physicalMemory': 17179869184}], 'authenticate': False, 'logLevel': 'DEBUG', 'regexMaxCaptures': 20, 'byteorder': 'little', 'ARROW_VERSION': '7.0.0'}
```