### PR TITLE
Closes #2147 - Adding API for hashArrays

### DIFF
--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -423,7 +423,7 @@ def cos(pda: pdarray) -> pdarray:
 @typechecked
 def hash(
     pda: Union[pdarray, list[pdarray]], full: bool = True
-) -> Union[list[Tuple], Tuple[pdarray, pdarray], pdarray]:
+) -> Union[Tuple[pdarray, pdarray], pdarray]:
     """
     Return an element-wise hash of the array.
 

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import ForwardRef, Optional, Tuple, Union
+from typing import ForwardRef, List, Optional, Tuple, Union
 from typing import cast as type_cast
 
 import numpy as np  # type: ignore
@@ -422,7 +422,7 @@ def cos(pda: pdarray) -> pdarray:
 
 @typechecked
 def hash(
-    pda: Union[pdarray, list[pdarray]], full: bool = True
+    pda: Union[pdarray, List[pdarray]], full: bool = True
 ) -> Union[Tuple[pdarray, pdarray], pdarray]:
     """
     Return an element-wise hash of the array.

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -473,7 +473,7 @@ def hash(
     the array.
     """
     if isinstance(pda, pdarray):
-        return hash_single(pda, full)
+        return _hash_single(pda, full)
 
     repMsg = type_cast(
         str,
@@ -493,7 +493,7 @@ def hash(
 
 
 @typechecked
-def hash_single(pda: pdarray, full: bool = True):
+def _hash_single(pda: pdarray, full: bool = True):
     repMsg = type_cast(
         str,
         generic_msg(

--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -752,21 +752,18 @@ module EfuncMsg
 
         // Call hashArrays on list of given array names
         var hashes = hashArrays(size, names, types, st);
-
-        // Init upper and lower 64-bit entries
-        var upper = new shared SymEntry(s, uint);
-        var lower = new shared SymEntry(s, uint);
+        var upper = makeDistArray(s, uint);
+        var lower = makeDistArray(s, uint);
 
         // Assign upper and lower bit values to their respective entries
-        forall (i, (up, low)) in zip(0..#s, hashes) {
-            upper.a[i] = up;
-            lower.a[i] = low;
+        forall (up, low, h) in zip(upper, lower, hashes) {
+            (up, low) = h;
         }
 
         var upperName = st.nextName();
-        st.addEntry(upperName, upper);
+        st.addEntry(upperName, new shared SymEntry(upper));
         var lowerName = st.nextName();
-        st.addEntry(lowerName, lower);
+        st.addEntry(lowerName, new shared SymEntry(lower));
 
         var repMsg = "created %s+created %s".format(st.attrib(upperName), st.attrib(lowerName));
         eLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg); 


### PR DESCRIPTION
This PR closes #2147 

Through the existing `ak.numeric.hash()` function, adds support to input a list of pdarrays which will then process and return the results from `hashArrays` in Chapel. This will return in a format equivalent to the existing `hash()` functionality which is a Tuple of pdarrays containing the upper and lower 64-bits of the hash. 

Single-pdarray hash functionality is maintained.