### PR TITLE
Closes #2350 - Fixes DataFrame Column Subset

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -399,6 +399,7 @@ class DataFrame(UserDict):
                     result.data[k] = UserDict.__getitem__(self, k)
                     result._columns.append(k)
                 result._empty = False
+                result._set_index(self.index)  # column lens remain the same. Copy the indexing
                 return result
             else:
                 raise TypeError(

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -710,3 +710,15 @@ class DataFrameTest(ArkoudaTest):
         })
         df['a'] = df['a'].export_uint()
         self.assertListEqual(ak.arange(10).to_list(), df['a'].to_list())
+    def test_subset(self):
+        df = ak.DataFrame({
+            'a': ak.arange(100),
+            'b': ak.randint(0, 20, 100),
+            'c': ak.random_strings_uniform(0, 16, 100),
+            'd': ak.randint(25, 75, 100)
+        })
+        df2 = df[['a', 'b']]
+        self.assertListEqual(['a', 'b'], df2.columns)
+        self.assertListEqual(df.index.to_list(), df2.index.to_list())
+        self.assertListEqual(df['a'].to_list(), df2['a'].to_list())
+        self.assertListEqual(df['b'].to_list(), df2['b'].to_list())


### PR DESCRIPTION
Closes #2350 

Adds code to set the index of the resulting DataFrame. Since the DataFrame is created first and then columns added when a list of columns is provided, we need to set the index once it is built. It is configured to use the same index as the DataFrame the columns are being accessed from.

Adds testing.