### PR TITLE
Closes #2015 - Efficient NaN read from Parquet

### DIFF
--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -721,7 +721,8 @@ int cpp_readColumnByName(const char* filename, void* chpl_arr, const char* colna
           (void)reader->ReadBatch(batchSize, def_lvl, rep_lvl, tmpArr, &values_read);
           // copy values to Chapel array. Convert to double if not NaN
           for (int64_t j = 0; j < batchSize; j++){
-            if (max_def != 0 && def_lvl[j] == 0) { // when definition level is 0, mean Null which equated to NaN here
+            // when definition level is 0, mean Null which equated to NaN here unless 0 is the max meaning no null/nan values
+            if (max_def != 0 && def_lvl[j] == 0) {
               chpl_ptr[i] = NAN;
               idx_adjust++; // account for the NaN at the indexes after because tmpArr only stores values
             } else {
@@ -749,8 +750,8 @@ int cpp_readColumnByName(const char* filename, void* chpl_arr, const char* colna
           (void)reader->ReadBatch(batchSize, def_lvl, rep_lvl, tmpArr, &values_read);
           // copy values into our Chapel array
           for (int64_t j = 0; j < batchSize; j++){
-            std::cout << "j = " << j << " Def Lvl: " << def_lvl[j] << " Rep Lvl: " << rep_lvl[j];
-            if (max_def != 0 && def_lvl[j] == 0) { // when definition level is 0, mean Null which equated to NaN here
+            // when definition level is 0, mean Null which equated to NaN here unless 0 is the max meaning no null/nan values
+            if (max_def != 0 && def_lvl[j] == 0) {
               chpl_ptr[i] = NAN;
               idx_adjust++; // account for the NaN at the indexes after because tmpArr only stores values
             } else {


### PR DESCRIPTION
Closes #2015 

Previously Parquet read workflows for `float` and `double` types were updated to allow reading of NaN values. This update only read value by value, which is not the most efficient. This PR updates these workflows to read in batches and identify the NaN values using the definition level and a temporary array. Because we are able to read the data in chunks and then process/set the return, performance is improved. It is also worth noting that List columns (used for SegArrays) do not require a check of the Definition Level to set NaN values.

The example runtimes below were run on a single locale with a DataFrame containing 2 columns, one with all NaN values and one with some NaN values. The DataFrame contained 10**8 rows.

**Before this PR**
```
Runtime: 4.234747886657715
```

**After this PR**
```
Runtime: 1.29227876663208
```