### PR TITLE
Closes #2960 int version of memory_usage

### DIFF
--- a/PROTO_tests/tests/dataframe_test.py
+++ b/PROTO_tests/tests/dataframe_test.py
@@ -879,13 +879,13 @@ class TestDataFrame:
         assert test_df["col_B"].to_list() == [False, False]
 
     def test_corr(self):
-        df = ak.DataFrame({'col1': [1, 2], 'col2': [-1, -2]})
+        df = ak.DataFrame({"col1": [1, 2], "col2": [-1, -2]})
         corr = df.corr()
         pd_corr = df.to_pandas().corr()
         assert_frame_equal(corr.to_pandas(retain_index=True), pd_corr)
 
         for i in range(5):
-            df = ak.DataFrame({'col1': ak.randint(0, 10, 10), 'col2': ak.randint(0, 10, 10)})
+            df = ak.DataFrame({"col1": ak.randint(0, 10, 10), "col2": ak.randint(0, 10, 10)})
             corr = df.corr()
             pd_corr = df.to_pandas().corr()
             assert_frame_equal(corr.to_pandas(retain_index=True), pd_corr)
@@ -989,6 +989,31 @@ class TestDataFrame:
                     # from pandas.testing import assert_frame_equal
                     # assert_frame_equal(sorted_ak.to_pandas()[sorted_column_names],
                     # sorted_pd[sorted_column_names])
+
+    def test_memory_usage(self):
+        dtypes = [ak.int64, ak.float64, ak.bool]
+        data = dict([(str(t), ak.ones(5000, dtype=ak.int64).astype(t)) for t in dtypes])
+        df = ak.DataFrame(data)
+        ak_memory_usage = df.memory_usage()
+        pd_memory_usage = pd.Series(
+            [40000, 40000, 40000, 5000], index=["Index", "int64", "float64", "bool"]
+        )
+        assert_series_equal(ak_memory_usage.to_pandas(), pd_memory_usage)
+
+        assert df.memory_usage_info(unit="B") == "125000.00 B"
+        assert df.memory_usage_info(unit="KB") == "122.07 KB"
+        assert df.memory_usage_info(unit="MB") == "0.12 MB"
+        assert df.memory_usage_info(unit="GB") == "0.00 GB"
+
+        ak_memory_usage = df.memory_usage(index=False)
+        pd_memory_usage = pd.Series([40000, 40000, 5000], index=["int64", "float64", "bool"])
+        assert_series_equal(ak_memory_usage.to_pandas(), pd_memory_usage)
+
+        ak_memory_usage = df.memory_usage(unit="KB")
+        pd_memory_usage = pd.Series(
+            [39.0625, 39.0625, 39.0625, 4.88281], index=["Index", "int64", "float64", "bool"]
+        )
+        assert_series_equal(ak_memory_usage.to_pandas(), pd_memory_usage)
 
 
 def pda_to_str_helper(pda):

--- a/PROTO_tests/tests/dtypes_test.py
+++ b/PROTO_tests/tests/dtypes_test.py
@@ -72,6 +72,24 @@ class TestDTypes:
         assert "uint64" == dtypes.resolve_scalar_dtype(2**63 + 1)
         assert "bigint" == dtypes.resolve_scalar_dtype(2**64)
 
+    def test_nbytes(self):
+        from arkouda.dtypes import BigInt
+
+        a = ak.cast(ak.array([1, 2, 3]), dt="bigint")
+        assert a.nbytes == 3 * BigInt.itemsize
+
+        dtype_list = [
+            ak.dtypes.uint8,
+            ak.dtypes.uint64,
+            ak.dtypes.int64,
+            ak.dtypes.float64,
+            ak.dtypes.bool,
+        ]
+
+        for dt in dtype_list:
+            a = ak.array([1, 2, 3], dtype=dt)
+            assert a.nbytes == 3 * dt.itemsize
+
     def test_pdarrays_datatypes(self):
         assert dtypes.dtype("int64") == ak.array(np.arange(10)).dtype
         assert dtypes.dtype("uint64") == ak.array(np.arange(10), ak.uint64).dtype
