### PR TITLE
Closes #2459 and #2434: `ak.hash` for `Segarray` and `Strings`

### DIFF
--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -1,3 +1,4 @@
+import json
 from enum import Enum
 from typing import ForwardRef, List, Optional, Tuple, Union
 from typing import cast as type_cast
@@ -426,11 +427,12 @@ def cos(pda: pdarray) -> pdarray:
 
 
 def _hash_helper(a):
-    from arkouda import SegArray as _Segarray
+    from arkouda import SegArray as Segarray_
 
-    # TODO move to JSON (see issue #2464), right now we '+' as a delimiter
-    if isinstance(a, _Segarray):
-        return f"{a.segments.name}+{a.values.name}+{a.values.objType}"
+    if isinstance(a, Segarray_):
+        return json.dumps(
+            {"segments": a.segments.name, "values": a.values.name, "valObjType": a.values.objType}
+        )
     else:
         return a.name
 
@@ -487,9 +489,9 @@ def hash(
     because equivalent values will cancel each other out, hence we
     do a rotation by the ordinal of the array.
     """
-    from arkouda import SegArray as _Segarray
+    from arkouda import SegArray as Segarray_
 
-    if isinstance(pda, (pdarray, Strings, _Segarray)):
+    if isinstance(pda, (pdarray, Strings, Segarray_)):
         return _hash_single(pda, full) if isinstance(pda, pdarray) else pda.hash()
     elif isinstance(pda, List):
         types_list = [a.objType for a in pda]

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -24,6 +24,7 @@ from arkouda.pdarraycreation import array
 from arkouda.strings import Strings
 
 Categorical = ForwardRef("Categorical")
+SegArray = ForwardRef("SegArray")
 
 __all__ = [
     "cast",
@@ -41,6 +42,8 @@ __all__ = [
     "isnan",
     "ErrorMode",
 ]
+
+hashable = Union[pdarray, Strings, SegArray]  # type: ignore
 
 
 class ErrorMode(Enum):
@@ -422,16 +425,26 @@ def cos(pda: pdarray) -> pdarray:
     return create_pdarray(repMsg)
 
 
+def _hash_helper(a):
+    from arkouda import SegArray as _Segarray
+
+    # TODO move to JSON (see issue #2464), right now we '+' as a delimiter
+    if isinstance(a, _Segarray):
+        return f"{a.segments.name}+{a.values.name}+{a.values.objType}"
+    else:
+        return a.name
+
+
 @typechecked
 def hash(
-    pda: Union[pdarray, List[pdarray]], full: bool = True
+    pda: Union[hashable, List[hashable]], full: bool = True
 ) -> Union[Tuple[pdarray, pdarray], pdarray]:
     """
-    Return an element-wise hash of the array.
+    Return an element-wise hash of the array or list of arrays.
 
     Parameters
     ----------
-    pda : Union[pdarray, list[pdarray]]
+    pda : Union[pdarray, Strings, Segarray], List[Union[pdarray, Strings, Segarray]]]
 
     full : bool
         This is only used when a single pdarray is passed into hash
