### PR TITLE
Closes #3148: Update IO functions to always return a dictionary

### DIFF
--- a/PROTO_tests/tests/io_test.py
+++ b/PROTO_tests/tests/io_test.py
@@ -152,19 +152,19 @@ class TestParquet:
         with tempfile.TemporaryDirectory(dir=TestParquet.par_test_base_tmp) as tmp_dirname:
             file_name = f"{tmp_dirname}/pq_test_correct"
             ak_arr.to_parquet(file_name, "my-dset", compression=comp)
-            pq_arr = ak.read_parquet(f"{file_name}*", "my-dset")
+            pq_arr = ak.read_parquet(f"{file_name}*", "my-dset")["my-dset"]
             assert (ak_arr == pq_arr).all()
 
             # verify generic read works
-            gen_arr = ak.read(f"{file_name}*", "my-dset")
+            gen_arr = ak.read(f"{file_name}*", "my-dset")["my-dset"]
             assert (ak_arr == gen_arr).all()
 
             # verify generic load works
-            gen_arr = ak.load(path_prefix=file_name, dataset="my-dset")
+            gen_arr = ak.load(path_prefix=file_name, dataset="my-dset")["my-dset"]
             assert (ak_arr == gen_arr).all()
 
             # verify generic load works with file_format parameter
-            gen_arr = ak.load(path_prefix=file_name, dataset="my-dset", file_format="Parquet")
+            gen_arr = ak.load(path_prefix=file_name, dataset="my-dset", file_format="Parquet")["my-dset"]
             assert (ak_arr == gen_arr).all()
 
             # verify load_all works
@@ -192,7 +192,7 @@ class TestParquet:
                     arr_in_file_i.to_parquet(f"{file_name}{i:04d}", "test-dset")
 
             assert len(glob.glob(f"{file_name}*")) == NUM_FILES
-            pq_arr = ak.read_parquet(f"{file_name}*", "test-dset")
+            pq_arr = ak.read_parquet(f"{file_name}*", "test-dset")["test-dset"]
             assert (ak_arr == pq_arr).all()
 
     def test_wrong_dset_name(self):
@@ -214,7 +214,7 @@ class TestParquet:
         ak_edge_case = ak.array(np_edge_case)
         with tempfile.TemporaryDirectory(dir=TestParquet.par_test_base_tmp) as tmp_dirname:
             ak_edge_case.to_parquet(f"{tmp_dirname}/pq_test_edge_case", "my-dset", compression=comp)
-            pq_arr = ak.read_parquet(f"{tmp_dirname}/pq_test_edge_case*", "my-dset")
+            pq_arr = ak.read_parquet(f"{tmp_dirname}/pq_test_edge_case*", "my-dset")["my-dset"]
             if dtype == "float64":
                 assert np.allclose(np_edge_case, pq_arr.to_ndarray(), equal_nan=True)
             else:
@@ -253,7 +253,7 @@ class TestParquet:
         ak_arr = make_ak_arrays(32, dtype)
         with tempfile.TemporaryDirectory(dir=TestParquet.par_test_base_tmp) as tmp_dirname:
             ak_arr.to_parquet(f"{tmp_dirname}/pq_test_correct", "my-dset", mode="append")
-            pq_arr = ak.read_parquet(f"{tmp_dirname}/pq_test_correct*", "my-dset")
+            pq_arr = ak.read_parquet(f"{tmp_dirname}/pq_test_correct*", "my-dset")["my-dset"]
 
             assert ak_arr.to_list() == pq_arr.to_list()
 
@@ -264,11 +264,11 @@ class TestParquet:
             file_name = f"{tmp_dirname}/null_strings"
             null_strings.to_parquet(file_name, compression=comp)
 
-            ak_data = ak.read_parquet(f"{file_name}*")
+            ak_data = ak.read_parquet(f"{file_name}*").popitem()[1]
             assert (null_strings == ak_data).all()
 
             # datasets must be specified for get_null_indices
-            res = ak.get_null_indices(f"{file_name}*", datasets="strings_array")
+            res = ak.get_null_indices(f"{file_name}*", datasets="strings_array").popitem()[1]
             assert [0, 1, 0, 1, 0, 1, 1] == res.to_list()
 
     @pytest.mark.parametrize("comp", COMPRESSIONS)
@@ -334,7 +334,7 @@ class TestParquet:
 
             # verify individual column selection
             for k, v in df.items():
-                ak_data = ak.read_parquet(f"{file_name}*", datasets=k)
+                ak_data = ak.read_parquet(f"{file_name}*", datasets=k)[k]
                 assert isinstance(ak_data, ak.SegArray)
                 for x, y in zip(v.tolist(), ak_data.to_list()):
                     if isinstance(x, np.ndarray):
@@ -347,7 +347,7 @@ class TestParquet:
         with tempfile.TemporaryDirectory(dir=TestParquet.par_test_base_tmp) as tmp_dirname:
             pq.write_table(table, f"{tmp_dirname}/empty_segments", compression=comp)
 
-            ak_data = ak.read_parquet(f"{tmp_dirname}/empty_segments*")
+            ak_data = ak.read_parquet(f"{tmp_dirname}/empty_segments*")["ListCol"]
             assert isinstance(ak_data, ak.SegArray)
             assert ak_data.size == 5
             for i in range(5):
@@ -367,10 +367,10 @@ class TestParquet:
                 assert df[k].tolist() == v.to_list()
 
             # read individual datasets
-            ak_data = ak.read_parquet(f"{file_name}*", datasets="IntCol")
+            ak_data = ak.read_parquet(f"{file_name}*", datasets="IntCol")["IntCol"]
             assert isinstance(ak_data, ak.pdarray)
             assert df["IntCol"].to_list() == ak_data.to_list()
-            ak_data = ak.read_parquet(f"{file_name}*", datasets="ListCol")
+            ak_data = ak.read_parquet(f"{file_name}*", datasets="ListCol")["ListCol"]
             assert isinstance(ak_data, ak.SegArray)
             assert df["ListCol"].to_list() == ak_data.to_list()
 
@@ -409,7 +409,7 @@ class TestParquet:
                     # when single locale artifically create multiple files
                     for i in range(NUM_FILES):
                         pq.write_table(tables[i], f"{file_name}_LOCALE{i:04d}", compression=comp)
-                ak_data = ak.read_parquet(f"{file_name}*")
+                ak_data = ak.read_parquet(f"{file_name}*")["ListCol"]
                 assert isinstance(ak_data, ak.SegArray)
                 assert ak_data.size == len(lists[0]) * NUM_FILES
                 for i in range(ak_data.size):
@@ -423,7 +423,7 @@ class TestParquet:
         with tempfile.TemporaryDirectory(dir=TestParquet.par_test_base_tmp) as tmp_dirname:
             s.to_parquet(f"{tmp_dirname}/segarray_test")
 
-            rd_data = ak.read_parquet(f"{tmp_dirname}/segarray_test*")
+            rd_data = ak.read_parquet(f"{tmp_dirname}/segarray_test*").popitem()[1]
             for i in range(3):
                 x, y = s[i].to_list(), rd_data[i].to_list()
                 assert x == y if dtype != "float64" else np.allclose(x, y, equal_nan=True)
@@ -432,7 +432,7 @@ class TestParquet:
         with tempfile.TemporaryDirectory(dir=TestParquet.par_test_base_tmp) as tmp_dirname:
             s.to_parquet(f"{tmp_dirname}/segarray_test_empty")
 
-            rd_data = ak.read_parquet(f"{tmp_dirname}/segarray_test_empty*")
+            rd_data = ak.read_parquet(f"{tmp_dirname}/segarray_test_empty*").popitem()[1]
             for i in range(6):
                 x, y = s[i].to_list(), rd_data[i].to_list()
                 assert x == y if dtype != "float64" else np.allclose(x, y, equal_nan=True)
@@ -485,7 +485,7 @@ class TestParquet:
             assert df["seg"].to_list() == data["seg"].to_list()
 
             # test read with read_nested=false and no supplied datasets
-            data = ak.read_parquet(f"{file_name}*", read_nested=False)
+            data = ak.read_parquet(f"{file_name}*", read_nested=False)["idx"]
             assert isinstance(data, ak.pdarray)
             assert df["idx"].to_list() == data.to_list()
 
@@ -540,31 +540,35 @@ class TestHDF5:
             ak_arr.to_hdf(file_name)
 
             # test read_hdf with glob
-            gen_arr = ak.read_hdf(f"{file_name}*")
+            gen_arr = ak.read_hdf(f"{file_name}*").popitem()[1]
             assert (ak_arr == gen_arr).all()
 
             # test read_hdf with filenames
-            gen_arr = ak.read_hdf(filenames=[f"{file_name}_LOCALE{i:04d}" for i in range(pytest.nl)])
+            gen_arr = ak.read_hdf(
+                filenames=[f"{file_name}_LOCALE{i:04d}" for i in range(pytest.nl)]
+            ).popitem()[1]
             assert (ak_arr == gen_arr).all()
 
             # verify generic read works
-            gen_arr = ak.read(f"{file_name}*")
+            gen_arr = ak.read(f"{file_name}*").popitem()[1]
             assert (ak_arr == gen_arr).all()
 
             # verify generic load works
             if dtype == "str":
                 # we have to specify the dataset for strings since it differs from default of "array"
-                gen_arr = ak.load(path_prefix=file_name, dataset="strings_array")
+                gen_arr = ak.load(path_prefix=file_name, dataset="strings_array")["strings_array"]
             else:
-                gen_arr = ak.load(path_prefix=file_name)
+                gen_arr = ak.load(path_prefix=file_name).popitem()[1]
             assert (ak_arr == gen_arr).all()
 
             # verify generic load works with file_format parameter
             if dtype == "str":
                 # we have to specify the dataset for strings since it differs from default of "array"
-                gen_arr = ak.load(path_prefix=file_name, dataset="strings_array", file_format="HDF5")
+                gen_arr = ak.load(path_prefix=file_name, dataset="strings_array", file_format="HDF5")[
+                    "strings_array"
+                ]
             else:
-                gen_arr = ak.load(path_prefix=file_name, file_format="HDF5")
+                gen_arr = ak.load(path_prefix=file_name, file_format="HDF5").popitem()[1]
             assert (ak_arr == gen_arr).all()
 
             # verify load_all works
