### PR TITLE
Fixes #2567 - Error when reading SegArray containing `nan` with parquet

### DIFF
--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -419,20 +419,19 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
           while (float_reader->HasNext()) {
             float value;
             (void)float_reader->ReadBatch(1, &definition_level, &rep_lvl, &value, &values_read);
-            // not worried about NaN here so don't need to check values read.
-            if (values_read == 0 || (!first && rep_lvl == 0)) {
+            if ((values_read == 0 && definition_level != 2) || (!first && rep_lvl == 0)) {
               seg_sizes[i] = seg_size;
               i++;
               seg_size = 0;
             }
-            if (values_read != 0) {
+            if (values_read != 0 || (values_read == 0 && definition_level == 2)) {
               seg_size++;
               vct++;
               if (first) {
                 first = false;
               }
             }
-            if (values_read != 0 && !float_reader->HasNext()){
+            if ((values_read != 0 || (values_read == 0 && definition_level == 2)) && !float_reader->HasNext()){
               seg_sizes[i] = seg_size;
             }
           }
@@ -443,20 +442,19 @@ int64_t cpp_getListColumnSize(const char* filename, const char* colname, void* c
           while (dbl_reader->HasNext()) {
             double value;
             (void)dbl_reader->ReadBatch(1, &definition_level, &rep_lvl, &value, &values_read);
-            // not worried about NaN here so don't need to check values read.
-            if (values_read == 0 || (!first && rep_lvl == 0)) {
+            if ((values_read == 0 && definition_level != 2) || (!first && rep_lvl == 0)) {
               seg_sizes[i] = seg_size;
               i++;
               seg_size = 0;
             }
-            if (values_read != 0) {
+            if (values_read != 0 || (values_read == 0 && definition_level == 2)) {
               seg_size++;
               vct++;
               if (first) {
                 first = false;
               }
             }
-            if (values_read != 0 && !dbl_reader->HasNext()){
+            if ((values_read != 0 || (values_read == 0 && definition_level == 2)) && !dbl_reader->HasNext()){
               seg_sizes[i] = seg_size;
             }
           }
@@ -617,18 +615,29 @@ int cpp_readListColumnByName(const char* filename, void* chpl_arr, const char* c
           while (reader->HasNext() && i < numElems) {
             if((numElems - i) < batchSize) // adjust batchSize if needed
               batchSize = numElems - i;
-            // unlike the base case, the list stores NaN values and is able to read them out. 
-            // This prevents the need for any additional processing
-            // setting nullptr for def and rep levels allows use to ignore the empty segments since we only care about values here.
-            // However, for floats we still need a temporary array to allow for conversion to double
-            float* tmpArr = new float[batchSize] { 0 }; // this will not include NaN values
-            (void)reader->ReadBatch(batchSize, nullptr, nullptr, tmpArr, &values_read);
+            float* tmpArr = new float[batchSize]; // this will not include NaN values
+            int16_t* def_lvl = new int16_t[batchSize];
+            int16_t* rep_lvl = new int16_t[batchSize];
+            (void)reader->ReadBatch(batchSize, def_lvl, rep_lvl, tmpArr, &values_read);
 
-            for(int64_t j = 0; j < values_read; j++){
-              chpl_ptr[i+j] = (double)tmpArr[j];
+            int64_t tmp_offset = 0; // used to properly access tmp after NaN encountered
+            int64_t val_ct = 0;
+            int64_t j = 0;
+            while (val_ct < values_read){
+              if (def_lvl[j] == 2) {
+                chpl_ptr[i+j] = NAN;
+                tmp_offset++;
+              }
+              else {
+                chpl_ptr[i+j] = (double)tmpArr[j-tmp_offset];
+                val_ct++;
+              }
+              j++;
             }
-            i += values_read;
+            i += values_read + tmp_offset; // account for values and NaNs
             delete[] tmpArr;
+            delete[] def_lvl;
+            delete[] rep_lvl;
           }
         } else if(lty == ARROWDOUBLE) {
           auto chpl_ptr = (double*)chpl_arr;
@@ -638,11 +647,28 @@ int cpp_readListColumnByName(const char* filename, void* chpl_arr, const char* c
           while (reader->HasNext() && i < numElems) {
             if((numElems - i) < batchSize) // adjust batchSize if needed
               batchSize = numElems - i;
-            // unlike the base case, the list stores NaN values and is able to read them out. 
-            // This prevents the need for any additional processing
-            // setting nullptr for def and rep levels allows use to ignore the empty segments since we only care about values here.
-            (void)reader->ReadBatch(batchSize, nullptr, nullptr, &chpl_ptr[i], &values_read);
-            i += values_read;
+            double* tmpArr = new double[batchSize]; // NaNs not included here
+            int16_t* def_lvl = new int16_t[batchSize];
+            int16_t* rep_lvl = new int16_t[batchSize];
+            (void)reader->ReadBatch(batchSize, def_lvl, rep_lvl, tmpArr, &values_read);
+            int64_t tmp_offset = 0; // used to properly access tmp after NaN encountered
+            int64_t val_ct = 0;
+            int64_t j = 0;
+            while (val_ct < values_read){
+              if (def_lvl[j] == 2) {
+                chpl_ptr[i+j] = NAN;
+                tmp_offset++;
+              }
+              else {
+                chpl_ptr[i+j] = tmpArr[j-tmp_offset];
+                val_ct++;
+              }
+              j++;
+            }
+            i += values_read + tmp_offset; // account for values and NaNs
+            delete[] tmpArr;
+            delete[] def_lvl;
+            delete[] rep_lvl;
           }
         }
       }

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -621,20 +621,25 @@ int cpp_readListColumnByName(const char* filename, void* chpl_arr, const char* c
             (void)reader->ReadBatch(batchSize, def_lvl, rep_lvl, tmpArr, &values_read);
 
             int64_t tmp_offset = 0; // used to properly access tmp after NaN encountered
-            int64_t val_ct = 0;
-            int64_t j = 0;
-            while (val_ct < values_read){
+            int64_t val_idx = 0;
+            for (int64_t j = 0; j< batchSize; j++){
+              // skip any empty segments
+              if (def_lvl[j] == 1)
+                continue;
+              
+              // Null values treated as NaN
               if (def_lvl[j] == 2) {
-                chpl_ptr[i+j] = NAN;
-                tmp_offset++;
+                chpl_ptr[i+val_idx] = NAN;
+                tmp_offset++; // adjustment for values array since Nulls are not included
               }
-              else {
-                chpl_ptr[i+j] = (double)tmpArr[j-tmp_offset];
-                val_ct++;
+              else if (def_lvl[j] == 3){ // defined value to write
+                chpl_ptr[i+val_idx] = (double)tmpArr[val_idx-tmp_offset];
               }
-              j++;
+              val_idx++;
             }
-            i += values_read + tmp_offset; // account for values and NaNs
+
+            i += values_read + tmp_offset; // account for values and NaNs, but not empty segments
+
             delete[] tmpArr;
             delete[] def_lvl;
             delete[] rep_lvl;
@@ -651,21 +656,27 @@ int cpp_readListColumnByName(const char* filename, void* chpl_arr, const char* c
             int16_t* def_lvl = new int16_t[batchSize];
             int16_t* rep_lvl = new int16_t[batchSize];
             (void)reader->ReadBatch(batchSize, def_lvl, rep_lvl, tmpArr, &values_read);
+            
             int64_t tmp_offset = 0; // used to properly access tmp after NaN encountered
-            int64_t val_ct = 0;
-            int64_t j = 0;
-            while (val_ct < values_read){
+            int64_t val_idx = 0;
+            for (int64_t j = 0; j< batchSize; j++){
+              // skip any empty segments
+              if (def_lvl[j] == 1)
+                continue;
+              
+              // Null values treated as NaN
               if (def_lvl[j] == 2) {
-                chpl_ptr[i+j] = NAN;
-                tmp_offset++;
+                chpl_ptr[i+val_idx] = NAN;
+                tmp_offset++; // adjustment for values array since Nulls are not included
               }
-              else {
-                chpl_ptr[i+j] = tmpArr[j-tmp_offset];
-                val_ct++;
+              else if (def_lvl[j] == 3){ // defined value to write
+                chpl_ptr[i+val_idx] = (double)tmpArr[val_idx-tmp_offset];
               }
-              j++;
+              val_idx++;
             }
-            i += values_read + tmp_offset; // account for values and NaNs
+
+            i += values_read + tmp_offset; // account for values and NaNs, but not empty segments
+
             delete[] tmpArr;
             delete[] def_lvl;
             delete[] rep_lvl;

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -535,7 +535,7 @@ class ParquetTest(ArkoudaTest):
             self.assertListEqual(s.to_list(), rd_data.to_list())
 
     def test_float_edge(self):
-        df = pd.DataFrame({"FloatList": [[3.14, np.nan, 2.23], [], [3.08], [np.inf, 6.8], [-0.0]]})
+        df = pd.DataFrame({"FloatList": [[3.14, np.nan, 2.23], [], [3.08], [np.inf, 6.8], [-0.0, np.nan, np.nan]]})
 
         with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
             table = pa.Table.from_pandas(df)

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -534,6 +534,18 @@ class ParquetTest(ArkoudaTest):
             rd_data = ak.read_parquet(f"{tmp_dirname}/segarray_test_empty_*")
             self.assertListEqual(s.to_list(), rd_data.to_list())
 
+    def test_float_edge(self):
+        df = pd.DataFrame({"FloatList": [[3.14, np.nan, 2.23], [], [3.08], [np.inf, 6.8], [-0.0]]})
+
+        with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
+            table = pa.Table.from_pandas(df)
+            pq.write_table(table, f"{tmp_dirname}/segarray_float_edge")
+            ak_data = ak.read_parquet(f"{tmp_dirname}/segarray_float_edge")
+            pd_l = df["FloatList"].tolist()
+            ak_l = ak_data.to_list()
+            for i in range(len(pd_l)):
+                self.assertTrue(np.allclose(pd_l[i], ak_l[i], equal_nan=True))
+
     @pytest.mark.optional_parquet
     def test_against_standard_files(self):
         datadir = "resources/parquet-testing"


### PR DESCRIPTION
Closes #2567 

This PR corrects detection of `NaN` values and properly returns them. It is worth noting the Pandas will return these as Null when reading from Parquet so the 2 do not align 100% for testing. Previously there was a bad assumption that the SegArray case was handling `NaN` because it properly handles `inf`. This has been updated and detection/processing has been configured to properly return NaN values.

Adds Testing to validate functionality.