### PR TITLE
Add scaffolding for multi dimensional arrays in Arkouda

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1941,10 +1941,7 @@ def create_pdarray(repMsg: str, max_bits=None) -> pdarray:
         size = int(fields[3])
         ndim = int(fields[4])
 
-        # remove comma from 1 tuple with trailing comma
-        if fields[5][len(fields[5]) - 2] == ",":
-            fields[5] = fields[5].replace(",", "")
-        shape = [int(el) for el in fields[5][1:-1].split(",")]
+        shape = [int(el) for el in fields[5][1:-2].split(",")]
         itemsize = int(fields[6])
     except Exception as e:
         raise ValueError(e)

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1941,7 +1941,10 @@ def create_pdarray(repMsg: str, max_bits=None) -> pdarray:
         size = int(fields[3])
         ndim = int(fields[4])
 
-        shape = [int(el) for el in fields[5][1:-2].split(",")]
+        if fields[5][len(fields[5]) - 2] == ",":
+            shape = [int(el) for el in fields[5][1:-2].split(",")]
+        else:
+            shape = [int(el) for el in fields[5][1:-1].split(",")]
         itemsize = int(fields[6])
     except Exception as e:
         raise ValueError(e)

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -34,12 +34,17 @@ module AryUtil
       :arg A: array to be printed
     */
     proc formatAry(A):string throws {
+      // TODO: Update to print pretty with greater than 1 dimension
+      if A.domain.rank == 1 {
         if A.size <= printThresh {
             return "%t".format(A);
         } else {
             return "%t ... %t".format(A[A.domain.low..A.domain.low+2],
                                       A[A.domain.high-2..A.domain.high]);
         }
+      } else {
+        return "%t".format(A);
+      }
     }
 
     proc printAry(name:string, A) {

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -756,11 +756,11 @@ module HDF5Msg {
         }
     }
 
