### PR TITLE
Closes #2092: Disable bulk transfer when using quick compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ARKOUDA_RUNTIME_CHECKS = true
 endif
 
 ifdef ARKOUDA_QUICK_COMPILE
-CHPL_FLAGS += --no-checks --no-loop-invariant-code-motion --no-fast-followers --ccflags="-O0"
+CHPL_FLAGS += --no-checks --no-loop-invariant-code-motion --no-fast-followers --ccflags="-O0" -suseBulkTransfer=false
 else
 CHPL_FLAGS += --fast
 endif


### PR DESCRIPTION
Opening PR for work from and behalf of @e-kayrakli. 

When investigating ways to improve Arkouda compilation time for developers, @e-kayrakli discovered that if we disable the bulk transfer optimization we can see significant build time improvements when compiling with gasnet (>2 minutes observed on my machine). This disables a performance optimization, so we only want to use it when doing a developer build.


| CHPL_COMM | master | this branch |
| --------- | ------:| -----------:|
| none      | 426s   | 424s        |
| gasnet    | 1332s  | 1185s       |

Closes: #2092 