### PR TITLE
Closes #2220 - PyTest Benchmark for `ak.argsort`

### DIFF
--- a/benchmark.ini
+++ b/benchmark.ini
@@ -2,7 +2,7 @@
 filterwarnings =
     ignore:Version mismatch between client .*
 testpaths =
-    benchmark_v2/example_benchmark.py
+    benchmark_v2/argsort_benchmark.py
 python_functions = bench_*
 env =
     D:ARKOUDA_SERVER_HOST=localhost

--- a/benchmark_v2/argsort_benchmark.py
+++ b/benchmark_v2/argsort_benchmark.py
@@ -1,0 +1,36 @@
+import arkouda as ak
+import pytest
+
+TYPES = ("int64", "uint64", "float64", "str")
+
+@pytest.mark.parametrize("dtype", TYPES)
+def bench_argsort(benchmark, dtype):
+    """
+    Measure ArgSort performance. Runs for each dtype in TYPES
+
+    Note
+    -----
+    str dtype is significantly slower than numerics
+    """
+    cfg = ak.get_config()
+    N = pytest.prob_size * cfg["numLocales"]
+    if dtype in pytest.dtype:
+        if dtype == "int64":
+            a = ak.randint(0, 2**32, N, seed=pytest.seed)
+            nbytes = a.size * a.itemsize
+        elif dtype == "uint64":
+            a = ak.randint(0, 2**32, N, dtype=ak.uint64, seed=pytest.seed)
+            nbytes = a.size * a.itemsize
+        elif dtype == "float64":
+            a = ak.randint(0, 1, N, dtype=ak.float64, seed=pytest.seed)
+            nbytes = a.size * a.itemsize
+        elif dtype == "str":
+            a = ak.random_strings_uniform(1, 16, N, seed=pytest.seed)
+            nbytes = a.nbytes * a.entry.itemsize
+
+        benchmark.pedantic(ak.argsort, args=[a], rounds=pytest.trials)
+
+        benchmark.extra_info["description"] = "Measures the performance of ak.argsort"
+        benchmark.extra_info["problem_size"] = pytest.prob_size
+        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
+            (nbytes / benchmark.stats["mean"]) / 2 ** 30)

--- a/benchmark_v2/conftest.py
+++ b/benchmark_v2/conftest.py
@@ -1,7 +1,6 @@
 import pytest
 import os
 import importlib
-import argparse
 
 import arkouda as ak
 

--- a/benchmark_v2/conftest.py
+++ b/benchmark_v2/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 import os
 import importlib
+import argparse
 
 import arkouda as ak
 
@@ -10,6 +11,14 @@ from server_util.test.server_test_util import (
     start_arkouda_server,
     stop_arkouda_server,
 )
+
+default_dtype = ["int64", "uint64", "float64", "bool", "str"]
+def pytest_configure(config):
+    pytest.prob_size = config.getoption("size")
+    pytest.trials = config.getoption("trials")
+    pytest.seed = config.getoption("seed")
+    dtype_str = config.getoption("dtype")
+    pytest.dtype = default_dtype if dtype_str is None else dtype_str.split(",")
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -52,7 +61,8 @@ def startup_teardown():
 
 @pytest.fixture(scope="function", autouse=True)
 def manage_connection():
-    pytest.problem_size = eval(os.getenv("ARKOUDA_PROBLEM_SIZE", "10**8"))
+    # pytest.problem_size = eval(os.getenv("ARKOUDA_PROBLEM_SIZE", "10**8"))
+    # pytest.trials = eval(os.getenv("ARKOUDA_TRIALS", "10"))
     port = int(os.getenv("ARKOUDA_SERVER_PORT", 5555))
     server = os.getenv("ARKOUDA_SERVER_HOST", "localhost")
     timeout = int(os.getenv("ARKOUDA_CLIENT_TIMEOUT", 5))

