### PR TITLE
Closes #2726: Skip categorical registration until bug is resolved

### DIFF
--- a/tests/categorical_test.py
+++ b/tests/categorical_test.py
@@ -2,6 +2,7 @@ import glob
 import os
 import shutil
 import tempfile
+import pytest
 
 import numpy as np
 from base_test import ArkoudaTest
@@ -417,6 +418,7 @@ class CategoricalTest(ArkoudaTest):
             self.assertCountEqual(x["pda1"].to_list(), pda1.to_list())
             self.assertCountEqual(x["strings1"].to_list(), strings1.to_list())
 
+    @pytest.mark.skip(reason="Bug with new registration code")
     def testNA(self):
         s = ak.array(["A", "B", "C", "B", "C"])
         # NAval present in categories


### PR DESCRIPTION
There is a bug with the new categorical registration code that is causing nightly failures. In advance of a fix, skipping this test would allow us to test the other tests prior to the fix of the bug.

Closes #2726