### PR TITLE
Closes #2416 and #2006: bigint shift performance

### DIFF
--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -1161,10 +1161,19 @@ module BinOp
         // can't shift a bigint by a bigint
         select op {
           when "<<" {
-            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
-              t <<= ri;
-              if has_max_bits {
-                t &= local_max_size;
+            var too_big = makeDistArray(ra.size, bool);
+            if has_max_bits {
+              too_big = ra >= max_bits;
+            }
+            forall (t, ri, tb) in zip(tmp, ra, too_big) with (var local_max_size = max_size) {
+              if tb {
+                t = 0;
+              }
+              else {
+                t <<= ri;
+                if has_max_bits {
+                  t &= local_max_size;
+                }
               }
             }
             visted = true;
@@ -1173,12 +1182,21 @@ module BinOp
             // workaround for right shift until chapel issue #21206
             // makes it into a release, eventually we can just do
             // tmp = la >> ra;
-            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
-              var dB = 1:bigint;
-              dB <<= ri;
-              t /= dB;
-              if has_max_bits {
-                t &= local_max_size;
+            var too_big = makeDistArray(ra.size, bool);
+            if has_max_bits {
+              too_big = ra >= max_bits;
+            }
+            forall (t, ri, tb) in zip(tmp, ra, too_big) with (var local_max_size = max_size) {
+              if tb {
+                t = 0;
+              }
+              else {
+                var dB = 1:bigint;
+                dB <<= ri;
+                t /= dB;
+                if has_max_bits {
+                  t &= local_max_size;
+                }
               }
             }
             visted = true;
@@ -1418,10 +1436,17 @@ module BinOp
         // can't shift a bigint by a bigint
         select op {
           when "<<" {
-            forall t in tmp with (var local_val = val, var local_max_size = max_size) {
-              t <<= local_val;
-              if has_max_bits {
-                t &= local_max_size;
+            if has_max_bits && val >= max_bits {
+              forall t in tmp with (var local_zero = 0:bigint) {
+                t = local_zero;
+              }
+            }
+            else {
+              forall t in tmp with (var local_val = val, var local_max_size = max_size) {
+                t <<= local_val;
+                if has_max_bits {
+                  t &= local_max_size;
+                }
               }
             }
             visted = true;
@@ -1430,10 +1455,17 @@ module BinOp
             // workaround for right shift until chapel issue #21206
             // makes it into a release, eventually we can just do
             // tmp = la >> ra;
-            forall t in tmp with (var dB = (1:bigint) << val, var local_max_size = max_size) {
-              t /= dB;
-              if has_max_bits {
-                t &= local_max_size;
+            if has_max_bits && val >= max_bits {
+              forall t in tmp with (var local_zero = 0:bigint) {
+                t = local_zero;
+              }
+            }
+            else {
+              forall t in tmp with (var dB = (1:bigint) << val, var local_max_size = max_size) {
+                t /= dB;
+                if has_max_bits {
+                  t &= local_max_size;
+                }
               }
             }
             visted = true;
@@ -1690,10 +1722,19 @@ module BinOp
         // can't shift a bigint by a bigint
         select op {
           when "<<" {
-            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
-              t <<= ri;
-              if has_max_bits {
-                t &= local_max_size;
+            var too_big = makeDistArray(ra.size, bool);
+            if has_max_bits {
+              too_big = ra >= max_bits;
+            }
+            forall (t, ri, tb) in zip(tmp, ra, too_big) with (var local_max_size = max_size) {
+              if tb {
+                t = 0;
+              }
+              else {
+                t <<= ri;
+                if has_max_bits {
+                  t &= local_max_size;
+                }
               }
             }
             visted = true;
@@ -1702,12 +1743,21 @@ module BinOp
             // workaround for right shift until chapel issue #21206
             // makes it into a release, eventually we can just do
             // tmp = val >> ra;
-            forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
-              var dB = 1:bigint;
-              dB <<= ri;
-              t /= dB;
-              if has_max_bits {
-                t &= local_max_size;
+            var too_big = makeDistArray(ra.size, bool);
+            if has_max_bits {
+              too_big = ra >= max_bits;
+            }
+            forall (t, ri, tb) in zip(tmp, ra, too_big) with (var local_max_size = max_size) {
+              if tb {
+                t = 0;
+              }
+              else {
+                var dB = 1:bigint;
+                dB <<= ri;
+                t /= dB;
+                if has_max_bits {
+                  t &= local_max_size;
+                }
               }
             }
             visted = true;

--- a/src/compat/e-129/ArkoudaBigIntCompat.chpl
+++ b/src/compat/e-129/ArkoudaBigIntCompat.chpl
@@ -29,4 +29,75 @@ module ArkoudaBigIntCompat {
               const ref mod: bigint)  {
     result.powMod(base, exp, mod);
   }
+
+  // methods needed to to right shift for int and uint
+  use CTypes;
+  use GMP;
+  extern type mp_bitcnt_t = c_ulong;
+
+  proc rightShift(const ref a: bigint, b: int): bigint {
+    var c = new bigint();
+    shiftRight(c, a, b);
+    return c;
+  }
+
+  proc rightShift(const ref a: bigint, b: uint): bigint {
+    return a >> b;
+  }
+
+  proc rightShiftEq(ref a: bigint, b:  int) {
+    shiftRight(a, a, b);
+  }
+
+  proc rightShiftEq(ref a: bigint, b:  uint) {
+    a >>= b;
+  }
+
+  private inline proc shiftRight(ref result: bigint, const ref a: bigint, b: int) {
+    if b >= 0 {
+      shiftRight(result, a, b:uint);
+    } else {
+      mul_2exp(result, a, (0 - b):uint);
+    }
+  }
+
+  private inline proc shiftRight(ref result: bigint, const ref a: bigint, b: uint) {
+    divQ2Exp(result, a, b);
+  }
+
+  proc mul_2exp(ref result: bigint, const ref a: bigint, b: integral) {
+    const b_ = b.safeCast(mp_bitcnt_t);
+
+    if _local {
+      mpz_mul_2exp(result.mpz, a.mpz, b_);
+    } else if result.localeId == chpl_nodeID {
+      const a_ = a;
+      mpz_mul_2exp(result.mpz, a_.mpz, b_);
+    } else {
+      const resultLoc = chpl_buildLocaleID(result.localeId, c_sublocid_any);
+      on __primitive("chpl_on_locale_num", resultLoc) {
+        const a_ = a;
+        mpz_mul_2exp(result.mpz, a_.mpz, b_);
+      }
+    }
+  }
+
+  proc divQ2Exp(ref result: bigint,
+                const ref numer: bigint,
+                exp: integral) {
+    const exp_ = exp.safeCast(mp_bitcnt_t);
+
+    if _local {
+      mpz_fdiv_q_2exp(result.mpz, numer.mpz, exp_);
+    } else if result.localeId == chpl_nodeID {
+      const numer_ = numer;
+      mpz_fdiv_q_2exp(result.mpz, numer_.mpz, exp_);
+    } else {
+      const resultLoc = chpl_buildLocaleID(result.localeId, c_sublocid_any);
+      on __primitive("chpl_on_locale_num", resultLoc) {
+        const numer_ = numer;
+        mpz_fdiv_q_2exp(result.mpz, numer_.mpz, exp_);
+      }
+    }
+  }
 }

--- a/src/compat/e-130/ArkoudaBigIntCompat.chpl
+++ b/src/compat/e-130/ArkoudaBigIntCompat.chpl
@@ -29,4 +29,20 @@ module ArkoudaBigIntCompat {
               const ref mod: bigint)  {
     result.powMod(base, exp, mod);
   }
+
+  proc rightShift(const ref a: bigint, b: int): bigint {
+    return a >> b;
+  }
+
+  proc rightShift(const ref a: bigint, b: uint): bigint {
+    return a >> b;
+  }
+
+  proc rightShiftEq(ref a: bigint, b:  int) {
+    a >>= b;
+  }
+
+  proc rightShiftEq(ref a: bigint, b:  uint) {
+    a >>= b;
+  }
 }

--- a/src/compat/gt-130/ArkoudaBigIntCompat.chpl
+++ b/src/compat/gt-130/ArkoudaBigIntCompat.chpl
@@ -1,1 +1,17 @@
-module ArkoudaBigIntCompat {}
+module ArkoudaBigIntCompat {
+  proc rightShift(const ref a: bigint, b: int): bigint {
+    return a >> b;
+  }
+
+  proc rightShift(const ref a: bigint, b: uint): bigint {
+    return a >> b;
+  }
+
+  proc rightShiftEq(ref a: bigint, b:  int) {
+    a >>= b;
+  }
+
+  proc rightShiftEq(ref a: bigint, b:  uint) {
+    a >>= b;
+  }
+}


### PR DESCRIPTION
This PR (closes #2416 and closes #2006) avoids shifting when the shift amount exceeds max_bits. This will always result in 0, so it's unnecessary to do the shift and AND. Also remove workaround for `>>` and compat code for version 1.29