### PR TITLE
Closes #2969 PROTO_tests/tests/client_test.py unit tests failing

### DIFF
--- a/PROTO_tests/tests/client_test.py
+++ b/PROTO_tests/tests/client_test.py
@@ -136,5 +136,5 @@ class TestClient:
         sample of commands.
         """
         cmds = ak.client.get_server_commands()
-        for cmd in ["connect", "array", "create", "tondarray", "info", "str"]:
+        for cmd in ["connect", "array", "create1D", "tondarray1D", "info", "str"]:
             assert cmd in cmds


### PR DESCRIPTION
Closes #2969 PROTO_tests/tests/client_test.py unit tests failing

The unit tests in PROTO_tests/tests/client_test.py should now all pass.