### PR TITLE
Closes #1844: Add option for `hierarchical` behavior to `search_intervals`

### DIFF
--- a/arkouda/alignment.py
+++ b/arkouda/alignment.py
@@ -279,7 +279,7 @@ def in1d_intervals(vals, intervals, symmetric=False):
         return found
 
 
-def search_intervals(vals, intervals, tiebreak=None, composite=False):
+def search_intervals(vals, intervals, tiebreak=None, hierarchical=False):
     """
     Given an array of query vals and non-overlapping, closed intervals, return
     the index of the best (see tiebreak) interval containing each query value,
@@ -297,7 +297,7 @@ def search_intervals(vals, intervals, tiebreak=None, composite=False):
         When a value is present in more than one interval, the interval with the
         lowest tiebreak value will be chosen. If no tiebreak is given, the
         first containing interval will be chosen.
-    composite: boolean
+    hierarchical: boolean
         When True, sequences of pdarrays will be treated as components specifying
         a single dimension (i.e. hierarchical)
         When False, sequences of pdarrays will be specifying multi-dimensional intervals
@@ -321,7 +321,7 @@ def search_intervals(vals, intervals, tiebreak=None, composite=False):
     >>> vals = (ak.array([0, 0, 2, 5, 5, 6, 6, 9]), ak.array([0, 20, 1, 5, 15, 0, 12, 30]))
     >>> ak.search_intervals(vals, (starts, ends))
     array([0 -1 0 0 1 -1 1 -1])
-    >>> ak.search_intervals(vals, (starts, ends), composite=True)
+    >>> ak.search_intervals(vals, (starts, ends), hierarchical=True)
     array([0 0 0 0 1 1 1 -1])
     """
     from arkouda.join import gen_ranges
@@ -399,7 +399,7 @@ def search_intervals(vals, intervals, tiebreak=None, composite=False):
         if lowsize != highsize:
             raise ValueError("Lower and upper bound arrays must be same size")
         # verify upper bounds are greater than lower bounds
-        if composite:
+        if hierarchical:
             if not is_cosorted(low):
                 raise ValueError("Intervals must be sorted in ascending order")
             bounds_okay = True
@@ -437,7 +437,7 @@ def search_intervals(vals, intervals, tiebreak=None, composite=False):
 
         perm = coargsort([concatenate((lo, va, hi)) for lo, va, hi in zip(low, vals, high)])
 
-    if singleton or (isinstance(vals, Sequence) and composite):
+    if singleton or (isinstance(vals, Sequence) and hierarchical):
         # Index of interval containing each unique value (initialized to -1: not found)
         containing_interval = -ones(valsize, dtype=akint64)
         # iperm is the indices of the original values in the sorted array

--- a/arkouda/alignment.py
+++ b/arkouda/alignment.py
@@ -1,4 +1,5 @@
 import functools
+from typing import Sequence
 from warnings import warn
 
 import numpy as np  # type: ignore
@@ -12,7 +13,7 @@ from arkouda.numeric import where
 from arkouda.pdarrayclass import pdarray
 from arkouda.pdarraycreation import arange, full, ones, zeros
 from arkouda.pdarraysetops import concatenate, in1d
-from arkouda.sorting import argsort
+from arkouda.sorting import argsort, coargsort
 from arkouda.strings import Strings
 
 
@@ -278,23 +279,28 @@ def in1d_intervals(vals, intervals, symmetric=False):
         return found
 
 
