### PR TITLE
Closes #474 - HDF5 Overwrite Dataset

### DIFF
--- a/arkouda/array_view.py
+++ b/arkouda/array_view.py
@@ -409,7 +409,7 @@ class ArrayView:
     def update_hdf(
         self,
         prefix_path: str,
-        dataset: str = "array",
+        dataset: str = "ArrayView",
         repack: bool = True,
     ):
         """

--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -930,8 +930,10 @@ class Categorical:
         """
         # due to the possibility that components will be different sizes,
         # writing to Parquet is not supported at this time
-        raise RuntimeError("Categorical cannot be written to Parquet at this time due to its components "
-                           "potentially having different sizes.")
+        raise RuntimeError(
+            "Categorical cannot be written to Parquet at this time due to its components "
+            "potentially having different sizes."
+        )
         result = []
         comp_dict = {k: v for k, v in self._get_components_dict().items() if v is not None}
 
@@ -1012,6 +1014,7 @@ class Categorical:
         - ak.Categorical.to_hdf
         """
         from warnings import warn
+
         warn(
             "ak.Categorical.save has been deprecated. "
             "Please use ak.Categorical.to_parquet or ak.Categorical.to_hdf",

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -248,6 +248,48 @@ class Index:
         """
         return self.values.to_hdf(prefix_path, dataset=dataset, mode=mode, file_type=file_type)
 
