### PR TITLE
Fixes #2508 and #2519: Fixes `uint` scalar handling and overhauls `mod/fmod` for floats

### DIFF
--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -559,7 +559,7 @@ def arctan(pda: pdarray) -> pdarray:
 
 
 @typechecked
-def arctan2(num: Union[numeric_scalars, pdarray], denom: Union[numeric_scalars, pdarray]) -> pdarray:
+def arctan2(num: Union[pdarray, numeric_scalars], denom: Union[pdarray, numeric_scalars]) -> pdarray:
     """
     Return the element-wise inverse tangent of the array pair. The result chosen is the
     signed angle in radians between the ray ending at the origin and passing through the
@@ -584,55 +584,29 @@ def arctan2(num: Union[numeric_scalars, pdarray], denom: Union[numeric_scalars, 
     TypeError
         Raised if the parameter is not a pdarray
     """
-    if isinstance(num, pdarray) and isinstance(denom, pdarray):
-        return create_pdarray(
-            type_cast(
-                str,
-                generic_msg(
-                    cmd="efunc2vv",
-                    args={
-                        "func": "arctan2",
-                        "num": num,
-                        "denom": denom,
-                    },
-                ),
-            )
-        )
-    elif isinstance(num, pdarray) and isSupportedNumber(denom):
-        return create_pdarray(
-            type_cast(
-                str,
-                generic_msg(
-                    cmd="efunc2vs",
-                    args={
-                        "func": "arctan2",
-                        "num": num,
-                        "scalar": denom,
-                        "dtype": resolve_scalar_dtype(denom),
-                    },
-                ),
-            )
-        )
-    elif isSupportedNumber(num) and isinstance(denom, pdarray):
-        return create_pdarray(
-            type_cast(
-                str,
-                generic_msg(
-                    cmd="efunc2sv",
-                    args={
-                        "func": "arctan2",
-                        "scalar": num,
-                        "denom": denom,
-                        "dtype": resolve_scalar_dtype(num),
-                    },
-                ),
-            )
-        )
-    else:
+    if not all(isSupportedNumber(arg) or isinstance(arg, pdarray) for arg in [num, denom]):
         raise TypeError(
             f"Unsupported types {type(num)} and/or {type(denom)}. Supported "
-            f"types are numeric scalars and pdarrays. At least one argument must be a pdarray."
+            "types are numeric scalars and pdarrays. At least one argument must be a pdarray."
         )
+    if isSupportedNumber(num) and isSupportedNumber(denom):
+        raise TypeError(
+            f"Unsupported types {type(num)} and/or {type(denom)}. Supported "
+            "types are numeric scalars and pdarrays. At least one argument must be a pdarray."
+        )
+    return create_pdarray(
+        type_cast(
+            str,
+            generic_msg(
+                cmd="efunc2",
+                args={
+                    "func": "arctan2",
+                    "A": num,
+                    "B": denom,
+                },
+            ),
+        )
+    )
 
 
 @typechecked

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -681,7 +681,25 @@ module BinOp
         }
       var repMsg = "created %s".format(st.attrib(rname));
       return new MsgTuple(repMsg, MsgType.NORMAL);
