### PR TITLE
Raise instantiation limit for 1.26/1.27

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,10 +264,12 @@ ARKOUDA_MAIN_SOURCE := $(ARKOUDA_SOURCE_DIR)/$(ARKOUDA_MAIN_MODULE).chpl
 
 ifeq ($(shell expr $(CHPL_MINOR) \< 27),1)
 	ARKOUDA_COMPAT_MODULES += -M $(ARKOUDA_SOURCE_DIR)/compat/lt-127
+	CHPL_FLAGS += --instantiate-max 512
 endif
 
 ifeq ($(shell expr $(CHPL_MINOR) \= 27),1)
 	ARKOUDA_COMPAT_MODULES += -M $(ARKOUDA_SOURCE_DIR)/compat/e-127
+	CHPL_FLAGS += --instantiate-max 512
 endif
 
 ifeq ($(shell expr $(CHPL_MINOR) \>= 28),1)


### PR DESCRIPTION
Chapel will error if a generic function is instantiated too many times in order to avoid infinite loops with recursive instantiations. Recently, we've hit the default limit of 256 instantiations for some internal functions used for I/O, but this isn't actually an issue so just raise the default to 512 instantiations. Note that Chapel 1.28 improved the situation by ignoring the specific IO function and raising the default to 512 so we only need this for older versions.