### PR TITLE
3050 next

### DIFF
--- a/PROTO_tests/tests/groupby_test.py
+++ b/PROTO_tests/tests/groupby_test.py
@@ -18,7 +18,7 @@ class TestGroupBy:
     OPS = list(ak.GroupBy.Reductions)
     OPS.append("count")
     NAN_OPS = frozenset(["mean", "min", "max", "sum", "prod"])
-    seed = pytest.seed if pytest.seed is not None else 867530
+    seed = pytest.seed if pytest.seed is not None else 8675309
     np.random.seed(seed)
 
     @classmethod

--- a/PROTO_tests/tests/groupby_test.py
+++ b/PROTO_tests/tests/groupby_test.py
@@ -18,6 +18,8 @@ class TestGroupBy:
     OPS = list(ak.GroupBy.Reductions)
     OPS.append("count")
     NAN_OPS = frozenset(["mean", "min", "max", "sum", "prod"])
+    seed = pytest.seed if pytest.seed is not None else 867530
+    np.random.seed(seed)
 
     @classmethod
     def setup_class(cls):

--- a/PROTO_tests/tests/groupby_test.py
+++ b/PROTO_tests/tests/groupby_test.py
@@ -84,11 +84,17 @@ class TestGroupBy:
 
         assert np.allclose(pdvals, akvals.to_ndarray(), equal_nan=True)  # value validation
 
+# For pandas equivalency tests, the standard problem size of 10**8 is much too large, especially
+# in the case of "aggregate by product."  For large vectors of random integers from 0 through N,
+# it's inevitable that the product will either be zero (if the vector includes a zero) or infinity
+# (if it doesn't).  So in the case of 'prod', size is arbitrarily reduced to 20.
+
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("levels", LEVELS)
     @pytest.mark.parametrize("op", OPS)
     def test_pandas_equivalency(self, size, levels, op):
-        data = self.make_arrays(size)
+        SIZE = 100 if op == 'prod' else size
+        data = self.make_arrays(SIZE)
         df = pd.DataFrame(data)
         akdf = {k: ak.array(v) for k, v in data.items()}
         if levels == 1:
@@ -406,6 +412,7 @@ class TestGroupBy:
 
         with pytest.raises(TypeError):
             ak.GroupBy(self.fvalues)
+#       ak.GroupBy(self.fvalues)  # will this cause a different error?
 
         with pytest.raises(TypeError):
             gb.broadcast([])


### PR DESCRIPTION
Fixes some more issues from PR # 3050, involving the tests in PROTOS/tests.

In numeric_test.py, (1) removes the superfluous variable prob_size, since the pytest.prob_size overruled it anyway, and (2) restricts casting to the types supported per serverConfig.json.

In groupby_test.py, (1) adds a random number seed so results will be reproducible (uses the same seed from numeric_test.py), (2) hardcodes problem size to 100 in test_pandas_equivalency when op = 'prod'. (Larger problem sizes virtually guarantee that the 'prod' aggregate will produce mostly zeroes with occasional overflows beyond the limits of np.int64 and np.uint64).

There remains an issue in test_error_handling where ak.GroupBy(self.fvalues) does not raise the expected TypeError.