### PR TITLE
Add aggregation interface for `bigint`

### DIFF
--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -14,8 +14,11 @@ module CommAggregation {
 
   /* Creates a new destination aggregator (dst/lhs will be remote). */
   proc newDstAggregator(type elemType, param useUnorderedCopy=false) {
+    use BigInteger, BigIntegerAggregation;
     if CHPL_COMM == "none" || useUnorderedCopy {
       return new DstUnorderedAggregator(elemType);
+    } else if elemType == bigint {
+      return new DstAggregatorBigint();
     } else {
       return new DstAggregator(elemType);
     }
@@ -23,8 +26,11 @@ module CommAggregation {
 
   /* Creates a new source aggregator (src/rhs will be remote). */
   proc newSrcAggregator(type elemType, param useUnorderedCopy=false) {
+    use BigInteger, BigIntegerAggregation;
     if CHPL_COMM == "none" || useUnorderedCopy {
       return new SrcUnorderedAggregator(elemType);
+    } else if elemType == bigint {
+      return new SrcAggregatorBigint();
     } else {
       return new SrcAggregator(elemType);
     }
@@ -137,10 +143,11 @@ module CommAggregation {
       flush();
     }
     proc flush() {
-      unorderedCopyTaskFence();
+      if isPOD(elemType) then unorderedCopyTaskFence();
     }
     inline proc copy(ref dst: elemType, const in srcVal: elemType) {
-      unorderedCopy(dst, srcVal);
+      if isPOD(elemType) then unorderedCopy(dst, srcVal);
+                         else dst = srcVal;
     }
   }
 
@@ -273,11 +280,12 @@ module CommAggregation {
       flush();
     }
     proc flush() {
-      unorderedCopyTaskFence();
+      if isPOD(elemType) then unorderedCopyTaskFence();
     }
     inline proc copy(ref dst: elemType, const ref src: elemType) {
       assert(dst.locale.id == here.id);
-      unorderedCopy(dst, src);
+      if isPOD(elemType) then unorderedCopy(dst, src);
+                         else dst = src;
     }
   }
 
@@ -388,4 +396,225 @@ module CommAggregation {
     const cachePaddedLocales = (numLocales + 7) & ~7;
     return c_aligned_alloc(int, 64, cachePaddedLocales);
   }
+
+  module BigIntegerAggregation {
+    use CTypes;
+    use CommPrimitives;
+    use CommAggregation;
+    use BigInteger, GMP;
+
+    record DstAggregatorBigint {
+      type elemType = bigint;
+      type aggType = (c_ptr(elemType), elemType);
+      const bufferSize = dstBuffSize;
+      const myLocaleSpace = 0..<numLocales;
+      var lastLocale: int;
+      var opsUntilYield = yieldFrequency;
+      var lBuffers: c_ptr(c_ptr(aggType));
+      var rBuffers: [myLocaleSpace] remoteBuffer(aggType);
+      var bufferIdxs: c_ptr(int);
+
+      proc postinit() {
+        lBuffers = c_malloc(c_ptr(aggType), numLocales);
+        bufferIdxs = bufferIdxAlloc();
+        for loc in myLocaleSpace {
+          lBuffers[loc] = c_malloc(aggType, bufferSize);
+          bufferIdxs[loc] = 0;
+          rBuffers[loc] = new remoteBuffer(aggType, bufferSize, loc);
+        }
+      }
+
+      proc deinit() {
+        flush();
+        for loc in myLocaleSpace {
+          c_free(lBuffers[loc]);
+        }
+        c_free(lBuffers);
+        c_free(bufferIdxs);
+      }
+
+      proc flush() {
+        for offsetLoc in myLocaleSpace + lastLocale {
+          const loc = offsetLoc % numLocales;
+          _flushBuffer(loc, bufferIdxs[loc], freeData=true);
+        }
+      }
+
+      inline proc copy(ref dst: elemType, const ref src: elemType) {
+        // TODO aggregation not supported today, just do plain assignment
+        dst = src;
+        return;
+
+        // Get the locale of dst and the local address on that locale
+        const loc = dst.locale.id;
+        lastLocale = loc;
+        const dstAddr = getAddr(dst);
+
+        // Get our current index into the buffer for dst's locale
+        ref bufferIdx = bufferIdxs[loc];
+
+        // Buffer the address and desired value
+        lBuffers[loc][bufferIdx] = (dstAddr, src);
+        bufferIdx += 1;
+
+        // Flush our buffer if it's full. If it's been a while since we've let
+        // other tasks run, yield so that we're not blocking remote tasks from
+        // flushing their buffers.
+        if bufferIdx == bufferSize {
+          _flushBuffer(loc, bufferIdx, freeData=false);
+          opsUntilYield = yieldFrequency;
+        } else if opsUntilYield == 0 {
+          chpl_task_yield();
+          opsUntilYield = yieldFrequency;
+        } else {
+          opsUntilYield -= 1;
+        }
+      }
+
+      proc _flushBuffer(loc: int, ref bufferIdx, freeData) {
+        const myBufferIdx = bufferIdx;
+        if myBufferIdx == 0 then return;
+
+        // Allocate a remote buffer
+        ref rBuffer = rBuffers[loc];
+        const remBufferPtr = rBuffer.cachedAlloc();
+
+        // Copy local buffer to remote buffer
+        rBuffer.PUT(lBuffers[loc], myBufferIdx);
+
+        // Process remote buffer
+        on Locales[loc] {
+          for (dstAddr, srcVal) in rBuffer.localIter(remBufferPtr, myBufferIdx) {
+            dstAddr.deref() = srcVal;
+          }
+          if freeData {
+            rBuffer.localFree(remBufferPtr);
+          }
+        }
+        if freeData {
+          rBuffer.markFreed();
+        }
+        bufferIdx = 0;
+      }
+    }
+
+    record SrcAggregatorBigint {
+      type elemType = bigint;
+      type aggType = c_ptr(elemType);
+      const bufferSize = srcBuffSize;
+      const myLocaleSpace = 0..<numLocales;
+      var lastLocale: int;
+      var opsUntilYield = yieldFrequency;
+      var dstAddrs: c_ptr(c_ptr(aggType));
+      var lSrcAddrs: c_ptr(c_ptr(aggType));
+      var lSrcVals: [myLocaleSpace][0..#bufferSize] elemType;
+      var rSrcAddrs: [myLocaleSpace] remoteBuffer(aggType);
+      var rSrcVals: [myLocaleSpace] remoteBuffer(elemType);
+      var bufferIdxs: c_ptr(int);
+
+      proc postinit() {
+        dstAddrs = c_malloc(c_ptr(aggType), numLocales);
+        lSrcAddrs = c_malloc(c_ptr(aggType), numLocales);
+        bufferIdxs = bufferIdxAlloc();
+        for loc in myLocaleSpace {
+          dstAddrs[loc] = c_malloc(aggType, bufferSize);
+          lSrcAddrs[loc] = c_malloc(aggType, bufferSize);
+          bufferIdxs[loc] = 0;
+          rSrcAddrs[loc] = new remoteBuffer(aggType, bufferSize, loc);
+          rSrcVals[loc] = new remoteBuffer(elemType, bufferSize, loc);
+        }
+      }
+
+      proc deinit() {
+        flush();
+        for loc in myLocaleSpace {
+          c_free(dstAddrs[loc]);
+          c_free(lSrcAddrs[loc]);
+        }
+        c_free(dstAddrs);
+        c_free(lSrcAddrs);
+        c_free(bufferIdxs);
+      }
+
+      proc flush() {
+        for offsetLoc in myLocaleSpace + lastLocale {
+          const loc = offsetLoc % numLocales;
+          _flushBuffer(loc, bufferIdxs[loc], freeData=true);
+        }
+      }
+
+      inline proc copy(ref dst: elemType, const ref src: elemType) {
+        // TODO aggregation not supported today, just do plain assignment
+        dst = src;
+        return;
+
+        if boundsChecking {
+          assert(dst.locale.id == here.id);
+        }
+        const dstAddr = getAddr(dst);
+
+        const loc = src.locale.id;
+        lastLocale = loc;
+        const srcAddr = getAddr(src);
+
+        ref bufferIdx = bufferIdxs[loc];
+        lSrcAddrs[loc][bufferIdx] = srcAddr;
+        dstAddrs[loc][bufferIdx] = dstAddr;
+        bufferIdx += 1;
+
+        if bufferIdx == bufferSize {
+          _flushBuffer(loc, bufferIdx, freeData=false);
+          opsUntilYield = yieldFrequency;
+        } else if opsUntilYield == 0 {
+          chpl_task_yield();
+          opsUntilYield = yieldFrequency;
+        } else {
+          opsUntilYield -= 1;
+        }
+      }
+
+      proc _flushBuffer(loc: int, ref bufferIdx, freeData) {
+        const myBufferIdx = bufferIdx;
+        if myBufferIdx == 0 then return;
+
+        ref myLSrcVals = lSrcVals[loc];
+        ref myRSrcAddrs = rSrcAddrs[loc];
+        ref myRSrcVals = rSrcVals[loc];
+
+        // Allocate remote buffers
+        const rSrcAddrPtr = myRSrcAddrs.cachedAlloc();
+        const rSrcValPtr = myRSrcVals.cachedAlloc();
+
+        // Copy local addresses to remote buffer
+        myRSrcAddrs.PUT(lSrcAddrs[loc], myBufferIdx);
+
+        // Process remote buffer, copying the value of our addresses into a
+        // remote buffer
+        on Locales[loc] {
+          for i in 0..<myBufferIdx {
+            rSrcValPtr[i] = rSrcAddrPtr[i].deref();
+          }
+          if freeData {
+            myRSrcAddrs.localFree(rSrcAddrPtr);
+          }
+        }
+        if freeData {
+          myRSrcAddrs.markFreed();
+        }
+
+        // Copy remote values into local buffer
+        myRSrcVals.GET(myLSrcVals, myBufferIdx);
+
+        // Assign the srcVal to the dstAddrs
+        var dstAddrPtr = c_ptrTo(dstAddrs[loc][0]);
+        var srcValPtr = c_ptrTo(myLSrcVals[0]);
+        for i in 0..<myBufferIdx {
+          dstAddrPtr[i].deref() = srcValPtr[i];
+        }
+
+        bufferIdx = 0;
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
This does **not** actually aggregate `bigint`, it just adds the interface so we can start writing code to use it. This is a code clone of the normal aggregators with plain assignments added in. I want the code clone so it's easier to parse the diff when actual aggregation support is added. This also turns unorderedCopy into plain assignment for non-POD types (like bigint) since unorderedCopy only works for POD.

Part of #1994