### PR TITLE
Closes #2728: Convert per-locale memory logging to total memory logging

### DIFF
--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -297,7 +297,7 @@ module ServerConfig
             if total > getMemLimit() {
                 var pct = AutoMath.round((total:real / getMemLimit():real * 100):uint);
                 var msg = "cmd requiring %i bytes of memory exceeds %i limit with projected pct memory used of %i%%".doFormat(
-                                   total, getMemLimit(), pct);
+                                   total * numLocales, getMemLimit() * numLocales, pct);
                 scLogger.error(getModuleName(),getRoutineName(),getLineNumber(), msg);  
                 throw getErrorWithContext(
                           msg=msg,
@@ -338,7 +338,7 @@ module ServerConfig
                 if total > getMemLimit() {
                     var pct = AutoMath.round((total:real / getMemLimit():real * 100):uint);
                     var msg = "cmd requiring %i bytes of memory exceeds %i limit with projected pct memory used of %i%%".doFormat(
-                                   total, getMemLimit(), pct);
+                                   total * numLocales, getMemLimit() * numLocales, pct);
                     scLogger.error(getModuleName(),getRoutineName(),getLineNumber(), msg);  
                     throw getErrorWithContext(
                               msg=msg,


### PR DESCRIPTION
Closes #2728 

This PR updates memory logging to consistently report total memory (locale0 memory used * numLocales and locale0 memory available at startup/per memMax * numLocales) for all logging.