### PR TITLE
Closes #1963 - Message Arg failure when List contains `Strings` and `pdarray`

### DIFF
--- a/arkouda/message.py
+++ b/arkouda/message.py
@@ -130,7 +130,7 @@ class ParameterObject:
                 if t not in [pdarray.__name__, Strings.__name__]:
                     t_str = ", ".join(dtypes)
                     raise TypeError(f"Lists of multiple types can only "
-                                    f"conatin strings and pdarray. Found {t_str}")
+                                    f"contain strings and pdarray. Found {t_str}")
             # using pdarray for now. May change in future. This does not impact functionality
             t = pdarray.__name__
         if any(x == t for x in [pdarray.__name__, Strings.__name__]):

--- a/arkouda/message.py
+++ b/arkouda/message.py
@@ -123,10 +123,15 @@ class ParameterObject:
 
         # want the object type. If pdarray the content dtypes can vary
         dtypes = {type(p).__name__ for p in val}
-        if len(dtypes) > 1:
-            t_str = ", ".join(dtypes)
-            raise TypeError(f"List values must be of the same type. Found {t_str}")
-        t = dtypes.pop()
+        if len(dtypes) == 1:
+            t = dtypes.pop()
+        else:
+            for t in dtypes:
+                if t not in [pdarray.__name__, Strings.__name__]:
+                    t_str = ", ".join(dtypes)
+                    raise TypeError(f"Lists of multiple types can only conatin strings and pdarray. Found {t_str}")
+            # using pdarray for now. May change in future. This does not impact functionality
+            t = pdarray.__name__
         if any(x == t for x in [pdarray.__name__, Strings.__name__]):
             return ParameterObject(key, ObjectType.LIST, t, json.dumps([x.name for x in val]))
         else:

--- a/arkouda/message.py
+++ b/arkouda/message.py
@@ -129,7 +129,8 @@ class ParameterObject:
             for t in dtypes:
                 if t not in [pdarray.__name__, Strings.__name__]:
                     t_str = ", ".join(dtypes)
-                    raise TypeError(f"Lists of multiple types can only conatin strings and pdarray. Found {t_str}")
+                    raise TypeError(f"Lists of multiple types can only "
+                                    f"conatin strings and pdarray. Found {t_str}")
             # using pdarray for now. May change in future. This does not impact functionality
             t = pdarray.__name__
         if any(x == t for x in [pdarray.__name__, Strings.__name__]):


### PR DESCRIPTION
Closes #1963 

Updates the logic for parsing message arguments that are lists. Expects lists to contain a single type with the exception of `pdarray` and `Strings`. A list can contain `pdarray` and `Strings` objects. In these cases, the type is set to `pdarray`. This does not have an impact on processing and is simply metadata. 