### PR TITLE
Closes #3008: Add generator sym entry and stateful uniform distribution

### DIFF
--- a/PROTO_tests/tests/random_test.py
+++ b/PROTO_tests/tests/random_test.py
@@ -53,49 +53,6 @@ class TestRandom:
     def test_uniform(self):
         # verify same seed gives different but reproducible arrays
         rng = ak.random.default_rng(18)
-        first = rng.integers(-(2**32), 2**32, 10)
-        second = rng.integers(-(2**32), 2**32, 10)
-        assert first.to_list() != second.to_list()
-
-        rng = ak.random.default_rng(18)
-        same_seed_first = rng.integers(-(2**32), 2**32, 10)
-        same_seed_second = rng.integers(-(2**32), 2**32, 10)
-        assert first.to_list() == same_seed_first.to_list()
-        assert second.to_list() == same_seed_second.to_list()
-
-        # test endpoint
-        rng = ak.random.default_rng()
-        all_zero = rng.integers(0, 1, 20)
-        assert all(all_zero.to_ndarray() == 0)
-
-        not_all_zero = rng.integers(0, 1, 20, endpoint=True)
-        assert any(not_all_zero.to_ndarray() != 0)
-
-        # verify that switching dtype and function from seed is still reproducible
-        rng = ak.random.default_rng(74)
-        uint_arr = rng.integers(2**32, size=10, dtype="uint")
-        float_arr = rng.uniform(-1.0, 1.0, size=5)
-        bool_arr = rng.integers(0, 1, size=20, dtype="int")
-        int_arr = rng.integers(-(2**32), 2**32, size=10, dtype="int")
-
-        rng = ak.random.default_rng(74)
-        same_seed_uint_arr = rng.integers(2**32, size=10, dtype="uint")
-        same_seed_float_arr = rng.uniform(-1.0, 1.0, size=5)
-        same_seed_bool_arr = rng.integers(0, 1, size=20, dtype="int")
-        same_seed_int_arr = rng.integers(-(2**32), 2**32, size=10, dtype="int")
-
-        assert uint_arr.to_list() == same_seed_uint_arr.to_list()
-        assert float_arr.to_list() == same_seed_float_arr.to_list()
-        assert bool_arr.to_list() == same_seed_bool_arr.to_list()
-        assert int_arr.to_list() == same_seed_int_arr.to_list()
-
-        # verify within bounds (lower inclusive and upper exclusive)
-        rng = ak.random.default_rng()
-        bounded_arr = rng.integers(-5, 5, 1000)
-        assert all(bounded_arr.to_ndarray() >= -5)
-        assert all(bounded_arr.to_ndarray() < 5)
-        # verify same seed gives different but reproducible arrays
-        rng = ak.random.default_rng(18)
         first = rng.uniform(-(2**32), 2**32, 10)
         second = rng.uniform(-(2**32), 2**32, 10)
         assert first.to_list() != second.to_list()

