### PR TITLE
Closes #2873: Short strings optimization for multicol groupby

### DIFF
--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -243,7 +243,7 @@ module ArgSortMsg
       var arrTypes = msgArgs.get("arr_types").getList(n);
       asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), 
                                    "number of arrays: %i arrNames: %?, arrTypes: %?".doFormat(n,arrNames, arrTypes));
-      var (arrSize, hasStr, names, types) = validateArraysSameLength(n, arrNames, arrTypes, st);
+      var (arrSize, hasStr, allSmallStrs, extraArraysNeeded, numStrings, names, types) = validateArraysSameLength(n, arrNames, arrTypes, st);
 
       // If there were no string arrays, merge the arrays into a single array and sort
       // that. This eliminates having to merge index vectors, but has a memory overhead

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -232,6 +232,10 @@ module AryUtil
       var size: int;
       // Check that all arrays exist in the symbol table and have the same size
       var hasStr = false;
+      var allSmallStrs = true;
+      var extraArraysNeeded = 0;
+      var numStrings = 0;
+      const smallStrCap = 17;  // one bigger to ignore null byte
       for (name, objtype, i) in zip(names, types, 1..) {
         var thisSize: int;
         select objtype.toUpper(): ObjType {
@@ -244,6 +248,17 @@ module AryUtil
             var g = getSegStringEntry(myNames, st);
             thisSize = g.size;
             hasStr = true;
+            numStrings += 1;
+            if allSmallStrs {
+              var strings = getSegString(myNames, st);
+              const maxLen = max reduce strings.getLengths();
+              if maxLen > smallStrCap {
+                allSmallStrs = false;
+              }
+              else if maxLen > 9 {
+                extraArraysNeeded += 1;
+              }
+            }
           }
           when ObjType.CATEGORICAL {
             if st.contains(name) {
@@ -290,7 +305,7 @@ module AryUtil
             }
         }
       }
