### PR TITLE
Prototype arkouda.for_each method.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,9 @@ CHPL := chpl
 CHPL_FLAGS += --ccflags="-DH5_USE_110_API"
 
 # Python
+ifdef ARKOUDA_PYTHON_SERVER
 CHPL_FLAGS += $(shell python3-config --includes) $(shell python3-config --ldflags) -lpython3.$(shell python -c "import sys; print(sys.version_info.minor)")
+endif
 
 # silence warnings about '@arkouda' annotations being unrecognized
 CHPL_FLAGS += --using-attribute-toolname arkouda

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ CHPL := chpl
 # We need to make the HDF5 API use the 1.10.x version for compatibility between 1.10 and 1.12
 CHPL_FLAGS += --ccflags="-DH5_USE_110_API"
 
+# Python
+CHPL_FLAGS += $(shell python3-config --includes) $(shell python3-config --ldflags) -lpython3.$(shell python -c "import sys; print(sys.version_info.minor)")
+
 # silence warnings about '@arkouda' annotations being unrecognized
 CHPL_FLAGS += --using-attribute-toolname arkouda
 

--- a/ServerModules.cfg
+++ b/ServerModules.cfg
@@ -22,7 +22,7 @@ LogMsg
 ManipulationMsg
 OperatorMsg
 ParquetMsg
-PythonMsg
+#PythonMsg
 RandMsg
 ReductionMsg
 RegistrationMsg

--- a/ServerModules.cfg
+++ b/ServerModules.cfg
@@ -22,6 +22,7 @@ LogMsg
 ManipulationMsg
 OperatorMsg
 ParquetMsg
+PythonMsg
 RandMsg
 ReductionMsg
 RegistrationMsg

--- a/arkouda/__init__.py
+++ b/arkouda/__init__.py
@@ -44,3 +44,4 @@ from arkouda.scipy.special import *
 from arkouda.scipy import *
 from arkouda.random import *
 from arkouda.testing import *
+from arkouda.for_each import *

--- a/arkouda/dispatch_utils.py
+++ b/arkouda/dispatch_utils.py
@@ -1,0 +1,11 @@
+import base64
+import pickle
+import numba
+
+print("importing arkouda.dispatch_utils")
+
+
+def compile(func, typ):
+    f = pickle.loads(base64.b64decode(func))
+    numf = numba.cfunc(f"{typ}({typ})")(f)
+    return numf.address

--- a/arkouda/for_each.py
+++ b/arkouda/for_each.py
@@ -1,0 +1,22 @@
+import base64
+import cloudpickle
+
+import arkouda as ak
+
+__all__ = ['for_each']
+
+
+def for_each(pda_in, functor, inplace=False):
+    s = cloudpickle.dumps(functor)
+
+    enc_s = base64.b64encode(s)
+    u_enc_s = enc_s.decode('UTF-8')
+
+    server_msg = ak.client.generic_msg(
+        "python1D",
+        {"a": pda_in, "pickle": u_enc_s, "inplace": inplace})
+
+    if not inplace:
+        return ak.create_pdarray(server_msg)
+
+    return pda_in

--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,7 @@ setup(
         "tables>=3.7.0",
         "pyarrow",
         "scipy<=1.13.1",
+        "cloudpickle",
     ],
     # List additional groups of dependencies here (e.g. development
     # dependencies). Users will be able to install these using the "extras"

