### PR TITLE
Closes #2156: Bigint stream benchmark

### DIFF
--- a/benchmarks/bigint_bitwise_binops.py
+++ b/benchmarks/bigint_bitwise_binops.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+
+import argparse
+import time
+
+import numpy as np
+
+import arkouda as ak
+
+
+def time_ak_bitwise_binops(N_per_locale, trials, max_bits, seed):
+    print(">>> arkouda bigint bitwise binops")
+    cfg = ak.get_config()
+    N = N_per_locale * cfg["numLocales"]
+    print("numLocales = {}, N = {:,}".format(cfg["numLocales"], N))
+    a1 = ak.randint(0, 2**32, N, dtype=ak.uint64, seed=seed)
+    a2 = ak.randint(0, 2**32, N, dtype=ak.uint64, seed=seed)
+    a = ak.bigint_from_uint_arrays([a1, a2], max_bits=max_bits)
+    b1 = ak.randint(0, 2**32, N, dtype=ak.uint64, seed=seed)
+    b2 = ak.randint(0, 2**32, N, dtype=ak.uint64, seed=seed)
+    b = ak.bigint_from_uint_arrays([b1, b2], max_bits=max_bits)
+
+    # bytes per bigint array (N * 16) since it's made of 2 uint64 arrays
+    tot_bytes = N * 8 * 2
+
+    and_timings = []
+    or_timings = []
+    shift_timings = []
+    for i in range(trials):
+        start = time.time()
+        c = a & b
+        end = time.time()
+        and_timings.append(end - start)
+
+        start = time.time()
+        c = a | b
+        end = time.time()
+        or_timings.append(end - start)
+
+        start = time.time()
+        c = a >> 10
+        end = time.time()
+        shift_timings.append(end - start)
+
+    andtavg = sum(and_timings) / trials
+    ortavg = sum(or_timings) / trials
+    shifttavg = sum(shift_timings) / trials
+
+    print("Average bigint AND time = {:.4f} sec".format(andtavg))
+    bytes_per_sec = (tot_bytes * 2) / andtavg
+    print("Average bigint AND rate = {:.2f} GiB/sec".format(bytes_per_sec / 2**30))
+    print()
+
+    print("Average bigint OR time = {:.4f} sec".format(ortavg))
+    bytes_per_sec = (tot_bytes * 2) / ortavg
+    print("Average bigint OR rate = {:.2f} GiB/sec".format(bytes_per_sec / 2**30))
+    print()
+
+    print("Average bigint SHIFT time = {:.4f} sec".format(shifttavg))
+    bytes_per_sec = tot_bytes / shifttavg
+    print("Average bigint SHIFT rate = {:.2f} GiB/sec".format(bytes_per_sec / 2**30))
+
+
+def check_correctness(max_bits, seed):
+    N = 10**4
+    if seed is not None:
+        np.random.seed(seed)
+    np_a, np_b = np.random.randint(0, 2**32, N), np.random.randint(0, 2**32, N)
+    ak_a = ak.array(np_a, dtype=ak.bigint, max_bits=max_bits)
+    ak_b = ak.array(np_b, dtype=ak.bigint, max_bits=max_bits)
+    np_arrays = [np_a & np_b, np_a | np_b, np_a >> 10]
+    ak_arrays = [ak_a & ak_b, ak_a | ak_b, ak_a >> 10]
+
+    for npc, akc in zip(np_arrays, ak_arrays):
+        np_ans = (npc % (2**max_bits)).astype(np.uint) if max_bits != -1 else npc
+        ak_ans = akc.to_ndarray().astype(np.uint)
+        assert np.all(np_ans == ak_ans)
+
+
+def create_parser():
+    parser = argparse.ArgumentParser(description="Run the bigint bitwise binops benchmarks")
+    parser.add_argument("hostname", help="Hostname of arkouda server")
+    parser.add_argument("port", type=int, help="Port of arkouda server")
+    parser.add_argument(
+        "-n", "--size", type=int, default=10**8, help="Problem size: length of arrays A and B"
+    )
+    parser.add_argument(
+        "-t", "--trials", type=int, default=6, help="Number of times to run the benchmark"
+    )
+    parser.add_argument(
+        "--max-bits",
+        type=int,
+        default=-1,
+        help="Maximum number of bits, so values > 2**max_bits will wraparound. -1 is interpreted as no maximum",
+    )
+    parser.add_argument(
+        "--correctness-only",
+        default=False,
+        action="store_true",
+        help="Only check correctness, not performance.",
+    )
+    parser.add_argument(
+        "-s", "--seed", default=None, type=int, help="Value to initialize random number generator"
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    import sys
+
+    parser = create_parser()
+    args = parser.parse_args()
+    ak.verbose = False
+    ak.connect(server=args.hostname, port=args.port)
+
+    if args.correctness_only:
+        check_correctness(args.max_bits, args.seed)
+        sys.exit(0)
+
+    print("array size = {:,}".format(args.size))
+    print("number of trials = ", args.trials)
+    time_ak_bitwise_binops(args.size, args.trials, args.max_bits, args.seed)
+
+    sys.exit(0)

--- a/benchmarks/bigint_conversion.py
+++ b/benchmarks/bigint_conversion.py
@@ -43,8 +43,15 @@ def time_bigint_conversion(N_per_locale, trials, seed, max_bits):
             (2 * a.size * a.itemsize) / 2**30 / avg_conversion
         )
     )
-    assert ak.all(a == u_arrays[0])
-    assert ak.all(b == u_arrays[1])
+    if max_bits == -1 or max_bits > 128:
+        assert ak.all(a == u_arrays[0])
+        assert ak.all(b == u_arrays[1])
+    elif max_bits <= 64:
+        assert ak.all(b % (2**max_bits - 1) == u_arrays[0])
+    else:
+        max_bits -= 64
+        assert ak.all(a & (2**max_bits - 1) == u_arrays[0])
+        assert ak.all(b == u_arrays[1])
 
 
 def check_correctness(seed, max_bits):
@@ -54,8 +61,15 @@ def check_correctness(seed, max_bits):
     b = ak.randint(0, N, N, dtype=ak.uint64, seed=seed)
     u_arrays = ak.bigint_from_uint_arrays([a, b], max_bits=max_bits).bigint_to_uint_arrays()
 
-    assert ak.all(a == u_arrays[0])
-    assert ak.all(b == u_arrays[1])
+    if max_bits == -1 or max_bits > 128:
+        assert ak.all(a == u_arrays[0])
+        assert ak.all(b == u_arrays[1])
+    elif max_bits <= 64:
+        assert ak.all(b % (2**max_bits - 1) == u_arrays[0])
+    else:
+        max_bits -= 64
+        assert ak.all(a & (2**max_bits - 1) == u_arrays[0])
+        assert ak.all(b == u_arrays[1])
 
 
 def create_parser():

