### PR TITLE
Closes #1831 - `DataFrame._get_head_tail_server` return typing bug

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -147,6 +147,7 @@ jobs:
       run: |
         make check
     - name: Arkouda unit tests
+      if: matrix.image != 'chapel-gasnet-smp'
       env:
         ARKOUDA_PYTEST_OPTIONS: "--durations=0 --durations-min=5.0"
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -147,7 +147,6 @@ jobs:
       run: |
         make check
     - name: Arkouda unit tests
-      if: matrix.image != 'chapel-gasnet-smp'
       env:
         ARKOUDA_PYTEST_OPTIONS: "--durations=0 --durations-min=5.0"
       run: |

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -618,7 +618,7 @@ class DataFrame(UserDict):
             elif t == "Datetime":
                 df_dict[msg[1]] = Datetime(create_pdarray(msg[2]))
             elif t == "BitVector":
-                df_dict[msg[1]] = BitVector(create_pdarray(msg[2]))
+                df_dict[msg[1]] = BitVector(create_pdarray(msg[2]), width=self[msg[1]].width)
             else:
                 df_dict[msg[1]] = create_pdarray(msg[2])
 

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -34,6 +34,8 @@ from arkouda.segarray import SegArray
 from arkouda.series import Series
 from arkouda.sorting import argsort, coargsort
 from arkouda.strings import Strings
+from arkouda.client_dtypes import Fields, IPv4, BitVector
+from arkouda.timeclass import Datetime
 
 # This is necessary for displaying DataFrames with BitVector columns,
 # because pandas _html_repr automatically truncates the number of displayed bits
@@ -573,6 +575,14 @@ class DataFrame(UserDict):
                 msg_list.append(f"SegArray+{col}+{self[col].segments.name}+{self[col].values.name}")
             elif isinstance(self[col], Strings):
                 msg_list.append(f"Strings+{col}+{self[col].name}")
+            elif isinstance(self[col], Fields):
+                msg_list.append(f"Fields+{col}+{self[col].name}")
+            elif isinstance(self[col], IPv4):
+                msg_list.append(f"IPv4+{col}+{self[col].name}")
+            elif isinstance(self[col], Datetime):
+                msg_list.append(f"Datetime+{col}+{self[col].name}")
+            elif isinstance(self[col], Fields):
+                msg_list.append(f"BitVector+{col}+{self[col].name}")
             else:
                 msg_list.append(f"pdarray+{col}+{self[col].name}")
 
@@ -601,6 +611,14 @@ class DataFrame(UserDict):
                 # split creates for segments and values
                 eles = msg[2].split("+")
                 df_dict[msg[1]] = SegArray.from_parts(create_pdarray(eles[0]), create_pdarray(eles[1]))
+            elif t == "Fields":
+                df_dict[msg[1]] = Fields(create_pdarray(msg[2]), self[msg[1]].names)
+            elif t == "IPv4":
+                df_dict[msg[1]] = IPv4(create_pdarray(msg[2]))
+            elif t == "Datetime":
+                df_dict[msg[1]] = Datetime(create_pdarray(msg[2]))
+            elif t == "BitVector":
+                df_dict[msg[1]] = BitVector(create_pdarray(msg[2]))
             else:
                 df_dict[msg[1]] = create_pdarray(msg[2])
 

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -612,13 +612,22 @@ class DataFrame(UserDict):
                 eles = msg[2].split("+")
                 df_dict[msg[1]] = SegArray.from_parts(create_pdarray(eles[0]), create_pdarray(eles[1]))
             elif t == "Fields":
-                df_dict[msg[1]] = Fields(create_pdarray(msg[2]), self[msg[1]].names)
+                df_dict[msg[1]] = Fields(
+                    create_pdarray(msg[2]),
+                    self[msg[1]].names,
+                    MSB_left=self[msg[1]].MSB_left,
+                    pad=self[msg[1]].padchar,
+                    separator=self[msg[1]].separator,
+                    show_int=self[msg[1]].show_int,
+                )
             elif t == "IPv4":
                 df_dict[msg[1]] = IPv4(create_pdarray(msg[2]))
             elif t == "Datetime":
