### PR TITLE
Closes #2934 DataFrame.unregister_dataframe_by_name string return typ…

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -4333,7 +4333,7 @@ class DataFrame(UserDict):
 
     @staticmethod
     @typechecked
-    def unregister_dataframe_by_name(user_defined_name: str) -> None:
+    def unregister_dataframe_by_name(user_defined_name: str) -> str:
         """
         Function to unregister DataFrame object by name which was registered
         with the arkouda server via register().
@@ -4368,7 +4368,6 @@ class DataFrame(UserDict):
         >>> df.unregister_dataframe_by_name("my_table_name")
         >>> df.is_registered()
         False
-
 
         """
         import warnings

--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -215,7 +215,7 @@ def attach(name: str):
 
 
 @typechecked
-def unregister(name: str):
+def unregister(name: str) -> str:
     rep_msg = cast(str, generic_msg(cmd="unregister", args={"name": name}))
 
     return rep_msg


### PR DESCRIPTION
Closes #2934 DataFrame.unregister_dataframe_by_name string return type.

Changed the return type to str for two functions so the @typechecked wouldn't throw an error.

