### PR TITLE
Closes #2974 Series.map

### DIFF
--- a/PROTO_tests/tests/categorical_test.py
+++ b/PROTO_tests/tests/categorical_test.py
@@ -74,6 +74,24 @@ class TestCategorical:
     def test_to_list(self):
         assert self.non_unique_cat.to_list() == np.array(self.non_unique_strs).tolist()
 
+    def test_to_strings(self):
+        cat = self.non_unique_cat
+        cat_list = [
+            "string",
+            "string1",
+            "non-string",
+            "non-string2",
+            "string",
+            "non-string",
+            "string3",
+            "non-string2",
+            "string",
+            "non-string",
+        ]
+
+        assert cat.to_strings().to_list() == cat_list
+        assert isinstance(cat.to_strings(), ak.Strings)
+
     def test_equality(self):
         cat = self.create_basic_categorical()
         cat_dupe = self.create_basic_categorical()

--- a/PROTO_tests/tests/series_test.py
+++ b/PROTO_tests/tests/series_test.py
@@ -208,3 +208,39 @@ class TestSeries:
         )
         assert s.memory_usage(unit="KB", index=True) == 2 * size * ak.dtypes.int64.itemsize / 1024
         assert s.memory_usage(unit="B", index=True) == 2 * size * ak.dtypes.int64.itemsize
+
+    def test_map(self):
+        a = ak.Series(ak.array(["1", "1", "4", "4", "4"]))
+        b = ak.Series(ak.array([2, 3, 2, 3, 4]))
+        c = ak.Series(ak.array([1.0, 1.0, 2.2, 2.2, 4.4]), index=ak.array([5, 4, 2, 3, 1]))
+
+        result = a.map({"4": 25, "5": 30, "1": 7})
+        assert result.index.values.to_list() == [0, 1, 2, 3, 4]
+        assert result.values.to_list() == [7, 7, 25, 25, 25]
+
+        result = a.map({"1": 7})
+        assert result.index.values.to_list() == [0, 1, 2, 3, 4]
+        assert (
+            result.values.to_list()
+            == ak.cast(ak.array([7, 7, np.nan, np.nan, np.nan]), dt=ak.int64).to_list()
+        )
+
+        result = a.map({"1": 7.0})
+        assert result.index.values.to_list() == [0, 1, 2, 3, 4]
+        assert np.allclose(result.values.to_list(), [7.0, 7.0, np.nan, np.nan, np.nan], equal_nan=True)
+
+        result = b.map({4: 25.0, 2: 30.0, 1: 7.0, 3: 5.0})
+        assert result.index.values.to_list() == [0, 1, 2, 3, 4]
+        assert result.values.to_list() == [30.0, 5.0, 30.0, 5.0, 25.0]
+
+        result = c.map({1.0: "a", 2.2: "b", 4.4: "c", 5.0: "d"})
+        assert result.index.values.to_list() == [5, 4, 2, 3, 1]
+        assert result.values.to_list() == ["a", "a", "b", "b", "c"]
+
+        result = c.map({1.0: "a"})
+        assert result.index.values.to_list() == [5, 4, 2, 3, 1]
+        assert result.values.to_list() == ["a", "a", "null", "null", "null"]
+
+        result = c.map({1.0: "a", 2.2: "b", 4.4: "c", 5.0: "d", 6.0: "e"})
+        assert result.index.values.to_list() == [5, 4, 2, 3, 1]
+        assert result.values.to_list() == ["a", "a", "b", "b", "c"]

--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -380,6 +380,32 @@ class Categorical:
         """
         return self.to_ndarray().tolist()
 
+    def to_strings(self) -> List:
+        """
+        Convert the Categorical to Strings.
+
+        Returns
+        -------
+        arkouda.strings.Strings
+            A Strings object corresponding to the values in
+            this Categorical.
+
+        Examples
+        --------
+        >>> from arkouda import ak
+        >>> ak.connect()
+        >>> a = ak.array(["a","b","c"])
+        >>> a
+        >>> c = ak.Categorical(a)
+        >>>  c.to_strings()
+        c.to_strings()
+
+        >>> isinstance(c.to_strings(), ak.Strings)
+        True
+
+        """
+        return self.categories[self.codes]
+
     def __iter__(self):
         raise NotImplementedError(
             "Categorical does not support iteration. To force data transfer from server, use to_ndarray"

--- a/tests/categorical_test.py
+++ b/tests/categorical_test.py
@@ -2,13 +2,13 @@ import glob
 import os
 import shutil
 import tempfile
-import pytest
 
 import numpy as np
+import pytest
 from base_test import ArkoudaTest
 from context import arkouda as ak
 
-from arkouda import io_util, io
+from arkouda import Strings, io, io_util
 
 
 class CategoricalTest(ArkoudaTest):
@@ -137,6 +137,24 @@ class CategoricalTest(ArkoudaTest):
             ]
         )
         self.assertListEqual(cat.to_list(), ndcat.tolist())
+
+    def testToStrings(self):
+        cat = self._getRandomizedCategorical()
+        cat_list = [
+            "string",
+            "string1",
+            "non-string",
+            "non-string2",
+            "string",
+            "non-string",
+            "string3",
+            "non-string2",
+            "string",
+            "non-string",
+        ]
+
+        self.assertListEqual(cat.to_strings().to_list(), cat_list)
+        self.assertTrue(isinstance(cat.to_strings(), Strings))
 
     def testEquality(self):
         cat = self._getCategorical()
@@ -374,7 +392,6 @@ class CategoricalTest(ArkoudaTest):
             self.assertListEqual(d.segments.to_list(), replace_cat.segments.to_list())
             self.assertListEqual(d._akNAcode.to_list(), replace_cat._akNAcode.to_list())
             self.assertListEqual(d.categories.to_list(), replace_cat.categories.to_list())
-
 
     def test_unused_categories_logic(self):
         """

