### PR TITLE
multidimensional array bug fixes

### DIFF
--- a/arkouda/array_api/_array_object.py
+++ b/arkouda/array_api/_array_object.py
@@ -27,6 +27,7 @@ from ._dtypes import (
     _result_type,
     _dtype_categories,
 )
+from ._creation_functions import asarray
 
 from typing import TYPE_CHECKING, Optional, Tuple, Union, Any, Dict, Callable
 import types
@@ -384,6 +385,8 @@ class Array:
                 k = key._array[0]
             else:
                 k = key._array
+        elif isinstance(key, np.ndarray):
+            k = asarray(key)
         elif isinstance(key, tuple):
             k = []
             for kt in key:
@@ -392,6 +395,8 @@ class Array:
                         k.append(kt._array[0])
                     else :
                         k.append(kt._array)
+                elif isinstance(kt, np.ndarray):
+                    k.append(asarray(kt)._array)
                 else:
                     k.append(kt)
             k = tuple(k)

--- a/arkouda/array_api/_creation_functions.py
+++ b/arkouda/array_api/_creation_functions.py
@@ -43,6 +43,7 @@ def asarray(
         float,
         NestedSequence[bool | int | float],
         SupportsBufferProtocol,
+        ak.pdarray,
     ],
     /,
     *,
@@ -55,7 +56,9 @@ def asarray(
     if device not in ["cpu", None]:
         raise ValueError(f"Unsupported device {device!r}")
 
-    if (
+    if isinstance(obj, ak.pdarray):
+        return Array._new(obj)
+    elif (
         isinstance(obj, bool)
         or isinstance(obj, int)
         or isinstance(obj, float)

--- a/arkouda/array_api/_data_type_functions.py
+++ b/arkouda/array_api/_data_type_functions.py
@@ -164,7 +164,9 @@ def result_type(*arrays_and_dtypes: Union[Array, Dtype]) -> Dtype:
     for a in arrays_and_dtypes:
         if isinstance(a, Array):
             a = a.dtype
-        elif isinstance(a, np.ndarray) or a not in _all_dtypes:
+        elif isinstance(a, np.ndarray):
+            a = a.dtype
+        elif a not in _all_dtypes:
             raise TypeError("result_type() inputs must be array_api arrays or dtypes")
         A.append(a)
 

--- a/arkouda/array_api/_elementwise_functions.py
+++ b/arkouda/array_api/_elementwise_functions.py
@@ -498,7 +498,7 @@ def logical_not(x: Array, /) -> Array:
             "array": x._array,
         },
     )
-    return ak.create_pdarray(repMsg)
+    return Array._new(ak.create_pdarray(repMsg))
 
 
 def logical_or(x1: Array, x2: Array, /) -> Array:

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -248,7 +248,7 @@ def _parse_none_and_ellipsis_keys(key, ndim):
     ret_key = key
 
     # how many 'None' arguments are in the key tuple
-    num_none = ret_key.count(None)
+    num_none = reduce(lambda x, y: x + (1 if y is None else 0), ret_key, 0)
 
     # replace '...' with the appropriate number of ':'
     elipsis_axis_idx = -1
@@ -472,10 +472,10 @@ class pdarray:
             except ValueError:
                 raise ValueError(f"shape mismatch {self.shape} {other.shape}")
             repMsg = generic_msg(cmd=f"binopvv{x1.ndim}D", args={"op": op, "a": x1, "b": x2})
-            if tmp_x1:
-                del x1
-            if tmp_x2:
-                del x2
+            # if tmp_x1:
+            #     del x1
+            # if tmp_x2:
+            #     del x2
             return create_pdarray(repMsg)
         # pdarray binop scalar
         # If scalar cannot be safely cast, server will infer the return dtype

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -472,10 +472,10 @@ class pdarray:
             except ValueError:
                 raise ValueError(f"shape mismatch {self.shape} {other.shape}")
             repMsg = generic_msg(cmd=f"binopvv{x1.ndim}D", args={"op": op, "a": x1, "b": x2})
-            # if tmp_x1:
-            #     del x1
-            # if tmp_x2:
-            #     del x2
+            if tmp_x1:
+                del x1
+            if tmp_x2:
+                del x2
             return create_pdarray(repMsg)
         # pdarray binop scalar
         # If scalar cannot be safely cast, server will infer the return dtype

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -739,6 +739,8 @@ module AryUtil
     proc unflatten(const ref a: [?d] ?t, shape: ?N*int): [] t throws {
       var unflat = makeDistArray((...shape), t);
 
+      writeln("unflatten from: ", d.size, " to: ", shape);
+
       if N == 1 {
         unflat = a;
         return unflat;
@@ -794,6 +796,10 @@ module AryUtil
           }
         }
       }
+
+      writeln("---------------------");
+      writeln("unflat: ", unflat);
+      writeln("---------------------");
 
       return unflat;
     }

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -739,8 +739,6 @@ module AryUtil
     proc unflatten(const ref a: [?d] ?t, shape: ?N*int): [] t throws {
       var unflat = makeDistArray((...shape), t);
 
-      writeln("unflatten from: ", d.size, " to: ", shape);
-
       if N == 1 {
         unflat = a;
         return unflat;
@@ -796,10 +794,6 @@ module AryUtil
           }
         }
       }
-
-      writeln("---------------------");
-      writeln("unflat: ", unflat);
-      writeln("---------------------");
 
       return unflat;
     }

--- a/tests/array_api/array_manipulation.py
+++ b/tests/array_api/array_manipulation.py
@@ -20,12 +20,19 @@ class ManipulationTests(ArkoudaTest):
         a = Array.ones((1, 6, 1))
         b = Array.ones((5, 1, 10))
         c = Array.ones((5, 6, 1))
+        d = Array.ones((6, 10))
 
-        abc = Array.broadcast_arrays(a, b, c)
-        self.assertEqual(len(abc), 3)
-        self.assertEqual(abc[0].shape, (5, 6, 10))
-        self.assertEqual(abc[1].shape, (5, 6, 10))
-        self.assertEqual(abc[2].shape, (5, 6, 10))
+        abcd = Array.broadcast_arrays(a, b, c, d)
+        self.assertEqual(len(abcd), 4)
+        self.assertEqual(abcd[0].shape, (5, 6, 10))
+        self.assertEqual(abcd[1].shape, (5, 6, 10))
+        self.assertEqual(abcd[2].shape, (5, 6, 10))
+        self.assertEqual(abcd[3].shape, (5, 6, 10))
+
+        self.assertTrue((abcd[0] == 1).all())
+        self.assertTrue((abcd[1] == 1).all())
+        self.assertTrue((abcd[2] == 1).all())
+        self.assertTrue((abcd[3] == 1).all())
 
     def test_concat(self):
         a = randArr((5, 3, 10))


### PR DESCRIPTION
* fix bug in `broadcastToMsg` where rank-expanding broadcasts were not transferring all data from the original array
* fix a bug in `permuteDimsMsg` where invalid memory was being accessed
* fix bug in indexing, where `None` arguments weren't always handled correctly
* improve compatibility of array-api arrays with numpy

