### PR TITLE
Closed #2648: `logger_test.py` conversion for new framework

### DIFF
--- a/PROTO_tests/tests/logger_test.py
+++ b/PROTO_tests/tests/logger_test.py
@@ -1,0 +1,100 @@
+import os
+import tempfile
+from logging import DEBUG, INFO, WARN, FileHandler, StreamHandler
+
+import pytest
+
+import arkouda as ak
+from arkouda import io_util
+from arkouda.logger import LogLevel, getArkoudaClientLogger, getArkoudaLogger
+
+
+class TestLogger:
+    logger_test_base_tmp = f"{os.getcwd()}/logger_io_test"
+    io_util.get_directory(logger_test_base_tmp)
+
+    def test_log_level(self):
+        assert "DEBUG" == LogLevel.DEBUG.value
+        assert "INFO" == LogLevel.INFO.value
+        assert "WARN" == LogLevel.WARN.value
+        assert "CRITICAL" == LogLevel.CRITICAL.value
+        assert "ERROR" == LogLevel.ERROR.value
+
+        assert LogLevel.DEBUG == LogLevel("DEBUG")
+        assert LogLevel.INFO == LogLevel("INFO")
+        assert LogLevel.WARN == LogLevel("WARN")
+        assert LogLevel.CRITICAL == LogLevel("CRITICAL")
+        assert LogLevel.ERROR == LogLevel("ERROR")
+
+    def test_arkouda_logger(self):
+        handler = StreamHandler()
+        handler.name = "streaming"
+        logger = getArkoudaLogger(name=self.__class__.__name__, handlers=[handler])
+        assert DEBUG == logger.level
+        assert "TestLogger" == logger.name
+        assert logger.getHandler("streaming") is not None
+        logger.debug("debug message")
+
+    def test_arkouda_client_logger(self):
+        logger = getArkoudaClientLogger(name="ClientLogger")
+        assert DEBUG == logger.level
+        assert "ClientLogger" == logger.name
+        logger.debug("debug message")
+        assert logger.getHandler("console-handler") is not None
+        with pytest.raises(ValueError):
+            logger.getHandler("console-handlers")
+
+    def test_update_arkouda_logger_log_level(self):
+        with tempfile.TemporaryDirectory(dir=TestLogger.logger_test_base_tmp) as tmp_dirname:
+            file_name = f"{tmp_dirname}/logger_test_output.txt"
+
+            logger = getArkoudaLogger(name="UpdateLogger")
+            assert DEBUG == logger.level
+            logger.debug("debug before level change")
+            logger.changeLogLevel(LogLevel.WARN)
+            assert WARN == logger.handlers[0].level
+            logger.debug("debug after level change")
+
+            handlerOne = StreamHandler()
+            handlerOne.name = "handler-one"
+            handlerOne.setLevel(DEBUG)
+            handlerTwo = FileHandler(filename=file_name)
+            handlerTwo.name = "handler-two"
+            handlerTwo.setLevel(INFO)
+            logger = getArkoudaLogger(name="UpdateLogger", handlers=[handlerOne, handlerTwo])
+            logger.changeLogLevel(level=LogLevel.WARN, handlerNames=["handler-one"])
+            assert WARN == handlerOne.level
+            assert INFO == handlerTwo.level
+
+    def test_verbosity_controls(self):
+        logger = getArkoudaLogger(name="VerboseLogger", logLevel=LogLevel("INFO"))
+
+        assert INFO == logger.getHandler("console-handler").level
+        logger.debug("non-working debug message")
+        logger.enableVerbose()
+        assert DEBUG == logger.getHandler("console-handler").level
+        logger.debug("working debug message")
+        logger.disableVerbose()
+        assert INFO == logger.getHandler("console-handler").level
+        logger.debug("next non-working debug message")
+
+    def test_enable_disable_verbose(self):
+        loggerOne = getArkoudaLogger(name="loggerOne", logLevel=LogLevel.INFO)
+        loggerTwo = getArkoudaLogger("loggerTwo", logLevel=LogLevel.INFO)
+
+        loggerOne.debug("loggerOne before enableVerbose")
+        loggerTwo.debug("loggerTwo before enableVerbose")
+        ak.enableVerbose()
+        loggerOne.debug("loggerOne after enableVerbose")
+        loggerTwo.debug("loggerTwo after enableVerbose")
+        ak.disableVerbose()
+        loggerOne.debug("loggerOne after disableVerbose")
+        loggerTwo.debug("loggerTwo after disableVerbose")
+
+    def test_error_handling(self):
+        logger = getArkoudaLogger(name="VerboseLogger", logLevel=LogLevel("INFO"))
+        with pytest.raises(ValueError):
+            logger.getHandler("not-a-handler")
+
+        with pytest.raises(TypeError):
+            logger.disableVerbose(logLevel="INFO")


### PR DESCRIPTION
This PR (Closes #2648 ) updates `logger_test.py` to the new testing framework.