### PR TITLE
Closes #2374: Pin hdf5 version to 1.12.2

### DIFF
--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -12,6 +12,7 @@ dependencies:
   - versioneer
   - matplotlib>=3.3.2
   - h5py>=3.7.0
+  - hdf5==1.12.2
   - pip
   - types-tabulate
   - pytables>=3.7.0

--- a/arkouda-env.yml
+++ b/arkouda-env.yml
@@ -12,6 +12,7 @@ dependencies:
   - versioneer
   - matplotlib>=3.3.2
   - h5py>=3.7.0
+  - hdf5==1.12.2
   - pip
   - types-tabulate
   - pytables>=3.7.0

--- a/pydoc/requirements.txt
+++ b/pydoc/requirements.txt
@@ -9,6 +9,7 @@ pyfiglet
 versioneer
 matplotlib>=3.3.2
 h5py>=3.7.0
+hdf5==1.12.2
 pip
 types-tabulate
 tables>=3.7.0

--- a/pydoc/setup/REQUIREMENTS.md
+++ b/pydoc/setup/REQUIREMENTS.md
@@ -27,6 +27,7 @@ The following python packages are required by the Arkouda client package.
 - `versioneer`
 - `matplotlib>=3.3.2`
 - `h5py>=3.7.0`
+- `hdf5==1.12.2`
 - `pip`
 - `types-tabulate`
 - `tables>=3.7.0`


### PR DESCRIPTION
This PR (closes #2374) pins the hdf5 version specified in the yaml files to `1.12.2`

Verified building a new conda env with yaml does have the specified version
```
% conda env create -n testing -f arkouda-env-dev.yml
% conda activate testing 

# updated Makefile.paths to point to testing

% conda list hdf                                    
# packages in environment at /opt/homebrew/Caskroom/miniforge/base/envs/testing:
#
# Name                    Version                   Build  Channel
hdf5                      1.12.2          nompi_ha7af310_101    conda-forge

% make check-hdf5 
Checking for HDF5
Success compiling program
/Users/pierce/proj/arkouda//dep/check-hdf5 -nl 1
Found HDF5 version: 1.12.2
```

I made arkouda and verified that `make test` was successful