### PR TITLE
Resolve deprecation warning about not using 'new' in dmapped expressions

### DIFF
--- a/src/compat/ge-20/SymArrayDmapCompat.chpl
+++ b/src/compat/ge-20/SymArrayDmapCompat.chpl
@@ -40,7 +40,7 @@ module SymArrayDmapCompat
                 }
                 // fix the annoyance about boundingBox being empty
                 else {
-                  return dom dmapped blockDist(boundingBox=dom.expand(1));
+                  return dom dmapped new blockDist(boundingBox=dom.expand(1));
                 }
             }
             otherwise {


### PR DESCRIPTION
Resolves a new deprecation warning introduced in https://github.com/chapel-lang/chapel/pull/24952