### PR TITLE
Closes #2243 - Initial implementation of dataframe benchmark updates

### DIFF
--- a/benchmark.ini
+++ b/benchmark.ini
@@ -15,6 +15,7 @@ testpaths =
     benchmark_v2/encoding_benchmark.py
     benchmark_v2/gather_benchmark.py
     benchmark_v2/scatter_benchmark.py
+    benchmark_v2/dataframe_indexing_benchmark.py
 python_functions = bench_*
 env =
     D:ARKOUDA_SERVER_HOST=localhost

--- a/benchmark_v2/conftest.py
+++ b/benchmark_v2/conftest.py
@@ -84,6 +84,7 @@ def manage_connection():
     yield
 
     try:
+        ak.clear()
         ak.disconnect()
     except Exception as e:
         raise ConnectionError(e)

--- a/benchmark_v2/conftest.py
+++ b/benchmark_v2/conftest.py
@@ -84,7 +84,6 @@ def manage_connection():
     yield
 
     try:
-        ak.clear()
         ak.disconnect()
     except Exception as e:
         raise ConnectionError(e)

--- a/benchmark_v2/dataframe_indexing_benchmark.py
+++ b/benchmark_v2/dataframe_indexing_benchmark.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+import numpy as np
+import pandas as pd
+import pytest
+
+import arkouda as ak
+
+OPS = ["_get_head_tail_server", "_get_head_tail"]
+
+
+def generate_dataframe():
+    cfg = ak.get_config()
+    N = pytest.prob_size * cfg["numLocales"]
+    types = [ak.Categorical, ak.pdarray, ak.Strings, ak.SegArray]
+
+    # generate random columns to build dataframe
+    df_dict = {}
+    np.random.seed(pytest.seed)
+    for x in range(20):  # loop to create 20 random columns
+        key = f"c_{x}"
+        d = types[x % 4]
+        if d == ak.Categorical:
+            str_arr = ak.random_strings_uniform(minlen=5, maxlen=6, size=N, seed=pytest.seed)
+            df_dict[key] = ak.Categorical(str_arr)
+        elif d == ak.pdarray:
+            df_dict[key] = ak.array(np.random.randint(0, 2**32, N))
+        elif d == ak.Strings:
+            df_dict[key] = ak.random_strings_uniform(minlen=5, maxlen=6, size=N, seed=pytest.seed)
+        elif d == ak.SegArray:
+            df_dict[key] = ak.segarray(
+                ak.arange(0, N), ak.array(np.random.randint(0, 2**32, N))
+            )
+    return ak.DataFrame(df_dict)
+
+
+@pytest.mark.parametrize("op", OPS)
+def bench_ak_dataframe(benchmark, op):
+    """
+    Measures the performance of arkouda Dataframe indexing
+
+    """
+    pd.set_option("display.max_rows", 100)
+    pd.set_option("display.min_rows", 10)
+    pd.set_option("display.max_columns", 20)
+
+    df = generate_dataframe()
+
+    fxn = getattr(df, op)
+    benchmark.pedantic(fxn, rounds=pytest.trials)
+
+    # calculate nbytes based on the columns
+    nbytes = 0
+    for col in df.columns:
+        col_obj = df[col]
+        if isinstance(col_obj, ak.pdarray):
+            nbytes += col_obj.size * col_obj.itemsize
+        elif isinstance(col_obj, ak.Categorical):
+            nbytes += col_obj.codes.size * col_obj.codes.itemsize
+        elif isinstance(col_obj, ak.Strings):
+            nbytes += col_obj.nbytes * col_obj.entry.itemsize
+        elif isinstance(col_obj, ak.SegArray):
+            nbytes += col_obj.values.size * col_obj.values.itemsize
+
+    # benchmark.extra_info["description"] = "Measures the performance of arkouda Dataframe indexing"
+    # benchmark.extra_info["problem_size"] = pytest.prob_size
+    # benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
+    #     (nbytes / benchmark.stats["mean"]) / 2 ** 30)

--- a/benchmark_v2/dataframe_indexing_benchmark.py
+++ b/benchmark_v2/dataframe_indexing_benchmark.py
@@ -33,6 +33,7 @@ def generate_dataframe():
     return ak.DataFrame(df_dict)
 
 
+@pytest.mark.benchmark(group="Dataframe_Indexing")
 @pytest.mark.parametrize("op", OPS)
 def bench_ak_dataframe(benchmark, op):
     """
@@ -59,9 +60,10 @@ def bench_ak_dataframe(benchmark, op):
         elif isinstance(col_obj, ak.Strings):
             nbytes += col_obj.nbytes * col_obj.entry.itemsize
         elif isinstance(col_obj, ak.SegArray):
-            nbytes += col_obj.values.size * col_obj.values.itemsize
+            nbytes += col_obj.values.size * col_obj.values.itemsize + \
+                      (col_obj.segments.size * col_obj.segments.itemsize)
 
-    # benchmark.extra_info["description"] = "Measures the performance of arkouda Dataframe indexing"
-    # benchmark.extra_info["problem_size"] = pytest.prob_size
-    # benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-    #     (nbytes / benchmark.stats["mean"]) / 2 ** 30)
+    benchmark.extra_info["description"] = "Measures the performance of arkouda Dataframe indexing"
+    benchmark.extra_info["problem_size"] = pytest.prob_size
+    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
+        (nbytes / benchmark.stats["mean"]) / 2 ** 30)

--- a/benchmarks/dataframe.py
+++ b/benchmarks/dataframe.py
@@ -75,7 +75,7 @@ def time_ak_df_display(N_per_locale, trials, seed):
         elif isinstance(col_obj, ak.Strings):
             nbytes += col_obj.nbytes * col_obj.entry.itemsize
         elif isinstance(col_obj, ak.SegArray):
-            nbytes += col_obj.values.size * col_obj.values.itemsize \
+            nbytes += col_obj.values.size * col_obj.values.itemsize + \
                       (col_obj.segments.size * col_obj.segments.itemsize)
 
     for op, t in tavg.items():

--- a/benchmarks/dataframe.py
+++ b/benchmarks/dataframe.py
@@ -33,7 +33,7 @@ def generate_dataframe(N, seed):
             df_dict[key] = ak.random_strings_uniform(minlen=5, maxlen=6, size=N, seed=seed)
         elif d == ak.SegArray:
             df_dict[key] = ak.segarray(
-                ak.arange(0, N * 5, 5), ak.array(np.random.randint(0, 2**32, N * 5))
+                ak.arange(0, N), ak.array(np.random.randint(0, 2**32, N))
             )
     return ak.DataFrame(df_dict)
 
@@ -75,7 +75,8 @@ def time_ak_df_display(N_per_locale, trials, seed):
         elif isinstance(col_obj, ak.Strings):
             nbytes += col_obj.nbytes * col_obj.entry.itemsize
         elif isinstance(col_obj, ak.SegArray):
-            nbytes += col_obj.values.size * col_obj.values.itemsize
+            nbytes += col_obj.values.size * col_obj.values.itemsize \
+                      (col_obj.segments.size * col_obj.segments.itemsize)
 
     for op, t in tavg.items():
         print("  {} Average time = {:.4f} sec".format(op, t))


### PR DESCRIPTION
This PR closes #2243 

Below issue has been resolved, maintaining description here for record.

Potential issue with performance when setting segarray generation to 

`ak.arange(0, N * 5, 5), ak.array(np.random.randint(0, 2**32, N * 5))`

as it is in the original benchmark. removing the `* 5` appears to work, but it's worth exploring some more