### PR TITLE
3231 unique unit tests

### DIFF
--- a/PROTO_tests/tests/groupby_test.py
+++ b/PROTO_tests/tests/groupby_test.py
@@ -732,14 +732,12 @@ class TestGroupBy:
         # should just be list(range(len(nda))), and the indices will be
         # exactly what the list method returns as the first index
 
-        srange = np.array(list(range(len(nda))))
-        check1 = np.all(srange == ak_TTF[1].to_ndarray())
+        srange = np.arange(len(nda))
+        assert(np.all(srange == ak_TTF[1].to_ndarray()))
         indices = ak_TTF[2]
-        check2 = T
         nda_list = list(s_nda)
         for i in range(len(indices)):
-            check2 = check2 and indices[i] == nda_list.index(np_unique[i])
-        assert check1 and check2
+            assert(indices[i] == nda_list.index(np_unique[i]))
 
         # for unsorted data, a bit more work is required.  A reordered
         # copy of the pdarray is created based on the returned permutation,

--- a/PROTO_tests/tests/groupby_test.py
+++ b/PROTO_tests/tests/groupby_test.py
@@ -733,32 +733,19 @@ class TestGroupBy:
         # exactly what the list method returns as the first index
 
         srange = np.arange(len(nda))
-        assert(np.all(srange == ak_TTF[1].to_ndarray()))
+        assert np.all(srange == ak_TTF[1].to_ndarray())
         indices = ak_TTF[2]
-        nda_list = list(s_nda)
-        for i in range(len(indices)):
-            assert(indices[i] == nda_list.index(np_unique[i]))
+        assert ak.all(s_pda == ak.broadcast(indices, ak_TTF[0], len(s_nda)))
 
-        # for unsorted data, a bit more work is required.  A reordered
-        # copy of the pdarray is created based on the returned permutation,
-        # and the indices are used to confirm that elements within a segment
-        # match.
+        # for unsorted data, a reordered copy of the pdarray is created
+        # based on the returned permutation, and the indices are used to
+        # confirm that elements within a segment match.
 
         aku = ak.unique(us_pda).to_ndarray()
-        reordering = ak_TFF[1].to_ndarray()
-        reordered = [nda[i] for i in reordering]
+        reordering = ak_TFF[1]
+        reordered = us_pda[reordering]
         indices = ak_TFF[2]
-        checker = True
-        for j in range(len(aku)):
-            if j < len(aku) - 1:
-                checker = checker and np.all(
-                    [reordered[i] == aku[j] for i in range(indices[j], indices[j + 1])]
-                )
-            else:
-                checker = checker and np.all(
-                    [reordered[i] == aku[j] for i in range(indices[j], len(aku))]
-                )
-        assert checker
+        assert ak.all(reordered == ak.broadcast(indices, ak_TFF[0], len(nda)))
 
     def test_unique_aggregation(self):
         keys = ak.array([0, 1, 0, 1, 0, 1, 0, 1])

--- a/PROTO_tests/tests/groupby_test.py
+++ b/PROTO_tests/tests/groupby_test.py
@@ -725,9 +725,8 @@ class TestGroupBy:
 
         # Check for correct unique keys.
 
-        assert np.all(np_unique == np.sort(ak_TFF[0].to_ndarray())) and np.all(
-            np_unique == np.sort(ak_TTF[0].to_ndarray())
-        )
+        assert np.all(np_unique == np.sort(ak_TFF[0].to_ndarray()))
+        assert np.all(np_unique == np.sort(ak_TTF[0].to_ndarray()))
 
         # Check groups and indices.  If data was sorted, the group ndarray
         # should just be list(range(len(nda))), and the indices will be

--- a/PROTO_tests/tests/groupby_test.py
+++ b/PROTO_tests/tests/groupby_test.py
@@ -9,11 +9,11 @@ from arkouda.dtypes import npstr
 
 #  block of variables and functions used in test_unique
 
-UNIQUE_TYPES = [ak.categorical,ak.int64,ak.float64,npstr]
-VOWELS_AND_SUCH = ['a','e','i','o','u','AB',47,2,3.14159]
+UNIQUE_TYPES = [ak.categorical, ak.int64, ak.float64, npstr]
+VOWELS_AND_SUCH = ["a", "e", "i", "o", "u", "AB", 47, 2, 3.14159]
 PICKS = np.array([f"base {i}" for i in range(10)])
 
-isSorted = lambda x : np.all(x[:-1] <= x[1:])  # short for is x[i] <= x[i+1] for all i
+isSorted = lambda x: np.all(x[:-1] <= x[1:])  # short for is x[i] <= x[i+1] for all i
 
 #  This function (almost) guarantees both a sorted and unsorted version of
 #  a 1d array.  The only exception is an array of all identical values.
