### PR TITLE
Partially addresses issue #3050, updating PROTO tests.

### DIFF
--- a/PROTO_tests/tests/message_test.py
+++ b/PROTO_tests/tests/message_test.py
@@ -90,7 +90,9 @@ class TestMessage:
 class TestJSONArgs:
     # TODO numpy dtypes are not supported by json, we probably want to add an issue to handle this
     SCALAR_TYPES = [int, float, bool, str]
-    PDA_TYPES = [ak.dtype(t) for t in ak.DTypes if t != "str"]
+#   The types below are support in arkouda, as noted in serverConfig.json.  This may be
+#   the same issue noted in the above comment.
+    SUPPORTED_TYPES = [ak.bool, ak.uint64, ak.int64, ak.bigint, ak.uint8, ak.float64]
 
     @pytest.mark.parametrize("dtype", SCALAR_TYPES)
     def test_scalar_args(self, dtype):
@@ -204,7 +206,7 @@ class TestJSONArgs:
         )
         assert args == expected
 
-    @pytest.mark.parametrize("dtype", PDA_TYPES)
+    @pytest.mark.parametrize("dtype", SUPPORTED_TYPES)
     def test_pda_arg(self, dtype):
         pda1 = ak.arange(3, dtype=dtype)
         pda2 = ak.arange(4, dtype=dtype)

--- a/PROTO_tests/tests/series_test.py
+++ b/PROTO_tests/tests/series_test.py
@@ -148,8 +148,10 @@ class TestSeries:
 
     def test_concat(self):
         s = ak.Series(ak.arange(5))
-        s2 = ak.Series(ak.arange(5, 11), ak.arange(5, 11))
-        s3 = ak.Series(ak.arange(5, 10), ak.arange(5, 10))
+        # added data= and index= clarifiers to the next two lines.
+        # without them, the index was interpreted as the name.
+        s2 = ak.Series(data=ak.arange(5, 11), index=ak.arange(5, 11))
+        s3 = ak.Series(data=ak.arange(5, 10), index=ak.arange(5, 10))
 
         df = ak.Series.concat([s, s2], axis=1)
         assert isinstance(df, ak.DataFrame)


### PR DESCRIPTION
Involves #3050

This fixes two small things that were failing in the PROTOs tests.

In messages_test, the variable PDA_TYPES included types that aren't supported in Arkouda, as noted in serverConfig.json.  All of those tests failed.  This has been changed to SUPPORTED_TYPES.

In series_test, there are two lines which now read:

       s2 = ak.Series(data=ak.arange(5, 11), index=ak.arange(5, 11))
       s3 = ak.Series(data=ak.arange(5, 10), index=ak.arange(5, 10))

Previously they didn't have the "data=" and "index=" clarifiers, which caused the 2nd argument to be interpreted as the name, and producing the wrong result, which caused the test to fail.