### PR TITLE
Closes #2561: Add casting directly from bool to bigint

### DIFF
--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -8,7 +8,6 @@ module BinOp
   use Logging;
   use Message;
   use BitOps;
-  use BigInteger;
 
   use ArkoudaBigIntCompat;
 
@@ -1176,7 +1175,7 @@ module BinOp
     }
     ref la = l.a;
     ref ra = r.a;
-    var tmp = if l.etype == bigint then la else if l.etype == bool then la:int:bigint else la:bigint;
+    var tmp = if l.etype == bigint then la else la:bigint;
     // these cases are not mutually exclusive,
     // so we have a flag to track if tmp is ever populated
     var visted = false;
@@ -1422,7 +1421,7 @@ module BinOp
       max_size -= 1;
     }
     ref la = l.a;
-    var tmp = if l.etype == bigint then la else if l.etype == bool then la:int:bigint else la:bigint;
+    var tmp = if l.etype == bigint then la else la:bigint;
     // these cases are not mutually exclusive,
     // so we have a flag to track if tmp is ever populated
     var visted = false;
@@ -1682,8 +1681,7 @@ module BinOp
     }
     ref ra = r.a;
     var tmp = makeDistArray(ra.size, bigint);
-    // TODO we have to cast to bigint until chape issue #21290 is resolved, see issue #2007
-    tmp = if val.type == bool then val:int:bigint else val:bigint;
+    tmp = val:bigint;
     // these cases are not mutually exclusive,
     // so we have a flag to track if tmp is ever populated
     var visted = false;