@@ -468,30 +481,38 @@ def hash(
     fixed key for the hash, which makes it possible for an
     adversary with control over input to engineer collisions.
 
-    In the case of a list of pdrrays being passed, a non-linear
-    function must be applied to each array since hashes of subsequent
-    arrays cannot be simply XORed because equivalent values will
-    cancel each other out, hence we do a rotation by the ordinal of
-    the array.
+    In the case of a list of pdrrays, Strings, or Segarrays
+    being passed, a non-linear function must be applied to each
+    array since hashes of subsequent arrays cannot be simply XORed
+    because equivalent values will cancel each other out, hence we
+    do a rotation by the ordinal of the array.
     """
-    if isinstance(pda, pdarray):
-        return _hash_single(pda, full)
+    from arkouda import SegArray as _Segarray
 
-    repMsg = type_cast(
-        str,
-        generic_msg(
-            cmd="efuncArr",
-            args={
-                "nameslist": [n.name for n in pda],
-                "typeslist": [n.objType for n in pda],
-                "length": len(pda),
-                "size": len(pda[0]),
-            },
-        ),
-    )
-
-    a, b = repMsg.split("+")
-    return create_pdarray(a), create_pdarray(b)
+    if isinstance(pda, (pdarray, Strings, _Segarray)):
+        return _hash_single(pda, full) if isinstance(pda, pdarray) else pda.hash()
+    elif isinstance(pda, List):
+        types_list = [a.objType for a in pda]
+        names_list = [_hash_helper(a) for a in pda]
+        repMsg = type_cast(
+            str,
+            generic_msg(
+                cmd="hashList",
+                args={
+                    "nameslist": names_list,
+                    "typeslist": types_list,
+                    "length": len(pda),
+                    "size": len(pda[0]),
+                },
+            ),
+        )
+        a, b = repMsg.split("+")
+        return create_pdarray(a), create_pdarray(b)
+    else:
+        raise TypeError(
+            f"Unsupported type {type(pda)}. Supported types are pdarray,"
+            f" SegArray, Strings, and Lists of these types."
+        )
 
 
 @typechecked

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -428,7 +428,7 @@ def cos(pda: pdarray) -> pdarray:
     return create_pdarray(repMsg)
 
 
-def _hash_helper(a):
+def _hash_helper(a: hashable):
     from arkouda import SegArray as Segarray_
 
     if isinstance(a, Segarray_):

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -362,7 +362,7 @@ class SegArray:
         return eq
 
     def __len__(self) -> int:
-        return self.segments.size
+        return self.size
 
     def __str__(self):
         if self.size <= 6:

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -184,6 +184,12 @@ module AryUtil
             var g = getGenericTypedArrayEntry(name, st);
             thisSize = g.size;
           }
+          when ObjType.SEGARRAY {
+            var (segName, valName, _) = name.splitMsgToTuple('+', 3);
+            var segs = getGenericTypedArrayEntry(segName, st);
+            var vals = getGenericTypedArrayEntry(valName, st);
+            thisSize = segs.size;
+          }
           otherwise {
               var errorMsg = "Unrecognized object type: %s".format(objtype);
               auLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);  

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -9,6 +9,7 @@ module AryUtil
     use MultiTypeSymEntry;
     use ServerErrors;
     use BitOps;
+    use GenSymIO;
 
     use ArkoudaPOSIXCompat;
 
@@ -185,7 +186,8 @@ module AryUtil
             thisSize = g.size;
           }
           when ObjType.SEGARRAY {
-            var (segName, valName, _) = name.splitMsgToTuple('+', 3);
+            var segComps = jsonToMap(name);
+            var (segName, valName) = (segComps["segments"], segComps["values"]);
             var segs = getGenericTypedArrayEntry(segName, st);
             var vals = getGenericTypedArrayEntry(valName, st);
             thisSize = segs.size;

--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -745,7 +745,7 @@ module EfuncMsg
         return new MsgTuple(repMsg, MsgType.NORMAL); 
     }
 
-    proc efuncArrMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+    proc hashArraysMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         var n = msgArgs.get("length").getIntValue();
         var s = msgArgs.get("size").getIntValue();
         var namesList = msgArgs.get("nameslist").getList(n);
@@ -872,5 +872,5 @@ module EfuncMsg
     registerFunction("efunc3vs", efunc3vsMsg, getModuleName());
     registerFunction("efunc3sv", efunc3svMsg, getModuleName());
     registerFunction("efunc3ss", efunc3ssMsg, getModuleName());
-    registerFunction("efuncArr", efuncArrMsg, getModuleName());
+    registerFunction("hashList", hashArraysMsg, getModuleName());
 }

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -1,0 +1,129 @@
+module SegmentedArray {
+  use MultiTypeSymbolTable;
+  use MultiTypeSymEntry;
+  use ServerConfig;
+  use ReductionMsg;
+  use Broadcast;
+  use UniqueMsg;
+  use SipHash;
+  use SegmentedString;
+
+  proc hashHelper(size, names, types, st): [] 2*uint throws {
+    // Basically a duplicate of hashArrays which only operates on pdarray and strings
+    // we can't just call hashArrays because the compiler complains about recursion
+    overMemLimit(numBytes(uint) * size * 2);
+    var dom = makeDistDom(size);
+    var hashes: [dom] 2*uint(64);
+    /* Hashes of subsequent arrays cannot be simply XORed
+     * because equivalent values will cancel each other out.
+     * Thus, a non-linear function must be applied to each array,
+     * hence we do a rotation by the ordinal of the array. This
+     * will only handle up to 128 arrays before rolling back around.
+     */
+    proc rotl(h:2*uint(64), n:int):2*uint(64) {
+      use BitOps;
+      // no rotation
+      if (n == 0) { return h; }
+      // Rotate each 64-bit word independently, then swap tails
+      const (h1, h2) = h;
+      // Mask for tail (right-hand portion)
+      const rmask = (1 << n) - 1;
+      // Mask for head (left-hand portion)
+      const lmask = 2**64 - 1 - rmask;
+      // Rotate each word
+      var r1 = rotl(h1, n);
+      var r2 = rotl(h2, n);
+      // Swap tails
+      r1 = (r1 & lmask) | (r2 & rmask);
+      r2 = (r2 & lmask) | (r1 & rmask);
+      return (r1, r2);
+    }
+    for (name, objtype, i) in zip(names, types, 0..) {
+      select objtype.toUpper(): ObjType {
+        when ObjType.PDARRAY {
+          var g = getGenericTypedArrayEntry(name, st);
+          select g.dtype {
+            when DType.Int64 {
+              var e = toSymEntry(g, int);
+              ref ea = e.a;
+              forall (h, x) in zip(hashes, ea) {
+                h ^= rotl(sipHash128(x), i);
+              }
+            }
+            when DType.UInt64 {
+              var e = toSymEntry(g, uint);
+              ref ea = e.a;
+              forall (h, x) in zip(hashes, ea) {
+                h ^= rotl(sipHash128(x), i);
+              }
+            }
+            when DType.Float64 {
+              var e = toSymEntry(g, real);
+              ref ea = e.a;
+              forall (h, x) in zip(hashes, ea) {
+                h ^= rotl(sipHash128(x), i);
+              }
+            }
+            when DType.Bool {
+              var e = toSymEntry(g, bool);
+              ref ea = e.a;
+              forall (h, x) in zip(hashes, ea) {
+                h ^= rotl((0:uint, x:uint), i);
+              }
+            }
+          }
+        }
+        when ObjType.STRINGS {
+          var (myNames, _) = name.splitMsgToTuple('+', 2);
+          var g = getSegString(myNames, st);
+          hashes ^= rotl(g.siphash(), i);
+        }
+      }
+    }
+    return hashes;
+  }
+
+  proc segarrayHash(segName: string, valName: string, valObjType: string, st: borrowed SymTab) throws {
+    const segments = toSymEntry(getGenericTypedArrayEntry(segName, st), int);
+    var values = getGenericTypedArrayEntry(valName, st);
+    const size = values.size;
+    const broadcastedSegs = broadcast(segments.a, segments.a, size);
+    const valInd = makeDistDom(size);
+
+    // calculate segment indices (we use this to prevent segXor from zeroing out arrays like [5,5,5,5])
+    // see comments of issue #2459 for more details
+    // temporarily add to symtab for hashArrays and then delete entry
+    var segInds = [(b, i) in zip (broadcastedSegs, valInd)] i - b;
+    var siName = st.nextName();
+    st.addEntry(siName, new shared SymEntry(segInds));
+    // we can't just call hashArrays because the compiler complains about recursion
+    var hashes = hashHelper(size, [valName, siName], [valObjType, ObjType.PDARRAY:string], st);
+    st.deleteEntry(siName);
+
+    var upper = makeDistArray(size, uint);
+    var lower = makeDistArray(size, uint);
+    forall (up, low, h) in zip(upper, lower, hashes) {
+      (up, low) = h;
+    }
+
+    // we have to hash twice before the XOR to avoid collisions with
+    // things like ak.Segarray(ak.array([0,2],ak.array([1,1,2,2]))
+    var upperName = st.nextName();
+    st.addEntry(upperName, new shared SymEntry(upper));
+    var lowerName = st.nextName();
+    st.addEntry(lowerName, new shared SymEntry(lower));
+    var rehash = hashHelper(size, [upperName, lowerName], [ObjType.PDARRAY:string, ObjType.PDARRAY:string], st);
+    st.deleteEntry(upperName);
+    st.deleteEntry(lowerName);
+
+    var rehashUpper = makeDistArray(size, uint);
+    var rehashLower = makeDistArray(size, uint);
+    forall (up, low, h) in zip(rehashUpper, rehashLower, rehash) {
+      (up, low) = h;
+    }
+
+    var xorUpper = segXor(rehashUpper, segments.a);
+    var xorLower = segXor(rehashLower, segments.a);
+    return (xorUpper, xorLower);
+  }
+}

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -29,6 +29,7 @@ module UniqueMsg
     use Unique;
     use SipHash;
     use CommAggregation;
+    use SegmentedArray;
     
     private config const logLevel = ServerConfig.logLevel;
     private config const logChannel = ServerConfig.logChannel;
@@ -253,25 +254,29 @@ module UniqueMsg
             select g.dtype {
               when DType.Int64 {
                 var e = toSymEntry(g, int);
-                forall (h, x) in zip(hashes, e.a) {
+                ref ea = e.a;
+                forall (h, x) in zip(hashes, ea) {
                   h ^= rotl(sipHash128(x), i);
                 }
               }
               when DType.UInt64 {
                 var e = toSymEntry(g, uint);
-                forall (h, x) in zip(hashes, e.a) {
+                ref ea = e.a;
+                forall (h, x) in zip(hashes, ea) {
                   h ^= rotl(sipHash128(x), i);
                 }
               }
               when DType.Float64 {
                 var e = toSymEntry(g, real);
-                forall (h, x) in zip(hashes, e.a) {
+                ref ea = e.a;
+                forall (h, x) in zip(hashes, ea) {
                   h ^= rotl(sipHash128(x), i);
                 }
               }
               when DType.Bool {
                 var e = toSymEntry(g, bool);
-                forall (h, x) in zip(hashes, e.a) {
+                ref ea = e.a;
+                forall (h, x) in zip(hashes, ea) {
                   h ^= rotl((0:uint, x:uint), i);
                 }
               }
@@ -281,6 +286,13 @@ module UniqueMsg
             var (myNames, _) = name.splitMsgToTuple('+', 2);
             var g = getSegString(myNames, st);
             hashes ^= rotl(g.siphash(), i);
+          }
+          when ObjType.SEGARRAY {
+            var (segName, valName, valObjType) = name.splitMsgToTuple('+', 3);
+            var (upper, lower) = segarrayHash(segName, valName, valObjType, st);
+            forall (h, u, l) in zip(hashes, upper, lower) {
+              h ^= rotl((u,l), i);
+            }
           }
         }
       }

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -19,6 +19,7 @@ module UniqueMsg
     use ServerErrors;
     use Logging;
     use Message;
+    use GenSymIO;
 
     use MultiTypeSymbolTable;
     use MultiTypeSymEntry;
@@ -288,8 +289,8 @@ module UniqueMsg
             hashes ^= rotl(g.siphash(), i);
           }
           when ObjType.SEGARRAY {
-            var (segName, valName, valObjType) = name.splitMsgToTuple('+', 3);
-            var (upper, lower) = segarrayHash(segName, valName, valObjType, st);
+            var segComps = jsonToMap(name);
+            var (upper, lower) = segarrayHash(segComps["segments"], segComps["values"], segComps["valObjType"], st);
             forall (h, u, l) in zip(hashes, upper, lower) {
               h ^= rotl((u,l), i);
             }


### PR DESCRIPTION
This PR (closes #2459 and closes #2434) adds:
- segarray hashing `sa.hash()` and `ak.hash(sa)` for pdarray and Strings values
- support for Strings in `ak.hash`
- testing for these cases