### PR TITLE
Avoid a warning about mismatched parSafe settings for list initialization

### DIFF
--- a/src/Message.chpl
+++ b/src/Message.chpl
@@ -374,8 +374,6 @@ module Message {
             this.param_list = new list(ParameterObj);
             this.size = param_list.size;
 
-            init this;
-
             this.param_list = param_list;
         }
 

--- a/src/Message.chpl
+++ b/src/Message.chpl
@@ -366,6 +366,19 @@ module Message {
             this.size = param_list.size;
         }
 
+        proc init(param_list: list(ParameterObj, parSafe=true)) {
+            // Intentionally initializes the param_list with `parSafe=false`.
+            // It would be initialized that way anyways due to the field
+            // declaration relying on the default value, this just makes it
+            // explicit (and avoids a warning as a result).
+            this.param_list = new list(ParameterObj);
+            this.size = param_list.size;
+
+            init this;
+
+            this.param_list = param_list;
+        }
+
         proc getJSON(keys: list(string) = list(string)): string throws {
             const noKeys: bool = keys.isEmpty();
             var s: int = if noKeys then this.size else keys.size;


### PR DESCRIPTION
The next release of Chapel will add a warning when initializing a list from another list with a different value for `parSafe`, because it tripped up another user.  This warning triggered for the creation of a new MessageArgs in parseMessageArgs, because the MessageArgs type relies on the default parSafe setting but the list being passed in was intentionally parSafe when it was created (to allow for populating it more rapidly).

Rather than silence the warning for the program as a whole (and risk not catching other list cases that did want the parSafe setting that is being ignored), add an explicit initializer to MessageArgs that takes in a parallel safe list, copying the contents rather than trying to use the list in the field's initialization.

This should not have a performance impact, as the list's contents are still only being copied once.

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>