### PR TITLE
Closes #2047 - CSV Support

### DIFF
--- a/ServerModules.cfg
+++ b/ServerModules.cfg
@@ -26,6 +26,7 @@ StatsMsg
 TimeClassMsg
 HDF5Msg
 ParquetMsg
+CSVMsg
 EncodingMsg
 GroupByMsg
 

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -22,6 +22,7 @@ from arkouda.dtypes import int64 as akint64
 from arkouda.groupbyclass import GroupBy as akGroupBy
 from arkouda.groupbyclass import unique
 from arkouda.index import Index
+from arkouda.io import get_filetype, load_all
 from arkouda.numeric import cast as akcast
 from arkouda.numeric import cumsum
 from arkouda.numeric import isnan as akisnan
@@ -30,7 +31,6 @@ from arkouda.pdarrayclass import RegistrationError
 from arkouda.pdarrayclass import attach as pd_attach
 from arkouda.pdarrayclass import pdarray, unregister_pdarray_by_name
 from arkouda.pdarraycreation import arange, array, create_pdarray, zeros
-from arkouda.io import get_filetype, load_all
 from arkouda.pdarraysetops import concatenate, in1d, intersect1d
 from arkouda.row import Row
 from arkouda.segarray import SegArray
@@ -1532,6 +1532,115 @@ class DataFrame(UserDict):
 
         data = self._prep_data(index=index, columns=columns)
         to_parquet(data, prefix_path=path, compression=compression)
