### PR TITLE
Fixes #3087: Failure reading non-float parquet columns with null values

### DIFF
--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -763,6 +763,7 @@ def read_parquet(
     allow_errors: bool = False,
     tag_data: bool = False,
     read_nested: bool = True,
+    has_non_float_nulls: bool = False,
 ) -> Union[
     pdarray,
     Strings,
@@ -819,6 +820,9 @@ def read_parquet(
         Default True, when True, SegArray objects will be read from the file. When False,
         SegArray (or other nested Parquet columns) will be ignored.
         If datasets is not None, this will be ignored.
+    has_non_float_nulls: bool
+        Default False. This flag must be set to True to read non-float parquet columns
+        that contain null values.
 
     Returns
     -------
@@ -883,6 +887,7 @@ def read_parquet(
                 allow_errors=allow_errors,
                 tag_data=tag_data,
                 read_nested=read_nested,
+                has_non_float_nulls=has_non_float_nulls,
             )[dset]
             for dset in datasets
         }
@@ -897,6 +902,7 @@ def read_parquet(
                 "dsets": datasets,
                 "filenames": filenames,
                 "tag_data": tag_data,
+                "has_non_float_nulls": has_non_float_nulls,
             },
         )
         rep = json.loads(rep_msg)  # See GenSymIO._buildReadAllMsgJson for json structure
@@ -1847,6 +1853,7 @@ def read(
     calc_string_offsets=False,
     column_delim: str = ",",
     read_nested: bool = True,
+    has_non_float_nulls: bool = False,
 ) -> Union[
     pdarray,
     Strings,
@@ -1908,7 +1915,9 @@ def read(
         SegArray (or other nested Parquet columns) will be ignored.
         Ignored if datasets is not None
         Parquet Files only.
-
+    has_non_float_nulls: bool
+        Default False. This flag must be set to True to read non-float parquet columns
+        that contain null values.
 
     Returns
     -------
@@ -1973,6 +1982,7 @@ def read(
             strict_types=strictTypes,
             allow_errors=allow_errors,
             read_nested=read_nested,
+            has_non_float_nulls=has_non_float_nulls,
         )
     elif ftype.lower() == "csv":
         return read_csv(
@@ -1989,6 +1999,7 @@ def read_tagged_data(
     allow_errors: bool = False,
     calc_string_offsets=False,
     read_nested: bool = True,
+    has_non_float_nulls: bool = False,
 ):
     """
     Read datasets from files and tag each record to the file it was read from.
@@ -2020,6 +2031,9 @@ def read_tagged_data(
         SegArray (or other nested Parquet columns) will be ignored.
         Ignored if datasets is not `None`
         Parquet Files only.
+    has_non_float_nulls: bool
+        Default False. This flag must be set to True to read non-float parquet columns
+        that contain null values.
 
     Notes
     ------
@@ -2070,6 +2084,7 @@ def read_tagged_data(
                 allow_errors=allow_errors,
                 tag_data=True,
                 read_nested=read_nested,
+                has_non_float_nulls=has_non_float_nulls,
             ),
             file_cat,
         )

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -775,7 +775,6 @@ int cpp_readColumnByName(const char* filename, void* chpl_arr, bool* where_null_
             (void)reader->ReadBatch(1, &definition_level, nullptr, &chpl_ptr[i], &values_read);
             // if values_read is 0, that means that it was a null value
             if(values_read == 0) {
-              chpl_ptr[i] = NAN;
               where_null_chpl[i] = true;
             }
             i++;
@@ -808,7 +807,6 @@ int cpp_readColumnByName(const char* filename, void* chpl_arr, bool* where_null_
             (void)reader->ReadBatch(1, &definition_level, nullptr, &tmp, &values_read);
             // if values_read is 0, that means that it was a null value
             if(values_read == 0) {
-              chpl_ptr[i] = NAN;
               where_null_chpl[i] = true;
             }
             else {
@@ -837,7 +835,6 @@ int cpp_readColumnByName(const char* filename, void* chpl_arr, bool* where_null_
             (void)reader->ReadBatch(1, &definition_level, nullptr, &chpl_ptr[i], &values_read);
             // if values_read is 0, that means that it was a null value
             if(values_read == 0) {
-              chpl_ptr[i] = NAN;
               where_null_chpl[i] = true;
             }
             i++;

--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -48,12 +48,12 @@ extern "C" {
   int64_t c_getNumRows(const char*, char** errMsg);
   int64_t cpp_getNumRows(const char*, char** errMsg);
 
-  int c_readColumnByName(const char* filename, void* chpl_arr,
+  int c_readColumnByName(const char* filename, void* chpl_arr, bool* where_null_chpl,
                          const char* colname, int64_t numElems, int64_t startIdx,
-                         int64_t batchSize, int64_t byteLength, char** errMsg);
-  int cpp_readColumnByName(const char* filename, void* chpl_arr,
+                         int64_t batchSize, int64_t byteLength, bool hasNonFloatNulls, char** errMsg);
+  int cpp_readColumnByName(const char* filename, void* chpl_arr, bool* where_null_chpl,
                            const char* colname, int64_t numElems, int64_t startIdx,
-                           int64_t batchSize, int64_t byteLength, char** errMsg);
+                           int64_t batchSize, int64_t byteLength, bool hasNonFloatNulls, char** errMsg);
 
   int c_readListColumnByName(const char* filename, void* chpl_arr, 
                             const char* colname, int64_t numElems, 


### PR DESCRIPTION
This PR fixes #3087, a bug encountered by user while reading the nyc taxi cab data. The parquet file contained an `int64` column with null values. Pandas handles this by converting into a `float64` column and replaces the null values with `NaN`.

Properly handling null values is slower than the regular workflow because we can't read in batches. Since non-float columns having nulls is a fairly rare case, I decided to default to the faster way so the common case wouldn't take a performance hit. In the rare case, we fail with an informative error message that specifies which flag needs to be set to handle the null values. Rerunning with that flag behaves correctly and returns an array that matches pandas

```python
>>> pddf = pd.read_parquet('/Users/pierce/Downloads/yellow_tripdata_2023-02.parquet')
>>> akdf = ak.DataFrame(ak.read_parquet('/Users/pierce/Downloads/yellow_tripdata_2023-02.parquet'))
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)

RuntimeError: ParquetError 145 readFilesByName:ParquetMsg Unexpected end of stream. This may be due to null values in a non-float column. Try again with the flag has_non_float_nulls=True

>>> akdf = ak.DataFrame(ak.read_parquet('/Users/pierce/Downloads/yellow_tripdata_2023-02.parquet', has_non_float_nulls=True))

>>> akdf['passenger_count']
array([2.00000000000000000 1.00000000000000000 1.00000000000000000 ... nan nan nan])

>>> np.allclose(pddf['passenger_count'].to_list(), akdf['passenger_count'].to_list(), equal_nan=True)
True
```