### PR TITLE
Fixes #3158: `Dataframe` containing a `Segarray .__str__()` bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ UsedModules.cfg
 arkouda/*.pyi
 arkouda/numpy/*.pyi
 arkouda/scipy/*.pyi
+arkouda/scipy/stats/*.pyi

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -4,7 +4,7 @@ import json
 import os
 import random
 from collections import UserDict
-from typing import Callable, Dict, List, Optional, Union, cast
+from typing import Callable, Dict, List, Optional, Tuple, Union, cast
 from warnings import warn
 
 import numpy as np  # type: ignore
@@ -209,11 +209,26 @@ class DataFrameGroupBy:
     def _return_agg_series(self, values, sort_index=True):
         if self.as_index is True:
             if isinstance(self.gb_key_names, str):
+                # handle when values is a tuple/list containing data and index
+                # since we are also sending the index keyword
+                if isinstance(values, (Tuple, List)) and len(values) == 2:
+                    _, values = values
+
                 series = Series(values, index=Index(self.gb.unique_keys, name=self.gb_key_names))
             elif isinstance(self.gb_key_names, list) and len(self.gb_key_names) == 1:
+                # handle when values is a tuple/list containing data and index
+                # since we are also sending the index keyword
+                if isinstance(values, (Tuple, List)) and len(values) == 2:
+                    _, values = values
+
                 series = Series(values, index=Index(self.gb.unique_keys, name=self.gb_key_names[0]))
             elif isinstance(self.gb_key_names, list) and len(self.gb_key_names) > 1:
                 from arkouda.index import MultiIndex
+
+                # handle when values is a tuple/list containing data and index
+                # since we are also sending the index keyword
+                if isinstance(values, (Tuple, List)) and len(values) == 2:
+                    _, values = values
 
                 series = Series(
                     values,

--- a/arkouda/segarray.py
+++ b/arkouda/segarray.py
@@ -212,6 +212,19 @@ class SegArray:
                 broadcast(self.segments[self.non_empty], arange(self._non_empty_count), self.valsize)
             )
 
+    @property
+    def nbytes(self):
+        """
+        The size of the segarray in bytes.
+
+        Returns
+        -------
+        int
+            The size of the segarray in bytes.
+
+        """
+        return self.values.nbytes
+
     def _get_lengths(self):
         if self.size == 0:
             return zeros(0, dtype=akint64)

--- a/arkouda/series.py
+++ b/arkouda/series.py
@@ -137,7 +137,7 @@ class Series:
         index: Optional[Union[pdarray, Strings, Tuple, List, Index]] = None,
     ):
         self.registered_name: Optional[str] = None
-        if isinstance(data, (tuple, list)) and len(data) == 2:
+        if index is None and isinstance(data, (tuple, list)) and len(data) == 2:
             # handles the previous `ar_tuple` case
             if not isinstance(data[0], (pdarray, Index, Strings, Categorical, list, tuple)):
                 raise TypeError("indices must be a pdarray, Strings, Categorical, List, or Tuple")


### PR DESCRIPTION
This PR (closes #3158) fixes bug when printing a dataframe containing a segarray.

To handle this I added an `nbytes` attribute to segarray which just wraps the underlying values. I also modified the series init to not assume that when `data` is a list that it contains 2 elements (the first being the data and the second being the index) when the `index` is provided. This actual broke `_return_agg_series` because it was ignoring what was being passed in as the `index` keyword

It also adds `arkouda/scipy/stats/*.pyi` to the `.gitignore` cause it was showing up in my untracked files. I'm not sure if this is necessary

```python
>>> akdf = ak.DataFrame({'just_vals': ak.SegArray(ak.array([0,3,5,7]), ak.arange(10))})
>>> print(akdf)  # this used to break
```