### PR TITLE
Cloases #2798: Resolve `chpl 1.32` deprecations for `make check-deps`

### DIFF
--- a/dep/checkArrow.chpl
+++ b/dep/checkArrow.chpl
@@ -6,7 +6,7 @@ require "../src/ArrowFunctions.h";
 require "../src/ArrowFunctions.o";
 
 proc getVersionInfo() {
-  extern proc c_getVersionInfo(): c_string;
+  extern proc c_getVersionInfo(): c_string_ptr;
   extern proc strlen(str): c_int;
   extern proc c_free_string(ptr);
   var cVersionString = c_getVersionInfo();

--- a/dep/checkHDF5.chpl
+++ b/dep/checkHDF5.chpl
@@ -1,8 +1,9 @@
 use HDF5, CTypes;
+use ArkoudaIOCompat;
 
 proc main() {
   var H5major: c_uint, H5minor: c_uint, H5micro: c_uint;
   C_HDF5.H5get_libversion(H5major, H5minor, H5micro);
-  writef("Found HDF5 version: %t.%t.%t\n", H5major, H5minor, H5micro);
+  writef("Found HDF5 version: %?.%?.%?\n", H5major, H5minor, H5micro);
   return 0;
 }

--- a/dep/checkHDF5.chpl
+++ b/dep/checkHDF5.chpl
@@ -4,6 +4,6 @@ use ArkoudaIOCompat;
 proc main() {
   var H5major: c_uint, H5minor: c_uint, H5micro: c_uint;
   C_HDF5.H5get_libversion(H5major, H5minor, H5micro);
-  writef("Found HDF5 version: %?.%?.%?\n", H5major, H5minor, H5micro);
+  writefCompat("Found HDF5 version: %?.%?.%?\n", H5major, H5minor, H5micro);
   return 0;
 }

--- a/dep/checkIconv.chpl
+++ b/dep/checkIconv.chpl
@@ -1,8 +1,9 @@
 use iconv;
+use ArkoudaCTypesCompat;
 
 proc main() {
-  var enc = "UTF-8";
-  var cd = libiconv_open(enc.c_str(), enc.c_str());
+  var enc = "UTF-8": c_string_ptr;
+  var cd = libiconv_open(enc, enc);
   libiconv_close(cd);
   writeln("Found libiconv version: ", _libiconv_version);
 }

--- a/dep/checkIdn2.chpl
+++ b/dep/checkIdn2.chpl
@@ -1,7 +1,8 @@
-use idna, CTypes;
+use idna;
+use ArkoudaCTypesCompat;
 
 proc main() {
-  extern proc idn2_check_version(a): c_string;
+  extern proc idn2_check_version(a): c_string_ptr;
   var idnaCVerStr = idn2_check_version(nil);
   writeln("Found idn2 version: ", idnaCVerStr:string);
 }

--- a/dep/checkZMQ.chpl
+++ b/dep/checkZMQ.chpl
@@ -3,6 +3,6 @@ use ArkoudaIOCompat;
 
 proc main() {
   var (Zmajor, Zminor, Zmicro) = ZMQ.version;
-  writef("Found ZMQ version: %?.%?.%?\n", Zmajor, Zminor, Zmicro);
+  writefCompat("Found ZMQ version: %?.%?.%?\n", Zmajor, Zminor, Zmicro);
   return 0;
 }

--- a/dep/checkZMQ.chpl
+++ b/dep/checkZMQ.chpl
@@ -1,7 +1,8 @@
 use ZMQ;
+use ArkoudaIOCompat;
 
 proc main() {
   var (Zmajor, Zminor, Zmicro) = ZMQ.version;
-  writef("Found ZMQ version: %t.%t.%t\n", Zmajor, Zminor, Zmicro);
+  writef("Found ZMQ version: %?.%?.%?\n", Zmajor, Zminor, Zmicro);
   return 0;
 }

--- a/src/compat/e-130/ArkoudaIOCompat.chpl
+++ b/src/compat/e-130/ArkoudaIOCompat.chpl
@@ -48,6 +48,11 @@ module ArkoudaIOCompat {
     nreader.readf("%jt", obj);
   }
 
+  proc writefCompat(fmt: ?t, const args ...?k) where isStringType(t) || isBytesType(t) {
+    var newFmt = fmt.replace('%?', '%t');
+    writef(newFmt, (...args));
+  }
+
   proc getByteOrderCompat() throws {
     use IO;
     var writeVal = 1, readVal = 0;

--- a/src/compat/eq-131/ArkoudaIOCompat.chpl
+++ b/src/compat/eq-131/ArkoudaIOCompat.chpl
@@ -43,6 +43,11 @@ module ArkoudaIOCompat {
     return array;
   }
 
+  proc writefCompat(fmt: ?t, const args ...?k) where isStringType(t) || isBytesType(t) {
+    var newFmt = fmt.replace('%?', '%t');
+    writef(newFmt, (...args));
+  }
+
   proc readfCompat(f: file, str: string, ref obj) throws {
     var nreader = f.reader();
     nreader.readf("%jt", obj);

--- a/src/compat/gt-131/ArkoudaIOCompat.chpl
+++ b/src/compat/gt-131/ArkoudaIOCompat.chpl
@@ -45,6 +45,10 @@ module ArkoudaIOCompat {
     return array;
   }
 
+  proc writefCompat(fmt: ?t, const args ...?k) where isStringType(t) || isBytesType(t) {
+    writef(fmt, (...args));
+  }
+
   proc readfCompat(f: file, str: string, ref obj) throws {
     var nreader = f.reader(deserializer=new jsonDeserializer());
     nreader.readf("%?", obj);


### PR DESCRIPTION
This PR (closes #2798) updates the `make check-deps` files to use the compat modules to avoid the `1.32` deprecation warnings