### PR TITLE
Closes #3002: Add `ak.clip` functionality

### DIFF
--- a/PROTO_tests/tests/numeric_test.py
+++ b/PROTO_tests/tests/numeric_test.py
@@ -609,91 +609,43 @@ class TestNumeric:
     @pytest.mark.parametrize("prob_size", pytest.prob_size)
     def test_clip(self, prob_size):
         ia = np.random.randint(1, 100, prob_size)
-    # test clip on ints, floats, and mash-ups; note if any input is float, output is float
         ilo = 25
         ihi = 75
 
-        # test with scalars
+        dtypes = ["int64","float64"]
 
-        dtypes = ["int64", "float64"]
+        # test clip.
+        # array to be clipped can be integer or float
+        # range limits can be integer, float, or none, and can be scalars or arrays
 
-        for dtype1 in dtypes:
-            for dtype2 in dtypes:
-                for dtype3 in dtypes:
-                    hi = np.dtype(dtype1).type(ihi)
-                    lo = np.dtype(dtype2).type(ilo)
+        # Looping over all data types, the interior loop tests using lo, hi as:
+
+        #   None, Scalar
+        #   None, Array
+        #   Scalar, Scalar
+        #   Scalar, Array
+        #   Scalar, None
+        #   Array, Scalar
+        #   Array, Array
+        #   Array, None
+
+        # There is no test with lo and hi both equal to None, because that's not allowed
+
+        for dtype1 in dtypes :
+            hi = np.full(ia.shape,ihi,dtype=dtype1)
+            akhi = ak.array(hi)
+            for dtype2 in dtypes :
+                lo = np.full(ia.shape,ilo,dtype=dtype2)
+                aklo = ak.array(lo)
+                for dtype3 in dtypes :
                     nd_arry = ia.astype(dtype3)
                     ak_arry = ak.array(nd_arry)
-                    assert np.allclose(np.clip(nd_arry, lo, hi), ak.clip(ak_arry, lo, hi).to_ndarray())
+                    assert np.allclose(np.clip(nd_arry,None,hi[0]),ak.clip(ak_arry, None, hi[0]).to_ndarray())
+                    assert np.allclose(np.clip(nd_arry,None,hi),ak.clip(ak_arry, None, akhi).to_ndarray())
+                    assert np.allclose(np.clip(nd_arry,lo[0],hi[0]),ak.clip(ak_arry, lo[0], hi[0]).to_ndarray())
+                    assert np.allclose(np.clip(nd_arry,lo[0],hi),ak.clip(ak_arry, lo[0], akhi).to_ndarray())
+                    assert np.allclose(np.clip(nd_arry,lo[0],None),ak.clip(ak_arry, lo[0], None).to_ndarray())
+                    assert np.allclose(np.clip(nd_arry,lo,hi[0]),ak.clip(ak_arry, aklo, hi[0]).to_ndarray())
+                    assert np.allclose(np.clip(nd_arry,lo,hi),ak.clip(ak_arry, aklo, akhi).to_ndarray())
+                    assert np.allclose(np.clip(nd_arry,lo,None),ak.clip(ak_arry, aklo, None).to_ndarray())
 
-        # test with None for lower limit
-
-        lo = None
-        for dtype1 in dtypes:
-            for dtype2 in dtypes:
-                for dtype3 in dtypes:
-                    hi = np.dtype(dtype1).type(ihi)
-                    nd_arry = ia.astype(dtype3)
-                    ak_arry = ak.array(nd_arry)
-                    assert np.allclose(np.clip(nd_arry, lo, hi), ak.clip(ak_arry, lo, hi).to_ndarray())
-
-        # test with None for upper limit
-
-        hi = None
-        for dtype1 in dtypes:
-            for dtype2 in dtypes:
-                for dtype3 in dtypes:
-                    lo = np.dtype(dtype2).type(ilo)
-                    nd_arry = ia.astype(dtype3)
-                    ak_arry = ak.array(nd_arry)
-                    assert np.allclose(np.clip(nd_arry, lo, hi), ak.clip(ak_arry, lo, hi).to_ndarray())
-
-        # test with arrays for lo
-
-        ilo = np.full(ia.shape, ilo)
-        for dtype1 in dtypes:
-            for dtype2 in dtypes:
-                for dtype3 in dtypes:
-                    hi = np.dtype(dtype1).type(ihi)
-                    nd_lo = ilo.astype(dtype2)
-                    nd_arry = ia.astype(dtype3)
-                    ak_lo = ak.array(nd_lo)
-                    ak_arry = ak.array(nd_arry)
-                    assert np.allclose(
-                        np.clip(nd_arry, nd_lo, hi),
-                        ak.clip(ak_arry, ak_lo, hi).to_ndarray(),
-                    )
-
-        # test with arrays for hi
-
-        ilo = 25
-        ihi = np.full(ia.shape, ihi)
-        for dtype1 in dtypes:
-            for dtype2 in dtypes:
-                for dtype3 in dtypes:
-                    lo = np.dtype(dtype2).type(ilo)
-                    nd_hi = ihi.astype(dtype1)
-                    nd_arry = ia.astype(dtype3)
-                    ak_hi = ak.array(nd_hi)
-                    ak_arry = ak.array(nd_arry)
-                    assert np.allclose(
-                        np.clip(nd_arry, lo, nd_hi),
-                        ak.clip(ak_arry, lo, ak_hi).to_ndarray(),
-                    )
-
-        # test with arrays for both
-
-        ilo = np.full(ia.shape, ilo)
-        for dtype1 in dtypes:
-            for dtype2 in dtypes:
-                for dtype3 in dtypes:
-                    nd_hi = ihi.astype(dtype1)
-                    nd_lo = ilo.astype(dtype2)
-                    nd_arry = ia.astype(dtype3)
-                    ak_lo = ak.array(nd_lo)
-                    ak_hi = ak.array(nd_hi)
-                    ak_arry = ak.array(nd_arry)
-                    assert np.allclose(
-                        np.clip(nd_arry, nd_lo, nd_hi),
-                        ak.clip(ak_arry, ak_lo, ak_hi).to_ndarray(),
-                    )

--- a/PROTO_tests/tests/numeric_test.py
+++ b/PROTO_tests/tests/numeric_test.py
@@ -3,8 +3,7 @@ import pytest
 import arkouda as ak
 from arkouda.dtypes import npstr
 
-#prob_size = 1000
-prob_size = 10
+prob_size = 1000
 NUMERIC_TYPES = [ak.int64, ak.float64, ak.bool, ak.uint64]
 NO_BOOL = [ak.int64, ak.float64, ak.uint64]
 NO_FLOAT = [ak.int64, ak.bool, ak.uint64]

--- a/PROTO_tests/tests/numeric_test.py
+++ b/PROTO_tests/tests/numeric_test.py
@@ -3,7 +3,8 @@ import pytest
 import arkouda as ak
 from arkouda.dtypes import npstr
 
-prob_size = 1000
+#prob_size = 1000
+prob_size = 10
 NUMERIC_TYPES = [ak.int64, ak.float64, ak.bool, ak.uint64]
 NO_BOOL = [ak.int64, ak.float64, ak.uint64]
 NO_FLOAT = [ak.int64, ak.bool, ak.uint64]
@@ -604,3 +605,96 @@ class TestNumeric:
         h3, h4 = ak.hash([bi])
         assert h1.to_list() == h3.to_list()
         assert h2.to_list() == h4.to_list()
