### PR TITLE
Closes #2405: Add server <-> server transfers of pdarrays

### DIFF
--- a/ServerModules.cfg
+++ b/ServerModules.cfg
@@ -25,6 +25,7 @@ BroadcastMsg
 FlattenMsg
 StatsMsg
 TimeClassMsg
+TransferMsg
 HDF5Msg
 ParquetMsg
 CSVMsg

--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -195,10 +195,7 @@ class Categorical:
         eles = json.loads(rep_msg)
         codes = create_pdarray(eles["codes"])
         cats = Strings.from_return_msg(eles["categories"])
-        if "_akNAcode" in eles:
-            na_code = create_pdarray(eles["_akNAcode"])
-        else:
-            na_code = None
+        na_code = create_pdarray(eles["_akNAcode"])
 
         segments = None
         perm = None

--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -1446,5 +1446,3 @@ class Categorical:
             cmd="sendArray",
             args=args,
         )
-
-    

--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -1402,12 +1402,13 @@ class Categorical:
 
     def send_array(self, hostname: str, port: int_scalars):
         """
-        Sends a strings object to a different Arkouda server
+        Sends a Categorical object to a different Arkouda server
 
         Parameters
         ----------
         hostname : str
-            The hostname of the pdarray to receive the array
+            The hostname where the Arkouda server intended to
+            receive the Categorical is running.
         port : int_scalars
             The port to send the array over. This needs to be an
             open port (i.e., not one that the Arkouda server is
@@ -1423,7 +1424,7 @@ class Categorical:
 
         Returns
         -------
-        None
+        A message indicating a complete transfer
 
         Raises
         ------

--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -1396,3 +1396,52 @@ class Categorical:
                 result_categoricals[base_name] = Categorical.from_codes(**cat_parts)
 
         return removal_names, result_categoricals
+
+    def send_array(self, hostname: str, port: int_scalars):
+        """
+        Sends a strings object to a different Arkouda server
+
+        Parameters
+        ----------
+        hostname : str
+            The hostname of the pdarray to receive the array
+        port : int_scalars
+            The port to send the array over. This needs to be an
+            open port (i.e., not one that the Arkouda server is
+            running on). This will open up `numLocales` ports,
+            each of which in succession, so will use ports of the
+            range {port..(port+numLocales)} (e.g., running an
+            Arkouda server of 4 nodes, port 1234 is passed as
+            `port`, Arkouda will use ports 1234, 1235, 1236,
+            and 1237 to send the array data).
+            This port much match the port passed to the call to
+            `ak.receive_array()`.
+
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        ValueError
+            Raised if the op is not within the pdarray.BinOps set
+        TypeError
+            Raised if other is not a pdarray or the pdarray.dtype is not
+            a supported dtype
+        """
+        # hostname is the hostname to send to
+        args = {
+            "codes": self.codes,
+            "categories": self.categories,
+            "objType": "categorical",
+            "NA_codes": self._akNAcode,
+            "hostname": hostname,
+            "port": port
+        }
+        return generic_msg(
+            cmd="sendArray",
+            args=args,
+        )
+
+    

--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -1400,7 +1400,7 @@ class Categorical:
 
         return removal_names, result_categoricals
 
-    def send_array(self, hostname: str, port: int_scalars):
+    def transfer(self, hostname: str, port: int_scalars):
         """
         Sends a Categorical object to a different Arkouda server
 
