### PR TITLE
Closes #2559 - `dataframe_test.py` conversion for new framework 

### DIFF
--- a/PROTO_tests/tests/dataframe_test.py
+++ b/PROTO_tests/tests/dataframe_test.py
@@ -1,13 +1,12 @@
-import arkouda as ak
-import pandas as pd
-from pandas.testing import assert_frame_equal, assert_series_equal
-import numpy as np
-import pytest
-import random
-import string
-import tempfile
-import glob
 import os
+import tempfile
+
+import numpy as np
+import pandas as pd
+import pytest
+from pandas.testing import assert_frame_equal, assert_series_equal
+
+import arkouda as ak
 from arkouda import io_util
 
 
@@ -22,9 +21,16 @@ class TestDataFrame:
         item = ak.array([0, 0, 1, 1, 2, 0])
         day = ak.array([5, 5, 6, 5, 6, 6])
         amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
-        bi = ak.arange(2 ** 200, 2 ** 200 + 6)
+        bi = ak.arange(2**200, 2**200 + 6)
         return ak.DataFrame(
-            {"userName": username, "userID": userid, "item": item, "day": day, "amount": amount, "bi": bi}
+            {
+                "userName": username,
+                "userID": userid,
+                "item": item,
+                "day": day,
+                "amount": amount,
+                "bi": bi,
+            }
         )
 
     @staticmethod
@@ -34,9 +40,16 @@ class TestDataFrame:
         item = [0, 0, 1, 1, 2, 0]
         day = [5, 5, 6, 5, 6, 6]
         amount = [0.5, 0.6, 1.1, 1.2, 4.3, 0.6]
-        bi = [2 ** 200, 2 ** 200 + 1, 2 ** 200 + 2, 2 ** 200 + 3, 2 ** 200 + 4, 2 ** 200 + 5]
+        bi = [2**200, 2**200 + 1, 2**200 + 2, 2**200 + 3, 2**200 + 4, 2**200 + 5]
         return pd.DataFrame(
-            {"userName": username, "userID": userid, "item": item, "day": day, "amount": amount, "bi": bi}
+            {
+                "userName": username,
+                "userID": userid,
+                "item": item,
+                "day": day,
+                "amount": amount,
+                "bi": bi,
+            }
         )
 
     @staticmethod
@@ -62,9 +75,16 @@ class TestDataFrame:
         item = ak.array([0, 2])
         day = ak.array([1, 2])
         amount = ak.array([0.5, 5.1])
-        bi = ak.array([2 ** 200 + 6, 2 ** 200 + 7])
+        bi = ak.array([2**200 + 6, 2**200 + 7])
         return ak.DataFrame(
-            {"userName": username, "userID": userid, "item": item, "day": day, "amount": amount, "bi": bi}
+            {
+                "userName": username,
+                "userID": userid,
+                "item": item,
+                "day": day,
+                "amount": amount,
+                "bi": bi,
+            }
         )
 
     @staticmethod
@@ -75,17 +95,24 @@ class TestDataFrame:
         day = [5, 5, 6, 5, 6, 6, 1, 2]
         amount = [0.5, 0.6, 1.1, 1.2, 4.3, 0.6, 0.5, 5.1]
         bi = [
-            2 ** 200,
-            2 ** 200 + 1,
-            2 ** 200 + 2,
-            2 ** 200 + 3,
-            2 ** 200 + 4,
-            2 ** 200 + 5,
-            2 ** 200 + 6,
-            2 ** 200 + 7,
+            2**200,
+            2**200 + 1,
+            2**200 + 2,
+            2**200 + 3,
+            2**200 + 4,
+            2**200 + 5,
+            2**200 + 6,
+            2**200 + 7,
         ]
         return pd.DataFrame(
-            {"userName": username, "userID": userid, "item": item, "day": day, "amount": amount, "bi": bi}
+            {
+                "userName": username,
+                "userID": userid,
+                "item": item,
+                "day": day,
+                "amount": amount,
+                "bi": bi,
+            }
         )
 
     @staticmethod
@@ -101,9 +128,16 @@ class TestDataFrame:
         item = ak.array([0, 0, 1, 1, 2, 0])
         day = ak.array([5, 5, 6, 5, 6, 6])
         amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
-        bi = ak.arange(2 ** 200, 2 ** 200 + 6)
+        bi = ak.arange(2**200, 2**200 + 6)
         return ak.DataFrame(
-            {"userName": username, "userID": userid, "item": item, "day": day, "amount": amount, "bi": bi}
+            {
+                "userName": username,
+                "userID": userid,
+                "item": item,
+                "day": day,
+                "amount": amount,
+                "bi": bi,
+            }
         )
 
     @pytest.mark.parametrize("size", pytest.prob_size)
@@ -114,26 +148,30 @@ class TestDataFrame:
         assert df.empty
 
         # Validation of Creation from Pandas
-        pddf = pd.DataFrame({
-            "int": np.arange(size),
-            "uint": np.random.randint(0, size/2, size, dtype=np.uint64),
-            "bigint": np.arange(2**200, 2**200+size),
-            "bool": np.random.randint(0, 1, size=size, dtype=bool),
-            "segarray": [np.random.randint(0, size / 2, 2) for i in range(size)]
-        })
+        pddf = pd.DataFrame(
+            {
+                "int": np.arange(size),
+                "uint": np.random.randint(0, size / 2, size, dtype=np.uint64),
+                "bigint": np.arange(2**200, 2**200 + size),
+                "bool": np.random.randint(0, 1, size=size, dtype=bool),
+                "segarray": [np.random.randint(0, size / 2, 2) for i in range(size)],
+            }
+        )
         akdf = ak.DataFrame(pddf)
         assert isinstance(akdf, ak.DataFrame)
         assert len(akdf) == size
         assert_frame_equal(pddf, akdf.to_pandas())
 
         # validation of creation from dictionary
