### PR TITLE
Closes #3245: Add `poisson` distribution to random number generators

### DIFF
--- a/PROTO_tests/tests/random_test.py
+++ b/PROTO_tests/tests/random_test.py
@@ -1,3 +1,5 @@
+from collections import Counter
+
 import numpy as np
 import pytest
 from scipy import stats as sp_stats
@@ -128,31 +130,6 @@ class TestRandom:
         assert all(bounded_arr.to_ndarray() >= -5)
         assert all(bounded_arr.to_ndarray() < 5)
 
-    def test_choice_hypothesis_testing(self):
-        # perform a weighted sample and use chisquare to test
-        # if the observed frequency matches the expected frequency
-
-        # I tested this many times without a set seed, but with no seed
-        # it's expected to fail one out of every ~20 runs given a pval limit of 0.05.
-        rng = ak.random.default_rng(43)
-        num_samples = 10**4
-
-        weights = ak.array([0.25, 0.15, 0.20, 0.10, 0.30])
-        weighted_sample = rng.choice(ak.arange(5), size=num_samples, p=weights)
-
-        # count how many of each category we saw
-        uk, f_obs = ak.GroupBy(weighted_sample).size()
-
-        # I think the keys should always be sorted but just in case
-        if not ak.is_sorted(uk):
-            f_obs = f_obs[ak.argsort(uk)]
-
-        f_exp = weights * num_samples
-        _, pval = akchisquare(f_obs=f_obs, f_exp=f_exp)
-
-        # if pval <= 0.05, the difference from the expected distribution is significant
-        assert pval > 0.05
-
     def test_choice(self):
         # verify without replacement works
         rng = ak.random.default_rng()
@@ -223,6 +200,47 @@ class TestRandom:
             == both_array
         )
 
+    def test_poissson(self):
+        rng = ak.random.default_rng(17)
+        num_samples = 5
+        # scalar lambda
+        scal_lam = 2
+        scal_sample = rng.poisson(lam=scal_lam, size=num_samples).to_list()
+
+        # array lambda
+        arr_lam = ak.arange(5)
+        arr_sample = rng.poisson(lam=arr_lam, size=num_samples).to_list()
+
+        # reset rng with same seed and ensure we get same results
+        rng = ak.random.default_rng(17)
+        assert rng.poisson(lam=scal_lam, size=num_samples).to_list() == scal_sample
+        assert rng.poisson(lam=arr_lam, size=num_samples).to_list() == arr_sample
+
+    def test_choice_hypothesis_testing(self):
+        # perform a weighted sample and use chisquare to test
+        # if the observed frequency matches the expected frequency
+
+        # I tested this many times without a set seed, but with no seed
+        # it's expected to fail one out of every ~20 runs given a pval limit of 0.05.
+        rng = ak.random.default_rng(43)
+        num_samples = 10**4
+
+        weights = ak.array([0.25, 0.15, 0.20, 0.10, 0.30])
+        weighted_sample = rng.choice(ak.arange(5), size=num_samples, p=weights)
+
+        # count how many of each category we saw
+        uk, f_obs = ak.GroupBy(weighted_sample).size()
+
+        # I think the keys should always be sorted but just in case
+        if not ak.is_sorted(uk):
+            f_obs = f_obs[ak.argsort(uk)]
+
+        f_exp = weights * num_samples
+        _, pval = akchisquare(f_obs=f_obs, f_exp=f_exp)
+
+        # if pval <= 0.05, the difference from the expected distribution is significant
+        assert pval > 0.05
+
     def test_normal_hypothesis_testing(self):
         # I tested this many times without a set seed, but with no seed
         # it's expected to fail one out of every ~20 runs given a pval limit of 0.05.
@@ -245,6 +263,33 @@ class TestRandom:
             sp_stats.norm, sample_list, known_params={"loc": mean, "scale": deviation}
         )
         assert good_fit_res.pvalue > 0.05
