### PR TITLE
Switch to C++17 for Arrow compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ endif
 
 .PHONY: compile-arrow-cpp
 compile-arrow-cpp:
-	$(CXX) -O3 -std=c++11 -c $(ARROW_CPP) -o $(ARROW_O) $(INCLUDE_FLAGS) $(ARROW_SANITIZE)
+	$(CXX) -O3 -std=c++17 -c $(ARROW_CPP) -o $(ARROW_O) $(INCLUDE_FLAGS) $(ARROW_SANITIZE)
 
 $(ARROW_O): $(ARROW_CPP) $(ARROW_H)
 	make compile-arrow-cpp


### PR DESCRIPTION
The Arrow pre-release for 10.0.0 came out today and it now requires C++17 and our CI was getting that latest version, which apparently includes pre-releases.

After chatting with Ethan and Pierce, we decided it is probably best to have the CI be using the `make install-arrow` command that is in the Makefile so the CI is installing in the same way that a user would be on their machine, rather than the specific install of getting the latest that it is using today.

We want to keep up to date with the new releases, but figure we will just hardcode the release for now, since Arkouda is already doing that for a number of other dependencies.

Chapel requires GCC 7+, which supports the majority of C++17 features, so Elliot thought it wouldn't be the end of the world to use C++17 in the Arkouda build, so if we end up wanting to support the new Arrow versions, that _probably_ won't cause any issues, but I think we are going to defer that for now.