### PR TITLE
Closes #2505: Update `resolve_scalar_dtype` to handle `uint` and `bigint`

### DIFF
--- a/arkouda/dtypes.py
+++ b/arkouda/dtypes.py
@@ -32,7 +32,7 @@ __all__ = [
     "all_scalars",
     "get_byteorder",
     "get_server_byteorder",
-    "isSupportedNumber"
+    "isSupportedNumber",
 ]
 
 NUMBER_FORMAT_STRINGS = {
@@ -121,7 +121,6 @@ The DType enum defines the supported Arkouda data types in string form.
 
 
 class DType(Enum):
-
     BOOL = "bool"
     FLOAT = "float"
     FLOAT64 = "float64"
@@ -260,7 +259,11 @@ def resolve_scalar_dtype(val: object) -> str:  # type: ignore
         return "bool"
     # Python int or np.int* or np.uint*
     elif isinstance(val, int) or (hasattr(val, "dtype") and cast(np.uint, val).dtype.kind in "ui"):
-        if isinstance(val, np.uint64):
+        # we've established these are int, uint, or bigint,
+        # so we can do comparisons
+        if isSupportedInt(val) and val >= 2**64:  # type: ignore
+            return "bigint"
+        elif isinstance(val, np.uint64) or val >= 2**63:  # type: ignore
             return "uint64"
         else:
             return "int64"

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -314,10 +314,6 @@ class pdarray:
             # do the cast so that return array will have same dtype
             dt = self.dtype.name
             other = self.dtype.type(other)
-        else:
-            # see if other is a bigint
-            if isSupportedInt(other) and other >= 2**64:
-                dt = bigint.name
         if dt not in DTypes:
             raise TypeError(f"Unhandled scalar type: {other} ({type(other)})")
         repMsg = generic_msg(
@@ -363,10 +359,6 @@ class pdarray:
             # do the cast so that return array will have same dtype
             dt = self.dtype.name
             other = self.dtype.type(other)
-        else:
-            # see if other is a bigint
-            if isSupportedInt(other) and other >= 2**64:
-                dt = bigint.name
         if dt not in DTypes:
             raise TypeError(f"Unhandled scalar type: {other} ({type(other)})")
         repMsg = generic_msg(

--- a/tests/message_test.py
+++ b/tests/message_test.py
@@ -114,7 +114,7 @@ class JSONArgs(ArkoudaTest):
         self.assertListEqual(
             [
                 '{"key": "arg1", "objType": "VALUE", "dtype": "str", "val": "Test"}',
-                '{"key": "arg2", "objType": "VALUE", "dtype": "int", "val": "5"}',
+                '{"key": "arg2", "objType": "VALUE", "dtype": "int64", "val": "5"}',
             ],
             json.loads(args),
         )
@@ -124,7 +124,7 @@ class JSONArgs(ArkoudaTest):
         self.assertEqual(size, 1)
         self.assertListEqual(
             [
-                '{"key": "list1", "objType": "LIST", "dtype": "int", "val": "[\\"3\\", \\"2\\", \\"4\\"]"}'
+                '{"key": "list1", "objType": "LIST", "dtype": "int64", "val": "[\\"3\\", \\"2\\", \\"4\\"]"}'
             ],
             json.loads(args),
         )
@@ -168,7 +168,6 @@ class JSONArgs(ArkoudaTest):
         self.assertEqual(msgArgs["objType"], "PDARRAY")
         self.assertEqual(msgArgs["dtype"], "uint64")
         self.assertRegex(msgArgs["val"], "^id_\\w{7}_\\d+$")
-
 
         # test list of pdarray
         pd1 = arange(3)
@@ -214,7 +213,7 @@ class JSONArgs(ArkoudaTest):
             self.assertEqual(p["key"], f"param{i+1}")
             if i == 0:
                 self.assertEqual(p["objType"], "VALUE")
-                self.assertEqual(p["dtype"], "int")
+                self.assertEqual(p["dtype"], "int64")
                 self.assertEqual(p["val"], "1")
             elif i == 1:
                 self.assertEqual(p["objType"], "VALUE")
@@ -222,5 +221,5 @@ class JSONArgs(ArkoudaTest):
                 self.assertEqual(p["val"], "abc")
             else:
                 self.assertEqual(p["objType"], "LIST")
-                self.assertEqual(p["dtype"], "int")
+                self.assertEqual(p["dtype"], "int64")
                 self.assertListEqual(json.loads(p["val"]), ["1", "2", "3"])


### PR DESCRIPTION
This PR (closes #2505) updates `resolve_scalar_dtype` to correctly handle `bigint` and `uint` scalars. It also updates places where this is handled differently to just call that function.