--- a/benchmarks/bigint_stream.py
+++ b/benchmarks/bigint_stream.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+import argparse
+import time
+
+import numpy as np
+
+import arkouda as ak
+
+
+def time_ak_stream(N_per_locale, trials, alpha, max_bits, random, seed):
+    print(">>> arkouda bigint stream")
+    cfg = ak.get_config()
+    N = N_per_locale * cfg["numLocales"]
+    print("numLocales = {}, N = {:,}".format(cfg["numLocales"], N))
+    # default tot_bytes to ones case
+    tot_bytes = N * 8 * 3
+    if random or seed is not None:
+        a1 = ak.randint(0, 2**32, N, dtype=ak.uint64, seed=seed)
+        a2 = ak.randint(0, 2**32, N, dtype=ak.uint64, seed=seed)
+        a = ak.bigint_from_uint_arrays([a1, a2], max_bits=max_bits)
+        b1 = ak.randint(0, 2**32, N, dtype=ak.uint64, seed=seed)
+        b2 = ak.randint(0, 2**32, N, dtype=ak.uint64, seed=seed)
+        b = ak.bigint_from_uint_arrays([b1, b2], max_bits=max_bits)
+        # update tot_bytes to account for using 2 uint64
+        tot_bytes *= 2
+    else:
+        a = ak.bigint_from_uint_arrays([ak.ones(N, dtype=ak.uint64)], max_bits=max_bits)
+        b = ak.bigint_from_uint_arrays([ak.ones(N, dtype=ak.uint64)], max_bits=max_bits)
+
+    timings = []
+    for i in range(trials):
+        start = time.time()
+        c = a + b * alpha
+        end = time.time()
+        timings.append(end - start)
+    tavg = sum(timings) / trials
+
+    print("Average bigint stream time = {:.4f} sec".format(tavg))
+    bytes_per_sec = tot_bytes / tavg
+    print("Average bigint stream rate = {:.2f} GiB/sec".format(bytes_per_sec / 2**30))
+
+
+def check_correctness(alpha, max_bits, random, seed):
+    N = 10**4
+    if seed is not None:
+        np.random.seed(seed)
+    if random or seed is not None:
+        a = np.random.randint(0, 2**32, N)
+        b = np.random.randint(0, 2**32, N)
+    else:
+        a = np.ones(N, dtype=np.uint)
+        b = np.ones(N, dtype=np.uint)
+    npc = a + b * alpha
+    akc = (
+        ak.array(a, dtype=ak.bigint, max_bits=max_bits)
+        + ak.array(b, dtype=ak.bigint, max_bits=max_bits) * alpha
+    )
+    np_ans = (npc % (2 ** max_bits)).astype(np.uint) if max_bits != -1 else npc
+    ak_ans = akc.to_ndarray().astype(np.uint)
+    assert np.all(np_ans == ak_ans)
+
+
+def create_parser():
+    parser = argparse.ArgumentParser(description="Run the bigint stream benchmark: C = A + alpha*B")
+    parser.add_argument("hostname", help="Hostname of arkouda server")
+    parser.add_argument("port", type=int, help="Port of arkouda server")
+    parser.add_argument(
+        "-n", "--size", type=int, default=10**8, help="Problem size: length of arrays A and B"
+    )
+    parser.add_argument(
+        "-t", "--trials", type=int, default=6, help="Number of times to run the benchmark"
+    )
+    parser.add_argument(
+        "--max-bits",
+        type=int,
+        default=-1,
+        help="Maximum number of bits, so values > 2**max_bits will wraparound. -1 is interpreted as no maximum",
+    )
+    parser.add_argument(
+        "-r",
+        "--randomize",
+        default=False,
+        action="store_true",
+        help="Fill arrays with random values instead of ones",
+    )
+    parser.add_argument("-a", "--alpha", default=1, help="Scalar multiple")
+    parser.add_argument(
+        "--correctness-only",
+        default=False,
+        action="store_true",
+        help="Only check correctness, not performance.",
+    )
+    parser.add_argument(
+        "-s", "--seed", default=None, type=int, help="Value to initialize random number generator"
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    import sys
+
+    parser = create_parser()
+    args = parser.parse_args()
+    args.alpha = int(args.alpha)
+    ak.verbose = False
+    ak.connect(server=args.hostname, port=args.port)
+
+    if args.correctness_only:
+        check_correctness(args.alpha, args.max_bits, args.randomize, args.seed)
+        sys.exit(0)
+
+    print("array size = {:,}".format(args.size))
+    print("number of trials = ", args.trials)
+    time_ak_stream(args.size, args.trials, args.alpha, args.max_bits, args.randomize, args.seed)
+
+    sys.exit(0)

--- a/benchmarks/graph_infra/arkouda.graph
+++ b/benchmarks/graph_infra/arkouda.graph
@@ -147,3 +147,15 @@ graphkeys: bigint_from_uint_arrays GiB/s, bigint_to_uint_arrays GiB/s
 files: bigint_conversion.dat, bigint_conversion.dat
 graphtitle: Bigint Conversion Performance
 ylabel: Performance (GiB/s)
+
+perfkeys: Average bigint stream rate =
+graphkeys: bigint stream GiB/s
+files: bigint_stream.dat
+graphtitle: Bigint Stream Performance
+ylabel: Performance (GiB/s)
+
+perfkeys: Average bigint AND rate =, Average bigint OR rate =, Average bigint SHIFT rate =
+graphkeys: bigint bitwise binops GiB/s, bigint bitwise binops GiB/s, bigint bitwise binops GiB/s
+files: bigint_bitwise_binops.dat
+graphtitle: Bigint Bitwise Binops Performance
+ylabel: Performance (GiB/s)

--- a/benchmarks/graph_infra/arkouda.graph
+++ b/benchmarks/graph_infra/arkouda.graph
@@ -155,7 +155,7 @@ graphtitle: Bigint Stream Performance
 ylabel: Performance (GiB/s)
 
 perfkeys: Average bigint AND rate =, Average bigint OR rate =, Average bigint SHIFT rate =
-graphkeys: bigint bitwise binops GiB/s, bigint bitwise binops GiB/s, bigint bitwise binops GiB/s
-files: bigint_bitwise_binops.dat
+graphkeys: bigint AND GiB/s, bigint OR GiB/s, bigint SHIFT GiB/s
+files: bigint_bitwise_binops.dat, bigint_bitwise_binops.dat, bigint_bitwise_binops.dat
 graphtitle: Bigint Bitwise Binops Performance
 ylabel: Performance (GiB/s)

--- a/benchmarks/graph_infra/bigint_bitwise_binops.perfkeys
+++ b/benchmarks/graph_infra/bigint_bitwise_binops.perfkeys
@@ -1,0 +1,6 @@
+Average bigint AND time =
+Average bigint AND rate =
+Average bigint OR time =
+Average bigint OR rate =
+Average bigint SHIFT time =
+Average bigint SHIFT rate =

--- a/benchmarks/graph_infra/bigint_stream.perfkeys
+++ b/benchmarks/graph_infra/bigint_stream.perfkeys
@@ -1,0 +1,2 @@
+Average bigint stream time =
+Average bigint stream rate =

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -49,6 +49,8 @@ BENCHMARKS = [
     "dataframe",
     "encode",
     "bigint_conversion",
+    "bigint_stream",
+    "bigint_bitwise_binops",
 ]
 
 if os.getenv("ARKOUDA_SERVER_PARQUET_SUPPORT"):

--- a/src/BigIntMsg.chpl
+++ b/src/BigIntMsg.chpl
@@ -37,10 +37,11 @@ module BigIntMsg {
 
         if max_bits != -1 {
             // modBy should always be non-zero since we start at 1 and left shift
-            var modBy = 1:bigint;
-            modBy <<= max_bits;
-            forall bA in bigIntArray with (var local_modBy = modBy) {
-              bA.mod(bA, local_modBy);
+            var max_size = 1:bigint;
+            max_size <<= max_bits;
+            max_size -= 1;
+            forall bA in bigIntArray with (var local_max_size = max_size) {
+              bA &= local_max_size;
             }
         }
 

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -1099,10 +1099,11 @@ module BinOp
     var has_max_bits = max_bits != -1;
     if has_max_bits {
       max_size <<= max_bits;
+      max_size -= 1;
     }
     ref la = l.a;
     ref ra = r.a;
-    var tmp = makeDistArray(la.size, bigint);
+    var tmp = if l.etype == bigint then la else if l.etype == bool then la:int:bigint else la:bigint;
     // these cases are not mutually exclusive,
     // so we have a flag to track if tmp is ever populated
     var visted = false;
@@ -1114,19 +1115,59 @@ module BinOp
       // both being bigint
       select op {
         when "&" {
-          tmp = la & ra;
+          if has_max_bits {
+            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+              t &= ri;
+              t &= local_max_size;
+            }
+          }
+          else {
+            forall (t, ri) in zip(tmp, ra) {
+              t &= ri;
+            }
+          }
           visted = true;
         }
         when "|" {
-          tmp = la | ra;
+          if has_max_bits {
+            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+              t |= ri;
+              t &= local_max_size;
+            }
+          }
+          else {
+            forall (t, ri) in zip(tmp, ra) {
+              t |= ri;
+            }
+          }
           visted = true;
         }
         when "^" {
-          tmp = la ^ ra;
+          if has_max_bits {
+            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+              t ^= ri;
+              t &= local_max_size;
+            }
+          }
+          else {
+            forall (t, ri) in zip(tmp, ra) {
+              t ^= ri;
+            }
+          }
           visted = true;
         }
         when "/" {
-          tmp = la / ra;
+          if has_max_bits {
+            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+              t /= ri;
+              t &= local_max_size;
+            }
+          }
+          else {
+            forall (t, ri) in zip(tmp, ra) {
+              t /= ri;
+            }
+          }
           visted = true;
         }
       }
