### PR TITLE
Closes #2989 PROTO_tests/tests/pdarray_creation_test.py has failing test

### DIFF
--- a/arkouda/dtypes.py
+++ b/arkouda/dtypes.py
@@ -193,6 +193,7 @@ ARKOUDA_SUPPORTED_NUMBERS = (
     np.int32,
     np.int64,
     float,
+    np.float32,
     np.float64,
     np.uint8,
     np.uint16,


### PR DESCRIPTION
Add float32 to list of supported types.  This causes all unit tests to pass in PROTO_tests/tests/pdarray_creation_test.py

closes #2989