### PR TITLE
Closes #1865 - Remove unused return value in `MultiTypeSymbolTable`

### DIFF
--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -309,7 +309,7 @@ module MultiTypeSymbolTable
         */
         proc parseJson(names:string): [] string throws {
             var mem = openmem();
-            var writer = mem.writer().write(names);
+            mem.writer().write(names);
             var reader = mem.reader();
 
             var num_elements = 0;


### PR DESCRIPTION
Closes #1865 

Removes unused return value in `parseJson` function to prepare for upcoming chapel PR that will cause `channel.write` to return `void`.