### PR TITLE
Closes #1972: Switch to allclose for float comparison in operator test

### DIFF
--- a/benchmarks/gather.py
+++ b/benchmarks/gather.py
@@ -100,7 +100,7 @@ def check_correctness(dtype, random, seed):
         elif dtype == "bool":
             npv = np.random.randint(0, 1, Nv, dtype=np.bool)
         elif dtype == "str":
-            npv = np.array([np.str(x) for x in np.random.randint(0, 2**32, Nv)])
+            npv = np.array([str(x) for x in np.random.randint(0, 2**32, Nv)])
     else:
         npv = np.ones(Nv, dtype=dtype)
     akv = ak.array(npv)

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -314,7 +314,7 @@ class OperatorsTest(ArkoudaTest):
         np_uints = [np_uint, scalar_uint]
         ak_floats = [ak_float, scalar_float]
         np_floats = [np_float, scalar_float]
-        for aeku, akf, npu, npf in zip(ak_uints, ak_floats, np_uints, np_floats):
+        for aku, akf, npu, npf in zip(ak_uints, ak_floats, np_uints, np_floats):
             self.assertTrue(
                 np.allclose((ak_uint + akf).to_ndarray(), np_uint + npf, equal_nan=True)
             )

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -314,9 +314,13 @@ class OperatorsTest(ArkoudaTest):
         np_uints = [np_uint, scalar_uint]
         ak_floats = [ak_float, scalar_float]
         np_floats = [np_float, scalar_float]
-        for aku, akf, npu, npf in zip(ak_uints, ak_floats, np_uints, np_floats):
-            self.assertEqual(ak_uint + akf, np_uint + npf)
-            self.assertEqual(akf + ak_uint, npf + np_uint)
+        for aeku, akf, npu, npf in zip(ak_uints, ak_floats, np_uints, np_floats):
+            self.assertTrue(
+                np.allclose((ak_uint + akf).to_ndarray(), np_uint + npf, equal_nan=True)
+            )
+            self.assertTrue(
+                np.allclose((akf + ak_uint).to_ndarray(), npf + np_uint, equal_nan=True)
+            )
             self.assertTrue(
                 np.allclose((ak_float + aku).to_ndarray(), np_float + npu, equal_nan=True)
             )
@@ -324,8 +328,12 @@ class OperatorsTest(ArkoudaTest):
                 np.allclose((aku + ak_float).to_ndarray(), npu + np_float, equal_nan=True)
             )
 
-            self.assertEqual(ak_uint - akf, np_uint - npf)
-            self.assertEqual(akf - ak_uint, npf - np_uint)
+            self.assertTrue(
+                np.allclose((ak_uint - akf).to_ndarray(), np_uint - npf, equal_nan=True)
+            )
+            self.assertTrue(
+                np.allclose((akf - ak_uint).to_ndarray(), npf - np_uint, equal_nan=True)
+            )
             self.assertTrue(
                 np.allclose((ak_float - aku).to_ndarray(), np_float - npu, equal_nan=True)
             )
@@ -333,8 +341,12 @@ class OperatorsTest(ArkoudaTest):
                 np.allclose((aku - ak_float).to_ndarray(), npu - np_float, equal_nan=True)
             )
 
-            self.assertEqual(ak_uint * akf, np_uint * npf)
-            self.assertEqual(akf * ak_uint, npf * np_uint)
+            self.assertTrue(
+                np.allclose((ak_uint * akf).to_ndarray(), np_uint * npf, equal_nan=True)
+            )
+            self.assertTrue(
+                np.allclose((akf * ak_uint).to_ndarray(), npf * np_uint, equal_nan=True)
+            )
             self.assertTrue(
                 np.allclose((ak_float * aku).to_ndarray(), np_float * npu, equal_nan=True)
             )
@@ -342,8 +354,12 @@ class OperatorsTest(ArkoudaTest):
                 np.allclose((aku * ak_float).to_ndarray(), npu * np_float, equal_nan=True)
             )
 
-            self.assertEqual(ak_uint / akf, np_uint / npf)
-            self.assertEqual(akf / ak_uint, npf / np_uint)
+            self.assertTrue(
+                np.allclose((ak_uint / akf).to_ndarray(), np_uint / npf, equal_nan=True)
+            )
+            self.assertTrue(
+                np.allclose((akf / ak_uint).to_ndarray(), npf / np_uint, equal_nan=True)
+            )            
             self.assertTrue(
                 np.allclose((ak_float / aku).to_ndarray(), np_float / npu, equal_nan=True)
             )
@@ -351,8 +367,12 @@ class OperatorsTest(ArkoudaTest):
                 np.allclose((aku / ak_float).to_ndarray(), npu / np_float, equal_nan=True)
             )
 
