### PR TITLE
Closes #2077 Remove duplicated `bigint` logic in `IndexingMsg.chpl`

### DIFF
--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -963,7 +963,7 @@ module IndexingMsg
             }
             else {
                 var e = toSymEntry(gX,t);
-                // var truth = toSymEntry(gIV,bool);
+                var truth = toSymEntry(gIV,bool);
                 const ref ead = e.a.domain;
                 ref ea = e.a;
                 ref trutha = truth.a;

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -970,22 +970,23 @@ module IndexingMsg
             //         }
             //     }
             // }
-            if t == bigint {
-                var e = toSymEntry(gX, bigint);
-                var truth = toSymEntry(gIV,bool);
-                // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
-                overMemLimit(numBytes(int) * truth.size);
-                var iv: [truth.a.domain] int = (+ scan truth.a);
-                var pop = iv[iv.size-1];
-                imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
-                                            "pop = %t last-scan = %t".format(pop,iv[iv.size-1]));
-                var y = toSymEntry(gY,t);
-                if (y.size != pop) {
-                    var errorMsg = "Error: %s: pop size mismatch %i %i".format(pn,pop,y.size);
-                    imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                    return new MsgTuple(errorMsg,MsgType.ERROR);
-                }
-                ref ya = y.a;
+            
+            var e = toSymEntry(gX, bigint);
+            var truth = toSymEntry(gIV,bool);
+            // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+            overMemLimit(numBytes(int) * truth.size);
+            var iv: [truth.a.domain] int = (+ scan truth.a);
+            var pop = iv[iv.size-1];
+            imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
+                                        "pop = %t last-scan = %t".format(pop,iv[iv.size-1]));
+            var y = toSymEntry(gY,t);
+            if (y.size != pop) {
+                var errorMsg = "Error: %s: pop size mismatch %i %i".format(pn,pop,y.size);
+                imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                return new MsgTuple(errorMsg,MsgType.ERROR);
+            }
+            ref ya = y.a;
+            if gX.dtype == DType.BigInt {
                 // NOTE y.etype will never be real when gX.dtype is bigint, but the compiler doesn't know that
                 var tmp = if y.etype == bigint then ya else if (y.etype == bool || y.etype == real) then ya:int:bigint else ya:bigint;
                 ref ea = e.a;
@@ -999,19 +1000,6 @@ module IndexingMsg
             }
             else {
                 var e = toSymEntry(gX,t);
-                var truth = toSymEntry(gIV,bool);
-                // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
-                overMemLimit(numBytes(int) * truth.size);
-                var iv: [truth.a.domain] int = (+ scan truth.a);
-                var pop = iv[iv.size-1];
-                imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
-                                            "pop = %t last-scan = %t".format(pop,iv[iv.size-1]));
-                var y = toSymEntry(gY,t);
-                if (y.size != pop) {
-                    var errorMsg = "Error: %s: pop size mismatch %i %i".format(pn,pop,y.size);
-                    imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                    return new MsgTuple(errorMsg,MsgType.ERROR);
-                }
                 var ya = y.a;
                 const ref ead = e.a.domain;
                 ref ea = e.a;

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -933,44 +933,6 @@ module IndexingMsg
                 imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
                 return new MsgTuple(errorMsg,MsgType.ERROR);
             }
-            // var e = toSymEntry(gX, bigint);
-            // var truth = toSymEntry(gIV,bool);
-            // // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
-            // overMemLimit(numBytes(int) * truth.size);
-            // var iv: [truth.a.domain] int = (+ scan truth.a);
-            // var pop = iv[iv.size-1];
-            // imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
-            //                             "pop = %t last-scan = %t".format(pop,iv[iv.size-1]));
-            // var y = toSymEntry(gY,t);
-            // if (y.size != pop) {
-            //     var errorMsg = "Error: %s: pop size mismatch %i %i".format(pn,pop,y.size);
-            //     imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-            //     return new MsgTuple(errorMsg,MsgType.ERROR);
-            // }
-            // ref ya = y.a;                
-            // ref trutha = truth.a;
-            // if gX.dtype == DType.BigInt {
-            //     // NOTE y.etype will never be real when gX.dtype is bigint, but the compiler doesn't know that
-            //     var tmp = if y.etype == bigint then ya else if (y.etype == bool || y.etype == real) then ya:int:bigint else ya:bigint;
-            //     ref ea = e.a;
-            //     const ref ead = ea.domain;
-            //     forall (eai, i) in zip(ea, ead) with (var agg = newSrcAggregator(bigint)) {
-            //         if trutha[i] {
-            //             agg.copy(eai,tmp[iv[i]-1]);
-            //         }
-            //     }
-            // }
-            // else {
-            //     var e = toSymEntry(gX,t);
-            //     const ref ead = e.a.domain;
-            //     ref ea = e.a;
-            //     forall (eai, i) in zip(ea, ead) with (var agg = newSrcAggregator(t)) {
-            //         if trutha[i] {
-            //             agg.copy(eai,ya[iv[i]-1]);
-            //         }
-            //     }
-            // }
-            
             var truth = toSymEntry(gIV,bool);
             // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
             overMemLimit(numBytes(int) * truth.size);
@@ -985,13 +947,13 @@ module IndexingMsg
                 return new MsgTuple(errorMsg,MsgType.ERROR);
             }
             ref ya = y.a;
