### PR TITLE
Closes #2029 - Undo IO Function Deprecation

### DIFF
--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -909,6 +909,10 @@ class Categorical:
         TypeError
             Raised if prefix_path, dataset, or mode is not a str
         """
+        # due to the possibility that components will be different sizes,
+        # writing to Parquet is not supported at this time
+        raise RuntimeError("Categorical cannot be written to Parquet at this time due to its components "
+                           "potentially having different sizes.")
         result = []
         comp_dict = {k: v for k, v in self._get_components_dict().items() if v is not None}
 

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -1483,6 +1483,7 @@ class DataFrame(UserDict):
         locale number.
         """
         from arkouda.io import to_hdf
+
         data = self._prep_data(index=index, columns=columns)
         to_hdf(data, prefix_path=path, file_type=file_type)
 
@@ -1510,8 +1511,60 @@ class DataFrame(UserDict):
         locale number.
         """
         from arkouda.io import to_parquet
+
         data = self._prep_data(index=index, columns=columns)
         to_parquet(data, prefix_path=path, compression=compression)
+
+    def save(
+        self,
+        path,
+        index=False,
+        columns=None,
+        file_format="HDF5",
+        file_type="distribute",
+        compression: Optional[str] = None,
+    ):
+        """
+        DEPRECATED
+        Save DataFrame to disk, preserving column names.
+        Parameters
+        ----------
+        path : str
+            File path to save data
+        index : bool
+            If True, save the index column. By default, do not save the index.
+        columns: List
+            List of columns to include in the file. If None, writes out all columns
+        file_format: str
+            'HDF5' or 'Parquet'. Defaults to 'HDF5'
+        file_type: str
+            ("single" | "distribute")
+            Defaults to distribute.
+            If single, will right a single file to locale 0
+        compression: str (Optional)
+            (None | "snappy" | "gzip" | "brotli" | "zstd" | "lz4")
+            Compression type. Only used for Parquet
+        Notes
+        -----
+        This method saves one file per locale of the arkouda server. All
+        files are prefixed by the path argument and suffixed by their
+        locale number.
+        See Also
+        --------
+        to_parquet, to_hdf
+        """
+        warn(
+            "ak.DataFrame.save has been deprecated. "
+            "Please use ak.DataFrame.to_hdf or ak.DataFrame.to_parquet",
+            DeprecationWarning,
+        )
+
+        if file_format.lower() == "hdf5":
+            return self.to_hdf(path, index=index, columns=columns, file_type=file_type)
+        elif file_format.lower() == "parquet":
+            return self.to_parquet(path, index=index, columns=columns, compression=compression)
+        else:
+            raise ValueError("Valid file types are HDF5 or Parquet")
 
     @classmethod
     def load(cls, prefix_path, file_format="INFER"):

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -213,6 +213,89 @@ class Index:
     ):
         return self.values.to_parquet(prefix_path, dataset=dataset, mode=mode, compression=compression)
 
+    def save(
+        self,
+        prefix_path: str,
+        dataset: str = "index",
+        mode: str = "truncate",
+        compression: Optional[str] = None,
+        file_format: str = "HDF5",
+        file_type: str = "distribute",
+    ) -> str:
+        """
+        DEPRECATED
+        Save the index to HDF5 or Parquet. The result is a collection of files,
+        one file per locale of the arkouda server, where each filename starts
+        with prefix_path. Each locale saves its chunk of the array to its
+        corresponding file.
+        Parameters
+        ----------
+        prefix_path : str
+            Directory and filename prefix that all output files share
+        dataset : str
+            Name of the dataset to create in files (must not already exist)
+        mode : str {'truncate' | 'append'}
+            By default, truncate (overwrite) output files, if they exist.
+            If 'append', attempt to create new dataset in existing files.
+        compression : str (Optional)
+            (None | "snappy" | "gzip" | "brotli" | "zstd" | "lz4")
+            Sets the compression type used with Parquet files
+        file_format : str {'HDF5', 'Parquet'}
+            By default, saved files will be written to the HDF5 file format. If
+            'Parquet', the files will be written to the Parquet file format. This
+            is case insensitive.
+        file_type: str ("single" | "distribute")
+            Default: "distribute"
+            When set to single, dataset is written to a single file.
+            When distribute, dataset is written on a file per locale.
+            This is only supported by HDF5 files and will have no impact of Parquet Files.
+        Returns
+        -------
+        string message indicating result of save operation
+        Raises
+        ------
+        RuntimeError
+            Raised if a server-side error is thrown saving the pdarray
+        ValueError
+            Raised if there is an error in parsing the prefix path pointing to
+            file write location or if the mode parameter is neither truncate
+            nor append
+        TypeError
+            Raised if any one of the prefix_path, dataset, or mode parameters
+            is not a string
+        See Also
+        --------
+        save_all, load, read, to_parquet, to_hdf
+        Notes
+        -----
+        The prefix_path must be visible to the arkouda server and the user must
+        have write permission.
+        Output files have names of the form ``<prefix_path>_LOCALE<i>``, where ``<i>``
+        ranges from 0 to ``numLocales``. If any of the output files already exist and
+        the mode is 'truncate', they will be overwritten. If the mode is 'append'
+        and the number of output files is less than the number of locales or a
+        dataset with the same name already exists, a ``RuntimeError`` will result.
+        Previously all files saved in Parquet format were saved with a ``.parquet`` file extension.
+        This will require you to use load as if you saved the file with the extension. Try this if
+        an older file is not being found.
+        Any file extension can be used. The file I/O does not rely on the extension to determine the
+        file format.
+        """
+        from warnings import warn
+        warn(
+            "ak.Index.save has been deprecated. Please use ak.Index.to_parquet or ak.Index.to_hdf",
+            DeprecationWarning,
+        )
+        if mode.lower() not in ["append", "truncate"]:
+            raise ValueError("Allowed modes are 'truncate' and 'append'")
+
+        if file_format.lower() == "hdf5":
+            return self.to_hdf(prefix_path, dataset=dataset, mode=mode, file_type=file_type)
+        elif file_format.lower() == "parquet":
+            return self.to_parquet(prefix_path, dataset=dataset, mode=mode, compression=compression)
+        else:
+            raise ValueError("Valid file types are HDF5 or Parquet")
+
 
 class MultiIndex(Index):
     def __init__(self, values):

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1087,7 +1087,7 @@ class pdarray:
         """
         if low > high:
             raise ValueError("low must not exceed high")
