### PR TITLE
Closes #3261 deprecate tests/numpy

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,6 @@
 filterwarnings =
     ignore:Version mismatch between client .*
 testpaths =
-    tests/numpy/numpy_test.py
     tests/alignment_tests.py
     tests/array_view_test.py
     tests/bitops_test.py

--- a/tests/numpy/numpy_test.py
+++ b/tests/numpy/numpy_test.py
@@ -1,6 +1,0 @@
-from base_test import ArkoudaTest
-
-
-class StatsTest(ArkoudaTest):
-    def setUp(self):
-        ArkoudaTest.setUp(self)


### PR DESCRIPTION
Closes #3261 deprecate tests/numpy

I verified there were no tests in tests/numpy, so I just deleted the directory and removed the tests from the pytest.ini file.