### PR TITLE
Fixes #2076: Fixes integer overflow in `groupby.mean`

### DIFF
--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -777,18 +777,21 @@ module ReductionMsg
     proc segMean(values:[] ?t, segments:[?D] int, skipNan=false): [D] real throws {
       var res: [D] real;
       if (D.size == 0) { return res; }
+      // convert to real early to avoid int overflow
+      overMemLimit(numBytes(real) * values.size);
+      var real_values = values: real;
       var sums;
       var counts;
-      if isRealType(t) && skipNan {
-        // first verify that we can make a copy of values
-        overMemLimit(numBytes(t) * values.size);
-        // calculate sum and counts with nan values replaced with 0.0
-        var arrCopy = [elem in values] if isnan(elem) then 0.0 else elem;
+      if skipNan {
+        // first verify that we can make a copy of real_values
+        overMemLimit(numBytes(real) * real_values.size);
+        // calculate sum and counts with nan real_values replaced with 0.0
+        var arrCopy = [elem in real_values] if isnan(elem) then 0.0 else elem;
         sums = segSum(arrCopy, segments);
-        counts = segCount(segments, values.size) - nanCounts(values, segments);
+        counts = segCount(segments, real_values.size) - nanCounts(real_values, segments);
       } else {
-        sums = segSum(values, segments);
-        counts = segCount(segments, values.size);
+        sums = segSum(real_values, segments);
+        counts = segCount(segments, real_values.size);
       }
       forall (r, s, c) in zip(res, sums, counts) {
         if (c > 0) {

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -495,6 +495,15 @@ class GroupByTest(ArkoudaTest):
         self.assertListEqual(ans, res2[0].to_list())
         self.assertListEqual(ans, res2[1].to_list())
 
+    def test_large_mean_aggregation(self):
+        # reproducer for integer overflow in groupby.mean
+        a = ak.full(10, 2**63 - 1, dtype=ak.int64)
+
+        # since all values of a are the same, all means should be 2**63 - 1
+        _, means = ak.GroupBy(ak.arange(10) % 3).mean(a)
+        for m in means.to_list():
+            self.assertTrue(np.isclose(float(a[0]), m))
+
     def test_unique_aggregation(self):
         keys = ak.array([0, 1, 0, 1, 0, 1, 0, 1])
         vals = ak.array([4, 3, 5, 3, 5, 2, 6, 2])


### PR DESCRIPTION
This PR (fixes #2076) casts to `real` early in `groupby.mean` to avoid integer overflow when aggregating over large values

<details>
  <summary>Output on reproducer</summary>

set up:
```python
>>> b = ak.arange(10) % 2 == 0
>>> g = ak.GroupBy(b)
>>> g.count()
(array([False True]), array([5 5]))

>>> a = ak.full(10, 2**63 - 1, dtype=ak.int64)
>>> a
array([9223372036854775807 9223372036854775807 9223372036854775807 9223372036854775807 9223372036854775807 9223372036854775807 9223372036854775807 9223372036854775807 9223372036854775807 9223372036854775807])
```

before this PR:
```python
# since all the values are the same, the means should be 2**63 - 1, we see that's not the case
>>> g.mean(a)
(array([False True]), array([1.8446744073709553e+18 1.8446744073709553e+18]))
>>> float(a[0])
9.223372036854776e+18
```

after this PR:
```python
# now the means are 2**63 - 1
>>> g.mean(a)
(array([False True]), array([9.2233720368547758e+18 9.2233720368547758e+18]))
>>> float(a[0])
9.223372036854776e+18
```
</details>