### PR TITLE
Closes #2168 - Remove push from on clause

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request, merge_group]
+on: [pull_request, merge_group]
 
 env:
   ARKOUDA_QUICK_COMPILE: true


### PR DESCRIPTION
Closes #2168 

Removes `push` from `on` clause in `CI.yml` since we are not using Merge Queue, we don't need to rerun CI on master after running on the Queue.