### PR TITLE
Closes #2010 - overflow notification for GroupBy Aggregations

### DIFF
--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -779,6 +779,8 @@ module ReductionMsg
       var sums;
       var counts;
       if isRealType(t) && skipNan {
+        // first verify that we can make a copy of values
+        overMemLimit(numBytes(t) * values.size);
         // calculate sum and counts with nan values replaced with 0.0
         var arrCopy = [elem in values] if isnan(elem) then 0.0 else elem;
         sums = segSum(arrCopy, segments);


### PR DESCRIPTION
Closes #2010

After reviewing the code in https://github.com/Bears-R-Us/arkouda/blob/0a380edf81c332deec547d82a51c829acdb80ae1/src/ReductionMsg.chpl#L776

I am fairly certain this is occurring when `isRealType(t) == true && skipNan == true`. Previously we were creating a copy of values with no memory check that we could do so without exceeding available memory.

This adds and `overMemLimit` check to ensure we can create a copy of values and provide an error message to the user if we cannot.