### PR TITLE
Closes #2038: Add percentage used to `overmemlimit`

### DIFF
--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -252,9 +252,10 @@ module ServerConfig
                 if (total > memHighWater) {
                     memHighWater = total;
                     scLogger.info(getModuleName(),getRoutineName(),getLineNumber(),
-                    "memory high watermark = %i memory limit = %i".format(
+                    "memory high watermark = %i memory limit = %i percentage used = %i%%".format(
                            memHighWater:uint * numLocales:uint, 
-                           getMemLimit():uint * numLocales:uint));
+                           getMemLimit():uint * numLocales:uint,
+                           AutoMath.round((memHighWater:real / (getMemLimit():real * numLocales)) * 100):uint));
                 }
             }
             if total > getMemLimit() {


### PR DESCRIPTION
This PR (closes #2038) add percentage used to `overmemlimit` check

```ipython
>>> ak.ones(1024 * 1024 * 1024)
array([1 1 1 ... 1 1 1])
>>> ak.get_mem_used(as_percent=True)
28
```
and the logs show
```
overMemLimit Line 254 INFO [Chapel] memory high watermark = 8589934592 memory limit = 30923764531 percentage used = 28%
```