### PR TITLE
Closes #2292 - Write Log from Client

### DIFF
--- a/ServerModules.cfg
+++ b/ServerModules.cfg
@@ -1,34 +1,36 @@
 # Comment out modules using a `#` to exclude
 # a module from a build
 
-ArraySetopsMsg
-KExtremeMsg
-ArgSortMsg
-SegmentedMsg
-DataFrameIndexingMsg
-OperatorMsg
-RandMsg
-IndexingMsg
-UniqueMsg
-In1dMsg
-HistogramMsg
-SequenceMsg
-SortMsg
-ReductionMsg
-EfuncMsg
-ConcatenateMsg
-JoinEqWithDTMsg
-RegistrationMsg
-CastMsg
-BroadcastMsg
-FlattenMsg
-StatsMsg
-TimeClassMsg
-HDF5Msg
-ParquetMsg
-CSVMsg
-EncodingMsg
-GroupByMsg
+# ArraySetopsMsg
+# KExtremeMsg
+# ArgSortMsg
+# SegmentedMsg
+# DataFrameIndexingMsg
+# OperatorMsg
+# RandMsg
+# IndexingMsg
+# UniqueMsg
+# In1dMsg
+# HistogramMsg
+# SequenceMsg
+# SortMsg
+# ReductionMsg
+# EfuncMsg
+# ConcatenateMsg
+# JoinEqWithDTMsg
+# RegistrationMsg
+# CastMsg
+# BroadcastMsg
+# FlattenMsg
+# StatsMsg
+# TimeClassMsg
+# HDF5Msg
+# ParquetMsg
+# CSVMsg
+# EncodingMsg
+# GroupByMsg
+
+LogMsg
 
 # Add additional modules located outside
 # of the Arkouda src/ directory below.

--- a/ServerModules.cfg
+++ b/ServerModules.cfg
@@ -1,35 +1,34 @@
 # Comment out modules using a `#` to exclude
 # a module from a build
 
-# ArraySetopsMsg
-# KExtremeMsg
-# ArgSortMsg
-# SegmentedMsg
-# DataFrameIndexingMsg
-# OperatorMsg
-# RandMsg
-# IndexingMsg
-# UniqueMsg
-# In1dMsg
-# HistogramMsg
-# SequenceMsg
-# SortMsg
-# ReductionMsg
-# EfuncMsg
-# ConcatenateMsg
-# JoinEqWithDTMsg
-# RegistrationMsg
-# CastMsg
-# BroadcastMsg
-# FlattenMsg
-# StatsMsg
-# TimeClassMsg
-# HDF5Msg
-# ParquetMsg
-# CSVMsg
-# EncodingMsg
-# GroupByMsg
-
+ArraySetopsMsg
+KExtremeMsg
+ArgSortMsg
+SegmentedMsg
+DataFrameIndexingMsg
+OperatorMsg
+RandMsg
+IndexingMsg
+UniqueMsg
+In1dMsg
+HistogramMsg
+SequenceMsg
+SortMsg
+ReductionMsg
+EfuncMsg
+ConcatenateMsg
+JoinEqWithDTMsg
+RegistrationMsg
+CastMsg
+BroadcastMsg
+FlattenMsg
+StatsMsg
+TimeClassMsg
+HDF5Msg
+ParquetMsg
+CSVMsg
+EncodingMsg
+GroupByMsg
 LogMsg
 
 # Add additional modules located outside

--- a/arkouda/logger.py
+++ b/arkouda/logger.py
@@ -340,10 +340,26 @@ def disableVerbose(logLevel: LogLevel = LogLevel.INFO) -> None:
 
 
 @typechecked
-def write_log(log_msg: str, log_lvl: LogLevel = LogLevel.INFO):
+def write_log(log_msg: str, tag: str= "ClientGeneratedLog", log_lvl: LogLevel = LogLevel.INFO):
     """
     Allows the user to write custom logs.
+
+    Parameters
+    -----------
+    log_msg: str
+        The message to be added to the server log
+    tag: str
+        The tag to use in the log. This takes the place of the server function name.
+        Allows for easy identification of custom logs.
+        Defaults to "ClientGeneratedLog"
+    log_lvl: LogLevel
+        The type of log to be written
+        Defaults to LogLevel.INFO
+
+    See Also
+    ---------
+    LogLevel
     """
     from arkouda.client import generic_msg
 
-    generic_msg(cmd="clientlog", args={"log_msg": log_msg, "log_lvl": log_lvl.name})
+    generic_msg(cmd="clientlog", args={"log_msg": log_msg, "log_lvl": log_lvl.name, "tag": tag})

--- a/arkouda/logger.py
+++ b/arkouda/logger.py
@@ -15,7 +15,7 @@ from typing import List, Optional, cast
 
 from typeguard import typechecked
 
-__all__ = ["enableVerbose", "disableVerbose"]
+__all__ = ["LogLevel", "enableVerbose", "disableVerbose", "write_log"]
 
 loggers = {}
 
