### PR TITLE
Closes #2862: Implement `histogram2d`

### DIFF
--- a/src/Histogram.chpl
+++ b/src/Histogram.chpl
@@ -15,34 +15,33 @@ module Histogram
     const hgLogger = new Logger(logLevel, logChannel);
 
     /*
-    Takes the data in array a, creates an atomic histogram in parallel, 
-    and copies the result of the histogram operation into a distributed int array
+        Takes the data in array a, creates an atomic histogram in parallel,
+        and copies the result of the histogram operation into a distributed int array
 
-    Returns the histogram (distributed int array).
+        Returns the histogram (distributed int array).
 
-    :arg a: array of data to be histogrammed
-    :type a: [] ?etype
+        :arg a: array of data to be histogrammed
+        :type a: [] ?etype
 
-    :arg aMin: Min value in array a
-    :type aMin: etype
+        :arg aMin: Min value in array a
+        :type aMin: etype
 
-    :arg aMax: Max value in array a
-    :type aMax: etype
+        :arg aMax: Max value in array a
+        :type aMax: etype
 
-    :arg bins: allocate size of the histogram's distributed domain
-    :type bins: int
+        :arg bins: allocate size of the histogram's distributed domain
+        :type bins: int
 
-    :arg binWidth: set value for either 1:1 unique value counts, or multiple unique values per bin.
-    :type binWidth: real
+        :arg binWidth: set value for either 1:1 unique value counts, or multiple unique values per bin.
+        :type binWidth: real
 
-    :returns: [] int
-
+        :returns: [] int
     */
     proc histogramGlobalAtomic(a: [?aD] ?etype, aMin: etype, aMax: etype, bins: int, binWidth: real) throws {
 
         var hD = makeDistDom(bins);
         var atomicHist: [hD] atomic int;
-        
+
         // count into atomic histogram
         forall v in a {
             var vBin = ((v - aMin) / binWidth):int;
@@ -52,7 +51,7 @@ module Histogram
             }
             atomicHist[vBin].add(1);
         }
-        
+
         var hist = makeDistArray(bins,int);
         // copy from atomic histogram to normal histogram
         [(e,ae) in zip(hist, atomicHist)] e = ae.read();
@@ -62,29 +61,54 @@ module Histogram
         return hist;
     }
 
+    proc histogramGlobalAtomic(x: [?aD] ?etype, y: [aD] etype, xMin: etype, xMax: etype, yMin: etype, yMax: etype, numXBins: int, numYBins: int, xBinWidth: real, yBinWidth: real) throws {
+        const totNumBins = numXBins * numYBins;
+        var hD = makeDistDom(totNumBins);
+        var atomicHist: [hD] atomic int;
+
+        // count into atomic histogram
+        forall (xi, yi) in zip(x, y) {
+            var xiBin = ((xi - xMin) / xBinWidth):int;
+            var yiBin = ((yi - yMin) / yBinWidth):int;
+            if xi == xMax {xiBin = numXBins-1;}
+            if yi == yMax {yiBin = numYBins-1;}
+            if xiBin < 0 | yiBin < 0 | (xiBin > (numXBins-1)) | (yiBin > (numYBins-1)) {
+                try! hgLogger.error(getModuleName(),getRoutineName(),getLineNumber(),"OOB");
+            }
+            atomicHist[(xiBin * numYBins) + yiBin].add(1);
+        }
+
+        var hist = makeDistArray(totNumBins,int);
+        // copy from atomic histogram to normal histogram
+        [(e,ae) in zip(hist, atomicHist)] e = ae.read();
+        try! hgLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                                             "hist = %?".doFormat(hist));
+
+        return hist;
+    }
+
     /*
-    Takes the data in array a, creates an atomic histogram in each locale,
-    + reduces each locale's histogram computations into a distributed int array
+        Takes the data in array a, creates an atomic histogram in each locale,
+        + reduces each locale's histogram computations into a distributed int array
 
-    Returns the histogram (distributed int array).
+        Returns the histogram (distributed int array).
 
-    :arg a: array of data to be histogrammed
-    :type a: [] ?etype
+        :arg a: array of data to be histogrammed
+        :type a: [] ?etype
 
-    :arg aMin: Min value in array a
-    :type aMin: etype
+        :arg aMin: Min value in array a
+        :type aMin: etype
 
-    :arg aMax: Max value in array a
-    :type aMax: etype
+        :arg aMax: Max value in array a
+        :type aMax: etype
 
-    :arg bins: allocate size of the histogram's distributed domain
-    :type bins: int
+        :arg bins: allocate size of the histogram's distributed domain
+        :type bins: int
 
-    :arg binWidth: set value for either 1:1 unique value counts, or multiple unique values per bin.
-    :type binWidth: real
+        :arg binWidth: set value for either 1:1 unique value counts, or multiple unique values per bin.
+        :type binWidth: real
 
-    :returns: [] int
-
+        :returns: [] int
     */
     proc histogramLocalAtomic(a: [?aD] ?etype, aMin: etype, aMax: etype, bins: int, binWidth: real) throws {
 
@@ -107,31 +131,53 @@ module Histogram
         hist = lHist;
         return hist;
     }
