### PR TITLE
test_histogram_multidim failing

### DIFF
--- a/PROTO_tests/tests/numeric_test.py
+++ b/PROTO_tests/tests/numeric_test.py
@@ -321,27 +321,27 @@ class TestNumeric:
         # only do the first one so results are easier to find since the first one breaks
         # on the machine in question
 
-        # np_hist, np_x_edges, np_y_edges = np.histogram2d(np_x, np_y, bins=(10, 20))
-        # ak_hist, ak_x_edges, ak_y_edges = ak.histogram2d(ak_x, ak_y, bins=(10, 20))
-        # print_failure_indices(np_hist, ak_hist)
-        # print_failure_indices(np_x_edges, ak_x_edges)
-        # print_failure_indices(np_y_edges, ak_y_edges)
+        np_hist, np_x_edges, np_y_edges = np.histogram2d(np_x, np_y, bins=(10, 20))
+        ak_hist, ak_x_edges, ak_y_edges = ak.histogram2d(ak_x, ak_y, bins=(10, 20))
+        print_failure_indices(np_hist, ak_hist)
+        print_failure_indices(np_x_edges, ak_x_edges)
+        print_failure_indices(np_y_edges, ak_y_edges)
 
         # assert np.allclose(np_hist.tolist(), ak_hist.to_list())
         # assert np.allclose(np_x_edges.tolist(), ak_x_edges.to_list())
         # assert np.allclose(np_y_edges.tolist(), ak_y_edges.to_list())
 
         # test arbitrary dimensional histogram
-        # dim_list = [3, 4, 5]
-        # bin_list = [[2, 4, 5], [2, 4, 5, 2], [2, 4, 5, 2, 3]]
-        # for dim, bins in zip(dim_list, bin_list):
-        #     np_arrs = [np.random.randint(1, 100, 1000) for _ in range(dim)]
-        #     ak_arrs = [ak.array(a) for a in np_arrs]
-        #     np_hist, np_bin_edges = np.histogramdd(np_arrs, bins=bins)
-        #     ak_hist, ak_bin_edges = ak.histogramdd(ak_arrs, bins=bins)
-        #     assert np.allclose(np_hist.tolist(), ak_hist.to_list())
-        #     for np_edge, ak_edge in zip(np_bin_edges, ak_bin_edges):
-        #         assert np.allclose(np_edge.tolist(), ak_edge.to_list())
+        dim_list = [3, 4, 5]
+        bin_list = [[2, 4, 5], [2, 4, 5, 2], [2, 4, 5, 2, 3]]
+        for dim, bins in zip(dim_list, bin_list):
+            np_arrs = [np.random.randint(1, 100, 1000) for _ in range(dim)]
+            ak_arrs = [ak.array(a) for a in np_arrs]
+            np_hist, np_bin_edges = np.histogramdd(np_arrs, bins=bins)
+            ak_hist, ak_bin_edges = ak.histogramdd(ak_arrs, bins=bins)
+            assert np.allclose(np_hist.tolist(), ak_hist.to_list())
+            for np_edge, ak_edge in zip(np_bin_edges, ak_bin_edges):
+                assert np.allclose(np_edge.tolist(), ak_edge.to_list())
 
     @pytest.mark.parametrize("num_type", NO_BOOL)
     def test_log_and_exp(self, num_type):

--- a/PROTO_tests/tests/numeric_test.py
+++ b/PROTO_tests/tests/numeric_test.py
@@ -302,6 +302,15 @@ class TestNumeric:
         np_hist, np_x_edges, np_y_edges = np.histogram2d(np_x, np_y)
         ak_hist, ak_x_edges, ak_y_edges = ak.histogram2d(ak_x, ak_y)
 
+        print()
+        print()
+        print()
+        print("np_hist[0]")
+        print(np_hist[0])
+        print()
+        print("ak_hist[0]")
+        print(ak_hist[0])
+
         print_failure_indices(np_hist, ak_hist)
         print_failure_indices(np_x_edges, ak_x_edges)
         print_failure_indices(np_y_edges, ak_y_edges)
