### PR TITLE
Closes #2796: Reduce Parquet IO benchmark default size

### DIFF
--- a/benchmarks/parquetIO.py
+++ b/benchmarks/parquetIO.py
@@ -17,7 +17,7 @@ def create_parser():
     parser.add_argument("hostname", help="Hostname of arkouda server")
     parser.add_argument("port", type=int, help="Port of arkouda server")
     parser.add_argument(
-        "-n", "--size", type=int, default=10**8, help="Problem size: length of array to read/write"
+        "-n", "--size", type=int, default=10**6, help="Problem size: length of array to read/write"
     )
     parser.add_argument(
         "-t", "--trials", type=int, default=1, help="Number of times to run the benchmark"


### PR DESCRIPTION
Since the Parquet IO benchmark is now testing many different compression formats, some of those can take a long time. Reducing the default problem size to keep the total time of the benchmark under 5 minutes for 16-node testing.

Closes #2796