### PR TITLE
Closes #1876 - Multi-Column Write Parquet

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -1457,7 +1457,7 @@ class DataFrame(UserDict):
             data = {c: self.data[c] for c in columns}
 
         if index:
-            data["Index"] = self.index
+            data["Index"] = self.index.values
         return data
 
     def to_hdf(self, path, index=False, columns=None, file_type="distribute"):

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -862,15 +862,32 @@ def to_parquet(
     >>> # Save using names instead of mapping
     >>> ak.to_parquet([a, b], 'path/name_prefix', names=['a', 'b'])
     """
-    if mode.lower() not in ["append", "truncate"]:
-        raise ValueError("Allowed modes are 'truncate' and 'append'")
-
-    datasetNames, pdarrays = _bulk_write_prep(columns, names)
-
-    for arr, name in zip(pdarrays, cast(List[str], datasetNames)):
-        arr.to_parquet(prefix_path=prefix_path, dataset=name, mode=mode, compressed=compressed)
-        if mode.lower() == "truncate":
-            mode = "append"
+    # if mode.lower() not in ["append", "truncate"]:
+    #     raise ValueError("Allowed modes are 'truncate' and 'append'")
+    #
+    # datasetNames, pdarrays = _bulk_write_prep(columns, names)
+    #
+    # for arr, name in zip(pdarrays, cast(List[str], datasetNames)):
+    #     arr.to_parquet(prefix_path=prefix_path, dataset=name, mode=mode, compressed=compressed)
+    #     if mode.lower() == "truncate":
+    #         mode = "append"
+    print(list(columns.values()))
+    print(list(columns.keys()))
+    print(len(columns.values()))
+    repmsg = cast(
+        str,
+        generic_msg(
+            cmd="toParquet_multi",
+            args={
+                "columns": list(columns.values()),
+                "col_names": list(columns.keys()),
+                "filename": prefix_path,
+                "num_cols": len(columns.values()),
+                "compressed": compressed,
+            },
+        ),
+    )
+    print(repmsg)
 
 
 def to_hdf(

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -883,7 +883,7 @@ def to_parquet(
                     "columns": pdarrays,
                     "col_names": datasetNames,
                     "filename": prefix_path,
-                    "num_cols": len(columns.values()),
+                    "num_cols": len(pdarrays),
                     "compressed": compressed,
                 },
             )

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -1,7 +1,6 @@
 import glob
 import json
 import os
-import warnings
 from typing import Dict, List, Mapping, Optional, Union, cast
 from warnings import warn
 
@@ -334,7 +333,7 @@ def _parse_errors(rep_msg, allow_errors: bool = False):
     file_errors = rep_msg["file_errors"] if "file_errors" in rep_msg else []
     if allow_errors and file_errors:
         file_error_count = rep_msg["file_error_count"] if "file_error_count" in rep_msg else -1
-        warnings.warn(
+        warn(
             f"There were {file_error_count} errors reading files on the server. "
             + f"Sample error messages {file_errors}",
             RuntimeWarning,
@@ -822,10 +821,8 @@ def to_parquet(
     mode : {'truncate' | 'append'}
         By default, truncate (overwrite) the output files if they exist.
         If 'append', attempt to create new dataset in existing files.
-    file_type : str ("single" | "distribute")
-            Default: distribute
-            Single writes the dataset to a single file
-            Distribute writes the dataset to a file per locale
+        'append' is deprecated, please use the multi-column write
+
 
     Returns
     -------
@@ -862,32 +859,32 @@ def to_parquet(
     >>> # Save using names instead of mapping
     >>> ak.to_parquet([a, b], 'path/name_prefix', names=['a', 'b'])
     """
-    # if mode.lower() not in ["append", "truncate"]:
-    #     raise ValueError("Allowed modes are 'truncate' and 'append'")
-    #
-    # datasetNames, pdarrays = _bulk_write_prep(columns, names)
-    #
-    # for arr, name in zip(pdarrays, cast(List[str], datasetNames)):
-    #     arr.to_parquet(prefix_path=prefix_path, dataset=name, mode=mode, compressed=compressed)
-    #     if mode.lower() == "truncate":
-    #         mode = "append"
-    print(list(columns.values()))
-    print(list(columns.keys()))
-    print(len(columns.values()))
-    repmsg = cast(
-        str,
+    if mode.lower() not in ["append", "truncate"]:
+        raise ValueError("Allowed modes are 'truncate' and 'append'")
+
+    if mode.lower() == "append":
+        warn(
+            "Append has been deprecated when writing Parquet files. "
+            "Please write all columns to the file at once.",
+            DeprecationWarning,
+        )
+
+    datasetNames, pdarrays = _bulk_write_prep(columns, names)
+    # append or single column use the old logic
+    if mode.lower() == "append" or len(pdarrays) == 1:
+        for arr, name in zip(pdarrays, cast(List[str], datasetNames)):
+            arr.to_parquet(prefix_path=prefix_path, dataset=name, mode=mode, compressed=compressed)
+    else:
         generic_msg(
             cmd="toParquet_multi",
             args={
-                "columns": list(columns.values()),
-                "col_names": list(columns.keys()),
+                "columns": pdarrays,
+                "col_names": datasetNames,
                 "filename": prefix_path,
                 "num_cols": len(columns.values()),
                 "compressed": compressed,
             },
         ),
-    )
-    print(repmsg)
 
 
 def to_hdf(
@@ -1251,7 +1248,7 @@ def read(
     elif file_format == "parquet":
         cmd = "readAllParquet"
     else:
-        warnings.warn(f"Unrecognized file format string: {file_format}. Inferring file type")
+        warn(f"Unrecognized file format string: {file_format}. Inferring file type")
         cmd = "readany"
     if iterative:  # iterative calls to server readhdf
         return {
@@ -1283,7 +1280,7 @@ def read(
         file_errors = rep["file_errors"] if "file_errors" in rep else []
         if allow_errors and file_errors:
             file_error_count = rep["file_error_count"] if "file_error_count" in rep else -1
-            warnings.warn(
+            warn(
                 f"There were {file_error_count} errors reading files on the server. "
                 + f"Sample error messages {file_errors}",
                 RuntimeWarning,

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -875,16 +875,19 @@ def to_parquet(
         for arr, name in zip(pdarrays, cast(List[str], datasetNames)):
             arr.to_parquet(prefix_path=prefix_path, dataset=name, mode=mode, compressed=compressed)
     else:
-        generic_msg(
-            cmd="toParquet_multi",
-            args={
-                "columns": pdarrays,
-                "col_names": datasetNames,
-                "filename": prefix_path,
-                "num_cols": len(columns.values()),
-                "compressed": compressed,
-            },
-        ),
+        print(cast(
+            str,
+            generic_msg(
+                cmd="toParquet_multi",
+                args={
+                    "columns": pdarrays,
+                    "col_names": datasetNames,
+                    "filename": prefix_path,
+                    "num_cols": len(columns.values()),
+                    "compressed": compressed,
+                },
+            )
+        ))
 
 
 def to_hdf(

--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -14,6 +14,7 @@
 #include <parquet/arrow/writer.h>
 #include <parquet/column_reader.h>
 #include <parquet/api/writer.h>
+#include <queue>
 extern "C" {
 #endif
 
@@ -85,12 +86,12 @@ extern "C" {
                                 char** errMsg);
   
   int c_writeMultiColToParquet(const char* filename, void* column_names, 
-                                void** ptr_arr, void** offset_ptrs, void* datatypes,
+                                void** ptr_arr, void* datatypes,
                                 int64_t colnum, int64_t numelems, int64_t rowGroupSize,
                                 bool compressed, char** errMsg);
 
   int cpp_writeMultiColToParquet(const char* filename, void* column_names, 
-                                  void** ptr_arr, void** offset_ptrs, void* datatypes,
+                                  void** ptr_arr, void* datatypes,
                                   int64_t colnum, int64_t numelems, int64_t rowGroupSize,
                                   bool compressed, char** errMsg);
     

--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -3,9 +3,13 @@
 
 // Wrap functions in C extern if compiling C++ object file
 #ifdef __cplusplus
+#include <cassert>
+#include <fstream>
 #include <iostream>
+#include <memory>
 #include <arrow/api.h>
 #include <arrow/io/api.h>
+#include <arrow/table.h>
 #include <parquet/arrow/reader.h>
 #include <parquet/arrow/writer.h>
 #include <parquet/column_reader.h>
@@ -79,6 +83,16 @@ extern "C" {
                                 const char* dsetname, int64_t numelems,
                                 int64_t dtype, bool compressed,
                                 char** errMsg);
+  
+  int c_writeMultiColToParquet(const char* filename, void* column_names, 
+                                void** ptr_arr, void** offset_ptrs, void* datatypes,
+                                int64_t colnum, int64_t numelems, int64_t rowGroupSize,
+                                bool compressed, char** errMsg);
+
+  int cpp_writeMultiColToParquet(const char* filename, void* column_names, 
+                                  void** ptr_arr, void** offset_ptrs, void* datatypes,
+                                  int64_t colnum, int64_t numelems, int64_t rowGroupSize,
+                                  bool compressed, char** errMsg);
     
   const char* c_getVersionInfo(void);
   const char* cpp_getVersionInfo(void);

--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -3,13 +3,9 @@
 
 // Wrap functions in C extern if compiling C++ object file
 #ifdef __cplusplus
-#include <cassert>
-#include <fstream>
 #include <iostream>
-#include <memory>
 #include <arrow/api.h>
 #include <arrow/io/api.h>
-#include <arrow/table.h>
 #include <parquet/arrow/reader.h>
 #include <parquet/arrow/writer.h>
 #include <parquet/column_reader.h>

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -12,6 +12,7 @@ module ParquetMsg {
   use NumPyDType;
   use Sort;
   use CommAggregation;
+  use AryUtil;
 
   use SegmentedString;
 
@@ -769,6 +770,201 @@ module ParquetMsg {
     }
   }
 
+  proc writeMultiColParquet(filename: string, col_names: [] string, 
+                              ncols: int, sym_names: [] string, targetLocales: [] locale, 
+                              compressed: bool, st: borrowed SymTab) throws {
+
+    extern proc c_writeMultiColToParquet(filename, column_names, ptr_arr, offset_ptrs,
+                                      datatypes, colnum, numelems, rowGroupSize, compressed, errMsg): int;
+
+    var prefix: string;
+    var extension: string;
+    (prefix, extension) = getFileMetadata(filename);
+
+    // Generate the filenames based upon the number of targetLocales.
+    var filenames = generateFilenames(prefix, extension, targetLocales.size);
+
+    //Generate a list of matching filenames to test against. 
+    var matchingFilenames = getMatchingFilenames(prefix, extension);
+
+    // TODO when APPEND is fully deprecated update this to not need the mode.
+    var filesExist = processParquetFilenames(filenames, matchingFilenames, TRUNCATE); // set to truncate. We will not be supporting appending. 
+
+    coforall (loc, idx) in zip(targetLocales, filenames.domain) do on loc {
+      var pqErr = new parquetErrorMsg();
+      const fname = filenames[idx];
+
+      var ptrList: [0..#ncols] c_void_ptr;
+      var offsetPtrs: [0..#ncols] c_void_ptr;
+      var datatypes: [0..#ncols] int;
+      var sizeList: [0..#ncols] int;
+
+      var my_column_names = col_names;
+      var c_names: [0..#ncols] c_string;
+
+      forall (i, column) in zip(0..#ncols, sym_names) {
+        // generate the local c string list of column names
+        c_names[i] = my_column_names[i].localize().c_str();
+
+        var entry = st.lookup(column);
+
+        // access the dtype of each 
+        var entryDtype = DType.UNDEF;
+        if (entry.isAssignableTo(SymbolEntryType.TypedArraySymEntry)) {
+          entryDtype = (entry: borrowed GenSymEntry).dtype;
+        } else if (entry.isAssignableTo(SymbolEntryType.SegStringSymEntry)) {
+          entryDtype = (entry: borrowed SegStringSymEntry).dtype;
+        } else {
+          throw getErrorWithContext(
+              msg="Unknown SymEntry Type",
+              lineNumber=getLineNumber(), 
+              routineName=getRoutineName(), 
+              moduleName=getModuleName(), 
+              errorClass='ValueError'
+          );
+        }
+        
+        select entryDtype {
+          when DType.Int64 {
+            var e = toSymEntry(toGenSymEntry(entry), int);
+            var locDom = e.a.localSubdomain();
+            // set the pointer to the entry array in the list of Pointers
+            ptrList[i] = c_ptrTo(e.a[locDom]): c_void_ptr;
+            datatypes[i] = ARROWINT64;
+            sizeList[i] = locDom.size;
+          }
+          when DType.UInt64 {
+            var e = toSymEntry(toGenSymEntry(entry), uint);
+            var locDom = e.a.localSubdomain();
+            // set the pointer to the entry array in the list of Pointers
+            ptrList[i] = c_ptrTo(e.a[locDom]): c_void_ptr;
+            datatypes[i] = ARROWINT64;
+            sizeList[i] = locDom.size;
+          }
+          when DType.Bool {
+            var e = toSymEntry(toGenSymEntry(entry), bool);
+            var locDom = e.a.localSubdomain();
+            // set the pointer to the entry array in the list of Pointers
+            ptrList[i] = c_ptrTo(e.a[locDom]): c_void_ptr;
+            datatypes[i] = ARROWBOOLEAN;
+            sizeList[i] = locDom.size;
+          } when DType.Float64 {
+            var e = toSymEntry(toGenSymEntry(entry), real);
+            var locDom = e.a.localSubdomain();
+            // set the pointer to the entry array in the list of Pointers
+            ptrList[i] = c_ptrTo(e.a[locDom]): c_void_ptr;
+            datatypes[i] = ARROWDOUBLE;
+            sizeList[i] = locDom.size;
+          } when DType.Strings {
+            var e: SegStringSymEntry = toSegStringSymEntry(entry);
+            var segStr = new SegString("", e);
+            ref ss = segStr;
+            var A = ss.offsets.a;
+            const lastOffset = A[A.domain.high];
+            const lastValIdx = ss.values.a.domain.high;
+            const locDom = ss.offsets.a.localSubdomain();
+
+            var localOffsets = A[locDom];
+            var startValIdx = localOffsets[locDom.low];
+            var endValIdx = if (lastOffset == localOffsets[locDom.high]) then lastValIdx else A[locDom.high + 1] - 1;
+            var valIdxRange = startValIdx..endValIdx;
+            var localVals = new lowLevelLocalizingSlice(ss.values.a, valIdxRange);
+            offsetPtrs[i] = c_ptrTo(ss.offsets.a[locDom]): c_void_ptr;
+            ptrList[i] = localVals.ptr: c_void_ptr;
+            datatypes[i] = ARROWSTRING;
+            sizeList[i] = locDom.size; // TODO - may need a plus 1 here
+          } otherwise {
+            throw getErrorWithContext(
+                              msg="Writing Parquet files (multi-column) does not support columns of type %s".format(entryDtype),
+                              lineNumber=getLineNumber(), 
+                              routineName=getRoutineName(), 
+                              moduleName=getModuleName(), 
+                              errorClass='DataTypeError'
+            );
+          }
+        }
+      }
+      
+      // validate all elements same size
+      var numelems: int = sizeList[0];
+      if !(|| reduce (sizeList==numelems)) {
+        throw getErrorWithContext(
+              msg="Columns must be the same size",
+              lineNumber=getLineNumber(), 
+              routineName=getRoutineName(), 
+              moduleName=getModuleName(), 
+              errorClass='ValueError'
+        );
+      }
+      var result: int = c_writeMultiColToParquet(fname.localize().c_str(), c_ptrTo(c_names), c_ptrTo(ptrList), c_ptrTo(offsetPtrs), c_ptrTo(datatypes), ncols, numelems, ROWGROUPS, compressed, c_ptrTo(pqErr.errMsg));
+    }
+    
+  }
+
+  proc toParquetMultiColMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+    const filename: string = msgArgs.getValueOf("filename");
+    const ncols: int = msgArgs.get("num_cols").getIntValue();
+
+    // get list of the names for the columns
+    var col_names: [0..#ncols] string = msgArgs.get("col_names").getList(ncols);
+
+    // get list of sym entry names holding column data
+    var sym_names: [0..#ncols] string = msgArgs.get("columns").getList(ncols);
+
+    var compressed = msgArgs.get("compressed").getBoolValue();
+
+    // Assuming all columns have same distribution, access the first to get target locales
+    var entry = st.lookup(sym_names[0]);
+
+    // access the dtype to create symentry from abstract
+    var entryDtype = DType.UNDEF;
+    if (entry.isAssignableTo(SymbolEntryType.TypedArraySymEntry)) {
+      entryDtype = (entry: borrowed GenSymEntry).dtype;
+    } else if (entry.isAssignableTo(SymbolEntryType.SegStringSymEntry)) {
+      entryDtype = (entry: borrowed SegStringSymEntry).dtype;
+    } else {
+      throw getErrorWithContext(
+          msg="Unknown SymEntry Type",
+          lineNumber=getLineNumber(), 
+          routineName=getRoutineName(), 
+          moduleName=getModuleName(), 
+          errorClass='ValueError'
+      );
+    }
+
+    var targetLocales;
+    select entryDtype {
+      when DType.Int64 {
+        var e = toSymEntry(toGenSymEntry(entry), int);
+        targetLocales = e.a.targetLocales();
+      }
+      when DType.UInt64 {
+        var e = toSymEntry(toGenSymEntry(entry), uint);
+        targetLocales = e.a.targetLocales();
+      }
+      when DType.Bool {
+        var e = toSymEntry(toGenSymEntry(entry), bool);
+        targetLocales = e.a.targetLocales();
+      } when DType.Float64 {
+        var e = toSymEntry(toGenSymEntry(entry), real);
+        targetLocales = e.a.targetLocales();
+      // } when DType.Strings {
+      } otherwise {
+        throw getErrorWithContext(
+                          msg="Writing Parquet files (multi-column) does not support columns of type %s".format(entryDtype),
+                          lineNumber=getLineNumber(), 
+                          routineName=getRoutineName(), 
+                          moduleName=getModuleName(), 
+                          errorClass='DataTypeError'
+        );
+      }
+    }
+
+    writeMultiColParquet(filename, col_names, ncols, sym_names, targetLocales, compressed, st);
+
+    return new MsgTuple("IN TESTING", MsgType.NORMAL);
+  }
+
   proc lspqMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     // reqMsg: "lshdf [<json_filename>]"
     var repMsg: string;
@@ -938,6 +1134,7 @@ module ParquetMsg {
 
   use CommandMap;
   registerFunction("readAllParquet", readAllParquetMsg, getModuleName());
+  registerFunction("toParquet_multi", toParquetMultiColMsg, getModuleName());
   registerFunction("writeParquet", toparquetMsg, getModuleName());
   registerFunction("lspq", lspqMsg, getModuleName());
   registerFunction("getnullparquet", nullIndicesMsg, getModuleName());

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -857,7 +857,7 @@ module ParquetMsg {
             var locDom = e.a.localSubdomain();
             // set the pointer to the entry array in the list of Pointers
             ptrList[i] = c_ptrTo(e.a[locDom]): c_void_ptr;
-            datatypes[i] = ARROWINT64;
+            datatypes[i] = ARROWUINT64;
             sizeList[i] = locDom.size;
           }
           when DType.Bool {
@@ -906,7 +906,7 @@ module ParquetMsg {
       
       // validate all elements same size
       var numelems: int = sizeList[0];
-      if !(|| reduce (sizeList==numelems)) {
+      if !(&& reduce (sizeList==numelems)) {
         throw getErrorWithContext(
               msg="Parquet columns must be the same size",
               lineNumber=getLineNumber(), 

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -528,7 +528,7 @@ class DataFrameTest(ArkoudaTest):
             akdf.to_parquet(f"{tmp_dirname}/testName")
 
             ak_loaded = ak.DataFrame.load(f"{tmp_dirname}/testName")
-            self.assertTrue(validation_df.equals(ak_loaded.to_pandas()))
+            self.assertTrue(validation_df.equals(ak_loaded[akdf.columns].to_pandas()))
 
             # test save with index true
             akdf.to_parquet(f"{tmp_dirname}/testName_with_index.pq", index=True)

--- a/tests/import_export_test.py
+++ b/tests/import_export_test.py
@@ -100,11 +100,10 @@ class ImportExportTest(ArkoudaTest):
         akdf = self.build_arkouda_dataframe()
         with tempfile.TemporaryDirectory(dir=ImportExportTest.ie_test_base_tmp) as tmp_dirname:
             akdf.to_parquet(f"{tmp_dirname}/ak_write")
-            print(akdf.__repr__())
 
             pddf = ak.export(f"{tmp_dirname}/ak_write", write_file=f"{tmp_dirname}/pd_from_ak.parquet", index=True)
             self.assertEqual(len(glob.glob(f"{tmp_dirname}/pd_from_ak.parquet")), 1)
-            self.assertTrue(pddf.equals(akdf.to_pandas()))
+            self.assertTrue(pddf[akdf.columns].equals(akdf.to_pandas()))
 
             with self.assertRaises(RuntimeError):
                 pddf = ak.export(f"{tmp_dirname}/foo.h5", write_file=f"{tmp_dirname}/pd_from_ak.h5", index=True)


### PR DESCRIPTION
Closes #1876 

This PR adds a separate workflow for writing multiple columns to Parquet. We now write all columns at once using the Arrow Parquet low level API. `append` write modes is maintained for Parquet for the time being, but is only used if `append` is specifically set as the write mode.  Since the `append` workflow is so inefficient, #1967 has been added to remove this. However, I think it would be good to get some benchmark data comparing the two write methods for multiple columns (#1968).

This implementation does require accessing `SymEntries` on each locale to get the local elements. This may not be the most efficient workflow, but I am unaware of another way to achieve the desired functionality. If anyone knows a better way to handle this, please let me know. However, for an initial implementation, this should be ready to go. If there is another option I would think we would handle the update under a separate PR.