### PR TITLE
Closes #2723: Fix bug with naming after new registry refactor

### DIFF
--- a/src/MultiTypeRegEntry.chpl
+++ b/src/MultiTypeRegEntry.chpl
@@ -70,6 +70,7 @@ module MultiTypeRegEntry {
         proc init(array_name: string, objType: ObjType) {
             super.init(objType);
             this.array = array_name;
+            this.name = array_name;
         }
 
         proc asMap(st: borrowed SymTab): map(string, string) throws {
@@ -96,6 +97,7 @@ module MultiTypeRegEntry {
             this.array = array_name;
             this.width = width;
             this.reverse = reverse;
+            this.name = array_name;
         }
 
         proc asMap(st:borrowed SymTab): map(string, string) throws {


### PR DESCRIPTION
#2638 introduced a bug when attempting to unregister an array. When creating a registry entry, the `name` field isn't set, but is then attempted to be used to unregister an array. To get around that, in the initializers, the name field needs to be set. This PR handles that for the `ArrayRegEntry`, which was causing testing failures, but there are other types that have multiple names where it isn't as clear what "name" should be. I suspect those cases need to be fixed as well.

Closes #2723 