### PR TITLE
Throw error when reading a Parquet type that isn't supported

### DIFF
--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -1912,6 +1912,8 @@ int cpp_getDatasetNames(const char* filename, char** dsetResult, bool readNested
         else
           fields += (sc->field(i)->name());
         first = false;
+      } else if (sc->field(i)->type()->id() == arrow::Type::LIST && !readNested) {
+        continue;
       } else {
         std::string fname(filename);
         std::string dname(sc->field(i)->ToString());

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -1912,6 +1912,12 @@ int cpp_getDatasetNames(const char* filename, char** dsetResult, bool readNested
         else
           fields += (sc->field(i)->name());
         first = false;
+      } else {
+        std::string fname(filename);
+        std::string dname(sc->field(i)->ToString());
+        std::string msg = "Unsupported type on column: " + dname + " in " + filename; 
+        *errMsg = strdup(msg.c_str());
+        return ARROWERROR;
       }
     }
     *dsetResult = strdup(fields.c_str());

--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -147,7 +147,7 @@ extern "C" {
   const char* cpp_getVersionInfo(void);
 
   int c_getDatasetNames(const char* filename, char** dsetResult, bool readNested, char** errMsg);
-  int cpp_getDatasetNames(const char* filename, char** dsetResult, char** errMsg);
+  int cpp_getDatasetNames(const char* filename, char** dsetResult, bool readNested, char** errMsg);
 
   void c_free_string(void* ptr);
   void cpp_free_string(void* ptr);


### PR DESCRIPTION
When reading an entire file into Parquet without specifying column names, Parquet will currently silently ignore the columns it can't read, but that can be problematic if data is being dropped without realizing it, so would like to throw an error in that case.