### PR TITLE
Closes #3108: Add `groupby.sample` and `dataframe.groupby.sample`

### DIFF
--- a/PROTO_tests/tests/dataframe_test.py
+++ b/PROTO_tests/tests/dataframe_test.py
@@ -6,6 +6,7 @@ import pytest
 from pandas.testing import assert_frame_equal, assert_series_equal
 
 import arkouda as ak
+from arkouda.scipy import chisquare as akchisquare
 
 
 class TestDataFrame:
@@ -1172,6 +1173,95 @@ class TestDataFrame:
             tablefmt="grid", index=False
         )
         assert df.to_markdown(tablefmt="jira") == df.to_pandas().to_markdown(tablefmt="jira")
+
+    def test_sample_hypothesis_testing(self):
+        # perform a weighted sample and use chisquare to test
+        # if the observed frequency matches the expected frequency
+
+        # I tested this many times without a set seed, but with no seed
+        # it's expected to fail one out of every ~20 runs given a pval limit of 0.05
+        rng = ak.random.default_rng(43)
+        num_samples = 10**4
+
+        prob_arr = ak.array([0.35, 0.10, 0.55])
+        weights = ak.concatenate([prob_arr, prob_arr, prob_arr])
+        keys = ak.concatenate([ak.zeros(3, int), ak.ones(3, int), ak.full(3, 2, int)])
+        values = ak.arange(9)
+
+        akdf = ak.DataFrame({"keys": keys, "vals": values})
+
+        g = akdf.groupby("keys")
+
+        weighted_sample = g.sample(n=num_samples, replace=True, weights=weights, random_state=rng)
+
+        # count how many of each category we saw
+        uk, f_obs = ak.GroupBy(weighted_sample["vals"]).size()
+
+        # I think the keys should always be sorted but just in case
+        if not ak.is_sorted(uk):
+            f_obs = f_obs[ak.argsort(uk)]
+
+        f_exp = weights * num_samples
+        _, pval = akchisquare(f_obs=f_obs, f_exp=f_exp)
+
+        # if pval <= 0.05, the difference from the expected distribution is significant
+        assert pval > 0.05
+
+    def test_sample_flags(self):
+        # use numpy to randomly generate a set seed
+        seed = np.random.default_rng().choice(2**63)
+        cfg = ak.get_config()
+
+        rng = ak.random.default_rng(seed)
+        weights = rng.uniform(size=12)
+        a_vals = [
+            rng.integers(0, 2**32, size=12, dtype="uint"),
+            rng.uniform(-1.0, 1.0, size=12),
+            rng.integers(0, 1, size=12, dtype="bool"),
+            rng.integers(-(2**32), 2**32, size=12, dtype="int"),
+        ]
+        grouping_keys = ak.concatenate([ak.zeros(4, int), ak.ones(4, int), ak.full(4, 2, int)])
+        rng.shuffle(grouping_keys)
+
+        choice_arrays = []
+        # return_indices and permute_samples are tested by the dataframe version
+        rng = ak.random.default_rng(seed)
+        for a in a_vals:
+            for size in 2, 4:
+                for replace in True, False:
+                    for p in [None, weights]:
+                        akdf = ak.DataFrame({"keys": grouping_keys, "vals": a})
+                        g = akdf.groupby("keys")
+                        choice_arrays.append(
+                            g.sample(n=size, replace=replace, weights=p, random_state=rng)
+                        )
+                        choice_arrays.append(
+                            g.sample(frac=(size / 4), replace=replace, weights=p, random_state=rng)
+                        )
+
+        # reset generator to ensure we get the same arrays
+        rng = ak.random.default_rng(seed)
+        for a in a_vals:
+            for size in 2, 4:
+                for replace in True, False:
+                    for p in [None, weights]:
+                        previous1 = choice_arrays.pop(0)
+                        previous2 = choice_arrays.pop(0)
+
+                        akdf = ak.DataFrame({"keys": grouping_keys, "vals": a})
+                        g = akdf.groupby("keys")
+                        current1 = g.sample(n=size, replace=replace, weights=p, random_state=rng)
+                        current2 = g.sample(
+                            frac=(size / 4), replace=replace, weights=p, random_state=rng
+                        )
+
+                        res = (
+                            np.allclose(previous1["vals"].to_list(), current1["vals"].to_list())
+                        ) and (np.allclose(previous2["vals"].to_list(), current2["vals"].to_list()))
+                        if not res:
+                            print(f"\nnum locales: {cfg['numLocales']}")
+                            print(f"Failure with seed:\n{seed}")
+                        assert res
 
 
 def pda_to_str_helper(pda):

--- a/PROTO_tests/tests/groupby_test.py
+++ b/PROTO_tests/tests/groupby_test.py
@@ -4,6 +4,7 @@ import pytest
 
 import arkouda as ak
 from arkouda.groupbyclass import GroupByReductionType
+from arkouda.scipy import chisquare as akchisquare
 
 
 def to_tuple_dict(labels, values):
@@ -86,16 +87,16 @@ class TestGroupBy:
 
         assert np.allclose(pdvals, akvals.to_ndarray(), equal_nan=True)  # value validation
 
-# For pandas equivalency tests, the standard problem size of 10**8 is much too large, especially
-# in the case of "aggregate by product."  For large vectors of random integers from 0 through N,
-# it's inevitable that the product will either be zero (if the vector includes a zero) or infinity
-# (if it doesn't).  So in the case of 'prod', size is arbitrarily set to 100.
+    # For pandas equivalency tests, the standard problem size of 10**8 is much too large, especially
+    # in the case of "aggregate by product."  For large vectors of random integers from 0 through N,
+    # it's inevitable that the product will either be zero (if the vector includes a zero) or infinity
+    # (if it doesn't).  So in the case of 'prod', size is arbitrarily set to 100.
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("levels", LEVELS)
     @pytest.mark.parametrize("op", OPS)
     def test_pandas_equivalency(self, size, levels, op):
-        SIZE = 100 if op == 'prod' else size
+        SIZE = 100 if op == "prod" else size
         data = self.make_arrays(SIZE)
         df = pd.DataFrame(data)
         akdf = {k: ak.array(v) for k, v in data.items()}
@@ -636,6 +637,93 @@ class TestGroupBy:
             assert a == r
         for a, r in zip(ans, res2[1].to_list()):
             assert a == r