@@ -309,26 +318,30 @@ class TestNumeric:
         # assert np.allclose(np_x_edges.tolist(), ak_x_edges.to_list())
         # assert np.allclose(np_y_edges.tolist(), ak_y_edges.to_list())
 
-        np_hist, np_x_edges, np_y_edges = np.histogram2d(np_x, np_y, bins=(10, 20))
-        ak_hist, ak_x_edges, ak_y_edges = ak.histogram2d(ak_x, ak_y, bins=(10, 20))
-        print_failure_indices(np_hist, ak_hist)
-        print_failure_indices(np_x_edges, ak_x_edges)
-        print_failure_indices(np_y_edges, ak_y_edges)
+        # only do the first one so results are easier to find since the first one breaks
+        # on the machine in question
+
+        # np_hist, np_x_edges, np_y_edges = np.histogram2d(np_x, np_y, bins=(10, 20))
+        # ak_hist, ak_x_edges, ak_y_edges = ak.histogram2d(ak_x, ak_y, bins=(10, 20))
+        # print_failure_indices(np_hist, ak_hist)
+        # print_failure_indices(np_x_edges, ak_x_edges)
+        # print_failure_indices(np_y_edges, ak_y_edges)
+
         # assert np.allclose(np_hist.tolist(), ak_hist.to_list())
         # assert np.allclose(np_x_edges.tolist(), ak_x_edges.to_list())
         # assert np.allclose(np_y_edges.tolist(), ak_y_edges.to_list())
 
         # test arbitrary dimensional histogram
-        dim_list = [3, 4, 5]
-        bin_list = [[2, 4, 5], [2, 4, 5, 2], [2, 4, 5, 2, 3]]
-        for dim, bins in zip(dim_list, bin_list):
-            np_arrs = [np.random.randint(1, 100, 1000) for _ in range(dim)]
-            ak_arrs = [ak.array(a) for a in np_arrs]
-            np_hist, np_bin_edges = np.histogramdd(np_arrs, bins=bins)
-            ak_hist, ak_bin_edges = ak.histogramdd(ak_arrs, bins=bins)
-            assert np.allclose(np_hist.tolist(), ak_hist.to_list())
-            for np_edge, ak_edge in zip(np_bin_edges, ak_bin_edges):
-                assert np.allclose(np_edge.tolist(), ak_edge.to_list())
+        # dim_list = [3, 4, 5]
+        # bin_list = [[2, 4, 5], [2, 4, 5, 2], [2, 4, 5, 2, 3]]
+        # for dim, bins in zip(dim_list, bin_list):
+        #     np_arrs = [np.random.randint(1, 100, 1000) for _ in range(dim)]
+        #     ak_arrs = [ak.array(a) for a in np_arrs]
+        #     np_hist, np_bin_edges = np.histogramdd(np_arrs, bins=bins)
+        #     ak_hist, ak_bin_edges = ak.histogramdd(ak_arrs, bins=bins)
+        #     assert np.allclose(np_hist.tolist(), ak_hist.to_list())
+        #     for np_edge, ak_edge in zip(np_bin_edges, ak_bin_edges):
+        #         assert np.allclose(np_edge.tolist(), ak_edge.to_list())
 
     @pytest.mark.parametrize("num_type", NO_BOOL)
     def test_log_and_exp(self, num_type):

--- a/PROTO_tests/tests/numeric_test.py
+++ b/PROTO_tests/tests/numeric_test.py
@@ -281,21 +281,42 @@ class TestNumeric:
     #   log and exp tests were identical, and so have been combined.
 
     def test_histogram_multidim(self):