+
+    def test_poisson_hypothesis_testing(self):
+        # I tested this many times without a set seed, but with no seed
+        # it's expected to fail one out of every ~20 runs given a pval limit of 0.05.
+        rng = ak.random.default_rng()
+        num_samples = 10**4
+        lam = rng.uniform(0, 10)
+
+        sample = rng.poisson(lam=lam, size=num_samples)
+        count_dict = Counter(sample.to_list())
+
+        # the sum of exp freq must be within 1e-08, so use the cdf to find out how many
+        # elements we need to ensure we're within that tolerance
+        tol = 1e-09
+        num_elems = 5
+        while (1 - sp_stats.poisson.cdf(num_elems, mu=lam)) > tol:
+            num_elems += 5
+
+        obs_counts = np.array([0] * num_elems)
+        for k, v in count_dict.items():
+            obs_counts[k] = v
+
+        # use the probability mass function to get the probability of seeing each value
+        # and multiply by num_samples to get the expected counts
+        exp_counts = np.array([sp_stats.poisson.pmf(v, mu=lam) for v in range(num_elems)]) * num_samples
+        _, pval = sp_stats.chisquare(f_obs=obs_counts, f_exp=exp_counts)
+        assert pval > 0.05
 
     def test_legacy_randint(self):
         testArray = ak.random.randint(0, 10, 5)

--- a/PROTO_tests/tests/random_test.py
+++ b/PROTO_tests/tests/random_test.py
@@ -267,7 +267,7 @@ class TestRandom:
     def test_poisson_hypothesis_testing(self):
         # I tested this many times without a set seed, but with no seed
         # it's expected to fail one out of every ~20 runs given a pval limit of 0.05.
-        rng = ak.random.default_rng()
+        rng = ak.random.default_rng(43)
         num_samples = 10**4
         lam = rng.uniform(0, 10)
 

--- a/PROTO_tests/tests/random_test.py
+++ b/PROTO_tests/tests/random_test.py
@@ -287,7 +287,7 @@ class TestRandom:
 
         # use the probability mass function to get the probability of seeing each value
         # and multiply by num_samples to get the expected counts
-        exp_counts = np.array([sp_stats.poisson.pmf(v, mu=lam) for v in range(num_elems)]) * num_samples
+        exp_counts = sp_stats.poisson.pmf(range(num_elems), mu=lam) * num_samples
         _, pval = sp_stats.chisquare(f_obs=obs_counts, f_exp=exp_counts)
         assert pval > 0.05
 

--- a/pydoc/usage/random.rst
+++ b/pydoc/usage/random.rst
@@ -33,6 +33,10 @@ permutation
 ---------
 .. autofunction:: arkouda.random.Generator.permutation
 
+poisson
+---------
+.. autofunction:: arkouda.random.Generator.poisson
+
 shuffle
 ---------
 .. autofunction:: arkouda.random.Generator.shuffle

--- a/src/RandMsg.chpl
+++ b/src/RandMsg.chpl
@@ -10,6 +10,7 @@ module RandMsg
     use Logging;
     use Message;
     use RandArray;
+    use Unique;
     use CommAggregation;
     
     use MultiTypeSymbolTable;