--- a/tests/series_test.py
+++ b/tests/series_test.py
@@ -632,3 +632,59 @@ class SeriesTest(ArkoudaTest):
         )
         self.assertEqual(s.memory_usage(unit="KB", index=True), 2 * n * ak.dtypes.int64.itemsize / 1024)
         self.assertEqual(s.memory_usage(unit="B", index=True), 2 * n * ak.dtypes.int64.itemsize)
+
+    def test_map(self):
+        a = ak.Series(ak.array(["1", "1", "4", "4", "4"]))
+        b = ak.Series(ak.array([2, 3, 2, 3, 4]))
+        c = ak.Series(ak.array([1.0, 1.0, 2.2, 2.2, 4.4]), index=ak.array([5, 4, 2, 3, 1]))
+        d = ak.Series(ak.Categorical(a.values))
+
+        result = a.map({"4": 25, "5": 30, "1": 7})
+        self.assertListEqual(result.index.values.to_list(), [0, 1, 2, 3, 4])
+        self.assertListEqual(result.values.to_list(), [7, 7, 25, 25, 25])
+
+        result = a.map({"1": 7})
+        self.assertListEqual(result.index.values.to_list(), [0, 1, 2, 3, 4])
+        self.assertListEqual(
+            result.values.to_list(),
+            ak.cast(ak.array([7, 7, np.nan, np.nan, np.nan]), dt=ak.int64).to_list(),
+        )
+
+        result = a.map({"1": 7.0})
+        self.assertListEqual(result.index.values.to_list(), [0, 1, 2, 3, 4])
+        self.assertTrue(
+            np.allclose(result.values.to_list(), [7.0, 7.0, np.nan, np.nan, np.nan], equal_nan=True)
+        )
+
+        result = b.map({4: 25.0, 2: 30.0, 1: 7.0, 3: 5.0})
+        self.assertListEqual(result.index.values.to_list(), [0, 1, 2, 3, 4])
+        self.assertListEqual(result.values.to_list(), [30.0, 5.0, 30.0, 5.0, 25.0])
+
+        result = c.map({1.0: "a", 2.2: "b", 4.4: "c", 5.0: "d"})
+        self.assertListEqual(result.index.values.to_list(), [5, 4, 2, 3, 1])
+        self.assertListEqual(result.values.to_list(), ["a", "a", "b", "b", "c"])
+
+        result = c.map({1.0: "a"})
+        self.assertListEqual(result.index.values.to_list(), [5, 4, 2, 3, 1])
+        self.assertListEqual(result.values.to_list(), ["a", "a", "null", "null", "null"])
+
+        result = c.map({1.0: "a", 2.2: "b", 4.4: "c", 5.0: "d", 6.0: "e"})
+        self.assertListEqual(result.index.values.to_list(), [5, 4, 2, 3, 1])
+        self.assertListEqual(result.values.to_list(), ["a", "a", "b", "b", "c"])
+
+        result = d.map({"4": 25, "5": 30, "1": 7})
+        self.assertListEqual(result.index.values.to_list(), [0, 1, 2, 3, 4])
+        self.assertListEqual(result.values.to_list(), [7, 7, 25, 25, 25])
+
+        result = d.map({"1": 7})
+        self.assertListEqual(result.index.values.to_list(), [0, 1, 2, 3, 4])
+        self.assertListEqual(
+            result.values.to_list(),
+            ak.cast(ak.array([7, 7, np.nan, np.nan, np.nan]), dt=ak.int64).to_list(),
+        )
+
+        result = d.map({"1": 7.0})
+        self.assertListEqual(result.index.values.to_list(), [0, 1, 2, 3, 4])
+        self.assertTrue(
+            np.allclose(result.values.to_list(), [7.0, 7.0, np.nan, np.nan, np.nan], equal_nan=True)
+        )


### PR DESCRIPTION
Closes #2974 Series.map

This adds Series.map function that accepts a dict or arkouda.Series as the mapping correspondence.