### PR TITLE
Closes #2472, #2800: Update IndexingMsg to use `&` instead of `mod` for setting bigint pdarrays

### DIFF
--- a/PROTO_tests/tests/indexing_test.py
+++ b/PROTO_tests/tests/indexing_test.py
@@ -106,5 +106,5 @@ class TestIndexing:
 
     def test_handling_bigint_max_bits(self):
         a = ak.arange(2**200 - 1, 2**200 + 11)
-        a.max_bits = 3
+        a[:] = ak.array(a, dtype=ak.bigint, max_bits=3)
         assert [7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2] == a.to_list()

--- a/PROTO_tests/tests/indexing_test.py
+++ b/PROTO_tests/tests/indexing_test.py
@@ -106,5 +106,5 @@ class TestIndexing:
 
     def test_handling_bigint_max_bits(self):
         a = ak.arange(2**200 - 1, 2**200 + 11, max_bits=3)
-        a[:] = ak.array(a, dtype=ak.bigint)
+        a[:] = ak.arange(2**200 - 1, 2**200 + 11)
         assert [7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2] == a.to_list()

--- a/PROTO_tests/tests/indexing_test.py
+++ b/PROTO_tests/tests/indexing_test.py
@@ -105,6 +105,6 @@ class TestIndexing:
         assert max_bits == a[:].max_bits
 
     def test_handling_bigint_max_bits(self):
-        a = ak.arange(2**200 - 1, 2**200 + 11)
-        a[:] = ak.array(a, dtype=ak.bigint, max_bits=3)
+        a = ak.arange(2**200 - 1, 2**200 + 11, max_bits=3)
+        a[:] = ak.array(a, dtype=ak.bigint)
         assert [7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2] == a.to_list()

--- a/PROTO_tests/tests/indexing_test.py
+++ b/PROTO_tests/tests/indexing_test.py
@@ -103,3 +103,8 @@ class TestIndexing:
         a = ak.arange(2**200 - 1, 2**200 + 11, max_bits=max_bits)
         assert max_bits == a[ak.arange(10)].max_bits
         assert max_bits == a[:].max_bits
