### PR TITLE
Closes #2675: Argsort for bool arrays

### DIFF
--- a/PROTO_tests/tests/coargsort_test.py
+++ b/PROTO_tests/tests/coargsort_test.py
@@ -5,7 +5,7 @@ import pytest
 import arkouda as ak
 from arkouda.sorting import SortingAlgorithm
 
-NUMERIC_AND_BIGINT_TYPES = ["int64", "float64", "uint64", "bigint"]
+NUMERIC_TYPES = ["int64", "float64", "uint64", "bigint", "bool"]
 
 
 def make_ak_arrays(size, dtype, minimum=-(2**32), maximum=2**32):
@@ -14,6 +14,8 @@ def make_ak_arrays(size, dtype, minimum=-(2**32), maximum=2**32):
         return ak.randint(minimum, maximum, size=size, dtype=dtype)
     elif dtype == "uint64":
         return ak.cast(ak.randint(minimum, maximum, size=size), dtype)
+    elif dtype == "bool":
+        return ak.cast(ak.randint(0, 2, size=size), dtype)
     elif dtype == "bigint":
         return ak.cast(ak.randint(minimum, maximum, size=size), dtype) + 2**200
     return None
@@ -21,7 +23,7 @@ def make_ak_arrays(size, dtype, minimum=-(2**32), maximum=2**32):
 
 class TestCoargsort:
     @pytest.mark.parametrize("prob_size", pytest.prob_size)
-    @pytest.mark.parametrize("dtype", NUMERIC_AND_BIGINT_TYPES)
+    @pytest.mark.parametrize("dtype", NUMERIC_TYPES)
     @pytest.mark.parametrize("algo", SortingAlgorithm)
     def test_coargsort_single_type(self, prob_size, dtype, algo):
         # add test for large number of arrays and all permutations of mixed sizes
@@ -52,7 +54,7 @@ class TestCoargsort:
     @pytest.mark.parametrize("algo", SortingAlgorithm)
     def test_coargsort_mixed_types(self, prob_size, algo):
         for arr_list in permutations(
-            make_ak_arrays(prob_size, dt, 0, 2**63) for dt in NUMERIC_AND_BIGINT_TYPES
+            make_ak_arrays(prob_size, dt, 0, 2**63) for dt in NUMERIC_TYPES
         ):
             if not isinstance(arr_list, list):
                 arr_list = list(arr_list)
@@ -85,6 +87,13 @@ class TestCoargsort:
         empty_str = ak.random_strings_uniform(1, 16, 0)
         for empty in empty_str, ak.Categorical(empty_str):
             assert [] == ak.coargsort([empty], algo).to_list()
+
+    def test_coargsort_bool(self):
+        # Reproducer for issue #2675
+        args = [ak.arange(5) % 2 == 0, ak.arange(5, 0, -1)]
+        perm = ak.coargsort(args)
+        assert args[0][perm].to_list() == [False, False, True, True, True]
+        assert args[1][perm].to_list() == [2, 4, 1, 3, 5]
 
     @pytest.mark.parametrize("algo", SortingAlgorithm)
     def test_error_handling(self, algo):

--- a/PROTO_tests/tests/operator_test.py
+++ b/PROTO_tests/tests/operator_test.py
@@ -512,9 +512,6 @@ class TestOperator:
             with pytest.raises(NotImplementedError):
                 iter(arr)
 
-        with pytest.raises(RuntimeError):
-            ak.concatenate([ak.array([True]), ak.array([True])]).is_sorted()
-
         with pytest.raises(TypeError):
             ak.ones(100).any([0])
 

--- a/PROTO_tests/tests/setops_test.py
+++ b/PROTO_tests/tests/setops_test.py
@@ -103,8 +103,9 @@ class TestSetOps:
 
         # # bool is not supported by argsortMsg (only impacts single array case)
         a, b = self.make_np_arrays(size, ak.bool)
-        with pytest.raises(RuntimeError):
-            func(ak.array(a, dtype=ak.bool), ak.array(b, dtype=ak.bool))
+        if op in ["in1d", "setdiff1d"]:
+            with pytest.raises(RuntimeError):
+                func(ak.array(a, dtype=ak.bool), ak.array(b, dtype=ak.bool))
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("op", OPS)

--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -157,6 +157,18 @@ module ArgSortMsg
               }
               deltaIV = argsortDefault(newa);
           }
