### PR TITLE
Closes #1932: binopvv support for uint and bool types

### DIFF
--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -52,7 +52,7 @@ module BinOp
   :returns: (MsgTuple) 
   :throws: `UndefinedSymbolError(name)`
   */
-  proc doBinOpvv (l, r, e, op: string, rname, pn, st) throws {
+  proc doBinOpvv(l, r, e, op: string, rname, pn, st) throws {
     if e.etype == bool {
       // Since we know that the result type is a boolean, we know
       // that it either (1) is an operation between bools or (2) uses
@@ -367,13 +367,13 @@ module BinOp
     } else if ((l.etype == uint && r.etype == bool) || (l.etype == bool && r.etype == uint)) {
       select op {
           when "+" {
-            e.a = l.a:real + r.a:real;
+            e.a = l.a:uint + r.a:uint;
           }
           when "-" {
-            e.a = l.a:real - r.a:real;
+            e.a = l.a:uint - r.a:uint;
           }
           when "*" {
-            e.a = l.a:real * r.a:real;
+            e.a = l.a:uint * r.a:uint;
           }
           otherwise {
             var errorMsg = notImplementedError(pn,l.dtype,op,r.dtype);

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -52,7 +52,7 @@ module BinOp
   :returns: (MsgTuple) 
   :throws: `UndefinedSymbolError(name)`
   */
-  proc doBinOpvv(l, r, e, op: string, rname, pn, st) throws {
+  proc doBinOpvv (l, r, e, op: string, rname, pn, st) throws {
     if e.etype == bool {
       // Since we know that the result type is a boolean, we know
       // that it either (1) is an operation between bools or (2) uses
@@ -364,6 +364,25 @@ module BinOp
         }
       var repMsg = "created %s".format(st.attrib(rname));
       return new MsgTuple(repMsg, MsgType.NORMAL);
+    } else if ((l.etype == uint && r.etype == bool) || (l.etype == bool && r.etype == uint)) {
+      select op {
+          when "+" {
+            e.a = l.a:real + r.a:real;
+          }
+          when "-" {
+            e.a = l.a:real - r.a:real;
+          }
+          when "*" {
+            e.a = l.a:real * r.a:real;
+          }
+          otherwise {
+            var errorMsg = notImplementedError(pn,l.dtype,op,r.dtype);
+            omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+          }
+        }
+      var repMsg = "created %s".format(st.attrib(rname));
+      return new MsgTuple(repMsg, MsgType.NORMAL);  
     } else if ((l.etype == real && r.etype == bool) || (l.etype == bool && r.etype == real)) {
       select op {
           when "+" {

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -187,7 +187,7 @@ module OperatorMsg
               var e = st.addEntry(rname, l.size, bool);
               return doBinOpvv(l, r, e, op, rname, pn, st);
             }
-            var e = st.addEntry(rname, l.size, uint);
+            var e = st.addEntry(rname, l.size, real);
             return doBinOpvv(l, r, e, op, rname, pn, st);
           }
           when (DType.UInt64, DType.Bool) {
@@ -197,7 +197,7 @@ module OperatorMsg
               var e = st.addEntry(rname, l.size, bool);
               return doBinOpvv(l, r, e, op, rname, pn, st);
             }
-            var e = st.addEntry(rname, l.size, uint);
+            var e = st.addEntry(rname, l.size, real);
             return doBinOpvv(l, r, e, op, rname, pn, st);
           }
           when (DType.UInt64, DType.UInt64) {

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -187,14 +187,14 @@ module OperatorMsg
               var e = st.addEntry(rname, l.size, bool);
               return doBinOpvv(l, r, e, op, rname, pn, st);
             }
-            var e = st.addEntry(rname, l.size, real);
+            var e = st.addEntry(rname, l.size, uint);
             return doBinOpvv(l, r, e, op, rname, pn, st);
           }
           when (DType.UInt64, DType.Bool) {
             var l = toSymEntry(left,uint);
             var r = toSymEntry(right,bool);
             if boolOps.contains(op) {
-              var e = st.addEntry(rname, l.size, bool);
+              var e = st.addEntry(rname, l.size, uint);
               return doBinOpvv(l, r, e, op, rname, pn, st);
             }
             var e = st.addEntry(rname, l.size, real);

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -194,10 +194,10 @@ module OperatorMsg
             var l = toSymEntry(left,uint);
             var r = toSymEntry(right,bool);
             if boolOps.contains(op) {
-              var e = st.addEntry(rname, l.size, uint);
+              var e = st.addEntry(rname, l.size, bool);
               return doBinOpvv(l, r, e, op, rname, pn, st);
             }
-            var e = st.addEntry(rname, l.size, real);
+            var e = st.addEntry(rname, l.size, uint);
             return doBinOpvv(l, r, e, op, rname, pn, st);
           }
           when (DType.UInt64, DType.UInt64) {

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -305,9 +305,8 @@ class OperatorsTest(ArkoudaTest):
         # Adding support to binopvv to correctly handle uint and bool types
         ak_uint = ak.arange(10, dtype=ak.uint64)
         ak_bool = ak_uint % 2 == 0
-        self.assertTrue(np.allclose((ak_uint + ak_bool).to_ndarray(),
-                                    (ak.arange(10) + ak_bool).to_ndarray(), equal_nan=True))
-
+        self.assertListEqual((ak_uint + ak_bool).tolist(), (ak.arange(10) + ak_bool).to_list())
+        
     def test_float_uint_binops(self):
         # Test fix for issue #1620
         ak_uint = ak.array([5], dtype=ak.uint64)

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -305,7 +305,7 @@ class OperatorsTest(ArkoudaTest):
         # Adding support to binopvv to correctly handle uint and bool types
         ak_uint = ak.arange(10, dtype=ak.uint64)
         ak_bool = ak_uint % 2 == 0
-        self.assertListEqual((ak_uint + ak_bool).tolist(), (ak.arange(10) + ak_bool).to_list())
+        self.assertListEqual((ak_uint + ak_bool).to_list(), (ak.arange(10) + ak_bool).to_list())
         
     def test_float_uint_binops(self):
         # Test fix for issue #1620

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -300,6 +300,14 @@ class OperatorsTest(ArkoudaTest):
         np_uint_inv = ~np.arange(10, dtype=np.uint)
         self.assertListEqual(np_uint_inv.tolist(), inverted.to_list())
 
+    def test_uint_bool_binops(self):
+        # Test fix for issue #1932
+        # Adding support to binopvv to correctly handle uint and bool types
+        ak_uint = ak.arange(10, dtype=ak.uint64)
+        ak_bool = ak_uint % 2 == 0
+        self.assertTrue(np.allclose((ak_uint + ak_bool).to_ndarray(),
+                                    (ak.arange(10) + ak_bool).to_ndarray(), equal_nan=True))
+
     def test_float_uint_binops(self):
         # Test fix for issue #1620
         ak_uint = ak.array([5], dtype=ak.uint64)
@@ -353,20 +361,18 @@ class OperatorsTest(ArkoudaTest):
             self.assertTrue(
                 np.allclose((aku * ak_float).to_ndarray(), npu * np_float, equal_nan=True)
             )
-
             self.assertTrue(
                 np.allclose((ak_uint / akf).to_ndarray(), np_uint / npf, equal_nan=True)
             )
             self.assertTrue(
                 np.allclose((akf / ak_uint).to_ndarray(), npf / np_uint, equal_nan=True)
-            )            
+            )
             self.assertTrue(
                 np.allclose((ak_float / aku).to_ndarray(), np_float / npu, equal_nan=True)
             )
             self.assertTrue(
                 np.allclose((aku / ak_float).to_ndarray(), npu / np_float, equal_nan=True)
             )
-
             self.assertTrue(
                 np.allclose((ak_uint // akf).to_ndarray(), np_uint // npf, equal_nan=True)
             )
@@ -379,13 +385,12 @@ class OperatorsTest(ArkoudaTest):
             self.assertTrue(
                 np.allclose((aku // ak_float).to_ndarray(), npu // np_float, equal_nan=True)
             )
-
             self.assertTrue(
                 np.allclose((ak_uint ** akf).to_ndarray(), np_uint ** npf, equal_nan=True)
             )
             self.assertTrue(
                 np.allclose((akf ** ak_uint).to_ndarray(), npf ** np_uint, equal_nan=True)
-            )            
+            )
             self.assertTrue(
                 np.allclose((ak_float ** aku).to_ndarray(), np_float ** npu, equal_nan=True)
             )


### PR DESCRIPTION
This PR (closes #1932)

- Adds support to allow for proper binopvv compatibility for uint64 and boolean types
- Fixes resulting type bug
- Adds testing to ensure proper implementation