### PR TITLE
Closes #2111: Enable `load_all` and `read` workflows with dataframes containing segarrays

### DIFF
--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -12,7 +12,6 @@ from arkouda.dtypes import int64 as akint64
 from arkouda.dtypes import isSupportedInt, str_, translate_np_dtype
 from arkouda.groupbyclass import GroupBy, broadcast
 from arkouda.infoclass import list_registry
-from arkouda.io import load
 from arkouda.logger import getArkoudaLogger
 from arkouda.numeric import cumsum
 from arkouda.pdarrayclass import RegistrationError, create_pdarray, is_sorted, pdarray
@@ -1074,6 +1073,7 @@ class SegArray:
         to_hdf, load
         """
         from warnings import warn
+
         warn(
             "ak.SegArray.save has been deprecated. Please use ak.SegArray.to_hdf",
             DeprecationWarning,
@@ -1114,6 +1114,8 @@ class SegArray:
         -------
         SegArray
         """
+        from arkouda.io import load
+
         if segment_suffix == value_suffix:
             raise ValueError("Segment suffix and value suffix must be different")
         segments = load(prefix_path, dataset=dataset + segment_suffix)

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -597,6 +597,13 @@ class DataFrameTest(ArkoudaTest):
             ak_loaded = ak.DataFrame.load(f"{tmp_dirname}/seg_test.h5")
             self.assertTrue(akdf.to_pandas().equals(ak_loaded.to_pandas()))
 
+            # test load_all and read workflows
+            ak_load_all = ak.DataFrame(ak.load_all(f"{tmp_dirname}/seg_test.h5"))
+            self.assertTrue(akdf.to_pandas().equals(ak_load_all.to_pandas()))
+
+            ak_read = ak.DataFrame(ak.read(f"{tmp_dirname}/seg_test*"))
+            self.assertTrue(akdf.to_pandas().equals(ak_read.to_pandas()))
+
     def test_isin(self):
         df = ak.DataFrame({"col_A": ak.array([7, 3]), "col_B": ak.array([1, 9])})
 


### PR DESCRIPTION
This PR (closes #2111):
- Adds support for `ak.DataFrame(ak.load_all('seg_test.h5'))` and `ak.DataFrame(ak.read('seg_test*'))`
- Adds support for reading segarrays
- Adds testing of these functions

I would appreciate an extra close review from @Ethan-DeBandi99 (our resident io overlord) since this is my first time diving into this section of the codebase. It's all client side, so I _think_ it should be fine

example:
```python
>>> df_dict = {"c1": ak.arange(3, 6),"c2": ak.arange(6, 9),"c3": ak.segarray(ak.array([0, 9, 14]), ak.arange(20))}
>>> akdf = ak.DataFrame(df_dict)
>>> akdf
   c1  c2                           c3
0   3   6  [0, 1, 2, 3, 4, 5, 6, 7, 8]
1   4   7          [9, 10, 11, 12, 13]
2   5   8     [14, 15, 16, 17, 18, 19] (3 rows x 3 columns)

>>> akdf.to_hdf('seg_test.h5')

>>> ak.DataFrame(ak.read('seg_test*'))
   c1  c2                           c3
0   3   6  [0, 1, 2, 3, 4, 5, 6, 7, 8]
1   4   7          [9, 10, 11, 12, 13]
2   5   8     [14, 15, 16, 17, 18, 19] (3 rows x 3 columns)

>>> ak.DataFrame.load("seg_test.h5")
   c1  c2                           c3
0   3   6  [0, 1, 2, 3, 4, 5, 6, 7, 8]
1   4   7          [9, 10, 11, 12, 13]
2   5   8     [14, 15, 16, 17, 18, 19] (3 rows x 3 columns)

>>> ak.DataFrame(ak.load_all('seg_test.h5'))
   c1  c2                           c3
0   3   6  [0, 1, 2, 3, 4, 5, 6, 7, 8]
1   4   7          [9, 10, 11, 12, 13]
2   5   8     [14, 15, 16, 17, 18, 19] (3 rows x 3 columns)
```