### PR TITLE
Bump bigint groupby benchmark problem size

### DIFF
--- a/benchmarks/bigint_groupby.py
+++ b/benchmarks/bigint_groupby.py
@@ -13,7 +13,7 @@ def create_parser():
         "-n",
         "--size",
         type=int,
-        default=10**6,
+        default=10**8,
         help="Problem size: total length of all arrays to group",
     )
     parser.add_argument(


### PR DESCRIPTION
Now that we have bigint aggregation, the benchmark runs much faster so bump to the usual `10**8` problem size.