### PR TITLE
Eliminate some communication from datetime methods

### DIFF
--- a/src/TimeClassMsg.chpl
+++ b/src/TimeClassMsg.chpl
@@ -20,14 +20,14 @@ module TimeClassMsg {
     // The first 13 entries give the month days elapsed as of the first of month N
     // (or the total number of days in the year for N=13) in non-leap years.
     // The remaining 13 entries give the days elapsed in leap years.
-    const MONTHOFFSET = [
+    const MONTHOFFSET = (
         0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365,
         0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366
-    ];
+    );
 
     // To get UNITS do (values // (PROD_PREVIOUS_FACTORS)) % CURRENT_FACTOR
     // for example seconds = (values // (1000*1000*1000)) % 60
-    const FACTORS = [
+    const FACTORS = (
         1000,  // nanosecond
         1000,  // microsecond
         1000,  // millisecond
@@ -35,9 +35,9 @@ module TimeClassMsg {
         60,  // minute
         24,  // hour
         7,  // day
-    ];
+    );
 
-    const UNITS = ["nanosecond", "microsecond", "millisecond", "second", "minute", "hour", "day"];
+    const UNITS = ("nanosecond", "microsecond", "millisecond", "second", "minute", "hour", "day");
 
     proc dateTimeAttributesMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         var values: borrowed GenSymEntry = getGenericTypedArrayEntry(msgArgs.getValueOf("values"), st);
@@ -49,16 +49,19 @@ module TimeClassMsg {
         var month: [valDom] int;
         var day: [valDom] int;
         var isoYear: [valDom] int;
+        var is_leap_year: [valDom] bool;
         var weekOfYear: [valDom] int;
+        var dayOfYear: [valDom] int;
         var dayOfWeek: [valDom] int;
-        forall (v, y, m, d, iso_y, woy, dow) in zip(valuesEntry.a, year, month, day, isoYear, weekOfYear, dayOfWeek) {
+
+        forall (v, y, m, d, iso_y, is_ly, woy, doy, dow) in zip(valuesEntry.a, year, month, day, isoYear, is_leap_year, weekOfYear, dayOfYear, dayOfWeek) {
             // convert to seconds and create date
             var t = date.fromTimestamp(floorDivisionHelper(v, 10**9):int);
             (y, m, d, (iso_y, woy, dow)) = (t.year, t.month, t.day, t.isoCalendar());
             dow -= 1;
+            is_ly = isLeapYear(y);
+            doy = MONTHOFFSET[is_ly * 13 + m - 1] + d;
         }
-        const is_leap_year: [valDom] bool = isLeapYear(year);
-        const dayOfYear: [valDom] int = MONTHOFFSET[is_leap_year * 13 + month - 1] + day;
 
         var retname = st.nextName();
         st.addEntry(retname, new shared SymEntry(day));


### PR DESCRIPTION
Previously, helper arrays like `MONTHOFFSET` required communication from non-0 locales because they were arrays declared on locale 0. This resulted in a significant amount of communication for datetime methods running on non-0 locales.

Here, switch helper arrays to tuples, which eliminates comm because the Chapel compiler knows how to serialize tuples and since they're consts that allows Chapel to broadcast/replicate the tuples to remote locales a program startup and later uses will refer to the replicated locale private version instead of doing communication. This is similar to what was done upstream in chapel-lang/chapel#22050 for helper arrays in the datetime module. Ideally, Chapel would be able to replicate/broadcast small const arrays too, but it doesn't have support for that today.

Part of #2317