### PR TITLE
Closes #2110 - Updates `_buildReadAllJSON` to use Map

### DIFF
--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -460,7 +460,7 @@ def _build_objects(
     RuntimeError
         - If no objects were returned
     """
-    items = rep_msg["items"] if "items" in rep_msg else []
+    items = json.loads(rep_msg["items"]) if "items" in rep_msg else []
     # We have a couple possible return conditions
     # 1. We have multiple items returned i.e. multi pdarrays, multi strings, multi pdarrays & strings
     # 2. We have a single pdarray
@@ -587,6 +587,7 @@ def read_hdf(
             },
         )
         rep = json.loads(rep_msg)  # See GenSymIO._buildReadAllMsgJson for json structure
+        print(rep)
         _parse_errors(rep, allow_errors)
         return _build_objects(rep)
 

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -587,7 +587,6 @@ def read_hdf(
             },
         )
         rep = json.loads(rep_msg)  # See GenSymIO._buildReadAllMsgJson for json structure
-        print(rep)
         _parse_errors(rep, allow_errors)
         return _build_objects(rep)
 


### PR DESCRIPTION
Closes #2110

Updates the workflow for `_buildReadAllJSON` to use Chapel Maps and Lists instead of manually building the JSON string. This is the first step in moving away from `string` based returns and towards fully JSON formatted messaging.