@@ -588,25 +592,25 @@ class TestHDF5:
             ak_arr.to_hdf(file_name, "my_dset")
 
             # test read_hdf with glob
-            gen_arr = ak.read_hdf(f"{file_name}*", "my_dset")
+            gen_arr = ak.read_hdf(f"{file_name}*", "my_dset")["my_dset"]
             assert (ak_arr == gen_arr).all()
 
             # test read_hdf with filenames
             gen_arr = ak.read_hdf(
                 filenames=[f"{file_name}_LOCALE{i:04d}" for i in range(pytest.nl)], datasets="my_dset"
-            )
+            )["my_dset"]
             assert (ak_arr == gen_arr).all()
 
             # verify generic read works
-            gen_arr = ak.read(f"{file_name}*", "my_dset")
+            gen_arr = ak.read(f"{file_name}*", "my_dset")["my_dset"]
             assert (ak_arr == gen_arr).all()
 
             # verify generic load works
-            gen_arr = ak.load(path_prefix=file_name, dataset="my_dset")
+            gen_arr = ak.load(path_prefix=file_name, dataset="my_dset")["my_dset"]
             assert (ak_arr == gen_arr).all()
 
             # verify generic load works with file_format parameter
-            gen_arr = ak.load(path_prefix=file_name, dataset="my_dset", file_format="HDF5")
+            gen_arr = ak.load(path_prefix=file_name, dataset="my_dset", file_format="HDF5")["my_dset"]
             assert (ak_arr == gen_arr).all()
 
             # verify load_all works
@@ -623,7 +627,7 @@ class TestHDF5:
         ak_edge_case = ak.array(np_edge_case)
         with tempfile.TemporaryDirectory(dir=TestHDF5.hdf_test_base_tmp) as tmp_dirname:
             ak_edge_case.to_hdf(f"{tmp_dirname}/hdf_test_edge_case", "my-dset")
-            hdf_arr = ak.read_hdf(f"{tmp_dirname}/hdf_test_edge_case*", "my-dset")
+            hdf_arr = ak.read_hdf(f"{tmp_dirname}/hdf_test_edge_case*", "my-dset")["my-dset"]
             if dtype == "float64":
                 assert np.allclose(np_edge_case, hdf_arr.to_ndarray(), equal_nan=True)
             else:
@@ -651,7 +655,7 @@ class TestHDF5:
 
             # test read_hdf with only one dataset specified (each tested)
             for col_name in akdf.columns.values:
-                gen_arr = ak.read_hdf(f"{file_name}*", datasets=[col_name])
+                gen_arr = ak.read_hdf(f"{file_name}*", datasets=[col_name])[col_name]
                 if akdf[col_name].dtype != ak.float64:
                     assert akdf[col_name].to_list() == gen_arr.to_list()
                 else:
@@ -691,7 +695,7 @@ class TestHDF5:
 
             for col_name in akdf.columns.values:
                 # verify generic load works
-                gen_arr = ak.load(path_prefix=file_name, dataset=col_name)
+                gen_arr = ak.load(path_prefix=file_name, dataset=col_name)[col_name]
                 if akdf[col_name].dtype != ak.float64:
                     assert akdf[col_name].to_list() == gen_arr.to_list()
                 else:
@@ -703,7 +707,7 @@ class TestHDF5:
                         assert np.allclose(a, b, equal_nan=True)
 
                 # verify generic load works with file_format parameter
-                gen_arr = ak.load(path_prefix=file_name, dataset=col_name, file_format="HDF5")
+                gen_arr = ak.load(path_prefix=file_name, dataset=col_name, file_format="HDF5")[col_name]
                 if akdf[col_name].dtype != ak.float64:
                     assert akdf[col_name].to_list() == gen_arr.to_list()
                 else:
@@ -716,7 +720,10 @@ class TestHDF5:
 
             # Test load with invalid file
             with pytest.raises(RuntimeError):
-                ak.load(path_prefix=f"{TestHDF5.hdf_test_base_tmp}/not-a-file", dataset=akdf.columns.values[0])
+                ak.load(
+                    path_prefix=f"{TestHDF5.hdf_test_base_tmp}/not-a-file",
+                    dataset=akdf.columns.values[0],
+                )
 
             # verify load_all works
             rd_data = ak.load_all(path_prefix=file_name)
@@ -825,11 +832,11 @@ class TestHDF5:
             with tempfile.TemporaryDirectory(dir=TestHDF5.hdf_test_base_tmp) as tmp_dirname:
                 file_name = f"{tmp_dirname}/test_strings_hdf"
                 strings_array.to_hdf(file_name)
-                r_strings_array = ak.read_hdf(f"{file_name}*")
+                r_strings_array = ak.read_hdf(f"{file_name}*").popitem()[1]
                 assert (strings_array == r_strings_array).all()
 
                 # Read a part of a saved Strings dataset from one hdf5 file
-                r_strings_subset = ak.read_hdf(filenames=f"{file_name}_LOCALE0000")
+                r_strings_subset = ak.read_hdf(filenames=f"{file_name}_LOCALE0000").popitem()[1]
                 assert isinstance(r_strings_subset, ak.Strings)
                 assert (strings_array[: r_strings_subset.size] == r_strings_subset).all()
 
@@ -837,14 +844,14 @@ class TestHDF5:
                 # have server calculate offsets array
                 r_strings_subset = ak.read_hdf(
                     filenames=f"{file_name}_LOCALE0000", calc_string_offsets=True
-                )
+                ).popitem()[1]
                 assert isinstance(r_strings_subset, ak.Strings)
                 assert (strings_array[: r_strings_subset.size] == r_strings_subset).all()
 
                 # test append
                 strings_array.to_hdf(file_name, dataset="strings-dupe", mode="append")
-                r_strings = ak.read_hdf(f"{file_name}*", datasets="strings_array")
-                r_strings_dupe = ak.read_hdf(f"{file_name}*", datasets="strings-dupe")
+                r_strings = ak.read_hdf(f"{file_name}*", datasets="strings_array")["strings_array"]
+                r_strings_dupe = ak.read_hdf(f"{file_name}*", datasets="strings-dupe")["strings-dupe"]
                 assert (r_strings == r_strings_dupe).all()
 
     def test_save_multi_type_dict_dataset(self):
@@ -863,7 +870,7 @@ class TestHDF5:
 
             for col_name in keys:
                 # verify load by dataset and returned mixed dict at col_name
-                loaded = ak.load(file_name, dataset=col_name)
+                loaded = ak.load(file_name, dataset=col_name)[col_name]
                 for arr in [loaded, r_mixed[col_name]]:
                     if df_dict[col_name].dtype != ak.float64:
                         assert df_dict[col_name].to_list() == arr.to_list()
@@ -887,7 +894,7 @@ class TestHDF5:
 
             for col_name in keys:
                 # verify load by dataset and returned mixed dict at col_name
-                loaded = ak.load(file_name, dataset=col_name)
+                loaded = ak.load(file_name, dataset=col_name)[col_name]
                 for arr in [loaded, r_mixed[col_name]]:
                     if df_dict[col_name].dtype != ak.float64:
                         assert df_dict[col_name].to_list() == arr.to_list()
@@ -926,7 +933,7 @@ class TestHDF5:
         for arr in [ak.array([1]), ak.array(["ab", "cd"]), ak.array(["123456789"])]:
             with tempfile.TemporaryDirectory(dir=TestHDF5.hdf_test_base_tmp) as tmp_dirname:
                 arr.to_hdf(f"{tmp_dirname}/small_numeric")
-                ret_arr = ak.read_hdf(f"{tmp_dirname}/small_numeric*")
+                ret_arr = ak.read_hdf(f"{tmp_dirname}/small_numeric*").popitem()[1]
                 assert (arr == ret_arr).all()
 
     def test_bigint(self):
@@ -943,21 +950,21 @@ class TestHDF5:
             ak.to_hdf(df_dict, file_name)
             ret_dict = ak.read_hdf(f"{tmp_dirname}/bigint_test*")
 
-            pda_loaded = ak.read_hdf(f"{tmp_dirname}/bigint_test*", datasets="pdarray")
+            pda_loaded = ak.read_hdf(f"{tmp_dirname}/bigint_test*", datasets="pdarray")["pdarray"]
             a = df_dict["pdarray"]
             for rd_a in [ret_dict["pdarray"], pda_loaded]:
                 assert isinstance(rd_a, ak.pdarray)
                 assert a.to_list() == rd_a.to_list()
                 assert a.max_bits == rd_a.max_bits
 
-            av_loaded = ak.read_hdf(f"{tmp_dirname}/bigint_test*", datasets="arrayview")
+            av_loaded = ak.read_hdf(f"{tmp_dirname}/bigint_test*", datasets="arrayview")["arrayview"]
             av = df_dict["arrayview"]
             for rd_av in [ret_dict["arrayview"], av_loaded]:
                 assert isinstance(rd_av, ak.ArrayView)
                 assert av.base.to_list() == rd_av.base.to_list()
                 assert av.base.max_bits == rd_av.base.max_bits
 
-            g_loaded = ak.read_hdf(f"{tmp_dirname}/bigint_test*", datasets="groupby")
+            g_loaded = ak.read_hdf(f"{tmp_dirname}/bigint_test*", datasets="groupby")["groupby"]
             g = df_dict["groupby"]
             for rd_g in [ret_dict["groupby"], g_loaded]:
                 assert isinstance(rd_g, ak.GroupBy)
@@ -966,7 +973,7 @@ class TestHDF5:
                 assert g.permutation.to_list() == rd_g.permutation.to_list()
                 assert g.segments.to_list() == rd_g.segments.to_list()
 
-            sa_loaded = ak.read_hdf(f"{tmp_dirname}/bigint_test*", datasets="segarray")
+            sa_loaded = ak.read_hdf(f"{tmp_dirname}/bigint_test*", datasets="segarray")["segarray"]
             sa = df_dict["segarray"]
             for rd_sa in [ret_dict["segarray"], sa_loaded]:
                 assert isinstance(rd_sa, ak.SegArray)
@@ -995,11 +1002,11 @@ class TestHDF5:
         else:  # assume arkouda root dir
             cwd += "/resources/hdf5-testing"
 
