### PR TITLE
Closes #2021 - Compression Fixes for Benchmarks

### DIFF
--- a/benchmarks/IO.py
+++ b/benchmarks/IO.py
@@ -34,7 +34,7 @@ def time_ak_write(N_per_locale, numfiles, trials, dtype, path, seed, parquet, co
         for j in range(numfiles):
             start = time.time()
             a.to_hdf(f"{path}{j:04}") if not parquet else a.to_parquet(
-                f"{path}{j:04}", compressed=compressed
+                f"{path}{j:04}", compression="snappy" if compressed else None
             )
             end = time.time()
             writetimes.append(end - start)


### PR DESCRIPTION
Closes #2021 

Updates benchmarks to set `compression='snappy'` if `compressed=True`. Otherwise, it is set to `None`. This will allow the benchmark to handle compression as it was before it was made selectable. 

A separate issue/PR will be added to update the benchmark to run against all available compression types.