### PR TITLE
Closes #2721 - Add request id framework to support arkouda proxy server

### DIFF
--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -313,7 +313,7 @@ class Channel():
             self.token = tokens.get(url)
 
     def send_string_message(self, cmd: str, recv_binary: bool = False, args: str = None,
-                            size: int = -1) -> Union[str, memoryview]:
+                            size: int = -1, request_id: str = None) -> Union[str, memoryview]:
         """
         Generates a RequestMessage encapsulating command and requesting
         user information, sends it to the Arkouda server, and returns
@@ -325,11 +325,13 @@ class Channel():
             The name of the command to be executed by the Arkouda server
         recv_binary : bool, defaults to False
             Indicates if the return message will be a string or binary data
-        args : str
+        args : str, defaults to None
             A delimited string containing 1..n command arguments
         size : int
             Default -1
             Number of parameters contained in args. Only set if args is json.
+        request_id: str, defaults to None
+            Specifies an identifier for each request submitted to Arkouda
 
         Returns
         -------
@@ -352,7 +354,8 @@ class Channel():
         raise NotImplementedError('send_string_message must be implemented in derived class')
 
     def send_binary_message(self, cmd: str, payload: memoryview, recv_binary: bool = False,
-                            args: str = None, size: int = -1) -> Union[str, memoryview]:
+                            args: str = None, size: int = -1,
+                            request_id: str = None) -> Union[str, memoryview]:
         """
         Generates a RequestMessage encapsulating command and requesting user information,
         information prepends the binary payload, sends the binary request to the Arkouda
@@ -369,6 +372,8 @@ class Channel():
             Indicates if the return message will be a string or binary data
         args : str
             A delimited string containing 1..n command arguments
+        request_id: str, defaults to None
+            Specifies an identifier for each request submitted to Arkouda
 
         Returns
         -------
@@ -424,12 +429,13 @@ class ZmqChannel(Channel):
     __slots__ = ('socket')
 
     def send_string_message(self, cmd: str, recv_binary: bool = False, args: str = None,
-                            size: int = -1) -> Union[str, memoryview]:
+                            size: int = -1, request_id: str = None) -> Union[str, memoryview]:
 
         message = RequestMessage(
             user=username, token=self.token, cmd=cmd, format=MessageFormat.STRING, args=args, size=size
         )
-
+        # Note - Size is a placeholder here because Binary msg not yet support json args and
+        # request_id is a noop for now
         logger.debug(f"sending message {json.dumps(message.asdict())}")
 
         self.socket.send_string(json.dumps(message.asdict()))
@@ -458,8 +464,10 @@ class ZmqChannel(Channel):
                 raise ValueError(f"Return message is not valid JSON: {raw_message}")
 
     def send_binary_message(self, cmd: str, payload: memoryview, recv_binary: bool = False,
-                            args: str = None, size: int = -1) -> Union[str, memoryview]:
-        # Note - Size is a placeholder here because Binary msg not yet support json args
+                            args: str = None, size: int = -1,
+                            request_id: str = None) -> Union[str, memoryview]:
+        # Note - Size is a placeholder here because Binary msg not yet support json args and
+        # request_id is a noop for now
         message = RequestMessage(
             user=username, token=self.token, cmd=cmd, format=MessageFormat.BINARY, args=args, size=size
         )


### PR DESCRIPTION
Closes #2721 

This PR adds the request_id parameter to the base Channel class and noop's within the arkouda ZmqChannel class. The request_id is used in the arkouda-contrib [GrpcChannel](https://github.com/Bears-R-Us/arkouda-contrib/blob/7e9116dbf78ed7e0432b0ac56394779665f4ac29/arkouda_proxy_client/arkouda_proxy_client/client.py#L16) class hiearchy