### PR TITLE
Closes #2488: Quiet deprecation warnings in prep for Chapel 1.31

### DIFF
--- a/dep/checkIdn2.chpl
+++ b/dep/checkIdn2.chpl
@@ -2,6 +2,6 @@ use idna, CTypes;
 
 proc main() {
   extern proc idn2_check_version(a): c_string;
-  var idnaCVerStr = idn2_check_version(c_nil);
+  var idnaCVerStr = idn2_check_version(nil);
   writeln("Found idn2 version: ", idnaCVerStr:string);
 }

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -398,7 +398,7 @@ module AryUtil
         /* Do we own the memory? */
         var isOwned: bool = false;
 
-        proc init(A: [] ?t, region: range(stridable=false)) {
+        proc init(A: [] ?t, region: range()) {
             use CommPrimitives;
             use CTypes;
 

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -1,6 +1,5 @@
 module AryUtil
 {
-    use CTypes;
     use Random;
     use Reflection;
     use Logging;
@@ -12,6 +11,7 @@ module AryUtil
     use GenSymIO;
 
     use ArkoudaPOSIXCompat;
+    use ArkoudaCTypesCompat;
 
     param bitsPerDigit = RSLSD_bitsPerDigit;
     private param numBuckets = 1 << bitsPerDigit; // these need to be const for comms/performance reasons
@@ -422,7 +422,7 @@ module AryUtil
                 } else {
                     // If data is contiguous on a single remote node,
                     // alloc+bulk GET and return owned c_ptr
-                    this.ptr = c_malloc(t, region.size);
+                    this.ptr = allocate(t, region.size);
                     this.isOwned = true;
                     const byteSize = region.size:c_size_t * c_sizeof(t);
                     GET(ptr, startLocale, getAddr(start), byteSize);
@@ -430,7 +430,7 @@ module AryUtil
             } else {
                 // If data is non-contiguous or split across nodes, get element
                 // at a time and return owned c_ptr (slow, expected to be rare)
-                this.ptr = c_malloc(t, region.size);
+                this.ptr = allocate(t, region.size);
                 this.isOwned = true;
                 for i in 0..<region.size {
                     this.ptr[i] = A[region.low + i];
@@ -440,7 +440,7 @@ module AryUtil
 
         proc deinit() {
             if isOwned {
-                c_free(ptr);
+                deallocate(ptr);
             }
         }
     }

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -394,7 +394,7 @@ module AryUtil
     record lowLevelLocalizingSlice {
         type t;
         /* Pointer to localized memory */
-        var ptr: c_ptr(t) = c_nil;
+        var ptr: c_ptr(t) = nil;
         /* Do we own the memory? */
         var isOwned: bool = false;
 
@@ -404,7 +404,7 @@ module AryUtil
 
             this.t = t;
             if region.isEmpty() {
-                this.ptr = c_nil;
+                this.ptr = nil;
                 this.isOwned = false;
                 return;
             }

--- a/src/Codecs.chpl
+++ b/src/Codecs.chpl
@@ -75,7 +75,7 @@ module Codecs {
         return tmp.size+1;
       } else if fromEncoding == "IDNA" {
         // Check valid round trip characters
-        var validChars = idn2_lookup_u8(obj, c_nil, 0);
+        var validChars = idn2_lookup_u8(obj, nil, 0);
         if validChars != 0 {
           return 1;
         }

--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -299,7 +299,7 @@ module CommAggregation {
     // Allocate a buffer on loc if we haven't already. Return a c_ptr to the
     // remote locales buffer
     proc cachedAlloc(): c_ptr(elemType) {
-      if data == c_nil {
+      if data == nil {
         const rvf_size = size;
         on Locales[loc] do {
           data = allocate(elemType, rvf_size);
@@ -314,7 +314,7 @@ module CommAggregation {
       if boundsChecking {
         assert(this.loc == here.id);
         assert(this.data == data);
-        assert(data != c_nil);
+        assert(data != nil);
       }
       for i in 0..<size {
         yield data[i];
@@ -329,7 +329,7 @@ module CommAggregation {
       if boundsChecking {
         assert(this.loc == here.id);
         assert(this.data == data);
-        assert(data != c_nil);
+        assert(data != nil);
       }
       deallocate(data);
     }
@@ -340,7 +340,7 @@ module CommAggregation {
       if boundsChecking {
         assert(this.locale.id == here.id);
       }
-      data = c_nil;
+      data = nil;
     }
 
     // Copy size elements from lArr to the remote buffer. Must be running on
@@ -376,7 +376,7 @@ module CommAggregation {
     }
 
     proc deinit() {
-      if data != c_nil {
+      if data != nil {
         const rvf_data=data;
         on Locales[loc] {
           localFree(rvf_data);

--- a/src/FileIO.chpl
+++ b/src/FileIO.chpl
@@ -13,6 +13,7 @@ module FileIO {
 
     use ArkoudaFileCompat;
     use ArkoudaMapCompat;
+    use ArkoudaRangeCompat;
 
     use ServerConfig, Logging, CommandMap;
     private config const logLevel = ServerConfig.logLevel;
@@ -220,7 +221,7 @@ module FileIO {
             //TODO: change this to throw
             halt("At least one domain must have stride 1");
         }
-        if !d1.stridable && !d2.stridable {
+        if !stridable(d1) && !stridable(d2) {
             return {low..high};
         } else {
             var stride = max(d1.stride, d2.stride);

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -1,6 +1,5 @@
 module GenSymIO {
     use IO;
-    use CTypes;
     use Path;
     use MultiTypeSymbolTable;
     use MultiTypeSymEntry;
@@ -21,6 +20,7 @@ module GenSymIO {
     use ArkoudaMapCompat;
     use ArkoudaListCompat;
     use ArkoudaStringBytesCompat;
+    use ArkoudaCTypesCompat;
 
 
     private config const logLevel = ServerConfig.logLevel;
@@ -147,7 +147,7 @@ module GenSymIO {
         overMemLimit(2 * entry.getSizeEstimate());
 
         proc distArrToBytes(A: [?D] ?eltType) {
-            var ptr = c_malloc(eltType, D.size);
+            var ptr = allocate(eltType, D.size);
             var localA = makeArrayFromPtr(ptr, D.size:uint);
             localA = A;
             const size = D.size*c_sizeof(eltType):int;

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -1,5 +1,4 @@
 module HDF5Msg {
-    use CTypes;
     use FileSystem;
     use HDF5;
     use IO;
@@ -31,6 +30,7 @@ module HDF5Msg {
     use ArkoudaMapCompat;
     use ArkoudaListCompat;
     use ArkoudaStringBytesCompat;
+    use ArkoudaCTypesCompat;
 
 
     private config const logLevel = ServerConfig.logLevel;
@@ -373,7 +373,7 @@ module HDF5Msg {
                             C_HDF5.H5P_DEFAULT);
 
         // For the value, we need to build a ptr to a char[]; c_string doesn't work because it is a const char*        
-        var akVersion = c_calloc(c_char, arkoudaVersion.size+1);
+        var akVersion = allocate(c_char, arkoudaVersion.size+1, clear=true);
         for (c, i) in zip(arkoudaVersion.codepoints(), 0..<arkoudaVersion.size) {
             akVersion[i] = c:c_char;
         }
@@ -383,7 +383,7 @@ module HDF5Msg {
         C_HDF5.H5Aclose(attrId);
 
         // release ArkoudaVersion HDF5 resources
-        c_free(akVersion);
+        deallocate(akVersion);
         C_HDF5.H5Sclose(attrSpaceId);
         C_HDF5.H5Tclose(attrStringType);
         C_HDF5.H5Oclose(obj_id);
@@ -458,7 +458,7 @@ module HDF5Msg {
                             C_HDF5.H5P_DEFAULT);
 
         // For the value, we need to build a ptr to a char[]; c_string doesn't work because it is a const char*        
-        var akVersion = c_calloc(c_char, arkoudaVersion.size+1);
+        var akVersion = allocate(c_char, arkoudaVersion.size+1, clear=true);
         for (c, i) in zip(arkoudaVersion.codepoints(), 0..<arkoudaVersion.size) {
             akVersion[i] = c:c_char;
         }
@@ -468,7 +468,7 @@ module HDF5Msg {
         C_HDF5.H5Aclose(attrId);
 
         // release ArkoudaVersion HDF5 resources
-        c_free(akVersion);
+        deallocate(akVersion);
         C_HDF5.H5Sclose(attrSpaceId);
         C_HDF5.H5Tclose(attrStringType);
         C_HDF5.H5Oclose(obj_id);
@@ -2019,12 +2019,12 @@ module HDF5Msg {
         C_HDF5.H5Literate(fid, C_HDF5.H5_INDEX_NAME, C_HDF5.H5_ITER_NATIVE, idx_p, c_ptrTo(_get_item_count), c_ptrTo(nfields));
         
         // Allocate space for array of strings
-        var c_field_names = c_calloc(c_char, 255 * nfields);
+        var c_field_names = allocate(c_char, 255 * nfields, clear=true);
         idx_p = 0:C_HDF5.hsize_t; // reset our iteration counter
         C_HDF5.H5Literate(fid, C_HDF5.H5_INDEX_NAME, C_HDF5.H5_ITER_NATIVE, idx_p, c_ptrTo(_simulate_h5ls), c_field_names);
         var pos = c_strlen(c_field_names):int;
         var items = string.createCopyingBuffer(c_field_names, pos, pos+1);
-        c_free(c_field_names);
+        deallocate(c_field_names);
         return items;
     }
 
@@ -2440,7 +2440,7 @@ module HDF5Msg {
             (subdoms, len, skips) = get_subdoms(filenames, "%s/Limb_%i".format(dset, l), validFiles);
             var limb = new shared SymEntry(len, uint);
             read_files_into_distributed_array(limb.a, subdoms, filenames, "%s/Limb_%i".format(dset, l), skips);
-            limbs.append(limb);
+            limbs.pushBack(limb);
         }
 
         var bigIntArray = makeDistArray(limbs[0].size, bigint);

--- a/src/Indexing.chpl
+++ b/src/Indexing.chpl
@@ -12,10 +12,11 @@ module Indexing {
     use MultiTypeSymbolTable;
 
     use CommAggregation;
+    use ArkoudaRangeCompat;
     
     // Return a slice of array `a` from `start` to `stop` by `stride`
     proc sliceIndex(a: [?aD] ?t, start: int, stop: int, stride: int) {
-      var slice: range(stridable=true);
+      var slice: stridableRange;
       
       slice = start..(stop-1) by stride;
 

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -20,6 +20,7 @@ module IndexingMsg
     use ArkoudaMapCompat;
     use ArkoudaFileCompat;
     use ArkoudaBigIntCompat;
+    use ArkoudaRangeCompat;
 
     private config const logLevel = ServerConfig.logLevel;
     private config const logChannel = ServerConfig.logChannel;
@@ -67,7 +68,7 @@ module IndexingMsg
                 }
                 when "slice" {
                     var (start, stop, stride) = jsonToTuple(typeCoords[i+1], 3*int);
-                    var slice: range(stridable=true) = convertSlice(start, stop, stride);
+                    var slice: stridableRange = convertSlice(start, stop, stride);
                     var scaled: [0..#slice.size] int = slice * dimProdEntry.a[i/2];
                     for j in 0..#slice.size {
                         scaledCoords[offsets[i/2]+j] = scaled[j];
@@ -267,8 +268,8 @@ module IndexingMsg
     }
 
     /* convert python slice to chapel slice */
-    proc convertSlice(start: int, stop: int, stride: int): range(stridable=true) {
-        var slice: range(stridable=true);
+    proc convertSlice(start: int, stop: int, stride: int): stridableRange {
+        var slice: stridableRange;
         // backwards iteration with negative stride
         if  (start > stop) & (stride < 0) {slice = (stop+1)..start by stride;}
         // forward iteration with positive stride
@@ -285,7 +286,7 @@ module IndexingMsg
         const start = msgArgs.get("start").getIntValue();
         const stop = msgArgs.get("stop").getIntValue();
         const stride = msgArgs.get("stride").getIntValue();
-        var slice: range(stridable=true) = convertSlice(start, stop, stride);
+        var slice: stridableRange = convertSlice(start, stop, stride);
 
         // get next symbol name
         var rname = st.nextName();
@@ -1061,7 +1062,7 @@ module IndexingMsg
         const stop = msgArgs.get("stop").getIntValue();
         const stride = msgArgs.get("stride").getIntValue();
         const dtype = str2dtype(msgArgs.getValueOf("dtype"));
-        var slice: range(stridable=true) = convertSlice(start, stop, stride);
+        var slice: stridableRange = convertSlice(start, stop, stride);
         var value = msgArgs.get("value");
 
         imLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
@@ -1206,7 +1207,7 @@ module IndexingMsg
         const start = msgArgs.get("start").getIntValue();
         const stop = msgArgs.get("stop").getIntValue();
         const stride = msgArgs.get("stride").getIntValue();
-        var slice: range(stridable=true);
+        var slice: stridableRange;
 
         const name = msgArgs.getValueOf("array");
         const yname = msgArgs.getValueOf("value");

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -63,7 +63,7 @@ module ParquetMsg {
   record parquetErrorMsg {
     var errMsg: c_ptr(uint(8));
     proc init() {
-      errMsg = c_nil;
+      errMsg = nil;
     }
     
     proc deinit() {

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -1,5 +1,4 @@
 module SegmentedMsg {
-  use CTypes;
   use Reflection;
   use ServerErrors;
   use Logging;
@@ -18,6 +17,7 @@ module SegmentedMsg {
 
   use ArkoudaMapCompat;
   use ArkoudaStringBytesCompat;
+  use ArkoudaCTypesCompat;
 
   private config const logLevel = ServerConfig.logLevel;
   private config const logChannel = ServerConfig.logChannel;
@@ -74,7 +74,7 @@ module SegmentedMsg {
         var arrayBytes: bytes;
 
         proc distArrToBytes(A: [?D] ?eltType) {
-            var ptr = c_malloc(eltType, D.size);
+            var ptr = allocate(eltType, D.size);
             var localA = makeArrayFromPtr(ptr, D.size:uint);
             localA = A;
             const size = D.size*c_sizeof(eltType):int;

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -791,7 +791,7 @@ module SegmentedMsg {
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
-  proc convertPythonSliceToChapel(start:int, stop:int): range(stridable=false) {
+  proc convertPythonSliceToChapel(start:int, stop:int): range() {
     if (start <= stop) {
       return start..(stop-1);
     } else {

--- a/src/SegmentedString.chpl
+++ b/src/SegmentedString.chpl
@@ -166,7 +166,7 @@ module SegmentedString {
     /* Take a slice of strings from the array. The slice must be a 
        Chapel range, i.e. low..high by stride, not a Python slice.
        Returns arrays for the segment offsets and bytes of the slice.*/
-    proc this(const slice: range(stridable=false)) throws {
+    proc this(const slice: range()) throws {
       if (slice.low < offsets.a.domain.low) || (slice.high > offsets.a.domain.high) {
           ssLogger.error(getModuleName(),getRoutineName(),getLineNumber(),
           "Array is out of bounds");

--- a/src/compat/e-129/ArkoudaCTypesCompat.chpl
+++ b/src/compat/e-129/ArkoudaCTypesCompat.chpl
@@ -1,0 +1,61 @@
+module ArkoudaCTypesCompat {
+  public use CTypes;
+
+  private proc offset_ARRAY_ELEMENTS {
+    extern const CHPL_RT_MD_ARRAY_ELEMENTS:chpl_mem_descInt_t;
+    pragma "fn synchronization free"
+    extern proc chpl_memhook_md_num(): chpl_mem_descInt_t;
+    return CHPL_RT_MD_ARRAY_ELEMENTS - chpl_memhook_md_num();
+  }
+  
+  inline proc allocate(type eltType, size: c_size_t, clear: bool = false,
+                       alignment: c_size_t = 0) : c_ptr(eltType) {
+    const alloc_size = size * c_sizeof(eltType);
+    const aligned : bool = (alignment != 0);
+    var ptr : c_void_ptr = nil;
+
+    // pick runtime allocation function based on requested zeroing + alignment
+    if (!aligned) {
+      if (clear) {
+        // normal calloc
+        ptr = chpl_here_calloc(alloc_size, 1, offset_ARRAY_ELEMENTS);
+      } else {
+        // normal malloc
+        ptr = chpl_here_alloc(alloc_size, offset_ARRAY_ELEMENTS);
+      }
+    } else {
+      // check alignment, size restriction
+      // Alignment of 0 is our sentinel value for no specified alignment,
+      // so no need to check for it.
+      if boundsChecking {
+        use Math;
+        var one:c_size_t = 1;
+        // Round the alignment up to the nearest power of 2
+        var p = log2(alignment); // power of 2 rounded down
+        // compute alignment rounded up
+        if (one << p) < alignment then
+          p += 1;
+        assert(alignment <= (one << p));
+        if alignment != (one << p) then
+          halt("allocate called with non-power-of-2 alignment ", alignment);
+        if alignment < c_sizeof(c_void_ptr) then
+          halt("allocate called with alignment smaller than pointer size");
+      }
+
+      // normal aligned alloc, whether we clear after or not
+      ptr = chpl_here_aligned_alloc(alignment, alloc_size,
+                                    offset_ARRAY_ELEMENTS);
+
+      if (clear) {
+        // there is no aligned calloc; have to aligned_alloc + memset to 0
+        c_memset(ptr, 0, alloc_size);
+      }
+    }
+
+    return ptr : c_ptr(eltType);
+  }
+
+  inline proc deallocate(data: c_void_ptr) {
+    chpl_here_free(data);
+  }
+}

--- a/src/compat/e-129/ArkoudaRangeCompat.chpl
+++ b/src/compat/e-129/ArkoudaRangeCompat.chpl
@@ -1,0 +1,6 @@
+module ArkoudaRangeCompat {
+  type stridableRange = range(stridable=true);
+  proc stridable(a) param {
+    return a.stridable;
+  }
+}

--- a/src/compat/e-130/ArkoudaCTypesCompat.chpl
+++ b/src/compat/e-130/ArkoudaCTypesCompat.chpl
@@ -1,0 +1,61 @@
+module ArkoudaCTypesCompat {
+  public use CTypes;
+
+  private proc offset_ARRAY_ELEMENTS {
+    extern const CHPL_RT_MD_ARRAY_ELEMENTS:chpl_mem_descInt_t;
+    pragma "fn synchronization free"
+    extern proc chpl_memhook_md_num(): chpl_mem_descInt_t;
+    return CHPL_RT_MD_ARRAY_ELEMENTS - chpl_memhook_md_num();
+  }
+  
+  inline proc allocate(type eltType, size: c_size_t, clear: bool = false,
+                       alignment: c_size_t = 0) : c_ptr(eltType) {
+    const alloc_size = size * c_sizeof(eltType);
+    const aligned : bool = (alignment != 0);
+    var ptr : c_void_ptr = nil;
+
+    // pick runtime allocation function based on requested zeroing + alignment
+    if (!aligned) {
+      if (clear) {
+        // normal calloc
+        ptr = chpl_here_calloc(alloc_size, 1, offset_ARRAY_ELEMENTS);
+      } else {
+        // normal malloc
+        ptr = chpl_here_alloc(alloc_size, offset_ARRAY_ELEMENTS);
+      }
+    } else {
+      // check alignment, size restriction
+      // Alignment of 0 is our sentinel value for no specified alignment,
+      // so no need to check for it.
+      if boundsChecking {
+        use Math;
+        var one:c_size_t = 1;
+        // Round the alignment up to the nearest power of 2
+        var p = log2(alignment); // power of 2 rounded down
+        // compute alignment rounded up
+        if (one << p) < alignment then
+          p += 1;
+        assert(alignment <= (one << p));
+        if alignment != (one << p) then
+          halt("allocate called with non-power-of-2 alignment ", alignment);
+        if alignment < c_sizeof(c_void_ptr) then
+          halt("allocate called with alignment smaller than pointer size");
+      }
+
+      // normal aligned alloc, whether we clear after or not
+      ptr = chpl_here_aligned_alloc(alignment, alloc_size,
+                                    offset_ARRAY_ELEMENTS);
+
+      if (clear) {
+        // there is no aligned calloc; have to aligned_alloc + memset to 0
+        c_memset(ptr, 0, alloc_size);
+      }
+    }
+
+    return ptr : c_ptr(eltType);
+  }
+
+  inline proc deallocate(data: c_void_ptr) {
+    chpl_here_free(data);
+  }
+}

--- a/src/compat/e-130/ArkoudaRangeCompat.chpl
+++ b/src/compat/e-130/ArkoudaRangeCompat.chpl
@@ -1,0 +1,6 @@
+module ArkoudaRangeCompat {
+  type stridableRange = range(stridable=true);
+  proc stridable(a) param {
+    return a.stridable;
+  }
+}

--- a/src/compat/gt-130/ArkoudaCTypesCompat.chpl
+++ b/src/compat/gt-130/ArkoudaCTypesCompat.chpl
@@ -1,0 +1,3 @@
+module ArkoudaCTypesCompat {
+  public use CTypes;
+}

--- a/src/compat/gt-130/ArkoudaRangeCompat.chpl
+++ b/src/compat/gt-130/ArkoudaRangeCompat.chpl
@@ -1,0 +1,6 @@
+module ArkoudaRangeCompat {
+  type stridableRange = range(strides=strideKind.any);
+  proc stridable(a) param {
+    return !(a.strides==strideKind.one);
+  }
+}


### PR DESCRIPTION
The last remaining symbols deprecated in Chapel 1.31 that need to have compatibility modules added for are:
- `c_malloc` deprecated in favor of `allocate`
- `c_free` deprecated in favor of `deallocate`
- `c_aligned_alloc` deprecated in favor of `allocate` with `alignment` argument
- `c_calloc` deprecated in favor of `allocate` with `clear` argument
- `c_nil` deprecated in favor of `nil`
- `stridable` deprecated in favor of `strides`

Closes: #2488 