### PR TITLE
Closes #1774 - Message Function Definition Update

### DIFF
--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -57,8 +57,9 @@ class ClientMode(Enum):
     Arkouda client is in UI mode or API mode. If in API mode, it is assumed the
     Arkouda client is being used via an API call instead of a Python shell or notebook.
     """
-    UI = 'UI'
-    API = 'API'
+
+    UI = "UI"
+    API = "API"
 
     def __str__(self) -> str:
         """
@@ -74,7 +75,7 @@ class ClientMode(Enum):
 
 
 # Get ClientMode, defaulting to UI
-mode = ClientMode(os.getenv('ARKOUDA_CLIENT_MODE', 'UI').upper())
+mode = ClientMode(os.getenv("ARKOUDA_CLIENT_MODE", "UI").upper())
 
 # Print splash message if in UI mode
 if mode == ClientMode.UI:
@@ -661,7 +662,9 @@ def generic_msg(
     try:
         if send_binary:
             assert payload is not None
-            return _send_binary_message(cmd=cmd, payload=payload, recv_binary=recv_binary, args=args, size=size)
+            return _send_binary_message(
+                cmd=cmd, payload=payload, recv_binary=recv_binary, args=args, size=size
+            )
         else:
             assert payload is None
             return _send_string_message(cmd=cmd, args=args, size=size, recv_binary=recv_binary)

--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -431,7 +431,7 @@ def _send_string_message(
 
 
 def _send_binary_message(
-    cmd: str, payload: memoryview, recv_binary: bool = False, args: str = None
+    cmd: str, payload: memoryview, recv_binary: bool = False, args: str = None, size: int = -1
 ) -> Union[str, memoryview]:
     """
     Generates a RequestMessage encapsulating command and requesting user information,
@@ -466,7 +466,7 @@ def _send_binary_message(
     """
     # Note - Size is a placeholder here because Binary msg not yet support json args
     message = RequestMessage(
-        user=username, token=token, cmd=cmd, format=MessageFormat.BINARY, args=args, size=-1
+        user=username, token=token, cmd=cmd, format=MessageFormat.BINARY, args=args, size=size
     )
 
     logger.debug(f"sending message {message}")
@@ -661,7 +661,7 @@ def generic_msg(
     try:
         if send_binary:
             assert payload is not None
-            return _send_binary_message(cmd=cmd, payload=payload, recv_binary=recv_binary, args=args)
+            return _send_binary_message(cmd=cmd, payload=payload, recv_binary=recv_binary, args=args, size=size)
         else:
             assert payload is None
             return _send_string_message(cmd=cmd, args=args, size=size, recv_binary=recv_binary)

--- a/arkouda/infoclass.py
+++ b/arkouda/infoclass.py
@@ -68,10 +68,10 @@ def information(names: Union[List[str], str] = RegisteredSymbols) -> str:
     """
     if isinstance(names, str):
         if names in [AllSymbols, RegisteredSymbols]:
-            return cast(str, generic_msg(cmd="info", args="{}".format(names)))
+            return cast(str, generic_msg(cmd="info", args={"names": names}))
         else:
             names = [names]  # allows user to call ak.information(pda.name)
-    return cast(str, generic_msg(cmd="info", args=json.dumps(names)))
+    return cast(str, generic_msg(cmd="info", args={"names": json.dumps(names)}))
 
 
 def list_registry() -> List[str]:

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -660,7 +660,10 @@ def histogram(pda: pdarray, bins: int_scalars = 10) -> Tuple[np.ndarray, pdarray
     if bins < 1:
         raise ValueError("bins must be 1 or greater")
     b = np.linspace(pda.min(), pda.max(), bins + 1)[:-1]  # type: ignore
-    repMsg = generic_msg(cmd="histogram", args="{} {}".format(pda.name, bins))
+    repMsg = generic_msg(cmd="histogram", args={
+        "array": pda,
+        "bins": bins
+    })
     return b, create_pdarray(type_cast(str, repMsg))
 
 

--- a/arkouda/pdarrayIO.py
+++ b/arkouda/pdarrayIO.py
@@ -464,7 +464,7 @@ def get_filetype(filenames: Union[str, List[str]]) -> str:
     if not (fname and fname.strip()):
         raise ValueError("filename cannot be an empty string")
 
-    return cast(str, generic_msg(cmd="getfiletype", args="{}".format(json.dumps([fname]))))
+    return cast(str, generic_msg(cmd="getfiletype", args={"filename": fname}))
 
 
 @typechecked

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -184,7 +184,7 @@ class pdarray:
     def __del__(self):
         try:
             logger.debug(f"deleting pdarray with name {self.name}")
-            generic_msg(cmd="delete", args="{}".format(self.name))
+            generic_msg(cmd="delete", args={"name": self.name})
         except RuntimeError:
             pass
 
@@ -202,12 +202,12 @@ class pdarray:
     def __str__(self):
         from arkouda.client import pdarrayIterThresh
 
-        return generic_msg(cmd="str", args="{} {}".format(self.name, pdarrayIterThresh))
+        return generic_msg(cmd="str", args={"array": self, "printThresh": pdarrayIterThresh})
 
     def __repr__(self):
         from arkouda.client import pdarrayIterThresh
 
-        return generic_msg(cmd="repr", args="{} {}".format(self.name, pdarrayIterThresh))
+        return generic_msg(cmd="repr", args={"array": self, "printThresh": pdarrayIterThresh})
 
     def format_other(self, other: object) -> str:
         """
@@ -657,8 +657,7 @@ class pdarray:
             Raised if value is not an int, int64, float, or float64
         """
         generic_msg(
-            cmd="set",
-            args="{} {} {}".format(self.name, self.dtype.name, self.format_other(value)),
+            cmd="set", args={"array": self, "dtype": self.dtype.name, "val": self.format_other(value)}
         )
 
     def any(self) -> np.bool_:
@@ -1123,7 +1122,7 @@ class pdarray:
         # The reply from the server will be binary data
         data = cast(
             memoryview,
-            generic_msg(cmd="tondarray", args="{}".format(self.name), recv_binary=True),
+            generic_msg(cmd="tondarray", args={"array": self}, recv_binary=True),
         )
         # Make sure the received data has the expected length
         if len(data) != self.size * self.dtype.itemsize:

--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -226,9 +226,11 @@ def array(
                 f"allowed transfer size. Increase ak.maxTransferBytes to force."
             )
         encoded_np = np.array(encoded, dtype=np.uint8)
-        args = f"{encoded_np.dtype.name} {encoded_np.size} seg_string={True}"
         rep_msg = generic_msg(
-            cmd="array", args=args, payload=_array_memview(encoded_np), send_binary=True
+            cmd="array",
+            args={"dtype": encoded_np.dtype.name, "size": encoded_np.size, "seg_string": True},
+            payload=_array_memview(encoded_np),
+            send_binary=True,
         )
         parts = cast(str, rep_msg).split("+", maxsplit=3)
         return (
@@ -249,8 +251,12 @@ def array(
     # than our numpy array we need to swap to match since the server expects
     # native endian bytes
     aview = _array_memview(a)
-    args = f"{a.dtype.name} {size} seg_strings={False}"
-    rep_msg = generic_msg(cmd="array", args=args, payload=aview, send_binary=True)
+    rep_msg = generic_msg(
+        cmd="array",
+        args={"dtype": a.dtype.name, "size": size, "seg_string": False},
+        payload=aview,
+        send_binary=True,
+    )
     return create_pdarray(rep_msg) if dtype is None else akcast(create_pdarray(rep_msg), dtype)
 
 
@@ -307,7 +313,7 @@ def zeros(size: Union[int_scalars, str], dtype: Union[np.dtype, type, str] = flo
     # check dtype for error
     if cast(np.dtype, dtype).name not in NumericDTypes:
         raise TypeError(f"unsupported dtype {dtype}")
-    repMsg = generic_msg(cmd="create", args="{} {}".format(cast(np.dtype, dtype).name, str(size)))
+    repMsg = generic_msg(cmd="create", args={"dtype": cast(np.dtype, dtype).name, "size": size})
 
     return create_pdarray(repMsg)
 
@@ -356,7 +362,7 @@ def ones(size: Union[int_scalars, str], dtype: Union[np.dtype, type, str] = floa
     # check dtype for error
     if cast(np.dtype, dtype).name not in NumericDTypes:
         raise TypeError(f"unsupported dtype {dtype}")
-    repMsg = generic_msg(cmd="create", args="{} {}".format(cast(np.dtype, dtype).name, str(size)))
+    repMsg = generic_msg(cmd="create", args={"dtype": cast(np.dtype, dtype).name, "size": size})
     a = create_pdarray(repMsg)
     a.fill(1)
     return a
@@ -410,7 +416,7 @@ def full(
     # check dtype for error
     if cast(np.dtype, dtype).name not in NumericDTypes:
         raise TypeError(f"unsupported dtype {dtype}")
-    repMsg = generic_msg(cmd="create", args="{} {}".format(cast(np.dtype, dtype).name, str(size)))
+    repMsg = generic_msg(cmd="create", args={"dtype": cast(np.dtype, dtype).name, "size": size})
     a = create_pdarray(repMsg)
     a.fill(fill_value)
     return a

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -435,7 +435,10 @@ def union1d(
             and pda2.dtype == int
             or (pda1.dtype == akuint64 and pda2.dtype == akuint64)
         ):
-            repMsg = generic_msg(cmd="union1d", args="{} {}".format(pda1.name, pda2.name))
+            repMsg = generic_msg(cmd="union1d", args={
+                "arg1": pda1,
+                "arg2": pda2
+            })
             return cast(pdarray, create_pdarray(repMsg))
         return cast(
             pdarray, unique(cast(pdarray, concatenate((unique(pda1), unique(pda2)), ordered=False)))
@@ -522,7 +525,7 @@ def intersect1d(
             pda1.dtype == akuint64 and pda2.dtype == akuint64
         ):
             repMsg = generic_msg(
-                cmd="intersect1d", args="{} {} {}".format(pda1.name, pda2.name, assume_unique)
+                cmd="intersect1d", args={"arg1": pda1, "arg2": pda2, "assume_unique": assume_unique}
             )
             return create_pdarray(cast(str, repMsg))
         if not assume_unique:
@@ -635,7 +638,11 @@ def setdiff1d(
             pda1.dtype == akuint64 and pda2.dtype == akuint64
         ):
             repMsg = generic_msg(
-                cmd="setdiff1d", args="{} {} {}".format(pda1.name, pda2.name, assume_unique)
+                cmd="setdiff1d", args={
+                    "arg1": pda1,
+                    "arg2": pda2,
+                    "assume_unique": assume_unique
+                }
             )
             return create_pdarray(cast(str, repMsg))
         if not assume_unique:
@@ -740,8 +747,11 @@ def setxor1d(pda1: groupable, pda2: groupable, assume_unique: bool = False) -> U
             pda1.dtype == akuint64 and pda2.dtype == akuint64
         ):
             repMsg = generic_msg(
-                cmd="setxor1d", args="{} {} {}".format(pda1.name, pda2.name, assume_unique)
-            )
+                cmd="setxor1d", args={
+                    "arg1": pda1,
+                    "arg2": pda2,
+                    "assume_unique": assume_unique
+                })
             return create_pdarray(cast(str, repMsg))
         if not assume_unique:
             pda1 = cast(pdarray, unique(pda1))

--- a/src/ArraySetopsMsg.chpl
+++ b/src/ArraySetopsMsg.chpl
@@ -36,17 +36,16 @@ module ArraySetopsMsg
     :type st: borrowed SymTab
     :returns: (MsgTuple) response message
     */
-    proc intersect1dMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc intersect1dMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        // split request into fields
-        var (name, name2, assume_unique) = payload.splitMsgToTuple(3);
-        var isUnique = stringtobool(assume_unique);
+        var msgArgs = parseMessageArgs(payload, argSize);
+        var isUnique = msgArgs.get("assume_unique").getBoolValue();
         
         var vname = st.nextName();
 
-        var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(name, st);
-        var gEnt2: borrowed GenSymEntry = getGenericTypedArrayEntry(name2, st);
+        var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(msgArgs.getValueOf("arg1"), st);
+        var gEnt2: borrowed GenSymEntry = getGenericTypedArrayEntry(msgArgs.getValueOf("arg2"), st);
         
         var gEnt_sortMem = radixSortLSD_memEst(gEnt.size, gEnt.itemsize);
         var gEnt2_sortMem = radixSortLSD_memEst(gEnt2.size, gEnt2.itemsize);
@@ -92,17 +91,16 @@ module ArraySetopsMsg
     :type st: borrowed SymTab
     :returns: (MsgTuple) response message
     */
-    proc setxor1dMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc setxor1dMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        // split request into fields
-        var (name, name2, assume_unique) = payload.splitMsgToTuple(3);
-        var isUnique = stringtobool(assume_unique);
+        var msgArgs = parseMessageArgs(payload, argSize);
+        var isUnique = msgArgs.get("assume_unique").getBoolValue();
 
         var vname = st.nextName();
 
-        var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(name, st);
-        var gEnt2: borrowed GenSymEntry = getGenericTypedArrayEntry(name2, st);
+        var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(msgArgs.getValueOf("arg1"), st);
+        var gEnt2: borrowed GenSymEntry = getGenericTypedArrayEntry(msgArgs.getValueOf("arg2"), st);
 
         var gEnt_sortMem = radixSortLSD_memEst(gEnt.size, gEnt.itemsize);
         var gEnt2_sortMem = radixSortLSD_memEst(gEnt2.size, gEnt2.itemsize);
@@ -148,17 +146,16 @@ module ArraySetopsMsg
     :type st: borrowed SymTab
     :returns: (MsgTuple) response message
     */
-    proc setdiff1dMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc setdiff1dMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        // split request into fields
-        var (name, name2, assume_unique) = payload.splitMsgToTuple(3);
-        var isUnique = stringtobool(assume_unique);
+        var msgArgs = parseMessageArgs(payload, argSize);
+        var isUnique = msgArgs.get("assume_unique").getBoolValue();
 
         var vname = st.nextName();
 
-        var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(name, st);
-        var gEnt2: borrowed GenSymEntry = getGenericTypedArrayEntry(name2, st);
+        var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(msgArgs.getValueOf("arg1"), st);
+        var gEnt2: borrowed GenSymEntry = getGenericTypedArrayEntry(msgArgs.getValueOf("arg2"), st);
 
         var gEnt_sortMem = radixSortLSD_memEst(gEnt.size, gEnt.itemsize);
         var gEnt2_sortMem = radixSortLSD_memEst(gEnt2.size, gEnt2.itemsize);
@@ -204,16 +201,15 @@ module ArraySetopsMsg
     :type st: borrowed SymTab
     :returns: (MsgTuple) response message
     */
-    proc union1dMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc union1dMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
       param pn = Reflection.getRoutineName();
       var repMsg: string; // response message
-        // split request into fields
-      var (name, name2) = payload.splitMsgToTuple(2);
+      var msgArgs = parseMessageArgs(payload, argSize);
 
       var vname = st.nextName();
 
-      var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(name, st);
-      var gEnt2: borrowed GenSymEntry = getGenericTypedArrayEntry(name2, st);
+      var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(msgArgs.getValueOf("arg1"), st);
+      var gEnt2: borrowed GenSymEntry = getGenericTypedArrayEntry(msgArgs.getValueOf("arg2"), st);
       
       var gEnt_sortMem = radixSortLSD_memEst(gEnt.size, gEnt.itemsize);
       var gEnt2_sortMem = radixSortLSD_memEst(gEnt2.size, gEnt2.itemsize);

--- a/src/BroadcastMsg.chpl
+++ b/src/BroadcastMsg.chpl
@@ -16,9 +16,8 @@ module BroadcastMsg {
    * full size of the array, optionally applying a permutation
    * to return the result in the order of the original array.
    */
-  proc broadcastMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
-    var (permName, segName, valName, usePermStr, sizeStr) = payload.splitMsgToTuple(5);
-    var msgArgs = parseMessageArgs(payload, 5);
+  proc broadcastMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    var msgArgs = parseMessageArgs(payload, argSize);
     const size = msgArgs.get("size").getIntValue();
     // Segments must be an int64 array
     const gs = getGenericTypedArrayEntry(msgArgs.getValueOf("segName"), st);

--- a/src/CastMsg.chpl
+++ b/src/CastMsg.chpl
@@ -14,9 +14,9 @@ module CastMsg {
   private config const logLevel = ServerConfig.logLevel;
   const castLogger = new Logger(logLevel);
 
-  proc castMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+  proc castMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
     param pn = Reflection.getRoutineName();
-    var msgArgs = parseMessageArgs(payload, 4);
+    var msgArgs = parseMessageArgs(payload, argSize);
     var name = msgArgs.getValueOf("name");
     var objtype = msgArgs.getValueOf("objType");
     var targetDtype = msgArgs.getValueOf("targetDtype");

--- a/src/CommandMap.chpl
+++ b/src/CommandMap.chpl
@@ -9,7 +9,7 @@ module CommandMap {
    * construct the FCF type, but there is no way to generate a
    * FCF that throws using `func()` today.
    */
-  proc akMsgSign(a: string, b: string, c: borrowed SymTab): MsgTuple throws {
+  proc akMsgSign(a: string, b: string, c: int, d: borrowed SymTab): MsgTuple throws {
     var rep = new MsgTuple("dummy-msg", MsgType.NORMAL);
     return rep;
   }
@@ -18,7 +18,7 @@ module CommandMap {
    * Just like akMsgSign, but Messages which have a binary return
    * require a different signature
    */
-  proc akBinMsgSign(a: string, b: string, c: borrowed SymTab): bytes throws {
+  proc akBinMsgSign(a: string, b: string, c: int, d: borrowed SymTab): bytes throws {
     var nb = b"\x00";
     return nb;
   }
@@ -79,11 +79,11 @@ module CommandMap {
     return cm1(0..idx_close-1) + ", " + cm2(1..cm2.size-1);
   }
 
-  proc executeCommand(cmd: string, args, st) throws {
+  proc executeCommand(cmd: string, args, argSize, st) throws {
     var repTuple: MsgTuple;
     if commandMap.contains(cmd) {
       usedModules.add(moduleMap[cmd]);
-      repTuple = commandMap.getBorrowed(cmd)(cmd, args, st);
+      repTuple = commandMap.getBorrowed(cmd)(cmd, args, argSize, st);
     } else {
       repTuple = new MsgTuple("Unrecognized command: %s".format(cmd), MsgType.ERROR);
     }

--- a/src/ConcatenateMsg.chpl
+++ b/src/ConcatenateMsg.chpl
@@ -24,10 +24,10 @@ module ConcatenateMsg
     /* Concatenate a list of arrays together
        to form one array
      */
-    proc concatenateMsg(cmd: string, payload: string, st: borrowed SymTab) : MsgTuple throws {
+    proc concatenateMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab) : MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string;
-        var msgArgs = parseMessageArgs(payload, 4);
+        var msgArgs = parseMessageArgs(payload, argSize);
         var objtype = msgArgs.getValueOf("objType");
         var mode = msgArgs.getValueOf("mode");
         var n = msgArgs.get("nstr").getIntValue(); // number of arrays to sort

--- a/src/DataFrameIndexingMsg.chpl
+++ b/src/DataFrameIndexingMsg.chpl
@@ -93,10 +93,10 @@
         return "SegArray+%s+created %s+created %s".format(col, st.attrib(s_name), st.attrib(v_name));
     }
 
-    proc dataframeBatchIndexingMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc dataframeBatchIndexingMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, 3);
+        var msgArgs = parseMessageArgs(payload, argSize);
         var jsonsize = msgArgs.get("size").getIntValue();
 
         var eleList = msgArgs.get("columns").getList(jsonsize);

--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -36,10 +36,10 @@ module EfuncMsg
       :throws: `UndefinedSymbolError(name)`
       */
 
-    proc efuncMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc efuncMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message; attributes of returned array(s) will be appended to this string
-        var msgArgs = parseMessageArgs(payload, 2);
+        var msgArgs = parseMessageArgs(payload, argSize);
         var name = msgArgs.getValueOf("array");
         var efunc = msgArgs.getValueOf("func");
         var rname = st.nextName();
@@ -310,11 +310,11 @@ module EfuncMsg
     :returns: (MsgTuple)
     :throws: `UndefinedSymbolError(name)`
     */
-    proc efunc3vvMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc efunc3vvMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
         // split request into fields
-        var msgArgs = parseMessageArgs(payload, 4);
+        var msgArgs = parseMessageArgs(payload, argSize);
         var rname = st.nextName();
         
         var efunc = msgArgs.getValueOf("func");
@@ -419,10 +419,10 @@ module EfuncMsg
     :returns: (MsgTuple)
     :throws: `UndefinedSymbolError(name)`
     */
-    proc efunc3vsMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc efunc3vsMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, 5);
+        var msgArgs = parseMessageArgs(payload, argSize);
         var efunc = msgArgs.getValueOf("func");
         var dtype = str2dtype(msgArgs.getValueOf("dtype"));
         var rname = st.nextName();
@@ -534,10 +534,10 @@ module EfuncMsg
     :returns: (MsgTuple)
     :throws: `UndefinedSymbolError(name)`
     */
-    proc efunc3svMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc efunc3svMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, 5);
+        var msgArgs = parseMessageArgs(payload, argSize);
         var efunc = msgArgs.getValueOf("func");
         var dtype = str2dtype(msgArgs.getValueOf("dtype"));
         var rname = st.nextName();
@@ -649,10 +649,10 @@ module EfuncMsg
     :returns: (MsgTuple)
     :throws: `UndefinedSymbolError(name)`
     */
-    proc efunc3ssMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc efunc3ssMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, 5);
+        var msgArgs = parseMessageArgs(payload, argSize);
         var dtype = str2dtype(msgArgs.getValueOf("dtype"));
         var efunc = msgArgs.getValueOf("func");
         var rname = st.nextName();

--- a/src/FlattenMsg.chpl
+++ b/src/FlattenMsg.chpl
@@ -12,8 +12,8 @@ module FlattenMsg {
   private config const logLevel = ServerConfig.logLevel;
   const fmLogger = new Logger(logLevel);
 
-  proc segFlattenMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
-    var msgArgs = parseMessageArgs(payload, 5);
+  proc segFlattenMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    var msgArgs = parseMessageArgs(payload, argSize);
     const objtype = msgArgs.getValueOf("objtype");
     const returnSegs: bool = msgArgs.get("return_segs").getBoolValue();
     const regex: bool = msgArgs.get("regex").getBoolValue();
@@ -45,10 +45,10 @@ module FlattenMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc segmentedSplitMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+  proc segmentedSplitMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    var msgArgs = parseMessageArgs(payload, 5);
+    var msgArgs = parseMessageArgs(payload, argSize);
 
     const objtype = msgArgs.getValueOf("objtype");
     const name = msgArgs.getValueOf("parent_name");

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -39,7 +39,7 @@ module GenSymIO {
         try {
             dtype = str2dtype(msgArgs.getValueOf("dtype"));
             size = msgArgs.get("size").getIntValue();
-            asSegStr = msgArgs.get("asSegStr").getBoolValue();
+            asSegStr = msgArgs.get("seg_string").getBoolValue();
         } catch {
             var errorMsg = "Error parsing/decoding either dtypeBytes or size";
             gsLogger.error(getModuleName(), getRoutineName(), getLineNumber(), errorMsg);
@@ -71,7 +71,7 @@ module GenSymIO {
         } else if dtype == DType.UInt8 {
             rname = bytesToSymEntry(size, uint(8), st, data);
         } else {
-            msg = "Unhandled data type %s".format(dtypeBytes);
+            msg = "Unhandled data type %s".format(msgArgs.getValueOf("dtype"));
             msgType = MsgType.ERROR;
             gsLogger.error(getModuleName(),getRoutineName(),getLineNumber(),msg);
         }

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -26,21 +26,20 @@ module GenSymIO {
      * Creates a pdarray server-side and returns the SymTab name used to
      * retrieve the pdarray from the SymTab.
      */
-    proc arrayMsg(cmd: string, args: string, ref data: bytes, st: borrowed SymTab): MsgTuple throws {
+    proc arrayMsg(cmd: string, args: string, argSize: int, ref data: bytes, st: borrowed SymTab): MsgTuple throws {
         // Set up our return items
         var msgType = MsgType.NORMAL;
         var msg:string = "";
         var rname:string = "";
-
-        var (dtypeBytes, sizeBytes, segStr) = args.splitMsgToTuple(" ", 3);
+        var msgArgs = parseMessageArgs(args, argSize);
         var dtype = DType.UNDEF;
         var size:int;
         var asSegStr = false;
         
         try {
-            dtype = str2dtype(dtypeBytes);
-            size = sizeBytes:int;
-            asSegStr = "seg_string=True" == segStr.strip();
+            dtype = str2dtype(msgArgs.getValueOf("dtype"));
+            size = msgArgs.get("size").getIntValue();
+            asSegStr = msgArgs.get("asSegStr").getBoolValue();
         } catch {
             var errorMsg = "Error parsing/decoding either dtypeBytes or size";
             gsLogger.error(getModuleName(), getRoutineName(), getLineNumber(), errorMsg);
@@ -129,10 +128,11 @@ module GenSymIO {
      * Outputs the pdarray as a Numpy ndarray in the form of a 
      * Chapel Bytes object
      */
-    proc tondarrayMsg(cmd: string, payload: string, st: 
+    proc tondarrayMsg(cmd: string, payload: string, argSize: int, st: 
                                           borrowed SymTab): bytes throws {
         var arrayBytes: bytes;
-        var abstractEntry = st.lookup(payload);
+        var msgArgs = parseMessageArgs(payload, argSize);
+        var abstractEntry = st.lookup(msgArgs.getValueOf("array"));
         if !abstractEntry.isAssignableTo(SymbolEntryType.TypedArraySymEntry) {
             var errorMsg = "Error: Unhandled SymbolEntryType %s".format(abstractEntry.entryType);
             gsLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -47,10 +47,10 @@ module HDF5Msg {
      * :returns: string formatted as json list
      * i.e. ["_arkouda_metadata", "pda1", "s1"]
      */
-    proc lshdfMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc lshdfMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         // reqMsg: "lshdf [<json_filename>]"
         var repMsg: string;
-        var msgArgs = parseMessageArgs(payload, 1);
+        var msgArgs = parseMessageArgs(payload, argSize);
 
         // Retrieve filename from payload
         var filename: string = msgArgs.getValueOf("filename");
@@ -1774,9 +1774,9 @@ module HDF5Msg {
     /**
      * Reads all datasets from 1..n HDF5 files into an Arkouda symbol table. 
      */
-    proc readAllHdfMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc readAllHdfMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         var repMsg: string;
-        var msgArgs = parseMessageArgs(payload, 7);
+        var msgArgs = parseMessageArgs(payload, argSize);
         var strictTypes: bool = msgArgs.get("strict_types").getBoolValue();
 
         var allowErrors: bool = msgArgs.get("allow_errors").getBoolValue(); // default is false
@@ -2054,8 +2054,8 @@ module HDF5Msg {
         return new MsgTuple(repMsg,MsgType.NORMAL);
     }
 
-    proc tohdfMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
-        var msgArgs = parseMessageArgs(payload, 7);
+    proc tohdfMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+        var msgArgs = parseMessageArgs(payload, argSize);
         var mode = msgArgs.get("mode").getIntValue();
         var filename: string = msgArgs.getValueOf("prefix");
         var entry = st.lookup(msgArgs.getValueOf("values"));

--- a/src/HDF5MultiDim.chpl
+++ b/src/HDF5MultiDim.chpl
@@ -116,9 +116,9 @@ module HDF5MultiDim {
     The resulting data is always in flattened form (as expected by ArrayView)
     Adds a pdarray containing the flattened data and a pdarray containing the shape of the object to the symbol table
     */
-    proc read_hdf_multi_msg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc read_hdf_multi_msg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         // Currently always load flat as row major
-        var msgArgs = parseMessageArgs(payload, 2);
+        var msgArgs = parseMessageArgs(payload, argSize);
         var filename = msgArgs.getValueOf("filename");
         var dset_name = msgArgs.getValueOf("dset");
 
@@ -255,8 +255,8 @@ module HDF5MultiDim {
     * Takes a multidimensional array obj and writes it into and HDF5 dataset.
     * Provides the ability to store the data flat or multidimensional.
     */
-    proc write_hdf_multi_msg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
-        var msgArgs = parseMessageArgs(payload, 7);
+    proc write_hdf_multi_msg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+        var msgArgs = parseMessageArgs(payload, argSize);
 
         var method: int = msgArgs.get("method").getIntValue();
 

--- a/src/HistogramMsg.chpl
+++ b/src/HistogramMsg.chpl
@@ -12,6 +12,7 @@ module HistogramMsg
     use ServerErrorStrings;
 
     use Histogram;
+    use Message;
  
     private config const logLevel = ServerConfig.logLevel;
     const hgmLogger = new Logger(logLevel);
@@ -20,12 +21,12 @@ module HistogramMsg
     private config const mBound = 2**25;
 
     /* histogram takes a pdarray and returns a pdarray with the histogram in it */
-    proc histogramMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc histogramMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        // split request into fields
-        var (name, binsStr) = payload.splitMsgToTuple(2);
-        var bins = try! binsStr:int;
+        var msgArgs = parseMessageArgs(payload, argSize);
+        const bins = msgArgs.get("bins").getIntValue();
+        const name = msgArgs.getValueOf("array");
         
         // get next symbol name
         var rname = st.nextName();

--- a/src/In1dMsg.chpl
+++ b/src/In1dMsg.chpl
@@ -24,10 +24,10 @@ module In1dMsg
        which implementation
        of in1d to utilize.
     */
-    proc in1dMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc in1dMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, 3);
+        var msgArgs = parseMessageArgs(payload, argSize);
         var invert: bool = msgArgs.get("invert").getBoolValue();
 
         // get next symbol name

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -33,8 +33,8 @@ module IndexingMsg
         return tup;
     }
 
-    proc arrayViewMixedIndexMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
-        var msgArgs = parseMessageArgs(payload, 5);
+    proc arrayViewMixedIndexMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+        var msgArgs = parseMessageArgs(payload, argSize);
         var ndim = msgArgs.get("ndim").getIntValue();
         const pdaName = msgArgs.getValueOf("base");
         const indexDimName = msgArgs.getValueOf("index_dim");
@@ -122,9 +122,9 @@ module IndexingMsg
     }
 
     /* arrayViewIntIndexMsg "av[int_list]" response to __getitem__(int_list) where av is an ArrayView */
-    proc arrayViewIntIndexMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc arrayViewIntIndexMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
-        var msgArgs = parseMessageArgs(payload, 3);
+        var msgArgs = parseMessageArgs(payload, argSize);
         const pdaName = msgArgs.getValueOf("base");
         const dimProdName = msgArgs.getValueOf("dim_prod");
         const coordsName = msgArgs.getValueOf("coords");
@@ -144,18 +144,32 @@ module IndexingMsg
             when (DType.Int64) {
                 var coordsEntry = toSymEntry(coords, int);
                 var idx = + reduce (dimProdEntry.a * coordsEntry.a);
+<<<<<<< HEAD
                 idxParam.setVal(idx:string);
                 idxParam.setDType("int");
                 const json: [0..#2] string = [arrParam.getJSON(), idxParam.getJSON()];
                 return intIndexMsg(cmd, "%jt".format(json), st);
+=======
+                idxMap.add("dtype", "int");
+                idxMap.add("val", idx: string);
+                const json: [0..#2] string = ["%jt".format(arrayMap), "%jt".format(idxMap)];
+                return intIndexMsg(cmd, "%jt".format(json), json.size, st);
+>>>>>>> 802c5977 (Updated message parsing to use argSize parameter. Updated any messages that were still parsing strings.)
             }
             when (DType.UInt64) {
                 var coordsEntry = toSymEntry(coords, uint);
                 var idx = + reduce (dimProdEntry.a: uint * coordsEntry.a);
+<<<<<<< HEAD
                 idxParam.setVal(idx:string);
                 idxParam.setDType("uint");
                 const json: [0..#2] string = [arrParam.getJSON(), idxParam.getJSON()];
                 return intIndexMsg(cmd, "%jt".format(json), st);
+=======
+                idxMap.add("dtype", "uint");
+                idxMap.add("val", idx: string);
+                const json: [0..#2] string = ["%jt".format(arrayMap), "%jt".format(idxMap)];
+                return intIndexMsg(cmd, "%jt".format(json), json.size, st);
+>>>>>>> 802c5977 (Updated message parsing to use argSize parameter. Updated any messages that were still parsing strings.)
             }
             otherwise {
                  var errorMsg = notImplementedError(pn, "("+dtype2str(coords.dtype)+")");
@@ -166,9 +180,9 @@ module IndexingMsg
     }
 
     /* arrayViewIntIndexAssignMsg "av[int_list]=value" response to __getitem__(int_list) where av is an ArrayView */
-    proc arrayViewIntIndexAssignMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc arrayViewIntIndexAssignMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
-        var msgArgs = parseMessageArgs(payload, 5);
+        var msgArgs = parseMessageArgs(payload, argSize);
         const pdaName = msgArgs.getValueOf("base");
         const dimProdName = msgArgs.getValueOf("dim_prod");
         const coordsName = msgArgs.getValueOf("coords");
@@ -192,18 +206,32 @@ module IndexingMsg
             when (DType.Int64) {
                 var coordsEntry = toSymEntry(coords, int);
                 var idx = + reduce (dimProdEntry.a * coordsEntry.a);
+<<<<<<< HEAD
                 idxParam.setVal(idx:string);
                 idxParam.setDType("int");
                 var json: [0..#4] string = [arrParam.getJSON(), valJSON, dtypeJSON, idxParam.getJSON()];
                 return setIntIndexToValueMsg(cmd, "%jt".format(json), st);
+=======
+                idxMap.add("val", idx:string);
+                idxMap.add("dtype", "int");
+                var json: [0..#4] string = ["%jt".format(arrayMap), "%jt".format(valMap), "%jt".format(dtypeMap), "%jt".format(idxMap)];
+                return setIntIndexToValueMsg(cmd, "%jt".format(json), json.size, st);
+>>>>>>> 802c5977 (Updated message parsing to use argSize parameter. Updated any messages that were still parsing strings.)
             }
             when (DType.UInt64) {
                 var coordsEntry = toSymEntry(coords, uint);
                 var idx = + reduce (dimProdEntry.a: uint * coordsEntry.a);
+<<<<<<< HEAD
                 idxParam.setVal(idx:string);
                 idxParam.setDType("uint");
                 var json: [0..#4] string = [arrParam.getJSON(), valJSON, dtypeJSON, idxParam.getJSON()];
                 return setIntIndexToValueMsg(cmd, "%jt".format(json), st);
+=======
+                idxMap.add("val", idx:string);
+                idxMap.add("dtype", "uint");
+                var json: [0..#4] string = ["%jt".format(arrayMap), "%jt".format(valMap), "%jt".format(dtypeMap), "%jt".format(idxMap)];
+                return setIntIndexToValueMsg(cmd, "%jt".format(json), json.size, st);
+>>>>>>> 802c5977 (Updated message parsing to use argSize parameter. Updated any messages that were still parsing strings.)
             }
             otherwise {
                  var errorMsg = notImplementedError(pn, "("+dtype2str(coords.dtype)+")");
@@ -214,10 +242,10 @@ module IndexingMsg
     }
 
     /* intIndex "a[int]" response to __getitem__(int) */
-    proc intIndexMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc intIndexMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, 2);
+        var msgArgs = parseMessageArgs(payload, argSize);
         var idx = msgArgs.get("idx").getIntValue();
         const name = msgArgs.getValueOf("array");
         imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
@@ -276,10 +304,10 @@ module IndexingMsg
     }
 
     /* sliceIndex "a[slice]" response to __getitem__(slice) */
-    proc sliceIndexMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc sliceIndexMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, 4);
+        var msgArgs = parseMessageArgs(payload, argSize);
         const start = msgArgs.get("start").getIntValue();
         const stop = msgArgs.get("stop").getIntValue();
         const stride = msgArgs.get("stride").getIntValue();
@@ -329,10 +357,10 @@ module IndexingMsg
     }
 
     /* pdarrayIndex "a[pdarray]" response to __getitem__(pdarray) */
-    proc pdarrayIndexMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc pdarrayIndexMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, 2);
+        var msgArgs = parseMessageArgs(payload, argSize);
         const name = msgArgs.getValueOf("array");
         const iname = msgArgs.getValueOf("idx");
 
@@ -499,10 +527,10 @@ module IndexingMsg
     }
 
     /* setIntIndexToValue "a[int] = value" response to __setitem__(int, value) */
-    proc setIntIndexToValueMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc setIntIndexToValueMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, 4);
+        var msgArgs = parseMessageArgs(payload, argSize);
         const name = msgArgs.getValueOf("array");
         const idx = msgArgs.get("idx").getIntValue();
         var dtype = str2dtype(msgArgs.getValueOf("dtype"));
@@ -610,10 +638,10 @@ module IndexingMsg
     }
 
     /* setPdarrayIndexToValue "a[pdarray] = value" response to __setitem__(pdarray, value) */
-    proc setPdarrayIndexToValueMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc setPdarrayIndexToValueMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, 4);
+        var msgArgs = parseMessageArgs(payload, argSize);
         const dtype = str2dtype(msgArgs.getValueOf("dtype"));
         const name = msgArgs.getValueOf("array");
         const iname = msgArgs.getValueOf("idx");
@@ -766,10 +794,10 @@ module IndexingMsg
     }
 
     /* setPdarrayIndexToPdarray "a[pdarray] = pdarray" response to __setitem__(pdarray, pdarray) */
-    proc setPdarrayIndexToPdarrayMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc setPdarrayIndexToPdarrayMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, 3);
+        var msgArgs = parseMessageArgs(payload, argSize);
         const name = msgArgs.getValueOf("array");
         const iname = msgArgs.getValueOf("idx");
         const yname = msgArgs.getValueOf("value");
@@ -941,10 +969,10 @@ module IndexingMsg
     }
 
     /* setSliceIndexToValue "a[slice] = value" response to __setitem__(slice, value) */
-    proc setSliceIndexToValueMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc setSliceIndexToValueMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, 6);
+        var msgArgs = parseMessageArgs(payload, argSize);
         const name = msgArgs.getValueOf("array");
         const start = msgArgs.get("start").getIntValue();
         const stop = msgArgs.get("stop").getIntValue();
@@ -1056,10 +1084,10 @@ module IndexingMsg
     }
     
     /* setSliceIndexToPdarray "a[slice] = pdarray" response to __setitem__(slice, pdarray) */
-    proc setSliceIndexToPdarrayMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc setSliceIndexToPdarrayMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, 5);
+        var msgArgs = parseMessageArgs(payload, argSize);
         const start = msgArgs.get("start").getIntValue();
         const stop = msgArgs.get("stop").getIntValue();
         const stride = msgArgs.get("stride").getIntValue();

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -118,7 +118,7 @@ module IndexingMsg
         var idxParam = new ParameterObj("idx", indiciesName, ObjectType.PDARRAY, "int");
 
         var json: [0..#2] string = [arrParam.getJSON(), idxParam.getJSON()];
-        return pdarrayIndexMsg(cmd, "%jt".format(json), st);
+        return pdarrayIndexMsg(cmd, "%jt".format(json), json.size, st);
     }
 
     /* arrayViewIntIndexMsg "av[int_list]" response to __getitem__(int_list) where av is an ArrayView */
@@ -144,32 +144,18 @@ module IndexingMsg
             when (DType.Int64) {
                 var coordsEntry = toSymEntry(coords, int);
                 var idx = + reduce (dimProdEntry.a * coordsEntry.a);
-<<<<<<< HEAD
                 idxParam.setVal(idx:string);
                 idxParam.setDType("int");
                 const json: [0..#2] string = [arrParam.getJSON(), idxParam.getJSON()];
-                return intIndexMsg(cmd, "%jt".format(json), st);
-=======
-                idxMap.add("dtype", "int");
-                idxMap.add("val", idx: string);
-                const json: [0..#2] string = ["%jt".format(arrayMap), "%jt".format(idxMap)];
                 return intIndexMsg(cmd, "%jt".format(json), json.size, st);
->>>>>>> 802c5977 (Updated message parsing to use argSize parameter. Updated any messages that were still parsing strings.)
             }
             when (DType.UInt64) {
                 var coordsEntry = toSymEntry(coords, uint);
                 var idx = + reduce (dimProdEntry.a: uint * coordsEntry.a);
-<<<<<<< HEAD
                 idxParam.setVal(idx:string);
                 idxParam.setDType("uint");
                 const json: [0..#2] string = [arrParam.getJSON(), idxParam.getJSON()];
-                return intIndexMsg(cmd, "%jt".format(json), st);
-=======
-                idxMap.add("dtype", "uint");
-                idxMap.add("val", idx: string);
-                const json: [0..#2] string = ["%jt".format(arrayMap), "%jt".format(idxMap)];
                 return intIndexMsg(cmd, "%jt".format(json), json.size, st);
->>>>>>> 802c5977 (Updated message parsing to use argSize parameter. Updated any messages that were still parsing strings.)
             }
             otherwise {
                  var errorMsg = notImplementedError(pn, "("+dtype2str(coords.dtype)+")");
@@ -206,32 +192,18 @@ module IndexingMsg
             when (DType.Int64) {
                 var coordsEntry = toSymEntry(coords, int);
                 var idx = + reduce (dimProdEntry.a * coordsEntry.a);
-<<<<<<< HEAD
                 idxParam.setVal(idx:string);
                 idxParam.setDType("int");
                 var json: [0..#4] string = [arrParam.getJSON(), valJSON, dtypeJSON, idxParam.getJSON()];
-                return setIntIndexToValueMsg(cmd, "%jt".format(json), st);
-=======
-                idxMap.add("val", idx:string);
-                idxMap.add("dtype", "int");
-                var json: [0..#4] string = ["%jt".format(arrayMap), "%jt".format(valMap), "%jt".format(dtypeMap), "%jt".format(idxMap)];
                 return setIntIndexToValueMsg(cmd, "%jt".format(json), json.size, st);
->>>>>>> 802c5977 (Updated message parsing to use argSize parameter. Updated any messages that were still parsing strings.)
             }
             when (DType.UInt64) {
                 var coordsEntry = toSymEntry(coords, uint);
                 var idx = + reduce (dimProdEntry.a: uint * coordsEntry.a);
-<<<<<<< HEAD
                 idxParam.setVal(idx:string);
                 idxParam.setDType("uint");
                 var json: [0..#4] string = [arrParam.getJSON(), valJSON, dtypeJSON, idxParam.getJSON()];
-                return setIntIndexToValueMsg(cmd, "%jt".format(json), st);
-=======
-                idxMap.add("val", idx:string);
-                idxMap.add("dtype", "uint");
-                var json: [0..#4] string = ["%jt".format(arrayMap), "%jt".format(valMap), "%jt".format(dtypeMap), "%jt".format(idxMap)];
                 return setIntIndexToValueMsg(cmd, "%jt".format(json), json.size, st);
->>>>>>> 802c5977 (Updated message parsing to use argSize parameter. Updated any messages that were still parsing strings.)
             }
             otherwise {
                  var errorMsg = notImplementedError(pn, "("+dtype2str(coords.dtype)+")");

--- a/src/JoinEqWithDTMsg.chpl
+++ b/src/JoinEqWithDTMsg.chpl
@@ -223,10 +223,10 @@ module JoinEqWithDTMsg
        pred: is the dt-predicate ("absDT","posDT","trueDT")
        resLimit: is how many answers can you tolerate ;-)
     */
-    proc joinEqWithDTMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc joinEqWithDTMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, 9);
+        var msgArgs = parseMessageArgs(payload, argSize);
         const dt = msgArgs.get("dt").getIntValue();
         const pred = msgArgs.get("pred").getIntValue();
         const resLimit = msgArgs.get("resLimit").getIntValue();

--- a/src/KExtremeMsg.chpl
+++ b/src/KExtremeMsg.chpl
@@ -34,10 +34,10 @@ module KExtremeMsg
     :type st: borrowed SymTab
     :returns: (MsgTuple) response message
     */
-    proc minkMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc minkMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, 3);
+        var msgArgs = parseMessageArgs(payload, argSize);
 
         var vname = st.nextName();
 
@@ -97,10 +97,10 @@ module KExtremeMsg
     :type st: borrowed SymTab
     :returns: (MsgTuple) response message
     */
-    proc maxkMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc maxkMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, 3);
+        var msgArgs = parseMessageArgs(payload, argSize);
 
         var vname = st.nextName();
         var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(msgArgs.getValueOf("array"), st);

--- a/src/MetricsMsg.chpl
+++ b/src/MetricsMsg.chpl
@@ -399,8 +399,8 @@ module MetricsMsg {
         }
     }
 
-    proc metricsMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {    
-        var msgArgs = parseMessageArgs(payload, 1);   
+    proc metricsMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {    
+        var msgArgs = parseMessageArgs(payload, argSize);   
         var category = msgArgs.getValueOf("category"):MetricCategory;
             
         mLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -33,11 +33,11 @@ module OperatorMsg
       :returns: (MsgTuple) 
       :throws: `UndefinedSymbolError(name)`
     */
-    proc binopvvMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {       
+    proc binopvvMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {       
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
         
-        var msgArgs = parseMessageArgs(payload, 3);
+        var msgArgs = parseMessageArgs(payload, argSize);
         const op = msgArgs.getValueOf("op");
         const aname = msgArgs.getValueOf("a");
         const bname = msgArgs.getValueOf("b");
@@ -263,11 +263,11 @@ module OperatorMsg
       :returns: (MsgTuple) 
       :throws: `UndefinedSymbolError(name)`
     */
-    proc binopvsMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc binopvsMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string = ""; // response message
 
-        var msgArgs = parseMessageArgs(payload, 4);
+        var msgArgs = parseMessageArgs(payload, argSize);
         const aname = msgArgs.getValueOf("a");
         const op = msgArgs.getValueOf("op");
         const value = msgArgs.get("value");
@@ -481,11 +481,11 @@ module OperatorMsg
       :returns: (MsgTuple) 
       :throws: `UndefinedSymbolError(name)`
     */
-    proc binopsvMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc binopsvMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string = ""; // response message
 
-        var msgArgs = parseMessageArgs(payload, 4);
+        var msgArgs = parseMessageArgs(payload, argSize);
         const op = msgArgs.getValueOf("op");
         const aname = msgArgs.getValueOf("a");
         const value = msgArgs.get("value");
@@ -705,11 +705,11 @@ module OperatorMsg
     :returns: (MsgTuple) 
     :throws: `UndefinedSymbolError(name)`
     */
-    proc opeqvvMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc opeqvvMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
 
-        var msgArgs = parseMessageArgs(payload, 3);
+        var msgArgs = parseMessageArgs(payload, argSize);
         const op = msgArgs.getValueOf("op");
         const aname = msgArgs.getValueOf("a");
         const bname = msgArgs.getValueOf("b");
@@ -881,11 +881,11 @@ module OperatorMsg
     :returns: (MsgTuple)
     :throws: `UndefinedSymbolError(name)`
     */
-    proc opeqvsMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc opeqvsMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
 
-        var msgArgs = parseMessageArgs(payload, 4);
+        var msgArgs = parseMessageArgs(payload, argSize);
         const op = msgArgs.getValueOf("op");
         const aname = msgArgs.getValueOf("a");
         const value = msgArgs.get("value");

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -528,9 +528,9 @@ module ParquetMsg {
     return writeDistArrayToParquet(A, filename, dsetname, dtype, ROWGROUPS, compressed, mode);
   }
 
-  proc readAllParquetMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+  proc readAllParquetMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
     var repMsg: string;
-    var msgArgs = parseMessageArgs(payload, 7);
+    var msgArgs = parseMessageArgs(payload, argSize);
     var strictTypes: bool = msgArgs.get("strict_types").getBoolValue();
 
     var allowErrors: bool = msgArgs.get("allow_errors").getBoolValue(); // default is false
@@ -697,8 +697,8 @@ module ParquetMsg {
     return new list(datasets.split(","));
   }
   
-  proc toparquetMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
-    var msgArgs = parseMessageArgs(payload, 7);
+  proc toparquetMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    var msgArgs = parseMessageArgs(payload, argSize);
     var mode = msgArgs.get("mode").getIntValue();
     var filename: string = msgArgs.getValueOf("prefix");
     var entry = st.lookup(msgArgs.getValueOf("values"));
@@ -771,10 +771,10 @@ module ParquetMsg {
     }
   }
 
-  proc lspqMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+  proc lspqMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
     // reqMsg: "lshdf [<json_filename>]"
     var repMsg: string;
-    var msgArgs = parseMessageArgs(payload, 1);
+    var msgArgs = parseMessageArgs(payload, argSize);
 
     // Retrieve filename from payload
     var filename: string = msgArgs.getValueOf("filename");
@@ -829,9 +829,9 @@ module ParquetMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc nullIndicesMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+  proc nullIndicesMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
     var repMsg: string;
-    var msgArgs = parseMessageArgs(payload, 4);
+    var msgArgs = parseMessageArgs(payload, argSize);
 
     var ndsets = msgArgs.get("dset_size").getIntValue();
     var nfiles = msgArgs.get("filename_size").getIntValue();

--- a/src/RandMsg.chpl
+++ b/src/RandMsg.chpl
@@ -23,11 +23,11 @@ module RandMsg
 
     :arg reqMsg: message to process (contains cmd,aMin,aMax,len,dtype)
     */
-    proc randintMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc randintMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
         
-        var msgArgs = parseMessageArgs(payload, 5);
+        var msgArgs = parseMessageArgs(payload, argSize);
         const len = msgArgs.get("size").getIntValue();
         const dtype = str2dtype(msgArgs.getValueOf("dtype"));
         const seed = msgArgs.getValueOf("seed");
@@ -122,9 +122,9 @@ module RandMsg
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 
-    proc randomNormalMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc randomNormalMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         var pn = Reflection.getRoutineName();
-        var msgArgs = parseMessageArgs(payload, 2);
+        var msgArgs = parseMessageArgs(payload, argSize);
         const len = msgArgs.get("size").getIntValue();
         // Result + 2 scratch arrays
         overMemLimit(3*8*len);

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -27,10 +27,10 @@ module ReductionMsg
     // these functions take an array and produce a scalar
     // parse and respond to reduction message
     // scalar = reductionop(vector)
-    proc reductionMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc reductionMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string = ""; // response message
-        var msgArgs = parseMessageArgs(payload, 2);
+        var msgArgs = parseMessageArgs(payload, argSize);
         const reductionop = msgArgs.getValueOf("op");
         const name = msgArgs.getValueOf("array");
         rmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
@@ -267,11 +267,11 @@ module ReductionMsg
         return new MsgTuple(repMsg, MsgType.NORMAL);          
     }
 
-    proc countReductionMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc countReductionMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
       // reqMsg: segmentedReduction values segments operator
       // 'segments_name' describes the segment offsets
-      var msgArgs = parseMessageArgs(payload, 2);
+      var msgArgs = parseMessageArgs(payload, argSize);
       const segments_name = msgArgs.getValueOf("segments");
       const size = msgArgs.get("size").getIntValue();
       var rname = st.nextName();
@@ -308,13 +308,13 @@ module ReductionMsg
       return counts;
     }
     
-    proc segmentedReductionMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc segmentedReductionMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         // reqMsg: segmentedReduction values segments operator
         // 'values_name' is the segmented array of values to be reduced
         // 'segments_name' is the sement offsets
         // 'op' is the reduction operator
-        var msgArgs = parseMessageArgs(payload, 4);
+        var msgArgs = parseMessageArgs(payload, argSize);
         const skipNan = msgArgs.get("skip_nan").getBoolValue();
         const values_name = msgArgs.getValueOf("values");
         const segments_name = msgArgs.getValueOf("segments");

--- a/src/RegistrationMsg.chpl
+++ b/src/RegistrationMsg.chpl
@@ -29,10 +29,10 @@ module RegistrationMsg
 
     :returns: MsgTuple response message
     */
-    proc registerMsg(cmd: string, payload: string,  
+    proc registerMsg(cmd: string, payload: string, argSize: int,
                                         st: borrowed SymTab): MsgTuple throws {
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, 2);
+        var msgArgs = parseMessageArgs(payload, argSize);
         const name = msgArgs.getValueOf("array");
         const userDefinedName = msgArgs.getValueOf("user_name");
 
@@ -67,11 +67,11 @@ module RegistrationMsg
 
     :returns: MsgTuple response message
     */
-    proc attachMsg(cmd: string, payload: string, 
+    proc attachMsg(cmd: string, payload: string, argSize: int,
                                           st: borrowed SymTab): MsgTuple throws {
         var repMsg: string; // response message
 
-        var msgArgs = parseMessageArgs(payload, 1);
+        var msgArgs = parseMessageArgs(payload, argSize);
         const name = msgArgs.getValueOf("name");
 
         // if verbose print action
@@ -334,10 +334,10 @@ module RegistrationMsg
 
     :returns: MsgTuple response message
     */
-    proc genAttachMsg(cmd: string, payload: string, 
+    proc genAttachMsg(cmd: string, payload: string, argSize: int,
                                             st: borrowed SymTab): MsgTuple throws {
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, 2);
+        var msgArgs = parseMessageArgs(payload, argSize);
         var dtype = msgArgs.getValueOf("dtype");
         const name = msgArgs.getValueOf("name");
 
@@ -355,7 +355,7 @@ module RegistrationMsg
             when ("simple") {
                 var json: [0..#1] string = [msgArgs.get("name").getJSON()];
                 // pdarray and strings can use the attachMsg method
-                return attachMsg(cmd, "%jt".format(json), st);
+                return attachMsg(cmd, "%jt".format(json), json.size, st);
             }
             when ("categorical") {
                 return attachCategoricalMsg(cmd, name, st);
@@ -403,11 +403,11 @@ module RegistrationMsg
 
     :returns: MsgTuple response message
     */
-    proc unregisterMsg(cmd: string, payload: string, 
+    proc unregisterMsg(cmd: string, payload: string, argSize: int,
                                       st: borrowed SymTab): MsgTuple throws {
         var repMsg: string; // response message
         // split request into fields
-        var msgArgs = parseMessageArgs(payload, 1);
+        var msgArgs = parseMessageArgs(payload, argSize);
         const name = msgArgs.getValueOf("name");
 
         // if verbose print action
@@ -422,8 +422,8 @@ module RegistrationMsg
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 
-    proc unregisterByNameMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
-        var msgArgs = parseMessageArgs(payload, 2);
+    proc unregisterByNameMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+        var msgArgs = parseMessageArgs(payload, argSize);
         var dtype = msgArgs.getValueOf("dtype");
         const name = msgArgs.getValueOf("name");
         var status = "";
@@ -442,7 +442,7 @@ module RegistrationMsg
             when ("simple") {
                 // pdarray and strings can use the unregisterMsg method without any other processing
                 var json: [0..#1] string = [msgArgs.get("name").getJSON()];
-                return unregisterMsg(cmd, "%jt".format(json), st);
+                return unregisterMsg(cmd, "%jt".format(json), json.size, st);
             }
             when ("categorical") {
                 // Create an array with 5 strings, one for each component of categorical, and assign the names
@@ -465,7 +465,7 @@ module RegistrationMsg
                     if n != "" {
                         base_json.set("val", n);
                         var json: [0..#1] string = ["%jt".format(base_json)];
-                        var resp = unregisterMsg(cmd, "%jt".format(json), st);
+                        var resp = unregisterMsg(cmd, "%jt".format(json), json.size, st);
                         status += " %s: %s ".format(n, resp.msg);
                     }
                 }
@@ -482,7 +482,7 @@ module RegistrationMsg
                 for n in nameList {
                     base_json.set("val", n);
                     var json: [0..#1] string = ["%jt".format(base_json)];
-                    var resp = unregisterMsg(cmd, "%jt".format(json), st);
+                    var resp = unregisterMsg(cmd, "%jt".format(json), json.size, st);
                     status += " %s: %s ".format(n, resp.msg);
                 }
             }
@@ -510,7 +510,7 @@ module RegistrationMsg
                 forall n in nameList with (in base_json, + reduce status) {
                     base_json.set("val", n);
                     var json: [0..#1] string = ["%jt".format(base_json)];
-                    var resp = unregisterMsg(cmd, "%jt".format(json), st);
+                    var resp = unregisterMsg(cmd, "%jt".format(json), json.size, st);
                     status += " %s: %s ".format(n, resp.msg);
                 }
             }

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -21,8 +21,8 @@ module SegmentedMsg {
   /**
   * Build a Segmented Array object based on the segments/values specified.
   **/
-  proc assembleSegArrayMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
-    var msgArgs = parseMessageArgs(payload, 2);
+  proc assembleSegArrayMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    var msgArgs = parseMessageArgs(payload, argSize);
     var segName = msgArgs.getValueOf("segments");
     var valName = msgArgs.getValueOf("values"); 
     smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
@@ -78,9 +78,9 @@ module SegmentedMsg {
   * Procedure to access the Segments of a Segmented Array
   * This may not be needed once all functionality is server side
   **/
-  proc getSASegmentsMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+  proc getSASegmentsMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
     var repMsg: string = "";
-    var msgArgs = parseMessageArgs(payload, 1);
+    var msgArgs = parseMessageArgs(payload, argSize);
     var name = msgArgs.getValueOf("name"): string;
     var entry = st.tab.getBorrowed(name);
     var compEntry: CompositeSymEntry = toCompositeSymEntry(entry);
@@ -127,9 +127,9 @@ module SegmentedMsg {
   * Procedure to access the Segments of a Segmented Array
   * This may not be needed once all functionality is moved server side
   **/
-  proc getSAValuesMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+  proc getSAValuesMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
     var repMsg: string = "";
-    var msgArgs = parseMessageArgs(payload, 1);
+    var msgArgs = parseMessageArgs(payload, argSize);
     var name = msgArgs.getValueOf("name"): string;
     var entry = st.tab.getBorrowed(name);
     var compEntry: CompositeSymEntry = toCompositeSymEntry(entry);
@@ -173,9 +173,9 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc getSALengthsMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+  proc getSALengthsMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
     var repMsg: string = "";
-    var msgArgs = parseMessageArgs(payload, 1);
+    var msgArgs = parseMessageArgs(payload, argSize);
     var name = msgArgs.getValueOf("name"): string;
     var entry = st.tab.getBorrowed(name);
     var compEntry: CompositeSymEntry = toCompositeSymEntry(entry);
@@ -218,9 +218,9 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc getSANonEmptyMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+  proc getSANonEmptyMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
     var repMsg: string = "";
-    var msgArgs = parseMessageArgs(payload, 1);
+    var msgArgs = parseMessageArgs(payload, argSize);
     var name = msgArgs.getValueOf("name"): string;
     var entry = st.tab.getBorrowed(name);
     var compEntry: CompositeSymEntry = toCompositeSymEntry(entry);
@@ -271,8 +271,8 @@ module SegmentedMsg {
    * we'll either encapsulate both parts in a single message or do the
    * parsing and offsets construction on the server.
   */
-  proc assembleStringsMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
-    var msgArgs = parseMessageArgs(payload, 2);
+  proc assembleStringsMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    var msgArgs = parseMessageArgs(payload, argSize);
     const offsetsName = msgArgs.getValueOf("offsets");
     const valuesName = msgArgs.getValueOf("values");
     smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
@@ -294,8 +294,8 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc segStrTondarrayMsg(cmd: string, payload: string, st: borrowed SymTab): bytes throws {
-      var msgArgs = parseMessageArgs(payload, 2);
+  proc segStrTondarrayMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): bytes throws {
+      var msgArgs = parseMessageArgs(payload, argSize);
       var entry = getSegString(msgArgs.getValueOf("obj"), st);
       const comp = msgArgs.getValueOf("comp");
       if comp == "offsets" {
@@ -341,9 +341,9 @@ module SegmentedMsg {
        return arrayBytes;
     }
 
-  proc randomStringsMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+  proc randomStringsMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
       var pn = Reflection.getRoutineName();
-      var msgArgs = parseMessageArgs(payload, 6);
+      var msgArgs = parseMessageArgs(payload, argSize);
       const dist = msgArgs.getValueOf("dist");
       const len = msgArgs.get("size").getIntValue();
       const charset = str2CharSet(msgArgs.getValueOf("chars"));
@@ -379,10 +379,10 @@ module SegmentedMsg {
       return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc segmentLengthsMsg(cmd: string, payload: string, 
+  proc segmentLengthsMsg(cmd: string, payload: string, argSize: int,
                                           st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
-    var msgArgs = parseMessageArgs(payload, 2);
+    var msgArgs = parseMessageArgs(payload, argSize);
     const objtype = msgArgs.getValueOf("objType");
     const name = msgArgs.getValueOf("obj");
 
@@ -413,10 +413,10 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc caseChangeMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+  proc caseChangeMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    var msgArgs = parseMessageArgs(payload, 3);
+    var msgArgs = parseMessageArgs(payload, argSize);
     const subcmd = msgArgs.getValueOf("subcmd");
     const objtype = msgArgs.getValueOf("objType");
     const name = msgArgs.getValueOf("obj");
@@ -464,10 +464,10 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc checkCharsMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+  proc checkCharsMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    var msgArgs = parseMessageArgs(payload, 3);
+    var msgArgs = parseMessageArgs(payload, argSize);
     const subcmd = msgArgs.getValueOf("subcmd");
     const objtype = msgArgs.getValueOf("objType");
     const name = msgArgs.getValueOf("obj");
@@ -512,10 +512,10 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc segmentedSearchMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+  proc segmentedSearchMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
       var pn = Reflection.getRoutineName();
       var repMsg: string;
-      var msgArgs = parseMessageArgs(payload, 4);
+      var msgArgs = parseMessageArgs(payload, argSize);
       const objtype = msgArgs.getValueOf("objType");
       const name = msgArgs.getValueOf("obj");
       const valtype = msgArgs.getValueOf("valType");
@@ -560,10 +560,10 @@ module SegmentedMsg {
     }
   }
 
-  proc segmentedFindLocMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+  proc segmentedFindLocMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    var msgArgs = parseMessageArgs(payload, 4);
+    var msgArgs = parseMessageArgs(payload, argSize);
     const objtype = msgArgs.getValueOf("objType");
     const name = msgArgs.getValueOf("parent_name");
     const groupNum = msgArgs.get("groupNum").getIntValue();
@@ -622,10 +622,10 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc segmentedFindAllMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+  proc segmentedFindAllMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    var msgArgs = parseMessageArgs(payload, 7);
+    var msgArgs = parseMessageArgs(payload, argSize);
     const objtype = msgArgs.getValueOf("objType");
     const name = msgArgs.getValueOf("parent_name");
     const numMatchesName = msgArgs.getValueOf("num_matches");
@@ -690,10 +690,10 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc segmentedSubMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+  proc segmentedSubMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    var msgArgs = parseMessageArgs(payload, 6);
+    var msgArgs = parseMessageArgs(payload, argSize);
     const objtype = msgArgs.getValueOf("objType");
     const name = msgArgs.getValueOf("obj");
     const repl = msgArgs.getValueOf("repl");
@@ -729,11 +729,11 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc segmentedStripMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+  proc segmentedStripMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
 
-    var msgArgs = parseMessageArgs(payload, 3);
+    var msgArgs = parseMessageArgs(payload, argSize);
     var objtype = msgArgs.getValueOf("objType");
     var name = msgArgs.getValueOf("name");
 
@@ -762,10 +762,10 @@ module SegmentedMsg {
     return (leftEntry.name, rightEntry.name);
   }
 
-  proc segmentedPeelMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+  proc segmentedPeelMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    var msgArgs = parseMessageArgs(payload, 10);
+    var msgArgs = parseMessageArgs(payload, argSize);
     const subcmd = msgArgs.getValueOf("subcmd");
     const objtype = msgArgs.getValueOf("objType");
     const name = msgArgs.getValueOf("obj");
@@ -859,10 +859,10 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc segmentedHashMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+  proc segmentedHashMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    var msgArgs = parseMessageArgs(payload, 2);
+    var msgArgs = parseMessageArgs(payload, argSize);
     const objtype = msgArgs.getValueOf("objType");
     const name = msgArgs.getValueOf("obj");
 
@@ -903,12 +903,12 @@ module SegmentedMsg {
    * 2. sliceIndex : segSliceIndex
    * 3. pdarrayIndex : segPdarrayIndex
   */ 
-  proc segmentedIndexMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+  proc segmentedIndexMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
     // 'subcmd' is the type of indexing to perform
     // 'objtype' is the type of segmented array
-    var msgArgs = parseMessageArgs(payload, 4);
+    var msgArgs = parseMessageArgs(payload, argSize);
     const subcmd = msgArgs.getValueOf("subcmd");
     const objtype = msgArgs.getValueOf("objType");
     const name = msgArgs.getValueOf("obj");
@@ -1105,11 +1105,11 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc segBinopvvMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+  proc segBinopvvMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
 
-    var msgArgs = parseMessageArgs(payload, 7);
+    var msgArgs = parseMessageArgs(payload, argSize);
     const op = msgArgs.getValueOf("op");
     const ltype = msgArgs.getValueOf("objType");
     const leftName = msgArgs.getValueOf("obj");
@@ -1169,10 +1169,10 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc segBinopvsMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+  proc segBinopvsMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
       var pn = Reflection.getRoutineName();
       var repMsg: string;
-      var msgArgs = parseMessageArgs(payload, 5);
+      var msgArgs = parseMessageArgs(payload, argSize);
       const op = msgArgs.getValueOf("op");
       const objtype = msgArgs.getValueOf("objType");
       const name = msgArgs.getValueOf("obj");
@@ -1215,10 +1215,10 @@ module SegmentedMsg {
       return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc segIn1dMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+  proc segIn1dMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
       var pn = Reflection.getRoutineName();
       var repMsg: string;
-      var msgArgs = parseMessageArgs(payload, 5);
+      var msgArgs = parseMessageArgs(payload, argSize);
       const mainObjtype = msgArgs.getValueOf("objType");
       const mainName = msgArgs.getValueOf("obj");
       const testObjtype = msgArgs.getValueOf("otherType");
@@ -1250,9 +1250,9 @@ module SegmentedMsg {
       return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc segGroupMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+  proc segGroupMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
       var pn = Reflection.getRoutineName();
-      var msgArgs = parseMessageArgs(payload, 2);
+      var msgArgs = parseMessageArgs(payload, argSize);
       const objtype = msgArgs.getValueOf("objType");
       const name = msgArgs.getValueOf("obj");
 
@@ -1278,8 +1278,8 @@ module SegmentedMsg {
       return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc stringsToJSONMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
-    var msgArgs = parseMessageArgs(payload, 1);
+  proc stringsToJSONMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    var msgArgs = parseMessageArgs(payload, argSize);
     var strings = getSegString(msgArgs.getValueOf("name"), st);
     var size = strings.size;
     var rtn: [0..#size] string;

--- a/src/SequenceMsg.chpl
+++ b/src/SequenceMsg.chpl
@@ -22,9 +22,9 @@ module SequenceMsg {
 
     :returns: MsgTuple
     */
-    proc arangeMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc arangeMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, 3);
+        var msgArgs = parseMessageArgs(payload, argSize);
         var start = msgArgs.get("start").getIntValue();
         var stop = msgArgs.get("stop").getIntValue();
         var stride = msgArgs.get("stride").getIntValue();
@@ -69,9 +69,9 @@ module SequenceMsg {
 
     :returns: MsgTuple
     */
-    proc linspaceMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc linspaceMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, 3);
+        var msgArgs = parseMessageArgs(payload, argSize);
         var start = msgArgs.get("start").getRealValue();
         var stop = msgArgs.get("stop").getRealValue();
         var len = msgArgs.get("len").getIntValue();

--- a/src/SortMsg.chpl
+++ b/src/SortMsg.chpl
@@ -27,10 +27,10 @@ module SortMsg
     }
 
     /* sort takes pdarray and returns a sorted copy of the array */
-    proc sortMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc sortMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
       param pn = Reflection.getRoutineName();
       var repMsg: string; // response message
-      var msgArgs = parseMessageArgs(payload, 2);
+      var msgArgs = parseMessageArgs(payload, argSize);
       const algoName = msgArgs.getValueOf("alg");
       const name = msgArgs.getValueOf("array");
       var algorithm: SortingAlgorithm = defaultSortAlgorithm;

--- a/src/StatsMsg.chpl
+++ b/src/StatsMsg.chpl
@@ -15,10 +15,10 @@ module StatsMsg {
     private config const logLevel = ServerConfig.logLevel;
     const sLogger = new Logger(logLevel);
 
-    proc meanMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc meanMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string;
-        var args = parseMessageArgs(payload, 1);
+        var args = parseMessageArgs(payload, argSize);
 
         var x: borrowed GenSymEntry = getGenericTypedArrayEntry(args.getValueOf("x"), st);
 
@@ -45,10 +45,10 @@ module StatsMsg {
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 
-    proc varMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc varMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string;
-        var args = parseMessageArgs(payload, 2);
+        var args = parseMessageArgs(payload, argSize);
 
         var ddof = args.get("ddof").getIntValue();
         var x: borrowed GenSymEntry = getGenericTypedArrayEntry(args.getValueOf("x"), st);
@@ -76,10 +76,10 @@ module StatsMsg {
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 
-    proc stdMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc stdMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string;
-        var args = parseMessageArgs(payload, 2);
+        var args = parseMessageArgs(payload, argSize);
 
         var ddof = args.get("ddof").getIntValue();
         var x: borrowed GenSymEntry = getGenericTypedArrayEntry(args.getValueOf("x"), st);
@@ -107,10 +107,10 @@ module StatsMsg {
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 
-    proc covMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc covMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string;
-        var args = parseMessageArgs(payload, 2);
+        var args = parseMessageArgs(payload, argSize);
 
         var x: borrowed GenSymEntry = getGenericTypedArrayEntry(args.getValueOf("x"), st);
         var y: borrowed GenSymEntry = getGenericTypedArrayEntry(args.getValueOf("y"), st);
@@ -206,9 +206,9 @@ module StatsMsg {
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 
-    proc corrMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc corrMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
-        var args = parseMessageArgs(payload, 2);
+        var args = parseMessageArgs(payload, argSize);
 
         var x: borrowed GenSymEntry = getGenericTypedArrayEntry(args.getValueOf("x"), st);
         var y: borrowed GenSymEntry = getGenericTypedArrayEntry(args.getValueOf("y"), st);
@@ -277,9 +277,9 @@ module StatsMsg {
         }
     }
 
-    proc corrMatrixMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+    proc corrMatrixMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
-        var args = parseMessageArgs(payload, 3);
+        var args = parseMessageArgs(payload, argSize);
 
         var size = args.get("size").getIntValue();
         var columns = args.get("columns").getList(size);

--- a/src/TimeClassMsg.chpl
+++ b/src/TimeClassMsg.chpl
@@ -38,8 +38,8 @@ module TimeClassMsg {
 
     const UNITS = ["nanosecond", "microsecond", "millisecond", "second", "minute", "hour", "day"];
 
-    proc dateTimeAttributesMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
-        var values: borrowed GenSymEntry = getGenericTypedArrayEntry(parseMessageArgs(payload, 1).getValueOf("values"), st);
+    proc dateTimeAttributesMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+        var values: borrowed GenSymEntry = getGenericTypedArrayEntry(parseMessageArgs(payload, argSize).getValueOf("values"), st);
         var valuesEntry = toSymEntry(values, int);
         var attributesDict = simpleAttributesHelper(valuesEntry.a, st);
 
@@ -90,8 +90,8 @@ module TimeClassMsg {
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 
-    proc timeDeltaAttributesMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
-        var values: borrowed GenSymEntry = getGenericTypedArrayEntry(parseMessageArgs(payload, 1).getValueOf("values"), st);
+    proc timeDeltaAttributesMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+        var values: borrowed GenSymEntry = getGenericTypedArrayEntry(parseMessageArgs(payload, argSize).getValueOf("values"), st);
         var repMsg: string = "%jt".format(simpleAttributesHelper(toSymEntry(values, int).a, st));
 
         tLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -65,8 +65,8 @@ module UniqueMsg
       return skipSortHelper(2*uint(64), hashArrays(size, names, types, st));
     }
 
-    proc uniqueMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
-        var msgArgs = parseMessageArgs(payload, 5);
+    proc uniqueMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+        var msgArgs = parseMessageArgs(payload, argSize);
         // flag to return segments and permutation for GroupBy
         const returnGroups = msgArgs.get("returnGroupStr").getBoolValue();
         const assumeSorted = msgArgs.get("assumeSortedStr").getBoolValue();

--- a/tests/registration_test.py
+++ b/tests/registration_test.py
@@ -403,17 +403,17 @@ class RegistrationTest(ArkoudaTest):
         # registered objects are not deleted from symbol table
         a.register("keep")
         self.assertEqual(
-            ak.client.generic_msg(cmd="delete", args=a.name), f"registered symbol, {a.name}, not deleted"
+            ak.client.generic_msg(cmd="delete", args={"name": a.name}), f"registered symbol, {a.name}, not deleted"
         )
         self.assertTrue(a.name in ak.list_symbol_table())
 
         # non-registered objects are deleted from symbol table
-        self.assertEqual(ak.client.generic_msg(cmd="delete", args=b.name), "deleted " + b.name)
+        self.assertEqual(ak.client.generic_msg(cmd="delete", args={"name": b.name}), "deleted " + b.name)
         self.assertTrue(b.name not in ak.list_symbol_table())
 
         # RuntimeError when calling delete on an object not in the symbol table
         with self.assertRaises(RuntimeError):
-            ak.client.generic_msg(cmd="delete", args="not_in_table")
+            ak.client.generic_msg(cmd="delete", args={"name": "not_in_table"})
 
     def test_categorical_registration_suite(self):
         """


### PR DESCRIPTION
Closes #1774 

Due to limitations with `generic` functions when dealing with the message parsing, we are not currently able to send `MessageArgs` objects directly into the functions. This prevents us from pre-parsing the JSON. This PR is intended to simplify parsing of the arguments for the time being.

This updates function in the command map to take the following parameters:
```chapel
proc exampleMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {}
```
Notice the addition of the `argSize` parameter. This parameter indicates the number of parameters in the JSON object. It is sent as part of the message by the client. This prevents the developer from having to manually enter the size. Additionally, this may provide the opportunity for messages with varying parameter numbers in the same message.

This is purely a convenience feature for developers, but simplifies the messaging. 

I know this is a lot of files, but we had to do everything in one shot to avoid issues with message parsing.