### PR TITLE
Closes #3475 make fails when lib and lib64 directories are both present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,10 +57,9 @@ define add-path
 ifneq ("$(wildcard $(1)/lib64)","")
   INCLUDE_FLAGS += -I$(1)/include -L$(1)/lib64
   CHPL_FLAGS    += -I$(1)/include -L$(1)/lib64 --ldflags="-Wl,-rpath,$(1)/lib64"
-else
-  INCLUDE_FLAGS += -I$(1)/include -L$(1)/lib
-  CHPL_FLAGS    += -I$(1)/include -L$(1)/lib --ldflags="-Wl,-rpath,$(1)/lib"
 endif
+INCLUDE_FLAGS += -I$(1)/include -L$(1)/lib
+CHPL_FLAGS    += -I$(1)/include -L$(1)/lib --ldflags="-Wl,-rpath,$(1)/lib"
 endef
 # Usage: $(eval $(call add-path,/home/user/anaconda3/envs/arkouda))
 #                               ^ no space after comma


### PR DESCRIPTION
This fixes the issue described in #3475.  The solution was to revert changes in PR #3423 .


Closes #3475 make fails when lib and lib64 directories are both present