### PR TITLE
Only use `tryCreateArray` interface to create 1D arrays

### DIFF
--- a/src/compat/e-132/SymArrayDmapCompat.chpl
+++ b/src/compat/e-132/SymArrayDmapCompat.chpl
@@ -67,7 +67,7 @@ module SymArrayDmapCompat
       return dom.tryCreateArray(etype);
     }
 
-    proc makeDistArray(shape: int ...?) throws
+    proc makeDistArray(shape: int ...?N, type etype) throws
       where N > 1
     {
       var a: [makeDistDom((...shape))] etype;
@@ -118,7 +118,7 @@ module SymArrayDmapCompat
     proc makeDistArray(D: domain(?), initExpr: ?t) throws
       where D.rank > 1
     {
-      var res = [D] t = initExpr;
+      var res: [D] t = initExpr;
       return res;
     }
 

--- a/src/compat/e-132/SymArrayDmapCompat.chpl
+++ b/src/compat/e-132/SymArrayDmapCompat.chpl
@@ -60,33 +60,66 @@ module SymArrayDmapCompat
 
     :returns: [] ?etype
     */
-    proc makeDistArray(shape: int ...?N, type etype) throws {
-      // var dom = makeDistDom((...shape));
-      // return dom.tryCreateArray(etype);
+    proc makeDistArray(shape: int ...?N, type etype) throws
+      where N == 1
+    {
+      var dom = makeDistDom((...shape));
+      return dom.tryCreateArray(etype);
+    }
+
+    proc makeDistArray(shape: int ...?) throws
+      where N > 1
+    {
       var a: [makeDistDom((...shape))] etype;
       return a;
     }
 
     proc makeDistArray(in a: [?D] ?etype) throws
       where MyDmap != Dmap.defaultRectangular && a.isDefaultRectangular() {
-        var res = makeDistArray(D.size, etype);
+        var res = makeDistArray((...D.shape), etype);
         res = a;
         return res;
     }
-    
-    proc makeDistArray(in a: [?D] ?etype) throws {
+
+    proc makeDistArray(in a: [?D] ?etype) throws
+      where D.rank == 1
+    {
       var res = D.tryCreateArray(etype);
       res = a;
       return res;
     }
 
-    proc makeDistArray(D: domain(?), type etype) throws {
+    proc makeDistArray(in a: [?D] ?etype) throws
+      where D.rank > 1
+    {
+      return a;
+    }
+
+    proc makeDistArray(D: domain(?), type etype) throws
+      where D.rank == 1
+    {
       var res = D.tryCreateArray(etype);
       return res;
     }
 
-    proc makeDistArray(D: domain(?), initExpr: ?t) throws {
+    proc makeDistArray(D: domain(?), type etype) throws
+      where D.rank > 1
+    {
+      var res = [D] etype;
+      return res;
+    }
+
+    proc makeDistArray(D: domain(?), initExpr: ?t) throws
+      where D.rank == 1
+    {
       return D.tryCreateArray(t, initExpr);
+    }
+
+    proc makeDistArray(D: domain(?), initExpr: ?t) throws
+      where D.rank > 1
+    {
+      var res = [D] t = initExpr;
+      return res;
     }
 
     /* 

--- a/src/compat/eq-131/SymArrayDmapCompat.chpl
+++ b/src/compat/eq-131/SymArrayDmapCompat.chpl
@@ -65,7 +65,7 @@ module SymArrayDmapCompat
 
     proc makeDistArray(in a: [?D] ?etype)
       where MyDmap != Dmap.defaultRectangular && a.isDefaultRectangular() {
-        var res = makeDistArray(...(D.shape), etype);
+        var res = makeDistArray((...D.shape), etype);
         res = a;
         return res;
     }

--- a/src/compat/eq-131/SymArrayDmapCompat.chpl
+++ b/src/compat/eq-131/SymArrayDmapCompat.chpl
@@ -65,7 +65,7 @@ module SymArrayDmapCompat
 
     proc makeDistArray(in a: [?D] ?etype)
       where MyDmap != Dmap.defaultRectangular && a.isDefaultRectangular() {
-        var res = makeDistArray(D.size, etype);
+        var res = makeDistArray(...(D.shape), etype);
         res = a;
         return res;
     }

--- a/src/compat/gt-132/SymArrayDmapCompat.chpl
+++ b/src/compat/gt-132/SymArrayDmapCompat.chpl
@@ -76,7 +76,7 @@ module SymArrayDmapCompat
 
     proc makeDistArray(in a: [?D] ?etype) throws
       where MyDmap != Dmap.defaultRectangular && a.isDefaultRectangular() {
-        var res = makeDistArray(...(D.shape), etype);
+        var res = makeDistArray((...D.shape), etype);
         res = a;
         return res;
     }

--- a/src/compat/gt-132/SymArrayDmapCompat.chpl
+++ b/src/compat/gt-132/SymArrayDmapCompat.chpl
@@ -48,8 +48,8 @@ module SymArrayDmapCompat
             }
         }
     }
-    
-    /* 
+
+    /*
     Makes an array of specified type over a distributed domain
 
     :arg shape: size of the domain in each dimension
@@ -60,33 +60,66 @@ module SymArrayDmapCompat
 
     :returns: [] ?etype
     */
-    proc makeDistArray(shape: int ...?N, type etype) throws {
-      // var dom = makeDistDom((...shape));
-      // return dom.tryCreateArray(etype);
+    proc makeDistArray(shape: int ...?N, type etype) throws
+      where N == 1
+    {
+      var dom = makeDistDom((...shape));
+      return dom.tryCreateArray(etype);
+    }
+
+    proc makeDistArray(shape: int ...?) throws
+      where N > 1
+    {
       var a: [makeDistDom((...shape))] etype;
       return a;
     }
 
     proc makeDistArray(in a: [?D] ?etype) throws
       where MyDmap != Dmap.defaultRectangular && a.isDefaultRectangular() {
-        var res = makeDistArray(D.size, etype);
+        var res = makeDistArray(...(D.shape), etype);
         res = a;
         return res;
     }
-    
-    proc makeDistArray(in a: [?D] ?etype) throws {
+
+    proc makeDistArray(in a: [?D] ?etype) throws
+      where D.rank == 1
+    {
       var res = D.tryCreateArray(etype);
       res = a;
       return res;
     }
 
-    proc makeDistArray(D: domain(?), type etype) throws {
+    proc makeDistArray(in a: [?D] ?etype) throws
+      where D.rank > 1
+    {
+      return a;
+    }
+
+    proc makeDistArray(D: domain(?), type etype) throws
+      where D.rank == 1
+    {
       var res = D.tryCreateArray(etype);
       return res;
     }
 
-    proc makeDistArray(D: domain(?), initExpr: ?t) throws {
+    proc makeDistArray(D: domain(?), type etype) throws
+      where D.rank > 1
+    {
+      var res = [D] etype;
+      return res;
+    }
+
+    proc makeDistArray(D: domain(?), initExpr: ?t) throws
+      where D.rank == 1
+    {
       return D.tryCreateArray(t, initExpr);
+    }
+
+    proc makeDistArray(D: domain(?), initExpr: ?t) throws
+      where D.rank > 1
+    {
+      var res = [D] t = initExpr;
+      return res;
     }
 
     /* 

--- a/src/compat/gt-132/SymArrayDmapCompat.chpl
+++ b/src/compat/gt-132/SymArrayDmapCompat.chpl
@@ -67,7 +67,7 @@ module SymArrayDmapCompat
       return dom.tryCreateArray(etype);
     }
 
-    proc makeDistArray(shape: int ...?) throws
+    proc makeDistArray(shape: int ...?, type etype) throws
       where N > 1
     {
       var a: [makeDistDom((...shape))] etype;
@@ -118,7 +118,7 @@ module SymArrayDmapCompat
     proc makeDistArray(D: domain(?), initExpr: ?t) throws
       where D.rank > 1
     {
-      var res = [D] t = initExpr;
+      var res: [D] t = initExpr;
       return res;
     }
 


### PR DESCRIPTION
Modifies `makeDistArray` procedures to use the `tryCreateArray` only for 1D arrays. ND arrays use the old interface that doesn't throw when an allocation cannot be completed. This is due to a limitation on the Chapel side which could be removed in the future.

