### PR TITLE
Remove deprecation warnings about `domain(?)` vs. `domain`

### DIFF
--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -20,7 +20,8 @@ module ArgSortMsg
     use CommAggregation;
 
     use AryUtil;
-    
+    use ArkoudaAryUtilCompat;
+
     use MultiTypeSymbolTable;
     use MultiTypeSymEntry;
     use ServerErrorStrings;

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -567,59 +567,6 @@ module AryUtil
     }
 
     /*
-      Get a domain that selects out the idx'th set of indices along the specified axes
-
-      :arg D: the domain to slice
-      :arg idx: the index to select along the specified axes (must have the same rank as D)
-      :arg axes: the axes to slice along (must be a subset of the axes of D)
-
-      For example, if D represents a stack of 1000 10x10 matrices (ex: {1..10, 1..10, 1..1000})
-      Then, domOnAxis(D, (1, 1, 25), 0, 1) will return D sliced with {1..10, 1..10, 25..25}
-      (i.e., the 25th matrix)
-    */
-    proc domOnAxis(D: domain, idx: D.rank*int, axes: int ...?NA): domain
-      where NA < D.rank
-    {
-      var outDims: D.rank*range;
-      label ranks for i in 0..<D.rank {
-        for param j in 0..<NA {
-          if i == axes[j] {
-            outDims[i] = D.dim(i);
-            continue ranks;
-          }
-        }
-        outDims[i] = idx[i]..idx[i];
-      }
-      return D[{(...outDims)}];
-    }
-
-    /*
-      Get a domain over the set of indices orthogonal to the specified axes
-
-      :arg D: the domain to slice
-      :arg axes: the axes to slice along (must be a subset of the axes of D)
-
-      For example, if D represents a stack of 1000 10x10 matrices (ex: {1..10, 1..10, 1..1000})
-      Then, domOffAxis(D, 0, 1) will return D sliced with {0..0, 0..0, 1..1000}
-      (i.e., a set of indices for the 1000 matrices)
-    */
-    proc domOffAxis(D: domain, axes: int ...?NA): domain
-      where NA < D.rank
-    {
-      var outDims: D.rank*range;
-      label ranks for i in 0..<D.rank {
-        for param j in 0..<NA {
-          if i == axes[j] {
-            outDims[i] = 0..0;
-            continue ranks;
-          }
-        }
-        outDims[i] = D.dim(i);
-      }
-      return D[{(...outDims)}];
-    }
-
-    /*
     Algorithm to determine shape of broadcasted PD array given two array shapes
 
     see: https://data-apis.org/array-api/latest/API_specification/broadcasting.html#algorithm

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -8,6 +8,7 @@ module IndexingMsg
     use Logging;
     use Message;
     use AryUtil;
+    use ArkoudaAryUtilCompat;
 
     use MultiTypeSymEntry;
     use MultiTypeSymbolTable;

--- a/src/LinalgMsg.chpl
+++ b/src/LinalgMsg.chpl
@@ -9,6 +9,7 @@ module LinalgMsg {
     use MultiTypeSymEntry;
     use ServerErrorStrings;
     use AryUtil;
+    use ArkoudaAryUtilCompat;
 
     private config const logLevel = ServerConfig.logLevel;
     private config const logChannel = ServerConfig.logChannel;

--- a/src/compat/e-132/ArkoudaAryUtilCompat.chpl
+++ b/src/compat/e-132/ArkoudaAryUtilCompat.chpl
@@ -1,0 +1,54 @@
+module ArkoudaAryUtilCompat {
+  /*
+    Get a domain that selects out the idx'th set of indices along the specified axes
+
+    :arg D: the domain to slice
+    :arg idx: the index to select along the specified axes (must have the same rank as D)
+    :arg axes: the axes to slice along (must be a subset of the axes of D)
+
+    For example, if D represents a stack of 1000 10x10 matrices (ex: {1..10, 1..10, 1..1000})
+    Then, domOnAxis(D, (1, 1, 25), 0, 1) will return D sliced with {1..10, 1..10, 25..25}
+    (i.e., the 25th matrix)
+  */
+  proc domOnAxis(D: domain, idx: D.rank*int, axes: int ...?NA): domain
+    where NA < D.rank
+  {
+    var outDims: D.rank*range;
+    label ranks for i in 0..<D.rank {
+      for param j in 0..<NA {
+        if i == axes[j] {
+          outDims[i] = D.dim(i);
+          continue ranks;
+        }
+      }
+      outDims[i] = idx[i]..idx[i];
+    }
+    return D[{(...outDims)}];
+  }
+
+  /*
+    Get a domain over the set of indices orthogonal to the specified axes
+
+    :arg D: the domain to slice
+    :arg axes: the axes to slice along (must be a subset of the axes of D)
+
+    For example, if D represents a stack of 1000 10x10 matrices (ex: {1..10, 1..10, 1..1000})
+    Then, domOffAxis(D, 0, 1) will return D sliced with {0..0, 0..0, 1..1000}
+    (i.e., a set of indices for the 1000 matrices)
+  */
+  proc domOffAxis(D: domain, axes: int ...?NA): domain
+    where NA < D.rank
+  {
+    var outDims: D.rank*range;
+    label ranks for i in 0..<D.rank {
+      for param j in 0..<NA {
+        if i == axes[j] {
+          outDims[i] = 0..0;
+          continue ranks;
+        }
+      }
+      outDims[i] = D.dim(i);
+    }
+    return D[{(...outDims)}];
+  }
+}