@@ -1438,7 +1438,7 @@ class Categorical:
         args = {
             "codes": self.codes,
             "categories": self.categories,
-            "objType": "categorical",
+            "objType": self.objType,
             "NA_codes": self._akNAcode,
             "hostname": hostname,
             "port": port

--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -195,7 +195,10 @@ class Categorical:
         eles = json.loads(rep_msg)
         codes = create_pdarray(eles["codes"])
         cats = Strings.from_return_msg(eles["categories"])
-        na_code = create_pdarray(eles["_akNAcode"])
+        if "_akNAcode" in eles:
+            na_code = create_pdarray(eles["_akNAcode"])
+        else:
+            na_code = None
 
         segments = None
         perm = None

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -2687,16 +2687,16 @@ def invert_permutation(perm):
     return coargsort([perm, arange(perm.size)])
 
 
-def receive_dataframe(hostname : str, port):
+def receive(hostname : str, port):
     """
-    Receive a pdarray sent by `pdarray.send_array()`.
+    Receive a pdarray sent by `dataframe.transfer()`.
 
     Parameters
     ----------
     hostname : str
-        The hostname of the pdarray that sent the array
+        The hostname of the dataframe that sent the array
     port : int_scalars
-        The port to send the array over. This needs to be an
+        The port to send the dataframe over. This needs to be an
         open port (i.e., not one that the Arkouda server is
         running on). This will open up `numLocales` ports,
         each of which in succession, so will use ports of the
@@ -2710,8 +2710,8 @@ def receive_dataframe(hostname : str, port):
     Returns
     -------
     pdarray
-        The pdarray sent from the sending server to the current
-        receiving server.
+        The dataframe sent from the sending server to the
+        current receiving server.
 
     Raises
     ------

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -634,7 +634,7 @@ class DataFrame(UserDict):
         msg_list = []
         for col in self._columns:
             if isinstance(self[col], Categorical):
-                msg_list.append(f"Categorical+{col}+{self[col].codes.name}+{self[col].categories.name}")
+                msg_list.append(f"Categorical+{col}+{self[col].codes.name}+{self[col].categories.name}+{self[col]._akNAcode.name}")
             elif isinstance(self[col], SegArray):
                 msg_list.append(f"SegArray+{col}+{self[col].segments.name}+{self[col].values.name}")
             elif isinstance(self[col], Strings):

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -21,7 +21,6 @@ from arkouda.groupbyclass import GROUPBY_REDUCTION_TYPES
 from arkouda.groupbyclass import GroupBy as akGroupBy
 from arkouda.groupbyclass import unique
 from arkouda.index import Index
-from arkouda.io import _dict_recombine_segarrays_categoricals, get_filetype, load_all, _build_objects
 from arkouda.numeric import cast as akcast
 from arkouda.numeric import cumsum, where
 from arkouda.pdarrayclass import RegistrationError, pdarray
@@ -33,6 +32,7 @@ from arkouda.series import Series
 from arkouda.sorting import argsort, coargsort
 from arkouda.strings import Strings
 from arkouda.timeclass import Datetime, Timedelta
+from arkouda.io import _build_objects
 
 # This is necessary for displaying DataFrames with BitVector columns,
 # because pandas _html_repr automatically truncates the number of displayed bits

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -2690,8 +2690,5 @@ def receive_dataframe(hostname : str, port):
     """
     rep_msg = generic_msg(cmd="receiveDataframe", args={"hostname": hostname,
                                                         "port"    : port})
-    #ret = rep_msg.split('--')
     rep = json.loads(rep_msg)
-    #rep = json.loads(ret[0])
-    #vals = ret[1].split('-')
     return DataFrame(_build_objects(rep))

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -2653,6 +2653,7 @@ def invert_permutation(perm):
         raise ValueError("The array is not a permutation.")
     return coargsort([perm, arange(perm.size)])
 
+
 def receive_dataframe(hostname : str, port):
     """
     Receive a pdarray sent by `pdarray.send_array()`.

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -2690,5 +2690,8 @@ def receive_dataframe(hostname : str, port):
     """
     rep_msg = generic_msg(cmd="receiveDataframe", args={"hostname": hostname,
                                                         "port"    : port})
+    #ret = rep_msg.split('--')
     rep = json.loads(rep_msg)
+    #rep = json.loads(ret[0])
+    #vals = ret[1].split('-')
     return DataFrame(_build_objects(rep))

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -32,7 +32,6 @@ from arkouda.series import Series
 from arkouda.sorting import argsort, coargsort
 from arkouda.strings import Strings
 from arkouda.timeclass import Datetime, Timedelta
-from arkouda.io import _build_objects
 
 # This is necessary for displaying DataFrames with BitVector columns,
 # because pandas _html_repr automatically truncates the number of displayed bits

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -634,7 +634,8 @@ class DataFrame(UserDict):
         msg_list = []
         for col in self._columns:
             if isinstance(self[col], Categorical):
-                msg_list.append(f"Categorical+{col}+{self[col].codes.name}+{self[col].categories.name}+{self[col]._akNAcode.name}")
+                msg_list.append(f"Categorical+{col}+{self[col].codes.name} \
+                +{self[col].categories.name}+{self[col]._akNAcode.name}")
             elif isinstance(self[col], SegArray):
                 msg_list.append(f"SegArray+{col}+{self[col].segments.name}+{self[col].values.name}")
             elif isinstance(self[col], Strings):

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -44,7 +44,6 @@ __all__ = [
     "intersect",
     "invert_permutation",
     "intx",
-    "receive_dataframe",
 ]
 
 
@@ -2686,43 +2685,3 @@ def invert_permutation(perm):
     if (unique(perm).size != perm.size) and (perm.size != rng + 1):
         raise ValueError("The array is not a permutation.")
     return coargsort([perm, arange(perm.size)])
-
-
-def receive_dataframe(hostname : str, port):
-    """
-    Receive a pdarray sent by `dataframe.transfer()`.
-
-    Parameters
-    ----------
-    hostname : str
-        The hostname of the dataframe that sent the array
-    port : int_scalars
-        The port to send the dataframe over. This needs to be an
-        open port (i.e., not one that the Arkouda server is
-        running on). This will open up `numLocales` ports,
-        each of which in succession, so will use ports of the
-        range {port..(port+numLocales)} (e.g., running an
-        Arkouda server of 4 nodes, port 1234 is passed as
-        `port`, Arkouda will use ports 1234, 1235, 1236,
-        and 1237 to send the array data).
-        This port much match the port passed to the call to
-        `pdarray.send_array()`.
-
-    Returns
-    -------
-    pdarray
-        The dataframe sent from the sending server to the
-        current receiving server.
-
-    Raises
-    ------
-    ValueError
-        Raised if the op is not within the pdarray.BinOps set
-    TypeError
-        Raised if other is not a pdarray or the pdarray.dtype is not
-        a supported dtype
-    """
-    rep_msg = generic_msg(cmd="receiveDataframe", args={"hostname": hostname,
-                                                        "port"    : port})
-    rep = json.loads(rep_msg)
-    return DataFrame(_build_objects(rep))

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -596,6 +596,39 @@ class DataFrame(UserDict):
         return new_df.to_pandas(retain_index=True)[self._columns]
 
     def transfer(self, hostname, port):
+        """
+        Sends a DataFrame to a different Arkouda server
+
+        Parameters
+        ----------
+        hostname : str
+            The hostname where the Arkouda server intended to
+            receive the DataFrame is running.
+        port : int_scalars
+            The port to send the array over. This needs to be an
+            open port (i.e., not one that the Arkouda server is
+            running on). This will open up `numLocales` ports,
+            each of which in succession, so will use ports of the
+            range {port..(port+numLocales)} (e.g., running an
+            Arkouda server of 4 nodes, port 1234 is passed as
+            `port`, Arkouda will use ports 1234, 1235, 1236,
+            and 1237 to send the array data).
+            This port much match the port passed to the call to
+            `ak.receive_array()`.
+
+
+        Returns
+        -------
+        A message indicating a complete transfer
+
+        Raises
+        ------
+        ValueError
+            Raised if the op is not within the pdarray.BinOps set
+        TypeError
+            Raised if other is not a pdarray or the pdarray.dtype is not
+            a supported dtype
+        """
         self.update_size()
         idx = self._index
         msg_list = []

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -2687,7 +2687,7 @@ def invert_permutation(perm):
     return coargsort([perm, arange(perm.size)])
 
 
-def receive(hostname : str, port):
+def receive_dataframe(hostname : str, port):
     """
     Receive a pdarray sent by `dataframe.transfer()`.
 

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -2009,7 +2009,6 @@ def restore(filename):
 
 
 def receive(hostname : str, port):
->>>>>>> feb32522 (Fix naming of receive functinos)
     """
     Receive a pdarray sent by `pdarray.transfer()`.
 

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -42,6 +42,7 @@ __all__ = [
     "update_hdf",
     "snapshot",
     "restore",
+    "receive_array",
 ]
 
 ARKOUDA_HDF5_FILE_METADATA_GROUP = "_arkouda_metadata"
@@ -2005,3 +2006,44 @@ def restore(filename):
     """
     restore_files = glob.glob(f"{filename}_SNAPSHOT_LOCALE*")
     return read_hdf(sorted(restore_files))
+
+
+def receive_array(hostname : str, port):
+    """
+    Receive a pdarray sent by `pdarray.send_array()`.
+
+    Parameters
+    ----------
+    hostname : str
+        The hostname of the pdarray that sent the array
+    port : int_scalars
+        The port to send the array over. This needs to be an
+        open port (i.e., not one that the Arkouda server is
+        running on). This will open up `numLocales` ports,
+        each of which in succession, so will use ports of the
+        range {port..(port+numLocales)} (e.g., running an
+        Arkouda server of 4 nodes, port 1234 is passed as
+        `port`, Arkouda will use ports 1234, 1235, 1236,
+        and 1237 to send the array data).
+        This port much match the port passed to the call to
+        `pdarray.send_array()`.
+
+    Returns
+    -------
+    pdarray
+        The pdarray sent from the sending server to the current
+        receiving server.
+
+    Raises
+    ------
+    ValueError
+        Raised if the op is not within the pdarray.BinOps set
+    TypeError
+        Raised if other is not a pdarray or the pdarray.dtype is not
+        a supported dtype
+    """
+    rep_msg = generic_msg(cmd="receiveArray", args={"hostname": hostname,
+                                                   "port"    : port})
+    rep = json.loads(rep_msg)
+    return _build_objects(rep)
+

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -42,7 +42,7 @@ __all__ = [
     "update_hdf",
     "snapshot",
     "restore",
-    "receive_array",
+    "receive",
 ]
 
 ARKOUDA_HDF5_FILE_METADATA_GROUP = "_arkouda_metadata"
@@ -1946,7 +1946,6 @@ def read_tagged_data(
         raise RuntimeError(f"Invalid File Type detected, {ftype}")
 
 
-
 def snapshot(filename):
     """
     Create a snapshot of the current Arkouda namespace. All currently accessible variables containing
@@ -2009,7 +2008,8 @@ def restore(filename):
     return read_hdf(sorted(restore_files))
 
 
-def receive_array(hostname : str, port):
+def receive(hostname : str, port):
+>>>>>>> feb32522 (Fix naming of receive functinos)
     """
     Receive a pdarray sent by `pdarray.transfer()`.
 

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -1946,6 +1946,7 @@ def read_tagged_data(
         raise RuntimeError(f"Invalid File Type detected, {ftype}")
 
 
+
 def snapshot(filename):
     """
     Create a snapshot of the current Arkouda namespace. All currently accessible variables containing
@@ -2043,7 +2044,6 @@ def receive_array(hostname : str, port):
         a supported dtype
     """
     rep_msg = generic_msg(cmd="receiveArray", args={"hostname": hostname,
-                                                   "port"    : port})
+                                                    "port"    : port})
     rep = json.loads(rep_msg)
     return _build_objects(rep)
-

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -2011,7 +2011,7 @@ def restore(filename):
 
 def receive_array(hostname : str, port):
     """
-    Receive a pdarray sent by `pdarray.send_array()`.
+    Receive a pdarray sent by `pdarray.transfer()`.
 
     Parameters
     ----------
@@ -2027,7 +2027,7 @@ def receive_array(hostname : str, port):
         `port`, Arkouda will use ports 1234, 1235, 1236,
         and 1237 to send the array data).
         This port much match the port passed to the call to
-        `pdarray.send_array()`.
+        `pdarray.transfer()`.
 
     Returns
     -------

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -43,6 +43,7 @@ __all__ = [
     "snapshot",
     "restore",
     "receive",
+    "receive_dataframe",
 ]
 
 ARKOUDA_HDF5_FILE_METADATA_GROUP = "_arkouda_metadata"
@@ -2046,3 +2047,43 @@ def receive(hostname : str, port):
                                                     "port"    : port})
     rep = json.loads(rep_msg)
     return _build_objects(rep)
+
+
+def receive_dataframe(hostname : str, port):
+    """
+    Receive a pdarray sent by `dataframe.transfer()`.
+
+    Parameters
+    ----------
+    hostname : str
+        The hostname of the dataframe that sent the array
+    port : int_scalars
+        The port to send the dataframe over. This needs to be an
+        open port (i.e., not one that the Arkouda server is
+        running on). This will open up `numLocales` ports,
+        each of which in succession, so will use ports of the
+        range {port..(port+numLocales)} (e.g., running an
+        Arkouda server of 4 nodes, port 1234 is passed as
+        `port`, Arkouda will use ports 1234, 1235, 1236,
+        and 1237 to send the array data).
+        This port much match the port passed to the call to
+        `pdarray.send_array()`.
+
+    Returns
+    -------
+    pdarray
+        The dataframe sent from the sending server to the
+        current receiving server.
+
+    Raises
+    ------
+    ValueError
+        Raised if the op is not within the pdarray.BinOps set
+    TypeError
+        Raised if other is not a pdarray or the pdarray.dtype is not
+        a supported dtype
+    """
+    rep_msg = generic_msg(cmd="receiveDataframe", args={"hostname": hostname,
+                                                        "port"    : port})
+    rep = json.loads(rep_msg)
+    return DataFrame(_build_objects(rep))

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -382,7 +382,8 @@ class pdarray:
         Parameters
         ----------
         hostname : str
