### PR TITLE
Close #1522 - Add `Index`&`MultiIndex` Support for `key` in `Series.locate()`

### DIFF
--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -193,7 +193,11 @@ class Index:
 
     def lookup(self, key):
         if not isinstance(key, pdarray):
-            raise TypeError("Lookup must be on an arkouda array")
+            # try to handle single value
+            try:
+                key = array([key])
+            except Exception:
+                raise TypeError("Lookup must be on an arkouda array")
 
         return in1d(self.values, key)
 
@@ -448,8 +452,10 @@ class MultiIndex(Index):
     def __getitem__(self, key):
         from arkouda.series import Series
 
-        if type(key) == Series:
+        if isinstance(key, Series):
             key = key.values
+
+
         return MultiIndex([i[key] for i in self.index])
 
     def __repr__(self):
@@ -526,7 +532,9 @@ class MultiIndex(Index):
         return MultiIndex(idx)
 
     def lookup(self, key):
-        if type(key) != list and type(key) != tuple:
+        if not isinstance(key, list) and not isinstance(key, tuple):
             raise TypeError("MultiIndex lookup failure")
-
+        # if individual vals convert to pdarrays
+        if not isinstance(key[0], pdarray):
+            key = [array([x]) for x in key]
         return in1d(self.index, key)

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -454,8 +454,6 @@ class MultiIndex(Index):
 
         if isinstance(key, Series):
             key = key.values
-
-
         return MultiIndex([i[key] for i in self.index])
 
     def __repr__(self):

--- a/arkouda/series.py
+++ b/arkouda/series.py
@@ -276,7 +276,6 @@ class Series:
 
     @typechecked
     def add(self, b: Series) -> Series:
-
         index = self.index.concat(b.index).index
 
         values = concatenate([self.values, b.values], ordered=False)
@@ -566,7 +565,6 @@ class Series:
                 value_labels = [f"val_{i}" for i in range(len(arrays))]
 
             if Series._all_aligned(arrays):
-
                 data = next(iter(arrays)).index.to_dict(index_labels)
 
                 if value_labels is not None:

--- a/arkouda/series.py
+++ b/arkouda/series.py
@@ -14,7 +14,7 @@ from arkouda.alignment import lookup
 from arkouda.categorical import Categorical
 from arkouda.dtypes import float64, int64
 from arkouda.groupbyclass import GroupBy, groupable_element_type
-from arkouda.index import Index
+from arkouda.index import Index, MultiIndex
 from arkouda.numeric import cast as akcast
 from arkouda.numeric import value_counts
 from arkouda.pdarrayclass import argmaxk, attach_pdarray, create_pdarray, pdarray
@@ -198,7 +198,7 @@ class Series:
         return Series(data=boolean, index=self.index)
 
     @typechecked
-    def locate(self, key: Union[int, pdarray, Series, List, Tuple]) -> Series:
+    def locate(self, key: Union[int, pdarray, Index, Series, List, Tuple]) -> Series:
         """Lookup values by index label
 
         The input can be a scalar, a list of scalers, or a list of lists (if the series has a
@@ -214,6 +214,10 @@ class Series:
         if isinstance(key, Series):
             # special case, keep the index values of the Series, and lookup the values
             return Series(index=key.index, data=lookup(self.index.index, self.values, key.values))
+        elif isinstance(key, MultiIndex):
+            idx = self.index.lookup(key.index)
+        elif isinstance(key, Index):
+            idx = self.index.lookup(key.index)
         elif isinstance(key, pdarray):
             idx = self.index.lookup(key)
         elif isinstance(key, (list, tuple)):

--- a/tests/series_test.py
+++ b/tests/series_test.py
@@ -64,6 +64,35 @@ class SeriesTest(ArkoudaTest):
         self.assertEqual(lk.index[1], 2)
         self.assertEqual(lk.values[1], "C")
 
+        # testing index lookup
+        i = ak.Index([1])
+        lk = s.locate(i)
+        self.assertIsInstance(lk, ak.Series)
+        self.assertListEqual(lk.index.to_list(), i.index.to_list())
+        self.assertEqual(lk.values[0], v[1])
+
+        i = ak.Index([0, 2])
+        lk = s.locate(i)
+        self.assertIsInstance(lk, ak.Series)
+        self.assertListEqual(lk.index.to_list(), i.index.to_list())
+        self.assertEqual(lk.values.to_list(), v[ak.array([0,2])].to_list())
+
+        # testing multi-index lookup
+        mi = ak.MultiIndex([ak.arange(3), ak.array([2, 1, 0])])
+        s = ak.Series(data=v, index=mi)
+        lk = s.locate(mi[0])
+        self.assertIsInstance(lk, ak.Series)
+        self.assertListEqual(lk.index.index, mi[0].index)
+        self.assertEqual(lk.values[0], v[0])
+
+        # ensure error with scalar and multi-index
+        with self.assertRaises(TypeError):
+            lk = s.locate(0)
+
+        with self.assertRaises(TypeError):
+            lk = s.locate([0,2])
+
+
     def test_shape(self):
         v = ak.array(["A", "B", "C"])
         i = ak.arange(3)


### PR DESCRIPTION
Closes #1522

Adds support for `MultiIndex` and `Index` in `Series.locate()`. 

Updates `MultiIndex.lookup` and `Index.lookup` to allow for single value objects to be passed for proper functionality when called from `Series.locate()`.

Adds testing to validate functionality.