### PR TITLE
Closes #2724 & #2730 - Adds HDF5 support for Index and MultiIndex 

### DIFF
--- a/PROTO_tests/tests/io_test.py
+++ b/PROTO_tests/tests/io_test.py
@@ -1267,29 +1267,65 @@ class TestHDF5:
                 else:
                     assert (ref_data[key] == data[key]).all()
 
-    def test_index_save_and_load(self):
+    @pytest.mark.parametrize("dtype", NUMERIC_AND_STR_TYPES)
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_index_save_and_load(self, dtype, size):
+        idx = ak.Index(make_ak_arrays(size, dtype))
         with tempfile.TemporaryDirectory(dir=TestHDF5.hdf_test_base_tmp) as tmp_dirname:
-            file_name = f"{tmp_dirname}/idx_file"
-            idx = ak.Index(ak.arange(5))
-            idx.to_hdf(f"{file_name}.h5")
-            assert len(glob.glob(f"{file_name}*.h5")) == pytest.nl
-            ret_idx = ak.read_hdf(f"{file_name}*")
-            assert (idx == ret_idx).all()
+            idx.to_hdf(f"{tmp_dirname}/idx_test")
+            rd_idx = ak.read_hdf(f"{tmp_dirname}/idx_test*")
+
+            assert isinstance(rd_idx, ak.Index)
+            assert type(rd_idx.values) == type(idx.values)
+            assert idx.to_list() == rd_idx.to_list()
+
+        if dtype == ak.str_:
+            # if strings we need to also test Categorical
+            idx = ak.Index(ak.Categorical(make_ak_arrays(size, dtype)))
+            with tempfile.TemporaryDirectory(dir=TestHDF5.hdf_test_base_tmp) as tmp_dirname:
+                idx.to_hdf(f"{tmp_dirname}/idx_test")
+                rd_idx = ak.read_hdf(f"{tmp_dirname}/idx_test*")
+
+                assert isinstance(rd_idx, ak.Index)
+                assert type(rd_idx.values) == type(idx.values)
+                assert idx.to_list() == rd_idx.to_list()
+
+    @pytest.mark.parametrize("dtype1", NUMERIC_AND_STR_TYPES)
+    @pytest.mark.parametrize("dtype2", NUMERIC_AND_STR_TYPES)
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_multi_index(self, dtype1, dtype2, size):
+        t1 = make_ak_arrays(size, dtype1)
+        t2 = make_ak_arrays(size, dtype2)
+        idx = ak.Index.factory([t1, t2])
+        with tempfile.TemporaryDirectory(dir=TestHDF5.hdf_test_base_tmp) as tmp_dirname:
+            idx.to_hdf(f"{tmp_dirname}/idx_test")
+            rd_idx = ak.read_hdf(f"{tmp_dirname}/idx_test*")
+
+            assert isinstance(rd_idx, ak.MultiIndex)
+            assert idx.to_list() == rd_idx.to_list()
+        # handle categorical cases as well
+        if dtype1 == ak.str_:
+            t1 = ak.Categorical(t1)
+        if dtype2 == ak.str_:
+            t2 = ak.Categorical(t2)
+        idx = ak.Index.factory([t1, t2])
+        with tempfile.TemporaryDirectory(dir=TestHDF5.hdf_test_base_tmp) as tmp_dirname:
+            idx.to_hdf(f"{tmp_dirname}/idx_test")
+            rd_idx = ak.read_hdf(f"{tmp_dirname}/idx_test*")
+
+            assert isinstance(rd_idx, ak.MultiIndex)
+            assert idx.to_list() == rd_idx.to_list()
 
     def test_special_objtype(self):
         """
-                This test is simply to ensure that the dtype is persisted through the io
-                operation. It ultimately uses the process of pdarray, but need to ensure
-                correct Arkouda Object Type is returned
-                """
+        This test is simply to ensure that the dtype is persisted through the io
+        operation. It ultimately uses the process of pdarray, but need to ensure
+        correct Arkouda Object Type is returned
+        """
         ip = ak.IPv4(ak.arange(10))
         dt = ak.Datetime(ak.arange(10))
         td = ak.Timedelta(ak.arange(10))
-        df = ak.DataFrame({
-            "ip": ip,
-            "datetime": dt,
-            "timedelta": td
-        })
+        df = ak.DataFrame({"ip": ip, "datetime": dt, "timedelta": td})
 
         with tempfile.TemporaryDirectory(dir=TestHDF5.hdf_test_base_tmp) as tmp_dirname:
             ip.to_hdf(f"{tmp_dirname}/ip_test")

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -388,7 +388,50 @@ class Index:
         - Any file extension can be used.The file I/O does not rely on the extension to
         determine the file format.
         """
