### PR TITLE
Fixes #2614 - Snapshot test fails with distributed runs

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -2539,7 +2539,7 @@ class DataFrame(UserDict):
         columns = {}
         for k, create_data in data.items():
             if k == "index":
-                idx = Index(create_pdarray(data["permutation"]))
+                idx = Index(create_pdarray(create_data))
             else:
                 comps = create_data.split("+|+")
                 if comps[0] == pdarray.objType.upper():

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -347,7 +347,6 @@ class DataFrame(UserDict):
                 self._set_index(arange(self._size))
             else:
                 self._set_index(index)
-
             self.update_size()
 
     def __getattr__(self, key):
@@ -2538,10 +2537,13 @@ class DataFrame(UserDict):
         idx = None
         columns = {}
         for k, create_data in data.items():
-            if k == "index":
-                idx = Index(create_pdarray(create_data))
+            comps = create_data.split("+|+")
+            if k.lower() == "index":
+                if comps[0] == Strings.objType.upper():
+                    idx = Index(Strings.from_return_msg(comps[1]))
+                else:
+                    idx = Index(create_pdarray(comps[1]))
             else:
-                comps = create_data.split("+|+")
                 if comps[0] == pdarray.objType.upper():
                     columns[k] = create_pdarray(comps[1])
                 elif comps[0] == Strings.objType.upper():

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -1984,4 +1984,4 @@ def restore(filename):
     objects in HDF5. Thus, they are returned within the dictionary as a dataframe.
     """
     restore_files = glob.glob(f"{filename}_SNAPSHOT_LOCALE*")
-    return read_hdf(restore_files)
+    return read_hdf(sorted(restore_files))

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -1234,7 +1234,7 @@ class IOTest(ArkoudaTest):
         df_str_idx._set_index(["A" + str(i) for i in range(len(df))])
         col_order = df.columns
         df_ref = df.to_pandas()
-        df_str_idx_ref = df_str_idx.to_pandas()
+        df_str_idx_ref = df_str_idx.to_pandas(retain_index=True)
         a = ak.randint(0, 10, 100)
         a_ref = a.to_list()
         s = ak.random_strings_uniform(0, 5, 50)
@@ -1280,10 +1280,10 @@ class IOTest(ArkoudaTest):
 
             # validate that restored variables are correct
             self.assertTrue(
-                assert_frame_equal(df_ref[col_order], data["df"].to_pandas()[col_order]) is None
+                assert_frame_equal(df_ref[col_order], data["df"].to_pandas(retain_index=True)[col_order]) is None
             )
             self.assertTrue(
-                assert_frame_equal(df_str_idx_ref[col_order], data["df_str_idx"].to_pandas()[col_order]) is None
+                assert_frame_equal(df_str_idx_ref[col_order], data["df_str_idx"].to_pandas(retain_index=True)[col_order]) is None
             )
             self.assertListEqual(a_ref, data["a"].to_list())
             self.assertListEqual(s_ref, data["s"].to_list())


### PR DESCRIPTION
Closes #2614 

The issue was caused by `glob` potentially not returning the files in the appropriate order. Snapshot does not do the glob call on the server, so it was not hitting the sort. Added a `sorted` to the filenames being sent to the server in order to ensure that data is loaded in the correct order.

I also discovered an issue with properly setting the index on restore. That has been addressed. Testing was updated so that `to_pandas(retain_index=True)` so that indexes are validated as well.