### PR TITLE
Closes #1854 - Take advantage of set and generator comprehensions in client code 

### DIFF
--- a/arkouda/_version.py
+++ b/arkouda/_version.py
@@ -185,11 +185,11 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         if verbose:
             print("keywords are unexpanded, not using")
         raise NotThisMethod("unexpanded keywords, not a git-archive tarball")
-    refs = set([r.strip() for r in refnames.strip("()").split(",")])
+    refs = {r.strip() for r in refnames.strip("()").split(",")}
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = set([r[len(TAG) :] for r in refs if r.startswith(TAG)])
+    tags = {r[len(TAG) :] for r in refs if r.startswith(TAG)}
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -198,7 +198,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = set([r for r in refs if re.search(r"\d", r)])
+        tags = {r for r in refs if re.search(r"\d", r)}
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:

--- a/arkouda/alignment.py
+++ b/arkouda/alignment.py
@@ -131,8 +131,8 @@ def find(query, space):
     else:
         if len(query) != len(space):
             raise TypeError("Multi-array arguments must have same number of arrays")
-        spacesize = set(s.size for s in space)
-        querysize = set(q.size for q in query)
+        spacesize = {s.size for s in space}
+        querysize = {q.size for q in query}
         if len(spacesize) != 1 or len(querysize) != 1:
             raise TypeError("Multi-array arguments must be non-empty and have equal-length arrays")
         spacesize = spacesize.pop()
@@ -380,15 +380,15 @@ def search_intervals(vals, intervals, tiebreak=None):
         if len(vals) != len(low) or len(vals) != len(high):
             raise TypeError("Multi-array arguments must have same number of arrays")
         if (
-            any([not isinstance(v, pdarray) for v in vals])
-            or any([not isinstance(lo, pdarray) for lo in low])
-            or any([not isinstance(hi, pdarray) for hi in high])
+            any(not isinstance(v, pdarray) for v in vals)
+            or any(not isinstance(lo, pdarray) for lo in low)
+            or any(not isinstance(hi, pdarray) for hi in high)
         ):
             raise TypeError("All elements of Multi-array arguments must be pdarrays")
 
-        valsize = set(v.size for v in vals)
-        lowsize = set(lo.size for lo in low)
-        highsize = set(hi.size for hi in high)
+        valsize = {v.size for v in vals}
+        lowsize = {lo.size for lo in low}
+        highsize = {hi.size for hi in high}
         if len(valsize) != 1 or len(lowsize) != 1 or len(highsize) != 1:
             raise TypeError("Multi-array arguments must be non-empty and have equal-length arrays")
 
@@ -406,7 +406,7 @@ def search_intervals(vals, intervals, tiebreak=None):
         if lowsize != highsize:
             raise ValueError("Lower and upper bound arrays must be same size")
         # verify upper bounds are greater than lower bounds
-        if not all([(hi >= lo).all() for hi, lo in zip(high, low)]):
+        if not all((hi >= lo).all() for hi, lo in zip(high, low)):
             raise ValueError("Upper bounds must be greater than lower bounds")
 
         # Index of interval containing each unique value (initialized to -1: not found)

--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -1160,7 +1160,7 @@ class Categorical:
 
         # for each of the groups, find categorical by testing values in the group for ".categories"
         for k, v in groups.items():  # str->list[str]
-            if any([i.endswith(".categories") for i in v]):  # we have a categorical
+            if any(i.endswith(".categories") for i in v):  # we have a categorical
                 # gather categorical pieces and replace the original mapping with the categorical object
                 cat_parts = {}
                 base_name = ""

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -1983,7 +1983,7 @@ class DataFrame(UserDict):
         # Total number of registered parts should equal number of columns plus an entry
         # for the index and the column order
         total = len(self.data) + 2
-        registered = sum([data.is_registered() for col, data in self.data.items()])
+        registered = sum(data.is_registered() for col, data in self.data.items())
 
         if self.index.values.is_registered():
             registered += 1

--- a/arkouda/dtypes.py
+++ b/arkouda/dtypes.py
@@ -145,8 +145,8 @@ ARKOUDA_SUPPORTED_DTYPES = frozenset(
     [member.value for _, member in DType.__members__.items()]
 )
 
