### PR TITLE
Closes #2794: Fix distributed makeDistArray call for Chapel 1.30 and 1.31

### DIFF
--- a/src/compat/e-130/SymArrayDmapCompat.chpl
+++ b/src/compat/e-130/SymArrayDmapCompat.chpl
@@ -70,7 +70,7 @@ module SymArrayDmapCompat
         return a;
     }
 
-    proc makeDistArray(D: domain(1), type etype) {
+    proc makeDistArray(D: domain, type etype) {
       var res: [D] etype;
       return res;
     }

--- a/src/compat/eq-131/SymArrayDmapCompat.chpl
+++ b/src/compat/eq-131/SymArrayDmapCompat.chpl
@@ -70,7 +70,7 @@ module SymArrayDmapCompat
         return a;
     }
 
-    proc makeDistArray(D: domain(1), type etype) {
+    proc makeDistArray(D: domain, type etype) {
       var res: [D] etype;
       return res;
     }


### PR DESCRIPTION
In the compatability modules for 1.30 and 1.31, one of the `makeDistArray` calls had a `domain(1)`, which is treated as a default rectangular array, meaning that block arrays cannot be passed to the function. Removing the `(1)` and getting it back to a generic domain fixes this issue.

Closes #2794 