### PR TITLE
Add implementations of `clip`, `diff`,`pad` to Array API module

### DIFF
--- a/ArrayAPIServerModules.cfg
+++ b/ArrayAPIServerModules.cfg
@@ -17,6 +17,7 @@ SetMsg
 SortMsg
 StatsMsg
 TransferMsg
+UtilMsg
 
 # Add additional modules located outside
 # of the Arkouda src/ directory below.

--- a/arkouda/array_api/__init__.py
+++ b/arkouda/array_api/__init__.py
@@ -139,7 +139,7 @@ from ._sorting_functions import argsort, sort
 
 from ._statistical_functions import max, mean, min, prod, std, sum, var, cumulative_sum
 
-from ._utility_functions import all, any
+from ._utility_functions import all, any, clip, diff, pad
 
 __array_api_version__ = "2022.12"
 
@@ -282,6 +282,6 @@ __all__ += ["argsort", "sort"]
 
 __all__ += ["max", "mean", "min", "prod", "std", "sum", "var", "cumulative_sum"]
 
-__all__ += ["all", "any"]
+__all__ += ["all", "any", "clip", "diff", "pad"]
 
 warnings.warn("The arkouda.array_api submodule is still experimental.")

--- a/arkouda/array_api/_array_object.py
+++ b/arkouda/array_api/_array_object.py
@@ -354,7 +354,8 @@ class Array:
         return array_api
 
     def __bool__(self: Array, /) -> bool:
