### PR TITLE
Fixes #3234: segarray with empty segments and nans parquet bug

### DIFF
--- a/PROTO_tests/tests/io_test.py
+++ b/PROTO_tests/tests/io_test.py
@@ -537,7 +537,7 @@ class TestParquet:
         df_dict = dict()
         seed = np.random.default_rng().choice(2**63)
         rng = ak.random.default_rng(seed)
-        some_nans = rng.uniform(-(2 ** 10), 2 ** 10, val_size)
+        some_nans = rng.uniform(-(2**10), 2**10, val_size)
         some_nans[ak.arange(val_size) % 2 == 0] = np.nan
         vals_list = [
             rng.uniform(-(2**10), 2**10, val_size),
@@ -551,7 +551,9 @@ class TestParquet:
             # segs must start with 0, all other segment lengths are random
             # by having val_size number of segments, except in the extremely unlikely case of
             # randomly getting exactly arange(val_size), we are guaranteed empty segs
-            segs = ak.concatenate([ak.array([0]), ak.sort(ak.randint(0, val_size, val_size - 1, seed=seed))])
+            segs = ak.concatenate(
+                [ak.array([0]), ak.sort(ak.randint(0, val_size, val_size - 1, seed=seed))]
+            )
             df_dict["rand"] = ak.SegArray(segs, vals).to_list()
 
             pddf = pd.DataFrame(df_dict)
@@ -567,7 +569,7 @@ class TestParquet:
                 # we pass the same absolute and relative tolerances as the numpy default in allclose
                 # to ensure float point differences don't cause errors
                 print("\nseed: ", seed)
-                assert_series_equal(pddf['rand'], to_pd, check_names=False, rtol=1e-05, atol=1e-08)
+                assert_series_equal(pddf["rand"], to_pd, check_names=False, rtol=1e-05, atol=1e-08)
 
 
 class TestHDF5:

--- a/PROTO_tests/tests/io_test.py
+++ b/PROTO_tests/tests/io_test.py
@@ -551,7 +551,7 @@ class TestParquet:
             # segs must start with 0, all other segment lengths are random
             # by having val_size number of segments, except in the extremely unlikely case of
             # randomly getting exactly arange(val_size), we are guaranteed empty segs
-            segs = ak.concatenate([ak.array([0]), ak.sort(ak.randint(0, val_size, val_size - 1))])
+            segs = ak.concatenate([ak.array([0]), ak.sort(ak.randint(0, val_size, val_size - 1, seed=seed))])
             df_dict["rand"] = ak.SegArray(segs, vals).to_list()
 
             pddf = pd.DataFrame(df_dict)

--- a/PROTO_tests/tests/io_test.py
+++ b/PROTO_tests/tests/io_test.py
@@ -535,12 +535,16 @@ class TestParquet:
         val_size = 1000000
 
         df_dict = dict()
-        rng = ak.random.default_rng()
+        seed = np.random.default_rng().choice(2**63)
+        rng = ak.random.default_rng(seed)
+        some_nans = rng.uniform(-(2 ** 10), 2 ** 10, val_size)
+        some_nans[ak.arange(val_size) % 2 == 0] = np.nan
         vals_list = [
             rng.uniform(-(2**10), 2**10, val_size),
             rng.integers(0, 2**32, size=val_size, dtype="uint"),
             rng.integers(0, 1, size=val_size, dtype="bool"),
             rng.integers(-(2**32), 2**32, size=val_size, dtype="int"),
+            some_nans,
         ]
 
         for vals in vals_list:
@@ -562,6 +566,7 @@ class TestParquet:
                 # are lists of lists. assert_series_equal handles this and properly handles nans.
                 # we pass the same absolute and relative tolerances as the numpy default in allclose
                 # to ensure float point differences don't cause errors
+                print("\nseed: ", seed)
                 assert_series_equal(pddf['rand'], to_pd, check_names=False, rtol=1e-05, atol=1e-08)
 
 

--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -585,6 +585,20 @@ int cpp_readListColumnByName(const char* filename, void* chpl_arr, const char* c
         int16_t definition_level; // needed for any type that is nullable
 
         std::shared_ptr<parquet::ColumnReader> column_reader = row_group_reader->Column(idx);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
         if(lty == ARROWINT64 || lty == ARROWUINT64) {
           int16_t definition_level; // nullable type and only reading single records in batch
           auto chpl_ptr = (int64_t*)chpl_arr;
@@ -600,7 +614,32 @@ int cpp_readListColumnByName(const char* filename, void* chpl_arr, const char* c
             }
             i++;
           }
-        } else if(lty == ARROWINT32 || lty == ARROWUINT32) {
+        } 
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        else if(lty == ARROWINT32 || lty == ARROWUINT32) {
           int16_t definition_level; // nullable type and only reading single records in batch
           auto chpl_ptr = (int64_t*)chpl_arr;
           parquet::Int32Reader* reader =
@@ -688,43 +727,63 @@ int cpp_readListColumnByName(const char* filename, void* chpl_arr, const char* c
             delete[] rep_lvl;
           }
         } else if(lty == ARROWDOUBLE) {
+          std::cout << "\n\n\n\n\n\n\n\n we are double\n";
+
+          int16_t definition_level; // nullable type and only reading single records in batch
           auto chpl_ptr = (double*)chpl_arr;
           parquet::DoubleReader* reader =
             static_cast<parquet::DoubleReader*>(column_reader.get());
 
-          while (reader->HasNext() && i < numElems) {
-            if((numElems - i) < batchSize) // adjust batchSize if needed
-              batchSize = numElems - i;
-            double* tmpArr = new double[batchSize]; // NaNs not included here
-            int16_t* def_lvl = new int16_t[batchSize];
-            int16_t* rep_lvl = new int16_t[batchSize];
-            (void)reader->ReadBatch(batchSize, def_lvl, rep_lvl, tmpArr, &values_read);
-            
-            int64_t tmp_offset = 0; // used to properly access tmp after NaN encountered
-            int64_t val_idx = 0;
-            for (int64_t j = 0; j< batchSize; j++){
-              // skip any empty segments
-              if (def_lvl[j] == 1)
-                continue;
-              
-              // Null values treated as NaN
-              if (def_lvl[j] == 2) {
-                chpl_ptr[i+val_idx] = NAN;
-                tmp_offset++; // adjustment for values array since Nulls are not included
-              }
-              else if (def_lvl[j] == 3){ // defined value to write
-                chpl_ptr[i+val_idx] = (double)tmpArr[val_idx-tmp_offset];
-              }
-              val_idx++;
+          while (reader->HasNext() && arrayIdx < numElems) {
+            (void)reader->ReadBatch(1, &definition_level, nullptr, &chpl_ptr[arrayIdx], &values_read);
+            // if values_read is 0, that means that it was a null value
+            if (values_read != 0) {
+              arrayIdx++;
             }
-
-            i += values_read + tmp_offset; // account for values and NaNs, but not empty segments
-
-            delete[] tmpArr;
-            delete[] def_lvl;
-            delete[] rep_lvl;
+            else {
+              // check if nan otherwise just treat as empty seg
+              if (definition_level == 2) {
+                chpl_ptr[arrayIdx] = NAN;
+                arrayIdx++;
+              }
+            }
+            i++;
           }
-        }
+        } 
+
+          // while (reader->HasNext() && i < numElems) {
+          //   if((numElems - i) < batchSize) // adjust batchSize if needed
+          //     batchSize = numElems - i;
+          //   double* tmpArr = new double[batchSize]; // NaNs not included here
+          //   int16_t* def_lvl = new int16_t[batchSize];
+          //   int16_t* rep_lvl = new int16_t[batchSize];
+          //   (void)reader->ReadBatch(batchSize, def_lvl, rep_lvl, tmpArr, &values_read);
+            
+          //   int64_t tmp_offset = 0; // used to properly access tmp after NaN encountered
+          //   int64_t val_idx = 0;
+          //   for (int64_t j = 0; j< batchSize; j++){
+          //     // skip any empty segments
+          //     if (def_lvl[j] == 1)
+          //       continue;
+              
+          //     // Null values treated as NaN
+          //     if (def_lvl[j] == 2) {
+          //       chpl_ptr[i+val_idx] = NAN;
+          //       tmp_offset++; // adjustment for values array since Nulls are not included
+          //     }
+          //     else if (def_lvl[j] == 3){ // defined value to write
+          //       chpl_ptr[i+val_idx] = (double)tmpArr[val_idx-tmp_offset];
+          //     }
+          //     val_idx++;
+          //   }
+
+          //   i += values_read + tmp_offset; // account for values and NaNs, but not empty segments
+
+          //   delete[] tmpArr;
+          //   delete[] def_lvl;
+          //   delete[] rep_lvl;
+          // }
+        // }
       }
       return 0;
     }

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -614,8 +614,10 @@ class ParquetTest(ArkoudaTest):
                 file_path = f"{tmp_dirname}/empty_segs"
                 pddf.to_parquet(file_path)
                 akdf = ak.DataFrame(ak.read_parquet(file_path))
