### PR TITLE
Closes #2672, #2662 - Update `CommPrimitives` functions and precision in `test_str_repr`

### DIFF
--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -16,20 +16,20 @@ module AryUtil
     param bitsPerDigit = RSLSD_bitsPerDigit;
     private param numBuckets = 1 << bitsPerDigit; // these need to be const for comms/performance reasons
     private param maskDigit = numBuckets-1; // these need to be const for comms/performance reasons
-    
+
     private config const logLevel = ServerConfig.logLevel;
     private config const logChannel = ServerConfig.logChannel;
     const auLogger = new Logger(logLevel, logChannel);
-    
+
     /*
-      Threshold for the amount of data that will be printed. 
+      Threshold for the amount of data that will be printed.
       Arrays larger than printThresh will print less data.
     */
     var printThresh = 30;
-    
+
     /*
       Prints the passed array.
-      
+
       :arg name: name of the array
       :arg A: array to be printed
     */
@@ -45,11 +45,11 @@ module AryUtil
     proc printAry(name:string, A) {
         try! writeln(name, formatAry(A));
     }
-    
-    /* 1.18 version print out localSubdomains 
-       
+
+    /* 1.18 version print out localSubdomains
+
        :arg x: array
-       :type x: [] 
+       :type x: []
     */
     proc printOwnership(x) {
         for loc in Locales do
@@ -57,13 +57,13 @@ module AryUtil
                 write(x.localSubdomain(), " ");
         writeln();
     }
-    
-    
+
+
     /*
       Determines if the passed array is sorted.
-      
+
       :arg A: array to check
-      
+
     */
     proc isSorted(A:[?D] ?t): bool {
         var sorted: bool;
@@ -75,13 +75,13 @@ module AryUtil
         }
         return sorted;
     }
