### PR TITLE
Closes #1991 - Additional Compression Support for Parquet

### DIFF
--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -922,7 +922,7 @@ class Categorical:
                         prefix_path,
                         dataset=f"{dataset}.{k}",
                         mode=(mode if first else "append"),
-                        compressed=compressed,
+                        compression=compression,
                     )
                 )
                 first = False

--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -875,7 +875,7 @@ class Categorical:
         prefix_path: str,
         dataset: str = "categorical_array",
         mode: str = "truncate",
-        compressed: bool = False,
+        compression: Optional[str] = None,
     ) -> str:
         """
         Save the Categorical object to Parquet. The result is a collection of Parquet files,
@@ -892,8 +892,10 @@ class Categorical:
         mode : str {'truncate' | 'append'}
             By default, truncate (overwrite) output files, if they exist.
             If 'append', create a new Categorical dataset within existing files.
-        compressed : bool
-            By default, write without Snappy compression and RLE encoding.
+        compression : str (Optional)
+            Default None
+            Provide the compression type to use when writing the file.
+            Supported values: snappy, gzip, brotli, zstd, lz4
 
         Returns
         -------

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -1486,7 +1486,7 @@ class DataFrame(UserDict):
         data = self._prep_data(index=index, columns=columns)
         to_hdf(data, prefix_path=path, file_type=file_type)
 
-    def to_parquet(self, path, index=False, columns=None):
+    def to_parquet(self, path, index=False, columns=None, compression: Optional[str] = None):
         """
         Save DataFrame to disk as parquet, preserving column names.
 
@@ -1498,9 +1498,10 @@ class DataFrame(UserDict):
             If True, save the index column. By default, do not save the index.
         columns: List
             List of columns to include in the file. If None, writes out all columns
-        file_type: str (single | distribute)
-            Default: distribute
-            Whether to save to a single file or distribute across Locales
+        compression : str (Optional)
+            Default None
+            Provide the compression type to use when writing the file.
+            Supported values: snappy, gzip, brotli, zstd, lz4
 
         Notes
         -----
@@ -1510,7 +1511,7 @@ class DataFrame(UserDict):
         """
         from arkouda.io import to_parquet
         data = self._prep_data(index=index, columns=columns)
-        to_parquet(data, prefix_path=path)
+        to_parquet(data, prefix_path=path, compression=compression)
 
     @classmethod
     def load(cls, prefix_path, file_format="INFER"):

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -205,9 +205,9 @@ class Index:
         return self.values.to_hdf(prefix_path, dataset=dataset, mode=mode, file_type=file_type)
 
     def to_parquet(
-        self, prefix_path: str, dataset: str = "index", mode: str = "truncate", compressed: bool = False
+        self, prefix_path: str, dataset: str = "index", mode: str = "truncate", compression: Optional[str] = None
     ):
-        return self.values.to_parquet(prefix_path, dataset=dataset, mode=mode, compressed=compressed)
+        return self.values.to_parquet(prefix_path, dataset=dataset, mode=mode, compression=compression)
 
 
 class MultiIndex(Index):

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -205,7 +205,11 @@ class Index:
         return self.values.to_hdf(prefix_path, dataset=dataset, mode=mode, file_type=file_type)
 
     def to_parquet(
-        self, prefix_path: str, dataset: str = "index", mode: str = "truncate", compression: Optional[str] = None
+        self,
+        prefix_path: str,
+        dataset: str = "index",
+        mode: str = "truncate",
+        compression: Optional[str] = None,
     ):
         return self.values.to_parquet(prefix_path, dataset=dataset, mode=mode, compression=compression)
 

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -876,7 +876,7 @@ def to_parquet(
     # append or single column use the old logic
     if mode.lower() == "append" or len(pdarrays) == 1:
         for arr, name in zip(pdarrays, cast(List[str], datasetNames)):
-            arr.to_parquet(prefix_path=prefix_path, dataset=name, mode=mode, compressed=compression)
+            arr.to_parquet(prefix_path=prefix_path, dataset=name, mode=mode, compression=compression)
     else:
         print(
             cast(

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -697,7 +697,9 @@ def import_data(read_path: str, write_file: str = None, return_obj: bool = True,
     df = DataFrame(df_def)
 
     if write_file:
-        df.to_hdf(write_file, index=index) if filetype == "HDF5" else df.to_parquet(write_file, index=index)
+        df.to_hdf(write_file, index=index) if filetype == "HDF5" else df.to_parquet(
+            write_file, index=index
+        )
 
     if return_obj:
         return df
@@ -880,7 +882,8 @@ def to_parquet(
             # TODO update all other to_parquet calls
             arr.to_parquet(prefix_path=prefix_path, dataset=name, mode=mode, compressed=compression)
     else:
-        print(cast(
+        print(
+            cast(
                 str,
                 generic_msg(
                     cmd="toParquet_multi",
@@ -891,7 +894,7 @@ def to_parquet(
                         "num_cols": len(pdarrays),
                         "compression": compression,
                     },
-                )
+                ),
             )
         )
 

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -872,14 +872,10 @@ def to_parquet(
             DeprecationWarning,
         )
 
-    # TODO - ensure that compression is valid
-    # TODO - write method to convert compression string to int
-
     datasetNames, pdarrays = _bulk_write_prep(columns, names)
     # append or single column use the old logic
     if mode.lower() == "append" or len(pdarrays) == 1:
         for arr, name in zip(pdarrays, cast(List[str], datasetNames)):
-            # TODO update all other to_parquet calls
             arr.to_parquet(prefix_path=prefix_path, dataset=name, mode=mode, compressed=compression)
     else:
         print(

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -697,10 +697,7 @@ def import_data(read_path: str, write_file: str = None, return_obj: bool = True,
     df = DataFrame(df_def)
 
     if write_file:
-        if filetype == "HDF5":
-            df.to_hdf(write_file, index=index)
-        elif filetype == "Parquet":
-            df.to_parquet(write_file, index=index)
+        df.to_hdf(write_file, index=index) if filetype == "HDF5" else df.to_parquet(write_file, index=index)
 
     if return_obj:
         return df
@@ -805,7 +802,7 @@ def to_parquet(
     prefix_path: str,
     names: List[str] = None,
     mode: str = "truncate",
-    compressed: bool = False,
+    compression: Optional[str] = None,
 ) -> None:
     """
     Save multiple named pdarrays to Parquet files.
