### PR TITLE
Closes #2248 - Pytest Benchmark for Gather

### DIFF
--- a/benchmark.ini
+++ b/benchmark.ini
@@ -13,6 +13,7 @@ testpaths =
     benchmark_v2/coargsort_benchmark.py
     benchmark_v2/flatten_benchmark.py
     benchmark_v2/encoding_benchmark.py
+    benchmark_v2/gather_benchmark.py
 python_functions = bench_*
 env =
     D:ARKOUDA_SERVER_HOST=localhost

--- a/benchmark_v2/conftest.py
+++ b/benchmark_v2/conftest.py
@@ -27,6 +27,8 @@ def pytest_configure(config):
     pytest.numpy = config.getoption("numpy")
     encode_str = config.getoption("encoding")
     pytest.encoding = default_encoding if encode_str == "" else encode_str.split(",")
+    pytest.idx_size = None if config.getoption("index_size") == "" else eval(config.getoption("index_size"))
+    pytest.val_size = None if config.getoption("value_size") == "" else eval(config.getoption("value_size"))
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/benchmark_v2/gather_benchmark.py
+++ b/benchmark_v2/gather_benchmark.py
@@ -1,0 +1,97 @@
+import arkouda as ak
+import pytest
+import numpy as np
+
+TYPES = ("int64", "float64", "bool", "str")
+
+
+def _ak_gather(a, i):
+    """
+    Helper function allowing for the gather to be benchmarked
+    """
+    return a[i]
+
+
+@pytest.mark.benchmark(group="AK_Gather")
+@pytest.mark.parametrize("dtype", TYPES)
+def bench_ak_gather(benchmark, dtype):
+    cfg = ak.get_config()
+    isize = pytest.prob_size if pytest.idx_size is None else pytest.idx_size
+    vsize = pytest.prob_size if pytest.val_size is None else pytest.val_size
+    Ni = isize * cfg["numLocales"]
+    Nv = vsize * cfg["numLocales"]
+
+    if dtype in pytest.dtype:
+        i = ak.randint(0, Nv, Ni, seed=pytest.seed)
+        if pytest.seed is not None:
+            pytest.seed += 1
+        if pytest.random or pytest.seed is not None:
+            if dtype == "int64":
+                v = ak.randint(0, 2 ** 32, Nv, seed=pytest.seed)
+            elif dtype == "float64":
+                v = ak.randint(0, 1, Nv, dtype=ak.float64, seed=pytest.seed)
+            elif dtype == "bool":
+                v = ak.randint(0, 1, Nv, dtype=ak.bool, seed=pytest.seed)
+            elif dtype == "str":
+                v = ak.random_strings_uniform(1, 16, Nv, seed=pytest.seed)
+        else:
+            if dtype == "str":
+                v = ak.cast(ak.arange(Nv), "str")
+            else:
+                v = ak.ones(Nv, dtype=dtype)
+
+        c = benchmark.pedantic(_ak_gather, args=[v, i], rounds=pytest.trials)
+
+        if dtype == "str":
+            offsets_transferred = 3 * c.size * 8
+            bytes_transferred = (c.size * 8) + (2 * c.nbytes)
+            bytes_per_sec = (offsets_transferred + bytes_transferred) / benchmark.stats["mean"]
+        else:
+            bytes_per_sec = (c.size * c.itemsize * 3) / benchmark.stats["mean"]
+
+        bytes_per_sec / 2 ** 30
+        benchmark.extra_info["description"] = "Measures the performance of Arkouda gather"
+        benchmark.extra_info["problem_size"] = pytest.prob_size
+        benchmark.extra_info["index_size"] = isize
+        benchmark.extra_info["value_size"] = vsize
+        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
+            (bytes_per_sec / 2 ** 30))
+
+
+def _np_gather(a, i):
+    """
+    Helper function allowing for the gather to be benchmarked
+    """
+    return a[i]
+
+
+@pytest.mark.benchmark(group="NumPy_Gather")
+@pytest.mark.parametrize("dtype", TYPES)
+def bench_np_gather(benchmark, dtype):
+    if pytest.numpy:
+        Ni = pytest.prob_size if pytest.idx_size is None else pytest.idx_size
+        Nv = pytest.prob_size if pytest.val_size is None else pytest.val_size
+        if pytest.seed is not None:
+            np.random.seed(pytest.seed)
+        i = np.random.randint(0, Nv, Ni)
+
+        if pytest.random or pytest.seed is not None:
+            if dtype == "int64":
+                v = np.random.randint(0, 2**32, Nv)
+            elif dtype == "float64":
+                v = np.random.random(Nv)
+            elif dtype == "bool":
+                v = np.random.randint(0, 1, Nv, dtype=np.bool)
+            elif dtype == "str":
+                v = np.array(np.random.randint(0, 2**32, Nv), dtype="str")
+        else:
+            v = np.ones(Nv, dtype=dtype)
+
+        c = benchmark.pedantic(_np_gather, args=[v, i], rounds=pytest.trials)
+        bytes_per_sec = (c.size * c.itemsize * 3) / benchmark.stats["mean"]
+        benchmark.extra_info["description"] = "Measures the performance of NumPy gather"
+        benchmark.extra_info["problem_size"] = pytest.prob_size
+        benchmark.extra_info["index_size"] = Ni
+        benchmark.extra_info["value_size"] = Nv
+        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
+            (bytes_per_sec / 2 ** 30))

