### PR TITLE
Closes #2778: Add `convert_categoricals` flag to `dataframe.to_parquet`

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -1666,7 +1666,8 @@ class DataFrame(UserDict):
             Supported values: snappy, gzip, brotli, zstd, lz4
         convert_categoricals: bool
             Defaults to False
-            Parquet requires all columns to be the same size and Categoricals don't satisfy that requirement.
+            Parquet requires all columns to be the same size and Categoricals
+            don't satisfy that requirement.
             if set, write the equivalent Strings in place of any Categorical columns.
         Returns
         -------
@@ -1688,9 +1689,11 @@ class DataFrame(UserDict):
 
         data = self._prep_data(index=index, columns=columns)
         if not convert_categoricals and any(isinstance(val, Categorical) for val in data.values()):
-            raise ValueError("to_parquet doesn't support Categorical columns. To write the equivalent "
-                             "Strings in place of any Categorical columns, rerun with convert_categoricals "
-                             "set to True.")
+            raise ValueError(
+                "to_parquet doesn't support Categorical columns. To write the equivalent "
+                "Strings in place of any Categorical columns, rerun with convert_categoricals "
+                "set to True."
+            )
         to_parquet(
             data, prefix_path=path, compression=compression, convert_categoricals=convert_categoricals
         )

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -632,8 +632,10 @@ class DataFrame(UserDict):
         msg_list = []
         for col in self._columns:
             if isinstance(self[col], Categorical):
-                msg_list.append(f"Categorical+{col}+{self[col].codes.name} \
-                +{self[col].categories.name}+{self[col]._akNAcode.name}")
+                msg_list.append(
+                    f"Categorical+{col}+{self[col].codes.name} \
+                +{self[col].categories.name}+{self[col]._akNAcode.name}"
+                )
             elif isinstance(self[col], SegArray):
                 msg_list.append(f"SegArray+{col}+{self[col].segments.name}+{self[col].values.name}")
             elif isinstance(self[col], Strings):
@@ -654,11 +656,11 @@ class DataFrame(UserDict):
             generic_msg(
                 cmd="sendDataframe",
                 args={
-                    "size"     : len(msg_list),
-                    "idx_name" : idx.name,
-                    "columns"  : msg_list,
-                    "hostname" : hostname,
-                    "port"     : port
+                    "size": len(msg_list),
+                    "idx_name": idx.name,
+                    "columns": msg_list,
+                    "hostname": hostname,
+                    "port": port,
                 },
             ),
         )
@@ -1639,7 +1641,14 @@ class DataFrame(UserDict):
         data = self._prep_data(index=index, columns=columns)
         update_hdf(data, prefix_path=prefix_path, repack=repack)
 
-    def to_parquet(self, path, index=False, columns=None, compression: Optional[str] = None):
+    def to_parquet(
+        self,
+        path,
+        index=False,
+        columns=None,
+        compression: Optional[str] = None,
+        convert_categoricals: bool = False,
+    ):
         """
         Save DataFrame to disk as parquet, preserving column names.
 
@@ -1655,6 +1664,10 @@ class DataFrame(UserDict):
             Default None
             Provide the compression type to use when writing the file.
             Supported values: snappy, gzip, brotli, zstd, lz4
+        convert_categoricals: bool
+            Defaults to False
+            Parquet requires all columns to be the same size and Categoricals don't satisfy that requirement.
+            if set, write the equivalent Strings in place of any Categorical columns.
         Returns
         -------
         None
@@ -1674,7 +1687,13 @@ class DataFrame(UserDict):
         from arkouda.io import to_parquet
 
         data = self._prep_data(index=index, columns=columns)
-        to_parquet(data, prefix_path=path, compression=compression)
+        if not convert_categoricals and any(isinstance(val, Categorical) for val in data.values()):
+            raise ValueError("to_parquet doesn't support Categorical columns. To write the equivalent "
+                             "Strings in place of any Categorical columns, rerun with convert_categoricals "
+                             "set to True.")
+        to_parquet(
+            data, prefix_path=path, compression=compression, convert_categoricals=convert_categoricals
+        )
 
     @typechecked
     def to_csv(

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -965,7 +965,7 @@ def import_data(read_path: str, write_file: str = None, return_obj: bool = True,
     from arkouda.dataframe import DataFrame
 
     # verify file path
-    is_glob = False if os.path.isfile(read_path) else True
+    is_glob = not os.path.isfile(read_path)
     file_list = glob.glob(read_path)
     if len(file_list) == 0:
         raise FileNotFoundError(f"Invalid read_path, {read_path}. No files found.")
@@ -1080,6 +1080,7 @@ def _bulk_write_prep(
         List[Union[pdarray, Strings, SegArray, ArrayView]],
     ],
     names: List[str] = None,
+    convert_categoricals: bool = False,
 ):
     datasetNames = []
     if names is not None:
@@ -1101,6 +1102,11 @@ def _bulk_write_prep(
     if len(data) == 0:
         raise RuntimeError("No data was found.")
 
+    if convert_categoricals:
+        for i, val in enumerate(data):
+            if isinstance(val, Categorical):
+                data[i] = val.categories[val.codes]
+
     col_objtypes = [c.objType for c in data]
 
     return datasetNames, data, col_objtypes
@@ -1115,6 +1121,7 @@ def to_parquet(
     names: List[str] = None,
     mode: str = "truncate",
     compression: Optional[str] = None,
+    convert_categoricals: bool = False,
 ) -> None:
     """
     Save multiple named pdarrays to Parquet files.
