### PR TITLE
Closes #1727: Add `where` argument to `sqrt` and `power`

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -2638,8 +2638,6 @@ def rotr(x, rot) -> pdarray:
     >>> A = ak.arange(10)
     >>> ak.rotr(1024 * A, A)
     array([0, 512, 512, 384, 256, 160, 96, 56, 32, 18])
-
-
     """
     if isinstance(x, pdarray) and x.dtype in [akint64, akuint64]:
         if (isinstance(rot, pdarray) and rot.dtype in [akint64, akuint64]) or isSupportedInt(rot):
@@ -2658,18 +2656,19 @@ def power(pda: pdarray, pwr: Union[int, float, pdarray], where: Union[bool, pdar
     Raises an array to a power. If where is given, the operation will only take place in the positions
     where the where condition is True.
 
-    Notes:
-    This function was modified to deviate from the previous implementation that matched numpy.
-    If a False condition was given, numpy would return 0. This implementation will now return
-    the original value.
+    Note:
+    Our implementation of the where argument deviates from numpy. The difference in behavior occurs
+    at positions where the where argument contains a False. In numpy, these position will have
+    uninitialized memory (which can contain anything and will vary between runs). We have chosen to
+    instead return the value of the original array in these positions.
 
     Parameters
     ----------
     pda : pdarray
-        A pdarry of values that will be raised to a power (pwr)
+        A pdarray of values that will be raised to a power (pwr)
     pwr : integer, float, or pdarray
         The power(s) that pda is raised to
-    where : Boolean or pdaarray
+    where : Boolean or pdarray
         This condition is broadcast over the input. At locations where the condition is True, the
         corresponding value will be raised to the respective power. Elsewhere, it will retain its
         original value. Default set to True.
@@ -2681,7 +2680,10 @@ def power(pda: pdarray, pwr: Union[int, float, pdarray], where: Union[bool, pdar
 
     Examples
     --------
-    >>> ak.power(ak.arange(5), 3, truth)
+    >>> a = ak.arange(5)
+    >>> ak.power(a, 3)
+    array([0, 1, 8, 27, 64])
+    >>> ak.power(a), 3, a % 2 == 0)
     array([0, 1, 8, 3, 64])
     """
     from arkouda.numeric import cast as akcast
@@ -2717,9 +2719,10 @@ def sqrt(pda: pdarray, where: Union[bool, pdarray] = True) -> pdarray:
         Returns a pdarray of square rooted values, under the boolean where condition.
 
     Examples:
-    >>> A = ak.arange(5)
-    >>> truth = ak.sqrt([True, True, False, False, True])
-    >>> ak.sqrt(A, truth)
+    >>> a = ak.arange(5)
+    >>> ak.sqrt(a)
+    array([0 1 1.4142135623730951 1.7320508075688772 2])
+    >>> ak.sqrt(a, ak.sqrt([True, True, False, False, True]))
     array([0, 1, 2, 3, 2])
     """
     return power(pda, 0.5, where)

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -2638,6 +2638,8 @@ def rotr(x, rot) -> pdarray:
     >>> A = ak.arange(10)
     >>> ak.rotr(1024 * A, A)
     array([0, 512, 512, 384, 256, 160, 96, 56, 32, 18])
+
+
     """
     if isinstance(x, pdarray) and x.dtype in [akint64, akuint64]:
         if (isinstance(rot, pdarray) and rot.dtype in [akint64, akuint64]) or isSupportedInt(rot):
@@ -2651,13 +2653,76 @@ def rotr(x, rot) -> pdarray:
 
 
 @typechecked
