### PR TITLE
Closes #2129: Periodic 403 error for integration and metrics-enabled Arkouda

### DIFF
--- a/src/ServerDaemon.chpl
+++ b/src/ServerDaemon.chpl
@@ -25,12 +25,14 @@ module ServerDaemon {
     use ExternalIntegration;
     use MetricsMsg;
     use BigIntMsg;
+    use NumPyDType;
 
     enum ServerDaemonType {DEFAULT,INTEGRATION,METRICS}
 
     private config const logLevel = ServerConfig.logLevel;
-    const sdLogger = new Logger(logLevel);
-
+    private config const logChannel = ServerConfig.logChannel;
+    const sdLogger = new Logger(logLevel,logChannel);
+    
     private config const daemonTypes = 'ServerDaemonType.DEFAULT';
     
     var serverDaemonTypes = try! getDaemonTypes();
@@ -377,7 +379,6 @@ module ServerDaemon {
             return arkDirectory;
         }
 
-
         /**
          * The overridden shutdown function calls exit(0) if there are multiple 
          * ServerDaemons configured for this Arkouda instance.
@@ -389,6 +390,62 @@ module ServerDaemon {
                 exit(0);
             }
         }
+
+        proc processMetrics(user: string, cmd: string, args: MessageArgs, elapsedTime: real) throws {
+            proc getArrayParameterObj(args: MessageArgs) throws {
+                var obj : ParameterObj;
+
+                for item in args.items() {
+                    if item.key == 'a' || item.key == 'array' { 
+                        obj = item;
+                    }
+                }
+                
+                return obj;
+            }
+          
+            proc computeArrayMetrics(obj: ParameterObj): bool {
+               return !obj.key.isEmpty();
+            }
+          
+            // Update Request Metrics
+            requestMetrics.increment(cmd);
+            
+            // Update User-Scoped Request Metrics
+            userMetrics.incrementPerUserRequestMetrics(user,cmd);
+
+            var apo = getArrayParameterObj(args);
+
+            // Check to see if the incoming request corresponds to a pdarray operation
+            if computeArrayMetrics(apo) {
+                var name = apo.val;
+                var value = elapsedTime;
+                
+                // Add the response time to the avg response time for the corresponding cmd
+                avgResponseTimeMetrics.add(cmd,value);
+            
+                /*
+                 * Create the ArrayMetric object and output the individual response time
+                 * as JSON to the console or arkouda.log for now. In the future, individual  
+                 * values will be output to external channels such as Prometheus, Kafka, etc...
+                 * to enable downstream metrics processing and presentation.
+                 */
+                var metric = new ArrayMetric(name=name,
+                                             category=MetricCategory.RESPONSE_TIME,
+                                             scope=MetricScope.REQUEST,
+                                             value=value,
+                                             cmd=cmd,
+                                             dType=str2dtype(apo.dtype),
+                                             size=getGenericTypedArrayEntry(apo.val, st).size
+                                            );
+                
+                // Log to the console or arkouda.log file
+                sdLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                              "%jt".format(metric)); 
+            }
+            
+        }
+
 
         override proc run() throws {
             this.arkDirectory = this.initArkoudaDirectory();
@@ -473,6 +530,11 @@ module ServerDaemon {
                     else {
                         msgArgs = new owned MessageArgs();
                     }
+
+                    sdLogger.info(getModuleName(),
+                                  getRoutineName(),
+                                  getLineNumber(),
+                                  "MessageArgs: %t".format(msgArgs));                    
 
                     /*
                      * If authentication is enabled with the --authenticate flag, authenticate
@@ -572,21 +634,22 @@ module ServerDaemon {
                                                               msgFormat=MsgFormat.STRING, user=user));
                 }
 
+                var elapsedTime = getCurrentTime() - s0;
+
                 /*
                  * log that the request message has been handled and reply message has been sent 
                  * along with the time to do so
                  */
                 if trace {
                     sdLogger.info(getModuleName(),getRoutineName(),getLineNumber(), 
-                                              "<<< %s took %.17r sec".format(cmd, getCurrentTime() - s0));
+                                              "<<< %s took %.17r sec".format(cmd, elapsedTime));
                 }
                 if (trace && memTrack) {
                     sdLogger.info(getModuleName(),getRoutineName(),getLineNumber(),
                         "bytes of memory used after command %t".format(getMemUsed():uint * numLocales:uint));
                 }
                 if metricsEnabled() {
-                    userMetrics.incrementPerUserRequestMetrics(user,cmd);
-                    requestMetrics.increment(cmd);
+                    processMetrics(user, cmd, msgArgs, elapsedTime);
                 }
             } catch (e: ErrorWithMsg) {
                 // Generate a ReplyMsg of type ERROR and serialize to a JSON-formatted string

--- a/src/ServerDaemon.chpl
+++ b/src/ServerDaemon.chpl
@@ -25,14 +25,12 @@ module ServerDaemon {
     use ExternalIntegration;
     use MetricsMsg;
     use BigIntMsg;
-    use NumPyDType;
 
     enum ServerDaemonType {DEFAULT,INTEGRATION,METRICS}
 
     private config const logLevel = ServerConfig.logLevel;
-    private config const logChannel = ServerConfig.logChannel;
-    const sdLogger = new Logger(logLevel,logChannel);
-    
+    const sdLogger = new Logger(logLevel);
+
     private config const daemonTypes = 'ServerDaemonType.DEFAULT';
     
     var serverDaemonTypes = try! getDaemonTypes();
@@ -379,6 +377,7 @@ module ServerDaemon {
             return arkDirectory;
         }
 
+
         /**
          * The overridden shutdown function calls exit(0) if there are multiple 
          * ServerDaemons configured for this Arkouda instance.
@@ -390,62 +389,6 @@ module ServerDaemon {
                 exit(0);
             }
         }
-
-        proc processMetrics(user: string, cmd: string, args: MessageArgs, elapsedTime: real) throws {
-            proc getArrayParameterObj(args: MessageArgs) throws {
-                var obj : ParameterObj;
-
-                for item in args.items() {
-                    if item.key == 'a' || item.key == 'array' { 
-                        obj = item;
-                    }
-                }
-                
-                return obj;
-            }
-          
-            proc computeArrayMetrics(obj: ParameterObj): bool {
-               return !obj.key.isEmpty();
-            }
-          
-            // Update Request Metrics
-            requestMetrics.increment(cmd);
-            
-            // Update User-Scoped Request Metrics
-            userMetrics.incrementPerUserRequestMetrics(user,cmd);
-
-            var apo = getArrayParameterObj(args);
-
-            // Check to see if the incoming request corresponds to a pdarray operation
-            if computeArrayMetrics(apo) {
-                var name = apo.val;
-                var value = elapsedTime;
-                
-                // Add the response time to the avg response time for the corresponding cmd
-                avgResponseTimeMetrics.add(cmd,value);
-            
-                /*
-                 * Create the ArrayMetric object and output the individual response time
-                 * as JSON to the console or arkouda.log for now. In the future, individual  
-                 * values will be output to external channels such as Prometheus, Kafka, etc...
-                 * to enable downstream metrics processing and presentation.
-                 */
-                var metric = new ArrayMetric(name=name,
-                                             category=MetricCategory.RESPONSE_TIME,
-                                             scope=MetricScope.REQUEST,
-                                             value=value,
-                                             cmd=cmd,
-                                             dType=str2dtype(apo.dtype),
-                                             size=getGenericTypedArrayEntry(apo.val, st).size
-                                            );
-                
-                // Log to the console or arkouda.log file
-                sdLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                              "%jt".format(metric)); 
-            }
-            
-        }
-
 
         override proc run() throws {
             this.arkDirectory = this.initArkoudaDirectory();
@@ -530,11 +473,6 @@ module ServerDaemon {
                     else {
                         msgArgs = new owned MessageArgs();
                     }
-
-                    sdLogger.info(getModuleName(),
-                                  getRoutineName(),
-                                  getLineNumber(),
-                                  "MessageArgs: %t".format(msgArgs));                    
 
                     /*
                      * If authentication is enabled with the --authenticate flag, authenticate
@@ -634,22 +572,21 @@ module ServerDaemon {
                                                               msgFormat=MsgFormat.STRING, user=user));
                 }
 
-                var elapsedTime = getCurrentTime() - s0;
-
                 /*
                  * log that the request message has been handled and reply message has been sent 
                  * along with the time to do so
                  */
                 if trace {
                     sdLogger.info(getModuleName(),getRoutineName(),getLineNumber(), 
-                                              "<<< %s took %.17r sec".format(cmd, elapsedTime));
+                                              "<<< %s took %.17r sec".format(cmd, getCurrentTime() - s0));
                 }
                 if (trace && memTrack) {
                     sdLogger.info(getModuleName(),getRoutineName(),getLineNumber(),
                         "bytes of memory used after command %t".format(getMemUsed():uint * numLocales:uint));
                 }
                 if metricsEnabled() {
-                    processMetrics(user, cmd, msgArgs, elapsedTime);
+                    userMetrics.incrementPerUserRequestMetrics(user,cmd);
+                    requestMetrics.increment(cmd);
                 }
             } catch (e: ErrorWithMsg) {
                 // Generate a ReplyMsg of type ERROR and serialize to a JSON-formatted string
@@ -711,10 +648,6 @@ module ServerDaemon {
         }
 
         override proc run() throws {
-            if integrationEnabled() {
-                register(ServiceEndpoint.METRICS);
-            }
-
             while !this.shutdownDaemon {
                 sdLogger.debug(getModuleName(), getRoutineName(), getLineNumber(),
                                "awaiting message on port %i".format(this.port));
@@ -756,9 +689,6 @@ module ServerDaemon {
                                                 msgFormat=MsgFormat.STRING, user=user));
             }
 
-            if integrationEnabled() {
-                deregisterFromExternalSystem(ServiceEndpoint.METRICS);
-            }
             return;
         }
     }
@@ -775,6 +705,10 @@ module ServerDaemon {
          */
         override proc run() throws {
             register(ServiceEndpoint.ARKOUDA_CLIENT);
+            // if metrics enabled, register the metrics socket
+            if metricsEnabled() {
+                register(ServiceEndpoint.METRICS);
+            }
             super.run();
         }
 


### PR DESCRIPTION
This PR fixes #2129 (intermittent 403 error) by consolidating all Kubernetes API calls into the ExternalIntegrationServerDaemon. 

Testing indicates that there is a race condition in the current ServerDaemon class hierarchy where both the ExternalIntegrationServerDaemon and MetricsServerDaemon attempt to register Kubernetes services in rapid succession, presumably causing a 403 error to be thrown by the Kubernetes API sever.

This PR ensures the two ServerDaemon.register function invocations occur sequentially.