### PR TITLE
Closes #2893 dataframe.GroupBy.count to align with pandas

### DIFF
--- a/PROTO_tests/tests/groupby_test.py
+++ b/PROTO_tests/tests/groupby_test.py
@@ -100,7 +100,7 @@ class TestGroupBy:
 
         for vname in ("int64", "uint64", "float64", "bool"):
             if op == "count":
-                print(f"Doing .count() - {vname}")
+                print(f"Doing .size() - {vname}")
             else:
                 print(f"\nDoing aggregate({vname}, {op})")
 
@@ -111,7 +111,7 @@ class TestGroupBy:
                 print("Pandas does not implement")
                 do_check = False
             try:
-                akkeys, akvals = akg.count() if op == "count" else akg.aggregate(akdf[vname], op)
+                akkeys, akvals = akg.size() if op == "count" else akg.aggregate(akdf[vname], op)
             except Exception as E:
                 print("Arkouda error: ", E)
                 continue  # skip check
@@ -174,7 +174,7 @@ class TestGroupBy:
         a = ak.array([True, False, True, True, False])
         true_ct = a.sum()
         g = ak.GroupBy(a)
-        k, ct = g.count()
+        k, ct = g.size()
 
         assert ct[1] == true_ct
         assert k.to_list() == [False, True]
@@ -187,7 +187,7 @@ class TestGroupBy:
 
         b = ak.array([False, False, True, False, False])
         g = ak.GroupBy([a, b])
-        k, ct = g.count()
+        k, ct = g.size()
         assert ct.to_list() == [2, 2, 1]
         assert k[0].to_list() == [False, True, True]
         assert k[1].to_list() == [False, False, True]
@@ -234,13 +234,13 @@ class TestGroupBy:
             )
 
     def test_count(self):
-        keys, counts = self.igb.count()
+        keys, counts = self.igb.size()
 
         assert [1, 2, 3, 4, 5] == keys.to_list()
         assert [1, 4, 2, 1, 2] == counts.to_list()
 
     def test_broadcast_ints(self):
-        keys, counts = self.igb.count()
+        keys, counts = self.igb.size()
 
         results = self.igb.broadcast(1 * (counts > 2), permute=False)
         assert [0, 1, 1, 1, 1, 0, 0, 0, 0, 0] == results.to_list()
@@ -261,7 +261,7 @@ class TestGroupBy:
         assert [1, 1, 1, 0, 0, 0, 1, 1, 0, 1] == results.to_list()
 
     def test_broadcast_uints(self):
-        keys, counts = self.ugb.count()
+        keys, counts = self.ugb.size()
         assert [1, 4, 2, 1, 2] == counts.to_list()
         assert [1, 2, 3, 4, 5] == keys.to_list()
 
@@ -291,7 +291,7 @@ class TestGroupBy:
         assert i_results.to_list() == u_results.to_list()
 
     def test_broadcast_strings(self):
-        keys, counts = self.sgb.count()
+        keys, counts = self.sgb.size()
         assert [1, 4, 2, 1, 2] == counts.to_list()
         assert ["1", "2", "3", "4", "5"] == keys.to_list()
 
@@ -332,7 +332,7 @@ class TestGroupBy:
         assert bi_broad.max_bits == a.max_bits
 
         # do the same tests as uint and compare the results
-        keys, counts = self.bigb.count()
+        keys, counts = self.bigb.size()
         assert [1, 4, 2, 1, 2] == counts.to_list()
         assert [1, 2, 3, 4, 5] == keys.to_list()
 
@@ -364,7 +364,7 @@ class TestGroupBy:
         assert bi_results.to_list() == u_results.to_list()
 
     def test_broadcast_booleans(self):
-        keys, counts = self.igb.count()
+        keys, counts = self.igb.size()
 
         results = self.igb.broadcast(counts > 2, permute=False)
         assert [0, 1, 1, 1, 1, 0, 0, 0, 0, 0] == results.to_list()
@@ -403,9 +403,6 @@ class TestGroupBy:
 
         with pytest.raises(TypeError):
             ak.GroupBy(ak.arange(4), ak.arange(4))