-        akdf = ak.DataFrame({
-            "int": ak.arange(size),
-            "uint": ak.array(pddf["uint"]),
-            "bigint": ak.arange(2 ** 200, 2 ** 200 + size),
-            "bool": ak.array(pddf["bool"]),
-            "segarray": ak.SegArray.from_multi_array([ak.array(x) for x in pddf["segarray"]])
-        })
+        akdf = ak.DataFrame(
+            {
+                "int": ak.arange(size),
+                "uint": ak.array(pddf["uint"]),
+                "bigint": ak.arange(2**200, 2**200 + size),
+                "bool": ak.array(pddf["bool"]),
+                "segarray": ak.SegArray.from_multi_array([ak.array(x) for x in pddf["segarray"]]),
+            }
+        )
         assert isinstance(akdf, ak.DataFrame)
         assert len(akdf) == size
 
@@ -146,8 +184,8 @@ class TestDataFrame:
             np.random.randint(5, 10, size),
         ]
         pddf = pd.DataFrame(x)
-        l = [ak.array(val) for val in list(zip(x[0], x[1], x[2]))]
-        akdf = ak.DataFrame(l)
+        l_cols = [ak.array(val) for val in list(zip(x[0], x[1], x[2]))]
+        akdf = ak.DataFrame(l_cols)
         assert isinstance(akdf, ak.DataFrame)
         assert len(akdf) == len(pddf)
         # arkouda does not allow for numeric columns.
@@ -195,7 +233,11 @@ class TestDataFrame:
         assert df.index.to_list() == ref_df.index.to_list()
 
         # column validation [] and . access
-        for cname, col, ref_col in zip(df.columns, [df.userName, df.userID, df.item, df.day, df.amount, df.bi], [ref_df.userName, ref_df.userID, ref_df.item, ref_df.day, ref_df.amount, ref_df.bi]):
+        for cname, col, ref_col in zip(
+            df.columns,
+            [df.userName, df.userID, df.item, df.day, df.amount, df.bi],
+            [ref_df.userName, ref_df.userID, ref_df.item, ref_df.day, ref_df.amount, ref_df.bi],
+        ):
             assert isinstance(col, ak.Series)
             assert col.to_list() == ref_col.to_list()
             assert isinstance(df[cname], (ak.pdarray, ak.Strings, ak.Categorical))
@@ -227,7 +269,9 @@ class TestDataFrame:
         assert len(akdf.columns) == len(akdf.dtypes)
         # dtypes returns objType for categorical, segarray. We should probably fix
         # this and add a df.objTypes property. pdarrays return actual dtype
-        for ref_type, c in zip(["int64", "int64", "int64", "str", "Categorical", "SegArray", "bigint"], akdf.columns):
+        for ref_type, c in zip(
+            ["int64", "int64", "int64", "str", "Categorical", "SegArray", "bigint"], akdf.columns
+        ):
             assert ref_type == str(akdf.dtypes[c])
 
     def test_from_pandas(self):
@@ -608,7 +652,8 @@ class TestDataFrame:
 
         bool_idx = df[df["cnt"] > 3]
         bool_idx.__repr__()
-        # the new index is first False and rest True (because we lose first 4), so equivalent to arange(61, bool)
+        # the new index is first False and rest True (because we lose first 4),
+        # so equivalent to arange(61, bool)
         assert bool_idx.index.index.to_list() == ak.arange(61, dtype=bool).to_list()
 
         slice_idx = df[:]
@@ -617,55 +662,43 @@ class TestDataFrame:
 
     def test_ipv4_columns(self):
         # test with single IPv4 column
-        df = ak.DataFrame({
-            'a': ak.arange(10),
-            'b': ak.IPv4(ak.arange(10))
-        })
-        with tempfile.TemporaryDirectory(dir=TestDataFrame.df_test_base_tmp) as tmp_dirname:
-            fname = tmp_dirname + "/ipv4_df"
-            df.to_parquet(fname)
-
-            data = ak.read(fname+"*")
-            rddf = ak.DataFrame({
-                'a': data['a'],
-                'b': ak.IPv4(data['b'])
-            })
-
-            assert_frame_equal(df.to_pandas(), rddf.to_pandas())
-
-        # test with multiple
-        df = ak.DataFrame({
-            'a': ak.IPv4(ak.arange(10)),
-            'b': ak.IPv4(ak.arange(10))
-        })
+        df = ak.DataFrame({"a": ak.arange(10), "b": ak.IPv4(ak.arange(10))})
         with tempfile.TemporaryDirectory(dir=TestDataFrame.df_test_base_tmp) as tmp_dirname:
             fname = tmp_dirname + "/ipv4_df"
             df.to_parquet(fname)
 
             data = ak.read(fname + "*")
-            rddf = ak.DataFrame({
-                'a': ak.IPv4(data['a']),
-                'b': ak.IPv4(data['b'])
-            })
+            rddf = ak.DataFrame({"a": data["a"], "b": ak.IPv4(data["b"])})
+
+            assert_frame_equal(df.to_pandas(), rddf.to_pandas())
+
+        # test with multiple
+        df = ak.DataFrame({"a": ak.IPv4(ak.arange(10)), "b": ak.IPv4(ak.arange(10))})
+        with tempfile.TemporaryDirectory(dir=TestDataFrame.df_test_base_tmp) as tmp_dirname:
+            fname = tmp_dirname + "/ipv4_df"
+            df.to_parquet(fname)
+
+            data = ak.read(fname + "*")
+            rddf = ak.DataFrame({"a": ak.IPv4(data["a"]), "b": ak.IPv4(data["b"])})
 
             assert_frame_equal(df.to_pandas(), rddf.to_pandas())
 
         # test replacement of IPv4 with uint representation
-        df = ak.DataFrame({
-            'a': ak.IPv4(ak.arange(10))
-        })
-        df['a'] = df['a'].export_uint()
-        assert ak.arange(10).to_list() == df['a'].to_list()
+        df = ak.DataFrame({"a": ak.IPv4(ak.arange(10))})
+        df["a"] = df["a"].export_uint()
+        assert ak.arange(10).to_list() == df["a"].to_list()
 
     def test_subset(self):
