### PR TITLE
Closes #1882, #2833: CI failures due to python `3.x/3.12`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.x']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     container:
       image: chapel/chapel:1.31.0
     steps:


### PR DESCRIPTION
The python `3.x` job in the CI started pulling down `3.12`. This caused the CI to break. I imagine there's just some wheels or deps that aren't python `3.12` compatible yet. We saw something similar for python `3.11` a while back. This PR (closes #2833 and closes #1882) fixes this by removing the `3.x` job for the time being and specfically checking `3.11`. We'll revisit once the dust settles a bit and try to add back the `3.12` and `3.x` checks

Any existing PRs will need to rebase once this is merged into master to pass CI