### PR TITLE
Closes #2905 add strings isalnum

### DIFF
--- a/PROTO_tests/tests/string_test.py
+++ b/PROTO_tests/tests/string_test.py
@@ -494,6 +494,12 @@ class TestString:
         expected = ak.arange(40) >= 30
         assert istitle.to_list() == expected.to_list()
 
+    def test_string_isalnum(self):
+        not_alnum = ak.array([f"%Strings {i}" for i in range(3)])
+        alnum = ak.array([f"Strings{i}" for i in range(3)])
+        test_strings = ak.concatenate([not_alnum, alnum])
+        assert test_strings.isalnum().to_list() == [False, False, False, True, True, True]
+
     def test_where(self):
         revs = ak.arange(10) % 2 == 0
         s1 = ak.array([f"str {i}" for i in range(10)])

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -699,6 +699,44 @@ class Strings:
         )
 
     @typechecked
+    def isalnum(self) -> pdarray:
+        """
+        Returns a boolean pdarray where index i indicates whether string i of the
+        Strings is alphanumeric.
+
+        Returns
+        -------
+        pdarray, bool
+            True for elements that are alphanumeric, False otherwise
+
+        Raises
+        ------
+        RuntimeError
+            Raised if there is a server-side error thrown
+
+        See Also
+        --------
+        Strings.is_lower
+        Strings.is_upper
+        Strings.is_title
+
+        Examples
+        --------
+        >>> not_alnum = ak.array([f'%Strings {i}' for i in range(3)])
+        >>> alnum = ak.array([f'Strings{i}' for i in range(3)])
+        >>> strings = ak.concatenate([not_alnum, alnum])
+        >>> strings
+        array(['%Strings 0', '%Strings 1', '%Strings 2', 'Strings0', 'Strings1', 'Strings2'])
+        >>> strings.isalnum()
+        array([False False False True True True])
+        """
+        return create_pdarray(
+            generic_msg(
+                cmd="checkChars", args={"subcmd": "isalnum", "objType": self.objType, "obj": self.entry}
+            )
+        )
+
+    @typechecked
     def strip(self, chars: Optional[Union[bytes, str_scalars]] = "") -> Strings:
         """
         Returns a new Strings object with all leading and trailing occurrences of characters contained

--- a/src/SegmentedComputation.chpl
+++ b/src/SegmentedComputation.chpl
@@ -48,6 +48,7 @@ module SegmentedComputation {
     StringIsLower,
     StringIsUpper,
     StringIsTitle,
+    StringIsAlphaNumeric,
   }
   
   proc computeOnSegments(segments: [?D] int, ref values: [?vD] ?t, param function: SegFunction, type retType, const strArg: string = "") throws {
@@ -107,6 +108,9 @@ module SegmentedComputation {
                 }
                 when SegFunction.StringIsTitle {
                   agg.copy(res[i], stringIsTitle(values, start..#len));
+                }
+                when SegFunction.StringIsAlphaNumeric {
+                  agg.copy(res[i], stringIsAlphaNumeric(values, start..#len));
                 }
                 otherwise {
                   compilerError("Unrecognized segmented function");

--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -285,6 +285,10 @@ module SegmentedMsg {
             truth.a = strings.isTitle();
             repMsg = "created "+st.attrib(rname);
           }
+          when "isalnum" {
+            truth.a = strings.isalnum();
+            repMsg = "created "+st.attrib(rname);
+          }
           otherwise {
             var errorMsg = notImplementedError(pn, "%s".doFormat(subcmd));
             smLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);

--- a/src/SegmentedString.chpl
+++ b/src/SegmentedString.chpl
@@ -493,6 +493,14 @@ module SegmentedString {
       return computeOnSegments(offsets.a, values.a, SegFunction.StringIsTitle, bool);
     }
 
+    /*
+      Returns list of bools where index i indicates whether the string i of the SegString is alphanumeric
+      :returns: [domain] bool where index i indicates whether the string i of the SegString is alphanumeric
+    */
+    proc isalnum() throws {
+      return computeOnSegments(offsets.a, values.a, SegFunction.StringIsAlphaNumeric, bool);
+    }
+
     proc bytesToUintArr(const max_bytes:int, lens: [?D] ?t, st) throws {
       // bytes contained in strings < 128 bits, so concatenating is better than the hash
       ref off = offsets.a;
@@ -1432,6 +1440,13 @@ module SegmentedString {
   */
   inline proc stringIsTitle(ref values, rng) throws {
     return interpretAsString(values, rng, borrow=true).isTitle();
+  }
+
+  /*
+    The SegFunction called by computeOnSegments for isalnum
+  */
+  inline proc stringIsAlphaNumeric(ref values, rng) throws {
+    return interpretAsString(values, rng, borrow=true).isAlnum();
   }
 
   inline proc stringBytesToUintArr(ref values, rng) throws {

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -580,6 +580,12 @@ class StringTest(ArkoudaTest):
         expected = ak.arange(40) >= 30
         self.assertListEqual(istitle.to_list(), expected.to_list())
 
+    def test_string_isalnum(self):
+        not_alnum = ak.array([f"%Strings {i}" for i in range(3)])
+        alnum = ak.array([f"Strings{i}" for i in range(3)])
+        test_strings = ak.concatenate([not_alnum, alnum])
+        self.assertListEqual(test_strings.isalnum().to_list(), [False, False, False, True, True, True])
+
     def test_where(self):
         revs = ak.arange(10) % 2 == 0
         s1 = ak.array([f"str {i}" for i in range(10)])


### PR DESCRIPTION
This ticket adds the Strings.isalnum() function to align with the numpy functionality:
https://numpy.org/doc/stable/reference/generated/numpy.char.isalnum.html