### PR TITLE
Fixes #3035 - Inconsistent results when broadcasting with empty segments

### DIFF
--- a/src/Broadcast.chpl
+++ b/src/Broadcast.chpl
@@ -23,6 +23,10 @@ module Broadcast {
    * original array. Intended to be used with arkouda.GroupBy.
    */
   proc broadcast(perm: [?D] int, segs: [?sD] int, vals: [sD] ?t) throws {
+    if sD.size == 0 {
+      // early out if size 0
+      return makeDistArray(D.size, t);
+    }
     // The stragegy is to go from the segment domain to the full
     // domain by forming the full derivative and integrating it
     var keepSegs = makeDistArray(sD, bool);
@@ -112,6 +116,10 @@ module Broadcast {
    * original array. Intended to be used with arkouda.GroupBy.
    */
   proc broadcast(perm: [?D] int, segs: [?sD] int, vals: [sD] bool) throws {
+    if sD.size == 0 {
+      // early out if size 0
+      return makeDistArray(D.size, bool);
+    }
     // The stragegy is to go from the segment domain to the full
     // domain by forming the full derivative and integrating it    
     var keepSegs = makeDistArray(sD, bool);
@@ -229,6 +237,10 @@ module Broadcast {
    * vector such that each nonzero receives its row's value.
    */
   proc broadcast(segs: [?sD] int, vals: [sD] ?t, size: int) throws {
+    if sD.size == 0 {
+      // early out if size 0
+      return makeDistArray(size, t);
+    }
     // The stragegy is to go from the segment domain to the full
     // domain by forming the full derivative and integrating it
     var keepSegs = makeDistArray(sD, bool);
@@ -299,6 +311,10 @@ module Broadcast {
   }
 
   proc broadcast(segs: [?sD] int, vals: [sD] bool, size: int) throws {
+    if sD.size == 0 {
+      // early out if size 0
+      return makeDistArray(size, bool);
+    }
     // The stragegy is to go from the segment domain to the full
     // domain by forming the full derivative and integrating it
     var keepSegs = makeDistArray(sD, bool);


### PR DESCRIPTION
This PR (fixes #3035) a race condition bug that caused inconsistent results when broadcasting with empty segments (though both results given were incorrect).

We get around this by masking out the segments and values associated with the empty segments. We only do this when empty segments exist, so it shouldn't affect the performance of the common case too much but will give correct results in the empty seg case.

More details on bug in comment below