+                pddupe = pd.DataFrame(pd.read_parquet(file_path))
 
                 to_pd = pd.Series(akdf["rand"].values.to_list())
+                pddupe_series = pd.Series(pddupe["rand"].values)
                 # raises an error if the two series aren't equal
                 # we can't use np.allclose(pddf['rand'].to_list, akdf['rand'].to_list) since these
                 # are lists of lists. assert_series_equal handles this and properly handles nans.
@@ -628,6 +630,11 @@ class ParquetTest(ArkoudaTest):
                 print("pddf['rand'][263047]: ", pddf['rand'][263047])
                 print("akdf['rand'][263047]: ", akdf['rand'][263047])
                 print("to_pd[263047]: ", to_pd[263047])
+                print()
+                print("pddupe['rand'][263047]: ", pddupe['rand'][263047])
+                print("pddupe_series[263047]: ", pddupe_series[263047])
+                assert_series_equal(pddf['rand'], pddupe_series, check_names=False, rtol=1e-05, atol=1e-08)
+                assert_series_equal(pddf['rand'], pddupe['rand'], check_names=False, rtol=1e-05, atol=1e-08)
                 assert_series_equal(pddf['rand'], to_pd, check_names=False, rtol=1e-05, atol=1e-08)
 
     @pytest.mark.optional_parquet

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -589,15 +589,16 @@ class ParquetTest(ArkoudaTest):
         val_size = 1000000
 
         df_dict = dict()
