### PR TITLE
Closes #2268 - Fixes Sporadic failures of Parquet `segarray_write` test with gasnet

### DIFF
--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -328,7 +328,6 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
             (void)int_reader->ReadBatch(1, &definition_level, &rep_lvl, &value, &values_read);
             if (values_read == 0 || (!first && rep_lvl == 0)) {
               seg_sizes[i] = seg_size;
-              std::cout << "\n\ni: "<<i<<"\nseg_sizes[i]: "<<seg_sizes[i]<<"\n\n";
               i++;
               seg_size = 0;
             }
@@ -341,7 +340,6 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
             }
             if (values_read != 0 && !int_reader->HasNext()){
               seg_sizes[i] = seg_size;
-              std::cout << "\n\ni: "<<i<<"\nseg_sizes[i]: "<<seg_sizes[i]<<"\n\n";
             }
           }
         } else if(lty == ARROWINT32 || lty == ARROWUINT32) {
@@ -363,7 +361,7 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
                 first = false;
               }
             }
-            if (!int_reader->HasNext()){
+            if (values_read != 0 && !int_reader->HasNext()){
               seg_sizes[i] = seg_size;
             }
           }
@@ -386,7 +384,7 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
                 first = false;
               }
             }
-            if (!reader->HasNext()){
+            if (values_read != 0 && !reader->HasNext()){
               seg_sizes[i] = seg_size;
             }
           }
@@ -409,7 +407,7 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
                 first = false;
               }
             }
-            if (!bool_reader->HasNext()){
+            if (values_read != 0 && !bool_reader->HasNext()){
               seg_sizes[i] = seg_size;
             }
           }
@@ -434,7 +432,7 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
                 first = false;
               }
             }
-            if (!float_reader->HasNext()){
+            if (values_read != 0 && !float_reader->HasNext()){
               seg_sizes[i] = seg_size;
             }
           }
@@ -458,7 +456,7 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
                 first = false;
               }
             }
-            if (!dbl_reader->HasNext()){
+            if (values_read != 0 && !dbl_reader->HasNext()){
               seg_sizes[i] = seg_size;
             }
           }