-                df_dict[msg[1]] = Datetime(create_pdarray(msg[2]))
+                df_dict[msg[1]] = Datetime(create_pdarray(msg[2]), unit=self[msg[1]].unit)
             elif t == "BitVector":
-                df_dict[msg[1]] = BitVector(create_pdarray(msg[2]), width=self[msg[1]].width)
+                df_dict[msg[1]] = BitVector(
+                    create_pdarray(msg[2]), width=self[msg[1]].width, reverse=self[msg[1]].reverse
+                )
             else:
                 df_dict[msg[1]] = create_pdarray(msg[2])
 

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -581,7 +581,7 @@ class DataFrame(UserDict):
                 msg_list.append(f"IPv4+{col}+{self[col].name}")
             elif isinstance(self[col], Datetime):
                 msg_list.append(f"Datetime+{col}+{self[col].name}")
-            elif isinstance(self[col], Fields):
+            elif isinstance(self[col], BitVector):
                 msg_list.append(f"BitVector+{col}+{self[col].name}")
             else:
                 msg_list.append(f"pdarray+{col}+{self[col].name}")

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -15,6 +15,7 @@ from typeguard import typechecked
 from arkouda import list_registry
 from arkouda.categorical import Categorical
 from arkouda.client import generic_msg, maxTransferBytes
+from arkouda.client_dtypes import BitVector, Fields, IPv4
 from arkouda.dtypes import bool as akbool
 from arkouda.dtypes import float64 as akfloat64
 from arkouda.dtypes import int64 as akint64
@@ -34,7 +35,6 @@ from arkouda.segarray import SegArray
 from arkouda.series import Series
 from arkouda.sorting import argsort, coargsort
 from arkouda.strings import Strings
-from arkouda.client_dtypes import Fields, IPv4, BitVector
 from arkouda.timeclass import Datetime
 
 # This is necessary for displaying DataFrames with BitVector columns,

--- a/src/DataFrameIndexingMsg.chpl
+++ b/src/DataFrameIndexingMsg.chpl
@@ -17,7 +17,7 @@
     const dfiLogger = new Logger(logLevel);
 
     // gather indexing by integer index vector
-    proc dfIdxHelper(idx: borrowed SymEntry(int), columnVals: borrowed SymEntry(?t), st: borrowed SymTab, col: string, rtnName: bool=false): string throws {
+    proc dfIdxHelper(idx: borrowed SymEntry(int), columnVals: borrowed SymEntry(?t), st: borrowed SymTab, col: string, objType: string, rtnName: bool=false): string throws {
         param pn = Reflection.getRoutineName();
         // get next symbol name
         var rname = st.nextName();
@@ -54,7 +54,7 @@
             return rname;
         }
 
-        var repMsg =  "pdarray+%s+created %s".format(col, st.attrib(rname));
+        var repMsg =  "%s+%s+created %s".format(objType, col, st.attrib(rname));
         return repMsg;
     }
 
