### PR TITLE
Move some definitions from ArrowFunctions header to source

### DIFF
--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -1,5 +1,10 @@
 #include "ArrowFunctions.h"
 
+static std::map<int, std::shared_ptr<parquet::ParquetFileReader>> globalFiles;
+static std::map<int, std::shared_ptr<parquet::RowGroupReader>> globalRowGroupReaders;
+static std::map<int, std::shared_ptr<parquet::ColumnReader>> globalColumnReaders;
+
+
 /*
   Arrow Error Helpers
   -------------------
@@ -9,7 +14,6 @@
   these helpers are similar to the provided macros but matching our
   functionality. 
 */
-
 // The `ARROWRESULT_OK` macro should be used when trying to
 // assign the result of an Arrow/Parquet function to a value that can
 // potentially throw an error, so the argument `cmd` is the Arrow

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -4,7 +4,6 @@ static std::map<int, std::shared_ptr<parquet::ParquetFileReader>> globalFiles;
 static std::map<int, std::shared_ptr<parquet::RowGroupReader>> globalRowGroupReaders;
 static std::map<int, std::shared_ptr<parquet::ColumnReader>> globalColumnReaders;
 
-
 /*
   Arrow Error Helpers
   -------------------
@@ -14,6 +13,7 @@ static std::map<int, std::shared_ptr<parquet::ColumnReader>> globalColumnReaders
   these helpers are similar to the provided macros but matching our
   functionality. 
 */
+
 // The `ARROWRESULT_OK` macro should be used when trying to
 // assign the result of an Arrow/Parquet function to a value that can
 // potentially throw an error, so the argument `cmd` is the Arrow

--- a/src/ArrowFunctions.h
+++ b/src/ArrowFunctions.h
@@ -185,8 +185,5 @@ extern "C" {
   void cpp_freeMapValues(void* row);
   
 #ifdef __cplusplus
-  std::map<int, std::shared_ptr<parquet::ParquetFileReader>> globalFiles;
-  std::map<int, std::shared_ptr<parquet::RowGroupReader>> globalRowGroupReaders;
-  std::map<int, std::shared_ptr<parquet::ColumnReader>> globalColumnReaders;
 }
 #endif


### PR DESCRIPTION
This PR is a small fix for issues we've encountered with GPU testing.

ArrowFunctions.h header has some `map` definitions that causes multiple definitions issues as the header is used in multiple places. This only comes up in Chapel's GPU testing because it uses C++ linkage. Note that the problematic definitions are in `ifdef __cplusplus` which is only true when compiling ArrowFunctions.cpp normally. However, that's always true when using GPU support because of C++ linkage.

To me, it looks like these maps are implementations details for ArrowFunctions.cpp. So, this PR just moves them to be static globals in that file. If they need to be used in more than one source file down the road, the correct way of doing that is to, declare them as `extern`s in the header and remove the `static` qualifier in the source code.