### PR TITLE
Closes #1799 - idna `encoding`/`decoding`

### DIFF
--- a/ServerModules.cfg
+++ b/ServerModules.cfg
@@ -27,6 +27,7 @@ TimeClassMsg
 HDF5Msg
 ParquetMsg
 HDF5MultiDim
+EncodingMsg
 
 # Add additional modules located outside
 # of the Arkouda src/ directory below.

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -356,6 +356,14 @@ class Strings:
             generic_msg(cmd="segmentLengths", args={"objType": self.objtype, "obj": self.entry})
         )
 
+    def idna_encode(self):
+        rep_msg = generic_msg(cmd="encode", args={"encoding": "idna", "obj": self.entry})
+        return Strings.from_return_msg(rep_msg)
+
+    def idna_decode(self):
+        rep_msg = generic_msg(cmd="decode", args={"encoding": "idna", "obj": self.entry})
+        return Strings.from_return_msg(rep_msg)
+
     @typechecked
     def to_lower(self) -> Strings:
         """
@@ -1500,17 +1508,20 @@ class Strings:
             Boolean array that is True where the string was long enough to return
             an n-character prefix, False otherwise.
         """
-        repMsg = cast(str, generic_msg(
-            cmd="segmentedSubstring",
-            args={
-                "objType": self.objtype,
-                "name": self,
-                "nChars": n,
-                "returnOrigins": return_origins,
-                "kind": "prefixes",
-                "proper": proper,
-            },
-        ))
+        repMsg = cast(
+            str,
+            generic_msg(
+                cmd="segmentedSubstring",
+                args={
+                    "objType": self.objtype,
+                    "name": self,
+                    "nChars": n,
+                    "returnOrigins": return_origins,
+                    "kind": "prefixes",
+                    "proper": proper,
+                },
+            ),
+        )
         if return_origins:
             parts = repMsg.split("+")
             prefixes = Strings.from_return_msg("+".join(parts[:2]))
