### PR TITLE
Closes #2712: Adds stridable slicing to Strings

### DIFF
--- a/src/SegmentedString.chpl
+++ b/src/SegmentedString.chpl
@@ -23,6 +23,7 @@ module SegmentedString {
 
   use ArkoudaRegexCompat;
   use ArkoudaStringBytesCompat;
+  use ArkoudaRangeCompat;
 
   private config const logLevel = ServerConfig.logLevel;
   private config const logChannel = ServerConfig.logChannel;
@@ -205,6 +206,14 @@ module SegmentedString {
         agg.copy(nv, va[start + i]);
       }
       return (newSegs, newVals);
+    }
+
+    proc this(const slice: stridableRange()) throws {
+      var aa = makeDistArray(slice.size, int);
+      forall (elt,j) in zip(aa, slice) with (var agg = newSrcAggregator(int)) {
+        agg.copy(elt,j);
+      }
+      return this[aa];
     }
 
     /* Gather strings by index. Returns arrays for the segment offsets


### PR DESCRIPTION
This PR (closes #2712) adds stridable slicing to strings.

I know this isn't the most optimized implementation (since we create an unnecessary indexing array and use the general purpose array indexing method). But it's fairly simple and since this is functionality that isn't supported today, it seems worthwhile to add.

Adding @ronawho as a reviewer mainly because I want to make sure there isn't a good reason this wasn't implemented sooner. I don't know of any, so maybe it was before my time

```python
>>> s = ak.array(['hi', 'what', 'is', 'happening'])
>>> s[::-1]
array(['happening', 'is', 'what', 'hi'])

>>> s[::-2]
array(['happening', 'what'])

>>> s[::2]
array(['hi', 'is'])
```