### PR TITLE
Closes #3204 is_numeric to handle Index and Series type

### DIFF
--- a/PROTO_tests/tests/util_test.py
+++ b/PROTO_tests/tests/util_test.py
@@ -25,25 +25,58 @@ class TestUtil:
         assert (merge_vals == sort_vals).all()
 
     def test_is_numeric(self):
-        a = ak.array(["a", "b"])
-        b = ak.array([1, 2])
-        c = ak.Categorical(a)
-        d = ak.array([1, np.nan])
+        strings = ak.array(["a", "b"])
+        ints = ak.array([1, 2])
+        categoricals = ak.Categorical(strings)
+        floats = ak.array([1, np.nan])
 
-        assert ~is_numeric(a)
-        assert is_numeric(b)
-        assert ~is_numeric(c)
-        assert is_numeric(d)
+        from arkouda.series import Series
+        from arkouda.index import Index
 
-        assert ~is_int(a)
-        assert is_int(b)
-        assert ~is_int(c)
-        assert ~is_int(d)
+        for item in [
+            strings,
+            Index(strings),
+            Series(strings),
+            categoricals,
+            Index(categoricals),
+            Series(categoricals),
+        ]:
+            assert ~is_numeric(item)
 
-        assert ~is_float(a)
-        assert ~is_float(b)
-        assert ~is_float(c)
-        assert is_float(d)
+        for item in [ints, Index(ints), Series(ints), floats, Index(floats), Series(floats)]:
+            assert is_numeric(item)
+
+        for item in [
+            strings,
+            Index(strings),
+            Series(strings),
+            categoricals,
+            Index(categoricals),
+            Series(categoricals),
+            floats,
+            Index(floats),
+            Series(floats),
+        ]:
+            assert ~is_int(item)
+
+        for item in [ints, Index(ints), Series(ints)]:
+            assert is_int(item)
+
+        for item in [
+            strings,
+            Index(strings),
+            Series(strings),
+            ints,
+            Index(ints),
+            Series(ints),
+            categoricals,
+            Index(categoricals),
+            Series(categoricals),
+        ]:
+            assert ~is_float(item)
+
+        for item in [floats, Index(floats), Series(floats)]:
+            assert is_float(item)
 
     def test_map(self):
         a = ak.array(["1", "1", "4", "4", "4"])

--- a/arkouda/util.py
+++ b/arkouda/util.py
@@ -28,6 +28,7 @@ from arkouda.strings import Strings
 from arkouda.timeclass import Datetime, Timedelta
 
 if TYPE_CHECKING:
+    from arkouda.index import Index
     from arkouda.series import Series
 
 
@@ -423,7 +424,9 @@ def convert_bytes(nbytes, unit="B"):
         return nbytes / gb
 
 
-def is_numeric(arry: Union[pdarray, Strings, Categorical]) -> builtins.bool:  # noqa: F821
+def is_numeric(
+    arry: Union[pdarray, Strings, Categorical, "Series", "Index"]  # noqa: F821
+) -> builtins.bool:
     """
     Check if the dtype of the given array is numeric.
 
@@ -448,13 +451,16 @@ def is_numeric(arry: Union[pdarray, Strings, Categorical]) -> builtins.bool:  # 
         False
 
     """
-    if isinstance(arry, pdarray):
+    from arkouda.index import Index
+    from arkouda.series import Series
+
+    if isinstance(arry, (pdarray, Series, Index)):
         return _is_dtype_in_union(dtype(arry.dtype), numeric_scalars)
     else:
         return False
 
 
-def is_float(arry: Union[pdarray, Strings, Categorical]):  # noqa: F821
+def is_float(arry: Union[pdarray, Strings, Categorical, "Series", "Index"]):  # noqa: F821
     """
     Check if the dtype of the given array is float.
 
@@ -479,13 +485,16 @@ def is_float(arry: Union[pdarray, Strings, Categorical]):  # noqa: F821
         False
 
     """
-    if isinstance(arry, pdarray):
+    from arkouda.index import Index
+    from arkouda.series import Series
+
+    if isinstance(arry, (pdarray, Series, Index)):
         return _is_dtype_in_union(dtype(arry.dtype), float_scalars)
     else:
         return False
 
 