-            The hostname of the pdarray to receive the array
+            The hostname where the Arkouda server intended to
+            receive the pdarray is running.
         port : int_scalars
             The port to send the array over. This needs to be an
             open port (i.e., not one that the Arkouda server is
@@ -398,7 +399,7 @@ class pdarray:
 
         Returns
         -------
-        None
+        A message indicating a complete transfer
 
         Raises
         ------

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -376,7 +376,39 @@ class pdarray:
         )
         return create_pdarray(repMsg)
 
-    def send_array(self, hostname, port):
+    def send_array(self, hostname: str, port: int_scalars):
+        """
+        Sends a pdarray to a different Arkouda server
+
+        Parameters
+        ----------
+        hostname : str
+            The hostname of the pdarray to receive the array
+        port : int_scalars
+            The port to send the array over. This needs to be an
+            open port (i.e., not one that the Arkouda server is
+            running on). This will open up `numLocales` ports,
+            each of which in succession, so will use ports of the
+            range {port..(port+numLocales)} (e.g., running an
+            Arkouda server of 4 nodes, port 1234 is passed as
+            `port`, Arkouda will use ports 1234, 1235, 1236,
+            and 1237 to send the array data).
+            This port much match the port passed to the call to
+            `ak.receive_array()`.
+        
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        ValueError
+            Raised if the op is not within the pdarray.BinOps set
+        TypeError
+            Raised if other is not a pdarray or the pdarray.dtype is not
+            a supported dtype
+        """
         # hostname is the hostname to send to
         generic_msg(cmd="sendArray", args={"arg1": self,
                                            "hostname": hostname,
@@ -3322,6 +3354,39 @@ def unregister_pdarray_by_name(user_defined_name: str) -> None:
     return unregister(user_defined_name)
 
 def receive_array(hostname, port):
+    """
+    Receive a pdarray sent by `pdarray.send_array()`.
+
+    Parameters
+    ----------
+    hostname : str
+        The hostname of the pdarray that sent the array
+    port : int_scalars
+        The port to send the array over. This needs to be an
+        open port (i.e., not one that the Arkouda server is
+        running on). This will open up `numLocales` ports,
+        each of which in succession, so will use ports of the
+        range {port..(port+numLocales)} (e.g., running an
+        Arkouda server of 4 nodes, port 1234 is passed as
+        `port`, Arkouda will use ports 1234, 1235, 1236,
+        and 1237 to send the array data).
+        This port much match the port passed to the call to
+        `pdarray.send_array()`.
+
+    Returns
+    -------
+    pdarray
+        The pdarray sent from the sending server to the current
+        receiving server.
+
+    Raises
+    ------
+    ValueError
+        Raised if the op is not within the pdarray.BinOps set
+    TypeError
+        Raised if other is not a pdarray or the pdarray.dtype is not
+        a supported dtype
+    """
     repMsg = generic_msg(cmd="receiveArray", args={"hostname": hostname,
                                                    "port"    : port})
     return create_pdarray(repMsg)

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -395,7 +395,7 @@ class pdarray:
             and 1237 to send the array data).
             This port much match the port passed to the call to
             `ak.receive_array()`.
-        
+
 
         Returns
         -------
@@ -3353,7 +3353,8 @@ def unregister_pdarray_by_name(user_defined_name: str) -> None:
     )
     return unregister(user_defined_name)
 
-def receive_array(hostname, port):
+
+def receive_array(hostname : str, port : int_scalars):
     """
     Receive a pdarray sent by `pdarray.send_array()`.
 
@@ -3390,6 +3391,7 @@ def receive_array(hostname, port):
     repMsg = generic_msg(cmd="receiveArray", args={"hostname": hostname,
                                                    "port"    : port})
     return create_pdarray(repMsg)
+
 
 # TODO In the future move this to a specific errors file
 class RegistrationError(Exception):

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -375,7 +375,7 @@ class pdarray:
         )
         return create_pdarray(repMsg)
 
-    def send_array(self, hostname: str, port: int_scalars):
+    def transfer(self, hostname: str, port: int_scalars):
         """
         Sends a pdarray to a different Arkouda server
 

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -65,6 +65,7 @@ __all__ = [
     "attach_pdarray",
     "unregister_pdarray_by_name",
     "RegistrationError",
+    "receive_array"
 ]
 
 logger = getArkoudaLogger(name="pdarrayclass")
@@ -374,6 +375,12 @@ class pdarray:
             args={"op": op, "dtype": dt, "value": other, "a": self},
         )
         return create_pdarray(repMsg)
+
+    def send_array(self, hostname, port):
+        # hostname is the hostname to send to
+        generic_msg(cmd="sendArray", args={"arg1": self,
+                                           "hostname": hostname,
+                                           "port": port})
 
     # overload + for pdarray, other can be {pdarray, int, float}
     def __add__(self, other):
@@ -3314,6 +3321,10 @@ def unregister_pdarray_by_name(user_defined_name: str) -> None:
     )
     return unregister(user_defined_name)
 
+def receive_array(hostname, port):
+    repMsg = generic_msg(cmd="receiveArray", args={"hostname": hostname,
+                                                   "port"    : port})
+    return create_pdarray(repMsg)
 
 # TODO In the future move this to a specific errors file
 class RegistrationError(Exception):

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -410,9 +410,10 @@ class pdarray:
             a supported dtype
         """
         # hostname is the hostname to send to
-        generic_msg(cmd="sendArray", args={"arg1": self,
-                                           "hostname": hostname,
-                                           "port": port})
+        return generic_msg(cmd="sendArray", args={"arg1": self,
+                                                  "hostname": hostname,
+                                                  "port": port,
+                                                  "objType": "pdarray"})
 
     # overload + for pdarray, other can be {pdarray, int, float}
     def __add__(self, other):

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -64,7 +64,7 @@ __all__ = [
     "fmod",
     "attach_pdarray",
     "unregister_pdarray_by_name",
-    "RegistrationError"
+    "RegistrationError",
 ]
 
 logger = getArkoudaLogger(name="pdarrayclass")

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -64,8 +64,7 @@ __all__ = [
     "fmod",
     "attach_pdarray",
     "unregister_pdarray_by_name",
-    "RegistrationError",
-    "receive_array"
+    "RegistrationError"
 ]
 
 logger = getArkoudaLogger(name="pdarrayclass")
@@ -3353,45 +3352,6 @@ def unregister_pdarray_by_name(user_defined_name: str) -> None:
         DeprecationWarning,
     )
     return unregister(user_defined_name)
-
-
-def receive_array(hostname : str, port : int_scalars):
-    """
-    Receive a pdarray sent by `pdarray.send_array()`.
-
-    Parameters
-    ----------
-    hostname : str
-        The hostname of the pdarray that sent the array
-    port : int_scalars
-        The port to send the array over. This needs to be an
-        open port (i.e., not one that the Arkouda server is
-        running on). This will open up `numLocales` ports,
-        each of which in succession, so will use ports of the
-        range {port..(port+numLocales)} (e.g., running an
-        Arkouda server of 4 nodes, port 1234 is passed as
-        `port`, Arkouda will use ports 1234, 1235, 1236,
-        and 1237 to send the array data).
-        This port much match the port passed to the call to
-        `pdarray.send_array()`.
-
-    Returns
-    -------
-    pdarray
-        The pdarray sent from the sending server to the current
-        receiving server.
-
-    Raises
-    ------
-    ValueError
-        Raised if the op is not within the pdarray.BinOps set
-    TypeError
-        Raised if other is not a pdarray or the pdarray.dtype is not
-        a supported dtype
-    """
-    repMsg = generic_msg(cmd="receiveArray", args={"hostname": hostname,
-                                                   "port"    : port})
-    return create_pdarray(repMsg)
 
 
 # TODO In the future move this to a specific errors file

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -1560,3 +1560,43 @@ class SegArray:
             )
         else:
             return is_registered(self.registered_name)
+
+    def send_array(self, hostname: str, port: int_scalars):
+        """
+        Sends a pdarray to a different Arkouda server
+        
+        Parameters
+        ----------
+        hostname : str
+            The hostname of the pdarray to receive the array
+        port : int_scalars
+            The port to send the array over. This needs to be an
+            open port (i.e., not one that the Arkouda server is
+            running on). This will open up `numLocales` ports,
+            each of which in succession, so will use ports of the
+            range {port..(port+numLocales)} (e.g., running an
+            Arkouda server of 4 nodes, port 1234 is passed as
+            `port`, Arkouda will use ports 1234, 1235, 1236,
+            and 1237 to send the array data).
+            This port much match the port passed to the call to
+            `ak.receive_array()`.
+
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        ValueError
+            Raised if the op is not within the pdarray.BinOps set
+        TypeError
+            Raised if other is not a pdarray or the pdarray.dtype is not
+            a supported dtype
+        """
+        return generic_msg(cmd="sendArray", args={"seg_name": self.name,
+                                                  "hostname": hostname,
+                                                  "port": port,
+                                                  "dtype": self.dtype,
+                                                  "objType": "segarray"})
+

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -11,7 +11,7 @@ import numpy as np  # type: ignore
 from arkouda.client import generic_msg
 from arkouda.dtypes import bool as akbool
 from arkouda.dtypes import int64 as akint64
-from arkouda.dtypes import isSupportedInt, str_
+from arkouda.dtypes import isSupportedInt, str_, int_scalars
 from arkouda.dtypes import uint64 as akuint64
 from arkouda.groupbyclass import GroupBy, broadcast
 from arkouda.join import gen_ranges
@@ -1564,7 +1564,7 @@ class SegArray:
     def send_array(self, hostname: str, port: int_scalars):
         """
         Sends a pdarray to a different Arkouda server
