### PR TITLE
Closes #2732: Fix missed symbol table entry creation for distributed builds

### DIFF
--- a/src/KExtremeMsg.chpl
+++ b/src/KExtremeMsg.chpl
@@ -49,7 +49,7 @@ module KExtremeMsg
             when (DType.Int64) {
                 var e = toSymEntry(gEnt,int);
                 var aV = if !returnIndices then computeExtremaValues(e.a, k) else computeExtremaIndices(e.a, k);
-                st.addEntry(vname, new shared SymEntry(aV));
+                st.addEntry(vname, createSymEntry(aV));
 
                 repMsg = "created " + st.attrib(vname);
                 keLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
@@ -59,14 +59,14 @@ module KExtremeMsg
                 var e = toSymEntry(gEnt,uint);
                 if !returnIndices {
                     var aV = computeExtremaValues(e.a, k);
-                    st.addEntry(vname, new shared SymEntry(aV));
+                    st.addEntry(vname, createSymEntry(aV));
 
                     repMsg = "created " + st.attrib(vname);
                     keLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
                     return new MsgTuple(repMsg, MsgType.NORMAL);
                 } else {
                     var aV = computeExtremaIndices(e.a, k);
-                    st.addEntry(vname, new shared SymEntry(aV));
+                    st.addEntry(vname, createSymEntry(aV));
 
                     repMsg = "created " + st.attrib(vname);
                     keLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
@@ -77,14 +77,14 @@ module KExtremeMsg
                 var e = toSymEntry(gEnt,real);
                 if !returnIndices {
                     var aV = computeExtremaValues(e.a, k);
-                    st.addEntry(vname, new shared SymEntry(aV));
+                    st.addEntry(vname, createSymEntry(aV));
 
                     repMsg = "created " + st.attrib(vname);
                     keLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
                     return new MsgTuple(repMsg, MsgType.NORMAL);
                 } else {
                     var aV = computeExtremaIndices(e.a, k);
-                    st.addEntry(vname, new shared SymEntry(aV));
+                    st.addEntry(vname, createSymEntry(aV));
 
                     repMsg = "created " + st.attrib(vname);
                     keLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
@@ -120,7 +120,7 @@ module KExtremeMsg
             when (DType.Int64) {
                 var e = toSymEntry(gEnt,int);
                 var aV = if !returnIndices then computeExtremaValues(e.a, k, false) else computeExtremaIndices(e.a, k, false);
-                st.addEntry(vname, new shared SymEntry(aV));
+                st.addEntry(vname, createSymEntry(aV));
 
                 repMsg = "created " + st.attrib(vname);
                 keLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
@@ -130,14 +130,14 @@ module KExtremeMsg
                 var e = toSymEntry(gEnt,uint);
                if !returnIndices {
                    var aV = computeExtremaValues(e.a, k, false);
-                   st.addEntry(vname, new shared SymEntry(aV));
+                   st.addEntry(vname, createSymEntry(aV));
 
                    repMsg = "created " + st.attrib(vname);
                    keLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
                    return new MsgTuple(repMsg, MsgType.NORMAL);
                } else {
                    var aV = computeExtremaIndices(e.a, k, false);
-                   st.addEntry(vname, new shared SymEntry(aV));
+                   st.addEntry(vname, createSymEntry(aV));
 
                    repMsg = "created " + st.attrib(vname);
                    keLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
@@ -148,14 +148,14 @@ module KExtremeMsg
                 var e = toSymEntry(gEnt,real);
                if !returnIndices {
                    var aV = computeExtremaValues(e.a, k, false);
-                   st.addEntry(vname, new shared SymEntry(aV));
+                   st.addEntry(vname, createSymEntry(aV));
 
                    repMsg = "created " + st.attrib(vname);
                    keLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
                    return new MsgTuple(repMsg, MsgType.NORMAL);
                } else {
                    var aV = computeExtremaIndices(e.a, k, false);
-                   st.addEntry(vname, new shared SymEntry(aV));
+                   st.addEntry(vname, createSymEntry(aV));
 
                    repMsg = "created " + st.attrib(vname);
                    keLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);


### PR DESCRIPTION
In #2653, the compatability shim was added to support the new tryCreateArray throwing interface and that interface removed initializers for block-distributed symbol table entries, replacing with the new createSymEntry helper function. There were a few instances of this missed in the KExtreme code, which was causing distributed builds to fail.

Closes #2732