### PR TITLE
Closes #1776: GroupBy Strings Optimization

### DIFF
--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1636,14 +1636,14 @@ class Strings:
             generic_msg(cmd="segmentedGroup", args={"objType": self.objtype, "obj": self.entry})
         )
 
-    def _get_grouping_keys(self) -> List[pdarray]:
+    def _get_grouping_keys(self) -> List[Strings]:
         """
         Private method for generating grouping keys used by GroupBy.
 
         API: this method must be defined by all groupable arrays, and it
         must return a list of arrays that can be (co)argsorted.
         """
-        return list(self.hash())
+        return [self]
 
     def to_ndarray(self) -> np.ndarray:
         """

--- a/src/GroupBy.chpl
+++ b/src/GroupBy.chpl
@@ -28,7 +28,7 @@ module GroupBy {
     proc getGroupBy(keyCount: int, keys: [] string, keyTypes: [] string, assumeSorted: bool, st: borrowed SymTab): owned GroupBy throws {
         var keyNamesEntry = new shared SymEntry(keys);
         var keyTypesEntry = new shared SymEntry(keyTypes);
-        var (permEntry, segmentsEntry) = if assumeSorted then assumeSortedShortcut(keyCount, keys, keyTypes, st) else uniqueAndCount(keyCount, keys, keyTypes, st);
+        var (permEntry, segmentsEntry) = uniqueAndCount(keyCount, keys, keyTypes, assumeSorted, st);
 
         var uniqueKeyInds = new shared SymEntry(segmentsEntry.size, int);
         if (segmentsEntry.size > 0) {

--- a/src/SegmentedComputation.chpl
+++ b/src/SegmentedComputation.chpl
@@ -48,6 +48,8 @@ module SegmentedComputation {
     StringIsLower,
     StringIsUpper,
     StringIsTitle,
+    StringBytesToUintArr,
+    StringBytesTo2UintArrs,
   }
   
   proc computeOnSegments(segments: [?D] int, values: [?vD] ?t, param function: SegFunction, type retType, const strArg: string = "") throws {
@@ -108,6 +110,9 @@ module SegmentedComputation {
                 when SegFunction.StringIsTitle {
                   agg.copy(res[i], stringIsTitle(values, start..#len));
                 }
+                when SegFunction.StringBytesToUintArr {
+                  agg.copy(res[i], stringBytesToUintArr(values, start..#len));
+                }
                 otherwise {
                   compilerError("Unrecognized segmented function");
                 }
@@ -124,5 +129,55 @@ module SegmentedComputation {
       }
     }
     return res;
+  }
+
+  proc twoReturnComputeOnSegments(segments: [?D] int, values: [?vD] ?t, param function: SegFunction, type retType) throws {
+    // I hate duplicating the code from computeOnSegments but I need to return 2 arrays
+    var res1: [D] retType;
+    var res2: [D] retType;
+    if D.size == 0 {
+      return (res1, res2);
+    }
+
+    const (startSegInds, numSegs, lengths) = computeSegmentOwnership(segments, vD);
+
+    // Start task parallelism
+    coforall loc in Locales {
+      on loc {
+        const myFirstSegIdx = startSegInds[loc.id];
+        const myNumSegs = max(0, numSegs[loc.id]);
+        const mySegInds = {myFirstSegIdx..#myNumSegs};
+        // Segment offsets whose bytes are owned by loc
+        // Lengths of segments whose bytes are owned by loc
+        var mySegs, myLens: [mySegInds] int;
+        forall i in mySegInds with (var agg = new SrcAggregator(int)) {
+          agg.copy(mySegs[i], segments[i]);
+          agg.copy(myLens[i], lengths[i]);
+        }
+        try {
+          // Apply function to bytes of each owned segment, aggregating return values to res1 and res2
+          forall (start, len, i) in zip(mySegs, myLens, mySegInds) with (var agg1 = newDstAggregator(retType),
+                                                                         var agg2 = newDstAggregator(retType)) {
+            select function {
+              when SegFunction.StringBytesTo2UintArrs {
+                var half = (len/2):int;
+                agg1.copy(res1[i], stringBytesToUintArr(values, start..#half));
+                agg2.copy(res2[i], stringBytesToUintArr(values, (start+half)..#half));
+              }
+              otherwise {
+                compilerError("Unrecognized segmented function");
+              }
+            }
+          }
+        } catch {
+          throw new owned ErrorWithContext("Error computing %s on string or segment".format(function:string),
+                                           getLineNumber(),
+                                           getRoutineName(),
+                                           getModuleName(),
+                                           "IllegalArgumentError");
+        }
+      }
+    }
+    return (res1, res2);
   }
 }

--- a/tests/categorical_test.py
+++ b/tests/categorical_test.py
@@ -42,7 +42,7 @@ class CategoricalTest(ArkoudaTest):
         cat = self._getCategorical()
 
         self.assertListEqual(
-            [7, 5, 9, 8, 2, 1, 4, 0, 3, 6],
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
             cat.codes.to_list(),
         )
         self.assertListEqual(
@@ -51,16 +51,16 @@ class CategoricalTest(ArkoudaTest):
         )
         self.assertListEqual(
             [
-                "string 8",
-                "string 6",
-                "string 5",
-                "string 9",
-                "string 7",
-                "string 2",
-                "string 10",
                 "string 1",
-                "string 4",
+                "string 2",
                 "string 3",
+                "string 4",
+                "string 5",
+                "string 6",
+                "string 7",
+                "string 8",
+                "string 9",
+                "string 10",
                 "N/A",
             ],
             cat.categories.to_list(),
@@ -109,14 +109,14 @@ class CategoricalTest(ArkoudaTest):
 
     def testGroup(self):
         group = self._getRandomizedCategorical().group()
-        self.assertListEqual([2, 5, 9, 6, 1, 3, 7, 0, 4, 8], group.to_list())
+        self.assertListEqual([0, 4, 8, 1, 6, 2, 5, 9, 3, 7], group.to_list())
 
     def testUnique(self):
         cat = self._getRandomizedCategorical()
 
         self.assertListEqual(
             ak.Categorical(
-                ak.array(["non-string", "string3", "string1", "non-string2", "string"])
+                ak.array(["string", "string1", "string3", "non-string", "non-string2"])
             ).to_list(),
             cat.unique().to_list(),
         )

--- a/tests/coargsort_test.py
+++ b/tests/coargsort_test.py
@@ -166,12 +166,10 @@ class CoargsortTest(ArkoudaTest):
             codes=ak.array([0, 1, 0, 1, 2]), categories=ak.array(["a", "b", "c"])
         )
         for algo in ak.SortingAlgorithm:
-            str_perm = ak.coargsort([string], algo)
-            str_sorted = string[str_perm].to_list()
-
             # coargsort on categorical
+            # coargsort sorts using codes, the order isn't guaranteed, only grouping
             cat_perm = ak.coargsort([cat], algo)
-            self.assertListEqual(str_sorted, cat[cat_perm].to_list())
+            self.assertListEqual(["a", "a", "b", "b", "c"], cat[cat_perm].to_list())
 
             # coargsort on categorical.from_codes
             # coargsort sorts using codes, the order isn't guaranteed, only grouping
@@ -180,11 +178,11 @@ class CoargsortTest(ArkoudaTest):
 
             # coargsort on 2 categoricals (one from_codes)
             cat_perm = ak.coargsort([cat, cat_from_codes], algo)
-            self.assertListEqual(str_sorted, cat[cat_perm].to_list())
+            self.assertListEqual(["a", "a", "b", "b", "c"], cat[cat_perm].to_list())
 
             # coargsort on mixed strings and categoricals
             mixed_perm = ak.coargsort([cat, string, cat_from_codes], algo)
-            self.assertListEqual(str_sorted, cat_from_codes[mixed_perm].to_list())
+            self.assertListEqual(["a", "a", "b", "b", "c"], cat_from_codes[mixed_perm].to_list())
 
 
 def create_parser():

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -111,12 +111,7 @@ class DataFrameTest(ArkoudaTest):
         df = ak.DataFrame(df_dict)
         pd_d = [pd.to_datetime(x, unit="ns") for x in d.to_list()]
         pddf = pd.DataFrame(
-            {
-                "fields": f.to_list(),
-                "ip": ip.to_list(),
-                "date": pd_d,
-                "bitvector": bv.to_list()
-            }
+            {"fields": f.to_list(), "ip": ip.to_list(), "date": pd_d, "bitvector": bv.to_list()}
         )
         shape = f"({df._shape_str()})".replace("(", "[").replace(")", "]")
         pd.set_option("display.max_rows", 4)
@@ -354,19 +349,18 @@ class DataFrameTest(ArkoudaTest):
 
     def test_groupby_standard(self):
         df = build_ak_df()
-
         gb = df.GroupBy("userName")
         keys, count = gb.count()
-        self.assertTrue(keys.to_list(), ["Alice", "Carol", "Bob"])
-        self.assertListEqual(count.to_list(), [3, 1, 2])
-        self.assertListEqual(gb.permutation.to_list(), [0, 2, 5, 3, 1, 4])
+        self.assertListEqual(keys.to_list(), ["Bob", "Alice", "Carol"])
+        self.assertListEqual(count.to_list(), [2, 3, 1])
+        self.assertListEqual(gb.permutation.to_list(), [1, 4, 0, 2, 5, 3])
 
         gb = df.GroupBy(["userName", "userID"])
         keys, count = gb.count()
         self.assertEqual(len(keys), 2)
-        self.assertListEqual(keys[0].to_list(), ["Carol", "Alice", "Bob"])
-        self.assertTrue(keys[1].to_list(), [111, 333, 222])
-        self.assertTrue(count.to_list(), [3, 1, 2])
+        self.assertListEqual(keys[0].to_list(), ["Carol", "Bob", "Alice"])
+        self.assertListEqual(keys[1].to_list(), [333, 222, 111])
+        self.assertListEqual(count.to_list(), [1, 2, 3])
 
     def test_gb_series(self):
         username = ak.array(["Alice", "Bob", "Alice", "Carol", "Bob", "Alice"])
@@ -382,8 +376,8 @@ class DataFrameTest(ArkoudaTest):
 
         c = gb.count()
         self.assertIsInstance(c, ak.Series)
-        self.assertListEqual(c.index.to_list(), ["Alice", "Carol", "Bob"])
-        self.assertListEqual(c.values.to_list(), [3, 1, 2])
+        self.assertListEqual(c.index.to_list(), ["Bob", "Alice", "Carol"])
+        self.assertListEqual(c.values.to_list(), [2, 3, 1])
 
     def test_to_pandas(self):
         df = build_ak_df()

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -477,8 +477,8 @@ class GroupByTest(ArkoudaTest):
         vals = ak.array([str(i) for i in range(8)] + [str(i) for i in range(3)])
         g = ak.GroupBy(keys)
         unique_keys, nuniq = g.nunique(vals)
-        expected_unique_keys = ["2", "1"]
-        expected_nuniq = [3, 8]
+        expected_unique_keys = ["1", "2"]
+        expected_nuniq = [8, 3]
         self.assertListEqual(expected_unique_keys, unique_keys.to_list())
         self.assertListEqual(expected_nuniq, nuniq.to_list())
 

--- a/tests/setops_test.py
+++ b/tests/setops_test.py
@@ -291,8 +291,8 @@ class SetOpsTest(ArkoudaTest):
         b1 = ak.array(c)
         b2 = ak.array(d)
         t = ak.union1d([a1, a2], [b1, b2])
-        self.assertListEqual(["def", "xyz", "abc"], t[0].to_list())
-        self.assertListEqual(["456", "0", "123"], t[1].to_list())
+        self.assertListEqual(["xyz", "def", "abc"], t[0].to_list())
+        self.assertListEqual(["0", "456", "123"], t[1].to_list())
 
         # Test for Categorical
         cat_a1 = ak.Categorical(a1)
@@ -300,8 +300,8 @@ class SetOpsTest(ArkoudaTest):
         cat_b1 = ak.Categorical(b1)
         cat_b2 = ak.Categorical(b2)
         t = ak.union1d([cat_a1, cat_a2], [cat_b1, cat_b2])
-        self.assertListEqual(["abc", "xyz", "def"], t[0].to_list())
-        self.assertListEqual(["123", "0", "456"], t[1].to_list())
+        self.assertListEqual(["abc", "def", "xyz"], t[0].to_list())
+        self.assertListEqual(["123", "456", "0"], t[1].to_list())
 
     def testIn1d(self):
         pdaOne = ak.array([-1, 0, 1, 3])


### PR DESCRIPTION
This PR (Closes #1776):
- Removes duplicated string hash in `Strings._get_grouping_keys()` since this will be performed on all arrays during `unique`
- When perfroming groupby on a single strings array with max length < 16 bytes, we now concat the bytes into 1 or 2 uint arrays and then use the regular numeric unique logic. This is hopefully more efficient than uniquing/sorting the hashed arrays (since 16 bytes <= 128 bits from the hash and we don't have to do the computation of the hash)
- Combines the logic in `assumeSortedShortcut` and `uniqueAndCount` 

The performance of these changes will be tracked by the `String Groupby Performance` benchmark and the `Small String Groupby Performance` benchmark

NOTE:
This takes advantage of `computeOnSegments`, but I had to duplicate the logic in `twoReturnComputeOnSegments` because I need to return 2 arrays. I really hate doing that so I would love suggestions on a better way to accomplish this