+
+
+    @pytest.mark.parametrize("prob_size", pytest.prob_size)
+    def test_clip(self, prob_size):
+        ia = np.random.randint(1, 100, prob_size)
+    # test clip on ints, floats, and mash-ups; note if any input is float, output is float
+        ilo = 25
+        ihi = 75
+
+        # test with scalars
+
+        dtypes = ["int64", "float64"]
+
+        for dtype1 in dtypes:
+            for dtype2 in dtypes:
+                for dtype3 in dtypes:
+                    hi = np.dtype(dtype1).type(ihi)
+                    lo = np.dtype(dtype2).type(ilo)
+                    nd_arry = ia.astype(dtype3)
+                    ak_arry = ak.array(nd_arry)
+                    assert np.allclose(np.clip(nd_arry, lo, hi), ak.clip(ak_arry, lo, hi).to_ndarray())
+
+        # test with None for lower limit
+
+        lo = None
+        for dtype1 in dtypes:
+            for dtype2 in dtypes:
+                for dtype3 in dtypes:
+                    hi = np.dtype(dtype1).type(ihi)
+                    nd_arry = ia.astype(dtype3)
+                    ak_arry = ak.array(nd_arry)
+                    assert np.allclose(np.clip(nd_arry, lo, hi), ak.clip(ak_arry, lo, hi).to_ndarray())
+
+        # test with None for upper limit
+
+        hi = None
+        for dtype1 in dtypes:
+            for dtype2 in dtypes:
+                for dtype3 in dtypes:
+                    lo = np.dtype(dtype2).type(ilo)
+                    nd_arry = ia.astype(dtype3)
+                    ak_arry = ak.array(nd_arry)
+                    assert np.allclose(np.clip(nd_arry, lo, hi), ak.clip(ak_arry, lo, hi).to_ndarray())
+
+        # test with arrays for lo
+
+        ilo = np.full(ia.shape, ilo)
+        for dtype1 in dtypes:
+            for dtype2 in dtypes:
+                for dtype3 in dtypes:
+                    hi = np.dtype(dtype1).type(ihi)
+                    nd_lo = ilo.astype(dtype2)
+                    nd_arry = ia.astype(dtype3)
+                    ak_lo = ak.array(nd_lo)
+                    ak_arry = ak.array(nd_arry)
+                    assert np.allclose(
+                        np.clip(nd_arry, nd_lo, hi),
+                        ak.clip(ak_arry, ak_lo, hi).to_ndarray(),
+                    )
+
+        # test with arrays for hi
+
+        ilo = 25
+        ihi = np.full(ia.shape, ihi)
+        for dtype1 in dtypes:
+            for dtype2 in dtypes:
+                for dtype3 in dtypes:
+                    lo = np.dtype(dtype2).type(ilo)
+                    nd_hi = ihi.astype(dtype1)
+                    nd_arry = ia.astype(dtype3)
+                    ak_hi = ak.array(nd_hi)
+                    ak_arry = ak.array(nd_arry)
+                    assert np.allclose(
+                        np.clip(nd_arry, lo, nd_hi),
+                        ak.clip(ak_arry, lo, ak_hi).to_ndarray(),
+                    )
+
+        # test with arrays for both
+
+        ilo = np.full(ia.shape, ilo)
+        for dtype1 in dtypes:
+            for dtype2 in dtypes:
+                for dtype3 in dtypes:
+                    nd_hi = ihi.astype(dtype1)
+                    nd_lo = ilo.astype(dtype2)
+                    nd_arry = ia.astype(dtype3)
+                    ak_lo = ak.array(nd_lo)
+                    ak_hi = ak.array(nd_hi)
+                    ak_arry = ak.array(nd_arry)
+                    assert np.allclose(
+                        np.clip(nd_arry, nd_lo, nd_hi),
+                        ak.clip(ak_arry, ak_lo, ak_hi).to_ndarray(),
+                    )

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -2101,8 +2101,6 @@ def clip(
     pda1 = pda
     if lo is not None:
         pda1 = where(pda < lo, lo, pda)
-#    else:
-#        pda1 = pda[:]
     if hi is not None:
         pda1 = where(pda1 > hi, hi, pda1)
     return pda1

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -2098,10 +2098,11 @@ def clip(
 
     # Now do the clipping.
 
+    pda1 = pda
     if lo is not None:
         pda1 = where(pda < lo, lo, pda)
-    else:
-        pda1 = pda[:]
+#    else:
+#        pda1 = pda[:]
     if hi is not None:
         pda1 = where(pda1 > hi, hi, pda1)
     return pda1

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -1004,7 +1004,9 @@ def arctan2(
     TypeError
         Raised if the parameter is not a pdarray
     """
-    if not all(isSupportedNumber(arg) or isinstance(arg, pdarray) for arg in [num, denom]):
+    if not all(
+        isSupportedNumber(arg) or isinstance(arg, pdarray) for arg in [num, denom]
+    ):
         raise TypeError(
             f"Unsupported types {type(num)} and/or {type(denom)}. Supported "
             "types are numeric scalars and pdarrays. At least one argument must be a pdarray."
@@ -1225,7 +1227,9 @@ def arctanh(pda: pdarray, where: Union[bool, pdarray] = True) -> pdarray:
     return _trig_helper(pda, "arctanh", where)
 
 
-def _trig_helper(pda: pdarray, func: str, where: Union[bool, pdarray] = True) -> pdarray:
+def _trig_helper(
+    pda: pdarray, func: str, where: Union[bool, pdarray] = True
+) -> pdarray:
     """
     Returns the result of the input trig function acting element-wise on the array.
 
@@ -1363,7 +1367,11 @@ def _hash_helper(a):
 
     if isinstance(a, SegArray_):
         return json.dumps(
-            {"segments": a.segments.name, "values": a.values.name, "valObjType": a.values.objType}
+            {
+                "segments": a.segments.name,
+                "values": a.values.name,
+                "valObjType": a.values.objType,
+            }
         )
     elif isinstance(a, Categorical_):
         return json.dumps({"categories": a.categories.name, "codes": a.codes.name})
@@ -1437,7 +1445,10 @@ def hash(
         return _hash_single(pda, full) if isinstance(pda, pdarray) else pda.hash()
     elif isinstance(pda, List):
         if any(
-            wrong_type := [not isinstance(a, (pdarray, Strings, SegArray_, Categorical_)) for a in pda]
+            wrong_type := [
+                not isinstance(a, (pdarray, Strings, SegArray_, Categorical_))
+                for a in pda
+            ]
         ):
             raise TypeError(
                 f"Unsupported type {type(pda[np.argmin(wrong_type)])}. Supported types are pdarray,"
@@ -1519,16 +1530,22 @@ def _str_cat_where(
             new_categories = concatenate([A.categories, array([B])])
             b_code = A.codes.size + 1
         new_codes = where(condition, A.codes, b_code)
-        return Categorical.from_codes(new_codes, new_categories, NAvalue=A.NAvalue).reset_categories()
+        return Categorical.from_codes(
+            new_codes, new_categories, NAvalue=A.NAvalue
+        ).reset_categories()
 
     # both cat
     if isinstance(A, Categorical) and isinstance(B, Categorical):
         if A.codes.size != B.codes.size:
             raise TypeError("Categoricals must be same length")
-        if A.categories.size != B.categories.size or not ak_all(A.categories == B.categories):
+        if A.categories.size != B.categories.size or not ak_all(
+            A.categories == B.categories
+        ):
             A, B = A.standardize_categories([A, B])
         new_codes = where(condition, A.codes, B.codes)
-        return Categorical.from_codes(new_codes, A.categories, NAvalue=A.NAvalue).reset_categories()
+        return Categorical.from_codes(
+            new_codes, A.categories, NAvalue=A.NAvalue
+        ).reset_categories()
 
     # one strings and one str
     if isinstance(A, Strings) and isinstance(B, str):
@@ -1709,7 +1726,9 @@ def where(
             dt = dtA
         # Cannot safely cast
         else:
-            raise TypeError(f"Cannot cast between scalars {str(A)} and {str(B)} to supported dtype")
+            raise TypeError(
+                f"Cannot cast between scalars {str(A)} and {str(B)} to supported dtype"
+            )
         repMsg = generic_msg(
             cmd="efunc3ss",
             args={
@@ -1853,13 +1872,17 @@ def histogram2d(
         x_bins, y_bins = bins, bins
     else:
         if len(bins) != 2:
-            raise ValueError("Sequences of bins must contain two elements (num_x_bins, num_y_bins)")
+            raise ValueError(
+                "Sequences of bins must contain two elements (num_x_bins, num_y_bins)"
+            )
         x_bins, y_bins = bins
     if x_bins < 1 or y_bins < 1:
         raise ValueError("bins must be 1 or greater")
     x_bin_boundaries = linspace(x.min(), x.max(), x_bins + 1)
     y_bin_boundaries = linspace(y.min(), y.max(), y_bins + 1)
-    repMsg = generic_msg(cmd="histogram2D", args={"x": x, "y": y, "xBins": x_bins, "yBins": y_bins})
+    repMsg = generic_msg(
+        cmd="histogram2D", args={"x": x, "y": y, "xBins": x_bins, "yBins": y_bins}
+    )
     return (
         create_pdarray(type_cast(str, repMsg)).reshape(x_bins, y_bins),
         x_bin_boundaries,
@@ -1937,7 +1960,9 @@ def histogramdd(
         bins = [bins] * num_dims
     else:
         if len(bins) != num_dims:
-            raise ValueError("Sequences of bins must contain same number of elements as the sample")
+            raise ValueError(
+                "Sequences of bins must contain same number of elements as the sample"
+            )
     if any(b < 1 for b in bins):
         raise ValueError("bins must be 1 or greater")
 
@@ -2003,8 +2028,13 @@ def value_counts(
     """
     return GroupBy(pda).count()
 
-@typechecked 
-def clip (pda:pdarray,lo:Union[numeric_scalars,pdarray],hi:Union[numeric_scalars,pdarray]) -> pdarray :
+
+@typechecked
+def clip(
+    pda: pdarray,
+    lo: Union[numeric_scalars, pdarray],
+    hi: Union[numeric_scalars, pdarray],
+) -> pdarray:
     """
     Mimic the behavior of numpy.clip.
 
@@ -2036,23 +2066,39 @@ def clip (pda:pdarray,lo:Union[numeric_scalars,pdarray],hi:Union[numeric_scalars
 
     clip_min = True if type(lo) == pdarray else True if lo != None else False
     clip_max = True if type(hi) == pdarray else True if hi != None else False
-    if not (clip_min or clip_max) : raise ValueError ("Either min or max must be supplied.")
+    if not (clip_min or clip_max):
+        raise ValueError("Either min or max must be supplied.")
 
     # if any of the inputs are float, then make everything float
     # note that some type checking is needed, because scalars and pdarrays get cast differently
 
-    dataFloat = (pda.dtype==float)
-    minFloat = True if type(lo)==float else (True if (type(lo)==pdarray and lo.dtype==float) else False)
-    maxFloat = True if type(hi)==float else (True if (type(hi)==pdarray and hi.dtype==float) else False)
+    dataFloat = pda.dtype == float
+    minFloat = (
+        True
+        if type(lo) == float
+        else (True if (type(lo) == pdarray and lo.dtype == float) else False)
+    )
+    maxFloat = (
+        True
+        if type(hi) == float
+        else (True if (type(hi) == pdarray and hi.dtype == float) else False)
+    )
     forceFloat = dataFloat or minFloat or maxFloat
-    if forceFloat :
-        if not dataFloat : pda = cast(pda,np.float64)
-        if clip_min and not minFloat : lo = cast(lo,np.float64) if type(lo) == pdarray else float(lo)
-        if clip_max and not maxFloat : hi = cast(hi,np.float64) if type(hi) == pdarray else float(hi)
-    
+    if forceFloat:
+        if not dataFloat:
+            pda = cast(pda, np.float64)
+        if clip_min and not minFloat:
+#            lo = cast(lo, np.float64) if type(lo) == pdarray else float(lo)
+            lo = cast(lo, np.float64) if isinstance(lo,pdarray) else float(lo)
+        if clip_max and not maxFloat:
+#            hi = cast(hi, np.float64) if type(hi) == pdarray else float(hi)
+            hi = cast(hi, np.float64) if isinstance(hi,pdarray) else float(hi)
+
     # now do the computation.  The below mimics numpy.clip, including the anomaly where lo>hi
 
     pda1 = pda[:]
-    if clip_min : pda1 = where (pda1<lo,lo,pda1)
-    if clip_max : pda1 = where (pda1>hi,hi,pda1)
+    if clip_min:
+        pda1 = where(pda1 < lo, lo, pda1)
+    if clip_max:
+        pda1 = where(pda1 > hi, hi, pda1)
     return pda1

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -2088,11 +2088,9 @@ def clip(
         if not dataFloat:
             pda = cast(pda, np.float64)
         if clip_min and not minFloat:
-#            lo = cast(lo, np.float64) if type(lo) == pdarray else float(lo)
-            lo = cast(lo, np.float64) if isinstance(lo,pdarray) else float(lo)
+            lo = cast(lo, np.float64) if isinstance(lo, pdarray) else float(lo)
         if clip_max and not maxFloat:
-#            hi = cast(hi, np.float64) if type(hi) == pdarray else float(hi)
-            hi = cast(hi, np.float64) if isinstance(hi,pdarray) else float(hi)
+            hi = cast(hi, np.float64) if isinstance(hi, pdarray) else float(hi)
 
     # now do the computation.  The below mimics numpy.clip, including the anomaly where lo>hi
 

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -1004,7 +1004,9 @@ def arctan2(
     TypeError
         Raised if the parameter is not a pdarray
     """
-    if not all(isSupportedNumber(arg) or isinstance(arg, pdarray) for arg in [num, denom]):
+    if not all(
+        isSupportedNumber(arg) or isinstance(arg, pdarray) for arg in [num, denom]
+    ):
         raise TypeError(
             f"Unsupported types {type(num)} and/or {type(denom)}. Supported "
             "types are numeric scalars and pdarrays. At least one argument must be a pdarray."
@@ -1225,7 +1227,9 @@ def arctanh(pda: pdarray, where: Union[bool, pdarray] = True) -> pdarray:
     return _trig_helper(pda, "arctanh", where)
 
 
-def _trig_helper(pda: pdarray, func: str, where: Union[bool, pdarray] = True) -> pdarray:
+def _trig_helper(
+    pda: pdarray, func: str, where: Union[bool, pdarray] = True
+) -> pdarray:
     """
     Returns the result of the input trig function acting element-wise on the array.
 
@@ -1441,7 +1445,10 @@ def hash(
         return _hash_single(pda, full) if isinstance(pda, pdarray) else pda.hash()
     elif isinstance(pda, List):
         if any(
-            wrong_type := [not isinstance(a, (pdarray, Strings, SegArray_, Categorical_)) for a in pda]
+            wrong_type := [
+                not isinstance(a, (pdarray, Strings, SegArray_, Categorical_))
+                for a in pda
+            ]
         ):
             raise TypeError(
                 f"Unsupported type {type(pda[np.argmin(wrong_type)])}. Supported types are pdarray,"
@@ -1523,16 +1530,22 @@ def _str_cat_where(
             new_categories = concatenate([A.categories, array([B])])
             b_code = A.codes.size + 1
         new_codes = where(condition, A.codes, b_code)
-        return Categorical.from_codes(new_codes, new_categories, NAvalue=A.NAvalue).reset_categories()
+        return Categorical.from_codes(
+            new_codes, new_categories, NAvalue=A.NAvalue
+        ).reset_categories()
 
     # both cat
     if isinstance(A, Categorical) and isinstance(B, Categorical):
         if A.codes.size != B.codes.size:
             raise TypeError("Categoricals must be same length")
-        if A.categories.size != B.categories.size or not ak_all(A.categories == B.categories):
+        if A.categories.size != B.categories.size or not ak_all(
+            A.categories == B.categories
+        ):
             A, B = A.standardize_categories([A, B])
         new_codes = where(condition, A.codes, B.codes)
-        return Categorical.from_codes(new_codes, A.categories, NAvalue=A.NAvalue).reset_categories()
+        return Categorical.from_codes(
+            new_codes, A.categories, NAvalue=A.NAvalue
+        ).reset_categories()
 
     # one strings and one str
     if isinstance(A, Strings) and isinstance(B, str):
@@ -1713,7 +1726,9 @@ def where(
             dt = dtA
         # Cannot safely cast
         else:
-            raise TypeError(f"Cannot cast between scalars {str(A)} and {str(B)} to supported dtype")
+            raise TypeError(
+                f"Cannot cast between scalars {str(A)} and {str(B)} to supported dtype"
+            )
         repMsg = generic_msg(
             cmd="efunc3ss",
             args={
@@ -1857,13 +1872,17 @@ def histogram2d(
         x_bins, y_bins = bins, bins
     else:
         if len(bins) != 2:
-            raise ValueError("Sequences of bins must contain two elements (num_x_bins, num_y_bins)")
+            raise ValueError(
+                "Sequences of bins must contain two elements (num_x_bins, num_y_bins)"
+            )
         x_bins, y_bins = bins
     if x_bins < 1 or y_bins < 1:
         raise ValueError("bins must be 1 or greater")
     x_bin_boundaries = linspace(x.min(), x.max(), x_bins + 1)
     y_bin_boundaries = linspace(y.min(), y.max(), y_bins + 1)
-    repMsg = generic_msg(cmd="histogram2D", args={"x": x, "y": y, "xBins": x_bins, "yBins": y_bins})
+    repMsg = generic_msg(
+        cmd="histogram2D", args={"x": x, "y": y, "xBins": x_bins, "yBins": y_bins}
+    )
     return (
         create_pdarray(type_cast(str, repMsg)).reshape(x_bins, y_bins),
         x_bin_boundaries,
@@ -1941,7 +1960,9 @@ def histogramdd(
         bins = [bins] * num_dims
     else:
         if len(bins) != num_dims:
-            raise ValueError("Sequences of bins must contain same number of elements as the sample")
+            raise ValueError(
+                "Sequences of bins must contain same number of elements as the sample"
+            )
     if any(b < 1 for b in bins):
         raise ValueError("bins must be 1 or greater")
 

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -2064,8 +2064,8 @@ def clip(
 
     # see if lo or hi are None
 
-    clip_min = True if type(lo) == pdarray else True if lo != None else False
-    clip_max = True if type(hi) == pdarray else True if hi != None else False
+    clip_min = True if isinstance(lo, pdarray) else True if lo is not None else False
+    clip_max = True if isinstance(hi, pdarray) else True if hi is not None else False
     if not (clip_min or clip_max):
         raise ValueError("Either min or max must be supplied.")
 
@@ -2075,13 +2075,13 @@ def clip(
     dataFloat = pda.dtype == float
     minFloat = (
         True
-        if type(lo) == float
-        else (True if (type(lo) == pdarray and lo.dtype == float) else False)
+        if isinstance(lo, float)
+        else (True if (isinstance(lo, pdarray) and lo.dtype == float) else False)
     )
     maxFloat = (
         True
-        if type(hi) == float
-        else (True if (type(hi) == pdarray and hi.dtype == float) else False)
+        if isinstance(hi, float)
+        else (True if (isinstance(hi, pdarray) and hi.dtype == float) else False)
     )
     forceFloat = dataFloat or minFloat or maxFloat
     if forceFloat:

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -2044,7 +2044,7 @@ def clip(
                                                 or becomes lo if x < lo,
                                                 or becomes hi if x > hi.
 
-    Examples:
+    Examples
     --------
     >>> a = ak.array([1,2,3,4,5,6,7,8,9,10])
     >>> ak.clip(a,3,8)

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -38,10 +38,7 @@ class NumericTest(ArkoudaTest):
         )
         # Strings (uniformly distributed length)
         self.assertFalse(
-            (
-                ak.random_strings_uniform(1, 10, N)
-                == ak.random_strings_uniform(1, 10, N)
-            ).all()
+            (ak.random_strings_uniform(1, 10, N) == ak.random_strings_uniform(1, 10, N)).all()
         )
         self.assertListEqual(
             ak.random_strings_uniform(1, 10, N, seed=seed).to_list(),
@@ -49,10 +46,7 @@ class NumericTest(ArkoudaTest):
         )
         # Strings (log-normally distributed length)
         self.assertFalse(
-            (
-                ak.random_strings_lognormal(2, 1, N)
-                == ak.random_strings_lognormal(2, 1, N)
-            ).all()
+            (ak.random_strings_lognormal(2, 1, N) == ak.random_strings_lognormal(2, 1, N)).all()
         )
         self.assertListEqual(
             ak.random_strings_lognormal(2, 1, N, seed=seed).to_list(),
@@ -111,12 +105,8 @@ class NumericTest(ArkoudaTest):
         uintNAN = 0
         uintstr = ak.array(["1", "2 ", "3?", "-4", "  5", "45", "0b101", "0x30", "N/A"])
         uintans = np.array([1, 2, uintNAN, uintNAN, 5, 45, 0b101, 0x30, uintNAN])
-        floatstr = ak.array(
-            ["1.1", "2.2 ", "3?.3", "4.!4", "  5.5", "6.6e-6", "78.91E+4", "6", "N/A"]
-        )
-        floatans = np.array(
-            [1.1, 2.2, np.nan, np.nan, 5.5, 6.6e-6, 78.91e4, 6.0, np.nan]
-        )
+        floatstr = ak.array(["1.1", "2.2 ", "3?.3", "4.!4", "  5.5", "6.6e-6", "78.91E+4", "6", "N/A"])
+        floatans = np.array([1.1, 2.2, np.nan, np.nan, 5.5, 6.6e-6, 78.91e4, 6.0, np.nan])
         boolstr = ak.array(
             [
                 "True",
@@ -170,9 +160,7 @@ class NumericTest(ArkoudaTest):
 
         # test 2d histogram
         seed = 1
-        ak_x, ak_y = ak.randint(1, 100, 1000, seed=seed), ak.randint(
-            1, 100, 1000, seed=seed + 1
-        )
+        ak_x, ak_y = ak.randint(1, 100, 1000, seed=seed), ak.randint(1, 100, 1000, seed=seed + 1)
         np_x, np_y = ak_x.to_ndarray(), ak_y.to_ndarray()
         np_hist, np_x_edges, np_y_edges = np.histogram2d(np_x, np_y)
         ak_hist, ak_x_edges, ak_y_edges = ak.histogram2d(ak_x, ak_y)
@@ -219,9 +207,7 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
 
         self.assertTrue(np.allclose(np.abs(na), ak.abs(pda).to_ndarray()))
-        self.assertListEqual(
-            ak.arange(5, 1, -1).to_list(), ak.abs(ak.arange(-5, -1)).to_list()
-        )
+        self.assertListEqual(ak.arange(5, 1, -1).to_list(), ak.abs(ak.arange(-5, -1)).to_list())
         self.assertListEqual(
             [5, 4, 3, 2, 1],
             ak.abs(ak.linspace(-5, -1, 5)).to_list(),
@@ -243,12 +229,8 @@ class NumericTest(ArkoudaTest):
                 pda1 = ak.array(na1)
                 pda2 = ak.array(na2)
                 self.assertTrue(np.allclose(np.dot(na1, na2), ak.dot(pda1, pda2)))
-                self.assertTrue(
-                    np.allclose(np.dot(na1[0], na2), ak.dot(pda1[0], pda2).to_ndarray())
-                )
-                self.assertTrue(
-                    np.allclose(np.dot(na1, na2[0]), ak.dot(pda1, pda2[0]).to_ndarray())
-                )
+                self.assertTrue(np.allclose(np.dot(na1[0], na2), ak.dot(pda1[0], pda2).to_ndarray()))
+                self.assertTrue(np.allclose(np.dot(na1, na2[0]), ak.dot(pda1, pda2[0]).to_ndarray()))
 
     def testCumSum(self):
         na = np.linspace(1, 10)
@@ -278,9 +260,7 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(
-            np.allclose(np.sin(na, where=True), ak.sin(pda, where=True).to_ndarray())
-        )
+        self.assertTrue(np.allclose(np.sin(na, where=True), ak.sin(pda, where=True).to_ndarray()))
         self.assertTrue(np.allclose(na, ak.sin(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -293,9 +273,7 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(
-            np.allclose(np.sin(na, where=True), ak.sin(pda, where=True).to_ndarray())
-        )
+        self.assertTrue(np.allclose(np.sin(na, where=True), ak.sin(pda, where=True).to_ndarray()))
         self.assertTrue(np.allclose(na, ak.sin(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -308,9 +286,7 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(
-            np.allclose(np.sin(na, where=True), ak.sin(pda, where=True).to_ndarray())
-        )
+        self.assertTrue(np.allclose(np.sin(na, where=True), ak.sin(pda, where=True).to_ndarray()))
         self.assertTrue(np.allclose(na, ak.sin(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -327,9 +303,7 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(
-            np.allclose(np.cos(na, where=True), ak.cos(pda, where=True).to_ndarray())
-        )
+        self.assertTrue(np.allclose(np.cos(na, where=True), ak.cos(pda, where=True).to_ndarray()))
         self.assertTrue(np.allclose(na, ak.cos(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -342,9 +316,7 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(
-            np.allclose(np.cos(na, where=True), ak.cos(pda, where=True).to_ndarray())
-        )
+        self.assertTrue(np.allclose(np.cos(na, where=True), ak.cos(pda, where=True).to_ndarray()))
         self.assertTrue(np.allclose(na, ak.cos(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -357,9 +329,7 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(
-            np.allclose(np.cos(na, where=True), ak.cos(pda, where=True).to_ndarray())
-        )
+        self.assertTrue(np.allclose(np.cos(na, where=True), ak.cos(pda, where=True).to_ndarray()))
         self.assertTrue(np.allclose(na, ak.cos(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -376,9 +346,7 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(
-            np.allclose(np.tan(na, where=True), ak.tan(pda, where=True).to_ndarray())
-        )
+        self.assertTrue(np.allclose(np.tan(na, where=True), ak.tan(pda, where=True).to_ndarray()))
         self.assertTrue(np.allclose(na, ak.tan(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -391,9 +359,7 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(
-            np.allclose(np.tan(na, where=True), ak.tan(pda, where=True).to_ndarray())
-        )
+        self.assertTrue(np.allclose(np.tan(na, where=True), ak.tan(pda, where=True).to_ndarray()))
         self.assertTrue(np.allclose(na, ak.tan(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -406,9 +372,7 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(
-            np.allclose(np.tan(na, where=True), ak.tan(pda, where=True).to_ndarray())
-        )
+        self.assertTrue(np.allclose(np.tan(na, where=True), ak.tan(pda, where=True).to_ndarray()))
         self.assertTrue(np.allclose(na, ak.tan(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -425,11 +389,7 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(
-            np.allclose(
-                np.arcsin(na, where=True), ak.arcsin(pda, where=True).to_ndarray()
-            )
-        )
+        self.assertTrue(np.allclose(np.arcsin(na, where=True), ak.arcsin(pda, where=True).to_ndarray()))
         self.assertTrue(np.allclose(na, ak.arcsin(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -442,11 +402,7 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(
-            np.allclose(
-                np.arcsin(na, where=True), ak.arcsin(pda, where=True).to_ndarray()
-            )
-        )
+        self.assertTrue(np.allclose(np.arcsin(na, where=True), ak.arcsin(pda, where=True).to_ndarray()))
         self.assertTrue(np.allclose(na, ak.arcsin(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -459,11 +415,7 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(
-            np.allclose(
-                np.arcsin(na, where=True), ak.arcsin(pda, where=True).to_ndarray()
-            )
-        )
+        self.assertTrue(np.allclose(np.arcsin(na, where=True), ak.arcsin(pda, where=True).to_ndarray()))
         self.assertTrue(np.allclose(na, ak.arcsin(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -480,11 +432,7 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(
-            np.allclose(
-                np.arccos(na, where=True), ak.arccos(pda, where=True).to_ndarray()
-            )
-        )
+        self.assertTrue(np.allclose(np.arccos(na, where=True), ak.arccos(pda, where=True).to_ndarray()))
         self.assertTrue(np.allclose(na, ak.arccos(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -497,11 +445,7 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(
-            np.allclose(
-                np.arccos(na, where=True), ak.arccos(pda, where=True).to_ndarray()
-            )
-        )
+        self.assertTrue(np.allclose(np.arccos(na, where=True), ak.arccos(pda, where=True).to_ndarray()))
         self.assertTrue(np.allclose(na, ak.arccos(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -514,11 +458,7 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(
-            np.allclose(
-                np.arccos(na, where=True), ak.arccos(pda, where=True).to_ndarray()
-            )
-        )
+        self.assertTrue(np.allclose(np.arccos(na, where=True), ak.arccos(pda, where=True).to_ndarray()))
         self.assertTrue(np.allclose(na, ak.arccos(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -535,11 +475,7 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(
-            np.allclose(
-                np.arctan(na, where=True), ak.arctan(pda, where=True).to_ndarray()
-            )
-        )
+        self.assertTrue(np.allclose(np.arctan(na, where=True), ak.arctan(pda, where=True).to_ndarray()))
         self.assertTrue(np.allclose(na, ak.arctan(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -552,11 +488,7 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(
-            np.allclose(
-                np.arctan(na, where=True), ak.arctan(pda, where=True).to_ndarray()
-            )
-        )
+        self.assertTrue(np.allclose(np.arctan(na, where=True), ak.arctan(pda, where=True).to_ndarray()))
         self.assertTrue(np.allclose(na, ak.arctan(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -569,9 +501,7 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(
-            np.allclose(np.arctan(na), ak.arctan(pda, where=True).to_ndarray())
-        )
+        self.assertTrue(np.allclose(np.arctan(na), ak.arctan(pda, where=True).to_ndarray()))
         self.assertTrue(np.allclose(na, ak.arctan(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -586,9 +516,7 @@ class NumericTest(ArkoudaTest):
         # Edge case: infinities
         na = np.array([np.inf, -np.inf])
         pda = ak.array(na)
-        self.assertTrue(
-            np.allclose(np.arctan(na), ak.arctan(pda).to_ndarray(), equal_nan=True)
-        )
+        self.assertTrue(np.allclose(np.arctan(na), ak.arctan(pda).to_ndarray(), equal_nan=True))
 
     def testArctan2(self):
         na1_int = np.arange(10, 0, -1, dtype="int64")
@@ -614,11 +542,7 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(
                 [
-                    (
-                        np.arctan2(na1_int[i], na2_int[i])
-                        if truth_np[i]
-                        else na1_int[i] / na2_int[i]
-                    )
+                    (np.arctan2(na1_int[i], na2_int[i]) if truth_np[i] else na1_int[i] / na2_int[i])
                     for i in range(len(na1_int))
                 ],
                 ak.arctan2(pda1_int, pda2_int, where=truth_ak).to_ndarray(),
@@ -627,11 +551,7 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(
                 [
-                    (
-                        np.arctan2(na1_int[i], na2_uint[i])
-                        if truth_np[i]
-                        else na1_int[i] / na2_uint[i]
-                    )
+                    (np.arctan2(na1_int[i], na2_uint[i]) if truth_np[i] else na1_int[i] / na2_uint[i])
                     for i in range(len(na1_int))
                 ],
                 ak.arctan2(pda1_int, pda2_uint, where=truth_ak).to_ndarray(),
@@ -640,11 +560,7 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(
                 [
-                    (
-                        np.arctan2(na1_int[i], na2_float[i])
-                        if truth_np[i]
-                        else na1_int[i] / na2_float[i]
-                    )
+                    (np.arctan2(na1_int[i], na2_float[i]) if truth_np[i] else na1_int[i] / na2_float[i])
                     for i in range(len(na1_int))
                 ],
                 ak.arctan2(pda1_int, pda2_float, where=truth_ak).to_ndarray(),
@@ -654,11 +570,7 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(
                 [
-                    (
-                        np.arctan2(na1_uint[i], na2_int[i])
-                        if truth_np[i]
-                        else na1_uint[i] / na2_int[i]
-                    )
+                    (np.arctan2(na1_uint[i], na2_int[i]) if truth_np[i] else na1_uint[i] / na2_int[i])
                     for i in range(len(na1_uint))
                 ],
                 ak.arctan2(pda1_uint, pda2_int, where=truth_ak).to_ndarray(),
@@ -667,11 +579,7 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(
                 [
-                    (
-                        np.arctan2(na1_uint[i], na2_uint[i])
-                        if truth_np[i]
-                        else na1_uint[i] / na2_uint[i]
-                    )
+                    (np.arctan2(na1_uint[i], na2_uint[i]) if truth_np[i] else na1_uint[i] / na2_uint[i])
                     for i in range(len(na1_uint))
                 ],
                 ak.arctan2(pda1_uint, pda2_uint, where=truth_ak).to_ndarray(),
@@ -694,11 +602,7 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(
                 [
-                    (
-                        np.arctan2(na1_float[i], na2_int[i])
-                        if truth_np[i]
-                        else na1_float[i] / na2_int[i]
-                    )
+                    (np.arctan2(na1_float[i], na2_int[i]) if truth_np[i] else na1_float[i] / na2_int[i])
                     for i in range(len(na1_float))
                 ],
                 ak.arctan2(pda1_float, pda2_int, where=truth_ak).to_ndarray(),
@@ -749,11 +653,7 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(
                 [
-                    (
-                        np.arctan2(na1_int[i], denom[0])
-                        if truth_np[i]
-                        else na1_int[i] / denom[0]
-                    )
+                    (np.arctan2(na1_int[i], denom[0]) if truth_np[i] else na1_int[i] / denom[0])
                     for i in range(len(na1_int))
                 ],
                 ak.arctan2(pda1_int, denom[0], where=truth_ak).to_ndarray(),
@@ -781,11 +681,7 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(
                 [
-                    (
-                        np.arctan2(na1_uint[i], denom[0])
-                        if truth_np[i]
-                        else na1_uint[i] / denom[0]
-                    )
+                    (np.arctan2(na1_uint[i], denom[0]) if truth_np[i] else na1_uint[i] / denom[0])
                     for i in range(len(na1_uint))
                 ],
                 ak.arctan2(pda1_uint, denom[0], where=truth_ak).to_ndarray(),
@@ -813,11 +709,7 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(
                 [
-                    (
-                        np.arctan2(na1_float[i], denom[0])
-                        if truth_np[i]
-                        else na1_float[i] / denom[0]
-                    )
+                    (np.arctan2(na1_float[i], denom[0]) if truth_np[i] else na1_float[i] / denom[0])
                     for i in range(len(na1_float))
                 ],
                 ak.arctan2(pda1_float, denom[0], where=truth_ak).to_ndarray(),
@@ -874,11 +766,7 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(
                 [
-                    (
-                        np.arctan2(num[0], na2_int[i])
-                        if truth_np[i]
-                        else num[0] / na2_int[i]
-                    )
+                    (np.arctan2(num[0], na2_int[i]) if truth_np[i] else num[0] / na2_int[i])
                     for i in range(len(na1_uint))
                 ],
                 ak.arctan2(num[0], pda2_int, where=truth_ak).to_ndarray(),
@@ -887,11 +775,7 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(
                 [
-                    (
-                        np.arctan2(num[0], na2_uint[i])
-                        if truth_np[i]
-                        else num[0] / na2_uint[i]
-                    )
+                    (np.arctan2(num[0], na2_uint[i]) if truth_np[i] else num[0] / na2_uint[i])
                     for i in range(len(na1_uint))
                 ],
                 ak.arctan2(num[0], pda2_uint, where=truth_ak).to_ndarray(),
@@ -900,11 +784,7 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(
                 [
-                    (
-                        np.arctan2(num[0], na2_float[i])
-                        if truth_np[i]
-                        else num[0] / na2_float[i]
-                    )
+                    (np.arctan2(num[0], na2_float[i]) if truth_np[i] else num[0] / na2_float[i])
                     for i in range(len(na1_uint))
                 ],
                 ak.arctan2(num[0], pda2_float, where=truth_ak).to_ndarray(),
@@ -969,24 +849,16 @@ class NumericTest(ArkoudaTest):
             )
         )
         self.assertTrue(
-            np.allclose(
-                np.arctan2(na1, 5), ak.arctan2(pda1, 5).to_ndarray(), equal_nan=True
-            )
+            np.allclose(np.arctan2(na1, 5), ak.arctan2(pda1, 5).to_ndarray(), equal_nan=True)
         )
         self.assertTrue(
-            np.allclose(
-                np.arctan2(5, na1), ak.arctan2(5, pda1).to_ndarray(), equal_nan=True
-            )
+            np.allclose(np.arctan2(5, na1), ak.arctan2(5, pda1).to_ndarray(), equal_nan=True)
         )
         self.assertTrue(
-            np.allclose(
-                np.arctan2(na1, 0), ak.arctan2(pda1, 0).to_ndarray(), equal_nan=True
-            )
+            np.allclose(np.arctan2(na1, 0), ak.arctan2(pda1, 0).to_ndarray(), equal_nan=True)
         )
         self.assertTrue(
-            np.allclose(
-                np.arctan2(0, na1), ak.arctan2(0, pda1).to_ndarray(), equal_nan=True
-            )
+            np.allclose(np.arctan2(0, na1), ak.arctan2(0, pda1).to_ndarray(), equal_nan=True)
         )
 
     def testSinh(self):
@@ -994,9 +866,7 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(
-            np.allclose(np.sinh(na, where=True), ak.sinh(pda, where=True).to_ndarray())
-        )
+        self.assertTrue(np.allclose(np.sinh(na, where=True), ak.sinh(pda, where=True).to_ndarray()))
         self.assertTrue(np.allclose(na, ak.sinh(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -1009,9 +879,7 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(
-            np.allclose(np.sinh(na, where=True), ak.sinh(pda, where=True).to_ndarray())
-        )
+        self.assertTrue(np.allclose(np.sinh(na, where=True), ak.sinh(pda, where=True).to_ndarray()))
         self.assertTrue(np.allclose(na, ak.sinh(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -1024,9 +892,7 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(
-            np.allclose(np.sinh(na, where=True), ak.sinh(pda, where=True).to_ndarray())
-        )
+        self.assertTrue(np.allclose(np.sinh(na, where=True), ak.sinh(pda, where=True).to_ndarray()))
         self.assertTrue(np.allclose(na, ak.sinh(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -1041,18 +907,14 @@ class NumericTest(ArkoudaTest):
         # Edge case: infinities
         na = np.array([np.inf, -np.inf])
         pda = ak.array(na)
-        self.assertTrue(
-            np.allclose(np.sinh(na), ak.sinh(pda).to_ndarray(), equal_nan=True)
-        )
+        self.assertTrue(np.allclose(np.sinh(na), ak.sinh(pda).to_ndarray(), equal_nan=True))
 
     def testCosh(self):
         na = np.arange(-5, 5, dtype="int64")
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(
-            np.allclose(np.cosh(na, where=True), ak.cosh(pda, where=True).to_ndarray())
-        )
+        self.assertTrue(np.allclose(np.cosh(na, where=True), ak.cosh(pda, where=True).to_ndarray()))
         self.assertTrue(np.allclose(na, ak.cosh(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -1065,9 +927,7 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(
-            np.allclose(np.cosh(na, where=True), ak.cosh(pda, where=True).to_ndarray())
-        )
+        self.assertTrue(np.allclose(np.cosh(na, where=True), ak.cosh(pda, where=True).to_ndarray()))
         self.assertTrue(np.allclose(na, ak.cosh(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -1080,9 +940,7 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(
-            np.allclose(np.cosh(na, where=True), ak.cosh(pda, where=True).to_ndarray())
-        )
+        self.assertTrue(np.allclose(np.cosh(na, where=True), ak.cosh(pda, where=True).to_ndarray()))
         self.assertTrue(np.allclose(na, ak.cosh(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -1097,18 +955,14 @@ class NumericTest(ArkoudaTest):
         # Edge case: infinities
         na = np.array([np.inf, -np.inf])
         pda = ak.array(na)
-        self.assertTrue(
-            np.allclose(np.cosh(na), ak.cosh(pda).to_ndarray(), equal_nan=True)
-        )
+        self.assertTrue(np.allclose(np.cosh(na), ak.cosh(pda).to_ndarray(), equal_nan=True))
 
     def testTanh(self):
         na = np.arange(-5, 5, dtype="int64")
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(
-            np.allclose(np.tanh(na, where=True), ak.tanh(pda, where=True).to_ndarray())
-        )
+        self.assertTrue(np.allclose(np.tanh(na, where=True), ak.tanh(pda, where=True).to_ndarray()))
         self.assertTrue(np.allclose(na, ak.tanh(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -1121,9 +975,7 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(
-            np.allclose(np.tanh(na, where=True), ak.tanh(pda, where=True).to_ndarray())
-        )
+        self.assertTrue(np.allclose(np.tanh(na, where=True), ak.tanh(pda, where=True).to_ndarray()))
         self.assertTrue(np.allclose(na, ak.tanh(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -1136,9 +988,7 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(
-            np.allclose(np.tanh(na, where=True), ak.tanh(pda, where=True).to_ndarray())
-        )
+        self.assertTrue(np.allclose(np.tanh(na, where=True), ak.tanh(pda, where=True).to_ndarray()))
         self.assertTrue(np.allclose(na, ak.tanh(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -1153,9 +1003,7 @@ class NumericTest(ArkoudaTest):
         # Edge case: infinities
         na = np.array([np.inf, -np.inf])
         pda = ak.array(na)
-        self.assertTrue(
-            np.allclose(np.tanh(na), ak.tanh(pda).to_ndarray(), equal_nan=True)
-        )
+        self.assertTrue(np.allclose(np.tanh(na), ak.tanh(pda).to_ndarray(), equal_nan=True))
 
     def testArcsinh(self):
         na = np.arange(-5, 5, dtype="int64")
@@ -1163,9 +1011,7 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(
-                np.arcsinh(na, where=True), ak.arcsinh(pda, where=True).to_ndarray()
-            )
+            np.allclose(np.arcsinh(na, where=True), ak.arcsinh(pda, where=True).to_ndarray())
         )
         self.assertTrue(np.allclose(na, ak.arcsinh(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1180,9 +1026,7 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(
-                np.arcsinh(na, where=True), ak.arcsinh(pda, where=True).to_ndarray()
-            )
+            np.allclose(np.arcsinh(na, where=True), ak.arcsinh(pda, where=True).to_ndarray())
         )
         self.assertTrue(np.allclose(na, ak.arcsinh(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1197,9 +1041,7 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(
-                np.arcsinh(na, where=True), ak.arcsinh(pda, where=True).to_ndarray()
-            )
+            np.allclose(np.arcsinh(na, where=True), ak.arcsinh(pda, where=True).to_ndarray())
         )
         self.assertTrue(np.allclose(na, ak.arcsinh(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1215,9 +1057,7 @@ class NumericTest(ArkoudaTest):
         # Edge case: infinities
         na = np.array([np.inf, -np.inf])
         pda = ak.array(na)
-        self.assertTrue(
-            np.allclose(np.arcsinh(na), ak.arcsinh(pda).to_ndarray(), equal_nan=True)
-        )
+        self.assertTrue(np.allclose(np.arcsinh(na), ak.arcsinh(pda).to_ndarray(), equal_nan=True))
 
     def testArccosh(self):
         na = np.arange(1, 5, dtype="int64")
@@ -1225,9 +1065,7 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(
-                np.arccosh(na, where=True), ak.arccosh(pda, where=True).to_ndarray()
-            )
+            np.allclose(np.arccosh(na, where=True), ak.arccosh(pda, where=True).to_ndarray())
         )
         self.assertTrue(np.allclose(na, ak.arccosh(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1242,9 +1080,7 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(
-                np.arccosh(na, where=True), ak.arccosh(pda, where=True).to_ndarray()
-            )
+            np.allclose(np.arccosh(na, where=True), ak.arccosh(pda, where=True).to_ndarray())
         )
         self.assertTrue(np.allclose(na, ak.arccosh(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1259,9 +1095,7 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(
-                np.arccosh(na, where=True), ak.arccosh(pda, where=True).to_ndarray()
-            )
+            np.allclose(np.arccosh(na, where=True), ak.arccosh(pda, where=True).to_ndarray())
         )
         self.assertTrue(np.allclose(na, ak.arccosh(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1277,14 +1111,8 @@ class NumericTest(ArkoudaTest):
         # Edge case: infinities
         na = np.array([1, np.inf])
         pda = ak.array(na)
-        self.assertTrue(
-            np.allclose(
-                np.arccosh(na).tolist(), ak.arccosh(pda).to_list(), equal_nan=True
-            )
-        )
-        self.assertTrue(
-            np.allclose(np.arccosh(na), ak.arccosh(pda).to_ndarray(), equal_nan=True)
-        )
+        self.assertTrue(np.allclose(np.arccosh(na).tolist(), ak.arccosh(pda).to_list(), equal_nan=True))
+        self.assertTrue(np.allclose(np.arccosh(na), ak.arccosh(pda).to_ndarray(), equal_nan=True))
 
     def testArctanh(self):
         na = np.arange(-1, 2, dtype="int64")
@@ -1292,9 +1120,7 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(
-                np.arctanh(na, where=True), ak.arctanh(pda, where=True).to_ndarray()
-            )
+            np.allclose(np.arctanh(na, where=True), ak.arctanh(pda, where=True).to_ndarray())
         )
         self.assertTrue(np.allclose(na, ak.arctanh(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1309,9 +1135,7 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(
-                np.arctanh(na, where=True), ak.arctanh(pda, where=True).to_ndarray()
-            )
+            np.allclose(np.arctanh(na, where=True), ak.arctanh(pda, where=True).to_ndarray())
         )
         self.assertTrue(np.allclose(na, ak.arctanh(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1326,9 +1150,7 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(
-                np.arctanh(na, where=True), ak.arctanh(pda, where=True).to_ndarray()
-            )
+            np.allclose(np.arctanh(na, where=True), ak.arctanh(pda, where=True).to_ndarray())
         )
         self.assertTrue(np.allclose(na, ak.arctanh(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1347,9 +1169,7 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(
-                np.rad2deg(na, where=True), ak.rad2deg(pda, where=True).to_ndarray()
-            )
+            np.allclose(np.rad2deg(na, where=True), ak.rad2deg(pda, where=True).to_ndarray())
         )
         self.assertTrue(np.allclose(na, ak.rad2deg(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1364,9 +1184,7 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(
-                np.rad2deg(na, where=True), ak.rad2deg(pda, where=True).to_ndarray()
-            )
+            np.allclose(np.rad2deg(na, where=True), ak.rad2deg(pda, where=True).to_ndarray())
         )
         self.assertTrue(np.allclose(na, ak.rad2deg(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1381,9 +1199,7 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(
-                np.rad2deg(na, where=True), ak.rad2deg(pda, where=True).to_ndarray()
-            )
+            np.allclose(np.rad2deg(na, where=True), ak.rad2deg(pda, where=True).to_ndarray())
         )
         self.assertTrue(np.allclose(na, ak.rad2deg(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1402,9 +1218,7 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(
-                np.deg2rad(na, where=True), ak.deg2rad(pda, where=True).to_ndarray()
-            )
+            np.allclose(np.deg2rad(na, where=True), ak.deg2rad(pda, where=True).to_ndarray())
         )
         self.assertTrue(np.allclose(na, ak.deg2rad(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1419,9 +1233,7 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(
-                np.deg2rad(na, where=True), ak.deg2rad(pda, where=True).to_ndarray()
-            )
+            np.allclose(np.deg2rad(na, where=True), ak.deg2rad(pda, where=True).to_ndarray())
         )
         self.assertTrue(np.allclose(na, ak.deg2rad(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1436,9 +1248,7 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(
-                np.deg2rad(na, where=True), ak.deg2rad(pda, where=True).to_ndarray()
-            )
+            np.allclose(np.deg2rad(na, where=True), ak.deg2rad(pda, where=True).to_ndarray())
         )
         self.assertTrue(np.allclose(na, ak.deg2rad(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1529,9 +1339,7 @@ class NumericTest(ArkoudaTest):
         self.assertNotEqual(h2[0], h2[1])
 
         # test categorical hash
-        categories, codes = ak.array([f"str {i}" for i in range(3)]), ak.randint(
-            0, 3, 10**5
-        )
+        categories, codes = ak.array([f"str {i}" for i in range(3)]), ak.randint(0, 3, 10**5)
         my_cat = ak.Categorical.from_codes(codes=codes, categories=categories)
         h1, h2 = ak.hash(my_cat)
         rev = ak.arange(10**5)[::-1]
@@ -1583,9 +1391,7 @@ class NumericTest(ArkoudaTest):
 
         # Currently we can't make an int64 array with a NaN in it so verify that we throw an Exception
         ark_s_int64 = ak.array(np.array([1, 2, 3, 4], dtype="int64"))
-        with self.assertRaises(
-            RuntimeError, msg="Currently isnan on int64 is not supported"
-        ):
+        with self.assertRaises(RuntimeError, msg="Currently isnan on int64 is not supported"):
             ak.isnan(ark_s_int64)
 
     def test_str_cat_cast(self):
@@ -1593,9 +1399,7 @@ class NumericTest(ArkoudaTest):
             ak.array([f"str {i}" for i in range(101)]),
             ak.array([f"str {i%3}" for i in range(101)]),
         ]
-        for test_str, test_cat in zip(
-            test_strs, [ak.Categorical(s) for s in test_strs]
-        ):
+        for test_str, test_cat in zip(test_strs, [ak.Categorical(s) for s in test_strs]):
             cast_str = ak.cast(test_cat, ak.Strings)
             self.assertTrue((cast_str == test_str).all())
             cast_cat = ak.cast(test_str, ak.Categorical)
@@ -1629,7 +1433,7 @@ class NumericTest(ArkoudaTest):
 
         # test with scalars
 
-        dtypes = ['int64', 'float64']
+        dtypes = ["int64", "float64"]
 
         for dtype1 in dtypes:
             for dtype2 in dtypes:
@@ -1638,7 +1442,7 @@ class NumericTest(ArkoudaTest):
                     lo = np.dtype(dtype2).type(ilo)
                     nd_arry = ia.astype(dtype3)
                     ak_arry = ak.array(nd_arry)
-                    assert (np.allclose(np.clip(nd_arry, lo, hi), ak.clip(ak_arry, lo, hi).to_ndarray()))
+                    assert np.allclose(np.clip(nd_arry, lo, hi), ak.clip(ak_arry, lo, hi).to_ndarray())
 
         # test with None for lower limit
 
@@ -1649,7 +1453,7 @@ class NumericTest(ArkoudaTest):
                     hi = np.dtype(dtype1).type(ihi)
                     nd_arry = ia.astype(dtype3)
                     ak_arry = ak.array(nd_arry)
-                    assert (np.allclose(np.clip(nd_arry, lo, hi), ak.clip(ak_arry, lo, hi).to_ndarray()))
+                    assert np.allclose(np.clip(nd_arry, lo, hi), ak.clip(ak_arry, lo, hi).to_ndarray())
 
         # test with None for upper limit
 
@@ -1660,11 +1464,11 @@ class NumericTest(ArkoudaTest):
                     lo = np.dtype(dtype2).type(ilo)
                     nd_arry = ia.astype(dtype3)
                     ak_arry = ak.array(nd_arry)
-                    assert (np.allclose(np.clip(nd_arry, lo, hi), ak.clip(ak_arry, lo, hi).to_ndarray()))
+                    assert np.allclose(np.clip(nd_arry, lo, hi), ak.clip(ak_arry, lo, hi).to_ndarray())
 
         # test with arrays for lo
 
-        ilo = np.full(ia.shape,ilo)
+        ilo = np.full(ia.shape, ilo)
         for dtype1 in dtypes:
             for dtype2 in dtypes:
                 for dtype3 in dtypes:
@@ -1673,12 +1477,15 @@ class NumericTest(ArkoudaTest):
                     nd_arry = ia.astype(dtype3)
                     ak_lo = ak.array(nd_lo)
                     ak_arry = ak.array(nd_arry)
-                    assert (np.allclose(np.clip(nd_arry, nd_lo, hi), ak.clip(ak_arry, ak_lo, hi).to_ndarray()))
+                    assert np.allclose(
+                        np.clip(nd_arry, nd_lo, hi),
+                        ak.clip(ak_arry, ak_lo, hi).to_ndarray(),
+                    )
 
         # test with arrays for hi
 
         ilo = 25
-        ihi = np.full(ia.shape,ihi)
+        ihi = np.full(ia.shape, ihi)
         for dtype1 in dtypes:
             for dtype2 in dtypes:
                 for dtype3 in dtypes:
@@ -1687,11 +1494,14 @@ class NumericTest(ArkoudaTest):
                     nd_arry = ia.astype(dtype3)
                     ak_hi = ak.array(nd_hi)
                     ak_arry = ak.array(nd_arry)
-                    assert (np.allclose(np.clip(nd_arry, lo, nd_hi), ak.clip(ak_arry, lo, ak_hi).to_ndarray()))
+                    assert np.allclose(
+                        np.clip(nd_arry, lo, nd_hi),
+                        ak.clip(ak_arry, lo, ak_hi).to_ndarray(),
+                    )
 
-        # test with arrays for both 
+        # test with arrays for both
 
-        ilo = np.full(ia.shape,ilo)
+        ilo = np.full(ia.shape, ilo)
         for dtype1 in dtypes:
             for dtype2 in dtypes:
                 for dtype3 in dtypes:
@@ -1701,5 +1511,7 @@ class NumericTest(ArkoudaTest):
                     ak_lo = ak.array(nd_lo)
                     ak_hi = ak.array(nd_hi)
                     ak_arry = ak.array(nd_arry)
-                    assert (np.allclose(np.clip(nd_arry, nd_lo, nd_hi), ak.clip(ak_arry, ak_lo, ak_hi).to_ndarray()))
-
+                    assert np.allclose(
+                        np.clip(nd_arry, nd_lo, nd_hi),
+                        ak.clip(ak_arry, ak_lo, ak_hi).to_ndarray(),
+                    )

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -1431,87 +1431,63 @@ class NumericTest(ArkoudaTest):
         ilo = 25
         ihi = 75
 
-        # test with scalars
-
         dtypes = ["int64", "float64"]
 
-        for dtype1 in dtypes:
+        # test clip.
+        # array to be clipped can be integer or float
+        # range limits can be integer, float, or none, and can be scalars or arrays
+
+        # Looping over all data types, the interior loop tests using lo, hi as:
+
+        #   None, Scalar
+        #   None, Array
+        #   Scalar, Scalar
+        #   Scalar, Array
+        #   Scalar, None
+        #   Array, Scalar
+        #   Array, Array
+        #   Array, None
+
+        # There is no test with lo and hi both equal to None, because that's not allowed
+
+        for dtype3 in dtypes:
+            nd_arry = ia.astype(dtype3)
+            ak_arry = ak.array(nd_arry)
             for dtype2 in dtypes:
-                for dtype3 in dtypes:
-                    hi = np.dtype(dtype1).type(ihi)
-                    lo = np.dtype(dtype2).type(ilo)
-                    nd_arry = ia.astype(dtype3)
-                    ak_arry = ak.array(nd_arry)
-                    assert np.allclose(np.clip(nd_arry, lo, hi), ak.clip(ak_arry, lo, hi).to_ndarray())
-
-        # test with None for lower limit
-
-        lo = None
-        for dtype1 in dtypes:
-            for dtype2 in dtypes:
-                for dtype3 in dtypes:
-                    hi = np.dtype(dtype1).type(ihi)
-                    nd_arry = ia.astype(dtype3)
-                    ak_arry = ak.array(nd_arry)
-                    assert np.allclose(np.clip(nd_arry, lo, hi), ak.clip(ak_arry, lo, hi).to_ndarray())
-
-        # test with None for upper limit
-
-        hi = None
-        for dtype1 in dtypes:
-            for dtype2 in dtypes:
-                for dtype3 in dtypes:
-                    lo = np.dtype(dtype2).type(ilo)
-                    nd_arry = ia.astype(dtype3)
-                    ak_arry = ak.array(nd_arry)
-                    assert np.allclose(np.clip(nd_arry, lo, hi), ak.clip(ak_arry, lo, hi).to_ndarray())
-
-        # test with arrays for lo
-
-        ilo = np.full(ia.shape, ilo)
-        for dtype1 in dtypes:
-            for dtype2 in dtypes:
-                for dtype3 in dtypes:
-                    hi = np.dtype(dtype1).type(ihi)
-                    nd_lo = ilo.astype(dtype2)
-                    nd_arry = ia.astype(dtype3)
-                    ak_lo = ak.array(nd_lo)
-                    ak_arry = ak.array(nd_arry)
+                lo = np.full(ia.shape, ilo, dtype=dtype2)
+                aklo = ak.array(lo)
+                for dtype1 in dtypes:
+                    hi = np.full(ia.shape, ihi, dtype=dtype1)
+                    akhi = ak.array(hi)
                     assert np.allclose(
-                        np.clip(nd_arry, nd_lo, hi),
-                        ak.clip(ak_arry, ak_lo, hi).to_ndarray(),
+                        np.clip(nd_arry, None, hi[0]),
+                        ak.clip(ak_arry, None, hi[0]).to_ndarray(),
                     )
-
-        # test with arrays for hi
-
-        ilo = 25
-        ihi = np.full(ia.shape, ihi)
-        for dtype1 in dtypes:
-            for dtype2 in dtypes:
-                for dtype3 in dtypes:
-                    lo = np.dtype(dtype2).type(ilo)
-                    nd_hi = ihi.astype(dtype1)
-                    nd_arry = ia.astype(dtype3)
-                    ak_hi = ak.array(nd_hi)
-                    ak_arry = ak.array(nd_arry)
                     assert np.allclose(
-                        np.clip(nd_arry, lo, nd_hi),
-                        ak.clip(ak_arry, lo, ak_hi).to_ndarray(),
+                        np.clip(nd_arry, None, hi),
+                        ak.clip(ak_arry, None, akhi).to_ndarray(),
                     )
-
-        # test with arrays for both
-
-        ilo = np.full(ia.shape, ilo)
-        for dtype1 in dtypes:
-            for dtype2 in dtypes:
-                for dtype3 in dtypes:
-                    nd_hi = ihi.astype(dtype1)
-                    nd_lo = ilo.astype(dtype2)
-                    nd_arry = ia.astype(dtype3)
-                    ak_lo = ak.array(nd_lo)
-                    ak_hi = ak.array(nd_hi)
-                    ak_arry = ak.array(nd_arry)
                     assert np.allclose(
-                        np.clip(nd_arry, nd_lo, nd_hi),
-                        ak.clip(ak_arry, ak_lo, ak_hi).to_ndarray(),
+                        np.clip(nd_arry, lo[0], hi[0]),
+                        ak.clip(ak_arry, lo[0], hi[0]).to_ndarray(),
+                    )
+                    assert np.allclose(
+                        np.clip(nd_arry, lo[0], hi),
+                        ak.clip(ak_arry, lo[0], akhi).to_ndarray(),
+                    )
+                    assert np.allclose(
+                        np.clip(nd_arry, lo[0], None),
+                        ak.clip(ak_arry, lo[0], None).to_ndarray(),
+                    )
+                    assert np.allclose(
+                        np.clip(nd_arry, lo, hi[0]),
+                        ak.clip(ak_arry, aklo, hi[0]).to_ndarray(),
+                    )
+                    assert np.allclose(
+                        np.clip(nd_arry, lo, hi),
+                        ak.clip(ak_arry, aklo, akhi).to_ndarray(),
+                    )
+                    assert np.allclose(
+                        np.clip(nd_arry, lo, None),
+                        ak.clip(ak_arry, aklo, None).to_ndarray(),
                     )

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -1394,3 +1394,84 @@ class NumericTest(ArkoudaTest):
         _, floatmean = g.mean(floatval)
         ak_mse = ak.mean((intmean - floatmean) ** 2)
         self.assertTrue(np.isclose(ak_mse, 0.0))
+
+# test clip on ints, floats, and mash-ups; note if any input is float, output is float
+
+    def testClip(self) :
+        ia = np.random.randint(1,100,100)
+        ilo = 25
+        ihi = 75
+        fa = ia.astype(float)
+        flo = 25.0
+        fhi = 75.0
+        ipda = ak.array(ia)
+        fpda = ak.array(fa)
+
+        # test with scalars
+
+        self.assertTrue(np.all(np.equal(np.clip(ia,ilo,ihi),ak.clip(ipda,ilo,ihi).to_ndarray()))) # all ints
+        self.assertTrue(np.allclose(np.clip(fa,flo,fhi),ak.clip(fpda,flo,fhi).to_ndarray()))      # all floats
+        self.assertTrue(np.allclose(np.clip(ia,ilo,fhi),ak.clip(ipda,ilo,fhi).to_ndarray()))      # int array and lo, float hi
+        self.assertTrue(np.allclose(np.clip(ia,flo,ihi),ak.clip(ipda,flo,ihi).to_ndarray()))      # int array and hi, float lo
+        self.assertTrue(np.allclose(np.clip(fa,ilo,ihi),ak.clip(fpda,ilo,ihi).to_ndarray()))      # int lo and hi, float array
+
+        # test with None for lower limit
+
+        ilo = None
+        flo = None
+        self.assertTrue(np.all(np.equal(np.clip(ia,ilo,ihi),ak.clip(ipda,ilo,ihi).to_ndarray()))) # all ints
+        self.assertTrue(np.allclose(np.clip(fa,flo,fhi),ak.clip(fpda,flo,fhi).to_ndarray()))      # all floats
+        self.assertTrue(np.allclose(np.clip(ia,ilo,fhi),ak.clip(ipda,ilo,fhi).to_ndarray()))      # int array and lo, float hi
+        self.assertTrue(np.allclose(np.clip(ia,flo,ihi),ak.clip(ipda,flo,ihi).to_ndarray()))      # int array and hi, float lo
+        self.assertTrue(np.allclose(np.clip(fa,ilo,ihi),ak.clip(fpda,ilo,ihi).to_ndarray()))      # int lo and hi, float array
+
+        # test with None for upper limit
+
+        ilo = 25 
+        flo = float(ilo)
+        ihi = None
+        fhi = None
+        self.assertTrue(np.all(np.equal(np.clip(ia,ilo,ihi),ak.clip(ipda,ilo,ihi).to_ndarray()))) # all ints
+        self.assertTrue(np.allclose(np.clip(fa,flo,fhi),ak.clip(fpda,flo,fhi).to_ndarray()))      # all floats
+        self.assertTrue(np.allclose(np.clip(ia,ilo,fhi),ak.clip(ipda,ilo,fhi).to_ndarray()))      # int array and lo, float hi
+        self.assertTrue(np.allclose(np.clip(ia,flo,ihi),ak.clip(ipda,flo,ihi).to_ndarray()))      # int array and hi, float lo
+        self.assertTrue(np.allclose(np.clip(fa,ilo,ihi),ak.clip(fpda,ilo,ihi).to_ndarray()))      # int lo and hi, float array
+
+        # test with arrays for lo
+        
+        ilo = np.array([ilo]*ia.size).reshape(ia.shape)
+        iilo = ak.array(ilo)
+        ihi = 75
+        flo = np.array([flo]*ia.size).reshape(ia.shape)
+        fflo = ak.array(flo)
+        fhi = 75.0
+        self.assertTrue(np.all(np.equal(np.clip(ia,ilo,ihi),ak.clip(ipda,iilo,ihi).to_ndarray()))) # all ints
+        self.assertTrue(np.allclose(np.clip(fa,flo,fhi),ak.clip(fpda,fflo,fhi).to_ndarray()))      # all floats
+        self.assertTrue(np.allclose(np.clip(ia,ilo,fhi),ak.clip(ipda,iilo,fhi).to_ndarray()))      # int array and lo, float hi
+        self.assertTrue(np.allclose(np.clip(ia,flo,ihi),ak.clip(ipda,fflo,ihi).to_ndarray()))      # int array and hi, float lo
+        self.assertTrue(np.allclose(np.clip(fa,ilo,ihi),ak.clip(fpda,iilo,ihi).to_ndarray()))      # int lo and hi, float array
+
+        # test with arrays for hi
+        
+        ilo = 25
+        flo = 25.0
+        ihi = np.array([ihi]*ia.size).reshape(ia.shape)
+        iihi = ak.array(ihi)
+        fhi = np.array([fhi]*ia.size).reshape(ia.shape)
+        ffhi = ak.array(fhi)
+        self.assertTrue(np.all(np.equal(np.clip(ia,ilo,ihi),ak.clip(ipda,ilo,iihi).to_ndarray()))) # all ints
+        self.assertTrue(np.allclose(np.clip(fa,flo,fhi),ak.clip(fpda,flo,ffhi).to_ndarray()))      # all floats
+        self.assertTrue(np.allclose(np.clip(ia,ilo,fhi),ak.clip(ipda,ilo,ffhi).to_ndarray()))      # int array and lo, float hi
+        self.assertTrue(np.allclose(np.clip(ia,flo,ihi),ak.clip(ipda,flo,iihi).to_ndarray()))      # int array and hi, float lo
+        self.assertTrue(np.allclose(np.clip(fa,ilo,ihi),ak.clip(fpda,ilo,iihi).to_ndarray()))      # int lo and hi, float array
+
+        # test with arrays for both
+
+        ilo = np.array([ilo]*ia.size).reshape(ia.shape)
+        iilo = ak.array(ilo)
+        self.assertTrue(np.all(np.equal(np.clip(ia,ilo,ihi),ak.clip(ipda,iilo,iihi).to_ndarray()))) # all ints
+        self.assertTrue(np.allclose(np.clip(fa,flo,fhi),ak.clip(fpda,fflo,ffhi).to_ndarray()))      # all floats
+        self.assertTrue(np.allclose(np.clip(ia,ilo,fhi),ak.clip(ipda,iilo,ffhi).to_ndarray()))      # int array and lo, float hi
+        self.assertTrue(np.allclose(np.clip(ia,flo,ihi),ak.clip(ipda,fflo,iihi).to_ndarray()))      # int array and hi, float lo
+        self.assertTrue(np.allclose(np.clip(fa,ilo,ihi),ak.clip(fpda,iilo,iihi).to_ndarray()))      # int lo and hi, float array
+#        self.assertTrue(np.isclose(ak_mse, 0.0))

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -1622,153 +1622,84 @@ class NumericTest(ArkoudaTest):
 
     # test clip on ints, floats, and mash-ups; note if any input is float, output is float
 
-    def testClip(self):
+    def test_clip(self):
         ia = np.random.randint(1, 100, 100)
         ilo = 25
         ihi = 75
-        fa = ia.astype(float)
-        flo = 25.0
-        fhi = 75.0
-        ipda = ak.array(ia)
-        fpda = ak.array(fa)
 
         # test with scalars
 
-        self.assertTrue(
-            np.all(
-                np.equal(np.clip(ia, ilo, ihi), ak.clip(ipda, ilo, ihi).to_ndarray())
-            )
-        )  # all ints
-        self.assertTrue(
-            np.allclose(np.clip(fa, flo, fhi), ak.clip(fpda, flo, fhi).to_ndarray())
-        )  # all floats
-        self.assertTrue(
-            np.allclose(np.clip(ia, ilo, fhi), ak.clip(ipda, ilo, fhi).to_ndarray())
-        )  # int array and lo, float hi
-        self.assertTrue(
-            np.allclose(np.clip(ia, flo, ihi), ak.clip(ipda, flo, ihi).to_ndarray())
-        )  # int array and hi, float lo
-        self.assertTrue(
-            np.allclose(np.clip(fa, ilo, ihi), ak.clip(fpda, ilo, ihi).to_ndarray())
-        )  # int lo and hi, float array
+        dtypes = ['int64', 'float64']
+
+        for dtype1 in dtypes:
+            for dtype2 in dtypes:
+                for dtype3 in dtypes:
+                    hi = np.dtype(dtype1).type(ihi)
+                    lo = np.dtype(dtype2).type(ilo)
+                    nd_arry = ia.astype(dtype3)
+                    ak_arry = ak.array(nd_arry)
+                    assert (np.allclose(np.clip(nd_arry, lo, hi), ak.clip(ak_arry, lo, hi).to_ndarray()))
 
         # test with None for lower limit
 
-        ilo = None
-        flo = None
-        self.assertTrue(
-            np.all(
-                np.equal(np.clip(ia, ilo, ihi), ak.clip(ipda, ilo, ihi).to_ndarray())
-            )
-        )  # all ints
-        self.assertTrue(
-            np.allclose(np.clip(fa, flo, fhi), ak.clip(fpda, flo, fhi).to_ndarray())
-        )  # all floats
-        self.assertTrue(
-            np.allclose(np.clip(ia, ilo, fhi), ak.clip(ipda, ilo, fhi).to_ndarray())
-        )  # int array and lo, float hi
-        self.assertTrue(
-            np.allclose(np.clip(ia, flo, ihi), ak.clip(ipda, flo, ihi).to_ndarray())
-        )  # int array and hi, float lo
-        self.assertTrue(
-            np.allclose(np.clip(fa, ilo, ihi), ak.clip(fpda, ilo, ihi).to_ndarray())
-        )  # int lo and hi, float array
+        lo = None
+        for dtype1 in dtypes:
+            for dtype2 in dtypes:
+                for dtype3 in dtypes:
+                    hi = np.dtype(dtype1).type(ihi)
+                    nd_arry = ia.astype(dtype3)
+                    ak_arry = ak.array(nd_arry)
+                    assert (np.allclose(np.clip(nd_arry, lo, hi), ak.clip(ak_arry, lo, hi).to_ndarray()))
 
         # test with None for upper limit
 
-        ilo = 25
-        flo = float(ilo)
-        ihi = None
-        fhi = None
-        self.assertTrue(
-            np.all(
-                np.equal(np.clip(ia, ilo, ihi), ak.clip(ipda, ilo, ihi).to_ndarray())
-            )
-        )  # all ints
-        self.assertTrue(
-            np.allclose(np.clip(fa, flo, fhi), ak.clip(fpda, flo, fhi).to_ndarray())
-        )  # all floats
-        self.assertTrue(
-            np.allclose(np.clip(ia, ilo, fhi), ak.clip(ipda, ilo, fhi).to_ndarray())
-        )  # int array and lo, float hi
-        self.assertTrue(
-            np.allclose(np.clip(ia, flo, ihi), ak.clip(ipda, flo, ihi).to_ndarray())
-        )  # int array and hi, float lo
-        self.assertTrue(
-            np.allclose(np.clip(fa, ilo, ihi), ak.clip(fpda, ilo, ihi).to_ndarray())
-        )  # int lo and hi, float array
+        hi = None
+        for dtype1 in dtypes:
+            for dtype2 in dtypes:
+                for dtype3 in dtypes:
+                    lo = np.dtype(dtype2).type(ilo)
+                    nd_arry = ia.astype(dtype3)
+                    ak_arry = ak.array(nd_arry)
+                    assert (np.allclose(np.clip(nd_arry, lo, hi), ak.clip(ak_arry, lo, hi).to_ndarray()))
 
         # test with arrays for lo
 
-        ilo = np.array([ilo] * ia.size).reshape(ia.shape)
-        iilo = ak.array(ilo)
-        ihi = 75
-        flo = np.array([flo] * ia.size).reshape(ia.shape)
-        fflo = ak.array(flo)
-        fhi = 75.0
-        self.assertTrue(
-            np.all(
-                np.equal(np.clip(ia, ilo, ihi), ak.clip(ipda, iilo, ihi).to_ndarray())
-            )
-        )  # all ints
-        self.assertTrue(
-            np.allclose(np.clip(fa, flo, fhi), ak.clip(fpda, fflo, fhi).to_ndarray())
-        )  # all floats
-        self.assertTrue(
-            np.allclose(np.clip(ia, ilo, fhi), ak.clip(ipda, iilo, fhi).to_ndarray())
-        )  # int array and lo, float hi
-        self.assertTrue(
-            np.allclose(np.clip(ia, flo, ihi), ak.clip(ipda, fflo, ihi).to_ndarray())
-        )  # int array and hi, float lo
-        self.assertTrue(
-            np.allclose(np.clip(fa, ilo, ihi), ak.clip(fpda, iilo, ihi).to_ndarray())
-        )  # int lo and hi, float array
+        ilo = np.array([ilo]*ia.size).reshape(ia.shape)
+        for dtype1 in dtypes:
+            for dtype2 in dtypes:
+                for dtype3 in dtypes:
+                    hi = np.dtype(dtype1).type(ihi)
+                    nd_lo = ilo.astype(dtype2)
+                    nd_arry = ia.astype(dtype3)
+                    ak_lo = ak.array(nd_lo)
+                    ak_arry = ak.array(nd_arry)
+                    assert (np.allclose(np.clip(nd_arry, nd_lo, hi), ak.clip(ak_arry, ak_lo, hi).to_ndarray()))
 
         # test with arrays for hi
 
         ilo = 25
-        flo = 25.0
-        ihi = np.array([ihi] * ia.size).reshape(ia.shape)
-        iihi = ak.array(ihi)
-        fhi = np.array([fhi] * ia.size).reshape(ia.shape)
-        ffhi = ak.array(fhi)
-        self.assertTrue(
-            np.all(
-                np.equal(np.clip(ia, ilo, ihi), ak.clip(ipda, ilo, iihi).to_ndarray())
-            )
-        )  # all ints
-        self.assertTrue(
-            np.allclose(np.clip(fa, flo, fhi), ak.clip(fpda, flo, ffhi).to_ndarray())
-        )  # all floats
-        self.assertTrue(
-            np.allclose(np.clip(ia, ilo, fhi), ak.clip(ipda, ilo, ffhi).to_ndarray())
-        )  # int array and lo, float hi
-        self.assertTrue(
-            np.allclose(np.clip(ia, flo, ihi), ak.clip(ipda, flo, iihi).to_ndarray())
-        )  # int array and hi, float lo
-        self.assertTrue(
-            np.allclose(np.clip(fa, ilo, ihi), ak.clip(fpda, ilo, iihi).to_ndarray())
-        )  # int lo and hi, float array
+        ihi = np.array([ihi]*ia.size).reshape(ia.shape)
+        for dtype1 in dtypes:
+            for dtype2 in dtypes:
+                for dtype3 in dtypes:
+                    lo = np.dtype(dtype2).type(ilo)
+                    nd_hi = ihi.astype(dtype1)
+                    nd_arry = ia.astype(dtype3)
+                    ak_hi = ak.array(nd_hi)
+                    ak_arry = ak.array(nd_arry)
+                    assert (np.allclose(np.clip(nd_arry, lo, nd_hi), ak.clip(ak_arry, lo, ak_hi).to_ndarray()))
 
-        # test with arrays for both
+        # test with arrays for both 
 
-        ilo = np.array([ilo] * ia.size).reshape(ia.shape)
-        iilo = ak.array(ilo)
-        self.assertTrue(
-            np.all(
-                np.equal(np.clip(ia, ilo, ihi), ak.clip(ipda, iilo, iihi).to_ndarray())
-            )
-        )  # all ints
-        self.assertTrue(
-            np.allclose(np.clip(fa, flo, fhi), ak.clip(fpda, fflo, ffhi).to_ndarray())
-        )  # all floats
-        self.assertTrue(
-            np.allclose(np.clip(ia, ilo, fhi), ak.clip(ipda, iilo, ffhi).to_ndarray())
-        )  # int array and lo, float hi
-        self.assertTrue(
-            np.allclose(np.clip(ia, flo, ihi), ak.clip(ipda, fflo, iihi).to_ndarray())
-        )  # int array and hi, float lo
-        self.assertTrue(
-            np.allclose(np.clip(fa, ilo, ihi), ak.clip(fpda, iilo, iihi).to_ndarray())
-        )  # int lo and hi, float array
+        ilo = np.array([ilo]*ia.size).reshape(ia.shape)
+        for dtype1 in dtypes:
+            for dtype2 in dtypes:
+                for dtype3 in dtypes:
+                    nd_hi = ihi.astype(dtype1)
+                    nd_lo = ilo.astype(dtype2)
+                    nd_arry = ia.astype(dtype3)
+                    ak_lo = ak.array(nd_lo)
+                    ak_hi = ak.array(nd_hi)
+                    ak_arry = ak.array(nd_arry)
+                    assert (np.allclose(np.clip(nd_arry, nd_lo, nd_hi), ak.clip(ak_arry, ak_lo, ak_hi).to_ndarray()))
 

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -1664,7 +1664,7 @@ class NumericTest(ArkoudaTest):
 
         # test with arrays for lo
 
-        ilo = np.array([ilo]*ia.size).reshape(ia.shape)
+        ilo = np.full(ia.shape,ilo)
         for dtype1 in dtypes:
             for dtype2 in dtypes:
                 for dtype3 in dtypes:
@@ -1678,7 +1678,7 @@ class NumericTest(ArkoudaTest):
         # test with arrays for hi
 
         ilo = 25
-        ihi = np.array([ihi]*ia.size).reshape(ia.shape)
+        ihi = np.full(ia.shape,ihi)
         for dtype1 in dtypes:
             for dtype2 in dtypes:
                 for dtype3 in dtypes:
@@ -1691,7 +1691,7 @@ class NumericTest(ArkoudaTest):
 
         # test with arrays for both 
 
-        ilo = np.array([ilo]*ia.size).reshape(ia.shape)
+        ilo = np.full(ia.shape,ilo)
         for dtype1 in dtypes:
             for dtype2 in dtypes:
                 for dtype3 in dtypes:

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -38,7 +38,10 @@ class NumericTest(ArkoudaTest):
         )
         # Strings (uniformly distributed length)
         self.assertFalse(
-            (ak.random_strings_uniform(1, 10, N) == ak.random_strings_uniform(1, 10, N)).all()
+            (
+                ak.random_strings_uniform(1, 10, N)
+                == ak.random_strings_uniform(1, 10, N)
+            ).all()
         )
         self.assertListEqual(
             ak.random_strings_uniform(1, 10, N, seed=seed).to_list(),
@@ -46,7 +49,10 @@ class NumericTest(ArkoudaTest):
         )
         # Strings (log-normally distributed length)
         self.assertFalse(
-            (ak.random_strings_lognormal(2, 1, N) == ak.random_strings_lognormal(2, 1, N)).all()
+            (
+                ak.random_strings_lognormal(2, 1, N)
+                == ak.random_strings_lognormal(2, 1, N)
+            ).all()
         )
         self.assertListEqual(
             ak.random_strings_lognormal(2, 1, N, seed=seed).to_list(),
@@ -84,7 +90,8 @@ class NumericTest(ArkoudaTest):
                 if (t1, t2) in roundtripable:
                     roundtrip = ak.cast(other, t1)
                     self.assertTrue(
-                        (orig == roundtrip).all(), f"{t1}: {orig[:5]}, {t2}: {roundtrip[:5]}"
+                        (orig == roundtrip).all(),
+                        f"{t1}: {orig[:5]}, {t2}: {roundtrip[:5]}",
                     )
 
         self.assertListEqual(
@@ -104,10 +111,24 @@ class NumericTest(ArkoudaTest):
         uintNAN = 0
         uintstr = ak.array(["1", "2 ", "3?", "-4", "  5", "45", "0b101", "0x30", "N/A"])
         uintans = np.array([1, 2, uintNAN, uintNAN, 5, 45, 0b101, 0x30, uintNAN])
-        floatstr = ak.array(["1.1", "2.2 ", "3?.3", "4.!4", "  5.5", "6.6e-6", "78.91E+4", "6", "N/A"])
-        floatans = np.array([1.1, 2.2, np.nan, np.nan, 5.5, 6.6e-6, 78.91e4, 6.0, np.nan])
+        floatstr = ak.array(
+            ["1.1", "2.2 ", "3?.3", "4.!4", "  5.5", "6.6e-6", "78.91E+4", "6", "N/A"]
+        )
+        floatans = np.array(
+            [1.1, 2.2, np.nan, np.nan, 5.5, 6.6e-6, 78.91e4, 6.0, np.nan]
+        )
         boolstr = ak.array(
-            ["True", "False ", "Neither", "N/A", "  True", "true", "false", "TRUE", "NOTTRUE"]
+            [
+                "True",
+                "False ",
+                "Neither",
+                "N/A",
+                "  True",
+                "true",
+                "false",
+                "TRUE",
+                "NOTTRUE",
+            ]
         )
         boolans = np.array([True, False, False, False, True, True, False, True, False])
         validans = ak.array([True, True, False, False, True, True, True, True, False])
@@ -149,7 +170,9 @@ class NumericTest(ArkoudaTest):
 
         # test 2d histogram
         seed = 1
-        ak_x, ak_y = ak.randint(1, 100, 1000, seed=seed), ak.randint(1, 100, 1000, seed=seed + 1)
+        ak_x, ak_y = ak.randint(1, 100, 1000, seed=seed), ak.randint(
+            1, 100, 1000, seed=seed + 1
+        )
         np_x, np_y = ak_x.to_ndarray(), ak_y.to_ndarray()
         np_hist, np_x_edges, np_y_edges = np.histogram2d(np_x, np_y)
         ak_hist, ak_x_edges, ak_y_edges = ak.histogram2d(ak_x, ak_y)
@@ -196,7 +219,9 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
 
         self.assertTrue(np.allclose(np.abs(na), ak.abs(pda).to_ndarray()))
-        self.assertListEqual(ak.arange(5, 1, -1).to_list(), ak.abs(ak.arange(-5, -1)).to_list())
+        self.assertListEqual(
+            ak.arange(5, 1, -1).to_list(), ak.abs(ak.arange(-5, -1)).to_list()
+        )
         self.assertListEqual(
             [5, 4, 3, 2, 1],
             ak.abs(ak.linspace(-5, -1, 5)).to_list(),
@@ -218,8 +243,12 @@ class NumericTest(ArkoudaTest):
                 pda1 = ak.array(na1)
                 pda2 = ak.array(na2)
                 self.assertTrue(np.allclose(np.dot(na1, na2), ak.dot(pda1, pda2)))
-                self.assertTrue(np.allclose(np.dot(na1[0], na2), ak.dot(pda1[0], pda2).to_ndarray()))
-                self.assertTrue(np.allclose(np.dot(na1, na2[0]), ak.dot(pda1, pda2[0]).to_ndarray()))
+                self.assertTrue(
+                    np.allclose(np.dot(na1[0], na2), ak.dot(pda1[0], pda2).to_ndarray())
+                )
+                self.assertTrue(
+                    np.allclose(np.dot(na1, na2[0]), ak.dot(pda1, pda2[0]).to_ndarray())
+                )
 
     def testCumSum(self):
         na = np.linspace(1, 10)
@@ -249,7 +278,9 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(np.allclose(np.sin(na, where=True), ak.sin(pda, where=True).to_ndarray()))
+        self.assertTrue(
+            np.allclose(np.sin(na, where=True), ak.sin(pda, where=True).to_ndarray())
+        )
         self.assertTrue(np.allclose(na, ak.sin(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -262,7 +293,9 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(np.allclose(np.sin(na, where=True), ak.sin(pda, where=True).to_ndarray()))
+        self.assertTrue(
+            np.allclose(np.sin(na, where=True), ak.sin(pda, where=True).to_ndarray())
+        )
         self.assertTrue(np.allclose(na, ak.sin(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -275,7 +308,9 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(np.allclose(np.sin(na, where=True), ak.sin(pda, where=True).to_ndarray()))
+        self.assertTrue(
+            np.allclose(np.sin(na, where=True), ak.sin(pda, where=True).to_ndarray())
+        )
         self.assertTrue(np.allclose(na, ak.sin(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -292,7 +327,9 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(np.allclose(np.cos(na, where=True), ak.cos(pda, where=True).to_ndarray()))
+        self.assertTrue(
+            np.allclose(np.cos(na, where=True), ak.cos(pda, where=True).to_ndarray())
+        )
         self.assertTrue(np.allclose(na, ak.cos(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -305,7 +342,9 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(np.allclose(np.cos(na, where=True), ak.cos(pda, where=True).to_ndarray()))
+        self.assertTrue(
+            np.allclose(np.cos(na, where=True), ak.cos(pda, where=True).to_ndarray())
+        )
         self.assertTrue(np.allclose(na, ak.cos(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -318,7 +357,9 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(np.allclose(np.cos(na, where=True), ak.cos(pda, where=True).to_ndarray()))
+        self.assertTrue(
+            np.allclose(np.cos(na, where=True), ak.cos(pda, where=True).to_ndarray())
+        )
         self.assertTrue(np.allclose(na, ak.cos(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -335,7 +376,9 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(np.allclose(np.tan(na, where=True), ak.tan(pda, where=True).to_ndarray()))
+        self.assertTrue(
+            np.allclose(np.tan(na, where=True), ak.tan(pda, where=True).to_ndarray())
+        )
         self.assertTrue(np.allclose(na, ak.tan(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -348,7 +391,9 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(np.allclose(np.tan(na, where=True), ak.tan(pda, where=True).to_ndarray()))
+        self.assertTrue(
+            np.allclose(np.tan(na, where=True), ak.tan(pda, where=True).to_ndarray())
+        )
         self.assertTrue(np.allclose(na, ak.tan(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -361,7 +406,9 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(np.allclose(np.tan(na, where=True), ak.tan(pda, where=True).to_ndarray()))
+        self.assertTrue(
+            np.allclose(np.tan(na, where=True), ak.tan(pda, where=True).to_ndarray())
+        )
         self.assertTrue(np.allclose(na, ak.tan(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -378,7 +425,11 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(np.allclose(np.arcsin(na, where=True), ak.arcsin(pda, where=True).to_ndarray()))
+        self.assertTrue(
+            np.allclose(
+                np.arcsin(na, where=True), ak.arcsin(pda, where=True).to_ndarray()
+            )
+        )
         self.assertTrue(np.allclose(na, ak.arcsin(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -391,7 +442,11 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(np.allclose(np.arcsin(na, where=True), ak.arcsin(pda, where=True).to_ndarray()))
+        self.assertTrue(
+            np.allclose(
+                np.arcsin(na, where=True), ak.arcsin(pda, where=True).to_ndarray()
+            )
+        )
         self.assertTrue(np.allclose(na, ak.arcsin(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -404,7 +459,11 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(np.allclose(np.arcsin(na, where=True), ak.arcsin(pda, where=True).to_ndarray()))
+        self.assertTrue(
+            np.allclose(
+                np.arcsin(na, where=True), ak.arcsin(pda, where=True).to_ndarray()
+            )
+        )
         self.assertTrue(np.allclose(na, ak.arcsin(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -421,7 +480,11 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(np.allclose(np.arccos(na, where=True), ak.arccos(pda, where=True).to_ndarray()))
+        self.assertTrue(
+            np.allclose(
+                np.arccos(na, where=True), ak.arccos(pda, where=True).to_ndarray()
+            )
+        )
         self.assertTrue(np.allclose(na, ak.arccos(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -434,7 +497,11 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(np.allclose(np.arccos(na, where=True), ak.arccos(pda, where=True).to_ndarray()))
+        self.assertTrue(
+            np.allclose(
+                np.arccos(na, where=True), ak.arccos(pda, where=True).to_ndarray()
+            )
+        )
         self.assertTrue(np.allclose(na, ak.arccos(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -447,7 +514,11 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(np.allclose(np.arccos(na, where=True), ak.arccos(pda, where=True).to_ndarray()))
+        self.assertTrue(
+            np.allclose(
+                np.arccos(na, where=True), ak.arccos(pda, where=True).to_ndarray()
+            )
+        )
         self.assertTrue(np.allclose(na, ak.arccos(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -464,7 +535,11 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(np.allclose(np.arctan(na, where=True), ak.arctan(pda, where=True).to_ndarray()))
+        self.assertTrue(
+            np.allclose(
+                np.arctan(na, where=True), ak.arctan(pda, where=True).to_ndarray()
+            )
+        )
         self.assertTrue(np.allclose(na, ak.arctan(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -477,7 +552,11 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(np.allclose(np.arctan(na, where=True), ak.arctan(pda, where=True).to_ndarray()))
+        self.assertTrue(
+            np.allclose(
+                np.arctan(na, where=True), ak.arctan(pda, where=True).to_ndarray()
+            )
+        )
         self.assertTrue(np.allclose(na, ak.arctan(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -490,7 +569,9 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(np.allclose(np.arctan(na), ak.arctan(pda, where=True).to_ndarray()))
+        self.assertTrue(
+            np.allclose(np.arctan(na), ak.arctan(pda, where=True).to_ndarray())
+        )
         self.assertTrue(np.allclose(na, ak.arctan(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -505,7 +586,9 @@ class NumericTest(ArkoudaTest):
         # Edge case: infinities
         na = np.array([np.inf, -np.inf])
         pda = ak.array(na)
-        self.assertTrue(np.allclose(np.arctan(na), ak.arctan(pda).to_ndarray(), equal_nan=True))
+        self.assertTrue(
+            np.allclose(np.arctan(na), ak.arctan(pda).to_ndarray(), equal_nan=True)
+        )
 
     def testArctan2(self):
         na1_int = np.arange(10, 0, -1, dtype="int64")
@@ -531,7 +614,11 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(
                 [
-                    np.arctan2(na1_int[i], na2_int[i]) if truth_np[i] else na1_int[i] / na2_int[i]
+                    (
+                        np.arctan2(na1_int[i], na2_int[i])
+                        if truth_np[i]
+                        else na1_int[i] / na2_int[i]
+                    )
                     for i in range(len(na1_int))
                 ],
                 ak.arctan2(pda1_int, pda2_int, where=truth_ak).to_ndarray(),
@@ -540,7 +627,11 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(
                 [
-                    np.arctan2(na1_int[i], na2_uint[i]) if truth_np[i] else na1_int[i] / na2_uint[i]
+                    (
+                        np.arctan2(na1_int[i], na2_uint[i])
+                        if truth_np[i]
+                        else na1_int[i] / na2_uint[i]
+                    )
                     for i in range(len(na1_int))
                 ],
                 ak.arctan2(pda1_int, pda2_uint, where=truth_ak).to_ndarray(),
@@ -549,7 +640,11 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(
                 [
-                    np.arctan2(na1_int[i], na2_float[i]) if truth_np[i] else na1_int[i] / na2_float[i]
+                    (
+                        np.arctan2(na1_int[i], na2_float[i])
+                        if truth_np[i]
+                        else na1_int[i] / na2_float[i]
+                    )
                     for i in range(len(na1_int))
                 ],
                 ak.arctan2(pda1_int, pda2_float, where=truth_ak).to_ndarray(),
@@ -559,7 +654,11 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(
                 [
-                    np.arctan2(na1_uint[i], na2_int[i]) if truth_np[i] else na1_uint[i] / na2_int[i]
+                    (
+                        np.arctan2(na1_uint[i], na2_int[i])
+                        if truth_np[i]
+                        else na1_uint[i] / na2_int[i]
+                    )
                     for i in range(len(na1_uint))
                 ],
                 ak.arctan2(pda1_uint, pda2_int, where=truth_ak).to_ndarray(),
@@ -568,7 +667,11 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(
                 [
-                    np.arctan2(na1_uint[i], na2_uint[i]) if truth_np[i] else na1_uint[i] / na2_uint[i]
+                    (
+                        np.arctan2(na1_uint[i], na2_uint[i])
+                        if truth_np[i]
+                        else na1_uint[i] / na2_uint[i]
+                    )
                     for i in range(len(na1_uint))
                 ],
                 ak.arctan2(pda1_uint, pda2_uint, where=truth_ak).to_ndarray(),
@@ -577,7 +680,11 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(
                 [
-                    np.arctan2(na1_uint[i], na2_float[i]) if truth_np[i] else na1_uint[i] / na2_float[i]
+                    (
+                        np.arctan2(na1_uint[i], na2_float[i])
+                        if truth_np[i]
+                        else na1_uint[i] / na2_float[i]
+                    )
                     for i in range(len(na1_uint))
                 ],
                 ak.arctan2(pda1_uint, pda2_float, where=truth_ak).to_ndarray(),
@@ -587,7 +694,11 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(
                 [
-                    np.arctan2(na1_float[i], na2_int[i]) if truth_np[i] else na1_float[i] / na2_int[i]
+                    (
+                        np.arctan2(na1_float[i], na2_int[i])
+                        if truth_np[i]
+                        else na1_float[i] / na2_int[i]
+                    )
                     for i in range(len(na1_float))
                 ],
                 ak.arctan2(pda1_float, pda2_int, where=truth_ak).to_ndarray(),
@@ -596,7 +707,11 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(
                 [
-                    np.arctan2(na1_float[i], na2_uint[i]) if truth_np[i] else na1_float[i] / na2_uint[i]
+                    (
+                        np.arctan2(na1_float[i], na2_uint[i])
+                        if truth_np[i]
+                        else na1_float[i] / na2_uint[i]
+                    )
                     for i in range(len(na1_float))
                 ],
                 ak.arctan2(pda1_float, pda2_uint, where=truth_ak).to_ndarray(),
@@ -605,9 +720,11 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(
                 [
-                    np.arctan2(na1_float[i], na2_float[i])
-                    if truth_np[i]
-                    else na1_float[i] / na2_float[i]
+                    (
+                        np.arctan2(na1_float[i], na2_float[i])
+                        if truth_np[i]
+                        else na1_float[i] / na2_float[i]
+                    )
                     for i in range(len(na1_float))
                 ],
                 ak.arctan2(pda1_float, pda2_float, where=truth_ak).to_ndarray(),
@@ -632,7 +749,11 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(
                 [
-                    np.arctan2(na1_int[i], denom[0]) if truth_np[i] else na1_int[i] / denom[0]
+                    (
+                        np.arctan2(na1_int[i], denom[0])
+                        if truth_np[i]
+                        else na1_int[i] / denom[0]
+                    )
                     for i in range(len(na1_int))
                 ],
                 ak.arctan2(pda1_int, denom[0], where=truth_ak).to_ndarray(),
@@ -660,7 +781,11 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(
                 [
-                    np.arctan2(na1_uint[i], denom[0]) if truth_np[i] else na1_uint[i] / denom[0]
+                    (
+                        np.arctan2(na1_uint[i], denom[0])
+                        if truth_np[i]
+                        else na1_uint[i] / denom[0]
+                    )
                     for i in range(len(na1_uint))
                 ],
                 ak.arctan2(pda1_uint, denom[0], where=truth_ak).to_ndarray(),
@@ -688,7 +813,11 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(
                 [
-                    np.arctan2(na1_float[i], denom[0]) if truth_np[i] else na1_float[i] / denom[0]
+                    (
+                        np.arctan2(na1_float[i], denom[0])
+                        if truth_np[i]
+                        else na1_float[i] / denom[0]
+                    )
                     for i in range(len(na1_float))
                 ],
                 ak.arctan2(pda1_float, denom[0], where=truth_ak).to_ndarray(),
@@ -745,7 +874,11 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(
                 [
-                    np.arctan2(num[0], na2_int[i]) if truth_np[i] else num[0] / na2_int[i]
+                    (
+                        np.arctan2(num[0], na2_int[i])
+                        if truth_np[i]
+                        else num[0] / na2_int[i]
+                    )
                     for i in range(len(na1_uint))
                 ],
                 ak.arctan2(num[0], pda2_int, where=truth_ak).to_ndarray(),
@@ -754,7 +887,11 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(
                 [
-                    np.arctan2(num[0], na2_uint[i]) if truth_np[i] else num[0] / na2_uint[i]
+                    (
+                        np.arctan2(num[0], na2_uint[i])
+                        if truth_np[i]
+                        else num[0] / na2_uint[i]
+                    )
                     for i in range(len(na1_uint))
                 ],
                 ak.arctan2(num[0], pda2_uint, where=truth_ak).to_ndarray(),
@@ -763,7 +900,11 @@ class NumericTest(ArkoudaTest):
         self.assertTrue(
             np.allclose(
                 [
-                    np.arctan2(num[0], na2_float[i]) if truth_np[i] else num[0] / na2_float[i]
+                    (
+                        np.arctan2(num[0], na2_float[i])
+                        if truth_np[i]
+                        else num[0] / na2_float[i]
+                    )
                     for i in range(len(na1_uint))
                 ],
                 ak.arctan2(num[0], pda2_float, where=truth_ak).to_ndarray(),
@@ -814,22 +955,38 @@ class NumericTest(ArkoudaTest):
         pda2 = ak.array(na2)
 
         self.assertTrue(
-            np.allclose(np.arctan2(na1, na2), ak.arctan2(pda1, pda2).to_ndarray(), equal_nan=True)
+            np.allclose(
+                np.arctan2(na1, na2),
+                ak.arctan2(pda1, pda2).to_ndarray(),
+                equal_nan=True,
+            )
         )
         self.assertTrue(
-            np.allclose(np.arctan2(na2, na1), ak.arctan2(pda2, pda1).to_ndarray(), equal_nan=True)
+            np.allclose(
+                np.arctan2(na2, na1),
+                ak.arctan2(pda2, pda1).to_ndarray(),
+                equal_nan=True,
+            )
         )
         self.assertTrue(
-            np.allclose(np.arctan2(na1, 5), ak.arctan2(pda1, 5).to_ndarray(), equal_nan=True)
+            np.allclose(
+                np.arctan2(na1, 5), ak.arctan2(pda1, 5).to_ndarray(), equal_nan=True
+            )
         )
         self.assertTrue(
-            np.allclose(np.arctan2(5, na1), ak.arctan2(5, pda1).to_ndarray(), equal_nan=True)
+            np.allclose(
+                np.arctan2(5, na1), ak.arctan2(5, pda1).to_ndarray(), equal_nan=True
+            )
         )
         self.assertTrue(
-            np.allclose(np.arctan2(na1, 0), ak.arctan2(pda1, 0).to_ndarray(), equal_nan=True)
+            np.allclose(
+                np.arctan2(na1, 0), ak.arctan2(pda1, 0).to_ndarray(), equal_nan=True
+            )
         )
         self.assertTrue(
-            np.allclose(np.arctan2(0, na1), ak.arctan2(0, pda1).to_ndarray(), equal_nan=True)
+            np.allclose(
+                np.arctan2(0, na1), ak.arctan2(0, pda1).to_ndarray(), equal_nan=True
+            )
         )
 
     def testSinh(self):
@@ -837,7 +994,9 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(np.allclose(np.sinh(na, where=True), ak.sinh(pda, where=True).to_ndarray()))
+        self.assertTrue(
+            np.allclose(np.sinh(na, where=True), ak.sinh(pda, where=True).to_ndarray())
+        )
         self.assertTrue(np.allclose(na, ak.sinh(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -850,7 +1009,9 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(np.allclose(np.sinh(na, where=True), ak.sinh(pda, where=True).to_ndarray()))
+        self.assertTrue(
+            np.allclose(np.sinh(na, where=True), ak.sinh(pda, where=True).to_ndarray())
+        )
         self.assertTrue(np.allclose(na, ak.sinh(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -863,7 +1024,9 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(np.allclose(np.sinh(na, where=True), ak.sinh(pda, where=True).to_ndarray()))
+        self.assertTrue(
+            np.allclose(np.sinh(na, where=True), ak.sinh(pda, where=True).to_ndarray())
+        )
         self.assertTrue(np.allclose(na, ak.sinh(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -878,14 +1041,18 @@ class NumericTest(ArkoudaTest):
         # Edge case: infinities
         na = np.array([np.inf, -np.inf])
         pda = ak.array(na)
-        self.assertTrue(np.allclose(np.sinh(na), ak.sinh(pda).to_ndarray(), equal_nan=True))
+        self.assertTrue(
+            np.allclose(np.sinh(na), ak.sinh(pda).to_ndarray(), equal_nan=True)
+        )
 
     def testCosh(self):
         na = np.arange(-5, 5, dtype="int64")
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(np.allclose(np.cosh(na, where=True), ak.cosh(pda, where=True).to_ndarray()))
+        self.assertTrue(
+            np.allclose(np.cosh(na, where=True), ak.cosh(pda, where=True).to_ndarray())
+        )
         self.assertTrue(np.allclose(na, ak.cosh(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -898,7 +1065,9 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(np.allclose(np.cosh(na, where=True), ak.cosh(pda, where=True).to_ndarray()))
+        self.assertTrue(
+            np.allclose(np.cosh(na, where=True), ak.cosh(pda, where=True).to_ndarray())
+        )
         self.assertTrue(np.allclose(na, ak.cosh(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -911,7 +1080,9 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(np.allclose(np.cosh(na, where=True), ak.cosh(pda, where=True).to_ndarray()))
+        self.assertTrue(
+            np.allclose(np.cosh(na, where=True), ak.cosh(pda, where=True).to_ndarray())
+        )
         self.assertTrue(np.allclose(na, ak.cosh(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -926,14 +1097,18 @@ class NumericTest(ArkoudaTest):
         # Edge case: infinities
         na = np.array([np.inf, -np.inf])
         pda = ak.array(na)
-        self.assertTrue(np.allclose(np.cosh(na), ak.cosh(pda).to_ndarray(), equal_nan=True))
+        self.assertTrue(
+            np.allclose(np.cosh(na), ak.cosh(pda).to_ndarray(), equal_nan=True)
+        )
 
     def testTanh(self):
         na = np.arange(-5, 5, dtype="int64")
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(np.allclose(np.tanh(na, where=True), ak.tanh(pda, where=True).to_ndarray()))
+        self.assertTrue(
+            np.allclose(np.tanh(na, where=True), ak.tanh(pda, where=True).to_ndarray())
+        )
         self.assertTrue(np.allclose(na, ak.tanh(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -946,7 +1121,9 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(np.allclose(np.tanh(na, where=True), ak.tanh(pda, where=True).to_ndarray()))
+        self.assertTrue(
+            np.allclose(np.tanh(na, where=True), ak.tanh(pda, where=True).to_ndarray())
+        )
         self.assertTrue(np.allclose(na, ak.tanh(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -959,7 +1136,9 @@ class NumericTest(ArkoudaTest):
         pda = ak.array(na)
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
-        self.assertTrue(np.allclose(np.tanh(na, where=True), ak.tanh(pda, where=True).to_ndarray()))
+        self.assertTrue(
+            np.allclose(np.tanh(na, where=True), ak.tanh(pda, where=True).to_ndarray())
+        )
         self.assertTrue(np.allclose(na, ak.tanh(pda, where=False).to_ndarray()))
         self.assertTrue(
             np.allclose(
@@ -974,7 +1153,9 @@ class NumericTest(ArkoudaTest):
         # Edge case: infinities
         na = np.array([np.inf, -np.inf])
         pda = ak.array(na)
-        self.assertTrue(np.allclose(np.tanh(na), ak.tanh(pda).to_ndarray(), equal_nan=True))
+        self.assertTrue(
+            np.allclose(np.tanh(na), ak.tanh(pda).to_ndarray(), equal_nan=True)
+        )
 
     def testArcsinh(self):
         na = np.arange(-5, 5, dtype="int64")
@@ -982,7 +1163,9 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(np.arcsinh(na, where=True), ak.arcsinh(pda, where=True).to_ndarray())
+            np.allclose(
+                np.arcsinh(na, where=True), ak.arcsinh(pda, where=True).to_ndarray()
+            )
         )
         self.assertTrue(np.allclose(na, ak.arcsinh(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -997,7 +1180,9 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(np.arcsinh(na, where=True), ak.arcsinh(pda, where=True).to_ndarray())
+            np.allclose(
+                np.arcsinh(na, where=True), ak.arcsinh(pda, where=True).to_ndarray()
+            )
         )
         self.assertTrue(np.allclose(na, ak.arcsinh(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1012,7 +1197,9 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(np.arcsinh(na, where=True), ak.arcsinh(pda, where=True).to_ndarray())
+            np.allclose(
+                np.arcsinh(na, where=True), ak.arcsinh(pda, where=True).to_ndarray()
+            )
         )
         self.assertTrue(np.allclose(na, ak.arcsinh(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1028,7 +1215,9 @@ class NumericTest(ArkoudaTest):
         # Edge case: infinities
         na = np.array([np.inf, -np.inf])
         pda = ak.array(na)
-        self.assertTrue(np.allclose(np.arcsinh(na), ak.arcsinh(pda).to_ndarray(), equal_nan=True))
+        self.assertTrue(
+            np.allclose(np.arcsinh(na), ak.arcsinh(pda).to_ndarray(), equal_nan=True)
+        )
 
     def testArccosh(self):
         na = np.arange(1, 5, dtype="int64")
@@ -1036,7 +1225,9 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(np.arccosh(na, where=True), ak.arccosh(pda, where=True).to_ndarray())
+            np.allclose(
+                np.arccosh(na, where=True), ak.arccosh(pda, where=True).to_ndarray()
+            )
         )
         self.assertTrue(np.allclose(na, ak.arccosh(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1051,7 +1242,9 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(np.arccosh(na, where=True), ak.arccosh(pda, where=True).to_ndarray())
+            np.allclose(
+                np.arccosh(na, where=True), ak.arccosh(pda, where=True).to_ndarray()
+            )
         )
         self.assertTrue(np.allclose(na, ak.arccosh(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1066,7 +1259,9 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(np.arccosh(na, where=True), ak.arccosh(pda, where=True).to_ndarray())
+            np.allclose(
+                np.arccosh(na, where=True), ak.arccosh(pda, where=True).to_ndarray()
+            )
         )
         self.assertTrue(np.allclose(na, ak.arccosh(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1082,8 +1277,14 @@ class NumericTest(ArkoudaTest):
         # Edge case: infinities
         na = np.array([1, np.inf])
         pda = ak.array(na)
-        self.assertTrue(np.allclose(np.arccosh(na).tolist(), ak.arccosh(pda).to_list(), equal_nan=True))
-        self.assertTrue(np.allclose(np.arccosh(na), ak.arccosh(pda).to_ndarray(), equal_nan=True))
+        self.assertTrue(
+            np.allclose(
+                np.arccosh(na).tolist(), ak.arccosh(pda).to_list(), equal_nan=True
+            )
+        )
+        self.assertTrue(
+            np.allclose(np.arccosh(na), ak.arccosh(pda).to_ndarray(), equal_nan=True)
+        )
 
     def testArctanh(self):
         na = np.arange(-1, 2, dtype="int64")
@@ -1091,7 +1292,9 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(np.arctanh(na, where=True), ak.arctanh(pda, where=True).to_ndarray())
+            np.allclose(
+                np.arctanh(na, where=True), ak.arctanh(pda, where=True).to_ndarray()
+            )
         )
         self.assertTrue(np.allclose(na, ak.arctanh(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1106,7 +1309,9 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(np.arctanh(na, where=True), ak.arctanh(pda, where=True).to_ndarray())
+            np.allclose(
+                np.arctanh(na, where=True), ak.arctanh(pda, where=True).to_ndarray()
+            )
         )
         self.assertTrue(np.allclose(na, ak.arctanh(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1121,7 +1326,9 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(np.arctanh(na, where=True), ak.arctanh(pda, where=True).to_ndarray())
+            np.allclose(
+                np.arctanh(na, where=True), ak.arctanh(pda, where=True).to_ndarray()
+            )
         )
         self.assertTrue(np.allclose(na, ak.arctanh(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1140,7 +1347,9 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(np.rad2deg(na, where=True), ak.rad2deg(pda, where=True).to_ndarray())
+            np.allclose(
+                np.rad2deg(na, where=True), ak.rad2deg(pda, where=True).to_ndarray()
+            )
         )
         self.assertTrue(np.allclose(na, ak.rad2deg(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1155,7 +1364,9 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(np.rad2deg(na, where=True), ak.rad2deg(pda, where=True).to_ndarray())
+            np.allclose(
+                np.rad2deg(na, where=True), ak.rad2deg(pda, where=True).to_ndarray()
+            )
         )
         self.assertTrue(np.allclose(na, ak.rad2deg(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1170,7 +1381,9 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(np.rad2deg(na, where=True), ak.rad2deg(pda, where=True).to_ndarray())
+            np.allclose(
+                np.rad2deg(na, where=True), ak.rad2deg(pda, where=True).to_ndarray()
+            )
         )
         self.assertTrue(np.allclose(na, ak.rad2deg(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1189,7 +1402,9 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(np.deg2rad(na, where=True), ak.deg2rad(pda, where=True).to_ndarray())
+            np.allclose(
+                np.deg2rad(na, where=True), ak.deg2rad(pda, where=True).to_ndarray()
+            )
         )
         self.assertTrue(np.allclose(na, ak.deg2rad(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1204,7 +1419,9 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(np.deg2rad(na, where=True), ak.deg2rad(pda, where=True).to_ndarray())
+            np.allclose(
+                np.deg2rad(na, where=True), ak.deg2rad(pda, where=True).to_ndarray()
+            )
         )
         self.assertTrue(np.allclose(na, ak.deg2rad(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1219,7 +1436,9 @@ class NumericTest(ArkoudaTest):
         truth_np = np.arange(len(na)) % 2 == 0
         truth_ak = ak.array(truth_np)
         self.assertTrue(
-            np.allclose(np.deg2rad(na, where=True), ak.deg2rad(pda, where=True).to_ndarray())
+            np.allclose(
+                np.deg2rad(na, where=True), ak.deg2rad(pda, where=True).to_ndarray()
+            )
         )
         self.assertTrue(np.allclose(na, ak.deg2rad(pda, where=False).to_ndarray()))
         self.assertTrue(
@@ -1310,7 +1529,9 @@ class NumericTest(ArkoudaTest):
         self.assertNotEqual(h2[0], h2[1])
 
         # test categorical hash
-        categories, codes = ak.array([f"str {i}" for i in range(3)]), ak.randint(0, 3, 10**5)
+        categories, codes = ak.array([f"str {i}" for i in range(3)]), ak.randint(
+            0, 3, 10**5
+        )
         my_cat = ak.Categorical.from_codes(codes=codes, categories=categories)
         h1, h2 = ak.hash(my_cat)
         rev = ak.arange(10**5)[::-1]
@@ -1362,7 +1583,9 @@ class NumericTest(ArkoudaTest):
 
         # Currently we can't make an int64 array with a NaN in it so verify that we throw an Exception
         ark_s_int64 = ak.array(np.array([1, 2, 3, 4], dtype="int64"))
-        with self.assertRaises(RuntimeError, msg="Currently isnan on int64 is not supported"):
+        with self.assertRaises(
+            RuntimeError, msg="Currently isnan on int64 is not supported"
+        ):
             ak.isnan(ark_s_int64)
 
     def test_str_cat_cast(self):
@@ -1370,7 +1593,9 @@ class NumericTest(ArkoudaTest):
             ak.array([f"str {i}" for i in range(101)]),
             ak.array([f"str {i%3}" for i in range(101)]),
         ]
-        for test_str, test_cat in zip(test_strs, [ak.Categorical(s) for s in test_strs]):
+        for test_str, test_cat in zip(
+            test_strs, [ak.Categorical(s) for s in test_strs]
+        ):
             cast_str = ak.cast(test_cat, ak.Strings)
             self.assertTrue((cast_str == test_str).all())
             cast_cat = ak.cast(test_str, ak.Categorical)
@@ -1395,10 +1620,10 @@ class NumericTest(ArkoudaTest):
         ak_mse = ak.mean((intmean - floatmean) ** 2)
         self.assertTrue(np.isclose(ak_mse, 0.0))
 
-# test clip on ints, floats, and mash-ups; note if any input is float, output is float
+    # test clip on ints, floats, and mash-ups; note if any input is float, output is float
 
-    def testClip(self) :
-        ia = np.random.randint(1,100,100)
+    def testClip(self):
+        ia = np.random.randint(1, 100, 100)
         ilo = 25
         ihi = 75
         fa = ia.astype(float)
@@ -1409,69 +1634,141 @@ class NumericTest(ArkoudaTest):
 
         # test with scalars
 
-        self.assertTrue(np.all(np.equal(np.clip(ia,ilo,ihi),ak.clip(ipda,ilo,ihi).to_ndarray()))) # all ints
-        self.assertTrue(np.allclose(np.clip(fa,flo,fhi),ak.clip(fpda,flo,fhi).to_ndarray()))      # all floats
-        self.assertTrue(np.allclose(np.clip(ia,ilo,fhi),ak.clip(ipda,ilo,fhi).to_ndarray()))      # int array and lo, float hi
-        self.assertTrue(np.allclose(np.clip(ia,flo,ihi),ak.clip(ipda,flo,ihi).to_ndarray()))      # int array and hi, float lo
-        self.assertTrue(np.allclose(np.clip(fa,ilo,ihi),ak.clip(fpda,ilo,ihi).to_ndarray()))      # int lo and hi, float array
+        self.assertTrue(
+            np.all(
+                np.equal(np.clip(ia, ilo, ihi), ak.clip(ipda, ilo, ihi).to_ndarray())
+            )
+        )  # all ints
+        self.assertTrue(
+            np.allclose(np.clip(fa, flo, fhi), ak.clip(fpda, flo, fhi).to_ndarray())
+        )  # all floats
+        self.assertTrue(
+            np.allclose(np.clip(ia, ilo, fhi), ak.clip(ipda, ilo, fhi).to_ndarray())
+        )  # int array and lo, float hi
+        self.assertTrue(
+            np.allclose(np.clip(ia, flo, ihi), ak.clip(ipda, flo, ihi).to_ndarray())
+        )  # int array and hi, float lo
+        self.assertTrue(
+            np.allclose(np.clip(fa, ilo, ihi), ak.clip(fpda, ilo, ihi).to_ndarray())
+        )  # int lo and hi, float array
 
         # test with None for lower limit
 
         ilo = None
         flo = None
-        self.assertTrue(np.all(np.equal(np.clip(ia,ilo,ihi),ak.clip(ipda,ilo,ihi).to_ndarray()))) # all ints
-        self.assertTrue(np.allclose(np.clip(fa,flo,fhi),ak.clip(fpda,flo,fhi).to_ndarray()))      # all floats
-        self.assertTrue(np.allclose(np.clip(ia,ilo,fhi),ak.clip(ipda,ilo,fhi).to_ndarray()))      # int array and lo, float hi
-        self.assertTrue(np.allclose(np.clip(ia,flo,ihi),ak.clip(ipda,flo,ihi).to_ndarray()))      # int array and hi, float lo
-        self.assertTrue(np.allclose(np.clip(fa,ilo,ihi),ak.clip(fpda,ilo,ihi).to_ndarray()))      # int lo and hi, float array
+        self.assertTrue(
+            np.all(
+                np.equal(np.clip(ia, ilo, ihi), ak.clip(ipda, ilo, ihi).to_ndarray())
+            )
+        )  # all ints
+        self.assertTrue(
+            np.allclose(np.clip(fa, flo, fhi), ak.clip(fpda, flo, fhi).to_ndarray())
+        )  # all floats
+        self.assertTrue(
+            np.allclose(np.clip(ia, ilo, fhi), ak.clip(ipda, ilo, fhi).to_ndarray())
+        )  # int array and lo, float hi
+        self.assertTrue(
+            np.allclose(np.clip(ia, flo, ihi), ak.clip(ipda, flo, ihi).to_ndarray())
+        )  # int array and hi, float lo
+        self.assertTrue(
+            np.allclose(np.clip(fa, ilo, ihi), ak.clip(fpda, ilo, ihi).to_ndarray())
+        )  # int lo and hi, float array
 
         # test with None for upper limit
 
-        ilo = 25 
+        ilo = 25
         flo = float(ilo)
         ihi = None
         fhi = None
-        self.assertTrue(np.all(np.equal(np.clip(ia,ilo,ihi),ak.clip(ipda,ilo,ihi).to_ndarray()))) # all ints
-        self.assertTrue(np.allclose(np.clip(fa,flo,fhi),ak.clip(fpda,flo,fhi).to_ndarray()))      # all floats
-        self.assertTrue(np.allclose(np.clip(ia,ilo,fhi),ak.clip(ipda,ilo,fhi).to_ndarray()))      # int array and lo, float hi
-        self.assertTrue(np.allclose(np.clip(ia,flo,ihi),ak.clip(ipda,flo,ihi).to_ndarray()))      # int array and hi, float lo
-        self.assertTrue(np.allclose(np.clip(fa,ilo,ihi),ak.clip(fpda,ilo,ihi).to_ndarray()))      # int lo and hi, float array
+        self.assertTrue(
+            np.all(
+                np.equal(np.clip(ia, ilo, ihi), ak.clip(ipda, ilo, ihi).to_ndarray())
+            )
+        )  # all ints
+        self.assertTrue(
+            np.allclose(np.clip(fa, flo, fhi), ak.clip(fpda, flo, fhi).to_ndarray())
+        )  # all floats
+        self.assertTrue(
+            np.allclose(np.clip(ia, ilo, fhi), ak.clip(ipda, ilo, fhi).to_ndarray())
+        )  # int array and lo, float hi
+        self.assertTrue(
+            np.allclose(np.clip(ia, flo, ihi), ak.clip(ipda, flo, ihi).to_ndarray())
+        )  # int array and hi, float lo
+        self.assertTrue(
+            np.allclose(np.clip(fa, ilo, ihi), ak.clip(fpda, ilo, ihi).to_ndarray())
+        )  # int lo and hi, float array
 
         # test with arrays for lo
-        
-        ilo = np.array([ilo]*ia.size).reshape(ia.shape)
+
+        ilo = np.array([ilo] * ia.size).reshape(ia.shape)
         iilo = ak.array(ilo)
         ihi = 75
-        flo = np.array([flo]*ia.size).reshape(ia.shape)
+        flo = np.array([flo] * ia.size).reshape(ia.shape)
         fflo = ak.array(flo)
         fhi = 75.0
-        self.assertTrue(np.all(np.equal(np.clip(ia,ilo,ihi),ak.clip(ipda,iilo,ihi).to_ndarray()))) # all ints
-        self.assertTrue(np.allclose(np.clip(fa,flo,fhi),ak.clip(fpda,fflo,fhi).to_ndarray()))      # all floats
-        self.assertTrue(np.allclose(np.clip(ia,ilo,fhi),ak.clip(ipda,iilo,fhi).to_ndarray()))      # int array and lo, float hi
-        self.assertTrue(np.allclose(np.clip(ia,flo,ihi),ak.clip(ipda,fflo,ihi).to_ndarray()))      # int array and hi, float lo
-        self.assertTrue(np.allclose(np.clip(fa,ilo,ihi),ak.clip(fpda,iilo,ihi).to_ndarray()))      # int lo and hi, float array
+        self.assertTrue(
+            np.all(
+                np.equal(np.clip(ia, ilo, ihi), ak.clip(ipda, iilo, ihi).to_ndarray())
+            )
+        )  # all ints
+        self.assertTrue(
+            np.allclose(np.clip(fa, flo, fhi), ak.clip(fpda, fflo, fhi).to_ndarray())
+        )  # all floats
+        self.assertTrue(
+            np.allclose(np.clip(ia, ilo, fhi), ak.clip(ipda, iilo, fhi).to_ndarray())
+        )  # int array and lo, float hi
+        self.assertTrue(
+            np.allclose(np.clip(ia, flo, ihi), ak.clip(ipda, fflo, ihi).to_ndarray())
+        )  # int array and hi, float lo
+        self.assertTrue(
+            np.allclose(np.clip(fa, ilo, ihi), ak.clip(fpda, iilo, ihi).to_ndarray())
+        )  # int lo and hi, float array
 
         # test with arrays for hi
-        
+
         ilo = 25
         flo = 25.0
-        ihi = np.array([ihi]*ia.size).reshape(ia.shape)
+        ihi = np.array([ihi] * ia.size).reshape(ia.shape)
         iihi = ak.array(ihi)
-        fhi = np.array([fhi]*ia.size).reshape(ia.shape)
+        fhi = np.array([fhi] * ia.size).reshape(ia.shape)
         ffhi = ak.array(fhi)
-        self.assertTrue(np.all(np.equal(np.clip(ia,ilo,ihi),ak.clip(ipda,ilo,iihi).to_ndarray()))) # all ints
-        self.assertTrue(np.allclose(np.clip(fa,flo,fhi),ak.clip(fpda,flo,ffhi).to_ndarray()))      # all floats
-        self.assertTrue(np.allclose(np.clip(ia,ilo,fhi),ak.clip(ipda,ilo,ffhi).to_ndarray()))      # int array and lo, float hi
-        self.assertTrue(np.allclose(np.clip(ia,flo,ihi),ak.clip(ipda,flo,iihi).to_ndarray()))      # int array and hi, float lo
-        self.assertTrue(np.allclose(np.clip(fa,ilo,ihi),ak.clip(fpda,ilo,iihi).to_ndarray()))      # int lo and hi, float array
+        self.assertTrue(
+            np.all(
+                np.equal(np.clip(ia, ilo, ihi), ak.clip(ipda, ilo, iihi).to_ndarray())
+            )
+        )  # all ints
+        self.assertTrue(
+            np.allclose(np.clip(fa, flo, fhi), ak.clip(fpda, flo, ffhi).to_ndarray())
+        )  # all floats
+        self.assertTrue(
+            np.allclose(np.clip(ia, ilo, fhi), ak.clip(ipda, ilo, ffhi).to_ndarray())
+        )  # int array and lo, float hi
+        self.assertTrue(
+            np.allclose(np.clip(ia, flo, ihi), ak.clip(ipda, flo, iihi).to_ndarray())
+        )  # int array and hi, float lo
+        self.assertTrue(
+            np.allclose(np.clip(fa, ilo, ihi), ak.clip(fpda, ilo, iihi).to_ndarray())
+        )  # int lo and hi, float array
 
         # test with arrays for both
 
-        ilo = np.array([ilo]*ia.size).reshape(ia.shape)
+        ilo = np.array([ilo] * ia.size).reshape(ia.shape)
         iilo = ak.array(ilo)
-        self.assertTrue(np.all(np.equal(np.clip(ia,ilo,ihi),ak.clip(ipda,iilo,iihi).to_ndarray()))) # all ints
-        self.assertTrue(np.allclose(np.clip(fa,flo,fhi),ak.clip(fpda,fflo,ffhi).to_ndarray()))      # all floats
-        self.assertTrue(np.allclose(np.clip(ia,ilo,fhi),ak.clip(ipda,iilo,ffhi).to_ndarray()))      # int array and lo, float hi
-        self.assertTrue(np.allclose(np.clip(ia,flo,ihi),ak.clip(ipda,fflo,iihi).to_ndarray()))      # int array and hi, float lo
-        self.assertTrue(np.allclose(np.clip(fa,ilo,ihi),ak.clip(fpda,iilo,iihi).to_ndarray()))      # int lo and hi, float array
-#        self.assertTrue(np.isclose(ak_mse, 0.0))
+        self.assertTrue(
+            np.all(
+                np.equal(np.clip(ia, ilo, ihi), ak.clip(ipda, iilo, iihi).to_ndarray())
+            )
+        )  # all ints
+        self.assertTrue(
+            np.allclose(np.clip(fa, flo, fhi), ak.clip(fpda, fflo, ffhi).to_ndarray())
+        )  # all floats
+        self.assertTrue(
+            np.allclose(np.clip(ia, ilo, fhi), ak.clip(ipda, iilo, ffhi).to_ndarray())
+        )  # int array and lo, float hi
+        self.assertTrue(
+            np.allclose(np.clip(ia, flo, ihi), ak.clip(ipda, fflo, iihi).to_ndarray())
+        )  # int array and hi, float lo
+        self.assertTrue(
+            np.allclose(np.clip(fa, ilo, ihi), ak.clip(fpda, iilo, iihi).to_ndarray())
+        )  # int lo and hi, float array
+


### PR DESCRIPTION
Closes #3002, adding np.clip functionality.

Usage:  a_clipped = ak.clip(a,lo_value,high_value)

Notes regarding np.clip anomalies are in the comments.

This passes unit testing, but I'm aware that my python may not match our standards.  Please let me know if something needs to be changed.