### PR TITLE
Fixes #2596: datetime columns in dataframe display bug

### DIFF
--- a/PROTO_tests/tests/dataframe_test.py
+++ b/PROTO_tests/tests/dataframe_test.py
@@ -592,6 +592,14 @@ class TestDataFrame:
         df = pd.DataFrame({"Test": [2**64 - 1, 0]})
         assert df["Test"].dtype == ak.uint64
 
+    def test_head_tail_datetime_display(self):
+        # Reproducer for issue #2596
+        values = ak.array([1689221916000000] * 100, dtype=ak.int64)
+        dt = ak.Datetime(values, unit='u')
+        df = ak.DataFrame({"Datetime from Microseconds": dt})
+        # verify _get_head_tail and _get_head_tail_server match
+        assert df._get_head_tail_server().__repr__() == df._get_head_tail().__repr__()
+
     def test_head_tail_resetting_index(self):
         # Test that issue #2183 is resolved
         df = ak.DataFrame({"cnt": ak.arange(65)})

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -627,7 +627,7 @@ class DataFrame(UserDict):
             elif t == "IPv4":
                 df_dict[msg[1]] = IPv4(create_pdarray(msg[2]))
             elif t == "Datetime":
-                df_dict[msg[1]] = Datetime(create_pdarray(msg[2]), unit=self[msg[1]].unit)
+                df_dict[msg[1]] = Datetime(create_pdarray(msg[2]))
             elif t == "BitVector":
                 df_dict[msg[1]] = BitVector(
                     create_pdarray(msg[2]), width=self[msg[1]].width, reverse=self[msg[1]].reverse

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -641,6 +641,14 @@ class DataFrameTest(ArkoudaTest):
         df = pd.DataFrame({"Test": [2**64 - 1, 0]})
         self.assertEqual(df["Test"].dtype, ak.uint64)
 
+    def test_head_tail_datetime_display(self):
+        # Reproducer for issue #2596
+        values = ak.array([1689221916000000] * 100, dtype=ak.int64)
+        dt = ak.Datetime(values, unit='u')
+        df = ak.DataFrame({"Datetime from Microseconds": dt})
+        # verify _get_head_tail and _get_head_tail_server match
+        self.assertEqual(df._get_head_tail_server().__repr__(), df._get_head_tail().__repr__())
+
     def test_head_tail_resetting_index(self):
         # Test that issue #2183 is resolved
         df = ak.DataFrame({"cnt": ak.arange(65)})


### PR DESCRIPTION
This PR (fixes #2596) fixes the bug in displaying a dataframe with a datetime column and adds test showing the reproducer works correctly now