### PR TITLE
Add some function calls so that iconv check works properly

### DIFF
--- a/dep/checkIconv.chpl
+++ b/dep/checkIconv.chpl
@@ -1,5 +1,8 @@
 use iconv;
 
 proc main() {
+  var enc = "UTF-8";
+  var cd = libiconv_open(enc.c_str(), enc.c_str());
+  libiconv_close(cd);
   writeln("Found libiconv version: ", _libiconv_version);
 }


### PR DESCRIPTION
Since the existing `checkIconv.chpl` file only uses an extern variable, this was causing it to pass unexpectedly in some environments when the header files were included, but not linked. This PR adds some function calls so that it should always fail in the case of missing iconv.