### PR TITLE
Fix CSV Reading Bugs

### DIFF
--- a/src/CSVMsg.chpl
+++ b/src/CSVMsg.chpl
@@ -404,6 +404,22 @@ module CSVMsg {
                 moduleName=getModuleName(),
                 errorClass="DatasetNotFoundError");
 
+        // The same file might have data meant to be distributed across locales,
+        // Therefore the 0th line in the file may not correspond to the 0th index of the array
+        // So we skip over lines till we get the lower bound of the intersection
+        // But the filedom may not start at 0, so we need to substract that offset
+        for 0..<(intersection.low-filedom.low) {
+            try {fr.advanceThrough(b'\n');}
+            catch {
+                throw getErrorWithContext(
+                    msg="This CSV file is missing lines.",
+                    lineNumber=getLineNumber(),
+                    routineName=getRoutineName(),
+                    moduleName=getModuleName(),
+                    errorClass="IOError");
+            }
+        }
+
         var line = new csvLine(t, colIdx, colDelim);
         for x in intersection {
             try {


### PR DESCRIPTION
Resolves failures with CSV testing in multilocale configurations where the files do not correspond to a single locale's data.

Some files have data meant to be distributed across multiple locales
therefore we have to be aware of the lower bound of the line indices to
be read in. In order to do this, we skip over the lines until this lower
bound of the intersection is reached. 

Since the domains are continuous, we don't need to worry about any other bounds.