### PR TITLE
Closes #2145 - Enable Parquet Read SegArray w/ Empty Segments

### DIFF
--- a/pydoc/file_io/PARQUET.md
+++ b/pydoc/file_io/PARQUET.md
@@ -31,10 +31,11 @@ Data can also be saved using no compression. Arkouda now supports writting Parqu
 ## Supported Write Modes
 
 **Truncate**
-> When writing to Parquet in `truncate` mode, any existing HDF5 file with the same name will be overwritten. If no file exists, one will be created. If writing multiple objects, all corresponding columns will be written to the Paruqet file at once. 
+> When writing to Parquet in `truncate` mode, any existing Parquet file with the same name will be overwritten. If no file exists, one will be created. If writing multiple objects, all corresponding columns will be written to the Paruqet file at once.
 
 **Append**
 > When writting to Parquet in `append` mode, all datasets will be appended to the file. If no file with the supplied name exists, one will be created. If any datasets being written have a name that is already the name of a dataset within the file, an error will be generated.
+>
 >*Please Note: appending to a Parquet file is not natively support and is extremely ineffiecent. It is recommended to read the file out and call `arkouda.io.to_parquet` on the output with the additional columns added and then writting in `truncate` mode.*
 
 ## API Reference

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -265,10 +265,10 @@ int64_t cpp_getStringColumnNumBytes(const char* filename, const char* colname, v
   }
 }
 
-int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* chpl_offsets, int64_t numElems, int64_t startIdx, char** errMsg) {
+int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* chpl_seg_sizes, int64_t numElems, int64_t startIdx, char** errMsg) {
   try {
     int64_t ty = cpp_getType(filename, colname, errMsg);
-    auto offsets = (int64_t*)chpl_offsets;
+    auto seg_sizes = (int64_t*)chpl_seg_sizes;
     int64_t listSize = 0;
     
     if (ty == ARROWLIST){
@@ -313,7 +313,7 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
             int64_t value;
             (void)int_reader->ReadBatch(1, &definition_level, &rep_lvl, &value, &values_read);
             if (values_read == 0 || (!first && rep_lvl == 0)) {
-              offsets[i] = seg_size;
+              seg_sizes[i] = seg_size;
               i++;
               seg_size = 0;
             }
@@ -325,7 +325,7 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
               }
             }
             if (!int_reader->HasNext()){
-              offsets[i] = seg_size;
+              seg_sizes[i] = seg_size;
             }
           }
         } else if(lty == ARROWINT32 || lty == ARROWUINT32) {
@@ -336,7 +336,7 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
             int32_t value;
             (void)int_reader->ReadBatch(1, &definition_level, &rep_lvl, &value, &values_read);
             if (values_read == 0 || (!first && rep_lvl == 0)) {
-              offsets[i] = seg_size;
+              seg_sizes[i] = seg_size;
               i++;
               seg_size = 0;
             }
@@ -348,7 +348,7 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
               }
             }
             if (!int_reader->HasNext()){
-              offsets[i] = seg_size;
+              seg_sizes[i] = seg_size;
             }
           }
         } else if(lty == ARROWBOOLEAN) {
@@ -359,7 +359,7 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
             bool value;
             (void)bool_reader->ReadBatch(1, &definition_level, &rep_lvl, &value, &values_read);
             if (values_read == 0 || (!first && rep_lvl == 0)) {
-              offsets[i] = seg_size;
+              seg_sizes[i] = seg_size;
               i++;
               seg_size = 0;
             }
@@ -371,7 +371,7 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
               }
             }
             if (!bool_reader->HasNext()){
-              offsets[i] = seg_size;
+              seg_sizes[i] = seg_size;
             }
           }
         } else if (lty == ARROWFLOAT) {
@@ -384,7 +384,7 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
             (void)float_reader->ReadBatch(1, &definition_level, &rep_lvl, &value, &values_read);
             // not worried about NaN here so don't need to check values read.
             if (values_read == 0 || (!first && rep_lvl == 0)) {
-              offsets[i] = seg_size;
+              seg_sizes[i] = seg_size;
               i++;
               seg_size = 0;
             }
@@ -396,7 +396,7 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
               }
             }
             if (!float_reader->HasNext()){
-              offsets[i] = seg_size;
+              seg_sizes[i] = seg_size;
             }
           }
         } else if(lty == ARROWDOUBLE) {
@@ -408,7 +408,7 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
             (void)dbl_reader->ReadBatch(1, &definition_level, &rep_lvl, &value, &values_read);
             // not worried about NaN here so don't need to check values read.
             if (values_read == 0 || (!first && rep_lvl == 0)) {
-              offsets[i] = seg_size;
+              seg_sizes[i] = seg_size;
               i++;
               seg_size = 0;
             }
@@ -420,7 +420,7 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
               }
             }
             if (!dbl_reader->HasNext()){
-              offsets[i] = seg_size;
+              seg_sizes[i] = seg_size;
             }
           }
         }
