### PR TITLE
Closes #1926: Fix `+=` for `uint` arrays

### DIFF
--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -753,6 +753,7 @@ module OperatorMsg
                 }
             }
             when (DType.Int64, DType.UInt64) {
+                // The result of operations between int and uint are float by default which doesn't fit in either type
                 var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
                 omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
                 return new MsgTuple(errorMsg, MsgType.ERROR);
@@ -777,6 +778,7 @@ module OperatorMsg
                 }
             }
             when (DType.UInt64, DType.Int64) {
+                // The result of operations between int and uint are float by default which doesn't fit in either type
                 var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
                 omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
                 return new MsgTuple(errorMsg, MsgType.ERROR);
@@ -787,14 +789,7 @@ module OperatorMsg
                 select op {
                     when "+=" { l.a += r.a; }
                     when "-=" {
-                        if || reduce (l.a < r.a) {
-                            // will result in a negative which won't work in a uint
-                            var errorMsg = "Subtracting by an amount larger than self results in a negative";
-                            return new MsgTuple(errorMsg, MsgType.ERROR);
-                        }
-                        else {
-                            l.a -= r.a;
-                        }
+                        l.a -= r.a;
                     }
                     when "*=" { l.a *= r.a; }
                     when "//=" {
@@ -1005,6 +1000,7 @@ module OperatorMsg
                 }
             }
             when (DType.Int64, DType.UInt64) {
+                // The result of operations between int and uint are float by default which doesn't fit in either type
                 var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
                 omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
                 return new MsgTuple(errorMsg, MsgType.ERROR);
@@ -1029,6 +1025,7 @@ module OperatorMsg
                 }
             }
             when (DType.UInt64, DType.Int64) {
+                // The result of operations between int and uint are float by default which doesn't fit in either type
                 var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
                 omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
                 return new MsgTuple(errorMsg, MsgType.ERROR);
@@ -1039,14 +1036,7 @@ module OperatorMsg
                 select op {
                     when "+=" { l.a += val; }
                     when "-=" {
-                        if || reduce (l.a < val) {
-                            // will result in a negative which won't work in a uint
-                            var errorMsg = "Subtracting by an amount larger than self results in a negative";
-                            return new MsgTuple(errorMsg, MsgType.ERROR);
-                        }
-                        else {
-                            l.a -= val;
-                        }
+                        l.a -= val;
                     }
                     when "*=" { l.a *= val; }
                     when "//=" {

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -722,8 +722,7 @@ module OperatorMsg
             when (DType.Int64, DType.Int64) {
                 var l = toSymEntry(left,int);
                 var r = toSymEntry(right,int);
-                select op
-                {
+                select op {
                     when "+=" { l.a += r.a; }
                     when "-=" { l.a -= r.a; }
                     when "*=" { l.a *= r.a; }
@@ -749,7 +748,20 @@ module OperatorMsg
                     otherwise {
                         var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
                         omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);                          
+                        return new MsgTuple(errorMsg, MsgType.ERROR);
+                    }
+                }
+            }
+            when (DType.Int64, DType.UInt64) {
+                var l = toSymEntry(left,int);
+                var r = toSymEntry(right,uint);
+                select op {
+                    when "+=" { l.a += r.a:int; }
+                    when "-=" { l.a -= r.a:int; }
+                    otherwise {
+                        var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
+                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                        return new MsgTuple(errorMsg, MsgType.ERROR);
                     }
                 }
             }
@@ -759,14 +771,95 @@ module OperatorMsg
 
                 var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
                 omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg, MsgType.ERROR);  
+                return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+            when (DType.Int64, DType.Bool) {
+                var l = toSymEntry(left, int);
+                var r = toSymEntry(right, bool);
+                select op {
+                    when "+=" {l.a += r.a:int;}
+                    when "-=" {l.a -= r.a:int;}
+                    when "*=" {l.a *= r.a:int;}
+                    otherwise {
+                        var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
+                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                        return new MsgTuple(errorMsg, MsgType.ERROR);
+                    }
+                }
+            }
+            when (DType.UInt64, DType.Int64) {
+                var l = toSymEntry(left,uint);
+                var r = toSymEntry(right,int);
+
+                var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
+                omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+            when (DType.UInt64, DType.UInt64) {
+                var l = toSymEntry(left,uint);
+                var r = toSymEntry(right,uint);
+                select op {
+                    when "+=" { l.a += r.a; }
+                    when "-=" {
+                        if || reduce (l.a < r.a) {
+                            // will result in a negative which won't work in a uint
+                            var errorMsg = "Subtracting by an amount larger than self results in a negative";
+                            return new MsgTuple(errorMsg, MsgType.ERROR);
+                        }
+                        else {
+                            l.a -= r.a;
+                        }
+                    }
+                    when "*=" { l.a *= r.a; }
+                    when "//=" {
+                        //l.a /= r.a;
+                        ref la = l.a;
+                        ref ra = r.a;
+                        [(li,ri) in zip(la,ra)] li = if ri != 0 then li/ri else 0;
+                    }//floordiv
+                    when "%=" {
+                        //l.a /= r.a;
+                        ref la = l.a;
+                        ref ra = r.a;
+                        [(li,ri) in zip(la,ra)] li = if ri != 0 then li%ri else 0;
+                    }
+                    when "**=" {
+                        l.a **= r.a;
+                    }
+                    otherwise {
+                        var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
+                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                        return new MsgTuple(errorMsg, MsgType.ERROR);
+                    }
+                }
+            }
+            when (DType.UInt64, DType.Float64) {
+                var l = toSymEntry(left,uint);
+                var r = toSymEntry(right,real);
+
+                var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
+                omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+            when (DType.UInt64, DType.Bool) {
+                var l = toSymEntry(left, uint);
+                var r = toSymEntry(right, bool);
+                select op {
+                    when "+=" {l.a += r.a:uint;}
+                    when "-=" {l.a -= r.a:uint;}
+                    when "*=" {l.a *= r.a:uint;}
+                    otherwise {
+                        var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
+                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                        return new MsgTuple(errorMsg, MsgType.ERROR);
+                    }
+                }
             }
             when (DType.Float64, DType.Int64) {
                 var l = toSymEntry(left,real);
                 var r = toSymEntry(right,int);
 
-                select op
-                {
+                select op {
                     when "+=" {l.a += r.a;}
                     when "-=" {l.a -= r.a;}
                     when "*=" {l.a *= r.a;}
@@ -774,21 +867,42 @@ module OperatorMsg
                     when "//=" { //floordiv
                         ref la = l.a;
                         ref ra = r.a;
-                        [(li,ri) in zip(la,ra)] li = if ri != 0 then floor(li / ri) else NAN;
+                        [(li,ri) in zip(la,ra)] li = floorDivisionHelper(li, ri);
                     }
                     when "**=" { l.a **= r.a; }
                     otherwise {
                         var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
                         omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);  
+                        return new MsgTuple(errorMsg, MsgType.ERROR);
+                    }
+                }
+            }
+            when (DType.Float64, DType.UInt64) {
+                var l = toSymEntry(left,real);
+                var r = toSymEntry(right,uint);
+
+                select op {
+                    when "+=" {l.a += r.a;}
+                    when "-=" {l.a -= r.a;}
+                    when "*=" {l.a *= r.a;}
+                    when "/=" {l.a /= r.a:real;} //truediv
+                    when "//=" { //floordiv
+                        ref la = l.a;
+                        ref ra = r.a;
+                        [(li,ri) in zip(la,ra)] li = floorDivisionHelper(li, ri);
+                    }
+                    when "**=" { l.a **= r.a; }
+                    otherwise {
+                        var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
+                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                        return new MsgTuple(errorMsg, MsgType.ERROR);
                     }
                 }
             }
             when (DType.Float64, DType.Float64) {
                 var l = toSymEntry(left,real);
                 var r = toSymEntry(right,real);
-                select op
-                {
+                select op {
                     when "+=" {l.a += r.a;}
                     when "-=" {l.a -= r.a;}
                     when "*=" {l.a *= r.a;}
@@ -796,58 +910,41 @@ module OperatorMsg
                     when "//=" { //floordiv
                         ref la = l.a;
                         ref ra = r.a;
-                        [(li,ri) in zip(la,ra)] li = if ri != 0 then floor(li / ri) else NAN;
+                        [(li,ri) in zip(la,ra)] li = floorDivisionHelper(li, ri);
                     }
                     when "**=" { l.a **= r.a; }
                     otherwise {
                         var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
                         omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);      
-                    }
-                }
-            }
-            when (DType.Bool, DType.Bool) {
-                var l = toSymEntry(left, bool);
-                var r = toSymEntry(right, bool);
-                select op
-                {
-                    when "|=" {l.a |= r.a;}
-                    when "&=" {l.a &= r.a;}
-                    when "^=" {l.a ^= r.a;}
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);                          
-                    }
-                }
-            }
-            when (DType.Int64, DType.Bool) {
-                var l = toSymEntry(left, int);
-                var r = toSymEntry(right, bool);
-                select op
-                { 
-                    when "+=" {l.a += r.a:int;}
-                    when "-=" {l.a -= r.a:int;}
-                    when "*=" {l.a *= r.a:int;}
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);                          
+                        return new MsgTuple(errorMsg, MsgType.ERROR);
                     }
                 }
             }
             when (DType.Float64, DType.Bool) {
                 var l = toSymEntry(left, real);
                 var r = toSymEntry(right, bool);
-                select op
-                {
+                select op {
                     when "+=" {l.a += r.a:real;}
                     when "-=" {l.a -= r.a:real;}
                     when "*=" {l.a *= r.a:real;}
                     otherwise {
                         var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
                         omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);                          
+                        return new MsgTuple(errorMsg, MsgType.ERROR);
+                    }
+                }
+            }
+            when (DType.Bool, DType.Bool) {
+                var l = toSymEntry(left, bool);
+                var r = toSymEntry(right, bool);
+                select op {
+                    when "|=" {l.a |= r.a;}
+                    when "&=" {l.a &= r.a;}
+                    when "^=" {l.a ^= r.a;}
+                    otherwise {
+                        var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
+                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                        return new MsgTuple(errorMsg, MsgType.ERROR);
                     }
                 }
             }
