### PR TITLE
Fixing a missing `iloc` usage

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -6248,7 +6248,7 @@ def _inner_join_merge(
         new_dict[new_col] = left[col].iloc[left_inds]
     for col in right_cols:
         new_col = col + right_suffix if col in col_intersect else col
-        new_dict[new_col] = right[col][right_inds]
+        new_dict[new_col] = right[col].iloc[right_inds]
 
     ret_df = DataFrame(new_dict)
     if sort is True:


### PR DESCRIPTION
Some of our tests were timing out during the DataFrame tests. I believe it to be caused by the missing `iloc` fixed here. On my mac, for the gasnet + asan configuration, the test was hanging and now completes.

