### PR TITLE
Closes #3249: Fix issue with finding incorrect conftest file for proto tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -529,7 +529,7 @@ test-python:
 
 size=100
 test-python-proto:
-	python3 -m pytest -c pytest_PROTO.ini --size=$(size) $(ARKOUDA_PYTEST_OPTIONS)
+	python3 -m pytest -c pytest_PROTO.ini PROTO_tests/ --size=$(size) $(ARKOUDA_PYTEST_OPTIONS)
 
 CLEAN_TARGETS += test-clean
 .PHONY: test-clean


### PR DESCRIPTION
In certain environments, pytest was finding the incorrect version of the conftest when running the proto tests. Adding the directory explicitly to the proto test call fixes this issue.

Closes #3249 