### PR TITLE
Closes #1962: Update ak.get_mem_* methods

### DIFF
--- a/src/ServerDaemon.chpl
+++ b/src/ServerDaemon.chpl
@@ -354,6 +354,7 @@ module ServerDaemon {
             registerFunction("repr", reprMsg);
             registerFunction("getconfig", getconfigMsg);
             registerFunction("getmemused", getmemusedMsg);
+            registerFunction("getavailmem", getmemavailMsg);
             registerFunction("getCmdMap", getCommandMapMsg);
             registerFunction("clear", clearMsg);
             registerFunction("lsany", lsAnyMsg);

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -83,7 +83,7 @@ class ClientTest(ArkoudaTest):
 
     def test_get_mem_used(self):
         """
-        Tests the ak.client.get_mem_used method
+        Tests the ak.get_mem_used and ak.get_mem_avail methods
 
         :return: None
         :raise: AssertionError if one or more ak.get_mem_used values are not as
@@ -96,6 +96,20 @@ class ClientTest(ArkoudaTest):
         except Exception as e:
             raise AssertionError(e)
         self.assertTrue(mem_used > 0)
+
+        # test units
+        mem_used = ak.get_mem_used()
+        mem_avail = ak.get_mem_avail()
+        for u, f in ak.client._memunit2factor.items():
+            self.assertEqual(round(mem_used / f), ak.get_mem_used(u))
+            self.assertEqual(round(mem_avail / f), ak.get_mem_avail(u))
+
+        # test as_percent
+        tot_mem = ak.get_mem_used() + ak.get_mem_avail()
+        self.assertEqual(ak.get_mem_used(as_percent=True), round((ak.get_mem_used() / tot_mem) * 100))
+        self.assertEqual(ak.get_mem_avail(as_percent=True), round((ak.get_mem_avail() / tot_mem) * 100))
+
+        self.assertEqual(100, ak.get_mem_used(as_percent=True) + ak.get_mem_avail(as_percent=True))
 
     def test_no_op(self):
         """


### PR DESCRIPTION
This PR (closes #1962):
- Adds `unit` and `as_percent` parameters to `ak.get_mem_used`
- Adds `ak.get_mem_avail` with same parameters
- Adds testing for this functionality

Example:
Note `tot_mem` below matches `memory limit` from the arkouda logs
```
overMemLimit Line 254 INFO [Chapel] memory high watermark = 8589934592 memory limit = 30923764531
```
```python
>>> a = ak.ones(1024 ** 3)
>>> ak.get_mem_used()
8589934592

>>> ak.get_mem_avail()
22333829939

>>> tot_mem = ak.get_mem_avail() + ak.get_mem_used()
>>> tot_mem
30923764531

>>> ak.get_mem_avail(as_percent=True)
72

>>> round((ak.get_mem_avail() / tot_mem) * 100)
72

>>> ak.get_mem_used(as_percent=True)
28

>>> ak.get_mem_used(as_percent=True) + ak.get_mem_avail(as_percent=True)
100

>>> round(ak.get_mem_used() / 10**9)
9

>>> ak.get_mem_used('gb')
9

>>> ak.get_mem_used('g')
9

>>> ak.get_mem_used('gigabytes')
9

>>> ak.get_mem_used('GIG')
9
```