-            self.assertEqual(ak_uint // akf, np_uint // npf)
-            self.assertEqual(akf // ak_uint, npf // np_uint)
+            self.assertTrue(
+                np.allclose((ak_uint // akf).to_ndarray(), np_uint // npf, equal_nan=True)
+            )
+            self.assertTrue(
+                np.allclose((akf // ak_uint).to_ndarray(), npf // np_uint, equal_nan=True)
+            )
             self.assertTrue(
                 np.allclose((ak_float // aku).to_ndarray(), np_float // npu, equal_nan=True)
             )
@@ -360,8 +380,12 @@ class OperatorsTest(ArkoudaTest):
                 np.allclose((aku // ak_float).to_ndarray(), npu // np_float, equal_nan=True)
             )
 
-            self.assertEqual(ak_uint**akf, np_uint**npf)
-            self.assertEqual(akf**ak_uint, npf**np_uint)
+            self.assertTrue(
+                np.allclose((ak_uint ** akf).to_ndarray(), np_uint ** npf, equal_nan=True)
+            )
+            self.assertTrue(
+                np.allclose((akf ** ak_uint).to_ndarray(), npf ** np_uint, equal_nan=True)
+            )            
             self.assertTrue(
                 np.allclose((ak_float ** aku).to_ndarray(), np_float ** npu, equal_nan=True)
             )

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -317,33 +317,57 @@ class OperatorsTest(ArkoudaTest):
         for aku, akf, npu, npf in zip(ak_uints, ak_floats, np_uints, np_floats):
             self.assertEqual(ak_uint + akf, np_uint + npf)
             self.assertEqual(akf + ak_uint, npf + np_uint)
-            self.assertEqual(ak_float + aku, np_float + npu)
-            self.assertEqual(aku + ak_float, npu + np_float)
+            self.assertTrue(
+                np.allclose((ak_float + aku).to_ndarray(), np_float + npu, equal_nan=True)
+            )
+            self.assertTrue(
+                np.allclose((aku + ak_float).to_ndarray(), npu + np_float, equal_nan=True)
+            )
 
             self.assertEqual(ak_uint - akf, np_uint - npf)
             self.assertEqual(akf - ak_uint, npf - np_uint)
-            self.assertEqual(ak_float - aku, np_float - npu)
-            self.assertEqual(aku - ak_float, npu - np_float)
+            self.assertTrue(
+                np.allclose((ak_float - aku).to_ndarray(), np_float - npu, equal_nan=True)
+            )
+            self.assertTrue(
+                np.allclose((aku - ak_float).to_ndarray(), npu - np_float, equal_nan=True)
+            )
 
             self.assertEqual(ak_uint * akf, np_uint * npf)
             self.assertEqual(akf * ak_uint, npf * np_uint)
-            self.assertEqual(ak_float * aku, np_float * npu)
-            self.assertEqual(aku * ak_float, npu * np_float)
+            self.assertTrue(
+                np.allclose((ak_float * aku).to_ndarray(), np_float * npu, equal_nan=True)
+            )
+            self.assertTrue(
+                np.allclose((aku * ak_float).to_ndarray(), npu * np_float, equal_nan=True)
+            )
 
             self.assertEqual(ak_uint / akf, np_uint / npf)
             self.assertEqual(akf / ak_uint, npf / np_uint)
-            self.assertEqual(ak_float / aku, np_float / npu)
-            self.assertEqual(aku / ak_float, npu / np_float)
+            self.assertTrue(
+                np.allclose((ak_float / aku).to_ndarray(), np_float / npu, equal_nan=True)
+            )
+            self.assertTrue(
+                np.allclose((aku / ak_float).to_ndarray(), npu / np_float, equal_nan=True)
+            )
 
             self.assertEqual(ak_uint // akf, np_uint // npf)
             self.assertEqual(akf // ak_uint, npf // np_uint)
-            self.assertEqual(ak_float // aku, np_float // npu)
-            self.assertEqual(aku // ak_float, npu // np_float)
+            self.assertTrue(
+                np.allclose((ak_float // aku).to_ndarray(), np_float // npu, equal_nan=True)
+            )
+            self.assertTrue(
+                np.allclose((aku // ak_float).to_ndarray(), npu // np_float, equal_nan=True)
+            )
 
             self.assertEqual(ak_uint**akf, np_uint**npf)
             self.assertEqual(akf**ak_uint, npf**np_uint)
-            self.assertEqual(ak_float**aku, np_float**npu)
-            self.assertEqual(aku**ak_float, npu**np_float)
+            self.assertTrue(
+                np.allclose((ak_float ** aku).to_ndarray(), np_float ** npu, equal_nan=True)
+            )
+            self.assertTrue(
+                np.allclose((aku ** ak_float).to_ndarray(), npu ** np_float, equal_nan=True)
+            )
 
     def test_concatenate_type_preservation(self):
         # Test that concatenate preserves special pdarray types (IPv4, Datetime, BitVector, ...)


### PR DESCRIPTION
The operator test is currently using `assertEqual` to do float comparison and this can cause some issues when Chapel generates a floating point number slightly different than numpy. This PR switches it to instead use `np.allclose` to avoid this problem.

Additionally, this PR fixes another CI issue that was occurring due to the removal of `np.str()` from the numpy library (see https://numpy.org/devdocs/release/1.24.0-notes.html)

Closes: https://github.com/Bears-R-Us/arkouda/issues/1974