### PR TITLE
Closes #2790: Convert non sym entry array creations to new throwing interface

### DIFF
--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -160,7 +160,7 @@ module ArgSortMsg
           when DType.Bool {
               var e = toSymEntry(g, bool);
               // Permute the keys array with the initial iv
-              var newa: [e.a.domain] int;
+              var newa = makeDistArray(e.a.domain, int);
               ref olda = e.a;
               // Effectively: newa = olda[iv]
               forall (newai, idx) in zip(newa, iv) with (var agg = newSrcAggregator(int)) {

--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -387,7 +387,7 @@ module ArgSortMsg
                 }
                 when (DType.Bool) {
                     var e = toSymEntry(gEnt,bool);
-                    var int_ea = e.a:int;
+                    var int_ea = makeDistArray(e.a:int);
                     var iv = argsortDefault(int_ea, algorithm=algorithm);
                     st.addEntry(ivname, createSymEntry(iv));
                 }

--- a/src/BigIntMsg.chpl
+++ b/src/BigIntMsg.chpl
@@ -68,7 +68,7 @@ module BigIntMsg {
                 var retList: list(string);
                 // default to false because we want to do first loop whether or not tmp is all_zero
                 var all_zero = false;
-                var low: [tmp.domain] uint;
+                var low = makeDistArray(tmp.domain, uint);
                 const ushift = 64:uint;
                 while !all_zero {
                   low = tmp:uint;

--- a/src/Broadcast.chpl
+++ b/src/Broadcast.chpl
@@ -27,7 +27,7 @@ module Broadcast {
     // domain by forming the full derivative and integrating it
 
     // Compute the sparse derivative (in segment domain) of values
-    var diffs: [sD] t;
+    var diffs = makeDistArray(sD, t);
     forall (i, d, v) in zip(sD, diffs, vals) {
       if i == sD.low {
         d = v;
@@ -36,7 +36,7 @@ module Broadcast {
       }
     }
     // Convert to the dense derivative (in full domain) of values
-    var expandedVals: [D] t;
+    var expandedVals = makeDistArray(D, t);
     forall (s, d) in zip(segs, diffs) with (var agg = newDstAggregator(t)) {
       agg.copy(expandedVals[s], d);
     }
@@ -48,7 +48,7 @@ module Broadcast {
     // Integrate to recover full values
     expandedVals = (+ scan expandedVals);
     // Permute to the original array order
-    var permutedVals: [D] t;
+    var permutedVals = makeDistArray(D, t);
     forall (i, v) in zip(perm, expandedVals) with (var agg = newDstAggregator(t)) {
       agg.copy(permutedVals[i], v);
     }
@@ -69,7 +69,7 @@ module Broadcast {
     
     // Compute the sparse derivative (in segment domain) of values
     // Treat booleans as integers
-    var diffs: [sD] int(8);
+    var diffs = makeDistArray(sD, int(8));
     forall (i, d, v) in zip(sD, diffs, vals) {
       if i == sD.low {
         d = v:int(8);
@@ -78,7 +78,7 @@ module Broadcast {
       }
     }
     // Convert to the dense derivative (in full domain) of values
-    var expandedVals: [D] int(8);
+    var expandedVals = makeDistArray(D, int(8));
     forall (s, d) in zip(segs, diffs) with (var agg = newDstAggregator(int(8))) {
       agg.copy(expandedVals[s], d);
     }
@@ -87,7 +87,7 @@ module Broadcast {
     // Integrate to recover full values
     expandedVals = (+ scan expandedVals);
     // Permute to the original array order and convert back to bool
-    var permutedVals: [D] bool;
+    var permutedVals = makeDistArray(D, bool);
     forall (i, v) in zip(perm, expandedVals) with (var agg = newDstAggregator(bool)) {
       agg.copy(permutedVals[i], v == 1);
     }
@@ -99,8 +99,8 @@ module Broadcast {
     ref vals = segString.values.a;
     const size = perm.size;
     const high = sD.high;
-    var strLens: [sD] int;
-    var segLens: [sD] int;
+    var strLens = makeDistArray(sD, int);
+    var segLens = makeDistArray(sD, int);
     var expandedLen: int;
 
     forall (i, off, str_len, seg, seg_len) in zip (sD, offs, strLens, segs, segLens) with (+ reduce expandedLen) {
@@ -138,7 +138,7 @@ module Broadcast {
     // domain by forming the full derivative and integrating it
     
     // Compute the sparse derivative (in segment domain) of values
-    var diffs: [sD] t;
+    var diffs = makeDistArray(sD, t);
     forall (i, d, v) in zip(sD, diffs, vals) {
       if i == sD.low {
         d = v;
@@ -167,7 +167,7 @@ module Broadcast {
     
     // Compute the sparse derivative (in segment domain) of values
     // Treat booleans as integers
-    var diffs: [sD] int(8);
+    var diffs = makeDistArray(sD, int(8));
     forall (i, d, v) in zip(sD, diffs, vals) {
       if i == sD.low {
         d = v:int(8);
@@ -191,8 +191,8 @@ module Broadcast {
     ref offs = segString.offsets.a;
     ref vals = segString.values.a;
     const high = sD.high;
-    var strLens: [sD] int;
-    var segLens: [sD] int;
+    var strLens = makeDistArray(sD, int);
+    var segLens = makeDistArray(sD, int);
     var expandedLen: int;
 
     forall (i, off, str_len, seg, seg_len) in zip (sD, offs, strLens, segs, segLens) with (+ reduce expandedLen) {

--- a/src/CSVMsg.chpl
+++ b/src/CSVMsg.chpl
@@ -375,7 +375,7 @@ module CSVMsg {
     proc generate_subdoms(filenames: [?D] string, row_counts: [D] int, validFiles: [D] bool) throws {
         var skips = new set(string);
         var offsets = (+ scan row_counts) - row_counts;
-        var subdoms: [D] domain(1);
+        var subdoms = makeDistArray(D, domain(1));
         for (i, fname, off, ct, vf) in zip(D, filenames, offsets, row_counts, validFiles) {
             if (!vf) {
                 skips.add(fname);

--- a/src/Cast.chpl
+++ b/src/Cast.chpl
@@ -61,7 +61,7 @@ module Cast {
     const before = toSymEntry(gse, fromType);
     const oname = st.nextName();
     var segments = st.addEntry(oname, before.size, int);
-    var strings: [before.a.domain] string;
+    var strings = makeDistArray(before.a.domain, string);
     if fromType == real {
       try {
           forall (s, v) in zip(strings, before.a) {

--- a/src/DataFrameIndexingMsg.chpl
+++ b/src/DataFrameIndexingMsg.chpl
@@ -78,7 +78,7 @@
             }
         }
 
-        var rvals: [0..#(+ reduce lens)] t;
+        var rvals = makeDistArray(+ reduce lens, t);
         var rsegs = (+ scan lens) - lens;
 
         forall(i, rs, os, l) in zip(orig_segs.domain, rsegs, orig_segs, lens){

--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -249,13 +249,15 @@ module EfuncMsg
                 select efunc
                 {
                     when "cumsum" {
-                        var ia = makeDistArray(e.a:int); // make a copy of bools as ints blah!
+                        var ia = makeDistArray(e.a.domain, int); // make a copy of bools as ints blah!
+                        ia = e.a:int;
                         // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
                         overMemLimit(numBytes(int) * ia.size);
                         st.addEntry(rname, new shared SymEntry(+ scan ia));
                     }
                     when "cumprod" {
-                        var ia = makeDistArray(e.a:int); // make a copy of bools as ints blah!
+                        var ia = makeDistArray(e.a.domain, int); // make a copy of bools as ints blah!
+                        ia = e.a:int;
                         // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
                         overMemLimit(numBytes(int) * ia.size);
                         st.addEntry(rname, new shared SymEntry(* scan ia));
@@ -1181,7 +1183,7 @@ module EfuncMsg
        :arg kind:
        :type kind: param
        */
-    proc where_helper(cond:[?D] bool, A:[D] ?t, B:[D] t, param kind):[D] t where (kind == 0) {
+    proc where_helper(cond:[?D] bool, A:[D] ?t, B:[D] t, param kind):[D] t throws where (kind == 0) {
       var C = makeDistArray(D, t);
       forall (ch, a, b, c) in zip(cond, A, B, C) {
         c = if ch then a else b;
@@ -1203,7 +1205,7 @@ module EfuncMsg
     :arg kind:
     :type kind: param
     */
-    proc where_helper(cond:[?D] bool, A:[D] ?t, b:t, param kind):[D] t where (kind == 1) {
+    proc where_helper(cond:[?D] bool, A:[D] ?t, b:t, param kind):[D] t throws where (kind == 1) {
       var C = makeDistArray(D, t);
       forall (ch, a, c) in zip(cond, A, C) {
         c = if ch then a else b;
@@ -1225,7 +1227,7 @@ module EfuncMsg
     :arg kind:
     :type kind: param
     */
-    proc where_helper(cond:[?D] bool, a:?t, B:[D] t, param kind):[D] t where (kind == 2) {
+    proc where_helper(cond:[?D] bool, a:?t, B:[D] t, param kind):[D] t throws where (kind == 2) {
       var C = makeDistArray(D, t);
       forall (ch, b, c) in zip(cond, B, C) {
         c = if ch then a else b;
@@ -1247,7 +1249,7 @@ module EfuncMsg
     :arg kind:
     :type kind: param
     */
-    proc where_helper(cond:[?D] bool, a:?t, b:t, param kind):[D] t where (kind == 3) {
+    proc where_helper(cond:[?D] bool, a:?t, b:t, param kind):[D] t throws where (kind == 3) {
       var C = makeDistArray(D, t);
       forall (ch, c) in zip(cond, C) {
         c = if ch then a else b;

--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -249,13 +249,13 @@ module EfuncMsg
                 select efunc
                 {
                     when "cumsum" {
-                        var ia: [e.a.domain] int = (e.a:int); // make a copy of bools as ints blah!
+                        var ia = makeDistArray(e.a:int); // make a copy of bools as ints blah!
                         // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
                         overMemLimit(numBytes(int) * ia.size);
                         st.addEntry(rname, new shared SymEntry(+ scan ia));
                     }
                     when "cumprod" {
-                        var ia: [e.a.domain] int = (e.a:int); // make a copy of bools as ints blah!
+                        var ia = makeDistArray(e.a:int); // make a copy of bools as ints blah!
                         // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
                         overMemLimit(numBytes(int) * ia.size);
                         st.addEntry(rname, new shared SymEntry(* scan ia));
@@ -1182,7 +1182,7 @@ module EfuncMsg
        :type kind: param
        */
     proc where_helper(cond:[?D] bool, A:[D] ?t, B:[D] t, param kind):[D] t where (kind == 0) {
-      var C:[D] t;
+      var C = makeDistArray(D, t);
       forall (ch, a, b, c) in zip(cond, A, B, C) {
         c = if ch then a else b;
       }
@@ -1204,7 +1204,7 @@ module EfuncMsg
     :type kind: param
     */
     proc where_helper(cond:[?D] bool, A:[D] ?t, b:t, param kind):[D] t where (kind == 1) {
-      var C:[D] t;
+      var C = makeDistArray(D, t);
       forall (ch, a, c) in zip(cond, A, C) {
         c = if ch then a else b;
       }
@@ -1226,7 +1226,7 @@ module EfuncMsg
     :type kind: param
     */
     proc where_helper(cond:[?D] bool, a:?t, B:[D] t, param kind):[D] t where (kind == 2) {
-      var C:[D] t;
+      var C = makeDistArray(D, t);
       forall (ch, b, c) in zip(cond, B, C) {
         c = if ch then a else b;
       }
@@ -1248,7 +1248,7 @@ module EfuncMsg
     :type kind: param
     */
     proc where_helper(cond:[?D] bool, a:?t, b:t, param kind):[D] t where (kind == 3) {
-      var C:[D] t;
+      var C = makeDistArray(D, t);
       forall (ch, c) in zip(cond, C) {
         c = if ch then a else b;
       }

--- a/src/EncodingMsg.chpl
+++ b/src/EncodingMsg.chpl
@@ -56,7 +56,7 @@ module EncodingMsg {
     }
 
     proc getBufLengths(segments: [?D] int, ref values: [?vD] ?t, toEncoding: string, fromEncoding: string) throws {
-      var res: [D] int;
+      var res = makeDistArray(D, int);
       if (D.size == 0) {
         return res;
       }

--- a/src/Flatten.chpl
+++ b/src/Flatten.chpl
@@ -168,7 +168,7 @@ module Flatten {
       matchAgg.copy(numMatches[i], matchessize);
     }
     // writeToVal is true for positions to copy origVals (non-matches) and positions to write a null byte
-    var splitVals = makeDistArray(+ redue writeToVal, uint(8));
+    var splitVals = makeDistArray(+ reduce writeToVal, uint(8));
     // Each match is replaced with a null byte, so new offsets.size = totalNumMatches + old offsets.size
     var splitOffsets = makeDistArray((+ reduce numMatches) + this.offsets.size, int);
 

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -126,7 +126,7 @@ module GenSymIO {
         var nb_locs = forall (i,v) in zip(valuesDom, values) do if v == NULL_STRINGS_VALUE then i+1;
         // We need to adjust nb_locs b/c offsets is really the starting position of each string
         // So allocated a new array of zeros and assign nb_locs offset by one
-        var offsets: [nb_locs.domain] int;
+        var offsets = makeDistArray(nb_locs.domain, int);
         offsets[1..offsets.domain.high] = nb_locs[0..#nb_locs.domain.high];
         return offsets;
     }

--- a/src/HDF5Msg.chpl
+++ b/src/HDF5Msg.chpl
@@ -3835,7 +3835,7 @@ module HDF5Msg {
         return (dset, ObjType.DATAFRAME, formatJson(rtnMap));
     }
 
-    proc index_readhdfMsg(filenames: [?fD] string, dset: string, validFiles: [] bool, calcStringOffsets: bool, st: borrowed SymTab): (string, ObjType, string) throws {
+    proc index_readhdfMsg(filenames: [?fD] string, dset: string, ref validFiles: [] bool, calcStringOffsets: bool, st: borrowed SymTab): (string, ObjType, string) throws {
         var rtnList: list(string);
         // identify the index of the first valid file
         var (v, fIdx) = maxloc reduce zip(validFiles, validFiles.domain);

--- a/src/HashMsg.chpl
+++ b/src/HashMsg.chpl
@@ -27,7 +27,7 @@ module HashMsg {
     var hashes = categories.siphash();
     // then do expansion indexing at codes
     ref ca = codes.a;
-    var expandedHashes: [ca.domain] (uint, uint);
+    var expandedHashes = makeDistArray(ca.domain, (uint, uint));
     forall (eh, c) in zip(expandedHashes, ca) with (var agg = newSrcAggregator((uint, uint))) {
       agg.copy(eh, hashes[c]);
     }

--- a/src/Histogram.chpl
+++ b/src/Histogram.chpl
@@ -41,7 +41,7 @@ module Histogram
     proc histogramGlobalAtomic(a: [?aD] ?etype, aMin: etype, aMax: etype, bins: int, binWidth: real) throws {
 
         var hD = makeDistDom(bins);
-        var atomicHist: [hD] atomic int;
+        var atomicHist = makeDistArray(hD, atomic int);
         
         // count into atomic histogram
         forall v in a {

--- a/src/Histogram.chpl
+++ b/src/Histogram.chpl
@@ -41,7 +41,7 @@ module Histogram
     proc histogramGlobalAtomic(a: [?aD] ?etype, aMin: etype, aMax: etype, bins: int, binWidth: real) throws {
 
         var hD = makeDistDom(bins);
-        var atomicHist = makeDistArray(hD, atomic int);
+        var atomicHist: [hD] atomic int;
         
         // count into atomic histogram
         forall v in a {

--- a/src/In1d.chpl
+++ b/src/In1d.chpl
@@ -36,7 +36,7 @@ module In1d
      * size and space when ar2 is "small".
      */
     proc in1dAr2PerLocAssoc(ar1: [?aD1] ?t, ref ar2: [?aD2] t) {
-        var truth: [aD1] bool;
+        var truth = makeDistArray(aD1, bool);
         
         coforall loc in Locales with (ref truth, ref ar2) {
             on loc {
@@ -70,18 +70,18 @@ module In1d
         const ar = concatArrays(u1, u2);
         const D = ar.domain;
         // Sort unique arrays together to find duplicates
-        var sar: [D] t;
-        var order: [D] int;
+        var sar = makeDistArray(D, t);
+        var order = makeDistArray(D, int);
         forall (s, o, so) in zip(sar, order, radixSortLSD(ar)) {
             (s, o) = so;
         }
         // Duplicates correspond to values in both arrays
-        var flag: [D] bool;
+        var flag = makeDistArray(D, bool);
         forall i in D[D.low..<D.high] with (var agg = newDstAggregator(bool)) {
             agg.copy(flag[order[i]], sar[i+1] == sar[i]);
         }
         // Use the inverse index to map from u1 domain to ar1 domain
-        var truth: [aD1] bool;
+        var truth = makeDistArray(aD1, bool);
         forall (t, idx) in zip(truth, inv) with (var agg = newSrcAggregator(bool)) {
             agg.copy(t, flag[idx]);
         }

--- a/src/In1d.chpl
+++ b/src/In1d.chpl
@@ -35,7 +35,7 @@ module In1d
      * localize ar2 and put it in the set, so only appropriate in terms of
      * size and space when ar2 is "small".
      */
-    proc in1dAr2PerLocAssoc(ar1: [?aD1] ?t, ref ar2: [?aD2] t) {
+    proc in1dAr2PerLocAssoc(ar1: [?aD1] ?t, ref ar2: [?aD2] t) throws {
         var truth = makeDistArray(aD1, bool);
         
         coforall loc in Locales with (ref truth, ref ar2) {

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -49,7 +49,7 @@ module IndexingMsg
         // String array containing the type of the following value at even indicies then the value ex. ["int", "7", "slice", "(0,5,-1)", "pdarray", "id_4"]
         var typeCoords: [0..#(ndim*2)] string = msgArgs.get("coords").getList(ndim*2);
 
-        var scaledCoords: [makeDistDom(+ reduce dims)] int;
+        var scaledCoords = makeDistArray(+ reduce dims, int);
         // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
         overMemLimit(numBytes(int) * dims.size);
         var offsets = (+ scan dims) - dims;

--- a/src/JoinEqWithDTMsg.chpl
+++ b/src/JoinEqWithDTMsg.chpl
@@ -101,9 +101,9 @@ module JoinEqWithDTMsg
         var locResJ: [PrivateSpace] [0..#resLimitPerLocale] int;
 
         // atomic result counter per locale
-        var resCounters: [PrivateSpace] atomic int;
+        var resCounters = makeDistArray(PrivateSpace, atomic int);
         // actual number of results per locale
-        var locNumResults: [PrivateSpace] int;
+        var locNumResults = makeDistArray(PrivateSpace, int);
         
         coforall loc in Locales with (ref locResI, ref locResJ, ref locNumResults, ref resCounters) {
             on loc {

--- a/src/JoinEqWithDTMsg.chpl
+++ b/src/JoinEqWithDTMsg.chpl
@@ -101,9 +101,9 @@ module JoinEqWithDTMsg
         var locResJ: [PrivateSpace] [0..#resLimitPerLocale] int;
 
         // atomic result counter per locale
-        var resCounters = makeDistArray(PrivateSpace, atomic int);
+        var resCounters: [PrivateSpace] atomic int;
         // actual number of results per locale
-        var locNumResults = makeDistArray(PrivateSpace, int);
+        var locNumResults: [PrivateSpace] int;
         
         coforall loc in Locales with (ref locResI, ref locResJ, ref locNumResults, ref resCounters) {
             on loc {

--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -70,8 +70,7 @@ module RadixSortLSD
         var temp = a;
         
         // create a global count array to scan
-        var gD = blockDist.createDomain({0..#(numLocales * numTasks * numBuckets)});
-        var globalCounts = makeDistArray(gD, int);
+        var globalCounts = makeDistArray((numLocales*numTasks*numBuckets), int);
         
         // loop over digits
         for rshift in {0..#nBits by bitsPerDigit} {

--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -64,7 +64,7 @@ module RadixSortLSD
        In-place radix sort a block distributed array
        comparator is used to extract the key from array elements
      */
-    private proc radixSortLSDCore(ref a:[?aD] ?t, nBits, negs, comparator) {
+    private proc radixSortLSDCore(ref a:[?aD] ?t, nBits, negs, comparator) throws {
         try! rsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                        "type = %s nBits = %?".doFormat(t:string,nBits));
         var temp = a;
@@ -166,7 +166,7 @@ module RadixSortLSD
         } // for rshift
     }//proc radixSortLSDCore
 
-    proc radixSortLSD(a:[?aD] ?t, checkSorted: bool = true): [aD] (t, int) {
+    proc radixSortLSD(a:[?aD] ?t, checkSorted: bool = true): [aD] (t, int) throws {
         var kr: [aD] (t,int) = [(key,rank) in zip(a,aD)] (key,rank);
         if (checkSorted && isSorted(a)) {
             return kr;
@@ -179,7 +179,7 @@ module RadixSortLSD
     /* Radix Sort Least Significant Digit
        radix sort a block distributed array
        returning a permutation vector as a block distributed array */
-    proc radixSortLSD_ranks(a:[?aD] ?t, checkSorted: bool = true): [aD] int {
+    proc radixSortLSD_ranks(a:[?aD] ?t, checkSorted: bool = true): [aD] int throws {
         if (checkSorted && isSorted(a)) {
             var ranks: [aD] int = [i in aD] i;
             return ranks;
@@ -195,7 +195,7 @@ module RadixSortLSD
     /* Radix Sort Least Significant Digit
        radix sort a block distributed array
        returning sorted keys as a block distributed array */
-    proc radixSortLSD_keys(a: [?aD] ?t, checkSorted: bool = true): [aD] t {
+    proc radixSortLSD_keys(a: [?aD] ?t, checkSorted: bool = true): [aD] t throws {
         var copy = a;
         if (checkSorted && isSorted(a)) {
             return copy;

--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -71,7 +71,7 @@ module RadixSortLSD
         
         // create a global count array to scan
         var gD = blockDist.createDomain({0..#(numLocales * numTasks * numBuckets)});
-        var globalCounts: [gD] int;
+        var globalCounts = makeDistArray(gD, int);
         
         // loop over digits
         for rshift in {0..#nBits by bitsPerDigit} {

--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -67,7 +67,7 @@ module RadixSortLSD
     private proc radixSortLSDCore(ref a:[?aD] ?t, nBits, negs, comparator) throws {
         try! rsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                        "type = %s nBits = %?".doFormat(t:string,nBits));
-        var temp = a;
+        var temp = makeDistArray(a);
         
         // create a global count array to scan
         var globalCounts = makeDistArray((numLocales*numTasks*numBuckets), int);
@@ -166,7 +166,8 @@ module RadixSortLSD
     }//proc radixSortLSDCore
 
     proc radixSortLSD(a:[?aD] ?t, checkSorted: bool = true): [aD] (t, int) throws {
-        var kr: [aD] (t,int) = [(key,rank) in zip(a,aD)] (key,rank);
+        var kr: [aD] (t,int) = makeDistArray(aD, (t, int));
+        kr = [(key,rank) in zip(a,aD)] (key,rank);
         if (checkSorted && isSorted(a)) {
             return kr;
         }
@@ -184,10 +185,12 @@ module RadixSortLSD
             return ranks;
         }
 
-        var kr: [aD] (t,int) = [(key,rank) in zip(a,aD)] (key,rank);
+        var kr = makeDistArray(aD, (t, int));
+        kr = [(key,rank) in zip(a,aD)] (key,rank);
         var (nBits, negs) = getBitWidth(a);
         radixSortLSDCore(kr, nBits, negs, new KeysRanksComparator());
-        var ranks: [aD] int = [(_, rank) in kr] rank;
+        var ranks = makeDistArray(aD, int);
+        ranks = [(_, rank) in kr] rank;
         return ranks;
     }
 

--- a/src/RandArray.chpl
+++ b/src/RandArray.chpl
@@ -149,7 +149,8 @@ module RandArray {
     var ltemp = makeDistArray(n, real);
     fillNormal(ltemp, seedStr=seedStr);
     ltemp = exp(logMean + logStd*ltemp);
-    var lengths:[ltemp.domain] int = [l in ltemp] ceil(l):int;
+    var lengths = makeDistArray(ltemp.domain, int);
+    lengths = [l in ltemp] ceil(l):int;
     const nBytes = + reduce lengths;
     // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
     overMemLimit(numBytes(int) * lengths.size);

--- a/src/RandArray.chpl
+++ b/src/RandArray.chpl
@@ -57,8 +57,8 @@ module RandArray {
   }
 
   proc fillNormal(ref a:[?D] real, const seedStr:string="None") throws {
-    var u1:[D] real;
-    var u2:[D] real;
+    var u1 = makeDistArray(D, real);
+    var u2 = makeDistArray(D, real);
     if (seedStr.toLower() == "none") {
       fillRandom(u1);
       fillRandom(u2);

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -1373,7 +1373,7 @@ module ReductionMsg
       var count: [kD] int = (+ scan truth);
       var pop = count[kD.high];
       // find steps to get unique (key, val) pairs
-      var hD: domain(1) dmapped blockDist(boundingBox={0..#pop}) = {0..#pop};
+      var hD = makeDistDom(pop);
       // save off only the key from each pair (now there will be nunique of each key)
       var keyhits = makeDistArray(hD, int);
       forall i in truth.domain with (var agg = newDstAggregator(int)) {
@@ -1388,13 +1388,13 @@ module ReductionMsg
                                        "Finding unique keys and num unique vals per key.");
       // find steps in keys
       var truth2 = makeDistArray(hD, bool);
-      truth2[hD.low] = true;
+      truth2[0] = true;
       [(tr, k, i) in zip(truth2, keyhits, hD)] if (i > hD.low) { tr = (keyhits[i-1] != k); }
       // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
       overMemLimit(numBytes(int) * truth2.size);
       var kiv: [hD] int = (+ scan truth2);
       var nKeysPresent = kiv[hD.high];
-      var nD: domain(1) dmapped blockDist(boundingBox={0..#(nKeysPresent+1)}) = {0..#(nKeysPresent+1)};
+      var nD = makeDistDom(nKeysPresent+1);
       // get step indices and take diff to get number of times each key appears
       var stepInds = makeDistArray(nD, int);
       stepInds[nKeysPresent] = keyhits.size;

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -305,7 +305,7 @@ module ReductionMsg
       return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 
-    proc segCount(segments:[?D] int, upper: int):[D] int {
+    proc segCount(segments:[?D] int, upper: int):[D] int throws {
       var counts = makeDistArray(D, int);
       if (D.size == 0) { return counts; }
       forall (c, low, i) in zip(counts, segments, D) {
@@ -897,7 +897,7 @@ module ReductionMsg
       }
 
       var tmp1 = makeDistArray(D, t);
-      var tmp = makeDistArray(D, t);
+      var tmp2 = makeDistArray(D, t);
       forall (s, c, r, t1, t2) in zip(segments, counts, res, tmp1, tmp2) with (var resAgg = newSrcAggregator(t)) {
         if c % 2 != 0 {
           // odd case: grab middle of sorted values
@@ -1204,7 +1204,7 @@ module ReductionMsg
     }
 
     proc segAnd(values:[?vD] ?t, segments:[?D] int): [D] t throws {
-      var res = makeDistArray(D, int);
+      var res = makeDistArray(D, t);
       if (D.size == 0) { return res; }
       // Set reset flag at segment boundaries
       var flagvalues: [vD] (bool, t) = [v in values] (false, v);

--- a/src/SegStringSort.chpl
+++ b/src/SegStringSort.chpl
@@ -56,7 +56,7 @@ module SegStringSort {
     overMemLimit(numBytes(int) * isLong.size);
     var longLocs = + scan isLong;
     locs -= longLocs;
-    var gatherInds: [ss.offsets.a.domain] int;
+    var gatherInds = makeDistArray(ss.offsets.a.domain, int);
     forall (i, l, ll, t) in zip(ss.offsets.a.domain, locs, longLocs, isLong) 
       with (var agg = newDstAggregator(int)) {
       if !t {
@@ -145,8 +145,8 @@ module SegStringSort {
     ref oa = ss.offsets.a;
     ref va = ss.values.a;
     const myD: domain(1) = D;
-    const myInds: [myD] int = longInds;
-    var stringsWithInds: [myD] (string, int);
+    const myInd = makeDistArray(longInds);
+    var stringsWithInds = makeDistArray(myD, (string, int);
     forall (i, si) in zip(myInds, stringsWithInds) {
       const l = lengths[i];
       var buf: [0..#(l+1)] uint(8);
@@ -219,16 +219,16 @@ module SegStringSort {
       }
     }
     
-    var kr0: [aD] state;
+    var kr0 = makeDistArray(aD, state);
     ssLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"rshift = 0");
     forall (k, rank) in zip(kr0, inds) with (var agg = newSrcAggregator(uint(8))) {
       copyDigit(k, offsets[rank], lengths[rank], rank, pivot, agg);
     }
-    var kr1: [aD] state;
+    var kr1 = makeDistArray(aD, state);
     // create a global count array to scan
     var gD = blockDist.createDomain({0..#(numLocales * numTasks * numBuckets)});
-    var globalCounts: [gD] int;
-    var globalStarts: [gD] int;
+    var globalCounts = makeDistArray(gD, int);
+    var globalStarts = makeDistArray(gD, int);
         
     // loop over digits
     for rshift in {2..#pivot by 2} {
@@ -240,7 +240,7 @@ module SegStringSort {
             // bucket domain
             var bD = {0..#numBuckets};
             // allocate counts
-            var taskBucketCounts: [bD] int;
+            var taskBucketCounts = makeDistArray(bD, int);
             // get local domain's indices
             var lD = kr0.localSubdomain();
             // calc task's indices from local domain's indices
@@ -275,7 +275,7 @@ module SegStringSort {
             // bucket domain
             var bD = {0..#numBuckets};
             // allocate counts
-            var taskBucketPos: [bD] int;
+            var taskBucketPos = makeDistArray(bD, int);
             // get local domain's indices
             var lD = kr0.localSubdomain();
             // calc task's indices from local domain's indices

--- a/src/SegStringSort.chpl
+++ b/src/SegStringSort.chpl
@@ -141,12 +141,12 @@ module SegStringSort {
     }
   }
   
-  proc gatherLongStrings(ss: SegString, lengths: [] int, longInds: [?D] int): [] (string, int) {
+  proc gatherLongStrings(ss: SegString, lengths: [] int, longInds: [?D] int): [] (string, int) throws {
     ref oa = ss.offsets.a;
     ref va = ss.values.a;
     const myD: domain(1) = D;
-    const myInd = makeDistArray(longInds);
-    var stringsWithInds = makeDistArray(myD, (string, int);
+    const myInds = makeDistArray(longInds);
+    var stringsWithInds = makeDistArray(myD, (string, int));
     forall (i, si) in zip(myInds, stringsWithInds) {
       const l = lengths[i];
       var buf: [0..#(l+1)] uint(8);

--- a/src/SegStringSort.chpl
+++ b/src/SegStringSort.chpl
@@ -226,9 +226,8 @@ module SegStringSort {
     }
     var kr1 = makeDistArray(aD, state);
     // create a global count array to scan
-    var gD = blockDist.createDomain({0..#(numLocales * numTasks * numBuckets)});
-    var globalCounts = makeDistArray(gD, int);
-    var globalStarts = makeDistArray(gD, int);
+    var globalCounts = makeDistArray(numLocales * numTasks * numBuckets, int);
+    var globalStarts = makeDistArray(numLocales * numTasks * numBuckets, int);
         
     // loop over digits
     for rshift in {2..#pivot by 2} {

--- a/src/SegmentedArray.chpl
+++ b/src/SegmentedArray.chpl
@@ -13,7 +13,7 @@ module SegmentedArray {
     // we can't just call hashArrays because the compiler complains about recursion
     overMemLimit(numBytes(uint) * size * 2);
     var dom = makeDistDom(size);
-    var hashes: [dom] 2*uint(64);
+    var hashes = makeDistArray(dom, 2*uint);
     /* Hashes of subsequent arrays cannot be simply XORed
      * because equivalent values will cancel each other out.
      * Thus, a non-linear function must be applied to each array,

--- a/src/SegmentedComputation.chpl
+++ b/src/SegmentedComputation.chpl
@@ -11,7 +11,7 @@ module SegmentedComputation {
     // Locale that owns each segment's bytes
     var startLocales: [D] int = [seg in segments] ((seg - low)*numLocales) / size;
     // Index of first segment each locale owns bytes for
-    var startSegInds: [LocaleSpace] int;
+    var startSegInds = makeDistArray(LocaleSpace, int);
     // Mark true where owning locale changes
     const change = [(i, sl) in zip(D, startLocales)] if (i == D.low) then true else (sl != startLocales[i-1]);
     // Wherever the owning locale increments, record that as first segment for the locale
@@ -22,7 +22,7 @@ module SegmentedComputation {
     }
 
     // Number of segments each locale owns bytes for
-    var numSegs: [LocaleSpace] int;
+    var numSegs = makeDistArray(LocaleSpace, int);
     // small number of iterations, no comms
     for l in Locales {
       if (l.id == numLocales - 1) {
@@ -53,7 +53,7 @@ module SegmentedComputation {
   
   proc computeOnSegments(segments: [?D] int, ref values: [?vD] ?t, param function: SegFunction, type retType, const strArg: string = "") throws {
     // type retType = if (function == SegFunction.StringToNumericReturnValidity) then (outType, bool) else outType;
-    var res: [D] retType;
+    var res = makeDistArray(D, retType);
     if (D.size == 0) {
       return res;
     }
@@ -68,7 +68,7 @@ module SegmentedComputation {
         const mySegInds = {myFirstSegIdx..#myNumSegs};
         // Segment offsets whose bytes are owned by loc
         // Lengths of segments whose bytes are owned by loc
-        var mySegs, myLens: [mySegInds] int;
+        var mySegs, myLens = makeDistArray(mySegInds, int);
         forall i in mySegInds with (var agg = new SrcAggregator(int)) {
           agg.copy(mySegs[i], segments[i]);
           agg.copy(myLens[i], lengths[i]);
@@ -132,7 +132,7 @@ module SegmentedComputation {
 
   proc computeOnSegmentsWithoutAggregation(segments: [?D] int, ref values: [?vD] ?t, param function: SegFunction, type retType, const strArg: string = "") throws {
     // perform computeOnSegments logic for types that dont support aggregation (namely bigint)
-    var res: [D] retType;
+    var res = makeDistArray(D, retType);
     if (D.size == 0) {
       return res;
     }
@@ -147,7 +147,7 @@ module SegmentedComputation {
         const mySegInds = {myFirstSegIdx..#myNumSegs};
         // Segment offsets whose bytes are owned by loc
         // Lengths of segments whose bytes are owned by loc
-        var mySegs, myLens: [mySegInds] int;
+        var mySegs, myLens = makeDistArray(mySegInds, int);
         forall i in mySegInds with (var agg = new SrcAggregator(int)) {
           agg.copy(mySegs[i], segments[i]);
           agg.copy(myLens[i], lengths[i]);

--- a/src/SegmentedComputation.chpl
+++ b/src/SegmentedComputation.chpl
@@ -5,7 +5,7 @@ module SegmentedComputation {
   private use Cast;
   use Reflection;
 
-  proc computeSegmentOwnership(segments: [?D] int, vD) {
+  proc computeSegmentOwnership(segments: [?D] int, vD) throws {
     const low = vD.low;
     const size = vD.size;
     // Locale that owns each segment's bytes

--- a/src/SegmentedString.chpl
+++ b/src/SegmentedString.chpl
@@ -437,7 +437,7 @@ module SegmentedString {
     proc upper() throws {
       ref origVals = this.values.a;
       ref offs = this.offsets.a;
-      var upperVals: [this.values.a.domain] uint(8);
+      var upperVals = makeDistArray(this.values.a.domain, uint(8));
       const lengths = this.getLengths();
       forall (off, len) in zip(offs, lengths) with (var valAgg = newDstAggregator(uint(8))) {
         var i = 0;
@@ -523,12 +523,12 @@ module SegmentedString {
       }
     }
 
-    proc findSubstringInBytes(const substr: string) {
+    proc findSubstringInBytes(const substr: string) throws {
       // Find the start position of every occurence of substr in the flat bytes array
       // Start by making a right-truncated subdomain representing all valid starting positions for substr of given length
       var D: subdomain(values.a.domain) = values.a.domain[values.a.domain.low..#(values.size - substr.numBytes + 1)];
       // Every start position is valid until proven otherwise
-      var truth: [D] bool = true;
+      var truth = makeDistArray(D, true);
       // Shift the flat values one byte at a time and check against corresponding byte of substr
       for (b, i) in zip(substr.chpl_bytes(), 0..) {
         truth &= (values.a[D.translate(i)] == b);
@@ -1194,7 +1194,8 @@ module SegmentedString {
       if checkSorted && isSorted() {
           ssLogger.warn(getModuleName(),getRoutineName(),getLineNumber(),
                                                    "argsort called on already sorted array");
-          var ranks: [D] int = [i in D] i;
+          var ranks = makeDistArray(D, int);
+          ranks = [i in D] i;
           return ranks;
       }
       var ranks = twoPhaseStringSort(this);
@@ -1215,8 +1216,8 @@ module SegmentedString {
         o = i * (n + 1);
       }
       const retDom = makeDistDom(nFound * (n + 1));
-      var retBytes: [retDom] uint(8);
-      var srcInds: [retDom] int;
+      var retBytes = makeDistArray(retDom, uint(8));
+      var srcInds = makeDistArray(retDom, int);
       var dstInds = (+ scan longEnough) - longEnough;
       ref oa = offsets.a;
       if kind == Fixes.prefixes {

--- a/src/SegmentedString.chpl
+++ b/src/SegmentedString.chpl
@@ -1155,7 +1155,7 @@ module SegmentedString {
       return (newOffsets, newVals);
     }
 
-    proc ediff():[offsets.a.domain] int {
+    proc ediff():[offsets.a.domain] int throws {
       var diff = makeDistArray(offsets.a.domain, int);
       if (size < 2) {
         return diff;
@@ -1181,7 +1181,7 @@ module SegmentedString {
       return diff;
     }
 
-    proc isSorted():bool {
+    proc isSorted():bool throws {
       if (size < 2) {
         return true;
       }

--- a/src/SegmentedString.chpl
+++ b/src/SegmentedString.chpl
@@ -391,8 +391,8 @@ module SegmentedString {
     }
 
     /* Return lengths of all strings, including null terminator. */
-    proc getLengths() {
-      var lengths: [offsets.a.domain] int;
+    proc getLengths() throws {
+      var lengths = makeDistArray(offsets.a.domain, int);
       if (size == 0) {
         return lengths;
       }
@@ -418,7 +418,7 @@ module SegmentedString {
     proc lower() throws {
       ref origVals = this.values.a;
       ref offs = this.offsets.a;
-      var lowerVals: [this.values.a.domain] uint(8);
+      var lowerVals = makeDistArray(this.values.a.domain, uint(8));
       const lengths = this.getLengths();
       forall (off, len) in zip(offs, lengths) with (var valAgg = newDstAggregator(uint(8))) {
         var i = 0;
@@ -509,7 +509,7 @@ module SegmentedString {
         ref vals = values.a;
         // should we do strings.getLengths()-1 to not account for null byte
         const lens = getLengths();
-        var numeric1, numeric2: [offsets.a.domain] uint;
+        var numeric1, numeric2 = makeDistArray(offsets.a.domain, uint);
         forall (o, l, n1, n2) in zip(off, lens, numeric1, numeric2) {
           const half = (l/2):int;
           n1 = stringBytesToUintArr(vals, o..#half);

--- a/src/SortMsg.chpl
+++ b/src/SortMsg.chpl
@@ -62,7 +62,7 @@ module SortMsg
       proc doSort(a: [?D] ?t) throws {
         select algorithm {
           when SortingAlgorithm.TwoArrayRadixSort {
-            var b: [D] t = a;
+            var b = makeDistArray(a);
             Sort.TwoArrayRadixSort.twoArrayRadixSort(b, comparator=myDefaultComparator);
             return b;
           }

--- a/src/TimeClassMsg.chpl
+++ b/src/TimeClassMsg.chpl
@@ -47,14 +47,14 @@ module TimeClassMsg {
         var attributesDict = simpleAttributesHelper(valuesEntry.a, st);
 
         const valDom = valuesEntry.a.domain;
-        var year: [valDom] int;
-        var month: [valDom] int;
-        var day: [valDom] int;
-        var isoYear: [valDom] int;
-        var is_leap_year: [valDom] bool;
-        var weekOfYear: [valDom] int;
-        var dayOfYear: [valDom] int;
-        var dayOfWeek: [valDom] int;
+        var year = makeDistArray(valDom, int);
+        var month = makeDistArray(valDom, int);
+        var day = makeDistArray(valDom, int);
+        var isoYear = makeDistArray(valDom, int);
+        var is_leap_year = makeDistArray(valDom, bool);
+        var weekOfYear = makeDistArray(valDom, int);
+        var dayOfYear = makeDistArray(valDom, int);
+        var dayOfWeek = makeDistArray(valDom, int);
 
         forall (v, y, m, d, iso_y, is_ly, woy, doy, dow) in zip(valuesEntry.a, year, month, day, isoYear, is_leap_year, weekOfYear, dayOfYear, dayOfWeek) {
             // convert to seconds and create date

--- a/src/Unique.chpl
+++ b/src/Unique.chpl
@@ -67,8 +67,8 @@ module Unique
             var inv = makeDistArray(0, int);
             return (u, c, inv);
         }
-        var sorted: [aD] eltType;
-        var perm: [aD] int;
+        var sorted = makeDistArray(aD, eltType);
+        var perm = makeDistArray(aD, int);
         forall (s, p, sp) in zip(sorted, perm, radixSortLSD(a)) {
           (s, p) = sp;
         }
@@ -76,7 +76,7 @@ module Unique
         // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
         overMemLimit(numBytes(int) * c.size);
         var segs = (+ scan c) - c;
-        var bcast: [aD] int;
+        var bcast = makeDistArray(aD, int);
         forall s in segs with (var agg = newDstAggregator(int)) {
             agg.copy(bcast[s], 1);
         }
@@ -84,7 +84,7 @@ module Unique
         // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
         overMemLimit(numBytes(int) * bcast.size);
         bcast = (+ scan bcast);
-        var inv: [aD] int;
+        var inv = makeDistArray(aD, int);
         forall (p, b) in zip(perm, bcast) with (var agg = newDstAggregator(int)) {
             agg.copy(inv[p], b);
         }
@@ -92,7 +92,7 @@ module Unique
     }
     
     proc uniqueFromSorted(sorted: [?aD] ?eltType, param needCounts = true) throws {
-        var truth: [aD] bool;
+        var truth = makeDistArray(aD, bool);
         truth[0] = true;
         [(t, s, i) in zip(truth, sorted, aD)] if i > aD.low { t = (sorted[i-1] != s); }
         var allUnique: int = + reduce truth;
@@ -169,20 +169,20 @@ module Unique
         } else {
           invD = {0..-1};
         }
-        var inv: [invD] int;
-        var truth: [aD] bool;
-        var perm: [aD] int;
+        var inv = makeDistArray(invD, int);
+        var truth = makeDistArray(aD, bool);
+        var perm = makeDistArray(aD, int);
         if SegmentedStringUseHash {
           var hashes = str.siphash();
-          var sorted: [aD] 2*uint;
+          var sorted = makeDistArray(aD, 2*uint);
           forall (s, p, sp) in zip(sorted, perm, radixSortLSD(hashes)) {
             (s, p) = sp;
           }
           truth[0] = true;
           [(t, s, i) in zip(truth, sorted, aD)] if i > aD.low { t = (sorted[i-1] != s); }
         } else {
-          var soff: [aD] int;
-          var sval: [str.values.a.domain] uint(8);
+          var soff = makeDistArray(aD, int);
+          var sval = makeDistArray(str.values.a.domain, uint(8));
           perm = str.argsort();
           (soff, sval) = str[perm];
           truth[0] = true;
@@ -215,7 +215,7 @@ module Unique
             // check there's enough room to create a copy for scan and throw if creating a copy would go over memory limit
             overMemLimit(numBytes(int) * c.size);
             var segs = (+ scan c) - c;
-            var bcast: [invD] int;
+            var bcast = makeDistArray(invD, int);
             forall s in segs with (var agg = newDstAggregator(int)) {
                 agg.copy(bcast[s], 1);
             }

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -143,7 +143,7 @@ module UniqueMsg
       }
       proc helper(itemsize, type t, keys: [?D] t) throws {
         var permutation = createSymEntry(keys.size, int);
-        var sortedKeys: [D] t = keys;
+        var sortedKeys = makeDistArray(keys);
 
         if assumeSorted {
           // set permutation to 0..#size and go directly to finding segment boundaries.
@@ -224,7 +224,7 @@ module UniqueMsg
     proc hashArrays(size, names, types, st): [] 2*uint throws {
       overMemLimit(numBytes(uint) * size * 2);
       var dom = makeDistDom(size);
-      var hashes: [dom] 2*uint(64);
+      var hashes = makeDistArray(dom, 2*uint);
       /* Hashes of subsequent arrays cannot be simply XORed
        * because equivalent values will cancel each other out.
        * Thus, a non-linear function must be applied to each array,

--- a/src/compat/e-130/SymArrayDmapCompat.chpl
+++ b/src/compat/e-130/SymArrayDmapCompat.chpl
@@ -75,6 +75,11 @@ module SymArrayDmapCompat
       return res;
     }
 
+    proc makeDistArray(D: domain, initExpr: ?t) throws {
+      var res: [D] t = initExpr;
+      return res;
+    }
+
     /* 
     Returns the type of the distributed domain
 

--- a/src/compat/e-130/SymArrayDmapCompat.chpl
+++ b/src/compat/e-130/SymArrayDmapCompat.chpl
@@ -70,6 +70,11 @@ module SymArrayDmapCompat
         return a;
     }
 
+    proc makeDistArray(D: domain(1), type etype) {
+      var res: [D] etype;
+      return res;
+    }
+
     /* 
     Returns the type of the distributed domain
 

--- a/src/compat/e-130/SymArrayDmapCompat.chpl
+++ b/src/compat/e-130/SymArrayDmapCompat.chpl
@@ -69,7 +69,7 @@ module SymArrayDmapCompat
     proc makeDistArray(in a: [?D] ?etype) {
         return a;
     }
-    
+
     /* 
     Returns the type of the distributed domain
 

--- a/src/compat/eq-131/SymArrayDmapCompat.chpl
+++ b/src/compat/eq-131/SymArrayDmapCompat.chpl
@@ -75,6 +75,11 @@ module SymArrayDmapCompat
       return res;
     }
 
+    proc makeDistArray(D: domain, initExpr: ?t) throws {
+      var res: [D] t = initExpr;
+      return res;
+    }
+
     /* 
     Returns the type of the distributed domain
 

--- a/src/compat/eq-131/SymArrayDmapCompat.chpl
+++ b/src/compat/eq-131/SymArrayDmapCompat.chpl
@@ -70,6 +70,11 @@ module SymArrayDmapCompat
         return a;
     }
 
+    proc makeDistArray(D: domain(1), type etype) {
+      var res: [D] etype;
+      return res;
+    }
+
     /* 
     Returns the type of the distributed domain
 

--- a/src/compat/gt-131/SymArrayDmapCompat.chpl
+++ b/src/compat/gt-131/SymArrayDmapCompat.chpl
@@ -72,12 +72,12 @@ module SymArrayDmapCompat
       return res;
     }
 
-    proc makeDistArray(D: domain(1), type etype) throws {
+    proc makeDistArray(D: domain(?), type etype) throws {
       var res = D.tryCreateArray(etype);
       return res;
     }
 
-    proc makeDistArray(D: domain(1), initExpr: ?t) throws {
+    proc makeDistArray(D: domain(?), initExpr: ?t) throws {
       return D.tryCreateArray(t, initExpr);
     }
 

--- a/src/compat/gt-131/SymArrayDmapCompat.chpl
+++ b/src/compat/gt-131/SymArrayDmapCompat.chpl
@@ -72,6 +72,15 @@ module SymArrayDmapCompat
       return res;
     }
 
+    proc makeDistArray(D: domain(1), type etype) throws {
+      var res = D.tryCreateArray(etype);
+      return res;
+    }
+
+    proc makeDistArray(D: domain(1), initExpr: ?t) throws {
+      return D.tryCreateArray(t, initExpr);
+    }
+
     /* 
     Returns the type of the distributed domain
 


### PR DESCRIPTION
The initial work to convert array creations to the new throwing creations focused on symbol table entries, leaving out freestanding arrays created during a function. This PR converts those remaining arrays, meaning that all block distributed arrays created should be converted over to the new interface. Default rectangular arrays are not included and some of the more complex initialization expression arrays were not converted due to an internal error, but have been noted and are in progress as follow up work.

Closes #2790 