### PR TITLE
Fixes #2306: `Datetime.date` scaling

### DIFF
--- a/arkouda/timeclass.py
+++ b/arkouda/timeclass.py
@@ -517,7 +517,10 @@ class Datetime(_AbstractBaseTime):
 
     @property
     def date(self):
-        self._ensure_components()
+        # no need to call _ensure_components for the date
+        # if _date has been set, return it. Otherwise set it first
+        if not hasattr(self, "_date"):
+            self._date = self.floor("d")
         return self._date
 
     @property


### PR DESCRIPTION
This PR (closes #2306) fixes scaling issue with `Datetime.date` by avoiding the unnecessary `_ensure_components` call

Using reproducer from issue:
```python
def date_test(i):
  import pandas as pd
  first = pd.to_datetime('1970-01-01')
  last = pd.to_datetime('2023-03-27')
  size = 10**i
  aktimestamps = ak.Datetime(ak.randint(first.value,last.value,size))
  timer1 = pd.Timestamp.now()
  a = aktimestamps.date
  timer2 = pd.Timestamp.now()
  b = ak.Datetime(aktimestamps.values - aktimestamps.values % (24 * 3600 * 10**9))
  timer3 = pd.Timestamp.now()
  
  print((a==b).all())
  print(size, timer2-timer1, timer3-timer2)
```

Timings with `gasnet=None`
before:
```python
>>> date_test(8)
True
100000000 0 days 00:00:19.819625 0 days 00:00:00.556690
```

now:
```python
>>> date_test(8)
True
100000000 0 days 00:00:00.364566 0 days 00:00:00.517705
```

Timings with gasnet enabled and 2 locales
before:
```python
>>> date_test(8)
True
100000000 0 days 00:00:04.017719 0 days 00:00:06.341203
```

now: (NOTE this is much less data than the other timings)
```python
>>> date_test(4)
True
10000 0 days 00:00:17.289936 0 days 00:00:00.108681
```


The performance of `_ensure_components` does seem quite bad and it will be investigated in #2317, but it seemed worthwhile to go ahead and add this since it's the component the issue specifically asked for