+            ref trutha = truth.a;
             if gX.dtype == DType.BigInt {
                 var e = toSymEntry(gX, bigint);
                 // NOTE y.etype will never be real when gX.dtype is bigint, but the compiler doesn't know that
                 var tmp = if y.etype == bigint then ya else if (y.etype == bool || y.etype == real) then ya:int:bigint else ya:bigint;
                 ref ea = e.a;
                 const ref ead = ea.domain;
-                ref trutha = truth.a;
                 forall (eai, i) in zip(ea, ead) with (var agg = newSrcAggregator(bigint)) {
                     if trutha[i] {
                         agg.copy(eai,tmp[iv[i]-1]);
@@ -1000,10 +962,8 @@ module IndexingMsg
             }
             else {
                 var e = toSymEntry(gX,t);
-                var ya = y.a;
                 const ref ead = e.a.domain;
                 ref ea = e.a;
-                ref trutha = truth.a;
                 forall (eai, i) in zip(ea, ead) with (var agg = newSrcAggregator(t)) {
                     if trutha[i] {
                         agg.copy(eai,ya[iv[i]-1]);

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -865,7 +865,8 @@ module IndexingMsg
                 ref ya = y.a;
                 // writeln(y.etype);
                 writeln(ya);
-                var tmp = if y.etype == bigint then ya else if y.etype == bool then ya:int:bigint else ya:bigint;
+                // NOTE y.etype will never be real when gX.dtype is bigint, but the compiler doesn't know that
+                var tmp = if y.etype == bigint then ya else if (y.etype == bool || y.etype == real) then ya:int:bigint else ya:bigint;
                 writeln(tmp);
                 // writeln(tmp.type);
 
@@ -937,7 +938,7 @@ module IndexingMsg
                 //[(i,v) in zip(iv.a,y.a)] e.a[i] = v;
                 ref iva = iv.a;
                 ref ya = y.a;
-                var tmp = if y.etype == bigint then ya else if y.etype == bool then ya:int:bigint else ya:bigint;
+                var tmp = if y.etype == bigint then ya else if (y.etype == bool || y.etype == real) then ya:int:bigint else ya:bigint;
                 // var ya = if y.a.type == bigint then y.a else if y.a.type == bool then y.a:int:bigint else y.a:bigint;
                 ref ea = e.a;
                 forall (i,v) in zip(iva,tmp) with (var agg = newDstAggregator(bigint)) {
@@ -1030,7 +1031,7 @@ module IndexingMsg
                     return new MsgTuple(errorMsg,MsgType.ERROR);
                 }
                 ref ya = y.a;
-                var tmp = if y.etype == bigint then ya else if y.etype == bool then ya:int:bigint else ya:bigint;
+                var tmp = if y.etype == bigint then ya else if (y.etype == bool || y.etype == real) then ya:int:bigint else ya:bigint;
                 // var ya = if y.a.type == bigint then y.a else if y.a.type == bool then y.a:int:bigint else y.a:bigint;
                 ref ea = e.a;
                 const ref ead = ea.domain;
@@ -1143,7 +1144,7 @@ module IndexingMsg
                 return ivBoolHelper(bool);
             }
             when (DType.BigInt, DType.Int64, DType.BigInt) {
-                writeln("did i get here?");
+                writeln("did i get here?"); 
                 return ivInt64Helper(bigint);
             }
             when (DType.BigInt, DType.UInt64, DType.BigInt) {

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -825,7 +825,7 @@ module IndexingMsg
         var gX: borrowed GenSymEntry = getGenericTypedArrayEntry(name, st);
         var gIV: borrowed GenSymEntry = getGenericTypedArrayEntry(iname, st);
         var gY: borrowed GenSymEntry = getGenericTypedArrayEntry(yname, st);
-        const dtype = if gX.dtype == DType.BigInt then DType.BigInt else gY.dtype;
+        // const dtype = if gX.dtype == DType.BigInt then DType.BigInt else gY.dtype;
 
         if logLevel == LogLevel.DEBUG {
             imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
@@ -844,28 +844,66 @@ module IndexingMsg
                 imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
                 return new MsgTuple(errorMsg,MsgType.ERROR);
             }
-            var e = toSymEntry(gX,t);
-            var iv = toSymEntry(gIV,int);
-            var ivMin = min reduce iv.a;
-            var ivMax = max reduce iv.a;
-            var y = toSymEntry(gY,t);
-            if ivMin < 0 {
-                var errorMsg = "Error: %s: OOBindex %i < 0".format(pn,ivMin);
-                imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg); 
-                return new MsgTuple(errorMsg,MsgType.ERROR);
+            if gX.dtype == DType.BigInt {
+                var e = toSymEntry(gX, bigint);
+                var iv = toSymEntry(gIV,int);
+                var ivMin = min reduce iv.a;
+                var ivMax = max reduce iv.a;
+                var y = toSymEntry(gY,t);
+                if ivMin < 0 {
+                    var errorMsg = "Error: %s: OOBindex %i < 0".format(pn,ivMin);
+                    imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg); 
+                    return new MsgTuple(errorMsg,MsgType.ERROR);
+                }
+                if ivMax >= e.size {
+                    var errorMsg = "Error: %s: OOBindex %i > %i".format(pn,ivMax,e.size-1);
+                    imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
+                    return new MsgTuple(errorMsg,MsgType.ERROR);
+                }
+                ref iva = iv.a;
+                writeln("gX.dtype == DType.BigInt");
+                ref ya = y.a;
+                // writeln(y.etype);
+                writeln(ya);
+                var tmp = if y.etype == bigint then ya else if y.etype == bool then ya:int:bigint else ya:bigint;
+                writeln(tmp);
+                // writeln(tmp.type);
+
+
+                // var bigint_ya = if ya.type == bigint then ya else ya:bigint;
+                // var ya = if y.a.type == bigint then y.a else y.a:bigint;
+                ref ea = e.a;
+                forall (i,v) in zip(iva,tmp) with (var agg = newDstAggregator(bigint)) {
+                    writeln("idx ", i);
+                    writeln("val ", v);
+                    writeln();
+                    agg.copy(ea[i],v);
+                }
             }
-            if ivMax >= e.size {
-                var errorMsg = "Error: %s: OOBindex %i > %i".format(pn,ivMax,e.size-1);
-                imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
-                return new MsgTuple(errorMsg,MsgType.ERROR);
+            else {
+                var e = toSymEntry(gX,t);
+                var iv = toSymEntry(gIV,int);
+                var ivMin = min reduce iv.a;
+                var ivMax = max reduce iv.a;
+                var y = toSymEntry(gY,t);
+                if ivMin < 0 {
+                    var errorMsg = "Error: %s: OOBindex %i < 0".format(pn,ivMin);
+                    imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg); 
+                    return new MsgTuple(errorMsg,MsgType.ERROR);
+                }
+                if ivMax >= e.size {
+                    var errorMsg = "Error: %s: OOBindex %i > %i".format(pn,ivMax,e.size-1);
+                    imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
+                    return new MsgTuple(errorMsg,MsgType.ERROR);
+                }
+                ref iva = iv.a;
+                var ya = y.a;
+                ref ea = e.a;
+                forall (i,v) in zip(iva,ya) with (var agg = newDstAggregator(t)) {
+                    agg.copy(ea[i],v);
+                }
             }
-            //[(i,v) in zip(iv.a,y.a)] e.a[i] = v;
-            ref iva = iv.a;
-            ref ya = y.a;
-            ref ea = e.a;
-            forall (i,v) in zip(iva,ya) with (var agg = newDstAggregator(t)) {
-              agg.copy(ea[i],v);
-            }
+            writeln("surely we didn't get this far");
             var repMsg = "%s success".format(pn);
             imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
             return new MsgTuple(repMsg, MsgType.NORMAL);
@@ -879,28 +917,79 @@ module IndexingMsg
                 imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
                 return new MsgTuple(errorMsg,MsgType.ERROR);
             }
-            var e = toSymEntry(gX,t);
-            var iv = toSymEntry(gIV,uint);
-            var ivMin = min reduce iv.a;
-            var ivMax = max reduce iv.a;
-            var y = toSymEntry(gY,t);
-            if ivMin < 0 {
-                var errorMsg = "Error: %s: OOBindex %i < 0".format(pn,ivMin);
-                imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg); 
-                return new MsgTuple(errorMsg,MsgType.ERROR);
+            // var e = toSymEntry(gX,t);
+            if t == bigint {
+                var e = toSymEntry(gX, bigint);
+                var iv = toSymEntry(gIV,uint);
+                var ivMin = min reduce iv.a;
+                var ivMax = max reduce iv.a;
+                var y = toSymEntry(gY,t);
+                if ivMin < 0 {
+                    var errorMsg = "Error: %s: OOBindex %i < 0".format(pn,ivMin);
+                    imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg); 
+                    return new MsgTuple(errorMsg,MsgType.ERROR);
+                }
+                if ivMax >= e.size {
+                    var errorMsg = "Error: %s: OOBindex %i > %i".format(pn,ivMax,e.size-1);
+                    imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
+                    return new MsgTuple(errorMsg,MsgType.ERROR);
+                }
+                //[(i,v) in zip(iv.a,y.a)] e.a[i] = v;
+                ref iva = iv.a;
+                ref ya = y.a;
+                var tmp = if y.etype == bigint then ya else if y.etype == bool then ya:int:bigint else ya:bigint;
+                // var ya = if y.a.type == bigint then y.a else if y.a.type == bool then y.a:int:bigint else y.a:bigint;
+                ref ea = e.a;
+                forall (i,v) in zip(iva,tmp) with (var agg = newDstAggregator(bigint)) {
+                    agg.copy(ea[i:int],v);
+                }
+                // if gY.dtype == DType.BigInt {
+                //     ref ya = y.a;
+                //     ref ea = e.a;
+                //     forall (i,v) in zip(iva,ya) with (var agg = newDstAggregator(t)) {
+                //         agg.copy(ea[i],v);
+                //     }
+                // }
+                // else if gY.dtype == DType.Bool {
+                //     var ya = y.a:int:bigint;
+                //     ref ea = e.a;
+                //     forall (i,v) in zip(iva,ya) with (var agg = newDstAggregator(t)) {
+                //         agg.copy(ea[i]:int,v);
+                //     }
+                // }
+                // else {
+                //     var ya = y.a:bigint;
+                //     ref ea = e.a;
+                //     forall (i,v) in zip(iva,ya) with (var agg = newDstAggregator(t)) {
+                //         agg.copy(ea[i:int],v);
+                //     }
+                // }
             }
-            if ivMax >= e.size {
-                var errorMsg = "Error: %s: OOBindex %i > %i".format(pn,ivMax,e.size-1);
-                imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
-                return new MsgTuple(errorMsg,MsgType.ERROR);
+            else {
+                var e = toSymEntry(gX,t);
+                var iv = toSymEntry(gIV,uint);
+                var ivMin = min reduce iv.a;
+                var ivMax = max reduce iv.a;
+                var y = toSymEntry(gY,t);
+                if ivMin < 0 {
+                    var errorMsg = "Error: %s: OOBindex %i < 0".format(pn,ivMin);
+                    imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg); 
+                    return new MsgTuple(errorMsg,MsgType.ERROR);
+                }
+                if ivMax >= e.size {
+                    var errorMsg = "Error: %s: OOBindex %i > %i".format(pn,ivMax,e.size-1);
+                    imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
+                    return new MsgTuple(errorMsg,MsgType.ERROR);
+                }
+                //[(i,v) in zip(iv.a,y.a)] e.a[i] = v;
+                ref iva = iv.a;
+                var ya = y.a;
+                ref ea = e.a;
+                forall (i,v) in zip(iva,ya) with (var agg = newDstAggregator(t)) {
+                    agg.copy(ea[i:int],v);
+                }
             }
-            //[(i,v) in zip(iv.a,y.a)] e.a[i] = v;
-            ref iva = iv.a;
-            ref ya = y.a;
-            ref ea = e.a;
-            forall (i,v) in zip(iva,ya) with (var agg = newDstAggregator(t)) {
-              agg.copy(ea[i:int],v);
-            }
+
             var repMsg = "%s success".format(pn);
             imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
             return new MsgTuple(repMsg, MsgType.NORMAL);
@@ -914,28 +1003,101 @@ module IndexingMsg
                 imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
                 return new MsgTuple(errorMsg,MsgType.ERROR);
             }
-            var e = toSymEntry(gX,t);
-            var truth = toSymEntry(gIV,bool);
-            // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
-            overMemLimit(numBytes(int) * truth.size);
-            var iv: [truth.a.domain] int = (+ scan truth.a);
-            var pop = iv[iv.size-1];
-            imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
-                                         "pop = %t last-scan = %t".format(pop,iv[iv.size-1]));
-            var y = toSymEntry(gY,t);
-            if (y.size != pop) {
-                var errorMsg = "Error: %s: pop size mismatch %i %i".format(pn,pop,y.size);
-                imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg,MsgType.ERROR);
+            // var e = toSymEntry(gX,t);
+            // var ya = if gY.dtype == DType.BigInt then y.a else if gY.dtype == DType.Bool then y.a:int:bigint else y.a:bigint;
+            // //ref ya = y.a;
+            // const ref ead = e.a.domain;
+            // ref ea = e.a;
+            // ref trutha = truth.a;
+            // forall (eai, i) in zip(ea, ead) with (var agg = newSrcAggregator(t)) {
+            //   if (trutha[i] == true) {
+            //     agg.copy(eai,ya[iv[i]-1]);
+            //   }
+            // }
+            if t == bigint {
+                var e = toSymEntry(gX, bigint);
+                var truth = toSymEntry(gIV,bool);
+                // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+                overMemLimit(numBytes(int) * truth.size);
+                var iv: [truth.a.domain] int = (+ scan truth.a);
+                var pop = iv[iv.size-1];
+                imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
+                                            "pop = %t last-scan = %t".format(pop,iv[iv.size-1]));
+                var y = toSymEntry(gY,t);
+                if (y.size != pop) {
+                    var errorMsg = "Error: %s: pop size mismatch %i %i".format(pn,pop,y.size);
+                    imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                    return new MsgTuple(errorMsg,MsgType.ERROR);
+                }
+                ref ya = y.a;
+                var tmp = if y.etype == bigint then ya else if y.etype == bool then ya:int:bigint else ya:bigint;
+                // var ya = if y.a.type == bigint then y.a else if y.a.type == bool then y.a:int:bigint else y.a:bigint;
+                ref ea = e.a;
+                const ref ead = ea.domain;
+                ref trutha = truth.a;
+                forall (eai, i) in zip(ea, ead) with (var agg = newSrcAggregator(bigint)) {
+                    if trutha[i] {
+                        agg.copy(eai,tmp[iv[i]-1]);
+                    }
+                }
+                // if gY.dtype == DType.BigInt {
+                //     ref ya = y.a;
+                //     const ref ead = e.a.domain;
+                //     ref ea = e.a;
+                //     ref trutha = truth.a;
+                //     forall (eai, i) in zip(ea, ead) with (var agg = newSrcAggregator(t)) {
+                //         if (trutha[i] == true) {
+                //             agg.copy(eai,ya[iv[i]-1]);
+                //         }
+                //     }
+                // }
+                // else if gY.dtype == DType.Bool {
+                //     var ya = y.a:int:bigint;
+                //     const ref ead = e.a.domain;
+                //     ref ea = e.a;
+                //     ref trutha = truth.a;
+                //     forall (eai, i) in zip(ea, ead) with (var agg = newSrcAggregator(t)) {
+                //         if (trutha[i] == true) {
+                //             agg.copy(eai,ya[iv[i]-1]);
+                //         }
+                //     }
+                // }
+                // else {
+                //     var ya = y.a:bigint;
+                //     const ref ead = e.a.domain;
+                //     ref ea = e.a;
+                //     ref trutha = truth.a;
+                //     forall (eai, i) in zip(ea, ead) with (var agg = newSrcAggregator(t)) {
+                //         if (trutha[i] == true) {
+                //             agg.copy(eai,ya[iv[i]-1]);
+                //         }
+                //     }
+                // }
             }
