### PR TITLE
Closes #1914 - Adding `autoShutdown` flag to server to shutdown on client disconnect

### DIFF
--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -58,6 +58,11 @@ module ServerConfig
     config const serverConnectionInfo: string = getEnv("ARKOUDA_SERVER_CONNECTION_INFO", "");
 
     /*
+    Flag to shut down the arkouda server automatically when the client disconnects
+    */
+    config const autoShutdown = false;
+
+    /*
     Hostname where I am running
     */
     var serverHostname: string = try! get_hostname();
@@ -146,6 +151,7 @@ module ServerConfig
             const logLevel: LogLevel;
             const regexMaxCaptures: int;
             const byteorder: string;
+            const autoShutdown: bool;
         }
 
         var (Zmajor, Zminor, Zmicro) = ZMQ.version;
@@ -168,7 +174,8 @@ module ServerConfig
             authenticate = authenticate,
             logLevel = logLevel,
             regexMaxCaptures = regexMaxCaptures,
-            byteorder = try! getByteorder()
+            byteorder = try! getByteorder(),
+            autoShutdown = autoShutdown
         );
         return try! "%jt".format(cfg);
 

--- a/src/ServerDaemon.chpl
+++ b/src/ServerDaemon.chpl
@@ -493,14 +493,18 @@ module ServerDaemon {
                        }
                 }
 
-                // If cmd is shutdown, don't bother generating a repMsg
-                if cmd == "shutdown" {
+                inline proc sendShutdownRequest(user: string) throws {
                     requestShutdown(user=user);
                     if (trace) {
                         sdLogger.info(getModuleName(),getRoutineName(),getLineNumber(),
-                                         "<<< shutdown initiated by %s took %.17r sec".format(user, 
-                                                   t1.elapsed() - s0));
+                                        "<<< shutdown initiated by %s took %.17r sec".format(user, 
+                                                t1.elapsed() - s0));
                     }
+                }
+
+                // If cmd is shutdown, don't bother generating a repMsg
+                if cmd == "shutdown" {
+                    sendShutdownRequest(user=user);
                     break;
                 }
 
@@ -526,6 +530,11 @@ module ServerDaemon {
                         }
                     }
                     when "disconnect" {
+                        if autoShutdown {
+                            sendShutdownRequest(user=user);
+                            break;
+                        }
+                        
                         repTuple = new MsgTuple("disconnected from arkouda server tcp://*:%i".format(ServerPort), MsgType.NORMAL);
                     }
                     when "noop" {


### PR DESCRIPTION
This PR Closes #1914 

Adds optional `--autoShutdown=<true/false>` flag to server startup command to automatically shutdown the server when the client disconnects. This flag is defaulted to false.

I tested this manually through `ipython`, with a script that uses `util.tests.util.start_arkouda_server(1, server_args=["--autoShutdown=true"])`, and through a jupyter notebook.