### PR TITLE
Closes #2108: Update contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,13 +102,24 @@ If you’re fixing a bug, add a test. Run it first to confirm it fails, then fix
 
 If adding a new feature, add a test to make sure it behaves properly.
 
+Things to note:
+- If you make a new test, be sure to include `test_` at the beginning. Otherwise `pytest` will not run it.
+- If you make a new file of tests, be sure to include the file in `pytest.ini`, so it will be run during a `make test`.
+
 See our wiki for more info on how to run our tests and create your own:
 https://github.com/Bears-R-Us/arkouda/wiki/Unit-Testing
 
 #### Running python tests
 
 ```terminal
+# Run all tests in pytest.ini
 make test
+
+# Run all tests in the CategoricalTest class (-v will print out the test name)
+python3 -m pytest tests/categorical_test.py::CategoricalTest -v
+
+# Run a single test from CategoricalTest named foo_test
+python3 -m pytest tests/categorical_test.py::CategoricalTest::foo_test
 ```
 
 #### Running chapel tests
@@ -118,6 +129,12 @@ python3 server_util/test/parallel_start_test.py -d test
 ```
 
 ### Writing Pull Requests
+
+Before posting a pull request, be sure to test locally to catch common CI failures early.
+This usually includes running:
+- `make test`
+- `make mypy`
+- `flake8 arkouda`
 
 Every pull request should have at least one associated issue (if there's not one, create one!).
 
@@ -165,6 +182,4 @@ For the most part, only the core dev team or those assigned should review PRs.
 ### Release Process
 
 New versions should only be released after the core dev team has reached a consensus.
-Instructions on our release process:
-
-https://github.com/Bears-R-Us/arkouda/wiki/Release-Process
+Follow our [release process](developer/RELEASE_PROCESS.md)


### PR DESCRIPTION
This PR (closes #2108) updates contrib docs to:
- Add more info on testing
- Add section about testing locally before pushing a PR
- Update link to release process