### PR TITLE
Closes #2368 - Cleans up Strings references in SegArray

### DIFF
--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -188,6 +188,8 @@ class SegArray:
         # validate inputs
         if not isinstance(segments, pdarray) or segments.dtype != akint64:
             raise TypeError("Segments must be int64 pdarray")
+        if not isinstance(values, pdarray):
+            raise TypeError("Values must be a pdarray.")
         if not is_sorted(segments):
             raise ValueError("Segments must be unique and in sorted order")
         if segments.size > 0:

--- a/tests/segarray_test.py
+++ b/tests/segarray_test.py
@@ -294,13 +294,6 @@ class SegArrayTest(ArkoudaTest):
         with self.assertRaises(ValueError):
             segarr.set_jth(1, 4, 999)
 
-        s = ak.array(["abc", "123"])
-        s_segments = ak.array([0])
-        segarr = ak.segarray(s_segments, s)
-
-        with self.assertRaises(TypeError):
-            segarr.set_jth(0, 0, "test")
-
     def test_get_length_n(self):
         a = [10, 11, 12, 13, 14, 15]
         b = [20, 21]


### PR DESCRIPTION
Closes #2368 

Because SegArrays built on SegStrings objects is not fully supported, we are removing the current references to SegStrings within the SegArray workflows.

Currently, I do not believe there is a need for SegStrings support by SegArray, but if I am wrong, I would prefer to fully develop the solution rather than leaving these scattered pieces in our code base.