### PR TITLE
Closes #1808 - `ak.in1d()` Runtime Errors

### DIFF
--- a/arkouda/message.py
+++ b/arkouda/message.py
@@ -199,8 +199,11 @@ class ParameterObject:
         ParameterObject - The parameter object formatted to be parsed by the chapel server
         """
         from arkouda.pdarrayclass import pdarray
+
         dispatch = ParameterObject.generate_dispatch()
-        if isinstance(val, pdarray):  # this is done here to avoid multiple dispatch entries for the same type
+        if isinstance(
+            val, pdarray
+        ):  # this is done here to avoid multiple dispatch entries for the same type
             return cls._build_pdarray_param(key, val)
         elif (f := dispatch.get(type(val).__name__)) is not None:
             return f(key, val)

--- a/tests/message_test.py
+++ b/tests/message_test.py
@@ -145,7 +145,7 @@ class JSONArgs(ArkoudaTest):
         self.assertEqual(size, 1)
         msgArgs = json.loads(json.loads(args)[0])
         self.assertEqual(msgArgs["key"], "datetime")
-        self.assertEqual(msgArgs["objType"], "DATETIME")
+        self.assertEqual(msgArgs["objType"], "PDARRAY")
         self.assertEqual(msgArgs["dtype"], "int64")
         self.assertRegex(msgArgs["val"], "^id_\\w{7}_\\d$")
 

--- a/tests/message_test.py
+++ b/tests/message_test.py
@@ -153,6 +153,7 @@ class JSONArgs(ArkoudaTest):
         a = arange(10)
         ip = ip_address(a)
         size, args = _json_args_to_str({"ip": ip})
+        self.assertEqual(size, 1)
         msgArgs = json.loads(json.loads(args)[0])
         self.assertEqual(msgArgs["key"], "ip")
         self.assertEqual(msgArgs["objType"], "PDARRAY")
@@ -161,16 +162,13 @@ class JSONArgs(ArkoudaTest):
 
         f = Fields(a, names="ABCD")
         size, args = _json_args_to_str({"fields": f})
+        self.assertEqual(size, 1)
         msgArgs = json.loads(json.loads(args)[0])
         self.assertEqual(msgArgs["key"], "fields")
         self.assertEqual(msgArgs["objType"], "PDARRAY")
         self.assertEqual(msgArgs["dtype"], "uint64")
         self.assertRegex(msgArgs["val"], "^id_\\w{7}_\\d+$")
 
-        # test ip_address
-        ip = ip_address(a)
-        size, args = _json_args_to_str({"ip": ip})
-        self.assertEqual(size, 1)
 
         # test list of pdarray
         pd1 = arange(3)

--- a/tests/setops_test.py
+++ b/tests/setops_test.py
@@ -318,6 +318,22 @@ class SetOpsTest(ArkoudaTest):
 
         self.assertListEqual([x < 2 for x in vals], ak.in1d(stringsOne, stringsTwo).to_list())
 
+        # adding tests for unique dtypes
+        a = ak.arange(10)
+        b = ak.arange(5, 15)
+
+        ip1 = ak.ip_address(a)
+        ip2 = ak.ip_address(b)
+        self.assertListEqual([x >= 5 for x in range(10)], ak.in1d(ip1, ip2).to_list())
+
+        dt1 = ak.Datetime(a)
+        dt2 = ak.Datetime(b)
+        self.assertListEqual([x >= 5 for x in range(10)], ak.in1d(dt1, dt2).to_list())
+
+        f1 = ak.Fields(a, names="ABCD")
+        f2 = ak.Fields(b, names="ABCD")
+        self.assertListEqual([x >= 5 for x in range(10)], ak.in1d(f1, f2).to_list())
+
     def test_multiarray_validation(self):
         x = [ak.arange(3), ak.arange(3), ak.arange(3)]
         y = [ak.arange(2), ak.arange(2)]


### PR DESCRIPTION
Closes #1808 

This updates the JSON parsing to properly format JSON for server messages. The issue was that the types breaking were not in the dispatch table. However, since all of the types return true for `isinstance(obj, pdarray)`, The factory method has been updated to check if the value is a pdarray and then run the pdarray conversion.  This prevents the need for multiple entries in the dispatch table doing the same thing.