@@ -1138,7 +1179,17 @@ module BinOp
         // can't shift a bigint by a bigint
         select op {
           when "<<" {
-            tmp = la << ra;
+            if has_max_bits {
+              forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+                t <<= ri;
+                t &= local_max_size;
+              }
+            }
+            else {
+              forall (t, ri) in zip(tmp, ra) {
+                t <<= ri;
+              }
+            }
             visted = true;
           }
           when ">>" {
@@ -1148,7 +1199,17 @@ module BinOp
             var divideBy = makeDistArray(la.size, bigint);
             divideBy = 1:bigint;
             divideBy <<= ra;
-            tmp = la / divideBy;
+            if has_max_bits {
+              forall (t, dB) in zip(tmp, divideBy) with (var local_max_size = max_size) {
+                t /= dB;
+                t &= local_max_size;
+              }
+            }
+            else {
+              forall (t, dB) in zip(tmp, divideBy) {
+                t /= dB;
+              }
+            }
             visted = true;
           }
           when "<<<" {
@@ -1157,21 +1218,27 @@ module BinOp
             }
             // should be as simple as the below, see issue #2006
             // return (la << ra) | (la >> (max_bits - ra));
-            tmp = la << ra;
             var botBits = la;
             if r.etype == int {
-              var shift_amt = max_bits - ra;
               // cant just do botBits >>= shift_amt;
-              var divideBy = makeDistArray(la.size, bigint);
-              divideBy = 1:bigint;
-              divideBy <<= shift_amt;
-              botBits = botBits / divideBy;
-              tmp += botBits;
+              forall (t, ri, bot_bits) in zip(tmp, ra, botBits) with (var local_max_size = max_size) {
+                t <<= ri;
+                var div_by = 1:bigint;
+                var shift_amt = max_bits - ri;
+                div_by <<= shift_amt;
+                bot_bits /= div_by;
+                t += bot_bits;
+                t &= local_max_size;
+              }
             }
             else {
-              var shift_amt = max_bits:uint - ra;
-              botBits >>= shift_amt;
-              tmp += botBits;
+              forall (t, ri, bot_bits) in zip(tmp, ra, botBits) with (var local_max_size = max_size) {
+                t <<= ri;
+                var shift_amt = max_bits:uint - ri;
+                bot_bits >>= shift_amt;
+                t += bot_bits;
+                t &= local_max_size;
+              }
             }
             visted = true;
           }
@@ -1181,23 +1248,16 @@ module BinOp
             }
             // should be as simple as the below, see issue #2006
             // return (la >> ra) | (la << (max_bits - ra));
-            tmp = la;
             // cant just do tmp >>= ra;
-            var divideBy = makeDistArray(la.size, bigint);
-            divideBy = 1:bigint;
-            divideBy <<= ra;
-            tmp = tmp / divideBy;
-
             var topBits = la;
-            if r.etype == int {
-              var shift_amt = max_bits - ra;
-              topBits <<= shift_amt;
-              tmp += topBits;
-            }
-            else {
-              var shift_amt = max_bits:uint - ra;
-              topBits <<= shift_amt;
-              tmp += topBits;
+            forall (t, ri, tB) in zip(tmp, ra, topBits) with (var local_max_size = max_size) {
+              var div_by = 1:bigint;
+              div_by <<= ri;
+              t /= div_by;
+              var shift_amt = if r.etype == int then max_bits - ri else max_bits:uint - ri;
+              tB <<= shift_amt;
+              t += tB;
+              t &= local_max_size;
             }
             visted = true;
           }
@@ -1205,13 +1265,53 @@ module BinOp
       }
       select op {
         when "//" { // floordiv
-          [(ei,li,ri) in zip(tmp,la,ra)] ei = if ri != 0 then li/ri else 0:bigint;
+          if has_max_bits {
+            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+              if ri != 0 {
+                t /= ri;
+              }
+              else {
+                t = 0:bigint;
+              }
+              t &= local_max_size;
+            }
+          }
+          else {
+            forall (t, ri) in zip(tmp, ra) {
+              if ri != 0 {
+                t /= ri;
+              }
+              else {
+                t = 0:bigint;
+              }
+            }
+          }
           visted = true;
         }
         when "%" { // modulo
           // we only do in place mod when ri != 0, tmp will be 0 in other locations
           // we can't use ei = li % ri because this can result in negatives
-          [(ei,li,ri) in zip(tmp,la,ra)] if ri != 0 then ei.mod(li, ri);
+          if has_max_bits {
+            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+              if ri != 0 {
+                t.mod(t, ri);
+              }
+              else {
+                t = 0:bigint;
+              }
+              t &= local_max_size;
+            }
+          }
+          else {
+            forall (t, ri) in zip(tmp, ra) {
+              if ri != 0 {
+                t.mod(t, ri);
+              }
+              else {
+                t = 0:bigint;
+              }
+            }
+          }
           visted = true;
         }
         when "**" {
@@ -1219,10 +1319,14 @@ module BinOp
             throw new Error("Attempt to exponentiate base of type BigInt to negative exponent");
           }
           if has_max_bits {
-            [(ei,li,ri) in zip(tmp,la,ra)] ei.powMod(li, ri, max_size);
+            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+              t.powMod(t, ri, local_max_size + 1);
+            }
           }
           else {
-            tmp = la ** ra:int;
+            forall (t, ri) in zip(tmp, ra) {
+              t **= ri:uint;
+            }
           }
           visted = true;
         }
@@ -1233,15 +1337,45 @@ module BinOp
        (r.etype == bigint && (l.etype == int || l.etype == uint || l.etype == bool)) {
       select op {
         when "+" {
-          tmp = la + ra;
+          if has_max_bits {
+            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+              t += ri;
+              t &= local_max_size;
+            }
+          }
+          else {
+            forall (t, ri) in zip(tmp, ra) {
+              t += ri;
+            }
+          }
           visted = true;
         }
         when "-" {
-          tmp = l.a - r.a;
+          if has_max_bits {
+            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+              t -= ri;
+              t &= local_max_size;
+            }
+          }
+          else {
+            forall (t, ri) in zip(tmp, ra) {
+              t -= ri;
+            }
+          }
           visted = true;
         }
         when "*" {
-          tmp = l.a * r.a;
+          if has_max_bits {
+            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+              t *= ri;
+              t &= local_max_size;
+            }
+          }
+          else {
+            forall (t, ri) in zip(tmp, ra) {
+              t *= ri;
+            }
+          }
           visted = true;
         }
       }
@@ -1249,13 +1383,7 @@ module BinOp
     if !visted {
       throw new Error("Unsupported operation: " + l.etype:string +" "+ op +" "+ r.etype:string);
     }
