### PR TITLE
Closes #2490: Change `checkInstall` path to be relative to script, not Arkouda

### DIFF
--- a/server_util/test/checkInstall
+++ b/server_util/test/checkInstall
@@ -8,7 +8,7 @@ import logging
 import sys
 import os
 
-from server_util.test.server_test_util import *
+from server_test_util import *
 
 logging.basicConfig(level=logging.INFO)
 


### PR DESCRIPTION
The `checkInstall` script lives in `server_util/test/` was importing the module based on the Arkouda repo path, rather than the relative path of that script. This could cause some imports to fail on newer versions of Python.

Closes: #2490 