-        
+
         Parameters
         ----------
         hostname : str
@@ -1581,7 +1581,6 @@ class SegArray:
             This port much match the port passed to the call to
             `ak.receive_array()`.
 
-
         Returns
         -------
         None
@@ -1595,7 +1594,7 @@ class SegArray:
             a supported dtype
         """
         return generic_msg(cmd="sendArray", args={"segments": self.segments,
-                                                  "values": self.vales,
+                                                  "values": self.values,
                                                   "hostname": hostname,
                                                   "port": port,
                                                   "dtype": self.dtype,

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -1563,12 +1563,13 @@ class SegArray:
 
     def send_array(self, hostname: str, port: int_scalars):
         """
-        Sends a pdarray to a different Arkouda server
+        Sends a Segmented Array to a different Arkouda server
 
         Parameters
         ----------
         hostname : str
-            The hostname of the pdarray to receive the array
+            The hostname where the Arkouda server intended to
+            receive the Segmented Array is running.
         port : int_scalars
             The port to send the array over. This needs to be an
             open port (i.e., not one that the Arkouda server is
@@ -1583,7 +1584,7 @@ class SegArray:
 
         Returns
         -------
-        None
+        A message indicating a complete transfer
 
         Raises
         ------

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -1561,7 +1561,7 @@ class SegArray:
         else:
             return is_registered(self.registered_name)
 
-    def send_array(self, hostname: str, port: int_scalars):
+    def transfer(self, hostname: str, port: int_scalars):
         """
         Sends a Segmented Array to a different Arkouda server
 

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -1594,7 +1594,8 @@ class SegArray:
             Raised if other is not a pdarray or the pdarray.dtype is not
             a supported dtype
         """
-        return generic_msg(cmd="sendArray", args={"seg_name": self.name,
+        return generic_msg(cmd="sendArray", args={"segments": self.segments,
+                                                  "values": self.vales,
                                                   "hostname": hostname,
                                                   "port": port,
                                                   "dtype": self.dtype,

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -1600,4 +1600,3 @@ class SegArray:
                                                   "port": port,
                                                   "dtype": self.dtype,
                                                   "objType": "segarray"})
-

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -2555,5 +2555,3 @@ class Strings:
                                                   "hostname": hostname,
                                                   "port": port,
                                                   "objType": "strings"})
-
-

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -2518,7 +2518,7 @@ class Strings:
 
     def send_array(self, hostname: str, port: int_scalars):
          """
-         Sends a pdarray to a different Arkouda server
+         Sends a strings object to a different Arkouda server
  
          Parameters
          ----------

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -2517,42 +2517,43 @@ class Strings:
         return unregister(user_defined_name)
 
     def send_array(self, hostname: str, port: int_scalars):
-         """
-         Sends a strings object to a different Arkouda server
- 
-         Parameters
-         ----------
-         hostname : str
-             The hostname of the pdarray to receive the array
-         port : int_scalars
-             The port to send the array over. This needs to be an
-             open port (i.e., not one that the Arkouda server is
-             running on). This will open up `numLocales` ports,
-             each of which in succession, so will use ports of the
-             range {port..(port+numLocales)} (e.g., running an
-             Arkouda server of 4 nodes, port 1234 is passed as
-             `port`, Arkouda will use ports 1234, 1235, 1236,
-             and 1237 to send the array data).
-             This port much match the port passed to the call to
-             `ak.receive_array()`.
- 
- 
-         Returns
-         -------
-         None
- 
-         Raises
-         ------
-         ValueError
-             Raised if the op is not within the pdarray.BinOps set
-         TypeError
-             Raised if other is not a pdarray or the pdarray.dtype is not
-             a supported dtype
-         """
-         # hostname is the hostname to send to
-         return generic_msg(cmd="sendArray", args={"values": self.entry,
-                                                   "hostname": hostname,
-                                                   "port": port,
-                                                   "objType": "strings"})
+        """
+        Sends a Strings object to a different Arkouda server
+
+        Parameters
+        ----------
+        hostname : str
+            The hostname where the Arkouda server intended to
+            receive the Strings object is running.
+        port : int_scalars
+            The port to send the array over. This needs to be an
+            open port (i.e., not one that the Arkouda server is
+            running on). This will open up `numLocales` ports,
+            each of which in succession, so will use ports of the
+            range {port..(port+numLocales)} (e.g., running an
+            Arkouda server of 4 nodes, port 1234 is passed as
+            `port`, Arkouda will use ports 1234, 1235, 1236,
+            and 1237 to send the array data).
+            This port much match the port passed to the call to
+            `ak.receive_array()`.
+
+
+        Returns
+        -------
+        A message indicating a complete transfer
+
+        Raises
+        ------
+        ValueError
+            Raised if the op is not within the pdarray.BinOps set
+        TypeError
+            Raised if other is not a pdarray or the pdarray.dtype is not
+            a supported dtype
+        """
+        # hostname is the hostname to send to
+        return generic_msg(cmd="sendArray", args={"values": self.entry,
+                                                  "hostname": hostname,
+                                                  "port": port,
+                                                  "objType": "strings"})
 
 

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -2515,3 +2515,44 @@ class Strings:
             DeprecationWarning,
         )
         return unregister(user_defined_name)
+
+    def send_array(self, hostname: str, port: int_scalars):
+         """
+         Sends a pdarray to a different Arkouda server
+ 
+         Parameters
+         ----------
+         hostname : str
+             The hostname of the pdarray to receive the array
+         port : int_scalars
+             The port to send the array over. This needs to be an
+             open port (i.e., not one that the Arkouda server is
+             running on). This will open up `numLocales` ports,
+             each of which in succession, so will use ports of the
+             range {port..(port+numLocales)} (e.g., running an
+             Arkouda server of 4 nodes, port 1234 is passed as
+             `port`, Arkouda will use ports 1234, 1235, 1236,
+             and 1237 to send the array data).
+             This port much match the port passed to the call to
+             `ak.receive_array()`.
+ 
+ 
+         Returns
+         -------
+         None
+ 
+         Raises
+         ------
+         ValueError
+             Raised if the op is not within the pdarray.BinOps set
+         TypeError
+             Raised if other is not a pdarray or the pdarray.dtype is not
+             a supported dtype
+         """
+         # hostname is the hostname to send to
+         return generic_msg(cmd="sendArray", args={"values": self.entry,
+                                                   "hostname": hostname,
+                                                   "port": port,
+                                                   "objType": "strings"})
+
+

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -2516,7 +2516,7 @@ class Strings:
         )
         return unregister(user_defined_name)
 
-    def send_array(self, hostname: str, port: int_scalars):
+    def transfer(self, hostname: str, port: int_scalars):
         """
         Sends a Strings object to a different Arkouda server
 

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -193,7 +193,7 @@ module GenSymIO {
         }
     }
 
