### PR TITLE
Closes #1988 Update `pydoc/quickstart.rst`

### DIFF
--- a/pydoc/quickstart.rst
+++ b/pydoc/quickstart.rst
@@ -87,7 +87,7 @@ In another terminal window, launch an interactive Python 3 session, such as ``ip
 .. code-block:: python
 
    >>> import arkouda as ak
-   >>> default way to connect is
+   # default way to connect is
    >>> ak.connect(connect_url='tcp://node01:5555')
    ...
    connected to tcp://node01:5555

--- a/pydoc/quickstart.rst
+++ b/pydoc/quickstart.rst
@@ -4,10 +4,51 @@
 Quickstart
 #######################
 
-This guide assumes you have satisfied the `Requirements <setup/REQUIREMENTS.html>`_ and followed the :ref:`installation-label` to build the arkouda server. Also, both your ``PATH`` and ``PYTHONPATH`` environment variables should contain the arkouda root directory.
+This guide is intended to instruct users on the installation Arkouda. It will also walk through launching and shutting down the server. For usage information, visit our :ref:`usage-label`
 
 **********************
-Launch Arkouda Server
+Install Dependencies
+**********************
+
+1. Follow the `Chapel Quickstart Guide <https://chapel-lang.org/docs/usingchapel/QUICKSTART.html>`_
+2. Follow the `Anaconda Installtion Guide <https://docs.anaconda.com/anaconda/install/index.html>`_
+3. Configure your conda environment
+
+   .. substitution-code-block:: bash
+
+       conda env create -f arkouda-env.yml
+
+**********************
+Install Arkouda
+**********************
+
+1. Download Arkouda `v2023.01.11 <https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.01.11.tar.gz>`_
+2. Unpack the source files:
+
+   .. substitution-code-block:: bash
+
+       tar xzf arkouda-2023.01.11.tar.gz
+
+3. Change to the arkouda directory
+
+   .. substitution-code-block:: bash
+
+       cd arkouda-2023.01.11
+
+4. Build Arkouda
+
+   .. substitution-code-block:: bash
+
+       make
+
+5. Test Arkouda functionality
+
+   .. substitution-code-block:: bash
+
+       make test
+
+**********************
+Launching the Server
 **********************
 
 In a terminal, run the arkouda server program with one locale
@@ -16,11 +57,12 @@ You should see a startup message like
 
 .. substitution-code-block:: bash
 
-    $ ./arkouda_server -nl 1
-    server listening on tcp://<your_machine>.local:5555
-    arkouda server version = |release|
-    memory limit = 15461882265
-    bytes of memory used = 0
+   $ ./arkouda_server -nl 1
+   server listening on tcp://<your_machine>.local:5555
+   arkouda server version = |release|
+   built with chapel version <chapel_version>
+   memory limit = 15461882265
+   bytes of memory used = 0
 
 or with authentication turned on 
 
@@ -28,12 +70,13 @@ or with authentication turned on
 
    $ ./arkouda_server -nl 1 --authenticate
    server listening on tcp://<your_machine>:5555?token=<token_string>
-    arkouda server version = |release|
-    memory limit = 15461882265
-    bytes of memory used = 0
+   arkouda server version = |release|
+   built with chapel version <chapel_version>
+   memory limit = 15461882265
+   bytes of memory used = 0
 
 
-The last line is the most important, because it contains the connection url with the hostname and port required for the client to connect to the server.
+The first output line is the most important, because it contains the connection url with the hostname and port required for the client to connect to the server.
 
 ******************************
 Connect the Python 3 Client
@@ -49,98 +92,28 @@ In another terminal window, launch an interactive Python 3 session, such as ``ip
    ...
    connected to tcp://node01:5555
    
-
-substituting the hostname and port appropriately (defaults are 'localhost' and 5555).
+Substituting the hostname and port appropriately (defaults are 'localhost' and 5555).
 
 ******************************
-Simple Computations
+Shutdown/Disconnect
 ******************************
 
-Create and sum an array
-=========================
-
-The following code creates an arkouda ``pdarray`` that resides on the arkouda server and performs a server-side computation, returning the result to the Python client.
+If desired, you can disconnect from the arkouda server from a connected client with
 
 .. code-block:: python
 
