### PR TITLE
2171 enhance arkouda response time metrics

### DIFF
--- a/src/MetricsMsg.chpl
+++ b/src/MetricsMsg.chpl
@@ -28,6 +28,8 @@ module MetricsMsg {
     var requestMetrics = new CounterTable();
     
     var avgResponseTimeMetrics = new AverageMeasurementTable();
+    
+    var responseTimeMetrics = new MeasurementTable();
 
     var users = new Users();
     
@@ -170,8 +172,13 @@ module MetricsMsg {
             }
         }   
 
-        proc set(metric: string, measurement: real) {
+        proc set(metric: string, measurement: real) throws {
             this.measurements.addOrSet(metric, measurement);
+            
+            mLogger.debug(getModuleName(),
+                          getRoutineName(),
+                          getLineNumber(),
+                          "Set Response Time cmd: %s time %t".format(metric,measurement));
         }
 
         proc size() {
@@ -294,6 +301,9 @@ module MetricsMsg {
         for metric in getNumRequestMetrics() {
             metrics.append(metric);
         }
+        for metric in getResponseTimeMetrics() {
+            metrics.append(metric);
+        }        
         for metric in getAvgResponseTimeMetrics() {
             metrics.append(metric);
         }
@@ -359,6 +369,18 @@ module MetricsMsg {
         return metrics;
     }
 
+
+    proc getResponseTimeMetrics() throws {
+        var metrics = new list(owned Metric?);
+
+        for item in responseTimeMetrics.items() {
+            metrics.append(new Metric(name=item[0], 
+                                      category=MetricCategory.RESPONSE_TIME,
+                                      value=item[1]));
+        }
+
+        return metrics;
+    }
 
     proc getAvgResponseTimeMetrics() throws {
         var metrics = new list(owned Metric?);

--- a/src/MetricsMsg.chpl
+++ b/src/MetricsMsg.chpl
@@ -174,11 +174,6 @@ module MetricsMsg {
 
         proc set(metric: string, measurement: real) throws {
             this.measurements.addOrSet(metric, measurement);
-            
-            mLogger.debug(getModuleName(),
-                          getRoutineName(),
-                          getLineNumber(),
-                          "Set Response Time cmd: %s time %t".format(metric,measurement));
         }
 
         proc size() {
@@ -230,13 +225,8 @@ module MetricsMsg {
             this.measurementTotals(metric) += measurement;
 
             var value: real = this.measurementTotals(metric)/numMeasurements;
-  
-            this.measurements.addOrSet(metric, value);
 
-            mLogger.debug(getModuleName(),
-                          getRoutineName(),
-                          getLineNumber(),
-                          "Added Avg Response Time cmd: %s time %t".format(metric,value));
+            this.measurements.addOrSet(metric, value);
         }
     }
 

--- a/src/ServerDaemon.chpl
+++ b/src/ServerDaemon.chpl
@@ -413,17 +413,16 @@ module ServerDaemon {
             
             // Update User-Scoped Request Metrics
             userMetrics.incrementPerUserRequestMetrics(user,cmd);
+            
+            // Add the response time to the avg response time for the corresponding cmd
+            avgResponseTimeMetrics.add(cmd,elapsedTime);
 
             var apo = getArrayParameterObj(args);
 
             // Check to see if the incoming request corresponds to a pdarray operation
             if computeArrayMetrics(apo) {
                 var name = apo.val;
-                var value = elapsedTime;
-                
-                // Add the response time to the avg response time for the corresponding cmd
-                avgResponseTimeMetrics.add(cmd,value);
-            
+
                 /*
                  * Create the ArrayMetric object and output the individual response time
                  * as JSON to the console or arkouda.log for now. In the future, individual  
@@ -433,7 +432,7 @@ module ServerDaemon {
                 var metric = new ArrayMetric(name=name,
                                              category=MetricCategory.RESPONSE_TIME,
                                              scope=MetricScope.REQUEST,
-                                             value=value,
+                                             value=elapsedTime,
                                              cmd=cmd,
                                              dType=str2dtype(apo.dtype),
                                              size=getGenericTypedArrayEntry(apo.val, st).size

--- a/src/ServerDaemon.chpl
+++ b/src/ServerDaemon.chpl
@@ -646,10 +646,11 @@ module ServerDaemon {
                 }
                 if (trace && memTrack) {
                     var memUsed = getMemUsed():uint * numLocales:uint;
-                    var pctMemUsed = ((memUsed:real/memMax:real)*100):int;
+                    var pctMemUsed = ((memUsed:real/getMemLimit():real)*100):int;
                     sdLogger.info(getModuleName(),getRoutineName(),getLineNumber(),
-                        "bytes of memory %t pct of max memory %t%% used after command".format(memUsed,
-                                                                                            pctMemUsed));
+                        "bytes of memory %t pct of max memory %t%% used after %s command".format(memUsed,
+                                                                                                 pctMemUsed,
+                                                                                                 cmd));
                 }
                 if metricsEnabled() {
                     processMetrics(user, cmd, msgArgs, elapsedTime);

--- a/src/ServerDaemon.chpl
+++ b/src/ServerDaemon.chpl
@@ -408,13 +408,16 @@ module ServerDaemon {
                return !obj.key.isEmpty();
             }
           
-            // Update Request Metrics
+            // Update request metrics for the cmd
             requestMetrics.increment(cmd);
             
-            // Update User-Scoped Request Metrics
+            // Update user-scoped request metrics for the cmd
             userMetrics.incrementPerUserRequestMetrics(user,cmd);
+
+            // Update response time metric for the cmd
+            responseTimeMetrics.set(cmd,elapsedTime);
             
-            // Add the response time to the avg response time for the corresponding cmd
+            // Add response time to the avg response time for the cmd
             avgResponseTimeMetrics.add(cmd,elapsedTime);
 
             var apo = getArrayParameterObj(args);

--- a/src/ServerDaemon.chpl
+++ b/src/ServerDaemon.chpl
@@ -417,8 +417,18 @@ module ServerDaemon {
             // Update response time metric for the cmd
             responseTimeMetrics.set(cmd,elapsedTime);
             
+            sdLogger.debug(getModuleName(),
+                          getRoutineName(),
+                          getLineNumber(),
+                          "Set Response Time cmd: %s time %t".format(cmd,elapsedTime));
+            
             // Add response time to the avg response time for the cmd
             avgResponseTimeMetrics.add(cmd,elapsedTime);
+            
+            sdLogger.debug(getModuleName(),
+                          getRoutineName(),
+                          getLineNumber(),
+                          "Added Avg Response Time cmd: %s time %t".format(cmd,elapsedTime));
 
             var apo = getArrayParameterObj(args);
 


### PR DESCRIPTION
Closes #2171 

This PR does the following:

1. updates the avgResponseTimeMetrics logic, moving it from  [here](https://github.com/Bears-R-Us/arkouda/blob/6d33135b9894f0cf7294ecd41d9edaa6ce2b2bb3/src/ServerDaemon.chpl#L425) to ensure all command response times are calculated as implemented [here](https://github.com/hokiegeek2/arkouda/blob/e384a933a87a888406bc3c27605e6011179df576/src/ServerDaemon.chpl#L418). This was needed b/c avg response times were only being calculated for commands executed on existing pdarrays
2. enables response times for all commands