### PR TITLE
Closes #2327 - Fixes Issue Loading 16-bit and 32-bit from Parquet

### DIFF
--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -89,15 +89,16 @@ int cpp_getType(const char* filename, const char* colname, char** errMsg) {
       return ARROWERROR;
     }
     auto myType = sc -> field(idx) -> type();
+    std::cout << "\n\nCol: " << colname << " Type: " << myType->name() << "\n\n";
 
     if(myType->id() == arrow::Type::INT64)
       return ARROWINT64;
-    else if(myType->id() == arrow::Type::INT32)
-      return ARROWINT32;
+    else if(myType->id() == arrow::Type::INT32 || myType->id() == arrow::Type::INT16)
+      return ARROWINT32; // 16bit stored as 32bit so can treat both as 32bit
     else if(myType->id() == arrow::Type::UINT64)
       return ARROWUINT64;
-    else if(myType->id() == arrow::Type::UINT32)
-      return ARROWUINT32;
+    else if(myType->id() == arrow::Type::UINT32 || myType->id() == arrow::Type::UINT16)
+      return ARROWUINT32; // 16bit stored as 32bit so can treat both as 32bit
     else if(myType->id() == arrow::Type::TIMESTAMP)
       return ARROWTIMESTAMP;
     else if(myType->id() == arrow::Type::BOOL)