--- a/PROTO_tests/tests/random_test.py
+++ b/PROTO_tests/tests/random_test.py
@@ -1,0 +1,270 @@
+import numpy as np
+import pytest
+
+import arkouda as ak
+
+
+class TestRandom:
+    def test_integers(self):
+        # verify same seed gives different but reproducible arrays
+        rng = ak.random.default_rng(18)
+        first = rng.integers(-(2**32), 2**32, 10)
+        second = rng.integers(-(2**32), 2**32, 10)
+        assert first.to_list() != second.to_list()
+
+        rng = ak.random.default_rng(18)
+        same_seed_first = rng.integers(-(2**32), 2**32, 10)
+        same_seed_second = rng.integers(-(2**32), 2**32, 10)
+        assert first.to_list() == same_seed_first.to_list()
+        second.to_list() == same_seed_second.to_list()
+
+        # test endpoint
+        rng = ak.random.default_rng()
+        all_zero = rng.integers(0, 1, 20)
+        assert all(all_zero.to_ndarray() == 0)
+
+        not_all_zero = rng.integers(0, 1, 20, endpoint=True)
+        assert any(not_all_zero.to_ndarray() != 0)
+
+        # verify that switching dtype and function from seed is still reproducible
+        rng = ak.random.default_rng(74)
+        uint_arr = rng.integers(0, 2**32, size=10, dtype="uint")
+        float_arr = rng.uniform(-1.0, 1.0, size=5)
+        bool_arr = rng.integers(0, 1, size=20, dtype="bool")
+        int_arr = rng.integers(-(2**32), 2**32, size=10, dtype="int")
+
+        rng = ak.random.default_rng(74)
+        same_seed_uint_arr = rng.integers(0, 2**32, size=10, dtype="uint")
+        same_seed_float_arr = rng.uniform(-1.0, 1.0, size=5)
+        same_seed_bool_arr = rng.integers(0, 1, size=20, dtype="bool")
+        same_seed_int_arr = rng.integers(-(2**32), 2**32, size=10, dtype="int")
+
+        assert uint_arr.to_list() == same_seed_uint_arr.to_list()
+        assert float_arr.to_list() == same_seed_float_arr.to_list()
+        assert bool_arr.to_list() == same_seed_bool_arr.to_list()
+        assert int_arr.to_list() == same_seed_int_arr.to_list()
+
+        # verify within bounds (lower inclusive and upper exclusive)
+        rng = ak.random.default_rng()
+        bounded_arr = rng.integers(-5, 5, 1000)
+        assert all(bounded_arr.to_ndarray() >= -5)
+        assert all(bounded_arr.to_ndarray() < 5)
+
+    def test_uniform(self):
+        # verify same seed gives different but reproducible arrays
+        rng = ak.random.default_rng(18)
+        first = rng.integers(-(2**32), 2**32, 10)
+        second = rng.integers(-(2**32), 2**32, 10)
+        assert first.to_list() != second.to_list()
+
+        rng = ak.random.default_rng(18)
+        same_seed_first = rng.integers(-(2**32), 2**32, 10)
+        same_seed_second = rng.integers(-(2**32), 2**32, 10)
+        assert first.to_list() == same_seed_first.to_list()
+        assert second.to_list() == same_seed_second.to_list()
+
+        # test endpoint
+        rng = ak.random.default_rng()
+        all_zero = rng.integers(0, 1, 20)
+        assert all(all_zero.to_ndarray() == 0)
+
+        not_all_zero = rng.integers(0, 1, 20, endpoint=True)
+        assert any(not_all_zero.to_ndarray() != 0)
+
+        # verify that switching dtype and function from seed is still reproducible
+        rng = ak.random.default_rng(74)
+        uint_arr = rng.integers(2**32, size=10, dtype="uint")
+        float_arr = rng.uniform(-1.0, 1.0, size=5)
+        bool_arr = rng.integers(0, 1, size=20, dtype="int")
+        int_arr = rng.integers(-(2**32), 2**32, size=10, dtype="int")
+
+        rng = ak.random.default_rng(74)
+        same_seed_uint_arr = rng.integers(2**32, size=10, dtype="uint")
+        same_seed_float_arr = rng.uniform(-1.0, 1.0, size=5)
+        same_seed_bool_arr = rng.integers(0, 1, size=20, dtype="int")
+        same_seed_int_arr = rng.integers(-(2**32), 2**32, size=10, dtype="int")
+
+        assert uint_arr.to_list() == same_seed_uint_arr.to_list()
+        assert float_arr.to_list() == same_seed_float_arr.to_list()
+        assert bool_arr.to_list() == same_seed_bool_arr.to_list()
+        assert int_arr.to_list() == same_seed_int_arr.to_list()
+
+        # verify within bounds (lower inclusive and upper exclusive)
+        rng = ak.random.default_rng()
+        bounded_arr = rng.integers(-5, 5, 1000)
+        assert all(bounded_arr.to_ndarray() >= -5)
+        assert all(bounded_arr.to_ndarray() < 5)
+        # verify same seed gives different but reproducible arrays
+        rng = ak.random.default_rng(18)
+        first = rng.uniform(-(2**32), 2**32, 10)
+        second = rng.uniform(-(2**32), 2**32, 10)
+        assert first.to_list() != second.to_list()
+
+        rng = ak.random.default_rng(18)
+        same_seed_first = rng.uniform(-(2**32), 2**32, 10)
+        same_seed_second = rng.uniform(-(2**32), 2**32, 10)
+        assert first.to_list() == same_seed_first.to_list()
+        assert second.to_list() == same_seed_second.to_list()
+
+        # verify within bounds (lower inclusive and upper exclusive)
+        rng = ak.random.default_rng()
+        bounded_arr = rng.uniform(-5, 5, 1000)
+        assert all(bounded_arr.to_ndarray() >= -5)
+        assert all(bounded_arr.to_ndarray() < 5)
+
+    def test_legacy_randint(self):
+        testArray = ak.random.randint(0, 10, 5)
+        assert isinstance(testArray, ak.pdarray)
+        assert 5 == len(testArray)
+        assert ak.int64 == testArray.dtype
+
+        testArray = ak.random.randint(np.int64(0), np.int64(10), np.int64(5))
+        assert isinstance(testArray, ak.pdarray)
+        assert 5 == len(testArray)
+        assert ak.int64 == testArray.dtype
+
+        testArray = ak.random.randint(np.float64(0), np.float64(10), np.int64(5))
+        assert isinstance(testArray, ak.pdarray)
+        assert 5 == len(testArray)
+        assert ak.int64 == testArray.dtype
+
+        test_ndarray = testArray.to_ndarray()
+
+        for value in test_ndarray:
+            assert 0 <= value <= 10
+
+        test_array = ak.random.randint(0, 1, 3, dtype=ak.float64)
+        assert ak.float64 == test_array.dtype
+
+        test_array = ak.random.randint(0, 1, 5, dtype=ak.bool)
+        assert ak.bool == test_array.dtype
+
+        test_ndarray = test_array.to_ndarray()
+
+        # test resolution of modulus overflow - issue #1174
+        test_array = ak.random.randint(-(2**63), 2**63 - 1, 10)
+        to_validate = np.full(10, -(2**63))
+        assert not (test_array.to_ndarray() == to_validate).all()
+
+        for value in test_ndarray:
+            assert value in [True, False]
+
+        with pytest.raises(TypeError):
+            ak.random.randint(low=5)
+
+        with pytest.raises(TypeError):
+            ak.random.randint(high=5)
+
+        with pytest.raises(TypeError):
+            ak.random.randint()
+
+        with pytest.raises(ValueError):
+            ak.random.randint(low=0, high=1, size=-1, dtype=ak.float64)
+
+        with pytest.raises(ValueError):
+            ak.random.randint(low=1, high=0, size=1, dtype=ak.float64)
+
+        with pytest.raises(TypeError):
+            ak.random.randint(0, 1, "1000")
+
+        with pytest.raises(TypeError):
+            ak.random.randint("0", 1, 1000)
+
+        with pytest.raises(TypeError):
+            ak.random.randint(0, "1", 1000)
+
+        # Test that int_scalars covers uint8, uint16, uint32
+        ak.random.randint(low=np.uint8(1), high=np.uint16(100), size=np.uint32(100))
+
+    def test_legacy_randint_with_seed(self):
+        values = ak.random.randint(1, 5, 10, seed=2)
+
+        assert [4, 3, 1, 3, 2, 4, 4, 2, 3, 4] == values.to_list()
+
+        values = ak.random.randint(1, 5, 10, dtype=ak.float64, seed=2)
+
+        assert [
+            2.9160772326374946,
+            4.353429832157099,
+            4.5392023718621486,
+            4.4019932101126606,
+            3.3745324569952304,
+            1.1642002901528308,
+            4.4714086874555292,
+            3.7098921109084522,
+            4.5939589352472314,
+            4.0337935981006172,
+        ] == values.to_list()
+
+        values = ak.random.randint(1, 5, 10, dtype=ak.bool, seed=2)
+        assert [False, True, True, True, True, False, True, True, True, True] == values.to_list()
+
+        values = ak.random.randint(1, 5, 10, dtype=bool, seed=2)
+        assert [False, True, True, True, True, False, True, True, True, True] == values.to_list()
+
+        # Test that int_scalars covers uint8, uint16, uint32
+        ak.random.randint(np.uint8(1), np.uint32(5), np.uint16(10), seed=np.uint8(2))
+
+    def test_legacy_uniform(self):
+        testArray = ak.random.uniform(3)
+        assert isinstance(testArray, ak.pdarray)
+        assert 3 == len(testArray)
+        assert ak.float64 == testArray.dtype
+
+        testArray = ak.random.uniform(np.int64(3))
+        assert isinstance(testArray, ak.pdarray)
+        assert 3 == len(testArray)
+        assert ak.float64 == testArray.dtype
+
+        uArray = ak.random.uniform(size=3, low=0, high=5, seed=0)
+        assert [0.30013431967121934, 0.47383036230759112, 1.0441791878997098] == uArray.to_list()
+
+        uArray = ak.random.uniform(size=np.int64(3), low=np.int64(0), high=np.int64(5), seed=np.int64(0))
+        assert [0.30013431967121934, 0.47383036230759112, 1.0441791878997098] == uArray.to_list()
+
+        with pytest.raises(TypeError):
+            ak.random.uniform(low="0", high=5, size=100)
+
+        with pytest.raises(TypeError):
+            ak.random.uniform(low=0, high="5", size=100)
+
+        with pytest.raises(TypeError):
+            ak.random.uniform(low=0, high=5, size="100")
+
+        # Test that int_scalars covers uint8, uint16, uint32
+        ak.random.uniform(low=np.uint8(0), high=5, size=np.uint32(100))
+
+    def test_legacy_standard_normal(self):
+        pda = ak.random.standard_normal(100)
+        assert isinstance(pda, ak.pdarray)
+        assert 100 == len(pda)
+        assert ak.float64 == pda.dtype
+
+        pda = ak.random.standard_normal(np.int64(100))
+        assert isinstance(pda, ak.pdarray)
+        assert 100 == len(pda)
+        assert ak.float64 == pda.dtype
+
+        pda = ak.random.standard_normal(np.int64(100), np.int64(1))
+        assert isinstance(pda, ak.pdarray)
+        assert 100 == len(pda)
+        assert ak.float64 == pda.dtype
+
+        npda = pda.to_ndarray()
+        pda = ak.random.standard_normal(np.int64(100), np.int64(1))
+
+        assert npda.tolist() == pda.to_list()
+
+        with pytest.raises(TypeError):
+            ak.random.standard_normal("100")
+
+        with pytest.raises(TypeError):
+            ak.random.standard_normal(100.0)
+
+        with pytest.raises(ValueError):
+            ak.random.standard_normal(-1)
+
+        # Test that int_scalars covers uint8, uint16, uint32
+        ak.random.standard_normal(np.uint8(100))
+        ak.random.standard_normal(np.uint16(100))
+        ak.random.standard_normal(np.uint32(100))