-        seed = np.random.default_rng().choice(2**63)
+        # seed = np.random.default_rng().choice(2**63)
+        seed = 9219146137719780068
         rng = ak.random.default_rng(seed)
         some_nans = rng.uniform(-(2 ** 10), 2 ** 10, val_size)
         some_nans[ak.arange(val_size) % 2 == 0] = np.nan
         vals_list = [
-            rng.uniform(-(2**10), 2**10, val_size),
-            rng.integers(0, 2**32, size=val_size, dtype="uint"),
-            rng.integers(0, 1, size=val_size, dtype="bool"),
-            rng.integers(-(2**32), 2**32, size=val_size, dtype="int"),
+            # rng.uniform(-(2**10), 2**10, val_size),
+            # rng.integers(0, 2**32, size=val_size, dtype="uint"),
+            # rng.integers(0, 1, size=val_size, dtype="bool"),
+            # rng.integers(-(2**32), 2**32, size=val_size, dtype="int"),
             some_nans,
         ]
 
@@ -605,7 +606,7 @@ class ParquetTest(ArkoudaTest):
             # segs must start with 0, all other segment lengths are random
             # by having val_size number of segments, except in the extremely unlikely case of
             # randomly getting exactly arange(val_size), we are guaranteed empty segs
-            segs = ak.concatenate([ak.array([0]), ak.sort(ak.randint(0, val_size, val_size - 1))])
+            segs = ak.concatenate([ak.array([0]), ak.sort(ak.randint(0, val_size, val_size - 1, seed=seed))])
             df_dict["rand"] = ak.SegArray(segs, vals).to_list()
 
             pddf = pd.DataFrame(df_dict)

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -626,6 +626,7 @@ class ParquetTest(ArkoudaTest):
                 print("pd version: ", pd.__version__)
                 print()
                 print("pddf['rand'][263047]: ", pddf['rand'][263047])
