### PR TITLE
Closes #2830 Implement division and floor division for int64 and uint64 dtypes.

### DIFF
--- a/PROTO_tests/tests/operator_test.py
+++ b/PROTO_tests/tests/operator_test.py
@@ -214,6 +214,12 @@ class TestOperator:
         assert dtype == ak_concat.dtype.name
         assert np.allclose(ak_concat.to_ndarray(), np_concat)
 
+    def test_max_bits_concatenation(self):
+        # reproducer for issue #2802
+        concatenated = ak.concatenate([ak.arange(5, max_bits=3), ak.arange(2 ** 200 - 1, 2 ** 200 + 4)])
+        assert concatenated.max_bits == 3
+        assert [0, 1, 2, 3, 4, 7, 0, 1, 2, 3] == concatenated.to_list()
+
     def test_fixed_concatenate(self):
         for pda1, pda2 in zip(
             (ak.arange(4), ak.linspace(0, 3, 4)), (ak.arange(4, 7), ak.linspace(4, 6, 3))

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -20,6 +20,7 @@ module BinOp
     Helper function to ensure that floor division cases are handled in accordance with numpy
   */
   inline proc floorDivisionHelper(numerator: ?t, denom: ?t2): real {
+    use Math;
     if (numerator == 0 && denom == 0) || (isInf(numerator) && (denom != 0 || isInf(denom))){
       return nan;
     }
@@ -27,7 +28,7 @@ module BinOp
       return -1:real;
     }
     else {
-      return floor(numerator/denom);
+    return AutoMath.floor(numerator/denom);
     }
   }
 
