### PR TITLE
Closes #2843: Add python 3.12/3.x check to CI 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.x']
     container:
       image: chapel/chapel:1.31.0
     steps:

--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -15,8 +15,8 @@ dependencies:
   - hdf5==1.12.2
   - pip
   - types-tabulate
-  - pytables>=3.7.0,<3.9.0
-  - pyarrow==11.0.0
+  - pytables>=3.7.0
+  - pyarrow
   - libiconv
   - libidn2
   - jupyter

--- a/arkouda-env.yml
+++ b/arkouda-env.yml
@@ -15,8 +15,8 @@ dependencies:
   - hdf5==1.12.2
   - pip
   - types-tabulate
-  - pytables>=3.7.0,<3.9.0
-  - pyarrow==11.0.0
+  - pytables>=3.7.0
+  - pyarrow
   - libiconv
   - libidn2
   - jupyter

--- a/pydoc/requirements.txt
+++ b/pydoc/requirements.txt
@@ -12,8 +12,8 @@ h5py>=3.7.0
 hdf5==1.12.2
 pip
 types-tabulate
-tables>=3.7.0,<3.9.0
-pyarrow==11.0.0
+tables>=3.7.0
+pyarrow
 libiconv
 libidn2
 

--- a/pydoc/setup/REQUIREMENTS.md
+++ b/pydoc/setup/REQUIREMENTS.md
@@ -30,8 +30,8 @@ The following python packages are required by the Arkouda client package.
 - `hdf5==1.12.2`
 - `pip`
 - `types-tabulate`
-- `tables>=3.7.0,<3.9.0`
-- `pyarrow==11.0.0`
+- `tables>=3.7.0`
+- `pyarrow`
 
 ### Developer Specific
 

--- a/setup.py
+++ b/setup.py
@@ -142,8 +142,8 @@ setup(
         'h5py>=3.7.0',
         'pip',
         'types-tabulate',
-        'tables>=3.7.0,<3.9.0',
-        'pyarrow==11.0.0',
+        'tables>=3.7.0',
+        'pyarrow',
     ],
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
This PR (closes https://github.com/Bears-R-Us/arkouda/issues/2843) adds back the 3.12/3.x python checks to the CI.

Unpinning tables and pyarrow seems to fix our dependency issues with the 3.12 check. These are the only two deps that have an upper bound so arkouda should be compatible with all the latest versions of our dependencies