### PR TITLE
Closes #1784: Enable `pyzmq>=24.0.0`

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -15,7 +15,7 @@ The following python packages are required by the Arkouda client package.
 - `python>=3.8`
 - `numpy>=1.22.2`
 - `pandas>=1.4.0`
-- `pyzmq>=20.0.0,<24.0.0`
+- `pyzmq>=20.0.0`
 - `typeguard==2.10.0`
 - `tabulate`
 - `pyfiglet`

--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -6,7 +6,7 @@ dependencies:
   - python>=3.8   # minimum 3.8
   - numpy>=1.22.2
   - pandas>=1.4.0
-  - pyzmq>=20.0.0,<24.0.0
+  - pyzmq>=20.0.0
   - tabulate
   - pyfiglet
   - versioneer

--- a/arkouda-env.yml
+++ b/arkouda-env.yml
@@ -6,7 +6,7 @@ dependencies:
   - python>=3.8   # minimum 3.8
   - numpy>=1.22.2
   - pandas>=1.4.0
-  - pyzmq>=20.0.0,<24.0.0
+  - pyzmq>=20.0.0
   - tabulate
   - pyfiglet
   - versioneer

--- a/pydoc/requirements.txt
+++ b/pydoc/requirements.txt
@@ -2,7 +2,7 @@
 python>=3.8
 numpy>=1.22.2
 pandas>=1.4.0
-pyzmq>=20.0.0,<24.0.0
+pyzmq>=20.0.0
 typeguard==2.10.0
 tabulate
 pyfiglet

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ setup(
     install_requires=[
         'numpy>=1.22.2',
         'pandas>=1.4.0',
-        'pyzmq>=20.0.0,<24.0.0',
+        'pyzmq>=20.0.0',
         'typeguard==2.10.0',
         'tabulate',
         'pyfiglet',


### PR DESCRIPTION
This PR (Closes #1784):
- Enable`pyzmq>=24.0.0`

The CI failure with latest version was caused by a failure during the build of the pyzmq wheels. These wheels have been rebuilt, so it *should* work now (we'll know if the CI passes on this PR 😉). See https://github.com/zeromq/pyzmq/issues/1763 for more info