### PR TITLE
Fixes #2773: Fixes bug in multi-locale coargsort with bool arrays

### DIFF
--- a/PROTO_tests/tests/coargsort_test.py
+++ b/PROTO_tests/tests/coargsort_test.py
@@ -1,5 +1,6 @@
 from itertools import permutations
 
+import numpy as np
 import pytest
 
 import arkouda as ak
@@ -53,9 +54,11 @@ class TestCoargsort:
     @pytest.mark.parametrize("prob_size", pytest.prob_size)
     @pytest.mark.parametrize("algo", SortingAlgorithm)
     def test_coargsort_mixed_types(self, prob_size, algo):
-        for arr_list in permutations(
-            make_ak_arrays(prob_size, dt, 0, 2**63) for dt in NUMERIC_TYPES
-        ):
+        for dt in NUMERIC_TYPES:
+            dtypes = [dt] + np.random.choice(
+                list(set(NUMERIC_TYPES) - {dt}), size=len(NUMERIC_TYPES) - 1, replace=False
+            ).tolist()
+            arr_list = [make_ak_arrays(prob_size, dt, 0, 2**63) for dt in dtypes]
             if not isinstance(arr_list, list):
                 arr_list = list(arr_list)
             perm = ak.coargsort(arr_list, algo)

--- a/PROTO_tests/tests/series_test.py
+++ b/PROTO_tests/tests/series_test.py
@@ -73,17 +73,21 @@ class TestSeries:
             with pytest.raises(TypeError):
                 s.locate([0, 2])
 
-    @pytest.mark.parametrize("prob_size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", NO_STRING)
-    def test_add(self, prob_size, dtype):
-        added = ak.Series(ak.arange(prob_size // 2, dtype=dtype)).add(
+    def test_add(self, dtype):
+        size = 100
+        added = ak.Series(ak.arange(size // 2, dtype=dtype)).add(
             ak.Series(
-                data=ak.arange(prob_size // 2, prob_size, dtype=dtype),
-                index=ak.arange(prob_size // 2, prob_size),
+                data=ak.arange(size // 2, size, dtype=dtype),
+                index=ak.arange(size // 2, size),
             )
         )
-        assert (added.index == ak.arange(prob_size)).all()
-        assert (added.values == ak.arange(prob_size, dtype=dtype)).all()
+        assert (added.index == ak.arange(size)).all()
+        if dtype != ak.bool:
+            assert all(i in added.values.to_list() for i in range(size))
+        else:
+            # we have exactly one False
+            assert added.values.sum() == 99
 
     @pytest.mark.parametrize("dtype", [ak.int64, ak.uint64, ak.float64])
     def test_topn(self, dtype):
@@ -122,7 +126,6 @@ class TestSeries:
         n = 10
         s = ak.Series(ak.arange(n, dtype=dtype))
         for i in range(n):
-
             head = s.head(i)
             assert head.index.to_list() == list(range(i))
             assert head.values.to_list() == ak.arange(i, dtype=dtype).to_list()


### PR DESCRIPTION
This PR (fixes #2773) fixes multi-locale coargsort on bool arrays and updates tests that were failing multi-locale make test