### PR TITLE
Closes #3167: Add `normal` to random number generators

### DIFF
--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -29,6 +29,8 @@ dependencies:
   - Sphinx>=5.1.1
   - sphinx-argparse
   - sphinx-autoapi
+  - sphinx-design
+  - sphinx-autodoc-typehints
   - typed-ast
   - flake8
   - mypy>=0.931,<0.990
@@ -36,11 +38,13 @@ dependencies:
   - isort
   - pytest-json-report
   - pytest-benchmark
-  
+  - mathjax
+
   - pip:
     # Developer dependencies
     - typeguard==2.10.0
     - furo # sphinx theme
     - myst-parser
     - linkify-it-py
-  
+    - sphinx-autopackagesummary
+

--- a/arkouda/random/_generator.py
+++ b/arkouda/random/_generator.py
@@ -210,8 +210,8 @@ class Generator:
         return create_pdarray(rep_msg)
 
     def normal(self, loc=0.0, scale=1.0, size=None):
-        """
-        Draw samples from a normal distribution
+        r"""
+        Draw samples from a normal (Gaussian) distribution
 
         Parameters
         ----------
@@ -223,6 +223,16 @@ class Generator:
 
         size: numeric_scalars, optional
             Output shape. Default is None, in which case a single value is returned.
+
+        Notes
+        -----
+        The probability density for the Gaussian distribution is:
+
+        .. math::
+           p(x) = \frac{1}{\sqrt{2\pi \sigma^2}} e^{-\frac{(x-\mu)^2}{2\sigma^2}}
+
+        where :math:`\mu` is the mean and :math:`\sigma` the standard deviation.
+        The square of the standard deviation, :math:`\sigma^2`, is called the variance.
 
         Returns
         -------
@@ -300,7 +310,7 @@ class Generator:
         return create_pdarray(rep_msg)
 
     def standard_normal(self, size=None):
-        """
+        r"""
         Draw samples from a standard Normal distribution (mean=0, stdev=1).
 
         Parameters
@@ -315,10 +325,14 @@ class Generator:
 
         Notes
         -----
-        For random samples from :math:`N(\\mu, \\sigma^2)`, use:
+        For random samples from :math:`N(\mu, \sigma^2)`, either call `normal` or do:
 
-        ``(sigma * standard_normal(size)) + mu``
+        .. math::
+            (\sigma \cdot \texttt{standard_normal}(size)) + \mu
 
+        See Also
+        --------
+        normal
 
         Examples
         --------

--- a/arkouda/random/_generator.py
+++ b/arkouda/random/_generator.py
@@ -209,6 +209,45 @@ class Generator:
         self._state += size
         return create_pdarray(rep_msg)
 
+    def normal(self, loc=0.0, scale=1.0, size=None):
+        """
+        Draw samples from a normal distribution
+
+        Parameters
+        ----------
+        loc: float or pdarray of floats, optional
+            Mean of the distribution. Default of 0.
+
+        scale: float or pdarray of floats, optional
+            Standard deviation of the distribution. Must be non-negative. Default of 1.
+
+        size: numeric_scalars, optional
+            Output shape. Default is None, in which case a single value is returned.
+
+        Returns
+        -------
+        pdarray
+            Pdarray of floats (unless size=None, in which case a single float is returned).
+
+        See Also
+        --------
+        standard_normal
+        uniform
+
+        Examples
+        --------
+        >>> ak.random.default_rng(17).normal(3, 2.5, 10)
+        array([2.3673425816523577 4.0532529435624589 2.0598322696795694])
+        """
+        if size is None:
+            # delegate to numpy when return size is 1
+            return self._np_generator.standard_normal(loc, scale)
+
+        if (scale < 0).any() if isinstance(scale, pdarray) else scale < 0:
+            raise TypeError("scale must be non-negative.")
+
+        return loc + scale * self.standard_normal(size=size)
+
     def random(self, size=None):
         """
         Return random floats in the half-open interval [0.0, 1.0).
@@ -289,12 +328,20 @@ class Generator:
         >>> rng.standard_normal(3)
         array([0.8797352989638163, -0.7085325853376141, 0.021728052940979934])  # random
         """
-        from arkouda.random._legacy import standard_normal
-
         if size is None:
             # delegate to numpy when return size is 1
             return self._np_generator.standard_normal()
