### PR TITLE
Closes #2738: Skip symbol_table_test until registry issues resolved

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -39,7 +39,7 @@ testpaths =
     tests/stats_test.py
     tests/string_test.py
     tests/summarization_test.py
-    tests/symbol_table_test.py
+    #tests/symbol_table_test.py
     tests/where_test.py
 norecursedirs = .git dist build *egg* tests/deprecated/* PROTO_test
 python_functions = test*


### PR DESCRIPTION
Some issues with the new registry have been identified, so skipping the tests for now will allow nightly testing to run the full test suite prior to the issues being resolved.

Closes #2738 and related to #2737