-    
+
+    proc histogramLocalAtomic(x: [?aD] ?etype, y: [aD] etype, xMin: etype, xMax: etype, yMin: etype, yMax: etype, numXBins: int, numYBins: int, xBinWidth: real, yBinWidth: real) throws {
+        const totNumBins = numXBins * numYBins;
+        // allocate per-locale atomic histogram
+        var atomicHist: [PrivateSpace] [0..#totNumBins] atomic int;
+
+        // count into per-locale private atomic histogram
+        forall (xi, yi) in zip(x, y) {
+            var xiBin = ((xi - xMin) / xBinWidth):int;
+            var yiBin = ((yi - yMin) / yBinWidth):int;
+            if xi == xMax {xiBin = numXBins-1;}
+            if yi == yMax {yiBin = numYBins-1;}
+            atomicHist[here.id][(xiBin * numYBins) + yiBin].add(1);
+        }
+
+        // +reduce across per-locale histograms to get counts
+        var lHist: [0..#totNumBins] int;
+        forall i in PrivateSpace with (+ reduce lHist) do
+          lHist reduce= atomicHist[i].read();
+
+        var hist = makeDistArray(totNumBins,int);
+        hist = lHist;
+        return hist;
+    }
 
     /*
-    Iterates in parallel over all values of a, histogramming into a new array as each value is processed. 
-    This new array is returned as the histogram.
-    
-    Returns the histogram (distributed int array).
+        Iterates in parallel over all values of a, histogramming into a new array as each value is processed.
+        This new array is returned as the histogram.
 
-    :arg a: array of data to be histogrammed
-    :type a: [] ?etype
+        Returns the histogram (distributed int array).
 
-    :arg aMin: Min value in array a
-    :type aMin: etype
+        :arg a: array of data to be histogrammed
+        :type a: [] ?etype
 
-    :arg aMax: Max value in array a
-    :type aMax: etype
+        :arg aMin: Min value in array a
+        :type aMin: etype
 
-    :arg bins: allocate size of the histogram's distributed domain
-    :type bins: int
+        :arg aMax: Max value in array a
+        :type aMax: etype
 
-    :arg binWidth: set value for either 1:1 unique value counts, or multiple unique values per bin.
-    :type binWidth: real
+        :arg bins: allocate size of the histogram's distributed domain
+        :type bins: int
 
-    :returns: [] int
+        :arg binWidth: set value for either 1:1 unique value counts, or multiple unique values per bin.
+        :type binWidth: real
 
+        :returns: [] int
     */
     proc histogramReduceIntent(a: [?aD] ?etype, aMin: etype, aMax: etype, bins: int, binWidth: real) throws {
 
@@ -149,5 +195,21 @@ module Histogram
         return hist;
     }
 
+    proc histogramReduceIntent(x: [?aD] ?etype, y: [aD] etype, xMin: etype, xMax: etype, yMin: etype, yMax: etype, numXBins: int, numYBins: int, xBinWidth: real, yBinWidth: real) throws {
+        const totNumBins = numXBins * numYBins;
+        var gHist: [0..#totNumBins] int;
 
+        // count into per-task/per-locale histogram and then reduce as tasks complete
+        forall (xi, yi) in zip(x, y) with (+ reduce gHist) {
+            var xiBin = ((xi - xMin) / xBinWidth):int;
+            var yiBin = ((yi - yMin) / yBinWidth):int;
+            if xi == xMax {xiBin = numXBins-1;}
+            if yi == yMax {yiBin = numYBins-1;}
+            gHist[(xiBin * numYBins) + yiBin] += 1;
+        }
+
+        var hist = makeDistArray(totNumBins,int);
+        hist = gHist;
+        return hist;
+    }
 }

--- a/src/HistogramMsg.chpl
+++ b/src/HistogramMsg.chpl
@@ -80,6 +80,74 @@ module HistogramMsg
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 
+
+    /* histogram takes a pdarray and returns a pdarray with the histogram in it */
+    proc histogram2DMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        param pn = Reflection.getRoutineName();
+        var repMsg: string; // response message
+        const xBins = msgArgs.get("xBins").getIntValue();
+        const yBins = msgArgs.get("yBins").getIntValue();
+        const xName = msgArgs.getValueOf("x");
+        const yName = msgArgs.getValueOf("y");
+
+        // get next symbol name
+        var rname = st.nextName();
+        hgmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                      "cmd: %s xName: %s yName: %s xBins: %i yBins: %i rname: %s".doFormat(cmd, xName, yName, xBins, yBins, rname));
+
+        var xGenEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(xName, st);
+        var yGenEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(yName, st);
+
+        // helper nested procedure
+        proc histogramHelper(type t) throws {
+            var x = toSymEntry(xGenEnt,t);
+            var y = toSymEntry(yGenEnt,t);
+            var xMin = min reduce x.a;
+            var xMax = max reduce x.a;
+            var yMin = min reduce y.a;
+            var yMax = max reduce y.a;
+            var xBinWidth:real = (xMax - xMin):real / xBins:real;
+            var yBinWidth:real = (yMax - yMin):real / yBins:real;
+            hgmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                                            "xBinWidth %r yBinWidth %r".doFormat(xBinWidth, yBinWidth));
+
+            var totBins = xBins * yBins;
+            if (totBins <= sBound) {
+                hgmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                                            "%? <= %?".doFormat(totBins,sBound));
+                var hist = histogramReduceIntent(x.a, y.a, xMin, xMax, yMin, yMax, xBins, yBins, xBinWidth, yBinWidth);
+                st.addEntry(rname, createSymEntry(hist));
+            }
+            else if (totBins <= mBound) {
+                hgmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                                            "%? <= %?".doFormat(totBins,mBound));
+                var hist = histogramLocalAtomic(x.a, y.a, xMin, xMax, yMin, yMax, xBins, yBins, xBinWidth, yBinWidth);
+                st.addEntry(rname, createSymEntry(hist));
+            }
+            else {
+                hgmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                                                "%? > %?".doFormat(totBins,mBound));
+                var hist = histogramGlobalAtomic(x.a, y.a, xMin, xMax, yMin, yMax, xBins, yBins, xBinWidth, yBinWidth);
+                st.addEntry(rname, createSymEntry(hist));
+            }
+        }
+        select (xGenEnt.dtype, yGenEnt.dtype) {
+            when (DType.Int64, DType.Int64)   {histogramHelper(int);}
+            when (DType.UInt64, DType.UInt64)  {histogramHelper(uint);}
+            when (DType.Float64, DType.Float64) {histogramHelper(real);}
+            otherwise {
+                var errorMsg = notImplementedError(pn,"("+dtype2str(xGenEnt.dtype)+","+dtype2str(yGenEnt.dtype)+")");
+                hgmLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+        }
+
+        repMsg = "created " + st.attrib(rname);
+        hgmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+        return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+
     use CommandMap;
     registerFunction("histogram", histogramMsg, getModuleName());
+    registerFunction("histogram2D", histogram2DMsg, getModuleName());
 }

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -127,12 +127,16 @@ class NumericTest(ArkoudaTest):
 
     def testHistogram(self):
         pda = ak.randint(10, 30, 40)
