### PR TITLE
Closes 1943: Quiet deprecation warnings in prep for Chapel 1.29

### DIFF
--- a/src/FileIO.chpl
+++ b/src/FileIO.chpl
@@ -20,7 +20,7 @@ module FileIO {
     enum FileType {HDF5, ARROW, PARQUET, UNKNOWN};
 
     proc appendFile(filePath : string, line : string) throws {
-        var writer : channel;
+        var writer;
         if exists(filePath) {
             use Version;
             var aFile = open(filePath, iomode.rw);
@@ -40,9 +40,8 @@ module FileIO {
     }
 
     proc writeToFile(filePath : string, line : string) throws {
-        var writer : channel;
         var aFile = open(filePath, iomode.cwr);
-        writer = aFile.writer();
+        var writer = aFile.writer();
 
         writer.writeln(line);
         writer.flush();
@@ -50,9 +49,8 @@ module FileIO {
     }
     
     proc writeLinesToFile(filePath : string, lines : string) throws {
-        var writer : channel;
         var aFile = open(filePath, iomode.cwr);
-        writer = aFile.writer();
+        var writer = aFile.writer();
 
         for line in lines {
             writer.writeln(line);
@@ -82,7 +80,7 @@ module FileIO {
     
     proc getLineFromFile(path: string, match: string) throws {
         var aFile = open(path, iomode.r);
-        var reader: channel = aFile.reader();
+        var reader = aFile.reader();
         var returnLine: string;
 
         for line in reader.lines() {

--- a/src/FileIO.chpl
+++ b/src/FileIO.chpl
@@ -22,13 +22,9 @@ module FileIO {
     proc appendFile(filePath : string, line : string) throws {
         var writer;
         if exists(filePath) {
-            use Version;
+            use ArkoudaFileCompat;
             var aFile = open(filePath, iomode.rw);
-            if chplVersion >= createVersion(1,28) {
-              writer = aFile.writer(region=aFile.size..);
-            } else {
-              writer = aFile.writer(start=aFile.size);
-            }
+            writer = aFile.appendWriter();
         } else {
             var aFile = open(filePath, iomode.cwr);
             writer = aFile.writer();

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -22,7 +22,7 @@ module IndexingMsg
     const imLogger = new Logger(logLevel);
 
     proc jsonToTuple(json: string, type t) throws {
-        var f = opentmp(); defer { ensureClose(f); }
+        var f = openmem(); defer { ensureClose(f); }
         var w = f.writer();
         w.write(json);
         w.close();

--- a/src/Message.chpl
+++ b/src/Message.chpl
@@ -421,7 +421,7 @@ module Message {
      * Converts the JSON array to a pdarray
      */
     proc jsonToPdArray(json: string, size: int) throws {
-        var f = opentmp(); defer { ensureClose(f); }
+        var f = openmem(); defer { ensureClose(f); }
         var w = f.writer();
         w.write(json);
         w.close();

--- a/src/RegistrationMsg.chpl
+++ b/src/RegistrationMsg.chpl
@@ -11,6 +11,7 @@ module RegistrationMsg
     use List;
     use Map;
     use Set;
+    use Sort;
 
     use MultiTypeSymbolTable;
     use MultiTypeSymEntry;
@@ -241,7 +242,7 @@ module RegistrationMsg
         // if Series matches MultiIndex format
         if st.contains("%s_key_0".format(name)) {
             var nameList = st.findAll("%s_key_\\d".format(name));
-            nameList = nameList.sorted();  // Sort the list to return the indexes in order from 0 to N
+            sort(nameList);
             for regName in nameList {
                 var entry = st.attrib(regName);
                 if (regName.startsWith("Error:")) { 

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -8,7 +8,7 @@ module SegmentedArray {
     use Logging;
     use ServerErrors;
     use CommAggregation;
-    use Time only Timer, getCurrentTime;
+    use Time only getCurrentTime;
     use Map;
 
     private config const logLevel = ServerConfig.logLevel;

--- a/src/SegmentedString.chpl
+++ b/src/SegmentedString.chpl
@@ -11,7 +11,7 @@ module SegmentedString {
   use PrivateDist;
   use ServerConfig;
   use Unique;
-  use Time only Timer, getCurrentTime;
+  use Time only getCurrentTime;
   use Reflection;
   use Logging;
   use ServerErrors;
@@ -340,26 +340,24 @@ module SegmentedString {
        this permutation will not sort the strings, but all equivalent strings
        will fall in one contiguous block. */
     proc argGroup() throws {
-      var t = new Timer();
       if useHash {
         // Hash all strings
         ssLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "Hashing strings"); 
-        if logLevel == LogLevel.DEBUG { t.start(); }
+        var t1: real;
+        if logLevel == LogLevel.DEBUG { t1 = getCurrentTime(); }
         var hashes = this.siphash();
 
         if logLevel == LogLevel.DEBUG { 
-            t.stop();    
             ssLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                           "hashing took %t seconds\nSorting hashes".format(t.elapsed())); 
-            t.clear(); t.start(); 
+                           "hashing took %t seconds\nSorting hashes".format(getCurrentTime() - t1));
+            t1 = getCurrentTime();
         }
 
         // Return the permutation that sorts the hashes
         var iv = radixSortLSD_ranks(hashes);
         if logLevel == LogLevel.DEBUG { 
-            t.stop(); 
             ssLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                            "sorting took %t seconds".format(t.elapsed())); 
+                                            "sorting took %t seconds".format(getCurrentTime() - t1));
         }
         if logLevel == LogLevel.DEBUG {
           var sortedHashes = [i in iv] hashes[i];

--- a/src/ServerDaemon.chpl
+++ b/src/ServerDaemon.chpl
@@ -4,7 +4,7 @@ module ServerDaemon {
     use Security;
     use ServerConfig;
     use ServerErrors;
-    use Time only;
+    use Time;
     use ZMQ only;
     use Memory;
     use FileSystem;
@@ -409,9 +409,7 @@ module ServerDaemon {
             }
             this.registerServerCommands();
                     
-            var t1 = new Time.Timer();
-            t1.clear();
-            t1.start();            
+            var startTime = getCurrentTime();
         
             while !this.shutdownDaemon {
                 // receive message on the zmq socket
@@ -419,7 +417,7 @@ module ServerDaemon {
 
                 this.reqCount += 1;
 
-                var s0 = t1.elapsed();
+                var s0 = getCurrentTime();
         
                 /*
                  * Separate the first tuple, which is a string binary containing the JSON binary
@@ -503,7 +501,7 @@ module ServerDaemon {
                     if (trace) {
                         sdLogger.info(getModuleName(),getRoutineName(),getLineNumber(),
                                         "<<< shutdown initiated by %s took %.17r sec".format(user, 
-                                                t1.elapsed() - s0));
+                                                getCurrentTime() - s0));
                     }
                 }
 
@@ -579,7 +577,7 @@ module ServerDaemon {
                  */
                 if trace {
                     sdLogger.info(getModuleName(),getRoutineName(),getLineNumber(), 
-                                              "<<< %s took %.17r sec".format(cmd, t1.elapsed() - s0));
+                                              "<<< %s took %.17r sec".format(cmd, getCurrentTime() - s0));
                 }
                 if (trace && memTrack) {
                     sdLogger.info(getModuleName(),getRoutineName(),getLineNumber(),
@@ -595,7 +593,7 @@ module ServerDaemon {
                                                         user=user));
                 if trace {
                     sdLogger.error(getModuleName(),getRoutineName(),getLineNumber(),
-                        "<<< %s resulted in error %s in  %.17r sec".format(cmd, e.msg, t1.elapsed() - s0));
+                        "<<< %s resulted in error %s in  %.17r sec".format(cmd, e.msg, getCurrentTime() - s0));
                 }
             } catch (e: Error) {
                 // Generate a ReplyMsg of type ERROR and serialize to a JSON-formatted string
@@ -610,19 +608,19 @@ module ServerDaemon {
                 if trace {
                     sdLogger.error(getModuleName(), getRoutineName(), getLineNumber(), 
                     "<<< %s resulted in error: %s in %.17r sec".format(cmd, e.message(),
-                                                                                 t1.elapsed() - s0));
+                                                                                 getCurrentTime() - s0));
                 }
             }
         }
 
-        t1.stop();
+        var elapsed = getCurrentTime() - startTime;
 
         deleteServerConnectionInfo();
 
         sdLogger.info(getModuleName(), getRoutineName(), getLineNumber(),
             "requests = %i responseCount = %i elapsed sec = %i".format(reqCount,
                                                                        repCount,
-                                                                       t1.elapsed()));
+                                                                       elapsed));
         this.shutdown(); 
         }
     }

--- a/src/compat/e-127/ArkoudaFileCompat.chpl
+++ b/src/compat/e-127/ArkoudaFileCompat.chpl
@@ -1,0 +1,6 @@
+module ArkoudaFileCompat {
+  use IO;
+  proc file.appendWriter() throws {
+    return this.writer(start=this.size);
+  }
+}

--- a/src/compat/ge-128/ArkoudaFileCompat.chpl
+++ b/src/compat/ge-128/ArkoudaFileCompat.chpl
@@ -1,0 +1,6 @@
+module ArkoudaFileCompat {
+  use IO;
+  proc file.appendWriter() throws {
+    return this.writer(region=this.size..);
+  }
+}


### PR DESCRIPTION
There are a number of new deprecations in Chapel 1.29. Quiet them here while maintaining compatibly (and quiet builds) for 1.27/1.28. The specific changes are:

- Handle `channel` type deprecation: The `channel` type is deprecated in favor of `fileReader`/`fileWriter`, but we don't actually need to refer to the type so just avoid it.
- Handle `Array.sorted` deprecation: `Array.sorted` is deprecated in favor of just calling the pre-existing `sort(Array)`
- Handle `Timer` deprecation: `Timer` is deprecated in favor of `stopwatch`, but most places in arkouda use `getCurrentTime()` so I just switched to that style for the few places using a timer.
- Handle `opentmp` deprecation: `opentmp` is deprecated in favor of `openTempFile`, but we didn't actually need a file here, so just use `openmem` instead.
- Handle `createVersion()` deprecation: `createVersion()` is deprecated in favor of `new versionValue()`. This version check was being used as a compatibility shim, so just create a real compat shim for appending to the end of an existing file instead of doing a version check in source.

Closes #1943