@@ -565,7 +563,7 @@ int cpp_readListColumnByName(const char* filename, void* chpl_arr, const char* c
             if((numElems - i) < batchSize)
               batchSize = numElems - i;
             (void)reader->ReadBatch(batchSize, nullptr, nullptr, &chpl_ptr[i], &values_read);
-            i+=1;
+            i+=values_read;
           }
         } else if(lty == ARROWINT32 || lty == ARROWUINT32) {
           auto chpl_ptr = (int64_t*)chpl_arr;
@@ -1248,6 +1246,10 @@ int cpp_writeColumnToParquet(const char* filename, void* chpl_arr,
     int64_t i = 0;
     int64_t numLeft = numelems;
 
+    if (chpl_arr == NULL) {
+      return 0;
+    }
+
     if(dtype == ARROWINT64 || dtype == ARROWUINT64) {
       auto chpl_ptr = (int64_t*)chpl_arr;
       while(numLeft > 0) {
@@ -1772,6 +1774,9 @@ int cpp_appendColumnToParquet(const char* filename, void* chpl_arr,
                               int64_t dtype, int64_t compression,
                               char** errMsg) {
   try {
+    if (chpl_arr == NULL){
+      return 0;
+    }
     std::shared_ptr<arrow::io::ReadableFile> infile;
     ARROWRESULT_OK(arrow::io::ReadableFile::Open(filename, arrow::default_memory_pool()),
                    infile);

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -557,7 +557,6 @@ int cpp_readListColumnByName(const char* filename, void* chpl_arr, const char* c
           auto chpl_ptr = (int64_t*)chpl_arr;
           parquet::Int64Reader* reader =
             static_cast<parquet::Int64Reader*>(column_reader.get());
-          // startIdx -= reader->Skip(startIdx);
 
           while (reader->HasNext() && i < numElems) {
             if((numElems - i) < batchSize)
@@ -569,7 +568,6 @@ int cpp_readListColumnByName(const char* filename, void* chpl_arr, const char* c
           auto chpl_ptr = (int64_t*)chpl_arr;
           parquet::Int32Reader* reader =
             static_cast<parquet::Int32Reader*>(column_reader.get());
-          startIdx -= reader->Skip(startIdx);
 
           int32_t* tmpArr = (int32_t*)malloc(batchSize * sizeof(int32_t));
           while (reader->HasNext() && i < numElems) {
@@ -604,7 +602,6 @@ int cpp_readListColumnByName(const char* filename, void* chpl_arr, const char* c
           auto chpl_ptr = (bool*)chpl_arr;
           parquet::BoolReader* reader =
             static_cast<parquet::BoolReader*>(column_reader.get());
-          startIdx -= reader->Skip(startIdx);
 
           while (reader->HasNext() && i < numElems) {
             if((numElems - i) < batchSize)
@@ -616,7 +613,6 @@ int cpp_readListColumnByName(const char* filename, void* chpl_arr, const char* c
           auto chpl_ptr = (double*)chpl_arr;
           parquet::FloatReader* reader =
             static_cast<parquet::FloatReader*>(column_reader.get());
-          startIdx -= reader->Skip(startIdx);
           
           while (reader->HasNext() && i < numElems) {
             if((numElems - i) < batchSize) // adjust batchSize if needed
@@ -638,7 +634,6 @@ int cpp_readListColumnByName(const char* filename, void* chpl_arr, const char* c
           auto chpl_ptr = (double*)chpl_arr;
           parquet::DoubleReader* reader =
             static_cast<parquet::DoubleReader*>(column_reader.get());
-          startIdx -= reader->Skip(startIdx);
 
           while (reader->HasNext() && i < numElems) {
             if((numElems - i) < batchSize) // adjust batchSize if needed
@@ -973,11 +968,9 @@ int cpp_writeMultiColToParquet(const char* filename, void* column_names,
               else {
                 // empty segment denoted by null value that is not repeated (first of segment) defined at the list level (1)
                 segSize = 1; // even though segment is length=0, write null to hold the empty segment
-                int16_t* def_lvl = new int16_t[segSize] { 1 };
-                int16_t* rep_lvl = new int16_t[segSize] { 0 };
-                writer->WriteBatch(segSize, def_lvl, rep_lvl, nullptr);
-                delete[] def_lvl;
-                delete[] rep_lvl;
+                int16_t def_lvl = 1;
+                int16_t rep_lvl = 0;
+                writer->WriteBatch(segSize, &def_lvl, &rep_lvl, nullptr);
               }
               offIdx++;
               count++;
@@ -1027,11 +1020,9 @@ int cpp_writeMultiColToParquet(const char* filename, void* column_names,
               else {
                 // empty segment denoted by null value that is not repeated (first of segment) defined at the list level (1)
                 segSize = 1; // even though segment is length=0, write null to hold the empty segment
-                int16_t* def_lvl = new int16_t[segSize] { 1 };
-                int16_t* rep_lvl = new int16_t[segSize] { 0 };
-                writer->WriteBatch(segSize, def_lvl, rep_lvl, nullptr);
-                delete[] def_lvl;
-                delete[] rep_lvl;
+                int16_t def_lvl = 1;
+                int16_t rep_lvl = 0;
+                writer->WriteBatch(segSize, &def_lvl, &rep_lvl, nullptr);
               }
               offIdx++;
               count++;
@@ -1081,11 +1072,9 @@ int cpp_writeMultiColToParquet(const char* filename, void* column_names,
               else {
                 // empty segment denoted by null value that is not repeated (first of segment) defined at the list level (1)
                 segSize = 1; // even though segment is length=0, write null to hold the empty segment
-                int16_t* def_lvl = new int16_t[segSize] { 1 };
-                int16_t* rep_lvl = new int16_t[segSize] { 0 };
-                writer->WriteBatch(segSize, def_lvl, rep_lvl, nullptr);
-                delete[] def_lvl;
-                delete[] rep_lvl;
+                int16_t def_lvl = 1;
+                int16_t rep_lvl =0;
+                writer->WriteBatch(segSize, &def_lvl, &rep_lvl, nullptr);
               }
               offIdx++;
               count++;

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -1236,6 +1236,7 @@ int cpp_writeColumnToParquet(const char* filename, void* chpl_arr,
     int64_t numLeft = numelems;
 
     if (chpl_arr == NULL) {
+      // early out to prevent bad memory access
       return 0;
     }
 
@@ -1764,6 +1765,7 @@ int cpp_appendColumnToParquet(const char* filename, void* chpl_arr,
                               char** errMsg) {
   try {
     if (chpl_arr == NULL){
+      // early out to prevent bad memory access
       return 0;
     }
     std::shared_ptr<arrow::io::ReadableFile> infile;

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -338,7 +338,6 @@ module ParquetMsg {
     
     if listSize == ARROWERROR then
       pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
-    writeln("\n\nListSize: %jt\nSeg_Sizes: %jt\n\n".format(listSize, seg_sizes));
     return listSize;
   }
   
@@ -465,14 +464,18 @@ module ParquetMsg {
 
         var locDom = A.localSubdomain();
         var locArr = A[locDom];
+        var valPtr: c_void_ptr = nil;
+        if locArr.size != 0 {
+          valPtr = c_ptrTo(locArr);
+        }
         if mode == TRUNCATE || !filesExist {
-          if c_writeColumnToParquet(myFilename.localize().c_str(), c_ptrTo(locArr), 0,
+          if c_writeColumnToParquet(myFilename.localize().c_str(), valPtr, 0,
                                     dsetname.localize().c_str(), locDom.size, rowGroupSize,
                                     dtypeRep, compression, c_ptrTo(pqErr.errMsg)) == ARROWERROR {
             pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
           }
         } else {
-          if c_appendColumnToParquet(myFilename.localize().c_str(), c_ptrTo(locArr),
+          if c_appendColumnToParquet(myFilename.localize().c_str(), valPtr,
                                      dsetname.localize().c_str(), locDom.size,
                                      dtypeRep, compression, c_ptrTo(pqErr.errMsg)) == ARROWERROR {
             pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -346,17 +346,19 @@ class ParquetTest(ArkoudaTest):
             rd_data = ak.read_parquet(f"{tmp_dirname}/int_test*")
             for i in range(3):
                 self.assertListEqual(s[i].to_list(), rd_data[i].to_list())
+        print("Finished Int")
 
         # integer with empty segments
         a = [0, 1, 2]
         c = [15, 21]
         s = ak.SegArray(ak.array([0, 0, len(a), len(a), len(a), len(a) + len(c)]), ak.array(a + c))
         with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
-            s.to_parquet(f"{tmp_dirname}/int_test")
+            s.to_parquet(f"{tmp_dirname}/int_test_empty")
 
-            rd_data = ak.read_parquet(f"{tmp_dirname}/int_test*")
+            rd_data = ak.read_parquet(f"{tmp_dirname}/int_test_empty*")
             for i in range(6):
                 self.assertListEqual(s[i].to_list(), rd_data[i].to_list())
+        print("Finished Int Empty")
 
         # uint test
         a = [0, 1, 2]
@@ -364,11 +366,13 @@ class ParquetTest(ArkoudaTest):
         c = [15, 21]
         s = ak.SegArray(ak.array([0, len(a), len(a) + len(b)]), ak.array(a + b + c, dtype=ak.uint64))
         with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
-            s.to_parquet(f"{tmp_dirname}/int_test")
+            s.to_parquet(f"{tmp_dirname}/uint_test")
 
-            rd_data = ak.read_parquet(f"{tmp_dirname}/int_test*")
+            rd_data = ak.read_parquet(f"{tmp_dirname}/uint_test*")
             for i in range(3):
                 self.assertListEqual(s[i].to_list(), rd_data[i].to_list())
+
+        print("Finished UInt")
 
         # uint with empty segments
         a = [0, 1, 2]
@@ -377,11 +381,12 @@ class ParquetTest(ArkoudaTest):
             ak.array([0, 0, len(a), len(a), len(a), len(a) + len(c)]), ak.array(a + c, dtype=ak.uint64)
         )
         with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
-            s.to_parquet(f"{tmp_dirname}/int_test")
+            s.to_parquet(f"{tmp_dirname}/uint_test_empty")
 
-            rd_data = ak.read_parquet(f"{tmp_dirname}/int_test*")
+            rd_data = ak.read_parquet(f"{tmp_dirname}/uint_test_empty*")
             for i in range(6):
                 self.assertListEqual(s[i].to_list(), rd_data[i].to_list())
+        print("Finished UInt Empty")
 
         # bool test
         a = [0, 1, 1]
@@ -389,11 +394,12 @@ class ParquetTest(ArkoudaTest):
         c = [1, 0]
         s = ak.SegArray(ak.array([0, len(a), len(a) + len(b)]), ak.array(a + b + c, dtype=ak.bool))
         with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
-            s.to_parquet(f"{tmp_dirname}/int_test")
+            s.to_parquet(f"{tmp_dirname}/bool_test")
 
-            rd_data = ak.read_parquet(f"{tmp_dirname}/int_test*")
+            rd_data = ak.read_parquet(f"{tmp_dirname}/bool_test*")
             for i in range(3):
                 self.assertListEqual(s[i].to_list(), rd_data[i].to_list())
+        print("Finished Bool")
 
         # bool with empty segments
         a = [0, 1, 1]
@@ -402,11 +408,12 @@ class ParquetTest(ArkoudaTest):
             ak.array([0, 0, len(a), len(a), len(a), len(a) + len(c)]), ak.array(a + c, dtype=ak.bool)
         )
         with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
-            s.to_parquet(f"{tmp_dirname}/int_test")
+            s.to_parquet(f"{tmp_dirname}/bool_test_empty")
 
-            rd_data = ak.read_parquet(f"{tmp_dirname}/int_test*")
+            rd_data = ak.read_parquet(f"{tmp_dirname}/bool_test_empty*")
             for i in range(6):
                 self.assertListEqual(s[i].to_list(), rd_data[i].to_list())
+        print("Finished Bool Empty")
 
         # float test
         a = [1.1, 1.1, 2.7]
@@ -414,22 +421,24 @@ class ParquetTest(ArkoudaTest):
         c = [15.2, 21.0]
         s = ak.SegArray(ak.array([0, len(a), len(a) + len(b)]), ak.array(a + b + c))
         with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
-            s.to_parquet(f"{tmp_dirname}/int_test")
+            s.to_parquet(f"{tmp_dirname}/float_test")
 
-            rd_data = ak.read_parquet(f"{tmp_dirname}/int_test*")
+            rd_data = ak.read_parquet(f"{tmp_dirname}/float_test*")
             for i in range(3):
                 self.assertListEqual(s[i].to_list(), rd_data[i].to_list())
+        print("Finished Float")
 
         # float with empty segments
         a = [1.1, 1.1, 2.7]
         c = [15.2, 21.0]
         s = ak.SegArray(ak.array([0, 0, len(a), len(a), len(a), len(a) + len(c)]), ak.array(a + c))
         with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
-            s.to_parquet(f"{tmp_dirname}/int_test")
+            s.to_parquet(f"{tmp_dirname}/float_test_empty")
 
-            rd_data = ak.read_parquet(f"{tmp_dirname}/int_test*")
+            rd_data = ak.read_parquet(f"{tmp_dirname}/float_test_empty*")
             for i in range(6):
                 self.assertListEqual(s[i].to_list(), rd_data[i].to_list())
+        print("Finished Float Empty")
 
     def test_multicol_write(self):
         df_dict = {

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -372,8 +372,6 @@ class ParquetTest(ArkoudaTest):
             for i in range(3):
                 self.assertListEqual(s[i].to_list(), rd_data[i].to_list())
 
-        print("Finished UInt")
-
         # uint with empty segments
         a = [0, 1, 2]
         c = [15, 21]
@@ -386,7 +384,6 @@ class ParquetTest(ArkoudaTest):
             rd_data = ak.read_parquet(f"{tmp_dirname}/uint_test_empty*")
             for i in range(6):
                 self.assertListEqual(s[i].to_list(), rd_data[i].to_list())
-        print("Finished UInt Empty")
 
         # bool test
         a = [0, 1, 1]
@@ -399,7 +396,6 @@ class ParquetTest(ArkoudaTest):
             rd_data = ak.read_parquet(f"{tmp_dirname}/bool_test*")
             for i in range(3):
                 self.assertListEqual(s[i].to_list(), rd_data[i].to_list())
-        print("Finished Bool")
 
         # bool with empty segments
         a = [0, 1, 1]
@@ -413,7 +409,6 @@ class ParquetTest(ArkoudaTest):
             rd_data = ak.read_parquet(f"{tmp_dirname}/bool_test_empty*")
             for i in range(6):
                 self.assertListEqual(s[i].to_list(), rd_data[i].to_list())
-        print("Finished Bool Empty")
 
         # float test
         a = [1.1, 1.1, 2.7]
@@ -426,7 +421,6 @@ class ParquetTest(ArkoudaTest):
             rd_data = ak.read_parquet(f"{tmp_dirname}/float_test*")
             for i in range(3):
                 self.assertListEqual(s[i].to_list(), rd_data[i].to_list())
-        print("Finished Float")
 
         # float with empty segments
         a = [1.1, 1.1, 2.7]
@@ -438,7 +432,6 @@ class ParquetTest(ArkoudaTest):
             rd_data = ak.read_parquet(f"{tmp_dirname}/float_test_empty*")
             for i in range(6):
                 self.assertListEqual(s[i].to_list(), rd_data[i].to_list())
-        print("Finished Float Empty")
 
     def test_multicol_write(self):
         df_dict = {

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -346,7 +346,6 @@ class ParquetTest(ArkoudaTest):
             rd_data = ak.read_parquet(f"{tmp_dirname}/int_test*")
             for i in range(3):
                 self.assertListEqual(s[i].to_list(), rd_data[i].to_list())
-        print("Finished Int")
 
         # integer with empty segments
         a = [0, 1, 2]
@@ -358,7 +357,6 @@ class ParquetTest(ArkoudaTest):
             rd_data = ak.read_parquet(f"{tmp_dirname}/int_test_empty*")
             for i in range(6):
                 self.assertListEqual(s[i].to_list(), rd_data[i].to_list())
-        print("Finished Int Empty")
 
         # uint test
         a = [0, 1, 2]


### PR DESCRIPTION
Closes #2268 

This PR updates the processing for SegArray reads and writes to prevent memory corruption errors from occurring. From my testing, these were the errors I was seeing. They were different than those reported. Either way these errors needed to be resolved as they occur mainly when a locale only contains empty segments.

- Adds handling for writing to locales with segment values where all segments are empty
- Adds handling for reading from files with only empty segments
- Adds better memory management and cleanup of memory used during processing
- Updates testing file names
- Adds column with strings longer than 1 character for testing

If these updates do not also address the specific reported issue, we will reopen the issue and continue troubleshooting.