### PR TITLE
Benchmark Display Performance Fix

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -1211,7 +1211,7 @@ class DataFrame(UserDict):
             if isinstance(self[col], Categorical):
                 newdf[col] = self[col].categories[self[col].codes[idx]]
             else:
-                newdf[col] = self[col][idx]
+                newdf[col] = self[col].iloc[idx]
         newdf._set_index(self.index.index[idx])
         return newdf.to_pandas(retain_index=True)
 


### PR DESCRIPTION
`_get_head_tail` was missing an `iloc` call. This affected performance. Adding the `iloc` call should bring performance back towards the baseline for the display benchmarks.