### PR TITLE
Closes #2244 - PyTest Benchmark for Encodings

### DIFF
--- a/benchmark.ini
+++ b/benchmark.ini
@@ -12,6 +12,7 @@ testpaths =
     benchmark_v2/groupby_benchmark.py
     benchmark_v2/coargsort_benchmark.py
     benchmark_v2/flatten_benchmark.py
+    benchmark_v2/encoding_benchmark.py
 python_functions = bench_*
 env =
     D:ARKOUDA_SERVER_HOST=localhost

--- a/benchmark_v2/conftest.py
+++ b/benchmark_v2/conftest.py
@@ -13,6 +13,8 @@ from server_util.test.server_test_util import (
 
 default_dtype = ["int64", "uint64", "float64", "bool", "str", "bigint", "mixed"]
 default_encoding = ["ascii", "idna"]
+
+
 def pytest_configure(config):
     pytest.prob_size = eval(config.getoption("size"))
     pytest.trials = eval(config.getoption("trials"))

--- a/benchmark_v2/conftest.py
+++ b/benchmark_v2/conftest.py
@@ -12,6 +12,7 @@ from server_util.test.server_test_util import (
 )
 
 default_dtype = ["int64", "uint64", "float64", "bool", "str", "bigint", "mixed"]
+default_encoding = ["ascii", "idna"]
 def pytest_configure(config):
     pytest.prob_size = eval(config.getoption("size"))
     pytest.trials = eval(config.getoption("trials"))
@@ -22,6 +23,8 @@ def pytest_configure(config):
     pytest.alpha = eval(config.getoption("alpha"))
     pytest.random = config.getoption("randomize")
     pytest.numpy = config.getoption("numpy")
+    encode_str = config.getoption("encoding")
+    pytest.encoding = default_encoding if encode_str == "" else encode_str.split(",")
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/benchmark_v2/encoding_benchmark.py
+++ b/benchmark_v2/encoding_benchmark.py
@@ -1,0 +1,36 @@
+import arkouda as ak
+import pytest
+
+ENCODINGS = ("idna", "ascii")
+
+
+@pytest.mark.benchmark(group="Strings_EncodeDecode")
+@pytest.mark.parametrize("encoding", ENCODINGS)
+def bench_encode(benchmark, encoding):
+    cfg = ak.get_config()
+    N = pytest.prob_size * cfg["numLocales"]
+    if encoding in pytest.encoding:
+        a = ak.random_strings_uniform(1, 16, N, seed=pytest.seed)
+        nbytes = a.nbytes * a.entry.itemsize
+
+        benchmark.pedantic(a.encode, args=[encoding], rounds=pytest.trials)
+        benchmark.extra_info["description"] = "Measures the performance of Strings.encode"
+        benchmark.extra_info["problem_size"] = pytest.prob_size
+        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
+            (nbytes / benchmark.stats["mean"]) / 2 ** 30)
+
+
+@pytest.mark.benchmark(group="Strings_EncodeDecode")
+@pytest.mark.parametrize("encoding", ENCODINGS)
+def bench_decode(benchmark, encoding):
+    cfg = ak.get_config()
+    N = pytest.prob_size * cfg["numLocales"]
+    if encoding in pytest.encoding:
+        a = ak.random_strings_uniform(1, 16, N, seed=pytest.seed)
+        nbytes = a.nbytes * a.entry.itemsize
+
+        benchmark.pedantic(a.decode, args=[encoding], rounds=pytest.trials)
+        benchmark.extra_info["description"] = "Measures the performance of Strings.decode"
+        benchmark.extra_info["problem_size"] = pytest.prob_size
+        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
+            (nbytes / benchmark.stats["mean"]) / 2 ** 30)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,12 @@ def pytest_addoption(parser):
         "--randomize", action="store_true", default=False,
         help="Fill arrays with random values instead of ones"
     )
+    parser.addoption(
+        "--encoding", action="store", default="",
+        help="Benchmark only option. Only applies to encoding benchmarks."
+             "Comma separated list (NO SPACES) allowing for multiple"
+             "Encoding to be used. Accepted values: idna, ascii"
+    )
 
 
 def pytest_collection_modifyitems(config, items):


### PR DESCRIPTION
Closes #2244 

- Adds the pytest-benchmark for encodings corresponding to `benchmarks/encode.py`.
- Adds `--encoding` command line option.
