### PR TITLE
Closes #3112: Fix Parquet string column free

### DIFF
--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -2058,8 +2058,9 @@ int cpp_getNumRowGroups(int64_t readerIdx) {
 }
 
 void cpp_freeMapValues(void* row) {
-  auto curr = static_cast<parquet::ByteArray*>(row);
-  delete curr;
+  parquet::ByteArray* string_values =
+    static_cast<parquet::ByteArray*>(row);
+  free(string_values);
   globalColumnReaders.clear();
   globalRowGroupReaders.clear();
   globalFiles.clear();


### PR DESCRIPTION
In the Parquet string read code, delete was being
called when free should have been used, which was
causing address sanitizer issues.

Closes #3112 