### PR TITLE
Resolve CSV Asan "use after free" memory issues

### DIFF
--- a/src/CSVMsg.chpl
+++ b/src/CSVMsg.chpl
@@ -85,9 +85,8 @@ module CSVMsg {
         }
 
         var col_delim: string = msgArgs.getValueOf("col_delim");
-        var column_names = if !hasHeader then line.split(col_delim).strip()
-                           else
-                             reader.readLine(stripNewline = true).split(col_delim).strip();
+        if hasHeader then line = reader.readLine(stripNewline = true);
+        var column_names = line.split(col_delim).strip();
         return new MsgTuple(formatJson(column_names), MsgType.NORMAL);
 
     }
@@ -348,10 +347,12 @@ module CSVMsg {
                 }
             }
         }
-
-        var columns = if !hasHeader then line.split(col_delim).strip()
-                      else
-                        reader.readLine(stripNewline = true).split(col_delim).strip();
+        var column_names: string;
+        if hasHeader then
+            column_names = reader.readLine(stripNewline = true);
+        else
+            column_names = line;
+        var columns = column_names.split(col_delim).strip();
         var file_dtypes: [0..#columns.size] string;
         if hasHeader {
             file_dtypes = line.split(",").strip(); // Line was already read above


### PR DESCRIPTION
The recent changes to CSV reads were causing issues with ASAN testing where we were getting a "heap use after free" error message in both `lscsv` and `get_info`.

The offending code pattern was similar in both cases, even though the pattern itself looks pretty innocent.

This PR fixes the ASAN issues by rewriting the code to be a little more verbose and avoids the offending pattern.

When I have more time, I will try to see if we can reproduce this ASAN issue outside of Arkouda (i.e. if it's a problem on the Chapel side)

- [X] `tests/io_test.py::IOTest::test_csv_read_write` in ASAN+gasnet
- [x] `tests/io_test.py::IOTest::test_csv_read_write` in gasnet
- [x] `tests/io_test.py::IOTest::test_csv_read_write` in default 