### PR TITLE
Add initial implementation for Sparse Matrix Mult

### DIFF
--- a/arkouda/__init__.py
+++ b/arkouda/__init__.py
@@ -23,6 +23,8 @@ from arkouda.logger import *
 from arkouda.timeclass import *
 from arkouda.infoclass import *
 from arkouda.segarray import *
+from arkouda.sparrayclass import *
+from arkouda.sparsematrix import *
 from arkouda.dataframe import *
 from arkouda.row import *
 from arkouda.index import *

--- a/arkouda/sparrayclass.py
+++ b/arkouda/sparrayclass.py
@@ -8,13 +8,11 @@ import numpy as np
 from typeguard import typechecked
 
 from arkouda.client import generic_msg
-from arkouda.dtypes import dtype
-from arkouda.dtypes import (
-    int_scalars
-)
+from arkouda.dtypes import dtype, int_scalars
 from arkouda.logger import getArkoudaLogger
 
 logger = getArkoudaLogger(name="sparrayclass")
+
 
 class sparray:
     """
@@ -82,6 +80,9 @@ class sparray:
     def __len__(self):
         return reduce(lambda x, y: x * y, self.shape)
 
+    def __getitem__(self, key):
+        raise NotImplementedError("sparray does not support __getitem__")
+
     # def __str__(self): # This won't work out of the box for sparrays need to add this in later
     #     from arkouda.client import pdarrayIterThresh
 
@@ -91,6 +92,7 @@ class sparray:
     #     from arkouda.client import pdarrayIterThresh
 
     #     return generic_msg(cmd="repr", args={"array": self, "printThresh": pdarrayIterThresh})
+
 
 # creates sparray object
 #   only after:
@@ -128,7 +130,6 @@ def create_sparray(repMsg: str, max_bits=None) -> sparray:
         mydtype = fields[2]
         size = int(fields[3])
         ndim = int(fields[4])
-        
 
         if fields[5] == "[]":
             shape = []

--- a/arkouda/sparrayclass.py
+++ b/arkouda/sparrayclass.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import builtins
+from functools import reduce
+from typing import Optional, Sequence, Union
+
+import numpy as np
+from typeguard import typechecked
+
+from arkouda.client import generic_msg
+from arkouda.dtypes import dtype
+from arkouda.dtypes import (
+    int_scalars
+)
+from arkouda.logger import getArkoudaLogger
+
+logger = getArkoudaLogger(name="sparrayclass")
+
+class sparray:
+    """
+    The class for sparse arrays. This class contains only the
+    attributies of the array; the data resides on the arkouda
+    server. When a server operation results in a new array, arkouda
+    will create a sparray instance that points to the array data on
+    the server. As such, the user should not initialize sparray
+    instances directly.
+
+    Attributes
+    ----------
+    name : str
+        The server-side identifier for the array
+    dtype : dtype
+        The element type of the array
+    size : int_scalars
+        The size of any one dimension of the array (all dimensions are assumed to be equal sized for now)
+    ndim : int_scalars
+        The rank of the array (currently only rank 2 arrays supported)
+    shape : Sequence[int]
+        A list or tuple containing the sizes of each dimension of the array
+    layout: str
+        The layout of the array ("CSR" or "CSC" are the only valid values)
+    itemsize : int_scalars
+        The size in bytes of each element
+    """
+
+    def __init__(
+        self,
+        name: str,
+        mydtype: Union[np.dtype, str],
+        size: int_scalars,
+        ndim: int_scalars,
+        shape: Sequence[int],
+        layout: str,
+        itemsize: int_scalars,
+        max_bits: Optional[int] = None,
+    ) -> None:
+        self.name = name
+        self.dtype = dtype(mydtype)
+        self.size = size
+        self.ndim = ndim
+        self.shape = shape
+        self.layout = layout
+        self.itemsize = itemsize
+        if max_bits:
+            self.max_bits = max_bits
+
+    def __del__(self):
+        try:
+            logger.debug(f"deleting pdarray with name {self.name}")
+            generic_msg(cmd="delete", args={"name": self.name})
+        except (RuntimeError, AttributeError):
+            pass
+
+    def __bool__(self) -> builtins.bool:
+        if self.size != 1:
+            raise ValueError(
+                "The truth value of an array with more than one element is ambiguous."
+                "Use a.any() or a.all()"
+            )
+        return builtins.bool(self[0])
+
+    def __len__(self):
+        return reduce(lambda x, y: x * y, self.shape)
+
+    # def __str__(self): # This won't work out of the box for sparrays need to add this in later
+    #     from arkouda.client import pdarrayIterThresh
+
+    #     return generic_msg(cmd="str", args={"array": self, "printThresh": pdarrayIterThresh})
+
+    # def __repr__(self):
+    #     from arkouda.client import pdarrayIterThresh
+
+    #     return generic_msg(cmd="repr", args={"array": self, "printThresh": pdarrayIterThresh})
+
+# creates sparray object
+#   only after:
+#       all values have been checked by python module and...
+#       server has created pdarray already before this is called
+@typechecked
+def create_sparray(repMsg: str, max_bits=None) -> sparray:
+    """
+    Return a sparray instance pointing to an array created by the arkouda server.
+    The user should not call this function directly.
+
+    Parameters
+    ----------
+    repMsg : str
+        space-delimited string containing the sparray name, datatype, size
+        dimension, shape,and itemsize
+
+    Returns
+    -------
+    sparray
+        A sparray with the same attributes as on the server
+
+    Raises
+    -----
+    ValueError
+        If there's an error in parsing the repMsg parameter into the six
+        values needed to create the pdarray instance
+    RuntimeError
+        Raised if a server-side error is thrown in the process of creating
+        the pdarray instance
+    """
+    try:
+        fields = repMsg.split()
+        name = fields[1]
+        mydtype = fields[2]
+        size = int(fields[3])
+        ndim = int(fields[4])
+        
+
+        if fields[5] == "[]":
+            shape = []
+        else:
+            trailing_comma_offset = -2 if fields[5][len(fields[5]) - 2] == "," else -1
+            shape = [int(el) for el in fields[5][1:trailing_comma_offset].split(",")]
+        layout = fields[6]
+        itemsize = int(fields[7])
+    except Exception as e:
+        raise ValueError(e)
+    logger.debug(
+        f"created Chapel sparse array with name: {name} dtype: {mydtype} ndim: {ndim} "
+        + f"shape: {shape} layout: {layout} itemsize: {itemsize}"
+    )
+    return sparray(name, dtype(mydtype), size, ndim, shape, layout, itemsize, max_bits)

--- a/arkouda/sparsematrix.py
+++ b/arkouda/sparsematrix.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typeguard import typechecked
+from arkouda.client import generic_msg
+from arkouda.logger import getArkoudaLogger
+from arkouda.sparrayclass import sparray, create_sparray
+
+__all__ = ["random_sparse_matrix", "sparse_matrix_matrix_mult"]
+
+logger = getArkoudaLogger(name="sparsematrix")
+
+@typechecked
+def random_sparse_matrix(size: int, density: float, layout:str) -> sparray:
+    """
+    Create a random sparse matrix with the specified number of rows and columns
+    and the specified density. The density is the fraction of non-zero elements
+    in the matrix. The non-zero elements are uniformly distributed random
+    numbers in the range [0,1).
+
+    Parameters
+    ----------
+    nrows : int
+        The number of rows in the matrix
+    ncols : int
+        The number of columns in the matrix
+    density : float
+        The fraction of non-zero elements in the matrix
+    dtype : Union[DTypes, str]
+        The dtype of the elements in the matrix
+
+    Returns
+    -------
+    sparray
+        A sparse matrix with the specified number of rows and columns
+        and the specified density
+
+    Raises
+    ------
+    ValueError
+        Raised if density is not in the range [0,1]
+    """
+    if density < 0.0 or density > 1.0:
+        raise ValueError("density must be in the range [0,1]")
+    repMsg = generic_msg(
+        cmd="random_sparse_matrix",
+        args={
+            # "dtype": dtype,
+            "size":size,
+            "density": density,
+            # shape : always 2D
+            "layout": layout,
+            # distributed ? maybe always true? maybe not for now
+        },
+    )
+
+    return create_sparray(repMsg)
+
+@typechecked
+def sparse_matrix_matrix_mult(A, B: sparray) -> sparray:
+    """
+    Multiply two sparse matrices.
+
+    Parameters
+    ----------
+    A : sparray
+        The left-hand sparse matrix
+    B : sparray
+        The right-hand sparse matrix
+
+    Returns
+    -------
+    sparray
+        The product of the two sparse matrices
+    """
+    if not (isinstance(A, sparray) and isinstance(B, sparray)):
+        raise TypeError("A and B must be sparrays for sparse_matrix_matrix_mult")
+    repMsg = generic_msg(
+        cmd="sparse_matrix_matrix_mult",
+        args={"arg1": A.name, "arg2": B.name},
+    )
+
+    return create_sparray(repMsg)

--- a/arkouda/sparsematrix.py
+++ b/arkouda/sparsematrix.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
 from typeguard import typechecked
+
 from arkouda.client import generic_msg
 from arkouda.logger import getArkoudaLogger
-from arkouda.sparrayclass import sparray, create_sparray
+from arkouda.sparrayclass import create_sparray, sparray
 
 __all__ = ["random_sparse_matrix", "sparse_matrix_matrix_mult"]
 
 logger = getArkoudaLogger(name="sparsematrix")
 
+
 @typechecked
-def random_sparse_matrix(size: int, density: float, layout:str) -> sparray:
+def random_sparse_matrix(size: int, density: float, layout: str) -> sparray:
     """
     Create a random sparse matrix with the specified number of rows and columns
     and the specified density. The density is the fraction of non-zero elements