@@ -547,6 +548,101 @@ module RandMsg
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 
+    proc poissonGeneratorMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        const pn = Reflection.getRoutineName(),
+              name = msgArgs.getValueOf("name"),                                // generator name
+              isSingleLam = msgArgs.get("is_single_lambda").getBoolValue(),     // boolean indicated if lambda is a single value or array
+              lamStr = msgArgs.getValueOf("lam"),                               // lambda for poisson distribution
+              size = msgArgs.get("size").getIntValue(),                         // number of values to be generated
+              state = msgArgs.get("state").getIntValue(),                       // rng state
+              rname = st.nextName();
+
+
+        randLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                                "name: %? size %i isSingleLam %? lamStr %? state %i".doFormat(name, size, isSingleLam, lamStr, state));
+
+        st.checkTable(name);
+
+        var generatorEntry: borrowed GeneratorSymEntry(real) = toGeneratorSymEntry(st.lookup(name), real);
+        ref rng = generatorEntry.generator;
+        if state != 1 {
+            // you have to skip to one before where you want to be
+            rng.skipTo(state-1);
+        }
+
+        // uses the algorithm from knuth found here:
+        // https://en.wikipedia.org/wiki/Poisson_distribution#Random_variate_generation
+        // generates values drawn from poisson distribution using a stream of uniformly distributed random numbers
+
+        const nTasksPerLoc = here.maxTaskPar; // tasks per locale based on locale0
+        const Tasks = {0..#nTasksPerLoc}; // these need to be const for comms/performance reasons
+
+        const generatorSeed = (rng.next() * 2**62):int;
+        var poissonArr = makeDistArray(size, int);
+
+        // I hate the code duplication here but it's not immediately obvious to me how to avoid it
+        if isSingleLam {
+            const lam = lamStr:real;
+            // using nested coforall over locales and tasks so we know how to generate taskSeed
+            for loc in Locales do on loc {
+                const generatorIdxOffset = here.id * nTasksPerLoc,
+                    locSubDom = poissonArr.localSubdomain(),  // the chunk that this locale needs to handle
+                    indicesPerTask = locSubDom.size / nTasksPerLoc;  // the number of elements each task needs to handle
+
+                coforall tid in Tasks {
+                    const taskSeed = generatorSeed + generatorIdxOffset + tid,  // initial seed offset by other locales threads plus current thread id
+                        startIdx = tid * indicesPerTask,
+                        stopIdx = if tid == nTasksPerLoc - 1 then locSubDom.size else (tid + 1) * indicesPerTask;  // the last task picks up the remainder of indices
+                    var rs = new randomStream(real, taskSeed);
+                    for i in startIdx..<stopIdx {
+                        var L = exp(-lam);
+                        var k = 0;
+                        var p = 1.0;
+
+                        do {
+                            k += 1;
+                            p = p * rs.next(0, 1);
+                        } while p > L;
+                        poissonArr[locSubDom.low + i] = k - 1;
+                    }
+                }
+            }
+        }
+        else {
+            st.checkTable(lamStr);
+            const lamArr = toSymEntry(getGenericTypedArrayEntry(lamStr, st),real).a;
+            // using nested coforall over locales and task so we know exactly how many generators we need
+            for loc in Locales do on loc {
+                const generatorIdxOffset = here.id * nTasksPerLoc,
+                    locSubDom = poissonArr.localSubdomain(),  // the chunk that this locale needs to handle
+                    indicesPerTask = locSubDom.size / nTasksPerLoc;  // the number of elements each task needs to handle
+
+                coforall tid in Tasks {
+                    const taskSeed = generatorSeed + generatorIdxOffset + tid,
+                        startIdx = tid * indicesPerTask,
+                        stopIdx = if tid == nTasksPerLoc - 1 then locSubDom.size else (tid + 1) * indicesPerTask;  // the last task picks up the remainder of indices
+                    var rs = new randomStream(real, taskSeed);
+                    for i in startIdx..<stopIdx {
+                        const lam = lamArr[locSubDom.low + i];
+                        var L = exp(-lam);
+                        var k = 0;
+                        var p = 1.0;
+
+                        do {
+                            k += 1;
+                            p = p * rs.next(0, 1);
+                        } while p > L;
+                        poissonArr[locSubDom.low + i] = k - 1;
+                    }
+                }
+            }
+        }
+        st.addEntry(rname, createSymEntry(poissonArr));
+        const repMsg = "created " + st.attrib(rname);
+        randLogger.debug(getModuleName(),pn,getLineNumber(),repMsg);
+        return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+
     proc shuffleMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         const pn = Reflection.getRoutineName();
         const name = msgArgs.getValueOf("name");
@@ -606,5 +702,6 @@ module RandMsg
     registerFunction("segmentedSample", segmentedSampleMsg, getModuleName());
     registerFunction("choice", choiceMsg, getModuleName());
     registerFunction("permutation", permutationMsg, getModuleName());
+    registerFunction("poissonGenerator", poissonGeneratorMsg, getModuleName());
     registerFunction("shuffle", shuffleMsg, getModuleName());
 }

--- a/src/RandMsg.chpl
+++ b/src/RandMsg.chpl
@@ -10,7 +10,6 @@ module RandMsg
     use Logging;
     use Message;
     use RandArray;
-    use Unique;
     use CommAggregation;
     
     use MultiTypeSymbolTable;

--- a/src/compat/e-132/ArkoudaRandomCompat.chpl
+++ b/src/compat/e-132/ArkoudaRandomCompat.chpl
@@ -38,6 +38,7 @@ module ArkoudaRandomCompat {
       return x[idx];
     }
     proc ref next(): eltType do return r.getNext();
