### PR TITLE
Closes #3071: Add permutation to our generators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ UsedModules.cfg
 .DS_Store
 */.benchmarks
 */.pytest_cache
+.cls-commands.json

--- a/PROTO_tests/tests/random_test.py
+++ b/PROTO_tests/tests/random_test.py
@@ -62,6 +62,11 @@ class TestRandom:
         # verify all the same elements are in permutation as the original
         assert (ak.sort(pda) == ak.sort(array_permute)).all()
 
+        pda = rng.uniform(-(2**32), 2**32, 10)
+        float_array_permute = rng.permutation(pda)
+        # verify all the same elements are in permutation as the original
+        assert np.allclose(ak.sort(pda).to_list(), ak.sort(float_array_permute).to_list())
+
         rng = ak.random.default_rng(18)
         same_seed_range_permute = rng.permutation(20)
         assert (range_permute == same_seed_range_permute).all()
@@ -69,6 +74,11 @@ class TestRandom:
         pda = rng.integers(-(2**32), 2**32, 10)
         same_seed_array_permute = rng.permutation(pda)
         assert (array_permute == same_seed_array_permute).all()
+
+        pda = rng.uniform(-(2**32), 2**32, 10)
+        same_seed_float_array_permute = rng.permutation(pda)
+        # verify all the same elements are in permutation as the original
+        assert np.allclose(float_array_permute.to_list(), same_seed_float_array_permute.to_list())
 
     def test_uniform(self):
         # verify same seed gives different but reproducible arrays
@@ -80,8 +90,8 @@ class TestRandom:
         rng = ak.random.default_rng(18)
         same_seed_first = rng.uniform(-(2**32), 2**32, 10)
         same_seed_second = rng.uniform(-(2**32), 2**32, 10)
-        assert first.to_list() == same_seed_first.to_list()
-        assert second.to_list() == same_seed_second.to_list()
+        assert np.allclose(first.to_list(), same_seed_first.to_list())
+        assert np.allclose(second.to_list(), same_seed_second.to_list())
 
         # verify within bounds (lower inclusive and upper exclusive)
         rng = ak.random.default_rng()
@@ -194,10 +204,10 @@ class TestRandom:
         assert ak.float64 == testArray.dtype
 
         uArray = ak.random.uniform(size=3, low=0, high=5, seed=0)
-        assert [0.30013431967121934, 0.47383036230759112, 1.0441791878997098] == uArray.to_list()
+        assert np.allclose([0.30013431967121934, 0.47383036230759112, 1.0441791878997098], uArray.to_list())
 
         uArray = ak.random.uniform(size=np.int64(3), low=np.int64(0), high=np.int64(5), seed=np.int64(0))
-        assert [0.30013431967121934, 0.47383036230759112, 1.0441791878997098] == uArray.to_list()
+        assert np.allclose([0.30013431967121934, 0.47383036230759112, 1.0441791878997098], uArray.to_list())
 
         with pytest.raises(TypeError):
             ak.random.uniform(low="0", high=5, size=100)
@@ -230,7 +240,7 @@ class TestRandom:
         npda = pda.to_ndarray()
         pda = ak.random.standard_normal(np.int64(100), np.int64(1))
 
-        assert npda.tolist() == pda.to_list()
+        assert np.allclose(npda.tolist(), pda.to_list())
 
         with pytest.raises(TypeError):
             ak.random.standard_normal("100")

--- a/PROTO_tests/tests/random_test.py
+++ b/PROTO_tests/tests/random_test.py
@@ -50,6 +50,26 @@ class TestRandom:
         assert all(bounded_arr.to_ndarray() >= -5)
         assert all(bounded_arr.to_ndarray() < 5)
 
+    def test_permutation(self):
+        # verify same seed gives reproducible arrays
+        rng = ak.random.default_rng(18)
+        # providing just a number permutes the range(num)
+        range_permute = rng.permutation(20)
+        assert (ak.arange(20) == ak.sort(range_permute)).all()
+
+        pda = rng.integers(-(2**32), 2**32, 10)
+        array_permute = rng.permutation(pda)
+        # verify all the same elements are in permutation as the original
+        assert (ak.sort(pda) == ak.sort(array_permute)).all()
+
+        rng = ak.random.default_rng(18)
+        same_seed_range_permute = rng.permutation(20)
+        assert (range_permute == same_seed_range_permute).all()
+
+        pda = rng.integers(-(2**32), 2**32, 10)
+        same_seed_array_permute = rng.permutation(pda)
+        assert (array_permute == same_seed_array_permute).all()
+
     def test_uniform(self):
         # verify same seed gives different but reproducible arrays
         rng = ak.random.default_rng(18)

