### PR TITLE
Use Chapel runtime view of allocatable memory when available

### DIFF
--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -210,11 +210,18 @@ module ServerConfig
     }
 
     /*
-    Get the physical memory available on this locale
+    Get an estimate for how much memory can be allocated. Based on runtime with
+    chpl_comm_regMemHeapInfo if using a fixed heap, otherwise physical memory
     */ 
     proc getPhysicalMemHere() {
-        use Memory.Diagnostics;
-        return here.physicalMemory();
+        use Memory.Diagnostics, CTypes;
+        extern proc chpl_comm_regMemHeapInfo(start: c_ptr(c_void_ptr), size: c_ptr(c_size_t)): void;
+        var unused: c_void_ptr;
+        var heap_size: c_size_t;
+        chpl_comm_regMemHeapInfo(c_ptrTo(unused), c_ptrTo(heap_size));
+        if heap_size != 0 then
+            return heap_size.safeCast(int);
+        return here.physicalMemory(unit = MemUnits.Bytes);
     }
 
     /*


### PR DESCRIPTION
Historically, Arkouda has just used the amount of physical memory to determine when an operation may exceed memory capacity, but this isn't always and accurate representation of how much memory can be allocated. When a fixed heap is being used, ask the runtime how large the heap is since that represents the max amount of memory that can be allocated.

Currently, this uses an internal runtime call but I'll look to see if something like this could be added to the standard library.

Part of #2044