### PR TITLE
Remove single-column cases from multi-col-merge test. 

### DIFF
--- a/PROTO_tests/tests/dataframe_test.py
+++ b/PROTO_tests/tests/dataframe_test.py
@@ -1016,9 +1016,6 @@ class TestDataFrame:
 
             for how in "inner", "left", "right":
                 for on in (
-                    "first",
-                    "second",
-                    "third",
                     ["first", "third"],
                     ["second", "third"],
                     None,

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -1452,7 +1452,7 @@ class DataFrameTest(ArkoudaTest):
             l_pd, r_pd = left_df.to_pandas(), right_df.to_pandas()
 
             for how in "inner", "left", "right", "outer":
-                for on in "first", "second", "third", ["first", "third"], ["second", "third"], None:
+                for on in ["first", "third"], ["second", "third"], None:
                     ak_merge = ak.merge(left_df, right_df, on=on, how=how)
                     pd_merge = pd.merge(l_pd, r_pd, on=on, how=how)
 


### PR DESCRIPTION
The single-column cases are handled by `test_merge`, so I removed them from `test_multi_col_merge`. This should improve overall test duration, as `test_multi_col_merge` is far and away the longest test case. On my mac, the test went from ~5 minutes to ~2.