@@ -1326,8 +1326,8 @@ extern "C" {
     return cpp_getStringColumnNumBytes(filename, colname, chpl_offsets, numElems, startIdx, errMsg);
   }
 
-  int64_t c_getListColumnSize(const char* filename, const char* colname, void* chpl_offsets, int64_t numElems, int64_t startIdx, char** errMsg) {
-    return cpp_getListColumnSize(filename, colname, chpl_offsets, numElems, startIdx, errMsg);
+  int64_t c_getListColumnSize(const char* filename, const char* colname, void* chpl_seg_sizes, int64_t numElems, int64_t startIdx, char** errMsg) {
+    return cpp_getListColumnSize(filename, colname, chpl_seg_sizes, numElems, startIdx, errMsg);
   }
 
   int64_t c_getStringColumnNullIndices(const char* filename, const char* colname, void* chpl_nulls, char** errMsg) {

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -312,27 +312,20 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
           while (int_reader->HasNext()) {
             int64_t value;
             (void)int_reader->ReadBatch(1, &definition_level, &rep_lvl, &value, &values_read);
-            if (values_read == 0){ // empty segment
-              if (!int_reader->HasNext() || !first){ // last value 
-                offsets[i] = seg_size;
-                seg_size = 0;
-              }
+            if (values_read == 0 || (!first && rep_lvl == 0)) {
+              offsets[i] = seg_size;
               i++;
-            } else {
-              if (rep_lvl == 0 && !first) {
-                offsets[i] = seg_size;
-                i++;
-                seg_size = 0;
-              }
-              // increment counters
+              seg_size = 0;
+            }
+            if (values_read != 0) {
               seg_size++;
               vct++;
-              first = false;
-              
-              // if this is the last value in the iterator, assign the value in order to set last offset
-              if (!int_reader->HasNext()){
-                offsets[i] = seg_size;
+              if (first) {
+                first = false;
               }
+            }
+            if (!int_reader->HasNext()){
+              offsets[i] = seg_size;
             }
           }
         } else if(lty == ARROWINT32 || lty == ARROWUINT32) {
@@ -341,29 +334,21 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
 
           while (int_reader->HasNext()) {
             int32_t value;
-            
             (void)int_reader->ReadBatch(1, &definition_level, &rep_lvl, &value, &values_read);
-            if (values_read == 0){ // empty segment
-              if (!int_reader->HasNext() || !first){ // last value 
-                offsets[i] = seg_size;
-                seg_size = 0;
-              }
+            if (values_read == 0 || (!first && rep_lvl == 0)) {
+              offsets[i] = seg_size;
               i++;
-            } else {
-              if (rep_lvl == 0 && !first) {
-                offsets[i] = seg_size;
-                i++;
-                seg_size = 0;
-              }
-              // increment counters
+              seg_size = 0;
+            }
+            if (values_read != 0) {
               seg_size++;
               vct++;
-              first = false;
-              
-              // if this is the last value in the iterator, assign the value in order to set last offset
-              if (!int_reader->HasNext()){
-                offsets[i] = seg_size;
+              if (first) {
+                first = false;
               }
+            }
+            if (!int_reader->HasNext()){
+              offsets[i] = seg_size;
             }
           }
         } else if(lty == ARROWBOOLEAN) {
@@ -373,27 +358,20 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
           while (bool_reader->HasNext()) {
             bool value;
             (void)bool_reader->ReadBatch(1, &definition_level, &rep_lvl, &value, &values_read);
-            if (values_read == 0){ // empty segment
-              if (!bool_reader->HasNext() || !first){ // last value 
-                offsets[i] = seg_size;
-                seg_size = 0;
-              }
+            if (values_read == 0 || (!first && rep_lvl == 0)) {
+              offsets[i] = seg_size;
               i++;
-            } else {
-              if (rep_lvl == 0 && !first) {
-                offsets[i] = seg_size;
-                i++;
-                seg_size = 0;
-              }
-              // increment counters
+              seg_size = 0;
+            }
+            if (values_read != 0) {
               seg_size++;
               vct++;
-              first = false;
-              
-              // if this is the last value in the iterator, assign the value in order to set last offset
-              if (!bool_reader->HasNext()){
-                offsets[i] = seg_size;
+              if (first) {
+                first = false;
               }
+            }
+            if (!bool_reader->HasNext()){
+              offsets[i] = seg_size;
             }
           }
         } else if (lty == ARROWFLOAT) {
@@ -403,30 +381,22 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
           int64_t numRead = 0;
           while (float_reader->HasNext()) {
             float value;
-            
             (void)float_reader->ReadBatch(1, &definition_level, &rep_lvl, &value, &values_read);
             // not worried about NaN here so don't need to check values read.
-            if (values_read == 0){ // empty segment
-              if (!float_reader->HasNext() || !first){ // last value 
-                offsets[i] = seg_size;
-                seg_size = 0;
-              }
+            if (values_read == 0 || (!first && rep_lvl == 0)) {
+              offsets[i] = seg_size;
               i++;
-            } else {
-              if (rep_lvl == 0 && !first) {
-                offsets[i] = seg_size;
-                i++;
-                seg_size = 0;
-              }
-              // increment counters
+              seg_size = 0;
+            }
+            if (values_read != 0) {
               seg_size++;
               vct++;
-              first = false;
-              
-              // if this is the last value in the iterator, assign the value in order to set last offset
-              if (!float_reader->HasNext()){
-                offsets[i] = seg_size;
+              if (first) {
+                first = false;
               }
+            }
+            if (!float_reader->HasNext()){
+              offsets[i] = seg_size;
             }
           }
         } else if(lty == ARROWDOUBLE) {
@@ -435,30 +405,22 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
 
           while (dbl_reader->HasNext()) {
             double value;
-            
             (void)dbl_reader->ReadBatch(1, &definition_level, &rep_lvl, &value, &values_read);
             // not worried about NaN here so don't need to check values read.
-            if (values_read == 0){ // empty segment
-              if (!dbl_reader->HasNext() || !first){ // last value 
-                offsets[i] = seg_size;
-                seg_size = 0;
-              }
+            if (values_read == 0 || (!first && rep_lvl == 0)) {
+              offsets[i] = seg_size;
               i++;
-            } else {
-              if (rep_lvl == 0 && !first) {
-                offsets[i] = seg_size;
-                i++;
-                seg_size = 0;
-              }
-              // increment counters
+              seg_size = 0;
+            }
+            if (values_read != 0) {
               seg_size++;
               vct++;
-              first = false;
-              
-              // if this is the last value in the iterator, assign the value in order to set last offset
-              if (!dbl_reader->HasNext()){
-                offsets[i] = seg_size;
+              if (first) {
+                first = false;
               }
+            }
+            if (!dbl_reader->HasNext()){
+              offsets[i] = seg_size;
             }
           }
         }

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -303,6 +303,7 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
         column_reader = row_group_reader->Column(idx);
         int16_t definition_level;
         int16_t rep_lvl;
+        bool first = true;
 
         if(lty == ARROWINT64 || lty == ARROWUINT64) {
           parquet::Int64Reader* int_reader =
@@ -312,15 +313,13 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
             int64_t value;
             (void)int_reader->ReadBatch(1, &definition_level, &rep_lvl, &value, &values_read);
             if (values_read == 0){ // empty segment
-              if (!int_reader->HasNext()){ // last value 
+              if (!int_reader->HasNext() || !first){ // last value 
                 offsets[i] = seg_size;
+                seg_size = 0;
               }
-              else {
-                i++;
-              }
+              i++;
             } else {
-              // new segment starts. This has to be before increment to avoid false empty on first segment.
-              if (rep_lvl == 0 && seg_size >0) {
+              if (rep_lvl == 0 && !first) {
                 offsets[i] = seg_size;
                 i++;
                 seg_size = 0;
@@ -328,6 +327,7 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
               // increment counters
               seg_size++;
               vct++;
+              first = false;
               
               // if this is the last value in the iterator, assign the value in order to set last offset
               if (!int_reader->HasNext()){
@@ -344,15 +344,13 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
             
             (void)int_reader->ReadBatch(1, &definition_level, &rep_lvl, &value, &values_read);
             if (values_read == 0){ // empty segment
-              if (!int_reader->HasNext()){ // last value 
+              if (!int_reader->HasNext() || !first){ // last value 
                 offsets[i] = seg_size;
+                seg_size = 0;
               }
-              else {
-                i++;
-              }
+              i++;
             } else {
-              // new segment starts. This has to be before increment to avoid false empty on first segment.
-              if (rep_lvl == 0 && seg_size >0) {
+              if (rep_lvl == 0 && !first) {
                 offsets[i] = seg_size;
                 i++;
                 seg_size = 0;
@@ -360,6 +358,7 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
               // increment counters
               seg_size++;
               vct++;
+              first = false;
               
               // if this is the last value in the iterator, assign the value in order to set last offset
               if (!int_reader->HasNext()){
@@ -375,15 +374,13 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
             bool value;
             (void)bool_reader->ReadBatch(1, &definition_level, &rep_lvl, &value, &values_read);
             if (values_read == 0){ // empty segment
-              if (!bool_reader->HasNext()){ // last value 
+              if (!bool_reader->HasNext() || !first){ // last value 
                 offsets[i] = seg_size;
+                seg_size = 0;
               }
-              else {
-                i++;
-              }
+              i++;
             } else {
-              // new segment starts. This has to be before increment to avoid false empty on first segment.
-              if (rep_lvl == 0 && seg_size >0) {
+              if (rep_lvl == 0 && !first) {
                 offsets[i] = seg_size;
                 i++;
                 seg_size = 0;
@@ -391,6 +388,7 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
               // increment counters
               seg_size++;
               vct++;
+              first = false;
               
               // if this is the last value in the iterator, assign the value in order to set last offset
               if (!bool_reader->HasNext()){
@@ -409,15 +407,13 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
             (void)float_reader->ReadBatch(1, &definition_level, &rep_lvl, &value, &values_read);
             // not worried about NaN here so don't need to check values read.
             if (values_read == 0){ // empty segment
-              if (!float_reader->HasNext()){ // last value 
+              if (!float_reader->HasNext() || !first){ // last value 
                 offsets[i] = seg_size;
+                seg_size = 0;
               }
-              else {
-                i++;
-              }
+              i++;
             } else {
-              // new segment starts. This has to be before increment to avoid false empty on first segment.
-              if (rep_lvl == 0 && seg_size >0) {
+              if (rep_lvl == 0 && !first) {
                 offsets[i] = seg_size;
                 i++;
                 seg_size = 0;
@@ -425,6 +421,7 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
               // increment counters
               seg_size++;
               vct++;
+              first = false;
               
               // if this is the last value in the iterator, assign the value in order to set last offset
               if (!float_reader->HasNext()){
@@ -442,15 +439,13 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
             (void)dbl_reader->ReadBatch(1, &definition_level, &rep_lvl, &value, &values_read);
             // not worried about NaN here so don't need to check values read.
             if (values_read == 0){ // empty segment
-              if (!dbl_reader->HasNext()){ // last value 
+              if (!dbl_reader->HasNext() || !first){ // last value 
                 offsets[i] = seg_size;
+                seg_size = 0;
               }
-              else {
-                i++;
-              }
+              i++;
             } else {
-              // new segment starts. This has to be before increment to avoid false empty on first segment.
-              if (rep_lvl == 0 && seg_size >0) {
+              if (rep_lvl == 0 && !first) {
                 offsets[i] = seg_size;
                 i++;
                 seg_size = 0;
@@ -458,6 +453,7 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
               // increment counters
               seg_size++;
               vct++;
+              first = false;
               
               // if this is the last value in the iterator, assign the value in order to set last offset
               if (!dbl_reader->HasNext()){

--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -61,9 +61,9 @@ extern "C" {
                                     void* chpl_offsets, int64_t numElems, int64_t startIdx, char** errMsg);
 
   int64_t c_getListColumnSize(const char* filename, const char* colname,
-                                    void* chpl_offsets, int64_t numElems, int64_t startIdx, char** errMsg);
+                                    void* chpl_seg_sizes, int64_t numElems, int64_t startIdx, char** errMsg);
   int64_t cpp_getListColumnSize(const char* filename, const char* colname,
-                                    void* chpl_offsets, int64_t numElems, int64_t startIdx, char** errMsg);
+                                    void* chpl_seg_sizes, int64_t numElems, int64_t startIdx, char** errMsg);
   
   int64_t c_getStringColumnNullIndices(const char* filename, const char* colname, void* chpl_nulls, char** errMsg);
   int64_t cpp_getStringColumnNullIndices(const char* filename, const char* colname, void* chpl_nulls, char** errMsg);

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -673,7 +673,6 @@ module ParquetMsg {
     var seg_sizes = makeDistArray(len, int);
     var listSizes: [filedom] int = calcListSizesandOffset(seg_sizes, filenames, sizes, dsetname);
     var segments = (+ scan seg_sizes) - seg_sizes; // converts segment sizes into offsets
-    writeln("\n\nSegSizes: %jt, Offsets: %jt".format(seg_sizes, segments));
     var rtnmap: map(string, string) = new map(string, string);
 
     if ty == ArrowTypes.int64 || ty == ArrowTypes.int32 {

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -179,6 +179,7 @@ module ParquetMsg {
   }
 
   proc computeIdx(offsets: [] int, val: int, lower_bound: bool = false): int throws {
+    // compute the index of the segment containing val
     if lower_bound {
       var (v, idx) = maxloc reduce zip(offsets >= val, offsets.domain);
       return if v then idx else 0;
@@ -190,6 +191,7 @@ module ParquetMsg {
   }
 
   proc computeEmptySegs(seg_sizes: [] int, offsets: [] int, filedom: domain(1), intersection: domain(1), fileoffset: int): int throws {
+    // Compute the number of empty segments preceeding the current chunk
     if (intersection.low-fileoffset == 0){ //starts the file, no shift needed
       return 0;
     }

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -369,16 +369,16 @@ class ParquetTest(ArkoudaTest):
         })
         table = pa.Table.from_pandas(df)
         table2 = pa.Table.from_pandas(df2)
+        combo = pd.concat([df, df2], ignore_index=True)
         with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
             pq.write_table(table, f"{tmp_dirname}/empty_segments_LOCALE0000")
             pq.write_table(table2, f"{tmp_dirname}/empty_segments_LOCALE0001")
 
             ak_data = ak.read_parquet(f"{tmp_dirname}/empty_segments*")
-            print(ak_data.to_list())
             self.assertIsInstance(ak_data, ak.SegArray)
             self.assertEqual(ak_data.size, 9)
-            for i in range(5):
-                self.assertListEqual(df["ListCol"][i], ak_data[i].tolist())
+            for i in range(9):
+                self.assertListEqual(combo["ListCol"][i], ak_data[i].tolist())
 
         # multi-file with empty segs
         df = pd.DataFrame({
@@ -400,16 +400,16 @@ class ParquetTest(ArkoudaTest):
         })
         table = pa.Table.from_pandas(df)
         table2 = pa.Table.from_pandas(df2)
+        combo = pd.concat([df, df2], ignore_index=True)
         with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
             pq.write_table(table, f"{tmp_dirname}/empty_segments_LOCALE0000")
             pq.write_table(table2, f"{tmp_dirname}/empty_segments_LOCALE0001")
 
             ak_data = ak.read_parquet(f"{tmp_dirname}/empty_segments*")
-            print(ak_data.to_list())
             self.assertIsInstance(ak_data, ak.SegArray)
             self.assertEqual(ak_data.size, 9)
-            for i in range(5):
-                self.assertListEqual(df["ListCol"][i], ak_data[i].tolist())
+            for i in range(9):
+                self.assertListEqual(combo["ListCol"][i], ak_data[i].tolist())
 
 
 

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -309,25 +309,109 @@ class ParquetTest(ArkoudaTest):
             for i in range(8):
                 self.assertListEqual(combo["ListCol"][i], ak_data[i].tolist())
 
+        #test for handling empty segments
+        df = pd.DataFrame({
+            "ListCol": [
+                [],
+                [0, 1],
+                [],
+                [3, 4, 5, 6],
+                []
+            ]
+        })
+        table = pa.Table.from_pandas(df)
+        with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
+            pq.write_table(table, f"{tmp_dirname}/empty_segments")
+
+            ak_data = ak.read_parquet(f"{tmp_dirname}/empty_segments*")
+            self.assertIsInstance(ak_data, ak.SegArray)
+            self.assertEqual(ak_data.size, 5)
+            for i in range(5):
+                self.assertListEqual(df["ListCol"][i], ak_data[i].tolist())
+
         # test for handling empty segments
-        # df = pd.DataFrame({
-        #     "ListCol": [
-        #         [],
-        #         [0, 1],
-        #         []
-        #         [3, 4, 5, 6],
-        #         []
-        #     ]
-        # })
-        # table = pa.Table.from_pandas(df)
-        # with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
-        #     pq.write_table(table, f"{tmp_dirname}/empty_segments")
-        #
-        #     ak_data = ak.read_parquet(f"{tmp_dirname}/empty_segments*")
-        #     self.assertIsInstance(ak_data, ak.SegArray)
-        #     self.assertEqual(ak_data.size, 4)
-        #     for i in range(4):
-        #         self.assertListEqual(df["ListCol"][i], ak_data[i].tolist())
+        df = pd.DataFrame({
+            "ListCol": [
+                [8],
+                [0, 1],
+                [],
+                [3, 4, 5, 6],
+                []
+            ]
+        })
+        table = pa.Table.from_pandas(df)
+        with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
+            pq.write_table(table, f"{tmp_dirname}/empty_segments")
+
+            ak_data = ak.read_parquet(f"{tmp_dirname}/empty_segments*")
+            self.assertIsInstance(ak_data, ak.SegArray)
+            self.assertEqual(ak_data.size, 5)
+            for i in range(5):
+                self.assertListEqual(df["ListCol"][i], ak_data[i].tolist())
+
+        # multi-file with empty segs
+        df = pd.DataFrame({
+            "ListCol": [
+                [],
+                [0, 1],
+                [],
+                [3, 4, 5, 6],
+                []
+            ]
+        })
+        df2 = pd.DataFrame({
+            "ListCol": [
+                [0, 1],
+                [],
+                [3, 4, 5, 6],
+                [1, 2, 3]
+            ]
+        })
+        table = pa.Table.from_pandas(df)
+        table2 = pa.Table.from_pandas(df2)
+        with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
+            pq.write_table(table, f"{tmp_dirname}/empty_segments_LOCALE0000")
+            pq.write_table(table2, f"{tmp_dirname}/empty_segments_LOCALE0001")
+
+            ak_data = ak.read_parquet(f"{tmp_dirname}/empty_segments*")
+            print(ak_data.to_list())
+            self.assertIsInstance(ak_data, ak.SegArray)
+            self.assertEqual(ak_data.size, 9)
+            for i in range(5):
+                self.assertListEqual(df["ListCol"][i], ak_data[i].tolist())
+
+        # multi-file with empty segs
+        df = pd.DataFrame({
+            "ListCol": [
+                [8],
+                [0, 1],
+                [],
+                [3, 4, 5, 6],
+                []
+            ]
+        })
+        df2 = pd.DataFrame({
+            "ListCol": [
+                [0, 1],
+                [],
+                [3, 4, 5, 6],
+                [1, 2, 3]
+            ]
+        })
+        table = pa.Table.from_pandas(df)
+        table2 = pa.Table.from_pandas(df2)
+        with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
+            pq.write_table(table, f"{tmp_dirname}/empty_segments_LOCALE0000")
+            pq.write_table(table2, f"{tmp_dirname}/empty_segments_LOCALE0001")
+
+            ak_data = ak.read_parquet(f"{tmp_dirname}/empty_segments*")
+            print(ak_data.to_list())
+            self.assertIsInstance(ak_data, ak.SegArray)
+            self.assertEqual(ak_data.size, 9)
+            for i in range(5):
+                self.assertListEqual(df["ListCol"][i], ak_data[i].tolist())
+
+
 
     @pytest.mark.optional_parquet
     def test_against_standard_files(self):


### PR DESCRIPTION
Closes #2145 

- Updates Parquet SegArray read workflow to properly account for and handle SegArrays with empty segments.
- Adds multiple test cases to ensure functionality with different locations of empty segments.
- Minor updates to documentation for Parquet to correct formatting.

**Important Note**
This code does not functions for SegArrays saved to Parquet with ALL segments empty. This is because most toolsets save this as a list of `nulls`. Currently, Arkouda does not have any support for Parquet `nulls` to be read. This will need to be added as a handled datatype and will be handled separately.