### PR TITLE
Closes #2009: Add `bigint` support for `sort`, `in1d`, `search_intervals`, and `groupby`

### DIFF
--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -11,6 +11,7 @@ import numpy as np  # type: ignore
 from typeguard import typechecked
 
 from arkouda.client import generic_msg
+from arkouda.dtypes import bigint
 from arkouda.dtypes import float64 as akfloat64
 from arkouda.dtypes import int64 as akint64
 from arkouda.dtypes import int_scalars
@@ -995,7 +996,7 @@ class GroupBy:
         else:
             # Treat as a sequence of groupable arrays
             for v in values:
-                if isinstance(v, pdarray) and v.dtype not in [akint64, akuint64]:
+                if isinstance(v, pdarray) and v.dtype not in [akint64, akuint64, bigint]:
                     raise TypeError("grouping/uniquing unsupported for this dtype")
             togroup = [unique_key_idx] + list(values)
         return togroup

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1540,6 +1540,8 @@ class pdarray:
         elif self.dtype in (akint64, akuint64):
             # Integral pdarrays are their own grouping keys
             return [self]
+        elif self.dtype == bigint:
+            return self.bigint_to_uint_arrays()
         else:
             raise TypeError("Grouping is only supported on numeric data (integral types) and bools.")
 

--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -354,6 +354,8 @@ def bigint_from_uint_arrays(arrays, max_bits=-1):
         raise TypeError("Sequence must contain only uint pdarrays")
     if len({a.size for a in arrays}) != 1:
         raise TypeError("All pdarrays must be same size")