+                print("akdf['rand'][263047]: ", akdf['rand'][263047])
                 print("to_pd[263047]: ", to_pd[263047])
                 assert_series_equal(pddf['rand'], to_pd, check_names=False, rtol=1e-05, atol=1e-08)
 

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -622,6 +622,11 @@ class ParquetTest(ArkoudaTest):
                 # we pass the same absolute and relative tolerances as the numpy default in allclose
                 # to ensure float point differences don't cause errors
                 print("\nseed: ", seed)
+                print("np version: ", np.__version__)
+                print("pd version: ", pd.__version__)
+                print()
+                print("pddf['rand'][263047]: ", pddf['rand'][263047])
+                print("to_pd[263047]: ", to_pd[263047])
                 assert_series_equal(pddf['rand'], to_pd, check_names=False, rtol=1e-05, atol=1e-08)
 
     @pytest.mark.optional_parquet

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -589,12 +589,16 @@ class ParquetTest(ArkoudaTest):
         val_size = 1000000
 
         df_dict = dict()
-        rng = ak.random.default_rng()
+        seed = np.random.default_rng().choice(2**63)
+        rng = ak.random.default_rng(seed)
+        some_nans = rng.uniform(-(2 ** 10), 2 ** 10, val_size)
+        some_nans[ak.arange(val_size) % 2 == 0] = np.nan
         vals_list = [
             rng.uniform(-(2**10), 2**10, val_size),
             rng.integers(0, 2**32, size=val_size, dtype="uint"),
             rng.integers(0, 1, size=val_size, dtype="bool"),
             rng.integers(-(2**32), 2**32, size=val_size, dtype="int"),
+            some_nans,
         ]
 
         for vals in vals_list:
@@ -616,6 +620,7 @@ class ParquetTest(ArkoudaTest):
                 # are lists of lists. assert_series_equal handles this and properly handles nans.
                 # we pass the same absolute and relative tolerances as the numpy default in allclose
                 # to ensure float point differences don't cause errors
+                print("\nseed: ", seed)
                 assert_series_equal(pddf['rand'], to_pd, check_names=False, rtol=1e-05, atol=1e-08)
 
     @pytest.mark.optional_parquet

--- a/tests/parquet_test.py
+++ b/tests/parquet_test.py
@@ -586,19 +586,21 @@ class ParquetTest(ArkoudaTest):
 
     def test_empty_segs_segarray(self):
         # verify reproducer for #3074 is resolved
+
+        # bug seemed to consistently appear for val_sizes
+        # exceeding 700000, round up to ensure we'd hit it
         val_size = 1000000
 
         df_dict = dict()
-        # seed = np.random.default_rng().choice(2**63)
-        seed = 9219146137719780068
+        seed = np.random.default_rng().choice(2**63)
         rng = ak.random.default_rng(seed)
