### PR TITLE
Closes #2219 - Implementation of v2 aggregation benchmark

### DIFF
--- a/benchmark.ini
+++ b/benchmark.ini
@@ -3,6 +3,7 @@ filterwarnings =
     ignore:Version mismatch between client .*
 testpaths =
     benchmark_v2/argsort_benchmark.py
+    benchmark_v2/aggregate_benchmark.py
 python_functions = bench_*
 env =
     D:ARKOUDA_SERVER_HOST=localhost

--- a/benchmark_v2/aggregate_benchmark.py
+++ b/benchmark_v2/aggregate_benchmark.py
@@ -4,7 +4,7 @@ import pytest
 
 def setup_agg(t="int"):
     cfg = ak.get_config()
-    N = pytest.problem_size * cfg["numLocales"]
+    N = pytest.prob_size * cfg["numLocales"]
 
     # Sort keys so that aggregations will not have to permute values
     # We just want to measure aggregation time, not gather
@@ -33,9 +33,9 @@ def bench_aggs(benchmark, op):
     else:
         g, vals = setup_agg()
 
-    numBytes = benchmark.pedantic(run_agg, args=(g, vals, op), rounds=pytest.num_trials)
+    numBytes = benchmark.pedantic(run_agg, args=(g, vals, op), rounds=pytest.trials)
 
-    benchmark.extra_info["Problem size"] = pytest.problem_size
+    benchmark.extra_info["Problem size"] = pytest.prob_size
     benchmark.extra_info["Bytes per second"] = "{:.4f} GiB/sec".format(
         (numBytes / benchmark.stats["mean"]) / 2 ** 30)
     benchmark.extra_info["Description"] = f"This benchmark tests GroupBy Aggregation using the {op} operator."

--- a/benchmark_v2/aggregate_benchmark.py
+++ b/benchmark_v2/aggregate_benchmark.py
@@ -34,8 +34,10 @@ def bench_aggs(benchmark, op):
         g, vals = setup_agg()
 
     numBytes = benchmark.pedantic(run_agg, args=(g, vals, op), rounds=pytest.trials)
-
-    benchmark.extra_info["Problem size"] = pytest.prob_size
-    benchmark.extra_info["Bytes per second"] = "{:.4f} GiB/sec".format(
-        (numBytes / benchmark.stats["mean"]) / 2 ** 30)
-    benchmark.extra_info["Description"] = f"This benchmark tests GroupBy Aggregation using the {op} operator."
+    benchmark.extra_info[
+        "description"
+    ] = f"Measures performance of GroupBy.aggregate using the {op} operator."
+    benchmark.extra_info["problem_size"] = pytest.prob_size
+    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
+        (numBytes / benchmark.stats["mean"]) / 2**30
+    )

--- a/benchmark_v2/aggregate_benchmark.py
+++ b/benchmark_v2/aggregate_benchmark.py
@@ -1,0 +1,41 @@
+import arkouda as ak
+import pytest
+
+
+def setup_agg(t="int"):
+    cfg = ak.get_config()
+    N = pytest.problem_size * cfg["numLocales"]
+
+    # Sort keys so that aggregations will not have to permute values
+    # We just want to measure aggregation time, not gather
+    keys = ak.sort(ak.randint(0, 2**32, N, seed=pytest.seed))
+    intvals = ak.randint(0, 2**16, N, seed=(pytest.seed + 1 if pytest.seed is not None else None))
+    g = ak.GroupBy(keys, assume_sorted=True)
+
+    if t == "int":
+        return g, intvals
+    else:
+        boolvals = (intvals % 2) == 0
+        return g, boolvals
+
+
+def run_agg(g, vals, op):
+    g.aggregate(vals, op)
+
+    return vals.size + vals.itemsize
+
+
+@pytest.mark.benchmark(group="GroupBy.aggregate")
+@pytest.mark.parametrize("op", ak.GroupBy.Reductions)
+def bench_aggs(benchmark, op):
+    if op in ["any", "all"]:
+        g, vals = setup_agg("bool")
+    else:
+        g, vals = setup_agg()
+
+    numBytes = benchmark.pedantic(run_agg, args=(g, vals, op), rounds=pytest.num_trials)
+
+    benchmark.extra_info["Problem size"] = pytest.problem_size
+    benchmark.extra_info["Bytes per second"] = "{:.4f} GiB/sec".format(
+        (numBytes / benchmark.stats["mean"]) / 2 ** 30)
+    benchmark.extra_info["Description"] = f"This benchmark tests GroupBy Aggregation using the {op} operator."


### PR DESCRIPTION
This PR Closes #2219 

The new `aggregate_benchmark.py` mirrors the test functionality of the original `aggregate.py` benchmark while implementing `pytest-benchmark`