### PR TITLE
Closes #1939 - Adds `%` and `%=` for floats

### DIFF
--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -317,6 +317,9 @@ module BinOp
           when "**" { 
             e.a= l.a**r.a;
           }
+          when "%" {
+            e.a = AutoMath.mod(l.a, r.a);
+          }
           otherwise {
             var errorMsg = notImplementedError(pn,l.dtype,op,r.dtype);
             omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
@@ -347,6 +350,9 @@ module BinOp
           }
           when "**" { 
             e.a= l.a:real**r.a:real;
+          }
+          when "%" {
+            e.a = AutoMath.mod(l.a:real, r.a:real);
           }
           otherwise {
             var errorMsg = notImplementedError(pn,l.dtype,op,r.dtype);
@@ -662,6 +668,9 @@ module BinOp
           when "**" { 
             e.a= l.a**val;
           }
+          when "%" {
+            e.a = AutoMath.mod(l.a, val);
+          }
           otherwise {
             var errorMsg = notImplementedError(pn,l.dtype,op,dtype);
             omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
@@ -691,6 +700,9 @@ module BinOp
           }
           when "**" { 
             e.a= l.a: real**val: real;
+          }
+          when "%" {
+            e.a = AutoMath.mod(l.a:real, val:real);
           }
           otherwise {
             var errorMsg = notImplementedError(pn,l.dtype,op,dtype);
@@ -990,6 +1002,9 @@ module BinOp
           when "**" { 
             e.a= val**r.a;
           }
+          when "%" {
+            e.a = AutoMath.mod(val, r.a);
+          }
           otherwise {
             var errorMsg = notImplementedError(pn,dtype,op,r.dtype);
             omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
@@ -1019,6 +1034,9 @@ module BinOp
           }
           when "**" { 
             e.a= val:real**r.a:real;
+          }
+          when "%" {
+            e.a = AutoMath.mod(val:real, r.a:real);
           }
           otherwise {
             var errorMsg = notImplementedError(pn,dtype,op,r.dtype);

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -1175,6 +1175,7 @@ module OperatorMsg
                         [(li,ri) in zip(la,ra)] li = floorDivisionHelper(li, ri);
                     }
                     when "**=" { l.a **= r.a; }
+                    when "%=" {l.a = AutoMath.mod(l.a, r.a);}
                     otherwise {
                         var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
                         omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
@@ -1197,6 +1198,7 @@ module OperatorMsg
                         [(li,ri) in zip(la,ra)] li = floorDivisionHelper(li, ri);
                     }
                     when "**=" { l.a **= r.a; }
+                    when "%=" {l.a = AutoMath.mod(l.a, r.a:real);}
                     otherwise {
                         var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
                         omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
@@ -1218,6 +1220,7 @@ module OperatorMsg
                         [(li,ri) in zip(la,ra)] li = floorDivisionHelper(li, ri);
                     }
                     when "**=" { l.a **= r.a; }
+                    when "%=" {l.a = AutoMath.mod(l.a, r.a);}
                     otherwise {
                         var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
                         omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
@@ -1593,6 +1596,7 @@ module OperatorMsg
                         [li in la] li = floorDivisionHelper(li, val);
                     }
                     when "**=" { l.a **= val; }
+                    when "%=" {l.a = AutoMath.mod(l.a, val);}
                     otherwise {
                         var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
                         omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
@@ -1614,6 +1618,7 @@ module OperatorMsg
                     when "**=" {
                         l.a **= val;
                     }
+                    when "%=" {l.a = AutoMath.mod(l.a, val:real);}
                     otherwise {
                         var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
                         omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
@@ -1634,6 +1639,7 @@ module OperatorMsg
                         [li in la] li = floorDivisionHelper(li, val);
                     }
                     when "**=" { l.a **= val; }
+                    when "%=" {l.a = AutoMath.mod(l.a, val);}
                     otherwise {
                         var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
                         omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -348,6 +348,8 @@ class OperatorsTest(ArkoudaTest):
             self.assertTrue(np.allclose((akf**ak_uint).to_ndarray(), npf**np_uint, equal_nan=True))
             self.assertTrue(np.allclose((ak_float**aku).to_ndarray(), np_float**npu, equal_nan=True))
             self.assertTrue(np.allclose((aku**ak_float).to_ndarray(), npu**np_float, equal_nan=True))
+            self.assertTrue(np.allclose((ak_float % aku).to_ndarray(), np_float % npu, equal_nan=True))
+            self.assertTrue(np.allclose((aku % ak_float).to_ndarray(), npu % np_float, equal_nan=True))
 
     def test_shift_binop(self):
         # This tests for a bug when left shifting by a value >=64 bits for int/uint, Issue #2099
@@ -871,6 +873,58 @@ class OperatorsTest(ArkoudaTest):
         for s in [i_scalar, u_scalar, bi_scalar]:
             self.assertListEqual([(bi[i] * s) % mod_by for i in range(bi.size)], (bi * s).to_list())
             self.assertListEqual([(s * bi[i]) % mod_by for i in range(bi.size)], (s * bi).to_list())
+
+    def test_fmod(self):
+        # Note - uint/float and float/uint handles in another test case
+        npf = np.array([2.23, 3.14, 3.08, 5.7])
+        npf2 = np.array([3.14, 2.23, 1.1, 4.1])
+        npi = np.array([1, 4, 1, 5])
+
+        akf = ak.array(npf)
+        akf2 = ak.array(npf2)
+        aki = ak.array(npi)
+
+        # vector-vector operations
+        self.assertTrue(np.allclose((akf % akf2).to_ndarray(), npf % npf2, equal_nan=True))
+        self.assertTrue(np.allclose((akf2 % akf).to_ndarray(), npf2 % npf, equal_nan=True))
+        self.assertTrue(np.allclose((akf % aki).to_ndarray(), npf % npi, equal_nan=True))
+        self.assertTrue(np.allclose((aki % akf).to_ndarray(), npi % npf, equal_nan=True))
+        self.assertTrue(np.allclose((akf2 % aki).to_ndarray(), npf2 % npi, equal_nan=True))
+        self.assertTrue(np.allclose((aki % akf2).to_ndarray(), npi % npf2, equal_nan=True))
+
+        # vector scalar and scalar vector
+        self.assertTrue(np.allclose((akf % 2).to_ndarray(), npf % 2, equal_nan=True))
+        self.assertTrue(np.allclose((2 % akf).to_ndarray(), 2 % npf, equal_nan=True))
+        self.assertTrue(np.allclose((akf % 2.14).to_ndarray(), npf % 2.14, equal_nan=True))
+        self.assertTrue(np.allclose((2.14 % akf).to_ndarray(), 2.14 % npf, equal_nan=True))
+        u = np.array([4]).astype(np.uint64)[0]
+        self.assertTrue(np.allclose((akf % u).to_ndarray(), npf % u, equal_nan=True))
+        self.assertTrue(np.allclose((u % akf).to_ndarray(), u % npf, equal_nan=True))
+
+        #opequal
+        npf_copy = npf
+        akf_copy = ak.array(npf_copy)
+        npf_copy %= npf2
+        akf_copy %= akf2
+        self.assertTrue(np.allclose(akf_copy.to_ndarray(), npf_copy, equal_nan=True))
+
+        npf_copy = npf
+        akf_copy = ak.array(npf_copy)
+        npf_copy %= npi
+        akf_copy %= aki
+        self.assertTrue(np.allclose(akf_copy.to_ndarray(), npf_copy, equal_nan=True))
+
+        npf_copy = npf
+        akf_copy = ak.array(npf_copy)
+        npf_copy %= 2
+        akf_copy %= 2
+        self.assertTrue(np.allclose(akf_copy.to_ndarray(), npf_copy, equal_nan=True))
+
+        npf_copy = npf
+        akf_copy = ak.array(npf_copy)
+        npf_copy %= 2.14
+        akf_copy %= 2.14
+        self.assertTrue(np.allclose(akf_copy.to_ndarray(), npf_copy, equal_nan=True))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #1939

- Adds `%` support for vector-vector, vector-scalar, and scalar-vector. 
- Adds `%=` for vector-vector and vector-scalar
- Supported types:
  - `float-float`
  - `float-int` & `int-float`
  - `float-uint` & `uint-float`
- Testing for all combinations.