### PR TITLE
Closes #1917 - Adds server config json to stdout

### DIFF
--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -207,8 +207,6 @@ def connect(
     regexMaxCaptures = serverConfig["regexMaxCaptures"]  # type:ignore
     clientLogger.info(return_message)
 
-    return cast(str, generic_msg(cmd="getconfig", args={}))
-
 
 def _parse_url(url: str) -> Tuple[str, int, Optional[str]]:
     """

--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -106,7 +106,7 @@ def connect(
     timeout: int = 0,
     access_token: str = None,
     connect_url=None,
-) -> str:
+) -> None:
     """
     Connect to a running arkouda server.
 

--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -129,7 +129,7 @@ def connect(
 
     Returns
     -------
-    JSON string of connection configuration information
+    None
 
     Raises
     ------

--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -106,7 +106,7 @@ def connect(
     timeout: int = 0,
     access_token: str = None,
     connect_url=None,
-) -> None:
+) -> str:
     """
     Connect to a running arkouda server.
 
@@ -129,7 +129,7 @@ def connect(
 
     Returns
     -------
-    None
+    JSON string of connection configuration information
 
     Raises
     ------
@@ -206,6 +206,8 @@ def connect(
         )
     regexMaxCaptures = serverConfig["regexMaxCaptures"]  # type:ignore
     clientLogger.info(return_message)
+
+    return cast(str, generic_msg(cmd="getconfig", args={}))
 
 
 def _parse_url(url: str) -> Tuple[str, int, Optional[str]]:

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -63,6 +63,11 @@ module ServerConfig
     config const autoShutdown = false;
 
     /*
+    Flag to print the server information on startup
+    */
+    config const serverInfoNoSplash = false;
+
+    /*
     Hostname where I am running
     */
     var serverHostname: string = try! get_hostname();
@@ -152,6 +157,7 @@ module ServerConfig
             const regexMaxCaptures: int;
             const byteorder: string;
             const autoShutdown: bool;
+            const serverInfoNoSplash: bool;
         }
 
         var (Zmajor, Zminor, Zmicro) = ZMQ.version;
@@ -175,7 +181,8 @@ module ServerConfig
             logLevel = logLevel,
             regexMaxCaptures = regexMaxCaptures,
             byteorder = try! getByteorder(),
-            autoShutdown = autoShutdown
+            autoShutdown = autoShutdown,
+            serverInfoNoSplash = serverInfoNoSplash
         );
         return try! "%jt".format(cfg);
 

--- a/src/ServerDaemon.chpl
+++ b/src/ServerDaemon.chpl
@@ -402,10 +402,7 @@ module ServerDaemon {
             this.connectUrl = this.getConnectUrl(this.serverToken);
             this.createServerConnectionInfo();
             if serverInfoNoSplash {
-                writeln("Server Information:");
                 writeln(getConfig());
-                writeln();
-                writeln();
             } else {
                 this.printServerSplashMessage(this.serverToken,this.arkDirectory);
             }

--- a/src/ServerDaemon.chpl
+++ b/src/ServerDaemon.chpl
@@ -401,7 +401,14 @@ module ServerDaemon {
     
             this.connectUrl = this.getConnectUrl(this.serverToken);
             this.createServerConnectionInfo();
-            this.printServerSplashMessage(this.serverToken,this.arkDirectory);
+            if serverInfoNoSplash {
+                writeln("Server Information:");
+                writeln(getConfig());
+                writeln();
+                writeln();
+            } else {
+                this.printServerSplashMessage(this.serverToken,this.arkDirectory);
+            }
             this.registerServerCommands();
                     
             var t1 = new Time.Timer();

--- a/src/ServerDaemon.chpl
+++ b/src/ServerDaemon.chpl
@@ -403,6 +403,7 @@ module ServerDaemon {
             this.createServerConnectionInfo();
             if serverInfoNoSplash {
                 writeln(getConfig());
+                stdout.flush();
             } else {
                 this.printServerSplashMessage(this.serverToken,this.arkDirectory);
             }


### PR DESCRIPTION
This PR closes #1917 

Adds a server startup command flag `--serverInfoNoSplash=<true/false>` that replaces the normal server splash message with a json string of server information.

This also adds that the server info string gets returned to the client through the `ak.connect()` call, so it's easily accessible from the client.

With `--serverInfoNoSplash=false` (default setting)

![image](https://user-images.githubusercontent.com/65456732/202780818-33b82803-9f60-4618-9a68-a709178753e6.png)


With `--serverInfoNoSplash=true`

![image](https://user-images.githubusercontent.com/65456732/202789511-32212bda-cdec-41db-89d6-016701f68465.png)

**note: `akserver` is an alias I have setup. To remove confusion, this is what it does: 
```
alias arkouda="cd /home/josh/git/arkouda"
alias akserver="arkouda;./arkouda_server -nl 1"
```