### PR TITLE
Fixes #2328: Bug when printing Dataframes containing bigint

### DIFF
--- a/src/DataFrameIndexingMsg.chpl
+++ b/src/DataFrameIndexingMsg.chpl
@@ -9,6 +9,7 @@
     use Message;
     use SegmentedMsg;
     use AryUtil;
+    use BigInteger;
 
     use MultiTypeSymEntry;
     use MultiTypeSymbolTable;
@@ -50,7 +51,7 @@
         forall (a1,i) in zip(aa,iva) {
             a1 = a2[i];
         }
-        
+
         if rtnName {
             return rname;
         }
@@ -155,6 +156,10 @@
                         }
                         when (DType.Float64){
                             var col_vals = toSymEntry(gCol, real);
+                            rpm = "%jt".format(dfIdxHelper(idx, col_vals, st, col_name, ele_parts[0]));
+                        }
+                        when (DType.BigInt){
+                            var col_vals = toSymEntry(gCol, bigint);
                             rpm = "%jt".format(dfIdxHelper(idx, col_vals, st, col_name, ele_parts[0]));
                         }
                         otherwise {


### PR DESCRIPTION
This PR (fixes #2328) adds support for bigint in `dataframe_idx`. This enables printing a dataframe containing a bigint column

Output on reproducer (but with data size bumped up to `10**8` and `max_bits=512` to ensure scaling)
```python
In [3]: bi = ak.bigint_from_uint_arrays([
   ...:     ak.ones(10**8, dtype=ak.uint64),
   ...:     ak.ones(10**8, dtype=ak.uint64),
   ...:     ak.ones(10**8, dtype=ak.uint64),
   ...:     ak.ones(10**8,  dtype=ak.uint64)
   ...:     ], max_bits=512)
   ...: df = ak.DataFrame({"myind":ak.arange(10**8), "bigint_col":bi  })
   ...: df
Out[3]: 
             myind                                                  bigint_col
0                0  6277101735386680764176071790128604879584176795969512275969
1                1  6277101735386680764176071790128604879584176795969512275969
2                2  6277101735386680764176071790128604879584176795969512275969
3                3  6277101735386680764176071790128604879584176795969512275969
4                4  6277101735386680764176071790128604879584176795969512275969
...            ...                                                         ...
99999995  99999995  6277101735386680764176071790128604879584176795969512275969
99999996  99999996  6277101735386680764176071790128604879584176795969512275969
99999997  99999997  6277101735386680764176071790128604879584176795969512275969
99999998  99999998  6277101735386680764176071790128604879584176795969512275969
99999999  99999999  6277101735386680764176071790128604879584176795969512275969 (100000000 rows x 2 columns)

In [4]: df.head()
Out[4]: 
   myind                                                  bigint_col
0      0  6277101735386680764176071790128604879584176795969512275969
1      1  6277101735386680764176071790128604879584176795969512275969
2      2  6277101735386680764176071790128604879584176795969512275969
3      3  6277101735386680764176071790128604879584176795969512275969
4      4  6277101735386680764176071790128604879584176795969512275969 (5 rows x 2 columns)

In [5]: df.tail()
Out[5]: 
             myind                                                  bigint_col
99999995  99999995  6277101735386680764176071790128604879584176795969512275969
99999996  99999996  6277101735386680764176071790128604879584176795969512275969
99999997  99999997  6277101735386680764176071790128604879584176795969512275969
99999998  99999998  6277101735386680764176071790128604879584176795969512275969
99999999  99999999  6277101735386680764176071790128604879584176795969512275969 (5 rows x 2 columns)

```