### PR TITLE
Closes #2086 - Cleans up extra `SymEntry` creation calls in `SegmentedMsg.chpl`

### DIFF
--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -91,33 +91,27 @@ module SegmentedMsg {
     select genEntry.dtype {
       when (DType.Int64) {
         var segArr = getSegArray(name, st, int);
-        st.addEntry(neName, new shared SymEntry(segArr.getNonEmpty()));
-        repMsg = "created " + st.attrib(neName) + "+" + segArr.getNonEmptyCount():string;
+        repMsg = "created " + st.attrib(name) + "+" + segArr.getNonEmptyCount():string;
       }
       when (DType.UInt64) {
         var segArr = getSegArray(name, st, uint);
-        st.addEntry(neName, new shared SymEntry(segArr.getNonEmpty()));
-        repMsg = "created " + st.attrib(neName) + "+" + segArr.getNonEmptyCount():string;
+        repMsg = "created " + st.attrib(name) + "+" + segArr.getNonEmptyCount():string;
       }
       when (DType.Float64) {
         var segArr = getSegArray(name, st, real);
-        st.addEntry(neName, new shared SymEntry(segArr.getNonEmpty()));
-        repMsg = "created " + st.attrib(neName) + "+" + segArr.getNonEmptyCount():string;
+        repMsg = "created " + st.attrib(name) + "+" + segArr.getNonEmptyCount():string;
       }
       when (DType.Bool) {
         var segArr = getSegArray(name, st, bool);
-        st.addEntry(neName, new shared SymEntry(segArr.getNonEmpty()));
-        repMsg = "created " + st.attrib(neName) + "+" + segArr.getNonEmptyCount():string;
+        repMsg = "created " + st.attrib(name) + "+" + segArr.getNonEmptyCount():string;
       }
       when (DType.UInt8){
         var segArr = getSegArray(name, st, uint(8));
-        st.addEntry(neName, new shared SymEntry(segArr.getNonEmpty()));
-        repMsg = "created " + st.attrib(neName) + "+" + segArr.getNonEmptyCount():string;
+        repMsg = "created " + st.attrib(name) + "+" + segArr.getNonEmptyCount():string;
       }
       when (DType.BigInt){
         var segArr = getSegArray(name, st, bigint);
-        st.addEntry(neName, new shared SymEntry(segArr.getNonEmpty()));
-        repMsg = "created " + st.attrib(neName) + "+" + segArr.getNonEmptyCount():string;
+        repMsg = "created " + st.attrib(name) + "+" + segArr.getNonEmptyCount():string;
       }
       otherwise {
         throw new owned ErrorWithContext("Values array has unsupported dtype %s".format(genEntry.dtype:string),

--- a/tests/segarray_test.py
+++ b/tests/segarray_test.py
@@ -604,7 +604,7 @@ class SegArrayTest(ArkoudaTest):
         with tempfile.TemporaryDirectory(dir=SegArrayTest.seg_test_base_tmp) as tmp_dirname:
             segarr.to_hdf(f"{tmp_dirname}/seg_test.h5")
 
-            seg_load = ak.SegArray.load(f"{tmp_dirname}/seg_test*")
+            seg_load = ak.SegArray.read_hdf(f"{tmp_dirname}/seg_test*")
             self.assertTrue(ak.all(segarr == seg_load))
 
     def test_bigint(self):


### PR DESCRIPTION
This PR Closes #2086 

Small changes to remove extra `SymEntry` creation calls and update a deprecated method in the `segarray_test` file.

The first of the two recommendations outlined in #2086 was found in testing to be not beneficial and would add additional complexity instead of removing complexity.