### PR TITLE
Closes #2207: Create task private copies of values for pdarray=value

### DIFF
--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -690,8 +690,8 @@ module IndexingMsg
             // [i in iv.a] e.a[i] = val;
             ref iva = iv.a;
             ref ea = e.a;
-            forall i in iva with (var agg = newDstAggregator(dtype)) {
-              agg.copy(ea[i],val);
+            forall i in iva with (var agg = newDstAggregator(dtype), var locVal = val) {
+              agg.copy(ea[i],locVal);
             }
             var repMsg = "%s success".format(pn);
             imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
@@ -722,8 +722,8 @@ module IndexingMsg
             // [i in iv.a] e.a[i] = val;
             ref iva = iv.a;
             ref ea = e.a;
-            forall i in iva with (var agg = newDstAggregator(dtype)) {
-              agg.copy(ea[i:int],val);
+            forall i in iva with (var agg = newDstAggregator(dtype), var locVal = val) {
+              agg.copy(ea[i:int],locVal);
             }
             var repMsg = "%s success".format(pn);
             imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
@@ -748,9 +748,9 @@ module IndexingMsg
             const ref ead = e.a.domain;
             ref ea = e.a;
             ref trutha = truth.a;
-            forall i in ead with (var agg = newDstAggregator(dtype)) {
-              if (trutha[i] == true) {
-                agg.copy(ea[i],val);
+            forall i in ead with (var agg = newDstAggregator(dtype), var locVal = val) {
+              if (trutha[i]) {
+                agg.copy(ea[i],locVal);
               }
             }
 


### PR DESCRIPTION
Now that bigint is using the shared code with the other types for indexing implemented in #2081, there was a bug uncovered in the bigint module failing with remote assignments that will be fixed in 1.30. For 1.29, using task-private copies is a suitable workaround to avoid the remote assignmnets.

Also, this will result in a performance improvement for bigint indexing, as discussed in
https://github.com/Bears-R-Us/arkouda/pull/2157#discussion_r1110440741.

Closes: #2207 