### PR TITLE
Closes #2199 - Fixes `fixupSegBoundaries` Index Bug

### DIFF
--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -1463,7 +1463,7 @@ module HDF5Msg {
         
         // compute amount to adjust 
         var adjustments = (+ scan diffs) - diffs;
-        forall(i, sd, adj) in zip(fD, segSubdoms, adjustments) {
+        forall(sd, adj) in zip(segSubdoms, adjustments) {
             // adjust offset of the segment based on the sizes of the segments preceeding it
             a[sd] += adj;
         }


### PR DESCRIPTION
Closes #2199 

Updates the workflow to account for cases when locality of data may not be consecutive. This now uses the same convention we use for computing offsets where lengths are calculated and then offsets are computed via `(+ scan lengths) - lengths`. Maintains the indication of locales with no data by setting `-1` for the boundary. However, the `boundaries` array is now initialized to all values of `-1`. 

This should resolve issues that @bmcdonald3 reported from the nightly testing.