-        rd_arr = ak.read_hdf(f"{cwd}/Legacy_String.hdf5")
+        rd_arr = ak.read_hdf(f"{cwd}/Legacy_String.hdf5").popitem()[1]
         assert ["ABC", "DEF", "GHI"] == rd_arr.to_list()
 
-        v0 = ak.load(f"{cwd}/array_v0.hdf5", file_format="hdf5")
-        v1 = ak.load(f"{cwd}/array_v1.hdf5", file_format="hdf5")
+        v0 = ak.load(f"{cwd}/array_v0.hdf5", file_format="hdf5").popitem()[1]
+        v1 = ak.load(f"{cwd}/array_v1.hdf5", file_format="hdf5").popitem()[1]
         assert 50 == v0.size
         assert 50 == v1.size
 
@@ -1007,7 +1014,9 @@ class TestHDF5:
         av = ak.ArrayView(ak.arange(27), ak.array([3, 3, 3]))
         with tempfile.TemporaryDirectory(dir=TestHDF5.hdf_test_base_tmp) as tmp_dirname:
             av.to_hdf(f"{tmp_dirname}/multi_dim_test", dataset="MultiDimObj", mode="append")
-            read_av = ak.read_hdf(f"{tmp_dirname}/multi_dim_test*", datasets="MultiDimObj")
+            read_av = ak.read_hdf(f"{tmp_dirname}/multi_dim_test*", datasets="MultiDimObj")[
+                "MultiDimObj"
+            ]
             assert np.array_equal(av.to_ndarray(), read_av.to_ndarray())
 
     def test_hdf_groupby(self):
@@ -1026,7 +1035,7 @@ class TestHDF5:
         with tempfile.TemporaryDirectory(dir=TestHDF5.hdf_test_base_tmp) as tmp_dirname:
             for g in [pda_grouping, str_grouping, cat_grouping]:
                 g.to_hdf(f"{tmp_dirname}/groupby_test")
-                g_load = ak.read(f"{tmp_dirname}/groupby_test*")
+                g_load = ak.read(f"{tmp_dirname}/groupby_test*").popitem()[1]
                 assert len(g_load.keys) == len(g.keys)
                 assert g_load.permutation.to_list() == g.permutation.to_list()
                 assert g_load.segments.to_list() == g.segments.to_list()
@@ -1045,7 +1054,7 @@ class TestHDF5:
         with tempfile.TemporaryDirectory(dir=TestHDF5.hdf_test_base_tmp) as tmp_dirname:
             for c in cat, cat_from_codes:
                 c.to_hdf(f"{tmp_dirname}/categorical_test")
-                c_load = ak.read(f"{tmp_dirname}/categorical_test*")
+                c_load = ak.read(f"{tmp_dirname}/categorical_test*").popitem()[1]
 
                 assert c_load.categories.to_list() == (["a", "b", "c", "N/A"])
                 if c.segments is not None:
@@ -1082,7 +1091,7 @@ class TestHDF5:
             for size, dtype in [(15, ak.uint64), (150, ak.float64), (1000, ak.bool)]:
                 b = ak.arange(size, dtype=dtype)
                 b.update_hdf(file_name)
-                data = ak.read_hdf(f"{file_name}*")
+                data = ak.read_hdf(f"{file_name}*").popitem()[1]
                 assert data.to_list() == b.to_list()
 
     def test_hdf_overwrite_strings(self):
@@ -1205,7 +1214,7 @@ class TestHDF5:
             file_name = f"{tmp_dirname}/array_view_test"
             av.to_hdf(file_name)
             av2.update_hdf(file_name, repack=False)
-            data = ak.read_hdf(f"{file_name}*")
+            data = ak.read_hdf(f"{file_name}*").popitem()[1]
             assert av2.to_list() == data.to_list()
 
     def test_overwrite_single_dset(self):
@@ -1273,7 +1282,7 @@ class TestHDF5:
         idx = ak.Index(make_ak_arrays(size, dtype))
         with tempfile.TemporaryDirectory(dir=TestHDF5.hdf_test_base_tmp) as tmp_dirname:
             idx.to_hdf(f"{tmp_dirname}/idx_test")
-            rd_idx = ak.read_hdf(f"{tmp_dirname}/idx_test*")
+            rd_idx = ak.read_hdf(f"{tmp_dirname}/idx_test*").popitem()[1]
 
             assert isinstance(rd_idx, ak.Index)
             assert type(rd_idx.values) == type(idx.values)
@@ -1284,7 +1293,7 @@ class TestHDF5:
             idx = ak.Index(ak.Categorical(make_ak_arrays(size, dtype)))
             with tempfile.TemporaryDirectory(dir=TestHDF5.hdf_test_base_tmp) as tmp_dirname:
                 idx.to_hdf(f"{tmp_dirname}/idx_test")
-                rd_idx = ak.read_hdf(f"{tmp_dirname}/idx_test*")
+                rd_idx = ak.read_hdf(f"{tmp_dirname}/idx_test*").popitem()[1]
 
                 assert isinstance(rd_idx, ak.Index)
                 assert type(rd_idx.values) == type(idx.values)
@@ -1299,7 +1308,7 @@ class TestHDF5:
         idx = ak.Index.factory([t1, t2])
         with tempfile.TemporaryDirectory(dir=TestHDF5.hdf_test_base_tmp) as tmp_dirname:
             idx.to_hdf(f"{tmp_dirname}/idx_test")
-            rd_idx = ak.read_hdf(f"{tmp_dirname}/idx_test*")
+            rd_idx = ak.read_hdf(f"{tmp_dirname}/idx_test*").popitem()[1]
 
             assert isinstance(rd_idx, ak.MultiIndex)
             assert idx.to_list() == rd_idx.to_list()
@@ -1313,7 +1322,7 @@ class TestHDF5:
             idx = ak.Index.factory([t1, t2])
             with tempfile.TemporaryDirectory(dir=TestHDF5.hdf_test_base_tmp) as tmp_dirname:
                 idx.to_hdf(f"{tmp_dirname}/idx_test")
-                rd_idx = ak.read_hdf(f"{tmp_dirname}/idx_test*")
+                rd_idx = ak.read_hdf(f"{tmp_dirname}/idx_test*").popitem()[1]
 
                 assert isinstance(rd_idx, ak.MultiIndex)
                 assert idx.to_list() == rd_idx.to_list()
@@ -1355,17 +1364,17 @@ class TestHDF5:
 
         with tempfile.TemporaryDirectory(dir=TestHDF5.hdf_test_base_tmp) as tmp_dirname:
             ip.to_hdf(f"{tmp_dirname}/ip_test")
-            rd_ip = ak.read_hdf(f"{tmp_dirname}/ip_test*")
+            rd_ip = ak.read_hdf(f"{tmp_dirname}/ip_test*").popitem()[1]
             assert isinstance(rd_ip, ak.IPv4)
             assert ip.to_list() == rd_ip.to_list()
 
             dt.to_hdf(f"{tmp_dirname}/dt_test")
-            rd_dt = ak.read_hdf(f"{tmp_dirname}/dt_test*")
+            rd_dt = ak.read_hdf(f"{tmp_dirname}/dt_test*").popitem()[1]
             assert isinstance(rd_dt, ak.Datetime)
             assert dt.to_list() == rd_dt.to_list()
 
             td.to_hdf(f"{tmp_dirname}/td_test")
-            rd_td = ak.read_hdf(f"{tmp_dirname}/td_test*")
+            rd_td = ak.read_hdf(f"{tmp_dirname}/td_test*").popitem()[1]
             assert isinstance(rd_td, ak.Timedelta)
             assert td.to_list() == rd_td.to_list()
 
@@ -1403,7 +1412,7 @@ class TestCSV:
             assert data["ColB"].to_list() == b
             assert data["ColC"].to_list() == c
 
-            data = ak.read_csv(file_name, datasets="ColB")
+            data = ak.read_csv(file_name, datasets="ColB")["ColB"]
             assert isinstance(data, ak.Strings)
             assert data.to_list() == b
 
@@ -1438,7 +1447,7 @@ class TestCSV:
                 assert data["ColC"].to_list() == [round(float(x), 2) for x in c]
 
                 # test reading subset of columns
