### PR TITLE
Remove legacy 'supported_scalar_types' section from config file

### DIFF
--- a/arkouda/array_api/creation_functions.py
+++ b/arkouda/array_api/creation_functions.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, List, Optional, Tuple, Union, cast
 
 from arkouda.client import generic_msg
 import numpy as np
-from arkouda.pdarrayclass import create_pdarray, pdarray, _to_pdarray
+from arkouda.pdarrayclass import create_pdarray, pdarray, _to_pdarray, scalar_array
 from arkouda.dtypes import dtype as akdtype
 from arkouda.dtypes import resolve_scalar_dtype
 
@@ -375,7 +375,7 @@ def zeros(
         ndim = len(shape)
     else:
         if shape == 0:
-            ndim = 0
+            return Array._new(scalar_array(0))
         else:
             ndim = 1
 
@@ -383,12 +383,8 @@ def zeros(
     dtype_name = cast(np.dtype, dtype).name
 
     repMsg = generic_msg(
-        cmd=f"create{ndim}D",
-        args={
-            "dtype": dtype_name,
-            "shape": shape,
-            "value": 0,
-        },
+        cmd=f"create<{dtype_name},{ndim}>",
+        args={"shape": shape},
     )
 
     return Array._new(create_pdarray(repMsg))

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -133,9 +133,8 @@ def _create_scalar_array(value):
     """
     return create_pdarray(
         generic_msg(
-            cmd="create0D",
+            cmd=f"createScalarArray<{resolve_scalar_dtype(value)}>",
             args={
-                "dtype": resolve_scalar_dtype(value),
                 "value": value,
             },
         )
@@ -292,12 +291,7 @@ def _to_pdarray(value: np.ndarray, dt=None) -> pdarray:
         )
 
     if value.shape == ():
-        return create_pdarray(
-            generic_msg(
-                cmd="create0D",
-                args={"dtype": _dtype, "value": value.item()},
-            )
-        )
+        return _create_scalar_array(value.item())
     else:
         value_flat = value.flatten()
         return create_pdarray(
@@ -1250,7 +1244,7 @@ class pdarray:
         TypeError
             Raised if value is not an int, int64, float, or float64
         """
-        cmd = f"set{self.ndim}D"
+        cmd = f"set<{self.dtype},{self.ndim}>"
         generic_msg(
             cmd=cmd, args={"array": self, "dtype": self.dtype.name, "val": self.format_other(value)}
         )
@@ -3933,15 +3927,7 @@ def fmod(dividend: Union[pdarray, numeric_scalars], divisor: Union[pdarray, nume
         )
     else:
         m = mod(dividend, divisor)
-        return create_pdarray(
-            generic_msg(
-                cmd="create0D",
-                args={
-                    "dtype": resolve_scalar_dtype(m),
-                    "value": m,
-                },
-            )
-        )
+        return _create_scalar_array(m)
 
 
 @typechecked

--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -479,7 +479,7 @@ def zeros(
     # check dtype for error
     if dtype_name not in NumericDTypes:
         raise TypeError(f"unsupported dtype {dtype}")
-    repMsg = generic_msg(cmd="create1D", args={"dtype": dtype_name, "shape": size})
+    repMsg = generic_msg(cmd=f"create<{dtype_name},1>", args={"shape": size})
 
     return create_pdarray(repMsg, max_bits=max_bits)
 
@@ -535,7 +535,7 @@ def ones(
     # check dtype for error
     if dtype_name not in NumericDTypes:
         raise TypeError(f"unsupported dtype {dtype}")
-    repMsg = generic_msg(cmd="create1D", args={"dtype": dtype_name, "shape": size})
+    repMsg = generic_msg(cmd=f"create<{dtype_name},1>", args={"shape": size})
     a = create_pdarray(repMsg)
     a.fill(1)
     if max_bits:
@@ -600,7 +600,7 @@ def full(
     # check dtype for error
     if dtype_name not in NumericDTypes:
         raise TypeError(f"unsupported dtype {dtype}")
-    repMsg = generic_msg(cmd="create1D", args={"dtype": dtype_name, "shape": size})
+    repMsg = generic_msg(cmd=f"create<{dtype_name},1>", args={"shape": size})
     a = create_pdarray(repMsg)
     a.fill(fill_value)
     if max_bits:
@@ -626,11 +626,8 @@ def scalar_array(value: numeric_scalars):
 
     return create_pdarray(
         generic_msg(
-            cmd="create0D",
-            args={
-                "dtype": resolve_scalar_dtype(value),
-                "value": value,
-            },
+            cmd=f"createScalarArray<{resolve_scalar_dtype(value)}>",
+            args={"value": value},
         )
     )
 

--- a/arkouda/random/_legacy.py
+++ b/arkouda/random/_legacy.py
@@ -97,13 +97,12 @@ def randint(
         raise TypeError(f"unsupported dtype {dtype}")
 
     repMsg = generic_msg(
-        cmd=f"randint{ndim}D",
+        cmd=f"randint<{dtype.name},{ndim}>",
         args={
             "shape": shape,
-            "dtype": dtype.name,
             "low": NUMBER_FORMAT_STRINGS[dtype.name].format(low),
             "high": NUMBER_FORMAT_STRINGS[dtype.name].format(high),
-            "seed": seed,
+            "seed": seed if seed is not None else -1,
         },
     )
     return create_pdarray(repMsg)

--- a/registration-config.json
+++ b/registration-config.json
@@ -7,23 +7,9 @@
                 "int",
                 "uint",
                 "real",
-                "bool"
+                "bool",
+                "bigint"
             ]
         }
-    },
-    "supported_scalar_types": {
-        "uint8": true,
-        "uint16": false,
-        "uint32": false,
-        "uint64": true,
-        "int8": false,
-        "int16": false,
-        "int32": false,
-        "int64": true,
-        "float32": false,
-        "float64": true,
-        "complex64": false,
-        "complex128": false,
-        "bool": true
     }
 }

--- a/src/CastMsg.chpl
+++ b/src/CastMsg.chpl
@@ -15,345 +15,65 @@ module CastMsg {
   private config const logChannel = ServerConfig.logChannel;
   const castLogger = new Logger(logLevel, logChannel);
 
-  @arkouda.registerND
-  proc castMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, param nd: int): MsgTuple throws {
-    param pn = Reflection.getRoutineName();
-    const name = msgArgs.getValueOf("name"),
-          objtype = msgArgs.getValueOf("objType").toUpper(): ObjType,
-          targetDtype = str2dtype(msgArgs.getValueOf("targetDtype")),
-          opt = msgArgs.getValueOf("opt");
-    castLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-          "name: %s obgtype: %? targetDtype: %? opt: %?".format(
-                                                 name,objtype,targetDtype,opt));
+  proc isFloatingType(type t) param : bool {
+    return isRealType(t) || isImagType(t) || isComplexType(t);
+  }
 
-    select objtype {
-      when ObjType.PDARRAY {
-        var gse: borrowed GenSymEntry = getGenericTypedArrayEntry(name, st);
+  @arkouda.instantiateAndRegister(prefix="cast")
+  proc castArray(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab,
+    type array_dtype_from,
+    type array_dtype_to,
+    param array_nd: int
+  ): MsgTuple throws
+    where !(isFloatingType(array_dtype_from) && (array_dtype_to == bigint || array_dtype_to == bool)) &&
+          !(array_dtype_from == bigint && array_dtype_to == bool)
+  {
+    const a = st[msgArgs["name"]]: SymEntry(array_dtype_from, array_nd);
+    try {
+      const b = a.a: array_dtype_to;
+      return st.insert(new shared SymEntry(b));
+    } catch {
+      return MsgTuple.error("bad value in cast from %s to %s".format(
+        type2str(array_dtype_from),
+        type2str(array_dtype_to)
+      ));
+    }
+  }
 
-        proc doScalarCast(type from, type to): MsgTuple throws
-          where isSupportedType(from) && isSupportedType(to)
-        {
-          const (success, msg) = castGenSymEntry(gse, st, from, to, nd);
-          return new MsgTuple(msg, if success then MsgType.NORMAL else MsgType.ERROR);
-        }
+  // cannot cast float types to bigint or bool, cannot cast bigint to bool
+  proc castArray(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab,
+    type array_dtype_from,
+    type array_dtype_to,
+    param array_nd: int
+  ): MsgTuple throws
+    where (isFloatingType(array_dtype_from) && (array_dtype_to == bigint || array_dtype_to == bool)) ||
+          (array_dtype_from == bigint && array_dtype_to == bool)
+  {
+    return MsgTuple.error(
+      "cannot cast array of type %s to %s".format(
+      type2str(array_dtype_from),
+      type2str(array_dtype_to)
+    ));
+  }
 
-        proc doScalarCast(type from, type to): MsgTuple throws
-          where !isSupportedType(from) || !isSupportedType(to)
-        {
-          const errorMsg = unsupportedTypeError(from, pn);
-          castLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-          return new MsgTuple(errorMsg, MsgType.ERROR);
-        }
+  @arkouda.instantiateAndRegister(prefix="castToStrings")
+  proc castArrayToStrings(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype): MsgTuple throws {
+    const name = msgArgs["name"].toScalar(string);
+    var gse: borrowed GenSymEntry = getGenericTypedArrayEntry(name, st);
+    return castGenSymEntryToString(gse, st, array_dtype);
+  }
 
-        proc doBigintCast(type from): MsgTuple throws
-          where isSupportedType(from)
-        {
-          const (success, msg) = castGenSymEntryToBigInt(gse, st, from, nd);
-          return new MsgTuple(msg, if success then MsgType.NORMAL else MsgType.ERROR);
-        }
+  @arkouda.instantiateAndRegister(prefix="castStringsTo")
+  proc castStringsToArray(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype): MsgTuple throws {
+    const name = msgArgs["name"].toScalar(string),
+          errors = msgArgs["opt"].toScalar(string).toLower() : ErrorMode;
 
-        proc doBigintCast(type from): MsgTuple throws
-          where !isSupportedType(from)
-        {
-          const errorMsg = unsupportedTypeError(from, pn);
-          castLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-          return new MsgTuple(errorMsg, MsgType.ERROR);
-        }
+    const strings = getSegString(name, st);
 
-        proc doStringCast(type from): MsgTuple throws
-          where isSupportedType(from) && nd == 1
-        {
-          const (success, msg) = castGenSymEntryToString(gse, st, from);
-          return new MsgTuple(msg, if success then MsgType.NORMAL else MsgType.ERROR);
-        }
-
-        proc doStringCast(type from): MsgTuple throws
-          where !isSupportedType(from) || nd > 1
-        {
-          const errorMsg = unsupportedTypeError(from, pn) + ". note: currently only 1D arrays can be cast to strings";
-          castLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-          return new MsgTuple(errorMsg, MsgType.ERROR);
-        }
-
-        select (gse.dtype, targetDtype) {
-            when (DType.Int64, DType.Int8) do return doScalarCast(int, int(8));
-            when (DType.Int64, DType.Int16) do return doScalarCast(int, int(16));
-            when (DType.Int64, DType.Int32) do return doScalarCast(int, int(32));
-            when (DType.Int64, DType.Int64) do return doScalarCast(int, int);
-            when (DType.Int64, DType.UInt8) do return doScalarCast(int, uint(8));
-            when (DType.Int64, DType.UInt16) do return doScalarCast(int, uint(16));
-            when (DType.Int64, DType.UInt32) do return doScalarCast(int, uint(32));
-            when (DType.Int64, DType.UInt64) do return doScalarCast(int, uint);
-            when (DType.Int64, DType.Float32) do return doScalarCast(int, real(32));
-            when (DType.Int64, DType.Float64) do return doScalarCast(int, real(64));
-            when (DType.Int64, DType.Complex64) do return doScalarCast(int, complex(64));
-            when (DType.Int64, DType.Complex128) do return doScalarCast(int, complex(128));
-            when (DType.Int64, DType.Bool) do return doScalarCast(int, bool);
-            when (DType.Int64, DType.Strings) do return doStringCast(int);
-            when (DType.Int64, DType.BigInt) do return doBigintCast(int);
-
-            when (DType.Int32, DType.Int8) do return doScalarCast(int(32), int(8));
-            when (DType.Int32, DType.Int16) do return doScalarCast(int(32), int(16));
-            when (DType.Int32, DType.Int32) do return doScalarCast(int(32), int(32));
-            when (DType.Int32, DType.Int64) do return doScalarCast(int(32), int(64));
-            when (DType.Int32, DType.UInt8) do return doScalarCast(int(32), uint(8));
-            when (DType.Int32, DType.UInt16) do return doScalarCast(int(32), uint(16));
-            when (DType.Int32, DType.UInt32) do return doScalarCast(int(32), uint(32));
-            when (DType.Int32, DType.UInt64) do return doScalarCast(int(32), uint(64));
-            when (DType.Int32, DType.Float32) do return doScalarCast(int(32), real(32));
-            when (DType.Int32, DType.Float64) do return doScalarCast(int(32), real(64));
-            when (DType.Int32, DType.Complex64) do return doScalarCast(int(32), complex(64));
-            when (DType.Int32, DType.Complex128) do return doScalarCast(int(32), complex(128));
-            when (DType.Int32, DType.Bool) do return doScalarCast(int(32), bool);
-            when (DType.Int32, DType.Strings) do return doStringCast(int(32));
-            when (DType.Int32, DType.BigInt) do return doBigintCast(int(32));
-
-            when (DType.Int16, DType.Int8) do return doScalarCast(int(16), int(8));
-            when (DType.Int16, DType.Int16) do return doScalarCast(int(16), int(16));
-            when (DType.Int16, DType.Int32) do return doScalarCast(int(16), int(32));
-            when (DType.Int16, DType.Int64) do return doScalarCast(int(16), int(64));
-            when (DType.Int16, DType.UInt8) do return doScalarCast(int(16), uint(8));
-            when (DType.Int16, DType.UInt16) do return doScalarCast(int(16), uint(16));
-            when (DType.Int16, DType.UInt32) do return doScalarCast(int(16), uint(32));
-            when (DType.Int16, DType.UInt64) do return doScalarCast(int(16), uint(64));
-            when (DType.Int16, DType.Float32) do return doScalarCast(int(16), real(32));
-            when (DType.Int16, DType.Float64) do return doScalarCast(int(16), real(64));
-            when (DType.Int16, DType.Complex64) do return doScalarCast(int(16), complex(64));
-            when (DType.Int16, DType.Complex128) do return doScalarCast(int(16), complex(128));
-            when (DType.Int16, DType.Bool) do return doScalarCast(int(16), bool);
-            when (DType.Int16, DType.Strings) do return doStringCast(int(16));
-            when (DType.Int16, DType.BigInt) do return doBigintCast(int(16));
-
-            when (DType.Int8, DType.Int8) do return doScalarCast(int(8), int(8));
-            when (DType.Int8, DType.Int16) do return doScalarCast(int(8), int(16));
-            when (DType.Int8, DType.Int32) do return doScalarCast(int(8), int(32));
-            when (DType.Int8, DType.Int64) do return doScalarCast(int(8), int);
-            when (DType.Int8, DType.UInt8) do return doScalarCast(int(8), uint(8));
-            when (DType.Int8, DType.UInt16) do return doScalarCast(int(8), uint(16));
-            when (DType.Int8, DType.UInt32) do return doScalarCast(int(8), uint(32));
-            when (DType.Int8, DType.UInt64) do return doScalarCast(int(8), uint);
-            when (DType.Int8, DType.Float32) do return doScalarCast(int(8), real(32));
-            when (DType.Int8, DType.Float64) do return doScalarCast(int(8), real(64));
-            when (DType.Int8, DType.Complex64) do return doScalarCast(int(8), complex(64));
-            when (DType.Int8, DType.Complex128) do return doScalarCast(int(8), complex(128));
-            when (DType.Int8, DType.Bool) do return doScalarCast(int(8), bool);
-            when (DType.Int8, DType.Strings) do return doStringCast(int(8));
-            when (DType.Int8, DType.BigInt) do return doBigintCast(int(8));
-
-            when (DType.UInt64, DType.Int8) do return doScalarCast(uint, int(8));
-            when (DType.UInt64, DType.Int16) do return doScalarCast(uint, int(16));
-            when (DType.UInt64, DType.Int32) do return doScalarCast(uint, int(32));
-            when (DType.UInt64, DType.Int64) do return doScalarCast(uint, int);
-            when (DType.UInt64, DType.UInt8) do return doScalarCast(uint, uint(8));
-            when (DType.UInt64, DType.UInt16) do return doScalarCast(uint, uint(16));
-            when (DType.UInt64, DType.UInt32) do return doScalarCast(uint, uint(32));
-            when (DType.UInt64, DType.UInt64) do return doScalarCast(uint, uint);
-            when (DType.UInt64, DType.Float32) do return doScalarCast(uint, real(32));
-            when (DType.UInt64, DType.Float64) do return doScalarCast(uint, real(64));
-            when (DType.UInt64, DType.Complex64) do return doScalarCast(uint, complex(64));
-            when (DType.UInt64, DType.Complex128) do return doScalarCast(uint, complex(128));
-            when (DType.UInt64, DType.Bool) do return doScalarCast(uint, bool);
-            when (DType.UInt64, DType.Strings) do return doStringCast(uint);
-            when (DType.UInt64, DType.BigInt) do return doBigintCast(uint);
-
-            when (DType.UInt32, DType.Int8) do return doScalarCast(uint(32), int(8));
-            when (DType.UInt32, DType.Int16) do return doScalarCast(uint(32), int(16));
-            when (DType.UInt32, DType.Int32) do return doScalarCast(uint(32), int(32));
-            when (DType.UInt32, DType.Int64) do return doScalarCast(uint(32), int(64));
-            when (DType.UInt32, DType.UInt8) do return doScalarCast(uint(32), uint(8));
-            when (DType.UInt32, DType.UInt16) do return doScalarCast(uint(32), uint(16));
-            when (DType.UInt32, DType.UInt32) do return doScalarCast(uint(32), uint(32));
-            when (DType.UInt32, DType.UInt64) do return doScalarCast(uint(32), uint(64));
-            when (DType.UInt32, DType.Float32) do return doScalarCast(uint(32), real(32));
-            when (DType.UInt32, DType.Float64) do return doScalarCast(uint(32), real(64));
-            when (DType.UInt32, DType.Complex64) do return doScalarCast(uint(32), complex(64));
-            when (DType.UInt32, DType.Complex128) do return doScalarCast(uint(32), complex(128));
-            when (DType.UInt32, DType.Bool) do return doScalarCast(uint(32), bool);
-            when (DType.UInt32, DType.Strings) do return doStringCast(uint(32));
-            when (DType.UInt32, DType.BigInt) do return doBigintCast(uint(32));
-
-            when (DType.UInt16, DType.Int8) do return doScalarCast(uint(16), int(8));
-            when (DType.UInt16, DType.Int16) do return doScalarCast(uint(16), int(16));
-            when (DType.UInt16, DType.Int32) do return doScalarCast(uint(16), int(32));
-            when (DType.UInt16, DType.Int64) do return doScalarCast(uint(16), int(64));
-            when (DType.UInt16, DType.UInt8) do return doScalarCast(uint(16), uint(8));
-            when (DType.UInt16, DType.UInt16) do return doScalarCast(uint(16), uint(16));
-            when (DType.UInt16, DType.UInt32) do return doScalarCast(uint(16), uint(32));
-            when (DType.UInt16, DType.UInt64) do return doScalarCast(uint(16), uint(64));
-            when (DType.UInt16, DType.Float32) do return doScalarCast(uint(16), real(32));
-            when (DType.UInt16, DType.Float64) do return doScalarCast(uint(16), real(64));
-            when (DType.UInt16, DType.Complex64) do return doScalarCast(uint(16), complex(64));
-            when (DType.UInt16, DType.Complex128) do return doScalarCast(uint(16), complex(128));
-            when (DType.UInt16, DType.Bool) do return doScalarCast(uint(16), bool);
-            when (DType.UInt16, DType.Strings) do return doStringCast(uint(16));
-            when (DType.UInt16, DType.BigInt) do return doBigintCast(uint(16));
-
-            when (DType.UInt8, DType.Int8) do return doScalarCast(uint(8), int(8));
-            when (DType.UInt8, DType.Int16) do return doScalarCast(uint(8), int(16));
-            when (DType.UInt8, DType.Int32) do return doScalarCast(uint(8), int(32));
-            when (DType.UInt8, DType.Int64) do return doScalarCast(uint(8), int);
-            when (DType.UInt8, DType.UInt8) do return doScalarCast(uint(8), uint(8));
-            when (DType.UInt8, DType.UInt16) do return doScalarCast(uint(8), uint(16));
-            when (DType.UInt8, DType.UInt32) do return doScalarCast(uint(8), uint(32));
-            when (DType.UInt8, DType.UInt64) do return doScalarCast(uint(8), uint);
-            when (DType.UInt8, DType.Float32) do return doScalarCast(uint(8), real(32));
-            when (DType.UInt8, DType.Float64) do return doScalarCast(uint(8), real(64));
-            when (DType.UInt8, DType.Complex64) do return doScalarCast(uint(8), complex(64));
-            when (DType.UInt8, DType.Complex128) do return doScalarCast(uint(8), complex(128));
-            when (DType.UInt8, DType.Bool) do return doScalarCast(uint(8), bool);
-            when (DType.UInt8, DType.Strings) do return doStringCast(uint(8));
-            when (DType.UInt8, DType.BigInt) do return doBigintCast(uint(8));
-
-            when (DType.Float64, DType.Int8) do return doScalarCast(real, int(8));
-            when (DType.Float64, DType.Int16) do return doScalarCast(real, int(16));
-            when (DType.Float64, DType.Int32) do return doScalarCast(real, int(32));
-            when (DType.Float64, DType.Int64) do return doScalarCast(real, int(64));
-            when (DType.Float64, DType.UInt8) do return doScalarCast(real, uint(8));
-            when (DType.Float64, DType.UInt16) do return doScalarCast(real, uint(16));
-            when (DType.Float64, DType.UInt32) do return doScalarCast(real, uint(32));
-            when (DType.Float64, DType.UInt64) do return doScalarCast(real, uint(64));
-            when (DType.Float64, DType.Float32) do return doScalarCast(real, real(32));
-            when (DType.Float64, DType.Float64) do return doScalarCast(real, real(64));
-            when (DType.Float64, DType.Complex64) do return doScalarCast(real, complex(64));
-            when (DType.Float64, DType.Complex128) do return doScalarCast(real, complex(128));
-            when (DType.Float64, DType.Bool) do return doScalarCast(real, bool);
-            when (DType.Float64, DType.Strings) do return doStringCast(real);
-
-            when (DType.Float32, DType.Int8) do return doScalarCast(real(32), int(8));
-            when (DType.Float32, DType.Int16) do return doScalarCast(real(32), int(16));
-            when (DType.Float32, DType.Int32) do return doScalarCast(real(32), int(32));
-            when (DType.Float32, DType.Int64) do return doScalarCast(real(32), int(64));
-            when (DType.Float32, DType.UInt8) do return doScalarCast(real(32), uint(8));
-            when (DType.Float32, DType.UInt16) do return doScalarCast(real(32), uint(16));
-            when (DType.Float32, DType.UInt32) do return doScalarCast(real(32), uint(32));
-            when (DType.Float32, DType.UInt64) do return doScalarCast(real(32), uint(64));
-            when (DType.Float32, DType.Float32) do return doScalarCast(real(32), real(32));
-            when (DType.Float32, DType.Float64) do return doScalarCast(real(32), real(64));
-            when (DType.Float32, DType.Complex64) do return doScalarCast(real(32), complex(64));
-            when (DType.Float32, DType.Complex128) do return doScalarCast(real(32), complex(128));
-            when (DType.Float32, DType.Bool) do return doScalarCast(real(32), bool);
-            when (DType.Float32, DType.Strings) do return doStringCast(real(32));
-
-            when (DType.Complex128, DType.Int8) do return doScalarCast(complex(128), int(8));
-            when (DType.Complex128, DType.Int16) do return doScalarCast(complex(128), int(16));
-            when (DType.Complex128, DType.Int32) do return doScalarCast(complex(128), int(32));
-            when (DType.Complex128, DType.Int64) do return doScalarCast(complex(128), int(64));
-            when (DType.Complex128, DType.UInt8) do return doScalarCast(complex(128), uint(8));
-            when (DType.Complex128, DType.UInt16) do return doScalarCast(complex(128), uint(16));
-            when (DType.Complex128, DType.UInt32) do return doScalarCast(complex(128), uint(32));
-            when (DType.Complex128, DType.UInt64) do return doScalarCast(complex(128), uint(64));
-            when (DType.Complex128, DType.Float32) do return doScalarCast(complex(128), real(32));
-            when (DType.Complex128, DType.Float64) do return doScalarCast(complex(128), real(64));
-            when (DType.Complex128, DType.Complex64) do return doScalarCast(complex(128), complex(64));
-            when (DType.Complex128, DType.Complex128) do return doScalarCast(complex(128), complex(128));
-            when (DType.Complex128, DType.Strings) do return doStringCast(complex(128));
-
-            when (DType.Complex64, DType.Int8) do return doScalarCast(complex(64), int(8));
-            when (DType.Complex64, DType.Int16) do return doScalarCast(complex(64), int(16));
-            when (DType.Complex64, DType.Int32) do return doScalarCast(complex(64), int(32));
-            when (DType.Complex64, DType.Int64) do return doScalarCast(complex(64), int(64));
-            when (DType.Complex64, DType.UInt8) do return doScalarCast(complex(64), uint(8));
-            when (DType.Complex64, DType.UInt16) do return doScalarCast(complex(64), uint(16));
-            when (DType.Complex64, DType.UInt32) do return doScalarCast(complex(64), uint(32));
-            when (DType.Complex64, DType.UInt64) do return doScalarCast(complex(64), uint(64));
-            when (DType.Complex64, DType.Float32) do return doScalarCast(complex(64), real(32));
-            when (DType.Complex64, DType.Float64) do return doScalarCast(complex(64), real(64));
-            when (DType.Complex64, DType.Complex64) do return doScalarCast(complex(64), complex(64));
-            when (DType.Complex64, DType.Complex128) do return doScalarCast(complex(64), complex(128));
-            when (DType.Complex64, DType.Strings) do return doStringCast(complex(64));
-
-            when (DType.Bool, DType.Int8) do return doScalarCast(bool, int(8));
-            when (DType.Bool, DType.Int16) do return doScalarCast(bool, int(16));
-            when (DType.Bool, DType.Int32) do return doScalarCast(bool, int(32));
-            when (DType.Bool, DType.Int64) do return doScalarCast(bool, int(64));
-            when (DType.Bool, DType.UInt8) do return doScalarCast(bool, uint(8));
-            when (DType.Bool, DType.UInt16) do return doScalarCast(bool, uint(16));
-            when (DType.Bool, DType.UInt32) do return doScalarCast(bool, uint(32));
-            when (DType.Bool, DType.UInt64) do return doScalarCast(bool, uint(64));
-            when (DType.Bool, DType.Float32) do return doScalarCast(bool, real(32));
-            when (DType.Bool, DType.Float64) do return doScalarCast(bool, real(64));
-            when (DType.Bool, DType.Complex64) do return doScalarCast(bool, complex(64));
-            when (DType.Bool, DType.Complex128) do return doScalarCast(bool, complex(128));
-            when (DType.Bool, DType.Bool) do return doScalarCast(bool, bool);
-            when (DType.Bool, DType.Strings) do return doStringCast(bool);
-            when (DType.Bool, DType.BigInt) do return doBigintCast(bool);
-
-            when (DType.BigInt, DType.UInt8) do return doScalarCast(bigint, uint(8));
-            when (DType.BigInt, DType.UInt16) do return doScalarCast(bigint, uint(16));
-            when (DType.BigInt, DType.UInt32) do return doScalarCast(bigint, uint(32));
-            when (DType.BigInt, DType.UInt64) do return doScalarCast(bigint, uint(64));
-            when (DType.BigInt, DType.Int8) do return doScalarCast(bigint, int(8));
-            when (DType.BigInt, DType.Int16) do return doScalarCast(bigint, int(16));
-            when (DType.BigInt, DType.Int32) do return doScalarCast(bigint, int(32));
-            when (DType.BigInt, DType.Int64) do return doScalarCast(bigint, int(64));
-            when (DType.BigInt, DType.Float32) do return doScalarCast(bigint, real(32));
-            when (DType.BigInt, DType.Float64) do return doScalarCast(bigint, real(64));
-            when (DType.BigInt, DType.Strings) do return doStringCast(bigint);
-            when (DType.BigInt, DType.BigInt) do return doBigintCast(bigint);
-
-            otherwise {
-                var errorMsg = notImplementedError(pn,gse.dtype,":",targetDtype);
-                castLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg, MsgType.ERROR);
-            }
-        }
-      }
-      when ObjType.STRINGS {
-          const strings = getSegString(name, st);
-          const errors = opt.toLower() : ErrorMode;
-
-          proc doCastString(type to): MsgTuple throws
-            where isSupportedType(to)
-          {
-            const msg = castStringToSymEntry(strings, st, to, errors);
-            return new MsgTuple(msg, MsgType.NORMAL);
-          }
-
-          proc doCastString(type to): MsgTuple throws
-            where !isSupportedType(to)
-          {
-            const errorMsg = unsupportedTypeError(to, pn);
-            castLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-            return new MsgTuple(errorMsg, MsgType.ERROR);
-          }
-
-          select targetDtype {
-            when DType.Int64 do return doCastString(int);
-            when DType.Int32 do return doCastString(int(32));
-            when DType.Int16 do return doCastString(int(16));
-            when DType.Int8 do return doCastString(int(8));
-            when DType.UInt8 do return doCastString(uint(8));
-            when DType.UInt16 do return doCastString(uint(16));
-            when DType.UInt32 do return doCastString(uint(32));
-            when DType.UInt64 do return doCastString(uint);
-            when DType.Float64 do return doCastString(real);
-            when DType.Float32 do return doCastString(real(32));
-            when DType.Complex128 do return doCastString(complex(128));
-            when DType.Complex64 do return doCastString(complex(64));
-            when DType.Bool do return doCastString(bool);
-            when DType.BigInt do {
-              const msg = castStringToBigInt(strings, st, errors);
-              return new MsgTuple(msg, MsgType.NORMAL);
-            }
-            when DType.Strings {
-              const oname = st.nextName();
-              const vname = st.nextName();
-              var offsets = st.addEntry(oname, createSymEntry(strings.offsets.a));
-              var values = st.addEntry(vname, createSymEntry(strings.values.a));
-              return new MsgTuple("created " + st.attrib(oname) + "+created " + st.attrib(vname), MsgType.NORMAL);
-            }
-            otherwise {
-              var errorMsg = notImplementedError(pn,DType.Strings,":",targetDtype);
-              castLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-              return new MsgTuple(errorMsg, MsgType.ERROR);
-            }
-          }
-      }
-      otherwise {
-        var errorMsg = notImplementedError(pn,objtype:string);
-        castLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-        return new MsgTuple(errorMsg, MsgType.ERROR);
-      }
+    if array_dtype == bigint {
+      return MsgTuple.success(castStringToBigInt(strings, st, errors));
+    } else {
+      return MsgTuple.success(castStringToSymEntry(strings, st, array_dtype, errors));
     }
   }
 

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -72,9 +72,7 @@ module MultiTypeSymbolTable
 
             :returns: borrow of newly created `SymEntry(t)`
         */
-        proc addEntry(name: string, shape: int ...?N, type t): borrowed SymEntry(t, N) throws
-            where isSupportedType(t)
-        {
+        proc addEntry(name: string, shape: int ...?N, type t): borrowed SymEntry(t, N) throws {
             // check and throw if memory limit would be exceeded
             // TODO figure out a way to do memory checking for bigint
             if t != bigint {
@@ -99,16 +97,6 @@ module MultiTypeSymbolTable
 
         proc addEntry(name: string, shape: ?ND*int, type t): borrowed SymEntry(t, ND) throws
             do return addEntry(name, (...shape), t);
-
-        proc addEntry(name: string, shape: int ...?N, type t): borrowed SymEntry(t, N) throws
-            where !isSupportedType(t)
-        {
-            throw new ConfigurationError(
-                "The server was not configured to support pdarray's of type %s. ".format(t:string) +
-                "Please update the configuration and recompile.",
-                getLineNumber(),getRoutineName(),getModuleName()
-            );
-        }
 
         /*
         Takes an already created AbstractSymEntry and creates a new AbstractSymEntry.

--- a/src/NumPyDType.chpl
+++ b/src/NumPyDType.chpl
@@ -79,6 +79,10 @@ module NumPyDType
       }
     }
 
+    proc typeSize(type t): int {
+      return dtypeSize(whichDtype(t));
+    }
+
     /* Turns a dtype string in pythonland into a DType
 
     :arg dstr: pythonic dtype to be converted

--- a/src/RandArray.chpl
+++ b/src/RandArray.chpl
@@ -19,15 +19,6 @@ module RandArray {
   private config const logChannel = ServerConfig.logChannel;
   const raLogger = new Logger(logLevel, logChannel);
 
-  proc fillRand(ref a: [] ?t, const in aMin: t, const in aMax: t, const seedStr:string="None") throws {
-    if (seedStr == "None") {
-      fillRandom(a, aMin, aMax);
-    } else {
-      var seed = (seedStr:int) + here.id;
-      fillRandom(a, aMin, aMax, seed);
-    }
-  }
-
   proc fillInt(ref a:[] ?t, const aMin: t, const aMax: t, const seedStr:string="None") throws where isIntType(t) {
       if (seedStr.toLower() == "none") {
         //Subtracting 1 from aMax to make the value exclusive to follow numpy standard.
@@ -50,23 +41,6 @@ module RandArray {
       }
   }
 
-  proc fillReal(ref a:[] real, const aMin:numeric=0.0, const aMax:numeric=1.0, const seedStr:string="None") throws {
-    if (seedStr.toLower() == "none") {
-      fillRandom(a, aMin, aMax);
-    } else {
-      var seed = (seedStr:int) + here.id;
-      fillRandom(a, aMin, aMax, seed);
-    }
-  }
-
-  proc fillBool(ref a:[] bool, const seedStr:string="None") throws {
-    if (seedStr.toLower() == "none") {
-      fillRandom(a);
-    } else {
-      var seed = (seedStr:int) + here.id;
-      fillRandom(a, seed);
-    }
-  }
 
   proc fillNormal(ref a:[?D] real, const seedStr:string="None") throws {
     // uses Box–Muller transform

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -45,63 +45,6 @@ module ServerConfig
     config param MaxArrayDims: int = 1;
 
     /*
-      Scalar (numpy) data types supported by the server
-      set by 'serverModuleGen.py' based on 'serverConfig.json'
-    */
-    config param  SupportsUint8 = true,
-                  SupportsUint16 = false,
-                  SupportsUint32 = false,
-                  SupportsUint64 = true,
-                  SupportsInt8 = false,
-                  SupportsInt16 = false,
-                  SupportsInt32 = false,
-                  SupportsInt64 = true,
-                  SupportsFloat32 = false,
-                  SupportsFloat64 = true,
-                  SupportsComplex64 = false,
-                  SupportsComplex128 = false,
-                  SupportsBool = true;
-
-    proc isSupportedType(type t) param: bool {
-      if t == uint(8) then return SupportsUint8;
-      if t == uint(16) then return SupportsUint16;
-      if t == uint(32) then return SupportsUint32;
-      if t == uint then return SupportsUint64;
-      if t == int(8) then return SupportsInt8;
-      if t == int(16) then return SupportsInt16;
-      if t == int(32) then return SupportsInt32;
-      if t == int(64) then return SupportsInt64;
-      if t == real(32) then return SupportsFloat32;
-      if t == real then return SupportsFloat64;
-      if t == complex(64) then return SupportsComplex64;
-      if t == complex(128) then return SupportsComplex128;
-      if t == bool then return SupportsBool;
-      if t == string then return true;
-      if t == bytes then return true;
-      if t == bigint then return true;
-      return false;
-    }
-
-    proc isSupportedDType(dt: DType): bool {
-      if dt == DType.UInt8 then return SupportsUint8;
-      if dt == DType.UInt16 then return SupportsUint16;
-      if dt == DType.UInt32 then return SupportsUint32;
-      if dt == DType.UInt64 then return SupportsUint64;
-      if dt == DType.Int8 then return SupportsInt8;
-      if dt == DType.Int16 then return SupportsInt16;
-      if dt == DType.Int32 then return SupportsInt32;
-      if dt == DType.Int64 then return SupportsInt64;
-      if dt == DType.Float32 then return SupportsFloat32;
-      if dt == DType.Float64 then return SupportsFloat64;
-      if dt == DType.Complex64 then return SupportsComplex64;
-      if dt == DType.Complex128 then return SupportsComplex128;
-      if dt == DType.Bool then return SupportsBool;
-      if dt == DType.Strings then return true;
-      if dt == DType.BigInt then return true;
-      return false;
-    }
-
-    /*
     Type of deployment, which currently is either STANDARD, meaning
     that Arkouda is deployed bare-metal or within an HPC environment, 
     or on Kubernetes, defaults to Deployment.STANDARD

--- a/src/ServerDaemon.chpl
+++ b/src/ServerDaemon.chpl
@@ -350,7 +350,6 @@ module ServerDaemon {
          * 3. "Optional" modules which are included at compilation time via ServerModules.cfg
          */
         proc registerServerCommands() {
-            registerFunction("create0D", createMsg0D);
             registerFunction("delete", deleteMsg);
             registerFunction("info", infoMsg);
             registerFunction("str", strMsg);

--- a/src/parseServerConfig.py
+++ b/src/parseServerConfig.py
@@ -149,16 +149,6 @@ def createNDHandlerInstantiations(config, modules, src_dir):
     return f"{filename} -sMaxArrayDims={max_dims}"
 
 
-def getSupportedTypes(config):
-    supportedFlags = []
-    for t in ["uint8", "uint16", "uint32", "uint64", \
-              "int8", "int16", "int32", "int64", \
-              "float32", "float64", "complex64", "complex128", "bool"]:
-        isSupported = "true" if config["supported_scalar_types"][t] else "false"
-        supportedFlags.append(f"-sSupports{t.capitalize()}={isSupported}")
-    return " ".join(supportedFlags)
-
-
 def parseServerConfig(config_filename, reg_config_name, src_dir):
     server_config = json.load(open(reg_config_name, 'r'))
 
@@ -172,10 +162,7 @@ def parseServerConfig(config_filename, reg_config_name, src_dir):
     # will be instantiated for each rank from 1..max_array_dims
     nd_stamp_flags = createNDHandlerInstantiations(server_config, modules, src_dir)
 
-    # Create build flags to designate which types the server should support
-    type_flags = getSupportedTypes(server_config)
-
-    print(f"{module_source_files} {nd_stamp_flags} {type_flags}")
+    print(f"{module_source_files} {nd_stamp_flags} ")
 
 
 if __name__ == "__main__":

--- a/src/registry/Commands.chpl
+++ b/src/registry/Commands.chpl
@@ -2,6 +2,8 @@ module Commands {
 
 use CommandMap, Message, MultiTypeSymbolTable, MultiTypeSymEntry;
 
+use BigInteger;
+
 import ArgSortMsg;
 
 import ArraySetopsMsg;
@@ -9,6 +11,146 @@ import ArraySetopsMsg;
 import BroadcastMsg;
 
 import CastMsg;
+
+proc ark_cast_int_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArray(cmd, msgArgs, st, array_dtype_from=int, array_dtype_to=int, array_nd=1);
+registerFunction('cast<int64,int64,1>', ark_cast_int_int_1, 'CastMsg', 23);
+
+proc ark_cast_int_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArray(cmd, msgArgs, st, array_dtype_from=int, array_dtype_to=uint, array_nd=1);
+registerFunction('cast<int64,uint64,1>', ark_cast_int_uint_1, 'CastMsg', 23);
+
+proc ark_cast_int_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArray(cmd, msgArgs, st, array_dtype_from=int, array_dtype_to=real, array_nd=1);
+registerFunction('cast<int64,float64,1>', ark_cast_int_real_1, 'CastMsg', 23);
+
+proc ark_cast_int_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArray(cmd, msgArgs, st, array_dtype_from=int, array_dtype_to=bool, array_nd=1);
+registerFunction('cast<int64,bool,1>', ark_cast_int_bool_1, 'CastMsg', 23);
+
+proc ark_cast_int_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArray(cmd, msgArgs, st, array_dtype_from=int, array_dtype_to=bigint, array_nd=1);
+registerFunction('cast<int64,bigint,1>', ark_cast_int_bigint_1, 'CastMsg', 23);
+
+proc ark_cast_uint_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArray(cmd, msgArgs, st, array_dtype_from=uint, array_dtype_to=int, array_nd=1);
+registerFunction('cast<uint64,int64,1>', ark_cast_uint_int_1, 'CastMsg', 23);
+
+proc ark_cast_uint_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArray(cmd, msgArgs, st, array_dtype_from=uint, array_dtype_to=uint, array_nd=1);
+registerFunction('cast<uint64,uint64,1>', ark_cast_uint_uint_1, 'CastMsg', 23);
+
+proc ark_cast_uint_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArray(cmd, msgArgs, st, array_dtype_from=uint, array_dtype_to=real, array_nd=1);
+registerFunction('cast<uint64,float64,1>', ark_cast_uint_real_1, 'CastMsg', 23);
+
+proc ark_cast_uint_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArray(cmd, msgArgs, st, array_dtype_from=uint, array_dtype_to=bool, array_nd=1);
+registerFunction('cast<uint64,bool,1>', ark_cast_uint_bool_1, 'CastMsg', 23);
+
+proc ark_cast_uint_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArray(cmd, msgArgs, st, array_dtype_from=uint, array_dtype_to=bigint, array_nd=1);
+registerFunction('cast<uint64,bigint,1>', ark_cast_uint_bigint_1, 'CastMsg', 23);
+
+proc ark_cast_real_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArray(cmd, msgArgs, st, array_dtype_from=real, array_dtype_to=int, array_nd=1);
+registerFunction('cast<float64,int64,1>', ark_cast_real_int_1, 'CastMsg', 23);
+
+proc ark_cast_real_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArray(cmd, msgArgs, st, array_dtype_from=real, array_dtype_to=uint, array_nd=1);
+registerFunction('cast<float64,uint64,1>', ark_cast_real_uint_1, 'CastMsg', 23);
+
+proc ark_cast_real_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArray(cmd, msgArgs, st, array_dtype_from=real, array_dtype_to=real, array_nd=1);
+registerFunction('cast<float64,float64,1>', ark_cast_real_real_1, 'CastMsg', 23);
+
+proc ark_cast_real_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArray(cmd, msgArgs, st, array_dtype_from=real, array_dtype_to=bool, array_nd=1);
+registerFunction('cast<float64,bool,1>', ark_cast_real_bool_1, 'CastMsg', 23);
+
+proc ark_cast_real_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArray(cmd, msgArgs, st, array_dtype_from=real, array_dtype_to=bigint, array_nd=1);
+registerFunction('cast<float64,bigint,1>', ark_cast_real_bigint_1, 'CastMsg', 23);
+
+proc ark_cast_bool_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArray(cmd, msgArgs, st, array_dtype_from=bool, array_dtype_to=int, array_nd=1);
+registerFunction('cast<bool,int64,1>', ark_cast_bool_int_1, 'CastMsg', 23);
+
+proc ark_cast_bool_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArray(cmd, msgArgs, st, array_dtype_from=bool, array_dtype_to=uint, array_nd=1);
+registerFunction('cast<bool,uint64,1>', ark_cast_bool_uint_1, 'CastMsg', 23);
+
+proc ark_cast_bool_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArray(cmd, msgArgs, st, array_dtype_from=bool, array_dtype_to=real, array_nd=1);
+registerFunction('cast<bool,float64,1>', ark_cast_bool_real_1, 'CastMsg', 23);
+
+proc ark_cast_bool_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArray(cmd, msgArgs, st, array_dtype_from=bool, array_dtype_to=bool, array_nd=1);
+registerFunction('cast<bool,bool,1>', ark_cast_bool_bool_1, 'CastMsg', 23);
+
+proc ark_cast_bool_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArray(cmd, msgArgs, st, array_dtype_from=bool, array_dtype_to=bigint, array_nd=1);
+registerFunction('cast<bool,bigint,1>', ark_cast_bool_bigint_1, 'CastMsg', 23);
+
+proc ark_cast_bigint_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArray(cmd, msgArgs, st, array_dtype_from=bigint, array_dtype_to=int, array_nd=1);
+registerFunction('cast<bigint,int64,1>', ark_cast_bigint_int_1, 'CastMsg', 23);
+
+proc ark_cast_bigint_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArray(cmd, msgArgs, st, array_dtype_from=bigint, array_dtype_to=uint, array_nd=1);
+registerFunction('cast<bigint,uint64,1>', ark_cast_bigint_uint_1, 'CastMsg', 23);
+
+proc ark_cast_bigint_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArray(cmd, msgArgs, st, array_dtype_from=bigint, array_dtype_to=real, array_nd=1);
+registerFunction('cast<bigint,float64,1>', ark_cast_bigint_real_1, 'CastMsg', 23);
+
+proc ark_cast_bigint_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArray(cmd, msgArgs, st, array_dtype_from=bigint, array_dtype_to=bool, array_nd=1);
+registerFunction('cast<bigint,bool,1>', ark_cast_bigint_bool_1, 'CastMsg', 23);
+
+proc ark_cast_bigint_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArray(cmd, msgArgs, st, array_dtype_from=bigint, array_dtype_to=bigint, array_nd=1);
+registerFunction('cast<bigint,bigint,1>', ark_cast_bigint_bigint_1, 'CastMsg', 23);
+
+proc ark_castToStrings_int(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArrayToStrings(cmd, msgArgs, st, array_dtype=int);
+registerFunction('castToStrings<int64>', ark_castToStrings_int, 'CastMsg', 57);
+
+proc ark_castToStrings_uint(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArrayToStrings(cmd, msgArgs, st, array_dtype=uint);
+registerFunction('castToStrings<uint64>', ark_castToStrings_uint, 'CastMsg', 57);
+
+proc ark_castToStrings_real(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArrayToStrings(cmd, msgArgs, st, array_dtype=real);
+registerFunction('castToStrings<float64>', ark_castToStrings_real, 'CastMsg', 57);
+
+proc ark_castToStrings_bool(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArrayToStrings(cmd, msgArgs, st, array_dtype=bool);
+registerFunction('castToStrings<bool>', ark_castToStrings_bool, 'CastMsg', 57);
+
+proc ark_castToStrings_bigint(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castArrayToStrings(cmd, msgArgs, st, array_dtype=bigint);
+registerFunction('castToStrings<bigint>', ark_castToStrings_bigint, 'CastMsg', 57);
+
+proc ark_castStringsTo_int(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castStringsToArray(cmd, msgArgs, st, array_dtype=int);
+registerFunction('castStringsTo<int64>', ark_castStringsTo_int, 'CastMsg', 64);
+
+proc ark_castStringsTo_uint(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castStringsToArray(cmd, msgArgs, st, array_dtype=uint);
+registerFunction('castStringsTo<uint64>', ark_castStringsTo_uint, 'CastMsg', 64);
+
+proc ark_castStringsTo_real(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castStringsToArray(cmd, msgArgs, st, array_dtype=real);
+registerFunction('castStringsTo<float64>', ark_castStringsTo_real, 'CastMsg', 64);
+
+proc ark_castStringsTo_bool(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castStringsToArray(cmd, msgArgs, st, array_dtype=bool);
+registerFunction('castStringsTo<bool>', ark_castStringsTo_bool, 'CastMsg', 64);
+
+proc ark_castStringsTo_bigint(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return CastMsg.castStringsToArray(cmd, msgArgs, st, array_dtype=bigint);
+registerFunction('castStringsTo<bigint>', ark_castStringsTo_bigint, 'CastMsg', 64);
 
 import ConcatenateMsg;
 
@@ -56,6 +198,10 @@ proc ark_broadcast_bool_1_1(cmd: string, msgArgs: borrowed MessageArgs, st: borr
   return ManipulationMsg.broadcastToMsg(cmd, msgArgs, st, array_dtype=bool, array_nd_in=1, array_nd_out=1);
 registerFunction('broadcast<bool,1,1>', ark_broadcast_bool_1_1, 'ManipulationMsg', 62);
 
+proc ark_broadcast_bigint_1_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ManipulationMsg.broadcastToMsg(cmd, msgArgs, st, array_dtype=bigint, array_nd_in=1, array_nd_out=1);
+registerFunction('broadcast<bigint,1,1>', ark_broadcast_bigint_1_1, 'ManipulationMsg', 62);
+
 proc ark_concat_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ManipulationMsg.concatMsg(cmd, msgArgs, st, array_dtype=int, array_nd=1);
 registerFunction('concat<int64,1>', ark_concat_int_1, 'ManipulationMsg', 159);
@@ -71,6 +217,10 @@ registerFunction('concat<float64,1>', ark_concat_real_1, 'ManipulationMsg', 159)
 proc ark_concat_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ManipulationMsg.concatMsg(cmd, msgArgs, st, array_dtype=bool, array_nd=1);
 registerFunction('concat<bool,1>', ark_concat_bool_1, 'ManipulationMsg', 159);
+
+proc ark_concat_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ManipulationMsg.concatMsg(cmd, msgArgs, st, array_dtype=bigint, array_nd=1);
+registerFunction('concat<bigint,1>', ark_concat_bigint_1, 'ManipulationMsg', 159);
 
 proc ark_concatFlat_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ManipulationMsg.concatFlatMsg(cmd, msgArgs, st, array_dtype=int, array_nd=1);
@@ -88,6 +238,10 @@ proc ark_concatFlat_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borro
   return ManipulationMsg.concatFlatMsg(cmd, msgArgs, st, array_dtype=bool, array_nd=1);
 registerFunction('concatFlat<bool,1>', ark_concatFlat_bool_1, 'ManipulationMsg', 215);
 
+proc ark_concatFlat_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ManipulationMsg.concatFlatMsg(cmd, msgArgs, st, array_dtype=bigint, array_nd=1);
+registerFunction('concatFlat<bigint,1>', ark_concatFlat_bigint_1, 'ManipulationMsg', 215);
+
 proc ark_expandDims_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ManipulationMsg.expandDimsMsg(cmd, msgArgs, st, array_dtype=int, array_nd=1);
 registerFunction('expandDims<int64,1>', ark_expandDims_int_1, 'ManipulationMsg', 239);
@@ -103,6 +257,10 @@ registerFunction('expandDims<float64,1>', ark_expandDims_real_1, 'ManipulationMs
 proc ark_expandDims_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ManipulationMsg.expandDimsMsg(cmd, msgArgs, st, array_dtype=bool, array_nd=1);
 registerFunction('expandDims<bool,1>', ark_expandDims_bool_1, 'ManipulationMsg', 239);
+
+proc ark_expandDims_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ManipulationMsg.expandDimsMsg(cmd, msgArgs, st, array_dtype=bigint, array_nd=1);
+registerFunction('expandDims<bigint,1>', ark_expandDims_bigint_1, 'ManipulationMsg', 239);
 
 proc ark_flip_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ManipulationMsg.flipMsg(cmd, msgArgs, st, array_dtype=int, array_nd=1);
@@ -120,6 +278,10 @@ proc ark_flip_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed Sy
   return ManipulationMsg.flipMsg(cmd, msgArgs, st, array_dtype=bool, array_nd=1);
 registerFunction('flip<bool,1>', ark_flip_bool_1, 'ManipulationMsg', 291);
 
+proc ark_flip_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ManipulationMsg.flipMsg(cmd, msgArgs, st, array_dtype=bigint, array_nd=1);
+registerFunction('flip<bigint,1>', ark_flip_bigint_1, 'ManipulationMsg', 291);
+
 proc ark_flipAll_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ManipulationMsg.flipAllMsg(cmd, msgArgs, st, array_dtype=int, array_nd=1);
 registerFunction('flipAll<int64,1>', ark_flipAll_int_1, 'ManipulationMsg', 359);
@@ -135,6 +297,10 @@ registerFunction('flipAll<float64,1>', ark_flipAll_real_1, 'ManipulationMsg', 35
 proc ark_flipAll_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ManipulationMsg.flipAllMsg(cmd, msgArgs, st, array_dtype=bool, array_nd=1);
 registerFunction('flipAll<bool,1>', ark_flipAll_bool_1, 'ManipulationMsg', 359);
+
+proc ark_flipAll_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ManipulationMsg.flipAllMsg(cmd, msgArgs, st, array_dtype=bigint, array_nd=1);
+registerFunction('flipAll<bigint,1>', ark_flipAll_bigint_1, 'ManipulationMsg', 359);
 
 proc ark_permuteDims_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ManipulationMsg.permuteDims(cmd, msgArgs, st, array_dtype=int, array_nd=1);
@@ -152,6 +318,10 @@ proc ark_permuteDims_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borr
   return ManipulationMsg.permuteDims(cmd, msgArgs, st, array_dtype=bool, array_nd=1);
 registerFunction('permuteDims<bool,1>', ark_permuteDims_bool_1, 'ManipulationMsg', 390);
 
+proc ark_permuteDims_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ManipulationMsg.permuteDims(cmd, msgArgs, st, array_dtype=bigint, array_nd=1);
+registerFunction('permuteDims<bigint,1>', ark_permuteDims_bigint_1, 'ManipulationMsg', 390);
+
 proc ark_reshape_int_1_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ManipulationMsg.reshapeMsg(cmd, msgArgs, st, array_dtype=int, array_nd_in=1, array_nd_out=1);
 registerFunction('reshape<int64,1,1>', ark_reshape_int_1_1, 'ManipulationMsg', 440);
@@ -167,6 +337,10 @@ registerFunction('reshape<float64,1,1>', ark_reshape_real_1_1, 'ManipulationMsg'
 proc ark_reshape_bool_1_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ManipulationMsg.reshapeMsg(cmd, msgArgs, st, array_dtype=bool, array_nd_in=1, array_nd_out=1);
 registerFunction('reshape<bool,1,1>', ark_reshape_bool_1_1, 'ManipulationMsg', 440);
+
+proc ark_reshape_bigint_1_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ManipulationMsg.reshapeMsg(cmd, msgArgs, st, array_dtype=bigint, array_nd_in=1, array_nd_out=1);
+registerFunction('reshape<bigint,1,1>', ark_reshape_bigint_1_1, 'ManipulationMsg', 440);
 
 proc ark_roll_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ManipulationMsg.rollMsg(cmd, msgArgs, st, array_dtype=int, array_nd=1);
@@ -184,6 +358,10 @@ proc ark_roll_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed Sy
   return ManipulationMsg.rollMsg(cmd, msgArgs, st, array_dtype=bool, array_nd=1);
 registerFunction('roll<bool,1>', ark_roll_bool_1, 'ManipulationMsg', 522);
 
+proc ark_roll_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ManipulationMsg.rollMsg(cmd, msgArgs, st, array_dtype=bigint, array_nd=1);
+registerFunction('roll<bigint,1>', ark_roll_bigint_1, 'ManipulationMsg', 522);
+
 proc ark_rollFlattened_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ManipulationMsg.rollFlattenedMsg(cmd, msgArgs, st, array_dtype=int, array_nd=1);
 registerFunction('rollFlattened<int64,1>', ark_rollFlattened_int_1, 'ManipulationMsg', 587);
@@ -199,6 +377,10 @@ registerFunction('rollFlattened<float64,1>', ark_rollFlattened_real_1, 'Manipula
 proc ark_rollFlattened_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ManipulationMsg.rollFlattenedMsg(cmd, msgArgs, st, array_dtype=bool, array_nd=1);
 registerFunction('rollFlattened<bool,1>', ark_rollFlattened_bool_1, 'ManipulationMsg', 587);
+
+proc ark_rollFlattened_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ManipulationMsg.rollFlattenedMsg(cmd, msgArgs, st, array_dtype=bigint, array_nd=1);
+registerFunction('rollFlattened<bigint,1>', ark_rollFlattened_bigint_1, 'ManipulationMsg', 587);
 
 proc ark_squeeze_int_1_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ManipulationMsg.squeezeMsg(cmd, msgArgs, st, array_dtype=int, array_nd_in=1, array_nd_out=1);
@@ -216,6 +398,10 @@ proc ark_squeeze_bool_1_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrow
   return ManipulationMsg.squeezeMsg(cmd, msgArgs, st, array_dtype=bool, array_nd_in=1, array_nd_out=1);
 registerFunction('squeeze<bool,1,1>', ark_squeeze_bool_1_1, 'ManipulationMsg', 608);
 
+proc ark_squeeze_bigint_1_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ManipulationMsg.squeezeMsg(cmd, msgArgs, st, array_dtype=bigint, array_nd_in=1, array_nd_out=1);
+registerFunction('squeeze<bigint,1,1>', ark_squeeze_bigint_1_1, 'ManipulationMsg', 608);
+
 proc ark_stack_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ManipulationMsg.stackMsg(cmd, msgArgs, st, array_dtype=int, array_nd=1);
 registerFunction('stack<int64,1>', ark_stack_int_1, 'ManipulationMsg', 687);
@@ -231,6 +417,10 @@ registerFunction('stack<float64,1>', ark_stack_real_1, 'ManipulationMsg', 687);
 proc ark_stack_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ManipulationMsg.stackMsg(cmd, msgArgs, st, array_dtype=bool, array_nd=1);
 registerFunction('stack<bool,1>', ark_stack_bool_1, 'ManipulationMsg', 687);
+
+proc ark_stack_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ManipulationMsg.stackMsg(cmd, msgArgs, st, array_dtype=bigint, array_nd=1);
+registerFunction('stack<bigint,1>', ark_stack_bigint_1, 'ManipulationMsg', 687);
 
 proc ark_tile_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ManipulationMsg.tileMsg(cmd, msgArgs, st, array_dtype=int, array_nd=1);
@@ -248,6 +438,10 @@ proc ark_tile_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed Sy
   return ManipulationMsg.tileMsg(cmd, msgArgs, st, array_dtype=bool, array_nd=1);
 registerFunction('tile<bool,1>', ark_tile_bool_1, 'ManipulationMsg', 778);
 
+proc ark_tile_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ManipulationMsg.tileMsg(cmd, msgArgs, st, array_dtype=bigint, array_nd=1);
+registerFunction('tile<bigint,1>', ark_tile_bigint_1, 'ManipulationMsg', 778);
+
 proc ark_unstack_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ManipulationMsg.unstackMsg(cmd, msgArgs, st, array_dtype=int, array_nd=1);
 registerFunction('unstack<int64,1>', ark_unstack_int_1, 'ManipulationMsg', 819);
@@ -263,6 +457,10 @@ registerFunction('unstack<float64,1>', ark_unstack_real_1, 'ManipulationMsg', 81
 proc ark_unstack_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ManipulationMsg.unstackMsg(cmd, msgArgs, st, array_dtype=bool, array_nd=1);
 registerFunction('unstack<bool,1>', ark_unstack_bool_1, 'ManipulationMsg', 819);
+
+proc ark_unstack_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ManipulationMsg.unstackMsg(cmd, msgArgs, st, array_dtype=bigint, array_nd=1);
+registerFunction('unstack<bigint,1>', ark_unstack_bigint_1, 'ManipulationMsg', 819);
 
 proc ark_repeatFlat_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ManipulationMsg.repeatFlatMsg(cmd, msgArgs, st, array_dtype=int, array_nd=1);
@@ -280,11 +478,35 @@ proc ark_repeatFlat_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borro
   return ManipulationMsg.repeatFlatMsg(cmd, msgArgs, st, array_dtype=bool, array_nd=1);
 registerFunction('repeatFlat<bool,1>', ark_repeatFlat_bool_1, 'ManipulationMsg', 903);
 
+proc ark_repeatFlat_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ManipulationMsg.repeatFlatMsg(cmd, msgArgs, st, array_dtype=bigint, array_nd=1);
+registerFunction('repeatFlat<bigint,1>', ark_repeatFlat_bigint_1, 'ManipulationMsg', 903);
+
 import OperatorMsg;
 
 import ParquetMsg;
 
 import RandMsg;
+
+proc ark_randint_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return RandMsg.randint(cmd, msgArgs, st, array_dtype=int, array_nd=1);
+registerFunction('randint<int64,1>', ark_randint_int_1, 'RandMsg', 33);
+
+proc ark_randint_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return RandMsg.randint(cmd, msgArgs, st, array_dtype=uint, array_nd=1);
+registerFunction('randint<uint64,1>', ark_randint_uint_1, 'RandMsg', 33);
+
+proc ark_randint_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return RandMsg.randint(cmd, msgArgs, st, array_dtype=real, array_nd=1);
+registerFunction('randint<float64,1>', ark_randint_real_1, 'RandMsg', 33);
+
+proc ark_randint_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return RandMsg.randint(cmd, msgArgs, st, array_dtype=bool, array_nd=1);
+registerFunction('randint<bool,1>', ark_randint_bool_1, 'RandMsg', 33);
+
+proc ark_randint_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return RandMsg.randint(cmd, msgArgs, st, array_dtype=bigint, array_nd=1);
+registerFunction('randint<bigint,1>', ark_randint_bigint_1, 'RandMsg', 33);
 
 import ReductionMsg;
 
@@ -323,6 +545,10 @@ proc ark_mean_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed Sy
   return ark_reg_mean_generic(cmd, msgArgs, st, array_dtype_0=bool, array_nd_0=1);
 registerFunction('mean<bool,1>', ark_mean_bool_1, 'StatsMsg', 25);
 
+proc ark_mean_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_mean_generic(cmd, msgArgs, st, array_dtype_0=bigint, array_nd_0=1);
+registerFunction('mean<bigint,1>', ark_mean_bigint_1, 'StatsMsg', 25);
+
 proc ark_reg_meanReduce_generic(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype_0, param array_nd_0: int): MsgTuple throws {
   var x_array_sym = st[msgArgs['x']]: SymEntry(array_dtype_0, array_nd_0);
   ref x = x_array_sym.a;
@@ -350,6 +576,10 @@ proc ark_meanReduce_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borro
   return ark_reg_meanReduce_generic(cmd, msgArgs, st, array_dtype_0=bool, array_nd_0=1);
 registerFunction('meanReduce<bool,1>', ark_meanReduce_bool_1, 'StatsMsg', 32);
 
+proc ark_meanReduce_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_meanReduce_generic(cmd, msgArgs, st, array_dtype_0=bigint, array_nd_0=1);
+registerFunction('meanReduce<bigint,1>', ark_meanReduce_bigint_1, 'StatsMsg', 32);
+
 proc ark_reg_variance_generic(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype_0, param array_nd_0: int): MsgTuple throws {
   var x_array_sym = st[msgArgs['x']]: SymEntry(array_dtype_0, array_nd_0);
   ref x = x_array_sym.a;
@@ -375,6 +605,10 @@ registerFunction('var<float64,1>', ark_var_real_1, 'StatsMsg', 43);
 proc ark_var_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ark_reg_variance_generic(cmd, msgArgs, st, array_dtype_0=bool, array_nd_0=1);
 registerFunction('var<bool,1>', ark_var_bool_1, 'StatsMsg', 43);
+
+proc ark_var_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_variance_generic(cmd, msgArgs, st, array_dtype_0=bigint, array_nd_0=1);
+registerFunction('var<bigint,1>', ark_var_bigint_1, 'StatsMsg', 43);
 
 proc ark_reg_varReduce_generic(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype_0, param array_nd_0: int): MsgTuple throws {
   var x_array_sym = st[msgArgs['x']]: SymEntry(array_dtype_0, array_nd_0);
@@ -404,6 +638,10 @@ proc ark_varReduce_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrow
   return ark_reg_varReduce_generic(cmd, msgArgs, st, array_dtype_0=bool, array_nd_0=1);
 registerFunction('varReduce<bool,1>', ark_varReduce_bool_1, 'StatsMsg', 50);
 
+proc ark_varReduce_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_varReduce_generic(cmd, msgArgs, st, array_dtype_0=bigint, array_nd_0=1);
+registerFunction('varReduce<bigint,1>', ark_varReduce_bigint_1, 'StatsMsg', 50);
+
 proc ark_reg_std_generic(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype_0, param array_nd_0: int): MsgTuple throws {
   var x_array_sym = st[msgArgs['x']]: SymEntry(array_dtype_0, array_nd_0);
   ref x = x_array_sym.a;
@@ -429,6 +667,10 @@ registerFunction('std<float64,1>', ark_std_real_1, 'StatsMsg', 61);
 proc ark_std_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ark_reg_std_generic(cmd, msgArgs, st, array_dtype_0=bool, array_nd_0=1);
 registerFunction('std<bool,1>', ark_std_bool_1, 'StatsMsg', 61);
+
+proc ark_std_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_std_generic(cmd, msgArgs, st, array_dtype_0=bigint, array_nd_0=1);
+registerFunction('std<bigint,1>', ark_std_bigint_1, 'StatsMsg', 61);
 
 proc ark_reg_stdReduce_generic(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype_0, param array_nd_0: int): MsgTuple throws {
   var x_array_sym = st[msgArgs['x']]: SymEntry(array_dtype_0, array_nd_0);
@@ -458,6 +700,10 @@ proc ark_stdReduce_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrow
   return ark_reg_stdReduce_generic(cmd, msgArgs, st, array_dtype_0=bool, array_nd_0=1);
 registerFunction('stdReduce<bool,1>', ark_stdReduce_bool_1, 'StatsMsg', 68);
 
+proc ark_stdReduce_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_stdReduce_generic(cmd, msgArgs, st, array_dtype_0=bigint, array_nd_0=1);
+registerFunction('stdReduce<bigint,1>', ark_stdReduce_bigint_1, 'StatsMsg', 68);
+
 proc ark_reg_cov_generic(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype_0, param array_nd_0: int, type array_dtype_1, param array_nd_1: int): MsgTuple throws {
   var x_array_sym = st[msgArgs['x']]: SymEntry(array_dtype_0, array_nd_0);
   ref x = x_array_sym.a;
@@ -484,6 +730,10 @@ proc ark_cov_int_1_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrow
   return ark_reg_cov_generic(cmd, msgArgs, st, array_dtype_0=int, array_nd_0=1, array_dtype_1=bool, array_nd_1=1);
 registerFunction('cov<int64,1,bool,1>', ark_cov_int_1_bool_1, 'StatsMsg', 79);
 
+proc ark_cov_int_1_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_cov_generic(cmd, msgArgs, st, array_dtype_0=int, array_nd_0=1, array_dtype_1=bigint, array_nd_1=1);
+registerFunction('cov<int64,1,bigint,1>', ark_cov_int_1_bigint_1, 'StatsMsg', 79);
+
 proc ark_cov_uint_1_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ark_reg_cov_generic(cmd, msgArgs, st, array_dtype_0=uint, array_nd_0=1, array_dtype_1=int, array_nd_1=1);
 registerFunction('cov<uint64,1,int64,1>', ark_cov_uint_1_int_1, 'StatsMsg', 79);
@@ -499,6 +749,10 @@ registerFunction('cov<uint64,1,float64,1>', ark_cov_uint_1_real_1, 'StatsMsg', 7
 proc ark_cov_uint_1_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ark_reg_cov_generic(cmd, msgArgs, st, array_dtype_0=uint, array_nd_0=1, array_dtype_1=bool, array_nd_1=1);
 registerFunction('cov<uint64,1,bool,1>', ark_cov_uint_1_bool_1, 'StatsMsg', 79);
+
+proc ark_cov_uint_1_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_cov_generic(cmd, msgArgs, st, array_dtype_0=uint, array_nd_0=1, array_dtype_1=bigint, array_nd_1=1);
+registerFunction('cov<uint64,1,bigint,1>', ark_cov_uint_1_bigint_1, 'StatsMsg', 79);
 
 proc ark_cov_real_1_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ark_reg_cov_generic(cmd, msgArgs, st, array_dtype_0=real, array_nd_0=1, array_dtype_1=int, array_nd_1=1);
@@ -516,6 +770,10 @@ proc ark_cov_real_1_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borro
   return ark_reg_cov_generic(cmd, msgArgs, st, array_dtype_0=real, array_nd_0=1, array_dtype_1=bool, array_nd_1=1);
 registerFunction('cov<float64,1,bool,1>', ark_cov_real_1_bool_1, 'StatsMsg', 79);
 
+proc ark_cov_real_1_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_cov_generic(cmd, msgArgs, st, array_dtype_0=real, array_nd_0=1, array_dtype_1=bigint, array_nd_1=1);
+registerFunction('cov<float64,1,bigint,1>', ark_cov_real_1_bigint_1, 'StatsMsg', 79);
+
 proc ark_cov_bool_1_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ark_reg_cov_generic(cmd, msgArgs, st, array_dtype_0=bool, array_nd_0=1, array_dtype_1=int, array_nd_1=1);
 registerFunction('cov<bool,1,int64,1>', ark_cov_bool_1_int_1, 'StatsMsg', 79);
@@ -531,6 +789,30 @@ registerFunction('cov<bool,1,float64,1>', ark_cov_bool_1_real_1, 'StatsMsg', 79)
 proc ark_cov_bool_1_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ark_reg_cov_generic(cmd, msgArgs, st, array_dtype_0=bool, array_nd_0=1, array_dtype_1=bool, array_nd_1=1);
 registerFunction('cov<bool,1,bool,1>', ark_cov_bool_1_bool_1, 'StatsMsg', 79);
+
+proc ark_cov_bool_1_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_cov_generic(cmd, msgArgs, st, array_dtype_0=bool, array_nd_0=1, array_dtype_1=bigint, array_nd_1=1);
+registerFunction('cov<bool,1,bigint,1>', ark_cov_bool_1_bigint_1, 'StatsMsg', 79);
+
+proc ark_cov_bigint_1_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_cov_generic(cmd, msgArgs, st, array_dtype_0=bigint, array_nd_0=1, array_dtype_1=int, array_nd_1=1);
+registerFunction('cov<bigint,1,int64,1>', ark_cov_bigint_1_int_1, 'StatsMsg', 79);
+
+proc ark_cov_bigint_1_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_cov_generic(cmd, msgArgs, st, array_dtype_0=bigint, array_nd_0=1, array_dtype_1=uint, array_nd_1=1);
+registerFunction('cov<bigint,1,uint64,1>', ark_cov_bigint_1_uint_1, 'StatsMsg', 79);
+
+proc ark_cov_bigint_1_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_cov_generic(cmd, msgArgs, st, array_dtype_0=bigint, array_nd_0=1, array_dtype_1=real, array_nd_1=1);
+registerFunction('cov<bigint,1,float64,1>', ark_cov_bigint_1_real_1, 'StatsMsg', 79);
+
+proc ark_cov_bigint_1_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_cov_generic(cmd, msgArgs, st, array_dtype_0=bigint, array_nd_0=1, array_dtype_1=bool, array_nd_1=1);
+registerFunction('cov<bigint,1,bool,1>', ark_cov_bigint_1_bool_1, 'StatsMsg', 79);
+
+proc ark_cov_bigint_1_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_cov_generic(cmd, msgArgs, st, array_dtype_0=bigint, array_nd_0=1, array_dtype_1=bigint, array_nd_1=1);
+registerFunction('cov<bigint,1,bigint,1>', ark_cov_bigint_1_bigint_1, 'StatsMsg', 79);
 
 proc ark_reg_corr_generic(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype_0, param array_nd_0: int, type array_dtype_1, param array_nd_1: int): MsgTuple throws {
   var x_array_sym = st[msgArgs['x']]: SymEntry(array_dtype_0, array_nd_0);
@@ -558,6 +840,10 @@ proc ark_corr_int_1_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borro
   return ark_reg_corr_generic(cmd, msgArgs, st, array_dtype_0=int, array_nd_0=1, array_dtype_1=bool, array_nd_1=1);
 registerFunction('corr<int64,1,bool,1>', ark_corr_int_1_bool_1, 'StatsMsg', 101);
 
+proc ark_corr_int_1_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_corr_generic(cmd, msgArgs, st, array_dtype_0=int, array_nd_0=1, array_dtype_1=bigint, array_nd_1=1);
+registerFunction('corr<int64,1,bigint,1>', ark_corr_int_1_bigint_1, 'StatsMsg', 101);
+
 proc ark_corr_uint_1_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ark_reg_corr_generic(cmd, msgArgs, st, array_dtype_0=uint, array_nd_0=1, array_dtype_1=int, array_nd_1=1);
 registerFunction('corr<uint64,1,int64,1>', ark_corr_uint_1_int_1, 'StatsMsg', 101);
@@ -573,6 +859,10 @@ registerFunction('corr<uint64,1,float64,1>', ark_corr_uint_1_real_1, 'StatsMsg',
 proc ark_corr_uint_1_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ark_reg_corr_generic(cmd, msgArgs, st, array_dtype_0=uint, array_nd_0=1, array_dtype_1=bool, array_nd_1=1);
 registerFunction('corr<uint64,1,bool,1>', ark_corr_uint_1_bool_1, 'StatsMsg', 101);
+
+proc ark_corr_uint_1_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_corr_generic(cmd, msgArgs, st, array_dtype_0=uint, array_nd_0=1, array_dtype_1=bigint, array_nd_1=1);
+registerFunction('corr<uint64,1,bigint,1>', ark_corr_uint_1_bigint_1, 'StatsMsg', 101);
 
 proc ark_corr_real_1_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ark_reg_corr_generic(cmd, msgArgs, st, array_dtype_0=real, array_nd_0=1, array_dtype_1=int, array_nd_1=1);
@@ -590,6 +880,10 @@ proc ark_corr_real_1_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borr
   return ark_reg_corr_generic(cmd, msgArgs, st, array_dtype_0=real, array_nd_0=1, array_dtype_1=bool, array_nd_1=1);
 registerFunction('corr<float64,1,bool,1>', ark_corr_real_1_bool_1, 'StatsMsg', 101);
 
+proc ark_corr_real_1_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_corr_generic(cmd, msgArgs, st, array_dtype_0=real, array_nd_0=1, array_dtype_1=bigint, array_nd_1=1);
+registerFunction('corr<float64,1,bigint,1>', ark_corr_real_1_bigint_1, 'StatsMsg', 101);
+
 proc ark_corr_bool_1_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ark_reg_corr_generic(cmd, msgArgs, st, array_dtype_0=bool, array_nd_0=1, array_dtype_1=int, array_nd_1=1);
 registerFunction('corr<bool,1,int64,1>', ark_corr_bool_1_int_1, 'StatsMsg', 101);
@@ -605,6 +899,30 @@ registerFunction('corr<bool,1,float64,1>', ark_corr_bool_1_real_1, 'StatsMsg', 1
 proc ark_corr_bool_1_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ark_reg_corr_generic(cmd, msgArgs, st, array_dtype_0=bool, array_nd_0=1, array_dtype_1=bool, array_nd_1=1);
 registerFunction('corr<bool,1,bool,1>', ark_corr_bool_1_bool_1, 'StatsMsg', 101);
+
+proc ark_corr_bool_1_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_corr_generic(cmd, msgArgs, st, array_dtype_0=bool, array_nd_0=1, array_dtype_1=bigint, array_nd_1=1);
+registerFunction('corr<bool,1,bigint,1>', ark_corr_bool_1_bigint_1, 'StatsMsg', 101);
+
+proc ark_corr_bigint_1_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_corr_generic(cmd, msgArgs, st, array_dtype_0=bigint, array_nd_0=1, array_dtype_1=int, array_nd_1=1);
+registerFunction('corr<bigint,1,int64,1>', ark_corr_bigint_1_int_1, 'StatsMsg', 101);
+
+proc ark_corr_bigint_1_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_corr_generic(cmd, msgArgs, st, array_dtype_0=bigint, array_nd_0=1, array_dtype_1=uint, array_nd_1=1);
+registerFunction('corr<bigint,1,uint64,1>', ark_corr_bigint_1_uint_1, 'StatsMsg', 101);
+
+proc ark_corr_bigint_1_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_corr_generic(cmd, msgArgs, st, array_dtype_0=bigint, array_nd_0=1, array_dtype_1=real, array_nd_1=1);
+registerFunction('corr<bigint,1,float64,1>', ark_corr_bigint_1_real_1, 'StatsMsg', 101);
+
+proc ark_corr_bigint_1_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_corr_generic(cmd, msgArgs, st, array_dtype_0=bigint, array_nd_0=1, array_dtype_1=bool, array_nd_1=1);
+registerFunction('corr<bigint,1,bool,1>', ark_corr_bigint_1_bool_1, 'StatsMsg', 101);
+
+proc ark_corr_bigint_1_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_corr_generic(cmd, msgArgs, st, array_dtype_0=bigint, array_nd_0=1, array_dtype_1=bigint, array_nd_1=1);
+registerFunction('corr<bigint,1,bigint,1>', ark_corr_bigint_1_bigint_1, 'StatsMsg', 101);
 
 proc ark_reg_cumSum_generic(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype_0, param array_nd_0: int): MsgTuple throws {
   var x_array_sym = st[msgArgs['x']]: SymEntry(array_dtype_0, array_nd_0);
@@ -633,10 +951,76 @@ proc ark_cumSum_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed 
   return ark_reg_cumSum_generic(cmd, msgArgs, st, array_dtype_0=bool, array_nd_0=1);
 registerFunction('cumSum<bool,1>', ark_cumSum_bool_1, 'StatsMsg', 123);
 
+proc ark_cumSum_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_cumSum_generic(cmd, msgArgs, st, array_dtype_0=bigint, array_nd_0=1);
+registerFunction('cumSum<bigint,1>', ark_cumSum_bigint_1, 'StatsMsg', 123);
+
 import TimeClassMsg;
 
 import TransferMsg;
 
 import UniqueMsg;
+
+import MsgProcessing;
+
+proc ark_create_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return MsgProcessing.create(cmd, msgArgs, st, array_dtype=int, array_nd=1);
+registerFunction('create<int64,1>', ark_create_int_1, 'MsgProcessing', 35);
+
+proc ark_create_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return MsgProcessing.create(cmd, msgArgs, st, array_dtype=uint, array_nd=1);
+registerFunction('create<uint64,1>', ark_create_uint_1, 'MsgProcessing', 35);
+
+proc ark_create_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return MsgProcessing.create(cmd, msgArgs, st, array_dtype=real, array_nd=1);
+registerFunction('create<float64,1>', ark_create_real_1, 'MsgProcessing', 35);
+
+proc ark_create_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return MsgProcessing.create(cmd, msgArgs, st, array_dtype=bool, array_nd=1);
+registerFunction('create<bool,1>', ark_create_bool_1, 'MsgProcessing', 35);
+
+proc ark_create_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return MsgProcessing.create(cmd, msgArgs, st, array_dtype=bigint, array_nd=1);
+registerFunction('create<bigint,1>', ark_create_bigint_1, 'MsgProcessing', 35);
+
+proc ark_createScalarArray_int(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return MsgProcessing.createScalarArray(cmd, msgArgs, st, array_dtype=int);
+registerFunction('createScalarArray<int64>', ark_createScalarArray_int, 'MsgProcessing', 49);
+
+proc ark_createScalarArray_uint(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return MsgProcessing.createScalarArray(cmd, msgArgs, st, array_dtype=uint);
+registerFunction('createScalarArray<uint64>', ark_createScalarArray_uint, 'MsgProcessing', 49);
+
+proc ark_createScalarArray_real(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return MsgProcessing.createScalarArray(cmd, msgArgs, st, array_dtype=real);
+registerFunction('createScalarArray<float64>', ark_createScalarArray_real, 'MsgProcessing', 49);
+
+proc ark_createScalarArray_bool(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return MsgProcessing.createScalarArray(cmd, msgArgs, st, array_dtype=bool);
+registerFunction('createScalarArray<bool>', ark_createScalarArray_bool, 'MsgProcessing', 49);
+
+proc ark_createScalarArray_bigint(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return MsgProcessing.createScalarArray(cmd, msgArgs, st, array_dtype=bigint);
+registerFunction('createScalarArray<bigint>', ark_createScalarArray_bigint, 'MsgProcessing', 49);
+
+proc ark_set_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return MsgProcessing.setMsg(cmd, msgArgs, st, array_dtype=int, array_nd=1);
+registerFunction('set<int64,1>', ark_set_int_1, 'MsgProcessing', 299);
+
+proc ark_set_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return MsgProcessing.setMsg(cmd, msgArgs, st, array_dtype=uint, array_nd=1);
+registerFunction('set<uint64,1>', ark_set_uint_1, 'MsgProcessing', 299);
+
+proc ark_set_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return MsgProcessing.setMsg(cmd, msgArgs, st, array_dtype=real, array_nd=1);
+registerFunction('set<float64,1>', ark_set_real_1, 'MsgProcessing', 299);
+
+proc ark_set_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return MsgProcessing.setMsg(cmd, msgArgs, st, array_dtype=bool, array_nd=1);
+registerFunction('set<bool,1>', ark_set_bool_1, 'MsgProcessing', 299);
+
+proc ark_set_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return MsgProcessing.setMsg(cmd, msgArgs, st, array_dtype=bigint, array_nd=1);
+registerFunction('set<bigint,1>', ark_set_bigint_1, 'MsgProcessing', 299);
 
 }

--- a/src/registry/register_commands.py
+++ b/src/registry/register_commands.py
@@ -1,6 +1,11 @@
 import chapel
 import sys
 import json
+import itertools
+
+DEFAULT_MODS = [
+    "MsgProcessing"
+]
 
 registerAttr = ("arkouda.registerCommand", ["name"])
 instAndRegisterAttr = ("arkouda.instantiateAndRegister", ["prefix"])
@@ -25,6 +30,7 @@ chapel_scalar_types = {
     "complex(64)": "complex64",
     "complex(128)": "complex128",
     "complex": "complex128",
+    "bigint": "bigint",
 }
 
 # type and variable names from arkouda infrastructure that could conceivable be changed in the future:
@@ -597,6 +603,7 @@ def register_commands(config, source_files):
     stamps = [
         "module Commands {",
         "use CommandMap, Message, MultiTypeSymbolTable, MultiTypeSymEntry;",
+        "use BigInteger;",
     ]
 
     count = 0
@@ -711,7 +718,7 @@ def register_commands(config, source_files):
 def getModuleFiles(config, src_dir):
     with open(config, 'r') as cfg_file:
         mods = []
-        for line in cfg_file.readlines():
+        for line in itertools.chain(cfg_file.readlines(), DEFAULT_MODS):
             mod = line.split("#")[0].strip()
             if mod != "":
                 mods.append(f"{mod}.chpl" if mod[0] == '/' else f"{src_dir}/{mod}.chpl")


### PR DESCRIPTION
Removes the supported_scalar_types section from the registration-config.json file. With the new registration framework, this is replaced by the `dtype` section in the same json file.

As a part of this effort, the following commands that relied on the old type configurability system were refactored to use the new framework:
* cast
* set
* create
* randint

