### PR TITLE
Closes #2118 Parquet Read Columns containing Array Elements

### DIFF
--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -698,7 +698,6 @@ def read_parquet(
                 "filenames": filenames,
             },
         )
-        print(rep_msg)
         rep = json.loads(rep_msg)  # See GenSymIO._buildReadAllMsgJson for json structure
         _parse_errors(rep, allow_errors)
         return _build_objects(rep)

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -13,7 +13,6 @@ from arkouda.client import generic_msg
 from arkouda.pdarrayclass import create_pdarray, pdarray
 from arkouda.segarray import SegArray
 from arkouda.strings import Strings
-from arkouda.segarray import SegArray
 
 __all__ = [
     "get_filetype",

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -13,6 +13,7 @@ from arkouda.client import generic_msg
 from arkouda.pdarrayclass import create_pdarray, pdarray
 from arkouda.segarray import SegArray
 from arkouda.strings import Strings
+from arkouda.segarray import SegArray
 
 __all__ = [
     "get_filetype",
@@ -383,7 +384,7 @@ def _parse_errors(rep_msg, allow_errors: bool = False):
         )
 
 
-def _parse_obj(obj: Dict) -> Union[Strings, pdarray, arkouda.array_view.ArrayView]:
+def _parse_obj(obj: Dict) -> Union[Strings, pdarray, arkouda.array_view.ArrayView, SegArray]:
     """
     Helper function to create an Arkouda object from read response
 
@@ -403,6 +404,8 @@ def _parse_obj(obj: Dict) -> Union[Strings, pdarray, arkouda.array_view.ArrayVie
     """
     if "seg_string" == obj["arkouda_type"]:
         return Strings.from_return_msg(obj["created"])
+    elif "seg_array" == obj["arkouda_type"]:
+        return SegArray.from_return_msg(obj["created"])
     elif "pdarray" == obj["arkouda_type"]:
         return create_pdarray(obj["created"])
     elif "ArrayView" == obj["arkouda_type"]:
@@ -696,6 +699,7 @@ def read_parquet(
                 "filenames": filenames,
             },
         )
+        print(rep_msg)
         rep = json.loads(rep_msg)  # See GenSymIO._buildReadAllMsgJson for json structure
         _parse_errors(rep, allow_errors)
         return _build_objects(rep)

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from typing import cast as type_cast
+from typing import Optional
 
 import numpy as np  # type: ignore
 
@@ -12,6 +13,11 @@ from arkouda.dtypes import int64 as akint64
 from arkouda.dtypes import isSupportedInt, str_, translate_np_dtype
 from arkouda.groupbyclass import GroupBy, broadcast
 from arkouda.infoclass import list_registry
+<<<<<<< HEAD
+=======
+
+# from arkouda.io import load
+>>>>>>> 4bda71bf (SegArray read support for Parquet files. Testing to ensure proper functionality.)
 from arkouda.logger import getArkoudaLogger
 from arkouda.numeric import cumsum
 from arkouda.pdarrayclass import RegistrationError, create_pdarray, is_sorted, pdarray

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import json
-from typing import cast as type_cast
 from typing import Optional
+from typing import cast as type_cast
 
 import numpy as np  # type: ignore
 
@@ -13,11 +13,6 @@ from arkouda.dtypes import int64 as akint64
 from arkouda.dtypes import isSupportedInt, str_, translate_np_dtype
 from arkouda.groupbyclass import GroupBy, broadcast
 from arkouda.infoclass import list_registry
-<<<<<<< HEAD
-=======
-
-# from arkouda.io import load
->>>>>>> 4bda71bf (SegArray read support for Parquet files. Testing to ensure proper functionality.)
 from arkouda.logger import getArkoudaLogger
 from arkouda.numeric import cumsum
 from arkouda.pdarrayclass import RegistrationError, create_pdarray, is_sorted, pdarray

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from typing import Optional
 from typing import cast as type_cast
 
 import numpy as np  # type: ignore