--- a/benchmark_v2/conftest.py
+++ b/benchmark_v2/conftest.py
@@ -13,9 +13,9 @@ from server_util.test.server_test_util import (
 
 default_dtype = ["int64", "uint64", "float64", "bool", "str"]
 def pytest_configure(config):
-    pytest.prob_size = config.getoption("size")
-    pytest.trials = config.getoption("trials")
-    pytest.seed = config.getoption("seed")
+    pytest.prob_size = eval(config.getoption("size"))
+    pytest.trials = eval(config.getoption("trials"))
+    pytest.seed = eval(config.getoption("seed"))
     dtype_str = config.getoption("dtype")
     pytest.dtype = default_dtype if dtype_str is None else dtype_str.split(",")
 

--- a/benchmark_v2/conftest.py
+++ b/benchmark_v2/conftest.py
@@ -61,8 +61,6 @@ def startup_teardown():
 
 @pytest.fixture(scope="function", autouse=True)
 def manage_connection():
-    # pytest.problem_size = eval(os.getenv("ARKOUDA_PROBLEM_SIZE", "10**8"))
-    # pytest.trials = eval(os.getenv("ARKOUDA_TRIALS", "10"))
     port = int(os.getenv("ARKOUDA_SERVER_PORT", 5555))
     server = os.getenv("ARKOUDA_SERVER_HOST", "localhost")
     timeout = int(os.getenv("ARKOUDA_CLIENT_TIMEOUT", 5))

--- a/benchmark_v2/conftest.py
+++ b/benchmark_v2/conftest.py
@@ -15,9 +15,9 @@ default_dtype = ["int64", "uint64", "float64", "bool", "str"]
 def pytest_configure(config):
     pytest.prob_size = eval(config.getoption("size"))
     pytest.trials = eval(config.getoption("trials"))
-    pytest.seed = eval(config.getoption("seed"))
+    pytest.seed = None if config.getoption("seed") == "" else eval(config.getoption("seed"))
     dtype_str = config.getoption("dtype")
-    pytest.dtype = default_dtype if dtype_str is None else dtype_str.split(",")
+    pytest.dtype = default_dtype if dtype_str == "" else dtype_str.split(",")
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/benchmark_v2/example_benchmark.py
+++ b/benchmark_v2/example_benchmark.py
@@ -39,7 +39,7 @@ def append_col_parquet_write(df):
 
 
 def bench_append_parquet(benchmark):
-    benchmark.extra_info["problem_size"] = pytest.prob_size #pytest.getoption("problem_size")
+    benchmark.extra_info["problem_size"] = pytest.prob_size
     df_dict = {
         "c_1": ak.arange(3),
         # "c_2": ak.segarray(ak.array([0, 9, 14]), ak.arange(20)),

--- a/benchmark_v2/example_benchmark.py
+++ b/benchmark_v2/example_benchmark.py
@@ -39,7 +39,7 @@ def append_col_parquet_write(df):
 
 
 def bench_append_parquet(benchmark):
-    benchmark.extra_info["problem_size"] = pytest.problem_size
+    benchmark.extra_info["problem_size"] = pytest.prob_size #pytest.getoption("problem_size")
     df_dict = {
         "c_1": ak.arange(3),
         # "c_2": ak.segarray(ak.array([0, 9, 14]), ak.arange(20)),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,31 @@ def pytest_addoption(parser):
         "--optional-parquet", action="store_true", default=False, help="run optional parquet tests"
     )
 
+    # due to the order pytest looks for conftest in, options for our benchmarks are added here
+    # this has no impact on testing, but allows quick and easy access to settings without the need
+    # for env vars. Everything below is for workflows in arkouda/benchmark_v2
+    parser.addoption(
+        "--size", action="store", default=10**8, type=int,
+        help="Benchmark only option. Problem size: length of array to use for benchmarks."
+    )
+    parser.addoption(
+        "--trials", action="store", default=5, type=int,
+        help="Benchmark only option. Problem size: length of array to use for benchmarks."
+    )
+    parser.addoption(
+        "--seed", action="store", default=None, type=int,
+        help="Benchmark only option. Value to initialize random number generator."
+    )
+    parser.addoption(
+        "--dtype", action="store", default=None, type=str,
+        help="Benchmark only option. Dtypes to run benchmarks against. Comma separated list "
+             "(NO SPACES) allowing for multiple. Accepted values: int64, uint64, float64, bool, and str."
+    )
+    parser.addoption(
+        "--numpy", action="store_true", default=False, type=bool,
+        help="Benchmark only option. When set, runs numpy comparison benchmarks."
+    )
+
 
 def pytest_collection_modifyitems(config, items):
     if config.getoption("--optional-parquet"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,11 +22,11 @@ def pytest_addoption(parser):
         help="Benchmark only option. Problem size: length of array to use for benchmarks."
     )
     parser.addoption(
-        "--seed", action="store", default="None",
+        "--seed", action="store", default="",
         help="Benchmark only option. Value to initialize random number generator."
     )
     parser.addoption(
-        "--dtype", action="store", default="None",
+        "--dtype", action="store", default="",
         help="Benchmark only option. Dtypes to run benchmarks against. Comma separated list "
              "(NO SPACES) allowing for multiple. Accepted values: int64, uint64, float64, bool, and str."
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,24 +14,24 @@ def pytest_addoption(parser):
     # this has no impact on testing, but allows quick and easy access to settings without the need
     # for env vars. Everything below is for workflows in arkouda/benchmark_v2
     parser.addoption(
-        "--size", action="store", default=10**8, type=int,
+        "--size", action="store", default="10**8",
         help="Benchmark only option. Problem size: length of array to use for benchmarks."
     )
     parser.addoption(
-        "--trials", action="store", default=5, type=int,
+        "--trials", action="store", default="5",
         help="Benchmark only option. Problem size: length of array to use for benchmarks."
     )
     parser.addoption(
-        "--seed", action="store", default=None, type=int,
+        "--seed", action="store", default="None",
         help="Benchmark only option. Value to initialize random number generator."
     )
     parser.addoption(
-        "--dtype", action="store", default=None, type=str,
+        "--dtype", action="store", default="None",
         help="Benchmark only option. Dtypes to run benchmarks against. Comma separated list "
              "(NO SPACES) allowing for multiple. Accepted values: int64, uint64, float64, bool, and str."
     )
     parser.addoption(
-        "--numpy", action="store_true", default=False, type=bool,
+        "--numpy", action="store_true", default=False,
         help="Benchmark only option. When set, runs numpy comparison benchmarks."
     )
 


### PR DESCRIPTION
Closes #2220 

- Adds pytest benchmark for `ak.argsort`.
- Adds command line options for benchmarks. These are added to `tests/conftest.py` in order to function due to the way pytest looks for and utilizes conftest.py files. This should not be an issue as the eventual plan is to move to a uniform system only having a single `conftest.py` file to maintain once our tests can be updated.
- Allows for setting more than 1 dtype. Our old benchmarks required you to run for a single dtype. This allows for running with as many of the supported dtypes as needed.
- All command line arguments are set as pytest variables. For example, using `--size x` will trigger the `pytest.prob_size` variable to be set to `x`. All variables configured this way can be accessed by importing `pytest`.
- The `--check-correctness` option was not moved over because these checks are going to be moved into the main testing suite. Again, once this is being done, we will most likely make use of the options supplied for benchmarks.
- All command line args are pulled as strings, so the proper parsing is added to ensure correct values for usage.
- The `--numpy` arg is added to allow for running numpy comparisons. However, the comparison in `argsort` is not running anything, so it was not ported over.

**Example Call**
This example demonstrates a call setting all flags.
```bash
python3 -m pytest -c benchmark.ini --size="10**6" --trials=10 --seed="2**20" --dtype=int64,float64
```

**Output from Example Call**
```bash
benchmark_v2/argsort_benchmark.py ....                                                                                                                                             [100%]

==================================================================================== warnings summary ====================================================================================
benchmark_v2/argsort_benchmark.py::bench_argsort[uint64]
benchmark_v2/argsort_benchmark.py::bench_argsort[str]
  benchmark_v2/argsort_benchmark.py:6: PytestBenchmarkWarning: Benchmark fixture was not used at all in this test!
    @pytest.mark.parametrize("dtype", TYPES)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

-------------------------------------------------------------------------------------- benchmark: 2 tests -------------------------------------------------------------------------------------
Name (time in ms)               Min                 Max                Mean             StdDev              Median               IQR            Outliers      OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
bench_argsort[int64]        72.3735 (1.0)      111.7408 (1.0)       78.1717 (1.0)      12.0035 (2.29)      74.6366 (1.0)      4.3496 (1.66)          1;1  12.7924 (1.0)          10           1
bench_argsort[float64]     130.5417 (1.80)     149.0939 (1.33)     140.1040 (1.79)      5.2396 (1.0)      138.8819 (1.86)     2.6208 (1.0)           3;3   7.1376 (0.56)         10           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
============================================================================= 4 passed, 2 warnings in 4.55s ==============================================================================
```