### PR TITLE
Closes #2654 `sort_test.py` conversion for new test framework

### DIFF
--- a/PROTO_tests/tests/sort_test.py
+++ b/PROTO_tests/tests/sort_test.py
@@ -11,13 +11,24 @@ def make_ak_arrays(dtype):
     if dtype in ["int64", "uint64"]:
         return ak.randint(0, 100, 1000, dtype)
     elif dtype == "float64":
-        return ak.array(np.random.rand(100) * 10000)
+        return ak.array(np.random.rand(1000) * 10000)
     elif dtype == "bigint":
         return ak.randint(0, 100, 1000, dtype=ak.uint64)
     return None
 
 
+def np_is_sorted(arr):
+    return np.all(arr[:-1] <= arr[1:])
+
+
 class TestSort:
+    @pytest.mark.parametrize("dtype", NUMERIC_AND_BIGINT_TYPES)
+    def test_is_sorted(self, dtype):
+        pda = make_ak_arrays(dtype)
+        sorted_pda = ak.sort(pda)
+        assert ak.is_sorted(sorted_pda)
+        assert np_is_sorted(sorted_pda.to_ndarray())
+
     @pytest.mark.parametrize("algo", SortingAlgorithm)
     @pytest.mark.parametrize("dtype", NUMERIC_AND_BIGINT_TYPES)
     def test_sort_dtype(self, algo, dtype):

--- a/PROTO_tests/tests/sort_test.py
+++ b/PROTO_tests/tests/sort_test.py
@@ -4,68 +4,71 @@ import pytest
 import arkouda as ak
 from arkouda.sorting import SortingAlgorithm
 
+NUMERIC_AND_BIGINT_TYPES = ["int64", "float64", "uint64", "bigint"]
+
+
+def make_ak_arrays(dtype):
+    if dtype in ["int64", "uint64"]:
+        return ak.randint(0, 100, 1000, dtype)
+    elif dtype == "float64":
+        return ak.array(np.random.rand(100) * 10000)
+    elif dtype == "bigint":
+        return ak.randint(0, 100, 1000, dtype=ak.uint64)
+    return None
+
 
 class TestSort:
-    @pytest.mark.parametrize("size", pytest.prob_size)
-    def test_sort_dtype(self, size):
-        for dtype in ak.int64, ak.uint64:
-            pda = ak.randint(0, 100, size, dtype)
-            for algo in SortingAlgorithm:
-                spda = ak.sort(pda, algo)
-                assert ak.is_sorted(spda)
+    @pytest.mark.parametrize("algo", SortingAlgorithm)
+    @pytest.mark.parametrize("dtype", NUMERIC_AND_BIGINT_TYPES)
+    def test_sort_dtype(self, algo, dtype):
+        pda = make_ak_arrays(dtype)
 
-        pda_float = ak.array(np.random.rand(100) * 10000)
-        for algo in SortingAlgorithm:
-            spda = ak.sort(pda_float, algo)
-            assert ak.is_sorted(spda)
-
-        pda = ak.randint(0, 100, size, dtype=ak.uint64)
-        pda_bigint = pda + 2**200
-        for algo in SortingAlgorithm:
+        if dtype != "bigint":
+            assert ak.is_sorted(ak.sort(pda, algo))
+        else:
+            pda_bigint = pda + 2**200
             sorted_pda = ak.sort(pda, algo)
             sorted_bi = ak.sort(pda_bigint, algo)
             assert (sorted_bi - 2**200).to_list() == sorted_pda.to_list()
 
-    def test_bit_boundary_hardcode(self):
+    @pytest.mark.parametrize("algo", SortingAlgorithm)
+    def test_bit_boundary_hardcode(self, algo):
         # test hardcoded 16/17-bit boundaries with and without negative values
         a = ak.array([1, -1, 32767])  # 16 bit
         b = ak.array([1, 0, 32768])  # 16 bit
         c = ak.array([1, -1, 32768])  # 17 bit
-        for algo in SortingAlgorithm:
-            for arr in a, b, c:
-                assert ak.is_sorted(ak.sort(arr, algo))
+        for arr in a, b, c:
+            assert ak.is_sorted(ak.sort(arr, algo))
 
         # test hardcoded 64-bit boundaries with and without negative values
         d = ak.array([1, -1, 2**63 - 1])
         e = ak.array([1, 0, 2**63 - 1])
         f = ak.array([1, -(2**63), 2**63 - 1])
-        for algo in SortingAlgorithm:
-            for arr in d, e, f:
-                assert ak.is_sorted(ak.sort(arr, algo))
+        for arr in d, e, f:
+            assert ak.is_sorted(ak.sort(arr, algo))
 
-    @pytest.mark.parametrize("size", pytest.prob_size)
-    def test_bit_boundary(self, size):
+    @pytest.mark.parametrize("algo", SortingAlgorithm)
+    def test_bit_boundary(self, algo):
         # test 17-bit sort
         lower = -(2**15)
         upper = 2**16
