### PR TITLE
Address `Random.choice` deprecation

### DIFF
--- a/src/Security.chpl
+++ b/src/Security.chpl
@@ -16,7 +16,7 @@ module Security {
             "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"
             ];
 
-        return ''.join(try! sample(alphanum, len, withReplacement=true));
+        return ''.join(try! sample(alphanum, len-1, withReplacement=true));
     }
 
     proc getArkoudaToken(tokensPath : string) : string throws {

--- a/src/Security.chpl
+++ b/src/Security.chpl
@@ -16,18 +16,7 @@ module Security {
             "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"
             ];
 
-        var upper_bound = alphanum.size;
-        var indices : [0..upper_bound-1] int;
-        for i in 0..upper_bound-1 do
-            indices[i] = i;
-
-        var ret : [0..len-1] string;
-        var r = new randomStream(int);
-        var rindices = try! r.choice(indices, len);
-
-        for i in 1..len-1 do
-            ret[i] = alphanum[rindices[i]];
-        return ''.join(ret);
+        return ''.join(try! sample(alphanum, len, withReplacement=true));
     }
 
     proc getArkoudaToken(tokensPath : string) : string throws {

--- a/src/compat/e-132/ArkoudaAryUtilCompat.chpl
+++ b/src/compat/e-132/ArkoudaAryUtilCompat.chpl
@@ -10,7 +10,7 @@ module ArkoudaAryUtilCompat {
     Then, domOnAxis(D, (1, 1, 25), 0, 1) will return D sliced with {1..10, 1..10, 25..25}
     (i.e., the 25th matrix)
   */
-  proc domOnAxis(D: domain, idx: D.rank*int, axes: int ...?NA): domain
+  proc domOnAxis(D: domain(?), idx: D.rank*int, axes: int ...?NA): domain
     where NA < D.rank
   {
     var outDims: D.rank*range;
@@ -36,7 +36,7 @@ module ArkoudaAryUtilCompat {
     Then, domOffAxis(D, 0, 1) will return D sliced with {0..0, 0..0, 1..1000}
     (i.e., a set of indices for the 1000 matrices)
   */
-  proc domOffAxis(D: domain, axes: int ...?NA): domain
+  proc domOffAxis(D: domain(?), axes: int ...?NA): domain
     where NA < D.rank
   {
     var outDims: D.rank*range;

--- a/src/compat/e-132/ArkoudaRandomCompat.chpl
+++ b/src/compat/e-132/ArkoudaRandomCompat.chpl
@@ -11,6 +11,10 @@ module ArkoudaRandomCompat {
       eltType = t;
       r = new owned PCGRandomStream(eltType, seed);
     }
-    
+  }
+
+  proc sample(arr: [?d] ?t, n: int, withReplacement: bool): [] t throws {
+    var r = new randomStream(int);
+    return r.r.choice(arr, size=n, replace=withReplacement);
   }
 }

--- a/src/compat/eq-131/ArkoudaRandomCompat.chpl
+++ b/src/compat/eq-131/ArkoudaRandomCompat.chpl
@@ -11,6 +11,10 @@ module ArkoudaRandomCompat {
       eltType = t;
       r = new owned PCGRandomStream(eltType, seed);
     }
-    
+  }
+
+  proc sample(arr: [?d] ?t, n: int, withReplacement: bool): [] t throws {
+    var r = new randomStream(int);
+    return r.r.choice(arr, size=n, replace=withReplacement);
   }
 }

--- a/src/compat/eq-133/ArkoudaRandomCompat.chpl
+++ b/src/compat/eq-133/ArkoudaRandomCompat.chpl
@@ -1,2 +1,7 @@
 module ArkoudaRandomCompat {
+  use Random;
+  proc sample(arr: [?d] ?t, n: int, withReplacement: bool): [] t throws {
+    var r = new randomStream(int);
+    return r.choice(arr, size=n, replace=withReplacement);
+  }
 }


### PR DESCRIPTION
Switch from `Random.choice` to new `sample` interface to be added in 1.34. Add necessary compatibility modules for older versions.

Also fix deprecation warning coming from AryUtilCompat with Chapel 1.32.