### PR TITLE
Closes #2512 - Snapshot to HDF5 

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -1543,7 +1543,7 @@ class DataFrame(UserDict):
                 }
             )
             if isinstance(obj, Categorical_)
-            else json.dumps({"segments": obj.segments, "values": obj.values})
+            else json.dumps({"segments": obj.segments.name, "values": obj.values.name})
             for k, obj in self.items()
         ]
         dtypes = [

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -4,7 +4,6 @@ import os
 from typing import Dict, List, Mapping, Optional, Union, cast
 from warnings import warn
 
-import dill
 import pandas as pd  # type: ignore
 from typeguard import typechecked
 
@@ -1937,9 +1936,7 @@ def snapshot(filename):
     for name, val in [
         (n, v) for n, v in callers_local_vars if not n.startswith("__") and not isinstance(v, ModuleType)
     ]:
-        # TODO - should dataframe save format be updated so we don't need separate files
         if isinstance(val, (pdarray, Categorical, SegArray, Strings, DataFrame, GroupBy)):
-            # currently save dataframes to own files so they can be recreated as dataframe
             if isinstance(val, DataFrame):
                 val._to_hdf_snapshot(filename, dataset=name, mode=mode)
             else:
@@ -1948,12 +1945,5 @@ def snapshot(filename):
 
 
 def restore(filename):
-    # TODO - remove commented out code if just returning dict
-    # import inspect
     restore_files = glob.glob(f"{filename}_SNAPSHOT_LOCALE*")
     return read_hdf(restore_files)
-
-    # for name, obj in restore_data.items():
-    #     inspect.currentframe().f_back.f_locals[name] = obj
-    # print(inspect.currentframe().f_back.f_locals.keys())
-    # return restore_data.keys()

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -1926,6 +1926,27 @@ def read_tagged_data(
 
 
 def snapshot(filename):
+    """
+    Create a snapshot of the current Arkouda namespace. All currently accessible variables containing
+    Arkouda objects will be written to an HDF5 file.
+
+    Unlike other save/load functions, this maintains the integrity of dataframes.
+
+    Current Variable names are used as the dataset name when saving.
+
+    Parameters
+    ----------
+    filename: str
+    Name to use when storing file
+
+    Returns
+    --------
+    None
+
+    See Also
+    ---------
+    ak.restore
+    """
     import inspect
     from types import ModuleType
     from arkouda.dataframe import DataFrame
@@ -1945,5 +1966,22 @@ def snapshot(filename):
 
 
 def restore(filename):
+    """
+    Return data saved using `ak.snapshot`
+
+    Parameters
+    ----------
+    filename: str
+    Name used to create snapshot to be read
+
+    Returns
+    --------
+    Dict
+
+    Notes
+    ------
+    Unlike other save/load methods using snapshot restore will save DataFrames alongside other
+    objects in HDF5. Thus, they are returned within the dictionary as a dataframe.
+    """
     restore_files = glob.glob(f"{filename}_SNAPSHOT_LOCALE*")
     return read_hdf(restore_files)

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -2411,22 +2411,18 @@ module HDF5Msg {
                                 when DType.Int64 {
                                     var values = toSymEntry(vals_entry, int);
                                     writeSegmentedDistDset(filenames, "/%s/%s".format(group, dset), ot: string, overwrite, values.a, segments.a, st, int);
-                                    // writeSegmentedDistDset(filenames, group, ot: string, overwrite, values.a, segments.a, st, int);
                                 }
                                 when DType.UInt64 {
                                     var values = toSymEntry(vals_entry, uint);
                                     writeSegmentedDistDset(filenames, "/%s/%s".format(group, dset), ot: string, overwrite, values.a, segments.a, st, uint);
-                                    // writeSegmentedDistDset(filenames, group, ot: string, overwrite, values.a, segments.a, st, uint);
                                 }
                                 when DType.Float64 {
                                     var values = toSymEntry(vals_entry, real);
                                     writeSegmentedDistDset(filenames, "/%s/%s".format(group, dset), ot: string, overwrite, values.a, segments.a, st, real);
-                                    // writeSegmentedDistDset(filenames, group, ot: string, overwrite, values.a, segments.a, st, real);
                                 }
                                 when DType.Bool {
                                     var values = toSymEntry(vals_entry, bool);
                                     writeSegmentedDistDset(filenames, "/%s/%s".format(group, dset), ot: string, overwrite, values.a, segments.a, st, bool);
-                                    // writeSegmentedDistDset(filenames, group, ot: string, overwrite, values.a, segments.a, st, bool);
                                 }
                                 when DType.BigInt {
                                     var values = toSymEntry(vals_entry, bigint);

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -2181,31 +2181,31 @@ module HDF5Msg {
                                 when DType.Int64 {
                                     var values = toSymEntry(vals_entry, int);
                                     //localize values and write dataset
-                                    writeSegmentedLocalDset(file_id, group, values, segments, true, int);
+                                    writeSegmentedLocalDset(file_id, "%s/%s".format(group, dset), values, segments, true, int);
                                     dtype = getDataType(int);
                                 }
                                 when DType.UInt64 {
                                     var values = toSymEntry(vals_entry, uint);
                                     //localize values and write dataset
-                                    writeSegmentedLocalDset(file_id, group, values, segments, true, uint);
+                                    writeSegmentedLocalDset(file_id, "%s/%s".format(group, dset), values, segments, true, uint);
                                     dtype = getDataType(uint);
                                 }
                                 when DType.Float64 {
                                     var values = toSymEntry(vals_entry, real);
                                     //localize values and write dataset
-                                    writeSegmentedLocalDset(file_id, group, values, segments, true, real);
+                                    writeSegmentedLocalDset(file_id, "%s/%s".format(group, dset), values, segments, true, real);
                                     dtype = getDataType(real);
                                 }
                                 when DType.Bool {
                                     var values = toSymEntry(vals_entry, bool);
                                     //localize values and write dataset
-                                    writeSegmentedLocalDset(file_id, group, values, segments, true, bool);
+                                    writeSegmentedLocalDset(file_id, "%s/%s".format(group, dset), values, segments, true, bool);
                                     dtype = getDataType(bool);
                                 }
                                 when (DType.BigInt) {
                                     var values = toSymEntry(vals_entry, bigint);
                                     // create the group
-                                    validateGroup(file_id, f, "%s/%s".format(group, SEGMENTED_VALUE_NAME), overwrite); // stored as group - group uses the dataset name
+                                    validateGroup(file_id, f, "%s/%s/%s".format(group, dset, SEGMENTED_VALUE_NAME), overwrite); // stored as group - group uses the dataset name
                                     //localize values and write dataset
                                     writeSegmentedLocalDset(file_id, group, values, segments, true, bigint);
                                     dtype = getDataType(uint);
@@ -2213,9 +2213,9 @@ module HDF5Msg {
                                 when (DType.Strings){
                                     var values = toSegStringSymEntry(vals_entry);
                                     // create the group
-                                    validateGroup(file_id, f, "%s/%s".format(group, SEGMENTED_VALUE_NAME), overwrite);
+                                    validateGroup(file_id, f, "%s/%s/%s".format(group, dset, SEGMENTED_VALUE_NAME), overwrite);
                                     //localize values and write dataset
-                                    writeNestedSegmentedLocalDset(file_id, group, values, segments, true, uint(8));
+                                    writeNestedSegmentedLocalDset(file_id, "%s/%s".format(group, dset), values, segments, true, uint(8));
                                     dtype = getDataType(uint(8));
                                 }
                                 otherwise {
@@ -2410,27 +2410,31 @@ module HDF5Msg {
                             select vals_entry.dtype {
                                 when DType.Int64 {
                                     var values = toSymEntry(vals_entry, int);
-                                    writeSegmentedDistDset(filenames, group, ot: string, overwrite, values.a, segments.a, st, int);
+                                    writeSegmentedDistDset(filenames, "/%s/%s".format(group, dset), ot: string, overwrite, values.a, segments.a, st, int);
+                                    // writeSegmentedDistDset(filenames, group, ot: string, overwrite, values.a, segments.a, st, int);
                                 }
                                 when DType.UInt64 {
                                     var values = toSymEntry(vals_entry, uint);
-                                    writeSegmentedDistDset(filenames, group, ot: string, overwrite, values.a, segments.a, st, uint);
+                                    writeSegmentedDistDset(filenames, "/%s/%s".format(group, dset), ot: string, overwrite, values.a, segments.a, st, uint);
+                                    // writeSegmentedDistDset(filenames, group, ot: string, overwrite, values.a, segments.a, st, uint);
                                 }
                                 when DType.Float64 {
                                     var values = toSymEntry(vals_entry, real);
-                                    writeSegmentedDistDset(filenames, group, ot: string, overwrite, values.a, segments.a, st, real);
+                                    writeSegmentedDistDset(filenames, "/%s/%s".format(group, dset), ot: string, overwrite, values.a, segments.a, st, real);
+                                    // writeSegmentedDistDset(filenames, group, ot: string, overwrite, values.a, segments.a, st, real);
                                 }
                                 when DType.Bool {
                                     var values = toSymEntry(vals_entry, bool);
-                                    writeSegmentedDistDset(filenames, group, ot: string, overwrite, values.a, segments.a, st, bool);
+                                    writeSegmentedDistDset(filenames, "/%s/%s".format(group, dset), ot: string, overwrite, values.a, segments.a, st, bool);
+                                    // writeSegmentedDistDset(filenames, group, ot: string, overwrite, values.a, segments.a, st, bool);
                                 }
                                 when DType.BigInt {
                                     var values = toSymEntry(vals_entry, bigint);
-                                    writeSegmentedDistDset(filenames, group, ot: string, overwrite, values.a, segments.a, st, bigint, values.max_bits);
+                                    writeSegmentedDistDset(filenames, "/%s/%s".format(group, dset), ot: string, overwrite, values.a, segments.a, st, bigint, values.max_bits);
                                 }
                                 when DType.Strings {
                                     var values = toSegStringSymEntry(vals_entry);
-                                    writeNestedSegmentedDistDset(filenames, group, ot: string, overwrite, values, segments.a, st, uint(8));
+                                    writeNestedSegmentedDistDset(filenames, "/%s/%s".format(group, dset), ot: string, overwrite, values, segments.a, st, uint(8));
                                 }
                                 otherwise {
                                     throw getErrorWithContext(

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -719,30 +719,3 @@ class DataFrameTest(ArkoudaTest):
         self.assertListEqual(df.index.to_list(), df2.index.to_list())
         self.assertListEqual(df["a"].to_list(), df2["a"].to_list())
         self.assertListEqual(df["b"].to_list(), df2["b"].to_list())
-
-    def test_snapshot(self):
-        from pandas.testing import assert_frame_equal
-
-        df = build_ak_df()
-        # standard index
-        column_order = ["userName", "userID", "item", "day", "amount", "bi"]
-        with tempfile.TemporaryDirectory(dir=DataFrameTest.df_test_base_tmp) as tmp_dirname:
-            fname = tmp_dirname + "/snapshot_test"
-            df._to_hdf_snapshot(fname)
-            rd_data = ak.read_hdf(fname + "_*")
-
-            self.assertTrue(
-                assert_frame_equal(df[column_order].to_pandas(), rd_data[column_order].to_pandas())
-                is None
-            )
-
-        df._set_index(["A" + str(i) for i in range(len(df))])
-        with tempfile.TemporaryDirectory(dir=DataFrameTest.df_test_base_tmp) as tmp_dirname:
-            fname = tmp_dirname + "/snapshot_test"
-            df._to_hdf_snapshot(fname)
-            rd_data = ak.read_hdf(fname + "_*")
-
-            self.assertTrue(
-                assert_frame_equal(df[column_order].to_pandas(), rd_data[column_order].to_pandas())
-                is None
-            )

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -1250,9 +1250,9 @@ class IOTest(ArkoudaTest):
 
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
             ak.snapshot(f"{tmp_dirname}/arkouda_snapshot_test")
-            print(dir())
             # delete variables
             del df
+            del df_str_idx
             del a
             del s
             del c
@@ -1261,6 +1261,8 @@ class IOTest(ArkoudaTest):
             # verify no longer in the namespace
             with self.assertRaises(NameError):
                 self.assertTrue(not df)
+            with self.assertRaises(NameError):
+                self.assertTrue(not df)df_str_idx
             with self.assertRaises(NameError):
                 self.assertTrue(not a)
             with self.assertRaises(NameError):

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -1262,7 +1262,7 @@ class IOTest(ArkoudaTest):
             with self.assertRaises(NameError):
                 self.assertTrue(not df)
             with self.assertRaises(NameError):
-                self.assertTrue(not df)df_str_idx
+                self.assertTrue(not df_str_idx)
             with self.assertRaises(NameError):
                 self.assertTrue(not a)
             with self.assertRaises(NameError):

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -1217,6 +1217,79 @@ class IOTest(ArkoudaTest):
             self.assertListEqual(x.segments.to_list(), rd.segments.to_list())
             self.assertListEqual(x.values.to_list(), rd.values.to_list())
 
+    def test_snapshot(self):
+        from pandas.testing import assert_frame_equal
+        df = ak.DataFrame(
+            {
+                "int_col": ak.arange(10),
+                "uint_col": ak.array([i + 2**63 for i in range(10)], dtype=ak.uint64),
+                "float_col": ak.linspace(-3.5, 3.5, 10),
+                "bool_col": ak.randint(0, 2, 10, dtype=ak.bool),
+                "bigint_col": ak.array([i + 2**200 for i in range(10)], dtype=ak.bigint),
+                "segarr_col": ak.SegArray(ak.arange(0, 20, 2), ak.randint(0, 3, 20)),
+                "str_col": ak.random_strings_uniform(0, 3, 10),
+            }
+        )
+        df_str_idx = df.copy()
+        df_str_idx._set_index(["A" + str(i) for i in range(len(df))])
+        col_order = df.columns
+        df_ref = df.to_pandas()
+        df_str_idx_ref = df_str_idx.to_pandas()
+        a = ak.randint(0, 10, 100)
+        a_ref = a.to_list()
+        s = ak.random_strings_uniform(0, 5, 50)
+        s_ref = s.to_list()
+        c = ak.Categorical(s)
+        c_ref = c.to_list()
+        g = ak.GroupBy(a)
+        g_ref = {
+            "perm": g.permutation.to_list(),
+            "keys": g.keys.to_list(),
+            "segments": g.segments.to_list(),
+        }
+
+        with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
+            ak.snapshot(f"{tmp_dirname}/arkouda_snapshot_test")
+            print(dir())
+            # delete variables
+            del df
+            del a
+            del s
+            del c
+            del g
+
+            # verify no longer in the namespace
+            with self.assertRaises(NameError):
+                self.assertTrue(not df)
+            with self.assertRaises(NameError):
+                self.assertTrue(not a)
+            with self.assertRaises(NameError):
+                self.assertTrue(not s)
+            with self.assertRaises(NameError):
+                self.assertTrue(not c)
+            with self.assertRaises(NameError):
+                self.assertTrue(not g)
+
+            # restore the variables
+            data = ak.restore(f"{tmp_dirname}/arkouda_snapshot_test")
+            for vn in ["df", "df_str_idx", "a", "s", "c", "g"]:
+                # ensure all variable names returned
+                self.assertTrue(vn in data.keys())
+
+            # validate that restored variables are correct
+            self.assertTrue(
+                assert_frame_equal(df_ref[col_order], data["df"].to_pandas()[col_order]) is None
+            )
+            self.assertTrue(
+                assert_frame_equal(df_str_idx_ref[col_order], data["df_str_idx"].to_pandas()[col_order]) is None
+            )
+            self.assertListEqual(a_ref, data["a"].to_list())
+            self.assertListEqual(s_ref, data["s"].to_list())
+            self.assertListEqual(c_ref, data["c"].to_list())
+            self.assertListEqual(g_ref["perm"], data["g"].permutation.to_list())
+            self.assertListEqual(g_ref["keys"], data["g"].keys.to_list())
+            self.assertListEqual(g_ref["segments"], data["g"].segments.to_list())
+
     def tearDown(self):
         super(IOTest, self).tearDown()
         for f in glob.glob("{}/*".format(IOTest.io_test_dir)):


### PR DESCRIPTION
Closes #2512

This PR adds the ability to snapshot to HDF5 within Arkouda. The workflow takes and saves off all supported Arkouda objects in the namespace using `ak.snapshot(filename)`. These snapshots can then be loaded using `ak.restore(filename)`. The initial hope was to run the variables to the namespace upon restore, but there were a few scoping issues that prevented this in all situations. Instead, of using one method in certain situations and another elsewhere, I felt it better for this feature to remain consistent. As a result, `ak.restore` will return a dictionary identical to those from `ak.read` and `ak.load_all`. This uses the DataFrame storage format added in PR #2599, so on loading the file, DataFrames are returned as DataFrames within the return dictionary.

The return dictionary will be such that the key is the variable name that was in use at the time of the snapshot and the value will be the object.

Supporting updates to testing. The snapshot test is removed from `dataframe_test.py` and then full snapshot testing is added `io_test.py`. Expands testing to include segarray in dataframes.

Fixes some oversights from #2599 with SegArray