### PR TITLE
Closes #2089 - Update MacOS Install

### DIFF
--- a/pydoc/setup/MAC_INSTALL.md
+++ b/pydoc/setup/MAC_INSTALL.md
@@ -81,13 +81,14 @@ brew install chapel
 Arkouda provides 2 `.yml` files for configuration, one for users and one for developers. The `.yml` files are configured with a default name for the environment, which is used for example interactions with conda. *Please note that you are able to provide a different name by using the `-n` or `--name` parameters when calling `conda env create`
 
 ```bash
-#Works with all Chipsets (including Apple Silicon)
-brew install miniforge
-#Add /opt/homebrew/Caskroom/miniforge/base/bin as the first line in /etc/paths
-
-#works with only x86 Architecture (excludes Apple Silicon)
+# we recommend running the full Anaconda 
 brew install anaconda3
-#Add /opt/homebrew/Caskroom/anaconda3/base/bin as the first line in /etc/paths
+
+# Note - the exact path may vary based on the release of Anaconda that is current. Run the script to install Anaconda.
+/opt/homebrew/Caskroom/anaconda/2022.10/Anaconda3-2022.10-MacOSX-arm64.sh
+
+# initialize conda
+conda init
 
 # User conda env
 conda env create -f arkouda-env.yml


### PR DESCRIPTION
Closes #2089 

Updates the install documentation for MacOS to only recommend `anaconda3`. Previously, there were issues on `m1` chipset machines prevent it from being used. These issues have been resolved. Since, `anaconda3` provides more features and it now works on all platforms,  we will now only be recommending it for environment management. 

Adds additional steps to ensure `conda` gets installed and is configured properly.