-        df = ak.DataFrame({
-            'a': ak.arange(100),
-            'b': ak.randint(0, 20, 100),
-            'c': ak.random_strings_uniform(0, 16, 100),
-            'd': ak.randint(25, 75, 100)
-        })
-        df2 = df[['a', 'b']]
-        assert ['a', 'b'] == df2.columns
+        df = ak.DataFrame(
+            {
+                "a": ak.arange(100),
+                "b": ak.randint(0, 20, 100),
+                "c": ak.random_strings_uniform(0, 16, 100),
+                "d": ak.randint(25, 75, 100),
+            }
+        )
+        df2 = df[["a", "b"]]
+        assert ["a", "b"] == df2.columns
         assert df.index.to_list() == df2.index.to_list()
-        assert df['a'].to_list() == df2['a'].to_list()
-        assert df['b'].to_list() == df2['b'].to_list()
+        assert df["a"].to_list() == df2["a"].to_list()
+        assert df["b"].to_list() == df2["b"].to_list()

--- a/PROTO_tests/tests/dataframe_test.py
+++ b/PROTO_tests/tests/dataframe_test.py
@@ -1,0 +1,716 @@
+import arkouda as ak
+import pandas as pd
+import numpy as np
+import pytest
+import random
+import string
+import tempfile
+import glob
+import os
+from arkouda import io_util
+
+
+class TestDataFrame:
+    df_test_base_tmp = "{}/df_test".format(os.getcwd())
+    io_util.get_directory(df_test_base_tmp)
+
+    @staticmethod
+    def build_ak_df():
+        username = ak.array(["Alice", "Bob", "Alice", "Carol", "Bob", "Alice"])
+        userid = ak.array([111, 222, 111, 333, 222, 111])
+        item = ak.array([0, 0, 1, 1, 2, 0])
+        day = ak.array([5, 5, 6, 5, 6, 6])
+        amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
+        bi = ak.arange(2 ** 200, 2 ** 200 + 6)
+        return ak.DataFrame(
+            {"userName": username, "userID": userid, "item": item, "day": day, "amount": amount, "bi": bi}
+        )
+
+    @staticmethod
+    def build_pd_df():
+        username = ["Alice", "Bob", "Alice", "Carol", "Bob", "Alice"]
+        userid = [111, 222, 111, 333, 222, 111]
+        item = [0, 0, 1, 1, 2, 0]
+        day = [5, 5, 6, 5, 6, 6]
+        amount = [0.5, 0.6, 1.1, 1.2, 4.3, 0.6]
+        bi = [2 ** 200, 2 ** 200 + 1, 2 ** 200 + 2, 2 ** 200 + 3, 2 ** 200 + 4, 2 ** 200 + 5]
+        return pd.DataFrame(
+            {"userName": username, "userID": userid, "item": item, "day": day, "amount": amount, "bi": bi}
+        )
+
+    @staticmethod
+    def build_ak_df_duplicates():
+        username = ak.array(["Alice", "Bob", "Alice", "Carol", "Bob", "Alice"])
+        userid = ak.array([111, 222, 111, 333, 222, 111])
+        item = ak.array([0, 1, 0, 2, 1, 0])
+        day = ak.array([5, 5, 5, 5, 5, 5])
+        return ak.DataFrame({"userName": username, "userID": userid, "item": item, "day": day})
+
+    @staticmethod
+    def build_pd_df_duplicates():
+        username = ["Alice", "Bob", "Alice", "Carol", "Bob", "Alice"]
+        userid = [111, 222, 111, 333, 222, 111]
+        item = [0, 1, 0, 2, 1, 0]
+        day = [5, 5, 5, 5, 5, 5]
+        return pd.DataFrame({"userName": username, "userID": userid, "item": item, "day": day})
+
+    @staticmethod
+    def build_ak_append():
+        username = ak.array(["John", "Carol"])
+        userid = ak.array([444, 333])
+        item = ak.array([0, 2])
+        day = ak.array([1, 2])
+        amount = ak.array([0.5, 5.1])
+        bi = ak.array([2 ** 200 + 6, 2 ** 200 + 7])
+        return ak.DataFrame(
+            {"userName": username, "userID": userid, "item": item, "day": day, "amount": amount, "bi": bi}
+        )
+
+    @staticmethod
+    def build_pd_df_append():
+        username = ["Alice", "Bob", "Alice", "Carol", "Bob", "Alice", "John", "Carol"]
+        userid = [111, 222, 111, 333, 222, 111, 444, 333]
+        item = [0, 0, 1, 1, 2, 0, 0, 2]
+        day = [5, 5, 6, 5, 6, 6, 1, 2]
+        amount = [0.5, 0.6, 1.1, 1.2, 4.3, 0.6, 0.5, 5.1]
+        bi = [
+            2 ** 200,
+            2 ** 200 + 1,
+            2 ** 200 + 2,
+            2 ** 200 + 3,
+            2 ** 200 + 4,
+            2 ** 200 + 5,
+            2 ** 200 + 6,
+            2 ** 200 + 7,
+        ]
+        return pd.DataFrame(
+            {"userName": username, "userID": userid, "item": item, "day": day, "amount": amount, "bi": bi}
+        )
+
+    @staticmethod
+    def build_ak_keyerror():
+        userid = ak.array([444, 333])
+        item = ak.array([0, 2])
+        return ak.DataFrame({"user_id": userid, "item": item})
+
+    @staticmethod
+    def build_ak_typeerror():
+        username = ak.array([111, 222, 111, 333, 222, 111])
+        userid = ak.array(["Alice", "Bob", "Alice", "Carol", "Bob", "Alice"])
+        item = ak.array([0, 0, 1, 1, 2, 0])
+        day = ak.array([5, 5, 6, 5, 6, 6])
+        amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
+        bi = ak.arange(2 ** 200, 2 ** 200 + 6)
+        return ak.DataFrame(
+            {"userName": username, "userID": userid, "item": item, "day": day, "amount": amount, "bi": bi}
+        )
+
+    def test_dataframe_creation(self):
+        # Validate empty DataFrame
+        df = ak.DataFrame()
+        assert isinstance(df, ak.DataFrame)
+        assert df.empty
+
+        df = self.build_ak_df()
+        ref_df = self.build_pd_df()
+        assert isinstance(df, ak.DataFrame)
+        assert len(df) == 6
+        assert ref_df.equals(df.to_pandas())
+
+    def test_client_type_creation(self):
+        f = ak.Fields(ak.arange(10), ["A", "B", "c"])
+        ip = ak.ip_address(ak.arange(10))
+        d = ak.Datetime(ak.arange(10))
+        bv = ak.BitVector(ak.arange(10), width=4)
+
+        df_dict = {"fields": f, "ip": ip, "date": d, "bitvector": bv}
+        df = ak.DataFrame(df_dict)
+        pd_d = [pd.to_datetime(x, unit="ns") for x in d.to_list()]
+        pddf = pd.DataFrame(
+            {"fields": f.to_list(), "ip": ip.to_list(), "date": pd_d, "bitvector": bv.to_list()}
+        )
+        shape = f"({df._shape_str()})".replace("(", "[").replace(")", "]")
+        pd.set_option("display.max_rows", 4)
+        s = df.__repr__().replace(f" ({df._shape_str()})", f"\n\n{shape}")
+        assert s == pddf.__repr__()
+
+        pd.set_option("display.max_rows", 10)
+        pdf = pd.DataFrame({"a": list(range(1000)), "b": list(range(1000))})
+        pdf["a"] = pdf["a"].apply(lambda x: "AA" + str(x))
+        pdf["b"] = pdf["b"].apply(lambda x: "BB" + str(x))
+        df = ak.DataFrame(pdf)
+        shape = f"({df._shape_str()})".replace("(", "[").replace(")", "]")
+        s = df.__repr__().replace(f" ({df._shape_str()})", f"\n\n{shape}")
+        assert s, pdf.__repr__()
+
+    def test_boolean_indexing(self):
+        df = self.build_ak_df()
+        ref_df = self.build_pd_df()
+        row = df[df["userName"] == "Carol"]
+
+        assert len(row) == 1
+        assert ref_df[ref_df["userName"] == "Carol"].equals(row.to_pandas(retain_index=True))
+
+    def test_column_indexing(self):
+        df = self.build_ak_df()
+        assert isinstance(df.userName, ak.Series)
+        assert isinstance(df.userID, ak.Series)
+        assert isinstance(df.item, ak.Series)
+        assert isinstance(df.day, ak.Series)
+        assert isinstance(df.amount, ak.Series)
+        assert isinstance(df.bi, ak.Series)
+        for col in ("userName", "userID", "item", "day", "amount", "bi"):
+            assert isinstance(df[col], (ak.pdarray, ak.Strings, ak.Categorical))
+        assert isinstance(df[["userName", "amount", "bi"]], ak.DataFrame)
+        assert isinstance(df[("userID", "item", "day", "bi")], ak.DataFrame)
+        assert isinstance(df.index, ak.Index)
+
+    def test_dtype_prop(self):
+        str_arr = ak.array(
+            ["".join(random.choices(string.ascii_letters + string.digits, k=5)) for _ in range(3)]
+        )
+        df_dict = {
+            "i": ak.arange(3),
+            "c_1": ak.arange(3, 6, 1),
+            "c_2": ak.arange(6, 9, 1),
+            "c_3": str_arr,
+            "c_4": ak.Categorical(str_arr),
+            "c_5": ak.SegArray(ak.array([0, 9, 14]), ak.arange(20)),
+            "c_6": ak.arange(2**200, 2**200 + 3),
+        }
+        akdf = ak.DataFrame(df_dict)
+        assert len(akdf.columns) == len(akdf.dtypes)
+
+    def test_from_pandas(self):
+        username = ["Alice", "Bob", "Alice", "Carol", "Bob", "Alice", "John", "Carol"]
+        userid = [111, 222, 111, 333, 222, 111, 444, 333]
+        item = [0, 0, 1, 1, 2, 0, 0, 2]
+        day = [5, 5, 6, 5, 6, 6, 1, 2]
+        amount = [0.5, 0.6, 1.1, 1.2, 4.3, 0.6, 0.5, 5.1]
+        bi = 2**200
+        bi_arr = [bi, bi + 1, bi + 2, bi + 3, bi + 4, bi + 5, bi + 6, bi + 7]
+        ref_df = pd.DataFrame(
+            {
+                "userName": username,
+                "userID": userid,
+                "item": item,
+                "day": day,
+                "amount": amount,
+                "bi": bi_arr,
+            }
+        )
+
+        df = ak.DataFrame(ref_df)
+
+        assert ((ref_df == df.to_pandas()).all()).all()
+
+        df = ak.DataFrame.from_pandas(ref_df)
+        assert ((ref_df == df.to_pandas()).all()).all()
+
+    def test_drop(self):
+        # create an arkouda df.
+        df = self.build_ak_df()
+        # create pandas df to validate functionality against
+        pd_df = self.build_pd_df()
+
+        # test out of place drop
+        df_drop = df.drop([0, 1, 2])
+        pddf_drop = pd_df.drop(labels=[0, 1, 2])
+        pddf_drop.reset_index(drop=True, inplace=True)
+        assert pddf_drop.equals(df_drop.to_pandas())
+
+        df_drop = df.drop("userName", axis=1)
+        pddf_drop = pd_df.drop(labels=["userName"], axis=1)
+        assert pddf_drop.equals(df_drop.to_pandas())
+
+        # Test dropping columns
+        df.drop("userName", axis=1, inplace=True)
+        pd_df.drop(labels=["userName"], axis=1, inplace=True)
+
+        assert ((df.to_pandas() == pd_df).all()).all()
+
+        # Test dropping rows
+        df.drop([0, 2, 5], inplace=True)
+        # pandas retains original indexes when dropping rows, need to reset to line up with arkouda
+        pd_df.drop(labels=[0, 2, 5], inplace=True)
+        pd_df.reset_index(drop=True, inplace=True)
+
+        assert pd_df.equals(df.to_pandas())
+
+        # verify that index keys must be ints
+        with pytest.raises(TypeError):
+            df.drop("index")
+
+        # verify axis can only be 0 or 1
+        with pytest.raises(ValueError):
+            df.drop("amount", 15)
+
+    def test_drop_duplicates(self):
+        df = self.build_ak_df_duplicates()
+        ref_df = self.build_pd_df_duplicates()
+
+        dedup = df.drop_duplicates()
+        dedup_pd = ref_df.drop_duplicates()
+        # pandas retains original indexes when dropping dups, need to reset to line up with arkouda
+        dedup_pd.reset_index(drop=True, inplace=True)
+
+        dedup_test = dedup.to_pandas().sort_values("userName").reset_index(drop=True)
+        dedup_pd_test = dedup_pd.sort_values("userName").reset_index(drop=True)
+
+        assert dedup_test.equals(dedup_pd_test)
+
+    def test_shape(self):
+        df = self.build_ak_df()
+
+        row, col = df.shape
+        assert row == 6
+        assert col == 6
+
+    def test_reset_index(self):
+        df = self.build_ak_df()
+
+        slice_df = df[ak.array([1, 3, 5])]
+        assert slice_df.index.to_list() == [1, 3, 5]
+
+        df_reset = slice_df.reset_index()
+        assert df_reset.index.to_list() == [0, 1, 2]
+        assert slice_df.index.to_list(), [1, 3, 5]
+
+        slice_df.reset_index(inplace=True)
+        assert slice_df.index.to_list(), [0, 1, 2]
+
+    def test_rename(self):
+        df = self.build_ak_df()
+
+        rename = {"userName": "name_col", "userID": "user_id"}
+
+        # Test out of Place - column
+        df_rename = df.rename(rename, axis=1)
+        assert "user_id" in df_rename.columns
+        assert "name_col" in df_rename.columns
+        assert "userName" not in df_rename.columns
+        assert "userID" not in df_rename.columns
+        assert "userID" in df.columns
+        assert "userName" in df.columns
+        assert "user_id" not in df.columns
+        assert "name_col" not in df.columns
+
+        # Test in place - column
+        df.rename(column=rename, inplace=True)
+        assert "user_id" in df.columns
+        assert "name_col" in df.columns
+        assert "userName" not in df.columns
+        assert "userID" not in df.columns
+
+        # prep for index renaming
+        rename_idx = {1: 17, 2: 93}
+        conf = list(range(6))
+        conf[1] = 17
+        conf[2] = 93
+
+        # Test out of Place - index
+        df_rename = df.rename(rename_idx)
+        assert df_rename.index.values.to_list() == conf
+        assert df.index.values.to_list() == list(range(6))
+
+        # Test in place - index
+        df.rename(index=rename_idx, inplace=True)
+        assert df.index.values.to_list() == conf
+
+    def test_append(self):
+        df = self.build_ak_df()
+        df_toappend = self.build_ak_append()
+
+        df.append(df_toappend)
+
+        ref_df = self.build_pd_df_append()
+
+        # dataframe equality returns series with bool result for each row.
+        assert ref_df.equals(df.to_pandas())
+
+        idx = np.arange(8)
+        assert idx.tolist() == df.index.index.to_list()
+
+        df_keyerror = self.build_ak_keyerror()
+        with pytest.raises(KeyError):
+            df.append(df_keyerror)
+
+        df_typeerror = self.build_ak_typeerror()
+        with pytest.raises(TypeError):
+            df.append(df_typeerror)
+
+    def test_concat(self):
+        df = self.build_ak_df()
+        df_toappend = self.build_ak_append()
+
+        glued = ak.DataFrame.concat([df, df_toappend])
+
+        ref_df = self.build_pd_df_append()
+
+        # dataframe equality returns series with bool result for each row.
+        assert ref_df.equals(glued.to_pandas())
+
+        df_keyerror = self.build_ak_keyerror()
+        with pytest.raises(KeyError):
+            ak.DataFrame.concat([df, df_keyerror])
+
+        df_typeerror = self.build_ak_typeerror()
+        with pytest.raises(TypeError):
+            ak.DataFrame.concat([df, df_typeerror])
+
+    def test_head(self):
+        df = self.build_ak_df()
+        ref_df = self.build_pd_df()
+
+        hdf = df.head(3)
+        hdf_ref = ref_df.head(3).reset_index(drop=True)
+        assert hdf_ref.equals(hdf.to_pandas())
+
+    def test_tail(self):
+        df = self.build_ak_df()
+        ref_df = self.build_pd_df()
+
+        hdf = df.tail(2)
+        hdf_ref = ref_df.tail(2).reset_index(drop=True)
+        assert hdf_ref.equals(hdf.to_pandas())
+
+    def test_groupby_standard(self):
+        df = self.build_ak_df()
+        gb = df.GroupBy("userName")
+        keys, count = gb.count()
+        assert keys.to_list() == ["Bob", "Alice", "Carol"]
+        assert count.to_list() == [2, 3, 1]
+        assert gb.permutation.to_list() == [1, 4, 0, 2, 5, 3]
+
+        gb = df.GroupBy(["userName", "userID"])
+        keys, count = gb.count()
+        assert len(keys) == 2
+        assert keys[0].to_list() == ["Carol", "Bob", "Alice"]
+        assert keys[1].to_list() == [333, 222, 111]
+        assert count.to_list() == [1, 2, 3]
+
+        # testing counts with IPv4 column
+        s = ak.DataFrame({"a": ak.IPv4(ak.arange(1, 5))}).groupby("a").count()
+        pds = pd.Series(
+            data=np.ones(4, dtype=np.int64),
+            index=pd.Index(data=np.array(["0.0.0.1", "0.0.0.2", "0.0.0.3", "0.0.0.4"], dtype="<U7")),
+        )
+        assert s.to_pandas().equals(other=pds)
+
+        # testing counts with Categorical column
+        s = ak.DataFrame({"a": ak.Categorical(ak.array(["a", "a", "a", "b"]))}).groupby("a").count()
+        pds = pd.Series(data=np.array([3, 1]), index=pd.Index(data=np.array(["a", "b"], dtype="<U7")))
+        assert s.to_pandas().equals(other=pds)
+
+    def test_gb_series(self):
+        username = ak.array(["Alice", "Bob", "Alice", "Carol", "Bob", "Alice"])
+        userid = ak.array([111, 222, 111, 333, 222, 111])
+        item = ak.array([0, 0, 1, 1, 2, 0])
+        day = ak.array([5, 5, 6, 5, 6, 6])
+        amount = ak.array([0.5, 0.6, 1.1, 1.2, 4.3, 0.6])
+        bi = ak.arange(2**200, 2**200 + 6)
+        df = ak.DataFrame(
+            {
+                "userName": username,
+                "userID": userid,
+                "item": item,
+                "day": day,
+                "amount": amount,
+                "bi": bi,
+            }
+        )
+
+        gb = df.GroupBy("userName", use_series=True)
+
+        c = gb.count()
+        assert isinstance(c, ak.Series)
+        assert c.index.to_list() == ["Bob", "Alice", "Carol"]
+        assert c.values.to_list() == [2, 3, 1]
+
+    def test_to_pandas(self):
+        df = self.build_ak_df()
+        pd_df = self.build_pd_df()
+
+        assert pd_df.equals(df.to_pandas())
+
+        slice_df = df[ak.array([1, 3, 5])]
+        pd_df = slice_df.to_pandas(retain_index=True)
+        assert pd_df.index.tolist() == [1, 3, 5]
+
+        pd_df = slice_df.to_pandas()
+        assert pd_df.index.tolist() == [0, 1, 2]
+
+    def test_argsort(self):
+        df = self.build_ak_df()
+
+        p = df.argsort(key="userName")
+        assert p.to_list() == [0, 2, 5, 1, 4, 3]
+
+        p = df.argsort(key="userName", ascending=False)
+        assert p.to_list() == [3, 4, 1, 5, 2, 0]
+
+    def test_coargsort(self):
+        df = self.build_ak_df()
+
+        p = df.coargsort(keys=["userID", "amount"])
+        assert p.to_list() == [0, 5, 2, 1, 4, 3]
+
+        p = df.coargsort(keys=["userID", "amount"], ascending=False)
+        assert p.to_list() == [3, 4, 1, 2, 5, 0]
+
+    def test_sort_values(self):
+        userid = [111, 222, 111, 333, 222, 111]
+        userid_ak = ak.array(userid)
+
+        # sort userid to build dataframes to reference
+        userid.sort()
+
+        df = ak.DataFrame({"userID": userid_ak})
+        ord = df.sort_values()
+        assert ord.to_pandas().equals(pd.DataFrame(data=userid, columns=["userID"]))
+        ord = df.sort_values(ascending=False)
+        userid.reverse()
+        assert ord.to_pandas().equals(pd.DataFrame(data=userid, columns=["userID"]))
+
+        df = self.build_ak_df()
+        ord = df.sort_values(by="userID")
+        ref_df = self.build_pd_df()
+        ref_df = ref_df.sort_values(by="userID").reset_index(drop=True)
+        assert ref_df.equals(ord.to_pandas())
+
+        ord = df.sort_values(by=["userID", "day"])
+        ref_df = ref_df.sort_values(by=["userID", "day"]).reset_index(drop=True)
+        assert ref_df.equals(ord.to_pandas())
+
+        with pytest.raises(TypeError):
+            df.sort_values(by=1)
+
+    def test_intx(self):
+        username = ak.array(["Alice", "Bob", "Alice", "Carol", "Bob", "Alice"])
+        userid = ak.array([111, 222, 111, 333, 222, 111])
+        df_1 = ak.DataFrame({"user_name": username, "user_id": userid})
+
+        username = ak.array(["Bob", "Alice"])
+        userid = ak.array([222, 445])
+        df_2 = ak.DataFrame({"user_name": username, "user_id": userid})
+
+        rows = ak.intx(df_1, df_2)
+        assert rows.to_list() == [False, True, False, False, True, False]
+
+        df_3 = ak.DataFrame({"user_name": username, "user_number": userid})
+        with pytest.raises(ValueError):
+            rows = ak.intx(df_1, df_3)
+
+    def test_apply_perm(self):
+        df = self.build_ak_df()
+        ref_df = self.build_pd_df()
+
+        ord = df.sort_values(by="userID")
+        perm_list = [0, 3, 1, 5, 4, 2]
+        default_perm = ak.array(perm_list)
+        ord.apply_permutation(default_perm)
+
+        ord_ref = ref_df.sort_values(by="userID").reset_index(drop=True)
+        ord_ref = ord_ref.reindex(perm_list).reset_index(drop=True)
+        assert ord_ref.equals(ord.to_pandas())
+
+    def test_filter_by_range(self):
+        userid = ak.array([111, 222, 111, 333, 222, 111])
+        amount = ak.array([0, 1, 1, 2, 3, 15])
+        df = ak.DataFrame({"userID": userid, "amount": amount})
+
+        filtered = df.filter_by_range(keys=["userID"], low=1, high=2)
+        assert filtered.to_list() == [False, True, False, True, True, False]
+
+    def test_copy(self):
+        username = ak.array(["Alice", "Bob", "Alice", "Carol", "Bob", "Alice"])
+        userid = ak.array([111, 222, 111, 333, 222, 111])
+        df = ak.DataFrame({"userName": username, "userID": userid})
+
+        df_copy = df.copy(deep=True)
+        assert df.__repr__() == df_copy.__repr__()
+
+        df_copy.__setitem__("userID", ak.array([1, 2, 1, 3, 2, 1]))
+        assert df.__repr__() != df_copy.__repr__()
+
+        df_copy = df.copy(deep=False)
+        df_copy.__setitem__("userID", ak.array([1, 2, 1, 3, 2, 1]))
+        assert df.__repr__() == df_copy.__repr__()
+
+    # TODO - This should be covered in HDF5 and Parquet testing
+    def test_save(self):
+        i = list(range(3))
+        c1 = [9, 7, 17]
+        c2 = [2, 4, 6]
+        df_dict = {"i": ak.array(i), "c_1": ak.array(c1), "c_2": ak.array(c2)}
+
+        akdf = ak.DataFrame(df_dict)
+
+        validation_df = pd.DataFrame(
+            {
+                "i": i,
+                "c_1": c1,
+                "c_2": c2,
+            }
+        )
+        with tempfile.TemporaryDirectory(dir=self.df_test_base_tmp) as tmp_dirname:
+            akdf.to_parquet(f"{tmp_dirname}/testName")
+
+            ak_loaded = ak.DataFrame.load(f"{tmp_dirname}/testName")
+            assert validation_df.equals(ak_loaded[akdf.columns].to_pandas())
+
+            # test save with index true
+            akdf.to_parquet(f"{tmp_dirname}/testName_with_index.pq", index=True)
+            assert (
+                len(glob.glob(f"{tmp_dirname}/testName_with_index*.pq")) == ak.get_config()["numLocales"]
+            )
+
+            # Test for df having seg array col
+            df = ak.DataFrame({"a": ak.arange(10), "b": ak.SegArray(ak.arange(10), ak.arange(10))})
+            df.to_hdf(f"{tmp_dirname}/seg_test.h5")
+            assert (
+                len(glob.glob(f"{tmp_dirname}/seg_test*.h5")) == ak.get_config()["numLocales"]
+            )
+            ak_loaded = ak.DataFrame.load(f"{tmp_dirname}/seg_test.h5")
+            assert df.to_pandas().equals(ak_loaded.to_pandas())
+
+            # test with segarray with _ in column name
+            df_dict = {
+                "c_1": ak.arange(3, 6),
+                "c_2": ak.arange(6, 9),
+                "c_3": ak.SegArray(ak.array([0, 9, 14]), ak.arange(20)),
+            }
+            akdf = ak.DataFrame(df_dict)
+            akdf.to_hdf(f"{tmp_dirname}/seg_test.h5")
+            assert (
+                len(glob.glob(f"{tmp_dirname}/seg_test*.h5")) == ak.get_config()["numLocales"]
+            )
+            ak_loaded = ak.DataFrame.load(f"{tmp_dirname}/seg_test.h5")
+            assert akdf.to_pandas().equals(ak_loaded.to_pandas())
+
+            # test load_all and read workflows
+            ak_load_all = ak.DataFrame(ak.load_all(f"{tmp_dirname}/seg_test.h5"))
+            assert akdf.to_pandas().equals(ak_load_all.to_pandas())
+
+            ak_read = ak.DataFrame(ak.read(f"{tmp_dirname}/seg_test*"))
+            assert akdf.to_pandas().equals(ak_read.to_pandas())
+
+    def test_isin(self):
+        df = ak.DataFrame({"col_A": ak.array([7, 3]), "col_B": ak.array([1, 9])})
+
+        # test against pdarray
+        test_df = df.isin(ak.array([0, 1]))
+        assert test_df["col_A"].to_list() == [False, False]
+        assert test_df["col_B"].to_list() == [True, False]
+
+        # Test against dict
+        test_df = df.isin({"col_A": ak.array([0, 3])})
+        assert test_df["col_A"].to_list() == [False, True]
+        assert test_df["col_B"].to_list() == [False, False]
+
+        # test against series
+        i = ak.Index(ak.arange(2))
+        s = ak.Series(data=ak.array([3, 9]), index=i.index)
+        test_df = df.isin(s)
+        assert test_df["col_A"].to_list() == [False, False]
+        assert test_df["col_B"].to_list() == [False, True]
+
+        # test against another dataframe
+        other_df = ak.DataFrame({"col_A": ak.array([7, 3], dtype=ak.bigint), "col_C": ak.array([0, 9])})
+        test_df = df.isin(other_df)
+        assert test_df["col_A"].to_list() == [True, True]
+        assert test_df["col_B"].to_list() == [False, False]
+
+    def test_multiindex_compat(self):
+        # Added for testing Issue #1505
+        df = ak.DataFrame({"a": ak.arange(10), "b": ak.arange(10), "c": ak.arange(10)})
+        df.groupby(["a", "b"]).sum("c")
+
+    def test_uint_greediness(self):
+        # default to uint when all supportedInt and any value > 2**63
+        # to avoid loss of precision see (#1983)
+        df = pd.DataFrame({"Test": [2**64 - 1, 0]})
+        assert df["Test"].dtype == ak.uint64
+
+    def test_head_tail_resetting_index(self):
+        # Test that issue #2183 is resolved
+        df = ak.DataFrame({"cnt": ak.arange(65)})
+        # Note we have to call __repr__ to trigger head_tail_server call
+
+        bool_idx = df[df["cnt"] > 3]
+        bool_idx.__repr__()
+        assert bool_idx.index.index.to_list() == list(range(4, 65))
+
+        slice_idx = df[:]
+        slice_idx.__repr__()
+        assert slice_idx.index.index.to_list() == list(range(65))
+
+        # verify it persists non-int Index
+        idx = ak.concatenate([ak.zeros(5, bool), ak.ones(60, bool)])
+        df = ak.DataFrame({"cnt": ak.arange(65)}, index=idx)
+
+        bool_idx = df[df["cnt"] > 3]
+        bool_idx.__repr__()
+        # the new index is first False and rest True (because we lose first 4), so equivalent to arange(61, bool)
+        assert bool_idx.index.index.to_list() == ak.arange(61, dtype=bool).to_list()
+
+        slice_idx = df[:]
+        slice_idx.__repr__()
+        assert slice_idx.index.index.to_list() == idx.to_list()
+
+    def test_ipv4_columns(self):
+        # test with single IPv4 column
+        df = ak.DataFrame({
+            'a': ak.arange(10),
+            'b': ak.IPv4(ak.arange(10))
+        })
+        with tempfile.TemporaryDirectory(dir=TestDataFrame.df_test_base_tmp) as tmp_dirname:
+            fname = tmp_dirname + "/ipv4_df"
+            df.to_parquet(fname)
+
+            data = ak.read(fname+"*")
+            rddf = ak.DataFrame({
+                'a': data['a'],
+                'b': ak.IPv4(data['b'])
+            })
+
+            assert df['a'].to_list() == rddf['a'].to_list()
+            assert df['b'].to_list() == rddf['b'].to_list()
+
+        # test with multiple
+        df = ak.DataFrame({
+            'a': ak.IPv4(ak.arange(10)),
+            'b': ak.IPv4(ak.arange(10))
+        })
+        with tempfile.TemporaryDirectory(dir=TestDataFrame.df_test_base_tmp) as tmp_dirname:
+            fname = tmp_dirname + "/ipv4_df"
+            df.to_parquet(fname)
+
+            data = ak.read(fname + "*")
+            rddf = ak.DataFrame({
+                'a': ak.IPv4(data['a']),
+                'b': ak.IPv4(data['b'])
+            })
+
+            assert df['a'].to_list() == rddf['a'].to_list()
+            assert df['b'].to_list() == rddf['b'].to_list()
+
+        # test replacement of IPv4 with uint representation
+        df = ak.DataFrame({
+            'a': ak.IPv4(ak.arange(10))
+        })
+        df['a'] = df['a'].export_uint()
+        assert ak.arange(10).to_list() == df['a'].to_list()
+
+    def test_subset(self):
+        df = ak.DataFrame({
+            'a': ak.arange(100),
+            'b': ak.randint(0, 20, 100),
+            'c': ak.random_strings_uniform(0, 16, 100),
+            'd': ak.randint(25, 75, 100)
+        })
+        df2 = df[['a', 'b']]
+        assert ['a', 'b'] == df2.columns
+        assert df.index.to_list() == df2.index.to_list()
+        assert df['a'].to_list() == df2['a'].to_list()
+        assert df['b'].to_list() == df2['b'].to_list()

