### PR TITLE
Closes #1836 - Removing gasnet from CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -124,8 +124,8 @@ jobs:
         include:
           - image: chapel
             threads: 2
-          - image: chapel-gasnet-smp
-            threads: 1
+#          - image: chapel-gasnet-smp
+#            threads: 1
     env:
       CHPL_RT_NUM_THREADS_PER_LOCALE: ${{matrix.threads}}
     container:


### PR DESCRIPTION
Closes #1836 

Removes gasnet from CI testing. This is not ideal, but due to the high number of failures compiling the gasnet code due to OOM errors we need to remove this until there is a way to handle compilation with less memory pressure.

Commented out code that triggers the gasnet testing so it can be easily added back in at a later date.