+
+    def test_sample_hypothesis_testing(self):
+        # perform a weighted sample and use chisquare to test
+        # if the observed frequency matches the expected frequency
+
+        # I tested this many times without a set seed, but with no seed
+        # it's expected to fail one out of every ~20 runs given a pval limit of 0.05
+        rng = ak.random.default_rng(43)
+        num_samples = 10**4
+
+        prob_arr = ak.array([0.35, 0.10, 0.55])
+        weights = ak.concatenate([prob_arr, prob_arr, prob_arr])
+        keys = ak.concatenate([ak.zeros(3, int), ak.ones(3, int), ak.full(3, 2, int)])
+        values = ak.arange(9)
+
+        g = ak.GroupBy(keys)
+
+        weighted_sample = g.sample(
+            values, n=num_samples, replace=True, weights=weights, random_state=rng
+        )
+
+        # count how many of each category we saw
+        uk, f_obs = ak.GroupBy(weighted_sample).size()
+
+        # I think the keys should always be sorted but just in case
+        if not ak.is_sorted(uk):
+            f_obs = f_obs[ak.argsort(uk)]
+
+        f_exp = weights * num_samples
+
+        _, pval = akchisquare(f_obs=f_obs, f_exp=f_exp)
+
+        # if pval <= 0.05, the difference from the expected distribution is significant
+        assert pval > 0.05
+
+    def test_sample_flags(self):
+        # use numpy to randomly generate a set seed
+        seed = np.random.default_rng().choice(2**63)
+        cfg = ak.get_config()
+
+        rng = ak.random.default_rng(seed)
+        weights = rng.uniform(size=12)
+        a_vals = [
+            rng.integers(0, 2**32, size=12, dtype="uint"),
+            rng.uniform(-1.0, 1.0, size=12),
+            rng.integers(0, 1, size=12, dtype="bool"),
+            rng.integers(-(2**32), 2**32, size=12, dtype="int"),
+        ]
+        grouping_keys = ak.concatenate([ak.zeros(4, int), ak.ones(4, int), ak.full(4, 2, int)])
+        rng.shuffle(grouping_keys)
+
+        choice_arrays = []
+        # return_indices and permute_samples are tested by the dataframe version
+        rng = ak.random.default_rng(seed)
+        for a in a_vals:
+            for size in 2, 4:
+                for replace in True, False:
+                    for p in [None, weights]:
+                        g = ak.GroupBy(grouping_keys)
+                        choice_arrays.append(
+                            g.sample(a, n=size, replace=replace, weights=p, random_state=rng)
+                        )
+                        choice_arrays.append(
+                            g.sample(a, frac=(size / 4), replace=replace, weights=p, random_state=rng)
+                        )
+
+        # reset generator to ensure we get the same arrays
+        rng = ak.random.default_rng(seed)
+        for a in a_vals:
+            for size in 2, 4:
+                for replace in True, False:
+                    for p in [None, weights]:
+                        previous1 = choice_arrays.pop(0)
+                        previous2 = choice_arrays.pop(0)
+                        g = ak.GroupBy(grouping_keys)
+                        current1 = g.sample(a, n=size, replace=replace, weights=p, random_state=rng)
+                        current2 = g.sample(
+                            a, frac=(size / 4), replace=replace, weights=p, random_state=rng
+                        )
+
+                        res = np.allclose(previous1.to_list(), current1.to_list()) and np.allclose(
+                            previous2.to_list(), current2.to_list()
+                        )
+                        if not res:
+                            print(f"\nnum locales: {cfg['numLocales']}")
+                            print(f"Failure with seed:\n{seed}")
+                        assert res
 
     def test_nunique_ordering_bug(self):
         keys = ak.array(["1" for _ in range(8)] + ["2" for _ in range(3)])

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -260,6 +260,124 @@ class DataFrameGroupBy:
         else:
             return self._return_agg_dataframe(self.gb.size(), "size", sort_index=sort_index)
 
+    def sample(self, n=None, frac=None, replace=False, weights=None, random_state=None):
+        """
+        Return a random sample from each group. You can either specify the number of elements
+        or the fraction of elements to be sampled. random_state can be used for reproducibility
+
+        Parameters
+        ----------
+        n: int, optional
+            Number of items to return for each group.
+            Cannot be used with frac and must be no larger than
+            the smallest group unless replace is True.
+            Default is one if frac is None.
+
+        frac: float, optional
+            Fraction of items to return. Cannot be used with n.
+
+        replace: bool, default False
+            Allow or disallow sampling of the same row more than once.
+
+        weights: pdarray, optional
+            Default None results in equal probability weighting.
+            If passed a pdarray, then values must have the same length as the underlying DataFrame
+            and will be used as sampling probabilities after normalization within each group.
+            Weights must be non-negative with at least one positive element within each group.
+
+        random_state: int or ak.random.Generator, optional
+            If int, seed for random number generator.
+            If ak.random.Generator, use as given.
+
+        Returns
+        -------
+        DataFrame
+            A new DataFrame containing items randomly sampled from each group
+            sorted according to the grouped columns.
+
+        Examples
+        --------
+
+        >>> import arkouda as ak
+        >>> ak.connect()
+        >>> df = ak.DataFrame({"A":[3,1,2,1,2,3],"B":[3,4,5,6,7,8]})
+        >>> display(df)
+        +----+-----+-----+
+        |    |   A |   B |
+        +====+=====+=====+
+        |  0 |   3 |   3 |
+        +----+-----+-----+
+        |  1 |   1 |   4 |
+        +----+-----+-----+
+        |  2 |   2 |   5 |
+        +----+-----+-----+
+        |  3 |   1 |   6 |
+        +----+-----+-----+
+        |  4 |   2 |   7 |
+        +----+-----+-----+
+        |  5 |   3 |   8 |
+        +----+-----+-----+
+
+        >>> df.groupby("A").sample(random_state=6)
+
+        +----+-----+-----+
+        |    |   A |   B |
+        +====+=====+=====+
+        |  3 |   1 |   6 |
+        +----+-----+-----+
+        |  4 |   2 |   7 |
+        +----+-----+-----+
+        |  5 |   3 |   8 |
+        +----+-----+-----+
+
+        >>> df.groupby("A").sample(frac=0.5, random_state=3, weights=ak.array([1,1,1,0,0,0]))
+
+        +----+-----+-----+
+        |    |   A |   B |
+        +====+=====+=====+
+        |  1 |   1 |   4 |
+        +----+-----+-----+
+        |  2 |   2 |   5 |
+        +----+-----+-----+
+        |  0 |   3 |   3 |
+        +----+-----+-----+
+
+        >>> df.groupby("A").sample(n=3, replace=True, random_state=ak.random.default_rng(7))
+        +----+-----+-----+
+        |    |   A |   B |
+        +====+=====+=====+
+        |  1 |   1 |   4 |
+        +----+-----+-----+
+        |  3 |   1 |   6 |
+        +----+-----+-----+
+        |  1 |   1 |   4 |
+        +----+-----+-----+
+        |  4 |   2 |   7 |
+        +----+-----+-----+
+        |  4 |   2 |   7 |
+        +----+-----+-----+
+        |  4 |   2 |   7 |
+        +----+-----+-----+
+        |  0 |   3 |   3 |
+        +----+-----+-----+
+        |  5 |   3 |   8 |
+        +----+-----+-----+
+        |  5 |   3 |   8 |
+        +----+-----+-----+
+        """
+        return self.df[
+            self.gb.sample(
+                values=self.df.index.values,
+                n=n,
+                frac=frac,
+                replace=replace,
+                weights=weights,
+                random_state=random_state,
+                return_indices=True,
+                permute_samples=True,
+            )
+        ]
+
     def _return_agg_series(self, values, sort_index=True):
         if self.as_index is True:
             if isinstance(self.gb_key_names, str):

