### PR TITLE
Closes #1828 - `Strings.to_ndarray()` UTF-8 Bug Fix

### DIFF
--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1690,7 +1690,7 @@ class Strings:
         res = np.empty(self.size, dtype=dt)
         # Form a string from each segment and store in numpy array
         for i, (o, l) in enumerate(zip(npoffsets, lengths)):
-            res[i] = np.str_(codecs.decode(npvalues[o : o + l].tolist()))
+            res[i] = np.str_(codecs.decode(b"".join(npvalues[o:o + l])))
         return res
 
     def to_list(self) -> list:

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import codecs
 import itertools
 import re
 from typing import Dict, List, Optional, Tuple, Union, cast
@@ -1689,7 +1690,7 @@ class Strings:
         res = np.empty(self.size, dtype=dt)
         # Form a string from each segment and store in numpy array
         for i, (o, l) in enumerate(zip(npoffsets, lengths)):
-            res[i] = np.str_("".join(chr(b) for b in npvalues[o : o + l]))
+            res[i] = np.str_(codecs.decode(npvalues[o : o + l]))
         return res
 
     def to_list(self) -> list:

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1690,7 +1690,7 @@ class Strings:
         res = np.empty(self.size, dtype=dt)
         # Form a string from each segment and store in numpy array
         for i, (o, l) in enumerate(zip(npoffsets, lengths)):
-            res[i] = np.str_(codecs.decode(npvalues[o : o + l]))
+            res[i] = np.str_(codecs.decode(npvalues[o : o + l].tolist()))
         return res
 
     def to_list(self) -> list:

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -649,3 +649,9 @@ class StringTest(ArkoudaTest):
         result = s2.idna_decode()
         # using the below assertion due to a bug in `Strings.to_ndarray`. See issue #1828
         self.assertEqual("array(['münchen', 'zürich', '', ''])", result.__repr__())
+
+    def test_tondarray(self):
+        v1 = ["münchen","zürich", "abc", "123", ""]
+        s1 = ak.array(v1)
+        nd1 = s1.to_ndarray()
+        self.assertListEqual(nd1.tolist(), v1)

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -648,7 +648,7 @@ class StringTest(ArkoudaTest):
         s2 = ak.array(a2)
         result = s2.idna_decode()
         # using the below assertion due to a bug in `Strings.to_ndarray`. See issue #1828
-        self.assertEqual("array(['münchen', 'zürich', '', ''])", result.__repr__())
+        self.assertListEqual(["münchen", "zürich", "", ""], result.to_list())
 
     def test_tondarray(self):
         v1 = ["münchen","zürich", "abc", "123", ""]


### PR DESCRIPTION
Closes #1828 

This PR updates the `Strings.to_ndarray()` to use the Python codecs to properly decode `uint(8)` arrays representing Strings objs when the values represent non-ASCII characters. 

Adds testing to ensure that `Strings.to_ndarray()` properly returns the strings used to create the Arkouda `Strings` object.