-        if s := self._single_elem():
+        s = self._single_elem()
+        if s is not None:
             return bool(s)
         else:
             raise ValueError(

--- a/arkouda/array_api/_utility_functions.py
+++ b/arkouda/array_api/_utility_functions.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 from ._array_object import Array
+from ._manipulation_functions import concat
 
 from typing import Optional, Tuple, Union
 
 from arkouda.pdarraycreation import scalar_array
+from arkouda.client import generic_msg
+from arkouda.pdarrayclass import create_pdarray
 import arkouda as ak
 
 
@@ -36,3 +39,94 @@ def any(
     See its docstring for more information.
     """
     return Array._new(scalar_array(ak.any(x._array)))
+
+
+def clip(a: Array, a_min, a_max, /) -> Array:
+    return Array._new(
+        create_pdarray(
+            generic_msg(
+                cmd=f"clip{a.ndim}D",
+                args={
+                    "name": a._array,
+                    "min": a_min,
+                    "max": a_max,
+                },
+            ),
+        )
+    )
+
+
+def diff(a: Array, /, n: int = 1, axis: int = -1, prepend=None, append=None) -> Array:
+    if prepend is not None and append is not None:
+        a_ = concat((prepend, a, append), axis=axis)
+    elif prepend is not None:
+        a_ = concat((prepend, a), axis=axis)
+    elif append is not None:
+        a_ = concat((a, append), axis=axis)
+    else:
+        a_ = a
+
+    return Array._new(
+        create_pdarray(
+            generic_msg(
+                cmd=f"diff{a.ndim}D",
+                args={
+                    "name": a_._array,
+                    "n": n,
+                    "axis": axis,
+                },
+            ),
+        )
+    )
+
+
+def pad(
+    array: Array,
+    pad_width,  # Union[int, Tuple[int, int], Tuple[Tuple[int, int], ...]]
+    mode='constant',
+    **kwargs
+) -> Array:
+    if mode != 'constant':
+        raise NotImplementedError(f"pad mode '{mode}' is not supported")
+
+    if 'constant_values' not in kwargs:
+        cvals = 0
+    else:
+        cvals = kwargs['constant_values']
+
+    if isinstance(pad_width, int):
+        pad_widths_b = [pad_width] * array.ndim
+        pad_widths_a = [pad_width] * array.ndim
+    elif isinstance(pad_width, tuple):
+        if isinstance(pad_width[0], int):
+            pad_widths_b = [pad_width[0]] * array.ndim
+            pad_widths_a = [pad_width[1]] * array.ndim
+        elif isinstance(pad_width[0], tuple):
+            pad_widths_b = [pw[0] for pw in pad_width]
+            pad_widths_a = [pw[1] for pw in pad_width]
+
+    if isinstance(cvals, int):
+        pad_vals_b = [cvals] * array.ndim
+        pad_vals_a = [cvals] * array.ndim
+    elif isinstance(cvals, tuple):
+        if isinstance(cvals[0], int):
+            pad_vals_b = [cvals[0]] * array.ndim
+            pad_vals_a = [cvals[1]] * array.ndim
+        else:
+            pad_vals_b = [cv[0] for cv in cvals]
+            pad_vals_a = [cv[1] for cv in cvals]
+
+    return Array._new(
+        create_pdarray(
+            generic_msg(
+                cmd=f"pad{array.ndim}D",
+                args={
+                    "name": array._array,
+                    "padWidthBefore": tuple(pad_widths_b),
+                    "padWidthAfter": tuple(pad_widths_a),
+                    "padValsBefore": pad_vals_b,
+                    "padValsAfter": pad_vals_a,
+                },
+            ),
+        )
+    )

--- a/src/UtilMsg.chpl
+++ b/src/UtilMsg.chpl
@@ -1,0 +1,236 @@
+module UtilMsg {
+
+  use ServerConfig;
+  use ServerErrorStrings;
+
+  use Reflection;
+  use ServerErrors;
+  use Logging;
+  use Message;
+  use AryUtil;
+  use ArkoudaAryUtilCompat;
+
+  use MultiTypeSymEntry;
+  use MultiTypeSymbolTable;
+
+  private config const logLevel = ServerConfig.logLevel;
+  private config const logChannel = ServerConfig.logChannel;
+  const uLogger = new Logger(logLevel, logChannel);
+
+  /*
+    Constrain an array's values to be within a specified range [min, max]
+
+    see: https://numpy.org/doc/stable/reference/generated/numpy.clip.html
+  */
+  @arkouda.registerND
+  proc clipMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, param nd: int): MsgTuple throws {
+    param pn = Reflection.getRoutineName();
+
+    const name = msgArgs.getValueOf("name"),
+          min = msgArgs.get("min"),
+          max = msgArgs.get("max"),
+          rname = st.nextName();
+
+    var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(name, st);
+
+    proc doClip(type t): MsgTuple throws {
+      const minVal = min.getScalarValue(t),
+            maxVal = max.getScalarValue(t);
+
+      const e = toSymEntry(gEnt, t, nd);
+      var c = st.addEntry(rname, (...e.tupShape), t);
+
+      forall i in e.a.domain {
+        if e.a[i] < minVal then
+          c.a[i] = minVal;
+        else if e.a[i] > maxVal then
+          c.a[i] = maxVal;
+        else
+          c.a[i] = e.a[i];
+      }
+
+      const repMsg = "created " + st.attrib(rname);
+      uLogger.debug(getModuleName(),pn,getLineNumber(),repMsg);
+      return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+
+    select gEnt.dtype {
+      when DType.Int64 do return doClip(int);
+      when DType.UInt8 do return doClip(uint(8));
+      when DType.UInt64 do return doClip(uint);
+      when DType.Float64 do return doClip(real);
+      when DType.Bool do return doClip(bool);
+      otherwise {
+        const errorMsg = notImplementedError(pn,gEnt.dtype);
+        uLogger.error(getModuleName(),pn,getLineNumber(),errorMsg);
+        return new MsgTuple(errorMsg, MsgType.ERROR);
+      }
+    }
+  }
+
+  /*
+    Compute the n'th order discrete difference along a given axis
+
+    see: https://numpy.org/doc/stable/reference/generated/numpy.diff.html
+  */
+  @arkouda.registerND
+  proc diffMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, param nd: int): MsgTuple throws {
+    param pn = Reflection.getRoutineName();
+
+    const name = msgArgs.getValueOf("name"),
+          n = msgArgs.get("n").getIntValue(),
+          axis = msgArgs.get("axis").getPositiveIntValue(nd),
+          rname = st.nextName();
+
+    var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(name, st);
+
+    proc doDiff(type t): MsgTuple throws {
+      const e = toSymEntry(gEnt, t, nd);
+
+      if n == 1 {
+        // 1st order difference: requires no temporary storage
+        const outDom = subDomain(e.tupShape, axis, 1);
+        var d = st.addEntry(rname, (...outDom.shape), t);
+
+        forall axisSliceIdx in domOffAxis(e.a.domain, axis) {
+          const slice = domOnAxis(outDom, tuplify(axisSliceIdx), axis);
+          for i in slice {
+            var idxp = tuplify(i);
+            idxp[axis] += 1;
+            d.a[i] = e.a[idxp] - e.a[i];
+          }
+        }
+      } else {
+        // n'th order difference: requires 2 temporary arrays
+        var d1 = makeDistArray(e.a);
+
+        {
+          var d2 = makeDistArray(e.a.domain, e.a.eltType);
+          for m in 1..n {
+            d1 <=> d2;
+            const diffSubDom = subDomain(e.tupShape, axis, m);
+
+            forall axisSliceIdx in domOffAxis(e.a.domain, axis) {
+              const slice = domOnAxis(diffSubDom, tuplify(axisSliceIdx), axis);
+
+              for i in slice {
+                var idxp = tuplify(i);
+                idxp[axis] += 1;
+                d1[i] = d2[idxp] - d2[i];
+              }
+            }
+          }
+        } // d2 deinit here
+
+        const outDom = subDomain(e.tupShape, axis, n),
+              d = createSymEntry(d1[outDom]);
+        st.addEntry(rname, d);
+      }
+
+      const repMsg = "created " + st.attrib(rname);
+      uLogger.debug(getModuleName(),pn,getLineNumber(),repMsg);
+      return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+
+    select gEnt.dtype {
+      when DType.Int64 do return doDiff(int);
+      when DType.UInt8 do return doDiff(uint(8));
+      when DType.UInt64 do return doDiff(uint);
+      when DType.Float64 do return doDiff(real);
+      otherwise {
+        const errorMsg = notImplementedError(pn,gEnt.dtype);
+        uLogger.error(getModuleName(),pn,getLineNumber(),errorMsg);
+        return new MsgTuple(errorMsg, MsgType.ERROR);
+      }
+    }
+  }
+
+  // helper to create a domain that's 'n' elements smaller in the 'axis' dimension
+  private proc subDomain(shape: ?N*int, axis: int, n: int) {
+    var rngs: N*range;
+    for i in 0..<N {
+      if i == axis
+        // then rngs[i] = (n/2)..<(shape[i] - (n/2 + n%2));
+        then rngs[i] = 0..<(shape[i] - n);
+        else rngs[i] = 0..<shape[i];
+    }
+    return {(...rngs)};
+  }
+
+  private proc tuplify(x: int) do return (x,);
+  private proc tuplify(t: ?N*int) do return t;
+
+
+  /*
+    Pad an array with a set of specified values
+
+    Implements the 'constant' mode of numpy.pad: https://numpy.org/doc/stable/reference/generated/numpy.pad.html
+  */
+  @arkouda.registerND
+  proc padMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, param nd: int): MsgTuple throws {
+    param pn = Reflection.getRoutineName();
+
+    const name = msgArgs.getValueOf("name"),
+          padWidthBefore = msgArgs.get("padWidthBefore").getTuple(nd),
+          padWidthAfter = msgArgs.get("padWidthAfter").getTuple(nd),
+          padValsBefore = msgArgs.get("padValsBefore"),
+          padValsAfter = msgArgs.get("padValsAfter"),
+          rname = st.nextName();
+
+    var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(name, st);
+
+    proc doPad(type t): MsgTuple throws {
+      const e = toSymEntry(gEnt, t, nd);
+
+      const pvb = padValsBefore.getListAs(t, nd),
+            pva = padValsAfter.getListAs(t, nd);
+
+      // compute the padded shape
+      var outShape: nd*int;
+      for i in 0..<nd do outShape[i] = padWidthBefore[i] + e.tupShape[i] + padWidthAfter[i];
+
+      var p = st.addEntry(rname, (...outShape), t);
+
+      // copy the original array into the padded array
+      const dOffset = e.a.domain.translate(padWidthBefore);
+      p.a[dOffset] = e.a;
+
+      // starting with the last dimension, pad the array (i.e., dimension 0 overwrites dimension 1 in the corners, etc.)
+      for rank in 0..<nd {
+        var beforeSlice, afterSlice: nd*range;
+        for i in 0..<nd {
+          // TODO: compute the exact slice for each pad-section so these assignments can be done
+          // in parallel and to avoid accessing the corners of the array unnecessarily (which
+          // could result in additional comm for large pad widths)
+          if i == rank {
+            beforeSlice[i] = 0..<padWidthBefore[i];
+            afterSlice[i] = (outShape[i]-padWidthAfter[i])..<outShape[i];
+          } else {
+            beforeSlice[i] = 0..<outShape[i];
+            afterSlice[i] = 0..<outShape[i];
+          }
+        }
+
+        p.a[(...beforeSlice)] = pvb[rank];
+        p.a[(...afterSlice)] = pva[rank];
+      }
+
+      const repMsg = "created " + st.attrib(rname);
+      uLogger.debug(getModuleName(),pn,getLineNumber(),repMsg);
+      return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+
+    select gEnt.dtype {
+      when DType.Int64 do return doPad(int);
+      when DType.UInt8 do return doPad(uint(8));
+      when DType.UInt64 do return doPad(uint);
+      when DType.Float64 do return doPad(real);
+      when DType.Bool do return doPad(bool);
+      otherwise {
+        const errorMsg = notImplementedError(pn,gEnt.dtype);
+        uLogger.error(getModuleName(),pn,getLineNumber(),errorMsg);
+        return new MsgTuple(errorMsg, MsgType.ERROR);
+      }
+    }
+  }
+}

--- a/src/compat/e-132/ArkoudaAryUtilCompat.chpl
+++ b/src/compat/e-132/ArkoudaAryUtilCompat.chpl
@@ -6,12 +6,16 @@ module ArkoudaAryUtilCompat {
     :arg idx: the index to select along the specified axes (must have the same rank as D)
     :arg axes: the axes to slice along (must be a subset of the axes of D)
 
-    For example, if D represents a stack of 1000 10x10 matrices (ex: {1..10, 1..10, 1..1000})
+    Example 1: if D represents a stack of 1000 10x10 matrices (ex: {1..10, 1..10, 1..1000})
     Then, domOnAxis(D, (1, 1, 25), 0, 1) will return D sliced with {1..10, 1..10, 25..25}
     (i.e., the 25th matrix)
+
+    Example 2: if D belongs to a 3D array {1..100, 1..100, 1..100}, then
+    domOnAxis(D, (5, 1, 7), 1) will return D sliced with {5..5, 1..100, 7..7}, i.e.,
+    the set of indices for the (5,7)-th 1D sub-array along axis 1
   */
   proc domOnAxis(D: domain(?), idx: D.rank*int, axes: int ...?NA): domain
-    where NA < D.rank
+    where NA <= D.rank
   {
     var outDims: D.rank*range;
     label ranks for i in 0..<D.rank {
@@ -49,12 +53,16 @@ module ArkoudaAryUtilCompat {
     :arg D: the domain to slice
     :arg axes: the axes to slice along (must be a subset of the axes of D)
 
-    For example, if D represents a stack of 1000 10x10 matrices (ex: {1..10, 1..10, 1..1000})
+    Example 1: if D represents a stack of 1000 10x10 matrices (ex: {1..10, 1..10, 1..1000})
     Then, domOffAxis(D, 0, 1) will return D sliced with {0..0, 0..0, 1..1000}
     (i.e., a set of indices for the 1000 matrices)
+
+    Example 2: if D belongs to a 3D array {1..100, 1..100, 1..100}, then
+    domOffAxis(D, 1) will return D sliced with {1..100, 0..0, 1..100}, i.e.,
+    the set of indices for all the 1D sub-arrays along axis 1
   */
   proc domOffAxis(D: domain(?), axes: int ...?NA): domain(?)
-    where NA < D.rank
+    where NA <= D.rank
   {
     var outDims: D.rank*range;
     label ranks for i in 0..<D.rank {

--- a/src/compat/eq-131/ArkoudaAryUtilCompat.chpl
+++ b/src/compat/eq-131/ArkoudaAryUtilCompat.chpl
@@ -11,7 +11,7 @@ module ArkoudaAryUtilCompat {
     (i.e., the 25th matrix)
   */
   proc domOnAxis(D: domain, idx: D.rank*int, axes: int ...?NA): domain
-    where NA < D.rank
+    where NA <= D.rank
   {
     var outDims: D.rank*range;
     label ranks for i in 0..<D.rank {
@@ -54,7 +54,7 @@ module ArkoudaAryUtilCompat {
     (i.e., a set of indices for the 1000 matrices)
   */
   proc domOffAxis(D: domain, axes: int ...?NA): domain
-    where NA < D.rank
+    where NA <= D.rank
   {
     var outDims: D.rank*range;
     label ranks for i in 0..<D.rank {

--- a/src/compat/eq-133/ArkoudaAryUtilCompat.chpl
+++ b/src/compat/eq-133/ArkoudaAryUtilCompat.chpl
@@ -11,7 +11,7 @@ module ArkoudaAryUtilCompat {
     (i.e., the 25th matrix)
   */
   proc domOnAxis(D: domain(?), idx: D.rank*int, axes: int ...?NA): domain(?)
-    where NA < D.rank
+    where NA <= D.rank
   {
     var outDims: D.rank*range;
     label ranks for i in 0..<D.rank {
@@ -54,7 +54,7 @@ module ArkoudaAryUtilCompat {
     (i.e., a set of indices for the 1000 matrices)
   */
   proc domOffAxis(D: domain(?), axes: int ...?NA): domain(?)
-    where NA < D.rank
+    where NA <= D.rank
   {
     var outDims: D.rank*range;
     label ranks for i in 0..<D.rank {

--- a/src/compat/eq-134/ArkoudaAryUtilCompat.chpl
+++ b/src/compat/eq-134/ArkoudaAryUtilCompat.chpl
@@ -11,7 +11,7 @@ module ArkoudaAryUtilCompat {
     (i.e., the 25th matrix)
   */
   proc domOnAxis(D: domain(?), idx: D.rank*int, axes: int ...?NA): domain(?)
-    where NA < D.rank
+    where NA <= D.rank
   {
     var outDims: D.rank*range;
     label ranks for i in 0..<D.rank {
@@ -54,7 +54,7 @@ module ArkoudaAryUtilCompat {
     (i.e., a set of indices for the 1000 matrices)
   */
   proc domOffAxis(D: domain(?), axes: int ...?NA): domain(?)
-    where NA < D.rank
+    where NA <= D.rank
   {
     var outDims: D.rank*range;
     label ranks for i in 0..<D.rank {

--- a/src/compat/ge-20/ArkoudaAryUtilCompat.chpl
+++ b/src/compat/ge-20/ArkoudaAryUtilCompat.chpl
@@ -11,7 +11,7 @@ module ArkoudaAryUtilCompat {
     (i.e., the 25th matrix)
   */
   proc domOnAxis(D: domain(?), idx: D.rank*int, axes: int ...?NA): domain(?)
-    where NA < D.rank
+    where NA <= D.rank
   {
     var outDims: D.rank*range;
     label ranks for i in 0..<D.rank {
@@ -54,7 +54,7 @@ module ArkoudaAryUtilCompat {
     (i.e., a set of indices for the 1000 matrices)
   */
   proc domOffAxis(D: domain(?), axes: int ...?NA): domain(?)
-    where NA < D.rank
+    where NA <= D.rank
   {
     var outDims: D.rank*range;
     label ranks for i in 0..<D.rank {

--- a/tests/array_api/util_functions.py
+++ b/tests/array_api/util_functions.py
@@ -1,0 +1,67 @@
+
+from base_test import ArkoudaTest
+from context import arkouda as ak
+import arkouda.array_api as xp
+import numpy as np
+
+SEED = 314159
+s = SEED
+
+
+def randArr(shape):
+    global s
+    s += 2
+    return xp.asarray(ak.randint(0, 100, shape, dtype=ak.int64, seed=s))
+
+
+class UtilFunctions(ArkoudaTest):
+    def test_all(self):
+        a = xp.ones((10, 10), dtype=ak.bool)
+        self.assertTrue(xp.all(a))
+
+        a[3, 4] = False
+        self.assertFalse(xp.all(a))
+
+    def test_any(self):
+        a = xp.zeros((10, 10), dtype=ak.bool)
+        self.assertFalse(xp.any(a))
+
+        a[3, 4] = True
+        self.assertTrue(xp.any(a))
+
+    def test_clip(self):
+        a = randArr((5, 6, 7))
+        anp = a.to_ndarray()
+
+        a_c = xp.clip(a, 10, 90)
+        anp_c = np.clip(anp, 10, 90)
+        self.assertEqual(a_c.tolist(), anp_c.tolist())
+
+    def test_diff(self):
+        a = randArr((5, 6, 7))
+        anp = a.to_ndarray()
+
+        a_d = xp.diff(a, n=1, axis=1)
+        anp_d = np.diff(anp, n=1, axis=1)
+        self.assertEqual(a_d.tolist(), anp_d.tolist())
+
+        a_d = xp.diff(a, n=2, axis=0)
+        anp_d = np.diff(anp, n=2, axis=0)
+
+        self.assertEqual(a_d.tolist(), anp_d.tolist())
+
+    def test_pad(self):
+        a = xp.ones((5, 6, 7))
+        anp = np.ones((5, 6, 7))
+
+        a_p = xp.pad(a, ((1, 1), (2, 2), (3, 3)), mode='constant', constant_values=((-1, 1), (-2, 2), (-3, 3)))
+        anp_p = np.pad(anp, ((1, 1), (2, 2), (3, 3)), mode='constant', constant_values=((-1, 1), (-2, 2), (-3, 3)))
+        self.assertEqual(a_p.tolist(), anp_p.tolist())
+
+        a_p = xp.pad(a, (2, 3), constant_values=(55, 44))
+        anp_p = np.pad(anp, (2, 3), constant_values=(55, 44))
+        self.assertEqual(a_p.tolist(), anp_p.tolist())
+
+        a_p = xp.pad(a, 2, constant_values=3)
+        anp_p = np.pad(anp, 2, constant_values=3)
+        self.assertEqual(a_p.tolist(), anp_p.tolist())


### PR DESCRIPTION
XArray requires its array backends to implement a few numpy functions that are not yet included in the Array API standard: [`clip`](https://numpy.org/doc/stable/reference/generated/numpy.clip.html), [`diff`](https://numpy.org/doc/stable/reference/generated/numpy.diff.html), and [`pad`](https://numpy.org/doc/stable/reference/generated/numpy.pad.html). Note, `np.repeat` also falls under this category, but was already added in [this PR](https://github.com/Bears-R-Us/arkouda/pull/3056).

This PR adds implementations of the functions to the utility_functions array-api module. The `pad` function only implements the `constant` mode, as it appears the other modes aren't used in XArray (other padding modes can be added as needed).

*also fixes a bug in `Array.__bool__`