### PR TITLE
Closes #1905: Add encoding libraries to conda dependencies

### DIFF
--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -16,6 +16,8 @@ dependencies:
   - types-tabulate
   - pytables>=3.7.0
   - pyarrow==9.0.0
+  - libiconv
+  - libidn2
 
   # Developer dependencies
   - pexpect

--- a/arkouda-env.yml
+++ b/arkouda-env.yml
@@ -16,6 +16,8 @@ dependencies:
   - types-tabulate
   - pytables>=3.7.0
   - pyarrow==9.0.0
+  - libiconv
+  - libidn2
 
   - pip:
       - typeguard==2.10.0

--- a/pydoc/requirements.txt
+++ b/pydoc/requirements.txt
@@ -12,7 +12,9 @@ h5py
 pip
 types-tabulate
 tables>=3.7.0
-pyarrow>=1.0.1
+pyarrow==9.0.0
+libiconv
+libidn2
 
 # Developer dependencies
 pexpect

--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,6 @@ setup(
         'types-tabulate',
         'tables>=3.7.0',
         'pyarrow==9.0.0',
-        'libiconv',
         'libidn2'
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,9 @@ setup(
         'pip',
         'types-tabulate',
         'tables>=3.7.0',
-        'pyarrow==9.0.0'
+        'pyarrow==9.0.0',
+        'libiconv',
+        'libidn2'
     ],
 
     # List additional groups of dependencies here (e.g. development

--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,6 @@ setup(
         'types-tabulate',
         'tables>=3.7.0',
         'pyarrow==9.0.0',
-        'libidn2'
     ],
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
This PR (Closes #1905):
- Updates the relevant locations to reflect new encoding library dependencies

I pulled down PR #1897 and verified that I could build with a new conda env created with the updated `arkouda-env-dev.yml` file (after pointing my `Makefile.paths` and `LD_LIBRARY_PATH` to the new env)

This PR is supporting #1897, so we should make sure to merge them both in the same release cycle