### PR TITLE
Closes #1801 - Reorganizes Symbol Table

### DIFF
--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -283,8 +283,8 @@ class GroupBy:
             rep_json = json.loads(repmsg)
             fields = rep_json["groupby"].split()
             self.name = fields[1]
-            self.length = int(fields[3])
-            self.ngroups = int(fields[4])
+            self.length = int(fields[2])
+            self.ngroups = int(fields[3])
             self.permutation = create_pdarray(rep_json["permutation"])
             self.segments = create_pdarray(rep_json["segments"])
             uki = create_pdarray(rep_json["uniqueKeyIdx"])

--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -453,14 +453,14 @@ module MultiTypeSymEntry
     }
 
     /**
-     * Helper proc to cast AbstrcatSymEntry to CompositeSymEntry
+     * Helper proc to cast AbstractSymEntry to CompositeSymEntry
      */
     proc toCompositeSymEntry(entry: borrowed AbstractSymEntry) throws {
         return (entry: borrowed CompositeSymEntry);
     }
     
     /**
-     * Helper proc to cast AbstrcatSymEntry to SegStringSymEntry
+     * Helper proc to cast AbstractSymEntry to SegStringSymEntry
      */
     proc toSegStringSymEntry(entry: borrowed AbstractSymEntry) throws {
         return (entry: borrowed SegStringSymEntry);

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -132,9 +132,9 @@ module MultiTypeSymbolTable
             if entry.isAssignableTo(SymbolEntryType.TypedArraySymEntry) {
                 overMemLimit( (entry:GenSymEntry).size * (entry:GenSymEntry).itemsize);
 
-            } else if entry.isAssignableTo(SymbolEntryType.CompositeSymEntry) {
-                // TODO invoke memory check ... maybe the mem check should be part of the SymbolType API?
-            }
+            } // } else if entry.isAssignableTo(SymbolEntryType.CompositeSymEntry) {
+            //     // TODO invoke memory check ... maybe the mem check should be part of the SymbolType API?
+            // }
             
 
             if (tab.contains(name)) {
@@ -383,10 +383,13 @@ module MultiTypeSymbolTable
             checkTable(name, "attrib");
 
             var entry = tab.getBorrowed(name);
-            if entry.isAssignableTo(SymbolEntryType.TypedArraySymEntry) || 
-                    entry.isAssignableTo(SymbolEntryType.CompositeSymEntry) {
+            if entry.isAssignableTo(SymbolEntryType.TypedArraySymEntry){ //Anything considered a GenSymEntry
                 var g:GenSymEntry = toGenSymEntry(entry);
                 return "%s %s %t %t %t %t".format(name, dtype2str(g.dtype), g.size, g.ndim, g.shape, g.itemsize);
+            }
+            else if entry.isAssignableTo(SymbolEntryType.CompositeSymEntry) { //CompositeSymEntry
+                var c: CompositeSymEntry = toCompositeSymEntry(entry);
+                return "%s %t %t".format(name, c.size, c.ndim);
             }
             
             throw new Error("attrib - Unsupported Entry Type %s".format(entry.entryType));

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -81,9 +81,9 @@ module SegmentedMsg {
     var msgArgs = parseMessageArgs(payload, argSize);
     var name = msgArgs.getValueOf("name"): string;
     var entry = st.tab.getBorrowed(name);
-    var compEntry: CompositeSymEntry = toCompositeSymEntry(entry);
+    var genEntry: GenSymEntry = toGenSymEntry(entry);
     var neName = st.nextName();
-    select compEntry.dtype {
+    select genEntry.dtype {
       when (DType.Int64) {
         var segArr = getSegArray(name, st, int);
         st.addEntry(neName, new shared SymEntry(segArr.getNonEmpty()));
@@ -110,7 +110,7 @@ module SegmentedMsg {
         repMsg = "created " + st.attrib(neName) + "+" + segArr.getNonEmptyCount():string;
       }
       otherwise {
-        throw new owned ErrorWithContext("Values array has unsupported dtype %s".format(compEntry.dtype:string),
+        throw new owned ErrorWithContext("Values array has unsupported dtype %s".format(genEntry.dtype:string),
                                       getLineNumber(),
                                       getRoutineName(),
                                       getModuleName(),


### PR DESCRIPTION
Closes #1801

Reorganizes the symbol table so that the structure is more intuitive. `GenSymEntry` now allows for entires that contain multiple symbol table entries. In these cases the multiple entries are required to represent a singular object. For example, `SegArraySymEntry` contains `values` and `offsets` `SymEntries`. However, the each independently is required to conceptualize the `SegArray`. These objects also have a defined type. `CompositeSymEntry` is to be used for `SymEntries` that contain multiple entries, but those entries have varying types and are not necessarily required to conceptualize the full object.

**NOTE - At this time only `GroupBySymEntry` should inherit from `CompositeSymEntry`.**

- Updates `SegStringSymEntry` and `SegArraySymEntry` to inherit from `GenSymEntry`
- Updates `GroupBySymEntry` to inherit from `CompositeSymEntry`
- Adds `attrib` case for `CompositeSymEntry`
- Adds `toCompositeSymEntry`
