### PR TITLE
Reduce file size for csvIO benchmark

### DIFF
--- a/benchmarks/csvIO.py
+++ b/benchmarks/csvIO.py
@@ -17,7 +17,7 @@ def create_parser():
     parser.add_argument("hostname", help="Hostname of arkouda server")
     parser.add_argument("port", type=int, help="Port of arkouda server")
     parser.add_argument(
-        "-n", "--size", type=int, default=10**6, help="Problem size: length of array to read/write"
+        "-n", "--size", type=int, default=2*10**5, help="Problem size: length of array to read/write"
     )
     parser.add_argument(
         "-t", "--trials", type=int, default=1, help="Number of times to run the benchmark"


### PR DESCRIPTION
The csvIO benchmark is timing out in multilocale runs due to bad performance of the current implementation. There is a PR up
(https://github.com/Bears-R-Us/arkouda/pull/3238) which will improve this implementation, but it may take a while to merge based on feedback. 

Therefore we will reduce the file size here to 1/5th of the current and bring it back up later once the performance improves. The timeout happens after 300 seconds and this size takes ~100 seconds so we should be safe 🤞 
For reference with the new implementation `./benchmarks/run_benchmarks.py csvIO -nl 16` takes `46.4425` seconds, so if the other PR is merged before this one, we don't need to merge this.