### PR TITLE
Fixes #2883: Fix ambiguity in `makeDistArray` where clauses

### DIFF
--- a/src/compat/e-132/SymArrayDmapCompat.chpl
+++ b/src/compat/e-132/SymArrayDmapCompat.chpl
@@ -82,7 +82,7 @@ module SymArrayDmapCompat
     }
 
     proc makeDistArray(in a: [?D] ?etype) throws
-      where D.rank == 1
+      where D.rank == 1 && (MyDmap == Dmap.defaultRectangular || !a.isDefaultRectangular())
     {
       var res = D.tryCreateArray(etype);
       res = a;
@@ -90,7 +90,7 @@ module SymArrayDmapCompat
     }
 
     proc makeDistArray(in a: [?D] ?etype) throws
-      where D.rank > 1
+      where D.rank > 1 && (MyDmap == Dmap.defaultRectangular || !a.isDefaultRectangular())
     {
       return a;
     }

--- a/src/compat/gt-132/SymArrayDmapCompat.chpl
+++ b/src/compat/gt-132/SymArrayDmapCompat.chpl
@@ -82,7 +82,7 @@ module SymArrayDmapCompat
     }
 
     proc makeDistArray(in a: [?D] ?etype) throws
-      where D.rank == 1
+      where D.rank == 1 && (MyDmap == Dmap.defaultRectangular || !a.isDefaultRectangular())
     {
       var res = D.tryCreateArray(etype);
       res = a;
@@ -90,7 +90,7 @@ module SymArrayDmapCompat
     }
 
     proc makeDistArray(in a: [?D] ?etype) throws
-      where D.rank > 1
+      where D.rank > 1 && (MyDmap == Dmap.defaultRectangular || !a.isDefaultRectangular())
     {
       return a;
     }


### PR DESCRIPTION
A change in https://github.com/Bears-R-Us/arkouda/pull/2879 caused an ambiguity error when building with gasnet and Chapel >= 1.32. This PR adds some additional expressions to the where clauses on some `makeDistArray` procedures to remove the ambiguity.

resolves: https://github.com/Bears-R-Us/arkouda/issues/2883

- [x] `make test` passing on gasnet