### PR TITLE
Closes #1889 - MessageArgs Parameter for CommandMap Functions

### DIFF
--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -207,10 +207,9 @@ module ArgSortMsg
     /* Find the permutation that sorts multiple arrays, treating each array as a
        new level of the sorting key.
      */
-    proc coargsortMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc coargsortMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
       param pn = Reflection.getRoutineName();
       var repMsg: string;
-      var msgArgs = parseMessageArgs(payload, argSize);
       var algoName = msgArgs.getValueOf("algoName");
       var algorithm: SortingAlgorithm = defaultSortAlgorithm;
       if algoName != "" {
@@ -325,10 +324,9 @@ module ArgSortMsg
     }
     
     /* argsort takes pdarray and returns an index vector iv which sorts the array */
-    proc argsortMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc argsortMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, argSize);
         var name = msgArgs.getValueOf("name");
         var algoName = msgArgs.getValueOf("algoName");
         var algorithm: SortingAlgorithm = defaultSortAlgorithm;

--- a/src/ArraySetopsMsg.chpl
+++ b/src/ArraySetopsMsg.chpl
@@ -36,10 +36,9 @@ module ArraySetopsMsg
     :type st: borrowed SymTab
     :returns: (MsgTuple) response message
     */
-    proc intersect1dMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc intersect1dMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, argSize);
         var isUnique = msgArgs.get("assume_unique").getBoolValue();
         
         var vname = st.nextName();
@@ -91,10 +90,9 @@ module ArraySetopsMsg
     :type st: borrowed SymTab
     :returns: (MsgTuple) response message
     */
-    proc setxor1dMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc setxor1dMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, argSize);
         var isUnique = msgArgs.get("assume_unique").getBoolValue();
 
         var vname = st.nextName();
@@ -146,10 +144,9 @@ module ArraySetopsMsg
     :type st: borrowed SymTab
     :returns: (MsgTuple) response message
     */
-    proc setdiff1dMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc setdiff1dMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, argSize);
         var isUnique = msgArgs.get("assume_unique").getBoolValue();
 
         var vname = st.nextName();
@@ -201,10 +198,9 @@ module ArraySetopsMsg
     :type st: borrowed SymTab
     :returns: (MsgTuple) response message
     */
-    proc union1dMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc union1dMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
       param pn = Reflection.getRoutineName();
       var repMsg: string; // response message
-      var msgArgs = parseMessageArgs(payload, argSize);
 
       var vname = st.nextName();
 

