### PR TITLE
Fixes #3074: Bug reading segarrays from parquet files

### DIFF
--- a/PROTO_tests/tests/io_test.py
+++ b/PROTO_tests/tests/io_test.py
@@ -536,15 +536,11 @@ class TestParquet:
 
         df_dict = dict()
         rng = ak.random.default_rng()
-        some_nans = rng.uniform(-(2**10), 2**10, val_size)
-        # set every other position to nan
-        some_nans[ak.arange(val_size) % 2 == 0] = np.nan
         vals_list = [
             rng.uniform(-(2**10), 2**10, val_size),
             rng.integers(0, 2**32, size=val_size, dtype="uint"),
             rng.integers(0, 1, size=val_size, dtype="bool"),
             rng.integers(-(2**32), 2**32, size=val_size, dtype="int"),
-            some_nans,
         ]
 
         for vals in vals_list:

--- a/PROTO_tests/tests/io_test.py
+++ b/PROTO_tests/tests/io_test.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
+from pandas.testing import assert_series_equal
 
 import arkouda as ak
 from arkouda import io_util
@@ -525,6 +526,47 @@ class TestParquet:
         df = ak.DataFrame({"a": ak.IPv4(ak.arange(10))})
         df["a"] = df["a"].values.export_uint()
         assert ak.arange(10).to_list() == df["a"].to_list()
+
+    def test_empty_segs_segarray(self):
+        # verify reproducer for #3074 is resolved
+
+        # bug seemed to consistently appear for val_sizes
+        # exceeding 700000, round up to ensure we'd hit it
+        val_size = 1000000
+
+        df_dict = dict()
+        rng = ak.random.default_rng()
+        some_nans = rng.uniform(-(2**10), 2**10, val_size)
+        # set every other position to nan
+        some_nans[ak.arange(val_size) % 2 == 0] = np.nan
+        vals_list = [
+            rng.uniform(-(2**10), 2**10, val_size),
+            rng.integers(0, 2**32, size=val_size, dtype="uint"),
+            rng.integers(0, 1, size=val_size, dtype="bool"),
+            rng.integers(-(2**32), 2**32, size=val_size, dtype="int"),
+            some_nans,
+        ]
+
+        for vals in vals_list:
+            # segs must start with 0, all other segment lengths are random
+            # by having val_size number of segments, except in the extremely unlikely case of
+            # randomly getting exactly arange(val_size), we are guaranteed empty segs
+            segs = ak.concatenate([ak.array([0]), ak.sort(ak.randint(0, val_size, val_size - 1))])
+            df_dict["rand"] = ak.SegArray(segs, vals).to_list()
+
+            pddf = pd.DataFrame(df_dict)
+            with tempfile.TemporaryDirectory(dir=TestParquet.par_test_base_tmp) as tmp_dirname:
+                file_path = f"{tmp_dirname}/empty_segs"
+                pddf.to_parquet(file_path)
+                akdf = ak.DataFrame(ak.read_parquet(file_path))
+
+                to_pd = pd.Series(akdf["rand"].values.to_list())
+                # raises an error if the two series aren't equal
+                # we can't use np.allclose(pddf['rand'].to_list, akdf['rand'].to_list) since these
+                # are lists of lists. assert_series_equal handles this and properly handles nans.
+                # we pass the same absolute and relative tolerances as the numpy default in allclose
+                # to ensure float point differences don't cause errors
+                assert_series_equal(pddf['rand'], to_pd, check_names=False, rtol=1e-05, atol=1e-08)
 
 
 class TestHDF5:

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -199,22 +199,6 @@ module ParquetMsg {
     }
   }
 
