### PR TITLE
Closes #1857 - Remove `OPTIONAL_CHECKS`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,6 @@ endif
 CHPL_FLAGS += -lhdf5 -lhdf5_hl -lzmq
 
 CHPL_FLAGS += -lparquet -larrow
-OPTIONAL_CHECKS += check-arrow
 ARROW_FILE_NAME += $(ARKOUDA_SOURCE_DIR)/ArrowFunctions
 ARROW_CPP += $(ARROW_FILE_NAME).cpp
 ARROW_H += $(ARROW_FILE_NAME).h
@@ -143,7 +142,7 @@ endif
 
 .PHONY: check-deps
 ifndef ARKOUDA_SKIP_CHECK_DEPS
-CHECK_DEPS = check-chpl check-zmq check-hdf5 check-re2 $(OPTIONAL_CHECKS)
+CHECK_DEPS = check-chpl check-zmq check-hdf5 check-re2 check-arrow
 endif
 check-deps: $(CHECK_DEPS)
 


### PR DESCRIPTION
Closes #1857 

Removed the `OPTIONAL_CHECKS` variable and replaces in `check-deps` with `check-arrow` because we require arrow and should always be checking it.