### PR TITLE
Closes #2293: `ak.where` support Strings and Categoricals

### DIFF
--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -526,12 +526,6 @@ def _str_cat_where(
     from arkouda.categorical import Categorical
     from arkouda.pdarraysetops import concatenate
 
-    if not isinstance(A, (str, Strings, Categorical)) or not isinstance(B, (str, Strings, Categorical)):
-        raise TypeError(
-            "both A and B must be an int, np.int64, float, np.float64, pdarray OR"
-            " both A and B must be an str, Strings, Categorical"
-        )
-
     if isinstance(A, str) and isinstance(B, (Categorical, Strings)):
         # This allows us to assume if a str is present it is B
         A, B, condition = B, A, ~condition
@@ -671,6 +665,18 @@ def where(
     if (not isSupportedNumber(A) and not isinstance(A, pdarray)) or (
         not isSupportedNumber(B) and not isinstance(B, pdarray)
     ):
+        from arkouda.categorical import Categorical  # type: ignore
+
+        # fmt: off
+        if (
+            not isinstance(A, (str, Strings, Categorical))  # type: ignore
+            or not isinstance(B, (str, Strings, Categorical))  # type: ignore
+        ):
+            # fmt:on
+            raise TypeError(
+                "both A and B must be an int, np.int64, float, np.float64, pdarray OR"
+                " both A and B must be an str, Strings, Categorical"
+            )
         return _str_cat_where(condition, A, B)
     if isinstance(A, pdarray) and isinstance(B, pdarray):
         repMsg = generic_msg(

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from typing import ForwardRef, List, Optional, Tuple, Union
 from typing import cast as type_cast
+from typing import no_type_check
 
 import numpy as np  # type: ignore
 from typeguard import typechecked
@@ -16,7 +17,10 @@ from arkouda.dtypes import (
     resolve_scalar_dtype,
 )
 from arkouda.groupbyclass import GroupBy
-from arkouda.pdarrayclass import create_pdarray, pdarray
+from arkouda.pdarrayclass import all as ak_all
+from arkouda.pdarrayclass import any as ak_any
+from arkouda.pdarrayclass import argmax, create_pdarray, pdarray
+from arkouda.pdarraycreation import array
 from arkouda.strings import Strings
 
 Categorical = ForwardRef("Categorical")
@@ -511,10 +515,89 @@ def _hash_single(pda: pdarray, full: bool = True):
         return create_pdarray(repMsg)
 
 
+@no_type_check
+def _str_cat_where(
+    condition: pdarray,
+    A: Union[str, Strings, Categorical],
+    B: Union[str, Strings, Categorical],
+) -> Union[Strings, Categorical]:
+    # added @no_type_check because mypy can't handle Categorical not being declared
+    # sooner, but there are circular dependencies preventing that
+    from arkouda.categorical import Categorical
+    from arkouda.pdarraysetops import concatenate
+
+    if not isinstance(A, (str, Strings, Categorical)) or not isinstance(B, (str, Strings, Categorical)):
+        raise TypeError(
+            "both A and B must be an int, np.int64, float, np.float64, pdarray OR"
+            " both A and B must be an str, Strings, Categorical"
+        )
+
+    if isinstance(A, str) and isinstance(B, (Categorical, Strings)):
+        # This allows us to assume if a str is present it is B
+        A, B, condition = B, A, ~condition
+
+    # one cat and one str
+    if isinstance(A, Categorical) and isinstance(B, str):
+        is_in_categories = A.categories == B
+        if ak_any(is_in_categories):
+            new_categories = A.categories
+            b_code = argmax(is_in_categories)
+        else:
+            new_categories = concatenate([A.categories, array([B])])
+            b_code = A.codes.size + 1
+        new_codes = where(condition, A.codes, b_code)
+        return Categorical.from_codes(new_codes, new_categories, NAvalue=A.NAvalue).reset_categories()
+
+    # both cat
+    if isinstance(A, Categorical) and isinstance(B, Categorical):
+        if A.codes.size != B.codes.size:
+            raise TypeError("Categoricals must be same length")
+        if A.categories.size != B.categories.size or not ak_all(A.categories == B.categories):
+            A, B = A.standardize_categories([A, B])
+        new_codes = where(condition, A.codes, B.codes)
+        return Categorical.from_codes(new_codes, A.categories, NAvalue=A.NAvalue).reset_categories()
+
+    # one strings and one str
+    if isinstance(A, Strings) and isinstance(B, str):
+        new_lens = where(condition, A.get_lengths(), len(B))
+        repMsg = generic_msg(
+            cmd="segmentedWhere",
+            args={
+                "seg_str": A,
+                "other": B,
+                "is_str_literal": True,
+                "new_lens": new_lens,
+                "condition": condition,
+            },
+        )
+        return Strings.from_return_msg(repMsg)
+
+    # both strings
+    if isinstance(A, Strings) and isinstance(B, Strings):
+        if A.size != B.size:
+            raise TypeError("Strings must be same length")
+        new_lens = where(condition, A.get_lengths(), B.get_lengths())
+        repMsg = generic_msg(
+            cmd="segmentedWhere",
+            args={
+                "seg_str": A,
+                "other": B,
+                "is_str_literal": False,
+                "new_lens": new_lens,
+                "condition": condition,
+            },
+        )
+        return Strings.from_return_msg(repMsg)
+
+    raise TypeError("ak.where is not supported between Strings and Categorical")
+
+
 @typechecked
 def where(
-    condition: pdarray, A: Union[numeric_scalars, pdarray], B: Union[numeric_scalars, pdarray]
-) -> pdarray:
+    condition: pdarray,
+    A: Union[str, numeric_scalars, pdarray, Strings, Categorical],  # type: ignore
+    B: Union[str, numeric_scalars, pdarray, Strings, Categorical],  # type: ignore
+) -> Union[pdarray, Strings, Categorical]:  # type: ignore
     """
     Returns an array with elements chosen from A and B based upon a
     conditioning array. As is the case with numpy.where, the return array
@@ -526,9 +609,9 @@ def where(
     ----------
     condition : pdarray
         Used to choose values from A or B
-    A : Union[numeric_scalars, pdarray]
+    A : Union[numeric_scalars, str, pdarray, Strings, Categorical]
         Value(s) used when condition is True
-    B : Union[numeric_scalars, pdarray]
+    B : Union[numeric_scalars, str, pdarray, Strings, Categorical]
         Value(s) used when condition is False
 
     Returns
@@ -541,9 +624,9 @@ def where(
     ------
     TypeError
         Raised if the condition object is not a pdarray, if A or B is not
-        an int, np.int64, float, np.float64, or pdarray, if pdarray dtypes
-        are not supported or do not match, or multiple condition clauses (see
-        Notes section) are applied
+        an int, np.int64, float, np.float64, pdarray, str, Strings, Categorical
+        if pdarray dtypes are not supported or do not match, or multiple
+        condition clauses (see Notes section) are applied
     ValueError
         Raised if the shapes of the condition, A, and B pdarrays are unequal
 
@@ -567,6 +650,18 @@ def where(
     >>> ak.where(cond,a1,a2)
     array([1, 2, 3, 4, 10, 10, 10, 10, 10])
 
+    >>> s1 = ak.array([f'str {i}' for i in range(10)])
+    >>> s2 = 'str 21'
+    >>> cond = (ak.arange(10) % 2 == 0)
+    >>> ak.where(cond,s1,s2)
+    array(['str 0', 'str 21', 'str 2', 'str 21', 'str 4', 'str 21', 'str 6', 'str 21', 'str 8','str 21'])
+
+    >>> c1 = ak.Categorical(ak.array([f'str {i}' for i in range(10)]))
+    >>> c2 = ak.Categorical(ak.array([f'str {i}' for i in range(9, -1, -1)]))
+    >>> cond = (ak.arange(10) % 2 == 0)
+    >>> ak.where(cond,c1,c2)
+    array(['str 0', 'str 8', 'str 2', 'str 6', 'str 4', 'str 4', 'str 6', 'str 2', 'str 8', 'str 0'])
+
     Notes
     -----
     A and B must have the same dtype and only one conditional clause
@@ -576,7 +671,7 @@ def where(
     if (not isSupportedNumber(A) and not isinstance(A, pdarray)) or (
         not isSupportedNumber(B) and not isinstance(B, pdarray)
     ):
-        raise TypeError("both A and B must be an int, np.int64, float, np.float64, or pdarray")
+        return _str_cat_where(condition, A, B)
     if isinstance(A, pdarray) and isinstance(B, pdarray):
         repMsg = generic_msg(
             cmd="efunc3vv",

--- a/src/SegmentedString.chpl
+++ b/src/SegmentedString.chpl
@@ -741,6 +741,59 @@ module SegmentedString {
       return (subbedOffsets, subbedVals, numReplacements);
     }
 
+    proc segStrWhere(otherStr: ?t, condition: [] bool, newLens: [] int) throws where t == string {
+      // add one to account for null bytes
+      newLens += 1;
+      ref origOffs = this.offsets.a;
+      ref origVals = this.values.a;
+      const other = otherStr:bytes;
+
+      overMemLimit(newLens.size * numBytes(int));
+      var whereOffs = (+ scan newLens) - newLens;
+      const valSize = (+ reduce newLens);
+      var whereVals = makeDistArray(valSize, uint(8));
+
+      forall (whereOff, origOff, len, cond) in zip(whereOffs, origOffs, newLens, condition) with (var valAgg = newDstAggregator(uint(8))) {
+        if cond {
+          var localizedVals = new lowLevelLocalizingSlice(origVals, origOff..#len);
+          for i in 0..#len {
+            valAgg.copy(whereVals[whereOff+i], localizedVals.ptr[i]);
+          }
+        }
+        else {
+          for i in 0..#(len-1) {
+            valAgg.copy(whereVals[whereOff+i], other[i]:uint(8));
+          }
+          // write null byte
+          valAgg.copy(whereVals[whereOff+(len-1)], 0:uint(8));
+        }
+      }
+      return (whereOffs, whereVals);
+    }
+
+   proc segStrWhere(other: ?t, condition: [] bool, newLens: [] int) throws where t == owned SegString {
+      // add one to account for null bytes
+      newLens += 1;
+      ref origOffs = this.offsets.a;
+      ref origVals = this.values.a;
+      ref otherOffs = other.offsets.a;
+      ref otherVals = other.values.a;
+
+      overMemLimit(newLens.size * numBytes(int));
+      var whereOffs = (+ scan newLens) - newLens;
+      const valSize = (+ reduce newLens);
+      var whereVals = makeDistArray(valSize, uint(8));
+
+      forall (whereOff, origOff, otherOff, len, cond) in zip(whereOffs, origOffs, otherOffs, newLens, condition) with (var valAgg = newDstAggregator(uint(8))) {
+        const localizedVals = if cond then new lowLevelLocalizingSlice(origVals, origOff..#len) else new lowLevelLocalizingSlice(otherVals, otherOff..#len);
+        for i in 0..#len {
+          valAgg.copy(whereVals[whereOff+i], localizedVals.ptr[i]);
+        }
+      }
+      return (whereOffs, whereVals);
+    }
+
+
     /*
       Strip out all of the leading and trailing characters of each element of a segstring that are
       called out in the "chars" argument.


### PR DESCRIPTION
This PR (closes #2293) adds `where` support Strings, Categoricals, and string literals. Adds testing for this functionality