### PR TITLE
Fix typo in #2879

### DIFF
--- a/src/compat/gt-132/SymArrayDmapCompat.chpl
+++ b/src/compat/gt-132/SymArrayDmapCompat.chpl
@@ -67,7 +67,7 @@ module SymArrayDmapCompat
       return dom.tryCreateArray(etype);
     }
 
-    proc makeDistArray(shape: int ...?, type etype) throws
+    proc makeDistArray(shape: int ...?N, type etype) throws
       where N > 1
     {
       var a: [makeDistDom((...shape))] etype;


### PR DESCRIPTION
Adds a missing query to one of the `makeDistArray` overloads added in #2879.

- [x] `make test` passing on Chapel main