### PR TITLE
Part of #3229: Re-enable find implementation of `indexof1d`

### DIFF
--- a/arkouda/pdarraysetops.py
+++ b/arkouda/pdarraysetops.py
@@ -275,7 +275,6 @@ def indexof1d(query: groupable, space: groupable) -> pdarray:
     RuntimeError
         Raised if the dtype of either array is not supported
     """
-    # from arkouda.alignment import find as akfind
     from arkouda.categorical import Categorical as Categorical_
 
     if isinstance(query, (pdarray, Strings, Categorical_)):
@@ -284,15 +283,16 @@ def indexof1d(query: groupable, space: groupable) -> pdarray:
         elif isinstance(query, pdarray) and not isinstance(space, pdarray):
             raise TypeError("If keys is pdarray, arr must also be pdarray")
 
-    repMsg = generic_msg(
-        cmd="indexof1d",
-        args={"keys": query, "arr": space},
-    )
-    return create_pdarray(cast(str, repMsg))
+    # repMsg = generic_msg(
+    #     cmd="indexof1d",
+    #     args={"keys": query, "arr": space},
+    # )
+    # return create_pdarray(cast(str, repMsg))
 
-    # TODO see issue #3229 reverted back to old implementation until we can investigate
-    # found = akfind(query, space, all_occurrences=True, remove_missing=True)
-    # return found if isinstance(found, pdarray) else found.values
+    from arkouda.alignment import find as akfind
+
+    found = akfind(query, space, all_occurrences=True, remove_missing=True)
+    return found if isinstance(found, pdarray) else found.values
 
 
 # fmt: off


### PR DESCRIPTION
This PR is part of #3229. Re-enable the `find` implementation. I modified it to have a more optimized way of finding all occurrences. Part of the trade off for the more optimized approach is it's not as easy to replace missing elements with `-1`. Since this isn't a common case and no one is asking for this functionality I decided to have `all_occurrences` being set automatically enable `replace_missing`. I tried to make this clear in the doc string. While I'm not sure if this is the best way of calculating this, it's no longer the bottleneck and it gets better performance than the current implementation.

I'm hopeful the updated find way will also solve the issue we were seeing in the CI. But previously I added seeds to the `indexof1d` test, so it will be easier to reproduce if any remain failures. I'm not closing the issue yet since there's still some code cleanup to be done, and I want to leave existing code to make it easier to fall back to a similar approach in the event that the `find` way still has issues