### PR TITLE
Fixes #3001: nan broadcast bug

### DIFF
--- a/PROTO_tests/tests/groupby_test.py
+++ b/PROTO_tests/tests/groupby_test.py
@@ -242,6 +242,14 @@ class TestGroupBy:
                 == ak.broadcast(compressed_segs, compressed_vals, size, perm).to_list()
             )
 
+    def test_nan_broadcast(self):
+        # verify the reproducer from issue #3001 gives correct answer
+        # test with int and bool vals
+        res = ak.broadcast(
+            ak.array([0, 2, 4]), ak.array([np.nan, 5.0, 25.0]), permutation=ak.array([0, 1, 2, 3, 4])
+        )
+        assert np.allclose(res.to_ndarray(), np.array([np.nan, np.nan, 5.0, 5.0, 25.0]), equal_nan=True)
+
     def test_count(self):
         keys, counts = self.igb.size()
 

--- a/src/BroadcastMsg.chpl
+++ b/src/BroadcastMsg.chpl
@@ -75,8 +75,9 @@ module BroadcastMsg {
         }
         when DType.Float64 {
           const vals = toSymEntry(gv, real);
+          const transmuted = [ei in vals.a] ei.transmute(uint(64));
           var res = st.addEntry(rname, size, real);
-          res.a = broadcast(perm.a, segs.a, vals.a);
+          res.a = [bi in broadcast(perm.a, segs.a, transmuted)] bi.transmute(real(64));
         }
         when DType.BigInt {
           const vals = toSymEntry(gv, bigint);

--- a/tests/groupby_test.py
+++ b/tests/groupby_test.py
@@ -251,6 +251,16 @@ class GroupByTest(ArkoudaTest):
                 ak.broadcast(compressed_segs, compressed_vals, size, perm).to_list(),
             )
 
+    def test_nan_broadcast(self):
+        # verify the reproducer from issue #3001 gives correct answer
+        # test with int and bool vals
+        res = ak.broadcast(
+            ak.array([0, 2, 4]), ak.array([np.nan, 5.0, 25.0]), permutation=ak.array([0, 1, 2, 3, 4])
+        )
+        self.assertTrue(
+            np.allclose(res.to_ndarray(), np.array([np.nan, np.nan, 5.0, 5.0, 25.0]), equal_nan=True)
+        )
+
     def test_broadcast_ints(self):
         keys, counts = self.igb.size()
 


### PR DESCRIPTION
This PR fixes #3001 by using transmute to interpret the floats as `uint64`s before broadcasting and transmuting back afterwards