+        def print_failure_indices(npa, pda):
+            if not np.allclose(npa.tolist(), pda.to_list()):
+                npa = npa.reshape(npa.size)
+                pda = pda.base
+                where_fail = [
+                    i for i, (n, a) in enumerate(zip(npa.tolist(), pda.to_list())) if not np.isclose(n, a)
+                ]
+                where_fail = where_fail if len(where_fail) <= 20 else where_fail[:20]
+                print()
+                print("where fail: \n", where_fail)
+                print("\n  numpy one:\n", npa[where_fail])
+                print("\n  arkouda one:\n", pda[where_fail])
+            assert np.allclose(npa.tolist(), pda.to_list())
+
         # test 2d histogram
         seed = 1
         ak_x, ak_y = ak.randint(1, 100, 1000, seed=seed), ak.randint(1, 100, 1000, seed=seed + 1)
         np_x, np_y = ak_x.to_ndarray(), ak_y.to_ndarray()
         np_hist, np_x_edges, np_y_edges = np.histogram2d(np_x, np_y)
         ak_hist, ak_x_edges, ak_y_edges = ak.histogram2d(ak_x, ak_y)
-        assert np.allclose(np_hist.tolist(), ak_hist.to_list())
-        assert np.allclose(np_x_edges.tolist(), ak_x_edges.to_list())
-        assert np.allclose(np_y_edges.tolist(), ak_y_edges.to_list())
+
+        print_failure_indices(np_hist, ak_hist)
+        print_failure_indices(np_x_edges, ak_x_edges)
+        print_failure_indices(np_y_edges, ak_y_edges)
+        # assert np.allclose(np_hist.tolist(), ak_hist.to_list())
+        # assert np.allclose(np_x_edges.tolist(), ak_x_edges.to_list())
+        # assert np.allclose(np_y_edges.tolist(), ak_y_edges.to_list())
 
         np_hist, np_x_edges, np_y_edges = np.histogram2d(np_x, np_y, bins=(10, 20))
         ak_hist, ak_x_edges, ak_y_edges = ak.histogram2d(ak_x, ak_y, bins=(10, 20))
-        assert np.allclose(np_hist.tolist(), ak_hist.to_list())
-        assert np.allclose(np_x_edges.tolist(), ak_x_edges.to_list())
-        assert np.allclose(np_y_edges.tolist(), ak_y_edges.to_list())
+        print_failure_indices(np_hist, ak_hist)
+        print_failure_indices(np_x_edges, ak_x_edges)
+        print_failure_indices(np_y_edges, ak_y_edges)
+        # assert np.allclose(np_hist.tolist(), ak_hist.to_list())
+        # assert np.allclose(np_x_edges.tolist(), ak_x_edges.to_list())
+        # assert np.allclose(np_y_edges.tolist(), ak_y_edges.to_list())
 
         # test arbitrary dimensional histogram
         dim_list = [3, 4, 5]