-
-        with pytest.raises(TypeError):
-            ak.GroupBy(self.fvalues)
 
         with pytest.raises(TypeError):
             gb.broadcast([])
@@ -509,6 +506,29 @@ class TestGroupBy:
         assert u_unique_keys.to_list() == i_unique_keys.to_list()
         assert u_group_nunique.to_list() == i_group_nunique.to_list()
 
+    def test_groupby_count(self):
+        a = ak.array([1, 0, -1, 1, -1, -1])
+        b0 = ak.array([1, np.nan, 1, 1, np.nan, np.nan])
+
+        dtypes = ["float64", "bool", "int64"]
+
+        gb = ak.GroupBy(a)
+
+        for dt in dtypes:
+            b = ak.cast(b0, dt=dt)
+            keys, counts = gb.count(b)
+            assert np.allclose(keys.to_ndarray(), np.array([-1, 0, 1]), equal_nan=True)
+
+            if dt == "float64":
+                assert np.allclose(counts.to_ndarray(), np.array([1, 0, 2]), equal_nan=True)
+            else:
+                assert np.allclose(counts.to_ndarray(), np.array([3, 1, 2]), equal_nan=True)
+
+        #   Test BigInt separately
+        b = ak.array(np.array([1, 0, 1, 1, 0, 0]), dtype="bigint")
+        assert np.allclose(keys.to_ndarray(), np.array([-1, 0, 1]), equal_nan=True)
+        assert np.allclose(counts.to_ndarray(), np.array([3, 1, 2]), equal_nan=True)
+
     def test_bigint_groupby(self):
         bi = 2**200
         # these bigint arrays are the int arrays shifted up by 2**200
@@ -521,8 +541,8 @@ class TestGroupBy:
         int_arrays = [a, b]
         bigint_arrays = [bi_a, bi_b]
         for i_arr, bi_arr in zip(int_arrays, bigint_arrays):
-            i_unique, i_counts = ak.GroupBy(i_arr).count()
-            bi_unique, bi_counts = ak.GroupBy(bi_arr).count()
+            i_unique, i_counts = ak.GroupBy(i_arr).size()
+            bi_unique, bi_counts = ak.GroupBy(bi_arr).size()
             shift_down = ak.cast(bi_unique - bi, ak.int64)
             # order isn't guaranteed so argsort and permute
             i_perm = ak.argsort(i_unique)
@@ -531,8 +551,8 @@ class TestGroupBy:
             assert i_unique[i_perm].to_list() == shift_down[bi_perm].to_list()
 
         # multilevel groupby
-        (i1_unique, i2_unique), i_counts = ak.GroupBy(int_arrays).count()
-        (bi1_unique, bi2_unique), bi_counts = ak.GroupBy(bigint_arrays).count()
+        (i1_unique, i2_unique), i_counts = ak.GroupBy(int_arrays).size()
+        (bi1_unique, bi2_unique), bi_counts = ak.GroupBy(bigint_arrays).size()
         shift_down1 = ak.cast(bi1_unique - bi, ak.int64)
         shift_down2 = ak.cast(bi2_unique - bi, ak.int64)
         # order isn't guaranteed so argsort and permute
@@ -545,7 +565,7 @@ class TestGroupBy:
         # verify we can groupby bigint with other typed arrays
         mixted_types_arrays = [[bi_a, b], [a, bi_b], [bi_b, a], [b, bi_a]]
         for arrs in mixted_types_arrays:
-            ak.GroupBy(arrs).count()
+            ak.GroupBy(arrs).size()
 
     def test_bigint_groupby_aggregations(self):
         # test equivalent to uint when max_bits=64

--- a/arkouda/alignment.py
+++ b/arkouda/alignment.py
@@ -537,7 +537,7 @@ def search_intervals(vals, intervals, tiebreak=None, hierarchical=True):
             )
             by_val_interval = GroupBy([all_uval_idx, all_match_interval_idx])
             # a true hit happens when a value is contained in all of an interval's 1-d projections
