### PR TITLE
Closes #1995: `bigint` binops

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1117,7 +1117,7 @@ class pdarray:
         >>> a.bigint_to_uint_arrays()
         [array([1 1 1 1 1]), array([0 1 2 3 4])]
         """
-        ret_list = json.loads(generic_msg(cmd="break_into_arrays", args={"array": self}))
+        ret_list = json.loads(generic_msg(cmd="bigint_to_uint_list", args={"array": self}))
         return list(reversed([create_pdarray(a) for a in ret_list]))
 
     def reshape(self, *shape, order="row_major"):

--- a/src/BigIntMsg.chpl
+++ b/src/BigIntMsg.chpl
@@ -84,5 +84,5 @@ module BigIntMsg {
 
     use CommandMap;
     registerFunction("big_int_creation", bigIntCreationMsg, getModuleName());
-    registerFunction("break_into_arrays", bigintToUintArraysMsg, getModuleName());
+    registerFunction("bigint_to_uint_list", bigintToUintArraysMsg, getModuleName());
 }

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -1056,8 +1056,6 @@ module BinOp
     ref la = l.a;
     ref ra = r.a;
     var tmp = makeDistArray(la.size, bigint);
-    // i think tmp should be initialized to 0 but just to be sure
-    tmp = 0:bigint;
     // these cases are not mutually exclusive,
     // so we have a flag to track if tmp is ever populated
     var visted = false;
@@ -1110,6 +1108,7 @@ module BinOp
             if !has_max_bits {
               throw new Error("Must set max_bits to rotl");
             }
+            // should be as simple as the below, see issue #2006
             // return (la << ra) | (la >> (max_bits - ra));
             tmp = la << ra;
             var botBits = la;
@@ -1133,6 +1132,7 @@ module BinOp
             if !has_max_bits {
               throw new Error("Must set max_bits to rotr");
             }
+            // should be as simple as the below, see issue #2006
             // return (la >> ra) | (la << (max_bits - ra));
             tmp = la;
             // cant just do tmp >>= ra;
@@ -1248,8 +1248,6 @@ module BinOp
     }
     ref la = l.a;
     var tmp = makeDistArray(la.size, bigint);
-    // i think tmp should be initialized to 0 but just to be sure
-    tmp = 0:bigint;
     // these cases are not mutually exclusive,
     // so we have a flag to track if tmp is ever populated
     var visted = false;
@@ -1302,6 +1300,7 @@ module BinOp
             if !has_max_bits {
               throw new Error("Must set max_bits to rotl");
             }
+            // should be as simple as the below, see issue #2006
             // return (la << val) | (la >> (max_bits - val));
             tmp = la << val;
             var botBits = la;
@@ -1325,6 +1324,7 @@ module BinOp
             if !has_max_bits {
               throw new Error("Must set max_bits to rotr");
             }
+            // should be as simple as the below, see issue #2006
             // return (la >> val) | (la << (max_bits - val));
             tmp = la;
             // cant just do tmp >>= ra;
@@ -1440,8 +1440,6 @@ module BinOp
     }
     ref ra = r.a;
     var tmp = makeDistArray(ra.size, bigint);
-    // i think tmp should be initialized to 0 but just to be sure
-    tmp = 0:bigint;
     // these cases are not mutually exclusive,
     // so we have a flag to track if tmp is ever populated
     var visted = false;
@@ -1494,6 +1492,7 @@ module BinOp
             if !has_max_bits {
               throw new Error("Must set max_bits to rotl");
             }
+            // should be as simple as the below, see issue #2006
             // return (val << ra) | (val >> (max_bits - ra));
             tmp = val << ra;
             var botBits = makeDistArray(ra.size, bigint);
@@ -1518,6 +1517,7 @@ module BinOp
             if !has_max_bits {
               throw new Error("Must set max_bits to rotr");
             }
+            // should be as simple as the below, see issue #2006
             // return (val >> ra) | (val << (max_bits - ra));
             tmp = val;
             // cant just do tmp >>= ra;
@@ -1570,7 +1570,7 @@ module BinOp
     if (val.type == bigint && r.etype == bigint) ||
        (val.type == bigint && (r.etype == int || r.etype == uint || r.etype == bool)) ||
        (r.etype == bigint && (val.type == int || val.type == uint || val.type == bool)) {
-      // TODO we have to cast to bigint until #21290 is resolved
+      // TODO we have to cast to bigint until chape issue #21290 is resolved, see issue #2007
       var cast_val = if val.type == bool then val:int:bigint else val:bigint;
       select op {
         when "+" {

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -8,6 +8,7 @@ module BinOp
   use Logging;
   use Message;
   use BitOps;
+  use BigInteger;
 
   private config const logLevel = ServerConfig.logLevel;
   const omLogger = new Logger(logLevel);
@@ -1043,5 +1044,586 @@ module BinOp
     var errorMsg = unrecognizedTypeError(pn, "("+dtype2str(dtype)+","+dtype2str(r.dtype)+")");
     omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
     return new MsgTuple(errorMsg, MsgType.ERROR);
+  }
+
+  proc doBigIntBinOpvv(l, r, op: string) throws {
+    var max_bits = max(l.max_bits, r.max_bits);
+    var max_size = 1:bigint;
+    var has_max_bits = max_bits != -1;
+    if has_max_bits {
+      max_size <<= max_bits;
+    }
+    ref la = l.a;
+    ref ra = r.a;
+    var tmp = makeDistArray(la.size, bigint);
+    // i think tmp should be initialized to 0 but just to be sure
+    tmp = 0:bigint;
+    // these cases are not mutually exclusive,
+    // so we have a flag to track if tmp is ever populated
+    var visted = false;
+
+    // had to create bigint specific BinOp procs which return
+    // the distributed array because we need it at SymEntry creation time
+    if l.etype == bigint && r.etype == bigint {
+      // first we try the ops that only work with
+      // both being bigint
+      select op {
+        when "&" {
+          tmp = la & ra;
+          visted = true;
+        }
+        when "|" {
+          tmp = la | ra;
+          visted = true;
+        }
+        when "^" {
+          tmp = la ^ ra;
+          visted = true;
+        }
+        when "/" {
+          tmp = la / ra;
+          visted = true;
+        }
+      }
+    }
+    if l.etype == bigint && (r.etype == bigint || r.etype == int || r.etype == uint) {
+      // then we try the ops that only work with a
+      // left hand side of bigint
+      if r.etype != bigint {
+        // can't shift a bigint by a bigint
+        select op {
+          when "<<" {
+            tmp = la << ra;
+            visted = true;
+          }
+          when ">>" {
+            // workaround for right shift until chapel issue #21206
+            // makes it into a release, eventually we can just do
+            // tmp = la >> ra;
+            var divideBy = makeDistArray(la.size, bigint);
+            divideBy = 1:bigint;
+            divideBy <<= ra;
+            tmp = la / divideBy;
+            visted = true;
+          }
+          when "<<<" {
+            if !has_max_bits {
+              throw new Error("Must set max_bits to rotl");
+            }
+            // return (la << ra) | (la >> (max_bits - ra));
+            tmp = la << ra;
+            var botBits = la;
+            if r.etype == int {
+              var shift_amt = max_bits - ra;
+              // cant just do botBits >>= shift_amt;
+              var divideBy = makeDistArray(la.size, bigint);
+              divideBy = 1:bigint;
+              divideBy <<= shift_amt;
+              botBits = botBits / divideBy;
+              tmp += botBits;
+            }
+            else {
+              var shift_amt = max_bits:uint - ra;
+              botBits >>= shift_amt;
+              tmp += botBits;
+            }
+            visted = true;
+          }
+          when ">>>" {
+            if !has_max_bits {
+              throw new Error("Must set max_bits to rotr");
+            }
+            // return (la >> ra) | (la << (max_bits - ra));
+            tmp = la;
+            // cant just do tmp >>= ra;
+            var divideBy = makeDistArray(la.size, bigint);
+            divideBy = 1:bigint;
+            divideBy <<= ra;
+            tmp = tmp / divideBy;
+
+            var topBits = la;
+            if r.etype == int {
+              var shift_amt = max_bits - ra;
+              topBits <<= shift_amt;
+              tmp += topBits;
+            }
+            else {
+              var shift_amt = max_bits:uint - ra;
+              topBits <<= shift_amt;
+              tmp += topBits;
+            }
+            visted = true;
+          }
+        }
+      }
+      select op {
+        when "//" { // floordiv
+          [(ei,li,ri) in zip(tmp,la,ra)] ei = if ri != 0 then li/ri else 0:bigint;
+          visted = true;
+        }
+        when "%" { // modulo
+          // we only do in place mod when ri != 0, tmp will be 0 in other locations
+          // we can't use ei = li % ri because this can result in negatives
+          [(ei,li,ri) in zip(tmp,la,ra)] if ri != 0 then ei.mod(li, ri);
+          visted = true;
+        }
+        when "**" {
+          if || reduce (ra<0) {
+            throw new Error("Attempt to exponentiate base of type BigInt to negative exponent");
+          }
+          if has_max_bits {
+            [(ei,li,ri) in zip(tmp,la,ra)] ei.powMod(li, ri, max_size);
+          }
+          else {
+            tmp = la ** ra;
+          }
+          visted = true;
+        }
+      }
+    }
+    if (l.etype == bigint && r.etype == bigint) ||
+       (l.etype == bigint && (r.etype == int || r.etype == uint || r.etype == bool)) ||
+       (r.etype == bigint && (l.etype == int || l.etype == uint || l.etype == bool)) {
+      select op {
+        when "+" {
+          tmp = la + ra;
+          visted = true;
+        }
+        when "-" {
+          tmp = l.a - r.a;
+          visted = true;
+        }
+        when "*" {
+          tmp = l.a * r.a;
+          visted = true;
+        }
+      }
+    }
+    if !visted {
+      throw new Error("Unsupported operation: " + l.etype:string +" "+ op +" "+ r.etype:string);
+    }
+    else {
+      if has_max_bits {
+        // max_size should always be non-zero since we start at 1 and left shift
+        tmp.mod(tmp, max_size);
+      }
+      return (tmp, max_bits);
+    }
+  }
+
+  proc doBigIntBinOpvvBoolReturn(l, r, op: string) throws {
+    select op {
+      when "<" {
+        return l.a < r.a;
+      }
+      when ">" {
+        return l.a > r.a;
+      }
+      when "<=" {
+        return l.a <= r.a;
+      }
+      when ">=" {
+        return l.a >= r.a;
+      }
+      when "==" {
+        return l.a == r.a;
+      }
+      when "!=" {
+        return l.a != r.a;
+      }
+      otherwise {
+        // we should never reach this since we only enter this proc
+        // if boolOps.contains(op)
+        throw new Error("Unsupported operation: " + l.etype:string +" "+ op +" "+ r.etype:string);
+      }
+    }
+  }
+
+  proc doBigIntBinOpvs(l, val, op: string) throws {
+    var max_bits = l.max_bits;
+    var max_size = 1:bigint;
+    var has_max_bits = max_bits != -1;
+    if has_max_bits {
+      max_size <<= max_bits;
+    }
+    ref la = l.a;
+    var tmp = makeDistArray(la.size, bigint);
+    // i think tmp should be initialized to 0 but just to be sure
+    tmp = 0:bigint;
+    // these cases are not mutually exclusive,
+    // so we have a flag to track if tmp is ever populated
+    var visted = false;
+
+    // had to create bigint specific BinOp procs which return
+    // the distributed array because we need it at SymEntry creation time
+    if l.etype == bigint && val.type == bigint {
+      // first we try the ops that only work with
+      // both being bigint
+      select op {
+        when "&" {
+          tmp = la & val;
+          visted = true;
+        }
+        when "|" {
+          tmp = la | val;
+          visted = true;
+        }
+        when "^" {
+          tmp = la ^ val;
+          visted = true;
+        }
+        when "/" {
+          tmp = la / val;
+          visted = true;
+        }
+      }
+    }
+    if l.etype == bigint && (val.type == bigint || val.type == int || val.type == uint) {
+      // then we try the ops that only work with a
+      // left hand side of bigint
+      if val.type != bigint {
+        // can't shift a bigint by a bigint
+        select op {
+          when "<<" {
+            tmp = la << val;
+            visted = true;
+          }
+          when ">>" {
+            // workaround for right shift until chapel issue #21206
+            // makes it into a release, eventually we can just do
+            // tmp = la >> ra;
+            var divideBy = makeDistArray(la.size, bigint);
+            divideBy = 1:bigint;
+            divideBy <<= val;
+            tmp = la / divideBy;
+            visted = true;
+          }
+          when "<<<" {
+            if !has_max_bits {
+              throw new Error("Must set max_bits to rotl");
+            }
+            // return (la << val) | (la >> (max_bits - val));
+            tmp = la << val;
+            var botBits = la;
+            if val.type == int {
+              var shift_amt = max_bits - val;
+              // cant just do botBits >>= shift_amt;
+              var divideBy = makeDistArray(la.size, bigint);
+              divideBy = 1:bigint;
+              divideBy <<= shift_amt;
+              botBits = botBits / divideBy;
+              tmp += botBits;
+            }
+            else {
+              var shift_amt = max_bits:uint - val;
+              botBits >>= shift_amt;
+              tmp += botBits;
+            }
+            visted = true;
+          }
+          when ">>>" {
+            if !has_max_bits {
+              throw new Error("Must set max_bits to rotr");
+            }
+            // return (la >> val) | (la << (max_bits - val));
+            tmp = la;
+            // cant just do tmp >>= ra;
+            var divideBy = makeDistArray(la.size, bigint);
+            divideBy = 1:bigint;
+            divideBy <<= val;
+            tmp = tmp / divideBy;
+
+            var topBits = la;
+            if val.type == int {
+              var shift_amt = max_bits - val;
+              topBits <<= shift_amt;
+              tmp += topBits;
+            }
+            else {
+              var shift_amt = max_bits:uint - val;
+              topBits <<= shift_amt;
+              tmp += topBits;
+            }
+            visted = true;
+          }
+        }
+      }
+      select op {
+        when "//" { // floordiv
+          [(ei,li) in zip(tmp,la)] ei = if val != 0 then li/val else 0:bigint;
+          visted = true;
+        }
+        when "%" { // modulo
+          // we only do in place mod when val != 0, tmp will be 0 in other locations
+          // we can't use ei = li % val because this can result in negatives
+          [(ei,li) in zip(tmp,la)] if val != 0 then ei.mod(li, val);
+          visted = true;
+        }
+        when "**" {
+          if val<0 {
+            throw new Error("Attempt to exponentiate base of type BigInt to negative exponent");
+          }
+          if has_max_bits {
+            [(ei,li) in zip(tmp,la)] ei.powMod(li, val, max_size);
+          }
+          else {
+            tmp = la ** val;
+          }
+          visted = true;
+        }
+      }
+    }
+    if (l.etype == bigint && val.type == bigint) ||
+       (l.etype == bigint && (val.type == int || val.type == uint || val.type == bool)) ||
+       (val.type == bigint && (l.etype == int || l.etype == uint || l.etype == bool)) {
+      select op {
+        when "+" {
+          tmp = la + val;
+          visted = true;
+        }
+        when "-" {
+          tmp = l.a - val;
+          visted = true;
+        }
+        when "*" {
+          tmp = l.a * val;
+          visted = true;
+        }
+      }
+    }
+    if !visted {
+      throw new Error("Unsupported operation: " + l.etype:string +" "+ op +" "+ val.type:string);
+    }
+    else {
+      if has_max_bits {
+        // max_size should always be non-zero since we start at 1 and left shift
+        tmp.mod(tmp, max_size);
+      }
+      return (tmp, max_bits);
+    }
+  }
+
+  proc doBigIntBinOpvsBoolReturn(l, val, op: string) throws {
+    select op {
+      when "<" {
+        return l.a < val;
+      }
+      when ">" {
+        return l.a > val;
+      }
+      when "<=" {
+        return l.a <= val;
+      }
+      when ">=" {
+        return l.a >= val;
+      }
+      when "==" {
+        return l.a == val;
+      }
+      when "!=" {
+        return l.a != val;
+      }
+      otherwise {
+        // we should never reach this since we only enter this proc
+        // if boolOps.contains(op)
+        throw new Error("Unsupported operation: " +" "+ l.etype:string + op +" "+ val.type:string);
+      }
+    }
+  }
+
+  proc doBigIntBinOpsv(val, r, op: string) throws {
+    var max_bits = r.max_bits;
+    var max_size = 1:bigint;
+    var has_max_bits = max_bits != -1;
+    if has_max_bits {
+      max_size <<= max_bits;
+    }
+    ref ra = r.a;
+    var tmp = makeDistArray(ra.size, bigint);
+    // i think tmp should be initialized to 0 but just to be sure
+    tmp = 0:bigint;
+    // these cases are not mutually exclusive,
+    // so we have a flag to track if tmp is ever populated
+    var visted = false;
+
+    // had to create bigint specific BinOp procs which return
+    // the distributed array because we need it at SymEntry creation time
+    if val.type == bigint && r.etype == bigint {
+      // first we try the ops that only work with
+      // both being bigint
+      select op {
+        when "&" {
+          tmp = val & ra;
+          visted = true;
+        }
+        when "|" {
+          tmp = val | ra;
+          visted = true;
+        }
+        when "^" {
+          tmp = val ^ ra;
+          visted = true;
+        }
+        when "/" {
+          tmp = val / ra;
+          visted = true;
+        }
+      }
+    }
+    if val.type == bigint && (r.etype == bigint || r.etype == int || r.etype == uint) {
+      // then we try the ops that only work with a
+      // left hand side of bigint
+      if r.etype != bigint {
+        // can't shift a bigint by a bigint
+        select op {
+          when "<<" {
+            tmp = val << ra;
+            visted = true;
+          }
+          when ">>" {
+            // workaround for right shift until chapel issue #21206
+            // makes it into a release, eventually we can just do
+            // tmp = val >> ra;
+            var divideBy = makeDistArray(ra.size, bigint);
+            divideBy = 1:bigint;
+            divideBy <<= ra;
+            tmp = val / divideBy;
+            visted = true;
+          }
+          when "<<<" {
+            if !has_max_bits {
+              throw new Error("Must set max_bits to rotl");
+            }
+            // return (val << ra) | (val >> (max_bits - ra));
+            tmp = val << ra;
+            var botBits = makeDistArray(ra.size, bigint);
+            botBits = val;
+            if r.etype == int {
+              var shift_amt = max_bits - ra;
+              // cant just do botBits >>= shift_amt;
+              var divideBy = makeDistArray(ra.size, bigint);
+              divideBy = 1:bigint;
+              divideBy <<= shift_amt;
+              botBits = botBits / divideBy;
+              tmp += botBits;
+            }
+            else {
+              var shift_amt = max_bits:uint - ra;
+              botBits >>= shift_amt;
+              tmp += botBits;
+            }
+            visted = true;
+          }
+          when ">>>" {
+            if !has_max_bits {
+              throw new Error("Must set max_bits to rotr");
+            }
+            // return (val >> ra) | (val << (max_bits - ra));
+            tmp = val;
+            // cant just do tmp >>= ra;
+            var divideBy = makeDistArray(ra.size, bigint);
+            divideBy = 1:bigint;
+            divideBy <<= ra;
+            tmp = tmp / divideBy;
+
+            var topBits = makeDistArray(ra.size, bigint);
+            topBits = val;
+            if r.etype == int {
+              var shift_amt = max_bits - ra;
+              topBits <<= shift_amt;
+              tmp += topBits;
+            }
+            else {
+              var shift_amt = max_bits:uint - ra;
+              topBits <<= shift_amt;
+              tmp += topBits;
+            }
+            visted = true;
+          }
+        }
+      }
+      select op {
+        when "//" { // floordiv
+          [(ei,ri) in zip(tmp,ra)] ei = if ri != 0 then val/ri else 0:bigint;
+          visted = true;
+        }
+        when "%" { // modulo
+          // we only do in place mod when val != 0, tmp will be 0 in other locations
+          // we can't use ei = li % val because this can result in negatives
+          [(ei,ri) in zip(tmp,ra)] if ri != 0 then ei.mod(val, ri);
+          visted = true;
+        }
+        when "**" {
+          if || reduce(ra<0) {
+            throw new Error("Attempt to exponentiate base of type BigInt to negative exponent");
+          }
+          if has_max_bits {
+            [(ei,ri) in zip(tmp,ra)] ei.powMod(val, ri, max_size);
+          }
+          else {
+            tmp = val ** ra;
+          }
+          visted = true;
+        }
+      }
+    }
+    if (val.type == bigint && r.etype == bigint) ||
+       (val.type == bigint && (r.etype == int || r.etype == uint || r.etype == bool)) ||
+       (r.etype == bigint && (val.type == int || val.type == uint || val.type == bool)) {
+      // TODO we have to cast to bigint until #21290 is resolved
+      var cast_val = if val.type == bool then val:int:bigint else val:bigint;
+      select op {
+        when "+" {
+          tmp = cast_val + ra;
+          visted = true;
+        }
+        when "-" {
+          tmp = cast_val - r.a;
+          visted = true;
+        }
+        when "*" {
+          tmp = cast_val * r.a;
+          visted = true;
+        }
+      }
+    }
+    if !visted {
+      throw new Error("Unsupported operation: " + val.type:string +" "+ op +" "+ r.etype:string);
+    }
+    else {
+      if has_max_bits {
+        // max_size should always be non-zero since we start at 1 and left shift
+        tmp.mod(tmp, max_size);
+      }
+      return (tmp, max_bits);
+    }
+  }
+
+  proc doBigIntBinOpsvBoolReturn(val, r, op: string) throws {
+    select op {
+      when "<" {
+        return val < r.a;
+      }
+      when ">" {
+        return val > r.a;
+      }
+      when "<=" {
+        return val <= r.a;
+      }
+      when ">=" {
+        return val >= r.a;
+      }
+      when "==" {
+        return val == r.a;
+      }
+      when "!=" {
+        return val != r.a;
+      }
+      otherwise {
+        // we should never reach this since we only enter this proc
+        // if boolOps.contains(op)
+        throw new Error("Unsupported operation: " + val.type:string +" "+ op +" "+ r.etype:string);
+      }
+    }
   }
 }

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -9,6 +9,7 @@ module OperatorMsg
     use Reflection;
     use ServerErrors;
     use BinOp;
+    use BigInteger;
 
     use MultiTypeSymbolTable;
     use MultiTypeSymEntry;
@@ -243,6 +244,111 @@ module OperatorMsg
               return doBinOpvv(l, r, e, op, rname, pn, st);
             }
           }
+          when (DType.BigInt, DType.BigInt) {
+            var l = toSymEntry(left,bigint);
+            var r = toSymEntry(right,bigint);
+            if boolOps.contains(op) {
+              // call bigint specific func which returns distr bool array
+              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
+              var repMsg = "created %s".format(st.attrib(rname));
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            // call bigint specific func which returns dist bigint array
+            var (tmp, max_bits) = doBigIntBinOpvv(l, r, op);
+            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var repMsg = "created %s".format(st.attrib(rname));
+            return new MsgTuple(repMsg, MsgType.NORMAL);
+          }
+          when (DType.BigInt, DType.Int64) {
+            var l = toSymEntry(left,bigint);
+            var r = toSymEntry(right,int);
+            if boolOps.contains(op) {
+              // call bigint specific func which returns distr bool array
+              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
+              var repMsg = "created %s".format(st.attrib(rname));
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            // call bigint specific func which returns dist bigint array
+            var (tmp, max_bits) = doBigIntBinOpvv(l, r, op);
+            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var repMsg = "created %s".format(st.attrib(rname));
+            return new MsgTuple(repMsg, MsgType.NORMAL);
+          }
+          when (DType.BigInt, DType.UInt64) {
+            var l = toSymEntry(left,bigint);
+            var r = toSymEntry(right,uint);
+            if boolOps.contains(op) {
+              // call bigint specific func which returns distr bool array
+              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
+              var repMsg = "created %s".format(st.attrib(rname));
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            // call bigint specific func which returns dist bigint array
+            var (tmp, max_bits) = doBigIntBinOpvv(l, r, op);
+            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var repMsg = "created %s".format(st.attrib(rname));
+            return new MsgTuple(repMsg, MsgType.NORMAL);
+          }
+          when (DType.BigInt, DType.Bool) {
+            var l = toSymEntry(left,bigint);
+            var r = toSymEntry(right,bool);
+            if boolOps.contains(op) {
+              // call bigint specific func which returns distr bool array
+              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
+              var repMsg = "created %s".format(st.attrib(rname));
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            // call bigint specific func which returns dist bigint array
+            var (tmp, max_bits) = doBigIntBinOpvv(l, r, op);
+            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var repMsg = "created %s".format(st.attrib(rname));
+            return new MsgTuple(repMsg, MsgType.NORMAL);
+          }
+          when (DType.Int64, DType.BigInt) {
+            var l = toSymEntry(left,int);
+            var r = toSymEntry(right,bigint);
+            if boolOps.contains(op) {
+              // call bigint specific func which returns distr bool array
+              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
+              var repMsg = "created %s".format(st.attrib(rname));
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            // call bigint specific func which returns dist bigint array
+            var (tmp, max_bits) = doBigIntBinOpvv(l, r, op);
+            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var repMsg = "created %s".format(st.attrib(rname));
+            return new MsgTuple(repMsg, MsgType.NORMAL);
+          }
+          when (DType.UInt64, DType.BigInt) {
+            var l = toSymEntry(left,uint);
+            var r = toSymEntry(right,bigint);
+            if boolOps.contains(op) {
+              // call bigint specific func which returns distr bool array
+              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
+              var repMsg = "created %s".format(st.attrib(rname));
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            // call bigint specific func which returns dist bigint array
+            var (tmp, max_bits) = doBigIntBinOpvv(l, r, op);
+            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var repMsg = "created %s".format(st.attrib(rname));
+            return new MsgTuple(repMsg, MsgType.NORMAL);
+          }
+          when (DType.Bool, DType.BigInt) {
+            var l = toSymEntry(left,bool);
+            var r = toSymEntry(right,bigint);
+            if boolOps.contains(op) {
+              // call bigint specific func which returns distr bool array
+              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
+              var repMsg = "created %s".format(st.attrib(rname));
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            // call bigint specific func which returns dist bigint array
+            var (tmp, max_bits) = doBigIntBinOpvv(l, r, op);
+            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var repMsg = "created %s".format(st.attrib(rname));
+            return new MsgTuple(repMsg, MsgType.NORMAL);
+          }
         }
         var errorMsg = unrecognizedTypeError(pn, "("+dtype2str(left.dtype)+","+dtype2str(right.dtype)+")");
         omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
@@ -459,6 +565,111 @@ module OperatorMsg
             }
             var e = st.addEntry(rname, l.size, int);
             return doBinOpvs(l, val, e, op, dtype, rname, pn, st); 
+          }
+          when (DType.BigInt, DType.BigInt) {
+            var l = toSymEntry(left,bigint);
+            var val = value.getBigIntValue();
+            if boolOps.contains(op) {
+              // call bigint specific func which returns distr bool array
+              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
+              var repMsg = "created %s".format(st.attrib(rname));
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            // call bigint specific func which returns dist bigint array
+            var (tmp, max_bits) = doBigIntBinOpvs(l, val, op);
+            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var repMsg = "created %s".format(st.attrib(rname));
+            return new MsgTuple(repMsg, MsgType.NORMAL);
+          }
+          when (DType.BigInt, DType.Int64) {
+            var l = toSymEntry(left,bigint);
+            var val = value.getIntValue();
+            if boolOps.contains(op) {
+              // call bigint specific func which returns distr bool array
+              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
+              var repMsg = "created %s".format(st.attrib(rname));
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            // call bigint specific func which returns dist bigint array
+            var (tmp, max_bits) = doBigIntBinOpvs(l, val, op);
+            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var repMsg = "created %s".format(st.attrib(rname));
+            return new MsgTuple(repMsg, MsgType.NORMAL);
+          }
+          when (DType.BigInt, DType.UInt64) {
+            var l = toSymEntry(left,bigint);
+            var val = value.getUIntValue();
+            if boolOps.contains(op) {
+              // call bigint specific func which returns distr bool array
+              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
+              var repMsg = "created %s".format(st.attrib(rname));
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            // call bigint specific func which returns dist bigint array
+            var (tmp, max_bits) = doBigIntBinOpvs(l, val, op);
+            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var repMsg = "created %s".format(st.attrib(rname));
+            return new MsgTuple(repMsg, MsgType.NORMAL);
+          }
+          when (DType.BigInt, DType.Bool) {
+            var l = toSymEntry(left,bigint);
+            var val = value.getBoolValue();
+            if boolOps.contains(op) {
+              // call bigint specific func which returns distr bool array
+              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
+              var repMsg = "created %s".format(st.attrib(rname));
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            // call bigint specific func which returns dist bigint array
+            var (tmp, max_bits) = doBigIntBinOpvs(l, val, op);
+            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var repMsg = "created %s".format(st.attrib(rname));
+            return new MsgTuple(repMsg, MsgType.NORMAL);
+          }
+          when (DType.Int64, DType.BigInt) {
+            var l = toSymEntry(left,int);
+            var val = value.getBigIntValue();
+            if boolOps.contains(op) {
+              // call bigint specific func which returns distr bool array
+              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
+              var repMsg = "created %s".format(st.attrib(rname));
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            // call bigint specific func which returns dist bigint array
+            var (tmp, max_bits) = doBigIntBinOpvs(l, val, op);
+            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var repMsg = "created %s".format(st.attrib(rname));
+            return new MsgTuple(repMsg, MsgType.NORMAL);
+          }
+          when (DType.UInt64, DType.BigInt) {
+            var l = toSymEntry(left,uint);
+            var val = value.getBigIntValue();
+            if boolOps.contains(op) {
+              // call bigint specific func which returns distr bool array
+              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
+              var repMsg = "created %s".format(st.attrib(rname));
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            // call bigint specific func which returns dist bigint array
+            var (tmp, max_bits) = doBigIntBinOpvs(l, val, op);
+            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var repMsg = "created %s".format(st.attrib(rname));
+            return new MsgTuple(repMsg, MsgType.NORMAL);
+          }
+          when (DType.Bool, DType.BigInt) {
+            var l = toSymEntry(left,bool);
+            var val = value.getBigIntValue();
+            if boolOps.contains(op) {
+              // call bigint specific func which returns distr bool array
+              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
+              var repMsg = "created %s".format(st.attrib(rname));
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            // call bigint specific func which returns dist bigint array
+            var (tmp, max_bits) = doBigIntBinOpvs(l, val, op);
+            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var repMsg = "created %s".format(st.attrib(rname));
+            return new MsgTuple(repMsg, MsgType.NORMAL);
           }
         }
         var errorMsg = unrecognizedTypeError(pn, "("+dtype2str(left.dtype)+","+dtype2str(dtype)+")");
@@ -682,6 +893,111 @@ module OperatorMsg
             }
             var e = st.addEntry(rname, r.size, uint);
             return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          }
+          when (DType.BigInt, DType.BigInt) {
+            var val = value.getBigIntValue();
+            var r = toSymEntry(right,bigint);
+            if boolOps.contains(op) {
+              // call bigint specific func which returns distr bool array
+              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
+              var repMsg = "created %s".format(st.attrib(rname));
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            // call bigint specific func which returns dist bigint array
+            var (tmp, max_bits) = doBigIntBinOpsv(val, r, op);
+            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var repMsg = "created %s".format(st.attrib(rname));
+            return new MsgTuple(repMsg, MsgType.NORMAL);
+          }
+          when (DType.BigInt, DType.Int64) {
+            var val = value.getBigIntValue();
+            var r = toSymEntry(right,int);
+            if boolOps.contains(op) {
+              // call bigint specific func which returns distr bool array
+              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
+              var repMsg = "created %s".format(st.attrib(rname));
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            // call bigint specific func which returns dist bigint array
+            var (tmp, max_bits) = doBigIntBinOpsv(val, r, op);
+            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var repMsg = "created %s".format(st.attrib(rname));
+            return new MsgTuple(repMsg, MsgType.NORMAL);
+          }
+          when (DType.BigInt, DType.UInt64) {
+            var val = value.getBigIntValue();
+            var r = toSymEntry(right,uint);
+            if boolOps.contains(op) {
+              // call bigint specific func which returns distr bool array
+              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
+              var repMsg = "created %s".format(st.attrib(rname));
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            // call bigint specific func which returns dist bigint array
+            var (tmp, max_bits) = doBigIntBinOpsv(val, r, op);
+            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var repMsg = "created %s".format(st.attrib(rname));
+            return new MsgTuple(repMsg, MsgType.NORMAL);
+          }
+          when (DType.BigInt, DType.Bool) {
+            var val = value.getBigIntValue();
+            var r = toSymEntry(right,bool);
+            if boolOps.contains(op) {
+              // call bigint specific func which returns distr bool array
+              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
+              var repMsg = "created %s".format(st.attrib(rname));
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            // call bigint specific func which returns dist bigint array
+            var (tmp, max_bits) = doBigIntBinOpsv(val, r, op);
+            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var repMsg = "created %s".format(st.attrib(rname));
+            return new MsgTuple(repMsg, MsgType.NORMAL);
+          }
+          when (DType.Int64, DType.BigInt) {
+            var val = value.getIntValue();
+            var r = toSymEntry(right,bigint);
+            if boolOps.contains(op) {
+              // call bigint specific func which returns distr bool array
+              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
+              var repMsg = "created %s".format(st.attrib(rname));
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            // call bigint specific func which returns dist bigint array
+            var (tmp, max_bits) = doBigIntBinOpsv(val, r, op);
+            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var repMsg = "created %s".format(st.attrib(rname));
+            return new MsgTuple(repMsg, MsgType.NORMAL);
+          }
+          when (DType.UInt64, DType.BigInt) {
+            var val = value.getUIntValue();
+            var r = toSymEntry(right,bigint);
+            if boolOps.contains(op) {
+              // call bigint specific func which returns distr bool array
+              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
+              var repMsg = "created %s".format(st.attrib(rname));
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            // call bigint specific func which returns dist bigint array
+            var (tmp, max_bits) = doBigIntBinOpsv(val, r, op);
+            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var repMsg = "created %s".format(st.attrib(rname));
+            return new MsgTuple(repMsg, MsgType.NORMAL);
+          }
+          when (DType.Bool, DType.BigInt) {
+            var val = value.getBoolValue();
+            var r = toSymEntry(right,bigint);
+            if boolOps.contains(op) {
+              // call bigint specific func which returns distr bool array
+              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
+              var repMsg = "created %s".format(st.attrib(rname));
+              return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            // call bigint specific func which returns dist bigint array
+            var (tmp, max_bits) = doBigIntBinOpsv(val, r, op);
+            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var repMsg = "created %s".format(st.attrib(rname));
+            return new MsgTuple(repMsg, MsgType.NORMAL);
           }
         }
         var errorMsg = unrecognizedTypeError(pn, "("+dtype2str(dtype)+","+dtype2str(right.dtype)+")");

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -306,7 +306,7 @@ class OperatorsTest(ArkoudaTest):
         ak_uint = ak.arange(10, dtype=ak.uint64)
         ak_bool = ak_uint % 2 == 0
         self.assertListEqual((ak_uint + ak_bool).to_list(), (ak.arange(10) + ak_bool).to_list())
-        
+
     def test_float_uint_binops(self):
         # Test fix for issue #1620
         ak_uint = ak.array([5], dtype=ak.uint64)
@@ -322,80 +322,32 @@ class OperatorsTest(ArkoudaTest):
         ak_floats = [ak_float, scalar_float]
         np_floats = [np_float, scalar_float]
         for aku, akf, npu, npf in zip(ak_uints, ak_floats, np_uints, np_floats):
-            self.assertTrue(
-                np.allclose((ak_uint + akf).to_ndarray(), np_uint + npf, equal_nan=True)
-            )
-            self.assertTrue(
-                np.allclose((akf + ak_uint).to_ndarray(), npf + np_uint, equal_nan=True)
-            )
-            self.assertTrue(
-                np.allclose((ak_float + aku).to_ndarray(), np_float + npu, equal_nan=True)
-            )
-            self.assertTrue(
-                np.allclose((aku + ak_float).to_ndarray(), npu + np_float, equal_nan=True)
-            )
+            self.assertTrue(np.allclose((ak_uint + akf).to_ndarray(), np_uint + npf, equal_nan=True))
+            self.assertTrue(np.allclose((akf + ak_uint).to_ndarray(), npf + np_uint, equal_nan=True))
+            self.assertTrue(np.allclose((ak_float + aku).to_ndarray(), np_float + npu, equal_nan=True))
+            self.assertTrue(np.allclose((aku + ak_float).to_ndarray(), npu + np_float, equal_nan=True))
 
-            self.assertTrue(
-                np.allclose((ak_uint - akf).to_ndarray(), np_uint - npf, equal_nan=True)
-            )
-            self.assertTrue(
-                np.allclose((akf - ak_uint).to_ndarray(), npf - np_uint, equal_nan=True)
-            )
-            self.assertTrue(
-                np.allclose((ak_float - aku).to_ndarray(), np_float - npu, equal_nan=True)
-            )
-            self.assertTrue(
-                np.allclose((aku - ak_float).to_ndarray(), npu - np_float, equal_nan=True)
-            )
+            self.assertTrue(np.allclose((ak_uint - akf).to_ndarray(), np_uint - npf, equal_nan=True))
+            self.assertTrue(np.allclose((akf - ak_uint).to_ndarray(), npf - np_uint, equal_nan=True))
+            self.assertTrue(np.allclose((ak_float - aku).to_ndarray(), np_float - npu, equal_nan=True))
+            self.assertTrue(np.allclose((aku - ak_float).to_ndarray(), npu - np_float, equal_nan=True))
 
-            self.assertTrue(
-                np.allclose((ak_uint * akf).to_ndarray(), np_uint * npf, equal_nan=True)
-            )
-            self.assertTrue(
-                np.allclose((akf * ak_uint).to_ndarray(), npf * np_uint, equal_nan=True)
-            )
-            self.assertTrue(
-                np.allclose((ak_float * aku).to_ndarray(), np_float * npu, equal_nan=True)
-            )
-            self.assertTrue(
-                np.allclose((aku * ak_float).to_ndarray(), npu * np_float, equal_nan=True)
-            )
-            self.assertTrue(
-                np.allclose((ak_uint / akf).to_ndarray(), np_uint / npf, equal_nan=True)
-            )
-            self.assertTrue(
-                np.allclose((akf / ak_uint).to_ndarray(), npf / np_uint, equal_nan=True)
-            )
-            self.assertTrue(
-                np.allclose((ak_float / aku).to_ndarray(), np_float / npu, equal_nan=True)
-            )
-            self.assertTrue(
-                np.allclose((aku / ak_float).to_ndarray(), npu / np_float, equal_nan=True)
-            )
-            self.assertTrue(
-                np.allclose((ak_uint // akf).to_ndarray(), np_uint // npf, equal_nan=True)
-            )
-            self.assertTrue(
-                np.allclose((akf // ak_uint).to_ndarray(), npf // np_uint, equal_nan=True)
-            )
-            self.assertTrue(
-                np.allclose((ak_float // aku).to_ndarray(), np_float // npu, equal_nan=True)
-            )
-            self.assertTrue(
-                np.allclose((aku // ak_float).to_ndarray(), npu // np_float, equal_nan=True)
-            )
-            self.assertTrue(
-                np.allclose((ak_uint ** akf).to_ndarray(), np_uint ** npf, equal_nan=True)
-            )
-            self.assertTrue(
-                np.allclose((akf ** ak_uint).to_ndarray(), npf ** np_uint, equal_nan=True)
-            )
-            self.assertTrue(
-                np.allclose((ak_float ** aku).to_ndarray(), np_float ** npu, equal_nan=True)
-            )
-            self.assertTrue(
-                np.allclose((aku ** ak_float).to_ndarray(), npu ** np_float, equal_nan=True)
-            )
+            self.assertTrue(np.allclose((ak_uint * akf).to_ndarray(), np_uint * npf, equal_nan=True))
+            self.assertTrue(np.allclose((akf * ak_uint).to_ndarray(), npf * np_uint, equal_nan=True))
+            self.assertTrue(np.allclose((ak_float * aku).to_ndarray(), np_float * npu, equal_nan=True))
+            self.assertTrue(np.allclose((aku * ak_float).to_ndarray(), npu * np_float, equal_nan=True))
+            self.assertTrue(np.allclose((ak_uint / akf).to_ndarray(), np_uint / npf, equal_nan=True))
+            self.assertTrue(np.allclose((akf / ak_uint).to_ndarray(), npf / np_uint, equal_nan=True))
+            self.assertTrue(np.allclose((ak_float / aku).to_ndarray(), np_float / npu, equal_nan=True))
+            self.assertTrue(np.allclose((aku / ak_float).to_ndarray(), npu / np_float, equal_nan=True))
+            self.assertTrue(np.allclose((ak_uint // akf).to_ndarray(), np_uint // npf, equal_nan=True))
+            self.assertTrue(np.allclose((akf // ak_uint).to_ndarray(), npf // np_uint, equal_nan=True))
+            self.assertTrue(np.allclose((ak_float // aku).to_ndarray(), np_float // npu, equal_nan=True))
+            self.assertTrue(np.allclose((aku // ak_float).to_ndarray(), npu // np_float, equal_nan=True))
+            self.assertTrue(np.allclose((ak_uint**akf).to_ndarray(), np_uint**npf, equal_nan=True))
+            self.assertTrue(np.allclose((akf**ak_uint).to_ndarray(), npf**np_uint, equal_nan=True))
+            self.assertTrue(np.allclose((ak_float**aku).to_ndarray(), np_float**npu, equal_nan=True))
+            self.assertTrue(np.allclose((aku**ak_float).to_ndarray(), npu**np_float, equal_nan=True))
 
     def test_concatenate_type_preservation(self):
         # Test that concatenate preserves special pdarray types (IPv4, Datetime, BitVector, ...)
@@ -537,8 +489,9 @@ class OperatorsTest(ArkoudaTest):
 
         # Test a singleton with a mixed Boolean argument
         a = ak.arange(10)
-        self.assertListEqual([i if i % 2 else i**2 for i in range(10)],
-                             ak.power(a, 2, a % 2 == 0).to_list())
+        self.assertListEqual(
+            [i if i % 2 else i**2 for i in range(10)], ak.power(a, 2, a % 2 == 0).to_list()
+        )
 
         # Test invalid input, negative
         n = np.array([-1.0, -3.0])
@@ -562,7 +515,9 @@ class OperatorsTest(ArkoudaTest):
 
         # Test with a mixed Boolean array
         a = ak.arange(5)
-        self.assertListEqual([i if i % 2 else i**.5 for i in range(5)], ak.sqrt(a, a % 2 == 0).to_list())
+        self.assertListEqual(
+            [i if i % 2 else i**0.5 for i in range(5)], ak.sqrt(a, a % 2 == 0).to_list()
+        )
 
     def test_uint_operation_equals(self):
         u_arr = ak.arange(10, dtype=ak.uint64)
@@ -694,6 +649,145 @@ class OperatorsTest(ArkoudaTest):
         ak.client.pdarrayIterThresh = (
             ak.client.pdarrayIterThreshDefVal
         )  # Don't forget to set this back for other tests.
+
+    def test_bigint_binops(self):
+        # test bigint array with max_bits=64 against an equivalent uint64
+        u = ak.array([0, 1, 2, 2**64 - 3, 2**64 - 2, 2**64 - 1], dtype=ak.uint64)
+        bi = ak.array([0, 1, 2, 2**64 - 3, 2**64 - 2, 2**64 - 1], dtype=ak.bigint, max_bits=64)
+        mod_by = 2**64
+
+        bi_range = ak.arange(6, dtype=ak.bigint)
+        u_range = ak.arange(6, dtype=ak.uint64)
+        i_range = ak.arange(6, dtype=ak.int64)
+        neg_range = -i_range
+        b = u_range % 2 == 0
+        bi_scalar = 2**100
+        i_scalar = -10
+        u_scalar = 10
+
+        # TODO update once to_ndarray supports bigint to not cast into uint
+
+        # logical bit ops: only work if both arguments are bigint
+        self.assertListEqual((u & u_range).to_list(), ak.cast((bi & bi_range), ak.uint64).to_list())
+        self.assertListEqual(
+            [(bi[i] & bi_scalar) % mod_by for i in range(bi.size)],
+            ak.cast((bi & bi_scalar), ak.uint64).to_list(),
+        )
+        self.assertListEqual(
+            [(bi_scalar & bi[i]) % mod_by for i in range(bi.size)],
+            ak.cast((bi_scalar & bi), ak.uint64).to_list(),
+        )
+
+        self.assertListEqual((u | u_range).to_list(), ak.cast((bi | bi_range), ak.uint64).to_list())
+        self.assertListEqual(
+            [(bi[i] | bi_scalar) % mod_by for i in range(bi.size)],
+            ak.cast((bi | bi_scalar), ak.uint64).to_list(),
+        )
+        self.assertListEqual(
+            [(bi_scalar | bi[i]) % mod_by for i in range(bi.size)],
+            ak.cast((bi_scalar | bi), ak.uint64).to_list(),
+        )
+
+        self.assertListEqual((u ^ u_range).to_list(), ak.cast((bi ^ bi_range), ak.uint64).to_list())
+        self.assertListEqual(
+            [(bi[i] ^ bi_scalar) % mod_by for i in range(bi.size)],
+            ak.cast((bi ^ bi_scalar), ak.uint64).to_list(),
+        )
+        self.assertListEqual(
+            [(bi_scalar ^ bi[i]) % mod_by for i in range(bi.size)],
+            ak.cast((bi_scalar ^ bi), ak.uint64).to_list(),
+        )
+
+        # bit shifts: left side must be bigint, right side must be int/uint
+        ans = u << u_range
+        self.assertListEqual(ans.to_list(), ak.cast((bi << u_range), ak.uint64).to_list())
+        self.assertListEqual(ans.to_list(), ak.cast((bi << i_range), ak.uint64).to_list())
+
+        ans = u >> u_range
+        self.assertListEqual(ans.to_list(), ak.cast((bi >> u_range), ak.uint64).to_list())
+        self.assertListEqual(ans.to_list(), ak.cast((bi >> i_range), ak.uint64).to_list())
+
+        ans = u.rotl(u_range)
+        self.assertListEqual(ans.to_list(), ak.cast((bi.rotl(u_range)), ak.uint64).to_list())
+        self.assertListEqual(ans.to_list(), ak.cast((bi.rotl(i_range)), ak.uint64).to_list())
+        ans = u.rotr(u_range)
+        self.assertListEqual(ans.to_list(), ak.cast((bi.rotr(u_range)), ak.uint64).to_list())
+        self.assertListEqual(ans.to_list(), ak.cast((bi.rotr(i_range)), ak.uint64).to_list())
+
+        # ops where left side has to bigint
+        ans = u // u_range
+        self.assertListEqual(ans.to_list(), ak.cast((bi // bi_range), ak.uint64).to_list())
+        self.assertListEqual(ans.to_list(), ak.cast((bi // u_range), ak.uint64).to_list())
+        self.assertListEqual(ans.to_list(), ak.cast((bi // i_range), ak.uint64).to_list())
+
+        ans = u % u_range
+        self.assertListEqual(ans.to_list(), ak.cast((bi % bi_range), ak.uint64).to_list())
+        self.assertListEqual(ans.to_list(), ak.cast((bi % u_range), ak.uint64).to_list())
+        self.assertListEqual(ans.to_list(), ak.cast((bi % i_range), ak.uint64).to_list())
+
+        ans = u**u_range
+        self.assertListEqual(ans.to_list(), ak.cast((bi**bi_range), ak.uint64).to_list())
+        self.assertListEqual(ans.to_list(), ak.cast((bi**u_range), ak.uint64).to_list())
+        self.assertListEqual(ans.to_list(), ak.cast((bi**i_range), ak.uint64).to_list())
+
+        # ops where either side can any of bigint, int, uint, bool
+        ans = u + u_range
+        self.assertListEqual(ans.to_list(), ak.cast((bi + bi_range), ak.uint64).to_list())
+        self.assertListEqual(ans.to_list(), ak.cast((bi + u_range), ak.uint64).to_list())
+        self.assertListEqual(ans.to_list(), ak.cast((bi + i_range), ak.uint64).to_list())
+        self.assertListEqual(ans.to_list(), ak.cast((i_range + bi), ak.uint64).to_list())
+        self.assertListEqual(ans.to_list(), ak.cast((u_range + bi), ak.uint64).to_list())
+        ans = u + b
+        self.assertListEqual(ans.to_list(), ak.cast((bi + b), ak.uint64).to_list())
+        self.assertListEqual(ans.to_list(), ak.cast((b + bi), ak.uint64).to_list())
+        for s in [i_scalar, u_scalar, bi_scalar]:
+            self.assertListEqual(
+                [(bi[i] + s) % mod_by for i in range(bi.size)],
+                ak.cast((bi + s), ak.uint64).to_list(),
+            )
+            self.assertListEqual(
+                [(s + bi[i]) % mod_by for i in range(bi.size)],
+                ak.cast((s + bi), ak.uint64).to_list(),
+            )
+
+        ans = u - u_range
+        self.assertListEqual(ans.to_list(), ak.cast((bi - bi_range), ak.uint64).to_list())
+        self.assertListEqual(ans.to_list(), ak.cast((bi - u_range), ak.uint64).to_list())
+        self.assertListEqual(ans.to_list(), ak.cast((bi - i_range), ak.uint64).to_list())
+        self.assertListEqual((u - b).to_list(), ak.cast((bi - b), ak.uint64).to_list())
+        self.assertListEqual((b - u).to_list(), ak.cast((b - bi), ak.uint64).to_list())
+
+        for s in [i_scalar, u_scalar, bi_scalar]:
+            self.assertListEqual(
+                [(bi[i] - s) % mod_by for i in range(bi.size)],
+                ak.cast((bi - s), ak.uint64).to_list(),
+            )
+            self.assertListEqual(
+                [(s - bi[i]) % mod_by for i in range(bi.size)],
+                ak.cast((s - bi), ak.uint64).to_list(),
+            )
+
+        self.assertListEqual(
+            ak.cast((bi - neg_range), ak.uint64).to_list(), ak.cast((bi + u_range), ak.uint64).to_list()
+        )
+
+        ans = u * u_range
+        self.assertListEqual(ans.to_list(), ak.cast((bi * bi_range), ak.uint64).to_list())
+        self.assertListEqual(ans.to_list(), ak.cast((bi * u_range), ak.uint64).to_list())
+        self.assertListEqual(ans.to_list(), ak.cast((bi * i_range), ak.uint64).to_list())
+        ans = u * b
+        self.assertListEqual(ans.to_list(), ak.cast((bi * b), ak.uint64).to_list())
+        self.assertListEqual(ans.to_list(), ak.cast((b * bi), ak.uint64).to_list())
+
+        for s in [i_scalar, u_scalar, bi_scalar]:
+            self.assertListEqual(
+                [(bi[i] * s) % mod_by for i in range(bi.size)],
+                ak.cast((bi * s), ak.uint64).to_list(),
+            )
+            self.assertListEqual(
+                [(s * bi[i]) % mod_by for i in range(bi.size)],
+                ak.cast((s * bi), ak.uint64).to_list(),
+            )
 
 
 if __name__ == "__main__":

--- a/tests/pdarray_creation_test.py
+++ b/tests/pdarray_creation_test.py
@@ -90,6 +90,16 @@ class PdarrayCreationTest(ArkoudaTest):
         for i in range(5):
             self.assertEqual(2**128 + i, three_arrays[i])
 
+        # test round_trip of ak.bigint_to/from_uint_arrays
+        t = ak.arange(bi - 1, bi + 9)
+        t_dup = ak.bigint_from_uint_arrays(t.bigint_to_uint_arrays())
+        self.assertListEqual(ak.cast(t, ak.uint64).to_list(), ak.cast(t_dup, ak.uint64).to_list())
+
+        # test slice_bits along 64 bit boundaries matches return from bigint_to_uint_arrays
+        for i, uint_bits in enumerate(t.bigint_to_uint_arrays()):
+            slice_bits = t.slice_bits(64 * (4 - (i + 1)), 64 * (4 - i))
+            self.assertListEqual(uint_bits.to_list(), ak.cast(slice_bits, ak.uint64).to_list())
+
     def test_arange(self):
         self.assertListEqual([0, 1, 2, 3, 4], ak.arange(0, 5, 1).to_list())
         self.assertListEqual([5, 4, 3, 2, 1], ak.arange(5, 0, -1).to_list())


### PR DESCRIPTION
This PR (closes #1995):
- Adds `binopvv`, `binopsv`, `binopvs` for `bigint`
- Adds `.bigint_to_uint_arrays`
- Adds `slice_bits`
- Adds testing for all this functionality

Note: I'm going to add operation equals for binops in a separate PR (see issue #2000) since this got a bit long