### PR TITLE
Closes #1859- Updating Arrow version to 9.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ install-hdf5:
 	rm -rf $(HDF5_BUILD_DIR)
 	echo '$$(eval $$(call add-path,$(HDF5_INSTALL_DIR)))' >> Makefile.paths
 
-ARROW_VER := 7.0.0
+ARROW_VER := 9.0.0
 ARROW_NAME_VER := apache-arrow-$(ARROW_VER)
 ARROW_FULL_NAME_VER := arrow-apache-arrow-$(ARROW_VER)
 ARROW_BUILD_DIR := $(DEP_BUILD_DIR)/$(ARROW_FULL_NAME_VER)

--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -15,7 +15,7 @@ dependencies:
   - pip
   - types-tabulate
   - pytables>=3.7.0
-  - pyarrow==7.0.0
+  - pyarrow==9.0.0
 
   # Developer dependencies
   - pexpect

--- a/arkouda-env.yml
+++ b/arkouda-env.yml
@@ -15,7 +15,7 @@ dependencies:
   - pip
   - types-tabulate
   - pytables>=3.7.0
-  - pyarrow==7.0.0
+  - pyarrow==9.0.0
 
   - pip:
       - typeguard==2.10.0

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ setup(
         'pip',
         'types-tabulate',
         'tables>=3.7.0',
-        'pyarrow==7.0.0'
+        'pyarrow==9.0.0'
     ],
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
Closes #1859 

Updates Arrow and `pyarrow` versions to 9.0.0. This gets them as close to latest as possible. In the future we will need to update this and the CI to ensure they are installing the same version.