+
+    @typechecked
+    def to_csv(
+        self,
+        path: str,
+        index: bool = False,
+        columns: Optional[List[str]] = None,
+        col_delim: str = ",",
+        overwrite: bool = False,
+    ):
+        """
+        Writes DataFrame to CSV file(s). File will contain a column for each column in the DataFrame.
+        All CSV Files written by Arkouda include a header denoting data types of the columns.
+        Unlike other file formats, CSV files store Strings as their UTF-8 format instead of storing
+        bytes as uint(8).
+
+        Parameters
+        -----------
+        path: str
+            The filename prefix to be used for saving files. Files will have _LOCALE#### appended
+            when they are written to disk.
+        index: bool
+            Defaults to False. If True, the index of the DataFrame will be written to the file
+            as a column
+        columns: List[str] (Optional)
+            Column names to assign when writing data
+        col_delim: str
+            Defaults to ",". Value to be used to separate columns within the file.
+            Please be sure that the value used DOES NOT appear in your dataset.
+        overwrite: bool
+            Defaults to False. If True, any existing files matching your provided prefix_path will
+            be overwritten. If False, an error will be returned if existing files are found.
+
+        Returns
+        --------
+        None
+
+        Raises
+        ------
+        ValueError
+            Raised if all datasets are not present in all parquet files or if one or
+            more of the specified files do not exist
+        RuntimeError
+            Raised if one or more of the specified files cannot be opened.
+            If `allow_errors` is true this may be raised if no values are returned
+            from the server.
+        TypeError
+            Raised if we receive an unknown arkouda_type returned from the server
+
+        Notes
+        ------
+        - CSV format is not currently supported by load/load_all operations
+        - The column delimiter is expected to be the same for column names and data
+        - Be sure that column delimiters are not found within your data.
+        - All CSV files must delimit rows using newline (`\n`) at this time.
+        """
+        from arkouda.io import to_csv
+
+        data = self._prep_data(index=index, columns=columns)
+        to_csv(data, path, columns=columns, col_delim=col_delim, overwrite=overwrite)
+
+    @classmethod
+    def read_csv(cls, filename: str, col_delim: str = ","):
+        """
+        Read the columns of a CSV file into an Arkouda DataFrame.
+        If the file contains the appropriately formatted header, typed data will be returned.
+        Otherwise, all data will be returned as a Strings objects.
+
+        Parameters
+        -----------
+        filename: str
+            Filename to read data from
+        col_delim: str
+            Defaults to ",". The delimiter for columns within the data.
+
+        Returns
+        --------
+        Arkouda DataFrame containing the columns from the CSV file.
+
+        Raises
+        ------
+        ValueError
+            Raised if all datasets are not present in all parquet files or if one or
+            more of the specified files do not exist
+        RuntimeError
+            Raised if one or more of the specified files cannot be opened.
+            If `allow_errors` is true this may be raised if no values are returned
+            from the server.
+        TypeError
+            Raised if we receive an unknown arkouda_type returned from the server
+
+        See Also
+        ---------
+        to_csv
+
+        Notes
+        ------
+        - CSV format is not currently supported by load/load_all operations
+        - The column delimiter is expected to be the same for column names and data
+        - Be sure that column delimiters are not found within your data.
+        - All CSV files must delimit rows using newline (`\n`) at this time.
+        - Unlike other file formats, CSV files store Strings as their UTF-8 format instead of storing
+        bytes as uint(8).
+
+        """
+        from arkouda.io import read_csv
+
+        data = read_csv(filename, column_delim=col_delim)
+        return cls(data)
 
     def save(
         self,

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -1591,7 +1591,7 @@ class DataFrame(UserDict):
         from arkouda.io import to_csv
 
         data = self._prep_data(index=index, columns=columns)
-        to_csv(data, path, columns=columns, col_delim=col_delim, overwrite=overwrite)
+        to_csv(data, path, names=columns, col_delim=col_delim, overwrite=overwrite)
 
     @classmethod
     def read_csv(cls, filename: str, col_delim: str = ","):

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -291,6 +291,57 @@ class Index:
         """
         return self.values.to_parquet(prefix_path, dataset=dataset, mode=mode, compression=compression)
 
+    @typechecked
+    def to_csv(
+        self,
+        prefix_path: str,
+        dataset: str = "array",
+        col_delim: str = ",",
+        overwrite: bool = False,
+    ):
+        """
+        Write pdarray to CSV file(s). File will contain a single column with the pdarray data.
+        All CSV Files written by Arkouda include a header denoting data types of the columns.
+
+        Parameters
+        -----------
+        prefix_path: str
+            The filename prefix to be used for saving files. Files will have _LOCALE#### appended
+            when they are written to disk.
+        dataset: str
+            Column name to save the pdarray under. Defaults to "array".
+        col_delim: str
+            Defaults to ",". Value to be used to separate columns within the file.
+            Please be sure that the value used DOES NOT appear in your dataset.
+        overwrite: bool
+            Defaults to False. If True, any existing files matching your provided prefix_path will
+            be overwritten. If False, an error will be returned if existing files are found.
+
+        Returns
+        --------
+        str reponse message
+
+        Raises
+        ------
+        ValueError
+            Raised if all datasets are not present in all parquet files or if one or
+            more of the specified files do not exist
+        RuntimeError
+            Raised if one or more of the specified files cannot be opened.
+            If `allow_errors` is true this may be raised if no values are returned
+            from the server.
+        TypeError
+            Raised if we receive an unknown arkouda_type returned from the server
+
+        Notes
+        ------
+        - CSV format is not currently supported by load/load_all operations
+        - The column delimiter is expected to be the same for column names and data
+        - Be sure that column delimiters are not found within your data.
+        - All CSV files must delimit rows using newline (`\n`) at this time.
+        """
+        return self.values.to_csv(prefix_path, dataset=dataset, col_delim=col_delim, overwrite=overwrite)
+
     def save(
         self,
         prefix_path: str,

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -295,12 +295,12 @@ class Index:
     def to_csv(
         self,
         prefix_path: str,
-        dataset: str = "array",
+        dataset: str = "index",
         col_delim: str = ",",
         overwrite: bool = False,
     ):
         """
-        Write pdarray to CSV file(s). File will contain a single column with the pdarray data.
+        Write Index to CSV file(s). File will contain a single column with the pdarray data.
         All CSV Files written by Arkouda include a header denoting data types of the columns.
 
         Parameters

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -924,6 +924,9 @@ def _bulk_write_prep(columns: Union[Mapping[str, pdarray], List[pdarray]], names
         if names is None:
             datasetNames = [str(column) for column in range(len(columns))]
 
+    if len(pdarrays) == 0:
+        raise RuntimeError("No data was found.")
+
     return datasetNames, pdarrays
 
 
@@ -1140,7 +1143,7 @@ def to_csv(
     Raises
     ------
     ValueError
-        Raised if all datasets are not present in all parquet files or if one or
+        Raised if not all datasets are present in all csv files or if one or
         more of the specified files do not exist
     RuntimeError
         Raised if one or more of the specified files cannot be opened.
@@ -1163,9 +1166,7 @@ def to_csv(
     bytes as uint(8).
     """
     datasetNames, pdarrays = _bulk_write_prep(columns, names)
-    dtypes = []
-    for a in pdarrays:
-        dtypes.append(a.dtype.name)
+    dtypes = [a.dtype.name for a in pdarrays]
 
     generic_msg(
         cmd="writecsv",

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -1143,7 +1143,7 @@ def to_csv(
     Raises
     ------
     ValueError
-        Raised if not all datasets are present in all csv files or if one or
+        Raised if any datasets are present in all csv files or if one or
         more of the specified files do not exist
     RuntimeError
         Raised if one or more of the specified files cannot be opened.

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -754,7 +754,7 @@ def read_csv(
         },
     )
     rep = json.loads(rep_msg)  # See GenSymIO._buildReadAllMsgJson for json structure
-    _parse_errors(rep, False)
+    _parse_errors(rep, allow_errors)
     return _build_objects(rep)
 
 

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -680,7 +680,12 @@ def read_csv(
     datasets: Optional[Union[str, List[str]]] = None,
     column_delim: str = ",",
     allow_errors: bool = False,
-) -> Union[pdarray, Strings, Mapping[str, Union[pdarray, Strings]],]:
+) -> Union[
+    pdarray,
+    Strings,
+    arkouda.array_view.ArrayView,
+    Mapping[str, Union[pdarray, Strings, arkouda.array_view.ArrayView]],
+]:
     """
     Read CSV file(s) into Arkouda objects. If more than one dataset is found, the objects
     will be returned in a dictionary mapping the dataset name to the Arkouda object

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1490,6 +1490,72 @@ class pdarray:
             ),
         )
 
+    @typechecked
+    def to_csv(
+        self,
+        prefix_path: str,
+        dataset: str = "array",
+        col_delim: str = ",",
+        overwrite: bool = False,
+    ):
+        """
+        Write pdarray to CSV file(s). File will contain a single column with the pdarray data.
+        All CSV Files written by Arkouda include a header denoting data types of the columns.
+
+        Parameters
+        -----------
+        prefix_path: str
+            The filename prefix to be used for saving files. Files will have _LOCALE#### appended
+            when they are written to disk.
+        dataset: str
+            Column name to save the pdarray under. Defaults to "array".
+        col_delim: str
+            Defaults to ",". Value to be used to separate columns within the file.
+            Please be sure that the value used DOES NOT appear in your dataset.
+        overwrite: bool
+            Defaults to False. If True, any existing files matching your provided prefix_path will
+            be overwritten. If False, an error will be returned if existing files are found.
+
+        Returns
+        --------
+        str reponse message
+
+        Raises
+        ------
+        ValueError
+            Raised if all datasets are not present in all parquet files or if one or
+            more of the specified files do not exist
+        RuntimeError
+            Raised if one or more of the specified files cannot be opened.
+            If `allow_errors` is true this may be raised if no values are returned
+            from the server.
+        TypeError
+            Raised if we receive an unknown arkouda_type returned from the server
+
+        Notes
+        ------
+        - CSV format is not currently supported by load/load_all operations
+        - The column delimiter is expected to be the same for column names and data
+        - Be sure that column delimiters are not found within your data.
+        - All CSV files must delimit rows using newline (`\n`) at this time.
+        """
+        return cast(
+            str,
+            generic_msg(
+                cmd="writecsv",
+                args={
+                    "datasets": [self],
+                    "col_names": [dataset],
+                    "filename": prefix_path,
+                    "num_dsets": 1,
+                    "col_delim": col_delim,
+                    "dtypes": [self.dtype.name],
+                    "row_count": self.size,
+                    "overwrite": overwrite,
+                },
+            ),
+        )
+
     def save(
         self,
         prefix_path: str,
@@ -1574,6 +1640,7 @@ class pdarray:
         ``cwd/path/name_prefix_LOCALE####.parquet`` where #### is replaced by each locale number
         """
         from warnings import warn
+
         warn(
             "ak.pdarray.save has been deprecated. Please use ak.pdarray.to_parquet or ak.pdarray.to_hdf",
             DeprecationWarning,

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -2052,7 +2052,7 @@ class Strings:
             The filename prefix to be used for saving files. Files will have _LOCALE#### appended
             when they are written to disk.
         dataset: str
-            Column name to save the pdarray under. Defaults to "strings_array".
+            Column name to save the Strings under. Defaults to "strings_array".
         col_delim: str
             Defaults to ",". Value to be used to separate columns within the file.
             Please be sure that the value used DOES NOT appear in your dataset.

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -2033,6 +2033,74 @@ class Strings:
         )
 
     @typechecked
+    def to_csv(
+        self,
+        prefix_path: str,
+        dataset: str = "strings_array",
+        col_delim: str = ",",
+        overwrite: bool = False,
+    ):
+        """
+        Write Strings to CSV file(s). File will contain a single column with the Strings data.
+        All CSV Files written by Arkouda include a header denoting data types of the columns.
+        Unlike other file formats, CSV files store Strings as their UTF-8 format instead of storing
+        bytes as uint(8).
+
+        Parameters
+        -----------
+        prefix_path: str
+            The filename prefix to be used for saving files. Files will have _LOCALE#### appended
+            when they are written to disk.
+        dataset: str
+            Column name to save the pdarray under. Defaults to "strings_array".
+        col_delim: str
+            Defaults to ",". Value to be used to separate columns within the file.
+            Please be sure that the value used DOES NOT appear in your dataset.
+        overwrite: bool
+            Defaults to False. If True, any existing files matching your provided prefix_path will
+            be overwritten. If False, an error will be returned if existing files are found.
+
+        Returns
+        --------
+        str reponse message
+
+        Raises
+        ------
+        ValueError
+            Raised if all datasets are not present in all parquet files or if one or
+            more of the specified files do not exist
+        RuntimeError
+            Raised if one or more of the specified files cannot be opened.
+            If `allow_errors` is true this may be raised if no values are returned
+            from the server.
+        TypeError
+            Raised if we receive an unknown arkouda_type returned from the server
+
+        Notes
+        ------
+        - CSV format is not currently supported by load/load_all operations
+        - The column delimiter is expected to be the same for column names and data
+        - Be sure that column delimiters are not found within your data.
+        - All CSV files must delimit rows using newline (`\n`) at this time.
+        """
+        return cast(
+            str,
+            generic_msg(
+                cmd="writecsv",
+                args={
+                    "datasets": [self],
+                    "col_names": [dataset],
+                    "filename": prefix_path,
+                    "num_dsets": 1,
+                    "col_delim": col_delim,
+                    "dtypes": [self.dtype.name],
+                    "row_count": self.size,
+                    "overwrite": overwrite,
+                },
+            ),
+        )
+
+    @typechecked
     def save(
         self,
         prefix_path: str,

--- a/pydoc/file_io/CSV.md
+++ b/pydoc/file_io/CSV.md
@@ -1,6 +1,6 @@
 # CSV
 
-Arkouda now has support for reading and writing CSV file formats. CSV will not perform at the same level as HDF5 and Parquet. It is intended for interacting with smaller datasets and preventing the need to convert files that are already in CSV format to HDF5 or Parquet.
+Arkouda now has support for reading and writing CSV file formats. CSV will not perform at the same level as HDF5 and Parquet. It is intended for interacting with smaller datasets and will prevent the need to convert files already in CSV format to HDF5 or Parquet.
 
 ## Support Arkouda Data Types
 
@@ -11,7 +11,7 @@ Arkouda now has support for reading and writing CSV file formats. CSV will not p
 
 ## File Formatting
 
-Arkouda supports reading CSV files of various formats. There are some limitations currently in place, which are listed below.
+Arkouda supports reading CSV files of various formats. Current limitations include:
 
 - All lines/rows of the CSV file must be newline (`\n`) delimited
 - It is assumed that all files contain column names. The column names should be the first line of data in the file.
@@ -20,7 +20,7 @@ Arkouda supports reading CSV files of various formats. There are some limitation
 
 ### Example Files
 
-In order to provide a clear description of the formats Arkouda supports for CSV files, we have provide an example file written by Arkouda and a file written outside of arkouda that can also be read.
+To give an idea of arkouda supported formats for CSV files, we have provided two example files that Arkouda can read: one written by arkouda and one written outside of Arkouda.
 
 #### Arkouda Formatted File
 
@@ -55,7 +55,7 @@ CSV files have one major difference in how they store data in comparison to HDF5
 
 Due to differences in execution of the CSV format, generic load/read functionality is not currently supported. As a result, the provided `read_csv` methods must be used at this time.
 
-`ls`/`get_dataset` functionality is supported, but is once again separate from the generic implementation. To return a list of columns in the CSV use the `ak.get_columns()` function.
+`ls`/`get_dataset` functionality is supported, but is once again separate from the generic implementation. To return a list of columns in the CSV use the `ls_csv()`/`ak.get_columns()` function.
 
 ### pdarray
 

--- a/pydoc/file_io/CSV.md
+++ b/pydoc/file_io/CSV.md
@@ -17,6 +17,7 @@ Arkouda supports reading CSV files of various formats. Current limitations inclu
 - It is assumed that all files contain column names. The column names should be the first line of data in the file.
 - Files written by Arkouda will contain a "header" with typing information for the columns. Files without this header will return all read data as Strings objects.
 - Custom column delimiters can be used. The default column delimiter is ",". The column delimiter set for the file will also be used to delimit the column names.
+- Header contents are always comma (`,`) delimited.
 
 ### Example Files
 

--- a/pydoc/file_io/CSV.md
+++ b/pydoc/file_io/CSV.md
@@ -1,0 +1,83 @@
+# CSV
+
+Arkouda now has support for reading and writing CSV file formats. CSV will not perform at the same level as HDF5 and Parquet. It is intended for interacting with smaller datasets and preventing the need to convert files that are already in CSV format to HDF5 or Parquet.
+
+## Support Arkouda Data Types
+
+- pdarray
+- Strings
+- Index
+- DataFrame
+
+## File Formatting
+
+Arkouda supports reading CSV files of various formats. There are some limitations currently in place, which are listed below.
+
+- All lines/rows of the CSV file must be newline (`\n`) delimited
+- It is assumed that all files contain column names. The column names should be the first line of data in the file.
+- Files written by Arkouda will contain a "header" with typing information for the columns. Files without this header will return all read data as Strings objects.
+- Custom column delimiters can be used. The default column delimiter is ",". The column delimiter set for the file will also be used to delimit the column names.
+
+### Example Files
+
+In order to provide a clear description of the formats Arkouda supports for CSV files, we have provide an example file written by Arkouda and a file written outside of arkouda that can also be read.
+
+#### Arkouda Formatted File
+
+```text
+**HEADER**
+int64,str,float64
+*/HEADER/*
+ColA,ColB,ColC
+0,ABC,3.14
+1,DEF,5.56
+2,GHI,2.11
+```
+
+#### File Without Header
+
+Arkouda can read files without the header. All data will be read out to Strings objects in this case.
+
+```text
+ColA,ColB,ColC
+0,ABC,3.14
+1,DEF,5.56
+2,GHI,2.11
+```
+
+## Data Formatting
+
+Because CSV is a text format, all data is stored as a string. If the header is provided, the pdarray resulting from a read will be the assigned type.
+
+CSV files have one major difference in how they store data in comparison to HDF5 and Parquet, specifically for Strings objects. CSV stores Strings objects as the actual string, not as a `uint(8)` array as in HDF5 and Parquet.
+
+## API Reference
+
+Due to differences in execution of the CSV format, generic load/read functionality is not currently supported. As a result, the provided `read_csv` methods must be used at this time.
+
+`ls`/`get_dataset` functionality is supported, but is once again separate from the generic implementation. To return a list of columns in the CSV use the `ak.get_columns()` function.
+
+### pdarray
+
+```{eval-rst}  
+- :py:meth:`arkouda.pdarray.to_csv`
+```
+
+### Strings
+
+```{eval-rst}  
+- :py:meth:`arkouda.Strings.to_csv`
+```
+
+### Index
+
+```{eval-rst}  
+- :py:meth:`arkouda.Index.to_csv`
+```
+
+### DataFrame
+
+```{eval-rst}  
+- :py:meth:`arkouda.DataFrame.to_csv`
+- :py:meth:`arkodua.DataFrame.read_csv`
+```

--- a/pydoc/file_io/HDF5.md
+++ b/pydoc/file_io/HDF5.md
@@ -130,7 +130,7 @@ Providing these attributes allows for the ArrayView object to be reconstructed f
 > If the user elects to write to a single HDF5 file, all data will be pulled to the processing node and saved to ONE file with the supplied file name. It is important to ensure that the object is small enough to prevent memory exhaustion on the node.
 
 **Distributed Files**
-> if the user elects to write data to distributed files, data will be written to one file per locale. Each file will contain the data from the object local to the locale of that file. File names will be the name provided by the user with the suffix `_LOCALE####` where `####` will be replaced with the locale number. Because the data is distributed across multiple nodes, there is a much lower risk of memory exhaustion.
+> If the user elects to write data to distributed files, data will be written to one file per locale. Each file will contain the data from the object local to the locale of that file. File names will be the name provided by the user with the suffix `_LOCALE####` where `####` will be replaced with the locale number. Because the data is distributed across multiple nodes, there is a much lower risk of memory exhaustion.
 
 ## Legacy File Support
 

--- a/pydoc/file_io/io_menu.rst
+++ b/pydoc/file_io/io_menu.rst
@@ -13,6 +13,7 @@ Arkouda also supports importing files written by Pandas.
 
     HDF5
     PARQUET
+    CSV
 
 Import/Export Support
 ----------------------

--- a/pydoc/file_io/io_menu.rst
+++ b/pydoc/file_io/io_menu.rst
@@ -34,6 +34,7 @@ Write
 ^^^^^^
 - :py:func:`arkouda.io.to_parquet`
 - :py:func:`arkouda.io.to_hdf`
+- :py:func:`arkouda.io.to_csv`
 - :py:func:`arkouda.io.save_all`
 
 Read
@@ -42,4 +43,14 @@ Read
 - :py:func:`arkouda.io.load_all`
 - :py:func:`arkouda.io.read_parquet`
 - :py:func:`arkouda.io.read_hdf`
+- :py:func:`arkouda.io.read_csv`
 - :py:func:`arkouda.io.read`
+
+`ls` Functionality
+^^^^^^^^^^^^^^^^^^^
+These functions allow the user to access a list of datasets/columns stored in the provided file.
+
+- :py:func:`arkouda.io.ls`
+- :py:func:`arkouda.io.ls_csv`
+- :py:func:`arkouda.io.get_datasets`
+- :py:func:`arkouda.io.get_columns`

--- a/src/CSVMsg.chpl
+++ b/src/CSVMsg.chpl
@@ -1,0 +1,655 @@
+module CSVMsg {
+    use CommAggregation;
+    use IO;
+    use GenSymIO;
+    use List;
+    use Reflection;
+    use Logging;
+    use Message;
+    use MultiTypeSymbolTable;
+    use MultiTypeSymEntry;
+    use NumPyDType;
+    use ServerConfig;
+    use ServerErrors;
+    use ServerErrorStrings;
+    use SegmentedString;
+    use FileSystem;
+    use Sort;
+    use FileIO;
+    use Set;
+
+    const CSV_HEADER_OPEN = "**HEADER**";
+    const CSV_HEADER_CLOSE = "*/HEADER/*";
+    const LINE_DELIM = "\n"; // currently assumed all files are newline delimited. 
+
+    private config const logLevel = ServerConfig.logLevel;
+    const csvLogger = new Logger(logLevel);
+
+    // Future Work (TODO)
+    //  - write to single file
+    //  - Custom Line Delimiters 
+    //  - Handle CSV without column names
+
+    proc lsCSVMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        var filename = msgArgs.getValueOf("filename");
+        if filename.isEmpty() {
+            var errorMsg = "Filename was Empty";
+            csvLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+        }
+
+        // If the filename represents a glob pattern, retrieve the locale 0 filename
+        if isGlobPattern(filename) {
+            // Attempt to interpret filename as a glob expression and ls the first result
+            var tmp = glob(filename);
+            csvLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                      "glob-expanded filename: %s to size: %i files".format(filename, tmp.size));
+
+            if tmp.size <= 0 {
+                var errorMsg = "Cannot retrieve filename from glob expression %s, check file name or format".format(filename);
+                csvLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+            
+            // Set filename to globbed filename corresponding to locale 0
+            filename = tmp[tmp.domain.first];
+        }
+        
+        // Check to see if the file exists. If not, return an error message
+        if !exists(filename) {
+            var errorMsg = "File %s does not exist in a location accessible to Arkouda".format(filename);
+            csvLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg,MsgType.ERROR);
+        } 
+
+        // open file and determine if header exists.
+        var idx = 0;
+        var csvFile = open(filename, iomode.r);
+        var reader = csvFile.reader();
+        var lines = reader.lines().strip();
+        if lines[0] == CSV_HEADER_OPEN {
+            idx = 3; // set to first line after header
+        }
+
+        var col_delim: string = msgArgs.getValueOf("col_delim");
+        var column_names = lines[idx].split(col_delim);
+        reader.close();
+        csvFile.close();
+        return new MsgTuple("%jt".format(column_names), MsgType.NORMAL);
+
+    }
+
+    proc prepFiles(filename: string, overwrite: bool, A) throws { 
+        var prefix: string;
+        var extension: string;
+        (prefix,extension) = getFileMetadata(filename);
+
+        var targetSize: int = A.targetLocales().size;
+        var filenames: [0..#targetSize] string;
+        forall i in 0..#targetSize {
+            filenames[i] = generateFilename(prefix, extension, i);
+        }
+
+        csvLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "Identified %i files for provided name, %s".format(filenames.size, filename));
+
+        var matchingFilenames = glob("%s_LOCALE*%s".format(prefix, extension));
+        var filesExist: bool = matchingFilenames.size > 0;
+
+        if !overwrite && filesExist {
+            throw getErrorWithContext(
+                msg="Filenames for the provided name exist. Overwrite must be set to true in order to save with the name %s".format(filename),
+                lineNumber=getLineNumber(),
+                routineName=getRoutineName(), 
+                moduleName=getModuleName(),
+                errorClass="InvalidArgumentError");
+        }
+        else {
+            coforall loc in A.targetLocales() do on loc {
+                var fn = filenames[loc.id].localize();
+                var existList = glob(fn);
+                if overwrite && existList.size == 1 {
+                    remove(fn);
+                    csvLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "Overwriting CSV File, %s".format(fn));
+                }
+            }
+        }
+        return filenames; 
+    }
+
+    proc getLocalDomain(GSE: GenSymEntry) throws {
+        select GSE.dtype {    
+            when DType.Int64 {
+                var e = toSymEntry(GSE, int);
+                return e.a.localSubdomain();
+            }
+            when DType.UInt64 {
+                var e = toSymEntry(GSE, uint);
+                return e.a.localSubdomain();
+            }
+            when DType.Float64 {
+                var e = toSymEntry(GSE, real);
+                return e.a.localSubdomain();
+            }
+            when DType.Bool {
+                var e = toSymEntry(GSE, bool);
+                return e.a.localSubdomain();
+            }
+            when DType.Strings {
+                var e = GSE: borrowed SegStringSymEntry;
+                var ss = new SegString("", e);
+                return ss.offsets.a.localSubdomain();
+            }
+            otherwise {
+                throw getErrorWithContext(
+                    msg="Invalid DType Found, %s".format(dtype2str(GSE.dtype)),
+                    lineNumber=getLineNumber(),
+                    routineName=getRoutineName(), 
+                    moduleName=getModuleName(),
+                    errorClass="DataTypeError");
+            }
+        }
+    }
+
+    proc writeCSVMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        const filename = msgArgs.getValueOf("filename");
+        const ndsets = msgArgs.get("num_dsets").getIntValue();
+        var datasets = msgArgs.get("datasets").getList(ndsets);
+        var dtypes = msgArgs.get("dtypes").getList(ndsets);
+        var col_names = msgArgs.get("col_names").getList(ndsets);
+        const col_delim = msgArgs.getValueOf("col_delim");
+        const row_count = msgArgs.get("row_count").getIntValue();
+        const overwrite = msgArgs.get("overwrite").getBoolValue();
+
+        // access the first SymEntry -> all SymEntries should have same locality due to them being required to be the same size.
+        var gse = toGenSymEntry(st.lookup(datasets[0]));
+        var filenames;
+        select gse.dtype {
+            when DType.Int64 {
+                var e = toSymEntry(gse, int);
+                filenames = prepFiles(filename, overwrite, e.a);
+            }
+            when DType.UInt64 {
+                var e = toSymEntry(gse, uint);
+                filenames = prepFiles(filename, overwrite, e.a);
+            }
+            when DType.Float64 {
+                var e = toSymEntry(gse, real);
+                filenames = prepFiles(filename, overwrite, e.a);
+            }
+            when DType.Bool {
+                var e = toSymEntry(gse, bool);
+                filenames = prepFiles(filename, overwrite, e.a);
+            }
+            when DType.Strings {
+                var e = gse: borrowed SegStringSymEntry;
+                var ss = new SegString("", e);
+                filenames = prepFiles(filename, overwrite, ss.offsets.a);
+            }
+            otherwise {
+                throw getErrorWithContext(
+                           msg="Invalid DType Found, %s".format(dtype2str(gse.dtype)),
+                           lineNumber=getLineNumber(),
+                           routineName=getRoutineName(), 
+                           moduleName=getModuleName(),
+                           errorClass="DataTypeError");
+            }
+        }
+
+        coforall loc in Locales do on loc{
+            const localeFilename = filenames[loc.id];
+            
+            // create the file to write to
+            var csvFile = open(localeFilename, iomode.cw);
+            var writer = csvFile.writer();
+
+            // write the header
+            writer.write(CSV_HEADER_OPEN + LINE_DELIM);
+            var header_dtypes:[0..#ndsets] string;
+            forall (i, dt) in zip(0..#ndsets, dtypes){
+                header_dtypes[i] = dt;
+            }
+            writer.write(",".join(header_dtypes) + LINE_DELIM);
+            writer.write(CSV_HEADER_CLOSE + LINE_DELIM);
+
+            // write the column names
+            var column_header:[0..#ndsets] string;
+            forall (i, cname) in zip(0..#ndsets, col_names) {
+                column_header[i] = cname;
+            }
+            writer.write(col_delim.join(column_header) + LINE_DELIM);
+
+            // need to get local subdomain -- should be the same for each element due to sizes being same
+            var localSubdomain = getLocalDomain(gse);
+
+            for r in localSubdomain {
+                var row: [0..#ndsets] string;
+                forall (i, cname) in zip(0..#ndsets, datasets) {
+                    var col_gen: borrowed GenSymEntry = getGenericTypedArrayEntry(cname, st);
+                    select col_gen.dtype {
+                        when DType.Int64 {
+                            var col = toSymEntry(col_gen, int);
+                            row[i] = col.a[r]: string;
+                        }
+                        when DType.UInt64 {
+                            var col = toSymEntry(col_gen, uint);
+                            row[i] = col.a[r]: string;
+                        }
+                        when DType.Float64 {
+                            var col = toSymEntry(col_gen, real);
+                            row[i] = col.a[r]: string;
+                        }
+                        when DType.Bool {
+                            var col = toSymEntry(col_gen, bool);
+                            row[i] = col.a[r]: string;
+                        }
+                        when DType.Strings {
+                            var segString:SegString = getSegString(cname, st);
+                            row[i] = segString[r];
+                            
+                        } otherwise {
+                            throw getErrorWithContext(
+                                    msg="Data Type %s cannot be written to CSV.".format(dtypes[i]),
+                                    lineNumber=getLineNumber(), 
+                                    routineName=getRoutineName(), 
+                                    moduleName=getModuleName(), 
+                                    errorClass='IOError'
+                            );
+                        }
+                    }
+                }
+                var write_row = col_delim.join(row) + LINE_DELIM;
+                writer.write(write_row);
+            }
+            writer.close();
+            csvFile.close();
+
+        }
+
+        return new MsgTuple("CSV Data written successfully!", MsgType.NORMAL);
+    }
+
+    proc get_info(filename: string, datasets: [] string, col_delim: string) throws {
+        // Verify that the file exists
+        if !exists(filename) {
+            throw getErrorWithContext(
+                           msg="The file %s does not exist".format(filename),
+                           lineNumber=getLineNumber(),
+                           routineName=getRoutineName(), 
+                           moduleName=getModuleName(),
+                           errorClass="FileNotFoundError");
+        }
+
+        var csvFile = open(filename, iomode.r);
+        var reader = csvFile.reader();
+        var lines = reader.lines();
+        var hasHeader = false;
+        var dtype_idx = 0;
+        var column_name_idx = 0;
+        
+        if lines[0] == CSV_HEADER_OPEN + "\n" {
+            hasHeader = true;
+            dtype_idx = 1;
+            column_name_idx = 3;
+        }
+        
+        var columns = lines[column_name_idx].split(col_delim).strip();
+        var file_dtypes: [0..#columns.size] string;
+        if dtype_idx > 0 {
+            file_dtypes = lines[dtype_idx].split(",").strip();
+        }
+        else {
+            file_dtypes = "str";
+        }
+        var data_start_offset = column_name_idx + 1;
+        // get the row count
+        var row_ct: int = lines.size - data_start_offset;
+
+        reader.close();
+        csvFile.close();
+
+        var dtypes: [0..#datasets.size] string;
+        forall (i, dset) in zip(0..#datasets.size, datasets) {
+            var (col_exists, idx) = columns.find(dset);
+            csvLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "Column: %s, Exists: %jt, IDX: %i".format(dset, col_exists, idx));
+            if !col_exists {
+                throw getErrorWithContext(
+                    msg="The dataset %s was not found in %s".format(dset, filename),
+                    lineNumber=getLineNumber(),
+                    routineName=getRoutineName(), 
+                    moduleName=getModuleName(),
+                    errorClass="DatasetNotFoundError");
+            }
+            dtypes[i] = file_dtypes[idx];
+        }
+
+        // get datatype of column
+        return (row_ct, hasHeader, new list(dtypes));
+    }
+
+    proc read_files_into_dist_array(A: [?D] ?t, dset: string, filenames: [] string, filedomains: [] domain(1), skips: set(string), hasHeaders: bool, col_delim: string) throws {
+
+        coforall loc in A.targetLocales() do on loc {
+            // Create local copies of args
+            var locFiles = filenames;
+            var locFiledoms = filedomains;
+            /* On this locale, find all files containing data that belongs in
+                this locale's chunk of A */
+            for (filedom, filename) in zip(locFiledoms, locFiles) {
+                if (skips.contains(filename)) {
+                    csvLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                             "File %s does not contain data for this dataset, skipping".format(filename));
+                    continue;
+                } else {
+                    var csvFile = open(filename, iomode.r);
+                    var reader = csvFile.reader();
+                    var lines = reader.lines().strip();
+                    var data_offset = 1;
+                    if hasHeaders {
+                        data_offset  = 4;
+                    }
+                    // determine the index of the column.
+                    var column_names = lines[data_offset-1].split(col_delim);
+                    var (colExists, colidx) = column_names.find(dset);
+                    if !colExists{
+                        throw getErrorWithContext(
+                            msg="The dataset %s was not found in %s".format(dset, filename),
+                            lineNumber=getLineNumber(),
+                            routineName=getRoutineName(), 
+                            moduleName=getModuleName(),
+                            errorClass="DatasetNotFoundError");
+                    }
+                    for locdom in A.localSubdomains() {
+                        const intersection = domain_intersection(locdom, filedom);
+                        if intersection.size > 0 {
+                            forall (i, x) in zip(0..#intersection.size, intersection) {
+                                var row = lines[i+data_offset].split(col_delim);
+                                A[x] = row[colidx]: t;
+                            }
+                        }
+                    }
+                    reader.close();
+                    csvFile.close();
+                }
+            }
+        }
+    }
+
+    proc generate_subdoms(filenames: [?D] string, row_counts: [D] int, validFiles: [D] bool) throws {
+        var skips = new set(string);
+        var offsets = (+ scan row_counts) - row_counts;
+        var subdoms: [D] domain(1);
+        for (i, fname, off, ct, vf) in zip(D, filenames, offsets, row_counts, validFiles) {
+            if (!vf) {
+                skips.add(fname);
+                csvLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                        "Adding invalid file to skips, %s".format(fname));
+                continue;
+            }
+            subdoms[i] = {off..#ct};
+        }
+        return (subdoms, offsets, skips);
+    }
+
+    proc readTypedCSV(filenames: [] string, datasets: [?D] string, dtypes: list(string), row_counts: [] int, validFiles: [] bool, col_delim: string, st: borrowed SymTab): list((string, string, string)) throws {
+        // assumes the file has header since we were able to access type info
+        var rtnData: list((string, string, string));
+        var record_count = + reduce row_counts;
+        var (subdoms, offsets, skips) = generate_subdoms(filenames, row_counts, validFiles);
+
+        for (i, dset) in zip(D, datasets) {
+            var dtype = str2dtype(dtypes[i]);
+            select dtype {
+                when DType.Int64 {
+                    var a = makeDistArray(record_count, int);
+                    read_files_into_dist_array(a, dset, filenames, subdoms, skips, true, col_delim);
+                    var entry = new shared SymEntry(a);
+                    var rname = st.nextName();
+                    st.addEntry(rname, entry);
+                    rtnData.append((dset, "pdarray", rname));
+                }
+                when DType.UInt64 {
+                    var a = makeDistArray(record_count, uint);
+                    read_files_into_dist_array(a, dset, filenames, subdoms, skips, true, col_delim);
+                    var entry = new shared SymEntry(a);
+                    var rname = st.nextName();
+                    st.addEntry(rname, entry);
+                    rtnData.append((dset, "pdarray", rname));
+                }
+                when DType.Float64 {
+                    var a = makeDistArray(record_count, real);
+                    read_files_into_dist_array(a, dset, filenames, subdoms, skips, true, col_delim);
+                    var entry = new shared SymEntry(a);
+                    var rname = st.nextName();
+                    st.addEntry(rname, entry);
+                    rtnData.append((dset, "pdarray", rname));
+                }
+                when DType.Bool {
+                    var a = makeDistArray(record_count, bool);
+                    read_files_into_dist_array(a, dset, filenames, subdoms, skips, true, col_delim);
+                    var entry = new shared SymEntry(a);
+                    var rname = st.nextName();
+                    st.addEntry(rname, entry);
+                    rtnData.append((dset, "pdarray", rname));
+                }
+                when DType.Strings {
+                    var a = makeDistArray(record_count, string);
+                    read_files_into_dist_array(a, dset, filenames, subdoms, skips, true, col_delim);
+                    var col_lens = makeDistArray(record_count, int);
+                    forall (i, v) in zip(0..#a.size, a) {
+                        var tmp_str = v + "\x00";
+                        var vbytes = tmp_str.bytes();
+                        col_lens[i] = vbytes.size;
+                    }
+                    var offsets = (+ scan col_lens) - col_lens;
+                    var value_size: int = + reduce col_lens;
+                    var data = makeDistArray(value_size, uint(8));
+                    forall (i, v) in zip(0..#a.size, a) {
+                        var tmp_str = v + "\x00";
+                        var vbytes = tmp_str.bytes();
+                        ref low = offsets[i];
+                        data[low..#vbytes.size] = vbytes;
+                    }
+                    var ss = getSegString(offsets, data, st);
+                    var rst = (dset, "seg_string", "%s+%t".format(ss.name, ss.nBytes));
+                    rtnData.append(rst);
+                }
+                otherwise {
+                    throw getErrorWithContext(
+                                    msg="Data Type %s cannot be read into Arkouda.".format(dtypes[i]),
+                                    lineNumber=getLineNumber(), 
+                                    routineName=getRoutineName(), 
+                                    moduleName=getModuleName(), 
+                                    errorClass='IOError'
+                            );
+                }
+            }
+        }
+        return rtnData;
+    }
+
+    proc readGenericCSV(filenames: [] string, datasets: [?D] string, row_counts: [] int, validFiles: [] bool, col_delim: string, st: borrowed SymTab): list((string, string, string)) throws {
+        // assumes the file does not have a header since we were not able to access type info
+        var rtnData: list((string, string, string));
+        var record_count = + reduce row_counts;
+        var (subdoms, offsets, skips) = generate_subdoms(filenames, row_counts, validFiles);
+
+        for (i, dset) in zip(D, datasets) {
+            var a = makeDistArray(record_count, string);
+            read_files_into_dist_array(a, dset, filenames, subdoms, skips, false, col_delim);
+            var col_lens = makeDistArray(record_count, int);
+            forall (i, v) in zip(0..#a.size, a) {
+                var tmp_str = v + "\x00";
+                var vbytes = tmp_str.bytes();
+                col_lens[i] = vbytes.size;
+            }
+            var offsets = (+ scan col_lens) - col_lens;
+            var value_size: int = + reduce col_lens;
+            var data = makeDistArray(value_size, uint(8));
+            forall (i, v) in zip(0..#a.size, a) {
+                var tmp_str = v + "\x00";
+                var vbytes = tmp_str.bytes();
+                ref low = offsets[i];
+                data[low..#vbytes.size] = vbytes;
+            }
+            var ss = getSegString(offsets, data, st);
+            var rst = (dset, "seg_string", "%s+%t".format(ss.name, ss.nBytes));
+            rtnData.append(rst);
+        }
+        return rtnData;
+    }
+
+    proc readCSVMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        const col_delim: string = msgArgs.getValueOf("col_delim");
+
+        var allowErrors = msgArgs.get("allow_errors").getBoolValue();
+
+        var nfiles = msgArgs.get("nfiles").getIntValue();
+        var filelist: [0..#nfiles] string;
+        try {
+            filelist = msgArgs.get("filenames").getList(nfiles);
+        } catch {
+            // limit length of file names to 2000 chars
+            var n: int = 1000;
+            var jsonfiles = msgArgs.getValueOf("filenames");
+            var files: string = if jsonfiles.size > 2*n then jsonfiles[0..#n]+'...'+jsonfiles[jsonfiles.size-n..#n] else jsonfiles;
+            var errorMsg = "Could not decode json filenames via tempfile (%i files: %s)".format(nfiles, files);
+            csvLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+        }
+
+        // access the list of datasets user
+        var ndsets = msgArgs.get("num_dsets").getIntValue();
+        var dsetlist: [0..#ndsets] string;
+        try {
+            dsetlist = msgArgs.get("datasets").getList(ndsets);
+        } catch {
+            // limit length of dataset names to 2000 chars
+            var n: int = 1000;
+            var jsondsets = msgArgs.getValueOf("datasets");
+            var dsets: string = if jsondsets.size > 2*n then jsondsets[0..#n]+'...'+jsondsets[jsondsets.size-n..#n] else jsondsets;
+            var errorMsg = "Could not decode json dataset names via tempfile (%i files: %s)".format(
+                                                ndsets, dsets);
+            csvLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+        }
+
+        var filedom = filelist.domain;
+        var filenames: [filedom] string;
+
+        if filelist.size == 1 {
+            if filelist[0].strip().size == 0 {
+                var errorMsg = "filelist was empty.";
+                csvLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+            var tmp = glob(filelist[0]);
+            csvLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                  "glob expanded %s to %i files".format(filelist[0], tmp.size));
+            if tmp.size == 0 {
+                var errorMsg = "The wildcarded filename %s either corresponds to files inaccessible to Arkouda or files of an invalid format".format(filelist[0]);
+                csvLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+            // Glob returns filenames in weird order. Sort for consistency
+            sort(tmp);
+            filedom = tmp.domain;
+            filenames = tmp;
+        } else {
+            // assumes that we are providing 
+            filenames = filelist;
+        }
+
+        var row_cts: [filedom] int;
+        var data_types: list(list(string));
+        var headers: [filedom] bool;
+        var rtnData: list((string, string, string));
+        var fileErrors: list(string);
+        var fileErrorCount:int = 0;
+        var fileErrorMsg:string = "";
+        var validFiles: [filedom] bool = true;
+        for (i, fname) in zip(filedom, filenames) {
+            var hadError = false;
+            try {
+                var dtypes: list(string);
+                (row_cts[i], headers[i], dtypes) = get_info(fname, dsetlist, col_delim);
+                data_types.append(dtypes);
+            } catch e: FileNotFoundError {
+                fileErrorMsg = "File %s not found".format(fname);
+                csvLogger.error(getModuleName(),getRoutineName(),getLineNumber(),fileErrorMsg);
+                hadError = true;
+                if !allowErrors { return new MsgTuple(fileErrorMsg, MsgType.ERROR); }
+            } catch e: PermissionError {
+                fileErrorMsg = "Permission error %s opening %s".format(e.message(),fname);
+                csvLogger.error(getModuleName(),getRoutineName(),getLineNumber(),fileErrorMsg);
+                hadError = true;
+                if !allowErrors { return new MsgTuple(fileErrorMsg, MsgType.ERROR); }
+            } catch e: DatasetNotFoundError {
+                fileErrorMsg = "1 or more Datasets not found in file %s".format(fname);
+                csvLogger.error(getModuleName(),getRoutineName(),getLineNumber(),fileErrorMsg);
+                hadError = true;
+                if !allowErrors { return new MsgTuple(e.message(), MsgType.ERROR); }
+            } catch e: NotHDF5FileError {
+                fileErrorMsg = "The file %s is not an HDF5 file: %s".format(fname,e.message());
+                csvLogger.error(getModuleName(),getRoutineName(),getLineNumber(),fileErrorMsg);
+                hadError = true;
+                if !allowErrors { return new MsgTuple(fileErrorMsg, MsgType.ERROR); }
+            } catch e: SegStringError {
+                fileErrorMsg = "SegmentedString error: %s".format(e.message());
+                csvLogger.error(getModuleName(),getRoutineName(),getLineNumber(),fileErrorMsg);
+                hadError = true;
+                if !allowErrors { return new MsgTuple(fileErrorMsg, MsgType.ERROR); }
+            } catch e : Error {
+                fileErrorMsg = "Other error in accessing file %s: %s".format(fname,e.message());
+                csvLogger.error(getModuleName(),getRoutineName(),getLineNumber(),fileErrorMsg);
+                hadError = true;
+                if !allowErrors { return new MsgTuple(fileErrorMsg, MsgType.ERROR); }
+            }
+
+            if hadError {
+                // Keep running total, but we'll only report back the first 10
+                if fileErrorCount < 10 {
+                    fileErrors.append(fileErrorMsg.replace("\n", " ").replace("\r", " ").replace("\t", " ").strip());
+                }
+                fileErrorCount += 1;
+                validFiles[i] = false;
+            }
+        }
+
+        var dtype = data_types[0];
+        var rows = row_cts[0];
+        var hasHeader = headers[0];
+        for (isValid, fname, dt, rc, hh) in zip(validFiles, filenames, data_types, row_cts, headers) {
+            if isValid {
+                if (dtype != dt) {
+                    var errorMsg = "Inconsistent dtypes in file %s".format(fname);
+                    csvLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                    return new MsgTuple(errorMsg, MsgType.ERROR);
+                }
+                else if (hasHeader != hh){
+                    var errorMsg = "Inconsistent file formatting. %s has no header.".format(fname);
+                    csvLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                    return new MsgTuple(errorMsg, MsgType.ERROR);
+                }
+            }
+            csvLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                        "Verified all dtypes across files for file %s".format(fname));
+        }
+
+        var rtnMsg: string;
+        if headers[0] {
+            rtnData = readTypedCSV(filenames, dsetlist, data_types[0], row_cts, validFiles, col_delim, st);
+            rtnMsg = _buildReadAllMsgJson(rtnData, allowErrors, fileErrorCount, fileErrors, st);
+        }
+        else {
+            rtnData = readGenericCSV(filenames, dsetlist, row_cts, validFiles, col_delim, st);
+            rtnMsg = _buildReadAllMsgJson(rtnData, allowErrors, fileErrorCount, fileErrors, st);
+        }
+        
+        return new MsgTuple(rtnMsg, MsgType.NORMAL);
+    } 
+
+    use CommandMap;
+    registerFunction("readcsv", readCSVMsg, getModuleName());
+    registerFunction("writecsv", writeCSVMsg, getModuleName());
+    registerFunction("lscsv", lsCSVMsg, getModuleName());
+}

--- a/src/CSVMsg.chpl
+++ b/src/CSVMsg.chpl
@@ -475,16 +475,16 @@ module CSVMsg {
                 var vbytes = tmp_str.bytes();
                 col_lens[i] = vbytes.size;
             }
-            var offsets = (+ scan col_lens) - col_lens;
+            var str_offsets = (+ scan col_lens) - col_lens;
             var value_size: int = + reduce col_lens;
             var data = makeDistArray(value_size, uint(8));
             forall (i, v) in zip(0..#a.size, a) {
                 var tmp_str = v + "\x00";
                 var vbytes = tmp_str.bytes();
-                ref low = offsets[i];
+                ref low = str_offsets[i];
                 data[low..#vbytes.size] = vbytes;
             }
-            var ss = getSegString(offsets, data, st);
+            var ss = getSegString(str_offsets, data, st);
             var rst = (dset, "seg_string", "%s+%t".format(ss.name, ss.nBytes));
             rtnData.append(rst);
         }

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -774,10 +774,10 @@ class IOTest(ArkoudaTest):
             cols[2]: ak.array([round(float(x), 2) for x in c]),
         }
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
-            ak.to_csv(d, f"{tmp_dirname}/non_ak.csv", col_delim="|*|")
+            ak.to_csv(d, f"{tmp_dirname}/non_standard_delim.csv", col_delim="|*|")
 
             # test reading that file with Arkouda
-            data = ak.read_csv(f"{tmp_dirname}/non_ak_LOCALE0000.csv", column_delim="|*|")
+            data = ak.read_csv(f"{tmp_dirname}/non_standard_delim_LOCALE0000.csv", column_delim="|*|")
             self.assertListEqual(list(data.keys()), cols)
             self.assertListEqual(data["ColA"].to_list(), a)
             self.assertListEqual(data["ColB"].to_list(), [int(x) for x in b])
@@ -785,7 +785,7 @@ class IOTest(ArkoudaTest):
 
             # test reading subset of columns
             data = ak.read_csv(
-                f"{tmp_dirname}/non_ak_LOCALE0000.csv", datasets="ColB", column_delim="|*|"
+                f"{tmp_dirname}/non_standard_delim_LOCALE0000.csv", datasets="ColB", column_delim="|*|"
             )
             self.assertIsInstance(data, ak.pdarray)
             self.assertListEqual(data.to_list(), [int(x) for x in b])

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -724,6 +724,72 @@ class IOTest(ArkoudaTest):
 
         self.assertListEqual(["ABC", "DEF", "GHI"], rd_arr.to_list())
 
+    def test_csv_read_write(self):
+        # first test that can read csv with no header not written by Arkouda
+        cols = ["ColA", "ColB", "ColC"]
+        a = ["ABC", "DEF"]
+        b = ["123", "345"]
+        c = ["3.14", "5.56"]
+        with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
+            with open(f"{tmp_dirname}/non_ak.csv", "w") as f:
+                f.write(",".join(cols) + "\n")
+                f.write(f"{a[0]},{b[0]},{c[0]}\n")
+                f.write(f"{a[1]},{b[1]},{c[1]}\n")
+
+            data = ak.read_csv(f"{tmp_dirname}/non_ak.csv")
+            self.assertListEqual(list(data.keys()), cols)
+            self.assertListEqual(data["ColA"].to_list(), a)
+            self.assertListEqual(data["ColB"].to_list(), b)
+            self.assertListEqual(data["ColC"].to_list(), c)
+
+            data = ak.read_csv(f"{tmp_dirname}/non_ak.csv", datasets="ColB")
+            self.assertIsInstance(data, ak.Strings)
+            self.assertListEqual(data.to_list(), b)
+
+        # test can read csv with header not written by Arkouda
+        with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
+            with open(f"{tmp_dirname}/non_ak.csv", "w") as f:
+                f.write("**HEADER**\n")
+                f.write("str,int64,float64\n")
+                f.write("*/HEADER/*\n")
+                f.write(",".join(cols) + "\n")
+                f.write(f"{a[0]},{b[0]},{c[0]}\n")
+                f.write(f"{a[1]},{b[1]},{c[1]}\n")
+
+            data = ak.read_csv(f"{tmp_dirname}/non_ak.csv")
+            self.assertListEqual(list(data.keys()), cols)
+            self.assertListEqual(data["ColA"].to_list(), a)
+            self.assertListEqual(data["ColB"].to_list(), [int(x) for x in b])
+            self.assertListEqual(data["ColC"].to_list(), [round(float(x), 2) for x in c])
+
+            # test reading subset of columns
+            data = ak.read_csv(f"{tmp_dirname}/non_ak.csv", datasets="ColB")
+            self.assertIsInstance(data, ak.pdarray)
+            self.assertListEqual(data.to_list(), [int(x) for x in b])
+
+        # test writing file with Arkouda with non-standard delim
+        d = {
+            cols[0]: ak.array(a),
+            cols[1]: ak.array([int(x) for x in b]),
+            cols[2]: ak.array([round(float(x), 2) for x in c]),
+        }
+        with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
+            ak.to_csv(d, f"{tmp_dirname}/non_ak.csv", col_delim="|*|")
+
+            # test reading that file with Arkouda
+            data = ak.read_csv(f"{tmp_dirname}/non_ak_LOCALE0000.csv", column_delim="|*|")
+            self.assertListEqual(list(data.keys()), cols)
+            self.assertListEqual(data["ColA"].to_list(), a)
+            self.assertListEqual(data["ColB"].to_list(), [int(x) for x in b])
+            self.assertListEqual(data["ColC"].to_list(), [round(float(x), 2) for x in c])
+
+            # test reading subset of columns
+            data = ak.read_csv(
+                f"{tmp_dirname}/non_ak_LOCALE0000.csv", datasets="ColB", column_delim="|*|"
+            )
+            self.assertIsInstance(data, ak.pdarray)
+            self.assertListEqual(data.to_list(), [int(x) for x in b])
+
     def tearDown(self):
         super(IOTest, self).tearDown()
         for f in glob.glob("{}/*".format(IOTest.io_test_dir)):


### PR DESCRIPTION
closes #2047 

This PR adds CSV support. This is the initial implementation and I have issues in to handle updates. I am also submitting this knowing that there are probably performance improvements to be made and plan to submit separate PRs for any performance improvements. With that said, please note/suggest any improvements that you see so we can document and track them.

In the current implementation, the following features/functionality is included:

- Read/Write CSV Files
- `ls` functionality for CSV files via `arkouda.io.get_columns()`
- Custom Column Delimiters. Commas are the default.
- Currently, files are required to use `\n` as the line delimiter to read properly. There is an issue in to update for custom delimiters for rows. #2065
- Files do not require the "header" to be read. If the "header" is not present, all columns are returned as Strings objects. All files written by Arkouda will include the header with data type information.
- It is currently assumed that all files have named columns which are the first row of the data. There is an issue in to handle files without column names. #2063
- Includes documentation that will be added to the GitHub pages.
- Testing for read/write included.