### PR TITLE
Fix CommAggregation build error on 1.32

### DIFF
--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -416,7 +416,7 @@ module CommAggregation {
       var sign_size = chpl_gmp_mpz_struct_sign_size(this.getImpl());
 
       var size_bytes = c_sizeof(mp_size_t):int;
-      var limb_bytes = abs(sign_size:int) * c_sizeof(mp_limb_t):int;
+      var limb_bytes = Math.abs(sign_size:int) * c_sizeof(mp_limb_t):int;
 
       return size_bytes + limb_bytes;
     }
@@ -428,7 +428,7 @@ module CommAggregation {
       var sign_size = chpl_gmp_mpz_struct_sign_size(this.getImpl());
 
       var size_bytes = c_sizeof(mp_size_t):int;
-      var limb_bytes = abs(sign_size:int) * c_sizeof(mp_limb_t):int;
+      var limb_bytes = Math.abs(sign_size:int) * c_sizeof(mp_limb_t):int;
 
       var limb_ptr = chpl_gmp_mpz_struct_limbs(this.getImpl());
 
@@ -447,7 +447,7 @@ module CommAggregation {
 
       memcpy(c_ptrTo(sign_size), x, size_bytes);
 
-      var nlimbs = abs(sign_size:int);
+      var nlimbs = Math.abs(sign_size:int);
       var limb_bytes = nlimbs * c_sizeof(mp_limb_t):int;
 
       _mpz_realloc(this.mpz, nlimbs);

--- a/src/CommAggregation.chpl
+++ b/src/CommAggregation.chpl
@@ -408,6 +408,7 @@ module CommAggregation {
     use BigInteger, GMP;
     use ArkoudaPOSIXCompat;
     use ArkoudaAggCompat;
+    use ArkoudaMathCompat;
     use Math;
 
     proc bigint.serializedSize() {
@@ -416,7 +417,7 @@ module CommAggregation {
       var sign_size = chpl_gmp_mpz_struct_sign_size(this.getImpl());
 
       var size_bytes = c_sizeof(mp_size_t):int;
-      var limb_bytes = Math.abs(sign_size:int) * c_sizeof(mp_limb_t):int;
+      var limb_bytes = mathAbs(sign_size:int) * c_sizeof(mp_limb_t):int;
 
       return size_bytes + limb_bytes;
     }
@@ -428,7 +429,7 @@ module CommAggregation {
       var sign_size = chpl_gmp_mpz_struct_sign_size(this.getImpl());
 
       var size_bytes = c_sizeof(mp_size_t):int;
-      var limb_bytes = Math.abs(sign_size:int) * c_sizeof(mp_limb_t):int;
+      var limb_bytes = mathAbs(sign_size:int) * c_sizeof(mp_limb_t):int;
 
       var limb_ptr = chpl_gmp_mpz_struct_limbs(this.getImpl());
 
@@ -447,7 +448,7 @@ module CommAggregation {
 
       memcpy(c_ptrTo(sign_size), x, size_bytes);
 
-      var nlimbs = Math.abs(sign_size:int);
+      var nlimbs = mathAbs(sign_size:int);
       var limb_bytes = nlimbs * c_sizeof(mp_limb_t):int;
 
       _mpz_realloc(this.mpz, nlimbs);

--- a/src/compat/e-132/ArkoudaMathCompat.chpl
+++ b/src/compat/e-132/ArkoudaMathCompat.chpl
@@ -1,4 +1,5 @@
 module ArkoudaMathCompat {
     private import Math;
     inline proc mathRound(x: real(64)): real(64) do return Math.round(x);
+    inline proc mathAbs(x) do return Math.abs(x);
 }

--- a/src/compat/eq-131/ArkoudaMathCompat.chpl
+++ b/src/compat/eq-131/ArkoudaMathCompat.chpl
@@ -7,4 +7,5 @@ module ArkoudaMathCompat {
   inline proc isFinite(x: real(64)): bool do return isfinite(x);
 
   inline proc mathRound(x) do return AutoMath.round(x);
+  inline proc mathAbs(x) do return abs(x);
 }

--- a/src/compat/gt-132/ArkoudaMathCompat.chpl
+++ b/src/compat/gt-132/ArkoudaMathCompat.chpl
@@ -1,4 +1,5 @@
 module ArkoudaMathCompat {
     private import Math;
     inline proc mathRound(x: real(64)): real(64) do return Math.round(x);
+    inline proc mathAbs(x) do return Math.abs(x);
 }


### PR DESCRIPTION
Add `Math.abs` to math compatibility modules to fix compilation error.

Chpl 1.31 includes `abs` in the AutoMath module, but 1.32 does not. This PR adds a `mathAbs` proc to the math compatibility modules to avoid compilation errors in CommAggregation.