### PR TITLE
Closes #2548: Recommend Chapel 1.31.0 and use it for CI testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -159,7 +159,7 @@ jobs:
     env:
       CHPL_RT_NUM_THREADS_PER_LOCALE: ${{matrix.threads}}
     container:
-      image: chapel/${{matrix.image}}:1.30.0
+      image: chapel/${{matrix.image}}:1.31.0
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -95,35 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        chpl-version: ['1.29.0']
-    container:
-      image: chapel/chapel:${{matrix.chpl-version}}
-    steps:
-    - uses: actions/checkout@v3
-    - name: Install dependencies
-      run: |
-        apt-get update && apt-get install -y -V ca-certificates lsb-release wget
-        wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-        apt-get install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-        apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip libarrow-dev libparquet-dev libcurl4-openssl-dev libidn2-dev
-        make install-iconv
-        echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" >> Makefile.paths
-    - name: Check chpl version
-      run: |
-        chpl --version
-    - name: Build/Install Arkouda
-      run: |
-        make
-        python3 -m pip install -e .[dev]
-    - name: Arkouda unit tests
-      run: |
-        make test-python
-
-  arkouda_chpl_portability:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        chpl-version: ['1.30.0']
+        chpl-version: ['1.29.0', '1.30.0']
     container:
       image: chapel/chapel:${{matrix.chpl-version}}
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.30.0
+      image: chapel/chapel:1.31.0
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies
@@ -32,7 +32,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.30.0
+      image: chapel/chapel:1.31.0
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies
@@ -47,7 +47,7 @@ jobs:
   flake8:
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.30.0
+      image: chapel/chapel:1.31.0
     steps:
       - uses: actions/checkout@v3
       - name: Install Dependencies
@@ -65,7 +65,7 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10']
     container:
-      image: chapel/chapel:1.30.0
+      image: chapel/chapel:1.31.0
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -96,6 +96,34 @@ jobs:
     strategy:
       matrix:
         chpl-version: ['1.29.0']
+    container:
+      image: chapel/chapel:${{matrix.chpl-version}}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install dependencies
+      run: |
+        apt-get update && apt-get install -y -V ca-certificates lsb-release wget
+        wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+        apt-get install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+        apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip libarrow-dev libparquet-dev libcurl4-openssl-dev libidn2-dev
+        make install-iconv
+        echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" >> Makefile.paths
+    - name: Check chpl version
+      run: |
+        chpl --version
+    - name: Build/Install Arkouda
+      run: |
+        make
+        python3 -m pip install -e .[dev]
+    - name: Arkouda unit tests
+      run: |
+        make test-python
+
+  arkouda_chpl_portability:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        chpl-version: ['1.30.0']
     container:
       image: chapel/chapel:${{matrix.chpl-version}}
     steps:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository == 'Bears-R-Us/arkouda'
     runs-on: ubuntu-latest
     container:
-      image: chapel/chapel:1.30.0
+      image: chapel/chapel:1.31.0
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies

--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ ifneq ($(CHPL_VERSION_OK),yes)
 	$(error Chapel 1.29.0 or newer is required)
 endif
 ifeq ($(CHPL_VERSION_WARN),yes)
-	$(warning Chapel 1.30.0 or newer is recommended)
+	$(warning Chapel 1.31.0 or newer is recommended)
 endif
 
 ZMQ_CHECK = $(DEP_INSTALL_DIR)/checkZMQ.chpl

--- a/pydoc/setup/LINUX_INSTALL.md
+++ b/pydoc/setup/LINUX_INSTALL.md
@@ -10,9 +10,9 @@ sudo apt-get update
 sudo apt-get install gcc g++ m4 perl python3 python3-pip python3-venv python3-dev bash make mawk git pkg-config cmake llvm-12-dev llvm-12 llvm-12-tools clang-12 libclang-12-dev libclang-cpp12-dev libedit-dev
 
 # Download latest Chapel release, explode archive, and navigate to source root directory
-wget https://github.com/chapel-lang/chapel/releases/download/1.30.0/chapel-1.30.0.tar.gz
-tar xvf chapel-1.30.0.tar.gz
-cd chapel-1.30.0/
+wget https://github.com/chapel-lang/chapel/releases/download/1.31.0/chapel-1.31.0.tar.gz
+tar xvf chapel-1.31.0.tar.gz
+cd chapel-1.31.0/
 
 # Set CHPL_HOME
 export CHPL_HOME=$PWD

--- a/pydoc/setup/MAC_INSTALL.md
+++ b/pydoc/setup/MAC_INSTALL.md
@@ -16,13 +16,13 @@ For convenience, the steps to install Chapel from source are detailed here. If y
 **Step 2**
 > Unpack the release
 > ```bash
-> tar xzf chapel-1.30.0.tar.gz
+> tar xzf chapel-1.31.0.tar.gz
 > ```
 
 **Step 3**
 > Access the directory created when the release was unpacked
 > ```bash
-> cd chapel-1.30.0
+> cd chapel-1.31.0
 > ```
 
 **Step 4**

--- a/pydoc/setup/WINDOWS_INSTALL.md
+++ b/pydoc/setup/WINDOWS_INSTALL.md
@@ -14,7 +14,7 @@ for installing Chapel & Arkouda.  We also recommend installing Anaconda for wind
 
 **Note:** When running `make` to build Chapel while using WSL, pathing issues to library dependencies are common. In most cases, a symlink pointing to the correct location or library will fix these errors.
 
-An example of one of these errors found while using Chapel 1.30.0 and Ubuntu 20.04 LTS with WSL is:
+An example of one of these errors found while using Chapel 1.31.0 and Ubuntu 20.04 LTS with WSL is:
 
 ```bash
 ../../../bin/llvm-tblgen: error while loading shared libraries: libtinfow.so.6: cannot open shared object file: No such file or directory


### PR DESCRIPTION
Chapel 1.31.0 includes improvements to the bigint library and further improves Arkouda compilation times with the LLVM backend.

Closes: #2548 