### PR TITLE
Closes #2119 - Parquet Write SegArray

### DIFF
--- a/ServerModules.cfg
+++ b/ServerModules.cfg
@@ -1,34 +1,42 @@
 # Comment out modules using a `#` to exclude
 # a module from a build
 
-ArraySetopsMsg
-KExtremeMsg
-ArgSortMsg
-SegmentedMsg
-DataFrameIndexingMsg
-OperatorMsg
-RandMsg
+# ArraySetopsMsg
+# KExtremeMsg
+# ArgSortMsg
+# SegmentedMsg
+# DataFrameIndexingMsg
+# OperatorMsg
+# RandMsg
+# IndexingMsg
+# UniqueMsg
+# In1dMsg
+# HistogramMsg
+# SequenceMsg
+# SortMsg
+# ReductionMsg
+# EfuncMsg
+# ConcatenateMsg
+# JoinEqWithDTMsg
+# RegistrationMsg
+# CastMsg
+# BroadcastMsg
+# FlattenMsg
+# StatsMsg
+# TimeClassMsg
+# HDF5Msg
+# ParquetMsg
+# CSVMsg
+# EncodingMsg
+# GroupByMsg
 IndexingMsg
-UniqueMsg
-In1dMsg
-HistogramMsg
 SequenceMsg
-SortMsg
-ReductionMsg
-EfuncMsg
-ConcatenateMsg
-JoinEqWithDTMsg
-RegistrationMsg
-CastMsg
 BroadcastMsg
-FlattenMsg
-StatsMsg
-TimeClassMsg
-HDF5Msg
+ReductionMsg
 ParquetMsg
-CSVMsg
-EncodingMsg
 GroupByMsg
+OperatorMsg
+SegmentedMsg
 
 # Add additional modules located outside
 # of the Arkouda src/ directory below.

--- a/ServerModules.cfg
+++ b/ServerModules.cfg
@@ -1,42 +1,34 @@
 # Comment out modules using a `#` to exclude
 # a module from a build
 
-# ArraySetopsMsg
-# KExtremeMsg
-# ArgSortMsg
-# SegmentedMsg
-# DataFrameIndexingMsg
-# OperatorMsg
-# RandMsg
-# IndexingMsg
-# UniqueMsg
-# In1dMsg
-# HistogramMsg
-# SequenceMsg
-# SortMsg
-# ReductionMsg
-# EfuncMsg
-# ConcatenateMsg
-# JoinEqWithDTMsg
-# RegistrationMsg
-# CastMsg
-# BroadcastMsg
-# FlattenMsg
-# StatsMsg
-# TimeClassMsg
-# HDF5Msg
-# ParquetMsg
-# CSVMsg
-# EncodingMsg
-# GroupByMsg
-IndexingMsg
-SequenceMsg
-BroadcastMsg
-ReductionMsg
-ParquetMsg
-GroupByMsg
-OperatorMsg
+ArraySetopsMsg
+KExtremeMsg
+ArgSortMsg
 SegmentedMsg
+DataFrameIndexingMsg
+OperatorMsg
+RandMsg
+IndexingMsg
+UniqueMsg
+In1dMsg
+HistogramMsg
+SequenceMsg
+SortMsg
+ReductionMsg
+EfuncMsg
+ConcatenateMsg
+JoinEqWithDTMsg
+RegistrationMsg
+CastMsg
+BroadcastMsg
+FlattenMsg
+StatsMsg
+TimeClassMsg
+HDF5Msg
+ParquetMsg
+CSVMsg
+EncodingMsg
+GroupByMsg
 
 # Add additional modules located outside
 # of the Arkouda src/ directory below.

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1409,6 +1409,7 @@ class pdarray:
                     "dset": dataset,
                     "mode": _mode_str_to_int(mode),
                     "prefix": prefix_path,
+                    "objType": "pdarray",
                     "dtype": self.dtype,
                     "compression": compression,
                 },

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -1036,7 +1036,7 @@ class SegArray:
         )
 
     def to_parquet(self, prefix_path, dataset="segarray", mode: str = "truncate", compression: Optional[str] = None):
