### PR TITLE
Fixes #2214: bigint rotate by more than max_bits bug

### DIFF
--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -1191,7 +1191,7 @@ module BinOp
             if r.etype == int {
               // cant just do botBits >>= shift_amt;
               forall (t, ri, bot_bits) in zip(tmp, ra, botBits) with (var local_max_size = max_size) {
-                var modded_shift = ri % max_bits;
+                var modded_shift = if r.etype == int then ri % max_bits else ri % max_bits:uint;
                 t <<= modded_shift;
                 var div_by = 1:bigint;
                 var shift_amt = max_bits - modded_shift;
@@ -1203,7 +1203,7 @@ module BinOp
             }
             else {
               forall (t, ri, bot_bits) in zip(tmp, ra, botBits) with (var local_max_size = max_size) {
-                var modded_shift = ri % max_bits;
+                var modded_shift = if r.etype == int then ri % max_bits else ri % max_bits:uint;
                 t <<= modded_shift;
                 var shift_amt = max_bits:uint - modded_shift;
                 bot_bits >>= shift_amt;
@@ -1222,7 +1222,7 @@ module BinOp
             // cant just do tmp >>= ra;
             var topBits = la;
             forall (t, ri, tB) in zip(tmp, ra, topBits) with (var local_max_size = max_size) {
-              var modded_shift = ri % max_bits;
+              var modded_shift = if r.etype == int then ri % max_bits else ri % max_bits:uint;
               var div_by = 1:bigint;
               div_by <<= modded_shift;
               t /= div_by;
@@ -1443,8 +1443,8 @@ module BinOp
             // should be as simple as the below, see issue #2006
             // return (la << val) | (la >> (max_bits - val));
             var botBits = la;
-            var modded_shift = val % max_bits;
             if val.type == int {
+              var modded_shift = val % max_bits;
               var shift_amt = max_bits - modded_shift;
               // cant just do botBits >>= shift_amt;
               forall (t, bot_bits) in zip(tmp, botBits) with (var local_val = modded_shift, var local_shift_amt = shift_amt, var local_max_size = max_size) {
@@ -1457,6 +1457,7 @@ module BinOp
               }
             }
             else {
+              var modded_shift = val % max_bits:uint;
               var shift_amt = max_bits:uint - modded_shift;
               forall (t, bot_bits) in zip(tmp, botBits) with (var local_val = modded_shift, var local_shift_amt = shift_amt, var local_max_size = max_size) {
                 t <<= local_val;
@@ -1475,7 +1476,7 @@ module BinOp
             // return (la >> val) | (la << (max_bits - val));
             // cant just do tmp >>= ra;
             var topBits = la;
-            var modded_shift = val % max_bits;
+            var modded_shift = if val.type == int then val % max_bits else val % max_bits:uint;
             var shift_amt = if val.type == int then max_bits - modded_shift else max_bits:uint - modded_shift;
             forall (t, tB) in zip(tmp, topBits) with (var local_val = modded_shift, var local_shift_amt = shift_amt, var local_max_size = max_size) {
               var div_by = 1:bigint;
@@ -1720,7 +1721,7 @@ module BinOp
             if r.etype == int {
               // cant just do botBits >>= shift_amt;
               forall (t, ri, bot_bits) in zip(tmp, ra, botBits) with (var local_max_size = max_size) {
-                var modded_shift = ri % max_bits;
+                var modded_shift = if r.etype == int then ri % max_bits else ri % max_bits:uint;
                 t <<= modded_shift;
                 var div_by = 1:bigint;
                 var shift_amt = max_bits - modded_shift;
@@ -1732,7 +1733,7 @@ module BinOp
             }
             else {
               forall (t, ri, bot_bits) in zip(tmp, ra, botBits) with (var local_max_size = max_size) {
-                var modded_shift = ri % max_bits;
+                var modded_shift = if r.etype == int then ri % max_bits else ri % max_bits:uint;
                 t <<= modded_shift;
                 var shift_amt = max_bits:uint - modded_shift;
                 bot_bits >>= shift_amt;
@@ -1752,7 +1753,7 @@ module BinOp
             var topBits = makeDistArray(ra.size, bigint);
             topBits = val;
             forall (t, ri, tB) in zip(tmp, ra, topBits) with (var local_max_size = max_size) {
-              var modded_shift = ri % max_bits;
+              var modded_shift = if r.etype == int then ri % max_bits else ri % max_bits:uint;
               var div_by = 1:bigint;
               div_by <<= modded_shift;
               t /= div_by;

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -1191,9 +1191,10 @@ module BinOp
             if r.etype == int {
               // cant just do botBits >>= shift_amt;
               forall (t, ri, bot_bits) in zip(tmp, ra, botBits) with (var local_max_size = max_size) {
-                t <<= ri;
+                var modded_shift = ri % max_bits;
+                t <<= modded_shift;
                 var div_by = 1:bigint;
-                var shift_amt = max_bits - ri;
+                var shift_amt = max_bits - modded_shift;
                 div_by <<= shift_amt;
                 bot_bits /= div_by;
                 t += bot_bits;
@@ -1202,8 +1203,9 @@ module BinOp
             }
             else {
               forall (t, ri, bot_bits) in zip(tmp, ra, botBits) with (var local_max_size = max_size) {
-                t <<= ri;
-                var shift_amt = max_bits:uint - ri;
+                var modded_shift = ri % max_bits;
+                t <<= modded_shift;
+                var shift_amt = max_bits:uint - modded_shift;
                 bot_bits >>= shift_amt;
                 t += bot_bits;
                 t &= local_max_size;
@@ -1220,10 +1222,11 @@ module BinOp
             // cant just do tmp >>= ra;
             var topBits = la;
             forall (t, ri, tB) in zip(tmp, ra, topBits) with (var local_max_size = max_size) {
+              var modded_shift = ri % max_bits;
               var div_by = 1:bigint;
-              div_by <<= ri;
+              div_by <<= modded_shift;
               t /= div_by;
-              var shift_amt = if r.etype == int then max_bits - ri else max_bits:uint - ri;
+              var shift_amt = if r.etype == int then max_bits - modded_shift else max_bits:uint - modded_shift;
               tB <<= shift_amt;
               t += tB;
               t &= local_max_size;
@@ -1440,10 +1443,11 @@ module BinOp
             // should be as simple as the below, see issue #2006
             // return (la << val) | (la >> (max_bits - val));
             var botBits = la;
+            var modded_shift = val % max_bits;
             if val.type == int {
-              var shift_amt = max_bits - val;
+              var shift_amt = max_bits - modded_shift;
               // cant just do botBits >>= shift_amt;
-              forall (t, bot_bits) in zip(tmp, botBits) with (var local_val = val, var local_shift_amt = shift_amt, var local_max_size = max_size) {
+              forall (t, bot_bits) in zip(tmp, botBits) with (var local_val = modded_shift, var local_shift_amt = shift_amt, var local_max_size = max_size) {
                 t <<= local_val;
                 var div_by = 1:bigint;
                 div_by <<= local_shift_amt;
@@ -1453,8 +1457,8 @@ module BinOp
               }
             }
             else {
-              var shift_amt = max_bits:uint - val;
-              forall (t, bot_bits) in zip(tmp, botBits) with (var local_val = val, var local_shift_amt = shift_amt, var local_max_size = max_size) {
+              var shift_amt = max_bits:uint - modded_shift;
+              forall (t, bot_bits) in zip(tmp, botBits) with (var local_val = modded_shift, var local_shift_amt = shift_amt, var local_max_size = max_size) {
                 t <<= local_val;
                 bot_bits >>= local_shift_amt;
                 t += bot_bits;
@@ -1471,8 +1475,9 @@ module BinOp
             // return (la >> val) | (la << (max_bits - val));
             // cant just do tmp >>= ra;
             var topBits = la;
-            var shift_amt = if val.type == int then max_bits - val else max_bits:uint - val;
-            forall (t, tB) in zip(tmp, topBits) with (var local_val = val, var local_shift_amt = shift_amt, var local_max_size = max_size) {
+            var modded_shift = val % max_bits;
+            var shift_amt = if val.type == int then max_bits - modded_shift else max_bits:uint - modded_shift;
+            forall (t, tB) in zip(tmp, topBits) with (var local_val = modded_shift, var local_shift_amt = shift_amt, var local_max_size = max_size) {
               var div_by = 1:bigint;
               div_by <<= local_val;
               t /= div_by;
@@ -1715,9 +1720,10 @@ module BinOp
             if r.etype == int {
               // cant just do botBits >>= shift_amt;
               forall (t, ri, bot_bits) in zip(tmp, ra, botBits) with (var local_max_size = max_size) {
-                t <<= ri;
+                var modded_shift = ri % max_bits;
+                t <<= modded_shift;
                 var div_by = 1:bigint;
-                var shift_amt = max_bits - ri;
+                var shift_amt = max_bits - modded_shift;
                 div_by <<= shift_amt;
                 bot_bits /= div_by;
                 t += bot_bits;
@@ -1726,8 +1732,9 @@ module BinOp
             }
             else {
               forall (t, ri, bot_bits) in zip(tmp, ra, botBits) with (var local_max_size = max_size) {
-                t <<= ri;
-                var shift_amt = max_bits:uint - ri;
+                var modded_shift = ri % max_bits;
+                t <<= modded_shift;
+                var shift_amt = max_bits:uint - modded_shift;
                 bot_bits >>= shift_amt;
                 t += bot_bits;
                 t &= local_max_size;
@@ -1745,10 +1752,11 @@ module BinOp
             var topBits = makeDistArray(ra.size, bigint);
             topBits = val;
             forall (t, ri, tB) in zip(tmp, ra, topBits) with (var local_max_size = max_size) {
+              var modded_shift = ri % max_bits;
               var div_by = 1:bigint;
-              div_by <<= ri;
+              div_by <<= modded_shift;
               t /= div_by;
-              var shift_amt = if r.etype == int then max_bits - ri else max_bits:uint - ri;
+              var shift_amt = if r.etype == int then max_bits - modded_shift else max_bits:uint - modded_shift;
               tB <<= shift_amt;
               t += tB;
               t &= local_max_size;

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -874,6 +874,24 @@ class OperatorsTest(ArkoudaTest):
             self.assertListEqual([(bi[i] * s) % mod_by for i in range(bi.size)], (bi * s).to_list())
             self.assertListEqual([(s * bi[i]) % mod_by for i in range(bi.size)], (s * bi).to_list())
 
+    def test_bigint_rotate(self):
+        # see issue #2214
+        # verify bigint pdarray correctly rotate when shift_amount exceeds max_bits
+        # in this test we are rotating 10 with max_bits=4, so even rotations will equal 10
+        # and odd rotations will equal 5. We test rotations up to 10 (which is > 4)
+
+        # rotate by scalar
+        for i in range(10):
+            self.assertEqual(ak.array([10], dtype=ak.bigint, max_bits=4).rotl(i), 10 if i % 2 == 0 else 5)
+            self.assertEqual(ak.array([10], dtype=ak.bigint, max_bits=4).rotr(i), 10 if i % 2 == 0 else 5)
+
+        # rotate by array
+        left_rot = ak.bigint_from_uint_arrays([ak.full(10, 10, ak.uint64)], max_bits=4).rotl(ak.arange(10))
+        right_rot = ak.bigint_from_uint_arrays([ak.full(10, 10, ak.uint64)], max_bits=4).rotr(ak.arange(10))
+        ans = [10 if i % 2 == 0 else 5 for i in range(10)]
+        self.assertListEqual(left_rot.to_list(), ans)
+        self.assertListEqual(right_rot.to_list(), ans)
+
     def test_fmod(self):
         # Note - uint/float and float/uint handles in another test case
         npf = np.array([2.23, 3.14, 3.08, 5.7])


### PR DESCRIPTION
This PR (fixes #2214) fixes a bug when rotating a bigint pdarray by more than max_bits and adds a test to verify