### PR TITLE
Closes #1996 - Remove Release from header

### DIFF
--- a/pydoc/conf.py
+++ b/pydoc/conf.py
@@ -26,7 +26,8 @@ copyright = '2020, Michael Merrill and William Reus'
 author = 'Michael Merrill and William Reus'
 
 # The full version, including alpha/beta/rc tags
-release = _version.get_versions()["version"]
+# release = _version.get_versions()["version"]
+release = ""
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
Closes #1996

Updates the release to be `release=""` in the `conf.py` file for Sphinx. The release results in the header render oddly because we do not have a true release here since our doc are only built on merge to master. For now this change is purely visual. Images for comparison below:

**With `release=_version.get_versions()["version"]`**
<img width="270" alt="Screenshot 2022-12-23 at 7 22 26 AM" src="https://user-images.githubusercontent.com/16845933/209336445-6da8c905-95af-4792-a9ae-5b78f8ce59af.png">

**With `release=""`**
<img width="287" alt="Screenshot 2022-12-23 at 7 22 08 AM" src="https://user-images.githubusercontent.com/16845933/209336485-b97cc31c-8e21-4c25-b7ac-3100603e9200.png">

- We should consider only cutting the documentation when we do a release. So that our documentation is tagged to our latest release? Or have the option to select between the `current tag` and `Beta` where Beta would be current to master. If anyone is in agreement on this, let me know and I will add an issue for it.