### PR TITLE
Closes #2337 - Fixes `ak.DataFrame.to_parquet` with IPv4 Columns

### DIFF
--- a/arkouda/dtypes.py
+++ b/arkouda/dtypes.py
@@ -32,6 +32,7 @@ __all__ = [
     "all_scalars",
     "get_byteorder",
     "get_server_byteorder",
+    "isSupportedNumber"
 ]
 
 NUMBER_FORMAT_STRINGS = {

--- a/arkouda/message.py
+++ b/arkouda/message.py
@@ -7,8 +7,7 @@ from typing import Dict
 
 from typeguard import typechecked
 
-import arkouda
-from arkouda.dtypes import bigint
+from arkouda.dtypes import bigint, all_scalars
 
 
 class ObjectType(Enum):
@@ -135,7 +134,7 @@ class ParameterObject:
                     or isinstance(p, Strings)
                     or isinstance(p, SegArray)
                     or isinstance(p, str)
-                    or isinstance(p, arkouda.dtypes.all_scalars)
+                    or isinstance(p, all_scalars)
                 ):
                     raise TypeError(
                         f"List parameters must be pdarray, Strings, SegArray, str or a type "
@@ -143,7 +142,7 @@ class ParameterObject:
                         f"does not meet that criteria."
                     )
             t = "mixed"
-        data = [str(p) if isinstance(p, arkouda.dtypes.all_scalars) else p.name for p in val]
+        data = [str(p) if isinstance(p, all_scalars) else p.name for p in val]
         return ParameterObject(key, ObjectType.LIST, t, json.dumps(data))
 
     @staticmethod

--- a/arkouda/message.py
+++ b/arkouda/message.py
@@ -108,11 +108,8 @@ class ParameterObject:
         import numpy as np
 
         return (
-            isinstance(val, str)
-            or isinstance(val, np.str_)
+            isinstance(val, (str, np.str_, builtins.bool, np.bool_))
             or isSupportedNumber(val)
-            or isinstance(val, builtins.bool)
-            or isinstance(val, np.bool_)
         )
 
     @staticmethod
@@ -143,9 +140,7 @@ class ParameterObject:
         else:
             for p in val:
                 if not (
-                    isinstance(p, pdarray)
-                    or isinstance(p, Strings)
-                    or isinstance(p, SegArray)
+                    isinstance(p, (pdarray, Strings, SegArray))
                     or ParameterObject._is_supported_value(p)
                 ):
                     raise TypeError(

--- a/arkouda/message.py
+++ b/arkouda/message.py
@@ -134,7 +134,7 @@ class ParameterObject:
                     or isinstance(p, Strings)
                     or isinstance(p, SegArray)
                     or isinstance(p, str)
-                    or isinstance(p, all_scalars)
+                    or isinstance(p, all_scalars)  # type: ignore
                 ):
                     raise TypeError(
                         f"List parameters must be pdarray, Strings, SegArray, str or a type "
@@ -142,7 +142,7 @@ class ParameterObject:
                         f"does not meet that criteria."
                     )
             t = "mixed"
-        data = [str(p) if isinstance(p, all_scalars) else p.name for p in val]
+        data = [str(p) if isinstance(p, all_scalars) else p.name for p in val]  # type: ignore
         return ParameterObject(key, ObjectType.LIST, t, json.dumps(data))
 
     @staticmethod

--- a/arkouda/message.py
+++ b/arkouda/message.py
@@ -106,11 +106,14 @@ class ParameterObject:
     def _is_supported_value(val):
         import builtins
         import numpy as np
-        return (isinstance(val, str)
-                or isinstance(val, np.str_)
-                or isSupportedNumber(val)
-                or isinstance(val, builtins.bool)
-                or isinstance(val, np.bool_))
+
+        return (
+            isinstance(val, str)
+            or isinstance(val, np.str_)
+            or isSupportedNumber(val)
+            or isinstance(val, builtins.bool)
+            or isinstance(val, np.bool_)
+        )
 
     @staticmethod
     @typechecked
@@ -151,7 +154,7 @@ class ParameterObject:
                         f"does not meet that criteria."
                     )
             t = "mixed"
-        data = [str(p) if ParameterObject._is_supported_value(p) else p.name for p in val]  # type: ignore
+        data = [str(p) if ParameterObject._is_supported_value(p) else p.name for p in val]
         return ParameterObject(key, ObjectType.LIST, t, json.dumps(data))
 
     @staticmethod

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -666,3 +666,40 @@ class DataFrameTest(ArkoudaTest):
         slice_idx = df[:]
         slice_idx.__repr__()
         self.assertListEqual(slice_idx.index.index.to_list(), idx.to_list())
+
+    def test_ipv4_columns(self):
+        # test with single IPv4 column
+        df = ak.DataFrame({
+            'a': ak.arange(10),
+            'b': ak.IPv4(ak.arange(10))
+        })
+        with tempfile.TemporaryDirectory(dir=DataFrameTest.df_test_base_tmp) as tmp_dirname:
+            fname = tmp_dirname + "/ipv4_df"
+            df.to_parquet(fname)
+
+            data = ak.read(fname+"*")
+            rddf = ak.DataFrame({
+                'a': data['a'],
+                'b': ak.IPv4(data['b'])
+            })
+
+            self.assertListEqual(df['a'].to_list(), rddf['a'].to_list())
+            self.assertListEqual(df['b'].to_list(), rddf['b'].to_list())
+
+        # test with multiple
+        df = ak.DataFrame({
+            'a': ak.IPv4(ak.arange(10)),
+            'b': ak.IPv4(ak.arange(10))
+        })
+        with tempfile.TemporaryDirectory(dir=DataFrameTest.df_test_base_tmp) as tmp_dirname:
+            fname = tmp_dirname + "/ipv4_df"
+            df.to_parquet(fname)
+
+            data = ak.read(fname + "*")
+            rddf = ak.DataFrame({
+                'a': ak.IPv4(data['a']),
+                'b': ak.IPv4(data['b'])
+            })
+
+            self.assertListEqual(df['a'].to_list(), rddf['a'].to_list())
+            self.assertListEqual(df['b'].to_list(), rddf['b'].to_list())


### PR DESCRIPTION
Closes #2337 

This PR adjusts the message parameter creation workflow to better support lists containing varying types. This allows IPv4 to properly be saved. 

As an additional note, this should make things much more flexible overall with list parameters for messages.

Adds testing to ensure 1 or more IPv4 columns can be saved in a dataframe.