### PR TITLE
Deprecation updates for `datetime` and `fromTimestamp`

### DIFF
--- a/src/Logging.chpl
+++ b/src/Logging.chpl
@@ -189,7 +189,7 @@ module Logging {
         }
          
         proc generateDateTimeString() throws {
-            var dts = datetime.now():string;
+            var dts = dateTime.now():string;
             var vals = dts.split("T");
             var cd = vals(0);
             var rawCms = vals(1).split(".");

--- a/src/MetricsMsg.chpl
+++ b/src/MetricsMsg.chpl
@@ -519,12 +519,12 @@ module MetricsMsg {
         var name: string;
         var category: MetricCategory;
         var scope: MetricScope;
-        var timestamp: datetime;
+        var timestamp: dateTime;
         var value: real;
         
         proc init(name: string, category: MetricCategory, 
                                 scope: MetricScope=MetricScope.GLOBAL, 
-                                timestamp: datetime=datetime.now(), 
+                                timestamp: dateTime=dateTime.now(), 
                                 value: real) {
             this.name = name;
             this.category = category;
@@ -540,7 +540,7 @@ module MetricsMsg {
 
         proc init(name: string, category: MetricCategory,
                                 scope: MetricScope=MetricScope.USER,
-                                timestamp: datetime=datetime.now(),
+                                timestamp: dateTime=dateTime.now(),
                                 value: real,
                                 user: string) {
 
@@ -562,7 +562,7 @@ module MetricsMsg {
         proc init(name: string, 
                   category: MetricCategory, 
                   scope: MetricScope=MetricScope.GLOBAL, 
-                  timestamp: datetime=datetime.now(), 
+                  timestamp: dateTime=dateTime.now(), 
                   value: real,
                   cmd: string,
                   dType: DType,
@@ -612,7 +612,7 @@ module MetricsMsg {
 
         proc init(name: string, category: MetricCategory, 
                                 scope: MetricScope=MetricScope.LOCALE, 
-                                timestamp: datetime=datetime.now(), 
+                                timestamp: dateTime=dateTime.now(), 
                                 value: real, 
                                 locale_num: int, 
                                 locale_name: string, 

--- a/src/TimeClassMsg.chpl
+++ b/src/TimeClassMsg.chpl
@@ -56,7 +56,7 @@ module TimeClassMsg {
 
         forall (v, y, m, d, iso_y, is_ly, woy, doy, dow) in zip(valuesEntry.a, year, month, day, isoYear, is_leap_year, weekOfYear, dayOfYear, dayOfWeek) {
             // convert to seconds and create date
-            var t = date.fromTimestamp(floorDivisionHelper(v, 10**9):int);
+            var t = date.createFromTimestamp(floorDivisionHelper(v, 10**9):int);
             (y, m, d, (iso_y, woy, dow)) = (t.year, t.month, t.day, t.isoCalendar());
             dow -= 1;
             is_ly = isLeapYear(y);

--- a/src/compat/e-129/ArkoudaTimeCompat.chpl
+++ b/src/compat/e-129/ArkoudaTimeCompat.chpl
@@ -346,7 +346,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   /* The date that is `timestamp` seconds from the epoch */
-  proc type date.fromTimestamp(timestamp) {
+  proc type date.createFromTimestamp(timestamp) {
     const sec = timestamp: int;
     const us = ((timestamp-sec) * 1000000 + 0.5): int;
     const td = new timedelta(seconds=sec, microseconds=us);
@@ -1102,13 +1102,13 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   /* The `dateTime` that is `timestamp` seconds from the epoch */
-  proc type dateTime.fromTimestamp(timestamp: real) {
-    return dateTime.fromTimestamp(timestamp, nil);
+  proc type dateTime.createFromTimestamp(timestamp: real) {
+    return dateTime.createFromTimestamp(timestamp, nil);
   }
 
   /* The `dateTime` that is `timestamp` seconds from the epoch */
   @unstable "tz is unstable; its type may change in the future"
-  proc type dateTime.fromTimestamp(timestamp: real,
+  proc type dateTime.createFromTimestamp(timestamp: real,
                                    in tz: shared Timezone?) {
     if tz.borrow() == nil {
       var t = (timestamp: int, ((timestamp - timestamp: int)*1000000): int);

--- a/src/compat/e-129/ArkoudaTimeCompat.chpl
+++ b/src/compat/e-129/ArkoudaTimeCompat.chpl
@@ -115,7 +115,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   private const DAYS_BEFORE_MONTH = init_days_before_month();
 
   /* The Unix Epoch date and time */
-  const unixEpoch = new datetime(1970, 1, 1);
+  const unixEpoch = new dateTime(1970, 1, 1);
 
   private const DI400Y = daysBeforeYear(401);
   private const DI100Y = daysBeforeYear(101);
@@ -509,7 +509,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     f.write(isoFormat());
   }
 
-  // Exists to support some common functionality for `datetime.readThis`
+  // Exists to support some common functionality for `dateTime.readThis`
   pragma "no doc"
   proc date._readCore(f) throws {
     const dash = "-";
@@ -748,7 +748,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     if timezone.borrow() == nil {
       return new timedelta();
     } else {
-      return timezone!.utcOffset(datetime.now());
+      return timezone!.utcOffset(dateTime.now());
     }
   }
 
@@ -757,7 +757,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     if timezone.borrow() == nil {
       return new timedelta();
     } else {
-      return timezone!.dst(datetime.now());
+      return timezone!.dst(dateTime.now());
     }
   }
 
@@ -766,7 +766,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     if timezone.borrow() == nil then
       return "";
     else
-      return timezone!.tzname(new datetime(1,1,1));
+      return timezone!.tzname(new dateTime(1,1,1));
   }
 
   /* Return a `string` matching the `format` argument for this `time` */
@@ -810,7 +810,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     f.write(isoFormat());
   }
 
-  // Exists to support some common functionality for `datetime.readThis`
+  // Exists to support some common functionality for `dateTime.readThis`
   pragma "no doc"
   proc time._readCore(f) throws {
     const colon = ":";
@@ -844,8 +844,8 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   pragma "no doc"
   operator time.==(t1: time, t2: time): bool {
-    var dt1 = datetime.combine(d=new date(2000, 1, 1), t=t1);
-    var dt2 = datetime.combine(d=new date(2000, 1, 1), t=t2);
+    var dt1 = dateTime.combine(d=new date(2000, 1, 1), t=t1);
+    var dt2 = dateTime.combine(d=new date(2000, 1, 1), t=t2);
     return dt1 == dt2;
   }
 
@@ -858,7 +858,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   operator time.<(t1: time, t2: time): bool {
     if (t1.timezone.borrow() != nil && t2.timezone.borrow() == nil) ||
         (t1.timezone.borrow() == nil && t2.timezone.borrow() != nil) {
-      halt("both datetimes must both be either naive or aware");
+      halt("both dateTimes must both be either naive or aware");
     } else if t1.timezone == t2.timezone {
       const sec1 = t1.hour*3600 + t1.minute*60 + t1.second;
       const usec1 = t1.microsecond;
@@ -871,21 +871,21 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       else
         return false;
     } else {
-      // As far as I can tell, python's datetime.time() comparisons don't
+      // As far as I can tell, python's dateTime.time() comparisons don't
       // pay attention to the timezones.
       // >>> central = pytz.timezone("US/Central")
       // >>> pacific = pytz.timezone("US/Pacific")
-      // >>> datetime.time(12,3,4,5,tz=central) >
-      //     datetime.time(12,3,4,5,tz=pacific)
+      // >>> dateTime.time(12,3,4,5,tz=central) >
+      //     dateTime.time(12,3,4,5,tz=pacific)
       // False
-      // >>> datetime.time(12,3,4,6,tz=central) >
-      //     datetime.time(12,3,4,5,tz=pacific)
+      // >>> dateTime.time(12,3,4,6,tz=central) >
+      //     dateTime.time(12,3,4,5,tz=pacific)
       // True
       //
       // This compares the time on a specific date, and factors in the
       // time zones.
-      const dt1 = datetime.combine(new date(1900, 1, 1), t1);
-      const dt2 = datetime.combine(new date(1900, 1, 1), t2);
+      const dt1 = dateTime.combine(new date(1900, 1, 1), t1);
+      const dt2 = dateTime.combine(new date(1900, 1, 1), t2);
       return dt1 < dt2;
       //return (t1.replace(tz=nil) - t1.utcOffset()) <
       //       (t2.replace(tz=nil) - t2.utcOffset());
@@ -896,7 +896,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   operator time.<=(t1: time, t2: time): bool {
     if (t1.timezone.borrow() != nil && t2.timezone.borrow() == nil) ||
         (t1.timezone.borrow() == nil && t2.timezone.borrow() != nil) {
-      halt("both datetimes must both be either naive or aware");
+      halt("both dateTimes must both be either naive or aware");
     } else if t1.timezone == t2.timezone {
       const sec1 = t1.hour*3600 + t1.minute*60 + t1.second;
       const usec1 = t1.microsecond;
@@ -909,8 +909,8 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       else
         return false;
     } else {
-      const dt1 = datetime.combine(new date(1900, 1, 1), t1);
-      const dt2 = datetime.combine(new date(1900, 1, 1), t2);
+      const dt1 = dateTime.combine(new date(1900, 1, 1), t1);
+      const dt2 = dateTime.combine(new date(1900, 1, 1), t2);
       return dt1 <= dt2;
     }
   }
@@ -919,7 +919,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   operator time.>(t1: time, t2: time): bool {
     if (t1.timezone.borrow() != nil && t2.timezone.borrow() == nil) ||
         (t1.timezone.borrow() == nil && t2.timezone.borrow() != nil) {
-      halt("both datetimes must both be either naive or aware");
+      halt("both dateTimes must both be either naive or aware");
     } else if t1.timezone == t2.timezone {
       const sec1 = t1.hour*3600 + t1.minute*60 + t1.second;
       const usec1 = t1.microsecond;
@@ -932,8 +932,8 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       else
         return false;
     } else {
-      const dt1 = datetime.combine(new date(1900, 1, 1), t1);
-      const dt2 = datetime.combine(new date(1900, 1, 1), t2);
+      const dt1 = dateTime.combine(new date(1900, 1, 1), t1);
+      const dt2 = dateTime.combine(new date(1900, 1, 1), t2);
       return dt1 > dt2;
     }
   }
@@ -942,7 +942,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   operator time.>=(t1: time, t2: time): bool {
     if (t1.timezone.borrow() != nil && t2.timezone.borrow() == nil) ||
         (t1.timezone.borrow() == nil && t2.timezone.borrow() != nil) {
-      halt("both datetimes must both be either naive or aware");
+      halt("both dateTimes must both be either naive or aware");
     } else if t1.timezone == t2.timezone {
       const sec1 = t1.hour*3600 + t1.minute*60 + t1.second;
       const usec1 = t1.microsecond;
@@ -955,14 +955,14 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       else
         return false;
     } else {
-      const dt1 = datetime.combine(new date(1900, 1, 1), t1);
-      const dt2 = datetime.combine(new date(1900, 1, 1), t2);
+      const dt1 = dateTime.combine(new date(1900, 1, 1), t1);
+      const dt2 = dateTime.combine(new date(1900, 1, 1), t2);
       return dt1 >= dt2;
     }
   }
 
   /* A record representing a combined `date` and `time` */
-  record datetime {
+  record dateTime {
     pragma "no doc"
     var chpl_date: date;
     pragma "no doc"
@@ -978,47 +978,47 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       return this.combine(date.max, time.max);
     }
 
-    /* The minimum non-zero difference between two datetimes */
+    /* The minimum non-zero difference between two dateTimes */
     proc type resolution {
       return new timedelta(microseconds=1);
     }
 
-    /* The year represented by this `datetime` value */
+    /* The year represented by this `dateTime` value */
     proc year {
       return chpl_date.year;
     }
 
-    /* The month represented by this `datetime` value */
+    /* The month represented by this `dateTime` value */
     proc month {
       return chpl_date.month;
     }
 
-    /* The day represented by this `datetime` value */
+    /* The day represented by this `dateTime` value */
     proc day {
       return chpl_date.day;
     }
 
-    /* The hour represented by this `datetime` value */
+    /* The hour represented by this `dateTime` value */
     proc hour {
       return chpl_time.hour;
     }
 
-    /* The minute represented by this `datetime` value */
+    /* The minute represented by this `dateTime` value */
     proc minute {
       return chpl_time.minute;
     }
 
-    /* The second represented by this `datetime` value */
+    /* The second represented by this `dateTime` value */
     proc second {
       return chpl_time.second;
     }
 
-    /* The microsecond represented by this `datetime` value */
+    /* The microsecond represented by this `dateTime` value */
     proc microsecond {
       return chpl_time.microsecond;
     }
 
-    /* The timezone represented by this `datetime` value */
+    /* The timezone represented by this `dateTime` value */
     proc timezone {
       return chpl_time.timezone;
     }
@@ -1030,56 +1030,56 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
   }
 
-  /* initializers/factories for datetime values */
+  /* initializers/factories for dateTime values */
 
   pragma "no doc"
-  proc datetime.init() {
+  proc dateTime.init() {
   }
 
-  /* Initialize a new `datetime` value from the given `year`, `month`, `day`,
+  /* Initialize a new `dateTime` value from the given `year`, `month`, `day`,
      `hour`, `minute`, `second`, `microsecond` and timezone.  The `year`,
      `month`, and `day` arguments are required, the rest are optional.
    */
   @unstable "tz is unstable; its type may change in the future"
-  proc datetime.init(year, month, day,
+  proc dateTime.init(year, month, day,
                      hour=0, minute=0, second=0, microsecond=0,
                      in tz) {
     chpl_date = new date(year, month, day);
     chpl_time = new time(hour, minute, second, microsecond, tz);
   }
 
-  /* Initialize a new `datetime` value from the given `year`, `month`, `day`,
+  /* Initialize a new `dateTime` value from the given `year`, `month`, `day`,
      `hour`, `minute`, `second`, `microsecond` and timezone.  The `year`,
      `month`, and `day` arguments are required, the rest are optional.
    */
-  proc datetime.init(year, month, day,
+  proc dateTime.init(year, month, day,
                      hour=0, minute=0, second=0, microsecond=0) {
     chpl_date = new date(year, month, day);
     chpl_time = new time(hour, minute, second, microsecond);
   }
 
-  /* Initialize a new `datetime` value from the given `date` and `time` */
-  proc datetime.init(d: date, t: time) {
+  /* Initialize a new `dateTime` value from the given `date` and `time` */
+  proc dateTime.init(d: date, t: time) {
     chpl_date = d;
     chpl_time = t;
   }
 
-  /* Return a `datetime` value representing the current time and date */
-  proc type datetime.now() {
+  /* Return a `dateTime` value representing the current time and date */
+  proc type dateTime.now() {
     const timeSinceEpoch = getTimeOfDay();
     const lt = getLocalTime(timeSinceEpoch);
-    return new datetime(year=lt.tm_year+1900, month=lt.tm_mon+1,
+    return new dateTime(year=lt.tm_year+1900, month=lt.tm_mon+1,
                         day=lt.tm_mday,       hour=lt.tm_hour,
                         minute=lt.tm_min,     second=lt.tm_sec,
                         microsecond=timeSinceEpoch(1));
   }
 
-  /* Return a `datetime` value representing the current time and date */
-  proc type datetime.now(in tz: shared Timezone?) {
+  /* Return a `dateTime` value representing the current time and date */
+  proc type dateTime.now(in tz: shared Timezone?) {
     if tz.borrow() == nil {
       const timeSinceEpoch = getTimeOfDay();
       const lt = getLocalTime(timeSinceEpoch);
-      return new datetime(year=lt.tm_year+1900, month=lt.tm_mon+1,
+      return new dateTime(year=lt.tm_year+1900, month=lt.tm_mon+1,
                           day=lt.tm_mday,       hour=lt.tm_hour,
                           minute=lt.tm_min,     second=lt.tm_sec,
                           microsecond=timeSinceEpoch(1));
@@ -1093,61 +1093,61 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
   }
 
-  /* Return a `datetime` value representing the current time and date in UTC */
-  proc type datetime.utcNow() {
+  /* Return a `dateTime` value representing the current time and date in UTC */
+  proc type dateTime.utcNow() {
     const timeSinceEpoch = getTimeOfDay();
     const td = new timedelta(seconds=timeSinceEpoch(0),
                              microseconds=timeSinceEpoch(1));
     return unixEpoch + td;
   }
 
-  /* The `datetime` that is `timestamp` seconds from the epoch */
-  proc type datetime.fromTimestamp(timestamp: real) {
-    return datetime.fromTimestamp(timestamp, nil);
+  /* The `dateTime` that is `timestamp` seconds from the epoch */
+  proc type dateTime.fromTimestamp(timestamp: real) {
+    return dateTime.fromTimestamp(timestamp, nil);
   }
 
-  /* The `datetime` that is `timestamp` seconds from the epoch */
+  /* The `dateTime` that is `timestamp` seconds from the epoch */
   @unstable "tz is unstable; its type may change in the future"
-  proc type datetime.fromTimestamp(timestamp: real,
+  proc type dateTime.fromTimestamp(timestamp: real,
                                    in tz: shared Timezone?) {
     if tz.borrow() == nil {
       var t = (timestamp: int, ((timestamp - timestamp: int)*1000000): int);
       const lt = getLocalTime(t);
-      return new datetime(year=lt.tm_year+1900, month=lt.tm_mon+1,
+      return new dateTime(year=lt.tm_year+1900, month=lt.tm_mon+1,
                           day=lt.tm_mday,       hour=lt.tm_hour,
                           minute=lt.tm_min,     second=lt.tm_sec,
                           microsecond=t(1));
     } else {
-      var dt = datetime.utcFromTimestamp(timestamp);
+      var dt = dateTime.utcFromTimestamp(timestamp);
       return (dt + tz!.utcOffset(dt)).replace(tz=tz);
     }
   }
 
-  /* The `datetime` that is `timestamp` seconds from the epoch in UTC */
-  proc type datetime.utcFromTimestamp(timestamp) {
+  /* The `dateTime` that is `timestamp` seconds from the epoch in UTC */
+  proc type dateTime.utcFromTimestamp(timestamp) {
     return unixEpoch + new timedelta(seconds=timestamp: int, microseconds=((timestamp-timestamp: int)*1000000): int);
   }
 
-  /* The `datetime` that is `ordinal` days from 1-1-0001 */
-  proc type datetime.fromOrdinal(ordinal) {
-    return datetime.combine(date.fromOrdinal(ordinal), new time());
+  /* The `dateTime` that is `ordinal` days from 1-1-0001 */
+  proc type dateTime.fromOrdinal(ordinal) {
+    return dateTime.combine(date.fromOrdinal(ordinal), new time());
   }
 
-  /* Form a `datetime` value from a given `date` and `time` */
-  proc type datetime.combine(d: date, t: time) {
-    return new datetime(d.year, d.month, d.day,
+  /* Form a `dateTime` value from a given `date` and `time` */
+  proc type dateTime.combine(d: date, t: time) {
+    return new dateTime(d.year, d.month, d.day,
                         t.hour, t.minute, t.second, t.microsecond, t.timezone);
   }
 
-  /* Methods on datetime values */
+  /* Methods on dateTime values */
 
-  /* Get the `date` portion of the `datetime` value */
-  proc datetime.getdate() {
+  /* Get the `date` portion of the `dateTime` value */
+  proc dateTime.getdate() {
     return chpl_date;
   }
 
-  /* Get the `time` portion of the `datetime` value, with `tz` = nil */
-  proc datetime.gettime() {
+  /* Get the `time` portion of the `dateTime` value, with `tz` = nil */
+  proc dateTime.gettime() {
     if chpl_time.timezone.borrow() == nil then
       return chpl_time;
     else
@@ -1155,21 +1155,21 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
                       second=second, microsecond=microsecond);
   }
 
-  /* Get the `time` portion of the `datetime` value including the
+  /* Get the `time` portion of the `dateTime` value including the
      `tz` field
    */
-  proc datetime.timetz() {
+  proc dateTime.timetz() {
     return chpl_time;
   }
 
   /* Replace the `year`, `month`, `day`, `hour`, `minute`, `second`,
-     `microsecond`, or `tz` to form a new `datetime` object. All
+     `microsecond`, or `tz` to form a new `dateTime` object. All
      arguments are optional.
    */
-  proc datetime.replace(year=-1, month=-1, day=-1,
+  proc dateTime.replace(year=-1, month=-1, day=-1,
                         hour=-1, minute=-1, second=-1, microsecond=-1,
                         in tz=this.timezone) {
-    return datetime.combine(
+    return dateTime.combine(
       new date(if year == -1 then this.year else year,
                if month == -1 then this.month else month,
                if day == -1 then this.day else day),
@@ -1182,7 +1182,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* Return the date and time converted into the timezone in the argument */
   @unstable "tz is unstable; its type may change in the future"
-  proc datetime.astimezone(in tz: shared Timezone) {
+  proc dateTime.astimezone(in tz: shared Timezone) {
     if timezone == tz {
       return this;
     }
@@ -1191,30 +1191,30 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   /* Return the offset from UTC */
-  proc datetime.utcOffset() {
+  proc dateTime.utcOffset() {
     if timezone.borrow() == nil {
-      halt("utcOffset called on naive datetime");
+      halt("utcOffset called on naive dateTime");
     } else {
       return timezone!.utcOffset(this);
     }
   }
   /* Return the daylight saving time offset */
-  proc datetime.dst() {
+  proc dateTime.dst() {
     if timezone.borrow() == nil then
       halt("dst() called with nil timezone");
     return timezone!.dst(this);
   }
 
-  /* Return the name of the timezone for this `datetime` value */
-  proc datetime.tzname() {
+  /* Return the name of the timezone for this `dateTime` value */
+  proc dateTime.tzname() {
     if timezone.borrow() == nil then
       return "";
     return timezone!.tzname(this);
   }
 
   /* Return a filled record matching the C `struct tm` type for the given
-     `datetime` */
-  proc datetime.timetuple() {
+     `dateTime` */
+  proc dateTime.timetuple() {
     var timeStruct: tm;
     timeStruct.tm_sec = second: int(32);
     timeStruct.tm_min = minute: int(32);
@@ -1237,9 +1237,9 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   /* Return a filled record matching the C `struct tm` type for the given
-     `datetime` in UTC
+     `dateTime` in UTC
    */
-  proc datetime.utctimetuple() {
+  proc dateTime.utctimetuple() {
     if timezone.borrow() == nil {
       var ret = timetuple();
       ret.tm_isdst = 0;
@@ -1252,46 +1252,46 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
   }
 
-  /* Return the number of days since 1-1-0001 this `datetime` represents */
-  proc datetime.toOrdinal() {
+  /* Return the number of days since 1-1-0001 this `dateTime` represents */
+  proc dateTime.toOrdinal() {
     return getdate().toOrdinal();
   }
 
   /* Return the day of the week as a `dayOfWeek`.
      `Monday` == 0, `Sunday` == 6
    */
-  proc datetime.weekday() {
+  proc dateTime.weekday() {
     return getdate().weekday();
   }
 
   /* Return the day of the week as an `isoDayOfWeek`.
      `Monday` == 1, `Sunday` == 7
    */
-  proc datetime.isoWeekday() {
+  proc dateTime.isoWeekday() {
     return getdate().isoWeekday();
   }
 
   pragma "no doc"
   deprecated "'isoweekday' is deprecated, please use 'isoWeekday' instead"
-  proc datetime.isoweekday() {
+  proc dateTime.isoweekday() {
     return isoWeekday();
   }
 
   /* Return the ISO date as a tuple containing the ISO year, ISO week number,
      and ISO day of the week
    */
-  proc datetime.isoCalendar() {
+  proc dateTime.isoCalendar() {
     return getdate().isoCalendar();
   }
 
   pragma "no doc"
   deprecated "'isocalendar' is deprecated, please use 'isoCalendar' instead"
-  proc datetime.isocalendar() {
+  proc dateTime.isocalendar() {
     return getdate().isoCalendar();
   }
 
-  /* Return the `datetime` as a `string` in ISO format */
-  proc datetime.isoFormat(sep="T") {
+  /* Return the `dateTime` as a `string` in ISO format */
+  proc dateTime.isoFormat(sep="T") {
     proc zeroPad(nDigits: int, i: int) {
       var numStr = i: string;
       for i in 1..nDigits-numStr.size {
@@ -1324,15 +1324,15 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     return strftime(year + "-%m-%d" + sep + "%H:%M:%S" + micro + offset);
   }
 
-  /* Create a `datetime` as described by the `date_string` and
+  /* Create a `dateTime` as described by the `date_string` and
      `format` string.  Note that this routine currently only supports
      the format strings of C's strptime().
   */
-  proc type datetime.strptime(date_string: string, format: string) {
+  proc type dateTime.strptime(date_string: string, format: string) {
     extern proc strptime(buf: c_string, format: c_string, ref ts: tm);
     var timeStruct: tm;
     strptime(date_string.c_str(), format.c_str(), timeStruct);
-    return new datetime(timeStruct.tm_year + 1900,
+    return new dateTime(timeStruct.tm_year + 1900,
                         timeStruct.tm_mon + 1,
                         timeStruct.tm_mday,
                         timeStruct.tm_hour,
@@ -1340,8 +1340,8 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
                         timeStruct.tm_sec);
   }
 
-  /* Create a `string` from a `datetime` matching the `format` string */
-  proc datetime.strftime(fmt: string) {
+  /* Create a `string` from a `dateTime` matching the `format` string */
+  proc dateTime.strftime(fmt: string) {
     extern proc strftime(s: c_void_ptr, size: c_size_t, format: c_string, ref timeStruct: tm);
     const bufLen: c_size_t = 100;
     var buf: [1..bufLen] c_char;
@@ -1365,7 +1365,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     timeStruct.tm_mon = (month-1): int(32);    // 0 based
     timeStruct.tm_mday = day: int(32);
     timeStruct.tm_wday = (weekday(): int(32) + 1) % 7; // shift Sunday to 0
-    timeStruct.tm_yday = (this.replace(tz=nil) - new datetime(year, 1, 1)).days: int(32);
+    timeStruct.tm_yday = (this.replace(tz=nil) - new dateTime(year, 1, 1)).days: int(32);
 
     // Iterate over format specifiers in strftime(), replacing %f with microseconds
     iter strftok(const ref s: string)
@@ -1410,20 +1410,20 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     return str;
   }
 
-  /* Return a `string` from a `datetime` in the form:
+  /* Return a `string` from a `dateTime` in the form:
      Wed Dec  4 20:30:40 2002
   */
-  proc datetime.ctime() {
+  proc dateTime.ctime() {
     return this.strftime("%a %b %e %T %Y");
   }
 
-  /* Writes this `datetime` in ISO format: YYYY-MM-DDThh:mm:ss.sss */
-  proc datetime.writeThis(f) throws {
+  /* Writes this `dateTime` in ISO format: YYYY-MM-DDThh:mm:ss.sss */
+  proc dateTime.writeThis(f) throws {
     f.write(isoFormat());
   }
 
-  /* Reads this `datetime` from ISO format: YYYY-MM-DDThh:mm:ss.sss */
-  proc datetime.readThis(f) throws {
+  /* Reads this `dateTime` from ISO format: YYYY-MM-DDThh:mm:ss.sss */
+  proc dateTime.readThis(f) throws {
     const binary = f.binary(),
           arrayStyle = f.styleElement(QIO_STYLE_ELEMENT_ARRAY),
           isjson = arrayStyle == QIO_ARRAY_FORMAT_JSON && !binary;
@@ -1440,12 +1440,12 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
 
-  // TODO: Add a datetime.timestamp() method
+  // TODO: Add a dateTime.timestamp() method
 
-  /* Operators on datetime values */
+  /* Operators on dateTime values */
 
   pragma "no doc"
-  operator datetime.+(td: timedelta, dt: datetime) {
+  operator dateTime.+(td: timedelta, dt: dateTime) {
     var newmicro = dt.microsecond + td.microseconds;
     var newsec = dt.second + td.seconds;
     var newmin = dt.minute;
@@ -1464,7 +1464,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     var adddays = td.days + newhour / 24;
     newhour %= 24;
 
-    return datetime.combine(date.fromOrdinal(dt.getdate().toOrdinal()+adddays),
+    return dateTime.combine(date.fromOrdinal(dt.getdate().toOrdinal()+adddays),
                             new time(hour=newhour, minute=newmin,
                                      second=newsec, microsecond=newmicro,
                                      tz=dt.timezone));
@@ -1472,12 +1472,12 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   pragma "no doc"
-  operator datetime.+(dt: datetime, td: timedelta) {
+  operator dateTime.+(dt: dateTime, td: timedelta) {
     return td + dt;
   }
 
   pragma "no doc"
-  operator datetime.-(dt: datetime, td: timedelta) {
+  operator dateTime.-(dt: dateTime, td: timedelta) {
     var deltasec  = td.seconds % 60;
     var deltamin  = (td.seconds / 60) % 60;
     var deltahour = td.seconds / (60*60);
@@ -1505,17 +1505,17 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       subDays += 1;
       newhour += 24;
     }
-    return datetime.combine(date.fromOrdinal(dt.getdate().toOrdinal()-subDays),
+    return dateTime.combine(date.fromOrdinal(dt.getdate().toOrdinal()-subDays),
                             new time(hour=newhour, minute=newmin,
                                      second=newsec, microsecond=newmicro,
                                      tz=dt.timezone));
   }
 
   pragma "no doc"
-  operator datetime.-(dt1: datetime, dt2: datetime): timedelta {
+  operator dateTime.-(dt1: dateTime, dt2: dateTime): timedelta {
     if (dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil) ||
        (dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil) {
-      halt("both datetimes must both be either naive or aware");
+      halt("both dateTimes must both be either naive or aware");
     }
     if dt1.timezone == dt2.timezone {
       const newmicro = dt1.microsecond - dt2.microsecond,
@@ -1533,10 +1533,10 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   pragma "no doc"
-  operator datetime.==(dt1: datetime, dt2: datetime): bool {
+  operator dateTime.==(dt1: dateTime, dt2: dateTime): bool {
     if dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil ||
        dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil {
-      halt("Cannot compare naive datetime to aware datetime");
+      halt("Cannot compare naive dateTime to aware dateTime");
     } else if dt1.timezone == dt2.timezone {
       // just ignore timezone
       var d1: date = dt1.replace(tz=nil).getdate(),
@@ -1555,15 +1555,15 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   pragma "no doc"
-  operator datetime.!=(dt1: datetime, dt2: datetime) {
+  operator dateTime.!=(dt1: dateTime, dt2: dateTime) {
     return !(dt1 == dt2);
   }
 
   pragma "no doc"
-  operator datetime.<(dt1: datetime, dt2: datetime): bool {
+  operator dateTime.<(dt1: dateTime, dt2: dateTime): bool {
     if (dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil) ||
         (dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil) {
-      halt("both datetimes must both be either naive or aware");
+      halt("both dateTimes must both be either naive or aware");
     } else if dt1.timezone == dt2.timezone {
       const date1 = dt1.getdate(),
             date2 = dt2.getdate();
@@ -1577,10 +1577,10 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   pragma "no doc"
-  operator datetime.<=(dt1: datetime, dt2: datetime): bool {
+  operator dateTime.<=(dt1: dateTime, dt2: dateTime): bool {
     if (dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil) ||
         (dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil) {
-      halt("both datetimes must both be either naive or aware");
+      halt("both dateTimes must both be either naive or aware");
     } else if dt1.timezone == dt2.timezone {
       const date1 = dt1.getdate(),
             date2 = dt2.getdate();
@@ -1594,10 +1594,10 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   pragma "no doc"
-  operator datetime.>(dt1: datetime, dt2: datetime): bool {
+  operator dateTime.>(dt1: dateTime, dt2: dateTime): bool {
     if (dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil) ||
         (dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil) {
-      halt("both datetimes must both be either naive or aware");
+      halt("both dateTimes must both be either naive or aware");
     } else if dt1.timezone == dt2.timezone {
       const date1 = dt1.getdate(),
             date2 = dt2.getdate();
@@ -1611,10 +1611,10 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   pragma "no doc"
-  operator datetime.>=(dt1: datetime, dt2: datetime): bool {
+  operator dateTime.>=(dt1: dateTime, dt2: dateTime): bool {
     if (dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil) ||
         (dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil) {
-      halt("both datetimes must both be either naive or aware");
+      halt("both dateTimes must both be either naive or aware");
     } else if dt1.timezone == dt2.timezone {
       const date1 = dt1.getdate(),
             date2 = dt2.getdate();
@@ -1872,27 +1872,27 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
      derived from it. */
   class Timezone {
     /* The offset from UTC this class represents */
-    proc utcOffset(dt: datetime): timedelta {
+    proc utcOffset(dt: dateTime): timedelta {
       HaltWrappers.pureVirtualMethodHalt();
       return new timedelta();
     }
 
     /* The `timedelta` for daylight saving time */
-    proc dst(dt: datetime): timedelta {
+    proc dst(dt: dateTime): timedelta {
       HaltWrappers.pureVirtualMethodHalt();
       return new timedelta();
     }
 
     /* The name of this time zone */
-    proc tzname(dt: datetime): string {
+    proc tzname(dt: dateTime): string {
       HaltWrappers.pureVirtualMethodHalt();
       return "";
     }
 
     /* Convert a `time` in UTC to this time zone */
-    proc fromUtc(dt: datetime): datetime {
+    proc fromUtc(dt: dateTime): dateTime {
       HaltWrappers.pureVirtualMethodHalt();
-      return new datetime(0,0,0);
+      return new dateTime(0,0,0);
     }
 
   }

--- a/src/compat/e-130/ArkoudaTimeCompat.chpl
+++ b/src/compat/e-130/ArkoudaTimeCompat.chpl
@@ -347,7 +347,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   /* The date that is `timestamp` seconds from the epoch */
-  proc type date.fromTimestamp(timestamp) {
+  proc type date.createFromTimestamp(timestamp) {
     const sec = timestamp: int;
     const us = ((timestamp-sec) * 1000000 + 0.5): int;
     const td = new timedelta(seconds=sec, microseconds=us);
@@ -1124,13 +1124,13 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   /* The `dateTime` that is `timestamp` seconds from the epoch */
-  proc type dateTime.fromTimestamp(timestamp: real) {
-    return dateTime.fromTimestamp(timestamp, nil);
+  proc type dateTime.createFromTimestamp(timestamp: real) {
+    return dateTime.createFromTimestamp(timestamp, nil);
   }
 
   /* The `dateTime` that is `timestamp` seconds from the epoch */
   @unstable("tz is unstable; its type may change in the future")
-  proc type dateTime.fromTimestamp(timestamp: real,
+  proc type dateTime.createFromTimestamp(timestamp: real,
                                    in tz: shared Timezone?) {
     if tz.borrow() == nil {
       var t = (timestamp: int, ((timestamp - timestamp: int)*1000000): int);

--- a/src/compat/e-130/ArkoudaTimeCompat.chpl
+++ b/src/compat/e-130/ArkoudaTimeCompat.chpl
@@ -116,7 +116,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   private const DAYS_BEFORE_MONTH = init_days_before_month();
 
   /* The Unix Epoch date and time */
-  const unixEpoch = new datetime(1970, 1, 1);
+  const unixEpoch = new dateTime(1970, 1, 1);
 
   private const DI400Y = daysBeforeYear(401);
   private const DI100Y = daysBeforeYear(101);
@@ -513,7 +513,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     f.write(isoFormat());
   }
 
-  // Exists to support some common functionality for `datetime.readThis`
+  // Exists to support some common functionality for `dateTime.readThis`
   pragma "no doc"
   proc date._readCore(f) throws {
     const dash = "-";
@@ -760,7 +760,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     if timezone.borrow() == nil {
       return new timedelta();
     } else {
-      return timezone!.utcOffset(datetime.now());
+      return timezone!.utcOffset(dateTime.now());
     }
   }
 
@@ -769,7 +769,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     if timezone.borrow() == nil {
       return new timedelta();
     } else {
-      return timezone!.dst(datetime.now());
+      return timezone!.dst(dateTime.now());
     }
   }
 
@@ -778,7 +778,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     if timezone.borrow() == nil then
       return "";
     else
-      return timezone!.tzname(new datetime(1,1,1));
+      return timezone!.tzname(new dateTime(1,1,1));
   }
 
   /* Return a `string` matching the `format` argument for this `time` */
@@ -823,7 +823,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     f.write(isoFormat());
   }
 
-  // Exists to support some common functionality for `datetime.readThis`
+  // Exists to support some common functionality for `dateTime.readThis`
   pragma "no doc"
   proc time._readCore(f) throws {
     const colon = ":";
@@ -866,8 +866,8 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   pragma "no doc"
   operator time.==(t1: time, t2: time): bool {
-    var dt1 = datetime.combine(d=new date(2000, 1, 1), t=t1);
-    var dt2 = datetime.combine(d=new date(2000, 1, 1), t=t2);
+    var dt1 = dateTime.combine(d=new date(2000, 1, 1), t=t1);
+    var dt2 = dateTime.combine(d=new date(2000, 1, 1), t=t2);
     return dt1 == dt2;
   }
 
@@ -880,7 +880,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   operator time.<(t1: time, t2: time): bool {
     if (t1.timezone.borrow() != nil && t2.timezone.borrow() == nil) ||
         (t1.timezone.borrow() == nil && t2.timezone.borrow() != nil) {
-      halt("both datetimes must both be either naive or aware");
+      halt("both dateTimes must both be either naive or aware");
     } else if t1.timezone == t2.timezone {
       const sec1 = t1.hour*3600 + t1.minute*60 + t1.second;
       const usec1 = t1.microsecond;
@@ -893,21 +893,21 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       else
         return false;
     } else {
-      // As far as I can tell, python's datetime.time() comparisons don't
+      // As far as I can tell, python's dateTime.time() comparisons don't
       // pay attention to the timezones.
       // >>> central = pytz.timezone("US/Central")
       // >>> pacific = pytz.timezone("US/Pacific")
-      // >>> datetime.time(12,3,4,5,tz=central) >
-      //     datetime.time(12,3,4,5,tz=pacific)
+      // >>> dateTime.time(12,3,4,5,tz=central) >
+      //     dateTime.time(12,3,4,5,tz=pacific)
       // False
-      // >>> datetime.time(12,3,4,6,tz=central) >
-      //     datetime.time(12,3,4,5,tz=pacific)
+      // >>> dateTime.time(12,3,4,6,tz=central) >
+      //     dateTime.time(12,3,4,5,tz=pacific)
       // True
       //
       // This compares the time on a specific date, and factors in the
       // time zones.
-      const dt1 = datetime.combine(new date(1900, 1, 1), t1);
-      const dt2 = datetime.combine(new date(1900, 1, 1), t2);
+      const dt1 = dateTime.combine(new date(1900, 1, 1), t1);
+      const dt2 = dateTime.combine(new date(1900, 1, 1), t2);
       return dt1 < dt2;
       //return (t1.replace(tz=nil) - t1.utcOffset()) <
       //       (t2.replace(tz=nil) - t2.utcOffset());
@@ -918,7 +918,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   operator time.<=(t1: time, t2: time): bool {
     if (t1.timezone.borrow() != nil && t2.timezone.borrow() == nil) ||
         (t1.timezone.borrow() == nil && t2.timezone.borrow() != nil) {
-      halt("both datetimes must both be either naive or aware");
+      halt("both dateTimes must both be either naive or aware");
     } else if t1.timezone == t2.timezone {
       const sec1 = t1.hour*3600 + t1.minute*60 + t1.second;
       const usec1 = t1.microsecond;
@@ -931,8 +931,8 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       else
         return false;
     } else {
-      const dt1 = datetime.combine(new date(1900, 1, 1), t1);
-      const dt2 = datetime.combine(new date(1900, 1, 1), t2);
+      const dt1 = dateTime.combine(new date(1900, 1, 1), t1);
+      const dt2 = dateTime.combine(new date(1900, 1, 1), t2);
       return dt1 <= dt2;
     }
   }
@@ -941,7 +941,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   operator time.>(t1: time, t2: time): bool {
     if (t1.timezone.borrow() != nil && t2.timezone.borrow() == nil) ||
         (t1.timezone.borrow() == nil && t2.timezone.borrow() != nil) {
-      halt("both datetimes must both be either naive or aware");
+      halt("both dateTimes must both be either naive or aware");
     } else if t1.timezone == t2.timezone {
       const sec1 = t1.hour*3600 + t1.minute*60 + t1.second;
       const usec1 = t1.microsecond;
@@ -954,8 +954,8 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       else
         return false;
     } else {
-      const dt1 = datetime.combine(new date(1900, 1, 1), t1);
-      const dt2 = datetime.combine(new date(1900, 1, 1), t2);
+      const dt1 = dateTime.combine(new date(1900, 1, 1), t1);
+      const dt2 = dateTime.combine(new date(1900, 1, 1), t2);
       return dt1 > dt2;
     }
   }
@@ -964,7 +964,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   operator time.>=(t1: time, t2: time): bool {
     if (t1.timezone.borrow() != nil && t2.timezone.borrow() == nil) ||
         (t1.timezone.borrow() == nil && t2.timezone.borrow() != nil) {
-      halt("both datetimes must both be either naive or aware");
+      halt("both dateTimes must both be either naive or aware");
     } else if t1.timezone == t2.timezone {
       const sec1 = t1.hour*3600 + t1.minute*60 + t1.second;
       const usec1 = t1.microsecond;
@@ -977,14 +977,14 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       else
         return false;
     } else {
-      const dt1 = datetime.combine(new date(1900, 1, 1), t1);
-      const dt2 = datetime.combine(new date(1900, 1, 1), t2);
+      const dt1 = dateTime.combine(new date(1900, 1, 1), t1);
+      const dt2 = dateTime.combine(new date(1900, 1, 1), t2);
       return dt1 >= dt2;
     }
   }
 
   /* A record representing a combined `date` and `time` */
-  record datetime {
+  record dateTime {
     pragma "no doc"
     var chpl_date: date;
     pragma "no doc"
@@ -1000,47 +1000,47 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       return this.combine(date.max, time.max);
     }
 
-    /* The minimum non-zero difference between two datetimes */
+    /* The minimum non-zero difference between two dateTimes */
     proc type resolution {
       return new timedelta(microseconds=1);
     }
 
-    /* The year represented by this `datetime` value */
+    /* The year represented by this `dateTime` value */
     proc year {
       return chpl_date.year;
     }
 
-    /* The month represented by this `datetime` value */
+    /* The month represented by this `dateTime` value */
     proc month {
       return chpl_date.month;
     }
 
-    /* The day represented by this `datetime` value */
+    /* The day represented by this `dateTime` value */
     proc day {
       return chpl_date.day;
     }
 
-    /* The hour represented by this `datetime` value */
+    /* The hour represented by this `dateTime` value */
     proc hour {
       return chpl_time.hour;
     }
 
-    /* The minute represented by this `datetime` value */
+    /* The minute represented by this `dateTime` value */
     proc minute {
       return chpl_time.minute;
     }
 
-    /* The second represented by this `datetime` value */
+    /* The second represented by this `dateTime` value */
     proc second {
       return chpl_time.second;
     }
 
-    /* The microsecond represented by this `datetime` value */
+    /* The microsecond represented by this `dateTime` value */
     proc microsecond {
       return chpl_time.microsecond;
     }
 
-    /* The timezone represented by this `datetime` value */
+    /* The timezone represented by this `dateTime` value */
     proc timezone {
       return chpl_time.timezone;
     }
@@ -1052,56 +1052,56 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
   }
 
-  /* initializers/factories for datetime values */
+  /* initializers/factories for dateTime values */
 
   pragma "no doc"
-  proc datetime.init() {
+  proc dateTime.init() {
   }
 
-  /* Initialize a new `datetime` value from the given `year`, `month`, `day`,
+  /* Initialize a new `dateTime` value from the given `year`, `month`, `day`,
      `hour`, `minute`, `second`, `microsecond` and timezone.  The `year`,
      `month`, and `day` arguments are required, the rest are optional.
    */
   @unstable("tz is unstable; its type may change in the future")
-  proc datetime.init(year:int, month:int, day:int,
+  proc dateTime.init(year:int, month:int, day:int,
                      hour:int=0, minute:int=0, second:int=0, microsecond:int=0,
                      in tz) {
     chpl_date = new date(year, month, day);
     chpl_time = new time(hour, minute, second, microsecond, tz);
   }
 
-  /* Initialize a new `datetime` value from the given `year`, `month`, `day`,
+  /* Initialize a new `dateTime` value from the given `year`, `month`, `day`,
      `hour`, `minute`, `second`, `microsecond` and timezone.  The `year`,
      `month`, and `day` arguments are required, the rest are optional.
    */
-  proc datetime.init(year:int, month:int, day:int,
+  proc dateTime.init(year:int, month:int, day:int,
                      hour:int=0, minute:int=0, second:int=0, microsecond:int=0) {
     chpl_date = new date(year, month, day);
     chpl_time = new time(hour, minute, second, microsecond);
   }
 
-  /* Initialize a new `datetime` value from the given `date` and `time` */
-  proc datetime.init(d: date, t: time) {
+  /* Initialize a new `dateTime` value from the given `date` and `time` */
+  proc dateTime.init(d: date, t: time) {
     chpl_date = d;
     chpl_time = t;
   }
 
-  /* Return a `datetime` value representing the current time and date */
-  proc type datetime.now() {
+  /* Return a `dateTime` value representing the current time and date */
+  proc type dateTime.now() {
     const timeSinceEpoch = getTimeOfDay();
     const lt = getLocalTime(timeSinceEpoch);
-    return new datetime(year=lt.tm_year+1900, month=lt.tm_mon+1,
+    return new dateTime(year=lt.tm_year+1900, month=lt.tm_mon+1,
                         day=lt.tm_mday,       hour=lt.tm_hour,
                         minute=lt.tm_min,     second=lt.tm_sec,
                         microsecond=timeSinceEpoch(1));
   }
 
-  /* Return a `datetime` value representing the current time and date */
-  proc type datetime.now(in tz: shared Timezone?) {
+  /* Return a `dateTime` value representing the current time and date */
+  proc type dateTime.now(in tz: shared Timezone?) {
     if tz.borrow() == nil {
       const timeSinceEpoch = getTimeOfDay();
       const lt = getLocalTime(timeSinceEpoch);
-      return new datetime(year=lt.tm_year+1900, month=lt.tm_mon+1,
+      return new dateTime(year=lt.tm_year+1900, month=lt.tm_mon+1,
                           day=lt.tm_mday,       hour=lt.tm_hour,
                           minute=lt.tm_min,     second=lt.tm_sec,
                           microsecond=timeSinceEpoch(1));
@@ -1115,61 +1115,61 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
   }
 
-  /* Return a `datetime` value representing the current time and date in UTC */
-  proc type datetime.utcNow() {
+  /* Return a `dateTime` value representing the current time and date in UTC */
+  proc type dateTime.utcNow() {
     const timeSinceEpoch = getTimeOfDay();
     const td = new timedelta(seconds=timeSinceEpoch(0),
                              microseconds=timeSinceEpoch(1));
     return unixEpoch + td;
   }
 
-  /* The `datetime` that is `timestamp` seconds from the epoch */
-  proc type datetime.fromTimestamp(timestamp: real) {
-    return datetime.fromTimestamp(timestamp, nil);
+  /* The `dateTime` that is `timestamp` seconds from the epoch */
+  proc type dateTime.fromTimestamp(timestamp: real) {
+    return dateTime.fromTimestamp(timestamp, nil);
   }
 
-  /* The `datetime` that is `timestamp` seconds from the epoch */
+  /* The `dateTime` that is `timestamp` seconds from the epoch */
   @unstable("tz is unstable; its type may change in the future")
-  proc type datetime.fromTimestamp(timestamp: real,
+  proc type dateTime.fromTimestamp(timestamp: real,
                                    in tz: shared Timezone?) {
     if tz.borrow() == nil {
       var t = (timestamp: int, ((timestamp - timestamp: int)*1000000): int);
       const lt = getLocalTime(t);
-      return new datetime(year=lt.tm_year+1900, month=lt.tm_mon+1,
+      return new dateTime(year=lt.tm_year+1900, month=lt.tm_mon+1,
                           day=lt.tm_mday,       hour=lt.tm_hour,
                           minute=lt.tm_min,     second=lt.tm_sec,
                           microsecond=t(1));
     } else {
-      var dt = datetime.utcFromTimestamp(timestamp);
+      var dt = dateTime.utcFromTimestamp(timestamp);
       return (dt + tz!.utcOffset(dt)).replace(tz=tz);
     }
   }
 
-  /* The `datetime` that is `timestamp` seconds from the epoch in UTC */
-  proc type datetime.utcFromTimestamp(timestamp) {
+  /* The `dateTime` that is `timestamp` seconds from the epoch in UTC */
+  proc type dateTime.utcFromTimestamp(timestamp) {
     return unixEpoch + new timedelta(seconds=timestamp: int, microseconds=((timestamp-timestamp: int)*1000000): int);
   }
 
-  /* The `datetime` that is `ordinal` days from 1-1-0001 */
-  proc type datetime.fromOrdinal(ordinal) {
-    return datetime.combine(date.fromOrdinal(ordinal), new time());
+  /* The `dateTime` that is `ordinal` days from 1-1-0001 */
+  proc type dateTime.fromOrdinal(ordinal) {
+    return dateTime.combine(date.fromOrdinal(ordinal), new time());
   }
 
-  /* Form a `datetime` value from a given `date` and `time` */
-  proc type datetime.combine(d: date, t: time) {
-    return new datetime(d.year, d.month, d.day,
+  /* Form a `dateTime` value from a given `date` and `time` */
+  proc type dateTime.combine(d: date, t: time) {
+    return new dateTime(d.year, d.month, d.day,
                         t.hour, t.minute, t.second, t.microsecond, t.timezone);
   }
 
-  /* Methods on datetime values */
+  /* Methods on dateTime values */
 
-  /* Get the `date` portion of the `datetime` value */
-  proc datetime.getdate() {
+  /* Get the `date` portion of the `dateTime` value */
+  proc dateTime.getdate() {
     return chpl_date;
   }
 
-  /* Get the `time` portion of the `datetime` value, with `tz` = nil */
-  proc datetime.gettime() {
+  /* Get the `time` portion of the `dateTime` value, with `tz` = nil */
+  proc dateTime.gettime() {
     if chpl_time.timezone.borrow() == nil then
       return chpl_time;
     else
@@ -1177,21 +1177,21 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
                       second=second, microsecond=microsecond);
   }
 
-  /* Get the `time` portion of the `datetime` value including the
+  /* Get the `time` portion of the `dateTime` value including the
      `tz` field
    */
-  proc datetime.timetz() {
+  proc dateTime.timetz() {
     return chpl_time;
   }
 
   /* Replace the `year`, `month`, `day`, `hour`, `minute`, `second`,
-     `microsecond`, or `tz` to form a new `datetime` object. All
+     `microsecond`, or `tz` to form a new `dateTime` object. All
      arguments are optional.
    */
-  proc datetime.replace(year=-1, month=-1, day=-1,
+  proc dateTime.replace(year=-1, month=-1, day=-1,
                         hour=-1, minute=-1, second=-1, microsecond=-1,
                         in tz=this.timezone) {
-    return datetime.combine(
+    return dateTime.combine(
       new date(if year == -1 then this.year else year,
                if month == -1 then this.month else month,
                if day == -1 then this.day else day),
@@ -1204,7 +1204,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* Return the date and time converted into the timezone in the argument */
   @unstable("tz is unstable; its type may change in the future")
-  proc datetime.astimezone(in tz: shared Timezone) {
+  proc dateTime.astimezone(in tz: shared Timezone) {
     if timezone == tz {
       return this;
     }
@@ -1213,31 +1213,31 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   /* Return the offset from UTC */
-  proc datetime.utcOffset() {
+  proc dateTime.utcOffset() {
     if timezone.borrow() == nil {
-      halt("utcOffset called on naive datetime");
+      halt("utcOffset called on naive dateTime");
     } else {
       return timezone!.utcOffset(this);
     }
   }
   /* Return the daylight saving time offset */
-  proc datetime.dst() {
+  proc dateTime.dst() {
     if timezone.borrow() == nil then
       halt("dst() called with nil timezone");
     return timezone!.dst(this);
   }
 
-  /* Return the name of the timezone for this `datetime` value */
-  proc datetime.tzname() {
+  /* Return the name of the timezone for this `dateTime` value */
+  proc dateTime.tzname() {
     if timezone.borrow() == nil then
       return "";
     return timezone!.tzname(this);
   }
 
   /* Return a filled record matching the C `struct tm` type for the given
-     `datetime` */
-  @unstable("'datetime.timetuple' is unstable")
-  proc datetime.timetuple() {
+     `dateTime` */
+  @unstable("'dateTime.timetuple' is unstable")
+  proc dateTime.timetuple() {
     var timeStruct: tm;
     timeStruct.tm_sec = second: int(32);
     timeStruct.tm_min = minute: int(32);
@@ -1260,10 +1260,10 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   /* Return a filled record matching the C `struct tm` type for the given
-     `datetime` in UTC
+     `dateTime` in UTC
    */
-  @unstable("'datetime.utctimetuple' is unstable")
-  proc datetime.utctimetuple() {
+  @unstable("'dateTime.utctimetuple' is unstable")
+  proc dateTime.utctimetuple() {
     if timezone.borrow() == nil {
       var ret = timetuple();
       ret.tm_isdst = 0;
@@ -1276,46 +1276,46 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
   }
 
-  /* Return the number of days since 1-1-0001 this `datetime` represents */
-  proc datetime.toOrdinal() {
+  /* Return the number of days since 1-1-0001 this `dateTime` represents */
+  proc dateTime.toOrdinal() {
     return getdate().toOrdinal();
   }
 
   /* Return the day of the week as a `dayOfWeek`.
      `Monday` == 0, `Sunday` == 6
    */
-  proc datetime.weekday() {
+  proc dateTime.weekday() {
     return getdate().weekday();
   }
 
   /* Return the day of the week as an `isoDayOfWeek`.
      `Monday` == 1, `Sunday` == 7
    */
-  proc datetime.isoWeekday() {
+  proc dateTime.isoWeekday() {
     return getdate().isoWeekday();
   }
 
   pragma "no doc"
   @deprecated(notes="'isoweekday' is deprecated, please use 'isoWeekday' instead")
-  proc datetime.isoweekday() {
+  proc dateTime.isoweekday() {
     return isoWeekday();
   }
 
   /* Return the ISO date as a tuple containing the ISO year, ISO week number,
      and ISO day of the week
    */
-  proc datetime.isoCalendar() {
+  proc dateTime.isoCalendar() {
     return getdate().isoCalendar();
   }
 
   pragma "no doc"
   @deprecated(notes="'isocalendar' is deprecated, please use 'isoCalendar' instead")
-  proc datetime.isocalendar() {
+  proc dateTime.isocalendar() {
     return getdate().isoCalendar();
   }
 
-  /* Return the `datetime` as a `string` in ISO format */
-  proc datetime.isoFormat(sep="T") {
+  /* Return the `dateTime` as a `string` in ISO format */
+  proc dateTime.isoFormat(sep="T") {
     proc zeroPad(nDigits: int, i: int) {
       var numStr = i: string;
       for i in 1..nDigits-numStr.size {
@@ -1348,16 +1348,16 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     return strftime(year + "-%m-%d" + sep + "%H:%M:%S" + micro + offset);
   }
 
-  /* Create a `datetime` as described by the `date_string` and
+  /* Create a `dateTime` as described by the `date_string` and
      `format` string.  Note that this routine currently only supports
      the format strings of C's strptime().
   */
-  @unstable("'datetime.strptime' is unstable")
-  proc type datetime.strptime(date_string: string, format: string) {
+  @unstable("'dateTime.strptime' is unstable")
+  proc type dateTime.strptime(date_string: string, format: string) {
     extern proc strptime(buf: c_string, format: c_string, ref ts: tm);
     var timeStruct: tm;
     strptime(date_string.c_str(), format.c_str(), timeStruct);
-    return new datetime(timeStruct.tm_year + 1900,
+    return new dateTime(timeStruct.tm_year + 1900,
                         timeStruct.tm_mon + 1,
                         timeStruct.tm_mday,
                         timeStruct.tm_hour,
@@ -1365,9 +1365,9 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
                         timeStruct.tm_sec);
   }
 
-  /* Create a `string` from a `datetime` matching the `format` string */
-  @unstable("'datetime.strftime' is unstable")
-  proc datetime.strftime(fmt: string) {
+  /* Create a `string` from a `dateTime` matching the `format` string */
+  @unstable("'dateTime.strftime' is unstable")
+  proc dateTime.strftime(fmt: string) {
     extern proc strftime(s: c_void_ptr, size: c_size_t, format: c_string, ref timeStruct: tm);
     const bufLen: c_size_t = 100;
     var buf: [1..bufLen] c_char;
@@ -1391,7 +1391,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     timeStruct.tm_mon = (month-1): int(32);    // 0 based
     timeStruct.tm_mday = day: int(32);
     timeStruct.tm_wday = (weekday(): int(32) + 1) % 7; // shift Sunday to 0
-    timeStruct.tm_yday = (this.replace(tz=nil) - new datetime(year, 1, 1)).days: int(32);
+    timeStruct.tm_yday = (this.replace(tz=nil) - new dateTime(year, 1, 1)).days: int(32);
 
     // Iterate over format specifiers in strftime(), replacing %f with microseconds
     iter strftok(const ref s: string)
@@ -1436,21 +1436,21 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     return str;
   }
 
-  /* Return a `string` from a `datetime` in the form:
+  /* Return a `string` from a `dateTime` in the form:
      Wed Dec  4 20:30:40 2002
   */
-  @unstable("'datetime.ctime' is unstable")
-  proc datetime.ctime() {
+  @unstable("'dateTime.ctime' is unstable")
+  proc dateTime.ctime() {
     return this.strftime("%a %b %e %T %Y");
   }
 
-  /* Writes this `datetime` in ISO format: YYYY-MM-DDThh:mm:ss.sss */
-  proc datetime.writeThis(f) throws {
+  /* Writes this `dateTime` in ISO format: YYYY-MM-DDThh:mm:ss.sss */
+  proc dateTime.writeThis(f) throws {
     f.write(isoFormat());
   }
 
-  /* Reads this `datetime` from ISO format: YYYY-MM-DDThh:mm:ss.sss */
-  proc datetime.readThis(f) throws {
+  /* Reads this `dateTime` from ISO format: YYYY-MM-DDThh:mm:ss.sss */
+  proc dateTime.readThis(f) throws {
     const binary = f.binary(),
           arrayStyle = f.styleElement(QIO_STYLE_ELEMENT_ARRAY),
           isjson = arrayStyle == QIO_ARRAY_FORMAT_JSON && !binary;
@@ -1470,18 +1470,18 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   // TODO: need to get this to work with the Json formatter
   //
   pragma "no doc"
-  proc datetime.init(f: fileReader) {
+  proc dateTime.init(f: fileReader) {
     this.init();
     readThis(f);
   }
 
 
-  // TODO: Add a datetime.timestamp() method
+  // TODO: Add a dateTime.timestamp() method
 
-  /* Operators on datetime values */
+  /* Operators on dateTime values */
 
   pragma "no doc"
-  operator datetime.+(td: timedelta, dt: datetime) {
+  operator dateTime.+(td: timedelta, dt: dateTime) {
     var newmicro = dt.microsecond + td.microseconds;
     var newsec = dt.second + td.seconds;
     var newmin = dt.minute;
@@ -1500,7 +1500,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     var adddays = td.days + newhour / 24;
     newhour %= 24;
 
-    return datetime.combine(date.fromOrdinal(dt.getdate().toOrdinal()+adddays),
+    return dateTime.combine(date.fromOrdinal(dt.getdate().toOrdinal()+adddays),
                             new time(hour=newhour, minute=newmin,
                                      second=newsec, microsecond=newmicro,
                                      tz=dt.timezone));
@@ -1508,12 +1508,12 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   pragma "no doc"
-  operator datetime.+(dt: datetime, td: timedelta) {
+  operator dateTime.+(dt: dateTime, td: timedelta) {
     return td + dt;
   }
 
   pragma "no doc"
-  operator datetime.-(dt: datetime, td: timedelta) {
+  operator dateTime.-(dt: dateTime, td: timedelta) {
     var deltasec  = td.seconds % 60;
     var deltamin  = (td.seconds / 60) % 60;
     var deltahour = td.seconds / (60*60);
@@ -1541,17 +1541,17 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       subDays += 1;
       newhour += 24;
     }
-    return datetime.combine(date.fromOrdinal(dt.getdate().toOrdinal()-subDays),
+    return dateTime.combine(date.fromOrdinal(dt.getdate().toOrdinal()-subDays),
                             new time(hour=newhour, minute=newmin,
                                      second=newsec, microsecond=newmicro,
                                      tz=dt.timezone));
   }
 
   pragma "no doc"
-  operator datetime.-(dt1: datetime, dt2: datetime): timedelta {
+  operator dateTime.-(dt1: dateTime, dt2: dateTime): timedelta {
     if (dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil) ||
        (dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil) {
-      halt("both datetimes must both be either naive or aware");
+      halt("both dateTimes must both be either naive or aware");
     }
     if dt1.timezone == dt2.timezone {
       const newmicro = dt1.microsecond - dt2.microsecond,
@@ -1569,10 +1569,10 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   pragma "no doc"
-  operator datetime.==(dt1: datetime, dt2: datetime): bool {
+  operator dateTime.==(dt1: dateTime, dt2: dateTime): bool {
     if dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil ||
        dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil {
-      halt("Cannot compare naive datetime to aware datetime");
+      halt("Cannot compare naive dateTime to aware dateTime");
     } else if dt1.timezone == dt2.timezone {
       // just ignore timezone
       var d1: date = dt1.replace(tz=nil).getdate(),
@@ -1591,15 +1591,15 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   pragma "no doc"
-  operator datetime.!=(dt1: datetime, dt2: datetime) {
+  operator dateTime.!=(dt1: dateTime, dt2: dateTime) {
     return !(dt1 == dt2);
   }
 
   pragma "no doc"
-  operator datetime.<(dt1: datetime, dt2: datetime): bool {
+  operator dateTime.<(dt1: dateTime, dt2: dateTime): bool {
     if (dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil) ||
         (dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil) {
-      halt("both datetimes must both be either naive or aware");
+      halt("both dateTimes must both be either naive or aware");
     } else if dt1.timezone == dt2.timezone {
       const date1 = dt1.getdate(),
             date2 = dt2.getdate();
@@ -1613,10 +1613,10 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   pragma "no doc"
-  operator datetime.<=(dt1: datetime, dt2: datetime): bool {
+  operator dateTime.<=(dt1: dateTime, dt2: dateTime): bool {
     if (dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil) ||
         (dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil) {
-      halt("both datetimes must both be either naive or aware");
+      halt("both dateTimes must both be either naive or aware");
     } else if dt1.timezone == dt2.timezone {
       const date1 = dt1.getdate(),
             date2 = dt2.getdate();
@@ -1630,10 +1630,10 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   pragma "no doc"
-  operator datetime.>(dt1: datetime, dt2: datetime): bool {
+  operator dateTime.>(dt1: dateTime, dt2: dateTime): bool {
     if (dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil) ||
         (dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil) {
-      halt("both datetimes must both be either naive or aware");
+      halt("both dateTimes must both be either naive or aware");
     } else if dt1.timezone == dt2.timezone {
       const date1 = dt1.getdate(),
             date2 = dt2.getdate();
@@ -1647,10 +1647,10 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   pragma "no doc"
-  operator datetime.>=(dt1: datetime, dt2: datetime): bool {
+  operator dateTime.>=(dt1: dateTime, dt2: dateTime): bool {
     if (dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil) ||
         (dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil) {
-      halt("both datetimes must both be either naive or aware");
+      halt("both dateTimes must both be either naive or aware");
     } else if dt1.timezone == dt2.timezone {
       const date1 = dt1.getdate(),
             date2 = dt2.getdate();
@@ -1908,27 +1908,27 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
      derived from it. */
   class Timezone {
     /* The offset from UTC this class represents */
-    proc utcOffset(dt: datetime): timedelta {
+    proc utcOffset(dt: dateTime): timedelta {
       HaltWrappers.pureVirtualMethodHalt();
       return new timedelta();
     }
 
     /* The `timedelta` for daylight saving time */
-    proc dst(dt: datetime): timedelta {
+    proc dst(dt: dateTime): timedelta {
       HaltWrappers.pureVirtualMethodHalt();
       return new timedelta();
     }
 
     /* The name of this time zone */
-    proc tzname(dt: datetime): string {
+    proc tzname(dt: dateTime): string {
       HaltWrappers.pureVirtualMethodHalt();
       return "";
     }
 
     /* Convert a `time` in UTC to this time zone */
-    proc fromUtc(dt: datetime): datetime {
+    proc fromUtc(dt: dateTime): dateTime {
       HaltWrappers.pureVirtualMethodHalt();
-      return new datetime(0,0,0);
+      return new dateTime(0,0,0);
     }
 
   }


### PR DESCRIPTION
Updates the following deprecations:

- `date.fromTimestamp` deprecated in favor of `date.createFromTimestamp`
- `datetime` being deprecated in favor of `dateTime`