### PR TITLE
Closes #2304: `inner_join` on `Strings` and `Categorical`

### DIFF
--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -1544,14 +1544,14 @@ class GroupBy:
 
     @typechecked
     def broadcast(
-        self, values: groupable_element_type, permute: bool = True
-    ) -> groupable_element_type:
+        self, values: Union[pdarray, Strings], permute: bool = True
+    ) -> Union[pdarray, Strings]:
         """
         Fill each group's segment with a constant value.
 
         Parameters
         ----------
-        values : pdarray, Strings, Categorical
+        values : pdarray, Strings
             The values to put in each group's segment
         permute : bool
             If True (default), permute broadcast values back to the ordering
@@ -1560,7 +1560,7 @@ class GroupBy:
 
         Returns
         -------
-        pdarray, Strings, Categorical
+        pdarray, Strings
             The broadcasted values
 
         Raises
@@ -1603,8 +1603,6 @@ class GroupBy:
         """
         if values.size != self.segments.size:
             raise ValueError("Must have one value per segment")
-        if isinstance(values, Categorical):
-            return Categorical.from_codes(self.broadcast(values.codes, permute), values.categories)
         cmd = "broadcast"
         repMsg = cast(
             str,
@@ -2035,7 +2033,7 @@ class GroupBy:
 
 def broadcast(
     segments: pdarray,
-    values: groupable_element_type,
+    values: Union[pdarray, Strings],
     size: Union[int, np.int64, np.uint64] = -1,
     permutation: Union[pdarray, None] = None,
 ):
@@ -2047,7 +2045,7 @@ def broadcast(
     segments : pdarray, int64
         Offsets of the start of each row in the sparse matrix or grouped array.
         Must be sorted in ascending order.
-    values : pdarray, Strings, Categorical
+    values : pdarray, Strings
         The values to broadcast, one per row (or group)
     size : int
         The total number of nonzeros in the matrix. If permutation is given, this
@@ -2061,7 +2059,7 @@ def broadcast(
 
     Returns
     -------
-    pdarray, Strings, Categorical
+    pdarray, Strings
         The broadcast values, one per nonzero
 
     Raises
@@ -2087,8 +2085,6 @@ def broadcast(
     >>> ak.broadcast(row_starts, row_number, permutation=permutation)
     array([2 2 1 1 1 0 0])
     """
-    if isinstance(values, Categorical):
-        return Categorical.from_codes(broadcast(segments, values.codes, size, permutation), values.categories)
     if segments.size != values.size:
         raise ValueError("segments and values arrays must be same size")
     if segments.size == 0:

--- a/arkouda/join.py
+++ b/arkouda/join.py
@@ -4,6 +4,7 @@ import numpy as np  # type: ignore
 from typeguard import typechecked
 
 from arkouda.alignment import right_align
+from arkouda.categorical import Categorical
 from arkouda.client import generic_msg
 from arkouda.dtypes import NUMBER_FORMAT_STRINGS
 from arkouda.dtypes import int64 as akint64
@@ -13,6 +14,7 @@ from arkouda.numeric import cumsum
 from arkouda.pdarrayclass import create_pdarray, pdarray
 from arkouda.pdarraycreation import arange, array, ones, zeros
 from arkouda.pdarraysetops import concatenate, in1d
+from arkouda.strings import Strings
 
 __all__ = ["join_on_eq_with_dt", "gen_ranges", "compute_join_size"]
 
@@ -169,12 +171,14 @@ def compute_join_size(a: pdarray, b: pdarray) -> Tuple[int, int]:
 
 @typechecked
 def inner_join(
-    left: pdarray, right: pdarray, wherefunc: Callable = None, whereargs: Tuple[pdarray, pdarray] = None
+    left: Union[pdarray, Strings, Categorical],
+    right: Union[pdarray, Strings, Categorical],
+    wherefunc: Callable = None,
+    whereargs: Tuple[Union[pdarray, Strings, Categorical], Union[pdarray, Strings, Categorical]] = None,
 ) -> Tuple[pdarray, pdarray]:
     """Perform inner join on values in <left> and <right>,
     using conditions defined by <wherefunc> evaluated on
     <whereargs>, returning indices of left-right pairs.
-
     Parameters
     ----------
     left : pdarray(int64)
@@ -187,23 +191,25 @@ def inner_join(
         which wherefunc is False will be dropped.
     whereargs : 2-tuple of pdarray
         The two pdarray arguments to wherefunc
-
     Returns
     -------
     leftInds : pdarray(int64)
         The left indices of pairs that meet the join condition
     rightInds : pdarray(int64)
         The right indices of pairs that meet the join condition
-
     Notes
     -----
     The return values satisfy the following assertions
-
     `assert (left[leftInds] == right[rightInds]).all()`
     `assert wherefunc(whereargs[0][leftInds], whereargs[1][rightInds]).all()`
-
     """
     from inspect import signature
+
+    # Reduce processing to codes to prevent groupbys being ran on entire Categorical
+    if isinstance(left, Categorical) and isinstance(right, Categorical):
+        l, r = Categorical.standardize_categories([left, right])
+        left = l.codes
+        right = r.codes
 
     sample = np.min((left.size, right.size, 5))  # type: ignore
     if wherefunc is not None:
@@ -244,7 +250,11 @@ def inner_join(
             # Gather right whereargs
             rightWhere = whereargs[1][byRight.permutation][ranges]
             # Expand left whereargs
-            leftWhere = broadcast(fullSegs, whereargs[0][keep], ranges.size)
+            keep_where = whereargs[0][keep]
+            if isinstance(keep_where, Categorical):
+                leftWhere = broadcast(fullSegs, keep_where.codes, ranges.size)
+            else:
+                leftWhere = broadcast(fullSegs, keep_where, ranges.size)
             # Evaluate wherefunc and filter ranges, recompute segments
             whereSatisfied = wherefunc(leftWhere, rightWhere)
             filtRanges = ranges[whereSatisfied]

--- a/src/Broadcast.chpl
+++ b/src/Broadcast.chpl
@@ -1,7 +1,18 @@
 module Broadcast {
+  use AryUtil;
   use SymArrayDmap;
   use CommAggregation;
   use BigInteger;
+  use SegmentedString;
+  use MultiTypeSymbolTable;
+  use MultiTypeSymEntry;
+  use Reflection;
+  use Logging;
+  use ServerConfig;
+
+  private config const logLevel = ServerConfig.logLevel;
+  private config const logChannel = ServerConfig.logChannel;
+  const brLogger = new Logger(logLevel, logChannel);
 
   /* 
    * Broadcast a value per segment of a segmented array to the
@@ -141,5 +152,39 @@ module Broadcast {
     // Integrate to recover full values
     expandedVals = (+ scan expandedVals);
     return (expandedVals == 1);
+  }
+
+  proc broadcast(segs: [?sD] int, segString: borrowed SegString, size: int) throws {
+    ref offs = segString.offsets.a;
+    ref vals = segString.values.a;
+    const high = sD.high;
+    var strLens: [sD] int;
+    var segLens: [sD] int;
+    var expandedLen: int;
+
+    forall (i, off, str_len, seg, seg_len) in zip (sD, offs, strLens, segs, segLens) with (+ reduce expandedLen) {
+      if i == high {
+        seg_len = size - seg;
+        str_len = vals.size - off;
+      } else {
+        seg_len = segs[i+1] - seg;
+        str_len = offs[i+1] - off;
+      }
+      expandedLen += seg_len * str_len;
+    }
+    var broadDist = broadcast(segs, strLens, size);
+    const offsets = (+ scan broadDist) - broadDist;
+    var expandedVals = makeDistArray(expandedLen, uint(8));
+
+    forall (off, str_len, seg, seg_len) in zip(offs, strLens, segs, segLens) with (var valAgg = newDstAggregator(uint(8))) {
+      var localizedVals = new lowLevelLocalizingSlice(vals, off..#str_len);
+      for i in seg..#seg_len {
+        var expValOff = offsets[i];
+        for k in 0..#str_len {
+          valAgg.copy(expandedVals[expValOff+k], localizedVals.ptr[k]);
+        }
+      }
+    }
+    return (expandedVals, offsets);
   }
 }

--- a/src/BroadcastMsg.chpl
+++ b/src/BroadcastMsg.chpl
@@ -8,7 +8,8 @@ module BroadcastMsg {
   use Logging;
   use Message;
   use BigInteger;
-
+  use SegmentedString;
+  
   private config const logLevel = ServerConfig.logLevel;
   private config const logChannel = ServerConfig.logChannel;
   const bmLogger = new Logger(logLevel, logChannel);
@@ -29,6 +30,12 @@ module BroadcastMsg {
                                        getModuleName(),
                                        "TypeError");
     }
+
+    const objType = msgArgs.getValueOf("objType");
+    if objType != "pdarray" {
+      return broadcastStrings(cmd, msgArgs, st);
+    }
+
     const segs = toSymEntry(gs, int);
     // Check that values exists (can be any dtype)
     const gv = getGenericTypedArrayEntry(msgArgs.getValueOf("valName"), st);
@@ -122,16 +129,31 @@ module BroadcastMsg {
         }
         otherwise {
           throw new owned ErrorWithContext("Values array has unsupported dtype %s".format(gv.dtype:string),
-                                           getLineNumber(),
-                                           getRoutineName(),
-                                           getModuleName(),
-                                           "TypeError");
+                                          getLineNumber(),
+                                          getRoutineName(),
+                                          getModuleName(),
+                                          "TypeError");
         }
       }
     }
     var repMsg = "created " + st.attrib(rname); 
     bmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
     return new MsgTuple(repMsg, MsgType.NORMAL);    
+  }
+
+  proc broadcastStrings(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+    const gs = getGenericTypedArrayEntry(msgArgs.getValueOf("segName"), st);
+    const segs = toSymEntry(gs, int);
+    // Check that values exists (can be any dtype)
+    const sE = getSegString(msgArgs.getValueOf("valName"), st);
+    const size = msgArgs.get("size").getIntValue();
+
+    var (vals, offs) = broadcast(segs.a, sE, size);
+    var res = getSegString(offs, vals, st);
+
+    var repMsg = "created %s".format(st.attrib(res.name)) + "+created bytes.size %t".format(res.nBytes);
+    bmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+    return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
   use CommandMap;

--- a/src/BroadcastMsg.chpl
+++ b/src/BroadcastMsg.chpl
@@ -143,7 +143,6 @@ module BroadcastMsg {
   proc broadcastStrings(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
     const gs = getGenericTypedArrayEntry(msgArgs.getValueOf("segName"), st);
     const segs = toSymEntry(gs, int);
-    // Check that values exists (can be any dtype)
     const sE = getSegString(msgArgs.getValueOf("valName"), st);
     const size = msgArgs.get("size").getIntValue();
 

--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -95,6 +95,11 @@ class JoinTest(ArkoudaTest):
         l, r = ak.join.inner_join(left, right)
         self.assertListEqual(left[l].to_list(), right[r].to_list())
 
+        l, r = ak.join.inner_join(
+            left, right, wherefunc=join_where, whereargs=(left, right)
+        )
+        self.assertListEqual(left[l].to_list(), right[r].to_list())
+
         with self.assertRaises(ValueError):
             l, r = ak.join.inner_join(left, right, wherefunc=ak.unique)
 
@@ -110,6 +115,60 @@ class JoinTest(ArkoudaTest):
             l, r = ak.join.inner_join(
                 left, right, wherefunc=ak.intersect1d, whereargs=(ak.arange(10), ak.arange(5))
             )
+
+    def test_str_inner_join(self):
+        intLeft = ak.arange(50)
+        intRight = ak.randint(0, 50, 50)
+        strLeft = ak.array([f"str {i}" for i in intLeft.to_list()])
+        strRight = ak.array([f"str {i}" for i in intRight.to_list()])
+
+        strL, strR = ak.join.inner_join(strLeft, strRight)
+        self.assertListEqual(strLeft[strL].to_list(), strRight[strR].to_list())
+
+        strLWhere, strRWhere = ak.join.inner_join(
+            strLeft, strRight, wherefunc=join_where, whereargs=(strLeft, strRight)
+        )
+        self.assertListEqual(strLeft[strLWhere].to_list(), strRight[strRWhere].to_list())
+
+    def test_cat_inner_join(self):
+        intLeft = ak.arange(50)
+        intRight = ak.randint(0, 50, 50)
+        strLeft = ak.array([f"str {i}" for i in intLeft.to_list()])
+        strRight = ak.array([f"str {i}" for i in intRight.to_list()])
+        catLeft = ak.Categorical(strLeft)
+        catRight = ak.Categorical(strRight)
+
+        # Base Case
+        catL, catR = ak.join.inner_join(catLeft, catRight)
+        self.assertListEqual(catLeft[catL].to_list(), catRight[catR].to_list())
+
+        catLWhere, catRWhere = ak.join.inner_join(
+            catLeft, catRight, wherefunc=join_where, whereargs=(catLeft, catRight)
+        )
+        self.assertListEqual(catLeft[catLWhere].to_list(), catRight[catRWhere].to_list())
+
+    def test_mixed_inner_join_where(self):
+        intLeft = ak.arange(50)
+        intRight = ak.randint(0, 50, 50)
+        strLeft = ak.array([f"str {i}" for i in intLeft.to_list()])
+        strRight = ak.array([f"str {i}" for i in intRight.to_list()])
+        catLeft = ak.Categorical(strLeft)
+        catRight = ak.Categorical(strRight)
+
+        L, R = ak.join.inner_join(
+            intLeft, intRight, wherefunc=join_where, whereargs=(catLeft, strRight)
+        )
+        self.assertListEqual(catLeft[L].to_list(), catRight[R].to_list())
+
+        L, R = ak.join.inner_join(
+            strLeft, strRight, wherefunc=join_where, whereargs=(catLeft, intRight)
+        )
+        self.assertListEqual(catLeft[L].to_list(), catRight[R].to_list())
+
+        L, R = ak.join.inner_join(
+            catLeft, catRight, wherefunc=join_where, whereargs=(strLeft, intRight)
+        )
+        self.assertListEqual(catLeft[L].to_list(), catRight[R].to_list())
 
     def test_lookup(self):
         keys = ak.arange(5)
@@ -152,3 +211,11 @@ class JoinTest(ArkoudaTest):
             ak.join_on_eq_with_dt(self.a1, self.a1, self.t1, self.t1 * 10, 8, "ab_dt")
         with self.assertRaises(ValueError):
             ak.join_on_eq_with_dt(self.a1, self.a1, self.t1, self.t1 * 10, 8, "abs_dt", -1)
+
+
+def join_where(L, R):
+    idx = []
+    for i in range(L.size):
+        idx.append(i % 2 == 0)
+    return ak.array(idx)
+

--- a/tests/join_test.py
+++ b/tests/join_test.py
@@ -130,6 +130,23 @@ class JoinTest(ArkoudaTest):
         )
         self.assertListEqual(strLeft[strLWhere].to_list(), strRight[strRWhere].to_list())
 
+        # reproducer from PR
+        int_left = ak.arange(10)
+        int_right = ak.array([0, 5, 3, 3, 4, 6, 7, 9, 8, 1])
+        str_left = ak.array([f'str {i}' for i in int_left.to_list()])
+        str_right = ak.array([f'str {i}' for i in int_right.to_list()])
+
+        sl, sr = ak.join.inner_join(str_left, str_right)
+        self.assertListEqual(str_left[sl].to_list(), str_right[sr].to_list())
+
+        def where_func(x, y):
+            return x % 2 == 0
+
+        il, ir = ak.join.inner_join(int_left, int_right, wherefunc=where_func, whereargs=(int_left, int_right))
+        sl, sr = ak.join.inner_join(str_left, str_right, wherefunc=where_func, whereargs=(int_left, int_right))
+        self.assertListEqual(sl.to_list(), il.to_list())
+        self.assertListEqual(sr.to_list(), ir.to_list())
+
     def test_cat_inner_join(self):
         intLeft = ak.arange(50)
         intRight = ak.randint(0, 50, 50)
@@ -214,8 +231,4 @@ class JoinTest(ArkoudaTest):
 
 
 def join_where(L, R):
-    idx = []
-    for i in range(L.size):
-        idx.append(i % 2 == 0)
-    return ak.array(idx)
-
+    return ak.arange(L.size) % 2 == 0


### PR DESCRIPTION
This PR (closes https://github.com/Bears-R-Us/arkouda/issues/2304) adds broadcasting (with and without permutation) for Strings and inner join on Strings and Categorical. Adds testing for all this functionality.

We can't add broadcasting to Categorical since we use `broadcast` in the init of Categorical so this causes circular dependencies. Otherwise we could just broadcast on the codes and build `from_codes`

This is built upon the work in https://github.com/Bears-R-Us/arkouda/pull/2376


I did some quick and dirty multi-locale comparisons of comm and time with the previous impl. This is a `10**4` long strings with ganset enabled and 2 locales:
```
new way time = 0

| locale | get | put | execute_on | execute_on_nb |
| -----: | --: | --: | ---------: | ------------: |
|      0 |  17 |   1 |          0 |            41 |
|      1 | 177 |  13 |          5 |             0 |
old way time = 115

| locale |    get |    put | execute_on | execute_on_nb |
| -----: | -----: | -----: | ---------: | ------------: |
|      0 | 800064 | 300000 |          0 |        600063 |
|      1 | 800203 | 100017 |     200004 |        600378 |
```

<details>
  <summary>quick python code used to generate the timings / comm</summary>

```python
In [3]: def test(i):
   ...:     TOT = 10**i
   ...:     SIZE = 10**(i-1)
   ...:     a = ak.arange(SIZE)
   ...:     segs = ak.arange(0,TOT,10)
   ...:     s = ak.cast(a, str)
   ...:     rand = ak.random_strings_uniform(1, 16, SIZE)
   ...:     s = s.stick(rand, delimiter="_")
   ...:     return ak.broadcast(segs, s, TOT)
   ...: 

In [4]: test(5)
Out[4]: array(['0_WXVTUR', '0_WXVTUR', '0_WXVTUR', ... , '9999_OZH', '9999_OZH', '9999_OZH'])
```
</details>