### PR TITLE
Closes #2166 - Add CI as Protection to Merge Queue

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [push, pull_request, merge_group]
 
 env:
   ARKOUDA_QUICK_COMPILE: true


### PR DESCRIPTION
Closes #2166 

Adds CI as a Protection to our merge queue. This will require CI to pass again before the merge is completed.