-            is_a_hit = by_val_interval.count()[1] == len(low)
+            is_a_hit = by_val_interval.size()[1] == len(low)
             # indices of the true hits and their containing intervals
             val_hits, interval_hits = [x[is_a_hit] for x in by_val_interval.unique_keys]
             # a value might be found in more than one interval, so we need to break ties

--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -304,7 +304,7 @@ class Categorical:
         )
         # Group combined categories to find matches
         g = GroupBy(bothcats)
-        ct = g.count()[1]
+        ct = g.size()[1]
         if (ct > 2).any():
             raise ValueError("User-specified categories must be unique")
         # Matches have two hits in concatenated array
@@ -392,7 +392,7 @@ class Categorical:
 
         Examples
         --------
-        >>> from arkouda import ak
+        >>> import arkouda as ak
         >>> ak.connect()
         >>> a = ak.array(["a","b","c"])
         >>> a

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -150,60 +150,6 @@ class GroupBy:
 
         return aggop
 
-    def count(self, as_series=None):
-        """
-        Compute the count of each value as the total number of rows, including NaN values.
-        This is an alias for size(), and may change in the future.
-
-        Parameters
-        ----------
-
-        as_series : bool, default=None
-            Indicates whether to return arkouda.dataframe.DataFrame (if as_series = False) or
-            arkouda.series.Series (if as_series = True)
-
-        Returns
-        -------
-        arkouda.dataframe.DataFrame or arkouda.series.Series
-
-        Examples
-        --------
-
-        >>> import arkouda as ak
-        >>> ak.connect()
-        >>> df = ak.DataFrame({"A":[1,2,2,3],"B":[3,4,5,6]})
-        >>> display(df)
-
-        +----+-----+-----+
-        |    |   A |   B |
-        +====+=====+=====+
-        |  0 |   1 |   3 |
-        +----+-----+-----+
-        |  1 |   2 |   4 |
-        +----+-----+-----+
-        |  2 |   2 |   5 |
-        +----+-----+-----+
-        |  3 |   3 |   6 |
-        +----+-----+-----+
-
-        >>> df.groupby("A").count(as_series = False)
-
-        +----+---------+
-        |    |   count |
-        +====+=========+
-        |  0 |       1 |
-        +----+---------+
-        |  1 |       2 |
-        +----+---------+
-        |  2 |       1 |
-        +----+---------+
-
-        """
-        if as_series is True or (as_series is None and self.as_index is True):
-            return self._return_agg_series(self.gb.count())
-        else:
-            return self._return_agg_dataframe(self.gb.count(), "count")
-
     def size(self, as_series=None, sort_index=True):
         """
         Compute the size of each value as the total number of rows, including NaN values.
@@ -3750,7 +3696,7 @@ class DataFrame(UserDict):
         if isinstance(keys, str):
             keys = [keys]
         gb = self.GroupBy(keys, use_series=False)
-        vals, cts = gb.count()
+        vals, cts = gb.size()
         if not high:
             positions = where(cts >= low, 1, 0)
         else:

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -171,7 +171,7 @@ class Index:
             return len(set(self.values)) == self.size
         else:
             g = GroupBy(self.values)
-            key, ct = g.count()
+            key, ct = g.size()
             return (ct == 1).all()
 
     @staticmethod

--- a/arkouda/join.py
+++ b/arkouda/join.py
@@ -177,9 +177,9 @@ def compute_join_size(a: pdarray, b: pdarray) -> Tuple[int, int]:
     both the number of elements and number of bytes required for the join.
     """
     bya = GroupBy(a)
-    ua, asize = bya.count()
+    ua, asize = bya.size()
     byb = GroupBy(b)
