### PR TITLE
Closes #2866: Fix empty domain creation for block arrays

### DIFF
--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -135,7 +135,7 @@ module MultiTypeSymEntry
         var itemsize: int; // answer to numpy itemsize = num bytes per elt
         var size: int = 0; // answer to numpy size == num elts
         var ndim: int = 1; // answer to numpy ndim == 1-axis for now
-        var shape: string = "[1]"; // answer to numpy shape == 1*int tuple
+        var shape: string = "[0]"; // answer to numpy shape == 1*int tuple
 
         // not sure yet how to implement numpy data() function
 

--- a/src/compat/gt-131/ArkoudaSymEntryCompat.chpl
+++ b/src/compat/gt-131/ArkoudaSymEntryCompat.chpl
@@ -37,7 +37,10 @@ module ArkoudaSymEntryCompat {
     this.size = len;
     this.ndim = ndim;
     init this;
-    this.shape = tupShapeString(1, ndim);
+    if len == 0 then
+      this.shape = "[0]";
+    else
+      this.shape = tupShapeString(1, ndim);
   }
 
   /*

--- a/src/compat/gt-131/SymArrayDmapCompat.chpl
+++ b/src/compat/gt-131/SymArrayDmapCompat.chpl
@@ -36,12 +36,10 @@ module SymArrayDmapCompat
             }
             when Dmap.blockDist {
                 if dom.size > 0 {
-                  writeln("MISTAKE");
                     return blockDist.createDomain(dom);
                 }
                 // fix the annoyance about boundingBox being empty
                 else {
-                  writeln("HERE");
                   return {0..#0} dmapped blockDist(boundingBox={0..0});
                 }
             }

--- a/src/compat/gt-131/SymArrayDmapCompat.chpl
+++ b/src/compat/gt-131/SymArrayDmapCompat.chpl
@@ -36,10 +36,14 @@ module SymArrayDmapCompat
             }
             when Dmap.blockDist {
                 if dom.size > 0 {
+                  writeln("MISTAKE");
                     return blockDist.createDomain(dom);
                 }
                 // fix the annoyance about boundingBox being empty
-                else {return blockDist.createDomain({0..0}); }
+                else {
+                  writeln("HERE");
+                  return {0..#0} dmapped blockDist(boundingBox={0..0});
+                }
             }
             otherwise {
                 halt("Unsupported distribution " + MyDmap:string);


### PR DESCRIPTION
When adding support for multidimensional arrays, the code to create block domains was changed, which resulted in incorrect handling of size 0 block distributed arrays and an unnecessary change in the default value for symbol table entry shapes. In order to fix empty array assignment, this PR reverts the empty block domain array creation.

Closes #2866 