### PR TITLE
Closes #3033: Optimize CSV write

### DIFF
--- a/src/CSVMsg.chpl
+++ b/src/CSVMsg.chpl
@@ -79,10 +79,7 @@ module CSVMsg {
     }
 
     proc prepFiles(filename: string, overwrite: bool, A) throws {
-        // TODO can prob make prefix and extension const
-        var prefix: string;
-        var extension: string;
-        (prefix,extension) = getFileMetadata(filename);
+        const (prefix,extension) = getFileMetadata(filename);
 
         var targetSize: int = A.targetLocales().size;
         // TODO maybe make filenames distributed? since we are accessing it within a coforall


### PR DESCRIPTION
This PR (closes #3033) improves the performance of the CSV write code

---------
### perf results
@bmcdonald3 was once again kind enough to do a performance head-to-head on one of the big computers.

This table is how long it took to call `df.to_csv` on a `DataFrame` with `10**4 * num_locales` rows and 3 columns (2 integer and 1 strings)
|    | old way  |  new way |
|----------|:-------------:|:------:|
| 1 nodes |  0.2064 sec | 0.0107 sec |
| 4 nodes |    4.0417 sec   | 0.0171 sec |
| 8 nodes | 4.3493 sec |  0.0220 sec |

We see the old way took a significant hit running on more than one locale, but the new way seems to scale much better. This was the biggest dataset the old way was able to finish in a reasonable amount of time. But we already see a pretty decent speed up with the new way being `~197` times faster on the 8 node test (if i did the math right)

<details>
<summary>The perf comparison code</summary>

```python
import time
import os
import arkouda as ak
ak.connect()

seed = 3
cfg = ak.get_config()
N = 10**4 * cfg["numLocales"]
key = ak.arange(N)
vals1 = ak.randint(-(2**32), 2**32, N, seed=seed)
vals2 = ak.random_strings_uniform(0, 16, N, seed=seed)
df = ak.DataFrame({"key": key, "vals1": vals1, "vals2":vals2})

start = time.time()
df.to_csv('test_old_way', new_way=False)
end = time.time()
print("csv write old way time = {:.4f} sec".format(end - start))

start = time.time()
df.to_csv('test_new_way', new_way=True)
end = time.time()
print("csv write new way time = {:.4f} sec".format(end - start))

# make sure the csv files match
for i in range(cfg["numLocales"]):
    assert 0 == os.system("diff test_new_way_LOCALE0000 test_old_way_LOCALE0000")

os.system("rm test_new_way_LOCALE000* test_old_way_LOCALE000*")
```
</details>

---------
### implementation notes

The performance increase comes from switching the inner and outer loop. We used to serially iterate the local subdomain and do an inner parallel loop over the columns. Instead, we serially iterate the columns and use local slices / bulk comm(?) to hopefully get less communication. I think there's probably other places we can optimize, but this seems to take care of the bottleneck

It's worth noting there is a time memory tradeoff here. The old way only ever had one row's worth of data in a string at a time. The new way has a chapel native strings array which contains all the data the locale needs to write (index `i` contains all the data of the `i`th row of that file). I feel the speedup is well worth it especially since I'm under the impression that csv is normally used for relatively small datasets.

If this is a problem and we want to trade some runtime for less memory usage, i **_think_** it should be pretty straightfoward to write in chunks (but now that I say that it definitely won't be). The idea is to take slices of `localSubdomain.size/N`, so the strings array will only have `(all data the locale needs to write) / N` at once.