### PR TITLE
Closes #2573: `pdarray_creation_test.py` Conversion for new test framework

### DIFF
--- a/PROTO_tests/tests/pdarray_creation_test.py
+++ b/PROTO_tests/tests/pdarray_creation_test.py
@@ -162,6 +162,11 @@ class TestPdarrayCreation:
         assert np_arange_uint.tolist() == ak_arange_uint.to_list()
         assert ak.uint64 == ak_arange_uint.dtype
 
+        uint_start_stop = ak.arange(2**63 + 3, 2**63 + 7)
+        ans = ak.arange(3, 7, dtype=ak.uint64) + 2**63
+        assert ans.to_list() == uint_start_stop.to_list()
+        assert ak.uint64 == uint_start_stop.dtype
+
         # test correct conversion to float64
         np_arange_float = np.arange(-5, -10, -1, dtype=np.float64)
         ak_arange_float = ak.arange(-5, -10, -1, dtype=ak.float64)
@@ -190,8 +195,10 @@ class TestPdarrayCreation:
         assert [size] == test_array.shape
         assert ((0 <= test_array) & (test_array <= size)).all()
 
+    # (The above function tests randint with various ARRAY dtypes; the function below
+    #  tests with various dtypes for the other parameters passed to randint)
     @pytest.mark.parametrize("dtype", NUMERIC_SCALARS)
-    def test_randint_dtype(self, dtype):
+    def test_randint_num_dtype(self, dtype):
         for test_array in ak.randint(dtype(0), 100, 1000), ak.randint(0, dtype(100), 1000):
             assert isinstance(test_array, ak.pdarray)
             assert 1000 == len(test_array)
@@ -338,12 +345,11 @@ class TestPdarrayCreation:
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", [ak.int64, ak.float64, ak.bool, ak.bigint])
     def test_ones_like(self, size, dtype):
-        int_ones = ak.ones(size, dtype)
-        int_ones_like = ak.ones_like(int_ones)
-
-        assert isinstance(int_ones_like, ak.pdarray)
-        assert dtype == int_ones_like.dtype
-        assert (1 == int_ones_like).all()
+        ones_arr = ak.ones(size, dtype)
+        ones_like_arr = ak.ones_like(ones_arr)
+        assert isinstance(ones_like_arr, ak.pdarray)
+        assert dtype == ones_like_arr.dtype
+        assert (1 == ones_like_arr).all()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", [int, ak.int64, ak.uint64, float, ak.float64, bool, ak.bool])
@@ -385,20 +391,20 @@ class TestPdarrayCreation:
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", [int, ak.int64, ak.uint64, float, ak.float64, bool, ak.bool])
     def test_full_like(self, size, dtype):
-        int_full = ak.full(size, 1, dtype)
-        int_full_like = ak.full_like(int_full, 1)
-        assert isinstance(int_full_like, ak.pdarray)
-        assert dtype == int_full_like.dtype
-        assert (int_full_like == 1).all()
+        full_arr = ak.full(size, 1, dtype)
+        full_like_arr = ak.full_like(full_arr, 1)
+        assert isinstance(full_like_arr, ak.pdarray)
+        assert dtype == full_like_arr.dtype
+        assert (full_like_arr == 1).all()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", [int, ak.int64, ak.uint64, float, ak.float64, bool, ak.bool])
     def test_zeros_like(self, size, dtype):
-        int_zeros = ak.zeros(size, dtype)
-        int_zeros_like = ak.zeros_like(int_zeros)
-        assert isinstance(int_zeros_like, ak.pdarray)
-        assert dtype == int_zeros_like.dtype
-        assert (int_zeros_like == 0).all()
+        zeros_arr = ak.zeros(size, dtype)
+        zeros_like_arr = ak.zeros_like(zeros_arr)
+        assert isinstance(zeros_like_arr, ak.pdarray)
+        assert dtype == zeros_like_arr.dtype
+        assert (zeros_like_arr == 0).all()
 
     def test_linspace(self):
         pda = ak.linspace(0, 100, 1000)

--- a/PROTO_tests/tests/pdarray_creation_test.py
+++ b/PROTO_tests/tests/pdarray_creation_test.py
@@ -2,7 +2,6 @@ import datetime as dt
 import math
 import statistics
 from collections import deque
-from typing import Tuple, Union, cast
 
 import numpy as np
 import pandas as pd

--- a/PROTO_tests/tests/pdarray_creation_test.py
+++ b/PROTO_tests/tests/pdarray_creation_test.py
@@ -49,8 +49,8 @@ class TestPdarrayCreation:
     def test_large_array_creation(self, size):
         # Using pytest.prob_size in various other tests can be problematic; this
         # test is here simply to verify the ability of the various functions to
-        # create large arrays, while the function-specific tests below are testing
-        # the core functionality of each
+        # create large pdarrays, while the function-specific tests below are testing
+        # the core functionality of each function
         for pda in [
             ak.ones(size, int),
             ak.array(ak.ones(size, int)),
@@ -59,7 +59,7 @@ class TestPdarrayCreation:
             ak.full(size, "test"),
             ak.zeros_like(ak.ones(size)),
             ak.ones_like(ak.zeros(size)),
-            ak.full_like(ak.zeros(size), "test"),
+            ak.full_like(ak.zeros(size), 9),
             ak.arange(size),
             ak.linspace(0, size, size),
             ak.randint(0, size, size),
@@ -67,11 +67,10 @@ class TestPdarrayCreation:
             ak.standard_normal(size),
             ak.random_strings_uniform(3, 30, size),
             ak.random_strings_lognormal(2, 0.25, size),
-            ak.from_series(pd.Series(ak.arange(size))),
-            ak.bigint_from_uint_arrays([ak.ones(size, dtype=ak.uint64)])
+            ak.from_series(pd.Series(ak.arange(size).to_ndarray())),
+            ak.bigint_from_uint_arrays([ak.ones(size, dtype=ak.uint64)]),
         ]:
