### PR TITLE
Part of #3229: CI failures due to `indexof1d`

### DIFF
--- a/PROTO_tests/tests/setops_test.py
+++ b/PROTO_tests/tests/setops_test.py
@@ -680,14 +680,24 @@ class TestSetOps:
         # index of nan (reproducer from #3009)
         s = ak.Series(ak.array([1, 2, 3]), index=ak.array([1, 2, np.nan]))
         assert ak.indexof1d(ak.array([np.nan]), s.index.values).to_list() == [2]
+        rng = np.random.default_rng()
+        seeds = [rng.choice(2**63), rng.choice(2**63), rng.choice(2**63), rng.choice(2**63)]
+        print("seeds: \n", seeds)
 
+        def are_pdarrays_equal(pda1, pda2):
+            # we first check the sizes so that we won't hit shape mismatch
+            # before we can print the seed (due to short-circuiting)
+            return (pda1.size == pda2.size) and ((pda1 == pda2).all())
+
+        count = 0
         select_from_list = [
-            ak.randint(-(2**32), 2**32, 10),
+            ak.randint(-(2**32), 2**32, 10, seed=seeds[0]),
             ak.linspace(-(2**32), 2**32, 10),
-            ak.random_strings_uniform(1, 16, 10),
+            ak.random_strings_uniform(1, 16, 10, seed=seeds[1]),
         ]
         for select_from in select_from_list:
-            arr1 = select_from[ak.randint(0, select_from.size, 20)]
+            count += 1
+            arr1 = select_from[ak.randint(0, select_from.size, 20, seed=seeds[2]+count)]
 
             # test unique search space, this should be identical to find
             # be sure to test when all items are present and when there are items missing
@@ -695,15 +705,27 @@ class TestSetOps:
                 found_in_second = ak.in1d(arr1, arr2)
                 idx_of_first_in_second = ak.indexof1d(arr1, arr2)
 
-                # ensure we match find
-                assert (idx_of_first_in_second == ak.find(arr1, arr2, remove_missing=True)).all()
+                # search space not guaranteed to be unique since select_from could have duplicates
+                # we will only match find with remove_missing when there's only one occurrence in the search space
+                all_unique = ak.unique(arr2).size == arr2.size
+                if all_unique:
+                    # ensure we match find
+                    if not are_pdarrays_equal(idx_of_first_in_second, ak.find(arr1, arr2, remove_missing=True)):
+                        print("failed to match find")
+                        print("second array all unique: ", all_unique)
+                        print(seeds)
+                    assert (idx_of_first_in_second == ak.find(arr1, arr2, remove_missing=True)).all()
 
-                # if an element of arr1 is found in arr2, return the index of that item in arr2
-                assert (arr2[idx_of_first_in_second] == arr1[found_in_second]).all()
+                    # if an element of arr1 is found in arr2, return the index of that item in arr2
+                    if not are_pdarrays_equal(arr2[idx_of_first_in_second], arr1[found_in_second]):
+                        print("arr1 at indices found_in_second doesn't match arr2[indexof1d]")
+                        print("second array all unique: ", all_unique)
+                        print(seeds)
+                    assert (arr2[idx_of_first_in_second] == arr1[found_in_second]).all()
 
             # test duplicate items in search space, the easiest way I can think
             # of to do this is to compare against pandas series getitem
-            arr2 = select_from[ak.randint(0, select_from.size, 20)]
+            arr2 = select_from[ak.randint(0, select_from.size, 20, seed=seeds[3]+count)]
             pd_s = pd.Series(index=arr1.to_ndarray(), data=arr2.to_ndarray())
             ak_s = ak.Series(index=arr1, data=arr2)
 

