### PR TITLE
DataFrame initializer improvements

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -205,7 +205,7 @@ class DataFrame(UserDict):
 
     objType = "DataFrame"
 
-    def __init__(self, initialdata=None, index=None):
+    def __init__(self, initialdata=None, index=None, columns=None):
         super().__init__()
         self.registered_name = None
 
@@ -249,6 +249,7 @@ class DataFrame(UserDict):
         self._bytes = 0
         self._empty = True
 
+        
         # Initial attempts to keep an order on the columns
         self._columns = []
         self._set_index(index)
@@ -276,11 +277,20 @@ class DataFrame(UserDict):
                     UserDict.__setitem__(self, key, val)
                     # Update the column index
                     self._columns.append(key)
+                
 
             # Initial data is a list of arkouda arrays
             elif isinstance(initialdata, list):
                 # Create string IDs for the columns
-                keys = [str(x) for x in range(len(initialdata))]
+                keys = []
+                if columns is not None:
+                    if any([not isinstance(label, str) for label in columns]):
+                        raise TypeError("Column labels must be strings.")
+                    if len(columns) != len(initialdata):
+                        raise ValueError("Must have as many labels as columns")
+                else:
+                    keys = [str(x) for x in range(len(initialdata))]
+                
                 for key, col in zip(keys, initialdata):
                     if isinstance(col, (list, tuple)):
                         col = array(col)

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -263,7 +263,6 @@ class DataFrame(UserDict):
         self._bytes = 0
         self._empty = True
 
