### PR TITLE
Adjustments to remove some chpl unstable warnings

### DIFF
--- a/src/CSVMsg.chpl
+++ b/src/CSVMsg.chpl
@@ -648,11 +648,11 @@ module CSVMsg {
         try {
             if headers[0] {
                 rtnData = readTypedCSV(filenames, dsetlist, data_types[0], row_cts, validFiles, col_delim, allowErrors, st);
-                rtnMsg = _buildReadAllMsgJson(rtnData, allowErrors, fileErrorCount, fileErrors, st);
+                rtnMsg = buildReadAllMsgJson(rtnData, allowErrors, fileErrorCount, fileErrors, st);
             }
             else {
                 rtnData = readGenericCSV(filenames, dsetlist, row_cts, validFiles, col_delim, allowErrors, st);
-                rtnMsg = _buildReadAllMsgJson(rtnData, allowErrors, fileErrorCount, fileErrors, st);
+                rtnMsg = buildReadAllMsgJson(rtnData, allowErrors, fileErrorCount, fileErrors, st);
             }
         }
         catch e: Error {

--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -408,6 +408,7 @@ module CommAggregation {
     use BigInteger, GMP;
     use ArkoudaPOSIXCompat;
     use ArkoudaAggCompat;
+    use Math;
 
     proc bigint._serializedSize() {
       extern proc chpl_gmp_mpz_struct_sign_size(from: __mpz_struct) : mp_size_t;
@@ -415,7 +416,7 @@ module CommAggregation {
       var sign_size = chpl_gmp_mpz_struct_sign_size(this.getImpl());
 
       var size_bytes = c_sizeof(mp_size_t):int;
-      var limb_bytes = AutoMath.abs(sign_size:int) * c_sizeof(mp_limb_t):int;
+      var limb_bytes = Math.abs(sign_size:int) * c_sizeof(mp_limb_t):int;
 
       return size_bytes + limb_bytes;
     }
@@ -427,7 +428,7 @@ module CommAggregation {
       var sign_size = chpl_gmp_mpz_struct_sign_size(this.getImpl());
 
       var size_bytes = c_sizeof(mp_size_t):int;
-      var limb_bytes = AutoMath.abs(sign_size:int) * c_sizeof(mp_limb_t):int;
+      var limb_bytes = Math.abs(sign_size:int) * c_sizeof(mp_limb_t):int;
 
       var limb_ptr = chpl_gmp_mpz_struct_limbs(this.getImpl());
 
@@ -446,7 +447,7 @@ module CommAggregation {
 
       memcpy(c_ptrTo(sign_size), x, size_bytes);
 
-      var nlimbs = AutoMath.abs(sign_size:int);
+      var nlimbs = Math.abs(sign_size:int);
       var limb_bytes = nlimbs * c_sizeof(mp_limb_t):int;
 
       _mpz_realloc(this.mpz, nlimbs);

--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -421,7 +421,7 @@ module CommAggregation {
       return size_bytes + limb_bytes;
     }
 
-    proc bigint._serializeInto(x: c_ptr(uint(8))) {
+    proc bigint.serializeInto(x: c_ptr(uint(8))) {
       extern proc chpl_gmp_mpz_struct_sign_size(from: __mpz_struct) : mp_size_t;
       extern proc chpl_gmp_mpz_struct_limbs(from: __mpz_struct) : c_ptr(mp_limb_t);
 
@@ -525,7 +525,7 @@ module CommAggregation {
 
         // Buffer the address and the serialized value
         memcpy(c_ptrTo(lBuffers[loc][bufferIdx]), c_ptrTo(dstAddr), addr_bytes);
-        src._serializeInto(c_ptrTo(lBuffers[loc][bufferIdx+addr_bytes]));
+        src.serializeInto(c_ptrTo(lBuffers[loc][bufferIdx+addr_bytes]));
         bufferIdx += addr_bytes + serialize_bytes;
 
         // If it's been a while since we've let other tasks run, yield so that
@@ -691,7 +691,7 @@ module CommAggregation {
               }
 
               // copy value for current address into value array
-              srcAddr.deref()._serializeInto(c_ptrTo(rSrcValPtr[valueBufferIdx]));
+              srcAddr.deref().serializeInto(c_ptrTo(rSrcValPtr[valueBufferIdx]));
 
               valueBufferIdx += ser_size;
               addrBufferIdx += 1;

--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -416,7 +416,7 @@ module CommAggregation {
       var sign_size = chpl_gmp_mpz_struct_sign_size(this.getImpl());
 
       var size_bytes = c_sizeof(mp_size_t):int;
-      var limb_bytes = Math.abs(sign_size:int) * c_sizeof(mp_limb_t):int;
+      var limb_bytes = abs(sign_size:int) * c_sizeof(mp_limb_t):int;
 
       return size_bytes + limb_bytes;
     }
@@ -428,7 +428,7 @@ module CommAggregation {
       var sign_size = chpl_gmp_mpz_struct_sign_size(this.getImpl());
 
       var size_bytes = c_sizeof(mp_size_t):int;
-      var limb_bytes = Math.abs(sign_size:int) * c_sizeof(mp_limb_t):int;
+      var limb_bytes = abs(sign_size:int) * c_sizeof(mp_limb_t):int;
 
       var limb_ptr = chpl_gmp_mpz_struct_limbs(this.getImpl());
 
@@ -447,7 +447,7 @@ module CommAggregation {
 
       memcpy(c_ptrTo(sign_size), x, size_bytes);
 
-      var nlimbs = Math.abs(sign_size:int);
+      var nlimbs = abs(sign_size:int);
       var limb_bytes = nlimbs * c_sizeof(mp_limb_t):int;
 
       _mpz_realloc(this.mpz, nlimbs);

--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -80,7 +80,7 @@ module CommAggregation {
     proc ref flush() {
       for offsetLoc in myLocaleSpace + lastLocale {
         const loc = offsetLoc % numLocales;
-        _flushBuffer(loc, bufferIdxs[loc], freeData=true);
+        flushBuffer(loc, bufferIdxs[loc], freeData=true);
       }
     }
 
@@ -101,7 +101,7 @@ module CommAggregation {
       // other tasks run, yield so that we're not blocking remote tasks from
       // flushing their buffers.
       if bufferIdx == bufferSize {
-        _flushBuffer(loc, bufferIdx, freeData=false);
+        flushBuffer(loc, bufferIdx, freeData=false);
         opsUntilYield = yieldFrequency;
       } else if opsUntilYield == 0 {
         yieldTask();
@@ -111,7 +111,7 @@ module CommAggregation {
       }
     }
 
-    proc ref _flushBuffer(loc: int, ref bufferIdx, freeData) {
+    proc ref flushBuffer(loc: int, ref bufferIdx, freeData) {
       const myBufferIdx = bufferIdx;
       if myBufferIdx == 0 then return;
 
@@ -203,7 +203,7 @@ module CommAggregation {
     proc ref flush() {
       for offsetLoc in myLocaleSpace + lastLocale {
         const loc = offsetLoc % numLocales;
-        _flushBuffer(loc, bufferIdxs[loc], freeData=true);
+        flushBuffer(loc, bufferIdxs[loc], freeData=true);
       }
     }
 
@@ -223,7 +223,7 @@ module CommAggregation {
       bufferIdx += 1;
 
       if bufferIdx == bufferSize {
-        _flushBuffer(loc, bufferIdx, freeData=false);
+        flushBuffer(loc, bufferIdx, freeData=false);
         opsUntilYield = yieldFrequency;
       } else if opsUntilYield == 0 {
         yieldTask();
@@ -233,7 +233,7 @@ module CommAggregation {
       }
     }
 
-    proc ref _flushBuffer(loc: int, ref bufferIdx, freeData) {
+    proc ref flushBuffer(loc: int, ref bufferIdx, freeData) {
       const myBufferIdx = bufferIdx;
       if myBufferIdx == 0 then return;
 
@@ -410,7 +410,7 @@ module CommAggregation {
     use ArkoudaAggCompat;
     use Math;
 
-    proc bigint._serializedSize() {
+    proc bigint.serializedSize() {
       extern proc chpl_gmp_mpz_struct_sign_size(from: __mpz_struct) : mp_size_t;
 
       var sign_size = chpl_gmp_mpz_struct_sign_size(this.getImpl());
@@ -436,7 +436,7 @@ module CommAggregation {
       memcpy(x+size_bytes, limb_ptr, limb_bytes);
     }
 
-    proc ref bigint._deserializeFrom(x: c_ptr(uint(8))) {
+    proc ref bigint.deserializeFrom(x: c_ptr(uint(8))) {
       extern proc chpl_gmp_mpz_struct_limbs(from: __mpz_struct) : c_ptr(mp_limb_t);
       extern proc chpl_gmp_mpz_set_sign_size(ref dst:mpz_t, sign_size:mp_size_t);
 
@@ -491,7 +491,7 @@ module CommAggregation {
       proc ref flush() {
         for offsetLoc in myLocaleSpace + lastLocale {
           const loc = offsetLoc % numLocales;
-          _flushBuffer(loc, bufferIdxs[loc], freeData=true);
+          flushBuffer(loc, bufferIdxs[loc], freeData=true);
         }
       }
 
@@ -501,7 +501,7 @@ module CommAggregation {
         // the same as the mpz storage itself.
         const loc = dst.locale.id;
 
-        const serialize_bytes = src._serializedSize();
+        const serialize_bytes = src.serializedSize();
 
         // Just do direct assignment if dst is local or src size is large
         if loc == here.id || serialize_bytes > (bufferSize >> 2) {
@@ -519,7 +519,7 @@ module CommAggregation {
 
         // Flush our buffer if this entry will exceed capacity
         if bufferIdx + addr_bytes + serialize_bytes > bufferSize {
-          _flushBuffer(loc, bufferIdx, freeData=false);
+          flushBuffer(loc, bufferIdx, freeData=false);
           opsUntilYield = yieldFrequency;
         }
 
@@ -538,7 +538,7 @@ module CommAggregation {
         }
       }
 
-      proc ref _flushBuffer(loc: int, ref bufferIdx, freeData) {
+      proc ref flushBuffer(loc: int, ref bufferIdx, freeData) {
         const myBufferIdx = bufferIdx;
         if myBufferIdx == 0 then return;
 
@@ -561,7 +561,7 @@ module CommAggregation {
             // assert that record locality matches mpz locality
             if boundsChecking { assert(dstAddr.deref().localeId == here.id); }
             // deserialize into bigint
-            var ser_bytes = dstAddr.deref()._deserializeFrom(c_ptrTo(remBufferPtr[curBufferIdx+addr_bytes]));
+            var ser_bytes = dstAddr.deref().deserializeFrom(c_ptrTo(remBufferPtr[curBufferIdx+addr_bytes]));
             curBufferIdx += addr_bytes + ser_bytes;
           }
 
@@ -617,7 +617,7 @@ module CommAggregation {
       proc ref flush() {
         for offsetLoc in myLocaleSpace + lastLocale {
           const loc = offsetLoc % numLocales;
-          _flushBuffer(loc, bufferIdxs[loc], freeData=true);
+          flushBuffer(loc, bufferIdxs[loc], freeData=true);
         }
       }
 
@@ -637,7 +637,7 @@ module CommAggregation {
         bufferIdx += 1;
 
         if bufferIdx == bufferSize {
-          _flushBuffer(loc, bufferIdx, freeData=false);
+          flushBuffer(loc, bufferIdx, freeData=false);
           opsUntilYield = yieldFrequency;
         } else if opsUntilYield == 0 {
           yieldTask();
@@ -647,7 +647,7 @@ module CommAggregation {
         }
       }
 
-      proc ref _flushBuffer(loc: int, ref bufferIdx, freeData) {
+      proc ref flushBuffer(loc: int, ref bufferIdx, freeData) {
         const myBufferIdx = bufferIdx;
         if myBufferIdx == 0 then return;
 
@@ -678,7 +678,7 @@ module CommAggregation {
             while valueBufferIdx < myBufferSize && addrBufferIdx < myBufferIdx {
               var srcAddr = rSrcAddrPtr[addrBufferIdx];
 
-              var ser_size = srcAddr.deref()._serializedSize();
+              var ser_size = srcAddr.deref().serializedSize();
               if ser_size > myBufferSize {
                 // Halt if the size is too big. A slow fallback would be to
                 // just break and have the initiator see the bytes written
@@ -712,7 +712,7 @@ module CommAggregation {
           var curBufferIdx = 0;
           while addrBufferIdx < bytesValsWritten(1) {
             var dstAddr = dstAddrPtr[addrBufferIdx];
-            var ser_size = dstAddr.deref()._deserializeFrom(c_ptrTo(srcValPtr[curBufferIdx]));
+            var ser_size = dstAddr.deref().deserializeFrom(c_ptrTo(srcValPtr[curBufferIdx]));
             curBufferIdx += ser_size:int;
             addrBufferIdx += 1;
           }

--- a/src/Extremas.chpl
+++ b/src/Extremas.chpl
@@ -34,7 +34,7 @@ to increase the efficiency of the merge step.
     var numEmpty: int = size-2;
     var isSorted: bool = false;
     var isMinReduction=true;
-    var _data: [dom] (eltType, int) = if isMinReduction then (max(eltType), -1) else (min(eltType), -1);
+    var data: [dom] (eltType, int) = if isMinReduction then (max(eltType), -1) else (min(eltType), -1);
     
     proc pushArr(arr: [?D]) {
       for i in D {
@@ -57,15 +57,15 @@ to increase the efficiency of the merge step.
         return;
       }
 
-      const shouldAdd = if isMinReduction then val(0)<_data[0](0) else val(0)>_data[0](0);
+      const shouldAdd = if isMinReduction then val(0)<data[0](0) else val(0)>data[0](0);
       const shouldAddEmpty = (numEmpty>0) && if isMinReduction then
-        _data[0](0)==max(eltType) else _data[0](0)==min(eltType);
+        data[0](0)==max(eltType) else data[0](0)==min(eltType);
 
       if shouldAddEmpty {
-        _data[numEmpty+1] = val;
+        data[numEmpty+1] = val;
         numEmpty-=1;
       } else if shouldAdd {
-        _data[0] = val;
+        data[0] = val;
         heapifyDown();
       }
     }
@@ -79,15 +79,15 @@ to increase the efficiency of the merge step.
         const l = 2*i+1; // left child
         const r = 2*i+2; // right child
         const cmpLeft = l<size && if isMinReduction then
-          _data[l](0) > _data[i](0) else _data[l](0) < _data[i](0);
+          data[l](0) > data[i](0) else data[l](0) < data[i](0);
         if (cmpLeft) then i = l;
         // if right child is more extreme than largest so far
         const cmpRight = r<size && if isMinReduction then
-          _data[r](0) > _data[i](0) else _data[r](0) < _data[i](0);
+          data[r](0) > data[i](0) else data[r](0) < data[i](0);
         if (cmpRight) then i = r;
         // if the extreme value isn't the initial 
         if (initial != i) {
-          _data[i] <=> _data[initial];
+          data[i] <=> data[initial];
         } else break;
       }
     }
@@ -95,12 +95,12 @@ to increase the efficiency of the merge step.
     // Sort the KExtreme values if needed,
     // moving from a heap to a sorted array
     proc ref doSort() {
-      sort(_data);
+      sort(data);
       isSorted = true;
     }
 
     iter these() {
-      for e in _data {
+      for e in data {
         yield e;
       }
     }
@@ -110,13 +110,13 @@ to increase the efficiency of the merge step.
   // returns an array that contains the
   // smallest values from each array sorted.
   // Returned array is size of the original heaps.
-  proc merge(ref v1: KExtreme(?t), ref v2: KExtreme(t)): [v1._data.domain] (t ,int) {
+  proc merge(ref v1: KExtreme(?t), ref v2: KExtreme(t)): [v1.data.domain] (t ,int) {
     const isMin = v1.isMinReduction;
     if !v1.isSorted then v1.doSort();
     if !v2.isSorted then v2.doSort();
 
-    const first = v1._data;
-    const second = v2._data;
+    const first = v1.data;
+    const second = v2.data;
     var ret: [first.domain] (v1.eltType, int);
     var a,b,i: int = if v1.isMinReduction then
       0 else first.domain.high;

--- a/src/FileIO.chpl
+++ b/src/FileIO.chpl
@@ -203,13 +203,13 @@ module FileIO {
     proc getFileTypeByMagic(header:bytes): FileType {
         var t = FileType.UNKNOWN;
         var length = header.size;
-        if (length >= 4 && MAGIC_PARQUET == header.this(0..3)) {
+        if (length >= 4 && MAGIC_PARQUET == header[0..3]) {
             t = FileType.PARQUET;
-        } else if (length >= 8 && MAGIC_HDF5 == header.this(0..7)) {
+        } else if (length >= 8 && MAGIC_HDF5 == header[0..7]) {
             t = FileType.HDF5;
-        } else if (length >= 8 && MAGIC_ARROW == header.this(0..7)) {
+        } else if (length >= 8 && MAGIC_ARROW == header[0..7]) {
             t = FileType.ARROW;
-        } else if (length >= 8 && MAGIC_CSV == header.this(0..7)) {
+        } else if (length >= 8 && MAGIC_CSV == header[0..7]) {
           t = FileType.CSV;
         }
         return t;

--- a/src/Flatten.chpl
+++ b/src/Flatten.chpl
@@ -41,7 +41,7 @@ module Flatten {
     var nullByteLocations = makeDistArray(this.values.a.domain, false);
 
     // since the delim matches are variable length, we don't know what the size of flattenedVals should be until we've found the matches
-    forall (i, off, len) in zip(this.offsets.a.domain, origOffsets, lengths) with (var myRegex = _unsafeCompileRegex(delim.encode()),
+    forall (i, off, len) in zip(this.offsets.a.domain, origOffsets, lengths) with (var myRegex = unsafeCompileRegex(delim.encode()),
                                                                              var writeAgg = newDstAggregator(bool),
                                                                              var nbAgg = newDstAggregator(bool),
                                                                              var matchAgg = newDstAggregator(int)) {
@@ -144,7 +144,7 @@ module Flatten {
     // maxSplit = 0 means replace all occurances, so we set maxsplit equal to 10**9
     var maxsplit = if initMaxSplit == 0 then 10**9:int else initMaxSplit;
     // since the pattern matches are variable length, we don't know what the size of splitVals should be until we've found the matches
-    forall (i, off, len) in zip(this.offsets.a.domain, origOffsets, lengths) with (var myRegex = _unsafeCompileRegex(pattern.encode()),
+    forall (i, off, len) in zip(this.offsets.a.domain, origOffsets, lengths) with (var myRegex = unsafeCompileRegex(pattern.encode()),
                                                                              var writeAgg = newDstAggregator(bool),
                                                                              var nbAgg = newDstAggregator(bool),
                                                                              var matchAgg = newDstAggregator(int)) {

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -192,7 +192,7 @@ module GenSymIO {
         }
     }
 
-    proc _buildReadAllMsgJson(rnames:list((string, ObjType, string)), allowErrors:bool, fileErrorCount:int, fileErrors:list(string), st: borrowed SymTab): string throws {
+    proc buildReadAllMsgJson(rnames:list((string, ObjType, string)), allowErrors:bool, fileErrorCount:int, fileErrors:list(string), st: borrowed SymTab): string throws {
         var items: list(map(string, string));
 
         for rname in rnames {

--- a/src/KReduce.chpl
+++ b/src/KReduce.chpl
@@ -63,7 +63,7 @@ module KReduce {
     // when combining, merge instead of
     // accumulating each individual value
     proc combine(state: borrowed kreduce(eltType)) {
-      v._data = merge(v, state.v);
+      v.data = merge(v, state.v);
     }
 
     proc generate() {

--- a/src/MemoryMgmt.chpl
+++ b/src/MemoryMgmt.chpl
@@ -3,6 +3,7 @@ module MemoryMgmt {
     use Subprocess;
     use FileSystem;
     use Reflection;
+    use Math;
 
     use Logging;
     use ServerErrors;
@@ -119,7 +120,7 @@ module MemoryMgmt {
             }
         }
 
-        return (AutoMath.round(availableMemoryPct/100 * memAvail)*1000):uint(64);
+        return (Math.round(availableMemoryPct/100 * memAvail)*1000):uint(64);
     }
     
     proc getTotalMemory() : uint(64) throws {

--- a/src/MemoryMgmt.chpl
+++ b/src/MemoryMgmt.chpl
@@ -9,7 +9,8 @@ module MemoryMgmt {
     use ServerErrors;
     use ArkoudaMemDiagnosticsCompat;
     use ArkoudaFileCompat;
-    
+    use ArkoudaMathCompat;
+
     private config const logLevel = LogLevel.DEBUG;
     private config const logChannel = LogChannel.CONSOLE;
     const mmLogger = new Logger(logLevel,logChannel);
@@ -120,7 +121,7 @@ module MemoryMgmt {
             }
         }
 
-        return (Math.round(availableMemoryPct/100 * memAvail)*1000):uint(64);
+        return (mathRound(availableMemoryPct/100 * memAvail)*1000):uint(64);
     }
     
     proc getTotalMemory() : uint(64) throws {

--- a/src/MsgProcessing.chpl
+++ b/src/MsgProcessing.chpl
@@ -3,7 +3,6 @@ module MsgProcessing
 {
     use ServerConfig;
 
-    use Math only;
     use Reflection;
     use ServerErrors;
     use Logging;
@@ -17,6 +16,7 @@ module MsgProcessing
 
     use ArkoudaBigIntCompat;
     use ArkoudaTimeCompat as Time;
+    use ArkoudaMathCompat;
 
     private config const logLevel = ServerConfig.logLevel;
     private config const logChannel = ServerConfig.logChannel;
@@ -176,10 +176,10 @@ module MsgProcessing
         mpLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"cmd: %s".doFormat(cmd));
         var memUsed = if memTrack then getMemUsed():real * numLocales else st.memUsed():real;
         if asPercent {
-            repMsg = Math.round((memUsed / (getMemLimit():real * numLocales)) * 100):uint:string;
+            repMsg = mathRound((memUsed / (getMemLimit():real * numLocales)) * 100):uint:string;
         }
         else {
-            repMsg = Math.round(memUsed / factor):uint:string;
+            repMsg = mathRound(memUsed / factor):uint:string;
         }
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }
@@ -203,10 +203,10 @@ module MsgProcessing
         var memUsed = if memTrack then getMemUsed():real * numLocales else st.memUsed():real;
         var totMem = getMemLimit():real * numLocales;
         if asPercent {
-            repMsg = (100 - Math.round((memUsed / totMem) * 100)):uint:string;
+            repMsg = (100 - mathRound((memUsed / totMem) * 100)):uint:string;
         }
         else {
-            repMsg = Math.round((totMem - memUsed) / factor):uint:string;
+            repMsg = mathRound((totMem - memUsed) / factor):uint:string;
         }
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }

--- a/src/MsgProcessing.chpl
+++ b/src/MsgProcessing.chpl
@@ -176,10 +176,10 @@ module MsgProcessing
         mpLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"cmd: %s".doFormat(cmd));
         var memUsed = if memTrack then getMemUsed():real * numLocales else st.memUsed():real;
         if asPercent {
-            repMsg = AutoMath.round((memUsed / (getMemLimit():real * numLocales)) * 100):uint:string;
+            repMsg = Math.round((memUsed / (getMemLimit():real * numLocales)) * 100):uint:string;
         }
         else {
-            repMsg = AutoMath.round(memUsed / factor):uint:string;
+            repMsg = Math.round(memUsed / factor):uint:string;
         }
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }
@@ -203,10 +203,10 @@ module MsgProcessing
         var memUsed = if memTrack then getMemUsed():real * numLocales else st.memUsed():real;
         var totMem = getMemLimit():real * numLocales;
         if asPercent {
-            repMsg = (100 - AutoMath.round((memUsed / totMem) * 100)):uint:string;
+            repMsg = (100 - Math.round((memUsed / totMem) * 100)):uint:string;
         }
         else {
-            repMsg = AutoMath.round((totMem - memUsed) / factor):uint:string;
+            repMsg = Math.round((totMem - memUsed) / factor):uint:string;
         }
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }

--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -103,7 +103,7 @@ module MultiTypeSymEntry
          *
          * :returns: s (string) containing the array data
          */
-        proc __str__(thresh:int=1, prefix:string="", suffix:string="", baseFormat:string=""): string throws {
+        proc entry__str__(thresh:int=1, prefix:string="", suffix:string="", baseFormat:string=""): string throws {
             genLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "__str__ invoked");
             var s = "AbstractSymEntry:subClasses should override this __str__ proc";
             return prefix + s + suffix;
@@ -173,7 +173,7 @@ module MultiTypeSymEntry
 
             :returns: s (string) containing the array data
         */
-        override proc __str__(thresh:int=1, prefix:string="", suffix:string="", baseFormat:string=""): string throws {
+        override proc entry__str__(thresh:int=1, prefix:string="", suffix:string="", baseFormat:string=""): string throws {
             genLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "__str__ invoked");
             var s = "DType: %s, itemsize: %?, size: %?".doFormat(this.dtype, this.itemsize, this.size);
             return prefix + s + suffix;
@@ -252,7 +252,7 @@ module MultiTypeSymEntry
 
             :returns: s (string) containing the array data
         */
-        override proc __str__(thresh:int=6, prefix:string = "[", suffix:string = "]", baseFormat:string = "%?"): string throws {
+        override proc entry__str__(thresh:int=6, prefix:string = "[", suffix:string = "]", baseFormat:string = "%?"): string throws {
             proc dimSummary(dim: int): string throws {
                 const dimSize = this.tupShape[dim];
                 var s: string;
@@ -394,7 +394,7 @@ module MultiTypeSymEntry
          *
          * :returns: s (string) containing the array data
          */
-        override proc __str__(thresh:int=1, prefix:string="", suffix:string="", baseFormat:string=""): string throws {
+        override proc entry__str__(thresh:int=1, prefix:string="", suffix:string="", baseFormat:string=""): string throws {
             genLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "__str__ invoked");
             var s = "DType: %s, itemsize: %?, size: %?".doFormat(this.dtype, this.itemsize, this.size);
             return prefix + s + suffix;

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -404,7 +404,7 @@ module MultiTypeSymbolTable
             //     mtLogger.error(getModuleName(),getRoutineName(),getLineNumber(),s);
             //     return s;
             // }
-            return u.__str__(thresh=thresh, prefix="[", suffix="]", baseFormat="%?");
+            return u.entry__str__(thresh=thresh, prefix="[", suffix="]", baseFormat="%?");
         }
 
         /*
@@ -433,7 +433,7 @@ module MultiTypeSymbolTable
                     return s;
                 }
                 var frmt:string = if (u.dtype == DType.Float64) then "%.17r" else "%?";
-                return u.__str__(thresh=thresh, prefix="array([", suffix="])", baseFormat=frmt);
+                return u.entry__str__(thresh=thresh, prefix="array([", suffix="])", baseFormat=frmt);
             } else {
                 return "Unhandled type %s".doFormat(entry.entryType);
             }

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -885,7 +885,7 @@ module ParquetMsg {
         }
     }
 
-    repMsg = _buildReadAllMsgJson(rnames, false, 0, fileErrors, st);
+    repMsg = buildReadAllMsgJson(rnames, false, 0, fileErrors, st);
     pqLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
     return new MsgTuple(repMsg,MsgType.NORMAL);
   }
@@ -1700,7 +1700,7 @@ module ParquetMsg {
     return filesExist;
   }
 
-  proc _identifyTargetLocales(name: string, objType: string, st: borrowed SymTab) throws {
+  proc identifyTargetLocales(name: string, objType: string, st: borrowed SymTab) throws {
     var targetLocales;
     select objType.toUpper(): ObjType {
       when ObjType.STRINGS {
@@ -1779,7 +1779,7 @@ module ParquetMsg {
     const compression = msgArgs.getValueOf("compression").toUpper(): CompressionType;
 
     // use the first entry to identify target locales. Assuming all have same distribution
-    var targetLocales = _identifyTargetLocales(sym_names[0], col_objType_strs[0], st);
+    var targetLocales = identifyTargetLocales(sym_names[0], col_objType_strs[0], st);
     
     var warnFlag: bool;
     try {
@@ -1973,7 +1973,7 @@ module ParquetMsg {
         }
     }
 
-    repMsg = _buildReadAllMsgJson(rnames, false, 0, fileErrors, st);
+    repMsg = buildReadAllMsgJson(rnames, false, 0, fileErrors, st);
     pqLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
     return new MsgTuple(repMsg,MsgType.NORMAL);
   }

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -120,7 +120,7 @@ module ParquetMsg {
   }
 
   proc readFilesByName(ref A: [] ?t, filenames: [] string, sizes: [] int, dsetname: string, ty, byteLength=-1) throws {
-    extern proc c_readColumnByName(filename, chpl_arr, colNum, numElems, startIdx, batchSize, byteLength, errMsg): int;
+    extern proc c_readColumnByName(filename, arr_chpl, colNum, numElems, startIdx, batchSize, byteLength, errMsg): int;
     var (subdoms, length) = getSubdomains(sizes);
     var fileOffsets = (+ scan sizes) - sizes;
     
@@ -149,7 +149,7 @@ module ParquetMsg {
   }
 
   proc readStrFilesByName(A: [] ?t, filenames: [] string, sizes: [] int, dsetname: string, ty) throws {
-    extern proc c_readColumnByName(filename, chpl_arr, colNum, numElems, startIdx, batchSize, byteLength, errMsg): int;
+    extern proc c_readColumnByName(filename, arr_chpl, colNum, numElems, startIdx, batchSize, byteLength, errMsg): int;
     var (subdoms, length) = getSubdomains(sizes);
     
     coforall loc in A.targetLocales() do on loc {
@@ -193,7 +193,7 @@ module ParquetMsg {
   }
 
   proc readListFilesByName(A: [] ?t, rows_per_file: [] int, seg_sizes: [] int, offsets: [] int, filenames: [] string, sizes: [] int, dsetname: string, ty) throws {
-    extern proc c_readListColumnByName(filename, chpl_arr, colNum, numElems, startIdx, batchSize, errMsg): int;
+    extern proc c_readListColumnByName(filename, arr_chpl, colNum, numElems, startIdx, batchSize, errMsg): int;
     var (subdoms, length) = getSubdomains(sizes);
     var fileOffsets = (+ scan sizes) - sizes;
     var segmentOffsets = (+ scan rows_per_file) - rows_per_file;
@@ -270,7 +270,7 @@ module ParquetMsg {
   }
 
   proc getNullIndices(A: [] ?t, filenames: [] string, sizes: [] int, dsetname: string, ty) throws {
-    extern proc c_getStringColumnNullIndices(filename, colname, chpl_nulls, errMsg): int;
+    extern proc c_getStringColumnNullIndices(filename, colname, nulls_chpl, errMsg): int;
     var (subdoms, length) = getSubdomains(sizes);
     
     coforall loc in A.targetLocales() do on loc {
@@ -326,7 +326,7 @@ module ParquetMsg {
   }
   
   proc getArrSize(filename: string) throws {
-    extern proc c_getNumRows(chpl_str, errMsg): int;
+    extern proc c_getNumRows(str_chpl, errMsg): int;
     var pqErr = new parquetErrorMsg();
 
     var size = c_getNumRows(filename.localize().c_str(),
@@ -409,10 +409,10 @@ module ParquetMsg {
   }
 
   proc writeDistArrayToParquet(A, filename, dsetname, dtype, rowGroupSize, compression, mode) throws {
-    extern proc c_writeColumnToParquet(filename, chpl_arr, colnum,
+    extern proc c_writeColumnToParquet(filename, arr_chpl, colnum,
                                        dsetname, numelems, rowGroupSize,
                                        dtype, compression, errMsg): int;
-    extern proc c_appendColumnToParquet(filename, chpl_arr,
+    extern proc c_appendColumnToParquet(filename, arr_chpl,
                                         dsetname, numelems,
                                         dtype, compression,
                                         errMsg): int;
@@ -562,10 +562,10 @@ module ParquetMsg {
   }
 
   private proc writeStringsComponentToParquet(filename, dsetname, ref values: [] uint(8), ref offsets: [] int, rowGroupSize, compression, mode, filesExist) throws {
-    extern proc c_writeStrColumnToParquet(filename, chpl_arr, chpl_offsets,
+    extern proc c_writeStrColumnToParquet(filename, arr_chpl, offsets_chpl,
                                           dsetname, numelems, rowGroupSize,
                                           dtype, compression, errMsg): int;
-    extern proc c_appendColumnToParquet(filename, chpl_arr,
+    extern proc c_appendColumnToParquet(filename, arr_chpl,
                                         dsetname, numelems,
                                         dtype, compression,
                                         errMsg): int;
@@ -1024,7 +1024,7 @@ module ParquetMsg {
 
   proc writeSegArrayComponent(filename: string, dsetname: string, const ref distVals: [] ?t, valIdxRange, segments, locDom, 
                               extraOffset, lastOffset, lastValId, c_dtype, compression) throws {
-    extern proc c_writeListColumnToParquet(filename, chpl_arr, chpl_offsets,
+    extern proc c_writeListColumnToParquet(filename, arr_chpl, offsets_chpl,
                                           dsetname, numelems, rowGroupSize,
                                           dtype, compression, errMsg): int;
     var localVals: [valIdxRange] t = distVals[valIdxRange];
@@ -1095,7 +1095,7 @@ module ParquetMsg {
   }
 
   proc writeStrSegArrayParquet(filename: string, dsetName: string, segments_entry, values_entry, compression: int): bool throws {
-    extern proc c_writeStrListColumnToParquet(filename, chpl_segs, chpl_offsets, chpl_arr,
+    extern proc c_writeStrListColumnToParquet(filename, segs_chpl, offsets_chpl, arr_chpl,
                                           dsetname, numelems, rowGroupSize,
                                           dtype, compression, errMsg): int;
     // get the array of segments

--- a/src/SegmentedComputation.chpl
+++ b/src/SegmentedComputation.chpl
@@ -75,7 +75,7 @@ module SegmentedComputation {
         try {
           // Apply function to bytes of each owned segment, aggregating return value to res
           if function == SegFunction.StringSearch {
-            forall (start, len, i) in zip(mySegs, myLens, mySegInds) with (var agg = newDstAggregator(retType), var myRegex = _unsafeCompileRegex(strArg)) {
+            forall (start, len, i) in zip(mySegs, myLens, mySegInds) with (var agg = newDstAggregator(retType), var myRegex = unsafeCompileRegex(strArg)) {
               agg.copy(res[i], stringSearch(values, start..#len, myRegex));
             }
           } else {

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -57,9 +57,9 @@ module SegmentedMsg {
       var entry = getSegString(msgArgs.getValueOf("obj"), st);
       const comp = msgArgs.getValueOf("comp");
       if comp == "offsets" {
-          return _tondarrayMsg(entry.offsets);
+          return tondarrayMsg(entry.offsets);
       } else if (comp == "values") {
-          return _tondarrayMsg(entry.values);
+          return tondarrayMsg(entry.values);
       } else {
           var msg = "Unrecognized component: %s".doFormat(comp);
           smLogger.error(getModuleName(),getRoutineName(),getLineNumber(), msg);
@@ -71,7 +71,7 @@ module SegmentedMsg {
      * Outputs the pdarray as a Numpy ndarray in the form of a 
      * Chapel Bytes object
      */
-    proc _tondarrayMsg(entry): bytes throws {
+    proc tondarrayMsg(entry): bytes throws {
         var arrayBytes: bytes;
 
         proc distArrToBytes(A: [?D] ?eltType) {

--- a/src/SegmentedString.chpl
+++ b/src/SegmentedString.chpl
@@ -558,7 +558,7 @@ module SegmentedString {
       var searchBools = makeDistArray(this.offsets.a.domain, false);
       var matchBools = makeDistArray(this.offsets.a.domain, false);
       var fullMatchBools = makeDistArray(this.offsets.a.domain, false);
-      forall (i, off, len) in zip(this.offsets.a.domain, origOffsets, lengths) with (var myRegex = _unsafeCompileRegex(pattern),
+      forall (i, off, len) in zip(this.offsets.a.domain, origOffsets, lengths) with (var myRegex = unsafeCompileRegex(pattern),
                                                                                var lenAgg = newDstAggregator(int),
                                                                                var startPosAgg = newDstAggregator(int),
                                                                                var startBoolAgg = newDstAggregator(bool),
@@ -708,7 +708,7 @@ module SegmentedString {
       // count = 0 means substitute all occurances, so we set count equal to 10**9
       var count = if initCount == 0 then 10**9:int else initCount;
       // since the pattern matches are variable length, we don't know what the size of subbedVals should be until we've found the matches
-      forall (i, off, len) in zip(this.offsets.a.domain, origOffsets, lengths) with (var myRegex = _unsafeCompileRegex(pattern),
+      forall (i, off, len) in zip(this.offsets.a.domain, origOffsets, lengths) with (var myRegex = unsafeCompileRegex(pattern),
                                                                                var numReplAgg = newDstAggregator(int),
                                                                                var LenAgg = newDstAggregator(int),
                                                                                var nonMatchAgg = newDstAggregator(bool),
@@ -903,7 +903,7 @@ module SegmentedString {
       var leftEnd = makeDistArray(offsets.a.domain, int);
       var rightStart = makeDistArray(offsets.a.domain, int);
 
-      forall (o, len, i) in zip(oa, lengths, offsets.a.domain) with (var myRegex = _unsafeCompileRegex(delimiter)) {
+      forall (o, len, i) in zip(oa, lengths, offsets.a.domain) with (var myRegex = unsafeCompileRegex(delimiter)) {
         var matches = myRegex.matches(interpretAsString(va, o..#len, borrow=true));
         if matches.size < times {
           // not enough occurances of delim, the entire string stays together, and the param args
@@ -1400,7 +1400,7 @@ module SegmentedString {
     }
   }
 
-  proc _unsafeCompileRegex(const pattern: ?t) where t == bytes || t == string {
+  proc unsafeCompileRegex(const pattern: ?t) where t == bytes || t == string {
     // This is a private function and should not be called to compile pattern. Use checkCompile instead
 
     // This proc is a workaound to allow declaring regexps using a with clause in forall loops

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -294,7 +294,7 @@ module ServerConfig
         // to use memoryUsed() procedure from Chapel's Memory module
         proc checkStaticMemoryLimit(total: real) {
             if total > getMemLimit() {
-                var pct = Math.round((total:real / getMemLimit():real * 100):uint);
+                var pct = round((total:real / getMemLimit():real * 100):uint);
                 var msg = "cmd requiring %i bytes of memory exceeds %i limit with projected pct memory used of %i%%".doFormat(
                                    total * numLocales, getMemLimit() * numLocales, pct);
                 scLogger.error(getModuleName(),getRoutineName(),getLineNumber(), msg);  
@@ -317,7 +317,7 @@ module ServerConfig
                     "memory high watermark = %i memory limit = %i projected pct memory used of %i%%".doFormat(
                            memHighWater:uint * numLocales:uint, 
                            getMemLimit():uint * numLocales:uint,
-                           Math.round((memHighWater:real * numLocales / 
+                           round((memHighWater:real * numLocales / 
                                          (getMemLimit():real * numLocales)) * 100):uint));
                 }
             }
@@ -335,7 +335,7 @@ module ServerConfig
              */
             if memMgmtType == MemMgmtType.STATIC {
                 if total > getMemLimit() {
-                    var pct = Math.round((total:real / getMemLimit():real * 100):uint);
+                    var pct = round((total:real / getMemLimit():real * 100):uint);
                     var msg = "cmd requiring %i bytes of memory exceeds %i limit with projected pct memory used of %i%%".doFormat(
                                    total * numLocales, getMemLimit() * numLocales, pct);
                     scLogger.error(getModuleName(),getRoutineName(),getLineNumber(), msg);  

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -17,6 +17,7 @@ module ServerConfig
     use Math;
 
     use ArkoudaFileCompat;
+    use ArkoudaMathCompat;
     private use ArkoudaCTypesCompat;
     
     enum Deployment {STANDARD,KUBERNETES}
@@ -294,7 +295,7 @@ module ServerConfig
         // to use memoryUsed() procedure from Chapel's Memory module
         proc checkStaticMemoryLimit(total: real) {
             if total > getMemLimit() {
-                var pct = round((total:real / getMemLimit():real * 100):uint);
+                var pct = mathRound((total:real / getMemLimit():real * 100):uint);
                 var msg = "cmd requiring %i bytes of memory exceeds %i limit with projected pct memory used of %i%%".doFormat(
                                    total * numLocales, getMemLimit() * numLocales, pct);
                 scLogger.error(getModuleName(),getRoutineName(),getLineNumber(), msg);  
@@ -317,7 +318,7 @@ module ServerConfig
                     "memory high watermark = %i memory limit = %i projected pct memory used of %i%%".doFormat(
                            memHighWater:uint * numLocales:uint, 
                            getMemLimit():uint * numLocales:uint,
-                           round((memHighWater:real * numLocales / 
+                           mathRound((memHighWater:real * numLocales / 
                                          (getMemLimit():real * numLocales)) * 100):uint));
                 }
             }
@@ -335,7 +336,7 @@ module ServerConfig
              */
             if memMgmtType == MemMgmtType.STATIC {
                 if total > getMemLimit() {
-                    var pct = round((total:real / getMemLimit():real * 100):uint);
+                    var pct = mathRound((total:real / getMemLimit():real * 100):uint);
                     var msg = "cmd requiring %i bytes of memory exceeds %i limit with projected pct memory used of %i%%".doFormat(
                                    total * numLocales, getMemLimit() * numLocales, pct);
                     scLogger.error(getModuleName(),getRoutineName(),getLineNumber(), msg);  

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -14,6 +14,7 @@ module ServerConfig
     use Logging;
     use MemoryMgmt;
     use CTypes;
+    use Math;
 
     use ArkoudaFileCompat;
     private use ArkoudaCTypesCompat;
@@ -293,7 +294,7 @@ module ServerConfig
         // to use memoryUsed() procedure from Chapel's Memory module
         proc checkStaticMemoryLimit(total: real) {
             if total > getMemLimit() {
-                var pct = AutoMath.round((total:real / getMemLimit():real * 100):uint);
+                var pct = Math.round((total:real / getMemLimit():real * 100):uint);
                 var msg = "cmd requiring %i bytes of memory exceeds %i limit with projected pct memory used of %i%%".doFormat(
                                    total * numLocales, getMemLimit() * numLocales, pct);
                 scLogger.error(getModuleName(),getRoutineName(),getLineNumber(), msg);  
@@ -316,7 +317,7 @@ module ServerConfig
                     "memory high watermark = %i memory limit = %i projected pct memory used of %i%%".doFormat(
                            memHighWater:uint * numLocales:uint, 
                            getMemLimit():uint * numLocales:uint,
-                           AutoMath.round((memHighWater:real * numLocales / 
+                           Math.round((memHighWater:real * numLocales / 
                                          (getMemLimit():real * numLocales)) * 100):uint));
                 }
             }
@@ -334,7 +335,7 @@ module ServerConfig
              */
             if memMgmtType == MemMgmtType.STATIC {
                 if total > getMemLimit() {
-                    var pct = AutoMath.round((total:real / getMemLimit():real * 100):uint);
+                    var pct = Math.round((total:real / getMemLimit():real * 100):uint);
                     var msg = "cmd requiring %i bytes of memory exceeds %i limit with projected pct memory used of %i%%".doFormat(
                                    total * numLocales, getMemLimit() * numLocales, pct);
                     scLogger.error(getModuleName(),getRoutineName(),getLineNumber(), msg);  

--- a/src/TransferMsg.chpl
+++ b/src/TransferMsg.chpl
@@ -369,7 +369,7 @@ module TransferMsg
       }
       
       var transferErrors: list(string);
-      var repMsg = _buildReadAllMsgJson(rnames, false, 0, transferErrors, st);
+      var repMsg = buildReadAllMsgJson(rnames, false, 0, transferErrors, st);
       return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 
@@ -690,7 +690,7 @@ module TransferMsg
       }
 
       var transferErrors: list(string);
-      var repMsg = _buildReadAllMsgJson(rnames, false, 0, transferErrors, st);
+      var repMsg = buildReadAllMsgJson(rnames, false, 0, transferErrors, st);
       return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 
@@ -872,13 +872,13 @@ module TransferMsg
       type idxType = int;
       var inds: range(idxType);
       const numelems = hi - lo + 1;
-      const (blo, bhi) = _computeBlock(numelems, numlocs, chpl__tuplify(locid)(0),
+      const (blo, bhi) = computeBlock(numelems, numlocs, chpl__tuplify(locid)(0),
                                        hi, lo, lo);
       inds = blo..bhi;
       return inds;
     }
 
-    proc _computeBlock(numelems, numblocks, blocknum, wayhi,
+    proc computeBlock(numelems, numblocks, blocknum, wayhi,
                        waylo=0:wayhi.type, lo=0:wayhi.type) {
       if numelems == 0 then
         return (1:lo.type, 0:lo.type);

--- a/src/comp.out
+++ b/src/comp.out
@@ -1,0 +1,1 @@
+make: *** No targets specified and no makefile found.  Stop.

--- a/src/comp.out
+++ b/src/comp.out
@@ -1,1 +1,0 @@
-make: *** No targets specified and no makefile found.  Stop.

--- a/src/compat/e-132/ArkoudaMathCompat.chpl
+++ b/src/compat/e-132/ArkoudaMathCompat.chpl
@@ -1,1 +1,4 @@
-module ArkoudaMathCompat {}
+module ArkoudaMathCompat {
+    private import Math;
+    inline proc mathRound(x: real(64)): real(64) do return Math.round(x);
+}

--- a/src/compat/eq-131/ArkoudaMathCompat.chpl
+++ b/src/compat/eq-131/ArkoudaMathCompat.chpl
@@ -4,4 +4,6 @@ module ArkoudaMathCompat {
 
   inline proc isNan(x: real(64)): bool do return isnan(x);
   inline proc isInf(x: real(64)): bool do return isinf(x);
+
+  inline proc mathRound(x) do return AutoMath.round(x);
 }

--- a/src/compat/gt-132/ArkoudaMathCompat.chpl
+++ b/src/compat/gt-132/ArkoudaMathCompat.chpl
@@ -1,1 +1,4 @@
-module ArkoudaMathCompat {}
+module ArkoudaMathCompat {
+    private import Math;
+    inline proc mathRound(x: real(64)): real(64) do return Math.round(x);
+}

--- a/src/serverModuleGen.py
+++ b/src/serverModuleGen.py
@@ -30,7 +30,7 @@ def stampOutNDArrayHandlers(mod, src_dir, stamp_file, max_dims):
             g = m.groups()
 
             base_proc_name = g[2]
-            msg_proc_name = "_nd_gen_" + base_proc_name
+            msg_proc_name = "arkouda_nd_gen_" + base_proc_name
 
             if g[0] == None:
                 # no 'cmd_prefix' argument


### PR DESCRIPTION
Makes some small code adjustments to remove a few common unstable warnings:

* warning: 'localSubdomains' on arrays is unstable and may change in the future
* warning: The module name 'AutoMath' is unstable.  If you want to use qualified naming on the symbols within it, please 'use' or 'import' the Math module
* warning: calling the 'this' method explicitly is unstable and may change in the future
* warning: symbol names with leading underscores ( ) are unstable
* warning: symbol names beginning with 'chpl_' ( ) are unstable