### PR TITLE
Fix Parquet double reads to properly account for null values

### DIFF
--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -847,36 +847,34 @@ int cpp_readColumnByName(const char* filename, void* chpl_arr, const char* colna
           delete[] rep_lvl;
         }
       } else if(ty == ARROWDOUBLE) {
+        int16_t definition_level; // nullable type and only reading single records in batch
         auto chpl_ptr = (double*)chpl_arr;
         parquet::DoubleReader* reader =
           static_cast<parquet::DoubleReader*>(column_reader.get());
         startIdx -= reader->Skip(startIdx);
 
-        while (reader->HasNext() && i < numElems) {
-          if((numElems - i) < batchSize) // adjust batchSize if needed
-            batchSize = numElems - i;
+        if (max_def != 0) {
+          // nulls are in this col
+          while (reader->HasNext() && i < numElems) {
+            if((numElems - i) < batchSize)
+              batchSize = numElems - i;
+            (void)reader->ReadBatch(batchSize, nullptr, nullptr, &chpl_ptr[i], &values_read);
+            i+=values_read;
+          }
+        } else {
+          while (reader->HasNext()) {
+            double value;
+            (void)reader->ReadBatch(1, &definition_level, nullptr, &value, &values_read);
+            // if values_read is 0, that means that it was a null value
+            if(values_read > 0) {
+              // this means it wasn't null
+              chpl_ptr[i] = value;
 
-          // define def and rep level tracking to the batch size. This is required to detect NaN
-          int16_t* def_lvl = new int16_t[batchSize] { 0 };
-          int16_t* rep_lvl = new int16_t[batchSize] { 0 };
-
-          double* tmpArr = new double[batchSize] { 0 }; // this will not include NaN values
-          int64_t idx_adjust = 0; // adjustment for NaNs encountered so index into tmpArr is correct
-          (void)reader->ReadBatch(batchSize, def_lvl, rep_lvl, tmpArr, &values_read);
-          // copy values into our Chapel array
-          for (int64_t j = 0; j < batchSize; j++){
-            // when definition level is 0, mean Null which equated to NaN here unless 0 is the max meaning no null/nan values
-            if (max_def != 0 && def_lvl[j] == 0) {
-              chpl_ptr[i] = NAN;
-              idx_adjust++; // account for the NaN at the indexes after because tmpArr only stores values
             } else {
-              chpl_ptr[i] = tmpArr[j-idx_adjust];
+              chpl_ptr[i] = NAN;
             }
             i++;
           }
-          delete[] tmpArr;
-          delete[] def_lvl;
-          delete[] rep_lvl;
         }
       } else if(ty == ARROWDECIMAL) {
         auto chpl_ptr = (double*)chpl_arr;


### PR DESCRIPTION
In the Parquet taxi cab dataset, we were hitting end of stream errors when reading in null values and this was identified by Tess in https://github.com/Bears-R-Us/arkouda/issues/3087.

To fix this, we switch to reading in single values in the case where nulls are allowed so that we can check the definition level before inserting a value into the Parquet array.

Potential optimizations are an `allow_nan` flag to avoid the check and then, additionally, we could modify the previous implementation by reading the definition level and values into temporary vectors and then only assign the value if the value is non-null.

The reason it didnt' work before was that it was bsaed off of `batchSize` to loop over the values, but batch size doesn't actually guarantee how many values were read, due to row group intricacies.