### PR TITLE
Closes #2757: Add overload of makeDistArray that takes an array

### DIFF
--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -300,9 +300,8 @@ module MultiTypeSymEntry
       return new shared SymEntry(a);
     }
 
-    inline proc createSymEntry(a: [?D] ?etype, max_bits=-1) throws {
-      var A = makeDistArray(D.size, etype);
-      A = a;
+    inline proc createSymEntry(in a: [?D] ?etype, max_bits=-1) throws {
+      var A = makeDistArray(a);
       return new shared SymEntry(A, max_bits=max_bits);
     }
 

--- a/src/compat/e-130/SymArrayDmapCompat.chpl
+++ b/src/compat/e-130/SymArrayDmapCompat.chpl
@@ -58,6 +58,11 @@ module SymArrayDmapCompat
         var a: [makeDistDom(size)] etype;
         return a;
     }
+
+    proc makeDistArray(in a: [?D] ?etype) {
+        return a;
+    }
+    
     /* 
     Returns the type of the distributed domain
 

--- a/src/compat/eq-131/SymArrayDmapCompat.chpl
+++ b/src/compat/eq-131/SymArrayDmapCompat.chpl
@@ -58,6 +58,11 @@ module SymArrayDmapCompat
         var a: [makeDistDom(size)] etype;
         return a;
     }
+
+    proc makeDistArray(in a: [?D] ?etype) {
+        return a;
+    }
+    
     /* 
     Returns the type of the distributed domain
 

--- a/src/compat/gt-131/SymArrayDmapCompat.chpl
+++ b/src/compat/gt-131/SymArrayDmapCompat.chpl
@@ -59,6 +59,12 @@ module SymArrayDmapCompat
       return dom.tryCreateArray(etype);
     }
 
+    proc makeDistArray(in a: [?D] ?etype) throws {
+      var res = D.tryCreateArray(a);
+      res = a;
+      return res;
+    }
+
     /* 
     Returns the type of the distributed domain
 


### PR DESCRIPTION
Previously when creating a copy of an array using `createSymEntry` we were always creating the array first and then assigning, which meant that the arrays were going to be default initializing, resulting in a performance hit.

Adding an overload of `makeDistArray` that takes an array and does not default initialize in that case resolves this performance hit prior to Chapel 1.31, but since there is no way to avoid default initialization, this is not fixed in 1.32 just yet, but we are avoiding an extra domain creation, which will improve performance slightly in 1.32.

Closes #2757