-    ub, bsize = byb.count()
+    ub, bsize = byb.size()
     afact = asize[in1d(ua, ub)]
     bfact = bsize[in1d(ub, ua)]
     nelem = (afact * bfact).sum()

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -2042,7 +2042,7 @@ def value_counts(
     >>> ak.value_counts(A)
     (array([0, 2, 4]), array([3, 2, 1]))
     """
-    return GroupBy(pda).count()
+    return GroupBy(pda).size()
 
 
 @typechecked

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -197,7 +197,7 @@ def in1d(
     isa = concatenate((ones(ua[0].size, dtype=akbool), zeros(ub[0].size, dtype=akbool)), ordered=False)
     c = [concatenate(x, ordered=False) for x in zip(ua, ub)]
     g = GroupBy(c)
-    k, ct = g.count()
+    k, ct = g.size()
     if assume_unique:
         # need to verify uniqueness, otherwise answer will be wrong
         if (g.sum(isa)[1] > 1).any():
@@ -504,7 +504,7 @@ def union1d(
 
         c = [concatenate(x, ordered=False) for x in zip(ua, ub)]
         g = GroupBy(c)
-        k, ct = g.count()
+        k, ct = g.size()
         return k
     else:
         raise TypeError(
@@ -621,7 +621,7 @@ def intersect1d(
                 raise ValueError("Called with assume_unique=True, but first argument is not unique")
             if (g.sum(~isa)[1] > 1).any():
                 raise ValueError("Called with assume_unique=True, but second argument is not unique")
-        k, ct = g.count()
+        k, ct = g.size()
         in_union = ct == 2
         return [x[in_union] for x in k]
     else:
@@ -735,7 +735,7 @@ def setdiff1d(
                 raise ValueError("Called with assume_unique=True, but first argument is not unique")
             if (g.sum(~isa)[1] > 1).any():
                 raise ValueError("Called with assume_unique=True, but second argument is not unique")
-        k, ct = g.count()
+        k, ct = g.size()
         truth = g.broadcast(ct == 1, permute=True)
         atruth = truth[isa]
         return [x[atruth] for x in ua]
@@ -849,7 +849,7 @@ def setxor1d(pda1: groupable, pda2: groupable, assume_unique: bool = False) -> U
                 raise ValueError("Called with assume_unique=True, but first argument is not unique")
             if (g.sum(~isa)[1] > 1).any():
                 raise ValueError("Called with assume_unique=True, but second argument is not unique")
-        k, ct = g.count()
+        k, ct = g.size()
         single = ct == 1
         return [x[single] for x in k]
     else:

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -820,7 +820,7 @@ class SegArray:
         keyidx = self.grouping.broadcast(arange(self.size), permute=True)
         ukey, uval = GroupBy([keyidx, x]).unique_keys
         g = GroupBy(ukey, assume_sorted=True)
-        _, lengths = g.count()
+        _, lengths = g.size()
         return SegArray(g.segments, uval, grouping=g, lengths=lengths)
 
     def hash(self) -> Tuple[pdarray, pdarray]:
@@ -1178,7 +1178,7 @@ class SegArray:
         else:
             segments = zeros(self.size, dtype=akint64)
             truth = ones(self.size, dtype=akbool)
-            k, ct = g.count()
+            k, ct = g.size()
             segments[k] = g.segments
             truth[k] = zeros(k.size, dtype=akbool)
             if truth[-1]:
@@ -1232,7 +1232,7 @@ class SegArray:
         else:
             segments = zeros(self.size, dtype=akint64)
             truth = ones(self.size, dtype=akbool)
-            k, ct = g.count()
+            k, ct = g.size()
             segments[k] = g.segments
             truth[k] = zeros(k.size, dtype=akbool)
             if truth[-1]:
@@ -1286,7 +1286,7 @@ class SegArray:
         else:
             segments = zeros(self.size, dtype=akint64)
             truth = ones(self.size, dtype=akbool)
-            k, ct = g.count()
+            k, ct = g.size()
             segments[k] = g.segments
             truth[k] = zeros(k.size, dtype=akbool)
             if truth[-1]:
@@ -1340,7 +1340,7 @@ class SegArray:
         else:
             segments = zeros(self.size, dtype=akint64)
             truth = ones(self.size, dtype=akbool)
-            k, ct = g.count()
+            k, ct = g.size()
             segments[k] = g.segments
             truth[k] = zeros(k.size, dtype=akbool)
             if truth[-1]:

--- a/arkouda/series.py
+++ b/arkouda/series.py
@@ -365,7 +365,7 @@ class Series:
             indices = self.index == key
         else:
             indices = in1d(self.index.values, key)  # type: ignore
-        tf, counts = GroupBy(indices).count()
+        tf, counts = GroupBy(indices).size()
         update_count = counts[1] if len(counts) == 2 else 0
         if update_count == 0:
             # adding a new entry
@@ -446,7 +446,7 @@ class Series:
         """
         Returns whether the Series has any labels that appear more than once
         """
-        tf, counts = GroupBy(self.index.values).count()
+        tf, counts = GroupBy(self.index.values).size()
         return counts.size != self.index.size
 
     @property

--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -97,7 +97,7 @@ def enrich_inplace(data, keynames, aggregations, **kwargs):
         except (KeyError, TypeError):
             pass
         if reduction == "count":
-            pergroupval = g.count()[1]
+            pergroupval = g.size()[1]
         else:
             pergroupval = g.aggregate(values, reduction)[1]
         data[resname] = g.broadcast(pergroupval, permute=True)

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -512,7 +512,7 @@ module ReductionMsg
       }
     }
 
-    proc countReductionMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+    proc sizeReductionMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
       // reqMsg: segmentedReduction values segments operator
       // 'segments_name' describes the segment offsets
@@ -661,6 +661,10 @@ module ReductionMsg
                         var res = segNumUnique(values.a, segments.a);
                         st.addEntry(rname, createSymEntry(res));
                     }
+                    when "count" {
+                        var res = segCount(segments.a, values.size);
+                        st.addEntry(rname, createSymEntry(res));
+                    }
                     otherwise {
                         var errorMsg = notImplementedError(pn,op,gVal.dtype);
                         rmLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
@@ -727,6 +731,10 @@ module ReductionMsg
                         var res = segNumUnique(values.a, segments.a);
                         st.addEntry(rname, createSymEntry(res));
                     }
+                    when "count" {
+                        var res = segCount(segments.a, values.size);
+                        st.addEntry(rname, createSymEntry(res));
+                    }
                     otherwise {
                         var errorMsg = notImplementedError(pn,op,gVal.dtype);
                         rmLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
@@ -777,6 +785,10 @@ module ReductionMsg
                         var (vals, locs) = segArgmax(values.a, segments.a);
                         st.addEntry(rname, createSymEntry(locs));
                     }
+                    when "count" {
+                        var res = segCount(segments.a, values.size) - nanCounts(values.a, segments.a);
+                        st.addEntry(rname, createSymEntry(res));
+                    }
                     otherwise {
                         var errorMsg = notImplementedError(pn,op,gVal.dtype);
                         rmLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);         
@@ -823,6 +835,10 @@ module ReductionMsg
                         var (vals, locs) = segArgmax(values.a, segments.a);
                         st.addEntry(rname, createSymEntry(locs));
                     }
+                    when "count" {
+                        var res = segCount(segments.a, values.size);
+                        st.addEntry(rname, createSymEntry(res));
+                    }
                     otherwise {
                         var errorMsg = notImplementedError(pn,op,gVal.dtype);
                         rmLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
@@ -867,6 +883,10 @@ module ReductionMsg
                         var res = segAnd(values.a, segments.a);
                         st.addEntry(rname, createSymEntry(res));
                     }
+                    when "count" {
+                        var res = segCount(segments.a, values.size);
+                        st.addEntry(rname, createSymEntry(res));
+                    }
                     otherwise {
                         var errorMsg = notImplementedError(pn,op,gVal.dtype);
                         rmLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
@@ -884,7 +904,6 @@ module ReductionMsg
        rmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
        return new MsgTuple(repMsg, MsgType.NORMAL);
     }
-
           
     /* Segmented Reductions of the form: seg<Op>(values:[] t, segments: [] int)
        Use <segments> as the boundary indices to divide <values> into chunks, 
@@ -1529,7 +1548,6 @@ module ReductionMsg
         return new unmanaged ResettingAndScanOp(eltType=eltType);
       }
     }
-    
 
     proc segXor(values:[] ?t, segments:[?D] int) throws {
       // Because XOR has an inverse (itself), this can be
@@ -1665,5 +1683,5 @@ module ReductionMsg
 
     use CommandMap;
     registerFunction("segmentedReduction", segmentedReductionMsg, getModuleName());
-    registerFunction("countReduction", countReductionMsg, getModuleName());
+    registerFunction("sizeReduction", sizeReductionMsg, getModuleName());
 }

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -466,38 +466,6 @@ class DataFrameTest(ArkoudaTest):
         hdf_ref = ref_df.tail(2).reset_index(drop=True)
         self.assertTrue(hdf_ref.equals(hdf.to_pandas()))
 
-    def test_groupby_standard(self):
-        df = build_ak_df()
-        gb = df.GroupBy("userName")
-        keys, count = gb.count()
-        self.assertListEqual(keys.to_list(), ["Bob", "Alice", "Carol"])
-        self.assertListEqual(count.to_list(), [2, 3, 1])
-        self.assertListEqual(gb.permutation.to_list(), [1, 4, 0, 2, 5, 3])
-
-        gb = df.GroupBy(["userName", "userID"])
-        keys, count = gb.count()
-        self.assertEqual(len(keys), 2)
-        self.assertListEqual(keys[0].to_list(), ["Bob", "Alice", "Carol"])
-        self.assertListEqual(keys[1].to_list(), [222, 111, 333])
-        self.assertListEqual(count.to_list(), [2, 3, 1])
-
-        # testing counts with IPv4 column
-        s = ak.DataFrame({"a": ak.IPv4(ak.arange(1, 5))}).groupby("a").count(as_series=True)
-        pds = pd.Series(
-            data=np.ones(4, dtype=np.int64),
-            index=pd.Index(data=np.array(["0.0.0.1", "0.0.0.2", "0.0.0.3", "0.0.0.4"], dtype="<U7")),
-        )
-        self.assertTrue(s.to_pandas().equals(other=pds))
-
-        # testing counts with Categorical column
-        s = (
-            ak.DataFrame({"a": ak.Categorical(ak.array(["a", "a", "a", "b"]))})
-            .groupby("a")
-            .count(as_series=True)
-        )
-        pds = pd.Series(data=np.array([3, 1]), index=pd.Index(data=np.array(["a", "b"], dtype="<U7")))
-        self.assertTrue(s.to_pandas().equals(other=pds))
-
     def test_gb_series(self):
         username = ak.array(["Alice", "Bob", "Alice", "Carol", "Bob", "Alice"])
         userid = ak.array([111, 222, 111, 333, 222, 111])
@@ -518,7 +486,7 @@ class DataFrameTest(ArkoudaTest):
 
         gb = df.GroupBy("userName", use_series=True)
 
-        c = gb.count(as_series=True)
+        c = gb.size(as_series=True)
         self.assertIsInstance(c, ak.Series)
         self.assertListEqual(c.index.to_list(), ["Alice", "Bob", "Carol"])
         self.assertListEqual(c.values.to_list(), [3, 2, 1])
@@ -532,20 +500,49 @@ class DataFrameTest(ArkoudaTest):
         pd_df = pd_df[cols_without_str]
 
         group_on = "userID"
-        for agg in ["sum", "first"]:
-            for col in df.columns:
-                if col == group_on:
-                    # pandas groupby doesn't return the column used to group
-                    continue
-                ak_ans = getattr(df.groupby(group_on), agg)()[col]
-                pd_ans = getattr(pd_df.groupby(group_on), agg)()[col]
-                self.assertListEqual(ak_ans.to_list(), pd_ans.to_list())
+        for agg in ["sum", "first", "count"]:
+            ak_result = getattr(df.groupby(group_on), agg)()
+            pd_result = getattr(pd_df.groupby(group_on), agg)()
+            assert_frame_equal(ak_result.to_pandas(retain_index=True), pd_result)
 
-            # pandas groupby doesn't return the column used to group
-            cols_without_group_on = list(set(df.columns) - {group_on})
-            ak_ans = getattr(df.groupby(group_on), agg)()[cols_without_group_on]
-            pd_ans = getattr(pd_df.groupby(group_on), agg)()[cols_without_group_on]
-            assert_frame_equal(pd_ans, ak_ans.to_pandas(retain_index=True))
+    def test_gb_aggregations_example_numeric_types(self):
+        df = build_ak_df_example_numeric_types()
+        pd_df = df.to_pandas()
+
+        aggs_to_test = [
+            "count",
+            "first",
+            "sum",
+        ]
+
+        group_on = "gb_id"
+        for agg in aggs_to_test:
+            ak_result = getattr(df.groupby(group_on), agg)()
+            pd_result = getattr(pd_df.groupby(group_on), agg)()
+            assert_frame_equal(ak_result.to_pandas(retain_index=True), pd_result)
+
+    def test_gb_aggregations_with_nans(self):
+        df = build_ak_df_with_nans()
+        # @TODO handle bool columns correctly
+        df.drop("bools", axis=1, inplace=True)
+        pd_df = df.to_pandas()
+
+        aggs_to_test = [
+            "count",
+            "max",
+            "mean",
+            "median",
+            "min",
+            "std",
+            "sum",
+            "var",
+        ]
+
+        group_on = ["key1", "key2"]
+        for agg in aggs_to_test:
+            ak_result = getattr(df.groupby(group_on), agg)()
+            pd_result = getattr(pd_df.groupby(group_on, as_index=False), agg)()
+            assert_frame_equal(ak_result.to_pandas(retain_index=True), pd_result)
 
     def test_gb_aggregations_return_dataframe(self):
         ak_df = build_ak_df_example2()
@@ -586,37 +583,6 @@ class DataFrameTest(ArkoudaTest):
             ak_df.groupby(["gb_id"]).sum().to_pandas(retain_index=True), pd_df.groupby(["gb_id"]).sum()
         )
         assert set(ak_df.groupby(["gb_id"]).sum().columns) == set(pd_df.groupby(["gb_id"]).sum().columns)
-
-    def test_gb_count_single(self):
-        ak_df = build_ak_df_example_numeric_types()
-        pd_df = ak_df.to_pandas(retain_index=True)
-
-        assert_frame_equal(
-            ak_df.groupby("gb_id").count(as_series=False).to_pandas(retain_index=True),
-            pd_df.groupby("gb_id")
-            .count()
-            .drop(["int64", "uint64", "bigint"], axis=1)
-            .rename(columns={"float64": "count"}, errors="raise"),
-        )
-
-        assert_frame_equal(
-            ak_df.groupby(["gb_id"]).count(as_series=False).to_pandas(retain_index=True),
-            pd_df.groupby(["gb_id"])
-            .count()
-            .drop(["int64", "uint64", "bigint"], axis=1)
-            .rename(columns={"float64": "count"}, errors="raise"),
-        )
-
-    def test_gb_count_multiple(self):
-        ak_df = build_ak_df_example2()
-        pd_df = ak_df.to_pandas(retain_index=True)
-
-        pd_result1 = (
-            pd_df.groupby(["key1", "key2"], as_index=False).count().drop(["nums", "key3"], axis=1)
-        )
-        ak_result1 = ak_df.groupby(["key1", "key2"], as_index=False).count()
-        assert_frame_equal(pd_result1, ak_result1.to_pandas(retain_index=True))
-        assert isinstance(ak_result1, ak.dataframe.DataFrame)
 
     def test_gb_size_single(self):
         ak_df = build_ak_df_example_numeric_types()

--- a/tests/nan_test.py
+++ b/tests/nan_test.py
@@ -73,7 +73,7 @@ def run_test(verbose=True):
 
     tests += 1
     pdkeys, pdvals = groupby_to_arrays(df, keyname, "float64", "count")
-    akkeys, akvals = akg.count()
+    akkeys, akvals = akg.size()
     akvals = akvals.to_ndarray()
 
     for op in OPS:


### PR DESCRIPTION
Closes #2893 dataframe.GroupBy.count to align with pandas

This change updates the `arkouda.dataframe.GroupBy.count` function to match pandas for numeric columns.