### PR TITLE
Closes #2240: `ak.coargsort` empty String and Categorical bug fix

### DIFF
--- a/arkouda/sorting.py
+++ b/arkouda/sorting.py
@@ -158,8 +158,9 @@ def coargsort(
             size = a.size
         elif size != a.size:
             raise ValueError("All pdarrays, Strings, or Categoricals must be of the same size")
+
     if size == 0:
-        return zeros(0, dtype=arrays[0].dtype)
+        return zeros(0, dtype=int if a.dtype=='str' else arrays[0].dtype)
 
     repMsg = generic_msg(
         cmd="coargsort",

--- a/arkouda/sorting.py
+++ b/arkouda/sorting.py
@@ -160,7 +160,7 @@ def coargsort(
             raise ValueError("All pdarrays, Strings, or Categoricals must be of the same size")
 
     if size == 0:
-        return zeros(0, dtype=int if a.dtype=='str' else arrays[0].dtype)
+        return zeros(0, dtype=int if a.dtype == 'str' else arrays[0].dtype)
 
     repMsg = generic_msg(
         cmd="coargsort",

--- a/arkouda/sorting.py
+++ b/arkouda/sorting.py
@@ -160,7 +160,7 @@ def coargsort(
             raise ValueError("All pdarrays, Strings, or Categoricals must be of the same size")
 
     if size == 0:
-        return zeros(0, dtype=int if a.dtype == 'str' else arrays[0].dtype)
+        return zeros(0, dtype=int if isinstance(arrays[0], (Strings, Categorical)) else arrays[0].dtype)
 
     repMsg = generic_msg(
         cmd="coargsort",

--- a/tests/coargsort_test.py
+++ b/tests/coargsort_test.py
@@ -191,6 +191,14 @@ class CoargsortTest(ArkoudaTest):
             mixed_perm = ak.coargsort([cat, string, cat_from_codes], algo)
             self.assertListEqual(["a", "a", "b", "b", "c"], cat_from_codes[mixed_perm].to_list())
 
+    def test_coargsort_empty(self):
+        empty_str = ak.random_strings_uniform(1, 16, 0)
+        empty_cat = ak.Categorical(empty_str)
+        empty_pda = ak.array([], int)
+        self.assertEqual(0, len(ak.coargsort([empty_pda])))
+        self.assertEqual(0, len(ak.coargsort([empty_str])))
+        self.assertEqual(0, len(ak.coargsort([empty_cat])))
+        
 
 def create_parser():
     parser = argparse.ArgumentParser(description="Check coargsort correctness.")

--- a/tests/coargsort_test.py
+++ b/tests/coargsort_test.py
@@ -194,8 +194,6 @@ class CoargsortTest(ArkoudaTest):
     def test_coargsort_empty(self):
         empty_str = ak.random_strings_uniform(1, 16, 0)
         empty_cat = ak.Categorical(empty_str)
-        empty_pda = ak.array([], int)
-        self.assertEqual(0, len(ak.coargsort([empty_pda])))
         self.assertEqual(0, len(ak.coargsort([empty_str])))
         self.assertEqual(0, len(ak.coargsort([empty_cat])))
 

--- a/tests/coargsort_test.py
+++ b/tests/coargsort_test.py
@@ -198,7 +198,7 @@ class CoargsortTest(ArkoudaTest):
         self.assertEqual(0, len(ak.coargsort([empty_pda])))
         self.assertEqual(0, len(ak.coargsort([empty_str])))
         self.assertEqual(0, len(ak.coargsort([empty_cat])))
-        
+
 
 def create_parser():
     parser = argparse.ArgumentParser(description="Check coargsort correctness.")


### PR DESCRIPTION
This PR (Closes #2240):

- Fixes error for empty arrays of String type and Categorical and handles them correctly.
- Adds a test to ensure that they properly produce an empty array.