### PR TITLE
Closes #2759: Fix tryCreateArray call in 1.32 compat module

### DIFF
--- a/src/compat/e-130/SymArrayDmapCompat.chpl
+++ b/src/compat/e-130/SymArrayDmapCompat.chpl
@@ -59,6 +59,13 @@ module SymArrayDmapCompat
         return a;
     }
 
+    proc makeDistArray(in a: [?D] ?etype)
+      where MyDmap != Dmap.defaultRectangular && a.isDefaultRectangular() {
+        var res = makeDistArray(D.size, etype);
+        res = a;
+        return res;
+    }
+
     proc makeDistArray(in a: [?D] ?etype) {
         return a;
     }

--- a/src/compat/eq-131/SymArrayDmapCompat.chpl
+++ b/src/compat/eq-131/SymArrayDmapCompat.chpl
@@ -59,10 +59,17 @@ module SymArrayDmapCompat
         return a;
     }
 
+    proc makeDistArray(in a: [?D] ?etype)
+      where MyDmap != Dmap.defaultRectangular && a.isDefaultRectangular() {
+        var res = makeDistArray(D.size, etype);
+        res = a;
+        return res;
+    }
+
     proc makeDistArray(in a: [?D] ?etype) {
         return a;
     }
-    
+
     /* 
     Returns the type of the distributed domain
 

--- a/src/compat/gt-131/SymArrayDmapCompat.chpl
+++ b/src/compat/gt-131/SymArrayDmapCompat.chpl
@@ -60,7 +60,7 @@ module SymArrayDmapCompat
     }
 
     proc makeDistArray(in a: [?D] ?etype) throws {
-      var res = D.tryCreateArray(a);
+      var res = D.tryCreateArray(etype);
       res = a;
       return res;
     }


### PR DESCRIPTION
While implementing a performance improvement for the new `createSymEntry` functions, I was working off a development branch of Chapel, not off of Chapel main, which resulted in code that does not compile with Chapel main today. This PR fixes that issue.

Also, when running with releases prior to 1.32 when running in distributed environments, Arkouda will not correctly construct a block distributed array from a default rectangular when constructing a symbol table entry.

Closes #2759 