### PR TITLE
Fixes #2804: Missing values in CSV bug

### DIFF
--- a/src/ServerErrors.chpl
+++ b/src/ServerErrors.chpl
@@ -186,6 +186,18 @@ module ServerErrors {
         proc init(){ super.init(); }
     }
 
+    /*
+     * The IOError is thrown if there is an error in IO code.
+     */
+    class IOError: ErrorWithContext {
+
+        proc init(msg : string, lineNumber: int, routineName: string,
+                                                           moduleName: string) {
+           super.init(msg,lineNumber,routineName,moduleName,errorClass='IOError');
+        }
+
+        proc init(){ super.init(); }
+    }
 
     /*
      * Generatea a detailed, context-rich error message for errors such as instances of 
@@ -265,7 +277,12 @@ module ServerErrors {
                                                           UnknownSymbolError(msg=msg,
                                                           lineNumber=lineNumber,
                                                           routineName=routineName,
-                                                          moduleName=moduleName); }                                                                                                                 
+                                                          moduleName=moduleName); }
+            when "IOError"                       { return new owned
+                                                          IOError(msg=msg,
+                                                          lineNumber=lineNumber,
+                                                          routineName=routineName,
+                                                          moduleName=moduleName); }
             otherwise                            { return new owned 
                                                           Error(generateErrorContext(
                                                           msg=msg,


### PR DESCRIPTION
Missing values in a CSV are interpreted as an empty string, which causes a bad cast when the column dtype `!= string`. This PR (fixes #2804) throws an `IOError` for missing values in a CSV file unless the `allow_errors` flag is set

If `allow_errors` is True, then any missing values are replaced with `min(col_dtype)`. In the future, we can look into converting the column to a float and using `nan`s. This matches pandas, but we don't know if there's missing values in a column until we've already started reading. So I'm not convinced there's gonna be an efficient way to do this. I'll sync with @egelberg and @alvaradoo and see what makes since

Working this bug uncovered an issue when an error is thrown in a parallel loop, this is being investigated further in https://github.com/chapel-lang/chapel/issues/23648. This would lose information on the error (giving the error message `RuntimeError: 0 errors:` and occasionally resulting in server crashes with `SIGSEGV(11)/SIGBUS(10)`

This PR works around this by using a boolean, `hadError`, and doing an or reduction across all the tasks, so we can throw the error after the parallel loop has completed

This is what the error message and result looks like with multi-locale on the reproducer from the issue. @alvaradoo if u don't mind taking a look and making sure it's seems reasonable, I'd appreciate it!
```python
>>> ak.read_csv("empty_test.csv")
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
Cell In[3], line 1
----> 1 ak.read_csv("empty_test.csv")

File ~/proj/arkouda/arkouda/io.py:995, in read_csv(filenames, datasets, column_delim, allow_errors)
    992 elif datasets is None:
    993     datasets = get_columns(filenames, col_delim=column_delim, allow_errors=allow_errors)
--> 995 rep_msg = generic_msg(
    996     cmd="readcsv",
    997     args={
    998         "filenames": filenames,
    999         "nfiles": len(filenames),
   1000         "datasets": datasets,
   1001         "num_dsets": len(datasets),
   1002         "col_delim": column_delim,
   1003         "allow_errors": allow_errors,
   1004     },
   1005 )
   1006 rep = json.loads(rep_msg)  # See GenSymIO._buildReadAllMsgJson for json structure
   1007 _parse_errors(rep, allow_errors)

File ~/proj/arkouda/arkouda/client.py:970, in generic_msg(cmd, args, payload, send_binary, recv_binary)
    968     else:
    969         assert payload is None
--> 970         return cast(Channel, channel).send_string_message(cmd=cmd, args=msg_args,
    971                                                           size=size, recv_binary=recv_binary)
    972 except KeyboardInterrupt as e:
    973     # if the user interrupts during command execution, the socket gets out
    974     # of sync reset the socket before raising the interrupt exception
    975     cast(Channel, channel).connect(timeout=0)

File ~/proj/arkouda/arkouda/client.py:503, in ZmqChannel.send_string_message(self, cmd, recv_binary, args, size, request_id)
    501 # raise errors or warnings sent back from the server
    502 if return_message.msgType == MessageType.ERROR:
--> 503     raise RuntimeError(return_message.msg)
    504 elif return_message.msgType == MessageType.WARNING:
    505     warnings.warn(return_message.msg)

RuntimeError: IOError Line 385 In CSVMsg.read_files_into_dist_array: This CSV is missing values. To read anyway and replace these with min(col_dtype), set allow_errors to True

>>> ak.read_csv("empty_test.csv", allow_errors=True)
{'vertex': array([34 69 89 89]),
 'name': array(['Ann', 'Dan', '', '']),
 'born': array([1990 1975 -9223372036854775808 -9223372036854775808]),
 'brand': array(['', '', 'Tesla', 'Tesla']),
 'model': array(['', '', 'Model X', 'Model X'])}
```