--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -275,7 +275,7 @@ def indexof1d(query: groupable, space: groupable) -> pdarray:
     RuntimeError
         Raised if the dtype of either array is not supported
     """
-    from arkouda.alignment import find as akfind
+    # from arkouda.alignment import find as akfind
     from arkouda.categorical import Categorical as Categorical_
 
     if isinstance(query, (pdarray, Strings, Categorical_)):
@@ -284,8 +284,15 @@ def indexof1d(query: groupable, space: groupable) -> pdarray:
         elif isinstance(query, pdarray) and not isinstance(space, pdarray):
             raise TypeError("If keys is pdarray, arr must also be pdarray")
 
-    found = akfind(query, space, all_occurrences=True, remove_missing=True)
-    return found if isinstance(found, pdarray) else found.values
+    repMsg = generic_msg(
+        cmd="indexof1d",
+        args={"keys": query, "arr": space},
+    )
+    return create_pdarray(cast(str, repMsg))
+
+    # TODO see issue #3229 reverted back to old implementation until we can investigate
+    # found = akfind(query, space, all_occurrences=True, remove_missing=True)
+    # return found if isinstance(found, pdarray) else found.values
 
 
 # fmt: off

--- a/src/In1d.chpl
+++ b/src/In1d.chpl
@@ -89,4 +89,25 @@ module In1d
         }
         return truth;
     }
+
+    // For each value in the first array, find the indices of their appearances
+    // in the second. Results are ordered by the order of the keys.
+    proc indexof1d(keys: ?t, arr: t) throws {
+        var l : list(int, false);
+        var indexLists: [0..<keys.size] list(int, false);
+
+        forall keyIdx in 0..<keys.size {
+            var keyVal = keys[keyIdx];
+            var indexList: list(int, false);
+            for i in 0..<arr.size do
+                if keyVal == arr[i] then indexList.pushBack(i);
+            indexLists[keyIdx] = indexList;
+        }
+
+        var finalList : list(int);
+        for l in indexLists do
+            finalList.pushBack(l);
+
+        return finalList.toArray();
+    }
 }

--- a/src/In1dMsg.chpl
+++ b/src/In1dMsg.chpl
@@ -79,6 +79,80 @@ module In1dMsg
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 
+    /*
+    Parse, execute, and respond to a indexof1d message
+    :arg reqMsg: request containing (cmd,name,name2)
+    :type reqMsg: string
+    :arg st: SymTab to act on
+    :type st: borrowed SymTab
+    :returns: (MsgTuple) response message
+    */
+    proc indexof1dMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        param pn = Reflection.getRoutineName();
+        var repMsg: string; // response message
+
+        var vname = st.nextName();
+
+        var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(msgArgs.getValueOf("keys"), st);
+        var gEnt2: borrowed GenSymEntry = getGenericTypedArrayEntry(msgArgs.getValueOf("arr"), st);
+
+        select(gEnt.dtype, gEnt2.dtype) {
+          when (DType.Int64, DType.Int64) {
+             var e = toSymEntry(gEnt,int);
+             var f = toSymEntry(gEnt2,int);
+
+             var aV = indexof1d(e.a, f.a);
+             st.addEntry(vname, createSymEntry(aV));
+
+             repMsg = "created " + st.attrib(vname);
+             iLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+             return new MsgTuple(repMsg, MsgType.NORMAL);
+           }
+           when (DType.UInt64, DType.UInt64) {
+             var e = toSymEntry(gEnt,uint);
+             var f = toSymEntry(gEnt2,uint);
+
+             var aV = indexof1d(e.a, f.a);
+             st.addEntry(vname, createSymEntry(aV));
+
+             repMsg = "created " + st.attrib(vname);
+             iLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+             return new MsgTuple(repMsg, MsgType.NORMAL);
+           }
+           when (DType.Float64, DType.Float64) {
+             var e = toSymEntry(gEnt,real);
+             var f = toSymEntry(gEnt2,real);
+
+             const transmuted1 = [ei in e.a] ei.transmute(uint(64));
+             const transmuted2 = [fi in f.a] fi.transmute(uint(64));
+
+             var aV = indexof1d(transmuted1, transmuted2);
+             st.addEntry(vname, createSymEntry(aV));
+
+             repMsg = "created " + st.attrib(vname);
+             iLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+             return new MsgTuple(repMsg, MsgType.NORMAL);
+           }
+           when (DType.Strings, DType.Strings) {
+             var e = getSegString(msgArgs.getValueOf("keys"), st);
+             var f = getSegString(msgArgs.getValueOf("arr"), st);
+
+             var aV = indexof1d(e, f);
+             st.addEntry(vname, createSymEntry(aV));
+
+             repMsg = "created " + st.attrib(vname);
+             iLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+             return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+           otherwise {
+               var errorMsg = notImplementedError("indexof1d",gEnt.dtype);
+               iLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+               return new MsgTuple(errorMsg, MsgType.ERROR);
+           }
+        }
+    }
+
     use CommandMap;
     registerFunction("in1d", in1dMsg, getModuleName());
+    registerFunction("indexof1d", indexof1dMsg, getModuleName());
 }

--- a/tests/setops_test.py
+++ b/tests/setops_test.py
@@ -337,14 +337,24 @@ class SetOpsTest(ArkoudaTest):
         # index of nan (reproducer from #3009)
         s = ak.Series(ak.array([1, 2, 3]), index=ak.array([1, 2, np.nan]))
         self.assertTrue(ak.indexof1d(ak.array([np.nan]), s.index.values).to_list() == [2])
+        rng = np.random.default_rng()
+        seeds = [rng.choice(2**63), rng.choice(2**63), rng.choice(2**63), rng.choice(2**63)]
+        print("seeds: \n", seeds)
 
+        def are_pdarrays_equal(pda1, pda2):
+            # we first check the sizes so that we won't hit shape mismatch
+            # before we can print the seed (due to short-circuiting)
+            return (pda1.size == pda2.size) and ((pda1 == pda2).all())
+
+        count = 0
         select_from_list = [
-            ak.randint(-(2**32), 2**32, 10),
+            ak.randint(-(2**32), 2**32, 10, seed=seeds[0]),
             ak.linspace(-(2**32), 2**32, 10),
-            ak.random_strings_uniform(1, 16, 10),
+            ak.random_strings_uniform(1, 16, 10, seed=seeds[1]),
         ]
         for select_from in select_from_list:
-            arr1 = select_from[ak.randint(0, select_from.size, 20)]
+            count += 1
+            arr1 = select_from[ak.randint(0, select_from.size, 20, seed=seeds[2]+count)]
 
             # test unique search space, this should be identical to find
             # be sure to test when all items are present and when there are items missing
@@ -352,17 +362,29 @@ class SetOpsTest(ArkoudaTest):
                 found_in_second = ak.in1d(arr1, arr2)
                 idx_of_first_in_second = ak.indexof1d(arr1, arr2)
 
-                # ensure we match find
-                self.assertTrue((idx_of_first_in_second == ak.find(arr1, arr2, remove_missing=True)).all())
+                # search space not guaranteed to be unique since select_from could have duplicates
+                # we will only match find with remove_missing when there's only one occurrence in the search space
+                all_unique = ak.unique(arr2).size == arr2.size
+                if all_unique:
+                    # ensure we match find
+                    if not are_pdarrays_equal(idx_of_first_in_second, ak.find(arr1, arr2, remove_missing=True)):
+                        print("failed to match find")
+                        print("second array all unique: ", all_unique)
+                        print(seeds)
+                    self.assertTrue((idx_of_first_in_second == ak.find(arr1, arr2, remove_missing=True)).all())
 
-                # if an element of arr1 is found in arr2, return the index of that item in arr2
-                self.assertTrue(
-                    (arr2[idx_of_first_in_second] == arr1[found_in_second]).all()
-                )
+                    # if an element of arr1 is found in arr2, return the index of that item in arr2
+                    if not are_pdarrays_equal(arr2[idx_of_first_in_second], arr1[found_in_second]):
+                        print("arr1 at indices found_in_second doesn't match arr2[indexof1d]")
+                        print("second array all unique: ", all_unique)
+                        print(seeds)
+                    self.assertTrue(
+                        (arr2[idx_of_first_in_second] == arr1[found_in_second]).all()
+                    )
 
             # test duplicate items in search space, the easiest way I can think
             # of to do this is to compare against pandas series getitem
-            arr2 = select_from[ak.randint(0, select_from.size, 20)]
+            arr2 = select_from[ak.randint(0, select_from.size, 20, seed=seeds[3]+count)]
             pd_s = pd.Series(index=arr1.to_ndarray(), data=arr2.to_ndarray())
             ak_s = ak.Series(index=arr1, data=arr2)
 


### PR DESCRIPTION
This PR is part of #3229. We were seeing CI failures due to `indexof1d`. I reverted back to the original implementation until I can look into this more. I added a transmute to ensure proper handling of `nan`s. I also modified the test to write out seeds to make future failures easier to reproduce