### PR TITLE
Closes #2734: Fix remaining missed symbol table entry creation for distributed builds

### DIFF
--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -257,7 +257,7 @@ module ArgSortMsg
           var merged = mergeNumericArrays(numDigits, arrSize, totalDigits, bitWidths, negs, names, st);
 
           var iv = argsortDefault(merged, algorithm=algorithm);
-          st.addEntry(ivname, new shared SymEntry(iv));
+          st.addEntry(ivname, createSymEntry(iv));
 
           var repMsg = "created " + st.attrib(ivname);
           asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
@@ -360,17 +360,17 @@ module ArgSortMsg
                 when (DType.Int64) {
                     var e = toSymEntry(gEnt,int);
                     var iv = argsortDefault(e.a, algorithm=algorithm);
-                    st.addEntry(ivname, new shared SymEntry(iv));
+                    st.addEntry(ivname, createSymEntry(iv));
                 }
                 when (DType.UInt64) {
                     var e = toSymEntry(gEnt,uint);
                     var iv = argsortDefault(e.a, algorithm=algorithm);
-                    st.addEntry(ivname, new shared SymEntry(iv));
+                    st.addEntry(ivname, createSymEntry(iv));
                 }
                 when (DType.Float64) {
                     var e = toSymEntry(gEnt, real);
                     var iv = argsortDefault(e.a);
-                    st.addEntry(ivname, new shared SymEntry(iv));
+                    st.addEntry(ivname, createSymEntry(iv));
                 }
                 otherwise {
                     var errorMsg = notImplementedError(pn,gEnt.dtype);
@@ -385,7 +385,7 @@ module ArgSortMsg
             overMemLimit((8 * strings.size * 8)
                          + (2 * here.maxTaskPar * numLocales * 2**16 * 8));
             var iv = strings.argsort();
-            st.addEntry(ivname, new shared SymEntry(iv));
+            st.addEntry(ivname, createSymEntry(iv));
           }
           otherwise {
               var errorMsg = notImplementedError(pn, objtype: string);

--- a/src/ArraySetopsMsg.chpl
+++ b/src/ArraySetopsMsg.chpl
@@ -58,7 +58,7 @@ module ArraySetopsMsg
             var f = toSymEntry(gEnt2,int);
 
             var aV = intersect1d(e.a, f.a, isUnique);
-            st.addEntry(vname, new shared SymEntry(aV));
+            st.addEntry(vname, createSymEntry(aV));
 
             repMsg = "created " + st.attrib(vname);
             asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
@@ -69,7 +69,7 @@ module ArraySetopsMsg
             var f = toSymEntry(gEnt2,uint);
 
             var aV = intersect1d(e.a, f.a, isUnique);
-            st.addEntry(vname, new shared SymEntry(aV));
+            st.addEntry(vname, createSymEntry(aV));
 
             repMsg = "created " + st.attrib(vname);
             asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
@@ -112,7 +112,7 @@ module ArraySetopsMsg
              var f = toSymEntry(gEnt2,int);
              
              var aV = setxor1d(e.a, f.a, isUnique);
-             st.addEntry(vname, new shared SymEntry(aV));
+             st.addEntry(vname, createSymEntry(aV));
 
              repMsg = "created " + st.attrib(vname);
              asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
@@ -123,7 +123,7 @@ module ArraySetopsMsg
              var f = toSymEntry(gEnt2,uint);
              
              var aV = setxor1d(e.a, f.a, isUnique);
-             st.addEntry(vname, new shared SymEntry(aV));
+             st.addEntry(vname, createSymEntry(aV));
 
              repMsg = "created " + st.attrib(vname);
              asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
@@ -166,7 +166,7 @@ module ArraySetopsMsg
              var f = toSymEntry(gEnt2, int);
              
              var aV = setdiff1d(e.a, f.a, isUnique);
-             st.addEntry(vname, new shared SymEntry(aV));
+             st.addEntry(vname, createSymEntry(aV));
 
              var repMsg = "created " + st.attrib(vname);
              asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
@@ -177,7 +177,7 @@ module ArraySetopsMsg
              var f = toSymEntry(gEnt2, uint);
              
              var aV = setdiff1d(e.a, f.a, isUnique);
-             st.addEntry(vname, new shared SymEntry(aV));
+             st.addEntry(vname, createSymEntry(aV));
 
              var repMsg = "created " + st.attrib(vname);
              asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
@@ -219,7 +219,7 @@ module ArraySetopsMsg
            var f = toSymEntry(gEnt2,int);
 
            var aV = union1d(e.a, f.a);
-           st.addEntry(vname, new shared SymEntry(aV));
+           st.addEntry(vname, createSymEntry(aV));
 
            var repMsg = "created " + st.attrib(vname);
            asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
@@ -230,7 +230,7 @@ module ArraySetopsMsg
            var f = toSymEntry(gEnt2,uint);
 
            var aV = union1d(e.a, f.a);
-           st.addEntry(vname, new shared SymEntry(aV));
+           st.addEntry(vname, createSymEntry(aV));
 
            var repMsg = "created " + st.attrib(vname);
            asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);

--- a/src/BigIntMsg.chpl
+++ b/src/BigIntMsg.chpl
@@ -48,7 +48,7 @@ module BigIntMsg {
         }
 
         var retname = st.nextName();
-        st.addEntry(retname, new shared SymEntry(bigIntArray, max_bits));
+        st.addEntry(retname, createSymEntry(bigIntArray, max_bits));
         var syment = toSymEntry(getGenericTypedArrayEntry(retname, st), bigint);
         repMsg = "created %s".doFormat(st.attrib(retname));
         biLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
