### PR TITLE
Fixes #2802: `concatenate` and `arange` mishandling `max_bits`

### DIFF
--- a/PROTO_tests/tests/operator_test.py
+++ b/PROTO_tests/tests/operator_test.py
@@ -214,6 +214,12 @@ class TestOperator:
         assert dtype == ak_concat.dtype.name
         assert np.allclose(ak_concat.to_ndarray(), np_concat)
 
+    def test_max_bits_concatenation(self):
+        # reproducer for issue #2802
+        concatenated = ak.concatenate([ak.arange(5, max_bits=3), ak.arange(2**200 - 1, 2**200 + 4)])
+        assert concatenated.max_bits == 3
+        assert [0, 1, 2, 3, 4, 7, 0, 1, 2, 3] == concatenated.to_list()
+
     def test_fixed_concatenate(self):
         for pda1, pda2 in zip(
             (ak.arange(4), ak.linspace(0, 3, 4)), (ak.arange(4, 7), ak.linspace(4, 6, 3))

--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -786,8 +786,6 @@ def arange(*args, **kwargs) -> pdarray:
     >>> ak.arange(-5, -10, -1)
     array([-5, -6, -7, -8, -9])
     """
-    from arkouda.numeric import cast as akcast
-
     # if one arg is given then arg is stop
     if len(args) == 1:
         start = 0
@@ -814,10 +812,9 @@ def arange(*args, **kwargs) -> pdarray:
 
     if isSupportedInt(start) and isSupportedInt(stop) and isSupportedInt(stride):
         arg_dtypes = [resolve_scalar_dtype(arg) for arg in (start, stop, stride)]
-        max_bits = None
+        max_bits = -1 if "max_bits" not in kwargs.keys() else kwargs["max_bits"]
         arg_dtype = "int64"
-        if dtype in ["bigint", bigint] or "bigint" in arg_dtypes:
-            max_bits = None if "max_bits" not in kwargs.keys() else kwargs["max_bits"]
+        if dtype in ["bigint", bigint] or "bigint" in arg_dtypes or max_bits != -1:
             arg_dtype = "bigint"
         elif "uint64" in arg_dtypes:
             arg_dtype = "uint64"
@@ -830,7 +827,7 @@ def arange(*args, **kwargs) -> pdarray:
         return (
             create_pdarray(repMsg, max_bits=max_bits)
             if dtype == akint64
-            else akcast(create_pdarray(repMsg, max_bits=max_bits), dtype)
+            else array(create_pdarray(repMsg), max_bits=max_bits, dtype=dtype)
         )
     else:
         raise TypeError(

--- a/src/ConcatenateMsg.chpl
+++ b/src/ConcatenateMsg.chpl
@@ -361,6 +361,14 @@ module ConcatenateMsg
                               start += o.size;
                             }
                         }
+                        if max_bits != -1 {
+                          var max_size = 1:bigint;
+                          max_size <<= max_bits;
+                          max_size -= 1;
+                          forall t in tmp with (var local_max_size = max_size) {
+                            t &= local_max_size;
+                          }
+                        }
                         st.addEntry(rname, createSymEntry(tmp, max_bits));
                         cmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                          "created concatenated pdarray: %s".doFormat(st.attrib(rname)));

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -293,6 +293,12 @@ class OperatorsTest(ArkoudaTest):
             ak.concatenate([pdaOne, pdaTwo]).to_list(),
         )
 
+        pdaOne = ak.arange(5, max_bits=3)
+        pdaTwo = ak.arange(2**200 - 1, 2**200 + 4)
+        concatenated = ak.concatenate([pdaOne, pdaTwo])
+        self.assertEqual(concatenated.max_bits, 3)
+        self.assertListEqual([0, 1, 2, 3, 4, 7, 0, 1, 2, 3], concatenated.to_list())
+
     def test_invert(self):
         ak_uint = ak.arange(10, dtype=ak.uint64)
         inverted = ~ak_uint
@@ -733,8 +739,10 @@ class OperatorsTest(ArkoudaTest):
         # Printing floating point values changed precision in Chapel 1.32
         answers = ["[1.100000e+00 2.300000e+00 5.000000e+00]", "[1.1 2.3 5.0]"]
         self.assertTrue(ak.array([1.1, 2.3, 5]).__str__() in answers)
-        answers = ["[0.000000e+00 5.263158e-01 1.052632e+00 ... 8.947368e+00 9.473684e+00 1.000000e+01]",
-                   "[0.0 0.526316 1.05263 ... 8.94737 9.47368 10.0]"]
+        answers = [
+            "[0.000000e+00 5.263158e-01 1.052632e+00 ... 8.947368e+00 9.473684e+00 1.000000e+01]",
+            "[0.0 0.526316 1.05263 ... 8.94737 9.47368 10.0]",
+        ]
         self.assertTrue(ak.linspace(0, 10, 20).__str__() in answers)
         self.assertEqual("[False False False]", ak.isnan(ak.array([1.1, 2.3, 5])).__str__())
         self.assertEqual(
@@ -744,14 +752,18 @@ class OperatorsTest(ArkoudaTest):
         # Test __repr__()
         self.assertEqual("array([1 2 3])", ak.array([1, 2, 3]).__repr__())
         self.assertEqual("array([1 2 3 ... 17 18 19])", ak.arange(1, 20).__repr__())
-        answers = ["array([1.1000000000000001 2.2999999999999998 5])",
-                   "array([1.1 2.3 5])",
-                   "array([1.1000000000000001 2.2999999999999998 5.00000000000000000])"]
+        answers = [
+            "array([1.1000000000000001 2.2999999999999998 5])",
+            "array([1.1 2.3 5])",
+            "array([1.1000000000000001 2.2999999999999998 5.00000000000000000])",
+        ]
         self.assertTrue(ak.array([1.1, 2.3, 5]).__repr__() in answers)
 
-        answers = ["array([0 0.52631578947368418 1.0526315789473684 ... 8.9473684210526319 9.473684210526315 10])",
-                   "array([0 0.5 1.1 ... 8.9 9.5 10])",
-                   "array([0.00000000000000000 0.52631578947368418 1.0526315789473684 ... 8.9473684210526319 9.473684210526315 10.00000000000000000])"]
+        answers = [
+            "array([0 0.52631578947368418 1.0526315789473684 ... 8.9473684210526319 9.473684210526315 10])",
+            "array([0 0.5 1.1 ... 8.9 9.5 10])",
+            "array([0.00000000000000000 0.52631578947368418 1.0526315789473684 ... 8.9473684210526319 9.473684210526315 10.00000000000000000])",
+        ]
         self.assertTrue(ak.linspace(0, 10, 20).__repr__() in answers)
         self.assertEqual("array([False False False])", ak.isnan(ak.array([1.1, 2.3, 5])).__repr__())
         self.assertEqual(


### PR DESCRIPTION
This PR (fixes #2802) fixes concatenate and arange's handling of `max_bits`