-        a = ak.randint(lower, upper, size)
-        for algo in SortingAlgorithm:
-            assert ak.is_sorted(ak.sort(a, algo))
+        a = ak.randint(lower, upper, 1000)
+        assert ak.is_sorted(ak.sort(a, algo))
 
-    def test_error_handling(self):
+    @pytest.mark.parametrize("algo", SortingAlgorithm)
+    def test_error_handling(self, algo):
         # Test RuntimeError from bool NotImplementedError
         ak_bools = ak.randint(0, 1, 1000, dtype=ak.bool)
         bools = ak.randint(0, 1, 1000, dtype=bool)
 
-        for algo in SortingAlgorithm:
-            for arr in ak_bools, bools:
-                with pytest.raises(ValueError):
-                    ak.sort(arr, algo)
+        for arr in ak_bools, bools:
+            with pytest.raises(ValueError):
+                ak.sort(arr, algo)
 
-            # Test TypeError from sort attempt on non-pdarray
-            with pytest.raises(TypeError):
-                ak.sort(list(range(0, 10)), algo)
+        # Test TypeError from sort attempt on non-pdarray
+        with pytest.raises(TypeError):
+            ak.sort(list(range(0, 10)), algo)
 
-            # Test attempt to sort Strings object, which is unsupported
-            with pytest.raises(TypeError):
-                ak.sort(ak.array([f"string {i}" for i in range(10)]), algo)
+        # Test attempt to sort Strings object, which is unsupported
+        with pytest.raises(TypeError):
+            ak.sort(ak.array([f"string {i}" for i in range(10)]), algo)

--- a/PROTO_tests/tests/sort_test.py
+++ b/PROTO_tests/tests/sort_test.py
@@ -1,0 +1,69 @@
+import arkouda as ak
+import pytest
+
+from arkouda.sorting import SortingAlgorithm
+
+
+class TestSort:
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype", [ak.int64, ak.uint64, ak.float64])
+    def test_sort_dtype(self, size, dtype):
+        pda = ak.randint(0, 100, size, dtype)
+        for algo in SortingAlgorithm:
+            spda = ak.sort(pda, algo)
+            assert ak.is_sorted(spda)
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_sort_bigint(self, size):
+        pda = ak.randint(0, 100, size, dtype=ak.uint64)
+        shift_up = pda + 2**200
+        for algo in SortingAlgorithm:
+            sorted_pda = ak.sort(pda, algo)
+            sorted_bi = ak.sort(shift_up, algo)
+            assert (sorted_bi - 2**200).to_list() == sorted_pda.to_list()
+
+    def test_bit_boundary_hardcode(self):
+        # test hardcoded 16/17-bit boundaries with and without negative values
+        a = ak.array([1, -1, 32767])  # 16 bit
+        b = ak.array([1, 0, 32768])  # 16 bit
+        c = ak.array([1, -1, 32768])  # 17 bit
+        for algo in SortingAlgorithm:
+            for arr in a, b, c:
+                assert ak.is_sorted(ak.sort(arr, algo))
+
+        # test hardcoded 64-bit boundaries with and without negative values
+        d = ak.array([1, -1, 2**63 - 1])
+        e = ak.array([1, 0, 2**63 - 1])
+        f = ak.array([1, -(2**63), 2**63 - 1])
+        for algo in SortingAlgorithm:
+            for arr in d, e, f:
+                assert ak.is_sorted(ak.sort(arr, algo))
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_bit_boundary(self, size):
+        # test 17-bit sort
+        lower = -(2**15)
+        upper = 2**16
+        a = ak.randint(lower, upper, size)
+        for algo in SortingAlgorithm:
+            assert ak.is_sorted(ak.sort(a, algo))
+
+    def test_error_handling(self):
+        # Test RuntimeError from bool NotImplementedError
+        ak_bools = ak.randint(0, 1, 1000, dtype=ak.bool)
+        bools = ak.randint(0, 1, 1000, dtype=bool)
+
+        for algo in SortingAlgorithm:
+            with pytest.raises(ValueError):
+                ak.sort(ak_bools, algo)
+
+            with pytest.raises(ValueError):
+                ak.sort(bools, algo)
+
+            # Test TypeError from sort attempt on non-pdarray
+            with pytest.raises(TypeError):
+                ak.sort(list(range(0, 10)), algo)
+
+            # Test attempt to sort Strings object, which is unsupported
+            with pytest.raises(TypeError):
+                ak.sort(ak.array(["String {}".format(i) for i in range(0, 10)]), algo)


### PR DESCRIPTION
This PR (Closes https://github.com/Bears-R-Us/arkouda/issues/2654):

Converts file to new test framework.

Added some looping for brevity and added sorting of floats.