### PR TITLE
Closes #3213 Index properties

### DIFF
--- a/PROTO_tests/tests/index_test.py
+++ b/PROTO_tests/tests/index_test.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import pytest
+from numpy import dtype as npdtype
 
 import arkouda as ak
 from arkouda.dtypes import dtype
@@ -52,6 +53,15 @@ class TestIndex:
         with pytest.raises(ValueError):
             idx = ak.MultiIndex([ak.arange(size), ak.arange(size - 1)])
 
+    def test_name_names(self):
+        i = ak.Index([1, 2, 3], name="test")
+        assert i.name == "test"
+        assert i.names == ["test"]
+
+        size = 10
+        m = ak.MultiIndex([ak.arange(size), ak.arange(size) * -1], names=["test", "test2"])
+        assert m.names == ["test", "test2"]
+
     def test_nlevels(self):
         i = ak.Index([1, 2, 3], name="test")
         assert i.nlevels == 1
@@ -59,6 +69,22 @@ class TestIndex:
         size = 10
         m = ak.MultiIndex([ak.arange(size), ak.arange(size) * -1])
         assert m.nlevels == 2
+
+    def test_ndim(self):
+        i = ak.Index([1, 2, 3], name="test")
+        assert i.ndim == 1
+
+        size = 10
+        m = ak.MultiIndex([ak.arange(size), ak.arange(size) * -1])
+        assert m.ndim == 1
+
+    def test_dtypes(self):
+        size = 10
+        i = ak.Index(ak.arange(size, dtype="float64"))
+        assert i.dtype == dtype("float64")
+
+        m = ak.MultiIndex([ak.arange(size), ak.arange(size) * -1])
+        assert m.dtype == npdtype("O")
 
     def test_inferred_type(self):
         i = ak.Index([1, 2, 3])

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, List, Optional, Union, Tuple
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 import pandas as pd  # type: ignore
 from numpy import array as ndarray
+from numpy import dtype as npdtype
 from typeguard import typechecked
 
 from arkouda import Categorical, Strings
@@ -195,6 +196,17 @@ class Index:
         return 1
 
     @property
+    def ndim(self):
+        """
+        Number of dimensions of the underlying data, by definition 1.
+
+        See Also
+        --------
+        MultiIndex.ndim
+        """
+        return 1
+
+    @property
     def inferred_type(self) -> str:
         """
         Return a string of the type inferred from the values.
@@ -210,6 +222,13 @@ class Index:
             elif self.dtype == "<U":
                 return "string"
         return self.values.inferred_type
+
+    @property
+    def names(self):
+        """
+        Return Index or MultiIndex names.
+        """
+        return [self.name]
 
     @property
     def index(self):
@@ -986,7 +1005,7 @@ class MultiIndex(Index):
             raise TypeError("MultiIndex should be an iterable")
         self.levels = levels
         first = True
-        self.names = names
+        self._names = names
         self.name = name
         for col in self.levels:
             # col can be a python int which doesn't have a size attribute
@@ -1026,6 +1045,13 @@ class MultiIndex(Index):
         return retval
 
     @property
+    def names(self):
+        """
+        Return Index or MultiIndex names.
+        """
+        return self._names
+
+    @property
     def index(self):
         return self.levels
 
@@ -1038,6 +1064,17 @@ class MultiIndex(Index):
         Index.nlevels
         """
         return len(self.levels)
+
+    @property
+    def ndim(self):
+        """
+        Number of dimensions of the underlying data, by definition 1.
+
+        See Also
+        --------
+        Index.ndim
+        """
+        return 1
 
     @property
     def inferred_type(self) -> str:
@@ -1064,6 +1101,13 @@ class MultiIndex(Index):
                 "Cannot get level values because level must be a string in names or "
                 "an integer with absolute value less than the number of levels."
             )
+
+    @property
+    def dtype(self) -> npdtype:
+        """
+        Return the dtype object of the underlying data.
+        """
+        return npdtype("O")
 
     def memory_usage(self, unit="B"):
         """

--- a/tests/index_test.py
+++ b/tests/index_test.py
@@ -2,9 +2,11 @@ import glob
 import os
 import tempfile
 
+
 import pandas as pd
 from base_test import ArkoudaTest
 from context import arkouda as ak
+from numpy import dtype as npdtype
 
 from arkouda import io_util
 from arkouda.dtypes import dtype
@@ -61,6 +63,15 @@ class IndexTest(ArkoudaTest):
         with self.assertRaises(ValueError):
             idx = ak.MultiIndex([ak.arange(5), ak.arange(3)])
 
+    def test_name_names(self):
+        i = ak.Index([1, 2, 3], name="test")
+        self.assertEqual(i.name, "test")
+        self.assertListEqual(i.names, ["test"])
+
+        size = 10
+        m = ak.MultiIndex([ak.arange(size), ak.arange(size) * -1], names=["test", "test2"])
+        self.assertListEqual(m.names, ["test", "test2"])
+
     def test_nlevels(self):
         i = ak.Index([1, 2, 3], name="test")
         assert i.nlevels == 1
@@ -68,6 +79,22 @@ class IndexTest(ArkoudaTest):
         size = 10
         m = ak.MultiIndex([ak.arange(size), ak.arange(size) * -1])
         assert m.nlevels == 2
+
+    def test_ndim(self):
+        i = ak.Index([1, 2, 3], name="test")
+        assert i.ndim == 1
+
+        size = 10
+        m = ak.MultiIndex([ak.arange(size), ak.arange(size) * -1])
+        assert m.ndim == 1
+
+    def test_dtypes(self):
+        size = 10
+        i = ak.Index(ak.arange(size, dtype="float64"))
+        assert i.dtype == dtype("float64")
+
+        m = ak.MultiIndex([ak.arange(size), ak.arange(size) * -1])
+        assert m.dtype == npdtype("O")
 
     def test_inferred_type(self):
         i = ak.Index([1, 2, 3])


### PR DESCRIPTION
Closes #3213 Index properties

Add some missing properties to Index to match pandas:

names:
https://pandas.pydata.org/docs/reference/api/pandas.Index.names.html

dtype:
https://pandas.pydata.org/docs/reference/api/pandas.Index.dtype.html

ndim:
https://pandas.pydata.org/docs/reference/api/pandas.Index.ndim.html#pandas.Index.ndim