-   # Create a server-side array with integers from 1 to N inclusive
-   # This syntax is from NumPy
-   >>> N = 10**6
-   >>> A = ak.arange(1, N+1, 1)
-   # Sum the array, returning the result to Python
-   >>> print(A.sum())
-   # Check the result
-   >>> assert A.sum() == (N * (N + 1)) // 2
+   >>> ak.disconnect()
 
-Array arithmetic
-=========================
-   
-Now, we will perform an operation on two ``pdarray`` objects to create a new ``pdarray``. This time, the result will not be returned to the Python client, but will be stored on the server. In general, only scalar results are automatically returned to Python; ``pdarray`` results remain on the server unless explicitly transferred by the user (see :py:meth:`arkouda.pdarray.to_ndarray`).
-
-.. code-block:: python
-
-   # Generate two (server-side) arrays of random integers 0-9
-   >>> B = ak.randint(0, 10, N)
-   >>> C = ak.randint(0, 10, N)
-   # Multiply them (server-side)
-   >>> D = B * C
-   # Print a small representation of the array
-   # This does NOT move the array to the client
-   >>> print(D)
-   # Get the min and max values
-   # Because these are scalars, they live in Python
-   >>> minVal = D.min()
-   >>> maxVal = D.max()
-   >>> print(minVal, maxVal)
-
-Indexing
-=========================
-
-Arkouda ``pdarray`` objects support most of the same indexing and assignment syntax of 1-dimensional NumPy ``ndarray``s (arkouda currently only supports 1-D arrays). This code shows two ways to get the even elements of ``A`` from above: with a slice, and with logical indexing.
-
-.. code-block:: python
-
-   # Use a slice
-   >>> evens1 = A[1::2]
-   # Create a logical index
-   # Bool pdarray of same size as A
-   >>> evenInds = ((A % 2) == 0)
-   # Use it to get the evens
-   >>> evens2 = A[evenInds]
-   # Compare the two (server-side) arrays
-   >>> assert (evens1 == evens2).all()
-
-Sorting
-===========================
-   
-Sorting arrays is a ubiquitous operation, and it is often useful to use the sorting of one array to order other arrays. Like NumPy, arkouda provides this functionality via the ``argsort`` function, which returns a permutation vector that can be used as an index to order other arrays. Here, we will order the arrays ``B`` and ``C`` from above according to the product of their elements (``D``).
-
-.. code-block:: python
-
-   # Compute the permutation that sorts the product array
-   >>> perm = ak.argsort(D)
-   # Reorder B, C, and D
-   >>> B = B[perm]
-   >>> C = C[perm]
-   >>> D = D[perm]
-   # Check that D is monotonically non-decreasing
-   >>> assert (D[:-1] <= D[1:]).all()
-   # Check that reordered B and C still produce D
-   >>> assert ((B * C) == D).all()
-
-And More
-=====================
-
-See the :ref:`usage-label` section for the full list of operations supported on arkouda arrays. These operations are quite composable and can be used to implement more complex algorithms as in the :ref:`examples-label` section.
-
-******************************
-Shutdown the server (optional)
-******************************
-
-If desired, you can shutdown the arkouda server from a connected client with
+or shutdown 
 
 .. code-block:: python
 
    >>> ak.shutdown()
 
 This command will delete all server-side arrays and cause the ``arkouda_server`` process in the first terminal to exit.
+
+******************************
+Using Arkouda
+******************************
+
+Want to learn more about using Arkouda? See the :ref:`usage-label` section for the full list of operations supported on arkouda arrays. These operations are quite composable and can be used to implement more complex algorithms as in the :ref:`examples-label` section.

--- a/pydoc/usage.rst
+++ b/pydoc/usage.rst
@@ -1,8 +1,8 @@
 .. _usage-label:
 
-##########
-Usage
-##########
+#############
+Usage Guide
+#############
 
 .. toctree::
 


### PR DESCRIPTION
closes #1988

Updates our `Quick Start Guide` to provide a simplified user install workflow. This provides a download link. Some of the basic information has been removed, but I have added a comment to #2046 to add this into a basic `Getting Started` doc.

**This will require updating the link after each release, but I believe it significantly lowers the barrier to entry for someone who may not want to pull the repo or has no need to.**