-    else {
-      if has_max_bits {
-        // max_size should always be non-zero since we start at 1 and left shift
-        tmp.mod(tmp, max_size);
-      }
-      return (tmp, max_bits);
-    }
+    return (tmp, max_bits);
   }
 
   proc doBigIntBinOpvvBoolReturn(l, r, op: string) throws {
@@ -1292,9 +1420,10 @@ module BinOp
     var has_max_bits = max_bits != -1;
     if has_max_bits {
       max_size <<= max_bits;
+      max_size -= 1;
     }
     ref la = l.a;
-    var tmp = makeDistArray(la.size, bigint);
+    var tmp = if l.etype == bigint then la else if l.etype == bool then la:int:bigint else la:bigint;
     // these cases are not mutually exclusive,
     // so we have a flag to track if tmp is ever populated
     var visted = false;
@@ -1306,19 +1435,59 @@ module BinOp
       // both being bigint
       select op {
         when "&" {
-          tmp = la & val;
+          if has_max_bits {
+            forall t in tmp with (var local_val = val, var local_max_size = max_size) {
+              t &= local_val;
+              t &= local_max_size;
+            }
+          }
+          else {
+            forall t in tmp with (var local_val = val) {
+              t &= local_val;
+            }
+          }
           visted = true;
         }
         when "|" {
-          tmp = la | val;
+          if has_max_bits {
+            forall t in tmp with (var local_val = val, var local_max_size = max_size) {
+              t |= local_val;
+              t &= local_max_size;
+            }
+          }
+          else {
+            forall t in tmp with (var local_val = val) {
+              t |= local_val;
+            }
+          }
           visted = true;
         }
         when "^" {
-          tmp = la ^ val;
+          if has_max_bits {
+            forall t in tmp with (var local_val = val, var local_max_size = max_size) {
+              t ^= local_val;
+              t &= local_max_size;
+            }
+          }
+          else {
+            forall t in tmp with (var local_val = val) {
+              t ^= local_val;
+            }
+          }
           visted = true;
         }
         when "/" {
-          tmp = la / val;
+          if has_max_bits {
+            forall t in tmp with (var local_val = val, var local_max_size = max_size) {
+              t /= local_val;
+              t &= local_max_size;
+            }
+          }
+          else {
+            forall t in tmp with (var local_val = val) {
+              t /= local_val;
+            }
+          }
           visted = true;
         }
       }
@@ -1330,7 +1499,17 @@ module BinOp
         // can't shift a bigint by a bigint
         select op {
           when "<<" {
-            tmp = la << val;
+            if has_max_bits {
+              forall t in tmp with (var local_val = val, var local_max_size = max_size) {
+                t <<= local_val;
+                t &= local_max_size;
+              }
+            }
+            else {
+              forall t in tmp with (var local_val = val) {
+                t <<= local_val;
+              }
+            }
             visted = true;
           }
           when ">>" {
@@ -1340,7 +1519,17 @@ module BinOp
             var divideBy = makeDistArray(la.size, bigint);
             divideBy = 1:bigint;
             divideBy <<= val;
-            tmp = la / divideBy;
+            if has_max_bits {
+              forall (t, dB) in zip(tmp, divideBy) with (var local_max_size = max_size) {
+                t /= dB;
+                t &= local_max_size;
+              }
+            }
+            else {
+              forall (t, dB) in zip(tmp, divideBy) {
+                t /= dB;
+              }
+            }
             visted = true;
           }
           when "<<<" {
@@ -1349,21 +1538,27 @@ module BinOp
             }
             // should be as simple as the below, see issue #2006
             // return (la << val) | (la >> (max_bits - val));
-            tmp = la << val;
             var botBits = la;
             if val.type == int {
               var shift_amt = max_bits - val;
               // cant just do botBits >>= shift_amt;
-              var divideBy = makeDistArray(la.size, bigint);
-              divideBy = 1:bigint;
-              divideBy <<= shift_amt;
-              botBits = botBits / divideBy;
-              tmp += botBits;
+              forall (t, bot_bits) in zip(tmp, botBits) with (var local_val = val, var local_shift_amt = shift_amt, var local_max_size = max_size) {
+                t <<= local_val;
+                var div_by = 1:bigint;
+                div_by <<= local_shift_amt;
+                bot_bits /= div_by;
+                t += bot_bits;
+                t &= local_max_size;
+              }
             }
             else {
               var shift_amt = max_bits:uint - val;
-              botBits >>= shift_amt;
-              tmp += botBits;
+              forall (t, bot_bits) in zip(tmp, botBits) with (var local_val = val, var local_shift_amt = shift_amt, var local_max_size = max_size) {
+                t <<= local_val;
+                bot_bits >>= local_shift_amt;
+                t += bot_bits;
+                t &= local_max_size;
+              }
             }
             visted = true;
           }
@@ -1373,23 +1568,16 @@ module BinOp
             }
             // should be as simple as the below, see issue #2006
             // return (la >> val) | (la << (max_bits - val));
-            tmp = la;
             // cant just do tmp >>= ra;
-            var divideBy = makeDistArray(la.size, bigint);
-            divideBy = 1:bigint;
-            divideBy <<= val;
-            tmp = tmp / divideBy;
-
             var topBits = la;
-            if val.type == int {
-              var shift_amt = max_bits - val;
-              topBits <<= shift_amt;
-              tmp += topBits;
-            }
-            else {
-              var shift_amt = max_bits:uint - val;
-              topBits <<= shift_amt;
-              tmp += topBits;
+            var shift_amt = if val.type == int then max_bits - val else max_bits:uint - val;
+            forall (t, tB) in zip(tmp, topBits) with (var local_val = val, var local_shift_amt = shift_amt, var local_max_size = max_size) {
+              var div_by = 1:bigint;
+              div_by <<= local_val;
+              t /= div_by;
+              tB <<= local_shift_amt;
+              t += tB;
+              t &= local_max_size;
             }
             visted = true;
           }
@@ -1397,13 +1585,53 @@ module BinOp
       }
       select op {
         when "//" { // floordiv
-          [(ei,li) in zip(tmp,la)] ei = if val != 0 then li/val else 0:bigint;
+          if has_max_bits {
+            forall t in tmp with (var local_val = val, var local_max_size = max_size) {
+              if local_val != 0 {
+                t /= local_val;
+              }
+              else {
+                t = 0:bigint;
+              }
+              t &= local_max_size;
+            }
+          }
+          else {
+            forall t in tmp with (var local_val = val) {
+              if local_val != 0 {
+                t /= local_val;
+              }
+              else {
+                t = 0:bigint;
+              }
+            }
+          }
           visted = true;
         }
         when "%" { // modulo
           // we only do in place mod when val != 0, tmp will be 0 in other locations
           // we can't use ei = li % val because this can result in negatives
-          [(ei,li) in zip(tmp,la)] if val != 0 then ei.mod(li, val);
+          if has_max_bits {
+            forall (t, li) in zip(tmp, la) with (var local_val = val, var local_max_size = max_size) {
+              if local_val != 0 {
+                t.mod(t, local_val);
+              }
+              else {
+                t = 0:bigint;
+              }
+              t &= local_max_size;
+            }
+          }
+          else {
+            forall (t, li) in zip(tmp, la) with (var local_val = val) {
+              if local_val != 0 {
+                t.mod(t, local_val);
+              }
+              else {
+                t = 0:bigint;
+              }
+            }
+          }
           visted = true;
         }
         when "**" {
@@ -1411,10 +1639,14 @@ module BinOp
             throw new Error("Attempt to exponentiate base of type BigInt to negative exponent");
           }
           if has_max_bits {
-            [(ei,li) in zip(tmp,la)] ei.powMod(li, val, max_size);
+            forall t in tmp with (var local_val = val, var local_max_size = max_size) {
+              t.powMod(t, local_val, local_max_size + 1);
+            }
           }
           else {
-            tmp = la ** val:int;
+            forall t in tmp with (var local_val = val) {
+              t **= local_val:uint;
+            }
           }
           visted = true;
         }
