### PR TITLE
Closes #2280: Improve `max_bits` handling

### DIFF
--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -303,6 +303,7 @@ module IndexingMsg
             forall (elt,j) in zip(aa, slice) with (var agg = newSrcAggregator(t)) {
               agg.copy(elt,ea[j]);
             }
+            a.max_bits = e.max_bits;
             var repMsg = "created " + st.attrib(rname);
             imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
             return new MsgTuple(repMsg, MsgType.NORMAL);
@@ -379,6 +380,7 @@ module IndexingMsg
             forall (a1,idx) in zip(aa,iva) with (var agg = newSrcAggregator(XType)) {
               agg.copy(a1,a2[idx]);
             }
+            a.max_bits = e.max_bits;
             
             var repMsg =  "created " + st.attrib(rname);
             imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg); 
@@ -415,6 +417,7 @@ module IndexingMsg
             forall (a1,idx) in zip(aa,iva) with (var agg = newSrcAggregator(XType)) {
               agg.copy(a1,a2[idx:int]);
             }
+            a.max_bits = e.max_bits;
             
             var repMsg =  "created " + st.attrib(rname);
             imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg); 
@@ -449,6 +452,7 @@ module IndexingMsg
                 agg.copy(aa[iv[i]-1], eai);
               }
             }
+            a.max_bits = e.max_bits;
 
             var repMsg = "created " + st.attrib(rname);
             imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg); 

--- a/tests/indexing_test.py
+++ b/tests/indexing_test.py
@@ -83,3 +83,9 @@ class IndexingTest(ArkoudaTest):
         a = ak.arange(10) * 2
         b = ak.cast(ak.array([3, 0, 8]), ak.uint64)
         a[b]
+
+    def test_bigint_indexing_preserves_max_bits(self):
+        max_bits = 64
+        a = ak.arange(2**200 - 1, 2**200 + 11, max_bits=max_bits)
+        self.assertEqual(max_bits, a[ak.arange(10)].max_bits)
+        self.assertEqual(max_bits, a[:].max_bits)

--- a/tests/pdarray_creation_test.py
+++ b/tests/pdarray_creation_test.py
@@ -70,7 +70,7 @@ class PdarrayCreationTest(ArkoudaTest):
 
         # test that max_bits being set results in a mod
         self.assertListEqual(
-            ak.array([bi, bi + 1, bi + 2, bi + 3, bi + 4], max_bits=200).to_list(),
+            ak.arange(bi, bi + 5, max_bits=200).to_list(),
             ak.arange(5).to_list(),
         )
 
@@ -90,6 +90,11 @@ class PdarrayCreationTest(ArkoudaTest):
         t = ak.arange(bi - 1, bi + 9)
         t_dup = ak.bigint_from_uint_arrays(t.bigint_to_uint_arrays())
         self.assertListEqual(t.to_list(), t_dup.to_list())
+        self.assertEqual(t_dup.max_bits, -1)
+
+        # test setting max_bits after creation still mods
+        t_dup.max_bits = 200
+        self.assertListEqual(t_dup.to_list(), [bi - 1, 0, 1, 2, 3, 4, 5, 6, 7, 8])
 
         # test slice_bits along 64 bit boundaries matches return from bigint_to_uint_arrays
         for i, uint_bits in enumerate(t.bigint_to_uint_arrays()):


### PR DESCRIPTION
This PR (closes #2280):
- Makes max_bits a field of the client side pdarray class (using `@property` `@.setter`). You can now set the `max_bits` of a bigint pdarray after creation
- Adds `max_bits` as an argument for all pdarray creation methods supported by bigint
- Fixes bug where `max_bits` was not preserved by indexing