@@ -1546,17 +1557,20 @@ class Strings:
             Boolean array that is True where the string was long enough to return
             an n-character suffix, False otherwise.
         """
-        repMsg = cast(str, generic_msg(
-            cmd="segmentedSubstring",
-            args={
-                "objType": self.objtype,
-                "name": self,
-                "nChars": n,
-                "returnOrigins": return_origins,
-                "kind": "suffixes",
-                "proper": proper,
-            },
-        ))
+        repMsg = cast(
+            str,
+            generic_msg(
+                cmd="segmentedSubstring",
+                args={
+                    "objType": self.objtype,
+                    "name": self,
+                    "nChars": n,
+                    "returnOrigins": return_origins,
+                    "kind": "suffixes",
+                    "proper": proper,
+                },
+            ),
+        )
         if return_origins:
             parts = repMsg.split("+")
             suffixes = Strings.from_return_msg("+".join(parts[:2]))

--- a/src/EncodingMsg.chpl
+++ b/src/EncodingMsg.chpl
@@ -1,0 +1,47 @@
+module EncodingMsg {
+    use Subprocess;
+    use Reflection;
+    use Logging;
+    use ServerConfig;
+    use Message;
+    use MultiTypeSymbolTable;
+    use MultiTypeSymEntry;
+    use CommAggregation;
+    use ServerErrors;
+    use ServerErrorStrings;
+
+    use SegmentedString;
+
+    private config const logLevel = ServerConfig.logLevel;
+    const emLogger = new Logger(logLevel);
+
+    proc encodeDecodeMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+        var repMsg: string;
+        var msgArgs = parseMessageArgs(payload, argSize);
+        var encoding = msgArgs.getValueOf("encoding");
+
+        var stringsObj = getSegString(msgArgs.getValueOf("obj"), st);
+
+        select encoding.toLower() {
+            when "idna" {
+                var (offsets, vals) = stringsObj.idnaEncodeDecode(cmd); // use the cmd to trigger correct action
+                var encodedStrings = getSegString(offsets, vals, st);
+                repMsg = "created " + st.attrib(encodedStrings.name) + "+created bytes.size %t".format(encodedStrings.nBytes);
+                
+            }
+            otherwise {
+                var errorMsg = "%s %s not currently supported".format(cmd, encoding);      
+                emLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);  
+                return new MsgTuple(errorMsg, MsgType.ERROR);    
+            }
+        }
+
+        emLogger.debug(getModuleName(), getRoutineName(), getLineNumber(), repMsg);
+        return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+
+
+    use CommandMap;
+    registerFunction("encode", encodeDecodeMsg, getModuleName());
+    registerFunction("decode", encodeDecodeMsg, getModuleName());
+}

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -1403,18 +1403,6 @@ module SegmentedMsg {
       }
     }
   }
-
-  proc encodeMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws  {
-    var msgArgs = parseMessageArgs(payload, argSize);
-    var strings = getSegString(msgArgs.getValueOf("obj"), st);
-    var (off, val) = strings.encode();
-    writeln("\n\n");
-    writeln(off);
-    writeln(val);
-    writeln("\n\n");
-    var repMsg = "THIS IS NOT A DRILL";
-    return new MsgTuple(repMsg, MsgType.NORMAL);
-  }
   
   use CommandMap;
   registerFunction("segmentLengths", segmentLengthsMsg, getModuleName());

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -1403,6 +1403,18 @@ module SegmentedMsg {
       }
     }
   }
+
+  proc encodeMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws  {
+    var msgArgs = parseMessageArgs(payload, argSize);
+    var strings = getSegString(msgArgs.getValueOf("obj"), st);
+    var (off, val) = strings.encode();
+    writeln("\n\n");
+    writeln(off);
+    writeln(val);
+    writeln("\n\n");
+    var repMsg = "THIS IS NOT A DRILL";
+    return new MsgTuple(repMsg, MsgType.NORMAL);
+  }
   
   use CommandMap;
   registerFunction("segmentLengths", segmentLengthsMsg, getModuleName());

--- a/src/SegmentedString.chpl
+++ b/src/SegmentedString.chpl
@@ -528,9 +528,6 @@ module SegmentedString {
         // var str_entry: string;
         const filename: string = basePath+"/src/exec/%i_tmp.txt".format(i);
         var str_entry: string = interpretAsString(origVals, off..#len);
-        // for b in interpretAsString(origVals, off..#len, borrow=true) {
-        //   str_entry = str_entry + b;
-        // }
         // use subprocessing to make a call to a python file for the encoding
         var sub = spawn(["python3", procFile, "-v", str_entry, "-f", filename]);
         sub.wait();
@@ -547,15 +544,8 @@ module SegmentedString {
       // calculate offsets and lengths
       encodeLengths = [e in encodeArr] e.numBytes;
       encodeOffsets = (+ scan encodeLengths) - encodeLengths + [i in 0..<encodeLengths.size] i;
-      // encodeOffsets = (+ scan encodeLengths) - encodeLengths;
-      // forall (i, o) in zip(0..#encodeOffsets.size, encodeOffsets){
-      //   if i != 0 {
-      //     o = o + i;
-      //   }
-      // }
       
       //calculate values for the segmentedstring
-      // var finalValues: [0..#((+ reduce encodeLengths)+encodeLengths.size)] uint(8);
       var finalValues = makeDistArray((+ reduce encodeLengths)+encodeLengths.size, uint(8));
       forall (s, o) in zip(encodeArr, encodeOffsets) with (var agg = newDstAggregator(uint(8))) {
         for (j, c) in zip(0.., s.chpl_bytes()) {

--- a/src/SegmentedString.chpl
+++ b/src/SegmentedString.chpl
@@ -525,11 +525,12 @@ module SegmentedString {
 
       const lengths = this.getLengths();
       forall (i, off, len) in zip(0..#this.size, offs, lengths) {
-        var str_entry: string;
+        // var str_entry: string;
         const filename: string = basePath+"/src/exec/%i_tmp.txt".format(i);
-        for b in interpretAsString(origVals, off..#len, borrow=true) {
-          str_entry = str_entry + b;
-        }
+        var str_entry: string = interpretAsString(origVals, off..#len);
+        // for b in interpretAsString(origVals, off..#len, borrow=true) {
+        //   str_entry = str_entry + b;
+        // }
         // use subprocessing to make a call to a python file for the encoding
         var sub = spawn(["python3", procFile, "-v", str_entry, "-f", filename]);
         sub.wait();
@@ -545,15 +546,17 @@ module SegmentedString {
       }
       // calculate offsets and lengths
       encodeLengths = [e in encodeArr] e.numBytes;
-      encodeOffsets = (+ scan encodeLengths) - encodeLengths;
-      forall (i, o) in zip(0..#encodeOffsets.size, encodeOffsets){
-        if i != 0 {
-          o = o + i;
-        }
-      }
+      encodeOffsets = (+ scan encodeLengths) - encodeLengths + [i in 0..<encodeLengths.size] i;
+      // encodeOffsets = (+ scan encodeLengths) - encodeLengths;
+      // forall (i, o) in zip(0..#encodeOffsets.size, encodeOffsets){
+      //   if i != 0 {
+      //     o = o + i;
+      //   }
+      // }
       
       //calculate values for the segmentedstring
-      var finalValues: [0..#((+ reduce encodeLengths)+encodeLengths.size)] uint(8);
+      // var finalValues: [0..#((+ reduce encodeLengths)+encodeLengths.size)] uint(8);
+      var finalValues = makeDistArray((+ reduce encodeLengths)+encodeLengths.size, uint(8));
       forall (s, o) in zip(encodeArr, encodeOffsets) with (var agg = newDstAggregator(uint(8))) {
         for (j, c) in zip(0.., s.chpl_bytes()) {
           agg.copy(finalValues[j+o], c);

--- a/src/SegmentedString.chpl
+++ b/src/SegmentedString.chpl
@@ -18,6 +18,10 @@ module SegmentedString {
   use Regex;
   use SegmentedComputation;
 
+  use Subprocess;
+  use Path;
+  use FileSystem;
+
   private config const logLevel = ServerConfig.logLevel;
   const ssLogger = new Logger(logLevel);
 
@@ -486,6 +490,69 @@ module SegmentedString {
     */
     proc isTitle() throws {
       return computeOnSegments(offsets.a, values.a, SegFunction.StringIsTitle, bool);
+    }
+
+    proc idnaEncodeDecode(cmd: string) throws {
+      // select the appropriate file based on the command
+      var procFile: string;
+      // we need to add this dir check for testing functionality
+      var basePath: string = realPath(curDir);
+      var (pathName, dirName) = splitPath(basePath);
+      if "tests" == dirName {
+        basePath = pathName;
+      }
+      select cmd {
+        when "encode" {
+          procFile = "/"+basePath+"/src/exec/ak_encode.py";
+        }
+        when "decode" {
+          procFile = "/"+basePath+"/src/exec/ak_decode.py";
+        }
+        otherwise {
+          throw getErrorWithContext(msg="Invalid encode/decode cmd. %s".format(cmd),
+                      lineNumber=getLineNumber(), 
+                      routineName=getRoutineName(), 
+                      moduleName=getModuleName(), 
+                      errorClass='ValueError');
+        }
+      }
+    
+      ref origVals = this.values.a;
+      ref offs = this.offsets.a;
+      var encodeArr: [0..#this.size] string; 
+      var encodeOffsets: [this.offsets.aD] int;
+      var encodeLengths: [this.offsets.aD] int;
+
+      const lengths = this.getLengths();
+      forall (i, off, len) in zip(0..#this.size, offs, lengths) {
+        var str_entry: string;
+        for b in interpretAsString(origVals, off..#len, borrow=true) {
+          str_entry = str_entry + b;
+        }
+        // use subprocessing to make a call to a python file for the encoding
+        var sub = spawn(["python3", procFile, "-v", str_entry], stdout=pipeStyle.pipe);
+        var line: string;
+        sub.stdout.readLine(line);
+        encodeArr[i] = line.strip();
+        sub.wait();
+      }
+      // calculate offsets and lengths
+      encodeLengths = [e in encodeArr] e.numBytes;
+      encodeOffsets = (+ scan encodeLengths) - encodeLengths;
+      forall (i, o) in zip(0..#encodeOffsets.size, encodeOffsets){
+        if i != 0 {
+          o = o + i;
+        }
+      }
+      
+      //calculate values for the segmentedstring
+      var finalValues: [0..#((+ reduce encodeLengths)+encodeLengths.size)] uint(8);
+      forall (s, o) in zip(encodeArr, encodeOffsets) with (var agg = newDstAggregator(uint(8))) {
+        for (j, c) in zip(0.., s.chpl_bytes()) {
+          agg.copy(finalValues[j+o], c);
+        }
+      }
+      return (encodeOffsets, finalValues);
     }
 
     proc findSubstringInBytes(const substr: string) {

--- a/src/exec/ak_decode.py
+++ b/src/exec/ak_decode.py
@@ -1,5 +1,7 @@
 import sys
 import optparse
+import codecs
+
 
 """
     This script will take a commandline argument that is the value to be decoded.
