### PR TITLE
Closes #2300 - `segString` Strip performance issue

### DIFF
--- a/src/SegmentedString.chpl
+++ b/src/SegmentedString.chpl
@@ -809,10 +809,6 @@ module SegmentedString {
       ref origVals = this.values.a;
       const lengths = this.getLengths();
 
-      ssLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                             "chars: %s - origOffsets: %t - origVals: %t"
-                                             .format(chars, origOffsets, origVals:bytes));
-
       var replacedLens: [this.offsets.a.domain] int;
 
       forall (off, len, rlen) in zip(origOffsets, lengths, replacedLens) {


### PR DESCRIPTION
This PR Closes #2300 

Through testing specific portions of the Chapel functions related to the `strip` workflow, I found that there was a debug statement that was generating a message with all of the starting offsets and values in the `segString`. The creation and print of this message using a segString of 8 - 2**16 characters, 1000 entries long, took 50 seconds of the overall 55 second process time. (In comparison, `peel` completed in ~1.3 seconds) When running the arkouda server without the `DEBUG` flag set, the message generation still occurred, but only took ~35 seconds of the roughly 40 second processing time.

After removing this Debug statement, the same data set parameters were used and resulted in a nearly identical process time for `strip` and `peel`, both around 1.2 seconds on average.

Incrementing this up to 10**4 length strings array, the times went up for `strip` to 10 seconds and `peel` to 12 seconds. Through my testing this has been fairly consistent. 

Times before removing the debug line: 10**3 problem size
```
------------------------------------------------------------------------- benchmark 'Strip_Peel': 2 tests -------------------------------------------------------------------------
Name (time in s)         Min                Max               Mean            StdDev             Median               IQR            Outliers     OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
bench_peel            1.3484 (1.0)       2.7216 (1.0)       1.7768 (1.0)      0.6091 (2.72)      1.3745 (1.0)      0.8623 (2.27)          1;0  0.5628 (1.0)           5           1
bench_strip          54.1791 (40.18)    54.7166 (20.10)    54.4497 (30.64)    0.2238 (1.0)      54.4100 (39.58)    0.3793 (1.0)           2;0  0.0184 (0.03)          5           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

After removing the debug ling: 10**3 problem size
```
----------------------------------------------------------------------- benchmark 'Strip_Peel': 2 tests -----------------------------------------------------------------------
Name (time in s)        Min               Max              Mean            StdDev            Median               IQR            Outliers     OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
bench_strip          1.1384 (1.0)      1.2784 (1.06)     1.1864 (1.01)     0.0553 (2.31)     1.1736 (1.0)      0.0654 (1.97)          1;0  0.8429 (0.99)          5           1
bench_peel           1.1487 (1.01)     1.2109 (1.0)      1.1760 (1.0)      0.0239 (1.0)      1.1779 (1.00)     0.0331 (1.0)           2;0  0.8503 (1.0)           5           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

After removing the debug line: 10**4 problem size
```
------------------------------------------------------------------------- benchmark 'Strip_Peel': 2 tests -------------------------------------------------------------------------
Name (time in s)         Min                Max               Mean            StdDev             Median               IQR            Outliers     OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
bench_strip          10.5100 (1.0)      11.0474 (1.0)      10.8077 (1.0)      0.2286 (1.0)      10.8177 (1.0)      0.3980 (1.0)           2;0  0.0925 (1.0)           5           1
bench_peel           11.5328 (1.10)     20.5974 (1.86)     13.7151 (1.27)     3.8651 (16.91)    12.1971 (1.13)     2.8083 (7.06)          1;1  0.0729 (0.79)          5           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