@@ -176,8 +194,8 @@ class TestDTypes:
         ) == str(ak.int_scalars)
 
         assert (
-            "typing.Union[float, numpy.float64, numpy.float32, int, numpy.int8, numpy.int16, numpy.int32, "
-            + "numpy.int64, numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64]"
+            "typing.Union[float, numpy.float64, numpy.float32, int, numpy.int8, numpy.int16, "
+            + "numpy.int32, numpy.int64, numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64]"
         ) == str(ak.numeric_scalars)
 
         assert "typing.Union[str, numpy.str_]" == str(ak.str_scalars)

--- a/PROTO_tests/tests/dtypes_test.py
+++ b/PROTO_tests/tests/dtypes_test.py
@@ -72,11 +72,12 @@ class TestDTypes:
         assert "uint64" == dtypes.resolve_scalar_dtype(2**63 + 1)
         assert "bigint" == dtypes.resolve_scalar_dtype(2**64)
 
-    def test_nbytes(self):
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_nbytes(self, size):
         from arkouda.dtypes import BigInt
 
-        a = ak.cast(ak.array([1, 2, 3]), dt="bigint")
-        assert a.nbytes == 3 * BigInt.itemsize
+        a = ak.cast(ak.arange(size), dt="bigint")
+        assert a.nbytes == size * BigInt.itemsize
 
         dtype_list = [
             ak.dtypes.uint8,
@@ -87,8 +88,8 @@ class TestDTypes:
         ]
 
         for dt in dtype_list:
-            a = ak.array([1, 2, 3], dtype=dt)
-            assert a.nbytes == 3 * dt.itemsize
+            a = ak.array(ak.arange(size), dtype=dt)
+            assert a.nbytes == size * dt.itemsize
 
         a = ak.array(["a", "b", "c"])
         c = ak.Categorical(a)

--- a/PROTO_tests/tests/dtypes_test.py
+++ b/PROTO_tests/tests/dtypes_test.py
@@ -90,6 +90,10 @@ class TestDTypes:
             a = ak.array([1, 2, 3], dtype=dt)
             assert a.nbytes == 3 * dt.itemsize
 
+        a = ak.array(["a", "b", "c"])
+        c = ak.Categorical(a)
+        assert c.nbytes == 82
+
     def test_pdarrays_datatypes(self):
         assert dtypes.dtype("int64") == ak.array(np.arange(10)).dtype
         assert dtypes.dtype("uint64") == ak.array(np.arange(10), ak.uint64).dtype

--- a/PROTO_tests/tests/index_test.py
+++ b/PROTO_tests/tests/index_test.py
@@ -50,26 +50,26 @@ class TestIndex:
         with pytest.raises(ValueError):
             idx = ak.MultiIndex([ak.arange(size), ak.arange(size - 1)])
 
-    def test_memory_usage(self):
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_memory_usage(self, size):
         from arkouda.dtypes import BigInt
         from arkouda.index import Index, MultiIndex
 
         idx = Index(ak.cast(ak.array([1, 2, 3]), dt="bigint"))
         assert idx.memory_usage() == 3 * BigInt.itemsize
 
-        n = 2000
-        idx = Index(ak.cast(ak.arange(n), dt="int64"))
-        assert idx.memory_usage(unit="GB") == n * ak.dtypes.int64.itemsize / (1024 * 1024 * 1024)
-        assert idx.memory_usage(unit="MB") == n * ak.dtypes.int64.itemsize / (1024 * 1024)
-        assert idx.memory_usage(unit="KB") == n * ak.dtypes.int64.itemsize / (1024)
-        assert idx.memory_usage(unit="B") == n * ak.dtypes.int64.itemsize
+        idx = Index(ak.cast(ak.arange(size), dt="int64"))
+        assert idx.memory_usage(unit="GB") == size * ak.dtypes.int64.itemsize / (1024 * 1024 * 1024)
+        assert idx.memory_usage(unit="MB") == size * ak.dtypes.int64.itemsize / (1024 * 1024)
+        assert idx.memory_usage(unit="KB") == size * ak.dtypes.int64.itemsize / 1024
+        assert idx.memory_usage(unit="B") == size * ak.dtypes.int64.itemsize
 
-        midx = MultiIndex([ak.cast(ak.arange(n), dt="int64"), ak.cast(ak.arange(n), dt="int64")])
-        assert midx.memory_usage(unit="GB") == 2 * n * ak.dtypes.int64.itemsize / (1024 * 1024 * 1024)
+        midx = MultiIndex([ak.cast(ak.arange(size), dt="int64"), ak.cast(ak.arange(size), dt="int64")])
+        assert midx.memory_usage(unit="GB") == 2 * size * ak.dtypes.int64.itemsize / (1024 * 1024 * 1024)
 