@@ -9,13 +11,21 @@ if __name__ == "__main__":
     parser = optparse.OptionParser()
     parser.add_option("-v", "--value", dest="value",
                       help="The value to be encoded.")
+    parser.add_option("-f", "--file", dest="filename",
+                      help="The name of the file to write output to.")
     (options, args) = parser.parse_args()
     try:
         decoded = options.value.encode("ascii").decode("idna")
         # if the decoded values is equivalent to the input, not a valid idna
-        if decoded == options.value:
-            sys.stdout.write("")
+        # if decoded == options.value:
+        #     sys.stdout.write("")
+        # else:
+        #     sys.stdout.write(decoded)
+        if decoded != options.value:
+            with codecs.open(options.filename, "w", "utf-8") as f:
+                f.write(decoded)
         else:
-            sys.stdout.write(decoded)
+            raise ValueError("Invalid encoding")
     except Exception:
-        sys.stdout.write("")
+        with open(options.filename, "w") as f:
+            f.write("")

--- a/src/exec/ak_decode.py
+++ b/src/exec/ak_decode.py
@@ -1,0 +1,21 @@
+import sys
+import optparse
+
+"""
+    This script will take a commandline argument that is the value to be decoded.
+    Currently, we are only able to decode idna strings. Bytes are not functional..
+"""
+if __name__ == "__main__":
+    parser = optparse.OptionParser()
+    parser.add_option("-v", "--value", dest="value",
+                      help="The value to be encoded.")
+    (options, args) = parser.parse_args()
+    try:
+        decoded = options.value.encode("ascii").decode("idna")
+        # if the decoded values is equivalent to the input, not a valid idna
+        if decoded == options.value:
+            sys.stdout.write("")
+        else:
+            sys.stdout.write(decoded)
+    except Exception:
+        sys.stdout.write("")

