### PR TITLE
Updates for Chapel `list.append` deprecation

### DIFF
--- a/src/BigIntMsg.chpl
+++ b/src/BigIntMsg.chpl
@@ -11,6 +11,8 @@ module BigIntMsg {
     use BigInteger;
     use List;
 
+    use ArkoudaListCompat;
+
 
     private config const logLevel = ServerConfig.logLevel;
     private config const logChannel = ServerConfig.logChannel;
@@ -72,7 +74,7 @@ module BigIntMsg {
                   low = tmp:uint;
                   var retname = st.nextName();
                   st.addEntry(retname, new shared SymEntry(low));
-                  retList.append("created %s".format(st.attrib(retname)));
+                  retList.pushBack("created %s".format(st.attrib(retname)));
 
                   all_zero = true;
                   forall t in tmp with (&& reduce all_zero) {

--- a/src/CSVMsg.chpl
+++ b/src/CSVMsg.chpl
@@ -19,6 +19,7 @@ module CSVMsg {
 
     use ArkoudaFileCompat;
     use ArkoudaArrayCompat;
+    use ArkoudaListCompat;
 
     const CSV_HEADER_OPEN = "**HEADER**";
     const CSV_HEADER_CLOSE = "*/HEADER/*";
@@ -402,7 +403,7 @@ module CSVMsg {
                     var entry = new shared SymEntry(a);
                     var rname = st.nextName();
                     st.addEntry(rname, entry);
-                    rtnData.append((dset, "pdarray", rname));
+                    rtnData.pushBack((dset, "pdarray", rname));
                 }
                 when DType.UInt64 {
                     var a = makeDistArray(record_count, uint);
@@ -410,7 +411,7 @@ module CSVMsg {
                     var entry = new shared SymEntry(a);
                     var rname = st.nextName();
                     st.addEntry(rname, entry);
-                    rtnData.append((dset, "pdarray", rname));
+                    rtnData.pushBack((dset, "pdarray", rname));
                 }
                 when DType.Float64 {
                     var a = makeDistArray(record_count, real);
@@ -418,7 +419,7 @@ module CSVMsg {
                     var entry = new shared SymEntry(a);
                     var rname = st.nextName();
                     st.addEntry(rname, entry);
-                    rtnData.append((dset, "pdarray", rname));
+                    rtnData.pushBack((dset, "pdarray", rname));
                 }
                 when DType.Bool {
                     var a = makeDistArray(record_count, bool);
@@ -426,7 +427,7 @@ module CSVMsg {
                     var entry = new shared SymEntry(a);
                     var rname = st.nextName();
                     st.addEntry(rname, entry);
-                    rtnData.append((dset, "pdarray", rname));
+                    rtnData.pushBack((dset, "pdarray", rname));
                 }
                 when DType.Strings {
                     var a = makeDistArray(record_count, string);
@@ -448,7 +449,7 @@ module CSVMsg {
                     }
                     var ss = getSegString(str_offsets, data, st);
                     var rst = (dset, "seg_string", "%s+%t".format(ss.name, ss.nBytes));
-                    rtnData.append(rst);
+                    rtnData.pushBack(rst);
                 }
                 otherwise {
                     throw getErrorWithContext(
@@ -490,7 +491,7 @@ module CSVMsg {
             }
             var ss = getSegString(str_offsets, data, st);
             var rst = (dset, "seg_string", "%s+%t".format(ss.name, ss.nBytes));
-            rtnData.append(rst);
+            rtnData.pushBack(rst);
         }
         return rtnData;
     }
@@ -569,7 +570,7 @@ module CSVMsg {
             try {
                 var dtypes: list(string);
                 (row_cts[i], headers[i], dtypes) = get_info(fname, dsetlist, col_delim);
-                data_types.append(dtypes);
+                data_types.pushBack(dtypes);
             } catch e: FileNotFoundError {
                 fileErrorMsg = "File %s not found".format(fname);
                 csvLogger.error(getModuleName(),getRoutineName(),getLineNumber(),fileErrorMsg);
@@ -600,7 +601,7 @@ module CSVMsg {
             if hadError {
                 // Keep running total, but we'll only report back the first 10
                 if fileErrorCount < 10 {
-                    fileErrors.append(fileErrorMsg.replace("\n", " ").replace("\r", " ").replace("\t", " ").strip());
+                    fileErrors.pushBack(fileErrorMsg.replace("\n", " ").replace("\r", " ").replace("\t", " ").strip());
                 }
                 fileErrorCount += 1;
                 validFiles[i] = false;

--- a/src/ExternalIntegration.chpl
+++ b/src/ExternalIntegration.chpl
@@ -168,16 +168,16 @@ module ExternalIntegration {
             var format = this.requestFormat;
             select(format) {     
                 when HttpRequestFormat.JSON {
-                    args.pushBack("Accept: application/json");
+                    args.append("Accept: application/json");
                     if this.requestType == HttpRequestType.PATCH {
-                        args.pushBack('Content-Type: application/json-patch+json');
+                        args.append('Content-Type: application/json-patch+json');
                     } else {
-                        args.pushBack("Content-Type: application/json");    
+                        args.append("Content-Type: application/json");    
                     }               
                 }     
                 when HttpRequestFormat.TEXT {
-                    args.pushBack("Accept: text/plain");
-                    args.pushBack("Content-Type: text/plain; charset=UTF-8");
+                    args.append("Accept: text/plain");
+                    args.append("Content-Type: text/plain; charset=UTF-8");
                 } 
                 otherwise {
                     throw new Error("Unsupported HttpFormat");

--- a/src/ExternalIntegration.chpl
+++ b/src/ExternalIntegration.chpl
@@ -7,6 +7,8 @@ module ExternalIntegration {
     use ServerConfig;
     use ServerErrors;
 
+    use ArkoudaListCompat;
+
     private config const logLevel = ServerConfig.logLevel;
     private config const logChannel = ServerConfig.logChannel;
     const eiLogger = new Logger(logLevel, logChannel);
@@ -166,16 +168,16 @@ module ExternalIntegration {
             var format = this.requestFormat;
             select(format) {     
                 when HttpRequestFormat.JSON {
-                    args.append("Accept: application/json");
+                    args.pushBack("Accept: application/json");
                     if this.requestType == HttpRequestType.PATCH {
-                        args.append('Content-Type: application/json-patch+json');
+                        args.pushBack('Content-Type: application/json-patch+json');
                     } else {
-                        args.append("Content-Type: application/json");    
+                        args.pushBack("Content-Type: application/json");    
                     }               
                 }     
                 when HttpRequestFormat.TEXT {
-                    args.append("Accept: text/plain");
-                    args.append("Content-Type: text/plain; charset=UTF-8");
+                    args.pushBack("Accept: text/plain");
+                    args.pushBack("Content-Type: text/plain; charset=UTF-8");
                 } 
                 otherwise {
                     throw new Error("Unsupported HttpFormat");

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -19,6 +19,7 @@ module GenSymIO {
     use SegmentedString;
 
     use ArkoudaMapCompat;
+    use ArkoudaListCompat;
 
     private config const logLevel = ServerConfig.logLevel;
     private config const logChannel = ServerConfig.logChannel;
@@ -219,7 +220,7 @@ module GenSymIO {
                 continue;
             }
             item.add("created", create_str);
-            items.append(item);
+            items.pushBack(item);
         }
         
         var reply: map(string, string) = new map(string, string);

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -28,6 +28,7 @@ module HDF5Msg {
     use Sort;
 
     use ArkoudaMapCompat;
+    use ArkoudaListCompat;
 
     private config const logLevel = ServerConfig.logLevel;
     private config const logChannel = ServerConfig.logChannel;
@@ -1650,7 +1651,7 @@ module HDF5Msg {
             var obj_type:C_HDF5.H5O_type_t;
             var status:C_HDF5.H5O_type_t = c_get_HDF5_obj_type(loc_id, obj_name, c_ptrTo(obj_type));
             if (obj_type == C_HDF5.H5O_TYPE_GROUP || obj_type == C_HDF5.H5O_TYPE_DATASET) {
-                // items.append(obj_name:string); This doesn't work unless items is global
+                // items.pushBack(obj_name:string); This doesn't work unless items is global
                 c_append_HDF5_fieldname(data, obj_name);
             }
             return 0; // to continue iteration
@@ -2800,7 +2801,7 @@ module HDF5Msg {
                 if hadError {
                     // Keep running total, but we'll only report back the first 10
                     if fileErrorCount < 10 {
-                        fileErrors.append(fileErrorMsg.replace("\n", " ").replace("\r", " ").replace("\t", " ").strip());
+                        fileErrors.pushBack(fileErrorMsg.replace("\n", " ").replace("\r", " ").replace("\t", " ").strip());
                     }
                     fileErrorCount += 1;
                     validFiles[i] = false;
@@ -2836,28 +2837,28 @@ module HDF5Msg {
 
             if tagData {
                 h5Logger.debug(getModuleName(),getRoutineName(),getLineNumber(), "Tagging Data with File Code");
-                rtnData.append(generateTagData(filenames, dsetName, objType, validFiles, st));
+                rtnData.pushBack(generateTagData(filenames, dsetName, objType, validFiles, st));
                 tagData = false; // turn off so we only run once
             }
 
             select objType {
                 when ObjType.ARRAYVIEW {
-                    rtnData.append(arrayView_readhdfMsg(filenames, dsetName, dataclass, bytesize, isSigned, validFiles, st));
+                    rtnData.pushBack(arrayView_readhdfMsg(filenames, dsetName, dataclass, bytesize, isSigned, validFiles, st));
                 }
                 when ObjType.PDARRAY {
-                    rtnData.append(pdarray_readhdfMsg(filenames, dsetName, dataclass, bytesize, isSigned, validFiles, st));
+                    rtnData.pushBack(pdarray_readhdfMsg(filenames, dsetName, dataclass, bytesize, isSigned, validFiles, st));
                 }
                 when ObjType.STRINGS {
-                    rtnData.append(strings_readhdfMsg(filenames, dsetName, dataclass, bytesize, isSigned, calcStringOffsets, validFiles, st));
+                    rtnData.pushBack(strings_readhdfMsg(filenames, dsetName, dataclass, bytesize, isSigned, calcStringOffsets, validFiles, st));
                 }
                 when ObjType.SEGARRAY {
-                    rtnData.append(segarray_readhdfMsg(filenames, dsetName, dataclass, bytesize, isSigned, validFiles, st));
+                    rtnData.pushBack(segarray_readhdfMsg(filenames, dsetName, dataclass, bytesize, isSigned, validFiles, st));
                 }
                 when ObjType.CATEGORICAL {
-                    rtnData.append(categorical_readhdfMsg(filenames, dsetName, validFiles, calcStringOffsets, st));
+                    rtnData.pushBack(categorical_readhdfMsg(filenames, dsetName, validFiles, calcStringOffsets, st));
                 }
                 when ObjType.GROUPBY {
-                    rtnData.append(groupby_readhdfMsg(filenames, dsetName, validFiles, calcStringOffsets, st));
+                    rtnData.pushBack(groupby_readhdfMsg(filenames, dsetName, validFiles, calcStringOffsets, st));
                 }
                 otherwise {
                     var errorMsg = "Unknown object type found";

--- a/src/Message.chpl
+++ b/src/Message.chpl
@@ -9,6 +9,7 @@ module Message {
 
     use ArkoudaFileCompat;
     use ArkoudaMapCompat;
+    use ArkoudaListCompat;
 
     enum MsgType {NORMAL,WARNING,ERROR}
     enum MsgFormat {STRING,BINARY}
@@ -397,7 +398,7 @@ module Message {
         var pArr = jsonToPdArray(json_str, size);
         var param_list = new list(ParameterObj, parSafe=true);
         forall j_str in pArr with (ref param_list) {
-            param_list.append(parseParameter(j_str));
+            param_list.pushBack(parseParameter(j_str));
         }
         return new owned MessageArgs(param_list);
     }

--- a/src/MetricsMsg.chpl
+++ b/src/MetricsMsg.chpl
@@ -13,6 +13,7 @@ module MetricsMsg {
     use ArkoudaTimeCompat as Time;
 
     use ArkoudaMapCompat;
+    use ArkoudaListCompat;
 
     enum MetricCategory{ALL,NUM_REQUESTS,RESPONSE_TIME,AVG_RESPONSE_TIME,TOTAL_RESPONSE_TIME,
                         TOTAL_MEMORY_USED,SYSTEM,SERVER,SERVER_INFO};
@@ -132,7 +133,7 @@ module MetricsMsg {
             var userMetrics = this.getUserMetrics(this.users.getUser(userName));
             var metrics = new list(owned UserMetric?);
             for (metric, value) in userMetrics.items() {
-                metrics.append(new UserMetric(name=metric,
+                metrics.pushBack(new UserMetric(name=metric,
                                               scope=MetricScope.USER,
                                               category=MetricCategory.NUM_REQUESTS,
                                               value=value,
@@ -145,7 +146,7 @@ module MetricsMsg {
             var metrics = new list(owned UserMetric?);
             for userName in this.users.getUserNames() {
                 for metric in this.getPerUserNumRequestsPerCommandMetrics(userName) {
-                    metrics.append(metric);
+                    metrics.pushBack(metric);
                 }
             }
 
@@ -334,28 +335,28 @@ module MetricsMsg {
         var metrics = new list(owned Metric?);
 
         for metric in getNumRequestMetrics() {
-            metrics.append(metric);
+            metrics.pushBack(metric);
         }
         for metric in getResponseTimeMetrics() {
-            metrics.append(metric);
+            metrics.pushBack(metric);
         }        
         for metric in getAvgResponseTimeMetrics() {
-            metrics.append(metric);
+            metrics.pushBack(metric);
         }
         for metric in getTotalResponseTimeMetrics() {
-            metrics.append(metric);
+            metrics.pushBack(metric);
         }
         for metric in getTotalMemoryUsedMetrics() {
-            metrics.append(metric);
+            metrics.pushBack(metric);
         }
         for metric in getSystemMetrics() {
-            metrics.append(metric);
+            metrics.pushBack(metric);
         }
         for metric in getServerMetrics() {
-            metrics.append(metric);
+            metrics.pushBack(metric);
         }
         for metric in getAllUserRequestMetrics() {
-            metrics.append(metric);
+            metrics.pushBack(metric);
         }
 
         return metrics.toArray();
@@ -373,7 +374,7 @@ module MetricsMsg {
         var metrics: list(owned Metric?);
          
         for item in serverMetrics.items(){
-            metrics.append(new Metric(name=item[0], category=MetricCategory.SERVER, 
+            metrics.pushBack(new Metric(name=item[0], category=MetricCategory.SERVER, 
                                           value=item[1]));
         }
 
@@ -384,12 +385,12 @@ module MetricsMsg {
         var metrics = new list(owned Metric?);
 
         for item in requestMetrics.items() {
-            metrics.append(new Metric(name=item[0], 
+            metrics.pushBack(new Metric(name=item[0], 
                                       category=MetricCategory.NUM_REQUESTS,
                                       value=item[1]));
         }
         
-        metrics.append(new Metric(name='total', 
+        metrics.pushBack(new Metric(name='total', 
                                   category=MetricCategory.NUM_REQUESTS, 
                                   value=requestMetrics.total()));
         return metrics;
@@ -399,12 +400,12 @@ module MetricsMsg {
         var metrics = new list(owned Metric?);
 
         for item in userMetrics.items() {
-            metrics.append(new Metric(name=item[0],
+            metrics.pushBack(new Metric(name=item[0],
                                       category=MetricCategory.NUM_REQUESTS,
                                       value=item[1]));
         }
 
-        metrics.append(new Metric(name='total',
+        metrics.pushBack(new Metric(name='total',
                                   category=MetricCategory.NUM_REQUESTS,
                                   value=requestMetrics.total()));
         return metrics;
@@ -415,7 +416,7 @@ module MetricsMsg {
         var metrics = new list(owned Metric?);
 
         for item in responseTimeMetrics.items() {
-            metrics.append(new Metric(name=item[0], 
+            metrics.pushBack(new Metric(name=item[0], 
                                       category=MetricCategory.RESPONSE_TIME,
                                       value=item[1]));
         }
@@ -427,7 +428,7 @@ module MetricsMsg {
         var metrics = new list(owned Metric?);
 
         for item in avgResponseTimeMetrics.items() {
-            metrics.append(new Metric(name=item[0], 
+            metrics.pushBack(new Metric(name=item[0], 
                                       category=MetricCategory.AVG_RESPONSE_TIME,
                                       value=item[1]));
         }
@@ -439,7 +440,7 @@ module MetricsMsg {
         var metrics = new list(owned Metric?);
 
         for item in totalResponseTimeMetrics.items() {
-            metrics.append(new Metric(name=item[0], 
+            metrics.pushBack(new Metric(name=item[0], 
                                       category=MetricCategory.TOTAL_RESPONSE_TIME,
                                       value=item[1]));
         }
@@ -451,7 +452,7 @@ module MetricsMsg {
         var metrics = new list(owned Metric?);
 
         for item in totalMemoryUsedMetrics.items() {
-            metrics.append(new Metric(name=item[0], 
+            metrics.pushBack(new Metric(name=item[0], 
                                       category=MetricCategory.TOTAL_MEMORY_USED,
                                       value=item[1]));
         }
@@ -476,13 +477,13 @@ module MetricsMsg {
             mLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                               'memoryUsed: %i physicalMemory: %i'.format(used,total));
 
-            metrics.append(new LocaleMetric(name="arkouda_memory_used_per_locale",
+            metrics.pushBack(new LocaleMetric(name="arkouda_memory_used_per_locale",
                              category=MetricCategory.SYSTEM,
                              locale_num=loc.id,
                              locale_name=loc.name,
                              locale_hostname = loc.hostname,
                              value=used):Metric);
-            metrics.append(new LocaleMetric(name="arkouda_percent_memory_used_per_locale",
+            metrics.pushBack(new LocaleMetric(name="arkouda_percent_memory_used_per_locale",
                              category=MetricCategory.SYSTEM,
                              locale_num=loc.id,
                              locale_name=loc.name,
@@ -505,7 +506,7 @@ module MetricsMsg {
                                       number_of_processing_units=loc.numPUs(),
                                       physical_memory=loc.physicalMemory():int,
                                       max_number_of_tasks=loc.maxTaskPar);   
-            localeInfos.append(info);                                                                                                                  
+            localeInfos.pushBack(info);                                                                                                                  
         }  
  
         var serverInfo = new ServerInfo(hostname=serverHostname, 

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -18,6 +18,7 @@ module ParquetMsg {
   use SegmentedArray;
 
   use ArkoudaMapCompat;
+  use ArkoudaListCompat;
 
   enum CompressionType {
     NONE=0,
@@ -821,7 +822,7 @@ module ParquetMsg {
             if hadError {
               // Keep running total, but we'll only report back the first 10
               if fileErrorCount < 10 {
-                fileErrors.append(fileErrorMsg.replace("\n", " ").replace("\r", " ").replace("\t", " ").strip());
+                fileErrors.pushBack(fileErrorMsg.replace("\n", " ").replace("\r", " ").replace("\t", " ").strip());
               }
               fileErrorCount += 1;
             }
@@ -836,7 +837,7 @@ module ParquetMsg {
           populateTagData(tagEntry.a, filenames, sizes);
           var rname = st.nextName();
           st.addEntry(rname, tagEntry);
-          rnames.append(("Filename_Codes", "pdarray", rname));
+          rnames.pushBack(("Filename_Codes", "pdarray", rname));
           tagData = false; // turn off so we only run once
         }
 
@@ -847,7 +848,7 @@ module ParquetMsg {
           readFilesByName(entryVal.a, filenames, sizes, dsetname, ty);
           var valName = st.nextName();
           st.addEntry(valName, entryVal);
-          rnames.append((dsetname, "pdarray", valName));
+          rnames.pushBack((dsetname, "pdarray", valName));
         } else if ty == ArrowTypes.uint64 || ty == ArrowTypes.uint32 {
           var entryVal = new shared SymEntry(len, uint);
           readFilesByName(entryVal.a, filenames, sizes, dsetname, ty);
@@ -859,13 +860,13 @@ module ParquetMsg {
           }
           var valName = st.nextName();
           st.addEntry(valName, entryVal);
-          rnames.append((dsetname, "pdarray", valName));
+          rnames.pushBack((dsetname, "pdarray", valName));
         } else if ty == ArrowTypes.boolean {
           var entryVal = new shared SymEntry(len, bool);
           readFilesByName(entryVal.a, filenames, sizes, dsetname, ty);
           var valName = st.nextName();
           st.addEntry(valName, entryVal);
-          rnames.append((dsetname, "pdarray", valName));
+          rnames.pushBack((dsetname, "pdarray", valName));
         } else if ty == ArrowTypes.stringArr {
           var entrySeg = new shared SymEntry(len, int);
           byteSizes = calcStrSizesAndOffset(entrySeg.a, filenames, sizes, dsetname);
@@ -875,13 +876,13 @@ module ParquetMsg {
           readStrFilesByName(entryVal.a, filenames, byteSizes, dsetname, ty);
           
           var stringsEntry = assembleSegStringFromParts(entrySeg, entryVal, st);
-          rnames.append((dsetname, "seg_string", "%s+%t".format(stringsEntry.name, stringsEntry.nBytes)));
+          rnames.pushBack((dsetname, "seg_string", "%s+%t".format(stringsEntry.name, stringsEntry.nBytes)));
         } else if ty == ArrowTypes.double || ty == ArrowTypes.float {
           var entryVal = new shared SymEntry(len, real);
           readFilesByName(entryVal.a, filenames, sizes, dsetname, ty);
           var valName = st.nextName();
           st.addEntry(valName, entryVal);
-          rnames.append((dsetname, "pdarray", valName));
+          rnames.pushBack((dsetname, "pdarray", valName));
         } else if ty == ArrowTypes.list {
           var list_ty = getListData(filenames[0], dsetname);
           if list_ty == ArrowTypes.notimplemented { // check for and skip further nested datasets
@@ -889,7 +890,7 @@ module ParquetMsg {
           }
           else {
             var create_str: string = parseListDataset(filenames, dsetname, list_ty, len, sizes, st);
-            rnames.append((dsetname, "seg_array", create_str));
+            rnames.pushBack((dsetname, "seg_array", create_str));
           }
         } else {
           var errorMsg = "DType %s not supported for Parquet reading".format(ty);
@@ -1811,7 +1812,7 @@ module ParquetMsg {
             if hadError {
               // Keep running total, but we'll only report back the first 10
               if fileErrorCount < 10 {
-                fileErrors.append(fileErrorMsg.replace("\n", " ").replace("\r", " ").replace("\t", " ").strip());
+                fileErrors.pushBack(fileErrorMsg.replace("\n", " ").replace("\r", " ").replace("\t", " ").strip());
               }
               fileErrorCount += 1;
             }
@@ -1824,7 +1825,7 @@ module ParquetMsg {
           getNullIndices(entryVal.a, filenames, sizes, dsetname, ty);
           var valName = st.nextName();
           st.addEntry(valName, entryVal);
-          rnames.append((dsetname, "pdarray", valName));
+          rnames.pushBack((dsetname, "pdarray", valName));
         } else {
           var errorMsg = "Null indices only supported on Parquet string columns, not {} columns".format(ty);
           pqLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);

--- a/src/ServerDaemon.chpl
+++ b/src/ServerDaemon.chpl
@@ -27,6 +27,7 @@ module ServerDaemon {
     use NumPyDType;
 
     use ArkoudaFileCompat;
+    use ArkoudaListCompat;
 
     enum ServerDaemonType {DEFAULT,INTEGRATION,METRICS}
 
@@ -50,7 +51,7 @@ module ServerDaemon {
         for rt in rawTypes {
             var daemonType: ServerDaemonType;
             daemonType = rt: ServerDaemonType;
-            types.append(daemonType);
+            types.pushBack(daemonType);
         }
         return types;
     }    
@@ -854,7 +855,7 @@ module ServerDaemon {
         var daemons = new list(shared ArkoudaServerDaemon);
 
         for (daemonType,i) in zip(serverDaemonTypes,0..serverDaemonTypes.size-1) {
-            daemons.append(getServerDaemon(daemonType));
+            daemons.pushBack(getServerDaemon(daemonType));
         }
         return daemons;
     }

--- a/src/compat/e-129/ArkoudaListCompat.chpl
+++ b/src/compat/e-129/ArkoudaListCompat.chpl
@@ -13,7 +13,7 @@ module ArkoudaListCompat {
     this.append(other);
   }
 
-  proc list.pushBack(other: range(this.eltType, ?, ?)) {
+  proc list.pushBack(other: range(this.eltType, ?)) {
     this.append(other);
   }
 

--- a/src/compat/e-129/ArkoudaListCompat.chpl
+++ b/src/compat/e-129/ArkoudaListCompat.chpl
@@ -1,0 +1,27 @@
+module ArkoudaListCompat {
+  use List;
+
+  proc list.pushBack(x: this.eltType): int {
+    return this.append(x);
+  }
+
+  proc list.pushBack(other: list(this.eltType)) {
+    this.append(other);
+  }
+
+  proc list.pushBack(other: [] this.elType) {
+    this.append(other);
+  }
+
+  proc list.pushBack(other: range(this.eltType, ?, ?)) {
+    this.append(other);
+  }
+
+  proc list.popBack(): this.elType {
+    return this.pop();
+  }
+
+  proc list.replace(i: int, x: this.eltType): bool {
+    return this.set(i, x);
+  }
+}

--- a/src/compat/e-129/ArkoudaListCompat.chpl
+++ b/src/compat/e-129/ArkoudaListCompat.chpl
@@ -1,19 +1,19 @@
 module ArkoudaListCompat {
   use List;
 
-  proc ref list.pushBack(x: this.eltType): int {
+  proc ref list.pushBack(in x: this.eltType): int {
     return this.append(x);
   }
 
-  proc ref list.pushBack(other: list(this.eltType)) {
+  proc ref list.pushBack(other: list(this.eltType)) lifetime this < other {
     this.append(other);
   }
 
-  proc ref list.pushBack(other: [] this.elType) {
+  proc ref list.pushBack(other: [] this.elType) lifetime this < other {
     this.append(other);
   }
 
-  proc ref list.pushBack(other: range(this.eltType, ?)) {
+  proc ref list.pushBack(other: range(this.eltType, ?)) lifetime this < other {
     this.append(other);
   }
 

--- a/src/compat/e-129/ArkoudaListCompat.chpl
+++ b/src/compat/e-129/ArkoudaListCompat.chpl
@@ -1,27 +1,27 @@
 module ArkoudaListCompat {
   use List;
 
-  proc list.pushBack(x: this.eltType): int {
+  proc ref list.pushBack(x: this.eltType): int {
     return this.append(x);
   }
 
-  proc list.pushBack(other: list(this.eltType)) {
+  proc ref list.pushBack(other: list(this.eltType)) {
     this.append(other);
   }
 
-  proc list.pushBack(other: [] this.elType) {
+  proc ref list.pushBack(other: [] this.elType) {
     this.append(other);
   }
 
-  proc list.pushBack(other: range(this.eltType, ?)) {
+  proc ref list.pushBack(other: range(this.eltType, ?)) {
     this.append(other);
   }
 
-  proc list.popBack(): this.elType {
+  proc ref list.popBack(): this.elType {
     return this.pop();
   }
 
-  proc list.replace(i: int, x: this.eltType): bool {
+  proc ref list.replace(i: int, x: this.eltType): bool {
     return this.set(i, x);
   }
 }

--- a/src/compat/e-130/ArkoudaListCompat.chpl
+++ b/src/compat/e-130/ArkoudaListCompat.chpl
@@ -13,7 +13,7 @@ module ArkoudaListCompat {
     this.append(other);
   }
 
-  proc list.pushBack(other: range(this.eltType, ?, ?)) {
+  proc list.pushBack(other: range(this.eltType, ?)) {
     this.append(other);
   }
 

--- a/src/compat/e-130/ArkoudaListCompat.chpl
+++ b/src/compat/e-130/ArkoudaListCompat.chpl
@@ -1,0 +1,27 @@
+module ArkoudaListCompat {
+  use List;
+
+  proc list.pushBack(x: this.eltType): int {
+    return this.append(x);
+  }
+
+  proc list.pushBack(other: list(this.eltType)) {
+    this.append(other);
+  }
+
+  proc list.pushBack(other: [] this.elType) {
+    this.append(other);
+  }
+
+  proc list.pushBack(other: range(this.eltType, ?, ?)) {
+    this.append(other);
+  }
+
+  proc list.popBack(): this.elType {
+    return this.pop();
+  }
+
+  proc list.replace(i: int, x: this.eltType): bool {
+    return this.set(i, x);
+  }
+}

--- a/src/compat/e-130/ArkoudaListCompat.chpl
+++ b/src/compat/e-130/ArkoudaListCompat.chpl
@@ -1,19 +1,19 @@
 module ArkoudaListCompat {
   use List;
 
-  proc ref list.pushBack(x: this.eltType): int {
+  proc ref list.pushBack(in x: this.eltType): int {
     return this.append(x);
   }
 
-  proc ref list.pushBack(other: list(this.eltType)) {
+  proc ref list.pushBack(other: list(this.eltType)) lifetime this < other {
     this.append(other);
   }
 
-  proc ref list.pushBack(other: [] this.elType) {
+  proc ref list.pushBack(other: [] this.elType) lifetime this < other {
     this.append(other);
   }
 
-  proc ref list.pushBack(other: range(this.eltType, ?)) {
+  proc ref list.pushBack(other: range(this.eltType, ?)) lifetime this < other {
     this.append(other);
   }
 

--- a/src/compat/e-130/ArkoudaListCompat.chpl
+++ b/src/compat/e-130/ArkoudaListCompat.chpl
@@ -1,27 +1,27 @@
 module ArkoudaListCompat {
   use List;
 
-  proc list.pushBack(x: this.eltType): int {
+  proc ref list.pushBack(x: this.eltType): int {
     return this.append(x);
   }
 
-  proc list.pushBack(other: list(this.eltType)) {
+  proc ref list.pushBack(other: list(this.eltType)) {
     this.append(other);
   }
 
-  proc list.pushBack(other: [] this.elType) {
+  proc ref list.pushBack(other: [] this.elType) {
     this.append(other);
   }
 
-  proc list.pushBack(other: range(this.eltType, ?)) {
+  proc ref list.pushBack(other: range(this.eltType, ?)) {
     this.append(other);
   }
 
-  proc list.popBack(): this.elType {
+  proc ref list.popBack(): this.elType {
     return this.pop();
   }
 
-  proc list.replace(i: int, x: this.eltType): bool {
+  proc ref list.replace(i: int, x: this.eltType): bool {
     return this.set(i, x);
   }
 }

--- a/src/compat/gt-130/ArkoudaListCompat.chpl
+++ b/src/compat/gt-130/ArkoudaListCompat.chpl
@@ -1,0 +1,1 @@
+module ArkoudaListCompat { }


### PR DESCRIPTION
Closes #2455 

Recently, `list.append` was deprecated in favor of `list.pushBack`. This PR changes uses of append to pushBack, and adds a compatibility module for versions 1.29 and 1.30.

Note that `list.pop` and `list.set` were also replaced with `list.popBack` and `list.replace` respectively. Although neither method is used, these changes are included in the compatibility modules just in case they are used in the near future.