--- a/arkouda/dtypes.py
+++ b/arkouda/dtypes.py
@@ -82,6 +82,23 @@ def _is_dtype_in_union(dtype, union_type) -> builtins.bool:  # type: ignore
     return hasattr(union_type, "__args__") and dtype in union_type.__args__
 
 
+def _val_isinstance_of_union(val, union_type) -> builtins.bool:  # type: ignore
+    """
+    Check if a given val is an instance of one of the types in the typing.Union
+
+    Args
+    ----
+        val: The val to do the isinstance check on.
+        union_type (type): The typing.Union type to check against.
+
+    Returns
+    -------
+        bool: True if the val is an instance of one
+            of the types in the union_type, False otherwise.
+    """
+    return hasattr(union_type, "__args__") and isinstance(val, union_type.__args__)
+
+
 class BigInt:
     # an estimate of the itemsize of bigint (128 bytes)
     itemsize = 128

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -3045,7 +3045,7 @@ def popcount(pda: pdarray) -> pdarray:
     if pda.dtype == bigint:
         from builtins import sum
 
-        return sum(popcount(a) for a in pda.bigint_to_uint_arrays())
+        return sum(popcount(a) for a in pda.bigint_to_uint_arrays())  # type: ignore
     else:
         repMsg = generic_msg(
             cmd=f"efunc{pda.ndim}D",

--- a/arkouda/random/_generator.py
+++ b/arkouda/random/_generator.py
@@ -8,7 +8,7 @@ from arkouda.dtypes import float64 as akfloat64
 from arkouda.dtypes import int64 as akint64
 from arkouda.dtypes import int_scalars
 from arkouda.dtypes import uint64 as akuint64
-from arkouda.pdarrayclass import create_pdarray
+from arkouda.pdarrayclass import create_pdarray, pdarray
 
 
 class Generator:
@@ -233,10 +233,12 @@ class Generator:
             is_domain_perm = True
             dtype = to_numpy_dtype(akint64)
             size = x
-        else:
+        elif isinstance(x, pdarray):
             is_domain_perm = False
             dtype = to_numpy_dtype(x.dtype)
             size = x.size
+        else:
+            raise TypeError("permtation only accepts a pdarray or int scalar.")
 
         # we have to use the int version since we permute the domain
         name = self._name_dict[to_numpy_dtype(akint64)]

--- a/arkouda/random/_generator.py
+++ b/arkouda/random/_generator.py
@@ -1,10 +1,12 @@
 import numpy.random as np_random
 
 from arkouda.client import generic_msg
+from arkouda.dtypes import _val_isinstance_of_union
 from arkouda.dtypes import bool as akbool
 from arkouda.dtypes import dtype as to_numpy_dtype
 from arkouda.dtypes import float64 as akfloat64
 from arkouda.dtypes import int64 as akint64
+from arkouda.dtypes import int_scalars
 from arkouda.dtypes import uint64 as akuint64
 from arkouda.pdarrayclass import create_pdarray
 
@@ -211,6 +213,47 @@ class Generator:
             # delegate to numpy when return size is 1
             return self._np_generator.standard_normal()
         return standard_normal(size=size, seed=self._seed)
+
+    def permutation(self, x):
+        """
+        Randomly permute a sequence, or return a permuted range.
+
+        Parameters
+        ----------
+        x: int or pdarray
+            If x is an integer, randomly permute ak.arange(x). If x is an array,
+            make a copy and shuffle the elements randomly.
+
+        Returns
+        -------
+        pdarray
+            pdarray of permuted elements
+        """
+        if _val_isinstance_of_union(x, int_scalars):
+            is_domain_perm = True
+            dtype = to_numpy_dtype(akint64)
+            size = x
+        else:
+            is_domain_perm = False
+            dtype = to_numpy_dtype(x.dtype)
+            size = x.size
+
+        # we have to use the int version since we permute the domain
+        name = self._name_dict[to_numpy_dtype(akint64)]
+
+        rep_msg = generic_msg(
+            cmd="permutation",
+            args={
+                "name": name,
+                "x": x,
+                "size": size,
+                "dtype": dtype,
+                "isDomPerm": is_domain_perm,
+                "state": self._state,
+            },
+        )
+        self._state += size
+        return create_pdarray(rep_msg)
 
     def uniform(self, low=0.0, high=1.0, size=None):
         """

--- a/src/RandMsg.chpl
+++ b/src/RandMsg.chpl
@@ -314,7 +314,7 @@ module RandMsg
 
         st.checkTable(name);
 
-        proc permuteHelper(type t, st: borrowed SymTab) throws {
+        proc permuteHelper(type t) throws {
             // we need the int generator in order for permute(domain) to work correctly
             var intGeneratorEntry: borrowed GeneratorSymEntry(int) = toGeneratorSymEntry(st.lookup(name), int);
             ref intRng = intGeneratorEntry.generator;
@@ -331,9 +331,8 @@ module RandMsg
                 st.addEntry(rname, permutedEntry);
             }
             else {
-                // permute requires idxType must be coercible from this stream’s eltType, so
-                // instead we use the permute(dom) and use that to gather the permuted vals. But we're
-                // not missing out on much bc permute(arr) seems to do the same thing but without aggregation
+                // permute requires that the stream's eltType is coercible to the array/domain's idxType,
+                // so we use permute(dom) and use that to gather the permuted vals
                 var permutedArr: [permutedDom] t;
                 ref myArr = toSymEntry(getGenericTypedArrayEntry(xName, st),t).a;
 
@@ -348,16 +347,16 @@ module RandMsg
 
         select dtype {
             when DType.Int64 {
-                permuteHelper(int, st);
+                permuteHelper(int);
             }
             when DType.UInt64 {
-                permuteHelper(uint, st);
+                permuteHelper(uint);
             }
             when DType.Float64 {
-                permuteHelper(real, st);
+                permuteHelper(real);
             }
             when DType.Bool {
-                permuteHelper(bool, st);
+                permuteHelper(bool);
             }
             otherwise {
                 var errorMsg = "Unhandled data type %s".doFormat(dtypeStr);

--- a/src/compat/e-132/ArkoudaRandomCompat.chpl
+++ b/src/compat/e-132/ArkoudaRandomCompat.chpl
@@ -1,5 +1,9 @@
 module ArkoudaRandomCompat {
   use Random.PCGRandom only PCGRandomStream;
+
+  private proc is1DRectangularDomain(d) param do
+    return d.isRectangular() && d.rank == 1;
+
   record randomStream {
     type eltType = int;
     forwarding var r: shared PCGRandomStream(eltType);
@@ -16,6 +20,15 @@ module ArkoudaRandomCompat {
     }
     proc ref fill(ref arr: [], min: arr.eltType, max: arr.eltType) where arr.isRectangular() {
       r.fillRandom(arr, min, max);
+    }
+    proc ref permute(const ref arr: [?d] ?t): [] t  where is1DRectangularDomain(d) && isCoercible(this.eltType, d.idxType) {
+      return r.permutation(arr);
+    }
+    proc ref permute(d: domain(?)): [] d.idxType  where is1DRectangularDomain(d) && isCoercible(this.eltType, d.idxType) {
+      // unfortunately there isn't a domain permutation function so we will create an array to permute
+      var domArr: [d] d.idxType = d;
+      r.permutation(domArr);
+      return domArr;
     }
     proc skipTo(n: int) do try! r.skipToNth(n);
   }

--- a/src/compat/eq-131/ArkoudaRandomCompat.chpl
+++ b/src/compat/eq-131/ArkoudaRandomCompat.chpl
@@ -1,5 +1,9 @@
 module ArkoudaRandomCompat {
   use Random.PCGRandom only PCGRandomStream;
+
+  private proc is1DRectangularDomain(d) param do
+    return d.isRectangular() && d.rank == 1;
+
   record randomStream {
     type eltType = int;
     forwarding var r: shared PCGRandomStream(eltType);
@@ -16,6 +20,15 @@ module ArkoudaRandomCompat {
     }
     proc ref fill(ref arr: [], min: arr.eltType, max: arr.eltType) where arr.isRectangular() {
       r.fillRandom(arr, min, max);
+    }
+    proc ref permute(const ref arr: [?d] ?t): [] t  where is1DRectangularDomain(d) && isCoercible(this.eltType, d.idxType) {
+      return r.permutation(arr);
+    }
+    proc ref permute(d: domain): [] d.idxType  where is1DRectangularDomain(d) && isCoercible(this.eltType, d.idxType) {
+      // unfortunately there isn't a domain permutation function so we will create an array to permute
+      var domArr: [d] d.idxType = d;
+      r.permutation(domArr);
+      return domArr;
     }
     proc skipTo(n: int) do try! r.skipToNth(n);
   }

--- a/src/compat/eq-133/ArkoudaRandomCompat.chpl
+++ b/src/compat/eq-133/ArkoudaRandomCompat.chpl
@@ -1,8 +1,21 @@
 module ArkoudaRandomCompat {
   public use Random;
+
+  private proc is1DRectangularDomain(d) param do
+    return d.isRectangular() && d.rank == 1;
+
   proc sample(arr: [?d] ?t, n: int, withReplacement: bool): [] t throws {
     var r = new randomStream(int);
     return r.choice(arr, size=n, replace=withReplacement);
   }
   proc ref randomStream.skipTo(n: int) do try! this.skipToNth(n);
+  proc ref randomStream.permute(const ref arr: [?d] ?t): [] t  where is1DRectangularDomain(d) && isCoercible(this.eltType, d.idxType) {
+    return this.permutation(arr);
+  }
+  proc ref randomStream.permute(d: domain(?)): [] d.idxType  where is1DRectangularDomain(d) && isCoercible(this.eltType, d.idxType) {
+    // unfortunately there isn't a domain permutation function so we will create an array to permute
+    var domArr: [d] d.idxType = d;
+    this.permutation(domArr);
+    return domArr;
+  }
 }

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -61,6 +61,11 @@ class RandomTest(ArkoudaTest):
         # verify all the same elements are in permutation as the original
         self.assertEqual(ak.sort(pda).to_list(), ak.sort(array_permute).to_list())
 
+        pda = rng.uniform(-(2**32), 2**32, 10)
+        float_array_permute = rng.permutation(pda)
+        # verify all the same elements are in permutation as the original
+        self.assertTrue(np.allclose(ak.sort(pda).to_list(), ak.sort(float_array_permute).to_list()))
+
         rng = ak.random.default_rng(18)
         same_seed_range_permute = rng.permutation(20)
         self.assertEqual(range_permute.to_list(), same_seed_range_permute.to_list())
@@ -68,6 +73,11 @@ class RandomTest(ArkoudaTest):
         pda = rng.integers(-(2**32), 2**32, 10)
         same_seed_array_permute = rng.permutation(pda)
         self.assertEqual(array_permute.to_list(), same_seed_array_permute.to_list())
+
+        pda = rng.uniform(-(2**32), 2**32, 10)
+        same_seed_float_array_permute = rng.permutation(pda)
+        # verify all the same elements are in permutation as the original
+        self.assertTrue(np.allclose(float_array_permute.to_list(), same_seed_float_array_permute.to_list()))
 
     def test_uniform(self):
         # verify same seed gives different but reproducible arrays

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -49,6 +49,26 @@ class RandomTest(ArkoudaTest):
         self.assertTrue(all(bounded_arr.to_ndarray() >= -5))
         self.assertTrue(all(bounded_arr.to_ndarray() < 5))
 
+    def test_permutation(self):
+        # verify same seed gives reproducible arrays
+        rng = ak.random.default_rng(18)
+        # providing just a number permutes the range(num)
+        range_permute = rng.permutation(20)
+        self.assertEqual(ak.arange(20).to_list(), ak.sort(range_permute).to_list())
+
+        pda = rng.integers(-(2**32), 2**32, 10)
+        array_permute = rng.permutation(pda)
+        # verify all the same elements are in permutation as the original
+        self.assertEqual(ak.sort(pda).to_list(), ak.sort(array_permute).to_list())
+
+        rng = ak.random.default_rng(18)
+        same_seed_range_permute = rng.permutation(20)
+        self.assertEqual(range_permute.to_list(), same_seed_range_permute.to_list())
+
+        pda = rng.integers(-(2**32), 2**32, 10)
+        same_seed_array_permute = rng.permutation(pda)
+        self.assertEqual(array_permute.to_list(), same_seed_array_permute.to_list())
+
     def test_uniform(self):
         # verify same seed gives different but reproducible arrays
         rng = ak.random.default_rng(18)


### PR DESCRIPTION
This PR (closes https://github.com/Bears-R-Us/arkouda/issues/3071) adds permutation to `rng`.

Note:
The array version of the chpl `permute` proc requires idxType must be coercible from this stream’s eltType, so instead we use the domain version of `permute` and use that to gather the permuted vals. But we're not missing out on much because the array version seems to do the same thing but without aggregation

I also added:
- `.cls-commands.json` to `.gitignore` which is added by the chpl vscode extension
-  a helper `_val_isinstance_of_union` to do an `isinstance` check on types in `Union`