+    def update_hdf(
+        self,
+        prefix_path: str,
+        dataset: str = "array",
+        repack: bool = True,
+    ):
+        """
+        Overwrite the dataset with the name provided with this Index object. If
+        the dataset does not exist it is added.
+
+        Parameters
+        -----------
+        prefix_path : str
+            Directory and filename prefix that all output files share
+        dataset : str
+            Name of the dataset to create in files
+        repack: bool
+            Default: True
+            HDF5 does not release memory on delete. When True, the inaccessible
+            data (that was overwritten) is removed. When False, the data remains, but is
+            inaccessible. Setting to false will yield better performance, but will cause
+            file sizes to expand.
+
+        Returns
+        --------
+        str - success message if successful
+
+        Raises
+        -------
+        RuntimeError
+            Raised if a server-side error is thrown saving the index
+
+        Notes
+        ------
+        - If file does not contain File_Format attribute to indicate how it was saved,
+          the file name is checked for _LOCALE#### to determine if it is distributed.
+        - If the dataset provided does not exist, it will be added
+        - Because HDF5 deletes do not release memory, this will create a copy of the
+          file with the new data
+        """
+        return self.values.update_hdf(prefix_path, dataset=dataset, repack=repack)
+
     def to_parquet(
         self,
         prefix_path: str,

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -1193,6 +1193,34 @@ def to_hdf(
             mode = "append"
 
 
+def _get_hdf_filetype(filename: str) -> str:
+    if not (filename and filename.strip()):
+        raise ValueError("filename cannot be an empty string")
+
+    cmd = "hdffileformat"
+    return cast(
+        str,
+        generic_msg(
+            cmd=cmd,
+            args={"filename": filename},
+        ),
+    )
+
+
+def update_hdf(
+    columns: Union[Mapping[str, pdarray], List[pdarray]],
+    prefix_path: str,
+    names: List[str] = None
+):
+    # TODO - add docstring
+    datasetNames, pdarrays = _bulk_write_prep(columns, names)
+    for arr, name in zip(pdarrays, cast(List[str], datasetNames)):
+        arr.update_hdf(
+            prefix_path=prefix_path,
+            dataset=name
+        )
+
+
 def to_csv(
     columns: Union[Mapping[str, pdarray], List[pdarray]],
     prefix_path: str,

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -35,6 +35,7 @@ __all__ = [
     "save_all",
     "load",
     "load_all",
+    "update_hdf"
 ]
 
 ARKOUDA_HDF5_FILE_METADATA_GROUP = "_arkouda_metadata"
@@ -1213,8 +1214,14 @@ def _repack_hdf(prefix_path: str):
     """
     file_type = _get_hdf_filetype(prefix_path + "*")
     dset_list = ls(prefix_path + "*")
+    if len(dset_list) == 1:
+        # early out because when overwriting only one value, hdf5 automatically releases memory
+        return
     data = read_hdf(prefix_path + "*")
-    return to_hdf(data, prefix_path, names=dset_list, file_type=file_type)
+    if not isinstance(data, dict):
+        # handles the case of reading only 1 dataset
+        data = [data]
+    to_hdf(data, prefix_path, names=dset_list, file_type=file_type)
 
 
 def update_hdf(

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -1248,6 +1248,7 @@ def update_hdf(
 ):
     """
     Overwrite the datasets with name appearing in names or keys in columns if columns
+    is a dictionary
 
     Parameters
     -----------

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -1207,18 +1207,63 @@ def _get_hdf_filetype(filename: str) -> str:
     )
 
 
+def _repack_hdf(prefix_path: str):
+    """
+    Overwrites the existing hdf5 file with a copy that removes any inaccessible datasets
+    """
+    file_type = _get_hdf_filetype(prefix_path + "*")
+    dset_list = ls(prefix_path + "*")
+    data = read_hdf(prefix_path + "*")
+    return to_hdf(data, prefix_path, names=dset_list, file_type=file_type)
+
+
 def update_hdf(
     columns: Union[Mapping[str, pdarray], List[pdarray]],
     prefix_path: str,
-    names: List[str] = None
+    names: List[str] = None,
+    repack: bool = True,
 ):
-    # TODO - add docstring
+    """
+    Overwrite the datasets with name appearing in names or keys in columns if columns
+
+    Parameters
+    -----------
+    columns : dict or list of pdarrays
+        Collection of arrays to save
+    prefix_path : str
+        Directory and filename prefix for output files
+    names : list of str
+        Dataset names for the pdarrays
+    repack: bool
+        Default: True
+        HDF5 does not release memory on delete. When True, the inaccessible
+        data (that was overwritten) is removed. When False, the data remains, but is
+        inaccessible. Setting to false will yield better performance, but will cause
+        file sizes to expand.
+
+    Raises
+    -------
+    RuntimeError
+        Raised if a server-side error is thrown saving the datasets
+
+    Notes
+    -----
+    - If file does not contain File_Format attribute to indicate how it was saved,
+      the file name is checked for _LOCALE#### to determine if it is distributed.
+    - If the datasets provided do not exist, they will be added
+    - Because HDF5 deletes do not release memory, this will create a copy of the
+      file with the new data
+    - This workflow is slightly different from `to_hdf` to prevent reading and
+      creating a copy of the file for each dataset
+    """
     datasetNames, pdarrays = _bulk_write_prep(columns, names)
+
     for arr, name in zip(pdarrays, cast(List[str], datasetNames)):
-        arr.update_hdf(
-            prefix_path=prefix_path,
-            dataset=name
-        )
+        # overwrite the data without repacking. Repack done once at end if set
+        arr.update_hdf(prefix_path, dataset=name, repack=False)
+
+    if repack:
+        _repack_hdf(prefix_path)
 
 
 def to_csv(

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -36,7 +36,7 @@ __all__ = [
     "save_all",
     "load",
     "load_all",
-    "update_hdf"
+    "update_hdf",
 ]
 
 ARKOUDA_HDF5_FILE_METADATA_GROUP = "_arkouda_metadata"
@@ -994,7 +994,13 @@ def export(
         return df
 
 
-def _bulk_write_prep(columns: Union[Mapping[str, Union[pdarray, Strings, SegArray, ArrayView]], List[Union[pdarray, Strings, SegArray, ArrayView]]], names: List[str] = None):
+def _bulk_write_prep(
+    columns: Union[
+        Mapping[str, Union[pdarray, Strings, SegArray, ArrayView]],
+        List[Union[pdarray, Strings, SegArray, ArrayView]],
+    ],
+    names: List[str] = None,
+):
     datasetNames = []
     if names is not None:
         if len(names) != len(columns):
@@ -1019,7 +1025,10 @@ def _bulk_write_prep(columns: Union[Mapping[str, Union[pdarray, Strings, SegArra
 
 
 def to_parquet(
-    columns: Union[Mapping[str, Union[pdarray, Strings, SegArray, ArrayView]], List[Union[pdarray, Strings, SegArray, ArrayView]]],
+    columns: Union[
+        Mapping[str, Union[pdarray, Strings, SegArray, ArrayView]],
+        List[Union[pdarray, Strings, SegArray, ArrayView]],
+    ],
     prefix_path: str,
     names: List[str] = None,
     mode: str = "truncate",
@@ -1117,7 +1126,10 @@ def to_parquet(
 
 
 def to_hdf(
-    columns: Union[Mapping[str, Union[pdarray, Strings, SegArray, ArrayView]], List[Union[pdarray, Strings, SegArray, ArrayView]]],
+    columns: Union[
+        Mapping[str, Union[pdarray, Strings, SegArray, ArrayView]],
+        List[Union[pdarray, Strings, SegArray, ArrayView]],
+    ],
     prefix_path: str,
     names: List[str] = None,
     mode: str = "truncate",
@@ -1226,7 +1238,10 @@ def _repack_hdf(prefix_path: str):
 
 
 def update_hdf(
-    columns: Union[Mapping[str, Union[pdarray, Strings, SegArray, ArrayView]], List[Union[pdarray, Strings, SegArray, ArrayView]]],
+    columns: Union[
+        Mapping[str, Union[pdarray, Strings, SegArray, ArrayView]],
+        List[Union[pdarray, Strings, SegArray, ArrayView]],
+    ],
     prefix_path: str,
     names: List[str] = None,
     repack: bool = True,
@@ -1351,7 +1366,10 @@ def to_csv(
 
 
 def save_all(
-    columns: Union[Mapping[str, Union[pdarray, Strings, SegArray, ArrayView]], List[Union[pdarray, Strings, SegArray, ArrayView]]],
+    columns: Union[
+        Mapping[str, Union[pdarray, Strings, SegArray, ArrayView]],
+        List[Union[pdarray, Strings, SegArray, ArrayView]],
+    ],
     prefix_path: str,
     names: List[str] = None,
     file_format="HDF5",

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1550,7 +1550,7 @@ class pdarray:
 
         # determine the format (single/distribute) that the file was saved in
         file_type = _get_hdf_filetype(prefix_path + "*")
-        
+
         generic_msg(
             cmd="tohdf",
             args={

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1550,7 +1550,7 @@ class pdarray:
 
         # determine the format (single/distribute) that the file was saved in
         file_type = _get_hdf_filetype(prefix_path + "*")
-
+        
         generic_msg(
             cmd="tohdf",
             args={

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -1037,6 +1037,68 @@ class SegArray:
             ),
         )
 
+    def update_hdf(
+        self,
+        prefix_path: str,
+        dataset: str = "array",
+        repack: bool = True,
+    ):
+        """
+        Overwrite the dataset with the name provided with this SegArray object. If
+        the dataset does not exist it is added.
+
+        Parameters
+        -----------
+        prefix_path : str
+            Directory and filename prefix that all output files share
+        dataset : str
+            Name of the dataset to create in files
+        repack: bool
+            Default: True
+            HDF5 does not release memory on delete. When True, the inaccessible
+            data (that was overwritten) is removed. When False, the data remains, but is
+            inaccessible. Setting to false will yield better performance, but will cause
+            file sizes to expand.
+
+        Returns
+        --------
+        str - success message if successful
+
+        Raises
+        -------
+        RuntimeError
+            Raised if a server-side error is thrown saving the SegArray
+
+        Notes
+        ------
+        - If file does not contain File_Format attribute to indicate how it was saved,
+          the file name is checked for _LOCALE#### to determine if it is distributed.
+        - If the dataset provided does not exist, it will be added
+        - Because HDF5 deletes do not release memory, this will create a copy of the
+          file with the new data
+        """
+        from arkouda.io import _get_hdf_filetype, _mode_str_to_int, _file_type_to_int, _repack_hdf
+
+        # determine the format (single/distribute) that the file was saved in
+        file_type = _get_hdf_filetype(prefix_path + "*")
+
+        generic_msg(
+            cmd="tohdf",
+            args={
+                "values": self,
+                "dset": dataset,
+                "write_mode": _mode_str_to_int("append"),
+                "filename": prefix_path,
+                "dtype": self.dtype,
+                "objType": "segarray",
+                "file_format": _file_type_to_int(file_type),
+                "overwrite": True,
+            },
+        )
+
+        if repack:
+            _repack_hdf(prefix_path)
+
     def to_parquet(
         self, prefix_path, dataset="segarray", mode: str = "truncate", compression: Optional[str] = None
     ):

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -1040,7 +1040,7 @@ class SegArray:
     def update_hdf(
         self,
         prefix_path: str,
-        dataset: str = "array",
+        dataset: str = "segarray",
         repack: bool = True,
     ):
         """
@@ -1085,7 +1085,7 @@ class SegArray:
         generic_msg(
             cmd="tohdf",
             args={
-                "values": self,
+                "seg_name": self.name,
                 "dset": dataset,
                 "write_mode": _mode_str_to_int("append"),
                 "filename": prefix_path,

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -2032,7 +2032,11 @@ class Strings:
         )
 
     def update_hdf(
-        self, prefix_path: str, dataset: str = "array", save_offsets: bool = True, repack: bool = True
+        self,
+        prefix_path: str,
+        dataset: str = "strings_array",
+        save_offsets: bool = True,
+        repack: bool = True,
     ):
         """
         Overwrite the dataset with the name provided with this Strings object. If

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -354,7 +354,7 @@ class Strings:
             generic_msg(cmd="segmentLengths", args={"objType": self.objtype, "obj": self.entry})
         )
 
-    def encode(self, toEncoding : str, fromEncoding : str = "UTF-8"):
+    def encode(self, toEncoding: str, fromEncoding: str = "UTF-8"):
         """
         Return a new strings object in `toEncoding`, expecting that the
         current Strings is encoded in `fromEncoding`
@@ -2030,6 +2030,68 @@ class Strings:
                 },
             ),
         )
+
+    def update_hdf(
+        self, prefix_path: str, dataset: str = "array", save_offsets: bool = True, repack: bool = True
+    ):
+        """
+        Overwrite the dataset with the name provided with this Strings object. If
+        the dataset does not exist it is added
+
+        Parameters
+        -----------
+        prefix_path : str
+            Directory and filename prefix that all output files share
+        dataset : str
+            Name of the dataset to create in files
+        save_offsets : bool
+            Defaults to True which will instruct the server to save the offsets array to HDF5
+            If False the offsets array will not be save and will be derived from the string values
+            upon load/read.
+        repack: bool
+            Default: True
+            HDF5 does not release memory on delete. When True, the inaccessible
+            data (that was overwritten) is removed. When False, the data remains, but is
+            inaccessible. Setting to false will yield better performance, but will cause
+            file sizes to expand.
+
+        Returns
+        --------
+        str - success message if successful
+
+        Raises
+        -------
+        RuntimeError
+            Raised if a server-side error is thrown saving the Strings object
+
+        Notes
+        ------
+        - If file does not contain File_Format attribute to indicate how it was saved,
+          the file name is checked for _LOCALE#### to determine if it is distributed.
+        - If the dataset provided does not exist, it will be added
+        """
+        from arkouda.io import _mode_str_to_int, _file_type_to_int, _get_hdf_filetype, _repack_hdf
+
+        # determine the format (single/distribute) that the file was saved in
+        file_type = _get_hdf_filetype(prefix_path + "*")
+
+        generic_msg(
+            cmd="tohdf",
+            args={
+                "values": self,
+                "dset": dataset,
+                "write_mode": _mode_str_to_int("append"),
+                "filename": prefix_path,
+                "dtype": self.dtype,
+                "save_offsets": save_offsets,
+                "objType": "strings",
+                "file_format": _file_type_to_int(file_type),
+                "overwrite": True,
+            },
+        )
+
+        if repack:
+            _repack_hdf(prefix_path)
 
     @typechecked
     def to_csv(

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -2323,8 +2323,7 @@ module HDF5Msg {
                 var file_format: int;
                 C_HDF5.H5Aread(file_format_id, getHDF5Type(int), c_ptrTo(file_format));
                 C_HDF5.H5Aclose(file_format_id);
-
-                writeln("\n\n\nFile_Format Attribute Found: %i\n\n\n".format(file_format));
+                
                 // convert integer to string
                 if file_format == 0 {
                     repMsg = "single";

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -9,7 +9,7 @@ module HDF5Msg {
     use Set;
     use ArkoudaTimeCompat as Time;
     use AryUtil;
-    use Regex;
+    use ArkoudaRegexCompat;
 
     use CommAggregation;
     use FileIO;
@@ -2343,7 +2343,7 @@ module HDF5Msg {
             }
             else{
                 // generate regex to match distributed filename
-                var dist_regex = new regex("_LOCALE\\d{4}");
+                var dist_regex = compile("_LOCALE\\d{4}");
 
                 if dist_regex.search(filename){
                     repMsg = "distribute";

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -1007,8 +1007,8 @@ class IOTest(ArkoudaTest):
             self.assertListEqual(data["c"].to_list(), odf["c"].to_list())
 
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
-            df.to_hdf(f"{tmp_dirname}/repack_test")
-            f_list = glob.glob(f"{tmp_dirname}/repack_test_*")
+            df.to_hdf(f"{tmp_dirname}/df_test")
+            f_list = glob.glob(f"{tmp_dirname}/df_test*")
             orig_size = 0
             for f in f_list:
                 orig_size += os.path.getsize(f)

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -876,6 +876,267 @@ class IOTest(ArkoudaTest):
             df_load = ak.DataFrame.load(f"{tmp_dirname}/dataframe_segarr")
             self.assertTrue(df.to_pandas().equals(df_load.to_pandas()))
 
+    def test_hdf_overwrite_pdarray(self):
+        # test repack with a single object
+        a = ak.arange(1000)
+        b = ak.randint(0, 100, 1000)
+        with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
+            a.to_hdf(f"{tmp_dirname}/repack_test")
+            f_list = glob.glob(f"{tmp_dirname}/repack_test_*")
+            orig_size = 0
+            for f in f_list:
+                orig_size += os.path.getsize(f)
+            b.update_hdf(f"{tmp_dirname}/repack_test")
+
+            new_size = 0
+            for f in f_list:
+                new_size += os.path.getsize(f)
+
+            # ensure that the column was actually overwritten
+            self.assertEqual(orig_size, new_size)
+            data = ak.read_hdf(f"{tmp_dirname}/repack_test_*")
+            self.assertListEqual(data.to_list(), b.to_list())
+
+        # test with repack off - file should get larger
+        b = ak.arange(1000)
+        c = ak.arange(15)
+        with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
+            a.to_hdf(f"{tmp_dirname}/repack_test")
+            b.to_hdf(f"{tmp_dirname}/repack_test", dataset="array_2", mode="append")
+            f_list = glob.glob(f"{tmp_dirname}/repack_test_*")
+            orig_size = 0
+            for f in f_list:
+                orig_size += os.path.getsize(f)
+            # hdf5 only releases memory if overwritting last dset so overwrite first
+            c.update_hdf(f"{tmp_dirname}/repack_test", dataset="array", repack=False)
+
+            new_size = 0
+            for f in f_list:
+                new_size += os.path.getsize(f)
+
+            # ensure that the column was actually overwritten
+            self.assertGreaterEqual(new_size, orig_size)  # ensure that overwritten data mem is not released
+            data = ak.read_hdf(f"{tmp_dirname}/repack_test_*")
+            self.assertListEqual(data["array"].to_list(), c.to_list())
+
+        # test overwrites with different types
+        with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
+            a.to_hdf(f"{tmp_dirname}/repack_test")
+            b = ak.arange(15, dtype=ak.uint64)
+            b.update_hdf(f"{tmp_dirname}/repack_test")
+            data = ak.read_hdf(f"{tmp_dirname}/repack_test_*")
+            self.assertListEqual(data.to_list(), b.to_list())
+
+            b = ak.arange(150, dtype=ak.float64)
+            b.update_hdf(f"{tmp_dirname}/repack_test")
+            data = ak.read_hdf(f"{tmp_dirname}/repack_test_*")
+            self.assertListEqual(data.to_list(), b.to_list())
+
+            b = ak.arange(1000, dtype=ak.bool)
+            b.update_hdf(f"{tmp_dirname}/repack_test")
+            data = ak.read_hdf(f"{tmp_dirname}/repack_test_*")
+            self.assertListEqual(data.to_list(), b.to_list())
+
+    def test_hdf_overwrite_strings(self):
+        # test repack with a single object
+        a = ak.random_strings_uniform(0, 16, 1000)
+        b = ak.random_strings_uniform(0, 16, 1000)
+        c = ak.random_strings_uniform(0, 16, 10)
+        with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
+            a.to_hdf(f"{tmp_dirname}/repack_test", dataset="test_set")
+            b.to_hdf(f"{tmp_dirname}/repack_test", mode="append")
+            f_list = glob.glob(f"{tmp_dirname}/repack_test_*")
+            orig_size = 0
+            for f in f_list:
+                orig_size += os.path.getsize(f)
+            c.update_hdf(f"{tmp_dirname}/repack_test", dataset="test_set")
+
+            new_size = 0
+            for f in f_list:
+                new_size += os.path.getsize(f)
+            # ensure that the column was actually overwritten
+            self.assertLessEqual(new_size, orig_size)
+            data = ak.read_hdf(f"{tmp_dirname}/repack_test_*")
+            self.assertListEqual(data["test_set"].to_list(), c.to_list())
+
+        with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
+            a.to_hdf(f"{tmp_dirname}/repack_test", dataset="test_set")
+            b.to_hdf(f"{tmp_dirname}/repack_test", mode="append")
+            f_list = glob.glob(f"{tmp_dirname}/repack_test_*")
+            orig_size = 0
+            for f in f_list:
+                orig_size += os.path.getsize(f)
+            # hdf5 only releases memory if overwritting last dset so overwrite first
+            c.update_hdf(f"{tmp_dirname}/repack_test", dataset="test_set", repack=False)
+
+            new_size = 0
+            for f in f_list:
+                new_size += os.path.getsize(f)
+            # ensure that the column was actually overwritten
+            self.assertGreaterEqual(new_size, orig_size)
+            data = ak.read_hdf(f"{tmp_dirname}/repack_test_*")
+            self.assertListEqual(data["test_set"].to_list(), c.to_list())
+
+    def test_hdf_overwrite_dataframe(self):
+        df = ak.DataFrame({
+            "a": ak.arange(1000),
+            "b": ak.random_strings_uniform(0, 16, 1000),
+            "c": ak.arange(1000, dtype=bool),
+            "d": ak.randint(0, 50, 1000)
+        })
+        odf = ak.DataFrame({
+            "b": ak.randint(0, 25, 50),
+            "c": ak.arange(50, dtype=bool),
+        })
+        with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
+            df.to_hdf(f"{tmp_dirname}/repack_test")
+            f_list = glob.glob(f"{tmp_dirname}/repack_test_*")
+            orig_size = 0
+            for f in f_list:
+                orig_size += os.path.getsize(f)
+            # hdf5 only releases memory if overwritting last dset so overwrite first
+            odf.update_hdf(f"{tmp_dirname}/repack_test")
+
+            new_size = 0
+            for f in f_list:
+                new_size += os.path.getsize(f)
+            print(f"\nOrig: {orig_size}\nNew: {new_size}\n")
+            # ensure that the column was actually overwritten
+            self.assertLessEqual(new_size, orig_size)
+            data = ak.read_hdf(f"{tmp_dirname}/repack_test_*")
+            self.assertListEqual(data["b"].to_list(), odf["b"].to_list())
+            self.assertListEqual(data["c"].to_list(), odf["c"].to_list())
+
+        with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
+            df.to_hdf(f"{tmp_dirname}/repack_test")
+            f_list = glob.glob(f"{tmp_dirname}/repack_test_*")
+            orig_size = 0
+            for f in f_list:
+                orig_size += os.path.getsize(f)
+            # hdf5 only releases memory if overwritting last dset so overwrite first
+            odf.update_hdf(f"{tmp_dirname}/repack_test", repack=False)
+
+            new_size = 0
+            for f in f_list:
+                new_size += os.path.getsize(f)
+            print(f"\nOrig: {orig_size}\nNew: {new_size}\n")
+            # ensure that the column was actually overwritten
+            self.assertGreaterEqual(new_size, orig_size)
+            data = ak.read_hdf(f"{tmp_dirname}/repack_test_*")
+            self.assertListEqual(data["b"].to_list(), odf["b"].to_list())
+            self.assertListEqual(data["c"].to_list(), odf["c"].to_list())
+
+    def test_overwrite_segarray(self):
+        sa1 = ak.segarray(ak.arange(0, 1000, 5), ak.arange(1000))
+        sa2 = ak.segarray(ak.arange(0, 100, 5), ak.arange(100))
+        with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
+            sa1.to_hdf(f"{tmp_dirname}/repack_test")
+            sa1.to_hdf(f"{tmp_dirname}/repack_test", dataset="seg2", mode="append")
+            f_list = glob.glob(f"{tmp_dirname}/repack_test_*")
+            orig_size = 0
+            for f in f_list:
+                orig_size += os.path.getsize(f)
+
+            sa2.update_hdf(f"{tmp_dirname}/repack_test")
+
+            new_size = 0
+            for f in f_list:
+                new_size += os.path.getsize(f)
+            # ensure that the column was actually overwritten
+            self.assertLessEqual(new_size, orig_size)
+            data = ak.read_hdf(f"{tmp_dirname}/repack_test_*")
+            self.assertListEqual(data["segarray"].values.to_list(), sa2.values.to_list())
+            self.assertListEqual(data["segarray"].segments.to_list(), sa2.segments.to_list())
+
+        with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
+            sa1.to_hdf(f"{tmp_dirname}/repack_test")
+            sa1.to_hdf(f"{tmp_dirname}/repack_test", dataset="seg2", mode="append")
+            f_list = glob.glob(f"{tmp_dirname}/repack_test_*")
+            orig_size = 0
+            for f in f_list:
+                orig_size += os.path.getsize(f)
+
+            sa2.update_hdf(f"{tmp_dirname}/repack_test", repack=False)
+
+            new_size = 0
+            for f in f_list:
+                new_size += os.path.getsize(f)
+            # ensure that the column was actually overwritten
+            self.assertGreaterEqual(new_size, orig_size)
+            data = ak.read_hdf(f"{tmp_dirname}/repack_test_*")
+            self.assertListEqual(data["segarray"].values.to_list(), sa2.values.to_list())
+            self.assertListEqual(data["segarray"].segments.to_list(), sa2.segments.to_list())
+
+    def test_overwrite(self):
+        df = ak.DataFrame({
+            "a": ak.arange(1000),
+            "b": ak.random_strings_uniform(0, 16, 1000),
+            "c": ak.arange(1000, dtype=bool),
+            "d": ak.randint(0, 50, 1000)
+        })
+        replace = {
+            "b": ak.randint(0, 25, 50),
+            "c": ak.arange(50, dtype=bool),
+        }
+        with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
+            df.to_hdf(f"{tmp_dirname}/repack_test")
+            f_list = glob.glob(f"{tmp_dirname}/repack_test_*")
+            orig_size = 0
+            for f in f_list:
+                orig_size += os.path.getsize(f)
+            # hdf5 only releases memory if overwritting last dset so overwrite first
+            ak.update_hdf(replace, f"{tmp_dirname}/repack_test")
+
+            new_size = 0
+            for f in f_list:
+                new_size += os.path.getsize(f)
+            print(f"\nOrig: {orig_size}\nNew: {new_size}\n")
+            # ensure that the column was actually overwritten
+            self.assertLessEqual(new_size, orig_size)
+            data = ak.read_hdf(f"{tmp_dirname}/repack_test_*")
+            self.assertListEqual(data["b"].to_list(), replace["b"].to_list())
+            self.assertListEqual(data["c"].to_list(), replace["c"].to_list())
+
+        with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
+            df.to_hdf(f"{tmp_dirname}/repack_test")
+            f_list = glob.glob(f"{tmp_dirname}/repack_test_*")
+            orig_size = 0
+            for f in f_list:
+                orig_size += os.path.getsize(f)
+            # hdf5 only releases memory if overwritting last dset so overwrite first
+            ak.update_hdf(replace, f"{tmp_dirname}/repack_test", repack=False)
+
+            new_size = 0
+            for f in f_list:
+                new_size += os.path.getsize(f)
+            print(f"\nOrig: {orig_size}\nNew: {new_size}\n")
+            # ensure that the column was actually overwritten
+            self.assertLessEqual(new_size, orig_size)
+            data = ak.read_hdf(f"{tmp_dirname}/repack_test_*")
+            self.assertListEqual(data["b"].to_list(), replace["b"].to_list())
+            self.assertListEqual(data["c"].to_list(), replace["c"].to_list())
+
+    def test_overwrite_single_dset(self):
+        # we need to test that both repack=False and repack=True generate the same file size here
+        a = ak.arange(1000)
+        b = ak.arange(15)
+        with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
+            a.to_hdf(f"{tmp_dirname}/test_file")
+            b.update_hdf(f"{tmp_dirname}/test_file")
+            f_list = glob.glob(f"{tmp_dirname}/test_file*")
+            f1_size = 0
+            for f in f_list:
+                f1_size += os.path.getsize(f)
+
+            a.to_hdf(f"{tmp_dirname}/test_file_2")
+            b.update_hdf(f"{tmp_dirname}/test_file_2", repack=False)
+            f_list = glob.glob(f"{tmp_dirname}/test_file_2_*")
+            f2_size = 0
+            for f in f_list:
+                f2_size += os.path.getsize(f)
+
+            self.assertEqual(f1_size, f2_size)
+
     def tearDown(self):
         super(IOTest, self).tearDown()
         for f in glob.glob("{}/*".format(IOTest.io_test_dir)):

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -881,12 +881,12 @@ class IOTest(ArkoudaTest):
         a = ak.arange(1000)
         b = ak.randint(0, 100, 1000)
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
-            a.to_hdf(f"{tmp_dirname}/repack_test")
-            f_list = glob.glob(f"{tmp_dirname}/repack_test_*")
+            a.to_hdf(f"{tmp_dirname}/pda_test")
+            f_list = glob.glob(f"{tmp_dirname}/pda_test_*")
             orig_size = 0
             for f in f_list:
                 orig_size += os.path.getsize(f)
-            b.update_hdf(f"{tmp_dirname}/repack_test")
+            b.update_hdf(f"{tmp_dirname}/pda_test")
 
             new_size = 0
             for f in f_list:
@@ -894,21 +894,21 @@ class IOTest(ArkoudaTest):
 
             # ensure that the column was actually overwritten
             self.assertEqual(orig_size, new_size)
-            data = ak.read_hdf(f"{tmp_dirname}/repack_test_*")
+            data = ak.read_hdf(f"{tmp_dirname}/pda_test_*")
             self.assertListEqual(data.to_list(), b.to_list())
 
         # test with repack off - file should get larger
         b = ak.arange(1000)
         c = ak.arange(15)
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
-            a.to_hdf(f"{tmp_dirname}/repack_test")
-            b.to_hdf(f"{tmp_dirname}/repack_test", dataset="array_2", mode="append")
-            f_list = glob.glob(f"{tmp_dirname}/repack_test_*")
+            a.to_hdf(f"{tmp_dirname}/pda_test")
+            b.to_hdf(f"{tmp_dirname}/pda_test", dataset="array_2", mode="append")
+            f_list = glob.glob(f"{tmp_dirname}/pda_test_*")
             orig_size = 0
             for f in f_list:
                 orig_size += os.path.getsize(f)
             # hdf5 only releases memory if overwritting last dset so overwrite first
-            c.update_hdf(f"{tmp_dirname}/repack_test", dataset="array", repack=False)
+            c.update_hdf(f"{tmp_dirname}/pda_test", dataset="array", repack=False)
 
             new_size = 0
             for f in f_list:
@@ -916,25 +916,25 @@ class IOTest(ArkoudaTest):
 
             # ensure that the column was actually overwritten
             self.assertGreaterEqual(new_size, orig_size)  # ensure that overwritten data mem is not released
-            data = ak.read_hdf(f"{tmp_dirname}/repack_test_*")
+            data = ak.read_hdf(f"{tmp_dirname}/pda_test_*")
             self.assertListEqual(data["array"].to_list(), c.to_list())
 
         # test overwrites with different types
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
-            a.to_hdf(f"{tmp_dirname}/repack_test")
+            a.to_hdf(f"{tmp_dirname}/pda_test")
             b = ak.arange(15, dtype=ak.uint64)
-            b.update_hdf(f"{tmp_dirname}/repack_test")
-            data = ak.read_hdf(f"{tmp_dirname}/repack_test_*")
+            b.update_hdf(f"{tmp_dirname}/pda_test")
+            data = ak.read_hdf(f"{tmp_dirname}/pda_test_*")
             self.assertListEqual(data.to_list(), b.to_list())
 
             b = ak.arange(150, dtype=ak.float64)
-            b.update_hdf(f"{tmp_dirname}/repack_test")
-            data = ak.read_hdf(f"{tmp_dirname}/repack_test_*")
+            b.update_hdf(f"{tmp_dirname}/pda_test")
+            data = ak.read_hdf(f"{tmp_dirname}/pda_test_*")
             self.assertListEqual(data.to_list(), b.to_list())
 
             b = ak.arange(1000, dtype=ak.bool)
-            b.update_hdf(f"{tmp_dirname}/repack_test")
-            data = ak.read_hdf(f"{tmp_dirname}/repack_test_*")
+            b.update_hdf(f"{tmp_dirname}/pda_test")
+            data = ak.read_hdf(f"{tmp_dirname}/pda_test_*")
             self.assertListEqual(data.to_list(), b.to_list())
 
     def test_hdf_overwrite_strings(self):
@@ -943,38 +943,38 @@ class IOTest(ArkoudaTest):
         b = ak.random_strings_uniform(0, 16, 1000)
         c = ak.random_strings_uniform(0, 16, 10)
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
-            a.to_hdf(f"{tmp_dirname}/repack_test", dataset="test_set")
-            b.to_hdf(f"{tmp_dirname}/repack_test", mode="append")
-            f_list = glob.glob(f"{tmp_dirname}/repack_test_*")
+            a.to_hdf(f"{tmp_dirname}/str_test", dataset="test_set")
+            b.to_hdf(f"{tmp_dirname}/str_test", mode="append")
+            f_list = glob.glob(f"{tmp_dirname}/str_test_*")
             orig_size = 0
             for f in f_list:
                 orig_size += os.path.getsize(f)
-            c.update_hdf(f"{tmp_dirname}/repack_test", dataset="test_set")
+            c.update_hdf(f"{tmp_dirname}/str_test", dataset="test_set")
 
             new_size = 0
             for f in f_list:
                 new_size += os.path.getsize(f)
             # ensure that the column was actually overwritten
             self.assertLessEqual(new_size, orig_size)
-            data = ak.read_hdf(f"{tmp_dirname}/repack_test_*")
+            data = ak.read_hdf(f"{tmp_dirname}/str_test_*")
             self.assertListEqual(data["test_set"].to_list(), c.to_list())
 
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
-            a.to_hdf(f"{tmp_dirname}/repack_test", dataset="test_set")
-            b.to_hdf(f"{tmp_dirname}/repack_test", mode="append")
-            f_list = glob.glob(f"{tmp_dirname}/repack_test_*")
+            a.to_hdf(f"{tmp_dirname}/str_test", dataset="test_set")
+            b.to_hdf(f"{tmp_dirname}/str_test", mode="append")
+            f_list = glob.glob(f"{tmp_dirname}/str_test_*")
             orig_size = 0
             for f in f_list:
                 orig_size += os.path.getsize(f)
             # hdf5 only releases memory if overwritting last dset so overwrite first
-            c.update_hdf(f"{tmp_dirname}/repack_test", dataset="test_set", repack=False)
+            c.update_hdf(f"{tmp_dirname}/str_test", dataset="test_set", repack=False)
 
             new_size = 0
             for f in f_list:
                 new_size += os.path.getsize(f)
             # ensure that the column was actually overwritten
             self.assertGreaterEqual(new_size, orig_size)
-            data = ak.read_hdf(f"{tmp_dirname}/repack_test_*")
+            data = ak.read_hdf(f"{tmp_dirname}/str_test_*")
             self.assertListEqual(data["test_set"].to_list(), c.to_list())
 
     def test_hdf_overwrite_dataframe(self):
@@ -989,21 +989,20 @@ class IOTest(ArkoudaTest):
             "c": ak.arange(50, dtype=bool),
         })
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
-            df.to_hdf(f"{tmp_dirname}/repack_test")
-            f_list = glob.glob(f"{tmp_dirname}/repack_test_*")
+            df.to_hdf(f"{tmp_dirname}/df_test")
+            f_list = glob.glob(f"{tmp_dirname}/df_test_*")
             orig_size = 0
             for f in f_list:
                 orig_size += os.path.getsize(f)
             # hdf5 only releases memory if overwritting last dset so overwrite first
-            odf.update_hdf(f"{tmp_dirname}/repack_test")
+            odf.update_hdf(f"{tmp_dirname}/df_test")
 
             new_size = 0
             for f in f_list:
                 new_size += os.path.getsize(f)
-            print(f"\nOrig: {orig_size}\nNew: {new_size}\n")
             # ensure that the column was actually overwritten
             self.assertLessEqual(new_size, orig_size)
-            data = ak.read_hdf(f"{tmp_dirname}/repack_test_*")
+            data = ak.read_hdf(f"{tmp_dirname}/df_test_*")
             self.assertListEqual(data["b"].to_list(), odf["b"].to_list())
             self.assertListEqual(data["c"].to_list(), odf["c"].to_list())
 
@@ -1014,15 +1013,14 @@ class IOTest(ArkoudaTest):
             for f in f_list:
                 orig_size += os.path.getsize(f)
             # hdf5 only releases memory if overwritting last dset so overwrite first
-            odf.update_hdf(f"{tmp_dirname}/repack_test", repack=False)
+            odf.update_hdf(f"{tmp_dirname}/df_test", repack=False)
 
             new_size = 0
             for f in f_list:
                 new_size += os.path.getsize(f)
-            print(f"\nOrig: {orig_size}\nNew: {new_size}\n")
             # ensure that the column was actually overwritten
             self.assertGreaterEqual(new_size, orig_size)
-            data = ak.read_hdf(f"{tmp_dirname}/repack_test_*")
+            data = ak.read_hdf(f"{tmp_dirname}/df_test_*")
             self.assertListEqual(data["b"].to_list(), odf["b"].to_list())
             self.assertListEqual(data["c"].to_list(), odf["c"].to_list())
 
@@ -1030,42 +1028,55 @@ class IOTest(ArkoudaTest):
         sa1 = ak.segarray(ak.arange(0, 1000, 5), ak.arange(1000))
         sa2 = ak.segarray(ak.arange(0, 100, 5), ak.arange(100))
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
-            sa1.to_hdf(f"{tmp_dirname}/repack_test")
-            sa1.to_hdf(f"{tmp_dirname}/repack_test", dataset="seg2", mode="append")
-            f_list = glob.glob(f"{tmp_dirname}/repack_test_*")
+            sa1.to_hdf(f"{tmp_dirname}/segarray_test")
+            sa1.to_hdf(f"{tmp_dirname}/segarray_test", dataset="seg2", mode="append")
+            f_list = glob.glob(f"{tmp_dirname}/segarray_test_*")
             orig_size = 0
             for f in f_list:
                 orig_size += os.path.getsize(f)
 
-            sa2.update_hdf(f"{tmp_dirname}/repack_test")
+            sa2.update_hdf(f"{tmp_dirname}/segarray_test")
 
             new_size = 0
             for f in f_list:
                 new_size += os.path.getsize(f)
             # ensure that the column was actually overwritten
             self.assertLessEqual(new_size, orig_size)
-            data = ak.read_hdf(f"{tmp_dirname}/repack_test_*")
+            data = ak.read_hdf(f"{tmp_dirname}/segarray_test_*")
             self.assertListEqual(data["segarray"].values.to_list(), sa2.values.to_list())
             self.assertListEqual(data["segarray"].segments.to_list(), sa2.segments.to_list())
 
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
-            sa1.to_hdf(f"{tmp_dirname}/repack_test")
-            sa1.to_hdf(f"{tmp_dirname}/repack_test", dataset="seg2", mode="append")
-            f_list = glob.glob(f"{tmp_dirname}/repack_test_*")
+            sa1.to_hdf(f"{tmp_dirname}/segarray_test")
+            sa1.to_hdf(f"{tmp_dirname}/segarray_test", dataset="seg2", mode="append")
+            f_list = glob.glob(f"{tmp_dirname}/segarray_test_*")
             orig_size = 0
             for f in f_list:
                 orig_size += os.path.getsize(f)
 
-            sa2.update_hdf(f"{tmp_dirname}/repack_test", repack=False)
+            sa2.update_hdf(f"{tmp_dirname}/segarray_test", repack=False)
 
             new_size = 0
             for f in f_list:
                 new_size += os.path.getsize(f)
             # ensure that the column was actually overwritten
             self.assertGreaterEqual(new_size, orig_size)
-            data = ak.read_hdf(f"{tmp_dirname}/repack_test_*")
+            data = ak.read_hdf(f"{tmp_dirname}/segarray_test_*")
             self.assertListEqual(data["segarray"].values.to_list(), sa2.values.to_list())
             self.assertListEqual(data["segarray"].segments.to_list(), sa2.segments.to_list())
+
+    def test_overwrite_arrayview(self):
+        a = ak.arange(27)
+        av = a.reshape((3, 3, 3))
+        a2 = ak.arange(8)
+        av2 = a2.reshape((2, 2, 2))
+        with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
+            av.to_hdf(f"{tmp_dirname}/array_view_test")
+            av2.update_hdf(f"{tmp_dirname}/array_view_test", repack=False)
+            data = ak.read_hdf(f"{tmp_dirname}/array_view_test_*")
+            print(data)
+            self.assertListEqual(av2.to_list(), data.to_list())
+
 
     def test_overwrite(self):
         df = ak.DataFrame({
@@ -1079,13 +1090,13 @@ class IOTest(ArkoudaTest):
             "c": ak.arange(50, dtype=bool),
         }
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
-            df.to_hdf(f"{tmp_dirname}/repack_test")
-            f_list = glob.glob(f"{tmp_dirname}/repack_test_*")
+            df.to_hdf(f"{tmp_dirname}/overwrite_test")
+            f_list = glob.glob(f"{tmp_dirname}/overwrite_test_*")
             orig_size = 0
             for f in f_list:
                 orig_size += os.path.getsize(f)
             # hdf5 only releases memory if overwritting last dset so overwrite first
-            ak.update_hdf(replace, f"{tmp_dirname}/repack_test")
+            ak.update_hdf(replace, f"{tmp_dirname}/overwrite_test")
 
             new_size = 0
             for f in f_list:
@@ -1093,18 +1104,18 @@ class IOTest(ArkoudaTest):
             print(f"\nOrig: {orig_size}\nNew: {new_size}\n")
             # ensure that the column was actually overwritten
             self.assertLessEqual(new_size, orig_size)
-            data = ak.read_hdf(f"{tmp_dirname}/repack_test_*")
+            data = ak.read_hdf(f"{tmp_dirname}/overwrite_test_*")
             self.assertListEqual(data["b"].to_list(), replace["b"].to_list())
             self.assertListEqual(data["c"].to_list(), replace["c"].to_list())
 
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
-            df.to_hdf(f"{tmp_dirname}/repack_test")
-            f_list = glob.glob(f"{tmp_dirname}/repack_test_*")
+            df.to_hdf(f"{tmp_dirname}/overwrite_test")
+            f_list = glob.glob(f"{tmp_dirname}/overwrite_test_*")
             orig_size = 0
             for f in f_list:
                 orig_size += os.path.getsize(f)
             # hdf5 only releases memory if overwritting last dset so overwrite first
-            ak.update_hdf(replace, f"{tmp_dirname}/repack_test", repack=False)
+            ak.update_hdf(replace, f"{tmp_dirname}/overwrite_test", repack=False)
 
             new_size = 0
             for f in f_list:
@@ -1112,7 +1123,7 @@ class IOTest(ArkoudaTest):
             print(f"\nOrig: {orig_size}\nNew: {new_size}\n")
             # ensure that the column was actually overwritten
             self.assertLessEqual(new_size, orig_size)
-            data = ak.read_hdf(f"{tmp_dirname}/repack_test_*")
+            data = ak.read_hdf(f"{tmp_dirname}/overwrite_test_*")
             self.assertListEqual(data["b"].to_list(), replace["b"].to_list())
             self.assertListEqual(data["c"].to_list(), replace["c"].to_list())
 


### PR DESCRIPTION
Closes #474 

- Adds dataset overwrite functionality via `update_hdf` method to `pdarray`, `Strings`, `SegArray`, `DataFrame`, `Index` and `ArrayView`. `Categorical` was not added because the storage format in HDF5 needs to be updated. Issues #2372 and #2373 have been added for updating the storage format and adding `update_hdf` to `Categorical`.
- Adds general `update_hdf` to the `Arkouda.io` package.
- Adds functionality to determine if the HDF5 file was saved as a single file or distributed file. This adds an attribute to HDF5 files to indicate this on write. For any files predating this change, it will check for an `_LOCALE####` suffix in the file name.
- Adds testing to ensure functionality of `ak.io.update_hdf`, `pdarray.update_hdf`, `Strings.update_hdf`, `DataFrame.update_hdf` and `SegArray.update_hdf`. `Index.update_hdf` testing was not added because it calls the `pdarray` code which is already being tested. Minimal `ArrayView.update_hdf` testing added because `ArrayView` will most likely be deprecated soon in favor of another multi-dimensional implementation.
- Adds private `_repack_hdf`. This method simulates the HDF5 repack command line tool which overwrites the file with a copy. The copy will contain only accessible data. This prevents issues due to HDF5 not releasing memory in certain situations. There is an early out check for the case when only 1 dataset exists in the file and is being overwritten. In this case, memory is released properly without the repack so we skip for efficiency. 

**Important Note**
This feature will repack by default to ensure that files don't expand with unaccessible data. However, if users desire the best performance and the file sizes are not a concern, repack can be turned off.