### PR TITLE
Fixes #2849: bug in `getEnv`

### DIFF
--- a/src/ExternalIntegration.chpl
+++ b/src/ExternalIntegration.chpl
@@ -501,7 +501,7 @@ module ExternalIntegration {
         return (serviceName,servicePort,targetServicePort);
     } 
 
-    proc getKubernetesDeregisterParameters(serviceEndpoint: ServiceEndpoint) {
+    proc getKubernetesDeregisterParameters(serviceEndpoint: ServiceEndpoint) throws {
         if serviceEndpoint == ServiceEndpoint.METRICS {
             return ServerConfig.getEnv('METRICS_SERVICE_NAME');
         } else {

--- a/src/MetricsMsg.chpl
+++ b/src/MetricsMsg.chpl
@@ -25,7 +25,7 @@ module MetricsMsg {
     private config const logChannel = ServerConfig.logChannel;
     const mLogger = new Logger(logLevel, logChannel);
 
-    var metricScope = ServerConfig.getEnv(name='METRIC_SCOPE',default='MetricScope.REQUEST');
+    var metricScope = try! ServerConfig.getEnv(name='METRIC_SCOPE',default='MetricScope.REQUEST');
     
     var serverMetrics = new CounterTable();
     

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -88,7 +88,7 @@ module ServerConfig
     /*
     Write the server `hostname:port` to this file.
     */
-    config const serverConnectionInfo: string = getEnv("ARKOUDA_SERVER_CONNECTION_INFO", "");
+    config const serverConnectionInfo: string = try! getEnv("ARKOUDA_SERVER_CONNECTION_INFO", "");
 
     /*
     Flag to shut down the arkouda server automatically when the client disconnects
@@ -231,10 +231,10 @@ module ServerConfig
         return cfgStr;
     }
 
-    proc getEnv(name: string, default=""): string {
+    proc getEnv(name: string, default=""): string throws {
         use OS.POSIX;
         var envBytes = getenv(name.localize().c_str());
-        var val = envBytes:string;
+        var val = string.createCopyingBuffer(envBytes:c_string_ptr);
         if envBytes == nil || val.isEmpty() { val = default; }
         return val;
     }


### PR DESCRIPTION
This PR (fixes #2849) since `c_string` has been deprecated we need to use `string.createCopyingBuffer` instead of casting (see https://chapel-lang.org/docs/language/evolution.html#c-string-deprecation)

I believe this should fix the issue @hokiegeek2 encountered