### PR TITLE
Closes #1979 - Update Sphinx Theme

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -39,6 +39,7 @@ The dependencies listed here are only required if you will be doing development 
 - `Sphinx`
 - `sphinx-argparse`
 - `sphinx-autoapi`
+- `sphinx-theme`
 - `typed-ast`
 - `mypy>=0.931,<0.990`
 - `flake8`

--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -35,4 +35,5 @@ dependencies:
   - pip:
     # Developer dependencies
     - typeguard==2.10.0
+    - sphinx-theme
   

--- a/pydoc/conf.py
+++ b/pydoc/conf.py
@@ -58,7 +58,9 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+import sphinx_theme
+html_theme = 'stanford_theme'
+html_theme_path = [sphinx_theme.get_html_theme_path('stanford-theme')]
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/pydoc/requirements.txt
+++ b/pydoc/requirements.txt
@@ -23,6 +23,7 @@ pytest-env
 Sphinx>=5.1.1
 sphinx-argparse
 sphinx-autoapi
+sphinx-theme
 typed-ast
 mypy>=0.931,0.990
 flake8

--- a/setup.py
+++ b/setup.py
@@ -158,7 +158,7 @@ setup(
         'dev': ['pexpect', 'pytest>=6.0', 'pytest-env',
                 'Sphinx>=5.1.1', 'sphinx-argparse', 'sphinx-autoapi',
                 'mypy>=0.931,<0.990', 'typed-ast', 'black', 'isort',
-                'flake8'],
+                'flake8', 'sphinx-theme'],
     },
     # replace original install command with version that also builds
     # chapel and the arkouda server.


### PR DESCRIPTION
Closes #1979

Updates the Sphinx theme for autogenerated documentation to use the `Standford` theme. This theme provides a more professional look than current. Additionally, it works well with the DarkReader extension for Chrome. An example is available [here](https://sphinx-themes.org/sample-sites/sphinx-theme/)

**Dark Reader Enabled**
![Screenshot 2022-12-20 at 8 39 45 AM](https://user-images.githubusercontent.com/16845933/208680483-196340c2-cdc0-43b6-9d3c-c0757b5ed299.png)

**Standard Theme**
![Screenshot 2022-12-20 at 8 37 42 AM](https://user-images.githubusercontent.com/16845933/208680506-d35b4939-e76e-481d-a5a8-7b158b094e62.png)
