### PR TITLE
Have code avoid using the "single-statement return exception"

### DIFF
--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -1028,7 +1028,9 @@ module ReductionMsg
       */
       var value = if eltType == (bool, int) then (false, 0) else (false, 0:uint);
 
-      proc identity return if eltType == (bool, int) then (false, 0) else (false, 0:uint);
+      proc identity {
+        return if eltType == (bool, int) then (false, 0) else (false, 0:uint);
+      }
 
       proc accumulate(x) {
         // Assume x is an element that has not yet been scanned, and
@@ -1111,7 +1113,9 @@ module ReductionMsg
       */
       var value = if eltType == (bool, int) then (false, 0xffffffffffffffff:int) else (false, 0xffffffffffffffff:uint);
 
-      proc identity return if eltType == (bool, int) then (false, 0xffffffffffffffff:int) else (false, 0xffffffffffffffff:uint);
+      proc identity {
+        return if eltType == (bool, int) then (false, 0xffffffffffffffff:int) else (false, 0xffffffffffffffff:uint);
+      }
 
       proc accumulate(x) {
         // Assume x is an element that has not yet been scanned, and
@@ -1159,7 +1163,7 @@ module ReductionMsg
       // Because XOR has an inverse (itself), this can be
       // done with a scan like segSum
       var res: [D] t;
-      if (D.size == 0) { return res; }
+      if (D.size == 0) {return res; }
       // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
       overMemLimit(numBytes(t) * values.size);
       var cumxor = ^ scan values;

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -1163,7 +1163,7 @@ module ReductionMsg
       // Because XOR has an inverse (itself), this can be
       // done with a scan like segSum
       var res: [D] t;
-      if (D.size == 0) {return res; }
+      if (D.size == 0) { return res; }
       // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
       overMemLimit(numBytes(t) * values.size);
       var cumxor = ^ scan values;


### PR DESCRIPTION
Historically, Chapel has permitted a special case for one-statement procedure bodies that happen to be 'return's.  We are moving away from supporting this exception, so this PR changes the two instances relying on it in Arkouda to use curly brackets instead.
