### PR TITLE
Fixes #2579 - Compression when writing bools with Parquet

### DIFF
--- a/PROTO_tests/tests/io_test.py
+++ b/PROTO_tests/tests/io_test.py
@@ -125,11 +125,10 @@ class TestParquet:
     def test_read_and_write(self, prob_size, dtype, comp):
         ak_arr = make_ak_arrays(prob_size * pytest.nl, dtype)
         with tempfile.TemporaryDirectory(dir=TestParquet.par_test_base_tmp) as tmp_dirname:
-            # compression doesn't work for bool see issue #2579
             ak_arr.to_parquet(
                 f"{tmp_dirname}/pq_test_correct",
                 "my-dset",
-                compression=comp #if dtype != "bool" else None,
+                compression=comp
             )
             pq_arr = ak.read_parquet(f"{tmp_dirname}/pq_test_correct*", "my-dset")
             assert (ak_arr == pq_arr).all()
@@ -187,11 +186,10 @@ class TestParquet:
         np_edge_case = make_edge_case_arrays(dtype)
         ak_edge_case = ak.array(np_edge_case)
         with tempfile.TemporaryDirectory(dir=TestParquet.par_test_base_tmp) as tmp_dirname:
-            # compression doesn't work for bool see issue #2579
             ak_edge_case.to_parquet(
                 f"{tmp_dirname}/pq_test_edge_case",
                 "my-dset",
-                compression=comp #if dtype != "bool" else None,
+                compression=comp
             )
             pq_arr = ak.read_parquet(f"{tmp_dirname}/pq_test_edge_case*", "my-dset")
             if dtype == "float64":
@@ -414,7 +412,6 @@ class TestParquet:
 
     @pytest.mark.parametrize("comp", COMPRESSIONS)
     def test_multi_col_write(self, comp):
-        # TODO update to add compression after this is added for bools in issue #2579
         df_dict = make_multi_col_df()
         akdf = ak.DataFrame(df_dict)
         with tempfile.TemporaryDirectory(dir=TestParquet.par_test_base_tmp) as tmp_dirname:

--- a/PROTO_tests/tests/io_test.py
+++ b/PROTO_tests/tests/io_test.py
@@ -129,7 +129,7 @@ class TestParquet:
             ak_arr.to_parquet(
                 f"{tmp_dirname}/pq_test_correct",
                 "my-dset",
-                compression=comp if dtype != "bool" else None,
+                compression=comp #if dtype != "bool" else None,
             )
             pq_arr = ak.read_parquet(f"{tmp_dirname}/pq_test_correct*", "my-dset")
             assert (ak_arr == pq_arr).all()
@@ -191,7 +191,7 @@ class TestParquet:
             ak_edge_case.to_parquet(
                 f"{tmp_dirname}/pq_test_edge_case",
                 "my-dset",
-                compression=comp if dtype != "bool" else None,
+                compression=comp #if dtype != "bool" else None,
             )
             pq_arr = ak.read_parquet(f"{tmp_dirname}/pq_test_edge_case*", "my-dset")
             if dtype == "float64":
@@ -412,20 +412,21 @@ class TestParquet:
                 x, y = s[i].to_list(), rd_data[i].to_list()
                 assert x == y if dtype != "float64" else np.allclose(x, y, equal_nan=True)
 
-    def test_multi_col_write(self):
+    @pytest.mark.parametrize("comp", COMPRESSIONS)
+    def test_multi_col_write(self, comp):
         # TODO update to add compression after this is added for bools in issue #2579
         df_dict = make_multi_col_df()
         akdf = ak.DataFrame(df_dict)
         with tempfile.TemporaryDirectory(dir=TestParquet.par_test_base_tmp) as tmp_dirname:
             # use multi-column write to generate parquet file
-            akdf.to_parquet(f"{tmp_dirname}/multi_col_parquet")
+            akdf.to_parquet(f"{tmp_dirname}/multi_col_parquet", compression=comp)
             # read files and ensure that all resulting fields are as expected
             rd_data = ak.read_parquet(f"{tmp_dirname}/multi_col_parquet*")
             rd_df = ak.DataFrame(rd_data)
             pd.testing.assert_frame_equal(akdf.to_pandas(), rd_df.to_pandas())
 
             # test save with index true
