### PR TITLE
Closes #2011 - Updating version requirement for  `h5py` and `numpy`

### DIFF
--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -4,14 +4,14 @@ channels:
   - defaults
 dependencies:
   - python>=3.8   # minimum 3.8
-  - numpy>=1.22.2
+  - numpy>=1.24.1
   - pandas>=1.4.0
   - pyzmq>=20.0.0
   - tabulate
   - pyfiglet
   - versioneer
   - matplotlib>=3.3.2
-  - h5py
+  - h5py>=3.7.0
   - pip
   - types-tabulate
   - pytables>=3.7.0

--- a/arkouda-env.yml
+++ b/arkouda-env.yml
@@ -4,14 +4,14 @@ channels:
   - defaults
 dependencies:
   - python>=3.8   # minimum 3.8
-  - numpy>=1.22.2
+  - numpy>=1.24.1
   - pandas>=1.4.0
   - pyzmq>=20.0.0
   - tabulate
   - pyfiglet
   - versioneer
   - matplotlib>=3.3.2
-  - h5py
+  - h5py>=3.7.0
   - pip
   - types-tabulate
   - pytables>=3.7.0

--- a/pydoc/requirements.txt
+++ b/pydoc/requirements.txt
@@ -1,6 +1,6 @@
 # dependencies
 python>=3.8
-numpy>=1.22.2
+numpy>=1.24.1
 pandas>=1.4.0
 pyzmq>=20.0.0
 typeguard==2.10.0
@@ -8,7 +8,7 @@ tabulate
 pyfiglet
 versioneer
 matplotlib>=3.3.2
-h5py
+h5py>=3.7.0
 pip
 types-tabulate
 tables>=3.7.0

--- a/pydoc/setup/REQUIREMENTS.md
+++ b/pydoc/setup/REQUIREMENTS.md
@@ -7,7 +7,7 @@ The dependencies listed here have varying installation instructions depending up
 - ``Chapel 1.29.0 or later``
 - `cmake>=3.11.0`
 - `zeromq>=4.2.5`
-- `hdf5`
+- `hdf5>=3.7.0`
 - `python>=3.8`
 - `iconv`
 - `idn2`
@@ -18,7 +18,7 @@ The dependencies listed here have varying installation instructions depending up
 The following python packages are required by the Arkouda client package.
 
 - `python>=3.8`
-- `numpy>=1.22.2`
+- `numpy>=1.24.1`
 - `pandas>=1.4.0`
 - `pyzmq>=20.0.0`
 - `typeguard==2.10.0`
@@ -26,7 +26,7 @@ The following python packages are required by the Arkouda client package.
 - `pyfiglet`
 - `versioneer`
 - `matplotlib>=3.3.2`
-- `h5py`
+- `h5py>=3.7.0`
 - `pip`
 - `types-tabulate`
 - `tables>=3.7.0`

--- a/pydoc/setup/REQUIREMENTS.md
+++ b/pydoc/setup/REQUIREMENTS.md
@@ -7,7 +7,7 @@ The dependencies listed here have varying installation instructions depending up
 - ``Chapel 1.29.0 or later``
 - `cmake>=3.11.0`
 - `zeromq>=4.2.5`
-- `hdf5>=3.7.0`
+- `hdf5`
 - `python>=3.8`
 - `iconv`
 - `idn2`

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ setup(
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'numpy>=1.22.2',
+        'numpy>=1.24.1',
         'pandas>=1.4.0',
         'pyzmq>=20.0.0',
         'typeguard==2.10.0',
@@ -139,7 +139,7 @@ setup(
         'pyfiglet',
         'versioneer',
         'matplotlib>=3.3.2',
-        'h5py',
+        'h5py>=3.7.0',
         'pip',
         'types-tabulate',
         'tables>=3.7.0',


### PR DESCRIPTION
This PR closes #2011 

`h5py` version requirement updated to 3.7.0
`numpy` version requirement updated to 1.24.1