### PR TITLE
Closes #1783 - `SegArray.__getitem__` to Server

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -600,7 +600,7 @@ class DataFrame(UserDict):
             elif t == "SegArray":
                 # split creates for segments and values
                 eles = msg[2].split("+")
-                df_dict[msg[1]] = SegArray(create_pdarray(eles[0]), create_pdarray(eles[1]))
+                df_dict[msg[1]] = SegArray.from_parts(create_pdarray(eles[0]), create_pdarray(eles[1]))
             else:
                 df_dict[msg[1]] = create_pdarray(msg[2])
 
@@ -1475,7 +1475,7 @@ class DataFrame(UserDict):
         # update dict to contain segarrays where applicable if any exist
         if len(seg_cols) > 0:
             df_dict = {
-                col: SegArray(df_dict[col + "_segments"], df_dict[col + "_values"])
+                col: SegArray.from_parts(df_dict[col + "_segments"], df_dict[col + "_values"])
                 if col in seg_cols
                 else df_dict[col]
                 for col in df_dict_keys

--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -1173,11 +1173,11 @@ class GroupBy:
         # Values are the unique elements of the values arg
         if len(unique_values) == 1:
             # Squeeze singleton results
-            ret = SegArray(g2.segments, unique_values[0])
+            ret = SegArray.from_parts(g2.segments, unique_values[0])
             if reorder:
                 ret = ret[perm]
         else:
-            ret = [SegArray(g2.segments, uv) for uv in unique_values]  # type: ignore
+            ret = [SegArray.from_parts(g2.segments, uv) for uv in unique_values]  # type: ignore
             if reorder:
                 ret = [r[perm] for r in ret]  # type: ignore
         return self.unique_keys, ret  # type: ignore

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -146,7 +146,7 @@ class SegArray:
         ndim = int(fields[4])
 
         # remove comma from 1 tuple with trailing comma
-        if fields[5][len(fields[5]) - 2] == ",":
+        if fields[5][-2] == ",":
             fields[5] = fields[5].replace(",", "")
         shape = [int(el) for el in fields[5][1:-1].split(",")]
         itemsize = int(fields[6])
@@ -206,7 +206,7 @@ class SegArray:
         return cls.from_return_msg(rep_msg, lengths, grouping)
 
     @classmethod
-    def from_attach_return_msg(cls, repMsg) -> SegArray:
+    def _from_attach_return_msg(cls, repMsg) -> SegArray:
         """
         Return a SegArray instance pointing to components created by the arkouda server.
         The user should not call this function directly.
@@ -214,7 +214,7 @@ class SegArray:
         Parameters
         ----------
         repMsg : str
-            ; delimited string containing the segments, values, and lengths details
+            + delimited string containing the segments, values, and lengths details
 
         Returns
         -------
@@ -464,7 +464,7 @@ class SegArray:
             )
             return SegArray.from_return_msg(repMsg)
         else:
-            raise TypeError(f"unsupported pdarray index type {i.__class__.__name__}")
+            raise TypeError(f"unsupported segarray index type {i.__class__.__name__}")
 
     def __eq__(self, other):
         if not isinstance(other, SegArray):

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -102,7 +102,7 @@ class SegArray:
         # references to supporting pdarrays
         self.values = values
         self.segments = segments
-        self._valsize = None  # cache - use .valsize to access/set
+        self.valsize = values.size
 
         """
         Note - if lengths is provided, it will need to be sent to the
@@ -276,64 +276,6 @@ class SegArray:
     def objtype(self):
         return self.objtype
 
-    # @property
-    # def segments(self):
-    #     """
-    #      Return the pdarray containing the segments.
-    #      This is configured to prevent the need to move all functionality to server at once.
-    #
-    #      Notes
-    #     ------
-    #     - Caches return value to prevent the need to recompute.
-    #     """
-    #     if self._segments is None:
-    #         rep_msg = generic_msg(
-    #             cmd="segArr-getSegments",
-    #             args={
-    #                 "name": self.name,
-    #             },
-    #         )
-    #         self._segments = create_pdarray(rep_msg)
-    #     return self._segments
-    #
-    # @property
-    # def values(self):
-    #     """
-    #     Return the pdarray containing the values of the segarray.
-    #     This is configured to prevent the need to move all functionality to server at once.
-    #
-    #     Notes
-    #     ------
-    #     - Caches return value to prevent the need to recompute.
-    #     """
-    #     if self._values is None:
-    #         rep_msg = generic_msg(
-    #             cmd="segArr-getValues",
-    #             args={
-    #                 "name": self.name,
-    #             },
-    #         )
-    #         self._values = (
-    #             Strings.from_return_msg(rep_msg)
-    #             if rep_msg.split()[2] == "str"
-    #             else create_pdarray(rep_msg)
-    #         )
-    #     return self._values
-
-    @property
-    def valsize(self):
-        """
-        Return the size of the values array.
-        This is configured to prevent the need to move all functionality to server at once.
-
-        Notes
-        ------
-        - Caches return value to prevent the need to recompute.
-        """
-        if self._valsize is None:
-            self._valsize = self.values.size
-        return self._valsize
-
     @property
     def lengths(self):
         """
@@ -463,7 +405,6 @@ class SegArray:
                 "Supported values for axis are 0 (vertical concat) or 1 (horizontal concat)"
             )
 
-    # TODO - make sure this works as a deep copy still
     def copy(self):
         """
         Return a deep copy.

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -253,24 +253,17 @@ class SegArray:
             Array of rows of input
         """
         if isinstance(m, pdarray):
-            size = m.size
-            n = 1
-            dtype = m.dtype
+            return cls.from_parts(arange(m.size), m)
         else:
-            s = set(mi.size for mi in m)
-            if len(s) != 1:
-                raise ValueError("All columns must have same length")
-            size = s.pop()
+            sd = set((mi.size, mi.dtype) for mi in m)
+            if len(sd) != 1:
+                raise ValueError("All columns must have same length and dtype")
+            size, dtype = sd.pop()
             n = len(m)
-            d = set(mi.dtype for mi in m)
-            if len(d) != 1:
-                raise ValueError("All columns must have same dtype")
-            dtype = d.pop()
-        newsegs = arange(size) * n
-        newvals = zeros(size * n, dtype=dtype)
-        for j in range(len(m)):
-            newvals[j :: len(m)] = m[j]
-        return cls.from_parts(newsegs, newvals)
+            newvals = zeros(size * n, dtype=dtype)
+            for j in range(n):
+                newvals[j:: n] = m[j]
+            return cls.from_parts(arange(size) * n, newvals)
 
     @property
     def objtype(self):

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+from typing import cast as type_cast
 from warnings import warn
 
 import numpy as np  # type: ignore
@@ -8,14 +10,14 @@ from arkouda import objtypedec
 from arkouda.client import generic_msg
 from arkouda.dtypes import bool as akbool
 from arkouda.dtypes import int64 as akint64
-from arkouda.dtypes import isSupportedInt, str_
+from arkouda.dtypes import isSupportedInt, str_, translate_np_dtype
 from arkouda.groupbyclass import GroupBy, broadcast
+from arkouda.logger import getArkoudaLogger
 from arkouda.numeric import cumsum
 from arkouda.pdarrayclass import attach_pdarray, create_pdarray, is_sorted, pdarray
 from arkouda.pdarraycreation import arange, array, ones, zeros
 from arkouda.pdarrayIO import load
 from arkouda.pdarraysetops import concatenate
-from arkouda.strings import Strings
 
 
 def gen_ranges(starts, ends, stride=1):
@@ -76,11 +78,90 @@ def _aggregator(func):
     return update_doc
 
 
+def segarray(segments: pdarray, values: pdarray, lengths=None, grouping=None):
+    """
+    Alias for the from_parts function. Prevents user from needing to call `ak.SegArray.from_parts`
+    """
+    return SegArray.from_parts(segments, values, lengths, grouping)
+
+
 @objtypedec
 class SegArray:
-    def __init__(self, segments, values, copy=False, lengths=None, grouping=None):
+    def __init__(
+        self, name, dtype, size, ndim, shape, itemsize, segments, values, lengths=None, grouping=None
+    ):
+        self.name = name
+        self.dtype = dtype
+        self.size = size
+        self.ndim = ndim
+        self.shape = shape
+        self.itemsize = itemsize
+
+        self.logger = getArkoudaLogger(name=__class__.__name__)  # type: ignore
+
+        # references to supporting pdarrays
+        self.values = values
+        self.segments = segments
+        self._valsize = None  # cache - use .valsize to access/set
+
         """
-        An array of variable-length arrays, also called a skyline array or ragged array.
+        Note - if lengths is provided, it will need to be sent to the
+        server in the future (or deprecated).
+        Since no computation is currently done on the server,
+        we will not be sending lengths right now
+        """
+        self._lengths = lengths  # cache - use .lengths to access/set. If passed, do not recompute
+        # the following is to maintain support for lengths being passed in
+        # (since not currently passed to server)
+        if self._lengths is not None:
+            self._non_empty = lengths > 0
+            self._non_empty_count = self._non_empty.sum()
+        else:
+            self._non_empty = None  # cache - use .non_empty to access/set
+            self._non_empty_count = None  # cache - use .non_empty_count to access/set
+
+        # grouping object computation. (This will need to be moved to the server)
+        # GroupBy computation left here because of lack of server obj. May need to move in Future
+        if grouping is None:
+            if self.size == 0 or self.non_empty_count == 0:
+                self.grouping = GroupBy(zeros(0, dtype=akint64))
+            else:
+                # Treat each sub-array as a group, for grouped aggregations
+                self.grouping = GroupBy(
+                    broadcast(self.segments[self.non_empty], arange(self.non_empty_count), self.valsize)
+                )
+        else:
+            self.grouping = grouping
+
+    @classmethod
+    def from_return_msg(cls, rep_msg, lengths=None, grouping=None) -> SegArray:
+        # parse return json
+        eles = json.loads(rep_msg)
+
+        # parse the create statement for segarray
+        fields = eles["segarray"].split()
+        name = fields[1]
+        dtype = fields[2]
+        size = int(fields[3])
+        ndim = int(fields[4])
+
+        # remove comma from 1 tuple with trailing comma
+        if fields[5][len(fields[5]) - 2] == ",":
+            fields[5] = fields[5].replace(",", "")
+        shape = [int(el) for el in fields[5][1:-1].split(",")]
+        itemsize = int(fields[6])
+
+        # parse the create for the values pdarray
+        values = create_pdarray(eles["values"])
+        segments = create_pdarray(eles["segments"])
+        lengths = create_pdarray(eles["lengths"]) if lengths is None else lengths
+
+        return cls(name, dtype, size, ndim, shape, itemsize, segments, values, lengths, grouping)
+
+    @classmethod
+    def from_parts(cls, segments, values, lengths=None, grouping=None) -> SegArray:
+        """
+        Construct a SegArray object from its parts
 
         Parameters
         ----------
@@ -88,9 +169,10 @@ class SegArray:
             Start index of each sub-array in the flattened values array
         values : pdarray
             The flattened values of all sub-arrays
-        copy : bool (Deprecated)
-            If True, make a copy of the input arrays; otherwise, just store a reference.
-            Moving the object to the server has resulted in this being deprecated.
+        lengths: pdarray
+            The length of each segment
+        grouping: GroupBy
+            grouping of segments
 
         Returns
         -------
@@ -121,104 +203,122 @@ class SegArray:
                 "values": values,
             },
         )
