### PR TITLE
Related to #3346: Disable `3.12` / `3.x` workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.x']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     container:
       image: chapel/chapel:1.33.0
     steps:
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.x']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     container:
       image: chapel/chapel:1.33.0
     steps:

--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python>=3.8   # minimum 3.8
+  - python>=3.8,<3.12.4   # minimum 3.8
   - numpy>=1.24.1,<2.0
   - pandas>=1.4.0,!=2.2.0
   - pyzmq>=20.0.0

--- a/arkouda-env.yml
+++ b/arkouda-env.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python>=3.8   # minimum 3.8
+  - python>=3.8,<3.12.4   # minimum 3.8
   - numpy>=1.24.1,<2.0
   - pandas>=1.4.0,!=2.2.0
   - pyzmq>=20.0.0

--- a/pydoc/requirements.txt
+++ b/pydoc/requirements.txt
@@ -1,5 +1,5 @@
 # dependencies
-python>=3.8
+python>=3.8,<3.12.4
 numpy>=1.24.1,<2.0
 pandas>=1.4.0,!=2.2.0
 pyzmq>=20.0.0

--- a/pydoc/setup/REQUIREMENTS.md
+++ b/pydoc/setup/REQUIREMENTS.md
@@ -17,7 +17,7 @@ The installation instructions for the dependencies listed here may vary dependin
 
 The following python packages are required by the Arkouda client package.
 
-- `python>=3.8`
+- `python>=3.8,<3.12.4`
 - `numpy>=1.24.1,<2.0`
 - `pandas>=1.4.0,!=2.2.0`
 - `pyzmq>=20.0.0`

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ setup(
     # and refuse to install the project if the version does not match. If you
     # do not support Python 2, you can simplify this to '>=3.5' or similar, see
     # https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
-    python_requires=">=3.8",
+    python_requires=">=3.8,<3.12.4",
     # This field lists other packages that your project depends on to run.
     # Any package you put here will be installed by pip when your project is
     # installed, so they must be valid existing projects.


### PR DESCRIPTION
Related to #3346, we were seeing some intermittent CI failures with python `3.x/3.12` due to `ForwardRef`. I tried a couple different things to resolve this but wasn't able to get it working. For the time being disable the typechecking on these functions

The biggest thing I tried was to try and use `TYPE_CHECKING` as shown here [this stackoverflow post](https://stackoverflow.com/questions/39740632/python-type-hinting-without-cyclic-imports). While this did get past mypy it would raise a type error when functions with this type annotation were called.