-        assert midx.memory_usage(unit="MB") == 2 * n * ak.dtypes.int64.itemsize / (1024 * 1024)
-        assert midx.memory_usage(unit="KB") == 2 * n * ak.dtypes.int64.itemsize / (1024)
-        assert midx.memory_usage(unit="B") == 2 * n * ak.dtypes.int64.itemsize
+        assert midx.memory_usage(unit="MB") == 2 * size * ak.dtypes.int64.itemsize / (1024 * 1024)
+        assert midx.memory_usage(unit="KB") == 2 * size * ak.dtypes.int64.itemsize / 1024
+        assert midx.memory_usage(unit="B") == 2 * size * ak.dtypes.int64.itemsize
 
     def test_is_unique(self):
         i = ak.Index(ak.array([0, 1, 2]))

--- a/PROTO_tests/tests/index_test.py
+++ b/PROTO_tests/tests/index_test.py
@@ -50,6 +50,27 @@ class TestIndex:
         with pytest.raises(ValueError):
             idx = ak.MultiIndex([ak.arange(size), ak.arange(size - 1)])
 
+    def test_memory_usage(self):
+        from arkouda.dtypes import BigInt
+        from arkouda.index import Index, MultiIndex
+
+        idx = Index(ak.cast(ak.array([1, 2, 3]), dt="bigint"))
+        assert idx.memory_usage() == 3 * BigInt.itemsize
+
+        n = 2000
+        idx = Index(ak.cast(ak.arange(n), dt="int64"))
+        assert idx.memory_usage(unit="GB") == n * ak.dtypes.int64.itemsize / (1024 * 1024 * 1024)
+        assert idx.memory_usage(unit="MB") == n * ak.dtypes.int64.itemsize / (1024 * 1024)
+        assert idx.memory_usage(unit="KB") == n * ak.dtypes.int64.itemsize / (1024)
+        assert idx.memory_usage(unit="B") == n * ak.dtypes.int64.itemsize
+
+        midx = MultiIndex([ak.cast(ak.arange(n), dt="int64"), ak.cast(ak.arange(n), dt="int64")])
+        assert midx.memory_usage(unit="GB") == 2 * n * ak.dtypes.int64.itemsize / (1024 * 1024 * 1024)
+
+        assert midx.memory_usage(unit="MB") == 2 * n * ak.dtypes.int64.itemsize / (1024 * 1024)
+        assert midx.memory_usage(unit="KB") == 2 * n * ak.dtypes.int64.itemsize / (1024)
+        assert midx.memory_usage(unit="B") == 2 * n * ak.dtypes.int64.itemsize
+
     def test_is_unique(self):
         i = ak.Index(ak.array([0, 1, 2]))
         assert i.is_unique

--- a/PROTO_tests/tests/series_test.py
+++ b/PROTO_tests/tests/series_test.py
@@ -189,3 +189,20 @@ class TestSeries:
         g = df.groupby(["a", "b"])
         series = ak.Series(data=g.sum("c")["c"], index=g.sum("c").index)
         g.broadcast(series)
+
+    def test_memory_usage(self):
+        n = 2000
+        s = ak.Series(ak.arange(n))
+        assert s.memory_usage(unit="GB", index=False) == n * ak.dtypes.int64.itemsize / (
+            1024 * 1024 * 1024
+        )
+        assert s.memory_usage(unit="MB", index=False) == n * ak.dtypes.int64.itemsize / (1024 * 1024)
+        assert s.memory_usage(unit="KB", index=False) == n * ak.dtypes.int64.itemsize / 1024
+        assert s.memory_usage(unit="B", index=False) == n * ak.dtypes.int64.itemsize
+
+        assert s.memory_usage(unit="GB", index=True) == 2 * n * ak.dtypes.int64.itemsize / (
+            1024 * 1024 * 1024
+        )
+        assert s.memory_usage(unit="MB", index=True) == 2 * n * ak.dtypes.int64.itemsize / (1024 * 1024)
+        assert s.memory_usage(unit="KB", index=True) == 2 * n * ak.dtypes.int64.itemsize / 1024
+        assert s.memory_usage(unit="B", index=True) == 2 * n * ak.dtypes.int64.itemsize

