### PR TITLE
Closes #2041: `bigint` compatibility for `dataframe`

### DIFF
--- a/arkouda/dtypes.py
+++ b/arkouda/dtypes.py
@@ -55,6 +55,9 @@ def dtype(x):
 
 
 class BigInt:
+    # an estimate of the itemsize of bigint (128 bytes)
+    itemsize = 128
+
     def __init__(self):
         self.name = "bigint"
 


### PR DESCRIPTION
This PR (closes #2041) adds support and testing for a `dataframe` containing a `bigint` column. To do this we add an estimate for `itemsize` which i've chosen to be 1024 bits (128 bytes)