### PR TITLE
Apply black formatter to array_api frontend code

### DIFF
--- a/arkouda/array_api/__init__.py
+++ b/arkouda/array_api/__init__.py
@@ -259,7 +259,7 @@ __all__ += [
     "reshape",
     "roll",
     "squeeze",
-    "stack"
+    "stack",
 ]
 
 __all__ += ["argmax", "argmin", "nonzero", "where"]
@@ -272,6 +272,4 @@ __all__ += ["max", "mean", "min", "prod", "std", "sum", "var"]
 
 __all__ += ["all", "any"]
 
-warnings.warn(
-    "The arkouda.array_api submodule is still experimental."
-)
+warnings.warn("The arkouda.array_api submodule is still experimental.")

--- a/arkouda/array_api/_array_object.py
+++ b/arkouda/array_api/_array_object.py
@@ -55,6 +55,7 @@ class Array:
     functions, such as asarray().
 
     """
+
     _array: ak.pdarray
     _empty: bool
 
@@ -131,8 +132,7 @@ class Array:
     # NumPy behavior
 
     def _check_allowed_dtypes(
-        self, other: bool | int | float | Array,
-        dtype_category: str, op: str
+        self, other: bool | int | float | Array, dtype_category: str, op: str
     ) -> Array:
         """
         Helper function for operators to only allow specific input dtypes
@@ -170,9 +170,7 @@ class Array:
 
             # The spec explicitly disallows this.
             if res_dtype != self.dtype:
-                raise TypeError(
-                    f"Cannot perform {op} with dtypes {self.dtype} and {other.dtype}"
-                )
+                raise TypeError(f"Cannot perform {op} with dtypes {self.dtype} and {other.dtype}")
 
         return other
 
@@ -190,14 +188,10 @@ class Array:
         # allowed.
         if isinstance(scalar, bool):
             if self.dtype not in _boolean_dtypes:
-                raise TypeError(
-                    "Python bool scalars can only be promoted with bool arrays"
-                )
+                raise TypeError("Python bool scalars can only be promoted with bool arrays")
         elif isinstance(scalar, int):
             if self.dtype in _boolean_dtypes:
-                raise TypeError(
-                    "Python int scalars cannot be promoted with bool arrays"
-                )
+                raise TypeError("Python int scalars cannot be promoted with bool arrays")
             if self.dtype in _integer_dtypes:
                 info = np.iinfo(int)
                 if not (info.min <= scalar <= info.max):
@@ -207,9 +201,7 @@ class Array:
             # int + array(floating) is allowed
         elif isinstance(scalar, float):
             if self.dtype not in _floating_dtypes:
