### PR TITLE
Closes #3311: Fix Parquet multi column byte writing

### DIFF
--- a/src/ArrowFunctions.cpp
+++ b/src/ArrowFunctions.cpp
@@ -952,7 +952,7 @@ std::shared_ptr<parquet::schema::GroupNode> SetupSchema(void* column_names, void
         auto list = parquet::schema::GroupNode::Make("list", parquet::Repetition::REPEATED, {element});
         fields.push_back(parquet::schema::GroupNode::Make(cname_ptr[i], parquet::Repetition::OPTIONAL, {list}, parquet::ConvertedType::LIST));
       } else {
-        fields.push_back(parquet::schema::PrimitiveNode::Make(cname_ptr[i], parquet::Repetition::REQUIRED, parquet::Type::BYTE_ARRAY, parquet::ConvertedType::NONE));
+        fields.push_back(parquet::schema::PrimitiveNode::Make(cname_ptr[i], parquet::Repetition::OPTIONAL, parquet::Type::BYTE_ARRAY, parquet::ConvertedType::NONE));
       }
     }
   }


### PR DESCRIPTION
For Parquet, we were previously incorrectly writing byte columns for segmented array values by setting reptition level to "required", when it should have been "optional". By fixing that schema setup, we will correctly write the definition level of each value.

Closes #3311 