@@ -302,6 +303,15 @@ module BinOp
         }
         when "-" {
           e.a = l.a:real - r.a:real;
+        }
+        when "/" { // truediv
+            e.a = l.a:real / r.a:real;
+        }
+        when "//" { // floordiv
+          ref ea = e.a;
+          var la = l.a:real;
+          var ra = r.a:real;
+          [(ei,li,ri) in zip(ea,la,ra)] ei = floorDivisionHelper(li, ri);
         }
         otherwise {
           var errorMsg = notImplementedError(pn,l.dtype,op,r.dtype);
@@ -717,6 +727,14 @@ module BinOp
           when "-" {
             e.a = l.a: real - val: real;
           }
+          when "/" { // truediv
+            e.a = l.a: real / val: real;
+          }
+          when "//" { // floordiv
+            ref ea = e.a;
+            var la = l.a;
+            [(ei,li) in zip(ea,la)] ei = floorDivisionHelper(li, val:real);
+          }
           otherwise {
             var errorMsg = notImplementedError(pn,l.dtype,op,dtype);
             omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
@@ -1074,6 +1092,14 @@ module BinOp
           }
           when "-" {
             e.a = val:real - r.a:real;
+          }
+          when "/" { // truediv
+            e.a = val:real / r.a:real;
+          }
+          when "//" { // floordiv
+            ref ea = e.a;
+            var ra = r.a;
+            [(ei,ri) in zip(ea,ra)] ei = floorDivisionHelper(val:real, ri);
           }
           otherwise {
             var errorMsg = notImplementedError(pn,dtype,op,r.dtype);

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -20,7 +20,6 @@ module BinOp
     Helper function to ensure that floor division cases are handled in accordance with numpy
   */
   inline proc floorDivisionHelper(numerator: ?t, denom: ?t2): real {
-    use Math;
     if (numerator == 0 && denom == 0) || (isInf(numerator) && (denom != 0 || isInf(denom))){
       return nan;
     }
@@ -28,7 +27,7 @@ module BinOp
       return -1:real;
     }
     else {
-    return AutoMath.floor(numerator/denom);
+      return floor(numerator/denom);
     }
   }
 

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -65,6 +65,12 @@ module OperatorMsg
         boolOps.add("==");
         boolOps.add("!=");
 
+        var realOps: set(string);
+        realOps.add("+");
+        realOps.add("-");
+        realOps.add("/");
+        realOps.add("//");
+
         select (left.dtype, right.dtype) {
           when (DType.Int64, DType.Int64) {
             var l = toSymEntry(left,int);
@@ -211,22 +217,27 @@ module OperatorMsg
               var e = st.addEntry(rname, l.size, bool);
               return doBinOpvv(l, r, e, op, rname, pn, st);
             }
-            var e = st.addEntry(rname, l.size, uint);
-            return doBinOpvv(l, r, e, op, rname, pn, st);
+            if realOps.contains(op) && op != "//"{
+              var e = st.addEntry(rname, l.size, real);
+              return doBinOpvv(l, r, e, op, rname, pn, st);
+            } else {
+              var e = st.addEntry(rname, l.size, uint);
+              return doBinOpvv(l, r, e, op, rname, pn, st);
+            }
           }
           when (DType.UInt64, DType.Int64) {
             var l = toSymEntry(left,uint);
             var r = toSymEntry(right,int);
             if boolOps.contains(op) {
               var e = st.addEntry(rname, l.size, bool);
-              return doBinOpvv(l, r, e, op, rname, pn, st);
+              return doBinOpvv(l, r , e, op, rname, pn, st);
             }
-            // + and - both result in real outputs to match NumPy
-            if op == "+" || op == "-" {
+            // +, -, /, // both result in real outputs to match NumPy
+            if realOps.contains(op) {
               var e = st.addEntry(rname, l.size, real);
               return doBinOpvv(l, r, e, op, rname, pn, st);
             } else {
-              // isn't + or -, so we can use LHS to determine type
+              // isn't +, -, /, // so we can use LHS to determine type
               var e = st.addEntry(rname, l.size, uint);
               return doBinOpvv(l, r, e, op, rname, pn, st);
             }
@@ -238,11 +249,12 @@ module OperatorMsg
               var e = st.addEntry(rname, l.size, bool);
               return doBinOpvv(l, r, e, op, rname, pn, st);
             }
-            if op == "+" || op == "-" {
+            // +, -, /, // both result in real outputs to match NumPy
+            if realOps.contains(op) {
               var e = st.addEntry(rname, l.size, real);
               return doBinOpvv(l, r, e, op, rname, pn, st);
             } else {
-              // isn't + or -, so we can use LHS to determine type
+              // isn't +, -, /, // so we can use LHS to determine type
               var e = st.addEntry(rname, l.size, int);
               return doBinOpvv(l, r, e, op, rname, pn, st);
             }
@@ -399,6 +411,12 @@ module OperatorMsg
         boolOps.add("==");
         boolOps.add("!=");
 
+        var realOps: set(string);
+        realOps.add("+");
+        realOps.add("-");
+        realOps.add("/");
+        realOps.add("//");
+
         select (left.dtype, dtype) {
           when (DType.Int64, DType.Int64) {
             var l = toSymEntry(left,int);
@@ -545,8 +563,13 @@ module OperatorMsg
               var e = st.addEntry(rname, l.size, bool);
               return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
             }
-            var e = st.addEntry(rname, l.size, uint);
-            return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+            if realOps.contains(op) && op != "//"{
+              var e = st.addEntry(rname, l.size, real);
+              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+            } else {
+              var e = st.addEntry(rname, l.size, uint);
+              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+            }
           }
           when (DType.UInt64, DType.Int64) {
             var l = toSymEntry(left,uint);
@@ -555,12 +578,12 @@ module OperatorMsg
               var e = st.addEntry(rname, l.size, bool);
               return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
             }
-            // + and - both result in real outputs to match NumPy
-            if op == "+" || op == "-" {
+            // +, -, /, // both result in real outputs to match NumPy
+            if realOps.contains(op) {
               var e = st.addEntry(rname, l.size, real);
               return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
             } else {
-              // isn't + or -, so we can use LHS to determine type
+              // isn't +, -, /, // so we can use LHS to determine type
               var e = st.addEntry(rname, l.size, uint);
               return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
             }
@@ -572,12 +595,12 @@ module OperatorMsg
               var e = st.addEntry(rname, l.size, bool);
               return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
             }
-            // + and - both result in real outputs to match NumPy
-            if op == "+" || op == "-" {
+            // +, -, /, // both result in real outputs to match NumPy
+            if realOps.contains(op) {
               var e = st.addEntry(rname, l.size, real);
               return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
             } else {
-              // isn't + or -, so we can use LHS to determine type
+              // isn't +, -, /, // so we can use LHS to determine type
               var e = st.addEntry(rname, l.size, int);
               return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
             }
@@ -734,6 +757,12 @@ module OperatorMsg
         boolOps.add("==");
         boolOps.add("!=");
         
+        var realOps: set(string);
+        realOps.add("+");
+        realOps.add("-");
+        realOps.add("/");
+        realOps.add("//");
+
         select (dtype, right.dtype) {
           when (DType.Int64, DType.Int64) {
             var val = value.getIntValue();
@@ -880,8 +909,13 @@ module OperatorMsg
               var e = st.addEntry(rname, r.size, bool);
               return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
             }
-            var e = st.addEntry(rname, r.size, uint);
-            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+            if realOps.contains(op) && op != "//"{
+              var e = st.addEntry(rname, r.size, real);
+              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+            } else {
+              var e = st.addEntry(rname, r.size, uint);
+              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+            }
           }
           when (DType.UInt64, DType.Int64) {
             var val = value.getUIntValue();
@@ -890,12 +924,12 @@ module OperatorMsg
               var e = st.addEntry(rname, r.size, bool);
               return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
             }
-            // + and - both result in real outputs to match NumPy
-            if op == "+" || op == "-" {
+            // +, -, /, // both result in real outputs to match NumPy
+            if realOps.contains(op) {
               var e = st.addEntry(rname, r.size, real);
               return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
             } else {
-              // isn't + or -, so we can use LHS to determine type
+              // isn't +, -, /, // so we can use LHS to determine type
               var e = st.addEntry(rname, r.size, uint);
               return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
             }
@@ -907,12 +941,12 @@ module OperatorMsg
               var e = st.addEntry(rname, r.size, bool);
               return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
             }
-            // + and - both result in real outputs to match NumPy
-            if op == "+" || op == "-" {
+            // +, -, /, // both result in real outputs to match NumPy
+            if realOps.contains(op) {
               var e = st.addEntry(rname, r.size, real);
               return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
             } else {
-              // isn't + or -, so we can use LHS to determine type
+              // isn't +, -, /, // so we can use LHS to determine type
               var e = st.addEntry(rname, r.size, int);
               return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
             }

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -217,7 +217,7 @@ module OperatorMsg
               var e = st.addEntry(rname, l.size, bool);
               return doBinOpvv(l, r, e, op, rname, pn, st);
             }
-            if realOps.contains(op) && op != "//"{
+            if op == "/"{
               var e = st.addEntry(rname, l.size, real);
               return doBinOpvv(l, r, e, op, rname, pn, st);
             } else {
@@ -563,7 +563,7 @@ module OperatorMsg
               var e = st.addEntry(rname, l.size, bool);
               return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
             }
-            if realOps.contains(op) && op != "//"{
+            if op == "/"{
               var e = st.addEntry(rname, l.size, real);
               return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
             } else {
@@ -909,7 +909,7 @@ module OperatorMsg
               var e = st.addEntry(rname, r.size, bool);
               return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
             }
-            if realOps.contains(op) && op != "//"{
+            if op == "/"{
               var e = st.addEntry(rname, r.size, real);
               return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
             } else {

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -292,6 +292,13 @@ class OperatorsTest(ArkoudaTest):
             [True, False, True, False, True, True],
             ak.concatenate([pdaOne, pdaTwo]).to_list(),
         )
+        
+        pdaOne = ak.arange(5, max_bits=3)
+        pdaTwo = ak.arange(2 ** 200 - 1, 2 ** 200 + 4)
+        concatenated = ak.concatenate([pdaOne, pdaTwo])
+        self.assertEqual(concatenated.max_bits, 3)
+        self.assertListEqual([0, 1, 2, 3, 4, 7, 0, 1, 2, 3], concatenated.to_list())
+
 
     def test_invert(self):
         ak_uint = ak.arange(10, dtype=ak.uint64)

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -293,12 +293,6 @@ class OperatorsTest(ArkoudaTest):
             ak.concatenate([pdaOne, pdaTwo]).to_list(),
         )
 
-        pdaOne = ak.arange(5, max_bits=3)
-        pdaTwo = ak.arange(2**200 - 1, 2**200 + 4)
-        concatenated = ak.concatenate([pdaOne, pdaTwo])
-        self.assertEqual(concatenated.max_bits, 3)
-        self.assertListEqual([0, 1, 2, 3, 4, 7, 0, 1, 2, 3], concatenated.to_list())
-
     def test_invert(self):
         ak_uint = ak.arange(10, dtype=ak.uint64)
         inverted = ~ak_uint
@@ -311,6 +305,63 @@ class OperatorsTest(ArkoudaTest):
         ak_uint = ak.arange(10, dtype=ak.uint64)
         ak_bool = ak_uint % 2 == 0
         self.assertListEqual((ak_uint + ak_bool).to_list(), (ak.arange(10) + ak_bool).to_list())
+
+    def test_int_uint_binops(self):
+        np_int = np.arange(-5, 5)
+        ak_int = ak.array(np_int)
+
+        np_uint = np.arange(2**64 - 10, 2**64, dtype=np.uint64)
+        ak_uint = ak.array(np_uint)
+
+        # Vector-Vector Case (Division and Floor Division)
+        self.assertTrue(np.allclose((ak_uint / ak_uint).to_ndarray(), np_uint / np_uint, equal_nan=True))
+        self.assertTrue(np.allclose((ak_int / ak_uint).to_ndarray(), np_int / np_uint, equal_nan=True))
+        self.assertTrue(np.allclose((ak_uint / ak_int).to_ndarray(), np_uint / np_int, equal_nan=True))
+        self.assertTrue(
+            np.allclose((ak_uint // ak_uint).to_ndarray(), np_uint // np_uint, equal_nan=True)
+        )
+        self.assertTrue(np.allclose((ak_int // ak_uint).to_ndarray(), np_int // np_uint, equal_nan=True))
+        self.assertTrue(np.allclose((ak_uint // ak_int).to_ndarray(), np_uint // np_int, equal_nan=True))
+
+        # Scalar-Vector Case (Division and Floor Division)
+        self.assertTrue(
+            np.allclose((ak_uint[0] / ak_uint).to_ndarray(), np_uint[0] / np_uint, equal_nan=True)
+        )
+        self.assertTrue(
+            np.allclose((ak_int[0] / ak_uint).to_ndarray(), np_int[0] / np_uint, equal_nan=True)
+        )
+        self.assertTrue(
+            np.allclose((ak_uint[0] / ak_int).to_ndarray(), np_uint[0] / np_int, equal_nan=True)
+        )
+        self.assertTrue(
+            np.allclose((ak_uint[0] // ak_uint).to_ndarray(), np_uint[0] // np_uint, equal_nan=True)
+        )
+        self.assertTrue(
+            np.allclose((ak_int[0] // ak_uint).to_ndarray(), np_int[0] // np_uint, equal_nan=True)
+        )
+        self.assertTrue(
+            np.allclose((ak_uint[0] // ak_int).to_ndarray(), np_uint[0] // np_int, equal_nan=True)
+        )
+
+        # Vector-Scalar Case (Division and Floor Division)
+        self.assertTrue(
+            np.allclose((ak_uint / ak_uint[0]).to_ndarray(), np_uint / np_uint[0], equal_nan=True)
+        )
+        self.assertTrue(
+            np.allclose((ak_int / ak_int[0]).to_ndarray(), np_int / np_int[0], equal_nan=True)
+        )
+        self.assertTrue(
+            np.allclose((ak_uint / ak_uint[0]).to_ndarray(), np_uint / np_uint[0], equal_nan=True)
+        )
+        self.assertTrue(
+            np.allclose((ak_uint // ak_uint[0]).to_ndarray(), np_uint // np_uint[0], equal_nan=True)
+        )
+        self.assertTrue(
+            np.allclose((ak_int // ak_uint[0]).to_ndarray(), np_int // np_uint[0], equal_nan=True)
+        )
+        self.assertTrue(
+            np.allclose((ak_uint // ak_int[0]).to_ndarray(), np_uint // np_int[0], equal_nan=True)
+        )
 
     def test_float_uint_binops(self):
         # Test fix for issue #1620

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -292,7 +292,7 @@ class OperatorsTest(ArkoudaTest):
             [True, False, True, False, True, True],
             ak.concatenate([pdaOne, pdaTwo]).to_list(),
         )
-        
+
         pdaOne = ak.arange(5, max_bits=3)
         pdaTwo = ak.arange(2 ** 200 - 1, 2 ** 200 + 4)
         concatenated = ak.concatenate([pdaOne, pdaTwo])


### PR DESCRIPTION
This PR (Closes #2830) will add functionality and testing to do division and floor division on previously unimplemented int64 and uint64 dtype combinations. 

This is planned to be used for the akwhere implementation on the trig functions.