### PR TITLE
Closes #1868 - `AbstractSymEntry` Name Property

### DIFF
--- a/src/GroupBy.chpl
+++ b/src/GroupBy.chpl
@@ -86,29 +86,21 @@ module GroupBy {
             //For initial implementation, UniqueKeyIndexes returned to compute UniqueKeys client side
         }
 
-        proc getSegmentsName(st: borrowed SymTab): string throws {
-            var sname = st.nextName();
-            st.addEntry(sname, segments);
-            return sname;
-        }
+        proc getComponentName(obj: SymEntry, st: borrowed SymTab): string throws {
+            if obj.name != "" {
+                return obj.name;
+            }
 
-        proc getPermutationName(st: borrowed SymTab): string throws {
-            var pname = st.nextName();
-            st.addEntry(pname, permutation);
-            return pname;
-        }
-
-        proc getUniqueKeyIndexName(st: borrowed SymTab): string throws {
-            var ukname = st.nextName();
-            st.addEntry(ukname, uniqueKeyIndexes);
-            return ukname;
+            var rname = st.nextName();
+            st.addEntry(rname, obj);
+            return obj.name;
         }
 
         proc fillReturnMap(ref rm: map(string, string), st: borrowed SymTab) throws {
             rm.add("groupby", "created " + st.attrib(this.name));
-            rm.add("segments", "created " + st.attrib(this.getSegmentsName(st)));
-            rm.add("permutation", "created " + st.attrib(this.getPermutationName(st)));
-            rm.add("uniqueKeyIdx", "created " + st.attrib(this.getUniqueKeyIndexName(st)));
+            rm.add("segments", "created " + st.attrib(this.getComponentName(this.segments, st)));
+            rm.add("permutation", "created " + st.attrib(this.getComponentName(this.permutation, st)));
+            rm.add("uniqueKeyIdx", "created " + st.attrib(this.getComponentName(this.uniqueKeyIndexes, st)));
         }
     }
 }

--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -412,7 +412,6 @@ module MultiTypeSymEntry
             this.valuesEntry = valuesSymEntry;
 
             ref sa = segmentsSymEntry.a;
-            const low = segmentsSymEntry.aD.low;
             const high = segmentsSymEntry.aD.high;
             var lengths = [(i, s) in zip (segmentsSymEntry.aD, sa)] if i == high then valuesSymEntry.size - s else sa[i+1] - s;
             

--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -396,18 +396,6 @@ module MultiTypeSymEntry
         }
     }
 
