### PR TITLE
Closes #3196 PROTO_tests/tests/symbol_table.py failing

### DIFF
--- a/PROTO_tests/tests/symbol_table_test.py
+++ b/PROTO_tests/tests/symbol_table_test.py
@@ -612,7 +612,7 @@ class TestRegistration:
 
         # verify that components seen as registered after original unregistered
         s.unregister()
-        assert df["SegArray"].is_registered()
+        assert df["SegArray"].values.is_registered()
 
     @pytest.mark.parametrize("dtype", DTYPES)
     def test_error_handling(self, dtype):


### PR DESCRIPTION
Closes #3196 PROTO_tests/tests/symbol_table.py failing

This fixes a minor bug in `test_registered_component` that was causing the unit test to fail.