### PR TITLE
Closes #2774: Resolve deprecation warnings in advance of 1.32 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,7 +320,6 @@ ARKOUDA_SOURCES = $(shell find $(ARKOUDA_SOURCE_DIR)/ -type f -name '*.chpl')
 ARKOUDA_MAIN_SOURCE := $(ARKOUDA_SOURCE_DIR)/$(ARKOUDA_MAIN_MODULE).chpl
 
 ifeq ($(shell expr $(CHPL_MINOR) \> 31),1)
-	CHPL_COMPAT_FLAGS += -sbigintInitThrows=true
 	ARKOUDA_COMPAT_MODULES += -M $(ARKOUDA_SOURCE_DIR)/compat/gt-131
 endif
 

--- a/dep/checkArrow.chpl
+++ b/dep/checkArrow.chpl
@@ -11,7 +11,7 @@ proc getVersionInfo() {
   extern proc c_free_string(ptr);
   var cVersionString = c_getVersionInfo();
   defer {
-    c_free_string(cVersionString: c_void_ptr);
+    c_free_string(cVersionString: c_ptr_void);
   }
   var ret: string;
   try {

--- a/src/ArraySetops.chpl
+++ b/src/ArraySetops.chpl
@@ -78,7 +78,7 @@ module ArraySetops
     }
 
     // returns the set difference of 2 arrays
-    proc setdiff1d(a: [] ?t, b: [] t, assume_unique: bool) throws {
+    proc setdiff1d(ref a: [] ?t, ref b: [] t, assume_unique: bool) throws {
       //if not unique, unique sort arrays then perform operation
       if (!assume_unique) {
         var a1  = uniqueSort(a, false);
@@ -94,7 +94,7 @@ module ArraySetops
     // as a boolean array and inverts these
     // values and returns the array indexed
     // with this inverted array
-    proc setdiff1dHelper(a: [] ?t, b: [] t) throws {
+    proc setdiff1dHelper(ref a: [] ?t, ref b: [] t) throws {
         var truth = in1d(a, b, invert=true);
         var ret = boolIndexer(a, truth);
         return ret;

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -12,6 +12,7 @@ module AryUtil
 
     use ArkoudaPOSIXCompat;
     use ArkoudaCTypesCompat;
+    use ArkoudaBlockCompat;
 
     param bitsPerDigit = RSLSD_bitsPerDigit;
     private param numBuckets = 1 << bitsPerDigit; // these need to be const for comms/performance reasons
@@ -129,7 +130,7 @@ module AryUtil
     */
     proc contiguousIndices(A: []) param {
         use BlockDist;
-        return A.isDefaultRectangular() || isSubtype(A.domain.distribution.type, Block);
+        return A.isDefaultRectangular() || isSubtype(A.domain.distribution.type, blockDist);
     }
 
     /*

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -129,7 +129,7 @@ module AryUtil
     */
     proc contiguousIndices(A: []) param {
         use BlockDist;
-        return A.isDefaultRectangular() || isSubtype(A.domain.dist.type, Block);
+        return A.isDefaultRectangular() || isSubtype(A.domain.distribution.type, Block);
     }
 
     /*

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -412,7 +412,7 @@ module AryUtil
         /* Do we own the memory? */
         var isOwned: bool = false;
 
-        proc init(A: [] ?t, region: range()) {
+        proc init(ref A: [] ?t, region: range()) {
             use CommPrimitives;
             use CTypes;
 

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -10,6 +10,7 @@ module BinOp
   use BitOps;
 
   use ArkoudaBigIntCompat;
+  use ArkoudaMathCompat;
 
   private config const logLevel = ServerConfig.logLevel;
   private config const logChannel = ServerConfig.logChannel;
@@ -19,10 +20,10 @@ module BinOp
     Helper function to ensure that floor division cases are handled in accordance with numpy
   */
   inline proc floorDivisionHelper(numerator: ?t, denom: ?t2): real {
-    if (numerator == 0 && denom == 0) || (isinf(numerator) && (denom != 0 || isinf(denom))){
-      return NAN;
+    if (numerator == 0 && denom == 0) || (isInf(numerator) && (denom != 0 || isInf(denom))){
+      return nan;
     }
-    else if (numerator > 0 && denom == -INFINITY) || (numerator < 0 && denom == INFINITY){
+    else if (numerator > 0 && denom == -inf) || (numerator < 0 && denom == inf){
       return -1:real;
     }
     else {

--- a/src/CSVMsg.chpl
+++ b/src/CSVMsg.chpl
@@ -323,7 +323,7 @@ module CSVMsg {
         return (row_ct, hasHeader, new list(dtypes));
     }
 
-    proc read_files_into_dist_array(A: [?D] ?t, dset: string, filenames: [] string, filedomains: [] domain(1), skips: set(string), hasHeaders: bool, col_delim: string, offsets: [] int) throws {
+    proc read_files_into_dist_array(ref A: [?D] ?t, dset: string, filenames: [] string, filedomains: [] domain(1), skips: set(string), hasHeaders: bool, col_delim: string, offsets: [] int) throws {
 
         coforall loc in A.targetLocales() with (ref A) do on loc {
             // Create local copies of args

--- a/src/CSVMsg.chpl
+++ b/src/CSVMsg.chpl
@@ -325,7 +325,7 @@ module CSVMsg {
 
     proc read_files_into_dist_array(A: [?D] ?t, dset: string, filenames: [] string, filedomains: [] domain(1), skips: set(string), hasHeaders: bool, col_delim: string, offsets: [] int) throws {
 
-        coforall loc in A.targetLocales() do on loc {
+        coforall loc in A.targetLocales() with (ref A) do on loc {
             // Create local copies of args
             var locFiles = filenames;
             var locFiledoms = filedomains;

--- a/src/Cast.chpl
+++ b/src/Cast.chpl
@@ -9,6 +9,7 @@ module Cast {
   use ServerConfig;
 
   use ArkoudaBigIntCompat;
+  use ArkoudaMathCompat;
   
   private config const logLevel = ServerConfig.logLevel;
   const castLogger = new Logger(logLevel);
@@ -119,7 +120,7 @@ module Cast {
       num = stringToNumericStrict(values, rng, toType);
     } catch {
       if toType == real {
-        num = NAN;
+        num = nan;
       } else if toType == int {
         // Use pandas.NaT, i.e. -2**63, as NaN for int
         num = min(int);
@@ -136,7 +137,7 @@ module Cast {
       num = stringToNumericStrict(values, rng, toType);
     } catch {
       if toType == real {
-        num = NAN;
+        num = nan;
       } else if toType == int {
         // Use pandas.NaT, i.e. -2**63, as NaN for int
         num = min(int);

--- a/src/Cast.chpl
+++ b/src/Cast.chpl
@@ -106,7 +106,7 @@ module Cast {
     return_validity,
   }
 
-  inline proc stringToNumericStrict(values, rng, type toType): toType throws {
+  inline proc stringToNumericStrict(ref values, rng, type toType): toType throws {
     if toType == bool {
       return interpretAsString(values, rng).toLower() : toType;
     } else {
@@ -114,7 +114,7 @@ module Cast {
     }
   }
 
-  inline proc stringToNumericIgnore(values, rng, type toType): toType {
+  inline proc stringToNumericIgnore(ref values, rng, type toType): toType {
     var num: toType;
     try {
       num = stringToNumericStrict(values, rng, toType);
@@ -130,7 +130,7 @@ module Cast {
     return num;
   }
 
-  inline proc stringToNumericReturnValidity(values, rng, type toType): (toType, bool) {
+  inline proc stringToNumericReturnValidity(ref values, rng, type toType): (toType, bool) {
     var num: toType;
     var valid = true;
     try {

--- a/src/Codecs.chpl
+++ b/src/Codecs.chpl
@@ -23,7 +23,7 @@ module Codecs {
       var tmp = cRes: c_ptr(uint(8));
       var ret: [0..#outBufSize] uint(8);
       for i in ret.domain do ret[i] = (tmp+i).deref();
-      idn2_free(cRes: c_void_ptr);
+      idn2_free(cRes: c_ptr_void);
       return ret;
     } else if fromEncoding == "IDNA" {
       if toEncoding != "UTF-8" {
@@ -40,7 +40,7 @@ module Codecs {
       var tmp = cRes: c_ptr(uint(8));
       var ret: [0..#outBufSize] uint(8);
       for i in ret.domain do ret[i] = (tmp+i).deref();
-      idn2_free(cRes: c_void_ptr);
+      idn2_free(cRes: c_ptr_void);
       return ret;
     } else {
       var cd = libiconv_open(toEncoding.c_str(), fromEncoding.c_str());
@@ -69,11 +69,11 @@ module Codecs {
         var rc = idn2_to_ascii_lz(obj:c_string_ptr, cRes, 0);
         if (rc != IDNA_SUCCESS) {
           // Error condition, we just want this to be empty string
-          idn2_free(cRes: c_void_ptr);
+          idn2_free(cRes: c_ptr_void);
           return 1;
         }
         var tmp = bytes.createCopyingBuffer(cRes);
-        idn2_free(cRes: c_void_ptr);
+        idn2_free(cRes: c_ptr_void);
         return tmp.size+1;
       } else if fromEncoding == "IDNA" {
         // Check valid round trip characters
@@ -85,11 +85,11 @@ module Codecs {
         var rc = idn2_to_unicode_8z8z(obj:c_string_ptr, cRes, 0);
         if (rc != IDNA_SUCCESS) {
           // Error condition, we just want this to be empty string
-          idn2_free(cRes: c_void_ptr);
+          idn2_free(cRes: c_ptr_void);
           return 1;
         }
         var tmp = bytes.createCopyingBuffer(cRes);
-        idn2_free(cRes: c_void_ptr);
+        idn2_free(cRes: c_ptr_void);
         return tmp.size+1;
       } else {
         var cd = libiconv_open(toEncoding.c_str(), fromEncoding.c_str());

--- a/src/Codecs.chpl
+++ b/src/Codecs.chpl
@@ -14,8 +14,8 @@ module Codecs {
         var ret: [0..0] uint(8) = 0x00;
         return ret;
       }
-      var cRes: c_string;
-      var rc = idn2_to_ascii_lz(obj:c_string, cRes, 0);
+      var cRes: c_string_ptr;
+      var rc = idn2_to_ascii_lz(obj:c_string_ptr, cRes, 0);
       if (rc != IDNA_SUCCESS) {
         throw new Error("Encode failed");
       }
@@ -31,8 +31,8 @@ module Codecs {
         var ret: [0..0] uint(8) = 0x00;
         return ret;
       }
-      var cRes: c_string;
-      var rc = idn2_to_unicode_8z8z(obj:c_string, cRes, 0);
+      var cRes: c_string_ptr;
+      var rc = idn2_to_unicode_8z8z(obj:c_string_ptr, cRes, 0);
       if (rc != IDNA_SUCCESS) {
         throw new Error("Decode failed");
       }
@@ -45,14 +45,14 @@ module Codecs {
       var cd = libiconv_open(toEncoding.c_str(), fromEncoding.c_str());
       if cd == (-1):libiconv_t then
         throw new Error("Unsupported encoding: " + toEncoding + " " + fromEncoding);
-      var inBuf = obj:c_string;
+      var inBuf = obj:c_string_ptr;
       // Null terminator already accounted for
       var inSize = (inBufSize): c_size_t;
 
       var chplRes: [0..#(outBufSize+1)] uint(8);
       var outSize = (outBufSize+1): c_size_t;
       
-      var outBuf = c_ptrTo(chplRes):c_string;
+      var outBuf = c_ptrTo(chplRes):c_string_ptr;
 
       if libiconv(cd, inBuf, inSize, outBuf, outSize) != 0 then
         throw new Error("Encoding to " + toEncoding + " failed");
@@ -64,8 +64,8 @@ module Codecs {
 
     proc getBufLength(obj: c_ptr(uint(8)), inBufSize: int, toEncoding: string = "IDNA", fromEncoding: string = "UTF-8"): int throws {
       if toEncoding == "IDNA" {
-        var cRes: c_string;
-        var rc = idn2_to_ascii_lz(obj:c_string, cRes, 0);
+        var cRes: c_string_ptr;
+        var rc = idn2_to_ascii_lz(obj:c_string_ptr, cRes, 0);
         if (rc != IDNA_SUCCESS) {
           // Error condition, we just want this to be empty string
           idn2_free(cRes: c_void_ptr);
@@ -80,8 +80,8 @@ module Codecs {
         if validChars != 0 {
           return 1;
         }
-        var cRes: c_string;
-        var rc = idn2_to_unicode_8z8z(obj:c_string, cRes, 0);
+        var cRes: c_string_ptr;
+        var rc = idn2_to_unicode_8z8z(obj:c_string_ptr, cRes, 0);
         if (rc != IDNA_SUCCESS) {
           // Error condition, we just want this to be empty string
           idn2_free(cRes: c_void_ptr);
@@ -94,7 +94,7 @@ module Codecs {
         var cd = libiconv_open(toEncoding.c_str(), fromEncoding.c_str());
         if cd == (-1):libiconv_t then
           throw new Error("Unsupported encoding: " + toEncoding + " " + fromEncoding);
-        var inBuf = obj:c_string;
+        var inBuf = obj:c_string_ptr;
         // Add 1 for null terminator
         var inSize = (inBufSize): c_size_t;
 
@@ -106,7 +106,7 @@ module Codecs {
         var origSize = chplRes.size;
         var outSize = chplRes.size: c_size_t;
       
-        var outBuf = c_ptrTo(chplRes):c_string;
+        var outBuf = c_ptrTo(chplRes):c_string_ptr;
 
         if libiconv(cd, inBuf, inSize, outBuf, outSize) != 0 then
           throw new Error("Getting buf length for " + toEncoding + " failed");

--- a/src/Codecs.chpl
+++ b/src/Codecs.chpl
@@ -5,6 +5,7 @@ module Codecs {
   use AryUtil;
 
   use ArkoudaCTypesCompat;
+  use CTypes;
   
   proc encodeStr(obj: c_ptr(uint(8)), inBufSize: int, outBufSize: int, toEncoding: string = "UTF-8", fromEncoding: string = "UTF-8"): [] uint(8) throws {
     if toEncoding == "IDNA" {

--- a/src/Codecs.chpl
+++ b/src/Codecs.chpl
@@ -5,6 +5,7 @@ module Codecs {
   use AryUtil;
 
   use ArkoudaCTypesCompat;
+  use ArkoudaStringBytesCompat;
   use CTypes;
   
   proc encodeStr(obj: c_ptr(uint(8)), inBufSize: int, outBufSize: int, toEncoding: string = "UTF-8", fromEncoding: string = "UTF-8"): [] uint(8) throws {

--- a/src/Codecs.chpl
+++ b/src/Codecs.chpl
@@ -72,7 +72,7 @@ module Codecs {
           idn2_free(cRes: c_void_ptr);
           return 1;
         }
-        var tmp = cRes: bytes;
+        var tmp = bytes.createCopyingBuffer(cRes);
         idn2_free(cRes: c_void_ptr);
         return tmp.size+1;
       } else if fromEncoding == "IDNA" {
@@ -88,7 +88,7 @@ module Codecs {
           idn2_free(cRes: c_void_ptr);
           return 1;
         }
-        var tmp = cRes: bytes;
+        var tmp = bytes.createCopyingBuffer(cRes);
         idn2_free(cRes: c_void_ptr);
         return tmp.size+1;
       } else {

--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -407,6 +407,7 @@ module CommAggregation {
     use CommAggregation;
     use BigInteger, GMP;
     use ArkoudaPOSIXCompat;
+    use ArkoudaAggCompat;
 
     proc bigint._serializedSize() {
       extern proc chpl_gmp_mpz_struct_sign_size(from: __mpz_struct) : mp_size_t;

--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -6,6 +6,7 @@ module CommAggregation {
 
   use ArkoudaCTypesCompat;
   use ArkoudaPOSIXCompat;
+  use ArkoudaAggCompat;
 
   // TODO should tune these values at startup
   private param defaultBuffSize =
@@ -103,7 +104,7 @@ module CommAggregation {
         _flushBuffer(loc, bufferIdx, freeData=false);
         opsUntilYield = yieldFrequency;
       } else if opsUntilYield == 0 {
-        chpl_task_yield();
+        yieldTask();
         opsUntilYield = yieldFrequency;
       } else {
         opsUntilYield -= 1;
@@ -225,7 +226,7 @@ module CommAggregation {
         _flushBuffer(loc, bufferIdx, freeData=false);
         opsUntilYield = yieldFrequency;
       } else if opsUntilYield == 0 {
-        chpl_task_yield();
+        yieldTask();
         opsUntilYield = yieldFrequency;
       } else {
         opsUntilYield -= 1;
@@ -528,7 +529,7 @@ module CommAggregation {
         // If it's been a while since we've let other tasks run, yield so that
         // we're not blocking remote tasks from flushing their buffers.
         if opsUntilYield == 0 {
-          chpl_task_yield();
+          yieldTask();
           opsUntilYield = yieldFrequency;
         } else {
           opsUntilYield -= 1;
@@ -637,7 +638,7 @@ module CommAggregation {
           _flushBuffer(loc, bufferIdx, freeData=false);
           opsUntilYield = yieldFrequency;
         } else if opsUntilYield == 0 {
-          chpl_task_yield();
+          yieldTask();
           opsUntilYield = yieldFrequency;
         } else {
           opsUntilYield -= 1;

--- a/src/ConcatenateMsg.chpl
+++ b/src/ConcatenateMsg.chpl
@@ -101,7 +101,7 @@ module ConcatenateMsg
             size += entrySize;
             if mode == "interleave" {
               const dummyDomain = makeDistDom(entrySize);
-              coforall loc in Locales {
+              coforall loc in Locales with (ref blocksizes, ref blockValSizes) {
                 on loc {
                   const mynumsegs = dummyDomain.localSubdomain().size;
                   blocksizes[here.id] += mynumsegs;
@@ -169,7 +169,7 @@ module ConcatenateMsg
                     var newSegs = thisSegs.a + valStart;
                     var thisVals = segString.values;
                     if mode == "interleave" {
-                      coforall loc in Locales {
+                      coforall loc in Locales with (ref blockstarts, ref blockValStarts) {
                         on loc {
                           // Number of strings on this locale for this input array
                           const mynsegs = thisSegs.a.domain.localSubdomain().size;
@@ -227,7 +227,7 @@ module ConcatenateMsg
                             // lookup and cast operand to copy from
                             const o = toSymEntry(getGenericTypedArrayEntry(name, st), int);
                             if mode == "interleave" {
-                              coforall loc in Locales {
+                              coforall loc in Locales with (ref blockstarts) {
                                 on loc {
                                   const size = o.a.domain.localSubdomain().size;
                                   e.a[{blockstarts[here.id]..#size}] = o.a.localSlice[o.a.domain.localSubdomain()];
@@ -256,7 +256,7 @@ module ConcatenateMsg
                             // lookup and cast operand to copy from
                             const o = toSymEntry(getGenericTypedArrayEntry(name, st), real);
                             if mode == "interleave" {
-                              coforall loc in Locales {
+                              coforall loc in Locales with (ref blockstarts) {
                                 on loc {
                                   const size = o.a.domain.localSubdomain().size;
                                   e.a[{blockstarts[here.id]..#size}] = o.a.localSlice[o.a.domain.localSubdomain()];
@@ -285,7 +285,7 @@ module ConcatenateMsg
                             // lookup and cast operand to copy from
                             const o = toSymEntry(getGenericTypedArrayEntry(name, st), bool);
                             if mode == "interleave" {
-                              coforall loc in Locales {
+                              coforall loc in Locales with (ref blockstarts) {
                                 on loc {
                                   const size = o.a.domain.localSubdomain().size;
                                   e.a[{blockstarts[here.id]..#size}] = o.a.localSlice[o.a.domain.localSubdomain()];
@@ -314,7 +314,7 @@ module ConcatenateMsg
                             // lookup and cast operand to copy from
                             const o = toSymEntry(getGenericTypedArrayEntry(name, st), uint);
                             if mode == "interleave" {
-                              coforall loc in Locales {
+                              coforall loc in Locales with (ref blockstarts) {
                                 on loc {
                                   const size = o.a.domain.localSubdomain().size;
                                   e.a[{blockstarts[here.id]..#size}] = o.a.localSlice[o.a.domain.localSubdomain()];
@@ -344,7 +344,7 @@ module ConcatenateMsg
                             const o = toSymEntry(getGenericTypedArrayEntry(name, st), bigint);
                             max_bits = max(max_bits, o.max_bits);
                             if mode == "interleave" {
-                              coforall loc in Locales {
+                              coforall loc in Locales with (ref blockstarts) {
                                 on loc {
                                   const size = o.a.domain.localSubdomain().size;
                                   tmp[{blockstarts[here.id]..#size}] = o.a.localSlice[o.a.domain.localSubdomain()];

--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -19,6 +19,7 @@ module EfuncMsg
     use AryUtil;
 
     use ArkoudaBitOpsCompat;
+    use ArkoudaMathCompat;
 
     private config const logLevel = ServerConfig.logLevel;
     private config const logChannel = ServerConfig.logChannel;
@@ -215,7 +216,7 @@ module EfuncMsg
                         st.addEntry(rname, new shared SymEntry(atanh(ea)));
                     }
                     when "isnan" {
-                        st.addEntry(rname, new shared SymEntry(isnan(ea)));
+                        st.addEntry(rname, new shared SymEntry(isNan(ea)));
                     }
                     when "hash64" {
                         overMemLimit(numBytes(real) * e.size);

--- a/src/EncodingMsg.chpl
+++ b/src/EncodingMsg.chpl
@@ -55,7 +55,7 @@ module EncodingMsg {
       return (encodeOffsets, encodedValues);
     }
 
-    proc getBufLengths(segments: [?D] int, values: [?vD] ?t, toEncoding: string, fromEncoding: string) throws {
+    proc getBufLengths(segments: [?D] int, ref values: [?vD] ?t, toEncoding: string, fromEncoding: string) throws {
       var res: [D] int;
       if (D.size == 0) {
         return res;
@@ -96,7 +96,7 @@ module EncodingMsg {
       return res;
     }
 
-    proc encodeSegments(segments: [?D] int, values: [?vD] uint(8), encodeOffsets: [D] int, encodeLengths: [D] int, toEncoding: string, fromEncoding: string) throws {
+    proc encodeSegments(segments: [?D] int, ref values: [?vD] uint(8), encodeOffsets: [D] int, encodeLengths: [D] int, toEncoding: string, fromEncoding: string) throws {
       var res = makeDistArray(+ reduce encodeLengths, uint(8));
       if (D.size == 0) {
         return res;

--- a/src/EncodingMsg.chpl
+++ b/src/EncodingMsg.chpl
@@ -64,7 +64,7 @@ module EncodingMsg {
       const (startSegInds, numSegs, lengths) = computeSegmentOwnership(segments, vD);
     
       // Start task parallelism
-      coforall loc in Locales {
+      coforall loc in Locales with (ref values, ref res) {
         on loc {
           const locTo = toEncoding;
           const locFrom = fromEncoding;
@@ -106,7 +106,7 @@ module EncodingMsg {
       const (eStartSegInds, eNumSegs, eLengths) = computeSegmentOwnership(encodeOffsets, res.domain);
     
       // Start task parallelism
-      coforall loc in Locales {
+      coforall loc in Locales with (ref values, ref res) {
         on loc {
           const locTo = toEncoding;
           const locFrom = fromEncoding;

--- a/src/Extremas.chpl
+++ b/src/Extremas.chpl
@@ -45,7 +45,7 @@ to increase the efficiency of the merge step.
     // Push a value into the KExtreme
     // instance, only pushes a value if
     // it is an encountered extreme
-    proc push(val: (eltType, int)) {
+    proc ref push(val: (eltType, int)) {
 
       // Accumulate/push can be called after combine/merge. This routine
       // expects the data to be a heap and not sorted, so it would fail if we
@@ -72,7 +72,7 @@ to increase the efficiency of the merge step.
 
     // Restore heap property from the
     // top element down
-    proc heapifyDown() {
+    proc ref heapifyDown() {
       var i = 0;
       while(i < size) {
         const initial = i;
@@ -94,7 +94,7 @@ to increase the efficiency of the merge step.
 
     // Sort the KExtreme values if needed,
     // moving from a heap to a sorted array
-    proc doSort() {
+    proc ref doSort() {
       sort(_data);
       isSorted = true;
     }

--- a/src/FileIO.chpl
+++ b/src/FileIO.chpl
@@ -232,9 +232,9 @@ module FileIO {
 
     proc getFirstEightBytesFromFile(path:string):bytes throws {
         var f:file = open(path, ioMode.r);
-        var reader = f.reader(kind=ionative);
+        var reader = fileIOReaderCompat(f);
         var header:bytes;
-        if (reader.binary()) {
+        if (binaryCheckCompat(reader)) {
           reader.bytesRead(header, 8);
         } else {
           throw getErrorWithContext(

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -59,7 +59,7 @@ module GenSymIO {
 
         proc bytesToSymEntry(size:int, type t, st: borrowed SymTab, ref data:bytes): string throws {
             var entry = createSymEntry(size, t);
-            var localA = makeArrayFromPtr(data.c_str():c_void_ptr:c_ptr(t), size:uint);
+            var localA = makeArrayFromPtr(data.c_str():c_ptr_void:c_ptr(t), size:uint);
             entry.a = localA;
             var name = st.nextName();
             st.addEntry(name, entry);

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -17,6 +17,7 @@ module GenSymIO {
     use ServerConfig;
     use SegmentedString;
     use Map;
+    use CTypes;
     use ArkoudaMapCompat;
 
     use ArkoudaListCompat;

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -120,7 +120,7 @@ module GenSymIO {
      * by finding the null terminators given the values/bytes array which should have already been
      * converted to uint8
      */
-    proc segmentedCalcOffsets(values:[] uint(8), valuesDom:domain): [] int throws {
+    proc segmentedCalcOffsets(values:[] uint(8), valuesDom): [] int throws {
         gsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"Calculating offsets for SegString");
         var nb_locs = forall (i,v) in zip(valuesDom, values) do if v == NULL_STRINGS_VALUE then i+1;
         // We need to adjust nb_locs b/c offsets is really the starting position of each string

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -574,7 +574,7 @@ module HDF5Msg {
             - Shape: [] int - stores the shape of object.
         Calls to writeArkoudaMetaData to write the arkouda metadata
     */
-    proc writeArrayViewAttrs(file_id: C_HDF5.hid_t, dset_name: string, objType: string, shape: SymEntry, dtype:C_HDF5.hid_t) throws {
+    proc writeArrayViewAttrs(file_id: C_HDF5.hid_t, dset_name: string, objType: string, shape, dtype:C_HDF5.hid_t) throws {
         h5Logger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                         "Writing ArrayView Attrs");
         //open the created dset so we can add attributes.
@@ -3148,7 +3148,7 @@ module HDF5Msg {
         var entryVal = createSymEntry(len, uint(8));
         read_files_into_distributed_array(entryVal.a, subdoms, filenames, dset + "/" + SEGMENTED_VALUE_NAME, skips);
 
-        proc _buildEntryCalcOffsets(): shared SymEntry throws {
+        proc _buildEntryCalcOffsets() throws {
             var offsetsArray = segmentedCalcOffsets(entryVal.a, entryVal.a.domain);
             return createSymEntry(offsetsArray);
         }

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -64,8 +64,8 @@ module HDF5Msg {
     require "c_helpers/help_h5ls.h", "c_helpers/help_h5ls.c";
     private extern proc c_get_HDF5_obj_type(loc_id:C_HDF5.hid_t, name:c_string_ptr, obj_type:c_ptr(C_HDF5.H5O_type_t)):C_HDF5.herr_t;
     private extern proc c_strlen(s:c_ptr(c_char)):c_size_t;
-    private extern proc c_incrementCounter(data:c_void_ptr);
-    private extern proc c_append_HDF5_fieldname(data:c_void_ptr, name:c_string_ptr);
+    private extern proc c_incrementCounter(data:c_ptr_void);
+    private extern proc c_append_HDF5_fieldname(data:c_ptr_void, name:c_string_ptr);
 
     /*
      * Returns the HDF5 data type corresponding to the dataset, which delegates
@@ -2558,7 +2558,7 @@ module HDF5Msg {
          * This is an H5Literate call-back function, c_helper funcs are used to process data in void*
          * this proc counts the number of of HDF5 groups/datasets under the root, non-recursive
          */
-        proc _get_item_count(loc_id:C_HDF5.hid_t, name:c_void_ptr, info:c_void_ptr, data:c_void_ptr) {
+        proc _get_item_count(loc_id:C_HDF5.hid_t, name:c_ptr_void, info:c_ptr_void, data:c_ptr_void) {
             var obj_name = name:c_string_ptr;
             var obj_type:C_HDF5.H5O_type_t;
             var status:C_HDF5.H5O_type_t = c_get_HDF5_obj_type(loc_id, obj_name, c_ptrTo(obj_type));
@@ -2572,7 +2572,7 @@ module HDF5Msg {
          * This is an H5Literate call-back function, c_helper funcs are used to process data in void*
          * this proc builds string of HDF5 group/dataset objects names under the root, non-recursive
          */
-        proc _simulate_h5ls(loc_id:C_HDF5.hid_t, name:c_void_ptr, info:c_void_ptr, data:c_void_ptr) {
+        proc _simulate_h5ls(loc_id:C_HDF5.hid_t, name:c_ptr_void, info:c_ptr_void, data:c_ptr_void) {
             var obj_name = name:c_string_ptr;
             var obj_type:C_HDF5.H5O_type_t;
             var status:C_HDF5.H5O_type_t = c_get_HDF5_obj_type(loc_id, obj_name, c_ptrTo(obj_type));

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -40,7 +40,7 @@ module HDF5Msg {
 
     const ARKOUDA_HDF5_FILE_METADATA_GROUP = "/_arkouda_metadata";
     const ARKOUDA_HDF5_ARKOUDA_VERSION_KEY = "arkouda_version"; // see ServerConfig.arkoudaVersion
-    type ARKOUDA_HDF5_ARKOUDA_VERSION_TYPE = c_string;
+    type ARKOUDA_HDF5_ARKOUDA_VERSION_TYPE = c_string_ptr;
     const ARKOUDA_HDF5_FILE_VERSION_KEY = "file_version";
     const ARKOUDA_HDF5_FILE_VERSION_VAL = 2.0:real(32);
     type ARKOUDA_HDF5_FILE_VERSION_TYPE = real(32);
@@ -62,10 +62,10 @@ module HDF5Msg {
     config const MULTI_FILE: int = 1;
 
     require "c_helpers/help_h5ls.h", "c_helpers/help_h5ls.c";
-    private extern proc c_get_HDF5_obj_type(loc_id:C_HDF5.hid_t, name:c_string, obj_type:c_ptr(C_HDF5.H5O_type_t)):C_HDF5.herr_t;
+    private extern proc c_get_HDF5_obj_type(loc_id:C_HDF5.hid_t, name:c_string_ptr, obj_type:c_ptr(C_HDF5.H5O_type_t)):C_HDF5.herr_t;
     private extern proc c_strlen(s:c_ptr(c_char)):c_size_t;
     private extern proc c_incrementCounter(data:c_void_ptr);
-    private extern proc c_append_HDF5_fieldname(data:c_void_ptr, name:c_string);
+    private extern proc c_append_HDF5_fieldname(data:c_void_ptr, name:c_string_ptr);
 
     /*
      * Returns the HDF5 data type corresponding to the dataset, which delegates
@@ -490,7 +490,7 @@ module HDF5Msg {
                             C_HDF5.H5P_DEFAULT,
                             C_HDF5.H5P_DEFAULT);
 
-        // For the value, we need to build a ptr to a char[]; c_string doesn't work because it is a const char*        
+        // For the value, we need to build a ptr to a char[]; c_string_ptr doesn't work because it is a const char*        
         var akVersion = allocate(c_char, arkoudaVersion.size+1, clear=true);
         for (c, i) in zip(arkoudaVersion.codepoints(), 0..<arkoudaVersion.size) {
             akVersion[i] = c:c_char;
@@ -550,7 +550,7 @@ module HDF5Msg {
                             C_HDF5.H5P_DEFAULT,
                             C_HDF5.H5P_DEFAULT);
 
-        // For the value, we need to build a ptr to a char[]; c_string doesn't work because it is a const char*        
+        // For the value, we need to build a ptr to a char[]; c_string_ptr doesn't work because it is a const char*        
         var akVersion = allocate(c_char, arkoudaVersion.size+1, clear=true);
         for (c, i) in zip(arkoudaVersion.codepoints(), 0..<arkoudaVersion.size) {
             akVersion[i] = c:c_char;
@@ -2559,7 +2559,7 @@ module HDF5Msg {
          * this proc counts the number of of HDF5 groups/datasets under the root, non-recursive
          */
         proc _get_item_count(loc_id:C_HDF5.hid_t, name:c_void_ptr, info:c_void_ptr, data:c_void_ptr) {
-            var obj_name = name:c_string;
+            var obj_name = name:c_string_ptr;
             var obj_type:C_HDF5.H5O_type_t;
             var status:C_HDF5.H5O_type_t = c_get_HDF5_obj_type(loc_id, obj_name, c_ptrTo(obj_type));
             if (obj_type == C_HDF5.H5O_TYPE_GROUP || obj_type == C_HDF5.H5O_TYPE_DATASET) {
@@ -2573,7 +2573,7 @@ module HDF5Msg {
          * this proc builds string of HDF5 group/dataset objects names under the root, non-recursive
          */
         proc _simulate_h5ls(loc_id:C_HDF5.hid_t, name:c_void_ptr, info:c_void_ptr, data:c_void_ptr) {
-            var obj_name = name:c_string;
+            var obj_name = name:c_string_ptr;
             var obj_type:C_HDF5.H5O_type_t;
             var status:C_HDF5.H5O_type_t = c_get_HDF5_obj_type(loc_id, obj_name, c_ptrTo(obj_type));
             if (obj_type == C_HDF5.H5O_TYPE_GROUP || obj_type == C_HDF5.H5O_TYPE_DATASET) {

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -1136,7 +1136,7 @@ module HDF5Msg {
      * :arg items: the array containing the data to be written for te specified Strings array component
      * :type items: [] ?etype
      */
-    private proc writeSegmentedComponentToHdf(fileId: int, group: string, component: string, items: [] ?etype) throws {
+    private proc writeSegmentedComponentToHdf(fileId: int, group: string, component: string, ref items: [] ?etype) throws {
         var numItems = items.size: uint(64);
         C_HDF5.H5LTmake_dataset_WAR(fileId, "/%s/%s".doFormat(group, component).c_str(), 1,
                 c_ptrTo(numItems), getDataType(etype), c_ptrTo(items));
@@ -2913,7 +2913,7 @@ module HDF5Msg {
     /*
         Read an ArrayView object from the files provided into a distributed array
     */
-    proc arrayView_readhdfMsg(filenames: [?fD] string, dset: string, dataclass, bytesize: int, isSigned: bool, validFiles: [] bool, st: borrowed SymTab): (string, ObjType, string) throws {
+    proc arrayView_readhdfMsg(filenames: [?fD] string, dset: string, dataclass, bytesize: int, isSigned: bool, ref validFiles: [] bool, st: borrowed SymTab): (string, ObjType, string) throws {
         var file_id = C_HDF5.H5Fopen(filenames[0].c_str(), C_HDF5.H5F_ACC_RDONLY, 
                                            C_HDF5.H5P_DEFAULT);
         var dset_id: C_HDF5.hid_t = C_HDF5.H5Oopen(file_id, dset.c_str(), C_HDF5.H5P_DEFAULT);
@@ -3042,7 +3042,7 @@ module HDF5Msg {
     /*
         Read an pdarray object from the files provided into a distributed array
     */
-    proc readPdarrayFromFile(filenames: [?fD] string, dset: string, dataclass, bytesize: int, isSigned: bool, validFiles: [] bool, st: borrowed SymTab): string throws {
+    proc readPdarrayFromFile(filenames: [?fD] string, dset: string, dataclass, bytesize: int, isSigned: bool, ref validFiles: [] bool, st: borrowed SymTab): string throws {
         // identify the index of the first valid file
         var (v, idx) = maxloc reduce zip(validFiles, validFiles.domain);
 
@@ -3109,7 +3109,7 @@ module HDF5Msg {
         return rname;
     }
 
-    proc pdarray_readhdfMsg(filenames: [?fD] string, dset: string, dataclass, bytesize: int, isSigned: bool, validFiles: [] bool, st: borrowed SymTab): (string, ObjType, string) throws {
+    proc pdarray_readhdfMsg(filenames: [?fD] string, dset: string, dataclass, bytesize: int, isSigned: bool, ref validFiles: [] bool, st: borrowed SymTab): (string, ObjType, string) throws {
         var pda_name = readPdarrayFromFile(filenames, dset, dataclass, bytesize, isSigned, validFiles, st);
         var (v, idx) = maxloc reduce zip(validFiles, validFiles.domain);
         var file_id = C_HDF5.H5Fopen(filenames[idx].c_str(), C_HDF5.H5F_ACC_RDONLY, C_HDF5.H5P_DEFAULT);
@@ -3170,7 +3170,7 @@ module HDF5Msg {
         return (dset, ObjType.STRINGS, "%s+%?".doFormat(stringsEntry.name, stringsEntry.nBytes));
     }
 
-    proc readSegArrayFromFile(filenames: [?fD] string, dset: string, dataclass, bytesize: int, isSigned: bool, calcStringOffsets: bool, validFiles: [] bool, st: borrowed SymTab) throws {        
+    proc readSegArrayFromFile(filenames: [?fD] string, dset: string, dataclass, bytesize: int, isSigned: bool, calcStringOffsets: bool, ref validFiles: [] bool, st: borrowed SymTab) throws {        
         var segSubdoms: [fD] domain(1);
         var skips = new set(string);
         var nSeg: int;
@@ -3210,7 +3210,7 @@ module HDF5Msg {
         return rtnMap;
     }
 
-    proc segarray_readhdfMsg(filenames: [?fD] string, dset: string, dataclass, bytesize: int, isSigned: bool, calcStringOffsets: bool, validFiles: [] bool, st: borrowed SymTab): (string, ObjType, string) throws {
+    proc segarray_readhdfMsg(filenames: [?fD] string, dset: string, dataclass, bytesize: int, isSigned: bool, calcStringOffsets: bool, ref validFiles: [] bool, st: borrowed SymTab): (string, ObjType, string) throws {
         var rtnMap = readSegArrayFromFile(filenames, dset, dataclass, bytesize, isSigned, calcStringOffsets, validFiles, st);
         return (dset, ObjType.SEGARRAY, formatJson(rtnMap));
     }
@@ -3288,7 +3288,7 @@ module HDF5Msg {
         return (dset, ObjType.CATEGORICAL, formatJson(rtnMap));
     }
 
-    proc groupby_readhdfMsg(filenames: [?fD] string, dset: string, validFiles: [] bool, calcStringOffsets: bool, st: borrowed SymTab): (string, ObjType, string) throws {
+    proc groupby_readhdfMsg(filenames: [?fD] string, dset: string, ref validFiles: [] bool, calcStringOffsets: bool, st: borrowed SymTab): (string, ObjType, string) throws {
         var rtnMap: map(string, string);
         // domain and size info for codes
         var perm_subdoms: [fD] domain(1);
@@ -3393,7 +3393,7 @@ module HDF5Msg {
         return (dset, ObjType.GROUPBY, formatJson(rtnMap));
     }
 
-    proc dataframe_readhdfMsg(filenames: [?fD] string, dset: string, validFiles: [] bool, calcStringOffsets: bool, st: borrowed SymTab): (string, ObjType, string) throws {
+    proc dataframe_readhdfMsg(filenames: [?fD] string, dset: string, ref validFiles: [] bool, calcStringOffsets: bool, st: borrowed SymTab): (string, ObjType, string) throws {
         var rtnMap: map(string, string);
         var file_id = C_HDF5.H5Fopen(filenames[0].c_str(), C_HDF5.H5F_ACC_RDONLY, 
                                            C_HDF5.H5P_DEFAULT);

--- a/src/In1d.chpl
+++ b/src/In1d.chpl
@@ -24,7 +24,7 @@ module In1d
        :returns truth: the distributed boolean array containing the result of ar1 being broadcast over ar2
        :type truth: [] bool
      */
-    proc in1d(ar1: [?aD1] ?t, ar2: [?aD2] t, invert: bool = false): [aD1] bool throws {
+    proc in1d(ar1: [?aD1] ?t, ref ar2: [?aD2] t, invert: bool = false): [aD1] bool throws {
         var truth = if ar2.size <= threshold then in1dAr2PerLocAssoc(ar1, ar2)
                                              else in1dSort(ar1, ar2);
         if invert then truth = !truth;
@@ -35,7 +35,7 @@ module In1d
      * localize ar2 and put it in the set, so only appropriate in terms of
      * size and space when ar2 is "small".
      */
-    proc in1dAr2PerLocAssoc(ar1: [?aD1] ?t, ar2: [?aD2] t) {
+    proc in1dAr2PerLocAssoc(ar1: [?aD1] ?t, ref ar2: [?aD2] t) {
         var truth: [aD1] bool;
         
         coforall loc in Locales with (ref truth, ref ar2) {

--- a/src/In1d.chpl
+++ b/src/In1d.chpl
@@ -38,7 +38,7 @@ module In1d
     proc in1dAr2PerLocAssoc(ar1: [?aD1] ?t, ar2: [?aD2] t) {
         var truth: [aD1] bool;
         
-        coforall loc in Locales {
+        coforall loc in Locales with (ref truth, ref ar2) {
             on loc {
                 var ar2Set: domain(t, parSafe=false); // create a set to hold ar2, parSafe modification is OFF
                 ar2Set.requestCapacity(ar2.size); // request a capacity for the initial set

--- a/src/JoinEqWithDTMsg.chpl
+++ b/src/JoinEqWithDTMsg.chpl
@@ -105,7 +105,7 @@ module JoinEqWithDTMsg
         // actual number of results per locale
         var locNumResults: [PrivateSpace] int;
         
-        coforall loc in Locales {
+        coforall loc in Locales with (ref locResI, ref locResJ, ref locNumResults, ref resCounters) {
             on loc {
                 forall i in a1.localSubdomain() {
                     // more space in result list???

--- a/src/Message.chpl
+++ b/src/Message.chpl
@@ -81,19 +81,19 @@ module Message {
             return formatJson(this);
         }
 
-        proc setKey(value: string) {
+        proc ref setKey(value: string) {
             this.key = value;
         }
 
-        proc setVal(value: string) {
+        proc ref setVal(value: string) {
             this.val = value;
         }
 
-        proc setObjType(value: ObjectType) {
+        proc ref setObjType(value: ObjectType) {
             this.ObjectType = value;
         }
 
-        proc setDType(value: string) {
+        proc ref setDType(value: string) {
             this.dtype = value;
         }
 

--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -230,27 +230,6 @@ module MultiTypeSymEntry
         proc deinit() {
             if logLevel == LogLevel.DEBUG {writeln("deinit SymEntry");try! stdout.flush();}
         }
-        
-        override proc writeThis(f) throws {
-          use Reflection;
-          proc writeField(f, param i) throws {
-            if !isArray(getField(this, i)) {
-              f.write(getFieldName(this.type, i), " = ", getField(this, i):string);
-            } else {
-              f.write(getFieldName(this.type, i), " = ", formatAry(getField(this, i)));
-            }
-          }
-
-          super.writeThis(f);
-          f.write(" {");
-          param nFields = numFields(this.type);
-          for param i in 0..nFields-2 {
-            writeField(f, i);
-            f.write(", ");
-          }
-          writeField(f, nFields-1);
-          f.write("}");
-        }
 
         /*
         Formats and returns data in this entry up to the specified threshold. 

--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -10,6 +10,7 @@ module MultiTypeSymEntry
 
     public use NumPyDType;
     public use SymArrayDmapCompat;
+    use ArkoudaSymEntryCompat;
 
     private config const logLevel = ServerConfig.logLevel;
     private config const logChannel = ServerConfig.logChannel;

--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -321,7 +321,7 @@ module MultiTypeSymEntry
         var offsetsEntry: shared SymEntry(int);
         var bytesEntry: shared SymEntry(uint(8));
 
-        proc init(offsetsSymEntry: shared SymEntry, bytesSymEntry: shared SymEntry, type etype) {
+        proc init(offsetsSymEntry: shared SymEntry(int), bytesSymEntry: shared SymEntry(uint(8)), type etype) {
             super.init(etype, bytesSymEntry.size);
             this.entryType = SymbolEntryType.SegStringSymEntry;
             assignableTypes.add(this.entryType);

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -312,7 +312,7 @@ module MultiTypeSymbolTable
 
         :returns: array of JSON formatted strings
         */
-        proc getEntries(infoList:map(string, shared GenSymEntry)): [] string throws {
+        proc getEntries(infoList:map(string, shared AbstractSymEntry)): [] string throws {
             var entries: [1..infoList.size] string;
             var i = 0;
             for name in infoList.keys() {

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -312,7 +312,7 @@ module MultiTypeSymbolTable
 
         :returns: array of JSON formatted strings
         */
-        proc getEntries(infoList:map): [] string throws {
+        proc getEntries(infoList:map(string, shared GenSymEntry)): [] string throws {
             var entries: [1..infoList.size] string;
             var i = 0;
             for name in infoList.keys() {

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -96,7 +96,7 @@ module ParquetMsg {
     extern proc c_free_string(ptr);
     var cVersionString = c_getVersionInfo();
     defer {
-      c_free_string(cVersionString: c_void_ptr);
+      c_free_string(cVersionString: c_ptr_void);
     }
     var ret: string;
     try {
@@ -447,7 +447,7 @@ module ParquetMsg {
 
         var locDom = A.localSubdomain();
         var locArr = A[locDom];
-        var valPtr: c_void_ptr = nil;
+        var valPtr: c_ptr_void = nil;
         if locArr.size != 0 {
           valPtr = c_ptrTo(locArr);
         }
@@ -996,7 +996,7 @@ module ParquetMsg {
 
     var pqErr = new parquetErrorMsg();
 
-    var valPtr: c_void_ptr = nil;
+    var valPtr: c_ptr_void = nil;
     if localVals.size != 0 {
       valPtr = c_ptrTo(localVals);
     }
@@ -1108,8 +1108,8 @@ module ParquetMsg {
 
         var pqErr = new parquetErrorMsg();
         var dtypeRep = ARROWSTRING;
-        var valPtr: c_void_ptr = nil;
-        var offPtr: c_void_ptr = nil;
+        var valPtr: c_ptr_void = nil;
+        var offPtr: c_ptr_void = nil;
 
         // need to get the local string values
         if offIdxRange.size > 0 {
@@ -1287,8 +1287,8 @@ module ParquetMsg {
       var pqErr = new parquetErrorMsg();
       const fname = filenames[idx];
 
-      var ptrList: [0..#ncols] c_void_ptr;
-      var segmentPtr: [0..#ncols] c_void_ptr; // ptrs to offsets for SegArray. Know number of rows so we know where to stop
+      var ptrList: [0..#ncols] c_ptr_void;
+      var segmentPtr: [0..#ncols] c_ptr_void; // ptrs to offsets for SegArray. Know number of rows so we know where to stop
       var objTypes: [0..#ncols] int; // ObjType enum integer values
       var datatypes: [0..#ncols] int;
       var sizeList: [0..#ncols] int;
@@ -1422,7 +1422,7 @@ module ParquetMsg {
               var valIdxRange = startValIdx..endValIdx;
               ref olda = ss.values.a;
               str_vals[si..#valIdxRange.size] = olda[valIdxRange];
-              ptrList[i] = c_ptrTo(str_vals[si]): c_void_ptr;
+              ptrList[i] = c_ptrTo(str_vals[si]): c_ptr_void;
               sizeList[i] = locDom.size;
             }
           }
@@ -1459,7 +1459,7 @@ module ParquetMsg {
                   var valIdxRange = startValIdx..endValIdx;
                   ref olda = values.a;
                   int_vals[ui..#valIdxRange.size] = olda[valIdxRange];
-                  ptrList[i] = c_ptrTo(int_vals[ui]): c_void_ptr;
+                  ptrList[i] = c_ptrTo(int_vals[ui]): c_ptr_void;
                 }
                 when DType.UInt64 {
                   segarray_sizes[i] = seg_sizes_int[i];
@@ -1472,7 +1472,7 @@ module ParquetMsg {
                   var valIdxRange = startValIdx..endValIdx;
                   ref olda = values.a;
                   int_vals[ui..#valIdxRange.size] = olda[valIdxRange]: int;
-                  ptrList[i] = c_ptrTo(int_vals[ui]): c_void_ptr;
+                  ptrList[i] = c_ptrTo(int_vals[ui]): c_ptr_void;
                 }
                 when DType.Float64 {
                   segarray_sizes[i] = seg_sizes_real[i];
@@ -1485,7 +1485,7 @@ module ParquetMsg {
                   var valIdxRange = startValIdx..endValIdx;
                   ref olda = values.a;
                   real_vals[ri..#valIdxRange.size] = olda[valIdxRange];
-                  ptrList[i] = c_ptrTo(real_vals[ri]): c_void_ptr;
+                  ptrList[i] = c_ptrTo(real_vals[ri]): c_ptr_void;
                 }
                 when DType.Bool {
                   segarray_sizes[i] = seg_sizes_bool[i];
@@ -1498,7 +1498,7 @@ module ParquetMsg {
                   var valIdxRange = startValIdx..endValIdx;
                   ref olda = values.a;
                   bool_vals[bi..#valIdxRange.size] = olda[valIdxRange];
-                  ptrList[i] = c_ptrTo(bool_vals[bi]): c_void_ptr;
+                  ptrList[i] = c_ptrTo(bool_vals[bi]): c_ptr_void;
                 }
                 when DType.Strings {
                   segarray_sizes[i] = val_sizes_str[i];
@@ -1525,7 +1525,7 @@ module ParquetMsg {
                     var endValIdx = if (lastOffsetIdx == offIdxRange.high) then lastValIdx else oldOff[offIdxRange.high + 1] - 1;
                     var valIdxRange = startValIdx..endValIdx;
                     str_vals[si..#valIdxRange.size] = oldVal[valIdxRange];
-                    ptrList[i] = c_ptrTo(str_vals[si]): c_void_ptr;
+                    ptrList[i] = c_ptrTo(str_vals[si]): c_ptr_void;
                   }
                 }
                 otherwise {
@@ -1580,7 +1580,7 @@ module ParquetMsg {
                 datatypes[i] = ARROWINT64;
                 // set the pointer to the entry array in the list of Pointers
                 if locDom.size > 0 {
-                  ptrList[i] = c_ptrTo(e.a[locDom]): c_void_ptr;
+                  ptrList[i] = c_ptrTo(e.a[locDom]): c_ptr_void;
                   sizeList[i] = locDom.size;
                 }
               }
@@ -1591,7 +1591,7 @@ module ParquetMsg {
                 datatypes[i] = ARROWUINT64;
                 // set the pointer to the entry array in the list of Pointers
                 if locDom.size > 0 {
-                  ptrList[i] = c_ptrTo(e.a[locDom]): c_void_ptr;
+                  ptrList[i] = c_ptrTo(e.a[locDom]): c_ptr_void;
                   sizeList[i] = locDom.size;
                 }
               }
@@ -1602,7 +1602,7 @@ module ParquetMsg {
                 datatypes[i] = ARROWDOUBLE;
                 // set the pointer to the entry array in the list of Pointers
                 if locDom.size > 0 {
-                  ptrList[i] = c_ptrTo(e.a[locDom]): c_void_ptr;
+                  ptrList[i] = c_ptrTo(e.a[locDom]): c_ptr_void;
                   sizeList[i] = locDom.size;
                 }
               }
@@ -1613,7 +1613,7 @@ module ParquetMsg {
                 datatypes[i] = ARROWBOOLEAN;
                 // set the pointer to the entry array in the list of Pointers
                 if locDom.size > 0 {
-                  ptrList[i] = c_ptrTo(e.a[locDom]): c_void_ptr;
+                  ptrList[i] = c_ptrTo(e.a[locDom]): c_ptr_void;
                   sizeList[i] = locDom.size;
                 }
               }

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -91,7 +91,7 @@ module ParquetMsg {
   }
   
   proc getVersionInfo() {
-    extern proc c_getVersionInfo(): c_string;
+    extern proc c_getVersionInfo(): c_string_ptr;
     extern proc strlen(str): c_int;
     extern proc c_free_string(ptr);
     var cVersionString = c_getVersionInfo();
@@ -1295,7 +1295,7 @@ module ParquetMsg {
       var segarray_sizes: [0..#ncols] int; // track # of values in each column. Used to determine last segment size.
 
       var my_column_names = col_names;
-      var c_names: [0..#ncols] c_string;
+      var c_names: [0..#ncols] c_string_ptr;
 
       var segment_ct: [0..#ncols] int;
       var seg_sizes_str: [0..#ncols] int; // Track the sizes of string columns and # of segments in segarray str column

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -123,7 +123,7 @@ module ParquetMsg {
     var (subdoms, length) = getSubdomains(sizes);
     var fileOffsets = (+ scan sizes) - sizes;
     
-    coforall loc in A.targetLocales() do on loc {
+    coforall loc in A.targetLocales() with (ref A) do on loc {
       var locFiles = filenames;
       var locFiledoms = subdoms;
       var locOffsets = fileOffsets;
@@ -227,7 +227,7 @@ module ParquetMsg {
 
     var listSizes: [filenames.domain] int;
     var file_offset: int = 0;
-    coforall loc in seg_sizes.targetLocales() do on loc{
+    coforall loc in seg_sizes.targetLocales() with (ref listSizes) do on loc{
       var locFiles = filenames;
       var locFiledoms = subdoms;
       
@@ -250,7 +250,7 @@ module ParquetMsg {
 
     var byteSizes: [filenames.domain] int;
 
-    coforall loc in offsets.targetLocales() do on loc {
+    coforall loc in offsets.targetLocales() with (ref byteSizes) do on loc {
       var locFiles = filenames;
       var locFiledoms = subdoms;
       

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -118,7 +118,7 @@ module ParquetMsg {
     return (subdoms, (+ reduce lengths));
   }
 
-  proc readFilesByName(A: [] ?t, filenames: [] string, sizes: [] int, dsetname: string, ty) throws {
+  proc readFilesByName(ref A: [] ?t, filenames: [] string, sizes: [] int, dsetname: string, ty) throws {
     extern proc c_readColumnByName(filename, chpl_arr, colNum, numElems, startIdx, batchSize, errMsg): int;
     var (subdoms, length) = getSubdomains(sizes);
     var fileOffsets = (+ scan sizes) - sizes;
@@ -294,7 +294,7 @@ module ParquetMsg {
     }
   }
 
-  proc getStrColSize(filename: string, dsetname: string, offsets: [] int) throws {
+  proc getStrColSize(filename: string, dsetname: string, ref offsets: [] int) throws {
     extern proc c_getStringColumnNumBytes(filename, colname, offsets, numElems, startIdx, errMsg): int;
     var pqErr = new parquetErrorMsg();
 
@@ -309,7 +309,7 @@ module ParquetMsg {
     return byteSize;
   }
 
-  proc getListColSize(filename: string, dsetname: string, seg_sizes: [] int) throws {
+  proc getListColSize(filename: string, dsetname: string, ref seg_sizes: [] int) throws {
     extern proc c_getListColumnSize(filename, colname, seg_sizes, numElems, startIdx, errMsg): int;
     var pqErr = new parquetErrorMsg();
 
@@ -559,7 +559,7 @@ module ParquetMsg {
     return filesExist && mode == TRUNCATE;
   }
 
-  private proc writeStringsComponentToParquet(filename, dsetname, values: [] uint(8), offsets: [] int, rowGroupSize, compression, mode, filesExist) throws {
+  private proc writeStringsComponentToParquet(filename, dsetname, ref values: [] uint(8), ref offsets: [] int, rowGroupSize, compression, mode, filesExist) throws {
     extern proc c_writeStrColumnToParquet(filename, chpl_arr, chpl_offsets,
                                           dsetname, numelems, rowGroupSize,
                                           dtype, compression, errMsg): int;

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -13,6 +13,7 @@ module ParquetMsg {
   use Sort;
   use CommAggregation;
   use AryUtil;
+  use CTypes;
 
   use SegmentedString;
 

--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -22,6 +22,7 @@ module RadixSortLSD
     use RangeChunk;
     use Logging;
     use ServerConfig;
+    use ArkoudaBlockCompat;
 
     private config const logLevel = ServerConfig.logLevel;
     private config const logChannel = ServerConfig.logChannel;
@@ -69,7 +70,7 @@ module RadixSortLSD
         var temp = a;
         
         // create a global count array to scan
-        var gD = Block.createDomain({0..#(numLocales * numTasks * numBuckets)});
+        var gD = blockDist.createDomain({0..#(numLocales * numTasks * numBuckets)});
         var globalCounts: [gD] int;
         
         // loop over digits

--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -63,7 +63,7 @@ module RadixSortLSD
        In-place radix sort a block distributed array
        comparator is used to extract the key from array elements
      */
-    private proc radixSortLSDCore(a:[?aD] ?t, nBits, negs, comparator) {
+    private proc radixSortLSDCore(ref a:[?aD] ?t, nBits, negs, comparator) {
         try! rsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                        "type = %s nBits = %?".doFormat(t:string,nBits));
         var temp = a;

--- a/src/RandArray.chpl
+++ b/src/RandArray.chpl
@@ -16,7 +16,7 @@ module RandArray {
   private config const logChannel = ServerConfig.logChannel;
   const raLogger = new Logger(logLevel, logChannel);
 
-  proc fillInt(a:[] ?t, const aMin: t, const aMax: t, const seedStr:string="None") throws where isIntType(t) {
+  proc fillInt(ref a:[] ?t, const aMin: t, const aMax: t, const seedStr:string="None") throws where isIntType(t) {
       if (seedStr.toLower() == "none") {
         //Subtracting 1 from aMax to make the value exclusive to follow numpy standard.
         fillRandom(a, aMin, aMax-1);
@@ -27,7 +27,7 @@ module RandArray {
       }
   }
 
-  proc fillUInt(a:[] ?t, const aMin: t, const aMax: t, const seedStr:string="None") throws where isUintType(t) {
+  proc fillUInt(ref a:[] ?t, const aMin: t, const aMax: t, const seedStr:string="None") throws where isUintType(t) {
       if (seedStr.toLower() == "none") {
         //Subtracting 1 from aMax to make the value exclusive to follow numpy standard.
         fillRandom(a, aMin, aMax-1);
@@ -38,7 +38,7 @@ module RandArray {
       }
   }
 
-  proc fillReal(a:[] real, const aMin:numeric=0.0, const aMax:numeric=1.0, const seedStr:string="None") throws {
+  proc fillReal(ref a:[] real, const aMin:numeric=0.0, const aMax:numeric=1.0, const seedStr:string="None") throws {
     if (seedStr.toLower() == "none") {
       fillRandom(a, aMin, aMax);
     } else {
@@ -47,7 +47,7 @@ module RandArray {
     }
   }
 
-  proc fillBool(a:[] bool, const seedStr:string="None") throws {
+  proc fillBool(ref a:[] bool, const seedStr:string="None") throws {
     if (seedStr.toLower() == "none") {
       fillRandom(a);
     } else {
@@ -56,7 +56,7 @@ module RandArray {
     }
   }
 
-  proc fillNormal(a:[?D] real, const seedStr:string="None") throws {
+  proc fillNormal(ref a:[?D] real, const seedStr:string="None") throws {
     var u1:[D] real;
     var u2:[D] real;
     if (seedStr.toLower() == "none") {

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -19,7 +19,7 @@ module ReductionMsg
     use AryUtil;
     use PrivateDist;
     use RadixSortLSD;
-    use ArkoudaMathCompat
+    use ArkoudaMathCompat;
 
     private config const lBins = 2**25 * numLocales;
 
@@ -96,7 +96,7 @@ module ReductionMsg
                     }
                     when "is_locally_sorted" {
                       var locSorted: [LocaleSpace] bool;
-                      coforall loc in Locales {
+                      coforall loc in Locales with (ref locSorted) {
                         on loc {
                           ref myA = e.a[e.a.localSubdomain()];
                           locSorted[here.id] = isSorted(myA);

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -20,6 +20,7 @@ module ReductionMsg
     use PrivateDist;
     use RadixSortLSD;
     use ArkoudaMathCompat;
+    use ArkoudaBlockCompat;
 
     private config const lBins = 2**25 * numLocales;
 
@@ -1372,7 +1373,7 @@ module ReductionMsg
       var count: [kD] int = (+ scan truth);
       var pop = count[kD.high];
       // find steps to get unique (key, val) pairs
-      var hD: domain(1) dmapped Block(boundingBox={0..#pop}) = {0..#pop};
+      var hD: domain(1) dmapped blockDist(boundingBox={0..#pop}) = {0..#pop};
       // save off only the key from each pair (now there will be nunique of each key)
       var keyhits: [hD] int;
       forall i in truth.domain with (var agg = newDstAggregator(int)) {
@@ -1393,7 +1394,7 @@ module ReductionMsg
       overMemLimit(numBytes(int) * truth2.size);
       var kiv: [hD] int = (+ scan truth2);
       var nKeysPresent = kiv[hD.high];
-      var nD: domain(1) dmapped Block(boundingBox={0..#(nKeysPresent+1)}) = {0..#(nKeysPresent+1)};
+      var nD: domain(1) dmapped blockDist(boundingBox={0..#(nKeysPresent+1)}) = {0..#(nKeysPresent+1)};
       // get step indices and take diff to get number of times each key appears
       var stepInds: [nD] int;
       stepInds[nKeysPresent] = keyhits.size;

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -805,7 +805,7 @@ module ReductionMsg
       return res;
     }
 
-    proc segVar(values:[?vD] ?t, segments:[?D] int, ddof:int, skipNan=false): [D] real throws {
+    proc segVar(ref values:[?vD] ?t, segments:[?D] int, ddof:int, skipNan=false): [D] real throws {
       var res: [D] real;
       if D.size == 0 { return res; }
 
@@ -829,12 +829,12 @@ module ReductionMsg
       return res;
     }
 
-    proc segStd(values:[] ?t, segments:[?D] int, ddof:int, skipNan=false): [D] real throws {
+    proc segStd(ref values:[] ?t, segments:[?D] int, ddof:int, skipNan=false): [D] real throws {
       if D.size == 0 { return [D] 0.0; }
       return sqrt(segVar(values, segments, ddof, skipNan));
     }
 
-    proc segMean(values:[] ?t, segments:[?D] int, skipNan=false): [D] real throws {
+    proc segMean(ref values:[] ?t, segments:[?D] int, skipNan=false): [D] real throws {
       var res: [D] real;
       if (D.size == 0) { return res; }
       // convert to real early to avoid int overflow
@@ -861,7 +861,7 @@ module ReductionMsg
       return res;
     }
 
-    proc segMedian(values:[?vD] ?intype, segments:[?D] int, skipNan=false): [D] real throws {
+    proc segMedian(ref values:[?vD] ?intype, segments:[?D] int, skipNan=false): [D] real throws {
       type t = if intype == bool then int else intype;
       var res: [D] real;
       if (D.size == 0) { return res; }

--- a/src/SegStringSort.chpl
+++ b/src/SegStringSort.chpl
@@ -108,12 +108,12 @@ module SegStringSort {
       const NBINS = 2**16;
       const BINDOM = {0..#NBINS};
       var pBins: [PrivateSpace][BINDOM] int;
-      coforall loc in Locales {
+      coforall loc in Locales with (ref pBins) {
         on loc {
           const lD = D.localSubdomain();
           ref locLengths = lengths.localSlice[lD];
           var locBins: [0..#numTasks][BINDOM] int;
-          coforall task in 0..#numTasks {
+          coforall task in 0..#numTasks with (ref locBins) {
             const tD = calcBlock(task, lD.low, lD.high);
             for i in tD {
               var bin = min(locLengths[i], NBINS-1);
@@ -233,9 +233,9 @@ module SegStringSort {
     for rshift in {2..#pivot by 2} {
       ssLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"rshift = %?".doFormat(rshift));
       // count digits
-      coforall loc in Locales {
+      coforall loc in Locales with (ref globalCounts) {
         on loc {
-          coforall task in 0..#numTasks {
+          coforall task in 0..#numTasks with (ref globalCounts) {
             // bucket domain
             var bD = {0..#numBuckets};
             // allocate counts
@@ -268,9 +268,9 @@ module SegStringSort {
       globalStarts = globalStarts - globalCounts;
             
       // calc new positions and permute
-      coforall loc in Locales {
+      coforall loc in Locales with (ref kr0, ref kr1) {
         on loc {
-          coforall task in 0..#numTasks {
+          coforall task in 0..#numTasks with (ref kr0, ref kr1) {
             // bucket domain
             var bD = {0..#numBuckets};
             // allocate counts

--- a/src/SegStringSort.chpl
+++ b/src/SegStringSort.chpl
@@ -12,6 +12,7 @@ module SegStringSort {
   use BlockDist;
 
   use ArkoudaStringBytesCompat;
+  use ArkoudaBlockCompat;
 
   private config const SSS_v = false;
   private const vv = SSS_v;
@@ -225,7 +226,7 @@ module SegStringSort {
     }
     var kr1: [aD] state;
     // create a global count array to scan
-    var gD = Block.createDomain({0..#(numLocales * numTasks * numBuckets)});
+    var gD = blockDist.createDomain({0..#(numLocales * numTasks * numBuckets)});
     var globalCounts: [gD] int;
     var globalStarts: [gD] int;
         

--- a/src/SegmentedComputation.chpl
+++ b/src/SegmentedComputation.chpl
@@ -61,7 +61,7 @@ module SegmentedComputation {
     const (startSegInds, numSegs, lengths) = computeSegmentOwnership(segments, vD);
     
     // Start task parallelism
-    coforall loc in Locales {
+    coforall loc in Locales with (ref res, ref values) {
       on loc {
         const myFirstSegIdx = startSegInds[loc.id];
         const myNumSegs = max(0, numSegs[loc.id]);
@@ -140,7 +140,7 @@ module SegmentedComputation {
     const (startSegInds, numSegs, lengths) = computeSegmentOwnership(segments, vD);
 
     // Start task parallelism
-    coforall loc in Locales {
+    coforall loc in Locales with (ref values, ref res) {
       on loc {
         const myFirstSegIdx = startSegInds[loc.id];
         const myNumSegs = max(0, numSegs[loc.id]);

--- a/src/SegmentedComputation.chpl
+++ b/src/SegmentedComputation.chpl
@@ -51,7 +51,7 @@ module SegmentedComputation {
     StringBytesToUintArr,
   }
   
-  proc computeOnSegments(segments: [?D] int, values: [?vD] ?t, param function: SegFunction, type retType, const strArg: string = "") throws {
+  proc computeOnSegments(segments: [?D] int, ref values: [?vD] ?t, param function: SegFunction, type retType, const strArg: string = "") throws {
     // type retType = if (function == SegFunction.StringToNumericReturnValidity) then (outType, bool) else outType;
     var res: [D] retType;
     if (D.size == 0) {
@@ -130,7 +130,7 @@ module SegmentedComputation {
     return res;
   }
 
-  proc computeOnSegmentsWithoutAggregation(segments: [?D] int, values: [?vD] ?t, param function: SegFunction, type retType, const strArg: string = "") throws {
+  proc computeOnSegmentsWithoutAggregation(segments: [?D] int, ref values: [?vD] ?t, param function: SegFunction, type retType, const strArg: string = "") throws {
     // perform computeOnSegments logic for types that dont support aggregation (namely bigint)
     var res: [D] retType;
     if (D.size == 0) {

--- a/src/SegmentedString.chpl
+++ b/src/SegmentedString.chpl
@@ -208,7 +208,7 @@ module SegmentedString {
       return (newSegs, newVals);
     }
 
-    proc this(const slice: stridableRange()) throws {
+    proc this(const slice: stridableRange) throws {
       var aa = makeDistArray(slice.size, int);
       forall (elt,j) in zip(aa, slice) with (var agg = newSrcAggregator(int)) {
         agg.copy(elt,j);

--- a/src/SegmentedString.chpl
+++ b/src/SegmentedString.chpl
@@ -74,7 +74,7 @@ module SegmentedString {
       return getSegString(offs.a, vals.a, st);
   }
 
-  proc assembleSegStringFromParts(offsets:SymEntry, values:SymEntry, st:borrowed SymTab): owned SegString throws {
+  proc assembleSegStringFromParts(offsets:SymEntry(int), values:SymEntry(uint(8)), st:borrowed SymTab): owned SegString throws {
       var stringsEntry = new shared SegStringSymEntry(offsets, values, string);
       var name = st.nextName();
       st.addEntry(name, stringsEntry);

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -243,8 +243,8 @@ module ServerConfig
     */ 
     proc getPhysicalMemHere() {
         use ArkoudaMemDiagnosticsCompat, ArkoudaCTypesCompat;
-        extern proc chpl_comm_regMemHeapInfo(start: c_ptr(c_void_ptr), size: c_ptr(c_size_t)): void;
-        var unused: c_void_ptr;
+        extern proc chpl_comm_regMemHeapInfo(start: c_ptr(c_ptr_void), size: c_ptr(c_size_t)): void;
+        var unused: c_ptr_void;
         var heap_size: c_size_t;
         chpl_comm_regMemHeapInfo(c_ptrTo(unused), c_ptrTo(heap_size));
         if heap_size != 0 then

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -13,6 +13,7 @@ module ServerConfig
     use ServerErrors;
     use Logging;
     use MemoryMgmt;
+    use CTypes;
 
     use ArkoudaFileCompat;
     private use ArkoudaCTypesCompat;

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -231,7 +231,7 @@ module ServerConfig
     }
 
     proc getEnv(name: string, default=""): string {
-        extern proc getenv(name : c_string) : c_string;
+        extern proc getenv(name : c_string_ptr) : c_string_ptr;
         var val = getenv(name.localize().c_str()): string;
         if val.isEmpty() { val = default; }
         return val;
@@ -436,8 +436,9 @@ module ServerConfig
     }
 
     proc getEnvInt(name: string, default: int): int {
-      extern proc getenv(name : c_string) : c_string;
-      var strval = getenv(name.localize().c_str()): string;
+      extern proc getenv(name) : c_string_ptr;
+      var strval:string;
+      try! strval = string.createCopyingBuffer(getenv(name.localize().c_str()));
       if strval.isEmpty() { return default; }
       return try! strval: int;
     }

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -17,6 +17,7 @@ module ServerConfig
 
     use ArkoudaFileCompat;
     private use ArkoudaCTypesCompat;
+    use ArkoudaStringBytesCompat;
     
     enum Deployment {STANDARD,KUBERNETES}
 

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -256,12 +256,8 @@ module ServerConfig
     Get the byteorder (endianness) of this locale
     */
     proc getByteorder() throws {
-        use IO;
-        var writeVal = 1, readVal = 0;
-        var tmpf = openMemFile();
-        tmpf.writer(kind=iobig).write(writeVal);
-        tmpf.reader(kind=ionative).read(readVal);
-        return if writeVal == readVal then "big" else "little";
+      use ArkoudaIOCompat;
+      return getByteOrderCompat();
     }
 
     /*

--- a/src/SipHash.chpl
+++ b/src/SipHash.chpl
@@ -89,7 +89,7 @@ module SipHash {
     return res;
   }
 
-  proc sipHash128(msg: [] ?t, D): 2*uint(64) where ((t == uint(8)) ||
+  proc sipHash128(ref msg: [] ?t, D): 2*uint(64) where ((t == uint(8)) ||
                                                     (t == int(64)) ||
                                                     (t == real(64))) {
     return computeSipHashLocalized(msg, D, 16);
@@ -107,7 +107,7 @@ module SipHash {
     return computeSipHash(c_ptrTo(val), 0..#1, 16, 8);
   }
   
-  private proc computeSipHashLocalized(msg: [] ?t, region: range(?), param outlen: int) {
+  private proc computeSipHashLocalized(ref msg: [] ?t, region: range(?), param outlen: int) {
     const localSlice = new lowLevelLocalizingSlice(msg, region);
     return computeSipHash(localSlice.ptr, 0..#region.size, outlen, numBytes(t));
   }

--- a/src/Stats.chpl
+++ b/src/Stats.chpl
@@ -1,23 +1,23 @@
 module Stats {
     use AryUtil;
 
-    proc mean(ar: [?aD] ?t): real throws {
+    proc mean(ref ar: [?aD] ?t): real throws {
         return (+ reduce ar:real) / aD.size:real;
     }
 
-    proc variance(ar: [?aD] ?t, ddof: int): real throws {
+    proc variance(ref ar: [?aD] ?t, ddof: int): real throws {
         return (+ reduce ((ar:real - mean(ar)) ** 2)) / (aD.size - ddof):real;
     }
 
-    proc std(ar: [?aD] ?t, ddof: int): real throws {
+    proc std(ref ar: [?aD] ?t, ddof: int): real throws {
         return sqrt(variance(ar, ddof));
     }
 
-    proc cov(ar1: [?aD1] ?t1, ar2: [?aD2] ?t2): real throws {
+    proc cov(ref ar1: [?aD1] ?t1, ref ar2: [?aD2] ?t2): real throws {
         return (+ reduce ((ar1:real - mean(ar1)) * (ar2:real - mean(ar2)))) / (aD1.size - 1):real;
     }
 
-    proc corr(ar1: [?aD1] ?t1, ar2: [?aD2] ?t2): real throws {
+    proc corr(ref ar1: [?aD1] ?t1, ref ar2: [?aD2] ?t2): real throws {
         return cov(ar1, ar2) / (std(ar1, 1) * std(ar2, 1));
     }
 }

--- a/src/TimeClassMsg.chpl
+++ b/src/TimeClassMsg.chpl
@@ -104,7 +104,7 @@ module TimeClassMsg {
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 
-    proc simpleAttributesHelper(values: [?aD] ?t, st: borrowed SymTab): map throws {
+    proc simpleAttributesHelper(values: [?aD] ?t, st: borrowed SymTab): map(string, string) throws {
         var attributesDict = new map(keyType=string, valType=string);
         var denominator = 1;
         for (u, f) in zip(UNITS, FACTORS) {

--- a/src/TimeClassMsg.chpl
+++ b/src/TimeClassMsg.chpl
@@ -58,8 +58,8 @@ module TimeClassMsg {
 
         forall (v, y, m, d, iso_y, is_ly, woy, doy, dow) in zip(valuesEntry.a, year, month, day, isoYear, is_leap_year, weekOfYear, dayOfYear, dayOfWeek) {
             // convert to seconds and create date
-            var t = date.createFromTimestamp(floorDivisionHelper(v, 10**9):int);
-            (y, m, d, (iso_y, woy, dow)) = (t.year, t.month, t.day, t.isoCalendar());
+            var t = createFromTimestampCompat(floorDivisionHelper(v, 10**9):int);
+            (y, m, d, (iso_y, woy, dow)) = (t.year, t.month, t.day, t.isoWeekDate());
             dow -= 1;
             is_ly = isLeapYear(y);
             doy = MONTHOFFSET[is_ly * 13 + m - 1] + d;

--- a/src/TransferMsg.chpl
+++ b/src/TransferMsg.chpl
@@ -16,6 +16,7 @@ module TransferMsg
     use SegmentedString;
     use ArkoudaListCompat;
     use ArkoudaStringBytesCompat;
+    use ArkoudaCTypesCompat;
 
     proc sendDataFrameSetupInfo(port:string, numColumns: int, elements: string) throws {
       var context: Context;

--- a/src/TransferMsg.chpl
+++ b/src/TransferMsg.chpl
@@ -801,7 +801,7 @@ module TransferMsg
       return (size, typeString, nodeNames, objType);
     }
 
-    proc sendArrChunk(port: int, A: [] ?t, intersection: domain(1)) throws {
+    proc sendArrChunk(port: int, ref A: [] ?t, intersection: domain(1)) throws {
       var context: Context;
       var socket = context.socket(ZMQ.PUSH);
       socket.bind("tcp://*:"+port:string);

--- a/src/TransferMsg.chpl
+++ b/src/TransferMsg.chpl
@@ -819,7 +819,7 @@ module TransferMsg
       else
         socket.connect("tcp://"+hostname+":"+port:string);
       var locData = socket.recv(bytes);
-      var locArr = makeArrayFromPtr(locData.c_str():c_void_ptr:c_ptr(t), intersection.size:uint);
+      var locArr = makeArrayFromPtr(locData.c_str():c_ptr_void:c_ptr(t), intersection.size:uint);
       A[intersection] = locArr;
     }
 
@@ -899,7 +899,7 @@ module TransferMsg
     }
 
     proc bytesToLocArray(size:int, type t, ref data:bytes) throws {
-      var res = makeArrayFromPtr(data.c_str():c_void_ptr:c_ptr(t), size:uint);
+      var res = makeArrayFromPtr(data.c_str():c_ptr_void:c_ptr(t), size:uint);
       return res;
     }
     

--- a/src/TransferMsg.chpl
+++ b/src/TransferMsg.chpl
@@ -56,7 +56,7 @@ module TransferMsg
 
       var localeCount = receiveLocaleCount(hostname, port:string);
       
-      sendDataFrameSetupInfo(port:string, numColumns, eleList: string);
+      sendDataFrameSetupInfo(port:string, numColumns, formatString(eleList));
 
       var colNames = "";
       for ele in eleList {

--- a/src/asd.chpl
+++ b/src/asd.chpl
@@ -1,0 +1,8 @@
+use AryUtil;
+
+var values: [0..10] int;
+var res: [0..10] int;
+
+coforall loc in Locales with (ref values, ref res) {
+  var slice = new lowLevelLocalizingSlice(values, start..#len);
+}

--- a/src/asd.chpl
+++ b/src/asd.chpl
@@ -1,8 +1,0 @@
-use AryUtil;
-
-var values: [0..10] int;
-var res: [0..10] int;
-
-coforall loc in Locales with (ref values, ref res) {
-  var slice = new lowLevelLocalizingSlice(values, start..#len);
-}

--- a/src/compat/e-130/ArkoudaAggCompat.chpl
+++ b/src/compat/e-130/ArkoudaAggCompat.chpl
@@ -1,0 +1,5 @@
+module ArkoudaAggCompat {
+  proc yieldTask() {
+    chpl_task_yield();
+  }
+}

--- a/src/compat/e-130/ArkoudaBlockCompat.chpl
+++ b/src/compat/e-130/ArkoudaBlockCompat.chpl
@@ -1,4 +1,5 @@
 module ArkoudaBlockCompat {
+
   use BlockDist;
 
   type blockDist = Block;

--- a/src/compat/e-130/ArkoudaCTypesCompat.chpl
+++ b/src/compat/e-130/ArkoudaCTypesCompat.chpl
@@ -58,4 +58,6 @@ module ArkoudaCTypesCompat {
   inline proc deallocate(data: c_void_ptr) {
     chpl_here_free(data);
   }
+
+  type c_string_ptr = c_string;
 }

--- a/src/compat/e-130/ArkoudaCTypesCompat.chpl
+++ b/src/compat/e-130/ArkoudaCTypesCompat.chpl
@@ -60,4 +60,5 @@ module ArkoudaCTypesCompat {
   }
 
   type c_string_ptr = c_string;
+  type c_ptr_void = c_void_ptr;
 }

--- a/src/compat/e-130/ArkoudaIOCompat.chpl
+++ b/src/compat/e-130/ArkoudaIOCompat.chpl
@@ -56,4 +56,12 @@ module ArkoudaIOCompat {
     tmpf.reader(kind=ionative).read(readVal);
     return if writeVal == readVal then "big" else "little";
   }
+
+  proc fileIOReaderCompat(infile) throws {
+    return infile.reader(kind=ionative);
+  }
+
+  proc binaryCheckCompat(reader) throws {
+    return reader.binary();
+  }
 }

--- a/src/compat/e-130/ArkoudaIOCompat.chpl
+++ b/src/compat/e-130/ArkoudaIOCompat.chpl
@@ -47,4 +47,13 @@ module ArkoudaIOCompat {
     var nreader = f.reader();
     nreader.readf("%jt", obj);
   }
+
+  proc getByteOrderCompat() throws {
+    use IO;
+    var writeVal = 1, readVal = 0;
+    var tmpf = openMemFile();
+    tmpf.writer(kind=iobig).write(writeVal);
+    tmpf.reader(kind=ionative).read(readVal);
+    return if writeVal == readVal then "big" else "little";
+  }
 }

--- a/src/compat/e-130/ArkoudaMathCompat.chpl
+++ b/src/compat/e-130/ArkoudaMathCompat.chpl
@@ -1,0 +1,7 @@
+module ArkoudaMathCompat {
+  inline proc nan param : real(64) do return chpl_NAN;
+  inline proc inf param : real(64) do return chpl_INFINITY;
+
+  inline proc isNan(x: real(64)): bool do return isnan(x);
+  inline proc isInf(x: real(64)): bool do return isinf(x);
+}

--- a/src/compat/e-130/ArkoudaSymEntryCompat.chpl
+++ b/src/compat/e-130/ArkoudaSymEntryCompat.chpl
@@ -1,0 +1,28 @@
+module ArkoudaSymEntryCompat {
+  use MultiTypeSymEntry;
+  use Map;
+
+  type SymEntryAny = SymEntry;
+  type mapAny = map;
+
+  override proc SymEntry.writeThis(f) throws {
+    use Reflection;
+    proc writeField(f, param i) throws {
+      if !isArray(getField(this, i)) {
+        f.write(getFieldName(this.type, i), " = ", getField(this, i):string);
+      } else {
+        f.write(getFieldName(this.type, i), " = ", formatAry(getField(this, i)));
+      }
+    }
+
+    super.writeThis(f);
+    f.write(" {");
+    param nFields = numFields(this.type);
+    for param i in 0..nFields-2 {
+      writeField(f, i);
+      f.write(", ");
+    }
+    writeField(f, nFields-1);
+    f.write("}");
+  }
+}

--- a/src/compat/e-130/ArkoudaTimeCompat.chpl
+++ b/src/compat/e-130/ArkoudaTimeCompat.chpl
@@ -144,6 +144,10 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       return c_string; // const char *
   }
 
+  proc createFromTimestampCompat(d) {
+    return date.createFromTimestamp(d);
+  }
+  
   /* Get the `time` since Unix Epoch in seconds
   */
   proc timeSinceEpoch(): timedelta {
@@ -307,6 +311,9 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
   }
 
+  proc isoWeekDate() {
+    return this.isoCalendar();
+  }
 
   /* initializers/factories for date values */
 

--- a/src/compat/e-130/ArkoudaTimeCompat.chpl
+++ b/src/compat/e-130/ArkoudaTimeCompat.chpl
@@ -309,10 +309,10 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     proc type resolution {
       return new timedelta(days=1);
     }
-  }
 
-  proc isoWeekDate() {
-    return this.isoCalendar();
+    proc isoWeekDate() {
+      return this.isoCalendar();
+    }
   }
 
   /* initializers/factories for date values */

--- a/src/compat/eq-131/ArkoudaAggCompat.chpl
+++ b/src/compat/eq-131/ArkoudaAggCompat.chpl
@@ -1,0 +1,5 @@
+module ArkoudaAggCompat {
+  proc yieldTask() {
+    chpl_task_yield();
+  }
+}

--- a/src/compat/eq-131/ArkoudaCTypesCompat.chpl
+++ b/src/compat/eq-131/ArkoudaCTypesCompat.chpl
@@ -1,3 +1,4 @@
 module ArkoudaCTypesCompat {
   public use CTypes;
+  type c_string_ptr = c_string;
 }

--- a/src/compat/eq-131/ArkoudaCTypesCompat.chpl
+++ b/src/compat/eq-131/ArkoudaCTypesCompat.chpl
@@ -1,4 +1,5 @@
 module ArkoudaCTypesCompat {
   public use CTypes;
   type c_string_ptr = c_string;
+  type c_ptr_void = c_void_ptr;
 }

--- a/src/compat/eq-131/ArkoudaIOCompat.chpl
+++ b/src/compat/eq-131/ArkoudaIOCompat.chpl
@@ -56,4 +56,12 @@ module ArkoudaIOCompat {
     tmpf.reader(kind=ionative).read(readVal);
     return if writeVal == readVal then "big" else "little";
   }
+
+  proc fileIOReaderCompat(infile) throws {
+    return infile.reader(kind=ionative);
+  }
+
+  proc binaryCheckCompat(reader) throws {
+    return reader.binary();
+  }
 }

--- a/src/compat/eq-131/ArkoudaIOCompat.chpl
+++ b/src/compat/eq-131/ArkoudaIOCompat.chpl
@@ -47,4 +47,13 @@ module ArkoudaIOCompat {
     var nreader = f.reader();
     nreader.readf("%jt", obj);
   }
+
+  proc getByteOrderCompat() throws {
+    use IO;
+    var writeVal = 1, readVal = 0;
+    var tmpf = openMemFile();
+    tmpf.writer(kind=iobig).write(writeVal);
+    tmpf.reader(kind=ionative).read(readVal);
+    return if writeVal == readVal then "big" else "little";
+  }
 }

--- a/src/compat/eq-131/ArkoudaMathCompat.chpl
+++ b/src/compat/eq-131/ArkoudaMathCompat.chpl
@@ -1,0 +1,7 @@
+module ArkoudaMathCompat {
+  inline proc nan param : real(64) do return chpl_NAN;
+  inline proc inf param : real(64) do return chpl_INFINITY;
+
+  inline proc isNan(x: real(64)): bool do return isnan(x);
+  inline proc isInf(x: real(64)): bool do return isinf(x);
+}

--- a/src/compat/eq-131/ArkoudaSymEntryCompat.chpl
+++ b/src/compat/eq-131/ArkoudaSymEntryCompat.chpl
@@ -1,0 +1,28 @@
+module ArkoudaSymEntryCompat {
+  use MultiTypeSymEntry;
+  use Map;
+
+  type SymEntryAny = SymEntry;
+  type mapAny = map;
+
+  override proc SymEntry.writeThis(f) throws {
+    use Reflection;
+    proc writeField(f, param i) throws {
+      if !isArray(getField(this, i)) {
+        f.write(getFieldName(this.type, i), " = ", getField(this, i):string);
+      } else {
+        f.write(getFieldName(this.type, i), " = ", formatAry(getField(this, i)));
+      }
+    }
+
+    super.writeThis(f);
+    f.write(" {");
+    param nFields = numFields(this.type);
+    for param i in 0..nFields-2 {
+      writeField(f, i);
+      f.write(", ");
+    }
+    writeField(f, nFields-1);
+    f.write("}");
+  }
+}

--- a/src/compat/eq-131/ArkoudaTimeCompat.chpl
+++ b/src/compat/eq-131/ArkoudaTimeCompat.chpl
@@ -1,3 +1,11 @@
 module ArkoudaTimeCompat {
   public use Time;
+
+  proc createFromTimestampCompat(d) {
+    return date.createFromTimestamp(d);
+  }
+
+  proc date.isoWeekDate() {
+    return this.isoCalendar();
+  }
 }

--- a/src/compat/gt-131/ArkoudaAggCompat.chpl
+++ b/src/compat/gt-131/ArkoudaAggCompat.chpl
@@ -1,0 +1,5 @@
+module ArkoudaAggCompat {
+  proc yieldTask() {
+    currentTask.yieldExecution();
+  }
+}

--- a/src/compat/gt-131/ArkoudaCTypesCompat.chpl
+++ b/src/compat/gt-131/ArkoudaCTypesCompat.chpl
@@ -11,7 +11,7 @@ module ArkoudaCTypesCompat {
   public use ChapelSysCTypes;
 
   // Redefine c_void_ptr to a usable form, without deprecation warning.
-  type c_void_ptr = c_ptr(void);
+  type c_ptr_void = c_ptr(void);
 
   type c_string_ptr = c_ptrConst(c_char);
 }

--- a/src/compat/gt-131/ArkoudaCTypesCompat.chpl
+++ b/src/compat/gt-131/ArkoudaCTypesCompat.chpl
@@ -12,4 +12,6 @@ module ArkoudaCTypesCompat {
 
   // Redefine c_void_ptr to a usable form, without deprecation warning.
   type c_void_ptr = c_ptr(void);
+
+  type c_string_ptr = c_ptrConst(c_char);
 }

--- a/src/compat/gt-131/ArkoudaIOCompat.chpl
+++ b/src/compat/gt-131/ArkoudaIOCompat.chpl
@@ -58,4 +58,12 @@ module ArkoudaIOCompat {
     tmpf.reader(deserializer=new binaryDeserializer(endian=ioendian.native)).read(readVal);
     return if writeVal == readVal then "big" else "little";
   }
+
+  proc fileIOReaderCompat(infile) throws {
+    return infile.reader(deserializer=new binarySerializer(endian=ioendian.native));
+  }
+
+  proc binaryCheckCompat(reader) throws {
+    return reader.deserializerType == binarySerializer;
+  }
 }

--- a/src/compat/gt-131/ArkoudaIOCompat.chpl
+++ b/src/compat/gt-131/ArkoudaIOCompat.chpl
@@ -7,13 +7,13 @@ module ArkoudaIOCompat {
 
   proc formatJson(input): string throws {
     var f = openMemFile();
-    f.writer(serializer = new JsonSerializer()).write(input);
+    f.writer(serializer = new jsonSerializer()).write(input);
     return f.reader().readAll(string);
   }
 
   proc formatJson(input:string, vals...?): string throws {
     var f = openMemFile();
-    f.writer(serializer = new JsonSerializer()).writef(input, (...vals));
+    f.writer(serializer = new jsonSerializer()).writef(input, (...vals));
     return f.reader().readAll(string);
   }
 
@@ -26,7 +26,7 @@ module ArkoudaIOCompat {
     var w = f.writer();
     w.write(json);
     w.close();
-    var r = f.reader(deserializer=new JsonDeserializer());
+    var r = f.reader(deserializer=new jsonDeserializer());
     var tup: t;
     r.readf("%?", tup);
     r.close();
@@ -38,7 +38,7 @@ module ArkoudaIOCompat {
     var w = f.writer();
     w.write(json);
     w.close();
-    var r = f.reader(deserializer=new JsonDeserializer());
+    var r = f.reader(deserializer=new jsonDeserializer());
     var array: [0..#size] string;
     r.readf("%?", array);
     r.close();
@@ -46,7 +46,7 @@ module ArkoudaIOCompat {
   }
 
   proc readfCompat(f: file, str: string, ref obj) throws {
-    var nreader = f.reader(deserializer=new JsonDeserializer());
+    var nreader = f.reader(deserializer=new jsonDeserializer());
     nreader.readf("%?", obj);
   }
 

--- a/src/compat/gt-131/ArkoudaIOCompat.chpl
+++ b/src/compat/gt-131/ArkoudaIOCompat.chpl
@@ -49,4 +49,13 @@ module ArkoudaIOCompat {
     var nreader = f.reader(deserializer=new JsonDeserializer());
     nreader.readf("%?", obj);
   }
+
+  proc getByteOrderCompat() throws {
+    use IO;
+    var writeVal = 1, readVal = 0;
+    var tmpf = openMemFile();
+    tmpf.writer(serializer = new binarySerializer(endian=ioendian.big)).write(writeVal);
+    tmpf.reader(deserializer=new binaryDeserializer(endian=ioendian.native)).read(readVal);
+    return if writeVal == readVal then "big" else "little";
+  }
 }

--- a/src/compat/gt-131/ArkoudaMathCompat.chpl
+++ b/src/compat/gt-131/ArkoudaMathCompat.chpl
@@ -1,0 +1,1 @@
+module ArkoudaMathCompat {}

--- a/src/compat/gt-131/ArkoudaSymEntryCompat.chpl
+++ b/src/compat/gt-131/ArkoudaSymEntryCompat.chpl
@@ -1,0 +1,31 @@
+module ArkoudaSymEntryCompat {
+  use MultiTypeSymEntry;
+  use Map;
+
+  type SymEntryAny = SymEntry(?);
+  type mapAny = map(?);
+
+  override proc SymEntry.serialize(writer, ref serializer) throws {
+    use Reflection;
+    var f = writer;
+    proc writeField(f, param i) throws {
+      if !isArray(getField(this, i)) {
+        f.write(getFieldName(this.type, i), " = ", getField(this, i):string);
+      } else {
+        f.write(getFieldName(this.type, i), " = ", formatAry(getField(this, i)));
+      }
+    }
+
+    super.writeThis(f);
+    f.write(" {");
+    param nFields = numFields(this.type);
+    for param i in 0..nFields-2 {
+      writeField(f, i);
+      f.write(", ");
+    }
+    writeField(f, nFields-1);
+    f.write("}");
+  }
+
+  implements writeSerializable(SymEntry);
+}

--- a/src/compat/gt-131/ArkoudaTimeCompat.chpl
+++ b/src/compat/gt-131/ArkoudaTimeCompat.chpl
@@ -1,3 +1,7 @@
 module ArkoudaTimeCompat {
   public use Time;
+
+  proc createFromTimestampCompat(d) {
+    return dateTime.createUtcFromTimestamp(d).getDate();
+  }
 }

--- a/src/compat/gt-131/SymArrayDmapCompat.chpl
+++ b/src/compat/gt-131/SymArrayDmapCompat.chpl
@@ -32,10 +32,10 @@ module SymArrayDmapCompat
             }
             when Dmap.blockDist {
                 if size > 0 {
-                    return {0..#size} dmapped Block(boundingBox={0..#size});
+                    return {0..#size} dmapped blockDist(boundingBox={0..#size});
                 }
                 // fix the annoyance about boundingBox being enpty
-                else {return {0..#0} dmapped Block(boundingBox={0..0});}
+                else {return {0..#0} dmapped blockDist(boundingBox={0..0});}
             }
             otherwise {
                 halt("Unsupported distribution " + MyDmap:string);

--- a/src/iconv.chpl
+++ b/src/iconv.chpl
@@ -8,17 +8,17 @@ require "iconv.h";
 use ArkoudaCTypesCompat;
 extern var _libiconv_version : c_int;
 
-extern proc libiconv_open(tocode : c_string, fromcode : c_string) : libiconv_t;
+extern proc libiconv_open(tocode : c_string_ptr, fromcode : c_string_ptr) : libiconv_t;
 
-extern proc libiconv(cd : libiconv_t, ref inbuf : c_string, ref inbytesleft : c_size_t, ref outbuf : c_string, ref outbytesleft : c_size_t) : c_size_t;
+extern proc libiconv(cd : libiconv_t, ref inbuf : c_string_ptr, ref inbytesleft : c_size_t, ref outbuf : c_string_ptr, ref outbytesleft : c_size_t) : c_size_t;
 
-extern proc libiconv(cd : libiconv_t, inbuf : c_ptr(c_string), inbytesleft : c_ptr(c_size_t), outbuf : c_ptr(c_string), outbytesleft : c_ptr(c_size_t)) : c_size_t;
+extern proc libiconv(cd : libiconv_t, inbuf : c_ptr(c_string_ptr), inbytesleft : c_ptr(c_size_t), outbuf : c_ptr(c_string_ptr), outbytesleft : c_ptr(c_size_t)) : c_size_t;
 
 extern proc libiconv_close(cd : libiconv_t) : c_int;
 
-extern proc libiconv_open_into(tocode : c_string, fromcode : c_string, ref resultp : iconv_allocation_t) : c_int;
+extern proc libiconv_open_into(tocode : c_string_ptr, fromcode : c_string_ptr, ref resultp : iconv_allocation_t) : c_int;
 
-extern proc libiconv_open_into(tocode : c_string, fromcode : c_string, resultp : c_ptr(iconv_allocation_t)) : c_int;
+extern proc libiconv_open_into(tocode : c_string_ptr, fromcode : c_string_ptr, resultp : c_ptr(iconv_allocation_t)) : c_int;
 
 extern proc libiconvctl(cd : libiconv_t, request : c_int, argument : c_void_ptr) : c_int;
 
@@ -38,9 +38,9 @@ extern "struct iconv_fallbacks" record iconv_fallbacks {
 
 extern proc libiconvlist(do_one : c_fn_ptr, data : c_void_ptr) : void;
 
-extern proc iconv_canonicalize(name : c_string) : c_string;
+extern proc iconv_canonicalize(name : c_string_ptr) : c_string_ptr;
 
-extern proc libiconv_set_relocation_prefix(orig_prefix : c_string, curr_prefix : c_string) : void;
+extern proc libiconv_set_relocation_prefix(orig_prefix : c_string_ptr, curr_prefix : c_string_ptr) : void;
 
 // ==== c2chapel typedefs ====
 

--- a/src/iconv.chpl
+++ b/src/iconv.chpl
@@ -20,12 +20,12 @@ extern proc libiconv_open_into(tocode : c_string_ptr, fromcode : c_string_ptr, r
 
 extern proc libiconv_open_into(tocode : c_string_ptr, fromcode : c_string_ptr, resultp : c_ptr(iconv_allocation_t)) : c_int;
 
-extern proc libiconvctl(cd : libiconv_t, request : c_int, argument : c_void_ptr) : c_int;
+extern proc libiconvctl(cd : libiconv_t, request : c_int, argument : c_ptr_void) : c_int;
 
 extern "struct iconv_hooks" record iconv_hooks {
   var uc_hook : iconv_unicode_char_hook;
   var wc_hook : iconv_wide_char_hook;
-  var data : c_void_ptr;
+  var data : c_ptr_void;
 }
 
 extern "struct iconv_fallbacks" record iconv_fallbacks {
@@ -33,10 +33,10 @@ extern "struct iconv_fallbacks" record iconv_fallbacks {
   var uc_to_mb_fallback : iconv_unicode_uc_to_mb_fallback;
   var mb_to_wc_fallback : iconv_wchar_mb_to_wc_fallback;
   var wc_to_mb_fallback : iconv_wchar_wc_to_mb_fallback;
-  var data : c_void_ptr;
+  var data : c_ptr_void;
 }
 
-extern proc libiconvlist(do_one : c_fn_ptr, data : c_void_ptr) : void;
+extern proc libiconvlist(do_one : c_fn_ptr, data : c_ptr_void) : void;
 
 extern proc iconv_canonicalize(name : c_string_ptr) : c_string_ptr;
 
@@ -45,7 +45,7 @@ extern proc libiconv_set_relocation_prefix(orig_prefix : c_string_ptr, curr_pref
 // ==== c2chapel typedefs ====
 
 extern record iconv_allocation_t {
-  var dummy1 : c_ptr(c_void_ptr);
+  var dummy1 : c_ptr(c_ptr_void);
   var dummy2 : mbstate_t;
 }
 
@@ -61,6 +61,6 @@ extern type iconv_wchar_wc_to_mb_fallback = c_fn_ptr;
 
 extern type iconv_wide_char_hook = c_fn_ptr;
 
-extern type libiconv_t = c_void_ptr;
+extern type libiconv_t = c_ptr_void;
 
 extern type mbstate_t = c_int;

--- a/src/idna.chpl
+++ b/src/idna.chpl
@@ -72,7 +72,7 @@ extern proc idn2_strerror_name(rc : c_int) : c_string_ptr;
 
 extern proc idn2_check_version(req_version : c_string_ptr) : c_string_ptr;
 
-extern proc idn2_free(ptr : c_void_ptr) : void;
+extern proc idn2_free(ptr : c_ptr_void) : void;
 
 // ==== c2chapel typedefs ====
 

--- a/src/idna.chpl
+++ b/src/idna.chpl
@@ -14,37 +14,37 @@ extern proc idn2_register_u8(ref ulabel : uint(8), ref alabel : uint(8), ref ins
 
 extern proc idn2_register_u8(ulabel : c_ptr(uint(8)), alabel : c_ptr(uint(8)), insertname : c_ptr(c_ptr(uint(8))), flags : c_int) : c_int;
 
-extern proc idn2_lookup_ul(src : c_string, ref lookupname : c_string, flags : c_int) : c_int;
+extern proc idn2_lookup_ul(src : c_string_ptr, ref lookupname : c_string_ptr, flags : c_int) : c_int;
 
-extern proc idn2_lookup_ul(src : c_string, lookupname : c_ptr(c_string), flags : c_int) : c_int;
+extern proc idn2_lookup_ul(src : c_string_ptr, lookupname : c_ptr(c_string_ptr), flags : c_int) : c_int;
 
-extern proc idn2_register_ul(ulabel : c_string, alabel : c_string, ref insertname : c_string, flags : c_int) : c_int;
+extern proc idn2_register_ul(ulabel : c_string_ptr, alabel : c_string_ptr, ref insertname : c_string_ptr, flags : c_int) : c_int;
 
-extern proc idn2_register_ul(ulabel : c_string, alabel : c_string, insertname : c_ptr(c_string), flags : c_int) : c_int;
+extern proc idn2_register_ul(ulabel : c_string_ptr, alabel : c_string_ptr, insertname : c_ptr(c_string_ptr), flags : c_int) : c_int;
 
-extern proc idn2_to_ascii_4i(ref input : uint(32), inlen : c_size_t, output : c_string, flags : c_int) : c_int;
+extern proc idn2_to_ascii_4i(ref input : uint(32), inlen : c_size_t, output : c_string_ptr, flags : c_int) : c_int;
 
-extern proc idn2_to_ascii_4i(input : c_ptr(uint(32)), inlen : c_size_t, output : c_string, flags : c_int) : c_int;
+extern proc idn2_to_ascii_4i(input : c_ptr(uint(32)), inlen : c_size_t, output : c_string_ptr, flags : c_int) : c_int;
 
-extern proc idn2_to_ascii_4i2(ref input : uint(32), inlen : c_size_t, ref output : c_string, flags : c_int) : c_int;
+extern proc idn2_to_ascii_4i2(ref input : uint(32), inlen : c_size_t, ref output : c_string_ptr, flags : c_int) : c_int;
 
-extern proc idn2_to_ascii_4i2(input : c_ptr(uint(32)), inlen : c_size_t, output : c_ptr(c_string), flags : c_int) : c_int;
+extern proc idn2_to_ascii_4i2(input : c_ptr(uint(32)), inlen : c_size_t, output : c_ptr(c_string_ptr), flags : c_int) : c_int;
 
-extern proc idn2_to_ascii_4z(ref input : uint(32), ref output : c_string, flags : c_int) : c_int;
+extern proc idn2_to_ascii_4z(ref input : uint(32), ref output : c_string_ptr, flags : c_int) : c_int;
 
-extern proc idn2_to_ascii_4z(input : c_ptr(uint(32)), output : c_ptr(c_string), flags : c_int) : c_int;
+extern proc idn2_to_ascii_4z(input : c_ptr(uint(32)), output : c_ptr(c_string_ptr), flags : c_int) : c_int;
 
-extern proc idn2_to_ascii_8z(input : c_string, ref output : c_string, flags : c_int) : c_int;
+extern proc idn2_to_ascii_8z(input : c_string_ptr, ref output : c_string_ptr, flags : c_int) : c_int;
 
-extern proc idn2_to_ascii_8z(input : c_string, output : c_ptr(c_string), flags : c_int) : c_int;
+extern proc idn2_to_ascii_8z(input : c_string_ptr, output : c_ptr(c_string_ptr), flags : c_int) : c_int;
 
-extern proc idn2_to_ascii_lz(input : c_string, ref output : c_string, flags : c_int) : c_int;
+extern proc idn2_to_ascii_lz(input : c_string_ptr, ref output : c_string_ptr, flags : c_int) : c_int;
 
-extern proc idn2_to_ascii_lz(input : c_string, output : c_ptr(c_string), flags : c_int) : c_int;
+extern proc idn2_to_ascii_lz(input : c_string_ptr, output : c_ptr(c_string_ptr), flags : c_int) : c_int;
 
-extern proc idn2_to_unicode_8z4z(input : c_string, ref output : c_ptr(uint(32)), flags : c_int) : c_int;
+extern proc idn2_to_unicode_8z4z(input : c_string_ptr, ref output : c_ptr(uint(32)), flags : c_int) : c_int;
 
-extern proc idn2_to_unicode_8z4z(input : c_string, output : c_ptr(c_ptr(uint(32))), flags : c_int) : c_int;
+extern proc idn2_to_unicode_8z4z(input : c_string_ptr, output : c_ptr(c_ptr(uint(32))), flags : c_int) : c_int;
 
 extern proc idn2_to_unicode_4z4z(ref input : uint(32), ref output : c_ptr(uint(32)), flags : c_int) : c_int;
 
@@ -54,23 +54,23 @@ extern proc idn2_to_unicode_44i(ref in_arg : uint(32), inlen : c_size_t, ref out
 
 extern proc idn2_to_unicode_44i(in_arg : c_ptr(uint(32)), inlen : c_size_t, out_arg : c_ptr(uint(32)), outlen : c_ptr(c_size_t), flags : c_int) : c_int;
 
-extern proc idn2_to_unicode_8z8z(input : c_string, ref output : c_string, flags : c_int) : c_int;
+extern proc idn2_to_unicode_8z8z(input : c_string_ptr, ref output : c_string_ptr, flags : c_int) : c_int;
 
-extern proc idn2_to_unicode_8z8z(input : c_string, output : c_ptr(c_string), flags : c_int) : c_int;
+extern proc idn2_to_unicode_8z8z(input : c_string_ptr, output : c_ptr(c_string_ptr), flags : c_int) : c_int;
 
-extern proc idn2_to_unicode_8zlz(input : c_string, ref output : c_string, flags : c_int) : c_int;
+extern proc idn2_to_unicode_8zlz(input : c_string_ptr, ref output : c_string_ptr, flags : c_int) : c_int;
 
-extern proc idn2_to_unicode_8zlz(input : c_string, output : c_ptr(c_string), flags : c_int) : c_int;
+extern proc idn2_to_unicode_8zlz(input : c_string_ptr, output : c_ptr(c_string_ptr), flags : c_int) : c_int;
 
-extern proc idn2_to_unicode_lzlz(input : c_string, ref output : c_string, flags : c_int) : c_int;
+extern proc idn2_to_unicode_lzlz(input : c_string_ptr, ref output : c_string_ptr, flags : c_int) : c_int;
 
-extern proc idn2_to_unicode_lzlz(input : c_string, output : c_ptr(c_string), flags : c_int) : c_int;
+extern proc idn2_to_unicode_lzlz(input : c_string_ptr, output : c_ptr(c_string_ptr), flags : c_int) : c_int;
 
-extern proc idn2_strerror(rc : c_int) : c_string;
+extern proc idn2_strerror(rc : c_int) : c_string_ptr;
 
-extern proc idn2_strerror_name(rc : c_int) : c_string;
+extern proc idn2_strerror_name(rc : c_int) : c_string_ptr;
 
-extern proc idn2_check_version(req_version : c_string) : c_string;
+extern proc idn2_check_version(req_version : c_string_ptr) : c_string_ptr;
 
 extern proc idn2_free(ptr : c_void_ptr) : void;
 


### PR DESCRIPTION
Deprecations addressed from Chapel 1.32:

- values modified in loop body must be specified as `ref` with intents
- `c_string` deprecated, not replaced, but can use `c_ptrConst(c_char))` now
- `domain.dist` deprecated in favor of `domain.distribution`
- `NAN`, `INFINITY` deprecated in favor of `nan` and `inf`
- casting to bytes/strings deprecated in favor of type method creation functions
- `chpl_task_yield` deprecated in favor of `currentTask.yieldExecution`
- file reader `kind` deprecated for use of serializers
- `writeThis` deprecated in favor of `serialize`
- generic class values must now have `(?)` to indicate they are generic
- `Block` deprecated in favor of `blockDist`
- `date.isoCalendar` deprecated in favor of `date.isoWeekDate`
- `JsonSerializer` changed name to `jsonSerializer`
- `dateTime.createFromTimestamp` deprecated in favor of `dateTime.createUtcFromTimestamp().getDate()`

Closes #2774 