### PR TITLE
Closes #2880: Add parallel writing when writing pdarrays to Parquet

### DIFF
--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -46,6 +46,8 @@ module ParquetMsg {
   // Undocumented for now, just for internal experiments
   private config const batchSize = getEnvInt("ARKOUDA_SERVER_PARQUET_BATCH_SIZE", 8192);
 
+  private config const parallelWriteThreshold = 512*1024*1024 / numBytes(int);
+
   extern var ARROWINT64: c_int;
   extern var ARROWINT32: c_int;
   extern var ARROWUINT64: c_int;
@@ -417,6 +419,7 @@ module ParquetMsg {
                                         dtype, compression,
                                         errMsg): int;
     var dtypeRep = toCDtype(dtype);
+    var doParallel = if A.size > parallelWriteThreshold then true else false;
     var prefix: string;
     var extension: string;
   
@@ -454,10 +457,39 @@ module ParquetMsg {
           valPtr = c_ptrTo(locArr);
         }
         if mode == TRUNCATE || !filesExist {
+<<<<<<< HEAD
           if c_writeColumnToParquet(myFilename.localize().c_str(), valPtr, 0,
                                     dsetname.localize().c_str(), locDom.size, rowGroupSize,
                                     dtypeRep, compression, c_ptrTo(pqErr.errMsg)) == ARROWERROR {
             pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
+=======
+          if !doParallel {
+            if c_writeColumnToParquet(myFilename.localize().c_str(), c_ptrTo(locArr), 0,
+                                      dsetname.localize().c_str(), locDom.size, rowGroupSize,
+                                      dtypeRep, compressed, c_ptrTo(pqErr.errMsg)) == ARROWERROR {
+              pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
+            }
+          } else {
+            var fileSizes: [0..#loc.maxTaskPar] int = locDom.size/loc.maxTaskPar;
+            // First file has the extra elements if it isn't evenly divisible by maxTaskPar
+            fileSizes[0] += locDom.size - ((locDom.size/loc.maxTaskPar)*loc.maxTaskPar);
+
+            var offsets = + scan fileSizes;
+
+            forall i in fileSizes.domain {
+              var suffix = '%04i'.format(idx): string;
+              var parSuffix = '%04i'.format(i): string;
+              const parFilename = filename + "_LOCALE" + suffix + "_CORE" + parSuffix + ".parquet";
+              var oi = if i == 0 then i else offsets[i-1];
+              var coreArr = locArr[oi..#(fileSizes[i])];
+              var pqErr = new parquetErrorMsg();
+              if c_writeColumnToParquet(parFilename.localize().c_str(), c_ptrTo(coreArr), 0,
+                                        dsetname.localize().c_str(), coreArr.size, rowGroupSize,
+                                        dtypeRep, compressed, c_ptrTo(pqErr.errMsg)) == ARROWERROR {
+                pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
+              }
+            }
+>>>>>>> 6e08f5bf5 (Add parallel writing for truncate Parquet)
           }
         } else {
           if c_appendColumnToParquet(myFilename.localize().c_str(), valPtr,

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -457,16 +457,10 @@ module ParquetMsg {
           valPtr = c_ptrTo(locArr);
         }
         if mode == TRUNCATE || !filesExist {
-<<<<<<< HEAD
-          if c_writeColumnToParquet(myFilename.localize().c_str(), valPtr, 0,
-                                    dsetname.localize().c_str(), locDom.size, rowGroupSize,
-                                    dtypeRep, compression, c_ptrTo(pqErr.errMsg)) == ARROWERROR {
-            pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
-=======
           if !doParallel {
-            if c_writeColumnToParquet(myFilename.localize().c_str(), c_ptrTo(locArr), 0,
+            if c_writeColumnToParquet(myFilename.localize().c_str(), valPtr, 0,
                                       dsetname.localize().c_str(), locDom.size, rowGroupSize,
-                                      dtypeRep, compressed, c_ptrTo(pqErr.errMsg)) == ARROWERROR {
+                                      dtypeRep, compression, c_ptrTo(pqErr.errMsg)) == ARROWERROR {
               pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
             }
           } else {
@@ -489,7 +483,6 @@ module ParquetMsg {
                 pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
               }
             }
->>>>>>> 6e08f5bf5 (Add parallel writing for truncate Parquet)
           }
         } else {
           if c_appendColumnToParquet(myFilename.localize().c_str(), valPtr,

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -479,7 +479,7 @@ module ParquetMsg {
               var pqErr = new parquetErrorMsg();
               if c_writeColumnToParquet(parFilename.localize().c_str(), c_ptrTo(coreArr), 0,
                                         dsetname.localize().c_str(), coreArr.size, rowGroupSize,
-                                        dtypeRep, compressed, c_ptrTo(pqErr.errMsg)) == ARROWERROR {
+                                        dtypeRep, compression, c_ptrTo(pqErr.errMsg)) == ARROWERROR {
                 pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
               }
             }


### PR DESCRIPTION
This PR adds support for a `parallelWriteThreshold` flag that
allows a user to determine the size of files of the Parquet files
to be written and then write those files in parallel, appending a
`_CORE####` to the end of the file name.

By running the Arkouda server with:
`./arkouda_server --ParquetMsg.parallelWriteThreshold=<num>`, a
user is able to control the size of the files that are going to be
written.

This is currently only supported on pdarrays of natively-supported
datatypes (meaning not strings or dataframes), but follow work is
on the way.