### PR TITLE
Closes #2677: Fix alignment in aggregation allocation

### DIFF
--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -394,7 +394,7 @@ module CommAggregation {
   // Cacheline aligned and padded allocation to avoid false-sharing
   inline proc bufferIdxAlloc() {
     const cachePaddedLocales = (numLocales + 7) & ~7;
-    return allocate(int, 64, alignment=cachePaddedLocales);
+    return allocate(int, cachePaddedLocales, alignment=64);
   }
 
   module BigIntegerAggregation {


### PR DESCRIPTION
In https://github.com/Bears-R-Us/arkouda/pull/2489, I had replaced calls to `c_aligned_alloc` to `allocate` and accidentally swapped the position of the padding and the number of locales in one spot, so reverting that here.

This was seen to cause crashes at 512 locales and the fix was identified by @ronawho.

See: https://github.com/Cray/chapel-private/issues/5247