### PR TITLE
Closes #2708 - `special_objType` support for HDF5

### DIFF
--- a/PROTO_tests/tests/io_test.py
+++ b/PROTO_tests/tests/io_test.py
@@ -1247,6 +1247,47 @@ class TestHDF5:
             ret_idx = ak.read_hdf(f"{file_name}*")
             assert (idx == ret_idx).all()
 
+    def test_special_objtype(self):
+        """
+                This test is simply to ensure that the dtype is persisted through the io
+                operation. It ultimately uses the process of pdarray, but need to ensure
+                correct Arkouda Object Type is returned
+                """
+        ip = ak.IPv4(ak.arange(10))
+        dt = ak.Datetime(ak.arange(10))
+        td = ak.Timedelta(ak.arange(10))
+        df = ak.DataFrame({
+            "ip": ip,
+            "datetime": dt,
+            "timedelta": td
+        })
+
+        with tempfile.TemporaryDirectory(dir=TestHDF5.hdf_test_base_tmp) as tmp_dirname:
+            ip.to_hdf(f"{tmp_dirname}/ip_test")
+            rd_ip = ak.read_hdf(f"{tmp_dirname}/ip_test*")
+            assert isinstance(rd_ip, ak.IPv4)
+            assert ip.to_list() == rd_ip.to_list()
+
+            dt.to_hdf(f"{tmp_dirname}/dt_test")
+            rd_dt = ak.read_hdf(f"{tmp_dirname}/dt_test*")
+            assert isinstance(rd_dt, ak.Datetime)
+            assert dt.to_list() == rd_dt.to_list()
+
+            td.to_hdf(f"{tmp_dirname}/td_test")
+            rd_td = ak.read_hdf(f"{tmp_dirname}/td_test*")
+            assert isinstance(rd_td, ak.Timedelta)
+            assert td.to_list() == rd_td.to_list()
+
+            df.to_hdf(f"{tmp_dirname}/df_test")
+            rd_df = ak.read_hdf(f"{tmp_dirname}/df_test*")
+
+            assert isinstance(rd_df["ip"], ak.IPv4)
+            assert isinstance(rd_df["datetime"], ak.Datetime)
+            assert isinstance(rd_df["timedelta"], ak.Timedelta)
+            assert df["ip"].to_list() == rd_df["ip"].to_list()
+            assert df["datetime"].to_list() == rd_df["datetime"].to_list()
+            assert df["timedelta"].to_list() == rd_df["timedelta"].to_list()
+
 
 class TestCSV:
     csv_test_base_tmp = f"{os.getcwd()}/csv_io_test"

--- a/arkouda/client_dtypes.py
+++ b/arkouda/client_dtypes.py
@@ -716,6 +716,38 @@ class IPv4(pdarray):
             ),
         )
 
+    def update_hdf(self, prefix_path: str, dataset: str = "array", repack: bool = True):
+        """
+        Override the pdarray implementation so that the special object type will be used.
+        """
+        from arkouda.client import generic_msg
+        from arkouda.io import (
+            _file_type_to_int,
+            _get_hdf_filetype,
+            _mode_str_to_int,
+            _repack_hdf,
+        )
+
+        # determine the format (single/distribute) that the file was saved in
+        file_type = _get_hdf_filetype(prefix_path + "*")
+
+        generic_msg(
+            cmd="tohdf",
+            args={
+                "values": self,
+                "dset": dataset,
+                "write_mode": _mode_str_to_int("append"),
+                "filename": prefix_path,
+                "dtype": self.dtype,
+                "objType": self.special_objType,
+                "file_format": _file_type_to_int(file_type),
+                "overwrite": True,
+            },
+        )
+
+        if repack:
+            _repack_hdf(prefix_path)
+
 
 @typechecked
 def is_ipv4(ip: Union[pdarray, IPv4], ip2: Optional[pdarray] = None) -> pdarray:

--- a/arkouda/client_dtypes.py
+++ b/arkouda/client_dtypes.py
@@ -685,6 +685,37 @@ class IPv4(pdarray):
         self.registered_name = user_defined_name
         return self
 
+    def to_hdf(
+        self,
+        prefix_path: str,
+        dataset: str = "array",
+        mode: str = "truncate",
+        file_type: str = "distribute",
+    ):
+        """
+        Override of the pdarray to_hdf to store the special dtype
+        """
+        from typing import cast as typecast
+
+        from arkouda.client import generic_msg
+        from arkouda.io import _file_type_to_int, _mode_str_to_int
+
+        return typecast(
+            str,
+            generic_msg(
+                cmd="tohdf",
+                args={
+                    "values": self,
+                    "dset": dataset,
+                    "write_mode": _mode_str_to_int(mode),
+                    "filename": prefix_path,
+                    "dtype": self.dtype,
+                    "objType": self.special_objType,
+                    "file_format": _file_type_to_int(file_type),
+                },
+            ),
+        )
+
 
 @typechecked
 def is_ipv4(ip: Union[pdarray, IPv4], ip2: Optional[pdarray] = None) -> pdarray:

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -1545,6 +1545,10 @@ class DataFrame(UserDict):
             str(obj.categories.dtype) if isinstance(obj, Categorical_) else str(obj.dtype)
             for obj in self.values()
         ]
