### PR TITLE
Closes #2690 - `ak.load_all` glob expression update

### DIFF
--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -1572,7 +1572,8 @@ def load(
     with a .parquet appended to the prefix_path.
     Parquet files were previously ALWAYS stored with a ``.parquet`` extension.
 
-    This function will be deprecated when glob flags are added to read_* functions
+    ak.load does not support loading a single file. This function automatically creates a glob expression.
+    For loading single HDF5 files without the _LOCALE#### suffix please use ak.read().
 
     CSV files without the Arkouda Header are not supported.
 
@@ -1589,8 +1590,11 @@ def load(
     #### is replaced by each locale numbers. Because filetype is inferred during processing,
     the extension is not required to be a specific format.
     """
+    if "*" in path_prefix:
+        raise ValueError("Glob expressions not supported by ak.load(). "
+                         "To read files using a glob expression, please use ak.read()")
     prefix, extension = os.path.splitext(path_prefix)
-    globstr = f"{prefix}*{extension}"
+    globstr = f"{prefix}_LOCALE*{extension}"
     try:
         file_format = get_filetype(globstr) if file_format.lower() == "infer" else file_format
         if file_format.lower() == "hdf5":

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -1572,7 +1572,7 @@ def load(
     with a .parquet appended to the prefix_path.
     Parquet files were previously ALWAYS stored with a ``.parquet`` extension.
 
-    ak.load does not support loading a single file. This function automatically creates a glob expression.
+    ak.load does not support loading a single file.
     For loading single HDF5 files without the _LOCALE#### suffix please use ak.read().
 
     CSV files without the Arkouda Header are not supported.

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -1126,9 +1126,9 @@ class SegArray:
         -------
         SegArray
         """
-        from arkouda.io import load
+        from arkouda.io import read_hdf
 
-        return load(prefix_path, dataset=dataset)
+        return read_hdf(prefix_path, datasets=dataset)
 
     @classmethod
     def load(cls, prefix_path, dataset="segarray", segment_name="segments", value_name="values"):


### PR DESCRIPTION
Closes #2690

Updates the glob expression from `filename*` to `filename_LOCALE*`. The previous functionality is still available through passing `filename*` to `ak.read()`. This also adds an error message to ensure that the user does not pass a glob expression to `ak.load()`.