-            ref ya = y.a;
-            const ref ead = e.a.domain;
-            ref ea = e.a;
-            ref trutha = truth.a;
-            forall (eai, i) in zip(ea, ead) with (var agg = newSrcAggregator(t)) {
-              if (trutha[i] == true) {
-                agg.copy(eai,ya[iv[i]-1]);
-              }
+            else {
+                var e = toSymEntry(gX,t);
+                var truth = toSymEntry(gIV,bool);
+                // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+                overMemLimit(numBytes(int) * truth.size);
+                var iv: [truth.a.domain] int = (+ scan truth.a);
+                var pop = iv[iv.size-1];
+                imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
+                                            "pop = %t last-scan = %t".format(pop,iv[iv.size-1]));
+                var y = toSymEntry(gY,t);
+                if (y.size != pop) {
+                    var errorMsg = "Error: %s: pop size mismatch %i %i".format(pn,pop,y.size);
+                    imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                    return new MsgTuple(errorMsg,MsgType.ERROR);
+                }
+                var ya = y.a;
+                const ref ead = e.a.domain;
+                ref ea = e.a;
+                ref trutha = truth.a;
+                forall (eai, i) in zip(ea, ead) with (var agg = newSrcAggregator(t)) {
+                    if trutha[i] {
+                        agg.copy(eai,ya[iv[i]-1]);
+                    }
+                }
             }
 
             var repMsg = "%s success".format(pn);
