### PR TITLE
Closes #2299 - Fixes file writes reporting success when directory does not exist

### DIFF
--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -1488,6 +1488,9 @@ module ParquetMsg {
         );
       }
       var result: int = c_writeMultiColToParquet(fname.localize().c_str(), c_ptrTo(c_names), c_ptrTo(ptrList), c_ptrTo(offsetPtr), c_ptrTo(objTypes), c_ptrTo(datatypes), c_ptrTo(segarray_sizes), ncols, numelems, ROWGROUPS, compression, c_ptrTo(pqErr.errMsg));
+      if result == ARROWERROR {
+        pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
+      }
     }
     return filesExist;
   }


### PR DESCRIPTION
Closes #2299

Adds check of the status that the C++ returns to the Chapel code. This allows us to properly report errors from the C++, which is what was being missed and causing the incorrect success message.