-      return (size, hasStr, names, types);
+      return (size, hasStr, allSmallStrs, extraArraysNeeded, numStrings, names, types);
     }
 
     inline proc getBitWidth(a: [?aD] int): (int, bool) {

--- a/src/HashMsg.chpl
+++ b/src/HashMsg.chpl
@@ -70,7 +70,7 @@ module HashMsg {
     var s = msgArgs.get("size").getIntValue();
     var namesList = msgArgs.get("nameslist").getList(n);
     var typesList = msgArgs.get("typeslist").getList(n);
-    var (size, hasStr, names, types) = validateArraysSameLength(n, namesList, typesList, st);
+    var (size, hasStr, allSmallStrs, extraArraysNeeded, numStrings, names, types) = validateArraysSameLength(n, namesList, typesList, st);
 
     // Call hashArrays on list of given array names
     var hashes = hashArrays(size, names, types, st);

--- a/src/SegmentedComputation.chpl
+++ b/src/SegmentedComputation.chpl
@@ -48,7 +48,6 @@ module SegmentedComputation {
     StringIsLower,
     StringIsUpper,
     StringIsTitle,
-    StringBytesToUintArr,
   }
   
   proc computeOnSegments(segments: [?D] int, ref values: [?vD] ?t, param function: SegFunction, type retType, const strArg: string = "") throws {
@@ -108,9 +107,6 @@ module SegmentedComputation {
                 }
                 when SegFunction.StringIsTitle {
                   agg.copy(res[i], stringIsTitle(values, start..#len));
-                }
-                when SegFunction.StringBytesToUintArr {
-                  agg.copy(res[i], stringBytesToUintArr(values, start..#len));
                 }
                 otherwise {
                   compilerError("Unrecognized segmented function");

--- a/src/SegmentedString.chpl
+++ b/src/SegmentedString.chpl
@@ -493,26 +493,27 @@ module SegmentedString {
       return computeOnSegments(offsets.a, values.a, SegFunction.StringIsTitle, bool);
     }
 
-    proc bytesToUintArr(const max_bytes:int, st) throws {
+    proc bytesToUintArr(const max_bytes:int, lens: [?D] ?t, st) throws {
       // bytes contained in strings < 128 bits, so concatenating is better than the hash
-      if max_bytes < 8 {
+      ref off = offsets.a;
+      ref vals = values.a;
+      if max_bytes <= 8 {
         // we only need one uint array
-        var numeric = computeOnSegments(offsets.a, values.a, SegFunction.StringBytesToUintArr, uint);
+        var numeric = makeDistArray(offsets.a.domain, uint);
+        forall (o, l, n) in zip(off, lens, numeric) {
+          n = stringBytesToUintArr(vals, o..#l);
+        }
         const concatName = st.nextName();
         st.addEntry(concatName, createSymEntry(numeric));
         return concatName;
       }
       else {
         // we need two uint arrays
-        ref off = offsets.a;
-        ref vals = values.a;
-        // should we do strings.getLengths()-1 to not account for null byte
-        const lens = getLengths();
         var numeric1, numeric2 = makeDistArray(offsets.a.domain, uint);
         forall (o, l, n1, n2) in zip(off, lens, numeric1, numeric2) {
           const half = (l/2):int;
           n1 = stringBytesToUintArr(vals, o..#half);
-          n2 = stringBytesToUintArr(vals, (o+half)..#half);
+          n2 = stringBytesToUintArr(vals, (o+half)..<(o+l));
         }
         const concat1Name = st.nextName();
         const concat2Name = st.nextName();
@@ -1433,9 +1434,6 @@ module SegmentedString {
     return interpretAsString(values, rng, borrow=true).isTitle();
   }
 
-  /*
-    The SegFunction called by computeOnSegments for bytesToUintArr
-  */
   inline proc stringBytesToUintArr(ref values, rng) throws {
       var localSlice = new lowLevelLocalizingSlice(values, rng);
       return | reduce [i in 0..#rng.size] (localSlice.ptr(i):uint)<<(8*(rng.size-1-i));

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -219,7 +219,9 @@ module UniqueMsg
       }
 
       var (perm, segments) = if replaceStrings then digitHelper(newNames, newTypes) else digitHelper();
-      cleanup(strNames, st);
+      if replaceStrings {
+        cleanup(strNames, st);
+      }
       return (perm, segments);
     }
 

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -137,8 +137,8 @@ module UniqueMsg
                                          getModuleName(),
                                          "ArgumentError");
       }
-      var (size, hasStr, names, types) = validateArraysSameLength(n, namesList, typesList, st);
-      if (size == 0) {
+      var (size, hasStr, allSmallStrs, extraArraysNeeded, numStrings, names, types) = validateArraysSameLength(n, namesList, typesList, st);
+      if size == 0 {
         return (createSymEntry(0, int), createSymEntry(0, int));
       }
       proc helper(itemsize, type t, keys: [?D] t) throws {
@@ -167,58 +167,60 @@ module UniqueMsg
         return (permutation, segments);
       }
 
-      inline proc cleanup(str_names: [] string, st) throws {
-        for name in str_names {
+      inline proc cleanup(strNames: [] string, st) throws {
+        for name in strNames {
           st.deleteEntry(name);
         }
       }
 
-      if hasStr && n == 1 {
-        // Only one array which is a strings
-        var (myNames, _) = namesList[0].splitMsgToTuple("+", 2);
-        var strings = getSegString(myNames, st);
-        // should we do strings.getLengths()-1 to not account for null
-        const max_bytes = max reduce strings.getLengths();
-        if max_bytes < 16 {
-          var str_names = strings.bytesToUintArr(max_bytes, st).split("+");
-          var (totalDigits, bitWidths, negs) = getNumDigitsNumericArrays(str_names, st);
-          if totalDigits <= 2 { 
-            var (perm, segments) = helper(2 * bitsPerDigit / 8, 2*uint(bitsPerDigit), mergeNumericArrays(2, size, totalDigits, bitWidths, negs, str_names, st));
-            cleanup(str_names, st);
-            return (perm, segments);
+      var strNames: [0..#(numStrings + extraArraysNeeded)] string;
+      var newNames: [0..#(n+extraArraysNeeded)] string;
+      var newTypes: [0..#(n+extraArraysNeeded)] string;
+      var replaceStrings = hasStr && allSmallStrs;
+      if replaceStrings {
+        var strIdx = 0;
+        var nameIdx = 0;
+        for (name, objtype) in zip(namesList, types) {
+          if objtype.toUpper(): ObjType == ObjType.STRINGS {
+            var (myNames, _) = name.splitMsgToTuple("+", 2);
+            var strings = getSegString(myNames, st);
+            const lengths = strings.getLengths() - 1;
+            const max_bytes = (max reduce lengths);
+            for arrName in strings.bytesToUintArr(max_bytes, lengths, st).split("+") {
+              strNames[strIdx] = arrName;
+              strIdx += 1;
+              newNames[nameIdx] = arrName;
+              newTypes[nameIdx] = "PDARRAY";
+              nameIdx += 1;
+            }
           }
-          if totalDigits <= 4 { 
-            var (perm, segments) = helper(4 * bitsPerDigit / 8, 4*uint(bitsPerDigit), mergeNumericArrays(4, size, totalDigits, bitWidths, negs, str_names, st));
-            cleanup(str_names, st);
-            return (perm, segments);
-          }
-          if totalDigits <= 6 { 
-            var (perm, segments) = helper(6 * bitsPerDigit / 8, 6*uint(bitsPerDigit), mergeNumericArrays(6, size, totalDigits, bitWidths, negs, str_names, st));
-            cleanup(str_names, st);
-            return (perm, segments);
-          }
-          if totalDigits <= 8 { 
-            var (perm, segments) = helper(8 * bitsPerDigit / 8, 8*uint(bitsPerDigit), mergeNumericArrays(8, size, totalDigits, bitWidths, negs, str_names, st));
-            cleanup(str_names, st);
-            return (perm, segments);
+          else {
+            newNames[nameIdx] = name;
+            newTypes[nameIdx] = objtype;
+            nameIdx += 1;
           }
         }
       }
 
-      // If no strings are present and row values can fit in 128 bits (8 digits),
-      // then pack into tuples of uint(16) for sorting keys.
-      if !hasStr {
-        var (totalDigits, bitWidths, negs) = getNumDigitsNumericArrays(names, st);
-        if totalDigits <= 2 { return helper(2 * bitsPerDigit / 8, 2*uint(bitsPerDigit), mergeNumericArrays(2, size, totalDigits, bitWidths, negs, names, st)); }
-        if totalDigits <= 4 { return helper(4 * bitsPerDigit / 8, 4*uint(bitsPerDigit), mergeNumericArrays(4, size, totalDigits, bitWidths, negs, names, st)); }
-        if totalDigits <= 6 { return helper(6 * bitsPerDigit / 8, 6*uint(bitsPerDigit), mergeNumericArrays(6, size, totalDigits, bitWidths, negs, names, st)); }
-        if totalDigits <= 8 { return helper(8 * bitsPerDigit / 8, 8*uint(bitsPerDigit), mergeNumericArrays(8, size, totalDigits, bitWidths, negs, names, st)); }
+      proc digitHelper(helperNames = names, helperTypes = types) throws {
+        // If row values can fit in 128 bits (8 digits) and all strings are small,
+        // then pack into tuples of uint(16) for sorting keys.
+        if !hasStr || allSmallStrs {
+          var (totalDigits, bitWidths, negs) = getNumDigitsNumericArrays(helperNames, st);
+          if totalDigits <= 2 { return helper(2 * bitsPerDigit / 8, 2*uint(bitsPerDigit), mergeNumericArrays(2, size, totalDigits, bitWidths, negs, helperNames, st)); }
+          else if totalDigits <= 4 { return helper(4 * bitsPerDigit / 8, 4*uint(bitsPerDigit), mergeNumericArrays(4, size, totalDigits, bitWidths, negs, helperNames, st)); }
+          else if totalDigits <= 6 { return helper(6 * bitsPerDigit / 8, 6*uint(bitsPerDigit), mergeNumericArrays(6, size, totalDigits, bitWidths, negs, helperNames, st)); }
+          else if totalDigits <= 8 { return helper(8 * bitsPerDigit / 8, 8*uint(bitsPerDigit), mergeNumericArrays(8, size, totalDigits, bitWidths, negs, helperNames, st)); }
+        }
+        // If here, either the row values are too large to fit in 128 bits, or
+        // large strings are present and must be hashed anyway, so hash all arrays
+        // and combine hashes of row values into sorting keys.
+        return helper(16, 2*uint(64), hashArrays(size, helperNames, helperTypes, st));
       }
 
-      // If here, either the row values are too large to fit in 128 bits, or
-      // strings are present and must be hashed anyway, so hash all arrays
-      // and combine hashes of row values into sorting keys.
-      return helper(16, 2*uint(64), hashArrays(size, names, types, st));
+      var (perm, segments) = if replaceStrings then digitHelper(newNames, newTypes) else digitHelper();
+      cleanup(strNames, st);
+      return (perm, segments);
     }
 
     proc hashArrays(size, names, types, st): [] 2*uint throws {

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -436,9 +436,9 @@ class DataFrameTest(ArkoudaTest):
         gb = df.GroupBy(["userName", "userID"])
         keys, count = gb.count()
         self.assertEqual(len(keys), 2)
-        self.assertListEqual(keys[0].to_list(), ["Carol", "Bob", "Alice"])
-        self.assertListEqual(keys[1].to_list(), [333, 222, 111])
-        self.assertListEqual(count.to_list(), [1, 2, 3])
+        self.assertListEqual(keys[0].to_list(), ["Bob", "Alice", "Carol"])
+        self.assertListEqual(keys[1].to_list(), [222, 111, 333])
+        self.assertListEqual(count.to_list(), [2, 3, 1])
 
         # testing counts with IPv4 column
         s = ak.DataFrame({"a": ak.IPv4(ak.arange(1, 5))}).groupby("a").count()

--- a/tests/setops_test.py
+++ b/tests/setops_test.py
@@ -282,8 +282,8 @@ class SetOpsTest(ArkoudaTest):
         b1 = ak.array(c)
         b2 = ak.array(d)
         t = ak.union1d([a1, a2], [b1, b2])
-        self.assertListEqual(["xyz", "def", "abc"], t[0].to_list())
-        self.assertListEqual(["0", "456", "123"], t[1].to_list())
+        self.assertListEqual(["abc", "def", "xyz"], t[0].to_list())
+        self.assertListEqual(["123", "456", "0"], t[1].to_list())
 
         # Test for Categorical
         cat_a1 = ak.Categorical(a1)


### PR DESCRIPTION
There's an optimization when calling groupby on a single array of small strings that skips the hash and operates on the byes directly. This PR (closes #2873) applies that optimization for multicolumn groupby where all the strings are small

NOTE: This only applies when the total number of bits being passed to radix sort is `<=128` (equivalently `totalDigits <= 8`). Otherwise all the columns are hashed and XORed together on a stride. So while this has less comm, it doesn't apply to as many cases as I'd like. Next steps are to try and improve the cause where `totalDigits>8`

```python
# function used to test
def setup_gb_perf(n, group_on):
     s = ak.full(n, "str ").stick(ak.cast(ak.arange(n) % 10, str))
     s2 = ak.full(n, "string ").stick(ak.cast(ak.arange(n) % 11, str))
     u = ak.full(n, 2**61, ak.uint64) - ak.cast(ak.arange(n) % 2 == 0, ak.uint64)
     df = ak.DataFrame({'s1': s, 's2': s2, 'u': u})
     return df.groupby(group_on)

setup_gb_perf(10**7, ['s1','s1'])
```

On master:
```
| locale |  get |  put | execute_on | execute_on_nb |
| -----: | ---: | ---: | ---------: | ------------: |
|      0 |  551 | 2981 |       3128 |           720 |
|      1 | 1285 | 3008 |       3021 |             0 |
|      2 | 1257 | 2795 |       2879 |             0 |
```

After this PR (using small str optimization):
```
| locale |  get |  put | execute_on | execute_on_nb |
| -----: | ---: | ---: | ---------: | ------------: |
|      0 |  433 |  908 |       1016 |           712 |
|      1 | 1093 | 1011 |       1009 |             0 |
|      2 | 1073 |  975 |       1033 |             0 |
```