--- a/arkouda/random/__init__.py
+++ b/arkouda/random/__init__.py
@@ -1,9 +1,8 @@
-from ._generator import Generator, default_rng
+from ._generator import Generator, default_rng  # noqa
 from ._legacy import randint, standard_normal, uniform
 
 __all__ = [
     'Generator',
-    'default_rng',
     'randint',
     'standard_normal',
     'uniform',

--- a/arkouda/random/_generator.py
+++ b/arkouda/random/_generator.py
@@ -23,6 +23,16 @@ class Generator:
     seed : int
         Seed to allow for reproducible random number generation.
 
+    name_dict: dict
+        Dictionary mapping the server side names associated with
+        the generators for each dtype.
+
+    state: int
+        The current state we are in the random number generation stream.
+        This information makes it so calls to any dtype generator
+        function affects the stream of random numbers for the other generators.
+        This mimics the behavior we see in numpy
+
     See Also
     --------
     default_rng : Recommended constructor for `Generator`.

--- a/arkouda/random/_generator.py
+++ b/arkouda/random/_generator.py
@@ -1,7 +1,12 @@
 import numpy.random as np_random
 
+from arkouda.client import generic_msg
+from arkouda.dtypes import bool as akbool
 from arkouda.dtypes import dtype as to_numpy_dtype
+from arkouda.dtypes import float64 as akfloat64
 from arkouda.dtypes import int64 as akint64
+from arkouda.dtypes import uint64 as akuint64
+from arkouda.pdarrayclass import create_pdarray
 
 
 class Generator:
@@ -23,9 +28,11 @@ class Generator:
     default_rng : Recommended constructor for `Generator`.
     """
 
-    def __init__(self, seed=None):
+    def __init__(self, name_dict=None, seed=None, state=1):
         self._seed = seed
         self._np_generator = np_random.default_rng(seed)
+        self._name_dict = name_dict
+        self._state = state
 
     def __repr__(self):
         return self.__str__()
@@ -78,19 +85,35 @@ class Generator:
         >>> rng.integers(5, size=10)
         array([2, 4, 0, 0, 0, 3, 1, 5, 5, 3])  # random
         """
-        from arkouda.random._legacy import randint
+        # normalize dtype so things like "int" will work
+        dtype = to_numpy_dtype(dtype)
+
+        if dtype is akfloat64:
+            raise TypeError("Unsupported dtype dtype('float64') for integers")
 
         if size is None:
             # delegate to numpy when return size is 1
-            return self._np_generator.integers(
-                low=low, high=high, dtype=to_numpy_dtype(dtype), endpoint=endpoint
-            )
+            return self._np_generator.integers(low=low, high=high, dtype=dtype, endpoint=endpoint)
         if high is None:
-            high = low + 1
+            high = low
             low = 0
-        elif endpoint:
-            high = high + 1
-        return randint(low=low, high=high, size=size, dtype=dtype, seed=self._seed)
+        elif not endpoint:
+            high = high - 1
+
+        name = self._name_dict[dtype]
+        rep_msg = generic_msg(
+            cmd="uniformGenerator",
+            args={
+                "name": name,
+                "low": low,
+                "high": high,
+                "size": size,
+                "dtype": dtype,
+                "state": self._state,
+            },
+        )
+        self._state += size
+        return create_pdarray(rep_msg)
 
     def random(self, size=None):
         """
@@ -129,7 +152,19 @@ class Generator:
         if size is None:
             # delegate to numpy when return size is 1
             return self._np_generator.random()
-        return self.uniform(low=0.0, high=1.0, size=size)
+        rep_msg = generic_msg(
+            cmd="uniformGenerator",
+            args={
+                "name": self._name_dict[akfloat64],
+                "low": 0.0,
+                "high": 1.0,
+                "size": size,
+                "dtype": akfloat64,
+                "state": self._state,
+            },
+        )
+        self._state += size
+        return create_pdarray(rep_msg)
 
     def standard_normal(self, size=None):
         """
@@ -203,12 +238,22 @@ class Generator:
         >>> rng.uniform(-1, 1, 3)
         array([0.030785499755523249, 0.08505865366367038, -0.38552048588998722])  # random
         """
-        from arkouda.random._legacy import uniform
-
         if size is None:
             # delegate to numpy when return size is 1
             return self._np_generator.uniform(low=low, high=high)
-        return uniform(low=low, high=high, size=size, seed=self._seed)
+        rep_msg = generic_msg(
+            cmd="uniformGenerator",
+            args={
+                "name": self._name_dict[akfloat64],
+                "low": low,
+                "high": high,
+                "size": size,
+                "dtype": akfloat64,
+                "state": self._state,
+            },
+        )
+        self._state += size
+        return create_pdarray(rep_msg)
 
 
 def default_rng(seed=None):
@@ -231,6 +276,33 @@ def default_rng(seed=None):
         The initialized generator object.
     """
     if isinstance(seed, Generator):
-        # Pass through a Generator.
+        # Pass through the generator
         return seed
-    return Generator(seed)
+    if seed is None:
+        seed = -1
+        has_seed = False
+    else:
+        has_seed = True
+
+    state = 1
+    # chpl has to know the type of the generator, in order to avoid having to declare
+    # the type of the generator beforehand (which is not what numpy does)
+    # we declare a generator for each type and fast-forward the state
+    int_name = generic_msg(
+        cmd="createGenerator",
+        args={"dtype": "int64", "has_seed": has_seed, "seed": seed, "state": state},
+    )
+    uint_name = generic_msg(
+        cmd="createGenerator",
+        args={"dtype": "uint64", "has_seed": has_seed, "seed": seed, "state": state},
+    )
+    float_name = generic_msg(
+        cmd="createGenerator",
+        args={"dtype": "float64", "has_seed": has_seed, "seed": seed, "state": state},
+    )
+    bool_name = generic_msg(
+        cmd="createGenerator",
+        args={"dtype": "bool", "has_seed": has_seed, "seed": seed, "state": state},
+    )
+    name_dict = {akint64: int_name, akuint64: uint_name, akfloat64: float_name, akbool: bool_name}
+    return Generator(name_dict, seed if has_seed else None, state=state)

--- a/pytest.ini
+++ b/pytest.ini
@@ -32,6 +32,7 @@ testpaths =
     tests/operator_tests.py
     tests/parquet_test.py
     tests/pdarray_creation_test.py
+    tests/random_test.py
     tests/regex_test.py
     tests/security_test.py
     tests/segarray_test.py

--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -11,6 +11,7 @@ module MultiTypeSymEntry
     public use NumPyDType;
     public use SymArrayDmapCompat;
     use ArkoudaSymEntryCompat;
+    use ArkoudaRandomCompat;
 
     private config const logLevel = ServerConfig.logLevel;
     private config const logChannel = ServerConfig.logChannel;
@@ -31,6 +32,8 @@ module MultiTypeSymEntry
                 SegStringSymEntry,    // SegString composed of offset-int[], bytes->uint(8)
 
             CompositeSymEntry,        // Entries that consist of multiple SymEntries of varying type
+
+            GeneratorSymEntry,  // Entry for random number generators
 
             AnythingSymEntry, // Placeholder to stick aritrary things in the map
             UnknownSymEntry,
@@ -371,6 +374,20 @@ module MultiTypeSymEntry
         }
     }
 
