### PR TITLE
Closes #2226 - Array Transfer Pytest Benchmark

### DIFF
--- a/benchmark.ini
+++ b/benchmark.ini
@@ -4,6 +4,7 @@ filterwarnings =
 testpaths =
     benchmark_v2/argsort_benchmark.py
     benchmark_v2/aggregate_benchmark.py
+    benchmark_v2/array_transfer_benchmark.py
 python_functions = bench_*
 env =
     D:ARKOUDA_SERVER_HOST=localhost

--- a/benchmark_v2/array_transfer_benchmark.py
+++ b/benchmark_v2/array_transfer_benchmark.py
@@ -1,0 +1,54 @@
+import arkouda as ak
+import pytest
+
+TYPES = ("int64", "float64", "bigint")
+
+@pytest.mark.benchmark(group="ArrayTransfer_tondarray")
+@pytest.mark.parametrize("dtype", TYPES)
+def bench_array_transfer_tondarray(benchmark, dtype):
+    if dtype in pytest.dtype:
+        if dtype == ak.bigint.name:
+            u1 = ak.randint(0, 2 ** 32, pytest.prob_size, dtype=ak.uint64, seed=pytest.seed)
+            u2 = ak.randint(0, 2 ** 32, pytest.prob_size, dtype=ak.uint64, seed=pytest.seed)
+            a = ak.bigint_from_uint_arrays([u1, u2], max_bits=pytest.max_bits)
+            # bytes per bigint array (N * 16) since it's made of 2 uint64 arrays
+            # if max_bits in [0, 64] then they're essentially 1 uint64 array
+            nb = a.size * 8 if pytest.max_bits != -1 and pytest.max_bits <= 64 else a.size * 8 * 2
+            ak.client.maxTransferBytes = nb
+        else:
+            a = ak.randint(0, 2 ** 32, pytest.prob_size, dtype=dtype, seed=pytest.seed)
+            nb = a.size * a.itemsize
+            ak.client.maxTransferBytes = nb
+
+        benchmark.pedantic(a.to_ndarray, rounds=pytest.trials)
+        benchmark.extra_info["description"] = "Measures the performance of pdarray.to_ndarray"
+        benchmark.extra_info["problem_size"] = pytest.prob_size
+        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
+            (nb / benchmark.stats["mean"]) / 2 ** 30)
+        benchmark.extra_info["max_bit"] = pytest.max_bits  # useful when looking at bigint
+
+
+@pytest.mark.benchmark(group="ArrayTransfer_ak.array")
+@pytest.mark.parametrize("dtype", TYPES)
+def bench_array_transfer_akarray(benchmark, dtype):
+    if dtype in pytest.dtype:
+        if dtype == ak.bigint.name:
+            u1 = ak.randint(0, 2 ** 32, pytest.prob_size, dtype=ak.uint64, seed=pytest.seed)
+            u2 = ak.randint(0, 2 ** 32, pytest.prob_size, dtype=ak.uint64, seed=pytest.seed)
+            a = ak.bigint_from_uint_arrays([u1, u2], max_bits=pytest.max_bits)
+            # bytes per bigint array (N * 16) since it's made of 2 uint64 arrays
+            # if max_bits in [0, 64] then they're essentially 1 uint64 array
+            nb = a.size * 8 if pytest.max_bits != -1 and pytest.max_bits <= 64 else a.size * 8 * 2
+            ak.client.maxTransferBytes = nb
+        else:
+            a = ak.randint(0, 2 ** 32, pytest.prob_size, dtype=dtype, seed=pytest.seed)
+            nb = a.size * a.itemsize
+            ak.client.maxTransferBytes = nb
+
+        npa = a.to_ndarray()
+        benchmark.pedantic(ak.array, args=[npa], kwargs={"max_bits": pytest.max_bits}, rounds=pytest.trials)
+        benchmark.extra_info["description"] = "Measures the performance of ak.array"
+        benchmark.extra_info["problem_size"] = pytest.prob_size
+        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
+            (nb / benchmark.stats["mean"]) / 2 ** 30)
+        benchmark.extra_info["max_bit"] = pytest.max_bits  # useful when looking at bigint

--- a/benchmark_v2/conftest.py
+++ b/benchmark_v2/conftest.py
@@ -11,13 +11,14 @@ from server_util.test.server_test_util import (
     stop_arkouda_server,
 )
 
-default_dtype = ["int64", "uint64", "float64", "bool", "str"]
+default_dtype = ["int64", "uint64", "float64", "bool", "str", "bigint"]
 def pytest_configure(config):
     pytest.prob_size = eval(config.getoption("size"))
     pytest.trials = eval(config.getoption("trials"))
     pytest.seed = None if config.getoption("seed") == "" else eval(config.getoption("seed"))
     dtype_str = config.getoption("dtype")
     pytest.dtype = default_dtype if dtype_str == "" else dtype_str.split(",")
+    pytest.max_bits = eval(config.getoption("maxbits"))
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,11 +28,16 @@ def pytest_addoption(parser):
     parser.addoption(
         "--dtype", action="store", default="",
         help="Benchmark only option. Dtypes to run benchmarks against. Comma separated list "
-             "(NO SPACES) allowing for multiple. Accepted values: int64, uint64, float64, bool, and str."
+             "(NO SPACES) allowing for multiple. Accepted values: int64, uint64, bigint, float64, bool, and str."
     )
     parser.addoption(
         "--numpy", action="store_true", default=False,
         help="Benchmark only option. When set, runs numpy comparison benchmarks."
+    )
+    parser.addoption(
+        "--maxbits", action="store", default="-1",
+        help="Benchmark only option. Only applies to bigint testing."
+             "Maximum number of bits, so values > 2**max_bits will wraparound. -1 is interpreted as no maximum."
     )
 
 


### PR DESCRIPTION
Closes #2226 

- Adds benchmarking for array transfers.
- Combines the separated `bigint` array transfer into a single file.
- Adds `maxbits` optional commandline argument. This is only used with `BigInt`. 
- Adds `bigint` to default dtypes list