-            assert isinstance(pda, Union[ak.pdarray, ak.Strings])
-            # assert isinstance(pda, ak.pdarray if pda.dtype != str else ak.Strings)
+            assert isinstance(pda, ak.pdarray if pda.dtype != str else ak.Strings)
             assert len(pda) == size
 
     def test_array_creation_misc(self):

--- a/PROTO_tests/tests/pdarray_creation_test.py
+++ b/PROTO_tests/tests/pdarray_creation_test.py
@@ -2,6 +2,7 @@ import datetime as dt
 import math
 import statistics
 from collections import deque
+from typing import Tuple, Union, cast
 
 import numpy as np
 import pandas as pd
@@ -43,6 +44,35 @@ class TestPdarrayCreation:
                 assert isinstance(pda, ak.pdarray if dtype != str else ak.Strings)
                 assert len(pda) == fixed_size
                 assert dtype == pda.dtype
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_large_array_creation(self, size):
+        # Using pytest.prob_size in various other tests can be problematic; this
+        # test is here simply to verify the ability of the various functions to
+        # create large arrays, while the function-specific tests below are testing
+        # the core functionality of each
+        for pda in [
+            ak.ones(size, int),
+            ak.array(ak.ones(size, int)),
+            ak.zeros(size),
+            ak.ones(size),
+            ak.full(size, "test"),
+            ak.zeros_like(ak.ones(size)),
+            ak.ones_like(ak.zeros(size)),
+            ak.full_like(ak.zeros(size), "test"),
+            ak.arange(size),
+            ak.linspace(0, size, size),
+            ak.randint(0, size, size),
+            ak.uniform(size, 0, 100),
+            ak.standard_normal(size),
+            ak.random_strings_uniform(3, 30, size),
+            ak.random_strings_lognormal(2, 0.25, size),
+            ak.from_series(pd.Series(ak.arange(size))),
+            ak.bigint_from_uint_arrays([ak.ones(size, dtype=ak.uint64)])
+        ]:
+            assert isinstance(pda, Union[ak.pdarray, ak.Strings])
+            # assert isinstance(pda, ak.pdarray if pda.dtype != str else ak.Strings)
+            assert len(pda) == size
 
     def test_array_creation_misc(self):
         av = ak.array(np.array([[0, 1], [0, 1]]))

--- a/PROTO_tests/tests/pdarray_creation_test.py
+++ b/PROTO_tests/tests/pdarray_creation_test.py
@@ -27,14 +27,13 @@ DTYPES = [
 
 
 class TestPdarrayCreation:
-    @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", DTYPES)
-    def test_array_creation(self, size, dtype):
+    def test_array_creation(self, dtype):
         # TODO - remove the 'if' below (to make everything that follows unconditional) after #2645 is complete
         if dtype != str:
             fixed_size = 100
             for pda in [
-                ak.array(ak.ones(size, int), dtype),
+                ak.array(ak.ones(fixed_size, int), dtype),
                 ak.array(np.ones(fixed_size), dtype),
                 ak.array(list(range(fixed_size)), dtype=dtype),
                 ak.array((range(fixed_size)), dtype),
@@ -42,7 +41,7 @@ class TestPdarrayCreation:
                 ak.array([f"{i}" for i in range(fixed_size)], dtype=dtype),
             ]:
                 assert isinstance(pda, ak.pdarray if dtype != str else ak.Strings)
-                assert len(pda) in (size, fixed_size)
+                assert len(pda) == fixed_size
                 assert dtype == pda.dtype
 
     def test_array_creation_misc(self):
@@ -111,20 +110,19 @@ class TestPdarrayCreation:
         assert np.arange(-5, -10, -1).tolist() == ak.arange(-5, -10, -1).to_list()
         assert np.arange(0, 10, 2).tolist() == ak.arange(0, 10, 2).to_list()
 
-    @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", ak.intTypes)
-    def test_arange_dtype(self, size, dtype):
+    def test_arange_dtype(self, dtype):
         # test dtype works with optional start/stride
-        stop = ak.arange(size, dtype=dtype)
-        assert np.arange(size, dtype=dtype).tolist() == stop.to_list()
+        stop = ak.arange(100, dtype=dtype)
+        assert np.arange(100, dtype=dtype).tolist() == stop.to_list()
         assert dtype == stop.dtype
 
-        start_stop = ak.arange(size, size + 5, dtype=dtype)
-        assert np.arange(size, size + 5, dtype=dtype).tolist() == start_stop.to_list()
+        start_stop = ak.arange(100, 105, dtype=dtype)
+        assert np.arange(100, 105, dtype=dtype).tolist() == start_stop.to_list()
         assert dtype == start_stop.dtype
 
-        start_stop_stride = ak.arange(size, size + 5, 2, dtype=dtype)
-        assert np.arange(size, size + 5, 2, dtype=dtype).tolist() == start_stop_stride.to_list()
+        start_stop_stride = ak.arange(100, 105, 2, dtype=dtype)
+        assert np.arange(100, 105, 2, dtype=dtype).tolist() == start_stop_stride.to_list()
         assert dtype == start_stop_stride.dtype
 
     def test_arange_misc(self):
@@ -164,15 +162,14 @@ class TestPdarrayCreation:
         assert [size] == test_array.shape
         assert ((0 <= test_array) & (test_array <= size)).all()
 
-    @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", NUMERIC_SCALARS)
-    def test_randint_dtype(self, size, dtype):
-        for test_array in ak.randint(dtype(0), size, size), ak.randint(0, dtype(size), size):
+    def test_randint_dtype(self, dtype):
+        for test_array in ak.randint(dtype(0), 100, 1000), ak.randint(0, dtype(100), 1000):
             assert isinstance(test_array, ak.pdarray)
-            assert size == len(test_array)
+            assert 1000 == len(test_array)
             assert ak.int64 == test_array.dtype
-            assert [size] == test_array.shape
-            assert ((0 <= test_array) & (test_array <= size)).all()
+            assert [1000] == test_array.shape
+            assert ((0 <= test_array) & (test_array <= 1000)).all()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_randint_misc(self, size):
@@ -418,23 +415,23 @@ class TestPdarrayCreation:
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", INT_SCALARS)
     def test_standard_normal(self, size, dtype):
-        pda = ak.standard_normal(size)
+        pda = ak.standard_normal(100)
         assert isinstance(pda, ak.pdarray)
-        assert size == len(pda)
+        assert 100 == len(pda)
         assert float == pda.dtype
 
-        pda = ak.standard_normal(dtype(size))
+        pda = ak.standard_normal(dtype(100))
         assert isinstance(pda, ak.pdarray)
-        assert size == len(pda)
+        assert 100 == len(pda)
         assert float == pda.dtype
 
-        pda = ak.standard_normal(dtype(size), dtype(1))
+        pda = ak.standard_normal(dtype(100), dtype(1))
         assert isinstance(pda, ak.pdarray)
-        assert size == len(pda)
+        assert 100 == len(pda)
         assert float == pda.dtype
 
         npda = pda.to_ndarray()
-        pda = ak.standard_normal(dtype(size), dtype(1))
+        pda = ak.standard_normal(dtype(100), dtype(1))
         assert npda.tolist() == pda.to_list()
 
     def test_standard_normal_errors(self):
@@ -456,12 +453,11 @@ class TestPdarrayCreation:
         ]:
             assert (int_arr == ak.standard_normal(*args)).all()
 