-                raise TypeError(
-                    "Python float scalars can only be promoted with floating-point arrays."
-                )
+                raise TypeError("Python float scalars can only be promoted with floating-point arrays.")
         elif isinstance(scalar, complex):
             if self.dtype not in _complex_floating_dtypes:
                 raise TypeError(
@@ -265,9 +257,7 @@ class Array:
     # Note: A large fraction of allowed indices are disallowed here (see the
     # docstring below)
     def _validate_index(self, key):
-        raise IndexError(
-            "not implemented"
-        )
+        raise IndexError("not implemented")
 
     # Everything below this line is required by the spec.
 
@@ -286,9 +276,7 @@ class Array:
     def __and__(self: Array, other: Union[int, bool, Array], /) -> Array:
         return self
 
-    def __array_namespace__(
-        self: Array, /, *, api_version: Optional[str] = None
-    ) -> types.ModuleType:
+    def __array_namespace__(self: Array, /, *, api_version: Optional[str] = None) -> types.ModuleType:
         if api_version is not None:
             raise ValueError(f"Unrecognized array API version: {api_version!r}")
         return array_api
@@ -318,9 +306,7 @@ class Array:
 
     def __getitem__(
         self: Array,
-        key: Union[
-            int, slice, Tuple[Union[int, slice], ...], Array
-        ],
+        key: Union[int, slice, Tuple[Union[int, slice], ...], Array],
         /,
     ) -> Array:
         if isinstance(key, Array):
@@ -382,9 +368,7 @@ class Array:
 
     def __setitem__(
         self,
-        key: Union[
-            int, slice, Tuple[Union[int, slice], ...], Array
-        ],
+        key: Union[int, slice, Tuple[Union[int, slice], ...], Array],
         value: Union[int, float, bool, Array],
         /,
     ) -> None:

--- a/arkouda/array_api/_creation_functions.py
+++ b/arkouda/array_api/_creation_functions.py
@@ -53,8 +53,12 @@ def asarray(
     if device not in ["cpu", None]:
         raise ValueError(f"Unsupported device {device!r}")
 
-    if isinstance(obj, bool) or isinstance(obj, int) or \
-       isinstance(obj, float) or isinstance(obj, complex):
+    if (
+        isinstance(obj, bool)
+        or isinstance(obj, int)
+        or isinstance(obj, float)
+        or isinstance(obj, complex)
+    ):
         if dtype is None:
             xdtype = resolve_scalar_dtype(obj)
         else:
@@ -79,6 +83,7 @@ def arange(
     device: Optional[Device] = None,
 ) -> Array:
     from ._array_object import Array
+
     if device not in ["cpu", None]:
         raise ValueError(f"Unsupported device {device!r}")
 
@@ -95,6 +100,7 @@ def empty(
     device: Optional[Device] = None,
 ) -> Array:
     from ._array_object import Array
+
     if device not in ["cpu", None]:
         raise ValueError(f"Unsupported device {device!r}")
 
@@ -104,27 +110,33 @@ def empty(
         for s in tshape:
             size *= s
         return Array._new(
-            pdarray("__empty__", akdtype(dtype), size, len(tshape), tshape, 0, None),
-            empty=True)
+            pdarray("__empty__", akdtype(dtype), size, len(tshape), tshape, 0, None), empty=True
+        )
     else:
         vshape = cast(int, shape)
         return Array._new(
-            pdarray("__empty__", akdtype(dtype), vshape, 1, (vshape,), 0, None),
-            empty=True)
+            pdarray("__empty__", akdtype(dtype), vshape, 1, (vshape,), 0, None), empty=True
+        )
 
 
-def empty_like(
-    x: Array, /, *, dtype: Optional[Dtype] = None, device: Optional[Device] = None
-) -> Array:
+def empty_like(x: Array, /, *, dtype: Optional[Dtype] = None, device: Optional[Device] = None) -> Array:
     from ._array_object import Array
+
     if device not in ["cpu", None]:
         raise ValueError(f"Unsupported device {device!r}")
 
     t = x.dtype if dtype is None else akdtype(dtype)
 
     return Array._new(
-        pdarray("__empty__", t, x._array.size, x._array.ndim,
-                x._array.shape, x._array.itemsize, x._array.max_bits),
+        pdarray(
+            "__empty__",
+            t,
+            x._array.size,
+            x._array.ndim,
+            x._array.shape,
+            x._array.itemsize,
+            x._array.max_bits,
+        ),
         empty=True,
     )
 
@@ -139,6 +151,7 @@ def eye(
     device: Optional[Device] = None,
 ) -> Array:
     from ._array_object import Array
+
     if device not in ["cpu", None]:
         raise ValueError(f"Unsupported device {device!r}")
 
@@ -246,9 +259,7 @@ def ones(
     return a
 
 
-def ones_like(
-    x: Array, /, *, dtype: Optional[Dtype] = None, device: Optional[Device] = None
-) -> Array:
+def ones_like(x: Array, /, *, dtype: Optional[Dtype] = None, device: Optional[Device] = None) -> Array:
     return ones(x.shape, dtype=dtype, device=device)
 
 
@@ -281,7 +292,9 @@ def triu(x: Array, /, *, k: int = 0) -> Array:
 
 
 def zeros(
-    shape: Union[int, Tuple[int, ...]], /, *,
+    shape: Union[int, Tuple[int, ...]],
+    /,
+    *,
     dtype: Optional[Dtype] = None,
     device: Optional[Device] = None,
 ) -> Array:
@@ -312,7 +325,5 @@ def zeros(
     return Array._new(create_pdarray(repMsg))
 
 
-def zeros_like(
-    x: Array, /, *, dtype: Optional[Dtype] = None, device: Optional[Device] = None
-) -> Array:
+def zeros_like(x: Array, /, *, dtype: Optional[Dtype] = None, device: Optional[Device] = None) -> Array:
     return zeros(x.shape, dtype=dtype, device=device)

--- a/arkouda/array_api/_data_type_functions.py
+++ b/arkouda/array_api/_data_type_functions.py
@@ -108,9 +108,7 @@ class iinfo_object:
 
 
 # Note: isdtype is a new function from the 2022.12 array API specification.
-def isdtype(
-    dtype: Dtype, kind: Union[Dtype, str, Tuple[Union[Dtype, str], ...]]
-) -> bool:
+def isdtype(dtype: Dtype, kind: Union[Dtype, str, Tuple[Union[Dtype, str], ...]]) -> bool:
     """
     Returns a boolean indicating whether a provided dtype is of a specified data type ``kind``.
 
@@ -124,27 +122,29 @@ def isdtype(
             raise TypeError("'kind' must be a dtype, str, or tuple of dtypes and strs")
         return any(isdtype(dtype, k) for k in kind)
     elif isinstance(kind, str):
-        if kind == 'bool':
+        if kind == "bool":
             return dtype in _boolean_dtypes
-        elif kind == 'signed integer':
+        elif kind == "signed integer":
             return dtype in _signed_integer_dtypes
-        elif kind == 'unsigned integer':
+        elif kind == "unsigned integer":
             return dtype in _unsigned_integer_dtypes
-        elif kind == 'integral':
+        elif kind == "integral":
             return dtype in _integer_dtypes
-        elif kind == 'real floating':
+        elif kind == "real floating":
             return dtype in _real_floating_dtypes
-        elif kind == 'complex floating':
+        elif kind == "complex floating":
             return dtype in _complex_floating_dtypes
-        elif kind == 'numeric':
+        elif kind == "numeric":
             return dtype in _numeric_dtypes
         else:
             raise ValueError(f"Unrecognized data type kind: {kind!r}")
     elif kind in _all_dtypes:
         return dtype == kind
     else:
-        raise TypeError(f"'kind' must be a dtype, str, \
-            or tuple of dtypes and strs, not {type(kind).__name__}")
+        raise TypeError(
+            f"'kind' must be a dtype, str, \
+            or tuple of dtypes and strs, not {type(kind).__name__}"
+        )
 
 
 def result_type(*arrays_and_dtypes: Union[Array, Dtype]) -> Dtype:

--- a/arkouda/array_api/_elementwise_functions.py
+++ b/arkouda/array_api/_elementwise_functions.py
@@ -131,10 +131,7 @@ def bitwise_and(x1: Array, x2: Array, /) -> Array:
 
     See its docstring for more information.
     """
-    if (
-        x1.dtype not in _integer_or_boolean_dtypes
-        or x2.dtype not in _integer_or_boolean_dtypes
-    ):
+    if x1.dtype not in _integer_or_boolean_dtypes or x2.dtype not in _integer_or_boolean_dtypes:
         raise TypeError("Only integer or boolean dtypes are allowed in bitwise_and")
     # Call result type here just to raise on disallowed type combinations
     _result_type(x1.dtype, x2.dtype)
@@ -174,10 +171,7 @@ def bitwise_or(x1: Array, x2: Array, /) -> Array:
 
     See its docstring for more information.
     """
-    if (
-        x1.dtype not in _integer_or_boolean_dtypes
-        or x2.dtype not in _integer_or_boolean_dtypes
-    ):
+    if x1.dtype not in _integer_or_boolean_dtypes or x2.dtype not in _integer_or_boolean_dtypes:
         raise TypeError("Only integer or boolean dtypes are allowed in bitwise_or")
     # Call result type here just to raise on disallowed type combinations
     _result_type(x1.dtype, x2.dtype)
@@ -207,10 +201,7 @@ def bitwise_xor(x1: Array, x2: Array, /) -> Array:
 
     See its docstring for more information.
     """
-    if (
-        x1.dtype not in _integer_or_boolean_dtypes
-        or x2.dtype not in _integer_or_boolean_dtypes
-    ):
+    if x1.dtype not in _integer_or_boolean_dtypes or x2.dtype not in _integer_or_boolean_dtypes:
         raise TypeError("Only integer or boolean dtypes are allowed in bitwise_xor")
     # Call result type here just to raise on disallowed type combinations
     _result_type(x1.dtype, x2.dtype)

--- a/arkouda/array_api/_manipulation_functions.py
+++ b/arkouda/array_api/_manipulation_functions.py
@@ -25,9 +25,7 @@ def broadcast_to(x: Array, /, shape: Tuple[int, ...]) -> Array:
 
 
 # Note: the function name is different here
-def concat(
-    arrays: Union[Tuple[Array, ...], List[Array]], /, *, axis: Optional[int] = 0
-) -> Array:
+def concat(arrays: Union[Tuple[Array, ...], List[Array]], /, *, axis: Optional[int] = 0) -> Array:
     """
     Array API compatible wrapper for :py:func:`np.concatenate <numpy.concatenate>`.
 
@@ -71,11 +69,7 @@ def permute_dims(x: Array, /, axes: Tuple[int, ...]) -> Array:
 
 
 # Note: the optional argument is called 'shape', not 'newshape'
-def reshape(x: Array,
-            /,
-            shape: Tuple[int, ...],
-            *,
-            copy: Optional[bool] = None) -> Array:
+def reshape(x: Array, /, shape: Tuple[int, ...], *, copy: Optional[bool] = None) -> Array:
     """
     Array API compatible wrapper for :py:func:`np.reshape <numpy.reshape>`.
 

--- a/arkouda/array_api/_set_functions.py
+++ b/arkouda/array_api/_set_functions.py
@@ -42,7 +42,5 @@ def unique_values(x: Array, /) -> Array:
 
     See its docstring for more information.
     """
-    res = ak.unique(
-        x._array
-    )
+    res = ak.unique(x._array)
     return Array._new(res)

--- a/arkouda/array_api/_sorting_functions.py
+++ b/arkouda/array_api/_sorting_functions.py
@@ -8,9 +8,7 @@ import arkouda as ak
 
 
 # Note: the descending keyword argument is new in this function
-def argsort(
-    x: Array, /, *, axis: int = -1, descending: bool = False, stable: bool = True
-) -> Array:
+def argsort(x: Array, /, *, axis: int = -1, descending: bool = False, stable: bool = True) -> Array:
     """
     Array API compatible wrapper for :py:func:`np.argsort <numpy.argsort>`.
 
@@ -29,9 +27,7 @@ def argsort(
 
 
 # Note: the descending keyword argument is new in this function
-def sort(
-    x: Array, /, *, axis: int = -1, descending: bool = False, stable: bool = True
-) -> Array:
+def sort(x: Array, /, *, axis: int = -1, descending: bool = False, stable: bool = True) -> Array:
     """
     Array API compatible wrapper for :py:func:`np.sort <numpy.sort>`.
 

--- a/arkouda/array_api/_typing.py
+++ b/arkouda/array_api/_typing.py
@@ -44,25 +44,30 @@ _T_co = TypeVar("_T_co", covariant=True)
 
 
 class NestedSequence(Protocol[_T_co]):
-    def __getitem__(self, key: int, /) -> _T_co | NestedSequence[_T_co]: ...
-    def __len__(self, /) -> int: ...
+    def __getitem__(self, key: int, /) -> _T_co | NestedSequence[_T_co]:
+        ...
+
+    def __len__(self, /) -> int:
+        ...
 
 
 Device = Literal["cpu"]
 
 
-Dtype = dtype[Union[
-    int8,
-    int16,
-    int32,
-    int64,
-    uint8,
-    uint16,
-    uint32,
-    uint64,
-    float32,
-    float64,
-]]
+Dtype = dtype[
+    Union[
+        int8,
+        int16,
+        int32,
+        int64,
+        uint8,
+        uint16,
+        uint32,
+        uint64,
+        float32,
+        float64,
+    ]
+]
 
 
 SupportsBufferProtocol = Any
@@ -70,4 +75,5 @@ PyCapsule = Any
 
 
 class SupportsDLPack(Protocol):
-    def __dlpack__(self, /, *, stream: None = ...) -> PyCapsule: ...
+    def __dlpack__(self, /, *, stream: None = ...) -> PyCapsule:
+        ...


### PR DESCRIPTION
The array_api code submitted with https://github.com/Bears-R-Us/arkouda/pull/2865 was not formatted properly. This PR applies the black autoformatter to correct those issues.

