### PR TITLE
Closes #2417 - `Filename_Codes` match `Categorical.codes`

### DIFF
--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -12,7 +12,7 @@ from arkouda.categorical import Categorical
 from arkouda.client import generic_msg
 from arkouda.groupbyclass import GroupBy
 from arkouda.pdarrayclass import create_pdarray, pdarray
-from arkouda.pdarraycreation import array
+from arkouda.pdarraycreation import array, arange
 from arkouda.segarray import SegArray
 from arkouda.strings import Strings
 
@@ -1871,9 +1871,10 @@ def read_tagged_data(
         cmd="globExpansion",
         args={"file_count": len(filenames), "filenames": filenames},
     )
-    file_list = json.loads(j_str)
-    file_cat = Categorical(
-        array(file_list)
+    file_list = array(json.loads(j_str))
+    file_cat = Categorical.from_codes(
+        arange(file_list.size),
+        file_list
     )  # create a categorical from the ak.Strings representation of the file list
 
     ftype = get_filetype(filenames)


### PR DESCRIPTION
Closes #2417 

Updates the filename `Categorical` generation to use `from_codes`. This uses an `arange(filelist.size)` for the code because we know the file list is ordered and the codes are assigned on the server based on the index. Verified with 11 locales that this ensures the `Categorical.codes` and associated categories align with the codes returned from the server.