@@ -943,7 +1105,7 @@ module IndexingMsg
             return new MsgTuple(repMsg, MsgType.NORMAL);
         }
 
-        select(gX.dtype, gIV.dtype, dtype) {
+        select(gX.dtype, gIV.dtype, gY.dtype) {
             when (DType.Int64, DType.Int64, DType.Int64) {
                 return ivInt64Helper(int);
             }
@@ -981,6 +1143,7 @@ module IndexingMsg
                 return ivBoolHelper(bool);
             }
             when (DType.BigInt, DType.Int64, DType.BigInt) {
+                writeln("did i get here?");
                 return ivInt64Helper(bigint);
             }
             when (DType.BigInt, DType.UInt64, DType.BigInt) {

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -843,24 +843,24 @@ module IndexingMsg
                 imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
                 return new MsgTuple(errorMsg,MsgType.ERROR);
             }
+            var iv = toSymEntry(gIV,int);
+            var ivMin = min reduce iv.a;
+            var ivMax = max reduce iv.a;
+            var y = toSymEntry(gY,t);
+            if ivMin < 0 {
+                var errorMsg = "Error: %s: OOBindex %i < 0".format(pn,ivMin);
+                imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg); 
+                return new MsgTuple(errorMsg,MsgType.ERROR);
+            }
+            if ivMax >= gX.size {
+                var errorMsg = "Error: %s: OOBindex %i > %i".format(pn,ivMax,gX.size-1);
+                imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
+                return new MsgTuple(errorMsg,MsgType.ERROR);
+            }
+            ref iva = iv.a;
+            ref ya = y.a;
             if gX.dtype == DType.BigInt {
                 var e = toSymEntry(gX, bigint);
-                var iv = toSymEntry(gIV,int);
-                var ivMin = min reduce iv.a;
-                var ivMax = max reduce iv.a;
-                var y = toSymEntry(gY,t);
-                if ivMin < 0 {
-                    var errorMsg = "Error: %s: OOBindex %i < 0".format(pn,ivMin);
-                    imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg); 
-                    return new MsgTuple(errorMsg,MsgType.ERROR);
-                }
-                if ivMax >= e.size {
-                    var errorMsg = "Error: %s: OOBindex %i > %i".format(pn,ivMax,e.size-1);
-                    imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
-                    return new MsgTuple(errorMsg,MsgType.ERROR);
-                }
-                ref iva = iv.a;
-                ref ya = y.a;
                 // NOTE y.etype will never be real when gX.dtype is bigint, but the compiler doesn't know that
                 var tmp = if y.etype == bigint then ya else if (y.etype == bool || y.etype == real) then ya:int:bigint else ya:bigint;
                 ref ea = e.a;
