### PR TITLE
Closes #2163 - Fixes SymEntry Destruction Issue

### DIFF
--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -246,6 +246,7 @@ class GroupBy:
         # This prevents non-bool values that can be evaluated to true (ie non-empty arrays)
         # from causing unexpected results. Experienced when forgetting to wrap multiple key arrays in [].
         # See Issue #1267
+        self.name = None
         if not isinstance(assume_sorted, bool):
             raise TypeError("assume_sorted must be of type bool.")
 

--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -294,6 +294,13 @@ class GroupBy:
             else:
                 self.unique_keys = tuple(a[uki] for a in self.keys)
 
+    def __del__(self):
+        try:
+            if self.name:
+                generic_msg(cmd="delete", args={"name": self.name})
+        except RuntimeError:
+            pass
+
     def size(self) -> Tuple[groupable, pdarray]:
         """
         Count the number of elements in each group, i.e. the number of times

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -164,6 +164,12 @@ module UniqueMsg
         return (permutation, segments);
       }
 
+      inline proc cleanup(str_names: [] string, st) throws {
+        forall name in str_names {
+          st.deleteEntry(name);
+        }
+      }
+
       if hasStr && n == 1 {
         // Only one array which is a strings
         var (myNames, _) = namesList[0].splitMsgToTuple("+", 2);
@@ -173,10 +179,26 @@ module UniqueMsg
         if max_bytes < 16 {
           var str_names = strings.bytesToUintArr(max_bytes, st).split("+");
           var (totalDigits, bitWidths, negs) = getNumDigitsNumericArrays(str_names, st);
-          if totalDigits <= 2 { return helper(2 * bitsPerDigit / 8, 2*uint(bitsPerDigit), mergeNumericArrays(2, size, totalDigits, bitWidths, negs, str_names, st)); }
-          if totalDigits <= 4 { return helper(4 * bitsPerDigit / 8, 4*uint(bitsPerDigit), mergeNumericArrays(4, size, totalDigits, bitWidths, negs, str_names, st)); }
-          if totalDigits <= 6 { return helper(6 * bitsPerDigit / 8, 6*uint(bitsPerDigit), mergeNumericArrays(6, size, totalDigits, bitWidths, negs, str_names, st)); }
-          if totalDigits <= 8 { return helper(8 * bitsPerDigit / 8, 8*uint(bitsPerDigit), mergeNumericArrays(8, size, totalDigits, bitWidths, negs, str_names, st)); }
+          if totalDigits <= 2 { 
+            var (perm, segments) = helper(2 * bitsPerDigit / 8, 2*uint(bitsPerDigit), mergeNumericArrays(2, size, totalDigits, bitWidths, negs, str_names, st));
+            cleanup(str_names, st);
+            return (perm, segments);
+          }
+          if totalDigits <= 4 { 
+            var (perm, segments) = helper(4 * bitsPerDigit / 8, 4*uint(bitsPerDigit), mergeNumericArrays(4, size, totalDigits, bitWidths, negs, str_names, st));
+            cleanup(str_names, st);
+            return (perm, segments);
+          }
+          if totalDigits <= 6 { 
+            var (perm, segments) = helper(6 * bitsPerDigit / 8, 6*uint(bitsPerDigit), mergeNumericArrays(6, size, totalDigits, bitWidths, negs, str_names, st));
+            cleanup(str_names, st);
+            return (perm, segments);
+          }
+          if totalDigits <= 8 { 
+            var (perm, segments) = helper(8 * bitsPerDigit / 8, 8*uint(bitsPerDigit), mergeNumericArrays(8, size, totalDigits, bitWidths, negs, str_names, st));
+            cleanup(str_names, st);
+            return (perm, segments);
+          }
         }
       }
 

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -165,7 +165,7 @@ module UniqueMsg
       }
 
       inline proc cleanup(str_names: [] string, st) throws {
-        forall name in str_names {
+        for name in str_names {
           st.deleteEntry(name);
         }
       }

--- a/tests/categorical_test.py
+++ b/tests/categorical_test.py
@@ -384,6 +384,17 @@ class CategoricalTest(ArkoudaTest):
         ret = ak.lookup(keys, values, args)
         self.assertListEqual(ret.to_list(), ["C", "B", "A", "N/A"])
 
+    def test_deletion(self):
+        cat = ak.Categorical(ak.array(["a", "b", "c"]))
+
+        # validate registration with server
+        self.assertTrue(len(ak.list_symbol_table()) > 0)
+
+        # set to none and validate no entries in symbol table
+        cat = None
+        self.assertEqual(len(ak.list_symbol_table()), 0)
+
+
     def tearDown(self):
         super(CategoricalTest, self).tearDown()
         for f in glob.glob("{}/*".format(CategoricalTest.cat_test_base_tmp)):

--- a/tests/categorical_test.py
+++ b/tests/categorical_test.py
@@ -362,6 +362,8 @@ class CategoricalTest(ArkoudaTest):
         c2 = ak.Categorical.attach("my_categorical")
         self.assertEqual(c2.NAvalue, "C")
 
+        c.unregister()
+
         # default NAval not present in categories
         c = ak.Categorical(s)
         self.assertTrue(not c.isna().any())
@@ -386,7 +388,6 @@ class CategoricalTest(ArkoudaTest):
 
     def test_deletion(self):
         cat = ak.Categorical(ak.array(["a", "b", "c"]))
-
         # validate registration with server
         self.assertTrue(len(ak.list_symbol_table()) > 0)
 


### PR DESCRIPTION
Closes #2163

Updates the `GroupBy` client class to send a `delete` command to the Arkouda Server to delete the associated `GroupBySymEntry` if one exists when the client destruction is called. 

Updates a workflow on the server to remove `SymEntries` from the Symbol Table after they are used. The code is calling a function that requires the entries be added to the symbol table, so we just remove them after they are used.

Adds testing to ensure that when the Categorical object is deleted, the associated components in the Symbol Table are removed.