### PR TITLE
Closes #2297 - Fixes HDF5 Single File Write Stall

### DIFF
--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -383,7 +383,7 @@ module HDF5Msg {
         writeArkoudaMetaData(file_id, dset_name, objType, dtype);
     }
 
-     /*
+    /*
         writes 1D array to dataset in single file
     */
     proc writeLocalDset(file_id: C_HDF5.hid_t, dset_name: string, A, dimension: int, type t) throws{


### PR DESCRIPTION
Closes #2297 

This PR updates the workflow for writing a single file to go to the locale where each chunk of data is and copy it to the root node using a `dstAggregator` instead of `lowLevelLocalizingSlice`. This results in significantly faster runtimes for the localization and better comms for numerics and strings. Based on the updates @ronawho suggested, I do not think we are going to squeeze any more performance out of this, but performance is ~25x better for numerics and ~96x better for strings at a minimum.

Before and after metrics posted below. Numerics using a pdarray of size `10**5` and strings using `ak.random_strings_uniform(1, 16, 10**5)`

Also noting that for review to ensure this performance make sure `-suseBulkTransfer=true` is set. 

**Numeric Localization Before PR**
```
Localize Time = 28

| locale |    get | put | execute_on |
| -----: | -----: | --: | ---------: |
|      0 | 320098 |  40 |        112 |
|      1 |      0 |  12 |          0 |
|      2 |      0 |  12 |          0 |
|      3 |      0 |  12 |          0 |
|      4 |      0 |  12 |          0 |
```

**Numeric Localization After PR**
```
Localize Time = 0

| locale | get | put | execute_on_nb |
| -----: | --: | --: | ------------: |
|      0 |   0 |   0 |             4 |
|      1 |   3 |   1 |             0 |
|      2 |   3 |   1 |             0 |
|      3 |   3 |   1 |             0 |
|      4 |   3 |   1 |             0 |

```

**Strings Localization Before PR**
```
Localize Values Time = 96

| locale |    get |
| -----: | -----: |
|      0 | 719086 |
|      1 |      0 |
|      2 |      0 |
|      3 |      0 |
|      4 |      0 |
```

**Strings Localization After PR**
```
Localize Time = 0

| locale | get | put | execute_on_nb |
| -----: | --: | --: | ------------: |
|      0 |   0 |   0 |             8 |
|      1 |   6 |   2 |             0 |
|      2 |   6 |   2 |             0 |
|      3 |   6 |   2 |             0 |
|      4 |   6 |   2 |             0 |
```