### PR TITLE
Closes #2427 - Deprecation updates related to Memory and Memory.Diagnostics

### DIFF
--- a/src/MetricsMsg.chpl
+++ b/src/MetricsMsg.chpl
@@ -8,7 +8,7 @@ module MetricsMsg {
     use MultiTypeSymbolTable;
     use MultiTypeSymEntry;
     use Message;
-    use Memory.Diagnostics;
+    use ArkoudaMemDiagnosticsCompat;
     use NumPyDType;
     use ArkoudaTimeCompat as Time;
 

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -216,7 +216,7 @@ module ServerConfig
     chpl_comm_regMemHeapInfo if using a fixed heap, otherwise physical memory
     */ 
     proc getPhysicalMemHere() {
-        use Memory.Diagnostics, CTypes;
+        use ArkoudaMemDiagnosticsCompat, CTypes;
         extern proc chpl_comm_regMemHeapInfo(start: c_ptr(c_void_ptr), size: c_ptr(c_size_t)): void;
         var unused: c_void_ptr;
         var heap_size: c_size_t;
@@ -242,7 +242,7 @@ module ServerConfig
     Get the memory used on this locale
     */
     proc getMemUsed() {
-        use Memory.Diagnostics;
+        use ArkoudaMemDiagnosticsCompat;
         return memoryUsed();
     }
 

--- a/src/ServerDaemon.chpl
+++ b/src/ServerDaemon.chpl
@@ -6,7 +6,6 @@ module ServerDaemon {
     use ServerErrors;
     use ArkoudaTimeCompat as Time;
     use ZMQ only;
-    use Memory;
     use FileSystem;
     use IO;
     use Logging;

--- a/src/compat/e-129/ArkoudaMemDiagnosticsCompat.chpl
+++ b/src/compat/e-129/ArkoudaMemDiagnosticsCompat.chpl
@@ -1,0 +1,3 @@
+module ArkoudaMemDiagnosticsCompat {
+  public use Memory.Diagnostics;
+}

--- a/src/compat/e-130/ArkoudaMemDiagnosticsCompat.chpl
+++ b/src/compat/e-130/ArkoudaMemDiagnosticsCompat.chpl
@@ -1,0 +1,3 @@
+module ArkoudaMemDiagnosticsCompat {
+  public use Memory.Diagnostics;
+}

--- a/src/compat/gt-130/ArkoudaMemDiagnosticsCompat.chpl
+++ b/src/compat/gt-130/ArkoudaMemDiagnosticsCompat.chpl
@@ -1,0 +1,3 @@
+module ArkoudaMemDiagnosticsCompat {
+  public use MemDiagnostics;
+}

--- a/toys/repro.chpl
+++ b/toys/repro.chpl
@@ -1,6 +1,6 @@
 module repro
 {
-    use Memory;
+    use ArkoudaMemDiagnosticsCompat;
     
     config const perLocaleMemLimit = 80;
     

--- a/toys/toy_countSort.chpl
+++ b/toys/toy_countSort.chpl
@@ -8,7 +8,7 @@ config const VR = 20; // 20 possible values are in [M,M+VR)
 use CyclicDist;
 use CountingSort;
 use AryUtil;
-use Memory;  // for physicalMemory()
+use ArkoudaMemDiagnosticsCompat;  // for physicalMemory()
 
 config const printLocaleInfo = true;  // permit testing to turn this off
 


### PR DESCRIPTION
Closes #2427

Updates for the following deprecations:

- `Memory.Diagnostics` is renamed to `MemDiagnostics`.
- `Memory` is deprecated with no replacement.

Adds a compatibility module for `MemDiagnostics`.