### PR TITLE
Remove I/O-locking and randomStream.skipTo deprecation messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -348,6 +348,10 @@ ifeq ($(shell expr $(CHPL_MINOR) \> 33),1)
 	ARKOUDA_RW_DEFAULT_FLAG := -sOpenReaderLockingDefault=false -sOpenWriterLockingDefault=false
 endif
 
+ifeq ($(shell expr $(CHPL_MAJOR) \= 2),1)
+	ARKOUDA_RW_DEFAULT_FLAG := -sOpenReaderLockingDefault=false -sOpenWriterLockingDefault=false
+endif
+
 SERVER_CONFIG_SCRIPT=$(ARKOUDA_SOURCE_DIR)/parseServerConfig.py
 # This is the main compilation statement section
 $(ARKOUDA_MAIN_MODULE): check-deps $(ARROW_O) $(ARKOUDA_SOURCES) $(ARKOUDA_MAKEFILES)

--- a/serverConfig.json
+++ b/serverConfig.json
@@ -1,5 +1,5 @@
 {
-    "max_array_dims": 1,
+    "max_array_dims": 3,
     "supported_scalar_types": {
         "uint8": true,
         "uint16": false,

--- a/serverConfig.json
+++ b/serverConfig.json
@@ -1,5 +1,5 @@
 {
-    "max_array_dims": 3,
+    "max_array_dims": 1,
     "supported_scalar_types": {
         "uint8": true,
         "uint16": false,

--- a/src/RandMsg.chpl
+++ b/src/RandMsg.chpl
@@ -200,7 +200,7 @@ module RandMsg
             var generator = if hasSeed then new randomStream(t, seed) else new randomStream(t);
             if state != 1 {
                 // you have to skip to one before where you want to be
-                generator.skipToNth(state-1);
+                generator.skipTo(state-1);
             }
             var entry = new shared GeneratorSymEntry(generator, state);
             var name = st.nextName();
@@ -253,7 +253,7 @@ module RandMsg
             ref rng = generatorEntry.generator;
             if state != 1 {
                 // you have to skip to one before where you want to be
-                rng.skipToNth(state-1);
+                rng.skipTo(state-1);
             }
             var uniformEntry = createSymEntry(size, t);
             if t != bool {

--- a/src/compat/e-132/ArkoudaRandomCompat.chpl
+++ b/src/compat/e-132/ArkoudaRandomCompat.chpl
@@ -17,6 +17,7 @@ module ArkoudaRandomCompat {
     proc ref fill(ref arr: [], min: arr.eltType, max: arr.eltType) where arr.isRectangular() {
       r.fillRandom(arr, min, max);
     }
+    proc skipTo(n: int) do r.skipToNth(n);
   }
 
   proc sample(arr: [?d] ?t, n: int, withReplacement: bool): [] t throws {

--- a/src/compat/e-132/ArkoudaRandomCompat.chpl
+++ b/src/compat/e-132/ArkoudaRandomCompat.chpl
@@ -17,7 +17,7 @@ module ArkoudaRandomCompat {
     proc ref fill(ref arr: [], min: arr.eltType, max: arr.eltType) where arr.isRectangular() {
       r.fillRandom(arr, min, max);
     }
-    proc skipTo(n: int) do r.skipToNth(n);
+    proc skipTo(n: int) do try! r.skipToNth(n);
   }
 
   proc sample(arr: [?d] ?t, n: int, withReplacement: bool): [] t throws {

--- a/src/compat/eq-131/ArkoudaRandomCompat.chpl
+++ b/src/compat/eq-131/ArkoudaRandomCompat.chpl
@@ -17,6 +17,7 @@ module ArkoudaRandomCompat {
     proc ref fill(ref arr: [], min: arr.eltType, max: arr.eltType) where arr.isRectangular() {
       r.fillRandom(arr, min, max);
     }
+    proc skipTo(n: int) do r.skipToNth(n);
   }
 
   proc sample(arr: [?d] ?t, n: int, withReplacement: bool): [] t throws {

--- a/src/compat/eq-131/ArkoudaRandomCompat.chpl
+++ b/src/compat/eq-131/ArkoudaRandomCompat.chpl
@@ -17,7 +17,7 @@ module ArkoudaRandomCompat {
     proc ref fill(ref arr: [], min: arr.eltType, max: arr.eltType) where arr.isRectangular() {
       r.fillRandom(arr, min, max);
     }
-    proc skipTo(n: int) do r.skipToNth(n);
+    proc skipTo(n: int) do try! r.skipToNth(n);
   }
 
   proc sample(arr: [?d] ?t, n: int, withReplacement: bool): [] t throws {

--- a/src/compat/eq-133/ArkoudaRandomCompat.chpl
+++ b/src/compat/eq-133/ArkoudaRandomCompat.chpl
@@ -4,5 +4,5 @@ module ArkoudaRandomCompat {
     var r = new randomStream(int);
     return r.choice(arr, size=n, replace=withReplacement);
   }
-  proc randomStream.skipTo(n: int) do this.skipToNth(n);
+  proc randomStream.skipTo(n: int) do try! this.skipToNth(n);
 }

--- a/src/compat/eq-133/ArkoudaRandomCompat.chpl
+++ b/src/compat/eq-133/ArkoudaRandomCompat.chpl
@@ -4,4 +4,5 @@ module ArkoudaRandomCompat {
     var r = new randomStream(int);
     return r.choice(arr, size=n, replace=withReplacement);
   }
+  proc randomStream.skipTo(n: int) do this.skipToNth(n);
 }


### PR DESCRIPTION
Make some updates to remove deprecation warnings introduced recently:

* openReader/openWriter `locking` default change (fixed in: [2987](https://github.com/Bears-R-Us/arkouda/pull/2987)), but coming back up when compiling with Chapel 2.0
  * added` -sOpenReaderLockingDefault=false -sOpenWriterLockingDefault=false` to the makefile for Chapel 2.0
* randomStream.skipTo (from recent improvements to randMsg)
  * added compatibility shims for older Chapel versions