### PR TITLE
Related to #2682: Downgrade sphinx

### DIFF
--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -24,7 +24,7 @@ dependencies:
   - pexpect
   - pytest>=6.0
   - pytest-env
-  - Sphinx>=5.1.1
+  - Sphinx>=5.1.1,<7.2.0
   - sphinx-argparse
   - sphinx-autoapi
   - typed-ast

--- a/pydoc/requirements.txt
+++ b/pydoc/requirements.txt
@@ -21,13 +21,13 @@ libidn2
 pexpect
 pytest>=6.0
 pytest-env
-Sphinx>=5.1.1
+Sphinx>=5.1.1,<7.2.0
 sphinx-argparse
 sphinx-autoapi
 myst-parser
 furo # sphinx theme
 linkify-it-py
 typed-ast
-mypy>=0.931,0.990
+mypy>=0.931,<0.990
 flake8
 pytest-benchmark

--- a/pydoc/setup/REQUIREMENTS.md
+++ b/pydoc/setup/REQUIREMENTS.md
@@ -40,7 +40,7 @@ The dependencies listed here are only required if you will be doing development 
 - `pexpect`
 - `pytest>=6.0`
 - `pytest-env`
-- `Sphinx`
+- `Sphinx>=5.1.1,<7.2.0`
 - `sphinx-argparse`
 - `sphinx-autoapi`
 - `furo`

--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,7 @@ setup(
     # projects.
     extras_require={  # Optional
         'dev': ['pexpect', 'pytest>=6.0', 'pytest-env',
-                'Sphinx>=5.1.1', 'sphinx-argparse', 'sphinx-autoapi',
+                'Sphinx>=5.1.1,<7.2.0', 'sphinx-argparse', 'sphinx-autoapi',
                 'mypy>=0.931,<0.990', 'typed-ast', 'black', 'isort',
                 'flake8', 'furo', 'myst-parser', 'linkify-it-py'],
     },


### PR DESCRIPTION
This PR (related to #2682) temporarily downgrades sphinx to `<7.2.0` because of [issues with furo](https://github.com/pradyunsg/furo/discussions/693) that seems to be causing our CI to fail. We can re-evaluate once the dust settles a bit

I am going to keep the issue open so we remember to revisit this. Any current PRs will need to rebase or merge with master in order to pass CI