@@ -822,6 +819,10 @@ def to_parquet(
         By default, truncate (overwrite) the output files if they exist.
         If 'append', attempt to create new dataset in existing files.
         'append' is deprecated, please use the multi-column write
+    compression : str (Optional)
+            Default None
+            Provide the compression type to use when writing the file.
+            Supported values: snappy, gzip, brotli, zstd, lz4
 
 
     Returns
@@ -869,14 +870,17 @@ def to_parquet(
             DeprecationWarning,
         )
 
+    # TODO - ensure that compression is valid
+    # TODO - write method to convert compression string to int
+
     datasetNames, pdarrays = _bulk_write_prep(columns, names)
     # append or single column use the old logic
     if mode.lower() == "append" or len(pdarrays) == 1:
         for arr, name in zip(pdarrays, cast(List[str], datasetNames)):
-            arr.to_parquet(prefix_path=prefix_path, dataset=name, mode=mode, compressed=compressed)
+            # TODO update all other to_parquet calls
+            arr.to_parquet(prefix_path=prefix_path, dataset=name, mode=mode, compressed=compression)
     else:
-        print(
-            cast(
+        print(cast(
                 str,
                 generic_msg(
                     cmd="toParquet_multi",
@@ -885,9 +889,9 @@ def to_parquet(
                         "col_names": datasetNames,
                         "filename": prefix_path,
                         "num_cols": len(pdarrays),
-                        "compressed": compressed,
+                        "compression": compression,
                     },
-                ),
+                )
             )
         )
 

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import builtins
 import json
-from typing import List, Sequence, Union, cast
+from typing import List, Optional, Sequence, Union, cast
 
 import numpy as np  # type: ignore
 from typeguard import typechecked
@@ -1331,7 +1331,11 @@ class pdarray:
 
     @typechecked
     def to_parquet(
-        self, prefix_path: str, dataset: str = "array", mode: str = "truncate", compression: Optional[str] = None
+        self,
+        prefix_path: str,
+        dataset: str = "array",
+        mode: str = "truncate",
+        compression: Optional[str] = None,
     ) -> str:
         from arkouda.io import mode_str_to_int
 

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1331,7 +1331,7 @@ class pdarray:
 
     @typechecked
     def to_parquet(
-        self, prefix_path: str, dataset: str = "array", mode: str = "truncate", compressed: bool = False
+        self, prefix_path: str, dataset: str = "array", mode: str = "truncate", compression: Optional[str] = None
     ) -> str:
         from arkouda.io import mode_str_to_int
 
@@ -1345,7 +1345,7 @@ class pdarray:
                     "mode": mode_str_to_int(mode),
                     "prefix": prefix_path,
                     "dtype": self.dtype,
-                    "compressed": compressed,
+                    "compression": compression,
                 },
             ),
         )

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1880,7 +1880,7 @@ class Strings:
         prefix_path: str,
         dataset: str = "strings_array",
         mode: str = "truncate",
