### PR TITLE
Closes #3188 multi index.equals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ __pycache__/
 .vscode/
 .local/
 .idea/
+.project
+.pydevproject
 doc/
 docs/
 test-bin/

--- a/PROTO_tests/tests/categorical_test.py
+++ b/PROTO_tests/tests/categorical_test.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 import arkouda as ak
+from arkouda.categorical import Categorical
 
 
 class TestCategorical:
@@ -40,6 +41,21 @@ class TestCategorical:
         prefix, size = "string", 10
         cat = self.create_basic_categorical(prefix, size)
         assert cat.inferred_type == "categorical"
+
+    def test_equals(self):
+        c = Categorical(ak.array(["a", "b", "c"]))
+        c_cpy = Categorical(ak.array(["a", "b", "c"]))
+        assert ak.sum((c == c_cpy) != ak.array([True, True, True])) == 0
+        assert ak.sum((c != c_cpy) != ak.array([False, False, False])) == 0
+        assert c.equals(c_cpy)
+
+        c2 = Categorical(ak.array(["a", "x", "c"]))
+        assert ak.sum((c == c2) != ak.array([True, False, True])) == 0
+        assert ak.sum((c != c2) != ak.array([False, True, False])) == 0
+        assert not c.equals(c2)
+
+        c3 = Categorical(ak.array(["a", "b", "c", "d"]))
+        assert not c.equals(c3)
 
     def test_from_codes(self):
         codes = ak.array([7, 5, 9, 8, 2, 1, 4, 0, 3, 6])

--- a/PROTO_tests/tests/string_test.py
+++ b/PROTO_tests/tests/string_test.py
@@ -53,6 +53,21 @@ class TestString:
     def compare_strings(s1, s2):
         return all(x == y for x, y in zip(s1, s2))
 
+    def test_equals(self):
+        s = ak.array(["a", "b", "c"])
+        s_cpy = ak.array(["a", "b", "c"])
+        assert ak.sum((s == s_cpy) != ak.array([True, True, True])) == 0
+        assert ak.sum((s != s_cpy) != ak.array([False, False, False])) == 0
+        assert s.equals(s_cpy)
+
+        s2 = ak.array(["a", "x", "c"])
+        assert ak.sum((s == s2) != ak.array([True, False, True])) == 0
+        assert ak.sum((s != s2) != ak.array([False, True, False])) == 0
+        assert not s.equals(s2)
+
+        s3 = ak.array(["a", "b", "c", "d"])
+        assert not s.equals(s3)
+
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_compare_strings(self, size):
         base_words, np_base_words = self.base_words(size)

--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -27,7 +27,9 @@ from arkouda.infoclass import information
 from arkouda.logger import getArkoudaLogger
 from arkouda.numeric import cast as akcast
 from arkouda.numeric import where
-from arkouda.pdarrayclass import RegistrationError, create_pdarray, pdarray
+from arkouda.pdarrayclass import RegistrationError
+from arkouda.pdarrayclass import all as akall
+from arkouda.pdarrayclass import create_pdarray, pdarray
 from arkouda.pdarraycreation import arange, array, ones, zeros, zeros_like
 from arkouda.pdarraysetops import concatenate, in1d
 from arkouda.sorting import argsort
@@ -271,6 +273,40 @@ class Categorical:
             # Append NA value
             new_categories = concatenate((new_categories, array([NAvalue])))
         return [arr.set_categories(new_categories, NAvalue=NAvalue) for arr in arrays]
+
+    def equals(self, other) -> bool:
+        """
+        Whether Categoricals are the same size and all entries are equal.
+
+        Parameters
+        ----------
+        other : object
+            object to compare.
+
+        Returns
+        -------
+        bool
+            True if the Categoricals are the same, o.w. False.
+
+        Examples
+        --------
+        >>> import arkouda as ak
+        >>> ak.connect()
+        >>> c = Categorical(ak.array(["a", "b", "c"]))
+        >>> c_cpy = Categorical(ak.array(["a", "b", "c"]))
+        >>> c.equals(c_cpy)
+        True
+        >>> c2 = Categorical(ak.array(["a", "x", "c"]))
+        >>> c.equals(c2)
+        False
+        """
+        if isinstance(other, Categorical):
+            if other.size != self.size:
+                return False
+            else:
+                return akall(self == other)
+        else:
+            return False
 
     def set_categories(self, new_categories, NAvalue=None):
         """

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -442,6 +442,28 @@ class pdarray:
     def equals(self, other) -> bool:
         """
         Whether pdarrays are the same size and all entries are equal.
