### PR TITLE
Recommend Chapel 1.29.0 and use it for CI testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.28.0
+      image: chapel/chapel:1.29.0
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies
@@ -32,7 +32,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.28.0
+      image: chapel/chapel:1.29.0
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies
@@ -47,7 +47,7 @@ jobs:
   flake8:
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.28.0
+      image: chapel/chapel:1.29.0
     steps:
       - uses: actions/checkout@v3
       - name: Install Dependencies
@@ -65,7 +65,7 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10']
     container:
-      image: chapel/chapel:1.28.0
+      image: chapel/chapel:1.29.0
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        chpl-version: ['1.27.0', '1.28.0']
+        chpl-version: ['1.27.0', '1.28.0', '1.29.0']
     container:
       image: chapel/chapel:${{matrix.chpl-version}}
     steps:
@@ -131,7 +131,7 @@ jobs:
     env:
       CHPL_RT_NUM_THREADS_PER_LOCALE: ${{matrix.threads}}
     container:
-      image: chapel/${{matrix.image}}:1.28.0
+      image: chapel/${{matrix.image}}:1.29.0
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -49,9 +49,9 @@ sudo apt-get update
 sudo apt-get install gcc g++ m4 perl python3 python3-pip python3-venv python3-dev bash make mawk git pkg-config cmake llvm-12-dev llvm-12 llvm-12-tools clang-12 libclang-12-dev libclang-cpp12-dev libedit-dev
 
 # Download latest Chapel release, explode archive, and navigate to source root directory
-wget https://github.com/chapel-lang/chapel/releases/download/1.28.0/chapel-1.28.0.tar.gz
-tar xvf chapel-1.28.0.tar.gz
-cd chapel-1.28.0/
+wget https://github.com/chapel-lang/chapel/releases/download/1.29.0/chapel-1.29.0.tar.gz
+tar xvf chapel-1.29.0.tar.gz
+cd chapel-1.29.0/
 
 # Set CHPL_HOME
 export CHPL_HOME=$PWD
@@ -156,7 +156,7 @@ for installing Chapel & Arkouda.  We also recommend installing Anaconda for wind
 
 <b>Note:</b> When running `make` to build Chapel while using WSL, pathing issues to library dependencies are common. In most cases, a symlink pointing to the correct location or library will fix these errors.
 
-An example of one of these errors found while using Chapel 1.28.0 and Ubuntu 20.04 LTS with WSL is:
+An example of one of these errors found while using Chapel 1.29.0 and Ubuntu 20.04 LTS with WSL is:
 ```
 ../../../bin/llvm-tblgen: error while loading shared libraries: libtinfow.so.6: cannot open shared object file: No such file or directory
 ````
@@ -201,11 +201,11 @@ For convenience, the steps to install Chapel from source are detailed here. If y
 
 2) Unpack the release
 ```bash
-tar xzf chapel-1.28.0.tar.gz
+tar xzf chapel-1.29.0.tar.gz
 ```
 3) Access the directory created when the release was unpacked
 ```bash
-cd chapel-1.28.0
+cd chapel-1.29.0
 ```
 4) Configure environment variables. *Please Note: This command assumes the use of `bash` or `zsh`. Please refer to the [Chapel Documentation](https://chapel-lang.org/docs/usingchapel/QUICKSTART.html#quickstart-with-other-shells) if you are using another shell.*
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -193,14 +193,14 @@ $(ARROW_O): $(ARROW_CPP) $(ARROW_H)
 
 CHPL_MINOR := $(shell $(CHPL) --version | sed -n "s/chpl version 1\.\([0-9]*\).*/\1/p")
 CHPL_VERSION_OK := $(shell test $(CHPL_MINOR) -ge 27 && echo yes)
-CHPL_VERSION_WARN := $(shell test $(CHPL_MINOR) -le 27 && echo yes)
+CHPL_VERSION_WARN := $(shell test $(CHPL_MINOR) -le 28 && echo yes)
 .PHONY: check-chpl
 check-chpl:
 ifneq ($(CHPL_VERSION_OK),yes)
 	$(error Chapel 1.27.0 or newer is required)
 endif
 ifeq ($(CHPL_VERSION_WARN),yes)
-	$(warning Chapel 1.28.0 or newer is recommended)
+	$(warning Chapel 1.29.0 or newer is recommended)
 endif
 
 ZMQ_CHECK = $(DEP_INSTALL_DIR)/checkZMQ.chpl

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -2,7 +2,7 @@
 
 The dependencies listed here have varying installation instructions depending upon your preferred operating system. Please use in the installation instructions provided in [INSTALL.md](INSTALL.md).
 
-- `Chapel 1.28.0 or later`
+- `Chapel 1.29.0 or later`
 - `cmake>=3.11.0`
 - `zeromq>=4.2.5`
 - `hdf5`

--- a/pydoc/setup/prerequisites.rst
+++ b/pydoc/setup/prerequisites.rst
@@ -7,7 +7,7 @@ Prerequisites
 *******************
 Chapel
 *******************
-(version 1.28.0 or greater)
+(version 1.29.0 or greater)
 
 The arkouda server application is written in Chapel_, a productive and performant parallel programming language. In order to use arkouda, you must first `download the current version of Chapel`_ and build it according to the instructions_ for your platform(s). Below are tips for building Chapel to support arkouda.
 


### PR DESCRIPTION
Chapel 1.29 includes array creation optimizations, which benefits most operations since array creation is common in Arkouda, but in particular operations that create a lot of arrays like binary operations and displaying dataframes.

More details about the 1.29 release can be found at: https://chapel-lang.org/blog/posts/announcing-chapel-1.29/