### PR TITLE
Closes #1938: Remove `float %= uint`

### DIFF
--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -1105,9 +1105,6 @@ module OperatorMsg
                         ref la = l.a;
                         [li in la] li = floorDivisionHelper(li, val);
                     }//floordiv
-                    when "%=" {
-                        if val != 0 {l.a %= val;} else {l.a = 0;}
-                    }
                     when "**=" {
                         l.a **= val;
                     }


### PR DESCRIPTION
This PR (closes #1938) removes support for `float %= uint` because this functionality is not currently supported by chapel main (see #1930). I do think we want this at some point to be in line with numpy (see #1939).