-        compressed: bool = False,
+        compression: Optional[str] = None,
     ) -> str:
         """
         Save the Strings object to Parquet. The result is a collection of Parquet files,
@@ -1897,9 +1897,10 @@ class Strings:
         mode : str {'truncate' | 'append'}
             By default, truncate (overwrite) output files, if they exist.
             If 'append', create a new Strings dataset within existing files.
-        compressed : bool
-            Defaults to False. When True, files will be written with Snappy compression
-            and RLE bit packing.
+        compression : str (Optional)
+            Default None
+            Provide the compression type to use when writing the file.
+            Supported values: snappy, gzip, brotli, zstd, lz4
 
         Returns
         -------
@@ -1925,7 +1926,7 @@ class Strings:
                     "mode": mode_str_to_int(mode),
                     "prefix": prefix_path,
                     "dtype": self.dtype,
-                    "compressed": compressed,
+                    "compression": compression,
                 },
             ),
         )

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -390,7 +390,7 @@ std::shared_ptr<parquet::schema::GroupNode> SetupSchema(void* column_names, void
 int cpp_writeMultiColToParquet(const char* filename, void* column_names, 
                                 void** ptr_arr, void* datatypes,
                                 int64_t colnum, int64_t numelems, int64_t rowGroupSize,
-                                bool compressed, char** errMsg) {
+                                int64_t compression, char** errMsg) {
   try {
     // initialize the file to write to
     using FileClass = ::arrow::io::FileOutputStream;
@@ -401,8 +401,21 @@ int cpp_writeMultiColToParquet(const char* filename, void* column_names,
     std::shared_ptr<parquet::schema::GroupNode> schema = SetupSchema(column_names, datatypes, colnum);
 
     parquet::WriterProperties::Builder builder;
-    if(compressed) {
+    // assign the proper compression
+    if(compression == SNAPPY_COMP) {
       builder.compression(parquet::Compression::SNAPPY);
+      builder.encoding(parquet::Encoding::RLE);
+    } else if (compression == GZIP_COMP) {
+      builder.compression(parquet::Compression::GZIP);
+      builder.encoding(parquet::Encoding::RLE);
+    } else if (compression == BROTLI_COMP) {
+      builder.compression(parquet::Compression::BROTLI);
+      builder.encoding(parquet::Encoding::RLE);
+    } else if (compression == ZSTD_COMP) {
+      builder.compression(parquet::Compression::ZSTD);
+      builder.encoding(parquet::Encoding::RLE);
+    } else if (compression == LZ4_COMP) {
+      builder.compression(parquet::Compression::LZ4);
       builder.encoding(parquet::Encoding::RLE);
     }
     std::shared_ptr<parquet::WriterProperties> props = builder.build();
@@ -490,7 +503,7 @@ int cpp_writeMultiColToParquet(const char* filename, void* column_names,
 
 int cpp_writeColumnToParquet(const char* filename, void* chpl_arr,
                              int64_t colnum, const char* dsetname, int64_t numelems,
-                             int64_t rowGroupSize, int64_t dtype, bool compressed,
+                             int64_t rowGroupSize, int64_t dtype, int64_t compression,
                              char** errMsg) {
   try {
     using FileClass = ::arrow::io::FileOutputStream;
@@ -510,8 +523,21 @@ int cpp_writeColumnToParquet(const char* filename, void* chpl_arr,
       (parquet::schema::GroupNode::Make("schema", parquet::Repetition::REQUIRED, fields));
 
     parquet::WriterProperties::Builder builder;
-    if(compressed) {
+    // assign the proper compression
+    if(compression == SNAPPY_COMP) {
       builder.compression(parquet::Compression::SNAPPY);
+      builder.encoding(parquet::Encoding::RLE);
+    } else if (compression == GZIP_COMP) {
+      builder.compression(parquet::Compression::GZIP);
+      builder.encoding(parquet::Encoding::RLE);
+    } else if (compression == BROTLI_COMP) {
+      builder.compression(parquet::Compression::BROTLI);
+      builder.encoding(parquet::Encoding::RLE);
+    } else if (compression == ZSTD_COMP) {
+      builder.compression(parquet::Compression::ZSTD);
+      builder.encoding(parquet::Encoding::RLE);
+    } else if (compression == LZ4_COMP) {
+      builder.compression(parquet::Compression::LZ4);
       builder.encoding(parquet::Encoding::RLE);
     }
     std::shared_ptr<parquet::WriterProperties> props = builder.build();
@@ -580,7 +606,7 @@ int cpp_writeColumnToParquet(const char* filename, void* chpl_arr,
 
 int cpp_writeStrColumnToParquet(const char* filename, void* chpl_arr, void* chpl_offsets,
                                 const char* dsetname, int64_t numelems,
-                                int64_t rowGroupSize, int64_t dtype, bool compressed,
+                                int64_t rowGroupSize, int64_t dtype, int64_t compression,
                                 char** errMsg) {
   try {
     using FileClass = ::arrow::io::FileOutputStream;
@@ -594,8 +620,21 @@ int cpp_writeStrColumnToParquet(const char* filename, void* chpl_arr, void* chpl
       (parquet::schema::GroupNode::Make("schema", parquet::Repetition::REQUIRED, fields));
 
     parquet::WriterProperties::Builder builder;
-    if(compressed) {
+    // assign the proper compression
+    if(compression == SNAPPY_COMP) {
       builder.compression(parquet::Compression::SNAPPY);
+      builder.encoding(parquet::Encoding::RLE);
+    } else if (compression == GZIP_COMP) {
+      builder.compression(parquet::Compression::GZIP);
+      builder.encoding(parquet::Encoding::RLE);
+    } else if (compression == BROTLI_COMP) {
+      builder.compression(parquet::Compression::BROTLI);
+      builder.encoding(parquet::Encoding::RLE);
+    } else if (compression == ZSTD_COMP) {
+      builder.compression(parquet::Compression::ZSTD);
+      builder.encoding(parquet::Encoding::RLE);
+    } else if (compression == LZ4_COMP) {
+      builder.compression(parquet::Compression::LZ4);
       builder.encoding(parquet::Encoding::RLE);
     }
     std::shared_ptr<parquet::WriterProperties> props = builder.build();
@@ -644,7 +683,7 @@ int cpp_writeStrColumnToParquet(const char* filename, void* chpl_arr, void* chpl
 }
 
 int cpp_createEmptyParquetFile(const char* filename, const char* dsetname, int64_t dtype,
-                               bool compressed, char** errMsg) {
+                               int64_t compression, char** errMsg) {
   try {
     using FileClass = ::arrow::io::FileOutputStream;
     std::shared_ptr<FileClass> out_file;
@@ -665,8 +704,21 @@ int cpp_createEmptyParquetFile(const char* filename, const char* dsetname, int64
       (parquet::schema::GroupNode::Make("schema", parquet::Repetition::REQUIRED, fields));
 
     parquet::WriterProperties::Builder builder;
-    if(compressed) {
+    // assign the proper compression
+    if(compression == SNAPPY_COMP) {
       builder.compression(parquet::Compression::SNAPPY);
+      builder.encoding(parquet::Encoding::RLE);
+    } else if (compression == GZIP_COMP) {
+      builder.compression(parquet::Compression::GZIP);
+      builder.encoding(parquet::Encoding::RLE);
+    } else if (compression == BROTLI_COMP) {
+      builder.compression(parquet::Compression::BROTLI);
+      builder.encoding(parquet::Encoding::RLE);
+    } else if (compression == ZSTD_COMP) {
+      builder.compression(parquet::Compression::ZSTD);
+      builder.encoding(parquet::Encoding::RLE);
+    } else if (compression == LZ4_COMP) {
+      builder.compression(parquet::Compression::LZ4);
       builder.encoding(parquet::Encoding::RLE);
     }
     std::shared_ptr<parquet::WriterProperties> props = builder.build();
@@ -685,7 +737,7 @@ int cpp_createEmptyParquetFile(const char* filename, const char* dsetname, int64
 
 int cpp_appendColumnToParquet(const char* filename, void* chpl_arr,
                               const char* dsetname, int64_t numelems,
-                              int64_t dtype, bool compressed,
+                              int64_t dtype, int64_t compression,
                               char** errMsg) {
   try {
     std::shared_ptr<arrow::io::ReadableFile> infile;
@@ -856,33 +908,33 @@ extern "C" {
 
   int c_writeColumnToParquet(const char* filename, void* chpl_arr,
                              int64_t colnum, const char* dsetname, int64_t numelems,
-                             int64_t rowGroupSize, int64_t dtype, bool compressed,
+                             int64_t rowGroupSize, int64_t dtype, int64_t compression,
                              char** errMsg) {
     return cpp_writeColumnToParquet(filename, chpl_arr, colnum, dsetname,
-                                    numelems, rowGroupSize, dtype, compressed,
+                                    numelems, rowGroupSize, dtype, compression,
                                     errMsg);
   }
   
   int c_writeStrColumnToParquet(const char* filename, void* chpl_arr, void* chpl_offsets,
                                 const char* dsetname, int64_t numelems,
-                                int64_t rowGroupSize, int64_t dtype, bool compressed,
+                                int64_t rowGroupSize, int64_t dtype, int64_t compression,
                                 char** errMsg) {
     return cpp_writeStrColumnToParquet(filename, chpl_arr, chpl_offsets,
-                                       dsetname, numelems, rowGroupSize, dtype, compressed, errMsg);
+                                       dsetname, numelems, rowGroupSize, dtype, compression, errMsg);
   }
 
   int c_createEmptyParquetFile(const char* filename, const char* dsetname, int64_t dtype,
-                               bool compressed, char** errMsg) {
-    return cpp_createEmptyParquetFile(filename, dsetname, dtype, compressed, errMsg);
+                               int64_t compression, char** errMsg) {
+    return cpp_createEmptyParquetFile(filename, dsetname, dtype, compression, errMsg);
   }
 
   int c_appendColumnToParquet(const char* filename, void* chpl_arr,
                               const char* dsetname, int64_t numelems,
-                              int64_t dtype, bool compressed,
+                              int64_t dtype, int64_t compression,
                               char** errMsg) {
     return cpp_appendColumnToParquet(filename, chpl_arr,
                                      dsetname, numelems,
-                                     dtype, compressed,
+                                     dtype, compression,
                                      errMsg);
   }
 
@@ -909,7 +961,7 @@ extern "C" {
   int c_writeMultiColToParquet(const char* filename, void* column_names, 
                                 void** ptr_arr, void* datatypes,
                                 int64_t colnum, int64_t numelems, int64_t rowGroupSize,
-                                bool compressed, char** errMsg){
-    return cpp_writeMultiColToParquet(filename, column_names, ptr_arr, datatypes, colnum, numelems, rowGroupSize, compressed, errMsg);
+                                int64_t compression, char** errMsg){
+    return cpp_writeMultiColToParquet(filename, column_names, ptr_arr, datatypes, colnum, numelems, rowGroupSize, compression, errMsg);
   }
 }

--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -25,6 +25,13 @@ extern "C" {
 #define ARROWSTRING 6
 #define ARROWERROR -1
 
+// compression mappings
+#define SNAPPY_COMP 1
+#define GZIP_COMP 2
+#define BROTLI_COMP 3
+#define ZSTD_COMP 4
+#define LZ4_COMP 5
+
   // Each C++ function contains the actual implementation of the
   // functionality, and there is a corresponding C function that
   // Chapel can call into through C interoperability, since there
@@ -52,44 +59,44 @@ extern "C" {
 
   int cpp_writeColumnToParquet(const char* filename, void* chpl_arr,
                                int64_t colnum, const char* dsetname, int64_t numelems,
-                               int64_t rowGroupSize, int64_t dtype, bool compressed,
+                               int64_t rowGroupSize, int64_t dtype, int64_t compression,
                                char** errMsg);
   int c_writeColumnToParquet(const char* filename, void* chpl_arr,
                              int64_t colnum, const char* dsetname, int64_t numelems,
-                             int64_t rowGroupSize, int64_t dtype, bool compressed, char** errMsg);
+                             int64_t rowGroupSize, int64_t dtype, int64_t compression, char** errMsg);
 
   int c_writeStrColumnToParquet(const char* filename, void* chpl_arr, void* chpl_offsets,
                                 const char* dsetname, int64_t numelems,
-                                int64_t rowGroupSize, int64_t dtype, bool compressed,
+                                int64_t rowGroupSize, int64_t dtype, int64_t compression,
                                 char** errMsg);
   int cpp_writeStrColumnToParquet(const char* filename, void* chpl_arr, void* chpl_offsets,
                                   const char* dsetname, int64_t numelems,
-                                  int64_t rowGroupSize, int64_t dtype, bool compressed,
+                                  int64_t rowGroupSize, int64_t dtype, int64_t compression,
                                   char** errMsg);
   
   int c_createEmptyParquetFile(const char* filename, const char* dsetname, int64_t dtype,
-                               bool compressed, char** errMsg);
+                               int64_t compression, char** errMsg);
   int cpp_createEmptyParquetFile(const char* filename, const char* dsetname, int64_t dtype,
-                                 bool compressed, char** errMsg);
+                                 int64_t compression, char** errMsg);
   
   int c_appendColumnToParquet(const char* filename, void* chpl_arr,
                               const char* dsetname, int64_t numelems,
-                              int64_t dtype, bool compressed,
+                              int64_t dtype, int64_t compression,
                               char** errMsg);
   int cpp_appendColumnToParquet(const char* filename, void* chpl_arr,
                                 const char* dsetname, int64_t numelems,
-                                int64_t dtype, bool compressed,
+                                int64_t dtype, int64_t compression,
                                 char** errMsg);
   
   int c_writeMultiColToParquet(const char* filename, void* column_names, 
                                 void** ptr_arr, void* datatypes,
                                 int64_t colnum, int64_t numelems, int64_t rowGroupSize,
-                                bool compressed, char** errMsg);
+                                int64_t compression, char** errMsg);
 
   int cpp_writeMultiColToParquet(const char* filename, void* column_names, 
                                   void** ptr_arr, void* datatypes,
                                   int64_t colnum, int64_t numelems, int64_t rowGroupSize,
-                                  bool compressed, char** errMsg);
+                                  int64_t compression, char** errMsg);
     
   const char* c_getVersionInfo(void);
   const char* cpp_getVersionInfo(void);

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -9,6 +9,7 @@ from context import arkouda as ak
 from arkouda import io_util
 
 TYPES = ("int64", "uint64", "bool", "float64", "str")
+COMPRESSIONS = ["snappy", "gzip", "brotli", "zstd", "lz4"]
 SIZE = 100
 NUMFILES = 5
 verbose = True
@@ -175,6 +176,20 @@ class ParquetTest(ArkoudaTest):
                 pq_arr = ak.read_parquet(f"{tmp_dirname}/pq_testcorrect*", "my-dset")
 
                 self.assertListEqual(ak_arr.to_list(), pq_arr.to_list())
+
+    def test_compression(self):
+        a = ak.arange(150)
+
+        for comp in COMPRESSIONS:
+            with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
+                # write with the selected compression
+                a.to_parquet(f"{tmp_dirname}/compress_test", compression=comp)
+
+                # ensure read functions
+                rd_arr = ak.read_parquet(f"{tmp_dirname}/compress_test*", "array")
+
+                # validate the list read out matches the array used to write
+                self.assertListEqual(rd_arr.to_list(), a.to_list())
 
     @pytest.mark.optional_parquet
     def test_against_standard_files(self):


### PR DESCRIPTION
Closes #1991

Adds support for GZip, Brotli, ZSTD, and LZ4 compression for Parquet files. Snappy compression is still supported. Reading all compression types was supported, but now Arkouda supports writing Parquet files with all compressions supported by Parquet. 

Replaces the `compressed` parameter in the `to_parquet` functions with `compression`. This optional parameter defaults to None, but can be set to `snappy`, `gzip`, `brotli`, `zstd`, or `lz4` depending upon the desired compression. 

This PR also adds testing to ensure read/write functionality with all compression types. 

**Example Usage**
```python
>> a = ak.arange(150)
>> a
array([0 1 2 ... 147 148 149])

>> // write the file using Brotli Compression
>> a.to_parquet('file_path/filename.parquet', dataset='dset_name', compression='brotli')

//read the file
>> rd_a = a.read_parquet('file_path/filename.parquet', 'dset_name')
>> rda_a
array([0 1 2 ... 147 148 149])
```