@@ -855,10 +952,9 @@ module OperatorMsg
                 var errorMsg = unrecognizedTypeError(pn,
                                   "("+dtype2str(left.dtype)+","+dtype2str(right.dtype)+")");
                 omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg, MsgType.ERROR);                                 
+                return new MsgTuple(errorMsg, MsgType.ERROR);
             }
         }
-
         repMsg = "opeqvv success";
         omLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
         return new MsgTuple(repMsg, MsgType.NORMAL);
@@ -898,23 +994,22 @@ module OperatorMsg
             when (DType.Int64, DType.Int64) {
                 var l = toSymEntry(left,int);
                 var val = value.getIntValue();
-                select op
-                {
+                select op {
                     when "+=" { l.a += val; }
                     when "-=" { l.a -= val; }
                     when "*=" { l.a *= val; }
-                    when "//=" { 
+                    when "//=" {
                         if val != 0 {l.a /= val;} else {l.a = 0;}
                     }//floordiv
-                    when "%=" { 
+                    when "%=" {
                         if val != 0 {l.a %= val;} else {l.a = 0;}
                     }
-                    when "**=" { 
-                        if (val<0){
+                    when "**=" {
+                        if (val<0) {
                             var errorMsg = "Attempt to exponentiate base of type Int64 to negative exponent";
                             omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),
                                                                               errorMsg);
-                            return new MsgTuple(errorMsg, MsgType.ERROR);                              
+                            return new MsgTuple(errorMsg, MsgType.ERROR);
                         }
                         else{ l.a **= val; }
 
@@ -926,50 +1021,23 @@ module OperatorMsg
                     }
                 }
             }
+            when (DType.Int64, DType.UInt64) {
+                var l = toSymEntry(left,int);
+                var val = value.getUIntValue();
+                select op {
+                    when "+=" { l.a += val:int; }
+                    when "-=" { l.a -= val:int; }
+                    otherwise {
+                        var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
+                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                        return new MsgTuple(errorMsg, MsgType.ERROR);
+                    }
+                }
+            }
             when (DType.Int64, DType.Float64) {
                 var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
                 omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg, MsgType.ERROR);  
-            }
-            when (DType.Float64, DType.Int64) {
-                var l = toSymEntry(left,real);
-                var val = value.getIntValue();
-                select op
-                {
-                    when "+=" {l.a += val;}
-                    when "-=" {l.a -= val;}
-                    when "*=" {l.a *= val;}
-                    when "/=" {l.a /= val:real;} //truediv
-                    when "//=" { //floordiv
-                        if val != 0 {l.a = floor(l.a / val);} else {l.a = NAN;}
-                    }
-                    when "**=" { l.a **= val; }
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);                          
-                    }
-                }
-            }
-            when (DType.Float64, DType.Float64) {
-                var l = toSymEntry(left,real);
-                var val = value.getRealValue();
-                select op
-                {
-                    when "+=" {l.a += val;}
-                    when "-=" {l.a -= val;}
-                    when "*=" {l.a *= val;}
-                    when "/=" {l.a /= val;}//truediv
-                    when "//=" { //floordiv
-                        if val != 0 {l.a = floor(l.a / val);} else {l.a = NAN;}
-                    }
-                    when "**=" { l.a **= val; }
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);                         
-                    }
-                }
+                return new MsgTuple(errorMsg, MsgType.ERROR);
             }
             when (DType.Int64, DType.Bool) {
                 var l = toSymEntry(left, int);
@@ -981,7 +1049,127 @@ module OperatorMsg
                     otherwise {
                         var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
                         omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);                         
+                        return new MsgTuple(errorMsg, MsgType.ERROR);
+                    }
+                }
+            }
+            when (DType.UInt64, DType.Int64) {
+                var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
+                omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+            when (DType.UInt64, DType.UInt64) {
+                var l = toSymEntry(left,uint);
+                var val = value.getUIntValue();
+                select op {
+                    when "+=" { l.a += val; }
+                    when "-=" {
+                        if || reduce (l.a < val) {
+                            // will result in a negative which won't work in a uint
+                            var errorMsg = "Subtracting by an amount larger than self results in a negative";
+                            return new MsgTuple(errorMsg, MsgType.ERROR);
+                        }
+                        else {
+                            l.a -= val;
+                        }
+                    }
+                    when "*=" { l.a *= val; }
+                    when "//=" {
+                        if val != 0 {l.a /= val;} else {l.a = 0;}
+                    }//floordiv
+                    when "%=" {
+                        if val != 0 {l.a %= val;} else {l.a = 0;}
+                    }
+                    when "**=" {
+                        l.a **= val;
+                    }
+                    otherwise {
+                        var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
+                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                        return new MsgTuple(errorMsg, MsgType.ERROR);
+                    }
+                }
+            }
+            when (DType.UInt64, DType.Float64) {
+                var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
+                omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+            when (DType.UInt64, DType.Bool) {
+                var l = toSymEntry(left, uint);
+                var val = value.getBoolValue();
+                select op {
+                    when "+=" {l.a += val:uint;}
+                    when "-=" {l.a -= val:uint;}
+                    when "*=" {l.a *= val:uint;}
+                    otherwise {
+                        var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
+                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                        return new MsgTuple(errorMsg, MsgType.ERROR);
+                    }
+                }
+            }
+            when (DType.Float64, DType.Int64) {
+                var l = toSymEntry(left,real);
+                var val = value.getIntValue();
+                select op {
+                    when "+=" {l.a += val;}
+                    when "-=" {l.a -= val;}
+                    when "*=" {l.a *= val;}
+                    when "/=" {l.a /= val:real;} //truediv
+                    when "//=" { //floordiv
+                        ref la = l.a;
+                        [li in la] li = floorDivisionHelper(li, val);
+                    }
+                    when "**=" { l.a **= val; }
+                    otherwise {
+                        var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
+                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                        return new MsgTuple(errorMsg, MsgType.ERROR);
+                    }
+                }
+            }
+            when (DType.Float64, DType.UInt64) {
+                var l = toSymEntry(left,real);
+                var val = value.getUIntValue();
+                select op {
+                    when "+=" { l.a += val; }
+                    when "-=" { l.a -= val; }
+                    when "*=" { l.a *= val; }
+                    when "//=" {
+                        ref la = l.a;
+                        [li in la] li = floorDivisionHelper(li, val);
+                    }//floordiv
+                    when "%=" {
+                        if val != 0 {l.a %= val;} else {l.a = 0;}
+                    }
+                    when "**=" {
+                        l.a **= val;
+                    }
+                    otherwise {
+                        var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
+                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                        return new MsgTuple(errorMsg, MsgType.ERROR);
+                    }
+                }
+            }
+            when (DType.Float64, DType.Float64) {
+                var l = toSymEntry(left,real);
+                var val = value.getRealValue();
+                select op {
+                    when "+=" {l.a += val;}
+                    when "-=" {l.a -= val;}
+                    when "*=" {l.a *= val;}
+                    when "/=" {l.a /= val;}//truediv
+                    when "//=" { //floordiv
+                        ref la = l.a;
+                        [li in la] li = floorDivisionHelper(li, val);
+                    }
+                    when "**=" { l.a **= val; }
+                    otherwise {
+                        var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
+                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                        return new MsgTuple(errorMsg, MsgType.ERROR);
                     }
                 }
             }
@@ -995,7 +1183,7 @@ module OperatorMsg
                     otherwise {
                         var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
                         omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);                          
+                        return new MsgTuple(errorMsg, MsgType.ERROR);
                     }
                 }
             }
