### PR TITLE
Add some subtimers to RadixSortLSD

### DIFF
--- a/src/Timers.chpl
+++ b/src/Timers.chpl
@@ -1,0 +1,37 @@
+use Time, AllLocalesBarriers;
+
+pragma "default intent is ref"
+record enumTimers {
+  type enumT;
+  param enabled = true;
+  var timers: if enabled then [0..<enumT.size] Timer else nothing;
+
+  proc mark(param e: enumT, param barrier=false, timingTask=true) {
+    if enabled {
+      if barrier {
+        allLocalesBarrier.barrier();
+      }
+      if timingTask {
+        ref t = timers[e:int];
+        if t.running then t.stop();
+                     else t.start();
+      }
+    }
+  }
+
+  inline proc writeThis(f) {
+    if enabled {
+      var maxSize = 0;
+      for e in enumT do
+        maxSize = max(maxSize, (e:string).size);
+      for e in enumT do
+        f.write("%s %s: %.2drs\n".format(e, (maxSize-(e:string).size)*" ", timers[e:int].elapsed()));
+    }
+  }
+
+  inline proc clear() {
+    if enabled {
+      timers.clear();
+    }
+  }
+}


### PR DESCRIPTION
When doing performance optimizations on sort, it's invaluable to have subtimings to see where time is going. Historically I've maintained branches that keep the timers in them, but I found myself wondering if it's worth adding the timing code more permanently. This prototypes that in a pretty efficient manner that is free when timers are disabled (currently by config param) and relatively cheap when timers are on, though it does add some barriers.)

Previous versions of this code had explicit timers per section, which felt ugly, so this adds an enum-based wrapper. Basically you declare an enum that has a value for each section you want to time and then mark when you want to start/stop timing. This results in efficient timing (just have to index into an array and start a timer) and the print order is defined by the enum order. Other things I tried were a (custom) orderedMap of strings->timers, but this is more error prone (no compile time checking of string values) and expensive (because it either requires string hashing or string comparison in some way.)

That said, I think the orderedMap may have value for cross module timings and non-production code and may be useful to commit for use in future explorations. For an example, see a use case in a previous work: https://github.com/Bears-R-Us/arkouda/pull/1579/files#diff-9831b61e058453cfb3a06ac7460e988d95b1344b6cafa626560133bfc71826ff