### PR TITLE
Closes #3504: Improve Parquet Integration: Stop Using Array Views

### DIFF
--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -1804,7 +1804,7 @@ module ParquetMsg {
                 datatypes[i] = ARROWINT64;
                 // set the pointer to the entry array in the list of Pointers
                 if locDom.size > 0 {
-                  ptrList[i] = c_ptrTo(e.a[locDom]): c_ptr(void);
+                  ptrList[i] = c_ptrTo(e.a[locDom.low]): c_ptr(void);
                   sizeList[i] = locDom.size;
                 }
               }
@@ -1815,7 +1815,7 @@ module ParquetMsg {
                 datatypes[i] = ARROWUINT64;
                 // set the pointer to the entry array in the list of Pointers
                 if locDom.size > 0 {
-                  ptrList[i] = c_ptrTo(e.a[locDom]): c_ptr(void);
+                  ptrList[i] = c_ptrTo(e.a[locDom.low]): c_ptr(void);
                   sizeList[i] = locDom.size;
                 }
               }
@@ -1826,7 +1826,7 @@ module ParquetMsg {
                 datatypes[i] = ARROWDOUBLE;
                 // set the pointer to the entry array in the list of Pointers
                 if locDom.size > 0 {
-                  ptrList[i] = c_ptrTo(e.a[locDom]): c_ptr(void);
+                  ptrList[i] = c_ptrTo(e.a[locDom.low]): c_ptr(void);
                   sizeList[i] = locDom.size;
                 }
               }
@@ -1837,7 +1837,7 @@ module ParquetMsg {
                 datatypes[i] = ARROWBOOLEAN;
                 // set the pointer to the entry array in the list of Pointers
                 if locDom.size > 0 {
-                  ptrList[i] = c_ptrTo(e.a[locDom]): c_ptr(void);
+                  ptrList[i] = c_ptrTo(e.a[locDom.low]): c_ptr(void);
                   sizeList[i] = locDom.size;
                 }
               }


### PR DESCRIPTION
This pull request addresses an inefficiency and recent build error related to how we interact with Parquet. Previously, we passed pointers to array views as c_ptrTo arguments. This approach had drawbacks:

- Performance: It wasn't the most efficient way to integrate with Parquet.
- Build Errors: Recent Chapel-side changes caused build errors for multi-locale builds when using c_ptrTo.

By switching to low-index array views, we achieve two key benefits:

- Fixes Build Errors: This change resolves the build errors encountered in multi-locale builds.
- Improved Performance: Low-index into domains, rather than array views offer a more performant approach.

Closes #3504