### PR TITLE
Closes #3063: Fix deprecation warnings

### DIFF
--- a/src/compat/eq-133/ArkoudaRandomCompat.chpl
+++ b/src/compat/eq-133/ArkoudaRandomCompat.chpl
@@ -4,5 +4,5 @@ module ArkoudaRandomCompat {
     var r = new randomStream(int);
     return r.choice(arr, size=n, replace=withReplacement);
   }
-  proc randomStream.skipTo(n: int) do try! this.skipToNth(n);
+  proc ref randomStream.skipTo(n: int) do try! this.skipToNth(n);
 }


### PR DESCRIPTION
Closes #3063

Read _*just barely*_ enough about this-intent on the chapel docs to get the warning to go away, so hopefully it is in fact what we want (hopefully jeremiah can validate that 😁). [This bit of the chpl docs](https://chapel-lang.org/docs/language/spec/methods.html#the-method-receiver-and-the-this-argument) seems to state a `ref` this-intent is what we are looking for since we're modifying `this`