### PR TITLE
Closes #3519, #3522: unpin hdf5 library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,8 +127,8 @@ install-zmq:
 	rm -r $(ZMQ_BUILD_DIR)
 	echo '$$(eval $$(call add-path,$(ZMQ_INSTALL_DIR)))' >> Makefile.paths
 
-HDF5_MAJ_MIN_VER := 1.12
-HDF5_VER := 1.12.1
+HDF5_MAJ_MIN_VER := 1.14
+HDF5_VER := 1.14.4
 HDF5_NAME_VER := hdf5-$(HDF5_VER)
 HDF5_BUILD_DIR := $(DEP_BUILD_DIR)/$(HDF5_NAME_VER)
 HDF5_INSTALL_DIR := $(DEP_INSTALL_DIR)/hdf5-install

--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -12,10 +12,10 @@ dependencies:
   - versioneer
   - matplotlib>=3.3.2
   - h5py>=3.7.0
-  - hdf5==1.12.2
+  - hdf5>=1.12.2
   - pip
   - types-tabulate
-  - pytables>=3.7.0
+  - pytables>=3.8.0
   - pyarrow
   - libiconv
   - libidn2

--- a/arkouda-env.yml
+++ b/arkouda-env.yml
@@ -12,10 +12,10 @@ dependencies:
   - versioneer
   - matplotlib>=3.3.2
   - h5py>=3.7.0
-  - hdf5==1.12.2
+  - hdf5>=1.12.2
   - pip
   - types-tabulate
-  - pytables>=3.7.0
+  - pytables>=3.8.0
   - pyarrow
   - libiconv
   - libidn2

--- a/pydoc/requirements.txt
+++ b/pydoc/requirements.txt
@@ -9,10 +9,10 @@ pyfiglet
 versioneer
 matplotlib>=3.3.2
 h5py>=3.7.0
-hdf5==1.12.2
+hdf5>=1.12.2
 pip
 types-tabulate
-tables>=3.7.0
+tables>=3.8.0
 pyarrow
 libiconv
 libidn2

--- a/pydoc/setup/REQUIREMENTS.md
+++ b/pydoc/setup/REQUIREMENTS.md
@@ -27,10 +27,10 @@ The following python packages are required by the Arkouda client package.
 - `versioneer`
 - `matplotlib>=3.3.2`
 - `h5py>=3.7.0`
-- `hdf5==1.12.2`
+- `hdf5>=1.12.2`
 - `pip`
 - `types-tabulate`
-- `tables>=3.7.0`
+- `tables>=3.8.0`
 - `pyarrow`
 - `scipy<=1.13.1`
 

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ setup(
         "h5py>=3.7.0",
         "pip",
         "types-tabulate",
-        "tables>=3.7.0",
+        "tables>=3.8.0",
         "pyarrow",
         "scipy<=1.13.1",
     ],


### PR DESCRIPTION
This changes was implemented in order to address the following problem:
local failing of test_import_hdf in `tests\impor_export_tests.py`:
```
E                   ImportError: Pandas requires version '3.8.0' or newer of 'tables' (version '3.7.0' currently installed).
```

The solution is to upgrade `tables` to `3.8.0`, which requires a newer version of `hdf5`.

Closes #3519 unpin hdf5 library
Closes #3522 local failing of test_import_hdf