### PR TITLE
Closes #2764: Add throws to new makeDistArray compat function

### DIFF
--- a/src/compat/gt-131/SymArrayDmapCompat.chpl
+++ b/src/compat/gt-131/SymArrayDmapCompat.chpl
@@ -59,7 +59,7 @@ module SymArrayDmapCompat
       return dom.tryCreateArray(etype);
     }
 
-    proc makeDistArray(in a: [?D] ?etype)
+    proc makeDistArray(in a: [?D] ?etype) throws
       where MyDmap != Dmap.defaultRectangular && a.isDefaultRectangular() {
         var res = makeDistArray(D.size, etype);
         res = a;


### PR DESCRIPTION
The 1.32 makeDistArray functions need to be throwing functions, so that we can catch out of memory errors if running out of memory when creating an array.

Closes #2764