+    if not isinstance(arrays, list):
+        arrays = list(arrays)
     return create_pdarray(
         generic_msg(
             cmd="big_int_creation",

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -10,6 +10,7 @@ from arkouda.client_dtypes import BitVector
 from arkouda.dtypes import bool as akbool
 from arkouda.dtypes import int64 as akint64
 from arkouda.dtypes import uint64 as akuint64
+from arkouda.dtypes import bigint
 from arkouda.groupbyclass import GroupBy, groupable, groupable_element_type, unique
 from arkouda.logger import getArkoudaLogger
 from arkouda.pdarrayclass import create_pdarray, pdarray
@@ -96,6 +97,8 @@ def _in1d_single(
     if hasattr(pda1, "categories"):
         return cast(Categorical_, pda1).in1d(pda2)
     elif isinstance(pda1, pdarray) and isinstance(pda2, pdarray):
+        if pda1.dtype == bigint and pda2.dtype == bigint:
+            return in1d(pda1.bigint_to_uint_arrays(), pda2.bigint_to_uint_arrays(), invert=invert)
         repMsg = generic_msg(
             cmd="in1d",
             args={

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -100,6 +100,7 @@ module MultiTypeSymbolTable
         */
         proc addEntry(name: string, len: int, type t): borrowed SymEntry(t) throws {
             // check and throw if memory limit would be exceeded
+            // TODO figure out a way to do memory checking for bigint
             if t != bigint {
                 if t == bool {overMemLimit(len);} else {overMemLimit(len*numBytes(t));}
             }

--- a/tests/alignment_tests.py
+++ b/tests/alignment_tests.py
@@ -36,17 +36,23 @@ class AlignmentTest(ArkoudaTest):
         ends = (ak.array([4, 14, 24]), ak.array([4, 14, 24]))
         vals = (ak.array([3, 13, 23]), ak.array([23, 13, 3]))
         ans = [-1, 1, -1]
-        self.assertListEqual(ans, ak.search_intervals(vals, (starts, ends), hierarchical=False).to_list())
+        self.assertListEqual(
+            ans, ak.search_intervals(vals, (starts, ends), hierarchical=False).to_list()
+        )
         self.assertListEqual(ans, ak.interval_lookup((starts, ends), ak.arange(3), vals).to_list())
 
         vals = (ak.array([23, 13, 3]), ak.array([23, 13, 3]))
         ans = [2, 1, 0]
-        self.assertListEqual(ans, ak.search_intervals(vals, (starts, ends), hierarchical=False).to_list())
+        self.assertListEqual(
+            ans, ak.search_intervals(vals, (starts, ends), hierarchical=False).to_list()
+        )
         self.assertListEqual(ans, ak.interval_lookup((starts, ends), ak.arange(3), vals).to_list())
 
         vals = (ak.array([23, 13, 33]), ak.array([23, 13, 3]))
         ans = [2, 1, -1]
-        self.assertListEqual(ans, ak.search_intervals(vals, (starts, ends), hierarchical=False).to_list())
+        self.assertListEqual(
+            ans, ak.search_intervals(vals, (starts, ends), hierarchical=False).to_list()
+        )
         self.assertListEqual(ans, ak.interval_lookup((starts, ends), ak.arange(3), vals).to_list())
 
         # test hierarchical flag
@@ -58,8 +64,15 @@ class AlignmentTest(ArkoudaTest):
             ak.search_intervals(vals, (starts, ends), hierarchical=False).to_list(),
             [0, -1, 0, 0, 1, -1, 1, -1],
         )
+        search_intervals_hierarchical = ak.search_intervals(vals, (starts, ends)).to_list()
+        self.assertListEqual(search_intervals_hierarchical, [0, 0, 0, 0, 1, 1, 1, -1])
+
+        # bigint is equivalent to hierarchical=True case
+        bi_starts = ak.bigint_from_uint_arrays([ak.cast(a, ak.uint64) for a in starts])
+        bi_ends = ak.bigint_from_uint_arrays([ak.cast(a, ak.uint64) for a in ends])
+        bi_vals = ak.bigint_from_uint_arrays([ak.cast(a, ak.uint64) for a in vals])
         self.assertListEqual(
-            ak.search_intervals(vals, (starts, ends)).to_list(), [0, 0, 0, 0, 1, 1, 1, -1]
+            ak.search_intervals(bi_vals, (bi_starts, bi_ends)).to_list(), search_intervals_hierarchical
         )
 
     def test_search_interval_nonunique(self):
@@ -161,5 +174,7 @@ class AlignmentTest(ArkoudaTest):
         smallest_answer = [-1, -1, 0, 2, -1, 2, 2, 1, -1, 0, 0, 3, -1]
         first_result = ak.search_intervals(values, intervals, hierarchical=False)
         self.assertListEqual(first_result.to_list(), first_answer)
-        smallest_result = ak.search_intervals(values, intervals, tiebreak=tiebreak_smallest, hierarchical=False)
+        smallest_result = ak.search_intervals(
+            values, intervals, tiebreak=tiebreak_smallest, hierarchical=False
+        )
         self.assertListEqual(smallest_result.to_list(), smallest_answer)

--- a/tests/coargsort_test.py
+++ b/tests/coargsort_test.py
@@ -91,19 +91,25 @@ def check_float(N, algo):
     assert ak.is_sorted(n[perm])
 
 
-def check_int_uint_float(N, algo):
+def check_int_uint_float_bigint(N, algo):
     f = ak.randint(0, 2**63, N, dtype=ak.float64)
     u = ak.randint(0, 2**63, N, dtype=ak.uint64)
     i = ak.randint(0, 2**63, N, dtype=ak.int64)
+    bi = u + 2**200
 
-    perm = ak.coargsort([f, u, i], algo)
+    perm = ak.coargsort([f, u, i, bi], algo)
     assert ak.is_sorted(f[perm])
 
-    perm = ak.coargsort([u, i, f], algo)
+    perm = ak.coargsort([u, i, bi, f], algo)
     assert ak.is_sorted(u[perm])
 
-    perm = ak.coargsort([i, f, u], algo)
+    perm = ak.coargsort([i, bi, f, u], algo)
     assert ak.is_sorted(i[perm])
+
+    perm = ak.coargsort([bi, f, u, i], algo)
+    # TODO remove cast once to_ndarray/list is avail for bigint
+    shifted_down = ak.cast(bi[perm] - 2**200, ak.uint64)
+    assert ak.is_sorted(shifted_down)
 
 
 def check_large(N, algo):
@@ -122,7 +128,7 @@ def check_coargsort(N_per_locale):
         check_integral(N, algo, ak.int64)
         check_integral(N, algo, ak.uint64)
         check_float(N, algo)
-        check_int_uint_float(N, algo)
+        check_int_uint_float_bigint(N, algo)
         check_large(N, algo)
 
 
@@ -139,9 +145,9 @@ class CoargsortTest(ArkoudaTest):
         for algo in ak.SortingAlgorithm:
             check_float(10**3, algo)
 
-    def test_int_uint_float(self):
+    def test_int_uint_float_bigint(self):
         for algo in ak.SortingAlgorithm:
-            check_int_uint_float(10**3, algo)
+            check_int_uint_float_bigint(10**3, algo)
 
     def test_large(self):
         for algo in ak.SortingAlgorithm:

--- a/tests/setops_test.py
+++ b/tests/setops_test.py
@@ -306,17 +306,19 @@ class SetOpsTest(ArkoudaTest):
     def testIn1d(self):
         pdaOne = ak.array([-1, 0, 1, 3])
         pdaTwo = ak.array([-1, 2, 2, 3])
-        self.assertListEqual(
-            ak.in1d(pdaOne, pdaTwo).to_list(),
-            [True, False, False, True],
-        )
+        bi_one = pdaOne + 2**200
+        bi_two = pdaTwo + 2**200
+        ans = [True, False, False, True]
+        self.assertListEqual(ak.in1d(pdaOne, pdaTwo).to_list(), ans)
+        # test bigint
+        self.assertListEqual(ak.in1d(bi_one, bi_two).to_list(), ans)
+        # test multilevel mixed types (int and bigint)
+        self.assertListEqual(ak.in1d([pdaOne, bi_one], [pdaTwo, bi_two]).to_list(), ans)
+        self.assertListEqual(ak.in1d([bi_one, pdaOne], [bi_two, pdaTwo]).to_list(), ans)
 
-        vals = [i % 3 for i in range(10)]
-        valsTwo = [i % 2 for i in range(10)]
-        stringsOne = ak.array(["String {}".format(i) for i in vals])
-        stringsTwo = ak.array(["String {}".format(i) for i in valsTwo])
-
-        self.assertListEqual([x < 2 for x in vals], ak.in1d(stringsOne, stringsTwo).to_list())
+        stringsOne = ak.array(["String {}".format(i % 3) for i in range(10)])
+        stringsTwo = ak.array(["String {}".format(i % 2) for i in range(10)])
+        self.assertListEqual([(x % 3) < 2 for x in range(10)], ak.in1d(stringsOne, stringsTwo).to_list())
 
         # adding tests for unique dtypes
         a = ak.arange(10)

--- a/tests/sort_test.py
+++ b/tests/sort_test.py
@@ -17,7 +17,16 @@ class SortTest(ArkoudaTest):
         pda = ak.randint(0, 100, 100, dtype=ak.uint64)
         for algo in ak.SortingAlgorithm:
             spda = ak.sort(pda, algo)
-            assert ak.is_sorted(spda)
+            self.assertTrue(ak.is_sorted(spda))
+
+        shift_up = pda + 2**200
+        for algo in ak.SortingAlgorithm:
+            sorted_pda = ak.sort(pda, algo)
+            sorted_bi = ak.sort(shift_up, algo)
+            # TODO remove cast once to_ndarray/list is avail for bigint
+            shift_down = ak.cast((sorted_bi - 2 ** 200), ak.uint64)
+            self.assertListEqual(shift_down.to_list(), sorted_pda.to_list())
+
 
     def testBitBoundaryHardcode(self):
 


### PR DESCRIPTION
This PR (closes #2009) adds `bigint` support for `sort`, `in1d`, `search_intervals`, and `groupby`. This required adding `ak.concatenate` functionality for `bigint` pdarrays. Adds testing for these features