### PR TITLE
Adds array_equal to match numpy

### DIFF
--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -1740,15 +1740,12 @@ def matching_shapes(pda_a: pdarray, pda_b: pdarray):
 
     Examples
     --------
-    >>> a = np.random.randint(0,10,10).astype(np.float64)
-    >>> b = np.random.randint(0,3,10)
-    >>> c = ak.array(a)
-    >>> d = ak.array(b)
-    >>> ak.matching_shapes(c,d)
+    >>> a = ak.randint(0,10,10)
+    >>> b = ak.randint(0,3,10)
+    >>> ak.matching_shapes(a,b)
     True
-    >>> b = np.random.randint(0,10,5000)
-    >>> d = ak.array(b)
-    >>> ak.matching_shapes(c,d)
+    >>> b = ak.randint(0,10,5000)
+    >>> ak.matching_shapes(a,b)
     False
 
     """
@@ -1770,6 +1767,8 @@ def array_equal(pda_a: pdarray, pda_b: pdarray, equal_nan: bool = False):
         equal_nan : boolean to determine how to handle nans, default False
 
     Returns:
+        boolean
+
         With string data: False if one array is of type npstr and the other isn't,
                             True is both are npstr and they match.
         With numeric data: True if neither array has any nan elements, and all elements pairwise equal.
@@ -1779,21 +1778,17 @@ def array_equal(pda_a: pdarray, pda_b: pdarray, equal_nan: bool = False):
 
     Examples
     --------
-    >>> a = np.random.randint(0,10,10).astype(np.float64)
-    >>> b = a.copy()
-    >>> c = ak.array(a)
-    >>> d = ak.array(b)
-    >>> ak.array_equal(c,d)
+    >>> a = ak.randint(0,10,10,dtype=ak.float64)
+    >>> b = a
+    >>> ak.array_equal(a,b)
     True
     >>> b[9] = np.nan
-    >>> d = ak.array(b)
-    >>> ak.array_equal(c,d)
+    >>> ak.array_equal(a,b)
     False
     >>> a[9] = np.nan
-    >>> c = ak.array(a)
-    >>> array_equal(c,d)
+    >>> array_equal(a,b)
     False
-    >>> ak.array_equal(c,d,True)
+    >>> ak.array_equal(a,b,True)
     True
     """
     if not matching_shapes(pda_a, pda_b):

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -1731,11 +1731,13 @@ def matching_shapes(pda_a: pdarray, pda_b: pdarray):
     It's included so that we can put placeholders in for the check as
     we implement n-dimensional array computation.
 
-    Parameters:
+    Parameters
+    ----------
         pda_a : pdarray
         pda_b : pdarray
 
-    Returns:
+    Returns
+    -------
         True if pda_a.size == pda_b.size, else False
 
     Examples

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -1733,12 +1733,12 @@ def matching_shapes(pda_a: pdarray, pda_b: pdarray):
 
     Parameters
     ----------
-        pda_a : pdarray
-        pda_b : pdarray
+    pda_a : pdarray
+    pda_b : pdarray
 
     Returns
     -------
-        True if pda_a.size == pda_b.size, else False
+    True if pda_a.size == pda_b.size, else False
 
     Examples
     --------
@@ -1765,19 +1765,18 @@ def array_equal(pda_a: pdarray, pda_b: pdarray, equal_nan: bool = False):
 
     Parameters
     ----------
-        pda_a : pdarray
-        pda_b : pdarray
-        equal_nan : boolean to determine how to handle nans, default False
+    pda_a : pdarray
+    pda_b : pdarray
+    equal_nan : boolean to determine how to handle nans, default False
 
     Returns
     -------
-        boolean
-
-        With string data: False if one array is of type npstr and the other isn't,
-                            True is both are npstr and they match.
-        With numeric data: True if neither array has any nan elements, and all elements pairwise equal.
-                            False if equal_Nan is False, and either array has any nan element.
-                            True if equal_Nan is True, all non-nan elements are pairwise equal,
+    boolean
+      With string data: False if one array is of type npstr and the other isn't,
+                        True is both are npstr and they match.
+      With numeric data: True if neither array has any nan elements, and all elements pairwise equal.
+                         False if equal_Nan is False, and either array has any nan element.
+                         True if equal_Nan is True, all non-nan elements are pairwise equal,
                                             and all nans in pda_a correspond to nans in pda_b
 
     Examples

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -1761,12 +1761,14 @@ def array_equal(pda_a: pdarray, pda_b: pdarray, equal_nan: bool = False):
     If equal_Nan is False, then any nan element in either array gives a False return.
     If equal_Nan is True, then pairwise-corresponding nans are considered equal.
 
-    Parameters:
+    Parameters
+    ----------
         pda_a : pdarray
         pda_b : pdarray
         equal_nan : boolean to determine how to handle nans, default False
 
-    Returns:
+    Returns
+    -------
         boolean
 
         With string data: False if one array is of type npstr and the other isn't,

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -1772,7 +1772,7 @@ def array_equal(pda_a: pdarray, pda_b: pdarray, equal_nan: bool = False):
     Returns:
         With string data: False if one array is of type npstr and the other isn't,
                             True is both are npstr and they match.
-        With numeric data: True if neither array has any nan elements, and all elements are pairwise equal.
+        With numeric data: True if neither array has any nan elements, and all elements pairwise equal.
                             False if equal_Nan is False, and either array has any nan element.
                             True if equal_Nan is True, all non-nan elements are pairwise equal,
                                             and all nans in pda_a correspond to nans in pda_b


### PR DESCRIPTION
Implements an array_equal function for two pdarrays, matching what numpy.array_equal does.

Also adds a utility function "matches_shape" which for now only compares pdarray sizes, but which will serve as a placeholder for when we expand pdarrays to n-dimensions.