--- a/src/Histogram.chpl
+++ b/src/Histogram.chpl
@@ -200,21 +200,14 @@ module Histogram
         var gHist: [0..#totNumBins] int;
 
         // count into per-task/per-locale histogram and then reduce as tasks complete
-        writeln("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
-        writeln("the zero bucket indices:");
-        forall (xi, yi, count) in zip(x, y, 1..) with (+ reduce gHist) {
+        forall (xi, yi, _) in zip(x, y, 1..) with (+ reduce gHist) {
             var xiBin = ((xi - xMin) / xBinWidth):int;
             var yiBin = ((yi - yMin) / yBinWidth):int;
             if xi == xMax {xiBin = numXBins-1;}
             if yi == yMax {yiBin = numYBins-1;}
-            var bucket_idx = (xiBin * numYBins) + yiBin;
+            const bucket_idx = (xiBin * numYBins) + yiBin;
             gHist[bucket_idx] += 1;
-
-            if (xiBin * numYBins) + yiBin == 0 {
-                writeln("\n", count:string);
-            }
         }
-        writeln();
 
         var hist = makeDistArray(totNumBins,int);
         hist = gHist;

--- a/src/Histogram.chpl
+++ b/src/Histogram.chpl
@@ -200,13 +200,38 @@ module Histogram
         var gHist: [0..#totNumBins] int;
 
         // count into per-task/per-locale histogram and then reduce as tasks complete
-        forall (xi, yi) in zip(x, y) with (+ reduce gHist) {
+
+        // this was breaking even with single locale, so convert to a for loop 
+        // forall (xi, yi) in zip(x, y) with (+ reduce gHist) {
+        var count = 0;
+        var zero_bucket = "";
+        for (xi, yi) in zip(x, y) {
             var xiBin = ((xi - xMin) / xBinWidth):int;
             var yiBin = ((yi - yMin) / yBinWidth):int;
             if xi == xMax {xiBin = numXBins-1;}
             if yi == yMax {yiBin = numYBins-1;}
-            gHist[(xiBin * numYBins) + yiBin] += 1;
+            var bucket_idx = (xiBin * numYBins) + yiBin;
+            gHist[bucket_idx] += 1;
+            count += 1;
+
+            if count < 10 {
+                writeln("xiBin: ", xiBin);
+                writeln("yiBin: ", yiBin);
+                writeln("bucket_idx: ", bucket_idx);
+                writeln();
+            }
+
+            if (xiBin * numYBins) + yiBin == 0 {
+                zero_bucket += count:string;
+                zero_bucket += ", ";
+            }
         }
+        writeln();
+        writeln("the zero bucket indices:");
+        writeln(zero_bucket);
+        writeln();
+        writeln();
+        writeln();
 
         var hist = makeDistArray(totNumBins,int);
         hist = gHist;

--- a/src/Histogram.chpl
+++ b/src/Histogram.chpl
@@ -200,8 +200,9 @@ module Histogram
         var gHist: [0..#totNumBins] int;
 
         // count into per-task/per-locale histogram and then reduce as tasks complete
-        var zero_bucket = "";
-        forall (xi, yi, count) in zip(x, y, 1..) with (+ reduce gHist, + reduce zero_bucket) {
+        writeln("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
+        writeln("the zero bucket indices:");
+        forall (xi, yi, count) in zip(x, y, 1..) with (+ reduce gHist) {
             var xiBin = ((xi - xMin) / xBinWidth):int;
             var yiBin = ((yi - yMin) / yBinWidth):int;
             if xi == xMax {xiBin = numXBins-1;}
@@ -209,19 +210,10 @@ module Histogram
             var bucket_idx = (xiBin * numYBins) + yiBin;
             gHist[bucket_idx] += 1;
 
-            if count < 10 {
-                writeln("xiBin: ", xiBin, "\nyiBin: ", yiBin, "\nbucket_idx: ", bucket_idx, "\n");
-            }
-
             if (xiBin * numYBins) + yiBin == 0 {
-                zero_bucket += count:string + ", ";
+                writeln("\n", count:string);
             }
         }
-        writeln();
-        writeln("the zero bucket indices:");
-        writeln(zero_bucket);
-        writeln();
-        writeln();
         writeln();
 
         var hist = makeDistArray(totNumBins,int);

--- a/src/Histogram.chpl
+++ b/src/Histogram.chpl
@@ -200,30 +200,21 @@ module Histogram
         var gHist: [0..#totNumBins] int;
 
         // count into per-task/per-locale histogram and then reduce as tasks complete
-
-        // this was breaking even with single locale, so convert to a for loop 
-        // forall (xi, yi) in zip(x, y) with (+ reduce gHist) {
-        var count = 0;
         var zero_bucket = "";
-        for (xi, yi) in zip(x, y) {
+        forall (xi, yi, count) in zip(x, y, 1..) with (+ reduce gHist, + reduce zero_bucket) {
             var xiBin = ((xi - xMin) / xBinWidth):int;
             var yiBin = ((yi - yMin) / yBinWidth):int;
             if xi == xMax {xiBin = numXBins-1;}
             if yi == yMax {yiBin = numYBins-1;}
             var bucket_idx = (xiBin * numYBins) + yiBin;
             gHist[bucket_idx] += 1;
-            count += 1;
 
             if count < 10 {
-                writeln("xiBin: ", xiBin);
-                writeln("yiBin: ", yiBin);
-                writeln("bucket_idx: ", bucket_idx);
-                writeln();
+                writeln("xiBin: ", xiBin, "\nyiBin: ", yiBin, "\nbucket_idx: ", bucket_idx, "\n");
             }
 
             if (xiBin * numYBins) + yiBin == 0 {
-                zero_bucket += count:string;
-                zero_bucket += ", ";
+                zero_bucket += count:string + ", ";
             }
         }
         writeln();

--- a/src/HistogramMsg.chpl
+++ b/src/HistogramMsg.chpl
@@ -108,24 +108,6 @@ module HistogramMsg
             var yMax = max reduce y.a;
             var xBinWidth:real = (xMax - xMin):real / xBins:real;
             var yBinWidth:real = (yMax - yMin):real / yBins:real;
-            writeln();
-            writeln();
-            writeln();
-            writeln();
-            writeln();
-            writeln("xBins: ", xBins);
-            writeln("yBins: ", yBins);
-            writeln();
-            writeln("xMin: ", xMin);
-            writeln("xMax: ", xMax);
-            writeln("yMin: ", yMin);
-            writeln("yMax: ", yMax);
-            writeln();
-            writeln();
-            // the bin widths are my first bet for a culprit
-            writeln("xBinWidth: ", xBinWidth);
-            writeln("yBinWidth: ", yBinWidth);
-            writeln();
             hgmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                                             "xBinWidth %r yBinWidth %r".format(xBinWidth, yBinWidth));
 
@@ -133,10 +115,6 @@ module HistogramMsg
             if (totBins <= sBound) {
                 hgmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                                             "%? <= %?".format(totBins,sBound));
-                writeln();
-                writeln();
-                writeln("Making sure we're in the small bound case");
-                writeln();
                 var hist = histogramReduceIntent(x.a, y.a, xMin, xMax, yMin, yMax, xBins, yBins, xBinWidth, yBinWidth);
                 st.addEntry(rname, createSymEntry(hist));
             }

--- a/src/HistogramMsg.chpl
+++ b/src/HistogramMsg.chpl
@@ -108,6 +108,24 @@ module HistogramMsg
             var yMax = max reduce y.a;
             var xBinWidth:real = (xMax - xMin):real / xBins:real;
             var yBinWidth:real = (yMax - yMin):real / yBins:real;
+            writeln();
+            writeln();
+            writeln();
+            writeln();
+            writeln();
+            writeln("xBins: ", xBins);
+            writeln("yBins: ", yBins);
+            writeln();
+            writeln("xMin: ", xMin);
+            writeln("xMax: ", xMax);
+            writeln("yMin: ", yMin);
+            writeln("yMax: ", yMax);
+            writeln();
+            writeln();
+            // the bin widths are my first bet for a culprit
+            writeln("xBinWidth: ", xBinWidth);
+            writeln("yBinWidth: ", yBinWidth);
+            writeln();
             hgmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                                             "xBinWidth %r yBinWidth %r".format(xBinWidth, yBinWidth));
 
@@ -115,6 +133,10 @@ module HistogramMsg
             if (totBins <= sBound) {
                 hgmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                                             "%? <= %?".format(totBins,sBound));
+                writeln();
+                writeln();
+                writeln("Making sure we're in the small bound case");
+                writeln();
                 var hist = histogramReduceIntent(x.a, y.a, xMin, xMax, yMin, yMax, xBins, yBins, xBinWidth, yBinWidth);
                 st.addEntry(rname, createSymEntry(hist));
             }


### PR DESCRIPTION
This has debug info for issue #3366, since I'm unable to reproduce this locally

Apparently it's failing on the nightly machine even in single locale mode. This make me think this a numeric precision issue somewhere with float math. It's really strange because the problem size lands us in the `+ reduce` case which has the simplest logic and very closely mirrors what is done in the 1d histogram case

we're seeing theses results for the first index of the 2d hist:
```
[11. 10. 12.  9. 10. 12.  7.  9. 11.  6.]
[10 10 11  9 10 11  7  9 11  6]
```
so we appear to undercounting by 1 inconsistently. I'm curious if these numbers are the same from run-to-run