### PR TITLE
Ignore new Parquet object files

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,3 +1,5 @@
 TAGS
-ArrowFunctions.o
 ServerRegistration.chpl
+ReadParquet.o
+WriteParquet.o
+UtilParquet.o


### PR DESCRIPTION
After splitting the Parquet code into multiple, distinct files, we need to add those to the gitignore in the case that someone adds the src directory non-descriminantly.