### PR TITLE
Replace use of binary 'or' with logical 'or'

### DIFF
--- a/src/Histogram.chpl
+++ b/src/Histogram.chpl
@@ -46,7 +46,7 @@ module Histogram
         forall v in a {
             var vBin = ((v - aMin) / binWidth):int;
             if v == aMax {vBin = bins-1;}
-            if (vBin < 0) | (vBin > (bins-1)) {
+            if (vBin < 0) || (vBin > (bins-1)) {
                 try! hgLogger.error(getModuleName(),getRoutineName(),getLineNumber(),"OOB");
             }
             atomicHist[vBin].add(1);
@@ -72,7 +72,7 @@ module Histogram
             var yiBin = ((yi - yMin) / yBinWidth):int;
             if xi == xMax {xiBin = numXBins-1;}
             if yi == yMax {yiBin = numYBins-1;}
-            if xiBin < 0 | yiBin < 0 | (xiBin > (numXBins-1)) | (yiBin > (numYBins-1)) {
+            if xiBin < 0 || yiBin < 0 || (xiBin > (numXBins-1)) || (yiBin > (numYBins-1)) {
                 try! hgLogger.error(getModuleName(),getRoutineName(),getLineNumber(),"OOB");
             }
             atomicHist[(xiBin * numYBins) + yiBin].add(1);


### PR DESCRIPTION
A recent Chapel PR (https://github.com/chapel-lang/chapel/pull/24155) disallowed the use of expressions like `a < b < c` because of its confusing meaning. Specifically, `a < b < c` is __not__ equivalent to `a < b && b < c`. Instead, the above expression is equivalent to `(a < b) < c`, which is likely not what the author intended. On `main`, Chapel requires explicit parentheses: `(a < b) < c` or `a < (b < c)`.

This led to us uncovering some bugs that have to do with the use of binary OR `|` instead of the logical or `||`. Notably, the the precedence for these operators is as follows: `|` > `>` > `||`. Thus, `a < b | c` parses as `a < (b | c)`, whereas `a < b || c` parses as `(a < b) || c`. This is significant in conditionals, such as those affected by the PR:

```Chapel
if xiBin < 0 | yiBin < 0 | (xiBin > (numXBins-1)) | (yiBin > (numYBins-1)) { /* ... */ }
//         ^^^^^^^^^ probably not what you want!
//                   Equivalent to:
if xiBin < (0 | yiBin) < (0 | (xiBin > (numXBins-1)) | (yiBin > (numYBins-1))) { /* ... */ }
```

As you can see, this was previously being interpreted as the ternary `.. < .. < ..` expression. This is both likely incorrect logically (I doubt the intention is to compare `xiBin` against `yiBin` or'ed with zero) and, on the `main` branch of the Chapel compiler, incorrect syntactically. 

This PR fixes the syntax error caused by this issue, and updates the uses of the bitiwse `|` operator to be uses of the logical `||`. 