-        return self.values.to_hdf(prefix_path, dataset=dataset, mode=mode, file_type=file_type)
+        from typing import cast as typecast
+
+        from arkouda.categorical import Categorical as Categorical_
+        from arkouda.client import generic_msg
+        from arkouda.io import _file_type_to_int, _mode_str_to_int
+
+        index_data = [
+            self.values.name
+            if not isinstance(self.values, (Categorical_))
+            else json.dumps(
+                {
+                    "codes": self.values.codes.name,
+                    "categories": self.values.categories.name,
+                    "NA_codes": self.values._akNAcode.name,
+                    **(
+                        {"permutation": self.values.permutation.name}
+                        if self.values.permutation is not None
+                        else {}
+                    ),
+                    **(
+                        {"segments": self.values.segments.name}
+                        if self.values.segments is not None
+                        else {}
+                    ),
+                }
+            )
+        ]
+        return typecast(
+            str,
+            generic_msg(
+                cmd="tohdf",
+                args={
+                    "filename": prefix_path,
+                    "dset": dataset,
+                    "file_format": _file_type_to_int(file_type),
+                    "write_mode": _mode_str_to_int(mode),
+                    "objType": self.objType,
+                    "num_idx": 1,
+                    "idx": index_data,
+                    "idx_objTypes": [self.values.objType],  # this will be pdarray, strings, or cat
+                    "idx_dtypes": [str(self.values.dtype)],
+                },
+            ),
+        )
 
     def update_hdf(
         self,
@@ -430,7 +473,58 @@ class Index:
         - Because HDF5 deletes do not release memory, this will create a copy of the
           file with the new data
         """
-        return self.values.update_hdf(prefix_path, dataset=dataset, repack=repack)
+        from arkouda.categorical import Categorical as Categorical_
+        from arkouda.client import generic_msg
+        from arkouda.io import (
+            _file_type_to_int,
+            _get_hdf_filetype,
+            _mode_str_to_int,
+            _repack_hdf,
+        )
+
+        # determine the format (single/distribute) that the file was saved in
+        file_type = _get_hdf_filetype(prefix_path + "*")
+
+        index_data = [
+            self.values.name
+            if not isinstance(self.values, (Categorical_))
+            else json.dumps(
+                {
+                    "codes": self.values.codes.name,
+                    "categories": self.values.categories.name,
+                    "NA_codes": self.values._akNAcode.name,
+                    **(
+                        {"permutation": self.values.permutation.name}
+                        if self.values.permutation is not None
+                        else {}
+                    ),
+                    **(
+                        {"segments": self.values.segments.name}
+                        if self.values.segments is not None
+                        else {}
+                    ),
+                }
+            )
+        ]
+
+        generic_msg(
+            cmd="tohdf",
+            args={
+                "filename": prefix_path,
+                "dset": dataset,
+                "file_format": _file_type_to_int(file_type),
+                "write_mode": _mode_str_to_int("append"),
+                "objType": self.objType,
+                "num_idx": 1,
+                "idx": index_data,
+                "idx_objTypes": [self.values.objType],  # this will be pdarray, strings, or cat
+                "idx_dtypes": [str(self.values.dtype)],
+                "overwrite": True,
+            },
+        ),
+
+        if repack:
+            _repack_hdf(prefix_path)
 
     def to_parquet(
         self,
@@ -808,3 +902,172 @@ class MultiIndex(Index):
         if not isinstance(key[0], pdarray):
             key = [array([x]) for x in key]
         return in1d(self.index, key)
+
+    def to_hdf(
+        self,
+        prefix_path: str,
+        dataset: str = "index",
+        mode: str = "truncate",
+        file_type: str = "distribute",
+    ) -> str:
+        """
+        Save the Index to HDF5.
+        The object can be saved to a collection of files or single file.
+        Parameters
+        ----------
+        prefix_path : str
+            Directory and filename prefix that all output files share
+        dataset : str
+            Name of the dataset to create in files (must not already exist)
+        mode : str {'truncate' | 'append'}
+            By default, truncate (overwrite) output files, if they exist.
+            If 'append', attempt to create new dataset in existing files.
+        file_type: str ("single" | "distribute")
+            Default: "distribute"
+            When set to single, dataset is written to a single file.
+            When distribute, dataset is written on a file per locale.
+            This is only supported by HDF5 files and will have no impact of Parquet Files.
+        Returns
+        -------
+        string message indicating result of save operation
+        Raises
+        -------
+        RuntimeError
+            Raised if a server-side error is thrown saving the pdarray
+        Notes
+        -----
+        - The prefix_path must be visible to the arkouda server and the user must
+        have write permission.
+        - Output files have names of the form ``<prefix_path>_LOCALE<i>``, where ``<i>``
+        ranges from 0 to ``numLocales`` for `file_type='distribute'`. Otherwise,
+        the file name will be `prefix_path`.
+        - If any of the output files already exist and
+        the mode is 'truncate', they will be overwritten. If the mode is 'append'
+        and the number of output files is less than the number of locales or a
+        dataset with the same name already exists, a ``RuntimeError`` will result.
+        - Any file extension can be used.The file I/O does not rely on the extension to
+        determine the file format.
+        """
+        from typing import cast as typecast
+
+        from arkouda.categorical import Categorical as Categorical_
+        from arkouda.client import generic_msg
+        from arkouda.io import _file_type_to_int, _mode_str_to_int
+
+        index_data = [
+            obj.name
+            if not isinstance(obj, (Categorical_))
+            else json.dumps(
+                {
+                    "codes": obj.codes.name,
+                    "categories": obj.categories.name,
+                    "NA_codes": obj._akNAcode.name,
+                    **({"permutation": obj.permutation.name} if obj.permutation is not None else {}),
+                    **({"segments": obj.segments.name} if obj.segments is not None else {}),
+                }
+            )
+            for obj in self.values
+        ]
+        return typecast(
+            str,
+            generic_msg(
+                cmd="tohdf",
+                args={
+                    "filename": prefix_path,
+                    "dset": dataset,
+                    "file_format": _file_type_to_int(file_type),
+                    "write_mode": _mode_str_to_int(mode),
+                    "objType": self.objType,
+                    "num_idx": len(self.values),
+                    "idx": index_data,
+                    "idx_objTypes": [obj.objType for obj in self.values],
+                    "idx_dtypes": [str(obj.dtype) for obj in self.values],
+                },
+            ),
+        )
+
+    def update_hdf(
+        self,
+        prefix_path: str,
+        dataset: str = "array",
+        repack: bool = True,
+    ):
+        """
+        Overwrite the dataset with the name provided with this Index object. If
+        the dataset does not exist it is added.
+
+        Parameters
+        -----------
+        prefix_path : str
+            Directory and filename prefix that all output files share
+        dataset : str
+            Name of the dataset to create in files
+        repack: bool
+            Default: True
+            HDF5 does not release memory on delete. When True, the inaccessible
+            data (that was overwritten) is removed. When False, the data remains, but is
+            inaccessible. Setting to false will yield better performance, but will cause
+            file sizes to expand.
+
+        Returns
+        --------
+        str - success message if successful
+
+        Raises
+        -------
+        RuntimeError
+            Raised if a server-side error is thrown saving the index
+
+        Notes
+        ------
+        - If file does not contain File_Format attribute to indicate how it was saved,
+          the file name is checked for _LOCALE#### to determine if it is distributed.
+        - If the dataset provided does not exist, it will be added
+        - Because HDF5 deletes do not release memory, this will create a copy of the
+          file with the new data
+        """
+        from arkouda.categorical import Categorical as Categorical_
+        from arkouda.client import generic_msg
+        from arkouda.io import (
+            _file_type_to_int,
+            _get_hdf_filetype,
+            _mode_str_to_int,
+            _repack_hdf,
+        )
+
+        # determine the format (single/distribute) that the file was saved in
+        file_type = _get_hdf_filetype(prefix_path + "*")
+
+        index_data = [
+            obj.name
+            if not isinstance(obj, (Categorical_))
+            else json.dumps(
+                {
+                    "codes": obj.codes.name,
+                    "categories": obj.categories.name,
+                    "NA_codes": obj._akNAcode.name,
+                    **({"permutation": obj.permutation.name} if obj.permutation is not None else {}),
+                    **({"segments": obj.segments.name} if obj.segments is not None else {}),
+                }
+            )
+            for obj in self.values
+        ]
+
+        generic_msg(
+            cmd="tohdf",
+            args={
+                "filename": prefix_path,
+                "dset": dataset,
+                "file_format": _file_type_to_int(file_type),
+                "write_mode": _mode_str_to_int("append"),
+                "objType": self.objType,
+                "num_idx": 1,
+                "idx": index_data,
+                "idx_objTypes": [obj.objType for obj in self.values],
+                "idx_dtypes": [str(obj.dtype) for obj in self.values],
+                "overwrite": True,
+            },
+        ),
+
+        if repack:
+            _repack_hdf(prefix_path)

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -1064,7 +1064,7 @@ class MultiIndex(Index):
                 "file_format": _file_type_to_int(file_type),
                 "write_mode": _mode_str_to_int("append"),
                 "objType": self.objType,
-                "num_idx": 1,
+                "num_idx": len(self.values),
                 "idx": index_data,
                 "idx_objTypes": [obj.objType for obj in self.values],
                 "idx_dtypes": [str(obj.dtype) for obj in self.values],

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -992,7 +992,7 @@ class MultiIndex(Index):
     def update_hdf(
         self,
         prefix_path: str,
-        dataset: str = "array",
+        dataset: str = "index",
         repack: bool = True,
     ):
         """

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -10,13 +10,14 @@ from typeguard import typechecked
 from arkouda.array_view import ArrayView
 from arkouda.categorical import Categorical
 from arkouda.client import generic_msg
+from arkouda.client_dtypes import IPv4
 from arkouda.dataframe import DataFrame
 from arkouda.groupbyclass import GroupBy
+from arkouda.index import Index, MultiIndex
 from arkouda.pdarrayclass import create_pdarray, pdarray
 from arkouda.pdarraycreation import arange, array
 from arkouda.segarray import SegArray
 from arkouda.strings import Strings
-from arkouda.client_dtypes import IPv4
 from arkouda.timeclass import Datetime, Timedelta
 
 __all__ = [
@@ -440,7 +441,19 @@ def _parse_errors(rep_msg, allow_errors: bool = False):
 
 def _parse_obj(
     obj: Dict,
-) -> Union[Strings, pdarray, ArrayView, SegArray, Categorical, DataFrame, IPv4, Datetime, Timedelta]:
+) -> Union[
+    Strings,
+    pdarray,
+    ArrayView,
+    SegArray,
+    Categorical,
+    DataFrame,
+    IPv4,
+    Datetime,
+    Timedelta,
+    Index,
+    MultiIndex,
+]:
     """
     Helper function to create an Arkouda object from read response
 
@@ -481,6 +494,11 @@ def _parse_obj(
         return GroupBy.from_return_msg(obj["created"])
     elif DataFrame.objType.upper() == obj["arkouda_type"]:
         return DataFrame.from_return_msg(obj["created"])
+    elif (
+        obj["arkouda_type"].lower() == Index.objType.lower()
+        or obj["arkouda_type"].lower() == MultiIndex.objType.lower()
+    ):
+        return Index.from_return_msg(obj["created"])
     else:
         raise TypeError(f"Unknown arkouda type:{obj['arkouda_type']}")
 
@@ -536,9 +554,21 @@ def _build_objects(
     IPv4,
     Datetime,
     Timedelta,
+    Index,
     Mapping[
         str,
-        Union[Strings, pdarray, SegArray, ArrayView, Categorical, DataFrame, IPv4, Datetime, Timedelta],
+        Union[
+            Strings,
+            pdarray,
+            SegArray,
+            ArrayView,
+            Categorical,
+            DataFrame,
+            IPv4,
+            Datetime,
+            Timedelta,
+            Index,
+        ],
     ],
 ]:
     """
@@ -590,7 +620,25 @@ def read_hdf(
     ArrayView,
     Categorical,
     DataFrame,
-    Mapping[str, Union[pdarray, Strings, SegArray, ArrayView, Categorical, DataFrame]],
+    IPv4,
+    Datetime,
+    Timedelta,
+    Index,
+    Mapping[
+        str,
+        Union[
+            pdarray,
+            Strings,
+            SegArray,
+            ArrayView,
+            Categorical,
+            DataFrame,
+            IPv4,
+            Datetime,
+            Timedelta,
+            Index,
+        ],
+    ],
 ]:
     """
     Read Arkouda objects from HDF5 file/s
@@ -720,7 +768,25 @@ def read_parquet(
     ArrayView,
     Categorical,
     DataFrame,
-    Mapping[str, Union[pdarray, Strings, SegArray, ArrayView, Categorical, DataFrame]],
+    IPv4,
+    Datetime,
+    Timedelta,
+    Index,
+    Mapping[
+        str,
+        Union[
+            pdarray,
+            Strings,
+            SegArray,
+            ArrayView,
+            Categorical,
+            DataFrame,
+            IPv4,
+            Datetime,
+            Timedelta,
+            Index,
+        ],
+    ],
 ]:
     """
     Read Arkouda objects from Parquet file/s
@@ -848,7 +914,25 @@ def read_csv(
     ArrayView,
     Categorical,
     DataFrame,
-    Mapping[str, Union[pdarray, Strings, SegArray, ArrayView, Categorical, DataFrame]],
+    IPv4,
+    Datetime,
+    Timedelta,
+    Index,
+    Mapping[
+        str,
+        Union[
+            pdarray,
+            Strings,
+            SegArray,
+            ArrayView,
+            Categorical,
+            DataFrame,
+            IPv4,
+            Datetime,
+            Timedelta,
+            Index,
+        ],
+    ],
 ]:
     """
     Read CSV file(s) into Arkouda objects. If more than one dataset is found, the objects
@@ -1540,7 +1624,25 @@ def load(
     ArrayView,
     Categorical,
     DataFrame,
-    Mapping[str, Union[pdarray, Strings, SegArray, ArrayView, Categorical, DataFrame]],
+    IPv4,
+    Datetime,
+    Timedelta,
+    Index,
+    Mapping[
+        str,
+        Union[
+            pdarray,
+            Strings,
+            SegArray,
+            ArrayView,
+            Categorical,
+            DataFrame,
+            IPv4,
+            Datetime,
+            Timedelta,
+            Index,
+        ],
+    ],
 ]:
     """
     Load a pdarray previously saved with ``pdarray.save()``.
@@ -1738,7 +1840,25 @@ def read(
     ArrayView,
     Categorical,
     DataFrame,
-    Mapping[str, Union[pdarray, Strings, SegArray, ArrayView, Categorical, DataFrame]],
+    IPv4,
+    Datetime,
+    Timedelta,
+    Index,
+    Mapping[
+        str,
+        Union[
+            pdarray,
+            Strings,
+            SegArray,
+            ArrayView,
+            Categorical,
+            DataFrame,
+            IPv4,
+            Datetime,
+            Timedelta,
+            Index,
+        ],
+    ],
 ]:
     """
     Read datasets from files.
@@ -1969,6 +2089,7 @@ def snapshot(filename):
     """
     import inspect
     from types import ModuleType
+
     from arkouda.dataframe import DataFrame
 
     filename = filename + "_SNAPSHOT"

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -214,7 +214,7 @@ module GenSymIO {
                     var (segName, nBytes) = id.splitMsgToTuple("+", 2);
                     create_str = "created " + st.attrib(segName) + "+created bytes.size " + nBytes;
                 }
-                when ObjType.SEGARRAY, ObjType.CATEGORICAL, ObjType.GROUPBY, ObjType.DATAFRAME {
+                when ObjType.SEGARRAY, ObjType.CATEGORICAL, ObjType.GROUPBY, ObjType.DATAFRAME, ObjType.INDEX, ObjType.MULTIINDEX {
                     create_str = id;
                 }
                 otherwise {


### PR DESCRIPTION
Closes #2724 
Closes #2730 

This PR adds support for `Index` and `MultiIndex` to HDF5 processing. This allows for these objects to be saved to and read from HDF5 without requiring the user to recreate the object for the `pdarray`/`Strings`/`Categorical` return.