### PR TITLE
Closes #1852: Add small string groupby perf to `run_benchmarks`

### DIFF
--- a/benchmarks/graph_infra/arkouda-string.graph
+++ b/benchmarks/graph_infra/arkouda-string.graph
@@ -16,6 +16,12 @@ files: str-groupby.dat, str-groupby.dat, str-groupby.dat, str-groupby.dat
 graphtitle: String Groupby Performance
 ylabel: Performance (GiB/S)
 
+perfkeys: small str array Average rate =, medium str array Average rate =, big str array Average rate =
+graphkeys: small str array GiB/s, medium str array GiB/s, big str array GiB/s
+files: small-str-groupby.dat, small-str-groupby.dat, small-str-groupby.dat
+graphtitle: Small String Groupby Performance
+ylabel: Performance (GiB/s)
+
 perfkeys: Average rate =
 graphkeys: Gather GiB/s
 files: str-gather.dat

--- a/benchmarks/graph_infra/arkouda.graph
+++ b/benchmarks/graph_infra/arkouda.graph
@@ -135,9 +135,3 @@ graphkeys: Noop ops/s
 files: noop.dat
 graphtitle: Noop Performance
 ylabel: Performance (ops/s)
-
-perfkeys: small str array Average rate =, medium str array Average rate =, big str array Average rate =
-graphkeys: small str array GiB/s, medium str array GiB/s, big str array GiB/s
-files: small-str-groupby.dat, small-str-groupby.dat, small-str-groupby.dat
-graphtitle: Small String Groupby Performance
-ylabel: Performance (GiB/s)

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -36,6 +36,7 @@ BENCHMARKS = [
     "array_create",
     "array_transfer",
     "IO",
+    "small-str-groupby",
     "str-argsort",
     "str-coargsort",
     "str-groupby",


### PR DESCRIPTION
This PR (closes #1852) adds small string groupby perf to `run_benchmarks` so it will get tested in the nightly.

EDIT:
I was misinterpreting the feedback and have moved the graph to `arkouda-string.graph`. My original note is in the quote below
> The PR feedback on #1848 mentioned `arkouda-string.graph` might be a more appropriate place for this benchmark rather than it's own graph. I considered having it there originally, but I felt like it wasn't really comparable to the other keys since they are comparing how groupby scales with multiple arrays 1,2,8,16 and this is tracking the performance based on the size of the strings within the SegString. That being said, I don't have terribly strong opinions on this and would be happy to change it if others feel that's the way to go