### PR TITLE
Closes #1752: Update `README` about

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,4 +1,4 @@
-name: docs-gh-pages
+name: docs
 
 # Only publish docs when master changes
 on:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <img src="pictures/arkouda_wide_marker1.png"
 />
-<h1 align="center">Arkouda (αρκούδα)</h1>
-<h2 align="center">Interactive Data Analytics at Supercomputing Scale -- </br>a Python API powered by Chapel :bear:</h2>
+<h1 align="center">Arkouda (αρκούδα) :bear:</h1>
+<h2 align="center">Interactive Data Analytics at Supercomputing Scale</br>a Python API powered by Chapel</h2>
 
 <p align="center">
 <a href="https://github.com/Bears-R-Us/arkouda/actions/workflows/CI.yml"><img alt="Actions Status" src="https://github.com/Bears-R-Us/arkouda/workflows/CI/badge.svg"></a>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
-![Arkouda logo](pictures/arkouda_wide_marker1.png)
+<p align="center">
+  <img src="pictures/arkouda_wide_marker1.png"
+/>
+<h1 align="center">Arkouda (αρκούδα)</h1>
+<h2 align="center">Interactive Data Analytics at Supercomputing Scale -- </br>a Python API powered by Chapel :bear:</h2>
 
-# Arkouda (αρκούδα): NumPy-like arrays at massive scale backed by Chapel.
-## _NOTE_: Arkouda is under the MIT license.
+<p align="center">
+<a href="https://github.com/Bears-R-Us/arkouda/actions/workflows/CI.yml"><img alt="Actions Status" src="https://github.com/Bears-R-Us/arkouda/workflows/CI/badge.svg"></a>
+<a href="https://bears-r-us.github.io/arkouda/"><img alt="Documentation Status" src="https://github.com/Bears-R-Us/arkouda/workflows/docs/badge.svg"></a>
+<a href="https://github.com/Bears-R-Us/arkouda/blob/master/LICENSE"><img alt="License: MIT" src="https://black.readthedocs.io/en/stable/_static/license.svg"></a>
+<a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
+</p>
 
 ## Online Documentation
 [Arkouda docs at Github Pages](https://bears-r-us.github.io/arkouda/)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 <p align="center">
   <img src="pictures/arkouda_wide_marker1.png"
 />
-<h1 align="center">Arkouda (αρκούδα) :bear:</h1>
-<h2 align="center">Interactive Data Analytics at Supercomputing Scale</br>a Python API powered by Chapel</h2>
+<h2 align="center">Arkouda (αρκούδα) :bear:</br>Interactive Data Analytics at Supercomputing Scale</br>a Python API powered by Chapel</h2>
 
 <p align="center">
 <a href="https://github.com/Bears-R-Us/arkouda/actions/workflows/CI.yml"><img alt="Actions Status" src="https://github.com/Bears-R-Us/arkouda/workflows/CI/badge.svg"></a>

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 <p align="center">
-  <img src="pictures/arkouda_wide_marker1.png"
-/>
+  <img src="pictures/arkouda_wide_marker1.png"/>
+
 <h2 align="center">Arkouda (αρκούδα) :bear:</br>Interactive Data Analytics at Supercomputing Scale</br>a Python API powered by Chapel</h2>
 
-<p align="center">
 <a href="https://github.com/Bears-R-Us/arkouda/actions/workflows/CI.yml"><img alt="Actions Status" src="https://github.com/Bears-R-Us/arkouda/workflows/CI/badge.svg"></a>
 <a href="https://bears-r-us.github.io/arkouda/"><img alt="Documentation Status" src="https://github.com/Bears-R-Us/arkouda/workflows/docs/badge.svg"></a>
 <a href="https://github.com/Bears-R-Us/arkouda/blob/master/LICENSE"><img alt="License: MIT" src="https://black.readthedocs.io/en/stable/_static/license.svg"></a>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 <p align="center">
   <img src="pictures/arkouda_wide_marker1.png"/>
+</p>
 
 <h2 align="center">Arkouda (αρκούδα) :bear:</br>Interactive Data Analytics at Supercomputing Scale</br>a Python API powered by Chapel</h2>
 
+<p align="center">
 <a href="https://github.com/Bears-R-Us/arkouda/actions/workflows/CI.yml"><img alt="Actions Status" src="https://github.com/Bears-R-Us/arkouda/workflows/CI/badge.svg"></a>
 <a href="https://bears-r-us.github.io/arkouda/"><img alt="Documentation Status" src="https://github.com/Bears-R-Us/arkouda/workflows/docs/badge.svg"></a>
 <a href="https://github.com/Bears-R-Us/arkouda/blob/master/LICENSE"><img alt="License: MIT" src="https://black.readthedocs.io/en/stable/_static/license.svg"></a>


### PR DESCRIPTION
This PR (Closes #1752):
- Updates the `README` to match the github about
- Centers the logo
- Adds badges for CI, docs, license, and code style
- Changes workflow name from `gh-pages-docs` to `docs` since we only support github pages

Note in these pictures the documentation badge isn't showing up, this is because the name change in this PR would need to merged first. It will look like the `CI` badge but say `docs`

Before this PR:
![image](https://user-images.githubusercontent.com/48131946/188721609-96b8b9f4-79c1-4ca6-a8f1-9b1247cd32f8.png)

After this PR:
![image](https://user-images.githubusercontent.com/48131946/188726241-680f8c75-f45c-48dd-8a5f-943ee0f1b4ac.png)

<details>
  <summary>Other options if people prefer:</summary>

![image](https://user-images.githubusercontent.com/48131946/188724896-df844224-ce1d-47b4-952e-8391c9b8cfeb.png)

![image](https://user-images.githubusercontent.com/48131946/188721707-bb18d65b-8e41-4724-8157-4018efcc38a0.png)
</details>