@@ -43,7 +45,7 @@ def random_sparse_matrix(size: int, density: float, layout:str) -> sparray:
         cmd="random_sparse_matrix",
         args={
             # "dtype": dtype,
-            "size":size,
+            "size": size,
             "density": density,
             # shape : always 2D
             "layout": layout,
@@ -52,6 +54,7 @@ def random_sparse_matrix(size: int, density: float, layout:str) -> sparray:
     )
 
     return create_sparray(repMsg)
+
 
 @typechecked
 def sparse_matrix_matrix_mult(A, B: sparray) -> sparray:

--- a/arkouda/sparsematrix.py
+++ b/arkouda/sparsematrix.py
@@ -19,10 +19,8 @@ def random_sparse_matrix(size: int, density: float, layout:str) -> sparray:
 
     Parameters
     ----------
-    nrows : int
-        The number of rows in the matrix
-    ncols : int
-        The number of columns in the matrix
+    size : int
+        The number of rows in the matrix, columns are equal to rows right now
     density : float
         The fraction of non-zero elements in the matrix
     dtype : Union[DTypes, str]

--- a/src/MultiTypeSymbolTable.chpl
+++ b/src/MultiTypeSymbolTable.chpl
@@ -420,7 +420,11 @@ module MultiTypeSymbolTable
             else if entry.isAssignableTo(SymbolEntryType.GeneratorSymEntry) {
                 return name;
             }