-        from arkouda.io import mode_str_to_int
+        from arkouda.io import _mode_str_to_int
         return type_cast(
             str,
             generic_msg(
@@ -1044,7 +1044,7 @@ class SegArray:
                 {
                     "values": self.name,
                     "dset": dataset,
-                    "mode": mode_str_to_int(mode),
+                    "mode": _mode_str_to_int(mode),
                     "prefix": prefix_path,
                     "objType": "segarray",
                     "dtype": self.dtype,

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -1074,7 +1074,6 @@ class SegArray:
         have write permission.
         - Output files have names of the form ``<prefix_path>_LOCALE<i>``, where ``<i>``
         ranges from 0 to ``numLocales`` for `file_type='distribute'`.
-        - 'append' write mode is supported, but is not efficient.
         - If any of the output files already exist and
         the mode is 'truncate', they will be overwritten. If the mode is 'append'
         and the number of output files is less than the number of locales or a

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import warnings
 from typing import cast as type_cast
+from typing import Optional
 
 import numpy as np  # type: ignore
 
@@ -1030,6 +1031,24 @@ class SegArray:
                     "dtype": self.dtype,
                     "objType": "segarray",
                     "file_format": _file_type_to_int(file_type),
+                },
+            ),
+        )
+
+    def to_parquet(self, prefix_path, dataset="segarray", mode: str = "truncate", compression: Optional[str] = None):
+        from arkouda.io import mode_str_to_int
+        return type_cast(
+            str,
+            generic_msg(
+                "writeParquet",
+                {
+                    "values": self.name,
+                    "dset": dataset,
+                    "mode": mode_str_to_int(mode),
+                    "prefix": prefix_path,
+                    "objType": "segarray",
+                    "dtype": self.dtype,
+                    "compression": compression,
                 },
             ),
         )

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -856,7 +856,7 @@ class SegArray:
         ndsegs = self.segments.to_ndarray()
         arr = [ndvals[start:end] for start, end in zip(ndsegs, ndsegs[1:])]
         if self.size > 0:
-            arr.append(ndvals[ndsegs[-1]:])
+            arr.append(ndvals[ndsegs[-1] :])
         return np.array(arr, dtype=object)
 
     def to_list(self):
@@ -1035,7 +1035,9 @@ class SegArray:
             ),
         )
 
