### PR TITLE
dynamic available memory calculation for all locales

### DIFF
--- a/src/MemoryMgmt.chpl
+++ b/src/MemoryMgmt.chpl
@@ -84,10 +84,11 @@ module MemoryMgmt {
         var availMemory = getAvailMemory();
 
         mmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                 "reqMemory: %i arkMemAlloc: %i arkMemUsed: %i availMemory: %i".format(reqMemory,
-                                                                                       arkMemAlloc,
-                                                                                       arkMemUsed,
-                                                                                       availMemory));
+                 "locale: %s reqMemory: %i arkMemAlloc: %i arkMemUsed: %i availMemory: %i".format(here.id,
+                                                                                                  reqMemory,
+                                                                                                  arkMemAlloc,
+                                                                                                  arkMemUsed,
+                                                                                                  availMemory));
         var newArkoudaMemory = reqMemory:int + arkMemUsed:int;
         
         if newArkoudaMemory:int <= arkMemAlloc:int {
@@ -96,9 +97,9 @@ module MemoryMgmt {
             if newArkoudaMemory:int <= availMemory {
                 return true;
             } else {
-                var msg = "memory exceeded on locale %s with new arkouda memory %i exceeding availMemory: %i".format(here.id,
-                                                                                                                     newArkoudaMemory,
-                                                                                                                     availMemory);
+                var msg = "Arkouda memory request %i on locale %s exceeds available memory %i".format(newArkoudaMemory,
+                                                                                                      here.id,
+                                                                                                      availMemory);
                 mmLogger.error(getModuleName(),getRoutineName(),getLineNumber(),msg);
                 return false;
             }

--- a/src/MemoryMgmt.chpl
+++ b/src/MemoryMgmt.chpl
@@ -96,6 +96,10 @@ module MemoryMgmt {
             if newArkoudaMemory:int <= availMemory {
                 return true;
             } else {
+                var msg = "memory exceeded on locale %s with new arkouda memory %i exceeding availMemory: %i".format(here.id,
+                                                                                                                     newArkoudaMemory,
+                                                                                                                     availMemory);
+                mmLogger.error(getModuleName(),getRoutineName(),getLineNumber(),msg);
                 return false;
             }
         }

--- a/src/MemoryMgmt.chpl
+++ b/src/MemoryMgmt.chpl
@@ -1,0 +1,94 @@
+module MemoryMgmt {
+
+    use Subprocess;
+    use Memory;
+
+    proc getArkoudaPid() : string throws {
+        var pid = spawn(["pgrep","arkouda"], stdout=pipeStyle.pipe);
+
+        var pid_string:string;
+        var line:string;
+
+        while pid.stdout.readLine(line) {
+            pid_string = line.strip();
+        }
+
+        pid.close();
+        return pid_string;
+    }
+
+    proc getArkoudaMemAlloc() : string throws {
+        var pid = getArkoudaPid();
+
+        var sub = spawn(["pmap", pid], stdout=pipeStyle.pipe);
+
+        var malloc_string:string;
+        var line:string;
+
+        while sub.stdout.readLine(line) {
+            if line.find("total") > 0 {
+                var splits = line.split('total');
+                malloc_string = splits(1).strip().strip('K');
+            }
+        }
+
+        sub.close();
+        return malloc_string;
+    }
+    
+    proc getAvailMemory() : int throws {
+        var aFile = open('/proc/meminfo', ioMode.r);
+        var lines = aFile.reader().lines();
+        var line : string;
+
+        var memAvail:int;
+
+        for line in lines do {
+            if line.find('MemAvailable:') >= 0 {
+                var splits = line.split('MemAvailable:');
+                memAvail = splits[1].strip().strip(' kB'):int;
+            }
+        }
+        
+        return memAvail;
+    }
+
+    proc localeMemAvailable(reqMemory: int, memLimitPct: int) : bool throws {
+        var arkMemAlloc = getArkoudaMemAlloc();
+        var arkMemUsed = getMemory()/1000;
+        var availMemory = getAvailMemory();
+
+        if reqMemory + arkMemUsed <= arkMemAlloc {
+            return true;
+        } else {
+            if reqMemory + arkMemUsed <= availMemory {
+                return true;
+            } else {
+                return false;
+            }
+        }
+    }
+    
+    proc memAvailable(reqMemory: int, memLimitPct: int) : bool throws {
+      var overMemLimit : bool = false;
+
+      coforall loc in Locales {
+        on loc {
+            if !localeMemAvailable(reqMemory, memLimitPct) {
+                overMemLimit = true;
+            }
+        }
+      }
+      
+      return if overMemLimit then false else true;
+    }
+
+    proc main() {
+      try {
+          var availMem = getAvailMemory();
+          writeln("availMem %s".format(availMem));
+      } catch e: Error{
+          try! writeln("error: %s".format(e));
+      }
+   }
+}

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -310,7 +310,14 @@ module ServerConfig
             
             /*
              * If the MemoryMgmt.memMgmtType is STATIC (default), use the memory management logic based upon
-             * a percentage of the locale0 host machine.
+             * a percentage of the locale0 host machine physical memory. 
+             *
+             * If DYNAMIC, use the new dynamic memory mgmt capability in the MemoryMgmt module that first determines 
+             * for each locale if there's sufficient space within the memory currently allocated to the Arkouda 
+             * Chapel process to accommodate the projected memory required by the cmd. If not, then MemoryMgmt 
+             * checks the available memory on each locale to see if more can be allocated to the Arkouda-Chapel process.
+             * If the answer is no on any locale, the cmd is not executed and MemoryMgmt logs the corresponding locales
+             * server-side. More detailed client-side reporting can be implemented in a later version. 
              */
             if memMgmtType == MemMgmtType.STATIC {
                 if total > getMemLimit() {

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -12,6 +12,7 @@ module ServerConfig
     use Reflection;
     use ServerErrors;
     use Logging;
+    use MemoryMgmt;
 
     use ArkoudaFileCompat;
     
@@ -277,6 +278,21 @@ module ServerConfig
     proc overMemLimit(additionalAmount:int) throws {
         // must set config var "-smemTrack=true"(compile time) or "--memTrack=true" (run time)
         // to use memoryUsed() procedure from Chapel's Memory module
+        proc checkStaticMemoryLimit(total: real) {
+            if total > getMemLimit() {
+                var pct = AutoMath.round((total:real / getMemLimit():real * 100):uint);
+                var msg = "cmd requiring %i bytes of memory exceeds %i limit with projected pct memory used of %i%%".format(
+                                   total, getMemLimit(), pct);
+                scLogger.error(getModuleName(),getRoutineName(),getLineNumber(), msg);  
+                throw getErrorWithContext(
+                          msg=msg,
+                          lineNumber=getLineNumber(),
+                          routineName=getRoutineName(),
+                          moduleName=getModuleName(),
+                          errorClass="ErrorWithContext");                                        
+            }        
+        }
+        
         if (memTrack) {
             // this is a per locale total
             var total = getMemUsed() + (additionalAmount:uint / numLocales:uint);
@@ -291,17 +307,36 @@ module ServerConfig
                                          (getMemLimit():real * numLocales)) * 100):uint));
                 }
             }
