### PR TITLE
Closes #2451: Remove pragma no doc instances in Chapel code

### DIFF
--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -135,7 +135,6 @@ module CommAggregation {
 
 
   /* "Aggregator" that uses unordered copy instead of actually aggregating */
-  pragma "no doc"
   record DstUnorderedAggregator {
     type elemType;
 
@@ -272,7 +271,6 @@ module CommAggregation {
   }
 
   /* "Aggregator" that uses unordered copy instead of actually aggregating */
-  pragma "no doc"
   record SrcUnorderedAggregator {
     type elemType;
 

--- a/src/compat/e-129/ArkoudaTimeCompat.chpl
+++ b/src/compat/e-129/ArkoudaTimeCompat.chpl
@@ -40,8 +40,6 @@ private extern proc chpl_now_time():real;
 
 
 
-
-pragma "no doc"
 // This is comparable to a Posix struct timeval
 extern type _timevalue;
 
@@ -85,7 +83,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     Sunday =    6
   }
 
-  pragma "no doc"
+  
   proc DayOfWeek {
     compilerError("'DayOfWeek' was renamed. Please use 'dayOfWeek' instead");
   }
@@ -101,7 +99,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     Sunday =    7
   }
 
-  pragma "no doc"
+  
   proc ISODayOfWeek {
     compilerError("'ISODayOfWeek was renamed. Please use 'isoDayOfWeek' instead");
   }
@@ -150,7 +148,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     return new timedelta(seconds + microseconds);
   }
 
