### PR TITLE
Adjust these modules to avoid deprecation warnings from non-default Math symbols

### DIFF
--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -4,7 +4,7 @@ module EfuncMsg
     use ServerConfig;
     
     use ArkoudaTimeCompat as Time;
-    use Math only;
+    use Math;
     use BitOps;
     use Reflection;
     use ServerErrors;

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -3,7 +3,7 @@ module ReductionMsg
     use ServerConfig;
 
     use ArkoudaTimeCompat as Time;
-    use Math only;
+    use Math;
     use Reflection only;
     use CommAggregation;
     use BigInteger;

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -14,6 +14,7 @@ module SegmentedMsg {
   use IO;
   use GenSymIO;
   use BigInteger;
+  use Math;
 
   use ArkoudaMapCompat;
 


### PR DESCRIPTION
`exp`, `sin` and `cos` will stop being included in all Chapel programs by default in 1.31 and will instead require a `use` or `import` of the Math module. Change these modules to fully use the Math module, which will be compatible with previous versions of Chapel since the module already existed.

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>