### PR TITLE
Fixes #2966: pip install from tar error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 from os import path
 import versioneer
 
@@ -115,7 +115,7 @@ setup(
     #
     #   py_modules=["my_module"],
     #
-    packages=["arkouda"],  # Required
+    packages=find_packages(),  # Required
 
     # Specify which Python versions you support. In contrast to the
     # 'Programming Language' classifiers above, 'pip install' will check this


### PR DESCRIPTION
This PR fixes #2966 where `import arkouda` was unable to find `akscipy`, resulting in a `ModuleNotFound` error

[Apparently all subfolders must be explicitly listed in the `setup.py`](https://stackoverflow.com/questions/15368054/import-error-on-installed-package-using-setup-py/15368107#15368107), so our packages line should look something like
```python
packages=['arkouda', 'arkouda.akscipy', 'arkouda.akscipy.special']
```
To avoid having to list these all out individually (and avoid this happening in the future if we forget to modify this line), we can use `find_packages` from `setuptools`
```python
packages=find_packages()
```

To reproduce the error @hokiegeek2 encountered, I created a clean conda environment, made a tar of my arkouda directory (up to date with `upstream/master`), ran `pip install arkouda.tar`, and attempted to import arkouda. I verified after modifying the `setup.py`, I was able import arkouda and that the functionality was accessible by calling `ak.akscipy.special.xlogy`