### PR TITLE
Closes #1901: Reduce SymEntry creation overheads

### DIFF
--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -197,11 +197,12 @@ module MultiTypeSymEntry
         type etype;
 
         /*
-        'aD' is the distributed domain for 'a' whose value and type
-        are defined by makeDistDom() to support varying distributions
+        'a' is the distributed array whose value and type are defined by
+        makeDist{Dom,Array}() to support varying distributions
         */
-        const aD: makeDistDom(size).type;
-        var a: [aD] etype;
+        var a = makeDistArray(size, etype);
+        /* Removed domain accessor, use `a.domain` instead */
+        proc aD { compilerError("SymEntry.aD has been removed, use SymEntry.a.domain instead"); }
         
         /*
         This init takes length and element type
@@ -218,31 +219,36 @@ module MultiTypeSymEntry
             assignableTypes.add(this.entryType);
 
             this.etype = etype;
-            this.aD = makeDistDom(len);
-            // this.a uses default initialization
+            this.a = makeDistArray(size, etype);
         }
 
-        /*This init takes an array of a type
+        /*
+        This init takes an array whose type matches `makeDistArray()`
 
         :arg a: array
         :type a: [] ?etype
         */
-        proc init(a: [?D] ?etype) {
+        proc init(in a: [?D] ?etype) {
             super.init(etype, D.size);
             this.entryType = SymbolEntryType.PrimitiveTypedArraySymEntry;
             assignableTypes.add(this.entryType);
 
             this.etype = etype;
-            this.aD = D;
             this.a = a;
         }
 
         /*
-        Verbose flag utility method
+        This init takes an array whose type is defaultRectangular (convenience
+        function for creating a distributed array from a non-distributed one)
+
+        :arg a: array
+        :type a: [] ?etype
         */
-        proc postinit() {
-            //if v {write("aD = "); printOwnership(this.a);}
+        proc init(a: [?D] ?etype) where MyDmap != Dmap.defaultRectangular && a.isDefaultRectangular() {
+            this.init(D.size, etype);
+            this.a = a;
         }
+
         /*
         Verbose flag utility method
         */

--- a/test/SymEntrySpeedTest.chpl
+++ b/test/SymEntrySpeedTest.chpl
@@ -1,0 +1,130 @@
+use TestBase, AggDiags;
+
+config const n = 10;
+config const trials = if printDiags || printDiagsSum then 1 else 250;
+
+proc main()  {
+
+  var D = makeDistDom(n);
+  var A: [D] int;
+  var S = new SymEntry(n, int);
+  for 1..trials {
+
+    //
+    // Create Array/SymEntry from scratch
+    //
+    diags[trials:string+" arrs from scratch"].startStop();
+    {
+      var A2 = makeDistArray(n, int);
+    }
+    diags[trials:string+" arrs from scratch"].startStop();
+
+    diags[trials:string+" syms from scratch"].startStop();
+    {
+      var A2 = new SymEntry(n, int);
+    }
+    diags[trials:string+" syms from scratch"].startStop();
+
+
+    //
+    // Create Array from existing Domain/SymEntry
+    //
+    diags[trials:string+" arrs from dom"].startStop();
+    {
+      var A2: [D] int;
+    }
+    diags[trials:string+" arrs from dom"].startStop();
+
+    diags[trials:string+" arrs from sym"].startStop();
+    {
+      var A2: [S.a.domain] int;
+    }
+    diags[trials:string+" arrs from sym"].startStop();
+
+
+    //
+    // Create Array/SymEntry from existing Array
+    //
+    diags[trials:string+" arrs from arr"].startStop();
+    {
+      var A2 = A;
+    }
+    diags[trials:string+" arrs from arr"].startStop();
+
+    diags[trials:string+" syms from arr"].startStop();
+    {
+      var A2 = new SymEntry(A);
+    }
+    diags[trials:string+" syms from arr"].startStop();
+
+
+    //
+    // Create Array/SymEntry from existing dead Array
+    //
+    {
+      var deadA = A;
+      diags[trials:string+" arrs from dead arr"].startStop();
+      {
+          var A2 = deadA;
+      }
+      diags[trials:string+" arrs from dead arr"].startStop();
+    }
+
+    {
+      var deadA = A;
+      diags[trials:string+" syms from dead arr"].startStop();
+      {
+          var A2 = new SymEntry(deadA);
+      }
+      diags[trials:string+" syms from dead arr"].startStop();
+    }
+  }
+}
+
+module AggDiags {
+  use List, TestBase;
+
+  record orderedMap {
+    type keyT, valueT;
+    var keys: list(keyT);
+    var vals: list(valueT);
+
+    proc this(k: keyT) ref {
+      if !keys.contains(k) {
+        keys.append(k);
+        var defValue: valueT;
+        vals.append(defValue);
+      }
+      return vals[keys.find(k)];
+    }
+    iter items() {
+      for (k, v) in zip(keys, vals) do yield (k, v);
+    }
+  }
+
+  record AggDiags {
+    var d: Diags;
+    var dAgg: Diags;
+
+    proc startStop() {
+      if d.T.running {
+        d.stop(printTime=false, printDiag=false, printDiagSum=false);
+        dAgg.elapsedTime += d.elapsed();
+        dAgg.D = d.D;
+      } else {
+        d.start();
+      }
+    }
+  }
+
+  var diags: orderedMap(string, AggDiags);
+  proc deinit()  {
+    const maxLen = max reduce for k in diags.keys do k.size;
+    for (k, v) in diags.items() {
+      if printTimes    then writef("%s %s: %.2drs\n", k, " "*(maxLen-k.size), v.dAgg.elapsed());
+      if printDiags    then writef("%s %s: %s\n",     k, " "*(maxLen-k.size), v.dAgg.comm():string);
+      if printDiagsSum then writef("%s %s: %t\n",     k, " "*(maxLen-k.size), v.dAgg.commSum());
+    }
+  }
+}
+


### PR DESCRIPTION
Eliminate overheads in `SymEntry` creation. Previously, creating a `SymEntry` was more expensive than just creating the underlying Chapel array. This is because `SymEntry` used to store the domain and array, and the way it was declared resulted in initializing the domain and then assigning to it, which has unnecessary overhead. We don't actually need to separately store the domain (we can access it through `a.domain`) so just stop storing it. This also optimizes the case where a new array is created and put into a SymEntry, but never used again. By adding the `in` intent to the `SymEntry` initializer the compiler is able to optimize this case and steal the dead array instead of creating a new array and assigning.

Here are 16-node-cs-hdr timings for the included `SymEntrySpeedTest` test, which measures Chapel array creation time compared to `SymEntry` creation time:

Before:
```
250 arrs from scratch  : 0.27s
250 syms from scratch  : 0.59s
250 arrs from dom      : 0.08s
250 arrs from sym      : 0.08s
250 arrs from arr      : 0.11s
250 syms from arr      : 0.43s
250 arrs from dead arr : 0.04s
250 syms from dead arr : 0.44s
```

Now:
```
250 arrs from scratch  : 0.27s
250 syms from scratch  : 0.27s
250 arrs from dom      : 0.08s
250 arrs from sym      : 0.08s
250 arrs from arr      : 0.11s
250 syms from arr      : 0.11s
250 arrs from dead arr : 0.04s
250 syms from dead arr : 0.04s
```

Where the important thing to note is that before there were various overheads for constructing a `SymEntry` compared to a plain Chapel array and now there aren't. Also note that these timings were with Chapel main, which has some array creation optimizations added so these timings are faster than the 1.28 release. The unchanged result (creating a array from a `SymEntry`) is just to highlight that `SymEntry.a.domain` doesn't add overhead, but adding a `proc aD` wrapper would have.

A side-effect of not storing the domain is that we need an explicit initializer for creating a SymEntry from a non-distributed array. There are a few cases in Arkouda that were relying on this and I want to preserve that functionality for now (previously this worked because we'd create the distributed array in the `SymEntry` and then assign the local array to it, but now we're directing creating or stealing from the passed in array in the main initializer)

Closes #1901