### PR TITLE
Closes #1987 - Updates AutoAPI Documentation

### DIFF
--- a/arkouda/accessor.py
+++ b/arkouda/accessor.py
@@ -2,6 +2,15 @@ from arkouda.categorical import Categorical
 from arkouda.strings import Strings
 from arkouda.timeclass import Datetime
 
+__all__ = [
+    "CachedAccessor",
+    "DatetimeAccessor",
+    "StringAccessor",
+    "Properties",
+    "string_operators",
+    "date_operators",
+]
+
 
 class CachedAccessor:
     """
@@ -64,7 +73,6 @@ class Properties:
 @date_operators
 class DatetimeAccessor(Properties):
     def __init__(self, series):
-
         data = series.values
         if not isinstance(data, Datetime):
             raise AttributeError("Can only use .dt accessor with datetimelike values")
@@ -75,7 +83,6 @@ class DatetimeAccessor(Properties):
 @string_operators
 class StringAccessor(Properties):
     def __init__(self, series):
-
         data = series.values
         if not (isinstance(data, Categorical) or isinstance(data, Strings)):
             raise AttributeError("Can only use .str accessor with string like values")

--- a/arkouda/accessor.py
+++ b/arkouda/accessor.py
@@ -2,15 +2,6 @@ from arkouda.categorical import Categorical
 from arkouda.strings import Strings
 from arkouda.timeclass import Datetime
 
-__all__ = [
-    "CachedAccessor",
-    "DatetimeAccessor",
-    "StringAccessor",
-    "Properties",
-    "string_operators",
-    "date_operators",
-]
-
 
 class CachedAccessor:
     """

--- a/arkouda/array_view.py
+++ b/arkouda/array_view.py
@@ -13,6 +13,8 @@ from arkouda.pdarrayclass import create_pdarray, parse_single_value, pdarray
 from arkouda.pdarraycreation import arange, array, ones, zeros
 from arkouda.pdarraysetops import concatenate
 
+__all__ = ["ArrayView"]
+
 OrderType = Enum("OrderType", ["ROW_MAJOR", "COLUMN_MAJOR"])
 
 
@@ -388,7 +390,7 @@ class ArrayView:
             Indicates the format to save the file. Single will store in a single file.
             Distribute will store the date in a file per locale.
         """
-        from arkouda.io import file_type_to_int, mode_str_to_int
+        from arkouda.io import _file_type_to_int, _mode_str_to_int
 
         generic_msg(
             cmd="tohdf",
@@ -397,9 +399,9 @@ class ArrayView:
                 "shape": self.shape,
                 "order": self.order,
                 "filename": filepath,
-                "file_format": file_type_to_int(file_type),
+                "file_format": _file_type_to_int(file_type),
                 "dset": dset,
-                "write_mode": mode_str_to_int(mode),
+                "write_mode": _mode_str_to_int(mode),
                 "objType": "ArrayView",
             },
         )

--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -1868,6 +1868,7 @@ def broadcast(
 
     Examples
     --------
+    >>>
     # Define a sparse matrix with 3 rows and 7 nonzeros
     >>> row_starts = ak.array([0, 2, 5])
     >>> nnz = 7
@@ -1875,7 +1876,6 @@ def broadcast(
     >>> row_number = ak.arange(3)
     >>> ak.broadcast(row_starts, row_number, nnz)
     array([0 0 1 1 1 2 2])
-
     # If the original nonzeros were in reverse order...
     >>> permutation = ak.arange(6, -1, -1)
     >>> ak.broadcast(row_starts, row_number, permutation=permutation)

--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -1387,11 +1387,9 @@ class GroupBy:
         # By default, result is in original order
         >>> g.broadcast(values)
         array([3, 5, 3, 5, 3])
-
         # With permute=False, result is in grouped order
         >>> g.broadcast(values, permute=False)
         array([3, 3, 3, 5, 5]
-
         >>> a = ak.randint(1,5,10)
         >>> a
         array([3, 1, 4, 4, 4, 1, 3, 3, 2, 2])

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -758,7 +758,7 @@ def read_csv(
     - Be sure that column delimiters are not found within your data.
     - All CSV files must delimit rows using newline (``\\n``) at this time.
     - Unlike other file formats, CSV files store Strings as their UTF-8 format instead of storing
-    bytes as uint(8).
+      bytes as uint(8).
     """
     if isinstance(filenames, str):
         filenames = [filenames]
