### PR TITLE
Closes #2083 - Adds `get_filetype` support for CSV

### DIFF
--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -1612,6 +1612,8 @@ def read(
             allow_errors=allow_errors,
         )
     elif ftype.lower() == "csv":
-        return read_csv(filenames, datasets=datasets, column_delim=column_delim, allow_errors=allow_errors)
+        return read_csv(
+            filenames, datasets=datasets, column_delim=column_delim, allow_errors=allow_errors
+        )
     else:
         raise RuntimeError(f"Invalid File Type detected, {ftype}")

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -121,10 +121,7 @@ def ls(filename: str, col_delim: str = ",") -> List[str]:
             str,
             generic_msg(
                 cmd=cmd,
-                args={
-                    "filename": filename,
-                    "col_delim": col_delim
-                },
+                args={"filename": filename, "col_delim": col_delim},
             ),
         )
     )
@@ -234,7 +231,9 @@ def _mode_str_to_int(mode: str) -> int:
         raise ValueError(f"Write Mode expected to be 'truncate' or 'append'. Got {mode}.")
 
 
-def get_datasets(filenames: Union[str, List[str]], allow_errors: bool = False, column_delim: str = ",") -> List[str]:
+def get_datasets(
+    filenames: Union[str, List[str]], allow_errors: bool = False, column_delim: str = ","
+) -> List[str]:
     """
     Get the names of the datasets in the provide files
 
@@ -1326,7 +1325,7 @@ def load(
     file_format: str = "INFER",
     dataset: str = "array",
     calc_string_offsets: bool = False,
-    column_delim: str = ","
+    column_delim: str = ",",
 ) -> Union[
     pdarray,
     Strings,
@@ -1470,7 +1469,7 @@ def load_all(
     try:
         result = {
             dataset: load(prefix, file_format=file_format, dataset=dataset)
-            for dataset in get_datasets(firstname, column_delim)
+            for dataset in get_datasets(firstname, column_delim=column_delim)
         }
 
         result = _dict_recombine_segarrays(result)
@@ -1511,7 +1510,7 @@ def read(
     strictTypes: bool = True,
     allow_errors: bool = False,
     calc_string_offsets=False,
-    column_delim: str = ","
+    column_delim: str = ",",
 ) -> Union[
     pdarray,
     Strings,
@@ -1613,11 +1612,6 @@ def read(
             allow_errors=allow_errors,
         )
     elif ftype.lower() == "csv":
-        return read_csv(
-            filenames,
-            datasets=datasets,
-            column_delim=",",
-            allow_errors=allow_errors
-        )
+        return read_csv(filenames, datasets=datasets, column_delim=",", allow_errors=allow_errors)
     else:
         raise RuntimeError(f"Invalid File Type detected, {ftype}")

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -234,7 +234,7 @@ def _mode_str_to_int(mode: str) -> int:
         raise ValueError(f"Write Mode expected to be 'truncate' or 'append'. Got {mode}.")
 
 
-def get_datasets(filenames: Union[str, List[str]], allow_errors: bool = False) -> List[str]:
+def get_datasets(filenames: Union[str, List[str]], allow_errors: bool = False, column_delim: str = ",") -> List[str]:
     """
     Get the names of the datasets in the provide files
 
@@ -245,6 +245,8 @@ def get_datasets(filenames: Union[str, List[str]], allow_errors: bool = False) -
     allow_errors: bool
         Default: False
         Whether or not to allow errors while accessing datasets
+    column_delim : str
+        Column delimiter to be used if dataset is CSV. Otherwise, unused.
 
     Returns
     -------
@@ -271,7 +273,7 @@ def get_datasets(filenames: Union[str, List[str]], allow_errors: bool = False) -
         filenames = [filenames]
     for fname in filenames:
         try:
-            datasets = ls(fname)
+            datasets = ls(fname, col_delim=column_delim)
             if datasets:
                 break
         except RuntimeError:
@@ -1415,7 +1417,7 @@ def load(
 
 @typechecked
 def load_all(
-    path_prefix: str, file_format: str = "INFER"
+    path_prefix: str, file_format: str = "INFER", column_delim: str = ","
 ) -> Mapping[str, Union[pdarray, Strings, SegArray, Categorical]]:
     """
     Load multiple pdarrays, Strings, SegArrays, or Categoricals previously
@@ -1428,7 +1430,9 @@ def load_all(
     file_format: str
         'INFER', 'HDF5', 'Parquet', or 'CSV'. Defaults to 'INFER'. Indicates the format being loaded.
         When 'INFER' the processing will detect the format
-        Defaults to 'HDF5'
+        Defaults to 'INFER'
+    column_delim : str
+        Column delimiter to be used if dataset is CSV. Otherwise, unused.
 
     Returns
     -------
@@ -1466,7 +1470,7 @@ def load_all(
     try:
         result = {
             dataset: load(prefix, file_format=file_format, dataset=dataset)
-            for dataset in get_datasets(firstname)
+            for dataset in get_datasets(firstname, column_delim)
         }
 
         result = _dict_recombine_segarrays(result)

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -1612,6 +1612,6 @@ def read(
             allow_errors=allow_errors,
         )
     elif ftype.lower() == "csv":
-        return read_csv(filenames, datasets=datasets, column_delim=",", allow_errors=allow_errors)
+        return read_csv(filenames, datasets=datasets, column_delim=column_delim, allow_errors=allow_errors)
     else:
         raise RuntimeError(f"Invalid File Type detected, {ftype}")


### PR DESCRIPTION
Closes #2083

- Adds support to `get_filetype` for CSV files. This will only work if when the file was written by Arkouda and contains the Arkouda Header used in CSV files.
- Integrates CSV support into `ak.io.load`, `ak.io.load_all`, `ak.io.read`, `ak.io.ls`, and `ak.io.get_datasets`. This adds the `column delimiter` as a parameter, which is only used when the file is a CSV.