### PR TITLE
Closes #2256 - Add `workflow_dispatch` to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [pull_request, merge_group]
+on: [pull_request, merge_group, workflow_dispatch]
 
 env:
   ARKOUDA_QUICK_COMPILE: true


### PR DESCRIPTION
Closes #2256 

Adds the `workflow_dispatch` flag to `on` in `CI.yml`. This should allow for manual runs of our CI.