### PR TITLE
Closes #1947 - Conversion Error when IPv4 is Index

### DIFF
--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -101,8 +101,8 @@ class Index:
             return MultiIndex(index)
 
     def to_pandas(self):
-        val = convert_if_categorical(self.values)
-        return pd.Index(data=val.to_ndarray(), dtype=self.dtype, name=self.name)
+        val = convert_if_categorical(self.values).to_ndarray()
+        return pd.Index(data=val, dtype=val.dtype, name=self.name)
 
     def to_ndarray(self):
         val = convert_if_categorical(self.values)

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -387,6 +387,11 @@ class DataFrameTest(ArkoudaTest):
         self.assertListEqual(c.index.to_list(), ["Bob", "Alice", "Carol"])
         self.assertListEqual(c.values.to_list(), [2, 3, 1])
 
+        # testing counts with IPv4 column
+        s = ak.DataFrame({'a': ak.IPv4(ak.array([1, 2, 3, 4]))}).groupby('a').count()
+        pds = pd.Series(data=np.array([1, 1, 1, 1]), index=pd.Index(data=np.array(['0.0.0.1', '0.0.0.2', '0.0.0.3', '0.0.0.4'], dtype="<U7")))
+        self.assertTrue(s.to_pandas().equals(other=pds))
+
     def test_to_pandas(self):
         df = build_ak_df()
         pd_df = build_pd_df()

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -388,8 +388,10 @@ class DataFrameTest(ArkoudaTest):
         self.assertListEqual(c.values.to_list(), [2, 3, 1])
 
         # testing counts with IPv4 column
-        s = ak.DataFrame({'a': ak.IPv4(ak.array([1, 2, 3, 4]))}).groupby('a').count()
-        pds = pd.Series(data=np.array([1, 1, 1, 1]), index=pd.Index(data=np.array(['0.0.0.1', '0.0.0.2', '0.0.0.3', '0.0.0.4'], dtype="<U7")))
+        s = ak.DataFrame({'a': ak.IPv4(ak.arange(1, 5))}).groupby('a').count()
+        pds = pd.Series(data=np.ones(4, dtype=np.int64), index=pd.Index(data=np.array(['0.0.0.1', '0.0.0.2', '0.0.0.3', '0.0.0.4'], dtype="<U7")))
+        print(pds)
+        print(s.to_pandas())
         self.assertTrue(s.to_pandas().equals(other=pds))
 
     def test_to_pandas(self):


### PR DESCRIPTION
Closes #1947 

Updates `ak.Index.to_pandas` method to assign the `dtype` of the pandas object based on the `dtype` of the NumPy object instead of the Arkouda object. Previously if an index contained an `IPv4`, it would attempt to assign the `dtype` to `uint64` because that was the Arkouda `dtype`. This resulted in an attempt to cast the `IPv4` string to `uint64`, causing the error.

Adds testing to ensure proper functionality moving forward based on the example provided in the issue.