### PR TITLE
Modify fix to performance regression in #2902

### DIFF
--- a/src/compat/e-132/ArkoudaSymEntryCompat.chpl
+++ b/src/compat/e-132/ArkoudaSymEntryCompat.chpl
@@ -67,6 +67,7 @@ module ArkoudaSymEntryCompat {
     this.a = try! makeDistArray((...args), etype);
     init this;
     this.shape = tupShapeString(this.tupShape);
+    this.ndim = this.tupShape.size;
   }
 
   /*
@@ -87,5 +88,6 @@ module ArkoudaSymEntryCompat {
     this.max_bits=max_bits;
     init this;
     this.shape = tupShapeString(this.tupShape);
+    this.ndim = this.tupShape.size;
   }
 }

--- a/src/compat/eq-131/ArkoudaSymEntryCompat.chpl
+++ b/src/compat/eq-131/ArkoudaSymEntryCompat.chpl
@@ -61,7 +61,7 @@ module ArkoudaSymEntryCompat {
     this.a = try! makeDistArray((...args), etype);
     this.complete();
     this.shape = tupShapeString(this.tupShape);
-    this.ndim = N;
+    this.ndim = this.tupShape.size;
   }
 
   /*
@@ -82,6 +82,6 @@ module ArkoudaSymEntryCompat {
     this.max_bits=max_bits;
     this.complete();
     this.shape = tupShapeString(this.tupShape);
-    this.ndim = D.rank;
+    this.ndim = this.tupShape.size;
   }
 }

--- a/src/compat/gt-132/ArkoudaSymEntryCompat.chpl
+++ b/src/compat/gt-132/ArkoudaSymEntryCompat.chpl
@@ -67,8 +67,7 @@ module ArkoudaSymEntryCompat {
     this.a = try! makeDistArray((...args), etype);
     init this;
     this.shape = tupShapeString(this.tupShape);
-    // commented out for perf reasons, needs further investigation
-    // this.ndim = N;
+    this.ndim = this.tupShape.size;
   }
 
   /*
@@ -89,7 +88,6 @@ module ArkoudaSymEntryCompat {
     this.max_bits=max_bits;
     init this;
     this.shape = tupShapeString(this.tupShape);
-    // commented out for perf reasons, needs further investigation
-    // this.ndim = D.rank;
+    this.ndim = this.tupShape.size;
   }
 }


### PR DESCRIPTION
https://github.com/Bears-R-Us/arkouda/pull/2902 commented out an assignment to the `ndim` field in some `SymEntry` initializers to correct a performance regression. This had the side effect of disabling some multidimensional array support that relied on queries to `ndim` on the client side.

This PR maintains the current performance and re-enables ND array support by setting the `ndim` field in a different way. Namely, the value is not assigned from a param formal, but rather from the value of another field set before `init this`. 

Rerunning the same 2 Locale scan benchmark from #2902 on master and this branch, performance is unaffected:

| before 2902 | master | this PR |
| :--- | :--- | :--- |
| 42.43 | 68.62 | 67.94 |