@@ -870,27 +870,61 @@ module IndexingMsg
             }
             else {
                 var e = toSymEntry(gX,t);
-                var iv = toSymEntry(gIV,int);
-                var ivMin = min reduce iv.a;
-                var ivMax = max reduce iv.a;
-                var y = toSymEntry(gY,t);
-                if ivMin < 0 {
-                    var errorMsg = "Error: %s: OOBindex %i < 0".format(pn,ivMin);
-                    imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg); 
-                    return new MsgTuple(errorMsg,MsgType.ERROR);
-                }
-                if ivMax >= e.size {
-                    var errorMsg = "Error: %s: OOBindex %i > %i".format(pn,ivMax,e.size-1);
-                    imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
-                    return new MsgTuple(errorMsg,MsgType.ERROR);
-                }
-                ref iva = iv.a;
-                var ya = y.a;
                 ref ea = e.a;
                 forall (i,v) in zip(iva,ya) with (var agg = newDstAggregator(t)) {
                     agg.copy(ea[i],v);
                 }
             }
+            // XXS
+            // if gX.dtype == DType.BigInt {
+            //     var e = toSymEntry(gX, bigint);
+            //     var iv = toSymEntry(gIV,int);
+            //     var ivMin = min reduce iv.a;
+            //     var ivMax = max reduce iv.a;
+            //     var y = toSymEntry(gY,t);
+            //     if ivMin < 0 {
+            //         var errorMsg = "Error: %s: OOBindex %i < 0".format(pn,ivMin);
+            //         imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg); 
+            //         return new MsgTuple(errorMsg,MsgType.ERROR);
+            //     }
+            //     if ivMax >= e.size {
+            //         var errorMsg = "Error: %s: OOBindex %i > %i".format(pn,ivMax,e.size-1);
+            //         imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
+            //         return new MsgTuple(errorMsg,MsgType.ERROR);
+            //     }
+            //     ref iva = iv.a;
+            //     ref ya = y.a;
+            //     // NOTE y.etype will never be real when gX.dtype is bigint, but the compiler doesn't know that
+            //     var tmp = if y.etype == bigint then ya else if (y.etype == bool || y.etype == real) then ya:int:bigint else ya:bigint;
+            //     ref ea = e.a;
+            //     forall (i,v) in zip(iva,tmp) with (var agg = newDstAggregator(bigint)) {
+            //         agg.copy(ea[i],v);
+            //     }
+            // }
+            // else {
+            //     var e = toSymEntry(gX,t);
+            //     var iv = toSymEntry(gIV,int);
+            //     var ivMin = min reduce iv.a;
+            //     var ivMax = max reduce iv.a;
+            //     var y = toSymEntry(gY,t);
+            //     if ivMin < 0 {
+            //         var errorMsg = "Error: %s: OOBindex %i < 0".format(pn,ivMin);
+            //         imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg); 
+            //         return new MsgTuple(errorMsg,MsgType.ERROR);
+            //     }
+            //     if ivMax >= e.size {
+            //         var errorMsg = "Error: %s: OOBindex %i > %i".format(pn,ivMax,e.size-1);
+            //         imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
+            //         return new MsgTuple(errorMsg,MsgType.ERROR);
+            //     }
+            //     ref iva = iv.a;
+            //     var ya = y.a;
+            //     ref ea = e.a;
+            //     forall (i,v) in zip(iva,ya) with (var agg = newDstAggregator(t)) {
+            //         agg.copy(ea[i],v);
+            //     }
+            // }
+            // XXE
             var repMsg = "%s success".format(pn);
             imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
             return new MsgTuple(repMsg, MsgType.NORMAL);
@@ -904,24 +938,24 @@ module IndexingMsg
                 imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
                 return new MsgTuple(errorMsg,MsgType.ERROR);
             }
-            if t == bigint {
+            var iv = toSymEntry(gIV,uint);
+            var ivMin = min reduce iv.a;
+            var ivMax = max reduce iv.a;
+            var y = toSymEntry(gY,t);
+            if ivMin < 0 {
+                var errorMsg = "Error: %s: OOBindex %i < 0".format(pn,ivMin);
+                imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg); 
+                return new MsgTuple(errorMsg,MsgType.ERROR);
+            }
+            if ivMax >= gX.size {
+                var errorMsg = "Error: %s: OOBindex %i > %i".format(pn,ivMax,gX.size-1);
+                imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
+                return new MsgTuple(errorMsg,MsgType.ERROR);
+            }
+            ref iva = iv.a;
+            ref ya = y.a;
+            if gX.dtype == DType.BigInt {
                 var e = toSymEntry(gX, bigint);
-                var iv = toSymEntry(gIV,uint);
-                var ivMin = min reduce iv.a;
-                var ivMax = max reduce iv.a;
-                var y = toSymEntry(gY,t);
-                if ivMin < 0 {
-                    var errorMsg = "Error: %s: OOBindex %i < 0".format(pn,ivMin);
-                    imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg); 
-                    return new MsgTuple(errorMsg,MsgType.ERROR);
-                }
-                if ivMax >= e.size {
-                    var errorMsg = "Error: %s: OOBindex %i > %i".format(pn,ivMax,e.size-1);
-                    imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
-                    return new MsgTuple(errorMsg,MsgType.ERROR);
-                }
-                ref iva = iv.a;
-                ref ya = y.a;
                 // NOTE y.etype will never be real when gX.dtype is bigint, but the compiler doesn't know that
                 var tmp = if y.etype == bigint then ya else if (y.etype == bool || y.etype == real) then ya:int:bigint else ya:bigint;
                 ref ea = e.a;
