### PR TITLE
Improve bigint `>>` performance

### DIFF
--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -1171,10 +1171,9 @@ module BinOp
             // workaround for right shift until chapel issue #21206
             // makes it into a release, eventually we can just do
             // tmp = la >> ra;
-            var divideBy = makeDistArray(la.size, bigint);
-            divideBy = 1:bigint;
-            divideBy <<= ra;
-            forall (t, dB) in zip(tmp, divideBy) with (var local_max_size = max_size) {
+            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+              var dB = 1:bigint;
+              dB <<= ri;
               t /= dB;
               if has_max_bits {
                 t &= local_max_size;
@@ -1426,10 +1425,7 @@ module BinOp
             // workaround for right shift until chapel issue #21206
             // makes it into a release, eventually we can just do
             // tmp = la >> ra;
-            var divideBy = makeDistArray(la.size, bigint);
-            divideBy = 1:bigint;
-            divideBy <<= val;
-            forall (t, dB) in zip(tmp, divideBy) with (var local_max_size = max_size) {
+            forall t in tmp with (var dB = (1:bigint) << val, var local_max_size = max_size) {
               t /= dB;
               if has_max_bits {
                 t &= local_max_size;
@@ -1698,10 +1694,9 @@ module BinOp
             // workaround for right shift until chapel issue #21206
             // makes it into a release, eventually we can just do
             // tmp = val >> ra;
-            var divideBy = makeDistArray(ra.size, bigint);
-            divideBy = 1:bigint;
-            divideBy <<= ra;
-            forall (t, dB) in zip(tmp, divideBy) with (var local_max_size = max_size) {
+            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
+              var dB = 1:bigint;
+              dB <<= ri;
               t /= dB;
               if has_max_bits {
                 t &= local_max_size;


### PR DESCRIPTION
Avoid assigning bigint arrays from a single bigint value, which results in lot of communication since that value lives on a single locale.

16-node-cs-hdr results for a small problem size:

Before:
```
./benchmarks/run_benchmarks.py bigint_bitwise_binops -nl 16 --size=1000000
Average bigint SHIFT time = 3.8234 sec
Average bigint SHIFT rate = 0.06 GiB/sec
```

After:
```
./benchmarks/run_benchmarks.py bigint_bitwise_binops -nl 16 --size=1000000
Average bigint SHIFT time = 0.0950 sec
Average bigint SHIFT rate = 2.51 GiB/sec
```

And with a larger (default) problem size after:
```
./benchmarks/run_benchmarks.py bigint_bitwise_binops -nl 16 --size=$((10**8))
Average bigint SHIFT time = 7.4676 sec
Average bigint SHIFT rate = 3.19 GiB/sec
```