### PR TITLE
Fixes #2183: Index reset in dataframe get_head_tail

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -385,7 +385,7 @@ class DataFrame(UserDict):
             for k in self._columns:
                 result[k] = UserDict.__getitem__(self, k)[key]
             # To stay consistent with numpy, provide the old index values
-            return DataFrame(initialdata=result, index=key)
+            return DataFrame(initialdata=result, index=self.index.index[key])
 
         # Select rows or columns using a list
         if isinstance(key, (list, tuple)):
@@ -427,7 +427,7 @@ class DataFrame(UserDict):
             s = key
             for k in self._columns:
                 rtn_data[k] = UserDict.__getitem__(self, k)[s]
-            return DataFrame(initialdata=rtn_data, index=arange(self.size)[s])
+            return DataFrame(initialdata=rtn_data, index=self.index.index[arange(self.size)[s]])
         else:
             raise IndexError("Invalid selector: unknown error.")
 
@@ -550,7 +550,7 @@ class DataFrame(UserDict):
                 newdf[col] = self[col].categories[self[col].codes[idx]]
             else:
                 newdf[col] = self[col][idx]
-        newdf._set_index(idx)
+        newdf._set_index(self.index.index[idx])
         return newdf.to_pandas(retain_index=True)
 
     def _get_head_tail_server(self):
@@ -634,7 +634,7 @@ class DataFrame(UserDict):
                 df_dict[msg[1]] = create_pdarray(msg[2])
 
         new_df = DataFrame(df_dict)
-        new_df._set_index(idx)
+        new_df._set_index(self.index.index[idx])
         return new_df.to_pandas(retain_index=True)[self._columns]
 
     def _shape_str(self):

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -640,3 +640,29 @@ class DataFrameTest(ArkoudaTest):
         # to avoid loss of precision see (#1983)
         df = pd.DataFrame({"Test": [2**64 - 1, 0]})
         self.assertEqual(df["Test"].dtype, ak.uint64)
+
+    def test_head_tail_resetting_index(self):
+        # Test that issue #2183 is resolved
+        df = ak.DataFrame({"cnt": ak.arange(65)})
+        # Note we have to call __repr__ to trigger head_tail_server call
+
+        bool_idx = df[df["cnt"] > 3]
+        bool_idx.__repr__()
+        self.assertListEqual(bool_idx.index.index.to_list(), list(range(4, 65)))
+
+        slice_idx = df[:]
+        slice_idx.__repr__()
+        self.assertListEqual(slice_idx.index.index.to_list(), list(range(65)))
+
+        # verify it persists non-int Index
+        idx = ak.concatenate([ak.zeros(5, bool), ak.ones(60, bool)])
+        df = ak.DataFrame({"cnt": ak.arange(65)}, index=idx)
+
+        bool_idx = df[df["cnt"] > 3]
+        bool_idx.__repr__()
+        # the new index is first False and rest True (because we lose first 4), so equivalent to arange(61, bool)
+        self.assertListEqual(bool_idx.index.index.to_list(), ak.arange(61, dtype=bool).to_list())
+
+        slice_idx = df[:]
+        slice_idx.__repr__()
+        self.assertListEqual(slice_idx.index.index.to_list(), idx.to_list())

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -413,29 +413,3 @@ class DatetimeTest(ArkoudaTest):
             ak.Datetime(ak.date_range("2005-01-01", periods=10, freq="d")).week.to_list(),
             pd.Series(pd.date_range("2005-01-01", periods=10, freq="d")).dt.isocalendar().week.to_list(),
         )
