### PR TITLE
Closes #2444 - SegArray with String Values Parquet Support

### DIFF
--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -1079,7 +1079,6 @@ class SegArray:
                     "mode": _mode_str_to_int(mode),
                     "prefix": prefix_path,
                     "objType": self.objType,
-                    "dtype": self.dtype,
                     "compression": compression,
                 },
             ),

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -1079,7 +1079,7 @@ class SegArray:
                     "mode": _mode_str_to_int(mode),
                     "prefix": prefix_path,
                     "objType": self.objType,
-                    "dtype": self.values.dtype,
+                    "dtype": self.dtype,
                     "compression": compression,
                 },
             ),

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -1065,10 +1065,6 @@ class SegArray:
         """
         from arkouda.io import _mode_str_to_int
 
-        if self.dtype == str_:
-            # Support will be added by Issue #2444
-            raise TypeError("SegArrays with Strings values are not yet supported by Parquet")
-
         if mode.lower() == "append":
             raise ValueError("Append mode is not supported for SegArray.")
 
@@ -1083,7 +1079,7 @@ class SegArray:
                     "mode": _mode_str_to_int(mode),
                     "prefix": prefix_path,
                     "objType": self.objType,
-                    "dtype": self.dtype,
+                    "dtype": self.values.dtype,
                     "compression": compression,
                 },
             ),

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -1251,7 +1251,92 @@ int cpp_writeStrColumnToParquet(const char* filename, void* chpl_arr, void* chpl
   }
 }
 
-int cpp_writeListColumnToParquet(const char* filename, void* chpl_arr, void* chpl_offsets,
+int cpp_writeStrListColumnToParquet(const char* filename, void* chpl_segs, void* chpl_offsets, void* chpl_arr,
+                                const char* dsetname, int64_t numelems,
+                                int64_t rowGroupSize, int64_t dtype, int64_t compression,
+                                char** errMsg) {
+  try {
+    if(dtype == ARROWSTRING) { // check the type here so if it is wrong we don't create a bad file
+      using FileClass = ::arrow::io::FileOutputStream;
+      std::shared_ptr<FileClass> out_file;
+      PARQUET_ASSIGN_OR_THROW(out_file, FileClass::Open(filename));
+
+      parquet::schema::NodeVector fields;
+
+      auto element = parquet::schema::PrimitiveNode::Make("item", parquet::Repetition::OPTIONAL, parquet::Type::BYTE_ARRAY, parquet::ConvertedType::NONE);
+      auto list = parquet::schema::GroupNode::Make("list", parquet::Repetition::REPEATED, {element});
+      fields.push_back(parquet::schema::GroupNode::Make(dsetname, parquet::Repetition::OPTIONAL, {list}, parquet::ConvertedType::LIST));
+      std::shared_ptr<parquet::schema::GroupNode> schema = std::static_pointer_cast<parquet::schema::GroupNode>
+          (parquet::schema::GroupNode::Make("schema", parquet::Repetition::REQUIRED, fields));
+
+      parquet::WriterProperties::Builder builder;
+      // assign the proper compression
+      if(compression == SNAPPY_COMP) {
+        builder.compression(parquet::Compression::SNAPPY);
+        builder.encoding(parquet::Encoding::RLE);
+      } else if (compression == GZIP_COMP) {
+        builder.compression(parquet::Compression::GZIP);
+        builder.encoding(parquet::Encoding::RLE);
+      } else if (compression == BROTLI_COMP) {
+        builder.compression(parquet::Compression::BROTLI);
+        builder.encoding(parquet::Encoding::RLE);
+      } else if (compression == ZSTD_COMP) {
+        builder.compression(parquet::Compression::ZSTD);
+        builder.encoding(parquet::Encoding::RLE);
+      } else if (compression == LZ4_COMP) {
+        builder.compression(parquet::Compression::LZ4);
+        builder.encoding(parquet::Encoding::RLE);
+      }
+      std::shared_ptr<parquet::WriterProperties> props = builder.build();
+
+      std::shared_ptr<parquet::ParquetFileWriter> file_writer =
+        parquet::ParquetFileWriter::Open(out_file, schema, props);
+
+      int64_t i = 0;
+      int64_t numLeft = numelems;
+      auto segments = (int64_t*)chpl_segs;
+      auto offsets = (int64_t*)chpl_offsets;
+      auto chpl_ptr = (uint8_t*)chpl_arr;
+      int64_t segIdx = 0; // index into segarray segments
+      int64_t offIdx = 0; // index into the segstring segments
+      int64_t valIdx = 0; // index into chpl_arr
+
+      while(numLeft > 0) { // write all local values to the file
+        parquet::RowGroupWriter* rg_writer = file_writer->AppendRowGroup();
+        parquet::ByteArrayWriter* ba_writer =
+          static_cast<parquet::ByteArrayWriter*>(rg_writer->NextColumn());
+        int64_t count = 0;
+        while (numLeft > 0 && count < rowGroupSize) { // ensures rowGroupSize maintained
+          int64_t segmentLength = segments[segIdx+1] - segments[segIdx];
+          for (int64_t x = 0; x < segmentLength; x++){
+            int16_t rep_lvl = (x == 0) ? 0 : 1;
+            int16_t def_lvl = 3;
+            parquet::ByteArray value;
+            value.ptr = reinterpret_cast<const uint8_t*>(&chpl_ptr[valIdx]);
+            value.len = offsets[offIdx+1] - offsets[offIdx] - 1;
+            ba_writer->WriteBatch(1, &def_lvl, &rep_lvl, &value);
+            offIdx++;
+            valIdx+=offsets[offIdx] - offsets[offIdx-1];
+          }
+          segIdx++;
+          numLeft--;count++;
+        }
+      }
+
+      file_writer->Close();
+        ARROWSTATUS_OK(out_file->Close());
+
+      return 0;
+    } else {
+      return ARROWERROR;
+    }
+  } catch (const std::exception& e) {
+    *errMsg = strdup(e.what());
+    return ARROWERROR;
+  }
+}
+
+int cpp_writeListColumnToParquet(const char* filename, void* chpl_segs, void* chpl_arr,
                                 const char* dsetname, int64_t numelems,
                                 int64_t rowGroupSize, int64_t dtype, int64_t compression,
                                 char** errMsg) {
@@ -1311,9 +1396,9 @@ int cpp_writeListColumnToParquet(const char* filename, void* chpl_arr, void* chp
 
     int64_t i = 0;
     int64_t numLeft = numelems;
-    auto offsets = (int64_t*)chpl_offsets;
+    auto segments = (int64_t*)chpl_segs;
     int64_t valIdx = 0; // index into chpl_arr
-    int64_t offIdx = 0; // index into offsets
+    int64_t segIdx = 0; // index into offsets
 
     if(dtype == ARROWINT64 || dtype == ARROWUINT64) {
       auto chpl_ptr = (int64_t*)chpl_arr;
@@ -1322,9 +1407,9 @@ int cpp_writeListColumnToParquet(const char* filename, void* chpl_arr, void* chp
         parquet::RowGroupWriter* rg_writer = file_writer->AppendRowGroup();
         parquet::Int64Writer* writer =
           static_cast<parquet::Int64Writer*>(rg_writer->NextColumn());
-
-        while (numLeft > 0 && offIdx < rowGroupSize) { // ensures rowGroupSize maintained
-          int64_t batchSize = offsets[offIdx+1] - offsets[offIdx];
+        int64_t count = 0;
+        while (numLeft > 0 && count < rowGroupSize) { // ensures rowGroupSize maintained
+          int64_t batchSize = segments[segIdx+1] - segments[segIdx];
           if (batchSize > 0) {
             int16_t* def_lvl = new int16_t[batchSize] { 3 };
             int16_t* rep_lvl = new int16_t[batchSize] { 0 };
@@ -1344,7 +1429,8 @@ int cpp_writeListColumnToParquet(const char* filename, void* chpl_arr, void* chp
             int16_t* rep_lvl = new int16_t[batchSize] { 0 };
             writer->WriteBatch(batchSize, def_lvl, rep_lvl, nullptr);
           }
-          offIdx++;
+          count++;
+          segIdx++;
           numLeft--;
         }
       }
@@ -1356,9 +1442,9 @@ int cpp_writeListColumnToParquet(const char* filename, void* chpl_arr, void* chp
         parquet::RowGroupWriter* rg_writer = file_writer->AppendRowGroup();
         parquet::BoolWriter* writer =
           static_cast<parquet::BoolWriter*>(rg_writer->NextColumn());
-
-        while (numLeft > 0 && offIdx < rowGroupSize) {
-          int64_t batchSize = offsets[offIdx+1] - offsets[offIdx];
+        int64_t count = 0;
+        while (numLeft > 0 && count < rowGroupSize) {
+          int64_t batchSize = segments[segIdx+1] - segments[segIdx];
           if (batchSize > 0) {
             // if the value is first in the segment rep_lvl = 0, otherwise 1
             // all values defined at the item level (3)
@@ -1378,7 +1464,8 @@ int cpp_writeListColumnToParquet(const char* filename, void* chpl_arr, void* chp
             int16_t* rep_lvl = new int16_t[batchSize] { 0 };
             writer->WriteBatch(batchSize, def_lvl, rep_lvl, nullptr);
           }
-          offIdx++;
+          count++;
+          segIdx++;
           numLeft--;
         }
       }
@@ -1390,9 +1477,9 @@ int cpp_writeListColumnToParquet(const char* filename, void* chpl_arr, void* chp
         parquet::RowGroupWriter* rg_writer = file_writer->AppendRowGroup();
         parquet::DoubleWriter* writer =
           static_cast<parquet::DoubleWriter*>(rg_writer->NextColumn());
-
-        while (numLeft > 0 && offIdx < rowGroupSize) {
-          int64_t batchSize = offsets[offIdx+1] - offsets[offIdx];
+        int64_t count = 0;
+        while (numLeft > 0 && count < rowGroupSize) {
+          int64_t batchSize = segments[segIdx+1] - segments[segIdx];
           if (batchSize > 0) {
             // if the value is first in the segment rep_lvl = 0, otherwise 1
             // all values defined at the item level (3)
@@ -1412,7 +1499,8 @@ int cpp_writeListColumnToParquet(const char* filename, void* chpl_arr, void* chp
             int16_t* rep_lvl = new int16_t[batchSize] { 0 };
             writer->WriteBatch(batchSize, def_lvl, rep_lvl, nullptr);
           }
-          offIdx++;
+          count++;
+          segIdx++;
           numLeft--;
         }
       }
@@ -1747,11 +1835,19 @@ extern "C" {
                                        dsetname, numelems, rowGroupSize, dtype, compression, errMsg);
   }
 
-  int c_writeListColumnToParquet(const char* filename, void* chpl_arr, void* chpl_offsets,
+  int c_writeListColumnToParquet(const char* filename, void* chpl_segs, void* chpl_arr,
                                 const char* dsetname, int64_t numelems,
                                 int64_t rowGroupSize, int64_t dtype, int64_t compression,
                                 char** errMsg) {
-    return cpp_writeListColumnToParquet(filename, chpl_arr, chpl_offsets,
+    return cpp_writeListColumnToParquet(filename, chpl_segs, chpl_arr,
+                                       dsetname, numelems, rowGroupSize, dtype, compression, errMsg);
+  }
+
+  int c_writeStrListColumnToParquet(const char* filename, void* chpl_segs, void* chpl_offsets, void* chpl_arr,
+                                const char* dsetname, int64_t numelems,
+                                int64_t rowGroupSize, int64_t dtype, int64_t compression,
+                                char** errMsg) {
+    return cpp_writeStrListColumnToParquet(filename, chpl_segs, chpl_offsets, chpl_arr,
                                        dsetname, numelems, rowGroupSize, dtype, compression, errMsg);
   }
 

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -460,7 +460,6 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
             }
           }
         }
-        // TODO - add string case
       }
       return vct;
     }

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -206,10 +206,17 @@ int cpp_getListType(const char* filename, const char* colname, char** errMsg) {
 int64_t cpp_getStringColumnNumBytes(const char* filename, const char* colname, void* chpl_offsets, int64_t numElems, int64_t startIdx, char** errMsg) {
   try {
     int64_t ty = cpp_getType(filename, colname, errMsg);
+    int64_t dty; // used to store the type of data so we can handle lists
+    if (ty == ARROWLIST) { // get the type of the list so we can verify it is ARROWSTRING
+      dty = cpp_getListType(filename, colname, errMsg);
+    }
+    else {
+      dty = ty;
+    }
     auto offsets = (int64_t*)chpl_offsets;
     int64_t byteSize = 0;
 
-    if(ty == ARROWLIST || ty == ARROWSTRING) {
+    if(dty == ARROWSTRING) {
       std::unique_ptr<parquet::ParquetFileReader> parquet_reader =
         parquet::ParquetFileReader::OpenFile(filename, false);
 

--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -101,12 +101,21 @@ extern "C" {
   int cpp_createEmptyListParquetFile(const char* filename, const char* dsetname, int64_t dtype,
                                int64_t compression, char** errMsg);
 
-  int c_writeListColumnToParquet(const char* filename, void* chpl_arr, void* chpl_offsets,
+  int c_writeListColumnToParquet(const char* filename, void* chpl_offsets, void* chpl_arr,
                                   const char* dsetname, int64_t numelems,
                                   int64_t rowGroupSize, int64_t dtype, int64_t compression,
                                   char** errMsg);
-  int cpp_writeListColumnToParquet(const char* filename, void* chpl_arr, void* chpl_offsets,
+  int cpp_writeListColumnToParquet(const char* filename, void* chpl_offsets, void* chpl_arr,
                                   const char* dsetname, int64_t numelems,
+                                  int64_t rowGroupSize, int64_t dtype, int64_t compression,
+                                  char** errMsg);
+
+  int c_writeStrListColumnToParquet(const char* filename, void* chpl_segs, void* chpl_offsets, 
+                                  void* chpl_arr, const char* dsetname, int64_t numelems,
+                                  int64_t rowGroupSize, int64_t dtype, int64_t compression,
+                                  char** errMsg);
+  int cpp_writeStrListColumnToParquet(const char* filename, void* chpl_segs, void* chpl_offsets, 
+                                  void* chpl_arr, const char* dsetname, int64_t numelems,
                                   int64_t rowGroupSize, int64_t dtype, int64_t compression,
                                   char** errMsg);
   

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -1087,8 +1087,6 @@ module ParquetMsg {
       const myFilename = filenames[idx];
 
       const locDom = segments.localSubdomain();
-      var dims: [0..#1] int;
-      dims[0] = locDom.size: int;
 
       if (locDom.isEmpty() || locDom.size <= 0) {
         // we know append is not supported so creating new empty file

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -981,11 +981,7 @@ module ParquetMsg {
     extern proc c_writeListColumnToParquet(filename, chpl_arr, chpl_offsets,
                                           dsetname, numelems, rowGroupSize,
                                           dtype, compression, errMsg): int;
-    var localVals: [valIdxRange] t;
-    forall (localVal, valIdx) in zip(localVals, valIdxRange) with (var agg = newSrcAggregator(t)) {
-      // Copy the remote value at index position valIdx to our local array
-      agg.copy(localVal, distVals[valIdx]); // in SrcAgg, the Right Hand Side is REMOTE
-    }
+    var localVals: [valIdxRange] t = distVals[valIdxRange];
     var locOffsets: [0..#locDom.size+1] int;
     locOffsets[0..#locDom.size] = segments[locDom];
     if locDom.high == segments.domain.high then
@@ -1044,7 +1040,6 @@ module ParquetMsg {
         var endValIdx = if (lastOffset == localSegments[locDom.high]) then lastValIdx else segments[locDom.high + 1] - 1;
               
         var valIdxRange = startValIdx..endValIdx;
-        // TODO - simplify this code into this function and remove aggregation.
         writeSegArrayComponent(myFilename, dsetName, olda, valIdxRange, segments, locDom, extraOffset, lastOffset, lastValIdx, dtype, compression);
       }
     }

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -210,7 +210,6 @@ module ParquetMsg {
 
             var shift = computeEmptySegs(seg_sizes, offsets, s, intersection, off); // compute the shift to account for any empty segments in the file before the current section.
 
-
             if c_readListColumnByName(filename.localize().c_str(), c_ptrTo(A[intersection.low]),
                                   dsetname.localize().c_str(), intersection.size, (intersection.low - off) + shift,
                                   batchSize, c_ptrTo(pqErr.errMsg)) == ARROWERROR {
@@ -660,7 +659,7 @@ module ParquetMsg {
       entrySeg.a = (+ scan entrySeg.a) - entrySeg.a;
       
       var entryVal = new shared SymEntry((+ reduce byteSizes), uint(8));
-      readListFilesByName(entryVal.a, sizes, seg_sizes, segments, filenames, listSizes, dsetname, ty);
+      readListFilesByName(entryVal.a, sizes, seg_sizes, segments, filenames, byteSizes, dsetname, ty);
       var stringsEntry = assembleSegStringFromParts(entrySeg, entryVal, st);
       rtnmap.add("values", "created %s+created bytes.size %t".format(st.attrib(stringsEntry.name), stringsEntry.nBytes));
     }

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -573,6 +573,21 @@ class ParquetTest(ArkoudaTest):
             self.assertListEqual(df["idx"].to_list(), data["idx"].to_list())
             self.assertListEqual(df["seg"].to_list(), data["seg"].to_list())
 
+    def test_segarray_string(self):
+        words = ak.array(['one,two,three', 'uno,dos,tres'])
+        strs, segs = words.split(',', return_segments=True)
+        x = ak.SegArray(segs, strs)
+
+        with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
+            x.to_parquet(f"{tmp_dirname}/segarr_str")
+
+            rd = ak.read_parquet(f"{tmp_dirname}/segarr_str_*")
+            self.assertIsInstance(rd, ak.SegArray)
+            self.assertListEqual(x.segments.to_list(), rd.segments.to_list())
+            self.assertListEqual(x.values.to_list(), rd.values.to_list())
+            self.assertListEqual(x.to_list(), rd.to_list())
+
+
     @pytest.mark.optional_parquet
     def test_against_standard_files(self):
         datadir = "resources/parquet-testing"


### PR DESCRIPTION
Closes #2444 

This PR adds support for writing SegArray objects with Strings values to Parquet. 

**This does not add support for the multi-column case. That will be handled separately.**