### PR TITLE
Closes #3118: Move `choice` implementation into arkouda

### DIFF
--- a/PROTO_tests/tests/random_test.py
+++ b/PROTO_tests/tests/random_test.py
@@ -173,7 +173,6 @@ class TestRandom:
         assert type(scalar) is np.int64
         assert scalar in [0, 1, 2, 3, 4]
 
-    @pytest.mark.skip(reason="skip until issue #3118 is resolved")
     def test_choice_flags(self):
         # use numpy to randomly generate a set seed
         seed = np.random.default_rng().choice(2**63)

--- a/src/compat/e-132/ArkoudaRandomCompat.chpl
+++ b/src/compat/e-132/ArkoudaRandomCompat.chpl
@@ -32,7 +32,70 @@ module ArkoudaRandomCompat {
     }
 
     proc ref sample(d: domain(?), n: int, withReplacement = false): [] d.idxType throws  where is1DRectangularDomain(d) {
-      return r.choice(d, n, withReplacement);
+      return choiceUniform(r, d, n, withReplacement);
+
+      /* _choice branch for uniform distribution */
+      proc choiceUniform(stream, X: domain(?), size: ?sizeType, replace: bool) throws
+      {
+        use Set;
+        use Math;
+
+        const low = X.low,
+              stride = abs(X.stride);
+
+        if isNothingType(sizeType) {
+          // Return 1 sample
+          var randVal = stream.getNext(resultType=int, 0, X.sizeAs(X.idxType)-1);
+          var randIdx = X.dim(0).orderToIndex(randVal);
+          return randIdx;
+        } else {
+          // Return numElements samples
+
+          // Compute numElements for tuple case
+          var m = 1;
+          if isDomainType(sizeType) then m = size.size;
+
+          var numElements = if isDomainType(sizeType) then m
+                            else if isIntegralType(sizeType) then size:int
+                            else compilerError('choice() size type must be integral or tuple of ranges');
+
+          // Return N samples
+          var samples: [0..<numElements] int;
+
+          if replace {
+            for sample in samples {
+              var randVal = stream.getNext(resultType=int, 0, X.sizeAs(X.idxType)-1);
+              var randIdx = X.dim(0).orderToIndex(randVal);
+              sample = randIdx;
+            }
+          } else {
+            if numElements < log2(X.sizeAs(X.idxType)) {
+              var indices: set(int);
+              var i: int = 0;
+              while i < numElements {
+                var randVal = stream.getNext(resultType=int, 0, X.sizeAs(X.idxType)-1);
+                if !indices.contains(randVal) {
+                  var randIdx = X.dim(0).orderToIndex(randVal);
+                  samples[i] = randIdx;
+                  indices.add(randVal);
+                  i += 1;
+                }
+              }
+            } else {
+              var indices: [X] int = X;
+              stream.shuffle(indices);
+              for i in samples.domain {
+                samples[i] = (indices[X.dim(0).orderToIndex(i)]);
+              }
+            }
+          }
+          if isIntegralType(sizeType) {
+            return samples;
+          } else if isDomainType(sizeType) {
+            return reshape(samples, size);
+          }
+        }
+      }
     }
     proc ref next(): eltType do return r.getNext();
     proc skipTo(n: int) do try! r.skipToNth(n);

--- a/src/compat/eq-131/ArkoudaRandomCompat.chpl
+++ b/src/compat/eq-131/ArkoudaRandomCompat.chpl
@@ -31,7 +31,70 @@ module ArkoudaRandomCompat {
       return domArr;
     }
     proc ref sample(d: domain, n: int, withReplacement = false): [] d.idxType throws  where is1DRectangularDomain(d) {
-      return r.choice(d, n, withReplacement);
+      return choiceUniform(r, d, n, withReplacement);
+
+      /* _choice branch for uniform distribution */
+      proc choiceUniform(stream, X: domain, size: ?sizeType, replace: bool) throws
+      {
+        use Set;
+        use Math;
+
+        const low = X.low,
+              stride = abs(X.stride);
+
+        if isNothingType(sizeType) {
+          // Return 1 sample
+          var randVal = stream.getNext(resultType=int, 0, X.sizeAs(X.idxType)-1);
+          var randIdx = X.dim(0).orderToIndex(randVal);
+          return randIdx;
+        } else {
+          // Return numElements samples
+
+          // Compute numElements for tuple case
+          var m = 1;
+          if isDomainType(sizeType) then m = size.size;
+
+          var numElements = if isDomainType(sizeType) then m
+                            else if isIntegralType(sizeType) then size:int
+                            else compilerError('choice() size type must be integral or tuple of ranges');
+
+          // Return N samples
+          var samples: [0..<numElements] int;
+
+          if replace {
+            for sample in samples {
+              var randVal = stream.getNext(resultType=int, 0, X.sizeAs(X.idxType)-1);
+              var randIdx = X.dim(0).orderToIndex(randVal);
+              sample = randIdx;
+            }
+          } else {
+            if numElements < log2(X.sizeAs(X.idxType)) {
+              var indices: set(int);
+              var i: int = 0;
+              while i < numElements {
+                var randVal = stream.getNext(resultType=int, 0, X.sizeAs(X.idxType)-1);
+                if !indices.contains(randVal) {
+                  var randIdx = X.dim(0).orderToIndex(randVal);
+                  samples[i] = randIdx;
+                  indices.add(randVal);
+                  i += 1;
+                }
+              }
+            } else {
+              var indices: [X] int = X;
+              stream.shuffle(indices);
+              for i in samples.domain {
+                samples[i] = (indices[X.dim(0).orderToIndex(i)]);
+              }
+            }
+          }
+          if isIntegralType(sizeType) {
+            return samples;
+          } else if isDomainType(sizeType) {
+            return reshape(samples, size);
+          }
+        }
+      }
     }
     proc ref next(): eltType do return r.getNext();
     proc skipTo(n: int) do try! r.skipToNth(n);