-            if total > getMemLimit() {
-                var pct = AutoMath.round((total:real / getMemLimit():real * 100):uint);
-                var msg = "cmd requiring %i bytes of memory exceeds %i limit with projected pct memory used of %i%%".format(
+            
+            /*
+             * If the MemoryMgmt.memMgmtType is STATIC (default), use the memory management logic based upon
+             * a percentage of the locale0 host machine.
+             */
+            if memMgmtType == MemMgmtType.STATIC {
+                if total > getMemLimit() {
+                    var pct = AutoMath.round((total:real / getMemLimit():real * 100):uint);
+                    var msg = "cmd requiring %i bytes of memory exceeds %i limit with projected pct memory used of %i%%".format(
                                    total, getMemLimit(), pct);
-                scLogger.error(getModuleName(),getRoutineName(),getLineNumber(), msg);  
-                throw getErrorWithContext(
-                          msg=msg,
-                          lineNumber=getLineNumber(),
-                          routineName=getRoutineName(),
-                          moduleName=getModuleName(),
-                          errorClass="ErrorWithContext");                                        
+                    scLogger.error(getModuleName(),getRoutineName(),getLineNumber(), msg);  
+                    throw getErrorWithContext(
+                              msg=msg,
+                              lineNumber=getLineNumber(),
+                              routineName=getRoutineName(),
+                              moduleName=getModuleName(),
+                              errorClass="ErrorWithContext");                                        
+                }
+            } else {
+                if !isMemAvailable(additionalAmount) {
+                    var msg = "cmd requiring %i more bytes of memory exceeds available memory on one or more locales".format(
+                                                                                                     additionalAmount);
+                    scLogger.error(getModuleName(),getRoutineName(),getLineNumber(), msg);  
+                    throw getErrorWithContext(
+                              msg=msg,
+                              lineNumber=getLineNumber(),
+                              routineName=getRoutineName(),
+                              moduleName=getModuleName(),
+                              errorClass="ErrorWithContext");                                     
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #2477 

This PR delivers the following dynamic Arkouda memory tracking, reporting, and mgmt features:

1. on each locale MemoryMgmt checks to see if the projected memory required for an incoming cmd can be accommodated by the memory allocated to the Arkouda chapel process _on every node_. If so, the command is allowed to proceed.
2. if the answer to (1) is false, on each locale MemoryMgmt checks to see if additional memory can be allocated to accommodate the new, projected total Arkouda memory _on every node_. If so, the command is allowed to proceed. If not, a server-side error is thrown and the locales that cannot support the new malloc request are logged.
3. message is sent back to the client that OOM occurred on 1..n locales
4. new CLI arguments to enable dynamic memory mgmt. The default is the existing, static memory tracking, reporting, and  mgmt Arkouda feature