### PR TITLE
Closes ticket #2909 rename is_upper and similar ops to match numpy

### DIFF
--- a/PROTO_tests/tests/pdarray_creation_test.py
+++ b/PROTO_tests/tests/pdarray_creation_test.py
@@ -493,7 +493,7 @@ class TestPdarrayCreation:
         assert str == pda.dtype
 
         assert ((1 <= pda.get_lengths()) & (pda.get_lengths() <= 5)).all()
-        assert (pda.is_upper()).all()
+        assert (pda.isupper()).all()
 
     def test_random_strings_uniform_errors(self):
         with pytest.raises(ValueError):

--- a/PROTO_tests/tests/string_test.py
+++ b/PROTO_tests/tests/string_test.py
@@ -469,28 +469,28 @@ class TestString:
     def test_case_change(self):
         mixed = ak.array([f"StrINgS {i}" for i in range(10)])
 
-        lower = mixed.to_lower()
+        lower = mixed.lower()
         assert lower.to_list() == [f"strings {i}" for i in range(10)]
 
-        upper = mixed.to_upper()
+        upper = mixed.upper()
         assert upper.to_list() == [f"STRINGS {i}" for i in range(10)]
 
-        title = mixed.to_title()
+        title = mixed.title()
         assert title.to_list() == [f"Strings {i}" for i in range(10)]
 
         # first 10 all lower, second 10 mixed case (not lower, upper, or title), third 10 all upper,
         # last 10 all title
         lmut = ak.concatenate([lower, mixed, upper, title])
 
-        islower = lmut.is_lower()
+        islower = lmut.islower()
         expected = 10 > ak.arange(40)
         assert islower.to_list() == expected.to_list()
 
-        isupper = lmut.is_upper()
+        isupper = lmut.isupper()
         expected = (30 > ak.arange(40)) & (ak.arange(40) >= 20)
         assert isupper.to_list() == expected.to_list()
 
-        istitle = lmut.is_title()
+        istitle = lmut.istitle()
         expected = ak.arange(40) >= 30
         assert istitle.to_list() == expected.to_list()
 

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -489,7 +489,7 @@ class Strings:
         return self.encode(toEncoding, fromEncoding)
 
     @typechecked
