### PR TITLE
Closes #2265 - Fixes `ak.DataFrame.to_parquet` with empty `Strings` Column

### DIFF
--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -813,7 +813,7 @@ module HDF5Msg {
 
                 ref ss = segString;
                 var A = ss.offsets.a;
-                const lastOffset = A[A.domain.high];
+                const lastOffset = if A.size == 0 then 0 else A[A.domain.high]; // prevent index error when empty
                 const lastValIdx = ss.values.a.domain.high;
 
                 // For each locale gather the string bytes corresponding to the offsets in its local domain

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -560,7 +560,7 @@ module ParquetMsg {
     }
     
     const extraOffset = ss.values.size;
-    const lastOffset = A[A.domain.high];
+    const lastOffset = if A.size == 0 then 0 else A[A.domain.high]; // prevent index error when empty
     const lastValIdx = ss.values.a.domain.high;
     // For each locale gather the string bytes corresponding to the offsets in its local domain
     coforall (loc, idx) in zip(A.targetLocales(), filenames.domain) with (ref ss) do on loc {
@@ -1026,7 +1026,7 @@ module ParquetMsg {
     }
     
     const extraOffset = sa.values.size;
-    const lastOffset = segments[segments.domain.high];
+    const lastOffset = if segments.size == 0 then 0 else segments[segments.domain.high]; // prevent index error when empty
     const lastValIdx = sa.values.a.domain.high;
 
     // pull values to the locale of the offset

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -1295,7 +1295,7 @@ module ParquetMsg {
               var segArray = new SegArray("", e, int);
               ref sa = segArray;
               var A = sa.segments.a;
-              const lastOffset = A[A.domain.high];
+              const lastOffset = if A.size == 0 then 0 else A[A.domain.high]; // prevent index error when empty;
               const lastValIdx = sa.values.a.domain.high;
               const locDom = sa.segments.a.localSubdomain();
 
@@ -1333,7 +1333,7 @@ module ParquetMsg {
               var segArray = new SegArray("", e, uint);
               ref sa = segArray;
               var A = sa.segments.a;
-              const lastOffset = A[A.domain.high];
+              const lastOffset = if A.size == 0 then 0 else A[A.domain.high]; // prevent index error when empty;
               const lastValIdx = sa.values.a.domain.high;
               const locDom = sa.segments.a.localSubdomain();
 
@@ -1371,7 +1371,7 @@ module ParquetMsg {
               var segArray = new SegArray("", e, bool);
               ref sa = segArray;
               var A = sa.segments.a;
-              const lastOffset = A[A.domain.high];
+              const lastOffset = if A.size == 0 then 0 else A[A.domain.high]; // prevent index error when empty
               const lastValIdx = sa.values.a.domain.high;
               const locDom = sa.segments.a.localSubdomain();
 
@@ -1409,7 +1409,7 @@ module ParquetMsg {
               var segArray = new SegArray("", e, real);
               ref sa = segArray;
               var A = sa.segments.a;
-              const lastOffset = A[A.domain.high];
+              const lastOffset = if A.size == 0 then 0 else A[A.domain.high]; // prevent index error when empty
               const lastValIdx = sa.values.a.domain.high;
               const locDom = sa.segments.a.localSubdomain();
 
@@ -1447,7 +1447,7 @@ module ParquetMsg {
             var segStr = new SegString("", e);
             ref ss = segStr;
             var A = ss.offsets.a;
-            const lastOffset = A[A.domain.high];
+            const lastOffset = if A.size == 0 then 0 else A[A.domain.high]; // prevent index error when empty
             const lastValIdx = ss.values.a.domain.high;
             const locDom = ss.offsets.a.localSubdomain();
 


### PR DESCRIPTION
Closes #2265 

Adds handling for when an empty `Strings` object is written to Parquet. Updates access of the `lastOffset` to default to `0` if there are no offsets. This allows the workflow to properly assign attributes in the file without hitting the index error.

Adds the same handling to Parquet workflows for `SegArray` as the same logic is used. The workflow for HDF5 is slightly different and does not require this change.