### PR TITLE
Closes #2175: Add check for local domain size before passing as C pointer

### DIFF
--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -1031,32 +1031,40 @@ module ParquetMsg {
             var e = toSymEntry(toGenSymEntry(entry), int);
             var locDom = e.a.localSubdomain();
             // set the pointer to the entry array in the list of Pointers
-            ptrList[i] = c_ptrTo(e.a[locDom]): c_void_ptr;
-            datatypes[i] = ARROWINT64;
-            sizeList[i] = locDom.size;
+            if locDom.size > 0 {
+              ptrList[i] = c_ptrTo(e.a[locDom]): c_void_ptr;
+              datatypes[i] = ARROWINT64;
+              sizeList[i] = locDom.size;
+            }
           }
           when DType.UInt64 {
             var e = toSymEntry(toGenSymEntry(entry), uint);
             var locDom = e.a.localSubdomain();
             // set the pointer to the entry array in the list of Pointers
-            ptrList[i] = c_ptrTo(e.a[locDom]): c_void_ptr;
-            datatypes[i] = ARROWUINT64;
-            sizeList[i] = locDom.size;
+            if locDom.size > 0 {
+              ptrList[i] = c_ptrTo(e.a[locDom]): c_void_ptr;
+              datatypes[i] = ARROWUINT64;
+              sizeList[i] = locDom.size;
+            }
           }
           when DType.Bool {
             var e = toSymEntry(toGenSymEntry(entry), bool);
             var locDom = e.a.localSubdomain();
             // set the pointer to the entry array in the list of Pointers
-            ptrList[i] = c_ptrTo(e.a[locDom]): c_void_ptr;
-            datatypes[i] = ARROWBOOLEAN;
-            sizeList[i] = locDom.size;
+            if locDom.size > 0 {
+              ptrList[i] = c_ptrTo(e.a[locDom]): c_void_ptr;
+              datatypes[i] = ARROWBOOLEAN;
+              sizeList[i] = locDom.size;
+            }
           } when DType.Float64 {
             var e = toSymEntry(toGenSymEntry(entry), real);
             var locDom = e.a.localSubdomain();
             // set the pointer to the entry array in the list of Pointers
-            ptrList[i] = c_ptrTo(e.a[locDom]): c_void_ptr;
-            datatypes[i] = ARROWDOUBLE;
-            sizeList[i] = locDom.size;
+            if locDom.size > 0 {
+              ptrList[i] = c_ptrTo(e.a[locDom]): c_void_ptr;
+              datatypes[i] = ARROWDOUBLE;
+              sizeList[i] = locDom.size;
+            }
           } when DType.Strings {
             var e: SegStringSymEntry = toSegStringSymEntry(entry);
             var segStr = new SegString("", e);


### PR DESCRIPTION
In the case where an Arkouda server is running with more locales than the number of columns in a dataframe, Arkouda is attempting to pass a C pointer to an empty slice, which results in an OOB error in Chapel.