### PR TITLE
Fixes #3627: multilocale choice failures

### DIFF
--- a/src/RandMsg.chpl
+++ b/src/RandMsg.chpl
@@ -559,8 +559,8 @@ module RandMsg
             const arrEntry = st[aName]: borrowed SymEntry(array_dtype, array_nd);
             const myArr = arrEntry.a;
 
-            forall (idx, arrIdx) in zip(choiceIdx, 0..) with (var agg = newSrcAggregator(array_dtype)) {
-                agg.copy(choiceArr[choiceArr.domain.orderToIndex(arrIdx)], myArr[idx]);
+            forall (c, idx) in zip(choiceArr, choiceIdx) with (var agg = newSrcAggregator(array_dtype)) {
+                agg.copy(c, myArr[idx]);
             }
 
             return st.insert(createSymEntry(choiceArr));


### PR DESCRIPTION
This PR (fixes #3627) I leftover some logic that I used to call `orderToIndex` when I was tryig to make `choice` work for multi-dimensional arrays. This was causing an assertion error. Since `choice` doesn't support multidim yet, I just switched back to looping over the array directly