### PR TITLE
Closes #3246 update norecursedirs parameter in pytest_PROTO.ini

### DIFF
--- a/pytest_PROTO.ini
+++ b/pytest_PROTO.ini
@@ -47,6 +47,7 @@ norecursedirs =
     tests/deprecated/*
     OLD_tests
     benchmark*
+    tests*
 python_functions =
     test_*
 ;    bench_*


### PR DESCRIPTION
Closes #3246 update norecursedirs parameter in pytest_PROTO.ini

This adds `test*` to the norecursedirs parameter in pytest_PROTO.ini.