### PR TITLE
Closes #2239 - PyTest Benchmark for CoArgSort

### DIFF
--- a/benchmark.ini
+++ b/benchmark.ini
@@ -7,6 +7,7 @@ testpaths =
     benchmark_v2/array_transfer_benchmark.py
     benchmark_v2/bigint_conversion_benchmark.py
     benchmark_v2/groupby_benchmark.py
+    benchmark_v2/coargsort_benchmark.py
 python_functions = bench_*
 env =
     D:ARKOUDA_SERVER_HOST=localhost

--- a/benchmark_v2/coargsort_benchmark.py
+++ b/benchmark_v2/coargsort_benchmark.py
@@ -1,0 +1,68 @@
+import arkouda as ak
+import pytest
+
+import numpy as np
+
+TYPES = ["int64", "uint64", "float64", "str"]
+NUM_ARR = [1, 2, 8, 16]
+
+
+@pytest.mark.benchmark(group="Arkouda_CoArgSort")
+@pytest.mark.parametrize("numArrays", NUM_ARR)
+@pytest.mark.parametrize("dtype", TYPES)
+def bench_coargsort(benchmark, dtype, numArrays):
+    cfg = ak.get_config()
+    N = pytest.prob_size * cfg["numLocales"]
+    if dtype in pytest.dtype:
+        if pytest.seed is None:
+            seeds = [None for _ in range(numArrays)]
+        else:
+            seeds = [pytest.seed + i for i in range(numArrays)]
+        if dtype == "int64":
+            arrs = [ak.randint(0, 2**32, N // numArrays, seed=s) for s in seeds]
+            nbytes = sum(a.size * a.itemsize for a in arrs)
+        elif dtype == "uint64":
+            arrs = [ak.randint(0, 2**32, N // numArrays, dtype=ak.uint64, seed=s) for s in seeds]
+            nbytes = sum(a.size * a.itemsize for a in arrs)
+        elif dtype == "float64":
+            arrs = [ak.randint(0, 1, N // numArrays, dtype=ak.float64, seed=s) for s in seeds]
+            nbytes = sum(a.size * a.itemsize for a in arrs)
+        elif dtype == "str":
+            arrs = [ak.random_strings_uniform(1, 16, N // numArrays, seed=s) for s in seeds]
+            nbytes = sum(a.nbytes * a.entry.itemsize for a in arrs)
+
+        benchmark.pedantic(ak.coargsort, args=[arrs], rounds=pytest.trials)
+        benchmark.extra_info["description"] = "Measures the performance of ak.coargsort"
+        benchmark.extra_info["problem_size"] = pytest.prob_size
+        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
+            (nbytes / benchmark.stats["mean"]) / 2 ** 30)
+
+
+@pytest.mark.benchmark(group="NumPy_CoArgSort")
+@pytest.mark.parametrize("numArrays", NUM_ARR)
+@pytest.mark.parametrize("dtype", TYPES)
+def bench_coargsort_numpy(benchmark, dtype, numArrays):
+    cfg = ak.get_config()
+    N = pytest.prob_size * cfg["numLocales"]
+    if pytest.numpy and dtype in pytest.dtype:
+        if pytest.seed is not None:
+            np.random.seed(pytest.seed)
+        if dtype == "int64":
+            arrs = [np.random.randint(0, 2 ** 32, N // numArrays) for _ in range(numArrays)]
+        elif dtype == "uint64":
+            arrs = [
+                np.random.randint(0, 2 ** 32, N // numArrays, dtype=np.uint64) for _ in range(numArrays)
+            ]
+        elif dtype == "float64":
+            arrs = [np.random.random(N // numArrays) for _ in range(numArrays)]
+        elif dtype == "str":
+            arrs = [
+                np.cast["str"](np.random.randint(0, 2 ** 32, N // numArrays)) for _ in range(numArrays)
+            ]
+
+        nbytes = sum(a.size * a.itemsize for a in arrs)
+        benchmark.pedantic(np.lexsort, args=[arrs], rounds=pytest.trials)
+        benchmark.extra_info["description"] = "Measures the performance of np.lexsort for comparison"
+        benchmark.extra_info["problem_size"] = pytest.prob_size
+        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
+            (nbytes / benchmark.stats["mean"]) / 2 ** 30)

--- a/benchmark_v2/coargsort_benchmark.py
+++ b/benchmark_v2/coargsort_benchmark.py
@@ -35,7 +35,8 @@ def bench_coargsort(benchmark, dtype, numArrays):
         benchmark.extra_info["description"] = "Measures the performance of ak.coargsort"
         benchmark.extra_info["problem_size"] = pytest.prob_size
         benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-            (nbytes / benchmark.stats["mean"]) / 2 ** 30)
+            (nbytes / benchmark.stats["mean"]) / 2**30
+        )
 
 
 @pytest.mark.benchmark(group="NumPy_CoArgSort")
@@ -43,21 +44,24 @@ def bench_coargsort(benchmark, dtype, numArrays):
 @pytest.mark.parametrize("dtype", TYPES)
 def bench_coargsort_numpy(benchmark, dtype, numArrays):
     cfg = ak.get_config()
-    N = pytest.prob_size * cfg["numLocales"]
     if pytest.numpy and dtype in pytest.dtype:
         if pytest.seed is not None:
             np.random.seed(pytest.seed)
         if dtype == "int64":
-            arrs = [np.random.randint(0, 2 ** 32, N // numArrays) for _ in range(numArrays)]
+            arrs = [
+                np.random.randint(0, 2**32, pytest.prob_size // numArrays) for _ in range(numArrays)
+            ]
         elif dtype == "uint64":
             arrs = [
-                np.random.randint(0, 2 ** 32, N // numArrays, dtype=np.uint64) for _ in range(numArrays)
+                np.random.randint(0, 2**32, pytest.prob_size // numArrays, dtype=np.uint64)
+                for _ in range(numArrays)
             ]
         elif dtype == "float64":
-            arrs = [np.random.random(N // numArrays) for _ in range(numArrays)]
+            arrs = [np.random.random(pytest.prob_size // numArrays) for _ in range(numArrays)]
         elif dtype == "str":
             arrs = [
-                np.cast["str"](np.random.randint(0, 2 ** 32, N // numArrays)) for _ in range(numArrays)
+                np.cast["str"](np.random.randint(0, 2**32, pytest.prob_size // numArrays))
+                for _ in range(numArrays)
             ]
 
         nbytes = sum(a.size * a.itemsize for a in arrs)
@@ -65,4 +69,5 @@ def bench_coargsort_numpy(benchmark, dtype, numArrays):
         benchmark.extra_info["description"] = "Measures the performance of np.lexsort for comparison"
         benchmark.extra_info["problem_size"] = pytest.prob_size
         benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-            (nbytes / benchmark.stats["mean"]) / 2 ** 30)
+            (nbytes / benchmark.stats["mean"]) / 2**30
+        )

--- a/benchmark_v2/conftest.py
+++ b/benchmark_v2/conftest.py
@@ -19,6 +19,7 @@ def pytest_configure(config):
     dtype_str = config.getoption("dtype")
     pytest.dtype = default_dtype if dtype_str == "" else dtype_str.split(",")
     pytest.max_bits = eval(config.getoption("maxbits"))
+    pytest.numpy = config.getoption("numpy")
 
 
 @pytest.fixture(scope="module", autouse=True)


### PR DESCRIPTION
Closes #2239 

This PR adds the pytest-benchmark for coargsort. This corresponds to the legacy benchmarks in `benchmarks/coargsort.py` and `benchmarks/str-coargsort.py`. 

Please Note: In order to run successfully, a problem size of 16 or larger must be used. See Issue #2240 for more details on this.

This duplicates the access of the `--numpy` command line arg. If this causes merge conflict (depending on what is merged first) I will address.