### PR TITLE
Closes #2538 - `client_test.py` conversion for new test framework

### DIFF
--- a/PROTO_tests/tests/client_test.py
+++ b/PROTO_tests/tests/client_test.py
@@ -82,6 +82,20 @@ class TestClient:
             raise AssertionError(e)
         assert mem_used > 0
 
+        # test units
+        mem_used = ak.get_mem_used()
+        mem_avail = ak.get_mem_avail()
+        for u, f in ak.client._memunit2factor.items():
+            assert round(mem_used / f) == ak.get_mem_used(u)
+            assert round(mem_avail / f) == ak.get_mem_avail(u)
+
+        # test as_percent
+        tot_mem = ak.get_mem_used() + ak.get_mem_avail()
+        assert ak.get_mem_used(as_percent=True) == round((ak.get_mem_used() / tot_mem) * 100)
+        assert ak.get_mem_avail(as_percent=True), round((ak.get_mem_avail() / tot_mem) * 100)
+
+        assert 100 == ak.get_mem_used(as_percent=True) + ak.get_mem_avail(as_percent=True)
+
     def test_no_op(self):
         """
         Tests the ak.client._no_op method

--- a/PROTO_tests/tests/client_test.py
+++ b/PROTO_tests/tests/client_test.py
@@ -1,6 +1,5 @@
 import arkouda as ak
 import pytest
-import os
 
 from server_util.test.server_test_util import start_arkouda_server
 
@@ -66,6 +65,22 @@ class TestClient:
         assert pytest.port == config["ServerPort"]
         assert "arkoudaVersion" in config
         assert "INFO" == config["logLevel"]
+
+    def test_get_mem_used(self):
+        """
+        Tests the ak.get_mem_used and ak.get_mem_avail methods
+
+        :return: None
+        :raise: AssertionError if one or more ak.get_mem_used values are not as
+                expected or the call to ak.client.get_mem_used() fails
+        """
+        try:
+            config = ak.client.get_config()
+            a = ak.ones(1024 * 1024 * config["numLocales"])
+            mem_used = ak.client.get_mem_used()
+        except Exception as e:
+            raise AssertionError(e)
+        assert mem_used > 0
 
     def test_no_op(self):
         """


### PR DESCRIPTION
Closes #2538 

This PR adds `client_test.py` to the new test framework. The only change was adding a call to `ak.connect` at the end of the `test_shutdown` to ensure that any tests within the file after this one pass.

`conftest.py` has also been updated to add `pytest.server`, `pytest.port` and `pytest.timeout` as properties that can be accessed in each test to allow for reconnection during the client testing.