### PR TITLE
Closes #2612 - oob error with multilocale `read_hdf` of a segarray with string values and empty segments 

### DIFF
--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -1364,35 +1364,40 @@ module HDF5Msg {
                 // create local copy of the string offsets (values) according to the locality of the SegArray Segments
                 var localSegs = segments[locDom];
                 var startOffIdx = localSegs[locDom.low];
-                var endOffIdx = if (lastSegIdx == locDom.high) then lastOffIdx else segments[locDom.high + 1] - 1;
-                var offIdxRange = startOffIdx..endOffIdx;
-
-                var localOffsets: [offIdxRange] int;
-                forall (localOff, offIdx) in zip(localOffsets, offIdxRange) with (var agg = newSrcAggregator(int)) {
-                    // Copy the remote value at index position valIdx to our local array
-                    agg.copy(localOff, strSegs[offIdx]); // in SrcAgg, the Right Hand Side is REMOTE
-                }
-
-                // Copy the String Values local based on the offsets pulled local.
-                var startValIdx = localOffsets[offIdxRange.low];
-                var endValIdx = if (lastOffIdx == offIdxRange.high) then lastValIdx else strSegs[offIdxRange.high + 1] - 1;
-                var valsIdxRange = startValIdx..endValIdx;
-
-                var localVals: [valsIdxRange] t;
-                forall (localVal, valIdx) in zip(localVals, valsIdxRange) with (var agg = newSrcAggregator(t)) {
-                    // Copy the remote value at index position valIdx to our local array
-                    agg.copy(localVal, strVals[valIdx]); // in SrcAgg, the Right Hand Side is REMOTE
-                }
-
                 // write the SegArray segments
                 localSegs = localSegs - startOffIdx;
                 writeSegmentedComponentToHdf(file_id, group, SEGMENTED_OFFSET_NAME, localSegs);
 
-                // create the group for SegString components - write the segments and offsets
-                validateGroup(file_id, localeFilename, "%s/%s".format(group, SEGMENTED_VALUE_NAME), overwrite);
-                localOffsets = localOffsets - startValIdx;
-                writeSegmentedComponentToHdf(file_id, "%s/%s".format(group, SEGMENTED_VALUE_NAME), SEGMENTED_OFFSET_NAME, localOffsets);
-                writeSegmentedComponentToHdf(file_id, "%s/%s".format(group, SEGMENTED_VALUE_NAME), SEGMENTED_VALUE_NAME, localVals);
+                var endOffIdx = if (lastSegIdx == locDom.high) then lastOffIdx else segments[locDom.high + 1] - 1;
+                var offIdxRange = startOffIdx..endOffIdx;
+                if offIdxRange.size > 0 {
+                    var localOffsets: [offIdxRange] int;
+                    forall (localOff, offIdx) in zip(localOffsets, offIdxRange) with (var agg = newSrcAggregator(int)) {
+                        // Copy the remote value at index position valIdx to our local array
+                        agg.copy(localOff, strSegs[offIdx]); // in SrcAgg, the Right Hand Side is REMOTE
+                    }
+
+                    // Copy the String Values local based on the offsets pulled local.
+                    var startValIdx = localOffsets[offIdxRange.low];
+                    var endValIdx = if (lastOffIdx == offIdxRange.high) then lastValIdx else strSegs[offIdxRange.high + 1] - 1;
+                    var valsIdxRange = startValIdx..endValIdx;
+
+                    var localVals: [valsIdxRange] t;
+                    forall (localVal, valIdx) in zip(localVals, valsIdxRange) with (var agg = newSrcAggregator(t)) {
+                        // Copy the remote value at index position valIdx to our local array
+                        agg.copy(localVal, strVals[valIdx]); // in SrcAgg, the Right Hand Side is REMOTE
+                    }
+
+                    // create the group for SegString components - write the segments and offsets
+                    validateGroup(file_id, localeFilename, "%s/%s".format(group, SEGMENTED_VALUE_NAME), overwrite);
+                    localOffsets = localOffsets - startValIdx;
+                    writeSegmentedComponentToHdf(file_id, "%s/%s".format(group, SEGMENTED_VALUE_NAME), SEGMENTED_OFFSET_NAME, localOffsets);
+                    writeSegmentedComponentToHdf(file_id, "%s/%s".format(group, SEGMENTED_VALUE_NAME), SEGMENTED_VALUE_NAME, localVals);
+                }
+                else {
+                    validateGroup(file_id, localeFilename, "%s/%s".format(group, SEGMENTED_VALUE_NAME), overwrite);
+                    writeNilSegmentedGroupToHdf(file_id, "%s/%s".format(group, SEGMENTED_VALUE_NAME), true, dtype);
+                }
             }
             // write attributes for arkouda meta info
             writeArkoudaMetaData(file_id, group, objType, dtype);

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -3173,13 +3173,17 @@ module HDF5Msg {
         var len: int;
         var rtnMap: map(string, string) = new map(string, string);
 
-        if isStringsObject(filenames[0], "%s/%s".format(dset, SEGMENTED_VALUE_NAME)) {
+        // need to get fist valid file
+        var (v, idx) = maxloc reduce zip(validFiles, validFiles.domain);
+        var first_file = filenames[idx];
+
+        if isStringsObject(first_file, "%s/%s".format(dset, SEGMENTED_VALUE_NAME)) {
             (valSubdoms, len, vskips) = get_subdoms(filenames, "%s/%s/%s".format(dset, SEGMENTED_VALUE_NAME, SEGMENTED_OFFSET_NAME), validFiles);
             var stringsEntry = readStringsFromFile(filenames, "%s/%s".format(dset, SEGMENTED_VALUE_NAME), dataclass, bytesize, isSigned, calcStringOffsets, validFiles, st);
             rtnMap.add("values", "created %s+created bytes.size %t".format(st.attrib(stringsEntry.name), stringsEntry.nBytes));
         }
         else {
-            if isBigIntPdarray(filenames[0], "%s/%s".format(dset, SEGMENTED_VALUE_NAME)) {
+            if isBigIntPdarray(first_file, "%s/%s".format(dset, SEGMENTED_VALUE_NAME)) {
                 (valSubdoms, len, vskips) = get_subdoms(filenames, "%s/%s/Limb_0".format(dset, SEGMENTED_VALUE_NAME), validFiles);
             }
             else {

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -1292,6 +1292,29 @@ class IOTest(ArkoudaTest):
             self.assertListEqual(g_ref["keys"], data["g"].keys.to_list())
             self.assertListEqual(g_ref["segments"], data["g"].segments.to_list())
 
+    def test_segarr_edge(self):
+        """
+        This test was added specifically for issue #2612.
+        Pierce will be adding testing to the new framework for this.
+        """
+        df = ak.DataFrame({
+            "c_11": ak.SegArray(ak.array([0, 2, 3, 3]), ak.array(["a", "b", "", "c", "d", "e", "f", "g", "h", "i"]))
+        })
+        with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
+            df.to_hdf(f"{tmp_dirname}/seg_test")
+
+            rd_data = ak.read_hdf(f"{tmp_dirname}/seg_test*")
+            self.assertListEqual(df["c_11"].to_list(), rd_data.to_list())
+
+        df = ak.DataFrame({"c_2": ak.SegArray(ak.array([0, 9, 14]), ak.arange(-10, 10))})
+        with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
+            df.to_hdf(f"{tmp_dirname}/seg_test")
+
+            # only verifying the read is successful
+            rd_arr = ak.read_hdf(filenames=[f"{tmp_dirname}/seg_test_LOCALE0000", f"{tmp_dirname}/seg_test_MISSING"],
+                                 strict_types=False, allow_errors=True)
+
+
     def tearDown(self):
         super(IOTest, self).tearDown()
         for f in glob.glob("{}/*".format(IOTest.io_test_dir)):


### PR DESCRIPTION
Closes #2612 

Corrects issue with locale having segment indexes, but the segments being empty. In this case we write and empty object instead of nothing.

Corrects issue with allowing errors not working properly. This was due to not using the name of the first valid file for some operations.

Adds basic testing for each of the above. @pierce314159 will be adding more robust testing in the updates to the new test framework.