-def search_intervals(vals, intervals, tiebreak=None):
+def search_intervals(vals, intervals, tiebreak=None, composite=False):
     """
-    Given an array of query vals and closed intervals, return the index of the
-    best (see tiebreak) interval containing each query value, or -1 if not present in any
-    interval.
+    Given an array of query vals and non-overlapping, closed intervals, return
+    the index of the best (see tiebreak) interval containing each query value,
+    or -1 if not present in any interval.
 
     Parameters
     ----------
     vals : (sequence of) pdarray(int, uint, float)
         Values to search for in intervals. If multiple arrays, each "row" is an item.
     intervals : 2-tuple of (sequences of) pdarrays
-        Closed (inclusive) intervals, as a tuple of (lower_bounds_inclusive, upper_bounds_inclusive).
+        Non-overlapping, half-open intervals, as a tuple of
+        (lower_bounds_inclusive, upper_bounds_exclusive)
         Must have same dtype(s) as vals.
     tiebreak : (optional) pdarray, numeric
         When a value is present in more than one interval, the interval with the
         lowest tiebreak value will be chosen. If no tiebreak is given, the
         first containing interval will be chosen.
+    composite: boolean
+        When True, sequences of pdarrays will be treated as components specifying
+        a single dimension (i.e. hierarchical)
+        When False, sequences of pdarrays will be specifying multi-dimensional intervals
 
     Returns
     -------
@@ -307,22 +313,34 @@ def search_intervals(vals, intervals, tiebreak=None):
         present = idx > -1
         ((intervals[0][idx[present]] <= vals[present]) &
          (intervals[1][idx[present]] >= vals[present])).all()
+
+    Examples
+    --------
+    >>> starts = (ak.array([0, 5]), ak.array([0, 11]))
+    >>> ends = (ak.array([5, 9]), ak.array([10, 20]))
+    >>> vals = (ak.array([0, 0, 2, 5, 5, 6, 6, 9]), ak.array([0, 20, 1, 5, 15, 0, 12, 30]))
+    >>> ak.search_intervals(vals, (starts, ends))
+    array([0 -1 0 0 1 -1 1 -1])
+    >>> ak.search_intervals(vals, (starts, ends), composite=True)
+    array([0 0 0 0 1 1 1 -1])
     """
     from arkouda.join import gen_ranges
 
     if len(intervals) != 2:
         raise ValueError("intervals must be 2-tuple of (lower_bound_inclusive, upper_bounds_inclusive)")
 
-    low = intervals[0]
-    high = intervals[1]
-    intervalsize = low.size if isinstance(low, pdarray) else low[0].size
-    if tiebreak is None:
-        tiebreak = arange(intervalsize)
-    elif not isinstance(tiebreak, pdarray) or tiebreak.size != intervalsize:
+    low, high = intervals
+    singleton = isinstance(vals, pdarray)
+    lowsize = low.size if isinstance(low, pdarray) else low[0].size
+
+    if tiebreak is not None and (not isinstance(tiebreak, pdarray) or tiebreak.size != lowsize):
         raise TypeError("Tiebreak must be pdarray of same size as number of intervals")
 
-    if isinstance(vals, pdarray) and vals.dtype in (akint64, akuint64, akfloat64):
+    if singleton:
         # argument validation for pdarray
+        if vals.dtype not in (akint64, akuint64, akfloat64):
+            raise TypeError("arguments must be numeric arrays")
+
         if not isinstance(low, pdarray) or not isinstance(high, pdarray):
             raise TypeError("intervals must be same objtype as vals")
 
@@ -339,45 +357,17 @@ def search_intervals(vals, intervals, tiebreak=None):
         # verify upper bounds are greater than lower bounds
         if not (high >= low).all():
             raise ValueError("Upper bounds must be greater than lower bounds")
+        if not low.is_sorted():
+            raise ValueError("Intervals must be sorted in ascending order")
 
-        # Index of interval containing each unique value (initialized to -1: not found)
-        containinginterval = -ones(vals.size, dtype=akint64)
-        concat = concatenate((low, vals, high))
-        perm = argsort(concat)
-        # iperm is the indices of the original values in the sorted array
-        iperm = argsort(perm)  # aku.invert_permutation(perm)
-        boundary = vals.size + low.size
-        # indices of the lower bounds in the sorted array
-        starts = iperm[: low.size]
-        # indices of the upper bounds in the sorted array
-        ends = iperm[boundary:]
-        # which lower/upper bound pairs have any indices between them?
-        valid = ends > starts + 1
-        if valid.sum() > 0:
-            # pranges is all the indices in sorted array that fall between a lower and an uppper bound
-            segs, pranges = gen_ranges(starts[valid] + 1, ends[valid])
-            # matches are the indices of those items in the original array
-            matches = perm[pranges]
-            # integer indices of each interval containing a hit
-            hitidx = arange(valid.size)[valid]
-            # broadcast interval index out to matches
-            matchintervalidx = broadcast(segs, hitidx, matches.size)
-            # make sure not to include any of the bounds themselves
-            validmatch = (matches >= low.size) & (matches < boundary)
-            matchintervalidx = matchintervalidx[validmatch]
-            # indices of values found (translated from concat keys)
-            validx = matches[validmatch] - low.size
-            # break ties for values contained in more than one interval
-            byvalidx = GroupBy(validx)
-            validx, tmpidx = byvalidx.argmin(tiebreak[matchintervalidx])
-            # set index of containing interval for uvals that were found
-            containinginterval[validx] = matchintervalidx[tmpidx]
-        return containinginterval
-    elif isinstance(vals, (list, tuple)):
+        not_overlapping = (low[1:] > high[:-1]).all()
+        valsize = vals.size
+        perm = argsort(concatenate((low, vals, high)))
+    else:
         # argument validation for multi-array
