### PR TITLE
Fixes #2785: `make doc` failures

### DIFF
--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -24,6 +24,7 @@ dependencies:
   - pexpect
   - pytest>=6.0
   - pytest-env
+  - astroid<3.0.0
   - Sphinx>=5.1.1
   - sphinx-argparse
   - sphinx-autoapi

--- a/pydoc/requirements.txt
+++ b/pydoc/requirements.txt
@@ -21,6 +21,7 @@ libidn2
 pexpect
 pytest>=6.0
 pytest-env
+astroid<3.0.0
 Sphinx>=5.1.1
 sphinx-argparse
 sphinx-autoapi

--- a/pydoc/setup/REQUIREMENTS.md
+++ b/pydoc/setup/REQUIREMENTS.md
@@ -40,6 +40,7 @@ The dependencies listed here are only required if you will be doing development 
 - `pexpect`
 - `pytest>=6.0`
 - `pytest-env`
+- `astroid<3.0.0`
 - `Sphinx>=5.1.1`
 - `sphinx-argparse`
 - `sphinx-autoapi`

--- a/setup.py
+++ b/setup.py
@@ -155,7 +155,7 @@ setup(
     # Similar to `install_requires` above, these must be valid existing
     # projects.
     extras_require={  # Optional
-        'dev': ['pexpect', 'pytest>=6.0', 'pytest-env',
+        'dev': ['pexpect', 'pytest>=6.0', 'pytest-env', 'astroid<3.0.0',
                 'Sphinx>=5.1.1', 'sphinx-argparse', 'sphinx-autoapi',
                 'mypy>=0.931,<0.990', 'typed-ast', 'black', 'isort',
                 'flake8', 'furo', 'myst-parser', 'linkify-it-py'],


### PR DESCRIPTION
This PR (fixes #2785) pins astroid version to `<3.0.0` in an attempt to fix `make doc` failures