### PR TITLE
Fixes #2617: Bug in comparison of segarrays containing empty segments

### DIFF
--- a/PROTO_tests/tests/io_test.py
+++ b/PROTO_tests/tests/io_test.py
@@ -1197,18 +1197,7 @@ class TestHDF5:
             assert f1_size == f2_size
 
     def test_snapshot(self):
-        # Once issue #2617 is resolved, update to df = ak.DataFrame(make_multi_dtype_dict())
-        df = ak.DataFrame(
-            {
-                "int_col": ak.arange(10),
-                "uint_col": ak.array([i + 2**63 for i in range(10)], dtype=ak.uint64),
-                "float_col": ak.linspace(-3.5, 3.5, 10),
-                "bool_col": ak.randint(0, 2, 10, dtype=ak.bool),
-                "bigint_col": ak.array([i + 2**200 for i in range(10)], dtype=ak.bigint),
-                "segarr_col": ak.SegArray(ak.arange(0, 20, 2), ak.randint(0, 3, 20)),
-                "str_col": ak.random_strings_uniform(0, 3, 10),
-            }
-        )
+        df = ak.DataFrame(make_multi_dtype_dict())
         df_str_idx = df.copy()
         df_str_idx._set_index([f"A{i}" for i in range(len(df))])
         col_order = df.columns

--- a/src/DataFrameIndexingMsg.chpl
+++ b/src/DataFrameIndexingMsg.chpl
@@ -41,7 +41,7 @@
             throw new owned IllegalArgumentError(errorMsg);
         }
         if idxMax >= columnVals.size {
-            var errorMsg = "Error: %s: OOBindex %i > %i".doFormat(pn,idxMin,columnVals.size-1);
+            var errorMsg = "Error: %s: OOBindex %i > %i".doFormat(pn,idxMax,columnVals.size-1);
             dfiLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
             throw new owned IllegalArgumentError(errorMsg);
         }

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -363,7 +363,7 @@ module IndexingMsg
                 return new MsgTuple(errorMsg,MsgType.ERROR);               
             }
             if ivMax >= e.size {
-                var errorMsg = "Error: %s: OOBindex %i > %i".doFormat(pn,ivMin,e.size-1);
+                var errorMsg = "Error: %s: OOBindex %i > %i".doFormat(pn,ivMax,e.size-1);
                 imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);             
                 return new MsgTuple(errorMsg,MsgType.ERROR);
             }
@@ -399,7 +399,7 @@ module IndexingMsg
                 return new MsgTuple(errorMsg,MsgType.ERROR);               
             }
             if ivMax >= e.size {
-                var errorMsg = "Error: %s: OOBindex %i > %i".doFormat(pn,ivMin,e.size-1);
+                var errorMsg = "Error: %s: OOBindex %i > %i".doFormat(pn,ivMax,e.size-1);
                 imLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);             
                 return new MsgTuple(errorMsg,MsgType.ERROR);
             }


### PR DESCRIPTION
This PR (fixes #2617):
- Fixes bug in equality check of segarrays containing empty segments. Due to bug in gen_ranges, not using the `selfcmp` groupby, and size mismatch since `segarr.all()` excludes empty segs
- Fixed issue with empty segs in `gen_ranges`
- Added support for indexing segarray with a uint pdarray
- Fixed error message in indexing and dataframe indexing
- Added tests for segarray comparisons