### PR TITLE
Closes #2386 - `GroupBy.to_hdf` & `GroupBy.update_hdf`

### DIFF
--- a/arkouda/__init__.py
+++ b/arkouda/__init__.py
@@ -9,7 +9,6 @@ from arkouda.array_view import *
 from arkouda.client import *
 from arkouda.client_dtypes import *
 from arkouda.dtypes import *
-from arkouda.decorators import *
 from arkouda.pdarrayclass import *
 from arkouda.sorting import *
 from arkouda.pdarraysetops import *

--- a/arkouda/array_view.py
+++ b/arkouda/array_view.py
@@ -44,8 +44,9 @@ class ArrayView:
         If 'F'/'column_major', read and write data in column_major order
     """
 
+    objType = "ArrayView"
+
     def __init__(self, base: pdarray, shape, order="row_major"):
-        self.objtype = type(self).__name__
         self.shape = array(shape)
         if not isinstance(self.shape, pdarray):
             raise TypeError(f"ArrayView Shape cannot be type {type(self.shape)}. Expecting pdarray.")

--- a/arkouda/array_view.py
+++ b/arkouda/array_view.py
@@ -447,7 +447,12 @@ class ArrayView:
         - Because HDF5 deletes do not release memory, this will create a copy of the
           file with the new data
         """
-        from arkouda.io import _get_hdf_filetype, _mode_str_to_int, _file_type_to_int, _repack_hdf
+        from arkouda.io import (
+            _file_type_to_int,
+            _get_hdf_filetype,
+            _mode_str_to_int,
+            _repack_hdf,
+        )
 
         # determine the format (single/distribute) that the file was saved in
         file_type = _get_hdf_filetype(prefix_path + "*")

--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -21,7 +21,7 @@ from typeguard import typechecked
 from arkouda.client import generic_msg
 from arkouda.dtypes import bool as akbool
 from arkouda.dtypes import int64 as akint64
-from arkouda.dtypes import int_scalars, resolve_scalar_dtype, str_, str_scalars, npstr
+from arkouda.dtypes import int_scalars, npstr, resolve_scalar_dtype, str_, str_scalars
 from arkouda.groupbyclass import GroupBy, unique
 from arkouda.infoclass import information, list_registry
 from arkouda.logger import getArkoudaLogger
@@ -810,7 +810,7 @@ class Categorical:
             "filename": prefix_path,
             "objType": "categorical",
             "file_format": _file_type_to_int(file_type),
-            "NA_codes": self._akNAcode
+            "NA_codes": self._akNAcode,
         }
         if self.permutation is not None and self.segments is not None:
             args["permutation"] = self.permutation
@@ -821,12 +821,7 @@ class Categorical:
             args=args,
         )
 
-    def update_hdf(
-        self,
-        prefix_path,
-        dataset="categorical_array",
-        repack=True
-    ):
+    def update_hdf(self, prefix_path, dataset="categorical_array", repack=True):
         """
         Overwrite the dataset with the name provided with this Categorical object. If
         the dataset does not exist it is added.
@@ -861,7 +856,12 @@ class Categorical:
         - Because HDF5 deletes do not release memory, the repack option allows for
           automatic creation of a file without the inaccessible data.
         """
-        from arkouda.io import _get_hdf_filetype, _mode_str_to_int, _file_type_to_int, _repack_hdf
+        from arkouda.io import (
+            _file_type_to_int,
+            _get_hdf_filetype,
+            _mode_str_to_int,
+            _repack_hdf,
+        )
 
         # determine the format (single/distribute) that the file was saved in
         file_type = _get_hdf_filetype(prefix_path + "*")
@@ -875,7 +875,7 @@ class Categorical:
             "objType": "categorical",
             "overwrite": True,
             "file_format": _file_type_to_int(file_type),
-            "NA_codes": self._akNAcode
+            "NA_codes": self._akNAcode,
         }
         if self.permutation is not None and self.segments is not None:
             args["permutation"] = self.permutation
@@ -1244,6 +1244,7 @@ class Categorical:
         register, is_registered, unregister, unregister_categorical_by_name
         """
         from arkouda.util import attach
+
         return attach(user_defined_name, dtype="categorical")
 
     @staticmethod

--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -19,10 +19,9 @@ import numpy as np  # type: ignore
 from typeguard import typechecked
 
 from arkouda.client import generic_msg
-from arkouda.decorators import objtypedec
 from arkouda.dtypes import bool as akbool
 from arkouda.dtypes import int64 as akint64
-from arkouda.dtypes import int_scalars, resolve_scalar_dtype, str_, str_scalars
+from arkouda.dtypes import int_scalars, resolve_scalar_dtype, str_, str_scalars, npstr
 from arkouda.groupbyclass import GroupBy, unique
 from arkouda.infoclass import information, list_registry
 from arkouda.logger import getArkoudaLogger
@@ -42,7 +41,6 @@ from arkouda.strings import Strings
 __all__ = ["Categorical"]
 
 
-@objtypedec
 class Categorical:
     """
     Represents an array of values belonging to named categories. Converting a
@@ -83,6 +81,8 @@ class Categorical:
     RequiredPieces = frozenset(["categories", "codes", "_akNAcode"])
     permutation = None
     segments = None
+    objType = "Categorical"
+    dtype = npstr  # this is being set for now because Categoricals only supported on Strings
 
     def __init__(self, values, **kwargs) -> None:
         self.logger = getArkoudaLogger(name=__class__.__name__)  # type: ignore
@@ -142,10 +142,6 @@ class Categorical:
         self.shape = self.codes.shape
         self.dtype = str_
         self.name: Optional[str] = None
-
-    @property
-    def objtype(self):
-        return self.objtype
 
     @classmethod
     @typechecked

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -2150,7 +2150,7 @@ class DataFrame(UserDict):
         array(self.columns).register(f"df_columns_{user_defined_name}")
 
         for col, data in self.data.items():
-            data.register(f"df_data_{data.objtype}_{col}_{user_defined_name}")
+            data.register(f"df_data_{data.objType}_{col}_{user_defined_name}")
 
         self.name = user_defined_name
         return self
@@ -2262,8 +2262,8 @@ class DataFrame(UserDict):
         columns = dict.fromkeys(json.loads(col_resp))
         matches = []
         regEx = compile(
-            f"^df_data_({pdarray.objtype}|{Strings.objtype}|"
-            f"{Categorical.objtype}|{SegArray.objtype})_.*_{user_defined_name}"
+            f"^df_data_({pdarray.objType}|{Strings.objType}|"
+            f"{Categorical.objType}|{SegArray.objType})_.*_{user_defined_name}"
         )
         # Using the regex, cycle through the registered items and find all the columns in the DataFrame
         for name in list_registry():
@@ -2278,20 +2278,21 @@ class DataFrame(UserDict):
         # loop through
         for name in set(matches):
             colName = DataFrame._parse_col_name(name, user_defined_name)[0]
-            if f"_{Strings.objtype}_" in name:
+            if f"_{Strings.objType}_" in name:
                 columns[colName] = Strings.attach(name)
-            elif f"_{pdarray.objtype}_" in name:
+            elif f"_{pdarray.objType}_" in name:
                 columns[colName] = pd_attach(name)
-            elif f"_{Categorical.objtype}_" in name:
+            elif f"_{Categorical.objType}_" in name:
                 columns[colName] = Categorical.attach(name)
-            elif f"_{SegArray.objtype}_" in name:
+            elif f"_{SegArray.objType}_" in name:
                 columns[colName] = SegArray.attach(name)
 
         index_resp = cast(
             str, generic_msg(cmd="attach", args={"name": f"df_index_{user_defined_name}_key"})
         )
+        print(index_resp)
         dtype = index_resp.split()[2]
-        if dtype == Strings.objtype:
+        if dtype == "str":  # TODO - this should be updated in the future to Strings
             ind = Strings.from_return_msg(index_resp)
         else:  # pdarray
             ind = create_pdarray(index_resp)
@@ -2328,8 +2329,8 @@ class DataFrame(UserDict):
 
         matches = []
         regEx = compile(
-            f"^df_data_({pdarray.objtype}|{Strings.objtype}|"
-            f"{Categorical.objtype}|{SegArray.objtype})_.*_{user_defined_name}"
+            f"^df_data_({pdarray.objType}|{Strings.objType}|"
+            f"{Categorical.objType}|{SegArray.objType})_.*_{user_defined_name}"
         )
         # Using the regex, cycle through the registered items and find all the columns in the DataFrame
         for name in list_registry():
@@ -2342,13 +2343,13 @@ class DataFrame(UserDict):
 
         # Remove duplicates caused by multiple components in categorical and loop through
         for name in set(matches):
-            if f"_{Strings.objtype}_" in name:
+            if f"_{Strings.objType}_" in name:
                 Strings.unregister_strings_by_name(name)
-            elif f"_{pdarray.objtype}_" in name:
+            elif f"_{pdarray.objType}_" in name:
                 unregister_pdarray_by_name(name)
-            elif f"_{Categorical.objtype}_" in name:
+            elif f"_{Categorical.objType}_" in name:
                 Categorical.unregister_categorical_by_name(name)
-            elif f"_{SegArray.objtype}_" in name:
+            elif f"_{SegArray.objType}_" in name:
                 SegArray.unregister_segarray_by_name(name)
 
         unregister_pdarray_by_name(f"df_index_{user_defined_name}_key")
@@ -2374,7 +2375,7 @@ class DataFrame(UserDict):
         """
         nameParts = entryName.split(" ")
         regName = nameParts[1] if len(nameParts) > 1 else nameParts[0]
-
+        print(nameParts)
         colParts = regName.split("_")
         colType = colParts[2]
 
@@ -2413,7 +2414,7 @@ class DataFrame(UserDict):
 
         # index could be a pdarray or a Strings
         idxType = parts[3].split()[2]
-        if idxType == Strings.objtype:
+        if idxType == "str":  # TODO - we should update the create statment to check for Strings.objType here
             idx = Index.factory(Strings.from_return_msg(f"{parts[3]}+{parts[4]}"))
             i = 5
         else:  # pdarray

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -2290,7 +2290,6 @@ class DataFrame(UserDict):
         index_resp = cast(
             str, generic_msg(cmd="attach", args={"name": f"df_index_{user_defined_name}_key"})
         )
-        print(index_resp)
         dtype = index_resp.split()[2]
         if dtype == "str":  # TODO - this should be updated in the future to Strings
             ind = Strings.from_return_msg(index_resp)

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -2375,7 +2375,6 @@ class DataFrame(UserDict):
         """
         nameParts = entryName.split(" ")
         regName = nameParts[1] if len(nameParts) > 1 else nameParts[0]
-        print(nameParts)
         colParts = regName.split("_")
         colType = colParts[2]
 
@@ -2414,7 +2413,9 @@ class DataFrame(UserDict):
 
         # index could be a pdarray or a Strings
         idxType = parts[3].split()[2]
-        if idxType == "str":  # TODO - we should update the create statment to check for Strings.objType here
+        if (
+            idxType == "str"
+        ):  # TODO - we should update the create statment to check for Strings.objType here
             idx = Index.factory(Strings.from_return_msg(f"{parts[3]}+{parts[4]}"))
             i = 5
         else:  # pdarray
@@ -2435,7 +2436,7 @@ class DataFrame(UserDict):
 
             elif parts[i] == "categorical":
                 colName = DataFrame._parse_col_name(parts[i + 1], dfName)[0]
-                cols[colName] = Categorical.from_return_msg(parts[i+2] + "+" + parts[i+3])
+                cols[colName] = Categorical.from_return_msg(parts[i + 2] + "+" + parts[i + 3])
                 i += 3
 
             elif parts[i] == "segarray":

--- a/arkouda/decorators.py
+++ b/arkouda/decorators.py
@@ -1,3 +1,0 @@
-def objtypedec(orig_cls):
-    orig_cls.objtype = orig_cls.__name__
-    return orig_cls

--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -252,7 +252,6 @@ class GroupBy:
 
         self.logger = getArkoudaLogger(name=self.__class__.__name__)
         self.assume_sorted = assume_sorted
-        # TODO - add case where uki provided instead of unique_keys
         if (
             "orig_keys" in kwargs
             and "permutation" in kwargs
@@ -380,8 +379,8 @@ class GroupBy:
 
         GroupBy is not currently supported by Parquet
         """
-        from arkouda.io import _file_type_to_int, _mode_str_to_int
         from arkouda.categorical import Categorical as Categorical_
+        from arkouda.io import _file_type_to_int, _mode_str_to_int
 
         keys = self.keys
         if not isinstance(self.keys, Sequence):
@@ -429,7 +428,12 @@ class GroupBy:
         dataset: str = "groupby",
         repack: bool = True,
     ):
-        from arkouda.io import _mode_str_to_int, _file_type_to_int, _get_hdf_filetype, _repack_hdf
+        from arkouda.io import (
+            _file_type_to_int,
+            _get_hdf_filetype,
+            _mode_str_to_int,
+            _repack_hdf,
+        )
 
         # determine the format (single/distribute) that the file was saved in
         file_type = _get_hdf_filetype(prefix_path + "*")
@@ -1507,8 +1511,8 @@ class GroupBy:
         TypeError
             Raised if values is or contains Strings or Categorical
         """
-        from arkouda.segarray import SegArray
         from arkouda import Categorical
+        from arkouda.segarray import SegArray
 
         if isinstance(values, (Strings, Categorical)) or (
             isinstance(values, Sequence) and any([isinstance(v, (Strings, Categorical)) for v in values])

--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -334,13 +334,11 @@ class GroupBy:
                 continue
             comps = create_data.split("+|+")
             if comps[0] == "pdarray":
-                print(comps[1])
                 keys.append(create_pdarray(comps[1]))
             elif comps[0] == "seg_string":
                 keys.append(Strings.from_return_msg(comps[1]))
             elif comps[0] == "categorical":
                 keys.append(Categorical_.from_return_msg(comps[1]))
-        print(keys)
         if len(keys) == 1:
             keys = keys[0]
         return GroupBy(orig_keys=keys, permutation=perm, segments=segs, uki=uki)
@@ -428,7 +426,7 @@ class GroupBy:
     def update_hdf(
         self,
         prefix_path: str,
-        dataset: str = "strings_array",
+        dataset: str = "groupby",
         repack: bool = True,
     ):
         from arkouda.io import _mode_str_to_int, _file_type_to_int, _get_hdf_filetype, _repack_hdf
@@ -476,6 +474,7 @@ class GroupBy:
                 "filename": prefix_path,
                 "objType": "groupby",
                 "file_format": _file_type_to_int(file_type),
+                "overwrite": True,
             },
         )
 

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -694,7 +694,7 @@ def read_parquet(
     pdarray,
     Strings,
     SegArray,
-   ArrayView,
+    ArrayView,
     Categorical,
     Mapping[str, Union[pdarray, Strings, SegArray, ArrayView, Categorical]],
 ]:

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -8,14 +8,14 @@ import pandas as pd  # type: ignore
 from typeguard import typechecked
 
 import arkouda.array_view
+from arkouda.array_view import ArrayView
 from arkouda.categorical import Categorical
-from arkouda.groupbyclass import GroupBy
 from arkouda.client import generic_msg
+from arkouda.groupbyclass import GroupBy
 from arkouda.pdarrayclass import create_pdarray, pdarray
 from arkouda.pdarraycreation import array
 from arkouda.segarray import SegArray
 from arkouda.strings import Strings
-from arkouda.array_view import ArrayView
 
 __all__ = [
     "get_filetype",

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -7,7 +7,6 @@ from warnings import warn
 import pandas as pd  # type: ignore
 from typeguard import typechecked
 
-import arkouda.array_view
 from arkouda.array_view import ArrayView
 from arkouda.categorical import Categorical
 from arkouda.client import generic_msg
@@ -436,7 +435,7 @@ def _parse_errors(rep_msg, allow_errors: bool = False):
 
 def _parse_obj(
     obj: Dict,
-) -> Union[Strings, pdarray, arkouda.array_view.ArrayView, SegArray, Categorical]:
+) -> Union[Strings, pdarray, ArrayView, SegArray, Categorical]:
     """
     Helper function to create an Arkouda object from read response
 
@@ -464,7 +463,7 @@ def _parse_obj(
         components = obj["created"].split("+")
         flat = create_pdarray(components[0])
         shape = create_pdarray(components[1])
-        return arkouda.array_view.ArrayView(flat, shape)
+        return ArrayView(flat, shape)
     elif "categorical" == obj["arkouda_type"]:
         return Categorical.from_return_msg(obj["created"])
     elif "groupby" == obj["arkouda_type"]:
@@ -516,9 +515,9 @@ def _build_objects(
     Strings,
     pdarray,
     SegArray,
-    arkouda.array_view.ArrayView,
+    ArrayView,
     Categorical,
-    Mapping[str, Union[Strings, pdarray, SegArray, arkouda.array_view.ArrayView, Categorical]],
+    Mapping[str, Union[Strings, pdarray, SegArray, ArrayView, Categorical]],
 ]:
     """
     Helper function to create the Arkouda objects from a read operation