@@ -163,11 +164,11 @@ int cpp_getListType(const char* filename, const char* colname, char** errMsg) {
         auto f_type = field->type();
         if(f_type->id() == arrow::Type::INT64)
           return ARROWINT64;
-        else if(f_type->id() == arrow::Type::INT32)
+        else if(f_type->id() == arrow::Type::INT32 || f_type->id() == arrow::Type::INT16)
           return ARROWINT32;
         else if(f_type->id() == arrow::Type::UINT64)
           return ARROWUINT64;
-        else if(f_type->id() == arrow::Type::UINT32)
+        else if(f_type->id() == arrow::Type::UINT32 || f_type->id() == arrow::Type::UINT16)
           return ARROWUINT32;
         else if(f_type->id() == arrow::Type::TIMESTAMP)
           return ARROWTIMESTAMP;
@@ -1639,8 +1640,10 @@ int cpp_getDatasetNames(const char* filename, char** dsetResult, char** errMsg) 
       // only add fields of supported types
       if(sc->field(i)->type()->id() == arrow::Type::INT64 ||
          sc->field(i)->type()->id() == arrow::Type::INT32 ||
+         sc->field(i)->type()->id() == arrow::Type::INT16 ||
          sc->field(i)->type()->id() == arrow::Type::UINT64 ||
          sc->field(i)->type()->id() == arrow::Type::UINT32 ||
+         sc->field(i)->type()->id() == arrow::Type::UINT16 ||
          sc->field(i)->type()->id() == arrow::Type::TIMESTAMP ||
          sc->field(i)->type()->id() == arrow::Type::BOOL ||
          sc->field(i)->type()->id() == arrow::Type::STRING ||

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -94,11 +94,12 @@ int cpp_getType(const char* filename, const char* colname, char** errMsg) {
     if(myType->id() == arrow::Type::INT64)
       return ARROWINT64;
     else if(myType->id() == arrow::Type::INT32 || myType->id() == arrow::Type::INT16)
-      return ARROWINT32; // 16bit stored as 32bit so can treat both as 32bit
+      return ARROWINT32; // int16 is logical type, stored as int32
     else if(myType->id() == arrow::Type::UINT64)
       return ARROWUINT64;
-    else if(myType->id() == arrow::Type::UINT32 || myType->id() == arrow::Type::UINT16)
-      return ARROWUINT32; // 16bit stored as 32bit so can treat both as 32bit
+    else if(myType->id() == arrow::Type::UINT32 || 
+            myType->id() == arrow::Type::UINT16)
+      return ARROWUINT32; // uint16 is logical type, stored as uint32
     else if(myType->id() == arrow::Type::TIMESTAMP)
       return ARROWTIMESTAMP;
     else if(myType->id() == arrow::Type::BOOL)

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -830,6 +830,14 @@ module ParquetMsg {
         } else if ty == ArrowTypes.uint64 || ty == ArrowTypes.uint32 {
           var entryVal = new shared SymEntry(len, uint);
           readFilesByName(entryVal.a, filenames, sizes, dsetname, ty);
+          // when reading a uint32, conversion to uint64 does not handle the high bit correctly
+          if (ty == ArrowTypes.uint32){ 
+            ref ea = entryVal.a;
+            // Move the high bit of uint32 back to the 32nd bit from 64th bit and mask so
+            // uint32 can be represented in a uint64
+            entryVal.a = ((ea & (2**63))>>32 | ea) & (2**32 -1);
+          }
+
           var valName = st.nextName();
           st.addEntry(valName, entryVal);
           rnames.append((dsetname, "pdarray", valName));

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -830,14 +830,12 @@ module ParquetMsg {
         } else if ty == ArrowTypes.uint64 || ty == ArrowTypes.uint32 {
           var entryVal = new shared SymEntry(len, uint);
           readFilesByName(entryVal.a, filenames, sizes, dsetname, ty);
-          // when reading a uint32, conversion to uint64 does not handle the high bit correctly
-          if (ty == ArrowTypes.uint32){ 
+          if (ty == ArrowTypes.uint32){ // correction for high bit 
             ref ea = entryVal.a;
-            // Move the high bit of uint32 back to the 32nd bit from 64th bit and mask so
-            // uint32 can be represented in a uint64
+            // Access the high bit (64th bit) and shift it into the high bit for uint32 (32nd bit)
+            // Apply 32 bit mask to drop top 64 bits and properly store uint32
             entryVal.a = ((ea & (2**63))>>32 | ea) & (2**32 -1);
           }
-
           var valName = st.nextName();
           st.addEntry(valName, entryVal);
           rnames.append((dsetname, "pdarray", valName));

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -531,6 +531,19 @@ class ParquetTest(ArkoudaTest):
             rd_df = ak.DataFrame(rd_data)
             self.assertTrue(akdf.to_pandas().equals(rd_df.to_pandas()))
 
+    def test_small_ints(self):
+        df_pd = pd.DataFrame({
+            "int16": pd.Series([2 ** 15 - 1, -2 ** 15], dtype=np.int16),
+            "int32": pd.Series([2 ** 31 - 1, -2 ** 31], dtype=np.int32),
+            "uint16": pd.Series([2 ** 15 - 1, 2 ** 15], dtype=np.uint16),
+            "uint32": pd.Series([2 ** 31 - 1, 2 ** 31], dtype=np.uint32),
+        })
+        with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
+            fname = tmp_dirname+"/pq_small_int"
+            df_pd.to_parquet(fname)
+            df_ak = ak.DataFrame(ak.read(fname + "*"))
+            for c in df_ak.columns:
+                self.assertListEqual(df_ak[c].to_list(), df_pd[c].to_list())
 
     @pytest.mark.optional_parquet
     def test_against_standard_files(self):


### PR DESCRIPTION
Closes #2327

This PR fixes issues with reading `int16`, `uint16`, `int32` and `uint32` columns from Parquet files. `int16` and `uint16` are logical types in Parquet and are stored as `int32` or `uint32`. There was an issue with the handling of the high bit when converting from `uint32` to `uint64`. To resolve this, we shift the high bit to the correct position and apply a mask to remove the top 32 bits allowing `uint32` to be properly stored in a `uint64`.  `int16` and `uint16` were added as valid types to read from Parquet files. Because they are stored as 32-bit values, the same fix for 32-bit values apply to them.

Tested using the following python code:
```python
df_pd = pd.DataFrame({
"int16": pd.Series([2**15-1, -2**15], dtype=np.int16),
"int32": pd.Series([2**31-1, -2**31], dtype=np.int32),
"uint16": pd.Series([2**15-1, 2**15], dtype=np.uint16),
"uint32": pd.Series([2**31-1, 2**31], dtype=np.uint32),
})
print(df_pd)
df_pd.to_parquet(fname)
df_ak = ak.DataFrame(ak.read(fname+"*"))
print(df_ak.__repr__())

**Expected output from Pandas** 
```
 int16       int32  uint16      uint32
0  32767  2147483647   32767  2147483647
1 -32768 -2147483648   32768  2147483648
```

**Arkouda Read Output BEFORE this PR**
```
        int32                uint32
0  2147483647            2147483647
1 -2147483648  18446744071562067968 (2 rows x 2 columns)
```

**Arkouda Read Output AFTER this PR**
```
   int16       int32  uint16      uint32
0  32767  2147483647   32767  2147483647
1 -32768 -2147483648   32768  2147483648 (2 rows x 4 columns)
```