### PR TITLE
Closes #1742 - Symbol Table Structure Update

### DIFF
--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -302,23 +302,13 @@ module MultiTypeSymEntry
      * The base parent class for SymbolEntries that are composites
      * of other entry types.
      */
-    class CompositeSymEntry:AbstractSymEntry {
-        var dtype: DType; // answer to numpy dtype
-        var itemsize: int; // answer to numpy itemsize = num bytes per elt
-        var size: int = 0; // answer to numpy size == num elts
-        var ndim: int = 1; // answer to numpy ndim == 1-axis for now
-        var shape: 1*int = (0,); // answer to numpy shape == 1*int tuple
-
+    class CompositeSymEntry:GenSymEntry {
+        // This class is functionally equivalent to GenSymEntry, but used to denote
+        // a Symbol Table Entry made up of multiple components.
         proc init(type etype, len: int = 0) {
-            super.init();
-            this.entryType = SymbolEntryType.CompositeSymEntry;
-            assignableTypes.add(this.entryType);
-            
-            this.dtype = whichDtype(etype);
-            this.itemsize = dtypeSize(this.dtype);
-            this.size = len;
-            this.shape = (len,);
+            super.init(etype, len);
         }
+
     }
 
     /**

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -383,14 +383,10 @@ module MultiTypeSymbolTable
             checkTable(name, "attrib");
 
             var entry = tab.getBorrowed(name);
-            if entry.isAssignableTo(SymbolEntryType.SegStringSymEntry) {
-                var g:SegStringSymEntry = toSegStringSymEntry(entry);
-                return "%s %s %t %t %t %t".format(name, dtype2str(g.dtype), g.size, g.ndim, g.shape, g.itemsize);
-            } else if entry.isAssignableTo(SymbolEntryType.TypedArraySymEntry) || 
+            if entry.isAssignableTo(SymbolEntryType.TypedArraySymEntry) || 
                     entry.isAssignableTo(SymbolEntryType.CompositeSymEntry) {
                 var g:GenSymEntry = toGenSymEntry(entry);
                 return "%s %s %t %t %t %t".format(name, dtype2str(g.dtype), g.size, g.ndim, g.shape, g.itemsize);
-
             }
             
             throw new Error("attrib - Unsupported Entry Type %s".format(entry.entryType));

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -383,18 +383,14 @@ module MultiTypeSymbolTable
             checkTable(name, "attrib");
 
             var entry = tab.getBorrowed(name);
-            if entry.isAssignableTo(SymbolEntryType.TypedArraySymEntry) {
-                var g:GenSymEntry = toGenSymEntry(entry);
-                return "%s %s %t %t %t %t".format(name, dtype2str(g.dtype), g.size, g.ndim, g.shape, g.itemsize);
-            } else if entry.isAssignableTo(SymbolEntryType.SegStringSymEntry) {
+            if entry.isAssignableTo(SymbolEntryType.SegStringSymEntry) {
                 var g:SegStringSymEntry = toSegStringSymEntry(entry);
                 return "%s %s %t %t %t %t".format(name, dtype2str(g.dtype), g.size, g.ndim, g.shape, g.itemsize);
-            }
-            else if entry.isAssignableTo(SymbolEntryType.SegArraySymEntry) {
-                var g:CompositeSymEntry = toCompositeSymEntry(entry);
-                // Note - as SegArray functionality is moved, we may need to adjust this
-                // to provide more data. Though this will depend upon how the calculation is configured
+            } else if entry.isAssignableTo(SymbolEntryType.TypedArraySymEntry) || 
+                    entry.isAssignableTo(SymbolEntryType.CompositeSymEntry) {
+                var g:GenSymEntry = toGenSymEntry(entry);
                 return "%s %s %t %t %t %t".format(name, dtype2str(g.dtype), g.size, g.ndim, g.shape, g.itemsize);
+
             }
             
             throw new Error("attrib - Unsupported Entry Type %s".format(entry.entryType));


### PR DESCRIPTION
Closes #1742

Updated `CompositeSymEntry` to inherit `GenSymEntry` instead of `AbstractSymEntry` since the properties of `CompositeSymEntry` and `GenSymEntry` were identical. By doing this, the `attrib` function now only requires a single `if`.

Overall, this update was made to slim down the code and remove duplicate code for easier long term maintenance.