### PR TITLE
Closes #2521: Add uint support to histogram

### DIFF
--- a/PROTO_tests/tests/numeric_test.py
+++ b/PROTO_tests/tests/numeric_test.py
@@ -136,7 +136,7 @@ class TestNumeric:
         assert valid.to_list() == validans.to_list()
         assert np.allclose(ans, res.to_ndarray(), equal_nan=True)
 
-    @pytest.mark.parametrize("num_type", INT_FLOAT)
+    @pytest.mark.parametrize("num_type", NO_BOOL)
     def test_histogram(self, num_type):
         pda = ak.randint(10, 30, 40, dtype=num_type)
         bins, result = ak.histogram(pda, bins=20)

--- a/src/HistogramMsg.chpl
+++ b/src/HistogramMsg.chpl
@@ -66,6 +66,7 @@ module HistogramMsg
 
         select (gEnt.dtype) {
             when (DType.Int64)   {histogramHelper(int);}
+            when (DType.UInt64)   {histogramHelper(uint);}
             when (DType.Float64) {histogramHelper(real);}
             otherwise {
                 var errorMsg = notImplementedError(pn,gEnt.dtype);


### PR DESCRIPTION
This PR (closes #2521)  enables use of uint for histograms and expands test coverage accordingly