### PR TITLE
Closes #2424 - Adds `SegArray` support for `Strings` Values

### DIFF
--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -37,13 +37,6 @@ groupable = Union[groupable_element_type, Sequence[groupable_element_type]]
 # the circular import with Categorical
 
 
-def is_groupable_element(obj):
-    from arkouda.categorical import Categorical
-    if isinstance(obj, pdarray) or isinstance(obj, Strings) or isinstance(obj, Categorical):
-        return True
-    return False
-
-
 def _get_grouping_keys(pda: groupable):
     nkeys = 1
     if hasattr(pda, "_get_grouping_keys"):

--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -37,6 +37,13 @@ groupable = Union[groupable_element_type, Sequence[groupable_element_type]]
 # the circular import with Categorical
 
 
+def is_groupable_element(obj):
+    from arkouda.categorical import Categorical
+    if isinstance(obj, pdarray) or isinstance(obj, Strings) or isinstance(obj, Categorical):
+        return True
+    return False
+
+
 def _get_grouping_keys(pda: groupable):
     nkeys = 1
     if hasattr(pda, "_get_grouping_keys"):

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -433,14 +433,14 @@ def union1d(
     [array[1, 2, 2, 3, 4, 4, 5, 5], array[1, 2, 5, 3, 2, 4, 4, 5], array[1, 2, 4, 3, 5, 4, 2, 5]]
     """
     if is_groupable_element(pda1) and is_groupable_element(pda2) and type(pda1) == type(pda2):
-        if pda1.size == 0:
+        if pda1.size == 0:  # type: ignore
             return pda2  # union is pda2
-        if pda2.size == 0:
+        if pda2.size == 0:  # type: ignore
             return pda1  # union is pda1
         if (
-            pda1.dtype == int
-            and pda2.dtype == int
-            or (pda1.dtype == akuint64 and pda2.dtype == akuint64)
+            pda1.dtype == int  # type: ignore
+            and pda2.dtype == int  # type: ignore
+            or (pda1.dtype == akuint64 and pda2.dtype == akuint64)  # type: ignore
         ):
             repMsg = generic_msg(cmd="union1d", args={
                 "arg1": pda1,
@@ -524,12 +524,12 @@ def intersect1d(
     [array([1, 3]), array([1, 3]), array([1, 3])]
     """
     if is_groupable_element(pda1) and is_groupable_element(pda2) and type(pda1) == type(pda2):
-        if pda1.size == 0:
+        if pda1.size == 0:  # type: ignore
             return pda1  # nothing in the intersection
-        if pda2.size == 0:
+        if pda2.size == 0:  # type: ignore
             return pda2  # nothing in the intersection
-        if (pda1.dtype == int and pda2.dtype == int) or (
-            pda1.dtype == akuint64 and pda2.dtype == akuint64
+        if (pda1.dtype == int and pda2.dtype == int) or (  # type: ignore
+            pda1.dtype == akuint64 and pda2.dtype == akuint64  # type: ignore
         ):
             repMsg = generic_msg(
                 cmd="intersect1d", args={"arg1": pda1, "arg2": pda2, "assume_unique": assume_unique}
@@ -636,12 +636,12 @@ def setdiff1d(
     [array([2, 4, 5]), array([2, 4, 5]), array([2, 4, 5])]
     """
     if is_groupable_element(pda1) and is_groupable_element(pda2) and type(pda1) == type(pda2):
-        if pda1.size == 0:
+        if pda1.size == 0:  # type: ignore
             return pda1  # return a zero length pdarray
-        if pda2.size == 0:
+        if pda2.size == 0:  # type: ignore
             return pda1  # subtracting nothing return orig pdarray
-        if (pda1.dtype == int and pda2.dtype == int) or (
-            pda1.dtype == akuint64 and pda2.dtype == akuint64
+        if (pda1.dtype == int and pda2.dtype == int) or (  # type: ignore
+            pda1.dtype == akuint64 and pda2.dtype == akuint64  # type: ignore
         ):
             repMsg = generic_msg(
                 cmd="setdiff1d", args={
@@ -744,12 +744,12 @@ def setxor1d(pda1: groupable, pda2: groupable, assume_unique: bool = False) -> U
     [array([2, 2, 4, 4, 5, 5]), array([2, 5, 2, 4, 4, 5]), array([2, 4, 5, 4, 2, 5])]
     """
     if is_groupable_element(pda1) and is_groupable_element(pda2) and type(pda1) == type(pda2):
-        if pda1.size == 0:
+        if pda1.size == 0:  # type: ignore
             return pda2  # return other pdarray if pda1 is empty
-        if pda2.size == 0:
+        if pda2.size == 0:  # type: ignore
             return pda1  # return other pdarray if pda2 is empty
-        if (pda1.dtype == int and pda2.dtype == int) or (
-            pda1.dtype == akuint64 and pda2.dtype == akuint64
+        if (pda1.dtype == int and pda2.dtype == int) or (  # type: ignore
+            pda1.dtype == akuint64 and pda2.dtype == akuint64  # type: ignore
         ):
             repMsg = generic_msg(
                 cmd="setxor1d", args={

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -11,7 +11,7 @@ from arkouda.dtypes import bool as akbool
 from arkouda.dtypes import int64 as akint64
 from arkouda.dtypes import uint64 as akuint64
 from arkouda.dtypes import bigint
-from arkouda.groupbyclass import GroupBy, groupable, groupable_element_type, unique, is_groupable_element
+from arkouda.groupbyclass import GroupBy, groupable, groupable_element_type, unique
 from arkouda.logger import getArkoudaLogger
 from arkouda.pdarrayclass import create_pdarray, pdarray
 from arkouda.pdarraycreation import array, ones, zeros, zeros_like
@@ -432,15 +432,20 @@ def union1d(
     >>> ak.union1d(multia, multib)
     [array[1, 2, 2, 3, 4, 4, 5, 5], array[1, 2, 5, 3, 2, 4, 4, 5], array[1, 2, 4, 3, 5, 4, 2, 5]]
     """
-    if is_groupable_element(pda1) and is_groupable_element(pda2) and type(pda1) == type(pda2):
-        if pda1.size == 0:  # type: ignore
+    from arkouda.categorical import Categorical as Categorical_
+    if (
+            isinstance(pda1, (pdarray, Strings, Categorical_)) and
+            isinstance(pda2, (pdarray, Strings, Categorical_)) and
+            type(pda1) == type(pda2)
+    ):
+        if pda1.size == 0:
             return pda2  # union is pda2
-        if pda2.size == 0:  # type: ignore
+        if pda2.size == 0:
             return pda1  # union is pda1
         if (
-            pda1.dtype == int  # type: ignore
-            and pda2.dtype == int  # type: ignore
-            or (pda1.dtype == akuint64 and pda2.dtype == akuint64)  # type: ignore
+            pda1.dtype == int
+            and pda2.dtype == int
+            or (pda1.dtype == akuint64 and pda2.dtype == akuint64)
         ):
             repMsg = generic_msg(cmd="union1d", args={
                 "arg1": pda1,
@@ -523,13 +528,16 @@ def intersect1d(
     >>> ak.intersect1d(multia, multib)
     [array([1, 3]), array([1, 3]), array([1, 3])]
     """
-    if is_groupable_element(pda1) and is_groupable_element(pda2) and type(pda1) == type(pda2):
-        if pda1.size == 0:  # type: ignore
+    from arkouda.categorical import Categorical as Categorical_
+    if (isinstance(pda1, (pdarray, Strings, Categorical_)) and
+            isinstance(pda2, (pdarray, Strings, Categorical_)) and
+            type(pda1) == type(pda2)):
+        if pda1.size == 0:
             return pda1  # nothing in the intersection
-        if pda2.size == 0:  # type: ignore
+        if pda2.size == 0:
             return pda2  # nothing in the intersection
-        if (pda1.dtype == int and pda2.dtype == int) or (  # type: ignore
-            pda1.dtype == akuint64 and pda2.dtype == akuint64  # type: ignore
+        if (pda1.dtype == int and pda2.dtype == int) or (
+            pda1.dtype == akuint64 and pda2.dtype == akuint64
         ):
             repMsg = generic_msg(
                 cmd="intersect1d", args={"arg1": pda1, "arg2": pda2, "assume_unique": assume_unique}
@@ -635,13 +643,16 @@ def setdiff1d(
     >>> ak.setdiff1d(multia, multib)
     [array([2, 4, 5]), array([2, 4, 5]), array([2, 4, 5])]
     """
-    if is_groupable_element(pda1) and is_groupable_element(pda2) and type(pda1) == type(pda2):
-        if pda1.size == 0:  # type: ignore
+    from arkouda.categorical import Categorical as Categorical_
+    if (isinstance(pda1, (pdarray, Strings, Categorical_)) and
+            isinstance(pda2, (pdarray, Strings, Categorical_)) and
+            type(pda1) == type(pda2)):
+        if pda1.size == 0:
             return pda1  # return a zero length pdarray
-        if pda2.size == 0:  # type: ignore
+        if pda2.size == 0:
             return pda1  # subtracting nothing return orig pdarray
-        if (pda1.dtype == int and pda2.dtype == int) or (  # type: ignore
-            pda1.dtype == akuint64 and pda2.dtype == akuint64  # type: ignore
+        if (pda1.dtype == int and pda2.dtype == int) or (
+            pda1.dtype == akuint64 and pda2.dtype == akuint64
         ):
             repMsg = generic_msg(
                 cmd="setdiff1d", args={
@@ -743,13 +754,16 @@ def setxor1d(pda1: groupable, pda2: groupable, assume_unique: bool = False) -> U
     >>> ak.setxor1d(multia, multib)
     [array([2, 2, 4, 4, 5, 5]), array([2, 5, 2, 4, 4, 5]), array([2, 4, 5, 4, 2, 5])]
     """
-    if is_groupable_element(pda1) and is_groupable_element(pda2) and type(pda1) == type(pda2):
-        if pda1.size == 0:  # type: ignore
+    from arkouda.categorical import Categorical as Categorical_
+    if (isinstance(pda1, (pdarray, Strings, Categorical_)) and
+            isinstance(pda2, (pdarray, Strings, Categorical_)) and
+            type(pda1) == type(pda2)):
+        if pda1.size == 0:
             return pda2  # return other pdarray if pda1 is empty
-        if pda2.size == 0:  # type: ignore
+        if pda2.size == 0:
             return pda1  # return other pdarray if pda2 is empty
-        if (pda1.dtype == int and pda2.dtype == int) or (  # type: ignore
-            pda1.dtype == akuint64 and pda2.dtype == akuint64  # type: ignore
+        if (pda1.dtype == int and pda2.dtype == int) or (
+            pda1.dtype == akuint64 and pda2.dtype == akuint64
         ):
             repMsg = generic_msg(
                 cmd="setxor1d", args={

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -237,7 +237,6 @@ def concatenate(
     arrays: Sequence[Union[pdarray, Strings, "Categorical", ]],  # type: ignore
     ordered: bool = True,
 ) -> Union[pdarray, Strings, "Categorical"]:  # type: ignore
-    # fmt:on
     """
     Concatenate a list or tuple of ``pdarray`` or ``Strings`` objects into
     one ``pdarray`` or ``Strings`` object, respectively.
@@ -356,6 +355,7 @@ def concatenate(
         return Strings.from_return_msg(cast(str, repMsg))
     else:
         raise TypeError("arrays must be an array of pdarray or Strings objects")
+# fmt:on
 
 
 def multiarray_setop_validation(
@@ -433,10 +433,11 @@ def union1d(
     [array[1, 2, 2, 3, 4, 4, 5, 5], array[1, 2, 5, 3, 2, 4, 4, 5], array[1, 2, 4, 3, 5, 4, 2, 5]]
     """
     from arkouda.categorical import Categorical as Categorical_
+
     if (
-            isinstance(pda1, (pdarray, Strings, Categorical_)) and
-            isinstance(pda2, (pdarray, Strings, Categorical_)) and
-            type(pda1) == type(pda2)
+        isinstance(pda1, (pdarray, Strings, Categorical_))
+        and isinstance(pda2, (pdarray, Strings, Categorical_))
+        and type(pda1) == type(pda2)
     ):
         if pda1.size == 0:
             return pda2  # union is pda2
@@ -447,10 +448,7 @@ def union1d(
             and pda2.dtype == int
             or (pda1.dtype == akuint64 and pda2.dtype == akuint64)
         ):
-            repMsg = generic_msg(cmd="union1d", args={
-                "arg1": pda1,
-                "arg2": pda2
-            })
+            repMsg = generic_msg(cmd="union1d", args={"arg1": pda1, "arg2": pda2})
             return cast(pdarray, create_pdarray(repMsg))
         return cast(
             pdarray, unique(cast(pdarray, concatenate((unique(pda1), unique(pda2)), ordered=False)))
@@ -529,9 +527,12 @@ def intersect1d(
     [array([1, 3]), array([1, 3]), array([1, 3])]
     """
     from arkouda.categorical import Categorical as Categorical_
-    if (isinstance(pda1, (pdarray, Strings, Categorical_)) and
-            isinstance(pda2, (pdarray, Strings, Categorical_)) and
-            type(pda1) == type(pda2)):
+
+    if (
+        isinstance(pda1, (pdarray, Strings, Categorical_))
+        and isinstance(pda2, (pdarray, Strings, Categorical_))
+        and type(pda1) == type(pda2)
+    ):
         if pda1.size == 0:
             return pda1  # nothing in the intersection
         if pda2.size == 0:
@@ -644,9 +645,12 @@ def setdiff1d(
     [array([2, 4, 5]), array([2, 4, 5]), array([2, 4, 5])]
     """
     from arkouda.categorical import Categorical as Categorical_
-    if (isinstance(pda1, (pdarray, Strings, Categorical_)) and
-            isinstance(pda2, (pdarray, Strings, Categorical_)) and
-            type(pda1) == type(pda2)):
+
+    if (
+        isinstance(pda1, (pdarray, Strings, Categorical_))
+        and isinstance(pda2, (pdarray, Strings, Categorical_))
+        and type(pda1) == type(pda2)
+    ):
         if pda1.size == 0:
             return pda1  # return a zero length pdarray
         if pda2.size == 0:
@@ -655,11 +659,7 @@ def setdiff1d(
             pda1.dtype == akuint64 and pda2.dtype == akuint64
         ):
             repMsg = generic_msg(
-                cmd="setdiff1d", args={
-                    "arg1": pda1,
-                    "arg2": pda2,
-                    "assume_unique": assume_unique
-                }
+                cmd="setdiff1d", args={"arg1": pda1, "arg2": pda2, "assume_unique": assume_unique}
             )
             return create_pdarray(cast(str, repMsg))
         if not assume_unique:
@@ -755,9 +755,12 @@ def setxor1d(pda1: groupable, pda2: groupable, assume_unique: bool = False) -> U
     [array([2, 2, 4, 4, 5, 5]), array([2, 5, 2, 4, 4, 5]), array([2, 4, 5, 4, 2, 5])]
     """
     from arkouda.categorical import Categorical as Categorical_
-    if (isinstance(pda1, (pdarray, Strings, Categorical_)) and
-            isinstance(pda2, (pdarray, Strings, Categorical_)) and
-            type(pda1) == type(pda2)):
+
+    if (
+        isinstance(pda1, (pdarray, Strings, Categorical_))
+        and isinstance(pda2, (pdarray, Strings, Categorical_))
+        and type(pda1) == type(pda2)
+    ):
         if pda1.size == 0:
             return pda2  # return other pdarray if pda1 is empty
         if pda2.size == 0:
@@ -766,11 +769,8 @@ def setxor1d(pda1: groupable, pda2: groupable, assume_unique: bool = False) -> U
             pda1.dtype == akuint64 and pda2.dtype == akuint64
         ):
             repMsg = generic_msg(
-                cmd="setxor1d", args={
-                    "arg1": pda1,
-                    "arg2": pda2,
-                    "assume_unique": assume_unique
-                })
+                cmd="setxor1d", args={"arg1": pda1, "arg2": pda2, "assume_unique": assume_unique}
+            )
             return create_pdarray(cast(str, repMsg))
         if not assume_unique:
             pda1 = cast(pdarray, unique(pda1))

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -11,7 +11,7 @@ from arkouda.dtypes import bool as akbool
 from arkouda.dtypes import int64 as akint64
 from arkouda.dtypes import uint64 as akuint64
 from arkouda.dtypes import bigint
-from arkouda.groupbyclass import GroupBy, groupable, groupable_element_type, unique
+from arkouda.groupbyclass import GroupBy, groupable, groupable_element_type, unique, is_groupable_element
 from arkouda.logger import getArkoudaLogger
 from arkouda.pdarrayclass import create_pdarray, pdarray
 from arkouda.pdarraycreation import array, ones, zeros, zeros_like
@@ -380,8 +380,8 @@ def multiarray_setop_validation(
 # (A1 | A2) Set Union: elements are in one or the other or both
 @typechecked
 def union1d(
-    pda1: Union[pdarray, Sequence[groupable_element_type]],
-    pda2: Union[pdarray, Sequence[groupable_element_type]],
+    pda1: groupable,
+    pda2: groupable,
 ) -> Union[pdarray, groupable]:
     """
     Find the union of two arrays/List of Arrays.
@@ -432,7 +432,7 @@ def union1d(
     >>> ak.union1d(multia, multib)
     [array[1, 2, 2, 3, 4, 4, 5, 5], array[1, 2, 5, 3, 2, 4, 4, 5], array[1, 2, 4, 3, 5, 4, 2, 5]]
     """
-    if isinstance(pda1, pdarray) and isinstance(pda2, pdarray):
+    if is_groupable_element(pda1) and is_groupable_element(pda2) and type(pda1) == type(pda2):
         if pda1.size == 0:
             return pda2  # union is pda2
         if pda2.size == 0:
@@ -523,7 +523,7 @@ def intersect1d(
     >>> ak.intersect1d(multia, multib)
     [array([1, 3]), array([1, 3]), array([1, 3])]
     """
-    if isinstance(pda1, pdarray) and isinstance(pda2, pdarray):
+    if is_groupable_element(pda1) and is_groupable_element(pda2) and type(pda1) == type(pda2):
         if pda1.size == 0:
             return pda1  # nothing in the intersection
         if pda2.size == 0:
@@ -635,7 +635,7 @@ def setdiff1d(
     >>> ak.setdiff1d(multia, multib)
     [array([2, 4, 5]), array([2, 4, 5]), array([2, 4, 5])]
     """
-    if isinstance(pda1, pdarray) and isinstance(pda2, pdarray):
+    if is_groupable_element(pda1) and is_groupable_element(pda2) and type(pda1) == type(pda2):
         if pda1.size == 0:
             return pda1  # return a zero length pdarray
         if pda2.size == 0:
@@ -743,7 +743,7 @@ def setxor1d(pda1: groupable, pda2: groupable, assume_unique: bool = False) -> U
     >>> ak.setxor1d(multia, multib)
     [array([2, 2, 4, 4, 5, 5]), array([2, 5, 2, 4, 4, 5]), array([2, 4, 5, 4, 2, 5])]
     """
-    if isinstance(pda1, pdarray) and isinstance(pda2, pdarray):
+    if is_groupable_element(pda1) and is_groupable_element(pda2) and type(pda1) == type(pda2):
         if pda1.size == 0:
             return pda2  # return other pdarray if pda1 is empty
         if pda2.size == 0:

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -539,7 +539,7 @@ class SegArray:
         """
         longenough, newj = self._normalize_index(j)
         ind = (self.segments + newj)[longenough]
-        if compressed or self.dtype == str_: # Strings not supported by uncompressed version
+        if compressed or self.dtype == str_:  # Strings not supported by uncompressed version
             res = self.values[ind]
         else:
             res = zeros(self.size, dtype=self.dtype) + default

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -111,7 +111,7 @@ class SegArray:
         if not isinstance(segments, pdarray) or segments.dtype != akint64:
             raise TypeError("Segments must be int64 pdarray")
         if not isinstance(values, pdarray) and not isinstance(values, Strings):
-            raise TypeError("Values must be a pdarray.")
+            raise TypeError("Values must be a pdarray or Strings.")
         if not is_sorted(segments):
             raise ValueError("Segments must be unique and in sorted order")
         if segments.size > 0:
@@ -771,7 +771,7 @@ class SegArray:
         return [arr.tolist() for arr in self.to_ndarray()]
 
     def sum(self, x=None):
-        if x is None:  # TODO when values are Strings, supplying None does not work, should it?
+        if x is None:
             x = self.values
         return self.grouping.sum(x)[1]
 

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -1210,7 +1210,6 @@ class SegArray:
                 segments[-1] = g.permutation.size
                 truth[-1] = False
             segments[truth] = segments[arange(self.size)[truth] + 1]
-            # print(g.permutation)
             return SegArray(segments, new_values[g.permutation])
 
     def union(self, other):


### PR DESCRIPTION
Closes #2424

This PR makes the necessary updates to `SegArray` to allow its values to be a `Strings` object.

Additional supporting changes also allow for set operations on 2 Strings/Categorical objects. This was previously allowed by the parameter typing, but the actual workflow would not allow for it.

