### PR TITLE
Part of #1867: String GroupBy optimizations are timing out nightly tests

### DIFF
--- a/benchmarks/small-str-groupby.py
+++ b/benchmarks/small-str-groupby.py
@@ -5,7 +5,7 @@ import time
 
 import arkouda as ak
 
-SIZES = {"small": 7, "medium": 14, "big": 28}
+SIZES = {"small": 6, "medium": 12, "big": 24}
 
 
 def time_ak_groupby(N_per_locale, trials, seed):

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -168,7 +168,8 @@ module UniqueMsg
         // Only one array which is a strings
         var (myNames, _) = namesList[0].splitMsgToTuple("+", 2);
         var strings = getSegString(myNames, st);
-        var max_bytes = max reduce strings.getLengths();
+        // should we do strings.getLengths()-1 to not account for null
+        const max_bytes = max reduce strings.getLengths();
         if max_bytes < 16 {
           var str_names = strings.bytesToUintArr(max_bytes, st).split("+");
           var (totalDigits, bitWidths, negs) = getNumDigitsNumericArrays(str_names, st);


### PR DESCRIPTION
This PR (part of #1867):
- Changes the medium str logic (`8 <= max_bytes < 16`) to not use the 2 array return variation of `computeOnSegments`
- Updates `bytesToUintArr` to run in parallel

If the nightly still has issues, I think the next step is to remove the special logic for medium str until the next iteration