### PR TITLE
Closes #2050 - File of Origin on Read

### DIFF
--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -1648,7 +1648,6 @@ def read(
 def read_tagged_data(
     filenames: Union[str, List[str]],
     datasets: Optional[Union[str, List[str]]] = None,
-    iterative: bool = False,
     strictTypes: bool = True,
     allow_errors: bool = False,
     calc_string_offsets=False,
@@ -1663,8 +1662,6 @@ def read_tagged_data(
         Either a list of filenames or shell expression
     datasets : list or str or None
         (List of) name(s) of dataset(s) to read (default: all available)
-    iterative : bool
-        Iterative (True) or Single (False) function call(s) to server
     strictTypes: bool
         If True (default), require all dtypes of a given dataset to have the
         same precision and sign. If False, allow dtypes of different
@@ -1693,7 +1690,6 @@ def read_tagged_data(
         filenames = [filenames]
 
     # handle glob expansion
-    # TODO - may want to not make this call if len > 1 because won't do anything on server if it is
     j_str = generic_msg(
         cmd="globExpansion",
         args={"file_count": len(filenames), "filenames": filenames},
@@ -1703,14 +1699,13 @@ def read_tagged_data(
         array(file_list)
     )  # create a categorical from the ak.Strings representation of the file list
 
-    # TODO - Add parameter sent to server that triggers the filename mapping be added
     ftype = get_filetype(filenames)
     if ftype.lower() == "hdf5":
         return (
             read_hdf(
                 filenames,
                 datasets=datasets,
-                iterative=iterative,
+                iterative=False,
                 strict_types=strictTypes,
                 allow_errors=allow_errors,
                 calc_string_offsets=calc_string_offsets,
@@ -1723,7 +1718,7 @@ def read_tagged_data(
             read_parquet(
                 filenames,
                 datasets=datasets,
-                iterative=iterative,
+                iterative=False,  # hard-coded because iterative not supported
                 strict_types=strictTypes,
                 allow_errors=allow_errors,
                 tag_data=True,

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -514,7 +514,7 @@ def read_hdf(
     strict_types: bool = True,
     allow_errors: bool = False,
     calc_string_offsets: bool = False,
-    tag_data = False
+    tag_data=False,
 ) -> Union[
     pdarray,
     Strings,
@@ -612,7 +612,7 @@ def read_hdf(
                 strict_types=strict_types,
                 allow_errors=allow_errors,
                 calc_string_offsets=calc_string_offsets,
-                tag_data=tag_data
+                tag_data=tag_data,
             )[dset]
             for dset in datasets
         }
@@ -627,7 +627,7 @@ def read_hdf(
                 "calc_string_offsets": calc_string_offsets,
                 "dsets": datasets,
                 "filenames": filenames,
-                "tag_data": tag_data
+                "tag_data": tag_data,
             },
         )
         rep = json.loads(rep_msg)  # See GenSymIO._buildReadAllMsgJson for json structure
@@ -736,7 +736,7 @@ def read_parquet(
                 datasets=dset,
                 strict_types=strict_types,
                 allow_errors=allow_errors,
-                tag_data=tag_data
+                tag_data=tag_data,
             )[dset]
             for dset in datasets
         }
@@ -750,7 +750,7 @@ def read_parquet(
                 "allow_errors": allow_errors,
                 "dsets": datasets,
                 "filenames": filenames,
-                "tag_data": tag_data
+                "tag_data": tag_data,
             },
         )
         rep = json.loads(rep_msg)  # See GenSymIO._buildReadAllMsgJson for json structure
@@ -1645,12 +1645,14 @@ def read(
         raise RuntimeError(f"Invalid File Type detected, {ftype}")
 
 
-def read_tagged_data(filenames: Union[str, List[str]],
+def read_tagged_data(
+    filenames: Union[str, List[str]],
     datasets: Optional[Union[str, List[str]]] = None,
     iterative: bool = False,
     strictTypes: bool = True,
     allow_errors: bool = False,
-    calc_string_offsets=False,):
+    calc_string_offsets=False,
+):
     """
     Read datasets from files and tag each record to the file it was read from.
     File Type is determined automatically.
@@ -1683,7 +1685,7 @@ def read_tagged_data(filenames: Union[str, List[str]],
     ---------
     Read files and return data with tagging corresponding to the Categorical returned
     cat.codes will link the codes in data to the filename. Data will contain the code `Filename_Codes`
-    >>> data, cat = ak.read_tagged_data('path/name') # load HDF5 - processing determines file type not extension
+    >>> data, cat = ak.read_tagged_data('path/name')
     >>> data
     {'Filname_Codes': array([0 3 6 9 12]), 'col_name': array([0 0 0 1])}
     """
@@ -1694,35 +1696,40 @@ def read_tagged_data(filenames: Union[str, List[str]],
     # TODO - may want to not make this call if len > 1 because won't do anything on server if it is
     j_str = generic_msg(
         cmd="globExpansion",
-        args={
-            "file_count": len(filenames),
-            "filenames": filenames
-        },
+        args={"file_count": len(filenames), "filenames": filenames},
     )
     file_list = json.loads(j_str)
-    file_cat = Categorical(array(file_list))  # create a categorical from the ak.Strings representation of the file list
+    file_cat = Categorical(
+        array(file_list)
+    )  # create a categorical from the ak.Strings representation of the file list
 
     # TODO - Add parameter sent to server that triggers the filename mapping be added
     ftype = get_filetype(filenames)
     if ftype.lower() == "hdf5":
-        return read_hdf(
-            filenames,
-            datasets=datasets,
-            iterative=iterative,
-            strict_types=strictTypes,
-            allow_errors=allow_errors,
-            calc_string_offsets=calc_string_offsets,
-            tag_data=True
-        ), file_cat
+        return (
+            read_hdf(
+                filenames,
+                datasets=datasets,
+                iterative=iterative,
+                strict_types=strictTypes,
+                allow_errors=allow_errors,
+                calc_string_offsets=calc_string_offsets,
+                tag_data=True,
+            ),
+            file_cat,
+        )
     elif ftype.lower() == "parquet":
-        return read_parquet(
-            filenames,
-            datasets=datasets,
-            iterative=iterative,
-            strict_types=strictTypes,
-            allow_errors=allow_errors,
-            tag_data=True,
-        ), file_cat
+        return (
+            read_parquet(
+                filenames,
+                datasets=datasets,
+                iterative=iterative,
+                strict_types=strictTypes,
+                allow_errors=allow_errors,
+                tag_data=True,
+            ),
+            file_cat,
+        )
     elif ftype.lower() == "csv":
         raise RuntimeError("CSV does not support tagging data with file name associated.")
     else:

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -717,8 +717,33 @@ module ParquetMsg {
     }
   }
 
+  proc populateTagData(A, filenames: [?fD] string, sizes) throws {
+    var (subdoms, length) = getSubdomains(sizes);
+    var fileOffsets = (+ scan sizes) - sizes;
+    
+    coforall loc in A.targetLocales() do on loc {
+      var locFiles = filenames;
+      var locFiledoms = subdoms;
+      var locOffsets = fileOffsets;
+      
+      try {
+        forall (off, filedom, filename, tag) in zip(locOffsets, locFiledoms, locFiles, 0..) {
+          for locdom in A.localSubdomains() {
+            const intersection = domain_intersection(locdom, filedom);
+
+            if intersection.size > 0 {
+              // write the tag into the entry
+              A[intersection] = tag;
+            }
+          }
+        }
+      }
+    }
+  }
+
   proc readAllParquetMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     var repMsg: string;
+    var tagData: bool = msgArgs.get("tag_data").getBoolValue();
     var strictTypes: bool = msgArgs.get("strict_types").getBoolValue();
 
     var allowErrors: bool = msgArgs.get("allow_errors").getBoolValue(); // default is false
@@ -818,6 +843,17 @@ module ParquetMsg {
         }
         var len = + reduce sizes;
         var ty = types[dsetidx];
+
+        // If tagging is turned on, tag the data
+        if tagData {
+          pqLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "Tagging Data with File Code");
+          var tagEntry = new shared SymEntry(len, int); // this will always contain integer values
+          populateTagData(tagEntry.a, filenames, sizes);
+          var rname = st.nextName();
+          st.addEntry(rname, tagEntry);
+          rnames.append(("Filename_Codes", "pdarray", rname));
+          tagData = false; // turn off so we only run once
+        }
 
         // Only integer is implemented for now, do nothing if the Parquet
         // file has a different type

--- a/src/ServerDaemon.chpl
+++ b/src/ServerDaemon.chpl
@@ -363,6 +363,7 @@ module ServerDaemon {
             registerFunction("clear", clearMsg);
             registerFunction("lsany", lsAnyMsg);
             registerFunction("getfiletype", getFileTypeMsg);
+            registerFunction("globExpansion", globExpansionMsg);
 
             // For a few specialized cmds we're going to add dummy functions, so they
             // get added to the client listing of available commands. They will be


### PR DESCRIPTION
Closes #2050

This PR adds the ability to link the data returned during a file read to the file it was read from. This is done by first creating a Categorical and then returning a dataset that will always be named `Filename_Codes`. These codes can then be used to access the filename from the categorical object. 

Adds the function `ak.read_tagged_data`. This is functionally equivalent to `ak.read`, but triggers the addition of tagging with filename codes. This function also returns a tuple containing the data returned, where `Filename_Codes` will be included as a dataset and a `Categorical` object created from ALL filenames accessed.

As an example, running with 16 locales:
```python
import arkouda as ak

ak.connect()

fname = "path_to_file"

a = ak.SegArray.from_parts(ak.arange(0, 10, 2), ak.arange(10))
a.to_parquet(fname)
data, cat = ak.read_tagged_data(fname+"_*")
print(data)

{'Filname_Code': array([0 3 6 9 12]), 'segarray': SegArray([
[0 1]
[2 3]
[4 5]
[6 7]
[8 9]
])}

import pandas as pd
fcodes = data["Filname_Code"].to_list()
for fc in fcodes:
    fname = cat[fc]
    # verification that data is being properly linked to the file
    df = pd.read_parquet(fname, engine='pyarrow')
    print(f"File: {fname}\n{df}\n\n")

ak.disconnect()
```
**Output from the loop Print**
```python
File: /Users/ethandebandi/Documents/save_load_testing/tagged_hdf_LOCALE0000
  segarray
0   [0, 1]


File: /Users/ethandebandi/Documents/save_load_testing/tagged_hdf_LOCALE0003
  segarray
0   [2, 3]


File: /Users/ethandebandi/Documents/save_load_testing/tagged_hdf_LOCALE0006
  segarray
0   [4, 5]


File: /Users/ethandebandi/Documents/save_load_testing/tagged_hdf_LOCALE0009
  segarray
0   [6, 7]


File: /Users/ethandebandi/Documents/save_load_testing/tagged_hdf_LOCALE0012
  segarray
0   [8, 9]
```

This PR does add a message for handling of the glob expression. This is because we cannot guarantee that the client will have access to the file system containing data. This allows for access of the full file list in the case of a glob expression being provided and then allows creation of the `Categorical`. 