### PR TITLE
Closes #1792 - `GroupBy` Symbol Table Entry

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -65,7 +65,7 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.x']
     container:
-      image: chapel/chapel:1.27.0
+      image: chapel/chapel:1.28.0
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -129,7 +129,7 @@ jobs:
     env:
       CHPL_RT_NUM_THREADS_PER_LOCALE: ${{matrix.threads}}
     container:
-      image: chapel/${{matrix.image}}:1.27.0
+      image: chapel/${{matrix.image}}:1.28.0
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -129,7 +129,7 @@ jobs:
     env:
       CHPL_RT_NUM_THREADS_PER_LOCALE: ${{matrix.threads}}
     container:
-      image: chapel/${{matrix.image}}:1.28.0
+      image: chapel/${{matrix.image}}:1.27.0
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.27.0
+      image: chapel/chapel:1.28.0
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
@@ -32,7 +32,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.27.0
+      image: chapel/chapel:1.28.0
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        chpl-version: ['1.26.0', '1.27.0']
+        chpl-version: ['1.27.0', '1.28.0']
     container:
       image: chapel/chapel:${{matrix.chpl-version}}
     steps:
@@ -129,7 +129,7 @@ jobs:
     env:
       CHPL_RT_NUM_THREADS_PER_LOCALE: ${{matrix.threads}}
     container:
-      image: chapel/${{matrix.image}}:1.27.0
+      image: chapel/${{matrix.image}}:1.28.0
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.28.0
+      image: chapel/chapel:1.27.0
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
@@ -32,7 +32,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.28.0
+      image: chapel/chapel:1.27.0
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
@@ -65,7 +65,7 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.x']
     container:
-      image: chapel/chapel:1.28.0
+      image: chapel/chapel:1.27.0
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        chpl-version: ['1.27.0', '1.28.0']
+        chpl-version: ['1.26.0', '1.27.0']
     container:
       image: chapel/chapel:${{matrix.chpl-version}}
     steps:
@@ -129,7 +129,7 @@ jobs:
     env:
       CHPL_RT_NUM_THREADS_PER_LOCALE: ${{matrix.threads}}
     container:
-      image: chapel/${{matrix.image}}:1.28.0
+      image: chapel/${{matrix.image}}:1.27.0
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/ServerModules.cfg
+++ b/ServerModules.cfg
@@ -27,7 +27,11 @@ TimeClassMsg
 HDF5Msg
 ParquetMsg
 HDF5MultiDim
+<<<<<<< HEAD
 EncodingMsg
+=======
+GroupByMsg
+>>>>>>> 83712c49 (GroupBy objects added to the symbol table. This has workarounds that will be updated in the future to remove the dtype storage requirement. Currently only configured to build the GroupBy object from keys. Providing all elements is still fully client side, but will be moved in the future.)
 
 # Add additional modules located outside
 # of the Arkouda src/ directory below.

--- a/ServerModules.cfg
+++ b/ServerModules.cfg
@@ -27,11 +27,8 @@ TimeClassMsg
 HDF5Msg
 ParquetMsg
 HDF5MultiDim
-<<<<<<< HEAD
 EncodingMsg
-=======
 GroupByMsg
->>>>>>> 83712c49 (GroupBy objects added to the symbol table. This has workarounds that will be updated in the future to remove the dtype storage requirement. Currently only configured to build the GroupBy object from keys. Providing all elements is still fully client side, but will be moved in the future.)
 
 # Add additional modules located outside
 # of the Arkouda src/ directory below.