-        
         # Initial attempts to keep an order on the columns
         self._columns = []
         self._set_index(index)

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -156,6 +156,20 @@ class DataFrame(UserDict):
     """
     A DataFrame structure based on arkouda arrays.
 
+    Parameters
+    ----------
+    initialdata : List or dictionary of lists, tuples, or pdarrays
+        Each list/dictionary entry corresponds to one column of the data and
+        should be a homogenous type. Different columns may have different 
+        types. If using a dictionary, keys should be strings.
+
+    index : Index, pdarray, or Strings
+        Index for the resulting frame. Defaults to an integer range.
+    
+    columns : List, tuple, pdarray, or Strings
+        Column labels to use if the data does not include them. Elements must 
+        be strings. Defaults to an stringified integer range.
+
     Examples
     --------
 
@@ -288,6 +302,7 @@ class DataFrame(UserDict):
                         raise TypeError("Column labels must be strings.")
                     if len(columns) != len(initialdata):
                         raise ValueError("Must have as many labels as columns")
+                    keys = columns
                 else:
                     keys = [str(x) for x in range(len(initialdata))]
                 

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -160,14 +160,14 @@ class DataFrame(UserDict):
     ----------
     initialdata : List or dictionary of lists, tuples, or pdarrays
         Each list/dictionary entry corresponds to one column of the data and
-        should be a homogenous type. Different columns may have different 
+        should be a homogenous type. Different columns may have different
         types. If using a dictionary, keys should be strings.
 
     index : Index, pdarray, or Strings
         Index for the resulting frame. Defaults to an integer range.
-    
+
     columns : List, tuple, pdarray, or Strings
-        Column labels to use if the data does not include them. Elements must 
+        Column labels to use if the data does not include them. Elements must
         be strings. Defaults to an stringified integer range.
 
     Examples
@@ -290,7 +290,6 @@ class DataFrame(UserDict):
                     UserDict.__setitem__(self, key, val)
                     # Update the column index
                     self._columns.append(key)
-                
 
             # Initial data is a list of arkouda arrays
             elif isinstance(initialdata, list):
@@ -304,7 +303,7 @@ class DataFrame(UserDict):
                     keys = columns
                 else:
                     keys = [str(x) for x in range(len(initialdata))]
-                
+
                 for key, col in zip(keys, initialdata):
                     if isinstance(col, (list, tuple)):
                         col = array(col)

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -261,6 +261,8 @@ class DataFrame(UserDict):
             # Initial data is a dictionary of arkouda arrays
             if isinstance(initialdata, dict):
                 for key, val in initialdata.items():
+                    if isinstance(val, (list, tuple)):
+                        val = array(val)
                     if not isinstance(val, self.COLUMN_CLASSES):
                         raise ValueError(f"Values must be one of {self.COLUMN_CLASSES}.")
                     if key.lower() == "index":
@@ -280,6 +282,8 @@ class DataFrame(UserDict):
                 # Create string IDs for the columns
                 keys = [str(x) for x in range(len(initialdata))]
                 for key, col in zip(keys, initialdata):
+                    if isinstance(col, (list, tuple)):
+                        col = array(col)
                     if not isinstance(col, self.COLUMN_CLASSES):
                         raise ValueError(f"Values must be one of {self.COLUMN_CLASSES}.")
                     sizes.add(col.size)

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -296,7 +296,7 @@ class DataFrame(UserDict):
                 # Create string IDs for the columns
                 keys = []
                 if columns is not None:
-                    if any([not isinstance(label, str) for label in columns]):
+                    if any(not isinstance(label, str) for label in columns):
                         raise TypeError("Column labels must be strings.")
                     if len(columns) != len(initialdata):
                         raise ValueError("Must have as many labels as columns")

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -150,6 +150,31 @@ class DataFrameTest(ArkoudaTest):
         s = df.__repr__().replace(f" ({df._shape_str()})", f"\n\n{shape}")
         self.assertEqual(s, pdf.__repr__())
 
+    def test_convenience_init(self):
+        dict1 = {'0': [1,2], '1': [True, False], 
+                        '2': ['foo', 'bar'], '3': [2.3, -1.8]}
+        dict2 = {'0': (1,2), '1': (True, False), '2': 
+                        ('foo', 'bar'), '3': (2.3, -1.8)}
+        dict3 = {'0': (1,2), '1': [True, False], '2': 
+                        ['foo', 'bar'], '3': (2.3, -1.8)}
+        dict_dfs = [ak.DataFrame(d) for d in [dict1, dict2, dict3]]
+
+        lists1 = [[1,2],[True,False],['foo','bar'],[2.3,-1.8]]
+        lists2 = [(1,2),(True,False),('foo','bar'),(2.3,-1.8)]
+        lists3 = [(1,2),[True,False],['foo','bar'],(2.3,-1.8)]
+        lists_dfs = [ak.DataFrame(l) for l in [lists1, lists2, lists3]]
+
+        for df in dict_dfs + lists_dfs:
+            self.assertTrue(isinstance(df, ak.DataFrame))
+            self.assertTrue(isinstance(df['0'], ak.pdarray))
+            self.assertEqual(df['0'].dtype, int)
+            self.assertTrue(isinstance(df['1'], ak.pdarray))
+            self.assertEqual(df['1'].dtype, bool)
+            self.assertTrue(isinstance(df['2'], ak.Strings))
+            self.assertEqual(df['2'].dtype, str)
+            self.assertTrue(isinstance(df['3'], ak.pdarray))
+            self.assertEqual(df['3'].dtype, float)
+
     def test_boolean_indexing(self):
         df = build_ak_df()
         ref_df = build_pd_df()

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -174,6 +174,24 @@ class DataFrameTest(ArkoudaTest):
             self.assertEqual(df['2'].dtype, str)
             self.assertTrue(isinstance(df['3'], ak.pdarray))
             self.assertEqual(df['3'].dtype, float)
+    
+    def test_column_init(self):
+        unlabeled_data = [[1,2],[True,False],['foo','bar'],[2.3,-1.8]]
+        good_labels = ['one', 'two', 'three', 'four']
+        bad_labels1 = ['one', 'two']
+        bad_labels2 = good_labels + ['five']
+
+        df = ak.DataFrame(unlabeled_data,columns=good_labels)
+        self.assertEqual(df['one'][0], 1)
+        self.assertEqual(df['three'][0], 'foo')
+        self.assertEqual(df['four'][1], -1.8)
+        
+        with self.assertRaises(ValueError):
+            df = ak.DataFrame(unlabeled_data,columns=bad_labels1)
+        with self.assertRaises(ValueError):
+            df = ak.DataFrame(unlabeled_data,columns=bad_labels2)
+        with self.assertRaises(TypeError):
+            df = ak.DataFrame(unlabeled_data,columns=['one', 'two', 3, 'four'])
 
     def test_boolean_indexing(self):
         df = build_ak_df()

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -177,15 +177,16 @@ class DataFrameTest(ArkoudaTest):
     
     def test_column_init(self):
         unlabeled_data = [[1,2],[True,False],['foo','bar'],[2.3,-1.8]]
-        good_labels = ['one', 'two', 'three', 'four']
+        good_labels = ['one1', 'two2', 'three3', 'four4']
         bad_labels1 = ['one', 'two']
         bad_labels2 = good_labels + ['five']
 
         df = ak.DataFrame(unlabeled_data,columns=good_labels)
-        self.assertEqual(df['one'][0], 1)
-        self.assertEqual(df['three'][0], 'foo')
-        self.assertEqual(df['four'][1], -1.8)
-        
+        self.assertListEqual(df.columns, good_labels)
+        self.assertEqual(df['one1'][0], 1)
+        self.assertEqual(df['three3'][0], 'foo')
+        self.assertEqual(df['four4'][1], -1.8)
+
         with self.assertRaises(ValueError):
             df = ak.DataFrame(unlabeled_data,columns=bad_labels1)
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Two changes (with tests) and a docstring.
1. Column labels can be provided as an optional argument for use with unlabelled data
2. DataFrames can be initialized with dicts/lists that contain native lists and tuples in addition to pdarrays. Lists and tuples are converted to pdarrays as part of the initialization.

Tested locally.