### PR TITLE
Closes #1810 add `get_prefixes` and `get_suffixes` to `Strings`

### DIFF
--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1475,7 +1475,7 @@ class Strings:
 
     def get_prefixes(
         self, n: int_scalars, return_origins: bool = True, proper: bool = True
-    ) -> Union[Strings, Tuple[pdarray, Strings]]:
+    ) -> Union[Strings, Tuple[Strings, pdarray]]:
         """
         Return the n-long prefix of each string, where possible
 
@@ -1500,7 +1500,7 @@ class Strings:
             Boolean array that is True where the string was long enough to return
             an n-character prefix, False otherwise.
         """
-        repMsg = generic_msg(
+        repMsg = cast(str, generic_msg(
             cmd="segmentedSubstring",
             args={
                 "objType": self.objtype,
@@ -1510,18 +1510,18 @@ class Strings:
                 "kind": "prefixes",
                 "proper": str(proper).lower(),
             },
-        )
+        ))
         if return_origins:
             parts = repMsg.split("+")
             prefixes = Strings.from_return_msg("+".join(parts[:2]))
             longenough = create_pdarray(parts[2])
-            return prefixes, longenough
+            return prefixes, cast(pdarray, longenough)
         else:
             return Strings.from_return_msg(repMsg)
 
     def get_suffixes(
         self, n: int_scalars, return_origins: bool = True, proper: bool = True
-    ) -> Union[Strings, Tuple[pdarray, Strings]]:
+    ) -> Union[Strings, Tuple[Strings, pdarray]]:
         """
         Return the n-long suffix of each string, where possible
 
@@ -1546,7 +1546,7 @@ class Strings:
             Boolean array that is True where the string was long enough to return
             an n-character suffix, False otherwise.
         """
-        repMsg = generic_msg(
+        repMsg = cast(str, generic_msg(
             cmd="segmentedSubstring",
             args={
                 "objType": self.objtype,
@@ -1556,12 +1556,12 @@ class Strings:
                 "kind": "suffixes",
                 "proper": str(proper).lower(),
             },
-        )
+        ))
         if return_origins:
             parts = repMsg.split("+")
             suffixes = Strings.from_return_msg("+".join(parts[:2]))
             longenough = create_pdarray(parts[2])
-            return suffixes, longenough
+            return suffixes, cast(pdarray, longenough)
         else:
             return Strings.from_return_msg(repMsg)
 

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1504,11 +1504,11 @@ class Strings:
             cmd="segmentedSubstring",
             args={
                 "objType": self.objtype,
-                "name": self.name,
+                "name": self,
                 "nChars": n,
                 "returnOrigins": return_origins,
                 "kind": "prefixes",
-                "proper": str(proper).lower(),
+                "proper": proper,
             },
         ))
         if return_origins:
@@ -1550,11 +1550,11 @@ class Strings:
             cmd="segmentedSubstring",
             args={
                 "objType": self.objtype,
-                "name": self.name,
+                "name": self,
                 "nChars": n,
                 "returnOrigins": return_origins,
                 "kind": "suffixes",
-                "proper": str(proper).lower(),
+                "proper": proper,
             },
         ))
         if return_origins:

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1473,6 +1473,84 @@ class Strings:
     def __radd__(self, other: Strings) -> Strings:
         return self.lstick(other)
 
