### PR TITLE
2152 enhance memory management logging and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,10 +182,10 @@ Memory tracking is turned on by default now, you can run server with memory trac
 ./arkouda_server --memTrack=false
 ```
 
+For situations where it is desirable to limit the amount of memory allocated to each locale, the `--memMax=$MEM_MAX_IN_BYTES` flag sets the max per-locale memory in bytes. 
+
 By default, the server listens on port `5555`. This value can be overridden with the command-line flag 
 `--ServerPort=1234`
-
-Memory tracking is turned on by default and turned off by using the  `--memTrack=false` flag
 
 Trace logging messages are turned on by default and turned off by using the `--trace=false` flag
 

--- a/src/MetricsMsg.chpl
+++ b/src/MetricsMsg.chpl
@@ -372,12 +372,20 @@ module MetricsMsg {
         return metrics;
     }
 
+
+    proc getMaxLocaleMemory(loc) throws {
+       if memMax:real > 0 {
+           return memMax:real;
+       } else {
+           return loc.physicalMemory():real;
+       }
+    }
     proc getSystemMetrics() throws {
         var metrics = new list(owned Metric?);
 
         for loc in Locales {
             var used = memoryUsed():real;
-            var total = loc.physicalMemory():real;
+            var total = getMaxLocaleMemory(loc);
             
             mLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                               'memoryUsed: %i physicalMemory: %i'.format(used,total));

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -239,11 +239,11 @@ module ServerConfig
 
     /*
     Get the memory limit for this server run
-    returns a percentage of the physical memory per locale
+    returns either the memMax if set or a percentage of the physical memory per locale
     */
     proc getMemLimit():uint {
         if memMax:int > 0 {
-            return memMax:int;
+            return memMax:uint;
         } else {
             return ((perLocaleMemLimit:real / 100.0) * getPhysicalMemHere()):uint; // checks on locale-0
         }

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -242,7 +242,11 @@ module ServerConfig
     returns a percentage of the physical memory per locale
     */
     proc getMemLimit():uint {
-        return ((perLocaleMemLimit:real / 100.0) * getPhysicalMemHere()):uint; // checks on locale-0
+        if memMax:int > 0 {
+            return memMax:int;
+        } else {
+            return ((perLocaleMemLimit:real / 100.0) * getPhysicalMemHere()):uint; // checks on locale-0
+        }
     }
 
     var memHighWater:uint = 0;

--- a/src/ServerDaemon.chpl
+++ b/src/ServerDaemon.chpl
@@ -645,8 +645,11 @@ module ServerDaemon {
                                               "<<< %s took %.17r sec".format(cmd, elapsedTime));
                 }
                 if (trace && memTrack) {
+                    var memUsed = getMemUsed():uint * numLocales:uint;
+                    var pctMemUsed = ((memUsed:real/memMax:real)*100):int;
                     sdLogger.info(getModuleName(),getRoutineName(),getLineNumber(),
-                        "bytes of memory used after command %t".format(getMemUsed():uint * numLocales:uint));
+                        "bytes of memory %t pct of max memory %t used after command".format(memUsed,
+                                                                                            pctMemUsed));
                 }
                 if metricsEnabled() {
                     processMetrics(user, cmd, msgArgs, elapsedTime);

--- a/src/ServerDaemon.chpl
+++ b/src/ServerDaemon.chpl
@@ -648,7 +648,7 @@ module ServerDaemon {
                     var memUsed = getMemUsed():uint * numLocales:uint;
                     var pctMemUsed = ((memUsed:real/memMax:real)*100):int;
                     sdLogger.info(getModuleName(),getRoutineName(),getLineNumber(),
-                        "bytes of memory %t pct of max memory %t used after command".format(memUsed,
+                        "bytes of memory %t pct of max memory %t%% used after command".format(memUsed,
                                                                                             pctMemUsed));
                 }
                 if metricsEnabled() {


### PR DESCRIPTION
Closes #2152 

this PR encompasses the following:

1. Documents in README.md how to set --memMax to set a specific, per-locale memory limit
2. Adds logic to set per-locale memory limit per --memMax or host memory
3. Calculates pct memory used based upon configurable per-locale memory limit
4. Logs memory used and percentage memory used following each command execution