### PR TITLE
Fixes #2816: Resolve nil config file bug

### DIFF
--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -233,9 +233,10 @@ module ServerConfig
     }
 
     proc getEnv(name: string, default=""): string {
-        extern proc getenv(name : c_string_ptr) : c_string_ptr;
-        var val = getenv(name.localize().c_str()): string;
-        if val.isEmpty() { val = default; }
+        use OS.POSIX;
+        var envBytes = getenv(name.localize().c_str());
+        var val = envBytes:string;
+        if envBytes == nil || val.isEmpty() { val = default; }
         return val;
     }
 


### PR DESCRIPTION
This PR fixes #2816. When launching the server using chpl 1.32 with gasnet enabled, a file with the name `(nil)` or `0x0` was created containing the server connection info. Some change from 1.32 seems to have caused `getEnv`'s return value to change. This was resolved by doing a `nil` check along with the empty string check