-    
+
     /*
       Returns stats on a given array in form (int,int,real,real,real).
-      
+
       :arg a: array to produce statistics on
       :type a: [] int
-      
+
       :returns: a_min, a_max, a_mean, a_variation, a_stdDeviation
     */
     proc aStats(a: [?D] int): (int,int,real,real,real) {
@@ -136,7 +136,7 @@ module AryUtil
      * Takes a variable number of array names from a command message and
      * validates them, checking that they all exist and are the same length
      * and returning metadata about them.
-     * 
+     *
      * :arg n: number of arrays
      * :arg fields: the fields derived from the command message
      * :arg st: symbol table
@@ -145,7 +145,7 @@ module AryUtil
      */
     proc validateArraysSameLength(n:int, names:[] string, types: [] string, st: borrowed SymTab) throws {
       // Check that fields contains the stated number of arrays
-      if (names.size != n) { 
+      if (names.size != n) {
           var errorMsg = "Expected %i arrays but got %i".doFormat(n, names.size);
           auLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
           throw new owned ErrorWithContext(errorMsg,
@@ -154,7 +154,7 @@ module AryUtil
                                            getModuleName(),
                                            "ArgumentError");
       }
-      if (types.size != n) { 
+      if (types.size != n) {
           var errorMsg = "Expected %i types but got %i".doFormat(n, types.size);
           auLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
           throw new owned ErrorWithContext(errorMsg,
@@ -202,7 +202,7 @@ module AryUtil
           }
           otherwise {
               var errorMsg = "Unrecognized object type: %s".doFormat(objtype);
-              auLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);  
+              auLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
               throw new owned ErrorWithContext(errorMsg,
                                                getLineNumber(),
                                                getRoutineName(),
@@ -210,11 +210,11 @@ module AryUtil
                                                "TypeError");
           }
         }
-        
+
         if (i == 1) {
             size = thisSize;
         } else {
-            if (thisSize != size) { 
+            if (thisSize != size) {
               var errorMsg = "Arrays must all be same size; expected size %?, got size %?".doFormat(size, thisSize);
                 auLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
                 throw new owned ErrorWithContext(errorMsg,
@@ -223,7 +223,7 @@ module AryUtil
                                                  getModuleName(),
                                                  "ArgumentError");
             }
-        }   
+        }
       }
       return (size, hasStr, names, types);
     }
@@ -334,7 +334,7 @@ module AryUtil
           when DType.Int64   { (bitWidth, neg) = getBitWidth(toSymEntry(g, int ).a); }
           when DType.UInt64  { (bitWidth, neg) = getBitWidth(toSymEntry(g, uint).a); }
           when DType.Float64 { (bitWidth, neg) = getBitWidth(toSymEntry(g, real).a); }
-          otherwise { 
+          otherwise {
             throw getErrorWithContext(
                                       msg=dtype2str(g.dtype),
                                       lineNumber=getLineNumber(),
@@ -377,14 +377,14 @@ module AryUtil
           when DType.Int64   { mergeArray(int); }
           when DType.UInt64  { mergeArray(uint); }
           when DType.Float64 { mergeArray(real); }
-          otherwise { 
+          otherwise {
             throw getErrorWithContext(
                                       msg=dtype2str(g.dtype),
                                       lineNumber=getLineNumber(),
                                       routineName=getRoutineName(),
                                       moduleName=getModuleName(),
                                       errorClass="IllegalArgumentError"
-                                      ); 
+                                      );
           }
         }
       }
@@ -433,7 +433,7 @@ module AryUtil
                     this.ptr = allocate(t, region.size);
                     this.isOwned = true;
                     const byteSize = region.size:c_size_t * c_sizeof(t);
-                    GET(ptr, startLocale, getAddr(start), byteSize);
+                    GET(ptr, getAddr(start), startLocale, byteSize);
                 }
             } else {
                 // If data is non-contiguous or split across nodes, get element

--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -354,7 +354,7 @@ module CommAggregation {
         assert(lArr.locale.id == here.id);
       }
       const byte_size = size:c_size_t * c_sizeof(elemType);
-      CommPrimitives.PUT(c_ptrTo(lArr[0]), loc, data, byte_size);
+      CommPrimitives.PUT(data, c_ptrTo(lArr[0]), loc, byte_size);
     }
 
     proc PUT(lArr: c_ptr(elemType), size: int) {
@@ -362,7 +362,7 @@ module CommAggregation {
         assert(size <= this.size);
       }
       const byte_size = size:c_size_t * c_sizeof(elemType);
-      CommPrimitives.PUT(lArr, loc, data, byte_size);
+      CommPrimitives.PUT(data, lArr, loc, byte_size);
     }
 
     proc GET(lArr: [] elemType, size: int) where lArr.isDefaultRectangular() {
@@ -373,7 +373,7 @@ module CommAggregation {
         assert(lArr.locale.id == here.id);
       }
       const byte_size = size:c_size_t * c_sizeof(elemType);
-      CommPrimitives.GET(c_ptrTo(lArr[0]), loc, data, byte_size);
+      CommPrimitives.GET(c_ptrTo(lArr[0]), data, loc, byte_size);
     }
 
     proc deinit() {

--- a/src/CommPrimitives.chpl
+++ b/src/CommPrimitives.chpl
@@ -1,16 +1,11 @@
 module CommPrimitives {
   use CTypes;
+  use Communication;
+  public import Communication.get as GET;
+  public import Communication.put as PUT;
 
   inline proc getAddr(const ref p): c_ptr(p.type) {
     // TODO can this use c_ptrTo?
     return __primitive("_wide_get_addr", p): c_ptr(p.type);
-  }
-
-  inline proc GET(addr, node, rAddr, size) {
-    __primitive("chpl_comm_get", addr, node, rAddr, size);
-  }
-
-  inline proc PUT(addr, node, rAddr, size) {
-    __primitive("chpl_comm_put", addr, node, rAddr, size);
   }
 }

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -746,11 +746,14 @@ class OperatorsTest(ArkoudaTest):
         # Test __repr__()
         self.assertEqual("array([1 2 3])", ak.array([1, 2, 3]).__repr__())
         self.assertEqual("array([1 2 3 ... 17 18 19])", ak.arange(1, 20).__repr__())
-        answers = ["array([1.1000000000000001 2.2999999999999998 5])", "array([1.1 2.3 5])"]
+        answers = ["array([1.1000000000000001 2.2999999999999998 5])",
+                   "array([1.1 2.3 5])",
+                   "array([1.1000000000000001 2.2999999999999998 5.00000000000000000])"]
         self.assertTrue(ak.array([1.1, 2.3, 5]).__repr__() in answers)
 
         answers = ["array([0 0.52631578947368418 1.0526315789473684 ... 8.9473684210526319 9.473684210526315 10])",
-                   "array([0 0.5 1.1 ... 8.9 9.5 10])"]
+                   "array([0 0.5 1.1 ... 8.9 9.5 10])",
+                   "array([0.00000000000000000 0.52631578947368418 1.0526315789473684 ... 8.9473684210526319 9.473684210526315 10.00000000000000000])"]
         self.assertTrue(ak.linspace(0, 10, 20).__repr__() in answers)
         self.assertEqual("array([False False False])", ak.isnan(ak.array([1.1, 2.3, 5])).__repr__())
         self.assertEqual(


### PR DESCRIPTION
This PR resolves #2672 by replacing the use of Chapel `__primitive` calls for performing bulk `get`/`put` operations with calls to the Chapel `Communication` module, introduced in Chapel 1.28. 
This change is only for backend calls to `PUT` and `GET`, and should have no effect on any Arkouda interface.

While here, also updated the expected results in `operator_tests::test_str_repr` to resolve #2662.

TESTING:

- [x] make check
- [x] make test
- [x] make mypy
- [x] flake8 arkouda

Reviewer should note:
(also removed a bunch of trailing spaces)