### PR TITLE
Reformat 1-element array literals to use a trailing comma

### DIFF
--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -113,7 +113,7 @@ module HDF5Msg {
         var extension: string;
         (prefix,extension) = getFileMetadata(filename);
 
-        var filenames: [0..#1] string = ["%s%s".format(prefix, extension)];
+        var filenames: [0..#1] string = ["%s%s".format(prefix, extension), ];
         var matchingFilenames = glob("%s*%s".format(prefix, extension));
 
         const f = filenames[0];
@@ -700,7 +700,7 @@ module HDF5Msg {
     private proc writeNilStringsGroupToHdf(fileId: int, group: string, writeOffsets: bool) throws {
         var dset_id: C_HDF5.hid_t;
         C_HDF5.H5LTmake_dataset_WAR(fileId, "/%s/values".format(group).c_str(), 1,
-                c_ptrTo([0:uint(64)]), getHDF5Type(uint(8)), nil);
+                c_ptrTo([0:uint(64), ]), getHDF5Type(uint(8)), nil);
 
         dset_id = C_HDF5.H5Dopen(fileId, "/%s/values".format(group).c_str(), C_HDF5.H5P_DEFAULT);
 
@@ -719,7 +719,7 @@ module HDF5Msg {
 
         if (writeOffsets) {
             C_HDF5.H5LTmake_dataset_WAR(fileId, "/%s/segments".format(group).c_str(), 1,
-                c_ptrTo([0:uint(64)]), getHDF5Type(int), nil);
+                c_ptrTo([0:uint(64), ]), getHDF5Type(int), nil);
 
             dset_id = C_HDF5.H5Dopen(fileId, "/%s/segments".format(group).c_str(), C_HDF5.H5P_DEFAULT);
 
@@ -750,7 +750,7 @@ module HDF5Msg {
      */
     private proc writeStringsComponentToHdf(fileId: int, group: string, component: string, items: [] ?etype) throws {
         C_HDF5.H5LTmake_dataset_WAR(fileId, '/%s/%s'.format(group, component).c_str(), 1,
-                c_ptrTo([items.size:uint(64)]), getHDF5Type(etype), c_ptrTo(items));
+                c_ptrTo([items.size:uint(64), ]), getHDF5Type(etype), c_ptrTo(items));
 
         var dset_id: C_HDF5.hid_t = C_HDF5.H5Dopen(fileId, '/%s/%s'.format(group, component).c_str(), C_HDF5.H5P_DEFAULT);
 
@@ -805,13 +805,13 @@ module HDF5Msg {
 
                 //localize values and write dataset
                 var localVals = new lowLevelLocalizingSlice(segString.values.a, 0..#segString.values.size);
-                var val_dims: [0..#1] C_HDF5.hsize_t = [segString.values.size:C_HDF5.hsize_t];
+                var val_dims: [0..#1] C_HDF5.hsize_t = [segString.values.size:C_HDF5.hsize_t, ];
                 C_HDF5.H5LTmake_dataset(file_id, "/%s/values".format(group).c_str(), 1:c_int, val_dims, getHDF5Type(uint(8)), localVals.ptr);
                 
                 if (writeOffsets) {
                     //localize offsets and write dataset
                     var localOffsets = new lowLevelLocalizingSlice(segString.offsets.a, 0..#segString.size);
-                    var off_dims: [0..#1] C_HDF5.hsize_t = [segString.offsets.size:C_HDF5.hsize_t];
+                    var off_dims: [0..#1] C_HDF5.hsize_t = [segString.offsets.size:C_HDF5.hsize_t, ];
                     C_HDF5.H5LTmake_dataset(file_id, "/%s/segments".format(group).c_str(), 1:c_int, off_dims, getHDF5Type(int), localOffsets.ptr);
                 }
                 writeArkoudaMetaData(file_id, group, objType, getHDF5Type(uint(8)));
@@ -1166,14 +1166,14 @@ module HDF5Msg {
                             }
                             // do A[intersection] = file[intersection - offset]
                             var dataspace = C_HDF5.H5Dget_space(dataset);
-                            var dsetOffset = [(intersection.low - filedom.low): C_HDF5.hsize_t];
-                            var dsetStride = [intersection.stride: C_HDF5.hsize_t];
-                            var dsetCount = [intersection.size: C_HDF5.hsize_t];
+                            var dsetOffset = [(intersection.low - filedom.low): C_HDF5.hsize_t, ];
+                            var dsetStride = [intersection.stride: C_HDF5.hsize_t, ];
+                            var dsetCount = [intersection.size: C_HDF5.hsize_t, ];
                             C_HDF5.H5Sselect_hyperslab(dataspace, C_HDF5.H5S_SELECT_SET, c_ptrTo(dsetOffset), 
                                                             c_ptrTo(dsetStride), c_ptrTo(dsetCount), nil);
-                            var memOffset = [0: C_HDF5.hsize_t];
-                            var memStride = [1: C_HDF5.hsize_t];
-                            var memCount = [intersection.size: C_HDF5.hsize_t];
+                            var memOffset = [0: C_HDF5.hsize_t, ];
+                            var memStride = [1: C_HDF5.hsize_t, ];
+                            var memCount = [intersection.size: C_HDF5.hsize_t, ];
                             var memspace = C_HDF5.H5Screate_simple(1, c_ptrTo(memCount), nil);
                             C_HDF5.H5Sselect_hyperslab(memspace, C_HDF5.H5S_SELECT_SET, c_ptrTo(memOffset), 
                                                             c_ptrTo(memStride), c_ptrTo(memCount), nil);

--- a/src/RegistrationMsg.chpl
+++ b/src/RegistrationMsg.chpl
@@ -304,14 +304,14 @@ module RegistrationMsg
                             "%s: Collecting DataFrame components for '%s'".format(cmd, name));
 
         var jsonParam = new ParameterObj("name", colName, ObjectType.VALUE, "str");
-        var subArgs1 = new MessageArgs(new list([jsonParam]));
+        var subArgs1 = new MessageArgs(new list([jsonParam, ]));
         // Add columns as a json list
         var cols = stringsToJSONMsg(cmd, subArgs1, st).msg;
         repMsg += "+json %s".format(cols);
 
         // Get index 
         var indParam = new ParameterObj("name", "df_index_%s_key".format(name), ObjectType.VALUE, "");
-        var subArgs2 = new MessageArgs(new list([indParam]));
+        var subArgs2 = new MessageArgs(new list([indParam, ]));
         var ind = attachMsg(cmd, subArgs2, st).msg;
         if ind.startsWith("Error:") { 
             var errorMsg = ind;
@@ -343,12 +343,12 @@ module RegistrationMsg
             select (objtype){
                 when ("pdarray") {
                     var attParam = new ParameterObj("name", regName, ObjectType.VALUE, "");
-                    var subArgs = new MessageArgs(new list([attParam]));
+                    var subArgs = new MessageArgs(new list([attParam, ]));
                     msg = attachMsg(cmd, subArgs, st).msg;
                 }
                 when ("str") {
                     var attParam = new ParameterObj("name", regName, ObjectType.VALUE, "");
-                    var subArgs = new MessageArgs(new list([attParam]));
+                    var subArgs = new MessageArgs(new list([attParam, ]));
                     msg = attachMsg(cmd, subArgs, st).msg;
                 }
                 when ("SegArray") {
@@ -564,7 +564,7 @@ module RegistrationMsg
         select (dtype.toLower()) {
             when ("simple") {
                 // pdarray and strings can use the unregisterMsg method without any other processing
-                var subArgs = new MessageArgs(new list([msgArgs.get("name")]));
+                var subArgs = new MessageArgs(new list([msgArgs.get("name"), ]));
                 return unregisterMsg(cmd, subArgs, st);
             }
             when ("categorical") {
@@ -587,7 +587,7 @@ module RegistrationMsg
                     // Check for "" in case optional components aren't found
                     if n != "" {
                         base_json.setVal(n);
-                        var subArgs = new MessageArgs(new list([base_json]));
+                        var subArgs = new MessageArgs(new list([base_json, ]));
                         var resp = unregisterMsg(cmd, subArgs, st);
                         status += " %s: %s ".format(n, resp.msg);
                     }
@@ -616,7 +616,7 @@ module RegistrationMsg
                 var base_json = msgArgs.get("name");
                 forall n in nameList with (in base_json, + reduce status) {
                     base_json.setVal(n);
-                    var subArgs = new MessageArgs(new list([base_json]));
+                    var subArgs = new MessageArgs(new list([base_json, ]));
                     var resp = unregisterMsg(cmd, subArgs, st);
                     status += " %s: %s ".format(n, resp.msg);
                 }


### PR DESCRIPTION
Chapel has recently changed 1-element array literals to require a trailing comma, deprecating the previous syntax (due to user confusion, and to unify syntax with 1-tuples—see https://github.com/chapel-lang/chapel/issues/21092).  Here, I've updated 1-element arrays in Arkouda to use this trailing comma syntax.  Because trailing commas were supported prior to this deprecation, this is not a breaking change for older versions of Chapel (since Arkouda's inception).

I also did a second version of this PR that attempts to remove some 1-element arrays that were not necessary, and felt like overkill in terms of compilation/execution complexity.  See #2072 for details.  Only one of the two should be merged.