--- a/src/PythonMsg.chpl
+++ b/src/PythonMsg.chpl
@@ -1,0 +1,163 @@
+
+module PythonMsg
+{
+    use ServerConfig;
+
+    use Reflection;
+    use ServerErrors;
+    use Logging;
+    use Message;
+    use MultiTypeSymbolTable;
+    use MultiTypeSymEntry;
+    use NumPyDType;
+    use ServerErrorStrings;
+
+    use Map;
+    use ArkoudaIOCompat;
+    use ArkoudaAryUtilCompat;
+
+    private config const logLevel = ServerConfig.logLevel;
+    private config const logChannel = ServerConfig.logChannel;
+    const sLogger = new Logger(logLevel, logChannel);
+
+    extern {
+        #if defined(linux)
+
+        #include <stdio.h>
+
+        #ifdef _POSIX_C_SOURCE
+        #undef _POSIX_C_SOURCE
+        #endif
+
+        #ifdef _FILE_OFFSET_BITS
+        #undef _FILE_OFFSET_BITS
+        #endif
+
+        #ifdef _XOPEN_SOURCE
+        #undef _XOPEN_SOURCE
+        #endif
+
+        #ifdef _DARWIN_C_SOURCE
+        #undef _DARWIN_C_SOURCE
+        #endif
+
+        #ifdef _NETBSD_SOURCE
+        #undef _NETBSD_SOURCE
+        #endif
+
+        #endif // linux
+
+        #define PY_SSIZE_T_CLEAN
+        #include "Python.h"
+
+        static PyObject* arkjit_compile = NULL;
+        void initializePythonMsg(void);
+
+        typedef void (*gen_disp_t)(void);
+        typedef double (*disp_1d_t)(double);
+
+        int dispIsValid(gen_disp_t);
+        gen_disp_t dispatchPythonMsg(const char*, const char*, Py_ssize_t);
+
+        double callDisp1D(disp_1d_t, double);
+
+        void initializePythonMsg(void) {
+            PyObject* dispmod = NULL;
+
+            if (!Py_IsInitialized()) {
+        #if PY_VERSION_HEX < 0x03020000
+                PyEval_InitThreads();
+        #endif
+        #if PY_VERSION_HEX < 0x03080000
+                Py_Initialize();
+        #else
+                PyConfig config;
+                PyConfig_InitPythonConfig(&config);
+                PyConfig_SetString(&config, &config.program_name, L"arkouda");
+                Py_InitializeFromConfig(&config);
+        #endif
+        #if PY_VERSION_HEX >= 0x03020000
+        #if PY_VERSION_HEX < 0x03090000
+                PyEval_InitThreads();
+        #endif
+        #endif
+            }
+
+            dispmod = PyImport_ImportModule("arkouda.dispatch_utils");
+            if (dispmod) {
+                arkjit_compile = PyObject_GetAttrString(dispmod, "compile");
+                Py_DECREF(dispmod);
+            } else {
+                PyErr_Print();
+            }
+        }
+
+        gen_disp_t dispatchPythonMsg(const char* dt, const char* pkl, Py_ssize_t lpkl) {
+            PyObject* result = NULL;
+
+            if (arkjit_compile) {
+                PyObject* pyfunc = PyBytes_FromStringAndSize(pkl, lpkl);
+                result = PyObject_CallFunction(arkjit_compile, "Os", pyfunc, dt, NULL);
+                Py_DECREF(pyfunc);
+
+                if (!result)
+                    return NULL;
+
+                gen_disp_t fdisp = (gen_disp_t)PyLong_AsLongLong(result);
+
+                Py_DECREF(result);
+                return fdisp;
+            }
+            return NULL;
+        }
+
+        int dispIsValid(gen_disp_t fdisp) {
+            return (int)(fdisp != NULL);
+        }
+
+        double callDisp1D(disp_1d_t fdisp, double d) {
+            return fdisp(d);
+        }
+
+    }
+
+    initializePythonMsg();
+
+    @arkouda.registerND
+    proc pythonMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, param nd: int): MsgTuple throws {
+        const aname = msgArgs.getValueOf("a");
+        const pkl = msgArgs.getValueOf("pickle");
+        const inplace: bool = msgArgs.get("inplace").getBoolValue();
+
+        var arr: borrowed GenSymEntry = getGenericTypedArrayEntry(aname, st);
+        var dt: string = dtype2str(arr.dtype);
+
+        var pydisp = dispatchPythonMsg(dt.c_str(), pkl.c_str(), pkl.numBytes);
+
+        if (!dispIsValid(pydisp)) {
+            PyErr_Print();
+            return new MsgTuple("failed to compile Python function", MsgType.ERROR);
+        }
+
+        select (arr.dtype) {
+            when (DType.Float64) {
+                var l = toSymEntry(arr, real, nd);
+                if (inplace) {
+                    forall a in l.a do
+                        a = callDisp1D(pydisp, a);
+                    return new MsgTuple("success", MsgType.NORMAL);
+                } else {
+                    var rname = st.nextName();
+                    var e = st.addEntry(rname, l.tupShape, real);
+                    e.a = forall a in l.a do
+                              callDisp1D(pydisp, a);
+                    var repMsg = "created %s".format(st.attrib(rname));
+                    return new MsgTuple(repMsg, MsgType.NORMAL);
+                }
+            }
+        }
+
+        return new MsgTuple("unsupported array type", MsgType.ERROR);
+    }
+
+}


### PR DESCRIPTION
This PR is a WIP, added on request; it's an initial prototype showing how an `arkouda.for_each` method could be implemented. A true production version should take LLVM IR on the client side and send that instead of pickling the functor, then JIT it using ORCJit on the server. (Note that LLVM IR is not as stable as Python's pickle and thus there may be deviations between LLVM used in Chapel and LLVM used in Numba.) Doing so would remove the dependency on Python for the server.

There is a client-side dependency added on `cloudpickle`. That module allows for complete packaging of what is pickled as opposed to the standard pickle which only adds references to modules that are subsequently imported when unpickling. This is necessary since it can not be expected that client-side Python modules are available server-side. Going to LLVM IR instead would remove the need of this dependency.

`PythonMsg` needs to be uncommented in `ServerModules.cfg` to enable it, and building/linking with Python requires `ARKOUDA_PYTHON_SERVER=1` when running `make`.

Some rough numbers as to why we're doing this; single node, all local, 10^10 float64s, a 1D p3:
```
numpy, externalized loop:      1hr 50min (est.)
arkouda, externalized loop:    178days (est.)
numpy.poly1d:                  92s
C++ vector -O3:                8s
arkouda.for_each:              3s
```
I'm somewhat new to Chapel; I'm presuming that it outperforms C++ b/c the code is either vectorized or threaded. `numpy.poly1d` is that much slower because of the creation of temporary arrays and subsequent memory copies. The `arkouda.for_each` timing includes running the JIT (no warmup; Numba itself also adds a one-off overhead of ~0.3s here).