-  proc computeIdx(offsets: [] int, val: int): int throws {
-    var (v, idx) = maxloc reduce zip(offsets > val, offsets.domain);
-    return if v then idx-1 else offsets.size-1;
-  }
-
-  proc computeEmptySegs(seg_sizes: [] int, offsets: [] int, s: int, intersection: domain(1), fileoffset: int): int throws {
-    // Compute the number of empty segments preceeding the current chunk
-    if (intersection.low-fileoffset == 0){ //starts the file, no shift needed
-      return 0;
-    }
-    var highidx = computeIdx(offsets, intersection.low);
-    var sub_segs = seg_sizes[s..highidx];
-    var empty_segs = sub_segs == 0;
-    return (+ reduce empty_segs);
-  }
-
   proc readListFilesByName(A: [] ?t, rows_per_file: [] int, seg_sizes: [] int, offsets: [] int, filenames: [] string, sizes: [] int, dsetname: string, ty) throws {
     extern proc c_readListColumnByName(filename, arr_chpl, colNum, numElems, startIdx, batchSize, errMsg): int;
     var (subdoms, length) = getSubdomains(sizes);

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -9,6 +9,7 @@ import pyarrow.parquet as pq
 import pytest
 from base_test import ArkoudaTest
 from context import arkouda as ak
+from pandas.testing import assert_series_equal
 
 from arkouda import io_util
 
@@ -582,6 +583,44 @@ class ParquetTest(ArkoudaTest):
             ak_data = ak.read(f"{tmp_dirname}/decimal")
             for i in range(1, 39):
                 self.assertTrue(np.allclose(ak_data["decCol" + str(i)].to_ndarray(), data[i - 1]))
+
+    def test_empty_segs_segarray(self):
+        # verify reproducer for #3074 is resolved
+        val_size = 1000000
+
+        df_dict = dict()
+        rng = ak.random.default_rng()
+        some_nans = rng.uniform(-(2**10), 2**10, val_size)
+        # set every other position to nan
+        some_nans[ak.arange(val_size) % 2 == 0] = np.nan
+        vals_list = [
+            rng.uniform(-(2**10), 2**10, val_size),
+            rng.integers(0, 2**32, size=val_size, dtype="uint"),
+            rng.integers(0, 1, size=val_size, dtype="bool"),
+            rng.integers(-(2**32), 2**32, size=val_size, dtype="int"),
+            some_nans,
+        ]
+
+        for vals in vals_list:
+            # segs must start with 0, all other segment lengths are random
+            # by having val_size number of segments, except in the extremely unlikely case of
+            # randomly getting exactly arange(val_size), we are guaranteed empty segs
+            segs = ak.concatenate([ak.array([0]), ak.sort(ak.randint(0, val_size, val_size - 1))])
+            df_dict["rand"] = ak.SegArray(segs, vals).to_list()
+
+            pddf = pd.DataFrame(df_dict)
+            with tempfile.TemporaryDirectory(dir=ParquetTest.par_test_base_tmp) as tmp_dirname:
+                file_path = f"{tmp_dirname}/empty_segs"
+                pddf.to_parquet(file_path)
+                akdf = ak.DataFrame(ak.read_parquet(file_path))
+
+                to_pd = pd.Series(akdf["rand"].values.to_list())
+                # raises an error if the two series aren't equal
+                # we can't use np.allclose(pddf['rand'].to_list, akdf['rand'].to_list) since these
+                # are lists of lists. assert_series_equal handles this and properly handles nans.
+                # we pass the same absolute and relative tolerances as the numpy default in allclose
+                # to ensure float point differences don't cause errors
+                assert_series_equal(pddf['rand'], to_pd, check_names=False, rtol=1e-05, atol=1e-08)
 
     @pytest.mark.optional_parquet
     def test_against_standard_files(self):

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -590,15 +590,11 @@ class ParquetTest(ArkoudaTest):
 
         df_dict = dict()
         rng = ak.random.default_rng()
-        some_nans = rng.uniform(-(2**10), 2**10, val_size)
-        # set every other position to nan
-        some_nans[ak.arange(val_size) % 2 == 0] = np.nan
         vals_list = [
             rng.uniform(-(2**10), 2**10, val_size),
             rng.integers(0, 2**32, size=val_size, dtype="uint"),
             rng.integers(0, 1, size=val_size, dtype="bool"),
             rng.integers(-(2**32), 2**32, size=val_size, dtype="int"),
-            some_nans,
         ]
 
         for vals in vals_list:


### PR DESCRIPTION
We were seeing a bug where segarrays containing empty segments would fail if they exceeded ~700000 values. It seems our c++ code was mishandling the empty segments and this only appeared when values were large enough (my running theory is it has to do with the batch sizes). Reworked the logic to properly account for empty segment fixes #3074, but requires we read single elements instead of batches (which is standard when nans are present)