### PR TITLE
Closes #2139: Add benchmark for bigint conversion

### DIFF
--- a/benchmarks/bigint_conversion.py
+++ b/benchmarks/bigint_conversion.py
@@ -3,13 +3,14 @@ import arkouda as ak
 import time
 
 
-def time_bigint_conversion(N, trials, seed, max_bits):
+def time_bigint_conversion(N_per_locale, trials, seed, max_bits):
     print(">>> arkouda uint arrays from bigint array")
     cfg = ak.get_config()
+    N = N_per_locale * cfg["numLocales"]
     print("numLocales = {}, N = {:,}".format(cfg["numLocales"], N))
 
-    a = ak.randint(0, 2**32, args.size, dtype=ak.uint64, seed=seed)
-    b = ak.randint(0, 2**32, args.size, dtype=ak.uint64, seed=seed)
+    a = ak.randint(0, 2**32, N, dtype=ak.uint64, seed=seed)
+    b = ak.randint(0, 2**32, N, dtype=ak.uint64, seed=seed)
 
     convert_to_bigint_times = []
     for i in range(trials):
@@ -64,7 +65,12 @@ def create_parser():
     parser.add_argument("hostname", help="Hostname of arkouda server")
     parser.add_argument("port", type=int, help="Port of arkouda server")
     parser.add_argument("-n", "--size", type=int, default=10**8, help="Problem size: length of array")
-    parser.add_argument("--max-bits", type=int, default=-1)
+    parser.add_argument(
+        "--max-bits",
+        type=int,
+        default=-1,
+        help="Maximum number of bits, so values > 2**max_bits will wraparound. -1 is interpreted as no maximum",
+    )
     parser.add_argument(
         "-t", "--trials", type=int, default=6, help="Number of times to run the benchmark"
     )

--- a/benchmarks/graph_infra/arkouda.graph
+++ b/benchmarks/graph_infra/arkouda.graph
@@ -141,3 +141,9 @@ graphkeys: Noop ops/s
 files: noop.dat
 graphtitle: Noop Performance
 ylabel: Performance (ops/s)
+
+perfkeys: bigint_from_uint_arrays Average rate =, bigint_to_uint_arrays Average rate =
+graphkeys: bigint_from_uint_arrays GiB/s, bigint_to_uint_arrays GiB/s
+files: bigint_conversion.dat, bigint_conversion.dat
+graphtitle: Bigint Conversion Performance
+ylabel: Performance (GiB/s)

--- a/benchmarks/graph_infra/bigint_conversion.perfkeys
+++ b/benchmarks/graph_infra/bigint_conversion.perfkeys
@@ -1,0 +1,4 @@
+bigint_from_uint_arrays Average time =
+bigint_from_uint_arrays Average rate =
+bigint_to_uint_arrays Average time =
+bigint_to_uint_arrays Average rate =

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -48,6 +48,7 @@ BENCHMARKS = [
     "str-locality",
     "dataframe",
     "encode",
+    "bigint_conversion",
 ]
 
 if os.getenv("ARKOUDA_SERVER_PARQUET_SUPPORT"):

