### PR TITLE
Temporarily drop python 3.11 testing from CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.x']
+        python-version: ['3.8', '3.9', '3.10']
     container:
       image: chapel/chapel:1.28.0
     steps:


### PR DESCRIPTION
Python 3.11 was recently released and CI testing just picked it up with the 3.X (latest supported python 3) config, but pyarrow doesn't yet support 3.11 so the build was failing. Until pyarrow supports 3.11, just stop testing 3.11.

Note that when we're on top of version updates the latest python we specify is the same as 3.X, so in the steady state there is some testing duplication. However, this is useful when new versions come out since we (or at least I) don't track releases very closely and this alerts us to potential incompatibilities like this.

Closes #1881