@@ -1425,15 +1657,45 @@ module BinOp
        (val.type == bigint && (l.etype == int || l.etype == uint || l.etype == bool)) {
       select op {
         when "+" {
-          tmp = la + val;
+          if has_max_bits {
+            forall t in tmp with (var local_val = val, var local_max_size = max_size) {
+              t += local_val;
+              t &= local_max_size;
+            }
+          }
+          else {
+            forall t in tmp with (var local_val = val) {
+              t += local_val;
+            }
+          }
           visted = true;
         }
         when "-" {
-          tmp = l.a - val;
+          if has_max_bits {
+            forall t in tmp with (var local_val = val, var local_max_size = max_size) {
+              t -= local_val;
+              t &= local_max_size;
+            }
+          }
+          else {
+            forall t in tmp with (var local_val = val) {
+              t -= local_val;
+            }
+          }
           visted = true;
         }
         when "*" {
-          tmp = l.a * val;
+          if has_max_bits {
+            forall t in tmp with (var local_val = val, var local_max_size = max_size) {
+              t *= local_val;
+              t &= local_max_size;
+            }
+          }
+          else {
+            forall t in tmp with (var local_val = val) {
+              t *= local_val;
+            }
+          }
           visted = true;
         }
       }
@@ -1441,34 +1703,42 @@ module BinOp
     if !visted {
       throw new Error("Unsupported operation: " + l.etype:string +" "+ op +" "+ val.type:string);
     }
-    else {
-      if has_max_bits {
-        // max_size should always be non-zero since we start at 1 and left shift
-        tmp.mod(tmp, max_size);
-      }
-      return (tmp, max_bits);
-    }
+    return (tmp, max_bits);
   }
 
   proc doBigIntBinOpvsBoolReturn(l, val, op: string) throws {
+    ref la = l.a;
+    var tmp = makeDistArray(la.size, bool);
     select op {
       when "<" {
-        return l.a < val;
+        forall (t, li) in zip(tmp, la) with (var local_val = val) {
+          t = (li < local_val);
+        }
       }
       when ">" {
-        return l.a > val;
+        forall (t, li) in zip(tmp, la) with (var local_val = val) {
+          t = (li > local_val);
+        }
       }
       when "<=" {
-        return l.a <= val;
+        forall (t, li) in zip(tmp, la) with (var local_val = val) {
+          t = (li <= local_val);
+        }
       }
       when ">=" {
-        return l.a >= val;
+        forall (t, li) in zip(tmp, la) with (var local_val = val) {
+          t = (li >= local_val);
+        }
       }
       when "==" {
-        return l.a == val;
+        forall (t, li) in zip(tmp, la) with (var local_val = val) {
+          t = (li == local_val);
+        }
       }
       when "!=" {
-        return l.a != val;
+        forall (t, li) in zip(tmp, la) with (var local_val = val) {
+          t = (li != local_val);
+        }
       }
       otherwise {
         // we should never reach this since we only enter this proc
@@ -1476,6 +1746,7 @@ module BinOp
         throw new Error("Unsupported operation: " +" "+ l.etype:string + op +" "+ val.type:string);
       }
     }
+    return tmp;
   }
 
   proc doBigIntBinOpsv(val, r, op: string) throws {
@@ -1484,9 +1755,12 @@ module BinOp
     var has_max_bits = max_bits != -1;
     if has_max_bits {
       max_size <<= max_bits;
+      max_size -= 1;
     }
     ref ra = r.a;
     var tmp = makeDistArray(ra.size, bigint);
+    // TODO we have to cast to bigint until chape issue #21290 is resolved, see issue #2007
+    tmp = if val.type == bool then val:int:bigint else val:bigint;
     // these cases are not mutually exclusive,
     // so we have a flag to track if tmp is ever populated
     var visted = false;
@@ -1498,19 +1772,59 @@ module BinOp
       // both being bigint
       select op {
         when "&" {
-          tmp = val & ra;
+          if has_max_bits {
+            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+              t &= ri;
+              t &= local_max_size;
+            }
+          }
+          else {
+            forall (t, ri) in zip(tmp, ra) {
+              t &= ri;
+            }
+          }
           visted = true;
         }
         when "|" {
-          tmp = val | ra;
+          if has_max_bits {
+            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+              t |= ri;
+              t &= local_max_size;
+            }
+          }
+          else {
+            forall (t, ri) in zip(tmp, ra) {
+              t |= ri;
+            }
+          }
           visted = true;
         }
         when "^" {
-          tmp = val ^ ra;
+          if has_max_bits {
+            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+              t ^= ri;
+              t &= local_max_size;
+            }
+          }
+          else {
+            forall (t, ri) in zip(tmp, ra) {
+              t ^= ri;
+            }
+          }
           visted = true;
         }
         when "/" {
-          tmp = val / ra;
+          if has_max_bits {
+            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+              t /= ri;
+              t &= local_max_size;
+            }
+          }
+          else {
+            forall (t, ri) in zip(tmp, ra) {
+              t /= ri;
+            }
+          }
           visted = true;
         }
       }
@@ -1522,7 +1836,17 @@ module BinOp
         // can't shift a bigint by a bigint
         select op {
           when "<<" {
-            tmp = val << ra;
+            if has_max_bits {
+              forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+                t <<= ri;
+                t &= local_max_size;
+              }
+            }
+            else {
+              forall (t, ri) in zip(tmp, ra) {
+                t <<= ri;
+              }
+            }
             visted = true;
           }
           when ">>" {
@@ -1532,7 +1856,17 @@ module BinOp
             var divideBy = makeDistArray(ra.size, bigint);
             divideBy = 1:bigint;
             divideBy <<= ra;
-            tmp = val / divideBy;
+            if has_max_bits {
+              forall (t, dB) in zip(tmp, divideBy) with (var local_max_size = max_size) {
+                t /= dB;
+                t &= local_max_size;
+              }
+            }
+            else {
+              forall (t, dB) in zip(tmp, divideBy) {
+                t /= dB;
+              }
+            }
             visted = true;
           }
           when "<<<" {
@@ -1540,23 +1874,29 @@ module BinOp
               throw new Error("Must set max_bits to rotl");
             }
             // should be as simple as the below, see issue #2006
-            // return (val << ra) | (val >> (max_bits - ra));
-            tmp = val << ra;
+            // return (la << ra) | (la >> (max_bits - ra));
             var botBits = makeDistArray(ra.size, bigint);
             botBits = val;
             if r.etype == int {
-              var shift_amt = max_bits - ra;
               // cant just do botBits >>= shift_amt;
-              var divideBy = makeDistArray(ra.size, bigint);
-              divideBy = 1:bigint;
-              divideBy <<= shift_amt;
-              botBits = botBits / divideBy;
-              tmp += botBits;
+              forall (t, ri, bot_bits) in zip(tmp, ra, botBits) with (var local_max_size = max_size) {
+                t <<= ri;
+                var div_by = 1:bigint;
+                var shift_amt = max_bits - ri;
+                div_by <<= shift_amt;
+                bot_bits /= div_by;
+                t += bot_bits;
+                t &= local_max_size;
+              }
             }
             else {
-              var shift_amt = max_bits:uint - ra;
-              botBits >>= shift_amt;
-              tmp += botBits;
+              forall (t, ri, bot_bits) in zip(tmp, ra, botBits) with (var local_max_size = max_size) {
+                t <<= ri;
+                var shift_amt = max_bits:uint - ri;
+                bot_bits >>= shift_amt;
+                t += bot_bits;
+                t &= local_max_size;
+              }
             }
             visted = true;
           }
@@ -1565,25 +1905,18 @@ module BinOp
               throw new Error("Must set max_bits to rotr");
             }
             // should be as simple as the below, see issue #2006
-            // return (val >> ra) | (val << (max_bits - ra));
-            tmp = val;
+            // return (la >> ra) | (la << (max_bits - ra));
             // cant just do tmp >>= ra;
-            var divideBy = makeDistArray(ra.size, bigint);
-            divideBy = 1:bigint;
-            divideBy <<= ra;
-            tmp = tmp / divideBy;
-
             var topBits = makeDistArray(ra.size, bigint);
             topBits = val;
-            if r.etype == int {
-              var shift_amt = max_bits - ra;
-              topBits <<= shift_amt;
-              tmp += topBits;
-            }
-            else {
-              var shift_amt = max_bits:uint - ra;
-              topBits <<= shift_amt;
-              tmp += topBits;
+            forall (t, ri, tB) in zip(tmp, ra, topBits) with (var local_max_size = max_size) {
+              var div_by = 1:bigint;
+              div_by <<= ri;
+              t /= div_by;
+              var shift_amt = if r.etype == int then max_bits - ri else max_bits:uint - ri;
+              tB <<= shift_amt;
+              t += tB;
+              t &= local_max_size;
             }
             visted = true;
           }
