### PR TITLE
Closes #2823: Casting between `Strings` and `Categorical`

### DIFF
--- a/PROTO_tests/tests/numeric_test.py
+++ b/PROTO_tests/tests/numeric_test.py
@@ -396,6 +396,20 @@ class TestNumeric:
         with pytest.raises(RuntimeError):
             ak.isnan(ark_s_int64)
 
+    def test_str_cat_cast(self):
+        test_strs = [
+            ak.array([f"str {i}" for i in range(101)]),
+            ak.array([f"str {i%3}" for i in range(101)]),
+        ]
+        for test_str, test_cat in zip(test_strs, [ak.Categorical(s) for s in test_strs]):
+            cast_str = ak.cast(test_cat, ak.Strings)
+            assert (cast_str == test_str).all()
+            cast_cat = ak.cast(test_str, ak.Categorical)
+            assert (cast_cat == test_cat).all()
+
+            assert isinstance(cast_str, ak.Strings)
+            assert isinstance(cast_cat, ak.Categorical)
+
     def test_precision(self):
         # See https://github.com/Bears-R-Us/arkouda/issues/964
         # Grouped sum was exacerbating floating point errors

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -67,10 +67,10 @@ class ErrorMode(Enum):
 
 @typechecked
 def cast(
-    pda: Union[pdarray, Strings],
+    pda: Union[pdarray, Strings, Categorical],  # type: ignore
     dt: Union[np.dtype, type, str, BigInt],
     errors: ErrorMode = ErrorMode.strict,
-) -> Union[Union[pdarray, Strings], Tuple[pdarray, pdarray]]:
+) -> Union[Union[pdarray, Strings, Categorical], Tuple[pdarray, pdarray]]:  # type: ignore
     """
     Cast an array to another dtype.
 
@@ -119,11 +119,19 @@ def cast(
     >>> ak.cast(ak.linspace(0,4,5), dt=ak.bool)
     array([False, True, True, True, True])
     """
+    from arkouda.categorical import Categorical  # type: ignore
 
     if isinstance(pda, pdarray):
         name = pda.name
     elif isinstance(pda, Strings):
         name = pda.entry.name
+        if dt is Categorical or dt == "Categorical":
+            return Categorical(pda)  # type: ignore
+    elif isinstance(pda, Categorical):  # type: ignore
+        if dt is Strings or dt in ["Strings", "str"]:
+            return pda.categories[pda.codes]
+        else:
+            raise ValueError("Categoricals can only be casted to Strings")
     # typechecked decorator guarantees no other case
 
     dt = _as_dtype(dt)

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -728,6 +728,20 @@ class NumericTest(ArkoudaTest):
         with self.assertRaises(RuntimeError, msg="Currently isnan on int64 is not supported"):
             ak.isnan(ark_s_int64)
 
+    def test_str_cat_cast(self):
+        test_strs = [
+            ak.array([f"str {i}" for i in range(101)]),
+            ak.array([f"str {i%3}" for i in range(101)]),
+        ]
+        for test_str, test_cat in zip(test_strs, [ak.Categorical(s) for s in test_strs]):
+            cast_str = ak.cast(test_cat, ak.Strings)
+            self.assertTrue((cast_str == test_str).all())
+            cast_cat = ak.cast(test_str, ak.Categorical)
+            self.assertTrue((cast_cat == test_cat).all())
+
+            self.assertIsInstance(cast_str, ak.Strings)
+            self.assertIsInstance(cast_cat, ak.Categorical)
+
     def testPrecision(self):
         # See https://github.com/Bears-R-Us/arkouda/issues/964
         # Grouped sum was exacerbating floating point errors


### PR DESCRIPTION
This PR (closes #2823) adds the ability to cast to/from `Strings` and `Categorical`