### PR TITLE
Resolve formatting issue in NumpyDType server docs

### DIFF
--- a/src/NumPyDType.chpl
+++ b/src/NumPyDType.chpl
@@ -141,7 +141,8 @@ module NumPyDType
     /*
       Return the dtype that can store the result of
       an operation between two dtypes for the following
-      operations: +, -, *, **, //, %, &, |, ^, <<, >>,
+      operations: ``+``, ``-``, ``*``, ``**``, ``//``, ``%``,
+      ``&``, ``|``, ``^``, ``<<``, ``>>``
 
       follows Numpy's rules for type promotion
       (of which the array-api promotion rules are a subset)


### PR DESCRIPTION
Add backticks around symbols in NumpyDType docs to prevent them from being parsed as rst special characters.  With this change, chpldoc was running successfully on my machine.

resolves: #2991
