### PR TITLE
Fixes #2105: bug when loading a `dataframe` containing a `segarray` with an `_` in the column name

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -1599,9 +1599,11 @@ class DataFrame(UserDict):
 
         # this assumes segments will always have corresponding values.
         # This should happen due to save config
-        seg_cols = [col.split("_")[0] for col in df_dict.keys() if col.endswith("_segments")]
+        seg_cols = ["_".join(col.split("_")[:-1]) for col in df_dict.keys() if col.endswith("_segments")]
         df_dict_keys = [
-            col.split("_")[0] if col.endswith("_segments") or col.endswith("_values") else col
+            "_".join(col.split("_")[:-1])
+            if col.endswith("_segments") or col.endswith("_values")
+            else col
             for col in df_dict.keys()
         ]
 

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -583,6 +583,20 @@ class DataFrameTest(ArkoudaTest):
             ak_loaded = ak.DataFrame.load(f"{tmp_dirname}/seg_test.h5")
             self.assertTrue(df.to_pandas().equals(ak_loaded.to_pandas()))
 
+            # test with segarray with _ in column name
+            df_dict = {
+                "c_1": ak.arange(3, 6),
+                "c_2": ak.arange(6, 9),
+                "c_3": ak.segarray(ak.array([0, 9, 14]), ak.arange(20)),
+            }
+            akdf = ak.DataFrame(df_dict)
+            akdf.to_hdf(f"{tmp_dirname}/seg_test.h5")
+            self.assertEqual(
+                len(glob.glob(f"{tmp_dirname}/seg_test*.h5")), ak.get_config()["numLocales"]
+            )
+            ak_loaded = ak.DataFrame.load(f"{tmp_dirname}/seg_test.h5")
+            self.assertTrue(akdf.to_pandas().equals(ak_loaded.to_pandas()))
+
     def test_isin(self):
         df = ak.DataFrame({"col_A": ak.array([7, 3]), "col_B": ak.array([1, 9])})
 


### PR DESCRIPTION
This PR (fixes #2105) there was a bug preventing `ak.DataFrame.load` from handling segarrays when their column name contains an `_`

I think it's easiest to see this by looking at an example
```python
# this works when there's no `_` in the column name
>>> col = 'NO-UNDERSCORES-EVER_segments'
>>> col.split("_")[0]
'NO-UNDERSCORES-EVER'

>>> '_'.join(col.split("_")[:-1])
'NO-UNDERSCORES-EVER'

# but breaks when there is
>>> col = 'c_3_segments'
>>> col.split("_")[0]
'c'

>>> '_'.join(col.split("_")[:-1])
'c_3'
```