### PR TITLE
temporary fix for #3355: pin `scipy<=1.13.1` to avoid CI failures

### DIFF
--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -20,7 +20,7 @@ dependencies:
   - libiconv
   - libidn2
   - jupyter
-  - scipy
+  - scipy<=1.13.1
 
   # Developer dependencies
   - pexpect

--- a/arkouda-env.yml
+++ b/arkouda-env.yml
@@ -20,7 +20,7 @@ dependencies:
   - libiconv
   - libidn2
   - jupyter
-  - scipy
+  - scipy<=1.13.1
  
   - pip:
       - typeguard==2.10.0

--- a/pydoc/requirements.txt
+++ b/pydoc/requirements.txt
@@ -16,7 +16,7 @@ tables>=3.7.0
 pyarrow
 libiconv
 libidn2
-scipy
+scipy<=1.13.1
 
 # Developer dependencies
 pexpect

--- a/pydoc/setup/REQUIREMENTS.md
+++ b/pydoc/setup/REQUIREMENTS.md
@@ -32,7 +32,7 @@ The following python packages are required by the Arkouda client package.
 - `types-tabulate`
 - `tables>=3.7.0`
 - `pyarrow`
-- `scipy`
+- `scipy<=1.13.1`
 
 ### Developer Specific
 

--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ setup(
         "types-tabulate",
         "tables>=3.7.0",
         "pyarrow",
-        "scipy",
+        "scipy<=1.13.1",
     ],
     # List additional groups of dependencies here (e.g. development
     # dependencies). Users will be able to install these using the "extras"


### PR DESCRIPTION
This change pins scipy version to `<=1.13.1` in order to prevent unit tests from failing in the `arkouda.scipy` module due to a new release of scipy.

temporary fix for #3355: pin `scipy<=1.13.1` to avoid CI failures