-def power(pda: pdarray, pwr: Union[int, float, pdarray]) -> pdarray:
-    return pda**pwr
+def power(pda: pdarray, pwr: Union[int, float, pdarray], where: Union[bool, pdarray] = True) -> pdarray:
+    """
+    Raises an array to a power. If where is given, the operation will only take place in the positions
+    where the where condition is True.
+
+    Notes:
+    This function was modified to deviate from the previous implementation that matched numpy.
+    If a False condition was given, numpy would return 0. This implementation will now return
+    the original value.
+
+    Parameters
+    ----------
+    pda : pdarray
+        A pdarry of values that will be raised to a power (pwr)
+    pwr : integer, float, or pdarray
+        The power(s) that pda is raised to
+    where : Boolean or pdaarray
+        This condition is broadcast over the input. At locations where the condition is True, the
+        corresponding value will be raised to the respective power. Elsewhere, it will retain its
+        original value. Default set to True.
+
+    Returns
+    -------
+        pdarray
+        Returns a pdarray of values raised to a power, under the boolean where condition.
+
+    Examples
+    --------
+    >>> ak.power(ak.arange(5), 3, truth)
+    array([0, 1, 8, 3, 64])
+    """
+    from arkouda.numeric import cast as akcast
+    from arkouda.numeric import where as akwhere
+
+    if where is True:
+        return pda**pwr
+    elif where is False:
+        return pda
+    else:
+        exp = pda**pwr
+        return akwhere(where, exp, akcast(pda, dtype(exp)))
 
 
 @typechecked
-def sqrt(pda: pdarray) -> pdarray:
-    return power(pda, 0.5)
+def sqrt(pda: pdarray, where: Union[bool, pdarray] = True) -> pdarray:
+    """
+    Takes the square root of array. If where is given, the operation will only take place in
+    the positions where the where condition is True.
+
+    Parameters
+    ----------
+    pda : pdarray
+        A pdarry of values that will be square rooted
+    where : Boolean or pdaarray
+        This condition is broadcast over the input. At locations where the condition is True, the
+        corresponding value will be square rooted. Elsewhere, it will retain its original value.
+        Default set to True.
+
+    Returns
+    -------
+        pdarray
+        Returns a pdarray of square rooted values, under the boolean where condition.
+
+    Examples:
+    >>> A = ak.arange(5)
+    >>> truth = ak.sqrt([True, True, False, False, True])
+    >>> ak.sqrt(A, truth)
+    array([0, 1, 2, 3, 2])
+    """
+    return power(pda, 0.5, where)
 
 
 @typechecked

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -486,7 +486,8 @@ class OperatorsTest(ArkoudaTest):
 
         # Test a singleton with a mixed Boolean argument
         a = ak.arange(10)
-        self.assertListEqual([i if i % 2 else i ** 2 for i in range(10)], ak.power(a, 2, a % 2 == 0).to_list())
+        self.assertListEqual([i if i % 2 else i**2 for i in range(10)],
+                             ak.power(a, 2, a % 2 == 0).to_list())
 
         # Test invalid input, negative
         n = np.array([-1.0, -3.0])
@@ -497,11 +498,9 @@ class OperatorsTest(ArkoudaTest):
         self.assertTrue(np.allclose(p.to_ndarray(), ex, equal_nan=True))
 
         # Test edge case input, inf
-        I = np.inf
-        n = np.array([I, -I])
-        a = ak.array([I, -I])
+        n = np.array([np.inf, -np.inf])
+        a = ak.array([np.inf, -np.inf])
         self.assertListEqual(np.power(n, 2).tolist(), ak.power(a, 2).to_list())
-
 
     def test_pda_sqrt(self):
         # Base cases and edge cases
@@ -516,7 +515,7 @@ class OperatorsTest(ArkoudaTest):
 
         # Test with a mixed Boolean array
         a = ak.arange(5)
-        self.assertListEqual([i if i % 2 else i ** .5 for i in range(5)], ak.sqrt(a, a % 2 == 0).to_list())
+        self.assertListEqual([i if i % 2 else i**.5 for i in range(5)], ak.sqrt(a, a % 2 == 0).to_list())
 
     def testAllOperators(self):
         run_tests(verbose)

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -468,21 +468,14 @@ class OperatorsTest(ArkoudaTest):
         self.assertListEqual(p.to_list(), ex.tolist())
 
         # Test a singleton with and without a Boolean argument
-        n = np.array([7])
-        a = ak.array(n)
-
+        a = ak.array([7])
         self.assertListEqual(ak.power(a, 3, True).to_list(), ak.power(a, 3).to_list())
         self.assertListEqual(ak.power(a, 3, False).to_list(), a.to_list())
 
         # Test an with and without a Boolean argument, all the same