--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -21,15 +21,18 @@ import numpy as np  # type: ignore
 from typeguard import typechecked
 
 from arkouda.client import generic_msg
-from arkouda.dtypes import bigint
+from arkouda.dtypes import _val_isinstance_of_union, bigint
+from arkouda.dtypes import dtype as to_numpy_dtype
 from arkouda.dtypes import float64 as akfloat64
+from arkouda.dtypes import float_scalars
 from arkouda.dtypes import int64 as akint64
 from arkouda.dtypes import int_scalars
 from arkouda.dtypes import uint64 as akuint64
 from arkouda.logger import getArkoudaLogger
 from arkouda.pdarrayclass import RegistrationError, create_pdarray, is_sorted, pdarray
-from arkouda.pdarraycreation import arange
-from arkouda.sorting import argsort
+from arkouda.pdarraycreation import arange, full
+from arkouda.random import default_rng
+from arkouda.sorting import argsort, sort
 from arkouda.strings import Strings
 
 __all__ = ["unique", "GroupBy", "broadcast", "GROUPBY_REDUCTION_TYPES"]
@@ -678,6 +681,9 @@ class GroupBy:
         ----------
         values : pdarray
             The values to group and sum
+        skipna: bool
+            boolean which determines if NANs should be skipped
+
 
         Returns
         -------
@@ -685,8 +691,6 @@ class GroupBy:
             The unique keys, in grouped order
         group_sums : pdarray
             One sum per unique key in the GroupBy instance
-        skipna: bool
-            boolean which determines if NANs should be skipped
 
         Raises
         ------
@@ -1511,6 +1515,164 @@ class GroupBy:
         else:
             mode = [uv[mode_idx] for uv in unique_values]
         return self.unique_keys, mode  # type: ignore
