### PR TITLE
Closes #2937 : Fix string read bug for large Parquet files

### DIFF
--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -275,46 +275,25 @@ int64_t cpp_getStringColumnNumBytes(const char* filename, const char* colname, v
         }
         column_reader = row_group_reader->Column(idx);
 
+        int16_t definition_level;
         parquet::ByteArrayReader* ba_reader =
           static_cast<parquet::ByteArrayReader*>(column_reader.get());
 
         int64_t numRead = 0;
         while (ba_reader->HasNext() && numRead < numElems) {
-          if((numElems - numRead) < batchSize)
-            batchSize = numElems-numRead;
-          std::vector<parquet::ByteArray> string_values(batchSize);
-          std::vector<int16_t> definition_level(batchSize);
-          (void)ba_reader->ReadBatch(batchSize, definition_level.data(), nullptr, string_values.data(), &values_read);
-          numRead += values_read;
-          if (ty == ARROWSTRING) {
-            auto numCols = file_metadata -> num_columns();
-            int string_index = 0;
-            for(int idx = 0; idx < definition_level.size(); idx++) {
-              auto lvl = definition_level[idx];
-              if(lvl != 0 || numCols > 1) {
-                auto value = string_values[string_index];
-                offsets[i] = value.len + 1;
-                byteSize += value.len + 1;
-                string_index++;
-              } else {
-                offsets[i] = 1;
-                byteSize+=1;
-              }
-              i++;
+          parquet::ByteArray value;
+          (void)ba_reader->ReadBatch(1, &definition_level, nullptr, &value, &values_read);
+          if ((ty == ARROWLIST && definition_level == 3) || ty == ARROWSTRING) {
+            if(values_read > 0) {
+              offsets[i] = value.len + 1;
+              byteSize += value.len + 1;
+              numRead += values_read;
+            } else {
+              offsets[i] = 1;
+              byteSize+=1;
+              numRead+=1;
             }
-          } else if (ty == ARROWLIST) {
-            for(int string_index = 0; string_index < values_read; string_index++) {
-              auto level = definition_level[string_index];
-              auto value = string_values[string_index];
-              if(value.len != 0) {
-                offsets[i] = value.len + 1;
-                byteSize += value.len + 1;
-              } else {
-                offsets[i] = 1;
-                byteSize+=1;
-              }
-              i++;
-            }
+            i++;
           }
         }
       }
@@ -816,31 +795,23 @@ int cpp_readColumnByName(const char* filename, void* chpl_arr, const char* colna
           i+=values_read;
         }
       } else if(ty == ARROWSTRING) {
-        auto numCols = file_metadata -> num_columns();
         int16_t definition_level; // nullable type and only reading single records in batch
         auto chpl_ptr = (unsigned char*)chpl_arr;
         parquet::ByteArrayReader* reader =
           static_cast<parquet::ByteArrayReader*>(column_reader.get());
 
         while (reader->HasNext()) {
-          std::vector<parquet::ByteArray> string_values(batchSize);
-          std::vector<int16_t> definition_level(batchSize);
-          (void)reader->ReadBatch(batchSize, definition_level.data(), nullptr, string_values.data(), &values_read);
-
-          int string_index = 0;
-          for (int idx = 0; idx < definition_level.size(); idx++) {
-            auto lvl = definition_level[idx];
-            if(lvl > 0 || numCols > 1) {
-              auto value = string_values[string_index];
-              for(int j = 0; j < value.len; j++) {
-                chpl_ptr[i] = value.ptr[j];
-                i++;
-              }
-              string_index++;
+          parquet::ByteArray value;
+          (void)reader->ReadBatch(1, &definition_level, nullptr, &value, &values_read);
+          // if values_read is 0, that means that it was a null value
+          if(values_read > 0) {
+            for(int j = 0; j < value.len; j++) {
+              chpl_ptr[i] = value.ptr[j];
+              i++;
             }
-            i++; // skip one space so the strings are null terminated with a 0
           }
-        }
+          i++; // skip one space so the strings are null terminated with a 0
+        }        
       } else if(ty == ARROWFLOAT) {
         auto chpl_ptr = (double*)chpl_arr;
         parquet::FloatReader* reader =


### PR DESCRIPTION
When the size of the number of rows in a parquet string column exceeds the batch size, this can sometimes give incorrect results since the readBatch function utilizes the definition level in a unique way as opposed to other types, causing false positives for whether or not a string was read. In order to resolve this, I am reverting the batch size reading, which will reduce performance, but since we are planning on reworking string reads anyway, this isn't that big of a loss.

Closes #2937 