### PR TITLE
Add benchmark for for CSV Read and write perf

### DIFF
--- a/benchmarks/IO.py
+++ b/benchmarks/IO.py
@@ -174,9 +174,9 @@ def check_correctness(dtype, path, seed, fileFormat, multifile=False):
         raise ValueError(f"Invalid dtype: {dtype}")
 
     file_format_actions = {
-        FileFormat.HDF5: (a.to_hdf, b.to_hdf if b else None, ak.read_hdf),
-        FileFormat.PARQUET: (a.to_parquet, b.to_parquet if b else None, ak.read_parquet),
-        FileFormat.CSV: (a.to_csv, b.to_csv if b else None, ak.read_csv)
+        FileFormat.HDF5: (a.to_hdf, b.to_hdf if b is not None else None, ak.read_hdf),
+        FileFormat.PARQUET: (a.to_parquet, b.to_parquet if b is not None else None, ak.read_parquet),
+        FileFormat.CSV: (a.to_csv, b.to_csv if b is not None else None, ak.read_csv)
     }
 
     if fileFormat in file_format_actions:

--- a/benchmarks/IO.py
+++ b/benchmarks/IO.py
@@ -98,9 +98,9 @@ def time_ak_read(N_per_locale, numfiles, trials, dtype, path, fileFormat, comps=
         comps = COMPRESSIONS
 
     file_format_actions = {
-        FileFormat.HDF5: ">>> arkouda {} HDF5 write with compression={}".format(dtype, comps),
-        FileFormat.PARQUET: ">>> arkouda {} Parquet write with compression={}".format(dtype, comps),
-        FileFormat.CSV: ">>> arkouda {} CSV write".format(dtype)
+        FileFormat.HDF5: ">>> arkouda {} HDF5 read with compression={}".format(dtype, comps),
+        FileFormat.PARQUET: ">>> arkouda {} Parquet read with compression={}".format(dtype, comps),
+        FileFormat.CSV: ">>> arkouda {} CSV read".format(dtype)
     }
     print(file_format_actions.get(fileFormat, "Invalid file format"))
 

--- a/benchmarks/IO.py
+++ b/benchmarks/IO.py
@@ -90,7 +90,7 @@ def time_ak_write(N_per_locale, numfiles, trials, dtype, path, seed, fileFormat,
     nb = a.size * a.itemsize * numfiles
     for key in times.keys():
         print("write Average time {} = {:.4f} sec".format(key, times[key]))
-        print("write Average rate {} = {:.2f} GiB/sec".format(key, nb / 2**30 / times[key]))
+        print("write Average rate {} = {:.4f} GiB/sec".format(key, nb / 2**30 / times[key]))
 
 
 def time_ak_read(N_per_locale, numfiles, trials, dtype, path, fileFormat, comps=None):
@@ -143,7 +143,7 @@ def time_ak_read(N_per_locale, numfiles, trials, dtype, path, fileFormat, comps=
     nb = a.size * a.itemsize
     for key in times.keys():
         print("read Average time {} = {:.4f} sec".format(key, times[key]))
-        print("read Average rate {} = {:.2f} GiB/sec".format(key, nb / 2**30 / times[key]))
+        print("read Average rate {} = {:.4f} GiB/sec".format(key, nb / 2**30 / times[key]))
 
 
 def remove_files(path):

--- a/benchmarks/contributing.rst
+++ b/benchmarks/contributing.rst
@@ -71,8 +71,8 @@ Running your benchmark
 ======================
 
 To ensure your benchmark is working, you can run it by running the command from your root directory:
-``./benchmarks/run_benchmarks.py myMethod.py``
-where "myMethod.py" is replaced with your filename.
+``./benchmarks/run_benchmarks.py myMethod``
+where "myMethod" is replaced with your filename.
 
 Once everything is working here, correctness testing and numpy testing should be added to your benchmark in the following manner:
 

--- a/benchmarks/csvIO.py
+++ b/benchmarks/csvIO.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
 
     if args.correctness_only:
         for dtype in TYPES:
-            check_correctness(dtype, args.path, args.seed, True)
+            check_correctness(dtype, args.path, args.seed, FileFormat.CSV)
         sys.exit(0)
 
     print("array size = {:,}".format(args.size))

--- a/benchmarks/csvIO.py
+++ b/benchmarks/csvIO.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
 
     if args.correctness_only:
         for dtype in TYPES:
-            check_correctness(dtype, args.path, args.seed, FileFormat.PARQUET)
+            check_correctness(dtype, args.path, args.seed, True)
         sys.exit(0)
 
     print("array size = {:,}".format(args.size))
@@ -103,11 +103,11 @@ if __name__ == "__main__":
             args.dtype,
             args.path,
             args.seed,
-            FileFormat.PARQUET,
+            FileFormat.CSV,
             comp_types,
         )
     elif args.only_read:
-        time_ak_read(args.size, args.files_per_loc, args.trials, args.dtype, args.path, FileFormat.PARQUET, comp_types)
+        time_ak_read(args.size, args.files_per_loc, args.trials, args.dtype, args.path, FileFormat.CSV, comp_types)
     else:
         time_ak_write(
             args.size,
@@ -116,10 +116,10 @@ if __name__ == "__main__":
             args.dtype,
             args.path,
             args.seed,
-            FileFormat.PARQUET,
+            FileFormat.CSV,
             comp_types,
         )
-        time_ak_read(args.size, args.files_per_loc, args.trials, args.dtype, args.path, FileFormat.PARQUET, comp_types)
+        time_ak_read(args.size, args.files_per_loc, args.trials, args.dtype, args.path, FileFormat.CSV, comp_types)
         remove_files(args.path)
 
     sys.exit(0)

--- a/benchmarks/graph_infra/arkouda.graph
+++ b/benchmarks/graph_infra/arkouda.graph
@@ -112,6 +112,12 @@ repeat-files: parquetMultiIO.dat
 graphtitle: Parquet 10 Files/Loc IO Performance
 ylabel: Performance (GiB/s)
 
+perfkeys: write Average rate CSV =, read Average rate CSV =
+graphkeys: Write GiB/s, Read GiB/s
+repeat-files: csvIO.dat
+graphtitle: CSV IO Performance
+ylabel: Performance (GiB/s)
+
 perfkeys: non-regex with literal substring Average rate =, regex with literal substring Average rate =, regex with pattern Average rate =
 graphkeys: non-regex with literal substring GiB/s, regex with literal substring GiB/s, regex with pattern GiB/s
 files: substring_search.dat, substring_search.dat, substring_search.dat

--- a/benchmarks/graph_infra/csvIO.perfkeys
+++ b/benchmarks/graph_infra/csvIO.perfkeys
@@ -1,0 +1,4 @@
+write Average time CSV =
+write Average rate CSV =
+read Average time CSV =
+read Average rate CSV =

--- a/benchmarks/multiIO.py
+++ b/benchmarks/multiIO.py
@@ -41,9 +41,14 @@ def create_parser():
     parser.add_argument(
         "-s", "--seed", default=None, type=int, help="Value to initialize random number generator"
     )
-    parser.add_argument(
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
         "-q", "--parquet", default=False, action="store_true", help="Perform Parquet operations"
     )
+    group.add_argument(
+        "-v", "--csv", default=False, action="store_true", help="Perform CSV operations"
+    )
+
     parser.add_argument(
         "-w",
         "--only-write",
@@ -81,9 +86,11 @@ if __name__ == "__main__":
     ak.verbose = False
     ak.connect(args.hostname, args.port)
 
+    fileFormat = FileFormat.CSV if args.csv else FileFormat.PARQUET if args.parquet else FileFormat.HDF5
+
     if args.correctness_only:
         for dtype in TYPES:
-            check_correctness(dtype, args.path, args.seed, args.parquet, multifile=True)
+            check_correctness(dtype, args.path, args.seed, fileFormat, multifile=True)
         sys.exit(0)
 
     print("array size = {:,}".format(args.size))
@@ -91,20 +98,20 @@ if __name__ == "__main__":
 
     if args.only_write:
         time_ak_write(
-            args.size, args.files_per_loc, args.trials, args.dtype, args.path, args.seed, args.parquet
+            args.size, args.files_per_loc, args.trials, args.dtype, args.path, args.seed, fileFormat
         )
     elif args.only_read:
         time_ak_read(
-            args.size, args.files_per_loc, args.trials, args.dtype, args.path, args.seed, args.parquet
+            args.size, args.files_per_loc, args.trials, args.dtype, args.path, fileFormat
         )
     elif args.only_delete:
         remove_files(args.path)
     else:
         time_ak_write(
-            args.size, args.files_per_loc, args.trials, args.dtype, args.path, args.seed, args.parquet
+            args.size, args.files_per_loc, args.trials, args.dtype, args.path, args.seed, fileFormat
         )
         time_ak_read(
-            args.size, args.files_per_loc, args.trials, args.dtype, args.path, args.seed, args.parquet
+            args.size, args.files_per_loc, args.trials, args.dtype, args.path, fileFormat
         )
         remove_files(args.path)
 

--- a/benchmarks/parquetMultiIO.py
+++ b/benchmarks/parquetMultiIO.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
 
     if args.correctness_only:
         for dtype in TYPES:
-            check_correctness(dtype, args.path, args.seed, True, multifile=True)
+            check_correctness(dtype, args.path, args.seed, FileFormat.PARQUET, multifile=True)
         sys.exit(0)
 
     print("array size = {:,}".format(args.size))
@@ -105,11 +105,11 @@ if __name__ == "__main__":
             args.dtype,
             args.path,
             args.seed,
-            True,
+            FileFormat.PARQUET,
             comp_types,
         )
     elif args.only_read:
-        time_ak_read(args.size, args.files_per_loc, args.trials, args.dtype, args.path, args.seed, True, comp_types)
+        time_ak_read(args.size, args.files_per_loc, args.trials, args.dtype, args.path, FileFormat.PARQUET, comp_types)
     elif args.only_delete:
         remove_files(args.path)
     else:
@@ -120,10 +120,10 @@ if __name__ == "__main__":
             args.dtype,
             args.path,
             args.seed,
-            True,
+            FileFormat.PARQUET,
             comp_types,
         )
-        time_ak_read(args.size, args.files_per_loc, args.trials, args.dtype, args.path, args.seed, True, comp_types)
+        time_ak_read(args.size, args.files_per_loc, args.trials, args.dtype, args.path, FileFormat.PARQUET, comp_types)
         remove_files(args.path)
 
     sys.exit(0)

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -35,6 +35,7 @@ BENCHMARKS = [
     "array_create",
     "array_transfer",
     "IO",
+    "csvIO",
     "small-str-groupby",
     "str-argsort",
     "str-coargsort",


### PR DESCRIPTION
This PR does the following:
- Updates the `time_ak_write`, `time_ak_read`, and `check_correctness` functions in IO.py to take a `fileFormat` argument instead of a the old `parquet` argument.
- `fileFormat` is an enum to distinguish between the three different filetypes, namely- hdf5, parquet, and csv.
- Add support for testing performance of csv reads and write in the above functions
- Remove the unused `seed` argument from `time_ak_read`
- Add a new benchmark `csvIO.py`. Currently CSV read performance is pretty bad and the benchmark just says 0.0 because of rounding. I have a follow up task to improve CSV read performance.
- Update `multiIO.py`, `parquetIO.py`, and `multiParquetIO.py` to work with the new changes to `IO.py` described in the first bullet
- Add graph infrastructure to plot the new benchmark
- Small change to contributing.rst (we omit the `.py`)