### PR TITLE
Closes #2013: Create local copies of block size for bigint modulus

### DIFF
--- a/src/BigIntMsg.chpl
+++ b/src/BigIntMsg.chpl
@@ -63,17 +63,17 @@ module BigIntMsg {
                 var block_size = 1:bigint;
                 block_size <<= 64;
                 while || reduce (tmp!=0) {
-                  on tmp.locale {
-                    // create local copy, needed to work around bug fixed in Chapel, but
-                    // needed for backwards compatability for now
-                    var blockSize = block_size;
-                    var low = tmp % blockSize;
-                    var retname = st.nextName();
-
-                    st.addEntry(retname, new shared SymEntry(low:uint));
-                    retList.append("created %s".format(st.attrib(retname)));
-                    tmp /= block_size;
+                  var low: [tmp.domain] bigint;
+                  // create local copy, needed to work around bug fixed in Chapel, but
+                  // needed for backwards compatability for now
+                  forall val in low with (var local_block_size = block_size) {
+                    low = tmp % local_block_size;
                   }
+                  var retname = st.nextName();
+
+                  st.addEntry(retname, new shared SymEntry(low:uint));
+                  retList.append("created %s".format(st.attrib(retname)));
+                  tmp /= block_size;
                 }
                 var repMsg = "%jt".format(retList);
                 biLogger.debug(getModuleName(), getRoutineName(), getLineNumber(), repMsg);

--- a/src/BigIntMsg.chpl
+++ b/src/BigIntMsg.chpl
@@ -66,8 +66,8 @@ module BigIntMsg {
                   var low: [tmp.domain] bigint;
                   // create local copy, needed to work around bug fixed in Chapel, but
                   // needed for backwards compatability for now
-                  forall val in low with (var local_block_size = block_size) {
-                    low = tmp % local_block_size;
+                  forall (lowVal, tmpVal) in zip(low, tmp) with (var local_block_size = block_size) {
+                    lowVal = tmpVal % local_block_size;
                   }
                   var retname = st.nextName();
 

--- a/src/BigIntMsg.chpl
+++ b/src/BigIntMsg.chpl
@@ -63,12 +63,17 @@ module BigIntMsg {
                 var block_size = 1:bigint;
                 block_size <<= 64;
                 while || reduce (tmp!=0) {
-                    var low = tmp % block_size;
+                  on tmp.locale {
+                    // create local copy, needed to work around bug fixed in Chapel, but
+                    // needed for backwards compatability for now
+                    var blockSize = block_size;
+                    var low = tmp % blockSize;
                     var retname = st.nextName();
 
                     st.addEntry(retname, new shared SymEntry(low:uint));
                     retList.append("created %s".format(st.attrib(retname)));
                     tmp /= block_size;
+                  }
                 }
                 var repMsg = "%jt".format(retList);
                 biLogger.debug(getModuleName(), getRoutineName(), getLineNumber(), repMsg);


### PR DESCRIPTION
A Chapel bug in the bigint module was causing a crash in distributed settings due to an attempt to pass remote values to C. This should be fixed by https://github.com/chapel-lang/chapel/pull/21321 in the future (it is still a work in progress), but we still need a workaround for Arkouda until that fix is included in the oldest supported Chapel.

closes #2013 