### PR TITLE
Closes #2370 - Fixes Deprecation Warnings during `make` 

### DIFF
--- a/src/MetricsMsg.chpl
+++ b/src/MetricsMsg.chpl
@@ -204,7 +204,7 @@ module MetricsMsg {
          * metric name, setting the value if the metric does not exist.
          */
         proc add(metric: string, measurement: real) throws {
-            this.measurements.set(metric,(this.get(metric) + measurement));
+            this.measurements.replace(metric,(this.get(metric) + measurement));
         }
 
         iter items() {

--- a/src/compat/e-128/ArkoudaMapCompat.chpl
+++ b/src/compat/e-128/ArkoudaMapCompat.chpl
@@ -19,5 +19,9 @@ module ArkoudaMapCompat {
     proc const writeThis(ch) throws {
       m.writeThis(ch);
     }
+
+    proc replace(k: keyType, in v: valType):bool {
+      return m.set(k, v);
+    }
   }
 }

--- a/src/compat/e-129/ArkoudaMapCompat.chpl
+++ b/src/compat/e-129/ArkoudaMapCompat.chpl
@@ -19,5 +19,9 @@ module ArkoudaMapCompat {
     proc const writeThis(ch) throws {
       m.writeThis(ch);
     }
+
+    proc replace(k: keyType, in v: valType):bool {
+      return m.set(k, v);
+    }
   }
 }


### PR DESCRIPTION
Closes #2370 

Updates call from `Map.set` to `Map.replace` to remove deprecation warnings being seen when running `make` on Arkouda.