### PR TITLE
Closes #3174: loosens type return restrictions of sum

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -2472,7 +2472,7 @@ def is_sorted(pda: pdarray) -> np.bool_:
 
 
 @typechecked
-def sum(pda: pdarray) -> np.float64:
+def sum(pda: pdarray) -> numeric_and_bool_scalars:
     """
     Return the sum of all elements in the array.
 


### PR DESCRIPTION
This PR (closes #3174) loosens the type return restriction of sum to include all numeric and bool scalars in an attempt to prevent typeguard from throwing unnecessary type errors