### PR TITLE
Closes #2441: Adds missing `use Biginteger` in gt-130 bigint compat

### DIFF
--- a/src/compat/gt-130/ArkoudaBigIntCompat.chpl
+++ b/src/compat/gt-130/ArkoudaBigIntCompat.chpl
@@ -1,4 +1,6 @@
 module ArkoudaBigIntCompat {
+  use BigInteger;
+
   proc rightShift(const ref a: bigint, b: int): bigint {
     return a >> b;
   }


### PR DESCRIPTION
This PR (closes #2441) adds missing `use Biginteger` in gt-130 bigint compat