### PR TITLE
Closes #2068: Fix dataframe groupby with categorical index bug

### DIFF
--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Union
 import pandas as pd  # type: ignore
 from typeguard import typechecked
 
-from arkouda import Strings
+from arkouda import Categorical, Strings
 from arkouda.dtypes import bool as akbool
 from arkouda.dtypes import float64 as akfloat64
 from arkouda.dtypes import int64 as akint64
@@ -19,7 +19,9 @@ from arkouda.util import convert_if_categorical, generic_concat, get_callback, r
 class Index:
     @typechecked
     def __init__(
-        self, values: Union[List, pdarray, Strings, pd.Index, "Index"], name: Optional[str] = None
+        self,
+        values: Union[List, pdarray, Strings, Categorical, pd.Index, "Index"],
+        name: Optional[str] = None,
     ):
         if isinstance(values, Index):
             self.values = values.values
@@ -358,6 +360,7 @@ class Index:
         file format.
         """
         from warnings import warn
+
         warn(
             "ak.Index.save has been deprecated. Please use ak.Index.to_parquet or ak.Index.to_hdf",
             DeprecationWarning,

--- a/arkouda/series.py
+++ b/arkouda/series.py
@@ -123,8 +123,8 @@ class Series:
     ):
         if isinstance(data, (tuple, list)) and len(data) == 2:
             # handles the previous `ar_tuple` case
-            if not isinstance(data[0], (pdarray, Strings, list, tuple)):
-                raise TypeError("indices must be a pdarray, Strings, List, or Tuple")
+            if not isinstance(data[0], (pdarray, Strings, Categorical, list, tuple)):
+                raise TypeError("indices must be a pdarray, Strings, Categorical, List, or Tuple")
             if not isinstance(data[1], (pdarray, Strings, Categorical)):
                 raise TypeError("values must be a pdarray, Strings, or Categorical")
             self.values = data[1]
@@ -160,7 +160,7 @@ class Series:
             length_str = f"\nLength {len(self)}"
         return (
             prt.to_string(
-                dtype=prt.dtype, min_rows=get_option("display.min_rows"), max_rows=maxrows, length=False,
+                dtype=prt.dtype, min_rows=get_option("display.min_rows"), max_rows=maxrows, length=False
             )
             + length_str
         )
@@ -594,9 +594,7 @@ class Series:
 
     @staticmethod
     @typechecked
-    def pdconcat(
-        arrays: List, axis: int = 0, labels: Strings = None
-    ) -> Union[pd.Series, pd.DataFrame]:
+    def pdconcat(arrays: List, axis: int = 0, labels: Strings = None) -> Union[pd.Series, pd.DataFrame]:
         """Concatenate a list of arkouda Series or grouped arkouda arrays, returning a PANDAS object.
 
         If a list of grouped arkouda arrays is passed they are converted to a series. Each grouping

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -394,6 +394,19 @@ class DataFrameTest(ArkoudaTest):
         self.assertListEqual(keys[1].to_list(), [333, 222, 111])
         self.assertListEqual(count.to_list(), [1, 2, 3])
 
+        # testing counts with IPv4 column
+        s = ak.DataFrame({"a": ak.IPv4(ak.arange(1, 5))}).groupby("a").count()
+        pds = pd.Series(
+            data=np.ones(4, dtype=np.int64),
+            index=pd.Index(data=np.array(["0.0.0.1", "0.0.0.2", "0.0.0.3", "0.0.0.4"], dtype="<U7")),
+        )
+        self.assertTrue(s.to_pandas().equals(other=pds))
+
+        # testing counts with Categorical column
+        s = ak.DataFrame({"a": ak.Categorical(ak.array(["a", "a", "a", "b"]))}).groupby("a").count()
+        pds = pd.Series(data=np.array([3, 1]), index=pd.Index(data=np.array(["a", "b"], dtype="<U7")))
+        self.assertTrue(s.to_pandas().equals(other=pds))
+
     def test_gb_series(self):
         username = ak.array(["Alice", "Bob", "Alice", "Carol", "Bob", "Alice"])
         userid = ak.array([111, 222, 111, 333, 222, 111])
@@ -418,14 +431,6 @@ class DataFrameTest(ArkoudaTest):
         self.assertIsInstance(c, ak.Series)
         self.assertListEqual(c.index.to_list(), ["Bob", "Alice", "Carol"])
         self.assertListEqual(c.values.to_list(), [2, 3, 1])
-
-        # testing counts with IPv4 column
-        s = ak.DataFrame({"a": ak.IPv4(ak.arange(1, 5))}).groupby("a").count()
-        pds = pd.Series(
-            data=np.ones(4, dtype=np.int64),
-            index=pd.Index(data=np.array(["0.0.0.1", "0.0.0.2", "0.0.0.3", "0.0.0.4"], dtype="<U7")),
-        )
-        self.assertTrue(s.to_pandas().equals(other=pds))
 
     def test_to_pandas(self):
         df = build_ak_df()


### PR DESCRIPTION
This PR (closes #2068) fixes bug preventing a dataframe groupby with a categorical index