+    def get_prefixes(self, n: integral, return_origins:bool=True, proper:bool=True) -> Union[Strings,Tuple[pdarray,Strings]]:
+        """
+        Return the n-long prefix of each string, where possible
+
+        Parameters
+        ----------
+        n : int
+            Length of prefix
+        return_origins : bool
+            If True, return a logical index indicating which strings
+            were long enough to return an n-prefix
+        proper : bool
+            If True, only return proper prefixes, i.e. from strings
+            that are at least n+1 long. If False, allow the entire
+            string to be returned as a prefix.
+
+        Returns
+        -------
+        prefixes : Strings
+            The array of n-character prefixes; the number of elements is the number of 
+            True values in the returned mask.
+        origin_indices : pdarray, bool
+            Boolean array that is True where the string was long enough to return
+            an n-character prefix, False otherwise.
+        """
+        repMsg = generic_msg(cmd="segmentedSubstring", args={"objType": self.objtype,
+                                                             "name": self.name,
+                                                             "nChars": n,
+                                                             "returnOrigins": return_origins,
+                                                             "kind": "prefixes",
+                                                             "proper": str(proper).lower()})
+        if return_origins:
+            parts = repMsg.split("+")
+            prefixes = Strings.from_return_msg("+".join(parts[:2]))
+            longenough = create_pdarray(parts[2])
+            return prefixes, longenough
+        else:
+            return Strings.from_return_msg(repMsg)
+
+    def get_suffixes(self, n: integral, return_origins:bool=True, proper:bool=True) -> Union[Strings,Tuple[pdarray,Strings]]:
+        """
+        Return the n-long suffix of each string, where possible
+
+        Parameters
+        ----------
+        n : int
+            Length of suffix
+        return_origins : bool
+            If True, return a logical index indicating which strings
+            were long enough to return an n-suffix
+        proper : bool
+            If True, only return proper suffixes, i.e. from strings
+            that are at least n+1 long. If False, allow the entire
+            string to be returned as a suffix.
+
+        Returns
+        -------
+        suffixes : Strings
+            The array of n-character suffixes; the number of elements is the number of 
+            True values in the returned mask.
+        origin_indices : pdarray, bool
+            Boolean array that is True where the string was long enough to return
+            an n-character suffix, False otherwise.
+        """
+        repMsg = generic_msg(cmd="segmentedSubstring", args={"objType": self.objtype,
+                                                             "name": self.name,
+                                                             "nChars": n,
+                                                             "returnOrigins": return_origins,
+                                                             "kind": "suffixes",
+                                                             "proper": str(proper).lower()})
+        if return_origins:
+            parts = repMsg.split("+")
+            suffixes = Strings.from_return_msg("+".join(parts[:2]))
+            longenough = create_pdarray(parts[2])
+            return suffixes, longenough
+        else:
+            return Strings.from_return_msg(repMsg)
+
     def hash(self) -> Tuple[pdarray, pdarray]:
         """
         Compute a 128-bit hash of each string.

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1473,7 +1473,9 @@ class Strings:
     def __radd__(self, other: Strings) -> Strings:
         return self.lstick(other)
 
-    def get_prefixes(self, n: integral, return_origins:bool=True, proper:bool=True) -> Union[Strings,Tuple[pdarray,Strings]]:
+    def get_prefixes(
+        self, n: int_scalars, return_origins: bool = True, proper: bool = True
+    ) -> Union[Strings, Tuple[pdarray, Strings]]:
         """
         Return the n-long prefix of each string, where possible
 
@@ -1492,18 +1494,23 @@ class Strings:
         Returns
         -------
         prefixes : Strings
-            The array of n-character prefixes; the number of elements is the number of 
+            The array of n-character prefixes; the number of elements is the number of
             True values in the returned mask.
         origin_indices : pdarray, bool
             Boolean array that is True where the string was long enough to return
             an n-character prefix, False otherwise.
         """
-        repMsg = generic_msg(cmd="segmentedSubstring", args={"objType": self.objtype,
-                                                             "name": self.name,
-                                                             "nChars": n,
-                                                             "returnOrigins": return_origins,
-                                                             "kind": "prefixes",
-                                                             "proper": str(proper).lower()})
+        repMsg = generic_msg(
+            cmd="segmentedSubstring",
+            args={
+                "objType": self.objtype,
+                "name": self.name,
+                "nChars": n,
+                "returnOrigins": return_origins,
+                "kind": "prefixes",
+                "proper": str(proper).lower(),
+            },
+        )
         if return_origins:
             parts = repMsg.split("+")
             prefixes = Strings.from_return_msg("+".join(parts[:2]))
@@ -1512,7 +1519,9 @@ class Strings:
         else:
             return Strings.from_return_msg(repMsg)
 
-    def get_suffixes(self, n: integral, return_origins:bool=True, proper:bool=True) -> Union[Strings,Tuple[pdarray,Strings]]:
+    def get_suffixes(
+        self, n: int_scalars, return_origins: bool = True, proper: bool = True
+    ) -> Union[Strings, Tuple[pdarray, Strings]]:
         """
         Return the n-long suffix of each string, where possible
 