--- a/PROTO_tests/tests/dataframe_test.py
+++ b/PROTO_tests/tests/dataframe_test.py
@@ -11,8 +11,6 @@ from arkouda import io_util
 
 
 class TestDataFrame:
-    df_test_base_tmp = "{}/df_test".format(os.getcwd())
-    io_util.get_directory(df_test_base_tmp)
 
     @staticmethod
     def build_pd_df():

--- a/PROTO_tests/tests/dataframe_test.py
+++ b/PROTO_tests/tests/dataframe_test.py
@@ -1,13 +1,9 @@
-import os
-import tempfile
-
 import numpy as np
 import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal, assert_series_equal
 
 import arkouda as ak
-from arkouda import io_util
 
 
 class TestDataFrame:

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -275,13 +275,11 @@ class DataFrame(UserDict):
             else:
                 self._set_index(index)
             self.data = {}
-            # convert the lists defining each column into a pdarray
-            # pd.DataFrame.values is stored as rows, we need lists to be columns
-            for key, val in initialdata.to_dict("list").items():
+            for key in initialdata.columns:
                 self.data[key] = (
-                    SegArray.from_multi_array([array(r) for r in val])
-                    if isinstance(val[0], list)
-                    else array(val)
+                    SegArray.from_multi_array([array(r) for r in initialdata[key]])
+                    if isinstance(initialdata[key][0], (list, np.ndarray))
+                    else array(initialdata[key])
                 )
 
             self.data.update()

