### PR TITLE
Closes #1749 - Update `CONTRIBUTING.md` Bug Report

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ When reporting a bug, please be sure to include the following information:
   - Please provide code that will reproduce the problem if possible.
 Providing simplified programs demonstrating the problem will be appreciated.
 - Configuration Information
-  - What's the output of `ak.get_config()['arkoudaVersion']`?
+  - What's the output of `ak.get_config()`? This includes information like the `ArkoudaVersion` and the version of Chapel the server was built with.
 
 <a id="feature-requests"></a>
 ### Feature Requests <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>


### PR DESCRIPTION
Closes #1749 

Updates the `Bug Report` section of `CONTRIBUTING.md` to include all output from `ak.get_config()` now that we include the Chapel version that the server was built with. I went with this instead of including the server splash screen because some users may not be able to access the server directly and there does not appear to be any information there that is not in `ak.get_config()`.