### PR TITLE
Closes #1885 - Updating mypy to use >=0.931,<0.990

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -38,7 +38,7 @@ The dependencies listed here are only required if you will be doing development 
 - `sphinx-argparse`
 - `sphinx-autoapi`
 - `typed-ast`
-- `mypy>=0.931`
+- `mypy>=0.931,<0.990`
 - `flake8`
 
 ## Installing/Updating Python Dependencies

--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -26,7 +26,7 @@ dependencies:
   - sphinx-autoapi
   - typed-ast
   - flake8
-  - mypy>=0.931
+  - mypy>=0.931,<0.990
   - black
   - isort
   

--- a/pydoc/requirements.txt
+++ b/pydoc/requirements.txt
@@ -22,5 +22,5 @@ Sphinx>=5.1.1
 sphinx-argparse
 sphinx-autoapi
 typed-ast
-mypy>=0.931
+mypy>=0.931,0.990
 flake8

--- a/setup.py
+++ b/setup.py
@@ -157,7 +157,7 @@ setup(
     extras_require={  # Optional
         'dev': ['pexpect', 'pytest>=6.0', 'pytest-env',
                 'Sphinx>=5.1.1', 'sphinx-argparse', 'sphinx-autoapi',
-                'mypy>=0.931', 'typed-ast', 'black', 'isort',
+                'mypy>=0.931,<0.990', 'typed-ast', 'black', 'isort',
                 'flake8'],
     },
     # replace original install command with version that also builds


### PR DESCRIPTION
This PR Closes #1885 

mypy update 0.990 causes CI failures. Until these are fixed, we should be specifying to use less than version 0.990