-DTypes = frozenset([member.value for _, member in DType.__members__.items()])
-DTypeObjects = frozenset([bool, float, float64, int, int64, str, str_, uint8, uint64])
+DTypes = frozenset(member.value for _, member in DType.__members__.items())
+DTypeObjects = frozenset(bool, float, float64, int, int64, str, str_, uint8, uint64)
 NumericDTypes = frozenset(["bool", "float", "float64", "int", "int64", "uint64"])
 SeriesDTypes = {
     "string": np.str_,

--- a/arkouda/dtypes.py
+++ b/arkouda/dtypes.py
@@ -145,8 +145,8 @@ ARKOUDA_SUPPORTED_DTYPES = frozenset(
     [member.value for _, member in DType.__members__.items()]
 )
 
-DTypes = frozenset(member.value for _, member in DType.__members__.items())
-DTypeObjects = frozenset(bool, float, float64, int, int64, str, str_, uint8, uint64)
+DTypes = frozenset([member.value for _, member in DType.__members__.items()])
+DTypeObjects = frozenset([bool, float, float64, int, int64, str, str_, uint8, uint64])
 NumericDTypes = frozenset(["bool", "float", "float64", "int", "int64", "uint64"])
 SeriesDTypes = {
     "string": np.str_,

--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -135,7 +135,7 @@ def unique(
     if nkeys == 1:
         unique_keys = pda[unique_key_indices]
     else:
-        unique_keys = tuple([a[unique_key_indices] for a in pda])
+        unique_keys = tuple(a[unique_key_indices] for a in pda)
     if return_groups:
         return (unique_keys, permutation, segments, nkeys)
     else:
@@ -291,7 +291,7 @@ class GroupBy:
             if self.nkeys == 1:
                 self.unique_keys = self.keys[uki]
             else:
-                self.unique_keys = tuple([a[uki] for a in self.keys])
+                self.unique_keys = tuple(a[uki] for a in self.keys)
 
     def size(self) -> Tuple[groupable, pdarray]:
         """

--- a/arkouda/message.py
+++ b/arkouda/message.py
@@ -122,7 +122,7 @@ class ParameterObject:
         from arkouda.strings import Strings
 
         # want the object type. If pdarray the content dtypes can vary
-        dtypes = set([type(p).__name__ for p in val])
+        dtypes = {type(p).__name__ for p in val}
         if len(dtypes) > 1:
             t_str = ", ".join(dtypes)
             raise TypeError(f"List values must be of the same type. Found {t_str}")

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -294,14 +294,14 @@ def concatenate(
         # return object as it's original type
         return callback(arrays[0])
 
-    types = set([type(x) for x in arrays])
+    types = {type(x) for x in arrays}
     if len(types) != 1:
         raise TypeError(f"Items must all have same type: {types}")
 
     if isinstance(arrays[0], BitVector):
         # everything should be a BitVector because all have the same type, but do isinstance for mypy
-        widths = set([x.width for x in arrays if isinstance(x, BitVector)])
-        revs = set([x.reverse for x in arrays if isinstance(x, BitVector)])
+        widths = {x.width for x in arrays if isinstance(x, BitVector)}
+        revs = {x.reverse for x in arrays if isinstance(x, BitVector)}
         if len(widths) != 1 or len(revs) != 1:
             raise TypeError("BitVectors must all have same width and direction")
 
@@ -358,10 +358,10 @@ def multiarray_setop_validation(
 
     if len(pda1) != len(pda2):
         raise ValueError("multi-array setops require same number of arrays in arguments.")
-    size1 = set([x.size for x in pda1])
+    size1 = {x.size for x in pda1}
     if len(size1) > 1:
         raise ValueError("multi-array setops require arrays in pda1 be the same size.")
-    size2 = set([x.size for x in pda2])
+    size2 = {x.size for x in pda2}
     if len(size2) > 1:
         raise ValueError("multi-array setops require arrays in pda2 be the same size.")
     atypes = [akint64 if isinstance(x, Categorical_) else x.dtype for x in pda1]

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -255,7 +255,7 @@ class SegArray:
         if isinstance(m, pdarray):
             return cls.from_parts(arange(m.size), m)
         else:
-            sd = set((mi.size, mi.dtype) for mi in m)
+            sd = {(mi.size, mi.dtype) for mi in m}
             if len(sd) != 1:
                 raise ValueError("All columns must have same length and dtype")
             size, dtype = sd.pop()
@@ -356,7 +356,7 @@ class SegArray:
         for xi in x:
             if not isinstance(xi, cls):
                 return NotImplemented
-        if len(set(xi.dtype for xi in x)) != 1:
+        if len({xi.dtype for xi in x}) != 1:
             raise ValueError("SegArrays must all have same dtype to concatenate")
         if axis == 0:
             ctr = 0
@@ -370,7 +370,7 @@ class SegArray:
                 vals.append(xi.values)
             return cls.from_parts(concatenate(segs), concatenate(vals))
         elif axis == 1:
-            sizes = set(xi.size for xi in x)
+            sizes = {xi.size for xi in x}
             if len(sizes) != 1:
                 raise ValueError("SegArrays must all have same size to concatenate with axis=1")
             if sizes.pop() == 0:

--- a/arkouda/series.py
+++ b/arkouda/series.py
@@ -549,7 +549,7 @@ class Series:
         if len(arrays) == 0:
             raise IndexError("Array length must be non-zero")
 
-        types = set([type(x) for x in arrays])
+        types = {type(x) for x in arrays}
         if len(types) != 1:
             raise TypeError(f"Items must all have same type: {types}")
 
@@ -620,7 +620,7 @@ class Series:
         if len(arrays) == 0:
             raise IndexError("Array length must be non-zero")
 
-        types = set([type(x) for x in arrays])
+        types = {type(x) for x in arrays}
         if len(types) != 1:
             raise TypeError(f"Items must all have same type: {types}")
 

--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -50,7 +50,7 @@ def generic_concat(items, ordered=True):
     # this version can be called with Dataframe and Series (which have Class.concat methods)
     from arkouda.pdarraysetops import concatenate as pdarrayconcatenate
 
-    types = set([type(x) for x in items])
+    types = {type(x) for x in items}
     if len(types) != 1:
         raise TypeError(f"Items must all have same type: {types}")
     t = types.pop()
@@ -109,7 +109,7 @@ def register_all(data, prefix, overwrite=True):
     elif isinstance(data, list):
         return [register(v, f"{prefix}{i}") for i, v in enumerate(data)]
     elif isinstance(data, tuple):
-        return tuple([register(v, f"{prefix}{i}") for i, v in enumerate(data)])
+        return tuple(register(v, f"{prefix}{i}") for i, v in enumerate(data))
     else:
         try:
             return data.register(prefix)


### PR DESCRIPTION
This PR (Closes #1854):

- Changes some calls of builtin functions (set(), frozenset(), sum(), any(), all(), tuple()) from having a list comprehension as an argument,  to having a generator.
- Also some calls of the set() function were changed to set comprehensions for better uniformity in the code.