### PR TITLE
Closes #3208-Index.equals

### DIFF
--- a/PROTO_tests/tests/index_test.py
+++ b/PROTO_tests/tests/index_test.py
@@ -77,6 +77,52 @@ class TestIndex:
         m = ak.MultiIndex([ak.arange(size), ak.arange(size) * -1], names=["test", "test2"])
         assert m.inferred_type == "mixed"
 
+    def assert_equal(self, pda1, pda2):
+        from arkouda import sum as aksum
+
+        assert pda1.size == pda2.size
+        assert aksum(pda1 != pda2) == 0
+
+    def test_eq(self):
+        i = ak.Index([1, 2, 3])
+        i_cpy = ak.Index([1, 2, 3])
+        self.assert_equal(i == i_cpy, ak.array([True, True, True]))
+        self.assert_equal(i != i_cpy, ak.array([False, False, False]))
+        assert i.equals(i_cpy)
+
+        i2 = ak.Index([1, 2, 3], allow_list=True)
+        i2_cpy = ak.Index([1, 2, 3], allow_list=True)
+        self.assert_equal(i2 == i2_cpy, ak.array([True, True, True]))
+        self.assert_equal(i2 != i2_cpy, ak.array([False, False, False]))
+        assert i2.equals(i2_cpy)
+
+        self.assert_equal(i == i2, ak.array([True, True, True]))
+        self.assert_equal(i != i2, ak.array([False, False, False]))
+        assert i.equals(i2)
+
+        i3 = ak.Index(["a", "b", "c"], allow_list=True)
+        i3_cpy = ak.Index(["a", "b", "c"], allow_list=True)
+        self.assert_equal(i3 == i3_cpy, ak.array([True, True, True]))
+        self.assert_equal(i3 != i3_cpy, ak.array([False, False, False]))
+        assert i3.equals(i3_cpy)
+
+        i4 = ak.Index(["a", "x", "c"], allow_list=True)
+        self.assert_equal(i3 == i4, ak.array([True, False, True]))
+        self.assert_equal(i3 != i4, ak.array([False, True, False]))
+        assert not i3.equals(i4)
+
+        i5 = ak.Index(["a", "b", "c", "d"], allow_list=True)
+        with pytest.raises(ValueError):
+            i4 == i5
+
+        with pytest.raises(ValueError):
+            i4 != i5
+
+        assert not i4.equals(i5)
+
+        with pytest.raises(TypeError):
+            i.equals("string")
+
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_memory_usage(self, size):
         from arkouda.dtypes import BigInt

--- a/PROTO_tests/tests/operator_test.py
+++ b/PROTO_tests/tests/operator_test.py
@@ -239,13 +239,13 @@ class TestOperator:
         ak_x = ak.array(np_x)
         ak_y = ak.array(np_y)
         # Vector-Vector Case
-        assert (np_x+np_y).tolist() == (ak_x+ak_y).to_list()
+        assert (np_x + np_y).tolist() == (ak_x + ak_y).to_list()
         # Scalar-Vector Case
-        assert (np_x[0]+np_y).tolist() == (ak_x[0]+ak_y).to_list()
-        assert (np_x[-1]+np_y).tolist() == (ak_x[-1]+ak_y).to_list()
+        assert (np_x[0] + np_y).tolist() == (ak_x[0] + ak_y).to_list()
+        assert (np_x[-1] + np_y).tolist() == (ak_x[-1] + ak_y).to_list()
         # Vector-Scalar Case
-        assert (np_x+np_y[0]).tolist() == (ak_x+ak_y[0]).to_list()
-        assert (np_x+np_y[-1]).tolist() == (ak_x+ak_y[-1]).to_list()
+        assert (np_x + np_y[0]).tolist() == (ak_x + ak_y[0]).to_list()
+        assert (np_x + np_y[-1]).tolist() == (ak_x + ak_y[-1]).to_list()
 
     def test_bool_bool_addition_opeq(self):
         np_x = np.array([True, True, False, False])
@@ -849,3 +849,14 @@ class TestOperator:
         npf_copy %= 2.14
         akf_copy %= 2.14
         assert np.allclose(akf_copy.to_ndarray(), npf_copy, equal_nan=True)
+
+    def test_equals(self):
+        size = 10
+        a1 = ak.arange(size)
+        a1_cpy = ak.arange(size)
+        a2 = 2 * ak.arange(size)
+        a3 = ak.arange(size + 1)
+
+        assert a1.equals(a1_cpy)
+        assert not a1.equals(a2)
+        assert not a1.equals(a3)

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -395,6 +395,18 @@ class pdarray:
             generic_msg(cmd="set_max_bits", args={"array": self, "max_bits": max_bits})
             self._max_bits = max_bits
 
