### PR TITLE
Array creation perf patch

### DIFF
--- a/src/Message.chpl
+++ b/src/Message.chpl
@@ -258,11 +258,10 @@ module Message {
         Parse value as a tuple of integers with the given size
         */
         proc getTuple(param size: int): size*int throws {
-            try {
+            if size == 1 {
+                return (this.getIntValue(),);
+            } else {
                 return parseJsonTuple(this.val, size);
-            } catch {
-                var x: size*int; x[0] = this.getIntValue();
-                return x;
             }
         }
 


### PR DESCRIPTION
https://github.com/Bears-R-Us/arkouda/pull/2829 introduced a perf regression in array creation performance.

This is likely due to the [IO-based tuple parsing](https://github.com/Bears-R-Us/arkouda/blob/4d6141411f7d811f22daa3804696512f4b36ed0c/src/Message.chpl#L458-L474) that was added to `createMsg` to parse the array shape. This PR bypasses that code at compile time when `nd` is 1 to avoid the multidimensional array overhead for the common case.