### PR TITLE
Swap order of zippered for-loops in which an unbounded range was the leader

### DIFF
--- a/src/Cast.chpl
+++ b/src/Cast.chpl
@@ -64,7 +64,7 @@ module Cast {
     var values = st.addEntry(vname, totBytes, uint(8));
     ref va = values.a;
     forall (o, s) in zip(segments.a, strings) with (var agg = newDstAggregator(uint(8))) {
-      for (i, b) in zip(0.., s.bytes()) {
+      for (b, i) in zip(s.bytes(), 0..) {
         agg.copy(va[o+i], b);
       }
     }

--- a/src/SegmentedString.chpl
+++ b/src/SegmentedString.chpl
@@ -566,7 +566,7 @@ module SegmentedString {
       //calculate values for the segmentedstring
       var finalValues = makeDistArray((+ reduce encodeLengths)+encodeLengths.size, uint(8));
       forall (s, o) in zip(encodeArr, encodeOffsets) with (var agg = newDstAggregator(uint(8))) {
-        for (j, c) in zip(0.., s.chpl_bytes()) {
+        for (c, j) in zip(s.chpl_bytes(), 0..) {
           agg.copy(finalValues[j+o], c);
         }
       }
@@ -580,7 +580,7 @@ module SegmentedString {
       // Every start position is valid until proven otherwise
       var truth: [D] bool = true;
       // Shift the flat values one byte at a time and check against corresponding byte of substr
-      for (i, b) in zip(0.., substr.chpl_bytes()) {
+      for (b, i) in zip(substr.chpl_bytes(), 0..) {
         truth &= (values.a[D.translate(i)] == b);
       }
       return truth;

--- a/test/UnitTestPeelStick.chpl
+++ b/test/UnitTestPeelStick.chpl
@@ -245,7 +245,7 @@ proc makeSegArrayFromString(s:string, st) throws {
   var bytes_list = new list(uint(8));
   offset_list.append(0); // first string starts at zero
   const length = s.size;
-  for (i, b) in zip(0.., s.encode().items()){
+  for (b, i) in zip(s.encode().items(), 0..){
     if (nb_byt == b && (i+1) != length) {
       offset_list.append(i+1);
     }


### PR DESCRIPTION
In Chapel, we recently fixed an inconsistency between serial and parallel loops such that 'for (i,j) in zip(1.., whatever)' now results in a (conceptually) infinite execution because we make the first iterand determine the number of iterations of the loop, and subsequent iterands "follow" the first's lead.  Prior to this change, if the first iterand was an unbounded loop, it would just stop whenever the other iterators were complete.  This PR flips such cases around in the source to 'for (j,i) in zip(whatever, 1..)' to preserve the old behavior in the face of the new interpretation.

For further information and context, see https://github.com/chapel-lang/chapel/issues/20051 and https://github.com/chapel-lang/chapel/pull/20891