### PR TITLE
Part of #1901: Replace `SymEntry.Ad` with `SymEntry.a.domain`

### DIFF
--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -126,7 +126,7 @@ module ArgSortMsg
           when DType.Int64 {
               var e = toSymEntry(g, int);
               // Permute the keys array with the initial iv
-              var newa: [e.aD] int;
+              var newa: [e.a.domain] int;
               ref olda = e.a;
               // Effectively: newa = olda[iv]
               forall (newai, idx) in zip(newa, iv) with (var agg = newSrcAggregator(int)) {
@@ -138,7 +138,7 @@ module ArgSortMsg
           when DType.UInt64 {
               var e = toSymEntry(g, uint);
               // Permute the keys array with the initial iv
-              var newa: [e.aD] uint;
+              var newa: [e.a.domain] uint;
               ref olda = e.a;
               // Effectively: newa = olda[iv]
               forall (newai, idx) in zip(newa, iv) with (var agg = newSrcAggregator(uint)) {
@@ -149,7 +149,7 @@ module ArgSortMsg
           }
           when DType.Float64 {
               var e = toSymEntry(g, real);
-              var newa: [e.aD] real;
+              var newa: [e.a.domain] real;
               ref olda = e.a;
               forall (newai, idx) in zip(newa, iv) with (var agg = newSrcAggregator(real)) {
                   agg.copy(newai, olda[idx]);

--- a/src/Cast.chpl
+++ b/src/Cast.chpl
@@ -35,7 +35,7 @@ module Cast {
     const before = toSymEntry(gse, fromType);
     const oname = st.nextName();
     var segments = st.addEntry(oname, before.size, int);
-    var strings: [before.aD] string;
+    var strings: [before.a.domain] string;
     if fromType == real {
       try {
           forall (s, v) in zip(strings, before.a) {
@@ -138,7 +138,7 @@ module Cast {
           entry.a = computeOnSegments(oa, va, SegFunction.StringToNumericIgnore, toType);
         }
         when ErrorMode.return_validity {
-          var valWithFlag: [entry.aD] (toType, bool) = computeOnSegments(oa, va, SegFunction.StringToNumericReturnValidity, (toType, bool));
+          var valWithFlag: [entry.a.domain] (toType, bool) = computeOnSegments(oa, va, SegFunction.StringToNumericReturnValidity, (toType, bool));
           const vname = st.nextName();
           var valid = st.addEntry(vname, s.size, bool);
           forall (n, v, vf) in zip(entry.a, valid.a, valWithFlag) {

--- a/src/ConcatenateMsg.chpl
+++ b/src/ConcatenateMsg.chpl
@@ -112,17 +112,17 @@ module ConcatenateMsg
                   if (objtype == "str") && (mynumsegs > 0) {
                     const stringEntry = toSegStringSymEntry(abstractEntry);
                     const e = stringEntry.offsetsEntry;
-                    const firstSeg = e.a[e.aD.localSubdomain().low];
+                    const firstSeg = e.a[e.a.domain.localSubdomain().low];
                     var mybytes: int;
                     /* If this locale contains the last segment, we cannot use the
                      * next segment offset to calculate the number of bytes for this
                      * locale, and we must instead use the total size of the values
                      * array.
                      */
-                    if (e.aD.localSubdomain().high >= e.aD.high) {
+                    if (e.a.domain.localSubdomain().high >= e.a.domain.high) {
                       mybytes = valSize - firstSeg;
                     } else {
-                      mybytes = e.a[e.aD.localSubdomain().high + 1] - firstSeg;
+                      mybytes = e.a[e.a.domain.localSubdomain().high + 1] - firstSeg;
                     }
                     blockValSizes[here.id] += mybytes;
                   }
@@ -170,24 +170,24 @@ module ConcatenateMsg
                       coforall loc in Locales {
                         on loc {
                           // Number of strings on this locale for this input array
-                          const mynsegs = thisSegs.aD.localSubdomain().size;
+                          const mynsegs = thisSegs.a.domain.localSubdomain().size;
                           // If no strings on this locale, skip to avoid out of bounds array
                           // accesses
                           if mynsegs > 0 {
-                            ref mysegs = thisSegs.a.localSlice[thisSegs.aD.localSubdomain()];
+                            ref mysegs = thisSegs.a.localSlice[thisSegs.a.domain.localSubdomain()];
                             // Segments must be rebased to start from blockValStart,
                             // which is the current pointer to this locale's chunk of
                             // the values array
-                            esegs.a[{blockstarts[here.id]..#mynsegs}] = mysegs - mysegs[thisSegs.aD.localSubdomain().low] + blockValStarts[here.id];
+                            esegs.a[{blockstarts[here.id]..#mynsegs}] = mysegs - mysegs[thisSegs.a.domain.localSubdomain().low] + blockValStarts[here.id];
                             blockstarts[here.id] += mynsegs;
-                            const firstSeg = thisSegs.a[thisSegs.aD.localSubdomain().low];
+                            const firstSeg = thisSegs.a[thisSegs.a.domain.localSubdomain().low];
                             var mybytes: int;
                             // If locale contains last string, must use overall number of bytes
                             // to compute size, instead of start of next string
-                            if (thisSegs.aD.localSubdomain().high >= thisSegs.aD.high) {
+                            if (thisSegs.a.domain.localSubdomain().high >= thisSegs.a.domain.high) {
                               mybytes = thisVals.size - firstSeg;
                             } else {
-                              mybytes = thisSegs.a[thisSegs.aD.localSubdomain().high + 1] - firstSeg;
+                              mybytes = thisSegs.a[thisSegs.a.domain.localSubdomain().high + 1] - firstSeg;
                             }
                             evals.a[{blockValStarts[here.id]..#mybytes}] = thisVals.a[firstSeg..#mybytes];
                             blockValStarts[here.id] += mybytes;
@@ -198,7 +198,7 @@ module ConcatenateMsg
                       forall (i, s) in zip(newSegs.domain, newSegs) with (var agg = newDstAggregator(int)) {
                         agg.copy(esa[i+segStart], s);
                       }
-                      forall (i, v) in zip(thisVals.aD, thisVals.a) with (var agg = newDstAggregator(uint(8))) {
+                      forall (i, v) in zip(thisVals.a.domain, thisVals.a) with (var agg = newDstAggregator(uint(8))) {
                         agg.copy(eva[i+valStart], v);
                       }
                       segStart += thisSegs.size;
@@ -227,15 +227,15 @@ module ConcatenateMsg
                             if mode == "interleave" {
                               coforall loc in Locales {
                                 on loc {
-                                  const size = o.aD.localSubdomain().size;
-                                  e.a[{blockstarts[here.id]..#size}] = o.a.localSlice[o.aD.localSubdomain()];
+                                  const size = o.a.domain.localSubdomain().size;
+                                  e.a[{blockstarts[here.id]..#size}] = o.a.localSlice[o.a.domain.localSubdomain()];
                                   blockstarts[here.id] += size;
                                 }
                               }
                             } else {
                               ref ea = e.a;
                               // copy array into concatenation array
-                              forall (i, v) in zip(o.aD, o.a) with (var agg = newDstAggregator(int)) {
+                              forall (i, v) in zip(o.a.domain, o.a) with (var agg = newDstAggregator(int)) {
                                 agg.copy(ea[start+i], v);
                               }
                               // update new start for next array copy
@@ -256,15 +256,15 @@ module ConcatenateMsg
                             if mode == "interleave" {
                               coforall loc in Locales {
                                 on loc {
-                                  const size = o.aD.localSubdomain().size;
-                                  e.a[{blockstarts[here.id]..#size}] = o.a.localSlice[o.aD.localSubdomain()];
+                                  const size = o.a.domain.localSubdomain().size;
+                                  e.a[{blockstarts[here.id]..#size}] = o.a.localSlice[o.a.domain.localSubdomain()];
                                   blockstarts[here.id] += size;
                                 }
                               }
                             } else {
                               ref ea = e.a;
                               // copy array into concatenation array
-                              forall (i, v) in zip(o.aD, o.a) with (var agg = newDstAggregator(real)) {
+                              forall (i, v) in zip(o.a.domain, o.a) with (var agg = newDstAggregator(real)) {
                                 agg.copy(ea[start+i], v);
                               }
                               // update new start for next array copy
@@ -285,15 +285,15 @@ module ConcatenateMsg
                             if mode == "interleave" {
                               coforall loc in Locales {
                                 on loc {
-                                  const size = o.aD.localSubdomain().size;
-                                  e.a[{blockstarts[here.id]..#size}] = o.a.localSlice[o.aD.localSubdomain()];
+                                  const size = o.a.domain.localSubdomain().size;
+                                  e.a[{blockstarts[here.id]..#size}] = o.a.localSlice[o.a.domain.localSubdomain()];
                                   blockstarts[here.id] += size;
                                 }
                               }
                             } else {
                               ref ea = e.a;
                               // copy array into concatenation array
-                              forall (i, v) in zip(o.aD, o.a) with (var agg = newDstAggregator(bool)) {
+                              forall (i, v) in zip(o.a.domain, o.a) with (var agg = newDstAggregator(bool)) {
                                 agg.copy(ea[start+i], v);
                               }
                               // update new start for next array copy
@@ -314,15 +314,15 @@ module ConcatenateMsg
                             if mode == "interleave" {
                               coforall loc in Locales {
                                 on loc {
-                                  const size = o.aD.localSubdomain().size;
-                                  e.a[{blockstarts[here.id]..#size}] = o.a.localSlice[o.aD.localSubdomain()];
+                                  const size = o.a.domain.localSubdomain().size;
+                                  e.a[{blockstarts[here.id]..#size}] = o.a.localSlice[o.a.domain.localSubdomain()];
                                   blockstarts[here.id] += size;
                                 }
                               }
                             } else {
                               ref ea = e.a;
                               // copy array into concatenation array
-                              forall (i, v) in zip(o.aD, o.a) with (var agg = newDstAggregator(uint)) {
+                              forall (i, v) in zip(o.a.domain, o.a) with (var agg = newDstAggregator(uint)) {
                                 agg.copy(ea[start+i], v);
                               }
                               // update new start for next array copy

--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -194,13 +194,13 @@ module EfuncMsg
                 select efunc
                 {
                     when "cumsum" {
-                        var ia: [e.aD] int = (e.a:int); // make a copy of bools as ints blah!
+                        var ia: [e.a.domain] int = (e.a:int); // make a copy of bools as ints blah!
                         // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
                         overMemLimit(numBytes(int) * ia.size);
                         st.addEntry(rname, new shared SymEntry(+ scan ia));
                     }
                     when "cumprod" {
-                        var ia: [e.aD] int = (e.a:int); // make a copy of bools as ints blah!
+                        var ia: [e.a.domain] int = (e.a:int); // make a copy of bools as ints blah!
                         // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
                         overMemLimit(numBytes(int) * ia.size);
                         st.addEntry(rname, new shared SymEntry(* scan ia));

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -81,7 +81,7 @@ module GenSymIO {
                 var g = st.lookup(rname);
                 if g.isAssignableTo(SymbolEntryType.TypedArraySymEntry){
                     var values = toSymEntry( (g:GenSymEntry), uint(8) );
-                    var offsets = segmentedCalcOffsets(values.a, values.aD);
+                    var offsets = segmentedCalcOffsets(values.a, values.a.domain);
                     var oname = st.nextName();
                     var offsetsEntry = new shared SymEntry(offsets);
                     st.addEntry(oname, offsetsEntry);

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -822,7 +822,7 @@ module HDF5Msg {
                 ref ss = segString;
                 var A = ss.offsets.a;
                 const lastOffset = A[A.domain.high];
-                const lastValIdx = ss.values.aD.high;
+                const lastValIdx = ss.values.a.domain.high;
 
                 // For each locale gather the string bytes corresponding to the offsets in its local domain
                 coforall (loc, idx) in zip(A.targetLocales(), filenames.domain) with (ref ss) do on loc {
@@ -1493,7 +1493,7 @@ module HDF5Msg {
         read_files_into_distributed_array(entryVal.a, subdoms, filenames, dset + "/" + SEGSTRING_VALUE_NAME, skips);
 
         proc _buildEntryCalcOffsets(): shared SymEntry throws {
-            var offsetsArray = segmentedCalcOffsets(entryVal.a, entryVal.aD);
+            var offsetsArray = segmentedCalcOffsets(entryVal.a, entryVal.a.domain);
             return new shared SymEntry(offsetsArray);
         }
 

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -77,7 +77,7 @@ module IndexingMsg
                 //     var indArrEntry = toSymEntry(indArr, int);
                 //     var scaledArray = indArrEntry.a * dimProdEntry.a[i/2];
                 //     // var localizedArray = new lowLevelLocalizingSlice(scaledArray, offsets[i/2]..#indArrEntry.a.size);
-                //     forall (j, s) in zip(indArrEntry.aD, scaledArray) with (var DstAgg = newDstAggregator(int)) {
+                //     forall (j, s) in zip(indArrEntry.a.domain, scaledArray) with (var DstAgg = newDstAggregator(int)) {
                 //         DstAgg.copy(scaledCoords[offsets[i/2]+j], s);
                 //     }
                 // }
@@ -360,7 +360,7 @@ module IndexingMsg
                 return new MsgTuple(errorMsg,MsgType.ERROR);
             }
             var a = st.addEntry(rname, iv.size, XType);
-            //[i in iv.aD] a.a[i] = e.a[iv.a[i]]; // bounds check iv[i] against e.aD?
+            //[i in iv.a.domain] a.a[i] = e.a[iv.a[i]]; // bounds check iv[i] against e.a.domain?
             ref a2 = e.a;
             ref iva = iv.a;
             ref aa = a.a;
@@ -396,7 +396,7 @@ module IndexingMsg
                 return new MsgTuple(errorMsg,MsgType.ERROR);
             }
             var a = st.addEntry(rname, iv.size, XType);
-            //[i in iv.aD] a.a[i] = e.a[iv.a[i]]; // bounds check iv[i] against e.aD?
+            //[i in iv.a.domain] a.a[i] = e.a[iv.a[i]]; // bounds check iv[i] against e.a.domain?
             ref a2 = e.a;
             ref iva = iv.a;
             ref aa = a.a;
@@ -421,14 +421,14 @@ module IndexingMsg
             }
             // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
             overMemLimit(numBytes(int) * truth.size);
-            var iv: [truth.aD] int = (+ scan truth.a);
+            var iv: [truth.a.domain] int = (+ scan truth.a);
             var pop = iv[iv.size-1];
             imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
                                               "pop = %t last-scan = %t".format(pop,iv[iv.size-1]));
 
             var a = st.addEntry(rname, pop, XType);
-            //[i in e.aD] if (truth.a[i] == true) {a.a[iv[i]-1] = e.a[i];}// iv[i]-1 for zero base index
-            ref ead = e.aD;
+            //[i in e.a.domain] if (truth.a[i] == true) {a.a[iv[i]-1] = e.a[i];}// iv[i]-1 for zero base index
+            const ref ead = e.a.domain;
             ref ea = e.a;
             ref trutha = truth.a;
             ref aa = a.a;
@@ -694,7 +694,7 @@ module IndexingMsg
                 value = value.replace("False","false"); // chapel to python bool
             }
             var val = try! value:dtype;
-            ref ead = e.aD;
+            const ref ead = e.a.domain;
             ref ea = e.a;
             ref trutha = truth.a;
             forall i in ead with (var agg = newDstAggregator(dtype)) {
@@ -857,7 +857,7 @@ module IndexingMsg
             var truth = toSymEntry(gIV,bool);
             // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
             overMemLimit(numBytes(int) * truth.size);
-            var iv: [truth.aD] int = (+ scan truth.a);
+            var iv: [truth.a.domain] int = (+ scan truth.a);
             var pop = iv[iv.size-1];
             imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
                                          "pop = %t last-scan = %t".format(pop,iv[iv.size-1]));
@@ -868,7 +868,7 @@ module IndexingMsg
                 return new MsgTuple(errorMsg,MsgType.ERROR);;                
             }
             ref ya = y.a;
-            ref ead = e.aD;
+            const ref ead = e.a.domain;
             ref ea = e.a;
             ref trutha = truth.a;
             forall (eai, i) in zip(ea, ead) with (var agg = newSrcAggregator(t)) {

--- a/src/Merge.chpl
+++ b/src/Merge.chpl
@@ -101,9 +101,9 @@ module Merge {
                       mLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                           "OOB: outPos = %t not in %t".format(outPos, perm.domain));
                   }
-                  if (bigPos > big.offsets.aD.high) { 
+                  if (bigPos > big.offsets.a.domain.high) { 
                       mLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                          "OOB: bigPos = %t not in %t".format(bigPos, big.offsets.aD));
+                                          "OOB: bigPos = %t not in %t".format(bigPos, big.offsets.a.domain));
                   }
                   if (outOffset + bigS.numBytes >= vals.size) { 
                       mLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
@@ -131,9 +131,9 @@ module Merge {
                     mLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                "OOB: outPos = %t not in %t".format(outPos, perm.domain));
                 }
-                if (smallPos > small.offsets.aD.high) { 
+                if (smallPos > small.offsets.a.domain.high) { 
                     mLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                               "OOB: smallPos = %t not in %t".format(smallPos, small.offsets.aD));
+                               "OOB: smallPos = %t not in %t".format(smallPos, small.offsets.a.domain));
                 }
                 if (outOffset + bigS.numBytes >= vals.size) {
                     mLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),

--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -412,8 +412,8 @@ module MultiTypeSymEntry
             this.valuesEntry = valuesSymEntry;
 
             ref sa = segmentsSymEntry.a;
-            const high = segmentsSymEntry.aD.high;
-            var lengths = [(i, s) in zip (segmentsSymEntry.aD, sa)] if i == high then valuesSymEntry.size - s else sa[i+1] - s;
+            const high = segmentsSymEntry.a.domain.high;
+            var lengths = [(i, s) in zip (segmentsSymEntry.a.domain, sa)] if i == high then valuesSymEntry.size - s else sa[i+1] - s;
             
             lengthsEntry = new shared SymEntry(lengths);
 

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -421,7 +421,7 @@ module ParquetMsg {
     
     const extraOffset = ss.values.size;
     const lastOffset = A[A.domain.high];
-    const lastValIdx = ss.values.aD.high;
+    const lastValIdx = ss.values.a.domain.high;
     // For each locale gather the string bytes corresponding to the offsets in its local domain
     coforall (loc, idx) in zip(A.targetLocales(), filenames.domain) with (ref ss) do on loc {
         const myFilename = filenames[idx];

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -51,7 +51,7 @@ module ReductionMsg
                     when "all" {
                         var val:string;
                         var sum = + reduce (e.a != 0);
-                        if sum == e.aD.size {val = "True";} else {val = "False";}
+                        if sum == e.a.domain.size {val = "True";} else {val = "False";}
                        repMsg = "bool %s".format(val);
                     }
                     when "sum" {
@@ -73,11 +73,11 @@ module ReductionMsg
                         repMsg = "int64 %i".format(val);
                     }
                     when "argmin" {
-                        var (minVal, minLoc) = minloc reduce zip(e.a,e.aD);
+                        var (minVal, minLoc) = minloc reduce zip(e.a,e.a.domain);
                         repMsg = "int64 %i".format(minLoc);
                     }
                     when "argmax" {
-                        var (maxVal, maxLoc) = maxloc reduce zip(e.a,e.aD);
+                        var (maxVal, maxLoc) = maxloc reduce zip(e.a,e.a.domain);
                         repMsg = "int64 %i".format(maxLoc);
                     }
                     when "is_sorted" {
@@ -133,11 +133,11 @@ module ReductionMsg
                         repMsg = "uint64 %i".format(val);
                     }
                     when "argmin" {
-                        var (minVal, minLoc) = minloc reduce zip(e.a,e.aD);
+                        var (minVal, minLoc) = minloc reduce zip(e.a,e.a.domain);
                         repMsg = "uint64 %i".format(minLoc);
                     }
                     when "argmax" {
-                        var (maxVal, maxLoc) = maxloc reduce zip(e.a,e.aD);
+                        var (maxVal, maxLoc) = maxloc reduce zip(e.a,e.a.domain);
                         repMsg = "uint64 %i".format(maxLoc);
                     }
                     when "is_sorted" {
@@ -167,7 +167,7 @@ module ReductionMsg
                     when "all" {
                         var val:string;
                         var sum = + reduce (e.a != 0.0);
-                        if sum == e.aD.size {val = "True";} else {val = "False";}
+                        if sum == e.a.domain.size {val = "True";} else {val = "False";}
                         repMsg = "bool %s".format(val);
                     }
                     when "sum" {
@@ -187,11 +187,11 @@ module ReductionMsg
                         repMsg = "float64 %.17r".format(val);
                     }
                     when "argmin" {
-                        var (minVal, minLoc) = minloc reduce zip(e.a,e.aD);
+                        var (minVal, minLoc) = minloc reduce zip(e.a,e.a.domain);
                         repMsg = "int64 %i".format(minLoc);
                     }
                     when "argmax" {
-                        var (maxVal, maxLoc) = maxloc reduce zip(e.a,e.aD);
+                        var (maxVal, maxLoc) = maxloc reduce zip(e.a,e.a.domain);
                         repMsg = "int64 %i".format(maxLoc);
                     }
                     when "is_sorted" {
@@ -242,11 +242,11 @@ module ReductionMsg
                         repMsg = "bool %s".format(val);
                     }
                     when "argmax" {
-                        var (maxVal, maxLoc) = maxloc reduce zip(e.a,e.aD);
+                        var (maxVal, maxLoc) = maxloc reduce zip(e.a,e.a.domain);
                         repMsg = "int64 %i".format(maxLoc);
                     }
                     when "argmin" {
-                        var (minVal, minLoc) = minloc reduce zip(e.a,e.aD);
+                        var (minVal, minLoc) = minloc reduce zip(e.a,e.a.domain);
                         repMsg = "int64 %i".format(minLoc);
                     }
                     otherwise {

--- a/src/SegStringSort.chpl
+++ b/src/SegStringSort.chpl
@@ -31,7 +31,7 @@ module SegStringSort {
     }
   }
   
-  proc twoPhaseStringSort(ss: SegString): [ss.offsets.aD] int throws {
+  proc twoPhaseStringSort(ss: SegString): [ss.offsets.a.domain] int throws {
     var t = getCurrentTime();
     const lengths = ss.getLengths();
     ssLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
@@ -44,15 +44,15 @@ module SegStringSort {
     ssLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                        "Pivot = %t, nShort = %t".format(pivot, nShort)); 
     t = getCurrentTime();
-    const longStart = ss.offsets.aD.low + nShort;
+    const longStart = ss.offsets.a.domain.low + nShort;
     const isLong = (lengths >= pivot);
-    var locs = [i in ss.offsets.aD] i;
+    var locs = [i in ss.offsets.a.domain] i;
     // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
     overMemLimit(numBytes(int) * isLong.size);
     var longLocs = + scan isLong;
     locs -= longLocs;
-    var gatherInds: [ss.offsets.aD] int;
-    forall (i, l, ll, t) in zip(ss.offsets.aD, locs, longLocs, isLong) 
+    var gatherInds: [ss.offsets.a.domain] int;
+    forall (i, l, ll, t) in zip(ss.offsets.a.domain, locs, longLocs, isLong) 
       with (var agg = newDstAggregator(int)) {
       if !t {
         agg.copy(gatherInds[l], i);
@@ -64,7 +64,7 @@ module SegStringSort {
                    "Partitioned short/long strings in %t seconds".format(getCurrentTime() - t));
     on Locales[Locales.domain.high] {
       var tl = getCurrentTime();
-      const ref highDom = {longStart..ss.offsets.aD.high};
+      const ref highDom = {longStart..ss.offsets.a.domain.high};
       ref highInds = gatherInds[highDom];
       // Get local copy of the long strings as Chapel strings, and their original indices
       var stringsWithInds = gatherLongStrings(ss, lengths, highInds);

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -65,18 +65,18 @@ module SegmentedArray {
 
         /* Retrieve one string from the array */
         proc this(idx: ?t) throws where t == int || t == uint {
-            if (idx < segments.aD.low) || (idx > segments.aD.high) {
+            if (idx < segments.a.domain.low) || (idx > segments.a.domain.high) {
                 throw new owned OutOfBoundsError();
             }
             // Start index of the segment
             var start: int = segments.a[idx:int];
             // end index
-            var end: int = if idx:int == segments.aD.high then values.size-1 else segments.a[idx:int+1]-1;
+            var end: int = if idx:int == segments.a.domain.high then values.size-1 else segments.a[idx:int+1]-1;
             return values.a[start..end];
         }
 
         proc this(const slice: range(stridable=false)) throws {
-            if (slice.low < segments.aD.low) || (slice.high > segments.aD.high) {
+            if (slice.low < segments.a.domain.low) || (slice.high > segments.a.domain.high) {
                 saLogger.error(getModuleName(),getRoutineName(),getLineNumber(),
                 "Slice is out of bounds");
                 throw new owned OutOfBoundsError();
@@ -89,7 +89,7 @@ module SegmentedArray {
             ref sa = segments.a;
             var start = sa[slice.low];
             // end index
-            var end: int = if slice.high == segments.aD.high then values.size-1 else sa[slice.high:int+1]-1;
+            var end: int = if slice.high == segments.a.domain.high then values.size-1 else sa[slice.high:int+1]-1;
 
             // Segment offsets of the new slice
             var newSegs = makeDistArray(slice.size, int);
@@ -128,7 +128,7 @@ module SegmentedArray {
                                                     "Computing lengths and offsets");
             var t1 = getCurrentTime();
             ref oa = segments.a;
-            const low = segments.aD.low, high = segments.aD.high;
+            const low = segments.a.domain.low, high = segments.a.domain.high;
 
             // Gather the right and left boundaries of the indexed strings
             // NOTE: cannot compute lengths inside forall because agg.copy will
@@ -208,7 +208,7 @@ module SegmentedArray {
         /* Logical indexing (compress) of SegArray. */
         proc this(iv: [?D] bool) throws {
             // Index vector must be same domain as array
-            if (D != segments.aD) {
+            if (D != segments.a.domain) {
                 saLogger.info(getModuleName(),getRoutineName(),getLineNumber(),
                                                                 "Array out of bounds");
                 throw new owned OutOfBoundsError();
@@ -217,7 +217,7 @@ module SegmentedArray {
                                                         "Computing lengths and offsets");
 
             ref oa = segments.a;
-            const low = segments.aD.low, high = segments.aD.high;
+            const low = segments.a.domain.low, high = segments.a.domain.high;
             // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
             overMemLimit(numBytes(int) * iv.size);
             // Calculate the destination indices

--- a/src/SequenceMsg.chpl
+++ b/src/SequenceMsg.chpl
@@ -44,7 +44,7 @@ module SequenceMsg {
 
         t1 = Time.getCurrentTime();
         ref ea = e.a;
-        ref ead = e.aD;
+        const ref ead = e.a.domain;
         forall (ei, i) in zip(ea,ead) {
             ei = start + (i * stride);
         }
@@ -89,7 +89,7 @@ module SequenceMsg {
 
         t1 = Time.getCurrentTime();
         ref ea = e.a;
-        ref ead = e.aD;
+        const ref ead = e.a.domain;
         forall (ei, i) in zip(ea,ead) {
             ei = start + (i * stride);
         }

--- a/src/TimeClassMsg.chpl
+++ b/src/TimeClassMsg.chpl
@@ -43,7 +43,7 @@ module TimeClassMsg {
         var valuesEntry = toSymEntry(values, int);
         var attributesDict = simpleAttributesHelper(valuesEntry.a, st);
 
-        const valDom = valuesEntry.aD;
+        const valDom = valuesEntry.a.domain;
         var year: [valDom] int;
         var month: [valDom] int;
         var day: [valDom] int;

--- a/src/Unique.chpl
+++ b/src/Unique.chpl
@@ -161,7 +161,7 @@ module Unique
             var inv = makeDistArray(0, int);
             return (uo, uv, c, inv);
         }
-        const aD = str.offsets.aD;
+        const ref aD = str.offsets.a.domain;
         var invD: aD.type;
         if returnInverse {
           invD = aD;
@@ -181,7 +181,7 @@ module Unique
           [(t, s, i) in zip(truth, sorted, aD)] if i > aD.low { t = (sorted[i-1] != s); }
         } else {
           var soff: [aD] int;
-          var sval: [str.values.aD] uint(8);
+          var sval: [str.values.a.domain] uint(8);
           perm = str.argsort();
           (soff, sval) = str[perm];
           truth[0] = true;

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -143,7 +143,7 @@ module UniqueMsg
 
         if assumeSorted {
           // set permutation to 0..#size and go directly to finding segment boundaries.
-          permutation.a = permutation.aD;
+          permutation.a = permutation.a.domain;
         }
         else {
           // Sort the keys

--- a/test/IOSpeedTestMsg.chpl
+++ b/test/IOSpeedTestMsg.chpl
@@ -22,8 +22,8 @@ proc parseIdFromReadAllHdfMsgCreated(msg:string, start:int = 0):string {
 proc main() {
   var st = new owned SymTab();
   var A = st.addEntry("A", size*numLocales, int);
-  A.a = A.aD;
-  const GiB = (8*A.aD.size):real / (2**30):real;
+  A.a = A.a.domain;
+  const GiB = (8*A.a.domain.size):real / (2**30):real;
 
   var d: Diags;
 

--- a/test/UnitTestArgSortMsg.chpl
+++ b/test/UnitTestArgSortMsg.chpl
@@ -85,7 +85,7 @@ prototype module UnitTestArgSort
         var coa = toSymEntry(toGenSymEntry(st.lookup(coaname)), int);
         var cof = toSymEntry(toGenSymEntry(st.lookup(cofname)), real);
         var allSorted: atomic bool = true;
-        forall (a, f, i) in zip(coa.a[1..], cof.a[1..], coa.aD.low+1..) {
+        forall (a, f, i) in zip(coa.a[1..], cof.a[1..], coa.a.domain.low+1..) {
           ref coaa = coa.a;
           ref cofa = cof.a;
           if (coaa[i-1] > a) {

--- a/test/UnitTestGroupby.chpl
+++ b/test/UnitTestGroupby.chpl
@@ -70,7 +70,7 @@ prototype module UnitTestGroupby
     
     // sort keys and return iv
     var ivname = st.nextName();
-    var iv: [keys.aD] int;
+    var iv: [keys.a.domain] int;
     var eMin = min reduce keys.a;
     var eMax = max reduce keys.a;
     var d: Diags;

--- a/test/UnitTestPeelStick.chpl
+++ b/test/UnitTestPeelStick.chpl
@@ -76,7 +76,7 @@ proc testPeel(substr:string, n:int, minLen:int, maxLen:int, characters:charSet =
             writeln("Lengths <= 0: %t".format(badLen));
             if badLen > 0 {
               var n = 0;
-              for (i, ll, rl, ol) in zip(lstr.offsets.aD, llen, rlen, lengths) {
+              for (i, ll, rl, ol) in zip(lstr.offsets.a.domain, llen, rlen, lengths) {
                 if (ll <= 0) {
                   n += 1;
                   writeln("%i: %s (%i) -> <bad> (%i) | %s (%i)".format(i, strings[i], ol, ll, rstr[i], rl));
@@ -109,7 +109,7 @@ proc testPeel(substr:string, n:int, minLen:int, maxLen:int, characters:charSet =
           if !success {
             var n = 0;
             const rtlen = roundTrip.getLengths();
-            for (i, e) in zip(strings.offsets.aD, eq) {
+            for (i, e) in zip(strings.offsets.a.domain, eq) {
               if !e {
                 n += 1;
                 writeln("%i: %s (%i) -> %s (%i)".format(i, strings[i], lengths[i], roundTrip[i], rtlen[i]));

--- a/test/untested/UnitTestStringType.chpl
+++ b/test/untested/UnitTestStringType.chpl
@@ -96,12 +96,12 @@ proc main() {
   var giv = st.lookup(aname);
   var iv = toSymEntry(giv, bool);
   var steps = + scan iv.a;
-  var pop = steps[iv.aD.high];
+  var pop = steps[iv.a.domain.high];
   printAry("strings == %s: ".format(testString), iv.a);
   writeln("pop = ", pop);
   if (pop > 0) {
     var inds: [0..#pop] int;
-    [(idx, present, i) in zip(iv.aD, iv.a, steps)] if present {inds[i-1] = idx;}
+    [(idx, present, i) in zip(iv.a.domain, iv.a, steps)] if present {inds[i-1] = idx;}
     printAry("inds: ", inds);
     var diff = inds[1..#(pop-1)] - inds[0..#(pop-1)];
     var consecutive = && reduce (diff == 1);
@@ -164,12 +164,12 @@ proc main() {
   giv = st.lookup(aname);
   iv = toSymEntry(giv, bool);
   steps = + scan iv.a;
-  pop = steps[iv.aD.high];
+  pop = steps[iv.a.domain.high];
   printAry("strings == %s: ".format(testString), iv.a);
   writeln("pop = ", pop);
   if pop > 0 {
     var permInds: [0..#pop] int;
-    [(idx, present, i) in zip(iv.aD, iv.a, steps)] if present {permInds[i-1] = idx;}
+    [(idx, present, i) in zip(iv.a.domain, iv.a, steps)] if present {permInds[i-1] = idx;}
     //printAry("permInds: ", permInds);
     writeln("permInds: ", permInds);
     var permDiff = permInds[1..#(pop-1)] - permInds[0..#(pop-1)];


### PR DESCRIPTION
Motivated by #1901, I'd like to stop storing the domain in the `SymEntry` wrapper, so we now need to go through the array to get the domain (e.g. `symEntry.aD` is now `symEntry.a.domain`). You could imagine creating a wrapper to do this automatically with a wrapper like:

```chpl
proc aD const ref {
  return a.domain;
}
```

But unfortunately chapel-lang/chapel#20389 prevents using `const ref`, which is required to avoid a full domain copy on each call.