--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -115,24 +115,6 @@ def unique(
 
     # Get all grouping keys
     grouping_keys, nkeys = _get_grouping_keys(pda)
-    # if hasattr(pda, "_get_grouping_keys"):
-    #     # Single groupable array
-    #     nkeys = 1
-    #     grouping_keys = cast(list, cast(groupable_element_type, pda)._get_grouping_keys())
-    # else:
-    #     # Sequence of groupable arrays
-    #     nkeys = len(pda)
-    #     grouping_keys = []
-    #     first = True
-    #     for k in pda:
-    #         if first:
-    #             size = k.size
-    #             first = False
-    #         elif k.size != size:
-    #             raise ValueError("Key arrays must all be same size")
-    #         if not hasattr(k, "_get_grouping_keys"):
-    #             raise TypeError(f"{type(k)} does not support grouping")
-    #         grouping_keys.extend(cast(list, k._get_grouping_keys()))
     keynames = [k.name for k in grouping_keys]
     keytypes = [k.objtype for k in grouping_keys]
     effectiveKeys = len(grouping_keys)

--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -45,12 +45,8 @@ def _get_grouping_keys(pda: groupable):
         # Sequence of groupable arrays
         nkeys = len(pda)
         grouping_keys = []
-        first = True
         for k in pda:
-            if first:
-                size = k.size
-                first = False
-            elif k.size != size:
+            if k.size != pda[0].size:
                 raise ValueError("Key arrays must all be same size")
             if not hasattr(k, "_get_grouping_keys"):
                 raise TypeError(f"{type(k)} does not support grouping")

--- a/src/GroupBy.chpl
+++ b/src/GroupBy.chpl
@@ -1,0 +1,114 @@
+module GroupBy {
+    use AryUtil;
+    use CTypes;
+    use MultiTypeSymbolTable;
+    use MultiTypeSymEntry;
+    use ServerConfig;
+    use Reflection;
+    use Logging;
+    use ServerErrors;
+    use UniqueMsg;
+    use CommAggregation;
+    use Map;
+
+    private config const logLevel = ServerConfig.logLevel;
+    const gbLogger = new Logger(logLevel);
+
+    proc getGroupBy(name: string, st: borrowed SymTab): owned GroupBy throws {
+        var abstractEntry = st.lookup(name);
+        if !abstractEntry.isAssignableTo(SymbolEntryType.GroupBySymEntry) {
+            var errorMsg = "Error: Unhandled SymbolEntryType %s".format(abstractEntry.entryType);
+            gbLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            throw new Error(errorMsg);
+        }
+        var entry: GroupBySymEntry = abstractEntry: borrowed GroupBySymEntry();
+        return new owned GroupBy(name, entry);
+    }
+
+    proc getGroupBy(keyCount: int, keys: [] string, keyTypes: [] string, assumeSorted: bool, st: borrowed SymTab): owned GroupBy throws {
+        var keyNamesEntry = new shared SymEntry(keys);
+        var keyTypesEntry = new shared SymEntry(keyTypes);
+        var (permEntry, segmentsEntry) = if assumeSorted then assumeSortedShortcut(keyCount, keys, keyTypes, st) else uniqueAndCount(keyCount, keys, keyTypes, st);
+
+        var uniqueKeyInds = new shared SymEntry(segmentsEntry.size, int);
+        if (segmentsEntry.size > 0) {
+          // Avoid initializing aggregators if empty array
+          ref perm = permEntry.a;
+          ref segs = segmentsEntry.a;
+          ref inds = uniqueKeyInds.a;
+          forall (i, s) in zip(inds, segs) with (var agg = newSrcAggregator(int)) {
+            agg.copy(i, perm[s]);
+          }
+        }
+
+        // compute itemsize
+        var itemsize: int;
+        forall n in keyNamesEntry.a with (max reduce itemsize){
+            var entry: borrowed GenSymEntry = getGenericTypedArrayEntry(n, st);
+            itemsize = entry.itemsize;
+        }
+
+        var gbEntry = new shared GroupBySymEntry(keyNamesEntry, keyTypesEntry, segmentsEntry, permEntry, uniqueKeyInds, itemsize);
+        var name = st.nextName();
+        st.addEntry(name, gbEntry);
+        return getGroupBy(name, st);
+    }
+
+    class GroupBy {
+        var name: string;
+        var composite: borrowed GroupBySymEntry;
+
+        var keyNames: shared SymEntry(string);
+        var keyTypes: shared SymEntry(string);
+        var segments: shared SymEntry(int);
+        var permutation: shared SymEntry(int);
+        var uniqueKeyIndexes: shared SymEntry(int);
+
+        var length: int;
+        var ngroups: int;
+        var nkeys: int;
+
+        proc init(entryName: string, entry:borrowed GroupBySymEntry) {
+            name = entryName;
+            composite = entry;
+
+            keyNames = composite.keyNamesEntry;
+            keyTypes = composite.keyTypesEntry;
+            segments = composite.segmentsEntry;
+            permutation = composite.permEntry;
+            uniqueKeyIndexes = composite.ukIndEntry;
+
+            length = permutation.size;
+            ngroups = segments.size;
+            nkeys = keyNames.size;
+
+
+            //For initial implementation, UniqueKeyIndexes returned to compute UniqueKeys client side
+        }
+
+        proc getSegmentsName(st: borrowed SymTab): string throws {
+            var sname = st.nextName();
+            st.addEntry(sname, segments);
+            return sname;
+        }
+
+        proc getPermutationName(st: borrowed SymTab): string throws {
+            var pname = st.nextName();
+            st.addEntry(pname, permutation);
+            return pname;
+        }
+
+        proc getUniqueKeyIndexName(st: borrowed SymTab): string throws {
+            var ukname = st.nextName();
+            st.addEntry(ukname, uniqueKeyIndexes);
+            return ukname;
+        }
+
+        proc fillReturnMap(ref rm: map(string, string), st: borrowed SymTab) throws {
+            rm.add("groupby", "created " + st.attrib(this.name));
+            rm.add("segments", "created " + st.attrib(this.getSegmentsName(st)));
+            rm.add("permutation", "created " + st.attrib(this.getPermutationName(st)));
+            rm.add("uniqueKeyIdx", "created " + st.attrib(this.getUniqueKeyIndexName(st)));
+        }
+    }
+}

--- a/src/GroupByMsg.chpl
+++ b/src/GroupByMsg.chpl
@@ -1,0 +1,42 @@
+module GroupByMsg {
+    use CTypes;
+    use Reflection;
+    use ServerErrors;
+    use Logging;
+    use Message;
+    use SegmentedArray;
+    use SegmentedString;
+    use ServerErrorStrings;
+    use ServerConfig;
+    use MultiTypeSymbolTable;
+    use MultiTypeSymEntry;
+    use RandArray;
+    use IO;
+    use Map;
+    use GenSymIO;
+    use GroupBy;
+
+    private config const logLevel = ServerConfig.logLevel;
+    const gmLogger = new Logger(logLevel);
+
+    proc createGroupByMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+        var msgArgs = parseMessageArgs(payload, argSize);
+
+        const assumeSorted = msgArgs.get("assumeSortedStr").getBoolValue();
+        var n = msgArgs.get("nkeys").getIntValue();
+        var keynames = msgArgs.get("keynames").getList(n);
+        var keytypes = msgArgs.get("keytypes").getList(n); 
+
+        var gb = getGroupBy(n, keynames, keytypes, assumeSorted, st);
+
+        // Create message tuple containing the GroupBy obj, segments, permutation, and indexes of unique keys
+        var rtnmap: map(string, string) = new map(string, string);
+        gb.fillReturnMap(rtnmap, st);
+        var repMsg: string = "%jt".format(rtnmap);
+        gmLogger.debug(getModuleName(), getRoutineName(), getLineNumber(), repMsg);
+        return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+
+    use CommandMap;
+    registerFunction("createGroupBy", createGroupByMsg, getModuleName());
+}

--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -428,7 +428,8 @@ module MultiTypeSymEntry
         }
 
         override proc getSizeEstimate(): int {
-            return this.segmentsEntry.getSizeEstimate() + this.permEntry.getSizeEstimate();
+            return this.keyNamesEntry.getSizeEstimate() + this.keyTypesEntry.getSizeEstimate() + 
+            this.segmentsEntry.getSizeEstimate() + this.permEntry.getSizeEstimate() + this.ukIndEntry.getSizeEstimate();
         }
     }
 