--- a/src/BroadcastMsg.chpl
+++ b/src/BroadcastMsg.chpl
@@ -16,8 +16,7 @@ module BroadcastMsg {
    * full size of the array, optionally applying a permutation
    * to return the result in the order of the original array.
    */
-  proc broadcastMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
-    var msgArgs = parseMessageArgs(payload, argSize);
+  proc broadcastMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     const size = msgArgs.get("size").getIntValue();
     // Segments must be an int64 array
     const gs = getGenericTypedArrayEntry(msgArgs.getValueOf("segName"), st);

--- a/src/CastMsg.chpl
+++ b/src/CastMsg.chpl
@@ -13,9 +13,8 @@ module CastMsg {
   private config const logLevel = ServerConfig.logLevel;
   const castLogger = new Logger(logLevel);
 
-  proc castMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+  proc castMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     param pn = Reflection.getRoutineName();
-    var msgArgs = parseMessageArgs(payload, argSize);
     var name = msgArgs.getValueOf("name");
     var objtype = msgArgs.getValueOf("objType");
     var targetDtype = msgArgs.getValueOf("targetDtype");

--- a/src/CommandMap.chpl
+++ b/src/CommandMap.chpl
@@ -9,7 +9,7 @@ module CommandMap {
    * construct the FCF type, but there is no way to generate a
    * FCF that throws using `func()` today.
    */
-  proc akMsgSign(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+  proc akMsgSign(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     var rep = new MsgTuple("dummy-msg", MsgType.NORMAL);
     return rep;
   }
@@ -18,7 +18,7 @@ module CommandMap {
    * Just like akMsgSign, but Messages which have a binary return
    * require a different signature
    */
-  proc akBinMsgSign(cmd: string, payload: string, argSize: int, st: borrowed SymTab): bytes throws {
+  proc akBinMsgSign(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): bytes throws {
     var nb = b"\x00";
     return nb;
   }
@@ -79,11 +79,11 @@ module CommandMap {
     return cm1(0..idx_close-1) + ", " + cm2(1..cm2.size-1);
   }
 
-  proc executeCommand(cmd: string, args, argSize, st) throws {
+  proc executeCommand(cmd: string, msgArgs, st) throws {
     var repTuple: MsgTuple;
     if commandMap.contains(cmd) {
       usedModules.add(moduleMap[cmd]);
-      repTuple = commandMap.getBorrowed(cmd)(cmd, args, argSize, st);
+      repTuple = commandMap.getBorrowed(cmd)(cmd, msgArgs, st);
     } else {
       repTuple = new MsgTuple("Unrecognized command: %s".format(cmd), MsgType.ERROR);
     }

--- a/src/ConcatenateMsg.chpl
+++ b/src/ConcatenateMsg.chpl
@@ -24,10 +24,9 @@ module ConcatenateMsg
     /* Concatenate a list of arrays together
        to form one array
      */
-    proc concatenateMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab) : MsgTuple throws {
+    proc concatenateMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab) : MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string;
-        var msgArgs = parseMessageArgs(payload, argSize);
         var objtype = msgArgs.getValueOf("objType");
         var mode = msgArgs.getValueOf("mode");
         var n = msgArgs.get("nstr").getIntValue(); // number of arrays to sort

--- a/src/DataFrameIndexingMsg.chpl
+++ b/src/DataFrameIndexingMsg.chpl
@@ -93,10 +93,9 @@
         return "SegArray+%s+created %s+created %s".format(col, st.attrib(s_name), st.attrib(v_name));
     }
 
-    proc dataframeBatchIndexingMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc dataframeBatchIndexingMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, argSize);
         var jsonsize = msgArgs.get("size").getIntValue();
 
         var eleList = msgArgs.get("columns").getList(jsonsize);

--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -36,10 +36,9 @@ module EfuncMsg
       :throws: `UndefinedSymbolError(name)`
       */
 
-    proc efuncMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc efuncMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message; attributes of returned array(s) will be appended to this string
-        var msgArgs = parseMessageArgs(payload, argSize);
         var name = msgArgs.getValueOf("array");
         var efunc = msgArgs.getValueOf("func");
         var rname = st.nextName();
@@ -310,11 +309,10 @@ module EfuncMsg
     :returns: (MsgTuple)
     :throws: `UndefinedSymbolError(name)`
     */
-    proc efunc3vvMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc efunc3vvMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
         // split request into fields
-        var msgArgs = parseMessageArgs(payload, argSize);
         var rname = st.nextName();
         
         var efunc = msgArgs.getValueOf("func");
@@ -419,10 +417,9 @@ module EfuncMsg
     :returns: (MsgTuple)
     :throws: `UndefinedSymbolError(name)`
     */
-    proc efunc3vsMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc efunc3vsMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, argSize);
         var efunc = msgArgs.getValueOf("func");
         var dtype = str2dtype(msgArgs.getValueOf("dtype"));
         var rname = st.nextName();
@@ -534,10 +531,9 @@ module EfuncMsg
     :returns: (MsgTuple)
     :throws: `UndefinedSymbolError(name)`
     */
-    proc efunc3svMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc efunc3svMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, argSize);
         var efunc = msgArgs.getValueOf("func");
         var dtype = str2dtype(msgArgs.getValueOf("dtype"));
         var rname = st.nextName();
@@ -649,10 +645,9 @@ module EfuncMsg
     :returns: (MsgTuple)
     :throws: `UndefinedSymbolError(name)`
     */
-    proc efunc3ssMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc efunc3ssMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, argSize);
         var dtype = str2dtype(msgArgs.getValueOf("dtype"));
         var efunc = msgArgs.getValueOf("func");
         var rname = st.nextName();

--- a/src/EncodingMsg.chpl
+++ b/src/EncodingMsg.chpl
@@ -15,9 +15,8 @@ module EncodingMsg {
     private config const logLevel = ServerConfig.logLevel;
     const emLogger = new Logger(logLevel);
 
-    proc encodeDecodeMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc encodeDecodeMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         var repMsg: string;
-        var msgArgs = parseMessageArgs(payload, argSize);
         var encoding = msgArgs.getValueOf("encoding");
 
         var stringsObj = getSegString(msgArgs.getValueOf("obj"), st);

--- a/src/FileIO.chpl
+++ b/src/FileIO.chpl
@@ -262,8 +262,7 @@ module FileIO {
       return getFileTypeByMagic(getFirstEightBytesFromFile(filename));
     }
 
-    proc getFileTypeMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
-      var msgArgs = parseMessageArgs(payload, argSize);
+    proc getFileTypeMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
       var filename = msgArgs.getValueOf("filename");
 
       // If the filename represents a glob pattern, retrieve the locale 0 filename
@@ -298,9 +297,7 @@ module FileIO {
       }
     }
 
-    proc lsAnyMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
-      var msgArgs = parseMessageArgs(payload, argSize);
-      
+    proc lsAnyMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
       // Retrieve filename from payload
       var filename: string = msgArgs.getValueOf("filename");
       if filename.isEmpty() {
@@ -331,10 +328,10 @@ module FileIO {
 
       select getFileType(filename) {
         when FileType.HDF5 {
-          return executeCommand("lshdf", payload, argSize, st);
+          return executeCommand("lshdf", msgArgs, st);
         }
         when FileType.PARQUET {
-          return executeCommand("lspq", payload, argSize, st);
+          return executeCommand("lspq", msgArgs, st);
         } otherwise {
           var errorMsg = "Unsupported file type; Parquet and HDF5 are only supported formats";
           return new MsgTuple(errorMsg, MsgType.ERROR);
@@ -342,8 +339,7 @@ module FileIO {
       }
     }
 
-    proc readAnyMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
-      var msgArgs = parseMessageArgs(payload, argSize);
+    proc readAnyMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
       var nfiles = msgArgs.get("filename_size").getIntValue();
       var filelist: [0..#nfiles] string;
       
@@ -386,10 +382,10 @@ module FileIO {
 
       select getFileType(filenames[0]) {
         when FileType.HDF5 {
-          return executeCommand("readAllHdf", payload, argSize, st);
+          return executeCommand("readAllHdf", msgArgs, st);
         }
         when FileType.PARQUET {
-          return executeCommand("readAllParquet", payload, argSize, st);
+          return executeCommand("readAllParquet", msgArgs, st);
         } otherwise {
           var errorMsg = "Unsupported file type; Parquet and HDF5 are only supported formats";
           return new MsgTuple(errorMsg, MsgType.ERROR);

--- a/src/FlattenMsg.chpl
+++ b/src/FlattenMsg.chpl
@@ -12,8 +12,7 @@ module FlattenMsg {
   private config const logLevel = ServerConfig.logLevel;
   const fmLogger = new Logger(logLevel);
 
-  proc segFlattenMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
-    var msgArgs = parseMessageArgs(payload, argSize);
+  proc segFlattenMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     const objtype = msgArgs.getValueOf("objtype");
     const returnSegs: bool = msgArgs.get("return_segs").getBoolValue();
     const regex: bool = msgArgs.get("regex").getBoolValue();
@@ -45,10 +44,9 @@ module FlattenMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc segmentedSplitMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+  proc segmentedSplitMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    var msgArgs = parseMessageArgs(payload, argSize);
 
     const objtype = msgArgs.getValueOf("objtype");
     const name = msgArgs.getValueOf("parent_name");

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -26,12 +26,11 @@ module GenSymIO {
      * Creates a pdarray server-side and returns the SymTab name used to
      * retrieve the pdarray from the SymTab.
      */
-    proc arrayMsg(cmd: string, args: string, argSize: int, ref data: bytes, st: borrowed SymTab): MsgTuple throws {
+    proc arrayMsg(cmd: string, msgArgs: borrowed MessageArgs, ref data: bytes, st: borrowed SymTab): MsgTuple throws {
         // Set up our return items
         var msgType = MsgType.NORMAL;
         var msg:string = "";
         var rname:string = "";
-        var msgArgs = parseMessageArgs(args, argSize);
         var dtype = DType.UNDEF;
         var size:int;
         var asSegStr = false;
@@ -128,10 +127,9 @@ module GenSymIO {
      * Outputs the pdarray as a Numpy ndarray in the form of a 
      * Chapel Bytes object
      */
-    proc tondarrayMsg(cmd: string, payload: string, argSize: int, st: 
+    proc tondarrayMsg(cmd: string, msgArgs: borrowed MessageArgs, st: 
                                           borrowed SymTab): bytes throws {
         var arrayBytes: bytes;
-        var msgArgs = parseMessageArgs(payload, argSize);
         var abstractEntry = st.lookup(msgArgs.getValueOf("array"));
         if !abstractEntry.isAssignableTo(SymbolEntryType.TypedArraySymEntry) {
             var errorMsg = "Error: Unhandled SymbolEntryType %s".format(abstractEntry.entryType);

--- a/src/GroupByMsg.chpl
+++ b/src/GroupByMsg.chpl
@@ -19,9 +19,7 @@ module GroupByMsg {
     private config const logLevel = ServerConfig.logLevel;
     const gmLogger = new Logger(logLevel);
 
-    proc createGroupByMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
-        var msgArgs = parseMessageArgs(payload, argSize);
-
+    proc createGroupByMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         const assumeSorted = msgArgs.get("assumeSortedStr").getBoolValue();
         var n = msgArgs.get("nkeys").getIntValue();
         var keynames = msgArgs.get("keynames").getList(n);

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -869,9 +869,7 @@ module HDF5Msg {
         Parse and exectue tohdf message.
         Determines the type of the object to be written and calls the corresponding write functionality.
     */
-    proc tohdfMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
-        var msgArgs = parseMessageArgs(payload, argSize);
-
+    proc tohdfMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         var objType: ObjType = msgArgs.getValueOf("objType").toUpper(): ObjType; // pdarray, Strings, ArrayView
 
         select objType {
@@ -979,10 +977,8 @@ module HDF5Msg {
         return items;
     }
 
-    proc lshdfMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
-        // reqMsg: "lshdf [<json_filename>]"
+    proc lshdfMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         var repMsg: string;
-        var msgArgs = parseMessageArgs(payload, argSize);
 
         // Retrieve filename from payload
         var filename: string = msgArgs.getValueOf("filename");
@@ -1639,9 +1635,7 @@ module HDF5Msg {
     /*
         Read HDF5 files into an Arkouda Object
     */
-    proc readAllHdfMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
-        var msgArgs = parseMessageArgs(payload, argSize);
-
+    proc readAllHdfMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         var strictTypes: bool = msgArgs.get("strict_types").getBoolValue();
 
         var allowErrors: bool = msgArgs.get("allow_errors").getBoolValue(); // default is false

--- a/src/HDF5Msg_LEGACY.chpl
+++ b/src/HDF5Msg_LEGACY.chpl
@@ -1774,9 +1774,8 @@ module HDF5Msg_LEGACY {
     /**
      * Reads all datasets from 1..n HDF5 files into an Arkouda symbol table. 
      */
-    proc readAllHdfMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc readAllHdfMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         var repMsg: string;
-        var msgArgs = parseMessageArgs(payload, argSize);
         var strictTypes: bool = msgArgs.get("strict_types").getBoolValue();
 
         var allowErrors: bool = msgArgs.get("allow_errors").getBoolValue(); // default is false

--- a/src/HDF5MultiDim.chpl
+++ b/src/HDF5MultiDim.chpl
@@ -117,9 +117,8 @@ module HDF5MultiDim {
     The resulting data is always in flattened form (as expected by ArrayView)
     Adds a pdarray containing the flattened data and a pdarray containing the shape of the object to the symbol table
     */
-    proc read_hdf_multi_msg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc read_hdf_multi_msg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         // Currently always load flat as row major
-        var msgArgs = parseMessageArgs(payload, argSize);
         var filename = msgArgs.getValueOf("filename");
         var dset_name = msgArgs.getValueOf("dset");
 

--- a/src/HistogramMsg.chpl
+++ b/src/HistogramMsg.chpl
@@ -21,10 +21,9 @@ module HistogramMsg
     private config const mBound = 2**25;
 
     /* histogram takes a pdarray and returns a pdarray with the histogram in it */
-    proc histogramMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc histogramMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, argSize);
         const bins = msgArgs.get("bins").getIntValue();
         const name = msgArgs.getValueOf("array");
         

--- a/src/In1dMsg.chpl
+++ b/src/In1dMsg.chpl
@@ -24,10 +24,9 @@ module In1dMsg
        which implementation
        of in1d to utilize.
     */
-    proc in1dMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc in1dMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, argSize);
         var invert: bool = msgArgs.get("invert").getBoolValue();
 
         // get next symbol name

--- a/src/JoinEqWithDTMsg.chpl
+++ b/src/JoinEqWithDTMsg.chpl
@@ -223,10 +223,9 @@ module JoinEqWithDTMsg
        pred: is the dt-predicate ("absDT","posDT","trueDT")
        resLimit: is how many answers can you tolerate ;-)
     */
-    proc joinEqWithDTMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc joinEqWithDTMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, argSize);
         const dt = msgArgs.get("dt").getIntValue();
         const pred = msgArgs.get("pred").getIntValue();
         const resLimit = msgArgs.get("resLimit").getIntValue();

--- a/src/KExtremeMsg.chpl
+++ b/src/KExtremeMsg.chpl
@@ -34,10 +34,9 @@ module KExtremeMsg
     :type st: borrowed SymTab
     :returns: (MsgTuple) response message
     */
-    proc minkMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc minkMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, argSize);
 
         var vname = st.nextName();
 
@@ -97,10 +96,9 @@ module KExtremeMsg
     :type st: borrowed SymTab
     :returns: (MsgTuple) response message
     */
-    proc maxkMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc maxkMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, argSize);
 
         var vname = st.nextName();
         var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(msgArgs.getValueOf("array"), st);

--- a/src/Message.chpl
+++ b/src/Message.chpl
@@ -371,8 +371,8 @@ module Message {
     */
     proc parseMessageArgs(json_str: string, size: int) throws {
         var pArr = jsonToPdArray(json_str, size);
-        var param_list: list(ParameterObj) = new list(ParameterObj);
-        for (i, j_str) in zip(0..#size, pArr) {
+        var param_list = new list(ParameterObj, parSafe=true);
+        forall j_str in pArr with (ref param_list) {
             param_list.append(parseParameter(j_str));
         }
         return new owned MessageArgs(param_list);

--- a/src/Message.chpl
+++ b/src/Message.chpl
@@ -255,9 +255,15 @@ module Message {
     :size: int - number of parameters contained in list
     */
     class MessageArgs {
-        var param_list;
+        var param_list: list(ParameterObj);
         var size: int;
-        proc init(param_list: [?aD] ?t) {
+
+        proc init() {
+            this.param_list = new list(ParameterObj);
+            this.size = 0;
+        }
+
+        proc init(param_list: list(ParameterObj)) {
             this.param_list = param_list;
             this.size = param_list.size;
         }
@@ -365,11 +371,13 @@ module Message {
     */
     proc parseMessageArgs(json_str: string, size: int) throws {
         var pArr = jsonToPdArray(json_str, size);
-        var paramArr: [0..#size] ParameterObj;
-        forall (i, j_str) in zip(0..#size, pArr) {
-            paramArr[i] = parseParameter(j_str);
+        // var paramArr: [0..#size] ParameterObj;
+        var param_list: list(ParameterObj) = new list(ParameterObj);
+        for (i, j_str) in zip(0..#size, pArr) {
+            // paramArr[i] = parseParameter(j_str);
+            param_list.append(parseParameter(j_str));
         }
-        return new MessageArgs(paramArr);
+        return new owned MessageArgs(param_list);
     }
 
     /*

--- a/src/Message.chpl
+++ b/src/Message.chpl
@@ -371,10 +371,8 @@ module Message {
     */
     proc parseMessageArgs(json_str: string, size: int) throws {
         var pArr = jsonToPdArray(json_str, size);
-        // var paramArr: [0..#size] ParameterObj;
         var param_list: list(ParameterObj) = new list(ParameterObj);
         for (i, j_str) in zip(0..#size, pArr) {
-            // paramArr[i] = parseParameter(j_str);
             param_list.append(parseParameter(j_str));
         }
         return new owned MessageArgs(param_list);

--- a/src/MetricsMsg.chpl
+++ b/src/MetricsMsg.chpl
@@ -408,8 +408,7 @@ module MetricsMsg {
         }
     }
 
-    proc metricsMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {    
-        var msgArgs = parseMessageArgs(payload, argSize);   
+    proc metricsMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         var category = msgArgs.getValueOf("category"):MetricCategory;
             
         mLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),

--- a/src/MsgProcessing.chpl
+++ b/src/MsgProcessing.chpl
@@ -30,10 +30,9 @@ module MsgProcessing
 
     :returns: (MsgTuple) response message
     */
-    proc createMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc createMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         var repMsg: string; // response message
         // split request into fields
-        var msgArgs = parseMessageArgs(payload, argSize);
         var dtype = str2dtype(msgArgs.getValueOf("dtype"));
         var size = msgArgs.get("size").getIntValue();
         if (dtype == DType.UInt8) || (dtype == DType.Bool) {
@@ -70,10 +69,8 @@ module MsgProcessing
 
     :returns: MsgTuple
     */
-    proc deleteMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc deleteMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         var repMsg: string; // response message
-        // split request into fields
-        var msgArgs = parseMessageArgs(payload, argSize);
         const name = msgArgs.getValueOf("name");
         mpLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
                                      "cmd: %s array: %s".format(cmd,st.attrib(name)));
@@ -99,7 +96,7 @@ module MsgProcessing
 
     :returns: MsgTuple
      */
-    proc clearMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc clearMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         var repMsg: string; // response message
         mpLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "cmd: %s".format(cmd));
         st.clear();
@@ -121,10 +118,8 @@ module MsgProcessing
 
     :returns: MsgTuple
      */
-    proc infoMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc infoMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         var repMsg: string; // response message
-        // split request into fields
-        var msgArgs = parseMessageArgs(payload, argSize);
         const name = msgArgs.getValueOf("names");
  
         // if name == "__AllSymbols__" passes back info on all symbols       
@@ -144,7 +139,7 @@ module MsgProcessing
 
     :returns: MsgTuple
      */
-    proc getconfigMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc getconfigMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         var repMsg: string; // response message
         mpLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"cmd: %s".format(cmd));
         return new MsgTuple(getConfig(), MsgType.NORMAL);
@@ -161,7 +156,7 @@ module MsgProcessing
 
     :returns: MsgTuple
      */
-    proc getmemusedMsg(cmd: string, payload: string, argSize:int, st: borrowed SymTab): MsgTuple throws {
+    proc getmemusedMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         var repMsg: string; // response message
         mpLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"cmd: %s".format(cmd));
         if (memTrack) {
@@ -190,7 +185,7 @@ module MsgProcessing
      *
      * :returns: MsgTuple containing JSON formatted string of cmd -> function mapping
      */
-    proc getCommandMapMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab) throws {
+    proc getCommandMapMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab) throws {
         // We can ignore the args, we just need it to match the CommandMap call signature
         import CommandMap;
         try {
@@ -214,9 +209,8 @@ module MsgProcessing
 
     :returns: (string,MsgType)
    */
-    proc strMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc strMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, 2);
         const name = msgArgs.getValueOf("array");
 
         var printThresh = msgArgs.get("printThresh").getIntValue();
@@ -240,9 +234,8 @@ module MsgProcessing
 
        :returns: MsgTuple
       */ 
-    proc reprMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc reprMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, argSize);
         const name = msgArgs.getValueOf("array");
         var printThresh = msgArgs.get("printThresh").getIntValue();
 
@@ -263,10 +256,9 @@ module MsgProcessing
     :returns: MsgTuple
     :throws: `UndefinedSymbolError(name)`
     */
-    proc setMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc setMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, argSize);
         const name = msgArgs.getValueOf("array");
         var dtype = str2dtype(msgArgs.getValueOf("dtype"));
         const value = msgArgs.get("val");

--- a/src/MsgProcessing.chpl
+++ b/src/MsgProcessing.chpl
@@ -32,7 +32,6 @@ module MsgProcessing
     */
     proc createMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         var repMsg: string; // response message
-        // split request into fields
         var dtype = str2dtype(msgArgs.getValueOf("dtype"));
         var size = msgArgs.get("size").getIntValue();
         if (dtype == DType.UInt8) || (dtype == DType.Bool) {

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -33,11 +33,10 @@ module OperatorMsg
       :returns: (MsgTuple) 
       :throws: `UndefinedSymbolError(name)`
     */
-    proc binopvvMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {       
+    proc binopvvMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {       
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
         
-        var msgArgs = parseMessageArgs(payload, argSize);
         const op = msgArgs.getValueOf("op");
         const aname = msgArgs.getValueOf("a");
         const bname = msgArgs.getValueOf("b");
@@ -263,11 +262,10 @@ module OperatorMsg
       :returns: (MsgTuple) 
       :throws: `UndefinedSymbolError(name)`
     */
-    proc binopvsMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc binopvsMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string = ""; // response message
 
-        var msgArgs = parseMessageArgs(payload, argSize);
         const aname = msgArgs.getValueOf("a");
         const op = msgArgs.getValueOf("op");
         const value = msgArgs.get("value");
@@ -481,11 +479,10 @@ module OperatorMsg
       :returns: (MsgTuple) 
       :throws: `UndefinedSymbolError(name)`
     */
-    proc binopsvMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc binopsvMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string = ""; // response message
 
-        var msgArgs = parseMessageArgs(payload, argSize);
         const op = msgArgs.getValueOf("op");
         const aname = msgArgs.getValueOf("a");
         const value = msgArgs.get("value");
@@ -705,11 +702,10 @@ module OperatorMsg
     :returns: (MsgTuple) 
     :throws: `UndefinedSymbolError(name)`
     */
-    proc opeqvvMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc opeqvvMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
 
-        var msgArgs = parseMessageArgs(payload, argSize);
         const op = msgArgs.getValueOf("op");
         const aname = msgArgs.getValueOf("a");
         const bname = msgArgs.getValueOf("b");
@@ -881,11 +877,10 @@ module OperatorMsg
     :returns: (MsgTuple)
     :throws: `UndefinedSymbolError(name)`
     */
-    proc opeqvsMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc opeqvsMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
 
-        var msgArgs = parseMessageArgs(payload, argSize);
         const op = msgArgs.getValueOf("op");
         const aname = msgArgs.getValueOf("a");
         const value = msgArgs.get("value");

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -528,9 +528,8 @@ module ParquetMsg {
     return writeDistArrayToParquet(A, filename, dsetname, dtype, ROWGROUPS, compressed, mode);
   }
 
-  proc readAllParquetMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+  proc readAllParquetMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     var repMsg: string;
-    var msgArgs = parseMessageArgs(payload, argSize);
     var strictTypes: bool = msgArgs.get("strict_types").getBoolValue();
 
     var allowErrors: bool = msgArgs.get("allow_errors").getBoolValue(); // default is false
@@ -697,8 +696,7 @@ module ParquetMsg {
     return new list(datasets.split(","));
   }
   
-  proc toparquetMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
-    var msgArgs = parseMessageArgs(payload, argSize);
+  proc toparquetMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     var mode = msgArgs.get("mode").getIntValue();
     var filename: string = msgArgs.getValueOf("prefix");
     var entry = st.lookup(msgArgs.getValueOf("values"));
@@ -771,10 +769,9 @@ module ParquetMsg {
     }
   }
 
-  proc lspqMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+  proc lspqMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     // reqMsg: "lshdf [<json_filename>]"
     var repMsg: string;
-    var msgArgs = parseMessageArgs(payload, argSize);
 
     // Retrieve filename from payload
     var filename: string = msgArgs.getValueOf("filename");
@@ -829,9 +826,8 @@ module ParquetMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc nullIndicesMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+  proc nullIndicesMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     var repMsg: string;
-    var msgArgs = parseMessageArgs(payload, argSize);
 
     var ndsets = msgArgs.get("dset_size").getIntValue();
     var nfiles = msgArgs.get("filename_size").getIntValue();

--- a/src/RandMsg.chpl
+++ b/src/RandMsg.chpl
@@ -23,11 +23,10 @@ module RandMsg
 
     :arg reqMsg: message to process (contains cmd,aMin,aMax,len,dtype)
     */
-    proc randintMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc randintMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string; // response message
         
-        var msgArgs = parseMessageArgs(payload, argSize);
         const len = msgArgs.get("size").getIntValue();
         const dtype = str2dtype(msgArgs.getValueOf("dtype"));
         const seed = msgArgs.getValueOf("seed");
@@ -122,9 +121,8 @@ module RandMsg
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 
-    proc randomNormalMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc randomNormalMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         var pn = Reflection.getRoutineName();
-        var msgArgs = parseMessageArgs(payload, argSize);
         const len = msgArgs.get("size").getIntValue();
         // Result + 2 scratch arrays
         overMemLimit(3*8*len);

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -27,10 +27,9 @@ module ReductionMsg
     // these functions take an array and produce a scalar
     // parse and respond to reduction message
     // scalar = reductionop(vector)
-    proc reductionMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc reductionMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string = ""; // response message
-        var msgArgs = parseMessageArgs(payload, argSize);
         const reductionop = msgArgs.getValueOf("op");
         const name = msgArgs.getValueOf("array");
         rmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
@@ -267,11 +266,10 @@ module ReductionMsg
         return new MsgTuple(repMsg, MsgType.NORMAL);          
     }
 
-    proc countReductionMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc countReductionMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
       // reqMsg: segmentedReduction values segments operator
       // 'segments_name' describes the segment offsets
-      var msgArgs = parseMessageArgs(payload, argSize);
       const segments_name = msgArgs.getValueOf("segments");
       const size = msgArgs.get("size").getIntValue();
       var rname = st.nextName();
@@ -332,13 +330,12 @@ module ReductionMsg
       return nancounts;
     }
     
-    proc segmentedReductionMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc segmentedReductionMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         // reqMsg: segmentedReduction values segments operator
         // 'values_name' is the segmented array of values to be reduced
         // 'segments_name' is the sement offsets
         // 'op' is the reduction operator
-        var msgArgs = parseMessageArgs(payload, argSize);
         const skipNan = msgArgs.get("skip_nan").getBoolValue();
         const values_name = msgArgs.getValueOf("values");
         const segments_name = msgArgs.getValueOf("segments");

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -21,8 +21,7 @@ module SegmentedMsg {
   /**
   * Build a Segmented Array object based on the segments/values specified.
   **/
-  proc assembleSegArrayMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
-    var msgArgs = parseMessageArgs(payload, argSize);
+  proc assembleSegArrayMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     var segName = msgArgs.getValueOf("segments");
     var valName = msgArgs.getValueOf("values"); 
     smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
@@ -76,9 +75,8 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc getSANonEmptyMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+  proc getSANonEmptyMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     var repMsg: string = "";
-    var msgArgs = parseMessageArgs(payload, argSize);
     var name = msgArgs.getValueOf("name"): string;
     var entry = st.tab.getBorrowed(name);
     var genEntry: GenSymEntry = toGenSymEntry(entry);
@@ -129,8 +127,7 @@ module SegmentedMsg {
    * we'll either encapsulate both parts in a single message or do the
    * parsing and offsets construction on the server.
   */
-  proc assembleStringsMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
-    var msgArgs = parseMessageArgs(payload, argSize);
+  proc assembleStringsMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     const offsetsName = msgArgs.getValueOf("offsets");
     const valuesName = msgArgs.getValueOf("values");
     smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
@@ -152,8 +149,7 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc segStrTondarrayMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): bytes throws {
-      var msgArgs = parseMessageArgs(payload, argSize);
+  proc segStrTondarrayMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): bytes throws {
       var entry = getSegString(msgArgs.getValueOf("obj"), st);
       const comp = msgArgs.getValueOf("comp");
       if comp == "offsets" {
@@ -199,9 +195,8 @@ module SegmentedMsg {
        return arrayBytes;
     }
 
-  proc randomStringsMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+  proc randomStringsMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
       var pn = Reflection.getRoutineName();
-      var msgArgs = parseMessageArgs(payload, argSize);
       const dist = msgArgs.getValueOf("dist");
       const len = msgArgs.get("size").getIntValue();
       const charset = str2CharSet(msgArgs.getValueOf("chars"));
@@ -237,10 +232,9 @@ module SegmentedMsg {
       return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc segmentLengthsMsg(cmd: string, payload: string, argSize: int,
+  proc segmentLengthsMsg(cmd: string, msgArgs: borrowed MessageArgs,
                                           st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
-    var msgArgs = parseMessageArgs(payload, argSize);
     const objtype = msgArgs.getValueOf("objType");
     const name = msgArgs.getValueOf("obj");
 
@@ -271,10 +265,9 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc caseChangeMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+  proc caseChangeMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    var msgArgs = parseMessageArgs(payload, argSize);
     const subcmd = msgArgs.getValueOf("subcmd");
     const objtype = msgArgs.getValueOf("objType");
     const name = msgArgs.getValueOf("obj");
@@ -322,10 +315,9 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc checkCharsMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+  proc checkCharsMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    var msgArgs = parseMessageArgs(payload, argSize);
     const subcmd = msgArgs.getValueOf("subcmd");
     const objtype = msgArgs.getValueOf("objType");
     const name = msgArgs.getValueOf("obj");
@@ -370,10 +362,9 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc segmentedSearchMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+  proc segmentedSearchMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
       var pn = Reflection.getRoutineName();
       var repMsg: string;
-      var msgArgs = parseMessageArgs(payload, argSize);
       const objtype = msgArgs.getValueOf("objType");
       const name = msgArgs.getValueOf("obj");
       const valtype = msgArgs.getValueOf("valType");
@@ -418,10 +409,9 @@ module SegmentedMsg {
     }
   }
 
-  proc segmentedFindLocMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+  proc segmentedFindLocMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    var msgArgs = parseMessageArgs(payload, argSize);
     const objtype = msgArgs.getValueOf("objType");
     const name = msgArgs.getValueOf("parent_name");
     const groupNum = msgArgs.get("groupNum").getIntValue();
@@ -480,10 +470,9 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc segmentedFindAllMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+  proc segmentedFindAllMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    var msgArgs = parseMessageArgs(payload, argSize);
     const objtype = msgArgs.getValueOf("objType");
     const name = msgArgs.getValueOf("parent_name");
     const numMatchesName = msgArgs.getValueOf("num_matches");
@@ -548,10 +537,9 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc segmentedSubMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+  proc segmentedSubMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    var msgArgs = parseMessageArgs(payload, argSize);
     const objtype = msgArgs.getValueOf("objType");
     const name = msgArgs.getValueOf("obj");
     const repl = msgArgs.getValueOf("repl");
@@ -587,11 +575,10 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc segmentedStripMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+  proc segmentedStripMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
 
-    var msgArgs = parseMessageArgs(payload, argSize);
     var objtype = msgArgs.getValueOf("objType");
     var name = msgArgs.getValueOf("name");
 
@@ -620,10 +607,9 @@ module SegmentedMsg {
     return (leftEntry.name, rightEntry.name);
   }
 
-  proc segmentedPeelMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+  proc segmentedPeelMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    var msgArgs = parseMessageArgs(payload, argSize);
     const subcmd = msgArgs.getValueOf("subcmd");
     const objtype = msgArgs.getValueOf("objType");
     const name = msgArgs.getValueOf("obj");
@@ -717,10 +703,9 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc segmentedHashMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+  proc segmentedHashMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    var msgArgs = parseMessageArgs(payload, argSize);
     const objtype = msgArgs.getValueOf("objType");
     const name = msgArgs.getValueOf("obj");
 
@@ -761,12 +746,11 @@ module SegmentedMsg {
    * 2. sliceIndex : segSliceIndex
    * 3. pdarrayIndex : segPdarrayIndex
   */ 
-  proc segmentedIndexMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+  proc segmentedIndexMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
     // 'subcmd' is the type of indexing to perform
     // 'objtype' is the type of segmented array
-    var msgArgs = parseMessageArgs(payload, argSize);
     const subcmd = msgArgs.getValueOf("subcmd");
     const objtype = msgArgs.getValueOf("objType");
     const name = msgArgs.getValueOf("obj");
@@ -1167,11 +1151,10 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc segBinopvvMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+  proc segBinopvvMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
 
-    var msgArgs = parseMessageArgs(payload, argSize);
     const op = msgArgs.getValueOf("op");
     const ltype = msgArgs.getValueOf("objType");
     const leftName = msgArgs.getValueOf("obj");
@@ -1231,10 +1214,9 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc segBinopvsMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+  proc segBinopvsMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
       var pn = Reflection.getRoutineName();
       var repMsg: string;
-      var msgArgs = parseMessageArgs(payload, argSize);
       const op = msgArgs.getValueOf("op");
       const objtype = msgArgs.getValueOf("objType");
       const name = msgArgs.getValueOf("obj");
@@ -1277,10 +1259,9 @@ module SegmentedMsg {
       return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc segIn1dMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+  proc segIn1dMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
       var pn = Reflection.getRoutineName();
       var repMsg: string;
-      var msgArgs = parseMessageArgs(payload, argSize);
       const mainObjtype = msgArgs.getValueOf("objType");
       const mainName = msgArgs.getValueOf("obj");
       const testObjtype = msgArgs.getValueOf("otherType");
@@ -1312,9 +1293,8 @@ module SegmentedMsg {
       return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc segGroupMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+  proc segGroupMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
       var pn = Reflection.getRoutineName();
-      var msgArgs = parseMessageArgs(payload, argSize);
       const objtype = msgArgs.getValueOf("objType");
       const name = msgArgs.getValueOf("obj");
 
@@ -1340,8 +1320,7 @@ module SegmentedMsg {
       return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc stringsToJSONMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
-    var msgArgs = parseMessageArgs(payload, argSize);
+  proc stringsToJSONMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     var strings = getSegString(msgArgs.getValueOf("name"), st);
     var size = strings.size;
     var rtn: [0..#size] string;
@@ -1354,11 +1333,10 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc segmentedSubstringMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+  proc segmentedSubstringMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
 
-    var msgArgs = parseMessageArgs(payload, argSize);
     var objtype = msgArgs.getValueOf("objType");
     var name = msgArgs.getValueOf("name");
     

--- a/src/SequenceMsg.chpl
+++ b/src/SequenceMsg.chpl
@@ -22,9 +22,8 @@ module SequenceMsg {
 
     :returns: MsgTuple
     */
-    proc arangeMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc arangeMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, argSize);
         var start = msgArgs.get("start").getIntValue();
         var stop = msgArgs.get("stop").getIntValue();
         var stride = msgArgs.get("stride").getIntValue();
@@ -69,9 +68,8 @@ module SequenceMsg {
 
     :returns: MsgTuple
     */
-    proc linspaceMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc linspaceMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         var repMsg: string; // response message
-        var msgArgs = parseMessageArgs(payload, argSize);
         var start = msgArgs.get("start").getRealValue();
         var stop = msgArgs.get("stop").getRealValue();
         var len = msgArgs.get("len").getIntValue();

--- a/src/SortMsg.chpl
+++ b/src/SortMsg.chpl
@@ -27,10 +27,9 @@ module SortMsg
     }
 
     /* sort takes pdarray and returns a sorted copy of the array */
-    proc sortMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc sortMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
       param pn = Reflection.getRoutineName();
       var repMsg: string; // response message
-      var msgArgs = parseMessageArgs(payload, argSize);
       const algoName = msgArgs.getValueOf("alg");
       const name = msgArgs.getValueOf("array");
       var algorithm: SortingAlgorithm = defaultSortAlgorithm;

--- a/src/StatsMsg.chpl
+++ b/src/StatsMsg.chpl
@@ -15,12 +15,11 @@ module StatsMsg {
     private config const logLevel = ServerConfig.logLevel;
     const sLogger = new Logger(logLevel);
 
-    proc meanMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc meanMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string;
-        var args = parseMessageArgs(payload, argSize);
 
-        var x: borrowed GenSymEntry = getGenericTypedArrayEntry(args.getValueOf("x"), st);
+        var x: borrowed GenSymEntry = getGenericTypedArrayEntry(msgArgs.getValueOf("x"), st);
 
         select (x.dtype) {
             when (DType.Int64) {
@@ -45,13 +44,12 @@ module StatsMsg {
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 
-    proc varMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc varMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string;
-        var args = parseMessageArgs(payload, argSize);
 
-        var ddof = args.get("ddof").getIntValue();
-        var x: borrowed GenSymEntry = getGenericTypedArrayEntry(args.getValueOf("x"), st);
+        var ddof = msgArgs.get("ddof").getIntValue();
+        var x: borrowed GenSymEntry = getGenericTypedArrayEntry(msgArgs.getValueOf("x"), st);
 
         select (x.dtype) {
             when (DType.Int64) {
@@ -76,13 +74,12 @@ module StatsMsg {
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 
-    proc stdMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc stdMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string;
-        var args = parseMessageArgs(payload, argSize);
 
-        var ddof = args.get("ddof").getIntValue();
-        var x: borrowed GenSymEntry = getGenericTypedArrayEntry(args.getValueOf("x"), st);
+        var ddof = msgArgs.get("ddof").getIntValue();
+        var x: borrowed GenSymEntry = getGenericTypedArrayEntry(msgArgs.getValueOf("x"), st);
 
         select (x.dtype) {
             when (DType.Int64) {
@@ -107,13 +104,12 @@ module StatsMsg {
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 
-    proc covMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc covMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string;
-        var args = parseMessageArgs(payload, argSize);
 
-        var x: borrowed GenSymEntry = getGenericTypedArrayEntry(args.getValueOf("x"), st);
-        var y: borrowed GenSymEntry = getGenericTypedArrayEntry(args.getValueOf("y"), st);
+        var x: borrowed GenSymEntry = getGenericTypedArrayEntry(msgArgs.getValueOf("x"), st);
+        var y: borrowed GenSymEntry = getGenericTypedArrayEntry(msgArgs.getValueOf("y"), st);
 
         select (x.dtype, y.dtype) {
             when (DType.Int64, DType.Int64) {
@@ -206,12 +202,11 @@ module StatsMsg {
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 
-    proc corrMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc corrMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
-        var args = parseMessageArgs(payload, argSize);
 
-        var x: borrowed GenSymEntry = getGenericTypedArrayEntry(args.getValueOf("x"), st);
-        var y: borrowed GenSymEntry = getGenericTypedArrayEntry(args.getValueOf("y"), st);
+        var x: borrowed GenSymEntry = getGenericTypedArrayEntry(msgArgs.getValueOf("x"), st);
+        var y: borrowed GenSymEntry = getGenericTypedArrayEntry(msgArgs.getValueOf("y"), st);
 
         var repMsg: string = "float64 %.17r".format(corrHelper(x, y));
         sLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
@@ -277,13 +272,12 @@ module StatsMsg {
         }
     }
 
-    proc corrMatrixMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
+    proc corrMatrixMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
-        var args = parseMessageArgs(payload, argSize);
 
-        var size = args.get("size").getIntValue();
-        var columns = args.get("columns").getList(size);
-        var dataNames = args.get("data_names").getList(size);
+        var size = msgArgs.get("size").getIntValue();
+        var columns = msgArgs.get("columns").getList(size);
+        var dataNames = msgArgs.get("data_names").getList(size);
 
         var corrDict = new map(keyType=string, valType=string);
         for (col, d1, i) in zip(columns, dataNames, 0..) {

--- a/src/TimeClassMsg.chpl
+++ b/src/TimeClassMsg.chpl
@@ -38,8 +38,8 @@ module TimeClassMsg {
 
     const UNITS = ["nanosecond", "microsecond", "millisecond", "second", "minute", "hour", "day"];
 
-    proc dateTimeAttributesMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
-        var values: borrowed GenSymEntry = getGenericTypedArrayEntry(parseMessageArgs(payload, argSize).getValueOf("values"), st);
+    proc dateTimeAttributesMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        var values: borrowed GenSymEntry = getGenericTypedArrayEntry(msgArgs.getValueOf("values"), st);
         var valuesEntry = toSymEntry(values, int);
         var attributesDict = simpleAttributesHelper(valuesEntry.a, st);
 
@@ -90,8 +90,8 @@ module TimeClassMsg {
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 
-    proc timeDeltaAttributesMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
-        var values: borrowed GenSymEntry = getGenericTypedArrayEntry(parseMessageArgs(payload, argSize).getValueOf("values"), st);
+    proc timeDeltaAttributesMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        var values: borrowed GenSymEntry = getGenericTypedArrayEntry(msgArgs.getValueOf("values"), st);
         var repMsg: string = "%jt".format(simpleAttributesHelper(toSymEntry(values, int).a, st));
 
         tLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -33,8 +33,7 @@ module UniqueMsg
     private config const logLevel = ServerConfig.logLevel;
     const umLogger = new Logger(logLevel);
 
-    proc uniqueMsg(cmd: string, payload: string, argSize: int, st: borrowed SymTab): MsgTuple throws {
-        var msgArgs = parseMessageArgs(payload, argSize);
+    proc uniqueMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         // flag to return segments and permutation for GroupBy
         const returnGroups = msgArgs.get("returnGroupStr").getBoolValue();
         const assumeSorted = msgArgs.get("assumeSortedStr").getBoolValue();


### PR DESCRIPTION
Closes #1889 

Updates CommandMap function to take `msgArgs: borrowed MessageArgs` as a parameter in place of `payload: string, argSize: int`. This prevents the need to call `var msgArgs = parseMessageArgs(payload, argSize)` in each function. 

Adds the necessary processing to pass `msgArgs` to each function.