### PR TITLE
Fixes #2380: Segarray register bug

### DIFF
--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import json
 import warnings
-from typing import cast as type_cast
 from typing import Optional, Sequence
+from typing import cast as type_cast
+from warnings import warn
 
 import numpy as np  # type: ignore
 
@@ -13,12 +14,22 @@ from arkouda.dtypes import bool as akbool
 from arkouda.dtypes import int64 as akint64
 from arkouda.dtypes import isSupportedInt, str_, translate_np_dtype
 from arkouda.groupbyclass import GroupBy, broadcast
-from arkouda.infoclass import list_registry
 from arkouda.logger import getArkoudaLogger
 from arkouda.numeric import cumsum
-from arkouda.pdarrayclass import RegistrationError, create_pdarray, is_sorted, pdarray
+from arkouda.pdarrayclass import (
+    RegistrationError,
+    create_pdarray,
+    is_sorted,
+    pdarray,
+    unregister_pdarray_by_name,
+)
 from arkouda.pdarraycreation import arange, array, ones, zeros
 from arkouda.pdarraysetops import concatenate
+
+SEG_SUFFIX = "_segments"
+VAL_SUFFIX = "_values"
+LEN_SUFFIX = "_lengths"
+GROUP_SUFFIX = "_grouping"
 
 
 def gen_ranges(starts, ends, stride=1):
@@ -1077,7 +1088,12 @@ class SegArray:
         - Because HDF5 deletes do not release memory, this will create a copy of the
           file with the new data
         """
-        from arkouda.io import _get_hdf_filetype, _mode_str_to_int, _file_type_to_int, _repack_hdf
+        from arkouda.io import (
+            _file_type_to_int,
+            _get_hdf_filetype,
+            _mode_str_to_int,
+            _repack_hdf,
+        )
 
         # determine the format (single/distribute) that the file was saved in
         file_type = _get_hdf_filetype(prefix_path + "*")
@@ -1549,6 +1565,10 @@ class SegArray:
             raise RegistrationError(f"Server was unable to register {user_defined_name}")
 
         self.name = user_defined_name
+        self.segments.register(self.name + SEG_SUFFIX)
+        self.values.register(self.name + VAL_SUFFIX)
+        self.lengths.register(self.name + LEN_SUFFIX)
+        self.grouping.register(self.name + GROUP_SUFFIX)
         return self
 
     def unregister(self):
@@ -1569,6 +1589,10 @@ class SegArray:
         register, attach, is_registered
         """
         SegArray.unregister_segarray_by_name(self.name)
+        self.segments.unregister()
+        self.values.unregister()
+        self.lengths.unregister()
+        self.grouping.unregister()
 
     @staticmethod
     def unregister_segarray_by_name(user_defined_name):
@@ -1594,6 +1618,10 @@ class SegArray:
         register, unregister, attach, is_registered
         """
         generic_msg(cmd="unregister", args={"name": user_defined_name})
+        unregister_pdarray_by_name(user_defined_name + SEG_SUFFIX)
+        unregister_pdarray_by_name(user_defined_name + VAL_SUFFIX)
+        unregister_pdarray_by_name(user_defined_name + LEN_SUFFIX)
+        GroupBy.unregister_groupby_by_name(user_defined_name + GROUP_SUFFIX)
 
     @classmethod
     def attach(cls, user_defined_name):
@@ -1641,5 +1669,16 @@ class SegArray:
         --------
         register, unregister, attach
         """
+        regParts = [
+            self.segments.is_registered(),
+            self.values.is_registered(),
+            self.lengths.is_registered(),
+            self.grouping.is_registered(),
+        ]
 
