### PR TITLE
Closes #2560 - Fixes Missing empty segments for parquet read of segarray with string values

### DIFF
--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -660,7 +660,7 @@ module ParquetMsg {
       var entrySeg = new shared SymEntry((+ reduce listSizes), int);
       var byteSizes = calcStrSizesAndOffset(entrySeg.a, filenames, listSizes, dsetname);
       entrySeg.a = (+ scan entrySeg.a) - entrySeg.a;
-
+      
       var entryVal = new shared SymEntry((+ reduce byteSizes), uint(8));
       readListFilesByName(entryVal.a, sizes, seg_sizes, segments, filenames, byteSizes, dsetname, ty);
       var stringsEntry = assembleSegStringFromParts(entrySeg, entryVal, st);

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -526,6 +526,14 @@ class ParquetTest(ArkoudaTest):
             self.assertListEqual(x.values.to_list(), rd.values.to_list())
             self.assertListEqual(x.to_list(), rd.to_list())
 
+        # additional testing for empty segments. See Issue #2560
+        a, b, c = ["one", "two", "three"], ["un", "deux", "trois"], ["uno", "dos", "tres"]
+        s = ak.SegArray(ak.array([0, 0, len(a), len(a), len(a), len(a) + len(c)]), ak.array(a + c))
+        with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
+            s.to_parquet(f"{tmp_dirname}/segarray_test_empty")
+            rd_data = ak.read_parquet(f"{tmp_dirname}/segarray_test_empty_*")
+            self.assertListEqual(s.to_list(), rd_data.to_list())
+
     @pytest.mark.optional_parquet
     def test_against_standard_files(self):
         datadir = "resources/parquet-testing"


### PR DESCRIPTION
Closes #2560 

This issue resulted from the Strings case within SegArray's write workflow not properly handling empty segments. Thus, it only wrote segments with `length>0`. I added the check for 0 length segments and handling to write the empty segment into the Parquet file.

I also added a test using the example provided in the issue to ensure functionality.