### PR TITLE
Closes #2581 - `Strings.get_null_indicies` Not Reporting Correct Results in Parquet

### DIFF
--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -1354,6 +1354,8 @@ int cpp_writeStrColumnToParquet(const char* filename, void* chpl_arr, void* chpl
           value.ptr = reinterpret_cast<const uint8_t*>(&chpl_ptr[byteIdx]);
           // subtract 1 since we have the null terminator
           value.len = offsets[offIdx+1] - offsets[offIdx] - 1;
+          if (value.len == 0)
+            definition_level = 0;
           ba_writer->WriteBatch(1, &definition_level, nullptr, &value);
           numLeft--;count++;
           offIdx++;


### PR DESCRIPTION
Closes #2581 

This PR updates the workflow for writing Strings objects to Parquet. Previously, even empty string segments were being written with a `definition level=1`. This results in the read of those segments showing `values_read=1`, but the length of the value is 0. Because `values_read=1` was being seen, the null indicies were not being set properly. In order to get the `values_read=0` as expected, during the write workflow a check of the value length was added. If this is 0, then the `definition level` is updated to 0. I verified with the test provided by @pierce314159 that this is now functioning as expected in the existing test and the updated test that was provided.