-        return (self >> low) % 2**(high - low + 1)
+        return (self >> low) % 2 ** (high - low + 1)
 
     def bigint_to_uint_arrays(self):
         """
@@ -1379,6 +1379,103 @@ class pdarray:
                 },
             ),
         )
+
+    def save(
+        self,
+        prefix_path: str,
+        dataset: str = "array",
+        mode: str = "truncate",
+        compression: Optional[str] = None,
+        file_format: str = "HDF5",
+        file_type: str = "distribute",
+    ) -> str:
+        """
+        DEPRECATED
+        Save the pdarray to HDF5 or Parquet. The result is a collection of files,
+        one file per locale of the arkouda server, where each filename starts
+        with prefix_path. Each locale saves its chunk of the array to its
+        corresponding file.
+        Parameters
+        ----------
+        prefix_path : str
+            Directory and filename prefix that all output files share
+        dataset : str
+            Name of the dataset to create in files (must not already exist)
+        mode : str {'truncate' | 'append'}
+            By default, truncate (overwrite) output files, if they exist.
+            If 'append', attempt to create new dataset in existing files.
+        compression : str (Optional)
+            (None | "snappy" | "gzip" | "brotli" | "zstd" | "lz4")
+            Sets the compression type used with Parquet files
+        file_format : str {'HDF5', 'Parquet'}
+            By default, saved files will be written to the HDF5 file format. If
+            'Parquet', the files will be written to the Parquet file format. This
+            is case insensitive.
+        file_type: str ("single" | "distribute")
+            Default: "distribute"
+            When set to single, dataset is written to a single file.
+            When distribute, dataset is written on a file per locale.
+            This is only supported by HDF5 files and will have no impact of Parquet Files.
+        Returns
+        -------
+        string message indicating result of save operation
+        Raises
+        ------
+        RuntimeError
+            Raised if a server-side error is thrown saving the pdarray
+        ValueError
+            Raised if there is an error in parsing the prefix path pointing to
+            file write location or if the mode parameter is neither truncate
+            nor append
+        TypeError
+            Raised if any one of the prefix_path, dataset, or mode parameters
+            is not a string
+        See Also
+        --------
+        save_all, load, read
+        Notes
+        -----
+        The prefix_path must be visible to the arkouda server and the user must
+        have write permission.
+        Output files have names of the form ``<prefix_path>_LOCALE<i>``, where ``<i>``
+        ranges from 0 to ``numLocales``. If any of the output files already exist and
+        the mode is 'truncate', they will be overwritten. If the mode is 'append'
+        and the number of output files is less than the number of locales or a
+        dataset with the same name already exists, a ``RuntimeError`` will result.
+        Previously all files saved in Parquet format were saved with a ``.parquet`` file extension.
+        This will require you to use load as if you saved the file with the extension. Try this if
+        an older file is not being found.
+        Any file extension can be used.The file I/O does not rely on the extension to
+        determine the file format.
+        Examples
+        --------
+        >>> a = ak.arange(25)
+        >>> # Saving without an extension
+        >>> a.save('path/prefix', dataset='array')
+        Saves the array to numLocales HDF5 files with the name ``cwd/path/name_prefix_LOCALE####``
+        >>> # Saving with an extension (HDF5)
+        >>> a.save('path/prefix.h5', dataset='array')
+        Saves the array to numLocales HDF5 files with the name
+        ``cwd/path/name_prefix_LOCALE####.h5`` where #### is replaced by each locale number
+        >>> # Saving with an extension (Parquet)
+        >>> a.save('path/prefix.parquet', dataset='array', file_format='Parquet')
+        Saves the array in numLocales Parquet files with the name
+        ``cwd/path/name_prefix_LOCALE####.parquet`` where #### is replaced by each locale number
+        """
+        from warnings import warn
+        warn(
+            "ak.pdarray.save has been deprecated. Please use ak.pdarray.to_parquet or ak.pdarray.to_hdf",
+            DeprecationWarning,
+        )
+        if mode.lower() not in ["append", "truncate"]:
+            raise ValueError("Allowed modes are 'truncate' and 'append'")
+
+        if file_format.lower() == "hdf5":
+            return self.to_hdf(prefix_path, dataset=dataset, mode=mode, file_type=file_type)
+        elif file_format.lower() == "parquet":
+            return self.to_parquet(prefix_path, dataset=dataset, mode=mode, compression=compression)
+        else:
+            raise ValueError("Valid file types are HDF5 or Parquet")
 
     @typechecked
     def register(self, user_defined_name: str) -> pdarray:

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -1018,6 +1018,29 @@ class SegArray:
             prefix_path, dataset=dataset + value_suffix, mode="append", file_type=file_type
         )
 
+    def save(
+        self,
+        prefix_path,
+        dataset="segarray",
+        segment_suffix="_segments",
+        value_suffix="_values",
+        mode="truncate",
+        file_type="distribute",
+    ):
+        from warnings import warn
+        warn(
+            "ak.SegArray.save has been deprecated. Please use ak.SegArray.to_hdf",
+            DeprecationWarning,
+        )
+        return self.to_hdf(
+            prefix_path,
+            dataset,
+            segment_suffix=segment_suffix,
+            value_suffix=value_suffix,
+            mode=mode,
+            file_type=file_type,
+        )
+
     @classmethod
     def load(
         cls,


### PR DESCRIPTION
Closes #2029

Adds back the previously removed IO functions that have been deprecated. Updates these to call the new functions `to_parquet` and `to_hdf` as appropriate. Updates `compressed` to `compression` to allow for new compression formats.

Updates `ak.Categorical.to_parquet` to raise a `RuntimeError` because the components can have different sizes. Parquet columns must be equal lengths. Issue #2034 has been added to resolve this.