-    proc bigintToUint(entry): list(shared SymEntry(uint)) throws {
+    proc bigintToUint(entry): list(shared SymEntry(uint,1)) throws {
         select entry.dtype {
             when DType.BigInt {
                 var tmp = entry.a;
-                var limbs: list(shared SymEntry(uint)) = new list(shared SymEntry(uint));
+                var limbs: list(shared SymEntry(uint,1)) = new list(shared SymEntry(uint,1));
                 var all_zero = false;
                 var low: [tmp.domain] uint;
                 const ushift = 64:uint;
@@ -2432,7 +2432,7 @@ module HDF5Msg {
         }
         C_HDF5.H5Fclose(file_id);
 
-        var limbs: list(shared SymEntry(uint)) = new list(shared SymEntry(uint));
+        var limbs: list(shared SymEntry(uint,1)) = new list(shared SymEntry(uint,1));
         for l in 0..#numlimbs {
             var subdoms: [fD] domain(1);
             var skips = new set(string);

--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -118,8 +118,8 @@ module MultiTypeSymEntry
         :arg etype: type for gse to be cast to
         :type etype: type
        */
-    inline proc toSymEntry(gse: borrowed GenSymEntry, type etype) {
-        return gse.toSymEntry(etype);
+    inline proc toSymEntry(gse: borrowed GenSymEntry, type etype, param dimensions=1) {
+        return gse.toSymEntry(etype, dimensions);
     }
 
     /* 
@@ -135,17 +135,19 @@ module MultiTypeSymEntry
         var itemsize: int; // answer to numpy itemsize = num bytes per elt
         var size: int = 0; // answer to numpy size == num elts
         var ndim: int = 1; // answer to numpy ndim == 1-axis for now
-        var shape: 1*int = (0,); // answer to numpy shape == 1*int tuple
+        var shape: string = "[1,]"; // answer to numpy shape == 1*int tuple
         
         // not sure yet how to implement numpy data() function
 
-        proc init(type etype, len: int = 0) {
+        proc init(type etype, len: int = 0, ndim: int = 1) {
             this.entryType = SymbolEntryType.TypedArraySymEntry;
             assignableTypes.add(this.entryType);
             this.dtype = whichDtype(etype);
             this.itemsize = dtypeSize(this.dtype);
             this.size = len;
-            this.shape = (len,);
+            this.ndim = ndim;
+            // TODO: Update based on variable number of dims
+            this.shape = "[" + len:string + ",]";
         }
 
         override proc getSizeEstimate(): int {
@@ -159,8 +161,8 @@ module MultiTypeSymEntry
            :arg etype: `SymEntry` type parameter
            :type etype: type
          */
-        inline proc toSymEntry(type etype) {
-            return try! this :borrowed SymEntry(etype);
+        inline proc toSymEntry(type etype, param dimensions=1) {
+            return try! this :borrowed SymEntry(etype, dimensions);
         }
 
         /* 
@@ -200,14 +202,26 @@ module MultiTypeSymEntry
         type etype;
 
         /*
+        number of dimensions, to be passed back to the `GenSymEntry` so that
+        we are able to make it visible to the Python client
+        */
+        param dimensions: int;
+
+        /*
+        the actual shape of the array, this has to live here, since GenSymEntry
+        has to stay generic
+        */
+        var tupShape: dimensions*int;
+
+        /*
         'a' is the distributed array whose value and type are defined by
         makeDist{Dom,Array}() to support varying distributions
         */
-        var a = makeDistArray(size, etype);
+        var a: [makeDistDom((...tupShape))] etype;
         /* Removed domain accessor, use `a.domain` instead */
         proc aD { compilerError("SymEntry.aD has been removed, use SymEntry.a.domain instead"); }
         /* only used with bigint pdarrays */
-        var max_bits = -1;
+        var max_bits:int = -1;
 
         /*
         This init takes length and element type
@@ -218,13 +232,23 @@ module MultiTypeSymEntry
         :arg etype: type to be instantiated
         :type etype: type
         */
-        proc init(len: int, type etype) {
-            super.init(etype, len);
+        proc init(args: int ...?N, type etype) {
+            var len = 1;
+            for i in 0..#N {
+              len *= args[i];
+            }
+            super.init(etype, len, N);
             this.entryType = SymbolEntryType.PrimitiveTypedArraySymEntry;
             assignableTypes.add(this.entryType);
 
             this.etype = etype;
+            this.dimensions = N;
+            this.tupShape = args;
             this.a = makeDistArray(size, etype);
+            this.a = makeDistArray((...args), etype);
+            this.complete();
+            // TODO: fix this for multi dimensional
+            this.shape = "[" + tupShape[0]:string + "]";
         }
 
         /*
@@ -239,8 +263,13 @@ module MultiTypeSymEntry
             assignableTypes.add(this.entryType);
 
             this.etype = etype;
+            this.dimensions = D.rank;
+            this.tupShape = D.shape;
             this.a = a;
             this.max_bits=max_bits;
+            this.complete();
+            // TODO: Fix for multi dim
+            this.shape = "[" + tupShape[0]:string + "]";
         }
 
         /*
@@ -251,8 +280,11 @@ module MultiTypeSymEntry
         :type a: [] ?etype
         */
         proc init(a: [?D] ?etype) where MyDmap != Dmap.defaultRectangular && a.isDefaultRectangular() {
-            this.init(D.size, etype);
+            this.init(D.size, etype, D.rank);
+            this.tupShape = D.shape;
             this.a = a;
+            // TODO: Fix for multi dim
+            this.shape = "[" + tupShape[0]:string + "]";
         }
 
         /*
@@ -303,26 +335,31 @@ module MultiTypeSymEntry
             :returns: s (string) containing the array data
         */
         override proc __str__(thresh:int=6, prefix:string = "[", suffix:string = "]", baseFormat:string = "%t"): string throws {
+          if dimensions == 1 {
             var s:string = "";
             if (this.size == 0) {
-                s =  ""; // Unnecessary, but left for clarity
+              s =  ""; // Unnecessary, but left for clarity
             } else if (this.size < thresh || this.size <= 6) {
-                for i in 0..(this.size-2) {s += try! baseFormat.format(this.a[i]) + " ";}
-                s += try! baseFormat.format(this.a[this.size-1]);
+              for i in 0..(this.size-2) {s += try! baseFormat.format(this.a[i]) + " ";}
+              s += try! baseFormat.format(this.a[this.size-1]);
             } else {
-                var b = baseFormat + " " + baseFormat + " " + baseFormat + " ... " +
-                            baseFormat + " " + baseFormat + " " + baseFormat;
-                s = try! b.format(
-                            this.a[0], this.a[1], this.a[2],
-                            this.a[this.size-3], this.a[this.size-2], this.a[this.size-1]);
+              var b = baseFormat + " " + baseFormat + " " + baseFormat + " ... " +
+                baseFormat + " " + baseFormat + " " + baseFormat;
+              s = try! b.format(
+                                this.a[0], this.a[1], this.a[2],
+                                this.a[this.size-3], this.a[this.size-2], this.a[this.size-1]);
             }
-            
+
             if (bool == this.etype) {
-                s = s.replace("true","True");
-                s = s.replace("false","False");
+              s = s.replace("true","True");
+              s = s.replace("false","False");
             }
 
             return prefix + s + suffix;
+          } else {
+            // TODO: We want this to do something smart, not just print entire array
+            return this.a:string;
+          }
         }
     }
 
@@ -360,8 +397,8 @@ module MultiTypeSymEntry
     class SegStringSymEntry:GenSymEntry {
         type etype = string;
 
-        var offsetsEntry: shared SymEntry(int);
-        var bytesEntry: shared SymEntry(uint(8));
+        var offsetsEntry: shared SymEntry(int, 1);
+        var bytesEntry: shared SymEntry(uint(8), 1);
 
         proc init(offsetsSymEntry: shared SymEntry, bytesSymEntry: shared SymEntry, type etype) {
             super.init(etype, bytesSymEntry.size);

--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -147,7 +147,7 @@ module MultiTypeSymEntry
             this.size = len;
             this.ndim = ndim;
             // TODO: Update based on variable number of dims
-            this.shape = "[" + len:string + ",]";
+            this.shape = "[1,]";
         }
 
         override proc getSizeEstimate(): int {
@@ -246,8 +246,10 @@ module MultiTypeSymEntry
             this.tupShape = args;
             this.a = makeDistArray((...args), etype);
             this.complete();
-            // TODO: fix this for multi dimensional
-            this.shape = "[" + tupShape[0]:string + "]";
+            this.shape = "[";
+            for s in tupShape do
+              this.shape += s:string + ",";
+            this.shape += "]";
         }
 
         /*

--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -244,7 +244,6 @@ module MultiTypeSymEntry
             this.etype = etype;
             this.dimensions = N;
             this.tupShape = args;
-            this.a = makeDistArray(size, etype);
             this.a = makeDistArray((...args), etype);
             this.complete();
             // TODO: fix this for multi dimensional

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -103,13 +103,13 @@ module MultiTypeSymbolTable
 
             :returns: borrow of newly created `SymEntry(t)`
         */
-        proc addEntry(name: string, len: int, type t): borrowed SymEntry(t) throws {
+      proc addEntry(name: string, args: int ...?N, type t): borrowed SymEntry(t, N) throws {
             // check and throw if memory limit would be exceeded
             // TODO figure out a way to do memory checking for bigint
             if t != bigint {
-                if t == bool {overMemLimit(len);} else {overMemLimit(len*numBytes(t));}
+                if t == bool {overMemLimit(args[0]);} else {overMemLimit(args[0]*numBytes(t));}
             }
-            var entry = new shared SymEntry(len, t);
+            var entry = new shared SymEntry((...args), t);
             if (tab.contains(name)) {
                 mtLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                                         "redefined symbol: %s ".format(name));
@@ -122,7 +122,7 @@ module MultiTypeSymbolTable
             entry.setName(name);
             // When we retrieve from table, it comes back as AbstractSymEntry so we need to cast it
             // back to the original type. Since we know it already we can skip isAssignableTo check
-            return (tab[name]:borrowed GenSymEntry).toSymEntry(t);
+            return (tab[name]:borrowed GenSymEntry).toSymEntry(t, N);
         }
 
         /*
@@ -385,16 +385,16 @@ module MultiTypeSymbolTable
         proc formatEntry(name:string, abstractEntry:borrowed AbstractSymEntry): string throws {
             if abstractEntry.isAssignableTo(SymbolEntryType.TypedArraySymEntry) {
                 var item:borrowed GenSymEntry = toGenSymEntry(abstractEntry);
-                return '{"name":%jt, "dtype":%jt, "size":%jt, "ndim":%jt, "shape":%jt, "itemsize":%jt, "registered":%jt}'.format(name,
+                return '{"name":%jt, "dtype":%jt, "size":%jt, "ndim":%jt, "shape":%s, "itemsize":%jt, "registered":%jt}'.format(name,
                               dtype2str(item.dtype), item.size, item.ndim, item.shape, item.itemsize, registry.contains(name));
 
             } else if abstractEntry.isAssignableTo(SymbolEntryType.SegStringSymEntry) {
                 var item:borrowed SegStringSymEntry = toSegStringSymEntry(abstractEntry);
-                return '{"name":%jt, "dtype":%jt, "size":%jt, "ndim":%jt, "shape":%jt, "itemsize":%jt, "registered":%jt}'.format(name,
+                return '{"name":%jt, "dtype":%jt, "size":%jt, "ndim":%jt, "shape":%s, "itemsize":%jt, "registered":%jt}'.format(name,
                               dtype2str(item.dtype), item.size, item.ndim, item.shape, item.itemsize, registry.contains(name));
                               
             } else {
-                return '{"name":%jt, "dtype":%jt, "size":%jt, "ndim":%jt, "shape":%jt, "itemsize":%jt, "registered":%jt}'.format(name,
+                return '{"name":%jt, "dtype":%jt, "size":%jt, "ndim":%jt, "shape":%s, "itemsize":%jt, "registered":%jt}'.format(name,
                               dtype2str(DType.UNDEF), 0, 0, (0,), 0, registry.contains(name));
             }
         }
@@ -414,7 +414,7 @@ module MultiTypeSymbolTable
             var entry = tab[name];
             if entry.isAssignableTo(SymbolEntryType.TypedArraySymEntry){ //Anything considered a GenSymEntry
                 var g:GenSymEntry = toGenSymEntry(entry);
-                return "%s %s %t %t %t %t".format(name, dtype2str(g.dtype), g.size, g.ndim, g.shape, g.itemsize);
+                return "%s %s %t %t %s %t".format(name, dtype2str(g.dtype), g.size, g.ndim, g.shape, g.itemsize);
             }
             else if entry.isAssignableTo(SymbolEntryType.CompositeSymEntry) { //CompositeSymEntry
                 var c: CompositeSymEntry = toCompositeSymEntry(entry);

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -400,10 +400,10 @@ module SegmentedMsg {
       when "Matcher" {
         const optName: string = if returnMatchOrig then st.nextName() else "";
         var strings = getSegString(name, st);
-        var numMatches = getGenericTypedArrayEntry(numMatchesName, st): borrowed SymEntry(int);
-        var starts = getGenericTypedArrayEntry(startsName, st): borrowed SymEntry(int);
-        var lens = getGenericTypedArrayEntry(lensName, st): borrowed SymEntry(int);
-        var indices = getGenericTypedArrayEntry(indicesName,st): borrowed SymEntry(int);
+        var numMatches = getGenericTypedArrayEntry(numMatchesName, st): borrowed SymEntry(int, 1);
+        var starts = getGenericTypedArrayEntry(startsName, st): borrowed SymEntry(int, 1);
+        var lens = getGenericTypedArrayEntry(lensName, st): borrowed SymEntry(int, 1);
+        var indices = getGenericTypedArrayEntry(indicesName,st): borrowed SymEntry(int, 1);
 
         var (off, val, matchOrigins) = strings.findAllMatches(numMatches, starts, lens, indices, returnMatchOrig);
         var retString = getSegString(off, val, st);
@@ -418,10 +418,10 @@ module SegmentedMsg {
         const optName: string = if returnMatchOrig then st.nextName() else "";
         var strings = getSegString(name, st);
         // numMatches is the matched boolean array for Match objects
-        var numMatches = st.lookup(numMatchesName): borrowed SymEntry(bool);
-        var starts = st.lookup(startsName): borrowed SymEntry(int);
-        var lens = st.lookup(lensName): borrowed SymEntry(int);
-        var indices = st.lookup(indicesName): borrowed SymEntry(int);
+        var numMatches = st.lookup(numMatchesName): borrowed SymEntry(bool, 1);
+        var starts = st.lookup(startsName): borrowed SymEntry(int, 1);
+        var lens = st.lookup(lensName): borrowed SymEntry(int, 1);
+        var indices = st.lookup(indicesName): borrowed SymEntry(int, 1);
 
         var (off, val, matchOrigins) = strings.findAllMatches(numMatches, starts, lens, indices, returnMatchOrig);
         var retString = getSegString(off, val, st);

--- a/src/SegmentedString.chpl
+++ b/src/SegmentedString.chpl
@@ -95,14 +95,14 @@ module SegmentedString {
      * The pdarray containing the offsets, which are the start indices of
      * the bytearrays, each of which corresponds to an individual string.
      */ 
-    var offsets: shared SymEntry(int);
+    var offsets: shared SymEntry(int, 1);
 
     /**
      * The pdarray containing the complete byte array composed of bytes
      * corresponding to each string, joined by nulls. Note: the null byte
      * is uint(8) value of zero.
      */ 
-    var values: shared SymEntry(uint(8));
+    var values: shared SymEntry(uint(8), 1);
     
     /**
      * The number of strings in the segmented array
@@ -123,8 +123,8 @@ module SegmentedString {
     proc init(entryName:string, entry:borrowed SegStringSymEntry) {
         name = entryName;
         composite = entry;
-        offsets = composite.offsetsEntry: shared SymEntry(int);
-        values = composite.bytesEntry: shared SymEntry(uint(8));
+        offsets = composite.offsetsEntry: shared SymEntry(int, 1);
+        values = composite.bytesEntry: shared SymEntry(uint(8), 1);
         size = offsets.size;
         nBytes = values.size;
     }
@@ -607,7 +607,7 @@ module SegmentedString {
       :type returnMatchOrig: bool
       :returns: Strings – Only the portions of Strings which match pattern and (optional) int64 pdarray – For each pattern match, the index of the original string it was in
     */
-    proc findAllMatches(const numMatchesEntry: ?t, const startsEntry: borrowed SymEntry(int), const lensEntry: borrowed SymEntry(int), const indicesEntry: borrowed SymEntry(int), const returnMatchOrig: bool) throws where t == borrowed SymEntry(int) || t == borrowed SymEntry(bool) {
+    proc findAllMatches(const numMatchesEntry: ?t, const startsEntry: borrowed SymEntry(int,1), const lensEntry: borrowed SymEntry(int,1), const indicesEntry: borrowed SymEntry(int,1), const returnMatchOrig: bool) throws where t == borrowed SymEntry(int,1) || t == borrowed SymEntry(bool,1) {
       ref origVals = this.values.a;
       ref origOffsets = this.offsets.a;
       ref numMatches = numMatchesEntry.a;

--- a/src/SymArrayDmap.chpl
+++ b/src/SymArrayDmap.chpl
@@ -24,15 +24,21 @@ module SymArrayDmap
     :arg size: size of domain
     :type size: int
     */
-    proc makeDistDom(size:int) {
+    proc makeDistDom(args: int ...?N) {
         select MyDmap
-        {
+          {
             when Dmap.defaultRectangular {
-                return {0..#size};
+              var rngs: N*range;
+              for i in 0..#N do
+                rngs[i] = 0..#args[i];
+              return {(...rngs)};
             }
             when Dmap.blockDist {
-                if size > 0 {
-                    return {0..#size} dmapped Block(boundingBox={0..#size});
+                if args[0] > 0 {
+                  var rngs: N*range;
+                  for i in 0..#N do
+                    rngs[i] = 0..#args[i];
+                  return {(...rngs)} dmapped Block(boundingBox={(...rngs)});
                 }
                 // fix the annoyance about boundingBox being enpty
                 else {return {0..#0} dmapped Block(boundingBox={0..0});}
@@ -54,8 +60,8 @@ module SymArrayDmap
 
     :returns: [] ?etype
     */
-    proc makeDistArray(size:int, type etype) {
-        var a: [makeDistDom(size)] etype;
+    proc makeDistArray(args: int ...?N, type etype) {
+        var a: [makeDistDom((...args))] etype;
         return a;
     }
 


### PR DESCRIPTION
This PR updates the `SymEntry` class to have a `param dimensions` field that allows stamping out of multiple different pdarray dimensions in preparation for adding Array API functionality. No behavior will change after this PR is merged, but development of multi-dimensional pdarrays of the form below will be able to begin:

1. Add a `param dimensions=1` field to a function to add functionality to, like:
```chpl
proc randintMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, param dimensions=1): MsgTuple throws {
```

2. Update the code in the function to behave as expected with the different dimensions

3. Add a 1D, 2D... function to call this new function with different dimensions using signatures that can be registered in the command map:
```chpl
    proc randintMsg1D(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
      return randintMsg(cmd, msgArgs, st, 1);
    }

    proc randintMsg2D(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
      return randintMsg(cmd, msgArgs, st, 2);
    }
```

4. Register the new functions:
```chpl
    registerFunction("randint1D", randintMsg1D, getModuleName());
    registerFunction("randint2D", randintMsg2D, getModuleName());
```

5. update the client to somehow send the new messages as desired