-    proc createSegArrayEntry(segmentsSymEntry: shared SymEntry, valuesSymEntry: shared SymEntry, type etype, st: borrowed SymTab): shared SegArraySymEntry throws {
-        ref sa = segmentsSymEntry.a;
-        const low = segmentsSymEntry.aD.low;
-        const high = segmentsSymEntry.aD.high;
-        var lengths = [(i, s) in zip (segmentsSymEntry.aD, sa)] if i == high then valuesSymEntry.size - s else sa[i+1] - s;
-        var lname = st.nextName();
-        var lengthsSymEntry = new shared SymEntry(lengths);
-        st.addEntry(lname, lengthsSymEntry);
-
-        return new shared SegArraySymEntry(segmentsSymEntry, valuesSymEntry, lengthsSymEntry, etype);
-    }
-
     class SegArraySymEntry:GenSymEntry {
         type etype;
 
@@ -415,15 +403,20 @@ module MultiTypeSymEntry
         var valuesEntry: shared SymEntry(etype);
         var lengthsEntry: shared SymEntry(int);
 
-        proc init(segmentsSymEntry: shared SymEntry, valuesSymEntry: shared SymEntry, 
-                    lengthsSymEntry: shared SymEntry, type etype) {
+        proc init(segmentsSymEntry: shared SymEntry, valuesSymEntry: shared SymEntry, type etype) {
             super.init(etype, valuesSymEntry.size);
             this.entryType = SymbolEntryType.SegArraySymEntry;
             assignableTypes.add(this.entryType);
             this.etype = etype;
             this.segmentsEntry = segmentsSymEntry;
             this.valuesEntry = valuesSymEntry;
-            this.lengthsEntry = lengthsSymEntry;
+
+            ref sa = segmentsSymEntry.a;
+            const low = segmentsSymEntry.aD.low;
+            const high = segmentsSymEntry.aD.high;
+            var lengths = [(i, s) in zip (segmentsSymEntry.aD, sa)] if i == high then valuesSymEntry.size - s else sa[i+1] - s;
+            
+            lengthsEntry = new shared SymEntry(lengths);
 
             this.dtype = whichDtype(etype);
             this.itemsize = this.valuesEntry.itemsize;

--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -51,10 +51,18 @@ module MultiTypeSymEntry
     class AbstractSymEntry {
         var entryType:SymbolEntryType;
         var assignableTypes:set(SymbolEntryType); // All subclasses should add their type to this set
+        var name = ""; // used to track the symbol table name assigned to the entry
         proc init() {
             this.entryType = SymbolEntryType.AbstractSymEntry;
             this.assignableTypes = new set(SymbolEntryType);
             this.assignableTypes.add(this.entryType);
+        }
+
+        /*
+            Sets the name of the entry when it is added to the Symbol Table
+        */
+        proc setName(name: string) {
+            this.name = name;
         }
 
         /**
@@ -388,19 +396,34 @@ module MultiTypeSymEntry
         }
     }
 
+    proc createSegArrayEntry(segmentsSymEntry: shared SymEntry, valuesSymEntry: shared SymEntry, type etype, st: borrowed SymTab): shared SegArraySymEntry throws {
+        ref sa = segmentsSymEntry.a;
+        const low = segmentsSymEntry.aD.low;
+        const high = segmentsSymEntry.aD.high;
+        var lengths = [(i, s) in zip (segmentsSymEntry.aD, sa)] if i == high then valuesSymEntry.size - s else sa[i+1] - s;
+        var lname = st.nextName();
+        var lengthsSymEntry = new shared SymEntry(lengths);
+        st.addEntry(lname, lengthsSymEntry);
+
+        return new shared SegArraySymEntry(segmentsSymEntry, valuesSymEntry, lengthsSymEntry, etype);
+    }
+
     class SegArraySymEntry:GenSymEntry {
         type etype;
 
         var segmentsEntry: shared SymEntry(int);
         var valuesEntry: shared SymEntry(etype);
+        var lengthsEntry: shared SymEntry(int);
 
-        proc init(segmentsSymEntry: shared SymEntry, valuesSymEntry: shared SymEntry, type etype){
+        proc init(segmentsSymEntry: shared SymEntry, valuesSymEntry: shared SymEntry, 
+                    lengthsSymEntry: shared SymEntry, type etype) {
             super.init(etype, valuesSymEntry.size);
             this.entryType = SymbolEntryType.SegArraySymEntry;
             assignableTypes.add(this.entryType);
             this.etype = etype;
             this.segmentsEntry = segmentsSymEntry;
             this.valuesEntry = valuesSymEntry;
+            this.lengthsEntry = lengthsSymEntry;
 
             this.dtype = whichDtype(etype);
             this.itemsize = this.valuesEntry.itemsize;

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -111,6 +111,7 @@ module MultiTypeSymbolTable
             }
 
             tab.addOrSet(name, entry);
+            entry.setName(name);
             // When we retrieve from table, it comes back as AbstractSymEntry so we need to cast it
             // back to the original type. Since we know it already we can skip isAssignableTo check
             return (tab.getBorrowed(name):borrowed GenSymEntry).toSymEntry(t);
@@ -146,6 +147,7 @@ module MultiTypeSymbolTable
             }
 
             tab.addOrSet(name, entry);
+            entry.setName(name);
             return tab.getBorrowed(name);
         }
 

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -47,7 +47,7 @@ module SegmentedArray {
 
         var segments: shared SymEntry(int);
         var values;
-        var lengths: shared SymEntry(int); //[segments.aD] int;
+        var lengths: shared SymEntry(int);
         var size: int;
         var nBytes: int;
 
@@ -60,11 +60,6 @@ module SegmentedArray {
 
             size = segments.size;
             nBytes = values.size;
-
-            // ref sa = segments.a;
-            // const low = segments.aD.low;
-            // const high = segments.aD.high;
-            // lengths = [(i, s) in zip (segments.aD, sa)] if i == high then values.size - s else sa[i+1] - s;
 
             // Note - groupby remaining client side because groupby does not have server side object
         }

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -33,8 +33,7 @@ module SegmentedArray {
     proc getSegArray(segments: [] int, values: [] ?t, st: borrowed SymTab): owned SegArray throws {
         var segmentsEntry = new shared SymEntry(segments);
         var valuesEntry = new shared SymEntry(values);
-        // var segEntry = new shared SegArraySymEntry(segmentsEntry, valuesEntry, t, st);
-        var segEntry: shared SegArraySymEntry = createSegArrayEntry(segmentsEntry, valuesEntry, t, st);
+        var segEntry = new shared SegArraySymEntry(segmentsEntry, valuesEntry, t);
         var name = st.nextName();
         st.addEntry(name, segEntry);
         return getSegArray(name, st, segEntry.etype);


### PR DESCRIPTION
Closes #1868 

Adds `name` property to `AbstractSymEntry`. This is not 100% necessary at the current time. However, this should alleviate a few potential pain points with `register`/`attach` and allow us to support `copy` functionality. Currently, we ALWAYS create a new `SymEntry` to avoid changes in the object used for creation to impact any object it is used to create. This is something we are discussing changing and this change would make that easier because we get the name of the Symbol Table entry if it already exists. Otherwise, we create the entry and return that name.

This PR also updates the `SegArraySymEntry` initialization to support the `length` component to be stored as a SymEntry instead of just being an array. This also updates the `fillReturnMap` function to call a single function passing in the entry you want to return the name of. This eliminates the need for a function to return the name of each component.