### PR TITLE
Closes #2304 - Innerjoin support for Strings and Categorical

### DIFF
--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -1612,13 +1612,13 @@ class GroupBy:
                     "permName": self.permutation.name,
                     "segName": self.segments.name,
                     "valName": values.name,
-                    "objType": values.objtype,
+                    "objType": values.objType,
                     "permute": permute,
                     "size": self.length,
                 },
             ),
         )
-        if values.objtype == Strings.objtype:
+        if values.objType == Strings.objType:
             return Strings.from_return_msg(repMsg)
         else:
             return create_pdarray(repMsg)
@@ -2109,13 +2109,13 @@ def broadcast(
                 "permName": pname,
                 "segName": segments.name,
                 "valName": values.name,
-                "objType": values.objtype,
+                "objType": values.objType,
                 "permute": permute,
                 "size": size,
             },
         ),
     )
-    if values.objtype == Strings.objtype:
+    if values.objType == Strings.objType:
         return Strings.from_return_msg(repMsg)
     else:
         return create_pdarray(repMsg)

--- a/arkouda/join.py
+++ b/arkouda/join.py
@@ -13,6 +13,7 @@ from arkouda.numeric import cumsum
 from arkouda.pdarrayclass import create_pdarray, pdarray
 from arkouda.pdarraycreation import arange, array, ones, zeros
 from arkouda.pdarraysetops import concatenate, in1d
+from arkouda.strings import Strings
 
 __all__ = ["join_on_eq_with_dt", "gen_ranges", "compute_join_size"]
 
@@ -169,7 +170,8 @@ def compute_join_size(a: pdarray, b: pdarray) -> Tuple[int, int]:
 
 @typechecked
 def inner_join(
-    left: pdarray, right: pdarray, wherefunc: Callable = None, whereargs: Tuple[pdarray, pdarray] = None
+    left: Union[pdarray, Strings], right: Union[pdarray, Strings], wherefunc: Callable = None,
+        whereargs: Tuple[Union[pdarray, Strings], Union[pdarray, Strings]] = None
 ) -> Tuple[pdarray, pdarray]:
     """Perform inner join on values in <left> and <right>,
     using conditions defined by <wherefunc> evaluated on
@@ -177,9 +179,9 @@ def inner_join(
 
     Parameters
     ----------
-    left : pdarray(int64)
+    left : pdarray(int64), Strings
         The left values to join
-    right : pdarray(int64)
+    right : pdarray(int64), Strings
         The right values to join
     wherefunc : function, optional
         Function that takes two pdarray arguments and returns
@@ -204,6 +206,9 @@ def inner_join(
 
     """
     from inspect import signature
+
+    if type(left) != type(right):
+        raise TypeError("Left and Right arrays must be of same type")
 
     sample = np.min((left.size, right.size, 5))  # type: ignore
     if wherefunc is not None:

--- a/arkouda/join.py
+++ b/arkouda/join.py
@@ -3,7 +3,7 @@ from typing import Callable, Tuple, Union, cast
 import numpy as np  # type: ignore
 from typeguard import typechecked
 
-from arkouda.alignment import right_align
+from arkouda.alignment import right_align, align
 from arkouda.categorical import Categorical
 from arkouda.client import generic_msg
 from arkouda.dtypes import NUMBER_FORMAT_STRINGS