--- a/src/exec/ak_decode.py
+++ b/src/exec/ak_decode.py
@@ -1,7 +1,5 @@
-import sys
-import optparse
 import codecs
-
+import optparse
 
 """
     This script will take a commandline argument that is the value to be decoded.
@@ -9,18 +7,11 @@ import codecs
 """
 if __name__ == "__main__":
     parser = optparse.OptionParser()
-    parser.add_option("-v", "--value", dest="value",
-                      help="The value to be encoded.")
-    parser.add_option("-f", "--file", dest="filename",
-                      help="The name of the file to write output to.")
+    parser.add_option("-v", "--value", dest="value", help="The value to be encoded.")
+    parser.add_option("-f", "--file", dest="filename", help="The name of the file to write output to.")
     (options, args) = parser.parse_args()
     try:
         decoded = options.value.encode("ascii").decode("idna")
-        # if the decoded values is equivalent to the input, not a valid idna
-        # if decoded == options.value:
-        #     sys.stdout.write("")
-        # else:
-        #     sys.stdout.write(decoded)
         if decoded != options.value:
             with codecs.open(options.filename, "w", "utf-8") as f:
                 f.write(decoded)

--- a/src/exec/ak_encode.py
+++ b/src/exec/ak_encode.py
@@ -1,0 +1,16 @@
+import sys
+import optparse
+
+"""
+    This script will take a commandline argument that is the value to be encoded.
+    Currently, we are only able to encode idna (returning the ascii string instead of bytes).
+"""
+if __name__ == "__main__":
+    parser = optparse.OptionParser()
+    parser.add_option("-v", "--value", dest="value",
+                      help="The value to be encoded.")
+    (options, args) = parser.parse_args()
+    try:
+        sys.stdout.write(options.value.encode("idna").decode("ascii"))
+    except Exception:
+        sys.stdout.write("")

