### PR TITLE
Closes #3116 remove DataFrame._columns

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -685,9 +685,7 @@ class DataFrame(UserDict):
                     if len(sizes) > 1:
                         raise ValueError("Input arrays must have equal size.")
                     self._empty = False
-                    UserDict.__setitem__(self, key, val)
-                    # Update the column index
-                    self._columns.append(key)
+                    self[key] = val
 
             # Initial data is a list of arkouda arrays
             elif isinstance(initialdata, list):
@@ -711,9 +709,7 @@ class DataFrame(UserDict):
                     if len(sizes) > 1:
                         raise ValueError("Input arrays must have equal size.")
                     self._empty = False
-                    UserDict.__setitem__(self, key, col)
-                    # Update the column index
-                    self._columns.append(key)
+                    self[key] = col
 
             # Initial data is invalid.
             else:
@@ -778,8 +774,7 @@ class DataFrame(UserDict):
                 raise TypeError("Invalid selector: too many types in list.")
             if isinstance(key[0], str):
                 for k in key:
-                    result.data[k] = UserDict.__getitem__(self, k)
-                    result._columns.append(k)
+                    result[k] = self[k]
                 result._empty = False
                 result._set_index(self.index)  # column lens remain the same. Copy the indexing
                 return result


### PR DESCRIPTION
Closes #3116 remove DataFrame._columns

Having researched this, the only reason to keep the `._columns` attribute is to preserve the order.  The downside is that it could cause inconsistencies if accessed outside the `__setitem__ `method.  To remove this attribute and also preserve the column order we could make `DataFrame` an `OrderedDict` rather than a `UserDict`.  However, since the two classes have different APIs it would be a larger refactor.  

This change implements short term fix to remove instances where `._columns` is modified outside of the `__setitem__` method.