### PR TITLE
Closes #2445 - Deprecation updates related to string and byte factory functions 

### DIFF
--- a/dep/checkArrow.chpl
+++ b/dep/checkArrow.chpl
@@ -1,4 +1,5 @@
 use CTypes, IO;
+use ArkoudaStringBytesCompat;
 
 require "../src/ArrowFunctions.h";
 require "../src/ArrowFunctions.o";
@@ -13,7 +14,7 @@ proc getVersionInfo() {
   }
   var ret: string;
   try {
-    ret = createStringWithNewBuffer(cVersionString,
+    ret = string.createCopyingBuffer(cVersionString,
                               strlen(cVersionString));
   } catch e {
     ret = "Error converting Arrow version message to Chapel string";

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -19,6 +19,7 @@ module GenSymIO {
     use SegmentedString;
 
     use ArkoudaMapCompat;
+    use ArkoudaStringBytesCompat;
 
     private config const logLevel = ServerConfig.logLevel;
     private config const logChannel = ServerConfig.logChannel;
@@ -148,7 +149,7 @@ module GenSymIO {
             var localA = makeArrayFromPtr(ptr, D.size:uint);
             localA = A;
             const size = D.size*c_sizeof(eltType):int;
-            return createBytesWithOwnedBuffer(ptr:c_ptr(uint(8)), size, size);
+            return bytes.createAdoptingBuffer(ptr:c_ptr(uint(8)), size, size);
         }
 
         if entry.dtype == DType.Int64 {

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -28,6 +28,7 @@ module HDF5Msg {
     use Sort;
 
     use ArkoudaMapCompat;
+    use ArkoudaStringBytesCompat;
 
     private config const logLevel = ServerConfig.logLevel;
     private config const logChannel = ServerConfig.logChannel;
@@ -1319,7 +1320,7 @@ module HDF5Msg {
         idx_p = 0:C_HDF5.hsize_t; // reset our iteration counter
         C_HDF5.H5Literate(fid, C_HDF5.H5_INDEX_NAME, C_HDF5.H5_ITER_NATIVE, idx_p, c_ptrTo(_simulate_h5ls), c_field_names);
         var pos = c_strlen(c_field_names):int;
-        var items = createStringWithNewBuffer(c_field_names, pos, pos+1);
+        var items = string.createCopyingBuffer(c_field_names, pos, pos+1);
         c_free(c_field_names);
         return items;
     }

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -18,6 +18,7 @@ module ParquetMsg {
   use SegmentedArray;
 
   use ArkoudaMapCompat;
+  use ArkoudaStringBytesCompat;
 
   enum CompressionType {
     NONE=0,
@@ -81,7 +82,7 @@ module ParquetMsg {
       extern proc strlen(a): int;
       var err: string;
       try {
-        err = createStringWithNewBuffer(errMsg, strlen(errMsg));
+        err = string.createCopyingBuffer(errMsg, strlen(errMsg));
       } catch e {
         err = "Error converting Parquet error message to Chapel string";
       }
@@ -104,7 +105,7 @@ module ParquetMsg {
     }
     var ret: string;
     try {
-      ret = createStringWithNewBuffer(cVersionString,
+      ret = string.createCopyingBuffer(cVersionString,
                                 strlen(cVersionString));
     } catch e {
       ret = "Error converting Arrow version message to Chapel string";
@@ -924,7 +925,7 @@ module ParquetMsg {
       pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
     }
     var datasets: string;
-    try! datasets = createStringWithNewBuffer(res, strlen(res));
+    try! datasets = string.createCopyingBuffer(res, strlen(res));
     return new list(datasets.split(","));
   }
 
@@ -1722,7 +1723,7 @@ module ParquetMsg {
                            c_ptrTo(pqErr.errMsg)) == ARROWERROR {
         pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
       }
-      try! repMsg = createStringWithNewBuffer(res, strlen(res));
+      try! repMsg = string.createCopyingBuffer(res, strlen(res));
       var items = new list(repMsg.split(",")); // convert to json
 
       repMsg = "%jt".format(items);

--- a/src/SegStringSort.chpl
+++ b/src/SegStringSort.chpl
@@ -12,6 +12,7 @@ module SegStringSort {
   use BlockDist;
 
   use ArkoudaBlockCompat;
+  use ArkoudaStringBytesCompat;
 
   private config const SSS_v = false;
   private const vv = SSS_v;
@@ -150,7 +151,7 @@ module SegStringSort {
       const l = lengths[i];
       var buf: [0..#(l+1)] uint(8);
       buf[{0..#l}] = va[{oa[i]..#l}];
-      si = (try! createStringWithBorrowedBuffer(c_ptrTo(buf), l, l+1), i);
+      si = (try! string.createBorrowingBuffer(c_ptrTo(buf), l, l+1), i);
     }
     return stringsWithInds;
   }

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -17,6 +17,7 @@ module SegmentedMsg {
   use Math;
 
   use ArkoudaMapCompat;
+  use ArkoudaStringBytesCompat;
 
   private config const logLevel = ServerConfig.logLevel;
   private config const logChannel = ServerConfig.logChannel;
@@ -180,7 +181,7 @@ module SegmentedMsg {
             var localA = makeArrayFromPtr(ptr, D.size:uint);
             localA = A;
             const size = D.size*c_sizeof(eltType):int;
-            return createBytesWithOwnedBuffer(ptr:c_ptr(uint(8)), size, size);
+            return bytes.createAdoptingBuffer(ptr:c_ptr(uint(8)), size, size);
         }
 
         if entry.dtype == DType.Int64 {

--- a/src/SegmentedString.chpl
+++ b/src/SegmentedString.chpl
@@ -22,6 +22,7 @@ module SegmentedString {
   use FileSystem;
 
   use ArkoudaRegexCompat;
+  use ArkoudaStringBytesCompat;
 
   private config const logLevel = ServerConfig.logLevel;
   private config const logChannel = ServerConfig.logChannel;
@@ -1545,11 +1546,11 @@ module SegmentedString {
     try {
       if localSlice.isOwned {
         localSlice.isOwned = false;
-        return createStringWithOwnedBuffer(localSlice.ptr, region.size-1, region.size);
+        return string.createAdoptingBuffer(localSlice.ptr, region.size-1, region.size);
       } else if borrow {
-        return createStringWithBorrowedBuffer(localSlice.ptr, region.size-1, region.size);
+        return string.createBorrowingBuffer(localSlice.ptr, region.size-1, region.size);
       } else {
-        return createStringWithNewBuffer(localSlice.ptr, region.size-1, region.size);
+        return string.createCopyingBuffer(localSlice.ptr, region.size-1, region.size);
       }
     } catch {
       return "<error interpreting bytes as string>";
@@ -1565,11 +1566,11 @@ module SegmentedString {
     try {
       if localSlice.isOwned {
         localSlice.isOwned = false;
-        return createBytesWithOwnedBuffer(localSlice.ptr, region.size-1, region.size);
+        return bytes.createAdoptingBuffer(localSlice.ptr, region.size-1, region.size);
       } else if borrow {
-        return createBytesWithBorrowedBuffer(localSlice.ptr, region.size-1, region.size);
+        return string.createBorrowingBuffer(localSlice.ptr, region.size-1, region.size);
       } else {
-        return createBytesWithNewBuffer(localSlice.ptr, region.size-1, region.size);
+        return bytes.createCopyingBuffer(localSlice.ptr, region.size-1, region.size);
       }
     } catch {
       return b"<error interpreting uint(8) as bytes>";

--- a/src/compat/e-129/ArkoudaStringBytesCompat.chpl
+++ b/src/compat/e-129/ArkoudaStringBytesCompat.chpl
@@ -1,0 +1,99 @@
+module ArkoudaStringBytesCompat {
+
+  inline proc type
+  string.createBorrowingBuffer(x: string): string {
+    return createStringWithBorrowedBuffer(x);
+  }
+
+  inline proc type
+  string.createBorrowingBuffer(x: c_string,
+                               length=x.size)
+                               : string throws {
+    return createStringWithBorrowedBuffer(x, length);
+  }
+
+  inline proc type
+  string.createBorrowingBuffer(x: c_ptr(?t),
+                               length: int,
+                               size: int
+                               ): string throws {
+    return createStringWithBorrowedBuffer(x, length, size);
+  }
+
+  inline proc type
+  string.createAdoptingBuffer(x: c_string, length=x.size): string throws {
+    return createStringWithOwnedBuffer(x, length);
+  }
+
+  inline proc type
+  string.createAdoptingBuffer(x: c_ptr(?t),
+                              length: int,
+                              size: int
+                              ): string throws {
+    return createStringWithOwnedBuffer(x, length, size);
+  }
+
+  inline proc type
+  string.createCopyingBuffer(x: c_string,
+                             length=x.size,
+                             policy=decodePolicy.strict
+                             ): string throws {
+    return createStringWithNewBuffer(x, length, policy);
+  }
+
+  inline proc type
+  string.createCopyingBuffer(x: c_ptr(?t),
+                             length: int,
+                             size=length+1,
+                             policy=decodePolicy.strict
+                             ): string throws {
+    return createStringWithNewBuffer(x, length, size, policy);
+  }
+
+
+
+
+  inline proc type
+  bytes.createBorrowingBuffer(x: bytes): bytes {
+    return createBytesWithBorrowedBuffer(x);
+  }
+
+  inline proc type
+  bytes.createBorrowingBuffer(x: c_string,
+                              length=x.size
+                              ): bytes {
+    return createBytesWithBorrowedBuffer(x, length);
+  }
+
+  inline proc type
+  bytes.createBorrowingBuffer(x: c_ptr(?t),
+                              length: int,
+                              size: int
+                              ): bytes {
+    return createBytesWithBorrowedBuffer(x, length, size);
+  }
+
+  inline proc type
+  bytes.createAdoptingBuffer(x: c_string, length=x.size): bytes {
+    return createBytesWithOwnedBuffer(x, length);
+  }
+
+  inline proc type
+  bytes.createAdoptingBuffer(x: c_ptr(?t), length: int, size: int): bytes {
+    return createBytesWithOwnedBuffer(x, length, size);
+  }
+
+  inline proc type
+  bytes.createCopyingBuffer(x: c_string, length=x.size): bytes {
+    return createBytesWithNewBuffer(x, length);
+  }
+
+  inline proc type
+  bytes.createCopyingBuffer(x: c_ptr(?t),
+                            length: int,
+                            size=length+1
+                            ): bytes {
+    return createBytesWithNewBuffer(x, length, size);
+  }
+  
+}

--- a/src/compat/e-129/ArkoudaTimeCompat.chpl
+++ b/src/compat/e-129/ArkoudaTimeCompat.chpl
@@ -33,6 +33,7 @@
 module ArkoudaTimeCompat {
   import HaltWrappers;
   private use CTypes;
+  private use ArkoudaStringBytesCompat;
 
 // Returns the number of seconds since midnight.  Has the potential for
 // microsecond resolution if supported by the runtime platform
@@ -491,7 +492,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     strftime(c_ptrTo(buf), bufLen, fmt.c_str(), timeStruct);
     var str: string;
     try! {
-      str = createStringWithNewBuffer(c_ptrTo(buf):c_string);
+      str = string.createCopyingBuffer(c_ptrTo(buf):c_string);
     }
     return str;
   }
@@ -799,7 +800,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     strftime(c_ptrTo(buf), bufLen, fmt.c_str(), timeStruct);
     var str: string;
     try! {
-      str = createStringWithNewBuffer(c_ptrTo(buf):c_string);
+      str = string.createCopyingBuffer(c_ptrTo(buf):c_string);
     }
 
     return str;
@@ -1404,7 +1405,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
     var str: string;
     try! {
-      str = createStringWithNewBuffer(c_ptrTo(buf):c_string);
+      str = string.createCopyingBuffer(c_ptrTo(buf):c_string);
     }
 
     return str;

--- a/src/compat/e-130/ArkoudaStringBytesCompat.chpl
+++ b/src/compat/e-130/ArkoudaStringBytesCompat.chpl
@@ -1,0 +1,99 @@
+module ArkoudaStringBytesCompat {
+
+  inline proc type
+  string.createBorrowingBuffer(x: string): string {
+    return createStringWithBorrowedBuffer(x);
+  }
+
+  inline proc type
+  string.createBorrowingBuffer(x: c_string,
+                               length=x.size)
+                               : string throws {
+    return createStringWithBorrowedBuffer(x, length);
+  }
+
+  inline proc type
+  string.createBorrowingBuffer(x: c_ptr(?t),
+                               length: int,
+                               size: int
+                               ): string throws {
+    return createStringWithBorrowedBuffer(x, length, size);
+  }
+
+  inline proc type
+  string.createAdoptingBuffer(x: c_string, length=x.size): string throws {
+    return createStringWithOwnedBuffer(x, length);
+  }
+
+  inline proc type
+  string.createAdoptingBuffer(x: c_ptr(?t),
+                              length: int,
+                              size: int
+                              ): string throws {
+    return createStringWithOwnedBuffer(x, length, size);
+  }
+
+  inline proc type
+  string.createCopyingBuffer(x: c_string,
+                             length=x.size,
+                             policy=decodePolicy.strict
+                             ): string throws {
+    return createStringWithNewBuffer(x, length, policy);
+  }
+
+  inline proc type
+  string.createCopyingBuffer(x: c_ptr(?t),
+                             length: int,
+                             size=length+1,
+                             policy=decodePolicy.strict
+                             ): string throws {
+    return createStringWithNewBuffer(x, length, size, policy);
+  }
+
+
+
+
+  inline proc type
+  bytes.createBorrowingBuffer(x: bytes): bytes {
+    return createBytesWithBorrowedBuffer(x);
+  }
+
+  inline proc type
+  bytes.createBorrowingBuffer(x: c_string,
+                              length=x.size
+                              ): bytes {
+    return createBytesWithBorrowedBuffer(x, length);
+  }
+
+  inline proc type
+  bytes.createBorrowingBuffer(x: c_ptr(?t),
+                              length: int,
+                              size: int
+                              ): bytes {
+    return createBytesWithBorrowedBuffer(x, length, size);
+  }
+
+  inline proc type
+  bytes.createAdoptingBuffer(x: c_string, length=x.size): bytes {
+    return createBytesWithOwnedBuffer(x, length);
+  }
+
+  inline proc type
+  bytes.createAdoptingBuffer(x: c_ptr(?t), length: int, size: int): bytes {
+    return createBytesWithOwnedBuffer(x, length, size);
+  }
+
+  inline proc type
+  bytes.createCopyingBuffer(x: c_string, length=x.size): bytes {
+    return createBytesWithNewBuffer(x, length);
+  }
+
+  inline proc type
+  bytes.createCopyingBuffer(x: c_ptr(?t),
+                            length: int,
+                            size=length+1
+                            ): bytes {
+    return createBytesWithNewBuffer(x, length, size);
+  }
+  
+}

--- a/src/compat/e-130/ArkoudaTimeCompat.chpl
+++ b/src/compat/e-130/ArkoudaTimeCompat.chpl
@@ -33,6 +33,7 @@
 module ArkoudaTimeCompat {
   import HaltWrappers;
   private use CTypes;
+  private use ArkoudaStringBytesCompat;
 
 // Returns the number of seconds since midnight.  Has the potential for
 // microsecond resolution if supported by the runtime platform
@@ -495,7 +496,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     strftime(c_ptrTo(buf), bufLen, fmt.c_str(), timeStruct);
     var str: string;
     try! {
-      str = createStringWithNewBuffer(c_ptrTo(buf):c_string);
+      str = string.createCopyingBuffer(c_ptrTo(buf):c_string);
     }
     return str;
   }
@@ -812,7 +813,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     strftime(c_ptrTo(buf), bufLen, fmt.c_str(), timeStruct);
     var str: string;
     try! {
-      str = createStringWithNewBuffer(c_ptrTo(buf):c_string);
+      str = string.createCopyingBuffer(c_ptrTo(buf):c_string);
     }
 
     return str;
@@ -1430,7 +1431,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
     var str: string;
     try! {
-      str = createStringWithNewBuffer(c_ptrTo(buf):c_string);
+      str = string.createCopyingBuffer(c_ptrTo(buf):c_string);
     }
 
     return str;

--- a/src/compat/gt-130/ArkoudaStringBytesCompat.chpl
+++ b/src/compat/gt-130/ArkoudaStringBytesCompat.chpl
@@ -1,0 +1,1 @@
+module ArkoudaStringBytesCompat {}


### PR DESCRIPTION
closes #2445

Updates for the following deprecations:

- `createStringWithBorrowedBuffer` is renamed to `string.createBorrowingBuffer`
- `createStringWithOwnedBuffer` is renamed to `string.createAdoptingBuffer`
- `createStringWithNewBuffer` is renamed to `string.createCopyingBuffer`
- `createBytesWithBorrowedBuffer` is renamed to `bytes.createBorrowingBuffer`
- `createBytesWithOwnedBuffer` is renamed to `bytes.createAdoptingBuffer`
- `createBytesWithNewBuffer` is renamed to `bytes.createCopyingBuffer`

Adds a compatibility module for these functions