### PR TITLE
Add aggregator support for `bigint`

### DIFF
--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -401,12 +401,22 @@ module CommAggregation {
     use CTypes;
     use CommPrimitives;
     use CommAggregation;
+
+    // procs to get at internal mpz fields (copied from chapel GMP)
     use BigInteger, GMP;
+    private extern proc chpl_gmp_mpz_struct_sign_size(from: __mpz_struct) : mp_size_t;
+    private extern proc chpl_gmp_mpz_struct_limbs(from: __mpz_struct) : c_ptr(mp_limb_t);
+    private extern proc chpl_gmp_mpz_set_sign_size(ref dst:mpz_t, sign_size:mp_size_t);
+
+    // At minimum, need to store dst address, size+size of src, and 1 limb.
+    // Could be more limbs, but size to make comm comparisons to int64 agg.
+    private proc minInlineBigintSize() {
+      return (c_sizeof(c_ptr(bigint)) + c_sizeof(mp_size_t) + c_sizeof(mp_limb_t)):int;
+    }
 
     record DstAggregatorBigint {
-      type elemType = bigint;
-      type aggType = (c_ptr(elemType), elemType);
-      const bufferSize = dstBuffSize;
+      type aggType = uint(8);
+      const bufferSize = dstBuffSize * minInlineBigintSize();
       const myLocaleSpace = 0..<numLocales;
       var lastLocale: int;
       var opsUntilYield = yieldFrequency;
@@ -440,30 +450,50 @@ module CommAggregation {
         }
       }
 
-      inline proc copy(ref dst: elemType, const ref src: elemType) {
-        // TODO aggregation not supported today, just do plain assignment
-        dst = src;
-        return;
-
+      inline proc copy(ref dst: bigint, const ref src: bigint) {
         // Get the locale of dst and the local address on that locale
+        // TODO only works when record wrapper and mpz have same locale..
+        // should be true for most of arkouda but not guaranteed
         const loc = dst.locale.id;
         lastLocale = loc;
-        const dstAddr = getAddr(dst);
+        var dstAddr = getAddr(dst);
 
         // Get our current index into the buffer for dst's locale
         ref bufferIdx = bufferIdxs[loc];
 
-        // Buffer the address and desired value
-        lBuffers[loc][bufferIdx] = (dstAddr, src);
-        bufferIdx += 1;
+        // Get the src sign+size and pointer to the limbs
+        var sign_size = chpl_gmp_mpz_struct_sign_size(src.getImpl());
+        var src_limbs = chpl_gmp_mpz_struct_limbs(src.getImpl());
 
-        // Flush our buffer if it's full. If it's been a while since we've let
-        // other tasks run, yield so that we're not blocking remote tasks from
-        // flushing their buffers.
-        if bufferIdx == bufferSize {
+        // compute sizes of addr, sign+size, and limbs
+        var addr_bytes = c_sizeof(c_ptr(bigint));
+        var size_bytes = c_sizeof(mp_size_t);
+        var limb_bytes = abs(sign_size) * c_sizeof(mp_limb_t);
+
+        // Just do direct assignment if dst is local
+        // TODO also if size will exceed max buffer
+        if loc == here.id {
+          dst = src;
+          return;
+        }
+
+        // Flush our buffer if this entry will exceed capacity
+        if bufferIdx + addr_bytes + size_bytes + limb_bytes > bufferSize {
           _flushBuffer(loc, bufferIdx, freeData=false);
           opsUntilYield = yieldFrequency;
-        } else if opsUntilYield == 0 {
+        }
+
+        // Buffer the address and the serialized value (sign_sign, limbs)
+        c_memcpy(c_ptrTo(lBuffers[loc][bufferIdx]), c_ptrTo(dstAddr), addr_bytes);
+        bufferIdx += addr_bytes:int;
+        c_memcpy(c_ptrTo(lBuffers[loc][bufferIdx]), c_ptrTo(sign_size), size_bytes);
+        bufferIdx += size_bytes:int;
+        c_memcpy(c_ptrTo(lBuffers[loc][bufferIdx]), src_limbs, limb_bytes);
+        bufferIdx += limb_bytes:int;
+
+        // If it's been a while since we've let other tasks run, yield so that
+        // we're not blocking remote tasks from flushing their buffers.
+        if opsUntilYield == 0 {
           chpl_task_yield();
           opsUntilYield = yieldFrequency;
         } else {
@@ -484,9 +514,37 @@ module CommAggregation {
 
         // Process remote buffer
         on Locales[loc] {
-          for (dstAddr, srcVal) in rBuffer.localIter(remBufferPtr, myBufferIdx) {
-            dstAddr.deref() = srcVal;
+          var curBufferIdx = 0;
+          while curBufferIdx < myBufferIdx {
+            var dstAddr: c_ptr(bigint);
+            var sign_size: mp_size_t;
+            var src_limbs: c_ptr(mp_limb_t);
+
+            var addr_bytes = c_sizeof(c_ptr(bigint));
+            var size_bytes = c_sizeof(mp_size_t);
+
+            // Copy addr and size out of buffer
+            c_memcpy(c_ptrTo(dstAddr), c_ptrTo(remBufferPtr[curBufferIdx]), addr_bytes);
+            curBufferIdx += addr_bytes: int;
+            c_memcpy(c_ptrTo(sign_size), c_ptrTo(remBufferPtr[curBufferIdx]), size_bytes);
+            curBufferIdx += size_bytes:int;
+
+            // extract size from sign+size and compute limb bytes
+            var n = abs(sign_size);
+            var limb_bytes = n * c_sizeof(mp_limb_t);
+
+            // reallocate target bigint
+            _mpz_realloc(dstAddr.deref().mpz, n);
+
+            // extract pointer to target bigint limbs, and copy buffered limbs into it
+            var xp = chpl_gmp_mpz_struct_limbs(dstAddr.deref().getImpl());
+            c_memcpy(xp, c_ptrTo(remBufferPtr[curBufferIdx]), limb_bytes);
+            curBufferIdx += limb_bytes:int;
+
+            // update the sign+size of target bigint
+            chpl_gmp_mpz_set_sign_size(dstAddr.deref().mpz, sign_size);
           }
+
           if freeData {
             rBuffer.localFree(remBufferPtr);
           }


### PR DESCRIPTION
Add aggregators that support bigint.

Plain old integer DstAggregators locally aggregate the target address and the inline value by storing a tuple of `(c_ptr(int), int)` but it's not as simple with variable sized bigints. It's also not as easy to extract the raw value since bigints have metadata stored inline, but the values stored off in the heap. To enable aggregation, the buffers are no longer typed and are just raw bytes that we'll interpret. We now locally aggregate the target address, the 8-byte sign+size (int64 that stores the number of limbs and the sign of the limbs), and the variables sized limbs. This uses internal functions to expose the internal sign+size and limbs. With this we have our target address and "value" stored inline and can get data to the target side like normal. On the target side we then extract the address and size, and then resize the target bigint, copy the limbs over, and update the target sign+size.

SrcAggregator is a little more complicated since we don't know how big our src values are until we're on the remote node. Because of this we can't pre-allocate space for all our elements, so instead we just aggregate addresses locally and when those buffers are full we fill up value buffers as much as we can and just loop until we've processed all values.

Testing with single limb (64-bit value) bigints, I see aggregation performance that's within 2x of plain old int(64) aggregation. This is around what I'd expect since we have to aggregate an extra 8 bytes for the sign_size and there's other overheads with real location and extracting limbs. I don't think there's much more performance we can squeeze out of this, but there is certainly a lot of code cleanup we can do and a lot more testing I'd like to do. This is a prototype currently, but I wanted to capture what I have so far.

Implementation TODOs:
 - Fix support for bigints with more limbs than we can store
 - Fix support for mismatched bigint record and mpz locale.id
 - Tune buffer size (currently sized to fit the same number of elements as plain old int64 aggregation to do comm comparisons)
 - See if we can use public functions (`mpz_limbs_write`, `mpz_limbs_finish`) added in GMP 6 -- https://gmplib.org/manual/Integer-Special-Functions

Testing TODOs:
 - check negative numbers (gmp stores sign as part of size)
 - check massive numbers (more limbs than we have buffer space for, broken currently)
 - check variable sized limbs (only tested with single limb so far)
 - check performance with larger limbs (single limb is ~2x slower)
 - check with bigint record wrapper and heap-allocated mpz on different nodes (broken currently)
 - check with limb sizes that will grow and shrink target bigint
 - check with aggregating 0 values (no limbs), should work with current strategy, but would require special case with `mpz_limbs_write`
 
 Closes https://github.com/Bears-R-Us/arkouda/issues/1994