### PR TITLE
Fixes #3252: proto `test_segarray_read` failure with multi-locale

### DIFF
--- a/PROTO_tests/tests/io_test.py
+++ b/PROTO_tests/tests/io_test.py
@@ -405,7 +405,7 @@ class TestParquet:
                             for li in lists
                         ]
                     )
-                    concat_segarr.to_parquet(file_name, "test-dset", compression=comp)
+                    concat_segarr.to_parquet(file_name, "ListCol", compression=comp)
                 else:
                     # when single locale artifically create multiple files
                     for i in range(NUM_FILES):


### PR DESCRIPTION
This PR (fixes #3252) fixes an incorrect dataset name which was causing failures when ran with multiple locales