### PR TITLE
Closes #2963-PROTO_tests-tests-akscipy-unit-tests-failing

### DIFF
--- a/PROTO_tests/tests/akscipy/akscipy_test.py
+++ b/PROTO_tests/tests/akscipy/akscipy_test.py
@@ -4,7 +4,7 @@ import numpy as np
 from scipy.stats import power_divergence as scipy_power_divergence
 
 import arkouda as ak
-from arkouda.akstats import power_divergence as ak_power_divergence
+from arkouda.akscipy import power_divergence as ak_power_divergence
 
 
 class TestStats:
@@ -53,7 +53,7 @@ class TestStats:
     def test_chisquare(self):
         from scipy.stats import chisquare as scipy_chisquare
 
-        from arkouda.akstats import chisquare as ak_chisquare
+        from arkouda.akscipy import chisquare as ak_chisquare
 
         pairs = self.create_stat_test_pairs()
 

--- a/PROTO_tests/tests/akscipy/math_tests.py
+++ b/PROTO_tests/tests/akscipy/math_tests.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import arkouda as ak
 from arkouda.pdarrayclass import pdarray
-from arkouda.scipy.special import xlogy
+from arkouda.akscipy.special import xlogy
 
 
 class TestStats:


### PR DESCRIPTION
Closes #2963 

This fixes some import errors that was causing unit tests to fail in PROTO_tests/tests/akscipy.