### PR TITLE
Closes #1166: Adding additional `ak.DataFrame` Features

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -829,8 +829,6 @@ class DataFrame(UserDict):
         """
         return self.head(1)
 
-
-
     @property
     def dtypes(self):
         dtypes = []

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -823,6 +823,15 @@ class DataFrame(UserDict):
         return self._size
 
     @property
+    def first(self):
+        """
+        Returns the first group in a DataFrame
+        """
+        return self.head(1)
+
+
+
+    @property
     def dtypes(self):
         dtypes = []
         keys = []

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -22,7 +22,6 @@ def build_ak_df():
         {"userName": username, "userID": userid, "item": item, "day": day, "amount": amount}
     )
 
-
 def build_ak_df_duplicates():
     username = ak.array(["Alice", "Bob", "Alice", "Carol", "Bob", "Alice"])
     userid = ak.array([111, 222, 111, 333, 222, 111])
@@ -346,6 +345,15 @@ class DataFrameTest(ArkoudaTest):
         hdf = df.head(3)
         hdf_ref = ref_df.head(3).reset_index(drop=True)
         self.assertTrue(hdf_ref.equals(hdf.to_pandas()))
+
+    def test_first(self):
+        "special case of the head function, only calling the first row of the data frame"
+        df = build_ak_df()
+        ref_df = build_pd_df()
+
+        firstdf = df.first
+        firstdf_ref = ref_df.head(1).reset_index(drop=True)
+        self.assertTrue(firstdf_ref.equals(firstdf.to_pandas()))
 
     def test_tail(self):
         df = build_ak_df()


### PR DESCRIPTION
This PR (closes #1166) implements a `.first` feature and testing to DataFrames. This was done by creating a special case using the `.head` function.

The issue this PR is based on also requested to have GroupBy functionality, but those features may already be implemented.