### PR TITLE
Add a use of the Math module to avoid the anticipated `pi` deprecation warning

### DIFF
--- a/src/RandArray.chpl
+++ b/src/RandArray.chpl
@@ -8,6 +8,7 @@ module RandArray {
   use SipHash;
   use ServerConfig;
   private use IO;
+  use Math;
 
   use ArkoudaMapCompat;
   


### PR DESCRIPTION
`pi` will stop being included by default in Chapel 1.31.  To avoid
deprecation warnings when switching to that release in the future,
add a use of its new location (the `Math` module) to the context
where it is being referenced.

This will also avoid deprecation warnings for some other symbols
we intend to stop including by default in 1.31, as an added bonus.