--- a/PROTO_tests/tests/series_test.py
+++ b/PROTO_tests/tests/series_test.py
@@ -190,19 +190,21 @@ class TestSeries:
         series = ak.Series(data=g.sum("c")["c"], index=g.sum("c").index)
         g.broadcast(series)
 
-    def test_memory_usage(self):
-        n = 2000
-        s = ak.Series(ak.arange(n))
-        assert s.memory_usage(unit="GB", index=False) == n * ak.dtypes.int64.itemsize / (
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_memory_usage(self, size):
+        s = ak.Series(ak.arange(size))
+        assert s.memory_usage(unit="GB", index=False) == size * ak.dtypes.int64.itemsize / (
             1024 * 1024 * 1024
         )
-        assert s.memory_usage(unit="MB", index=False) == n * ak.dtypes.int64.itemsize / (1024 * 1024)
-        assert s.memory_usage(unit="KB", index=False) == n * ak.dtypes.int64.itemsize / 1024
-        assert s.memory_usage(unit="B", index=False) == n * ak.dtypes.int64.itemsize
+        assert s.memory_usage(unit="MB", index=False) == size * ak.dtypes.int64.itemsize / (1024 * 1024)
+        assert s.memory_usage(unit="KB", index=False) == size * ak.dtypes.int64.itemsize / 1024
+        assert s.memory_usage(unit="B", index=False) == size * ak.dtypes.int64.itemsize
 
-        assert s.memory_usage(unit="GB", index=True) == 2 * n * ak.dtypes.int64.itemsize / (
+        assert s.memory_usage(unit="GB", index=True) == 2 * size * ak.dtypes.int64.itemsize / (
             1024 * 1024 * 1024
         )
-        assert s.memory_usage(unit="MB", index=True) == 2 * n * ak.dtypes.int64.itemsize / (1024 * 1024)
-        assert s.memory_usage(unit="KB", index=True) == 2 * n * ak.dtypes.int64.itemsize / 1024
-        assert s.memory_usage(unit="B", index=True) == 2 * n * ak.dtypes.int64.itemsize
+        assert s.memory_usage(unit="MB", index=True) == 2 * size * ak.dtypes.int64.itemsize / (
+            1024 * 1024
+        )
+        assert s.memory_usage(unit="KB", index=True) == 2 * size * ak.dtypes.int64.itemsize / 1024
+        assert s.memory_usage(unit="B", index=True) == 2 * size * ak.dtypes.int64.itemsize

--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -138,6 +138,38 @@ class Categorical:
         self.dtype = str_
         self.registered_name: Optional[str] = None
 
+    @property
+    def nbytes(self):
+        """
+        The size of the Categorical in bytes.
+
+        Returns
+        -------
+        int
+            The size of the Categorical in bytes.
+
+        """
+        nbytes = 0
+        if self.categories is not None:
+            nbytes += self.categories.nbytes
+
+        if isinstance(self.codes, pdarray):
+            nbytes += self.codes.nbytes
+        elif isinstance(self.codes, akint64):
+            nbytes += 1
+
+        if isinstance(self.permutation, pdarray):
+            nbytes += self.permutation.nbytes
+        elif isinstance(self.permutation, akint64):
+            nbytes += 1
+
+        if isinstance(self.segments, pdarray):
+            nbytes += self.segments.nbytes
+        elif isinstance(self.segments, akint64):
+            nbytes += 1
+
+        return nbytes
+
     @classmethod
     @typechecked
     def from_codes(

--- a/arkouda/dtypes.py
+++ b/arkouda/dtypes.py
@@ -205,8 +205,9 @@ ARKOUDA_SUPPORTED_NUMBERS = (
 # TODO: bring supported data types into parity with all numpy dtypes
 # missing full support for: float32, int32, int16, int8, uint32, uint16, complex64, complex128
 # ARKOUDA_SUPPORTED_DTYPES = frozenset([member.value for _, member in DType.__members__.items()])
-ARKOUDA_SUPPORTED_DTYPES = frozenset(["bool", "float", "float64", "int", "int64",
-                                      "uint", "uint64", "uint8", "bigint", "str"])
+ARKOUDA_SUPPORTED_DTYPES = frozenset(
+    ["bool", "float", "float64", "int", "int64", "uint", "uint64", "uint8", "bigint", "str"]
+)
 
 DTypes = frozenset([member.value for _, member in DType.__members__.items()])
 DTypeObjects = frozenset([bool, float, float64, int, int64, str, str_, uint8, uint64])

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -198,7 +198,7 @@ class Index:
 
         Parameters
         ----------
-        unit : str, default = "GB"
+        unit : str, default = "B"
             Unit to return. One of {'B', 'KB', 'MB', 'GB'}.
 
         Returns

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -192,6 +192,41 @@ class Index:
 
         return cls.factory(idx) if len(idx) > 1 else cls.factory(idx[0])
 
+    def memory_usage(self, unit="B"):
+        """
+        Return the memory usage of the Index values.
+
+        Parameters
+        ----------
+        unit : str, default = "GB"
+            Unit to return. One of {'B', 'KB', 'MB', 'GB'}.
+
+        Returns
+        -------
+        int
+            Bytes of memory consumed.
+
+        See Also
+        --------
+        arkouda.pdarrayclass.nbytes
+        arkouda.index.MultiIndex.memory_usage
+        arkouda.series.Series.memory_usage
+        arkouda.dataframe.DataFrame.memory_usage
+
+        Examples
+        --------
+
+        >>> import arkouda as ak
+        >>> ak.connect()
+        >>> idx = Index(ak.array([1, 2, 3]))
+        >>> idx.memory_usage()
+        24
+
+        """
+        from arkouda.util import convert_bytes
+
+        return convert_bytes(self.values.nbytes, unit=unit)
+
     def to_pandas(self):
         if isinstance(self.values, list):
             val = ndarray(self.values)
@@ -866,6 +901,45 @@ class MultiIndex(Index):
     @property
     def index(self):
         return self.values
+
+    def memory_usage(self, unit="B"):
+        """
+        Return the memory usage of the MultiIndex values.
+
+        Parameters
+        ----------
+        unit : str, default = "B"
+            Unit to return. One of {'B', 'KB', 'MB', 'GB'}.
+
+        Returns
+        -------
+        int
+            Bytes of memory consumed.
+
+        See Also
+        --------
+        arkouda.pdarrayclass.nbytes
+        arkouda.index.Index.memory_usage
+        arkouda.series.Series.memory_usage
+        arkouda.dataframe.DataFrame.memory_usage
+
+        Examples
+        --------
+
+        >>> import arkouda as ak
+        >>> ak.connect()
+        >>> m = ak.index.MultiIndex([ak.array([1,2,3]),ak.array([4,5,6])])
+        >>> m.memory_usage()
+        48
+
+        """
+        from arkouda.util import convert_bytes
+
+        nbytes = 0
+        for item in self.values:
+            nbytes += item.nbytes
+
+        return convert_bytes(nbytes, unit=unit)
 
     def to_pandas(self):
         idx = [convert_if_categorical(i) for i in self.index]

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -806,13 +806,13 @@ class pdarray:
                             k += int(self.shape[dim])
                         if k < 0 or k >= int(self.shape[dim]):
                             raise IndexError(
-                                f"index {k} is out of bounds in dimension" +
-                                f"{dim} with size {self.shape[dim]}"
+                                f"index {k} is out of bounds in dimension"
+                                + f"{dim} with size {self.shape[dim]}"
                             )
                         else:
                             # treat this as a single element slice
                             starts.append(k)
-                            stops.append(k+1)
+                            stops.append(k + 1)
                             strides.append(1)
 
                 if allScalar:
@@ -839,9 +839,20 @@ class pdarray:
                         },
                     )
             else:
-                raise TypeError(
-                    f"Unhandled key type for ND arrays: {key} ({type(key)})"
-                )
+                raise TypeError(f"Unhandled key type for ND arrays: {key} ({type(key)})")
+
+    @property
+    def nbytes(self):
+        """
+        The size of the pdarray in bytes.
+
+        Returns
+        -------
+        int
+            The size of the pdarray in bytes.
+
+        """
+        return self.size * self.dtype.itemsize
 
     @typechecked
     def fill(self, value: numeric_scalars) -> None:
@@ -2214,9 +2225,7 @@ def any(pda: pdarray) -> np.bool_:
         Raised if there's a server-side error thrown
     """
     return parse_single_value(
-        generic_msg(
-            cmd=f"reduce->bool{pda.ndim}D", args={"op": "any", "x": pda, "nAxes": 0, "axis": []}
-        )
+        generic_msg(cmd=f"reduce->bool{pda.ndim}D", args={"op": "any", "x": pda, "nAxes": 0, "axis": []})
     )
 
 
@@ -2243,9 +2252,7 @@ def all(pda: pdarray) -> np.bool_:
         Raised if there's a server-side error thrown
     """
     return parse_single_value(
-        generic_msg(
-            cmd=f"reduce->bool{pda.ndim}D", args={"op": "all", "x": pda, "nAxes": 0, "axis": []}
-        )
+        generic_msg(cmd=f"reduce->bool{pda.ndim}D", args={"op": "all", "x": pda, "nAxes": 0, "axis": []})
     )
 
 

--- a/arkouda/series.py
+++ b/arkouda/series.py
@@ -389,6 +389,59 @@ class Series:
             self.values[indices] = val
             return
 
+    def memory_usage(self, index: bool = True, unit="B") -> int:
+        """
+        Return the memory usage of the Series.
+
+        The memory usage can optionally include the contribution of
+        the index.
+
+        Parameters
+        ----------
+        index : bool, default True
+            Specifies whether to include the memory usage of the Series index.
+        unit : str, default = "B"
+            Unit to return. One of {'B', 'KB', 'MB', 'GB'}.
+
+        Returns
+        -------
+        int
+            Bytes of memory consumed.
+
+        See Also
+        --------
+        arkouda.pdarrayclass.nbytes
+        arkouda.index.Index.memory_usage
+        arkouda.series.Series.memory_usage
+        arkouda.dataframe.DataFrame.memory_usage
+
+        Examples
+        --------
+        >>> from arkouda.series import Series
+        >>> s = ak.Series(ak.arange(3))
+        >>> s.memory_usage()
+        48
+
+        Not including the index gives the size of the rest of the data, which
+        is necessarily smaller:
+
+        >>> s.memory_usage(index=False)
+        24
+
+        Select the units:
+
+        >>> s = ak.Series(ak.arange(3000))
+        >>> s.memory_usage(unit="KB")
+        46.875
+
+        """
+        from arkouda.util import convert_bytes
+
+        v = convert_bytes(self.values.nbytes, unit=unit)
+        if index:
+            v += self.index.memory_usage(unit=unit)
+        return v
+
     def has_repeat_labels(self) -> bool:
         """
         Returns whether the Series has any labels that appear more than once
@@ -650,6 +703,7 @@ class Series:
     def to_pandas(self) -> pd.Series:
         """Convert the series to a local PANDAS series"""
         import copy
+
         idx = self.index.to_pandas()
         val = convert_if_categorical(self.values)
 

--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -363,3 +363,30 @@ def broadcast_dims(sa: Sequence[int], sb: Sequence[int]) -> Tuple[int, ...]:
         i -= 1
 
     return tuple(shapeOut)
+
+
+def convert_bytes(nbytes, unit="B"):
+    """
+    Convert the number of bytes to KB, MB, or GB.
+
+    Parameters
+    ----------
+    unit : str, default = "B"
+        Unit to return. One of {'B', 'KB', 'MB', 'GB'}.
+
+    Returns
+    -------
+    int
+
+    """
+    kb = 1024
+    mb = kb * kb
+    gb = mb * kb
+    if unit == "B":
+        return nbytes
+    elif unit == "KB":
+        return nbytes / kb
+    elif unit == "MB":
+        return nbytes / mb
+    elif unit == "GB":
+        return nbytes / gb

--- a/tests/dtypes_tests.py
+++ b/tests/dtypes_tests.py
@@ -11,7 +11,6 @@ DtypesTest encapsulates arkouda dtypes module methods
 
 class DtypesTest(ArkoudaTest):
     def test_check_np_dtype(self):
-
         """
         Tests dtypes.check_np_dtype method
 
@@ -115,6 +114,24 @@ class DtypesTest(ArkoudaTest):
         self.assertEqual("int64", dtypes.resolve_scalar_dtype(np.int64(1)))
         self.assertEqual("<class 'list'>", dtypes.resolve_scalar_dtype([1]))
 
+    def test_nbytes(self):
+        from arkouda.dtypes import BigInt
+
+        a = ak.cast(ak.array([1, 2, 3]), dt="bigint")
+        self.assertEqual(a.nbytes, 3 * BigInt.itemsize)
+
+        dtype_list = [
+            ak.dtypes.uint8,
+            ak.dtypes.uint64,
+            ak.dtypes.int64,
+            ak.dtypes.float64,
+            ak.dtypes.bool,
+        ]
+
+        for dt in dtype_list:
+            a = ak.array([1, 2, 3], dtype=dt)
+            self.assertEqual(a.nbytes, 3 * dt.itemsize)
+
     def test_pdarrays_datatypes(self):
         self.assertEqual(dtypes.dtype("float64"), ak.ones(10).dtype)
         self.assertEqual(
@@ -168,20 +185,41 @@ class DtypesTest(ArkoudaTest):
         self.assertEqual("str", str(dtypes.DType.STR))
         self.assertEqual("bigint", str(dtypes.DType.BIGINT))
         self.assertEqual(
-            frozenset({"float32", "float64", "float", "complex64", "complex128", \
-                       "int8", "int16", "int32", "int64", "int", \
-                       "uint8", "uint16", "uint32", "uint64", "uint", \
-                        "bool", "str", "bigint"}),
-            ak.DTypes
+            frozenset(
+                {
+                    "float32",
+                    "float64",
+                    "float",
+                    "complex64",
+                    "complex128",
+                    "int8",
+                    "int16",
+                    "int32",
+                    "int64",
+                    "int",
+                    "uint8",
+                    "uint16",
+                    "uint32",
+                    "uint64",
+                    "uint",
+                    "bool",
+                    "str",
+                    "bigint",
+                }
+            ),
+            ak.DTypes,
         )
         self.assertEqual(
-            frozenset({"bool", "float", "float64", "int", "int64", "uint", "uint64", "uint8", "bigint", "str"}),
+            frozenset(
+                {"bool", "float", "float64", "int", "int64", "uint", "uint64", "uint8", "bigint", "str"}
+            ),
             ak.ARKOUDA_SUPPORTED_DTYPES,
         )
 
     def test_NumericDTypes(self):
         self.assertEqual(
-            frozenset(["bool", "float", "float64", "int", "int64", "uint64", "bigint"]), dtypes.NumericDTypes
+            frozenset(["bool", "float", "float64", "int", "int64", "uint64", "bigint"]),
+            dtypes.NumericDTypes,
         )
 
     def test_SeriesDTypes(self):
@@ -210,8 +248,8 @@ class DtypesTest(ArkoudaTest):
         )
         self.assertEqual(
             (
-                "typing.Union[float, numpy.float64, numpy.float32, int, numpy.int8, numpy.int16, numpy.int32, "
-                + "numpy.int64, numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64]"
+                "typing.Union[float, numpy.float64, numpy.float32, int, numpy.int8, numpy.int16, "
+                + "numpy.int32, numpy.int64, numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64]"
             ),
             str(ak.numeric_scalars),
         )

--- a/tests/dtypes_tests.py
+++ b/tests/dtypes_tests.py
@@ -132,6 +132,10 @@ class DtypesTest(ArkoudaTest):
             a = ak.array([1, 2, 3], dtype=dt)
             self.assertEqual(a.nbytes, 3 * dt.itemsize)
 
+        a = ak.array(["a", "b", "c"])
+        c = ak.Categorical(a)
+        self.assertEqual(c.nbytes, 82)
+
     def test_pdarrays_datatypes(self):
         self.assertEqual(dtypes.dtype("float64"), ak.ones(10).dtype)
         self.assertEqual(

--- a/tests/index_test.py
+++ b/tests/index_test.py
@@ -59,6 +59,30 @@ class IndexTest(ArkoudaTest):
         with self.assertRaises(ValueError):
             idx = ak.MultiIndex([ak.arange(5), ak.arange(3)])
 
+    def test_memory_usage(self):
+        from arkouda.dtypes import BigInt
+        from arkouda.index import Index, MultiIndex
+
+        idx = Index(ak.cast(ak.array([1, 2, 3]), dt="bigint"))
+        self.assertEqual(idx.memory_usage(), 3 * BigInt.itemsize)
+
+        n = 2000
+        idx = Index(ak.cast(ak.arange(n), dt="int64"))
+        self.assertEqual(
+            idx.memory_usage(unit="GB"), n * ak.dtypes.int64.itemsize / (1024 * 1024 * 1024)
+        )
+        self.assertEqual(idx.memory_usage(unit="MB"), n * ak.dtypes.int64.itemsize / (1024 * 1024))
+        self.assertEqual(idx.memory_usage(unit="KB"), n * ak.dtypes.int64.itemsize / (1024))
+        self.assertEqual(idx.memory_usage(unit="B"), n * ak.dtypes.int64.itemsize)
+
+        midx = MultiIndex([ak.cast(ak.arange(n), dt="int64"), ak.cast(ak.arange(n), dt="int64")])
+        self.assertEqual(
+            midx.memory_usage(unit="GB"), 2 * n * ak.dtypes.int64.itemsize / (1024 * 1024 * 1024)
+        )
+        self.assertEqual(midx.memory_usage(unit="MB"), 2 * n * ak.dtypes.int64.itemsize / (1024 * 1024))
+        self.assertEqual(midx.memory_usage(unit="KB"), 2 * n * ak.dtypes.int64.itemsize / (1024))
+        self.assertEqual(midx.memory_usage(unit="B"), 2 * n * ak.dtypes.int64.itemsize)
+
     def test_is_unique(self):
         i = ak.Index(ak.array([0, 1, 2]))
         self.assertTrue(i.is_unique)

--- a/tests/series_test.py
+++ b/tests/series_test.py
@@ -1,7 +1,7 @@
+import numpy as np
 import pandas as pd
 from base_test import ArkoudaTest
 from context import arkouda as ak
-import numpy as np
 
 
 class SeriesTest(ArkoudaTest):
@@ -497,12 +497,8 @@ class SeriesTest(ArkoudaTest):
         with self.assertRaises(ValueError):
             s1[["A", "Z"]] = 2.0
 
-        s2 = ak.Series(
-            index=ak.array(["A", "C", "DE", "F", "Z"]), data=ak.array(ints)
-        )
-        _s2 = pd.Series(
-            index=pd.array(["A", "C", "DE", "F", "Z"]), data=pd.array(ints)
-        )
+        s2 = ak.Series(index=ak.array(["A", "C", "DE", "F", "Z"]), data=ak.array(ints))
+        _s2 = pd.Series(index=pd.array(["A", "C", "DE", "F", "Z"]), data=pd.array(ints))
         s2[["A", "Z"]] = 2
         _s2[["A", "Z"]] = 2
         self.assertListEqual(s2.values.to_list(), _s2.values.tolist())
@@ -614,3 +610,25 @@ class SeriesTest(ArkoudaTest):
             _s1.iloc[[True, False, True]]
         with self.assertRaises(IndexError):
             s1.iloc[[True, False, True]]
+
+    def test_memory_usage(self):
+        n = 2000
+        s = ak.Series(ak.arange(n))
+        self.assertEqual(
+            s.memory_usage(unit="GB", index=False), n * ak.dtypes.int64.itemsize / (1024 * 1024 * 1024)
+        )
+        self.assertEqual(
+            s.memory_usage(unit="MB", index=False), n * ak.dtypes.int64.itemsize / (1024 * 1024)
+        )
+        self.assertEqual(s.memory_usage(unit="KB", index=False), n * ak.dtypes.int64.itemsize / 1024)
+        self.assertEqual(s.memory_usage(unit="B", index=False), n * ak.dtypes.int64.itemsize)
+
+        self.assertEqual(
+            s.memory_usage(unit="GB", index=True),
+            2 * n * ak.dtypes.int64.itemsize / (1024 * 1024 * 1024),
+        )
+        self.assertEqual(
+            s.memory_usage(unit="MB", index=True), 2 * n * ak.dtypes.int64.itemsize / (1024 * 1024)
+        )
+        self.assertEqual(s.memory_usage(unit="KB", index=True), 2 * n * ak.dtypes.int64.itemsize / 1024)
+        self.assertEqual(s.memory_usage(unit="B", index=True), 2 * n * ak.dtypes.int64.itemsize)


### PR DESCRIPTION
Closes #2960 int version of memory_usage

Creates the following new functions to characterize the memory usage of various objects:
pdarray.nbytes
Index.memory_usage
MultiIndex.memory_usage
Series.memory_usage
DataFrame.memory_usage
DataFrame.memory_usage_info