### PR TITLE
Closes #2436 - Updates `_buildReadAllJSON` to use `ObjType` Enum

### DIFF
--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -324,11 +324,11 @@ class GroupBy:
             if k == "permutation" or k == "segments" or k == "uki":
                 continue
             comps = create_data.split("+|+")
-            if comps[0] == "pdarray":
+            if comps[0] == pdarray.objType.upper():
                 keys.append(create_pdarray(comps[1]))
-            elif comps[0] == "seg_string":  # TODO - update to use Strings.objType
+            elif comps[0] == Strings.objType.upper():
                 keys.append(Strings.from_return_msg(comps[1]))
-            elif comps[0] == "categorical":
+            elif comps[0] == Categorical_.objType.upper():
                 keys.append(Categorical_.from_return_msg(comps[1]))
         if len(keys) == 1:
             keys = keys[0]

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -453,20 +453,20 @@ def _parse_obj(
     TypeError
         - If return object is an unsupported type
     """
-    if "seg_string" == obj["arkouda_type"]:
+    if Strings.objType.upper() == obj["arkouda_type"]:
         return Strings.from_return_msg(obj["created"])
-    elif "seg_array" == obj["arkouda_type"]:
+    elif SegArray.objType.upper() == obj["arkouda_type"]:
         return SegArray.from_return_msg(obj["created"])
-    elif "pdarray" == obj["arkouda_type"]:
+    elif pdarray.objType.upper() == obj["arkouda_type"]:
         return create_pdarray(obj["created"])
-    elif "ArrayView" == obj["arkouda_type"]:
+    elif ArrayView.objType.upper() == obj["arkouda_type"]:
         components = obj["created"].split("+")
         flat = create_pdarray(components[0])
         shape = create_pdarray(components[1])
         return ArrayView(flat, shape)
-    elif "categorical" == obj["arkouda_type"]:
+    elif Categorical.objType.upper() == obj["arkouda_type"]:
         return Categorical.from_return_msg(obj["created"])
-    elif "groupby" == obj["arkouda_type"]:
+    elif GroupBy.objType.upper() == obj["arkouda_type"]:
         return GroupBy.from_return_msg(obj["created"])
     else:
         raise TypeError(f"Unknown arkouda type:{obj['arkouda_type']}")

--- a/src/CSVMsg.chpl
+++ b/src/CSVMsg.chpl
@@ -388,9 +388,9 @@ module CSVMsg {
         return (subdoms, offsets, skips);
     }
 
-    proc readTypedCSV(filenames: [] string, datasets: [?D] string, dtypes: list(string), row_counts: [] int, validFiles: [] bool, col_delim: string, st: borrowed SymTab): list((string, string, string)) throws {
+    proc readTypedCSV(filenames: [] string, datasets: [?D] string, dtypes: list(string), row_counts: [] int, validFiles: [] bool, col_delim: string, st: borrowed SymTab): list((string, ObjType, string)) throws {
         // assumes the file has header since we were able to access type info
-        var rtnData: list((string, string, string));
+        var rtnData: list((string, ObjType, string));
         var record_count = + reduce row_counts;
         var (subdoms, offsets, skips) = generate_subdoms(filenames, row_counts, validFiles);
 
@@ -403,7 +403,7 @@ module CSVMsg {
                     var entry = new shared SymEntry(a);
                     var rname = st.nextName();
                     st.addEntry(rname, entry);
-                    rtnData.pushBack((dset, "pdarray", rname));
+                    rtnData.pushBack((dset, ObjType.PDARRAY, rname));
                 }
                 when DType.UInt64 {
                     var a = makeDistArray(record_count, uint);
@@ -411,7 +411,7 @@ module CSVMsg {
                     var entry = new shared SymEntry(a);
                     var rname = st.nextName();
                     st.addEntry(rname, entry);
-                    rtnData.pushBack((dset, "pdarray", rname));
+                    rtnData.pushBack((dset, ObjType.PDARRAY, rname));
                 }
                 when DType.Float64 {
                     var a = makeDistArray(record_count, real);
@@ -419,7 +419,7 @@ module CSVMsg {
                     var entry = new shared SymEntry(a);
                     var rname = st.nextName();
                     st.addEntry(rname, entry);
-                    rtnData.pushBack((dset, "pdarray", rname));
+                    rtnData.pushBack((dset, ObjType.PDARRAY, rname));
                 }
                 when DType.Bool {
                     var a = makeDistArray(record_count, bool);
@@ -427,7 +427,7 @@ module CSVMsg {
                     var entry = new shared SymEntry(a);
                     var rname = st.nextName();
                     st.addEntry(rname, entry);
-                    rtnData.pushBack((dset, "pdarray", rname));
+                    rtnData.pushBack((dset, ObjType.PDARRAY, rname));
                 }
                 when DType.Strings {
                     var a = makeDistArray(record_count, string);
@@ -448,7 +448,7 @@ module CSVMsg {
                         data[low..#vbytes.size] = vbytes;
                     }
                     var ss = getSegString(str_offsets, data, st);
-                    var rst = (dset, "seg_string", "%s+%t".format(ss.name, ss.nBytes));
+                    var rst = (dset, ObjType.STRINGS, "%s+%t".format(ss.name, ss.nBytes));
                     rtnData.pushBack(rst);
                 }
                 otherwise {
@@ -465,9 +465,9 @@ module CSVMsg {
         return rtnData;
     }
 
-    proc readGenericCSV(filenames: [] string, datasets: [?D] string, row_counts: [] int, validFiles: [] bool, col_delim: string, st: borrowed SymTab): list((string, string, string)) throws {
+    proc readGenericCSV(filenames: [] string, datasets: [?D] string, row_counts: [] int, validFiles: [] bool, col_delim: string, st: borrowed SymTab): list((string, ObjType, string)) throws {
         // assumes the file does not have a header since we were not able to access type info
-        var rtnData: list((string, string, string));
+        var rtnData: list((string, ObjType, string));
         var record_count = + reduce row_counts;
         var (subdoms, offsets, skips) = generate_subdoms(filenames, row_counts, validFiles);
 
@@ -490,7 +490,7 @@ module CSVMsg {
                 data[low..#vbytes.size] = vbytes;
             }
             var ss = getSegString(str_offsets, data, st);
-            var rst = (dset, "seg_string", "%s+%t".format(ss.name, ss.nBytes));
+            var rst = (dset, ObjType.STRINGS, "%s+%t".format(ss.name, ss.nBytes));
             rtnData.pushBack(rst);
         }
         return rtnData;
@@ -560,7 +560,7 @@ module CSVMsg {
         var row_cts: [filedom] int;
         var data_types: list(list(string));
         var headers: [filedom] bool;
-        var rtnData: list((string, string, string));
+        var rtnData: list((string, ObjType, string));
         var fileErrors: list(string);
         var fileErrorCount:int = 0;
         var fileErrorMsg:string = "";

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -192,30 +192,35 @@ module GenSymIO {
         }
     }
 
-    proc _buildReadAllMsgJson(rnames:list(3*string), allowErrors:bool, fileErrorCount:int, fileErrors:list(string), st: borrowed SymTab): string throws {
+    proc _buildReadAllMsgJson(rnames:list((string, ObjType, string)), allowErrors:bool, fileErrorCount:int, fileErrors:list(string), st: borrowed SymTab): string throws {
         var items: list(map(string, string));
 
         for rname in rnames {
             var (dsetName, akType, id) = rname;
             var item: map(string, string) = new map(string, string);
             item.add("dataset_name", dsetName.replace(Q, ESCAPED_QUOTES, -1));
-            item.add("arkouda_type", akType);
+            item.add("arkouda_type", akType: string);
             var create_str: string;
-            if (akType == "ArrayView") {
+            // if (akType == "ArrayView") {
+            if akType == ObjType.ARRAYVIEW {
                 var (valName, segName) = id.splitMsgToTuple("+", 2);
                 create_str = "created " + st.attrib(valName) + "+created " + st.attrib(segName);
             }
-            else if (akType == "pdarray") {
+            // else if (akType == "pdarray") {
+            else if akType == ObjType.PDARRAY {
                 create_str = "created " + st.attrib(id);
             }
-            else if (akType == "seg_string") {
+            // else if (akType == "seg_string") {
+            else if akType == ObjType.STRINGS {
                 var (segName, nBytes) = id.splitMsgToTuple("+", 2);
                 create_str = "created " + st.attrib(segName) + "+created bytes.size " + nBytes;
             }
-            else if (akType == "seg_array" || akType == "categorical") {
+            // else if (akType == "seg_array" || akType == "categorical") {
+            else if (akType == ObjType.SEGARRAY || akType == ObjType.CATEGORICAL) {
                 create_str = id;
             } 
-            else if (akType == "groupby") {
+            // else if (akType == "groupby") {
+            else if akType == ObjType.GROUPBY {
                 create_str = id;
             }
             else {

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -201,25 +201,20 @@ module GenSymIO {
             item.add("dataset_name", dsetName.replace(Q, ESCAPED_QUOTES, -1));
             item.add("arkouda_type", akType: string);
             var create_str: string;
-            // if (akType == "ArrayView") {
             if akType == ObjType.ARRAYVIEW {
                 var (valName, segName) = id.splitMsgToTuple("+", 2);
                 create_str = "created " + st.attrib(valName) + "+created " + st.attrib(segName);
             }
-            // else if (akType == "pdarray") {
             else if akType == ObjType.PDARRAY {
                 create_str = "created " + st.attrib(id);
             }
-            // else if (akType == "seg_string") {
             else if akType == ObjType.STRINGS {
                 var (segName, nBytes) = id.splitMsgToTuple("+", 2);
                 create_str = "created " + st.attrib(segName) + "+created bytes.size " + nBytes;
             }
-            // else if (akType == "seg_array" || akType == "categorical") {
             else if (akType == ObjType.SEGARRAY || akType == ObjType.CATEGORICAL) {
                 create_str = id;
-            } 
-            // else if (akType == "groupby") {
+            }
             else if akType == ObjType.GROUPBY {
                 create_str = id;
             }

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -762,7 +762,7 @@ module ParquetMsg {
     var types: [dsetdom] ArrowTypes;
     var byteSizes: [filedom] int;
 
-    var rnames: list((string, string, string)); // tuple (dsetName, item type, id)
+    var rnames: list((string, ObjType, string)); // tuple (dsetName, item type, id)
     
     for (dsetidx, dsetname) in zip(dsetdom, dsetnames) do {
         types[dsetidx] = getArrType(filenames[0], dsetname);
@@ -798,7 +798,7 @@ module ParquetMsg {
           populateTagData(tagEntry.a, filenames, sizes);
           var rname = st.nextName();
           st.addEntry(rname, tagEntry);
-          rnames.pushBack(("Filename_Codes", "pdarray", rname));
+          rnames.pushBack(("Filename_Codes", ObjType.PDARRAY, rname));
           tagData = false; // turn off so we only run once
         }
 
@@ -809,7 +809,7 @@ module ParquetMsg {
           readFilesByName(entryVal.a, filenames, sizes, dsetname, ty);
           var valName = st.nextName();
           st.addEntry(valName, entryVal);
-          rnames.pushBack((dsetname, "pdarray", valName));
+          rnames.pushBack((dsetname, ObjType.PDARRAY, valName));
         } else if ty == ArrowTypes.uint64 || ty == ArrowTypes.uint32 {
           var entryVal = new shared SymEntry(len, uint);
           readFilesByName(entryVal.a, filenames, sizes, dsetname, ty);
@@ -821,13 +821,13 @@ module ParquetMsg {
           }
           var valName = st.nextName();
           st.addEntry(valName, entryVal);
-          rnames.pushBack((dsetname, "pdarray", valName));
+          rnames.pushBack((dsetname, ObjType.PDARRAY, valName));
         } else if ty == ArrowTypes.boolean {
           var entryVal = new shared SymEntry(len, bool);
           readFilesByName(entryVal.a, filenames, sizes, dsetname, ty);
           var valName = st.nextName();
           st.addEntry(valName, entryVal);
-          rnames.pushBack((dsetname, "pdarray", valName));
+          rnames.pushBack((dsetname, ObjType.PDARRAY, valName));
         } else if ty == ArrowTypes.stringArr {
           var entrySeg = new shared SymEntry(len, int);
           byteSizes = calcStrSizesAndOffset(entrySeg.a, filenames, sizes, dsetname);
@@ -837,13 +837,13 @@ module ParquetMsg {
           readStrFilesByName(entryVal.a, filenames, byteSizes, dsetname, ty);
           
           var stringsEntry = assembleSegStringFromParts(entrySeg, entryVal, st);
-          rnames.pushBack((dsetname, "seg_string", "%s+%t".format(stringsEntry.name, stringsEntry.nBytes)));
+          rnames.pushBack((dsetname, ObjType.STRINGS, "%s+%t".format(stringsEntry.name, stringsEntry.nBytes)));
         } else if ty == ArrowTypes.double || ty == ArrowTypes.float {
           var entryVal = new shared SymEntry(len, real);
           readFilesByName(entryVal.a, filenames, sizes, dsetname, ty);
           var valName = st.nextName();
           st.addEntry(valName, entryVal);
-          rnames.pushBack((dsetname, "pdarray", valName));
+          rnames.pushBack((dsetname, ObjType.PDARRAY, valName));
         } else if ty == ArrowTypes.list {
           var list_ty = getListData(filenames[0], dsetname);
           if list_ty == ArrowTypes.notimplemented { // check for and skip further nested datasets
@@ -851,7 +851,7 @@ module ParquetMsg {
           }
           else {
             var create_str: string = parseListDataset(filenames, dsetname, list_ty, len, sizes, st);
-            rnames.pushBack((dsetname, "seg_array", create_str));
+            rnames.pushBack((dsetname, ObjType.SEGARRAY, create_str));
           }
         } else {
           var errorMsg = "DType %s not supported for Parquet reading".format(ty);
@@ -1727,7 +1727,7 @@ module ParquetMsg {
     var types: [dsetdom] ArrowTypes;
     var byteSizes: [filedom] int;
 
-    var rnames: list((string, string, string)); // tuple (dsetName, item type, id)
+    var rnames: list((string, ObjType, string)); // tuple (dsetName, item type, id)
     
     for (dsetidx, dsetname) in zip(dsetdom, dsetnames) do {
         for (i, fname) in zip(filedom, filenames) {
@@ -1760,7 +1760,7 @@ module ParquetMsg {
           getNullIndices(entryVal.a, filenames, sizes, dsetname, ty);
           var valName = st.nextName();
           st.addEntry(valName, entryVal);
-          rnames.pushBack((dsetname, "pdarray", valName));
+          rnames.pushBack((dsetname, ObjType.PDARRAY, valName));
         } else {
           var errorMsg = "Null indices only supported on Parquet string columns, not {} columns".format(ty);
           pqLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);


### PR DESCRIPTION
Closes #2436 

This PR updates the `_buildReadAllJSON()` function in `GenSymIO.chpl` to use the `ObjType` enum for consistency across the server and the client. Because the server enum is all upper case, the checks on the client call `.upper`. 