-        return self.name in list_registry()
+        if any(regParts) and not all(regParts):
+            warn(
+                f"SegArray expected {len(regParts)} components to be registered,"
+                f" but only located {sum(regParts)}"
+            )
+        return all(regParts)

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -1589,10 +1589,6 @@ class SegArray:
         register, attach, is_registered
         """
         SegArray.unregister_segarray_by_name(self.name)
-        self.segments.unregister()
-        self.values.unregister()
-        self.lengths.unregister()
-        self.grouping.unregister()
 
     @staticmethod
     def unregister_segarray_by_name(user_defined_name):

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -69,7 +69,9 @@ module MultiTypeSymbolTable
             registry += userDefinedName; // add user defined name to registry
 
             // point at same shared table entry
-            tab.addOrSet(userDefinedName, tab.getAndRemove(name));
+            var entry = tab.getAndRemove(name);
+            tab.addOrSet(userDefinedName, entry);
+            entry.setName(userDefinedName);
         }
 
         proc unregName(name: string) throws {

--- a/tests/registration_test.py
+++ b/tests/registration_test.py
@@ -509,6 +509,7 @@ class RegistrationTest(ArkoudaTest):
         s.register("seriesTest")
         self.assertTrue(s.is_registered())
 
+        ak.clear()
         s2 = Series.attach("seriesTest")
         self.assertListEqual(s2.values.to_list(), s.values.to_list())
         sEq = s2.index == s.index
@@ -518,6 +519,7 @@ class RegistrationTest(ArkoudaTest):
         s = ak.array(["abc", "123", "abc"])
         sGroup = ak.GroupBy(s)
         sGroup.register("stringsTest")
+        ak.clear()
         sAttach = ak.GroupBy.attach("stringsTest")
 
         # Verify the attached GroupBy's components equal the original components
@@ -535,6 +537,7 @@ class RegistrationTest(ArkoudaTest):
         a = ak.randint(0, 10, 10)
         aGroup = ak.GroupBy(a)
         aGroup.register("pdarray_test")
+        ak.clear()
         aAttach = ak.GroupBy.attach("pdarray_test")
 
         # Verify the attached GroupBy's components equal the original components
@@ -553,6 +556,7 @@ class RegistrationTest(ArkoudaTest):
         cat = ak.Categorical(c)
         catGroup = ak.GroupBy(cat)
         catGroup.register("categorical_test")
+        ak.clear()
         catAttach = ak.GroupBy.attach("categorical_test")
 
         # Verify the attached GroupBy's components equal the original components
@@ -573,6 +577,7 @@ class RegistrationTest(ArkoudaTest):
         lx = [a, b, c]
         group = ak.GroupBy(lx)
         group.register("sequenceTest")
+        ak.clear()
         seqAttach = ak.GroupBy.attach("sequenceTest")
 
         # Verify the attached GroupBy's components equal the original components for each key
@@ -651,6 +656,7 @@ class RegistrationTest(ArkoudaTest):
         # Register DataFrame with name 'DataFrame_test'
         df.register("DataFrame_test")
         self.assertTrue(df.is_registered())
+        ak.clear()
 
         # Attach registered DataFrame 'DataFrame_test' into variable dfa and assert the original and
         # attached versions of the DataFrame are equal
@@ -667,14 +673,14 @@ class RegistrationTest(ArkoudaTest):
         df.unregister()
         self.assertFalse(df.is_registered())
 
-    def test_register_attach(self):
+    def test_segarray_register_attach(self):
         a = [1, 2, 3]
         b = [6, 7, 8]
 
         segarr = ak.segarray(ak.array([0, len(a)]), ak.array(a + b))
         # register the seg array
         segarr.register("segarrtest")
-
+        ak.clear()
         segarr_2 = ak.SegArray.attach("segarrtest")
 
         self.assertEqual(segarr.size, segarr_2.size)
@@ -687,13 +693,14 @@ class RegistrationTest(ArkoudaTest):
         segarr.unregister()
         self.assertFalse(segarr.is_registered())
 
-    def test_unregister_by_name(self):
+    def test_segarray_unregister_by_name(self):
         a = [1, 2, 3]
         b = [6, 7, 8]
 
         segarr = ak.segarray(ak.array([0, len(a)]), ak.array(a + b))
         # register the seg array
         segarr.register("segarr_unreg_name_test")
+        ak.clear()
 
         # Verify is_registered
         self.assertTrue(segarr.is_registered())


### PR DESCRIPTION
This PR (fixes #2380):
- Updates segarray to register it's underlying components. This seems to be necessary any time these components are exposed to the user (which is why it isn't an issue for segstrings)
- Updates some registration tests to call `ak.clear` to verify that attaching is not relying on any components that just happen to still be present. With the `clear`s, `test_segarray_register_attach` failed before this PR
- Updates `regName` to actually update `.name` component of the symentry to the new `user_defined_name`. This was required for `attach` to continue working as is, and it kinda blows my mind that this hasn't come up before

I verified this PR correctly handles the reproducers in the issue

I think going forward we should move this to in line with Categorical (perhaps using Registerable and Required pieces), but wanted to keep it straightforward/minimal changes since this is a bug fix