### PR TITLE
Closes #2977 PROTO_tests/tests/setops_test.py unit tests failing

### DIFF
--- a/PROTO_tests/tests/setops_test.py
+++ b/PROTO_tests/tests/setops_test.py
@@ -97,10 +97,6 @@ class TestSetOps:
         a, b = self.make_np_arrays(size, ak.float64)
         func = getattr(ak, op)
 
-        # float64 not implemented for in1dmsg
-        with pytest.raises(RuntimeError if op == "in1d" else TypeError):
-            func(ak.array(a, dtype=ak.float64), ak.array(b, dtype=ak.float64))
-
         # # bool is not supported by argsortMsg (only impacts single array case)
         a, b = self.make_np_arrays(size, ak.bool)
         if op in ["in1d", "setdiff1d"]:
@@ -403,8 +399,8 @@ class TestSetOps:
         b1 = ak.array(c)
         b2 = ak.array(d)
         t = ak.union1d([a1, a2], [b1, b2])
-        assert ["xyz", "def", "abc"] == t[0].to_list()
-        assert ["0", "456", "123"] == t[1].to_list()
+        assert len({"xyz", "def", "abc"}.symmetric_difference(t[0].to_list())) == 0
+        assert len({"0", "456", "123"}.symmetric_difference(t[1].to_list())) == 0
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_union1d_multiarray_categorical(self, size):

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -167,7 +167,7 @@ def in1d(
 
     Notes
     ------
-        Only works for pdarrays of int64 dtype, Strings, or Categorical
+        Only works for pdarrays of int64 dtype, float64, Strings, or Categorical
     """
     from arkouda.alignment import NonUniqueError
     from arkouda.categorical import Categorical as Categorical_


### PR DESCRIPTION
Closes #2977 PROTO_tests/tests/setops_test.py unit tests failing.

Alll unit tests in PROTO_tests/tests/setops_test.py should now pass.