--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -10,6 +10,7 @@ module MultiTypeSymEntry
 
     public use NumPyDType;
     public use SymArrayDmap;
+    use MultiTypeSymbolTable;
 
     private config const logLevel = ServerConfig.logLevel;
     const genLogger = new Logger(logLevel);
@@ -24,11 +25,11 @@ module MultiTypeSymEntry
             TypedArraySymEntry, // Parent type for Arrays with a dtype, legacy->GenSymEntry
                 PrimitiveTypedArraySymEntry, // int, uint8, bool, etc.
                 ComplexTypedArraySymEntry,   // DateTime, TimeDelta, IP Address, etc.
+                GroupBySymEntry,      // GroupBy
         
             CompositeSymEntry, // Parent type for things which are composites of arrays
                 SegStringSymEntry,    // SegString composed of offset-int[], bytes->uint(8)
                 CategoricalSymEntry,  // Categorical
-                GroupBySymEntry,      // GroupBy
                 SegArraySymEntry,     // Segmented Array
 
             AnythingSymEntry, // Placeholder to stick aritrary things in the map
@@ -398,6 +399,36 @@ module MultiTypeSymEntry
 
         override proc getSizeEstimate(): int {
             return this.segmentsEntry.getSizeEstimate() + this.valuesEntry.getSizeEstimate();
+        }
+    }
+
+    class GroupBySymEntry:GenSymEntry {
+
+        var keyNamesEntry: shared SymEntry(string);
+        var keyTypesEntry: shared SymEntry(string);
+        var segmentsEntry: shared SymEntry(int);
+        var permEntry: shared SymEntry(int);
+        var ukIndEntry: shared SymEntry(int);
+        
+        proc init(keyNamesEntry: shared SymEntry, keyTypesEntry: shared SymEntry, segmentsSymEntry: shared SymEntry, 
+                    permSymEntry: shared SymEntry, ukIndSymEntry: shared SymEntry, itemsize: int) {
+            super.init(int, permSymEntry.size); // sets this.size = permEntry.size
+            this.entryType = SymbolEntryType.GroupBySymEntry;
+            assignableTypes.add(this.entryType);
+            this.keyNamesEntry = keyNamesEntry;
+            this.keyTypesEntry = keyTypesEntry;
+            this.segmentsEntry = segmentsSymEntry;
+            this.permEntry = permSymEntry;
+            this.ukIndEntry = ukIndSymEntry;
+
+            this.dtype = DType.UNDEF; // not required by groupby, but needs initialization
+            this.itemsize = itemsize; // itemsize will vary and can be accessed from specific keys
+
+            this.ndim = this.segmentsEntry.size; // used as the number of groups
+        }
+
+        override proc getSizeEstimate(): int {
+            return this.segmentsEntry.getSizeEstimate() + this.permEntry.getSizeEstimate();
         }
     }
 


### PR DESCRIPTION
Closes #1792 

- Adds a Symbol Table Entry for `GroupBy` objects. These are only created currently in the case when `keys` is provided. If all elements are provided, the object remains client side. Issue #1803 addresses adding support creation from all components.
- `GroupBySymEntry` inherits from `GenSymEntry` in preparation for removing `CompositeSymEntry`. `CompositeSymEntry` currently does not add any information that is not found in `GenSymEntry` and does not appear necessary.
- Updates the client side constructor to send a server message to create the `GroupBy` object. 
- Adds `createGroupBy` message.
- Currently, the `unique_keys` property is not stored on the server. Issue #1804 will address computing Unique Keys on the server. 

This code utilizes components of `Unique`, but does not require the full workflow at this time.