@@ -22,19 +22,23 @@ isSorted = lambda x : np.all(x[:-1] <= x[1:])  # short for is x[i] <= x[i+1] for
 #  and the two are returned.  If it isn't, a sorted version is created,
 #  and those two are returned.
 
-def make_sorted_and_unsorted_data (sample) :
-    if np.all(sample == sample[0]) : return sample, sample
-    if isSorted(sample) :
+
+def make_sorted_and_unsorted_data(sample):
+    if np.all(sample == sample[0]):
+        return sample, sample
+    if isSorted(sample):
         s_a = sample[:]
         us_a = np.random.permutation(sample)
-        while isSorted(us_a) :
+        while isSorted(us_a):
             us_a = np.random.permutation(us_a)
-    else :
+    else:
         s_a = np.sort(sample)
         us_a = sample[:]
     return s_a, us_a
 
+
 #  end of block
+
 
 def to_tuple_dict(labels, values):
     # transforms labels from list of arrays into a list of tuples by index and builds a dictionary
@@ -683,45 +687,47 @@ class TestGroupBy:
         for m in means.to_list():
             assert np.isclose(float(a[0]), m)
 
-#   ak.unique takes 1 pda argument and 3 booleans
-#      However, not all 8 combinations of the booleans are needed to
-#      cover the test space.
-#      Combinations TTF and TFF are supersets of all other possible
-#      combinations, so only those are tested below.
+    #   ak.unique takes 1 pda argument and 3 booleans
+    #      However, not all 8 combinations of the booleans are needed to
+    #      cover the test space.
+    #      Combinations TTF and TFF are supersets of all other possible
+    #      combinations, so only those are tested below.
 
     @pytest.mark.parametrize("data_type", UNIQUE_TYPES)
     @pytest.mark.parametrize("prob_size", pytest.prob_size)
-    def test_unique(self, data_type, prob_size) :
+    def test_unique(self, data_type, prob_size):
         Jenny = pytest.seed if pytest.seed is not None else 8675309