-def is_int(arry: Union[pdarray, Strings, Categorical]):  # noqa: F821
+def is_int(arry: Union[pdarray, Strings, Categorical, "Series", "Index"]):  # noqa: F821
     """
     Check if the dtype of the given array is int.
 
@@ -511,7 +520,10 @@ def is_int(arry: Union[pdarray, Strings, Categorical]):  # noqa: F821
     True
 
     """
-    if isinstance(arry, pdarray):
+    from arkouda.index import Index
+    from arkouda.series import Series
+
+    if isinstance(arry, (pdarray, Series, Index)):
         return _is_dtype_in_union(dtype(arry.dtype), int_scalars)
     else:
         return False
@@ -527,7 +539,7 @@ def map(
     ----------
     values :  pdarray, Strings, or Categorical
         The values to be mapped.
-    mapping : dict or Series
+    mapping : dict or arkouda.Series
         The mapping correspondence.
 
     Returns
@@ -569,8 +581,8 @@ def map(
 
     if isinstance(mapping, dict):
         mapping = Series(
-            [array(list(mapping.keys())), array(list(mapping.values()))]  # type: ignore [assignment]
-        )
+            [array(list(mapping.keys())), array(list(mapping.values()))]
+        )  # type: ignore [assignment]
 
     if isinstance(mapping, Series):
         xtra_keys = gb_keys[in1d(gb_keys, mapping.index.values, invert=True)]

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -44,25 +44,58 @@ class UtilTest(ArkoudaTest):
             self.assertTrue(cond)
 
     def test_is_numeric(self):
-        a = ak.array(["a", "b"])
-        b = ak.array([1, 2])
-        c = ak.Categorical(a)
-        d = ak.array([1, np.nan])
+        strings = ak.array(["a", "b"])
+        ints = ak.array([1, 2])
+        categoricals = ak.Categorical(strings)
+        floats = ak.array([1, np.nan])
 
-        self.assertFalse(is_numeric(a))
-        self.assertTrue(is_numeric(b))
-        self.assertFalse(is_numeric(c))
-        self.assertTrue(is_numeric(d))
+        from arkouda.series import Series
+        from arkouda.index import Index
 
-        self.assertFalse(is_int(a))
-        self.assertTrue(is_int(b))
-        self.assertFalse(is_int(c))
-        self.assertFalse(is_int(d))
+        for item in [
+            strings,
+            Index(strings),
+            Series(strings),
+            categoricals,
+            Index(categoricals),
+            Series(categoricals),
+        ]:
+            self.assertFalse(is_numeric(item))
 
-        self.assertFalse(is_float(a))
-        self.assertFalse(is_float(b))
-        self.assertFalse(is_float(c))
-        self.assertTrue(is_float(d))
+        for item in [ints, Index(ints), Series(ints), floats, Index(floats), Series(floats)]:
+            self.assertTrue(is_numeric(item))
+
+        for item in [
+            strings,
+            Index(strings),
+            Series(strings),
+            categoricals,
+            Index(categoricals),
+            Series(categoricals),
+            floats,
+            Index(floats),
+            Series(floats),
+        ]:
+            self.assertFalse(is_int(item))
+
+        for item in [ints, Index(ints), Series(ints)]:
+            self.assertTrue(is_int(item))
+
+        for item in [
+            strings,
+            Index(strings),
+            Series(strings),
+            ints,
+            Index(ints),
+            Series(ints),
+            categoricals,
+            Index(categoricals),
+            Series(categoricals),
+        ]:
+            self.assertFalse(is_float(item))
+
+        for item in [floats, Index(floats), Series(floats)]:
+            self.assertTrue(is_float(item))
 
     def test_map(self):
         a = ak.array(["1", "1", "4", "4", "4"])


### PR DESCRIPTION
Closes #3204 is_numeric to handle Index and Series type

`is_numeric`, `is_float`, and `is_int` to handle Index and Series type.  

```python
In [5]: i = ak.Index(ak.array([1, 2, 3]))

In [6]: from arkouda.util import is_numeric

In [7]: i = ak.Index(ak.array([1, 2, 3]))

In [8]: is_numeric(i)
Out[8]: True

In [9]: s = ak.Series(ak.array(["a","b","c"]), index=ak.array([1, 2, 3]))

In [10]: is_numeric(s)
Out[10]: False

```