### PR TITLE
fixed bug in pct memory used calculation

### DIFF
--- a/src/ServerDaemon.chpl
+++ b/src/ServerDaemon.chpl
@@ -646,10 +646,11 @@ module ServerDaemon {
                 }
                 if (trace && memTrack) {
                     var memUsed = getMemUsed():uint * numLocales:uint;
-                    var pctMemUsed = ((memUsed:real/memMax:real)*100):int;
+                    var pctMemUsed = ((memUsed:real/getMemLimit():real)*100):int;
                     sdLogger.info(getModuleName(),getRoutineName(),getLineNumber(),
-                        "bytes of memory %t pct of max memory %t%% used after command".format(memUsed,
-                                                                                            pctMemUsed));
+                        "bytes of memory %t pct of max memory %t%% used after %s command".format(memUsed,
+                                                                                                 pctMemUsed,
+                                                                                                 cmd));
                 }
                 if metricsEnabled() {
                     processMetrics(user, cmd, msgArgs, elapsedTime);


### PR DESCRIPTION
Closes #2152 

There is a bug in ServerDaemon.chpl where the pctMemUsed is calculated:

![image](https://user-images.githubusercontent.com/10785153/220333372-cab9e4f9-25b5-424a-9165-2c4d136283d4.png)

the divisor was set to memMax for testing purposes (test setting max memory via --memMax), but should have been replaced with getMemLimit, which generates the max memory from either memMax or the lone, previous method of 90% of physical memory.

The new version is correct, invoking the getMemLimit() function to return either the limit set via --memMax or calculated from 90% of max physical memory:

![image](https://user-images.githubusercontent.com/10785153/220332692-b2192f6f-1049-4046-8fb9-8fcf53fe071f.png)

Testing shows that it is working correctly:

memMax set:

![image](https://user-images.githubusercontent.com/10785153/220334282-21676acb-496e-433e-8436-67a45df98639.png)

![image](https://user-images.githubusercontent.com/10785153/220334697-4fd2e87e-b10c-44a7-ae47-2184eec66700.png)

memMax not set:

![image](https://user-images.githubusercontent.com/10785153/220334826-aeff2090-d6c2-489f-b902-47bd478e9170.png)

![image](https://user-images.githubusercontent.com/10785153/220334956-bd5d7322-9918-4334-8cbd-bbaeea800ccc.png)