@@ -109,12 +109,12 @@
         for (i, rpm, ele) in zip(repMsgList.domain, repMsgList, eleList) { 
             var ele_parts = ele.split("+");
             ref col_name = ele_parts[1];
-            select (ele_parts[0]) {
-                when ("Categorical") {
-                    ref codes_name = ele_parts[2];
-                    ref categories_name = ele_parts[3];
-                    dfiLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"Element at %i is Categorical\nCodes Name: %s, Categories Name: %s".format(i, codes_name, categories_name));
+            if ele_parts[0] == "Categorical" {
+                ref codes_name = ele_parts[2];
+                ref categories_name = ele_parts[3];
+                dfiLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"Element at %i is Categorical\nCodes Name: %s, Categories Name: %s".format(i, codes_name, categories_name));
 
+<<<<<<< HEAD
                     var gCode: borrowed GenSymEntry = getGenericTypedArrayEntry(codes_name, st);
                     var code_vals = toSymEntry(gCode, int);
                     var idxCodeName = dfIdxHelper(idx, code_vals, st, col_name, true);
@@ -134,28 +134,56 @@
                     if repTup.msgType == MsgType.ERROR {
                         throw new IllegalArgumentError(repTup.msg);
                     }
-
-                    rpm = "%jt".format("Strings+%s+%s".format(col_name, repTup.msg));
+=======
+                var gCode: borrowed GenSymEntry = getGenericTypedArrayEntry(codes_name, st);
+                var code_vals = toSymEntry(gCode, int);
+                var idxCodeName = dfIdxHelper(idx, code_vals, st, col_name, "", true);
+                
+                // When smallIdx is set to true, some localization work will
+                // be skipped and a localizing slice will instead be done,
+                // which can perform better by avoiding those overhead costs.
+                var repTup = segPdarrayIndex("str", categories_name, idxCodeName, DType.UInt8, st, smallIdx=true);
+                
+                if repTup.msgType == MsgType.ERROR {
+                    throw new IllegalArgumentError(repTup.msg);
                 }
-                when ("pdarray"){
+>>>>>>> 9b9754fb (Updating handling to properly preserve types for client dtypes. Strings issue not yet resolved. Pushing against CI to test..)
+
+                rpm = "%jt".format("Strings+%s+%s".format(col_name, repTup.msg));
+            }
+            else if ele_parts[0] == "Strings"{
+                dfiLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"Element at %i is Strings. Name: %s".format(i, ele_parts[2]));
+                // When smallIdx is set to true, some localization work will
+                // be skipped and a localizing slice will instead be done,
+                // which can perform better by avoiding those overhead costs.
+                var repTup = segPdarrayIndex("str", ele_parts[2], msgArgs.getValueOf("idx_name"), DType.UInt8, st, smallIdx=true);
+                
+                if repTup.msgType == MsgType.ERROR {
+                    throw new IllegalArgumentError(repTup.msg);
+                }
+
+                rpm = "%jt".format("Strings+%s+%s".format(col_name, repTup.msg));
+            }
+            else if ele_parts[0] == "pdarray" || ele_parts[0] == "IPv4" || 
+                            ele_parts[0] == "Fields" || ele_parts[0] == "Datetime" || ele_parts[0] == "BitVector"{
                     dfiLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"Element at %i is pdarray. Name: %s".format(i, ele_parts[2]));
                     var gCol: borrowed GenSymEntry = getGenericTypedArrayEntry(ele_parts[2], st);
                     select (gCol.dtype) {
                         when (DType.Int64) {
                             var col_vals = toSymEntry(gCol, int);
-                            rpm = "%jt".format(dfIdxHelper(idx, col_vals, st, col_name));
+                            rpm = "%jt".format(dfIdxHelper(idx, col_vals, st, col_name, ele_parts[0]));
                         }
                         when (DType.UInt64) {
                             var col_vals = toSymEntry(gCol, uint);
-                            rpm = "%jt".format(dfIdxHelper(idx, col_vals, st, col_name));
+                            rpm = "%jt".format(dfIdxHelper(idx, col_vals, st, col_name, ele_parts[0]));
                         }
                         when (DType.Bool) {
                             var col_vals = toSymEntry(gCol, bool);
-                            rpm = "%jt".format(dfIdxHelper(idx, col_vals, st, col_name));
+                            rpm = "%jt".format(dfIdxHelper(idx, col_vals, st, col_name, ele_parts[0]));
                         }
                         when (DType.Float64){
                             var col_vals = toSymEntry(gCol, real);
-                            rpm = "%jt".format(dfIdxHelper(idx, col_vals, st, col_name));
+                            rpm = "%jt".format(dfIdxHelper(idx, col_vals, st, col_name, ele_parts[0]));
                         }
                         otherwise {
                             var errorMsg = notImplementedError(pn,dtype2str(gCol.dtype));
@@ -164,47 +192,45 @@
                         }
                     }
                 }
-                when ("SegArray"){
-                    dfiLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"Element at %i is SegArray".format(i));
-                    ref segments_name = ele_parts[2];
-                    ref values_name = ele_parts[3];
-                    dfiLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"Segments Name: %s, Values Name: %s".format(segments_name, values_name));
+            else if ele_parts[0] == "SegArray" {
+                dfiLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"Element at %i is SegArray".format(i));
+                ref segments_name = ele_parts[2];
+                ref values_name = ele_parts[3];
+                dfiLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"Segments Name: %s, Values Name: %s".format(segments_name, values_name));
 