--- a/src/compat/eq-133/ArkoudaRandomCompat.chpl
+++ b/src/compat/eq-133/ArkoudaRandomCompat.chpl
@@ -19,8 +19,84 @@ module ArkoudaRandomCompat {
     return domArr;
   }
   proc ref randomStream.sample(d: domain(?), n: int, withReplacement = false): [] d.idxType throws where is1DRectangularDomain(d) && isCoercible(this.eltType, d.idxType) {
-    // unfortunately there isn't a domain permutation function so we will create an array to permute
-    return this.choice(d, n, withReplacement);
+    return choiceUniform(this, d, n, withReplacement);
+    proc choiceUniform(ref stream, X: domain(?), size: ?sizeType, replace: bool) throws
+    {
+      use Math;
+      const low = X.low,
+            stride = abs(X.stride);
+
+      if isNothingType(sizeType) {
+        // Return 1 sample
+        var randVal;
+        // TODO: removed first branch of this conditional after PCG/NPBRandomStream deprecations
+        if __primitive("method call and fn resolves", stream, "getNext", X.idxType) {
+          randVal = stream.getNext(resultType=X.idxType, 0, X.sizeAs(X.idxType)-1);
+        } else {
+          randVal = stream.getNext(0, X.sizeAs(X.idxType)-1);
+        }
+        var randIdx = X.dim(0).orderToIndex(randVal);
+        return randIdx;
+      } else {
+        // Return numElements samples
+
+        // Compute numElements for tuple case
+        var m = 1;
+        if isDomainType(sizeType) then m = size.size;
+
+        var numElements = if isDomainType(sizeType) then m
+                          else if isIntegralType(sizeType) then size:int
+                          else compilerError('choice() size type must be integral or tuple of ranges');
+
+        // Return N samples
+        var samples: [0..<numElements] int;
+
+        if replace {
+          for sample in samples {
+            var randVal;
+            // TODO: removed first branch of this conditional after PCG/NPBRandomStream deprecations
+            if __primitive("method call and fn resolves", stream, "getNext", X.idxType) {
+              randVal = stream.getNext(resultType=X.idxType, 0, X.sizeAs(X.idxType)-1);
+            } else {
+              randVal = stream.getNext(0, X.sizeAs(X.idxType)-1);
+            }
+            var randIdx = X.dim(0).orderToIndex(randVal);
+            sample = randIdx;
+          }
+        } else {
+          if numElements < log2(X.sizeAs(X.idxType)) {
+            var indices: domain(int, parSafe=false);
+            var i: int = 0;
+            while i < numElements {
+              var randVal;
+              // TODO: removed first branch of this conditional after PCG/NPBRandomStream deprecations
+              if __primitive("method call and fn resolves", stream, "getNext", X.idxType) {
+                randVal = stream.getNext(resultType=X.idxType, 0, X.sizeAs(X.idxType)-1);
+              } else {
+                randVal = stream.getNext(0, X.sizeAs(X.idxType)-1);
+              }
+              if !indices.contains(randVal) {
+                var randIdx = X.dim(0).orderToIndex(randVal);
+                samples[i] = randIdx;
+                indices.add(randVal);
+                i += 1;
+              }
+            }
+          } else {
+            var indices: [X] int = X;
+            stream.shuffle(indices);
+            for i in samples.domain {
+              samples[i] = (indices[X.dim(0).orderToIndex(i)]);
+            }
+          }
+        }
+        if isIntegralType(sizeType) {
+          return samples;
+        } else if isDomainType(sizeType) {
+          return reshape(samples, size);
+        }
+      }
+    }
   }
   proc ref randomStream.next() do return this.getNext();
 }

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -176,7 +176,6 @@ class RandomTest(ArkoudaTest):
         self.assertIs(type(scalar), np.int64)
         self.assertIn(scalar, [0, 1, 2, 3, 4])
 
-    @pytest.mark.skip(reason="skip until issue #3118 is resolved")
     def test_choice_flags(self):
         # use numpy to randomly generate a set seed
         seed = np.random.default_rng().choice(2**63)


### PR DESCRIPTION
This PR closes #3118 by moving the implemention of `choice` into arkouda for chpl versions prior to 2.0. This allows us to no longer skip `test_choice_flags`.

We could have done this as part of #3114, since it was much less involved than I thought it would be. I was expecting to need to copy several internal procs and records from chpl's random modules, but it more or less just worked to copy it over and change `sample` to `stream.sample`