+    proc ref next(min: eltType, max: eltType): eltType do return r.getNext(min, max);
     proc skipTo(n: int) do try! r.skipToNth(n);
   }
 

--- a/src/compat/eq-131/ArkoudaRandomCompat.chpl
+++ b/src/compat/eq-131/ArkoudaRandomCompat.chpl
@@ -38,6 +38,7 @@ module ArkoudaRandomCompat {
       return x[idx];
     }
     proc ref next(): eltType do return r.getNext();
+    proc ref next(min: eltType, max: eltType): eltType do return r.getNext(min, max);
     proc skipTo(n: int) do try! r.skipToNth(n);
   }
 

--- a/src/compat/eq-133/ArkoudaRandomCompat.chpl
+++ b/src/compat/eq-133/ArkoudaRandomCompat.chpl
@@ -26,6 +26,7 @@ module ArkoudaRandomCompat {
       return x[idx];
     }
   proc ref randomStream.next() do return this.getNext();
+  proc ref randomStream.next(min: eltType, max: eltType): eltType do return r.getNext(min, max);
 
   proc choiceUniform(ref stream, X: domain(?), size: ?sizeType, replace: bool) throws
   {

--- a/src/compat/eq-133/ArkoudaRandomCompat.chpl
+++ b/src/compat/eq-133/ArkoudaRandomCompat.chpl
@@ -26,7 +26,7 @@ module ArkoudaRandomCompat {
       return x[idx];
     }
   proc ref randomStream.next() do return this.getNext();
-  proc ref randomStream.next(min: eltType, max: eltType): eltType do return r.getNext(min, max);
+  proc ref randomStream.next(min: eltType, max: eltType): eltType do return this.getNext(min, max);
 
   proc choiceUniform(ref stream, X: domain(?), size: ?sizeType, replace: bool) throws
   {

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -294,7 +294,7 @@ class RandomTest(ArkoudaTest):
 
         # use the probability mass function to get the probability of seeing each value
         # and multiply by num_samples to get the expected counts
-        exp_counts = np.array([sp_stats.poisson.pmf(v, mu=lam) for v in range(num_elems)]) * num_samples
+        exp_counts = sp_stats.poisson.pmf(range(num_elems), mu=lam) * num_samples
         _, pval = sp_stats.chisquare(f_obs=obs_counts, f_exp=exp_counts)
         self.assertTrue(pval > 0.05)
 

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -274,7 +274,7 @@ class RandomTest(ArkoudaTest):
     def test_poisson_hypothesis_testing(self):
         # I tested this many times without a set seed, but with no seed
         # it's expected to fail one out of every ~20 runs given a pval limit of 0.05.
-        rng = ak.random.default_rng()
+        rng = ak.random.default_rng(43)
         num_samples = 10**4
         lam = rng.uniform(0, 10)
 

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -1,3 +1,5 @@
+from collections import Counter
+
 import numpy as np
 from base_test import ArkoudaTest
 from context import arkouda as ak
@@ -130,31 +132,6 @@ class RandomTest(ArkoudaTest):
         self.assertTrue(all(bounded_arr.to_ndarray() >= -5))
         self.assertTrue(all(bounded_arr.to_ndarray() < 5))
 
-    def test_choice_hypothesis_testing(self):
-        # perform a weighted sample and use chisquare to test
-        # if the observed frequency matches the expected frequency
-
-        # I tested this many times without a set seed, but with no seed
-        # it's expected to fail one out of every ~20 runs given a pval limit of 0.05
-        rng = ak.random.default_rng(43)
-        num_samples = 10**4
-
-        weights = ak.array([0.25, 0.15, 0.20, 0.10, 0.30])
-        weighted_sample = rng.choice(ak.arange(5), size=num_samples, p=weights)
-
-        # count how many of each category we saw
-        uk, f_obs = ak.GroupBy(weighted_sample).size()
-
-        # I think the keys should always be sorted but just in case
-        if not ak.is_sorted(uk):
-            f_obs = f_obs[ak.argsort(uk)]
-
-        f_exp = weights * num_samples
-        _, pval = akchisquare(f_obs=f_obs, f_exp=f_exp)
-
-        # if pval <= 0.05, the difference from the expected distribution is significant
-        self.assertTrue(pval > 0.05)
-
     def test_choice(self):
         # verify without replacement works
         rng = ak.random.default_rng()
@@ -230,6 +207,47 @@ class RandomTest(ArkoudaTest):
             both_array,
         )
 
+    def test_poissson(self):
+        rng = ak.random.default_rng(17)
+        num_samples = 5
+        # scalar lambda
+        scal_lam = 2
+        scal_sample = rng.poisson(lam=scal_lam, size=num_samples).to_list()
+
+        # array lambda
+        arr_lam = ak.arange(5)
+        arr_sample = rng.poisson(lam=arr_lam, size=num_samples).to_list()
+
+        # reset rng with same seed and ensure we get same results
+        rng = ak.random.default_rng(17)
+        self.assertEqual(rng.poisson(lam=scal_lam, size=num_samples).to_list(), scal_sample)
+        self.assertEqual(rng.poisson(lam=arr_lam, size=num_samples).to_list(), arr_sample)
+
+    def test_choice_hypothesis_testing(self):
+        # perform a weighted sample and use chisquare to test
+        # if the observed frequency matches the expected frequency
+
+        # I tested this many times without a set seed, but with no seed
+        # it's expected to fail one out of every ~20 runs given a pval limit of 0.05
+        rng = ak.random.default_rng(43)
+        num_samples = 10**4
+
+        weights = ak.array([0.25, 0.15, 0.20, 0.10, 0.30])
+        weighted_sample = rng.choice(ak.arange(5), size=num_samples, p=weights)
+
+        # count how many of each category we saw
+        uk, f_obs = ak.GroupBy(weighted_sample).size()
+
+        # I think the keys should always be sorted but just in case
+        if not ak.is_sorted(uk):
+            f_obs = f_obs[ak.argsort(uk)]
+
+        f_exp = weights * num_samples
+        _, pval = akchisquare(f_obs=f_obs, f_exp=f_exp)
+
+        # if pval <= 0.05, the difference from the expected distribution is significant
+        self.assertTrue(pval > 0.05)
+
     def test_normal_hypothesis_testing(self):
         # I tested this many times without a set seed, but with no seed
         # it's expected to fail one out of every ~20 runs given a pval limit of 0.05.
@@ -252,6 +270,33 @@ class RandomTest(ArkoudaTest):
             sp_stats.norm, sample_list, known_params={"loc": mean, "scale": deviation}
         )
         self.assertTrue(good_fit_res.pvalue > 0.05)
