### PR TITLE
Closes #2203: Fix bigint shifting negative values for 1.30 release

### DIFF
--- a/src/BigIntMsg.chpl
+++ b/src/BigIntMsg.chpl
@@ -77,7 +77,7 @@ module BigIntMsg {
                   all_zero = true;
                   forall t in tmp with (&& reduce all_zero) {
                     t >>= ushift;
-                    all_zero &&= (t == 0);
+                    all_zero &&= (t <= 0);
                   }
                 }
                 var repMsg = "%jt".format(retList);

--- a/src/BigIntMsg.chpl
+++ b/src/BigIntMsg.chpl
@@ -77,7 +77,7 @@ module BigIntMsg {
                   all_zero = true;
                   forall t in tmp with (&& reduce all_zero) {
                     t >>= ushift;
-                    all_zero &&= (t <= 0);
+                    all_zero &&= (t == 0 || t == -1);
                   }
                 }
                 var repMsg = "%jt".format(retList);


### PR DESCRIPTION
In the 1.30 release, there was a bigint bug that was uncovered surrounding shifting bigints of/with negative values. The current behavior that was working in Arkouda was relying on the buggy behavior, so this fixes that (works on both 1.29 and 1.30).

Closes: #2203 

See: https://github.com/chapel-lang/chapel/pull/21784