### PR TITLE
Adjust formal names of function type for callback in 'registerFunction'

### DIFF
--- a/src/CommandMap.chpl
+++ b/src/CommandMap.chpl
@@ -9,7 +9,7 @@ module CommandMap {
    * construct the FCF type, but there is no way to generate a
    * FCF that throws using `func()` today.
    */
-  proc akMsgSign(a: string, b: string, c: int, d: borrowed SymTab): MsgTuple throws {
+  proc akMsgSign(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
     var rep = new MsgTuple("dummy-msg", MsgType.NORMAL);
     return rep;
   }
@@ -18,7 +18,7 @@ module CommandMap {
    * Just like akMsgSign, but Messages which have a binary return
    * require a different signature
    */
-  proc akBinMsgSign(a: string, b: string, c: int, d: borrowed SymTab): bytes throws {
+  proc akBinMsgSign(cmd: string, payload: string, argSize: int, st: borrowed SymTab): bytes throws {
     var nb = b"\x00";
     return nb;
   }

--- a/src/MsgProcessing.chpl
+++ b/src/MsgProcessing.chpl
@@ -161,7 +161,7 @@ module MsgProcessing
 
     :returns: MsgTuple
      */
-    proc getmemusedMsg(cmd: string, payload: string, size:int, st: borrowed SymTab): MsgTuple throws {
+    proc getmemusedMsg(cmd: string, payload: string, argSize:int, st: borrowed SymTab): MsgTuple throws {
         var repMsg: string; // response message
         mpLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"cmd: %s".format(cmd));
         if (memTrack) {


### PR DESCRIPTION
Adjust formal names of function type for callback in 'registerFunction'

A recent Chapel PR https://github.com/chapel-lang/chapel/pull/20554
has modified Chapel's FCF implementation. One of the effects (right
now, TBD) is that formal names become significant when comparing
function types.

The `registerFunction` function takes a FCF callback, and the naming
convention when defining these callbacks is to use formals like:

```chapel
proc foo(cmd: string, payload: string, argSize: int, st: borrowed SymTab);
```

However the function type used in `registerFunction` had the formal
names `a`/`b`/`c`/`d`.

Adjust the function type used in the definition of `registerFunction`
to have formal names `cmd`/`payload`/`argSize`/`st`.

Adjust the formal names of one callback `getmemusedMsg`.

Note that the first-class-function story in Chapel is unstable and
will be undergoing a lot of turbulence in the period before the
1.29 release.

We will do our best going forward to make sure that the old behavior
of FCFs is preserved until all the new functionality is finalized.

For now, ensuring that all callbacks have the same formal names as
used in the `registerFunction` callback formal, should keep things
stable moving forward.