### PR TITLE
Closes #1935: Increase encode benchmark size

### DIFF
--- a/benchmarks/encode.py
+++ b/benchmarks/encode.py
@@ -72,7 +72,7 @@ def create_parser():
     parser.add_argument("hostname", help="Hostname of arkouda server")
     parser.add_argument("port", type=int, help="Port of arkouda server")
     parser.add_argument(
-        "-n", "--size", type=int, default=10**5, help="Problem size: length of array to argsort"
+        "-n", "--size", type=int, default=10**7, help="Problem size: length of array to argsort"
     )
     parser.add_argument(
         "-t", "--trials", type=int, default=1, help="Number of times to run the benchmark"

--- a/benchmarks/encode.py
+++ b/benchmarks/encode.py
@@ -72,7 +72,7 @@ def create_parser():
     parser.add_argument("hostname", help="Hostname of arkouda server")
     parser.add_argument("port", type=int, help="Port of arkouda server")
     parser.add_argument(
-        "-n", "--size", type=int, default=10**7, help="Problem size: length of array to argsort"
+        "-n", "--size", type=int, default=10**7, help="Problem size: length of array to encode"
     )
     parser.add_argument(
         "-t", "--trials", type=int, default=1, help="Number of times to run the benchmark"


### PR DESCRIPTION
The codec default problem size is very small today because the unoptimized code was much less performant, so it needed to be small for the old code to finish in a reasonable amount of time. Now that it is more optimized, increasing the problem size will give us a better read of the performance.