### PR TITLE
Fixes #2115: Fixes bug in segarray load

### DIFF
--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -1074,6 +1074,7 @@ class SegArray:
         to_hdf, load
         """
         from warnings import warn
+
         warn(
             "ak.SegArray.save has been deprecated. Please use ak.SegArray.to_hdf",
             DeprecationWarning,
@@ -1118,7 +1119,7 @@ class SegArray:
             raise ValueError("Segment suffix and value suffix must be different")
         segments = load(prefix_path, dataset=dataset + segment_suffix)
         values = load(prefix_path, dataset=dataset + value_suffix)
-        return cls(segments, values)
+        return SegArray.from_parts(segments, values)
 
     def intersect(self, other):
         """

--- a/tests/segarray_test.py
+++ b/tests/segarray_test.py
@@ -1,8 +1,19 @@
+import os
+import tempfile
+
 from base_test import ArkoudaTest
 from context import arkouda as ak
 
+from arkouda import io_util
+
 
 class SegArrayTest(ArkoudaTest):
+    @classmethod
+    def setUpClass(cls):
+        super(SegArrayTest, cls).setUpClass()
+        SegArrayTest.seg_test_base_tmp = "{}/seg_test".format(os.getcwd())
+        io_util.get_directory(SegArrayTest.seg_test_base_tmp)
+
     def test_creation(self):
         a = [10, 11, 12, 13, 14, 15]
         b = [20, 21]
@@ -587,6 +598,14 @@ class SegArrayTest(ArkoudaTest):
         self.assertListEqual(xor.lengths.to_list(), [0, 2])
         self.assertListEqual(xor[0].tolist(), [])
         self.assertListEqual(xor[1].tolist(), [3, 4])
+
+    def test_segarray_load(self):
+        segarr = ak.segarray(ak.array([0, 9, 14]), ak.arange(20))
+        with tempfile.TemporaryDirectory(dir=SegArrayTest.seg_test_base_tmp) as tmp_dirname:
+            segarr.to_hdf(f"{tmp_dirname}/seg_test.h5")
+
+            seg_load = ak.SegArray.load(f"{tmp_dirname}/seg_test*")
+            self.assertTrue(ak.all(segarr == seg_load))
 
     def bigint_test(self):
         a = [2**80, 2**81]


### PR DESCRIPTION
This PR (fixes #2115) changes `ak.SegArray.load` to return `SegArray.from_parts` instead of `cls`. Adds test to verify this works