-    def to_lower(self) -> Strings:
+    def lower(self) -> Strings:
         """
         Returns a new Strings with all uppercase characters from the original replaced with
         their lowercase equivalent
@@ -507,14 +507,14 @@ class Strings:
 
         See Also
         --------
-        Strings.to_upper
+        Strings.upper
 
         Examples
         --------
         >>> strings = ak.array([f'StrINgS {i}' for i in range(5)])
         >>> strings
         array(['StrINgS 0', 'StrINgS 1', 'StrINgS 2', 'StrINgS 3', 'StrINgS 4'])
-        >>> strings.to_lower()
+        >>> strings.lower()
         array(['strings 0', 'strings 1', 'strings 2', 'strings 3', 'strings 4'])
         """
         rep_msg = generic_msg(
@@ -523,7 +523,7 @@ class Strings:
         return Strings.from_return_msg(cast(str, rep_msg))
 
     @typechecked
-    def to_upper(self) -> Strings:
+    def upper(self) -> Strings:
         """
         Returns a new Strings with all lowercase characters from the original replaced with
         their uppercase equivalent
@@ -541,14 +541,14 @@ class Strings:
 
         See Also
         --------
-        Strings.to_lower
+        Strings.lower
 
         Examples
         --------
         >>> strings = ak.array([f'StrINgS {i}' for i in range(5)])
         >>> strings
         array(['StrINgS 0', 'StrINgS 1', 'StrINgS 2', 'StrINgS 3', 'StrINgS 4'])
-        >>> strings.to_upper()
+        >>> strings.upper()
         array(['STRINGS 0', 'STRINGS 1', 'STRINGS 2', 'STRINGS 3', 'STRINGS 4'])
         """
         rep_msg = generic_msg(
@@ -557,7 +557,7 @@ class Strings:
         return Strings.from_return_msg(cast(str, rep_msg))
 
     @typechecked
-    def to_title(self) -> Strings:
+    def title(self) -> Strings:
         """
         Returns a new Strings from the original replaced with their titlecase equivalent
 
@@ -573,15 +573,15 @@ class Strings:
 
         See Also
         --------
-        Strings.to_lower
-        String.to_upper
+        Strings.lower
+        String.upper
 
         Examples
         --------
         >>> strings = ak.array([f'StrINgS {i}' for i in range(5)])
         >>> strings
         array(['StrINgS 0', 'StrINgS 1', 'StrINgS 2', 'StrINgS 3', 'StrINgS 4'])
-        >>> strings.to_title()
+        >>> strings.title()
         array(['Strings 0', 'Strings 1', 'Strings 2', 'Strings 3', 'Strings 4'])
         """
         rep_msg = generic_msg(
@@ -590,7 +590,7 @@ class Strings:
         return Strings.from_return_msg(cast(str, rep_msg))
 
     @typechecked
-    def is_lower(self) -> pdarray:
+    def islower(self) -> pdarray:
         """
         Returns a boolean pdarray where index i indicates whether string i of the
         Strings is entirely lowercase
@@ -607,7 +607,7 @@ class Strings:
 
         See Also
         --------
-        Strings.is_upper
+        Strings.isupper
 
         Examples
         --------
@@ -616,7 +616,7 @@ class Strings:
         >>> strings = ak.concatenate([lower, upper])
         >>> strings
         array(['strings 0', 'strings 1', 'strings 2', 'STRINGS 0', 'STRINGS 1', 'STRINGS 2'])
-        >>> strings.is_lower()
+        >>> strings.islower()
         array([True True True False False False])
         """
         return create_pdarray(
@@ -626,7 +626,7 @@ class Strings:
         )
 
     @typechecked
-    def is_upper(self) -> pdarray:
+    def isupper(self) -> pdarray:
         """
         Returns a boolean pdarray where index i indicates whether string i of the
         Strings is entirely uppercase
@@ -643,7 +643,7 @@ class Strings:
 
         See Also
         --------
-        Strings.is_lower
+        Strings.islower
 
         Examples
         --------
@@ -652,7 +652,7 @@ class Strings:
         >>> strings = ak.concatenate([lower, upper])
         >>> strings
         array(['strings 0', 'strings 1', 'strings 2', 'STRINGS 0', 'STRINGS 1', 'STRINGS 2'])
-        >>> strings.is_upper()
+        >>> strings.isupper()
         array([False False False True True True])
         """
         return create_pdarray(
@@ -662,7 +662,7 @@ class Strings:
         )
 
     @typechecked
-    def is_title(self) -> pdarray:
+    def istitle(self) -> pdarray:
         """
         Returns a boolean pdarray where index i indicates whether string i of the
         Strings is titlecase
@@ -679,8 +679,8 @@ class Strings:
 
         See Also
         --------
-        Strings.is_lower
-        Strings.is_upper
+        Strings.islower
+        Strings.isupper
 
         Examples
         --------
@@ -689,7 +689,7 @@ class Strings:
         >>> strings = ak.concatenate([mixed, title])
         >>> strings
         array(['sTrINgs 0', 'sTrINgs 1', 'sTrINgs 2', 'Strings 0', 'Strings 1', 'Strings 2'])
-        >>> strings.is_title()
+        >>> strings.istitle()
         array([False False False True True True])
         """
         return create_pdarray(

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -555,28 +555,28 @@ class StringTest(ArkoudaTest):
     def test_case_change(self):
         mixed = ak.array([f"StrINgS {i}" for i in range(10)])
 
-        lower = mixed.to_lower()
+        lower = mixed.lower()
         self.assertListEqual(lower.to_list(), [f"strings {i}" for i in range(10)])
 
-        upper = mixed.to_upper()
+        upper = mixed.upper()
         self.assertListEqual(upper.to_list(), [f"STRINGS {i}" for i in range(10)])
 
-        title = mixed.to_title()
+        title = mixed.title()
         self.assertListEqual(title.to_list(), [f"Strings {i}" for i in range(10)])
 
         # first 10 all lower, second 10 mixed case (not lower, upper, or title), third 10 all upper,
         # last 10 all title
         lmut = ak.concatenate([lower, mixed, upper, title])
 
-        islower = lmut.is_lower()
+        islower = lmut.islower()
         expected = 10 > ak.arange(40)
         self.assertListEqual(islower.to_list(), expected.to_list())
 
-        isupper = lmut.is_upper()
+        isupper = lmut.isupper()
         expected = (30 > ak.arange(40)) & (ak.arange(40) >= 20)
         self.assertListEqual(isupper.to_list(), expected.to_list())
 
-        istitle = lmut.is_title()
+        istitle = lmut.istitle()
         expected = ak.arange(40) >= 30
         self.assertListEqual(istitle.to_list(), expected.to_list())
 


### PR DESCRIPTION
This ticket (closes #2909) changes the following arkouda.strings.String function names to better align with numpy:
to_lower -> lower
to_upper -> upper
to_title -> title
is_lower -> islower
is_upper -> isupper
is_title -> istitile