### PR TITLE
Closes #2635: Fixes Strings double delete

### DIFF
--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -190,12 +190,14 @@ class Strings:
         self._regex_dict: Dict = dict()
         self.logger = getArkoudaLogger(name=__class__.__name__)  # type: ignore
 
-    def __del__(self):
-        try:
-            if self.name:
-                generic_msg(cmd="delete", args={"name": self.name})
-        except RuntimeError:
-            pass
+    """
+    NOTE:
+         The Strings.__del__() method should NOT be implemented.
+         Python will invoke the __del__() of any components by default.
+         Overriding this default behavior with an explicitly specified Strings.__del__() method may
+         introduce unknown symbol errors.
+         By allowing Python's garbage collecting to handle this automatically, we avoid extra maintenance
+    """
 
     def __iter__(self):
         raise NotImplementedError(

--- a/tests/registration_test.py
+++ b/tests/registration_test.py
@@ -828,6 +828,13 @@ class RegistrationTest(ArkoudaTest):
         seg = None
         self.assertEqual(len(ak.list_symbol_table()), 0)
 
+        str_seg = ak.SegArray(
+            ak.array([0, 6, 8]), ak.array([10, 11, 12, 13, 14, 15, 20, 21, 30, 31, 32, 33])
+        )
+        self.assertTrue(len(ak.list_symbol_table()) > 0)
+        str_seg = None
+        self.assertEqual(len(ak.list_symbol_table()), 0)
+
         g = ak.GroupBy(
             [ak.arange(3), ak.array(["a", "b", "c"]), ak.Categorical(ak.array(["a", "b", "c"]))]
         )


### PR DESCRIPTION
This PR (closes #2635) fixes unknown symbol errors caused by strings being deleted twice

The strings `__del__` method was causing a double delete when a Strings object went out of scope resulting in unknown symbol errors. This PR removes that method and allows pythons garbage collector to handle it

I also ran the following to verify that none of the following kept symentries around after going out of scope or resulted in unknown symbol errors
```python
# strings
>>> def del_test():
   ...:     ak.array(['hi', 'weird', 'stuff'])
   ...:
>>> del_test()

# segarray with strings vals
>>> def del_test():
   ...:     ak.segarray(ak.array([0, 6, 8]), ak.cast(ak.array([10, 11, 12, 13, 14, 15, 20, 21, 30, 31, 32, 33]), str))
   ...:
>>> del_test()

# df with strings and segarray with strings vals
>>> def df_del_test():
   ...:     ak.DataFrame({'a': ak.arange(3), 'b': ak.array(['hi', 'weird', 'stuff']), 'c': ak.segarray(ak.array([0, 6, 8]
   ...: ), ak.cast(ak.array([10, 11, 12, 13, 14, 15, 20, 21, 30, 31, 32, 33]), str))})
   ...:
>>> df_del_test()

# groupby with strings
>>> def gb_del_test():
    ...:     ak.GroupBy([ak.arange(3), ak.array(['hi', 'weird', 'stuff'])])
    ...:
>>> gb_del_test()

# verify empty sym tab
>>> ak.list_symbol_table()
[]
```