### PR TITLE
Closes #1297 and #1983: Change `ak.array` to prefer `uint` over `float` when `>2**63`

### DIFF
--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -202,7 +202,17 @@ def array(
     # If a is not already a numpy.ndarray, convert it
     if not isinstance(a, np.ndarray):
         try:
-            a = np.array(a, dtype=dtype)
+            if dtype is not None:
+                # if the user specified dtype, use that dtype
+                a = np.array(a, dtype=dtype)
+            elif all(isSupportedInt(i) for i in a) and any(i > 2 ** 63 for i in a):
+                # all supportedInt values but some >2**63, default to uint (see #1297)
+                # iterating shouldn't be too expensive since
+                # this is after the `isinstance(a, pdarray)` check
+                a = np.array(a, dtype=np.uint)
+            else:
+                # let numpy decide the type
+                a = np.array(a)
         except (RuntimeError, TypeError, ValueError):
             raise TypeError("a must be a pdarray, np.ndarray, or convertible to a numpy array")
     # Return multi-dimensional arrayview

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -571,3 +571,9 @@ class DataFrameTest(ArkoudaTest):
         # Added for testing Issue #1505
         df = ak.DataFrame({"a": ak.arange(10), "b": ak.arange(10), "c": ak.arange(10)})
         df.groupby(["a", "b"]).sum("c")
+
+    def test_uint_greediness(self):
+        # default to uint when all supportedInt and any value > 2**63
+        # to avoid loss of precision see (#1983)
+        df = pd.DataFrame({'Test': [2 ** 64 - 1, 0]})
+        self.assertEqual(df['Test'].dtype, ak.uint64)

--- a/tests/pdarray_creation_test.py
+++ b/tests/pdarray_creation_test.py
@@ -814,6 +814,12 @@ class PdarrayCreationTest(ArkoudaTest):
             self.assertTrue(np.all(a == i + 1))
             self.assertTrue(np.all(npa == i + 1))
 
+    def test_uint_greediness(self):
+        # default to uint when all supportedInt and any value > 2**63
+        # to avoid loss of precision see (#1297)
+        self.assertEqual(ak.array([2 ** 63, 6, 2 ** 63 - 1, 2 ** 63 + 1]).dtype, ak.uint64)
+        self.assertEqual(ak.array([2 ** 64 - 1, 0, -1]).dtype, ak.uint64)
+
     def randint_randomness(self):
         # THIS TEST DOES NOT RUN, see Issue #1672
         # To run rename to `test_randint_randomness`


### PR DESCRIPTION
This PR (closes #1297 and closes #1983):
- Changes `ak.array` to default to `uint` when all values are supportedInts and at least one is `> 2**63`
- Adds tests for the reproducers from the two issues