### PR TITLE
Closes #3343: Pin `numpy < 2.0` to avoid CI failures

### DIFF
--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - python>=3.8   # minimum 3.8
-  - numpy>=1.24.1
+  - numpy>=1.24.1,<2.0
   - pandas>=1.4.0,!=2.2.0
   - pyzmq>=20.0.0
   - tabulate

--- a/arkouda-env.yml
+++ b/arkouda-env.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - python>=3.8   # minimum 3.8
-  - numpy>=1.24.1
+  - numpy>=1.24.1,<2.0
   - pandas>=1.4.0,!=2.2.0
   - pyzmq>=20.0.0
   - tabulate

--- a/pydoc/requirements.txt
+++ b/pydoc/requirements.txt
@@ -1,6 +1,6 @@
 # dependencies
 python>=3.8
-numpy>=1.24.1
+numpy>=1.24.1,<2.0
 pandas>=1.4.0,!=2.2.0
 pyzmq>=20.0.0
 typeguard==2.10.0

--- a/pydoc/setup/REQUIREMENTS.md
+++ b/pydoc/setup/REQUIREMENTS.md
@@ -18,7 +18,7 @@ The installation instructions for the dependencies listed here may vary dependin
 The following python packages are required by the Arkouda client package.
 
 - `python>=3.8`
-- `numpy>=1.24.1`
+- `numpy>=1.24.1,<2.0`
 - `pandas>=1.4.0,!=2.2.0`
 - `pyzmq>=20.0.0`
 - `typeguard==2.10.0`

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ setup(
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        "numpy>=1.24.1",
+        "numpy>=1.24.1,<2.0",
         "pandas>=1.4.0,!=2.2.0",
         "pyzmq>=20.0.0",
         "typeguard==2.10.0",


### PR DESCRIPTION
This PR (closes #3343) pins `numpy < 2.0` to avoid CI failures