### PR TITLE
fixes typo, server host maintained for connect call

### DIFF
--- a/PROTO_tests/conftest.py
+++ b/PROTO_tests/conftest.py
@@ -56,10 +56,10 @@ def startup_teardown():
         raise EnvironmentError("pytest and pytest-env must be installed")
     if TestRunningMode.CLASS_SERVER == test_running_mode:
         try:
-            server, _, _ = start_arkouda_server(numlocales=pytest.nl, port=pytest.port)
+            pytest.server, _, _ = start_arkouda_server(numlocales=pytest.nl, port=pytest.port)
             print(
                 "Started arkouda_server in TEST_CLASS mode with "
-                "host: {} port: {} locales: {}".format(server, pytest.port, pytest.nl)
+                "host: {} port: {} locales: {}".format(pytest.server, pytest.port, pytest.nl)
             )
         except Exception as e:
             raise RuntimeError(


### PR DESCRIPTION
On systems where the server host name isn't local host and the `ARKOUDA_SERVER_HOST` environment variable isn't set, `make test-proto` fails to connect to the server it launches. Small fix; the hostname variable just needed to be correctly updated.  