@@ -566,9 +565,9 @@ def read_hdf(
     pdarray,
     Strings,
     SegArray,
-    arkouda.array_view.ArrayView,
+    ArrayView,
     Categorical,
-    Mapping[str, Union[pdarray, Strings, SegArray, arkouda.array_view.ArrayView, Categorical]],
+    Mapping[str, Union[pdarray, Strings, SegArray, ArrayView, Categorical]],
 ]:
     """
     Read Arkouda objects from HDF5 file/s
@@ -695,9 +694,9 @@ def read_parquet(
     pdarray,
     Strings,
     SegArray,
-    arkouda.array_view.ArrayView,
+   ArrayView,
     Categorical,
-    Mapping[str, Union[pdarray, Strings, SegArray, arkouda.array_view.ArrayView, Categorical]],
+    Mapping[str, Union[pdarray, Strings, SegArray, ArrayView, Categorical]],
 ]:
     """
     Read Arkouda objects from Parquet file/s
@@ -822,9 +821,9 @@ def read_csv(
     pdarray,
     Strings,
     SegArray,
-    arkouda.array_view.ArrayView,
+    ArrayView,
     Categorical,
-    Mapping[str, Union[pdarray, Strings, SegArray, arkouda.array_view.ArrayView, Categorical]],
+    Mapping[str, Union[pdarray, Strings, SegArray, ArrayView, Categorical]],
 ]:
     """
     Read CSV file(s) into Arkouda objects. If more than one dataset is found, the objects
@@ -1510,9 +1509,9 @@ def load(
     pdarray,
     Strings,
     SegArray,
-    arkouda.array_view.ArrayView,
+    ArrayView,
     Categorical,
-    Mapping[str, Union[pdarray, Strings, SegArray, arkouda.array_view.ArrayView, Categorical]],
+    Mapping[str, Union[pdarray, Strings, SegArray, ArrayView, Categorical]],
 ]:
     """
     Load a pdarray previously saved with ``pdarray.save()``.
@@ -1701,9 +1700,9 @@ def read(
     pdarray,
     Strings,
     SegArray,
-    arkouda.array_view.ArrayView,
+    ArrayView,
     Categorical,
-    Mapping[str, Union[pdarray, Strings, SegArray, arkouda.array_view.ArrayView, Categorical]],
+    Mapping[str, Union[pdarray, Strings, SegArray, ArrayView, Categorical]],
 ]:
     """
     Read datasets from files.

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -9,6 +9,7 @@ from typeguard import typechecked
 
 import arkouda.array_view
 from arkouda.categorical import Categorical
+from arkouda.groupbyclass import GroupBy
 from arkouda.client import generic_msg
 from arkouda.pdarrayclass import create_pdarray, pdarray
 from arkouda.pdarraycreation import array
@@ -466,6 +467,8 @@ def _parse_obj(
         return arkouda.array_view.ArrayView(flat, shape)
     elif "categorical" == obj["arkouda_type"]:
         return Categorical.from_return_msg(obj["created"])
+    elif "groupby" == obj["arkouda_type"]:
+        return GroupBy.from_return_msg(obj["created"])
     else:
         raise TypeError(f"Unknown arkouda type:{obj['arkouda_type']}")
 
@@ -1848,6 +1851,10 @@ def read_tagged_data(
         SegArray (or other nested Parquet columns) will be ignored.
         Ignored if datasets is not `None`
         Parquet Files only.
+
+    Notes
+    ------
+    Not currently supported for Categorical or GroupBy datasets
 
     Examples
     ---------

--- a/arkouda/matcher.py
+++ b/arkouda/matcher.py
@@ -26,7 +26,7 @@ class Matcher:
     )
 
     def __init__(self, pattern: str_scalars, parent_entry_name: str) -> None:
-        self.objtype = type(self).__name__
+        self.objType = type(self).__name__
         try:
             self.pattern = pattern
             re.compile(self.pattern)
@@ -59,7 +59,7 @@ class Matcher:
                 generic_msg(
                     cmd="segmentedFindLoc",
                     args={
-                        "objType": self.objtype,
+                        "objType": self.objType,
                         "parent_name": self.parent_entry_name,
                         "groupNum": 0,  # groupNum is 0 for regular matches
                         "pattern": self.pattern,
@@ -123,7 +123,7 @@ class Matcher:
                 cmd=cmd,
                 args={
                     "parent_name": self.parent_entry_name,
-                    "objtype": self.objtype,
+                    "objtype": self.objType,
                     "max": maxsplit,
                     "return_segs": return_segments,
                     "pattern": self.pattern,
@@ -148,7 +148,7 @@ class Matcher:
             generic_msg(
                 cmd="segmentedFindAll",
                 args={
-                    "objType": self.objtype,
+                    "objType": self.objType,
                     "parent_name": self.parent_entry_name,
                     "num_matches": self.num_matches,
                     "starts": self.starts,
@@ -178,7 +178,7 @@ class Matcher:
             generic_msg(
                 cmd="segmentedSub",
                 args={
-                    "objType": self.objtype,
+                    "objType": self.objType,
                     "obj": self.parent_entry_name,
                     "repl": repl,
                     "count": count,

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -106,10 +106,8 @@ def cast(
 
     if isinstance(pda, pdarray):
         name = pda.name
-        objtype = "pdarray"
     elif isinstance(pda, Strings):
         name = pda.entry.name
-        objtype = "str"
     # typechecked decorator guarantees no other case
 
     dt = _as_dtype(dt)
@@ -118,7 +116,7 @@ def cast(
         cmd=cmd,
         args={
             "name": name,
-            "objType": objtype,
+            "objType": pda.objType,
             "targetDtype": dt.name,
             "opt": errors.name,
         },
@@ -485,7 +483,7 @@ def hash(
             cmd="efuncArr",
             args={
                 "nameslist": [n.name for n in pda],
-                "typeslist": [n.objtype for n in pda],
+                "typeslist": [n.objType for n in pda],
                 "length": len(pda),
                 "size": len(pda[0]),
             },

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -168,7 +168,7 @@ class pdarray:
         ]
     )
     OpEqOps = frozenset(["+=", "-=", "*=", "/=", "%=", "//=", "&=", "|=", "^=", "<<=", ">>=", "**="])
-    objtype = "pdarray"
+    objType = "pdarray"
 
     __array_priority__ = 1000
 

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -324,13 +324,13 @@ def concatenate(
             raise TypeError("arrays must be an iterable of pdarrays or Strings")
         if objtype is None:
             objtype = a.objType
-        if objtype == "pdarray":
+        if objtype == pdarray.objType:
             if dtype is None:
                 dtype = a.dtype
             elif dtype != a.dtype:
                 raise ValueError("All pdarrays must have same dtype")
             names.append(cast(pdarray, a).name)
-        elif objtype == "Strings":
+        elif objtype == Strings.objType:
             names.append(cast(Strings, a).entry.name)
         else:
             raise NotImplementedError(f"concatenate not implemented for object type {objtype}")
@@ -349,9 +349,9 @@ def concatenate(
             "mode": mode,
             "names": names,
         })
-    if objtype == "pdarray":
+    if objtype == pdarray.objType:
         return callback(create_pdarray(cast(str, repMsg)))
-    elif objtype == "Strings":
+    elif objtype == Strings.objType:
         # ConcatenateMsg returns created attrib(name)+created nbytes=123
         return Strings.from_return_msg(cast(str, repMsg))
     else:

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -112,9 +112,9 @@ def _in1d_single(
         repMsg = generic_msg(
             cmd="segmentedIn1d",
             args={
-                "objType": pda1.objtype,
+                "objType": pda1.objType,
                 "obj": pda1.entry,
-                "otherType": pda2.objtype,
+                "otherType": pda2.objType,
                 "other": pda2.entry,
                 "invert": invert,
             },
@@ -323,14 +323,14 @@ def concatenate(
         if not isinstance(a, pdarray) and not isinstance(a, Strings):
             raise TypeError("arrays must be an iterable of pdarrays or Strings")
         if objtype is None:
-            objtype = a.objtype
+            objtype = a.objType
         if objtype == "pdarray":
             if dtype is None:
                 dtype = a.dtype
             elif dtype != a.dtype:
                 raise ValueError("All pdarrays must have same dtype")
             names.append(cast(pdarray, a).name)
-        elif objtype == "str":
+        elif objtype == "Strings":
             names.append(cast(Strings, a).entry.name)
         else:
             raise NotImplementedError(f"concatenate not implemented for object type {objtype}")
@@ -351,7 +351,7 @@ def concatenate(
         })
     if objtype == "pdarray":
         return callback(create_pdarray(cast(str, repMsg)))
-    elif objtype == "str":
+    elif objtype == "Strings":
         # ConcatenateMsg returns created attrib(name)+created nbytes=123
         return Strings.from_return_msg(cast(str, repMsg))
     else:

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -1019,13 +1019,6 @@ class SegArray:
         -------
         None
 
-        Notes
-        -----
-        Unlike for ak.Strings, SegArray is saved as two datasets in the top level of
-        the HDF5 file, not nested under a group.
-
-        SegArray is not currently supported by Parquet
-
         See Also
         ---------
         load

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -8,7 +8,6 @@ from warnings import warn
 
 import numpy as np  # type: ignore
 
-from arkouda import objtypedec
 from arkouda.client import generic_msg
 from arkouda.dtypes import bool as akbool
 from arkouda.dtypes import int64 as akint64
@@ -97,8 +96,9 @@ def segarray(segments: pdarray, values: pdarray, lengths=None, grouping=None):
     return SegArray.from_parts(segments, values, lengths, grouping)
 
 
-@objtypedec
 class SegArray:
+    objType = "SegArray"
+
     def __init__(
         self, name, dtype, size, ndim, shape, itemsize, segments, values, lengths=None, grouping=None
     ):
@@ -280,10 +280,6 @@ class SegArray:
             return cls.from_parts(arange(size) * n, newvals)
 
     @property
-    def objtype(self):
-        return self.objtype
-
-    @property
     def lengths(self):
         """
         Return the pdarray containing the lengths of the segments.
