### PR TITLE
Closes #2886: Cap small strs groupby optimization

### DIFF
--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -235,7 +235,7 @@ module AryUtil
       var allSmallStrs = true;
       var extraArraysNeeded = 0;
       var numStrings = 0;
-      const smallStrCap = 17;  // one bigger to ignore null byte
+      const smallStrCap = 9;  // one bigger to ignore null byte
       for (name, objtype, i) in zip(names, types, 1..) {
         var thisSize: int;
         select objtype.toUpper(): ObjType {

--- a/src/UniqueMsg.chpl
+++ b/src/UniqueMsg.chpl
@@ -173,6 +173,39 @@ module UniqueMsg
         }
       }
 
+      if hasStr && n == 1 {
+        // Only one array which is a strings
+        var (myNames, _) = namesList[0].splitMsgToTuple("+", 2);
+        var strings = getSegString(myNames, st);
+        // should we do strings.getLengths()-1 to not account for null
+        const lengths = strings.getLengths() - 1;
+        const max_bytes = (max reduce lengths);
+        if max_bytes < 16 {
+          var str_names = strings.bytesToUintArr(max_bytes, lengths, st).split("+");
+          var (totalDigits, bitWidths, negs) = getNumDigitsNumericArrays(str_names, st);
+          if totalDigits <= 2 {
+            var (perm, segments) = helper(2 * bitsPerDigit / 8, 2*uint(bitsPerDigit), mergeNumericArrays(2, size, totalDigits, bitWidths, negs, str_names, st));
+            cleanup(str_names, st);
+            return (perm, segments);
+          }
+          if totalDigits <= 4 {
+            var (perm, segments) = helper(4 * bitsPerDigit / 8, 4*uint(bitsPerDigit), mergeNumericArrays(4, size, totalDigits, bitWidths, negs, str_names, st));
+            cleanup(str_names, st);
+            return (perm, segments);
+          }
+          if totalDigits <= 6 {
+            var (perm, segments) = helper(6 * bitsPerDigit / 8, 6*uint(bitsPerDigit), mergeNumericArrays(6, size, totalDigits, bitWidths, negs, str_names, st));
+            cleanup(str_names, st);
+            return (perm, segments);
+          }
+          if totalDigits <= 8 {
+            var (perm, segments) = helper(8 * bitsPerDigit / 8, 8*uint(bitsPerDigit), mergeNumericArrays(8, size, totalDigits, bitWidths, negs, str_names, st));
+            cleanup(str_names, st);
+            return (perm, segments);
+          }
+        }
+      }
+
       var strNames: [0..#(numStrings + extraArraysNeeded)] string;
       var newNames: [0..#(n+extraArraysNeeded)] string;
       var newTypes: [0..#(n+extraArraysNeeded)] string;


### PR DESCRIPTION
This PR (closes #2886) caps strs for the small str optimization at 8 bytes since there was a drop off in our str groupby benchmarks. It also adds back in the up to 16 bytes optimization for a single str column

This is because we currently have our small str optimization set to kick in at 16 bytes (which is how long the strings are in the multi-col str groupby benchmark) but this is the max number of bits we can have before we hit the `totalDigits > 8` case, where we hash everything anyway. So these are all resulting in extra processing just to do what we were already doing