### PR TITLE
Closes #2366: Update graph files after IO benchmark changes

### DIFF
--- a/benchmarks/graph_infra/arkouda.graph
+++ b/benchmarks/graph_infra/arkouda.graph
@@ -102,13 +102,13 @@ ylabel: Performance (GiB/s)
 
 perfkeys: write Average rate none =, write Average rate snappy =, write Average rate gzip =, write Average rate brotli =, write Average rate zstd =, write Average rate lz4 =, read Average rate none =, read Average rate snappy =, read Average rate gzip =, read Average rate brotli =, read Average rate zstd =, read Average rate lz4 =
 graphkeys: Write no compression GiB/s, Write snappy GiB/s, Write gzip GiB/s, Write brotli GiB/s, Write zstd GiB/s, Write lz4 GiB/s, Read no compression GiB/s, Read snappy GiB/s, Read gzip GiB/s, Read brotli GiB/s, Read zstd GiB/s, Read lz4 GiB/s
-files: parquetIO.dat, parquetIO.dat
+repeat-files: parquetIO.dat
 graphtitle: Parquet IO Performance
 ylabel: Performance (GiB/s)
 
 perfkeys: write Average rate none =, write Average rate snappy =, write Average rate gzip =, write Average rate brotli =, write Average rate zstd =, write Average rate lz4 =, read Average rate none =, read Average rate snappy =, read Average rate gzip =, read Average rate brotli =, read Average rate zstd =, read Average rate lz4 =
 graphkeys: Write no compression GiB/s, Write snappy GiB/s, Write gzip GiB/s, Write brotli GiB/s, Write zstd GiB/s, Write lz4 GiB/s, Read no compression GiB/s, Read snappy GiB/s, Read gzip GiB/s, Read brotli GiB/s, Read zstd GiB/s, Read lz4 GiB/s
-files: parquetMultiIO.dat, parquetMultiIO.dat
+repeat-files: parquetMultiIO.dat
 graphtitle: Parquet 10 Files/Loc IO Performance
 ylabel: Performance (GiB/s)
 


### PR DESCRIPTION
Now that the IO benchmark is saving all of the different compression performance data, the graph file needs to be updated so that we are also graphing those new data points.