-        n = np.array([0, 0.0, 1, 7.0, 10])
-        a = ak.array(n)
-
-        truth_True = ak.ones(5, bool)
-        truth_False = ak.zeros(5, bool)
-
-        self.assertListEqual(ak.power(a, 3, truth_True).to_list(), ak.power(a, 3).to_list())
-        self.assertListEqual(ak.power(a, 3, truth_False).to_list(), a.to_list())
+        a = ak.array([0, 0.0, 1, 7.0, 10])
+        self.assertListEqual(ak.power(a, 3, ak.ones(5, bool)).to_list(), ak.power(a, 3).to_list())
+        self.assertListEqual(ak.power(a, 3, ak.zeros(5, bool)).to_list(), a.to_list())
 
         # Test a singleton with a mixed Boolean argument
         a = ak.arange(10)
@@ -507,11 +500,7 @@ class OperatorsTest(ArkoudaTest):
         # Most cases are taken care of in the test_pda_power tests
         n = np.array([4, 16.0, -1, 0, np.inf])
         a = ak.array(n)
-
-        s = ak.sqrt(a)
-        ex = np.sqrt(n)
-
-        self.assertTrue(np.allclose(s.to_ndarray(), ex, equal_nan=True))
+        self.assertTrue(np.allclose(ak.sqrt(a).to_ndarray(), np.sqrt(n), equal_nan=True))
 
         # Test with a mixed Boolean array
         a = ak.arange(5)

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -455,15 +455,6 @@ class OperatorsTest(ArkoudaTest):
                 )
             )
 
-    def test_pda_sqrt(self):
-        n = np.array([4, 16, -1, 0, np.inf])
-        a = ak.array(n)
-
-        s = ak.sqrt(a)
-        ex = np.sqrt(n)
-
-        self.assertTrue(np.allclose(s.to_ndarray(), ex, equal_nan=True))
-
     def test_pda_power(self):
         n = np.array([10, 5, 2])
         a = ak.array(n)
@@ -476,12 +467,56 @@ class OperatorsTest(ArkoudaTest):
         ex = np.power(n, [2, 3, 4])
         self.assertListEqual(p.to_list(), ex.tolist())
 
+        # Test a singleton with and without a Boolean argument
+        n = np.array([7])
+        a = ak.array(n)
+
+        self.assertListEqual(ak.power(a, 3, True).to_list(), ak.power(a, 3).to_list())
+        self.assertListEqual(ak.power(a, 3, False).to_list(), a.to_list())
+
+        # Test an with and without a Boolean argument, all the same
+        n = np.array([0, 0.0, 1, 7.0, 10])
+        a = ak.array(n)
+
+        truth_True = ak.ones(5, bool)
+        truth_False = ak.zeros(5, bool)
+
+        self.assertListEqual(ak.power(a, 3, truth_True).to_list(), ak.power(a, 3).to_list())
+        self.assertListEqual(ak.power(a, 3, truth_False).to_list(), a.to_list())
+
+        # Test a singleton with a mixed Boolean argument
+        a = ak.arange(10)
+        self.assertListEqual([i if i % 2 else i ** 2 for i in range(10)], ak.power(a, 2, a % 2 == 0).to_list())
+
+        # Test invalid input, negative
         n = np.array([-1.0, -3.0])
         a = ak.array(n)
 
         p = ak.power(a, 0.5)
         ex = np.power(n, 0.5)
         self.assertTrue(np.allclose(p.to_ndarray(), ex, equal_nan=True))
+
+        # Test edge case input, inf
+        I = np.inf
+        n = np.array([I, -I])
+        a = ak.array([I, -I])
+        self.assertListEqual(np.power(n, 2).tolist(), ak.power(a, 2).to_list())
+
+
+    def test_pda_sqrt(self):
+        # Base cases and edge cases
+        # Most cases are taken care of in the test_pda_power tests
+        n = np.array([4, 16.0, -1, 0, np.inf])
+        a = ak.array(n)
+
+        s = ak.sqrt(a)
+        ex = np.sqrt(n)
+
+        self.assertTrue(np.allclose(s.to_ndarray(), ex, equal_nan=True))
+
+        # Test with a mixed Boolean array
+        a = ak.arange(5)
+        self.assertListEqual([i if i % 2 else i ** .5 for i in range(5)], ak.sqrt(a, a % 2 == 0).to_list())
 
     def testAllOperators(self):
         run_tests(verbose)


### PR DESCRIPTION
This PR (Closes #1727)

- Implements an updated version of the Power and Sqrt functions
- Correctly accept boolean arguments, more closely matches Numpy and returns original value if False condition is input
- Updated and added additional testing and documentation