+    def equals(self, other) -> bool:
+        """
+        Whether pdarrays are the same size and all entries are equal.
+        """
+        if isinstance(other, pdarray):
+            if other.size != self.size:
+                return False
+            else:
+                return all(self == other)
+        else:
+            return False
+
     def format_other(self, other) -> str:
         """
         Attempt to cast scalar other to the element dtype of this pdarray,

--- a/tests/index_test.py
+++ b/tests/index_test.py
@@ -86,6 +86,43 @@ class IndexTest(ArkoudaTest):
         m = ak.MultiIndex([ak.arange(size), ak.arange(size) * -1], names=["test", "test2"])
         self.assertEqual(m.inferred_type, "mixed")
 
+    def assert_equal(self, pda1, pda2):
+        from arkouda import sum as aksum
+
+        assert pda1.size == pda2.size
+        assert aksum(pda1 != pda2) == 0
+
+    def test_eq(self):
+        i = ak.Index([1, 2, 3])
+        i_cpy = ak.Index([1, 2, 3])
+        self.assert_equal(i == i_cpy, ak.array([True, True, True]))
+        self.assert_equal(i != i_cpy, ak.array([False, False, False]))
+        assert i.equals(i_cpy)
+
+        i2 = ak.Index([1, 2, 3], allow_list=True)
+        i2_cpy = ak.Index([1, 2, 3], allow_list=True)
+        self.assert_equal(i2 == i2_cpy, ak.array([True, True, True]))
+        self.assert_equal(i2 != i2_cpy, ak.array([False, False, False]))
+        assert i2.equals(i2_cpy)
+
+        self.assert_equal(i == i2, ak.array([True, True, True]))
+        self.assert_equal(i != i2, ak.array([False, False, False]))
+        assert i.equals(i2)
+
+        i3 = ak.Index(["a", "b", "c"], allow_list=True)
+        i3_cpy = ak.Index(["a", "b", "c"], allow_list=True)
+        self.assert_equal(i3 == i3_cpy, ak.array([True, True, True]))
+        self.assert_equal(i3 != i3_cpy, ak.array([False, False, False]))
+        assert i3.equals(i3_cpy)
+
+        i4 = ak.Index(["a", "x", "c"], allow_list=True)
+        self.assert_equal(i3 == i4, ak.array([True, False, True]))
+        self.assert_equal(i3 != i4, ak.array([False, True, False]))
+        assert not i3.equals(i4)
+
+        i5 = ak.Index(["a", "b", "c", "d"], allow_list=True)
+        assert not i4.equals(i5)
+
     def test_memory_usage(self):
         from arkouda.dtypes import BigInt
         from arkouda.index import Index, MultiIndex

--- a/tests/operator_tests.py
+++ b/tests/operator_tests.py
@@ -311,13 +311,13 @@ class OperatorsTest(ArkoudaTest):
         ak_x = ak.array(np_x)
         ak_y = ak.array(np_y)
         # Vector-Vector Case
-        self.assertListEqual((np_x+np_y).tolist(), (ak_x+ak_y).to_list())
+        self.assertListEqual((np_x + np_y).tolist(), (ak_x + ak_y).to_list())
         # Scalar-Vector Case
-        self.assertListEqual((np_x[0]+np_y).tolist(), (ak_x[0]+ak_y).to_list())
-        self.assertListEqual((np_x[-1]+np_y).tolist(), (ak_x[-1]+ak_y).to_list())
+        self.assertListEqual((np_x[0] + np_y).tolist(), (ak_x[0] + ak_y).to_list())
+        self.assertListEqual((np_x[-1] + np_y).tolist(), (ak_x[-1] + ak_y).to_list())
         # Vector-Scalar Case
-        self.assertListEqual((np_x+np_y[0]).tolist(), (ak_x+ak_y[0]).to_list())
-        self.assertListEqual((np_x+np_y[-1]).tolist(), (ak_x+ak_y[-1]).to_list())
+        self.assertListEqual((np_x + np_y[0]).tolist(), (ak_x + ak_y[0]).to_list())
+        self.assertListEqual((np_x + np_y[-1]).tolist(), (ak_x + ak_y[-1]).to_list())
 
     def test_bool_bool_addition_opeq(self):
         np_x = np.array([True, True, False, False])
@@ -341,7 +341,7 @@ class OperatorsTest(ArkoudaTest):
         np_false += np_y
         ak_false += ak_y
         self.assertListEqual(np_x.tolist(), ak_x.to_list())
-        
+
     def test_uint_bool_binops(self):
         # Test fix for issue #1932
         # Adding support to binopvv to correctly handle uint and bool types
@@ -1167,6 +1167,17 @@ class OperatorsTest(ArkoudaTest):
         npf_copy %= 2.14
         akf_copy %= 2.14
         self.assertTrue(np.allclose(akf_copy.to_ndarray(), npf_copy, equal_nan=True))
+
+    def test_equals(self):
+        size = 10
+        a1 = ak.arange(size)
+        a1_cpy = ak.arange(size)
+        a2 = 2 * ak.arange(size)
+        a3 = ak.arange(size + 1)
+
+        self.assertTrue(a1.equals(a1_cpy))
+        self.assertFalse(a1.equals(a2))
+        self.assertFalse(a1.equals(a3))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #3208-Index.equals

Add `Index.equals` to match pandas:
https://pandas.pydata.org/docs/reference/api/pandas.Index.equals.html

Also adds the binops `==` and `!=` to the `Index` class.