### PR TITLE
Closes #2863: Implement `histogramdd`

### DIFF
--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -1325,7 +1325,7 @@ def histogram2d(
     Examples
     --------
     >>> x = ak.arange(0, 10, 1)
-    >>> y = ak.arange(9, 0, -1)
+    >>> y = ak.arange(9, -1, -1)
     >>> nbins = 3
     >>> h, x_edges, y_edges = ak.histogram2d(x, y, bins=nbins)
     >>> h
@@ -1358,6 +1358,63 @@ def histogram2d(
 def histogramdd(
     sample: Sequence[pdarray], bins: Union[int_scalars, Sequence[int_scalars]] = 10
 ) -> Tuple[pdarray, Sequence[pdarray]]:
+    """
+    Compute the multidimensional histogram of data in sample with evenly spaced bins.
+
+    Parameters
+    ----------
+    sample : Sequence[pdarray]
+        A sequence of pdarrays containing the coordinates of the points to be histogrammed.
+
+    bins : int_scalars or Sequence[int_scalars] = 10
+        The number of equal-size bins to use.
+        If int, the number of bins for all dimensions (nx=ny=...=bins).
+        If [int, int, ...], the number of bins in each dimension (nx, ny, ... = bins).
+        Defaults to 10
+
+    Returns
+    -------
+    hist : ArrayView, shape(nx, ny, ..., nd)
+        The multidimensional histogram of pdarrays in sample.
+        Values in first pdarray are histogrammed along the first dimension.
+        Values in second pdarray are histogrammed along the second dimension and so on.
+
+    edges : List[pdarray]
+        A list of pdarrays containing the bin edges for each dimension.
+
+
+    Raises
+    ------
+    ValueError
+        Raised if bins < 1
+    NotImplementedError
+        Raised if pdarray dtype is bool or uint8
+
+    See Also
+    --------
+    histogram
+
+    Notes
+    -----
+    The bins for each dimension, m, are evenly spaced in the interval [m.min(), m.max()]
+
+    Examples
+    --------
+    >>> x = ak.arange(0, 10, 1)
+    >>> y = ak.arange(9, -1, -1)
+    >>> z = ak.where(x % 2 == 0, x, y)
+    >>> h, edges = ak.histogramdd((x, y,z), bins=(2,2,5))
+    >>> h
+    array([[[0, 0, 0, 0, 0],
+            [1, 1, 1, 1, 1]],
+
+           [[1, 1, 1, 1, 1],
+            [0, 0, 0, 0, 0]]])
+    >>> edges
+    [array([0.0 4.5 9.0]),
+     array([0.0 4.5 9.0]),
+     array([0.0 1.6 3.2 4.8 6.4 8.0])]
+    """
     if not isinstance(sample, Sequence):
         raise ValueError("Sample must be a sequence of pdarrays")
     if len(set(pda.dtype for pda in sample)) != 1:

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -171,9 +171,9 @@ class NumericTest(ArkoudaTest):
             ak_arrs = [ak.array(a) for a in np_arrs]
             np_hist, np_bin_edges = np.histogramdd(np_arrs, bins=bins)
             ak_hist, ak_bin_edges = ak.histogramdd(ak_arrs, bins=bins)
-            self.assertListEqual(np_hist.tolist(), ak_hist.to_list())
+            self.assertTrue(np.allclose(np_hist.tolist(), ak_hist.to_list()))
             for np_edge, ak_edge in zip(np_bin_edges, ak_bin_edges):
-                self.assertListEqual(np_edge.tolist(), ak_edge.to_list())
+                self.assertTrue(np.allclose(np_edge.tolist(), ak_edge.to_list()))
 
     def testLog(self):
         na = np.linspace(1, 10, 10)

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -163,6 +163,18 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(np.allclose(np_x_edges.tolist(), ak_x_edges.to_list()))
         self.assertTrue(np.allclose(np_y_edges.tolist(), ak_y_edges.to_list()))
 
+        # test arbitrary dimensional histogram
+        dim_list = [3, 4, 5]
+        bin_list = [[2, 4, 5], [2, 4, 5, 2], [2, 4, 5, 2, 3]]
+        for dim, bins in zip(dim_list, bin_list):
+            np_arrs = [np.random.randint(1, 100, 1000) for _ in range(dim)]
+            ak_arrs = [ak.array(a) for a in np_arrs]
+            np_hist, np_bin_edges = np.histogramdd(np_arrs, bins=bins)
+            ak_hist, ak_bin_edges = ak.histogramdd(ak_arrs, bins=bins)
+            self.assertListEqual(np_hist.tolist(), ak_hist.to_list())
+            for np_edge, ak_edge in zip(np_bin_edges, ak_bin_edges):
+                self.assertListEqual(np_edge.tolist(), ak_edge.to_list())
+
     def testLog(self):
         na = np.linspace(1, 10, 10)
         pda = ak.array(na)


### PR DESCRIPTION
This PR (closes #2863) adds the logic for a histogram with an arbitrary nubmer of dimensions. This mimics `np.histogramdd`. Added tests against the numpy version to ensure we have the same resulting histogram when acting on the same arrays.

This is based on the existing single dimensional histogram, so it has 3 different implementations based on number of bins to take advantage of the time / space tradeoff when total number of bins is relatively small. I tested all three versions against numpy with and without gasnet enabled

This is related to the work being done by @ItsQuinnMoore 