-        return standard_normal(size=size, seed=self._seed)
+        rep_msg = generic_msg(
+            cmd="standardNormalGenerator",
+            args={
+                "name": self._name_dict[akfloat64],
+                "size": size,
+                "state": self._state,
+            },
+        )
+        # since we generate 2*size uniform samples for box-muller transform
+        self._state += (size * 2)
+        return create_pdarray(rep_msg)
 
     def shuffle(self, x):
         """

--- a/pydoc/usage/random.rst
+++ b/pydoc/usage/random.rst
@@ -27,7 +27,7 @@ integers
 
 normal
 ---------
-.. autofunction:: latex arkouda.random.Generator.normal
+.. autofunction:: arkouda.random.Generator.normal
 
 permutation
 ---------

--- a/pydoc/usage/random.rst
+++ b/pydoc/usage/random.rst
@@ -17,9 +17,25 @@ To create a ``Generator`` use the ``default_rng`` constructor
 Features
 ==========
 
+choice
+---------
+.. autofunction:: arkouda.random.Generator.choice
+
 integers
 ---------
 .. autofunction:: arkouda.random.Generator.integers
+
+normal
+---------
+.. autofunction:: latex arkouda.random.Generator.normal
+
+permutation
+---------
+.. autofunction:: arkouda.random.Generator.permutation
+
+shuffle
+---------
+.. autofunction:: arkouda.random.Generator.shuffle
 
 random
 ---------

--- a/src/RandArray.chpl
+++ b/src/RandArray.chpl
@@ -69,6 +69,9 @@ module RandArray {
   }
 
   proc fillNormal(ref a:[?D] real, const seedStr:string="None") throws {
+    // uses Box–Muller transform
+    // generates values drawn from the standard normal distribution using
+    // 2 uniformly distributed random numbers
     var u1 = makeDistArray(D, real);
     var u2 = makeDistArray(D, real);
     if (seedStr.toLower() == "none") {

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -1,6 +1,7 @@
 import numpy as np
 from base_test import ArkoudaTest
 from context import arkouda as ak
+from scipy import stats as sp_stats
 
 from arkouda.scipy import chisquare as akchisquare
 
@@ -211,6 +212,46 @@ class RandomTest(ArkoudaTest):
                             print(f"\nnum locales: {cfg['numLocales']}")
                             print(f"Failure with seed:\n{seed}")
                         self.assertTrue(res)
+
+    def test_normal(self):
+        rng = ak.random.default_rng(17)
+        both_scalar = rng.normal(loc=10, scale=2, size=10).to_list()
+        scale_scalar = rng.normal(loc=ak.array([0, 10, 20]), scale=1, size=3).to_list()
+        loc_scalar = rng.normal(loc=10, scale=ak.array([1, 2, 3]), size=3).to_list()
+        both_array = rng.normal(loc=ak.array([0, 10, 20]), scale=ak.array([1, 2, 3]), size=3).to_list()
+
+        # redeclare rng with same seed to test reproducibility
+        rng = ak.random.default_rng(17)
+        self.assertEqual(rng.normal(loc=10, scale=2, size=10).to_list(), both_scalar)
+        self.assertEqual(rng.normal(loc=ak.array([0, 10, 20]), scale=1, size=3).to_list(), scale_scalar)
+        self.assertEqual(rng.normal(loc=10, scale=ak.array([1, 2, 3]), size=3).to_list(), loc_scalar)
+        self.assertEqual(
+            rng.normal(loc=ak.array([0, 10, 20]), scale=ak.array([1, 2, 3]), size=3).to_list(),
+            both_array,
+        )
+
+    def test_normal_hypothesis_testing(self):
+        # I tested this many times without a set seed, but with no seed
+        # it's expected to fail one out of every ~20 runs given a pval limit of 0.05.
+        rng = ak.random.default_rng(43)
+        num_samples = 10**4
+
+        mean = rng.uniform(-10, 10)
+        deviation = rng.uniform(0, 10)
+        sample = rng.normal(loc=mean, scale=deviation, size=num_samples)
+        sample_list = sample.to_list()
+
+        # first test if samples are normal at all
+        _, pval = sp_stats.normaltest(sample_list)
+
+        # if pval <= 0.05, the difference from the expected distribution is significant
+        self.assertTrue(pval > 0.05)
+
+        # second goodness of fit test against the distribution with proper mean and std
+        good_fit_res = sp_stats.goodness_of_fit(
+            sp_stats.norm, sample_list, known_params={"loc": mean, "scale": deviation}
+        )
+        self.assertTrue(good_fit_res.pvalue > 0.05)
 
     def test_legacy_randint(self):
         testArray = ak.random.randint(0, 10, 5)


### PR DESCRIPTION
This PR (closes #3167) adds `normal` to our generators by transforming the results of standard normal. It also updates `standard_normal` to use generators to make sure we have the same multiple calls of the same function give different output as the other rand funcs. Adds goodness of fit testing against scipy to give confidence that we are actually drawing from the correct distribution

Added this to the docs with correct formatting of the math equations. I also added some deps to the conda env yaml files that were introduced in #3077. Also I changed the eol for that file in my pycharm from carriage return `\r\n` to just newline `\n`. This makes it look like every line in the yaml changed. In the `Files changed` tab you can click the setting wheel and hide whitespace to see what was actually added