### PR TITLE
Closes #2099: Bug in left and right shift by >=64 bits for int/uint

### DIFF
--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -937,12 +937,12 @@ module BinOp
         when ">>" {
           ref ea = e.a;
           ref ra = r.a;
-          [(ei,ri) in zip(ea,r.a)] if ri:uint < 64 then ei = val:uint >> ri:uint;
+          [(ei,ri) in zip(ea,ra)] if ri:uint < 64 then ei = val:uint >> ri:uint;
         }
         when "<<" {
           ref ea = e.a;
           ref ra = r.a;
-          [(ei,ri) in zip(ea,r.a)] if ri:uint < 64 then ei = val:uint << ri:uint;
+          [(ei,ri) in zip(ea,ra)] if ri:uint < 64 then ei = val:uint << ri:uint;
         }
         when ">>>" {
           e.a = rotr(val:uint, r.a:uint);

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -608,7 +608,7 @@ module BinOp
       select op {
         when ">>" {
           if val < 64 {
-            e.a = l.a << val:l.etype;
+            e.a = l.a >> val:l.etype;
           }
         }
         when "<<" {

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -192,7 +192,10 @@ module BinOp
             [(ei,li,ri) in zip(ea,la,ra)] if ri < 64 then ei = li << ri;
           }                    
           when ">>" {
-            e.a = l.a >> r.a;
+            ref ea = e.a;
+            ref la = l.a;
+            ref ra = r.a;
+            [(ei,li,ri) in zip(ea,la,ra)] if ri < 64 then ei = li >> ri;
           }
           when "<<<" {
             e.a = rotl(l.a, r.a);
@@ -245,7 +248,10 @@ module BinOp
             (e.etype == uint && r.etype == int) {
       select op {
         when ">>" {
-          e.a = l.a >> r.a;
+          ref ea = e.a;
+          ref la = l.a;
+          ref ra = r.a;
+          [(ei,li,ri) in zip(ea,la,ra)] if ri < 64 then ei = li >> ri;
         }
         when "<<" {
           ref ea = e.a;
@@ -551,7 +557,9 @@ module BinOp
             }
           }                    
           when ">>" {
-            e.a = l.a >> val;
+            if val < 64 {
+              e.a = l.a >> val;
+            }
           }
           when "<<<" {
             e.a = rotl(l.a, val);
@@ -599,7 +607,9 @@ module BinOp
             (e.etype == uint && val.type == int) {
       select op {
         when ">>" {
-          e.a = l.a >> val:l.etype;
+          if val < 64 {
+            e.a = l.a << val:l.etype;
+          }
         }
         when "<<" {
           if val < 64 {
@@ -872,7 +882,9 @@ module BinOp
             [(ei,ri) in zip(ea,ra)] if ri < 64 then ei = val << ri;
           }                    
           when ">>" {
-            e.a = val >> r.a;
+            ref ea = e.a;
+            ref ra = r.a;
+            [(ei,ri) in zip(ea,ra)] if ri < 64 then ei = val >> ri;
           }
           when "<<<" {
             e.a = rotl(val, r.a);
@@ -923,7 +935,9 @@ module BinOp
     } else if (val.type == int && r.etype == uint) {
       select op {
         when ">>" {
-          e.a = val:uint >> r.a:uint;
+          ref ea = e.a;
+          ref ra = r.a;
+          [(ei,ri) in zip(ea,r.a)] if ri:uint < 64 then ei = val:uint >> ri:uint;
         }
         when "<<" {
           ref ea = e.a;

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -186,7 +186,10 @@ module BinOp
             [(ei,li,ri) in zip(ea,la,ra)] ei = if ri != 0 then li%ri else 0;
           }
           when "<<" {
-            e.a = l.a << r.a;
+            ref ea = e.a;
+            ref la = l.a;
+            ref ra = r.a;
+            [(ei,li,ri) in zip(ea,la,ra)] if ri < 64 then ei = li << ri;
           }                    
           when ">>" {
             e.a = l.a >> r.a;
@@ -245,7 +248,10 @@ module BinOp
           e.a = l.a >> r.a;
         }
         when "<<" {
-          e.a = l.a << r.a;
+          ref ea = e.a;
+          ref la = l.a;
+          ref ra = r.a;
+          [(ei,li,ri) in zip(ea,la,ra)] if ri < 64 then ei = li << ri;
         }
         when ">>>" {
           e.a = rotr(l.a, r.a);
@@ -540,7 +546,9 @@ module BinOp
             [(ei,li) in zip(ea,la)] ei = if val != 0 then li%val else 0;
           }
           when "<<" {
-            e.a = l.a << val;
+            if val < 64 {
+              e.a = l.a << val;
+            }
           }                    
           when ">>" {
             e.a = l.a >> val;
@@ -594,7 +602,9 @@ module BinOp
           e.a = l.a >> val:l.etype;
         }
         when "<<" {
-          e.a = l.a << val:l.etype;
+          if val < 64 {
+            e.a = l.a << val:l.etype;
+          }
         }
         when ">>>" {
           e.a = rotr(l.a, val:l.etype);
@@ -857,7 +867,9 @@ module BinOp
             [(ei,ri) in zip(ea,ra)] ei = if ri != 0 then val%ri else 0;
           }
           when "<<" {
-            e.a = val << r.a;
+            ref ea = e.a;
+            ref ra = r.a;
+            [(ei,ri) in zip(ea,ra)] if ri < 64 then ei = val << ri;
           }                    
           when ">>" {
             e.a = val >> r.a;
@@ -914,7 +926,9 @@ module BinOp
           e.a = val:uint >> r.a:uint;
         }
         when "<<" {
-          e.a = val:uint << r.a:uint;
+          ref ea = e.a;
+          ref ra = r.a;
+          [(ei,ri) in zip(ea,r.a)] if ri:uint < 64 then ei = val:uint << ri:uint;
         }
         when ">>>" {
           e.a = rotr(val:uint, r.a:uint);

--- a/tests/indexing_test.py
+++ b/tests/indexing_test.py
@@ -28,7 +28,7 @@ class IndexingTest(ArkoudaTest):
     def test_pdarray_uint_indexing(self):
         # for every pda in array_dict test indexing with uint array and uint scalar
         for pda in self.array_dict.values():
-            self.asser tEqual(pda[np.uint(2)], pda[2])
+            self.assertEqual(pda[np.uint(2)], pda[2])
             self.assertListEqual(pda[self.ukeys].to_list(), pda[self.ikeys].to_list())
 
     def test_strings_uint_indexing(self):

--- a/tests/indexing_test.py
+++ b/tests/indexing_test.py
@@ -28,7 +28,7 @@ class IndexingTest(ArkoudaTest):
     def test_pdarray_uint_indexing(self):
         # for every pda in array_dict test indexing with uint array and uint scalar
         for pda in self.array_dict.values():
-            self.assertEqual(pda[np.uint(2)], pda[2])
+            self.asser tEqual(pda[np.uint(2)], pda[2])
             self.assertListEqual(pda[self.ukeys].to_list(), pda[self.ikeys].to_list())
 
     def test_strings_uint_indexing(self):

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -350,12 +350,39 @@ class OperatorsTest(ArkoudaTest):
             self.assertTrue(np.allclose((aku**ak_float).to_ndarray(), npu**np_float, equal_nan=True))
 
     def test_left_shift_binop(self):
-        ak_uint = ak.array([2**63 -1], dtype=ak.uint64)
-        np_uint = np.array([2**63 -1], dtype=np.uint64)
+        #This tests for a bug when left shifting by a value >=64 bits for int/uint, Issue #2099
+        #Max bit value
+        maxbits = 2 ** 63 - 1
 
-        self.assertTrue(np.allclose(ak_uint << 64, np_uint << 64))
-        self.assertTrue(np.allclose(ak_uint << 65, np_uint << 65))
+        #Value arrays
+        ak_uint = ak.array([maxbits], dtype=ak.uint64)
+        np_uint = np.array([maxbits], dtype=np.uint64)
+        ak_int = ak.array([maxbits], dtype=ak.int64)
+        np_int = np.array([maxbits], dtype=np.int64)
 
+        #Shifting value arrays
+        ak_uint_array = ak.array([64], dtype=ak.uint64)
+        np_uint_array = np.array([64], dtype=np.uint64)
+        ak_int_array = ak.array([64], dtype=ak.int64)
+        np_int_array = np.array([64], dtype=np.int64)
+
+        #Binopvs case
+        self.assertTrue(np.allclose((ak_uint << 64).to_ndarray(), np_uint << 64))
+        self.assertTrue(np.allclose((ak_uint << 65).to_ndarray(), np_uint << 65))
+        self.assertTrue(np.allclose((ak_int << 64).to_ndarray(), np_int << 64))
+        self.assertTrue(np.allclose((ak_int << 65).to_ndarray(), np_int << 65))
+
+        #Binopsv case
+        self.assertTrue(np.allclose((maxbits << ak_uint_array).to_ndarray(), maxbits << np_uint_array))
+        self.assertTrue(np.allclose((maxbits << ak_int_array).to_ndarray(), maxbits << np_int_array))
+
+        #Binopvv case, Same type
+        self.assertTrue(np.allclose((ak_uint << ak_uint_array).to_ndarray(), np_uint << np_uint_array))
+        self.assertTrue(np.allclose((ak_int << ak_int_array).to_ndarray(), np_int << np_int_array))
+
+        #Binopvv case, Mixed type
+        self.assertTrue(np.allclose((ak_uint << ak_int_array).to_ndarray(), np_uint << np_uint_array))
+        self.assertTrue(np.allclose((ak_int << ak_uint_array).to_ndarray(), np_int << np_int_array))
 
     def test_concatenate_type_preservation(self):
         # Test that concatenate preserves special pdarray types (IPv4, Datetime, BitVector, ...)

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -349,6 +349,14 @@ class OperatorsTest(ArkoudaTest):
             self.assertTrue(np.allclose((ak_float**aku).to_ndarray(), np_float**npu, equal_nan=True))
             self.assertTrue(np.allclose((aku**ak_float).to_ndarray(), npu**np_float, equal_nan=True))
 
+    def test_left_shift_binop(self):
+        ak_uint = ak.array([2**63 -1], dtype=ak.uint64)
+        np_uint = np.array([2**63 -1], dtype=np.uint64)
+
+        self.assertTrue(np.allclose(ak_uint << 64, np_uint << 64))
+        self.assertTrue(np.allclose(ak_uint << 65, np_uint << 65))
+
+
     def test_concatenate_type_preservation(self):
         # Test that concatenate preserves special pdarray types (IPv4, Datetime, BitVector, ...)
         from arkouda.util import generic_concat as akuconcat

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -350,39 +350,38 @@ class OperatorsTest(ArkoudaTest):
             self.assertTrue(np.allclose((aku**ak_float).to_ndarray(), npu**np_float, equal_nan=True))
 
     def test_left_shift_binop(self):
-        #This tests for a bug when left shifting by a value >=64 bits for int/uint, Issue #2099
-        #Max bit value
-        maxbits = 2 ** 63 - 1
+        # This tests for a bug when left shifting by a value >=64 bits for int/uint, Issue #2099
+        # Max bit value
+        maxbits = 2**63 - 1
 
-        #Value arrays
-        ak_uint = ak.array([maxbits], dtype=ak.uint64)
-        np_uint = np.array([maxbits], dtype=np.uint64)
-        ak_int = ak.array([maxbits], dtype=ak.int64)
-        np_int = np.array([maxbits], dtype=np.int64)
+        # Value arrays
+        ak_uint = ak.array([maxbits, maxbits, maxbits], dtype=ak.uint64)
+        np_uint = np.array([maxbits, maxbits, maxbits], dtype=np.uint64)
+        ak_int = ak.array([maxbits, maxbits, maxbits], dtype=ak.int64)
+        np_int = np.array([maxbits, maxbits, maxbits], dtype=np.int64)
 
-        #Shifting value arrays
-        ak_uint_array = ak.array([64], dtype=ak.uint64)
-        np_uint_array = np.array([64], dtype=np.uint64)
-        ak_int_array = ak.array([64], dtype=ak.int64)
-        np_int_array = np.array([64], dtype=np.int64)
+        # Shifting value arrays
+        ak_uint_array = ak.array([63, 64, 65], dtype=ak.uint64)
+        np_uint_array = np.array([63, 64, 65], dtype=np.uint64)
+        ak_int_array = ak.array([63, 64, 65], dtype=ak.int64)
+        np_int_array = np.array([63, 64, 65], dtype=np.int64)
 
-        #Binopvs case
-        self.assertTrue(np.allclose((ak_uint << 64).to_ndarray(), np_uint << 64))
-        self.assertTrue(np.allclose((ak_uint << 65).to_ndarray(), np_uint << 65))
-        self.assertTrue(np.allclose((ak_int << 64).to_ndarray(), np_int << 64))
-        self.assertTrue(np.allclose((ak_int << 65).to_ndarray(), np_int << 65))
+        # Binopvs case
+        for i in range(63, 66):
+            self.assertTrue(np.allclose((ak_uint << i).to_ndarray(), np_uint << i))
+            self.assertTrue(np.allclose((ak_int << i).to_ndarray(), np_int << i))
 
-        #Binopsv case
-        self.assertTrue(np.allclose((maxbits << ak_uint_array).to_ndarray(), maxbits << np_uint_array))
-        self.assertTrue(np.allclose((maxbits << ak_int_array).to_ndarray(), maxbits << np_int_array))
+        # Binopsv case
+        self.assertListEqual((maxbits << ak_uint_array).to_list(), (maxbits << np_uint_array).tolist())
+        self.assertListEqual((maxbits << ak_int_array).to_list(), (maxbits << np_int_array).tolist())
 
-        #Binopvv case, Same type
-        self.assertTrue(np.allclose((ak_uint << ak_uint_array).to_ndarray(), np_uint << np_uint_array))
-        self.assertTrue(np.allclose((ak_int << ak_int_array).to_ndarray(), np_int << np_int_array))
+        # # Binopvv case, Same type
+        self.assertListEqual((ak_uint << ak_uint_array).to_list(), (np_uint << np_uint_array).tolist())
+        self.assertListEqual((ak_int << ak_int_array).to_list(), (np_int << np_int_array).tolist())
 
-        #Binopvv case, Mixed type
-        self.assertTrue(np.allclose((ak_uint << ak_int_array).to_ndarray(), np_uint << np_uint_array))
-        self.assertTrue(np.allclose((ak_int << ak_uint_array).to_ndarray(), np_int << np_int_array))
+        # Binopvv case, Mixed type
+        self.assertListEqual((ak_uint << ak_int_array).to_list(), (np_uint << np_uint_array).tolist())
+        self.assertListEqual((ak_int << ak_uint_array).to_list(), (np_int << np_int_array).tolist())
 
     def test_concatenate_type_preservation(self):
         # Test that concatenate preserves special pdarray types (IPv4, Datetime, BitVector, ...)

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -376,7 +376,7 @@ class OperatorsTest(ArkoudaTest):
             self.assertTrue(np.allclose((ak_int >> i).to_ndarray(), np_int >> i))
 
         # Binopsv case
-        #Left Shift
+        # Left Shift
         self.assertListEqual((maxbits << ak_uint_array).to_list(), (maxbits << np_uint_array).tolist())
         self.assertListEqual((maxbits << ak_int_array).to_list(), (maxbits << np_int_array).tolist())
         # Right Shift
@@ -384,7 +384,7 @@ class OperatorsTest(ArkoudaTest):
         self.assertListEqual((maxbits >> ak_int_array).to_list(), (maxbits >> np_int_array).tolist())
 
         # Binopvv case, Same type
-        #Left Shift
+        # Left Shift
         self.assertListEqual((ak_uint << ak_uint_array).to_list(), (np_uint << np_uint_array).tolist())
         self.assertListEqual((ak_int << ak_int_array).to_list(), (np_int << np_int_array).tolist())
         # Right Shift
@@ -392,7 +392,7 @@ class OperatorsTest(ArkoudaTest):
         self.assertListEqual((ak_int >> ak_int_array).to_list(), (np_int >> np_int_array).tolist())
 
         # Binopvv case, Mixed type
-        #Left Shift
+        # Left Shift
         self.assertListEqual((ak_uint << ak_int_array).to_list(), (np_uint << np_uint_array).tolist())
         self.assertListEqual((ak_int << ak_uint_array).to_list(), (np_int << np_int_array).tolist())
         # Right shift

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -355,19 +355,19 @@ class OperatorsTest(ArkoudaTest):
         maxbits = 2**63 - 1
 
         # Value arrays
-        ak_uint = ak.array([maxbits, maxbits, maxbits], dtype=ak.uint64)
-        np_uint = np.array([maxbits, maxbits, maxbits], dtype=np.uint64)
-        ak_int = ak.array([maxbits, maxbits, maxbits], dtype=ak.int64)
-        np_int = np.array([maxbits, maxbits, maxbits], dtype=np.int64)
+        ak_uint = ak.array([maxbits, maxbits, maxbits, maxbits], dtype=ak.uint64)
+        np_uint = np.array([maxbits, maxbits, maxbits, maxbits], dtype=np.uint64)
+        ak_int = ak.array([maxbits, maxbits, maxbits, maxbits], dtype=ak.int64)
+        np_int = np.array([maxbits, maxbits, maxbits, maxbits], dtype=np.int64)
 
         # Shifting value arrays
-        ak_uint_array = ak.array([63, 64, 65], dtype=ak.uint64)
-        np_uint_array = np.array([63, 64, 65], dtype=np.uint64)
-        ak_int_array = ak.array([63, 64, 65], dtype=ak.int64)
-        np_int_array = np.array([63, 64, 65], dtype=np.int64)
+        ak_uint_array = ak.array([62, 63, 64, 65], dtype=ak.uint64)
+        np_uint_array = np.array([62, 63, 64, 65], dtype=np.uint64)
+        ak_int_array = ak.array([62, 63, 64, 65], dtype=ak.int64)
+        np_int_array = np.array([62, 63, 64, 65], dtype=np.int64)
 
         # Binopvs case
-        for i in range(63, 66):
+        for i in range(62, 66):
             self.assertTrue(np.allclose((ak_uint << i).to_ndarray(), np_uint << i))
             self.assertTrue(np.allclose((ak_int << i).to_ndarray(), np_int << i))
 
@@ -382,6 +382,40 @@ class OperatorsTest(ArkoudaTest):
         # Binopvv case, Mixed type
         self.assertListEqual((ak_uint << ak_int_array).to_list(), (np_uint << np_uint_array).tolist())
         self.assertListEqual((ak_int << ak_uint_array).to_list(), (np_int << np_int_array).tolist())
+
+    def test_right_shift_binop(self):
+        # This tests for a bug when right shifting by a value >=64 bits for int/uint, Issue #2099
+        # Max bit value
+        maxbits = 2**63 - 1
+
+        # Value arrays
+        ak_uint = ak.array([maxbits, maxbits, maxbits, maxbits], dtype=ak.uint64)
+        np_uint = np.array([maxbits, maxbits, maxbits, maxbits], dtype=np.uint64)
+        ak_int = ak.array([maxbits, maxbits, maxbits, maxbits], dtype=ak.int64)
+        np_int = np.array([maxbits, maxbits, maxbits, maxbits], dtype=np.int64)
+
+        # Shifting value arrays
+        ak_uint_array = ak.array([62, 63, 64, 65], dtype=ak.uint64)
+        np_uint_array = np.array([62, 63, 64, 65], dtype=np.uint64)
+        ak_int_array = ak.array([62, 63, 64, 65], dtype=ak.int64)
+        np_int_array = np.array([62, 63, 64, 65], dtype=np.int64)
+
+        # Binopvs case
+        for i in range(62, 66):
+            self.assertTrue(np.allclose((ak_uint >> i).to_ndarray(), np_uint >> i))
+            self.assertTrue(np.allclose((ak_int >> i).to_ndarray(), np_int >> i))
+
+        # Binopsv case
+        self.assertListEqual((maxbits >> ak_uint_array).to_list(), (maxbits >> np_uint_array).tolist())
+        self.assertListEqual((maxbits >> ak_int_array).to_list(), (maxbits >> np_int_array).tolist())
+
+        # # Binopvv case, Same type
+        self.assertListEqual((ak_uint >> ak_uint_array).to_list(), (np_uint >> np_uint_array).tolist())
+        self.assertListEqual((ak_int >> ak_int_array).to_list(), (np_int >> np_int_array).tolist())
+
+        # Binopvv case, Mixed type
+        self.assertListEqual((ak_uint >> ak_int_array).to_list(), (np_uint >> np_uint_array).tolist())
+        self.assertListEqual((ak_int >> ak_uint_array).to_list(), (np_int >> np_int_array).tolist())
 
     def test_concatenate_type_preservation(self):
         # Test that concatenate preserves special pdarray types (IPv4, Datetime, BitVector, ...)

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -349,7 +349,7 @@ class OperatorsTest(ArkoudaTest):
             self.assertTrue(np.allclose((ak_float**aku).to_ndarray(), np_float**npu, equal_nan=True))
             self.assertTrue(np.allclose((aku**ak_float).to_ndarray(), npu**np_float, equal_nan=True))
 
-    def test_left_shift_binop(self):
+    def test_shift_binop(self):
         # This tests for a bug when left shifting by a value >=64 bits for int/uint, Issue #2099
         # Max bit value
         maxbits = 2**63 - 1
@@ -368,52 +368,34 @@ class OperatorsTest(ArkoudaTest):
 
         # Binopvs case
         for i in range(62, 66):
+            # Left shift
             self.assertTrue(np.allclose((ak_uint << i).to_ndarray(), np_uint << i))
             self.assertTrue(np.allclose((ak_int << i).to_ndarray(), np_int << i))
-
-        # Binopsv case
-        self.assertListEqual((maxbits << ak_uint_array).to_list(), (maxbits << np_uint_array).tolist())
-        self.assertListEqual((maxbits << ak_int_array).to_list(), (maxbits << np_int_array).tolist())
-
-        # # Binopvv case, Same type
-        self.assertListEqual((ak_uint << ak_uint_array).to_list(), (np_uint << np_uint_array).tolist())
-        self.assertListEqual((ak_int << ak_int_array).to_list(), (np_int << np_int_array).tolist())
-
-        # Binopvv case, Mixed type
-        self.assertListEqual((ak_uint << ak_int_array).to_list(), (np_uint << np_uint_array).tolist())
-        self.assertListEqual((ak_int << ak_uint_array).to_list(), (np_int << np_int_array).tolist())
-
-    def test_right_shift_binop(self):
-        # This tests for a bug when right shifting by a value >=64 bits for int/uint, Issue #2099
-        # Max bit value
-        maxbits = 2**63 - 1
-
-        # Value arrays
-        ak_uint = ak.array([maxbits, maxbits, maxbits, maxbits], dtype=ak.uint64)
-        np_uint = np.array([maxbits, maxbits, maxbits, maxbits], dtype=np.uint64)
-        ak_int = ak.array([maxbits, maxbits, maxbits, maxbits], dtype=ak.int64)
-        np_int = np.array([maxbits, maxbits, maxbits, maxbits], dtype=np.int64)
-
-        # Shifting value arrays
-        ak_uint_array = ak.array([62, 63, 64, 65], dtype=ak.uint64)
-        np_uint_array = np.array([62, 63, 64, 65], dtype=np.uint64)
-        ak_int_array = ak.array([62, 63, 64, 65], dtype=ak.int64)
-        np_int_array = np.array([62, 63, 64, 65], dtype=np.int64)
-
-        # Binopvs case
-        for i in range(62, 66):
+            # Right shift
             self.assertTrue(np.allclose((ak_uint >> i).to_ndarray(), np_uint >> i))
             self.assertTrue(np.allclose((ak_int >> i).to_ndarray(), np_int >> i))
 
         # Binopsv case
+        #Left Shift
+        self.assertListEqual((maxbits << ak_uint_array).to_list(), (maxbits << np_uint_array).tolist())
+        self.assertListEqual((maxbits << ak_int_array).to_list(), (maxbits << np_int_array).tolist())
+        # Right Shift
         self.assertListEqual((maxbits >> ak_uint_array).to_list(), (maxbits >> np_uint_array).tolist())
         self.assertListEqual((maxbits >> ak_int_array).to_list(), (maxbits >> np_int_array).tolist())
 
-        # # Binopvv case, Same type
+        # Binopvv case, Same type
+        #Left Shift
+        self.assertListEqual((ak_uint << ak_uint_array).to_list(), (np_uint << np_uint_array).tolist())
+        self.assertListEqual((ak_int << ak_int_array).to_list(), (np_int << np_int_array).tolist())
+        # Right Shift
         self.assertListEqual((ak_uint >> ak_uint_array).to_list(), (np_uint >> np_uint_array).tolist())
         self.assertListEqual((ak_int >> ak_int_array).to_list(), (np_int >> np_int_array).tolist())
 
         # Binopvv case, Mixed type
+        #Left Shift
+        self.assertListEqual((ak_uint << ak_int_array).to_list(), (np_uint << np_uint_array).tolist())
+        self.assertListEqual((ak_int << ak_uint_array).to_list(), (np_int << np_int_array).tolist())
+        # Right shift
         self.assertListEqual((ak_uint >> ak_int_array).to_list(), (np_uint >> np_uint_array).tolist())
         self.assertListEqual((ak_int >> ak_uint_array).to_list(), (np_int >> np_int_array).tolist())
 


### PR DESCRIPTION
This PR (Closes #2099) fixes a bug when left or right shifting by >= 64 bits for ints and uints. Also adds testing to the Binop Operator testing file.