### PR TITLE
Closes #1825: Fix aggregator use in median reduction

### DIFF
--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -832,17 +832,28 @@ module ReductionMsg
         valsAgg.copy(sv, noNanVals[idx]);
       }
 
-      // Now that we have sorted segments, grab the middle element
-      forall (s, c, r) in zip(segments, counts, res) with (var resAgg = newSrcAggregator(real)) {
+      var tmp1: [D] t;
+      var tmp2: [D] t;
+      forall (s, c, r, t1, t2) in zip(segments, counts, res, tmp1, tmp2) with (var resAgg = newSrcAggregator(t)) {
         if c % 2 != 0 {
           // odd case: grab middle of sorted values
-          resAgg.copy(r, sortedVals[s + (c + 1)/2 - 1]:real);
+          resAgg.copy(t1, sortedVals[s + (c + 1)/2 - 1]);
         }
         else {
           // even case: average the 2 middles of the sorted values
-          resAgg.copy(r, (sortedVals[s + c/2 - 1]:real + sortedVals[s + c/2]:real) / 2.0 );
+          resAgg.copy(t1, sortedVals[s + c/2 - 1]);
+          resAgg.copy(t2, sortedVals[s + c/2]);
         }
       }
+
+      forall (c, r, t1, t2) in zip(counts, res, tmp1, tmp2) {
+        if c % 2 != 0 {
+          r = t1:real;
+        } else {
+          r = ((t1+t2):real)/2.0;
+        }
+      }
+
       return res;
     }
 


### PR DESCRIPTION
The newly added median reduction was trying to aggregate a temporary value, which meant that when the aggregator went to flush and copy the values over, the value had gone out of scope and the reference was to garbage memory, which may or may not still have held the correct value.

This PR introduces intermediary arrays that remove the temporary value from the aggregator and also aggregates the `GET`s to the `sortedVal`s array.

Closes: https://github.com/Bears-R-Us/arkouda/issues/1825