### PR TITLE
Closes #2141 - Fixes Parquet SegArray Read Index Bug

### DIFF
--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -532,7 +532,6 @@ int64_t cpp_getStringColumnNullIndices(const char* filename, const char* colname
 
 int cpp_readListColumnByName(const char* filename, void* chpl_arr, const char* colname, int64_t numElems, int64_t startIdx, int64_t batchSize, char** errMsg) {
   try {
-    std::cout << "\n\nStartIdx: " << startIdx << "NumElems" << numElems << "\n\n";
     int64_t ty = cpp_getType(filename, colname, errMsg);
     if (ty == ARROWLIST){
       int64_t lty = cpp_getListType(filename, colname, errMsg);

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -290,6 +290,7 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
 
       int64_t i = 0;
       int64_t vct = 0;
+      int64_t seg_size = 0;
       int64_t off = 0;
       for (int r = 0; r < num_row_groups; r++) {
         std::shared_ptr<parquet::RowGroupReader> row_group_reader =
@@ -310,13 +311,28 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
           while (int_reader->HasNext()) {
             int64_t value;
             (void)int_reader->ReadBatch(1, &definition_level, &rep_lvl, &value, &values_read);
-            if (rep_lvl == 0 && vct >0) {
-              i++;
-              offsets[i] = vct;
+            if (values_read == 0){ // empty segment
+              if (!int_reader->HasNext()){ // last value 
+                offsets[i] = seg_size;
+              }
+              else {
+                i++;
+              }
+            } else {
+              // new segment starts. This has to be before increment to avoid false empty on first segment.
+              if (rep_lvl == 0 && seg_size >0) {
+                offsets[i] = seg_size;
+                i++;
+                seg_size = 0;
+              }
+              // increment counters
+              seg_size++;
               vct++;
-            }
-            else {
-              vct++;
+              
+              // if this is the last value in the iterator, assign the value in order to set last offset
+              if (!int_reader->HasNext()){
+                offsets[i] = seg_size;
+              }
             }
           }
         } else if(lty == ARROWINT32 || lty == ARROWUINT32) {
@@ -327,13 +343,28 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
             int32_t value;
             
             (void)int_reader->ReadBatch(1, &definition_level, &rep_lvl, &value, &values_read);
-            if (rep_lvl == 0 && vct >0) {
-              i++;
-              offsets[i] = vct;
+            if (values_read == 0){ // empty segment
+              if (!int_reader->HasNext()){ // last value 
+                offsets[i] = seg_size;
+              }
+              else {
+                i++;
+              }
+            } else {
+              // new segment starts. This has to be before increment to avoid false empty on first segment.
+              if (rep_lvl == 0 && seg_size >0) {
+                offsets[i] = seg_size;
+                i++;
+                seg_size = 0;
+              }
+              // increment counters
+              seg_size++;
               vct++;
-            }
-            else {
-              vct++;
+              
+              // if this is the last value in the iterator, assign the value in order to set last offset
+              if (!int_reader->HasNext()){
+                offsets[i] = seg_size;
+              }
             }
           }
         } else if(lty == ARROWBOOLEAN) {
@@ -343,13 +374,28 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
           while (bool_reader->HasNext()) {
             bool value;
             (void)bool_reader->ReadBatch(1, &definition_level, &rep_lvl, &value, &values_read);
-            if (rep_lvl == 0 && vct >0) {
-              i++;
-              offsets[i] = vct;
+            if (values_read == 0){ // empty segment
+              if (!bool_reader->HasNext()){ // last value 
+                offsets[i] = seg_size;
+              }
+              else {
+                i++;
+              }
+            } else {
+              // new segment starts. This has to be before increment to avoid false empty on first segment.
+              if (rep_lvl == 0 && seg_size >0) {
+                offsets[i] = seg_size;
+                i++;
+                seg_size = 0;
+              }
+              // increment counters
+              seg_size++;
               vct++;
-            }
-            else {
-              vct++;
+              
+              // if this is the last value in the iterator, assign the value in order to set last offset
+              if (!bool_reader->HasNext()){
+                offsets[i] = seg_size;
+              }
             }
           }
         } else if (lty == ARROWFLOAT) {
@@ -362,13 +408,28 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
             
             (void)float_reader->ReadBatch(1, &definition_level, &rep_lvl, &value, &values_read);
             // not worried about NaN here so don't need to check values read.
-            if (rep_lvl == 0 && vct >0) {
-              i++;
-              offsets[i] = vct;
+            if (values_read == 0){ // empty segment
+              if (!float_reader->HasNext()){ // last value 
+                offsets[i] = seg_size;
+              }
+              else {
+                i++;
+              }
+            } else {
+              // new segment starts. This has to be before increment to avoid false empty on first segment.
+              if (rep_lvl == 0 && seg_size >0) {
+                offsets[i] = seg_size;
+                i++;
+                seg_size = 0;
+              }
+              // increment counters
+              seg_size++;
               vct++;
-            }
-            else {
-              vct++;
+              
+              // if this is the last value in the iterator, assign the value in order to set last offset
+              if (!float_reader->HasNext()){
+                offsets[i] = seg_size;
+              }
             }
           }
         } else if(lty == ARROWDOUBLE) {
@@ -380,13 +441,28 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
             
             (void)dbl_reader->ReadBatch(1, &definition_level, &rep_lvl, &value, &values_read);
             // not worried about NaN here so don't need to check values read.
-            if (rep_lvl == 0 && vct >0) {
-              i++;
-              offsets[i] = vct;
+            if (values_read == 0){ // empty segment
+              if (!dbl_reader->HasNext()){ // last value 
+                offsets[i] = seg_size;
+              }
+              else {
+                i++;
+              }
+            } else {
+              // new segment starts. This has to be before increment to avoid false empty on first segment.
+              if (rep_lvl == 0 && seg_size >0) {
+                offsets[i] = seg_size;
+                i++;
+                seg_size = 0;
+              }
+              // increment counters
+              seg_size++;
               vct++;
-            }
-            else {
-              vct++;
+              
+              // if this is the last value in the iterator, assign the value in order to set last offset
+              if (!dbl_reader->HasNext()){
+                offsets[i] = seg_size;
+              }
             }
           }
         }
@@ -456,6 +532,7 @@ int64_t cpp_getStringColumnNullIndices(const char* filename, const char* colname
 
 int cpp_readListColumnByName(const char* filename, void* chpl_arr, const char* colname, int64_t numElems, int64_t startIdx, int64_t batchSize, char** errMsg) {
   try {
+    std::cout << "\n\nStartIdx: " << startIdx << "NumElems" << numElems << "\n\n";
     int64_t ty = cpp_getType(filename, colname, errMsg);
     if (ty == ARROWLIST){
       int64_t lty = cpp_getListType(filename, colname, errMsg);

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -182,7 +182,6 @@ module ParquetMsg {
     extern proc c_readListColumnByName(filename, chpl_arr, colNum, numElems, startIdx, batchSize, errMsg): int;
     var (subdoms, length) = getSubdomains(sizes);
     var fileOffsets = (+ scan sizes) - sizes;
-    writeln("\n\nFilenames: %jt\nSizes: %jt".format(filenames, sizes));
     
     coforall loc in A.targetLocales() do on loc {
       var locFiles = filenames;
@@ -193,7 +192,6 @@ module ParquetMsg {
         forall (off, filedom, filename) in zip(locOffsets, locFiledoms, locFiles) {
           for locdom in A.localSubdomains() {
             const intersection = domain_intersection(locdom, filedom);
-            writeln("\n\nFileDom: %jt\nLocDom: %jt\nIntersection: %jt\nOffset: %i".format(filedom, locdom, intersection, off));
 
             if intersection.size > 0 {
               var pqErr = new parquetErrorMsg();
@@ -203,7 +201,6 @@ module ParquetMsg {
                                     batchSize, c_ptrTo(pqErr.errMsg)) == ARROWERROR {
                 pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
               }
-              // A[intersection] = col;
             }
           }
         }
@@ -331,11 +328,8 @@ module ParquetMsg {
     extern proc c_getNumRows(chpl_str, errMsg): int;
     var pqErr = new parquetErrorMsg();
 
-    
-    
     var size = c_getNumRows(filename.localize().c_str(),
                             c_ptrTo(pqErr.errMsg));
-    writeln("\n\nFile %s has %i rows".format(filename, size));
     if size == ARROWERROR {
       pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
     }
@@ -652,9 +646,7 @@ module ParquetMsg {
     var filedom = filenames.domain;
     var segments = makeDistArray(len, int);
     var listSizes: [filedom] int = calcListSizesandOffset(segments, filenames, sizes, dsetname);
-    writeln("Segments-PRE: %jt".format(segments));
     segments = (+ scan segments) - segments;
-    writeln("Segments: %jt".format(segments));
     var rtnmap: map(string, string) = new map(string, string);
 
     if ty == ArrowTypes.int64 || ty == ArrowTypes.int32 {

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -193,14 +193,14 @@ module ParquetMsg {
 
             if intersection.size > 0 {
               var pqErr = new parquetErrorMsg();
-              var col: [filedom] t;
+              var col: [intersection] t;
 
               if c_readListColumnByName(filename.localize().c_str(), c_ptrTo(col),
-                                    dsetname.localize().c_str(), intersection.size, 0,
+                                    dsetname.localize().c_str(), intersection.size, intersection.low,
                                     batchSize, c_ptrTo(pqErr.errMsg)) == ARROWERROR {
                 pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
               }
-              A[filedom] = col;
+              A[locdom] = col;
             }
           }
         }

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -181,26 +181,29 @@ module ParquetMsg {
   proc readListFilesByName(A: [] ?t, filenames: [] string, sizes: [] int, dsetname: string, ty) throws {
     extern proc c_readListColumnByName(filename, chpl_arr, colNum, numElems, startIdx, batchSize, errMsg): int;
     var (subdoms, length) = getSubdomains(sizes);
+    var fileOffsets = (+ scan sizes) - sizes;
+    writeln("\n\nFilenames: %jt\nSizes: %jt".format(filenames, sizes));
     
     coforall loc in A.targetLocales() do on loc {
       var locFiles = filenames;
       var locFiledoms = subdoms;
+      var locOffsets = fileOffsets;
 
       try {
-        forall (filedom, filename) in zip(locFiledoms, locFiles) {
+        forall (off, filedom, filename) in zip(locOffsets, locFiledoms, locFiles) {
           for locdom in A.localSubdomains() {
             const intersection = domain_intersection(locdom, filedom);
+            writeln("\n\nFileDom: %jt\nLocDom: %jt\nIntersection: %jt\nOffset: %i".format(filedom, locdom, intersection, off));
 
             if intersection.size > 0 {
               var pqErr = new parquetErrorMsg();
-              var col: [intersection] t;
 
-              if c_readListColumnByName(filename.localize().c_str(), c_ptrTo(col),
-                                    dsetname.localize().c_str(), intersection.size, intersection.low,
+              if c_readListColumnByName(filename.localize().c_str(), c_ptrTo(A[intersection.low]),
+                                    dsetname.localize().c_str(), intersection.size, intersection.low - off,
                                     batchSize, c_ptrTo(pqErr.errMsg)) == ARROWERROR {
                 pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
               }
-              A[locdom] = col;
+              // A[intersection] = col;
             }
           }
         }
@@ -214,7 +217,8 @@ module ParquetMsg {
     var (subdoms, length) = getSubdomains(sizes);
 
     var listSizes: [filenames.domain] int;
-    coforall loc in offsets.targetLocales() do on loc {
+    var file_offset: int = 0;
+    coforall loc in offsets.targetLocales() do on loc{
       var locFiles = filenames;
       var locFiledoms = subdoms;
       
@@ -326,9 +330,12 @@ module ParquetMsg {
   proc getArrSize(filename: string) throws {
     extern proc c_getNumRows(chpl_str, errMsg): int;
     var pqErr = new parquetErrorMsg();
+
+    
     
     var size = c_getNumRows(filename.localize().c_str(),
                             c_ptrTo(pqErr.errMsg));
+    writeln("\n\nFile %s has %i rows".format(filename, size));
     if size == ARROWERROR {
       pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
     }
@@ -645,6 +652,9 @@ module ParquetMsg {
     var filedom = filenames.domain;
     var segments = makeDistArray(len, int);
     var listSizes: [filedom] int = calcListSizesandOffset(segments, filenames, sizes, dsetname);
+    writeln("Segments-PRE: %jt".format(segments));
+    segments = (+ scan segments) - segments;
+    writeln("Segments: %jt".format(segments));
     var rtnmap: map(string, string) = new map(string, string);
 
     if ty == ArrowTypes.int64 || ty == ArrowTypes.int32 {


### PR DESCRIPTION
Closes #2141 

Corrects read indexing to account for distributed or singular files. Adds test case for distributed files.

*Commented out code in test is needed for #2145, which I will be working next. On that same note, this implementation is not fully functional for SegArrays containing empty segments being read.*