-            
+            else if entry.isAssignableTo(SymbolEntryType.SparseSymEntry){
+                var g: GenSparseSymEntry = toGenSparseSymEntry(entry);
+                return name + " " + g.attrib();
+            }
+
             throw new Error("attrib - Unsupported Entry Type %s".format(entry.entryType));
         }
 
@@ -557,5 +561,20 @@ module MultiTypeSymbolTable
             throw new Error(errorMsg);
         }
         return (abstractEntry: borrowed SegStringSymEntry);
+    }
+
+    /**
+     * Convenience proc to retrieve GenSparseSymEntry from SymTab
+     * Performs conversion from AbstractSymEntry to GenSparseSymEntry
+     * You can pass a logger from the calling function for better error reporting.
+     */
+    proc getGenericSparseArrayEntry(name:string, st: borrowed SymTab): borrowed GenSparseSymEntry throws {
+        var abstractEntry = st.lookup(name);
+        if ! abstractEntry.isAssignableTo(SymbolEntryType.SparseSymEntry) {
+            var errorMsg = "Error: SymbolEntryType %s is not assignable to GenSparseSymEntry".format(abstractEntry.entryType);
+            mtLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            throw new Error(errorMsg);
+        }
+        return (abstractEntry: borrowed GenSparseSymEntry);
     }
 }