--- a/src/Cast.chpl
+++ b/src/Cast.chpl
@@ -7,7 +7,8 @@ module Cast {
   use Logging;
   use CommAggregation;
   use ServerConfig;
-  use BigInteger;
+
+  use ArkoudaBigIntCompat;
   
   private config const logLevel = ServerConfig.logLevel;
   const castLogger = new Logger(logLevel);
@@ -36,12 +37,8 @@ module Cast {
     const name = st.nextName();
     var tmp = makeDistArray(before.size, bigint);
     try {
-      // TODO change once we can cast directly from bool to bigint
       if fromType == bigint {
         tmp = before.a;
-      }
-      else if fromType == bool {
-        tmp = before.a:int:bigint;
       }
       else {
         tmp = before.a:bigint;

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -12,11 +12,11 @@ module IndexingMsg
     use MultiTypeSymbolTable;
 
     use CommAggregation;
-    use BigInteger;
 
     use FileIO;
     use List;
 
+    use ArkoudaBigIntCompat;
     use ArkoudaMapCompat;
     use ArkoudaFileCompat;
     use ArkoudaBigIntCompat;
@@ -637,8 +637,7 @@ module IndexingMsg
              }
             when (DType.BigInt, DType.Bool) {
                 var e = toSymEntry(gEnt,bigint);
-                // TODO change once we can cast directly from bool to bigint
-                var val = valueArg.getBoolValue():int:bigint;
+                var val = valueArg.getBoolValue():bigint;
                 if e.max_bits != -1 {
                   mod(val, val, e.max_bits);
                 }
@@ -867,7 +866,7 @@ module IndexingMsg
             if gX.dtype == DType.BigInt {
                 var e = toSymEntry(gX, bigint);
                 // NOTE y.etype will never be real when gX.dtype is bigint, but the compiler doesn't know that
-                var tmp = if y.etype == bigint then ya else if (y.etype == bool || y.etype == real) then ya:int:bigint else ya:bigint;
+                var tmp = if y.etype == bigint then ya else if y.etype == real then ya:int:bigint else ya:bigint;
                 ref ea = e.a;
                 forall (i,v) in zip(iva,tmp) with (var agg = newDstAggregator(bigint)) {
                     agg.copy(ea[i],v);
@@ -912,7 +911,7 @@ module IndexingMsg
             if gX.dtype == DType.BigInt {
                 var e = toSymEntry(gX, bigint);
                 // NOTE y.etype will never be real when gX.dtype is bigint, but the compiler doesn't know that
-                var tmp = if y.etype == bigint then ya else if (y.etype == bool || y.etype == real) then ya:int:bigint else ya:bigint;
+                var tmp = if y.etype == bigint then ya else if y.etype == real then ya:int:bigint else ya:bigint;
                 ref ea = e.a;
                 forall (i,v) in zip(iva,tmp) with (var agg = newDstAggregator(bigint)) {
                     agg.copy(ea[i:int],v);
@@ -956,7 +955,7 @@ module IndexingMsg
             if gX.dtype == DType.BigInt {
                 var e = toSymEntry(gX, bigint);
                 // NOTE y.etype will never be real when gX.dtype is bigint, but the compiler doesn't know that
-                var tmp = if y.etype == bigint then ya else if (y.etype == bool || y.etype == real) then ya:int:bigint else ya:bigint;
+                var tmp = if y.etype == bigint then ya else if y.etype == real then ya:int:bigint else ya:bigint;
                 ref ea = e.a;
                 const ref ead = ea.domain;
                 forall (eai, i) in zip(ea, ead) with (var agg = newSrcAggregator(bigint)) {
@@ -1180,8 +1179,7 @@ module IndexingMsg
              }
             when (DType.BigInt, DType.Bool) {
                 var e = toSymEntry(gEnt,bigint);
-                // TODO change once we can cast directly from bool to bigint
-                var val = value.getBoolValue():int:bigint;
+                var val = value.getBoolValue():bigint;
                 if e.max_bits != -1 {
                   mod(val, val, e.max_bits);
                 }

--- a/src/MsgProcessing.chpl
+++ b/src/MsgProcessing.chpl
@@ -3,20 +3,21 @@ module MsgProcessing
 {
     use ServerConfig;
 
-    use ArkoudaTimeCompat as Time;
     use Math only;
     use Reflection;
     use ServerErrors;
     use Logging;
     use Message;
-    use BigInteger;
     
     use MultiTypeSymbolTable;
     use MultiTypeSymEntry;
     use ServerErrorStrings;
 
     use AryUtil;
-    
+
+    use ArkoudaBigIntCompat;
+    use ArkoudaTimeCompat as Time;
+
     private config const logLevel = ServerConfig.logLevel;
     private config const logChannel = ServerConfig.logChannel;
     const mpLogger = new Logger(logLevel, logChannel);
@@ -398,9 +399,7 @@ module MsgProcessing
             when (DType.BigInt, DType.Bool) {
                 var e = toSymEntry(gEnt,bigint);
                 var val: bool = value.getBoolValue();
-                // can't cast from a bool to a bigint, so first cast to int
-                // TODO update once that functionality is available
-                e.a = val:int:bigint;
+                e.a = val:bigint;
                 repMsg = "set %s to %t".format(name, val);
             }
             otherwise {

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -3,7 +3,6 @@ module OperatorMsg
 {
     use ServerConfig;
 
-    use ArkoudaTimeCompat as Time;
     use Math;
     use BitOps;
     use Reflection;
@@ -18,6 +17,7 @@ module OperatorMsg
     use Logging;
     use Message;
 
+    use ArkoudaTimeCompat as Time;
     use ArkoudaBigIntCompat;
     
     private config const logLevel = ServerConfig.logLevel;
@@ -1476,8 +1476,7 @@ module OperatorMsg
                 var l = toSymEntry(left,bigint);
                 var r = toSymEntry(right,bool);
                 ref la = l.a;
-                // TODO change once we can cast directly from bool to bigint
-                var ra = r.a:int:bigint;
+                var ra = r.a:bigint;
                 var max_bits = l.max_bits;
                 var max_size = 1:bigint;
                 var has_max_bits = max_bits != -1;

--- a/src/compat/e-129/ArkoudaBigIntCompat.chpl
+++ b/src/compat/e-129/ArkoudaBigIntCompat.chpl
@@ -1,5 +1,9 @@
 module ArkoudaBigIntCompat {
-  use BigInteger;
+  public use BigInteger;
+
+  inline operator bigint.:(src: bool, type toType: bigint): bigint throws {
+    return new bigint(src:int);
+  }
 
   proc mod(ref result: bigint, const ref a: bigint, const ref b: bigint) {
     result.mod(a, b);

--- a/src/compat/e-130/ArkoudaBigIntCompat.chpl
+++ b/src/compat/e-130/ArkoudaBigIntCompat.chpl
@@ -1,5 +1,9 @@
 module ArkoudaBigIntCompat {
-  use BigInteger;
+  public use BigInteger;
+
+  inline operator bigint.:(src: bool, type toType: bigint): bigint throws {
+    return new bigint(src:int);
+  }
 
   proc mod(ref result: bigint, const ref a: bigint, const ref b: bigint) {
     result.mod(a, b);

--- a/src/compat/gt-130/ArkoudaBigIntCompat.chpl
+++ b/src/compat/gt-130/ArkoudaBigIntCompat.chpl
@@ -1,5 +1,9 @@
 module ArkoudaBigIntCompat {
-  use BigInteger;
+  public use BigInteger;
+
+  inline operator bigint.:(src: bool, type toType: bigint): bigint throws {
+    return new bigint(src:int);
+  }
 
   proc rightShift(const ref a: bigint, b: int): bigint {
     return a >> b;


### PR DESCRIPTION
This PR (closes #2561) adds the code to cast directly from bool to bigint to the compat modules. The only place I was able to make this change is in the class private variables in [`OperatorMsg`](https://github.com/Bears-R-Us/arkouda/blob/0eb300869728f1cc272cbdc4838b69f330a77152/src/OperatorMsg.chpl#L2045-L2061) (trying to change these cause me to have an internal compilation error)