### PR TITLE
Closes #2311: Reenable bulk transfer for developer builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ARKOUDA_RUNTIME_CHECKS = true
 endif
 
 ifdef ARKOUDA_QUICK_COMPILE
-CHPL_FLAGS += --no-checks --no-loop-invariant-code-motion --no-fast-followers --ccflags="-O0" -suseBulkTransfer=false
+CHPL_FLAGS += --no-checks --no-loop-invariant-code-motion --no-fast-followers --ccflags="-O0"
 else
 CHPL_FLAGS += --fast
 endif


### PR DESCRIPTION
In #2090, we disabled bulk transfer for developer builds for Chapel 1.29. The impact appears to be much more modest in 1.30, so the decision to restore that has been made.

| Config     | enabled     | disabled |
| ---------: | ----------: | -------: |
| x86 mac    | 534s        | 528s     |
| M1 pro mac | 200s        | 190s     |

Closes #2311 