-        some_nans = rng.uniform(-(2 ** 10), 2 ** 10, val_size)
+        some_nans = rng.uniform(-(2**10), 2**10, val_size)
         some_nans[ak.arange(val_size) % 2 == 0] = np.nan
         vals_list = [
-            # rng.uniform(-(2**10), 2**10, val_size),
-            # rng.integers(0, 2**32, size=val_size, dtype="uint"),
-            # rng.integers(0, 1, size=val_size, dtype="bool"),
-            # rng.integers(-(2**32), 2**32, size=val_size, dtype="int"),
+            rng.uniform(-(2**10), 2**10, val_size),
+            rng.integers(0, 2**32, size=val_size, dtype="uint"),
+            rng.integers(0, 1, size=val_size, dtype="bool"),
+            rng.integers(-(2**32), 2**32, size=val_size, dtype="int"),
             some_nans,
         ]
 
@@ -606,7 +608,9 @@ class ParquetTest(ArkoudaTest):
             # segs must start with 0, all other segment lengths are random
             # by having val_size number of segments, except in the extremely unlikely case of
             # randomly getting exactly arange(val_size), we are guaranteed empty segs
-            segs = ak.concatenate([ak.array([0]), ak.sort(ak.randint(0, val_size, val_size - 1, seed=seed))])
+            segs = ak.concatenate(
+                [ak.array([0]), ak.sort(ak.randint(0, val_size, val_size - 1, seed=seed))]
+            )
             df_dict["rand"] = ak.SegArray(segs, vals).to_list()
 
             pddf = pd.DataFrame(df_dict)
@@ -614,28 +618,15 @@ class ParquetTest(ArkoudaTest):
                 file_path = f"{tmp_dirname}/empty_segs"
                 pddf.to_parquet(file_path)
                 akdf = ak.DataFrame(ak.read_parquet(file_path))
-                pddupe = pd.DataFrame(pd.read_parquet(file_path))
 
                 to_pd = pd.Series(akdf["rand"].values.to_list())
-                pddupe_series = pd.Series(pddupe["rand"].values)
                 # raises an error if the two series aren't equal
                 # we can't use np.allclose(pddf['rand'].to_list, akdf['rand'].to_list) since these
                 # are lists of lists. assert_series_equal handles this and properly handles nans.
                 # we pass the same absolute and relative tolerances as the numpy default in allclose
                 # to ensure float point differences don't cause errors
                 print("\nseed: ", seed)
-                print("np version: ", np.__version__)
-                print("pd version: ", pd.__version__)
-                print()
-                print("pddf['rand'][263047]: ", pddf['rand'][263047])
-                print("akdf['rand'][263047]: ", akdf['rand'][263047])
-                print("to_pd[263047]: ", to_pd[263047])
-                print()
-                print("pddupe['rand'][263047]: ", pddupe['rand'][263047])
-                print("pddupe_series[263047]: ", pddupe_series[263047])
-                assert_series_equal(pddf['rand'], pddupe_series, check_names=False, rtol=1e-05, atol=1e-08)
-                assert_series_equal(pddf['rand'], pddupe['rand'], check_names=False, rtol=1e-05, atol=1e-08)
-                assert_series_equal(pddf['rand'], to_pd, check_names=False, rtol=1e-05, atol=1e-08)
+                assert_series_equal(pddf["rand"], to_pd, check_names=False, rtol=1e-05, atol=1e-08)
 
     @pytest.mark.optional_parquet
     def test_against_standard_files(self):


### PR DESCRIPTION
Fixes #3234 

We found some odd behavior with the existing implementation, so I've opted not to squash my commits in order to make it easier to reproduce in case we want to dig into it more. With a set seed running the same code and versions, it seemed to consistently pass on arm64 macs and fail on x86 linux machines. It not immediately obvious what about the implementation was causing this seemingly architecture specific failure

To sidestep this, I opted for simpler single batch read logic for float/double segarrays. This will be slower but obviously correctness is most important. This is the latest in a string of read logic that I've changed to be single batched, so it might be worth revisiting in the future to see if we can reenable batch reads