### PR TITLE
Closes #2901: Fix performance regression due to setting ndim field in sym entry

### DIFF
--- a/src/compat/gt-132/ArkoudaSymEntryCompat.chpl
+++ b/src/compat/gt-132/ArkoudaSymEntryCompat.chpl
@@ -67,7 +67,8 @@ module ArkoudaSymEntryCompat {
     this.a = try! makeDistArray((...args), etype);
     init this;
     this.shape = tupShapeString(this.tupShape);
-    this.ndim = N;
+    // commented out for perf reasons, needs further investigation
+    // this.ndim = N;
   }
 
   /*
@@ -88,6 +89,7 @@ module ArkoudaSymEntryCompat {
     this.max_bits=max_bits;
     init this;
     this.shape = tupShapeString(this.tupShape);
-    this.ndim = D.rank;
+    // commented out for perf reasons, needs further investigation
+    // this.ndim = D.rank;
   }
 }


### PR DESCRIPTION
In #2865, the `ndim` field was being set after `init this`, which was resulting in a performance hit for multi locale runs. Commenting that line out for now to restore the performance, since it is only used in currently experimental features.

Scan benchmark on 2 locales of an XC:
| before      | this PR     |
| ----------- | ----------- |
| 42.86 GiB/s | 68.50 GiB/s |

Closes #2901