@@ -73,7 +73,7 @@ module BigIntMsg {
                 while !all_zero {
                   low = tmp:uint;
                   var retname = st.nextName();
-                  st.addEntry(retname, new shared SymEntry(low));
+                  st.addEntry(retname, createSymEntry(low));
                   retList.pushBack("created %s".doFormat(st.attrib(retname)));
 
                   all_zero = true;

--- a/src/CSVMsg.chpl
+++ b/src/CSVMsg.chpl
@@ -400,7 +400,7 @@ module CSVMsg {
                 when DType.Int64 {
                     var a = makeDistArray(record_count, int);
                     read_files_into_dist_array(a, dset, filenames, subdoms, skips, true, col_delim, offsets);
-                    var entry = new shared SymEntry(a);
+                    var entry = createSymEntry(a);
                     var rname = st.nextName();
                     st.addEntry(rname, entry);
                     rtnData.pushBack((dset, ObjType.PDARRAY, rname));
@@ -408,7 +408,7 @@ module CSVMsg {
                 when DType.UInt64 {
                     var a = makeDistArray(record_count, uint);
                     read_files_into_dist_array(a, dset, filenames, subdoms, skips, true, col_delim, offsets);
-                    var entry = new shared SymEntry(a);
+                    var entry = createSymEntry(a);
                     var rname = st.nextName();
                     st.addEntry(rname, entry);
                     rtnData.pushBack((dset, ObjType.PDARRAY, rname));
@@ -416,7 +416,7 @@ module CSVMsg {
                 when DType.Float64 {
                     var a = makeDistArray(record_count, real);
                     read_files_into_dist_array(a, dset, filenames, subdoms, skips, true, col_delim, offsets);
-                    var entry = new shared SymEntry(a);
+                    var entry = createSymEntry(a);
                     var rname = st.nextName();
                     st.addEntry(rname, entry);
                     rtnData.pushBack((dset, ObjType.PDARRAY, rname));
@@ -424,7 +424,7 @@ module CSVMsg {
                 when DType.Bool {
                     var a = makeDistArray(record_count, bool);
                     read_files_into_dist_array(a, dset, filenames, subdoms, skips, true, col_delim, offsets);
-                    var entry = new shared SymEntry(a);
+                    var entry = createSymEntry(a);
                     var rname = st.nextName();
                     st.addEntry(rname, entry);
                     rtnData.pushBack((dset, ObjType.PDARRAY, rname));

--- a/src/Cast.chpl
+++ b/src/Cast.chpl
@@ -48,7 +48,7 @@ module Cast {
       castLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
       return "Error: %s".doFormat(errorMsg);
     }
-    var after = st.addEntry(name, new shared SymEntry(tmp));
+    var after = st.addEntry(name, createSymEntry(tmp));
 
     var returnMsg = "created " + st.attrib(name);
     castLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),returnMsg);
@@ -185,11 +185,11 @@ module Cast {
       // do something like segmented computation w/o the aggregation
       select errors {
         when ErrorMode.strict {
-          var entry = st.addEntry(name, new shared SymEntry(computeOnSegmentsWithoutAggregation(oa, va, SegFunction.StringToNumericStrict, bigint)));
+          var entry = st.addEntry(name, createSymEntry(computeOnSegmentsWithoutAggregation(oa, va, SegFunction.StringToNumericStrict, bigint)));
           returnMsg = "created " + st.attrib(name);
         }
         when ErrorMode.ignore {
-          var entry = st.addEntry(name, new shared SymEntry(computeOnSegmentsWithoutAggregation(oa, va, SegFunction.StringToNumericIgnore, bigint)));
+          var entry = st.addEntry(name, createSymEntry(computeOnSegmentsWithoutAggregation(oa, va, SegFunction.StringToNumericIgnore, bigint)));
           returnMsg = "created " + st.attrib(name);
         }
         when ErrorMode.return_validity {
@@ -200,7 +200,7 @@ module Cast {
           forall (t, v, vf) in zip(tmp, valid.a, valWithFlag) {
             (t, v) = vf;
           }
-          var entry = st.addEntry(name, new shared SymEntry(tmp));
+          var entry = st.addEntry(name, createSymEntry(tmp));
           returnMsg = "created " + st.attrib(name);
           returnMsg += "+created " + st.attrib(vname);
         }

--- a/src/ConcatenateMsg.chpl
+++ b/src/ConcatenateMsg.chpl
@@ -361,7 +361,7 @@ module ConcatenateMsg
                               start += o.size;
                             }
                         }
-                        st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+                        st.addEntry(rname, createSymEntry(tmp, max_bits));
                         cmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                          "created concatenated pdarray: %s".doFormat(st.attrib(rname)));
                     }

--- a/src/DataFrameIndexingMsg.chpl
+++ b/src/DataFrameIndexingMsg.chpl
@@ -89,9 +89,9 @@
         }
 
         var s_name = st.nextName();
-        st.addEntry(s_name, new shared SymEntry(rsegs));
+        st.addEntry(s_name, createSymEntry(rsegs));
         var v_name = st.nextName();
-        st.addEntry(v_name, new shared SymEntry(rvals));
+        st.addEntry(v_name, createSymEntry(rvals));
 
         return "SegArray+%s+created %s+created %s".doFormat(col, st.attrib(s_name), st.attrib(v_name));
     }

--- a/src/FlattenMsg.chpl
+++ b/src/FlattenMsg.chpl
@@ -29,7 +29,7 @@ module FlattenMsg {
         repMsg = "created %s+created bytes.size %?".doFormat(st.attrib(stringsObj.name), stringsObj.nBytes);
         if returnSegs {
           const optName: string = st.nextName();
-          st.addEntry(optName, new shared SymEntry(segs));
+          st.addEntry(optName, createSymEntry(segs));
           repMsg += "+created %s".doFormat(st.attrib(optName));
         }
       } otherwise {
@@ -70,7 +70,7 @@ module FlattenMsg {
         var retString = getSegString(off, val, st);
         repMsg = "created " + st.attrib(retString.name) + "+created bytes.size %?".doFormat(retString.nBytes);
         if returnSegs {
-          st.addEntry(optName, new shared SymEntry(segs));
+          st.addEntry(optName, createSymEntry(segs));
           repMsg += "+created %s".doFormat(st.attrib(optName));
         }
       }

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -859,7 +859,7 @@ module HDF5Msg {
                 const ushift = 64:uint;
                 while !all_zero {
                     low = tmp:uint;
-                    limbs.pushBack(new shared SymEntry(low));
+                    limbs.pushBack(createSymEntry(low));
 
                     all_zero = true;
                     forall t in tmp with (&& reduce all_zero) {
@@ -2960,7 +2960,7 @@ module HDF5Msg {
         C_HDF5.H5Fclose(file_id);
         
         var sname = st.nextName();
-        st.addEntry(sname, new shared SymEntry(shape));
+        st.addEntry(sname, createSymEntry(shape));
         var rname = readPdarrayFromFile(filenames, dset, dataclass, bytesize, isSigned, validFiles, st);
         return (dset, ObjType.ARRAYVIEW, "%s+%s".doFormat(rname, sname));
     }
@@ -3035,7 +3035,7 @@ module HDF5Msg {
         }
 
         var rname = st.nextName();
-        st.addEntry(rname, new shared SymEntry(bigIntArray, max_bits));
+        st.addEntry(rname, createSymEntry(bigIntArray, max_bits));
         return rname;
     }
 
@@ -3150,7 +3150,7 @@ module HDF5Msg {
 
         proc _buildEntryCalcOffsets(): shared SymEntry throws {
             var offsetsArray = segmentedCalcOffsets(entryVal.a, entryVal.a.domain);
-            return new shared SymEntry(offsetsArray);
+            return createSymEntry(offsetsArray);
         }
 
         proc _buildEntryLoadOffsets() throws {
@@ -3204,7 +3204,7 @@ module HDF5Msg {
         read_files_into_distributed_array(segDist, segSubdoms, filenames, dset + "/" + SEGMENTED_OFFSET_NAME, skips);
         fixupSegBoundaries(segDist, segSubdoms, valSubdoms);
         var sname = st.nextName();
-        st.addEntry(sname, new shared SymEntry(segDist));
+        st.addEntry(sname, createSymEntry(segDist));
         rtnMap.add("segments", "created " + st.attrib(sname));
         
         return rtnMap;
@@ -3227,7 +3227,7 @@ module HDF5Msg {
         read_files_into_distributed_array(codes, subdoms, filenames, "%s/%s".doFormat(dset, CODES_NAME), skips);
         // create symEntry
         var codesName = st.nextName();
-        var codesEntry = new shared SymEntry(codes);
+        var codesEntry = createSymEntry(codes);
         st.addEntry(codesName, codesEntry);
 
         // read the categories
@@ -3244,7 +3244,7 @@ module HDF5Msg {
         read_files_into_distributed_array(naCodes, nacodes_subdoms, filenames, "%s/%s".doFormat(dset, NACODES_NAME), nacodes_skips);
         // create symEntry
         var naCodesName = st.nextName();
-        var naCodesEntry = new shared SymEntry(naCodes);
+        var naCodesEntry = createSymEntry(naCodes);
         st.addEntry(naCodesName, naCodesEntry);
 
         rtnMap.add("codes", "created " + st.attrib(codesEntry.name));
@@ -3267,7 +3267,7 @@ module HDF5Msg {
             var segments = makeDistArray(segs_len, int);
             read_files_into_distributed_array(segments, segs_subdoms, filenames, "%s/%s".doFormat(dset, SEGMENTS_NAME), segs_skips);
             var segName = st.nextName();
-            var segEntry = new shared SymEntry(segments);
+            var segEntry = createSymEntry(segments);
             st.addEntry(segName, segEntry);
 
             // get domain and size info for permutation
@@ -3279,7 +3279,7 @@ module HDF5Msg {
             var perm = makeDistArray(perm_len, int);
             read_files_into_distributed_array(perm, perm_subdoms, filenames, "%s/%s".doFormat(dset, PERMUTATION_NAME), perm_skips);
             var permName = st.nextName();
-            var permEntry = new shared SymEntry(perm);
+            var permEntry = createSymEntry(perm);
             st.addEntry(permName, permEntry);
 
             rtnMap.add("segments", "created " + st.attrib(segEntry.name));
@@ -3299,7 +3299,7 @@ module HDF5Msg {
         read_files_into_distributed_array(perm, perm_subdoms, filenames, "%s/%s".doFormat(dset, PERMUTATION_NAME), perm_skips);
         // create symEntry
         var permName = st.nextName();
-        var permEntry = new shared SymEntry(perm);
+        var permEntry = createSymEntry(perm);
         st.addEntry(permName, permEntry);
 
         var seg_subdoms: [fD] domain(1);
@@ -3310,7 +3310,7 @@ module HDF5Msg {
         read_files_into_distributed_array(segs, seg_subdoms, filenames, "%s/%s".doFormat(dset, SEGMENTS_NAME), seg_skips);
         // create symEntry
         var segName = st.nextName();
-        var segEntry = new shared SymEntry(segs);
+        var segEntry = createSymEntry(segs);
         st.addEntry(segName, segEntry);
 
         var uki_subdoms: [fD] domain(1);
@@ -3321,7 +3321,7 @@ module HDF5Msg {
         read_files_into_distributed_array(uki, uki_subdoms, filenames, "%s/%s".doFormat(dset, UKI_NAME), uki_skips);
         // create symEntry
         var ukiName = st.nextName();
-        var ukiEntry = new shared SymEntry(uki);
+        var ukiEntry = createSymEntry(uki);
         st.addEntry(ukiName, ukiEntry);
 
         rtnMap.add("permutation", "created " + st.attrib(permEntry.name));

--- a/src/HashMsg.chpl
+++ b/src/HashMsg.chpl
@@ -54,9 +54,9 @@ module HashMsg {
     st.checkTable(codesName);
     var (upper, lower) = categoricalHash(categoriesName, codesName, st);
     var upperName = st.nextName();
-    st.addEntry(upperName, new shared SymEntry(upper));
+    st.addEntry(upperName, createSymEntry(upper));
     var lowerName = st.nextName();
-    st.addEntry(lowerName, new shared SymEntry(lower));
+    st.addEntry(lowerName, createSymEntry(lower));
     var createdMap = new map(keyType=string,valType=string);
     createdMap.add("upperHash", "created %s".doFormat(st.attrib(upperName)));
     createdMap.add("lowerHash", "created %s".doFormat(st.attrib(lowerName)));
@@ -83,9 +83,9 @@ module HashMsg {
     }
 
     var upperName = st.nextName();
-    st.addEntry(upperName, new shared SymEntry(upper));
+    st.addEntry(upperName, createSymEntry(upper));
     var lowerName = st.nextName();
-    st.addEntry(lowerName, new shared SymEntry(lower));
+    st.addEntry(lowerName, createSymEntry(lower));
 
     var createdMap = new map(keyType=string,valType=string);
     createdMap.add("upperHash", "created %s".doFormat(st.attrib(upperName)));

--- a/src/HistogramMsg.chpl
+++ b/src/HistogramMsg.chpl
@@ -48,19 +48,19 @@ module HistogramMsg
               hgmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                                            "%? <= %?".doFormat(bins,sBound));
               var hist = histogramReduceIntent(e.a, aMin, aMax, bins, binWidth);
-              st.addEntry(rname, new shared SymEntry(hist));
+              st.addEntry(rname, createSymEntry(hist));
           }
           else if (bins <= mBound) {
               hgmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                                            "%? <= %?".doFormat(bins,mBound));
               var hist = histogramLocalAtomic(e.a, aMin, aMax, bins, binWidth);
-              st.addEntry(rname, new shared SymEntry(hist));
+              st.addEntry(rname, createSymEntry(hist));
           }
           else {
               hgmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                                             "%? > %?".doFormat(bins,mBound));
               var hist = histogramGlobalAtomic(e.a, aMin, aMax, bins, binWidth);
-              st.addEntry(rname, new shared SymEntry(hist));
+              st.addEntry(rname, createSymEntry(hist));
           }
         }
 

--- a/src/In1dMsg.chpl
+++ b/src/In1dMsg.chpl
@@ -49,14 +49,14 @@ module In1dMsg
                 var ar2 = toSymEntry(gAr2,int);
 
                 var truth = in1d(ar1.a, ar2.a, invert);
-                st.addEntry(rname, new shared SymEntry(truth));
+                st.addEntry(rname, createSymEntry(truth));
             }
             when (DType.UInt64, DType.UInt64) {
                 var ar1 = toSymEntry(gAr1,uint);
                 var ar2 = toSymEntry(gAr2,uint);
 
                 var truth = in1d(ar1.a, ar2.a, invert);
-                st.addEntry(rname, new shared SymEntry(truth));
+                st.addEntry(rname, createSymEntry(truth));
             }
             otherwise {
                 var errorMsg = notImplementedError(pn,gAr1.dtype,"in",gAr2.dtype);

--- a/src/JoinEqWithDTMsg.chpl
+++ b/src/JoinEqWithDTMsg.chpl
@@ -368,8 +368,8 @@ module JoinEqWithDTMsg
                                         t1.a, t2.a, dt, pred, resLimitPerLocale);
         
         // puth results in the symbol table
-        st.addEntry(resI_name, new shared SymEntry(resI));
-        st.addEntry(resJ_name, new shared SymEntry(resJ));
+        st.addEntry(resI_name, createSymEntry(resI));
+        st.addEntry(resJ_name, createSymEntry(resJ));
         
         repMsg = "created " + st.attrib(resI_name) + " +created " + st.attrib(resJ_name);
         jeLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);

--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -300,10 +300,10 @@ module MultiTypeSymEntry
       return new shared SymEntry(a);
     }
 
-    inline proc createSymEntry(a: [?D] ?etype) throws {
+    inline proc createSymEntry(a: [?D] ?etype, max_bits=-1) throws {
       var A = makeDistArray(D.size, etype);
       A = a;
-      return new shared SymEntry(A);
+      return new shared SymEntry(A, max_bits=max_bits);
     }
 
     /*

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -62,7 +62,7 @@ module MultiTypeSymbolTable
         proc addEntry(name: string, len: int, type t): borrowed SymEntry(t) throws {
             var A = makeDistArray(len, t);
 
-            var entry = new shared SymEntry(A);
+            var entry = createSymEntry(A);
             if (tab.contains(name)) {
                 mtLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                                         "redefined symbol: %s ".doFormat(name));

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -252,13 +252,13 @@ module OperatorMsg
             var r = toSymEntry(right,bigint);
             if boolOps.contains(op) {
               // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
+              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
               var repMsg = "created %s".doFormat(st.attrib(rname));
               return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             // call bigint specific func which returns dist bigint array
             var (tmp, max_bits) = doBigIntBinOpvv(l, r, op);
-            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
             var repMsg = "created %s".doFormat(st.attrib(rname));
             return new MsgTuple(repMsg, MsgType.NORMAL);
           }
@@ -267,13 +267,13 @@ module OperatorMsg
             var r = toSymEntry(right,int);
             if boolOps.contains(op) {
               // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
+              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
               var repMsg = "created %s".doFormat(st.attrib(rname));
               return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             // call bigint specific func which returns dist bigint array
             var (tmp, max_bits) = doBigIntBinOpvv(l, r, op);
-            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
             var repMsg = "created %s".doFormat(st.attrib(rname));
             return new MsgTuple(repMsg, MsgType.NORMAL);
           }
@@ -282,13 +282,13 @@ module OperatorMsg
             var r = toSymEntry(right,uint);
             if boolOps.contains(op) {
               // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
+              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
               var repMsg = "created %s".doFormat(st.attrib(rname));
               return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             // call bigint specific func which returns dist bigint array
             var (tmp, max_bits) = doBigIntBinOpvv(l, r, op);
-            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
             var repMsg = "created %s".doFormat(st.attrib(rname));
             return new MsgTuple(repMsg, MsgType.NORMAL);
           }
@@ -297,13 +297,13 @@ module OperatorMsg
             var r = toSymEntry(right,bool);
             if boolOps.contains(op) {
               // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
+              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
               var repMsg = "created %s".doFormat(st.attrib(rname));
               return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             // call bigint specific func which returns dist bigint array
             var (tmp, max_bits) = doBigIntBinOpvv(l, r, op);
-            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
             var repMsg = "created %s".doFormat(st.attrib(rname));
             return new MsgTuple(repMsg, MsgType.NORMAL);
           }
@@ -312,13 +312,13 @@ module OperatorMsg
             var r = toSymEntry(right,bigint);
             if boolOps.contains(op) {
               // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
+              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
               var repMsg = "created %s".doFormat(st.attrib(rname));
               return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             // call bigint specific func which returns dist bigint array
             var (tmp, max_bits) = doBigIntBinOpvv(l, r, op);
-            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
             var repMsg = "created %s".doFormat(st.attrib(rname));
             return new MsgTuple(repMsg, MsgType.NORMAL);
           }
@@ -327,13 +327,13 @@ module OperatorMsg
             var r = toSymEntry(right,bigint);
             if boolOps.contains(op) {
               // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
+              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
               var repMsg = "created %s".doFormat(st.attrib(rname));
               return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             // call bigint specific func which returns dist bigint array
             var (tmp, max_bits) = doBigIntBinOpvv(l, r, op);
-            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
             var repMsg = "created %s".doFormat(st.attrib(rname));
             return new MsgTuple(repMsg, MsgType.NORMAL);
           }
@@ -342,13 +342,13 @@ module OperatorMsg
             var r = toSymEntry(right,bigint);
             if boolOps.contains(op) {
               // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
+              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
               var repMsg = "created %s".doFormat(st.attrib(rname));
               return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             // call bigint specific func which returns dist bigint array
             var (tmp, max_bits) = doBigIntBinOpvv(l, r, op);
-            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
             var repMsg = "created %s".doFormat(st.attrib(rname));
             return new MsgTuple(repMsg, MsgType.NORMAL);
           }
@@ -587,13 +587,13 @@ module OperatorMsg
             var val = value.getBigIntValue();
             if boolOps.contains(op) {
               // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
+              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
               var repMsg = "created %s".doFormat(st.attrib(rname));
               return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             // call bigint specific func which returns dist bigint array
             var (tmp, max_bits) = doBigIntBinOpvs(l, val, op);
-            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
             var repMsg = "created %s".doFormat(st.attrib(rname));
             return new MsgTuple(repMsg, MsgType.NORMAL);
           }
@@ -602,13 +602,13 @@ module OperatorMsg
             var val = value.getIntValue();
             if boolOps.contains(op) {
               // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
+              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
               var repMsg = "created %s".doFormat(st.attrib(rname));
               return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             // call bigint specific func which returns dist bigint array
             var (tmp, max_bits) = doBigIntBinOpvs(l, val, op);
-            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
             var repMsg = "created %s".doFormat(st.attrib(rname));
             return new MsgTuple(repMsg, MsgType.NORMAL);
           }
@@ -617,13 +617,13 @@ module OperatorMsg
             var val = value.getUIntValue();
             if boolOps.contains(op) {
               // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
+              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
               var repMsg = "created %s".doFormat(st.attrib(rname));
               return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             // call bigint specific func which returns dist bigint array
             var (tmp, max_bits) = doBigIntBinOpvs(l, val, op);
-            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
             var repMsg = "created %s".doFormat(st.attrib(rname));
             return new MsgTuple(repMsg, MsgType.NORMAL);
           }
@@ -632,13 +632,13 @@ module OperatorMsg
             var val = value.getBoolValue();
             if boolOps.contains(op) {
               // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
+              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
               var repMsg = "created %s".doFormat(st.attrib(rname));
               return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             // call bigint specific func which returns dist bigint array
             var (tmp, max_bits) = doBigIntBinOpvs(l, val, op);
-            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
             var repMsg = "created %s".doFormat(st.attrib(rname));
             return new MsgTuple(repMsg, MsgType.NORMAL);
           }
@@ -647,13 +647,13 @@ module OperatorMsg
             var val = value.getBigIntValue();
             if boolOps.contains(op) {
               // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
+              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
               var repMsg = "created %s".doFormat(st.attrib(rname));
               return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             // call bigint specific func which returns dist bigint array
             var (tmp, max_bits) = doBigIntBinOpvs(l, val, op);
-            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
             var repMsg = "created %s".doFormat(st.attrib(rname));
             return new MsgTuple(repMsg, MsgType.NORMAL);
           }
@@ -662,13 +662,13 @@ module OperatorMsg
             var val = value.getBigIntValue();
             if boolOps.contains(op) {
               // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
+              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
               var repMsg = "created %s".doFormat(st.attrib(rname));
               return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             // call bigint specific func which returns dist bigint array
             var (tmp, max_bits) = doBigIntBinOpvs(l, val, op);
-            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
             var repMsg = "created %s".doFormat(st.attrib(rname));
             return new MsgTuple(repMsg, MsgType.NORMAL);
           }
@@ -677,13 +677,13 @@ module OperatorMsg
             var val = value.getBigIntValue();
             if boolOps.contains(op) {
               // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
+              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
               var repMsg = "created %s".doFormat(st.attrib(rname));
               return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             // call bigint specific func which returns dist bigint array
             var (tmp, max_bits) = doBigIntBinOpvs(l, val, op);
-            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
             var repMsg = "created %s".doFormat(st.attrib(rname));
             return new MsgTuple(repMsg, MsgType.NORMAL);
           }
@@ -922,13 +922,13 @@ module OperatorMsg
             var r = toSymEntry(right,bigint);
             if boolOps.contains(op) {
               // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
+              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
               var repMsg = "created %s".doFormat(st.attrib(rname));
               return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             // call bigint specific func which returns dist bigint array
             var (tmp, max_bits) = doBigIntBinOpsv(val, r, op);
-            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
             var repMsg = "created %s".doFormat(st.attrib(rname));
             return new MsgTuple(repMsg, MsgType.NORMAL);
           }
@@ -937,13 +937,13 @@ module OperatorMsg
             var r = toSymEntry(right,int);
             if boolOps.contains(op) {
               // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
+              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
               var repMsg = "created %s".doFormat(st.attrib(rname));
               return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             // call bigint specific func which returns dist bigint array
             var (tmp, max_bits) = doBigIntBinOpsv(val, r, op);
-            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
             var repMsg = "created %s".doFormat(st.attrib(rname));
             return new MsgTuple(repMsg, MsgType.NORMAL);
           }
@@ -952,13 +952,13 @@ module OperatorMsg
             var r = toSymEntry(right,uint);
             if boolOps.contains(op) {
               // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
+              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
               var repMsg = "created %s".doFormat(st.attrib(rname));
               return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             // call bigint specific func which returns dist bigint array
             var (tmp, max_bits) = doBigIntBinOpsv(val, r, op);
-            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
             var repMsg = "created %s".doFormat(st.attrib(rname));
             return new MsgTuple(repMsg, MsgType.NORMAL);
           }
@@ -967,13 +967,13 @@ module OperatorMsg
             var r = toSymEntry(right,bool);
             if boolOps.contains(op) {
               // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
+              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
               var repMsg = "created %s".doFormat(st.attrib(rname));
               return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             // call bigint specific func which returns dist bigint array
             var (tmp, max_bits) = doBigIntBinOpsv(val, r, op);
-            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
             var repMsg = "created %s".doFormat(st.attrib(rname));
             return new MsgTuple(repMsg, MsgType.NORMAL);
           }
@@ -982,13 +982,13 @@ module OperatorMsg
             var r = toSymEntry(right,bigint);
             if boolOps.contains(op) {
               // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
+              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
               var repMsg = "created %s".doFormat(st.attrib(rname));
               return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             // call bigint specific func which returns dist bigint array
             var (tmp, max_bits) = doBigIntBinOpsv(val, r, op);
-            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
             var repMsg = "created %s".doFormat(st.attrib(rname));
             return new MsgTuple(repMsg, MsgType.NORMAL);
           }
@@ -997,13 +997,13 @@ module OperatorMsg
             var r = toSymEntry(right,bigint);
             if boolOps.contains(op) {
               // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
+              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
               var repMsg = "created %s".doFormat(st.attrib(rname));
               return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             // call bigint specific func which returns dist bigint array
             var (tmp, max_bits) = doBigIntBinOpsv(val, r, op);
-            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
             var repMsg = "created %s".doFormat(st.attrib(rname));
             return new MsgTuple(repMsg, MsgType.NORMAL);
           }
@@ -1012,13 +1012,13 @@ module OperatorMsg
             var r = toSymEntry(right,bigint);
             if boolOps.contains(op) {
               // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, new shared SymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
+              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
               var repMsg = "created %s".doFormat(st.attrib(rname));
               return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             // call bigint specific func which returns dist bigint array
             var (tmp, max_bits) = doBigIntBinOpsv(val, r, op);
-            var e = st.addEntry(rname, new shared SymEntry(tmp, max_bits));
+            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
             var repMsg = "created %s".doFormat(st.attrib(rname));
             return new MsgTuple(repMsg, MsgType.NORMAL);
           }

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -630,32 +630,32 @@ module ParquetMsg {
     var listSizes: [filedom] int = calcListSizesandOffset(seg_sizes, filenames, sizes, dsetname);
     var segments = (+ scan seg_sizes) - seg_sizes; // converts segment sizes into offsets
     var sname = st.nextName();
-    st.addEntry(sname, new shared SymEntry(segments));
+    st.addEntry(sname, createSymEntry(segments));
     rtnmap.add("segments", "created " + st.attrib(sname));
 
     var vname = st.nextName();
     if ty == ArrowTypes.int64 || ty == ArrowTypes.int32 {
       var values = makeDistArray((+ reduce listSizes), int);
       readListFilesByName(values, sizes, seg_sizes, segments, filenames, listSizes, dsetname, ty);
-      st.addEntry(vname, new shared SymEntry(values));
+      st.addEntry(vname, createSymEntry(values));
       rtnmap.add("values", "created " + st.attrib(vname));
     }
     else if ty == ArrowTypes.uint64 || ty == ArrowTypes.uint32 {
       var values = makeDistArray((+ reduce listSizes), uint);
       readListFilesByName(values, sizes, seg_sizes, segments, filenames, listSizes, dsetname, ty);
-      st.addEntry(vname, new shared SymEntry(values));
+      st.addEntry(vname, createSymEntry(values));
       rtnmap.add("values", "created " + st.attrib(vname));
     }
     else if ty == ArrowTypes.double || ty == ArrowTypes.float {
       var values = makeDistArray((+ reduce listSizes), real);
       readListFilesByName(values, sizes, seg_sizes, segments, filenames, listSizes, dsetname, ty);
-      st.addEntry(vname, new shared SymEntry(values));
+      st.addEntry(vname, createSymEntry(values));
       rtnmap.add("values", "created " + st.attrib(vname));
     }
     else if ty == ArrowTypes.boolean {
       var values = makeDistArray((+ reduce listSizes), bool);
       readListFilesByName(values, sizes, seg_sizes, segments, filenames, listSizes, dsetname, ty);
-      st.addEntry(vname, new shared SymEntry(values));
+      st.addEntry(vname, createSymEntry(values));
       rtnmap.add("values", "created " + st.attrib(vname));
     }
     else if ty == ArrowTypes.stringArr {

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -290,7 +290,7 @@ module ReductionMsg
           return new MsgTuple(errorMsg, MsgType.ERROR); 
       }
       var counts = segCount(segments.a, size);
-      st.addEntry(rname, new shared SymEntry(counts));
+      st.addEntry(rname, createSymEntry(counts));
 
       var repMsg = "created " + st.attrib(rname);
       rmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);       
@@ -366,59 +366,59 @@ module ReductionMsg
                 select op {
                     when "sum" {
                         var res = segSum(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "prod" {
                         var res = segProduct(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "var" {
                         var res = segVar(values.a, segments.a, ddof);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "std" {
                         var res = segStd(values.a, segments.a, ddof);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "mean" {
                         var res = segMean(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "median" {
                         var res = segMedian(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "min" {
                         var res = segMin(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "max" {
                         var res = segMax(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "argmin" {
                         var (vals, locs) = segArgmin(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(locs));
+                        st.addEntry(rname, createSymEntry(locs));
                     }
                     when "argmax" {
                         var (vals, locs) = segArgmax(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(locs));
+                        st.addEntry(rname, createSymEntry(locs));
                     }
                     when "or" {
                         var res = segOr(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "and" {
                         var res = segAnd(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "xor" {
                         var res = segXor(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "nunique" {
                         var res = segNumUnique(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     otherwise {
                         var errorMsg = notImplementedError(pn,op,gVal.dtype);
@@ -432,59 +432,59 @@ module ReductionMsg
                 select op {
                     when "sum" {
                         var res = segSum(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "prod" {
                         var res = segProduct(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "var" {
                         var res = segVar(values.a, segments.a, ddof);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "std" {
                         var res = segStd(values.a, segments.a, ddof);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "mean" {
                         var res = segMean(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "median" {
                         var res = segMedian(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "min" {
                         var res = segMin(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "max" {
                         var res = segMax(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "argmin" {
                         var (vals, locs) = segArgmin(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(locs));
+                        st.addEntry(rname, createSymEntry(locs));
                     }
                     when "argmax" {
                         var (vals, locs) = segArgmax(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(locs));
+                        st.addEntry(rname, createSymEntry(locs));
                     }
                     when "or" {
                         var res = segOr(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "and" {
                         var res = segAnd(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "xor" {
                         var res = segXor(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "nunique" {
                         var res = segNumUnique(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     otherwise {
                         var errorMsg = notImplementedError(pn,op,gVal.dtype);
@@ -498,43 +498,43 @@ module ReductionMsg
                 select op {
                     when "sum" {
                         var res = segSum(values.a, segments.a, skipNan);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "prod" {
                         var res = segProduct(values.a, segments.a, skipNan);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     } 
                     when "var" {
                         var res = segVar(values.a, segments.a, ddof, skipNan);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "std" {
                         var res = segStd(values.a, segments.a, ddof, skipNan);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "mean" {
                         var res = segMean(values.a, segments.a, skipNan);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "median" {
                         var res = segMedian(values.a, segments.a, skipNan);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "min" {
                         var res = segMin(values.a, segments.a, skipNan);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "max" {
                         var res = segMax(values.a, segments.a, skipNan);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "argmin" {
                         var (vals, locs) = segArgmin(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(locs));
+                        st.addEntry(rname, createSymEntry(locs));
                     }
                     when "argmax" {
                         var (vals, locs) = segArgmax(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(locs));
+                        st.addEntry(rname, createSymEntry(locs));
                     }
                     otherwise {
                         var errorMsg = notImplementedError(pn,op,gVal.dtype);
@@ -548,39 +548,39 @@ module ReductionMsg
                 select op {
                     when "sum" {
                         var res = segSum(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "any" {
                         var res = segAny(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "all" {
                         var res = segAll(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "var" {
                         var res = segVar(values.a, segments.a, ddof);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "std" {
                         var res = segStd(values.a, segments.a, ddof);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "mean" {
                         var res = segMean(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "median" {
                         var res = segMedian(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "argmin" {
                         var (vals, locs) = segArgmin(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(locs));
+                        st.addEntry(rname, createSymEntry(locs));
                     }
                     when "argmax" {
                         var (vals, locs) = segArgmax(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(locs));
+                        st.addEntry(rname, createSymEntry(locs));
                     }
                     otherwise {
                         var errorMsg = notImplementedError(pn,op,gVal.dtype);
@@ -599,32 +599,32 @@ module ReductionMsg
                 select op {
                     when "sum" {
                         var res = segSum(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "min" {
                         if !has_max_bits {
                           throw new Error("Must set max_bits to MIN");
                         }
                         var res = segMin(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "max" {
                         if !has_max_bits {
                           throw new Error("Must set max_bits to MAX");
                         }
                         var res = segMax(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "or" {
                         var res = segOr(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     when "and" {
                         if !has_max_bits {
                           throw new Error("Must set max_bits to AND");
                         }
                         var res = segAnd(values.a, segments.a);
-                        st.addEntry(rname, new shared SymEntry(res));
+                        st.addEntry(rname, createSymEntry(res));
                     }
                     otherwise {
                         var errorMsg = notImplementedError(pn,op,gVal.dtype);

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -95,7 +95,7 @@ module SegmentedArray {
     // temporarily add to symtab for hashArrays and then delete entry
     var segInds = [(b, i) in zip (broadcastedSegs, valInd)] i - b;
     var siName = st.nextName();
-    st.addEntry(siName, new shared SymEntry(segInds));
+    st.addEntry(siName, createSymEntry(segInds));
     // we can't just call hashArrays because the compiler complains about recursion
     var hashes = hashHelper(size, [valName, siName], [valObjType, ObjType.PDARRAY:string], st);
     st.deleteEntry(siName);
@@ -109,9 +109,9 @@ module SegmentedArray {
     // we have to hash twice before the XOR to avoid collisions with
     // things like ak.Segarray(ak.array([0,2],ak.array([1,1,2,2]))
     var upperName = st.nextName();
-    st.addEntry(upperName, new shared SymEntry(upper));
+    st.addEntry(upperName, createSymEntry(upper));
     var lowerName = st.nextName();
-    st.addEntry(lowerName, new shared SymEntry(lower));
+    st.addEntry(lowerName, createSymEntry(lower));
     var rehash = hashHelper(size, [upperName, lowerName], [ObjType.PDARRAY:string, ObjType.PDARRAY:string], st);
     st.deleteEntry(upperName);
     st.deleteEntry(lowerName);

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -377,16 +377,16 @@ module SegmentedMsg {
       var strings = getSegString(name, st);
 
       var (numMatches, matchStarts, matchLens, matchesIndices, searchBools, searchScan, matchBools, matchScan, fullMatchBools, fullMatchScan) = strings.findMatchLocations(pattern, groupNum);
-      st.addEntry(rNumMatchesName, new shared SymEntry(numMatches));
-      st.addEntry(rStartsName, new shared SymEntry(matchStarts));
-      st.addEntry(rLensName, new shared SymEntry(matchLens));
-      st.addEntry(rIndicesName, new shared SymEntry(matchesIndices));
-      st.addEntry(rSearchBoolName, new shared SymEntry(searchBools));
-      st.addEntry(rSearchScanName, new shared SymEntry(searchScan));
-      st.addEntry(rMatchBoolName, new shared SymEntry(matchBools));
-      st.addEntry(rMatchScanName, new shared SymEntry(matchScan));
-      st.addEntry(rfullMatchBoolName, new shared SymEntry(fullMatchBools));
-      st.addEntry(rfullMatchScanName, new shared SymEntry(fullMatchScan));
+      st.addEntry(rNumMatchesName, createSymEntry(numMatches));
+      st.addEntry(rStartsName, createSymEntry(matchStarts));
+      st.addEntry(rLensName, createSymEntry(matchLens));
+      st.addEntry(rIndicesName, createSymEntry(matchesIndices));
+      st.addEntry(rSearchBoolName, createSymEntry(searchBools));
+      st.addEntry(rSearchScanName, createSymEntry(searchScan));
+      st.addEntry(rMatchBoolName, createSymEntry(matchBools));
+      st.addEntry(rMatchScanName, createSymEntry(matchScan));
+      st.addEntry(rfullMatchBoolName, createSymEntry(fullMatchBools));
+      st.addEntry(rfullMatchScanName, createSymEntry(fullMatchScan));
 
       var createdMap = new map(keyType=string,valType=string);
       createdMap.add("NumMatches", "created %s".doFormat(st.attrib(rNumMatchesName)));
@@ -445,7 +445,7 @@ module SegmentedMsg {
         repMsg = "created " + st.attrib(retString.name) + "+created bytes.size %?".doFormat(retString.nBytes);
         if returnMatchOrig {
           const optName: string = if returnMatchOrig then st.nextName() else "";
-          st.addEntry(optName, new shared SymEntry(matchOrigins));
+          st.addEntry(optName, createSymEntry(matchOrigins));
           repMsg += "+created %s".doFormat(st.attrib(optName));
         }
       }
@@ -462,7 +462,7 @@ module SegmentedMsg {
         var retString = getSegString(off, val, st);
         repMsg = "created " + st.attrib(retString.name) + "+created bytes.size %?".doFormat(retString.nBytes);
         if returnMatchOrig {
-          st.addEntry(optName, new shared SymEntry(matchOrigins));
+          st.addEntry(optName, createSymEntry(matchOrigins));
           repMsg += "+created %s".doFormat(st.attrib(optName));
         }
       }
@@ -501,7 +501,7 @@ module SegmentedMsg {
         var retString = getSegString(off, val, st);
         repMsg = "created " + st.attrib(retString.name) + "+created bytes.size %?".doFormat(retString.nBytes);
         if returnNumSubs {
-          st.addEntry(optName, new shared SymEntry(numSubs));
+          st.addEntry(optName, createSymEntry(numSubs));
           repMsg += "+created %s".doFormat(st.attrib(optName));
         }
       }
@@ -672,9 +672,9 @@ module SegmentedMsg {
             st.checkTable(valName);
             var (upper, lower) = segarrayHash(segName, valName, valObjType, st);
             var upperName = st.nextName();
-            st.addEntry(upperName, new shared SymEntry(upper));
+            st.addEntry(upperName, createSymEntry(upper));
             var lowerName = st.nextName();
-            st.addEntry(lowerName, new shared SymEntry(lower));
+            st.addEntry(lowerName, createSymEntry(lower));
             repMsg = "created %s+created %s".doFormat(st.attrib(upperName), st.attrib(lowerName));
         }
         otherwise {
@@ -1105,7 +1105,7 @@ module SegmentedMsg {
         repMsg = "created " + st.attrib(retString.name) + "+created bytes.size %?".doFormat(retString.nBytes);
         if returnOrigins {
           var leName = st.nextName();
-          st.addEntry(leName, new shared SymEntry(longEnough));
+          st.addEntry(leName, createSymEntry(longEnough));
           repMsg += "+created " + st.attrib(leName);
         } 
         return new MsgTuple(repMsg, MsgType.NORMAL);

--- a/src/SegmentedString.chpl
+++ b/src/SegmentedString.chpl
@@ -57,8 +57,8 @@ module SegmentedString {
    * offset and value SymTab lookup names to the alternate init method
    */
   proc getSegString(segments: [] int, values: [] uint(8), st: borrowed SymTab): owned SegString throws {
-      var offsetsEntry = new shared SymEntry(segments);
-      var valuesEntry = new shared SymEntry(values);
+      var offsetsEntry = createSymEntry(segments);
+      var valuesEntry = createSymEntry(values);
       var stringsEntry = new shared SegStringSymEntry(offsetsEntry, valuesEntry, string);
       var name = st.nextName();
       st.addEntry(name, stringsEntry);
@@ -490,7 +490,7 @@ module SegmentedString {
         // we only need one uint array
         var numeric = computeOnSegments(offsets.a, values.a, SegFunction.StringBytesToUintArr, uint);
         const concatName = st.nextName();
-        st.addEntry(concatName, new shared SymEntry(numeric));
+        st.addEntry(concatName, createSymEntry(numeric));
         return concatName;
       }
       else {
@@ -507,8 +507,8 @@ module SegmentedString {
         }
         const concat1Name = st.nextName();
         const concat2Name = st.nextName();
-        st.addEntry(concat1Name, new shared SymEntry(numeric1));
-        st.addEntry(concat2Name, new shared SymEntry(numeric2));
+        st.addEntry(concat1Name, createSymEntry(numeric1));
+        st.addEntry(concat2Name, createSymEntry(numeric2));
         return "%s+%s".doFormat(concat1Name, concat2Name);
       }
     }

--- a/src/SequenceMsg.chpl
+++ b/src/SequenceMsg.chpl
@@ -40,7 +40,7 @@ module SequenceMsg {
             forall (ei, i) in zip(ea, ead) {
                 ei = start + (i * stride);
             }
-            var e = st.addEntry(rname, new shared SymEntry(ea));
+            var e = st.addEntry(rname, createSymEntry(ea));
             smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                         "compute time = %i sec".doFormat(Time.timeSinceEpoch().totalSeconds() - t1));
         }

--- a/src/SortMsg.chpl
+++ b/src/SortMsg.chpl
@@ -86,17 +86,17 @@ module SortMsg
           when (DType.Int64) {
               var e = toSymEntry(gEnt, int);
               var sorted = doSort(e.a);
-              st.addEntry(sortedName, new shared SymEntry(sorted));
+              st.addEntry(sortedName, createSymEntry(sorted));
           }// end when(DType.Int64)
           when (DType.UInt64) {
               var e = toSymEntry(gEnt, uint);
               var sorted = doSort(e.a);
-              st.addEntry(sortedName, new shared SymEntry(sorted));
+              st.addEntry(sortedName, createSymEntry(sorted));
           }// end when(DType.UInt64)
           when (DType.Float64) {
               var e = toSymEntry(gEnt, real);
               var sorted = doSort(e.a);
-              st.addEntry(sortedName, new shared SymEntry(sorted));
+              st.addEntry(sortedName, createSymEntry(sorted));
           }// end when(DType.Float64)
           otherwise {
               var errorMsg = notImplementedError(pn,gEnt.dtype);

--- a/src/StatsMsg.chpl
+++ b/src/StatsMsg.chpl
@@ -290,7 +290,7 @@ module StatsMsg {
                 corrPdarray[j] = corrHelper(d1gEnt, d2gEnt);
             }
             var retname = st.nextName();
-            st.addEntry(retname, new shared SymEntry(corrPdarray));
+            st.addEntry(retname, createSymEntry(corrPdarray));
             corrDict.add(col, "created %s".doFormat(st.attrib(retname)));
         }
         var repMsg: string = formatJson(corrDict);

--- a/src/TimeClassMsg.chpl
+++ b/src/TimeClassMsg.chpl
@@ -66,28 +66,28 @@ module TimeClassMsg {
         }
 
         var retname = st.nextName();
-        st.addEntry(retname, new shared SymEntry(day));
+        st.addEntry(retname, createSymEntry(day));
         attributesDict.addOrReplace("day", "created %s".doFormat(st.attrib(retname)));
         retname = st.nextName();
-        st.addEntry(retname, new shared SymEntry(month));
+        st.addEntry(retname, createSymEntry(month));
         attributesDict.add("month", "created %s".doFormat(st.attrib(retname)));
         retname = st.nextName();
-        st.addEntry(retname, new shared SymEntry(year));
+        st.addEntry(retname, createSymEntry(year));
         attributesDict.add("year", "created %s".doFormat(st.attrib(retname)));
         retname = st.nextName();
-        st.addEntry(retname, new shared SymEntry(is_leap_year));
+        st.addEntry(retname, createSymEntry(is_leap_year));
         attributesDict.add("isLeapYear", "created %s".doFormat(st.attrib(retname)));
         retname = st.nextName();
-        st.addEntry(retname, new shared SymEntry(dayOfYear));
+        st.addEntry(retname, createSymEntry(dayOfYear));
         attributesDict.add("dayOfYear", "created %s".doFormat(st.attrib(retname)));
         retname = st.nextName();
-        st.addEntry(retname, new shared SymEntry(isoYear));
+        st.addEntry(retname, createSymEntry(isoYear));
         attributesDict.add("isoYear", "created %s".doFormat(st.attrib(retname)));
         retname = st.nextName();
-        st.addEntry(retname, new shared SymEntry(weekOfYear));
+        st.addEntry(retname, createSymEntry(weekOfYear));
         attributesDict.add("weekOfYear", "created %s".doFormat(st.attrib(retname)));
         retname = st.nextName();
-        st.addEntry(retname, new shared SymEntry(dayOfWeek));
+        st.addEntry(retname, createSymEntry(dayOfWeek));
         attributesDict.add("dayOfWeek", "created %s".doFormat(st.attrib(retname)));
 
         var repMsg: string = formatJson(attributesDict);


### PR DESCRIPTION
This PR (closes #2734) fixes the remaining missed symbol table entry creation for distributed builds

This is related to #2732, which only covered occurrences that were in `KExtremeMsg`. I'm not sure if all these spots need updating but I was still seeing similar failures when making with gasnet enabled, but in other files. I would especially like @bmcdonald3 to review since this is based on his PR