+    class GeneratorSymEntry:AbstractSymEntry {
+        type etype;
+        var generator: randomStream(etype);
+        var state: int;
+
+        proc init(generator: randomStream(?etype), state: int = 1) {
+            this.entryType = SymbolEntryType.GeneratorSymEntry;
+            assignableTypes.add(this.entryType);
+            this.etype = etype;
+            this.generator = generator;
+            this.state = state;
+        }
+    }
+
     /**
      * Helper proc to cast AbstrcatSymEntry to GenSymEntry
      */
@@ -390,6 +407,13 @@ module MultiTypeSymEntry
      */
     proc toSegStringSymEntry(entry: borrowed AbstractSymEntry) throws {
         return (entry: borrowed SegStringSymEntry);
+    }
+
+    /**
+     * Helper proc to cast AbstractSymEntry to GeneratorSymEntry
+     */
+    proc toGeneratorSymEntry(entry: borrowed AbstractSymEntry, type t) throws {
+        return (entry: borrowed GeneratorSymEntry(t));
     }
 
     /**

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -403,6 +403,9 @@ module MultiTypeSymbolTable
                 var c: CompositeSymEntry = toCompositeSymEntry(entry);
                 return "%s %? %?".doFormat(name, c.size, c.ndim);
             }
+            else if entry.isAssignableTo(SymbolEntryType.GeneratorSymEntry) {
+                return name;
+            }
             
             throw new Error("attrib - Unsupported Entry Type %s".doFormat(entry.entryType));
         }

--- a/src/compat/e-132/ArkoudaRandomCompat.chpl
+++ b/src/compat/e-132/ArkoudaRandomCompat.chpl
@@ -2,14 +2,20 @@ module ArkoudaRandomCompat {
   use Random.PCGRandom only PCGRandomStream;
   record randomStream {
     type eltType = int;
-    forwarding var r: owned PCGRandomStream(eltType);
+    forwarding var r: shared PCGRandomStream(eltType);
     proc init(type t) {
       eltType = t;
-      r = new owned PCGRandomStream(eltType);
+      r = new shared PCGRandomStream(eltType);
     }
     proc init(type t, seed) {
       eltType = t;
-      r = new owned PCGRandomStream(eltType, seed);
+      r = new shared PCGRandomStream(eltType, seed);
+    }
+    proc ref fill(ref arr: []) where arr.isRectangular() {
+      r.fillRandom(arr);
+    }
+    proc ref fill(ref arr: [], min: arr.eltType, max: arr.eltType) where arr.isRectangular() {
+      r.fillRandom(arr, min, max);
     }
   }
 

--- a/src/compat/eq-131/ArkoudaRandomCompat.chpl
+++ b/src/compat/eq-131/ArkoudaRandomCompat.chpl
@@ -2,14 +2,20 @@ module ArkoudaRandomCompat {
   use Random.PCGRandom only PCGRandomStream;
   record randomStream {
     type eltType = int;
-    forwarding var r: owned PCGRandomStream(eltType);
+    forwarding var r: shared PCGRandomStream(eltType);
     proc init(type t) {
       eltType = t;
-      r = new owned PCGRandomStream(eltType);
+      r = new shared PCGRandomStream(eltType);
     }
     proc init(type t, seed) {
       eltType = t;
-      r = new owned PCGRandomStream(eltType, seed);
+      r = new shared PCGRandomStream(eltType, seed);
+    }
+    proc ref fill(ref arr: []) where arr.isRectangular() {
+      r.fillRandom(arr);
+    }
+    proc ref fill(ref arr: [], min: arr.eltType, max: arr.eltType) where arr.isRectangular() {
+      r.fillRandom(arr, min, max);
     }
   }
 

--- a/src/compat/eq-133/ArkoudaRandomCompat.chpl
+++ b/src/compat/eq-133/ArkoudaRandomCompat.chpl
@@ -1,5 +1,5 @@
 module ArkoudaRandomCompat {
-  use Random;
+  public use Random;
   proc sample(arr: [?d] ?t, n: int, withReplacement: bool): [] t throws {
     var r = new randomStream(int);
     return r.choice(arr, size=n, replace=withReplacement);

--- a/src/compat/ge-20/ArkoudaRandomCompat.chpl
+++ b/src/compat/ge-20/ArkoudaRandomCompat.chpl
@@ -1,2 +1,3 @@
 module ArkoudaRandomCompat {
+  public use Random;
 }

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -52,49 +52,6 @@ class RandomTest(ArkoudaTest):
     def test_uniform(self):
         # verify same seed gives different but reproducible arrays
         rng = ak.random.default_rng(18)
-        first = rng.integers(-(2**32), 2**32, 10)
-        second = rng.integers(-(2**32), 2**32, 10)
-        self.assertNotEqual(first.to_list(), second.to_list())
-
-        rng = ak.random.default_rng(18)
-        same_seed_first = rng.integers(-(2**32), 2**32, 10)
-        same_seed_second = rng.integers(-(2**32), 2**32, 10)
-        self.assertEqual(first.to_list(), same_seed_first.to_list())
-        self.assertEqual(second.to_list(), same_seed_second.to_list())
-
-        # test endpoint
-        rng = ak.random.default_rng()
-        all_zero = rng.integers(0, 1, 20)
-        self.assertTrue(all(all_zero.to_ndarray() == 0))
-
-        not_all_zero = rng.integers(0, 1, 20, endpoint=True)
-        self.assertTrue(any(not_all_zero.to_ndarray() != 0))
-
-        # verify that switching dtype and function from seed is still reproducible
-        rng = ak.random.default_rng(74)
-        uint_arr = rng.integers(2**32, size=10, dtype="uint")
-        float_arr = rng.uniform(-1.0, 1.0, size=5)
-        bool_arr = rng.integers(0, 1, size=20, dtype="int")
-        int_arr = rng.integers(-(2**32), 2**32, size=10, dtype="int")
-
-        rng = ak.random.default_rng(74)
-        same_seed_uint_arr = rng.integers(2**32, size=10, dtype="uint")
-        same_seed_float_arr = rng.uniform(-1.0, 1.0, size=5)
-        same_seed_bool_arr = rng.integers(0, 1, size=20, dtype="int")
-        same_seed_int_arr = rng.integers(-(2**32), 2**32, size=10, dtype="int")
-
-        self.assertEqual(uint_arr.to_list(), same_seed_uint_arr.to_list())
-        self.assertEqual(float_arr.to_list(), same_seed_float_arr.to_list())
-        self.assertEqual(bool_arr.to_list(), same_seed_bool_arr.to_list())
-        self.assertEqual(int_arr.to_list(), same_seed_int_arr.to_list())
-
-        # verify within bounds (lower inclusive and upper exclusive)
-        rng = ak.random.default_rng()
-        bounded_arr = rng.integers(-5, 5, 1000)
-        self.assertTrue(all(bounded_arr.to_ndarray() >= -5))
-        self.assertTrue(all(bounded_arr.to_ndarray() < 5))
-        # verify same seed gives different but reproducible arrays
-        rng = ak.random.default_rng(18)
         first = rng.uniform(-(2**32), 2**32, 10)
         second = rng.uniform(-(2**32), 2**32, 10)
         self.assertNotEqual(first.to_list(), second.to_list())

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -1,0 +1,286 @@
+import numpy as np
+from base_test import ArkoudaTest
+from context import arkouda as ak
+
+
+class RandomTest(ArkoudaTest):
+    def test_integers(self):
+        # verify same seed gives different but reproducible arrays
+        rng = ak.random.default_rng(18)
+        first = rng.integers(-(2**32), 2**32, 10)
+        second = rng.integers(-(2**32), 2**32, 10)
+        self.assertNotEqual(first.to_list(), second.to_list())
+
+        rng = ak.random.default_rng(18)
+        same_seed_first = rng.integers(-(2**32), 2**32, 10)
+        same_seed_second = rng.integers(-(2**32), 2**32, 10)
+        self.assertEqual(first.to_list(), same_seed_first.to_list())
+        self.assertEqual(second.to_list(), same_seed_second.to_list())
+
+        # test endpoint
+        rng = ak.random.default_rng()
+        all_zero = rng.integers(0, 1, 20)
+        self.assertTrue(all(all_zero.to_ndarray() == 0))
+
+        not_all_zero = rng.integers(0, 1, 20, endpoint=True)
+        self.assertTrue(any(not_all_zero.to_ndarray() != 0))
+
+        # verify that switching dtype and function from seed is still reproducible
+        rng = ak.random.default_rng(74)
+        uint_arr = rng.integers(0, 2**32, size=10, dtype="uint")
+        float_arr = rng.uniform(-1.0, 1.0, size=5)
+        bool_arr = rng.integers(0, 1, size=20, dtype="bool")
+        int_arr = rng.integers(-(2**32), 2**32, size=10, dtype="int")
+
+        rng = ak.random.default_rng(74)
+        same_seed_uint_arr = rng.integers(0, 2**32, size=10, dtype="uint")
+        same_seed_float_arr = rng.uniform(-1.0, 1.0, size=5)
+        same_seed_bool_arr = rng.integers(0, 1, size=20, dtype="bool")
+        same_seed_int_arr = rng.integers(-(2**32), 2**32, size=10, dtype="int")
+
+        self.assertEqual(uint_arr.to_list(), same_seed_uint_arr.to_list())
+        self.assertEqual(float_arr.to_list(), same_seed_float_arr.to_list())
+        self.assertEqual(bool_arr.to_list(), same_seed_bool_arr.to_list())
+        self.assertEqual(int_arr.to_list(), same_seed_int_arr.to_list())
+
+        # verify within bounds (lower inclusive and upper exclusive)
+        rng = ak.random.default_rng()
+        bounded_arr = rng.integers(-5, 5, 1000)
+        self.assertTrue(all(bounded_arr.to_ndarray() >= -5))
+        self.assertTrue(all(bounded_arr.to_ndarray() < 5))
+
+    def test_uniform(self):
+        # verify same seed gives different but reproducible arrays
+        rng = ak.random.default_rng(18)
+        first = rng.integers(-(2**32), 2**32, 10)
+        second = rng.integers(-(2**32), 2**32, 10)
+        self.assertNotEqual(first.to_list(), second.to_list())
+
+        rng = ak.random.default_rng(18)
+        same_seed_first = rng.integers(-(2**32), 2**32, 10)
+        same_seed_second = rng.integers(-(2**32), 2**32, 10)
+        self.assertEqual(first.to_list(), same_seed_first.to_list())
+        self.assertEqual(second.to_list(), same_seed_second.to_list())
+
+        # test endpoint
+        rng = ak.random.default_rng()
+        all_zero = rng.integers(0, 1, 20)
+        self.assertTrue(all(all_zero.to_ndarray() == 0))
+
+        not_all_zero = rng.integers(0, 1, 20, endpoint=True)
+        self.assertTrue(any(not_all_zero.to_ndarray() != 0))
+
+        # verify that switching dtype and function from seed is still reproducible
+        rng = ak.random.default_rng(74)
+        uint_arr = rng.integers(2**32, size=10, dtype="uint")
+        float_arr = rng.uniform(-1.0, 1.0, size=5)
+        bool_arr = rng.integers(0, 1, size=20, dtype="int")
+        int_arr = rng.integers(-(2**32), 2**32, size=10, dtype="int")
+
+        rng = ak.random.default_rng(74)
+        same_seed_uint_arr = rng.integers(2**32, size=10, dtype="uint")
+        same_seed_float_arr = rng.uniform(-1.0, 1.0, size=5)
+        same_seed_bool_arr = rng.integers(0, 1, size=20, dtype="int")
+        same_seed_int_arr = rng.integers(-(2**32), 2**32, size=10, dtype="int")
+
+        self.assertEqual(uint_arr.to_list(), same_seed_uint_arr.to_list())
+        self.assertEqual(float_arr.to_list(), same_seed_float_arr.to_list())
+        self.assertEqual(bool_arr.to_list(), same_seed_bool_arr.to_list())
+        self.assertEqual(int_arr.to_list(), same_seed_int_arr.to_list())
+
+        # verify within bounds (lower inclusive and upper exclusive)
+        rng = ak.random.default_rng()
+        bounded_arr = rng.integers(-5, 5, 1000)
+        self.assertTrue(all(bounded_arr.to_ndarray() >= -5))
+        self.assertTrue(all(bounded_arr.to_ndarray() < 5))
+        # verify same seed gives different but reproducible arrays
+        rng = ak.random.default_rng(18)
+        first = rng.uniform(-(2**32), 2**32, 10)
+        second = rng.uniform(-(2**32), 2**32, 10)
+        self.assertNotEqual(first.to_list(), second.to_list())
+
+        rng = ak.random.default_rng(18)
+        same_seed_first = rng.uniform(-(2**32), 2**32, 10)
+        same_seed_second = rng.uniform(-(2**32), 2**32, 10)
+        self.assertEqual(first.to_list(), same_seed_first.to_list())
+        self.assertEqual(second.to_list(), same_seed_second.to_list())
+
+        # verify within bounds (lower inclusive and upper exclusive)
+        rng = ak.random.default_rng()
+        bounded_arr = rng.uniform(-5, 5, 1000)
+        self.assertTrue(all(bounded_arr.to_ndarray() >= -5))
+        self.assertTrue(all(bounded_arr.to_ndarray() < 5))
+
+    def test_legacy_randint(self):
+        testArray = ak.random.randint(0, 10, 5)
+        self.assertIsInstance(testArray, ak.pdarray)
+        self.assertEqual(5, len(testArray))
+        self.assertEqual(ak.int64, testArray.dtype)
+        self.assertEqual([5], testArray.shape)
+
+        testArray = ak.random.randint(np.int64(0), np.int64(10), np.int64(5))
+        self.assertIsInstance(testArray, ak.pdarray)
+        self.assertEqual(5, len(testArray))
+        self.assertEqual(ak.int64, testArray.dtype)
+        self.assertEqual([5], testArray.shape)
+
+        testArray = ak.random.randint(np.float64(0), np.float64(10), np.int64(5))
+        self.assertIsInstance(testArray, ak.pdarray)
+        self.assertEqual(5, len(testArray))
+        self.assertEqual(ak.int64, testArray.dtype)
+        self.assertEqual([5], testArray.shape)
+
+        test_ndarray = testArray.to_ndarray()
+
+        for value in test_ndarray:
+            self.assertTrue(0 <= value <= 10)
+
+        test_array = ak.random.randint(0, 1, 3, dtype=ak.float64)
+        self.assertEqual(ak.float64, test_array.dtype)
+
+        test_array = ak.random.randint(0, 1, 5, dtype=ak.bool)
+        self.assertEqual(ak.bool, test_array.dtype)
+
+        test_ndarray = test_array.to_ndarray()
+
+        # test resolution of modulus overflow - issue #1174
+        test_array = ak.random.randint(-(2**63), 2**63 - 1, 10)
+        to_validate = np.full(10, -(2**63))
+        self.assertFalse((test_array.to_ndarray() == to_validate).all())
+
+        for value in test_ndarray:
+            self.assertTrue(value in [True, False])
+
+        with self.assertRaises(TypeError):
+            ak.random.randint(low=5)
+
+        with self.assertRaises(TypeError):
+            ak.random.randint(high=5)
+
+        with self.assertRaises(TypeError):
+            ak.random.randint()
+
+        with self.assertRaises(ValueError):
+            ak.random.randint(low=0, high=1, size=-1, dtype=ak.float64)
+
+        with self.assertRaises(ValueError):
+            ak.random.randint(low=1, high=0, size=1, dtype=ak.float64)
+
+        with self.assertRaises(TypeError):
+            ak.random.randint(0, 1, "1000")
+
+        with self.assertRaises(TypeError):
+            ak.random.randint("0", 1, 1000)
+
+        with self.assertRaises(TypeError):
+            ak.random.randint(0, "1", 1000)
+
+        # Test that int_scalars covers uint8, uint16, uint32
+        ak.random.randint(low=np.uint8(1), high=np.uint16(100), size=np.uint32(100))
+
+    def test_legacy_randint_with_seed(self):
+        values = ak.random.randint(1, 5, 10, seed=2)
+
+        self.assertListEqual([4, 3, 1, 3, 2, 4, 4, 2, 3, 4], values.to_list())
+
+        values = ak.random.randint(1, 5, 10, dtype=ak.float64, seed=2)
+        self.assertListEqual(
+            [
+                2.9160772326374946,
+                4.353429832157099,
+                4.5392023718621486,
+                4.4019932101126606,
+                3.3745324569952304,
+                1.1642002901528308,
+                4.4714086874555292,
+                3.7098921109084522,
+                4.5939589352472314,
+                4.0337935981006172,
+            ],
+            values.to_list(),
+        )
+
+        values = ak.random.randint(1, 5, 10, dtype=ak.bool, seed=2)
+        self.assertListEqual(
+            [False, True, True, True, True, False, True, True, True, True],
+            values.to_list(),
+        )
+
+        values = ak.random.randint(1, 5, 10, dtype=bool, seed=2)
+        self.assertListEqual(
+            [False, True, True, True, True, False, True, True, True, True],
+            values.to_list(),
+        )
+
+        # Test that int_scalars covers uint8, uint16, uint32
+        ak.random.randint(np.uint8(1), np.uint32(5), np.uint16(10), seed=np.uint8(2))
+
+    def test_legacy_uniform(self):
+        testArray = ak.random.uniform(3)
+        self.assertIsInstance(testArray, ak.pdarray)
+        self.assertEqual(ak.float64, testArray.dtype)
+        self.assertEqual([3], testArray.shape)
+
+        testArray = ak.random.uniform(np.int64(3))
+        self.assertIsInstance(testArray, ak.pdarray)
+        self.assertEqual(ak.float64, testArray.dtype)
+        self.assertEqual([3], testArray.shape)
+
+        uArray = ak.random.uniform(size=3, low=0, high=5, seed=0)
+        self.assertListEqual(
+            [0.30013431967121934, 0.47383036230759112, 1.0441791878997098],
+            uArray.to_list(),
+        )
+
+        uArray = ak.random.uniform(size=np.int64(3), low=np.int64(0), high=np.int64(5), seed=np.int64(0))
+        self.assertListEqual(
+            [0.30013431967121934, 0.47383036230759112, 1.0441791878997098],
+            uArray.to_list(),
+        )
+
+        with self.assertRaises(TypeError):
+            ak.random.uniform(low="0", high=5, size=100)
+
+        with self.assertRaises(TypeError):
+            ak.random.uniform(low=0, high="5", size=100)
+
+        with self.assertRaises(TypeError):
+            ak.random.uniform(low=0, high=5, size="100")
+
+        # Test that int_scalars covers uint8, uint16, uint32
+        ak.random.uniform(low=np.uint8(0), high=5, size=np.uint32(100))
+
+    def test_legacy_standard_normal(self):
+        pda = ak.random.standard_normal(100)
+        self.assertIsInstance(pda, ak.pdarray)
+        self.assertEqual(100, len(pda))
+        self.assertEqual(float, pda.dtype)
+
+        pda = ak.random.standard_normal(np.int64(100))
+        self.assertIsInstance(pda, ak.pdarray)
+        self.assertEqual(100, len(pda))
+        self.assertEqual(float, pda.dtype)
+
+        pda = ak.random.standard_normal(np.int64(100), np.int64(1))
+        self.assertIsInstance(pda, ak.pdarray)
+        self.assertEqual(100, len(pda))
+        self.assertEqual(float, pda.dtype)
+
+        npda = pda.to_ndarray()
+        pda = ak.random.standard_normal(np.int64(100), np.int64(1))
+
+        self.assertListEqual(npda.tolist(), pda.to_list())
+
+        with self.assertRaises(TypeError):
+            ak.random.standard_normal("100")
+
+        with self.assertRaises(TypeError):
+            ak.random.standard_normal(100.0)
+
+        with self.assertRaises(ValueError):
+            ak.random.standard_normal(-1)
+
+        # Test that int_scalars covers uint8, uint16, uint32
+        ak.random.standard_normal(np.uint8(100))
+        ak.random.standard_normal(np.uint16(100))
+        ak.random.standard_normal(np.uint32(100))


### PR DESCRIPTION
This PR (closes #3008) adds a generator sym entry to the symbol table. It also add a stateful uniform distribution. So repeated method calls won't return the same array with a set seed, but a new generator with the same seed will produce the same sequence of random arrays. It updates the methods which draw a from a uniform distribution to use the stateful variant

Example:
```python
>>> rng = ak.random.default_rng(74)

>>> rng.integers(0, 2**32, size=3, dtype="uint")
array([103369013 434448015 1372864948])

>>> rng.uniform(-1.0, 1.0, size=3)
array([-0.31903782753174481 0.35896419541356117 0.45980632831507906])

>>> rng.integers(0, 1, size=5, dtype="bool")
array([False True False True True])

>>> rng.integers(-(2**32), 2**32, size=3, dtype="int")
array([-83456679 -540246299 -3756329859])

# repeat
>>> rng = ak.random.default_rng(74)

>>> rng.integers(0, 2**32, size=3, dtype="uint")
array([103369013 434448015 1372864948])

>>> rng.uniform(-1.0, 1.0, size=3)
array([-0.31903782753174481 0.35896419541356117 0.45980632831507906])

>>> rng.integers(0, 1, size=5, dtype="bool")
array([False True False True True])

>>> rng.integers(-(2**32), 2**32, size=3, dtype="int")
array([-83456679 -540246299 -3756329859])
```

Its adds tests for this functionality. Note the tests for the legacy functions are copied over from the existing ones in `pdarraycreation`