--- a/src/compat/eq-131/ArkoudaAryUtilCompat.chpl
+++ b/src/compat/eq-131/ArkoudaAryUtilCompat.chpl
@@ -1,0 +1,54 @@
+module ArkoudaAryUtilCompat {
+  /*
+    Get a domain that selects out the idx'th set of indices along the specified axes
+
+    :arg D: the domain to slice
+    :arg idx: the index to select along the specified axes (must have the same rank as D)
+    :arg axes: the axes to slice along (must be a subset of the axes of D)
+
+    For example, if D represents a stack of 1000 10x10 matrices (ex: {1..10, 1..10, 1..1000})
+    Then, domOnAxis(D, (1, 1, 25), 0, 1) will return D sliced with {1..10, 1..10, 25..25}
+    (i.e., the 25th matrix)
+  */
+  proc domOnAxis(D: domain, idx: D.rank*int, axes: int ...?NA): domain
+    where NA < D.rank
+  {
+    var outDims: D.rank*range;
+    label ranks for i in 0..<D.rank {
+      for param j in 0..<NA {
+        if i == axes[j] {
+          outDims[i] = D.dim(i);
+          continue ranks;
+        }
+      }
+      outDims[i] = idx[i]..idx[i];
+    }
+    return D[{(...outDims)}];
+  }
+
+  /*
+    Get a domain over the set of indices orthogonal to the specified axes
+
+    :arg D: the domain to slice
+    :arg axes: the axes to slice along (must be a subset of the axes of D)
+
+    For example, if D represents a stack of 1000 10x10 matrices (ex: {1..10, 1..10, 1..1000})
+    Then, domOffAxis(D, 0, 1) will return D sliced with {0..0, 0..0, 1..1000}
+    (i.e., a set of indices for the 1000 matrices)
+  */
+  proc domOffAxis(D: domain, axes: int ...?NA): domain
+    where NA < D.rank
+  {
+    var outDims: D.rank*range;
+    label ranks for i in 0..<D.rank {
+      for param j in 0..<NA {
+        if i == axes[j] {
+          outDims[i] = 0..0;
+          continue ranks;
+        }
+      }
+      outDims[i] = D.dim(i);
+    }
+    return D[{(...outDims)}];
+  }
+}

