### PR TITLE
Closes #2805: Upgrade arrow to 11 and add python 3.x compat 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.x']
     container:
       image: chapel/chapel:1.31.0
     steps:

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ install-hdf5:
 	rm -rf $(HDF5_BUILD_DIR)
 	echo '$$(eval $$(call add-path,$(HDF5_INSTALL_DIR)))' >> Makefile.paths
 
-ARROW_VER := 9.0.0
+ARROW_VER := 11.0.0
 ARROW_NAME_VER := apache-arrow-$(ARROW_VER)
 ARROW_FULL_NAME_VER := arrow-apache-arrow-$(ARROW_VER)
 ARROW_BUILD_DIR := $(DEP_BUILD_DIR)/$(ARROW_FULL_NAME_VER)

--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -16,7 +16,7 @@ dependencies:
   - pip
   - types-tabulate
   - pytables>=3.7.0,<3.9.0
-  - pyarrow==9.0.0
+  - pyarrow==11.0.0
   - libiconv
   - libidn2
 

--- a/arkouda-env.yml
+++ b/arkouda-env.yml
@@ -16,7 +16,7 @@ dependencies:
   - pip
   - types-tabulate
   - pytables>=3.7.0,<3.9.0
-  - pyarrow==9.0.0
+  - pyarrow==11.0.0
   - libiconv
   - libidn2
 

--- a/pydoc/requirements.txt
+++ b/pydoc/requirements.txt
@@ -13,7 +13,7 @@ hdf5==1.12.2
 pip
 types-tabulate
 tables>=3.7.0,<3.9.0
-pyarrow==9.0.0
+pyarrow==11.0.0
 libiconv
 libidn2
 

--- a/pydoc/setup/REQUIREMENTS.md
+++ b/pydoc/setup/REQUIREMENTS.md
@@ -31,7 +31,7 @@ The following python packages are required by the Arkouda client package.
 - `pip`
 - `types-tabulate`
 - `tables>=3.7.0,<3.9.0`
-- `pyarrow>=1.0.1`
+- `pyarrow==11.0.0`
 
 ### Developer Specific
 

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ setup(
         'pip',
         'types-tabulate',
         'tables>=3.7.0,<3.9.0',
-        'pyarrow==9.0.0',
+        'pyarrow==11.0.0',
     ],
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
This PR (closes https://github.com/Bears-R-Us/arkouda/issues/2805) upgrades to arrow v11.0.0 and adds back in python 3.x compat checks