-    def to_parquet(self, prefix_path, dataset="segarray", mode: str = "truncate", compression: Optional[str] = None):
+    def to_parquet(
+        self, prefix_path, dataset="segarray", mode: str = "truncate", compression: Optional[str] = None
+    ):
         """
         Save the SegArray object to Parquet. The result is a collection of files,
         one file per locale of the arkouda server, where each filename starts
@@ -1083,7 +1085,7 @@ class SegArray:
         from arkouda.io import _mode_str_to_int
 
         if mode.lower() == "append":
-            raise ValueError(f"Append mode is not supported for SegArray.")
+            raise ValueError("Append mode is not supported for SegArray.")
 
         return type_cast(
             str,
@@ -1191,7 +1193,7 @@ class SegArray:
             DeprecationWarning,
         )
         if segment_name != "segments" or value_name != "values":
-            dataset = [dataset+"_"+value_name, dataset+"_"+segment_name]
+            dataset = [dataset + "_" + value_name, dataset + "_" + segment_name]
         return cls.read_hdf(prefix_path, dataset)
 
     def intersect(self, other):

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1945,6 +1945,7 @@ class Strings:
                     "dset": dataset,
                     "mode": _mode_str_to_int(mode),
                     "prefix": prefix_path,
+                    "objType": "strings",
                     "dtype": self.dtype,
                     "compression": compression,
                 },

--- a/pydoc/file_io/PARQUET.md
+++ b/pydoc/file_io/PARQUET.md
@@ -13,7 +13,7 @@ More information on Parquet can be found [here](https://parquet.apache.org/).
 - DataFrame
 - Strings
 - SegArray
-  - Read Only (Writes coming soon. Track progress [here](https://github.com/Bears-R-Us/arkouda/issues/2119))
+  - Writing multi-column files not yet supported. Track [here](https://github.com/Bears-R-Us/arkouda/issues/2186))
   - Strings dtype not yet supported. Track [here](https://github.com/Bears-R-Us/arkouda/issues/2121)
 
 ## Compression
@@ -34,7 +34,7 @@ Data can also be saved using no compression. Arkouda now supports writting Parqu
 > When writing to Parquet in `truncate` mode, any existing Parquet file with the same name will be overwritten. If no file exists, one will be created. If writing multiple objects, all corresponding columns will be written to the Paruqet file at once.
 
 **Append**
-> When writting to Parquet in `append` mode, all datasets will be appended to the file. If no file with the supplied name exists, one will be created. If any datasets being written have a name that is already the name of a dataset within the file, an error will be generated.
+> When writting to Parquet in `append` mode, all datasets will be appended to the file. If no file with the supplied name exists, one will be created. If any datasets being written have a name that is already the name of a dataset within the file, an error will be generated. Append is not supported for SegArray objects.
 >
 >*Please Note: appending to a Parquet file is not natively support and is extremely ineffiecent. It is recommended to read the file out and call `arkouda.io.to_parquet` on the output with the additional columns added and then writting in `truncate` mode.*
 
@@ -67,6 +67,12 @@ Data can also be saved using no compression. Arkouda now supports writting Parqu
 ```{eval-rst}  
 - :py:meth:`arkouda.Strings.to_parquet`
 - :py:meth:`arkouda.Strings.save`
+```
+
+### SegArray
+
+```{eval-rst}  
+- :py:meth:`arkouda.SegArray.to_parquet`
 ```
 
 ### Categorical

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -569,13 +569,14 @@ int cpp_readListColumnByName(const char* filename, void* chpl_arr, const char* c
           while (reader->HasNext() && i < numElems) {
             float value;
             (void)reader->ReadBatch(1, &definition_level, nullptr, &value, &values_read);
-            if(values_read == 0) {
+            if(values_read == 0 && definition_level == 3) {
               chpl_ptr[i] = NAN;
+              i++;
             }
-            else {
-              chpl_ptr[i] = (double)value;
+            else if (values_read != 0){
+              chpl_ptr[i] = value;
+              i++;
             }
-            i++;
           }
         } else if(lty == ARROWDOUBLE) {
           auto chpl_ptr = (double*)chpl_arr;
@@ -586,13 +587,14 @@ int cpp_readListColumnByName(const char* filename, void* chpl_arr, const char* c
           while (reader->HasNext() && i < numElems) {
             double value;
             (void)reader->ReadBatch(1, &definition_level, nullptr, &value, &values_read);
-            if(values_read == 0) {
+            if(values_read == 0 && definition_level == 3) {
               chpl_ptr[i] = NAN;
+              i++;
             }
-            else {
+            else if (values_read != 0){
               chpl_ptr[i] = value;
+              i++;
             }
-            i++;
           }
         }
       }

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -292,6 +292,7 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
       int64_t vct = 0;
       int64_t seg_size = 0;
       int64_t off = 0;
+      bool first = true;
       for (int r = 0; r < num_row_groups; r++) {
         std::shared_ptr<parquet::RowGroupReader> row_group_reader =
           parquet_reader->RowGroup(r);
@@ -303,7 +304,6 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
         column_reader = row_group_reader->Column(idx);
         int16_t definition_level;
         int16_t rep_lvl;
-        bool first = true;
 
         if(lty == ARROWINT64 || lty == ARROWUINT64) {
           parquet::Int64Reader* int_reader =
@@ -312,6 +312,7 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
           while (int_reader->HasNext()) {
             int64_t value;
             (void)int_reader->ReadBatch(1, &definition_level, &rep_lvl, &value, &values_read);
+            std::cout << "\n\nDef Lvl: " << definition_level << " Rep Lvl: " << rep_lvl << " First: " << first << " vals Read: " << values_read << " val: " << value << "\n\n";
             if (values_read == 0 || (!first && rep_lvl == 0)) {
               seg_sizes[i] = seg_size;
               i++;
@@ -1056,6 +1057,108 @@ int cpp_writeStrColumnToParquet(const char* filename, void* chpl_arr, void* chpl
   }
 }
 
+// TODO - make magic happen
+int cpp_writeListColumnToParquet(const char* filename, void* chpl_arr, void* chpl_offsets,
+                                const char* dsetname, int64_t numelems,
+                                int64_t rowGroupSize, int64_t dtype, int64_t compression,
+                                char** errMsg) {
+  try {
+    using FileClass = ::arrow::io::FileOutputStream;
+    std::shared_ptr<FileClass> out_file;
+    PARQUET_ASSIGN_OR_THROW(out_file, FileClass::Open(filename));
+
+    parquet::schema::NodeVector fields;
+
+    // if(dtype == ARROWINT64)
+    //   fields.push_back(parquet::schema::PrimitiveNode::Make(dsetname, parquet::Repetition::REQUIRED, parquet::Type::INT64, parquet::ConvertedType::NONE));
+    // else if(dtype == ARROWUINT64)
+    //   fields.push_back(parquet::schema::PrimitiveNode::Make(dsetname, parquet::Repetition::REQUIRED, parquet::Type::INT64, parquet::ConvertedType::UINT_64));
+    // else if(dtype == ARROWBOOLEAN)
+    //   fields.push_back(parquet::schema::PrimitiveNode::Make(dsetname, parquet::Repetition::REQUIRED, parquet::Type::BOOLEAN, parquet::ConvertedType::NONE));
+    // else if(dtype == ARROWDOUBLE)
+    //   fields.push_back(parquet::schema::PrimitiveNode::Make(dsetname, parquet::Repetition::REQUIRED, parquet::Type::DOUBLE, parquet::ConvertedType::NONE));
+    // std::shared_ptr<parquet::schema::GroupNode> schema = std::static_pointer_cast<parquet::schema::GroupNode>
+    //   (parquet::schema::GroupNode::Make("schema", parquet::Repetition::REQUIRED, fields, parquet::ConvertedType::LIST));
+
+    // TODO - configure list for different types
+
+    auto element = parquet::schema::PrimitiveNode::Make("item", parquet::Repetition::OPTIONAL, parquet::Type::INT64, parquet::ConvertedType::NONE);
+    auto list = parquet::schema::GroupNode::Make("list", parquet::Repetition::REPEATED, {element});
+    fields.push_back(parquet::schema::GroupNode::Make(dsetname, parquet::Repetition::OPTIONAL, {list}, parquet::ConvertedType::LIST));
+    std::shared_ptr<parquet::schema::GroupNode> schema = std::static_pointer_cast<parquet::schema::GroupNode>
+      (parquet::schema::GroupNode::Make("schema", parquet::Repetition::REQUIRED, fields));
+
+    parquet::WriterProperties::Builder builder;
+    // assign the proper compression
+    if(compression == SNAPPY_COMP) {
+      builder.compression(parquet::Compression::SNAPPY);
+      builder.encoding(parquet::Encoding::RLE);
+    } else if (compression == GZIP_COMP) {
+      builder.compression(parquet::Compression::GZIP);
+      builder.encoding(parquet::Encoding::RLE);
+    } else if (compression == BROTLI_COMP) {
+      builder.compression(parquet::Compression::BROTLI);
+      builder.encoding(parquet::Encoding::RLE);
+    } else if (compression == ZSTD_COMP) {
+      builder.compression(parquet::Compression::ZSTD);
+      builder.encoding(parquet::Encoding::RLE);
+    } else if (compression == LZ4_COMP) {
+      builder.compression(parquet::Compression::LZ4);
+      builder.encoding(parquet::Encoding::RLE);
+    }
+    std::shared_ptr<parquet::WriterProperties> props = builder.build();
+
+    std::shared_ptr<parquet::ParquetFileWriter> file_writer =
+      parquet::ParquetFileWriter::Open(out_file, schema, props);
+
+    int64_t i = 0;
+    int64_t numLeft = numelems;
+    auto offsets = (int64_t*)chpl_offsets;
+    int64_t valIdx = 0;
+    int64_t offIdx = 0;
+
+    if(dtype == ARROWINT64 || dtype == ARROWUINT64) {
+      auto chpl_ptr = (int64_t*)chpl_arr;
+      
+      while(numLeft > 0) {
+        parquet::RowGroupWriter* rg_writer = file_writer->AppendRowGroup();
+        parquet::Int64Writer* int64_writer =
+          static_cast<parquet::Int64Writer*>(rg_writer->NextColumn());
+
+        while (numLeft > 0 && offIdx < rowGroupSize) {
+          int64_t batchSize = offsets[offIdx+1] - offsets[offIdx];
+          int16_t* def_lvl = new int16_t[batchSize] { 3 };
+          int16_t* rep_lvl = new int16_t[batchSize] { 0 };
+          if (batchSize > 0) {
+            for (int64_t x = 0; x < batchSize; x++){
+              rep_lvl[x] = (x == 0) ? 0 : 1;
+              def_lvl[x] = 3; // TODO - can this be removed??
+            }
+            int64_writer->WriteBatch(batchSize, def_lvl, rep_lvl, &chpl_ptr[valIdx]);
+            valIdx += batchSize;
+            numLeft -= batchSize;
+          }
+          else {
+            batchSize = 1;
+            def_lvl[0] = 1;
+            int64_writer->WriteBatch(batchSize, def_lvl, rep_lvl, nullptr);
+          }
+          offIdx++;
+        }
+      }
+    }
+    // TODO - add calls for other types
+
+    file_writer->Close();
+    ARROWSTATUS_OK(out_file->Close());
+
+    return 0;
+  } catch (const std::exception& e) {
+    *errMsg = strdup(e.what());
+    return ARROWERROR;
+  }
+}
+
 int cpp_createEmptyParquetFile(const char* filename, const char* dsetname, int64_t dtype,
                                int64_t compression, char** errMsg) {
   try {
@@ -1304,6 +1407,14 @@ extern "C" {
                                 int64_t rowGroupSize, int64_t dtype, int64_t compression,
                                 char** errMsg) {
     return cpp_writeStrColumnToParquet(filename, chpl_arr, chpl_offsets,
+                                       dsetname, numelems, rowGroupSize, dtype, compression, errMsg);
+  }
+
+  int c_writeListColumnToParquet(const char* filename, void* chpl_arr, void* chpl_offsets,
+                                const char* dsetname, int64_t numelems,
+                                int64_t rowGroupSize, int64_t dtype, int64_t compression,
+                                char** errMsg) {
+    return cpp_writeListColumnToParquet(filename, chpl_arr, chpl_offsets,
                                        dsetname, numelems, rowGroupSize, dtype, compression, errMsg);
   }
 

--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -90,6 +90,15 @@ extern "C" {
                                   const char* dsetname, int64_t numelems,
                                   int64_t rowGroupSize, int64_t dtype, int64_t compression,
                                   char** errMsg);
+
+  int c_writeListColumnToParquet(const char* filename, void* chpl_arr, void* chpl_offsets,
+                                  const char* dsetname, int64_t numelems,
+                                  int64_t rowGroupSize, int64_t dtype, int64_t compression,
+                                  char** errMsg);
+  int cpp_writeListColumnToParquet(const char* filename, void* chpl_arr, void* chpl_offsets,
+                                  const char* dsetname, int64_t numelems,
+                                  int64_t rowGroupSize, int64_t dtype, int64_t compression,
+                                  char** errMsg);
   
   int c_createEmptyParquetFile(const char* filename, const char* dsetname, int64_t dtype,
                                int64_t compression, char** errMsg);

--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -90,6 +90,11 @@ extern "C" {
                                   const char* dsetname, int64_t numelems,
                                   int64_t rowGroupSize, int64_t dtype, int64_t compression,
                                   char** errMsg);
+  
+  int c_createEmptyListParquetFile(const char* filename, const char* dsetname, int64_t dtype,
+                               int64_t compression, char** errMsg);
+  int cpp_createEmptyListParquetFile(const char* filename, const char* dsetname, int64_t dtype,
+                               int64_t compression, char** errMsg);
 
   int c_writeListColumnToParquet(const char* filename, void* chpl_arr, void* chpl_offsets,
                                   const char* dsetname, int64_t numelems,

--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -491,6 +491,10 @@ module MultiTypeSymEntry
         return (entry: borrowed SegStringSymEntry);
     }
 
+    proc toSegArraySymEntry(entry: borrowed AbstractSymEntry, type t) throws {
+        return (entry: borrowed SegArraySymEntry(t));
+    }
+
     /**
      * Temporary shim to ease transition to Typed Symbol Table Entries.
      * This attempts to retrieve the Dtype, size/array-length, and itemsize from a SymbolTable

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -502,7 +502,6 @@ class ParquetTest(ArkoudaTest):
             s.to_parquet(f"{tmp_dirname}/int_test")
 
             rd_data = ak.read_parquet(f"{tmp_dirname}/int_test*")
-            print(rd_data)
             for i in range(6):
                 self.assertListEqual(s[i].tolist(), rd_data[i].tolist())
 

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -208,7 +208,7 @@ class ParquetTest(ArkoudaTest):
             rd_df = ak.DataFrame(ak_data)
             self.assertTrue(pdf.equals(rd_df.to_pandas()))
 
-    def test_segarray_integration(self):
+    def test_segarray_read(self):
         df = pd.DataFrame({
             "ListCol": [
                 [0, 1, 2],
@@ -411,6 +411,100 @@ class ParquetTest(ArkoudaTest):
             for i in range(9):
                 self.assertListEqual(combo["ListCol"][i], ak_data[i].tolist())
 
+    def test_segarray_write(self):
+        # integer test
+        a = [0, 1, 2]
+        b = [1]
+        c = [15, 21]
+        s = ak.SegArray.from_parts(ak.array([0, len(a), len(a) + len(b)]), ak.array(a + b + c))
+        with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
+            s.to_parquet(f"{tmp_dirname}/int_test")
+
+            rd_data = ak.read_parquet(f"{tmp_dirname}/int_test*")
+            for i in range(3):
+                self.assertListEqual(s[i].tolist(), rd_data[i].tolist())
+
+        # integer with empty segments
+        a = [0, 1, 2]
+        c = [15, 21]
+        s = ak.SegArray.from_parts(ak.array([0, 0, len(a), len(a), len(a), len(a)+len(c)]), ak.array(a + c))
+        with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
+            s.to_parquet(f"{tmp_dirname}/int_test")
+
+            rd_data = ak.read_parquet(f"{tmp_dirname}/int_test*")
+            for i in range(6):
+                self.assertListEqual(s[i].tolist(), rd_data[i].tolist())
+
+        # uint test
+        a = [0, 1, 2]
+        b = [1]
+        c = [15, 21]
+        s = ak.SegArray.from_parts(ak.array([0, len(a), len(a) + len(b)]), ak.array(a + b + c, dtype=ak.uint64))
+        with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
+            s.to_parquet(f"{tmp_dirname}/int_test")
+
+            rd_data = ak.read_parquet(f"{tmp_dirname}/int_test*")
+            for i in range(3):
+                self.assertListEqual(s[i].tolist(), rd_data[i].tolist())
+
+        # uint with empty segments
+        a = [0, 1, 2]
+        c = [15, 21]
+        s = ak.SegArray.from_parts(ak.array([0, 0, len(a), len(a), len(a), len(a) + len(c)]), ak.array(a + c, dtype=ak.uint64))
+        with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
+            s.to_parquet(f"{tmp_dirname}/int_test")
+
+            rd_data = ak.read_parquet(f"{tmp_dirname}/int_test*")
+            for i in range(6):
+                self.assertListEqual(s[i].tolist(), rd_data[i].tolist())
+
+        # bool test
+        a = [0, 1, 1]
+        b = [0]
+        c = [1, 0]
+        s = ak.SegArray.from_parts(ak.array([0, len(a), len(a) + len(b)]), ak.array(a + b + c, dtype=ak.bool))
+        with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
+            s.to_parquet(f"{tmp_dirname}/int_test")
+
+            rd_data = ak.read_parquet(f"{tmp_dirname}/int_test*")
+            for i in range(3):
+                self.assertListEqual(s[i].tolist(), rd_data[i].tolist())
+
+        # bool with empty segments
+        a = [0, 1, 1]
+        c = [1, 0]
+        s = ak.SegArray.from_parts(ak.array([0, 0, len(a), len(a), len(a), len(a) + len(c)]), ak.array(a + c,
+                                   dtype=ak.bool))
+        with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
+            s.to_parquet(f"{tmp_dirname}/int_test")
+
+            rd_data = ak.read_parquet(f"{tmp_dirname}/int_test*")
+            for i in range(6):
+                self.assertListEqual(s[i].tolist(), rd_data[i].tolist())
+
+        # float test
+        a = [1.1, 1.1, 2.7]
+        b = [1.99]
+        c = [15.2, 21.0]
+        s = ak.SegArray.from_parts(ak.array([0, len(a), len(a) + len(b)]), ak.array(a + b + c))
+        with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
+            s.to_parquet(f"{tmp_dirname}/int_test")
+
+            rd_data = ak.read_parquet(f"{tmp_dirname}/int_test*")
+            for i in range(3):
+                self.assertListEqual(s[i].tolist(), rd_data[i].tolist())
+
+        # float with empty segments
+        a = [1.1, 1.1, 2.7]
+        c = [15.2, 21.0]
+        s = ak.SegArray.from_parts(ak.array([0, 0, len(a), len(a), len(a), len(a) + len(c)]), ak.array(a + c))
+        with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
+            s.to_parquet(f"{tmp_dirname}/int_test")
+
+            rd_data = ak.read_parquet(f"{tmp_dirname}/int_test*")
+            print(rd_data)
+            for i in range(6):
+                self.assertListEqual(s[i].tolist(), rd_data[i].tolist())
 
 
     @pytest.mark.optional_parquet


### PR DESCRIPTION
Closes #2119

- Adds support for writing SegArray objects to Parquet. This does not include the multi-column case, see #2186.
- Adds `ak.SegArray.to_parquet`
- Restructures Parquet write workflow to use `objType`, similar to HDF5 workflow. 
- Adds testing for writing SegArrays to Parquet files.