+        col_objTypes = [
+            obj.special_objType if hasattr(obj, "special_objType") else obj.objType
+            for obj in self.values()
+        ]
         return cast(
             str,
             generic_msg(
@@ -1557,7 +1561,7 @@ class DataFrame(UserDict):
                     "objType": self.objType,
                     "num_cols": len(self.columns),
                     "column_names": self.columns,
-                    "column_objTypes": [obj.objType for key, obj in self.items()],
+                    "column_objTypes": col_objTypes,
                     "column_dtypes": dtypes,
                     "columns": column_data,
                     "index": self.index.values.name,
@@ -2239,11 +2243,9 @@ class DataFrame(UserDict):
             if isinstance(obj, Categorical_)
             else json.dumps({"segments": obj.segments.name, "values": obj.values.name})
             if isinstance(obj, SegArray)
-            else json.dumps({  # BitVector Case
-                "name": obj.name,
-                "width": obj.width,
-                "reverse": obj.reverse
-            })
+            else json.dumps(
+                {"name": obj.name, "width": obj.width, "reverse": obj.reverse}  # BitVector Case
+            )
             for obj in self.values()
         ]
 

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -16,6 +16,8 @@ from arkouda.pdarrayclass import create_pdarray, pdarray
 from arkouda.pdarraycreation import arange, array
 from arkouda.segarray import SegArray
 from arkouda.strings import Strings
+from arkouda.client_dtypes import IPv4
+from arkouda.timeclass import Datetime, Timedelta
 
 __all__ = [
     "get_filetype",
@@ -438,7 +440,7 @@ def _parse_errors(rep_msg, allow_errors: bool = False):
 
 def _parse_obj(
     obj: Dict,
-) -> Union[Strings, pdarray, ArrayView, SegArray, Categorical, DataFrame]:
+) -> Union[Strings, pdarray, ArrayView, SegArray, Categorical, DataFrame, IPv4, Datetime, Timedelta]:
     """
     Helper function to create an Arkouda object from read response
 
@@ -462,6 +464,12 @@ def _parse_obj(
         return SegArray.from_return_msg(obj["created"])
     elif pdarray.objType.upper() == obj["arkouda_type"]:
         return create_pdarray(obj["created"])
+    elif IPv4.special_objType.upper() == obj["arkouda_type"]:
+        return IPv4(create_pdarray(obj["created"]))
+    elif Datetime.special_objType.upper() == obj["arkouda_type"]:
+        return Datetime(create_pdarray(obj["created"]))
+    elif Timedelta.special_objType.upper() == obj["arkouda_type"]:
+        return Timedelta(create_pdarray(obj["created"]))
     elif ArrayView.objType.upper() == obj["arkouda_type"]:
         components = obj["created"].split("+")
         flat = create_pdarray(components[0])
@@ -525,7 +533,10 @@ def _build_objects(
     ArrayView,
     Categorical,
     DataFrame,
-    Mapping[str, Union[Strings, pdarray, SegArray, ArrayView, Categorical, DataFrame]],
+    IPv4,
+    Datetime,
+    Timedelta,
+    Mapping[str, Union[Strings, pdarray, SegArray, ArrayView, Categorical, DataFrame, IPv4, Datetime, Timedelta]],
 ]:
     """
     Helper function to create the Arkouda objects from a read operation

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1518,7 +1518,7 @@ class pdarray:
                     "write_mode": _mode_str_to_int(mode),
                     "filename": prefix_path,
                     "dtype": self.dtype,
-                    "objType": "pdarray",
+                    "objType": self.objType,
                     "file_format": _file_type_to_int(file_type),
                 },
             ),

--- a/arkouda/timeclass.py
+++ b/arkouda/timeclass.py
@@ -224,7 +224,6 @@ class _AbstractBaseTime(pdarray):
         """
         from typing import cast as typecast
 
-        from arkouda.client import generic_msg
         from arkouda.io import _file_type_to_int, _mode_str_to_int
 
         return typecast(
@@ -242,6 +241,37 @@ class _AbstractBaseTime(pdarray):
                 },
             ),
         )
+
+    def update_hdf(self, prefix_path: str, dataset: str = "array", repack: bool = True):
+        """
+        Override the pdarray implementation so that the special object type will be used.
+        """
+        from arkouda.io import (
+            _file_type_to_int,
+            _get_hdf_filetype,
+            _mode_str_to_int,
+            _repack_hdf,
+        )
+
+        # determine the format (single/distribute) that the file was saved in
+        file_type = _get_hdf_filetype(prefix_path + "*")
+
+        generic_msg(
+            cmd="tohdf",
+            args={
+                "values": self,
+                "dset": dataset,
+                "write_mode": _mode_str_to_int("append"),
+                "filename": prefix_path,
+                "dtype": self.dtype,
+                "objType": self.special_objType,
+                "file_format": _file_type_to_int(file_type),
+                "overwrite": True,
+            },
+        )
+
+        if repack:
+            _repack_hdf(prefix_path)
 
     def __str__(self):
         from arkouda.client import pdarrayIterThresh

--- a/arkouda/timeclass.py
+++ b/arkouda/timeclass.py
@@ -84,6 +84,8 @@ class _AbstractBaseTime(pdarray):
     so that all resulting operations are transparent.
     """
 
