### PR TITLE
Closes #2679: Convert check for re2 in the compiler from a `.compile()` method to `new regex()`

### DIFF
--- a/dep/checkRE2.chpl
+++ b/dep/checkRE2.chpl
@@ -1,6 +1,6 @@
 proc main() {
   use Regex;
-  var myRegex = compile("a+");
+  var myRegex = new regex("a+");
   writeln("Chapel correctly made with RE2 support\n");
   return 0;
 }


### PR DESCRIPTION
In Chapel 1.30, regex.compile() was deprecated in favor of new regex(), however the program that verifies that regex is enabled in Arkouda wasn't updated, so was still relying on this routine.  We removed the routine tonight and broke our smoke tests, not realizing this.  Here, I've updated the test to use 'new regex()' instead.

Helps with https://github.com/Cray/chapel-private/issues/5406, though we may want to restore the dependency checks once this is merged.

Close https://github.com/Bears-R-Us/arkouda/issues/2679