### PR TITLE
Closes #2807: Pin `tables<3.9.0` to avoid CI failures 

### DIFF
--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -15,7 +15,7 @@ dependencies:
   - hdf5==1.12.2
   - pip
   - types-tabulate
-  - pytables>=3.7.0
+  - pytables>=3.7.0,<3.9.0
   - pyarrow==9.0.0
   - libiconv
   - libidn2

--- a/arkouda-env.yml
+++ b/arkouda-env.yml
@@ -15,7 +15,7 @@ dependencies:
   - hdf5==1.12.2
   - pip
   - types-tabulate
-  - pytables>=3.7.0
+  - pytables>=3.7.0,<3.9.0
   - pyarrow==9.0.0
   - libiconv
   - libidn2

--- a/pydoc/requirements.txt
+++ b/pydoc/requirements.txt
@@ -12,7 +12,7 @@ h5py>=3.7.0
 hdf5==1.12.2
 pip
 types-tabulate
-tables>=3.7.0
+tables>=3.7.0,<3.9.0
 pyarrow==9.0.0
 libiconv
 libidn2

--- a/pydoc/setup/REQUIREMENTS.md
+++ b/pydoc/setup/REQUIREMENTS.md
@@ -30,7 +30,7 @@ The following python packages are required by the Arkouda client package.
 - `hdf5==1.12.2`
 - `pip`
 - `types-tabulate`
-- `tables>=3.7.0`
+- `tables>=3.7.0,<3.9.0`
 - `pyarrow>=1.0.1`
 
 ### Developer Specific

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ setup(
         'h5py>=3.7.0',
         'pip',
         'types-tabulate',
-        'tables>=3.7.0',
+        'tables>=3.7.0,<3.9.0',
         'pyarrow==9.0.0',
     ],
 


### PR DESCRIPTION
This PR (closes https://github.com/Bears-R-Us/arkouda/issues/2807) pins `tables` to `<3.9.0` to avoid [CI failures](https://github.com/Bears-R-Us/arkouda/actions/runs/6421296595/job/17435712872?pr=2793). `table==3.9.0` pulls down `cython==3.0.3` which requires `python>=3.9`.

Cython [just released a new version](https://pypi.org/project/Cython/) yesterday, which according to the error message in the CI requires python >3.9
```
Downloading Cython-3.0.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (3.2 kB)
ERROR: Ignored the following versions that require a different python version: 2.2.8 Requires-Python <4,>=3.9
```

We have some users who are still using 3.8, so for the time being let's pin to `tables<3.9.0`