### PR TITLE
Closes #2246 - Pytest Benchmark for Flatten

### DIFF
--- a/benchmark.ini
+++ b/benchmark.ini
@@ -11,6 +11,7 @@ testpaths =
     benchmark_v2/array_create_benchmark.py
     benchmark_v2/groupby_benchmark.py
     benchmark_v2/coargsort_benchmark.py
+    benchmark_v2/flatten_benchmark.py
 python_functions = bench_*
 env =
     D:ARKOUDA_SERVER_HOST=localhost

--- a/benchmark_v2/flatten_benchmark.py
+++ b/benchmark_v2/flatten_benchmark.py
@@ -1,0 +1,49 @@
+import arkouda as ak
+import pytest
+
+
+def _generate_test_data():
+    cfg = ak.get_config()
+    N = pytest.prob_size * cfg["numLocales"]
+
+    thirds = [ak.cast(ak.arange(i, N * 3, 3), "str") for i in range(3)]
+    thickrange = thirds[0].stick(thirds[1], delimiter="_").stick(thirds[2], delimiter="_")
+    nbytes = thickrange.nbytes * thickrange.entry.itemsize
+
+    return thickrange, nbytes
+
+
+@pytest.mark.benchmark(group="AK_Flatten")
+def bench_flatten_nonregex(benchmark):
+    thickrange, nbytes = _generate_test_data()
+
+    benchmark.pedantic(thickrange.flatten, args=["_"], rounds=pytest.trials)
+    benchmark.extra_info["description"] = "Measures the performance of Strings.flatten"
+    benchmark.extra_info["problem_size"] = pytest.prob_size
+    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
+        (nbytes / benchmark.stats["mean"]) / 2**30
+    )
+
+
+@pytest.mark.benchmark(group="AK_Flatten")
+def bench_flatten_regexliteral(benchmark):
+    thickrange, nbytes = _generate_test_data()
+
+    benchmark.pedantic(thickrange.flatten, args=["_"], kwargs={"regex": True}, rounds=pytest.trials)
+    benchmark.extra_info["description"] = "Measures the performance of Strings.flatten"
+    benchmark.extra_info["problem_size"] = pytest.prob_size
+    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
+        (nbytes / benchmark.stats["mean"]) / 2**30
+    )
+
+
+@pytest.mark.benchmark(group="AK_Flatten")
+def bench_flatten_regexpattern(benchmark):
+    thickrange, nbytes = _generate_test_data()
+
+    benchmark.pedantic(thickrange.flatten, args=["_+"], kwargs={"regex": True}, rounds=pytest.trials)
+    benchmark.extra_info["description"] = "Measures the performance of Strings.flatten"
+    benchmark.extra_info["problem_size"] = pytest.prob_size
+    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
+        (nbytes / benchmark.stats["mean"]) / 2**30
+    )


### PR DESCRIPTION
Closes #2246 

Adds pytest-benchmark for  `Strings.Flatten` corresponding to `benchmarks/flatten.py`.