--- a/src/SparseMatrix.chpl
+++ b/src/SparseMatrix.chpl
@@ -1,0 +1,346 @@
+module SparseMatrix {
+
+  use CommDiagnostics, Time;
+  public use SpsMatUtil;
+
+  config const countComms=false,
+               printTimings=false;
+
+  // sparse, outer, matrix-matrix multiplication algorithm; A is assumed
+  // CSC and B CSR
+  //
+  proc sparseMatMatMult(A, B) {
+    if countComms then startCommDiagnostics();
+    var time: stopwatch;
+    time.start();
+
+    var spsData: sparseMatDat;
+
+    sparseMatMatMult(A, B, spsData);
+
+    var C = makeSparseMat(A.domain.parentDom, spsData);
+
+    const elapsed = time.elapsed();
+
+    if countComms {
+      stopCommDiagnostics();
+      printCommDiagnosticsTable();
+      writeln();
+    }
+
+    if printTimings then writeln("Elapsed time = ", elapsed, "\n");
+
+    return C;
+  }
+
+  // This version forms the guts of the above and permits a running set
+  // of nonzeroes to be passed in and updated rather than assuming that
+  // the multiplication is the first/only step.
+  //
+  proc sparseMatMatMult(A, B, ref spsData) {
+    forall ac_br in A.cols() with (merge reduce spsData) do
+      for (ar, a) in A.rowsAndVals(ac_br) do
+        for (bc, b) in B.colsAndVals(ac_br) do
+          spsData.add((ar, bc), a * b);
+  }
+
+  proc sparseMatMatMult(A, B) where (!A.chpl_isNonDistributedArray() &&
+                                     !B.chpl_isNonDistributedArray()) {
+    var CD = emptySparseDomLike(B);  // For now, hard-code C to use CSR, like B
+    var C: [CD] int;
+
+    ref targLocs = A.targetLocales();
+  
+    if countComms then startCommDiagnostics();
+    var time: stopwatch;
+    time.start();
+
+    coforall (locRow, locCol) in targLocs.domain {
+      on targLocs[locRow, locCol] {
+        var spsData: sparseMatDat;
+
+        for srcloc in targLocs.dim(0) {
+          // Make a local copy of the remote blocks of A and B; on my branch
+          // this will also make a local copy of the remote indices, so long
+          // as these are 'const'/read-only
+          //
+          const aBlk = A.getLocalSubarray(locRow, srcloc),
+                bBlk = B.getLocalSubarray(srcloc, locCol);
+
+          // This local block is not strictly necessary but ensures that the
+          // computation on the blocks will not require communication
+          local {
+            sparseMatMatMult(aBlk, bBlk, spsData);
+          }
+        }
+
+        // Get my locale's local indices and create a sparse matrix
+        // using them and the spsData computed above.
+        //
+        const locInds = A.domain.parentDom.localSubdomain();
+        var cBlk = makeSparseMat(locInds, spsData);
+
+        // Stitch the local portions back together into the global-view
+        //
+        CD.setLocalSubdomain(cBlk.domain);
+        C.setLocalSubarray(cBlk);
+      }
+    }
+
+    const elapsed = time.elapsed();
+    
+    if countComms {
+      stopCommDiagnostics();
+      printCommDiagnosticsTable();
+      writeln();
+    }
+
+    if printTimings then writeln("Elapsed time = ", elapsed, "\n");
+
+    return C;
+  }
+
+
+  // dense, simple matrix-matrix multiplication algorithm; this is
+  // wildly inefficient, both because it ignores the sparsity and
+  // because it uses random access of the sparse arrays which tends to
+  // be expensive.
+  //
+  proc denseMatMatMult(A, B) {
+    if countComms then startCommDiagnostics();
+    var time: stopwatch;
+    time.start();
+
+    const n = A.dim(0).size;
+
+    var spsData: sparseMatDat;
+
+    for i in 1..n {
+      for j in 1..n {
+        var prod = 0;
+
+        forall k in 1..n with (+ reduce prod) do
+          prod += A[i,k] * B[k,j];
+
+        if prod != 0 then
+          spsData.add((i,j), prod);
+      }
+    }
+
+    var C = makeSparseMat(A.domain.parentDom, spsData);
+
+    const elapsed = time.elapsed();
+
+    if countComms {
+      stopCommDiagnostics();
+      printCommDiagnosticsTable();
+      writeln();
+    }
+
+    if printTimings then writeln("Elapsed time = ", elapsed, "\n");
+
+    return C;
+  }
+
+  proc randSparseMatrix(size, density, param layout, param distributed=false, type eltType) {
+    const Dom = {1..size, 1..size};
+
+    // compute some random sparse index patterns for the matrices
+    //
+    const AD = randSparseDomain(Dom, density, layout, distributed);
+
+    var A: [AD] eltType;
+    return A;
+  }
+
+  module SpsMatUtil {
+    // The following are routines that should arguably be supported directly
+    // by the LayoutCS and SparseBlockDist modules themselves
+    //
+    //  public use LayoutCSUtil, SparseBlockDistUtil;
+
+    use BlockDist, LayoutCS, Map, Random;
+
+    enum layout { CSR, CSC };
+    public use layout;
+
+    config const seed = 0,
+                printSeed = seed == 0;
+
+    var rands = if seed == 0 then new randomStream(real)
+                          else new randomStream(real, seed);
+
+    // print library-selected seed, for reproducibility
+    //
+    if printSeed then
+      writeln("Using seed: ", rands.seed);
+
+    record sparseMatDat {
+      forwarding var m: map(2*int, int);
+
+      proc ref add(idx: 2*int, val: int) {
+        if val != 0 {
+          if m.contains(idx) {
+            m[idx] += val;
+          } else {
+            m.add(idx, val);
+          }
+        }
+      }
+    }
+
+
+    // create a local random sparse matrix within the space of 'Dom' of
+    // the given density and layout.  If distributed is true, this will
+    // be a block-distributed sparse matrix, otherwise it'll be local.
+    //
+    proc randSparseDomain(parentDom, density, param layout, param distributed)
+    where distributed == false {
+
+      var SD: sparse subdomain(parentDom) dmapped new dmap(new CS(compressRows=(layout==CSR)));
+
+      for (i,j) in parentDom do
+        if rands.next() <= density then
+          SD += (i,j);
+
+      return SD;
+    }
+
+    proc randSparseDomain(parentDom, density, param layout, param distributed)
+    where distributed == true {
+      const locsPerDim = sqrt(numLocales:real): int,
+            grid = {0..<locsPerDim, 0..<locsPerDim},
+            localeGrid = reshape(Locales[0..<grid.size], grid);
+
+
+      if grid.size != numLocales then
+        writeln("Warning: Only using ", grid.size, " of ", numLocales,
+                " locales");
+
+      // writeln(grid);
+
+      type layoutType = CS(compressRows=(layout==CSR));
+      const DenseBlkDom = parentDom dmapped new blockDist(boundingBox=parentDom,
+                                                    targetLocales=localeGrid,
+                                                    sparseLayoutType=layoutType);
+
+      var SD: sparse subdomain(DenseBlkDom);
+
+      for (i,j) in parentDom do
+        if rands.next() <= density then
+          SD += (i,j);
+
+      return SD;
+    }
+
+
+    proc emptySparseDomLike(Mat) {
+      var ResDom: sparse subdomain(Mat.domain.parentDom);
+      return ResDom;
+    }
+
+
+    // print out a sparse matrix (in a dense format)
+    //
+    proc writeSparseMatrix(msg, Arr) {
+      const ref SparseDom = Arr.domain,
+                DenseDom = SparseDom.parentDom;
+
+      writeln(msg);
+
+      for r in DenseDom.dim(0) {
+        for c in DenseDom.dim(1) {
+          write(Arr[r,c], " ");
+        }
+        writeln();
+      }
+      writeln();
+    }
+
+
+    // create a new sparse matrix from a map from sparse indices to values
+    //
+    proc makeSparseMat(parentDom, spsData) {
+      use Sort;
+
+      var CDom: sparse subdomain(parentDom) dmapped new dmap(new CS());
+      var inds: [0..<spsData.size] 2*int;
+      for (idx, i) in zip(spsData.keys(), 0..) do
+        inds[i] = idx;
+
+      sort(inds);
+    
+      for ij in inds do
+        CDom += ij;
+
+      var C: [CDom] int;
+      for ij in inds do
+        try! C[ij] += spsData[ij];  // TODO: Should this really throw?
+
+      return C;
+    }
+
+
+    // create a new sparse matrix from a collection of nonzero indices
+    // (nnzs) and values (vals)
+    //
+    proc makeSparseMat(parentDom, nnzs, vals) {
+      var CDom: sparse subdomain(parentDom);
+      for ij in nnzs do
+        CDom += ij;
+
+      var C: [CDom] int;
+      for (ij, c) in zip(nnzs, vals) do
+        C[ij] += c;
+      return C;
+    }
+
+
+    // This is a custom reduction, and a good case study for why our custom
+    // reduction interface needs a refresh
+    //
+    class merge: ReduceScanOp {
+      type eltType = sparseMatDat;
+      var value: eltType;  // TODO: lots of deep copying here to avoid
+
+      proc identity {
+        var ident: eltType;
+        return ident;
+      }
+
+      /*
+      proc initialAccumulate(x) {
+        if x.size != 0 then
+          halt("Error shouldn't call merge.initialAccumulate() with a non-empty table");
+      }
+      */
+
+      proc accumulate(x) {
+        // Why is this ever called with a sparseMatDat as the argument?!?
+        for (k,v) in zip(x.keys(), x.values()) {
+          if value.contains(k) {
+            value[k] += v;
+          } else {
+            value.add(k, v);
+          }
+        }
+      }
+
+      proc accumulateOntoState(ref state, x) {
+        halt("Error, shouldn't call merge.accumulateOntoState()");
+      }
+
+      proc combine(x) {
+        accumulate(x.value);
+      }
+
+      proc generate() {
+        return value;
+      }
+
+      inline proc clone() {
+        return new unmanaged merge(eltType=eltType);
+      }
+    }
+  }
+}