@@ -1531,18 +1540,23 @@ class Strings:
         Returns
         -------
         suffixes : Strings
-            The array of n-character suffixes; the number of elements is the number of 
+            The array of n-character suffixes; the number of elements is the number of
             True values in the returned mask.
         origin_indices : pdarray, bool
             Boolean array that is True where the string was long enough to return
             an n-character suffix, False otherwise.
         """
-        repMsg = generic_msg(cmd="segmentedSubstring", args={"objType": self.objtype,
-                                                             "name": self.name,
-                                                             "nChars": n,
-                                                             "returnOrigins": return_origins,
-                                                             "kind": "suffixes",
-                                                             "proper": str(proper).lower()})
+        repMsg = generic_msg(
+            cmd="segmentedSubstring",
+            args={
+                "objType": self.objtype,
+                "name": self.name,
+                "nChars": n,
+                "returnOrigins": return_origins,
+                "kind": "suffixes",
+                "proper": str(proper).lower(),
+            },
+        )
         if return_origins:
             parts = repMsg.split("+")
             suffixes = Strings.from_return_msg("+".join(parts[:2]))

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -1383,24 +1383,17 @@ module SegmentedMsg {
     select (objtype) {
       when ("str") {
         var strings = getSegString(name, st);
-        var returnOrigins = msgArgs.getValueOf("returnOrigins").toLower(): bool;
+        var returnOrigins = msgArgs.get("returnOrigins").getBoolValue();
+        var (off, byt, longEnough) = strings.getFixes(msgArgs.get("nChars").getIntValue(),
+                                                      msgArgs.getValueOf("kind"): Fixes,
+                                                      msgArgs.get("proper").getBoolValue());
+        var retString = getSegString(off, byt, st);
+        repMsg = "created " + st.attrib(retString.name) + "+created bytes.size %t".format(retString.nBytes);
         if returnOrigins {
-          var (off, byt, longEnough) = strings.getFixes(msgArgs.getValueOf("nChars"): int,
-                                                        msgArgs.getValueOf("kind"): Fixes,
-                                                        msgArgs.getValueOf("proper").toLower(): bool,
-                                                        true);
-          var retString = getSegString(off, byt, st);
           var leName = st.nextName();
           st.addEntry(leName, new shared SymEntry(longEnough));
-          repMsg = "created " + st.attrib(retString.name) + "+created bytes.size %t".format(retString.nBytes) + "+created " + st.attrib(leName);
-        } else {
-          var (off, byt) = strings.getFixes(msgArgs.getValueOf("nChars"): int,
-                                            msgArgs.getValueOf("kind"): Fixes,
-                                            msgArgs.getValueOf("proper").toLower(): bool,
-                                            false);
-          var retString = getSegString(off, byt, st);
-          repMsg = "created " + st.attrib(retString.name) + "+created bytes.size %t".format(retString.nBytes);
-        }
+          repMsg += "+created " + st.attrib(leName);
+        } 
         return new MsgTuple(repMsg, MsgType.NORMAL);
       }
       otherwise {

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -1368,6 +1368,48 @@ module SegmentedMsg {
     var repMsg = "%jt".format(rtn);
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
+
+  proc segmentedSubstringMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    var pn = Reflection.getRoutineName();
+    var repMsg: string;
+
+    var msgArgs = parseMessageArgs(payload, argSize);
+    var objtype = msgArgs.getValueOf("objType");
+    var name = msgArgs.getValueOf("name");
+    
+    // check to make sure symbols defined
+    st.checkTable(name);
+
+    select (objtype) {
+      when ("str") {
+        var strings = getSegString(name, st);
+        var returnOrigins = msgArgs.getValueOf("returnOrigins").toLower(): bool;
+        if returnOrigins {
+          var (off, byt, longEnough) = strings.getFixes(msgArgs.getValueOf("nChars"): int,
+                                                        msgArgs.getValueOf("kind"): Fixes,
+                                                        msgArgs.getValueOf("proper").toLower(): bool,
+                                                        true);
+          var retString = getSegString(off, byt, st);
+          var leName = st.nextName();
+          st.addEntry(leName, new shared SymEntry(longEnough));
+          repMsg = "created " + st.attrib(retString.name) + "+created bytes.size %t".format(retString.nBytes) + "+created " + st.attrib(leName);
+        } else {
+          var (off, byt) = strings.getFixes(msgArgs.getValueOf("nChars"): int,
+                                            msgArgs.getValueOf("kind"): Fixes,
+                                            msgArgs.getValueOf("proper").toLower(): bool,
+                                            false);
+          var retString = getSegString(off, byt, st);
+          repMsg = "created " + st.attrib(retString.name) + "+created bytes.size %t".format(retString.nBytes);
+        }
+        return new MsgTuple(repMsg, MsgType.NORMAL);
+      }
+      otherwise {
+          var errorMsg = notImplementedError(pn, "%s".format(objtype));
+          smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+          return new MsgTuple(errorMsg, MsgType.ERROR);
+      }
+    }
+  }
   
   use CommandMap;
   registerFunction("segmentLengths", segmentLengthsMsg, getModuleName());
@@ -1391,4 +1433,5 @@ module SegmentedMsg {
   registerFunction("segStr-assemble", assembleStringsMsg, getModuleName());
   registerFunction("stringsToJSON", stringsToJSONMsg, getModuleName());
   registerBinaryFunction("segStr-tondarray", segStrTondarrayMsg, getModuleName());
+  registerFunction("segmentedSubstring", segmentedSubstringMsg, getModuleName());
 }

--- a/src/SegmentedString.chpl
+++ b/src/SegmentedString.chpl
@@ -1117,7 +1117,7 @@ module SegmentedString {
       return ranks;
     }
 
-    proc getFixesHelper(n: int, kind: Fixes, proper: bool) {
+    proc getFixes(n: int, kind: Fixes, proper: bool) {
       const lengths = getLengths() - 1;
       var longEnough = makeDistArray(size, bool);
       if proper {
@@ -1159,15 +1159,6 @@ module SegmentedString {
         agg.copy(b, va[i]);
       }
       return (retOffsets, retBytes, longEnough);
-    }
-
-    proc getFixes(n: int, kind: Fixes, proper: bool, param returnOrigins) where returnOrigins {
-      return getFixesHelper(n, kind, proper);
-    }
-
-    proc getFixes(n: int, kind: Fixes, proper: bool, param returnOrigins) where !returnOrigins {
-      var (off, byt, le) = getFixesHelper(n, kind, proper);
-      return (off, byt);
     }
 
   } // class SegString

--- a/src/SegmentedString.chpl
+++ b/src/SegmentedString.chpl
@@ -1130,8 +1130,9 @@ module SegmentedString {
       forall (i, o) in zip(retOffsets.domain, retOffsets) {
         o = i * (n + 1);
       }
-      var retBytes = makeDistArray(nFound * (n + 1), uint(8));
-      var srcInds = makeDistArray(nFound * (n + 1), int);
+      const retDom = makeDistDom(nFound * (n + 1));
+      var retBytes: [retDom] uint(8);
+      var srcInds: [retDom] int;
       var dstInds = (+ scan longEnough) - longEnough;
       ref oa = offsets.a;
       if kind == Fixes.prefixes {

--- a/src/SegmentedString.chpl
+++ b/src/SegmentedString.chpl
@@ -24,6 +24,11 @@ module SegmentedString {
   private config param useHash = true;
   param SegmentedStringUseHash = useHash;
 
+  enum Fixes {
+    prefixes,
+    suffixes,
+  };  
+
   private config param regexMaxCaptures = ServerConfig.regexMaxCaptures;
 
   proc getSegString(name: string, st: borrowed SymTab): owned SegString throws {
@@ -1110,6 +1115,59 @@ module SegmentedString {
       }
       var ranks = twoPhaseStringSort(this);
       return ranks;
+    }
+
+    proc getFixesHelper(n: int, kind: Fixes, proper: bool) {
+      const lengths = getLengths() - 1;
+      var longEnough = makeDistArray(size, bool);
+      if proper {
+        longEnough = (lengths > n);
+      } else {
+        longEnough = (lengths >= n);
+      }
+      var nFound = + reduce longEnough;
+      var retOffsets = makeDistArray(nFound, int);
+      forall (i, o) in zip(retOffsets.domain, retOffsets) {
+        o = i * (n + 1);
+      }
+      var retBytes = makeDistArray(nFound * (n + 1), uint(8));
+      var srcInds = makeDistArray(nFound * (n + 1), int);
+      var dstInds = (+ scan longEnough) - longEnough;
+      ref oa = offsets.a;
+      if kind == Fixes.prefixes {
+        forall (d, o, le) in zip(dstInds, oa, longEnough) with (var agg = newDstAggregator(int)) {
+          if le {
+            const srcIndStart = d * (n + 1);
+            for j in 0..#(n+1) {
+              agg.copy(srcInds[srcIndStart + j], o + j);
+            }
+          }
+        }
+      } else if kind == Fixes.suffixes {
+        forall (d, o, l, le) in zip(dstInds, oa, lengths, longEnough) with (var agg = newDstAggregator(int)) {
+          if le {
+            const srcIndStart = d * (n + 1);
+            const byteStart = o + l - n;
+            for j in 0..#(n+1) {
+              agg.copy(srcInds[srcIndStart + j], byteStart + j);
+            }
+          }
+        }
+      }
+      ref va = values.a;
+      forall (b, i) in zip(retBytes, srcInds) with (var agg = newSrcAggregator(uint(8))) {
+        agg.copy(b, va[i]);
+      }
+      return (retOffsets, retBytes, longEnough);
+    }
+
+    proc getFixes(n: int, kind: Fixes, proper: bool, param returnOrigins) where returnOrigins {
+      return getFixesHelper(n, kind, proper);
+    }
+
+    proc getFixes(n: int, kind: Fixes, proper: bool, param returnOrigins) where !returnOrigins {
+      var (off, byt, le) = getFixesHelper(n, kind, proper);
+      return (off, byt);
     }
 
   } // class SegString

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -613,3 +613,27 @@ class StringTest(ArkoudaTest):
         # Unordered (but still deterministic) concatenation
         # TODO: the unordered concatenation test is disabled per #710 #721
         # s12unord = ak.concatenate([s1, s2], ordered=False)
+
+    def test_get_fixes(self):
+        strings = ak.array(["abc", "d", "efghi"])
+        p, r = strings.get_prefixes(1, return_origins=True, proper=True)
+        self.assertListEqual(["a", "e"], p.to_list())
+        self.assertListEqual([True, False, True], r.to_list())
+
+        p, r = strings.get_prefixes(1, return_origins=True, proper=False)
+        self.assertListEqual(["a", "d", "e"], p.to_list())
+        self.assertListEqual([True, True, True], r.to_list())
+
+        p = strings.get_prefixes(1, return_origins=False, proper=False)
+        self.assertListEqual(["a", "d", "e"], p.to_list())
+
+        p, r = strings.get_suffixes(1, return_origins=True, proper=True)
+        self.assertListEqual(["c", "i"], p.to_list())
+        self.assertListEqual([True, False, True], r.to_list())
+
+        p, r = strings.get_suffixes(1, return_origins=True, proper=False)
+        self.assertListEqual(["c", "d", "i"], p.to_list())
+        self.assertListEqual([True, True, True], r.to_list())
+
+        p = strings.get_suffixes(1, return_origins=False, proper=False)
+        self.assertListEqual(["c", "d", "i"], p.to_list())


### PR DESCRIPTION
Closes #1810 . This PR extends the `SegArray.get_prefixes()` and `.get_suffixes()` semantics to `Strings`. It includes a new unit test.