### PR TITLE
Closes #2425 - Import/Export lists from/to pandas

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -2439,7 +2439,7 @@ class DataFrame(UserDict):
 
             elif parts[i] == "categorical":
                 colName = DataFrame._parse_col_name(parts[i + 1], dfName)[0]
-                cols[colName] = Categorical.from_return_msg(parts[i+2] + "+" + parts[i+3])
+                cols[colName] = Categorical.from_return_msg(parts[i + 2] + "+" + parts[i + 3])
                 i += 3
 
             elif parts[i] == "segarray":

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -562,7 +562,7 @@ class DataFrame(UserDict):
     def _get_head_tail_server(self):
         if self._empty:
             return pd.DataFrame()
-        # self.update_size()
+        self.update_size()
         maxrows = pd.get_option("display.max_rows")
         if self._size <= maxrows:
             newdf = DataFrame()

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -278,7 +278,13 @@ class DataFrame(UserDict):
             # convert the lists defining each column into a pdarray
             # pd.DataFrame.values is stored as rows, we need lists to be columns
             for key, val in initialdata.to_dict("list").items():
-                self.data[key] = array(val)
+                if isinstance(val[0], list):
+                    multi_array = []
+                    for r in val:
+                        multi_array.append(array(r))
+                    self.data[key] = SegArray.from_multi_array(multi_array)
+                else:
+                    self.data[key] = array(val)
 
             self.data.update()
             return
@@ -556,7 +562,7 @@ class DataFrame(UserDict):
     def _get_head_tail_server(self):
         if self._empty:
             return pd.DataFrame()
-        self.update_size()
+        # self.update_size()
         maxrows = pd.get_option("display.max_rows")
         if self._size <= maxrows:
             newdf = DataFrame()
@@ -950,7 +956,6 @@ class DataFrame(UserDict):
         """
         Computes the number of bytes on the arkouda server.
         """
-
         sizes = set()
         for key, val in self.items():
             if val is not None:

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -277,7 +277,7 @@ class SegArray:
             offsets = np.cumsum(sizes) - sizes
             newvals = zeros(sum(sizes), dtype=dtypes.pop())
             for j in range(n):
-                newvals[offsets[j]:(offsets[j]+sizes[j])] = m[j]
+                newvals[offsets[j] : (offsets[j] + sizes[j])] = m[j]
             return cls.from_parts(array(offsets), newvals)
 
     @property

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -269,15 +269,16 @@ class SegArray:
         if isinstance(m, pdarray):
             return cls.from_parts(arange(m.size), m)
         else:
-            sd = {(mi.size, mi.dtype) for mi in m}
-            if len(sd) != 1:
-                raise ValueError("All columns must have same length and dtype")
-            size, dtype = sd.pop()
+            sizes = np.array([mi.size for mi in m])
+            dtypes = {mi.dtype for mi in m}
+            if len(dtypes) != 1:
+                raise ValueError("All values must have same dtype")
             n = len(m)
-            newvals = zeros(size * n, dtype=dtype)
+            offsets = np.cumsum(sizes) - sizes
+            newvals = zeros(sum(sizes), dtype=dtypes.pop())
             for j in range(n):
-                newvals[j::n] = m[j]
-            return cls.from_parts(arange(size) * n, newvals)
+                newvals[offsets[j]:(offsets[j]+sizes[j])] = m[j]
+            return cls.from_parts(array(offsets), newvals)
 
     @property
     def objtype(self):

--- a/tests/segarray_test.py
+++ b/tests/segarray_test.py
@@ -35,9 +35,10 @@ class SegArrayTest(ArkoudaTest):
         self.assertTrue(segarr.__eq__(segarr).all())
 
         multi_pd = ak.SegArray.from_multi_array(
-            [ak.array([10, 20, 30]), ak.array([11, 21, 31]), ak.array([12, 22, 32])]
+            [ak.array([10, 11, 12]), ak.array([20, 21, 22]), ak.array([30, 31, 32])]
         )
         self.assertIsInstance(multi_pd, ak.SegArray)
+        print(multi_pd.__str__())
         self.assertEqual(multi_pd.__str__(), "SegArray([\n[10 11 12]\n[20 21 22]\n[30 31 32]\n])")
         with self.assertRaises(TypeError):
             segarr.__getitem__("a")
@@ -120,7 +121,7 @@ class SegArrayTest(ArkoudaTest):
         multi_pd2 = ak.SegArray.from_multi_array(
             [ak.array([13, 23, 33]), ak.array([14, 24, 34]), ak.array([15, 25, 35])]
         )
-        concated = ak.SegArray.concat([multi_pd, multi_pd2], axis=1)
+        concated = ak.SegArray.concat([multi_pd, multi_pd2], axis=0)
 
         test = ak.SegArray.from_multi_array(
             [
@@ -132,8 +133,22 @@ class SegArrayTest(ArkoudaTest):
                 ak.array([15, 25, 35]),
             ]
         )
+        self.assertEqual(concated.size, test.size)
+        for i in range(test.size):
+            self.assertListEqual(concated[i].tolist(), test[i].tolist())
 
-        self.assertEqual(concated.__str__(), test.__str__())
+        concated = ak.SegArray.concat([multi_pd, multi_pd2], axis=1)
+
+        test = ak.SegArray.from_multi_array(
+            [
+                ak.array([10, 20, 30, 13, 23, 33]),
+                ak.array([11, 21, 31, 14, 24, 34]),
+                ak.array([12, 22, 32, 15, 25, 35]),
+            ]
+        )
+        self.assertEqual(concated.size, test.size)
+        for i in range(test.size):
+            self.assertListEqual(concated[i].tolist(), test[i].tolist())
 
     def test_suffixes(self):
         a = [10, 11, 12, 13, 14, 15]


### PR DESCRIPTION
Closes #2425 

Noting that exporting an Arkouda DataFrame to list was already supported by calling `ak.DataFrame.to_pandas`. This is also supported for a standalone SegArray using `ak.SegArray.to_ndarray()`.

The previous implementation of `ak.DataFrame.__init__` did not handle cases where pandas DataFrames contained lists (ie SegArrays). This constructor case has been updated to include handling for list columns. These will be read in a SegArrays.

In order to support this, `ak.SegArray.from_multi_array` has been updated so that each array is a segment instead of each array containing a value for a column. This prevents the requirement that everything be the same size when using this method, allowing true SegArray functionality.  This resulted in some tests requiring updates in order to support this, but these were minor.