@@ -1003,10 +1191,9 @@ module OperatorMsg
                 var errorMsg = unrecognizedTypeError(pn,
                                    "("+dtype2str(left.dtype)+","+dtype2str(dtype)+")");
                 omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                                           
-                return new MsgTuple(errorMsg, MsgType.ERROR);                
+                return new MsgTuple(errorMsg, MsgType.ERROR);
             }
         }
-
         repMsg = "opeqvs success";
         omLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
         return new MsgTuple(repMsg, MsgType.NORMAL);

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -753,22 +753,11 @@ module OperatorMsg
                 }
             }
             when (DType.Int64, DType.UInt64) {
-                var l = toSymEntry(left,int);
-                var r = toSymEntry(right,uint);
-                select op {
-                    when "+=" { l.a += r.a:int; }
-                    when "-=" { l.a -= r.a:int; }
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);
-                    }
-                }
+                var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
+                omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                return new MsgTuple(errorMsg, MsgType.ERROR);
             }
             when (DType.Int64, DType.Float64) {
-                var l = toSymEntry(left,int);
-                var r = toSymEntry(right,real);
-
                 var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
                 omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
                 return new MsgTuple(errorMsg, MsgType.ERROR);
@@ -788,9 +777,6 @@ module OperatorMsg
                 }
             }
             when (DType.UInt64, DType.Int64) {
-                var l = toSymEntry(left,uint);
-                var r = toSymEntry(right,int);
-
                 var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
                 omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
                 return new MsgTuple(errorMsg, MsgType.ERROR);
@@ -834,9 +820,6 @@ module OperatorMsg
                 }
             }
             when (DType.UInt64, DType.Float64) {
-                var l = toSymEntry(left,uint);
-                var r = toSymEntry(right,real);
-
                 var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
                 omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
                 return new MsgTuple(errorMsg, MsgType.ERROR);
@@ -1005,7 +988,7 @@ module OperatorMsg
                         if val != 0 {l.a %= val;} else {l.a = 0;}
                     }
                     when "**=" {
-                        if (val<0) {
+                        if val<0 {
                             var errorMsg = "Attempt to exponentiate base of type Int64 to negative exponent";
                             omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),
                                                                               errorMsg);
@@ -1022,17 +1005,9 @@ module OperatorMsg
                 }
             }
             when (DType.Int64, DType.UInt64) {
-                var l = toSymEntry(left,int);
-                var val = value.getUIntValue();
-                select op {
-                    when "+=" { l.a += val:int; }
-                    when "-=" { l.a -= val:int; }
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);
-                    }
-                }
+                var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
+                omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                return new MsgTuple(errorMsg, MsgType.ERROR);
             }
             when (DType.Int64, DType.Float64) {
                 var errorMsg = notImplementedError(pn,left.dtype,op,dtype);

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -561,7 +561,7 @@ class OperatorsTest(ArkoudaTest):
 
         # the only arrays that can be added in place are uint and bool
         # scalars are cast to same type if possible
-        for v in [u_arr, b_arr, u, b, i, f]:
+        for v in [b_arr, u, b, i, f]:
             u_tmp = u_arr[:]
             i_tmp = i_arr[:]
             u_tmp += v
@@ -580,9 +580,8 @@ class OperatorsTest(ArkoudaTest):
             u_arr -= 7
 
         # verify other types can have uint applied to them
-        for a in [i_arr, f_arr]:
-            a += u_arr
-            a += u
+        f_arr += u_arr
+        f_arr += u
 
     def testAllOperators(self):
         run_tests(verbose)

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -573,12 +573,6 @@ class OperatorsTest(ArkoudaTest):
             with self.assertRaises(RuntimeError):
                 u_arr += e
 
-        # test that subtraction which would be negative produces an error
-        with self.assertRaises(RuntimeError):
-            u_arr -= ak.full(10, 7, ak.uint64)
-        with self.assertRaises(RuntimeError):
-            u_arr -= 7
-
         # verify other types can have uint applied to them
         f_arr += u_arr
         f_arr += u

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -512,6 +512,78 @@ class OperatorsTest(ArkoudaTest):
         a = ak.arange(5)
         self.assertListEqual([i if i % 2 else i**.5 for i in range(5)], ak.sqrt(a, a % 2 == 0).to_list())
 
+    def test_uint_operation_equals(self):
+        u_arr = ak.arange(10, dtype=ak.uint64)
+        i_arr = ak.arange(10)
+        f_arr = ak.linspace(1, 5, 10)
+        b_arr = i_arr % 2 == 0
+        u = np.uint(7)
+        i = 7
+        f = 3.14
+        b = True
+
+        # test uint opequals uint functionality against numpy
+        np_arr = np.arange(10, dtype=np.uint)
+        u_tmp = u_arr[:]
+        u_tmp += u
+        np_arr += u
+        self.assertListEqual(u_tmp.to_list(), np_arr.tolist())
+        u_tmp += u_tmp
+        np_arr += np_arr
+        self.assertListEqual(u_tmp.to_list(), np_arr.tolist())
+        u_tmp -= u
+        np_arr -= u
+        self.assertListEqual(u_tmp.to_list(), np_arr.tolist())
+        u_tmp -= u_tmp
+        np_arr -= np_arr
+        self.assertListEqual(u_tmp.to_list(), np_arr.tolist())
+        u_tmp *= u
+        np_arr *= u
+        self.assertListEqual(u_tmp.to_list(), np_arr.tolist())
+        u_tmp *= u_tmp
+        np_arr *= np_arr
+        self.assertListEqual(u_tmp.to_list(), np_arr.tolist())
+        u_tmp **= u
+        np_arr **= u
+        self.assertListEqual(u_tmp.to_list(), np_arr.tolist())
+        u_tmp **= u_tmp
+        np_arr **= np_arr
+        self.assertListEqual(u_tmp.to_list(), np_arr.tolist())
+        u_tmp %= u
+        np_arr %= u
+        self.assertListEqual(u_tmp.to_list(), np_arr.tolist())
+        u_tmp //= u
+        np_arr //= u
+        self.assertListEqual(u_tmp.to_list(), np_arr.tolist())
+        u_tmp //= u_tmp
+        np_arr //= np_arr
+        self.assertListEqual(u_tmp.to_list(), np_arr.tolist())
+
+        # the only arrays that can be added in place are uint and bool
+        # scalars are cast to same type if possible
+        for v in [u_arr, b_arr, u, b, i, f]:
+            u_tmp = u_arr[:]
+            i_tmp = i_arr[:]
+            u_tmp += v
+            i_tmp += v
+            self.assertListEqual(u_tmp.to_list(), i_tmp.to_list())
+
+        # adding a float or int inplace could have a result which is not a uint
+        for e in [i_arr, f_arr]:
+            with self.assertRaises(RuntimeError):
+                u_arr += e
+
+        # test that subtraction which would be negative produces an error
+        with self.assertRaises(RuntimeError):
+            u_arr -= ak.full(10, 7, ak.uint64)
+        with self.assertRaises(RuntimeError):
+            u_arr -= 7
+
+        # verify other types can have uint applied to them
+        for a in [i_arr, f_arr]:
+            a += u_arr
+            a += u
+
     def testAllOperators(self):
         run_tests(verbose)
 


### PR DESCRIPTION
This PR (closes #1926):
- Adds support for operation equals with uint arrays and scalars
- Adds a test of this functionality
- Updates `//=` with reals to use `floorDivisionHelper` to ensure proper behavior for corner cases

NOTE:
Currently for `arr opequals scalar` we cast the scalar to the return type if possible, I left this the same for this PR. But I'm not sure if this is the behavior users would expect, so I wanted to get input from others.
```python
>>> u_arr = ak.arange(10, dtype=ak.uint64)
>>> u_arr
array([0 1 2 3 4 5 6 7 8 9])

>>> u_arr += 3.14
>>> u_arr
array([3 4 5 6 7 8 9 10 11 12])

>>> u_arr += -7
>>> u_arr
array([18446744073709551612 18446744073709551613 18446744073709551614 18446744073709551615 0 1 2 3 4 5])
```

Co-authored-by: jaketrookman <jaketrookman@users.noreply.github.com>