-    @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", INT_SCALARS)
-    def test_random_strings_uniform(self, size, dtype):
-        pda = ak.random_strings_uniform(minlen=dtype(1), maxlen=dtype(5), size=dtype(size))
+    def test_random_strings_uniform(self, dtype):
+        pda = ak.random_strings_uniform(minlen=dtype(1), maxlen=dtype(5), size=dtype(100))
         assert isinstance(pda, ak.Strings)
-        assert size == len(pda)
+        assert 100 == len(pda)
         assert str == pda.dtype
 
         assert ((1 <= pda.get_lengths()) & (pda.get_lengths() <= 5)).all()

--- a/PROTO_tests/tests/pdarray_creation_test.py
+++ b/PROTO_tests/tests/pdarray_creation_test.py
@@ -1,0 +1,748 @@
+import datetime as dt
+import math
+import statistics
+from collections import deque
+from typing import Iterable, List, Optional, Tuple, Union, cast
+from arkouda import full
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import arkouda as ak
+from arkouda import ARKOUDA_SUPPORTED_DTYPES
+from contextlib import nullcontext as does_not_raise
+
+INT_SCALARS = [
+    int,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+]
+NUMERIC_SCALARS = [
+    int,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    float,
+    np.float64,
+]
+
+NO_BIGINT = [
+    bool,
+    float,
+    ak.float64,
+    int,
+    ak.int64,
+    str,
+    ak.uint64,
+    ak.uint8,
+]
+
+
+"""
+Encapsulates test cases for pdarray creation methods
+"""
+
+
+class TestPdarrayCreation:
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype", NO_BIGINT)
+    def test_array_creation(self, dtype, size):
+
+    #ndarray * dtypes
+        pda = ak.array(np.ones(size), dtype)
+        assert isinstance(pda, Union[ak.pdarray, ak.Strings])
+        assert size == len(pda)
+        assert dtype == pda.dtype
+
+    # pdarray * dtypes
+        pda = ak.array(full(size, 1), dtype)
+        assert isinstance(pda, Union[ak.pdarray, ak.Strings])
+        assert size == len(pda)
+        assert dtype == pda.dtype
+
+    # other Iterable ; using all dtypes yields error: castMsg: str : str not implemented
+        pda = ak.array(list(range(0, size)), dtype=int)
+        assert isinstance(pda, ak.pdarray)
+        assert size == len(pda)
+        assert int == pda.dtype
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_array_creation_misc(self, size):
+        av = ak.array(np.array([[0, 1], [0, 1]]))
+        assert isinstance(av, ak.ArrayView)
+
+        with pytest.raises(TypeError):
+            ak.array({range(0, size)})
+
+        with pytest.raises(TypeError):
+            ak.array("not an iterable")
+
+        with pytest.raises(TypeError):
+            ak.array(list(list(0)))
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_bigint_creation(self, size):
+        bi = 2**200
+
+        pda_from_str = ak.array([f"{i}" for i in range(bi, bi + size)], dtype=ak.bigint)
+        pda_from_int = ak.array([i for i in range(bi, bi + size)])
+        cast_from_segstr = ak.cast(ak.array([f"{i}" for i in range(bi, bi + size)]), ak.bigint)
+        for pda in [pda_from_str, pda_from_int, cast_from_segstr]:
+            assert isinstance(pda, ak.pdarray)
+            assert size == len(pda)
+            assert ak.bigint == pda.dtype
+            assert pda[-1] == bi + size - 1
+
+        # test array and arange infer dtype
+        assert (
+            ak.array([bi, bi + 1, bi + 2, bi + 3, bi + 4]).to_list() == ak.arange(bi, bi + 5).to_list()
+        )
+
+        # test that max_bits being set results in a mod
+        assert ak.arange(bi, bi + size, max_bits=200).to_list() == ak.arange(size).to_list()
+
+        # test ak.bigint_from_uint_arrays
+        # top bits are all 1 which should be 2**64
+        top_bits = ak.ones(size, ak.uint64)
+        bot_bits = ak.arange(size, dtype=ak.uint64)
+        two_arrays = ak.bigint_from_uint_arrays([top_bits, bot_bits])
+        assert ak.bigint == two_arrays.dtype
+        assert two_arrays.to_list() == [2**64 + i for i in range(size)]
+        # top bits should represent 2**128
+        mid_bits = ak.zeros(size, ak.uint64)
+        three_arrays = ak.bigint_from_uint_arrays([top_bits, mid_bits, bot_bits])
+        assert three_arrays.to_list() == [2**128 + i for i in range(size)]
+
+        # test round_trip of ak.bigint_to/from_uint_arrays
+        t = ak.arange(bi - 1, bi + 9)
+        t_dup = ak.bigint_from_uint_arrays(t.bigint_to_uint_arrays())
+        assert t.to_list() == t_dup.to_list()
+        assert t_dup.max_bits == -1
+
+        # test setting max_bits after creation still mods
+        t_dup.max_bits = 200
+        assert t_dup.to_list() == [bi - 1, 0, 1, 2, 3, 4, 5, 6, 7, 8]
+
+        # test slice_bits along 64 bit boundaries matches return from bigint_to_uint_arrays
+        for i, uint_bits in enumerate(t.bigint_to_uint_arrays()):
+            slice_bits = t.slice_bits(64 * (4 - (i + 1)), 64 * (4 - i) - 1)
+            assert uint_bits.to_list() == slice_bits.to_list()
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_arange(self, size):
+        assert np.arange(0, size, 1).tolist() == ak.arange(0, size, 1).to_list()
+        assert np.arange(size, 0, -1).tolist() == ak.arange(size, 0, -1).to_list()
+        assert np.arange(-5, -size, -1).tolist() == ak.arange(-5, -size, -1).to_list()
+        assert np.arange(0, size, 2).tolist() == ak.arange(0, size, 2).to_list()
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype", ak.intTypes)
+    def test_arange_dtype(self, size, dtype):
+        # test dtype works with optional start/stride
+        stop = ak.arange(size, dtype=dtype)
+        assert np.arange(size, dtype=dtype).tolist() == stop.to_list()
+        assert dtype == stop.dtype
+
+        start_stop = ak.arange(size, size + 5, dtype=dtype)
+        assert np.arange(size, size + 5, dtype=dtype).tolist() == start_stop.to_list()
+        assert dtype == start_stop.dtype
+
+        start_stop_stride = ak.arange(size, size + 5, 2, dtype=dtype)
+        assert np.arange(size, size + 5, 2, dtype=dtype).tolist() == start_stop_stride.to_list()
+        assert dtype == start_stop_stride.dtype
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_arange_misc(self, size):
+        # test uint64 handles negatives correctly
+        np_arange_uint = np.arange(2**64 - 5, 2**64 - size, -1, dtype=np.uint64)
+        ak_arange_uint = ak.arange(-5, -size, -1, dtype=ak.uint64)
+        # np_arange_uint = array([18446744073709551611, 18446744073709551610, 18446744073709551609,
+        #        18446744073709551608, 18446744073709551607], dtype=uint64)
+        assert np_arange_uint.tolist() == ak_arange_uint.to_list()
+        assert ak.uint64 == ak_arange_uint.dtype
+
+        # test correct conversion to float64
+        np_arange_float = np.arange(-5, -size, -1, dtype=np.float64)
+        ak_arange_float = ak.arange(-5, -size, -1, dtype=ak.float64)
+        # array([-5., -6., -7., -8., -9.])
+        assert np_arange_float.tolist() == ak_arange_float.to_list()
+        assert ak.float64 == ak_arange_float.dtype
+
+        # test correct conversion to bool
+        expected_bool = [False, True, True, True, True]
+        ak_arange_bool = ak.arange(0, 10, 2, dtype=ak.bool)
+        assert expected_bool == ak_arange_bool.to_list()
+        assert ak.bool == ak_arange_bool.dtype
+
+        # test int_scalars covers uint8, uint16, uint32
+        does_not_raise(ak.arange(np.uint8(1), np.uint16(size), np.uint32(1)))
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("low_type", [float, int])
+    @pytest.mark.parametrize("high_type", [float, int])
+    @pytest.mark.parametrize("array_type", [ak.int64, ak.float64, bool])
+    def test_randint_dtype(self, size, low_type, high_type, array_type):
+        test_array = ak.randint(low_type(0), high_type(size), size, array_type)
+        assert isinstance(test_array, ak.pdarray)
+        assert size == len(test_array)
+        assert array_type == test_array.dtype
+        assert [size] == test_array.shape
+
+        test_ndarray = test_array.to_ndarray()
+
+        for value in test_ndarray:
+            assert 0 <= value <= size
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_randint_misc(self, size):
+        # test resolution of modulus overflow - issue #1174
+        test_array = ak.randint(-(2**63), 2**63 - 1, size)
+        to_validate = np.full(size, -(2**63))
+        assert not (test_array.to_ndarray().tolist() == to_validate.tolist())
+
+        with pytest.raises(TypeError):
+            ak.randint(low=5)
+
+        with pytest.raises(TypeError):
+            ak.randint(high=5)
+
+        with pytest.raises(TypeError):
+            ak.randint()
+
+        with pytest.raises(ValueError):
+            ak.randint(low=0, high=1, size=-1, dtype=ak.float64)
+
+        with pytest.raises(ValueError):
+            ak.randint(low=1, high=0, size=1, dtype=ak.float64)
+
+        with pytest.raises(TypeError):
+            ak.randint(0, 1, "1000")
+
+        with pytest.raises(TypeError):
+            ak.randint("0", 1, 1000)
+
+        with pytest.raises(TypeError):
+            ak.randint(0, "1", 1000)
+
+        # Test that int_scalars covers uint8, uint16, uint32
+        does_not_raise(ak.randint(low=np.uint8(1), high=np.uint16(100), size=np.uint32(size)))
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_randint_with_seed(self, size):
+        values = ak.randint(1, 5, 10, seed=2)
+
+        assert [4, 3, 1, 3, 2, 4, 4, 2, 3, 4] == values.to_list()
+
+        values = ak.randint(1, 5, 10, dtype=ak.float64, seed=2)
+        assert [
+            2.9160772326374946,
+            4.353429832157099,
+            4.5392023718621486,
+            4.4019932101126606,
+            3.3745324569952304,
+            1.1642002901528308,
+            4.4714086874555292,
+            3.7098921109084522,
+            4.5939589352472314,
+            4.0337935981006172,
+        ] == values.to_list()
+
+        bools = [False, True, True, True, True, False, True, True, True, True]
+        values = ak.randint(1, 5, 10, dtype=ak.bool, seed=2)
+        assert values.to_list() == bools
+
+        values = ak.randint(1, 5, 10, dtype=bool, seed=2)
+        assert values.to_list() == bools
+
+        # Test that int_scalars covers uint8, uint16, uint32
+        does_not_raise(ak.randint(np.uint8(1), np.uint32(5), np.uint16(size), seed=np.uint8(2)))
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_uniform(self, size):
+        test_array = ak.uniform(size)
+        assert isinstance(test_array, ak.pdarray)
+        assert ak.float64 == test_array.dtype
+        assert [size] == test_array.shape
+
+        u_array = ak.uniform(size=3, low=0, high=5, seed=0)
+        assert [0.30013431967121934, 0.47383036230759112, 1.0441791878997098] == u_array.to_list()
+
+        u_array = ak.uniform(size=np.int64(3), low=np.int64(0), high=np.int64(5), seed=np.int64(0))
+        assert [0.30013431967121934, 0.47383036230759112, 1.0441791878997098] == u_array.to_list()
+
+        with pytest.raises(TypeError):
+            ak.uniform(low="0", high=5, size=size)
+
+        with pytest.raises(TypeError):
+            ak.uniform(low=0, high="5", size=size)
+
+        with pytest.raises(TypeError):
+            ak.uniform(low=0, high=5, size="100")
+
+        # Test that int_scalars covers uint8, uint16, uint32
+        does_not_raise(ak.uniform(low=np.uint8(0), high=5, size=np.uint32(size)))
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype", [ak.int64, float, ak.float64, bool, ak.bool, ak.bigint])
+    def test_zeros(self, size, dtype):
+        zeros = ak.zeros(size, dtype)
+        assert isinstance(zeros, ak.pdarray)
+        assert dtype == zeros.dtype
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_zeros_errors(self, size):
+        with pytest.raises(TypeError):
+            ak.zeros(size, dtype=ak.uint8)
+
+        with pytest.raises(TypeError):
+            ak.zeros(size, dtype=str)
+
+        # Test that int_scalars covers uint8, uint16, uint32, str
+        does_not_raise(ak.zeros(np.uint8(size), dtype=ak.int64))
+        does_not_raise(ak.zeros(np.uint16(size), dtype=ak.int64))
+        does_not_raise(ak.zeros(np.uint32(size), dtype=ak.int64))
+        does_not_raise(ak.zeros(str(size), dtype=ak.int64))
+
+    @pytest.mark.parametrize("dtype", [int, ak.int64, float, ak.float64, bool, ak.bool, ak.bigint])
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_ones(self, size, dtype):
+        ones = ak.ones(size, dtype)
+        assert isinstance(ones, ak.pdarray)
+        assert dtype == ones.dtype
+        assert 1 == ones[0]
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_ones_errors(self, size):
+        with pytest.raises(TypeError):
+            ak.ones(size, dtype=ak.uint8)
+
+        with pytest.raises(TypeError):
+            ak.ones(size, dtype=str)
+
+        # Test that int_scalars covers uint8, uint16, uint32
+        does_not_raise(ak.ones(np.uint8(size), dtype=ak.int64))
+        does_not_raise(ak.ones(np.uint16(size), dtype=ak.int64))
+        does_not_raise(ak.ones(np.uint32(size), dtype=ak.int64))
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype", [ak.int64, ak.float64, ak.bool, ak.bigint])
+    def test_ones_like(self, size, dtype):
+        int_ones = ak.ones(size, dtype)
+        int_ones_like = ak.ones_like(int_ones)
+
+        assert isinstance(int_ones_like, ak.pdarray)
+        assert dtype == int_ones_like.dtype
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype", [int, ak.int64, ak.uint64, float, ak.float64, bool, ak.bool])
+    def test_full(self, size, dtype):
+        type_full = ak.full(size, 1, dtype)
+        assert isinstance(type_full, ak.pdarray)
+        assert dtype == type_full.dtype
+        assert type_full[0] == 1
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_full_errors(self, size):
+        string_len_full = ak.full("1000", 5)
+        assert 1000 == len(string_len_full)
+
+        with pytest.raises(TypeError):
+            ak.full(size, 1, dtype=ak.uint8)
+
+        with pytest.raises(TypeError):
+            ak.full(size, 8, dtype=str)
+
+        # Test that int_scalars covers uint8, uint16, uint32
+        does_not_raise(ak.full(np.uint8(size), np.uint16(size), dtype=int))
+        does_not_raise(ak.full(np.uint8(size), np.uint32(size), dtype=int))
+        does_not_raise(ak.full(np.uint16(size), np.uint32(size), dtype=int))
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype", [int, ak.int64, ak.uint64, float, ak.float64, bool, ak.bool])
+    def test_full_like(self, size, dtype):
+        int_full = ak.full(size, 1, dtype)
+        int_full_like = ak.full_like(int_full, 1)
+        assert isinstance(int_full_like, ak.pdarray)
+        assert dtype == int_full_like.dtype
+        assert int_full_like[0] == 1
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype", [int, ak.int64, ak.uint64, float, ak.float64, bool, ak.bool])
+    def test_zeros_like(self, size, dtype):
+        int_zeros = ak.zeros(size, dtype)
+        int_zeros_like = ak.zeros_like(int_zeros)
+
+        assert isinstance(int_zeros_like, ak.pdarray)
+        assert dtype == int_zeros_like.dtype
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_linspace(self, size):
+        pda = ak.linspace(0, 100, size)
+        assert size == len(pda)
+        assert float == pda.dtype
+        assert isinstance(pda, ak.pdarray)
+
+        pda = ak.linspace(start=5, stop=0, length=6)
+        assert 5.0000 == pda[0]
+        assert 0.0000 == pda[5]
+
+        pda = ak.linspace(start=5.0, stop=0.0, length=6)
+        assert 5.0000 == pda[0]
+        assert 0.0000 == pda[5]
+
+        pda = ak.linspace(start=float(5.0), stop=float(0.0), length=np.int64(6))
+        assert 5.0000 == pda[0]
+        assert 0.0000 == pda[5]
+
+        with pytest.raises(TypeError):
+            ak.linspace(0, "100", 1000)
+
+        with pytest.raises(TypeError):
+            ak.linspace("0", 100, 1000)
+
+        with pytest.raises(TypeError):
+            ak.linspace(0, 100, "1000")
+
+        # Test that int_scalars covers uint8, uint16, uint32
+        does_not_raise(ak.linspace(np.uint8(0), np.uint16(100), np.uint32(1000)))
+        does_not_raise(ak.linspace(np.uint32(0), np.uint16(100), np.uint8(1000 % 256)))
+        does_not_raise(ak.linspace(np.uint16(0), np.uint8(100), np.uint8(1000 % 256)))
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype", INT_SCALARS)
+    def test_standard_normal(self, size, dtype):
+        pda = ak.standard_normal(size)
+        assert isinstance(pda, ak.pdarray)
+        assert size == len(pda)
+        assert float == pda.dtype
+
+        pda = ak.standard_normal(dtype(size))
+        assert isinstance(pda, ak.pdarray)
+        assert size == len(pda)
+        assert float == pda.dtype
+
+        pda = ak.standard_normal(dtype(size), dtype(1))
+        assert isinstance(pda, ak.pdarray)
+        assert size == len(pda)
+        assert float == pda.dtype
+
+        npda = pda.to_ndarray()
+        pda = ak.standard_normal(dtype(size), dtype(1))
+
+        assert npda.tolist() == pda.to_list()
+
+        with pytest.raises(TypeError):
+            ak.standard_normal("100")
+
+        with pytest.raises(TypeError):
+            ak.standard_normal(100.0)
+
+        with pytest.raises(ValueError):
+            ak.standard_normal(-1)
+
+        # Test that int_scalars covers uint8, uint16, uint32
+        does_not_raise(ak.standard_normal(np.uint8(size)))
+        does_not_raise(ak.standard_normal(np.uint16(size)))
+        does_not_raise(ak.standard_normal(np.uint32(size)))
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype", INT_SCALARS)
+    def test_random_strings_uniform(self, size, dtype):
+        pda = ak.random_strings_uniform(minlen=dtype(1), maxlen=dtype(5), size=dtype(size))
+        nda = pda.to_ndarray()
+
+        assert isinstance(pda, ak.Strings)
+        assert size == len(pda)
+        assert str == pda.dtype
+        for string in nda:
+            assert 1 <= len(string) <= 5
+            assert string.isupper()
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_random_strings_uniform_errors(self, size):
+
+        with pytest.raises(ValueError):
+            ak.random_strings_uniform(maxlen=1, minlen=5, size=size)
+
+        with pytest.raises(ValueError):
+            ak.random_strings_uniform(maxlen=5, minlen=1, size=-1)
+
+        with pytest.raises(ValueError):
+            ak.random_strings_uniform(maxlen=5, minlen=5, size=10)
+
+        with pytest.raises(TypeError):
+            ak.random_strings_uniform(minlen="1", maxlen=5, size=10)
+
+        with pytest.raises(TypeError):
+            ak.random_strings_uniform(minlen=1, maxlen="5", size=10)
+
+        with pytest.raises(TypeError):
+            ak.random_strings_uniform(minlen=1, maxlen=5, size="10")
+
+        # Test that int_scalars covers uint8, uint16, uint32
+        does_not_raise(ak.random_strings_uniform(
+            minlen=np.uint8(1),
+            maxlen=np.uint32(5),
+            seed=np.uint16(1),
+            size=np.uint8(10),
+            characters="printable",
+        ))
+
+    def test_random_strings_uniform_with_seed(self):
+        pda = ak.random_strings_uniform(minlen=1, maxlen=5, seed=1, size=10)
+        assert ["VW", "JEXI", "EBBX", "HG", "S", "WOVK", "U", "WL", "JCSD", "DSN"] == pda.to_list()
+
+        pda = ak.random_strings_uniform(minlen=1, maxlen=5, seed=1, size=10, characters="printable")
+        assert ["eL", "6<OD", "o-GO", " l", "m", "PV y", "f", "}.", "b3Yc", "Kw,"] == pda.to_list()
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("num_dtype", NUMERIC_SCALARS)
+    def test_random_strings_lognormal(self, size, num_dtype):
+        pda = ak.random_strings_lognormal(logmean=num_dtype(2), logstd=num_dtype(1), size=np.int64(size), characters="printable")
+        assert isinstance(pda, ak.Strings)
+        assert size == len(pda)
+        assert str == pda.dtype
+
+    def test_random_strings_lognormal_errors(self):
+        with pytest.raises(TypeError):
+            ak.random_strings_lognormal("2", 0.25, 100)
+
+        with pytest.raises(TypeError):
+            ak.random_strings_lognormal(2, 0.25, "100")
+
+        with pytest.raises(TypeError):
+            ak.random_strings_lognormal(2, 0.25, 100, 1000000)
+
+        # Test that int_scalars covers uint8, uint16, uint32
+        does_not_raise(ak.random_strings_lognormal(np.uint8(2), 0.25, np.uint16(100)))
+
+    def test_random_strings_lognormal_with_seed(self):
+        pda = ak.random_strings_lognormal(2, 0.25, 10, seed=1)
+        assert [
+            "VWHJEX",
+            "BEBBXJHGM",
+            "RWOVKBUR",
+            "LNJCSDXD",
+            "NKEDQC",
+            "GIBAFPAVWF",
+            "IJIFHGDHKA",
+            "VUDYRA",
+            "QHQETTEZ",
+            "DJBPWJV",
+        ] == pda.to_list()
+
+        pda = ak.random_strings_lognormal(float(2), np.float64(0.25), np.int64(10), seed=1)
+        assert [
+            "VWHJEX",
+            "BEBBXJHGM",
+            "RWOVKBUR",
+            "LNJCSDXD",
+            "NKEDQC",
+            "GIBAFPAVWF",
+            "IJIFHGDHKA",
+            "VUDYRA",
+            "QHQETTEZ",
+            "DJBPWJV",
+        ] == pda.to_list()
+
+        pda = ak.random_strings_lognormal(2, 0.25, 10, seed=1, characters="printable")
+        assert [
+            "eL96<O",
+            ")o-GOe lR",
+            ")PV yHf(",
+            "._b3Yc&K",
+            ",7Wjef",
+            "R{lQs_g]5T",
+            "E[2dk\\2a9J",
+            "I*VknZ",
+            "0!u~e$Lm",
+            "9Q{TtHq",
+        ] == pda.to_list()
+
+        pda = ak.random_strings_lognormal(
+            np.int64(2), np.float64(0.25), np.int64(10), seed=1, characters="printable"
+        )
+        assert [
+            "eL96<O",
+            ")o-GOe lR",
+            ")PV yHf(",
+            "._b3Yc&K",
+            ",7Wjef",
+            "R{lQs_g]5T",
+            "E[2dk\\2a9J",
+            "I*VknZ",
+            "0!u~e$Lm",
+            "9Q{TtHq",
+        ] == pda.to_list()
+
+    def test_mulitdimensional_array_creation(self):
+        av = ak.array([[0, 0], [0, 1], [1, 1]])
+        assert isinstance(av, ak.ArrayView)
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype", [bool, np.float64, np.int64, str])
+    def test_from_series_dtypes(self, size, dtype):
+
+        p_array = ak.from_series(pd.Series(np.random.randint(0, 10, size)), dtype)
+        assert isinstance(p_array, (ak.pdarray, ak.Strings))
+        assert dtype == p_array.dtype
+
+        p_i_objects_array = ak.from_series(
+            pd.Series(np.random.randint(0, 10, size), dtype="object"), dtype=dtype
+        )
+        assert isinstance(p_i_objects_array, (ak.pdarray, ak.Strings))
+        assert dtype == p_i_objects_array.dtype
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_from_series_misc(self, size):
+
+        p_array = ak.from_series(pd.Series(np.random.choice([True, False], size=size)))
+
+        assert isinstance(p_array, ak.pdarray)
+        assert bool == p_array.dtype
+
+        p_array = ak.from_series(pd.Series([dt.datetime(2016, 1, 1, 0, 0, 1)]))
+
+        assert isinstance(p_array, ak.pdarray)
+        assert np.int64 == p_array.dtype
+
+        p_array = ak.from_series(pd.Series([np.datetime64("2018-01-01")]))
+
+        assert isinstance(p_array, ak.pdarray)
+        assert np.int64 == p_array.dtype
+
+        p_array = ak.from_series(
+            pd.Series(pd.to_datetime(["1/1/2018", np.datetime64("2018-01-01"), dt.datetime(2018, 1, 1)]))
+        )
+
+        assert isinstance(p_array, ak.pdarray)
+        assert np.int64 == p_array.dtype
+
+        with pytest.raises(TypeError):
+            ak.from_series(np.ones(size))
+
+        with pytest.raises(ValueError):
+            ak.from_series(pd.Series(np.random.randint(0, 10, size), dtype=np.int8))
+
+    @pytest.mark.parametrize("dtype", NUMERIC_SCALARS)
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_fill(self, size, dtype):
+        ones = ak.ones(size)
+
+        ones.fill(dtype(2))
+        assert (dtype(2) == ones.to_ndarray()).all()
+
+        ones.fill(np.int64(2))
+        assert (np.int64(2) == ones.to_ndarray()).all()
+
+        ones.fill(float(2))
+        assert (float(2) == ones.to_ndarray()).all()
+
+        ones.fill(np.float64(2))
+        assert (np.float64(2) == ones.to_ndarray()).all()
+
+        # Test that int_scalars covers uint8, uint16, uint32
+        does_not_raise(ones.fill(np.uint8(2)))
+        does_not_raise(ones.fill(np.uint16(2)))
+        does_not_raise(ones.fill(np.uint32(2)))
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_endian(self, size):
+        a = np.random.randint(1, size, size)
+        aka = ak.array(a)
+        npa = aka.to_ndarray()
+        assert np.allclose(a, npa)
+
+        a = a.newbyteorder().byteswap()
+        aka = ak.array(a)
+        npa = aka.to_ndarray()
+        assert np.allclose(a, npa)
+
+        a = a.newbyteorder().byteswap()
+        aka = ak.array(a)
+        npa = aka.to_ndarray()
+        assert np.allclose(a, npa)
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_clobber(self, size):
+        narrs = 10
+
+        arrs = [np.random.randint(1, size, size) for _ in range(narrs)]
+        akarrs = [ak.array(arr) for arr in arrs]
+        nparrs = [arr.to_ndarray() for arr in akarrs]
+        for a, npa in zip(arrs, nparrs):
+            assert np.allclose(a, npa)
+
+        arrs = [np.full(size, i) for i in range(narrs)]
+        akarrs = [ak.array(arr) for arr in arrs]
+        nparrs = [arr.to_ndarray() for arr in akarrs]
+
+        for a, npa, i in zip(arrs, nparrs, range(narrs)):
+            assert np.all(a == i)
+            assert np.all(npa == i)
+
+            a += 1
+            assert np.all(a == i + 1)
+            assert np.all(npa == i)
+
+            npa += 1
+            assert np.all(a == i + 1)
+            assert np.all(npa == i + 1)
+
+    def test_uint_greediness(self):
+        # default to uint when all supportedInt and any value > 2**63
+        # to avoid loss of precision see (#1297)
+        for greedy_list in ([2**63, 6, 2**63 - 1, 2**63 + 1], [2**64 - 1, 0, 2**64 - 1]):
+            greedy_pda = ak.array(greedy_list)
+            assert greedy_pda.dtype == ak.uint64
+            assert greedy_list == greedy_pda.to_list()
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def randint_randomness(self, size):
+        # THIS TEST DOES NOT RUN, see Issue #1672
+        # To run rename to `test_randint_randomness`
+        minVal = 0
+        maxVal = 2**32
+        passed = 0
+        trials = 20
+
+        for x in range(trials):
+            l = ak.randint(minVal, maxVal, size)
+            l_median = statistics.median(l.to_ndarray())
+
+            runs, n1, n2 = 0, 0, 0
+
+            # Checking for start of new run
+            for i in range(len(l)):
+                # no. of runs
+                if (l[i] >= l_median > l[i - 1]) or (l[i] < l_median <= l[i - 1]):
+                    runs += 1
+
+                # no. of positive values
+                if (l[i]) >= l_median:
+                    n1 += 1
+                # no. of negative values
+                else:
+                    n2 += 1
+
+            runs_exp = ((2 * n1 * n2) / (n1 + n2)) + 1
+            stan_dev = math.sqrt(
+                (2 * n1 * n2 * (2 * n1 * n2 - n1 - n2)) / (((n1 + n2) ** 2) * (n1 + n2 - 1))
+            )
+
+            if abs((runs - runs_exp) / stan_dev) < 1.9:
+                passed += 1
+
+        assert passed >= trials * 0.8


### PR DESCRIPTION
This PR (Closes https://github.com/Bears-R-Us/arkouda/issues/2573):

Converts file to new test framework by adding pytest.  The changes were mostly (entirely?) syntactical, as I didn't see any obvious potential uses for parameterization.