--- a/src/BigIntMsg.chpl
+++ b/src/BigIntMsg.chpl
@@ -68,22 +68,21 @@ module BigIntMsg {
                 if && reduce (tmp == 0) {
                   // early out if we are already all zeroes
                   var retname = st.nextName();
-                  st.addEntry(retname, new shared SymEntry(tmp:uint));
+                  st.addEntry(retname, new shared SymEntry(makeDistArray(tmp.size, uint)));
                   retList.append("created %s".format(st.attrib(retname)));
                 }
                 else {
+                  var low: [tmp.domain] uint;
                   while || reduce (tmp!=0) {
-                    var low: [tmp.domain] bigint;
-                    // create local copy, needed to work around bug fixed in Chapel, but
-                    // needed for backwards compatability for now
-                    forall (lowVal, tmpVal) in zip(low, tmp) with (var local_block_size = block_size) {
-                        lowVal = tmpVal % local_block_size;
-                    }
+                    low = tmp:uint;
                     var retname = st.nextName();
 
-                    st.addEntry(retname, new shared SymEntry(low:uint));
+                    st.addEntry(retname, new shared SymEntry(low));
                     retList.append("created %s".format(st.attrib(retname)));
-                    tmp /= block_size;
+                    forall t in tmp with (var local_block_size = block_size) {
+                      // TODO eventually we will likely want to >>= 64 here
+                      t /= local_block_size;
+                    }
                   }
                 }
                 var repMsg = "%jt".format(retList);

--- a/src/BigIntMsg.chpl
+++ b/src/BigIntMsg.chpl
@@ -63,26 +63,20 @@ module BigIntMsg {
                 var tmp = e.a;
                 // take in a bigint sym entry and return list of uint64 symentries
                 var retList: list(string);
-                var block_size = 1:bigint;
-                block_size <<= 64;
-                if && reduce (tmp == 0) {
-                  // early out if we are already all zeroes
+                // default to false because we want to do first loop whether or not tmp is all_zero
+                var all_zero = false;
+                var low: [tmp.domain] uint;
+                const ushift = 64:uint;
+                while !all_zero {
+                  low = tmp:uint;
                   var retname = st.nextName();
-                  st.addEntry(retname, new shared SymEntry(makeDistArray(tmp.size, uint)));
+                  st.addEntry(retname, new shared SymEntry(low));
                   retList.append("created %s".format(st.attrib(retname)));
-                }
-                else {
-                  var low: [tmp.domain] uint;
-                  while || reduce (tmp!=0) {
-                    low = tmp:uint;
-                    var retname = st.nextName();
 
-                    st.addEntry(retname, new shared SymEntry(low));
-                    retList.append("created %s".format(st.attrib(retname)));
-                    forall t in tmp with (var local_block_size = block_size) {
-                      // TODO eventually we will likely want to >>= 64 here
-                      t /= local_block_size;
-                    }
+                  all_zero = true;
+                  forall t in tmp with (&& reduce all_zero) {
+                    t >>= ushift;
+                    all_zero &&= (t == 0);
                   }
                 }
                 var repMsg = "%jt".format(retList);


### PR DESCRIPTION
This PR (closes #2139) adds:
- a benchmark for `ak.bigint_to/from_uint_arrays`
- optimizations for `ak.bigint_to_uint_arrays`
  - resulting in a >11x speedup locally!

The performance increase in `ak.bigint_to_uint_arrays` running the benchmark from this PR locally:
before this PR
```
% ./benchmarks/run_benchmarks.py bigint_conversion
Client Version: v2023.02.08+4.ge7164f13.dirty
array size = 100,000,000
number of trials =  6
>>> arkouda uint arrays from bigint array
numLocales = 1, N = 100,000,000
bigint_from_uint_arrays Average time = 3.6804 sec
bigint_from_uint_arrays Average rate = 0.4049 GiB/sec

>>> arkouda bigint array to uint arrays
bigint_to_uint_arrays Average time = 46.2472 sec
bigint_to_uint_arrays Average rate = 0.0322 GiB/sec
```
after this PR
```
% ./benchmarks/run_benchmarks.py bigint_conversion

Client Version: v2023.02.08+6.g791d030e
array size = 100,000,000
number of trials =  6
>>> arkouda uint arrays from bigint array
numLocales = 1, N = 100,000,000
bigint_from_uint_arrays Average time = 3.6700 sec
bigint_from_uint_arrays Average rate = 0.4060 GiB/sec

>>> arkouda bigint array to uint arrays
bigint_to_uint_arrays Average time = 3.9868 sec
bigint_to_uint_arrays Average rate = 0.3738 GiB/sec
```

if @ronawho or @bmcdonald3 has time next week to get the numbers on 16-node-cs-hdr, that would be awesome!