-    proc _buildReadAllMsgJson(rnames:list((string, ObjType, string)), allowErrors:bool, fileErrorCount:int, fileErrors:list(string), st: borrowed SymTab): string throws {
+    proc _buildReadAllMsgJson(rnames:list((string, ObjType, string),false), allowErrors:bool, fileErrorCount:int, fileErrors:list(string,false), st: borrowed SymTab): string throws {
         var items: list(map(string, string));
 
         for rname in rnames {

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -193,7 +193,7 @@ module GenSymIO {
         }
     }
 
-    proc _buildReadAllMsgJson(rnames:list((string, ObjType, string)), allowErrors:bool, fileErrorCount:int, fileErrors:list(string,false), st: borrowed SymTab): string throws {
+    proc _buildReadAllMsgJson(rnames:list((string, ObjType, string)), allowErrors:bool, fileErrorCount:int, fileErrors:list(string), st: borrowed SymTab): string throws {
         var items: list(map(string, string));
 
         for rname in rnames {

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -193,7 +193,7 @@ module GenSymIO {
         }
     }
 
-    proc _buildReadAllMsgJson(rnames:list((string, ObjType, string),false), allowErrors:bool, fileErrorCount:int, fileErrors:list(string,false), st: borrowed SymTab): string throws {
+    proc _buildReadAllMsgJson(rnames:list((string, ObjType, string)), allowErrors:bool, fileErrorCount:int, fileErrors:list(string,false), st: borrowed SymTab): string throws {
         var items: list(map(string, string));
 
         for rname in rnames {

--- a/src/TransferMsg.chpl
+++ b/src/TransferMsg.chpl
@@ -245,20 +245,25 @@ module TransferMsg
           var rname = st.nextName();
           var (size, typeString, nodeNames, _) = receiveSetupInfo(hostname, port);
           if typeString == "int(64)" {
+            overMemLimit(2*size*numBytes(int));
             var entry = new shared SymEntry(size, int);
             receiveInto(entry, nodeNames, port, colName, rname, st);
           } else if typeString == "uint(64)" {
+            overMemLimit(2*size*numBytes(uint));
             var entry = new shared SymEntry(size, uint);
             receiveInto(entry, nodeNames, port, colName, rname, st);
           } else if typeString == "real(64)" {
+            overMemLimit(2*size*numBytes(real));
             var entry = new shared SymEntry(size, real);
             receiveInto(entry, nodeNames, port, colName, rname, st);
           } else if typeString == "bool" {
+            overMemLimit(2*size*8);
             var entry = new shared SymEntry(size, bool);
             receiveInto(entry, nodeNames, port, colName, rname, st);
           }
         } else if currObjType == "Strings" {
           var (size, typeString, nodeNames, objType) = receiveSetupInfo(hostname, port);
+          overMemLimit(3*size*numBytes(uint(8)));
           var values = new shared SymEntry(size, uint(8));
           receiveData(values.a, nodeNames, port);
           var (offSize, _, _, _) = receiveSetupInfo(hostname, port);
@@ -268,6 +273,7 @@ module TransferMsg
           rnames.append((colName, ObjType.STRINGS, "%s+%t".format(stringsEntry.name, stringsEntry.nBytes)));
         } else if currObjType == "Categorical" {
           var (size, typeString, nodeNames, objType) = receiveSetupInfo(hostname, port);
+          overMemLimit(4*size*numBytes(uint));
           var rtnMap: map(string, string) = new map(string, string);
           // GET CODES
           var codes = new shared SymEntry(size, int);
@@ -296,6 +302,7 @@ module TransferMsg
           rnames.append((colName, ObjType.CATEGORICAL, "%jt".format(rtnMap)));
         } else if currObjType == "SegArray" {
           var (size, typeString, nodeNames, _) = receiveSetupInfo(hostname, port);
+          overMemLimit(3*size*numBytes(uint));
           var rtnMap: map(string, string) = new map(string, string);
           if typeString == "int(64)" {
             var entry = new shared SymEntry(size, int);
@@ -557,6 +564,7 @@ module TransferMsg
       var (size, typeString, nodeNames, objType) = receiveSetupInfo(hostname, port);
 
       if objType == "string" {
+        overMemLimit(3*size*numBytes(uint(8)));
         // this is a strings, so we know there are going to be two receives
         var values = new shared SymEntry(size, uint(8));
         receiveData(values.a, nodeNames, port);
@@ -568,6 +576,7 @@ module TransferMsg
         rnames.append(("", ObjType.STRINGS, "%s+%t".format(stringsEntry.name, stringsEntry.nBytes)));
       } else if objType == "seg_array" {
         var rtnMap: map(string, string) = new map(string, string);
+        overMemLimit(4*size*numBytes(uint(8)));
         if typeString == "int(64)" {
           var entry = new shared SymEntry(size, int);
           var vname = st.nextName();
@@ -629,6 +638,7 @@ module TransferMsg
         }
         rnames.append(("", ObjType.SEGARRAY, "%jt".format(rtnMap)));
       } else if objType == "categorical" {
+        overMemLimit(5*size*numBytes(uint(8)));
         var rtnMap: map(string, string) = new map(string, string);
         // GET CODES
         var codes = new shared SymEntry(size, int);

--- a/src/TransferMsg.chpl
+++ b/src/TransferMsg.chpl
@@ -114,7 +114,6 @@ module TransferMsg
 
       coforall loc in Locales do on loc {
         //TODO: parallelize
-        //TODO: These should be split, nodeNames can differ from intersections
         for (intersection,name,p) in zip(intersections, nodesToReceiveFrom, ports) {
           const intrsct = getIntersection(A.localSubdomain(), intersection);
           if intrsct.size > 0 {

--- a/src/TransferMsg.chpl
+++ b/src/TransferMsg.chpl
@@ -1,0 +1,291 @@
+module TransferMsg
+{
+    use MultiTypeSymbolTable;
+    use MultiTypeSymEntry;
+    use Message;
+    use Reflection;
+    use CTypes;
+    use ZMQ;
+    use List;
+
+    config const sports = true;
+    
+    proc sendArrMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+      var hostname = msgArgs.getValueOf("hostname");
+      var port = msgArgs.getValueOf("port");
+      
+      var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(msgArgs.getValueOf("arg1"), st);
+      select gEnt.dtype {
+        when DType.Int64 {
+          var e = toSymEntry(gEnt, int);
+          sendData(e, hostname, port);
+        } when DType.UInt64 {
+          var e = toSymEntry(gEnt, uint);
+          sendData(e, hostname, port);
+        } when DType.Float64 {
+          var e = toSymEntry(gEnt, real);
+          sendData(e, hostname, port);
+        } when DType.Bool {
+          var e = toSymEntry(gEnt, bool);
+          sendData(e, hostname, port);
+        }
+      }
+      
+      return new MsgTuple("Array sent", MsgType.NORMAL);
+    }
+
+    proc receiveArrMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+      var hostname = msgArgs.getValueOf("hostname");
+      var port = msgArgs.getValueOf("port");
+
+      // send number of locales so that the sender knows how to chunk data
+      sendLocaleCount(port);
+      
+      var context: Context;
+      var socket = context.socket(ZMQ.PULL);
+      socket.connect("tcp://"+hostname+":"+port);
+      var size = socket.recv(bytes):int;
+      var typeString = socket.recv(string);
+
+      // get names of nodes to receive from in order
+      var nodeNamesStr = socket.recv(string);
+      var nodeNames = nodeNamesStr.split(" ");
+
+      var rname = st.nextName();
+      if typeString == "int(64)" {
+        var entry = new shared SymEntry(size, int);
+        receiveData(entry.a, nodeNames, port);
+        st.addEntry(rname, entry);
+      } else if typeString == "uint(64)" {
+        var entry = new shared SymEntry(size, uint);
+        receiveData(entry.a, nodeNames, port);
+        st.addEntry(rname, entry);
+      } else if typeString == "real(64)" {
+        var entry = new shared SymEntry(size, real);
+        receiveData(entry.a, nodeNames, port);
+        st.addEntry(rname, entry);
+      } else if typeString == "bool" {
+        var entry = new shared SymEntry(size, bool);
+        receiveData(entry.a, nodeNames, port);
+        st.addEntry(rname, entry);
+      }
+      
+      var repMsg = "created " + st.attrib(rname);
+      return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+
+    proc sendData(e, hostname:string, port:string) throws {
+      // get locale count so that we can chunk data
+      var localeCount = receiveLocaleCount(hostname, port);
+
+      // these are the subdoms of the receiving node
+      const otherSubdoms = getSubdoms(e.a, localeCount);
+      const hereSubdoms = getSubdoms(e.a, Locales.size);
+
+      // size of this is how many messages are going to be sent
+      const intersections = getIntersections(otherSubdoms, hereSubdoms);
+
+      const names = Locales.name;
+      const namesThatWillSendMessages = getNodeList(intersections, hereSubdoms, names);
+      const ports = getPorts(namesThatWillSendMessages, port:int);
+
+      writeln();
+      writeln("OTHER: ", otherSubdoms);
+      writeln("HERE: ", hereSubdoms);
+      writeln("INTERSECTIONS: ", intersections);
+      writeln("PORTS: ", ports);
+      writeln();
+
+      sendSetupInfo(port, e.a, names);
+
+      coforall loc in Locales do on loc {
+        writeln("LOCAL SUBDOMAIN: ", e.a.localSubdomain());
+        var locdom = e.a.localSubdomain();
+        // TODO: Parallelize by using different ports
+        for (i,p) in zip(intersections, ports) {
+          const intersection = getIntersection(locdom, i);
+          if intersection.size > 0 {
+            writeln();
+            writeln("SENDING ", intersection, " FROM ", here.name, " ON PORT ", p);
+            writeln();
+            if sports then
+              sendArrChunk(p, e.a, intersection);
+          }
+        }
+      }
+    }
+
+    proc receiveData(A: [] ?t, nodeNames, port) throws {
+      const hereSubdoms = getSubdoms(A, Locales.size);
+      const otherSubdoms = getSubdoms(A, nodeNames.size);
+      // nodeNames lines up with intersections
+      const intersections = getIntersections(hereSubdoms, otherSubdoms);
+
+      writeln();
+      writeln("INTERSECTIONS: ", intersections, " HERE SUBDOMS ", hereSubdoms," REMOTE SUBDOMS: ", otherSubdoms, " NODENAMES: ", nodeNames);
+      writeln();
+
+      const nodesToReceiveFrom = getNodeList(intersections, otherSubdoms, nodeNames);
+      const ports = getPorts(nodesToReceiveFrom, port:int);
+
+      writeln();
+      writeln("NODES TO RECEIVE FROM: ", nodesToReceiveFrom);
+      writeln("PORTS TO RECEIVE FROM: ", ports);
+      writeln();
+
+      coforall loc in Locales do on loc {
+        writeln("LOCAL SUBDOMAIN: ", A.localSubdomain());
+        //TODO: parallelize
+        //TODO: These should be split, nodeNames can differ from intersections
+        for (intersection,name,p) in zip(intersections, nodesToReceiveFrom, ports) {
+          const intrsct = getIntersection(A.localSubdomain(), intersection);
+          if intrsct.size > 0 {
+            writeln("RECEIVING ", intersection, " FROM ", name, " ", p, " ON ", here.name);
+            if sports then receiveArrChunk(p, name, A, intersection);
+          }
+        }
+      }
+    }
+
+    proc sendLocaleCount(port) throws {
+      var context: Context;
+      var socket = context.socket(ZMQ.PUSH);
+      socket.bind("tcp://*:"+port);
+
+      // first send the size
+      socket.send(Locales.size:bytes);
+    }
+
+    proc receiveLocaleCount(hostname:string, port:string) throws {
+      var context: Context;
+      var socket = context.socket(ZMQ.PULL);
+      socket.connect("tcp://"+hostname+":"+port);
+      return socket.recv(bytes):int;
+    }
+
+    proc sendSetupInfo(port:string, A: [] ?t, names) throws {
+      var context: Context;
+      var socket = context.socket(ZMQ.PUSH);
+      socket.bind("tcp://*:"+port);
+
+      // first send the size
+      socket.send(A.size:bytes);
+
+      // next send the type
+      socket.send(t:string);
+
+      // next, send the names of the nodes as a string
+      var namesString = "";
+      for i in names.domain {
+        if i != names.domain.high then
+          namesString +=names[i] + " ";
+        else
+          namesString += names[i];
+      }
+      socket.send(namesString);
+    }
+
+    proc sendArrChunk(port: int, A: [] ?t, intersection: domain(1)) throws {
+      var locContext: Context;
+      var locSocket = locContext.socket(ZMQ.PUSH);
+      locSocket.bind("tcp://*:"+port:string);
+      // exchange some data to establish connection
+      locSocket.send(5);
+      const size = intersection.size*c_sizeof(t):int;
+      var locBuff = createBytesWithBorrowedBuffer(c_ptrTo(A[intersection.low]):c_ptr(uint(8)), size, size);
+      locSocket.send(locBuff);
+    }
+
+    proc receiveArrChunk(port: int, hostname:string, A: [] ?t, intersection: domain(1)) throws {
+      var locContext: Context;
+      var locSocket = locContext.socket(ZMQ.PULL);
+      locSocket.connect("tcp://"+hostname+":"+port:string);
+      // exchange some data so it works
+      locSocket.recv(int);
+      var locData = locSocket.recv(bytes);
+      var locArr = makeArrayFromPtr(locData.c_str():c_void_ptr:c_ptr(t), intersection.size:uint);
+      A[intersection] = locArr;
+    }
+
+    proc getPorts(nodeNames, port) throws {
+      // TODO: this could use less ports if we only incremented
+      //       duplicate names, but starting with the easier way
+      //       of just unique ports for everything
+      var ports = [i in 0..#nodeNames.size] port + i;
+      return ports;
+    }
+
+    proc getNodeList(intersects, subdoms, nodeNames) throws {
+      var nodeList: [0..#intersects.size] string;
+      for (subdom, nodeName) in zip(subdoms, nodeNames) {
+        for (i, val) in zip(intersects, nodeList) {
+          const intersection = getIntersection(i, subdom);
+          if intersection.size > 0 {
+            val = nodeName;
+          }
+        }
+      }
+      return nodeList;
+    }
+
+    proc getIntersection(d1: domain(1), d2: domain(1)) {
+      var low = max(d1.low, d2.low);
+      var high = min(d1.high, d2.high);
+      return {low..high};
+    }
+
+    proc getIntersections(sendingDoms, receivingDoms) {
+      var intersections: list(domain(1));
+      for d1 in sendingDoms {
+        for d2 in receivingDoms {
+          const intersection = getIntersection(d1, d2);
+          if intersection.size > 0 then
+            intersections.append(intersection);
+        }
+      }
+      return intersections;
+    }
+
+    proc getSubdoms(A: [] ?t, size:int) {
+      var subdoms: [0..#size] domain(1);
+      for i in 0..#size {
+        subdoms[i] = getBlock(A.domain.low, A.domain.high, size, i);
+      }
+      return subdoms;
+    }
+    proc getBlock(const lo: int, const hi:int, const numlocs: int, const locid: int) {
+      type idxType = int;
+      var inds: range(idxType);
+      const numelems = hi - lo + 1;
+      const (blo, bhi) = _computeBlock(numelems, numlocs, chpl__tuplify(locid)(0),
+                                       hi, lo, lo);
+      inds = blo..bhi;
+      return inds;
+    }
+
+    proc _computeBlock(numelems, numblocks, blocknum, wayhi,
+                       waylo=0:wayhi.type, lo=0:wayhi.type) {
+      if numelems == 0 then
+        return (1:lo.type, 0:lo.type);
+
+      const blo =
+        if blocknum == 0 then waylo
+        else lo + intCeilXDivByY(numelems:uint * blocknum:uint, numblocks:uint):lo.type;
+      const bhi =
+        if blocknum == numblocks - 1 then wayhi
+        else lo + intCeilXDivByY(numelems:uint * (blocknum+1):uint, numblocks:uint):lo.type - 1;
+
+      return (blo, bhi);
+    }
+
+    proc intCeilXDivByY(x, y) do return 1 + (x - 1)/y;
+
+    proc bytesToLocArray(size:int, type t, ref data:bytes) throws {
+      var res = makeArrayFromPtr(data.c_str():c_void_ptr:c_ptr(t), size:uint);
+      return res;
+    }
+    
+    use CommandMap;
+    registerFunction("sendArray", sendArrMsg, getModuleName());
+    registerFunction("receiveArray", receiveArrMsg, getModuleName());
+}

--- a/src/TransferMsg.chpl
+++ b/src/TransferMsg.chpl
@@ -168,9 +168,6 @@ module TransferMsg
       var context: Context;
       var socket = context.socket(ZMQ.PUSH);
       socket.bind("tcp://*:"+port:string);
-      // exchange some data to establish connection
-      var a = 5;
-      socket.send(a);
       const size = intersection.size*c_sizeof(t):int;
       var locBuff = createBytesWithBorrowedBuffer(c_ptrTo(A[intersection.low]):c_ptr(uint(8)), size, size);
       socket.send(locBuff);
@@ -184,8 +181,6 @@ module TransferMsg
         socket.connect("tcp://localhost:"+port:string);
       else
         socket.connect("tcp://"+hostname+":"+port:string);
-      // exchange some data so it works
-      var a = socket.recv(int);
       var locData = socket.recv(bytes);
       var locArr = makeArrayFromPtr(locData.c_str():c_void_ptr:c_ptr(t), intersection.size:uint);
       A[intersection] = locArr;

--- a/src/TransferMsg.chpl
+++ b/src/TransferMsg.chpl
@@ -246,28 +246,28 @@ module TransferMsg
           var (size, typeString, nodeNames, _) = receiveSetupInfo(hostname, port);
           if typeString == "int(64)" {
             overMemLimit(2*size*numBytes(int));
-            var entry = new shared SymEntry(size, int);
+            var entry = createSymEntry(size, int);
             receiveInto(entry, nodeNames, port, colName, rname, st);
           } else if typeString == "uint(64)" {
             overMemLimit(2*size*numBytes(uint));
-            var entry = new shared SymEntry(size, uint);
+            var entry = createSymEntry(size, uint);
             receiveInto(entry, nodeNames, port, colName, rname, st);
           } else if typeString == "real(64)" {
             overMemLimit(2*size*numBytes(real));
-            var entry = new shared SymEntry(size, real);
+            var entry = createSymEntry(size, real);
             receiveInto(entry, nodeNames, port, colName, rname, st);
           } else if typeString == "bool" {
             overMemLimit(2*size*8);
-            var entry = new shared SymEntry(size, bool);
+            var entry = createSymEntry(size, bool);
             receiveInto(entry, nodeNames, port, colName, rname, st);
           }
         } else if currObjType == "Strings" {
           var (size, typeString, nodeNames, objType) = receiveSetupInfo(hostname, port);
           overMemLimit(3*size*numBytes(uint(8)));
-          var values = new shared SymEntry(size, uint(8));
+          var values = createSymEntry(size, uint(8));
           receiveData(values.a, nodeNames, port);
           var (offSize, _, _, _) = receiveSetupInfo(hostname, port);
-          var offsets = new shared SymEntry(offSize, int);
+          var offsets = createSymEntry(offSize, int);
           receiveData(offsets.a, nodeNames, port);
           var stringsEntry = assembleSegStringFromParts(offsets, values, st);
           rnames.append((colName, ObjType.STRINGS, "%s+%t".format(stringsEntry.name, stringsEntry.nBytes)));
@@ -276,22 +276,22 @@ module TransferMsg
           overMemLimit(4*size*numBytes(uint));
           var rtnMap: map(string, string) = new map(string, string);
           // GET CODES
-          var codes = new shared SymEntry(size, int);
+          var codes = createSymEntry(size, int);
           receiveData(codes.a, nodeNames, port);
           var cname = st.nextName();
           st.addEntry(cname, codes);
         
           // GET CATS STRING
           var (valSize, _, _, _) = receiveSetupInfo(hostname, port);
-          var values = new shared SymEntry(valSize, uint(8));
+          var values = createSymEntry(valSize, uint(8));
           receiveData(values.a, nodeNames, port);
           var (offSize, _, _, _) = receiveSetupInfo(hostname, port);
-          var offsets = new shared SymEntry(offSize, int);
+          var offsets = createSymEntry(offSize, int);
           receiveData(offsets.a, nodeNames, port);
           var cats = assembleSegStringFromParts(offsets, values, st);
 
           // GET NA CODES
-          var nacodes = new shared SymEntry(size, int);
+          var nacodes = createSymEntry(size, int);
           receiveData(nacodes.a, nodeNames, port);
           var nname = st.nextName();
           st.addEntry(nname, nacodes);
@@ -305,12 +305,12 @@ module TransferMsg
           overMemLimit(3*size*numBytes(uint));
           var rtnMap: map(string, string) = new map(string, string);
           if typeString == "int(64)" {
-            var entry = new shared SymEntry(size, int);
+            var entry = createSymEntry(size, int);
             var vname = st.nextName();
             receiveData(entry.a, nodeNames, port);
 
             var (segSize, _, _, _) = receiveSetupInfo(hostname, port);
-            var segments = new shared SymEntry(segSize, int);
+            var segments = createSymEntry(segSize, int);
             var sname = st.nextName();
             receiveData(segments.a, nodeNames, port);
 
@@ -320,12 +320,12 @@ module TransferMsg
             rtnMap.add("segments", "created " + st.attrib(sname));
             rtnMap.add("values", "created " + st.attrib(vname));
           } else if typeString == "uint(64)" {
-            var entry = new shared SymEntry(size, uint);
+            var entry = createSymEntry(size, uint);
             var vname = st.nextName();
             receiveData(entry.a, nodeNames, port);
 
             var (segSize, _, _, _) = receiveSetupInfo(hostname, port);
-            var segments = new shared SymEntry(segSize, int);
+            var segments = createSymEntry(segSize, int);
             var sname = st.nextName();
             st.addEntry(sname, segments);
             st.addEntry(vname, entry);
@@ -333,12 +333,12 @@ module TransferMsg
             rtnMap.add("segments", "created " + st.attrib(sname));
             rtnMap.add("values", "created " + st.attrib(vname));
           } else if typeString == "real(64)" {
-            var entry = new shared SymEntry(size, real);
+            var entry = createSymEntry(size, real);
             var vname = st.nextName();
             receiveData(entry.a, nodeNames, port);
 
             var (segSize, _, _, _) = receiveSetupInfo(hostname, port);
-            var segments = new shared SymEntry(segSize, int);
+            var segments = createSymEntry(segSize, int);
             var sname = st.nextName();
             receiveData(segments.a, nodeNames, port);
           
@@ -348,12 +348,12 @@ module TransferMsg
             rtnMap.add("segments", "created " + st.attrib(sname));
             rtnMap.add("values", "created " + st.attrib(vname));
           } else if typeString == "bool" {
-            var entry = new shared SymEntry(size, bool);
+            var entry = createSymEntry(size, bool);
             receiveData(entry.a, nodeNames, port);
             var vname = st.nextName();
 
             var (segSize, _, _, _) = receiveSetupInfo(hostname, port);
-            var segments = new shared SymEntry(segSize, int);
+            var segments = createSymEntry(segSize, int);
             receiveData(segments.a, nodeNames, port);
             var sname = st.nextName();
           
@@ -566,10 +566,10 @@ module TransferMsg
       if objType == "string" {
         overMemLimit(3*size*numBytes(uint(8)));
         // this is a strings, so we know there are going to be two receives
-        var values = new shared SymEntry(size, uint(8));
+        var values = createSymEntry(size, uint(8));
         receiveData(values.a, nodeNames, port);
         var (offSize, _, _, _) = receiveSetupInfo(hostname, port);
-        var offsets = new shared SymEntry(offSize, int);
+        var offsets = createSymEntry(offSize, int);
         receiveData(offsets.a, nodeNames, port);
         var stringsEntry = assembleSegStringFromParts(offsets, values, st);
         //getSegString(offsets.a, values.a, st);
@@ -578,12 +578,12 @@ module TransferMsg
         var rtnMap: map(string, string) = new map(string, string);
         overMemLimit(4*size*numBytes(uint(8)));
         if typeString == "int(64)" {
-          var entry = new shared SymEntry(size, int);
+          var entry = createSymEntry(size, int);
           var vname = st.nextName();
           receiveData(entry.a, nodeNames, port);
 
           var (segSize, _, _, _) = receiveSetupInfo(hostname, port);
-          var segments = new shared SymEntry(segSize, int);
+          var segments = createSymEntry(segSize, int);
           var sname = st.nextName();
           receiveData(segments.a, nodeNames, port);
 
@@ -593,12 +593,12 @@ module TransferMsg
           rtnMap.add("segments", "created " + st.attrib(sname));
           rtnMap.add("values", "created " + st.attrib(vname));
         } else if typeString == "uint(64)" {
-          var entry = new shared SymEntry(size, uint);
+          var entry = createSymEntry(size, uint);
           var vname = st.nextName();
           receiveData(entry.a, nodeNames, port);
 
           var (segSize, _, _, _) = receiveSetupInfo(hostname, port);
-          var segments = new shared SymEntry(segSize, int);
+          var segments = createSymEntry(segSize, int);
           var sname = st.nextName();
           st.addEntry(sname, segments);
           st.addEntry(vname, entry);
@@ -606,12 +606,12 @@ module TransferMsg
           rtnMap.add("segments", "created " + st.attrib(sname));
           rtnMap.add("values", "created " + st.attrib(vname));
         } else if typeString == "real(64)" {
-          var entry = new shared SymEntry(size, real);
+          var entry = createSymEntry(size, real);
           var vname = st.nextName();
           receiveData(entry.a, nodeNames, port);
 
           var (segSize, _, _, _) = receiveSetupInfo(hostname, port);
-          var segments = new shared SymEntry(segSize, int);
+          var segments = createSymEntry(segSize, int);
           var sname = st.nextName();
           receiveData(segments.a, nodeNames, port);
           
@@ -621,12 +621,12 @@ module TransferMsg
           rtnMap.add("segments", "created " + st.attrib(sname));
           rtnMap.add("values", "created " + st.attrib(vname));
         } else if typeString == "bool" {
-          var entry = new shared SymEntry(size, bool);
+          var entry = createSymEntry(size, bool);
           receiveData(entry.a, nodeNames, port);
           var vname = st.nextName();
 
           var (segSize, _, _, _) = receiveSetupInfo(hostname, port);
-          var segments = new shared SymEntry(segSize, int);
+          var segments = createSymEntry(segSize, int);
           receiveData(segments.a, nodeNames, port);
           var sname = st.nextName();
           
@@ -641,23 +641,23 @@ module TransferMsg
         overMemLimit(5*size*numBytes(uint(8)));
         var rtnMap: map(string, string) = new map(string, string);
         // GET CODES
-        var codes = new shared SymEntry(size, int);
+        var codes = createSymEntry(size, int);
         receiveData(codes.a, nodeNames, port);
         var cname = st.nextName();
         st.addEntry(cname, codes);
         
         // GET CATS STRING
         var (valSize, _, _, _) = receiveSetupInfo(hostname, port);
-        var values = new shared SymEntry(valSize, uint(8));
+        var values = createSymEntry(valSize, uint(8));
         receiveData(values.a, nodeNames, port);
         var (offSize, _, _, _) = receiveSetupInfo(hostname, port);
-        var offsets = new shared SymEntry(offSize, int);
+        var offsets = createSymEntry(offSize, int);
         receiveData(offsets.a, nodeNames, port);
         var cats = assembleSegStringFromParts(offsets, values, st);
 
         // GET NACODES
         var (naCodesSize, _, _, _) = receiveSetupInfo(hostname, port);
-        var naCodes = new shared SymEntry(naCodesSize, int);
+        var naCodes = createSymEntry(naCodesSize, int);
         receiveData(naCodes.a, nodeNames, port);
         var nname = st.nextName();
         st.addEntry(nname, naCodes);
@@ -669,19 +669,19 @@ module TransferMsg
       } else {
         var rname = st.nextName();
         if typeString == "int(64)" {
-          var entry = new shared SymEntry(size, int);
+          var entry = createSymEntry(size, int);
           receiveData(entry.a, nodeNames, port);
           st.addEntry(rname, entry);
         } else if typeString == "uint(64)" {
-          var entry = new shared SymEntry(size, uint);
+          var entry = createSymEntry(size, uint);
           receiveData(entry.a, nodeNames, port);
           st.addEntry(rname, entry);
         } else if typeString == "real(64)" {
-          var entry = new shared SymEntry(size, real);
+          var entry = createSymEntry(size, real);
           receiveData(entry.a, nodeNames, port);
           st.addEntry(rname, entry);
         } else if typeString == "bool" {
-          var entry = new shared SymEntry(size, bool);
+          var entry = createSymEntry(size, bool);
           receiveData(entry.a, nodeNames, port);
           st.addEntry(rname, entry);
         }

--- a/src/TransferMsg.chpl
+++ b/src/TransferMsg.chpl
@@ -89,27 +89,15 @@ module TransferMsg
       const namesThatWillSendMessages = getNodeList(intersections, hereSubdoms, names);
       const ports = getPorts(namesThatWillSendMessages, port:int);
 
-      writeln();
-      writeln("OTHER: ", otherSubdoms);
-      writeln("HERE: ", hereSubdoms);
-      writeln("INTERSECTIONS: ", intersections);
-      writeln("PORTS: ", ports);
-      writeln();
-
       sendSetupInfo(port, e.a, names);
 
       coforall loc in Locales do on loc {
-        writeln("LOCAL SUBDOMAIN: ", e.a.localSubdomain());
         var locdom = e.a.localSubdomain();
         // TODO: Parallelize by using different ports
         for (i,p) in zip(intersections, ports) {
           const intersection = getIntersection(locdom, i);
           if intersection.size > 0 {
-            writeln();
-            writeln("SENDING ", intersection, " FROM ", here.name, " ON PORT ", p);
-            writeln();
-            if sports then
-              sendArrChunk(p, e.a, intersection);
+            sendArrChunk(p, e.a, intersection);
           }
         }
       }
@@ -121,27 +109,16 @@ module TransferMsg
       // nodeNames lines up with intersections
       const intersections = getIntersections(hereSubdoms, otherSubdoms);
 
-      writeln();
-      writeln("INTERSECTIONS: ", intersections, " HERE SUBDOMS ", hereSubdoms," REMOTE SUBDOMS: ", otherSubdoms, " NODENAMES: ", nodeNames);
-      writeln();
-
       const nodesToReceiveFrom = getNodeList(intersections, otherSubdoms, nodeNames);
       const ports = getPorts(nodesToReceiveFrom, port:int);
 
-      writeln();
-      writeln("NODES TO RECEIVE FROM: ", nodesToReceiveFrom);
-      writeln("PORTS TO RECEIVE FROM: ", ports);
-      writeln();
-
       coforall loc in Locales do on loc {
-        writeln("LOCAL SUBDOMAIN: ", A.localSubdomain());
         //TODO: parallelize
         //TODO: These should be split, nodeNames can differ from intersections
         for (intersection,name,p) in zip(intersections, nodesToReceiveFrom, ports) {
           const intrsct = getIntersection(A.localSubdomain(), intersection);
           if intrsct.size > 0 {
-            writeln("RECEIVING ", intersection, " FROM ", name, " ", p, " ON ", here.name);
-            if sports then receiveArrChunk(p, name, A, intersection);
+            receiveArrChunk(p, name, A, intersection);
           }
         }
       }

--- a/src/TransferMsg.chpl
+++ b/src/TransferMsg.chpl
@@ -254,7 +254,9 @@ module TransferMsg
       return (blo, bhi);
     }
 
-    proc intCeilXDivByY(x, y) do return 1 + (x - 1)/y;
+    proc intCeilXDivByY(x, y) {
+      return 1 + (x - 1)/y;
+    }
 
     proc bytesToLocArray(size:int, type t, ref data:bytes) throws {
       var res = makeArrayFromPtr(data.c_str():c_void_ptr:c_ptr(t), size:uint);

--- a/src/TransferMsg.chpl
+++ b/src/TransferMsg.chpl
@@ -353,10 +353,6 @@ module TransferMsg
       var objType: ObjType = msgArgs.getValueOf("objType").toUpper(): ObjType;
 
       select objType {
-        when ObjType.ARRAYVIEW {
-          // call handler for arrayview write msg
-          //arrayView_tohdfMsg(msgArgs, st);
-        }
         when ObjType.PDARRAY {
           // call handler for pdarray write
           pdarrayTransfer(msgArgs, st);


### PR DESCRIPTION
This PR adds the ability to send a pdarray from one server to
another server through ZMQ sockets. This can be useful when
multiple Arkouda servers would like to operate on smaller
subsets of one giant dataset that can't fit on each Arkouda
server individually. For example, one large "mother" Arkouda
server could load in the entire dataset, downselect the data
as needed for each "child" server, then send the portion of
that array to the child server that would like to operate on
that portion of the dataset.

Prior to this PR, this would need to be done by writing the
downselected portion from the mother server, reading those
files into the child server, and then operating. This aims
to replace the file system go-between of this use case,
simplifying the number of steps needed to get a pdarray
from one server to another and also potentially achieving 
better performance than would be possible using the file
system.

The performance could be improved, especially for the case
where the sending/receiving servers are of different element
sizes, but this initial work is focused on correctness.

Performance numbers collected on a Cray CS HDR transfers over
100G HDR-IB:

| Nodes     | Receiving 2  | Receiving 3  | Receiving 4  |
| --------: | -----------: | -----------: | -----------: |
| Sending 2 | 1.2385 GiB/s | 0.6264 GiB/s | 1.4077 GiB/s |
| Sending 3 | 0.6680 GiB/s | 1.6672 GiB/s | 0.6270 GiB/s |
| Sending 4 | 1.3586 GiB/s | 0.7278 GiB/s | 1.9504 GiB/s |

Types supported in initial implementation with `send_array`/`receive_array` interface:
- all native Arkouda datatypes (int, uint, bool, float)
- categorical
- strings
- segmented array

Additionally, DataFrames containing columns of the above supported types can be transferred with a slightly different interface of `DataFrame.transfer(hostname, port)`/`ak.receive_dataframe(hostname, port)`

Closes: #2405 