--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -241,7 +241,6 @@ def array(
         else:
             raise TypeError("Must be an iterable or have a numeric DType")
 
-
     # Check if array of strings
     # if a.dtype == numpy.object_ need to check first element
     if "U" in a.dtype.kind or (a.dtype == np.object_ and isinstance(a[0], str)):

--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -229,6 +229,7 @@ def array(
                 a = np.array(a)
         except (RuntimeError, TypeError, ValueError):
             raise TypeError("a must be a pdarray, np.ndarray, or convertible to a numpy array")
+
     # Return multi-dimensional arrayview
     if a.ndim != 1:
         # TODO add order
@@ -239,8 +240,11 @@ def array(
                 return flat_a.reshape(a.shape)
         else:
             raise TypeError("Must be an iterable or have a numeric DType")
+
+
     # Check if array of strings
-    if "U" in a.dtype.kind:
+    # if a.dtype == numpy.object_ need to check first element
+    if "U" in a.dtype.kind or (a.dtype == np.object_ and isinstance(a[0], str)):
         # encode each string and add a null byte terminator
         encoded = [i for i in itertools.chain.from_iterable(map(lambda x: x.encode() + b"\x00", a))]
         nbytes = len(encoded)

--- a/arkouda/series.py
+++ b/arkouda/series.py
@@ -358,6 +358,11 @@ class Series:
         val = convert_if_categorical(self.values)
         return pd.Series(val.to_ndarray(), index=idx)
 
+    @typechecked()
+    def to_list(self) -> list:
+        p = self.to_pandas()
+        return p.to_list()
+
     @typechecked
     def value_counts(self, sort: bool = True) -> Series:
         """Return a Series containing counts of unique values.

--- a/pytest_PROTO.ini
+++ b/pytest_PROTO.ini
@@ -2,7 +2,7 @@
 addopts =
     --benchmark-disable
     --benchmark-skip
-    --size=5
+    --size=100
 filterwarnings =
     ignore:Version mismatch between client .*
 testpaths =

--- a/pytest_PROTO.ini
+++ b/pytest_PROTO.ini
@@ -2,7 +2,7 @@
 addopts =
     --benchmark-disable
     --benchmark-skip
-    --size=100
+    --size=5
 filterwarnings =
     ignore:Version mismatch between client .*
 testpaths =


### PR DESCRIPTION
Closes #2559 

Updates the existing `dataframe_test.py` to function within the new test framework. Specific test for `to_pandas` was removed because this functionality is used in the majority of tests and does not require testing on its own. There is not a lot of parameterization here as I believe the cases we are dealing with are fairly representative. We may want to add additional general case testing in the future, but should not be required here.

This PR also adds a `to_list` method to `ak.Series` for use within test validation.

This PR updates `ak.array` to check the first element of an `ndarray` if its `dtype=numpy.object_`. This case can also occur with `BigInt` so we need to determine if the elements are strings or not for processing. This required a simple modification to an `if` block. I validated that all existing test cases pass with this modification as well.