@@ -213,25 +213,16 @@ def inner_join(
     if type(left) != type(right):
         raise TypeError("Left and Right arrays must be of same type")
 
-    # Convert Strings and Categorical left & right values to Categorical.codes. This generates an
-    # index representation of the strings. This way they can be handled as numerics and follow the
-    # same process as int
-    t = cast(str, pdarray.objtype)
-    cats = None
+    whereLeft = whereRight = None
+    if whereargs is not None:
+        whereLeft, whereRight = whereargs[0:2]
 
-    if isinstance(left, Strings) and isinstance(right, Strings):
-        left = Categorical(left)
-        right = Categorical(right)
+    if (isinstance(left, Strings) and isinstance(right, Strings)) or \
+            (isinstance(left, Categorical) and isinstance(right, Categorical)):
 
-    if isinstance(left, Categorical) and isinstance(right, Categorical):
-        t = cast(str, Categorical.objtype)
-        left, right = Categorical.standardize_categories([left, right])
-        if isinstance(left, Categorical) and isinstance(right, Categorical):
-            cats = left.categories[left.codes]  # Get standardized categories without NAvalue
-            leftKeepCodes = left.isna() == 0  # Invert bool array
-            rightKeepCodes = right.isna() == 0  # Invert bool array
-            left = left.codes[leftKeepCodes]
-            right = right.codes[rightKeepCodes]
+        left, right = align(left, right)
+        if whereargs is not None:
+            whereLeft, whereRight = align(whereLeft, whereRight)
 
     sample = np.min((left.size, right.size, 5))  # type: ignore
     if wherefunc is not None:
@@ -239,14 +230,14 @@ def inner_join(
             raise ValueError("wherefunc must be a function that accepts exactly two arguments")
         if whereargs is None or len(whereargs) != 2:
             raise ValueError("whereargs must be a 2-tuple with left and right arg arrays")
-        if whereargs[0].size != left.size:
+        if whereLeft.size != left.size:
             raise ValueError("Left whereargs must be same size as left join values")
-        if whereargs[1].size != right.size:
+        if whereRight.size != right.size:
             raise ValueError("Right whereargs must be same size as right join values")
-        if isinstance(whereargs[0], Strings) and t == pdarray.objtype:
+        if isinstance(whereLeft, Strings) and isinstance(left, pdarray):
             raise TypeError("Strings whereargs are only supported for Strings left and right arg arrays")
         try:
-            _ = wherefunc(whereargs[0][:sample], whereargs[1][:sample])
+            _ = wherefunc(whereLeft[:sample], whereRight[:sample])
         except Exception as e:
             raise ValueError("Error evaluating wherefunc") from e
 
@@ -271,43 +262,10 @@ def inner_join(
         keep12 = keep
     else:
         if whereargs is not None:
-            if (
-                t == Categorical.objtype
-                and isinstance(cats, Strings)
-                and isinstance(whereargs[0], Strings)
-            ):
-                # Find the corresponding codes value for each term in the whereargs
-                repMsg = generic_msg(
-                    cmd="codeMapping",
-                    args={
-                        "categories": cats,
-                        "query": whereargs[0][keep],  # type: ignore
-                    },
-                )
-                lCodes = create_pdarray(repMsg)
-
-                if isinstance(lCodes, pdarray):
-                    lIdx = broadcast(fullSegs, lCodes, ranges.size)
-                else:
-                    raise TypeError(
-                        f"Invalid type returned from lCodes generation: {type(lCodes)}. Expected pdarray"
-                    )
-                leftWhere = whereargs[0][lIdx]
-                # Gather right whereargs
-                repMsg = generic_msg(
-                    cmd="codeMapping",
-                    args={
-                        "categories": cats,
-                        "query": whereargs[1][byRight.permutation][ranges],  # type: ignore
-                    },
-                )
-                rCodes = create_pdarray(repMsg)
-                rightWhere = whereargs[1][rCodes]
-            else:
-                # Expand left whereargs
-                leftWhere = broadcast(fullSegs, whereargs[0][keep], ranges.size)
-                # Gather right whereargs
-                rightWhere = whereargs[1][byRight.permutation][ranges]
+            # Expand left whereargs
+            leftWhere = broadcast(fullSegs, whereLeft[keep], ranges.size)
+            # Gather right whereargs
+            rightWhere = whereRight[byRight.permutation][ranges]
 
             # Evaluate wherefunc and filter ranges, recompute segments
             whereSatisfied = wherefunc(leftWhere, rightWhere)

--- a/arkouda/join.py
+++ b/arkouda/join.py
@@ -184,14 +184,14 @@ def inner_join(
     ----------
     left : pdarray(int64), Strings, Categorical
         The left values to join
-    right : pdarray(int64), Strings
+    right : pdarray(int64), Strings, Categorical
         The right values to join
     wherefunc : function, optional
         Function that takes two pdarray arguments and returns
         a pdarray(bool) used to filter the join. Results for
         which wherefunc is False will be dropped.
-    whereargs : 2-tuple of pdarray
-        The two pdarray arguments to wherefunc
+    whereargs : 2-tuple of pdarray, Strings
+        The two pdarray or Strings arguments to wherefunc
 
     Returns
     -------

--- a/arkouda/join.py
+++ b/arkouda/join.py
@@ -181,9 +181,9 @@ def inner_join(
     <whereargs>, returning indices of left-right pairs.
     Parameters
     ----------
-    left : pdarray(int64)
+    left : pdarray(int64), Strings
         The left values to join
-    right : pdarray(int64)
+    right : pdarray(int64), Strings
         The right values to join
     wherefunc : function, optional
         Function that takes two pdarray arguments and returns
@@ -204,6 +204,9 @@ def inner_join(
     `assert wherefunc(whereargs[0][leftInds], whereargs[1][rightInds]).all()`
     """
     from inspect import signature
+
+    if type(left) != type(right):
+        raise TypeError("Left and Right arrays must be of same type")
 
     sample = np.min((left.size, right.size, 5))  # type: ignore
     if wherefunc is not None:

--- a/arkouda/join.py
+++ b/arkouda/join.py
@@ -245,9 +245,8 @@ def inner_join(
             rightWhere = whereargs[1][byRight.permutation][ranges]
             # Expand left whereargs
             keep_where = whereargs[0][keep]
-            if isinstance(keep_where, (Strings, Categorical)):
-                leftWhereIdx = broadcast(fullSegs, arange(keep_where.size), ranges.size)
-                leftWhere = keep_where[leftWhereIdx]
+            if isinstance(keep_where, Categorical):
+                leftWhere = broadcast(fullSegs, keep_where.codes, ranges.size)
             else:
                 leftWhere = broadcast(fullSegs, keep_where, ranges.size)
             # Evaluate wherefunc and filter ranges, recompute segments

--- a/arkouda/join.py
+++ b/arkouda/join.py
@@ -3,7 +3,7 @@ from typing import Callable, Tuple, Union, cast
 import numpy as np  # type: ignore
 from typeguard import typechecked
 
-from arkouda.alignment import right_align, align
+from arkouda.alignment import align, right_align
 from arkouda.categorical import Categorical
 from arkouda.client import generic_msg
 from arkouda.dtypes import NUMBER_FORMAT_STRINGS
@@ -217,8 +217,9 @@ def inner_join(
     if whereargs is not None:
         whereLeft, whereRight = whereargs[0:2]
 
-    if (isinstance(left, Strings) and isinstance(right, Strings)) or \
-            (isinstance(left, Categorical) and isinstance(right, Categorical)):
+    if (isinstance(left, Strings) and isinstance(right, Strings)) or (
+        isinstance(left, Categorical) and isinstance(right, Categorical)
+    ):
 
         left, right = align(left, right)
         if whereargs is not None:
@@ -230,16 +231,17 @@ def inner_join(
             raise ValueError("wherefunc must be a function that accepts exactly two arguments")
         if whereargs is None or len(whereargs) != 2:
             raise ValueError("whereargs must be a 2-tuple with left and right arg arrays")
-        if whereLeft.size != left.size:
+        if whereLeft is not None and whereLeft.size != left.size:
             raise ValueError("Left whereargs must be same size as left join values")
-        if whereRight.size != right.size:
+        if whereRight is not None and whereRight.size != right.size:
             raise ValueError("Right whereargs must be same size as right join values")
         if isinstance(whereLeft, Strings) and isinstance(left, pdarray):
             raise TypeError("Strings whereargs are only supported for Strings left and right arg arrays")
-        try:
-            _ = wherefunc(whereLeft[:sample], whereRight[:sample])
-        except Exception as e:
-            raise ValueError("Error evaluating wherefunc") from e
+        if whereLeft is not None and whereRight is not None:
+            try:
+                _ = wherefunc(whereLeft[:sample], whereRight[:sample])
+            except Exception as e:
+                raise ValueError("Error evaluating wherefunc") from e
 
     # Need dense 0-up right index, to filter out left not in right
     keep, (denseLeft, denseRight) = right_align(left, right)
@@ -261,7 +263,7 @@ def inner_join(
         filtSegs = fullSegs
         keep12 = keep
     else:
-        if whereargs is not None:
+        if whereLeft is not None and whereRight is not None:
             # Expand left whereargs
             leftWhere = broadcast(fullSegs, whereLeft[keep], ranges.size)
             # Gather right whereargs

--- a/arkouda/join.py
+++ b/arkouda/join.py
@@ -183,14 +183,15 @@ def inner_join(
     ----------
     left : pdarray(int64), Strings, Categorical
         The left values to join
-    right : pdarray(int64), Strings
+    right : pdarray(int64), Strings, Categorical
         The right values to join
     wherefunc : function, optional
         Function that takes two pdarray arguments and returns
         a pdarray(bool) used to filter the join. Results for
         which wherefunc is False will be dropped.
-    whereargs : 2-tuple of pdarray
-        The two pdarray arguments to wherefunc
+    whereargs : 2-tuple of pdarray, Strings
+        The two pdarray or Strings arguments to wherefunc
+
     Returns
     -------
     leftInds : pdarray(int64)

--- a/arkouda/join.py
+++ b/arkouda/join.py
@@ -205,6 +205,12 @@ def inner_join(
     """
     from inspect import signature
 
+    # Reduce processing to codes to prevent groupbys being ran on entire Categorical
+    if isinstance(left, Categorical) and isinstance(right, Categorical):
+        l, r = Categorical.standardize_categories([left, right])
+        left = l.codes
+        right = r.codes
+
     sample = np.min((left.size, right.size, 5))  # type: ignore
     if wherefunc is not None:
         if len(signature(wherefunc).parameters) != 2:

--- a/arkouda/join.py
+++ b/arkouda/join.py
@@ -222,11 +222,16 @@ def inner_join(
     if isinstance(left, Categorical) and isinstance(right, Categorical):
         t = cast(str, Categorical.objtype)
         left, right = Categorical.standardize_categories([left, right])
-        cats = left.categories[left.codes]  # Get standardized categories without NAvalue
-        leftKeepCodes = array([x is not True for x in left.isna().to_ndarray()])  # Keep codes that aren't NAvalue
-        rightKeepCodes = array([x is not True for x in right.isna().to_ndarray()])  # Keep codes that aren't NAvalue
-        left = left.codes[leftKeepCodes]
-        right = right.codes[rightKeepCodes]
+        if isinstance(left, Categorical) and isinstance(right, Categorical):
+            cats = left.categories[left.codes]  # Get standardized categories without NAvalue
+            leftKeepCodes = array(
+                [x is not True for x in left.isna().to_ndarray()]
+            )  # Keep codes that aren't NAvalue
+            rightKeepCodes = array(
+                [x is not True for x in right.isna().to_ndarray()]
+            )  # Keep codes that aren't NAvalue
+            left = left.codes[leftKeepCodes]
+            right = right.codes[rightKeepCodes]
 
     sample = np.min((left.size, right.size, 5))  # type: ignore
     if wherefunc is not None:
@@ -271,15 +276,10 @@ def inner_join(
                     args={
                         "categories": cats,
                         "query": whereargs[0][keep],  # type: ignore
-                    })
+                    },
+                )
                 lCodes = create_pdarray(repMsg)
-                # lCodes = array(
-                #     [
-                #         cats.to_list().index(w)
-                #         for w in whereargs[0][keep].to_ndarray()
-                #         if w in cats.to_ndarray()
-                #     ]
-                # )
+
                 if isinstance(lCodes, pdarray):
                     lIdx = broadcast(fullSegs, lCodes, ranges.size)
                 else:
@@ -293,15 +293,9 @@ def inner_join(
                     args={
                         "categories": cats,
                         "query": whereargs[1][byRight.permutation][ranges],  # type: ignore
-                    })
+                    },
+                )
                 rCodes = create_pdarray(repMsg)
-                # rCodes = array(
-                #     [
-                #         cats.to_list().index(w)
-                #         for w in whereargs[1][byRight.permutation][ranges].to_ndarray()
-                #         if w in cats.to_ndarray()
-                #     ]
-                # )
                 rightWhere = whereargs[1][rCodes]
             else:
                 # Expand left whereargs

--- a/arkouda/join.py
+++ b/arkouda/join.py
@@ -217,21 +217,20 @@ def inner_join(
     # index representation of the strings. This way they can be handled as numerics and follow the
     # same process as int
     t = cast(str, pdarray.objtype)
-    lCats = rCats = None
+    cats = None
+
     if isinstance(left, Strings) and isinstance(right, Strings):
-        t = cast(str, Strings.objtype)
-        catLeft = Categorical(left)
-        catRight = Categorical(right)
-        lCats = catLeft.categories
-        rCats = catRight.categories
-        left = catLeft.codes
-        right = catRight.codes
-    elif isinstance(left, Categorical) and isinstance(right, Categorical):
+        left = Categorical(left)
+        right = Categorical(right)
+
+    if isinstance(left, Categorical) and isinstance(right, Categorical):
         t = cast(str, Categorical.objtype)
-        lCats = left.categories
-        rCats = right.categories
-        left = left.codes
-        right = right.codes
+        left, right = Categorical.standardize_categories([left, right])
+        cats = left.categories[left.codes]  # Get standardized categories without NAvalue
+        leftKeepCodes = array([x is not True for x in left.isna().to_ndarray()])  # Keep codes that aren't NAvalue
+        rightKeepCodes = array([x is not True for x in right.isna().to_ndarray()])  # Keep codes that aren't NAvalue
+        left = left.codes[leftKeepCodes]
+        right = right.codes[rightKeepCodes]
 
     sample = np.min((left.size, right.size, 5))  # type: ignore
     if wherefunc is not None:
@@ -269,19 +268,22 @@ def inner_join(
         keep12 = keep
     else:
         if whereargs is not None:
-            if (
-                t in [Strings.objtype, Categorical.objtype]
-                and isinstance(lCats, Strings)
-                and isinstance(rCats, Strings)
-            ):
+            if t == Categorical.objtype and isinstance(cats, Strings):
                 # Find the corresponding codes value for each term in the whereargs
-                lCodes = array(
-                    [
-                        lCats.to_list().index(w)
-                        for w in whereargs[0][keep].to_ndarray()
-                        if w in lCats.to_ndarray()
-                    ]
-                )
+                repMsg = generic_msg(
+                    cmd="codeMapping",
+                    args={
+                        "categories": cats,
+                        "query": whereargs[0][keep],  # type: ignore
+                    })
+                lCodes = create_pdarray(repMsg)
+                # lCodes = array(
+                #     [
+                #         cats.to_list().index(w)
+                #         for w in whereargs[0][keep].to_ndarray()
+                #         if w in cats.to_ndarray()
+                #     ]
+                # )
                 if isinstance(lCodes, pdarray):
                     lIdx = broadcast(fullSegs, lCodes, ranges.size)
                 else:
@@ -290,13 +292,20 @@ def inner_join(
                     )
                 leftWhere = whereargs[0][lIdx]
                 # Gather right whereargs
-                rCodes = array(
-                    [
-                        rCats.to_list().index(w)
-                        for w in whereargs[1][byRight.permutation][ranges].to_ndarray()
-                        if w in rCats.to_ndarray()
-                    ]
-                )
+                repMsg = generic_msg(
+                    cmd="codeMapping",
+                    args={
+                        "categories": cats,
+                        "query": whereargs[1][byRight.permutation][ranges],  # type: ignore
+                    })
+                rCodes = create_pdarray(repMsg)
+                # rCodes = array(
+                #     [
+                #         cats.to_list().index(w)
+                #         for w in whereargs[1][byRight.permutation][ranges].to_ndarray()
+                #         if w in cats.to_ndarray()
+                #     ]
+                # )
                 rightWhere = whereargs[1][rCodes]
             else:
                 # Expand left whereargs

--- a/arkouda/join.py
+++ b/arkouda/join.py
@@ -224,12 +224,8 @@ def inner_join(
         left, right = Categorical.standardize_categories([left, right])
         if isinstance(left, Categorical) and isinstance(right, Categorical):
             cats = left.categories[left.codes]  # Get standardized categories without NAvalue
-            leftKeepCodes = array(
-                [x is not True for x in left.isna().to_ndarray()]
-            )  # Keep codes that aren't NAvalue
-            rightKeepCodes = array(
-                [x is not True for x in right.isna().to_ndarray()]
-            )  # Keep codes that aren't NAvalue
+            leftKeepCodes = left.isna() == 0  # Invert bool array
+            rightKeepCodes = right.isna() == 0  # Invert bool array
             left = left.codes[leftKeepCodes]
             right = right.codes[rightKeepCodes]
 
@@ -243,6 +239,8 @@ def inner_join(
             raise ValueError("Left whereargs must be same size as left join values")
         if whereargs[1].size != right.size:
             raise ValueError("Right whereargs must be same size as right join values")
+        if isinstance(whereargs[0], Strings) and t == pdarray.objtype:
+            raise TypeError("Strings whereargs are only supported for Strings left and right arg arrays")
         try:
             _ = wherefunc(whereargs[0][:sample], whereargs[1][:sample])
         except Exception as e:
@@ -269,7 +267,11 @@ def inner_join(
         keep12 = keep
     else:
         if whereargs is not None:
-            if t == Categorical.objtype and isinstance(cats, Strings):
+            if (
+                t == Categorical.objtype
+                and isinstance(cats, Strings)
+                and isinstance(whereargs[0], Strings)
+            ):
                 # Find the corresponding codes value for each term in the whereargs
                 repMsg = generic_msg(
                     cmd="codeMapping",

--- a/arkouda/join.py
+++ b/arkouda/join.py
@@ -226,11 +226,16 @@ def inner_join(
     if isinstance(left, Categorical) and isinstance(right, Categorical):
         t = cast(str, Categorical.objtype)
         left, right = Categorical.standardize_categories([left, right])
-        cats = left.categories[left.codes]  # Get standardized categories without NAvalue
-        leftKeepCodes = array([x is not True for x in left.isna().to_ndarray()])  # Keep codes that aren't NAvalue
-        rightKeepCodes = array([x is not True for x in right.isna().to_ndarray()])  # Keep codes that aren't NAvalue
-        left = left.codes[leftKeepCodes]
-        right = right.codes[rightKeepCodes]
+        if isinstance(left, Categorical) and isinstance(right, Categorical):
+            cats = left.categories[left.codes]  # Get standardized categories without NAvalue
+            leftKeepCodes = array(
+                [x is not True for x in left.isna().to_ndarray()]
+            )  # Keep codes that aren't NAvalue
+            rightKeepCodes = array(
+                [x is not True for x in right.isna().to_ndarray()]
+            )  # Keep codes that aren't NAvalue
+            left = left.codes[leftKeepCodes]
+            right = right.codes[rightKeepCodes]
 
     sample = np.min((left.size, right.size, 5))  # type: ignore
     if wherefunc is not None:
@@ -275,15 +280,10 @@ def inner_join(
                     args={
                         "categories": cats,
                         "query": whereargs[0][keep],  # type: ignore
-                    })
+                    },
+                )
                 lCodes = create_pdarray(repMsg)
-                # lCodes = array(
-                #     [
-                #         cats.to_list().index(w)
-                #         for w in whereargs[0][keep].to_ndarray()
-                #         if w in cats.to_ndarray()
-                #     ]
-                # )
+
                 if isinstance(lCodes, pdarray):
                     lIdx = broadcast(fullSegs, lCodes, ranges.size)
                 else:
@@ -297,15 +297,9 @@ def inner_join(
                     args={
                         "categories": cats,
                         "query": whereargs[1][byRight.permutation][ranges],  # type: ignore
-                    })
+                    },
+                )
                 rCodes = create_pdarray(repMsg)
-                # rCodes = array(
-                #     [
-                #         cats.to_list().index(w)
-                #         for w in whereargs[1][byRight.permutation][ranges].to_ndarray()
-                #         if w in cats.to_ndarray()
-                #     ]
-                # )
                 rightWhere = whereargs[1][rCodes]
             else:
                 # Expand left whereargs

--- a/arkouda/join.py
+++ b/arkouda/join.py
@@ -181,17 +181,16 @@ def inner_join(
     <whereargs>, returning indices of left-right pairs.
     Parameters
     ----------
-    left : pdarray(int64), Strings, Categorical
+    left : pdarray(int64)
         The left values to join
-    right : pdarray(int64), Strings, Categorical
+    right : pdarray(int64)
         The right values to join
     wherefunc : function, optional
         Function that takes two pdarray arguments and returns
         a pdarray(bool) used to filter the join. Results for
         which wherefunc is False will be dropped.
-    whereargs : 2-tuple of pdarray, Strings
-        The two pdarray or Strings arguments to wherefunc
-
+    whereargs : 2-tuple of pdarray
+        The two pdarray arguments to wherefunc
     Returns
     -------
     leftInds : pdarray(int64)
@@ -206,38 +205,20 @@ def inner_join(
     """
     from inspect import signature
 
-    if type(left) != type(right):
-        raise TypeError("Left and Right arrays must be of same type")
-
-    whereLeft = whereRight = None
-    if whereargs is not None:
-        whereLeft, whereRight = whereargs[0:2]
-
-    if (isinstance(left, Strings) and isinstance(right, Strings)) or (
-        isinstance(left, Categorical) and isinstance(right, Categorical)
-    ):
-
-        left, right = align(left, right)
-        if whereargs is not None:
-            whereLeft, whereRight = align(whereLeft, whereRight)
-
     sample = np.min((left.size, right.size, 5))  # type: ignore
     if wherefunc is not None:
         if len(signature(wherefunc).parameters) != 2:
             raise ValueError("wherefunc must be a function that accepts exactly two arguments")
         if whereargs is None or len(whereargs) != 2:
             raise ValueError("whereargs must be a 2-tuple with left and right arg arrays")
-        if whereLeft is not None and whereLeft.size != left.size:
+        if whereargs[0].size != left.size:
             raise ValueError("Left whereargs must be same size as left join values")
-        if whereRight is not None and whereRight.size != right.size:
+        if whereargs[1].size != right.size:
             raise ValueError("Right whereargs must be same size as right join values")
-        if isinstance(whereLeft, Strings) and isinstance(left, pdarray):
-            raise TypeError("Strings whereargs are only supported for Strings left and right arg arrays")
-        if whereLeft is not None and whereRight is not None:
-            try:
-                _ = wherefunc(whereLeft[:sample], whereRight[:sample])
-            except Exception as e:
-                raise ValueError("Error evaluating wherefunc") from e
+        try:
+            _ = wherefunc(whereargs[0][:sample], whereargs[1][:sample])
+        except Exception as e:
+            raise ValueError("Error evaluating wherefunc") from e
 
     # Need dense 0-up right index, to filter out left not in right
     keep, (denseLeft, denseRight) = right_align(left, right)
@@ -259,12 +240,16 @@ def inner_join(
         filtSegs = fullSegs
         keep12 = keep
     else:
-        if whereLeft is not None and whereRight is not None:
-            # Expand left whereargs
-            leftWhere = broadcast(fullSegs, whereLeft[keep], ranges.size)
+        if whereargs is not None:
             # Gather right whereargs
-            rightWhere = whereRight[byRight.permutation][ranges]
-
+            rightWhere = whereargs[1][byRight.permutation][ranges]
+            # Expand left whereargs
+            keep_where = whereargs[0][keep]
+            if isinstance(keep_where, (Strings, Categorical)):
+                leftWhereIdx = broadcast(fullSegs, arange(keep_where.size), ranges.size)
+                leftWhere = keep_where[leftWhereIdx]
+            else:
+                leftWhere = broadcast(fullSegs, keep_where, ranges.size)
             # Evaluate wherefunc and filter ranges, recompute segments
             whereSatisfied = wherefunc(leftWhere, rightWhere)
             filtRanges = ranges[whereSatisfied]
@@ -282,5 +267,4 @@ def inner_join(
     # Gather right inds and expand left inds
     rightInds = byRight.permutation[filtRanges]
     leftInds = broadcast(filtSegs, arange(left.size)[keep12], filtRanges.size)
-
     return leftInds, rightInds

--- a/arkouda/join.py
+++ b/arkouda/join.py
@@ -3,7 +3,7 @@ from typing import Callable, Tuple, Union, cast
 import numpy as np  # type: ignore
 from typeguard import typechecked
 
-from arkouda.alignment import align, right_align
+from arkouda.alignment import right_align
 from arkouda.categorical import Categorical
 from arkouda.client import generic_msg
 from arkouda.dtypes import NUMBER_FORMAT_STRINGS

--- a/src/Broadcast.chpl
+++ b/src/Broadcast.chpl
@@ -163,13 +163,10 @@ module Broadcast {
     }
 
     var broadDist = broadcast(segs, diffs, size);
-    var offDiff = makeDistArray(size, int);
-    offDiff[1..] = broadDist[..size-2];
-
-    var offsets = (+ scan offDiff);
+    var offsets = (+ scan broadDist) - broadDist;
     var r: [sD] int = 0..segString.size; 
     var ind = broadcast(segs, r, size);
-    var expandedVals: [0..#strSize] uint(8);
+    var expandedVals = makeDistArray(strSize, uint(8));
     ref vals = segString.values.a;
 
     forall (i, o, s) in zip(ind, offsets, 0..#size) with (ref vals) {

--- a/src/Broadcast.chpl
+++ b/src/Broadcast.chpl
@@ -170,11 +170,13 @@ module Broadcast {
     var r: [sD] int = 0..segString.size; 
     var ind = broadcast(segs, r, size);
     var expandedVals = makeDistArray(strSize, uint(8));
+    var agg = newDstAggregator(uint(8));
+    ref vals = segString.values.a;
 
-    forall (i, o, s) in zip(ind, offsets, 0..#size) with (var agg = newDstAggregator(uint(8)), ref vals = segString.values.a) {
+    forall (i, o, s) in zip(ind, offsets, 0..#size) with (ref agg, ref vals) {
       var inds = if i == high then segOff[i]..segString.nBytes-1 else segOff[i]..segOff[i+1]-1;
       var offs = if s == size - 1 then o..strSize-1 else o..offsets[s+1]-1;
-      forall (off, idx) in zip(offs, inds) {
+      forall (off, idx) in zip(offs, inds) with (ref agg, ref vals) {
         agg.copy(expandedVals[off], vals[idx]);
       }
     }

--- a/src/Broadcast.chpl
+++ b/src/Broadcast.chpl
@@ -169,16 +169,13 @@ module Broadcast {
     var offsets = (+ scan offDiff);
     var r: [sD] int = 0..segString.size; 
     var ind = broadcast(segs, r, size);
-    var expandedVals = makeDistArray(strSize, uint(8));
-    var agg = newDstAggregator(uint(8));
+    var expandedVals: [0..#strSize] uint(8);
     ref vals = segString.values.a;
 
-    forall (i, o, s) in zip(ind, offsets, 0..#size) with (ref agg, ref vals) {
+    forall (i, o, s) in zip(ind, offsets, 0..#size) with (ref vals) {
       var inds = if i == high then segOff[i]..segString.nBytes-1 else segOff[i]..segOff[i+1]-1;
       var offs = if s == size - 1 then o..strSize-1 else o..offsets[s+1]-1;
-      forall (off, idx) in zip(offs, inds) with (ref agg, ref vals) {
-        agg.copy(expandedVals[off], vals[idx]);
-      }
+      expandedVals[offs] = vals[inds];
     }
 
     return (expandedVals, offsets);

--- a/src/Broadcast.chpl
+++ b/src/Broadcast.chpl
@@ -181,41 +181,4 @@ module Broadcast {
 
     return (expandedVals, offsets);
   }
-
-  // proc broadcast(segs: [?sD] int, segString: borrowed SegString, size: int) throws {
-  //   var segOff = segString.offsets.a;
-  //   var strSize: int;
-  //   var diffs: [sD] int;
-
-  //   forall (i, seg, off) in zip (sD, segs, segOff) with (+ reduce strSize) {
-  //     if i == sD.low {
-  //       diffs[i] = segOff[i+1] - off;
-  //       strSize = (segs[i+1] - seg) * segOff[i+1];
-  //     } else if i == sD.high {
-  //       strSize += (size - seg) * (segString.nBytes - off);
-  //       diffs[i] = segString.nBytes - off;
-  //     } else {
-  //       strSize += (segs[i+1] - seg) * (segOff[i+1] - off);
-  //       diffs[i] = segOff[i+1] - off;
-  //     }
-  //   }
-
-  //   var broadDist = broadcast(segs, diffs, size);
-  //   var offDiff = makeDistArray(size, int);
-  //   offDiff[1..] = broadDist[..size-2];
-    
-  //   var offsets = (+ scan offDiff);
-  //   var r: [sD] int = 0..segString.size; 
-  //   var ind = broadcast(segs, r, size);
-  //   var expandedVals: [0..#strSize] uint(8);
-
-  //   forall (i, o, s) in zip(ind, offsets, 0..#size) {
-  //     var inds = if i == sD.high then segOff[i]..segString.nBytes-1 else segOff[i]..segOff[i+1]-1;
-  //     var offs = if s == size - 1 then o..strSize-1 else o..offsets[s+1]-1;
-  //     expandedVals[offs] = segString.values.a[inds];
-  //   }
-
-  //   return (expandedVals, offsets);
-  // }
-
 }

--- a/src/JoinEqWithDTMsg.chpl
+++ b/src/JoinEqWithDTMsg.chpl
@@ -377,43 +377,6 @@ module JoinEqWithDTMsg
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }// end joinEqWithDTMsg()
 
-    proc codeMappingMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
-        jeLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"Mapping codes from categories");
-
-        var catName = msgArgs.getValueOf("categories");
-        var queryName = msgArgs.getValueOf("query");
-
-        var catSym = getSegString(catName, st);
-        var querySym = getSegString(queryName, st);
-
-        var querySize = querySym.size;
-        var catSize = catSym.size;
-        var codes: [0..#querySize] int = -1;
-
-        var (catOff, catVal) = catSym[0..#catSize];
-        var (queryOff, queryVal) = querySym[0..#querySize];
-        
-        // For all indexes in the query segString, find the matching index in the categories segString
-        // Exponential Growth - break once a match is found
-        forall i in 0..#querySize {
-            for x in 0..#catSize {
-                if queryVal[i] == catVal[x]{
-                    codes[i] = x;
-                    break;
-                }
-            }
-        }
-
-        var name = st.nextName();
-        var codeEntry = new shared SymEntry(codes);
-        st.addEntry(name, codeEntry);
-
-        var repMsg = "created " + st.attrib(name);
-        jeLogger.debug(getModuleName(), getRoutineName(), getLineNumber(), repMsg);
-        return new MsgTuple(repMsg, MsgType.NORMAL);
-    }
-
     use CommandMap;
     registerFunction("joinEqWithDT", joinEqWithDTMsg, getModuleName());
-    registerFunction("codeMapping", codeMappingMsg, getModuleName());
 }// end module JoinEqWithDTMsg

--- a/src/JoinEqWithDTMsg.chpl
+++ b/src/JoinEqWithDTMsg.chpl
@@ -14,7 +14,6 @@ module JoinEqWithDTMsg
     use MultiTypeSymEntry;
     use ServerErrorStrings;
     use AryUtil;
-    use SegmentedString;
 
     param TRUE_DT = 0;
     param ABS_DT = 1;

--- a/src/JoinEqWithDTMsg.chpl
+++ b/src/JoinEqWithDTMsg.chpl
@@ -14,6 +14,7 @@ module JoinEqWithDTMsg
     use MultiTypeSymEntry;
     use ServerErrorStrings;
     use AryUtil;
+    use SegmentedString;
 
     param TRUE_DT = 0;
     param ABS_DT = 1;
@@ -377,7 +378,7 @@ module JoinEqWithDTMsg
     }// end joinEqWithDTMsg()
 
     proc codeMappingMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
-        catLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"Mapping codes from categories");
+        jeLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"Mapping codes from categories");
 
         var catName = msgArgs.getValueOf("categories");
         var queryName = msgArgs.getValueOf("query");
@@ -408,7 +409,7 @@ module JoinEqWithDTMsg
         st.addEntry(name, codeEntry);
 
         var repMsg = "created " + st.attrib(name);
-        catLogger.debug(getModuleName(), getRoutineName(), getLineNumber(), repMsg);
+        jeLogger.debug(getModuleName(), getRoutineName(), getLineNumber(), repMsg);
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 

--- a/src/JoinEqWithDTMsg.chpl
+++ b/src/JoinEqWithDTMsg.chpl
@@ -395,7 +395,7 @@ module JoinEqWithDTMsg
         
         // For all indexes in the query segString, find the matching index in the categories segString
         // Exponential Growth - break once a match is found
-        coforall i in 0..#querySize {
+        forall i in 0..#querySize {
             for x in 0..#catSize {
                 if queryVal[i] == catVal[x]{
                     codes[i] = x;

--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -117,8 +117,8 @@ class JoinTest(ArkoudaTest):
     def test_str_cat_inner_join(self):
         intLeft = ak.arange(50)
         intRight = ak.randint(0, 50, 50)
-        strLeft = ak.array([f'str {i}' for i in intLeft.to_list()])
-        strRight = ak.array([f'str {i}' for i in intRight.to_list()])
+        strLeft = ak.array([f"str {i}" for i in intLeft.to_list()])
+        strRight = ak.array([f"str {i}" for i in intRight.to_list()])
 
         strL, strR = ak.join.inner_join(strLeft, strRight)
         self.assertListEqual(strLeft[strL].to_list(), strRight[strR].to_list())

--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -95,7 +95,7 @@ class JoinTest(ArkoudaTest):
         l, r = ak.join.inner_join(left, right)
         self.assertListEqual(left[l].to_list(), right[r].to_list())
 
-        l, r = ak.join.inner_join(left, right, wherefunc=num_join_where, whereargs=(left, right))
+        l, r = ak.join.inner_join(left, right, wherefunc=join_where, whereargs=(left, right))
         self.assertListEqual(left[l].to_list(), right[r].to_list())
 
         with self.assertRaises(ValueError):
@@ -115,16 +115,16 @@ class JoinTest(ArkoudaTest):
             )
 
     def test_str_cat_inner_join(self):
-        int_left = ak.arange(10)
-        int_right = ak.array([0, 5, 3, 3, 4, 6, 7, 9, 8, 1])
-        strLeft = ak.array([f'str {i}' for i in int_left.to_list()])
-        strRight = ak.array([f'str {i}' for i in int_right.to_list()])
+        intLeft = ak.arange(10)
+        intRight = ak.array([0, 5, 3, 3, 4, 6, 7, 9, 8, 1])
+        strLeft = ak.array([f'str {i}' for i in intLeft.to_list()])
+        strRight = ak.array([f'str {i}' for i in intRight.to_list()])
 
         strL, strR = ak.join.inner_join(strLeft, strRight)
         self.assertListEqual(strLeft[strL].to_list(), strRight[strR].to_list())
 
         strLWhere, strRWhere = ak.join.inner_join(
-            strLeft, strRight, wherefunc=string_join_where, whereargs=(strLeft, strRight)
+            strLeft, strRight, wherefunc=join_where, whereargs=(strLeft, strRight)
         )
         self.assertListEqual(strLeft[strLWhere].to_list(), strRight[strRWhere].to_list())
 
@@ -135,7 +135,12 @@ class JoinTest(ArkoudaTest):
         self.assertListEqual(catLeft[catL].to_list(), catRight[catR].to_list())
 
         catLWhere, catRWhere = ak.join.inner_join(
-            catLeft, catRight, wherefunc=string_join_where, whereargs=(strLeft, strRight)
+            catLeft, catRight, wherefunc=join_where, whereargs=(strLeft, strRight)
+        )
+        self.assertListEqual(catLeft[catLWhere].to_list(), catRight[catRWhere].to_list())
+
+        catLWhere, catRWhere = ak.join.inner_join(
+            catLeft, catRight, wherefunc=join_where, whereargs=(intLeft, intRight)
         )
         self.assertListEqual(catLeft[catLWhere].to_list(), catRight[catRWhere].to_list())
 
@@ -182,23 +187,9 @@ class JoinTest(ArkoudaTest):
             ak.join_on_eq_with_dt(self.a1, self.a1, self.t1, self.t1 * 10, 8, "abs_dt", -1)
 
 
-def string_join_where(L, R):
+def join_where(L, R):
     idx = []
     for i in range(L.size):
-        if L[i] in ["str 0", "str 3", "str 9"] and R[i] in ["str 0", "str 1"]:
-            idx.append(True)
-        else:
-            idx.append(False)
-
-    return ak.array(idx)
-
-
-def num_join_where(L, R):
-    idx = []
-    for i in range(L.size):
-        if L[i] in [0, 2, 3] and R[i] in [0, 2]:
-            idx.append(True)
-        else:
-            idx.append(False)
+        idx.append(i % 2 == 0)
 
     return ak.array(idx)

--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -114,7 +114,7 @@ class JoinTest(ArkoudaTest):
                 left, right, wherefunc=ak.intersect1d, whereargs=(ak.arange(10), ak.arange(5))
             )
 
-    def test_str_cat_inner_join(self):
+    def test_str_inner_join(self):
         intLeft = ak.arange(50)
         intRight = ak.randint(0, 50, 50)
         strLeft = ak.array([f"str {i}" for i in intLeft.to_list()])
@@ -128,21 +128,46 @@ class JoinTest(ArkoudaTest):
         )
         self.assertListEqual(strLeft[strLWhere].to_list(), strRight[strRWhere].to_list())
 
+    def test_cat_inner_join(self):
+        intLeft = ak.arange(50)
+        intRight = ak.randint(0, 50, 50)
+        strLeft = ak.array([f"str {i}" for i in intLeft.to_list()])
+        strRight = ak.array([f"str {i}" for i in intRight.to_list()])
         catLeft = ak.Categorical(strLeft)
         catRight = ak.Categorical(strRight)
 
+        # Base Case
         catL, catR = ak.join.inner_join(catLeft, catRight)
         self.assertListEqual(catLeft[catL].to_list(), catRight[catR].to_list())
 
         catLWhere, catRWhere = ak.join.inner_join(
-            catLeft, catRight, wherefunc=join_where, whereargs=(strLeft, strRight)
+            catLeft, catRight, wherefunc=join_where, whereargs=(catLeft, catRight)
         )
         self.assertListEqual(catLeft[catLWhere].to_list(), catRight[catRWhere].to_list())
 
-        catLWhere, catRWhere = ak.join.inner_join(
-            catLeft, catRight, wherefunc=join_where, whereargs=(intLeft, intRight)
+    def test_mixed_inner_join_where(self):
+        intLeft = ak.arange(50)
+        intRight = ak.randint(0, 50, 50)
+        strLeft = ak.array([f"str {i}" for i in intLeft.to_list()])
+        strRight = ak.array([f"str {i}" for i in intRight.to_list()])
+        catLeft = ak.Categorical(strLeft)
+        catRight = ak.Categorical(strRight)
+
+        L, R = ak.join.inner_join(
+            intLeft, intRight, wherefunc=join_where, whereargs=(catLeft, strRight)
         )
-        self.assertListEqual(catLeft[catLWhere].to_list(), catRight[catRWhere].to_list())
+        self.assertListEqual(catLeft[L].to_list(), catRight[R].to_list())
+
+        L, R = ak.join.inner_join(
+            strLeft, strRight, wherefunc=join_where, whereargs=(catLeft, intRight)
+        )
+        self.assertListEqual(catLeft[L].to_list(), catRight[R].to_list())
+
+        L, R = ak.join.inner_join(
+            catLeft, catRight, wherefunc=join_where, whereargs=(strLeft, intRight)
+        )
+        self.assertListEqual(catLeft[L].to_list(), catRight[R].to_list())
+
 
     def test_lookup(self):
         keys = ak.arange(5)

--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -95,6 +95,12 @@ class JoinTest(ArkoudaTest):
         l, r = ak.join.inner_join(left, right)
         self.assertListEqual(left[l].to_list(), right[r].to_list())
 
+        strLeft = ak.array(["a", "b", "c", "d", "e", "f", "g", "h"])
+        strRight = ak.array(["c", "g", "a", "d", "f", "e", "b", "d"])
+
+        strL, strR = ak.join.inner_join(strLeft, strRight)
+        self.assertListEqual(strLeft[strL].to_list(), strRight[strR].to_list())
+
         with self.assertRaises(ValueError):
             l, r = ak.join.inner_join(left, right, wherefunc=ak.unique)
 

--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -115,8 +115,8 @@ class JoinTest(ArkoudaTest):
             )
 
     def test_str_cat_inner_join(self):
-        intLeft = ak.arange(10)
-        intRight = ak.array([0, 5, 3, 3, 4, 6, 7, 9, 8, 1])
+        intLeft = ak.arange(50)
+        intRight = ak.randint(0, 50, 50)
         strLeft = ak.array([f'str {i}' for i in intLeft.to_list()])
         strRight = ak.array([f'str {i}' for i in intRight.to_list()])
 

--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -95,7 +95,9 @@ class JoinTest(ArkoudaTest):
         l, r = ak.join.inner_join(left, right)
         self.assertListEqual(left[l].to_list(), right[r].to_list())
 
-        l, r = ak.join.inner_join(left, right, wherefunc=join_where, whereargs=(left, right))
+        l, r = ak.join.inner_join(
+            left, right, wherefunc=join_where, whereargs=(left, right)
+        )
         self.assertListEqual(left[l].to_list(), right[r].to_list())
 
         with self.assertRaises(ValueError):
@@ -168,7 +170,6 @@ class JoinTest(ArkoudaTest):
         )
         self.assertListEqual(catLeft[L].to_list(), catRight[R].to_list())
 
-
     def test_lookup(self):
         keys = ak.arange(5)
         values = 10 * keys
@@ -216,5 +217,3 @@ def join_where(L, R):
     idx = []
     for i in range(L.size):
         idx.append(i % 2 == 0)
-
-    return ak.array(idx)

--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -217,3 +217,5 @@ def join_where(L, R):
     idx = []
     for i in range(L.size):
         idx.append(i % 2 == 0)
+    return ak.array(idx)
+

--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -140,7 +140,10 @@ class JoinTest(ArkoudaTest):
 
         # Base Case
         catL, catR = ak.join.inner_join(catLeft, catRight)
-        self.assertListEqual(catLeft[catL].to_list(), catRight[catR].to_list())
+        self.assertListEqual(
+            catLeft[catL].to_list(),
+            catRight[catR].to_list(),
+        )
 
         catLWhere, catRWhere = ak.join.inner_join(
             catLeft, catRight, wherefunc=join_where, whereargs=(catLeft, catRight)

--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -140,10 +140,7 @@ class JoinTest(ArkoudaTest):
 
         # Base Case
         catL, catR = ak.join.inner_join(catLeft, catRight)
-        self.assertListEqual(
-            catLeft[catL].to_list(),
-            catRight[catR].to_list(),
-        )
+        self.assertListEqual(catLeft[catL].to_list(), catRight[catR].to_list())
 
         catLWhere, catRWhere = ak.join.inner_join(
             catLeft, catRight, wherefunc=join_where, whereargs=(catLeft, catRight)

--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -95,9 +95,7 @@ class JoinTest(ArkoudaTest):
         l, r = ak.join.inner_join(left, right)
         self.assertListEqual(left[l].to_list(), right[r].to_list())
 
-        l, r = ak.join.inner_join(
-            left, right, wherefunc=num_join_where, whereargs=(left, right)
-        )
+        l, r = ak.join.inner_join(left, right, wherefunc=num_join_where, whereargs=(left, right))
         self.assertListEqual(left[l].to_list(), right[r].to_list())
 
         with self.assertRaises(ValueError):
@@ -132,18 +130,12 @@ class JoinTest(ArkoudaTest):
         catRight = ak.Categorical(strRight)
 
         catL, catR = ak.join.inner_join(catLeft, catRight)
-        self.assertListEqual(
-            catLeft[catL].to_list(),
-            catRight[catR].to_list(),
-        )
+        self.assertListEqual(catLeft[catL].to_list(), catRight[catR].to_list())
 
         catLWhere, catRWhere = ak.join.inner_join(
             catLeft, catRight, wherefunc=string_join_where, whereargs=(strLeft, strRight)
         )
-        self.assertListEqual(
-            catLeft[catLWhere].to_list(),
-            catRight[catRWhere].to_list(),
-        )
+        self.assertListEqual(catLeft[catLWhere].to_list(), catRight[catRWhere].to_list())
 
     def test_lookup(self):
         keys = ak.arange(5)

--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -133,16 +133,16 @@ class JoinTest(ArkoudaTest):
 
         catL, catR = ak.join.inner_join(catLeft, catRight)
         self.assertListEqual(
-            catLeft.categories[catLeft.codes[catL]].to_list(),
-            catRight.categories[catRight.codes[catR]].to_list(),
+            catLeft[catL].to_list(),
+            catRight[catR].to_list(),
         )
 
         catLWhere, catRWhere = ak.join.inner_join(
             catLeft, catRight, wherefunc=string_join_where, whereargs=(strLeft, strRight)
         )
         self.assertListEqual(
-            catLeft.categories[catLeft.codes[catLWhere]].to_list(),
-            catRight.categories[catRight.codes[catRWhere]].to_list(),
+            catLeft[catLWhere].to_list(),
+            catRight[catRWhere].to_list(),
         )
 
     def test_lookup(self):

--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -115,8 +115,10 @@ class JoinTest(ArkoudaTest):
             )
 
     def test_str_cat_inner_join(self):
-        strLeft = ak.array(["a", "c", "c", "d", "a", "b", "a", "e"])
-        strRight = ak.array(["c", "b", "a", "d", "a", "c", "b", "d"])
+        int_left = ak.arange(10)
+        int_right = ak.array([0, 5, 3, 3, 4, 6, 7, 9, 8, 1])
+        strLeft = ak.array([f'str {i}' for i in int_left.to_list()])
+        strRight = ak.array([f'str {i}' for i in int_right.to_list()])
 
         strL, strR = ak.join.inner_join(strLeft, strRight)
         self.assertListEqual(strLeft[strL].to_list(), strRight[strR].to_list())
@@ -183,7 +185,7 @@ class JoinTest(ArkoudaTest):
 def string_join_where(L, R):
     idx = []
     for i in range(L.size):
-        if L[i] in ["a", "c", "e"] and R[i] in ["a", "c"]:
+        if L[i] in ["str 0", "str 3", "str 9"] and R[i] in ["str 0", "str 1"]:
             idx.append(True)
         else:
             idx.append(False)


### PR DESCRIPTION
This PR Closes #2304

Adds support for Strings and Categorical to the `ak.join.innerjoin` function. Includes `where` support against `pdarray, Strings, and Categorical` types using `pdarray` or `Strings` arguments in the where.

This was accomplished by converting `Strings` to `Categorical` and using `categorical.codes` as a numeric representation which could then follow the same workflow and processes as the original `pdarray` case. 

Adds test case for `Strings` and `Categorical` as well as a test using a `wherefunc` for each type.