+    special_objType = "Time"
+
     def __init__(self, pda, unit: str = _BASE_UNIT):  # type: ignore
         if isinstance(pda, Datetime) or isinstance(pda, Timedelta):
             self.unit: str = pda.unit
@@ -209,6 +211,37 @@ class _AbstractBaseTime(pdarray):
     def to_list(self):
         __doc__ = super().to_list().__doc__  # noqa
         return self.to_ndarray().tolist()
+
+    def to_hdf(
+        self,
+        prefix_path: str,
+        dataset: str = "array",
+        mode: str = "truncate",
+        file_type: str = "distribute",
+    ):
+        """
+        Override of the pdarray to_hdf to store the special dtype
+        """
+        from typing import cast as typecast
+
+        from arkouda.client import generic_msg
+        from arkouda.io import _file_type_to_int, _mode_str_to_int
+
+        return typecast(
+            str,
+            generic_msg(
+                cmd="tohdf",
+                args={
+                    "values": self,
+                    "dset": dataset,
+                    "write_mode": _mode_str_to_int(mode),
+                    "filename": prefix_path,
+                    "dtype": self.dtype,
+                    "objType": self.special_objType,
+                    "file_format": _file_type_to_int(file_type),
+                },
+            ),
+        )
 
     def __str__(self):
         from arkouda.client import pdarrayIterThresh

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -202,23 +202,24 @@ module GenSymIO {
             item.add("dataset_name", dsetName.replace(Q, ESCAPED_QUOTES, -1));
             item.add("arkouda_type", akType: string);
             var create_str: string;
-            if akType == ObjType.ARRAYVIEW {
-                var (valName, segName) = id.splitMsgToTuple("+", 2);
+            select akType {
+                when ObjType.ARRAYVIEW {
+                    var (valName, segName) = id.splitMsgToTuple("+", 2);
                 create_str = "created " + st.attrib(valName) + "+created " + st.attrib(segName);
-            }
-            else if akType == ObjType.PDARRAY {
-                create_str = "created " + st.attrib(id);
-            }
-            else if akType == ObjType.STRINGS {
-                var (segName, nBytes) = id.splitMsgToTuple("+", 2);
-                create_str = "created " + st.attrib(segName) + "+created bytes.size " + nBytes;
-            }
-            else if (akType == ObjType.SEGARRAY || akType == ObjType.CATEGORICAL || 
-                        akType == ObjType.GROUPBY || akType == ObjType.DATAFRAME) {
-                create_str = id;
-            }
-            else {
-                continue;
+                }
+                when ObjType.PDARRAY, ObjType.IPV4, ObjType.DATETIME, ObjType.TIMEDELTA {
+                    create_str = "created " + st.attrib(id);
+                }
+                when ObjType.STRINGS {
+                    var (segName, nBytes) = id.splitMsgToTuple("+", 2);
+                    create_str = "created " + st.attrib(segName) + "+created bytes.size " + nBytes;
+                }
+                when ObjType.SEGARRAY, ObjType.CATEGORICAL, ObjType.GROUPBY, ObjType.DATAFRAME {
+                    create_str = id;
+                }
+                otherwise {
+                    continue;
+                }
             }
             item.add("created", create_str);
             items.pushBack(item);

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -2303,7 +2303,7 @@ module HDF5Msg {
                 // loop columns and write each one.
                 for (dset, name, ot, dt) in zip(dset_names, col_names, col_objTypes, col_dtypes) {
                     select ot.toUpper(): ObjType {
-                        when ObjType.PDARRAY {
+                        when ObjType.PDARRAY, ObjType.IPV4, ObjType.DATETIME, ObjType.TIMEDELTA {
                             var entry = st.lookup(name);
                             select str2dtype(dt) {
                                 when DType.Int64 {


### PR DESCRIPTION
Closes #2708

This PR adds support for persisting special object types that inherit `pdarray`. These include `IPv4`, `Datetime`, and `Timedelta`. The workflow still uses the `pdarray` write logic on the server, but will assign the special object type on load. This prevents the users from having to identify and recreate these objects from the `pdarray` returned. Instead, they are returned as the object type they were when saved.

Testing has been added to ensure that the object type is preserved. This is using the same logic on the server as pdarray, so we do not need to retest in depth.