-                    var gSeg: borrowed GenSymEntry = getGenericTypedArrayEntry(segments_name, st);
-                    var segments = toSymEntry(gSeg, int);
-                    var gVal: borrowed GenSymEntry = getGenericTypedArrayEntry(values_name, st);
-                    select(gVal.dtype){
-                        when(DType.Int64){
-                            var values = toSymEntry(gVal, int);
-                            rpm = "%jt".format(df_seg_array_idx(idx, segments, values, col_name, st));
-                        }
-                        when(DType.UInt64){
-                            var values = toSymEntry(gVal, uint);
-                            rpm = "%jt".format(df_seg_array_idx(idx, segments, values, col_name, st));
-                        }
-                        when(DType.Float64){
-                            var values = toSymEntry(gVal, real);
-                            rpm = "%jt".format(df_seg_array_idx(idx, segments, values, col_name, st));
-                        }
-                        when(DType.Bool){
-                            var values = toSymEntry(gVal, bool);
-                            rpm = "%jt".format(df_seg_array_idx(idx, segments, values, col_name, st));
-                        }
-                        otherwise {
-                            var errorMsg = notImplementedError(pn,dtype2str(gVal.dtype));
-                            dfiLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                            throw new IllegalArgumentError(errorMsg);
-                        }
+                var gSeg: borrowed GenSymEntry = getGenericTypedArrayEntry(segments_name, st);
+                var segments = toSymEntry(gSeg, int);
+                var gVal: borrowed GenSymEntry = getGenericTypedArrayEntry(values_name, st);
+                select(gVal.dtype){
+                    when(DType.Int64){
+                        var values = toSymEntry(gVal, int);
+                        rpm = "%jt".format(df_seg_array_idx(idx, segments, values, col_name, st));
+                    }
+                    when(DType.UInt64){
+                        var values = toSymEntry(gVal, uint);
+                        rpm = "%jt".format(df_seg_array_idx(idx, segments, values, col_name, st));
+                    }
+                    when(DType.Float64){
+                        var values = toSymEntry(gVal, real);
+                        rpm = "%jt".format(df_seg_array_idx(idx, segments, values, col_name, st));
+                    }
+                    when(DType.Bool){
+                        var values = toSymEntry(gVal, bool);
+                        rpm = "%jt".format(df_seg_array_idx(idx, segments, values, col_name, st));
+                    }
+                    otherwise {
+                        var errorMsg = notImplementedError(pn,dtype2str(gVal.dtype));
+                        dfiLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                        throw new IllegalArgumentError(errorMsg);
                     }
                 }
-                otherwise {
-                    var errorMsg = notImplementedError(pn, ele_parts[0]);
-                    dfiLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                    throw new IllegalArgumentError(errorMsg);
-                }
+            }
+            else {
+                var errorMsg = notImplementedError(pn, ele_parts[0]);
+                dfiLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                throw new IllegalArgumentError(errorMsg);
             }
         }
-
         repMsg = "[%s]".format(",".join(repMsgList));
         dfiLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
         return new MsgTuple(repMsg, MsgType.NORMAL); 

--- a/src/DataFrameIndexingMsg.chpl
+++ b/src/DataFrameIndexingMsg.chpl
@@ -114,27 +114,6 @@
                 ref categories_name = ele_parts[3];
                 dfiLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"Element at %i is Categorical\nCodes Name: %s, Categories Name: %s".format(i, codes_name, categories_name));
 
-<<<<<<< HEAD
-                    var gCode: borrowed GenSymEntry = getGenericTypedArrayEntry(codes_name, st);
-                    var code_vals = toSymEntry(gCode, int);
-                    var idxCodeName = dfIdxHelper(idx, code_vals, st, col_name, true);
-                    
-                    var repTup = segPdarrayIndex("str", categories_name, idxCodeName, DType.UInt8, st);
-                    
-                    if repTup.msgType == MsgType.ERROR {
-                        throw new IllegalArgumentError(repTup.msg);
-                    }
-
-                    rpm = "%jt".format("Strings+%s+%s".format(col_name, repTup.msg));
-                }
-                when ("Strings") {
-                    dfiLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"Element at %i is Strings. Name: %s".format(i, ele_parts[2]));
-                    var repTup = segPdarrayIndex("str", ele_parts[2], msgArgs.getValueOf("idx_name"), DType.UInt8,  st);
-                    
-                    if repTup.msgType == MsgType.ERROR {
-                        throw new IllegalArgumentError(repTup.msg);
-                    }
-=======
                 var gCode: borrowed GenSymEntry = getGenericTypedArrayEntry(codes_name, st);
                 var code_vals = toSymEntry(gCode, int);
                 var idxCodeName = dfIdxHelper(idx, code_vals, st, col_name, "", true);
