### PR TITLE
Fixes #2825: Inconsistent `Categorical` print

### DIFF
--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -365,7 +365,7 @@ class Categorical:
         else:
             vals = [f"'{self[i]}'" for i in range(3)]
             vals.append("... ")
-            vals.extend([self[i] for i in range(self.size - 3, self.size)])
+            vals.extend([f"'{self[i]}'" for i in range(self.size - 3, self.size)])
         return "[{}]".format(", ".join(vals))
 
     def __repr__(self):


### PR DESCRIPTION
This PR fixes #2825. In the summarized output (when printing long Categoricals), we were missing the `'` around the tail end of the output

```python
>>> s = ak.array([f'str {i}' for i in range(101)])
>>> s
array(['str 0', 'str 1', 'str 2', ... , 'str 98', 'str 99', 'str 100'])

# before this PR:
>>> ak.Categorical(s)
array(['str 0', 'str 1', 'str 2', ... , str 98, str 99, str 100])

# after this PR:
>>> ak.Categorical(s)
array(['str 0', 'str 1', 'str 2', ... , 'str 98', 'str 99', 'str 100'])
```