--- a/pydoc/file_io/PARQUET.md
+++ b/pydoc/file_io/PARQUET.md
@@ -12,6 +12,9 @@ More information on Parquet can be found [here](https://parquet.apache.org/).
 - Index
 - DataFrame
 - Strings
+- SegArray
+  - Read Only (Writes coming soon. Track progress [here](https://github.com/Bears-R-Us/arkouda/issues/2119))
+  - Strings dtype not yet supported. Track [here](https://github.com/Bears-R-Us/arkouda/issues/2121)
 
 ## Compression
 

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -143,7 +143,7 @@ int cpp_getListType(const char* filename, const char* colname, char** errMsg) {
     if(idx == -1) {
       std::string fname(filename);
       std::string dname(colname);
-      std::string msg = "Dataset: " + dname + " does not exist in file: " + filename; 
+      std::string msg = "Dataset: " + dname + " does not exist in file: " + fname; 
       *errMsg = strdup(msg.c_str());
       return ARROWERROR;
     }
@@ -153,7 +153,7 @@ int cpp_getListType(const char* filename, const char* colname, char** errMsg) {
       if (myType->num_fields() != 1) {
         std::string fname(filename);
         std::string dname(colname);
-        std::string msg = "Column " + dname + " in " + filename + " cannot be read by Arkouda."; 
+        std::string msg = "Column " + dname + " in " + fname + " cannot be read by Arkouda."; 
         *errMsg = strdup(msg.c_str());
         return ARROWERROR;
       }
@@ -183,7 +183,7 @@ int cpp_getListType(const char* filename, const char* colname, char** errMsg) {
         else {
           std::string fname(filename);
           std::string dname(colname);
-          std::string msg = "Unsupported type on column: " + dname + " in " + filename; 
+          std::string msg = "Unsupported type on column: " + dname + " in " + fname; 
           *errMsg = strdup(msg.c_str());
           return ARROWERROR;
         }
@@ -192,7 +192,7 @@ int cpp_getListType(const char* filename, const char* colname, char** errMsg) {
     else {
       std::string fname(filename);
       std::string dname(colname);
-      std::string msg = "Column " + dname + " in " + filename + " is not a List"; 
+      std::string msg = "Column " + dname + " in " + fname + " is not a List"; 
       *errMsg = strdup(msg.c_str());
       return ARROWERROR;
     }
@@ -309,7 +309,6 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
 
           while (int_reader->HasNext()) {
             int64_t value;
-            
             (void)int_reader->ReadBatch(1, &definition_level, &rep_lvl, &value, &values_read);
             if (rep_lvl == 0 && vct >0) {
               i++;
@@ -534,7 +533,6 @@ int cpp_readListColumnByName(const char* filename, void* chpl_arr, const char* c
           
           while (reader->HasNext() && i < numElems) {
             float value;
-            // Can't read directly into chpl_ptr because it is a double
             (void)reader->ReadBatch(1, &definition_level, nullptr, &value, &values_read);
             if(values_read == 0) {
               chpl_ptr[i] = NAN;

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -457,8 +457,9 @@ int64_t cpp_getStringColumnNullIndices(const char* filename, const char* colname
 
 int cpp_readListColumnByName(const char* filename, void* chpl_arr, const char* colname, int64_t numElems, int64_t startIdx, int64_t batchSize, char** errMsg) {
   try {
+    int64_t ty = cpp_getType(filename, colname, errMsg);
     if (ty == ARROWLIST){
-      int64_t ty = cpp_getListType(filename, colname, errMsg);
+      int64_t lty = cpp_getListType(filename, colname, errMsg);
       std::unique_ptr<parquet::ParquetFileReader> parquet_reader =
           parquet::ParquetFileReader::OpenFile(filename, false);
 
@@ -484,7 +485,7 @@ int cpp_readListColumnByName(const char* filename, void* chpl_arr, const char* c
 
         std::shared_ptr<parquet::ColumnReader> column_reader = row_group_reader->Column(idx);
 
-        if(ty == ARROWINT64 || ty == ARROWUINT64) {
+        if(lty == ARROWINT64 || lty == ARROWUINT64) {
           auto chpl_ptr = (int64_t*)chpl_arr;
           parquet::Int64Reader* reader =
             static_cast<parquet::Int64Reader*>(column_reader.get());
@@ -496,7 +497,7 @@ int cpp_readListColumnByName(const char* filename, void* chpl_arr, const char* c
             (void)reader->ReadBatch(batchSize, nullptr, nullptr, &chpl_ptr[i], &values_read);
             i+=values_read;
           }
-        } else if(ty == ARROWINT32 || ty == ARROWUINT32) {
+        } else if(lty == ARROWINT32 || lty == ARROWUINT32) {
           auto chpl_ptr = (int64_t*)chpl_arr;
           parquet::Int32Reader* reader =
             static_cast<parquet::Int32Reader*>(column_reader.get());
@@ -513,7 +514,7 @@ int cpp_readListColumnByName(const char* filename, void* chpl_arr, const char* c
             i+=values_read;
           }
           free(tmpArr);
-        } else if(ty == ARROWBOOLEAN) {
+        } else if(lty == ARROWBOOLEAN) {
           auto chpl_ptr = (bool*)chpl_arr;
           parquet::BoolReader* reader =
             static_cast<parquet::BoolReader*>(column_reader.get());
@@ -525,7 +526,7 @@ int cpp_readListColumnByName(const char* filename, void* chpl_arr, const char* c
             (void)reader->ReadBatch(batchSize, nullptr, nullptr, &chpl_ptr[i], &values_read);
             i+=values_read;
           }
-        } else if(ty == ARROWFLOAT) {
+        } else if(lty == ARROWFLOAT) {
           auto chpl_ptr = (double*)chpl_arr;
           parquet::FloatReader* reader =
             static_cast<parquet::FloatReader*>(column_reader.get());
@@ -543,7 +544,7 @@ int cpp_readListColumnByName(const char* filename, void* chpl_arr, const char* c
             }
             i++;
           }
-        } else if(ty == ARROWDOUBLE) {
+        } else if(lty == ARROWDOUBLE) {
           auto chpl_ptr = (double*)chpl_arr;
           parquet::DoubleReader* reader =
             static_cast<parquet::DoubleReader*>(column_reader.get());

--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -24,6 +24,7 @@ extern "C" {
 #define ARROWDOUBLE 7
 #define ARROWTIMESTAMP ARROWINT64
 #define ARROWSTRING 6
+#define ARROWLIST 8
 #define ARROWERROR -1
 
 // compression mappings
@@ -47,9 +48,21 @@ extern "C" {
                            const char* colname, int64_t numElems, int64_t startIdx,
                            int64_t batchSize, char** errMsg);
 
+  int c_readListColumnByName(const char* filename, void* chpl_arr, 
+                            const char* colname, int64_t numElems, 
+                            int64_t startIdx, int64_t batchSize, char** errMsg);
+  int cpp_readListColumnByName(const char* filename, void* chpl_arr, 
+                              const char* colname, int64_t numElems, 
+                              int64_t startIdx, int64_t batchSize, char** errMsg);
+
   int64_t cpp_getStringColumnNumBytes(const char* filename, const char* colname,
                                       void* chpl_offsets, int64_t numElems, int64_t startIdx, char** errMsg);
   int64_t c_getStringColumnNumBytes(const char* filename, const char* colname,
+                                    void* chpl_offsets, int64_t numElems, int64_t startIdx, char** errMsg);
+
+  int64_t c_getListColumnSize(const char* filename, const char* colname,
+                                    void* chpl_offsets, int64_t numElems, int64_t startIdx, char** errMsg);
+  int64_t cpp_getListColumnSize(const char* filename, const char* colname,
                                     void* chpl_offsets, int64_t numElems, int64_t startIdx, char** errMsg);
   
   int64_t c_getStringColumnNullIndices(const char* filename, const char* colname, void* chpl_nulls, char** errMsg);
@@ -57,6 +70,9 @@ extern "C" {
 
   int c_getType(const char* filename, const char* colname, char** errMsg);
   int cpp_getType(const char* filename, const char* colname, char** errMsg);
+
+  int c_getListType(const char* filename, const char* colname, char** errMsg);
+  int cpp_getListType(const char* filename, const char* colname, char** errMsg);
 
   int cpp_writeColumnToParquet(const char* filename, void* chpl_arr,
                                int64_t colnum, const char* dsetname, int64_t numelems,

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -244,6 +244,9 @@ module GenSymIO {
                     var (segName, nBytes) = id.splitMsgToTuple("+", 2);
                     item += "," + Q + "created" + QCQ + "created " + st.attrib(segName) + "+created bytes.size " + nBytes + Q + "}";
                 }
+                when ("seg_array") {
+                    item += "," + Q + "created" + QCQ + id.replace(Q, ESCAPED_QUOTES) + Q + "}";
+                }
                 otherwise {
                     item += "}";
                 }

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -179,7 +179,6 @@ module ParquetMsg {
   }
 
   proc readListFilesByName(A: [] ?t, filenames: [] string, sizes: [] int, dsetname: string, ty) throws {
-    // TODO - update extern to list call
     extern proc c_readListColumnByName(filename, chpl_arr, colNum, numElems, startIdx, batchSize, errMsg): int;
     var (subdoms, length) = getSubdomains(sizes);
     
@@ -365,7 +364,6 @@ module ParquetMsg {
   }
 
   proc getListData(filename: string, dsetname: string) throws {
-    // TODO - loop filesnames and validate?
     extern proc c_getListType(filename, dsetname, errMsg): c_int;
     var pqErr = new parquetErrorMsg();
     
@@ -794,7 +792,6 @@ module ParquetMsg {
         // Only integer is implemented for now, do nothing if the Parquet
         // file has a different type
         if ty == ArrowTypes.int64 || ty == ArrowTypes.int32 {
-          writeln("\n\nInt Type: %jt".format(ty));
           var entryVal = new shared SymEntry(len, int);
           readFilesByName(entryVal.a, filenames, sizes, dsetname, ty);
           var valName = st.nextName();

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -317,7 +317,7 @@ module ParquetMsg {
                                              c_ptrTo(offsets),
                                              offsets.size, 0,
                                              c_ptrTo(pqErr.errMsg));
-    writeln("Offsets: %jt\nSize: %i\n\n".format(offsets, listSize));
+    
     if listSize == ARROWERROR then
       pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
     return listSize;
@@ -645,7 +645,6 @@ module ParquetMsg {
     var filedom = filenames.domain;
     var segments = makeDistArray(len, int);
     var listSizes: [filedom] int = calcListSizesandOffset(segments, filenames, sizes, dsetname);
-    writeln("List has type: ", ty);
     var rtnmap: map(string, string) = new map(string, string);
 
     if ty == ArrowTypes.int64 || ty == ArrowTypes.int32 {


### PR DESCRIPTION
Closes #2118
Part of #2051 

Adds support for reading columns from Parquet files containing data types of Arrow List. This translates into a SegArray in Arkouda. Modifications to the IO workflow to allow for SegArrays read from Parquet files to be returned as a SegArray object.

`ak.SegArray.load` not updated to handle as it will be deprecated. Because the type can be returned from the generic IO functions, loading should be done using `arkouda.io.read`, `arkouda.io.load` or `arkouda.io.load_all`.

Updates Parquet documentation to include SegArray info.

This implementation does not support columns of SegArrays of Strings. This will be addressed in issue #2121.