### PR TITLE
Closes #2529: Adjust getUserMetrics to return borrowed

### DIFF
--- a/src/MetricsMsg.chpl
+++ b/src/MetricsMsg.chpl
@@ -114,9 +114,9 @@ module MetricsMsg {
         var metrics = new map(keyType=User,valType=shared CounterTable);
         var users = new Users();
 
-        proc getUserMetrics(user: User) {
+        proc getUserMetrics(user: User) : borrowed CounterTable {
             if this.metrics.contains(user: User) {
-              return try! this.metrics[user];
+                return try! this.metrics[user];
             } else {
                 var userMetrics = new shared CounterTable();
                 this.metrics.add(user, userMetrics);


### PR DESCRIPTION
This PR is intended to fix Arkouda compilation failures after the Chapel PR https://github.com/chapel-lang/chapel/pull/21894 .

In particular, there is a change in behavior for statements like this:

     var userMetrics : borrowed CounterTable = this.getUserMetrics(...);

because after that PR, the 'shared' result of getUserMetrics is destroyed at the end of the statement, before 'userMetrics' can be used.

This PR changes getUserMetrics to return a 'borrowed CounterTable' which seems to better match how it is used in other places in the module and addresses the issue.

Closes #2529

- [x] make test-python passes, except for io_test.py, which I think reflects a configuration issue on my end