+        return cls.from_return_msg(rep_msg, lengths, grouping)
 
-        try:
-            # parse the return message from building the server object
-            fields = rep_msg.split()
-            self.name = fields[1]
-            self.dtype = fields[2]
-            self.size = int(fields[3])
-            self.ndim = int(fields[4])
-
-            # remove comma from 1 tuple with trailing comma
-            if fields[5][len(fields[5]) - 2] == ",":
-                fields[5] = fields[5].replace(",", "")
-            self.shape = [int(el) for el in fields[5][1:-1].split(",")]
-            self.itemsize = int(fields[6])
-        except Exception as e:
-            raise ValueError(e)
-
-        # Caching vars until all functionality is moved to server - these probably won't be
-        # needed once all functionality is moved to the server
-        self._values = None  # cache - use .values to access/set
-        self._segments = None  # cache - use .segments to access/set
-        self._valsize = None  # cache - use .valsize to access/set
+    @classmethod
+    def from_attach_return_msg(cls, repMsg) -> SegArray:
         """
-        Note - if lengths is provided, it will need to be sent to the
-        server in the future (or deprecated).
-        Since no computation is currently done on the server,
-        we will not be sending lengths right now
-        """
-        self._lengths = lengths  # cache - use .lengths to access/set. If passed, do not recompute
-        # the following is to maintain support for lengths being passed in
-        # (since not currently passed to server)
-        if self._lengths is not None:
-            self._non_empty = lengths > 0
-            self._non_empty_count = self._non_empty.sum()
-        else:
-            self._non_empty = None  # cache - use .non_empty to access/set
-            self._non_empty_count = None  # cache - use .non_empty_count to access/set
+        Return a SegArray instance pointing to components created by the arkouda server.
+        The user should not call this function directly.
 
-        # grouping object computation. (This will need to be moved to the server)
-        # GroupBy computation left here because of lack of server obj. May need to move in Future
-        if grouping is None:
-            if self.size == 0 or self.non_empty_count == 0:
-                self.grouping = GroupBy(zeros(0, dtype=akint64))
-            else:
-                # Treat each sub-array as a group, for grouped aggregations
-                self.grouping = GroupBy(
-                    broadcast(self.segments[self.non_empty], arange(self.non_empty_count), self.valsize)
-                )
+        Parameters
+        ----------
+        repMsg : str
+            ; delimited string containing the segments, values, and lengths details
+
+        Returns
+        -------
+        SegArray
+            A SegArray representing a set of pdarray components on the server
+
+        Raises
+        ------
+        RuntimeError
+            Raised if a server-side error is thrown in the process of creating
+            the categorical instance
+        """
+        # parts[0] is "segarray". Used by the generic attach method to identify the
+        # response message as a SegArray
+        parts = repMsg.split("+")
+        segments = create_pdarray(parts[1])
+        values = create_pdarray(parts[2])
+        lengths = create_pdarray(parts[3])
+
+        return cls(segments, values, lengths=lengths)
+
+    @classmethod
+    def from_multi_array(cls, m):
+        """
+        Construct a SegArray from a list of columns. This essentially transposes the input,
+        resulting in an array of rows.
+
+        Parameters
+        ----------
+        m : list of pdarray
+            List of columns, the rows of which will form the sub-arrays of the output
+
+        Returns
+        -------
+        SegArray
+            Array of rows of input
+        """
+        if isinstance(m, pdarray):
+            size = m.size
+            n = 1
+            dtype = m.dtype
         else:
-            self.grouping = grouping
+            s = set(mi.size for mi in m)
+            if len(s) != 1:
+                raise ValueError("All columns must have same length")
+            size = s.pop()
+            n = len(m)
+            d = set(mi.dtype for mi in m)
+            if len(d) != 1:
+                raise ValueError("All columns must have same dtype")
+            dtype = d.pop()
+        newsegs = arange(size) * n
+        newvals = zeros(size * n, dtype=dtype)
+        for j in range(len(m)):
+            newvals[j :: len(m)] = m[j]
+        return cls.from_parts(newsegs, newvals)
 
     @property
     def objtype(self):
         return self.objtype
 
-    @property
-    def segments(self):
-        """
-         Return the pdarray containing the segments.
-         This is configured to prevent the need to move all functionality to server at once.
-
-         Notes
-        ------
-        - Caches return value to prevent the need to recompute.
-        """
-        if self._segments is None:
-            rep_msg = generic_msg(
-                cmd="segArr-getSegments",
-                args={
-                    "name": self.name,
-                },
-            )
-            self._segments = create_pdarray(rep_msg)
-        return self._segments
-
-    @property
-    def values(self):
-        """
-        Return the pdarray containing the values of the segarray.
-        This is configured to prevent the need to move all functionality to server at once.
-
-        Notes
-        ------
-        - Caches return value to prevent the need to recompute.
-        """
-        if self._values is None:
-            rep_msg = generic_msg(
-                cmd="segArr-getValues",
-                args={
-                    "name": self.name,
-                },
-            )
-            self._values = (
-                Strings.from_return_msg(rep_msg)
-                if rep_msg.split()[2] == "str"
-                else create_pdarray(rep_msg)
-            )
-        return self._values
+    # @property
+    # def segments(self):
+    #     """
+    #      Return the pdarray containing the segments.
+    #      This is configured to prevent the need to move all functionality to server at once.
+    #
+    #      Notes
+    #     ------
+    #     - Caches return value to prevent the need to recompute.
+    #     """
+    #     if self._segments is None:
+    #         rep_msg = generic_msg(
+    #             cmd="segArr-getSegments",
+    #             args={
+    #                 "name": self.name,
+    #             },
+    #         )
+    #         self._segments = create_pdarray(rep_msg)
+    #     return self._segments
+    #
+    # @property
+    # def values(self):
+    #     """
+    #     Return the pdarray containing the values of the segarray.
+    #     This is configured to prevent the need to move all functionality to server at once.
+    #
+    #     Notes
+    #     ------
+    #     - Caches return value to prevent the need to recompute.
+    #     """
+    #     if self._values is None:
+    #         rep_msg = generic_msg(
+    #             cmd="segArr-getValues",
+    #             args={
+    #                 "name": self.name,
+    #             },
+    #         )
+    #         self._values = (
+    #             Strings.from_return_msg(rep_msg)
+    #             if rep_msg.split()[2] == "str"
+    #             else create_pdarray(rep_msg)
+    #         )
+    #     return self._values
 
     @property
     def valsize(self):
@@ -294,42 +394,6 @@ class SegArray:
         return self._non_empty_count
 
     @classmethod
