### PR TITLE
Closes #2396 - Fixes Nested parquet fields causing server crash

### DIFF
--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -96,6 +96,7 @@ def ls(filename: str, col_delim: str = ",", read_nested: bool = True) -> List[st
     read_nested: bool
         Default True, when True, SegArray objects will be read from the file. When False,
         SegArray (or other nested Parquet columns) will be ignored.
+        Only used for Parquet files.
 
     Returns
     -------
@@ -1472,7 +1473,6 @@ def load(
     dataset: str = "array",
     calc_string_offsets: bool = False,
     column_delim: str = ",",
-    read_nested: bool = True,
 ) -> Union[
     pdarray,
     Strings,

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -1648,7 +1648,7 @@ const char* cpp_getVersionInfo(void) {
   return strdup(arrow::GetBuildInfo().version_string.c_str());
 }
 
-int cpp_getDatasetNames(const char* filename, char** dsetResult, char** errMsg) {
+int cpp_getDatasetNames(const char* filename, char** dsetResult, bool readNested, char** errMsg) {
   try {
     std::shared_ptr<arrow::io::ReadableFile> infile;
     ARROWRESULT_OK(arrow::io::ReadableFile::Open(filename, arrow::default_memory_pool()),
@@ -1677,7 +1677,7 @@ int cpp_getDatasetNames(const char* filename, char** dsetResult, char** errMsg) 
          sc->field(i)->type()->id() == arrow::Type::BINARY ||
          sc->field(i)->type()->id() == arrow::Type::FLOAT ||
          sc->field(i)->type()->id() == arrow::Type::DOUBLE ||
-         sc->field(i)->type()->id() == arrow::Type::LIST
+         (sc->field(i)->type()->id() == arrow::Type::LIST && readNested)
          ) {
         if(!first)
           fields += ("," + sc->field(i)->name());
@@ -1791,8 +1791,8 @@ extern "C" {
     return cpp_getVersionInfo();
   }
 
-  int c_getDatasetNames(const char* filename, char** dsetResult, char** errMsg) {
-    return cpp_getDatasetNames(filename, dsetResult, errMsg);
+  int c_getDatasetNames(const char* filename, char** dsetResult, bool readNested, char** errMsg) {
+    return cpp_getDatasetNames(filename, dsetResult, readNested, errMsg);
   }
 
   void c_free_string(void* ptr) {

--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -137,7 +137,7 @@ extern "C" {
   const char* c_getVersionInfo(void);
   const char* cpp_getVersionInfo(void);
 
-  int c_getDatasetNames(const char* filename, char** dsetResult, char** errMsg);
+  int c_getDatasetNames(const char* filename, char** dsetResult, bool readNested, char** errMsg);
   int cpp_getDatasetNames(const char* filename, char** dsetResult, char** errMsg);
 
   void c_free_string(void* ptr);

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -1680,6 +1680,9 @@ module ParquetMsg {
     // reqMsg: "lshdf [<json_filename>]"
     var repMsg: string;
 
+    // determine if read nested flag is set
+    var read_nested: bool = msgArgs.get("read_nested").getBoolValue();
+
     // Retrieve filename from payload
     var filename: string = msgArgs.getValueOf("filename");
     if filename.isEmpty() {
@@ -1709,7 +1712,7 @@ module ParquetMsg {
     }
         
     try {
-      extern proc c_getDatasetNames(filename, dsetResult, errMsg): int(32);
+      extern proc c_getDatasetNames(filename, dsetResult, readNested, errMsg): int(32);
       extern proc strlen(a): int;
       var pqErr = new parquetErrorMsg();
       var res: c_ptr(uint(8));
@@ -1717,7 +1720,7 @@ module ParquetMsg {
         extern proc c_free_string(ptr);
         c_free_string(res);
       }
-      if c_getDatasetNames(filename.c_str(), c_ptrTo(res),
+      if c_getDatasetNames(filename.c_str(), c_ptrTo(res), read_nested,
                            c_ptrTo(pqErr.errMsg)) == ARROWERROR {
         pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
       }


### PR DESCRIPTION
Closes #2396 

In the interest of maintaining Arkouda's ability to read/write SegArrays with Parquet, this PR adds a flag that allows users to ignore nested fields (SegArrays). This was done to avoid some files that were previously readable from crashing the server due to these columns. The addition of the flag prevents the users from needing to manually specify the datasets to read.

- `read_nested` flag added to read functionality. This defaults to True allowing SegArrays to be read. When False, SegArray fields are ignored during the read.
- The `read_nested` flag is ignored if `datasets` is not `None`.
- Adds testing to validate functionality.

Ultimately, this was able to be configured so that if no datasets are explicitly provided, SegArray columns are either included or ignored based on the value of `read_nested`. This simplifies processing and was the least intrusive path forward. I provided examples below for clarity.

**Setup Code**
```python
fname = "/path/to/file/filename"
df = ak.DataFrame({
    "idx": ak.arange(5),
    "seg": ak.segarray(ak.arange(0, 10, 2), ak.arange(10))
})
df.to_parquet(fname)
```

**Default Results**
```python
ak.read_parquet(fname+"_*")

{'idx': array([0 1 2 3 4]), 'seg': SegArray([
[0 1]
[2 3]
[4 5]
[6 7]
[8 9]
])}
```

**`read_nested=False`**
```python
ak.read_parquet(fname+"_*", read_nested=False)

[0 1 2 3 4]
```

**`read_nested=False` with datasets not being None**
Here `read_nested` is ignored
```python
ak.read_parquet(fname+"_*", datasets=["idx", "seg"], read_nested=False)

{'idx': array([0 1 2 3 4]), 'seg': SegArray([
[0 1]
[2 3]
[4 5]
[6 7]
[8 9]
])}
```