### PR TITLE
Closes #2878: Add groupby for floats

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -27,6 +27,7 @@ from arkouda.dtypes import (
 from arkouda.dtypes import str_ as akstr_
 from arkouda.dtypes import translate_np_dtype
 from arkouda.dtypes import uint64 as akuint64
+from arkouda.dtypes import float64 as akfloat64
 from arkouda.infoclass import information, pretty_print_information
 from arkouda.logger import getArkoudaLogger
 
@@ -1968,6 +1969,9 @@ class pdarray:
         )
         return attach(user_defined_name)
 
+    def _float_to_uint(self):
+        return generic_msg(cmd="transmuteFloat", args={"name": self})
+
     def _get_grouping_keys(self) -> List[pdarray]:
         """
         Private method for generating grouping keys used by GroupBy.
@@ -1982,6 +1986,8 @@ class pdarray:
         elif self.dtype in (akint64, akuint64):
             # Integral pdarrays are their own grouping keys
             return [self]
+        elif self.dtype == akfloat64:
+            return [create_pdarray(self._float_to_uint())]
         elif self.dtype == bigint:
             return self.bigint_to_uint_arrays()
         else:

--- a/src/CastMsg.chpl
+++ b/src/CastMsg.chpl
@@ -190,6 +190,21 @@ module CastMsg {
     }
   }
 
+  proc transmuteFloatMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+    param pn = Reflection.getRoutineName();
+    var name = msgArgs.getValueOf("name");
+    castLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"name: %s".doFormat(name));
+    var e = toSymEntry(getGenericTypedArrayEntry(name, st), real);
+    var transmuted = makeDistArray(e.a.domain, uint);
+    transmuted = [ei in e.a] ei.transmute(uint(64));
+    var transmuteName = st.nextName();
+    st.addEntry(transmuteName, createSymEntry(transmuted));
+    var repMsg = "created " + st.attrib(transmuteName);
+    castLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+    return new MsgTuple(repMsg, MsgType.NORMAL);
+  }
+
   use CommandMap;
   registerFunction("cast", castMsg, getModuleName());
+  registerFunction("transmuteFloat", transmuteFloatMsg, getModuleName());
 }

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -403,9 +403,6 @@ class GroupByTest(ArkoudaTest):
             ak.GroupBy(ak.arange(4), ak.arange(4))
 
         with self.assertRaises(TypeError):
-            ak.GroupBy(self.fvalues)
-
-        with self.assertRaises(TypeError):
             gb.broadcast([])
 
         with self.assertRaises(TypeError):

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -736,10 +736,6 @@ class NumericTest(ArkoudaTest):
         self.assertEqual(ak.array([1]), result[0])
         self.assertEqual(ak.array([100]), result[1])
 
-        pda = ak.linspace(1, 10, 10)
-        with self.assertRaises(TypeError):
-            ak.value_counts(pda)
-
         with self.assertRaises(TypeError):
             ak.value_counts([0])
 

--- a/tests/setops_test.py
+++ b/tests/setops_test.py
@@ -94,9 +94,6 @@ class SetOpsTest(ArkoudaTest):
 
         self.assertListEqual([1, 4, 5, 7], ak.setxor1d(pdaOne, pdaTwo).to_list())
 
-        with self.assertRaises(TypeError):
-            ak.setxor1d(ak.array([-1.0, 0.0, 1.0]), ak.array([-2.0, 0.0, 2.0]))
-
     def testSetxor1d_Multi(self):
         # Test Numeric pdarray
         a = [1, 2, 3, 4, 5]
@@ -150,9 +147,6 @@ class SetOpsTest(ArkoudaTest):
 
         self.assertListEqual([1, 2], ak.setdiff1d(pdaOne, pdaTwo).to_list())
 
-        with self.assertRaises(TypeError):
-            ak.setdiff1d(ak.array([-1.0, 0.0, 1.0]), ak.array([-2.0, 0.0, 2.0]))
-
         with self.assertRaises(RuntimeError):
             ak.setdiff1d(ak.array([True, False, True]), ak.array([True, True]))
 
@@ -202,9 +196,6 @@ class SetOpsTest(ArkoudaTest):
         pdaTwo = ak.array([3, 1, 2, 1])
         self.assertListEqual([1, 3], ak.intersect1d(pdaOne, pdaTwo).to_list())
 
-        with self.assertRaises(TypeError):
-            ak.intersect1d(ak.array([-1.0, 0.0, 1.0]), ak.array([-2.0, 0.0, 2.0]))
-
     def testIntersect1d_Multi(self):
         # Test for numeric
         a = [1, 2, 3, 4, 5]
@@ -250,9 +241,6 @@ class SetOpsTest(ArkoudaTest):
         pdaOne = ak.array([-1, 0, 1])
         pdaTwo = ak.array([-2, 0, 2])
         self.assertListEqual([-2, -1, 0, 1, 2], ak.union1d(pdaOne, pdaTwo).to_list())
-
-        with self.assertRaises(TypeError):
-            ak.union1d(ak.array([-1.0, 0.0, 1.0]), ak.array([-2.0, 0.0, 2.0]))
 
     def testUnion1d_Multi(self):
         # test for numeric


### PR DESCRIPTION
This PR (closes #2878) adds groupby for floats by reinterpretting their bits as a uint (using transmute) and using the resulting uint pdarray for the groupby

Verification that groupby and related methods work on floats as expected
```python
>>> select_from =  ak.linspace(2**65, 2**66, 10)
>>> idx = ak.randint(1, 10, 100)
>>> group_on = select_from[idx]
>>> ak.GroupBy(group_on).count()
(array([4.099276460824345e+19 4.5092041069067796e+19 4.9191317529892135e+19 5.3290593990716482e+19 5.7389870451540828e+19 6.1489146912365167e+19 6.5588423373189513e+19 6.968769983401386e+19 73786976294838206464.00000000000000000]),
 array([9 10 14 10 11 6 17 11 12]))

>>> ak.GroupBy([group_on,group_on]).count()
((array([4.099276460824345e+19 4.5092041069067796e+19 4.9191317529892135e+19 5.3290593990716482e+19 5.7389870451540828e+19 6.1489146912365167e+19 6.5588423373189513e+19 6.968769983401386e+19 73786976294838206464.00000000000000000]),
  array([4.099276460824345e+19 4.5092041069067796e+19 4.9191317529892135e+19 5.3290593990716482e+19 5.7389870451540828e+19 6.1489146912365167e+19 6.5588423373189513e+19 6.968769983401386e+19 73786976294838206464.00000000000000000])),
 array([9 10 14 10 11 6 17 11 12]))

>>> ak.sort(group_on)
array([4.099276460824345e+19 4.099276460824345e+19 4.099276460824345e+19 ... 73786976294838206464.00000000000000000 73786976294838206464.00000000000000000 73786976294838206464.00000000000000000])

>>> ak.argsort(group_on)
array([2 14 16 ... 42 67 71])

>>> ak.coargsort([group_on,group_on])
array([2 14 16 ... 42 67 71])

>>> ak.unique(group_on)
array([4.099276460824345e+19 4.5092041069067796e+19 4.9191317529892135e+19 5.3290593990716482e+19 5.7389870451540828e+19 6.1489146912365167e+19 6.5588423373189513e+19 6.968769983401386e+19 73786976294838206464.00000000000000000])

>>> ak.GroupBy(group_on).unique_keys
array([4.099276460824345e+19 4.5092041069067796e+19 4.9191317529892135e+19 5.3290593990716482e+19 5.7389870451540828e+19 6.1489146912365167e+19 6.5588423373189513e+19 6.968769983401386e+19 73786976294838206464.00000000000000000])
```