### PR TITLE
Closes #3049: Remove mypy version upper bound

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -69,7 +69,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{matrix.python-version}}
     - name: Install dependencies

--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python>=3.9,<3.12.4   # minimum 3.9
+  - python>=3.9,!=3.12.4   # minimum 3.9
   - numpy>=1.24.1,<2.0
   - pandas>=1.4.0,!=2.2.0
   - pyzmq>=20.0.0
@@ -33,7 +33,7 @@ dependencies:
   - sphinx-autodoc-typehints
   - typed-ast
   - flake8
-  - mypy>=0.931,<0.990
+  - mypy>=0.931
   - black
   - isort
   - pytest-json-report

--- a/arkouda-env.yml
+++ b/arkouda-env.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python>=3.9,<3.12.4   # minimum 3.9
+  - python>=3.9,!=3.12.4   # minimum 3.9
   - numpy>=1.24.1,<2.0
   - pandas>=1.4.0,!=2.2.0
   - pyzmq>=20.0.0

--- a/pydoc/requirements.txt
+++ b/pydoc/requirements.txt
@@ -1,5 +1,5 @@
 # dependencies
-python>=3.9,<3.12.4
+python>=3.9,!=3.12.4
 numpy>=1.24.1,<2.0
 pandas>=1.4.0,!=2.2.0
 pyzmq>=20.0.0
@@ -34,7 +34,7 @@ myst-parser
 linkify-it-py
 typed-ast
 flake8
-mypy>=0.931,<0.990
+mypy>=0.931
 black
 isort
 pytest-json-report

--- a/pydoc/setup/REQUIREMENTS.md
+++ b/pydoc/setup/REQUIREMENTS.md
@@ -17,7 +17,7 @@ The installation instructions for the dependencies listed here may vary dependin
 
 The following python packages are required by the Arkouda client package.
 
-- `python>=3.9,<3.12.4`
+- `python>=3.9,!=3.12.4`
 - `numpy>=1.24.1,<2.0`
 - `pandas>=1.4.0,!=2.2.0`
 - `pyzmq>=20.0.0`
@@ -55,7 +55,7 @@ The dependencies listed here are only required if you will be doing development 
 - `linkify-it-py`
 - `typed-ast`
 - `flake8`
-- `mypy>=0.931,<0.990`
+- `mypy>=0.931`
 - `black`
 - `isort`
 - `pytest-json-report`

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
     # and refuse to install the project if the version does not match. If you
     # do not support Python 2, you can simplify this to '>=3.5' or similar, see
     # https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
-    python_requires=">=3.9,<3.12.4",
+    python_requires=">=3.9,!=3.12.4",
     # This field lists other packages that your project depends on to run.
     # Any package you put here will be installed by pip when your project is
     # installed, so they must be valid existing projects.
@@ -146,7 +146,7 @@ setup(
             "Sphinx>=5.1.1",
             "sphinx-argparse",
             "sphinx-autoapi",
-            "mypy>=0.931,<0.990",
+            "mypy>=0.931",
             "typed-ast",
             "black",
             "isort",


### PR DESCRIPTION
This PR (closes https://github.com/Bears-R-Us/arkouda/issues/3049) removes the upper bound of our `mypy` version since the latest works just fine. Also related to https://github.com/Bears-R-Us/arkouda/issues/3346, I changed the python restriction to be `!=3.12.4` since `3.12.3` works just fine. It seems version `3.12.5` was just released, so we'll have to see if the forward refs are still an issue