### PR TITLE
Closed #2616: `index_test.py` conversion for new framework

### DIFF
--- a/PROTO_tests/tests/index_test.py
+++ b/PROTO_tests/tests/index_test.py
@@ -1,0 +1,105 @@
+import pytest
+
+import arkouda as ak
+
+
+class TestIndex:
+    def test_index_creation(self):
+        idx = ak.Index(ak.arange(5))
+
+        assert isinstance(idx, ak.Index)
+        assert idx.size == 5
+        assert idx.to_list() == [i for i in range(5)]
+
+    def test_multiindex_creation(self):
+        # test list generation
+        idx = ak.MultiIndex([ak.arange(5), ak.arange(5)])
+        assert isinstance(idx, ak.MultiIndex)
+        assert idx.levels == 2
+        assert idx.size == 5
+
+        # test tuple generation
+        idx = ak.MultiIndex((ak.arange(5), ak.arange(5)))
+        assert isinstance(idx, ak.MultiIndex)
+        assert idx.levels == 2
+        assert idx.size == 5
+
+        with pytest.raises(TypeError):
+            idx = ak.MultiIndex(ak.arange(5))
+
+        with pytest.raises(ValueError):
+            idx = ak.MultiIndex([ak.arange(5), ak.arange(3)])
+
+    def test_is_unique(self):
+        i = ak.Index(ak.array([0, 1, 2]))
+        assert i.is_unique
+
+        i = ak.Index(ak.array([0, 1, 1]))
+        assert not i.is_unique
+
+    def test_factory(self):
+        idx = ak.Index.factory(ak.arange(5))
+        assert isinstance(idx, ak.Index)
+
+        idx = ak.Index.factory([ak.arange(5), ak.arange(5)])
+        assert isinstance(idx, ak.MultiIndex)
+
+    def test_argsort(self):
+        idx = ak.Index.factory(ak.arange(5))
+        i = idx.argsort(False)
+        assert i.to_list() == [4, 3, 2, 1, 0]
+
+        idx = ak.Index(ak.array([1, 0, 4, 2, 5, 3]))
+        i = idx.argsort()
+        # values should be the indexes in the array of idx
+        assert i.to_list() == [1, 0, 3, 5, 2, 4]
+
+    def test_concat(self):
+        idx_1 = ak.Index.factory(ak.arange(5))
+
+        idx_2 = ak.Index(ak.array([2, 4, 1, 3, 0]))
+
+        idx_full = idx_1.concat(idx_2)
+        assert idx_full.to_list() == [0, 1, 2, 3, 4, 2, 4, 1, 3, 0]
+
+    def test_lookup(self):
+        idx = ak.Index.factory(ak.arange(5))
+        lk = idx.lookup(ak.array([0, 4]))
+        assert lk.to_list() == [True, False, False, False, True]
+
+    def test_multi_argsort(self):
+        idx = ak.Index.factory([ak.arange(5), ak.arange(5)])
+        s = idx.argsort(False)
+        s.to_list() == [4, 3, 2, 1, 0]
+
+        s = idx.argsort()
+        s.to_list() == [i for i in range(5)]
+
+    def test_multi_concat(self):
+        idx = ak.Index.factory([ak.arange(5), ak.arange(5)])
+        idx_2 = ak.Index.factory(ak.array([0.1, 1.1, 2.2, 3.3, 4.4]))
+        with pytest.raises(TypeError):
+            idx.concat(idx_2)
+
+        idx_2 = ak.Index.factory([ak.arange(5), ak.arange(5)])
+        idx_full = idx.concat(idx_2)
+        assert idx_full.to_pandas().tolist() == [
+            (0, 0),
+            (1, 1),
+            (2, 2),
+            (3, 3),
+            (4, 4),
+            (0, 0),
+            (1, 1),
+            (2, 2),
+            (3, 3),
+            (4, 4),
+        ]
+
+    def test_multi_lookup(self):
+        idx = ak.Index.factory([ak.arange(5), ak.arange(5)])
+
+        lk = ak.array([0, 3, 2])
+
+        result = idx.lookup([lk, lk])
+        assert result.to_list() == [True, False, True, True, False]

--- a/PROTO_tests/tests/index_test.py
+++ b/PROTO_tests/tests/index_test.py
@@ -9,7 +9,7 @@ class TestIndex:
 
         assert isinstance(idx, ak.Index)
         assert idx.size == 5
-        assert idx.to_list() == [i for i in range(5)]
+        assert idx.to_list() == list(range(5))
 
     def test_multiindex_creation(self):
         # test list generation
@@ -70,10 +70,10 @@ class TestIndex:
     def test_multi_argsort(self):
         idx = ak.Index.factory([ak.arange(5), ak.arange(5)])
         s = idx.argsort(False)
-        s.to_list() == [4, 3, 2, 1, 0]
+        assert s.to_list() == list(reversed(range(5)))
 
         s = idx.argsort()
-        s.to_list() == [i for i in range(5)]
+        assert s.to_list() == list(range(5))
 
     def test_multi_concat(self):
         idx = ak.Index.factory([ak.arange(5), ak.arange(5)])
@@ -83,18 +83,8 @@ class TestIndex:
 
         idx_2 = ak.Index.factory([ak.arange(5), ak.arange(5)])
         idx_full = idx.concat(idx_2)
-        assert idx_full.to_pandas().tolist() == [
-            (0, 0),
-            (1, 1),
-            (2, 2),
-            (3, 3),
-            (4, 4),
-            (0, 0),
-            (1, 1),
-            (2, 2),
-            (3, 3),
-            (4, 4),
-        ]
+        ans = [(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (0, 0), (1, 1), (2, 2), (3, 3), (4, 4)]
+        assert idx_full.to_pandas().tolist() == ans
 
     def test_multi_lookup(self):
         idx = ak.Index.factory([ak.arange(5), ak.arange(5)])

--- a/PROTO_tests/tests/index_test.py
+++ b/PROTO_tests/tests/index_test.py
@@ -70,7 +70,7 @@ class TestIndex:
         idx = ak.Index.factory(ak.arange(size))
         lk = idx.lookup(ak.array([0, size - 1]))
 
-        assert lk.to_list() == [True if (i == 0 or i == size - 1) else False for i in range(size)]
+        assert lk.to_list() == [i in [0, size - 1] for i in range(size)]
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_multi_argsort(self, size):
@@ -99,4 +99,4 @@ class TestIndex:
         lk = ak.array(truth)
         result = idx.lookup([lk, lk])
 
-        assert result.to_list() == [True if i in truth else False for i in range(size)]
+        assert result.to_list() == [i in truth for i in range(size)]


### PR DESCRIPTION
This PR (Closes #2616) updates `index_test.py` to the new testing framework.

Removes the `test_save` test and will be handled by @pierce314159 in his HDF5 testing in #2602.