### PR TITLE
Fixes #2506 - Categorical Optional Components Required Bug

### DIFF
--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -498,8 +498,10 @@ def _dict_recombine_segarrays_categoricals(df_dict):
             else Categorical.from_codes(
                 df_dict[f"{col}.codes"],
                 df_dict[f"{col}.categories"],
-                permutation=df_dict[f"{col}.permutation"],
-                segments=df_dict[f"{col}.segments"],
+                permutation=df_dict[f"{col}.permutation"]
+                if f"{col}.permutation" in df_dict_keys
+                else None,
+                segments=df_dict[f"{col}.segments"] if f"{col}.segments" in df_dict_keys else None,
                 _akNAcode=df_dict[f"{col}._akNAcode"],
             )
             if col in cat_cols
@@ -1876,8 +1878,7 @@ def read_tagged_data(
     )
     file_list = array(json.loads(j_str))
     file_cat = Categorical.from_codes(
-        arange(file_list.size),
-        file_list
+        arange(file_list.size), file_list
     )  # create a categorical from the ak.Strings representation of the file list
 
     ftype = get_filetype(filenames)


### PR DESCRIPTION
Closes #2506 

Updates `_dict_recombine_segarrays_categoricals()` to properly reconstruct `Categorical` objects from  the components available. Since `.permutation` and `.segments` are not required, there is no guarantee they can be used to recreate the object. This is now handled by checking for these components existence and if they are not available, calling `ak.Categorical.from_codes` with `permutation=None` and `segments=None`. If these components are read from the file, they will be used.