### PR TITLE
Closes #1949: Allow conversions with IDNA and non-UTF-8 encodings

### DIFF
--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -396,7 +396,7 @@ class Strings:
                 },
             )
             return Strings.from_return_msg(rep_msg)
-            
+
         rep_msg = generic_msg(
             cmd="encode",
             args={

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -374,6 +374,29 @@ class Strings:
         RuntimeError
             Raised if there is a server-side error thrown
         """
+        if (toEncoding.upper() == "IDNA" and fromEncoding.upper() != "UTF-8") or \
+           (toEncoding.upper() != "UTF-8" and fromEncoding.upper() == "IDNA"):
+            # first convert to UTF-8
+            rep_msg = generic_msg(
+                cmd="encode",
+                args={
+                    "toEncoding": "UTF-8",
+                    "fromEncoding": fromEncoding,
+                    "obj": self.entry,
+                },
+            )
+            intermediate = Strings.from_return_msg(rep_msg)
+            # now go to idna
+            rep_msg = generic_msg(
+                cmd="encode",
+                args={
+                    "toEncoding": toEncoding,
+                    "fromEncoding": "UTF-8",
+                    "obj": intermediate,
+                },
+            )
+            return Strings.from_return_msg(rep_msg)
+            
         rep_msg = generic_msg(
             cmd="encode",
             args={

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -664,6 +664,16 @@ class StringTest(ArkoudaTest):
         a3 = ak.random_strings_uniform(1, 10, UNIQUE, characters="printable")
         self.assertTrue((a3 == a3.encode('ascii').decode('ascii')).all())
 
+    def test_idna_utf16(self):
+        s = ak.array(['xn--mnchen-3ya', 'xn--zrich-kva', 'example.com'])
+
+        # go from idna -> utf-16
+        result = s.encode(fromEncoding='idna', toEncoding='utf-16')
+
+        # roundtrip to return back to decoded values in UTF-8
+        decoded = result.decode(fromEncoding='utf-16', toEncoding="utf-8")
+        self.assertListEqual(["münchen", "zürich", "example.com"], decoded.to_list())
+
     def test_tondarray(self):
         v1 = ["münchen","zürich", "abc", "123", ""]
         s1 = ak.array(v1)


### PR DESCRIPTION
The `idn2` library only supports encoding/decoding IDNA to UTF-8,
so, in order to get to other encodings from IDNA, we can first
convert to UTF-8 through `idn2` and then convert to the desired
encoding through `iconv` (with the process being flipped for
decoding).