--- a/src/compat/eq-133/ArkoudaAryUtilCompat.chpl
+++ b/src/compat/eq-133/ArkoudaAryUtilCompat.chpl
@@ -1,0 +1,54 @@
+module ArkoudaAryUtilCompat {
+  /*
+    Get a domain that selects out the idx'th set of indices along the specified axes
+
+    :arg D: the domain to slice
+    :arg idx: the index to select along the specified axes (must have the same rank as D)
+    :arg axes: the axes to slice along (must be a subset of the axes of D)
+
+    For example, if D represents a stack of 1000 10x10 matrices (ex: {1..10, 1..10, 1..1000})
+    Then, domOnAxis(D, (1, 1, 25), 0, 1) will return D sliced with {1..10, 1..10, 25..25}
+    (i.e., the 25th matrix)
+  */
+  proc domOnAxis(D: domain(?), idx: D.rank*int, axes: int ...?NA): domain
+    where NA < D.rank
+  {
+    var outDims: D.rank*range;
+    label ranks for i in 0..<D.rank {
+      for param j in 0..<NA {
+        if i == axes[j] {
+          outDims[i] = D.dim(i);
+          continue ranks;
+        }
+      }
+      outDims[i] = idx[i]..idx[i];
+    }
+    return D[{(...outDims)}];
+  }
+
+  /*
+    Get a domain over the set of indices orthogonal to the specified axes
+
+    :arg D: the domain to slice
+    :arg axes: the axes to slice along (must be a subset of the axes of D)
+
+    For example, if D represents a stack of 1000 10x10 matrices (ex: {1..10, 1..10, 1..1000})
+    Then, domOffAxis(D, 0, 1) will return D sliced with {0..0, 0..0, 1..1000}
+    (i.e., a set of indices for the 1000 matrices)
+  */
+  proc domOffAxis(D: domain(?), axes: int ...?NA): domain
+    where NA < D.rank
+  {
+    var outDims: D.rank*range;
+    label ranks for i in 0..<D.rank {
+      for param j in 0..<NA {
+        if i == axes[j] {
+          outDims[i] = 0..0;
+          continue ranks;
+        }
+      }
+      outDims[i] = D.dim(i);
+    }
+    return D[{(...outDims)}];
+  }
+}

--- a/src/compat/ge-134/ArkoudaAryUtilCompat.chpl
+++ b/src/compat/ge-134/ArkoudaAryUtilCompat.chpl
@@ -1,0 +1,54 @@
+module ArkoudaAryUtilCompat {
+  /*
+    Get a domain that selects out the idx'th set of indices along the specified axes
+
+    :arg D: the domain to slice
+    :arg idx: the index to select along the specified axes (must have the same rank as D)
+    :arg axes: the axes to slice along (must be a subset of the axes of D)
+
+    For example, if D represents a stack of 1000 10x10 matrices (ex: {1..10, 1..10, 1..1000})
+    Then, domOnAxis(D, (1, 1, 25), 0, 1) will return D sliced with {1..10, 1..10, 25..25}
+    (i.e., the 25th matrix)
+  */
+  proc domOnAxis(D: domain(?), idx: D.rank*int, axes: int ...?NA): domain
+    where NA < D.rank
+  {
+    var outDims: D.rank*range;
+    label ranks for i in 0..<D.rank {
+      for param j in 0..<NA {
+        if i == axes[j] {
+          outDims[i] = D.dim(i);
+          continue ranks;
+        }
+      }
+      outDims[i] = idx[i]..idx[i];
+    }
+    return D[{(...outDims)}];
+  }
+
+  /*
+    Get a domain over the set of indices orthogonal to the specified axes
+
+    :arg D: the domain to slice
+    :arg axes: the axes to slice along (must be a subset of the axes of D)
+
+    For example, if D represents a stack of 1000 10x10 matrices (ex: {1..10, 1..10, 1..1000})
+    Then, domOffAxis(D, 0, 1) will return D sliced with {0..0, 0..0, 1..1000}
+    (i.e., a set of indices for the 1000 matrices)
+  */
+  proc domOffAxis(D: domain(?), axes: int ...?NA): domain
+    where NA < D.rank
+  {
+    var outDims: D.rank*range;
+    label ranks for i in 0..<D.rank {
+      for param j in 0..<NA {
+        if i == axes[j] {
+          outDims[i] = 0..0;
+          continue ranks;
+        }
+      }
+      outDims[i] = D.dim(i);
+    }
+    return D[{(...outDims)}];
+  }
+}


### PR DESCRIPTION
Compiling with newer versions of Chapel was producing deprecation warnings in the AryUtil module due to some domain types being written as `domain`, rather than `domain(?)`. This PR adds a compatibility module to address the warning.