### PR TITLE
Improve the CSV Read performance with new impl

### DIFF
--- a/benchmarks/csvIO.py
+++ b/benchmarks/csvIO.py
@@ -17,7 +17,7 @@ def create_parser():
     parser.add_argument("hostname", help="Hostname of arkouda server")
     parser.add_argument("port", type=int, help="Port of arkouda server")
     parser.add_argument(
-        "-n", "--size", type=int, default=2*10**5, help="Problem size: length of array to read/write"
+        "-n", "--size", type=int, default=10**6, help="Problem size: length of array to read/write"
     )
     parser.add_argument(
         "-t", "--trials", type=int, default=1, help="Number of times to run the benchmark"

--- a/src/CSVMsg.chpl
+++ b/src/CSVMsg.chpl
@@ -434,18 +434,20 @@ module CSVMsg {
         var item: itemType;
         const colIdx: int;
         const colDelim: string;
-        const r: regex(string);
+        var r: regex(string);
 
-        proc init(type itemType, colIdx: int, colDelim: string) {
+        proc init(type itemType, colIdx: int, colDelim: string) throws {
             this.itemType = itemType;
             this.colIdx = colIdx;
             this.colDelim = colDelim;
-            this.r = try! new regex("[\n"+this.colDelim+"]");
+            init this;
+            if this.itemType == string then
+                this.r = new regex("[\n"+this.colDelim+"]");
         }
 
         proc ref deserialize(reader: fileReader(?), ref deserializer) throws {
             // read the comma delimited items in a single line
-            for i in 0..<colIdx {
+            for 0..<colIdx {
                 reader.advanceThrough(this.colDelim:bytes);  // Skip over the columns we don't care about
             }
             if itemType == string then

--- a/src/CSVMsg.chpl
+++ b/src/CSVMsg.chpl
@@ -428,7 +428,7 @@ module CSVMsg {
     }
 
     use Regex;
-    record csvLine : readDeserializable{
+    record csvLine /*: readDeserializable*/{ // Re-add this when dropping support for 1.31
 
         type itemType;
         var item: itemType;

--- a/src/CSVMsg.chpl
+++ b/src/CSVMsg.chpl
@@ -428,7 +428,7 @@ module CSVMsg {
     }
 
     use Regex;
-    record csvLine /*: readDeserializable*/{ // Re-add this when dropping support for 1.31
+    record csvLine: readDeserializable {
 
         type itemType;
         var item: itemType;


### PR DESCRIPTION
This PR improves the CSV read performance, especially in multilocale and
multi-file settings where the performance previously was abysmal.



Here's the performance improvements in different settings:

This new implementation does the following:
- Create a new `read_csv_pattern` method that takes out the file reading logic from `read_files_into_dist_array`
- Creates a new `csvLine` custom record that uses Chapel deserializers to read the csv file faster and better.
- Instead of reading the entire file at all times in all locales and storing the entire file in memory we do the following:
    - Skip even opening the file when the file domains do not intersect with the local subdomains of the array for the current locale
    - Read the file line by line and only retain a single item from each line in memory, dropping the unnecessary data
    - Minimize unnecessary communication across locales by doing so
- We also read all files in parallel on all locales since there is little communication in this new implementation


These are the read time numbers from the `csvIO.py` benchmark
Please keep in mind that the numbers aren't the best that they can be for this machine, but the ratio of the speedup is what we should look at here.
The times are in seconds and file size is in number of lines of csv.

1. Single locale, single file:

| File Size | old      | new      |
|------|----------|----------|
| 1M   | 13.3876  | 9.5591   |
| 5M   | 63.3379  | 44.2360  |
| 10M  | 125.9585 | 87.3109  |
| 15M  | 186.5688 | 131.8712 |


2. Multi locale, single file per local

| 5 locales 1 file per locale N=5*value_below | old      | new      |
|---------------------------------------------|----------|----------|
| 1M                                          | 145.3038 | 18.2276  |
| 5M                                          | 711.4987 | 90.4563  |
| 10M                                         | -        | 176.2367 |
| 15M                                         | -        | 263.6036 |



3. Multi locale, multi file per locale:

| 5 locales n file per locale N=5M total | old      | new      |
|----------------------------------------|----------|----------|
| 1                                      | 145.3038 | 19.6761  |
| 5                                      | 668.5100 | 63.5184  |
| 10                                     | -        | 127.4142 |
| 15                                     | -        | 188.9333 |


The `-` for the old implementation values are because the trials were going to take too long and I didn't want to wait.


In general, this is a huge leap forward for multilocale settings.