@@ -1191,7 +1191,7 @@ def to_csv(
     - Be sure that column delimiters are not found within your data.
     - All CSV files must delimit rows using newline (``\\n``) at this time.
     - Unlike other file formats, CSV files store Strings as their UTF-8 format instead of storing
-    bytes as uint(8).
+      bytes as uint(8).
     """
     datasetNames, pdarrays = _bulk_write_prep(columns, names)
     dtypes = [a.dtype.name for a in pdarrays]

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -33,8 +33,6 @@ __all__ = [
     "save_all",
     "load",
     "load_all",
-    "file_type_to_int",
-    "mode_str_to_int",
 ]
 
 ARKOUDA_HDF5_FILE_METADATA_GROUP = "_arkouda_metadata"
@@ -174,7 +172,7 @@ def get_null_indices(
 
 
 @typechecked
-def file_type_to_int(file_type: str) -> int:
+def _file_type_to_int(file_type: str) -> int:
     """
     Convert a string to integer representing the format to save the file in
 
@@ -190,7 +188,7 @@ def file_type_to_int(file_type: str) -> int:
     Raises
     ------
     ValueError
-        - If mode is not 'single' or 'distribute'
+        If mode is not 'single' or 'distribute'
     """
     if file_type.lower() == "single":
         return 0
@@ -201,7 +199,7 @@ def file_type_to_int(file_type: str) -> int:
 
 
 @typechecked
-def mode_str_to_int(mode: str) -> int:
+def _mode_str_to_int(mode: str) -> int:
     """
     Convert string to integer representing the mode to write
 
@@ -217,7 +215,7 @@ def mode_str_to_int(mode: str) -> int:
     Raises
     ------
     ValueError
-        - If mode is not 'truncate' or 'append'
+        If mode is not 'truncate' or 'append'
     """
     if mode.lower() == "truncate":
         return 0
@@ -552,9 +550,10 @@ def read_hdf(
 
     Examples
     --------
-    Read with file Extension
+    >>>
+    # Read with file Extension
     >>> x = ak.read_hdf('path/name_prefix.h5') # load HDF5
-    Read Glob Expression
+    # Read Glob Expression
     >>> x = ak.read_hdf('path/name_prefix*') # Reads HDF5
     """
     if isinstance(filenames, str):
@@ -606,69 +605,69 @@ def read_parquet(
     """
     Read Arkouda objects from Parquet file/s
 
-        Parameters
-        ----------
-        filenames : str, List[str]
-            Filename/s to read objects from
-        datasets : Optional str, List[str]
-            datasets to read from the provided files
-        iterative : bool
-            Iterative (True) or Single (False) function call(s) to server
-        strict_types: bool
-            If True (default), require all dtypes of a given dataset to have the
-            same precision and sign. If False, allow dtypes of different
-            precision and sign across different files. For example, if one
-            file contains a uint32 dataset and another contains an int64
-            dataset with the same name, the contents of both will be read
-            into an int64 pdarray.
-        allow_errors: bool
-            Default False, if True will allow files with read errors to be skipped
-            instead of failing.  A warning will be included in the return containing
-            the total number of files skipped due to failure and up to 10 filenames.
+    Parameters
+    ----------
+    filenames : str, List[str]
+        Filename/s to read objects from
+    datasets : Optional str, List[str]
+        datasets to read from the provided files
+    iterative : bool
+        Iterative (True) or Single (False) function call(s) to server
+    strict_types: bool
+        If True (default), require all dtypes of a given dataset to have the
+        same precision and sign. If False, allow dtypes of different
+        precision and sign across different files. For example, if one
+        file contains a uint32 dataset and another contains an int64
+        dataset with the same name, the contents of both will be read
+        into an int64 pdarray.
+    allow_errors: bool
+        Default False, if True will allow files with read errors to be skipped
+        instead of failing.  A warning will be included in the return containing
+        the total number of files skipped due to failure and up to 10 filenames.
 
-        Returns
-        -------
-        For a single dataset returns an Arkouda pdarray, Arkouda Strings, or Arkouda ArrayView object
-        and for multiple datasets returns a dictionary of Arkouda pdarrays,
-        Arkouda Strings or Arkouda ArrayView.
-            Dictionary of {datasetName: pdarray or String}
+    Returns
+    -------
+    For a single dataset returns an Arkouda pdarray, Arkouda Strings, or Arkouda ArrayView object
+    and for multiple datasets returns a dictionary of Arkouda pdarrays,
+    Arkouda Strings or Arkouda ArrayView.
+        Dictionary of {datasetName: pdarray or String}
 
-        Raises
-        ------
-        ValueError
-            Raised if all datasets are not present in all parquet files or if one or
-            more of the specified files do not exist
-        RuntimeError
-            Raised if one or more of the specified files cannot be opened.
-            If `allow_errors` is true this may be raised if no values are returned
-            from the server.
-        TypeError
-            Raised if we receive an unknown arkouda_type returned from the server
+    Raises
+    ------
+    ValueError
+        Raised if all datasets are not present in all parquet files or if one or
+        more of the specified files do not exist
+    RuntimeError
+        Raised if one or more of the specified files cannot be opened.
+        If `allow_errors` is true this may be raised if no values are returned
+        from the server.
+    TypeError
+        Raised if we receive an unknown arkouda_type returned from the server
 
-        Notes
-        -----
-        If filenames is a string, it is interpreted as a shell expression
-        (a single filename is a valid expression, so it will work) and is
-        expanded with glob to read all matching files.
+    Notes
+    -----
+    If filenames is a string, it is interpreted as a shell expression
+    (a single filename is a valid expression, so it will work) and is
+    expanded with glob to read all matching files.
 
-        If iterative == True each dataset name and file names are passed to
-        the server as independent sequential strings while if iterative == False
-        all dataset names and file names are passed to the server in a single
-        string.
+    If iterative == True each dataset name and file names are passed to
+    the server as independent sequential strings while if iterative == False
+    all dataset names and file names are passed to the server in a single
+    string.
 
-        If datasets is None, infer the names of datasets from the first file
-        and read all of them. Use ``get_datasets`` to show the names of datasets
-        to Parquet files.
+    If datasets is None, infer the names of datasets from the first file
+    and read all of them. Use ``get_datasets`` to show the names of datasets
+    to Parquet files.
 
-        Parquet always recomputes offsets at this time
-        This will need to be updated once parquets workflow is updated
+    Parquet always recomputes offsets at this time
+    This will need to be updated once parquets workflow is updated
 
-        Examples
-        --------
-        Read without file Extension
-        >>> x = ak.read_parquet('path/name_prefix.parquet') # load Parquet
-        Read Glob Expression
-        >>> x = ak.read_parquet('path/name_prefix*') # Reads Parquet
+    Examples
+    --------
+    Read without file Extension
+    >>> x = ak.read_parquet('path/name_prefix.parquet') # load Parquet
+    Read Glob Expression
+    >>> x = ak.read_parquet('path/name_prefix*') # Reads Parquet
     """
     if isinstance(filenames, str):
         filenames = [filenames]
@@ -757,7 +756,7 @@ def read_csv(
     - CSV format is not currently supported by load/load_all operations
     - The column delimiter is expected to be the same for column names and data
     - Be sure that column delimiters are not found within your data.
-    - All CSV files must delimit rows using newline (`\n`) at this time.
+    - All CSV files must delimit rows using newline (``\\n``) at this time.
     - Unlike other file formats, CSV files store Strings as their UTF-8 format instead of storing
     bytes as uint(8).
     """
@@ -904,9 +903,9 @@ def export(
     Notes
     _____
     - If Arkouda file is exported for pandas, the format will not change. This mean parquet files
-    will remain parquet and hdf5 will remain hdf5.
+      will remain parquet and hdf5 will remain hdf5.
     - Export can only be performed from hdf5 or parquet files written by Arkouda. The result will be
-    the same file type, but formatted to be read by Pandas.
+      the same file type, but formatted to be read by Pandas.
     """
     from arkouda.dataframe import DataFrame
 
@@ -1190,7 +1189,7 @@ def to_csv(
     - CSV format is not currently supported by load/load_all operations
     - The column delimiter is expected to be the same for column names and data
     - Be sure that column delimiters are not found within your data.
-    - All CSV files must delimit rows using newline (`\n`) at this time.
+    - All CSV files must delimit rows using newline (``\\n``) at this time.
     - Unlike other file formats, CSV files store Strings as their UTF-8 format instead of storing
     bytes as uint(8).
     """

--- a/arkouda/join.py
+++ b/arkouda/join.py
@@ -14,7 +14,7 @@ from arkouda.pdarrayclass import create_pdarray, pdarray
 from arkouda.pdarraycreation import arange, array, ones, zeros
 from arkouda.pdarraysetops import concatenate, in1d
 
-__all__ = ["join_on_eq_with_dt"]
+__all__ = ["join_on_eq_with_dt", "gen_ranges", "compute_join_size"]
 
 predicates = {"true_dt": 0, "abs_dt": 1, "pos_dt": 2}
 
@@ -41,7 +41,7 @@ def join_on_eq_with_dt(
         pdarray to be joined
     t1 : pdarray
         timestamps in millis corresponding to the a1 pdarray
-    t2 : pdarray,
+    t2 : pdarray
         timestamps in millis corresponding to the a2 pdarray
     dt : Union[int,np.int64]
         time delta
@@ -117,7 +117,8 @@ def join_on_eq_with_dt(
 
 @typechecked
 def gen_ranges(starts: pdarray, ends: pdarray) -> Tuple[pdarray, pdarray]:
-    """Generate a segmented array of variable-length, contiguous
+    """
+    Generate a segmented array of variable-length, contiguous
     ranges between pairs of start- and end-points.
 
     Parameters
@@ -151,7 +152,8 @@ def gen_ranges(starts: pdarray, ends: pdarray) -> Tuple[pdarray, pdarray]:
 
 @typechecked
 def compute_join_size(a: pdarray, b: pdarray) -> Tuple[int, int]:
-    """Compute the internal size of a hypothetical join between a and b. Returns
+    """
+    Compute the internal size of a hypothetical join between a and b. Returns
     both the number of elements and number of bytes required for the join.
     """
     bya = GroupBy(a)

--- a/arkouda/match.py
+++ b/arkouda/match.py
@@ -5,6 +5,8 @@ from typing import cast
 from arkouda.client import generic_msg
 from arkouda.pdarrayclass import create_pdarray, pdarray
 
+__all__ = ["Match"]
+
 MatchType = Enum("MatchType", ["SEARCH", "MATCH", "FULLMATCH"])
 
 

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1398,7 +1398,7 @@ class pdarray:
         Saves the array to numLocales HDF5 files with the name
         ``cwd/path/name_prefix_LOCALE####.parquet`` where #### is replaced by each locale number
         """
-        from arkouda.io import mode_str_to_int
+        from arkouda.io import _mode_str_to_int
 
         return cast(
             str,
@@ -1407,7 +1407,7 @@ class pdarray:
                 args={
                     "values": self,
                     "dset": dataset,
-                    "mode": mode_str_to_int(mode),
+                    "mode": _mode_str_to_int(mode),
                     "prefix": prefix_path,
                     "dtype": self.dtype,
                     "compression": compression,
@@ -1475,7 +1475,7 @@ class pdarray:
         Saves the array in to single hdf5 file on the root node.
         ``cwd/path/name_prefix.hdf5``
         """
-        from arkouda.io import file_type_to_int, mode_str_to_int
+        from arkouda.io import _file_type_to_int, _mode_str_to_int
 
         return cast(
             str,
@@ -1484,11 +1484,11 @@ class pdarray:
                 args={
                     "values": self,
                     "dset": dataset,
-                    "write_mode": mode_str_to_int(mode),
+                    "write_mode": _mode_str_to_int(mode),
                     "filename": prefix_path,
                     "dtype": self.dtype,
                     "objType": "pdarray",
-                    "file_format": file_type_to_int(file_type),
+                    "file_format": _file_type_to_int(file_type),
                 },
             ),
         )

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -158,10 +158,14 @@ def in1d(
         to (but is faster than) ``~ak.in1d(a, b)``.
     Returns
     -------
-    pdarray, bool
         True for each row in a that is contained in b
 
-    Notes:
+    Return Type
+    ------------
+        pdarray, bool
+
+    Notes
+    ------
         Only works for pdarrays of int64 dtype, Strings, or Categorical
     """
     from arkouda.alignment import NonUniqueError
@@ -414,10 +418,10 @@ def union1d(
 
     Examples
     --------
+    >>>
     # 1D Example
     >>> ak.union1d(ak.array([-1, 0, 1]), ak.array([-2, 0, 2]))
     array([-2, -1, 0, 1, 2])
-
     #Multi-Array Example
     >>> a = ak.arange(1, 6)
     >>> b = ak.array([1, 5, 3, 4, 2])
@@ -505,10 +509,10 @@ def intersect1d(
 
     Examples
     --------
+    >>>
     # 1D Example
     >>> ak.intersect1d([1, 3, 4, 3], [3, 1, 2, 1])
     array([1, 3])
-
     # Multi-Array Example
     >>> a = ak.arange(5)
     >>> b = ak.array([1, 5, 3, 4, 2])
@@ -621,7 +625,6 @@ def setdiff1d(
     >>> b = ak.array([3, 4, 5, 6])
     >>> ak.setdiff1d(a, b)
     array([1, 2])
-
     #Multi-Array Example
     >>> a = ak.arange(1, 6)
     >>> b = ak.array([1, 5, 3, 4, 2])
@@ -730,7 +733,6 @@ def setxor1d(pda1: groupable, pda2: groupable, assume_unique: bool = False) -> U
     >>> b = ak.array([2, 3, 5, 7, 5])
     >>> ak.setxor1d(a,b)
     array([1, 4, 5, 7])
-
     #Multi-Array Example
     >>> a = ak.arange(1, 6)
     >>> b = ak.array([1, 5, 3, 4, 2])

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -64,7 +64,7 @@ def _in1d_single(
 
     See Also
     --------
-    unique, intersect1d, union1d
+    arkouda.groupbyclass.unique, intersect1d, union1d
 
     Notes
     -----
@@ -410,7 +410,7 @@ def union1d(
 
     See Also
     --------
-    intersect1d, unique
+    intersect1d, arkouda.groupbyclass.unique
 
     Notes
     -----
@@ -501,7 +501,7 @@ def intersect1d(
 
     See Also
     --------
-    unique, union1d
+    arkouda.groupbyclass.unique, union1d
 
     Notes
     -----
@@ -613,7 +613,7 @@ def setdiff1d(
 
     See Also
     --------
-    unique, setxor1d
+    arkouda.groupbyclass.unique, setxor1d
 
     Notes
     -----

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -27,11 +27,11 @@ def gen_ranges(starts, ends, stride=1):
     Parameters
     ----------
     starts : pdarray, int64
-    The start value of each range
+        The start value of each range
     ends : pdarray, int64
-    The end value (exclusive) of each range
+        The end value (exclusive) of each range
     stride: int
-    Difference between successive elements of each range
+        Difference between successive elements of each range
 
     Returns
     -------

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -36,9 +36,9 @@ def gen_ranges(starts, ends, stride=1):
     Returns
     -------
     segments : pdarray, int64
-    The starting index of each range in the resulting array
+        The starting index of each range in the resulting array
     ranges : pdarray, int64
-    The actual ranges, flattened into a single array
+        The actual ranges, flattened into a single array
     """
     if starts.size != ends.size:
         raise ValueError("starts and ends must be same length")

--- a/arkouda/sorting.py
+++ b/arkouda/sorting.py
@@ -13,7 +13,7 @@ from arkouda.strings import Strings
 
 numeric_dtypes = {int64, uint64, float64}
 
-__all__ = ["argsort", "coargsort", "sort", "SortingAlgorithm"]
+__all__ = ["argsort", "coargsort", "sort"]
 
 SortingAlgorithm = Enum("SortingAlgorithm", ["RadixSortLSD", "TwoArrayRadixSort"])
 

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1995,25 +1995,25 @@ class Strings:
         -----
         - Parquet files do not store the segments, only the values.
         - Strings state is saved as two datasets within an hdf5 group:
-        one for the string characters and one for the
-        segments corresponding to the start of each string
+          one for the string characters and one for the
+          segments corresponding to the start of each string
         - the hdf5 group is named via the dataset parameter.
         - The prefix_path must be visible to the arkouda server and the user must
-        have write permission.
+          have write permission.
         - Output files have names of the form ``<prefix_path>_LOCALE<i>``, where ``<i>``
-        ranges from 0 to ``numLocales`` for `file_type='distribute'`. Otherwise,
-        the file name will be `prefix_path`.
+          ranges from 0 to ``numLocales`` for `file_type='distribute'`. Otherwise,
+          the file name will be `prefix_path`.
         - If any of the output files already exist and
-        the mode is 'truncate', they will be overwritten. If the mode is 'append'
-        and the number of output files is less than the number of locales or a
-        dataset with the same name already exists, a ``RuntimeError`` will result.
+          the mode is 'truncate', they will be overwritten. If the mode is 'append'
+          and the number of output files is less than the number of locales or a
+          dataset with the same name already exists, a ``RuntimeError`` will result.
         - Any file extension can be used.The file I/O does not rely on the extension to
-        determine the file format.
+          determine the file format.
         See Also
         ---------
         to_hdf
         """
-        from arkouda.io import file_type_to_int, mode_str_to_int
+        from arkouda.io import _file_type_to_int, _mode_str_to_int
 
         return cast(
             str,
@@ -2022,12 +2022,12 @@ class Strings:
                 {
                     "values": self.entry,
                     "dset": dataset,
-                    "write_mode": mode_str_to_int(mode),
+                    "write_mode": _mode_str_to_int(mode),
                     "filename": prefix_path,
                     "dtype": self.dtype,
                     "save_offsets": save_offsets,
                     "objType": "strings",
-                    "file_format": file_type_to_int(file_type),
+                    "file_format": _file_type_to_int(file_type),
                 },
             ),
         )
@@ -2081,7 +2081,7 @@ class Strings:
         - CSV format is not currently supported by load/load_all operations
         - The column delimiter is expected to be the same for column names and data
         - Be sure that column delimiters are not found within your data.
-        - All CSV files must delimit rows using newline (`\n`) at this time.
+        - All CSV files must delimit rows using newline (``\\n``) at this time.
         """
         return cast(
             str,

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1936,7 +1936,7 @@ class Strings:
         - Any file extension can be used.The file I/O does not rely on the extension to
         determine the file format.
         """
-        from arkouda.io import mode_str_to_int
+        from arkouda.io import _mode_str_to_int
 
         return cast(
             str,
@@ -1945,7 +1945,7 @@ class Strings:
                 {
                     "values": self.entry,
                     "dset": dataset,
-                    "mode": mode_str_to_int(mode),
+                    "mode": _mode_str_to_int(mode),
                     "prefix": prefix_path,
                     "dtype": self.dtype,
                     "compression": compression,

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -659,7 +659,8 @@ class Strings:
 
         Parameters
         ----------
-        chars : the set of characters to be removed
+        chars
+            the set of characters to be removed
 
         Returns
         -------

--- a/benchmarks/sort-cases.py
+++ b/benchmarks/sort-cases.py
@@ -6,6 +6,7 @@ import time
 import numpy as np
 
 import arkouda as ak
+from arkouda.sorting import SortingAlgorithm
 
 
 def is_cosorted(data):
@@ -53,7 +54,7 @@ def check_correctness(data):
     """
     Only check accuracy of sorting, do not measure performance
     """
-    for algo in ak.SortingAlgorithm:
+    for algo in SortingAlgorithm:
         perm = do_argsort(data, algo)
         s = apply_perm(data, perm)
         assert check_sorted(s)
@@ -63,7 +64,7 @@ def time_sort(name, data, trials):
     """
     Measure both performance and correctness of sorting
     """
-    for algo in ak.SortingAlgorithm:
+    for algo in SortingAlgorithm:
         timings = []
         for i in range(trials):
             start = time.time()

--- a/pydoc/conf.py
+++ b/pydoc/conf.py
@@ -49,6 +49,11 @@ myst_enable_extensions = ["deflist", "linkify"]
 # path to directory containing files to autogenerate docs from comments
 autoapi_dirs = ['../arkouda']
 
+autoapi_options = ['members', 'undoc-members', 'show-inheritance', 'show-module-summary', 'imported-members', ]
+
+# do not create api reference for
+autoapi_ignore = ['*migrations*', "*_version.py", "*decorators.py", "*message.py"]
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/tests/coargsort_test.py
+++ b/tests/coargsort_test.py
@@ -4,6 +4,7 @@ import argparse
 
 from base_test import ArkoudaTest
 from context import arkouda as ak
+from arkouda.sorting import SortingAlgorithm
 
 
 def check_integral(N, algo, dtype):
@@ -124,7 +125,7 @@ def check_coargsort(N_per_locale):
     N = N_per_locale * cfg["numLocales"]
     print("numLocales = {}, N = {:,}".format(cfg["numLocales"], N))
 
-    for algo in ak.SortingAlgorithm:
+    for algo in SortingAlgorithm:
         check_integral(N, algo, ak.int64)
         check_integral(N, algo, ak.uint64)
         check_float(N, algo)
@@ -134,34 +135,34 @@ def check_coargsort(N_per_locale):
 
 class CoargsortTest(ArkoudaTest):
     def test_int(self):
-        for algo in ak.SortingAlgorithm:
+        for algo in SortingAlgorithm:
             check_integral(10**3, algo, ak.int64)
 
     def test_uint(self):
-        for algo in ak.SortingAlgorithm:
+        for algo in SortingAlgorithm:
             check_integral(10**3, algo, ak.uint64)
 
     def test_float(self):
-        for algo in ak.SortingAlgorithm:
+        for algo in SortingAlgorithm:
             check_float(10**3, algo)
 
     def test_int_uint_float_bigint(self):
-        for algo in ak.SortingAlgorithm:
+        for algo in SortingAlgorithm:
             check_int_uint_float_bigint(10**3, algo)
 
     def test_large(self):
-        for algo in ak.SortingAlgorithm:
+        for algo in SortingAlgorithm:
             check_large(10**3, algo)
 
     def test_error_handling(self):
         ones = ak.ones(100)
         short_ones = ak.ones(10)
 
-        for algo in ak.SortingAlgorithm:
+        for algo in SortingAlgorithm:
             with self.assertRaises(ValueError):
                 ak.coargsort([ones, short_ones], algo)
 
-        for algo in ak.SortingAlgorithm:
+        for algo in SortingAlgorithm:
             with self.assertRaises(TypeError):
                 ak.coargsort([list(range(0, 10)), [0]], algo)
 
@@ -171,7 +172,7 @@ class CoargsortTest(ArkoudaTest):
         cat_from_codes = ak.Categorical.from_codes(
             codes=ak.array([0, 1, 0, 1, 2]), categories=ak.array(["a", "b", "c"])
         )
-        for algo in ak.SortingAlgorithm:
+        for algo in SortingAlgorithm:
             # coargsort on categorical
             # coargsort sorts using codes, the order isn't guaranteed, only grouping
             cat_perm = ak.coargsort([cat], algo)

--- a/tests/sort_test.py
+++ b/tests/sort_test.py
@@ -1,5 +1,6 @@
 from base_test import ArkoudaTest
 from context import arkouda as ak
+from arkouda.sorting import SortingAlgorithm
 
 """
 Encapsulates test cases that test sort functionality
@@ -9,18 +10,18 @@ Encapsulates test cases that test sort functionality
 class SortTest(ArkoudaTest):
     def testSort(self):
         pda = ak.randint(0, 100, 100)
-        for algo in ak.SortingAlgorithm:
+        for algo in SortingAlgorithm:
             spda = ak.sort(pda, algo)
             maxIndex = spda.argmax()
             self.assertTrue(maxIndex > 0)
 
         pda = ak.randint(0, 100, 100, dtype=ak.uint64)
-        for algo in ak.SortingAlgorithm:
+        for algo in SortingAlgorithm:
             spda = ak.sort(pda, algo)
             self.assertTrue(ak.is_sorted(spda))
 
         shift_up = pda + 2**200
-        for algo in ak.SortingAlgorithm:
+        for algo in SortingAlgorithm:
             sorted_pda = ak.sort(pda, algo)
             sorted_bi = ak.sort(shift_up, algo)
             self.assertListEqual((sorted_bi - 2 ** 200).to_list(), sorted_pda.to_list())
@@ -31,7 +32,7 @@ class SortTest(ArkoudaTest):
         a = ak.array([1, -1, 32767])  # 16 bit
         b = ak.array([1, 0, 32768])  # 16 bit
         c = ak.array([1, -1, 32768])  # 17 bit
-        for algo in ak.SortingAlgorithm:
+        for algo in SortingAlgorithm:
             assert ak.is_sorted(ak.sort(a, algo))
             assert ak.is_sorted(ak.sort(b, algo))
             assert ak.is_sorted(ak.sort(c, algo))
@@ -40,7 +41,7 @@ class SortTest(ArkoudaTest):
         d = ak.array([1, -1, 2**63 - 1])
         e = ak.array([1, 0, 2**63 - 1])
         f = ak.array([1, -(2**63), 2**63 - 1])
-        for algo in ak.SortingAlgorithm:
+        for algo in SortingAlgorithm:
             assert ak.is_sorted(ak.sort(d, algo))
             assert ak.is_sorted(ak.sort(e, algo))
             assert ak.is_sorted(ak.sort(f, algo))
@@ -51,7 +52,7 @@ class SortTest(ArkoudaTest):
         L = -(2**15)
         U = 2**16
         a = ak.randint(L, U, 100)
-        for algo in ak.SortingAlgorithm:
+        for algo in SortingAlgorithm:
             assert ak.is_sorted(ak.sort(a, algo))
 
     def testErrorHandling(self):
@@ -60,7 +61,7 @@ class SortTest(ArkoudaTest):
         akbools = ak.randint(0, 1, 1000, dtype=ak.bool)
         bools = ak.randint(0, 1, 1000, dtype=bool)
 
-        for algo in ak.SortingAlgorithm:
+        for algo in SortingAlgorithm:
             with self.assertRaises(ValueError):
                 ak.sort(akbools, algo)
 


### PR DESCRIPTION
Closes #1987 

- Updates files to include client facing functions in `__all__` to ensure they are documented. Files where everything is client facing do not require `__all__`.
- Updates some helper functions to prefix with `_`. This does not include all that exist, but this will be an ongoing process.
- Updates formatting of DocStrings to ensure that they render properly in GitHub pages.
- Removes files that do not contain any client facing code from being included in the AutoAPI documentation creation.
  - arkouda/message.py
  - arkouda/_version.py
  - arkouda/decorators.py
- Updates `pydoc/conf.py` to set `autoapi_options` to `['members', 'undoc-members', 'show-inheritance', 'show-module-summary', 'imported-members', ]` as opposed to using the default. This removes `private-members` and `special-members`. This prevents private functions (`_func_name`) from being included in the AutoAPI docs. It also prevents functions like `__len__()` from being rendered in the AutoAPI.

*This PR does not address missing DocStrings. A separate issue will be put in to update missing DocStrings.*