-    } else if ((l.etype == uint && val.type == real) || (l.etype == real && val.type == uint)) {
+    }
+    else if e.etype == real && ((l.etype == uint && val.type == int) || (l.etype == int && val.type == uint)) {
+      select op {
+          when "+" {
+            e.a = l.a: real + val: real;
+          }
+          when "-" {
+            e.a = l.a: real - val: real;
+          }
+          otherwise {
+            var errorMsg = notImplementedError(pn,l.dtype,op,dtype);
+            omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+          }
+        }
+      var repMsg = "created %s".format(st.attrib(rname));
+      return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+    else if ((l.etype == uint && val.type == real) || (l.etype == real && val.type == uint)) {
       select op {
           when "+" {
             e.a = l.a: real + val: real;
@@ -946,29 +964,31 @@ module BinOp
       }
       var repMsg = "created %s".format(st.attrib(rname));
       return new MsgTuple(repMsg, MsgType.NORMAL);
-    } else if (val.type == int && r.etype == uint) {
+    }
+    else if (e.etype == int && val.type == uint) ||
+            (e.etype == uint && val.type == int) {
       select op {
         when ">>" {
           ref ea = e.a;
           ref ra = r.a;
-          [(ei,ri) in zip(ea,ra)] if ri:uint < 64 then ei = val:uint >> ri:uint;
+          [(ei,ri) in zip(ea,ra)] if ri:uint < 64 then ei = val:r.etype >> ri;
         }
         when "<<" {
           ref ea = e.a;
           ref ra = r.a;
-          [(ei,ri) in zip(ea,ra)] if ri:uint < 64 then ei = val:uint << ri:uint;
+          [(ei,ri) in zip(ea,ra)] if ri:uint < 64 then ei = val:r.etype << ri;
         }
         when ">>>" {
-          e.a = rotr(val:uint, r.a:uint);
+          e.a = rotr(val:r.etype, r.a);
         }
         when "<<<" {
-          e.a = rotl(val:uint, r.a:uint);
+          e.a = rotl(val:r.etype, r.a);
         }
         when "+" {
-          e.a = val:uint + r.a:uint;
+          e.a = val:r.etype + r.a;
         }
         when "-" {
-          e.a = val:uint - r.a:uint;
+          e.a = val:r.etype - r.a;
         }
         otherwise {
           var errorMsg = notImplementedError(pn,dtype,op,r.dtype);
@@ -1015,7 +1035,25 @@ module BinOp
         }
       var repMsg = "created %s".format(st.attrib(rname));
       return new MsgTuple(repMsg, MsgType.NORMAL);
-    } else if ((r.etype == uint && val.type == real) || (r.etype == real && val.type == uint)) {
+    }
+    else if e.etype == real && ((r.etype == uint && val.type == int) || (r.etype == int && val.type == uint)) {
+      select op {
+          when "+" {
+            e.a = val:real + r.a:real;
+          }
+          when "-" {
+            e.a = val:real - r.a:real;
+          }
+          otherwise {
+            var errorMsg = notImplementedError(pn,dtype,op,r.dtype);
+            omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+          }
+        }
+      var repMsg = "created %s".format(st.attrib(rname));
+      return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+    else if ((r.etype == uint && val.type == real) || (r.etype == real && val.type == uint)) {
       select op {
           when "+" {
             e.a = val:real + r.a:real;

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -17,7 +17,7 @@ module BinOp
   const omLogger = new Logger(logLevel, logChannel);
 
   /*
-  Helper function to ensure that floor division cases are handled in accordance with numpy
+    Helper function to ensure that floor division cases are handled in accordance with numpy
   */
   inline proc floorDivisionHelper(numerator: ?t, denom: ?t2): real {
     if (numerator == 0 && denom == 0) || (isinf(numerator) && (denom != 0 || isinf(denom))){
@@ -29,6 +29,25 @@ module BinOp
     else {
       return floor(numerator/denom);
     }
+  }
+
+  /*
+    Helper function to ensure that mod cases are handled in accordance with numpy
+  */
+  inline proc modHelper(dividend: ?t, divisor: ?t2): real {
+    extern proc fmod(x: real, y: real): real;
+
+    var res = fmod(dividend, divisor);
+    // to convert fmod (truncated) results into mod (floored) results
+    // when the dividend and divsor have opposite signs,
+    // we add the divsor into the result
+    // except for when res == 0 (divsor even divides dividend)
+    // see https://en.wikipedia.org/wiki/Modulo#math_1 for more information
+    if res != 0 && (((dividend < 0) && (divisor > 0)) || ((dividend > 0) && (divisor < 0))) {
+      // we do + either way because we want to shift up for positive divisors and shift down for negative
+      res += divisor;
+    }
+    return res;
   }
 
   /*
@@ -320,7 +339,10 @@ module BinOp
             e.a= l.a**r.a;
           }
           when "%" {
-            e.a = AutoMath.mod(l.a, r.a);
+            ref ea = e.a;
+            ref la = l.a;
+            ref ra = r.a;
+            [(ei,li,ri) in zip(ea,la,ra)] ei = modHelper(li, ri);
           }
           otherwise {
             var errorMsg = notImplementedError(pn,l.dtype,op,r.dtype);
@@ -354,7 +376,10 @@ module BinOp
             e.a= l.a:real**r.a:real;
           }
           when "%" {
-            e.a = AutoMath.mod(l.a:real, r.a:real);
+            ref ea = e.a;
+            ref la = l.a;
+            ref ra = r.a;
+            [(ei,li,ri) in zip(ea,la,ra)] ei = modHelper(li, ri);
           }
           otherwise {
             var errorMsg = notImplementedError(pn,l.dtype,op,r.dtype);
@@ -671,7 +696,9 @@ module BinOp
             e.a= l.a**val;
           }
           when "%" {
-            e.a = AutoMath.mod(l.a, val);
+            ref ea = e.a;
+            ref la = l.a;
+            [(ei,li) in zip(ea,la)] ei = modHelper(li, val);
           }
           otherwise {
             var errorMsg = notImplementedError(pn,l.dtype,op,dtype);
@@ -722,7 +749,9 @@ module BinOp
             e.a= l.a: real**val: real;
           }
           when "%" {
-            e.a = AutoMath.mod(l.a:real, val:real);
+            ref ea = e.a;
+            ref la = l.a;
+            [(ei,li) in zip(ea,la)] ei = modHelper(li, val);
           }
           otherwise {
             var errorMsg = notImplementedError(pn,l.dtype,op,dtype);
@@ -1025,7 +1054,9 @@ module BinOp
             e.a= val**r.a;
           }
           when "%" {
-            e.a = AutoMath.mod(val, r.a);
+            ref ea = e.a;
+            ref ra = r.a;
+            [(ei,ri) in zip(ea,ra)] ei = modHelper(val:real, ri);
           }
           otherwise {
             var errorMsg = notImplementedError(pn,dtype,op,r.dtype);
@@ -1076,7 +1107,9 @@ module BinOp
             e.a= val:real**r.a:real;
           }
           when "%" {
-            e.a = AutoMath.mod(val:real, r.a:real);
+            ref ea = e.a;
+            ref ra = r.a;
+            [(ei,ri) in zip(ea,ra)] ei = modHelper(val:real, ri);
           }
           otherwise {
             var errorMsg = notImplementedError(pn,dtype,op,r.dtype);

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -1197,7 +1197,11 @@ module OperatorMsg
                         [(li,ri) in zip(la,ra)] li = floorDivisionHelper(li, ri);
                     }
                     when "**=" { l.a **= r.a; }
-                    when "%=" {l.a = AutoMath.mod(l.a, r.a);}
+                    when "%=" {
+                        ref la = l.a;
+                        ref ra = r.a;
+                        [(li,ri) in zip(la,ra)] li = modHelper(li, ri);
+                    }
                     otherwise {
                         var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
                         omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
@@ -1220,7 +1224,11 @@ module OperatorMsg
                         [(li,ri) in zip(la,ra)] li = floorDivisionHelper(li, ri);
                     }
                     when "**=" { l.a **= r.a; }
-                    when "%=" {l.a = AutoMath.mod(l.a, r.a:real);}
+                    when "%=" {
+                        ref la = l.a;
+                        ref ra = r.a;
+                        [(li,ri) in zip(la,ra)] li = modHelper(li, ri);
+                    }
                     otherwise {
                         var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
                         omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
@@ -1242,7 +1250,11 @@ module OperatorMsg
                         [(li,ri) in zip(la,ra)] li = floorDivisionHelper(li, ri);
                     }
                     when "**=" { l.a **= r.a; }
-                    when "%=" {l.a = AutoMath.mod(l.a, r.a);}
+                    when "%=" {
+                        ref la = l.a;
+                        ref ra = r.a;
+                        [(li,ri) in zip(la,ra)] li = modHelper(li, ri);
+                    }
                     otherwise {
                         var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
                         omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
@@ -1762,7 +1774,10 @@ module OperatorMsg
                         [li in la] li = floorDivisionHelper(li, val);
                     }
                     when "**=" { l.a **= val; }
-                    when "%=" {l.a = AutoMath.mod(l.a, val);}
+                    when "%=" {
+                        ref la = l.a;
+                        [li in la] li = modHelper(li, val);
+                    }
                     otherwise {
                         var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
                         omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
@@ -1784,7 +1799,10 @@ module OperatorMsg
                     when "**=" {
                         l.a **= val;
                     }
-                    when "%=" {l.a = AutoMath.mod(l.a, val:real);}
+                    when "%=" {
+                        ref la = l.a;
+                        [li in la] li = modHelper(li, val);
+                    }
                     otherwise {
                         var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
                         omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
@@ -1805,7 +1823,10 @@ module OperatorMsg
                         [li in la] li = floorDivisionHelper(li, val);
                     }
                     when "**=" { l.a **= val; }
-                    when "%=" {l.a = AutoMath.mod(l.a, val);}
+                    when "%=" {
+                        ref la = l.a;
+                        [li in la] li = modHelper(li, val);
+                    }
                     otherwise {
                         var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
                         omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -23,7 +23,7 @@ module OperatorMsg
     private config const logLevel = ServerConfig.logLevel;
     private config const logChannel = ServerConfig.logChannel;
     const omLogger = new Logger(logLevel, logChannel);
-    
+
     /*
       Parse and respond to binopvv message.
       vv == vector op vector
@@ -555,9 +555,15 @@ module OperatorMsg
               var e = st.addEntry(rname, l.size, bool);
               return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
             }
-            // isn't + or -, so we can use LHS to determine type
-            var e = st.addEntry(rname, l.size, uint);
-            return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+            // + and - both result in real outputs to match NumPy
+            if op == "+" || op == "-" {
+              var e = st.addEntry(rname, l.size, real);
+              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+            } else {
+              // isn't + or -, so we can use LHS to determine type
+              var e = st.addEntry(rname, l.size, uint);
+              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+            }
           }
           when (DType.Int64, DType.UInt64) {
             var l = toSymEntry(left,int);
@@ -566,8 +572,15 @@ module OperatorMsg
               var e = st.addEntry(rname, l.size, bool);
               return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
             }
-            var e = st.addEntry(rname, l.size, int);
-            return doBinOpvs(l, val, e, op, dtype, rname, pn, st); 
+            // + and - both result in real outputs to match NumPy
+            if op == "+" || op == "-" {
+              var e = st.addEntry(rname, l.size, real);
+              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+            } else {
+              // isn't + or -, so we can use LHS to determine type
+              var e = st.addEntry(rname, l.size, int);
+              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+            }
           }
           when (DType.BigInt, DType.BigInt) {
             var l = toSymEntry(left,bigint);
@@ -894,8 +907,15 @@ module OperatorMsg
               var e = st.addEntry(rname, r.size, bool);
               return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
             }
-            var e = st.addEntry(rname, r.size, uint);
-            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+            // + and - both result in real outputs to match NumPy
+            if op == "+" || op == "-" {
+              var e = st.addEntry(rname, r.size, real);
+              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+            } else {
+              // isn't + or -, so we can use LHS to determine type
+              var e = st.addEntry(rname, r.size, int);
+              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+            }
           }
           when (DType.BigInt, DType.BigInt) {
             var val = value.getBigIntValue();

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -404,7 +404,7 @@ class NumericTest(ArkoudaTest):
         )
 
         with self.assertRaises(TypeError):
-            ak.arctan2(5,10)
+            ak.arctan2(5, 10)
         with self.assertRaises(TypeError):
             ak.arctan2(1, [range(0, 10)])
         with self.assertRaises(TypeError):

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -15,20 +15,19 @@ def run_tests(verbose):
     global pdarrays
     pdarrays = {
         "int64": ak.arange(0, SIZE, 1),
-        "uint64": ak.array(np.arange(0, SIZE, 1, dtype=np.uint64)),
+        "uint64": ak.array(np.arange(2**64 - SIZE, 2**64, 1, dtype=np.uint64)),
         "float64": ak.linspace(0, 2, SIZE),
         "bool": (ak.arange(0, SIZE, 1) % 2) == 0,
     }
     global ndarrays
     ndarrays = {
         "int64": np.arange(0, SIZE, 1),
-        "uint64": np.arange(0, SIZE, 1, dtype=np.uint64),
+        "uint64": np.arange(2**64 - SIZE, 2**64, 1, dtype=np.uint64),
         "float64": np.linspace(0, 2, SIZE),
         "bool": (np.arange(0, SIZE, 1) % 2) == 0,
     }
     global scalars
-    # scalars = {k: v[SIZE//2] for k, v in ndarrays.items()}
-    scalars = {"int64": 5, "uint64": np.uint64(5), "float64": 3.14159, "bool": True}
+    scalars = {"int64": 5, "uint64": np.uint64(2**63 + 1), "float64": 3.14159, "bool": True}
     dtypes = pdarrays.keys()
     if verbose:
         print("Operators: ", ak.pdarray.BinOps)
@@ -146,7 +145,7 @@ def run_tests(verbose):
     execerrors = []
     dtypeerrors = []
     valueerrors = []
-    for (expression, res, ex, dt, val) in results["both_implement"]:
+    for expression, res, ex, dt, val in results["both_implement"]:
         matches += not any((ex, dt, val))
         if ex:
             execerrors.append((expression, res))
@@ -882,12 +881,20 @@ class OperatorsTest(ArkoudaTest):
 
         # rotate by scalar
         for i in range(10):
-            self.assertEqual(ak.array([10], dtype=ak.bigint, max_bits=4).rotl(i), 10 if i % 2 == 0 else 5)
-            self.assertEqual(ak.array([10], dtype=ak.bigint, max_bits=4).rotr(i), 10 if i % 2 == 0 else 5)
+            self.assertEqual(
+                ak.array([10], dtype=ak.bigint, max_bits=4).rotl(i), 10 if i % 2 == 0 else 5
+            )
+            self.assertEqual(
+                ak.array([10], dtype=ak.bigint, max_bits=4).rotr(i), 10 if i % 2 == 0 else 5
+            )
 
         # rotate by array
-        left_rot = ak.bigint_from_uint_arrays([ak.full(10, 10, ak.uint64)], max_bits=4).rotl(ak.arange(10))
-        right_rot = ak.bigint_from_uint_arrays([ak.full(10, 10, ak.uint64)], max_bits=4).rotr(ak.arange(10))
+        left_rot = ak.bigint_from_uint_arrays([ak.full(10, 10, ak.uint64)], max_bits=4).rotl(
+            ak.arange(10)
+        )
+        right_rot = ak.bigint_from_uint_arrays([ak.full(10, 10, ak.uint64)], max_bits=4).rotr(
+            ak.arange(10)
+        )
         ans = [10 if i % 2 == 0 else 5 for i in range(10)]
         self.assertListEqual(left_rot.to_list(), ans)
         self.assertListEqual(right_rot.to_list(), ans)
@@ -919,7 +926,7 @@ class OperatorsTest(ArkoudaTest):
         self.assertTrue(np.allclose((akf % u).to_ndarray(), npf % u, equal_nan=True))
         self.assertTrue(np.allclose((u % akf).to_ndarray(), u % npf, equal_nan=True))
 
-        #opequal
+        # opequal
         npf_copy = npf
         akf_copy = ak.array(npf_copy)
         npf_copy %= npf2

--- a/tests/stats_test.py
+++ b/tests/stats_test.py
@@ -151,8 +151,8 @@ class StatsTest(ArkoudaTest):
         self.assertListEqual(ak_mod.to_list(), np_mod.tolist())
 
         # float float (non-whole numbers)
-        ak_div, ak_mod = ak.divmod(ak.cast(self.x+.5, ak.float64), ak.cast(self.y+1.5, ak.float64))
-        np_div, np_mod = np.divmod(self.npx.astype(float)+.5, self.npy.astype(float)+1.5)
+        ak_div, ak_mod = ak.divmod(ak.cast(self.x + 0.5, ak.float64), ak.cast(self.y + 1.5, ak.float64))
+        np_div, np_mod = np.divmod(self.npx.astype(float) + 0.5, self.npy.astype(float) + 1.5)
         self.assertListEqual(ak_div.to_list(), np_div.tolist())
         self.assertListEqual(ak_mod.to_list(), np_mod.tolist())
 
@@ -188,8 +188,8 @@ class StatsTest(ArkoudaTest):
         self.assertListEqual(ak_mod.to_list(), np_mod.tolist())
 
         # float float (non-whole numbers)
-        ak_div, ak_mod = ak.divmod(30.5, ak.cast(self.y+1.5, ak.float64))
-        np_div, np_mod = np.divmod(30.5, self.npy.astype(float)+1.5)
+        ak_div, ak_mod = ak.divmod(30.5, ak.cast(self.y + 1.5, ak.float64))
+        np_div, np_mod = np.divmod(30.5, self.npy.astype(float) + 1.5)
         self.assertListEqual(ak_div.to_list(), np_div.tolist())
         self.assertListEqual(ak_mod.to_list(), np_mod.tolist())
 
@@ -219,34 +219,43 @@ class StatsTest(ArkoudaTest):
         self.assertListEqual(ak_mod.to_list(), np_mod.tolist())
 
         # float float (non-whole numbers)
-        ak_div, ak_mod = ak.divmod(ak.cast(self.x+.5, ak.float64), 4.5)
-        np_div, np_mod = np.divmod(self.npx.astype(float)+.5, 4.5)
+        ak_div, ak_mod = ak.divmod(ak.cast(self.x + 0.5, ak.float64), 4.5)
+        np_div, np_mod = np.divmod(self.npx.astype(float) + 0.5, 4.5)
         self.assertListEqual(ak_div.to_list(), np_div.tolist())
         self.assertListEqual(ak_mod.to_list(), np_mod.tolist())
 
         # Boolean where argument
         truth = ak.arange(10) % 2 == 0
         ak_div_truth, ak_mod_truth = ak.divmod(self.x, self.y, where=truth)
-        self.assertListEqual(ak_div_truth.to_list(),
-                             [(self.x[i] // self.y[i]) if truth[i] else self.x[i] for i in range(10)])
-        self.assertListEqual(ak_mod_truth.to_list(),
-                             [(self.x[i] % self.y[i]) if truth[i] else self.x[i] for i in range(10)])
+        self.assertListEqual(
+            ak_div_truth.to_list(),
+            [(self.x[i] // self.y[i]) if truth[i] else self.x[i] for i in range(10)],
+        )
+        self.assertListEqual(
+            ak_mod_truth.to_list(),
+            [(self.x[i] % self.y[i]) if truth[i] else self.x[i] for i in range(10)],
+        )
 
         # Edge cases in the numerator
         edge_case = [-np.inf, -7.0, -0.0, np.nan, 0.0, 7.0, np.inf]
         np_edge_case = np.array(edge_case)
         ak_edge_case = ak.array(np_edge_case)
-        ak_div, ak_mod = ak.divmod(ak_edge_case, ak.arange(1, len(edge_case)+1))
-        np_div, np_mod = np.divmod(np_edge_case, np.arange(1, len(edge_case)+1))
+        np_ind = np.arange(1, len(edge_case) + 1)
+        ak_ind = ak.arange(1, len(edge_case) + 1)
+        ak_div, ak_mod = ak.divmod(ak_edge_case, ak_ind)
+        np_div, np_mod = np.divmod(np_edge_case, np_ind)
         self.assertTrue(np.allclose(ak_div.to_ndarray(), np_div, equal_nan=True))
         self.assertTrue(np.allclose(ak_mod.to_ndarray(), np_mod, equal_nan=True))
 
-        # Edge cases in the denominator
-        edge_case = [-np.inf, -7.0, np.nan, 7.0, np.inf]
-        np_edge_case = np.array(edge_case)
-        ak_edge_case = ak.array(np_edge_case)
-        ak_div, ak_mod = ak.divmod(ak_edge_case, ak.arange(1, len(edge_case)+1))
-        np_div, np_mod = np.divmod(np_edge_case, np.arange(1, len(edge_case)+1))
-        self.assertTrue(np.allclose(ak_div.to_ndarray(), np_div, equal_nan=True))
-        self.assertTrue(np.allclose(ak_mod.to_ndarray(), np_mod, equal_nan=True))
-
+        # TODO this was already broken but the num and denom were swapped
+        #  this will be addressed in #2519
+        # # Edge cases in the denominator
+        # edge_case = [-np.inf, -7.0, np.nan, 7.0, np.inf]
+        # np_edge_case = np.array(edge_case)
+        # ak_edge_case = ak.array(np_edge_case)
+        # np_ind = np.arange(1, len(edge_case)+1)
+        # ak_ind = ak.arange(1, len(edge_case)+1)
+        # ak_div, ak_mod = ak.divmod(ak_ind, ak_edge_case)
+        # np_div, np_mod = np.divmod(np_ind, np_edge_case)
+        # self.assertTrue(np.allclose(ak_div.to_ndarray(), np_div, equal_nan=True))
+        # self.assertTrue(np.allclose(ak_mod.to_ndarray(), np_mod, equal_nan=True))

--- a/tests/stats_test.py
+++ b/tests/stats_test.py
@@ -247,15 +247,13 @@ class StatsTest(ArkoudaTest):
         self.assertTrue(np.allclose(ak_div.to_ndarray(), np_div, equal_nan=True))
         self.assertTrue(np.allclose(ak_mod.to_ndarray(), np_mod, equal_nan=True))
 
-        # TODO this was already broken but the num and denom were swapped
-        #  this will be addressed in #2519
-        # # Edge cases in the denominator
-        # edge_case = [-np.inf, -7.0, np.nan, 7.0, np.inf]
-        # np_edge_case = np.array(edge_case)
-        # ak_edge_case = ak.array(np_edge_case)
-        # np_ind = np.arange(1, len(edge_case)+1)
-        # ak_ind = ak.arange(1, len(edge_case)+1)
-        # ak_div, ak_mod = ak.divmod(ak_ind, ak_edge_case)
-        # np_div, np_mod = np.divmod(np_ind, np_edge_case)
-        # self.assertTrue(np.allclose(ak_div.to_ndarray(), np_div, equal_nan=True))
-        # self.assertTrue(np.allclose(ak_mod.to_ndarray(), np_mod, equal_nan=True))
+        # Edge cases in the denominator
+        edge_case = [-np.inf, -7.0, np.nan, 7.0, np.inf]
+        np_edge_case = np.array(edge_case)
+        ak_edge_case = ak.array(np_edge_case)
+        np_ind = np.arange(1, len(edge_case)+1)
+        ak_ind = ak.arange(1, len(edge_case)+1)
+        ak_div, ak_mod = ak.divmod(ak_ind, ak_edge_case)
+        np_div, np_mod = np.divmod(np_ind, np_edge_case)
+        self.assertTrue(np.allclose(ak_div.to_ndarray(), np_div, equal_nan=True))
+        self.assertTrue(np.allclose(ak_mod.to_ndarray(), np_mod, equal_nan=True))


### PR DESCRIPTION
This PR (fixes #2508 and closes #2519) 
- resolves two bugs with our handling of uint scalars
- overhauls our `mod` and adds `fmod` 
  - adds testing to verify these match their numpy equivalents 
- fixes the `divmod` test

The two bugs involving uint scalars are:
- dtype mismatch:
  - `int arr +/- uint scalar` and vice versa resulted in an int array. It should be a real array to match numpy
  - Resolved 
- value mismatch:
  - `large real scalars (i.e. > 2 ** 63) % real arrays` were giving incorrect values. Since we cast `uint` scalars before doing operations with real arrays, this issue popped up
  - Resolved by shifting results from `fmod`. For more info see:
    - https://github.com/chapel-lang/chapel/issues/22584
    - #2519

Picking more representative examples for uint scalars and uint arrays in `testAllOperators` revealed this incorrect handling.
i.e.
```python
uint scalar: np.uint64(2**63 + 1)
uint array: np.arange(2**64 - SIZE, 2**64, 1, dtype=np.uint64)
```

`run_tests` on master before updating the test:
```
# ops not implemented by numpy or arkouda: 114
# ops implemented by numpy but not arkouda: 135
# ops implemented by arkouda but not numpy: 4
# ops implemented by both: 611
  Matching results:         611 / 611
  Arkouda execution errors: 0 / 611

  Dtype mismatches:         0 / 611

  Value mismatches:         0 / 611
```

`run_tests` on master after updating the test:
```
# ops not implemented by numpy or arkouda: 122
# ops implemented by numpy but not arkouda: 147
# ops implemented by arkouda but not numpy: 6
# ops implemented by both: 589
  Matching results:         584 / 589
  Arkouda execution errors: 0 / 589

  Dtype mismatches:         2 / 589
int64(array) + uint64(scalar): float64(np) vs. int64(ak)
int64(array) - uint64(scalar): float64(np) vs. int64(ak)
  Value mismatches:         3 / 589
uint64(array) % float64(array): np: [           nan 5.68434189e-14 5.68434189e-14 5.68434189e-14
 5.68434189e-14 1.33333333e-01 5.68434189e-14 1.46031746e+00
 5.68434189e-14 0.00000000e+00]
ak: [nan  0.  0.  0.  0.  0.  0.  0.  0.  0.]
uint64(array) % float64(scalar): np: [1.19112358 1.19112358 1.19112358 1.19112358 1.19112358 1.19112358
 1.19112358 1.19112358 1.19112358 1.19112358]
ak: [0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
uint64(scalar) % float64(array): np: [           nan 2.84217094e-14 2.84217094e-14 2.84217094e-14
 2.84217094e-14 6.22222222e-01 2.84217094e-14 7.30158730e-01
 2.84217094e-14 0.00000000e+00]
ak: [nan  0.  0.  0.  0.  0.  0.  0.  0.  0.]
```

`run_tests` on this PR after updating the tests:
```
# ops not implemented by numpy or arkouda: 122
# ops implemented by numpy but not arkouda: 145
# ops implemented by arkouda but not numpy: 6
# ops implemented by both: 591
  Matching results:         591 / 591
  Arkouda execution errors: 0 / 591

  Dtype mismatches:         0 / 591

  Value mismatches:         0 / 591
```

The biggest difference between the results from master before updating the tests and this PR after updating the tests is `ops implemented by numpy but not arkouda`. We see that this number has increased by 10. I hunted down the ones that it appeared like we supported before. They're all combinations of ops between `uint scalar` and `int array`. For all these operations the `uint array` and `int array` version is also not supported. So I think if we decide to add this support to arkouda we should do it a future issue and add the `vector-vector`, `vector-scalar`, and `scalar-vector` 
```
int64(array) / uint64(scalar)
int64(array) // uint64(scalar)
int64(array) * uint64(scalar)
int64(array) % uint64(scalar)
int64(array) ** uint64(scalar)

uint64(scalar) / int64(array)
uint64(scalar) // int64(array)
uint64(scalar) * int64(array)
uint64(scalar) % int64(array)
uint64(scalar) ** int64(array)
```