### PR TITLE
Deprecation updates for `BitOps.popcount` and `bigint.mod`

### DIFF
--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -18,6 +18,8 @@ module EfuncMsg
     
     use AryUtil;
 
+    use ArkoudaBitOpsCompat;
+
     private config const logLevel = ServerConfig.logLevel;
     private config const logChannel = ServerConfig.logChannel;
     const eLogger = new Logger(logLevel, logChannel);
@@ -106,7 +108,7 @@ module EfuncMsg
                     }
                     when "popcount" {
                         var a = st.addEntry(rname, e.size, int);
-                        a.a = popcount(e.a);
+                        a.a = popCount(e.a);
                     }
                     when "parity" {
                         var a = st.addEntry(rname, e.size, int);
@@ -220,7 +222,7 @@ module EfuncMsg
                 {
                     when "popcount" {
                         var a = st.addEntry(rname, e.size, uint);
-                        a.a = popcount(e.a);
+                        a.a = popCount(e.a);
                     }
                     when "clz" {
                         var a = st.addEntry(rname, e.size, uint);

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -1317,7 +1317,7 @@ module IndexingMsg
                 var x = toSymEntry(gX,bigint);
                 var y = toSymEntry(gY,bigint);
                 if x.max_bits != -1 {
-                    BigInteger.mod(y.a, y.a, x.max_bits);
+                    mod(y.a, y.a, x.max_bits);
                 }
                 x.a[slice] = y.a;
              }
@@ -1326,7 +1326,7 @@ module IndexingMsg
                 var y = toSymEntry(gY,int);
                 var ya = y.a:bigint;
                 if x.max_bits != -1 {
-                    BigInteger.mod(ya, ya, x.max_bits);
+                    mod(ya, ya, x.max_bits);
                 }
                 x.a[slice] = ya;
              }
@@ -1335,7 +1335,7 @@ module IndexingMsg
                 var y = toSymEntry(gY,uint);
                 var ya = y.a:bigint;
                 if x.max_bits != -1 {
-                    BigInteger.mod(ya, ya, x.max_bits);
+                    mod(ya, ya, x.max_bits);
                 }
                 x.a[slice] = ya;
              }
@@ -1345,7 +1345,7 @@ module IndexingMsg
                 // TODO change once we can cast directly from bool to bigint
                 var ya = y.a:int:bigint;
                 if x.max_bits != -1 {
-                    BigInteger.mod(ya, ya, x.max_bits);
+                    mod(ya, ya, x.max_bits);
                 }
                 x.a[slice] = ya;
              }

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -1317,7 +1317,7 @@ module IndexingMsg
                 var x = toSymEntry(gX,bigint);
                 var y = toSymEntry(gY,bigint);
                 if x.max_bits != -1 {
-                    y.a.mod(y.a, x.max_bits);
+                    BigInteger.mod(y.a, y.a, x.max_bits);
                 }
                 x.a[slice] = y.a;
              }
@@ -1326,7 +1326,7 @@ module IndexingMsg
                 var y = toSymEntry(gY,int);
                 var ya = y.a:bigint;
                 if x.max_bits != -1 {
-                    ya.mod(ya, x.max_bits);
+                    BigInteger.mod(ya, ya, x.max_bits);
                 }
                 x.a[slice] = ya;
              }
@@ -1335,7 +1335,7 @@ module IndexingMsg
                 var y = toSymEntry(gY,uint);
                 var ya = y.a:bigint;
                 if x.max_bits != -1 {
-                    ya.mod(ya, x.max_bits);
+                    BigInteger.mod(ya, ya, x.max_bits);
                 }
                 x.a[slice] = ya;
              }
@@ -1345,7 +1345,7 @@ module IndexingMsg
                 // TODO change once we can cast directly from bool to bigint
                 var ya = y.a:int:bigint;
                 if x.max_bits != -1 {
-                    ya.mod(ya, x.max_bits);
+                    BigInteger.mod(ya, ya, x.max_bits);
                 }
                 x.a[slice] = ya;
              }
@@ -1353,13 +1353,13 @@ module IndexingMsg
                 var errorMsg = notImplementedError(pn,
                                      "("+dtype2str(gX.dtype)+","+dtype2str(gY.dtype)+")");
                 imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg, MsgType.ERROR);                                           
+                return new MsgTuple(errorMsg, MsgType.ERROR);
             }
         }
 
         repMsg = "%s success".format(pn);
         imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-        return new MsgTuple(repMsg, MsgType.NORMAL); 
+        return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 
     use CommandMap;

--- a/src/compat/e-129/ArkoudaBitOpsCompat.chpl
+++ b/src/compat/e-129/ArkoudaBitOpsCompat.chpl
@@ -1,0 +1,7 @@
+module ArkoudaBitOpsCompat {
+  use BitOps;
+
+  proc popCount(x: integral) {
+    return popcount(x);
+  }
+}

--- a/src/compat/e-130/ArkoudaBitOpsCompat.chpl
+++ b/src/compat/e-130/ArkoudaBitOpsCompat.chpl
@@ -1,0 +1,7 @@
+module ArkoudaBitOpsCompat {
+  use BitOps;
+
+  proc popCount(x: integral) {
+    return popcount(x);
+  }
+}

--- a/src/compat/gt-130/ArkoudaBitOpsCompat.chpl
+++ b/src/compat/gt-130/ArkoudaBitOpsCompat.chpl
@@ -1,1 +1,7 @@
-module ArkoudaBitOpsCompat { }
+module ArkoudaBitOpsCompat {
+  use BitOps;
+
+  proc popCount(x: integral) {
+    return popcount(x);
+  }
+}

--- a/src/compat/gt-130/ArkoudaBitOpsCompat.chpl
+++ b/src/compat/gt-130/ArkoudaBitOpsCompat.chpl
@@ -1,0 +1,1 @@
+module ArkoudaBitOpsCompat { }

--- a/src/compat/gt-130/ArkoudaBitOpsCompat.chpl
+++ b/src/compat/gt-130/ArkoudaBitOpsCompat.chpl
@@ -1,7 +1,1 @@
-module ArkoudaBitOpsCompat {
-  use BitOps;
-
-  proc popCount(x: integral) {
-    return popcount(x);
-  }
-}
+module ArkoudaBitOpsCompat { }


### PR DESCRIPTION
Updates for the following deprecations:

- `bigint.mod`: replaced by the standalone `BigInteger.mod` function
- `popcount`: renamed to `popCount`

Adds a compatibility module for bitops. A compatibility module for BigInteger was already set up.