### PR TITLE
Closes #1760 - `Datetime` support in JSON message args

### DIFF
--- a/arkouda/message.py
+++ b/arkouda/message.py
@@ -19,6 +19,7 @@ class ObjectType(Enum):
     LIST = "LIST"
     DICT = "DICT"
     VALUE = "VALUE"
+    DATETIME = "DATETIME"
 
     def __str__(self) -> str:
         """
@@ -101,6 +102,27 @@ class ParameterObject:
 
     @staticmethod
     @typechecked
+    def _build_datetime_param(key: str, val) -> ParameterObject:
+        """
+        Create a ParameterObject from a Datetime value
+
+        Parameters
+        ----------
+        key : str
+            key from the dictionary object
+        val
+            Datetime object ot load from the symbol table
+
+        Returns
+        -------
+        ParameterObject
+        """
+        # empty string if name of String obj is none
+        name = val.name if val.name else ""
+        return ParameterObject(key, ObjectType.DATETIME, str(val.values.dtype), name)
+
+    @staticmethod
+    @typechecked
     def _build_list_param(key: str, val: list) -> ParameterObject:
         """
         Create a ParameterObject from a list
@@ -174,10 +196,12 @@ class ParameterObject:
         """
         from arkouda.pdarrayclass import pdarray
         from arkouda.strings import Strings
+        from arkouda.timeclass import Datetime
 
         return {
             pdarray.__name__: ParameterObject._build_pdarray_param,
             Strings.__name__: ParameterObject._build_strings_param,
+            Datetime.__name__: ParameterObject._build_datetime_param,
             list.__name__: ParameterObject._build_list_param,
             dict.__name__: ParameterObject._build_dict_param,
         }

--- a/src/Message.chpl
+++ b/src/Message.chpl
@@ -7,7 +7,7 @@ module Message {
 
     enum MsgType {NORMAL,WARNING,ERROR}
     enum MsgFormat {STRING,BINARY}
-    enum ObjectType {PDARRAY, SEGSTRING, LIST, DICT, VALUE}
+    enum ObjectType {PDARRAY, SEGSTRING, LIST, DICT, VALUE, DATETIME}
 
     /*
      * Encapsulates the message string and message type.

--- a/tests/message_test.py
+++ b/tests/message_test.py
@@ -6,6 +6,7 @@ from base_test import ArkoudaTest
 from arkouda.client import _json_args_to_str
 from arkouda.message import MessageFormat, MessageType, ReplyMessage, RequestMessage
 from arkouda.pdarraycreation import arange, array
+from arkouda.timeclass import date_range
 
 
 class MessageTest(unittest.TestCase):
@@ -137,6 +138,16 @@ class JSONArgs(ArkoudaTest):
             ],
             json.loads(args),
         )
+
+        # test Datetime arg
+        dt = date_range(start="2021-01-01 12:00:00", periods=100, freq="s")
+        size, args = _json_args_to_str({"datetime": dt})
+        self.assertEqual(size, 1)
+        msgArgs = json.loads(json.loads(args)[0])
+        self.assertEqual(msgArgs["key"], "datetime")
+        self.assertEqual(msgArgs["objType"], "DATETIME")
+        self.assertEqual(msgArgs["dtype"], "int64")
+        self.assertRegex(msgArgs["val"], "^id_\\w{7}_\\d$")
 
         # test list of pdarray
         pd1 = arange(3)


### PR DESCRIPTION
Closes #1760 

Updates the `_json_args_to_str` to add support for when the provided dictionary contains an Arkouda `Datetime` object as  a value. 

`DATETIME` added to the `objType` enum.
Function added to create `ParameterObj` for `Datetime`.
Testing added to ensure proper functionality.