### PR TITLE
Closes #2467: Arrow compilation can fail with clang 15 upgrade changes default PIE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,9 +193,14 @@ ifneq ($(SANITIZER),none)
 ARROW_SANITIZE=-fsanitize=$(SANITIZER)
 endif
 
+CHPL_CXX = $(shell $(CHPL_HOME)/util/config/compileline --compile-c++ 2>/dev/null)
+ifeq ($(CHPL_CXX),none)
+CHPL_CXX=$(CXX)
+endif
+
 .PHONY: compile-arrow-cpp
 compile-arrow-cpp:
-	$(CXX) -O3 -std=c++17 -c $(ARROW_CPP) -o $(ARROW_O) $(INCLUDE_FLAGS) $(ARROW_SANITIZE)
+	$(CHPL_CXX) -O3 -std=c++17 -c $(ARROW_CPP) -o $(ARROW_O) $(INCLUDE_FLAGS) $(ARROW_SANITIZE)
 
 $(ARROW_O): $(ARROW_CPP) $(ARROW_H)
 	make compile-arrow-cpp


### PR DESCRIPTION
Clang 15 changed the default PIE setting on some systems (https://releases.llvm.org/15.0.0/tools/clang/docs/ReleaseNotes.html), which can cause a problem when compiling the Arrow executable. In the Makefile today, `CXX` is used to compile the Arrow code, but that does not always line up with Chapel's C++ compiler, which could mean that the Arrow code may be using an older version of clang, which could throw the PIE versions out of sync.

This PR gets the Chapel C++ compiler in the Makefile and uses that to compile Arrow so that they won't have mismatched compilers.

Closes #2467 