### PR TITLE
Separate setting optimization level and enabling runtime checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,22 @@ CHPL := chpl
 CHPL_FLAGS += --ccflags="-DH5_USE_110_API"
 
 CHPL_DEBUG_FLAGS += --print-passes
+
 ifdef ARKOUDA_DEVELOPER
-CHPL_FLAGS += --ccflags="-O1"
-else ifdef ARKOUDA_QUICK_COMPILE
+ARKOUDA_QUICK_COMPILE = true
+ARKOUDA_RUNTIME_CHECKS = true
+endif
+
+ifdef ARKOUDA_QUICK_COMPILE
 CHPL_FLAGS += --no-checks --no-loop-invariant-code-motion --no-fast-followers --ccflags="-O0"
 else
 CHPL_FLAGS += --fast
 endif
+
+ifdef ARKOUDA_RUNTIME_CHECKS
+CHPL_FLAGS += --checks
+endif
+
 CHPL_FLAGS += -smemTrack=true -smemThreshold=1048576
 
 # We have seen segfaults with cache remote at some node counts


### PR DESCRIPTION
Previously, `ARKOUDA_QUICK_COMPILE` disabled all optimizations and disable runtime checks and `ARKOUDA_DEVELOPER` disabled some optimizations and enabled runtime checks.

However, there are times where you might want runtime checks without optimizations or maybe want runtime checks with full optimizations. This creates a new `ARKOUDA_RUNTIME_CHECKS` var that can independently toggle runtime checks to support that. It also changes `ARKOUDA_DEVELOPER` to map to `ARKOUDA_QUICK_COMPILE=true ARKOUDA_RUNTIME_CHECKS=true` since that is a more desired default for developers (speeds up compilation from previous default but still leaves runtime checks useful for debugging on.)

Some timings that Ben captured for me with Chapel 1.29 and Arkouda v2023.01.11 (~2018 x86 macbook):

| config      | default | Old AK_DEV | AK_QUICK | New AK_DEV |
| ----------- | ------: | ---------: | -------: | ---------: |
| COMM=none   |  761s   |  540s      |  411s    |  461s      |
| COMM=gasnet | 2245s   | 2019s      | 1255s    | 1423s      |

Resolves #2066