@@ -437,7 +433,7 @@ class SegArray:
                     cmd="segmentedIndex",
                     args={
                         "subcmd": "intIndex",
-                        "objType": self.objtype,
+                        "objType": self.objType,
                         "dtype": self.dtype,
                         "obj": self.name,
                         "key": i,
@@ -453,7 +449,7 @@ class SegArray:
                 cmd="segmentedIndex",
                 args={
                     "subcmd": "sliceIndex",
-                    "objType": self.objtype,
+                    "objType": self.objType,
                     "obj": self.name,
                     "dtype": self.dtype,
                     "key": [start, stop, stride],
@@ -470,7 +466,7 @@ class SegArray:
                 cmd="segmentedIndex",
                 args={
                     "subcmd": "pdarrayIndex",
-                    "objType": self.objtype,
+                    "objType": self.objType,
                     "dtype": self.values.dtype,
                     "obj": self.name,
                     "key": i,
@@ -1640,7 +1636,7 @@ class SegArray:
             cmd="attach",
             args={
                 "name": user_defined_name,
-                "objtype": SegArray.objtype,
+                "objtype": SegArray.objType,
             },
         )
         return cls.from_return_msg(repMsg)

--- a/arkouda/sorting.py
+++ b/arkouda/sorting.py
@@ -70,7 +70,7 @@ def argsort(
         args={
             "name": pda.entry.name if isinstance(pda, Strings) else pda.name,
             "algoName": algorithm.name,
-            "objType": pda.objtype,
+            "objType": pda.objType,
         },
     )
     return create_pdarray(cast(str, repMsg))
@@ -145,12 +145,12 @@ def coargsort(
     for a in expanded_arrays:
         if isinstance(a, pdarray):
             anames.append("+".join(a._list_component_names()))
-            atypes.append(a.objtype)
+            atypes.append(a.objType)
         elif isinstance(a, Categorical):
             anames.append(a.codes.name)
-            atypes.append(a.objtype)
+            atypes.append(a.objType)
         elif isinstance(a, Strings):
-            atypes.append(a.objtype)
+            atypes.append(a.objType)
             anames.append(a.entry.name)
         else:
             raise ValueError("Argument must be an iterable of pdarrays, Strings, or Categoricals")

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -69,7 +69,7 @@ class Strings:
     """
 
     BinOps = frozenset(["==", "!="])
-    objtype = "str"
+    objType = "Strings"
 
     @staticmethod
     def from_return_msg(rep_msg: str) -> Strings:
@@ -253,9 +253,9 @@ class Strings:
             cmd = "segmentedBinopvv"
             args = {
                 "op": op,
-                "objType": self.objtype,
+                "objType": self.objType,
                 "obj": self.entry,
-                "otherType": other.objtype,
+                "otherType": other.objType,
                 "other": other.entry,
                 "left": False,  # placeholder for stick
                 "delim": "",  # placeholder for stick
@@ -264,9 +264,9 @@ class Strings:
             cmd = "segmentedBinopvs"
             args = {
                 "op": op,
-                "objType": self.objtype,
+                "objType": self.objType,
                 "obj": self.entry,
-                "otherType": self.objtype,
+                "otherType": "str",
                 "other": other,
             }
         else:
@@ -292,7 +292,7 @@ class Strings:
                     cmd="segmentedIndex",
                     args={
                         "subcmd": "intIndex",
-                        "objType": self.objtype,
+                        "objType": self.objType,
                         "dtype": self.entry.dtype,
                         "obj": self.entry,
                         "key": key,
@@ -309,7 +309,7 @@ class Strings:
                 cmd="segmentedIndex",
                 args={
                     "subcmd": "sliceIndex",
-                    "objType": self.objtype,
+                    "objType": self.objType,
                     "obj": self.entry,
                     "dtype": self.entry.dtype,
                     "key": [start, stop, stride],
@@ -326,7 +326,7 @@ class Strings:
                 cmd="segmentedIndex",
                 args={
                     "subcmd": "pdarrayIndex",
-                    "objType": self.objtype,
+                    "objType": self.objType,
                     "dtype": self.entry.dtype,
                     "obj": self.entry,
                     "key": key,
@@ -351,7 +351,7 @@ class Strings:
             Raised if there is a server-side error thrown
         """
         return create_pdarray(
-            generic_msg(cmd="segmentLengths", args={"objType": self.objtype, "obj": self.entry})
+            generic_msg(cmd="segmentLengths", args={"objType": self.objType, "obj": self.entry})
         )
 
     def encode(self, toEncoding: str, fromEncoding: str = "UTF-8"):
@@ -466,7 +466,7 @@ class Strings:
         array(['strings 0', 'strings 1', 'strings 2', 'strings 3', 'strings 4'])
         """
         rep_msg = generic_msg(
-            cmd="caseChange", args={"subcmd": "toLower", "objType": self.objtype, "obj": self.entry}
+            cmd="caseChange", args={"subcmd": "toLower", "objType": self.objType, "obj": self.entry}
         )
         return Strings.from_return_msg(cast(str, rep_msg))
 
@@ -500,7 +500,7 @@ class Strings:
         array(['STRINGS 0', 'STRINGS 1', 'STRINGS 2', 'STRINGS 3', 'STRINGS 4'])
         """
         rep_msg = generic_msg(
-            cmd="caseChange", args={"subcmd": "toUpper", "objType": self.objtype, "obj": self.entry}
+            cmd="caseChange", args={"subcmd": "toUpper", "objType": self.objType, "obj": self.entry}
         )
         return Strings.from_return_msg(cast(str, rep_msg))
 
@@ -533,7 +533,7 @@ class Strings:
         array(['Strings 0', 'Strings 1', 'Strings 2', 'Strings 3', 'Strings 4'])
         """
         rep_msg = generic_msg(
-            cmd="caseChange", args={"subcmd": "toTitle", "objType": self.objtype, "obj": self.entry}
+            cmd="caseChange", args={"subcmd": "toTitle", "objType": self.objType, "obj": self.entry}
         )
         return Strings.from_return_msg(cast(str, rep_msg))
 
@@ -569,7 +569,7 @@ class Strings:
         """
         return create_pdarray(
             generic_msg(
-                cmd="checkChars", args={"subcmd": "isLower", "objType": self.objtype, "obj": self.entry}
+                cmd="checkChars", args={"subcmd": "isLower", "objType": self.objType, "obj": self.entry}
             )
         )
 
@@ -605,7 +605,7 @@ class Strings:
         """
         return create_pdarray(
             generic_msg(
-                cmd="checkChars", args={"subcmd": "isUpper", "objType": self.objtype, "obj": self.entry}
+                cmd="checkChars", args={"subcmd": "isUpper", "objType": self.objType, "obj": self.entry}
             )
         )
 
@@ -642,7 +642,7 @@ class Strings:
         """
         return create_pdarray(
             generic_msg(
-                cmd="checkChars", args={"subcmd": "isTitle", "objType": self.objtype, "obj": self.entry}
+                cmd="checkChars", args={"subcmd": "isTitle", "objType": self.objType, "obj": self.entry}
             )
         )
 
@@ -685,7 +685,7 @@ class Strings:
         if isinstance(chars, bytes):
             chars = chars.decode()
         rep_msg = generic_msg(
-            cmd="segmentedStrip", args={"objType": self.objtype, "name": self.entry, "chars": chars}
+            cmd="segmentedStrip", args={"objType": self.objType, "name": self.entry, "chars": chars}
         )
         return Strings.from_return_msg(cast(str, rep_msg))
 
@@ -1083,7 +1083,7 @@ class Strings:
         return create_pdarray(
             generic_msg(
                 cmd="segmentedSearch",
-                args={"objType": self.objtype, "obj": self.entry, "valType": "str", "val": substr},
+                args={"objType": self.objType, "obj": self.entry, "valType": "str", "val": substr},
             )
         )
 
@@ -1253,7 +1253,7 @@ class Strings:
                     cmd=cmd,
                     args={
                         "values": self.entry,
-                        "objtype": self.objtype,
+                        "objtype": self.objType,
                         "return_segs": return_segments,
                         "regex": regex,
                         "delim": delimiter,
@@ -1357,7 +1357,7 @@ class Strings:
             cmd="segmentedPeel",
             args={
                 "subcmd": "peel",
-                "objType": self.objtype,
+                "objType": self.objType,
                 "obj": self.entry,
                 "valType": "str",
                 "times": NUMBER_FORMAT_STRINGS["int64"].format(times),
@@ -1498,9 +1498,9 @@ class Strings:
             cmd="segmentedBinopvv",
             args={
                 "op": "stick",
-                "objType": self.objtype,
+                "objType": self.objType,
                 "obj": self.entry,
-                "otherType": other.objtype,
+                "otherType": other.objType,
                 "other": other.entry,
                 "left": NUMBER_FORMAT_STRINGS["bool"].format(toLeft),
                 "delim": delimiter,
@@ -1586,7 +1586,7 @@ class Strings:
             generic_msg(
                 cmd="segmentedSubstring",
                 args={
-                    "objType": self.objtype,
+                    "objType": self.objType,
                     "name": self,
                     "nChars": n,
                     "returnOrigins": return_origins,
@@ -1635,7 +1635,7 @@ class Strings:
             generic_msg(
                 cmd="segmentedSubstring",
                 args={
-                    "objType": self.objtype,
+                    "objType": self.objType,
                     "name": self,
                     "nChars": n,
                     "returnOrigins": return_origins,
@@ -1670,7 +1670,7 @@ class Strings:
         values is negligible.
         """
         # TODO fix this to return a single pdarray of hashes
-        repMsg = generic_msg(cmd="segmentedHash", args={"objType": self.objtype, "obj": self.entry})
+        repMsg = generic_msg(cmd="segmentedHash", args={"objType": self.objType, "obj": self.entry})
         h1, h2 = cast(str, repMsg).split("+")
         return create_pdarray(h1), create_pdarray(h2)
 
@@ -1705,7 +1705,7 @@ class Strings:
             creating the pdarray encapsulating the return message
         """
         return create_pdarray(
-            generic_msg(cmd="segmentedGroup", args={"objType": self.objtype, "obj": self.entry})
+            generic_msg(cmd="segmentedGroup", args={"objType": self.objType, "obj": self.entry})
         )
 
     def _get_grouping_keys(self) -> List[Strings]:

--- a/pydoc/file_io/HDF5.md
+++ b/pydoc/file_io/HDF5.md
@@ -26,6 +26,7 @@ While most objects in Arkouda can be saved, there are 3 main datatypes currently
 - Index
 - Categorical
 - SegArray
+- GroupBy
 
 HDF5 is able to contain any number of objects within the same file.
 
@@ -40,6 +41,8 @@ All data within the HDF5 file is expected to contain several attributes that aid
 - 1 = `pdarray`
 - 2 = `Strings`
 - 3 = `SegArray`
+- 4 = `Categorical`
+- 5 = `GroupBy`
 
 `isBool`: `int`
 > Integer value (0 or 1) representing a boolean value that indicates if the data stored contains boolean values. This is only required to be set when the dataset contains boolean values.
@@ -142,6 +145,89 @@ Providing these attributes allows for the ArrayView object to be reconstructed f
 >               4. arkouda_version: 'current_arkouda_version' (Optional)
 >           2. Data - int64 values representing the start index of each segmented value.
 
+### Categorical
+
+`Categorical` objects are stored within an HDF5 group. This group contains datasets storing the components of the Categorical.
+
+>1. Group (user provided dataset name. Defaults to 'categorical')
+>       1. Attributes
+>           1. ObjType: 4
+>           2. file_version: 2.0 (Optional)
+>           3. arkouda_version: 'current_arkouda_version' (Optional)
+>       2. Dataset - Codes
+>           1. Attributes
+>               1. ObjType: 1
+>               2. isBool: 0
+>               3. file_version: 2.0 (Optional)
+>               4. arkouda_version: 'current_arkouda_version' (Optional)
+>           2. Data - int64 values representing our codes of the Categorical.
+>       3. Dataset - Categories
+>           1. Attributes
+>               1. ObjType: 2
+>               2. isBool: 0
+>               3. file_version: 2.0 (Optional)
+>               4. arkouda_version: 'current_arkouda_version' (Optional)
+>           2. Data - Strings group representing the categories of the Categorical.
+>       4. Dataset - NA_Codes
+>           1. Attributes
+>               1. ObjType: 1
+>               2. isBool: 0
+>               3. file_version: 2.0 (Optional)
+>               4. arkouda_version: 'current_arkouda_version' (Optional)
+>           2. Data - int64 values representing the index in of categories with NA value.
+>       5. Dataset - Permutaion (Optional. Only include if Categorical object has permutation property)
+>           1. Attributes
+>               1. ObjType: 1
+>               2. isBool: 0
+>               3. file_version: 2.0 (Optional)
+>               4. arkouda_version: 'current_arkouda_version' (Optional)
+>           2. Data - int64 values representing the permutation of the categories.
+>       6. Dataset - Segments (Optional. Only include if Categorical object has segments property)
+>           1. Attributes
+>               1. ObjType: 1
+>               2. isBool: 0
+>               3. file_version: 2.0 (Optional)
+>               4. arkouda_version: 'current_arkouda_version' (Optional)
+>           2. Data - int64 values representing the start index of category segments.
+
+### GroupBy
+
+`GroupBy` objects are stored within an HDF5 group. This group contains datasets storing the components of the GroupBy.
+
+>1. Group (user provided dataset name. Defaults to 'groupby')
+>       1. Attributes
+>           1. ObjType: 5
+>           2. file_version: 2.0 (Optional)
+>           3. arkouda_version: 'current_arkouda_version' (Optional)
+>       2. Dataset - Permutaion
+>           1. Attributes
+>               1. ObjType: 1
+>               2. isBool: 0
+>               3. file_version: 2.0 (Optional)
+>               4. arkouda_version: 'current_arkouda_version' (Optional)
+>           2. Data - int64 values representing the permutation of the GroupBy.
+>       3. Dataset - Segments
+>           1. Attributes
+>               1. ObjType: 1
+>               2. isBool: 0
+>               3. file_version: 2.0 (Optional)
+>               4. arkouda_version: 'current_arkouda_version' (Optional)
+>           2. Data - int64 values representing the start index of GroupBy segments.
+>       4. Dataset - unique_key_idx
+>           1. Attributes
+>               1. ObjType: 1
+>               2. isBool: 0
+>               3. file_version: 2.0 (Optional)
+>               4. arkouda_version: 'current_arkouda_version' (Optional)
+>           2. Data - int64 values representing the index of Unique keys in the GroupBy.
+>       5. Dataset - KEY_# (multiple keys may be present. They will be numbered accordingly)
+>           1. Attributes
+>               1. ObjType: 1, 2, or 4 (pdarray, Strings, or Categorical)
+>               2. isBool: 0 or 1
+>               3. file_version: 2.0 (Optional)
+>               4. arkouda_version: 'current_arkouda_version' (Optional)
+>           2. Data - Key object used to generate the GroupBy. This will be a dataset or group depending on the object type.
+
 ## Supported Write Modes
 
 **Truncate**
@@ -205,4 +291,10 @@ Older version of Arkouda used different schemas for `pdarray` and `Strings` obje
 ```{eval-rst}  
 - :py:meth:`arkouda.SegArray.to_hdf`
 - :py:meth:`arkouda.SegArray.load`
+```
+
+### GroupBy
+
+```{eval-rst}  
+- :py:meth:`arkouda.Categorical.to_hdf`
 ```

--- a/pydoc/file_io/HDF5.md
+++ b/pydoc/file_io/HDF5.md
@@ -175,7 +175,7 @@ Providing these attributes allows for the ArrayView object to be reconstructed f
 >               3. file_version: 2.0 (Optional)
 >               4. arkouda_version: 'current_arkouda_version' (Optional)
 >           2. Data - int64 values representing the index in of categories with NA value.
->       5. Dataset - Permutaion (Optional. Only include if Categorical object has permutation property)
+>       5. Dataset - Permutation (Optional. Only include if Categorical object has permutation property)
 >           1. Attributes
 >               1. ObjType: 1
 >               2. isBool: 0
@@ -199,7 +199,7 @@ Providing these attributes allows for the ArrayView object to be reconstructed f
 >           1. ObjType: 5
 >           2. file_version: 2.0 (Optional)
 >           3. arkouda_version: 'current_arkouda_version' (Optional)
->       2. Dataset - Permutaion
+>       2. Dataset - Permutation
 >           1. Attributes
 >               1. ObjType: 1
 >               2. isBool: 0
@@ -296,5 +296,5 @@ Older version of Arkouda used different schemas for `pdarray` and `Strings` obje
 ### GroupBy
 
 ```{eval-rst}  
-- :py:meth:`arkouda.Categorical.to_hdf`
+- :py:meth:`arkouda.GroupBy.to_hdf`
 ```

--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -283,7 +283,7 @@ module ArgSortMsg
       // Starting with the last array, incrementally permute the IV by sorting each array
       for (i, j) in zip(names.domain.low..names.domain.high by -1,
                         types.domain.low..types.domain.high by -1) {
-        if (types[j] == "str") {
+        if (types[j].toUpper(): ObjType == ObjType.STRINGS) {
           var strings = getSegString(names[i], st);
           iv.a = incrementalArgSort(strings, iv.a);
         } else {
@@ -349,9 +349,9 @@ module ArgSortMsg
         asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                               "cmd: %s name: %s ivname: %s".format(cmd, name, ivname));
 
-        var objtype = msgArgs.getValueOf("objType");
+        var objtype = msgArgs.getValueOf("objType").toUpper(): ObjType;
         select objtype {
-          when "pdarray" {
+          when ObjType.PDARRAY {
             var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(name, st);
             // check and throw if over memory limit
             overMemLimit(radixSortLSD_memEst(gEnt.size, gEnt.itemsize));
@@ -379,7 +379,7 @@ module ArgSortMsg
                 }
             }
           }
-          when "str" {
+          when ObjType.STRINGS {
             var strings = getSegString(name, st);
             // check and throw if over memory limit
             overMemLimit((8 * strings.size * 8)
@@ -388,7 +388,7 @@ module ArgSortMsg
             st.addEntry(ivname, new shared SymEntry(iv));
           }
           otherwise {
-              var errorMsg = notImplementedError(pn, objtype);
+              var errorMsg = notImplementedError(pn, objtype: string);
               asLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                    
               return new MsgTuple(errorMsg, MsgType.ERROR);
           }

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -166,18 +166,18 @@ module AryUtil
       var hasStr = false;
       for (name, objtype, i) in zip(names, types, 1..) {
         var thisSize: int;
-        select objtype {
-          when "pdarray" {
+        select objtype.toUpper(): ObjType {
+          when ObjType.PDARRAY {
             var g = getGenericTypedArrayEntry(name, st);
             thisSize = g.size;
           }
-          when "str" {
+          when ObjType.STRINGS {
             var (myNames, _) = name.splitMsgToTuple('+', 2);
             var g = getSegStringEntry(myNames, st);
             thisSize = g.size;
             hasStr = true;
           }
-          when "Categorical" {
+          when ObjType.CATEGORICAL {
             // passed only Categorical.codes.name to be sorted on
             var g = getGenericTypedArrayEntry(name, st);
             thisSize = g.size;

--- a/src/CastMsg.chpl
+++ b/src/CastMsg.chpl
@@ -18,14 +18,14 @@ module CastMsg {
   proc castMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     param pn = Reflection.getRoutineName();
     var name = msgArgs.getValueOf("name");
-    var objtype = msgArgs.getValueOf("objType");
+    var objtype = msgArgs.getValueOf("objType").toUpper(): ObjType;
     var targetDtype = msgArgs.getValueOf("targetDtype");
     var opt = msgArgs.getValueOf("opt");
     castLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
           "name: %s obgtype: %t targetDtype: %t opt: %t".format(
                                                  name,objtype,targetDtype,opt));
     select objtype {
-      when "pdarray" {
+      when ObjType.PDARRAY {
         var gse: borrowed GenSymEntry = getGenericTypedArrayEntry(name, st);
         select (gse.dtype, targetDtype) {
             when (DType.Int64, "int64") {
@@ -146,7 +146,7 @@ module CastMsg {
             }
         }
       }
-      when "str" {
+      when ObjType.STRINGS {
           const strings = getSegString(name, st);
           const errors = opt.toLower() : ErrorMode;
           select targetDtype {
@@ -176,7 +176,7 @@ module CastMsg {
           }
       }
       otherwise {
-        var errorMsg = notImplementedError(pn,objtype);
+        var errorMsg = notImplementedError(pn,objtype:string);
         castLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                      
         return new MsgTuple(errorMsg, MsgType.ERROR);
       }

--- a/src/ConcatenateMsg.chpl
+++ b/src/ConcatenateMsg.chpl
@@ -29,7 +29,7 @@ module ConcatenateMsg
     proc concatenateMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab) : MsgTuple throws {
         param pn = Reflection.getRoutineName();
         var repMsg: string;
-        var objtype = msgArgs.getValueOf("objType");
+        var objtype = msgArgs.getValueOf("objType").toUpper(): ObjType;
         var mode = msgArgs.getValueOf("mode");
         var n = msgArgs.get("nstr").getIntValue(); // number of arrays to sort
         var names = msgArgs.get("names").getList(n);
@@ -54,7 +54,7 @@ module ConcatenateMsg
         for (name, i) in zip(names, 1..) {
             var valSize: int;
             select objtype {
-                when "str" {
+                when ObjType.STRINGS {
                     try {
                         // get the values/bytes portion of strings
                         var segString = getSegString(name, st);
@@ -71,12 +71,12 @@ module ConcatenateMsg
                     cmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                              "name: %s".format(name));
                 }
-                when "pdarray" {
+                when ObjType.PDARRAY {
                     cmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                  "pdarray name %s".format(name));
                 }
                 otherwise { 
-                    var errorMsg = notImplementedError(pn, objtype); 
+                    var errorMsg = notImplementedError(pn, objtype: string); 
                     cmLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);  
                     return new MsgTuple(errorMsg,MsgType.ERROR);                  
                 }
@@ -111,7 +111,7 @@ module ConcatenateMsg
                    * but it also causes an out of bounds array index due to the 
                    * way the low and high of the empty domain are computed. 
                    */
-                  if (objtype == "str") && (mynumsegs > 0) {
+                  if (objtype == ObjType.STRINGS) && (mynumsegs > 0) {
                     const stringEntry = toSegStringSymEntry(abstractEntry);
                     const e = stringEntry.offsetsEntry;
                     const firstSeg = e.a[e.a.domain.localSubdomain().low];
@@ -147,7 +147,7 @@ module ConcatenateMsg
         // allocate a new array in the symboltable
         // and copy in arrays
         select objtype {
-            when "str" {
+            when ObjType.STRINGS {
                 // var segName = st.nextName();
                 // var esegs = st.addEntry(segName, size, int);
                 // var valName = st.nextName();
@@ -213,7 +213,7 @@ module ConcatenateMsg
                                   "created concatenated pdarray %s".format(st.attrib(retString.name)));
                 return new MsgTuple(repMsg, MsgType.NORMAL);
             }
-            when "pdarray" {
+            when ObjType.PDARRAY {
                 var rname = st.nextName();
                 cmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
                                              "creating pdarray %s of type %t".format(rname,dtype));
@@ -377,7 +377,7 @@ module ConcatenateMsg
                 return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             otherwise { 
-                var errorMsg = notImplementedError(pn, objtype); 
+                var errorMsg = notImplementedError(pn, objtype: string); 
                 cmLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
                 return new MsgTuple(errorMsg, MsgType.ERROR);
             }

--- a/src/DataFrameIndexingMsg.chpl
+++ b/src/DataFrameIndexingMsg.chpl
@@ -119,7 +119,7 @@
                 var code_vals = toSymEntry(gCode, int);
                 var idxCodeName = dfIdxHelper(idx, code_vals, st, col_name, "", true);
                 
-                var repTup = segPdarrayIndex("str", categories_name, idxCodeName, DType.UInt8, st);
+                var repTup = segPdarrayIndex(ObjType.STRINGS, categories_name, idxCodeName, DType.UInt8, st);
                 
                 if repTup.msgType == MsgType.ERROR {
                     throw new IllegalArgumentError(repTup.msg);
@@ -129,7 +129,7 @@
             }
             else if ele_parts[0] == "Strings"{
                 dfiLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"Element at %i is Strings. Name: %s".format(i, ele_parts[2]));
-                var repTup = segPdarrayIndex("str", ele_parts[2], msgArgs.getValueOf("idx_name"), DType.UInt8, st);
+                var repTup = segPdarrayIndex(ObjType.STRINGS, ele_parts[2], msgArgs.getValueOf("idx_name"), DType.UInt8, st);
                 
                 if repTup.msgType == MsgType.ERROR {
                     throw new IllegalArgumentError(repTup.msg);

--- a/src/FlattenMsg.chpl
+++ b/src/FlattenMsg.chpl
@@ -14,13 +14,13 @@ module FlattenMsg {
   const fmLogger = new Logger(logLevel, logChannel);
 
   proc segFlattenMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
-    const objtype = msgArgs.getValueOf("objtype");
+    const objtype = msgArgs.getValueOf("objtype").toUpper(): ObjType;
     const returnSegs: bool = msgArgs.get("return_segs").getBoolValue();
     const regex: bool = msgArgs.get("regex").getBoolValue();
     const delim: string = msgArgs.getValueOf("delim");
     var repMsg: string;
     select objtype {
-      when "str" {
+      when ObjType.STRINGS {
         const rSegName = st.nextName();
         const rValName = st.nextName();
         const strings = getSegString(msgArgs.getValueOf("values"), st);

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -234,7 +234,7 @@ module GenSymIO {
 
     /*
      * Simple JSON parser to allow creating a map(string, string) for properly formatted JSON string.
-     * REQUIRES THAT 
+     * REQUIRES THAT DATA DOES NOT CONTAIN : or ". This will only work on JSON that is not nested.
     */
     proc jsonToMap(json: string): map(string, string) throws {
         // remove components not needed for parsing

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -212,6 +212,9 @@ module GenSymIO {
             else if (akType == "seg_array" || akType == "categorical") {
                 create_str = id;
             } 
+            else if (akType == "groupby") {
+                create_str = id;
+            }
             else {
                 continue;
             }
@@ -227,6 +230,36 @@ module GenSymIO {
             reply.add("file_errors", "%jt".format(fileErrors));
         }
         return "%jt".format(reply);
+    }
+
+    /*
+     * Simple JSON parser to allow creating a map(string, string) for properly formatted JSON string.
+     * REQUIRES THAT 
+    */
+    proc jsonToMap(json: string): map(string, string) throws {
+        // remove components not needed for parsing
+        var clean_json = json.strip().replace("\"", "").replace("{", "").replace("}", ""); // syntax highlight messed up by \".
+
+        // generate the return map
+        var m: map(string, string) = new map(string, string);
+
+        //get each key value pair
+        var key_value = clean_json.split(", ");
+        for kv in key_value  {
+            // split to 2 components key: value
+            var x = kv.split(": ");
+            var key: string;
+            var val: string;
+            for (i, y) in zip(0..#x.size, x){
+                if i == 0 {
+                    key = y; // first component is key
+                } else {
+                    val = y; // 2nd component is value
+                    m.addOrSet(key, val); // add to map
+                }
+            }
+        }
+        return m;
     }
 
 }

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -248,16 +248,7 @@ module GenSymIO {
         for kv in key_value  {
             // split to 2 components key: value
             var x = kv.split(": ");
-            var key: string;
-            var val: string;
-            for (i, y) in zip(0..#x.size, x){
-                if i == 0 {
-                    key = y; // first component is key
-                } else {
-                    val = y; // 2nd component is value
-                    m.addOrSet(key, val); // add to map
-                }
-            }
+            m.addOrSet(x[0], x[1]);
         }
         return m;
     }

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -2084,7 +2084,6 @@ module HDF5Msg {
                         // Not a boolean dataset, so add original SymEntry to SymTable
                         st.addEntry(rname, entryUInt);
                     }
-                    // return (dset, "pdarray", rname);
                 }
                 else {
                     var entryInt = new shared SymEntry(len, int);
@@ -2099,7 +2098,6 @@ module HDF5Msg {
                         // Not a boolean dataset, so add original SymEntry to SymTable
                         st.addEntry(rname, entryInt);
                     }
-                    // return (dset, "pdarray", rname);
                 }
             }
             when C_HDF5.H5T_FLOAT {
@@ -2109,7 +2107,6 @@ module HDF5Msg {
                 read_files_into_distributed_array(entryReal.a, subdoms, filenames, dset, skips);
                 rname = st.nextName();
                 st.addEntry(rname, entryReal);
-                // return (dset, "pdarray", rname);
             }
             otherwise {
                 var errorMsg = "detected unhandled datatype: objType? pdarray, class %i, size %i, " +

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -2395,7 +2395,7 @@ module HDF5Msg {
 
         for k in 0..#numkeys {
             //need to determine object type of the key to determine how to read it
-            var keyObjType: ObjType; //= getObjType(file_id, "%s/KEY_%i".format(dset, i));
+            var keyObjType: ObjType;
             var dataclass: C_HDF5.hid_t;
             var bytesize: int;
             var isSigned: bool;
@@ -2408,7 +2408,6 @@ module HDF5Msg {
                     var pda_name = readPdarrayFromFile(filenames, "%s/KEY_%i".format(dset, k), dataclass, bytesize, isSigned, validFiles, st);
                     readObjType = "pdarray";
                     readCreate = "created %s".format(st.attrib(pda_name));
-                    // (readDset, readObjType, readCreate) = pdarray_readhdfMsg(filenames, "%s/KEY_%i".format(dset, k), dataclass, bytesize, isSigned, validFiles, st);
                 }
                 when ObjType.STRINGS {
                     var segString = readStringsFromFile(filenames, "%s/KEY_%i".format(dset, k), dataclass, bytesize, isSigned, calcStringOffsets, validFiles, st);

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -48,15 +48,6 @@ module HDF5Msg {
     config const PERMUTATION_NAME = "permutation";
     config const CAT_SEGMENTS_NAME = "segments";
 
-    enum ObjType {
-      ARRAYVIEW=0,
-      PDARRAY=1,
-      STRINGS=2,
-      SEGARRAY=3,
-      CATEGORICAL=4,
-      GROUPBY=5
-    };
-
     config const TRUNCATE: int = 0;
     config const APPEND: int = 1;
 
@@ -1084,6 +1075,11 @@ module HDF5Msg {
     }
 
     proc categorical_tohdfMsg(msgArgs: borrowed MessageArgs, st: borrowed SymTab) throws {
+        use C_HDF5.HDF5_WAR;
+        var mode: int = msgArgs.get("write_mode").getIntValue();
+
+        var filename: string = msgArgs.getValueOf("filename");
+        var file_format = msgArgs.get("file_format").getIntValue();
         var group = msgArgs.getValueOf("dset");
         const objType = msgArgs.getValueOf("objType"); // needed for metadata
 
@@ -1214,55 +1210,55 @@ module HDF5Msg {
 
         // access the permutation and segments pdarrays because these are always int
         var seg_entry = st.lookup(msgArgs.getValueOf("segments"));
-        var segments = toSymEntry(toGenSymEntry(entry), int);
+        var segments = toSymEntry(toGenSymEntry(seg_entry), int);
         var perm_entry = st.lookup(msgArgs.getValueOf("permutation"));
-        var perm = toSymEntry(toGenSymEntry(entry), int);
+        var perm = toSymEntry(toGenSymEntry(perm_entry), int);
 
         // create the group
-        select file_format {
-            when SINGLE_FILE {
-                validateGroup(file_id, f, group);
-                var dtype: C_HDF5.hid_t;
+        // select file_format {
+        //     when SINGLE_FILE {
+        //         validateGroup(file_id, f, group);
+        //         var dtype: C_HDF5.hid_t;
 
-                select val_dtype {
-                    when (DType.Int64) {
+        //         select val_dtype {
+        //             when (DType.Int64) {
                     
-                    }
-                    when (DType.UInt64) {
+        //             }
+        //             when (DType.UInt64) {
 
-                    }
-                    when (DType.Float64) {
+        //             }
+        //             when (DType.Float64) {
 
-                    }
-                    when (DType.Bool) {
+        //             }
+        //             when (DType.Bool) {
 
-                    }
-                    when (DType.Strings) {
+        //             }
+        //             when (DType.Strings) {
 
-                    }
-                    otherwise {
-                        throw getErrorWithContext(
-                           msg="Unsupported DType %s".format(dtype2str(key_dtype)),
-                           lineNumber=getLineNumber(),
-                           routineName=getRoutineName(), 
-                           moduleName=getModuleName(),
-                           errorClass="IllegalArgumentError");
-                    }
-                }
+        //             }
+        //             otherwise {
+        //                 throw getErrorWithContext(
+        //                    msg="Unsupported DType %s".format(dtype2str(key_dtype)),
+        //                    lineNumber=getLineNumber(),
+        //                    routineName=getRoutineName(), 
+        //                    moduleName=getModuleName(),
+        //                    errorClass="IllegalArgumentError");
+        //             }
+        //         }
 
-            }
-            when MULTI_FILE {
+        //     }
+        //     when MULTI_FILE {
 
-            }
-            otherwise {
-                throw getErrorWithContext(
-                           msg="Unknown file format. Expecting 0 (single file) or 1 (file per locale). Found %i".format(file_format),
-                           lineNumber=getLineNumber(),
-                           routineName=getRoutineName(), 
-                           moduleName=getModuleName(),
-                           errorClass="IllegalArgumentError");
-            }
-        }
+        //     }
+        //     otherwise {
+        //         throw getErrorWithContext(
+        //                    msg="Unknown file format. Expecting 0 (single file) or 1 (file per locale). Found %i".format(file_format),
+        //                    lineNumber=getLineNumber(),
+        //                    routineName=getRoutineName(), 
+        //                    moduleName=getModuleName(),
+        //                    errorClass="IllegalArgumentError");
+        //     }
+        // }
     }
 
 

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -46,7 +46,8 @@ module HDF5Msg {
     config const CODES_NAME = "codes";
     config const NACODES_NAME = "NA_Codes";
     config const PERMUTATION_NAME = "permutation";
-    config const CAT_SEGMENTS_NAME = "segments";
+    config const SEGMENTS_NAME = "segments";
+    config const UKI_NAME = "unique_key_idx";
 
     config const TRUNCATE: int = 0;
     config const APPEND: int = 1;
@@ -245,7 +246,7 @@ module HDF5Msg {
         }
         else if dset_exists > 0 {
             throw getErrorWithContext(
-                           msg=" group named %s already exists in %s. If you would like to overwrite the group please use update_hdf.".format(dset_name, filename),
+                           msg=" Dataset named %s already exists in %s. If you would like to overwrite the group please use update_hdf.".format(dset_name, filename),
                            lineNumber=getLineNumber(),
                            routineName=getRoutineName(), 
                            moduleName=getModuleName(),
@@ -342,6 +343,66 @@ module HDF5Msg {
             C_HDF5.H5Awrite(attr_id, getHDF5Type(int), c_ptrTo(isBool));
             C_HDF5.H5Aclose(attr_id);
         }
+
+        var attrFileVersionType = getHDF5Type(ARKOUDA_HDF5_FILE_VERSION_TYPE);
+        var attrId = C_HDF5.H5Acreate2(obj_id,
+                          ARKOUDA_HDF5_FILE_VERSION_KEY.c_str(),
+                          attrFileVersionType,
+                          attrSpaceId,
+                          C_HDF5.H5P_DEFAULT,
+                          C_HDF5.H5P_DEFAULT);
+        
+        // H5Awrite requires a pointer and we have a const, so we need a variable ref we can turn into a pointer
+        var fileVersion = ARKOUDA_HDF5_FILE_VERSION_VAL;
+        C_HDF5.H5Awrite(attrId, attrFileVersionType, c_ptrTo(fileVersion));
+        C_HDF5.H5Aclose(attrId);
+
+        var attrStringType = C_HDF5.H5Tcopy(C_HDF5.H5T_C_S1): C_HDF5.hid_t;
+        C_HDF5.H5Tset_size(attrStringType, arkoudaVersion.size:uint(64) + 1); // ensure space for NULL terminator
+        C_HDF5.H5Tset_strpad(attrStringType, C_HDF5.H5T_STR_NULLTERM);
+        
+        attrId = C_HDF5.H5Acreate2(obj_id,
+                            ARKOUDA_HDF5_ARKOUDA_VERSION_KEY.c_str(),
+                            attrStringType,
+                            attrSpaceId,
+                            C_HDF5.H5P_DEFAULT,
+                            C_HDF5.H5P_DEFAULT);
+
+        // For the value, we need to build a ptr to a char[]; c_string doesn't work because it is a const char*        
+        var akVersion = c_calloc(c_char, arkoudaVersion.size+1);
+        for (c, i) in zip(arkoudaVersion.codepoints(), 0..<arkoudaVersion.size) {
+            akVersion[i] = c:c_char;
+        }
+        akVersion[arkoudaVersion.size] = 0:c_char; // ensure NULL termination
+
+        C_HDF5.H5Awrite(attrId, attrStringType, akVersion);
+        C_HDF5.H5Aclose(attrId);
+
+        // release ArkoudaVersion HDF5 resources
+        c_free(akVersion);
+        C_HDF5.H5Sclose(attrSpaceId);
+        C_HDF5.H5Tclose(attrStringType);
+        C_HDF5.H5Oclose(obj_id);
+    }
+
+    proc writeGroupByMetaData(file_id: C_HDF5.hid_t, objName: string, objType: string, num_keys: int) throws {
+        var obj_id: C_HDF5.hid_t = C_HDF5.H5Oopen(file_id, objName.localize().c_str(), C_HDF5.H5P_DEFAULT);
+
+        // Create the attribute space
+        var attrSpaceId: C_HDF5.hid_t = C_HDF5.H5Screate(C_HDF5.H5S_SCALAR);
+        var attr_id: C_HDF5.hid_t;
+
+        // Create the objectType. This will be important when merging with other read/write functionality.
+        attr_id = C_HDF5.H5Acreate2(obj_id, "ObjType".c_str(), getHDF5Type(int), attrSpaceId, C_HDF5.H5P_DEFAULT, C_HDF5.H5P_DEFAULT);
+        var t: ObjType = objType.toUpper(): ObjType;
+        var t_int: int = t: int;
+        C_HDF5.H5Awrite(attr_id, getHDF5Type(int), c_ptrTo(t_int));
+        C_HDF5.H5Aclose(attr_id);
+
+        attr_id = C_HDF5.H5Acreate2(obj_id, "NumKeys".c_str(), getHDF5Type(int), attrSpaceId, C_HDF5.H5P_DEFAULT, C_HDF5.H5P_DEFAULT);
+        var nk = num_keys; // need to generate c_ptrTo
+        C_HDF5.H5Awrite(attr_id, getHDF5Type(int), c_ptrTo(nk));
+        C_HDF5.H5Aclose(attr_id);
 
         var attrFileVersionType = getHDF5Type(ARKOUDA_HDF5_FILE_VERSION_TYPE);
         var attrId = C_HDF5.H5Acreate2(obj_id,
@@ -1074,6 +1135,39 @@ module HDF5Msg {
         }
     }
 
+    proc writeLocalCategoricalRequiredData(file_id: C_HDF5.hid_t, f: string, group: string, codes, categories, naCodes, overwrite: bool) throws {
+        // localize codes and write dataset
+        var localCodes: [0..#codes.size] int = codes.a;
+        writeLocalDset(file_id, "/%s/%s".format(group, CODES_NAME), c_ptrTo(localCodes), codes.size, int);
+
+        // ensure that the container for categories exists
+        validateGroup(file_id, f, "%s/%s".format(group, CATEGORIES_NAME), overwrite);
+
+
+        //localize categories values and write dataset
+        writeSegmentedLocalDset(file_id, "/%s/%s".format(group, CATEGORIES_NAME), categories.values, categories.offsets, true, uint(8));
+
+        // localize _akNAcode and write to dset
+        var localNACodes: [0..#naCodes.size] int = naCodes.a;
+        writeLocalDset(file_id, "/%s/%s".format(group, NACODES_NAME), c_ptrTo(localNACodes), naCodes.size, int);
+    }
+
+    proc writeLocalCategoricalOptionalData(file_id: C_HDF5.hid_t, group: string, permutation: string, segments: string, st: borrowed SymTab) throws {
+        var perm_entry = st.lookup(permutation);
+        var perm = toSymEntry(toGenSymEntry(perm_entry), int);
+
+        // localize permutation and write dataset
+        var localPerm: [0..#perm.size] int = perm.a;
+        writeLocalDset(file_id, "/%s/%s".format(group, PERMUTATION_NAME), c_ptrTo(localPerm), perm.size, int);
+
+        var segment_entry = st.lookup(segments);
+        var segs = toSymEntry(toGenSymEntry(segment_entry), int);
+
+        // localize segments and write dataset
+        var localSegs: [0..#segs.size] int = segs.a;
+        writeLocalDset(file_id, "/%s/%s".format(group, SEGMENTS_NAME), c_ptrTo(localSegs), segs.size, int);
+    }
+
     proc categorical_tohdfMsg(msgArgs: borrowed MessageArgs, st: borrowed SymTab) throws {
         use C_HDF5.HDF5_WAR;
         var mode: int = msgArgs.get("write_mode").getIntValue();
@@ -1117,36 +1211,10 @@ module HDF5Msg {
                 // ensure that container for categorical exists
                 validateGroup(file_id, f, group, overwrite);
 
-                // localize codes and write dataset
-                var localCodes: [0..#codes.size] int = codes.a;
-                writeLocalDset(file_id, "/%s/%s".format(group, CODES_NAME), c_ptrTo(localCodes), codes.size, int);
-
-
-                // ensure that the container for categories exists
-                validateGroup(file_id, f, "%s/%s".format(group, CATEGORIES_NAME), overwrite);
-
-
-                //localize categories values and write dataset
-                writeSegmentedLocalDset(file_id, "/%s/%s".format(group, CATEGORIES_NAME), cats.values, cats.offsets, true, uint(8));
-
-                // localize _akNAcode and write to dset
-                var localNACodes: [0..#naCodes.size] int = naCodes.a;
-                writeLocalDset(file_id, "/%s/%s".format(group, NACODES_NAME), c_ptrTo(localNACodes), naCodes.size, int);
+                writeLocalCategoricalRequiredData(file_id, f, group, codes, cats, naCodes, overwrite);
 
                 if perm_seg_exist {
-                    var perm_entry = st.lookup(msgArgs.getValueOf("permutation"));
-                    var perm = toSymEntry(toGenSymEntry(perm_entry), int);
-
-                    // localize permutation and write dataset
-                    var localPerm: [0..#perm.size] int = perm.a;
-                    writeLocalDset(file_id, "/%s/%s".format(group, PERMUTATION_NAME), c_ptrTo(localPerm), perm.size, int);
-
-                    var segment_entry = st.lookup(msgArgs.getValueOf("segments"));
-                    var segments = toSymEntry(toGenSymEntry(segment_entry), int);
-
-                    // localize segments and write dataset
-                    var localSegs: [0..#segments.size] int = segments.a;
-                    writeLocalDset(file_id, "/%s/%s".format(group, CAT_SEGMENTS_NAME), c_ptrTo(localSegs), segments.size, int);
+                    writeLocalCategoricalOptionalData(file_id, group, msgArgs.getValueOf("permutation"), msgArgs.getValueOf("segments"), st);
                 }
 
                 writeArkoudaMetaData(file_id, group, objType, getHDF5Type(uint(8))); 
@@ -1182,8 +1250,12 @@ module HDF5Msg {
 
                 // writes perms and segs if they exist
                 if perm_seg_exist {
-                    writeDistDset(filenames, "/%s/%s".format(group, PERMUTATION_NAME), "pdarray", overwrite, codes.a, st);
-                    writeDistDset(filenames, "/%s/%s".format(group, CAT_SEGMENTS_NAME), "pdarray", overwrite, codes.a, st);
+                    var perm_entry = st.lookup(msgArgs.getValueOf("permutation"));
+                    var perm = toSymEntry(toGenSymEntry(perm_entry), int);
+                    var segment_entry = st.lookup(msgArgs.getValueOf("segments"));
+                    var segs = toSymEntry(toGenSymEntry(segment_entry), int);
+                    writeDistDset(filenames, "/%s/%s".format(group, PERMUTATION_NAME), "pdarray", overwrite, perm.a, st);
+                    writeDistDset(filenames, "/%s/%s".format(group, SEGMENTS_NAME), "pdarray", overwrite, segs.a, st);
                 }
             }
             otherwise {
@@ -1203,64 +1275,279 @@ module HDF5Msg {
 
         var filename: string = msgArgs.getValueOf("filename");
         var file_format = msgArgs.get("file_format").getIntValue();
+        var overwrite: bool = if msgArgs.contains("overwrite")
+                                then msgArgs.get("overwrite").getBoolValue()
+                                else false; 
 
         var group = msgArgs.getValueOf("dset"); // name of the group containing components
-        var key_dtype = str2dtype(msgArgs.getValueOf("dtype")); // keys and unique-keys... we may not need
-        const objType = msgArgs.getValueOf("objType"); // needed to write metadata
+        const objType = msgArgs.getValueOf("objType").toUpper(): ObjType; // needed to write metadata
 
         // access the permutation and segments pdarrays because these are always int
         var seg_entry = st.lookup(msgArgs.getValueOf("segments"));
         var segments = toSymEntry(toGenSymEntry(seg_entry), int);
         var perm_entry = st.lookup(msgArgs.getValueOf("permutation"));
         var perm = toSymEntry(toGenSymEntry(perm_entry), int);
+        var uki_entry = st.lookup(msgArgs.getValueOf("unique_key_idx"));
+        var uki = toSymEntry(toGenSymEntry(uki_entry), int);
 
-        // create the group
-        // select file_format {
-        //     when SINGLE_FILE {
-        //         validateGroup(file_id, f, group);
-        //         var dtype: C_HDF5.hid_t;
+        // access groupby key information
+        var num_keys = msgArgs.get("num_keys").getIntValue();
+        var key_names = msgArgs.get("key_names").getList(num_keys);
+        var key_objTypes = msgArgs.get("key_objTypes").getList(num_keys);
+        var key_dtypes = msgArgs.get("key_dtypes").getList(num_keys);
 
-        //         select val_dtype {
-        //             when (DType.Int64) {
-                    
-        //             }
-        //             when (DType.UInt64) {
+        select file_format {
+            when SINGLE_FILE {
+                var f = prepFiles(filename, mode);
+                var file_id = C_HDF5.H5Fopen(f.c_str(), C_HDF5.H5F_ACC_RDWR, C_HDF5.H5P_DEFAULT);
+                if file_id < 0 { // HF5open returns negative value on failure
+                    C_HDF5.H5Fclose(file_id);
+                    var errorMsg = "Failure accessing file %s.".format(f);
+                    throw getErrorWithContext(
+                           msg=errorMsg,
+                           lineNumber=getLineNumber(),
+                           routineName=getRoutineName(), 
+                           moduleName=getModuleName(),
+                           errorClass="FileNotFoundError");
+                }
 
-        //             }
-        //             when (DType.Float64) {
+                // create/overwrite the group
+                validateGroup(file_id, f, group, overwrite);
 
-        //             }
-        //             when (DType.Bool) {
+                var localseg: [0..#segments.size] int = segments.a;
+                writeLocalDset(file_id, "/%s/%s".format(group, SEGMENTS_NAME), c_ptrTo(localseg), segments.size, int);
+                writeArkoudaMetaData(file_id, "/%s/%s".format(group, SEGMENTS_NAME), "pdarray", getDataType(int));
 
-        //             }
-        //             when (DType.Strings) {
+                var localperm: [0..#perm.size] int = perm.a;
+                writeLocalDset(file_id, "/%s/%s".format(group, PERMUTATION_NAME), c_ptrTo(localperm), perm.size, int);
+                writeArkoudaMetaData(file_id, "/%s/%s".format(group, PERMUTATION_NAME), "pdarray", getDataType(int));
 
-        //             }
-        //             otherwise {
-        //                 throw getErrorWithContext(
-        //                    msg="Unsupported DType %s".format(dtype2str(key_dtype)),
-        //                    lineNumber=getLineNumber(),
-        //                    routineName=getRoutineName(), 
-        //                    moduleName=getModuleName(),
-        //                    errorClass="IllegalArgumentError");
-        //             }
-        //         }
+                var localuki: [0..#uki.size] int = uki.a;
+                writeLocalDset(file_id, "/%s/%s".format(group, UKI_NAME), c_ptrTo(localuki), uki.size, int);
+                writeArkoudaMetaData(file_id, "/%s/%s".format(group, UKI_NAME), "pdarray", getDataType(int));
 
-        //     }
-        //     when MULTI_FILE {
+                // loop keys and create/write dataset for each
+                for (i, name, ot, dt) in zip(0..#num_keys, key_names, key_objTypes, key_dtypes) {
+                    select ot.toUpper(): ObjType {
+                        when ObjType.PDARRAY {
+                            var dtype: C_HDF5.hid_t;
+                            select str2dtype(dt) {
+                                when DType.Int64 {
+                                    var key_entry = st.lookup(name);
+                                    var key = toSymEntry(toGenSymEntry(key_entry), int);
 
-        //     }
-        //     otherwise {
-        //         throw getErrorWithContext(
-        //                    msg="Unknown file format. Expecting 0 (single file) or 1 (file per locale). Found %i".format(file_format),
-        //                    lineNumber=getLineNumber(),
-        //                    routineName=getRoutineName(), 
-        //                    moduleName=getModuleName(),
-        //                    errorClass="IllegalArgumentError");
-        //     }
-        // }
+                                    // localize permutation and write dataset
+                                    var localkey: [0..#key.size] int = key.a;
+                                    writeLocalDset(file_id, "/%s/KEY_%i".format(group, i), c_ptrTo(localkey), key.size, int);
+                                    dtype = getDataType(int);
+                                }
+                                when DType.UInt64 {
+                                    var key_entry = st.lookup(name);
+                                    var key = toSymEntry(toGenSymEntry(key_entry), uint);
+
+                                    // localize permutation and write dataset
+                                    var localkey: [0..#key.size] uint = key.a;
+                                    writeLocalDset(file_id, "/%s/KEY_%i".format(group, i), c_ptrTo(localkey), key.size, uint);
+                                    dtype = getDataType(uint);
+                                }
+                                when DType.Float64 {
+                                    var key_entry = st.lookup(name);
+                                    var key = toSymEntry(toGenSymEntry(key_entry), real);
+
+                                    // localize permutation and write dataset
+                                    var localkey: [0..#key.size] real = key.a;
+                                    writeLocalDset(file_id, "/%s/KEY_%i".format(group, i), c_ptrTo(localkey), key.size, real);
+                                    dtype = getDataType(real);
+                                }
+                                when DType.Bool {
+                                    var key_entry = st.lookup(name);
+                                    var key = toSymEntry(toGenSymEntry(key_entry), bool);
+
+                                    // localize permutation and write dataset
+                                    var localkey: [0..#key.size] bool = key.a;
+                                    writeLocalDset(file_id, "/%s/KEY_%i".format(group, i), c_ptrTo(localkey), key.size, bool);
+                                    dtype = C_HDF5.H5T_NATIVE_HBOOL;
+                                }
+                                otherwise {
+                                    throw getErrorWithContext(
+                                    msg="Unsupported DType %s".format(str2dtype(dt)),
+                                    lineNumber=getLineNumber(),
+                                    routineName=getRoutineName(), 
+                                    moduleName=getModuleName(),
+                                    errorClass="IllegalArgumentError");
+                                }
+                            }
+                            writeArkoudaMetaData(file_id, "/%s/KEY_%i".format(group, i), "pdarray", dtype);
+                        }
+                        when ObjType.STRINGS {
+                            // create/overwrite the group
+                            validateGroup(file_id, f, "%s/KEY_%i".format(group, i), overwrite);
+                            var key_entry: SegStringSymEntry = toSegStringSymEntry(st.lookup(name));
+                            var key = new SegString("", key_entry);
+                            writeSegmentedLocalDset(file_id, "/%s/KEY_%i".format(group, i), key.values, key.offsets, true, uint(8));
+                            writeArkoudaMetaData(file_id, "/%s/KEY_%i".format(group, i), "Strings", getHDF5Type(uint(8)));
+                        }
+                        when ObjType.CATEGORICAL {
+                            // create/overwrite the group
+                            validateGroup(file_id, f, "%s/KEY_%i".format(group, i), overwrite);
+                            var cat_comps = jsonToMap(name);
+                            var codes_entry = st.lookup(cat_comps["codes"]);
+                            var codes = toSymEntry(toGenSymEntry(codes_entry), int);
+                            var cat_entry:SegStringSymEntry = toSegStringSymEntry(st.lookup(cat_comps["categories"]));
+                            var cats = new SegString("", cat_entry);
+                            var naCodes_entry = st.lookup(cat_comps["NA_codes"]);
+                            var naCodes = toSymEntry(toGenSymEntry(naCodes_entry), int);
+                            writeLocalCategoricalRequiredData(file_id, f, "%s/KEY_%i".format(group, i), codes, cats, naCodes, overwrite);
+
+                            if cat_comps.contains["permutation"] && cat_comps.contains["segments"] {
+                                writeLocalCategoricalOptionalData(file_id, "%s/KEY_%i".format(group, i), cat_comps["permutation"], cat_comps["segments"], st);
+                            }
+                            writeArkoudaMetaData(file_id, "/%s/KEY_%i".format(group, i), "Categorical", getHDF5Type(uint(8)));
+                        }
+                        otherwise {
+                            throw getErrorWithContext(
+                            msg="Unsupported ObjType %s".format(ot: string),
+                            lineNumber=getLineNumber(),
+                            routineName=getRoutineName(), 
+                            moduleName=getModuleName(),
+                            errorClass="IllegalArgumentError");
+                        }
+                    }
+                }
+                // write attributes for arkouda meta info
+                writeGroupByMetaData(file_id, group, objType: string, num_keys);
+                C_HDF5.H5Fclose(file_id);
+
+            }
+            when MULTI_FILE {
+                var filenames = prepFiles(filename, mode, perm.a);
+
+                // need to add the group to all files
+                coforall (loc, idx) in zip(perm.a.targetLocales(), filenames.domain) do on loc {
+                    const localeFilename = filenames[idx];
+                    h5Logger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                "%s exists? %t".format(localeFilename, exists(localeFilename)));
+
+                    var file_id = C_HDF5.H5Fopen(localeFilename.c_str(), C_HDF5.H5F_ACC_RDWR, C_HDF5.H5P_DEFAULT);
+                    defer { // Close the file on scope exit
+                        C_HDF5.H5Fclose(file_id);
+                    }
+
+                    // create the group and generate metadata
+                    validateGroup(file_id, localeFilename, group, overwrite);
+                    writeGroupByMetaData(file_id, group, objType: string, num_keys); 
+                }
+
+                // write groupby.segments
+                writeDistDset(filenames, "/%s/%s".format(group, SEGMENTS_NAME), "pdarray", overwrite, segments.a, st);
+
+                //write groupby.permutation
+                writeDistDset(filenames, "/%s/%s".format(group, PERMUTATION_NAME), "pdarray", overwrite, perm.a, st);
+
+                // write groupby._uki
+                writeDistDset(filenames, "/%s/%s".format(group, UKI_NAME), "pdarray", overwrite, uki.a, st);
+
+                // loop keys and create/write dataset for each
+                for (i, name, ot, dt) in zip(0..#num_keys, key_names, key_objTypes, key_dtypes) {
+                    select ot.toUpper(): ObjType {
+                        when ObjType.PDARRAY {
+                            var entry = st.lookup(name);
+                            select str2dtype(dt) {
+                                when DType.Int64 {
+                                    var e = toSymEntry(toGenSymEntry(entry), int);
+                                    writeDistDset(filenames, "%s/KEY_%i".format(group, i), ot: string, overwrite, e.a, st);
+                                }
+                                when DType.UInt64 {
+                                    var e = toSymEntry(toGenSymEntry(entry), uint);
+                                    writeDistDset(filenames, "%s/KEY_%i".format(group, i), ot: string, overwrite, e.a, st);
+                                }
+                                when DType.Float64 {
+                                    var e = toSymEntry(toGenSymEntry(entry), real);
+                                    writeDistDset(filenames, "%s/KEY_%i".format(group, i), ot: string, overwrite, e.a, st);
+                                }
+                                when DType.Bool {
+                                    var e = toSymEntry(toGenSymEntry(entry), bool);
+                                    writeDistDset(filenames, "%s/KEY_%i".format(group, i), ot: string, overwrite, e.a, st);
+                                }
+                                otherwise {
+                                    throw getErrorWithContext(
+                                    msg="Unsupported DType %s".format(str2dtype(dt)),
+                                    lineNumber=getLineNumber(),
+                                    routineName=getRoutineName(), 
+                                    moduleName=getModuleName(),
+                                    errorClass="IllegalArgumentError");
+                                }
+                            }
+                        }
+                        when ObjType.STRINGS {
+                            var entry:SegStringSymEntry = toSegStringSymEntry(st.lookup(name));
+                            var segString = new SegString("", entry);
+                            var valEntry = segString.values;
+                            var segEntry = segString.offsets;
+                            writeSegmentedDistDset(filenames, "/%s/KEY_%i".format(group, i), ot: string, overwrite, valEntry.a, segEntry.a, st, uint(8));
+                        }
+                        when ObjType.CATEGORICAL {
+                            var cat_comps = jsonToMap(name);
+                            var codes_entry = st.lookup(cat_comps["codes"]);
+                            var codes = toSymEntry(toGenSymEntry(codes_entry), int);
+                            var cat_entry:SegStringSymEntry = toSegStringSymEntry(st.lookup(cat_comps["categories"]));
+                            var cats = new SegString("", cat_entry);
+                            var naCodes_entry = st.lookup(cat_comps["NA_codes"]);
+                            var naCodes = toSymEntry(toGenSymEntry(naCodes_entry), int);
+
+                            // need to add the group to all files
+                            coforall (loc, idx) in zip(codes.a.targetLocales(), filenames.domain) do on loc {
+                                const localeFilename = filenames[idx];
+                                var file_id = C_HDF5.H5Fopen(localeFilename.c_str(), C_HDF5.H5F_ACC_RDWR, C_HDF5.H5P_DEFAULT);
+                                defer { // Close the file on scope exit
+                                    C_HDF5.H5Fclose(file_id);
+                                }
+
+                                // create the group and generate metadata
+                                validateGroup(file_id, localeFilename, "%s/KEY_%i".format(group, i), overwrite);
+                                writeArkoudaMetaData(file_id, "%s/KEY_%i".format(group, i), ot:string, getHDF5Type(uint(8))); 
+                            }
+
+                            // write codes
+                            writeDistDset(filenames, "/%s/KEY_%i/%s".format(group, i, CODES_NAME), "pdarray", overwrite, codes.a, st);
+
+                            // write categories
+                            writeSegmentedDistDset(filenames, "/%s/KEY_%i/%s".format(group, i, CATEGORIES_NAME), "strings", overwrite, cats.values.a, cats.offsets.a, st, uint(8));
+
+                            // write NA Codes
+                            writeDistDset(filenames,"/%s/KEY_%i/%s".format(group, i, NACODES_NAME), "pdarray", overwrite, naCodes.a, st);
+
+                            // writes perms and segs if they exist
+                            if cat_comps.contains["permutation"] && cat_comps.contains["segments"] {
+                                var cat_perm_entry = st.lookup(cat_comps["permutation"]);
+                                var cat_perm = toSymEntry(toGenSymEntry(cat_perm_entry), int);
+                                var segment_entry = st.lookup(cat_comps["segments"]);
+                                var segs = toSymEntry(toGenSymEntry(segment_entry), int);
+                                writeDistDset(filenames, "/%s/KEY_%i/%s".format(group, i, PERMUTATION_NAME), "pdarray", overwrite, cat_perm.a, st);
+                                writeDistDset(filenames, "/%s/KEY_%i/%s".format(group, i, SEGMENTS_NAME), "pdarray", overwrite, segs.a, st);
+                            }
+                        }
+                        otherwise {
+                            throw getErrorWithContext(
+                            msg="Unsupported ObjType %s".format(ot: string),
+                            lineNumber=getLineNumber(),
+                            routineName=getRoutineName(), 
+                            moduleName=getModuleName(),
+                            errorClass="IllegalArgumentError");
+                        }
+                    }
+                }
+            }
+            otherwise {
+                throw getErrorWithContext(
+                           msg="Unknown file format. Expecting 0 (single file) or 1 (file per locale). Found %i".format(file_format),
+                           lineNumber=getLineNumber(),
+                           routineName=getRoutineName(), 
+                           moduleName=getModuleName(),
+                           errorClass="IllegalArgumentError");
+            }
+        }
     }
-
 
     /*
         Parse and exectue tohdf message.
@@ -1774,7 +2061,8 @@ module HDF5Msg {
     /*
         Read an pdarray object from the files provided into a distributed array
     */
-    proc pdarray_readhdfMsg(filenames: [?fD] string, dset: string, dataclass, bytesize: int, isSigned: bool, validFiles: [] bool, st: borrowed SymTab): (string, string, string) throws {
+    proc readPdarrayFromFile(filenames: [?fD] string, dset: string, dataclass, bytesize: int, isSigned: bool, validFiles: [] bool, st: borrowed SymTab): string throws {
+        var rname: string;
         var subdoms: [fD] domain(1);
         var skips = new set(string);
         var len: int;
@@ -1787,7 +2075,7 @@ module HDF5Msg {
                     var entryUInt = new shared SymEntry(len, uint);
                     h5Logger.debug(getModuleName(),getRoutineName(),getLineNumber(), "Initialized uint entry for dataset %s".format(dset));
                     read_files_into_distributed_array(entryUInt.a, subdoms, filenames, dset, skips);
-                    var rname = st.nextName();
+                    rname = st.nextName();
                     if isBoolDataset(filenames[idx], dset) {
                         var entryBool = new shared SymEntry(len, bool);
                         entryBool.a = entryUInt.a:bool;
@@ -1796,13 +2084,13 @@ module HDF5Msg {
                         // Not a boolean dataset, so add original SymEntry to SymTable
                         st.addEntry(rname, entryUInt);
                     }
-                    return (dset, "pdarray", rname);
+                    // return (dset, "pdarray", rname);
                 }
                 else {
                     var entryInt = new shared SymEntry(len, int);
                     h5Logger.debug(getModuleName(),getRoutineName(),getLineNumber(), "Initialized int entry for dataset %s".format(dset));
                     read_files_into_distributed_array(entryInt.a, subdoms, filenames, dset, skips);
-                    var rname = st.nextName();
+                    rname = st.nextName();
                     if isBoolDataset(filenames[idx], dset) {
                         var entryBool = new shared SymEntry(len, bool);
                         entryBool.a = entryInt.a:bool;
@@ -1811,7 +2099,7 @@ module HDF5Msg {
                         // Not a boolean dataset, so add original SymEntry to SymTable
                         st.addEntry(rname, entryInt);
                     }
-                    return (dset, "pdarray", rname);
+                    // return (dset, "pdarray", rname);
                 }
             }
             when C_HDF5.H5T_FLOAT {
@@ -1819,9 +2107,9 @@ module HDF5Msg {
                 h5Logger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                                                     "Initialized float entry");
                 read_files_into_distributed_array(entryReal.a, subdoms, filenames, dset, skips);
-                var rname = st.nextName();
+                rname = st.nextName();
                 st.addEntry(rname, entryReal);
-                return (dset, "pdarray", rname);
+                // return (dset, "pdarray", rname);
             }
             otherwise {
                 var errorMsg = "detected unhandled datatype: objType? pdarray, class %i, size %i, " +
@@ -1835,6 +2123,12 @@ module HDF5Msg {
                             errorClass='UnhandledDatatypeError');
             }
         }
+        return rname;
+    }
+
+    proc pdarray_readhdfMsg(filenames: [?fD] string, dset: string, dataclass, bytesize: int, isSigned: bool, validFiles: [] bool, st: borrowed SymTab): (string, string, string) throws {
+        var pda_name = readPdarrayFromFile(filenames, dset, dataclass, bytesize, isSigned, validFiles, st);
+        return (dset, "pdarray", pda_name);
     }
 
     /*
@@ -1998,18 +2292,19 @@ module HDF5Msg {
         
         // check first file for segments and permutation. If exist here should be everywhere
         var file_id = C_HDF5.H5Fopen(filenames[0].c_str(), C_HDF5.H5F_ACC_RDONLY, C_HDF5.H5P_DEFAULT);
-        var segments_exist = C_HDF5.H5Lexists(file_id, "%s/%s".format(dset, CAT_SEGMENTS_NAME).c_str(), C_HDF5.H5P_DEFAULT);
+        var segments_exist = C_HDF5.H5Lexists(file_id, "%s/%s".format(dset, SEGMENTS_NAME).c_str(), C_HDF5.H5P_DEFAULT);
         var perm_exists = C_HDF5.H5Lexists(file_id, "%s/%s".format(dset, PERMUTATION_NAME).c_str(), C_HDF5.H5P_DEFAULT);
+        C_HDF5.H5Fclose(file_id);
         
         if segments_exist > 0 && perm_exists > 0 {
             // get domain and size info for segments
             var segs_subdoms: [fD] domain(1);
             var segs_skips = new set(string);
             var segs_len: int;
-            (segs_subdoms, segs_len, segs_skips) = get_subdoms(filenames, "%s/%s".format(dset, CAT_SEGMENTS_NAME), validFiles);
+            (segs_subdoms, segs_len, segs_skips) = get_subdoms(filenames, "%s/%s".format(dset, SEGMENTS_NAME), validFiles);
             // read segments into distributed array
             var segments = makeDistArray(segs_len, int);
-            read_files_into_distributed_array(segments, segs_subdoms, filenames, "%s/%s".format(dset, CAT_SEGMENTS_NAME), segs_skips);
+            read_files_into_distributed_array(segments, segs_subdoms, filenames, "%s/%s".format(dset, SEGMENTS_NAME), segs_skips);
             var segName = st.nextName();
             var segEntry = new shared SymEntry(segments);
             st.addEntry(segName, segEntry);
@@ -2030,6 +2325,115 @@ module HDF5Msg {
             rtnMap.add("permutation", "created " + st.attrib(permEntry.name));
         }
         return (dset, "categorical", "%jt".format(rtnMap));
+    }
+
+    proc groupby_readhdfMsg(filenames: [?fD] string, dset: string, validFiles: [] bool, calcStringOffsets: bool, st: borrowed SymTab): (string, string, string) throws {
+        var rtnMap: map(string, string);
+        // domain and size info for codes
+        var perm_subdoms: [fD] domain(1);
+        var perm_skips = new set(string);
+        var perm_len: int;
+        (perm_subdoms, perm_len, perm_skips) = get_subdoms(filenames, "%s/%s".format(dset, PERMUTATION_NAME), validFiles);
+        var perm = makeDistArray(perm_len, int);
+        read_files_into_distributed_array(perm, perm_subdoms, filenames, "%s/%s".format(dset, PERMUTATION_NAME), perm_skips);
+        // create symEntry
+        var permName = st.nextName();
+        var permEntry = new shared SymEntry(perm);
+        st.addEntry(permName, permEntry);
+
+        var seg_subdoms: [fD] domain(1);
+        var seg_skips = new set(string);
+        var seg_len: int;
+        (seg_subdoms, seg_len, seg_skips) = get_subdoms(filenames, "%s/%s".format(dset, SEGMENTS_NAME), validFiles);
+        var segs = makeDistArray(seg_len, int);
+        read_files_into_distributed_array(segs, seg_subdoms, filenames, "%s/%s".format(dset, SEGMENTS_NAME), seg_skips);
+        // create symEntry
+        var segName = st.nextName();
+        var segEntry = new shared SymEntry(segs);
+        st.addEntry(segName, segEntry);
+
+        var uki_subdoms: [fD] domain(1);
+        var uki_skips = new set(string);
+        var uki_len: int;
+        (uki_subdoms, uki_len, uki_skips) = get_subdoms(filenames, "%s/%s".format(dset, UKI_NAME), validFiles);
+        var uki = makeDistArray(uki_len, int);
+        read_files_into_distributed_array(uki, uki_subdoms, filenames, "%s/%s".format(dset, UKI_NAME), uki_skips);
+        // create symEntry
+        var ukiName = st.nextName();
+        var ukiEntry = new shared SymEntry(uki);
+        st.addEntry(ukiName, ukiEntry);
+
+        rtnMap.add("permutation", "created " + st.attrib(permEntry.name));
+        rtnMap.add("segments", "created " + st.attrib(segEntry.name));
+        rtnMap.add("uki", "created " + st.attrib(ukiEntry.name));
+
+        // read the number of keys attribute
+        var file_id = C_HDF5.H5Fopen(filenames[0].c_str(), C_HDF5.H5F_ACC_RDONLY, C_HDF5.H5P_DEFAULT);
+        var obj_id: C_HDF5.hid_t;
+        obj_id = C_HDF5.H5Oopen(file_id, dset.c_str(), C_HDF5.H5P_DEFAULT);
+        if obj_id < 0 {
+            throw getErrorWithContext(
+                           msg="Dataset, %s, not found.".format(dset),
+                           lineNumber=getLineNumber(),
+                           routineName=getRoutineName(), 
+                           moduleName=getModuleName(),
+                           errorClass="IllegalArgumentError");
+        }
+        var numkeys: int = -1;
+        if C_HDF5.H5Aexists_by_name(obj_id, ".".c_str(), "NumKeys", C_HDF5.H5P_DEFAULT) > 0 {
+            var numkeys_id: C_HDF5.hid_t = C_HDF5.H5Aopen_by_name(obj_id, ".".c_str(), "NumKeys", C_HDF5.H5P_DEFAULT, C_HDF5.H5P_DEFAULT);
+            C_HDF5.H5Aread(numkeys_id, getHDF5Type(int), c_ptrTo(numkeys));
+            C_HDF5.H5Aclose(numkeys_id);
+        }
+        C_HDF5.H5Oclose(obj_id);
+
+        if numkeys == -1 {
+            throw getErrorWithContext(
+                           msg="NumKeys attribute not found. Required for GroupBy Reads.",
+                           lineNumber=getLineNumber(),
+                           routineName=getRoutineName(), 
+                           moduleName=getModuleName(),
+                           errorClass="RuntimeError");
+        }
+
+        for k in 0..#numkeys {
+            //need to determine object type of the key to determine how to read it
+            var keyObjType: ObjType; //= getObjType(file_id, "%s/KEY_%i".format(dset, i));
+            var dataclass: C_HDF5.hid_t;
+            var bytesize: int;
+            var isSigned: bool;
+            var readDset: string;
+            var readObjType: string;
+            var readCreate: string;
+            (keyObjType, dataclass, bytesize, isSigned) = get_info(filenames[0], "%s/KEY_%i".format(dset, k), calcStringOffsets);
+            select keyObjType {
+                when ObjType.PDARRAY {
+                    var pda_name = readPdarrayFromFile(filenames, "%s/KEY_%i".format(dset, k), dataclass, bytesize, isSigned, validFiles, st);
+                    readObjType = "pdarray";
+                    readCreate = "created %s".format(st.attrib(pda_name));
+                    // (readDset, readObjType, readCreate) = pdarray_readhdfMsg(filenames, "%s/KEY_%i".format(dset, k), dataclass, bytesize, isSigned, validFiles, st);
+                }
+                when ObjType.STRINGS {
+                    var segString = readStringsFromFile(filenames, "%s/KEY_%i".format(dset, k), dataclass, bytesize, isSigned, calcStringOffsets, validFiles, st);
+                    readObjType = "seg_string";
+                    readCreate = "created %s+created %t".format(st.attrib(segString.name), segString.nBytes);
+                }
+                when ObjType.CATEGORICAL {
+                    (readDset, readObjType, readCreate) = categorical_readhdfMsg(filenames, "%s/KEY_%i".format(dset, k), validFiles, calcStringOffsets, st);
+                }
+                otherwise {
+                    throw getErrorWithContext(
+                           msg="Unsupported GroupBy key type, %s".format(keyObjType: string),
+                           lineNumber=getLineNumber(),
+                           routineName=getRoutineName(), 
+                           moduleName=getModuleName(),
+                           errorClass="TypeError");
+                }
+            }
+            rtnMap.add("KEY_%i".format(k), "%s+|+%s".format(readObjType, readCreate));
+        }
+        C_HDF5.H5Fclose(file_id);
+        return (dset, "groupby", "%jt".format(rtnMap));
     }
 
     /*
@@ -2174,7 +2578,10 @@ module HDF5Msg {
                 try (dataclass, bytesize, isSigned) = 
                                            try get_dataset_info(file_id, valueDset);    
             } else if objType == ObjType.CATEGORICAL {
-                (dataclass, bytesize, isSigned) = get_dataset_info(file_id, "%s/%s".format(dsetName, CODES_NAME));   
+                (dataclass, bytesize, isSigned) = get_dataset_info(file_id, "%s/%s".format(dsetName, CODES_NAME));
+            } else if objType == ObjType.GROUPBY {
+                // for groupby this information will not be used, but needs to be returned for the workflow
+                (dataclass, bytesize, isSigned) = get_dataset_info(file_id, "%s/%s".format(dsetName, PERMUTATION_NAME)); 
             } else {
                 (dataclass, bytesize, isSigned) = get_dataset_info(file_id, dsetName);
             }
@@ -2452,6 +2859,9 @@ module HDF5Msg {
                 }
                 when ObjType.CATEGORICAL {
                     rtnData.append(categorical_readhdfMsg(filenames, dsetName, validFiles, calcStringOffsets, st));
+                }
+                when ObjType.GROUPBY {
+                    rtnData.append(groupby_readhdfMsg(filenames, dsetName, validFiles, calcStringOffsets, st));
                 }
                 otherwise {
                     var errorMsg = "Unknown object type found";

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -28,13 +28,6 @@ module ParquetMsg {
     LZ4=5
   };
 
-  enum ObjType {
-      ARRAYVIEW=0,
-      PDARRAY=1,
-      STRINGS=2,
-      SEGARRAY=3
-    };
-
 
   // Use reflection for error information
   use Reflection;

--- a/src/RegistrationMsg.chpl
+++ b/src/RegistrationMsg.chpl
@@ -304,7 +304,7 @@ module RegistrationMsg
         regLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
                             "%s: Collecting DataFrame components for '%s'".format(cmd, name));
 
-        var jsonParam = new ParameterObj("name", colName, ObjectType.VALUE, "strings");
+        var jsonParam = new ParameterObj("name", colName, ObjectType.VALUE, "str");
         var subArgs1 = new MessageArgs(new list([jsonParam, ]));
         // Add columns as a json list
         var cols = stringsToJSONMsg(cmd, subArgs1, st).msg;

--- a/src/RegistrationMsg.chpl
+++ b/src/RegistrationMsg.chpl
@@ -81,9 +81,9 @@ module RegistrationMsg
 
         const name = msgArgs.getValueOf("name");
 
-        var objType: string = "";
+        var objType: ObjType = ObjType.UNKNOWN;
         if msgArgs.contains("objtype") {
-            objType = msgArgs.getValueOf("objtype");
+            objType = msgArgs.getValueOf("objtype").toUpper(): ObjType;
         }
 
         // if verbose print action
@@ -102,7 +102,7 @@ module RegistrationMsg
             regLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
             return new MsgTuple(errorMsg, MsgType.ERROR); 
         } else {
-            if objType.toLower() == "segarray" {
+            if objType == ObjType.SEGARRAY {
                 var a = attrib.split(" ");
                 var dtype = str2dtype(a[1]: string);
                 var rtnmap: map(string, string) = new map(string, string);
@@ -128,7 +128,7 @@ module RegistrationMsg
 
                 repMsg = "%jt".format(rtnmap);
             }
-            else if objType == "" || objType == "str" || objType == "pdarray" {
+            else if objType == ObjType.UNKNOWN || objType == ObjType.STRINGS || objType == ObjType.PDARRAY {
                 repMsg = "created %s".format(attrib);
                 if (isStringAttrib(attrib)) {
                     var s = getSegString(name, st);
@@ -304,7 +304,7 @@ module RegistrationMsg
         regLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
                             "%s: Collecting DataFrame components for '%s'".format(cmd, name));
 
-        var jsonParam = new ParameterObj("name", colName, ObjectType.VALUE, "str");
+        var jsonParam = new ParameterObj("name", colName, ObjectType.VALUE, "strings");
         var subArgs1 = new MessageArgs(new list([jsonParam, ]));
         // Add columns as a json list
         var cols = stringsToJSONMsg(cmd, subArgs1, st).msg;
@@ -339,26 +339,26 @@ module RegistrationMsg
         // Use existing attach functionality to build the response message based on the objType of each data column
         forall regName in u with (+ reduce repMsg) {
             var parts = regName.split("_");
-            var objtype: string = parts[2];
+            var objtype: ObjType = parts[2].toUpper(): ObjType;
             var msg: string;
             select (objtype){
-                when ("pdarray") {
+                when (ObjType.PDARRAY) {
                     var attParam = new ParameterObj("name", regName, ObjectType.VALUE, "");
                     var subArgs = new MessageArgs(new list([attParam, ]));
                     msg = attachMsg(cmd, subArgs, st).msg;
                 }
-                when ("str") {
+                when (ObjType.STRINGS) {
                     var attParam = new ParameterObj("name", regName, ObjectType.VALUE, "");
                     var subArgs = new MessageArgs(new list([attParam, ]));
                     msg = attachMsg(cmd, subArgs, st).msg;
                 }
-                when ("SegArray") {
+                when (ObjType.SEGARRAY) {
                     var attParam = new ParameterObj("name", regName, ObjectType.VALUE, "");
-                    var objParam =  new ParameterObj("objtype", objtype, ObjectType.VALUE, "");
+                    var objParam =  new ParameterObj("objtype", objtype: string, ObjectType.VALUE, "");
                     var subArgs = new MessageArgs(new list([attParam, objParam]));
                     msg = "segarray+%s+%s".format(regName, attachMsg(cmd, subArgs, st).msg);
                 }
-                when ("Categorical") {
+                when (ObjType.CATEGORICAL) {
                     msg = attachCategoricalMsg(cmd, regName, st).msg;
                 }
                 otherwise {

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -242,7 +242,7 @@ module SegmentedMsg {
   proc segmentLengthsMsg(cmd: string, msgArgs: borrowed MessageArgs,
                                           st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
-    const objtype = msgArgs.getValueOf("objType");
+    const objtype = msgArgs.getValueOf("objType").toUpper(): ObjType;
     const name = msgArgs.getValueOf("obj");
 
     // check to make sure symbols defined
@@ -254,7 +254,7 @@ module SegmentedMsg {
                    cmd,objtype,name));
 
     select objtype {
-      when "str" {
+      when ObjType.STRINGS {
         var strings = getSegString(name, st);
         var lengths = st.addEntry(rname, strings.size, int);
         // Do not include the null terminator in the length
@@ -276,7 +276,7 @@ module SegmentedMsg {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
     const subcmd = msgArgs.getValueOf("subcmd");
-    const objtype = msgArgs.getValueOf("objType");
+    const objtype = msgArgs.getValueOf("objType").toUpper(): ObjType;
     const name = msgArgs.getValueOf("obj");
 
 
@@ -287,7 +287,7 @@ module SegmentedMsg {
     smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"cmd: %s objtype: %t name: %t".format(cmd,objtype,name));
 
     select objtype {
-      when "str" {
+      when ObjType.STRINGS {
         var strings = getSegString(name, st);
         select subcmd {
           when "toLower" {
@@ -326,7 +326,7 @@ module SegmentedMsg {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
     const subcmd = msgArgs.getValueOf("subcmd");
-    const objtype = msgArgs.getValueOf("objType");
+    const objtype = msgArgs.getValueOf("objType").toUpper(): ObjType;
     const name = msgArgs.getValueOf("obj");
 
     // check to make sure symbols defined
@@ -336,7 +336,7 @@ module SegmentedMsg {
     smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"cmd: %s objtype: %t name: %t".format(cmd,objtype,name));
 
     select objtype {
-      when "str" {
+      when ObjType.STRINGS {
         var strings = getSegString(name, st);
         var truth = st.addEntry(rname, strings.size, bool);
         select subcmd {
@@ -372,7 +372,7 @@ module SegmentedMsg {
   proc segmentedSearchMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
       var pn = Reflection.getRoutineName();
       var repMsg: string;
-      const objtype = msgArgs.getValueOf("objType");
+      const objtype = msgArgs.getValueOf("objType").toUpper(): ObjType;
       const name = msgArgs.getValueOf("obj");
       const valtype = msgArgs.getValueOf("valType");
       const val = msgArgs.getValueOf("val");
@@ -386,7 +386,7 @@ module SegmentedMsg {
                           cmd,objtype,valtype));
     
       select (objtype, valtype) {
-          when ("str", "str") {
+          when (ObjType.STRINGS, "str") {
               var strings = getSegString(name, st);
               var truth = st.addEntry(rname, strings.size, bool);
               truth.a = strings.substringSearch(val);
@@ -586,14 +586,14 @@ module SegmentedMsg {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
 
-    var objtype = msgArgs.getValueOf("objType");
+    var objtype = msgArgs.getValueOf("objType").toUpper(): ObjType;
     var name = msgArgs.getValueOf("name");
 
     // check to make sure symbols defined
     st.checkTable(name);
 
     select (objtype) {
-      when ("str") {
+      when (ObjType.STRINGS) {
         var strings = getSegString(name, st);
         var (off, val) = strings.strip(msgArgs.getValueOf("chars"));
         var retString = getSegString(off, val, st);
@@ -618,7 +618,7 @@ module SegmentedMsg {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
     const subcmd = msgArgs.getValueOf("subcmd");
-    const objtype = msgArgs.getValueOf("objType");
+    const objtype = msgArgs.getValueOf("objType").toUpper(): ObjType;
     const name = msgArgs.getValueOf("obj");
     const valtype = msgArgs.getValueOf("valType");
     const times = msgArgs.get("times").getIntValue();
@@ -637,7 +637,7 @@ module SegmentedMsg {
                           cmd,subcmd,objtype,valtype));
 
     select (objtype, valtype) {
-    when ("str", "str") {
+    when (ObjType.STRINGS, "str") {
       var strings = getSegString(name, st);
       select subcmd {
         when "peel" {
@@ -713,14 +713,14 @@ module SegmentedMsg {
   proc segmentedHashMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
-    const objtype = msgArgs.getValueOf("objType");
+    const objtype = msgArgs.getValueOf("objType").toUpper(): ObjType;
     const name = msgArgs.getValueOf("obj");
 
     // check to make sure symbols defined
     st.checkTable(name);
 
     select objtype {
-        when "str" {
+        when ObjType.STRINGS {
             var strings = getSegString(name, st);
             var hashes = strings.siphash();
             var name1 = st.nextName();
@@ -735,7 +735,7 @@ module SegmentedMsg {
             return new MsgTuple(repMsg, MsgType.NORMAL);
         }
         otherwise {
-            var errorMsg = notImplementedError(pn, objtype);
+            var errorMsg = notImplementedError(pn, objtype: string);
             smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);      
             return new MsgTuple(errorMsg, MsgType.ERROR);
         }
@@ -759,7 +759,7 @@ module SegmentedMsg {
     // 'subcmd' is the type of indexing to perform
     // 'objtype' is the type of segmented array
     const subcmd = msgArgs.getValueOf("subcmd");
-    const objtype = msgArgs.getValueOf("objType");
+    const objtype = msgArgs.getValueOf("objType").toUpper(): ObjType;
     const name = msgArgs.getValueOf("obj");
     const dtype = str2dtype(msgArgs.getValueOf("dtype"));
     smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
@@ -796,7 +796,7 @@ module SegmentedMsg {
   /*
   Returns the object corresponding to the index
   */ 
-  proc segIntIndex(objtype: string, objName: string, key: string, dtype: DType,
+  proc segIntIndex(objtype: ObjType, objName: string, key: string, dtype: DType,
                                          st: borrowed SymTab): MsgTuple throws {
       var pn = Reflection.getRoutineName();
 
@@ -805,7 +805,7 @@ module SegmentedMsg {
       st.checkTable(objName);
       
       select objtype {
-          when "str" {
+          when ObjType.STRINGS {
               // Make a temporary strings array
               var strings = getSegString(objName, st);
               // Parse the index
@@ -818,7 +818,7 @@ module SegmentedMsg {
               smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg); 
               return new MsgTuple(repMsg, MsgType.NORMAL);
           }
-          when "SegArray" {
+          when ObjType.SEGARRAY {
             var rname = st.nextName();
             const idx = key: int;  // negative indexes already handled by the client
             select (dtype) {
@@ -858,7 +858,7 @@ module SegmentedMsg {
             return new MsgTuple(repMsg, MsgType.NORMAL);
           }
           otherwise { 
-              var errorMsg = notImplementedError(pn, objtype); 
+              var errorMsg = notImplementedError(pn, objtype: string); 
               smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);      
               return new MsgTuple(errorMsg, MsgType.ERROR);                          
           }
@@ -876,7 +876,7 @@ module SegmentedMsg {
     return chplIdx;
   }
 
-  proc segSliceIndex(objtype: string, objName: string, key: [] string, dtype: DType,
+  proc segSliceIndex(objtype: ObjType, objName: string, key: [] string, dtype: DType,
                                          st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
@@ -900,7 +900,7 @@ module SegmentedMsg {
     var slice = convertPythonSliceToChapel(start, stop);
 
     select objtype {
-        when "str" {
+        when ObjType.STRINGS {
             // Make a temporary string array
             var strings = getSegString(objName, st);
 
@@ -910,7 +910,7 @@ module SegmentedMsg {
             var newStringsObj = getSegString(newSegs, newVals, st);
             repMsg = "created " + st.attrib(newStringsObj.name) + "+created bytes.size %t".format(newStringsObj.nBytes);
         }
-        when "SegArray" {
+        when ObjType.SEGARRAY {
           var rtnmap: map(string, string);
           select dtype {
             when (DType.Int64) { 
@@ -958,7 +958,7 @@ module SegmentedMsg {
           repMsg = "%jt".format(rtnmap);
         }
         otherwise {
-            var errorMsg = notImplementedError(pn, objtype);
+            var errorMsg = notImplementedError(pn, objtype: string);
             smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);      
             return new MsgTuple(errorMsg, MsgType.ERROR);          
         }
@@ -975,7 +975,7 @@ module SegmentedMsg {
     }
   }
 
-  proc segPdarrayIndex(objtype: string, objName: string, iname: string, dtype: DType,
+  proc segPdarrayIndex(objtype: ObjType, objName: string, iname: string, dtype: DType,
                        st: borrowed SymTab): MsgTuple throws {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
@@ -989,7 +989,7 @@ module SegmentedMsg {
     var gIV: borrowed GenSymEntry = getGenericTypedArrayEntry(iname, st);
     
     select objtype {
-        when "str" {
+        when ObjType.STRINGS {
             var newStringsName = "";
             var nBytes = 0;
             var strings = getSegString(objName, st);
@@ -1020,7 +1020,7 @@ module SegmentedMsg {
                         repMsg = "created " + st.attrib(newStringsName) + "+created bytes.size %t".format(nBytes);
                     }
                     otherwise {
-                        var errorMsg = "("+objtype+","+dtype2str(gIV.dtype)+")";
+                        var errorMsg = "("+objtype: string+","+dtype2str(gIV.dtype)+")";
                         smLogger.error(getModuleName(),getRoutineName(),
                                                       getLineNumber(),errorMsg); 
                         return new MsgTuple(notImplementedError(pn,errorMsg), MsgType.ERROR);
@@ -1032,7 +1032,7 @@ module SegmentedMsg {
                 return new MsgTuple(errorMsg, MsgType.ERROR);
             }
         }
-        when "SegArray" {
+        when ObjType.SEGARRAY {
           var rtnmap: map(string, string);
           select dtype {
             when DType.Int64 {
@@ -1057,7 +1057,7 @@ module SegmentedMsg {
                   newSegArr.fillReturnMap(rtnmap, st);
                 }
                 otherwise {
-                    var errorMsg = "("+objtype+","+dtype2str(gIV.dtype)+")";
+                    var errorMsg = "("+objtype: string+","+dtype2str(gIV.dtype)+")";
                     smLogger.error(getModuleName(),getRoutineName(),
                                                   getLineNumber(),errorMsg); 
                     return new MsgTuple(notImplementedError(pn,errorMsg), MsgType.ERROR);
@@ -1086,7 +1086,7 @@ module SegmentedMsg {
                   newSegArr.fillReturnMap(rtnmap, st);
                 }
                 otherwise {
-                    var errorMsg = "("+objtype+","+dtype2str(gIV.dtype)+")";
+                    var errorMsg = "("+objtype: string+","+dtype2str(gIV.dtype)+")";
                     smLogger.error(getModuleName(),getRoutineName(),
                                                   getLineNumber(),errorMsg); 
                     return new MsgTuple(notImplementedError(pn,errorMsg), MsgType.ERROR);
@@ -1115,7 +1115,7 @@ module SegmentedMsg {
                   newSegArr.fillReturnMap(rtnmap, st);
                 }
                 otherwise {
-                    var errorMsg = "("+objtype+","+dtype2str(gIV.dtype)+")";
+                    var errorMsg = "("+objtype: string+","+dtype2str(gIV.dtype)+")";
                     smLogger.error(getModuleName(),getRoutineName(),
                                                   getLineNumber(),errorMsg); 
                     return new MsgTuple(notImplementedError(pn,errorMsg), MsgType.ERROR);
@@ -1144,7 +1144,7 @@ module SegmentedMsg {
                   newSegArr.fillReturnMap(rtnmap, st);
                 }
                 otherwise {
-                    var errorMsg = "("+objtype+","+dtype2str(gIV.dtype)+")";
+                    var errorMsg = "("+objtype: string+","+dtype2str(gIV.dtype)+")";
                     smLogger.error(getModuleName(),getRoutineName(),
                                                   getLineNumber(),errorMsg); 
                     return new MsgTuple(notImplementedError(pn,errorMsg), MsgType.ERROR);
@@ -1173,7 +1173,7 @@ module SegmentedMsg {
                   newSegArr.fillReturnMap(rtnmap, st);
                 }
                 otherwise {
-                    var errorMsg = "("+objtype+","+dtype2str(gIV.dtype)+")";
+                    var errorMsg = "("+objtype: string+","+dtype2str(gIV.dtype)+")";
                     smLogger.error(getModuleName(),getRoutineName(),
                                                   getLineNumber(),errorMsg); 
                     return new MsgTuple(notImplementedError(pn,errorMsg), MsgType.ERROR);
@@ -1181,7 +1181,7 @@ module SegmentedMsg {
               }
             }
             otherwise {
-                var errorMsg = notImplementedError(pn, objtype);
+                var errorMsg = notImplementedError(pn, objtype: string);
                 smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);      
                 return new MsgTuple(errorMsg, MsgType.ERROR);          
             }
@@ -1191,7 +1191,7 @@ module SegmentedMsg {
         otherwise {
             var errorMsg = "unsupported objtype: %t".format(objtype);
             smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-            return new MsgTuple(notImplementedError(pn, objtype), MsgType.ERROR);
+            return new MsgTuple(notImplementedError(pn, objtype: string), MsgType.ERROR);
         }
     }
 
@@ -1204,9 +1204,9 @@ module SegmentedMsg {
     var repMsg: string;
 
     const op = msgArgs.getValueOf("op");
-    const ltype = msgArgs.getValueOf("objType");
+    const ltype = msgArgs.getValueOf("objType").toUpper(): ObjType;
     const leftName = msgArgs.getValueOf("obj");
-    const rtype = msgArgs.getValueOf("otherType");
+    const rtype = msgArgs.getValueOf("otherType").toUpper(): ObjType;
     const rightName = msgArgs.getValueOf("other");
 
     // check to make sure symbols defined
@@ -1214,7 +1214,7 @@ module SegmentedMsg {
     st.checkTable(rightName);
 
     select (ltype, rtype) {
-        when ("str", "str") {
+        when (ObjType.STRINGS, ObjType.STRINGS) {
             var lstrings = getSegString(leftName, st);
             var rstrings = getSegString(rightName, st);
 
@@ -1246,14 +1246,14 @@ module SegmentedMsg {
                     smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
                 }
                 otherwise {
-                    var errorMsg = notImplementedError(pn, ltype, op, rtype);
+                    var errorMsg = notImplementedError(pn, ltype: string, op, rtype: string);
                     smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
                     return new MsgTuple(errorMsg, MsgType.ERROR);
                 }
               }
            }
        otherwise {
-           var errorMsg = unrecognizedTypeError(pn, "("+ltype+", "+rtype+")");
+           var errorMsg = unrecognizedTypeError(pn, "("+ltype: string+", "+rtype: string+")");
            smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
            return new MsgTuple(errorMsg, MsgType.ERROR);
        } 
@@ -1266,7 +1266,7 @@ module SegmentedMsg {
       var pn = Reflection.getRoutineName();
       var repMsg: string;
       const op = msgArgs.getValueOf("op");
-      const objtype = msgArgs.getValueOf("objType");
+      const objtype = msgArgs.getValueOf("objType").toUpper(): ObjType;
       const name = msgArgs.getValueOf("obj");
       const valtype = msgArgs.getValueOf("otherType");
       const value = msgArgs.getValueOf("other");
@@ -1277,7 +1277,7 @@ module SegmentedMsg {
       var rname = st.nextName();
 
       select (objtype, valtype) {
-          when ("str", "str") {
+          when (ObjType.STRINGS, "str") {
               var strings = getSegString(name, st);
               select op {
                   when "==" {
@@ -1289,14 +1289,14 @@ module SegmentedMsg {
                       e.a = (strings != value);
                   }
                   otherwise {
-                      var errorMsg = notImplementedError(pn, objtype, op, valtype);
+                      var errorMsg = notImplementedError(pn, objtype: string, op, valtype);
                       smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
                       return new MsgTuple(errorMsg, MsgType.ERROR);
                   }
               }
           }
           otherwise {
-              var errorMsg = unrecognizedTypeError(pn, "("+objtype+", "+valtype+")");
+              var errorMsg = unrecognizedTypeError(pn, "("+objtype: string+", "+valtype+")");
               smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
               return new MsgTuple(errorMsg, MsgType.ERROR);
           } 
@@ -1310,9 +1310,9 @@ module SegmentedMsg {
   proc segIn1dMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
       var pn = Reflection.getRoutineName();
       var repMsg: string;
-      const mainObjtype = msgArgs.getValueOf("objType");
+      const mainObjtype = msgArgs.getValueOf("objType").toUpper(): ObjType;
       const mainName = msgArgs.getValueOf("obj");
-      const testObjtype = msgArgs.getValueOf("otherType");
+      const testObjtype = msgArgs.getValueOf("otherType").toUpper(): ObjType;
       const testName = msgArgs.getValueOf("other");
       const invert = msgArgs.get("invert").getBoolValue();
 
@@ -1323,14 +1323,14 @@ module SegmentedMsg {
       var rname = st.nextName();
  
       select (mainObjtype, testObjtype) {
-          when ("str", "str") {
+          when (ObjType.STRINGS, ObjType.STRINGS) {
               var mainStr = getSegString(mainName, st);
               var testStr = getSegString(testName, st);
               var e = st.addEntry(rname, mainStr.size, bool);
               e.a = in1d(mainStr, testStr, invert);
           }
           otherwise {
-              var errorMsg = unrecognizedTypeError(pn, "("+mainObjtype+", "+testObjtype+")");
+              var errorMsg = unrecognizedTypeError(pn, "("+mainObjtype: string+", "+testObjtype: string+")");
               smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);      
               return new MsgTuple(errorMsg, MsgType.ERROR);            
           }
@@ -1343,7 +1343,7 @@ module SegmentedMsg {
 
   proc segGroupMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
       var pn = Reflection.getRoutineName();
-      const objtype = msgArgs.getValueOf("objType");
+      const objtype = msgArgs.getValueOf("objType").toUpper(): ObjType;
       const name = msgArgs.getValueOf("obj");
 
       // check to make sure symbols defined
@@ -1351,13 +1351,13 @@ module SegmentedMsg {
       
       var rname = st.nextName();
       select (objtype) {
-          when "str" {
+          when ObjType.STRINGS {
               var strings = getSegString(name, st);
               var iv = st.addEntry(rname, strings.size, int);
               iv.a = strings.argGroup();
           }
           otherwise {
-              var errorMsg = notImplementedError(pn, "("+objtype+")");
+              var errorMsg = notImplementedError(pn, "("+objtype: string+")");
               smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);      
               return new MsgTuple(errorMsg, MsgType.ERROR);            
           }
@@ -1385,14 +1385,14 @@ module SegmentedMsg {
     var pn = Reflection.getRoutineName();
     var repMsg: string;
 
-    var objtype = msgArgs.getValueOf("objType");
+    var objtype = msgArgs.getValueOf("objType").toUpper(): ObjType;
     var name = msgArgs.getValueOf("name");
     
     // check to make sure symbols defined
     st.checkTable(name);
 
     select (objtype) {
-      when ("str") {
+      when (ObjType.STRINGS) {
         var strings = getSegString(name, st);
         var returnOrigins = msgArgs.get("returnOrigins").getBoolValue();
         var (off, byt, longEnough) = strings.getFixes(msgArgs.get("nChars").getIntValue(),

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -16,6 +16,16 @@ module ServerConfig
     use ArkoudaFileCompat;
     
     enum Deployment {STANDARD,KUBERNETES}
+
+    enum ObjType {
+      UNKNOWN=-1,
+      ARRAYVIEW=0,
+      PDARRAY=1,
+      STRINGS=2,
+      SEGARRAY=3,
+      CATEGORICAL=4,
+      GROUPBY=5
+    };
     
     /*
     Type of deployment, which currently is either STANDARD, meaning

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -83,8 +83,8 @@ module UniqueMsg
       // For each input array, gather unique values
       for (name, objtype, i) in zip(names, types, 0..) {
         var newName = st.nextName();
-        select objtype {
-          when "pdarray", "Categorical" {
+        select objtype.toUpper(): ObjType {
+          when ObjType.PDARRAY, ObjType.CATEGORICAL {
             var g = getGenericTypedArrayEntry(name, st);
             // Gathers unique values, stores in SymTab, and returns repMsg chunk
             proc gatherHelper(type t) throws {
@@ -114,7 +114,7 @@ module UniqueMsg
               }
             }
           }
-          when "str" {
+          when ObjType.STRINGS {
             var (myNames, _) = name.splitMsgToTuple('+', 2);
             var g = getSegString(myNames, st);
             var (uSegs, uVals) = g[gatherInds];
@@ -247,8 +247,8 @@ module UniqueMsg
         return (r1, r2);
       }
       for (name, objtype, i) in zip(names, types, 0..) {
-        select objtype {
-          when "pdarray", "Categorical" {
+        select objtype.toUpper(): ObjType {
+          when ObjType.PDARRAY, ObjType.CATEGORICAL {
             var g = getGenericTypedArrayEntry(name, st);
             select g.dtype {
               when DType.Int64 {
@@ -277,7 +277,7 @@ module UniqueMsg
               }
             }
           }
-          when "str" {
+          when ObjType.STRINGS {
             var (myNames, _) = name.splitMsgToTuple('+', 2);
             var g = getSegString(myNames, st);
             hashes ^= rotl(g.siphash(), i);

--- a/tests/categorical_test.py
+++ b/tests/categorical_test.py
@@ -66,7 +66,7 @@ class CategoricalTest(ArkoudaTest):
             cat.categories.to_list(),
         )
         self.assertEqual(10, cat.size)
-        self.assertEqual("Categorical", cat.objtype)
+        self.assertEqual("Categorical", cat.objType)
 
         with self.assertRaises(ValueError):
             ak.Categorical(ak.arange(0, 5, 10))
@@ -260,7 +260,7 @@ class CategoricalTest(ArkoudaTest):
         catTwo = self._getCategorical("string-two", 51)
 
         resultCat = catOne.concatenate([catTwo])
-        self.assertEqual("Categorical", resultCat.objtype)
+        self.assertEqual("Categorical", resultCat.objType)
         self.assertIsInstance(resultCat, ak.Categorical)
         self.assertEqual(100, resultCat.size)
 
@@ -270,7 +270,7 @@ class CategoricalTest(ArkoudaTest):
         self.assertFalse(resultCat.segments)
 
         resultCat = ak.concatenate([catOne, catOne], ordered=False)
-        self.assertEqual("Categorical", resultCat.objtype)
+        self.assertEqual("Categorical", resultCat.objType)
         self.assertIsInstance(resultCat, ak.Categorical)
         self.assertEqual(100, resultCat.size)
 

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -912,14 +912,11 @@ class IOTest(ArkoudaTest):
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
             g.to_hdf(f"{tmp_dirname}/pd_test")
             g_load = ak.read(f"{tmp_dirname}/pd_test*")
-            print(g.keys)
-            print(g_load.keys)
-            # self.assertEqual(len(g_load.keys), len(g.keys))
-            # self.assertListEqual(g_load.permutation.to_list(), g.permutation.to_list())
-            # self.assertListEqual(g_load.segments.to_list(), g.segments.to_list())
-            # self.assertListEqual(g_load._uki.to_list(), g._uki.to_list())
-            # for k, kload in zip(g_load.keys, g.keys):
-            #     self.assertListEqual(g_load.keys.to_list(), g.keys.to_list())
+            self.assertEqual(len(g_load.keys), len(g.keys))
+            self.assertListEqual(g_load.permutation.to_list(), g.permutation.to_list())
+            self.assertListEqual(g_load.segments.to_list(), g.segments.to_list())
+            self.assertListEqual(g_load._uki.to_list(), g._uki.to_list())
+            self.assertListEqual(g_load.keys.to_list(), g.keys.to_list())
 
     def test_hdf_overwrite_pdarray(self):
         # test repack with a single object

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -876,6 +876,51 @@ class IOTest(ArkoudaTest):
             df_load = ak.DataFrame.load(f"{tmp_dirname}/dataframe_segarr")
             self.assertTrue(df.to_pandas().equals(df_load.to_pandas()))
 
+    def test_hdf_groupby(self):
+        # test for categorical and multiple keys
+        string = ak.array(["a", "b", "a", "b", "c"])
+        cat = ak.Categorical(string)
+        cat_from_codes = ak.Categorical.from_codes(
+            codes=ak.array([0, 1, 0, 1, 2]), categories=ak.array(["a", "b", "c"])
+        )
+        cat_grouping = ak.GroupBy([cat, cat_from_codes])
+        with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
+            cat_grouping.to_hdf(f"{tmp_dirname}/cat_test")
+            cg_load = ak.read(f"{tmp_dirname}/cat_test*")
+            self.assertEqual(len(cg_load.keys), len(cat_grouping.keys))
+            self.assertListEqual(cg_load.permutation.to_list(), cat_grouping.permutation.to_list())
+            self.assertListEqual(cg_load.segments.to_list(), cat_grouping.segments.to_list())
+            self.assertListEqual(cg_load._uki.to_list(), cat_grouping._uki.to_list())
+            for k, kload in zip(cat_grouping.keys, cg_load.keys):
+                self.assertListEqual(k.to_list(), kload.to_list())
+
+        # test Strings GroupBy
+        str_grouping = ak.GroupBy(string)
+        with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
+            str_grouping.to_hdf(f"{tmp_dirname}/str_test")
+            str_load = ak.read(f"{tmp_dirname}/str_test*")
+            self.assertEqual(len(cg_load.keys), len(cat_grouping.keys))
+            self.assertListEqual(cg_load.permutation.to_list(), cat_grouping.permutation.to_list())
+            self.assertListEqual(cg_load.segments.to_list(), cat_grouping.segments.to_list())
+            self.assertListEqual(cg_load._uki.to_list(), cat_grouping._uki.to_list())
+            for k, kload in zip(cat_grouping.keys, cg_load.keys):
+                self.assertListEqual(k.to_list(), kload.to_list())
+
+        # test pdarray GroupBy
+        pda = ak.array([0, 1, 2, 0, 2])
+        g = ak.GroupBy(pda)
+        with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
+            g.to_hdf(f"{tmp_dirname}/pd_test")
+            g_load = ak.read(f"{tmp_dirname}/pd_test*")
+            print(g.keys)
+            print(g_load.keys)
+            # self.assertEqual(len(g_load.keys), len(g.keys))
+            # self.assertListEqual(g_load.permutation.to_list(), g.permutation.to_list())
+            # self.assertListEqual(g_load.segments.to_list(), g.segments.to_list())
+            # self.assertListEqual(g_load._uki.to_list(), g._uki.to_list())
+            # for k, kload in zip(g_load.keys, g.keys):
+            #     self.assertListEqual(g_load.keys.to_list(), g.keys.to_list())
+
     def test_hdf_overwrite_pdarray(self):
         # test repack with a single object
         a = ak.arange(1000)

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -899,12 +899,11 @@ class IOTest(ArkoudaTest):
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
             str_grouping.to_hdf(f"{tmp_dirname}/str_test")
             str_load = ak.read(f"{tmp_dirname}/str_test*")
-            self.assertEqual(len(cg_load.keys), len(cat_grouping.keys))
-            self.assertListEqual(cg_load.permutation.to_list(), cat_grouping.permutation.to_list())
-            self.assertListEqual(cg_load.segments.to_list(), cat_grouping.segments.to_list())
-            self.assertListEqual(cg_load._uki.to_list(), cat_grouping._uki.to_list())
-            for k, kload in zip(cat_grouping.keys, cg_load.keys):
-                self.assertListEqual(k.to_list(), kload.to_list())
+            self.assertEqual(len(str_load.keys), len(str_grouping.keys))
+            self.assertListEqual(str_load.permutation.to_list(), str_grouping.permutation.to_list())
+            self.assertListEqual(str_load.segments.to_list(), str_grouping.segments.to_list())
+            self.assertListEqual(str_load._uki.to_list(), str_grouping._uki.to_list())
+            self.assertListEqual(str_grouping.keys.to_list(), str_load.keys.to_list())
 
         # test pdarray GroupBy
         pda = ak.array([0, 1, 2, 0, 2])


### PR DESCRIPTION
Closes #2386 

This PR implements `GroupBy.to_hdf` and `GroupBy.update_hdf` features.

- Updates server code to use the `ObjType` enum globally. This is being done for better consistency across all modules.
- Updates Categorical and pdarray `to_hdf` workflows to prevent code duplication and allow same code to be used for the GroupBy Case
- Adds handling of metadata specific to GroupBy. This adds the `NumKeys` attribute to allow reading keys easily.
- Ensures all savable Arkouda objects have the `objType` property set on the client for consistency. Removes the `decorators.py` file because it is no longer needed and would not provide the proper object type value across all objects.
- Updates documentation for File I/O to include specs for GroupBy and Categorical
- Adds case to `GroupBy.__init__` to allow the unique key indexes to be passed. This prevents the need to save all the unique keys to the HDF5 file. Instead, only the indexes of unique keys are saved.
- Adds simple JSON parser to allow for use of JSON for the case where one or more GroupBy keys is a Categorical object.