--- a/benchmark_v2/gather_benchmark.py
+++ b/benchmark_v2/gather_benchmark.py
@@ -5,7 +5,7 @@ import numpy as np
 TYPES = ("int64", "float64", "bool", "str")
 
 
-def _ak_gather(a, i):
+def _run_gather(a, i):
     """
     Helper function allowing for the gather to be benchmarked
     """
@@ -40,7 +40,7 @@ def bench_ak_gather(benchmark, dtype):
             else:
                 v = ak.ones(Nv, dtype=dtype)
 
-        c = benchmark.pedantic(_ak_gather, args=[v, i], rounds=pytest.trials)
+        c = benchmark.pedantic(_run_gather, args=[v, i], rounds=pytest.trials)
 
         if dtype == "str":
             offsets_transferred = 3 * c.size * 8
@@ -49,20 +49,12 @@ def bench_ak_gather(benchmark, dtype):
         else:
             bytes_per_sec = (c.size * c.itemsize * 3) / benchmark.stats["mean"]
 
-        bytes_per_sec / 2 ** 30
         benchmark.extra_info["description"] = "Measures the performance of Arkouda gather"
         benchmark.extra_info["problem_size"] = pytest.prob_size
         benchmark.extra_info["index_size"] = isize
         benchmark.extra_info["value_size"] = vsize
         benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
             (bytes_per_sec / 2 ** 30))
-
-
-def _np_gather(a, i):
-    """
-    Helper function allowing for the gather to be benchmarked
-    """
-    return a[i]
 
 
 @pytest.mark.benchmark(group="NumPy_Gather")
@@ -87,7 +79,7 @@ def bench_np_gather(benchmark, dtype):
         else:
             v = np.ones(Nv, dtype=dtype)
 
-        c = benchmark.pedantic(_np_gather, args=[v, i], rounds=pytest.trials)
+        c = benchmark.pedantic(_run_gather, args=[v, i], rounds=pytest.trials)
         bytes_per_sec = (c.size * c.itemsize * 3) / benchmark.stats["mean"]
         benchmark.extra_info["description"] = "Measures the performance of NumPy gather"
         benchmark.extra_info["problem_size"] = pytest.prob_size

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,15 @@ def pytest_addoption(parser):
     )
     parser.addoption(
         "--randomize", action="store_true", default=False,
-        help="Fill arrays with random values instead of ones"
+        help="Benchmark only option. Fill arrays with random values instead of ones"
+    )
+    parser.addoption(
+        "--index_size", action="store", default="",
+        help="Benchmark only option. Length of index array (number of gathers to perform)"
+    )
+    parser.addoption(
+        "--value_size", action="store", default="",
+        help="Benchmark only option.Length of array from which values are gathered"
     )
     parser.addoption(
         "--encoding", action="store", default="",


### PR DESCRIPTION
Closes #2248 

- Adds pytest-benchmark for gather performance. Benchmarks for Arkouda and NumPy performance included.
- Adds `--idx_size` and `--val_size` command line parameters to set the size of the values and index individually. If they are not provided, defaults to `pytest.prob_size`.