### PR TITLE
Part of #1404: Avoid flushing aggregators in lockstep

### DIFF
--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -40,6 +40,7 @@ module CommAggregation {
     type aggType = (c_ptr(elemType), elemType);
     const bufferSize = dstBuffSize;
     const myLocaleSpace = 0..<numLocales;
+    var lastLocale: int;
     var opsUntilYield = yieldFrequency;
     var lBuffers: c_ptr(c_ptr(aggType));
     var rBuffers: [myLocaleSpace] remoteBuffer(aggType);
@@ -65,7 +66,8 @@ module CommAggregation {
     }
 
     proc flush() {
-      for loc in myLocaleSpace {
+      for offsetLoc in myLocaleSpace + lastLocale {
+        const loc = offsetLoc % numLocales;
         _flushBuffer(loc, bufferIdxs[loc], freeData=true);
       }
     }
@@ -73,6 +75,7 @@ module CommAggregation {
     inline proc copy(ref dst: elemType, const in srcVal: elemType) {
       // Get the locale of dst and the local address on that locale
       const loc = dst.locale.id;
+      lastLocale = loc;
       const dstAddr = getAddr(dst);
 
       // Get our current index into the buffer for dst's locale
@@ -152,13 +155,13 @@ module CommAggregation {
     type aggType = c_ptr(elemType);
     const bufferSize = srcBuffSize;
     const myLocaleSpace = 0..<numLocales;
+    var lastLocale: int;
     var opsUntilYield = yieldFrequency;
     var dstAddrs: c_ptr(c_ptr(aggType));
     var lSrcAddrs: c_ptr(c_ptr(aggType));
     var lSrcVals: [myLocaleSpace][0..#bufferSize] elemType;
     var rSrcAddrs: [myLocaleSpace] remoteBuffer(aggType);
     var rSrcVals: [myLocaleSpace] remoteBuffer(elemType);
-
     var bufferIdxs: c_ptr(int);
 
     proc postinit() {
@@ -186,7 +189,8 @@ module CommAggregation {
     }
 
     proc flush() {
-      for loc in myLocaleSpace {
+      for offsetLoc in myLocaleSpace + lastLocale {
+        const loc = offsetLoc % numLocales;
         _flushBuffer(loc, bufferIdxs[loc], freeData=true);
       }
     }
@@ -198,6 +202,7 @@ module CommAggregation {
       const dstAddr = getAddr(dst);
 
       const loc = src.locale.id;
+      lastLocale = loc;
       const srcAddr = getAddr(src);
 
       ref bufferIdx = bufferIdxs[loc];


### PR DESCRIPTION
When flushing, previously all aggregators would flush to locale 0, then 1 and so on in lockstep. This created a many-to-one bottleneck, especially at scale. This updates aggregators to start flushing to the locale they last aggregated a value for. Keeping track of the last locale should be trivially fast and getting rid of the lockstep comm behavior should improve performance of all aggregated operations, including sort, at higher scales.

I'll have more comprehensive performance results later, but on an older 240 node SGI InfiniBand machine I see a small sort (512 KiB per node) go from ~1.6s to ~0.7s and a medium sort (512 MiB per node) go from ~2.5s to ~1.8s.

Part of #1404