### PR TITLE
Closes #2348 - Fixes `IPv4` Removal from DataFrame

### DIFF
--- a/arkouda/client_dtypes.py
+++ b/arkouda/client_dtypes.py
@@ -5,7 +5,7 @@ from typing import Optional, Union
 import numpy as np  # type: ignore
 from typeguard import typechecked
 
-from arkouda.dtypes import bitType, intTypes, isSupportedInt
+from arkouda.dtypes import bitType, intTypes, isSupportedInt, uint64 as akuint64
 from arkouda.groupbyclass import GroupBy, broadcast
 from arkouda.numeric import cast as akcast
 from arkouda.numeric import where
@@ -455,6 +455,9 @@ class IPv4(pdarray):
             self.values.shape,
             self.values.itemsize,
         )
+
+    def export_uint(self):
+        return akcast(self.values, akuint64)
 
     def format(self, x):
         """

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -703,3 +703,10 @@ class DataFrameTest(ArkoudaTest):
 
             self.assertListEqual(df['a'].to_list(), rddf['a'].to_list())
             self.assertListEqual(df['b'].to_list(), rddf['b'].to_list())
+
+        # test replacement of IPv4 with uint representation
+        df = ak.DataFrame({
+            'a': ak.IPv4(ak.arange(10))
+        })
+        df['a'] = df['a'].export_uint()
+        self.assertListEqual(ak.arange(10).to_list(), df['a'].to_list())


### PR DESCRIPTION
Closes #2348 

This PR allows for an IPv4 column in a DataFrame to be replaced with its `uint` representation. The issue that prevented this is that the IPv4 went out of scope and resulted in the symbol table entry being removed. In order to prevent every call to `.values` from creating a new pdarray, the function, `export_uint()` was added to the IPv4 class. This simply takes the user's supplied work around to generate a new pdarray reference and wraps it so only a single function is needed.

**Before PR**
The below code would complete, but the symbol table reference to the pdarray would be removed because the original object reference was removed, which caused issues with further processing
```python
df=ak.DataFrame({ "ip":ak.IPv4(ak.arange(10)) })
df['ip'] = df['ip'].values
```

**After PR**
A copy of the original `IPv4.values` array is created and allows for normal processing.
```python
df=ak.DataFrame({ "ip":ak.IPv4(ak.arange(10)) })
df['ip'] = df['ip'].export_uint()
```