### PR TITLE
Closes #2103: Update messaging overview docs

### DIFF
--- a/training/MESSAGING_OVERVIEW.md
+++ b/training/MESSAGING_OVERVIEW.md
@@ -130,11 +130,10 @@ module ExampleModule {
     use MultiTypeSymEntry;
     use ServerErrorStrings;
     
-    proc exampleFunction(cmd: string, payload: string, argSize: int, 
+    proc exampleFunction(cmd: string, msgArgs: borrowed MessageArgs,
                                     st: borrowed SymTab): MsgTuple throws {
         var repMsg: string; // response message
 
-        var msgArgs = parseMessageArgs(payload, argSize);
         var arg1 = msgArgs.getValueOf("arg1");
         var arg2 = msgArgs.getIntValue("arg2");
         


### PR DESCRIPTION
This PR (closes #2103) updates the messaging overview docs to reflect changes in `msgArgs` parsing