-            akdf.to_parquet(f"{tmp_dirname}/multi_col_parquet", index=True)
+            akdf.to_parquet(f"{tmp_dirname}/multi_col_parquet", index=True, compression=comp)
             rd_data = ak.read_parquet(f"{tmp_dirname}/multi_col_parquet*")
             rd_df = ak.DataFrame(rd_data)
             pd.testing.assert_frame_equal(akdf.to_pandas(), rd_df.to_pandas())

--- a/PROTO_tests/tests/io_test.py
+++ b/PROTO_tests/tests/io_test.py
@@ -15,6 +15,7 @@ from arkouda import io_util
 NUMERIC_TYPES = ["int64", "float64", "bool", "uint64"]
 NUMERIC_AND_STR_TYPES = NUMERIC_TYPES + ["str"]
 
+
 def make_ak_arrays(size, dtype):
     if dtype in ["int64", "float64"]:
         # randint for float is equivalent to uniform
@@ -125,11 +126,7 @@ class TestParquet:
     def test_read_and_write(self, prob_size, dtype, comp):
         ak_arr = make_ak_arrays(prob_size * pytest.nl, dtype)
         with tempfile.TemporaryDirectory(dir=TestParquet.par_test_base_tmp) as tmp_dirname:
-            ak_arr.to_parquet(
-                f"{tmp_dirname}/pq_test_correct",
-                "my-dset",
-                compression=comp
-            )
+            ak_arr.to_parquet(f"{tmp_dirname}/pq_test_correct", "my-dset", compression=comp)
             pq_arr = ak.read_parquet(f"{tmp_dirname}/pq_test_correct*", "my-dset")
             assert (ak_arr == pq_arr).all()
 
@@ -143,7 +140,7 @@ class TestParquet:
 
             # verify load_all works
             gen_arr = ak.load_all(path_prefix=f"{tmp_dirname}/pq_test_correct")
-            assert (ak_arr == gen_arr['my-dset']).all()
+            assert (ak_arr == gen_arr["my-dset"]).all()
 
     @pytest.mark.parametrize("prob_size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", NUMERIC_AND_STR_TYPES)
@@ -186,11 +183,7 @@ class TestParquet:
         np_edge_case = make_edge_case_arrays(dtype)
         ak_edge_case = ak.array(np_edge_case)
         with tempfile.TemporaryDirectory(dir=TestParquet.par_test_base_tmp) as tmp_dirname:
-            ak_edge_case.to_parquet(
-                f"{tmp_dirname}/pq_test_edge_case",
-                "my-dset",
-                compression=comp
-            )
+            ak_edge_case.to_parquet(f"{tmp_dirname}/pq_test_edge_case", "my-dset", compression=comp)
             pq_arr = ak.read_parquet(f"{tmp_dirname}/pq_test_edge_case*", "my-dset")
             if dtype == "float64":
                 assert np.allclose(np_edge_case, pq_arr.to_ndarray(), equal_nan=True)

--- a/pytest_PROTO.ini
+++ b/pytest_PROTO.ini
@@ -6,7 +6,7 @@ addopts =
 filterwarnings =
     ignore:Version mismatch between client .*
 testpaths =
