### PR TITLE
Closes #3192 PROTO_tests/tests/dtypes_test.py is failing

### DIFF
--- a/PROTO_tests/tests/dtypes_test.py
+++ b/PROTO_tests/tests/dtypes_test.py
@@ -27,7 +27,7 @@ class TestDTypes:
     def test_check_np_dtype(self, dtype):
         dtypes.check_np_dtype(np.dtype(dtype))
 
-    @pytest.mark.parametrize("dtype", ["np.str", ak.bigint])
+    @pytest.mark.parametrize("dtype", ["np.str"])
     def test_check_np_dtype_errors(self, dtype):
         with pytest.raises(TypeError):
             dtypes.check_np_dtype(dtype)


### PR DESCRIPTION
Closes #3192 PROTO_tests/tests/dtypes_test.py is failing

This corrects the failing unit test `test_check_np_dtype` that was expecting a `TypeError` because in the past `bigint` `dtype` was not a supported type.  However, that is no longer the case.