### PR TITLE
Prototype distributed domains caching

### DIFF
--- a/src/SymArrayDmap.chpl
+++ b/src/SymArrayDmap.chpl
@@ -17,6 +17,7 @@ module SymArrayDmap
     config param MyDmap:Dmap = defaultDmap;
 
     public use BlockDist;
+    use Map;
 
     /* 
     Makes a domain distributed according to :param:`MyDmap`.
@@ -24,7 +25,7 @@ module SymArrayDmap
     :arg size: size of domain
     :type size: int
     */
-    proc makeDistDom(size:int) {
+    proc rawMakeDistDom(size:int) {
         select MyDmap
         {
             when Dmap.defaultRectangular {
@@ -41,6 +42,19 @@ module SymArrayDmap
                 halt("Unsupported distribution " + MyDmap:string);
             }
         }
+    }
+
+    class BoxedDistDom {
+      const size: int;
+      const d = rawMakeDistDom(size);
+    }
+    var tab: map(int, shared BoxedDistDom);
+
+    proc makeDistDom(size:int) const ref {
+      if !tab.contains(size) {
+        tab.add(size, new shared BoxedDistDom(size));
+      }
+      return tab.getReference(size).d;
     }
     
     /* 


### PR DESCRIPTION
Creating distributed domains has been optimized over the last several Chapel releases, but there is still a non-trivial creation overhead.

This prototypes caching distributed domains in a map to avoid recreating them each time. This has some minor performance benefits to SymEntry creation, which results in a ~5% speedup for things like stream and dataframe-display.

For now I just wanted to prototype this to evaluate performance, but I think if we want something like this it shouldn't be an unbounded cache, but some sort of LRU cache that only stores a couple of