### PR TITLE
Fixes #2627: Failures with `flake8` version 6.1.0

### DIFF
--- a/arkouda/alignment.py
+++ b/arkouda/alignment.py
@@ -125,7 +125,7 @@ def find(query, space):
 
     # Concatenate the space and query in fast (block interleaved) mode
     if isinstance(query, (pdarray, Strings, Categorical)):
-        if type(query) != type(space):
+        if type(query) is not type(space):
             raise TypeError("Arguments must have same type")
         c = concatenate((space, query), ordered=False)
         spacesize = space.size

--- a/arkouda/client_dtypes.py
+++ b/arkouda/client_dtypes.py
@@ -403,7 +403,7 @@ def ip_address(values):
     for importing Python lists of IP addresses into Arkouda.
     """
 
-    if type(values) == IPv4:
+    if isinstance(values, IPv4):
         return values
 
     if isinstance(values, pdarray):

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -302,7 +302,7 @@ class DataFrame(UserDict):
             sizes = set()
 
             # Initial data is a dictionary of arkouda arrays
-            if type(initialdata) == dict:
+            if isinstance(initialdata, dict):
                 for key, val in initialdata.items():
                     if not isinstance(val, self.COLUMN_CLASSES):
                         raise ValueError(f"Values must be one of {self.COLUMN_CLASSES}.")
@@ -319,7 +319,7 @@ class DataFrame(UserDict):
                     self._columns.append(key)
 
             # Initial data is a list of arkouda arrays
-            elif type(initialdata) == list:
+            elif isinstance(initialdata, list):
                 # Create string IDs for the columns
                 keys = [str(x) for x in range(len(initialdata))]
                 for key, col in zip(keys, initialdata):
@@ -394,7 +394,7 @@ class DataFrame(UserDict):
                 return result
             if len({type(x) for x in key}) > 1:
                 raise TypeError("Invalid selector: too many types in list.")
-            if type(key[0]) == str:
+            if isinstance(key[0], str):
                 for k in key:
                     result.data[k] = UserDict.__getitem__(self, k)
                     result._columns.append(k)
@@ -441,7 +441,7 @@ class DataFrame(UserDict):
             add_index = True
 
         # Set a single row in the dataframe using a dict of values
-        if type(key) == int:
+        if isinstance(key, int):
             for k in self._columns:
                 if isinstance(self.data[k], Strings):
                     raise ValueError(
@@ -463,7 +463,7 @@ class DataFrame(UserDict):
                     self[k][key] = v
 
         # Set a single column in the dataframe using a an arkouda array
-        elif type(key) == str:
+        elif isinstance(key, str):
             if not isinstance(value, self.COLUMN_CLASSES):
                 raise ValueError(f"Column must be one of {self.COLUMN_CLASSES}.")
             elif self._size is not None and self._size != value.size:
@@ -1046,12 +1046,12 @@ class DataFrame(UserDict):
             for i in range(obj.index.size):
                 oldval = obj.index[i]
                 newval = mapper(oldval)
-                if type(oldval) != type(newval):
+                if type(oldval) is not type(newval):
                     raise TypeError("Replacement value must have the same type as the original value")
                 obj.index.values[obj.index.values == oldval] = newval
         elif isinstance(mapper, dict):
             for key, val in mapper.items():
-                if type(key) != type(val):
+                if type(key) is not type(val):
                     raise TypeError("Replacement value must have the same type as the original value")
                 obj.index.values[obj.index.values == key] = val
         else:

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -148,13 +148,13 @@ class Index:
         data = {}
         if label is None:
             label = "idx"
-        elif type(label) == list:
+        elif isinstance(label, list):
             label = label[0]
         data[label] = self.index
         return data
 
     def _check_types(self, other):
-        if type(self) != type(other):
+        if type(self) is not type(other):
             raise TypeError("Index Types must match")
 
     def _merge(self, other):

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -299,7 +299,7 @@ class pdarray:
 
         """
         # For pdarray subclasses like ak.Datetime and ak.Timedelta, defer to child logic
-        if type(other) != pdarray and issubclass(type(other), pdarray):
+        if type(other) is not pdarray and issubclass(type(other), pdarray):
             return NotImplemented
         if op not in self.BinOps:
             raise ValueError(f"bad operator {op}")

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -85,6 +85,7 @@ def _in1d_single(
     """
     from arkouda.categorical import Categorical as Categorical_
     from arkouda.dtypes import bool as ak_bool
+
     if isinstance(pda1, pdarray) or isinstance(pda1, Strings) or isinstance(pda1, Categorical_):
         # While isinstance(thing, type) can be called on a tuple of types,
         # this causes an issue with mypy for unknown reasons.
@@ -437,7 +438,7 @@ def union1d(
     if (
         isinstance(pda1, (pdarray, Strings, Categorical_))
         and isinstance(pda2, (pdarray, Strings, Categorical_))
-        and type(pda1) == type(pda2)
+        and type(pda1) is type(pda2)
     ):
         if pda1.size == 0:
             return pda2  # union is pda2
@@ -532,7 +533,7 @@ def intersect1d(
     if (
         isinstance(pda1, (pdarray, Strings, Categorical_))
         and isinstance(pda2, (pdarray, Strings, Categorical_))
-        and type(pda1) == type(pda2)
+        and type(pda1) is type(pda2)
     ):
         if pda1.size == 0:
             return pda1  # nothing in the intersection
@@ -650,7 +651,7 @@ def setdiff1d(
     if (
         isinstance(pda1, (pdarray, Strings, Categorical_))
         and isinstance(pda2, (pdarray, Strings, Categorical_))
-        and type(pda1) == type(pda2)
+        and type(pda1) is type(pda2)
     ):
         if pda1.size == 0:
             return pda1  # return a zero length pdarray
@@ -761,7 +762,7 @@ def setxor1d(pda1: groupable, pda2: groupable, assume_unique: bool = False) -> U
     if (
         isinstance(pda1, (pdarray, Strings, Categorical_))
         and isinstance(pda2, (pdarray, Strings, Categorical_))
-        and type(pda1) == type(pda2)
+        and type(pda1) is type(pda2)
     ):
         if pda1.size == 0:
             return pda2  # return other pdarray if pda1 is empty

--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -25,7 +25,7 @@ def get_callback(x):
         return type(x)
     elif hasattr(x, "_cast"):
         return x._cast
-    elif type(x) == BitVector:
+    elif isinstance(x, BitVector):
         return BitVectorizer(width=x.width, reverse=x.reverse)
     else:
         return identity


### PR DESCRIPTION
This PR fixes #2627.

The latest version of `flake8`, 6.1.0, was released this weekend. This version update caused the CI to fail on master. This adds the changes needed for arkouda to pass.

NOTES:
- Any existing PRs will fail until this is merged. Once it's merged they will need to rebase/merge with master to get these changes
- We should all be sure to update our conda envs to have the latest version. For me the easiest way to do this was to blow away the old env and recreate from the yaml file. It might be necessary to update your conda channels with a command like
```
conda update -n base -c conda-forge conda
```