### PR TITLE
Part of #3088: Generate seed for sparse sum test

### DIFF
--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -303,7 +303,7 @@ def attach_all(names: list):
     return {n: attach(n) for n in names}
 
 
-def sparse_sum_help(idx1, idx2, val1, val2, merge=True, percent_transfer_limit=100):
+def sparse_sum_help(idx1, idx2, val1, val2, merge=False, percent_transfer_limit=100):
     """
     Helper for summing two sparse matrices together
 


### PR DESCRIPTION
This PR is more of a bandaid since I can't reproduce the error in #3088. I added randomly generated seeds that get printed to stdout when the test fails. This will make it easier to reproduce when it pops back up in the nightly

In the meantime I switched the sort workflow to be the default, so the merge workflow is opt in

More info about how I went about trying to reproduce it can be found in https://github.com/Bears-R-Us/arkouda/issues/3088#issuecomment-2043527577