### PR TITLE
Add function to retrieve server's maximum supported pdarray rank

### DIFF
--- a/PROTO_tests/tests/client_test.py
+++ b/PROTO_tests/tests/client_test.py
@@ -67,6 +67,12 @@ class TestClient:
         assert "arkoudaVersion" in config
         assert "INFO" == config["logLevel"]
 
+        try:
+            mar = ak.client.get_max_array_rank()
+            assert mar == 1
+        except Exception as e:
+            raise AssertionError(e)
+
     def test_get_mem_used(self):
         """
         Tests the ak.get_mem_used and ak.get_mem_avail methods

--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -1057,7 +1057,8 @@ def get_max_array_rank() -> int:
     if serverConfig is None:
         raise RuntimeError("client is not connected to a server")
 
-    return serverConfig["maxArrayDims"]
+    return int(serverConfig["maxArrayDims"])
+
 
 def _get_config_msg() -> Mapping[str, Union[str, int, float]]:
     """

--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -21,6 +21,7 @@ __all__ = [
     "disconnect",
     "shutdown",
     "get_config",
+    "get_max_array_rank",
     "get_mem_used",
     "get_mem_avail",
     "get_mem_status",
@@ -1038,6 +1039,25 @@ def get_config() -> Mapping[str, Union[str, int, float]]:
 
     return serverConfig
 
+
+def get_max_array_rank() -> int:
+    """
+    Get the maximum pdarray rank the server was compiled to support
+
+    This value corresponds to the maximum number in
+    parameter_classes -> array -> nd in the `registration-config.json`
+    file when the server was compiled.
+
+    Returns
+    -------
+    int
+        The maximum pdarray rank supported by the server
+    """
+
+    if serverConfig is None:
+        raise RuntimeError("client is not connected to a server")
+
+    return serverConfig["maxArrayDims"]
 
 def _get_config_msg() -> Mapping[str, Union[str, int, float]]:
     """

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -257,6 +257,7 @@ module ServerConfig
             const byteorder: string;
             const autoShutdown: bool;
             const serverInfoNoSplash: bool;
+            const maxArrayDims: int;
         }
 
         var (Zmajor, Zminor, Zmicro) = ZMQ.version;
@@ -282,7 +283,8 @@ module ServerConfig
             regexMaxCaptures = regexMaxCaptures,
             byteorder = try! getByteorder(),
             autoShutdown = autoShutdown,
-            serverInfoNoSplash = serverInfoNoSplash
+            serverInfoNoSplash = serverInfoNoSplash,
+            maxArrayDims = MaxArrayDims
         );
         return try! formatJson(cfg);
 

--- a/src/parseServerConfig.py
+++ b/src/parseServerConfig.py
@@ -130,7 +130,7 @@ def get_nd_setting(config):
 
 
 def createNDHandlerInstantiations(config, modules, src_dir):
-    max_dims = get_nd_setting(config)[-1]
+    max_dims = max(get_nd_setting(config))
     filename = f"{src_dir}/nd_support/nd_array_stamps.chpl"
 
     with open(filename, 'w') as stamps:


### PR DESCRIPTION
Adds a function `client.get_max_array_rank` to return the maximum array rank that the server was compiled to support.

resolves: https://github.com/Bears-R-Us/arkouda/issues/3383