@@ -1591,24 +1924,66 @@ module BinOp
       }
       select op {
         when "//" { // floordiv
-          [(ei,ri) in zip(tmp,ra)] ei = if ri != 0 then val/ri else 0:bigint;
+          if has_max_bits {
+            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+              if ri != 0 {
+                t /= ri;
+              }
+              else {
+                t = 0:bigint;
+              }
+              t &= local_max_size;
+            }
+          }
+          else {
+            forall (t, ri) in zip(tmp, ra) {
+              if ri != 0 {
+                t /= ri;
+              }
+              else {
+                t = 0:bigint;
+              }
+            }
+          }
           visted = true;
         }
         when "%" { // modulo
-          // we only do in place mod when val != 0, tmp will be 0 in other locations
-          // we can't use ei = li % val because this can result in negatives
-          [(ei,ri) in zip(tmp,ra)] if ri != 0 then ei.mod(val, ri);
+          if has_max_bits {
+            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+              if ri != 0 {
+                t.mod(t, ri);
+              }
+              else {
+                t = 0:bigint;
+              }
+              t &= local_max_size;
+            }
+          }
+          else {
+            forall (t, ri) in zip(tmp, ra) {
+              if ri != 0 {
+                t.mod(t, ri);
+              }
+              else {
+                t = 0:bigint;
+              }
+            }
+          }
           visted = true;
         }
         when "**" {
-          if || reduce(ra<0) {
+          if || reduce (ra<0) {
             throw new Error("Attempt to exponentiate base of type BigInt to negative exponent");
           }
           if has_max_bits {
-            [(ei,ri) in zip(tmp,ra)] ei.powMod(val, ri, max_size);
+            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+              t.powMod(t, ri, local_max_size + 1);
+            }
           }
           else {
-            tmp = val ** ra:int;
+            forall (t, ri) in zip(tmp, ra) {
+              t **= ri:uint;
+            }
           }
           visted = true;
         }
@@ -1617,19 +1992,47 @@ module BinOp
     if (val.type == bigint && r.etype == bigint) ||
        (val.type == bigint && (r.etype == int || r.etype == uint || r.etype == bool)) ||
        (r.etype == bigint && (val.type == int || val.type == uint || val.type == bool)) {
-      // TODO we have to cast to bigint until chape issue #21290 is resolved, see issue #2007
-      var cast_val = if val.type == bool then val:int:bigint else val:bigint;
       select op {
         when "+" {
-          tmp = cast_val + ra;
+          if has_max_bits {
+            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+              t += ri;
+              t &= local_max_size;
+            }
+          }
+          else {
+            forall (t, ri) in zip(tmp, ra) {
+              t += ri;
+            }
+          }
           visted = true;
         }
         when "-" {
-          tmp = cast_val - r.a;
+          if has_max_bits {
+            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+              t -= ri;
+              t &= local_max_size;
+            }
+          }
+          else {
+            forall (t, ri) in zip(tmp, ra) {
+              t -= ri;
+            }
+          }
           visted = true;
         }
         when "*" {
-          tmp = cast_val * r.a;
+          if has_max_bits {
+            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+              t *= ri;
+              t &= local_max_size;
+            }
+          }
+          else {
+            forall (t, ri) in zip(tmp, ra) {
+              t *= ri;
+            }
+          }
           visted = true;
         }
       }
@@ -1637,34 +2040,42 @@ module BinOp
     if !visted {
       throw new Error("Unsupported operation: " + val.type:string +" "+ op +" "+ r.etype:string);
     }