+
+        Parameters
+        ----------
+        other : object
+            object to compare.
+
+        Returns
+        -------
+        bool
+            True if the pdarrays are the same, o.w. False.
+
+        Examples
+        --------
+        >>> import arkouda as ak
+        >>> ak.connect()
+        >>> a = ak.array([1, 2, 3])
+        >>> a_cpy = ak.array([1, 2, 3])
+        >>> a.equals(a_cpy)
+        True
+        >>> a2 = ak.array([1, 2, 5)
+        >>> a.equals(a2)
+        False
         """
         if isinstance(other, pdarray):
             if other.size != self.size:

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -21,12 +21,9 @@ from arkouda.dtypes import (
 from arkouda.infoclass import information, list_symbol_table
 from arkouda.logger import getArkoudaLogger
 from arkouda.match import Match, MatchType
-from arkouda.pdarrayclass import (
-    RegistrationError,
-    create_pdarray,
-    parse_single_value,
-    pdarray,
-)
+from arkouda.pdarrayclass import RegistrationError
+from arkouda.pdarrayclass import all as akall
+from arkouda.pdarrayclass import create_pdarray, parse_single_value, pdarray
 
 __all__ = ["Strings"]
 
@@ -347,6 +344,40 @@ class Strings:
         Return a string of the type inferred from the values.
         """
         return "string"
+
+    def equals(self, other) -> bool:
+        """
+        Whether Strings are the same size and all entries are equal.
+
+        Parameters
+        ----------
+        other : object
+            object to compare.
+
+        Returns
+        -------
+        bool
+            True if the Strings are the same, o.w. False.
+
+        Examples
+        --------
+        >>> import arkouda as ak
+        >>> ak.connect()
+        >>> s = ak.array(["a", "b", "c"])
+        >>> s_cpy = ak.array(["a", "b", "c"])
+        >>> s.equals(s_cpy)
+        True
+        >>> s2 = ak.array(["a", "x", "c"])
+        >>> s.equals(s2)
+        False
+        """
+        if isinstance(other, Strings):
+            if other.size != self.size:
+                return False
+            else:
+                return akall(self == other)
+        else:
+            return False
 
     def get_lengths(self) -> pdarray:
         """

--- a/tests/categorical_test.py
+++ b/tests/categorical_test.py
@@ -9,6 +9,7 @@ from base_test import ArkoudaTest
 from context import arkouda as ak
 
 from arkouda import Strings, io, io_util
+from arkouda.categorical import Categorical
 
 
 class CategoricalTest(ArkoudaTest):
@@ -99,6 +100,21 @@ class CategoricalTest(ArkoudaTest):
     def test_inferred_type(self):
         cat = self._getCategorical()
         self.assertEqual(cat.inferred_type, "categorical")
+
+    def test_equals(self):
+        c = Categorical(ak.array(["a", "b", "c"]))
+        c_cpy = Categorical(ak.array(["a", "b", "c"]))
+        self.assertTrue(ak.sum((c == c_cpy) != ak.array([True, True, True])) == 0)
+        self.assertTrue(ak.sum((c != c_cpy) != ak.array([False, False, False])) == 0)
+        assert c.equals(c_cpy)
+
+        c2 = Categorical(ak.array(["a", "x", "c"]))
+        self.assertTrue(ak.sum((c == c2) != ak.array([True, False, True])) == 0)
+        self.assertTrue(ak.sum((c != c2) != ak.array([False, True, False])) == 0)
+        assert not c.equals(c2)
+
+        c3 = ak.array(["a", "b", "c", "d"])
+        assert not c.equals(c3)
 
     def test_substring_search(self):
         cat = ak.Categorical(ak.array([f"{i} string {i}" for i in range(10)]))

--- a/tests/index_test.py
+++ b/tests/index_test.py
@@ -139,31 +139,99 @@ class IndexTest(ArkoudaTest):
         i_cpy = ak.Index([1, 2, 3])
         self.assert_equal(i == i_cpy, ak.array([True, True, True]))
         self.assert_equal(i != i_cpy, ak.array([False, False, False]))
-        assert i.equals(i_cpy)
+        self.assertTrue(i.equals(i_cpy))
 
         i2 = ak.Index([1, 2, 3], allow_list=True)
         i2_cpy = ak.Index([1, 2, 3], allow_list=True)
         self.assert_equal(i2 == i2_cpy, ak.array([True, True, True]))
         self.assert_equal(i2 != i2_cpy, ak.array([False, False, False]))
-        assert i2.equals(i2_cpy)
+        self.assertTrue(i2.equals(i2_cpy))
 
         self.assert_equal(i == i2, ak.array([True, True, True]))
         self.assert_equal(i != i2, ak.array([False, False, False]))
-        assert i.equals(i2)
+        self.assertTrue(i.equals(i2))
 
         i3 = ak.Index(["a", "b", "c"], allow_list=True)
         i3_cpy = ak.Index(["a", "b", "c"], allow_list=True)
         self.assert_equal(i3 == i3_cpy, ak.array([True, True, True]))
         self.assert_equal(i3 != i3_cpy, ak.array([False, False, False]))
-        assert i3.equals(i3_cpy)
+        self.assertTrue(i3.equals(i3_cpy))
 
-        i4 = ak.Index(["a", "x", "c"], allow_list=True)
-        self.assert_equal(i3 == i4, ak.array([True, False, True]))
-        self.assert_equal(i3 != i4, ak.array([False, True, False]))
-        assert not i3.equals(i4)
+        i4 = ak.Index(["a", "b", "c"], allow_list=False)
+        i4_cpy = ak.Index(["a", "b", "c"], allow_list=False)
+        self.assert_equal(i4 == i4_cpy, ak.array([True, True, True]))
+        self.assert_equal(i4 != i4_cpy, ak.array([False, False, False]))
+        self.assertTrue(i3.equals(i3_cpy))
 
-        i5 = ak.Index(["a", "b", "c", "d"], allow_list=True)
-        assert not i4.equals(i5)
+        i5 = ak.Index(["a", "x", "c"], allow_list=True)
+        self.assert_equal(i3 == i5, ak.array([True, False, True]))
+        self.assert_equal(i3 != i5, ak.array([False, True, False]))
+        self.assertFalse(i3.equals(i5))
+
+        i6 = ak.Index(["a", "b", "c", "d"], allow_list=True)
+        self.assertFalse(i5.equals(i6))
+
+        with self.assertRaises(ValueError):
+            i5 == i6
+
+        with self.assertRaises(ValueError):
+            i5 != i6
+
+        with self.assertRaises(TypeError):
+            i.equals("string")
+
+    def test_multiindex_equals(self):
+        size = 10
+        arrays = [ak.array([1, 1, 2, 2]), ak.array(["red", "blue", "red", "blue"])]
+        m = ak.MultiIndex(arrays, names=["numbers", "colors"])
+        self.assertTrue(m.equals(m))
+
+        arrays2 = [ak.array([1, 1, 2, 2]), ak.array(["red", "blue", "red", "blue"])]
+        m2 = ak.MultiIndex(arrays2, names=["numbers2", "colors2"])
+        self.assertTrue(m.equals(m2))
+
+        arrays3 = [
+            ak.array([1, 1, 2, 2]),
+            ak.array(["red", "blue", "red", "blue"]),
+            ak.array([1, 1, 2, 2]),
+        ]
+        m3 = ak.MultiIndex(arrays3, names=["numbers", "colors2", "numbers3"])
+        self.assertFalse(m.equals(m3))
+
+        arrays4 = [ak.array([1, 1, 2, 2]), ak.array(["red", "blue", "red", "green"])]
+        m4 = ak.MultiIndex(arrays4, names=["numbers2", "colors2"])
+        self.assertFalse(m.equals(m4))
+
+        m5 = ak.MultiIndex([ak.arange(size)])
+        i = ak.Index(ak.arange(size))
+        self.assertFalse(m5.equals(i))
+        self.assertFalse(i.equals(m5))
+
+    def test_equal_levels(self):
+        m = ak.MultiIndex(
+            [ak.arange(3), ak.arange(3) * -1, ak.array(["a", 'b","c', "d"])],
+            names=["col1", "col2", "col3"],
+        )
+        m2 = ak.MultiIndex(
+            [ak.arange(3), ak.arange(3) * -1, ak.array(["a", 'b","c', "d"])],
+            names=["A", "B", "C"],
+        )
+
+        self.assertTrue(m.equal_levels(m2))
+
+        m3 = ak.MultiIndex(
+            [ak.arange(3), ak.arange(3) * -1, ak.array(["a", 'b","c', "d"]), 2 * ak.arange(3)],
+            names=["col1", "col2", "col3"],
+        )
+
+        self.assertFalse(m.equal_levels(m3))
+
+        m4 = ak.MultiIndex(
+            [ak.arange(3), ak.arange(3) * 2, ak.array(["a", 'b","c', "d"])],
+            names=["col1", "col2", "col3"],
+        )
+
+        self.assertFalse(m.equal_levels(m4))
 
     def test_get_level_values(self):
         m = ak.MultiIndex(

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -362,6 +362,21 @@ class StringTest(ArkoudaTest):
     def test_compare_strings(self):
         assert compare_strings(self.base_words.to_ndarray(), self.np_base_words)
 
+    def test_equals(self):
+        s = ak.array(["a", "b", "c"])
+        s_cpy = ak.array(["a", "b", "c"])
+        self.assertTrue(ak.sum((s == s_cpy) != ak.array([True, True, True])) == 0)
+        self.assertTrue(ak.sum((s != s_cpy) != ak.array([False, False, False])) == 0)
+        assert s.equals(s_cpy)
+
+        s2 = ak.array(["a", "x", "c"])
+        self.assertTrue(ak.sum((s == s2) != ak.array([True, False, True])) == 0)
+        self.assertTrue(ak.sum((s != s2) != ak.array([False, True, False])) == 0)
+        assert not s.equals(s2)
+
+        s3 = ak.array(["a", "b", "c", "d"])
+        assert not s.equals(s3)
+
     def test_argsort(self):
         run_test_argsort(self.strings, self.test_strings, self._get_categorical())
 


### PR DESCRIPTION
Closes #3188 multi index.equals

Add MultiIndex.equals to match pandas also MultiIndex.equal_levels:
https://pandas.pydata.org/pandas-docs/version/0.19.2/generated/pandas.MultiIndex.equal_levels.html

Also adds `String.equals` and `Categorical.equals` functions.