### PR TITLE
Fixes #3222: series of segarray print bug

### DIFF
--- a/PROTO_tests/tests/series_test.py
+++ b/PROTO_tests/tests/series_test.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
-from pandas.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal, assert_series_equal
 
 import arkouda as ak
 from arkouda.series import Series
@@ -341,3 +341,12 @@ class TestSeries:
 
         fill_values3 = 100.0
         assert data.fillna(fill_values3).to_list() == [1.0, 100.0, 3.0, 100.0, 5.0]
+
+    def test_series_segarray_to_pandas(self):
+        # reproducer for issue #3222
+        sa = ak.SegArray(ak.arange(0, 30, 3), ak.arange(30))
+        akdf = ak.DataFrame({"test": sa})
+        pddf = pd.DataFrame({"test": sa.to_list()})
+
+        assert_frame_equal(akdf.to_pandas(), pddf)
+        assert_series_equal(akdf['test'].to_pandas(), pddf['test'], check_names=False)

--- a/arkouda/series.py
+++ b/arkouda/series.py
@@ -738,12 +738,15 @@ class Series:
 
         idx = self.index.to_pandas()
         val = convert_if_categorical(self.values)
+        # pandas errors when ndarray formatted like a segarray is
+        # passed into Series but works when it's just a list of lists
+        vals_on_client = val.to_list() if isinstance(val, SegArray) else val.to_ndarray()
 
         if isinstance(self.name, str):
             name = copy.copy(self.name)
-            return pd.Series(val.to_ndarray(), index=idx, name=name)
+            return pd.Series(vals_on_client, index=idx, name=name)
         else:
-            return pd.Series(val.to_ndarray(), index=idx)
+            return pd.Series(vals_on_client, index=idx)
 
     def to_markdown(self, mode="wt", index=True, tablefmt="grid", storage_options=None, **kwargs):
         r"""

--- a/tests/series_test.py
+++ b/tests/series_test.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 from base_test import ArkoudaTest
 from context import arkouda as ak
+from pandas.testing import assert_frame_equal, assert_series_equal
 
 from arkouda.series import Series
 
@@ -808,3 +809,12 @@ class SeriesTest(ArkoudaTest):
 
         fill_values3 = 100.0
         self.assertListEqual(data.fillna(fill_values3).to_list(), [1.0, 100.0, 3.0, 100.0, 5.0])
+
+    def test_series_segarray_to_pandas(self):
+        # reproducer for issue #3222
+        sa = ak.SegArray(ak.arange(0, 30, 3), ak.arange(30))
+        akdf = ak.DataFrame({"test": sa})
+        pddf = pd.DataFrame({"test": sa.to_list()})
+
+        assert_frame_equal(akdf.to_pandas(), pddf)
+        assert_series_equal(akdf["test"].to_pandas(), pddf["test"], check_names=False)


### PR DESCRIPTION
This PR fixes #3222, the series of segaray print bug. The bug was due to pandas series erroring an ndarray where each element is a list, but it handles a list of lists just fine. So we just call `to_list` instead of `to_ndarray` for the segarray case

output is now what I would expect
```python
>>> test_df = ak.DataFrame({'test': ak.SegArray(ak.arange(0, 30, 3), ak.arange(30))})
>>> test_df['test']
0       [0, 1, 2]
1       [3, 4, 5]
2       [6, 7, 8]
3     [9, 10, 11]
4    [12, 13, 14]
5    [15, 16, 17]
6    [18, 19, 20]
7    [21, 22, 23]
8    [24, 25, 26]
9    [27, 28, 29]
dtype: object
```