-        T = True ; F = False
+        T = True
+        F = False
         np.random.seed(Jenny)
         arrays = {
-            npstr : np.random.choice(VOWELS_AND_SUCH,prob_size),
-            ak.int64 : np.random.randint(0,prob_size//3,prob_size),
-            ak.float64: np.random.uniform(0,prob_size//3,prob_size),
-            ak.categorical : np.random.choice(PICKS,prob_size),
+            npstr: np.random.choice(VOWELS_AND_SUCH, prob_size),
+            ak.int64: np.random.randint(0, prob_size // 3, prob_size),
+            ak.float64: np.random.uniform(0, prob_size // 3, prob_size),
+            ak.categorical: np.random.choice(PICKS, prob_size),
         }
         nda = arrays[data_type]
-        np_unique = np.unique(nda)          # get unique keys from np for comparison
+        np_unique = np.unique(nda)  # get unique keys from np for comparison
         s_nda, us_nda = make_sorted_and_unsorted_data(nda)
         s_pda = ak.array(s_nda)
         us_pda = ak.array(us_nda)
 
         # Categorical requires another step to make the pdarrays categorical
 
-        if data_type == "categorical" :
+        if data_type == "categorical":
             s_pda = ak.Categorical(s_pda)
             us_pda = ak.Categorical(us_pda)
-        
+
         # Call ak.unique with TTF and TFF
 
-        ak_TTF = ak.unique(s_pda,T,T,F)
-        ak_TFF = ak.unique(us_pda,T,F,F)
+        ak_TTF = ak.unique(s_pda, T, T, F)
+        ak_TFF = ak.unique(us_pda, T, F, F)
 
         # Check for correct unique keys.
 
-        assert ( np.all(np_unique == np.sort(ak_TFF[0].to_ndarray())) and \
-            np.all(np_unique == np.sort(ak_TTF[0].to_ndarray())) )
+        assert np.all(np_unique == np.sort(ak_TFF[0].to_ndarray())) and np.all(
+            np_unique == np.sort(ak_TTF[0].to_ndarray())
+        )
 
         # Check groups and indices.  If data was sorted, the group ndarray
         # should just be list(range(len(nda))), and the indices will be
@@ -730,10 +736,11 @@ class TestGroupBy:
         srange = np.array(list(range(len(nda))))
         check1 = np.all(srange == ak_TTF[1].to_ndarray())
         indices = ak_TTF[2]
-        check2 = T ; nda_list = list(s_nda)
-        for i in range(len(indices)) :
+        check2 = T
+        nda_list = list(s_nda)
+        for i in range(len(indices)):
             check2 = check2 and indices[i] == nda_list.index(np_unique[i])
-        assert (check1 and check2)
+        assert check1 and check2
 
         # for unsorted data, a bit more work is required.  A reordered
         # copy of the pdarray is created based on the returned permutation,
@@ -745,13 +752,16 @@ class TestGroupBy:
         reordered = [nda[i] for i in reordering]
         indices = ak_TFF[2]
         checker = True
-        for j in range(len(aku)) :
-            if j < len(aku) - 1 :
-                checker = checker and np.all([reordered[i] == aku[j] for i in range(indices[j],indices[j+1])])
-            else :
-                checker = checker and np.all([reordered[i] == aku[j] for i in range(indices[j],len(aku))])
-        assert (checker)
-
+        for j in range(len(aku)):
+            if j < len(aku) - 1:
+                checker = checker and np.all(
+                    [reordered[i] == aku[j] for i in range(indices[j], indices[j + 1])]
+                )
+            else:
+                checker = checker and np.all(
+                    [reordered[i] == aku[j] for i in range(indices[j], len(aku))]
+                )
+        assert checker
 
     def test_unique_aggregation(self):
         keys = ak.array([0, 1, 0, 1, 0, 1, 0, 1])

--- a/PROTO_tests/tests/groupby_test.py
+++ b/PROTO_tests/tests/groupby_test.py
@@ -735,8 +735,11 @@ class TestGroupBy:
         # In both cases, broadcasting the unique values using the returned
         # indices should create the sorted/reordered array.
 
+        # keys should always be returned sorted if data is int64
+
         # sorted
 
+        if data_type == ak.int64 : assert isSorted(ak_TFF[0].to_ndarray())
         srange = np.arange(len(nda))
         assert np.all(srange == ak_TTF[1].to_ndarray())
         indices = ak_TTF[2]
@@ -745,6 +748,7 @@ class TestGroupBy:
         # unsorted
 
         aku = ak.unique(us_pda).to_ndarray()
+        if data_type == ak.int64 : assert isSorted(aku)
         reordering = ak_TFF[1]
         reordered = us_pda[reordering]
         indices = ak_TFF[2]

--- a/PROTO_tests/tests/groupby_test.py
+++ b/PROTO_tests/tests/groupby_test.py
@@ -729,23 +729,26 @@ class TestGroupBy:
         assert np.all(np_unique == np.sort(ak_TTF[0].to_ndarray()))
 
         # Check groups and indices.  If data was sorted, the group ndarray
-        # should just be list(range(len(nda))), and the indices will be
-        # exactly what the list method returns as the first index
+        # should just be list(range(len(nda))).  
+        # For unsorted data, a reordered copy of the pdarray is created
+        # based on the returned permutation.
+        # In both cases, broadcasting the unique values using the returned
+        # indices should create the sorted/reordered array.
+
+        # sorted
 
         srange = np.arange(len(nda))
         assert np.all(srange == ak_TTF[1].to_ndarray())
         indices = ak_TTF[2]
         assert ak.all(s_pda == ak.broadcast(indices, ak_TTF[0], len(s_nda)))
 
-        # for unsorted data, a reordered copy of the pdarray is created
-        # based on the returned permutation, and the indices are used to
-        # confirm that elements within a segment match.
+        # unsorted
 
         aku = ak.unique(us_pda).to_ndarray()
         reordering = ak_TFF[1]
         reordered = us_pda[reordering]
         indices = ak_TFF[2]
-        assert ak.all(reordered == ak.broadcast(indices, ak_TFF[0], len(nda)))
+        assert ak.all(reordered == ak.broadcast(indices, ak_TFF[0], len(us_nda)))
 
     def test_unique_aggregation(self):
         keys = ak.array([0, 1, 0, 1, 0, 1, 0, 1])

--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -81,11 +81,11 @@ def unique(
         Input array.
     return_groups : bool, optional
         If True, also return grouping information for the array.
+    assume_sorted : bool, optional
+        If True, assume pda is sorted and skip sorting step
     return_indices: bool, optional
         Only applicable if return_groups is True.
         If True, return unique key indices along with other groups
-    assume_sorted : bool, optional
-        If True, assume pda is sorted and skip sorting step
 
     Returns
     -------


### PR DESCRIPTION
Adds PROTO-tests unit test for ak.unique.

Closes #3231

As discussed over Slack and in-person, it took me a bit of study to realize this was much simpler than I was making it out to be.  Although the 3 booleans make for 8 possible test cases, they're not independent.  As noted in the comments, these two cases are supersets of all the others:

return_groups = True, assume_sorted = True, return_indices = False
return_groups = True, assume_sorted = False, return_indices = False

So I am only testing those.  Strangely, the indices are returned regardless of the value of return_indices.  In fact, more values are returned when it's False than when it's True.

The test covers int, float, str and categorical, and makes use of parameterization.  There are (hopefully) ample comments to make it clear what I'm testing.