+
+    def test_poisson_hypothesis_testing(self):
+        # I tested this many times without a set seed, but with no seed
+        # it's expected to fail one out of every ~20 runs given a pval limit of 0.05.
+        rng = ak.random.default_rng()
+        num_samples = 10**4
+        lam = rng.uniform(0, 10)
+
+        sample = rng.poisson(lam=lam, size=num_samples)
+        count_dict = Counter(sample.to_list())
+
+        # the sum of exp freq must be within 1e-08, so use the cdf to find out how many
+        # elements we need to ensure we're within that tolerance
+        tol = 1e-09
+        num_elems = 5
+        while (1 - sp_stats.poisson.cdf(num_elems, mu=lam)) > tol:
+            num_elems += 5
+
+        obs_counts = np.array([0] * num_elems)
+        for k, v in count_dict.items():
+            obs_counts[k] = v
+
+        # use the probability mass function to get the probability of seeing each value
+        # and multiply by num_samples to get the expected counts
+        exp_counts = np.array([sp_stats.poisson.pmf(v, mu=lam) for v in range(num_elems)]) * num_samples
+        _, pval = sp_stats.chisquare(f_obs=obs_counts, f_exp=exp_counts)
+        self.assertTrue(pval > 0.05)
 
     def test_legacy_randint(self):
         testArray = ak.random.randint(0, 10, 5)


### PR DESCRIPTION
This PR (closes #3245) adds the `poisson` distribution to random number generators. This also adds the docs and testing including hypothesis testing against the probabilities expected from the poisson probability mass function. This PR does a coforall over the locals and tasks so I can ensure each task gets a unique seed that is reproducable

I also moved one of the other hypothesis tests so they are all together