+
+    def sample(
+        self,
+        values: groupable,
+        n=None,
+        frac=None,
+        replace=False,
+        weights=None,
+        random_state=None,
+        return_indices=False,
+        permute_samples=False,
+    ):
+        """
+        Return a random sample from each group. You can either specify the number of elements
+        or the fraction of elements to be sampled. random_state can be used for reproducibility
+
+        Parameters
+        ----------
+        values : (list of) pdarray-like
+            The values from which to sample, according to their group membership.
+
+        n: int, optional
+            Number of items to return for each group.
+            Cannot be used with frac and must be no larger than
+            the smallest group unless replace is True.
+            Default is one if frac is None.
+
+        frac: float, optional
+            Fraction of items to return. Cannot be used with n.
+
+        replace: bool, default False
+            Allow or disallow sampling of the value more than once.
+
+        weights: pdarray, optional
+            Default None results in equal probability weighting.
+            If passed a pdarray, then values must have the same length as the groupby keys
+            and will be used as sampling probabilities after normalization within each group.
+            Weights must be non-negative with at least one positive element within each group.
+
+        random_state: int or ak.random.Generator, optional
+            If int, seed for random number generator.
+            If ak.random.Generator, use as given.
+
+        return_indices: bool, default False
+            if True, return the indices of the sampled values.
+            Otherwise, return the sample values.
+
+        permute_samples: bool, default False
+            if True, return permute the samples according to group
+            Otherwise, keep samples in original order.
+
+        Returns
+        -------
+        pdarray
+            if return_indices is True, return the indices of the sampled values.
+            Otherwise, return the sample values.
+        """
+        from arkouda.numeric import cast as akcast
+        from arkouda.numeric import round as akround
+
+        if frac is not None and n is not None:
+            raise ValueError("Please enter a value for `frac` OR `n`, not both")
+        if frac is None and n is None:
+            n = 1
+
+        if not isinstance(values, Sequence):
+            if values.size != self.length:
+                raise ValueError("Attempt to group values using key array of different length")
+        else:
+            if any(val.size != self.length for val in values):
+                raise ValueError("Attempt to group values using key array of different length")
+
+        _, seg_lens = self.size()
+
+        if n is not None:
+            if not _val_isinstance_of_union(n, int_scalars):
+                raise TypeError("n must be an int scalar.")
+            num_samples = full(seg_lens.size, n, akint64)
+
+        if frac is not None:
+            if not _val_isinstance_of_union(frac, float_scalars):
+                raise TypeError("frac must be a float scalar.")
+            num_samples = akcast(akround(frac * seg_lens), dt=akint64)
+
+        if not replace and (num_samples > seg_lens).any():
+            raise ValueError("Cannot take a larger sample than population when replace is False")
+
+        if (num_samples <= 0).any():
+            raise ValueError("Cannot take a larger sample than population when replace is False")
+
+        has_weights = weights is not None
+        if has_weights:
+            if not isinstance(weights, pdarray):
+                raise TypeError("weights must be a pdarray")
+
+            if weights.size != self.length:
+                raise ValueError("Weights and values to be sampled must be of same length")
+
+            if (weights < 0).any():
+                raise ValueError("Weights may not include negative values")
+
+            permuted_weights = weights[self.permutation]
+
+            # the below is equivalent to doing `_, weight_sum = self.sum(weights)`, but
+            # by calling segmentedReduction directly, we avoid permuting the weights twice.
+            # it's unclear if this is worth the additional code complexity
+            repMsg = generic_msg(
+                cmd="segmentedReduction",
+                args={
+                    "values": permuted_weights,
+                    "segments": self.segments,
+                    "op": "sum",
+                    "skip_nan": True,
+                    "ddof": 1,
+                },
+            )
+            weight_sum = create_pdarray(repMsg)
+
+            if (weight_sum == 0).any():
+                raise ValueError("All segments must have at least one value of non-zero weight")
+
+            if permuted_weights.dtype != akfloat64:
+                permuted_weights = akcast(permuted_weights, akfloat64)
+        else:
+            permuted_weights = ""
+
+        random_state = default_rng(random_state)
+        gen_name = random_state._name_dict[to_numpy_dtype(akfloat64 if has_weights else akint64)]
+
+        has_seed = random_state._seed is not None
+
+        repMsg = generic_msg(
+            cmd="segmentedSample",
+            args={
+                "genName": gen_name,
+                "perm": self.permutation,
+                "segs": self.segments,
+                "segLens": seg_lens,
+                "weights": permuted_weights,
+                "numSamples": num_samples,
+                "replace": replace,
+                "hasWeights": has_weights,
+                "hasSeed": has_seed,
+                "seed": random_state._seed if has_seed else "",
+                "state": random_state._state,
+            },
+        )
+        random_state._state += self.length
+
+        self.logger.debug(repMsg)
+        # sorting the sample permutation gives the sampled indices
+        sampled_idx = create_pdarray(repMsg) if permute_samples else sort(create_pdarray(repMsg))
+        if return_indices:
+            return sampled_idx
+        elif not isinstance(values, Sequence):
+            return values[sampled_idx]
+        else:
+            return [val[sampled_idx] for val in values]
 
     def unique(self, values: groupable):  # type: ignore
         """

--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -1603,7 +1603,7 @@ class GroupBy:
             raise ValueError("Cannot take a larger sample than population when replace is False")
 
         if (num_samples <= 0).any():
-            raise ValueError("Cannot take a larger sample than population when replace is False")
+            raise ValueError("Cannot take a negative number of samples")
 
         has_weights = weights is not None
         if has_weights:

--- a/src/RandArray.chpl
+++ b/src/RandArray.chpl
@@ -175,12 +175,12 @@ module RandArray {
 
     // compute the normalized cumulative weights
     var cw = + scan weights;
-    cw /= cw[dw.size-1];
+    cw /= cw[dw.last];
 
     if !Sort.isSorted(cw) then
       throw new IllegalArgumentError("'weights' cannot contain negative values");
 
-    if cw[dw.size-1] <= 1e-15 then
+    if cw[dw.last] <= 1e-15 then
       throw new IllegalArgumentError("'weights' must contain at least one non-zero value");
 
     const dOut = {0..<n};
@@ -212,7 +212,7 @@ module RandArray {
 
         // recompute the normalized cumulative weights
         cw = + scan weightsCopy;
-        cw /= cw[dw.size-1];
+        cw /= cw[dw.last];
       }
     }
 

--- a/src/RandMsg.chpl
+++ b/src/RandMsg.chpl
@@ -297,6 +297,64 @@ module RandMsg
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 
+    proc segmentedSampleMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        const pn = Reflection.getRoutineName(),
+              genName = msgArgs.getValueOf("genName"),                          // generator name
+              permName = msgArgs.getValueOf("perm"),                            // values array name
+              segsName = msgArgs.getValueOf("segs"),                            // segments array name
+              segLensName = msgArgs.getValueOf("segLens"),                      // segment lengths array name
+              weightsName = msgArgs.getValueOf("weights"),                      // permuted weights array name
+              numSamplesName = msgArgs.getValueOf("numSamples"),                // number of samples per segment array name
+              replace = msgArgs.get("replace").getBoolValue(),                  // sample with replacement
+              hasWeights = msgArgs.get("hasWeights").getBoolValue(),            // flag indicating whether weighted sample
+              hasSeed = msgArgs.get("hasSeed").getBoolValue(),                  // flag indicating if generator is seeded
+              seed = if hasSeed then msgArgs.get("seed").getIntValue() else -1, // value of seed if present
+              state = msgArgs.get("state").getIntValue(),                       // rng state
+              rname = st.nextName();
+
+        randLogger.debug(getModuleName(),pn,getLineNumber(),
+                         "genName: %? permName %? segsName: %? weightsName: %? numSamplesName %? replace %i hasWeights %i state %i rname %?"
+                         .doFormat(genName, permName, segsName, weightsName, numSamplesName, replace, hasWeights, state, rname));
+
+        st.checkTable(permName);
+        st.checkTable(segsName);
+        st.checkTable(segLensName);
+        st.checkTable(numSamplesName);
+        const permutation = toSymEntry(getGenericTypedArrayEntry(permName, st),int).a;
+        const segments = toSymEntry(getGenericTypedArrayEntry(segsName, st),int).a;
+        const segLens = toSymEntry(getGenericTypedArrayEntry(segLensName, st),int).a;
+        const numSamples = toSymEntry(getGenericTypedArrayEntry(numSamplesName, st),int).a;
+
+        const sampleOffset = (+ scan numSamples) - numSamples;
+        var sampledPerm: [makeDistDom(+ reduce numSamples)] int;
+
+        if hasWeights {
+            st.checkTable(weightsName);
+            const weights = toSymEntry(getGenericTypedArrayEntry(weightsName, st),real).a;
+
+            forall (segOff, segLen, sampleOff, numSample) in zip(segments, segLens, sampleOffset, numSamples)
+                                                 with (var rs = if hasSeed then new randomStream(real, seed) else new randomStream(real)) {
+                if state != 1 then rs.skipTo((state+sampleOff) - 1); else rs.skipTo(sampleOff);
+                const ref segPerm = permutation[segOff..#segLen];
+                const ref segWeights = weights[segOff..#segLen];
+                sampledPerm[sampleOff..#numSample] = randSampleWeights(rs, segPerm, segWeights, numSample, replace);
+            }
+        }
+        else {
+            forall (segOff, segLen, sampleOff, numSample) in zip(segments, segLens, sampleOffset, numSamples)
+                                                 with (var rs = if hasSeed then new randomStream(int, seed) else new randomStream(int)) {
+                if state != 1 then rs.skipTo((state+sampleOff) - 1); else rs.skipTo(sampleOff);
+                const ref segPerm = permutation[segOff..#segLen];
+                sampledPerm[sampleOff..#numSample] = rs.sample(segPerm, numSample, replace);
+            }
+        }
+
+        st.addEntry(rname, createSymEntry(sampledPerm));
+        const repMsg = "created " + st.attrib(rname);
+        randLogger.debug(getModuleName(),pn,getLineNumber(),repMsg);
+        return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+
     proc choiceMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         const pn = Reflection.getRoutineName(),
               gName = msgArgs.getValueOf("gName"),                      // generator name
@@ -509,6 +567,7 @@ module RandMsg
     registerFunction("randomNormal", randomNormalMsg, getModuleName());
     registerFunction("createGenerator", createGeneratorMsg, getModuleName());
     registerFunction("uniformGenerator", uniformGeneratorMsg, getModuleName());
+    registerFunction("segmentedSample", segmentedSampleMsg, getModuleName());
     registerFunction("choice", choiceMsg, getModuleName());
     registerFunction("permutation", permutationMsg, getModuleName());
     registerFunction("shuffle", shuffleMsg, getModuleName());

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -577,6 +577,7 @@ module ReductionMsg
       return nancounts;
     }
     
+    // SegmentedSample is in RandMsg
     proc segmentedReductionMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         param pn = Reflection.getRoutineName();
         // reqMsg: segmentedReduction values segments operator

--- a/src/compat/e-132/ArkoudaRandomCompat.chpl
+++ b/src/compat/e-132/ArkoudaRandomCompat.chpl
@@ -30,72 +30,12 @@ module ArkoudaRandomCompat {
       r.permutation(domArr);
       return domArr;
     }
-
     proc ref sample(d: domain(?), n: int, withReplacement = false): [] d.idxType throws  where is1DRectangularDomain(d) {
       return choiceUniform(r, d, n, withReplacement);
-
-      /* _choice branch for uniform distribution */
-      proc choiceUniform(stream, X: domain(?), size: ?sizeType, replace: bool) throws
-      {
-        use Set;
-        use Math;
-
-        const low = X.low,
-              stride = abs(X.stride);
-
-        if isNothingType(sizeType) {
-          // Return 1 sample
-          var randVal = stream.getNext(resultType=int, 0, X.sizeAs(X.idxType)-1);
-          var randIdx = X.dim(0).orderToIndex(randVal);
-          return randIdx;
-        } else {
-          // Return numElements samples
-
-          // Compute numElements for tuple case
-          var m = 1;
-          if isDomainType(sizeType) then m = size.size;
-
-          var numElements = if isDomainType(sizeType) then m
-                            else if isIntegralType(sizeType) then size:int
-                            else compilerError('choice() size type must be integral or tuple of ranges');
-
-          // Return N samples
-          var samples: [0..<numElements] int;
-
-          if replace {
-            for sample in samples {
-              var randVal = stream.getNext(resultType=int, 0, X.sizeAs(X.idxType)-1);
-              var randIdx = X.dim(0).orderToIndex(randVal);
-              sample = randIdx;
-            }
-          } else {
-            if numElements < log2(X.sizeAs(X.idxType)) {
-              var indices: set(int);
-              var i: int = 0;
-              while i < numElements {
-                var randVal = stream.getNext(resultType=int, 0, X.sizeAs(X.idxType)-1);
-                if !indices.contains(randVal) {
-                  var randIdx = X.dim(0).orderToIndex(randVal);
-                  samples[i] = randIdx;
-                  indices.add(randVal);
-                  i += 1;
-                }
-              }
-            } else {
-              var indices: [X] int = X;
-              stream.shuffle(indices);
-              for i in samples.domain {
-                samples[i] = (indices[X.dim(0).orderToIndex(i)]);
-              }
-            }
-          }
-          if isIntegralType(sizeType) {
-            return samples;
-          } else if isDomainType(sizeType) {
-            return reshape(samples, size);
-          }
-        }
-      }
+    }
+    proc ref sample(const x: [?dom], size:?sizeType=none, replace=true) throws {
+      var idx = choiceUniform(this, dom, size, replace);
+      return x[idx];
     }
     proc ref next(): eltType do return r.getNext();
     proc skipTo(n: int) do try! r.skipToNth(n);
@@ -104,5 +44,66 @@ module ArkoudaRandomCompat {
   proc sample(arr: [?d] ?t, n: int, withReplacement: bool): [] t throws {
     var r = new randomStream(int);
     return r.r.choice(arr, size=n, replace=withReplacement);
+  }
+  proc choiceUniform(stream, X: domain(?), size: ?sizeType, replace: bool) throws
+  {
+    use Set;
+    use Math;
+
+    const low = X.low,
+          stride = abs(X.stride);
+
+    if isNothingType(sizeType) {
+      // Return 1 sample
+      var randVal = stream.getNext(resultType=int, 0, X.sizeAs(X.idxType)-1);
+      var randIdx = X.dim(0).orderToIndex(randVal);
+      return randIdx;
+    } else {
+      // Return numElements samples
+
+      // Compute numElements for tuple case
+      var m = 1;
+      if isDomainType(sizeType) then m = size.size;
+
+      var numElements = if isDomainType(sizeType) then m
+                        else if isIntegralType(sizeType) then size:int
+                        else compilerError('choice() size type must be integral or tuple of ranges');
+
+      // Return N samples
+      var samples: [0..<numElements] int;
+
+      if replace {
+        for sample in samples {
+          var randVal = stream.getNext(resultType=int, 0, X.sizeAs(X.idxType)-1);
+          var randIdx = X.dim(0).orderToIndex(randVal);
+          sample = randIdx;
+        }
+      } else {
+        if numElements < log2(X.sizeAs(X.idxType)) {
+          var indices: set(int);
+          var i: int = 0;
+          while i < numElements {
+            var randVal = stream.getNext(resultType=int, 0, X.sizeAs(X.idxType)-1);
+            if !indices.contains(randVal) {
+              var randIdx = X.dim(0).orderToIndex(randVal);
+              samples[i] = randIdx;
+              indices.add(randVal);
+              i += 1;
+            }
+          }
+        } else {
+          var indices: [X] int = X;
+          stream.shuffle(indices);
+          for i in samples.domain {
+            samples[i] = (indices[X.dim(0).orderToIndex(i)]);
+          }
+        }
+      }
+      if isIntegralType(sizeType) {
+        return samples;
+      } else if isDomainType(sizeType) {
+        return reshape(samples, size);
+      }
+    }
   }
 }

--- a/src/compat/eq-131/ArkoudaRandomCompat.chpl
+++ b/src/compat/eq-131/ArkoudaRandomCompat.chpl
@@ -32,69 +32,10 @@ module ArkoudaRandomCompat {
     }
     proc ref sample(d: domain, n: int, withReplacement = false): [] d.idxType throws  where is1DRectangularDomain(d) {
       return choiceUniform(r, d, n, withReplacement);
-
-      /* _choice branch for uniform distribution */
-      proc choiceUniform(stream, X: domain, size: ?sizeType, replace: bool) throws
-      {
-        use Set;
-        use Math;
-
-        const low = X.low,
-              stride = abs(X.stride);
-
-        if isNothingType(sizeType) {
-          // Return 1 sample
-          var randVal = stream.getNext(resultType=int, 0, X.sizeAs(X.idxType)-1);
-          var randIdx = X.dim(0).orderToIndex(randVal);
-          return randIdx;
-        } else {
-          // Return numElements samples
-
-          // Compute numElements for tuple case
-          var m = 1;
-          if isDomainType(sizeType) then m = size.size;
-
-          var numElements = if isDomainType(sizeType) then m
-                            else if isIntegralType(sizeType) then size:int
-                            else compilerError('choice() size type must be integral or tuple of ranges');
-
-          // Return N samples
-          var samples: [0..<numElements] int;
-
-          if replace {
-            for sample in samples {
-              var randVal = stream.getNext(resultType=int, 0, X.sizeAs(X.idxType)-1);
-              var randIdx = X.dim(0).orderToIndex(randVal);
-              sample = randIdx;
-            }
-          } else {
-            if numElements < log2(X.sizeAs(X.idxType)) {
-              var indices: set(int);
-              var i: int = 0;
-              while i < numElements {
-                var randVal = stream.getNext(resultType=int, 0, X.sizeAs(X.idxType)-1);
-                if !indices.contains(randVal) {
-                  var randIdx = X.dim(0).orderToIndex(randVal);
-                  samples[i] = randIdx;
-                  indices.add(randVal);
-                  i += 1;
-                }
-              }
-            } else {
-              var indices: [X] int = X;
-              stream.shuffle(indices);
-              for i in samples.domain {
-                samples[i] = (indices[X.dim(0).orderToIndex(i)]);
-              }
-            }
-          }
-          if isIntegralType(sizeType) {
-            return samples;
-          } else if isDomainType(sizeType) {
-            return reshape(samples, size);
-          }
-        }
-      }
+    }
+    proc ref sample(const x: [?dom], size:?sizeType=none, replace=true) throws {
+      var idx = choiceUniform(this, dom, size, replace);
+      return x[idx];
     }
     proc ref next(): eltType do return r.getNext();
     proc skipTo(n: int) do try! r.skipToNth(n);
@@ -103,5 +44,66 @@ module ArkoudaRandomCompat {
   proc sample(arr: [?d] ?t, n: int, withReplacement: bool): [] t throws {
     var r = new randomStream(int);
     return r.r.choice(arr, size=n, replace=withReplacement);
+  }
+  proc choiceUniform(stream, X: domain, size: ?sizeType, replace: bool) throws
+  {
+    use Set;
+    use Math;
+
+    const low = X.low,
+          stride = abs(X.stride);
+
+    if isNothingType(sizeType) {
+      // Return 1 sample
+      var randVal = stream.getNext(resultType=int, 0, X.sizeAs(X.idxType)-1);
+      var randIdx = X.dim(0).orderToIndex(randVal);
+      return randIdx;
+    } else {
+      // Return numElements samples
+
+      // Compute numElements for tuple case
+      var m = 1;
+      if isDomainType(sizeType) then m = size.size;
+
+      var numElements = if isDomainType(sizeType) then m
+                        else if isIntegralType(sizeType) then size:int
+                        else compilerError('choice() size type must be integral or tuple of ranges');
+
+      // Return N samples
+      var samples: [0..<numElements] int;
+
+      if replace {
+        for sample in samples {
+          var randVal = stream.getNext(resultType=int, 0, X.sizeAs(X.idxType)-1);
+          var randIdx = X.dim(0).orderToIndex(randVal);
+          sample = randIdx;
+        }
+      } else {
+        if numElements < log2(X.sizeAs(X.idxType)) {
+          var indices: set(int);
+          var i: int = 0;
+          while i < numElements {
+            var randVal = stream.getNext(resultType=int, 0, X.sizeAs(X.idxType)-1);
+            if !indices.contains(randVal) {
+              var randIdx = X.dim(0).orderToIndex(randVal);
+              samples[i] = randIdx;
+              indices.add(randVal);
+              i += 1;
+            }
+          }
+        } else {
+          var indices: [X] int = X;
+          stream.shuffle(indices);
+          for i in samples.domain {
+            samples[i] = (indices[X.dim(0).orderToIndex(i)]);
+          }
+        }
+      }
+      if isIntegralType(sizeType) {
+        return samples;
+      } else if isDomainType(sizeType) {
+        return reshape(samples, size);
+      }
+    }
   }
 }

--- a/src/compat/eq-133/ArkoudaRandomCompat.chpl
+++ b/src/compat/eq-133/ArkoudaRandomCompat.chpl
@@ -20,39 +20,61 @@ module ArkoudaRandomCompat {
   }
   proc ref randomStream.sample(d: domain(?), n: int, withReplacement = false): [] d.idxType throws where is1DRectangularDomain(d) && isCoercible(this.eltType, d.idxType) {
     return choiceUniform(this, d, n, withReplacement);
-    proc choiceUniform(ref stream, X: domain(?), size: ?sizeType, replace: bool) throws
-    {
-      use Math;
-      const low = X.low,
-            stride = abs(X.stride);
+  }
+  proc ref randomStream.sample(const x: [?dom], size:?sizeType=none, replace=true) throws {
+      var idx = choiceUniform(this, dom, size, replace);
+      return x[idx];
+    }
+  proc ref randomStream.next() do return this.getNext();
 
-      if isNothingType(sizeType) {
-        // Return 1 sample
-        var randVal;
-        // TODO: removed first branch of this conditional after PCG/NPBRandomStream deprecations
-        if __primitive("method call and fn resolves", stream, "getNext", X.idxType) {
-          randVal = stream.getNext(resultType=X.idxType, 0, X.sizeAs(X.idxType)-1);
-        } else {
-          randVal = stream.getNext(0, X.sizeAs(X.idxType)-1);
-        }
-        var randIdx = X.dim(0).orderToIndex(randVal);
-        return randIdx;
+  proc choiceUniform(ref stream, X: domain(?), size: ?sizeType, replace: bool) throws
+  {
+    use Math;
+    const low = X.low,
+          stride = abs(X.stride);
+
+    if isNothingType(sizeType) {
+      // Return 1 sample
+      var randVal;
+      // TODO: removed first branch of this conditional after PCG/NPBRandomStream deprecations
+      if __primitive("method call and fn resolves", stream, "getNext", X.idxType) {
+        randVal = stream.getNext(resultType=X.idxType, 0, X.sizeAs(X.idxType)-1);
       } else {
-        // Return numElements samples
+        randVal = stream.getNext(0, X.sizeAs(X.idxType)-1);
+      }
+      var randIdx = X.dim(0).orderToIndex(randVal);
+      return randIdx;
+    } else {
+      // Return numElements samples
 
-        // Compute numElements for tuple case
-        var m = 1;
-        if isDomainType(sizeType) then m = size.size;
+      // Compute numElements for tuple case
+      var m = 1;
+      if isDomainType(sizeType) then m = size.size;
 
-        var numElements = if isDomainType(sizeType) then m
-                          else if isIntegralType(sizeType) then size:int
-                          else compilerError('choice() size type must be integral or tuple of ranges');
+      var numElements = if isDomainType(sizeType) then m
+                        else if isIntegralType(sizeType) then size:int
+                        else compilerError('choice() size type must be integral or tuple of ranges');
 
-        // Return N samples
-        var samples: [0..<numElements] int;
+      // Return N samples
+      var samples: [0..<numElements] int;
 
-        if replace {
-          for sample in samples {
+      if replace {
+        for sample in samples {
+          var randVal;
+          // TODO: removed first branch of this conditional after PCG/NPBRandomStream deprecations
+          if __primitive("method call and fn resolves", stream, "getNext", X.idxType) {
+            randVal = stream.getNext(resultType=X.idxType, 0, X.sizeAs(X.idxType)-1);
+          } else {
+            randVal = stream.getNext(0, X.sizeAs(X.idxType)-1);
+          }
+          var randIdx = X.dim(0).orderToIndex(randVal);
+          sample = randIdx;
+        }
+      } else {
+        if numElements < log2(X.sizeAs(X.idxType)) {
+          var indices: domain(int, parSafe=false);
+          var i: int = 0;
+          while i < numElements {
             var randVal;
             // TODO: removed first branch of this conditional after PCG/NPBRandomStream deprecations
             if __primitive("method call and fn resolves", stream, "getNext", X.idxType) {
@@ -60,43 +82,26 @@ module ArkoudaRandomCompat {
             } else {
               randVal = stream.getNext(0, X.sizeAs(X.idxType)-1);
             }
-            var randIdx = X.dim(0).orderToIndex(randVal);
-            sample = randIdx;
+            if !indices.contains(randVal) {
+              var randIdx = X.dim(0).orderToIndex(randVal);
+              samples[i] = randIdx;
+              indices.add(randVal);
+              i += 1;
+            }
           }
         } else {
-          if numElements < log2(X.sizeAs(X.idxType)) {
-            var indices: domain(int, parSafe=false);
-            var i: int = 0;
-            while i < numElements {
-              var randVal;
-              // TODO: removed first branch of this conditional after PCG/NPBRandomStream deprecations
-              if __primitive("method call and fn resolves", stream, "getNext", X.idxType) {
-                randVal = stream.getNext(resultType=X.idxType, 0, X.sizeAs(X.idxType)-1);
-              } else {
-                randVal = stream.getNext(0, X.sizeAs(X.idxType)-1);
-              }
-              if !indices.contains(randVal) {
-                var randIdx = X.dim(0).orderToIndex(randVal);
-                samples[i] = randIdx;
-                indices.add(randVal);
-                i += 1;
-              }
-            }
-          } else {
-            var indices: [X] int = X;
-            stream.shuffle(indices);
-            for i in samples.domain {
-              samples[i] = (indices[X.dim(0).orderToIndex(i)]);
-            }
+          var indices: [X] int = X;
+          stream.shuffle(indices);
+          for i in samples.domain {
+            samples[i] = (indices[X.dim(0).orderToIndex(i)]);
           }
         }
-        if isIntegralType(sizeType) {
-          return samples;
-        } else if isDomainType(sizeType) {
-          return reshape(samples, size);
-        }
+      }
+      if isIntegralType(sizeType) {
+        return samples;
+      } else if isDomainType(sizeType) {
+        return reshape(samples, size);
       }
     }
   }
-  proc ref randomStream.next() do return this.getNext();
 }

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -13,6 +13,7 @@ from pandas.testing import assert_frame_equal, assert_series_equal
 
 from arkouda import io_util
 from arkouda.index import Index
+from arkouda.scipy import chisquare as akchisquare
 
 
 def build_ak_df():
@@ -1556,6 +1557,95 @@ class DataFrameTest(ArkoudaTest):
             df.to_pandas().to_markdown(tablefmt="grid", index=False),
         )
         self.assertEqual(df.to_markdown(tablefmt="jira"), df.to_pandas().to_markdown(tablefmt="jira"))
+
+    def test_sample_hypothesis_testing(self):
+        # perform a weighted sample and use chisquare to test
+        # if the observed frequency matches the expected frequency
+
+        # I tested this many times without a set seed, but with no seed
+        # it's expected to fail one out of every ~20 runs given a pval limit of 0.05
+        rng = ak.random.default_rng(43)
+        num_samples = 10**4
+
+        prob_arr = ak.array([0.35, 0.10, 0.55])
+        weights = ak.concatenate([prob_arr, prob_arr, prob_arr])
+        keys = ak.concatenate([ak.zeros(3, int), ak.ones(3, int), ak.full(3, 2, int)])
+        values = ak.arange(9)
+
+        akdf = ak.DataFrame({"keys": keys, "vals": values})
+
+        g = akdf.groupby("keys")
+
+        weighted_sample = g.sample(n=num_samples, replace=True, weights=weights, random_state=rng)
+
+        # count how many of each category we saw
+        uk, f_obs = ak.GroupBy(weighted_sample["vals"]).size()
+
+        # I think the keys should always be sorted but just in case
+        if not ak.is_sorted(uk):
+            f_obs = f_obs[ak.argsort(uk)]
+
+        f_exp = weights * num_samples
+        _, pval = akchisquare(f_obs=f_obs, f_exp=f_exp)
+
+        # if pval <= 0.05, the difference from the expected distribution is significant
+        self.assertTrue(pval > 0.05)
+
+    def test_sample_flags(self):
+        # use numpy to randomly generate a set seed
+        seed = np.random.default_rng().choice(2**63)
+        cfg = ak.get_config()
+
+        rng = ak.random.default_rng(seed)
+        weights = rng.uniform(size=12)
+        a_vals = [
+            rng.integers(0, 2**32, size=12, dtype="uint"),
+            rng.uniform(-1.0, 1.0, size=12),
+            rng.integers(0, 1, size=12, dtype="bool"),
+            rng.integers(-(2**32), 2**32, size=12, dtype="int"),
+        ]
+        grouping_keys = ak.concatenate([ak.zeros(4, int), ak.ones(4, int), ak.full(4, 2, int)])
+        rng.shuffle(grouping_keys)
+
+        choice_arrays = []
+        # return_indices and permute_samples are tested by the dataframe version
+        rng = ak.random.default_rng(seed)
+        for a in a_vals:
+            for size in 2, 4:
+                for replace in True, False:
+                    for p in [None, weights]:
+                        akdf = ak.DataFrame({"keys": grouping_keys, "vals": a})
+                        g = akdf.groupby("keys")
+                        choice_arrays.append(
+                            g.sample(n=size, replace=replace, weights=p, random_state=rng)
+                        )
+                        choice_arrays.append(
+                            g.sample(frac=(size / 4), replace=replace, weights=p, random_state=rng)
+                        )
+
+        # reset generator to ensure we get the same arrays
+        rng = ak.random.default_rng(seed)
+        for a in a_vals:
+            for size in 2, 4:
+                for replace in True, False:
+                    for p in [None, weights]:
+                        previous1 = choice_arrays.pop(0)
+                        previous2 = choice_arrays.pop(0)
+
+                        akdf = ak.DataFrame({"keys": grouping_keys, "vals": a})
+                        g = akdf.groupby("keys")
+                        current1 = g.sample(n=size, replace=replace, weights=p, random_state=rng)
+                        current2 = g.sample(
+                            frac=(size / 4), replace=replace, weights=p, random_state=rng
+                        )
+
+                        res = (
+                            np.allclose(previous1["vals"].to_list(), current1["vals"].to_list())
+                        ) and (np.allclose(previous2["vals"].to_list(), current2["vals"].to_list()))
+                        if not res:
+                            print(f"\nnum locales: {cfg['numLocales']}")
+                            print(f"Failure with seed:\n{seed}")
+                        self.assertTrue(res)
 
 
 def pda_to_str_helper(pda):

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -5,6 +5,7 @@ from context import arkouda as ak
 
 from arkouda.dtypes import float64, int64
 from arkouda.groupbyclass import GroupByReductionType
+from arkouda.scipy import chisquare as akchisquare
 
 SIZE = 100
 GROUPS = 8
@@ -650,6 +651,93 @@ class GroupByTest(ArkoudaTest):
             self.assertListEqual(a, r)
         for a, r in zip(ans, res2[1].to_list()):
             self.assertListEqual(a, r)
+
+    def test_sample_hypothesis_testing(self):
+        # perform a weighted sample and use chisquare to test
+        # if the observed frequency matches the expected frequency
+
+        # I tested this many times without a set seed, but with no seed
+        # it's expected to fail one out of every ~20 runs given a pval limit of 0.05
+        rng = ak.random.default_rng(43)
+        num_samples = 10**4
+
+        prob_arr = ak.array([0.35, 0.10, 0.55])
+        weights = ak.concatenate([prob_arr, prob_arr, prob_arr])
+        keys = ak.concatenate([ak.zeros(3, int), ak.ones(3, int), ak.full(3, 2, int)])
+        values = ak.arange(9)
+
+        g = ak.GroupBy(keys)
+
+        weighted_sample = g.sample(
+            values, n=num_samples, replace=True, weights=weights, random_state=rng
+        )
+
+        # count how many of each category we saw
+        uk, f_obs = ak.GroupBy(weighted_sample).size()
+
+        # I think the keys should always be sorted but just in case
+        if not ak.is_sorted(uk):
+            f_obs = f_obs[ak.argsort(uk)]
+
+        f_exp = weights * num_samples
+
+        _, pval = akchisquare(f_obs=f_obs, f_exp=f_exp)
+
+        # if pval <= 0.05, the difference from the expected distribution is significant
+        self.assertTrue(pval > 0.05)
+
+    def test_sample_flags(self):
+        # use numpy to randomly generate a set seed
+        seed = np.random.default_rng().choice(2**63)
+        cfg = ak.get_config()
+
+        rng = ak.random.default_rng(seed)
+        weights = rng.uniform(size=12)
+        a_vals = [
+            rng.integers(0, 2**32, size=12, dtype="uint"),
+            rng.uniform(-1.0, 1.0, size=12),
+            rng.integers(0, 1, size=12, dtype="bool"),
+            rng.integers(-(2**32), 2**32, size=12, dtype="int"),
+        ]
+        grouping_keys = ak.concatenate([ak.zeros(4, int), ak.ones(4, int), ak.full(4, 2, int)])
+        rng.shuffle(grouping_keys)
+
+        choice_arrays = []
+        # return_indices and permute_samples are tested by the dataframe version
+        rng = ak.random.default_rng(seed)
+        for a in a_vals:
+            for size in 2, 4:
+                for replace in True, False:
+                    for p in [None, weights]:
+                        g = ak.GroupBy(grouping_keys)
+                        choice_arrays.append(
+                            g.sample(a, n=size, replace=replace, weights=p, random_state=rng)
+                        )
+                        choice_arrays.append(
+                            g.sample(a, frac=(size / 4), replace=replace, weights=p, random_state=rng)
+                        )
+
+        # reset generator to ensure we get the same arrays
+        rng = ak.random.default_rng(seed)
+        for a in a_vals:
+            for size in 2, 4:
+                for replace in True, False:
+                    for p in [None, weights]:
+                        previous1 = choice_arrays.pop(0)
+                        previous2 = choice_arrays.pop(0)
+                        g = ak.GroupBy(grouping_keys)
+                        current1 = g.sample(a, n=size, replace=replace, weights=p, random_state=rng)
+                        current2 = g.sample(
+                            a, frac=(size / 4), replace=replace, weights=p, random_state=rng
+                        )
+
+                        res = np.allclose(previous1.to_list(), current1.to_list()) and np.allclose(
+                            previous2.to_list(), current2.to_list()
+                        )
+                        if not res:
+                            print(f"\nnum locales: {cfg['numLocales']}")
+                            print(f"Failure with seed:\n{seed}")
+                        self.assertTrue(res)
 
     def test_nunique_ordering_bug(self):
         keys = ak.array(["1" for _ in range(8)] + ["2" for _ in range(3)])

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -210,7 +210,7 @@ class RandomTest(ArkoudaTest):
                         if not res:
                             print(f"\nnum locales: {cfg['numLocales']}")
                             print(f"Failure with seed:\n{seed}")
-                        self.assertTrue()
+                        self.assertTrue(res)
 
     def test_legacy_randint(self):
         testArray = ak.random.randint(0, 10, 5)

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from base_test import ArkoudaTest
 from context import arkouda as ak
 
@@ -179,6 +178,7 @@ class RandomTest(ArkoudaTest):
     def test_choice_flags(self):
         # use numpy to randomly generate a set seed
         seed = np.random.default_rng().choice(2**63)
+        cfg = ak.get_config()
 
         rng = ak.random.default_rng(seed)
         weights = rng.uniform(size=10)
@@ -206,7 +206,11 @@ class RandomTest(ArkoudaTest):
                     for p in [None, weights]:
                         previous = choice_arrays.pop(0)
                         current = rng.choice(a, size, replace, p)
-                        self.assertTrue(np.allclose(previous.to_list(), current.to_list()))
+                        res = np.allclose(previous.to_list(), current.to_list())
+                        if not res:
+                            print(f"\nnum locales: {cfg['numLocales']}")
+                            print(f"Failure with seed:\n{seed}")
+                        self.assertTrue()
 
     def test_legacy_randint(self):
         testArray = ak.random.randint(0, 10, 5)


### PR DESCRIPTION
This PR (closes #3108) adds sampling to groupby and dataframe.groupby. It also includes a slight fix to account for non-zero based domains in `sampleDomWeighted`