### PR TITLE
Remove number of files multiplication for IO benchmark

### DIFF
--- a/benchmarks/IO.py
+++ b/benchmarks/IO.py
@@ -140,7 +140,7 @@ def time_ak_read(N_per_locale, numfiles, trials, dtype, path, fileFormat, comps=
     else:
         raise ValueError("Invalid file format")
 
-    nb = a.size * a.itemsize * numfiles if dtype != 'str' else a.nbytes * numfiles
+    nb = a.size * a.itemsize if dtype != 'str' else a.nbytes
     for key in times.keys():
         print("read Average time {} = {:.4f} sec".format(key, times[key]))
         print("read Average rate {} = {:.4f} GiB/sec".format(key, nb / 2**30 / times[key]))


### PR DESCRIPTION
In a previous PR, when adding IO benchmark support for strings, a `* numFiles` was added onto the number of bytes calculating, so it looked like the performance had suddenly gotten much better, when nothing had changed.