-  pragma "no doc"
+  
   extern "struct tm" record tm {
     var tm_sec:    c_int;         // seconds [0,61]
     var tm_min:    c_int;         // minutes [0,59]
@@ -271,7 +269,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
 /* A record representing a date */
   record date {
-    pragma "no doc"
+    
     var chpl_year, chpl_month, chpl_day: int;
 
     /* The year represented by this `date` value */
@@ -308,7 +306,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* initializers/factories for date values */
 
-  pragma "no doc"
+  
   proc date.init() {
   }
 
@@ -501,7 +499,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   // This method exists to work around a bug in chpldoc where the
   // 'private use' above this method somehow breaks documentation for the
   // method that follows (formerly 'writeThis')
-  pragma "no doc"
+  
   proc date._chpldoc_workaround() { }
 
   /* Writes this `date` in ISO 8601 format: YYYY-MM-DD */
@@ -510,7 +508,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   // Exists to support some common functionality for `dateTime.readThis`
-  pragma "no doc"
+  
   proc date._readCore(f) throws {
     const dash = "-";
 
@@ -538,42 +536,42 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
 
   /* Operators on date values */
-  pragma "no doc"
+  
   operator date.+(d: date, t: timedelta): date {
     return date.fromOrdinal(d.toOrdinal() + t.days);
   }
 
-  pragma "no doc"
+  
   operator date.+(t: timedelta, d: date): date {
     return d + t;
   }
 
-  pragma "no doc"
+  
   operator date.-(d: date, t: timedelta): date {
     return date.fromOrdinal(d.toOrdinal() - t.days);
   }
 
-  pragma "no doc"
+  
   operator date.-(d1: date, d2: date): timedelta {
     return new timedelta(days=d1.toOrdinal() - d2.toOrdinal());
   }
 
-  pragma "no doc"
+  
   operator date.<(d1: date, d2: date) {
     return d1.toOrdinal() < d2.toOrdinal();
   }
 
-  pragma "no doc"
+  
   operator date.<=(d1: date, d2: date) {
     return d1.toOrdinal() <= d2.toOrdinal();
   }
 
-  pragma "no doc"
+  
   operator date.>(d1: date, d2: date) {
     return d1.toOrdinal() > d2.toOrdinal();
   }
 
-  pragma "no doc"
+  
   operator date.>=(d1: date, d2: date) {
     return d1.toOrdinal() >= d2.toOrdinal();
   }
@@ -581,9 +579,9 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* A record representing a time */
   record time {
-    pragma "no doc"
+    
     var chpl_hour, chpl_minute, chpl_second, chpl_microsecond: int;
-    pragma "no doc"
+    
     var chpl_tz: shared Timezone?;
 
     /* The hour represented by this `time` value */
@@ -611,7 +609,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       return chpl_tz;
     }
 
-    pragma "no doc"
+    
     deprecated "'tzinfo' is deprecated, please use 'timezone' instead"
     proc tzinfo {
       return timezone;
@@ -679,7 +677,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
      `microsecond`, and `timezone`.  All arguments are optional
    */
 
-  pragma "no doc"
+  
   proc time.deinit() {
   }
 
@@ -811,7 +809,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   // Exists to support some common functionality for `dateTime.readThis`
-  pragma "no doc"
+  
   proc time._readCore(f) throws {
     const colon = ":";
 
@@ -842,19 +840,19 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* Operators on time values */
 
-  pragma "no doc"
+  
   operator time.==(t1: time, t2: time): bool {
     var dt1 = dateTime.combine(d=new date(2000, 1, 1), t=t1);
     var dt2 = dateTime.combine(d=new date(2000, 1, 1), t=t2);
     return dt1 == dt2;
   }
 
-  pragma "no doc"
+  
   operator time.!=(t1: time, t2: time) {
     return !(t1 == t2);
   }
 
-  pragma "no doc"
+  
   operator time.<(t1: time, t2: time): bool {
     if (t1.timezone.borrow() != nil && t2.timezone.borrow() == nil) ||
         (t1.timezone.borrow() == nil && t2.timezone.borrow() != nil) {
@@ -892,7 +890,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
   }
 
-  pragma "no doc"
+  
   operator time.<=(t1: time, t2: time): bool {
     if (t1.timezone.borrow() != nil && t2.timezone.borrow() == nil) ||
         (t1.timezone.borrow() == nil && t2.timezone.borrow() != nil) {
@@ -915,7 +913,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
   }
 
-  pragma "no doc"
+  
   operator time.>(t1: time, t2: time): bool {
     if (t1.timezone.borrow() != nil && t2.timezone.borrow() == nil) ||
         (t1.timezone.borrow() == nil && t2.timezone.borrow() != nil) {
@@ -938,7 +936,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
   }
 
-  pragma "no doc"
+  
   operator time.>=(t1: time, t2: time): bool {
     if (t1.timezone.borrow() != nil && t2.timezone.borrow() == nil) ||
         (t1.timezone.borrow() == nil && t2.timezone.borrow() != nil) {
@@ -963,9 +961,9 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* A record representing a combined `date` and `time` */
   record dateTime {
-    pragma "no doc"
+    
     var chpl_date: date;
-    pragma "no doc"
+    
     var chpl_time: time;
 
     /* The minimum representable `date` and `time` */
@@ -1023,7 +1021,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       return chpl_time.timezone;
     }
 
-    pragma "no doc"
+    
     deprecated "'tzinfo' is deprecated, please use 'timezone' instead"
     proc tzinfo {
       return timezone;
@@ -1032,7 +1030,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* initializers/factories for dateTime values */
 
-  pragma "no doc"
+  
   proc dateTime.init() {
   }
 
@@ -1271,7 +1269,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     return getdate().isoWeekday();
   }
 
-  pragma "no doc"
+  
   deprecated "'isoweekday' is deprecated, please use 'isoWeekday' instead"
   proc dateTime.isoweekday() {
     return isoWeekday();
@@ -1284,7 +1282,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     return getdate().isoCalendar();
   }
 
-  pragma "no doc"
+  
   deprecated "'isocalendar' is deprecated, please use 'isoCalendar' instead"
   proc dateTime.isocalendar() {
     return getdate().isoCalendar();
@@ -1444,7 +1442,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* Operators on dateTime values */
 
-  pragma "no doc"
+  
   operator dateTime.+(td: timedelta, dt: dateTime) {
     var newmicro = dt.microsecond + td.microseconds;
     var newsec = dt.second + td.seconds;
@@ -1471,12 +1469,12 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   }
 
-  pragma "no doc"
+  
   operator dateTime.+(dt: dateTime, td: timedelta) {
     return td + dt;
   }
 
-  pragma "no doc"
+  
   operator dateTime.-(dt: dateTime, td: timedelta) {
     var deltasec  = td.seconds % 60;
     var deltamin  = (td.seconds / 60) % 60;
@@ -1511,7 +1509,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
                                      tz=dt.timezone));
   }
 
-  pragma "no doc"
+  
   operator dateTime.-(dt1: dateTime, dt2: dateTime): timedelta {
     if (dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil) ||
        (dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil) {
@@ -1532,7 +1530,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
   }
 
-  pragma "no doc"
+  
   operator dateTime.==(dt1: dateTime, dt2: dateTime): bool {
     if dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil ||
        dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil {
@@ -1554,12 +1552,12 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
   }
 
-  pragma "no doc"
+  
   operator dateTime.!=(dt1: dateTime, dt2: dateTime) {
     return !(dt1 == dt2);
   }
 
-  pragma "no doc"
+  
   operator dateTime.<(dt1: dateTime, dt2: dateTime): bool {
     if (dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil) ||
         (dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil) {
@@ -1576,7 +1574,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
   }
 
-  pragma "no doc"
+  
   operator dateTime.<=(dt1: dateTime, dt2: dateTime): bool {
     if (dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil) ||
         (dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil) {
@@ -1593,7 +1591,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
   }
 
-  pragma "no doc"
+  
   operator dateTime.>(dt1: dateTime, dt2: dateTime): bool {
     if (dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil) ||
         (dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil) {
@@ -1610,7 +1608,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
   }
 
-  pragma "no doc"
+  
   operator dateTime.>=(dt1: dateTime, dt2: dateTime): bool {
     if (dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil) ||
         (dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil) {
@@ -1642,13 +1640,13 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
      It is an overflow error if `days` is outside the given range.
    */
   record timedelta {
-    pragma "no doc"
+    
     var chpl_days: int;
 
-    pragma "no doc"
+    
     var chpl_seconds: int;
 
-    pragma "no doc"
+    
     var chpl_microseconds: int;
 
     /* The number of days this `timedelta` represents */
@@ -1743,17 +1741,17 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* Operators on timedelta values */
 
-  pragma "no doc"
+  
   operator timedelta.*(i: int, t: timedelta) {
     return new timedelta(days=i*t.days, seconds=i*t.seconds, microseconds=i*t.microseconds);
   }
 
-  pragma "no doc"
+  
   operator timedelta.*(t: timedelta, i: int) {
     return new timedelta(days=i*t.days, seconds=i*t.seconds, microseconds=i*t.microseconds);
   }
 
-  pragma "no doc"
+  
   operator timedelta./(t: timedelta, i: int) {
     var day = t.days / i;
     var second = t.seconds + (t.days % i)*24*60*60;
@@ -1768,31 +1766,31 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     return new timedelta(days=day, seconds=second, microseconds=microsecond);
   }
 
-  pragma "no doc"
+  
   operator timedelta.+(t: timedelta) {
     return t;
   }
 
-  pragma "no doc"
+  
   operator timedelta.-(t: timedelta) {
     return new timedelta(days=-t.days, seconds=-t.seconds, microseconds=-t.microseconds);
   }
 
-  pragma "no doc"
+  
   operator timedelta.+(lhs: timedelta, rhs: timedelta) {
     return new timedelta(days=lhs.days+rhs.days,
                          seconds=lhs.seconds+rhs.seconds,
                          microseconds=lhs.microseconds+rhs.microseconds);
   }
 
-  pragma "no doc"
+  
   operator timedelta.-(lhs: timedelta, rhs: timedelta) {
     return new timedelta(days=lhs.days-rhs.days,
                          seconds=lhs.seconds-rhs.seconds,
                          microseconds=lhs.microseconds-rhs.microseconds);
   }
 
-  pragma "no doc"
+  
   operator timedelta.>(lhs: timedelta, rhs: timedelta) {
     const ls = (lhs.days*(24*60*60) + lhs.seconds);
     const rs = (rhs.days*(24*60*60) + rhs.seconds);
@@ -1801,12 +1799,12 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     return lhs.microseconds > rhs.microseconds;
   }
 
-  pragma "no doc"
+  
   operator timedelta.>=(lhs: timedelta, rhs: timedelta) {
     return lhs > rhs || lhs == rhs;
   }
 
-  pragma "no doc"
+  
   operator timedelta.<(lhs: timedelta, rhs: timedelta) {
     const ls = (lhs.days*(24*60*60) + lhs.seconds);
     const rs = (rhs.days*(24*60*60) + rhs.seconds);
@@ -1815,7 +1813,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     return lhs.microseconds < rhs.microseconds;
   }
 
-  pragma "no doc"
+  
   operator timedelta.<=(lhs: timedelta, rhs: timedelta) {
     return lhs < rhs || lhs == rhs;
   }
@@ -1830,7 +1828,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       return t;
   }
 
-  pragma "no doc"
+  
   operator :(t: timedelta, type s:string) {
     var str: string;
     if t.days != 0 {
@@ -1863,7 +1861,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     return str;
   }
 
-  pragma "no doc"
+  
   deprecated "'TZInfo' is deprecated, please use 'Timezone' instead"
   class TZInfo: Timezone { }
 
@@ -1970,13 +1968,13 @@ inline proc sleep(t: real, unit: TimeUnits = TimeUnits.seconds) : void {
    A :record:`!stopwatch` is either running or stopped.
 */
 record stopwatch {
-  pragma "no doc"
+  
   var time:        _timevalue = chpl_null_timevalue();
 
-  pragma "no doc"
+  
   var accumulated: real       = 0.0;
 
-  pragma "no doc"
+  
   var running:     bool       = false;
 
   /*
@@ -2055,13 +2053,13 @@ record stopwatch {
 
 deprecated "'Timer' is deprecated, please use 'stopwatch' instead"
 record Timer {
-  pragma "no doc"
+  
   var time:        _timevalue = chpl_null_timevalue();
 
-  pragma "no doc"
+  
   var accumulated: real       = 0.0;
 
-  pragma "no doc"
+  
   var running:     bool       = false;
 
   /*

--- a/src/compat/e-130/ArkoudaTimeCompat.chpl
+++ b/src/compat/e-130/ArkoudaTimeCompat.chpl
@@ -41,7 +41,7 @@ private extern proc chpl_now_time():real;
 
 
 
-pragma "no doc"
+
 // This is comparable to a Posix struct timeval
 extern type _timevalue;
 
@@ -86,7 +86,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     Sunday =    6
   }
 
-  pragma "no doc"
+  
   proc DayOfWeek {
     compilerError("'DayOfWeek' was renamed. Please use 'dayOfWeek' instead");
   }
@@ -102,7 +102,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     Sunday =    7
   }
 
-  pragma "no doc"
+  
   proc ISODayOfWeek {
     compilerError("'ISODayOfWeek was renamed. Please use 'isoDayOfWeek' instead");
   }
@@ -151,7 +151,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     return new timedelta(seconds + microseconds);
   }
 
-  pragma "no doc"
+  
   extern "struct tm" record tm {
     var tm_sec:    c_int;         // seconds [0,61]
     var tm_min:    c_int;         // minutes [0,59]
@@ -272,7 +272,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
 /* A record representing a date */
   record date {
-    pragma "no doc"
+    
     var chpl_year, chpl_month, chpl_day: int;
 
     /* The year represented by this `date` value */
@@ -309,7 +309,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* initializers/factories for date values */
 
-  pragma "no doc"
+  
   proc date.init() {
   }
 
@@ -505,7 +505,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   // This method exists to work around a bug in chpldoc where the
   // 'private use' above this method somehow breaks documentation for the
   // method that follows (formerly 'writeThis')
-  pragma "no doc"
+  
   proc date._chpldoc_workaround() { }
 
   /* Writes this `date` in ISO 8601 format: YYYY-MM-DD */
@@ -514,7 +514,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   // Exists to support some common functionality for `dateTime.readThis`
-  pragma "no doc"
+  
   proc date._readCore(f) throws {
     const dash = "-";
 
@@ -543,49 +543,49 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   //
   // TODO: need to get this to work with the Json formatter
   //
-  pragma "no doc"
+  
   proc date.init(f: fileReader) {
     this.init();
     readThis(f);
   }
 
   /* Operators on date values */
-  pragma "no doc"
+  
   operator date.+(d: date, t: timedelta): date {
     return date.fromOrdinal(d.toOrdinal() + t.days);
   }
 
-  pragma "no doc"
+  
   operator date.+(t: timedelta, d: date): date {
     return d + t;
   }
 
-  pragma "no doc"
+  
   operator date.-(d: date, t: timedelta): date {
     return date.fromOrdinal(d.toOrdinal() - t.days);
   }
 
-  pragma "no doc"
+  
   operator date.-(d1: date, d2: date): timedelta {
     return new timedelta(days=d1.toOrdinal() - d2.toOrdinal());
   }
 
-  pragma "no doc"
+  
   operator date.<(d1: date, d2: date) {
     return d1.toOrdinal() < d2.toOrdinal();
   }
 
-  pragma "no doc"
+  
   operator date.<=(d1: date, d2: date) {
     return d1.toOrdinal() <= d2.toOrdinal();
   }
 
-  pragma "no doc"
+  
   operator date.>(d1: date, d2: date) {
     return d1.toOrdinal() > d2.toOrdinal();
   }
 
-  pragma "no doc"
+  
   operator date.>=(d1: date, d2: date) {
     return d1.toOrdinal() >= d2.toOrdinal();
   }
@@ -593,9 +593,9 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* A record representing a time */
   record time {
-    pragma "no doc"
+    
     var chpl_hour, chpl_minute, chpl_second, chpl_microsecond: int;
-    pragma "no doc"
+    
     var chpl_tz: shared Timezone?;
 
     /* The hour represented by this `time` value */
@@ -623,7 +623,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       return chpl_tz;
     }
 
-    pragma "no doc"
+    
     @deprecated(notes="'tzinfo' is deprecated, please use 'timezone' instead")
     proc tzinfo {
       return timezone;
@@ -691,7 +691,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
      `microsecond`, and `timezone`.  All arguments are optional
    */
 
-  pragma "no doc"
+  
   proc time.deinit() {
   }
 
@@ -824,7 +824,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   // Exists to support some common functionality for `dateTime.readThis`
-  pragma "no doc"
+  
   proc time._readCore(f) throws {
     const colon = ":";
 
@@ -855,7 +855,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   //
   // TODO: need to get this to work with the Json formatter
   //
-  pragma "no doc"
+  
   proc time.init(f: fileReader) {
     this.init();
     readThis(f);
@@ -864,19 +864,19 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* Operators on time values */
 
-  pragma "no doc"
+  
   operator time.==(t1: time, t2: time): bool {
     var dt1 = dateTime.combine(d=new date(2000, 1, 1), t=t1);
     var dt2 = dateTime.combine(d=new date(2000, 1, 1), t=t2);
     return dt1 == dt2;
   }
 
-  pragma "no doc"
+  
   operator time.!=(t1: time, t2: time) {
     return !(t1 == t2);
   }
 
-  pragma "no doc"
+  
   operator time.<(t1: time, t2: time): bool {
     if (t1.timezone.borrow() != nil && t2.timezone.borrow() == nil) ||
         (t1.timezone.borrow() == nil && t2.timezone.borrow() != nil) {
@@ -914,7 +914,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
   }
 
-  pragma "no doc"
+  
   operator time.<=(t1: time, t2: time): bool {
     if (t1.timezone.borrow() != nil && t2.timezone.borrow() == nil) ||
         (t1.timezone.borrow() == nil && t2.timezone.borrow() != nil) {
@@ -937,7 +937,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
   }
 
-  pragma "no doc"
+  
   operator time.>(t1: time, t2: time): bool {
     if (t1.timezone.borrow() != nil && t2.timezone.borrow() == nil) ||
         (t1.timezone.borrow() == nil && t2.timezone.borrow() != nil) {
@@ -960,7 +960,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
   }
 
-  pragma "no doc"
+  
   operator time.>=(t1: time, t2: time): bool {
     if (t1.timezone.borrow() != nil && t2.timezone.borrow() == nil) ||
         (t1.timezone.borrow() == nil && t2.timezone.borrow() != nil) {
@@ -985,9 +985,9 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* A record representing a combined `date` and `time` */
   record dateTime {
-    pragma "no doc"
+    
     var chpl_date: date;
-    pragma "no doc"
+    
     var chpl_time: time;
 
     /* The minimum representable `date` and `time` */
@@ -1045,7 +1045,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       return chpl_time.timezone;
     }
 
-    pragma "no doc"
+    
     @deprecated(notes="'tzinfo' is deprecated, please use 'timezone' instead")
     proc tzinfo {
       return timezone;
@@ -1054,7 +1054,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* initializers/factories for dateTime values */
 
-  pragma "no doc"
+  
   proc dateTime.init() {
   }
 
@@ -1295,7 +1295,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     return getdate().isoWeekday();
   }
 
-  pragma "no doc"
+  
   @deprecated(notes="'isoweekday' is deprecated, please use 'isoWeekday' instead")
   proc dateTime.isoweekday() {
     return isoWeekday();
@@ -1308,7 +1308,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     return getdate().isoCalendar();
   }
 
-  pragma "no doc"
+  
   @deprecated(notes="'isocalendar' is deprecated, please use 'isoCalendar' instead")
   proc dateTime.isocalendar() {
     return getdate().isoCalendar();
@@ -1469,7 +1469,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   //
   // TODO: need to get this to work with the Json formatter
   //
-  pragma "no doc"
+  
   proc dateTime.init(f: fileReader) {
     this.init();
     readThis(f);
@@ -1480,7 +1480,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* Operators on dateTime values */
 
-  pragma "no doc"
+  
   operator dateTime.+(td: timedelta, dt: dateTime) {
     var newmicro = dt.microsecond + td.microseconds;
     var newsec = dt.second + td.seconds;
@@ -1507,12 +1507,12 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   }
 
-  pragma "no doc"
+  
   operator dateTime.+(dt: dateTime, td: timedelta) {
     return td + dt;
   }
 
-  pragma "no doc"
+  
   operator dateTime.-(dt: dateTime, td: timedelta) {
     var deltasec  = td.seconds % 60;
     var deltamin  = (td.seconds / 60) % 60;
@@ -1547,7 +1547,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
                                      tz=dt.timezone));
   }
 
-  pragma "no doc"
+  
   operator dateTime.-(dt1: dateTime, dt2: dateTime): timedelta {
     if (dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil) ||
        (dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil) {
@@ -1568,7 +1568,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
   }
 
-  pragma "no doc"
+  
   operator dateTime.==(dt1: dateTime, dt2: dateTime): bool {
     if dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil ||
        dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil {
@@ -1590,12 +1590,12 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
   }
 
-  pragma "no doc"
+  
   operator dateTime.!=(dt1: dateTime, dt2: dateTime) {
     return !(dt1 == dt2);
   }
 
-  pragma "no doc"
+  
   operator dateTime.<(dt1: dateTime, dt2: dateTime): bool {
     if (dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil) ||
         (dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil) {
@@ -1612,7 +1612,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
   }
 
-  pragma "no doc"
+  
   operator dateTime.<=(dt1: dateTime, dt2: dateTime): bool {
     if (dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil) ||
         (dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil) {
@@ -1629,7 +1629,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
   }
 
-  pragma "no doc"
+  
   operator dateTime.>(dt1: dateTime, dt2: dateTime): bool {
     if (dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil) ||
         (dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil) {
@@ -1646,7 +1646,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
   }
 
-  pragma "no doc"
+  
   operator dateTime.>=(dt1: dateTime, dt2: dateTime): bool {
     if (dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil) ||
         (dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil) {
@@ -1678,13 +1678,13 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
      It is an overflow error if `days` is outside the given range.
    */
   record timedelta {
-    pragma "no doc"
+    
     var chpl_days: int;
 
-    pragma "no doc"
+    
     var chpl_seconds: int;
 
-    pragma "no doc"
+    
     var chpl_microseconds: int;
 
     /* The number of days this `timedelta` represents */
@@ -1779,17 +1779,17 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* Operators on timedelta values */
 
-  pragma "no doc"
+  
   operator timedelta.*(i: int, t: timedelta) {
     return new timedelta(days=i*t.days, seconds=i*t.seconds, microseconds=i*t.microseconds);
   }
 
-  pragma "no doc"
+  
   operator timedelta.*(t: timedelta, i: int) {
     return new timedelta(days=i*t.days, seconds=i*t.seconds, microseconds=i*t.microseconds);
   }
 
-  pragma "no doc"
+  
   operator timedelta./(t: timedelta, i: int) {
     var day = t.days / i;
     var second = t.seconds + (t.days % i)*24*60*60;
@@ -1804,31 +1804,31 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     return new timedelta(days=day, seconds=second, microseconds=microsecond);
   }
 
-  pragma "no doc"
+  
   operator timedelta.+(t: timedelta) {
     return t;
   }
 
-  pragma "no doc"
+  
   operator timedelta.-(t: timedelta) {
     return new timedelta(days=-t.days, seconds=-t.seconds, microseconds=-t.microseconds);
   }
 
-  pragma "no doc"
+  
   operator timedelta.+(lhs: timedelta, rhs: timedelta) {
     return new timedelta(days=lhs.days+rhs.days,
                          seconds=lhs.seconds+rhs.seconds,
                          microseconds=lhs.microseconds+rhs.microseconds);
   }
 
-  pragma "no doc"
+  
   operator timedelta.-(lhs: timedelta, rhs: timedelta) {
     return new timedelta(days=lhs.days-rhs.days,
                          seconds=lhs.seconds-rhs.seconds,
                          microseconds=lhs.microseconds-rhs.microseconds);
   }
 
-  pragma "no doc"
+  
   operator timedelta.>(lhs: timedelta, rhs: timedelta) {
     const ls = (lhs.days*(24*60*60) + lhs.seconds);
     const rs = (rhs.days*(24*60*60) + rhs.seconds);
@@ -1837,12 +1837,12 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     return lhs.microseconds > rhs.microseconds;
   }
 
-  pragma "no doc"
+  
   operator timedelta.>=(lhs: timedelta, rhs: timedelta) {
     return lhs > rhs || lhs == rhs;
   }
 
-  pragma "no doc"
+  
   operator timedelta.<(lhs: timedelta, rhs: timedelta) {
     const ls = (lhs.days*(24*60*60) + lhs.seconds);
     const rs = (rhs.days*(24*60*60) + rhs.seconds);
@@ -1851,7 +1851,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     return lhs.microseconds < rhs.microseconds;
   }
 
-  pragma "no doc"
+  
   operator timedelta.<=(lhs: timedelta, rhs: timedelta) {
     return lhs < rhs || lhs == rhs;
   }
@@ -1866,7 +1866,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       return t;
   }
 
-  pragma "no doc"
+  
   operator :(t: timedelta, type s:string) {
     var str: string;
     if t.days != 0 {
@@ -1899,7 +1899,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     return str;
   }
 
-  pragma "no doc"
+  
   @deprecated(notes="'TZInfo' is deprecated, please use 'Timezone' instead")
   class TZInfo: Timezone { }
 
@@ -2027,13 +2027,13 @@ inline proc sleep(t: real) : void {
    A :record:`!stopwatch` is either running or stopped.
 */
 record stopwatch {
-  pragma "no doc"
+  
   var time:        _timevalue = chpl_null_timevalue();
 
-  pragma "no doc"
+  
   var accumulated: real       = 0.0;
 
-  pragma "no doc"
+  
   var running:     bool       = false;
 
   /*
@@ -2133,13 +2133,13 @@ record stopwatch {
 
 @deprecated(notes="'Timer' is deprecated, please use 'stopwatch' instead")
 record Timer {
-  pragma "no doc"
+  
   var time:        _timevalue = chpl_null_timevalue();
 
-  pragma "no doc"
+  
   var accumulated: real       = 0.0;
 
-  pragma "no doc"
+  
   var running:     bool       = false;
 
   /*


### PR DESCRIPTION
`pragma "no doc"` has been deprecated in Chapel to be replaced with `@chpldoc.nodoc` now that annotations have been added. This pragma does nothing in Arkouda, but is a remnant of code being copy/pasted from the Chapel source repository. Because of this, those references should be removed.

Closes #2451 