### PR TITLE
Recommend Chapel 1.30.0 and use it for CI testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.29.0
+      image: chapel/chapel:1.30.0
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies
@@ -32,7 +32,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.29.0
+      image: chapel/chapel:1.30.0
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies
@@ -47,7 +47,7 @@ jobs:
   flake8:
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.29.0
+      image: chapel/chapel:1.30.0
     steps:
       - uses: actions/checkout@v3
       - name: Install Dependencies
@@ -65,7 +65,7 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10']
     container:
-      image: chapel/chapel:1.29.0
+      image: chapel/chapel:1.30.0
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -131,7 +131,7 @@ jobs:
     env:
       CHPL_RT_NUM_THREADS_PER_LOCALE: ${{matrix.threads}}
     container:
-      image: chapel/${{matrix.image}}:1.29.0
+      image: chapel/${{matrix.image}}:1.30.0
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies

--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ ifneq ($(CHPL_VERSION_OK),yes)
 	$(error Chapel 1.28.0 or newer is required)
 endif
 ifeq ($(CHPL_VERSION_WARN),yes)
-	$(warning Chapel 1.29.0 or newer is recommended)
+	$(warning Chapel 1.30.0 or newer is recommended)
 endif
 
 ZMQ_CHECK = $(DEP_INSTALL_DIR)/checkZMQ.chpl

--- a/Makefile
+++ b/Makefile
@@ -419,7 +419,7 @@ doc-server: ${DOC_DIR} $(DOC_SERVER_OUTPUT_DIR)/index.html
 $(DOC_SERVER_OUTPUT_DIR)/index.html: $(ARKOUDA_SOURCES) $(ARKOUDA_MAKEFILES) | $(DOC_SERVER_OUTPUT_DIR)
 	@echo "Building documentation for: Server"
 	@# Build the documentation to the Chapel output directory
-	$(CHPLDOC) $(CHPLDOC_FLAGS) $(ARKOUDA_MAIN_SOURCE) -o $(DOC_SERVER_OUTPUT_DIR)
+	$(CHPLDOC) $(CHPLDOC_FLAGS) $(ARKOUDA_MAIN_SOURCE) $(ARKOUDA_SOURCE_DIR)/compat/ge-130/* -o $(DOC_SERVER_OUTPUT_DIR)
 	@# Create the .nojekyll file needed for github pages in the  Chapel output directory
 	touch $(DOC_SERVER_OUTPUT_DIR)/.nojekyll
 	@echo "Completed building documentation for: Server"

--- a/pydoc/setup/LINUX_INSTALL.md
+++ b/pydoc/setup/LINUX_INSTALL.md
@@ -10,9 +10,9 @@ sudo apt-get update
 sudo apt-get install gcc g++ m4 perl python3 python3-pip python3-venv python3-dev bash make mawk git pkg-config cmake llvm-12-dev llvm-12 llvm-12-tools clang-12 libclang-12-dev libclang-cpp12-dev libedit-dev
 
 # Download latest Chapel release, explode archive, and navigate to source root directory
-wget https://github.com/chapel-lang/chapel/releases/download/1.29.0/chapel-1.29.0.tar.gz
-tar xvf chapel-1.29.0.tar.gz
-cd chapel-1.29.0/
+wget https://github.com/chapel-lang/chapel/releases/download/1.30.0/chapel-1.30.0.tar.gz
+tar xvf chapel-1.30.0.tar.gz
+cd chapel-1.30.0/
 
 # Set CHPL_HOME
 export CHPL_HOME=$PWD

--- a/pydoc/setup/MAC_INSTALL.md
+++ b/pydoc/setup/MAC_INSTALL.md
@@ -16,13 +16,13 @@ For convenience, the steps to install Chapel from source are detailed here. If y
 **Step 2**
 > Unpack the release
 > ```bash
-> tar xzf chapel-1.29.0.tar.gz
+> tar xzf chapel-1.30.0.tar.gz
 > ```
 
 **Step 3**
 > Access the directory created when the release was unpacked
 > ```bash
-> cd chapel-1.29.0
+> cd chapel-1.30.0
 > ```
 
 **Step 4**

--- a/pydoc/setup/REQUIREMENTS.md
+++ b/pydoc/setup/REQUIREMENTS.md
@@ -4,7 +4,7 @@
 
 The dependencies listed here have varying installation instructions depending upon your preferred operating system. Please use in the installation instructions provided in the [Installation Section](install_menu.rst).
 
-- ``Chapel 1.29.0 or later``
+- ``Chapel 1.30.0 or later``
 - `cmake>=3.11.0`
 - `zeromq>=4.2.5`
 - `hdf5`

--- a/pydoc/setup/WINDOWS_INSTALL.md
+++ b/pydoc/setup/WINDOWS_INSTALL.md
@@ -14,7 +14,7 @@ for installing Chapel & Arkouda.  We also recommend installing Anaconda for wind
 
 **Note:** When running `make` to build Chapel while using WSL, pathing issues to library dependencies are common. In most cases, a symlink pointing to the correct location or library will fix these errors.
 
-An example of one of these errors found while using Chapel 1.29.0 and Ubuntu 20.04 LTS with WSL is:
+An example of one of these errors found while using Chapel 1.30.0 and Ubuntu 20.04 LTS with WSL is:
 
 ```bash
 ../../../bin/llvm-tblgen: error while loading shared libraries: libtinfow.so.6: cannot open shared object file: No such file or directory

--- a/src/compat/ge-130/ArkoudaRegexCompat.chpl
+++ b/src/compat/ge-130/ArkoudaRegexCompat.chpl
@@ -1,5 +1,5 @@
 module ArkoudaRegexCompat {
-  public import Regex.{regex, match};
+  public import Regex.regex;
 
   // Previous releases of Chapel do not support throwing
   // initializers and to work around that, we had to run


### PR DESCRIPTION
Chapel 1.30 includes non-trivial optimizations and bug fixes for bigints as well as some compilation speed improvements.

More details about the 1.30 release can be found at: https://chapel-lang.org/blog/posts/announcing-chapel-1.30