-        bins, result = ak.histogram(pda, bins=20)
+        nda = pda.to_ndarray()
+        ak_result, ak_bins = ak.histogram(pda, bins=20)
+        np_result, np_bins = np.histogram(nda, bins=20)
 
-        self.assertIsInstance(result, ak.pdarray)
-        self.assertEqual(20, len(bins))
-        self.assertEqual(20, len(result))
-        self.assertEqual(int, result.dtype)
+        self.assertIsInstance(ak_result, ak.pdarray)
+        self.assertEqual(20, len(ak_bins) - 1)
+        self.assertEqual(20, len(ak_result))
+        self.assertEqual(int, ak_result.dtype)
+        self.assertListEqual(ak_result.to_list(), np_result.tolist())
+        self.assertListEqual(ak_bins.to_list(), np_bins.tolist())
 
         with self.assertRaises(TypeError):
             ak.histogram([range(0, 10)], bins=1)
@@ -142,6 +146,22 @@ class NumericTest(ArkoudaTest):
 
         with self.assertRaises(TypeError):
             ak.histogram([range(0, 10)], bins="1")
+
+        # test 2d histogram
+        seed = 1
+        ak_x, ak_y = ak.randint(1, 100, 1000, seed=seed), ak.randint(1, 100, 1000, seed=seed + 1)
+        np_x, np_y = ak_x.to_ndarray(), ak_y.to_ndarray()
+        np_hist, np_x_edges, np_y_edges = np.histogram2d(np_x, np_y)
+        ak_hist, ak_x_edges, ak_y_edges = ak.histogram2d(ak_x, ak_y)
+        self.assertListEqual(np_hist.tolist(), ak_hist.to_list())
+        self.assertListEqual(np_x_edges.tolist(), ak_x_edges.to_list())
+        self.assertListEqual(np_y_edges.tolist(), ak_y_edges.to_list())
+
+        np_hist, np_x_edges, np_y_edges = np.histogram2d(np_x, np_y, bins=(10, 20))
+        ak_hist, ak_x_edges, ak_y_edges = ak.histogram2d(ak_x, ak_y, bins=(10, 20))
+        self.assertListEqual(np_hist.tolist(), ak_hist.to_list())
+        self.assertListEqual(np_x_edges.tolist(), ak_x_edges.to_list())
+        self.assertListEqual(np_y_edges.tolist(), ak_y_edges.to_list())
 
     def testLog(self):
         na = np.linspace(1, 10, 10)


### PR DESCRIPTION
This PR (closes #2862) adds the logic for a bidimension histogram which mimics [`np.histogram2d`](https://numpy.org/doc/stable/reference/generated/numpy.histogram2d.html). Added tests against the numpy version to ensure we have the same resulting histogram when acting on the same arrays. Modified the return of the single dimensional histogram slightly to more closely match the numpy return

This is based on the existing single dimensional histogram, so it has 3 different implementations based on number of bins to take advantage of the time / space tradeoff when total number of bins is relatively small. I tested all three versions against numpy with and without gasnet enabled 

I was originally going to try and do this and `histogramdd` in the same PR, but I figured that logic was different enough that it would be worth breaking out into it's own PR. Plus it will probably be easier to review one at a time