+
+    def test_handling_bigint_max_bits(self):
+        a = ak.arange(2**200 - 1, 2**200 + 11)
+        a.max_bits = 3
+        assert [7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2] == a.to_list()

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -607,8 +607,8 @@ module IndexingMsg
             when (DType.BigInt, DType.BigInt) {
                 var e = toSymEntry(gEnt,bigint);
                 var val = valueArg.getBigIntValue();
-                var max_size = 1:bigint;
                 if e.max_bits != -1 {
+                    var max_size = 1:bigint;
                     max_size <<= e.max_bits;
                     max_size -= 1;
                     val &= max_size;
@@ -618,8 +618,8 @@ module IndexingMsg
             when (DType.BigInt, DType.Int64) {
                 var e = toSymEntry(gEnt,bigint);
                 var val = valueArg.getIntValue():bigint;
-                var max_size = 1:bigint;
                 if e.max_bits != -1 {
+                    var max_size = 1:bigint;
                     max_size <<= e.max_bits;
                     max_size -= 1;
                     val &= max_size;
@@ -629,8 +629,8 @@ module IndexingMsg
             when (DType.BigInt, DType.UInt64) {
                 var e = toSymEntry(gEnt,bigint);
                 var val = valueArg.getUIntValue():bigint;
-                var max_size = 1:bigint;
                 if e.max_bits != -1 {
+                    var max_size = 1:bigint;
                     max_size <<= e.max_bits;
                     max_size -= 1;
                     val &= max_size;
@@ -640,8 +640,8 @@ module IndexingMsg
             when (DType.BigInt, DType.Bool) {
                 var e = toSymEntry(gEnt,bigint);
                 var val = valueArg.getBoolValue():bigint;
-                var max_size = 1:bigint;
                 if e.max_bits != -1 {
+                    var max_size = 1:bigint;
                     max_size <<= e.max_bits;
                     max_size -= 1;
                     val &= max_size;
@@ -1161,8 +1161,8 @@ module IndexingMsg
             when (DType.BigInt, DType.BigInt) {
                 var e = toSymEntry(gEnt,bigint);
                 var val = value.getBigIntValue();
-                var max_size = 1:bigint;
                 if e.max_bits != -1 {
+                    var max_size = 1:bigint;
                     max_size <<= e.max_bits;
                     max_size -= 1;
                     val &= max_size;
@@ -1172,8 +1172,8 @@ module IndexingMsg
             when (DType.BigInt, DType.Int64) {
                 var e = toSymEntry(gEnt,bigint);
                 var val = value.getIntValue():bigint;
-                var max_size = 1:bigint;
                 if e.max_bits != -1 {
+                    var max_size = 1:bigint;
                     max_size <<= e.max_bits;
                     max_size -= 1;
                     val &= max_size;
@@ -1183,8 +1183,8 @@ module IndexingMsg
             when (DType.BigInt, DType.UInt64) {
                 var e = toSymEntry(gEnt,bigint);
                 var val = value.getUIntValue():bigint;
-                var max_size = 1:bigint;
                 if e.max_bits != -1 {
+                    var max_size = 1:bigint;
                     max_size <<= e.max_bits;
                     max_size -= 1;
                     val &= max_size;
@@ -1194,8 +1194,8 @@ module IndexingMsg
             when (DType.BigInt, DType.Bool) {
                 var e = toSymEntry(gEnt,bigint);
                 var val = value.getBoolValue():bigint;
-                var max_size = 1:bigint;
                 if e.max_bits != -1 {
+                    var max_size = 1:bigint;
                     max_size <<= e.max_bits;
                     max_size -= 1;
                     val &= max_size;
@@ -1332,8 +1332,8 @@ module IndexingMsg
             when (DType.BigInt, DType.BigInt) {
                 var x = toSymEntry(gX,bigint);
                 var y = toSymEntry(gY,bigint);
-                var max_size = 1:bigint;
                 if x.max_bits != -1 {
+                    var max_size = 1:bigint;
                     max_size <<= x.max_bits;
                     max_size -= 1;
                     forall y in y.a with (var local_max_size = max_size) {
@@ -1346,11 +1346,13 @@ module IndexingMsg
                 var x = toSymEntry(gX,bigint);
                 var y = toSymEntry(gY,int);
                 var ya = y.a:bigint;
-                var max_size = 1:bigint;
                 if x.max_bits != -1 {
+                    var max_size = 1:bigint;
                     max_size <<= x.max_bits;
                     max_size -= 1;
-                    ya &= max_size;
+                    forall y in ya with (var local_max_size = max_size) {
+                        y &= local_max_size;
+                    }
                 }
                 x.a[slice] = ya;
              }
@@ -1358,11 +1360,13 @@ module IndexingMsg
                 var x = toSymEntry(gX,bigint);
                 var y = toSymEntry(gY,uint);
                 var ya = y.a:bigint;
-                var max_size = 1:bigint;
                 if x.max_bits != -1 {
+                    var max_size = 1:bigint;
                     max_size <<= x.max_bits;
                     max_size -= 1;
-                    ya &= max_size;
+                    forall y in ya with (var local_max_size = max_size) {
+                        y &= local_max_size;
+                    }
                 }
                 x.a[slice] = ya;
              }
@@ -1371,11 +1375,13 @@ module IndexingMsg
                 var y = toSymEntry(gY,bool);
                 // TODO change once we can cast directly from bool to bigint
                 var ya = y.a:int:bigint;
-                var max_size = 1:bigint;
                 if x.max_bits != -1 {
+                    var max_size = 1:bigint;
                     max_size <<= x.max_bits;
                     max_size -= 1;
-                    ya &= max_size;
+                    forall y in ya with (var local_max_size = max_size) {
+                        y &= local_max_size;
+                    }
                 }
                 x.a[slice] = ya;
              }

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -608,7 +608,7 @@ module IndexingMsg
                 var e = toSymEntry(gEnt,bigint);
                 var val = valueArg.getBigIntValue();
                 if e.max_bits != -1 {
-                  mod(val, val, e.max_bits);
+                  val = val % e.max_bits;
                 }
                 e.a[idx] = val;
              }
@@ -616,7 +616,7 @@ module IndexingMsg
                 var e = toSymEntry(gEnt,bigint);
                 var val = valueArg.getIntValue():bigint;
                 if e.max_bits != -1 {
-                  mod(val, val, e.max_bits);
+                  val = val % e.max_bits;
                 }
                 e.a[idx] = val;
              }
@@ -624,7 +624,7 @@ module IndexingMsg
                 var e = toSymEntry(gEnt,bigint);
                 var val = valueArg.getUIntValue():bigint;
                 if e.max_bits != -1 {
-                  mod(val, val, e.max_bits);
+                  val = val % e.max_bits;
                 }
                 e.a[idx] = val;
              }
@@ -632,7 +632,7 @@ module IndexingMsg
                 var e = toSymEntry(gEnt,bigint);
                 var val = valueArg.getBoolValue():bigint;
                 if e.max_bits != -1 {
-                  mod(val, val, e.max_bits);
+                  val = val % e.max_bits;
                 }
                 e.a[idx] = val;
              }
@@ -1150,7 +1150,7 @@ module IndexingMsg
                 var e = toSymEntry(gEnt,bigint);
                 var val = value.getBigIntValue();
                 if e.max_bits != -1 {
-                  mod(val, val, e.max_bits);
+                  val = val % e.max_bits;
                 }
                 e.a[slice] = val;
              }
@@ -1158,7 +1158,7 @@ module IndexingMsg
                 var e = toSymEntry(gEnt,bigint);
                 var val = value.getIntValue():bigint;
                 if e.max_bits != -1 {
-                  mod(val, val, e.max_bits);
+                  val = val % e.max_bits;
                 }
                 e.a[slice] = val;
              }
@@ -1166,7 +1166,7 @@ module IndexingMsg
                 var e = toSymEntry(gEnt,bigint);
                 var val = value.getUIntValue():bigint;
                 if e.max_bits != -1 {
-                  mod(val, val, e.max_bits);
+                  val = val % e.max_bits;
                 }
                 e.a[slice] = val;
              }
@@ -1174,7 +1174,7 @@ module IndexingMsg
                 var e = toSymEntry(gEnt,bigint);
                 var val = value.getBoolValue():bigint;
                 if e.max_bits != -1 {
-                  mod(val, val, e.max_bits);
+                  val = val % e.max_bits;
                 }
                 e.a[slice] = val;
              }
@@ -1309,7 +1309,7 @@ module IndexingMsg
                 var x = toSymEntry(gX,bigint);
                 var y = toSymEntry(gY,bigint);
                 if x.max_bits != -1 {
-                    mod(y.a, y.a, x.max_bits);
+                    y.a = y.a % x.max_bits;
                 }
                 x.a[slice] = y.a;
              }
@@ -1318,7 +1318,7 @@ module IndexingMsg
                 var y = toSymEntry(gY,int);
                 var ya = y.a:bigint;
                 if x.max_bits != -1 {
-                    mod(ya, ya, x.max_bits);
+                    y.a = y.a % x.max_bits;
                 }
                 x.a[slice] = ya;
              }
@@ -1327,7 +1327,7 @@ module IndexingMsg
                 var y = toSymEntry(gY,uint);
                 var ya = y.a:bigint;
                 if x.max_bits != -1 {
-                    mod(ya, ya, x.max_bits);
+                    y.a = y.a % x.max_bits;
                 }
                 x.a[slice] = ya;
              }

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -608,12 +608,9 @@ module IndexingMsg
                 var e = toSymEntry(gEnt,bigint);
                 var val = valueArg.getBigIntValue();
                 var max_size = 1:bigint;
-                var has_max_bits = e.max_bits != -1;
-                if has_max_bits {
+                if e.max_bits != -1 {
                     max_size <<= e.max_bits;
                     max_size -= 1;
-                }
-                if has_max_bits {
                     val &= max_size;
                 }
                 e.a[idx] = val;
@@ -622,12 +619,9 @@ module IndexingMsg
                 var e = toSymEntry(gEnt,bigint);
                 var val = valueArg.getIntValue():bigint;
                 var max_size = 1:bigint;
-                var has_max_bits = e.max_bits != -1;
-                if has_max_bits {
+                if e.max_bits != -1 {
                     max_size <<= e.max_bits;
                     max_size -= 1;
-                }
-                if has_max_bits {
                     val &= max_size;
                 }
                 e.a[idx] = val;
@@ -636,12 +630,9 @@ module IndexingMsg
                 var e = toSymEntry(gEnt,bigint);
                 var val = valueArg.getUIntValue():bigint;
                 var max_size = 1:bigint;
-                var has_max_bits = e.max_bits != -1;
-                if has_max_bits {
+                if e.max_bits != -1 {
                     max_size <<= e.max_bits;
                     max_size -= 1;
-                }
-                if has_max_bits {
                     val &= max_size;
                 }
                 e.a[idx] = val;
@@ -650,12 +641,9 @@ module IndexingMsg
                 var e = toSymEntry(gEnt,bigint);
                 var val = valueArg.getBoolValue():bigint;
                 var max_size = 1:bigint;
-                var has_max_bits = e.max_bits != -1;
-                if has_max_bits {
+                if e.max_bits != -1 {
                     max_size <<= e.max_bits;
                     max_size -= 1;
-                }
-                if has_max_bits {
                     val &= max_size;
                 }
                 e.a[idx] = val;
@@ -1174,12 +1162,9 @@ module IndexingMsg
                 var e = toSymEntry(gEnt,bigint);
                 var val = value.getBigIntValue();
                 var max_size = 1:bigint;
-                var has_max_bits = e.max_bits != -1;
-                if has_max_bits {
+                if e.max_bits != -1 {
                     max_size <<= e.max_bits;
                     max_size -= 1;
-                }
-                if has_max_bits {
                     val &= max_size;
                 }
                 e.a[slice] = val;
@@ -1188,12 +1173,9 @@ module IndexingMsg
                 var e = toSymEntry(gEnt,bigint);
                 var val = value.getIntValue():bigint;
                 var max_size = 1:bigint;
-                var has_max_bits = e.max_bits != -1;
-                if has_max_bits {
+                if e.max_bits != -1 {
                     max_size <<= e.max_bits;
                     max_size -= 1;
-                }
-                if has_max_bits {
                     val &= max_size;
                 }
                 e.a[slice] = val;
@@ -1202,12 +1184,9 @@ module IndexingMsg
                 var e = toSymEntry(gEnt,bigint);
                 var val = value.getUIntValue():bigint;
                 var max_size = 1:bigint;
-                var has_max_bits = e.max_bits != -1;
-                if has_max_bits {
+                if e.max_bits != -1 {
                     max_size <<= e.max_bits;
                     max_size -= 1;
-                }
-                if has_max_bits {
                     val &= max_size;
                 }
                 e.a[slice] = val;
@@ -1216,12 +1195,9 @@ module IndexingMsg
                 var e = toSymEntry(gEnt,bigint);
                 var val = value.getBoolValue():bigint;
                 var max_size = 1:bigint;
-                var has_max_bits = e.max_bits != -1;
-                if has_max_bits {
+                if e.max_bits != -1 {
                     max_size <<= e.max_bits;
                     max_size -= 1;
-                }
-                if has_max_bits {
                     val &= max_size;
                 }
                 e.a[slice] = val;
@@ -1357,13 +1333,12 @@ module IndexingMsg
                 var x = toSymEntry(gX,bigint);
                 var y = toSymEntry(gY,bigint);
                 var max_size = 1:bigint;
-                var has_max_bits = x.max_bits != -1;
-                if has_max_bits {
+                if x.max_bits != -1 {
                     max_size <<= x.max_bits;
                     max_size -= 1;
-                }
-                if has_max_bits {
-                    y.a &= max_size;
+                    forall y in y.a with (var local_max_size = max_size) {
+                        y &= local_max_size;
+                    }
                 }
                 x.a[slice] = y.a;
              }
@@ -1372,12 +1347,9 @@ module IndexingMsg
                 var y = toSymEntry(gY,int);
                 var ya = y.a:bigint;
                 var max_size = 1:bigint;
-                var has_max_bits = x.max_bits != -1;
-                if has_max_bits {
+                if x.max_bits != -1 {
                     max_size <<= x.max_bits;
                     max_size -= 1;
-                }
-                if has_max_bits {
                     ya &= max_size;
                 }
                 x.a[slice] = ya;
@@ -1387,12 +1359,9 @@ module IndexingMsg
                 var y = toSymEntry(gY,uint);
                 var ya = y.a:bigint;
                 var max_size = 1:bigint;
-                var has_max_bits = x.max_bits != -1;
-                if has_max_bits {
+                if x.max_bits != -1 {
                     max_size <<= x.max_bits;
                     max_size -= 1;
-                }
-                if has_max_bits {
                     ya &= max_size;
                 }
                 x.a[slice] = ya;
@@ -1403,12 +1372,9 @@ module IndexingMsg
                 // TODO change once we can cast directly from bool to bigint
                 var ya = y.a:int:bigint;
                 var max_size = 1:bigint;
-                var has_max_bits = x.max_bits != -1;
-                if has_max_bits {
+                if x.max_bits != -1 {
                     max_size <<= x.max_bits;
                     max_size -= 1;
-                }
-                if has_max_bits {
                     ya &= max_size;
                 }
                 x.a[slice] = ya;

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -607,32 +607,56 @@ module IndexingMsg
             when (DType.BigInt, DType.BigInt) {
                 var e = toSymEntry(gEnt,bigint);
                 var val = valueArg.getBigIntValue();
-                if e.max_bits != -1 {
-                  val = val % e.max_bits;
+                var max_size = 1:bigint;
+                var has_max_bits = e.max_bits != -1;
+                if has_max_bits {
+                    max_size <<= e.max_bits;
+                    max_size -= 1;
+                }
+                if has_max_bits {
+                    val &= max_size;
                 }
                 e.a[idx] = val;
              }
             when (DType.BigInt, DType.Int64) {
                 var e = toSymEntry(gEnt,bigint);
                 var val = valueArg.getIntValue():bigint;
-                if e.max_bits != -1 {
-                  val = val % e.max_bits;
+                var max_size = 1:bigint;
+                var has_max_bits = e.max_bits != -1;
+                if has_max_bits {
+                    max_size <<= e.max_bits;
+                    max_size -= 1;
+                }
+                if has_max_bits {
+                    val &= max_size;
                 }
                 e.a[idx] = val;
              }
             when (DType.BigInt, DType.UInt64) {
                 var e = toSymEntry(gEnt,bigint);
                 var val = valueArg.getUIntValue():bigint;
-                if e.max_bits != -1 {
-                  val = val % e.max_bits;
+                var max_size = 1:bigint;
+                var has_max_bits = e.max_bits != -1;
+                if has_max_bits {
+                    max_size <<= e.max_bits;
+                    max_size -= 1;
+                }
+                if has_max_bits {
+                    val &= max_size;
                 }
                 e.a[idx] = val;
              }
             when (DType.BigInt, DType.Bool) {
                 var e = toSymEntry(gEnt,bigint);
                 var val = valueArg.getBoolValue():bigint;
-                if e.max_bits != -1 {
-                  val = val % e.max_bits;
+                var max_size = 1:bigint;
+                var has_max_bits = e.max_bits != -1;
+                if has_max_bits {
+                    max_size <<= e.max_bits;
+                    max_size -= 1;
+                }
+                if has_max_bits {
+                    val &= max_size;
                 }
                 e.a[idx] = val;
              }
@@ -1149,32 +1173,56 @@ module IndexingMsg
             when (DType.BigInt, DType.BigInt) {
                 var e = toSymEntry(gEnt,bigint);
                 var val = value.getBigIntValue();
-                if e.max_bits != -1 {
-                  val = val % e.max_bits;
+                var max_size = 1:bigint;
+                var has_max_bits = e.max_bits != -1;
+                if has_max_bits {
+                    max_size <<= e.max_bits;
+                    max_size -= 1;
+                }
+                if has_max_bits {
+                    val &= max_size;
                 }
                 e.a[slice] = val;
              }
             when (DType.BigInt, DType.Int64) {
                 var e = toSymEntry(gEnt,bigint);
                 var val = value.getIntValue():bigint;
-                if e.max_bits != -1 {
-                  val = val % e.max_bits;
+                var max_size = 1:bigint;
+                var has_max_bits = e.max_bits != -1;
+                if has_max_bits {
+                    max_size <<= e.max_bits;
+                    max_size -= 1;
+                }
+                if has_max_bits {
+                    val &= max_size;
                 }
                 e.a[slice] = val;
              }
             when (DType.BigInt, DType.UInt64) {
                 var e = toSymEntry(gEnt,bigint);
                 var val = value.getUIntValue():bigint;
-                if e.max_bits != -1 {
-                  val = val % e.max_bits;
+                var max_size = 1:bigint;
+                var has_max_bits = e.max_bits != -1;
+                if has_max_bits {
+                    max_size <<= e.max_bits;
+                    max_size -= 1;
+                }
+                if has_max_bits {
+                    val &= max_size;
                 }
                 e.a[slice] = val;
              }
             when (DType.BigInt, DType.Bool) {
                 var e = toSymEntry(gEnt,bigint);
                 var val = value.getBoolValue():bigint;
-                if e.max_bits != -1 {
-                  val = val % e.max_bits;
+                var max_size = 1:bigint;
+                var has_max_bits = e.max_bits != -1;
+                if has_max_bits {
+                    max_size <<= e.max_bits;
+                    max_size -= 1;
+                }
+                if has_max_bits {
+                    val &= max_size;
                 }
                 e.a[slice] = val;
              }
@@ -1308,8 +1356,14 @@ module IndexingMsg
             when (DType.BigInt, DType.BigInt) {
                 var x = toSymEntry(gX,bigint);
                 var y = toSymEntry(gY,bigint);
-                if x.max_bits != -1 {
-                    y.a = y.a % x.max_bits;
+                var max_size = 1:bigint;
+                var has_max_bits = x.max_bits != -1;
+                if has_max_bits {
+                    max_size <<= x.max_bits;
+                    max_size -= 1;
+                }
+                if has_max_bits {
+                    y.a &= max_size;
                 }
                 x.a[slice] = y.a;
              }
@@ -1317,8 +1371,14 @@ module IndexingMsg
                 var x = toSymEntry(gX,bigint);
                 var y = toSymEntry(gY,int);
                 var ya = y.a:bigint;
-                if x.max_bits != -1 {
-                    y.a = y.a % x.max_bits;
+                var max_size = 1:bigint;
+                var has_max_bits = x.max_bits != -1;
+                if has_max_bits {
+                    max_size <<= x.max_bits;
+                    max_size -= 1;
+                }
+                if has_max_bits {
+                    ya &= max_size;
                 }
                 x.a[slice] = ya;
              }
@@ -1326,8 +1386,14 @@ module IndexingMsg
                 var x = toSymEntry(gX,bigint);
                 var y = toSymEntry(gY,uint);
                 var ya = y.a:bigint;
-                if x.max_bits != -1 {
-                    y.a = y.a % x.max_bits;
+                var max_size = 1:bigint;
+                var has_max_bits = x.max_bits != -1;
+                if has_max_bits {
+                    max_size <<= x.max_bits;
+                    max_size -= 1;
+                }
+                if has_max_bits {
+                    ya &= max_size;
                 }
                 x.a[slice] = ya;
              }
@@ -1336,8 +1402,14 @@ module IndexingMsg
                 var y = toSymEntry(gY,bool);
                 // TODO change once we can cast directly from bool to bigint
                 var ya = y.a:int:bigint;
-                if x.max_bits != -1 {
-                    mod(ya, ya, x.max_bits);
+                var max_size = 1:bigint;
+                var has_max_bits = x.max_bits != -1;
+                if has_max_bits {
+                    max_size <<= x.max_bits;
+                    max_size -= 1;
+                }
+                if has_max_bits {
+                    ya &= max_size;
                 }
                 x.a[slice] = ya;
              }

--- a/tests/indexing_test.py
+++ b/tests/indexing_test.py
@@ -91,6 +91,6 @@ class IndexingTest(ArkoudaTest):
         self.assertEqual(max_bits, a[:].max_bits)
 
     def test_handling_bigint_max_bits(self):
-        a = ak.arange(2**200 - 1, 2**200 + 11)
-        a[:] = ak.array(a, dtype=ak.bigint, max_bits=3)
+        a = ak.arange(2**200 - 1, 2**200 + 11, max_bits=3)
+        a[:] = ak.array(a, dtype=ak.bigint)
         self.assertListEqual([7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2], a.to_list())

--- a/tests/indexing_test.py
+++ b/tests/indexing_test.py
@@ -89,3 +89,8 @@ class IndexingTest(ArkoudaTest):
         a = ak.arange(2**200 - 1, 2**200 + 11, max_bits=max_bits)
         self.assertEqual(max_bits, a[ak.arange(10)].max_bits)
         self.assertEqual(max_bits, a[:].max_bits)
+
+    def test_handling_bigint_max_bits(self):
+        a = ak.arange(2**200 - 1, 2**200 + 11)
+        a[:] = ak.array(a, dtype=ak.bigint, max_bits=3)
+        self.assertListEqual([7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2], a.to_list())

--- a/tests/indexing_test.py
+++ b/tests/indexing_test.py
@@ -92,5 +92,5 @@ class IndexingTest(ArkoudaTest):
 
     def test_handling_bigint_max_bits(self):
         a = ak.arange(2**200 - 1, 2**200 + 11, max_bits=3)
-        a[:] = ak.array(a, dtype=ak.bigint)
+        a[:] = ak.arange(2**200 - 1, 2**200 + 11)
         self.assertListEqual([7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2], a.to_list())


### PR DESCRIPTION
This PR (Closes #2472 and closes #2800) updates the function calls of `mod` in IndexingMsg to use `%`, as they are more efficient.
The `bool` case still needs to be updated as there is not a way to directly cast a `bigint` to a `bool`.

Leaving as a draft until I know if this last case can be completed without this casting feature.