@@ -340,3 +340,11 @@ def disableVerbose(logLevel: LogLevel = LogLevel.INFO) -> None:
     """
     for logger in loggers.values():
         logger.disableVerbose(logLevel)
+
+@typechecked
+def write_log(log_msg: str, log_lvl: LogLevel = LogLevel.INFO):
+    """
+    Allows the user to write custom logs.
+    """
+    from arkouda.client import generic_msg
+    generic_msg(cmd="clientlog", args={"log_msg": log_msg, "log_lvl": log_lvl.name})

--- a/arkouda/logger.py
+++ b/arkouda/logger.py
@@ -340,7 +340,7 @@ def disableVerbose(logLevel: LogLevel = LogLevel.INFO) -> None:
 
 
 @typechecked
-def write_log(log_msg: str, tag: str= "ClientGeneratedLog", log_lvl: LogLevel = LogLevel.INFO):
+def write_log(log_msg: str, tag: str = "ClientGeneratedLog", log_lvl: LogLevel = LogLevel.INFO):
     """
     Allows the user to write custom logs.
 

--- a/arkouda/logger.py
+++ b/arkouda/logger.py
@@ -27,7 +27,6 @@ levels for ArkoudaLogger.
 
 
 class LogLevel(Enum):
-
     DEBUG = "DEBUG"
     CRITICAL = "CRITICAL"
     INFO = "INFO"
@@ -53,7 +52,6 @@ at varying levels including debug, info, critical, warn, and error
 
 
 class ArkoudaLogger(Logger):
-
     DEFAULT_LOG_FORMAT = "[%(name)s] Line %(lineno)d %(levelname)s: %(message)s"
 
     CLIENT_LOG_FORMAT = ""
@@ -74,7 +72,6 @@ class ArkoudaLogger(Logger):
         handlers: Optional[List[Handler]] = None,
         logFormat: Optional[str] = "[%(name)s] Line %(lineno)d %(levelname)s: %(message)s",
     ) -> None:
-
         """
         Initializes the ArkoudaLogger with the name, level, logFormat, and
         handlers parameters
@@ -341,10 +338,12 @@ def disableVerbose(logLevel: LogLevel = LogLevel.INFO) -> None:
     for logger in loggers.values():
         logger.disableVerbose(logLevel)
 
+
 @typechecked
 def write_log(log_msg: str, log_lvl: LogLevel = LogLevel.INFO):
     """
     Allows the user to write custom logs.
     """
     from arkouda.client import generic_msg
+
     generic_msg(cmd="clientlog", args={"log_msg": log_msg, "log_lvl": log_lvl.name})

--- a/src/LogMsg.chpl
+++ b/src/LogMsg.chpl
@@ -24,19 +24,19 @@ module LogMsg
 
         select logLvl {
             when Logging.LogLevel.DEBUG {
-                clLogger.debug(mod_replace,tag,getLineNumber(),logMsg);
+                clLogger.debug(mod_replace,tag,0,logMsg);
             }
             when Logging.LogLevel.INFO {
                 clLogger.info(mod_replace,tag,0,logMsg);
             }
             when Logging.LogLevel.WARN {
-                clLogger.warn(mod_replace,tag,getLineNumber(),logMsg);
+                clLogger.warn(mod_replace,tag,0,logMsg);
             }
             when Logging.LogLevel.ERROR {
-                clLogger.error(mod_replace,tag,getLineNumber(),logMsg);
+                clLogger.error(mod_replace,tag,0,logMsg);
             }
             when Logging.LogLevel.CRITICAL {
-                clLogger.critical(mod_replace,tag,getLineNumber(),logMsg);
+                clLogger.critical(mod_replace,tag,0,logMsg);
             }
             otherwise {
                 var errorMsg = "Unknown Log Type Found.";

--- a/src/LogMsg.chpl
+++ b/src/LogMsg.chpl
@@ -1,0 +1,52 @@
+module LogMsg
+{
+    use ServerConfig;
+
+    use Reflection;
+    use ServerErrors;
+    use Logging;
+    use Message;
+    
+    use MultiTypeSymbolTable;
+    use MultiTypeSymEntry;
+    use ServerErrorStrings;
+
+    private config const logLevel = ServerConfig.logLevel;
+    private config const logChannel = ServerConfig.logChannel;
+    const clLogger = new Logger(logLevel, logChannel);
+
+    proc clientLogMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        param pn = Reflection.getRoutineName();
+
+        const logMsg: string = msgArgs.getValueOf("log_msg");
+        const logLvl: Logging.LogLevel = msgArgs.getValueOf("log_lvl").toUpper(): Logging.LogLevel;
+
+        select logLvl {
+            when Logging.LogLevel.DEBUG {
+                clLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),logMsg);
+            }
+            when Logging.LogLevel.INFO {
+                clLogger.info(getModuleName(),getRoutineName(),getLineNumber(),logMsg);
+            }
+            when Logging.LogLevel.WARN {
+                clLogger.warn(getModuleName(),getRoutineName(),getLineNumber(),logMsg);
+            }
+            when Logging.LogLevel.ERROR {
+                clLogger.error(getModuleName(),getRoutineName(),getLineNumber(),logMsg);
+            }
+            when Logging.LogLevel.CRITICAL {
+                clLogger.critical(getModuleName(),getRoutineName(),getLineNumber(),logMsg);
+            }
+            otherwise {
+                var errorMsg = "Unknown Log Type Found.";
+                clLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+        }
+        return new MsgTuple("Log Message Written Successfully.", MsgType.NORMAL);
+
+    }
+
+    use CommandMap;
+    registerFunction("clientlog", clientLogMsg, getModuleName());
+}

--- a/src/LogMsg.chpl
+++ b/src/LogMsg.chpl
@@ -18,22 +18,25 @@ module LogMsg
 
         const logMsg: string = msgArgs.getValueOf("log_msg");
         const logLvl: Logging.LogLevel = msgArgs.getValueOf("log_lvl").toUpper(): Logging.LogLevel;
+        const tag: string = msgArgs.getValueOf("tag");
+
+        const mod_replace: string = "ClientGeneratedLog";
 
         select logLvl {
             when Logging.LogLevel.DEBUG {
-                clLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),logMsg);
+                clLogger.debug(mod_replace,tag,getLineNumber(),logMsg);
             }
             when Logging.LogLevel.INFO {
-                clLogger.info(getModuleName(),getRoutineName(),getLineNumber(),logMsg);
+                clLogger.info(mod_replace,tag,0,logMsg);
             }
             when Logging.LogLevel.WARN {
-                clLogger.warn(getModuleName(),getRoutineName(),getLineNumber(),logMsg);
+                clLogger.warn(mod_replace,tag,getLineNumber(),logMsg);
             }
             when Logging.LogLevel.ERROR {
-                clLogger.error(getModuleName(),getRoutineName(),getLineNumber(),logMsg);
+                clLogger.error(mod_replace,tag,getLineNumber(),logMsg);
             }
             when Logging.LogLevel.CRITICAL {
-                clLogger.critical(getModuleName(),getRoutineName(),getLineNumber(),logMsg);
+                clLogger.critical(mod_replace,tag,getLineNumber(),logMsg);
             }
             otherwise {
                 var errorMsg = "Unknown Log Type Found.";

--- a/src/LogMsg.chpl
+++ b/src/LogMsg.chpl
@@ -8,8 +8,6 @@ module LogMsg
     use Message;
     
     use MultiTypeSymbolTable;
-    use MultiTypeSymEntry;
-    use ServerErrorStrings;
 
     private config const logLevel = ServerConfig.logLevel;
     private config const logChannel = ServerConfig.logChannel;

--- a/src/Logging.chpl
+++ b/src/Logging.chpl
@@ -177,13 +177,14 @@ module Logging {
         
         proc generateLogMessage(moduleName: string, routineName, lineNumber, 
                            msg, level: string) throws {
+            var lineStr: string = if lineNumber != 0 then "Line %i ".format(lineNumber) else "";
              if printDate {
-                 return "%s [%s] %s Line %i %s [Chapel] %s".format(
-                 generateDateTimeString(), moduleName,routineName,lineNumber, 
+                 return "%s [%s] %s %s%s [Chapel] %s".format(
+                 generateDateTimeString(), moduleName,routineName,lineStr, 
                                      level,msg);
              } else {
-                 return "[%s] %s Line %i %s [Chapel] %s".format(moduleName, 
-                 routineName,lineNumber,level,msg);            
+                 return "[%s] %s %s%s [Chapel] %s".format(moduleName, 
+                 routineName,lineStr,level,msg);            
              }
         }
          


### PR DESCRIPTION
Closes #2292

Adds the client side `write_log` function. Updates also expose the `LogLevel` enum to allow setting the log level using `ak.LogLevel.<desired_lvl>`.

Adds the `LogMsg` module. 

This workflow allows the user to supply a custom message to be written to the logs and a log level `(DEBUG, INFO, WARN, ERROR, CRITICAL)`. An example of usage is below.

```python
import arkouda as ak
ak.connect()

# Note that the below is an example if setting log_lvl to something that is not the default.
# The default value for log_lvl is ak.LogLevel.INFO
ak.write_log("Example Log Message.", tag="MyCustomLog", log_lvl=ak.LogLevel.INFO)

ak.disconnect()
```

The above snippet of code will result in the output below being added to the log. Please note - the log output location will vary depending upon the log channel setting.

```
2023-03-24:12:28:22 [ClientGeneratedLog] MyCustomLog INFO [Chapel] Example Log Message.
```

This updates the Logging module to not print the `Line #` when client supplied logs are provided. All Logs generated using this method will show the module as `ClientGeneratedLog`. The log can also be tagged in place of the function name normally found in logs.