### PR TITLE
Closes #2186 - Adds Parquet Mutli-Column Write SegArray Support

### DIFF
--- a/arkouda/message.py
+++ b/arkouda/message.py
@@ -122,6 +122,7 @@ class ParameterObject:
         """
         from arkouda.pdarrayclass import pdarray
         from arkouda.strings import Strings
+        from arkouda.segarray import SegArray
 
         # want the object type. If pdarray the content dtypes can vary
         dtypes = {type(p).__name__ for p in val}
@@ -129,7 +130,7 @@ class ParameterObject:
             t = dtypes.pop()
         else:
             for t in dtypes:
-                if t not in [pdarray.__name__, Strings.__name__]:
+                if t not in [pdarray.__name__, Strings.__name__, SegArray.__name__]:
                     t_str = ", ".join(dtypes)
                     raise TypeError(f"Lists of multiple types can only "
                                     f"contain strings and pdarray. Found {t_str}")

--- a/pydoc/file_io/PARQUET.md
+++ b/pydoc/file_io/PARQUET.md
@@ -13,7 +13,6 @@ More information on Parquet can be found [here](https://parquet.apache.org/).
 - DataFrame
 - Strings
 - SegArray
-  - Writing multi-column files not yet supported. Track [here](https://github.com/Bears-R-Us/arkouda/issues/2186))
   - Strings dtype not yet supported. Track [here](https://github.com/Bears-R-Us/arkouda/issues/2121)
 
 ## Compression

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -743,29 +743,55 @@ int cpp_readColumnByName(const char* filename, void* chpl_arr, const char* colna
 }
 
 // configure the schema for a multicolumn file
-std::shared_ptr<parquet::schema::GroupNode> SetupSchema(void* column_names, void* datatypes, int64_t colnum) {
+std::shared_ptr<parquet::schema::GroupNode> SetupSchema(void* column_names, void * objTypes, void* datatypes, int64_t colnum) {
   parquet::schema::NodeVector fields;
   auto cname_ptr = (char**)column_names;
   auto dtypes_ptr = (int64_t*) datatypes;
+  auto objType_ptr = (int64_t*) objTypes;
   for (int64_t i = 0; i < colnum; i++){
-    if(dtypes_ptr[i] == ARROWINT64)
-      fields.push_back(parquet::schema::PrimitiveNode::Make(cname_ptr[i], parquet::Repetition::REQUIRED, parquet::Type::INT64, parquet::ConvertedType::NONE));
-    else if(dtypes_ptr[i] == ARROWUINT64)
-      fields.push_back(parquet::schema::PrimitiveNode::Make(cname_ptr[i], parquet::Repetition::REQUIRED, parquet::Type::INT64, parquet::ConvertedType::UINT_64));
-    else if(dtypes_ptr[i] == ARROWBOOLEAN)
-      fields.push_back(parquet::schema::PrimitiveNode::Make(cname_ptr[i], parquet::Repetition::REQUIRED, parquet::Type::BOOLEAN, parquet::ConvertedType::NONE));
-    else if(dtypes_ptr[i] == ARROWDOUBLE)
-      fields.push_back(parquet::schema::PrimitiveNode::Make(cname_ptr[i], parquet::Repetition::REQUIRED, parquet::Type::DOUBLE, parquet::ConvertedType::NONE));
-    else if(dtypes_ptr[i] == ARROWSTRING)
+    if(dtypes_ptr[i] == ARROWINT64) {
+      if (objType_ptr[i] == SEGARRAY){
+        auto element = parquet::schema::PrimitiveNode::Make("item", parquet::Repetition::OPTIONAL, parquet::Type::INT64, parquet::ConvertedType::NONE);
+        auto list = parquet::schema::GroupNode::Make("list", parquet::Repetition::REPEATED, {element});
+        fields.push_back(parquet::schema::GroupNode::Make(cname_ptr[i], parquet::Repetition::OPTIONAL, {list}, parquet::ConvertedType::LIST));
+      } else {
+        fields.push_back(parquet::schema::PrimitiveNode::Make(cname_ptr[i], parquet::Repetition::REQUIRED, parquet::Type::INT64, parquet::ConvertedType::NONE));
+      }
+    } else if(dtypes_ptr[i] == ARROWUINT64) {
+      if (objType_ptr[i] == SEGARRAY){
+        auto element = parquet::schema::PrimitiveNode::Make("item", parquet::Repetition::OPTIONAL, parquet::Type::INT64, parquet::ConvertedType::UINT_64);
+        auto list = parquet::schema::GroupNode::Make("list", parquet::Repetition::REPEATED, {element});
+        fields.push_back(parquet::schema::GroupNode::Make(cname_ptr[i], parquet::Repetition::OPTIONAL, {list}, parquet::ConvertedType::LIST));
+      } else {
+        fields.push_back(parquet::schema::PrimitiveNode::Make(cname_ptr[i], parquet::Repetition::REQUIRED, parquet::Type::INT64, parquet::ConvertedType::UINT_64));
+      }
+    } else if(dtypes_ptr[i] == ARROWBOOLEAN) {
+      if (objType_ptr[i] == SEGARRAY){
+        auto element = parquet::schema::PrimitiveNode::Make("item", parquet::Repetition::OPTIONAL, parquet::Type::BOOLEAN, parquet::ConvertedType::NONE);
+        auto list = parquet::schema::GroupNode::Make("list", parquet::Repetition::REPEATED, {element});
+        fields.push_back(parquet::schema::GroupNode::Make(cname_ptr[i], parquet::Repetition::OPTIONAL, {list}, parquet::ConvertedType::LIST));
+      } else {
+        fields.push_back(parquet::schema::PrimitiveNode::Make(cname_ptr[i], parquet::Repetition::REQUIRED, parquet::Type::BOOLEAN, parquet::ConvertedType::NONE));
+      }
+    } else if(dtypes_ptr[i] == ARROWDOUBLE) {
+      if (objType_ptr[i] == SEGARRAY) {
+        auto element = parquet::schema::PrimitiveNode::Make("item", parquet::Repetition::OPTIONAL, parquet::Type::DOUBLE, parquet::ConvertedType::NONE);
+        auto list = parquet::schema::GroupNode::Make("list", parquet::Repetition::REPEATED, {element});
+        fields.push_back(parquet::schema::GroupNode::Make(cname_ptr[i], parquet::Repetition::OPTIONAL, {list}, parquet::ConvertedType::LIST));
+      } else {
+        fields.push_back(parquet::schema::PrimitiveNode::Make(cname_ptr[i], parquet::Repetition::REQUIRED, parquet::Type::DOUBLE, parquet::ConvertedType::NONE));
+      }
+    } else if(dtypes_ptr[i] == ARROWSTRING) {
       fields.push_back(parquet::schema::PrimitiveNode::Make(cname_ptr[i], parquet::Repetition::REQUIRED, parquet::Type::BYTE_ARRAY, parquet::ConvertedType::NONE));
+    }
   }
   return std::static_pointer_cast<parquet::schema::GroupNode>(
       parquet::schema::GroupNode::Make("schema", parquet::Repetition::REQUIRED, fields));
 }
 
 int cpp_writeMultiColToParquet(const char* filename, void* column_names, 
-                                void** ptr_arr, void* datatypes,
-                                int64_t colnum, int64_t numelems, int64_t rowGroupSize,
+                                void** ptr_arr, void** offset_arr, void* objTypes, void* datatypes,
+                                void* segArr_sizes, int64_t colnum, int64_t numelems, int64_t rowGroupSize,
                                 int64_t compression, char** errMsg) {
   try {
     // initialize the file to write to
@@ -774,7 +800,7 @@ int cpp_writeMultiColToParquet(const char* filename, void* column_names,
     ARROWRESULT_OK(FileClass::Open(filename), out_file);
 
     // Setup the parquet schema
-    std::shared_ptr<parquet::schema::GroupNode> schema = SetupSchema(column_names, datatypes, colnum);
+    std::shared_ptr<parquet::schema::GroupNode> schema = SetupSchema(column_names, objTypes, datatypes, colnum);
 
     parquet::WriterProperties::Builder builder;
     // assign the proper compression
@@ -799,9 +825,12 @@ int cpp_writeMultiColToParquet(const char* filename, void* column_names,
     std::shared_ptr<parquet::ParquetFileWriter> file_writer =
       parquet::ParquetFileWriter::Open(out_file, schema, props);
 
-    std::queue<int64_t> idxQueue; // queue used to track string byteIdx 
+    std::queue<int64_t> idxQueue_str; // queue used to track string byteIdx 
+    std::queue<int64_t> idxQueue_segarray; // queue used to track string byteIdx 
 
     auto dtypes_ptr = (int64_t*) datatypes;
+    auto objType_ptr = (int64_t*) objTypes;
+    auto saSizes_ptr = (int64_t*) segArr_sizes;
     int64_t numLeft = numelems; // number of elements remaining to write (rows)
     int64_t x = 0;  // index to start writing batch from
     while (numLeft > 0) {
@@ -816,19 +845,155 @@ int cpp_writeMultiColToParquet(const char* filename, void* column_names,
         int64_t dtype = dtypes_ptr[i];
         if (dtype == ARROWINT64 || dtype == ARROWUINT64) {
           auto data_ptr = (int64_t*)ptr_arr[i];
-          parquet::Int64Writer* int64_writer =
-              static_cast<parquet::Int64Writer*>(rg_writer->NextColumn());
-          int64_writer->WriteBatch(batchSize, nullptr, nullptr, &data_ptr[x]);
+          parquet::Int64Writer* writer =
+                static_cast<parquet::Int64Writer*>(rg_writer->NextColumn());
+
+          if (objType_ptr[i] == SEGARRAY) {
+            auto offset_ptr = (int64_t*)offset_arr[i];
+            int64_t offIdx = 0; // index into offsets
+
+            if (x > 0){
+              offIdx = idxQueue_segarray.front();
+              idxQueue_segarray.pop();
+            }
+
+            int64_t count = 0;
+            while (count < batchSize) { // ensures rowGroupSize maintained
+              int64_t segSize;
+              if (offIdx == (numelems - 1)) {
+                segSize = saSizes_ptr[i] - offset_ptr[offIdx];
+              }
+              else {
+                segSize = offset_ptr[offIdx+1] - offset_ptr[offIdx];
+              }
+              if (segSize > 0) {
+                int16_t* def_lvl = new int16_t[segSize] { 3 };
+                int16_t* rep_lvl = new int16_t[segSize] { 0 };
+                for (int64_t s = 0; s < segSize; s++){
+                  // if the value is first in the segment rep_lvl = 0, otherwise 1
+                  // all values defined at the item level (3)
+                  rep_lvl[s] = (s == 0) ? 0 : 1;
+                  def_lvl[s] = 3;
+                }
+                int64_t valIdx = offset_ptr[offIdx];
+                writer->WriteBatch(segSize, def_lvl, rep_lvl, &data_ptr[valIdx]);
+              }
+              else {
+                // empty segment denoted by null value that is not repeated (first of segment) defined at the list level (1)
+                segSize = 1; // even though segment is length=0, write null to hold the empty segment
+                int16_t* def_lvl = new int16_t[segSize] { 1 };
+                int16_t* rep_lvl = new int16_t[segSize] { 0 };
+                writer->WriteBatch(segSize, def_lvl, rep_lvl, nullptr);
+              }
+              offIdx++;
+              count++;
+            }
+            if (numLeft - count > 0) {
+              idxQueue_segarray.push(offIdx);
+            }
+          } else {
+            writer->WriteBatch(batchSize, nullptr, nullptr, &data_ptr[x]);
+          }
         } else if(dtype == ARROWBOOLEAN) {
           auto data_ptr = (bool*)ptr_arr[i];
-          parquet::BoolWriter* bool_writer =
-            static_cast<parquet::BoolWriter*>(rg_writer->NextColumn());
-          bool_writer->WriteBatch(batchSize, nullptr, nullptr, &data_ptr[x]);
+            parquet::BoolWriter* writer =
+              static_cast<parquet::BoolWriter*>(rg_writer->NextColumn());
+          if (objType_ptr[i] == SEGARRAY) {
+            auto offset_ptr = (int64_t*)offset_arr[i];
+            int64_t offIdx = 0; // index into offsets
+
+            if (x > 0){
+              offIdx = idxQueue_segarray.front();
+              idxQueue_segarray.pop();
+            }
+
+            int64_t count = 0;
+            while (count < batchSize) { // ensures rowGroupSize maintained
+              int64_t segSize;
+              if (offIdx == numelems - 1) {
+                segSize = saSizes_ptr[i] - offset_ptr[offIdx];
+              }
+              else {
+                segSize = offset_ptr[offIdx+1] - offset_ptr[offIdx];
+              }
+              if (segSize > 0) {
+                int16_t* def_lvl = new int16_t[segSize] { 3 };
+                int16_t* rep_lvl = new int16_t[segSize] { 0 };
+                for (int64_t s = 0; s < segSize; s++){
+                  // if the value is first in the segment rep_lvl = 0, otherwise 1
+                  // all values defined at the item level (3)
+                  rep_lvl[s] = (s == 0) ? 0 : 1;
+                  def_lvl[s] = 3;
+                }
+                int64_t valIdx = offset_ptr[offIdx];
+                writer->WriteBatch(segSize, def_lvl, rep_lvl, &data_ptr[valIdx]);
+              }
+              else {
+                // empty segment denoted by null value that is not repeated (first of segment) defined at the list level (1)
+                segSize = 1; // even though segment is length=0, write null to hold the empty segment
+                int16_t* def_lvl = new int16_t[segSize] { 1 };
+                int16_t* rep_lvl = new int16_t[segSize] { 0 };
+                writer->WriteBatch(segSize, def_lvl, rep_lvl, nullptr);
+              }
+              offIdx++;
+              count++;
+            }
+            if (numLeft - count > 0) {
+              idxQueue_segarray.push(offIdx);
+            }
+          } else {
+            writer->WriteBatch(batchSize, nullptr, nullptr, &data_ptr[x]);
+          }
         } else if(dtype == ARROWDOUBLE) {
           auto data_ptr = (double*)ptr_arr[i];
-          parquet::DoubleWriter* dbl_writer =
-            static_cast<parquet::DoubleWriter*>(rg_writer->NextColumn());
-          dbl_writer->WriteBatch(batchSize, nullptr, nullptr, &data_ptr[x]);
+            parquet::DoubleWriter* writer =
+          static_cast<parquet::DoubleWriter*>(rg_writer->NextColumn());
+          if (objType_ptr[i] == SEGARRAY) {
+            auto offset_ptr = (int64_t*)offset_arr[i];
+            int64_t offIdx = 0; // index into offsets
+
+            if (x > 0){
+              offIdx = idxQueue_segarray.front();
+              idxQueue_segarray.pop();
+            }
+
+            int64_t count = 0;
+            while (count < batchSize) { // ensures rowGroupSize maintained
+              int64_t segSize;
+              if (offIdx == numelems - 1) {
+                segSize = saSizes_ptr[i] - offset_ptr[offIdx];
+              }
+              else {
+                segSize = offset_ptr[offIdx+1] - offset_ptr[offIdx];
+              }
+              if (segSize > 0) {
+                int16_t* def_lvl = new int16_t[segSize] { 3 };
+                int16_t* rep_lvl = new int16_t[segSize] { 0 };
+                for (int64_t s = 0; s < segSize; s++){
+                  // if the value is first in the segment rep_lvl = 0, otherwise 1
+                  // all values defined at the item level (3)
+                  rep_lvl[s] = (s == 0) ? 0 : 1;
+                  def_lvl[s] = 3;
+                }
+                int64_t valIdx = offset_ptr[offIdx];
+                writer->WriteBatch(segSize, def_lvl, rep_lvl, &data_ptr[valIdx]);
+              }
+              else {
+                // empty segment denoted by null value that is not repeated (first of segment) defined at the list level (1)
+                segSize = 1; // even though segment is length=0, write null to hold the empty segment
+                int16_t* def_lvl = new int16_t[segSize] { 1 };
+                int16_t* rep_lvl = new int16_t[segSize] { 0 };
+                writer->WriteBatch(segSize, def_lvl, rep_lvl, nullptr);
+              }
+              offIdx++;
+              count++;
+            }
+            if (numLeft - count > 0) {
+              idxQueue_segarray.push(offIdx);
+            }
+          } else {
+            writer->WriteBatch(batchSize, nullptr, nullptr, &data_ptr[x]);
+          }
         } else if(dtype == ARROWSTRING) {
           auto data_ptr = (uint8_t*)ptr_arr[i];
           parquet::ByteArrayWriter* ba_writer =
@@ -838,8 +1003,8 @@ int cpp_writeMultiColToParquet(const char* filename, void* column_names,
 
           // identify the starting byte index
           if (x > 0){
-            byteIdx = idxQueue.front();
-            idxQueue.pop();
+            byteIdx = idxQueue_str.front();
+            idxQueue_str.pop();
           }
           
           while(count < batchSize) {
@@ -857,7 +1022,7 @@ int cpp_writeMultiColToParquet(const char* filename, void* column_names,
             byteIdx = nextIdx + 1;
           }
           if (numLeft - count > 0) {
-            idxQueue.push(byteIdx);
+            idxQueue_str.push(byteIdx);
           }
         } else {
           return ARROWERROR;
@@ -1605,9 +1770,9 @@ extern "C" {
   }
 
   int c_writeMultiColToParquet(const char* filename, void* column_names, 
-                                void** ptr_arr, void* datatypes,
-                                int64_t colnum, int64_t numelems, int64_t rowGroupSize,
+                                void** ptr_arr, void** offset_arr, void* objTypes, void* datatypes,
+                                void* segArr_sizes, int64_t colnum, int64_t numelems, int64_t rowGroupSize,
                                 int64_t compression, char** errMsg){
-    return cpp_writeMultiColToParquet(filename, column_names, ptr_arr, datatypes, colnum, numelems, rowGroupSize, compression, errMsg);
+    return cpp_writeMultiColToParquet(filename, column_names, ptr_arr, offset_arr, objTypes, datatypes, segArr_sizes, colnum, numelems, rowGroupSize, compression, errMsg);
   }
 }

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -826,7 +826,7 @@ int cpp_writeMultiColToParquet(const char* filename, void* column_names,
       parquet::ParquetFileWriter::Open(out_file, schema, props);
 
     std::queue<int64_t> idxQueue_str; // queue used to track string byteIdx 
-    std::queue<int64_t> idxQueue_segarray; // queue used to track string byteIdx 
+    std::queue<int64_t> idxQueue_segarray; // queue used to track index into the offsets
 
     auto dtypes_ptr = (int64_t*) datatypes;
     auto objType_ptr = (int64_t*) objTypes;

--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -27,6 +27,11 @@ extern "C" {
 #define ARROWLIST 8
 #define ARROWERROR -1
 
+#define ARRAYVIEW 0 // not currently used, but included for continuity with Chapel
+#define PDARRAY 1
+#define STRINGS 2
+#define SEGARRAY 3
+
 // compression mappings
 #define SNAPPY_COMP 1
 #define GZIP_COMP 2
@@ -120,13 +125,13 @@ extern "C" {
                                 char** errMsg);
   
   int c_writeMultiColToParquet(const char* filename, void* column_names, 
-                                void** ptr_arr, void* datatypes,
-                                int64_t colnum, int64_t numelems, int64_t rowGroupSize,
+                                void** ptr_arr, void** offset_arr, void* objTypes, void* datatypes,
+                                void* segArr_sizes, int64_t colnum, int64_t numelems, int64_t rowGroupSize,
                                 int64_t compression, char** errMsg);
 
   int cpp_writeMultiColToParquet(const char* filename, void* column_names, 
-                                  void** ptr_arr, void* datatypes,
-                                  int64_t colnum, int64_t numelems, int64_t rowGroupSize,
+                                  void** ptr_arr, void** offset_arr, void* objTypes, void* datatypes,
+                                  void* segArr_sizes, int64_t colnum, int64_t numelems, int64_t rowGroupSize,
                                   int64_t compression, char** errMsg);
     
   const char* c_getVersionInfo(void);

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -1200,7 +1200,7 @@ module ParquetMsg {
 
       var offset_ct: [0..#ncols] int;
       var sections_sizes_str: [0..#ncols] int; // only fill in sizes for str columns
-      var sections_sizes_int: [0..#ncols] int; // only fill in sizes for int, uint, bool segarray columns
+      var sections_sizes_int: [0..#ncols] int; // only fill in sizes for int, uint segarray columns
       var sections_sizes_real: [0..#ncols] int; // only fill in sizes for float segarray columns
       var sections_sizes_bool: [0..#ncols] int; // only fill in sizes for bool segarray columns
       forall (i, column) in zip(0..#ncols, sym_names) {

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -1451,16 +1451,19 @@ module ParquetMsg {
             const lastValIdx = ss.values.a.domain.high;
             const locDom = ss.offsets.a.localSubdomain();
 
-            var localOffsets = A[locDom];
-            var startValIdx = localOffsets[locDom.low];
-            var endValIdx = if (lastOffset == localOffsets[locDom.high]) then lastValIdx else A[locDom.high + 1] - 1;
-            var valIdxRange = startValIdx..endValIdx;
-            ref olda = ss.values.a;
-            str_vals[si..#valIdxRange.size] = olda[valIdxRange];
-            ptrList[i] = c_ptrTo(str_vals[si]): c_void_ptr;
             objTypes[i] = ObjType.STRINGS: int;
             datatypes[i] = ARROWSTRING;
-            sizeList[i] = locDom.size;
+
+            if locDom.size > 0 {
+              var localOffsets = A[locDom];
+              var startValIdx = localOffsets[locDom.low];
+              var endValIdx = if (lastOffset == localOffsets[locDom.high]) then lastValIdx else A[locDom.high + 1] - 1;
+              var valIdxRange = startValIdx..endValIdx;
+              ref olda = ss.values.a;
+              str_vals[si..#valIdxRange.size] = olda[valIdxRange];
+              ptrList[i] = c_ptrTo(str_vals[si]): c_void_ptr;
+              sizeList[i] = locDom.size;
+            }
           } otherwise {
             throw getErrorWithContext(
               msg="Writing Parquet files (multi-column) does not support columns of type %s".format(entryDtype),

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -135,7 +135,7 @@ module ParquetMsg {
         forall (off, filedom, filename) in zip(locOffsets, locFiledoms, locFiles) {
           for locdom in A.localSubdomains() {
             const intersection = domain_intersection(locdom, filedom);
-            
+
             if intersection.size > 0 {
               var pqErr = new parquetErrorMsg();
               if c_readColumnByName(filename.localize().c_str(), c_ptrTo(A[intersection.low]),
@@ -1168,8 +1168,8 @@ module ParquetMsg {
                               ncols: int, sym_names: [] string, targetLocales: [] locale, 
                               compression: int, st: borrowed SymTab): bool throws {
 
-    extern proc c_writeMultiColToParquet(filename, column_names, ptr_arr,
-                                      datatypes, colnum, numelems, rowGroupSize, compression, errMsg): int;
+    extern proc c_writeMultiColToParquet(filename, column_names, ptr_arr, offset_arr, objTypes,
+                                      datatypes, segArr_sizes, colnum, numelems, rowGroupSize, compression, errMsg): int;
 
     var prefix: string;
     var extension: string;
@@ -1189,15 +1189,22 @@ module ParquetMsg {
       const fname = filenames[idx];
 
       var ptrList: [0..#ncols] c_void_ptr;
+      var offsetPtr: [0..#ncols] c_void_ptr; // ptrs to offsets for SegArray. Know number of rows so we know where to stop
+      var objTypes: [0..#ncols] int; // ObjType enum integer values
       var datatypes: [0..#ncols] int;
       var sizeList: [0..#ncols] int;
+      var segarray_sizes: [0..#ncols] int; // track # of values in each column. Used to determine last segment size.
 
       var my_column_names = col_names;
       var c_names: [0..#ncols] c_string;
 
-      var locSize: int = 0;
-      var sections_sizes: [0..#ncols] int; // only fill in sizes for str columns
-      forall (i, column) in zip(0..#ncols, sym_names) with (+ reduce locSize) {
+      var offset_ct: [0..#ncols] int;
+      var sections_sizes_str: [0..#ncols] int; // only fill in sizes for str columns
+      var sections_sizes_int: [0..#ncols] int; // only fill in sizes for int, uint, bool segarray columns
+      var sections_sizes_real: [0..#ncols] int; // only fill in sizes for float segarray columns
+      var sections_sizes_bool: [0..#ncols] int; // only fill in sizes for bool segarray columns
+      forall (i, column) in zip(0..#ncols, sym_names) {
+        var x: int;
         var entry = st.lookup(column);
         // need to calculate the total size of Strings on this local
         if (entry.isAssignableTo(SymbolEntryType.SegStringSymEntry)) {
@@ -1206,75 +1213,234 @@ module ParquetMsg {
           ref ss = segStr;
           var lens = ss.getLengths();
           const locDom = ss.offsets.a.localSubdomain();
-          var x: int;
           for i in locDom do x += lens[i];
-          sections_sizes[i] = x;
-          locSize += x;
+          sections_sizes_str[i] = x;
+        }
+        else if (entry.isAssignableTo(SymbolEntryType.SegArraySymEntry)) {
+          var dtype = _identifyDtype(entry, ObjType.SEGARRAY);
+          if dtype == DType.Int64 {
+            var e: SegArraySymEntry = toSegArraySymEntry(entry, int);
+            var segArr = new SegArray("", e, int);
+            ref sa = segArr;
+            var lens = sa.lengths.a;
+            const locDom = sa.segments.a.localSubdomain();
+            for i in locDom do x += lens[i];
+            sections_sizes_int[i] = x;
+            offset_ct[i] += locDom.size;
+          }
+          else if dtype == DType.UInt64 {
+            var e: SegArraySymEntry = toSegArraySymEntry(entry, uint);
+            var segArr = new SegArray("", e, uint);
+            ref sa = segArr;
+            var lens = sa.lengths.a;
+            const locDom = sa.segments.a.localSubdomain();
+            for i in locDom do x += lens[i];
+            sections_sizes_int[i] = x;
+            offset_ct[i] = locDom.size;
+          }
+          else if dtype == DType.Bool {
+            var e: SegArraySymEntry = toSegArraySymEntry(entry, bool);
+            var segArr = new SegArray("", e, bool);
+            ref sa = segArr;
+            var lens = sa.lengths.a;
+            const locDom = sa.segments.a.localSubdomain();
+            for i in locDom do x += lens[i];
+            sections_sizes_bool[i] = x;
+            offset_ct[i] = locDom.size;
+          }
+          else if dtype ==  DType.Float64 {
+            var e: SegArraySymEntry = toSegArraySymEntry(entry, real);
+            var segArr = new SegArray("", e, real);
+            ref sa = segArr;
+            var lens = sa.lengths.a;
+            const locDom = sa.segments.a.localSubdomain();
+            for i in locDom do x += lens[i];
+            sections_sizes_real[i] = x;
+            offset_ct[i] = locDom.size;
+          }
         }
       }
 
-      var str_vals: [0..#locSize] uint(8);
-      var str_idx = (+ scan sections_sizes) - sections_sizes;
-      forall (i, column, si) in zip(0..#ncols, sym_names, str_idx) {
+      var numoffsets: int = + reduce offset_ct; // total # of offsets on locale
+      var offset_tracking: [0..#numoffsets] int; // array to write offset values into after adjusting for locale
+      var offset_idx = (+ scan offset_ct) - offset_ct; // offset start indexes for each column
+
+      var locSize_str: int = + reduce sections_sizes_str;
+      var str_vals: [0..#locSize_str] uint(8);
+      var locSize_int: int = + reduce sections_sizes_int;
+      var int_vals: [0..#locSize_int] int; //int and uint written the same so no conversions will be needed
+      var locSize_real: int = + reduce sections_sizes_real;
+      var real_vals: [0..#locSize_real] real;
+      var locSize_bool: int = + reduce sections_sizes_bool;
+      var bool_vals: [0..#locSize_bool] bool;
+
+      // indexes for which values go to which columns
+      var str_idx = (+ scan sections_sizes_str) - sections_sizes_str;
+      var int_idx = (+ scan sections_sizes_int) - sections_sizes_int;
+      var real_idx = (+ scan sections_sizes_real) - sections_sizes_real;
+      var bool_idx = (+ scan sections_sizes_bool) - sections_sizes_bool;
+
+      // populate data based on object and data types
+      forall (i, column, si, ui, ri, bi, oi) in zip(0..#ncols, sym_names, str_idx, int_idx, real_idx, bool_idx, offset_idx) {
         // generate the local c string list of column names
         c_names[i] = my_column_names[i].localize().c_str();
 
         var entry = st.lookup(column);
-
-        // access the dtype of each 
-        var entryDtype = DType.UNDEF;
-        if (entry.isAssignableTo(SymbolEntryType.TypedArraySymEntry)) {
-          entryDtype = (entry: borrowed GenSymEntry).dtype;
-        } else if (entry.isAssignableTo(SymbolEntryType.SegStringSymEntry)) {
-          entryDtype = (entry: borrowed SegStringSymEntry).dtype;
-        } else {
-          throw getErrorWithContext(
-              msg="Unknown SymEntry Type",
-              lineNumber=getLineNumber(), 
-              routineName=getRoutineName(), 
-              moduleName=getModuleName(), 
-              errorClass='ValueError'
-          );
-        }
-        
+        var objType = _identifyObjectType(entry);
+        var entryDtype = _identifyDtype(entry, objType);
         select entryDtype {
           when DType.Int64 {
-            var e = toSymEntry(toGenSymEntry(entry), int);
-            var locDom = e.a.localSubdomain();
-            // set the pointer to the entry array in the list of Pointers
-            if locDom.size > 0 {
-              ptrList[i] = c_ptrTo(e.a[locDom]): c_void_ptr;
+            if objType == ObjType.SEGARRAY {
+              var e: SegArraySymEntry = toSegArraySymEntry(entry, int);
+              var segArray = new SegArray("", e, int);
+              ref sa = segArray;
+              var A = sa.segments.a;
+              const lastOffset = A[A.domain.high];
+              const lastValIdx = sa.values.a.domain.high;
+              const locDom = sa.segments.a.localSubdomain();
+
+              objTypes[i] = ObjType.SEGARRAY: int;
               datatypes[i] = ARROWINT64;
-              sizeList[i] = locDom.size;
+
+              if locDom.size > 0 {
+                var localOffsets = A[locDom];
+                var startValIdx = localOffsets[locDom.low];
+                var endValIdx = if (lastOffset == localOffsets[locDom.high]) then lastValIdx else A[locDom.high + 1] - 1;
+                var valIdxRange = startValIdx..endValIdx;
+                ref olda = sa.values.a;
+                int_vals[ui..#valIdxRange.size] = olda[valIdxRange];
+                ptrList[i] = c_ptrTo(int_vals[ui]): c_void_ptr;
+                sizeList[i] = locDom.size;
+                offset_tracking[oi..#locDom.size] = localOffsets - startValIdx;
+                offsetPtr[i] = c_ptrTo(offset_tracking[oi]);
+                segarray_sizes[i] = sections_sizes_int[i];
+              }
             }
-          }
-          when DType.UInt64 {
-            var e = toSymEntry(toGenSymEntry(entry), uint);
-            var locDom = e.a.localSubdomain();
-            // set the pointer to the entry array in the list of Pointers
-            if locDom.size > 0 {
-              ptrList[i] = c_ptrTo(e.a[locDom]): c_void_ptr;
+            else {
+              var e = toSymEntry(toGenSymEntry(entry), int);
+              var locDom = e.a.localSubdomain();
+              objTypes[i] = ObjType.PDARRAY: int;
+              datatypes[i] = ARROWINT64;
+              // set the pointer to the entry array in the list of Pointers
+              if locDom.size > 0 {
+                ptrList[i] = c_ptrTo(e.a[locDom]): c_void_ptr;
+                sizeList[i] = locDom.size;
+              }
+            }
+          } when DType.UInt64 {
+            if objType == ObjType.SEGARRAY {
+              var e: SegArraySymEntry = toSegArraySymEntry(entry, uint);
+              var segArray = new SegArray("", e, uint);
+              ref sa = segArray;
+              var A = sa.segments.a;
+              const lastOffset = A[A.domain.high];
+              const lastValIdx = sa.values.a.domain.high;
+              const locDom = sa.segments.a.localSubdomain();
+
+              objTypes[i] = ObjType.SEGARRAY: int;
               datatypes[i] = ARROWUINT64;
-              sizeList[i] = locDom.size;
+
+              if locDom.size > 0 {
+                var localOffsets = A[locDom];
+                var startValIdx = localOffsets[locDom.low];
+                var endValIdx = if (lastOffset == localOffsets[locDom.high]) then lastValIdx else A[locDom.high + 1] - 1;
+                var valIdxRange = startValIdx..endValIdx;
+                ref olda = sa.values.a;
+                int_vals[ui..#valIdxRange.size] = olda[valIdxRange]: int;
+                ptrList[i] = c_ptrTo(int_vals[ui]): c_void_ptr;
+                sizeList[i] = locDom.size;
+                offset_tracking[oi..#locDom.size] = localOffsets - startValIdx;
+                offsetPtr[i] = c_ptrTo(offset_tracking[oi]);
+                segarray_sizes[i] = sections_sizes_int[i];
+              }
             }
-          }
-          when DType.Bool {
-            var e = toSymEntry(toGenSymEntry(entry), bool);
-            var locDom = e.a.localSubdomain();
-            // set the pointer to the entry array in the list of Pointers
-            if locDom.size > 0 {
-              ptrList[i] = c_ptrTo(e.a[locDom]): c_void_ptr;
+            else {
+              var e = toSymEntry(toGenSymEntry(entry), uint);
+              var locDom = e.a.localSubdomain();
+              objTypes[i] = ObjType.PDARRAY: int;
+              datatypes[i] = ARROWUINT64;
+              // set the pointer to the entry array in the list of Pointers
+              if locDom.size > 0 {
+                ptrList[i] = c_ptrTo(e.a[locDom]): c_void_ptr;
+                sizeList[i] = locDom.size;
+              }
+            }
+          } when DType.Bool {
+            if objType == ObjType.SEGARRAY {
+              var e: SegArraySymEntry = toSegArraySymEntry(entry, bool);
+              var segArray = new SegArray("", e, bool);
+              ref sa = segArray;
+              var A = sa.segments.a;
+              const lastOffset = A[A.domain.high];
+              const lastValIdx = sa.values.a.domain.high;
+              const locDom = sa.segments.a.localSubdomain();
+
+              objTypes[i] = ObjType.SEGARRAY: int;
               datatypes[i] = ARROWBOOLEAN;
-              sizeList[i] = locDom.size;
+
+              if locDom.size > 0 {
+                var localOffsets = A[locDom];
+                var startValIdx = localOffsets[locDom.low];
+                var endValIdx = if (lastOffset == localOffsets[locDom.high]) then lastValIdx else A[locDom.high + 1] - 1;
+                var valIdxRange = startValIdx..endValIdx;
+                ref olda = sa.values.a;
+                bool_vals[bi..#valIdxRange.size] = olda[valIdxRange];
+                ptrList[i] = c_ptrTo(bool_vals[bi]): c_void_ptr;
+                sizeList[i] = locDom.size;
+                offset_tracking[oi..#locDom.size] = localOffsets - startValIdx;
+                offsetPtr[i] = c_ptrTo(offset_tracking[oi]);
+                segarray_sizes[i] = sections_sizes_bool[i];
+              }
+            }
+            else {
+              var e = toSymEntry(toGenSymEntry(entry), bool);
+              var locDom = e.a.localSubdomain();
+              // set the pointer to the entry array in the list of Pointers
+              objTypes[i] = ObjType.PDARRAY: int;
+              datatypes[i] = ARROWBOOLEAN;
+              if locDom.size > 0 {
+                ptrList[i] = c_ptrTo(e.a[locDom]): c_void_ptr;
+                sizeList[i] = locDom.size;
+              }
             }
           } when DType.Float64 {
-            var e = toSymEntry(toGenSymEntry(entry), real);
-            var locDom = e.a.localSubdomain();
-            // set the pointer to the entry array in the list of Pointers
-            if locDom.size > 0 {
-              ptrList[i] = c_ptrTo(e.a[locDom]): c_void_ptr;
+            if objType == ObjType.SEGARRAY {
+              var e: SegArraySymEntry = toSegArraySymEntry(entry, real);
+              var segArray = new SegArray("", e, real);
+              ref sa = segArray;
+              var A = sa.segments.a;
+              const lastOffset = A[A.domain.high];
+              const lastValIdx = sa.values.a.domain.high;
+              const locDom = sa.segments.a.localSubdomain();
+
+              objTypes[i] = ObjType.SEGARRAY: int;
               datatypes[i] = ARROWDOUBLE;
-              sizeList[i] = locDom.size;
+
+              if locDom.size > 0 {
+                var localOffsets = A[locDom];
+                var startValIdx = localOffsets[locDom.low];
+                var endValIdx = if (lastOffset == localOffsets[locDom.high]) then lastValIdx else A[locDom.high + 1] - 1;
+                var valIdxRange = startValIdx..endValIdx;
+                ref olda = sa.values.a;
+                real_vals[ri..#valIdxRange.size] = olda[valIdxRange];
+                ptrList[i] = c_ptrTo(real_vals[ri]): c_void_ptr;
+                sizeList[i] = locDom.size;
+                offset_tracking[oi..#locDom.size] = localOffsets - startValIdx;
+                offsetPtr[i] = c_ptrTo(offset_tracking[oi]);
+                segarray_sizes[i] = sections_sizes_real[i];
+              }
+            }
+            else {
+              var e = toSymEntry(toGenSymEntry(entry), real);
+              var locDom = e.a.localSubdomain();
+
+              objTypes[i] = ObjType.PDARRAY: int;
+              datatypes[i] = ARROWDOUBLE;
+              // set the pointer to the entry array in the list of Pointers
+              if locDom.size > 0 {
+                ptrList[i] = c_ptrTo(e.a[locDom]): c_void_ptr;
+                sizeList[i] = locDom.size;
+              }
             }
           } when DType.Strings {
             var e: SegStringSymEntry = toSegStringSymEntry(entry);
@@ -1292,20 +1458,20 @@ module ParquetMsg {
             ref olda = ss.values.a;
             str_vals[si..#valIdxRange.size] = olda[valIdxRange];
             ptrList[i] = c_ptrTo(str_vals[si]): c_void_ptr;
+            objTypes[i] = ObjType.STRINGS: int;
             datatypes[i] = ARROWSTRING;
             sizeList[i] = locDom.size;
           } otherwise {
             throw getErrorWithContext(
-                              msg="Writing Parquet files (multi-column) does not support columns of type %s".format(entryDtype),
-                              lineNumber=getLineNumber(), 
-                              routineName=getRoutineName(), 
-                              moduleName=getModuleName(), 
-                              errorClass='DataTypeError'
+              msg="Writing Parquet files (multi-column) does not support columns of type %s".format(entryDtype),
+              lineNumber=getLineNumber(), 
+              routineName=getRoutineName(), 
+              moduleName=getModuleName(), 
+              errorClass='DataTypeError'
             );
           }
         }
       }
-      
       // validate all elements same size
       var numelems: int = sizeList[0];
       if !(&& reduce (sizeList==numelems)) {
@@ -1317,9 +1483,102 @@ module ParquetMsg {
               errorClass='WriteModeError'
         );
       }
-      var result: int = c_writeMultiColToParquet(fname.localize().c_str(), c_ptrTo(c_names), c_ptrTo(ptrList), c_ptrTo(datatypes), ncols, numelems, ROWGROUPS, compression, c_ptrTo(pqErr.errMsg));
+      var result: int = c_writeMultiColToParquet(fname.localize().c_str(), c_ptrTo(c_names), c_ptrTo(ptrList), c_ptrTo(offsetPtr), c_ptrTo(objTypes), c_ptrTo(datatypes), c_ptrTo(segarray_sizes), ncols, numelems, ROWGROUPS, compression, c_ptrTo(pqErr.errMsg));
     }
     return filesExist;
+  }
+
+  proc _identifyObjectType(entry: borrowed AbstractSymEntry): ObjType throws {
+    if (entry.isAssignableTo(SymbolEntryType.SegArraySymEntry)){
+      return ObjType.SEGARRAY;
+    } else if (entry.isAssignableTo(SymbolEntryType.SegStringSymEntry)) {
+      return ObjType.STRINGS;
+    } else if (entry.isAssignableTo(SymbolEntryType.TypedArraySymEntry)) {
+      return ObjType.PDARRAY;
+    } else {
+      throw getErrorWithContext(
+          msg="Unable to identify object type. Only pdarray, Strings, and SegArray are supported for writing to Parquet.",
+          lineNumber=getLineNumber(), 
+          routineName=getRoutineName(), 
+          moduleName=getModuleName(), 
+          errorClass='ValueError'
+      );
+    }
+  }
+
+  proc _identifyDtype(entry: borrowed AbstractSymEntry, objType: ObjType): DType throws {
+    var entryDtype = DType.UNDEF;
+    if (objType == ObjType.PDARRAY || objType == ObjType.SEGARRAY) {
+      entryDtype = (entry: borrowed GenSymEntry).dtype;
+    }
+    else if (objType == ObjType.STRINGS) {
+      entryDtype = (entry: borrowed SegStringSymEntry).dtype;
+    } 
+    else {
+      throw getErrorWithContext(
+          msg="Unable to identify dtype",
+          lineNumber=getLineNumber(), 
+          routineName=getRoutineName(), 
+          moduleName=getModuleName(), 
+          errorClass='ValueError'
+      );
+    }
+    return entryDtype;
+  }
+
+  proc _identifyTargetLocales(entry: borrowed AbstractSymEntry) throws {
+    var objType = _identifyObjectType(entry);
+    var entryDtype = _identifyDtype(entry, objType);
+    
+    var targetLocales;
+    select entryDtype {
+      when DType.Int64 {
+        if objType == ObjType.SEGARRAY {
+          var segArray:SegArraySymEntry = toSegArraySymEntry(entry, int);
+          targetLocales = segArray.segmentsEntry.a.targetLocales();
+        } else {
+          var e = toSymEntry(toGenSymEntry(entry), int);
+          targetLocales = e.a.targetLocales();
+        }
+      } when DType.UInt64 {
+        if objType == ObjType.SEGARRAY {
+          var segArray:SegArraySymEntry = toSegArraySymEntry(entry, uint);
+          targetLocales = segArray.segmentsEntry.a.targetLocales();
+        } else {
+          var e = toSymEntry(toGenSymEntry(entry), uint);
+          targetLocales = e.a.targetLocales();
+        }
+      } when DType.Bool {
+        if objType == ObjType.SEGARRAY {
+          var segArray:SegArraySymEntry = toSegArraySymEntry(entry, bool);
+          targetLocales = segArray.segmentsEntry.a.targetLocales();
+        } else {
+          var e = toSymEntry(toGenSymEntry(entry), bool);
+          targetLocales = e.a.targetLocales();
+        }
+      } when DType.Float64 {
+        if objType == ObjType.SEGARRAY {
+          var segArray:SegArraySymEntry = toSegArraySymEntry(entry, real);
+          targetLocales = segArray.segmentsEntry.a.targetLocales();
+        } else {
+          var e = toSymEntry(toGenSymEntry(entry), real);
+          targetLocales = e.a.targetLocales();
+        }
+      } when DType.Strings {
+        var e: SegStringSymEntry = toSegStringSymEntry(entry);
+        var segStr = new SegString("", e);
+        targetLocales = segStr.offsets.a.targetLocales();
+      } otherwise {
+        throw getErrorWithContext(
+          msg="Writing Parquet files (multi-column) does not support columns of type %s".format(entryDtype),
+          lineNumber=getLineNumber(), 
+          routineName=getRoutineName(), 
+          moduleName=getModuleName(), 
+          errorClass='DataTypeError'
+        );
+      }
+    }
+    return targetLocales;
   }
 
   proc toParquetMultiColMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
@@ -1338,53 +1597,9 @@ module ParquetMsg {
     // Assuming all columns have same distribution, access the first to get target locales
     var entry = st.lookup(sym_names[0]);
 
-    // access the dtype to create symentry from abstract
-    var entryDtype = DType.UNDEF;
-    if (entry.isAssignableTo(SymbolEntryType.TypedArraySymEntry)) {
-      entryDtype = (entry: borrowed GenSymEntry).dtype;
-    } else if (entry.isAssignableTo(SymbolEntryType.SegStringSymEntry)) {
-      entryDtype = (entry: borrowed SegStringSymEntry).dtype;
-    } else {
-      throw getErrorWithContext(
-          msg="Unknown SymEntry Type",
-          lineNumber=getLineNumber(), 
-          routineName=getRoutineName(), 
-          moduleName=getModuleName(), 
-          errorClass='ValueError'
-      );
-    }
-
-    var targetLocales;
-    select entryDtype {
-      when DType.Int64 {
-        var e = toSymEntry(toGenSymEntry(entry), int);
-        targetLocales = e.a.targetLocales();
-      }
-      when DType.UInt64 {
-        var e = toSymEntry(toGenSymEntry(entry), uint);
-        targetLocales = e.a.targetLocales();
-      }
-      when DType.Bool {
-        var e = toSymEntry(toGenSymEntry(entry), bool);
-        targetLocales = e.a.targetLocales();
-      } when DType.Float64 {
-        var e = toSymEntry(toGenSymEntry(entry), real);
-        targetLocales = e.a.targetLocales();
-      } when DType.Strings {
-        var e: SegStringSymEntry = toSegStringSymEntry(entry);
-        var segStr = new SegString("", e);
-        targetLocales = segStr.offsets.a.targetLocales();
-      } otherwise {
-        throw getErrorWithContext(
-                          msg="Writing Parquet files (multi-column) does not support columns of type %s".format(entryDtype),
-                          lineNumber=getLineNumber(), 
-                          routineName=getRoutineName(), 
-                          moduleName=getModuleName(), 
-                          errorClass='DataTypeError'
-        );
-      }
-    }
-
+    // use the first entry to identify target locales.
+    var targetLocales = _identifyTargetLocales(entry);
+    
     var warnFlag: bool;
     try {
       warnFlag = writeMultiColParquet(filename, col_names, ncols, sym_names, targetLocales, compression:int, st);
@@ -1406,7 +1621,7 @@ module ParquetMsg {
       var warnMsg = "Warning: possibly overwriting existing files matching filename pattern";
       return new MsgTuple(warnMsg, MsgType.WARNING);
     } else {
-      var repMsg = "wrote array to file";
+      var repMsg = "File written successfully!";
       pqLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
       return new MsgTuple(repMsg, MsgType.NORMAL);
     }

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -515,6 +515,7 @@ class ParquetTest(ArkoudaTest):
             "c_6": ak.segarray(ak.array([0, 5, 10]), ak.randint(0, 1, 15, dtype=ak.bool)),
             "c_7": ak.array(np.random.uniform(0, 100, 3)),
             "c_8": ak.segarray(ak.array([0, 9, 14]), ak.array(np.random.uniform(0, 100, 20))),
+            "c_9": ak.array(["abc", "123", "xyz"])
         }
         akdf = ak.DataFrame(df_dict)
         with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:


### PR DESCRIPTION
Closes #2186
Closes #2211

- Adds SegArray support to the multi-column Parquet write workflow.
- Updates the workflow of `multi-column` parquet writes to be more readable and maintainable.
- Adds dedicated testing for the Multi-Column workflow testing all supported types and all currently supported segarray types.
- Simplifies some information tracking for maintainability/readability.
- Object Types and Data Types are set outside of the `locDom.size > 0` test to ensure that the schema gets configured properly and there are no issues when the empty files are encountered on read.
- Corrects bug with Strings in this workflow - when more locales than segments, the process would fail. Added `locDom.size > 0` check to the string case.