### PR TITLE
Closes #2603: Rework `arange` handling of `uint` and `bigint` arguments

### DIFF
--- a/src/NumPyDType.chpl
+++ b/src/NumPyDType.chpl
@@ -52,7 +52,7 @@ module NumPyDType
     */
     proc str2dtype(dstr:string): DType {
         if dstr == "int64" || dstr == "int" {return DType.Int64;}
-        if dstr == "uint64" || dstr == "unint" {return DType.UInt64;}
+        if dstr == "uint64" || dstr == "uint" {return DType.UInt64;}
         if dstr == "float64" || dstr == "float" {return DType.Float64;}        
         if dstr == "bool" {return DType.Bool;}
         if dstr == "uint8" {return DType.UInt8;}

--- a/src/SequenceMsg.chpl
+++ b/src/SequenceMsg.chpl
@@ -25,71 +25,63 @@ module SequenceMsg {
     :returns: MsgTuple
     */
     proc arangeMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
-        var repMsg: string; // response message
-        var start = msgArgs.get("start").getIntValue();
-        var stop = msgArgs.get("stop").getIntValue();
-        var stride = msgArgs.get("stride").getIntValue();
-        // compute length
-        var len = (stop - start + stride - 1) / stride;
-        overMemLimit(8*len);
-        // get next symbol name
-        var rname = st.nextName();
+        proc arangeHelper(start: ?t, stop: t, stride: t, len, rname) throws {
+            smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
+                "cmd: %s start: %t stop: %t stride: %t : len: %t rname: %s".format(
+                cmd, start, stop, stride, len, rname));
+            
+            var t1 = Time.timeSinceEpoch().totalSeconds();
+            var ea = makeDistArray(len, t);
+            smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                        "alloc time = %i sec".format(Time.timeSinceEpoch().totalSeconds() - t1));
 
-        smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
-                       "cmd: %s start: %i stop: %i stride: %i : len: %i rname: %s".format(
-                        cmd, start, stop, stride, len, rname));
-        
-        var t1 = Time.timeSinceEpoch().totalSeconds();
-        var e = st.addEntry(rname, len, int);
-        smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                      "alloc time = %i sec".format(Time.timeSinceEpoch().totalSeconds() - t1));
-
-        t1 = Time.timeSinceEpoch().totalSeconds();
-        ref ea = e.a;
-        const ref ead = e.a.domain;
-        forall (ei, i) in zip(ea,ead) {
-            ei = start + (i * stride);
+            t1 = Time.timeSinceEpoch().totalSeconds();
+            const ref ead = ea.domain;
+            forall (ei, i) in zip(ea, ead) {
+                ei = start + (i * stride);
+            }
+            var e = st.addEntry(rname, new shared SymEntry(ea));
+            smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                        "compute time = %i sec".format(Time.timeSinceEpoch().totalSeconds() - t1));
         }
 
-        smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                      "compute time = %i sec".format(Time.timeSinceEpoch().totalSeconds() - t1));
-
+        var repMsg: string; // response message
+        var dtype = str2dtype(msgArgs.getValueOf("dtype"));
+        // get next symbol name
+        var rname = st.nextName();
+        select dtype {
+            when DType.Int64 {
+                var start = msgArgs.get("start").getIntValue();
+                var stop = msgArgs.get("stop").getIntValue();
+                var stride = msgArgs.get("stride").getIntValue();
+                // compute length
+                var len = (stop - start + stride - 1) / stride;
+                overMemLimit(8*len);
+                arangeHelper(start, stop, stride, len, rname);
+            }
+            when DType.UInt64 {
+                var start = msgArgs.get("start").getUIntValue();
+                var stop = msgArgs.get("stop").getUIntValue();
+                var stride = msgArgs.get("stride").getUIntValue();
+                // compute length
+                var len = ((stop - start + stride - 1) / stride):int;
+                overMemLimit(8*len);
+                arangeHelper(start, stop, stride, len, rname);
+            }
+            when DType.BigInt {
+                var start = msgArgs.get("start").getBigIntValue();
+                var stop = msgArgs.get("stop").getBigIntValue();
+                var stride = msgArgs.get("stride").getBigIntValue();
+                // compute length
+                var len = ((stop - start + stride - 1) / stride):int;
+                // TODO update when we have a better way to handle bigint mem estimation
+                arangeHelper(start, stop, stride, len, rname);
+            }
+        }
         repMsg = "created " + st.attrib(rname);
         smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }
-
-    proc bigIntArangeMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
-        var repMsg: string; // response message
-        var start = msgArgs.get("start").getBigIntValue();
-        var stop = msgArgs.get("stop").getBigIntValue();
-        var stride = msgArgs.get("stride").getBigIntValue();
-        // compute length
-        var len = (stop - start + stride - 1) / stride;
-        // TODO figure out a way to do memory checking for bigint
-        // overMemLimit(8*len);
-        // get next symbol name
-        var rname = st.nextName();
-
-        smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
-                       "cmd: %s start: %jt stop: %jt stride: %jt : len: %jt rname: %s".format(
-                        cmd, start, stop, stride, len, rname));
-        
-        var t1 = Time.timeSinceEpoch().totalSeconds();
-        var tmp = makeDistArray(len:int, bigint);
-        const ref td = tmp.domain;
-        forall (ti, i) in zip(tmp,td) {
-            ti = start + (i * stride);
-        }
-        var e = st.addEntry(rname, new shared SymEntry(tmp));
-
-        smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                      "compute time = %i sec".format(Time.timeSinceEpoch().totalSeconds() - t1));
-
-        repMsg = "created " + st.attrib(rname);
-        smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-        return new MsgTuple(repMsg, MsgType.NORMAL);
-    }  
 
     /* 
     Creates a sym entry with distributed array adhering to the Msg parameters (start, stop, len)
@@ -139,6 +131,5 @@ module SequenceMsg {
 
     use CommandMap;
     registerFunction("arange", arangeMsg, getModuleName());
-    registerFunction("bigintArange", bigIntArangeMsg, getModuleName());
     registerFunction("linspace", linspaceMsg, getModuleName());
 }

--- a/tests/pdarray_creation_test.py
+++ b/tests/pdarray_creation_test.py
@@ -116,8 +116,9 @@ class PdarrayCreationTest(ArkoudaTest):
         self.assertListEqual([0, 1, 2], uint_stop.to_list())
         self.assertEqual(ak.uint64, uint_stop.dtype)
 
-        uint_start_stop = ak.arange(3, 7, dtype=ak.uint64)
-        self.assertListEqual([3, 4, 5, 6], uint_start_stop.to_list())
+        uint_start_stop = ak.arange(2**63 + 3, 2**63 + 7)
+        ans = ak.arange(3, 7, dtype=ak.uint64) + 2**63
+        self.assertListEqual(ans.to_list(), uint_start_stop.to_list())
         self.assertEqual(ak.uint64, uint_start_stop.dtype)
 
         uint_start_stop_stride = ak.arange(3, 7, 2, dtype=ak.uint64)


### PR DESCRIPTION
This PR (closes #2603) reworks how arange handles `uint` and `bigint` arguments. This update provides the correct return for something in the `> 2**63` range such as `ak.arange(2**63, 2**63+15)`

Note, we might need to update #2584 to account for this changed test