### PR TITLE
Closes #3514-add pandas-stubs to arkouda-env-dev.yml

### DIFF
--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -39,6 +39,10 @@ dependencies:
   - pytest-json-report
   - pytest-benchmark
   - mathjax
+  - sphinx-design
+  - sphinx-autodoc-typehints
+  - pandas-stubs
+  - types-python-dateutil
 
   - pip:
     # Developer dependencies


### PR DESCRIPTION
Closes #3514-add pandas-stubs to arkouda-env-dev.yml

Installing the `pandas-stubs` library prevents certain mypy errors.