### PR TITLE
Fixes #3185: strings broadcast bug

### DIFF
--- a/PROTO_tests/tests/string_test.py
+++ b/PROTO_tests/tests/string_test.py
@@ -853,3 +853,14 @@ class TestString:
     def test_inferred_type(self):
         a = ak.array(["a", "b", "c"])
         assert a.inferred_type == "string"
+
+    def test_string_broadcast(self):
+        keys = ak.randint(0, 10, 100, int)
+        g = ak.GroupBy(keys)
+        str_vals = ak.random_strings_uniform(0, 3, 10, characters="printable")
+        str_broadcast_ans = str_vals[keys]
+
+        gb_broadcasted = g.broadcast(str_vals)
+        manual_broadcasted = ak.broadcast(g.segments, str_vals, permutation=g.permutation)
+        assert (gb_broadcasted == str_broadcast_ans).all()
+        assert (manual_broadcasted == str_broadcast_ans).all()

--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -1792,6 +1792,10 @@ class GroupBy:
         """
         if values.size != self.segments.size:
             raise ValueError("Must have one value per segment")
+        is_str = isinstance(values, Strings)
+        if is_str:
+            str_vals = values
+            values = arange(str_vals.size)
         cmd = "broadcast"
         repMsg = cast(
             str,
@@ -1801,16 +1805,13 @@ class GroupBy:
                     "permName": self.permutation.name,
                     "segName": self.segments.name,
                     "valName": values.name,
-                    "objType": values.objType,
                     "permute": permute,
                     "size": self.length,
                 },
             ),
         )
-        if values.objType == Strings.objType:
-            return Strings.from_return_msg(repMsg)
-        else:
-            return create_pdarray(repMsg)
+        broadcasted = create_pdarray(repMsg)
+        return str_vals[broadcasted] if is_str else broadcasted
 
     @staticmethod
     def build_from_components(user_defined_name: Optional[str] = None, **kwargs) -> GroupBy:
@@ -2167,6 +2168,12 @@ def broadcast(
         size = cast(Union[int, np.int64, np.uint64], permutation.size)
     if size < 1:
         raise ValueError("result size must be greater than zero")
+
+    is_str = isinstance(values, Strings)
+    if is_str:
+        str_vals = values
+        values = arange(str_vals.size)
+
     cmd = "broadcast"
     repMsg = cast(
         str,
@@ -2176,13 +2183,10 @@ def broadcast(
                 "permName": pname,
                 "segName": segments.name,
                 "valName": values.name,
-                "objType": values.objType,
                 "permute": permute,
                 "size": size,
             },
         ),
     )
-    if values.objType == Strings.objType:
-        return Strings.from_return_msg(repMsg)
-    else:
-        return create_pdarray(repMsg)
+    broadcasted = create_pdarray(repMsg)
+    return str_vals[broadcasted] if is_str else broadcasted

--- a/src/BroadcastMsg.chpl
+++ b/src/BroadcastMsg.chpl
@@ -31,10 +31,6 @@ module BroadcastMsg {
                                        "TypeError");
     }
 
-    if msgArgs.getValueOf("objType").toUpper(): ObjType == ObjType.STRINGS {
-      return broadcastStrings(cmd, msgArgs, st);
-    }
-
     const segs = toSymEntry(gs, int);
     // Check that values exists (can be any dtype)
     const gv = getGenericTypedArrayEntry(msgArgs.getValueOf("valName"), st);
@@ -139,45 +135,6 @@ module BroadcastMsg {
     var repMsg = "created " + st.attrib(rname); 
     bmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
     return new MsgTuple(repMsg, MsgType.NORMAL);    
-  }
-
-  proc broadcastStrings(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
-    const gs = getGenericTypedArrayEntry(msgArgs.getValueOf("segName"), st);
-    const segs = toSymEntry(gs, int);
-    const sE = getSegString(msgArgs.getValueOf("valName"), st);
-    const size = msgArgs.get("size").getIntValue();
-
-    const usePerm: bool = msgArgs.get("permute").getBoolValue();
-    var repMsg = "";
-    if usePerm {
-      const gp = getGenericTypedArrayEntry(msgArgs.getValueOf("permName"), st);
-      if gp.dtype != DType.Int64 {
-        throw new owned ErrorWithContext("Permutation array must have dtype int64",
-                                         getLineNumber(),
-                                         getRoutineName(),
-                                         getModuleName(),
-                                         "TypeError");
-      }
-      if gp.size != size {
-        throw new owned ErrorWithContext("Requested result size must match permutation array size",
-                                         getLineNumber(),
-                                         getRoutineName(),
-                                         getModuleName(),
-                                         "ValueError");
-      }
-      const perm = toSymEntry(gp, int);
-      var (vals, offs) = broadcast(perm.a, segs.a, sE);
-      var res = getSegString(offs, vals, st);
-      repMsg = "created %s".doFormat(st.attrib(res.name)) + "+created bytes.size %?".doFormat(res.nBytes);
-    }
-    else {
-      var (vals, offs) = broadcast(segs.a, sE, size);
-      var res = getSegString(offs, vals, st);
-      repMsg = "created %s".doFormat(st.attrib(res.name)) + "+created bytes.size %?".doFormat(res.nBytes);
-    }
-
-    bmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-    return new MsgTuple(repMsg, MsgType.NORMAL);
   }
 
   use CommandMap;

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -921,3 +921,14 @@ class StringTest(ArkoudaTest):
     def test_inferred_type(self):
         a = ak.array(["a", "b", "c"])
         self.assertTrue(a.inferred_type, "string")
+
+    def test_string_broadcast(self):
+        keys = ak.randint(0, 10, 100, int)
+        g = ak.GroupBy(keys)
+        str_vals = ak.random_strings_uniform(0, 3, 10, characters="printable")
+        str_broadcast_ans = str_vals[keys]
+
+        gb_broadcasted = g.broadcast(str_vals)
+        manual_broadcasted = ak.broadcast(g.segments, str_vals, permutation=g.permutation)
+        self.assertTrue((gb_broadcasted == str_broadcast_ans).all())
+        self.assertTrue((manual_broadcasted == str_broadcast_ans).all())


### PR DESCRIPTION
This PR fixes #3185 by removing the custom string permutation logic in favor of broadcasting the indices and then indexing into the segstring. I realized that we overcomplicating things and that optimizing this solution would essientailly be duplicating the segstring indexing code. I don't know what lead me to take this approach in the first place, but this is much cleaner and makes use of existing well-tested and optimized functions