### PR TITLE
Closes #3084: Add `shuffle` to random number generators

### DIFF
--- a/PROTO_tests/tests/random_test.py
+++ b/PROTO_tests/tests/random_test.py
@@ -50,6 +50,33 @@ class TestRandom:
         assert all(bounded_arr.to_ndarray() >= -5)
         assert all(bounded_arr.to_ndarray() < 5)
 
+    def test_shuffle(self):
+        # verify same seed gives reproducible arrays
+        rng = ak.random.default_rng(18)
+
+        int_pda = rng.integers(-(2**32), 2**32, 10)
+        pda_copy = int_pda[:]
+        # shuffle int_pda in place
+        rng.shuffle(int_pda)
+        # verify all the same elements are in permutation as the original
+        assert (ak.sort(int_pda) == ak.sort(pda_copy)).all()
+
+        float_pda = rng.uniform(-(2**32), 2**32, 10)
+        pda_copy = float_pda[:]
+        rng.shuffle(float_pda)
+        # verify all the same elements are in permutation as the original
+        assert (ak.sort(float_pda) == ak.sort(pda_copy)).all()
+
+        rng = ak.random.default_rng(18)
+
+        pda = rng.integers(-(2**32), 2**32, 10)
+        rng.shuffle(pda)
+        assert (pda == int_pda).all()
+
+        pda = rng.uniform(-(2**32), 2**32, 10)
+        rng.shuffle(pda)
+        assert np.allclose(pda.to_list(), float_pda.to_list())
+
     def test_permutation(self):
         # verify same seed gives reproducible arrays
         rng = ak.random.default_rng(18)
@@ -204,10 +231,14 @@ class TestRandom:
         assert ak.float64 == testArray.dtype
 
         uArray = ak.random.uniform(size=3, low=0, high=5, seed=0)
-        assert np.allclose([0.30013431967121934, 0.47383036230759112, 1.0441791878997098], uArray.to_list())
+        assert np.allclose(
+            [0.30013431967121934, 0.47383036230759112, 1.0441791878997098], uArray.to_list()
+        )
 
         uArray = ak.random.uniform(size=np.int64(3), low=np.int64(0), high=np.int64(5), seed=np.int64(0))
-        assert np.allclose([0.30013431967121934, 0.47383036230759112, 1.0441791878997098], uArray.to_list())
+        assert np.allclose(
+            [0.30013431967121934, 0.47383036230759112, 1.0441791878997098], uArray.to_list()
+        )
 
         with pytest.raises(TypeError):
             ak.random.uniform(low="0", high=5, size=100)

--- a/arkouda/random/_generator.py
+++ b/arkouda/random/_generator.py
@@ -214,6 +214,35 @@ class Generator:
             return self._np_generator.standard_normal()
         return standard_normal(size=size, seed=self._seed)
 
+    def shuffle(self, x):
+        """
+        Randomly shuffle a pdarray in place.
+
+        Parameters
+        ----------
+        x: pdarray
+            shuffle the elements of x randomly in place
+
+        Returns
+        -------
+        None
+        """
+        if not isinstance(x, pdarray):
+            raise TypeError("shuffle only accepts a pdarray.")
+        dtype = to_numpy_dtype(x.dtype)
+        name = self._name_dict[to_numpy_dtype(akint64)]
+        generic_msg(
+            cmd="shuffle",
+            args={
+                "name": name,
+                "x": x,
+                "size": x.size,
+                "dtype": dtype,
+                "state": self._state,
+            },
+        )
+        self._state += x.size
+
     def permutation(self, x):
         """
         Randomly permute a sequence, or return a permuted range.

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -49,6 +49,33 @@ class RandomTest(ArkoudaTest):
         self.assertTrue(all(bounded_arr.to_ndarray() >= -5))
         self.assertTrue(all(bounded_arr.to_ndarray() < 5))
 
+    def test_shuffle(self):
+        # verify same seed gives reproducible arrays
+        rng = ak.random.default_rng(18)
+
+        int_pda = rng.integers(-(2**32), 2**32, 10)
+        pda_copy = int_pda[:]
+        # shuffle int_pda in place
+        rng.shuffle(int_pda)
+        # verify all the same elements are in permutation as the original
+        self.assertEqual(ak.sort(int_pda).to_list(), ak.sort(pda_copy).to_list())
+
+        float_pda = rng.uniform(-(2**32), 2**32, 10)
+        pda_copy = float_pda[:]
+        rng.shuffle(float_pda)
+        # verify all the same elements are in permutation as the original
+        self.assertEqual(ak.sort(float_pda).to_list(), ak.sort(pda_copy).to_list())
+
+        rng = ak.random.default_rng(18)
+
+        pda = rng.integers(-(2**32), 2**32, 10)
+        rng.shuffle(pda)
+        self.assertEqual(pda.to_list(), int_pda.to_list())
+
+        pda = rng.uniform(-(2**32), 2**32, 10)
+        rng.shuffle(pda)
+        self.assertTrue(np.allclose(pda.to_list(), float_pda.to_list()))
+
     def test_permutation(self):
         # verify same seed gives reproducible arrays
         rng = ak.random.default_rng(18)
@@ -77,7 +104,9 @@ class RandomTest(ArkoudaTest):
         pda = rng.uniform(-(2**32), 2**32, 10)
         same_seed_float_array_permute = rng.permutation(pda)
         # verify all the same elements are in permutation as the original
-        self.assertTrue(np.allclose(float_array_permute.to_list(), same_seed_float_array_permute.to_list()))
+        self.assertTrue(
+            np.allclose(float_array_permute.to_list(), same_seed_float_array_permute.to_list())
+        )
 
     def test_uniform(self):
         # verify same seed gives different but reproducible arrays


### PR DESCRIPTION
This PR (closes #3084) adds `shuffle` method to our random number generators