@@ -1135,7 +1142,10 @@ def to_parquet(
             Default None
             Provide the compression type to use when writing the file.
             Supported values: snappy, gzip, brotli, zstd, lz4
-
+        convert_categoricals: bool
+            Defaults to False
+            Parquet requires all columns to be the same size and Categoricals don't satisfy that requirement.
+            if set, write the equivalent Strings in place of any Categorical columns.
 
     Returns
     -------
@@ -1176,7 +1186,6 @@ def to_parquet(
     """
     if mode.lower() not in ["append", "truncate"]:
         raise ValueError("Allowed modes are 'truncate' and 'append'")
-
     if mode.lower() == "append":
         warn(
             "Append has been deprecated when writing Parquet files. "
@@ -1184,7 +1193,7 @@ def to_parquet(
             DeprecationWarning,
         )
 
-    datasetNames, data, col_objtypes = _bulk_write_prep(columns, names)
+    datasetNames, data, col_objtypes = _bulk_write_prep(columns, names, convert_categoricals)
     # append or single column use the old logic
     if mode.lower() == "append" or len(data) == 1:
         for arr, name in zip(data, cast(List[str], datasetNames)):

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -1144,7 +1144,8 @@ def to_parquet(
             Supported values: snappy, gzip, brotli, zstd, lz4
         convert_categoricals: bool
             Defaults to False
-            Parquet requires all columns to be the same size and Categoricals don't satisfy that requirement.
+            Parquet requires all columns to be the same size and Categoricals
+            don't satisfy that requirement.
             if set, write the equivalent Strings in place of any Categorical columns.
 
     Returns
@@ -2018,7 +2019,7 @@ def restore(filename):
     return read_hdf(sorted(restore_files))
 
 
-def receive(hostname : str, port):
+def receive(hostname: str, port):
     """
     Receive a pdarray sent by `pdarray.transfer()`.
 
@@ -2052,13 +2053,12 @@ def receive(hostname : str, port):
         Raised if other is not a pdarray or the pdarray.dtype is not
         a supported dtype
     """
-    rep_msg = generic_msg(cmd="receiveArray", args={"hostname": hostname,
-                                                    "port"    : port})
+    rep_msg = generic_msg(cmd="receiveArray", args={"hostname": hostname, "port": port})
     rep = json.loads(rep_msg)
     return _build_objects(rep)
 
 
-def receive_dataframe(hostname : str, port):
+def receive_dataframe(hostname: str, port):
     """
     Receive a pdarray sent by `dataframe.transfer()`.
 
@@ -2092,7 +2092,6 @@ def receive_dataframe(hostname : str, port):
         Raised if other is not a pdarray or the pdarray.dtype is not
         a supported dtype
     """
-    rep_msg = generic_msg(cmd="receiveDataframe", args={"hostname": hostname,
-                                                        "port"    : port})
+    rep_msg = generic_msg(cmd="receiveDataframe", args={"hostname": hostname, "port": port})
     rep = json.loads(rep_msg)
     return DataFrame(_build_objects(rep))


### PR DESCRIPTION
This PR (closes #2778) adds a `convert_categoricals` flag to `df.to_parquet`

The below shows the error message that's produced now upon a `df.to_parquet` call with categorical columns and the result after conversion to Strings:
```python
In [4]:  ak_df = ak.DataFrame({"a": ak.array(np.random.randn(10)),"b": ak.Categorical(ak.array([f'str {i%3}' for
   ...:  i in range(10)]))})

In [5]: ak_df.to_parquet('my_df')
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[5], line 1
----> 1 ak_df.to_parquet('my_df')

File ~/proj/arkouda/arkouda/dataframe.py:1691, in DataFrame.to_parquet(self, path, index, columns, compression, convert_categoricals)
   1689 data = self._prep_data(index=index, columns=columns)
   1690 if not convert_categoricals and any(isinstance(val, Categorical) for val in data.values()):
-> 1691     raise ValueError("to_parquet doesn't support Categorical columns. To write the equivalent "
   1692                      "Strings in place of any Categorical columns, rerun with convert_categoricals "
   1693                      "set to True.")
   1694 to_parquet(
   1695     data, prefix_path=path, compression=compression, convert_categoricals=convert_categoricals
   1696 )

ValueError: to_parquet doesn't support Categorical columns. To write the equivalent Strings in place of any Categorical columns, rerun with convert_categoricals set to True.

In [6]: ak_df.to_parquet('my_df', convert_categoricals=True)
File written successfully!

In [7]: ret_df = ak.read_parquet('my_df*')

In [8]: ret_df
Out[8]:
{'a': array([-1.35850797588448 1.9056672984981757 -0.19179854671741878 -0.31413858344290718 1.0941078122480539 0.53021234056249966 0.96981216114196966 -0.14788416424645109 0.56383175325924728 -0.3606840813918869]),
 'b': array(['str 0', 'str 1', 'str 2', 'str 0', 'str 1', 'str 2', 'str 0', 'str 1', 'str 2', 'str 0'])}

In [9]: ret_df['b']
Out[9]: array(['str 0', 'str 1', 'str 2', 'str 0', 'str 1', 'str 2', 'str 0', 'str 1', 'str 2', 'str 0'])

In [10]: type(ret_df['b'])
Out[10]: arkouda.strings.Strings
```