### PR TITLE
Closes #2372 & #2373 - Categorical HDF5 Format Update & `update_hdf` method

### DIFF
--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -770,7 +770,7 @@ class Categorical:
             new_categories = new_arrays[0].categories
             new_codes = cast(pdarray, concatenate([arr.codes for arr in new_arrays], ordered=ordered))
             return Categorical.from_codes(new_codes, new_categories, NAvalue=self.NAvalue)
-    
+
     def to_hdf(
         self,
         prefix_path,

--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -774,7 +774,7 @@ class Categorical:
     def to_hdf(
         self,
         prefix_path,
-        dataset="categorical",
+        dataset="categorical_array",
         mode="truncate",
         file_type="distribute",
     ):
@@ -828,7 +828,7 @@ class Categorical:
     def update_hdf(
         self,
         prefix_path,
-        dataset="categorical",
+        dataset="categorical_array",
         repack=True
     ):
         """

--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -855,7 +855,7 @@ class Categorical:
         Raises
         -------
         RuntimeError
-            Raised if a server-side error is thrown saving the SegArray
+            Raised if a server-side error is thrown saving the Categorical
 
         Notes
         ------

--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -862,8 +862,8 @@ class Categorical:
         - If file does not contain File_Format attribute to indicate how it was saved,
           the file name is checked for _LOCALE#### to determine if it is distributed.
         - If the dataset provided does not exist, it will be added
-        - Because HDF5 deletes do not release memory, this will create a copy of the
-          file with the new data
+        - Because HDF5 deletes do not release memory, the repack option allows for
+          automatic creation of a file without the inaccessible data.
         """
         from arkouda.io import _get_hdf_filetype, _mode_str_to_int, _file_type_to_int, _repack_hdf
 

--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import itertools
+import json
 from collections import defaultdict
 from typing import (
     DefaultDict,
@@ -17,6 +18,7 @@ from typing import (
 import numpy as np  # type: ignore
 from typeguard import typechecked
 
+from arkouda.client import generic_msg
 from arkouda.decorators import objtypedec
 from arkouda.dtypes import bool as akbool
 from arkouda.dtypes import int64 as akint64
@@ -119,7 +121,7 @@ class Categorical:
 
         # When read from file or attached, NA code will be passed as a pdarray
         # Otherwise, the NA value is set to a string
-        if "_akNAcode" in kwargs:
+        if "_akNAcode" in kwargs and kwargs["_akNAcode"] is not None:
             self._akNAcode = kwargs["_akNAcode"]
             self._NAcode = int(self._akNAcode[0])
             self.NAvalue = self.categories[self._NAcode]
@@ -188,6 +190,29 @@ class Categorical:
             segments=segments,
             **kwargs,
         )
+
+    @classmethod
+    def from_return_msg(cls, rep_msg) -> Categorical:
+        """
+        Create categorical from return message from server
+
+        Notes
+        ------
+        This is currently only used when reading a Categorical from HDF5 files.
+        """
+        # parse return json
+        eles = json.loads(rep_msg)
+        codes = create_pdarray(eles["codes"])
+        cats = Strings.from_return_msg(eles["categories"])
+        na_code = create_pdarray(eles["_akNAcode"])
+
+        segments = None
+        perm = None
+        if "segments" in eles and "permutation" in eles:
+            segments = create_pdarray(eles["segments"])
+            perm = create_pdarray(eles["permutation"])
+
+        return cls.from_codes(codes, cats, permutation=perm, segments=segments, _akNAcode=na_code)
 
     @classmethod
     def standardize_categories(cls, arrays, NAvalue="N/A"):
@@ -274,60 +299,6 @@ class Categorical:
         # Apply the lookup to map old codes to new codes
         new_codes = code_mapping[self.codes]
         return self.__class__.from_codes(new_codes, new_categories, NAvalue=NAvalue)
-
-    @staticmethod
-    def from_return_msg(repMsg):
-        """
-        Return a categorical instance pointing to components created by the arkouda server.
-        The user should not call this function directly.
-
-        Parameters
-        ----------
-        repMsg : str
-            ; delimited string containing the categories, codes, permutation, and segments
-            details
-
-        Returns
-        -------
-        categorical
-            A categorical representing a set of strings and pdarray components on the server
-
-        Raises
-        ------
-        RuntimeError
-            Raised if a server-side error is thrown in the process of creating
-            the categorical instance
-        """
-        # parts[0] is "categorical". Used by the generic attach method to identify the
-        # response message as a Categorical
-
-        repParts = repMsg.split("+")
-        stringsMsg = f"{repParts[1]}+{repParts[2]}"
-        parts = {
-            "categories": Strings.from_return_msg(stringsMsg),
-            "codes": create_pdarray(repParts[3]),
-            "_akNAcode": create_pdarray(repParts[4]),
-        }
-
-        if len(repParts) > 5:
-            for i in range(5, len(repParts)):
-                name = repParts[i].split()[1]
-                if ".permutation" in name:
-                    parts["permutation"] = create_pdarray(repParts[i])
-                elif ".segments" in name:
-                    parts["segments"] = create_pdarray(repParts[i])
-                else:
-                    raise ValueError(f"Unknown field, {name}, found in Categorical.")
-
-        # To get the name split the message into Categories, Codes, Permutation, Segments
-        # then split the categories into it's components, Name being second: name.categories
-        # split the name on . and take the first half to get the given name
-        # for example repParts[1] = "created user_defined_name.categories"
-        name = repParts[1].split()[1].split(".")[0]
-
-        c = Categorical(None, **parts)  # Call constructor with unpacked kwargs
-        c.name = name  # Update our name
-        return c
 
     def to_ndarray(self) -> np.ndarray:
         """
@@ -799,80 +770,60 @@ class Categorical:
             new_categories = new_arrays[0].categories
             new_codes = cast(pdarray, concatenate([arr.codes for arr in new_arrays], ordered=ordered))
             return Categorical.from_codes(new_codes, new_categories, NAvalue=self.NAvalue)
-
+    
     def to_hdf(
         self,
-        prefix_path: str,
-        dataset: str = "categorical_array",
-        mode: str = "truncate",
-        file_type: str = "distribute",
-    ) -> str:
+        prefix_path,
+        dataset="categorical",
+        mode="truncate",
+        file_type="distribute",
+    ):
         """
-        Save the Categorical object to HDF5.
-        The object can be saved to a collection of files or single file.
+        Save the Categorical to HDF5. The result is a collection of HDF5 files, one file
+        per locale of the arkouda server, where each filename starts with prefix_path.
 
         Parameters
         ----------
         prefix_path : str
-            Directory and filename prefix that all output files share
+            Directory and filename prefix that all output files will share
         dataset : str
-            Name of the dataset to create in HDF5 files (must not already exist)
+            Name prefix for saved data within the HDF5 file
         mode : str {'truncate' | 'append'}
             By default, truncate (overwrite) output files, if they exist.
-            If 'append', create a new Categorical dataset within existing files.
+            If 'append', add data as a new column to existing files.
         file_type: str ("single" | "distribute")
             Default: "distribute"
             When set to single, dataset is written to a single file.
             When distribute, dataset is written on a file per locale.
-            This is only supported by HDF5 files and will have no impact of Parquet Files.
 
         Returns
         -------
-        String message indicating result of save operation
+        None
 
-        Raises
-        ------
-        RuntimeError
-            Raised if a server-side error is thrown saving the pdarray
-        Notes
-        -----
-        - The prefix_path must be visible to the arkouda server and the user must
-        have write permission.
-        - Output files have names of the form ``<prefix_path>_LOCALE<i>``, where ``<i>``
-        ranges from 0 to ``numLocales`` for `file_type='distribute'`. Otherwise,
-        the file name will be `prefix_path`.
-        - If any of the output files already exist and
-        the mode is 'truncate', they will be overwritten. If the mode is 'append'
-        and the number of output files is less than the number of locales or a
-        dataset with the same name already exists, a ``RuntimeError`` will result.
-        - Any file extension can be used.The file I/O does not rely on the extension to
-        determine the file format.
         See Also
         ---------
-        to_parquet
+        load
         """
-        result = []
-        comp_dict = {k: v for k, v in self._get_components_dict().items() if v is not None}
+        from arkouda.io import _file_type_to_int, _mode_str_to_int
 
-        if self.RequiredPieces.issubset(comp_dict.keys()):
-            # Honor the first mode but switch to append for all others
-            # since each following comp may wipe out the file
-            first = True
-            for k, v in comp_dict.items():
-                result.append(
-                    v.to_hdf(
-                        prefix_path,
-                        dataset=f"{dataset}.{k}",
-                        mode=(mode if first else "append"),
-                        file_type=file_type,
-                    )
-                )
-                first = False
-        else:
-            raise Exception(
-                "The required pieces of `categories` and `codes` were not populated on this Categorical"
-            )
-        return ";".join(result)
+        args = {
+            "codes": self.codes,
+            "categories": self.categories,
+            "dset": dataset,
+            "write_mode": _mode_str_to_int(mode),
+            "filename": prefix_path,
+            "objType": "categorical",
+            "file_format": _file_type_to_int(file_type),
+            "NA_codes": self._akNAcode
+        }
+        if self.permutation is not None and self.segments is not None:
+            args["permutation"] = self.permutation
+            args["segments"] = self.segments
+
+        generic_msg(
+            cmd="tohdf",
+            args=args,
+        )
 
     def to_parquet(
         self,
@@ -1228,23 +1179,8 @@ class Categorical:
         --------
         register, is_registered, unregister, unregister_categorical_by_name
         """
-        # Build dict of registered components by invoking their corresponding Class.attach functions
-        parts = {
-            "categories": Strings.attach(f"{user_defined_name}.categories"),
-            "codes": pdarray.attach(f"{user_defined_name}.codes"),
-            "_akNAcode": pdarray.attach(f"{user_defined_name}._akNAcode"),
-        }
-
-        # Add optional pieces only if they're contained in the registry
-        registry = list_registry()
-        if f"{user_defined_name}.permutation" in registry:
-            parts["permutation"] = pdarray.attach(f"{user_defined_name}.permutation")
-        if f"{user_defined_name}.segments" in registry:
-            parts["segments"] = pdarray.attach(f"{user_defined_name}.segments")
-
-        c = Categorical(None, **parts)  # Call constructor with unpacked kwargs
-        c.name = user_defined_name  # Update our name
-        return c
+        from arkouda.util import attach
+        return attach(user_defined_name, dtype="categorical")
 
     @staticmethod
     @typechecked

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -2434,13 +2434,8 @@ class DataFrame(UserDict):
 
             elif parts[i] == "categorical":
                 colName = DataFrame._parse_col_name(parts[i + 1], dfName)[0]
-                # catMsg = (
-                #     f"{parts[i]}+{parts[i+1]}+{parts[i+2]}+{parts[i+3]}+"
-                #     f"{parts[i+4]}+{parts[i+5]}+{parts[i+6]}"
-                # )
                 cols[colName] = Categorical.from_return_msg(parts[i+2] + "+" + parts[i+3])
                 i += 3
-                # i += 6
 
             elif parts[i] == "segarray":
                 colName = DataFrame._parse_col_name(parts[i + 1], dfName)[0]

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -22,7 +22,7 @@ from arkouda.dtypes import int64 as akint64
 from arkouda.groupbyclass import GroupBy as akGroupBy
 from arkouda.groupbyclass import unique
 from arkouda.index import Index
-from arkouda.io import _dict_recombine_segarrays, get_filetype, load_all
+from arkouda.io import _dict_recombine_segarrays_categoricals, get_filetype, load_all
 from arkouda.numeric import cast as akcast
 from arkouda.numeric import cumsum
 from arkouda.numeric import isnan as akisnan
@@ -1744,7 +1744,7 @@ class DataFrame(UserDict):
         filetype = get_filetype(first_file) if file_format.lower() == "infer" else file_format
 
         # columns load backwards
-        df = cls(_dict_recombine_segarrays(load_all(prefix_path, file_format=filetype)))
+        df = cls(_dict_recombine_segarrays_categoricals(load_all(prefix_path, file_format=filetype)))
         # if parquet, return reversed dataframe to match what was saved
         return df if filetype == "HDF5" else df[df.columns[::-1]]
 
@@ -2434,12 +2434,13 @@ class DataFrame(UserDict):
 
             elif parts[i] == "categorical":
                 colName = DataFrame._parse_col_name(parts[i + 1], dfName)[0]
-                catMsg = (
-                    f"{parts[i]}+{parts[i+1]}+{parts[i+2]}+{parts[i+3]}+"
-                    f"{parts[i+4]}+{parts[i+5]}+{parts[i+6]}"
-                )
-                cols[colName] = Categorical.from_return_msg(catMsg)
-                i += 6
+                # catMsg = (
+                #     f"{parts[i]}+{parts[i+1]}+{parts[i+2]}+{parts[i+3]}+"
+                #     f"{parts[i+4]}+{parts[i+5]}+{parts[i+6]}"
+                # )
+                cols[colName] = Categorical.from_return_msg(parts[i+2] + "+" + parts[i+3])
+                i += 3
+                # i += 6
 
             elif parts[i] == "segarray":
                 colName = DataFrame._parse_col_name(parts[i + 1], dfName)[0]

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -415,7 +415,9 @@ def _parse_errors(rep_msg, allow_errors: bool = False):
         )
 
 
-def _parse_obj(obj: Dict) -> Union[Strings, pdarray, arkouda.array_view.ArrayView, SegArray, Categorical]:
+def _parse_obj(
+    obj: Dict,
+) -> Union[Strings, pdarray, arkouda.array_view.ArrayView, SegArray, Categorical]:
     """
     Helper function to create an Arkouda object from read response
 

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -456,7 +456,7 @@ def _dict_recombine_segarrays_categoricals(df_dict):
     # this assumes segments will always have corresponding values.
     # This should happen due to save config
     seg_cols = ["_".join(col.split("_")[:-1]) for col in df_dict.keys() if col.endswith("_segments")]
-    cat_cols = ["_".join(col.split(".")[:-1]) for col in df_dict.keys() if col.endswith(".categories")]
+    cat_cols = [".".join(col.split(".")[:-1]) for col in df_dict.keys() if col.endswith(".categories")]
     df_dict_keys = {
         "_".join(col.split("_")[:-1])
         if col.endswith("_segments") or col.endswith("_values")

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -1062,7 +1062,7 @@ class SegArray:
 
         Returns
         --------
-        str - success message if successful
+        None
 
         Raises
         -------

--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -229,7 +229,10 @@ def attach(name: str, dtype: str = "infer"):
     repType = repMsg.split("+")[0]
 
     if repType == "categorical":
-        return Categorical.from_return_msg(repMsg)
+        build_data = repMsg.split("+", 2)[-1]
+        c = Categorical.from_return_msg(build_data)
+        c.name = name
+        return c
     elif repType == "series":
         from arkouda.series import Series
 

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -209,9 +209,8 @@ module GenSymIO {
                 var (segName, nBytes) = id.splitMsgToTuple("+", 2);
                 create_str = "created " + st.attrib(segName) + "+created bytes.size " + nBytes;
             }
-            else if (akType == "seg_array") {
+            else if (akType == "seg_array" || akType == "categorical") {
                 create_str = id;
-
             } 
             else {
                 continue;

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -870,7 +870,7 @@ module HDF5Msg {
                 var valEntry = segString.values;
                 var segEntry = segString.offsets;
                 var filenames = prepFiles(filename, mode, segEntry.a);
-                writeSegmentedDistDset(filenames, group, objType, valEntry.a, segEntry.a, st, uint(8));
+                writeSegmentedDistDset(filenames, group, objType, overwrite, valEntry.a, segEntry.a, st, uint(8));
             }
             otherwise {
                 throw getErrorWithContext(
@@ -1091,6 +1091,10 @@ module HDF5Msg {
         var group = msgArgs.getValueOf("dset");
         const objType = msgArgs.getValueOf("objType"); // needed for metadata
 
+        var overwrite: bool = if msgArgs.contains("overwrite")
+                                then msgArgs.get("overwrite").getBoolValue()
+                                else false;
+
         // access entries - types are currently always the same for each
         var codes_entry = st.lookup(msgArgs.getValueOf("codes"));
         var codes = toSymEntry(toGenSymEntry(codes_entry), int);
@@ -1119,7 +1123,7 @@ module HDF5Msg {
                 }
 
                 // ensure that container for categorical exists
-                validateGroup(file_id, f, group);
+                validateGroup(file_id, f, group, overwrite);
 
                 // localize codes and write dataset
                 var localCodes: [0..#codes.size] int = codes.a;
@@ -1127,7 +1131,7 @@ module HDF5Msg {
 
 
                 // ensure that the container for categories exists
-                validateGroup(file_id, f, "%s/%s".format(group, CATEGORIES_NAME));
+                validateGroup(file_id, f, "%s/%s".format(group, CATEGORIES_NAME), overwrite);
 
 
                 //localize categories values and write dataset
@@ -1171,23 +1175,23 @@ module HDF5Msg {
                     }
 
                     // create the group and generate metadata
-                    validateGroup(file_id, localeFilename, group);
+                    validateGroup(file_id, localeFilename, group, overwrite);
                     writeArkoudaMetaData(file_id, group, objType, getHDF5Type(uint(8))); 
                 }
 
                 // write codes
-                writeDistDset(filenames, "/%s/%s".format(group, CODES_NAME), "pdarray", codes.a, st);
+                writeDistDset(filenames, "/%s/%s".format(group, CODES_NAME), "pdarray", overwrite, codes.a, st);
 
                 // write categories
-                writeSegmentedDistDset(filenames, "/%s/%s".format(group, CATEGORIES_NAME), "strings", cats.values.a, cats.offsets.a, st, uint(8));
+                writeSegmentedDistDset(filenames, "/%s/%s".format(group, CATEGORIES_NAME), "strings", overwrite, cats.values.a, cats.offsets.a, st, uint(8));
 
                 // write NA Codes
-                writeDistDset(filenames, "/%s/%s".format(group, NACODES_NAME), "pdarray", naCodes.a, st);
+                writeDistDset(filenames, "/%s/%s".format(group, NACODES_NAME), "pdarray", overwrite, naCodes.a, st);
 
                 // writes perms and segs if they exist
                 if perm_seg_exist {
-                    writeDistDset(filenames, "/%s/%s".format(group, PERMUTATION_NAME), "pdarray", codes.a, st);
-                    writeDistDset(filenames, "/%s/%s".format(group, CAT_SEGMENTS_NAME), "pdarray", codes.a, st);
+                    writeDistDset(filenames, "/%s/%s".format(group, PERMUTATION_NAME), "pdarray", overwrite, codes.a, st);
+                    writeDistDset(filenames, "/%s/%s".format(group, CAT_SEGMENTS_NAME), "pdarray", overwrite, codes.a, st);
                 }
             }
             otherwise {

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -1821,8 +1821,6 @@ module HDF5Msg {
         var entrySeg = if (calcStringOffsets || nSeg < 1 || !skips.isEmpty()) then _buildEntryCalcOffsets() else _buildEntryLoadOffsets();
 
         return assembleSegStringFromParts(entrySeg, entryVal, st);
-        // var stringsEntry = assembleSegStringFromParts(entrySeg, entryVal, st);
-        // return (dset, "seg_string", "%s+%t".format(stringsEntry.name, stringsEntry.nBytes));
     }
 
     proc strings_readhdfMsg(filenames: [?fD] string, dset: string, dataclass, bytesize: int, isSigned: bool, calcStringOffsets: bool, validFiles: [] bool, st: borrowed SymTab): (string, string, string) throws {

--- a/src/RegistrationMsg.chpl
+++ b/src/RegistrationMsg.chpl
@@ -64,10 +64,6 @@ module RegistrationMsg
         return msgTuple;
     }
 
-    proc categorical_attachMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws{
-
-    }
-
     /* 
     Parse, execute, and respond to a attach message 
 

--- a/src/RegistrationMsg.chpl
+++ b/src/RegistrationMsg.chpl
@@ -64,6 +64,10 @@ module RegistrationMsg
         return msgTuple;
     }
 
+    proc categorical_attachMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws{
+
+    }
+
     /* 
     Parse, execute, and respond to a attach message 
 
@@ -164,7 +168,7 @@ module RegistrationMsg
         regLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
                             "%s: Collecting Categorical components for '%s'".format(cmd, name));
 
-        var repMsg: string;
+        var rtnMap: map(string, string);
                 
         var cats = st.attrib("%s.categories".format(name));
         var codes = st.attrib("%s.codes".format(name));
@@ -186,15 +190,14 @@ module RegistrationMsg
             return new MsgTuple(errorMsg, MsgType.ERROR); 
         }
 
-        repMsg = "categorical+created %s".format(cats);
-        // Check if the categories is numeric or string, if string add byte size
+        // categories should always be string, add bytes for string return message
         if (isStringAttrib(cats)) {
             var s = getSegString("%s.categories".format(name), st);
-            repMsg += "+created bytes.size %t".format(s.nBytes);
+            rtnMap.add("categories", "created %s+created %t".format(st.attrib(s.name), s.nBytes));
         }
+        rtnMap.add("codes", "created " + codes);
+        rtnMap.add("_akNAcode", "created " + naCode);
 
-        repMsg += "+created %s".format(codes);
-        repMsg += "+created %s".format(naCode);
 
         // Optional components of categorical
         if st.contains("%s.permutation".format(name)) {
@@ -204,7 +207,7 @@ module RegistrationMsg
                 regLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
                 return new MsgTuple(errorMsg, MsgType.ERROR); 
             }
-            repMsg += "+created %s".format(perm);
+            rtnMap.add("permutation", "created " + perm);
         }
         if st.contains("%s.segments".format(name)) {
             var segs = st.attrib("%s.segments".format(name));
@@ -213,9 +216,10 @@ module RegistrationMsg
                 regLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
                 return new MsgTuple(errorMsg, MsgType.ERROR); 
             }
-            repMsg += "+created %s".format(segs);
+            rtnMap.add("segments", "created " + segs);
         }
 
+        var repMsg: string = "categorical+%s+%jt".format(name, rtnMap);
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 

--- a/tests/categorical_test.py
+++ b/tests/categorical_test.py
@@ -348,6 +348,35 @@ class CategoricalTest(ArkoudaTest):
             print(f"==> cat_from_hdf.size:{cat_from_hdf.size}")
             self.assertEqual(cat_from_hdf.size, num_elems - 1)
 
+    def test_hdf_update(self):
+        num_elems = 51  # _getCategorical starts counting at 1, so the size is really off by one
+        cat = self._getCategorical(size=num_elems)
+        with tempfile.TemporaryDirectory(dir=CategoricalTest.cat_test_base_tmp) as tmp_dirname:
+            dset_name = "categorical_array"  # name of categorical array
+            cat.to_hdf(f"{tmp_dirname}/cat-save-test", dataset=dset_name)
+
+            dset_name2 = "to_replace"
+            cat.to_hdf(f"{tmp_dirname}/cat-save-test", dataset=dset_name2, mode="append")
+
+            dset_name3 = "cat_array2"
+            cat.to_hdf(f"{tmp_dirname}/cat-save-test", dataset=dset_name3, mode="append")
+
+            replace_cat = self._getCategorical(size=23)
+            replace_cat.update_hdf(f"{tmp_dirname}/cat-save-test", dataset=dset_name2)
+
+            data = ak.read_hdf(f"{tmp_dirname}/cat-save-test_*")
+            self.assertTrue(dset_name in data)
+            self.assertTrue(dset_name2 in data)
+            self.assertTrue(dset_name3 in data)
+
+            d = data[dset_name2]
+            self.assertListEqual(d.codes.to_list(), replace_cat.codes.to_list())
+            self.assertListEqual(d.permutation.to_list(), replace_cat.permutation.to_list())
+            self.assertListEqual(d.segments.to_list(), replace_cat.segments.to_list())
+            self.assertListEqual(d._akNAcode.to_list(), replace_cat._akNAcode.to_list())
+            self.assertListEqual(d.categories.to_list(), replace_cat.categories.to_list())
+
+
     def test_unused_categories_logic(self):
         """
         Test that Categoricals built from_codes and from slices

--- a/tests/categorical_test.py
+++ b/tests/categorical_test.py
@@ -322,13 +322,12 @@ class CategoricalTest(ArkoudaTest):
             import h5py
 
             f = h5py.File(tmp_dirname + "/cat-save-test_LOCALE0000", mode="r")
-            keys = set(f.keys())
+            keys = list(f.keys())
             if io.ARKOUDA_HDF5_FILE_METADATA_GROUP in keys:  # Ignore the metadata group if it exists
                 keys.remove(io.ARKOUDA_HDF5_FILE_METADATA_GROUP)
-            self.assertEqual(len(keys), 5, "Expected 5 keys")
-            self.assertSetEqual(
-                set(f"categorical_array.{k}" for k in cat._get_components_dict().keys()), keys
-            )
+            self.assertEqual(len(keys), 1, f"Expected 1 key, {dset_name}")
+            self.assertListEqual([dset_name], keys)
+            d = f[dset_name]
             f.close()
 
             # Now try to read them back with load_all


### PR DESCRIPTION
Closes #2372 & #2373 

- Updates Categorical to save to HDF5 using the following format, which allows us to view it as a single object
  - Group: Name provided by user
    - Group: categories (this stores a SegString as 2 datasets)
    - Dataset: codes
    - Dataset: NA_Codes
    - Dataset: permutation (if present in the object)
    - Dataset: segments (if present in object)
- Maintains read functionality for any categorical written with the previous format.
- Updates `Categorical.from_return_msg` to use a dictionary format rather than a delimited string.
  - This required additional updates to `attach/register` for Categoricals as they were using `from_return_msg`. These were updated to use the new dictionary formatted response as well. I will be adding an issues to update ALL attach/register functionality to this.
- Adds Testing for `Categorical.update_hdf`.
- Modified existing testing for new Categorical Storage format (though these were minor).
- Updates read functionality typing to allow for Categorical return.