### PR TITLE
Improve Msg Function Registration for Module Tracking

### DIFF
--- a/src/parseServerConfig.py
+++ b/src/parseServerConfig.py
@@ -31,6 +31,8 @@ def ndStamp(nd_msg_handler_name, cmd_prefix, d, mod_name):
         f"    do return {nd_msg_handler_name}(cmd, msgArgs, st, {d});\n"
     if "Msg" in mod_name:
         ret_string += f"registerFunction(\"{cmd_prefix}{d}D\", {msg_proc_name}, \"{mod_name}\");\n"
+    else:
+        ret_string += f"registerFunction(\"{cmd_prefix}{d}D\", {msg_proc_name});\n"
     return ret_string
 
 

--- a/src/parseServerConfig.py
+++ b/src/parseServerConfig.py
@@ -27,10 +27,11 @@ def getModuleFiles(mods, src_dir):
 
 def ndStamp(nd_msg_handler_name, cmd_prefix, d, mod_name):
     msg_proc_name = f"arkouda_nd_stamp_{nd_msg_handler_name}{d}D"
-    return \
-    f"\nproc {msg_proc_name}(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws\n" + \
-    f"    do return {nd_msg_handler_name}(cmd, msgArgs, st, {d});\n" + \
-    f"registerFunction(\"{cmd_prefix}{d}D\", {msg_proc_name}, \"{mod_name}\");\n"
+    ret_string = f"\nproc {msg_proc_name}(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws\n" + \
+        f"    do return {nd_msg_handler_name}(cmd, msgArgs, st, {d});\n"
+    if "Msg" in mod_name:
+        ret_string += f"registerFunction(\"{cmd_prefix}{d}D\", {msg_proc_name}, \"{mod_name}\");\n"
+    return ret_string
 
 
 def ndStampMultiRank(nd_msg_handler_name, cmd_prefix, d1, d2, mod_name):


### PR DESCRIPTION
This pull request refines the logic for registering message-related functions (Msg functions) within the context of the saveUsedModules flag.

The `saveUsedModules` flag tracks modules that can be selectively included or excluded during the build process. However, including functions whose corresponding modules are always included by default creates unnecessary duplication in the generated function headers.

This PR introduces an explicit check to identify Msg functions with module names containing "Msg". These functions are skipped during registration, as their corresponding modules are inherently part of the build.

This will:
- Eliminates redundant function headers
- Ensure `saveUsedModules` accurately reflects modules subject to inclusion/exclusion
- Addresses build script errors caused by registering functions from always-included modules like GenSymIO