### PR TITLE
`add-path` modification for building on Horizon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,8 @@ ifneq ("$(wildcard $(1)/lib64)","")
   INCLUDE_FLAGS += -I$(1)/include -L$(1)/lib64
   CHPL_FLAGS    += -I$(1)/include -L$(1)/lib64 --ldflags="-Wl,-rpath,$(1)/lib64"
 else
-	INCLUDE_FLAGS += -I$(1)/include -L$(1)/lib
-	CHPL_FLAGS    += -I$(1)/include -L$(1)/lib --ldflags="-Wl,-rpath,$(1)/lib"
+  INCLUDE_FLAGS += -I$(1)/include -L$(1)/lib
+  CHPL_FLAGS    += -I$(1)/include -L$(1)/lib --ldflags="-Wl,-rpath,$(1)/lib"
 endif
 endef
 # Usage: $(eval $(call add-path,/home/user/anaconda3/envs/arkouda))

--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,10 @@ define add-path
 ifneq ("$(wildcard $(1)/lib64)","")
   INCLUDE_FLAGS += -I$(1)/include -L$(1)/lib64
   CHPL_FLAGS    += -I$(1)/include -L$(1)/lib64 --ldflags="-Wl,-rpath,$(1)/lib64"
+else
+	INCLUDE_FLAGS += -I$(1)/include -L$(1)/lib
+	CHPL_FLAGS    += -I$(1)/include -L$(1)/lib --ldflags="-Wl,-rpath,$(1)/lib"
 endif
-INCLUDE_FLAGS += -I$(1)/include -L$(1)/lib
-CHPL_FLAGS    += -I$(1)/include -L$(1)/lib --ldflags="-Wl,-rpath,$(1)/lib"
 endef
 # Usage: $(eval $(call add-path,/home/user/anaconda3/envs/arkouda))
 #                               ^ no space after comma


### PR DESCRIPTION
I wasn't able to build on Horizon because `add-path` was adding two sets of flags, one for `lib` and one for `lib64`. For some reason, this was causing a linker error. Changing `add-path` to only add one or the other fixed the problem.