### PR TITLE
Closes #1837: Intermittent failures in groupby prod aggregate test

### DIFF
--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -57,12 +57,7 @@ def compare_keys(pdkeys, akkeys, levels, pdvals, akvals) -> int:
                 print("Different keys")
                 return 1
 
-    def equality_helper(a, n):
-        # verify NAN in the same locations and equal in the locations they are not NAN
-        # Note: we have to do this becasue NAN != NAN
-        return ((nin := np.isnan(n)) == (ain := np.isnan(a))).all() and np.allclose(n[~nin], a[~ain])
-
-    if not equality_helper(pdvals, akvals):
+    if not np.allclose(pdvals, akvals, equal_nan=True):
         print(f"Different values (abs diff = {np.abs(pdvals - akvals).sum()})")
         return 1
     return 0

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -430,28 +430,30 @@ class OperatorsTest(ArkoudaTest):
         np_edge_cases = np.array(scalar_edge_cases)
         ak_edge_cases = ak.array(np_edge_cases)
 
-        def equality_helper(a, n):
-            # verify they are NAN in the same locations
-            np_is_nan = np.isnan(n)
-            ak_is_nan = ak.isnan(a)
-            self.assertListEqual(ak_is_nan.to_list(), np_is_nan.tolist())
-
-            # verify they are equal in the locations they are not NAN
-            # Note: we have to do this becasue NAN != NAN
-            self.assertListEqual(a[~ak_is_nan].to_list(), n[~np_is_nan].tolist())
-
         for s in scalar_edge_cases:
             # test vector // scalar
-            equality_helper(ak_edge_cases // s, np_edge_cases // s)
+            self.assertTrue(
+                np.allclose((ak_edge_cases // s).to_ndarray(), np_edge_cases // s, equal_nan=True)
+            )
 
             # test scalar // vector
-            equality_helper(s // ak_edge_cases, s // np_edge_cases)
+            self.assertTrue(
+                np.allclose((s // ak_edge_cases).to_ndarray(), s // np_edge_cases, equal_nan=True)
+            )
 
             # test both vector // vector
             n_vect = np.full(len(scalar_edge_cases), s)
             a_vect = ak.array(n_vect)
-            equality_helper(ak_edge_cases // a_vect, np_edge_cases // n_vect)
-            equality_helper(a_vect // ak_edge_cases, n_vect // np_edge_cases)
+            self.assertTrue(
+                np.allclose(
+                    (ak_edge_cases // a_vect).to_ndarray(), np_edge_cases // n_vect, equal_nan=True
+                )
+            )
+            self.assertTrue(
+                np.allclose(
+                    (a_vect // ak_edge_cases).to_ndarray(), n_vect // np_edge_cases, equal_nan=True
+                )
+            )
 
     def test_pda_sqrt(self):
         n = np.array([4, 16, -1, 0, np.inf])

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -460,13 +460,7 @@ class OperatorsTest(ArkoudaTest):
         s = ak.sqrt(a)
         ex = np.sqrt(n)
 
-        # id nans
-        nan = ak.isnan(s)
-        npnan = np.isnan(ex)
-        self.assertListEqual(nan.to_list(), npnan.tolist())
-
-        # check results are equal remove nans
-        self.assertListEqual(s[~nan].to_list(), ex[~npnan].tolist())
+        self.assertTrue(np.allclose(s.to_ndarray(), ex, equal_nan=True))
 
     def test_pda_power(self):
         n = np.array([10, 5, 2])
@@ -485,9 +479,7 @@ class OperatorsTest(ArkoudaTest):
 
         p = ak.power(a, 0.5)
         ex = np.power(n, 0.5)
-        nan = ak.isnan(p)
-        npnan = np.isnan(ex)
-        self.assertListEqual(nan.to_list(), npnan.tolist())
+        self.assertTrue(np.allclose(p.to_ndarray(), ex, equal_nan=True))
 
     def testAllOperators(self):
         run_tests(verbose)


### PR DESCRIPTION
This PR (Closes #1837)
- Updates code using `equality_helper` to use `np.allclose(equal_nan=True)` instead

A [github workflow in my fork](https://github.com/pierce314159/arkouda/actions/runs/3238079925/jobs/5305892891) saw a failure in the groupby prod aggregation in `test_groupby_on_one_level`
```
Doing aggregate(uint64, prod)
Different values (abs diff = 1.8446744073709564e+19)
```
I'm not sure if I'm just misinterpreting, but I think this should be within the tolerance of [`np.allclose`](https://numpy.org/doc/stable/reference/generated/numpy.allclose.html). So I'm not sure how this happened. Maybe there's something wrong with the way I calculate if the arrays are `NAN` in the same places in `equality_helper`?

While looking into this, I noticed the `equality_helper` is not necessary if we use the `equal_nan` flag. So I went ahead and updated this (and spots in `operator_test`) to use the functionality built into numpy instead. Hopefully this take care of the problem