-    def from_multi_array(cls, m):
-        """
-        Construct a SegArray from a list of columns. This essentially transposes the input,
-        resulting in an array of rows.
-
-        Parameters
-        ----------
-        m : list of pdarray
-            List of columns, the rows of which will form the sub-arrays of the output
-
-        Returns
-        -------
-        SegArray
-            Array of rows of input
-        """
-        if isinstance(m, pdarray):
-            size = m.size
-            n = 1
-            dtype = m.dtype
-        else:
-            s = set(mi.size for mi in m)
-            if len(s) != 1:
-                raise ValueError("All columns must have same length")
-            size = s.pop()
-            n = len(m)
-            d = set(mi.dtype for mi in m)
-            if len(d) != 1:
-                raise ValueError("All columns must have same dtype")
-            dtype = d.pop()
-        newsegs = arange(size) * n
-        newvals = zeros(size * n, dtype=dtype)
-        for j in range(len(m)):
-            newvals[j :: len(m)] = m[j]
-        return cls(newsegs, newvals)
-
-    @classmethod
     def concat(cls, x, axis=0, ordered=True):
         """
         Concatenate a sequence of SegArrays
@@ -399,57 +463,67 @@ class SegArray:
                 "Supported values for axis are 0 (vertical concat) or 1 (horizontal concat)"
             )
 
-    @staticmethod
-    def from_return_msg(repMsg) -> SegArray:
-        """
-        Return a SegArray instance pointing to components created by the arkouda server.
-        The user should not call this function directly.
-
-        Parameters
-        ----------
-        repMsg : str
-            ; delimited string containing the segments, values, and lengths details
-
-        Returns
-        -------
-        SegArray
-            A SegArray representing a set of pdarray components on the server
-
-        Raises
-        ------
-        RuntimeError
-            Raised if a server-side error is thrown in the process of creating
-            the categorical instance
-        """
-        # parts[0] is "segarray". Used by the generic attach method to identify the
-        # response message as a SegArray
-        parts = repMsg.split("+")
-        segments = create_pdarray(parts[1])
-        values = create_pdarray(parts[2])
-        lengths = create_pdarray(parts[3])
-
-        return SegArray(segments, values, lengths=lengths)
-
+    # TODO - make sure this works as a deep copy still
     def copy(self):
         """
         Return a deep copy.
         """
-        return SegArray(self.segments, self.values, copy=True)
+        return SegArray.from_parts(self.segments, self.values)
 
     def __getitem__(self, i):
         if isSupportedInt(i):
-            start = self.segments[i]
-            end = self.segments[i] + self.lengths[i]
-            return self.values[start:end].to_ndarray()
-        elif (isinstance(i, pdarray) and (i.dtype == akint64 or i.dtype == akbool)) or isinstance(
-            i, slice
-        ):
-            starts = self.segments[i]
-            ends = starts + self.lengths[i]
-            newsegs, inds = gen_ranges(starts, ends)
-            return SegArray(newsegs, self.values[inds], copy=True)
+            orig_key = i  # used for error message if out of bounds on negative index
+            # interpret -i as offset from end of array
+            if i < 0:
+                i += self.size
+
+            if i >= 0 and i < self.size:
+                repMsg = generic_msg(
+                    cmd="segmentedIndex",
+                    args={
+                        "subcmd": "intIndex",
+                        "objType": self.objtype,
+                        "dtype": self.dtype,
+                        "obj": self.name,
+                        "key": i,
+                    },
+                )
+                return create_pdarray(type_cast(str, repMsg)).to_ndarray()
+            else:
+                raise IndexError(f"[int] {orig_key} is out of bounds with size {self.size}")
+        elif isinstance(i, slice):
+            (start, stop, stride) = i.indices(self.size)
+            self.logger.debug(f"start: {start}; stop: {stop}; stride: {stride}")
+            repMsg = generic_msg(
+                cmd="segmentedIndex",
+                args={
+                    "subcmd": "sliceIndex",
+                    "objType": self.objtype,
+                    "obj": self.name,
+                    "dtype": self.dtype,
+                    "key": [start, stop, stride],
+                },
+            )
+            return SegArray.from_return_msg(repMsg)
+        elif isinstance(i, pdarray):
+            kind, _ = translate_np_dtype(i.dtype)
+            if kind not in ("bool", "int", "uint"):
+                raise TypeError(f"unsupported pdarray index type {i.dtype}")
+            if kind == "bool" and self.size != i.size:
+                raise ValueError(f"size mismatch {self.size} {i.size}")
+            repMsg = generic_msg(
+                cmd="segmentedIndex",
+                args={
+                    "subcmd": "pdarrayIndex",
+                    "objType": self.objtype,
+                    "dtype": self.values.dtype,
+                    "obj": self.name,
+                    "key": i,
+                },
+            )
+            return SegArray.from_return_msg(repMsg)
         else:
-            raise TypeError(f"Invalid index type: {type(i)}")
+            raise TypeError(f"unsupported pdarray index type {i.__class__.__name__}")
 
     def __eq__(self, other):
         if not isinstance(other, SegArray):

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -292,7 +292,13 @@ class Strings:
             if key >= 0 and key < self.size:
                 repMsg = generic_msg(
                     cmd="segmentedIndex",
-                    args={"subcmd": "intIndex", "objType": self.objtype, "obj": self.entry, "key": key},
+                    args={
+                        "subcmd": "intIndex",
+                        "objType": self.objtype,
+                        "dtype": self.entry.dtype,
+                        "obj": self.entry,
+                        "key": key,
+                    },
                 )
                 _, value = repMsg.split(maxsplit=1)
                 return parse_single_value(value)
@@ -307,6 +313,7 @@ class Strings:
                     "subcmd": "sliceIndex",
                     "objType": self.objtype,
                     "obj": self.entry,
+                    "dtype": self.entry.dtype,
                     "key": [start, stop, stride],
                 },
             )
@@ -319,7 +326,13 @@ class Strings:
                 raise ValueError(f"size mismatch {self.size} {key.size}")
             repMsg = generic_msg(
                 cmd="segmentedIndex",
-                args={"subcmd": "pdarrayIndex", "objType": self.objtype, "obj": self.entry, "key": key},
+                args={
+                    "subcmd": "pdarrayIndex",
+                    "objType": self.objtype,
+                    "dtype": self.entry.dtype,
+                    "obj": self.entry,
+                    "key": key,
+                },
             )
             return Strings.from_return_msg(repMsg)
         else:

--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -286,7 +286,7 @@ def attach(name: str, dtype: str = "infer"):
     if repMsg.split("+")[0] == "categorical":
         return Categorical.from_return_msg(repMsg)
     elif repMsg.split("+")[0] == "segarray":
-        return SegArray.from_return_msg(repMsg)
+        return SegArray.from_attach_return_msg(repMsg)
     elif repMsg.split("+")[0] == "series":
         from arkouda.series import Series
 

--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -286,7 +286,7 @@ def attach(name: str, dtype: str = "infer"):
     if repMsg.split("+")[0] == "categorical":
         return Categorical.from_return_msg(repMsg)
     elif repMsg.split("+")[0] == "segarray":
-        return SegArray.from_attach_return_msg(repMsg)
+        return SegArray._from_attach_return_msg(repMsg)
     elif repMsg.split("+")[0] == "series":
         from arkouda.series import Series
 

--- a/benchmarks/dataframe.py
+++ b/benchmarks/dataframe.py
@@ -32,7 +32,7 @@ def generate_dataframe(N, seed):
         elif d == ak.Strings:
             df_dict[key] = ak.random_strings_uniform(minlen=5, maxlen=6, size=N, seed=seed)
         elif d == ak.SegArray:
-            df_dict[key] = ak.SegArray(
+            df_dict[key] = ak.segarray(
                 ak.arange(0, N * 5, 5), ak.array(np.random.randint(0, 2**32, N * 5))
             )
     return ak.DataFrame(df_dict)

--- a/src/DataFrameIndexingMsg.chpl
+++ b/src/DataFrameIndexingMsg.chpl
@@ -122,7 +122,7 @@
                     // When smallIdx is set to true, some localization work will
                     // be skipped and a localizing slice will instead be done,
                     // which can perform better by avoiding those overhead costs.
-                    var repTup = segPdarrayIndex("str", categories_name, idxCodeName, st, smallIdx=true);
+                    var repTup = segPdarrayIndex("str", categories_name, idxCodeName, DType.UInt8, st, smallIdx=true);
                     
                     if repTup.msgType == MsgType.ERROR {
                         throw new IllegalArgumentError(repTup.msg);
@@ -135,7 +135,7 @@
                     // When smallIdx is set to true, some localization work will
                     // be skipped and a localizing slice will instead be done,
                     // which can perform better by avoiding those overhead costs.
-                    var repTup = segPdarrayIndex("str", ele_parts[2], msgArgs.getValueOf("idx_name"), st, smallIdx=true);
+                    var repTup = segPdarrayIndex("str", ele_parts[2], msgArgs.getValueOf("idx_name"), DType.UInt8,  st, smallIdx=true);
                     
                     if repTup.msgType == MsgType.ERROR {
                         throw new IllegalArgumentError(repTup.msg);

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -7,6 +7,9 @@ module SegmentedArray {
     use Reflection;
     use Logging;
     use ServerErrors;
+    use CommAggregation;
+    use Time only Timer, getCurrentTime;
+    use Map;
 
     private config const logLevel = ServerConfig.logLevel;
     const saLogger = new Logger(logLevel);
@@ -45,26 +48,19 @@ module SegmentedArray {
         var values;
         var size: int;
         var nBytes: int;
+        var lengths: [segments.aD] int;
 
         proc init(entryName:string, entry:borrowed SegArraySymEntry, type eType) {
             name = entryName;
             composite = entry;
             segments = composite.segmentsEntry: shared SymEntry(int);
             values = composite.valuesEntry: shared SymEntry(eType);
+
             
             size = segments.size;
             nBytes = values.size;
 
-            // Note - groupby remaining client side because groupby does not have server side object
-        }
-
-        proc getLengths() {
-            // Format the same as in SegmentedString
-            //Note that this logic may need to move into init when everything move to prevent recompute
-            var lengths: [segments.aD] int;
-            if (size == 0) {
-                return lengths;
-            }
+            lengths = makeDistArray(segments.size, int);
             ref sa = segments.a;
             const low = segments.aD.low;
             const high = segments.aD.high;
@@ -75,16 +71,228 @@ module SegmentedArray {
                     l = sa[i+1] - s;
                 }
             }
-            return lengths;
+
+            // Note - groupby remaining client side because groupby does not have server side object
+        }
+
+        /* Retrieve one string from the array */
+        proc this(idx: ?t) throws where t == int || t == uint {
+            if (idx < segments.aD.low) || (idx > segments.aD.high) {
+                throw new owned OutOfBoundsError();
+            }
+            // Start index of the segment
+            var start: int = segments.a[idx:int];
+            // end index
+            var end: int = if idx:int == segments.aD.high then values.size-1 else segments.a[idx:int+1]-1;
+            return values.a[start..end];
+        }
+
+        proc this(const slice: range(stridable=false)) throws {
+            if (slice.low < segments.aD.low) || (slice.high > segments.aD.high) {
+                saLogger.error(getModuleName(),getRoutineName(),getLineNumber(),
+                "Slice is out of bounds");
+                throw new owned OutOfBoundsError();
+            }
+            // Early return for zero-length result
+            if (size == 0) || (slice.size == 0) {
+                return (makeDistArray(0, int), makeDistArray(0, values.etype));
+            }
+
+            ref sa = segments.a;
+            var start = sa[slice.low];
+            // end index
+            var end: int = if slice.high == segments.aD.high then values.size-1 else sa[slice.high:int+1]-1;
+
+            // Segment offsets of the new slice
+            var newSegs = makeDistArray(slice.size, int);
+            // TODO - double check this aggregation
+            forall (i, ns) in zip(newSegs.domain, newSegs) with (var agg = newSrcAggregator(int)) {
+                agg.copy(ns, sa[slice.low + i]);
+            }
+
+            // re-zero segments
+            newSegs -= start;
+            
+            var newVals = makeDistArray(end - start + 1, values.etype);
+            ref va = values.a;
+            forall (i, nv) in zip(newVals.domain, newVals) with (var agg = newSrcAggregator(values.etype)) {
+                agg.copy(nv, va[start + i]);
+            }
+            return (newSegs, newVals);
+        }
+
+        /* Gather segments by index. Returns arrays for the segments and values.*/
+        proc this(iv: [?D] ?t, smallIdx=false) throws where t == int || t == uint {
+            use ChplConfig;
+
+            // Early return for zero-length result
+            if (D.size == 0) {
+                return (makeDistArray(0, int), makeDistArray(0, values.etype));
+            }
+            // Check all indices within bounds
+            var ivMin = min reduce iv;
+            var ivMax = max reduce iv;
+            if (ivMin < 0) || (ivMax >= segments.size) {
+                saLogger.error(getModuleName(),getRoutineName(),getLineNumber(),
+                                    "Array out of bounds");
+                throw new owned OutOfBoundsError();
+            }
+            saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                                    "Computing lengths and offsets");
+            var t1 = getCurrentTime();
+            ref oa = segments.a;
+            const low = segments.aD.low, high = segments.aD.high;
+
+            // Gather the right and left boundaries of the indexed strings
+            // NOTE: cannot compute lengths inside forall because agg.copy will
+            // experience race condition with loop-private variable
+            var right: [D] int, left: [D] int;
+            forall (r, l, idx) in zip(right, left, iv) with (var agg = newSrcAggregator(int)) {
+                if (idx == high) {
+                    agg.copy(r, values.size);
+                } else {
+                    agg.copy(r, oa[idx:int+1]);
+                }
+                agg.copy(l, oa[idx:int]);
+            }
+
+            // Lengths of segments including null bytes
+            var gatheredLengths: [D] int = right - left;
+            // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+            overMemLimit(numBytes(int) * gatheredLengths.size);
+            // The returned offsets are the 0-up cumulative lengths
+            var gatheredOffsets = (+ scan gatheredLengths);
+            // The total number of bytes in the gathered strings
+            var rtn = gatheredOffsets[D.high];
+            gatheredOffsets -= gatheredLengths;
+            
+            saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
+                                        "aggregation in %i seconds".format(getCurrentTime() - t1));
+            saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "Copying values");
+            if logLevel == LogLevel.DEBUG {
+                t1 = getCurrentTime();
+            }
+            var gatheredVals = makeDistArray(rtn, values.etype);
+            // Multi-locale requires some extra localization work that is not needed
+            // in CHPL_COMM=none. When smallArr is set to true, a lowLevelLocalizingSlice
+            // will take place that can perform better by avoiding the extra localization
+            // work.
+            if CHPL_COMM != 'none' && smallIdx {
+                forall (go, gl, idx) in zip(gatheredOffsets, gatheredLengths, iv) with (var agg = newDstAggregator(values.etype)) {
+                    var slice = new lowLevelLocalizingSlice(values.a, idx:int..#gl);
+                    for i in 0..#gl {
+                        agg.copy(gatheredVals[go+i], slice.ptr[i]);
+                    }
+                }
+            } else if CHPL_COMM != 'none' {
+                // Compute the src index for each byte in gatheredVals
+                /* For performance, we will do this with a scan, so first we need an array
+                with the difference in index between the current and previous byte. For
+                the interior of a segment, this is just one, but at the segment boundary,
+                it is the difference between the src offset of the current segment ("left")
+                and the src index of the last byte in the previous segment (right - 1).
+                */
+                var srcIdx = makeDistArray(rtn, int);
+                srcIdx = 1;
+                var diffs: [D] int;
+                diffs[D.low] = left[D.low]; // first offset is not affected by scan
+
+                forall idx in D {
+                if idx!=0 {
+                    diffs[idx] = left[idx] - (right[idx-1]-1);
+                }
+                }
+                // Set srcIdx to diffs at segment boundaries
+                forall (go, d) in zip(gatheredOffsets, diffs) with (var agg = newDstAggregator(int)) {
+                    agg.copy(srcIdx[go], d);
+                }
+                // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+                overMemLimit(numBytes(int) * srcIdx.size);
+                srcIdx = + scan srcIdx;
+                // Now srcIdx has a dst-local copy of the source index and vals can be efficiently gathered
+                ref va = values.a;
+                forall (v, si) in zip(gatheredVals, srcIdx) with (var agg = newSrcAggregator(values.etype)) {
+                    agg.copy(v, va[si]);
+                }
+            } else {
+                ref va = values.a;
+                // Copy string data to gathered result
+                forall (go, gl, idx) in zip(gatheredOffsets, gatheredLengths, iv) {
+                    for pos in 0..#gl {
+                        gatheredVals[go+pos] = va[oa[idx:int]+pos];
+                    }
+                }
+            }
+            saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                    "Gathered offsets and vals in %i seconds".format(
+                                                getCurrentTime() -t1));
+            return (gatheredOffsets, gatheredVals);
+        }
+
+        /* Logical indexing (compress) of SegArray. */
+        proc this(iv: [?D] bool) throws {
+            // Index vector must be same domain as array
+            if (D != segments.aD) {
+                saLogger.info(getModuleName(),getRoutineName(),getLineNumber(),
+                                                                "Array out of bounds");
+                throw new owned OutOfBoundsError();
+            }
+            saLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
+                                                        "Computing lengths and offsets");
+
+            ref oa = segments.a;
+            const low = segments.aD.low, high = segments.aD.high;
+            // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+            overMemLimit(numBytes(int) * iv.size);
+            // Calculate the destination indices
+            var steps = + scan iv;
+            var newSize = steps[high];
+            steps -= iv;
+            // Early return for zero-length result
+            if (newSize == 0) {
+                return (makeDistArray(0, int), makeDistArray(0, values.etype));
+            }
+            var segInds = makeDistArray(newSize, int);
+            forall (t, dst, idx) in zip(iv, steps, D) with (var agg = newDstAggregator(int)) {
+                if t {
+                    agg.copy(segInds[dst], idx);
+                }
+            }
+            return this[segInds];
         }
 
         proc getNonEmpty() throws {
-            return getLengths() > 0;
+            return lengths > 0;
         }
 
         proc getNonEmptyCount() throws {
             var non_empty = getNonEmpty();
             return + reduce non_empty:int;
+        }
+
+        proc getValuesName(st: borrowed SymTab): string throws {
+            var vname = st.nextName();
+            st.addEntry(vname, values);
+            return vname;
+        }
+
+        proc getSegmentsName(st: borrowed SymTab): string throws {
+            var sname = st.nextName();
+            st.addEntry(sname, segments);
+            return sname;
+        }
+
+        proc getLengthsName(st: borrowed SymTab): string throws {
+            var lname = st.nextName();
+            st.addEntry(lname, new shared SymEntry(lengths));
+            return lname;
+        }
+
+        proc buildReturnMap(ref rm: map(string, string), st: borrowed SymTab) throws {
+            rm.add("segarray", "created " + st.attrib(this.name));
+            rm.add("values", "created " + st.attrib(this.getValuesName(st)));
+            rm.add("segments", "created " + st.attrib(this.getSegmentsName(st)));
+            rm.add("lengths", "created " + st.attrib(this.getLengthsName(st)));
         }
     }
 }

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -56,7 +56,6 @@ module SegmentedArray {
             segments = composite.segmentsEntry: shared SymEntry(int);
             values = composite.valuesEntry: shared SymEntry(eType);
 
-            
             size = segments.size;
             nBytes = values.size;
 

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -37,7 +37,7 @@ module SegmentedMsg {
     if valEntry.isAssignableTo(SymbolEntryType.SegStringSymEntry){ //SegString
       var vals = getSegString(valName, st);
       var segArray = getSegArray(segs.a, vals.values.a, st);
-      segArray.buildReturnMap(rtnmap, st);
+      segArray.fillReturnMap(rtnmap, st);
     } 
     else { // pdarray
       var values = getGenericTypedArrayEntry(valName, st);
@@ -45,22 +45,22 @@ module SegmentedMsg {
         when (DType.Int64) {
           var vals = toSymEntry(values, int);
           var segArray = getSegArray(segs.a, vals.a, st);
-          segArray.buildReturnMap(rtnmap, st);
+          segArray.fillReturnMap(rtnmap, st);
         }
         when (DType.UInt64) {
           var vals = toSymEntry(values, uint);
           var segArray = getSegArray(segs.a, vals.a, st);
-          segArray.buildReturnMap(rtnmap, st);
+          segArray.fillReturnMap(rtnmap, st);
         }
         when (DType.Float64) {
           var vals = toSymEntry(values, real);
           var segArray = getSegArray(segs.a, vals.a, st);
-          segArray.buildReturnMap(rtnmap, st);
+          segArray.fillReturnMap(rtnmap, st);
         }
         when (DType.Bool) {
           var vals = toSymEntry(values, bool);
           var segArray = getSegArray(segs.a, vals.a, st);
-          segArray.buildReturnMap(rtnmap, st);
+          segArray.fillReturnMap(rtnmap, st);
         }
         otherwise {
             throw new owned ErrorWithContext("Values array has unsupported dtype %s".format(values.dtype:string),
@@ -922,30 +922,37 @@ module SegmentedMsg {
               // Compute the slice
               var (newSegs, newVals) = segarr[slice];
               var newSegArr = getSegArray(newSegs, newVals, st);
-              repMsg = "created " + st.attrib(newSegArr.name);
+              newSegArr.fillReturnMap(rtnmap, st);
             }
             when (DType.UInt64) { 
               var segarr = getSegArray(objName, st, uint);
               // Compute the slice
               var (newSegs, newVals) = segarr[slice];
               var newSegArr = getSegArray(newSegs, newVals, st);
-              repMsg = "created " + st.attrib(newSegArr.name);
+              newSegArr.fillReturnMap(rtnmap, st);
             }
             when (DType.Float64) { 
               var segarr = getSegArray(objName, st, real);
               // Compute the slice
               var (newSegs, newVals) = segarr[slice];
               var newSegArr = getSegArray(newSegs, newVals, st);
-              repMsg = "created " + st.attrib(newSegArr.name);
+              newSegArr.fillReturnMap(rtnmap, st);
             }
             when (DType.Bool) { 
               var segarr = getSegArray(objName, st, bool);
               // Compute the slice
               var (newSegs, newVals) = segarr[slice];
               var newSegArr = getSegArray(newSegs, newVals, st);
-              repMsg = "created " + st.attrib(newSegArr.name);
+              newSegArr.fillReturnMap(rtnmap, st);
+            }
+            otherwise {
+              var errorMsg = "Invalid segarray type";
+                      smLogger.error(getModuleName(),getRoutineName(),
+                                                    getLineNumber(),errorMsg); 
+                      return new MsgTuple(notImplementedError(pn,errorMsg), MsgType.ERROR);
             }
           }
+          repMsg = "%jt".format(rtnmap);
         }
         otherwise {
             var errorMsg = notImplementedError(pn, objtype);
@@ -1038,19 +1045,19 @@ module SegmentedMsg {
                   // which can perform better by avoiding those overhead costs.
                   var (newSegs, newVals) = segArr[iv.a, smallIdx=smallIdx];
                   var newSegArr = getSegArray(newSegs, newVals, st);
-                  newSegArr.buildReturnMap(rtnmap, st);
+                  newSegArr.fillReturnMap(rtnmap, st);
                 }
                 when DType.UInt64 {
                   var iv = toSymEntry(gIV, uint);
                   var (newSegs, newVals) = segArr[iv.a];
                   var newSegArr = getSegArray(newSegs, newVals, st);
-                  newSegArr.buildReturnMap(rtnmap, st);
+                  newSegArr.fillReturnMap(rtnmap, st);
                 }
                 when DType.Bool {
                   var iv = toSymEntry(gIV, bool);
                   var (newSegs, newVals) = segArr[iv.a];
                   var newSegArr = getSegArray(newSegs, newVals, st);
-                  newSegArr.buildReturnMap(rtnmap, st);
+                  newSegArr.fillReturnMap(rtnmap, st);
                 }
                 otherwise {
                     var errorMsg = "("+objtype+","+dtype2str(gIV.dtype)+")";
@@ -1070,19 +1077,19 @@ module SegmentedMsg {
                   // which can perform better by avoiding those overhead costs.
                   var (newSegs, newVals) = segArr[iv.a, smallIdx=smallIdx];
                   var newSegArr = getSegArray(newSegs, newVals, st);
-                  newSegArr.buildReturnMap(rtnmap, st);
+                  newSegArr.fillReturnMap(rtnmap, st);
                 }
                 when DType.UInt64 {
                   var iv = toSymEntry(gIV, uint);
                   var (newSegs, newVals) = segArr[iv.a];
                   var newSegArr = getSegArray(newSegs, newVals, st);
-                  newSegArr.buildReturnMap(rtnmap, st);
+                  newSegArr.fillReturnMap(rtnmap, st);
                 }
                 when DType.Bool {
                   var iv = toSymEntry(gIV, bool);
                   var (newSegs, newVals) = segArr[iv.a];
                   var newSegArr = getSegArray(newSegs, newVals, st);
-                  newSegArr.buildReturnMap(rtnmap, st);
+                  newSegArr.fillReturnMap(rtnmap, st);
                 }
                 otherwise {
                     var errorMsg = "("+objtype+","+dtype2str(gIV.dtype)+")";
@@ -1102,19 +1109,19 @@ module SegmentedMsg {
                   // which can perform better by avoiding those overhead costs.
                   var (newSegs, newVals) = segArr[iv.a, smallIdx=smallIdx];
                   var newSegArr = getSegArray(newSegs, newVals, st);
-                  newSegArr.buildReturnMap(rtnmap, st);
+                  newSegArr.fillReturnMap(rtnmap, st);
                 }
                 when DType.UInt64 {
                   var iv = toSymEntry(gIV, uint);
                   var (newSegs, newVals) = segArr[iv.a];
                   var newSegArr = getSegArray(newSegs, newVals, st);
-                  newSegArr.buildReturnMap(rtnmap, st);
+                  newSegArr.fillReturnMap(rtnmap, st);
                 }
                 when DType.Bool {
                   var iv = toSymEntry(gIV, bool);
                   var (newSegs, newVals) = segArr[iv.a];
                   var newSegArr = getSegArray(newSegs, newVals, st);
-                  newSegArr.buildReturnMap(rtnmap, st);
+                  newSegArr.fillReturnMap(rtnmap, st);
                 }
                 otherwise {
                     var errorMsg = "("+objtype+","+dtype2str(gIV.dtype)+")";
@@ -1134,19 +1141,19 @@ module SegmentedMsg {
                   // which can perform better by avoiding those overhead costs.
                   var (newSegs, newVals) = segArr[iv.a, smallIdx=smallIdx];
                   var newSegArr = getSegArray(newSegs, newVals, st);
-                  newSegArr.buildReturnMap(rtnmap, st);
+                  newSegArr.fillReturnMap(rtnmap, st);
                 }
                 when DType.UInt64 {
                   var iv = toSymEntry(gIV, uint);
                   var (newSegs, newVals) = segArr[iv.a];
                   var newSegArr = getSegArray(newSegs, newVals, st);
-                  newSegArr.buildReturnMap(rtnmap, st);
+                  newSegArr.fillReturnMap(rtnmap, st);
                 }
                 when DType.Bool {
                   var iv = toSymEntry(gIV, bool);
                   var (newSegs, newVals) = segArr[iv.a];
                   var newSegArr = getSegArray(newSegs, newVals, st);
-                  newSegArr.buildReturnMap(rtnmap, st);
+                  newSegArr.fillReturnMap(rtnmap, st);
                 }
                 otherwise {
                     var errorMsg = "("+objtype+","+dtype2str(gIV.dtype)+")";

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -28,7 +28,6 @@ module SegmentedMsg {
     smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
             "cmd: %s segmentsname: %s valuesName: %s".format(cmd, segName, valName));
 
-    // var repMsg: string;
     var segments = getGenericTypedArrayEntry(segName, st);
     var segs = toSymEntry(segments, int);
 
@@ -1045,13 +1044,13 @@ module SegmentedMsg {
                   var iv = toSymEntry(gIV, uint);
                   var (newSegs, newVals) = segArr[iv.a];
                   var newSegArr = getSegArray(newSegs, newVals, st);
-                  repMsg = "created " + st.attrib(newSegArr.name);
+                  newSegArr.buildReturnMap(rtnmap, st);
                 }
                 when DType.Bool {
                   var iv = toSymEntry(gIV, bool);
                   var (newSegs, newVals) = segArr[iv.a];
                   var newSegArr = getSegArray(newSegs, newVals, st);
-                  repMsg = "created " + st.attrib(newSegArr.name);
+                  newSegArr.buildReturnMap(rtnmap, st);
                 }
                 otherwise {
                     var errorMsg = "("+objtype+","+dtype2str(gIV.dtype)+")";
@@ -1071,19 +1070,19 @@ module SegmentedMsg {
                   // which can perform better by avoiding those overhead costs.
                   var (newSegs, newVals) = segArr[iv.a, smallIdx=smallIdx];
                   var newSegArr = getSegArray(newSegs, newVals, st);
-                  repMsg = "created " + st.attrib(newSegArr.name);
+                  newSegArr.buildReturnMap(rtnmap, st);
                 }
                 when DType.UInt64 {
                   var iv = toSymEntry(gIV, uint);
                   var (newSegs, newVals) = segArr[iv.a];
                   var newSegArr = getSegArray(newSegs, newVals, st);
-                  repMsg = "created " + st.attrib(newSegArr.name);
+                  newSegArr.buildReturnMap(rtnmap, st);
                 }
                 when DType.Bool {
                   var iv = toSymEntry(gIV, bool);
                   var (newSegs, newVals) = segArr[iv.a];
                   var newSegArr = getSegArray(newSegs, newVals, st);
-                  repMsg = "created " + st.attrib(newSegArr.name);
+                  newSegArr.buildReturnMap(rtnmap, st);
                 }
                 otherwise {
                     var errorMsg = "("+objtype+","+dtype2str(gIV.dtype)+")";
@@ -1103,19 +1102,19 @@ module SegmentedMsg {
                   // which can perform better by avoiding those overhead costs.
                   var (newSegs, newVals) = segArr[iv.a, smallIdx=smallIdx];
                   var newSegArr = getSegArray(newSegs, newVals, st);
-                  repMsg = "created " + st.attrib(newSegArr.name);
+                  newSegArr.buildReturnMap(rtnmap, st);
                 }
                 when DType.UInt64 {
                   var iv = toSymEntry(gIV, uint);
                   var (newSegs, newVals) = segArr[iv.a];
                   var newSegArr = getSegArray(newSegs, newVals, st);
-                  repMsg = "created " + st.attrib(newSegArr.name);
+                  newSegArr.buildReturnMap(rtnmap, st);
                 }
                 when DType.Bool {
                   var iv = toSymEntry(gIV, bool);
                   var (newSegs, newVals) = segArr[iv.a];
                   var newSegArr = getSegArray(newSegs, newVals, st);
-                  repMsg = "created " + st.attrib(newSegArr.name);
+                  newSegArr.buildReturnMap(rtnmap, st);
                 }
                 otherwise {
                     var errorMsg = "("+objtype+","+dtype2str(gIV.dtype)+")";
@@ -1135,19 +1134,19 @@ module SegmentedMsg {
                   // which can perform better by avoiding those overhead costs.
                   var (newSegs, newVals) = segArr[iv.a, smallIdx=smallIdx];
                   var newSegArr = getSegArray(newSegs, newVals, st);
-                  repMsg = "created " + st.attrib(newSegArr.name);
+                  newSegArr.buildReturnMap(rtnmap, st);
                 }
                 when DType.UInt64 {
                   var iv = toSymEntry(gIV, uint);
                   var (newSegs, newVals) = segArr[iv.a];
                   var newSegArr = getSegArray(newSegs, newVals, st);
-                  repMsg = "created " + st.attrib(newSegArr.name);
+                  newSegArr.buildReturnMap(rtnmap, st);
                 }
                 when DType.Bool {
                   var iv = toSymEntry(gIV, bool);
                   var (newSegs, newVals) = segArr[iv.a];
                   var newSegArr = getSegArray(newSegs, newVals, st);
-                  repMsg = "created " + st.attrib(newSegArr.name);
+                  newSegArr.buildReturnMap(rtnmap, st);
                 }
                 otherwise {
                     var errorMsg = "("+objtype+","+dtype2str(gIV.dtype)+")";
@@ -1381,9 +1380,6 @@ module SegmentedMsg {
   registerFunction("segmentedIn1d", segIn1dMsg, getModuleName());
   registerFunction("randomStrings", randomStringsMsg, getModuleName());
   registerFunction("segArr-assemble", assembleSegArrayMsg, getModuleName());
-  // registerFunction("segArr-getSegments", getSASegmentsMsg, getModuleName());
-  // registerFunction("segArr-getValues", getSAValuesMsg, getModuleName());
-  // registerFunction("segArr-getLengths", getSALengthsMsg, getModuleName());
   registerFunction("segArr-getNonEmpty", getSANonEmptyMsg, getModuleName());
   registerFunction("segStr-assemble", assembleStringsMsg, getModuleName());
   registerFunction("stringsToJSON", stringsToJSONMsg, getModuleName());

--- a/src/SegmentedString.chpl
+++ b/src/SegmentedString.chpl
@@ -25,8 +25,6 @@ module SegmentedString {
   param SegmentedStringUseHash = useHash;
 
   private config param regexMaxCaptures = ServerConfig.regexMaxCaptures;
-  
-  class OutOfBoundsError: Error {}
 
   proc getSegString(name: string, st: borrowed SymTab): owned SegString throws {
       var abstractEntry = st.lookup(name);

--- a/src/ServerErrors.chpl
+++ b/src/ServerErrors.chpl
@@ -3,6 +3,8 @@ module ServerErrors {
     use SysError;
     private use IO; // for string.format
 
+    class OutOfBoundsError: Error {}
+
     /*
      * Generates an error message that provides a fuller context to the error
      * by including the line number, proc name, and module name from which the 

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -132,7 +132,7 @@ class DataFrameTest(ArkoudaTest):
             "c_2": ak.arange(6, 9, 1),
             "c_3": str_arr,
             "c_4": ak.Categorical(str_arr),
-            "c_5": ak.SegArray(ak.array([0, 9, 14]), ak.arange(20)),
+            "c_5": ak.segarray(ak.array([0, 9, 14]), ak.arange(20)),
         }
         akdf = ak.DataFrame(df_dict)
         self.assertEqual(len(akdf.columns), len(akdf.dtypes))
@@ -500,7 +500,7 @@ class DataFrameTest(ArkoudaTest):
         self.assertEqual(len(glob.glob(f"{d}/testName_with_index*.pq")), ak.get_config()["numLocales"])
 
         # Test for df having seg array col
-        df = ak.DataFrame({"a": ak.arange(10), "b": ak.SegArray(ak.arange(10), ak.arange(10))})
+        df = ak.DataFrame({"a": ak.arange(10), "b": ak.segarray(ak.arange(10), ak.arange(10))})
         df.save(f"{d}/seg_test.h5")
         self.assertEqual(len(glob.glob(f"{d}/seg_test*.h5")), ak.get_config()["numLocales"])
         ak_loaded = ak.DataFrame.load(f"{d}/seg_test.h5")

--- a/tests/segarray_test.py
+++ b/tests/segarray_test.py
@@ -11,7 +11,7 @@ class SegArrayTest(ArkoudaTest):
         flat = a + b + c
         akflat = ak.array(flat)
         segments = ak.array([0, len(a), len(a) + len(b)])
-        segarr = ak.SegArray(segments, akflat)
+        segarr = ak.segarray(segments, akflat)
 
         self.assertIsInstance(segarr, ak.SegArray)
         self.assertListEqual(segarr.lengths.to_list(), [6, 2, 4])
@@ -39,21 +39,21 @@ class SegArrayTest(ArkoudaTest):
         # test empty as first elements
         flat = ak.array(b + c)
         segs = ak.array([0, 0, len(b)])
-        segarr = ak.SegArray(segs, flat)
+        segarr = ak.segarray(segs, flat)
         self.assertIsInstance(segarr, ak.SegArray)
         self.assertListEqual(segarr.lengths.to_list(), [0, 3, 1])
 
         # test empty as middle element
         flat = ak.array(a + c)
         segs = ak.array([0, len(a), len(a)])
-        segarr = ak.SegArray(segs, flat)
+        segarr = ak.segarray(segs, flat)
         self.assertIsInstance(segarr, ak.SegArray)
         self.assertListEqual(segarr.lengths.to_list(), [2, 0, 1])
 
         # test empty as last
         flat = ak.array(a + b + c)
         segs = ak.array([0, len(a), len(a) + len(b), len(a) + len(b) + len(c)])
-        segarr = ak.SegArray(segs, flat)
+        segarr = ak.segarray(segs, flat)
         self.assertIsInstance(segarr, ak.SegArray)
         self.assertListEqual(segarr.lengths.to_list(), [2, 3, 1, 0])
 
@@ -66,25 +66,25 @@ class SegArrayTest(ArkoudaTest):
         akflat = ak.array(flat)
         segments = ak.array([0, len(a)])
 
-        segarr = ak.SegArray(segments, akflat)
-        segarr_2 = ak.SegArray(ak.array([0]), ak.array(c))
+        segarr = ak.segarray(segments, akflat)
+        segarr_2 = ak.segarray(ak.array([0]), ak.array(c))
 
         concated = ak.SegArray.concat([segarr, segarr_2])
         self.assertEqual(concated.__str__(), f"SegArray([\n{a}\n{b}\n{c}\n])".replace(",", ""))
 
         # test concat with empty segments
-        empty_segs = ak.SegArray(ak.array([0, 2, 2]), ak.array(b + c))
+        empty_segs = ak.segarray(ak.array([0, 2, 2]), ak.array(b + c))
         concated = ak.SegArray.concat([segarr, empty_segs])
         self.assertEqual(concated.__str__(), f"SegArray([\n{a}\n{b}\n{b}\n[]\n{c}\n])".replace(",", ""))
 
         flat = ak.array(a)
         segs = ak.array([0, len(a)])
-        segarr = ak.SegArray(segs, flat)
+        segarr = ak.segarray(segs, flat)
         a2 = [10]
         b2 = [20]
         flat2 = ak.array(a2 + b2)
         segments2 = ak.array([0, 1])
-        segarr2 = ak.SegArray(segments2, flat2)
+        segarr2 = ak.segarray(segments2, flat2)
         concated = ak.SegArray.concat([segarr, segarr2], axis=1)
         self.assertListEqual(concated[0].tolist(), [10, 11, 12, 13, 14, 15, 10])
         self.assertListEqual(concated[1].tolist(), [20])
@@ -133,7 +133,7 @@ class SegArrayTest(ArkoudaTest):
         akflat = ak.array(flat)
         segments = ak.array([0, len(a), len(a) + len(b)])
 
-        segarr = ak.SegArray(segments, akflat)
+        segarr = ak.segarray(segments, akflat)
 
         suffix, origin = segarr.get_suffixes(1)
         self.assertTrue(origin.all())
@@ -154,7 +154,7 @@ class SegArrayTest(ArkoudaTest):
         # Test with empty segment
         flat = ak.array(a + b)
         segs = ak.array([0, len(a), len(a)])
-        segarr = ak.SegArray(segs, flat)
+        segarr = ak.segarray(segs, flat)
         suffix, origin = segarr.get_suffixes(1)
         self.assertListEqual(suffix[0].to_list(), [15, 21])
         self.assertListEqual(origin.to_list(), [True, False, True])
@@ -168,7 +168,7 @@ class SegArrayTest(ArkoudaTest):
         akflat = ak.array(flat)
         segments = ak.array([0, len(a), len(a) + len(b)])
 
-        segarr = ak.SegArray(segments, akflat)
+        segarr = ak.segarray(segments, akflat)
         prefix, origin = segarr.get_prefixes(1)
 
         self.assertListEqual(prefix[0].to_list(), [10, 20, 30])
@@ -189,7 +189,7 @@ class SegArrayTest(ArkoudaTest):
         # Test with empty segment
         flat = ak.array(a + b)
         segs = ak.array([0, len(a), len(a)])
-        segarr = ak.SegArray(segs, flat)
+        segarr = ak.segarray(segs, flat)
         prefix, origin = segarr.get_prefixes(1)
         self.assertListEqual(prefix[0].to_list(), [10, 20])
         self.assertListEqual(origin.to_list(), [True, False, True])
@@ -203,7 +203,7 @@ class SegArrayTest(ArkoudaTest):
         akflat = ak.array(flat)
         segments = ak.array([0, len(a), len(a) + len(b)])
 
-        segarr = ak.SegArray(segments, akflat)
+        segarr = ak.segarray(segments, akflat)
         ngram, origin = segarr.get_ngrams(2)
         self.assertListEqual(ngram[0].to_list(), [10, 11, 12, 13, 14, 20, 30, 31, 32])
         self.assertListEqual(ngram[1].to_list(), [11, 12, 13, 14, 15, 21, 31, 32, 33])
@@ -220,7 +220,7 @@ class SegArrayTest(ArkoudaTest):
         # Test with empty segment
         flat = ak.array(a + b)
         segs = ak.array([0, len(a), len(a)])
-        segarr = ak.SegArray(segs, flat)
+        segarr = ak.segarray(segs, flat)
         ngram, origin = segarr.get_ngrams(2)
         self.assertListEqual(ngram[0].to_list(), [10, 11, 12, 13, 14, 20])
         self.assertListEqual(ngram[1].to_list(), [11, 12, 13, 14, 15, 21])
@@ -238,7 +238,7 @@ class SegArrayTest(ArkoudaTest):
         akflat = ak.array(flat)
         segments = ak.array([0, len(a), len(a) + len(b)])
 
-        segarr = ak.SegArray(segments, akflat)
+        segarr = ak.segarray(segments, akflat)
 
         res, origins = segarr.get_jth(1)
         self.assertListEqual(res.to_list(), [11, 21, 31])
@@ -250,7 +250,7 @@ class SegArrayTest(ArkoudaTest):
         # Test with empty segment
         flat = ak.array(a + b)
         segs = ak.array([0, len(a), len(a)])
-        segarr = ak.SegArray(segs, flat)
+        segarr = ak.segarray(segs, flat)
         res, origin = segarr.get_jth(2)
         self.assertListEqual(res.to_list(), [12, 0, 0])
         self.assertListEqual(origin.to_list(), [True, False, False])
@@ -268,7 +268,7 @@ class SegArrayTest(ArkoudaTest):
         akflat = ak.array(flat)
         segments = ak.array([0, len(a), len(a) + len(b)])
 
-        segarr = ak.SegArray(segments, akflat)
+        segarr = ak.segarray(segments, akflat)
 
         segarr.set_jth(0, 1, 99)
         self.assertEqual(segarr[0].__str__(), f"{a}".replace(",", "").replace("11", "99"))
@@ -285,7 +285,7 @@ class SegArrayTest(ArkoudaTest):
 
         s = ak.array(["abc", "123"])
         s_segments = ak.array([0])
-        segarr = ak.SegArray(s_segments, s)
+        segarr = ak.segarray(s_segments, s)
 
         with self.assertRaises(TypeError):
             segarr.set_jth(0, 0, "test")
@@ -299,7 +299,7 @@ class SegArrayTest(ArkoudaTest):
         akflat = ak.array(flat)
         segments = ak.array([0, len(a), len(a) + len(b)])
 
-        segarr = ak.SegArray(segments, akflat)
+        segarr = ak.segarray(segments, akflat)
 
         elem, origin = segarr.get_length_n(2)
         self.assertListEqual(elem[0].to_list(), [20])
@@ -308,7 +308,7 @@ class SegArrayTest(ArkoudaTest):
         # Test with empty segment
         flat = ak.array(a + b)
         segs = ak.array([0, len(a), len(a)])
-        segarr = ak.SegArray(segs, flat)
+        segarr = ak.segarray(segs, flat)
         elem, origin = segarr.get_length_n(2)
         self.assertListEqual(elem[0].to_list(), [20])
         self.assertListEqual(elem[1].to_list(), [21])
@@ -323,7 +323,7 @@ class SegArrayTest(ArkoudaTest):
         akflat = ak.array(flat)
         segments = ak.array([0, len(a), len(a) + len(b)])
 
-        segarr = ak.SegArray(segments, akflat)
+        segarr = ak.segarray(segments, akflat)
 
         self.assertEqual(segarr.append(ak.array([1, 2, 3])), NotImplemented)
 
@@ -331,7 +331,7 @@ class SegArrayTest(ArkoudaTest):
         b2 = [1.1, 0.7]
         flat2 = ak.array(a2 + b2)
         segments2 = ak.array([0, len(a2)])
-        float_segarr = ak.SegArray(segments2, flat2)
+        float_segarr = ak.segarray(segments2, flat2)
 
         with self.assertRaises(TypeError):
             segarr.append(float_segarr)
@@ -340,7 +340,7 @@ class SegArrayTest(ArkoudaTest):
         b2 = [22, 23]
         flat2 = ak.array(a2 + b2)
         segments2 = ak.array([0, len(a2)])
-        segarr2 = ak.SegArray(segments2, flat2)
+        segarr2 = ak.segarray(segments2, flat2)
 
         appended = segarr.append(segarr2)
         self.assertEqual(appended.segments.size, 5)
@@ -350,7 +350,7 @@ class SegArrayTest(ArkoudaTest):
         a2 = [1, 2]
         b2 = [3]
         segments2 = ak.array([0, len(a2)])
-        segarr2 = ak.SegArray(segments2, ak.array(a2 + b2))
+        segarr2 = ak.segarray(segments2, ak.array(a2 + b2))
 
         with self.assertRaises(ValueError):
             appended = segarr.append(segarr2, axis=1)
@@ -360,12 +360,12 @@ class SegArrayTest(ArkoudaTest):
         flat = a + b
         akflat = ak.array(flat)
         segments = ak.array([0, len(a)])
-        segarr = ak.SegArray(segments, akflat)
+        segarr = ak.segarray(segments, akflat)
         a2 = [10]
         b2 = [20]
         flat2 = ak.array(a2 + b2)
         segments2 = ak.array([0, 1])
-        segarr2 = ak.SegArray(segments2, flat2)
+        segarr2 = ak.segarray(segments2, flat2)
         appended = segarr.append(segarr2, axis=1)
 
         self.assertListEqual(appended.lengths.to_list(), [3, 3])
@@ -375,7 +375,7 @@ class SegArrayTest(ArkoudaTest):
         # Test with empty segments
         flat = ak.array(a + b)
         segs = ak.array([0, len(a), len(a) + len(b)])
-        segarr = ak.SegArray(segs, flat)
+        segarr = ak.segarray(segs, flat)
         appended = segarr.append(segarr2)
         self.assertEqual(appended.segments.size, 5)
         self.assertListEqual(appended[3].tolist(), [10])
@@ -383,7 +383,7 @@ class SegArrayTest(ArkoudaTest):
 
         flat = ak.array(a)
         segs = ak.array([0, len(a)])
-        segarr = ak.SegArray(segs, flat)
+        segarr = ak.segarray(segs, flat)
         concated = segarr.append(segarr2, axis=1)
         self.assertListEqual(concated[0].tolist(), [1, 2, 10])
         self.assertListEqual(concated[1].tolist(), [20])
@@ -397,7 +397,7 @@ class SegArrayTest(ArkoudaTest):
         akflat = ak.array(flat)
         segments = ak.array([0, len(a), len(a) + len(b)])
 
-        segarr = ak.SegArray(segments, akflat)
+        segarr = ak.segarray(segments, akflat)
         to_append = ak.array([99, 98, 97])
 
         appended = segarr.append_single(to_append)
@@ -430,7 +430,7 @@ class SegArrayTest(ArkoudaTest):
         # test with empty segment
         flat = ak.array(a + b)
         segs = ak.array([0, len(a), len(a) + len(b)])
-        segarr = ak.SegArray(segs, flat)
+        segarr = ak.segarray(segs, flat)
         appended = segarr.append_single(99)
         self.assertListEqual(appended[0].tolist(), a + [99])
         self.assertListEqual(appended[1].tolist(), b + [99])
@@ -448,7 +448,7 @@ class SegArrayTest(ArkoudaTest):
         flat = ak.array(a + b)
         segments = ak.array([0, len(a)])
 
-        segarr = ak.SegArray(segments, flat)
+        segarr = ak.segarray(segments, flat)
         dedup = segarr.remove_repeats()
         self.assertListEqual(dedup.lengths.to_list(), [3, 3])
         self.assertListEqual(dedup[0].tolist(), list(set(a)))
@@ -456,7 +456,7 @@ class SegArrayTest(ArkoudaTest):
 
         # test with empty segments
         segments = ak.array([0, len(a), len(a), len(a) + len(b)])
-        segarr = ak.SegArray(segments, flat)
+        segarr = ak.segarray(segments, flat)
         dedup = segarr.remove_repeats()
         print(dedup.lengths)
         self.assertListEqual(dedup.lengths.to_list(), [3, 0, 3, 0])
@@ -466,7 +466,7 @@ class SegArrayTest(ArkoudaTest):
         self.assertListEqual(dedup[3].tolist(), [])
 
         segments = ak.array([0, len(a), len(a), len(a), len(a) + len(b)])
-        segarr = ak.SegArray(segments, flat)
+        segarr = ak.segarray(segments, flat)
         dedup = segarr.remove_repeats()
         self.assertListEqual(dedup.lengths.to_list(), [3, 0, 0, 3, 0])
         self.assertListEqual(dedup[0].tolist(), list(set(a)))
@@ -480,8 +480,8 @@ class SegArrayTest(ArkoudaTest):
         b = [6, 7, 8]
         c = [1, 2, 4]
         d = [8]
-        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + b))
-        segarr_2 = ak.SegArray(ak.array([0, len(c)]), ak.array(c + d))
+        segarr = ak.segarray(ak.array([0, len(a)]), ak.array(a + b))
+        segarr_2 = ak.segarray(ak.array([0, len(c)]), ak.array(c + d))
 
         intx = segarr.intersect(segarr_2)
 
@@ -490,14 +490,14 @@ class SegArrayTest(ArkoudaTest):
         self.assertListEqual(intx[1].tolist(), [8])
 
         # test with empty Segments
-        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
+        segarr = ak.segarray(ak.array([0, len(a)]), ak.array(a))
         intx = segarr.intersect(segarr_2)
         self.assertListEqual(intx.lengths.to_list(), [3, 0])
         self.assertListEqual(intx[0].tolist(), [1, 2, 4])
         self.assertListEqual(intx[1].tolist(), [])
 
-        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + c))
-        segarr_2 = ak.SegArray(ak.array([0, len(d)]), ak.array(d + c))
+        segarr = ak.segarray(ak.array([0, len(a)]), ak.array(a + c))
+        segarr_2 = ak.segarray(ak.array([0, len(d)]), ak.array(d + c))
         intx = segarr.intersect(segarr_2)
         self.assertListEqual(intx.lengths.to_list(), [0, 3])
         self.assertListEqual(intx[0].tolist(), [])
@@ -509,8 +509,8 @@ class SegArrayTest(ArkoudaTest):
         c = [1, 2, 4]
         d = [8]
 
-        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + b))
-        segarr_2 = ak.SegArray(ak.array([0, len(c)]), ak.array(c + d))
+        segarr = ak.segarray(ak.array([0, len(a)]), ak.array(a + b))
+        segarr_2 = ak.segarray(ak.array([0, len(c)]), ak.array(c + d))
 
         un = segarr.union(segarr_2)
         self.assertEqual(un.size, 2)
@@ -518,14 +518,14 @@ class SegArrayTest(ArkoudaTest):
         self.assertListEqual(un[1].tolist(), [6, 7, 8])
 
         # test with empty segments
-        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
+        segarr = ak.segarray(ak.array([0, len(a)]), ak.array(a))
         un = segarr.union(segarr_2)
         self.assertListEqual(un.lengths.to_list(), [5, 1])
         self.assertListEqual(un[0].tolist(), [1, 2, 3, 4, 5])
         self.assertListEqual(un[1].tolist(), [8])
 
-        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
-        segarr_2 = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
+        segarr = ak.segarray(ak.array([0, len(a)]), ak.array(a))
+        segarr_2 = ak.segarray(ak.array([0, len(a)]), ak.array(a))
         un = segarr.union(segarr_2)
         self.assertListEqual(un.lengths.to_list(), [5, 0])
         self.assertListEqual(un[0].tolist(), [1, 2, 3, 4, 5])
@@ -537,8 +537,8 @@ class SegArrayTest(ArkoudaTest):
         c = [1, 2, 4]
         d = [8]
 
-        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + b))
-        segarr_2 = ak.SegArray(ak.array([0, len(c)]), ak.array(c + d))
+        segarr = ak.segarray(ak.array([0, len(a)]), ak.array(a + b))
+        segarr_2 = ak.segarray(ak.array([0, len(c)]), ak.array(c + d))
 
         diff = segarr.setdiff(segarr_2)
         self.assertEqual(diff.size, 2)
@@ -546,14 +546,14 @@ class SegArrayTest(ArkoudaTest):
         self.assertListEqual(diff[1].tolist(), [6, 7])
 
         # test with empty segments
-        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
+        segarr = ak.segarray(ak.array([0, len(a)]), ak.array(a))
         diff = segarr.setdiff(segarr_2)
         self.assertListEqual(diff.lengths.to_list(), [2, 0])
         self.assertListEqual(diff[0].tolist(), [3, 5])
         self.assertListEqual(diff[1].tolist(), [])
 
-        segarr = ak.SegArray(ak.array([0, len(a), len(a)]), ak.array(a + a))
-        segarr_2 = ak.SegArray(ak.array([0, len(c), len(c + c)]), ak.array(c + c + c))
+        segarr = ak.segarray(ak.array([0, len(a), len(a)]), ak.array(a + a))
+        segarr_2 = ak.segarray(ak.array([0, len(c), len(c + c)]), ak.array(c + c + c))
         diff = segarr_2.setdiff(segarr)
         self.assertListEqual(diff.lengths.to_list(), [0, 3, 0])
         self.assertListEqual(diff[0].tolist(), [])
@@ -566,8 +566,8 @@ class SegArrayTest(ArkoudaTest):
         c = [1, 2, 4]
         d = [8, 12, 13]
 
-        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + b))
-        segarr_2 = ak.SegArray(ak.array([0, len(c)]), ak.array(c + d))
+        segarr = ak.segarray(ak.array([0, len(a)]), ak.array(a + b))
+        segarr_2 = ak.segarray(ak.array([0, len(c)]), ak.array(c + d))
         xor = segarr.setxor(segarr_2)
 
         self.assertEqual(xor.size, 2)
@@ -575,14 +575,14 @@ class SegArrayTest(ArkoudaTest):
         self.assertListEqual(xor[1].tolist(), [6, 7, 12, 13])
 
         # test with empty segment
-        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a))
+        segarr = ak.segarray(ak.array([0, len(a)]), ak.array(a))
         xor = segarr.setxor(segarr_2)
         self.assertListEqual(xor.lengths.to_list(), [2, 3])
         self.assertListEqual(xor[0].tolist(), [3, 4])
         self.assertListEqual(xor[1].tolist(), [8, 12, 13])
 
-        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + a))
-        segarr_2 = ak.SegArray(ak.array([0, len(a)]), ak.array(a + c))
+        segarr = ak.segarray(ak.array([0, len(a)]), ak.array(a + a))
+        segarr_2 = ak.segarray(ak.array([0, len(a)]), ak.array(a + c))
         xor = segarr.setxor(segarr_2)
         self.assertListEqual(xor.lengths.to_list(), [0, 2])
         self.assertListEqual(xor[0].tolist(), [])
@@ -592,7 +592,7 @@ class SegArrayTest(ArkoudaTest):
         a = [1, 2, 3]
         b = [6, 7, 8]
 
-        segarr = ak.SegArray(ak.array([0, len(a)]), ak.array(a + b))
+        segarr = ak.segarray(ak.array([0, len(a)]), ak.array(a + b))
         # register the seg array
         segarr.register("segarrtest")
 

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -52,7 +52,7 @@ class utilTest(ArkoudaTest):
         flat = a + b + c
         akflat = ak.array(flat)
         segments = ak.array([0, len(a), len(a) + len(b)])
-        segarr = ak.SegArray(segments, akflat)
+        segarr = ak.segarray(segments, akflat)
         segarr.register("segTest")
 
         attached = attach("segTest")


### PR DESCRIPTION
Closes #1783 
Closes #1708 

- Move `SegArray` indexing to the server and updates `__getitem__` to use server messages for indexing. The majority of the indexing logic was modeled from `SegString`.
- Moves `OutOfBoundsError` to `ServerErrors.chpl` because 2 modules are not utilizing this
- Updates `SegArray` creation response messages to be formatted as JSON. These messages also now return the `create` statements for the `values`, `segments`, and `lengths` pdarray components so that subsequent server calls are not required for access.
- Adds `ak.SegArray.from_parts`. This operates as the `__init__` previously did. The `__init__` method has been updated to build `SegArray` from the response message components. This was modeled after `SegmentedStrings` client side code.
- Adds `ak.segarray` method to ease the transition to this update for users. This is an alias to `ak.SegArray.from_parts` but the syntax resembles the creation of pdarrays via `ak.array` and only requires case changes in existing code.