### PR TITLE
Closes #2471:  ak.full() for Strings

### DIFF
--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -34,6 +34,7 @@ __all__ = [
     "zeros",
     "ones",
     "full",
+    "_full_string",
     "zeros_like",
     "ones_like",
     "full_like",
@@ -499,10 +500,10 @@ def ones(
 @typechecked
 def full(
     size: Union[int_scalars, str],
-    fill_value: int_scalars,
+    fill_value: Union[int_scalars, str],
     dtype: Union[np.dtype, type, str, BigInt] = float64,
     max_bits: Optional[int] = None,
-) -> pdarray:
+) -> Union[pdarray, Strings]:
     """
     Create a pdarray filled with fill_value.
 
@@ -519,7 +520,7 @@ def full(
 
     Returns
     -------
-    pdarray
+    pdarray or Strings
         array of the requested size and dtype filled with fill_value
 
     Raises
@@ -543,8 +544,12 @@ def full(
     >>> ak.full(5, 5, dtype=ak.bool)
     array([True, True, True, True, True])
     """
+
     if not np.isscalar(size):
         raise TypeError(f"size must be a scalar, not {size.__class__.__name__}")
+    if type(fill_value) == str:
+       return _full_string(size, fill_value)
+
     dtype = akdtype(dtype)  # normalize dtype
     dtype_name = dtype.name if isinstance(dtype, BigInt) else cast(np.dtype, dtype).name
     # check dtype for error
@@ -557,6 +562,28 @@ def full(
         a.max_bits = max_bits
     return a
 
+@typechecked
+def _full_string(
+    size: Union[int_scalars, str],
+    fill_value: str,
+) -> Strings:
+    """
+    Create a Strings object filled with fill_value.
+
+    Parameters
+    ----------
+    size: int_scalars
+        Size of the array (only rank-1 arrays supported)
+    fill_value: str
+        Value with which the array will be filled
+
+    Returns
+    -------
+    Strings
+        array of the requested size and dtype filled with fill_value
+"""
+    repMsg = generic_msg(cmd="segmentedFull", args={"size": size, "fill_value": fill_value})
+    return Strings.from_return_msg(cast(str, repMsg))
 
 @typechecked
 def zeros_like(pda: pdarray) -> pdarray:

--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -548,7 +548,7 @@ def full(
     if not np.isscalar(size):
         raise TypeError(f"size must be a scalar, not {size.__class__.__name__}")
     if type(fill_value) == str:
-       return _full_string(size, fill_value)
+        return _full_string(size, fill_value)
 
     dtype = akdtype(dtype)  # normalize dtype
     dtype_name = dtype.name if isinstance(dtype, BigInt) else cast(np.dtype, dtype).name
@@ -561,6 +561,7 @@ def full(
     if max_bits:
         a.max_bits = max_bits
     return a
+
 
 @typechecked
 def _full_string(
@@ -584,6 +585,7 @@ def _full_string(
 """
     repMsg = generic_msg(cmd="segmentedFull", args={"size": size, "fill_value": fill_value})
     return Strings.from_return_msg(cast(str, repMsg))
+
 
 @typechecked
 def zeros_like(pda: pdarray) -> pdarray:

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -1109,7 +1109,19 @@ module SegmentedMsg {
     smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
     return new MsgTuple(repMsg, MsgType.NORMAL);
   }
-  
+
+  proc segmentedFullMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+    var repMsg: string;
+    const segStrSize = msgArgs.getValueOf("size"): int;
+    const segStrFillValue = msgArgs.getValueOf("fill_value");
+
+    var (off, val) = segStrFull(segStrSize, segStrFillValue);
+    var retString = getSegString(off, val, st);
+    repMsg = "created " + st.attrib(retString.name) + "+created bytes.size %t".format(retString.nBytes);
+
+    return new MsgTuple(repMsg, MsgType.NORMAL);
+  }
+
   use CommandMap;
   registerFunction("segmentLengths", segmentLengthsMsg, getModuleName());
   registerFunction("caseChange", caseChangeMsg, getModuleName());
@@ -1132,4 +1144,5 @@ module SegmentedMsg {
   registerBinaryFunction("segStr-tondarray", segStrTondarrayMsg, getModuleName());
   registerFunction("segmentedSubstring", segmentedSubstringMsg, getModuleName());
   registerFunction("segmentedWhere", segmentedWhereMsg, getModuleName());
+  registerFunction("segmentedFull", segmentedFullMsg, getModuleName());
 }

--- a/tests/pdarray_creation_test.py
+++ b/tests/pdarray_creation_test.py
@@ -419,6 +419,10 @@ class PdarrayCreationTest(ArkoudaTest):
         string_len_full = ak.full("5", 5)
         self.assertEqual(5, len(string_len_full))
 
+        strings_full = ak.full(5, "test")
+        self.assertIsInstance(strings_full, ak.Strings)
+        self.assertEqual(5, len(strings_full))
+
         with self.assertRaises(TypeError):
             ak.full(5, 1, dtype=ak.uint8)
 


### PR DESCRIPTION
This PR (Closes #2471):
  -  expands the existing ak.full() function to enable the creation of a Strings object of provided size that is filled with provided str
  - adds testing for creation of Strings object via ak.full()