### PR TITLE
Closes #2400: Add arc and hyperbolic trig functions

### DIFF
--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -598,7 +598,7 @@ def arctan2(num: Union[numeric_scalars, pdarray], denom: Union[numeric_scalars, 
                 ),
             )
         )
-    if isinstance(num, pdarray) and isSupportedNumber(denom):
+    elif isinstance(num, pdarray) and isSupportedNumber(denom):
         return create_pdarray(
             type_cast(
                 str,
@@ -613,7 +613,7 @@ def arctan2(num: Union[numeric_scalars, pdarray], denom: Union[numeric_scalars, 
                 ),
             )
         )
-    if isSupportedNumber(num) and isinstance(denom, pdarray):
+    elif isSupportedNumber(num) and isinstance(denom, pdarray):
         return create_pdarray(
             type_cast(
                 str,
@@ -628,14 +628,10 @@ def arctan2(num: Union[numeric_scalars, pdarray], denom: Union[numeric_scalars, 
                 ),
             )
         )
-    if isSupportedNumber(num) and isSupportedNumber(denom):
-        raise TypeError(
-            "Scalar-scalar case is not supported. At least one argument must be a pdarray."
-        )
     else:
         raise TypeError(
             f"Unsupported types {type(num)} and/or {type(denom)}. Supported "
-            f"types are numeric scalars and pdarrays"
+            f"types are numeric scalars and pdarrays. At least one argument must be a pdarray."
         )
 
 

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -584,39 +584,54 @@ def arctan2(num: Union[numeric_scalars, pdarray], denom: Union[numeric_scalars, 
     TypeError
         Raised if the parameter is not a pdarray
     """
-    if (isinstance(num, pdarray) or isSupportedNumber(num)) and (
-        isinstance(denom, pdarray) or isSupportedNumber(denom)
-    ):
-        if isinstance(num, pdarray) and isinstance(denom, pdarray):
-            repMsg = generic_msg(
-                cmd="efunc2vv",
-                args={
-                    "func": "arctan2",
-                    "num": num,
-                    "denom": denom,
-                },
+    if isinstance(num, pdarray) and isinstance(denom, pdarray):
+        return create_pdarray(
+            type_cast(
+                str,
+                generic_msg(
+                    cmd="efunc2vv",
+                    args={
+                        "func": "arctan2",
+                        "num": num,
+                        "denom": denom,
+                    },
+                ),
             )
-        if isinstance(num, pdarray) and isSupportedNumber(denom):
-            repMsg = generic_msg(
-                cmd="efunc2vs",
-                args={
-                    "func": "arctan2",
-                    "num": num,
-                    "scalar": denom,
-                    "dtype": resolve_scalar_dtype(denom),
-                },
+        )
+    if isinstance(num, pdarray) and isSupportedNumber(denom):
+        return create_pdarray(
+            type_cast(
+                str,
+                generic_msg(
+                    cmd="efunc2vs",
+                    args={
+                        "func": "arctan2",
+                        "num": num,
+                        "scalar": denom,
+                        "dtype": resolve_scalar_dtype(denom),
+                    },
+                ),
             )
-        if isSupportedNumber(num) and isinstance(denom, pdarray):
-            repMsg = generic_msg(
-                cmd="efunc2sv",
-                args={
-                    "func": "arctan2",
-                    "scalar": num,
-                    "denom": denom,
-                    "dtype": resolve_scalar_dtype(num),
-                },
+        )
+    if isSupportedNumber(num) and isinstance(denom, pdarray):
+        return create_pdarray(
+            type_cast(
+                str,
+                generic_msg(
+                    cmd="efunc2sv",
+                    args={
+                        "func": "arctan2",
+                        "scalar": num,
+                        "denom": denom,
+                        "dtype": resolve_scalar_dtype(num),
+                    },
+                ),
             )
-        return create_pdarray(type_cast(str, repMsg))
+        )
+    if isSupportedNumber(num) and isSupportedNumber(denom):
+        raise TypeError(
+            "Scalar-scalar case is not supported. At least one argument must be a pdarray."
+        )
     else:
         raise TypeError(
             f"Unsupported types {type(num)} and/or {type(denom)}. Supported "

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -37,6 +37,19 @@ __all__ = [
     "cumprod",
     "sin",
     "cos",
+    "tan",
+    "arcsin",
+    "arccos",
+    "arctan",
+    "arctan2",
+    "sinh",
+    "cosh",
+    "tanh",
+    "arcsinh",
+    "arccosh",
+    "arctanh",
+    "rad2deg",
+    "deg2rad",
     "hash",
     "where",
     "histogram",
@@ -423,6 +436,418 @@ def cos(pda: pdarray) -> pdarray:
         ),
     )
     return create_pdarray(repMsg)
+
+
+@typechecked
+def tan(pda: pdarray) -> pdarray:
+    """
+    Return the element-wise tangent of the array.
+
+    Parameters
+    ----------
+    pda : pdarray
+
+    Returns
+    -------
+    pdarray
+        A pdarray containing tangent for each element
+        of the original pdarray
+
+    Raises
+    ------
+    TypeError
+        Raised if the parameter is not a pdarray
+    """
+    repMsg = generic_msg(
+        cmd="efunc",
+        args={
+            "func": "tan",
+            "array": pda,
+        },
+    )
+    return create_pdarray(type_cast(str, repMsg))
+
+
+@typechecked
+def arcsin(pda: pdarray) -> pdarray:
+    """
+    Return the element-wise inverse sine of the array. The result is between -pi/2 and pi/2.
+
+    Parameters
+    ----------
+    pda : pdarray
+
+    Returns
+    -------
+    pdarray
+        A pdarray containing inverse sine for each element
+        of the original pdarray
+
+    Raises
+    ------
+    TypeError
+        Raised if the parameter is not a pdarray
+    """
+    repMsg = generic_msg(
+        cmd="efunc",
+        args={
+            "func": "arcsin",
+            "array": pda,
+        },
+    )
+    return create_pdarray(type_cast(str, repMsg))
+
+
+@typechecked
+def arccos(pda: pdarray) -> pdarray:
+    """
+    Return the element-wise inverse cosine of the array. The result is between 0 and pi.
+
+    Parameters
+    ----------
+    pda : pdarray
+
+    Returns
+    -------
+    pdarray
+        A pdarray containing inverse cosine for each element
+        of the original pdarray
+
+    Raises
+    ------
+    TypeError
+        Raised if the parameter is not a pdarray
+    """
+    repMsg = generic_msg(
+        cmd="efunc",
+        args={
+            "func": "arccos",
+            "array": pda,
+        },
+    )
+    return create_pdarray(type_cast(str, repMsg))
+
+
+@typechecked
+def arctan(pda: pdarray) -> pdarray:
+    """
+    Return the element-wise inverse tangent of the array. The result is between -pi/2 and pi/2.
+
+    Parameters
+    ----------
+    pda : pdarray
+
+    Returns
+    -------
+    pdarray
+        A pdarray containing inverse tangent for each element
+        of the original pdarray
+
+    Raises
+    ------
+    TypeError
+        Raised if the parameter is not a pdarray
+    """
+    repMsg = generic_msg(
+        cmd="efunc",
+        args={
+            "func": "arctan",
+            "array": pda,
+        },
+    )
+    return create_pdarray(type_cast(str, repMsg))
+
+
+@typechecked
+def arctan2(num: Union[numeric_scalars, pdarray], denom: Union[numeric_scalars, pdarray]) -> pdarray:
+    """
+    Return the element-wise inverse tangent of the array pair. The result chosen is the
+    signed angle in radians between the ray ending at the origin and passing through the
+    point (1,0), and the ray ending at the origin and passing through the point (denom, num).
+    The result is between -pi and pi.
+
+    Parameters
+    ----------
+    num : Union[numeric_scalars, pdarray]
+        Numerator of the arctan2 argument.
+    denom : Union[numeric_scalars, pdarray]
+        Denominator of the arctan2 argument.
+    Returns
+    -------
+    pdarray
+        A pdarray containing inverse tangent for each corresponding element pair
+        of the original pdarray, using the signed values or the numerator and
+        denominator to get proper placement on unit circle.
+
+    Raises
+    ------
+    TypeError
+        Raised if the parameter is not a pdarray
+    """
+    if (isinstance(num, pdarray) or isSupportedNumber(num)) and (
+        isinstance(denom, pdarray) or isSupportedNumber(denom)
+    ):
+        if isinstance(num, pdarray) and isinstance(denom, pdarray):
+            repMsg = generic_msg(
+                cmd="efunc2vv",
+                args={
+                    "func": "arctan2",
+                    "num": num,
+                    "denom": denom,
+                },
+            )
+        if isinstance(num, pdarray) and isSupportedNumber(denom):
+            repMsg = generic_msg(
+                cmd="efunc2vs",
+                args={
+                    "func": "arctan2",
+                    "num": num,
+                    "scalar": denom,
+                    "dtype": resolve_scalar_dtype(denom),
+                },
+            )
+        if isSupportedNumber(num) and isinstance(denom, pdarray):
+            repMsg = generic_msg(
+                cmd="efunc2sv",
+                args={
+                    "func": "arctan2",
+                    "scalar": num,
+                    "denom": denom,
+                    "dtype": resolve_scalar_dtype(num),
+                },
+            )
+        return create_pdarray(type_cast(str, repMsg))
+    else:
+        raise TypeError(
+            f"Unsupported types {type(num)} and/or {type(denom)}. Supported "
+            f"types are numeric scalars and pdarrays"
+        )
+
+
+@typechecked
+def sinh(pda: pdarray) -> pdarray:
+    """
+    Return the element-wise hyperbolic sine of the array.
+
+    Parameters
+    ----------
+    pda : pdarray
+
+    Returns
+    -------
+    pdarray
+        A pdarray containing hyperbolic sine for each element
+        of the original pdarray
+
+    Raises
+    ------
+    TypeError
+        Raised if the parameter is not a pdarray
+    """
+    repMsg = generic_msg(
+        cmd="efunc",
+        args={
+            "func": "sinh",
+            "array": pda,
+        },
+    )
+    return create_pdarray(type_cast(str, repMsg))
+
+
+@typechecked
+def cosh(pda: pdarray) -> pdarray:
+    """
+    Return the element-wise hyperbolic cosine of the array.
+
+    Parameters
+    ----------
+    pda : pdarray
+
+    Returns
+    -------
+    pdarray
+        A pdarray containing hyperbolic cosine for each element
+        of the original pdarray
+
+    Raises
+    ------
+    TypeError
+        Raised if the parameter is not a pdarray
+    """
+    repMsg = generic_msg(
+        cmd="efunc",
+        args={
+            "func": "cosh",
+            "array": pda,
+        },
+    )
+    return create_pdarray(type_cast(str, repMsg))
+
+
+@typechecked
+def tanh(pda: pdarray) -> pdarray:
+    """
+    Return the element-wise hyperbolic tangent of the array.
+
+    Parameters
+    ----------
+    pda : pdarray
+
+    Returns
+    -------
+    pdarray
+        A pdarray containing hyperbolic tangent for each element
+        of the original pdarray
+
+    Raises
+    ------
+    TypeError
+        Raised if the parameter is not a pdarray
+    """
+    repMsg = generic_msg(
+        cmd="efunc",
+        args={
+            "func": "tanh",
+            "array": pda,
+        },
+    )
+    return create_pdarray(type_cast(str, repMsg))
+
+
+@typechecked
+def arcsinh(pda: pdarray) -> pdarray:
+    """
+    Return the element-wise inverse hyperbolic sine of the array.
+
+    Parameters
+    ----------
+    pda : pdarray
+
+    Returns
+    -------
+    pdarray
+        A pdarray containing inverse hyperbolic sine for each element
+        of the original pdarray
+
+    Raises
+    ------
+    TypeError
+        Raised if the parameter is not a pdarray
+    """
+    repMsg = generic_msg(
+        cmd="efunc",
+        args={
+            "func": "arcsinh",
+            "array": pda,
+        },
+    )
+    return create_pdarray(type_cast(str, repMsg))
+
+
+@typechecked
+def arccosh(pda: pdarray) -> pdarray:
+    """
+    Return the element-wise inverse hyperbolic cosine of the array.
+
+    Parameters
+    ----------
+    pda : pdarray
+
+    Returns
+    -------
+    pdarray
+        A pdarray containing inverse hyperbolic cosine for each element
+        of the original pdarray
+
+    Raises
+    ------
+    TypeError
+        Raised if the parameter is not a pdarray
+    """
+    repMsg = generic_msg(
+        cmd="efunc",
+        args={
+            "func": "arccosh",
+            "array": pda,
+        },
+    )
+    return create_pdarray(type_cast(str, repMsg))
+
+
+@typechecked
+def arctanh(pda: pdarray) -> pdarray:
+    """
+    Return the element-wise inverse hyperbolic tangent of the array.
+
+    Parameters
+    ----------
+    pda : pdarray
+
+    Returns
+    -------
+    pdarray
+        A pdarray containing inverse hyperbolic tangent for each element
+        of the original pdarray
+
+    Raises
+    ------
+    TypeError
+        Raised if the parameters are not a pdarray or numeric scalar.
+    """
+    repMsg = generic_msg(
+        cmd="efunc",
+        args={
+            "func": "arctanh",
+            "array": pda,
+        },
+    )
+    return create_pdarray(type_cast(str, repMsg))
+
+
+@typechecked
+def rad2deg(pda: pdarray) -> pdarray:
+    """
+    Converts angles element-wise from radians to degrees.
+
+    Parameters
+    ----------
+    pda : pdarray
+
+    Returns
+    -------
+    pdarray
+        A pdarray containing an angle converted to degrees, from radians, for each element
+        of the original pdarray
+
+    Raises
+    ------
+    TypeError
+        Raised if the parameter is not a pdarray
+    """
+    return 180 * pda / np.pi
+
+
+@typechecked
+def deg2rad(pda: pdarray) -> pdarray:
+    """
+    Converts angles element-wise from degrees to radians.
+
+    Parameters
+    ----------
+    pda : pdarray
+
+    Returns
+    -------
+    pdarray
+        A pdarray containing an angle converted to radians, from degrees, for each element
+        of the original pdarray
+
+    Raises
+    ------
+    TypeError
+        Raised if the parameter is not a pdarray
+    """
+    return np.pi * pda / 180
 
 
 def _hash_helper(a):

--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -55,19 +55,17 @@ module EfuncMsg
         select (gEnt.dtype) {
             when (DType.Int64) {
                 var e = toSymEntry(gEnt,int);
+                ref ea = e.a;
                 select efunc
                 {
                     when "abs" {
-                        var a = st.addEntry(rname, e.size, real);
-                        a.a = abs(e.a);
+                        st.addEntry(rname, new shared SymEntry(abs(ea)));
                     }
                     when "log" {
-                        var a = st.addEntry(rname, e.size, real);
-                        a.a = log(e.a);
+                        st.addEntry(rname, new shared SymEntry(log(ea)));
                     }
                     when "exp" {
-                        var a = st.addEntry(rname, e.size, real);
-                        a.a = exp(e.a);
+                        st.addEntry(rname, new shared SymEntry(exp(ea)));
                     }
                     when "cumsum" {
                         // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
@@ -80,12 +78,40 @@ module EfuncMsg
                         st.addEntry(rname, new shared SymEntry(* scan e.a));
                     }
                     when "sin" {
-                        var a = st.addEntry(rname, e.size, real);
-                        a.a = sin(e.a);
+                        st.addEntry(rname, new shared SymEntry(sin(ea)));
                     }
                     when "cos" {
-                        var a = st.addEntry(rname, e.size, real);
-                        a.a = cos(e.a);
+                        st.addEntry(rname, new shared SymEntry(cos(ea)));
+                    }
+                    when "tan" {
+                        st.addEntry(rname, new shared SymEntry(tan(ea)));
+                    }
+                    when "arcsin" {
+                        st.addEntry(rname, new shared SymEntry(asin(ea)));
+                    }
+                    when "arccos" {
+                        st.addEntry(rname, new shared SymEntry(acos(ea)));
+                    }
+                    when "arctan" {
+                        st.addEntry(rname, new shared SymEntry(atan(ea)));
+                    }
+                    when "sinh" {
+                        st.addEntry(rname, new shared SymEntry(sinh(ea)));
+                    }
+                    when "cosh" {
+                        st.addEntry(rname, new shared SymEntry(cosh(ea)));
+                    }
+                    when "tanh" {
+                        st.addEntry(rname, new shared SymEntry(tanh(ea)));
+                    }
+                    when "arcsinh" {
+                        st.addEntry(rname, new shared SymEntry(asinh(ea)));
+                    }
+                    when "arccosh" {
+                        st.addEntry(rname, new shared SymEntry(acosh(ea)));
+                    }
+                    when "arctanh" {
+                        st.addEntry(rname, new shared SymEntry(atanh(ea)));
                     }
                     when "hash64" {
                         overMemLimit(numBytes(int) * e.size);
@@ -107,20 +133,16 @@ module EfuncMsg
                         repMsg += "created " + st.attrib(rname2) + "+";
                     }
                     when "popcount" {
-                        var a = st.addEntry(rname, e.size, int);
-                        a.a = popCount(e.a);
+                        st.addEntry(rname, new shared SymEntry(popCount(ea)));
                     }
                     when "parity" {
-                        var a = st.addEntry(rname, e.size, int);
-                        a.a = parity(e.a);
+                        st.addEntry(rname, new shared SymEntry(parity(ea)));
                     }
                     when "clz" {
-                        var a = st.addEntry(rname, e.size, int);
-                        a.a = clz(e.a);
+                        st.addEntry(rname, new shared SymEntry(clz(ea)));
                     }
                     when "ctz" {
-                        var a = st.addEntry(rname, e.size, int);
-                        a.a = ctz(e.a);
+                        st.addEntry(rname, new shared SymEntry(ctz(ea)));
                     }
                     otherwise {
                         var errorMsg = notImplementedError(pn,efunc,gEnt.dtype);
@@ -131,19 +153,17 @@ module EfuncMsg
             }
             when (DType.Float64) {
                 var e = toSymEntry(gEnt,real);
+                ref ea = e.a;
                 select efunc
                 {
                     when "abs" {
-                        var a = st.addEntry(rname, e.size, real);
-                        a.a = abs(e.a);
+                        st.addEntry(rname, new shared SymEntry(abs(ea)));
                     }
                     when "log" {
-                        var a = st.addEntry(rname, e.size, real);
-                        a.a = log(e.a);
+                        st.addEntry(rname, new shared SymEntry(log(ea)));
                     }
                     when "exp" {
-                        var a = st.addEntry(rname, e.size, real);
-                        a.a = exp(e.a);
+                        st.addEntry(rname, new shared SymEntry(exp(ea)));
                     }
                     when "cumsum" {
                         // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
@@ -156,16 +176,43 @@ module EfuncMsg
                         st.addEntry(rname, new shared SymEntry(* scan e.a));
                     }
                     when "sin" {
-                        var a = st.addEntry(rname, e.size, real);
-                        a.a = sin(e.a);
+                        st.addEntry(rname, new shared SymEntry(sin(ea)));
                     }
                     when "cos" {
-                        var a = st.addEntry(rname, e.size, real);
-                        a.a = cos(e.a);
+                        st.addEntry(rname, new shared SymEntry(cos(ea)));
+                    }
+                    when "tan" {
+                        st.addEntry(rname, new shared SymEntry(tan(ea)));
+                    }
+                    when "arcsin" {
+                        st.addEntry(rname, new shared SymEntry(asin(ea)));
+                    }
+                    when "arccos" {
+                        st.addEntry(rname, new shared SymEntry(acos(ea)));
+                    }
+                    when "arctan" {
+                        st.addEntry(rname, new shared SymEntry(atan(ea)));
+                    }
+                    when "sinh" {
+                        st.addEntry(rname, new shared SymEntry(sinh(ea)));
+                    }
+                    when "cosh" {
+                        st.addEntry(rname, new shared SymEntry(cosh(ea)));
+                    }
+                    when "tanh" {
+                        st.addEntry(rname, new shared SymEntry(tanh(ea)));
+                    }
+                    when "arcsinh" {
+                        st.addEntry(rname, new shared SymEntry(asinh(ea)));
+                    }
+                    when "arccosh" {
+                        st.addEntry(rname, new shared SymEntry(acosh(ea)));
+                    }
+                    when "arctanh" {
+                        st.addEntry(rname, new shared SymEntry(atanh(ea)));
                     }
                     when "isnan" {
-                        var a = st.addEntry(rname, e.size, bool);
-                        a.a = isnan(e.a);
+                        st.addEntry(rname, new shared SymEntry(isnan(ea)));
                     }
                     when "hash64" {
                         overMemLimit(numBytes(real) * e.size);
@@ -218,19 +265,17 @@ module EfuncMsg
             }
             when (DType.UInt64) {
                 var e = toSymEntry(gEnt,uint);
+                ref ea = e.a;
                 select efunc
                 {
                     when "popcount" {
-                        var a = st.addEntry(rname, e.size, uint);
-                        a.a = popCount(e.a);
+                        st.addEntry(rname, new shared SymEntry(popCount(ea)));
                     }
                     when "clz" {
-                        var a = st.addEntry(rname, e.size, uint);
-                        a.a = clz(e.a);
+                        st.addEntry(rname, new shared SymEntry(clz(ea)));
                     }
                     when "ctz" {
-                        var a = st.addEntry(rname, e.size, uint);
-                        a.a = ctz(e.a);
+                        st.addEntry(rname, new shared SymEntry(ctz(ea)));
                     }
                     when "cumsum" {
                         // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
@@ -243,16 +288,43 @@ module EfuncMsg
                         st.addEntry(rname, new shared SymEntry(* scan e.a));
                     }
                     when "sin" {
-                        var a = st.addEntry(rname, e.size, real);
-                        a.a = sin(e.a);
+                        st.addEntry(rname, new shared SymEntry(sin(ea)));
                     }
                     when "cos" {
-                        var a = st.addEntry(rname, e.size, real);
-                        a.a = cos(e.a);
+                        st.addEntry(rname, new shared SymEntry(cos(ea)));
+                    }
+                    when "tan" {
+                        st.addEntry(rname, new shared SymEntry(tan(ea)));
+                    }
+                    when "arcsin" {
+                        st.addEntry(rname, new shared SymEntry(asin(ea)));
+                    }
+                    when "arccos" {
+                        st.addEntry(rname, new shared SymEntry(acos(ea)));
+                    }
+                    when "arctan" {
+                        st.addEntry(rname, new shared SymEntry(atan(ea)));
+                    }
+                    when "sinh" {
+                        st.addEntry(rname, new shared SymEntry(sinh(ea)));
+                    }
+                    when "cosh" {
+                        st.addEntry(rname, new shared SymEntry(cosh(ea)));
+                    }
+                    when "tanh" {
+                        st.addEntry(rname, new shared SymEntry(tanh(ea)));
+                    }
+                    when "arcsinh" {
+                        st.addEntry(rname, new shared SymEntry(asinh(ea)));
+                    }
+                    when "arccosh" {
+                        st.addEntry(rname, new shared SymEntry(acosh(ea)));
+                    }
+                    when "arctanh" {
+                        st.addEntry(rname, new shared SymEntry(atanh(ea)));
                     }
                     when "parity" {
-                        var a = st.addEntry(rname, e.size, uint);
-                        a.a = parity(e.a);
+                        st.addEntry(rname, new shared SymEntry(parity(ea)));
                     }
                     when "hash64" {
                         overMemLimit(numBytes(uint) * e.size);
@@ -274,12 +346,10 @@ module EfuncMsg
                         repMsg += "created " + st.attrib(rname2) + "+";
                     }
                     when "log" {
-                        var a = st.addEntry(rname, e.size, real);
-                        a.a = log(e.a);
+                        st.addEntry(rname, new shared SymEntry(log(ea)));
                     }
                     when "exp" {
-                        var a = st.addEntry(rname, e.size, real);
-                        a.a = exp(e.a);
+                        st.addEntry(rname, new shared SymEntry(exp(ea)));
                     }
                     otherwise {
                         var errorMsg = notImplementedError(pn,efunc,gEnt.dtype);
@@ -298,6 +368,390 @@ module EfuncMsg
         repMsg += "created " + st.attrib(rname);
         eLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg); 
         return new MsgTuple(repMsg, MsgType.NORMAL);         
+    }
+
+    /*
+    These are functions which take two arrays and produce an array.
+    vector = efunc(vector, vector)
+
+    :arg reqMsg: request containing (cmd,efunc,num,denom)
+    :type reqMsg: string 
+
+    :arg st: SymTab to act on
+    :type st: borrowed SymTab 
+
+    :returns: (MsgTuple)
+    :throws: `UndefinedSymbolError(name)`
+    */
+    proc efunc2vvMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        param pn = Reflection.getRoutineName();
+        var repMsg: string; // response message
+        // split request into fields
+        var rname = st.nextName();
+        var efunc = msgArgs.getValueOf("func");
+        var num: borrowed GenSymEntry = getGenericTypedArrayEntry(msgArgs.getValueOf("num"), st);
+        var denom: borrowed GenSymEntry = getGenericTypedArrayEntry(msgArgs.getValueOf("denom"), st);
+        if !(num.size == denom.size) {
+            var errorMsg = "size mismatch in arguments to "+pn;
+            eLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg); 
+            return new MsgTuple(errorMsg, MsgType.ERROR); 
+        }
+        select (num.dtype, denom.dtype) {
+            when (DType.Int64, DType.Int64) {
+                var en = toSymEntry(num, int);
+                var ed = toSymEntry(denom, int);
+                select efunc {
+                    when "arctan2" {
+                        var a = [(n,d) in zip(en.a, ed.a)] atan2(n,d);
+                        st.addEntry(rname, new shared SymEntry(a));
+                    }               
+                } 
+            }
+            when (DType.Int64, DType.UInt64) {
+                var en = toSymEntry(num, int);
+                var ed = toSymEntry(denom, uint);
+                select efunc {
+                    when "arctan2" {
+                        var a = [(n,d) in zip(en.a, ed.a)] atan2(n,d);
+                        st.addEntry(rname, new shared SymEntry(a));
+                    }
+                }
+            }
+            when (DType.Int64, DType.Float64) {
+                var en = toSymEntry(num, int);
+                var ed = toSymEntry(denom, real);
+                select efunc {
+                    when "arctan2" {
+                        var a = [(n,d) in zip(en.a, ed.a)] atan2(n,d);
+                        st.addEntry(rname, new shared SymEntry(a));
+                    }
+                }
+            }
+            when (DType.UInt64, DType.Int64) {
+                var en = toSymEntry(num, uint);
+                var ed = toSymEntry(denom, int);
+                select efunc {
+                    when "arctan2" {
+                        var a = [(n,d) in zip(en.a, ed.a)] atan2(n,d);
+                        st.addEntry(rname, new shared SymEntry(a));
+                    }               
+                } 
+            }
+            when (DType.UInt64, DType.UInt64) {
+                var en = toSymEntry(num, uint);
+                var ed = toSymEntry(denom, uint);
+                select efunc {
+                    when "arctan2" {
+                        var a = [(n,d) in zip(en.a, ed.a)] atan2(n,d);
+                        st.addEntry(rname, new shared SymEntry(a));
+                    }
+                }
+            }
+            when (DType.UInt64, DType.Float64) {
+                var en = toSymEntry(num, uint);
+                var ed = toSymEntry(denom, real);
+                select efunc {
+                    when "arctan2" {
+                        var a = [(n,d) in zip(en.a, ed.a)] atan2(n,d);
+                        st.addEntry(rname, new shared SymEntry(a));
+                    }
+                }
+            }
+            when (DType.Float64, DType.Int64) {
+                var en = toSymEntry(num, real);
+                var ed = toSymEntry(denom, int);
+                select efunc {
+                    when "arctan2" {
+                        var a = [(n,d) in zip(en.a, ed.a)] atan2(n,d);
+                        st.addEntry(rname, new shared SymEntry(a));
+                    }               
+                } 
+            }
+            when (DType.Float64, DType.UInt64) {
+                var en = toSymEntry(num, real);
+                var ed = toSymEntry(denom, uint);
+                select efunc {
+                    when "arctan2" {
+                        var a = [(n,d) in zip(en.a, ed.a)] atan2(n,d);
+                        st.addEntry(rname, new shared SymEntry(a));
+                    }
+                }
+            }
+            when (DType.Float64, DType.Float64) {
+                var en = toSymEntry(num, real);
+                var ed = toSymEntry(denom, real);
+                select efunc {
+                    when "arctan2" {
+                        var a = [(n,d) in zip(en.a, ed.a)] atan2(n,d);
+                        st.addEntry(rname, new shared SymEntry(a));
+                    }
+                }
+            }
+            otherwise {
+               var errorMsg = notImplementedError(pn,efunc,num.dtype,denom.dtype);
+               eLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);       
+               return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+        }
+        repMsg = "created " + st.attrib(rname);
+        eLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg); 
+        return new MsgTuple(repMsg, MsgType.NORMAL); 
+    }
+
+    /*
+    vector = efunc(vector, scalar)
+
+    :arg reqMsg: request containing (cmd,efunc,num,scalar,dtype)
+    :type reqMsg: string 
+
+    :arg st: SymTab to act on
+    :type st: borrowed SymTab 
+
+    :returns: (MsgTuple)
+    :throws: `UndefinedSymbolError(name)`
+    */
+    proc efunc2vsMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        param pn = Reflection.getRoutineName();
+        var repMsg: string; // response message
+        var efunc = msgArgs.getValueOf("func");
+        var rname = st.nextName();
+        var dtype = str2dtype(msgArgs.getValueOf("dtype"));
+
+        var name = msgArgs.getValueOf("num");
+        var num: borrowed GenSymEntry = getGenericTypedArrayEntry(name, st);
+
+        eLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+            "cmd: %s efunc: %s scalar: %s dtype: %s name: %s rname: %s".format(
+             cmd,efunc,msgArgs.getValueOf("dtype"),dtype,name,rname));
+        
+        select (num.dtype, dtype) {
+            when (DType.Int64, DType.Int64) {
+                var en = toSymEntry(num, int);
+                ref ena = en.a;
+                var val = msgArgs.get("scalar").getIntValue();
+                select efunc {
+                    when "arctan2" {
+                        st.addEntry(rname, new shared SymEntry(atan2(ena,val)));
+                    }
+                } 
+            }
+            when (DType.Int64, DType.UInt64) {
+                var en = toSymEntry(num, int);
+                ref ena = en.a;
+                var val = msgArgs.get("scalar").getUIntValue();
+                select efunc {
+                    when "arctan2" {
+                        st.addEntry(rname, new shared SymEntry(atan2(ena,val)));
+                    }
+                } 
+            }
+            when (DType.Int64, DType.Float64) {
+                var en = toSymEntry(num, int);
+                ref ena = en.a;
+                var val = msgArgs.get("scalar").getRealValue();
+                select efunc {
+                    when "arctan2" {
+                        st.addEntry(rname, new shared SymEntry(atan2(ena,val)));
+                    }
+                } 
+            }
+            when (DType.UInt64, DType.Int64) {
+                var en = toSymEntry(num, uint);
+                ref ena = en.a;
+                var val = msgArgs.get("scalar").getIntValue();
+                select efunc {
+                    when "arctan2" {
+                        st.addEntry(rname, new shared SymEntry(atan2(ena,val)));
+                    }
+                } 
+            }
+            when (DType.UInt64, DType.UInt64) {
+                var en = toSymEntry(num, uint);
+                ref ena = en.a;
+                var val = msgArgs.get("scalar").getUIntValue();
+                select efunc {
+                    when "arctan2" {
+                        st.addEntry(rname, new shared SymEntry(atan2(ena,val)));
+                    }
+                } 
+            }
+            when (DType.UInt64, DType.Float64) {
+                var en = toSymEntry(num, uint);
+                ref ena = en.a;
+                var val = msgArgs.get("scalar").getRealValue();
+                select efunc {
+                    when "arctan2" {
+                        st.addEntry(rname, new shared SymEntry(atan2(ena,val)));
+                    }
+                } 
+            }
+            when (DType.Float64, DType.Int64) {
+                var en = toSymEntry(num, real);
+                ref ena = en.a;
+                var val = msgArgs.get("scalar").getIntValue();
+                select efunc {
+                    when "arctan2" {
+                        st.addEntry(rname, new shared SymEntry(atan2(ena,val)));
+                    }
+                } 
+            }
+            when (DType.Float64, DType.UInt64) {
+                var en = toSymEntry(num, real);
+                ref ena = en.a;
+                var val = msgArgs.get("scalar").getUIntValue();
+                select efunc {
+                    when "arctan2" {
+                        st.addEntry(rname, new shared SymEntry(atan2(ena,val)));
+                    }
+                } 
+            }
+            when (DType.Float64, DType.Float64) {
+                var en = toSymEntry(num, real);
+                ref ena = en.a;
+                var val = msgArgs.get("scalar").getRealValue();
+                select efunc {
+                    when "arctan2" {
+                        st.addEntry(rname, new shared SymEntry(atan2(ena,val)));
+                    }
+                } 
+            }
+            otherwise {
+                var errorMsg = notImplementedError(pn,efunc,num.dtype,dtype);
+                eLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg); 
+                return new MsgTuple(errorMsg, MsgType.ERROR);            
+            }
+        }
+        repMsg = "created " + st.attrib(rname);
+        eLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg); 
+        return new MsgTuple(repMsg, MsgType.NORMAL); 
+    }
+
+    /*
+    vector = efunc(scalar, vector)
+
+    :arg reqMsg: request containing (cmd,efunc,scalar,denom,dtype)
+    :type reqMsg: string 
+
+    :arg st: SymTab to act on
+    :type st: borrowed SymTab 
+
+    :returns: (MsgTuple)
+    :throws: `UndefinedSymbolError(name)`
+    */
+    proc efunc2svMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        param pn = Reflection.getRoutineName();
+        var repMsg: string; // response message
+        var efunc = msgArgs.getValueOf("func");
+        var rname = st.nextName();
+        var dtype = str2dtype(msgArgs.getValueOf("dtype"));
+
+        var name = msgArgs.getValueOf("denom");
+        var denom: borrowed GenSymEntry = getGenericTypedArrayEntry(name, st);
+
+        eLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+            "cmd: %s efunc: %s scalar: %s dtype: %s name: %s rname: %s".format(
+             cmd,efunc,msgArgs.getValueOf("scalar"),dtype,name,rname));
+
+        select (dtype, denom.dtype) {
+            when (DType.Int64, DType.Int64) {
+                var val = msgArgs.get("scalar").getIntValue();
+                var ed = toSymEntry(denom, int);
+                ref eda = ed.a;
+                select efunc {
+                    when "arctan2" {
+                        st.addEntry(rname, new shared SymEntry(atan2(val, eda)));
+                    } 
+                } 
+            }
+            when (DType.Int64, DType.UInt64) {
+                var val = msgArgs.get("scalar").getIntValue();
+                var ed = toSymEntry(denom, uint);
+                ref eda = ed.a;
+                select efunc {
+                    when "arctan2" {
+                        st.addEntry(rname, new shared SymEntry(atan2(val, eda)));
+                    } 
+                } 
+            }
+            when (DType.Int64, DType.Float64) {
+                var val = msgArgs.get("scalar").getIntValue();
+                var ed = toSymEntry(denom, real);
+                ref eda = ed.a;
+                select efunc {
+                    when "arctan2" {
+                        st.addEntry(rname, new shared SymEntry(atan2(val, eda)));
+                    } 
+                } 
+            }
+            when (DType.UInt64, DType.Int64) {
+                var val = msgArgs.get("scalar").getUIntValue();
+                var ed = toSymEntry(denom, int);
+                ref eda = ed.a;
+                select efunc {
+                    when "arctan2" {
+                        st.addEntry(rname, new shared SymEntry(atan2(val, eda)));
+                    } 
+                } 
+            }
+            when (DType.UInt64, DType.UInt64) {
+                var val = msgArgs.get("scalar").getUIntValue();
+                var ed = toSymEntry(denom, uint);
+                ref eda = ed.a;
+                select efunc {
+                    when "arctan2" {
+                        st.addEntry(rname, new shared SymEntry(atan2(val, eda)));
+                    } 
+                } 
+            }
+            when (DType.UInt64, DType.Float64) {
+                var val = msgArgs.get("scalar").getUIntValue();
+                var ed = toSymEntry(denom, real);
+                ref eda = ed.a;
+                select efunc {
+                    when "arctan2" {
+                        st.addEntry(rname, new shared SymEntry(atan2(val, eda)));
+                    } 
+                } 
+            }
+            when (DType.Float64, DType.Int64) {
+                var val = msgArgs.get("scalar").getRealValue();
+                var ed = toSymEntry(denom, int);
+                ref eda = ed.a;
+                select efunc {
+                    when "arctan2" {
+                        st.addEntry(rname, new shared SymEntry(atan2(val, eda)));
+                    } 
+                } 
+            }
+            when (DType.Float64, DType.UInt64) {
+                var val = msgArgs.get("scalar").getRealValue();
+                var ed = toSymEntry(denom, uint);
+                ref eda = ed.a;
+                select efunc {
+                    when "arctan2" {
+                        st.addEntry(rname, new shared SymEntry(atan2(val, eda)));
+                    } 
+                } 
+            }
+            when (DType.Float64, DType.Float64) {
+                var val = msgArgs.get("scalar").getRealValue();
+                var ed = toSymEntry(denom, real);
+                ref eda = ed.a;
+                select efunc {
+                    when "arctan2" {
+                        st.addEntry(rname, new shared SymEntry(atan2(val, eda)));
+                    } 
+                } 
+            }
+            otherwise {
+                var errorMsg = notImplementedError(pn,efunc,dtype,denom.dtype);
+                eLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);                                                 
+                return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+        }
+        repMsg = "created " + st.attrib(rname);
+        eLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg); 
+        return new MsgTuple(repMsg, MsgType.NORMAL); 
     }
 
     /*
@@ -403,7 +857,6 @@ module EfuncMsg
                return new MsgTuple(errorMsg, MsgType.ERROR);
             }
         }
-
         repMsg = "created " + st.attrib(rname);
         eLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg); 
         return new MsgTuple(repMsg, MsgType.NORMAL); 
@@ -840,6 +1293,9 @@ module EfuncMsg
 
     use CommandMap;
     registerFunction("efunc", efuncMsg, getModuleName());
+    registerFunction("efunc2vv", efunc2vvMsg, getModuleName());
+    registerFunction("efunc2vs", efunc2vsMsg, getModuleName());
+    registerFunction("efunc2sv", efunc2svMsg, getModuleName());
     registerFunction("efunc3vv", efunc3vvMsg, getModuleName());
     registerFunction("efunc3vs", efunc3vsMsg, getModuleName());
     registerFunction("efunc3sv", efunc3svMsg, getModuleName());

--- a/src/ServerErrorStrings.chpl
+++ b/src/ServerErrorStrings.chpl
@@ -28,6 +28,12 @@ module ServerErrorStrings
                                                               dtype2str(ldtype));
     }
     /* efunc is not implemented for DTypes */
+    proc notImplementedError(pname: string, efunc: string, dt1: DType, dt2: DType): string {
+      return try! "Error: %s: %s %s %s not implemented".format(pname,
+                                                                  efunc,
+                                                                  dtype2str(dt1),
+                                                                  dtype2str(dt2));
+    }
     proc notImplementedError(pname: string, efunc: string, dt1: DType, dt2: DType, dt3: DType): string {
       return try! "Error: %s: %s %s %s %s not implemented".format(pname,
                                                                   efunc,

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -417,24 +417,24 @@ class NumericTest(ArkoudaTest):
         pda2 = ak.array(na2)
 
         self.assertTrue(
-            np.allclose(np.arctan2(na1, na2).tolist(), ak.arctan2(pda1, pda2).to_list(), equal_nan=True)
+            np.allclose(np.arctan2(na1, na2), ak.arctan2(pda1, pda2).to_ndarray(), equal_nan=True)
         )
         self.assertTrue(
-            np.allclose(np.arctan2(na2, na1).tolist(), ak.arctan2(pda2, pda1).to_list(), equal_nan=True)
+            np.allclose(np.arctan2(na2, na1), ak.arctan2(pda2, pda1).to_ndarray(), equal_nan=True)
         )
         self.assertTrue(
-            np.allclose(np.arctan2(na1, 5).tolist(), ak.arctan2(pda1, 5).to_list(), equal_nan=True)
+            np.allclose(np.arctan2(na1, 5), ak.arctan2(pda1, 5).to_ndarray(), equal_nan=True)
         )
         self.assertTrue(
-            np.allclose(np.arctan2(5, na1).tolist(), ak.arctan2(5, pda1).to_list(), equal_nan=True)
+            np.allclose(np.arctan2(5, na1), ak.arctan2(5, pda1).to_ndarray(), equal_nan=True)
         )
         self.assertTrue(
-            np.allclose(np.arctan2(na1, 0).tolist(), ak.arctan2(pda1, 0).to_list(), equal_nan=True)
+            np.allclose(np.arctan2(na1, 0), ak.arctan2(pda1, 0).to_ndarray(), equal_nan=True)
         )
         self.assertTrue(
-            np.allclose(np.arctan2(0, na1).tolist(), ak.arctan2(0, pda1).to_list(), equal_nan=True)
+            np.allclose(np.arctan2(0, na1), ak.arctan2(0, pda1).to_ndarray(), equal_nan=True)
         )
-
+    
     def testSinh(self):
         na = np.arange(0, 10, dtype="int64")
         pda = ak.array(na)
@@ -454,7 +454,8 @@ class NumericTest(ArkoudaTest):
         # Edge case: infinities
         na = np.array([np.inf, -np.inf])
         pda = ak.array(na)
-        self.assertTrue(np.allclose(np.sinh(na).tolist(), ak.sinh(pda).to_list(), equal_nan=True))
+        self.assertTrue(np.allclose(np.sinh(na), ak.sinh(pda).to_ndarray(), equal_nan=True))
+
 
     def testCosh(self):
         na = np.arange(0, 10, dtype="int64")
@@ -475,7 +476,8 @@ class NumericTest(ArkoudaTest):
         # Edge case: infinities
         na = np.array([np.inf, -np.inf])
         pda = ak.array(na)
-        self.assertTrue(np.allclose(np.cosh(na).tolist(), ak.cosh(pda).to_list(), equal_nan=True))
+        self.assertTrue(np.allclose(np.cosh(na), ak.cosh(pda).to_ndarray(), equal_nan=True))
+
 
     def testTanh(self):
         na = np.arange(0, 10, dtype="int64")
@@ -496,7 +498,8 @@ class NumericTest(ArkoudaTest):
         # Edge case: infinities
         na = np.array([np.inf, -np.inf])
         pda = ak.array(na)
-        self.assertTrue(np.allclose(np.tanh(na).tolist(), ak.tanh(pda).to_list(), equal_nan=True))
+        self.assertTrue(np.allclose(np.tanh(na), ak.tanh(pda).to_ndarray(), equal_nan=True))
+    
 
     def testArcsinh(self):
         na = np.arange(0, 10, dtype="int64")
@@ -517,7 +520,8 @@ class NumericTest(ArkoudaTest):
         # Edge case: infinities
         na = np.array([np.inf, -np.inf])
         pda = ak.array(na)
-        self.assertTrue(np.allclose(np.arcsinh(na).tolist(), ak.arcsinh(pda).to_list(), equal_nan=True))
+        self.assertTrue(np.allclose(np.arcsinh(na), ak.arcsinh(pda).to_ndarray(), equal_nan=True))
+
 
     def testArccosh(self):
         na = np.arange(1, 10, dtype="int64")
@@ -539,6 +543,8 @@ class NumericTest(ArkoudaTest):
         na = np.array([1, np.inf])
         pda = ak.array(na)
         self.assertTrue(np.allclose(np.arccosh(na).tolist(), ak.arccosh(pda).to_list(), equal_nan=True))
+        self.assertTrue(np.allclose(np.arccosh(na), ak.arccosh(pda).to_ndarray(), equal_nan=True))
+
 
     def testArctanh(self):
         na = np.arange(-1, 2, dtype="int64")

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -174,14 +174,14 @@ class NumericTest(ArkoudaTest):
             ak.abs([range(0, 10)])
 
     def testCumSum(self):
-        na = np.linspace(1, 10, 10)
+        na = np.linspace(1, 10)
         pda = ak.array(na)
 
         self.assertTrue(np.allclose(np.cumsum(na), ak.cumsum(pda).to_ndarray()))
 
         # Test uint case
-        na = np.linspace(1, 10, 10, "uint64")
-        pda = ak.cast(pda, ak.uint64)
+        na = np.arange(1, 10, dtype="uint64")
+        pda = ak.array(na)
 
         self.assertTrue(np.allclose(np.cumsum(na), ak.cumsum(pda).to_ndarray()))
 
@@ -197,20 +197,396 @@ class NumericTest(ArkoudaTest):
             ak.cumprod([range(0, 10)])
 
     def testSin(self):
-        na = np.linspace(1, 10, 10)
+        na = np.arange(0, 10, dtype="int64")
         pda = ak.array(na)
-
         self.assertTrue(np.allclose(np.sin(na), ak.sin(pda).to_ndarray()))
+
+        na = np.arange(0, 10, dtype="uint64")
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.sin(na), ak.sin(pda).to_ndarray()))
+
+        na = np.linspace(0, 10)
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.sin(na), ak.sin(pda).to_ndarray()))
+
         with self.assertRaises(TypeError):
-            ak.cos([range(0, 10)])
+            ak.sin([range(0, 10)])
 
     def testCos(self):
-        na = np.linspace(1, 10, 10)
+        na = np.arange(0, 10, dtype="int64")
         pda = ak.array(na)
-
         self.assertTrue(np.allclose(np.cos(na), ak.cos(pda).to_ndarray()))
+
+        na = np.arange(0, 10, dtype="uint64")
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.cos(na), ak.cos(pda).to_ndarray()))
+
+        na = np.linspace(0, 10)
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.cos(na), ak.cos(pda).to_ndarray()))
+
         with self.assertRaises(TypeError):
             ak.cos([range(0, 10)])
+
+    def testTan(self):
+        na = np.arange(0, 10, dtype="int64")
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.tan(na), ak.tan(pda).to_ndarray()))
+
+        na = np.arange(0, 10, dtype="uint64")
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.tan(na), ak.tan(pda).to_ndarray()))
+
+        na = np.linspace(0, 10)
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.tan(na), ak.tan(pda).to_ndarray()))
+
+        with self.assertRaises(TypeError):
+            ak.tan([range(0, 10)])
+
+    def testArcsin(self):
+        na = np.arange(-1, 2, dtype="int64")
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.arcsin(na), ak.arcsin(pda).to_ndarray()))
+
+        na = np.arange(0, 2, dtype="uint64")
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.arcsin(na), ak.arcsin(pda).to_ndarray()))
+
+        na = np.linspace(-1, 1)
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.arcsin(na), ak.arcsin(pda).to_ndarray()))
+
+        with self.assertRaises(TypeError):
+            ak.arcsin([range(0, 10)])
+
+    def testArccos(self):
+        na = np.arange(-1, 2, dtype="int64")
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.arccos(na), ak.arccos(pda).to_ndarray()))
+
+        na = np.arange(0, 2, dtype="uint64")
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.arccos(na), ak.arccos(pda).to_ndarray()))
+
+        na = np.linspace(-1, 1)
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.arccos(na), ak.arccos(pda).to_ndarray()))
+
+        with self.assertRaises(TypeError):
+            ak.arccos([range(0, 10)])
+
+    def testArctan(self):
+        na = np.arange(0, 10, dtype="int64")
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.arctan(na), ak.arctan(pda).to_ndarray()))
+
+        na = np.arange(0, 10, dtype="uint64")
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.arctan(na), ak.arctan(pda).to_ndarray()))
+
+        na = np.linspace(0, 10)
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.arctan(na), ak.arctan(pda).to_ndarray()))
+
+        with self.assertRaises(TypeError):
+            ak.arctan([range(0, 10)])
+
+        # Edge case: infinities
+        na = np.array([np.inf, -np.inf])
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.arctan(na), ak.arctan(pda).to_ndarray(), equal_nan=True))
+
+    def testArctan2(self):
+        na1_int = np.arange(10, 0, -1, dtype="int64")
+        pda1_int = ak.array(na1_int)
+        # this also checks that a divide by zero error is properly handled
+        na2_int = np.arange(0, 10, dtype="int64")
+        pda2_int = ak.array(na2_int)
+
+        na1_uint = np.arange(10, 0, -1, dtype="uint64")
+        pda1_uint = ak.array(na1_uint)
+        na2_uint = np.arange(0, 10, dtype="uint64")
+        pda2_uint = ak.array(na2_uint)
+
+        na1_float = np.linspace(0, 1, 10)
+        pda1_float = ak.array(na1_float)
+        na2_float = np.linspace(0, 10, 10)
+        pda2_float = ak.array(na2_float)
+
+        # vector-vector case
+        self.assertTrue(
+            np.allclose(np.arctan2(na1_int, na2_int), ak.arctan2(pda1_int, pda2_int).to_ndarray())
+        )
+        self.assertTrue(
+            np.allclose(np.arctan2(na1_int, na2_uint), ak.arctan2(pda1_int, pda2_uint).to_ndarray())
+        )
+        self.assertTrue(
+            np.allclose(np.arctan2(na1_int, na2_float), ak.arctan2(pda1_int, pda2_float).to_ndarray())
+        )
+
+        self.assertTrue(
+            np.allclose(np.arctan2(na1_uint, na2_int), ak.arctan2(pda1_uint, pda2_int).to_ndarray())
+        )
+        self.assertTrue(
+            np.allclose(np.arctan2(na1_uint, na2_uint), ak.arctan2(pda1_uint, pda2_uint).to_ndarray())
+        )
+        self.assertTrue(
+            np.allclose(np.arctan2(na1_uint, na2_float), ak.arctan2(pda1_uint, pda2_float).to_ndarray())
+        )
+
+        self.assertTrue(
+            np.allclose(np.arctan2(na1_float, na2_int), ak.arctan2(pda1_float, pda2_int).to_ndarray())
+        )
+        self.assertTrue(
+            np.allclose(np.arctan2(na1_float, na2_uint), ak.arctan2(pda1_float, pda2_uint).to_ndarray())
+        )
+        self.assertTrue(
+            np.allclose(
+                np.arctan2(na1_float, na2_float), ak.arctan2(pda1_float, pda2_float).to_ndarray()
+            )
+        )
+
+        with self.assertRaises(TypeError):
+            ak.arctan2([range(0, 10)], [range(0, 10)])
+
+        # vector-scalar case
+        denom = np.array([5]).astype(np.uint)  # work around to get a scalar uint
+
+        self.assertTrue(np.allclose(np.arctan2(na1_int, 5), ak.arctan2(pda1_int, 5).to_ndarray()))
+        self.assertTrue(
+            np.allclose(np.arctan2(na1_int, denom[0]), ak.arctan2(pda1_int, denom[0]).to_ndarray())
+        )
+        self.assertTrue(np.allclose(np.arctan2(na1_int, 5.0), ak.arctan2(pda1_int, 5.0).to_ndarray()))
+
+        self.assertTrue(np.allclose(np.arctan2(na1_uint, 5), ak.arctan2(pda1_uint, 5).to_ndarray()))
+        self.assertTrue(
+            np.allclose(np.arctan2(na1_uint, denom[0]), ak.arctan2(pda1_uint, denom[0]).to_ndarray())
+        )
+        self.assertTrue(np.allclose(np.arctan2(na1_uint, 5.0), ak.arctan2(pda1_uint, 5.0).to_ndarray()))
+
+        self.assertTrue(np.allclose(np.arctan2(na1_float, 5), ak.arctan2(pda1_float, 5).to_ndarray()))
+        self.assertTrue(
+            np.allclose(np.arctan2(na1_float, denom[0]), ak.arctan2(pda1_float, denom[0]).to_ndarray())
+        )
+        self.assertTrue(
+            np.allclose(np.arctan2(na1_float, 5.0), ak.arctan2(pda1_float, 5.0).to_ndarray())
+        )
+
+        with self.assertRaises(TypeError):
+            ak.arctan2([range(0, 10)], 5)
+        with self.assertRaises(TypeError):
+            ak.arctan2([range(0, 10)], denom[0])
+        with self.assertRaises(TypeError):
+            ak.arctan2([range(0, 10)], 5.0)
+
+        # scalar-vector case
+        num = np.array([1]).astype(np.uint)  # work around to get a scalar uint
+
+        self.assertTrue(np.allclose(np.arctan2(1, na2_int), ak.arctan2(1, pda2_int).to_ndarray()))
+        self.assertTrue(np.allclose(np.arctan2(1, na2_uint), ak.arctan2(1, pda2_uint).to_ndarray()))
+        self.assertTrue(np.allclose(np.arctan2(1, na2_float), ak.arctan2(1, pda2_float).to_ndarray()))
+
+        self.assertTrue(
+            np.allclose(np.arctan2(num[0], na2_int), ak.arctan2(num[0], pda2_int).to_ndarray())
+        )
+        self.assertTrue(
+            np.allclose(np.arctan2(num[0], na2_uint), ak.arctan2(num[0], pda2_uint).to_ndarray())
+        )
+        self.assertTrue(
+            np.allclose(np.arctan2(num[0], na2_float), ak.arctan2(num[0], pda2_float).to_ndarray())
+        )
+
+        self.assertTrue(np.allclose(np.arctan2(1.0, na2_int), ak.arctan2(1.0, pda2_int).to_ndarray()))
+        self.assertTrue(np.allclose(np.arctan2(1.0, na2_uint), ak.arctan2(1.0, pda2_uint).to_ndarray()))
+        self.assertTrue(
+            np.allclose(np.arctan2(1.0, na2_float), ak.arctan2(1.0, pda2_float).to_ndarray())
+        )
+
+        with self.assertRaises(TypeError):
+            ak.arctan2(1, [range(0, 10)])
+        with self.assertRaises(TypeError):
+            ak.arctan2(num[0], [range(0, 10)])
+        with self.assertRaises(TypeError):
+            ak.arctan2(1.0, [range(0, 10)])
+
+        # Edge case: Infinities and Zeros
+        na1 = np.array([np.inf, -np.inf])
+        pda1 = ak.array(na1)
+        na2 = np.array([1, 10])
+        pda2 = ak.array(na2)
+
+        self.assertTrue(
+            np.allclose(np.arctan2(na1, na2).tolist(), ak.arctan2(pda1, pda2).to_list(), equal_nan=True)
+        )
+        self.assertTrue(
+            np.allclose(np.arctan2(na2, na1).tolist(), ak.arctan2(pda2, pda1).to_list(), equal_nan=True)
+        )
+        self.assertTrue(
+            np.allclose(np.arctan2(na1, 5).tolist(), ak.arctan2(pda1, 5).to_list(), equal_nan=True)
+        )
+        self.assertTrue(
+            np.allclose(np.arctan2(5, na1).tolist(), ak.arctan2(5, pda1).to_list(), equal_nan=True)
+        )
+        self.assertTrue(
+            np.allclose(np.arctan2(na1, 0).tolist(), ak.arctan2(pda1, 0).to_list(), equal_nan=True)
+        )
+        self.assertTrue(
+            np.allclose(np.arctan2(0, na1).tolist(), ak.arctan2(0, pda1).to_list(), equal_nan=True)
+        )
+
+    def testSinh(self):
+        na = np.arange(0, 10, dtype="int64")
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.sinh(na), ak.sinh(pda).to_ndarray()))
+
+        na = np.arange(0, 10, dtype="uint64")
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.sinh(na), ak.sinh(pda).to_ndarray()))
+
+        na = np.linspace(0, 10)
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.sinh(na), ak.sinh(pda).to_ndarray()))
+
+        with self.assertRaises(TypeError):
+            ak.sinh([range(0, 10)])
+
+        # Edge case: infinities
+        na = np.array([np.inf, -np.inf])
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.sinh(na).tolist(), ak.sinh(pda).to_list(), equal_nan=True))
+
+    def testCosh(self):
+        na = np.arange(0, 10, dtype="int64")
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.cosh(na), ak.cosh(pda).to_ndarray()))
+
+        na = np.arange(0, 10, dtype="uint64")
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.cosh(na), ak.cosh(pda).to_ndarray()))
+
+        na = np.linspace(0, 10)
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.cosh(na), ak.cosh(pda).to_ndarray()))
+
+        with self.assertRaises(TypeError):
+            ak.cosh([range(0, 10)])
+
+        # Edge case: infinities
+        na = np.array([np.inf, -np.inf])
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.cosh(na).tolist(), ak.cosh(pda).to_list(), equal_nan=True))
+
+    def testTanh(self):
+        na = np.arange(0, 10, dtype="int64")
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.tanh(na), ak.tanh(pda).to_ndarray()))
+
+        na = np.arange(0, 10, dtype="uint64")
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.tanh(na), ak.tanh(pda).to_ndarray()))
+
+        na = np.linspace(0, 10)
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.tanh(na), ak.tanh(pda).to_ndarray()))
+
+        with self.assertRaises(TypeError):
+            ak.tanh([range(0, 10)])
+
+        # Edge case: infinities
+        na = np.array([np.inf, -np.inf])
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.tanh(na).tolist(), ak.tanh(pda).to_list(), equal_nan=True))
+
+    def testArcsinh(self):
+        na = np.arange(0, 10, dtype="int64")
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.arcsinh(na), ak.arcsinh(pda).to_ndarray()))
+
+        na = np.arange(0, 10, dtype="uint64")
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.arcsinh(na), ak.arcsinh(pda).to_ndarray()))
+
+        na = np.linspace(0, 10)
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.arcsinh(na), ak.arcsinh(pda).to_ndarray()))
+
+        with self.assertRaises(TypeError):
+            ak.arcsinh([range(0, 10)])
+
+        # Edge case: infinities
+        na = np.array([np.inf, -np.inf])
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.arcsinh(na).tolist(), ak.arcsinh(pda).to_list(), equal_nan=True))
+
+    def testArccosh(self):
+        na = np.arange(1, 10, dtype="int64")
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.arccosh(na), ak.arccosh(pda).to_ndarray()))
+
+        na = np.arange(1, 10, dtype="uint64")
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.arccosh(na), ak.arccosh(pda).to_ndarray()))
+
+        na = np.linspace(1, 10)
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.arccosh(na), ak.arccosh(pda).to_ndarray()))
+
+        with self.assertRaises(TypeError):
+            ak.arccosh([range(0, 10)])
+
+        # Edge case: infinities
+        na = np.array([1, np.inf])
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.arccosh(na).tolist(), ak.arccosh(pda).to_list(), equal_nan=True))
+
+    def testArctanh(self):
+        na = np.arange(-1, 2, dtype="int64")
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.arctanh(na), ak.arctanh(pda).to_ndarray()))
+
+        na = np.arange(0, 2, dtype="uint64")
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.arctanh(na), ak.arctanh(pda).to_ndarray()))
+
+        na = np.linspace(-1, 1)
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.arctanh(na), ak.arctanh(pda).to_ndarray()))
+
+        with self.assertRaises(TypeError):
+            ak.arctanh([range(0, 10)])
+
+    def testRad2deg(self):
+        na = np.arange(0, 10, dtype="int64")
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.rad2deg(na), ak.rad2deg(pda).to_ndarray()))
+
+        na = np.arange(0, 10, dtype="uint64")
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.rad2deg(na), ak.rad2deg(pda).to_ndarray()))
+
+        na = np.linspace(0, 10)
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.rad2deg(na), ak.rad2deg(pda).to_ndarray()))
+
+        with self.assertRaises(TypeError):
+            ak.rad2deg([range(0, 10)])
+
+    def testDeg2rad(self):
+        na = np.arange(0, 10, dtype="int64")
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.deg2rad(na), ak.deg2rad(pda).to_ndarray()))
+
+        na = np.arange(0, 10, dtype="uint64")
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.deg2rad(na), ak.deg2rad(pda).to_ndarray()))
+
+        na = np.linspace(0, 10)
+        pda = ak.array(na)
+        self.assertTrue(np.allclose(np.deg2rad(na), ak.deg2rad(pda).to_ndarray()))
+
+        with self.assertRaises(TypeError):
+            ak.deg2rad([range(0, 10)])
 
     def testHash(self):
         h1, h2 = ak.hash(ak.arange(10))

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -434,7 +434,7 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(np.arctan2(0, na1), ak.arctan2(0, pda1).to_ndarray(), equal_nan=True)
         )
-    
+
     def testSinh(self):
         na = np.arange(0, 10, dtype="int64")
         pda = ak.array(na)
@@ -455,7 +455,6 @@ class NumericTest(ArkoudaTest):
         na = np.array([np.inf, -np.inf])
         pda = ak.array(na)
         self.assertTrue(np.allclose(np.sinh(na), ak.sinh(pda).to_ndarray(), equal_nan=True))
-
 
     def testCosh(self):
         na = np.arange(0, 10, dtype="int64")
@@ -478,7 +477,6 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         self.assertTrue(np.allclose(np.cosh(na), ak.cosh(pda).to_ndarray(), equal_nan=True))
 
-
     def testTanh(self):
         na = np.arange(0, 10, dtype="int64")
         pda = ak.array(na)
@@ -499,7 +497,6 @@ class NumericTest(ArkoudaTest):
         na = np.array([np.inf, -np.inf])
         pda = ak.array(na)
         self.assertTrue(np.allclose(np.tanh(na), ak.tanh(pda).to_ndarray(), equal_nan=True))
-    
 
     def testArcsinh(self):
         na = np.arange(0, 10, dtype="int64")
@@ -522,7 +519,6 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         self.assertTrue(np.allclose(np.arcsinh(na), ak.arcsinh(pda).to_ndarray(), equal_nan=True))
 
-
     def testArccosh(self):
         na = np.arange(1, 10, dtype="int64")
         pda = ak.array(na)
@@ -544,7 +540,6 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         self.assertTrue(np.allclose(np.arccosh(na).tolist(), ak.arccosh(pda).to_list(), equal_nan=True))
         self.assertTrue(np.allclose(np.arccosh(na), ak.arccosh(pda).to_ndarray(), equal_nan=True))
-
 
     def testArctanh(self):
         na = np.arange(-1, 2, dtype="int64")

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -404,6 +404,8 @@ class NumericTest(ArkoudaTest):
         )
 
         with self.assertRaises(TypeError):
+            ak.arctan2(5,10)
+        with self.assertRaises(TypeError):
             ak.arctan2(1, [range(0, 10)])
         with self.assertRaises(TypeError):
             ak.arctan2(num[0], [range(0, 10)])


### PR DESCRIPTION
This PR (Closes #2400) adds:

- the requested inverse and hyperbolic trig functions
- angle unit conversion functions
- testing for `int`, `uint`, and `float` datatypes.

Additional issues have been created to implement `where` functionality to these functions to more closely match numpy. (#2458 and #2461). This will allow for easy single scalar cases to be put in.