### PR TITLE
Closes #3419: Remove intertwined list column and string column byte calculation logic

### DIFF
--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -290,7 +290,7 @@ module ParquetMsg {
             const intersection = domain_intersection(locdom, filedom);
             if intersection.size > 0 {
               var col: [filedom] t;
-              byteSizes[i] = getStrColSize(filename, dsetname, col);
+              byteSizes[i] = getStrListColSize(filename, dsetname, col);
               offsets[filedom] = col;
             }
           }

--- a/src/parquet/ReadParquet.cpp
+++ b/src/parquet/ReadParquet.cpp
@@ -342,6 +342,69 @@ int cpp_readListColumnByName(const char* filename, void* chpl_arr, const char* c
 int64_t cpp_getStringColumnNumBytes(const char* filename, const char* colname, void* chpl_offsets, int64_t numElems, int64_t startIdx, int64_t batchSize, char** errMsg) {
   try {
     int64_t ty = cpp_getType(filename, colname, errMsg);
+    auto offsets = (int64_t*)chpl_offsets;
+    int64_t byteSize = 0;
+
+    if(ty == ARROWSTRING) {
+      std::unique_ptr<parquet::ParquetFileReader> parquet_reader =
+        parquet::ParquetFileReader::OpenFile(filename, false);
+
+      std::shared_ptr<parquet::FileMetaData> file_metadata = parquet_reader->metadata();
+      int num_row_groups = file_metadata->num_row_groups();
+
+      int64_t i = 0;
+      for (int r = 0; r < num_row_groups; r++) {
+        std::shared_ptr<parquet::RowGroupReader> row_group_reader =
+          parquet_reader->RowGroup(r);
+
+        int64_t values_read = 0;
+
+        std::shared_ptr<parquet::ColumnReader> column_reader;
+
+        int64_t idx;
+        idx = file_metadata -> schema() -> ColumnIndex(colname);
+
+        if(idx < 0) {
+          std::string dname(colname);
+          std::string fname(filename);
+          std::string msg = "Dataset: " + dname + " does not exist in file: " + fname; 
+          *errMsg = strdup(msg.c_str());
+          return ARROWERROR;
+        }
+        column_reader = row_group_reader->Column(idx);
+
+        int16_t definition_level;
+        parquet::ByteArrayReader* ba_reader =
+          static_cast<parquet::ByteArrayReader*>(column_reader.get());
+
+        int64_t numRead = 0;
+        while (ba_reader->HasNext() && numRead < numElems) {
+          parquet::ByteArray value;
+          (void)ba_reader->ReadBatch(1, &definition_level, nullptr, &value, &values_read);
+          if(values_read > 0) {
+            offsets[i] = value.len + 1;
+            byteSize += value.len + 1;
+            numRead += values_read;
+          } else {
+            offsets[i] = 1;
+            byteSize+=1;
+            numRead+=1;
+          }
+          i++;
+        }
+      }
+      return byteSize;
+    }
+    return ARROWERROR;
+  } catch (const std::exception& e) {
+    *errMsg = strdup(e.what());
+    return ARROWERROR;
+  }
+}
+
+int64_t cpp_getStringListColumnNumBytes(const char* filename, const char* colname, void* chpl_offsets, int64_t numElems, int64_t startIdx, int64_t batchSize, char** errMsg) {
+  try {
+    int64_t ty = cpp_getType(filename, colname, errMsg);
     int64_t dty; // used to store the type of data so we can handle lists
     if (ty == ARROWLIST) { // get the type of the list so we can verify it is ARROWSTRING
       dty = cpp_getListType(filename, colname, errMsg);
@@ -620,5 +683,9 @@ extern "C" {
 
   int64_t c_getListColumnSize(const char* filename, const char* colname, void* chpl_seg_sizes, int64_t numElems, int64_t startIdx, char** errMsg) {
     return cpp_getListColumnSize(filename, colname, chpl_seg_sizes, numElems, startIdx, errMsg);
+  }
+
+  int64_t c_getStringListColumnNumBytes(const char* filename, const char* colname, void* chpl_offsets, int64_t numElems, int64_t startIdx, int64_t batchSize, char** errMsg) {
+    return cpp_getStringListColumnNumBytes(filename, colname, chpl_offsets, numElems, startIdx, batchSize, errMsg);
   }
 }

--- a/src/parquet/ReadParquet.h
+++ b/src/parquet/ReadParquet.h
@@ -40,6 +40,9 @@ extern "C" {
                                     void* chpl_seg_sizes, int64_t numElems, int64_t startIdx, char** errMsg);
   int64_t cpp_getListColumnSize(const char* filename, const char* colname,
                                     void* chpl_seg_sizes, int64_t numElems, int64_t startIdx, char** errMsg);
+
+  int64_t c_getStringListColumnNumBytes(const char* filename, const char* colname, void* chpl_offsets, int64_t numElems, int64_t startIdx, int64_t batchSize, char** errMsg);
+  int64_t cpp_getStringListColumnNumBytes(const char* filename, const char* colname, void* chpl_offsets, int64_t numElems, int64_t startIdx, int64_t batchSize, char** errMsg);
    
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This pull request addresses a code structure that previously intertwined string list handling with regular string handling within the readColumnByName function. This tight coupling made it difficult to isolate the impact of changes on string read performance, which is a current focus area.

By separating string handling logic for lists from regular strings, we achieve the following benefits:

- Enhanced Performance Isolation: Modifications to either string type (list or regular) become more targeted, allowing for clearer performance evaluation of each change.
- Simplified Code Maintenance: Decoupling the logic improves code maintainability and reduces the risk of unintended side effects when modifying either string type.

This improved isolation will be crucial as we continue to optimize string read performance.

Closes #3419