### PR TITLE
Closes #3215: Index.__get__item can accept a list

### DIFF
--- a/PROTO_tests/tests/index_test.py
+++ b/PROTO_tests/tests/index_test.py
@@ -4,6 +4,7 @@ import pytest
 import arkouda as ak
 from arkouda.dtypes import dtype
 from arkouda.pdarrayclass import pdarray
+from arkouda.index import Index
 
 
 class TestIndex:
@@ -77,11 +78,26 @@ class TestIndex:
         m = ak.MultiIndex([ak.arange(size), ak.arange(size) * -1], names=["test", "test2"])
         assert m.inferred_type == "mixed"
 
-    def assert_equal(self, pda1, pda2):
+    @staticmethod
+    def assert_equal(pda1, pda2):
         from arkouda import sum as aksum
 
         assert pda1.size == pda2.size
         assert aksum(pda1 != pda2) == 0
+
+    def test_get_item(self):
+        i = ak.Index([1, 2, 3])
+        assert i[2] == 3
+        assert isinstance(i[[0, 1]], Index)
+        assert i[[0, 1]].equals(Index([1, 2]))
+
+        i2 = ak.Index([1, 2, 3], allow_list=True)
+        assert i2[2] == 3
+        assert i2[[0, 1]].equals(Index([1, 2], allow_list=True))
+
+        i3 = ak.Index(["a", "b", "c"], allow_list=True)
+        assert i3[2] == "c"
+        assert i3[[0, 1]].equals(Index(["a", "b"], allow_list=True).values)
 
     def test_eq(self):
         i = ak.Index([1, 2, 3])

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -114,13 +114,26 @@ class Index:
     def __getitem__(self, key):
         from arkouda.series import Series
 
+        allow_list = False
+        if isinstance(self.values, list):
+            allow_list = True
+
         if isinstance(key, Series):
             key = key.values
 
         if isinstance(key, int):
             return self.values[key]
 
-        return Index(self.values[key])
+        if isinstance(key, list):
+            if len(key) < self.max_list_size:
+                return Index([self.values[k] for k in key], allow_list=allow_list)
+            else:
+                raise ValueError(
+                    f"Unable to get list of size greater than "
+                    f"Index.max_list_size ({self.max_list_size})."
+                )
+
+        return Index(self.values[key], allow_list=allow_list)
 
     def __repr__(self):
         # Configured to match pandas

--- a/tests/index_test.py
+++ b/tests/index_test.py
@@ -9,6 +9,7 @@ from context import arkouda as ak
 from arkouda import io_util
 from arkouda.dtypes import dtype
 from arkouda.pdarrayclass import pdarray
+from arkouda.index import Index
 
 
 class IndexTest(ArkoudaTest):
@@ -91,6 +92,19 @@ class IndexTest(ArkoudaTest):
 
         assert pda1.size == pda2.size
         assert aksum(pda1 != pda2) == 0
+
+    def test_get_item(self):
+        i = ak.Index([1, 2, 3])
+        self.assertEqual(i[2], 3)
+        self.assertTrue(i[[0, 1]].equals(Index([1, 2])))
+
+        i2 = ak.Index([1, 2, 3], allow_list=True)
+        self.assertEqual(i2[2], 3)
+        self.assertTrue(i2[[0, 1]].equals(Index([1, 2], allow_list=True)))
+
+        i3 = ak.Index(["a", "b", "c"], allow_list=True)
+        self.assertEqual(i3[2], "c")
+        self.assertTrue(i3[[0, 1]].equals(Index(["a", "b"], allow_list=True)))
 
     def test_eq(self):
         i = ak.Index([1, 2, 3])


### PR DESCRIPTION
Closes #3215: Index.__get__item can accept a list

Index.__get__item can accept a list when the length of the list is less than `Index.max_list_length`.