-    else {
-      if has_max_bits {
-        // max_size should always be non-zero since we start at 1 and left shift
-        tmp.mod(tmp, max_size);
-      }
-      return (tmp, max_bits);
-    }
+    return (tmp, max_bits);
   }
 
   proc doBigIntBinOpsvBoolReturn(val, r, op: string) throws {
+    ref ra = r.a;
+    var tmp = makeDistArray(ra.size, bool);
     select op {
       when "<" {
-        return val < r.a;
+        forall (t, ri) in zip(tmp, ra) with (var local_val = val) {
+          t = (local_val < ri);
+        }
       }
       when ">" {
-        return val > r.a;
+        forall (t, ri) in zip(tmp, ra) with (var local_val = val) {
+          t = (local_val > ri);
+        }
       }
       when "<=" {
-        return val <= r.a;
+        forall (t, ri) in zip(tmp, ra) with (var local_val = val) {
+          t = (local_val <= ri);
+        }
       }
       when ">=" {
-        return val >= r.a;
+        forall (t, ri) in zip(tmp, ra) with (var local_val = val) {
+          t = (local_val >= ri);
+        }
       }
       when "==" {
-        return val == r.a;
+        forall (t, ri) in zip(tmp, ra) with (var local_val = val) {
+          t = (local_val == ri);
+        }
       }
       when "!=" {
-        return val != r.a;
+        forall (t, ri) in zip(tmp, ra) with (var local_val = val) {
+          t = (local_val != ri);
+        }
       }
       otherwise {
         // we should never reach this since we only enter this proc
@@ -1672,5 +2083,6 @@ module BinOp
         throw new Error("Unsupported operation: " + val.type:string +" "+ op +" "+ r.etype:string);
       }
     }
+    return tmp;
   }
 }

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -1115,57 +1115,37 @@ module BinOp
       // both being bigint
       select op {
         when "&" {
-          if has_max_bits {
-            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
-              t &= ri;
+          forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+            t &= ri;
+            if has_max_bits {
               t &= local_max_size;
-            }
-          }
-          else {
-            forall (t, ri) in zip(tmp, ra) {
-              t &= ri;
             }
           }
           visted = true;
         }
         when "|" {
-          if has_max_bits {
-            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
-              t |= ri;
+          forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+            t |= ri;
+            if has_max_bits {
               t &= local_max_size;
-            }
-          }
-          else {
-            forall (t, ri) in zip(tmp, ra) {
-              t |= ri;
             }
           }
           visted = true;
         }
         when "^" {
-          if has_max_bits {
-            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
-              t ^= ri;
+          forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+            t ^= ri;
+            if has_max_bits {
               t &= local_max_size;
-            }
-          }
-          else {
-            forall (t, ri) in zip(tmp, ra) {
-              t ^= ri;
             }
           }
           visted = true;
         }
         when "/" {
-          if has_max_bits {
-            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
-              t /= ri;
+          forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+            t /= ri;
+            if has_max_bits {
               t &= local_max_size;
-            }
-          }
-          else {
-            forall (t, ri) in zip(tmp, ra) {
-              t /= ri;
             }
           }
           visted = true;
@@ -1179,15 +1159,10 @@ module BinOp
         // can't shift a bigint by a bigint
         select op {
           when "<<" {
-            if has_max_bits {
-              forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
-                t <<= ri;
+            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+              t <<= ri;
+              if has_max_bits {
                 t &= local_max_size;
-              }
-            }
-            else {
-              forall (t, ri) in zip(tmp, ra) {
-                t <<= ri;
               }
             }
             visted = true;
@@ -1199,15 +1174,10 @@ module BinOp
             var divideBy = makeDistArray(la.size, bigint);
             divideBy = 1:bigint;
             divideBy <<= ra;
-            if has_max_bits {
-              forall (t, dB) in zip(tmp, divideBy) with (var local_max_size = max_size) {
-                t /= dB;
+            forall (t, dB) in zip(tmp, divideBy) with (var local_max_size = max_size) {
+              t /= dB;
+              if has_max_bits {
                 t &= local_max_size;
-              }
-            }
-            else {
-              forall (t, dB) in zip(tmp, divideBy) {
-                t /= dB;
               }
             }
             visted = true;
@@ -1265,25 +1235,15 @@ module BinOp
       }
       select op {
         when "//" { // floordiv
-          if has_max_bits {
-            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
-              if ri != 0 {
-                t /= ri;
-              }
-              else {
-                t = 0:bigint;
-              }
-              t &= local_max_size;
+          forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+            if ri != 0 {
+              t /= ri;
             }
-          }
-          else {
-            forall (t, ri) in zip(tmp, ra) {
-              if ri != 0 {
-                t /= ri;
-              }
-              else {
-                t = 0:bigint;
-              }
+            else {
+              t = 0:bigint;
+            }
+            if has_max_bits {
+              t &= local_max_size;
             }
           }
           visted = true;
@@ -1291,25 +1251,15 @@ module BinOp
         when "%" { // modulo
           // we only do in place mod when ri != 0, tmp will be 0 in other locations
           // we can't use ei = li % ri because this can result in negatives
-          if has_max_bits {
-            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
-              if ri != 0 {
-                t.mod(t, ri);
-              }
-              else {
-                t = 0:bigint;
-              }
-              t &= local_max_size;
+          forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+            if ri != 0 {
+              t.mod(t, ri);
             }
-          }
-          else {
-            forall (t, ri) in zip(tmp, ra) {
-              if ri != 0 {
-                t.mod(t, ri);
-              }
-              else {
-                t = 0:bigint;
-              }
+            else {
+              t = 0:bigint;
+            }
+            if has_max_bits {
+              t &= local_max_size;
             }
           }
           visted = true;
@@ -1337,43 +1287,28 @@ module BinOp
        (r.etype == bigint && (l.etype == int || l.etype == uint || l.etype == bool)) {
       select op {
         when "+" {
-          if has_max_bits {
-            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
-              t += ri;
+          forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+            t += ri;
+            if has_max_bits {
               t &= local_max_size;
-            }
-          }
-          else {
-            forall (t, ri) in zip(tmp, ra) {
-              t += ri;
             }
           }
           visted = true;
         }
         when "-" {
-          if has_max_bits {
-            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
-              t -= ri;
+          forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+            t -= ri;
+            if has_max_bits {
               t &= local_max_size;
-            }
-          }
-          else {
-            forall (t, ri) in zip(tmp, ra) {
-              t -= ri;
             }
           }
           visted = true;
         }
         when "*" {
-          if has_max_bits {
-            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
-              t *= ri;
+          forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+            t *= ri;
+            if has_max_bits {
               t &= local_max_size;
-            }
-          }
-          else {
-            forall (t, ri) in zip(tmp, ra) {
-              t *= ri;
             }
           }
           visted = true;
@@ -1435,57 +1370,37 @@ module BinOp
       // both being bigint
       select op {
         when "&" {
-          if has_max_bits {
-            forall t in tmp with (var local_val = val, var local_max_size = max_size) {
-              t &= local_val;
+          forall t in tmp with (var local_val = val, var local_max_size = max_size) {
+            t &= local_val;
+            if has_max_bits {
               t &= local_max_size;
-            }
-          }
-          else {
-            forall t in tmp with (var local_val = val) {
-              t &= local_val;
             }
           }
           visted = true;
         }
         when "|" {
-          if has_max_bits {
-            forall t in tmp with (var local_val = val, var local_max_size = max_size) {
-              t |= local_val;
+          forall t in tmp with (var local_val = val, var local_max_size = max_size) {
+            t |= local_val;
+            if has_max_bits {
               t &= local_max_size;
-            }
-          }
-          else {
-            forall t in tmp with (var local_val = val) {
-              t |= local_val;
             }
           }
           visted = true;
         }
         when "^" {
-          if has_max_bits {
-            forall t in tmp with (var local_val = val, var local_max_size = max_size) {
-              t ^= local_val;
+          forall t in tmp with (var local_val = val, var local_max_size = max_size) {
+            t ^= local_val;
+            if has_max_bits {
               t &= local_max_size;
-            }
-          }
-          else {
-            forall t in tmp with (var local_val = val) {
-              t ^= local_val;
             }
           }
           visted = true;
         }
         when "/" {
-          if has_max_bits {
-            forall t in tmp with (var local_val = val, var local_max_size = max_size) {
-              t /= local_val;
+          forall t in tmp with (var local_val = val, var local_max_size = max_size) {
+            t /= local_val;
+            if has_max_bits {
               t &= local_max_size;
-            }
-          }
-          else {
-            forall t in tmp with (var local_val = val) {
-              t /= local_val;
             }
           }
           visted = true;
@@ -1499,15 +1414,10 @@ module BinOp
         // can't shift a bigint by a bigint
         select op {
           when "<<" {
-            if has_max_bits {
-              forall t in tmp with (var local_val = val, var local_max_size = max_size) {
-                t <<= local_val;
+            forall t in tmp with (var local_val = val, var local_max_size = max_size) {
+              t <<= local_val;
+              if has_max_bits {
                 t &= local_max_size;
-              }
-            }
-            else {
-              forall t in tmp with (var local_val = val) {
-                t <<= local_val;
               }
             }
             visted = true;
@@ -1519,15 +1429,10 @@ module BinOp
             var divideBy = makeDistArray(la.size, bigint);
             divideBy = 1:bigint;
             divideBy <<= val;
-            if has_max_bits {
-              forall (t, dB) in zip(tmp, divideBy) with (var local_max_size = max_size) {
-                t /= dB;
+            forall (t, dB) in zip(tmp, divideBy) with (var local_max_size = max_size) {
+              t /= dB;
+              if has_max_bits {
                 t &= local_max_size;
-              }
-            }
-            else {
-              forall (t, dB) in zip(tmp, divideBy) {
-                t /= dB;
               }
             }
             visted = true;
@@ -1585,25 +1490,15 @@ module BinOp
       }
       select op {
         when "//" { // floordiv
-          if has_max_bits {
-            forall t in tmp with (var local_val = val, var local_max_size = max_size) {
-              if local_val != 0 {
-                t /= local_val;
-              }
-              else {
-                t = 0:bigint;
-              }
-              t &= local_max_size;
+          forall t in tmp with (var local_val = val, var local_max_size = max_size) {
+            if local_val != 0 {
+              t /= local_val;
             }
-          }
-          else {
-            forall t in tmp with (var local_val = val) {
-              if local_val != 0 {
-                t /= local_val;
-              }
-              else {
-                t = 0:bigint;
-              }
+            else {
+              t = 0:bigint;
+            }
+            if has_max_bits {
+              t &= local_max_size;
             }
           }
           visted = true;
@@ -1611,25 +1506,15 @@ module BinOp
         when "%" { // modulo
           // we only do in place mod when val != 0, tmp will be 0 in other locations
           // we can't use ei = li % val because this can result in negatives
-          if has_max_bits {
-            forall (t, li) in zip(tmp, la) with (var local_val = val, var local_max_size = max_size) {
-              if local_val != 0 {
-                t.mod(t, local_val);
-              }
-              else {
-                t = 0:bigint;
-              }
-              t &= local_max_size;
+          forall (t, li) in zip(tmp, la) with (var local_val = val, var local_max_size = max_size) {
+            if local_val != 0 {
+              t.mod(t, local_val);
             }
-          }
-          else {
-            forall (t, li) in zip(tmp, la) with (var local_val = val) {
-              if local_val != 0 {
-                t.mod(t, local_val);
-              }
-              else {
-                t = 0:bigint;
-              }
+            else {
+              t = 0:bigint;
+            }
+            if has_max_bits {
+              t &= local_max_size;
             }
           }
           visted = true;
@@ -1657,43 +1542,28 @@ module BinOp
        (val.type == bigint && (l.etype == int || l.etype == uint || l.etype == bool)) {
       select op {
         when "+" {
-          if has_max_bits {
-            forall t in tmp with (var local_val = val, var local_max_size = max_size) {
-              t += local_val;
+          forall t in tmp with (var local_val = val, var local_max_size = max_size) {
+            t += local_val;
+            if has_max_bits {
               t &= local_max_size;
-            }
-          }
-          else {
-            forall t in tmp with (var local_val = val) {
-              t += local_val;
             }
           }
           visted = true;
         }
         when "-" {
-          if has_max_bits {
-            forall t in tmp with (var local_val = val, var local_max_size = max_size) {
-              t -= local_val;
+          forall t in tmp with (var local_val = val, var local_max_size = max_size) {
+            t -= local_val;
+            if has_max_bits {
               t &= local_max_size;
-            }
-          }
-          else {
-            forall t in tmp with (var local_val = val) {
-              t -= local_val;
             }
           }
           visted = true;
         }
         when "*" {
-          if has_max_bits {
-            forall t in tmp with (var local_val = val, var local_max_size = max_size) {
-              t *= local_val;
+          forall t in tmp with (var local_val = val, var local_max_size = max_size) {
+            t *= local_val;
+            if has_max_bits {
               t &= local_max_size;
-            }
-          }
-          else {
-            forall t in tmp with (var local_val = val) {
-              t *= local_val;
             }
           }
           visted = true;
@@ -1772,57 +1642,37 @@ module BinOp
       // both being bigint
       select op {
         when "&" {
-          if has_max_bits {
-            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
-              t &= ri;
+          forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+            t &= ri;
+            if has_max_bits {
               t &= local_max_size;
-            }
-          }
-          else {
-            forall (t, ri) in zip(tmp, ra) {
-              t &= ri;
             }
           }
           visted = true;
         }
         when "|" {
-          if has_max_bits {
-            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
-              t |= ri;
+          forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+            t |= ri;
+            if has_max_bits {
               t &= local_max_size;
-            }
-          }
-          else {
-            forall (t, ri) in zip(tmp, ra) {
-              t |= ri;
             }
           }
           visted = true;
         }
         when "^" {
-          if has_max_bits {
-            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
-              t ^= ri;
+          forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+            t ^= ri;
+            if has_max_bits {
               t &= local_max_size;
-            }
-          }
-          else {
-            forall (t, ri) in zip(tmp, ra) {
-              t ^= ri;
             }
           }
           visted = true;
         }
         when "/" {
-          if has_max_bits {
-            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
-              t /= ri;
+          forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+            t /= ri;
+            if has_max_bits {
               t &= local_max_size;
-            }
-          }
-          else {
-            forall (t, ri) in zip(tmp, ra) {
-              t /= ri;
             }
           }
           visted = true;
@@ -1836,15 +1686,10 @@ module BinOp
         // can't shift a bigint by a bigint
         select op {
           when "<<" {
-            if has_max_bits {
-              forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
-                t <<= ri;
+            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+              t <<= ri;
+              if has_max_bits {
                 t &= local_max_size;
-              }
-            }
-            else {
-              forall (t, ri) in zip(tmp, ra) {
-                t <<= ri;
               }
             }
             visted = true;
@@ -1856,15 +1701,10 @@ module BinOp
             var divideBy = makeDistArray(ra.size, bigint);
             divideBy = 1:bigint;
             divideBy <<= ra;
-            if has_max_bits {
-              forall (t, dB) in zip(tmp, divideBy) with (var local_max_size = max_size) {
-                t /= dB;
+            forall (t, dB) in zip(tmp, divideBy) with (var local_max_size = max_size) {
+              t /= dB;
+              if has_max_bits {
                 t &= local_max_size;
-              }
-            }
-            else {
-              forall (t, dB) in zip(tmp, divideBy) {
-                t /= dB;
               }
             }
             visted = true;
@@ -1924,49 +1764,29 @@ module BinOp
       }
       select op {
         when "//" { // floordiv
-          if has_max_bits {
-            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
-              if ri != 0 {
-                t /= ri;
-              }
-              else {
-                t = 0:bigint;
-              }
-              t &= local_max_size;
+          forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+            if ri != 0 {
+              t /= ri;
             }
-          }
-          else {
-            forall (t, ri) in zip(tmp, ra) {
-              if ri != 0 {
-                t /= ri;
-              }
-              else {
-                t = 0:bigint;
-              }
+            else {
+              t = 0:bigint;
+            }
+            if has_max_bits {
+              t &= local_max_size;
             }
           }
           visted = true;
         }
         when "%" { // modulo
-          if has_max_bits {
-            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
-              if ri != 0 {
-                t.mod(t, ri);
-              }
-              else {
-                t = 0:bigint;
-              }
-              t &= local_max_size;
+          forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+            if ri != 0 {
+              t.mod(t, ri);
             }
-          }
-          else {
-            forall (t, ri) in zip(tmp, ra) {
-              if ri != 0 {
-                t.mod(t, ri);
-              }
-              else {
-                t = 0:bigint;
-              }
+            else {
+              t = 0:bigint;
+            }
+            if has_max_bits {
+              t &= local_max_size;
             }
           }
           visted = true;
@@ -1994,43 +1814,28 @@ module BinOp
        (r.etype == bigint && (val.type == int || val.type == uint || val.type == bool)) {
       select op {
         when "+" {
-          if has_max_bits {
-            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
-              t += ri;
+          forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+            t += ri;
+            if has_max_bits {
               t &= local_max_size;
-            }
-          }
-          else {
-            forall (t, ri) in zip(tmp, ra) {
-              t += ri;
             }
           }
           visted = true;
         }
         when "-" {
-          if has_max_bits {
-            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
-              t -= ri;
+          forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+            t -= ri;
+            if has_max_bits {
               t &= local_max_size;
-            }
-          }
-          else {
-            forall (t, ri) in zip(tmp, ra) {
-              t -= ri;
             }
           }
           visted = true;
         }
         when "*" {
-          if has_max_bits {
-            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
-              t *= ri;
+          forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+            t *= ri;
+            if has_max_bits {
               t &= local_max_size;
-            }
-          }
-          else {
-            forall (t, ri) in zip(tmp, ra) {
-              t *= ri;
             }
           }
           visted = true;


### PR DESCRIPTION
This PR (closes #2156 and closes #2165) adds a bigint stream benchmark. The bigint stream does not scale well. I couldn't find any obvious optimizations

`bigint_stream` after this PR:
```
% ./benchmarks/run_benchmarks.py bigint_stream -t 1
array size = 100,000,000
number of trials =  1
>>> arkouda bigint stream
numLocales = 1, N = 100,000,000
Average bigint stream time = 22.1851 sec
Average bigint stream rate = 0.10 GiB/sec

% ./benchmarks/run_benchmarks.py bigint_stream -t 1 --max-bits=64
array size = 100,000,000
number of trials =  1
>>> arkouda bigint stream
numLocales = 1, N = 100,000,000
Average bigint stream time = 20.6594 sec
Average bigint stream rate = 0.11 GiB/sec
```
`bigint_stream` before this PR:
```
% ./benchmarks/run_benchmarks.py bigint_stream -t 1
array size = 100,000,000
number of trials =  1
>>> arkouda bigint stream
numLocales = 1, N = 100,000,000
Average bigint stream time = 57.1895 sec
Average bigint stream rate = 0.04 GiB/sec

% ./benchmarks/run_benchmarks.py bigint_stream -t 1 --max-bits=64
array size = 100,000,000
number of trials =  1
>>> arkouda bigint stream
numLocales = 1, N = 100,000,000
Average bigint stream time = 58.1247 sec
Average bigint stream rate = 0.04 GiB/sec
```

Compared to non-bigint `stream`:
```
% ./benchmarks/run_benchmarks.py stream                    
array size = 100,000,000
number of trials =  6
>>> arkouda float64 stream
numLocales = 1, N = 100,000,000
Average time = 0.2566 sec
Average rate = 8.71 GiB/sec
```

bigint bitwise binops after this PR:
```
% ./benchmarks/run_benchmarks.py bigint_bitwise_binops -t 1
array size = 100,000,000
number of trials =  1
>>> arkouda bigint bitwise binops
numLocales = 1, N = 100,000,000
Average bigint AND time = 9.9440 sec
Average bigint AND rate = 0.30 GiB/sec

Average bigint OR time = 14.2256 sec
Average bigint OR rate = 0.21 GiB/sec

Average bigint SHIFT time = 23.6632 sec
Average bigint SHIFT rate = 0.06 GiB/sec

% ./benchmarks/run_benchmarks.py bigint_bitwise_binops -t 1 --max-bits=64
array size = 100,000,000
number of trials =  1
>>> arkouda bigint bitwise binops
numLocales = 1, N = 100,000,000
Average bigint AND time = 9.2267 sec
Average bigint AND rate = 0.32 GiB/sec

Average bigint OR time = 14.2185 sec
Average bigint OR rate = 0.21 GiB/sec

Average bigint SHIFT time = 22.9780 sec
Average bigint SHIFT rate = 0.06 GiB/sec
```

bigint bitwise binops before this PR:
```
% ./benchmarks/run_benchmarks.py bigint_bitwise_binops -t 1
array size = 100,000,000
number of trials =  1
>>> arkouda bigint bitwise binops
numLocales = 1, N = 100,000,000
Average bigint AND time = 21.7934 sec
Average bigint AND rate = 0.14 GiB/sec

Average bigint OR time = 26.4953 sec
Average bigint OR rate = 0.11 GiB/sec

Average bigint SHIFT time = 39.9405 sec
Average bigint SHIFT rate = 0.04 GiB/sec

 ./benchmarks/run_benchmarks.py bigint_bitwise_binops -t 1 --max-bits=64
array size = 100,000,000
number of trials =  1
>>> arkouda bigint bitwise binops
numLocales = 1, N = 100,000,000
Average bigint AND time = 22.2118 sec
Average bigint AND rate = 0.13 GiB/sec

Average bigint OR time = 25.9856 sec
Average bigint OR rate = 0.11 GiB/sec

Average bigint SHIFT time = 39.0686 sec
Average bigint SHIFT rate = 0.04 GiB/sec
```