### PR TITLE
Closes #3417: Separate Parquet string read code from generic read function

### DIFF
--- a/src/parquet/ReadParquet.h
+++ b/src/parquet/ReadParquet.h
@@ -15,7 +15,9 @@
 #include <queue>
 extern "C" {
 #endif
- 
+  int c_readStrColumnByName(const char* filename, void* chpl_arr, const char* colname, int64_t batchSize, char** errMsg);
+  
+  int cpp_readStrColumnByName(const char* filename, void* chpl_arr, const char* colname, int64_t batchSize, char** errMsg);
 
   int c_readColumnByName(const char* filename, void* chpl_arr, bool* where_null_chpl,
                          const char* colname, int64_t numElems, int64_t startIdx,


### PR DESCRIPTION
Previously, the readColumnByName function included logic for handling strings directly within the function itself. This approach made it difficult to modify string-specific behavior because changes required updates to the entire function header across all call sites. Additionally, this approach made the code less clear as string handling logic was mixed with generic data type handling.

This pull request separates the string read code into a dedicated function. This improves code maintainability and readability by:
- Isolating string-specific logic, making it easier to modify without affecting other data types.
- Enhancing clarity by separating generic data type handling from string handling.

closes #3417