### PR TITLE
Closes #1909 uint not supported for binop __invert__

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -456,6 +456,8 @@ class pdarray:
     def __invert__(self):
         if self.dtype == akint64:
             return self._binop(~0, "^")
+        if self.dtype == akuint64:
+            return self._binop(~np.uint(0), "^")
         if self.dtype == bool:
             return self._binop(True, "^")
         raise TypeError(f"Unhandled dtype: {self} ({self.dtype})")

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -294,6 +294,10 @@ class OperatorsTest(ArkoudaTest):
             ak.concatenate([pdaOne, pdaTwo]).to_list(),
         )
 
+    def test_invert(self):
+        ak_uint = ak.arange(10, dtype=ak.uint64)
+        self.assertListEqual(np.arange(10, dtype=np.uint).tolist(), ak_uint.to_list())
+
     def test_float_uint_binops(self):
         # Test fix for issue #1620
         ak_uint = ak.array([5], dtype=ak.uint64)

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -296,7 +296,9 @@ class OperatorsTest(ArkoudaTest):
 
     def test_invert(self):
         ak_uint = ak.arange(10, dtype=ak.uint64)
-        self.assertListEqual(np.arange(10, dtype=np.uint).tolist(), ak_uint.to_list())
+        inverted = ~ak_uint
+        np_uint_inv = ~np.arange(10, dtype=np.uint)
+        self.assertListEqual(np_uint_inv.tolist(), inverted.to_list())
 
     def test_float_uint_binops(self):
         # Test fix for issue #1620


### PR DESCRIPTION
Closes #1909

Updated the `__invert__` override to include uint64 case.

Added testing to validate functionality against NumPy.