### PR TITLE
Add some error handling code for upcoming change to map module

### DIFF
--- a/src/MetricsMsg.chpl
+++ b/src/MetricsMsg.chpl
@@ -194,7 +194,7 @@ module MetricsMsg {
         // total value of measurements to be averaged for each metric measured.s
         var measurementTotals = new map(string, real);
 
-        proc getNumMeasurements(metric: string) {
+        proc getNumMeasurements(metric: string) throws {
             if this.numMeasurements.contains(metric) {
                 return this.numMeasurements(metric) + 1;
             } else {
@@ -202,7 +202,7 @@ module MetricsMsg {
             }
         }
         
-        proc getMeasurementTotal(metric: string) : real {
+        proc getMeasurementTotal(metric: string) : real throws {
             var value: real;
 
             if !this.measurementTotals.contains(metric) {

--- a/src/RandArray.chpl
+++ b/src/RandArray.chpl
@@ -104,11 +104,13 @@ module RandArray {
   }
 
   var charBounds: map(keyType=charSet, valType=2*int, parSafe=false);
-  charBounds[charSet.Uppercase] = (65, 91);
-  charBounds[charSet.Lowercase] = (97, 123);
-  charBounds[charSet.Numeric] = (48, 58);
-  charBounds[charSet.Printable] = (32, 127);
-  charBounds[charSet.Binary] = (0, 0);
+  try! {
+    charBounds[charSet.Uppercase] = (65, 91);
+    charBounds[charSet.Lowercase] = (97, 123);
+    charBounds[charSet.Numeric] = (48, 58);
+    charBounds[charSet.Printable] = (32, 127);
+    charBounds[charSet.Binary] = (0, 0);
+  }
 
   proc newRandStringsUniformLength(const n: int,
                                    const minLen: int, 


### PR DESCRIPTION
For the upcoming Chapel 1.30 release, we have made map methods throw instead of halt in https://github.com/chapel-lang/chapel/pull/21641. This means that, in order for Arkouda to build with the latest changes, we need to add `throws` in places where it was missing where the map accessors were being used in functions and add a `try!` when map accessors are used in module-level code (this is happening in `RandArray.chpl`). This does not change the behavior of the code in `RandArray`, but makes it so that invalid accesses will throw errors rather than crashing the server in `MetricsMsg`.