### PR TITLE
Replace `c_memcpy` with `OS.POSIX.memcpy` in CommAggregation module

### DIFF
--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -402,6 +402,7 @@ module CommAggregation {
     use CommPrimitives;
     use CommAggregation;
     use BigInteger, GMP;
+    use ArkoudaPOSIXCompat;
 
     proc bigint._serializedSize() {
       extern proc chpl_gmp_mpz_struct_sign_size(from: __mpz_struct) : mp_size_t;


### PR DESCRIPTION
Replace uses of `c_memcpy` with `memcpy` in CommAggregation module.

Resolves #2518