### PR TITLE
Closes #2922: Pin `pandas<2.2.0` to avoid CI failures

### DIFF
--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python>=3.8   # minimum 3.8
   - numpy>=1.24.1
-  - pandas>=1.4.0
+  - pandas>=1.4.0,<2.2.0
   - pyzmq>=20.0.0
   - tabulate
   - pyfiglet

--- a/arkouda-env.yml
+++ b/arkouda-env.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python>=3.8   # minimum 3.8
   - numpy>=1.24.1
-  - pandas>=1.4.0
+  - pandas>=1.4.0,<2.2.0
   - pyzmq>=20.0.0
   - tabulate
   - pyfiglet

--- a/pydoc/requirements.txt
+++ b/pydoc/requirements.txt
@@ -1,7 +1,7 @@
 # dependencies
 python>=3.8
 numpy>=1.24.1
-pandas>=1.4.0
+pandas>=1.4.0,<2.2.0
 pyzmq>=20.0.0
 typeguard==2.10.0
 tabulate

--- a/pydoc/setup/REQUIREMENTS.md
+++ b/pydoc/setup/REQUIREMENTS.md
@@ -19,7 +19,7 @@ The following python packages are required by the Arkouda client package.
 
 - `python>=3.8`
 - `numpy>=1.24.1`
-- `pandas>=1.4.0`
+- `pandas>=1.4.0,<2.2.0`
 - `pyzmq>=20.0.0`
 - `typeguard==2.10.0`
 - `tabulate`

--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
         'numpy>=1.24.1',
-        'pandas>=1.4.0',
+        'pandas>=1.4.0,<2.2.0',
         'pyzmq>=20.0.0',
         'typeguard==2.10.0',
         'tabulate',


### PR DESCRIPTION
We were seeing [CI failures](https://github.com/Bears-R-Us/arkouda/actions/runs/7612943973/) on `groupby.argmin`. Rerunning the last commit to master causes the [same failures ](https://github.com/Bears-R-Us/arkouda/actions/runs/7588960978/)

I believe this is due to pandas `v2.2.0` which was released [this past friday](https://pandas.pydata.org/docs/dev/whatsnew/v2.2.0.html). This PR (closes #2922) pins pandas to `<2.2.0` to get the CI working again until we can dig in a bit more to find the root cause

NOTE: any existing PRs will need to rebase / merge with master once this PR is merged in order to get through the CI