### PR TITLE
Fixes #2737: Address sanitization errors on `unregister`

### DIFF
--- a/src/RegistrationMsg.chpl
+++ b/src/RegistrationMsg.chpl
@@ -320,42 +320,42 @@ module RegistrationMsg {
     proc unregisterMsg(cmd: string, msgArgs: borrowed MessageArgs,
                         st: borrowed SymTab): MsgTuple throws {
         var name = msgArgs.getValueOf("name");
-        var gre = st.registry.lookup(name): borrowed GenRegEntry;
+        var gre = st.registry.lookup(name): shared GenRegEntry;
         select gre.objType {
             when ObjType.PDARRAY, ObjType.STRINGS, ObjType.DATETIME, ObjType.TIMEDELTA, ObjType.IPV4 {
-                var are = gre: borrowed ArrayRegEntry;
+                var are = gre: shared ArrayRegEntry;
                 st.registry.unregister_array(are);
             }
             when ObjType.SEGARRAY {
-                var sre = gre: borrowed SegArrayRegEntry;
+                var sre = gre: shared SegArrayRegEntry;
                 st.registry.unregister_segarray(sre);
             }
             when ObjType.DATAFRAME {
-                var dfre = gre: borrowed DataFrameRegEntry;
+                var dfre = gre: shared DataFrameRegEntry;
                 st.registry.unregister_dataframe(dfre);
             }
             when ObjType.GROUPBY {
-                var gbre = gre: borrowed GroupByRegEntry;
+                var gbre = gre: shared GroupByRegEntry;
                 st.registry.unregister_groupby(gbre);
             }
             when ObjType.CATEGORICAL {
-                var cre = gre: borrowed CategoricalRegEntry;
+                var cre = gre: shared CategoricalRegEntry;
                 st.registry.unregister_categorical(cre);
             }
             when ObjType.INDEX {
-                var ire = gre: borrowed IndexRegEntry;
+                var ire = gre: shared IndexRegEntry;
                 st.registry.unregister_index(ire);
             }
             when ObjType.MULTIINDEX {
-                var ire = gre: borrowed IndexRegEntry;
+                var ire = gre: shared IndexRegEntry;
                 st.registry.unregister_index(ire);
             }
             when ObjType.SERIES {
-                var sre = gre: borrowed SeriesRegEntry;
+                var sre = gre: shared SeriesRegEntry;
                 st.registry.unregister_series(sre);
             }
             when ObjType.BITVECTOR {
-                var bre = gre: borrowed BitVectorRegEntry;
+                var bre = gre: shared BitVectorRegEntry;
                 st.registry.unregister_bitvector(bre);
             }
             otherwise {
@@ -374,59 +374,59 @@ module RegistrationMsg {
     proc attachMsg(cmd: string, msgArgs: borrowed MessageArgs,
                         st: borrowed SymTab): MsgTuple throws {
         var name = msgArgs.getValueOf("name");
-        var gre = st.registry.lookup(name): borrowed GenRegEntry;
+        var gre = st.registry.lookup(name): shared GenRegEntry;
         var rtnMap: map(string, string);
         select gre.objType {
             when ObjType.PDARRAY {
-                var are = gre: borrowed ArrayRegEntry;
+                var are = gre: shared ArrayRegEntry;
                 rtnMap = are.asMap(st);
             }
             when ObjType.STRINGS {
-                var are = gre: borrowed ArrayRegEntry;
+                var are = gre: shared ArrayRegEntry;
                 rtnMap = are.asMap(st);
             }
             when ObjType.DATETIME {
-                var are = gre: borrowed ArrayRegEntry;
+                var are = gre: shared ArrayRegEntry;
                 rtnMap = are.asMap(st);
             }
             when ObjType.TIMEDELTA {
-                var are = gre: borrowed ArrayRegEntry;
+                var are = gre: shared ArrayRegEntry;
                 rtnMap = are.asMap(st);
             }
             when ObjType.IPV4 {
-                var are = gre: borrowed ArrayRegEntry;
+                var are = gre: shared ArrayRegEntry;
                 rtnMap = are.asMap(st);
             }
             when ObjType.SEGARRAY {
-                var sre = gre: borrowed SegArrayRegEntry;
+                var sre = gre: shared SegArrayRegEntry;
                 rtnMap = sre.asMap(st);
             }
             when ObjType.DATAFRAME {
-                var dfre = gre: borrowed DataFrameRegEntry;
+                var dfre = gre: shared DataFrameRegEntry;
                 rtnMap = dfre.asMap(st);
             }
             when ObjType.GROUPBY {
-                var gbre = gre: borrowed GroupByRegEntry;
+                var gbre = gre: shared GroupByRegEntry;
                 rtnMap = gbre.asMap(st);
             }
             when ObjType.CATEGORICAL {
-                var cre = gre: borrowed CategoricalRegEntry;
+                var cre = gre: shared CategoricalRegEntry;
                 rtnMap = cre.asMap(st);
             }
             when ObjType.INDEX {
-                var ire = gre: borrowed IndexRegEntry;
+                var ire = gre: shared IndexRegEntry;
                 rtnMap = ire.asMap(st);
             }
             when ObjType.MULTIINDEX {
-                var ire = gre: borrowed IndexRegEntry;
+                var ire = gre: shared IndexRegEntry;
                 rtnMap = ire.asMap(st);
             }
             when ObjType.SERIES {
-                var sre = gre: borrowed SeriesRegEntry;
+                var sre = gre: shared SeriesRegEntry;
                 rtnMap = sre.asMap(st);
             }
             when ObjType.BITVECTOR {
-                var bre = gre: borrowed BitVectorRegEntry;
+                var bre = gre: shared BitVectorRegEntry;
                 rtnMap = bre.asMap(st);
             }
             otherwise {

--- a/src/Registry.chpl
+++ b/src/Registry.chpl
@@ -160,7 +160,7 @@ module Registry {
             bre.setName(name);
         }
 
-        proc unregister_array(are: borrowed ArrayRegEntry) throws {
+        proc unregister_array(are: shared ArrayRegEntry) throws {
             registered_entries.remove(are.array);
             tab.remove(are.name);
         }
@@ -173,12 +173,12 @@ module Registry {
             }
         }
 
-        proc unregister_segarray(sre: borrowed SegArrayRegEntry) throws {
+        proc unregister_segarray(sre: shared SegArrayRegEntry) throws {
             unregister_segarray_components(sre);
             tab.remove(sre.name);
         }
 
-        proc unregister_dataframe(dfre: borrowed DataFrameRegEntry) throws {
+        proc unregister_dataframe(dfre: shared DataFrameRegEntry) throws {
             registered_entries.remove(dfre.idx);
             for c in dfre.columns {
                 var gre = c: borrowed GenRegEntry;
@@ -213,7 +213,7 @@ module Registry {
             tab.remove(dfre.name);
         }
 
-        proc unregister_groupby(gbre: borrowed GroupByRegEntry) throws {
+        proc unregister_groupby(gbre: shared GroupByRegEntry) throws {
             registered_entries.remove(gbre.segments);
             registered_entries.remove(gbre.permutation);
             registered_entries.remove(gbre.uki);
@@ -241,7 +241,7 @@ module Registry {
             }
         }
 
-        proc unregister_categorical(cre: borrowed CategoricalRegEntry) throws {
+        proc unregister_categorical(cre: shared CategoricalRegEntry) throws {
             unregister_categorical_components(cre);
             tab.remove(cre.name);            
         }
@@ -260,12 +260,12 @@ module Registry {
             }
         }
 
-        proc unregister_index(ire: borrowed IndexRegEntry) throws {
+        proc unregister_index(ire: shared IndexRegEntry) throws {
             unregister_index_components(ire);
             tab.remove(ire.name);
         }
 
-        proc unregister_series(sre: borrowed SeriesRegEntry) throws {
+        proc unregister_series(sre: shared SeriesRegEntry) throws {
             unregister_index_components(sre.idx);
 
             if sre.values.objType == ObjType.PDARRAY || sre.values.objType == ObjType.STRINGS {
@@ -279,12 +279,12 @@ module Registry {
             tab.remove(sre.name);
         }
 
-        proc unregister_bitvector(bre: borrowed BitVectorRegEntry) throws {
+        proc unregister_bitvector(bre: shared BitVectorRegEntry) throws {
             registered_entries.remove(bre.array);
             tab.remove(bre.name);
         }
 
-        proc lookup(name: string): borrowed AbstractRegEntry throws {
+        proc lookup(name: string): shared AbstractRegEntry throws {
             checkTable(name, "lookup");
             return tab[name];
         }

--- a/tests/categorical_test.py
+++ b/tests/categorical_test.py
@@ -418,7 +418,6 @@ class CategoricalTest(ArkoudaTest):
             self.assertCountEqual(x["pda1"].to_list(), pda1.to_list())
             self.assertCountEqual(x["strings1"].to_list(), strings1.to_list())
 
-    @pytest.mark.skip(reason="Bug with new registration code")
     def testNA(self):
         s = ak.array(["A", "B", "C", "B", "C"])
         # NAval present in categories


### PR DESCRIPTION
This PR (fixes #2737) changes `registry.lookup` to return a `shared` object instead of `borrowed`. This makes it so later references to `gre` in `unregisterMsg` don't cause us to access freed memory