### PR TITLE
Closes #2096: numpy overflow deprecations

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -213,7 +213,7 @@ class pdarray:
 
         return generic_msg(cmd="repr", args={"array": self, "printThresh": pdarrayIterThresh})
 
-    def format_other(self, other: object) -> str:
+    def format_other(self, other) -> str:
         """
         Attempt to cast scalar other to the element dtype of this pdarray,
         and print the resulting value to a string (e.g. for sending to a
@@ -236,7 +236,10 @@ class pdarray:
 
         """
         try:
-            other = self.dtype.type(other)
+            if self.dtype != bigint:
+                other = np.array([other]).astype(self.dtype)[0]
+            else:
+                other = int(other)
         except Exception:
             raise TypeError(f"Unable to convert {other} to {self.dtype.name}")
         if self.dtype == bool:
@@ -1574,6 +1577,7 @@ class pdarray:
         ``cwd/path/name_prefix_LOCALE####.parquet`` where #### is replaced by each locale number
         """
         from warnings import warn
+
         warn(
             "ak.pdarray.save has been deprecated. Please use ak.pdarray.to_parquet or ak.pdarray.to_hdf",
             DeprecationWarning,

--- a/tests/array_view_test.py
+++ b/tests/array_view_test.py
@@ -67,7 +67,7 @@ class ArrayViewTest(ArkoudaTest):
         inav[nind] = -9999
         unav[nind] = 2**64 - 9999
         iav[uind] = -9999
-        uav[iind] = 2**64 - 9999
+        uav[iind] = -9999
         self.assertEqual(iav[uind], inav[nind])
         self.assertEqual(iav[iind], iav[uind])
         self.assertEqual(uav[uind], unav[nind])

--- a/tests/array_view_test.py
+++ b/tests/array_view_test.py
@@ -65,9 +65,9 @@ class ArrayViewTest(ArkoudaTest):
         uind = ak.cast(iind, ak.uint64)
 
         inav[nind] = -9999
-        unav[nind] = -9999
+        unav[nind] = 2**64 - 9999
         iav[uind] = -9999
-        uav[iind] = -9999
+        uav[iind] = 2**64 - 9999
         self.assertEqual(iav[uind], inav[nind])
         self.assertEqual(iav[iind], iav[uind])
         self.assertEqual(uav[uind], unav[nind])

--- a/tests/indexing_test.py
+++ b/tests/indexing_test.py
@@ -50,7 +50,7 @@ class IndexingTest(ArkoudaTest):
             self.assertEqual(pda[np.uint(2)], pda[2])
 
             # set [slice] = scalar/pdarray
-            pda[:10] = np.uint(-2)
+            pda[:10] = np.array([-2]).astype(np.uint)[0]
             self.assertListEqual(pda[self.ukeys].to_list(), pda[self.ikeys].to_list())
             pda[:10] = ak.cast(ak.arange(10), t)
             self.assertListEqual(pda[self.ukeys].to_list(), pda[self.ikeys].to_list())
@@ -63,8 +63,8 @@ class IndexingTest(ArkoudaTest):
 
             if t == ak.bigint.name:
                 # bigint specific set [int] = val with uint key and value
-                pda[np.uint(2)] = 2 ** 200
-                self.assertEqual(pda[2], 2 ** 200)
+                pda[np.uint(2)] = 2**200
+                self.assertEqual(pda[2], 2**200)
 
                 # bigint specific set [slice] = scalar/pdarray
                 pda[:10] = 2**200

--- a/tests/indexing_test.py
+++ b/tests/indexing_test.py
@@ -50,7 +50,7 @@ class IndexingTest(ArkoudaTest):
             self.assertEqual(pda[np.uint(2)], pda[2])
 
             # set [slice] = scalar/pdarray
-            pda[:10] = np.array([-2]).astype(np.uint)[0]
+            pda[:10] = -2
             self.assertListEqual(pda[self.ukeys].to_list(), pda[self.ikeys].to_list())
             pda[:10] = ak.cast(ak.arange(10), t)
             self.assertListEqual(pda[self.ukeys].to_list(), pda[self.ikeys].to_list())

--- a/tests/pdarray_creation_test.py
+++ b/tests/pdarray_creation_test.py
@@ -120,8 +120,8 @@ class PdarrayCreationTest(ArkoudaTest):
         self.assertEqual(ak.uint64, uint_start_stop_stride.dtype)
 
         # test uint64 handles negatives correctly
-        np_arange_uint = np.arange(-5, -10, -1, dtype=np.uint64)
-        ak_arange_uint = ak.arange(-5, -10, -1, dtype=ak.uint64)
+        np_arange_uint = np.arange(2**64 - 5, 2**64 - 10, -1, dtype=np.uint64)
+        ak_arange_uint = ak.arange(2**64 - 5, 2**64 - 10, -1, dtype=ak.uint64)
         # np_arange_uint = array([18446744073709551611, 18446744073709551610, 18446744073709551609,
         #        18446744073709551608, 18446744073709551607], dtype=uint64)
         self.assertListEqual(np_arange_uint.tolist(), ak_arange_uint.to_list())
@@ -490,8 +490,8 @@ class PdarrayCreationTest(ArkoudaTest):
 
         # Test that int_scalars covers uint8, uint16, uint32
         ak.linspace(np.uint8(0), np.uint16(100), np.uint32(1000))
-        ak.linspace(np.uint32(0), np.uint16(100), np.uint8(1000))
-        ak.linspace(np.uint16(0), np.uint8(100), np.uint8(1000))
+        ak.linspace(np.uint32(0), np.uint16(100), np.uint8(1000 % 256))
+        ak.linspace(np.uint16(0), np.uint8(100), np.uint8(1000 % 256))
 
     def test_standard_normal(self):
         pda = ak.standard_normal(100)
@@ -876,7 +876,7 @@ class PdarrayCreationTest(ArkoudaTest):
         # default to uint when all supportedInt and any value > 2**63
         # to avoid loss of precision see (#1297)
         self.assertEqual(ak.array([2**63, 6, 2**63 - 1, 2**63 + 1]).dtype, ak.uint64)
-        self.assertEqual(ak.array([2**64 - 1, 0, -1]).dtype, ak.uint64)
+        self.assertEqual(ak.array([2**64 - 1, 0, 2**64 - 1]).dtype, ak.uint64)
 
     def randint_randomness(self):
         # THIS TEST DOES NOT RUN, see Issue #1672

--- a/tests/pdarray_creation_test.py
+++ b/tests/pdarray_creation_test.py
@@ -121,7 +121,7 @@ class PdarrayCreationTest(ArkoudaTest):
 
         # test uint64 handles negatives correctly
         np_arange_uint = np.arange(2**64 - 5, 2**64 - 10, -1, dtype=np.uint64)
-        ak_arange_uint = ak.arange(2**64 - 5, 2**64 - 10, -1, dtype=ak.uint64)
+        ak_arange_uint = ak.arange(-5, -10, -1, dtype=ak.uint64)
         # np_arange_uint = array([18446744073709551611, 18446744073709551610, 18446744073709551609,
         #        18446744073709551608, 18446744073709551607], dtype=uint64)
         self.assertListEqual(np_arange_uint.tolist(), ak_arange_uint.to_list())
@@ -875,8 +875,10 @@ class PdarrayCreationTest(ArkoudaTest):
     def test_uint_greediness(self):
         # default to uint when all supportedInt and any value > 2**63
         # to avoid loss of precision see (#1297)
-        self.assertEqual(ak.array([2**63, 6, 2**63 - 1, 2**63 + 1]).dtype, ak.uint64)
-        self.assertEqual(ak.array([2**64 - 1, 0, 2**64 - 1]).dtype, ak.uint64)
+        for greedy_list in ([2**63, 6, 2**63 - 1, 2**63 + 1], [2**64 - 1, 0, 2**64 - 1]):
+            greedy_pda = ak.array(greedy_list)
+            self.assertEqual(greedy_pda.dtype, ak.uint64)
+            self.assertListEqual(greedy_list, greedy_pda.to_list())
 
     def randint_randomness(self):
         # THIS TEST DOES NOT RUN, see Issue #1672


### PR DESCRIPTION
This PR (closes #2096) updates our tests to avoid the numpy overflow deprecation warning