-
-    def test_head_tail_resetting_index(self):
-        # Test that issue #2183 is resolved
-        df = ak.DataFrame({"cnt": ak.arange(65)})
-        # Note we have to call __repr__ to trigger head_tail_server call
-
-        bool_idx = df[df["cnt"] > 3]
-        bool_idx.__repr__()
-        self.assertListEqual(bool_idx.index.index.to_list(), list(range(4, 65)))
-
-        slice_idx = df[:]
-        slice_idx.__repr__()
-        self.assertListEqual(slice_idx.index.index.to_list(), list(range(65)))
-
-        # verify it persists non-int Index
-        idx = ak.concatenate([ak.zeros(5, bool), ak.ones(60, bool)])
-        df = ak.DataFrame({"cnt": ak.arange(65)}, index=idx)
-
-        bool_idx = df[df["cnt"] > 3]
-        bool_idx.__repr__()
-        # the new index is first False and rest True (because we lose first 4), so equivalent to arange(61, bool)
-        self.assertListEqual(bool_idx.index.index.to_list(), ak.arange(61, dtype=bool).to_list())
-
-        slice_idx = df[:]
-        slice_idx.__repr__()
-        self.assertListEqual(slice_idx.index.index.to_list(), idx.to_list())

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -413,3 +413,29 @@ class DatetimeTest(ArkoudaTest):
             ak.Datetime(ak.date_range("2005-01-01", periods=10, freq="d")).week.to_list(),
             pd.Series(pd.date_range("2005-01-01", periods=10, freq="d")).dt.isocalendar().week.to_list(),
         )
+
+    def test_head_tail_resetting_index(self):
+        # Test that issue #2183 is resolved
+        df = ak.DataFrame({"cnt": ak.arange(65)})
+        # Note we have to call __repr__ to trigger head_tail_server call
+
+        bool_idx = df[df["cnt"] > 3]
+        bool_idx.__repr__()
+        self.assertListEqual(bool_idx.index.index.to_list(), list(range(4, 65)))
+
+        slice_idx = df[:]
+        slice_idx.__repr__()
+        self.assertListEqual(slice_idx.index.index.to_list(), list(range(65)))
+
+        # verify it persists non-int Index
+        idx = ak.concatenate([ak.zeros(5, bool), ak.ones(60, bool)])
+        df = ak.DataFrame({"cnt": ak.arange(65)}, index=idx)
+
+        bool_idx = df[df["cnt"] > 3]
+        bool_idx.__repr__()
+        # the new index is first False and rest True (because we lose first 4), so equivalent to arange(61, bool)
+        self.assertListEqual(bool_idx.index.index.to_list(), ak.arange(61, dtype=bool).to_list())
+
+        slice_idx = df[:]
+        slice_idx.__repr__()
+        self.assertListEqual(slice_idx.index.index.to_list(), idx.to_list())


### PR DESCRIPTION
This PR (fixes #2183) Updates `get_head_tail` and `__getitem__` to retain original index. Adds test to verify this

Before this PR:
```python
# this should have 4-100
>>> df = ak.DataFrame( {'cnt' : ak.arange(101) })
>>> df[df['cnt'] > 3]
    cnt
0     4
1     5
2     6
3     7
4     8
..  ...
92   96
93   97
94   98
95   99
96  100 (97 rows x 1 columns)

# these should have bool Index
>>> idx = ak.concatenate([ak.ones(5, bool), ak.zeros(96, bool)])
>>> df = ak.DataFrame({'cnt': ak.arange(101)}, index=idx)
>>> df[:]
     cnt
0      0
1      1
2      2
3      3
4      4
..   ...
96    96
97    97
98    98
99    99
100  100 (101 rows x 1 columns)

>>> df[df['cnt'] > 3]
    cnt
0     4
1     5
2     6
3     7
4     8
..  ...
92   96
93   97
94   98
95   99
96  100 (97 rows x 1 columns)
```

After this PR:
```python
>>> df = ak.DataFrame( {'cnt' : ak.arange(101) })
>>> df[df['cnt'] > 3]
     cnt
4      4
5      5
6      6
7      7
8      8
..   ...
96    96
97    97
98    98
99    99
100  100 (97 rows x 1 columns)

>>> idx = ak.concatenate([ak.ones(5, bool), ak.zeros(96, bool)])
>>> df = ak.DataFrame({'cnt': ak.arange(101)}, index=idx)
>>> df[:]
       cnt
True     0
True     1
True     2
True     3
True     4
...    ...
False   96
False   97
False   98
False   99
False  100 (101 rows x 1 columns)

>>> df[df['cnt'] > 3]
       cnt
True     4
False    5
False    6
False    7
False    8
...    ...
False   96
False   97
False   98
False   99
False  100 (97 rows x 1 columns)
```