--- a/src/exec/ak_encode.py
+++ b/src/exec/ak_encode.py
@@ -9,8 +9,12 @@ if __name__ == "__main__":
     parser = optparse.OptionParser()
     parser.add_option("-v", "--value", dest="value",
                       help="The value to be encoded.")
+    parser.add_option("-f", "--file", dest="filename",
+                      help="The name of the file to write output to.")
     (options, args) = parser.parse_args()
     try:
-        sys.stdout.write(options.value.encode("idna").decode("ascii"))
+        with open(options.filename, "w") as f:
+            f.write(options.value.encode("idna").decode("ascii"))
+        # sys.stdout.write(options.value.encode("idna").decode("ascii"))
     except Exception:
         sys.stdout.write("")

--- a/src/exec/ak_encode.py
+++ b/src/exec/ak_encode.py
@@ -1,4 +1,3 @@
-import sys
 import optparse
 
 """
@@ -7,14 +6,12 @@ import optparse
 """
 if __name__ == "__main__":
     parser = optparse.OptionParser()
-    parser.add_option("-v", "--value", dest="value",
-                      help="The value to be encoded.")
-    parser.add_option("-f", "--file", dest="filename",
-                      help="The name of the file to write output to.")
+    parser.add_option("-v", "--value", dest="value", help="The value to be encoded.")
+    parser.add_option("-f", "--file", dest="filename", help="The name of the file to write output to.")
     (options, args) = parser.parse_args()
     try:
         with open(options.filename, "w") as f:
             f.write(options.value.encode("idna").decode("ascii"))
-        # sys.stdout.write(options.value.encode("idna").decode("ascii"))
     except Exception:
-        sys.stdout.write("")
+        with open(options.filename, "w") as f:
+            f.write("")

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -647,5 +647,5 @@ class StringTest(ArkoudaTest):
         a2 = ['xn--mnchen-3ya', 'xn--zrich-kva', ' xn--zrich-boguscode', 'xn--!!']
         s2 = ak.array(a2)
         result = s2.idna_decode()
-        # using the below assertion due to a bug in `Strings.to_ndarray`. See issue #
+        # using the below assertion due to a bug in `Strings.to_ndarray`. See issue #1828
         self.assertEqual("array(['münchen', 'zürich', '', ''])", result.__repr__())

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -637,3 +637,15 @@ class StringTest(ArkoudaTest):
 
         p = strings.get_suffixes(1, return_origins=False, proper=False)
         self.assertListEqual(["c", "d", "i"], p.to_list())
+
+    def test_encoding(self):
+        a1 = ["münchen", "zürich"]
+        s1 = ak.array(a1)
+        result = s1.idna_encode()
+        self.assertListEqual([i.encode("idna").decode("ascii") for i in a1], result.to_list())
+
+        a2 = ['xn--mnchen-3ya', 'xn--zrich-kva', ' xn--zrich-boguscode', 'xn--!!']
+        s2 = ak.array(a2)
+        result = s2.idna_decode()
+        # using the below assertion due to a bug in `Strings.to_ndarray`. See issue #
+        self.assertEqual("array(['münchen', 'zürich', '', ''])", result.__repr__())


### PR DESCRIPTION
Closes #1799

This PR is a work around until Chapel implements codec support. It uses Chapel's `Subprocess` module to call out to Python files that convert each individual string.  The Python files are configured to return `''` in the event of a failed conversion.

`idna_encode` and `idna_decode` methods are added to the client `Strings` class.

An `EncodingMsg` module to the Arkouda server. This module takes in the cmd `encode`/`decode` and the encoding type. Currently, only `idna` is supported, but other encodings can be added in the future if needed. 

Testing has been added to ensure proper functionality. Currently, the test for `idna_decode` uses string comparison against `Strings.__repr__()` due to issues with `Strings.to_ndarray()`. Issue #1828 has been added to correct the issues with non-ascii characters in UTF-8 strings. 