-    tests/tests/*_test
+    tests/*_test
 ;    tests/benchmarks/*_benchmark.py
 norecursedirs =
     .git

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -928,19 +928,14 @@ int cpp_writeMultiColToParquet(const char* filename, void* column_names,
     // assign the proper compression
     if(compression == SNAPPY_COMP) {
       builder.compression(parquet::Compression::SNAPPY);
-      builder.encoding(parquet::Encoding::RLE);
     } else if (compression == GZIP_COMP) {
       builder.compression(parquet::Compression::GZIP);
-      builder.encoding(parquet::Encoding::RLE);
     } else if (compression == BROTLI_COMP) {
       builder.compression(parquet::Compression::BROTLI);
-      builder.encoding(parquet::Encoding::RLE);
     } else if (compression == ZSTD_COMP) {
       builder.compression(parquet::Compression::ZSTD);
-      builder.encoding(parquet::Encoding::RLE);
     } else if (compression == LZ4_COMP) {
       builder.compression(parquet::Compression::LZ4);
-      builder.encoding(parquet::Encoding::RLE);
     }
     std::shared_ptr<parquet::WriterProperties> props = builder.build();
 
@@ -1250,19 +1245,14 @@ int cpp_writeColumnToParquet(const char* filename, void* chpl_arr,
     // assign the proper compression
     if(compression == SNAPPY_COMP) {
       builder.compression(parquet::Compression::SNAPPY);
-      builder.encoding(parquet::Encoding::RLE);
     } else if (compression == GZIP_COMP) {
       builder.compression(parquet::Compression::GZIP);
-      builder.encoding(parquet::Encoding::RLE);
     } else if (compression == BROTLI_COMP) {
       builder.compression(parquet::Compression::BROTLI);
-      builder.encoding(parquet::Encoding::RLE);
     } else if (compression == ZSTD_COMP) {
       builder.compression(parquet::Compression::ZSTD);
-      builder.encoding(parquet::Encoding::RLE);
     } else if (compression == LZ4_COMP) {
       builder.compression(parquet::Compression::LZ4);
-      builder.encoding(parquet::Encoding::RLE);
     }
     std::shared_ptr<parquet::WriterProperties> props = builder.build();
 
@@ -1352,19 +1342,14 @@ int cpp_writeStrColumnToParquet(const char* filename, void* chpl_arr, void* chpl
     // assign the proper compression
     if(compression == SNAPPY_COMP) {
       builder.compression(parquet::Compression::SNAPPY);
-      builder.encoding(parquet::Encoding::RLE);
     } else if (compression == GZIP_COMP) {
       builder.compression(parquet::Compression::GZIP);
-      builder.encoding(parquet::Encoding::RLE);
     } else if (compression == BROTLI_COMP) {
       builder.compression(parquet::Compression::BROTLI);
-      builder.encoding(parquet::Encoding::RLE);
     } else if (compression == ZSTD_COMP) {
       builder.compression(parquet::Compression::ZSTD);
-      builder.encoding(parquet::Encoding::RLE);
     } else if (compression == LZ4_COMP) {
       builder.compression(parquet::Compression::LZ4);
-      builder.encoding(parquet::Encoding::RLE);
     }
     std::shared_ptr<parquet::WriterProperties> props = builder.build();
 
@@ -1435,19 +1420,14 @@ int cpp_writeStrListColumnToParquet(const char* filename, void* chpl_segs, void*
       // assign the proper compression
       if(compression == SNAPPY_COMP) {
         builder.compression(parquet::Compression::SNAPPY);
-        builder.encoding(parquet::Encoding::RLE);
       } else if (compression == GZIP_COMP) {
         builder.compression(parquet::Compression::GZIP);
-        builder.encoding(parquet::Encoding::RLE);
       } else if (compression == BROTLI_COMP) {
         builder.compression(parquet::Compression::BROTLI);
-        builder.encoding(parquet::Encoding::RLE);
       } else if (compression == ZSTD_COMP) {
         builder.compression(parquet::Compression::ZSTD);
-        builder.encoding(parquet::Encoding::RLE);
       } else if (compression == LZ4_COMP) {
         builder.compression(parquet::Compression::LZ4);
-        builder.encoding(parquet::Encoding::RLE);
       }
       std::shared_ptr<parquet::WriterProperties> props = builder.build();
 
@@ -1544,19 +1524,14 @@ int cpp_writeListColumnToParquet(const char* filename, void* chpl_segs, void* ch
     // assign the proper compression
     if(compression == SNAPPY_COMP) {
       builder.compression(parquet::Compression::SNAPPY);
-      builder.encoding(parquet::Encoding::RLE);
     } else if (compression == GZIP_COMP) {
       builder.compression(parquet::Compression::GZIP);
-      builder.encoding(parquet::Encoding::RLE);
     } else if (compression == BROTLI_COMP) {
       builder.compression(parquet::Compression::BROTLI);
-      builder.encoding(parquet::Encoding::RLE);
     } else if (compression == ZSTD_COMP) {
       builder.compression(parquet::Compression::ZSTD);
-      builder.encoding(parquet::Encoding::RLE);
     } else if (compression == LZ4_COMP) {
       builder.compression(parquet::Compression::LZ4);
-      builder.encoding(parquet::Encoding::RLE);
     }
     std::shared_ptr<parquet::WriterProperties> props = builder.build();
 
@@ -1725,19 +1700,14 @@ int cpp_createEmptyListParquetFile(const char* filename, const char* dsetname, i
     // assign the proper compression
     if(compression == SNAPPY_COMP) {
       builder.compression(parquet::Compression::SNAPPY);
-      builder.encoding(parquet::Encoding::RLE);
     } else if (compression == GZIP_COMP) {
       builder.compression(parquet::Compression::GZIP);
-      builder.encoding(parquet::Encoding::RLE);
     } else if (compression == BROTLI_COMP) {
       builder.compression(parquet::Compression::BROTLI);
-      builder.encoding(parquet::Encoding::RLE);
     } else if (compression == ZSTD_COMP) {
       builder.compression(parquet::Compression::ZSTD);
-      builder.encoding(parquet::Encoding::RLE);
     } else if (compression == LZ4_COMP) {
       builder.compression(parquet::Compression::LZ4);
-      builder.encoding(parquet::Encoding::RLE);
     }
     std::shared_ptr<parquet::WriterProperties> props = builder.build();
     std::shared_ptr<parquet::ParquetFileWriter> file_writer =
@@ -1778,19 +1748,14 @@ int cpp_createEmptyParquetFile(const char* filename, const char* dsetname, int64
     // assign the proper compression
     if(compression == SNAPPY_COMP) {
       builder.compression(parquet::Compression::SNAPPY);
-      builder.encoding(parquet::Encoding::RLE);
     } else if (compression == GZIP_COMP) {
       builder.compression(parquet::Compression::GZIP);
-      builder.encoding(parquet::Encoding::RLE);
     } else if (compression == BROTLI_COMP) {
       builder.compression(parquet::Compression::BROTLI);
-      builder.encoding(parquet::Encoding::RLE);
     } else if (compression == ZSTD_COMP) {
       builder.compression(parquet::Compression::ZSTD);
-      builder.encoding(parquet::Encoding::RLE);
     } else if (compression == LZ4_COMP) {
       builder.compression(parquet::Compression::LZ4);
-      builder.encoding(parquet::Encoding::RLE);
     }
     std::shared_ptr<parquet::WriterProperties> props = builder.build();
     std::shared_ptr<parquet::ParquetFileWriter> file_writer =

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -194,6 +194,18 @@ class ParquetTest(ArkoudaTest):
                 # validate the list read out matches the array used to write
                 self.assertListEqual(rd_arr.to_list(), a.to_list())
 
+        b = ak.randint(0, 2, 150, dtype=ak.bool)
+        for comp in COMPRESSIONS:
+            with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
+                # write with the selected compression
+                b.to_parquet(f"{tmp_dirname}/compress_test", compression=comp)
+
+                # ensure read functions
+                rd_arr = ak.read_parquet(f"{tmp_dirname}/compress_test*", "array")
+
+                # validate the list read out matches the array used to write
+                self.assertListEqual(rd_arr.to_list(), b.to_list())
+
     def test_gzip_nan_rd(self):
         # create pandas dataframe
         pdf = pd.DataFrame(


### PR DESCRIPTION
Closes #2579

This PR removes the specification of `RLE` encoding when writing Parquet files. This was only being done with compression and is not necessary as Parquet will automatically determine the best encoding strategy if one is not specified. This allows `bool` values to be written to Parquet with no issue and does not impact writing of any other types.

Updates existing test framework to verify to test compression specifically with `bool` values.

Updates the `PROTO_tests` of Parquet to test compression on all types.

Updates `pytest_PROTO.ini` test path so that it runs properly without modification.