### PR TITLE
Fix a Makefile conditional to test for empty string instead of 'none'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ ARROW_SANITIZE=-fsanitize=$(SANITIZER)
 endif
 
 CHPL_CXX = $(shell $(CHPL_HOME)/util/config/compileline --compile-c++ 2>/dev/null)
-ifeq ($(CHPL_CXX),none)
+ifeq ($(CHPL_CXX),)
 CHPL_CXX=$(CXX)
 endif
 


### PR DESCRIPTION
I was hitting an issue where, due to not having CHPL_HOME set, CHPL_CXX was being set to the empty string and the 'make compile-arrow-cpp' step would fail as follows due to not having a C++ compiler specified (I'm still not sure where the '-' on the '-O3' option went...):

```
O3 -std=c++17 -c /Users/bradc/arkouda//src/ArrowFunctions.cpp -o /Users/bradc/arkouda//src/ArrowFunctions.o -I/Users/bradc/arkouda//dep/zeromq-install/include -L/Users/bradc/arkouda//dep/zeromq-install/lib -I/Users/bradc/arkouda//dep/hdf5-install/include -L/Users/bradc/arkouda//dep/hdf5-install/lib -I/Users/bradc/arkouda//dep/arrow-install/include -L/Users/bradc/arkouda//dep/arrow-install/lib -I/Users/bradc/arkouda//dep/arrow-install/include -L/Users/bradc/arkouda//dep/arrow-install/lib -I/opt/homebrew/opt/libiconv/include -L/opt/homebrew/opt/libiconv/lib -fsanitize=
make: O3: No such file or directory
```

The conditional that was designed to guard against this is the following:

```make
ifeq ($(CHPL_CXX),none)
CHPL_CXX=$(CXX)
endif
```

but this didn't fire because CHPL_CXX wasn't unset, it was simply set to the empty string.  Here, I've changed the logic to:

```make
ifeq ($(CHPL_CXX),)
CHPL_CXX=$(CXX)
endif
```

to test for the empty string, which causes CXX to be set to g++ as intended.