### PR TITLE
Closes #3603: Small bug in `register_commands.py`

### DIFF
--- a/src/registry/register_commands.py
+++ b/src/registry/register_commands.py
@@ -613,7 +613,7 @@ def register_commands(config, source_files):
         file_stamps = []
         found_annotation = False
 
-        root = ctx.parse(filename)[0]
+        root, _ = next(chapel.each_matching(ctx.parse(filename), chapel.Module))
         mod_name = filename.split("/")[-1].split(".")[0]
 
         file_stamps.append(f"import {mod_name};")


### PR DESCRIPTION
This PR (closes #3603)

@ajpotts was running into problems with `@arkouda.instantiateAndRegister`, but everything looked right. After some digging I found:
https://github.com/Bears-R-Us/arkouda/blob/5dbf619461f2c29817942b1fabad2e4b559fb5a5/src/registry/register_commands.py#L616

here `root` is meant to be the `Module object` from the chapel context. I printed out `ctx.parse(filename)` and saw:
```
/arkouda/src/ArgSortMsg.chpl
[<Comment object at 0x104a472d0>, <Module object at 0x1051b0c10>]

/arkouda/src/BroadcastMsg.chpl
[<Module object at 0x104a472d0>]
...
```
So the first element is not always the module object cause some of our chapel files start with a comment. At first I thought we could just do `root = ctx.parse(filename)[-1]` , but `JoinEqWithDTMsg` had to ruin that
```
/Users/pierce/proj/arkouda/src/JoinEqWithDTMsg.chpl
[<Module object at 0x1032c32d0>, <Comment object at 0x1032c24f0>]
```

The chapel python package has `each_matching` which returns an iterator of all the nodes matching a pattern. So I just grab the first node which matches `chapel.Module`. I'm not sure if this is the best way to do it, but it seems to do the trick