+          when DType.Bool {
+              var e = toSymEntry(g, bool);
+              // Permute the keys array with the initial iv
+              var newa: [e.a.domain] int;
+              ref olda = e.a;
+              // Effectively: newa = olda[iv]
+              forall (newai, idx) in zip(newa, iv) with (var agg = newSrcAggregator(int)) {
+                  agg.copy(newai, olda[idx]:int);
+              }
+              // Generate the next incremental permutation
+              deltaIV = argsortDefault(newa);
+          }
           otherwise { throw getErrorWithContext(
                                 msg="Unsupported DataType: %?".doFormat(dtype2str(g.dtype)),
                                 lineNumber=getLineNumber(),
@@ -370,6 +382,12 @@ module ArgSortMsg
                 when (DType.Float64) {
                     var e = toSymEntry(gEnt, real);
                     var iv = argsortDefault(e.a);
+                    st.addEntry(ivname, createSymEntry(iv));
+                }
+                when (DType.Bool) {
+                    var e = toSymEntry(gEnt,bool);
+                    var int_ea = e.a:int;
+                    var iv = argsortDefault(int_ea, algorithm=algorithm);
                     st.addEntry(ivname, createSymEntry(iv));
                 }
                 otherwise {

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -252,6 +252,10 @@ module AryUtil
       return (bitWidth, negs);
     }
 
+    inline proc getBitWidth(a: [?aD] bool): (int, bool) {
+      return (1, false);
+    }
+
     inline proc getBitWidth(a: [?aD] (uint, uint)): (int, bool) {
       const negs = false;
       var highMax = max reduce [(ai,_) in a] ai;
@@ -334,6 +338,7 @@ module AryUtil
           when DType.Int64   { (bitWidth, neg) = getBitWidth(toSymEntry(g, int ).a); }
           when DType.UInt64  { (bitWidth, neg) = getBitWidth(toSymEntry(g, uint).a); }
           when DType.Float64 { (bitWidth, neg) = getBitWidth(toSymEntry(g, real).a); }
+          when DType.Bool { (bitWidth, neg) = getBitWidth(toSymEntry(g, bool).a); }
           otherwise {
             throw getErrorWithContext(
                                       msg=dtype2str(g.dtype),
@@ -377,6 +382,7 @@ module AryUtil
           when DType.Int64   { mergeArray(int); }
           when DType.UInt64  { mergeArray(uint); }
           when DType.Float64 { mergeArray(real); }
+          when DType.Bool { mergeArray(bool); }
           otherwise {
             throw getErrorWithContext(
                                       msg=dtype2str(g.dtype),

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -255,6 +255,12 @@ module ReductionMsg
                         var (minVal, minLoc) = minloc reduce zip(e.a,e.a.domain);
                         repMsg = "int64 %i".doFormat(minLoc);
                     }
+                    when "is_sorted" {
+                        var sorted = isSorted(e.a);
+                        var val:string;
+                        if sorted {val = "True";} else {val = "False";}
+                        repMsg = "bool %s".doFormat(val);
+                    }
                     otherwise {
                         var errorMsg = notImplementedError(pn,reductionop,gEnt.dtype);
                         rmLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);

--- a/tests/coargsort_test.py
+++ b/tests/coargsort_test.py
@@ -197,6 +197,13 @@ class CoargsortTest(ArkoudaTest):
         self.assertEqual(0, len(ak.coargsort([empty_str])))
         self.assertEqual(0, len(ak.coargsort([empty_cat])))
 
+    def test_coargsort_bool(self):
+        # Reproducer for issue #2675
+        args = [ak.arange(5) % 2 == 0, ak.arange(5, 0, -1)]
+        perm = ak.coargsort(args)
+        self.assertListEqual(args[0][perm].to_list(), [False, False, True, True, True])
+        self.assertListEqual(args[1][perm].to_list(), [2, 4, 1, 3, 5])
+
 
 def create_parser():
     parser = argparse.ArgumentParser(description="Check coargsort correctness.")

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -711,8 +711,6 @@ class OperatorsTest(ArkoudaTest):
         # Test ak,histogram against unsupported dtype
         # with self.assertRaises(ValueError) as cm:
         #    ak.histogram((ak.randint(0, 1, 100, dtype=ak.bool)))
-        with self.assertRaises(RuntimeError):
-            ak.concatenate([ak.array([True]), ak.array([True])]).is_sorted()
 
         with self.assertRaises(TypeError):
             ak.ones(100).any([0])

--- a/tests/setops_test.py
+++ b/tests/setops_test.py
@@ -97,9 +97,6 @@ class SetOpsTest(ArkoudaTest):
         with self.assertRaises(TypeError):
             ak.setxor1d(ak.array([-1.0, 0.0, 1.0]), ak.array([-2.0, 0.0, 2.0]))
 
-        with self.assertRaises(RuntimeError):
-            ak.setxor1d(ak.array([True, False, True]), ak.array([True, True]))
-
     def testSetxor1d_Multi(self):
         # Test Numeric pdarray
         a = [1, 2, 3, 4, 5]
@@ -208,9 +205,6 @@ class SetOpsTest(ArkoudaTest):
         with self.assertRaises(TypeError):
             ak.intersect1d(ak.array([-1.0, 0.0, 1.0]), ak.array([-2.0, 0.0, 2.0]))
 
-        with self.assertRaises(RuntimeError):
-            ak.intersect1d(ak.array([True, False, True]), ak.array([True, True]))
-
     def testIntersect1d_Multi(self):
         # Test for numeric
         a = [1, 2, 3, 4, 5]
@@ -259,9 +253,6 @@ class SetOpsTest(ArkoudaTest):
 
         with self.assertRaises(TypeError):
             ak.union1d(ak.array([-1.0, 0.0, 1.0]), ak.array([-2.0, 0.0, 2.0]))
-
-        # with self.assertRaises(RuntimeError):
-        #     ak.union1d(ak.array([True, True, True]), ak.array([True,False,True]))
 
     def testUnion1d_Multi(self):
         # test for numeric


### PR DESCRIPTION
This PR (closes #2675) adds argsort/coargsort/is_sorted to bool arrays