### PR TITLE
Closes #1922 - Running Arkouda from a script example documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ This yielded a >20TB dataframe in Arkouda.
 2. [Building Arkouda](#build-ak)
 3. [Testing Arkouda](#test-ak)
 4. [Running arkouda_server](#run-ak)
+   - [Running the arkouda_server From a Script](#run-server-script)
    - [Sanity check](#run-ak-sanity)
    - [Token-Based Authentication](#run-ak-token-auth)
    - [Connecting to Arkouda](#run-ak-connect)
@@ -193,6 +194,25 @@ Other command line options are available and can be viewed by using the `--help`
 ```bash
 ./arkouda-server --help
 ```
+
+<a id="run-server-script"></a>
+### Running the arkouda_server From a Script
+
+With the addition of two server startup flags, `--autoShutdown` and `--serverInfoNoSplash`, running the arkouda_server from a script is easier than ever.
+
+To connect to the server via a script, you'll first have to issue a subprocess command to start the `arkouda_server` with the optional configuration flags.
+
+```python
+import subprocess
+
+# Update the below path to point to your arkouda_server
+cmd = "/Users/<username>/Documents/git/arkouda/arkouda_server -nl 1 --serverInfoNoSplash=true --autoShutdown=true"
+p = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+```
+
+This will allow you to access the server output, which on launch using `--serverInfoNoSplash=true` will be a JSON string with the server configuration which can be parsed for the server host, port, and other potentially useful information.
+
+For a full example and explanation, view the [Running From Script](training/RUNNING_FROM_SCRIPT.md) document.
 
 <a id="run-ak-sanity"></a>
 ### Sanity check arkouda\_server <sup><sup><sub><a href="#toc">toc</a></sub></sup></sup>

--- a/training/RUNNING_FROM_SCRIPT.md
+++ b/training/RUNNING_FROM_SCRIPT.md
@@ -1,0 +1,47 @@
+# Running Arkouda from a Script
+
+<a id="toc"></a>
+## Table of Contents
+1. [Overview](#overview)
+2. [New Server Startup Flags](#flags)
+3. [Example Implementation](#example)
+
+<a id="overview"></a>
+## Overview
+The purpose of this document is to provide an example process for using a script to automatically run the Arkouda server, connect to the server, perform required actions, then disconnect from the server without any user interaction required.
+
+<a id="flags"></a>
+## New Server Startup Flags
+Two new flags were added to the arkouda_server startup command to help streamline this type of Arkouda usage. These flags are both boolean flags that are `false` by default.
+
+- `--serverInfoNoSplash`
+  - This flag replaces the usual splash message in the output of the server startup with the server configuration JSON. This JSON can then be parsed to read the server host, server port, and any other configuration info you may need.
+- `--autoShutdown`
+  - This flag toggles whether the arkouda_server will shut itself down when the client disconnects. When set to `true`, `ak.disconnect()` will trigger the server shutdown process.
+
+<a id="example"></a>
+## Example Implementation
+
+```python
+import arkouda as ak
+
+import subprocess
+import json
+
+# Update the below path to point to your arkouda_server
+cmd = "/Users/<username>/Documents/git/arkouda/arkouda_server -nl 1 --serverInfoNoSplash=true --autoShutdown=true"
+p = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+# get the output as a string
+connect_str = p.stdout.readline()
+
+server_data = json.loads(connect_str)
+server, port = server_data['serverHostname'], server_data['ServerPort']
+
+ak.connect(server=server, port=int(port))
+
+# Perform whatever Arkouda actions you need
+a = ak.arange(15)
+b = ak.array(["This", "is", "an", "example"])
+
+ak.disconnect()
+```

--- a/training/RUNNING_FROM_SCRIPT.md
+++ b/training/RUNNING_FROM_SCRIPT.md
@@ -16,6 +16,31 @@ Two new flags were added to the arkouda_server startup command to help streamlin
 
 - `--serverInfoNoSplash`
   - This flag replaces the usual splash message in the output of the server startup with the server configuration JSON. This JSON can then be parsed to read the server host, server port, and any other configuration info you may need.
+  - An example of the JSON configuration that gets written to `stdout`: 
+```json
+{
+  "arkoudaVersion":"v2022.11.17",
+  "chplVersion":"1.28.0",
+  "ZMQVersion":"4.3.4",
+  "HDF5Version":"1.12.1",
+  "serverHostname":"MSI",
+  "ServerPort":5555,
+  "numLocales":1,
+  "numPUs":6,
+  "maxTaskPar":6,
+  "physicalMemory":13272535040,
+  "distributionType":"domain(1,int(64),false)",
+  "LocaleConfigs":[{"id":0, "name":"MSI", "numPUs":6, "maxTaskPar":6, "physicalMemory":13272535040}],
+  "authenticate":false,
+  "logLevel":"INFO",
+  "regexMaxCaptures":20,
+  "byteorder":"little",
+  "autoShutdown":true,
+  "serverInfoNoSplash":true,
+  "ARROW_VERSION":"7.0.0"
+}
+```
+
 - `--autoShutdown`
   - This flag toggles whether the arkouda_server will shut itself down when the client disconnects. When set to `true`, `ak.disconnect()` will trigger the server shutdown process.
 

--- a/training/RUNNING_FROM_SCRIPT.md
+++ b/training/RUNNING_FROM_SCRIPT.md
@@ -8,11 +8,12 @@
 
 <a id="overview"></a>
 ## Overview
-The purpose of this document is to provide an example process for using a script to automatically run the Arkouda server, connect to the server, perform required actions, then disconnect from the server without any user interaction required.
+The purpose of this document is to provide an example process for using a script to automatically run the Arkouda server, connect to the server, perform required actions, then shutdown the server without any user interaction required.
+
 
 <a id="flags"></a>
 ## New Server Startup Flags
-Two new flags were added to the arkouda_server startup command to help streamline this type of Arkouda usage. These flags are both boolean flags that are `false` by default.
+Two new flags were added to the arkouda_server startup command to help streamline this type of Arkouda usage. Both flags are booleans that default to `false`.
 
 - `--serverInfoNoSplash`
   - This flag replaces the usual splash message in the output of the server startup with the server configuration JSON. This JSON can then be parsed to read the server host, server port, and any other configuration info you may need.


### PR DESCRIPTION
This PR closes #1922 

This is a document that outlines an example implementation (provided by @Ethan-DeBandi99 ) for running Arkouda using a script with the new server config flags implemented in #1916 and #1920

I'm not sure what other information could be useful to include here, so any feedback is welcome