### PR TITLE
Closes #2403: Update c_getDatasetNames calls to match new behavior

### DIFF
--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -911,7 +911,7 @@ module ParquetMsg {
   }
 
   proc getDatasets(filename) throws {
-    extern proc c_getDatasetNames(filename, dsetResult, errMsg): int(32);
+    extern proc c_getDatasetNames(filename, dsetResult, readNested, errMsg): int(32);
     extern proc strlen(a): int;
     var pqErr = new parquetErrorMsg();
     var res: c_ptr(uint(8));
@@ -919,7 +919,7 @@ module ParquetMsg {
       extern proc c_free_string(ptr);
       c_free_string(res);
     }
-    if c_getDatasetNames(filename.c_str(), c_ptrTo(res),
+    if c_getDatasetNames(filename.c_str(), c_ptrTo(res), false,
                          c_ptrTo(pqErr.errMsg)) == ARROWERROR {
       pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
     }


### PR DESCRIPTION
In #2399, an extra argument was added to `c_getDatasetNames`, but not all usages in the Chapel code were updated to account for that, causing undefined behavior from passing garbage memory to the extern procedure.

Closes #2403 