### PR TITLE
Closes #2810: Expand `inner_join` to accept a list of pdarrays

### DIFF
--- a/PROTO_tests/tests/join_test.py
+++ b/PROTO_tests/tests/join_test.py
@@ -82,6 +82,26 @@ class TestJoin:
             with pytest.raises(ValueError):
                 l, r = ak.join.inner_join(left, right, wherefunc=ak.intersect1d, whereargs=where_args)
 
+    def test_multi_array_inner_join(self):
+        size = 1000
+        seed = 1
+        a = ak.randint(-size // 10, size // 10, size, seed=seed)
+        b = ak.randint(-size // 10, size // 10, size, seed=seed + 1)
+        left = [a, ak.ones(size, int)]
+        right = [b, ak.cast(ak.arange(size) % 2 == 0, int)]
+
+        # test with no where args
+        l_ind, r_ind = ak.join.inner_join(left, right)
+        for lf, rt in zip(left, right):
+            assert (lf[l_ind] == rt[r_ind]).all()
+
+        # test with where args
+        def where_func(x, y):
+            return (x[0] % 2 == 0) | (y[0] % 2 == 0)
+
+        l_ind, r_ind = ak.join.inner_join(left, right, where_func, (left, right))
+        assert where_func([lf[l_ind] for lf in left], [rt[r_ind] for rt in right]).all()
+
     def test_str_inner_join(self):
         int_left = ak.arange(50)
         int_right = ak.randint(0, 50, 50)

--- a/arkouda/alignment.py
+++ b/arkouda/alignment.py
@@ -60,23 +60,15 @@ def align(*args):
     aligned : list of pdarrays
         Arrays with values replaced by 0-up indices
     """
-    if not isinstance(args[0], Sequence):
-        inds = zero_up(concatenate(args))
-        pos = 0
-        ret = []
-        for arg in args:
-            ret.append(inds[pos : pos + arg.size])
-            pos += arg.size
+    if not any(isinstance(arg, Sequence) for arg in args):
+        key = concatenate([full(arg.size, i, akint64) for i, arg in enumerate(args)], ordered=False)
+        inds = zero_up(concatenate(args, ordered=False))
     else:
         if not all(isinstance(arg, Sequence) for arg in args):
             raise TypeError("If any of the arguments are a sequence of pdarray, they all have to be")
+        key = concatenate([full(arg[0].size, i, akint64) for i, arg in enumerate(args)], ordered=False)
         inds = zero_up([concatenate(x, ordered=False) for x in zip(*args)])
-        pos = 0
-        ret = []
-        for arg in args:
-            ret.append(inds[pos : pos + arg[0].size])
-            pos += arg[0].size
-    return ret
+    return [inds[key == i] for i in range(len(args))]
 
 
 def right_align(left, right):


### PR DESCRIPTION
This PR (closes #2810) expands the `inner_join` and `align` functionality to accept a list of pdarrays. Next steps are to update the dataframe merge functions to allow for multi-column merges