### PR TITLE
Fixes #2124: Chapel API reference broken link

### DIFF
--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -324,7 +324,7 @@ module MultiTypeSymEntry
         }
     }
 
-    /**
+    /*
         Base class for any entry that consists of multiple SymEntries that have varying types.
         These entries are related, but do not represent a single object.
         For Example, group by contains multiple SymEntries that are all considered part of the dataset.


### PR DESCRIPTION
This PR (fixes #2124) updates one of the docstrings to avoid breaking `chpldoc`. Testing locally shows this resolves issue with broken `Chapel API Reference` link

This line was causing the `chpldoc` to break 
https://github.com/Bears-R-Us/arkouda/blob/cefaa93a73755a84bdcc6278b8a87aad7f383e00/src/MultiTypeSymEntry.chpl#L327-L331

since it goes from `/**` to `*/`