### PR TITLE
Closes #3123-make-proto-tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,7 @@ If adding a new feature, add a test to make sure it behaves properly.
 Things to note:
 - If you make a new test, be sure to include `test_` at the beginning. Otherwise `pytest` will not run it.
 - If you make a new file of tests, be sure to include the file in `pytest.ini`, so it will be run during a `make test`.
+- If you make a new file of PROTO_tests, be sure to also include the file in `pytest_PROTO.ini`, so it will be run during a `make test-proto size=<size>`.
 
 See our wiki for more info on how to run our tests and create your own:
 https://github.com/Bears-R-Us/arkouda/wiki/Unit-Testing
@@ -114,6 +115,9 @@ https://github.com/Bears-R-Us/arkouda/wiki/Unit-Testing
 ```terminal
 # Run all tests in pytest.ini
 make test
+
+# Run all tests in pytest_PROTO.ini
+make test-proto size=<size>
 
 # Run all tests in the CategoricalTest class (-v will print out the test name)
 python3 -m pytest tests/categorical_test.py::CategoricalTest -v
@@ -133,6 +137,7 @@ python3 server_util/test/parallel_start_test.py -d test
 Before posting a pull request, be sure to test locally to catch common CI failures early.
 This usually includes running:
 - `make test`
+- `make test-proto size=<size>`
 - `make mypy`
 - `flake8 arkouda`
 

--- a/Makefile
+++ b/Makefile
@@ -501,12 +501,15 @@ $(eval $(call create_help_target,test-help,TEST_HELP_TEXT))
 .PHONY: test
 test: test-python
 
+.PHONY: test-proto
+test-proto: test-python-proto
+
 .PHONY: test-chapel
 test-chapel:
 	start_test $(TEST_SOURCE_DIR)
 
 .PHONY: test-all
-test-all: test-python test-chapel
+test-all: test-python test-python-proto test-chapel
 
 mypy:
 	python3 -m mypy arkouda
@@ -523,6 +526,10 @@ print-%:
 
 test-python:
 	python3 -m pytest $(ARKOUDA_PYTEST_OPTIONS) -c pytest.ini
+
+size=100
+test-python-proto:
+	python3 -m pytest --size=$(size) $(ARKOUDA_PYTEST_OPTIONS) -c pytest_PROTO.ini
 
 CLEAN_TARGETS += test-clean
 .PHONY: test-clean

--- a/pytest_PROTO.ini
+++ b/pytest_PROTO.ini
@@ -2,14 +2,46 @@
 addopts =
     --benchmark-disable
     --benchmark-skip
-    --size=100
 filterwarnings =
     ignore:Version mismatch between client .*
 testpaths =
-    tests/*_test
-    tests/scipy/test
-    tests/numpy/test
-;    tests/benchmarks/*_benchmark.py
+    PROTO_tests/tests/alignment_test.py
+    PROTO_tests/tests/array_view_test.py
+    PROTO_tests/tests/bigint_agg_test.py
+    PROTO_tests/tests/bitops_test.py
+    PROTO_tests/tests/categorical_test.py
+    PROTO_tests/tests/client_dtypes_test.py
+    PROTO_tests/tests/client_test.py
+    PROTO_tests/tests/coargsort_test.py
+    PROTO_tests/tests/dataframe_test.py
+    PROTO_tests/tests/datetime_test.py
+    PROTO_tests/tests/dtypes_test.py
+    PROTO_tests/tests/extrema_test.py
+    PROTO_tests/tests/groupby_test.py
+    PROTO_tests/tests/indexing_test.py
+    PROTO_tests/tests/index_test.py
+    PROTO_tests/tests/io_test.py
+    PROTO_tests/tests/io_util_test.py
+    PROTO_tests/tests/join_test.py
+    PROTO_tests/tests/logger_test.py
+    PROTO_tests/tests/message_test.py
+    PROTO_tests/tests/numeric_test.py
+    PROTO_tests/tests/numpy
+    PROTO_tests/tests/operator_test.py
+    PROTO_tests/tests/pdarray_creation_test.py
+    PROTO_tests/tests/random_test.py
+    PROTO_tests/tests/regex_test.py
+    PROTO_tests/tests/scipy/scipy_test.py
+    PROTO_tests/tests/security_test.py
+    PROTO_tests/tests/segarray_test.py
+    PROTO_tests/tests/series_test.py
+    PROTO_tests/tests/setops_test.py
+    PROTO_tests/tests/sort_test.py
+    PROTO_tests/tests/stats_test.py
+    PROTO_tests/tests/string_test.py
+    PROTO_tests/tests/symbol_table_test.py
+    PROTO_tests/tests/util_test.py
+    PROTO_tests/tests/where_test.py
 norecursedirs =
     .git
     dist


### PR DESCRIPTION
Closes #3123-make-proto-tests

With these changes the developer can run `make test-python-proto` to run `PROTO_tests/tests` with `--size=10*2`.