@@ -931,22 +965,6 @@ module IndexingMsg
             }
             else {
                 var e = toSymEntry(gX,t);
-                var iv = toSymEntry(gIV,uint);
-                var ivMin = min reduce iv.a;
-                var ivMax = max reduce iv.a;
-                var y = toSymEntry(gY,t);
-                if ivMin < 0 {
-                    var errorMsg = "Error: %s: OOBindex %i < 0".format(pn,ivMin);
-                    imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg); 
-                    return new MsgTuple(errorMsg,MsgType.ERROR);
-                }
-                if ivMax >= e.size {
-                    var errorMsg = "Error: %s: OOBindex %i > %i".format(pn,ivMax,e.size-1);
-                    imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
-                    return new MsgTuple(errorMsg,MsgType.ERROR);
-                }
-                ref iva = iv.a;
-                var ya = y.a;
                 ref ea = e.a;
                 forall (i,v) in zip(iva,ya) with (var agg = newDstAggregator(t)) {
                     agg.copy(ea[i:int],v);
@@ -1062,14 +1080,14 @@ module IndexingMsg
             when (DType.BigInt, DType.Int64, DType.BigInt) {
                 return ivInt64Helper(bigint);
             }
-            when (DType.BigInt, DType.UInt64, DType.BigInt) {
-                return ivUInt64Helper(bigint);
-            }
             when (DType.BigInt, DType.Int64, DType.Int64) {
                 return ivInt64Helper(int);
             }
             when (DType.BigInt, DType.Int64, DType.UInt64) {
                 return ivInt64Helper(uint);
+            }
+            when (DType.BigInt, DType.UInt64, DType.BigInt) {
+                return ivUInt64Helper(bigint);
             }
             when (DType.BigInt, DType.UInt64, DType.Int64) {
                 return ivUInt64Helper(int);

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -933,23 +933,59 @@ module IndexingMsg
                 imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
                 return new MsgTuple(errorMsg,MsgType.ERROR);
             }
-            
-            var e = toSymEntry(gX, bigint);
-            var truth = toSymEntry(gIV,bool);
-            // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
-            overMemLimit(numBytes(int) * truth.size);
-            var iv: [truth.a.domain] int = (+ scan truth.a);
-            var pop = iv[iv.size-1];
-            imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
-                                        "pop = %t last-scan = %t".format(pop,iv[iv.size-1]));
-            var y = toSymEntry(gY,t);
-            if (y.size != pop) {
-                var errorMsg = "Error: %s: pop size mismatch %i %i".format(pn,pop,y.size);
-                imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg,MsgType.ERROR);
-            }
-            ref ya = y.a;
-            if gX.dtype == DType.BigInt {
+            // var e = toSymEntry(gX, bigint);
+            // var truth = toSymEntry(gIV,bool);
+            // // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+            // overMemLimit(numBytes(int) * truth.size);
+            // var iv: [truth.a.domain] int = (+ scan truth.a);
+            // var pop = iv[iv.size-1];
+            // imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
+            //                             "pop = %t last-scan = %t".format(pop,iv[iv.size-1]));
+            // var y = toSymEntry(gY,t);
+            // if (y.size != pop) {
+            //     var errorMsg = "Error: %s: pop size mismatch %i %i".format(pn,pop,y.size);
+            //     imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            //     return new MsgTuple(errorMsg,MsgType.ERROR);
+            // }
+            // ref ya = y.a;                
+            // ref trutha = truth.a;
+            // if gX.dtype == DType.BigInt {
+            //     // NOTE y.etype will never be real when gX.dtype is bigint, but the compiler doesn't know that
+            //     var tmp = if y.etype == bigint then ya else if (y.etype == bool || y.etype == real) then ya:int:bigint else ya:bigint;
+            //     ref ea = e.a;
+            //     const ref ead = ea.domain;
+            //     forall (eai, i) in zip(ea, ead) with (var agg = newSrcAggregator(bigint)) {
+            //         if trutha[i] {
+            //             agg.copy(eai,tmp[iv[i]-1]);
+            //         }
+            //     }
+            // }
+            // else {
+            //     var e = toSymEntry(gX,t);
+            //     const ref ead = e.a.domain;
+            //     ref ea = e.a;
+            //     forall (eai, i) in zip(ea, ead) with (var agg = newSrcAggregator(t)) {
+            //         if trutha[i] {
+            //             agg.copy(eai,ya[iv[i]-1]);
+            //         }
+            //     }
+            // }
+            if t == bigint {
+                var e = toSymEntry(gX, bigint);
+                var truth = toSymEntry(gIV,bool);
+                // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+                overMemLimit(numBytes(int) * truth.size);
+                var iv: [truth.a.domain] int = (+ scan truth.a);
+                var pop = iv[iv.size-1];
+                imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
+                                            "pop = %t last-scan = %t".format(pop,iv[iv.size-1]));
+                var y = toSymEntry(gY,t);
+                if (y.size != pop) {
+                    var errorMsg = "Error: %s: pop size mismatch %i %i".format(pn,pop,y.size);
+                    imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                    return new MsgTuple(errorMsg,MsgType.ERROR);
+                }
+                ref ya = y.a;
                 // NOTE y.etype will never be real when gX.dtype is bigint, but the compiler doesn't know that
                 var tmp = if y.etype == bigint then ya else if (y.etype == bool || y.etype == real) then ya:int:bigint else ya:bigint;
                 ref ea = e.a;
@@ -964,6 +1000,19 @@ module IndexingMsg
             else {
                 var e = toSymEntry(gX,t);
                 var truth = toSymEntry(gIV,bool);
+                // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
+                overMemLimit(numBytes(int) * truth.size);
+                var iv: [truth.a.domain] int = (+ scan truth.a);
+                var pop = iv[iv.size-1];
+                imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
+                                            "pop = %t last-scan = %t".format(pop,iv[iv.size-1]));
+                var y = toSymEntry(gY,t);
+                if (y.size != pop) {
+                    var errorMsg = "Error: %s: pop size mismatch %i %i".format(pn,pop,y.size);
+                    imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                    return new MsgTuple(errorMsg,MsgType.ERROR);
+                }
+                var ya = y.a;
                 const ref ead = e.a.domain;
                 ref ea = e.a;
                 ref trutha = truth.a;

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -825,7 +825,6 @@ module IndexingMsg
         var gX: borrowed GenSymEntry = getGenericTypedArrayEntry(name, st);
         var gIV: borrowed GenSymEntry = getGenericTypedArrayEntry(iname, st);
         var gY: borrowed GenSymEntry = getGenericTypedArrayEntry(yname, st);
-        // const dtype = if gX.dtype == DType.BigInt then DType.BigInt else gY.dtype;
 
         if logLevel == LogLevel.DEBUG {
             imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
@@ -861,23 +860,11 @@ module IndexingMsg
                     return new MsgTuple(errorMsg,MsgType.ERROR);
                 }
                 ref iva = iv.a;
-                writeln("gX.dtype == DType.BigInt");
                 ref ya = y.a;
-                // writeln(y.etype);
-                writeln(ya);
                 // NOTE y.etype will never be real when gX.dtype is bigint, but the compiler doesn't know that
                 var tmp = if y.etype == bigint then ya else if (y.etype == bool || y.etype == real) then ya:int:bigint else ya:bigint;
-                writeln(tmp);
-                // writeln(tmp.type);
-
-
-                // var bigint_ya = if ya.type == bigint then ya else ya:bigint;
-                // var ya = if y.a.type == bigint then y.a else y.a:bigint;
                 ref ea = e.a;
                 forall (i,v) in zip(iva,tmp) with (var agg = newDstAggregator(bigint)) {
-                    writeln("idx ", i);
-                    writeln("val ", v);
-                    writeln();
                     agg.copy(ea[i],v);
                 }
             }