@@ -142,12 +121,11 @@
                 // When smallIdx is set to true, some localization work will
                 // be skipped and a localizing slice will instead be done,
                 // which can perform better by avoiding those overhead costs.
-                var repTup = segPdarrayIndex("str", categories_name, idxCodeName, DType.UInt8, st, smallIdx=true);
+                var repTup = segPdarrayIndex("str", categories_name, idxCodeName, DType.UInt8, st);
                 
                 if repTup.msgType == MsgType.ERROR {
                     throw new IllegalArgumentError(repTup.msg);
                 }
->>>>>>> 9b9754fb (Updating handling to properly preserve types for client dtypes. Strings issue not yet resolved. Pushing against CI to test..)
 
                 rpm = "%jt".format("Strings+%s+%s".format(col_name, repTup.msg));
             }
@@ -156,7 +134,7 @@
                 // When smallIdx is set to true, some localization work will
                 // be skipped and a localizing slice will instead be done,
                 // which can perform better by avoiding those overhead costs.
-                var repTup = segPdarrayIndex("str", ele_parts[2], msgArgs.getValueOf("idx_name"), DType.UInt8, st, smallIdx=true);
+                var repTup = segPdarrayIndex("str", ele_parts[2], msgArgs.getValueOf("idx_name"), DType.UInt8, st);
                 
                 if repTup.msgType == MsgType.ERROR {
                     throw new IllegalArgumentError(repTup.msg);

--- a/src/DataFrameIndexingMsg.chpl
+++ b/src/DataFrameIndexingMsg.chpl
@@ -118,9 +118,6 @@
                 var code_vals = toSymEntry(gCode, int);
                 var idxCodeName = dfIdxHelper(idx, code_vals, st, col_name, "", true);
                 
-                // When smallIdx is set to true, some localization work will
-                // be skipped and a localizing slice will instead be done,
-                // which can perform better by avoiding those overhead costs.
                 var repTup = segPdarrayIndex("str", categories_name, idxCodeName, DType.UInt8, st);
                 
                 if repTup.msgType == MsgType.ERROR {
@@ -131,9 +128,6 @@
             }
             else if ele_parts[0] == "Strings"{
                 dfiLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"Element at %i is Strings. Name: %s".format(i, ele_parts[2]));
-                // When smallIdx is set to true, some localization work will
-                // be skipped and a localizing slice will instead be done,
-                // which can perform better by avoiding those overhead costs.
                 var repTup = segPdarrayIndex("str", ele_parts[2], msgArgs.getValueOf("idx_name"), DType.UInt8, st);
                 
                 if repTup.msgType == MsgType.ERROR {

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -102,7 +102,6 @@ class DataFrameTest(ArkoudaTest):
         self.assertTrue(ref_df.equals(df.to_pandas()))
 
     def test_client_type_creation(self):
-        import datetime as dt
         f = ak.Fields(ak.arange(10), ["A", "B", "c"])
         ip = ak.ip_address(ak.arange(10))
         d = ak.Datetime(ak.arange(10))

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -101,6 +101,38 @@ class DataFrameTest(ArkoudaTest):
         self.assertEqual(len(df), 6)
         self.assertTrue(ref_df.equals(df.to_pandas()))
 
+    def test_client_type_creation(self):
+        import datetime as dt
+        f = ak.Fields(ak.arange(10), ["A", "B", "c"])
+        ip = ak.ip_address(ak.arange(10))
+        d = ak.Datetime(ak.arange(10))
+
+        df_dict = {
+            "fields": f,
+            "ip": ip,
+            "date": d
+        }
+        df = ak.DataFrame(df_dict)
+        pd_d = [pd.to_datetime(x, unit='ns') for x in d.to_list()]
+        pddf = pd.DataFrame({
+            "fields": f.to_list(),
+            "ip": ip.to_list(),
+            "date": pd_d
+        })
+        shape = f"({df._shape_str()})".replace("(", "[").replace(")", "]")
+        pd.set_option("display.max_rows", 4)
+        s = df.__repr__().replace(f" ({df._shape_str()})", f"\n\n{shape}")
+        self.assertEqual(s, pddf.__repr__())
+
+        pd.set_option("display.max_rows", 10)
+        pdf = pd.DataFrame({'a': list(range(1000)), 'b': list(range(1000))})
+        pdf['a'] = pdf['a'].apply(lambda x: 'AA' + str(x))
+        pdf['b'] = pdf['b'].apply(lambda x: 'BB' + str(x))
+        df = ak.DataFrame(pdf)
+        shape = f"({df._shape_str()})".replace("(", "[").replace(")", "]")
+        s = df.__repr__().replace(f" ({df._shape_str()})", f"\n\n{shape}")
+        self.assertEqual(s, pdf.__repr__())
+
     def test_boolean_indexing(self):
         df = build_ak_df()
         ref_df = build_pd_df()

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -5,7 +5,7 @@ import string
 from shutil import rmtree
 
 import pandas as pd  # type: ignore
-import numpy as np # type: ignore
+import numpy as np  # type: ignore
 from base_test import ArkoudaTest
 from context import arkouda as ak
 
@@ -105,28 +105,28 @@ class DataFrameTest(ArkoudaTest):
         f = ak.Fields(ak.arange(10), ["A", "B", "c"])
         ip = ak.ip_address(ak.arange(10))
         d = ak.Datetime(ak.arange(10))
+        bv = ak.BitVector(ak.arange(10), width=4)
 
-        df_dict = {
-            "fields": f,
-            "ip": ip,
-            "date": d
-        }
+        df_dict = {"fields": f, "ip": ip, "date": d, "bitvector": bv}
         df = ak.DataFrame(df_dict)
-        pd_d = [pd.to_datetime(x, unit='ns') for x in d.to_list()]
-        pddf = pd.DataFrame({
-            "fields": f.to_list(),
-            "ip": ip.to_list(),
-            "date": pd_d
-        })
+        pd_d = [pd.to_datetime(x, unit="ns") for x in d.to_list()]
+        pddf = pd.DataFrame(
+            {
+                "fields": f.to_list(),
+                "ip": ip.to_list(),
+                "date": pd_d,
+                "bitvector": bv.to_list()
+            }
+        )
         shape = f"({df._shape_str()})".replace("(", "[").replace(")", "]")
         pd.set_option("display.max_rows", 4)
         s = df.__repr__().replace(f" ({df._shape_str()})", f"\n\n{shape}")
         self.assertEqual(s, pddf.__repr__())
 
         pd.set_option("display.max_rows", 10)
-        pdf = pd.DataFrame({'a': list(range(1000)), 'b': list(range(1000))})
-        pdf['a'] = pdf['a'].apply(lambda x: 'AA' + str(x))
-        pdf['b'] = pdf['b'].apply(lambda x: 'BB' + str(x))
+        pdf = pd.DataFrame({"a": list(range(1000)), "b": list(range(1000))})
+        pdf["a"] = pdf["a"].apply(lambda x: "AA" + str(x))
+        pdf["b"] = pdf["b"].apply(lambda x: "BB" + str(x))
         df = ak.DataFrame(pdf)
         shape = f"({df._shape_str()})".replace("(", "[").replace(")", "]")
         s = df.__repr__().replace(f" ({df._shape_str()})", f"\n\n{shape}")


### PR DESCRIPTION
Closes #1831 

Updates the `ak.DataFrame._get_head_tail_server()` method used by the `ak.DataFrame.__repr__()` method to properly preserve the typing for the following client dtypes:
- BitVector
- Fields
- Datetime
- IPv4

Adds testing that the client types are preserved properly.

*Note for Developers - This updated the structure of Chapel code to use and `if` instead of a `select` since multiple cases became virtually identical. However, we needed to know the class of the object to properly preserve it on return.*

The issue reported with strings was resolved by PR #1833. 