-        if not isinstance(low, (list, tuple)) or not isinstance(high, (list, tuple)):
-            raise TypeError("intervals must be same type as vals")
-        if len(vals) != len(low) or len(vals) != len(high):
+        if not isinstance(low, Sequence) or not isinstance(high, Sequence):
+            raise TypeError("intervals must be same objtype as vals")
+        if len({len(low), len(high), len(vals)}) != 1:
             raise TypeError("Multi-array arguments must have same number of arrays")
         if (
             any(not isinstance(v, pdarray) for v in vals)
@@ -398,6 +388,9 @@ def search_intervals(vals, intervals, tiebreak=None):
         hightypes = np.array([hi.dtype for hi in high])
         if (valtypes != lowtypes).any() or (valtypes != hightypes).any():
             raise TypeError("Values and intervals must have matching dtypes")
+        for t in valtypes:
+            if t not in (akint64, akuint64, akfloat64):
+                raise TypeError("arguments must be numeric arrays")
 
         valsize = valsize.pop()
         lowsize = lowsize.pop()
@@ -406,13 +399,87 @@ def search_intervals(vals, intervals, tiebreak=None):
         if lowsize != highsize:
             raise ValueError("Lower and upper bound arrays must be same size")
         # verify upper bounds are greater than lower bounds
-        if not all((hi >= lo).all() for hi, lo in zip(high, low)):
+        if composite:
+            if not is_cosorted(low):
+                raise ValueError("Intervals must be sorted in ascending order")
+            bounds_okay = True
+            checked = zeros(lowsize, dtype=bool)
+            needtocheck = ones(lowsize, dtype=bool)
+            for lo, hi in zip(low, high):
+                if (needtocheck & (hi < lo)).any():
+                    bounds_okay = False
+                    break
+                checked |= needtocheck & (lo < hi)
+                if checked.all():
+                    bounds_okay = True
+                    break
+                needtocheck &= lo == hi
+        else:
+            bounds_okay = all((hi >= lo).all() for hi, lo in zip(high, low))
+
+        if not bounds_okay:
             raise ValueError("Upper bounds must be greater than lower bounds")
 
+        left = high[0][:-1]
+        right = low[0][1:]
+        not_overlapping = True
+        if (left < right).any():
+            not_overlapping = False
+        else:
+            boundary = left != right
+            for lo, hi in zip(low[1:], high[1:]):
+                left = hi[:-1]
+                right = lo[1:]
+                if not ((left <= right) | boundary).all():
+                    not_overlapping = False
+                    break
+                boundary = boundary | (left != right)
+
+        perm = coargsort([concatenate((lo, va, hi)) for lo, va, hi in zip(low, vals, high)])
+
+    if singleton or (isinstance(vals, Sequence) and composite):
         # Index of interval containing each unique value (initialized to -1: not found)
-        containinginterval = -ones(valsize, dtype=akint64)
-        concat = [concatenate((lo, v, hi)) for lo, v, hi in zip(low, vals, high)]
-        perm = [argsort(c) for c in concat]
+        containing_interval = -ones(valsize, dtype=akint64)
+        # iperm is the indices of the original values in the sorted array
+        iperm = argsort(perm)  # aku.invert_permutation(perm)
+        boundary = valsize + lowsize
+        # indices of the lower bounds in the sorted array
+        starts = iperm[:lowsize]
+        # indices of the upper bounds in the sorted array
+        ends = iperm[boundary:]
+        # which lower/upper bound pairs have any indices between them?
+        valid = ends > starts + 1
+        if valid.sum() > 0:
+            # pranges is all the indices in sorted array that fall between a lower and an uppper bound
+            segs, pranges = gen_ranges(starts[valid] + 1, ends[valid])
+            # matches are the indices of those items in the original array
+            matches = perm[pranges]
+            # integer indices of each interval containing a hit
+            hit_idx = arange(valid.size)[valid]
+            # broadcast interval index out to matches
+            match_interval_idx = broadcast(segs, hit_idx, matches.size)
+            # make sure not to include any of the bounds themselves
+            valid_match = (matches >= lowsize) & (matches < boundary)
+            match_interval_idx = match_interval_idx[valid_match]
+            # indices of unique values found (translated from concat keys)
+            uval_idx = matches[valid_match] - lowsize
+            if not_overlapping:
+                # set index of containing interval for uvals that were found
+                containing_interval[uval_idx] = match_interval_idx[valid_match]
+            else:
+                # break ties for values contained in more than one interval
+                by_item = GroupBy(uval_idx)
+                if tiebreak is None:
+                    best_match_idx = by_item.permutation[by_item.segments]
+                else:
+                    _, best_match_idx = by_item.argmin(tiebreak[match_interval_idx])
+                # set index of containing interval for uvals that were found
+                containing_interval[by_item.unique_keys] = match_interval_idx[best_match_idx]
+        return containing_interval
+    elif isinstance(vals, Sequence):
+        # Index of interval containing each unique value (initialized to -1: not found)
+        containing_interval = -ones(valsize, dtype=akint64)
+        perm = [argsort(concatenate((lo, v, hi))) for lo, v, hi in zip(low, vals, high)]
         # iperm is the indices of the original values in the sorted array
         iperm = [argsort(p) for p in perm]  # aku.invert_permutation(perm)
         boundary = valsize + lowsize
@@ -430,35 +497,82 @@ def search_intervals(vals, intervals, tiebreak=None):
             # matches are the indices of those items in the original array
             matches = [pm[pr] for pm, pr in zip(perm, pranges)]
             # integer indices of each one-dimensional interval containing a hit
-            hitidx = arange(valid.size)[valid]
+            hit_idx = arange(valid.size)[valid]
             # broadcast 1-d interval index out to matches
-            matchintervalidx = [broadcast(s, hitidx, m.size) for s, m in zip(segs, matches)]
+            match_interval_idx = [broadcast(s, hit_idx, m.size) for s, m in zip(segs, matches)]
             # make sure not to include any of the bounds themselves
-            validmatch = [(m >= lowsize) & (m < boundary) for m in matches]
+            valid_match = [(m >= lowsize) & (m < boundary) for m in matches]
             # indices of values found (translated from concat keys) in 1-d intervals
-            uvalidx = [m[vm] - lowsize for m, vm in zip(matches, validmatch)]
+            uval_idx = [m[vm] - lowsize for m, vm in zip(matches, valid_match)]
             # now go from 1-d to full dimensionality
             # for each interval, intersect the hits from its 1-d projections
             # do this by concatenating all the projections and grouping on the id of the hit
             # and the interval and looking for hits that cover all dimensions
-            alluvalidx = concatenate(uvalidx, ordered=False)
-            allmatchintervalidx = concatenate(
-                [mi[vm] for mi, vm in zip(matchintervalidx, validmatch)], ordered=False
+            all_uval_idx = concatenate(uval_idx, ordered=False)
+            all_match_interval_idx = concatenate(
+                [mi[vm] for mi, vm in zip(match_interval_idx, valid_match)], ordered=False
             )
-            byvalinterval = GroupBy([alluvalidx, allmatchintervalidx])
+            by_val_interval = GroupBy([all_uval_idx, all_match_interval_idx])
             # a true hit happens when a value is contained in all of an interval's 1-d projections
-            isahit = byvalinterval.count()[1] == len(low)
+            is_a_hit = by_val_interval.count()[1] == len(low)
             # indices of the true hits and their containing intervals
-            valhits, intervalhits = [x[isahit] for x in byvalinterval.unique_keys]
+            val_hits, interval_hits = [x[is_a_hit] for x in by_val_interval.unique_keys]
             # a value might be found in more than one interval, so we need to break ties
-            byval = GroupBy(valhits)
-            hitvalidx, tmpidx = byval.argmin(tiebreak[intervalhits])
-            winninginterval = intervalhits[tmpidx]
+            by_val = GroupBy(val_hits)
+            if tiebreak is None:
+                best_match_idx = by_val.permutation[by_val.segments]
+            else:
+                _, best_match_idx = by_val.argmin(tiebreak[interval_hits])
             # set index of best containing interval for values that were found
-            containinginterval[hitvalidx] = winninginterval
-            return containinginterval
+            containing_interval[by_val.unique_keys] = interval_hits[best_match_idx]
+            return containing_interval
     else:
         raise TypeError("arguments must be numeric pdarrays or a sequence of numeric pdarrays")
+
+
+def is_cosorted(arrays):
+    """
+    Return True iff the arrays are cosorted, i.e., if the arrays were columns in a table
+    then the rows are sorted.
+
+    Parameters
+    ----------
+    arrays : list-like of pdarrays
+        Arrays to check for cosortedness
+
+    Returns
+    -------
+    bool
+        True iff arrays are cosorted.
+
+    Raises
+    ------
+    ValueError
+        Raised if arrays are not the same length
+    TypeError
+        Raised if arrays is not a list-like of pdarrays
+    """
+
+    if not isinstance(arrays, Sequence) or not all(isinstance(array, pdarray) for array in arrays):
+        raise TypeError("Input must be a list-like of pdarrays")
+
+    # check for equal length
+    if len({array.size for array in arrays}) > 1:
+        raise ValueError("Arrays must all be same length")
+
+    # fail fast if the first array isn't sorted
+    if not arrays[0].is_sorted():
+        return False
+
+    # initialize the array to track boundary
+    boundary = arrays[0][:-1] != arrays[0][1:]
+    for array in arrays[1:]:
+        left = array[:-1]
+        right = array[1:]
+        if not ((left <= right) | boundary).all():
+            return False
+        boundary = boundary | (left != right)
+    return True
 
 
 def interval_lookup(keys, values, arguments, fillvalue=-1, tiebreak=None):

--- a/tests/alignment_tests.py
+++ b/tests/alignment_tests.py
@@ -49,7 +49,7 @@ class AlignmentTest(ArkoudaTest):
         self.assertListEqual(ans, ak.search_intervals(vals, (starts, ends)).to_list())
         self.assertListEqual(ans, ak.interval_lookup((starts, ends), ak.arange(3), vals).to_list())
 
-        # test composite flag
+        # test hierarchical flag
         starts = (ak.array([0, 5]), ak.array([0, 11]))
         ends = (ak.array([5, 9]), ak.array([10, 20]))
         vals = (ak.array([0, 0, 2, 5, 5, 6, 6, 9]), ak.array([0, 20, 1, 5, 15, 0, 12, 30]))
@@ -58,7 +58,7 @@ class AlignmentTest(ArkoudaTest):
             ak.search_intervals(vals, (starts, ends)).to_list(), [0, -1, 0, 0, 1, -1, 1, -1]
         )
         self.assertListEqual(
-            ak.search_intervals(vals, (starts, ends), composite=True).to_list(),
+            ak.search_intervals(vals, (starts, ends), hierarchical=True).to_list(),
             [0, 0, 0, 0, 1, 1, 1, -1],
         )
 

--- a/tests/alignment_tests.py
+++ b/tests/alignment_tests.py
@@ -2,7 +2,7 @@ from base_test import ArkoudaTest
 from context import arkouda as ak
 
 
-class DataFrameTest(ArkoudaTest):
+class AlignmentTest(ArkoudaTest):
     def test_search_interval(self):
         expected_result = [2, 5, 4, 0, 3, 1, 4, -1, -1]
         lb = [0, 10, 20, 30, 40, 50]
@@ -48,6 +48,19 @@ class DataFrameTest(ArkoudaTest):
         ans = [2, 1, -1]
         self.assertListEqual(ans, ak.search_intervals(vals, (starts, ends)).to_list())
         self.assertListEqual(ans, ak.interval_lookup((starts, ends), ak.arange(3), vals).to_list())
+
+        # test composite flag
+        starts = (ak.array([0, 5]), ak.array([0, 11]))
+        ends = (ak.array([5, 9]), ak.array([10, 20]))
+        vals = (ak.array([0, 0, 2, 5, 5, 6, 6, 9]), ak.array([0, 20, 1, 5, 15, 0, 12, 30]))
+
+        self.assertListEqual(
+            ak.search_intervals(vals, (starts, ends)).to_list(), [0, -1, 0, 0, 1, -1, 1, -1]
+        )
+        self.assertListEqual(
+            ak.search_intervals(vals, (starts, ends), composite=True).to_list(),
+            [0, 0, 0, 0, 1, 1, 1, -1],
+        )
 
     def test_search_interval_nonunique(self):
         expected_result = [2, 5, 2, 1, 3, 1, 4, -1, -1]


### PR DESCRIPTION
This PR (Closes #1844):
- Adds `hierarchical` flag which allows multi-arrays passed to `search_intervals` to be treated as hierarchical data specifying a single dimension
- Adds `is_cosorted` function
- Adds test based on the example provided in the issue