@@ -904,7 +891,6 @@ module IndexingMsg
                     agg.copy(ea[i],v);
                 }
             }
-            writeln("surely we didn't get this far");
             var repMsg = "%s success".format(pn);
             imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
             return new MsgTuple(repMsg, MsgType.NORMAL);
@@ -918,7 +904,6 @@ module IndexingMsg
                 imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
                 return new MsgTuple(errorMsg,MsgType.ERROR);
             }
-            // var e = toSymEntry(gX,t);
             if t == bigint {
                 var e = toSymEntry(gX, bigint);
                 var iv = toSymEntry(gIV,uint);
@@ -935,36 +920,14 @@ module IndexingMsg
                     imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
                     return new MsgTuple(errorMsg,MsgType.ERROR);
                 }
-                //[(i,v) in zip(iv.a,y.a)] e.a[i] = v;
                 ref iva = iv.a;
                 ref ya = y.a;
+                // NOTE y.etype will never be real when gX.dtype is bigint, but the compiler doesn't know that
                 var tmp = if y.etype == bigint then ya else if (y.etype == bool || y.etype == real) then ya:int:bigint else ya:bigint;
-                // var ya = if y.a.type == bigint then y.a else if y.a.type == bool then y.a:int:bigint else y.a:bigint;
                 ref ea = e.a;
                 forall (i,v) in zip(iva,tmp) with (var agg = newDstAggregator(bigint)) {
                     agg.copy(ea[i:int],v);
                 }
-                // if gY.dtype == DType.BigInt {
-                //     ref ya = y.a;
-                //     ref ea = e.a;
-                //     forall (i,v) in zip(iva,ya) with (var agg = newDstAggregator(t)) {
-                //         agg.copy(ea[i],v);
-                //     }
-                // }
-                // else if gY.dtype == DType.Bool {
-                //     var ya = y.a:int:bigint;
-                //     ref ea = e.a;
-                //     forall (i,v) in zip(iva,ya) with (var agg = newDstAggregator(t)) {
-                //         agg.copy(ea[i]:int,v);
-                //     }
-                // }
-                // else {
-                //     var ya = y.a:bigint;
-                //     ref ea = e.a;
-                //     forall (i,v) in zip(iva,ya) with (var agg = newDstAggregator(t)) {
-                //         agg.copy(ea[i:int],v);
-                //     }
-                // }
             }
             else {
                 var e = toSymEntry(gX,t);
@@ -982,7 +945,6 @@ module IndexingMsg
                     imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);           
                     return new MsgTuple(errorMsg,MsgType.ERROR);
                 }
-                //[(i,v) in zip(iv.a,y.a)] e.a[i] = v;
                 ref iva = iv.a;
                 var ya = y.a;
                 ref ea = e.a;
@@ -990,7 +952,6 @@ module IndexingMsg
                     agg.copy(ea[i:int],v);
                 }
             }
-
             var repMsg = "%s success".format(pn);
             imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
             return new MsgTuple(repMsg, MsgType.NORMAL);
@@ -1004,17 +965,6 @@ module IndexingMsg
                 imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
                 return new MsgTuple(errorMsg,MsgType.ERROR);
             }
-            // var e = toSymEntry(gX,t);
-            // var ya = if gY.dtype == DType.BigInt then y.a else if gY.dtype == DType.Bool then y.a:int:bigint else y.a:bigint;
-            // //ref ya = y.a;
-            // const ref ead = e.a.domain;
-            // ref ea = e.a;
-            // ref trutha = truth.a;
-            // forall (eai, i) in zip(ea, ead) with (var agg = newSrcAggregator(t)) {
-            //   if (trutha[i] == true) {
-            //     agg.copy(eai,ya[iv[i]-1]);
-            //   }
-            // }
             if t == bigint {
                 var e = toSymEntry(gX, bigint);
                 var truth = toSymEntry(gIV,bool);
@@ -1031,8 +981,8 @@ module IndexingMsg
                     return new MsgTuple(errorMsg,MsgType.ERROR);
                 }
                 ref ya = y.a;
+                // NOTE y.etype will never be real when gX.dtype is bigint, but the compiler doesn't know that
                 var tmp = if y.etype == bigint then ya else if (y.etype == bool || y.etype == real) then ya:int:bigint else ya:bigint;
