### PR TITLE
Closes #1761 - `RegistrationMsg.chpl` JSON Message Arguments

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -2018,7 +2018,7 @@ class DataFrame(UserDict):
         for name in set(matches):
             colName = name.split("_")[2]
             if f"_{Strings.objtype}_" in name or f"_{pdarray.objtype}_" in name:
-                cols_resp = cast(str, generic_msg(cmd="attach", args=name))
+                cols_resp = cast(str, generic_msg(cmd="attach", args={"name": name}))
                 dtype = cols_resp.split()[2]
                 if dtype == Strings.objtype:
                     columns[colName] = Strings.from_return_msg(cols_resp)
@@ -2029,7 +2029,9 @@ class DataFrame(UserDict):
             elif f"_{SegArray.objtype}_" in name:
                 columns[colName] = SegArray.attach(name)
 
-        index_resp = cast(str, generic_msg(cmd="attach", args=f"df_index_{user_defined_name}_key"))
+        index_resp = cast(
+            str, generic_msg(cmd="attach", args={"name": f"df_index_{user_defined_name}_key"})
+        )
         dtype = index_resp.split()[2]
         if dtype == Strings.objtype:
             ind = Strings.from_return_msg(index_resp)

--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -1488,7 +1488,7 @@ class GroupBy:
         for name in matches:
             # Parse the name for the dtype and use the proper create method to create the element
             if f"_{Strings.objtype}." in name or f"_{pdarray.objtype}." in name:
-                keys_resp = cast(str, generic_msg(cmd="attach", args=name))
+                keys_resp = cast(str, generic_msg(cmd="attach", args={"name": name}))
                 dtype = keys_resp.split()[2]
                 if ".unique_keys" in name:
                     if dtype == Strings.objtype:
@@ -1534,8 +1534,8 @@ class GroupBy:
                 f" is not registered"
             )
 
-        perm_resp = generic_msg(cmd="attach", args=f"{user_defined_name}.permutation")
-        segments_resp = generic_msg(cmd="attach", args=f"{user_defined_name}.segments")
+        perm_resp = generic_msg(cmd="attach", args={"name": f"{user_defined_name}.permutation"})
+        segments_resp = generic_msg(cmd="attach", args={"name": f"{user_defined_name}.segments"})
 
         parts = {
             "orig_keys": keys if len(keys) > 1 else keys[0],

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1560,7 +1560,7 @@ class pdarray:
         >>> b.unregister()
         """
         try:
-            rep_msg = generic_msg(cmd="register", args=f"{self.name} {user_defined_name}")
+            rep_msg = generic_msg(cmd="register", args={"array": self, "user_name": user_defined_name})
             if isinstance(rep_msg, bytes):
                 rep_msg = str(rep_msg, "UTF-8")
             if rep_msg != "success":
@@ -2671,7 +2671,7 @@ def attach_pdarray(user_defined_name: str) -> pdarray:
     >>> # ...other work...
     >>> b.unregister()
     """
-    repMsg = generic_msg(cmd="attach", args="{}".format(user_defined_name))
+    repMsg = generic_msg(cmd="attach", args={"name": user_defined_name})
     return create_pdarray(repMsg)
 
 
@@ -2713,7 +2713,7 @@ def unregister_pdarray_by_name(user_defined_name: str) -> None:
     >>> # ...other work...
     >>> ak.unregister_pdarray_by_name(b)
     """
-    generic_msg(cmd="unregister", args=user_defined_name)
+    generic_msg(cmd="unregister", args={"name": user_defined_name})
 
 
 # TODO In the future move this to a specific errors file

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -2023,7 +2023,7 @@ class Strings:
         Registered names/Strings objects in the server are immune to deletion
         until they are unregistered.
         """
-        rep_msg: str = cast(str, generic_msg(cmd="attach", args="{}".format(user_defined_name)))
+        rep_msg: str = cast(str, generic_msg(cmd="attach", args={"name": user_defined_name}))
         s = Strings.from_return_msg(rep_msg)
         s.name = user_defined_name
         return s

--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -281,7 +281,7 @@ def attach(name: str, dtype: str = "infer"):
     Attaches to a known element name. If a type is passed, the server will use that type
     to pull the corresponding parts, otherwise the server will try to infer the type
     """
-    repMsg = cast(str, generic_msg(cmd="genericAttach", args=f"{dtype}+{name}"))
+    repMsg = cast(str, generic_msg(cmd="genericAttach", args={"dtype": dtype, "name": name}))
 
     if repMsg.split("+")[0] == "categorical":
         return Categorical.from_return_msg(repMsg)
@@ -313,6 +313,6 @@ def unregister_by_name(name: str, dtype: str = "infer"):
         to identify the type based on registered symbols
         Supported types are: pdarray, strings, categorical, segarray, and series
     """
-    repMsg = cast(str, generic_msg(cmd="genericUnregisterByName", args=f"{dtype}+{name}"))
+    repMsg = cast(str, generic_msg(cmd="genericUnregisterByName", args={"dtype": dtype, "name": name}))
 
     return repMsg

--- a/src/Message.chpl
+++ b/src/Message.chpl
@@ -4,6 +4,7 @@ module Message {
     use Reflection;
     use ServerErrors;
     use NumPyDType;
+    use Map;
 
     enum MsgType {NORMAL,WARNING,ERROR}
     enum MsgFormat {STRING,BINARY}
@@ -59,6 +60,19 @@ module Message {
             this.val = val;
             this.objType = objType;
             this.dtype = dtype;
+        }
+
+        proc asMap() throws {
+            var m = new map(string, string);
+            m.add("key", this.key);
+            m.add("val", this.val);
+            m.add("objType", this.objType:string);
+            m.add("dtype", this.dtype);
+            return m;
+        }
+
+        proc getJSON() throws {
+            return "%jt".format(this);
         }
 
         /*

--- a/src/RegistrationMsg.chpl
+++ b/src/RegistrationMsg.chpl
@@ -353,7 +353,6 @@ module RegistrationMsg
 
         select (dtype.toLower()) {
             when ("simple") {
-                // var json_base = ;
                 var json: [0..#1] string = [msgArgs.get("name").getJSON()];
                 // pdarray and strings can use the attachMsg method
                 return attachMsg(cmd, "%jt".format(json), st);
@@ -507,8 +506,8 @@ module RegistrationMsg
 
                 // Convert the string back into an array for looping
                 var nameList = nameStr.split("+");
-                forall n in nameList with (+ reduce status) {
-                    var base_json = msgArgs.get("name").asMap();
+                var base_json = msgArgs.get("name").asMap();
+                forall n in nameList with (in base_json, + reduce status) {
                     base_json.set("val", n);
                     var json: [0..#1] string = ["%jt".format(base_json)];
                     var resp = unregisterMsg(cmd, "%jt".format(json), st);
@@ -531,7 +530,7 @@ module RegistrationMsg
 
         var repMsg = status;
         regLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-        return new MsgTuple("TEST", MsgType.NORMAL);
+        return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 
     use CommandMap;


### PR DESCRIPTION
Closes #1761 

Updates `RegistrationMsg.chpl` to use JSON message arguments.

Adds `proc` to `ParameterObj` to convert object to JSON formatted string.
Adds `proc` to `ParameterObj` to convert object to `Map` object.

The `proc`s added to `ParameterObj` are being added to prevent constantly rebuilding the object as a `Map` or JSON string manually. This is part of what is needed for #1731.