### PR TITLE
Closes #2762: Fix last outstanding error regarding OOM handling compat modules

### DIFF
--- a/src/compat/gt-131/SymArrayDmapCompat.chpl
+++ b/src/compat/gt-131/SymArrayDmapCompat.chpl
@@ -59,6 +59,13 @@ module SymArrayDmapCompat
       return dom.tryCreateArray(etype);
     }
 
+    proc makeDistArray(in a: [?D] ?etype)
+      where MyDmap != Dmap.defaultRectangular && a.isDefaultRectangular() {
+        var res = makeDistArray(D.size, etype);
+        res = a;
+        return res;
+    }
+    
     proc makeDistArray(in a: [?D] ?etype) throws {
       var res = D.tryCreateArray(etype);
       res = a;


### PR DESCRIPTION
In #2760, the compat modules for the 1.32 release switched to using the already created domain to create an array, rather than building the domain from scratch, which was causing some overhead. What that missed was the case where there may be a DR array passed in when you would like to create a block distributed array, so a check on the type of the domain is being added here.

Closes #2762