### PR TITLE
Closes #1722 - `unregister_by_name` added to SegArray

### DIFF
--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -241,7 +241,7 @@ class SegArray:
         values = create_pdarray(parts[2])
         lengths = create_pdarray(parts[3])
 
-        return cls.from_parts(segments, values, lengths=lengths)\
+        return cls.from_parts(segments, values, lengths=lengths)
 
     @classmethod
     def from_multi_array(cls, m):

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -97,8 +97,7 @@ class SegArray:
     def __init__(
         self, name, dtype, size, ndim, shape, itemsize, segments, values, lengths=None, grouping=None
     ):
-        self.name = None
-        self.serverName = name
+        self.name = name
         self.dtype = dtype
         self.size = size
         self.ndim = ndim
@@ -241,13 +240,8 @@ class SegArray:
         segments = create_pdarray(parts[1])
         values = create_pdarray(parts[2])
         lengths = create_pdarray(parts[3])
-        namePart = parts[1].split(" ")[1]
-        name = namePart[: namePart.index("_segments")]
 
-        segarr = cls.from_parts(segments, values, lengths=lengths)
-        segarr.name = name
-
-        return segarr
+        return cls.from_parts(segments, values, lengths=lengths)\
 
     @classmethod
     def from_multi_array(cls, m):
@@ -296,7 +290,7 @@ class SegArray:
             rep_msg = generic_msg(
                 cmd="segArr-getLengths",
                 args={
-                    "name": self.serverName,
+                    "name": self.name,
                 },
             )
             self._lengths = create_pdarray(rep_msg)
@@ -306,7 +300,7 @@ class SegArray:
         rep_msg = generic_msg(
             cmd="segArr-getNonEmpty",
             args={
-                "name": self.serverName,
+                "name": self.name,
             },
         )
         parts = rep_msg.split("+")
@@ -431,7 +425,7 @@ class SegArray:
                         "subcmd": "intIndex",
                         "objType": self.objtype,
                         "dtype": self.dtype,
-                        "obj": self.serverName,
+                        "obj": self.name,
                         "key": i,
                     },
                 )
@@ -446,7 +440,7 @@ class SegArray:
                 args={
                     "subcmd": "sliceIndex",
                     "objType": self.objtype,
-                    "obj": self.serverName,
+                    "obj": self.name,
                     "dtype": self.dtype,
                     "key": [start, stop, stride],
                 },
@@ -464,7 +458,7 @@ class SegArray:
                     "subcmd": "pdarrayIndex",
                     "objType": self.objtype,
                     "dtype": self.values.dtype,
-                    "obj": self.serverName,
+                    "obj": self.name,
                     "key": i,
                 },
             )
@@ -1339,14 +1333,11 @@ class SegArray:
         if len(set((segment_suffix, value_suffix, length_suffix, grouping_suffix))) != 4:
             raise ValueError("Suffixes must all be different")
         # TODO - add grouping attaching grouping=ak.GroupBy.attach(name+grouping_suffix)
-        segarr = cls.from_parts(
+        return cls.from_parts(
             attach_pdarray(name + segment_suffix),
             attach_pdarray(name + value_suffix),
             lengths=attach_pdarray(name + length_suffix),
         )
-
-        segarr.name = name
-        return segarr
 
     def is_registered(self) -> bool:
         """

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -1299,14 +1299,15 @@ class SegArray:
         self.segments.register(name + segment_suffix)
         self.values.register(name + value_suffix)
         self.lengths.register(name + length_suffix)
-        self.name = name
         # TODO - groupby does not have register.
         # self.grouping.register(name+grouping_suffix)
 
     def unregister(self):
-        SegArray.unregister_segarray_by_name(self.name)
-
-        self.name = None
+        self.segments.unregister()
+        self.values.unregister()
+        self.lengths.unregister()
+        # TODO - groupby does not have unregister.
+        # self.grouping.unregister()
 
     @staticmethod
     def unregister_segarray_by_name(name):

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -97,7 +97,8 @@ class SegArray:
     def __init__(
         self, name, dtype, size, ndim, shape, itemsize, segments, values, lengths=None, grouping=None
     ):
-        self.name = name
+        self.name = None
+        self.serverName = name
         self.dtype = dtype
         self.size = size
         self.ndim = ndim
@@ -295,7 +296,7 @@ class SegArray:
             rep_msg = generic_msg(
                 cmd="segArr-getLengths",
                 args={
-                    "name": self.name,
+                    "name": self.serverName,
                 },
             )
             self._lengths = create_pdarray(rep_msg)
@@ -305,7 +306,7 @@ class SegArray:
         rep_msg = generic_msg(
             cmd="segArr-getNonEmpty",
             args={
-                "name": self.name,
+                "name": self.serverName,
             },
         )
         parts = rep_msg.split("+")
@@ -430,7 +431,7 @@ class SegArray:
                         "subcmd": "intIndex",
                         "objType": self.objtype,
                         "dtype": self.dtype,
-                        "obj": self.name,
+                        "obj": self.serverName,
                         "key": i,
                     },
                 )
@@ -445,7 +446,7 @@ class SegArray:
                 args={
                     "subcmd": "sliceIndex",
                     "objType": self.objtype,
-                    "obj": self.name,
+                    "obj": self.serverName,
                     "dtype": self.dtype,
                     "key": [start, stop, stride],
                 },
@@ -463,7 +464,7 @@ class SegArray:
                     "subcmd": "pdarrayIndex",
                     "objType": self.objtype,
                     "dtype": self.values.dtype,
-                    "obj": self.name,
+                    "obj": self.serverName,
                     "key": i,
                 },
             )

--- a/tests/segarray_test.py
+++ b/tests/segarray_test.py
@@ -614,3 +614,21 @@ class SegArrayTest(ArkoudaTest):
         self.assertFalse(segarr.is_registered())
 
         self.assertEqual(len(ak.list_registry()), 0)
+
+    def test_unregister_by_name(self):
+        a = [1, 2, 3]
+        b = [6, 7, 8]
+
+        segarr = ak.segarray(ak.array([0, len(a)]), ak.array(a + b))
+        # register the seg array
+        segarr.register("segarr_unreg_name_test")
+
+        # Verify is_registered
+        self.assertTrue(segarr.is_registered())
+
+        # Unregister all components
+        ak.SegArray.unregister_segarray_by_name("segarr_unreg_name_test")
+
+        # Verify no registered components remain
+        self.assertFalse(segarr.is_registered())
+        self.assertEqual(len(ak.list_registry()), 0)


### PR DESCRIPTION
This PR Closes #1722 

Due to the way registration is done within segarray, the best solution for the current state is to implement the `unregister_by_name` functionality and call that instead of calling `segarray.unregister()`. Also due to the registration of segarray, an additional property `serverName` was added to maintain the connection between the `segarray` object and the server-generated name used to access it.

Issue #1894 was created to address this