-                data = ak.read_csv(file_name, datasets="ColB", column_delim=delim)
+                data = ak.read_csv(file_name, datasets="ColB", column_delim=delim)["ColB"]
                 assert isinstance(data, ak.pdarray)
                 assert data.to_list() == [int(x) for x in b]
 

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -160,7 +160,6 @@ def get_null_indices(
 
     Returns
     -------
-    For a single dataset returns an Arkouda pdarray and for multiple datasets
     returns a dictionary of Arkouda pdarrays
         Dictionary of {datasetName: pdarray}
 
@@ -547,16 +546,6 @@ def _dict_recombine_segarrays_categoricals(df_dict):
 def _build_objects(
     rep_msg: Dict,
 ) -> Union[
-    Strings,
-    pdarray,
-    SegArray,
-    ArrayView,
-    Categorical,
-    DataFrame,
-    IPv4,
-    Datetime,
-    Timedelta,
-    Index,
     Mapping[
         str,
         Union[
@@ -591,18 +580,10 @@ def _build_objects(
         - If no objects were returned
     """
     items = json.loads(rep_msg["items"]) if "items" in rep_msg else []
-    # We have a couple possible return conditions
-    # 1. We have multiple items returned i.e. multi pdarrays, multi strings, multi pdarrays & strings
-    # 2. We have a single pdarray
-    # 3. We have a single strings object
-    if len(items) > 1:  # DataSets condition
-        ds_dict = _dict_recombine_segarrays_categoricals(
+    if len(items) >= 1:
+        return _dict_recombine_segarrays_categoricals(
             {item["dataset_name"]: _parse_obj(item) for item in items}
         )
-        # if dict only has 1 element when it had >1 before, the element must be a segarray
-        return next(iter(ds_dict.values())) if len(ds_dict.keys()) == 1 else ds_dict
-    elif len(items) == 1:
-        return _parse_obj(items[0])
     else:
         raise RuntimeError("No items were returned")
 
@@ -616,16 +597,6 @@ def read_hdf(
     calc_string_offsets: bool = False,
     tag_data=False,
 ) -> Union[
-    pdarray,
-    Strings,
-    SegArray,
-    ArrayView,
-    Categorical,
-    DataFrame,
-    IPv4,
-    Datetime,
-    Timedelta,
-    Index,
     Mapping[
         str,
         Union[
@@ -674,9 +645,8 @@ def read_hdf(
 
     Returns
     -------
-    For a single dataset returns an Arkouda pdarray, Arkouda Strings, Arkouda Segarrays,
-    or Arkouda ArrayViews. For multiple datasets returns a dictionary of Arkouda pdarrays,
-    Arkouda Strings, Arkouda Segarrays, or Arkouda ArrayViews.
+    Returns a dictionary of Arkouda pdarrays, Arkouda Strings, Arkouda Segarrays,
+     or Arkouda ArrayViews.
         Dictionary of {datasetName: pdarray, String, SegArray, or ArrayView}
 
     Raises
@@ -765,16 +735,6 @@ def read_parquet(
     read_nested: bool = True,
     has_non_float_nulls: bool = False,
 ) -> Union[
-    pdarray,
-    Strings,
-    SegArray,
-    ArrayView,
-    Categorical,
-    DataFrame,
-    IPv4,
-    Datetime,
-    Timedelta,
-    Index,
     Mapping[
         str,
         Union[
@@ -826,10 +786,9 @@ def read_parquet(
 
     Returns
     -------
-    For a single dataset returns an Arkouda pdarray, Arkouda Strings, or Arkouda ArrayView object
-    and for multiple datasets returns a dictionary of Arkouda pdarrays,
-    Arkouda Strings or Arkouda ArrayView.
-        Dictionary of {datasetName: pdarray or String}
+    Returns a dictionary of Arkouda pdarrays, Arkouda Strings, Arkouda Segarrays,
+     or Arkouda ArrayViews.
+        Dictionary of {datasetName: pdarray, String, SegArray, or ArrayView}
 
     Raises
     ------
@@ -916,16 +875,6 @@ def read_csv(
     column_delim: str = ",",
     allow_errors: bool = False,
 ) -> Union[
-    pdarray,
-    Strings,
-    SegArray,
-    ArrayView,
-    Categorical,
-    DataFrame,
-    IPv4,
-    Datetime,
-    Timedelta,
-    Index,
     Mapping[
         str,
         Union[
@@ -963,7 +912,9 @@ def read_csv(
 
     Returns
     --------
-    pdarray, Strings or Mapping {dset_name: obj} where obj is a pdarray or Strings.
+    Returns a dictionary of Arkouda pdarrays, Arkouda Strings, Arkouda Segarrays,
+     or Arkouda ArrayViews.
+        Dictionary of {datasetName: pdarray, String, SegArray, or ArrayView}
 
     Raises
     ------
@@ -1638,16 +1589,6 @@ def load(
     calc_string_offsets: bool = False,
     column_delim: str = ",",
 ) -> Union[
-    pdarray,
-    Strings,
-    SegArray,
-    ArrayView,
-    Categorical,
-    DataFrame,
-    IPv4,
-    Datetime,
-    Timedelta,
-    Index,
     Mapping[
         str,
         Union[
@@ -1684,8 +1625,9 @@ def load(
 
     Returns
     -------
-    Union[pdarray, Strings]
-        The pdarray or Strings that was previously saved
+    Mapping[str, Union[pdarray, Strings, SegArray, Categorical]]
+        Dictionary of {datsetName: Union[pdarray, Strings, SegArray, Categorical]}
+        with the previously saved pdarrays, Strings, SegArrays, or Categoricals
 
     Raises
     ------
@@ -1808,10 +1750,9 @@ def load_all(
     prefix, extension = os.path.splitext(path_prefix)
     firstname = f"{prefix}_LOCALE0000{extension}"
     try:
-        result = {
-            dataset: load(prefix, file_format=file_format, dataset=dataset)
-            for dataset in get_datasets(firstname, column_delim=column_delim, read_nested=read_nested)
-        }
+        result = dict()
+        for dataset in get_datasets(firstname, column_delim=column_delim, read_nested=read_nested):
+            result[dataset] = load(prefix, file_format=file_format, dataset=dataset)[dataset]
 
         result = _dict_recombine_segarrays_categoricals(result)
         # Check for Categoricals and remove if necessary
@@ -1855,16 +1796,6 @@ def read(
     read_nested: bool = True,
     has_non_float_nulls: bool = False,
 ) -> Union[
-    pdarray,
-    Strings,
-    SegArray,
-    ArrayView,
-    Categorical,
-    DataFrame,
-    IPv4,
-    Datetime,
-    Timedelta,
-    Index,
     Mapping[
         str,
         Union[
@@ -1921,9 +1852,8 @@ def read(
 
     Returns
     -------
-    For a single dataset returns an Arkouda pdarray, Arkouda Strings, Arkouda Segarrays,
-    or Arkouda ArrayViews. For multiple datasets returns a dictionary of Arkouda pdarrays,
-    Arkouda Strings, Arkouda Segarrays, or Arkouda ArrayViews.
+    Returns a dictionary of Arkouda pdarrays, Arkouda Strings, Arkouda Segarrays,
+     or Arkouda ArrayViews.
         Dictionary of {datasetName: pdarray, String, SegArray, or ArrayView}
 
     Raises

--- a/benchmarks/IO.py
+++ b/benchmarks/IO.py
@@ -93,7 +93,7 @@ def time_ak_read(N_per_locale, numfiles, trials, dtype, path, seed, parquet, com
                 readtimes = []
                 for i in range(trials):
                     start = time.time()
-                    a = ak.read_parquet(path + comp + "*")
+                    a = ak.read_parquet(path + comp + "*").popitem()[1]
                     end = time.time()
                     readtimes.append(end - start)
                 times[comp] = sum(readtimes) / trials
@@ -102,7 +102,7 @@ def time_ak_read(N_per_locale, numfiles, trials, dtype, path, seed, parquet, com
         readtimes = []
         for i in range(trials):
             start = time.time()
-            a = ak.read_hdf(path + "*")
+            a = ak.read_hdf(path + "*").popitem()[1]
             end = time.time()
             readtimes.append(end - start)
         times["HDF5"] = sum(readtimes) / trials
@@ -142,6 +142,7 @@ def check_correctness(dtype, path, seed, parquet, multifile=False):
         b.to_hdf(f"{path}{2}") if not parquet else b.to_parquet(f"{path}{2}")
 
     c = ak.read_hdf(path + "*") if not parquet else ak.read_parquet(path + "*")
+    c = c.popitem()[1]
 
     remove_files(path)
     if not multifile:

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -299,17 +299,17 @@ class IOTest(ArkoudaTest):
         )
         result_array_tens = ak.load(
             path_prefix="{}/iotest_dict_columns".format(IOTest.io_test_dir), dataset="int_tens_pdarray"
-        )
+        )["int_tens_pdarray"]
         result_array_hundreds = ak.load(
             path_prefix="{}/iotest_dict_columns".format(IOTest.io_test_dir),
             dataset="int_hundreds_pdarray",
-        )
+        )["int_hundreds_pdarray"]
         result_array_floats = ak.load(
             path_prefix="{}/iotest_dict_columns".format(IOTest.io_test_dir), dataset="float_pdarray"
-        )
+        )["float_pdarray"]
         result_array_bools = ak.load(
             path_prefix="{}/iotest_dict_columns".format(IOTest.io_test_dir), dataset="bool_pdarray"
-        )
+        )["bool_pdarray"]
 
         ratens = result_array_tens.to_ndarray()
         ratens.sort()
@@ -334,22 +334,22 @@ class IOTest(ArkoudaTest):
             path_prefix="{}/iotest_dict_columns_parquet".format(IOTest.io_test_dir),
             dataset="int_tens_pdarray",
             file_format="Parquet",
-        )
+        )["int_tens_pdarray"]
         result_array_hundreds = ak.load(
             path_prefix="{}/iotest_dict_columns_parquet".format(IOTest.io_test_dir),
             dataset="int_hundreds_pdarray",
             file_format="Parquet",
-        )
+        )["int_hundreds_pdarray"]
         result_array_floats = ak.load(
             path_prefix="{}/iotest_dict_columns_parquet".format(IOTest.io_test_dir),
             dataset="float_pdarray",
             file_format="Parquet",
-        )
+        )["float_pdarray"]
         result_array_bools = ak.load(
             path_prefix="{}/iotest_dict_columns_parquet".format(IOTest.io_test_dir),
             dataset="bool_pdarray",
             file_format="Parquet",
-        )
+        )["bool_pdarray"]
         ratens = result_array_tens.to_ndarray()
         ratens.sort()
 
@@ -368,11 +368,13 @@ class IOTest(ArkoudaTest):
             ak.load(
                 path_prefix="{}/iotest_dict_column".format(IOTest.io_test_dir),
                 dataset="int_tens_pdarray",
-            )
+            )["int_tens_pdarray"]
 
         # Test load with invalid file
         with self.assertRaises(RuntimeError):
-            ak.load(path_prefix="{}/not-a-file".format(IOTest.io_test_dir), dataset="int_tens_pdarray")
+            ak.load(path_prefix="{}/not-a-file".format(IOTest.io_test_dir), dataset="int_tens_pdarray")[
+                "int_tens_pdarray"
+            ]
 
     def testLoadAll(self):
         self._create_file(
@@ -432,7 +434,9 @@ class IOTest(ArkoudaTest):
         # Create, save, and load Strings dataset
         strings_array = ak.array(["testing string{}".format(num) for num in list(range(0, 25))])
         strings_array.to_hdf("{}/strings-test".format(IOTest.io_test_dir), dataset="strings")
-        r_strings_array = ak.load("{}/strings-test".format(IOTest.io_test_dir), dataset="strings")
+        r_strings_array = ak.load("{}/strings-test".format(IOTest.io_test_dir), dataset="strings")[
+            "strings"
+        ]
 
         strings = strings_array.to_ndarray()
         strings.sort()
@@ -441,27 +445,29 @@ class IOTest(ArkoudaTest):
         self.assertListEqual(strings.tolist(), r_strings.tolist())
 
         # Read a part of a saved Strings dataset from one hdf5 file
-        r_strings_subset = ak.read_hdf(filenames="{}/strings-test_LOCALE0000".format(IOTest.io_test_dir))
+        r_strings_subset = ak.read_hdf(
+            filenames="{}/strings-test_LOCALE0000".format(IOTest.io_test_dir)
+        ).popitem()[1]
         self.assertIsNotNone(r_strings_subset)
         self.assertTrue(isinstance(r_strings_subset[0], str))
         self.assertIsNotNone(
             ak.read_hdf(
                 filenames="{}/strings-test_LOCALE0000".format(IOTest.io_test_dir),
                 datasets="strings/values",
-            )
+            )["strings/values"]
         )
         self.assertIsNotNone(
             ak.read_hdf(
                 filenames="{}/strings-test_LOCALE0000".format(IOTest.io_test_dir),
                 datasets="strings/segments",
-            )
+            )["strings/segments"]
         )
 
         # Repeat the test using the calc_string_offsets=True option to
         # have server calculate offsets array
         r_strings_subset = ak.read_hdf(
             filenames=f"{IOTest.io_test_dir}/strings-test_LOCALE0000", calc_string_offsets=True
-        )
+        ).popitem()[1]
         self.assertIsNotNone(r_strings_subset)
         self.assertTrue(isinstance(r_strings_subset[0], str))
         self.assertIsNotNone(
@@ -469,14 +475,14 @@ class IOTest(ArkoudaTest):
                 filenames=f"{IOTest.io_test_dir}/strings-test_LOCALE0000",
                 datasets="strings/values",
                 calc_string_offsets=True,
-            )
+            )["strings/values"]
         )
         self.assertIsNotNone(
             ak.read_hdf(
                 filenames=f"{IOTest.io_test_dir}/strings-test_LOCALE0000",
                 datasets="strings/segments",
                 calc_string_offsets=True,
-            )
+            )["strings/segments"]
         )
 
     def testStringsWithoutOffsets(self):
@@ -491,7 +497,7 @@ class IOTest(ArkoudaTest):
         )
         r_strings_array = ak.load(
             "{}/strings-test".format(IOTest.io_test_dir), dataset="strings", calc_string_offsets=True
-        )
+        )["strings"]
         strings = strings_array.to_ndarray()
         strings.sort()
         r_strings = r_strings_array.to_ndarray()
@@ -510,7 +516,9 @@ class IOTest(ArkoudaTest):
 
         n_strings = strings.to_ndarray()
         n_strings.sort()
-        r_strings = ak.load("{}/strings-test".format(IOTest.io_test_dir), dataset="strings").to_ndarray()
+        r_strings = ak.load("{}/strings-test".format(IOTest.io_test_dir), dataset="strings")[
+            "strings"
+        ].to_ndarray()
         r_strings.sort()
 
         self.assertListEqual(n_strings.tolist(), r_strings.tolist())
@@ -532,17 +540,21 @@ class IOTest(ArkoudaTest):
         self.assertIsNotNone(r_mixed["m_floats"])
         self.assertIsNotNone(r_mixed["m_ints"])
 
-        r_floats = ak.sort(ak.load("{}/multi-type-test".format(IOTest.io_test_dir), dataset="m_floats"))
+        r_floats = ak.sort(
+            ak.load("{}/multi-type-test".format(IOTest.io_test_dir), dataset="m_floats")["m_floats"]
+        )
         self.assertListEqual(m_floats.to_list(), r_floats.to_list())
 
-        r_ints = ak.sort(ak.load("{}/multi-type-test".format(IOTest.io_test_dir), dataset="m_ints"))
+        r_ints = ak.sort(
+            ak.load("{}/multi-type-test".format(IOTest.io_test_dir), dataset="m_ints")["m_ints"]
+        )
         self.assertListEqual(m_ints.to_list(), r_ints.to_list())
 
         strings = strings_array.to_ndarray()
         strings.sort()
-        r_strings = ak.load(
-            "{}/multi-type-test".format(IOTest.io_test_dir), dataset="m_strings"
-        ).to_ndarray()
+        r_strings = ak.load("{}/multi-type-test".format(IOTest.io_test_dir), dataset="m_strings")[
+            "m_strings"
+        ].to_ndarray()
         r_strings.sort()
 
         self.assertListEqual(strings.tolist(), r_strings.tolist())
@@ -554,10 +566,12 @@ class IOTest(ArkoudaTest):
             "{}/append-strings-test".format(IOTest.io_test_dir), dataset="strings-dupe", mode="append"
         )
 
-        r_strings = ak.load("{}/append-strings-test".format(IOTest.io_test_dir), dataset="strings")
+        r_strings = ak.load("{}/append-strings-test".format(IOTest.io_test_dir), dataset="strings")[
+            "strings"
+        ]
         r_strings_dupe = ak.load(
             "{}/append-strings-test".format(IOTest.io_test_dir), dataset="strings-dupe"
-        )
+        )["strings-dupe"]
         self.assertListEqual(r_strings.to_list(), r_strings_dupe.to_list())
 
     def testAppendMixedStringsDataset(self):
@@ -576,10 +590,12 @@ class IOTest(ArkoudaTest):
         self.assertIsNotNone(r_mixed["m_ints"])
 
         r_floats = ak.sort(
-            ak.load("{}/append-multi-type-test".format(IOTest.io_test_dir), dataset="m_floats")
+            ak.load("{}/append-multi-type-test".format(IOTest.io_test_dir), dataset="m_floats")[
+                "m_floats"
+            ]
         )
         r_ints = ak.sort(
-            ak.load("{}/append-multi-type-test".format(IOTest.io_test_dir), dataset="m_ints")
+            ak.load("{}/append-multi-type-test".format(IOTest.io_test_dir), dataset="m_ints")["m_ints"]
         )
         self.assertListEqual(m_floats.to_list(), r_floats.to_list())
         self.assertListEqual(m_ints.to_list(), r_ints.to_list())
@@ -629,7 +645,7 @@ class IOTest(ArkoudaTest):
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
             a1.to_hdf(f"{tmp_dirname}/small_numeric", dataset="a1")
             # Now load it back in
-            a2 = ak.load(f"{tmp_dirname}/small_numeric", dataset="a1")
+            a2 = ak.load(f"{tmp_dirname}/small_numeric", dataset="a1")["a1"]
             self.assertEqual(str(a1), str(a2))
 
     # This tests small array corner cases on multi-locale environments
@@ -638,7 +654,7 @@ class IOTest(ArkoudaTest):
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
             a1.to_hdf(f"{tmp_dirname}/small_string_array", dataset="a1")
             # Now load it back in
-            a2 = ak.load(f"{tmp_dirname}/small_string_array", dataset="a1")
+            a2 = ak.load(f"{tmp_dirname}/small_string_array", dataset="a1")["a1"]
             self.assertEqual(str(a1), str(a2))
 
         # Test a single string
@@ -646,7 +662,7 @@ class IOTest(ArkoudaTest):
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
             b1.to_hdf(f"{tmp_dirname}/single_string", dataset="b1")
             # Now load it back in
-            b2 = ak.load(f"{tmp_dirname}/single_string", dataset="b1")
+            b2 = ak.load(f"{tmp_dirname}/single_string", dataset="b1")["b1"]
             self.assertEqual(str(b1), str(b2))
 
     def testUint64ToFromHDF5(self):
@@ -660,7 +676,7 @@ class IOTest(ArkoudaTest):
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
             pda1.to_hdf(f"{tmp_dirname}/small_numeric", dataset="pda1")
             # Now load it back in
-            pda2 = ak.load(f"{tmp_dirname}/small_numeric", dataset="pda1")
+            pda2 = ak.load(f"{tmp_dirname}/small_numeric", dataset="pda1")["pda1"]
             self.assertEqual(str(pda1), str(pda2))
             self.assertEqual(18446744073709551500, pda2[0])
             self.assertListEqual(pda2.to_list(), npa1.tolist())
@@ -673,7 +689,7 @@ class IOTest(ArkoudaTest):
 
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
             a.to_hdf(f"{tmp_dirname}/bigint_test", dataset="bigint_test")
-            rd_a = ak.read_hdf(f"{tmp_dirname}/bigint_test*")
+            rd_a = ak.read_hdf(f"{tmp_dirname}/bigint_test*")["bigint_test"]
             self.assertListEqual(a.to_list(), rd_a.to_list())
             self.assertEqual(a.max_bits, rd_a.max_bits)
 
@@ -686,7 +702,7 @@ class IOTest(ArkoudaTest):
 
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
             av.to_hdf(f"{tmp_dirname}/bigint_test")
-            rd_av = ak.read_hdf(f"{tmp_dirname}/bigint_test*")
+            rd_av = ak.read_hdf(f"{tmp_dirname}/bigint_test*").popitem()[1]
             self.assertIsInstance(rd_av, ak.ArrayView)
             self.assertListEqual(av.base.to_list(), rd_av.base.to_list())
             self.assertEqual(av.base.max_bits, rd_av.base.max_bits)
@@ -696,7 +712,7 @@ class IOTest(ArkoudaTest):
         g = ak.GroupBy(a)
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
             g.to_hdf(f"{tmp_dirname}/bigint_test")
-            rd_g = ak.read_hdf(f"{tmp_dirname}/bigint_test*")
+            rd_g = ak.read_hdf(f"{tmp_dirname}/bigint_test*").popitem()[1]
             self.assertIsInstance(rd_g, ak.GroupBy)
             self.assertListEqual(g.keys.to_list(), rd_g.keys.to_list())
             self.assertListEqual(g.unique_keys.to_list(), rd_g.unique_keys.to_list())
@@ -711,7 +727,7 @@ class IOTest(ArkoudaTest):
         sa = ak.SegArray(s, a)
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
             sa.to_hdf(f"{tmp_dirname}/bigint_test")
-            rd_sa = ak.read_hdf(f"{tmp_dirname}/bigint_test*")
+            rd_sa = ak.read_hdf(f"{tmp_dirname}/bigint_test*").popitem()[1]
             self.assertIsInstance(rd_sa, ak.SegArray)
             self.assertListEqual(sa.values.to_list(), rd_sa.values.to_list())
             self.assertListEqual(sa.segments.to_list(), rd_sa.segments.to_list())
@@ -751,8 +767,8 @@ class IOTest(ArkoudaTest):
             cwd += "/tests/server/resources"
 
         # Now that we've figured out our loading path, load the files and test the lengths
-        v0 = ak.load(cwd + "/array_v0.hdf5", file_format="hdf5")
-        v1 = ak.load(cwd + "/array_v1.hdf5", file_format="hdf5")
+        v0 = ak.load(cwd + "/array_v0.hdf5", file_format="hdf5").popitem()[1]
+        v1 = ak.load(cwd + "/array_v1.hdf5", file_format="hdf5").popitem()[1]
         self.assertEqual(50, v0.size)
         self.assertEqual(50, v1.size)
 
@@ -761,7 +777,9 @@ class IOTest(ArkoudaTest):
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
             arr.to_hdf(tmp_dirname + "/multi_dim_test", dataset="MultiDimObj", mode="append")
             # load data back
-            read_arr = ak.read_hdf(tmp_dirname + "/multi_dim_test*", datasets="MultiDimObj")
+            read_arr = ak.read_hdf(tmp_dirname + "/multi_dim_test*", datasets="MultiDimObj")[
+                "MultiDimObj"
+            ]
             self.assertTrue(np.array_equal(arr.to_ndarray(), read_arr.to_ndarray()))
 
     def test_legacy_read(self):
@@ -770,7 +788,7 @@ class IOTest(ArkoudaTest):
             cwd = cwd + "/../resources/hdf5-testing"
         else:  # assume arkouda root dir
             cwd += "/resources/hdf5-testing"
-        rd_arr = ak.read_hdf(f"{cwd}/Legacy_String.hdf5")
+        rd_arr = ak.read_hdf(f"{cwd}/Legacy_String.hdf5").popitem()[1]
 
         self.assertListEqual(["ABC", "DEF", "GHI"], rd_arr.to_list())
 
@@ -792,7 +810,7 @@ class IOTest(ArkoudaTest):
             self.assertListEqual(data["ColB"].to_list(), b)
             self.assertListEqual(data["ColC"].to_list(), c)
 
-            data = ak.read_csv(f"{tmp_dirname}/non_ak.csv", datasets="ColB")
+            data = ak.read_csv(f"{tmp_dirname}/non_ak.csv", datasets="ColB")["ColB"]
             self.assertIsInstance(data, ak.Strings)
             self.assertListEqual(data.to_list(), b)
 
@@ -813,7 +831,7 @@ class IOTest(ArkoudaTest):
             self.assertListEqual(data["ColC"].to_list(), [round(float(x), 2) for x in c])
 
             # test reading subset of columns
-            data = ak.read_csv(f"{tmp_dirname}/non_ak.csv", datasets="ColB")
+            data = ak.read_csv(f"{tmp_dirname}/non_ak.csv", datasets="ColB")["ColB"]
             self.assertIsInstance(data, ak.pdarray)
             self.assertListEqual(data.to_list(), [int(x) for x in b])
 
@@ -834,7 +852,9 @@ class IOTest(ArkoudaTest):
             self.assertListEqual(data["ColC"].to_list(), [round(float(x), 2) for x in c])
 
             # test reading subset of columns
-            data = ak.read_csv(f"{tmp_dirname}/non_standard_delim*", datasets="ColB", column_delim="|*|")
+            data = ak.read_csv(
+                f"{tmp_dirname}/non_standard_delim*", datasets="ColB", column_delim="|*|"
+            )["ColB"]
             self.assertIsInstance(data, ak.pdarray)
             self.assertListEqual(data.to_list(), [int(x) for x in b])
 
@@ -867,7 +887,7 @@ class IOTest(ArkoudaTest):
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
             segarr.to_hdf(f"{tmp_dirname}/segarray_int")
             # Now load it back in
-            seg2 = ak.load(f"{tmp_dirname}/segarray_int", dataset="segarray")
+            seg2 = ak.load(f"{tmp_dirname}/segarray_int", dataset="segarray")["segarray"]
             self.assertListEqual(segarr.segments.to_list(), seg2.segments.to_list())
             self.assertListEqual(segarr.values.to_list(), seg2.values.to_list())
 
@@ -879,7 +899,7 @@ class IOTest(ArkoudaTest):
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
             segarr.to_hdf(f"{tmp_dirname}/segarray_uint")
             # Now load it back in
-            seg2 = ak.load(f"{tmp_dirname}/segarray_uint", dataset="segarray")
+            seg2 = ak.load(f"{tmp_dirname}/segarray_uint", dataset="segarray")["segarray"]
             self.assertListEqual(segarr.segments.to_list(), seg2.segments.to_list())
             self.assertListEqual(segarr.values.to_list(), seg2.values.to_list())
 
@@ -891,7 +911,7 @@ class IOTest(ArkoudaTest):
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
             segarr.to_hdf(f"{tmp_dirname}/segarray_float")
             # Now load it back in
-            seg2 = ak.load(f"{tmp_dirname}/segarray_float", dataset="segarray")
+            seg2 = ak.load(f"{tmp_dirname}/segarray_float", dataset="segarray")["segarray"]
             self.assertListEqual(segarr.segments.to_list(), seg2.segments.to_list())
             self.assertListEqual(segarr.values.to_list(), seg2.values.to_list())
 
@@ -903,7 +923,7 @@ class IOTest(ArkoudaTest):
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
             segarr.to_hdf(f"{tmp_dirname}/segarray_bool")
             # Now load it back in
-            seg2 = ak.load(f"{tmp_dirname}/segarray_bool", dataset="segarray")
+            seg2 = ak.load(f"{tmp_dirname}/segarray_bool", dataset="segarray")["segarray"]
             self.assertListEqual(segarr.segments.to_list(), seg2.segments.to_list())
             self.assertListEqual(segarr.values.to_list(), seg2.values.to_list())
 
@@ -936,7 +956,7 @@ class IOTest(ArkoudaTest):
         cat_grouping = ak.GroupBy([cat, cat_from_codes])
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
             cat_grouping.to_hdf(f"{tmp_dirname}/cat_test")
-            cg_load = ak.read(f"{tmp_dirname}/cat_test*")
+            cg_load = ak.read(f"{tmp_dirname}/cat_test*").popitem()[1]
             self.assertEqual(len(cg_load.keys), len(cat_grouping.keys))
             self.assertListEqual(cg_load.permutation.to_list(), cat_grouping.permutation.to_list())
             self.assertListEqual(cg_load.segments.to_list(), cat_grouping.segments.to_list())
@@ -948,7 +968,7 @@ class IOTest(ArkoudaTest):
         str_grouping = ak.GroupBy(string)
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
             str_grouping.to_hdf(f"{tmp_dirname}/str_test")
-            str_load = ak.read(f"{tmp_dirname}/str_test*")
+            str_load = ak.read(f"{tmp_dirname}/str_test*").popitem()[1]
             self.assertEqual(len(str_load.keys), len(str_grouping.keys))
             self.assertListEqual(str_load.permutation.to_list(), str_grouping.permutation.to_list())
             self.assertListEqual(str_load.segments.to_list(), str_grouping.segments.to_list())
@@ -960,7 +980,7 @@ class IOTest(ArkoudaTest):
         g = ak.GroupBy(pda)
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
             g.to_hdf(f"{tmp_dirname}/pd_test")
-            g_load = ak.read(f"{tmp_dirname}/pd_test*")
+            g_load = ak.read(f"{tmp_dirname}/pd_test*").popitem()[1]
             self.assertEqual(len(g_load.keys), len(g.keys))
             self.assertListEqual(g_load.permutation.to_list(), g.permutation.to_list())
             self.assertListEqual(g_load.segments.to_list(), g.segments.to_list())
@@ -1011,17 +1031,17 @@ class IOTest(ArkoudaTest):
             a.to_hdf(f"{tmp_dirname}/pda_test")
             b = ak.arange(15, dtype=ak.uint64)
             b.update_hdf(f"{tmp_dirname}/pda_test")
-            data = ak.read_hdf(f"{tmp_dirname}/pda_test_*")
+            data = ak.read_hdf(f"{tmp_dirname}/pda_test_*").popitem()[1]
             self.assertListEqual(data.to_list(), b.to_list())
 
             b = ak.arange(150, dtype=ak.float64)
             b.update_hdf(f"{tmp_dirname}/pda_test")
-            data = ak.read_hdf(f"{tmp_dirname}/pda_test_*")
+            data = ak.read_hdf(f"{tmp_dirname}/pda_test_*").popitem()[1]
             self.assertListEqual(data.to_list(), b.to_list())
 
             b = ak.arange(1000, dtype=ak.bool)
             b.update_hdf(f"{tmp_dirname}/pda_test")
-            data = ak.read_hdf(f"{tmp_dirname}/pda_test_*")
+            data = ak.read_hdf(f"{tmp_dirname}/pda_test_*").popitem()[1]
             self.assertListEqual(data.to_list(), b.to_list())
 
     def test_hdf_overwrite_strings(self):
@@ -1144,7 +1164,7 @@ class IOTest(ArkoudaTest):
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
             av.to_hdf(f"{tmp_dirname}/array_view_test")
             av2.update_hdf(f"{tmp_dirname}/array_view_test", repack=False)
-            data = ak.read_hdf(f"{tmp_dirname}/array_view_test_*")
+            data = ak.read_hdf(f"{tmp_dirname}/array_view_test_*").popitem()[1]
             self.assertListEqual(av2.to_list(), data.to_list())
 
     def test_overwrite(self):
@@ -1212,7 +1232,7 @@ class IOTest(ArkoudaTest):
         x = ak.SegArray(segs, strs)
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
             x.to_hdf(f"{tmp_dirname}/test_file")
-            rd = ak.read_hdf(f"{tmp_dirname}/test_file*")
+            rd = ak.read_hdf(f"{tmp_dirname}/test_file*").popitem()[1]
             self.assertIsInstance(rd, ak.SegArray)
             self.assertListEqual(x.segments.to_list(), rd.segments.to_list())
             self.assertListEqual(x.values.to_list(), rd.values.to_list())
@@ -1315,7 +1335,7 @@ class IOTest(ArkoudaTest):
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
             df.to_hdf(f"{tmp_dirname}/seg_test")
 
-            rd_data = ak.read_hdf(f"{tmp_dirname}/seg_test*")
+            rd_data = ak.read_hdf(f"{tmp_dirname}/seg_test*").popitem()[1]
             self.assertListEqual(df["c_11"].to_list(), rd_data.to_list())
 
         df = ak.DataFrame({"c_2": ak.SegArray(ak.array([0, 9, 14]), ak.arange(-10, 10))})
@@ -1342,17 +1362,17 @@ class IOTest(ArkoudaTest):
 
         with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
             ip.to_hdf(f"{tmp_dirname}/ip_test")
-            rd_ip = ak.read_hdf(f"{tmp_dirname}/ip_test*")
+            rd_ip = ak.read_hdf(f"{tmp_dirname}/ip_test*").popitem()[1]
             self.assertIsInstance(rd_ip, ak.IPv4)
             self.assertListEqual(ip.to_list(), rd_ip.to_list())
 
             dt.to_hdf(f"{tmp_dirname}/dt_test")
-            rd_dt = ak.read_hdf(f"{tmp_dirname}/dt_test*")
+            rd_dt = ak.read_hdf(f"{tmp_dirname}/dt_test*").popitem()[1]
             self.assertIsInstance(rd_dt, ak.Datetime)
             self.assertListEqual(dt.to_list(), rd_dt.to_list())
 
             td.to_hdf(f"{tmp_dirname}/td_test")
-            rd_td = ak.read_hdf(f"{tmp_dirname}/td_test*")
+            rd_td = ak.read_hdf(f"{tmp_dirname}/td_test*").popitem()[1]
             self.assertIsInstance(rd_td, ak.Timedelta)
             self.assertListEqual(td.to_list(), rd_td.to_list())
 
@@ -1378,7 +1398,7 @@ class IOTest(ArkoudaTest):
             idx = ak.Index(t)
             with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
                 idx.to_hdf(f"{tmp_dirname}/idx_test")
-                rd_idx = ak.read_hdf(f"{tmp_dirname}/idx_test*")
+                rd_idx = ak.read_hdf(f"{tmp_dirname}/idx_test*").popitem()[1]
 
                 self.assertIsInstance(rd_idx, ak.Index)
                 self.assertEqual(type(rd_idx.values), type(idx.values))
@@ -1396,7 +1416,7 @@ class IOTest(ArkoudaTest):
                 idx = ak.Index.factory([t1, t2])
                 with tempfile.TemporaryDirectory(dir=IOTest.io_test_dir) as tmp_dirname:
                     idx.to_hdf(f"{tmp_dirname}/idx_test")
-                    rd_idx = ak.read_hdf(f"{tmp_dirname}/idx_test*")
+                    rd_idx = ak.read_hdf(f"{tmp_dirname}/idx_test*").popitem()[1]
 
                     self.assertIsInstance(rd_idx, ak.MultiIndex)
                     self.assertListEqual(idx.to_list(), rd_idx.to_list())

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -1,15 +1,16 @@
 import glob
 import os
-import pandas as pd
 import tempfile
 
 import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 from base_test import ArkoudaTest
 from context import arkouda as ak
+
 from arkouda import io_util
-import pyarrow as pa
-import pyarrow.parquet as pq
 
 TYPES = ("int64", "uint64", "bool", "float64", "str")
 COMPRESSIONS = ["snappy", "gzip", "brotli", "zstd", "lz4"]
@@ -40,13 +41,13 @@ class ParquetTest(ArkoudaTest):
 
             with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
                 ak_arr.to_parquet(f"{tmp_dirname}/pq_testcorrect", "my-dset")
-                pq_arr = ak.read_parquet(f"{tmp_dirname}/pq_testcorrect*", "my-dset")
+                pq_arr = ak.read_parquet(f"{tmp_dirname}/pq_testcorrect*", "my-dset")["my-dset"]
                 self.assertListEqual(ak_arr.to_list(), pq_arr.to_list())
 
             # verify generic read
             with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
                 ak_arr.to_parquet(f"{tmp_dirname}/pq_testcorrect", "my-dset")
-                pq_arr = ak.read(f"{tmp_dirname}/pq_testcorrect*", "my-dset")
+                pq_arr = ak.read(f"{tmp_dirname}/pq_testcorrect*", "my-dset")["my-dset"]
                 self.assertListEqual(ak_arr.to_list(), pq_arr.to_list())
 
     def test_multi_file(self):
@@ -70,7 +71,7 @@ class ParquetTest(ArkoudaTest):
                     test_arrs.append(elems[(i * per_arr) : (i * per_arr) + per_arr])
                     test_arrs[i].to_parquet(f"{tmp_dirname}/pq_test{i:04d}", "test-dset")
 
-                pq_arr = ak.read_parquet(f"{tmp_dirname}/pq_test*", "test-dset")
+                pq_arr = ak.read_parquet(f"{tmp_dirname}/pq_test*", "test-dset")["test-dset"]
                 self.assertListEqual(elems.to_list(), pq_arr.to_list())
 
     def test_wrong_dset_name(self):
@@ -99,7 +100,7 @@ class ParquetTest(ArkoudaTest):
             a = ak.array([val])
             with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
                 a.to_parquet(f"{tmp_dirname}/pq_test", "test-dset")
-                ak_res = ak.read_parquet(f"{tmp_dirname}/pq_test*", "test-dset")
+                ak_res = ak.read_parquet(f"{tmp_dirname}/pq_test*", "test-dset")["test-dset"]
                 self.assertEqual(ak_res[0], val)
 
     def test_get_datasets(self):
@@ -149,7 +150,7 @@ class ParquetTest(ArkoudaTest):
         expected = ["first-string", "", "string2", "", "third", "", ""]
 
         filename = os.path.join(datadir, basename)
-        res = ak.read_parquet(filename)
+        res = ak.read_parquet(filename).popitem()[1]
 
         self.assertListEqual(expected, res.to_list())
 
@@ -158,7 +159,7 @@ class ParquetTest(ArkoudaTest):
         basename = "null-strings.parquet"
 
         filename = os.path.join(datadir, basename)
-        res = ak.get_null_indices(filename, datasets="col1")
+        res = ak.get_null_indices(filename, datasets="col1")["col1"]
 
         self.assertListEqual([0, 1, 0, 1, 0, 1, 1], res.to_list())
 
@@ -176,7 +177,7 @@ class ParquetTest(ArkoudaTest):
                 ak_arr = ak.random_strings_uniform(1, 10, SIZE)
             with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
                 ak_arr.to_parquet(f"{tmp_dirname}/pq_testcorrect", "my-dset", mode="append")
-                pq_arr = ak.read_parquet(f"{tmp_dirname}/pq_testcorrect*", "my-dset")
+                pq_arr = ak.read_parquet(f"{tmp_dirname}/pq_testcorrect*", "my-dset")["my-dset"]
 
                 self.assertListEqual(ak_arr.to_list(), pq_arr.to_list())
 
@@ -189,7 +190,7 @@ class ParquetTest(ArkoudaTest):
                 a.to_parquet(f"{tmp_dirname}/compress_test", compression=comp)
 
                 # ensure read functions
-                rd_arr = ak.read_parquet(f"{tmp_dirname}/compress_test*", "array")
+                rd_arr = ak.read_parquet(f"{tmp_dirname}/compress_test*", "array")["array"]
 
                 # validate the list read out matches the array used to write
                 self.assertListEqual(rd_arr.to_list(), a.to_list())
@@ -201,7 +202,7 @@ class ParquetTest(ArkoudaTest):
                 b.to_parquet(f"{tmp_dirname}/compress_test", compression=comp)
 
                 # ensure read functions
-                rd_arr = ak.read_parquet(f"{tmp_dirname}/compress_test*", "array")
+                rd_arr = ak.read_parquet(f"{tmp_dirname}/compress_test*", "array")["array"]
 
                 # validate the list read out matches the array used to write
                 self.assertListEqual(rd_arr.to_list(), b.to_list())
@@ -250,7 +251,9 @@ class ParquetTest(ArkoudaTest):
                     self.assertListEqual(x, y)
 
             # verify individual column selection
-            ak_data = ak.read_parquet(f"{tmp_dirname}/segarray_parquet*", datasets="FloatList")
+            ak_data = ak.read_parquet(f"{tmp_dirname}/segarray_parquet*", datasets="FloatList")[
+                "FloatList"
+            ]
             self.assertIsInstance(ak_data, ak.SegArray)
             for x, y in zip(df["FloatList"].tolist(), ak_data.to_list()):
                 self.assertListEqual(x, y)
@@ -268,10 +271,14 @@ class ParquetTest(ArkoudaTest):
                 self.assertListEqual(df[k].tolist(), v.to_list())
 
             # read individual datasets
-            ak_data = ak.read_parquet(f"{tmp_dirname}/segarray_varied_parquet*", datasets="IntCol")
+            ak_data = ak.read_parquet(f"{tmp_dirname}/segarray_varied_parquet*", datasets="IntCol")[
+                "IntCol"
+            ]
             self.assertIsInstance(ak_data, ak.pdarray)
             self.assertListEqual(df["IntCol"].to_list(), ak_data.to_list())
-            ak_data = ak.read_parquet(f"{tmp_dirname}/segarray_varied_parquet*", datasets="ListCol")
+            ak_data = ak.read_parquet(f"{tmp_dirname}/segarray_varied_parquet*", datasets="ListCol")[
+                "ListCol"
+            ]
             self.assertIsInstance(ak_data, ak.SegArray)
             self.assertListEqual(df["ListCol"].to_list(), ak_data.to_list())
 
@@ -284,7 +291,7 @@ class ParquetTest(ArkoudaTest):
         with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
             pq.write_table(table, f"{tmp_dirname}/segarray_varied_parquet_LOCALE0000")
             pq.write_table(table2, f"{tmp_dirname}/segarray_varied_parquet_LOCALE0001")
-            ak_data = ak.read_parquet(f"{tmp_dirname}/segarray_varied_parquet*")
+            ak_data = ak.read_parquet(f"{tmp_dirname}/segarray_varied_parquet*")["ListCol"]
             self.assertIsInstance(ak_data, ak.SegArray)
             self.assertEqual(ak_data.size, 8)
             for i in range(8):
@@ -296,7 +303,7 @@ class ParquetTest(ArkoudaTest):
         with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
             pq.write_table(table, f"{tmp_dirname}/empty_segments")
 
-            ak_data = ak.read_parquet(f"{tmp_dirname}/empty_segments*")
+            ak_data = ak.read_parquet(f"{tmp_dirname}/empty_segments*")["ListCol"]
             self.assertIsInstance(ak_data, ak.SegArray)
             self.assertEqual(ak_data.size, 5)
             for i in range(5):
@@ -308,7 +315,7 @@ class ParquetTest(ArkoudaTest):
         with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
             pq.write_table(table, f"{tmp_dirname}/empty_segments")
 
-            ak_data = ak.read_parquet(f"{tmp_dirname}/empty_segments*")
+            ak_data = ak.read_parquet(f"{tmp_dirname}/empty_segments*")["ListCol"]
             self.assertIsInstance(ak_data, ak.SegArray)
             self.assertEqual(ak_data.size, 5)
             for i in range(5):
@@ -324,7 +331,7 @@ class ParquetTest(ArkoudaTest):
             pq.write_table(table, f"{tmp_dirname}/empty_segments_LOCALE0000")
             pq.write_table(table2, f"{tmp_dirname}/empty_segments_LOCALE0001")
 
-            ak_data = ak.read_parquet(f"{tmp_dirname}/empty_segments*")
+            ak_data = ak.read_parquet(f"{tmp_dirname}/empty_segments*")["ListCol"]
             self.assertIsInstance(ak_data, ak.SegArray)
             self.assertEqual(ak_data.size, 9)
             for i in range(9):
@@ -340,7 +347,7 @@ class ParquetTest(ArkoudaTest):
             pq.write_table(table, f"{tmp_dirname}/empty_segments_LOCALE0000")
             pq.write_table(table2, f"{tmp_dirname}/empty_segments_LOCALE0001")
 
-            ak_data = ak.read_parquet(f"{tmp_dirname}/empty_segments*")
+            ak_data = ak.read_parquet(f"{tmp_dirname}/empty_segments*")["ListCol"]
             self.assertIsInstance(ak_data, ak.SegArray)
             self.assertEqual(ak_data.size, 9)
             for i in range(9):
@@ -355,7 +362,7 @@ class ParquetTest(ArkoudaTest):
         with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
             s.to_parquet(f"{tmp_dirname}/int_test")
 
-            rd_data = ak.read_parquet(f"{tmp_dirname}/int_test*")
+            rd_data = ak.read_parquet(f"{tmp_dirname}/int_test*").popitem()[1]
             for i in range(3):
                 self.assertListEqual(s[i].to_list(), rd_data[i].to_list())
 
@@ -366,7 +373,7 @@ class ParquetTest(ArkoudaTest):
         with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
             s.to_parquet(f"{tmp_dirname}/int_test_empty")
 
-            rd_data = ak.read_parquet(f"{tmp_dirname}/int_test_empty*")
+            rd_data = ak.read_parquet(f"{tmp_dirname}/int_test_empty*").popitem()[1]
             for i in range(6):
                 self.assertListEqual(s[i].to_list(), rd_data[i].to_list())
 
@@ -378,7 +385,7 @@ class ParquetTest(ArkoudaTest):
         with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
             s.to_parquet(f"{tmp_dirname}/uint_test")
 
-            rd_data = ak.read_parquet(f"{tmp_dirname}/uint_test*")
+            rd_data = ak.read_parquet(f"{tmp_dirname}/uint_test*").popitem()[1]
             for i in range(3):
                 self.assertListEqual(s[i].to_list(), rd_data[i].to_list())
 
@@ -391,7 +398,7 @@ class ParquetTest(ArkoudaTest):
         with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
             s.to_parquet(f"{tmp_dirname}/uint_test_empty")
 
-            rd_data = ak.read_parquet(f"{tmp_dirname}/uint_test_empty*")
+            rd_data = ak.read_parquet(f"{tmp_dirname}/uint_test_empty*").popitem()[1]
             for i in range(6):
                 self.assertListEqual(s[i].to_list(), rd_data[i].to_list())
 
@@ -403,7 +410,7 @@ class ParquetTest(ArkoudaTest):
         with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
             s.to_parquet(f"{tmp_dirname}/bool_test")
 
-            rd_data = ak.read_parquet(f"{tmp_dirname}/bool_test*")
+            rd_data = ak.read_parquet(f"{tmp_dirname}/bool_test*").popitem()[1]
             for i in range(3):
                 self.assertListEqual(s[i].to_list(), rd_data[i].to_list())
 
@@ -416,7 +423,7 @@ class ParquetTest(ArkoudaTest):
         with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
             s.to_parquet(f"{tmp_dirname}/bool_test_empty")
 
-            rd_data = ak.read_parquet(f"{tmp_dirname}/bool_test_empty*")
+            rd_data = ak.read_parquet(f"{tmp_dirname}/bool_test_empty*").popitem()[1]
             for i in range(6):
                 self.assertListEqual(s[i].to_list(), rd_data[i].to_list())
 
@@ -428,7 +435,7 @@ class ParquetTest(ArkoudaTest):
         with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
             s.to_parquet(f"{tmp_dirname}/float_test")
 
-            rd_data = ak.read_parquet(f"{tmp_dirname}/float_test*")
+            rd_data = ak.read_parquet(f"{tmp_dirname}/float_test*").popitem()[1]
             for i in range(3):
                 self.assertListEqual(s[i].to_list(), rd_data[i].to_list())
 
@@ -439,7 +446,7 @@ class ParquetTest(ArkoudaTest):
         with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
             s.to_parquet(f"{tmp_dirname}/float_test_empty")
 
-            rd_data = ak.read_parquet(f"{tmp_dirname}/float_test_empty*")
+            rd_data = ak.read_parquet(f"{tmp_dirname}/float_test_empty*").popitem()[1]
             for i in range(6):
                 self.assertListEqual(s[i].to_list(), rd_data[i].to_list())
 
@@ -513,7 +520,7 @@ class ParquetTest(ArkoudaTest):
             self.assertListEqual(df["seg"].to_list(), data["seg"].to_list())
 
             # test read with read_nested=false and no supplied datasets
-            data = ak.read_parquet(fname + "_*", read_nested=False)
+            data = ak.read_parquet(fname + "_*", read_nested=False).popitem()[1]
             self.assertIsInstance(data, ak.pdarray)
             self.assertListEqual(df["idx"].to_list(), data.to_list())
 
@@ -532,7 +539,7 @@ class ParquetTest(ArkoudaTest):
         with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
             x.to_parquet(f"{tmp_dirname}/segarr_str")
 
-            rd = ak.read_parquet(f"{tmp_dirname}/segarr_str_*")
+            rd = ak.read_parquet(f"{tmp_dirname}/segarr_str_*").popitem()[1]
             self.assertIsInstance(rd, ak.SegArray)
             self.assertListEqual(x.segments.to_list(), rd.segments.to_list())
             self.assertListEqual(x.values.to_list(), rd.values.to_list())
@@ -543,36 +550,38 @@ class ParquetTest(ArkoudaTest):
         s = ak.SegArray(ak.array([0, 0, len(a), len(a), len(a), len(a) + len(c)]), ak.array(a + c))
         with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
             s.to_parquet(f"{tmp_dirname}/segarray_test_empty")
-            rd_data = ak.read_parquet(f"{tmp_dirname}/segarray_test_empty_*")
+            rd_data = ak.read_parquet(f"{tmp_dirname}/segarray_test_empty_*").popitem()[1]
             self.assertListEqual(s.to_list(), rd_data.to_list())
 
     def test_float_edge(self):
-        df = pd.DataFrame({"FloatList": [[3.14, np.nan, 2.23], [], [3.08], [np.inf, 6.8], [-0.0, np.nan, np.nan]]})
+        df = pd.DataFrame(
+            {"FloatList": [[3.14, np.nan, 2.23], [], [3.08], [np.inf, 6.8], [-0.0, np.nan, np.nan]]}
+        )
 
         with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
             table = pa.Table.from_pandas(df)
             pq.write_table(table, f"{tmp_dirname}/segarray_float_edge")
             ak_data = ak.read_parquet(f"{tmp_dirname}/segarray_float_edge")
             pd_l = df["FloatList"].tolist()
-            ak_l = ak_data.to_list()
+            ak_l = ak_data["FloatList"].to_list()
             for i in range(len(pd_l)):
                 self.assertTrue(np.allclose(pd_l[i], ak_l[i], equal_nan=True))
 
     def test_decimal_reads(self):
         cols = []
         data = []
-        for i in range(1,39):
+        for i in range(1, 39):
             cols.append(("decCol" + str(i), pa.decimal128(i, 0)))
             data.append([i])
-            
+
         schema = pa.schema(cols)
 
         table = pa.Table.from_arrays(data, schema=schema)
         with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
             pq.write_table(table, f"{tmp_dirname}/decimal")
             ak_data = ak.read(f"{tmp_dirname}/decimal")
-            for i in range(1,39):
-                self.assertTrue(np.allclose(ak_data['decCol'+str(i)].to_ndarray(), data[i-1]))
+            for i in range(1, 39):
+                self.assertTrue(np.allclose(ak_data["decCol" + str(i)].to_ndarray(), data[i - 1]))
 
     @pytest.mark.optional_parquet
     def test_against_standard_files(self):

--- a/tests/segarray_test.py
+++ b/tests/segarray_test.py
@@ -670,7 +670,7 @@ class SegArrayTest(ArkoudaTest):
         with tempfile.TemporaryDirectory(dir=SegArrayTest.seg_test_base_tmp) as tmp_dirname:
             segarr.to_hdf(f"{tmp_dirname}/seg_test.h5")
 
-            seg_load = ak.SegArray.read_hdf(f"{tmp_dirname}/seg_test*")
+            seg_load = ak.SegArray.read_hdf(f"{tmp_dirname}/seg_test*").popitem()[1]
             self.assertTrue(ak.all(segarr == seg_load))
 
     def test_bigint(self):


### PR DESCRIPTION
Our IO functions used to return a dictionary if multiple columns or datasets were provided and if only was provided to just return the object. It has been requested by users that our IO functions always return a dictionary for consistency sake. This PR (closes #3148) makes the changes necessary for this and also updates all tests that relied on the old functionality

The majority of the changes are updating the tests. We index using the dataset name where explicit. Otherwise we use `.popitem()` which returns the `(key,item)` tuple (since there is only one). We can then index at `[1]` to get the object that would've been returned previously