-                // var ya = if y.a.type == bigint then y.a else if y.a.type == bool then y.a:int:bigint else y.a:bigint;
                 ref ea = e.a;
                 const ref ead = ea.domain;
                 ref trutha = truth.a;
@@ -1041,39 +991,6 @@ module IndexingMsg
                         agg.copy(eai,tmp[iv[i]-1]);
                     }
                 }
-                // if gY.dtype == DType.BigInt {
-                //     ref ya = y.a;
-                //     const ref ead = e.a.domain;
-                //     ref ea = e.a;
-                //     ref trutha = truth.a;
-                //     forall (eai, i) in zip(ea, ead) with (var agg = newSrcAggregator(t)) {
-                //         if (trutha[i] == true) {
-                //             agg.copy(eai,ya[iv[i]-1]);
-                //         }
-                //     }
-                // }
-                // else if gY.dtype == DType.Bool {
-                //     var ya = y.a:int:bigint;
-                //     const ref ead = e.a.domain;
-                //     ref ea = e.a;
-                //     ref trutha = truth.a;
-                //     forall (eai, i) in zip(ea, ead) with (var agg = newSrcAggregator(t)) {
-                //         if (trutha[i] == true) {
-                //             agg.copy(eai,ya[iv[i]-1]);
-                //         }
-                //     }
-                // }
-                // else {
-                //     var ya = y.a:bigint;
-                //     const ref ead = e.a.domain;
-                //     ref ea = e.a;
-                //     ref trutha = truth.a;
-                //     forall (eai, i) in zip(ea, ead) with (var agg = newSrcAggregator(t)) {
-                //         if (trutha[i] == true) {
-                //             agg.copy(eai,ya[iv[i]-1]);
-                //         }
-                //     }
-                // }
             }
             else {
                 var e = toSymEntry(gX,t);
@@ -1100,7 +1017,6 @@ module IndexingMsg
                     }
                 }
             }
-
             var repMsg = "%s success".format(pn);
             imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
             return new MsgTuple(repMsg, MsgType.NORMAL);
@@ -1144,7 +1060,6 @@ module IndexingMsg
                 return ivBoolHelper(bool);
             }
             when (DType.BigInt, DType.Int64, DType.BigInt) {
-                writeln("did i get here?"); 
                 return ivInt64Helper(bigint);
             }
             when (DType.BigInt, DType.UInt64, DType.BigInt) {

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -825,7 +825,8 @@ module IndexingMsg
         var gX: borrowed GenSymEntry = getGenericTypedArrayEntry(name, st);
         var gIV: borrowed GenSymEntry = getGenericTypedArrayEntry(iname, st);
         var gY: borrowed GenSymEntry = getGenericTypedArrayEntry(yname, st);
-        
+        const dtype = if gX.dtype == DType.BigInt then DType.BigInt else gY.dtype;
+
         if logLevel == LogLevel.DEBUG {
             imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                              "cmd: %s gX: %t gIV: %t gY: %t".format(
@@ -942,7 +943,7 @@ module IndexingMsg
             return new MsgTuple(repMsg, MsgType.NORMAL);
         }
 
-        select(gX.dtype, gIV.dtype, gY.dtype) {
+        select(gX.dtype, gIV.dtype, dtype) {
             when (DType.Int64, DType.Int64, DType.Int64) {
                 return ivInt64Helper(int);
             }
@@ -979,26 +980,17 @@ module IndexingMsg
             when (DType.Bool, DType.Bool, DType.Bool) {
                 return ivBoolHelper(bool);
             }
-            when (DType.BigInt, DType.Int64, DType.BigInt) {
-                return ivInt64Helper(bigint);
-            }
             when (DType.BigInt, DType.Int64, DType.Int64) {
                 return ivInt64Helper(int);
             }
             when (DType.BigInt, DType.Int64, DType.UInt64) {
                 return ivInt64Helper(uint);
             }
-            when (DType.BigInt, DType.UInt64, DType.BigInt) {
-                return ivUInt64Helper(bigint);
-            }
             when (DType.BigInt, DType.UInt64, DType.Int64) {
                 return ivUInt64Helper(int);
             }
             when (DType.BigInt, DType.UInt64, DType.UInt64) {
                 return ivUInt64Helper(uint);
-            }
-            when (DType.BigInt, DType.Bool, DType.BigInt) {
-                return ivBoolHelper(bigint);
             }
             when (DType.BigInt, DType.Bool, DType.Int64) {
                 return ivBoolHelper(int);

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -971,7 +971,6 @@ module IndexingMsg
             //     }
             // }
             
-            var e = toSymEntry(gX, bigint);
             var truth = toSymEntry(gIV,bool);
             // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
             overMemLimit(numBytes(int) * truth.size);
@@ -987,6 +986,7 @@ module IndexingMsg
             }
             ref ya = y.a;
             if gX.dtype == DType.BigInt {
+                var e = toSymEntry(gX, bigint);
                 // NOTE y.etype will never be real when gX.dtype is bigint, but the compiler doesn't know that
                 var tmp = if y.etype == bigint then ya else if (y.etype == bool || y.etype == real) then ya:int:bigint else ya:bigint;
                 ref ea = e.a;

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -980,6 +980,12 @@ module IndexingMsg
             when (DType.Bool, DType.Bool, DType.Bool) {
                 return ivBoolHelper(bool);
             }
+            when (DType.BigInt, DType.Int64, DType.BigInt) {
+                return ivInt64Helper(bigint);
+            }
+            when (DType.BigInt, DType.UInt64, DType.BigInt) {
+                return ivUInt64Helper(bigint);
+            }
             when (DType.BigInt, DType.Int64, DType.Int64) {
                 return ivInt64Helper(int);
             }
@@ -991,6 +997,9 @@ module IndexingMsg
             }
             when (DType.BigInt, DType.UInt64, DType.UInt64) {
                 return ivUInt64Helper(uint);
+            }
+            when (DType.BigInt, DType.Bool, DType.BigInt) {
+                return ivBoolHelper(bigint);
             }
             when (DType.BigInt, DType.Bool, DType.Int64) {
                 return ivBoolHelper(int);


### PR DESCRIPTION
This PR (closes #2077) cleans up `IndexingMsg.chpl` by removing the duplicated logic for `bigint` implementation, as we now have an aggregation interface for `bigint`.