--- a/src/SparseMatrix.chpl
+++ b/src/SparseMatrix.chpl
@@ -110,8 +110,11 @@ module SparseMatrix {
 
     use BlockDist, LayoutCS, Map, Random;
 
-    enum layout { CSR, CSC };
-    public use layout;
+    enum layout {
+      CSR,
+      CSC
+    };
+    // public use layout;
 
     config const seed = 0;
 
@@ -137,10 +140,10 @@ module SparseMatrix {
     // the given density and layout.  If distributed is true, this will
     // be a block-distributed sparse matrix, otherwise it'll be local.
     //
-    proc randSparseDomain(parentDom, density, param layout, param distributed)
+    proc randSparseDomain(parentDom, density, param matLayout, param distributed)
     where distributed == false {
 
-      var SD: sparse subdomain(parentDom) dmapped new dmap(new CS(compressRows=(layout==CSR)));
+      var SD: sparse subdomain(parentDom) dmapped new dmap(new CS(compressRows=(matLayout==layout.CSR)));
 
       for (i,j) in parentDom do
         if rands.next() <= density then
@@ -149,20 +152,13 @@ module SparseMatrix {
       return SD;
     }
 
-    proc randSparseDomain(parentDom, density, param layout, param distributed)
+    proc randSparseDomain(parentDom, density, param matLayout, param distributed)
     where distributed == true {
       const locsPerDim = sqrt(numLocales:real): int,
             grid = {0..<locsPerDim, 0..<locsPerDim},
             localeGrid = reshape(Locales[0..<grid.size], grid);
 
-
-      if grid.size != numLocales then
-        writeln("Warning: Only using ", grid.size, " of ", numLocales,
-                " locales");
-
-      // writeln(grid);
-
-      type layoutType = CS(compressRows=(layout==CSR));
+      type layoutType = CS(compressRows=(matLayout==layout.CSR));
       const DenseBlkDom = parentDom dmapped new blockDist(boundingBox=parentDom,
                                                     targetLocales=localeGrid,
                                                     sparseLayoutType=layoutType);

--- a/src/SparseMatrixMsg.chpl
+++ b/src/SparseMatrixMsg.chpl
@@ -29,9 +29,8 @@ module SparseMatrixMsg {
 
         var size: int = msgArgs.get("size").getIntValue();
         var density: real = msgArgs.get("density").getRealValue();
-        // var shape: always 2d?
         var l: string = msgArgs.getValueOf("layout");
-        // var distributed: bool = msgArgs.getBoolValueOf("distributed"); TODO does this need to be configurable?
+
 
         select l {
             when "CSR" {

--- a/src/SparseMatrixMsg.chpl
+++ b/src/SparseMatrixMsg.chpl
@@ -1,0 +1,89 @@
+module SparseMatrixMsg {
+    use ServerConfig;
+
+    use MultiTypeSymbolTable;
+    use MultiTypeSymEntry;
+    use SegmentedString;
+    use ServerErrorStrings;
+
+    use ArraySetops;
+    use Indexing;
+    use RadixSortLSD;
+    use Reflection;
+    use ServerErrors;
+    use Logging;
+    use Message;
+
+    use SparseMatrix;
+
+    private config const logLevel = ServerConfig.logLevel;
+    private config const logChannel = ServerConfig.logChannel;
+    const sparseLogger = new Logger(logLevel, logChannel);
+
+    param distributed = true;
+
+    proc randomSparseMatrixMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        var repMsg: string; // response message with the details of the new arr
+
+        var vName = st.nextName(); // symbol table key for resulting sparse arr
+
+        var size: int = msgArgs.get("size").getIntValue();
+        var density: real = msgArgs.get("density").getRealValue();
+        // var shape: always 2d?
+        var l: string = msgArgs.getValueOf("layout");
+        // var distributed: bool = msgArgs.getBoolValueOf("distributed"); TODO does this need to be configurable?
+
+        select l {
+            when "CSR" {
+                var aV = randSparseMatrix(size, density, CSR, distributed, int); // Hardcode int for now and false for distributed
+                st.addEntry(vName, createSparseSymEntry(aV, size, CSR, int));
+                repMsg = "created " + st.attrib(vName);
+                sparseLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+                return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            when "CSC" {
+                var aV = randSparseMatrix(size, density, CSC, distributed, int); // Hardcode int for now and false for distributed
+                st.addEntry(vName, createSparseSymEntry(aV, size, CSC, int));
+                repMsg = "created " + st.attrib(vName);
+                sparseLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+                return new MsgTuple(repMsg, MsgType.NORMAL);
+            }
+            otherwise {
+                var errorMsg = notImplementedError("unsupported layout for sparse matrix",l);
+                sparseLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                return new MsgTuple(errorMsg, MsgType.ERROR);
+            }
+        }
+
+    }
+
+
+
+    proc sparseMatrixMatrixMultMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        var repMsg: string; // response message with the details of the new arr
+
+        var vName = st.nextName(); // symbol table key for resulting sparse arr
+
+        var gEnt1 = getGenericSparseArrayEntry(msgArgs.getValueOf("arg1"), st);
+        var gEnt2 = getGenericSparseArrayEntry(msgArgs.getValueOf("arg2"), st);
+
+        // Hardcode for int right now
+        var e1 = gEnt1.toSparseSymEntry(int, dimensions=2, CSC);
+        var e2 = gEnt2.toSparseSymEntry(int, dimensions=2, CSR);
+
+        var size = gEnt2.size;
+
+        var aV = sparseMatMatMult(e1.a, e2.a);
+        st.addEntry(vName, createSparseSymEntry(aV, size, CSR, int));
+        repMsg = "created " + st.attrib(vName);
+        sparseLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+        return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+
+
+
+    use CommandMap;
+    registerFunction("random_sparse_matrix", randomSparseMatrixMsg, getModuleName());
+    registerFunction("sparse_matrix_matrix_mult", sparseMatrixMatrixMultMsg, getModuleName());
+
+}

--- a/src/SparseMatrixMsg.chpl
+++ b/src/SparseMatrixMsg.chpl
@@ -34,15 +34,15 @@ module SparseMatrixMsg {
 
         select l {
             when "CSR" {
-                var aV = randSparseMatrix(size, density, CSR, distributed, int); // Hardcode int for now and false for distributed
-                st.addEntry(vName, createSparseSymEntry(aV, size, CSR, int));
+                var aV = randSparseMatrix(size, density, layout.CSR, distributed, int); // Hardcode int for now and false for distributed
+                st.addEntry(vName, createSparseSymEntry(aV, size, layout.CSR, int));
                 repMsg = "created " + st.attrib(vName);
                 sparseLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
                 return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             when "CSC" {
-                var aV = randSparseMatrix(size, density, CSC, distributed, int); // Hardcode int for now and false for distributed
-                st.addEntry(vName, createSparseSymEntry(aV, size, CSC, int));
+                var aV = randSparseMatrix(size, density, layout.CSC, distributed, int); // Hardcode int for now and false for distributed
+                st.addEntry(vName, createSparseSymEntry(aV, size, layout.CSC, int));
                 repMsg = "created " + st.attrib(vName);
                 sparseLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
                 return new MsgTuple(repMsg, MsgType.NORMAL);
@@ -67,13 +67,13 @@ module SparseMatrixMsg {
         var gEnt2 = getGenericSparseArrayEntry(msgArgs.getValueOf("arg2"), st);
 
         // Hardcode for int right now
-        var e1 = gEnt1.toSparseSymEntry(int, dimensions=2, CSC);
-        var e2 = gEnt2.toSparseSymEntry(int, dimensions=2, CSR);
+        var e1 = gEnt1.toSparseSymEntry(int, dimensions=2, layout.CSC);
+        var e2 = gEnt2.toSparseSymEntry(int, dimensions=2, layout.CSR);
 
         var size = gEnt2.size;
 
         var aV = sparseMatMatMult(e1.a, e2.a);
-        st.addEntry(vName, createSparseSymEntry(aV, size, CSR, int));
+        st.addEntry(vName, createSparseSymEntry(aV, size, layout.CSR, int));
         repMsg = "created " + st.attrib(vName);
         sparseLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
         return new MsgTuple(repMsg, MsgType.NORMAL);


### PR DESCRIPTION
This PR does the following:

1. Add new types to the Symbol Table:
  - `SparseGenSymEntry` and `SparseSymEntry` are added to support sparse matrices.
2. Add a new type to the client
  - `sparray`  is the client representation of sparse matrices
3. Add functionality for this new type
  - New SparseMatrix module copied from https://github.com/chapel-lang/chapel/pull/25269/ which has:
  - Factory function to create a random 2D sparse array: `ak.random_sparse_matrix`
  - Function to multiply two sparse arrays: `ak.sparse_matrix_matrix_mult`

I am not adding the new SparseMatrixMsg to ServerModule.cfg by default today because it is an unstable prototype and may change in the future.

Future work here is to add support for printing the sparrays and add a test for the new functions.

 