### PR TITLE
Stop requiring manual installation of `chapel-py` to register commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -566,7 +566,7 @@ version:
 #####################
 
 register-commands:
-	python3 $(ARKOUDA_REGISTRY_DIR)/register_commands.py $(ARKOUDA_REGISTRATION_CONFIG) $(ARKOUDA_CONFIG_FILE) $(ARKOUDA_SOURCE_DIR)
+	$(ARKOUDA_REGISTRY_DIR)/register_commands.bash $(ARKOUDA_REGISTRY_DIR) $(ARKOUDA_REGISTRATION_CONFIG) $(ARKOUDA_CONFIG_FILE) $(ARKOUDA_SOURCE_DIR)
 
 #####################
 #### Epilogue.mk ####

--- a/src/registry/register_commands.bash
+++ b/src/registry/register_commands.bash
@@ -1,0 +1,13 @@
+if [ -z "$CHPL_HOME" ]; then
+    # We need CHPL_HOME to find run-in-venv.bash. Try falling back to a
+    # compiler in PATH.
+    if output=$(chpl --print-bootstrap-commands); then
+        eval "$output"
+    else
+        echo "Error: CHPL_HOME is not set" 1>&2
+        exit 1
+    fi
+fi
+
+exec $CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash \
+    python3 $1/register_commands.py $2 $3 $4

--- a/src/registry/register_commands.bash
+++ b/src/registry/register_commands.bash
@@ -9,5 +9,13 @@ if [ -z "$CHPL_HOME" ]; then
     fi
 fi
 
-exec $CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash \
+if $CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash \
+    python3 $1/register_commands.py $2 $3 $4;
+then
+    # registering commands with prebuilt python bindings suceeded
+    :
+else
+    # if not sucessfull (likely due to mismatched python version), try again with the current python environment
+    echo "...attempting to use chapel-py bindings from existing environment instead"
     python3 $1/register_commands.py $2 $3 $4
+fi


### PR DESCRIPTION
Following https://github.com/Bears-R-Us/arkouda/pull/3477, the chapel frontend python bindings (`chapel-py`) are required to build Arkouda. Because of this, chapel-py needed to be installed in the local python environment before running `make`.

This PR adjusts the makefile s.t., the prebuilt bindings shipped with Chapel are used to run `register-commands`. This avoids the need to manually install/build `chapel-py` before building Arkouda.

