### PR TITLE
Closes #2150: Update path in IO benchmarks

### DIFF
--- a/benchmarks/IO.py
+++ b/benchmarks/IO.py
@@ -96,8 +96,7 @@ def check_correctness(dtype, path, seed, parquet, multifile=False):
 
     c = ak.read_hdf(path + "*") if not parquet else ak.read_parquet(path + "*")
 
-    for f in glob(path + "*"):
-        os.remove(f)
+    remove_files(path)
     if not multifile:
         assert (a == c).all()
     else:
@@ -123,7 +122,7 @@ def create_parser():
     parser.add_argument(
         "-p",
         "--path",
-        default=os.getcwd() + "ak-io-test",
+        default=os.path.join(os.getcwd(), "ak-io-test"),
         help="Target path for measuring read/write rates",
     )
     parser.add_argument(

--- a/benchmarks/multiIO.py
+++ b/benchmarks/multiIO.py
@@ -29,7 +29,7 @@ def create_parser():
     parser.add_argument(
         "-p",
         "--path",
-        default=os.getcwd() + "ak-io-test",
+        default=os.path.join(os.getcwd(), "ak-io-test"),
         help="Target path for measuring read/write rates",
     )
     parser.add_argument(


### PR DESCRIPTION
This PR (closes #2150):
- Updates default path in IO benchmarks to do `os.path.join(os.getcwd(), "ak-io-test")` instead
- Changes one spot to use `remove_files` helper function