### PR TITLE
remove typeguard and python caps

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.x']
     container:
       image: chapel/chapel:2.1.0
     steps:

--- a/PROTO_tests/tests/array_api/util_functions.py
+++ b/PROTO_tests/tests/array_api/util_functions.py
@@ -32,7 +32,7 @@ class TestUtilFunctions:
         assert xp.all(a)
 
         a[3, 4] = False
-        assert ~xp.all(a)
+        assert not xp.all(a)
 
     @pytest.mark.skipif(
         get_server_max_array_dims() < 2,
@@ -40,7 +40,7 @@ class TestUtilFunctions:
     )
     def test_any(self):
         a = xp.zeros((10, 10), dtype=ak.bool_)
-        assert ~xp.any(a)
+        assert not xp.any(a)
 
         a[3, 4] = True
         assert xp.any(a)

--- a/PROTO_tests/tests/categorical_test.py
+++ b/PROTO_tests/tests/categorical_test.py
@@ -9,6 +9,7 @@ import arkouda as ak
 from arkouda import io, io_util
 from arkouda.categorical import Categorical
 from arkouda.testing import assert_categorical_equal
+from typeguard import TypeCheckError
 
 @pytest.fixture
 def df_test_base_tmp(request):
@@ -227,7 +228,7 @@ class TestCategorical:
         with pytest.raises(NotImplementedError):
             cat._binop("string 1", "===")
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             cat._binop(1, "==")
 
     def test_in1d(self):

--- a/PROTO_tests/tests/coargsort_test.py
+++ b/PROTO_tests/tests/coargsort_test.py
@@ -2,6 +2,7 @@ from itertools import permutations
 
 import numpy as np
 import pytest
+from typeguard import TypeCheckError
 
 import arkouda as ak
 from arkouda.sorting import SortingAlgorithm
@@ -105,5 +106,5 @@ class TestCoargsort:
         with pytest.raises(ValueError):
             ak.coargsort([ones, short_ones], algo)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.coargsort([list(range(0, 10)), [0]], algo)

--- a/PROTO_tests/tests/dtypes_test.py
+++ b/PROTO_tests/tests/dtypes_test.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from typeguard import TypeCheckError
 
 import arkouda as ak
 from arkouda import dtypes
@@ -29,7 +30,7 @@ class TestDTypes:
 
     @pytest.mark.parametrize("dtype", ["np.str"])
     def test_check_np_dtype_errors(self, dtype):
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             dtypes.check_np_dtype(dtype)
 
     def test_translate_np_dtype(self):
@@ -80,9 +81,9 @@ class TestDTypes:
         float_scalars = Union[float, np.float64, np.float32]
         assert _is_dtype_in_union(np.float64, float_scalars)
         # Test with a type not present in the union
-        assert ~_is_dtype_in_union(np.int64, float_scalars)
+        assert not _is_dtype_in_union(np.int64, float_scalars)
         # Test with a non-Union type
-        assert ~_is_dtype_in_union(np.float64, float)
+        assert not _is_dtype_in_union(np.float64, float)
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize(

--- a/PROTO_tests/tests/extrema_test.py
+++ b/PROTO_tests/tests/extrema_test.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from typeguard import TypeCheckError
 
 import arkouda as ak
 
@@ -96,10 +97,10 @@ class TestExtrema:
     def test_error_handling(self):
         test_array = ak.randint(0, 100, 100)
         for op in ak.mink, ak.maxk, ak.argmink, ak.argmaxk:
-            with pytest.raises(TypeError):
+            with pytest.raises(TypeCheckError):
                 op(list(range(10)), 1)
 
-            with pytest.raises(TypeError):
+            with pytest.raises(TypeCheckError):
                 op(test_array, "1")
 
             with pytest.raises(ValueError):

--- a/PROTO_tests/tests/groupby_test.py
+++ b/PROTO_tests/tests/groupby_test.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+from typeguard import TypeCheckError
 
 import arkouda as ak
 from arkouda import GroupBy, concatenate
@@ -456,7 +457,7 @@ class TestGroupBy:
         with pytest.raises(TypeError):
             ak.GroupBy(ak.arange(4), ak.arange(4))
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             gb.broadcast([])
 
         with pytest.raises(TypeError):

--- a/PROTO_tests/tests/join_test.py
+++ b/PROTO_tests/tests/join_test.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from typeguard import TypeCheckError
 
 import arkouda as ak
 
@@ -222,7 +223,7 @@ class TestJoin:
         """
         Tests error TypeError and ValueError handling
         """
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.join_on_eq_with_dt([list(range(0, 11))], self.a1, self.t1, self.t2, 8, "pos_dt")
         with pytest.raises(TypeError):
             ak.join_on_eq_with_dt([self.a1, list(range(0, 11))], self.t1, self.t2, 8, "pos_dt")
@@ -230,7 +231,7 @@ class TestJoin:
             ak.join_on_eq_with_dt([self.a1, self.a1, list(range(0, 11))], self.t2, 8, "pos_dt")
         with pytest.raises(TypeError):
             ak.join_on_eq_with_dt([self.a1, self.a1, self.t1, list(range(0, 11))], 8, "pos_dt")
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.join_on_eq_with_dt(self.a1, self.a1, self.t1, self.t2, "8", "pos_dt")
         with pytest.raises(ValueError):
             ak.join_on_eq_with_dt(self.a1, self.a1, self.t1, self.t1 * 10, 8, "ab_dt")

--- a/PROTO_tests/tests/logger_test.py
+++ b/PROTO_tests/tests/logger_test.py
@@ -3,6 +3,7 @@ import tempfile
 from logging import DEBUG, INFO, WARN, FileHandler, StreamHandler
 
 import pytest
+from typeguard import TypeCheckError
 
 import arkouda as ak
 from arkouda import io_util
@@ -96,5 +97,5 @@ class TestLogger:
         with pytest.raises(ValueError):
             logger.getHandler("not-a-handler")
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             logger.disableVerbose(logLevel="INFO")

--- a/PROTO_tests/tests/numeric_test.py
+++ b/PROTO_tests/tests/numeric_test.py
@@ -3,6 +3,7 @@ from math import isclose
 
 import numpy as np
 import pytest
+from typeguard import TypeCheckError
 
 import arkouda as ak
 
@@ -271,13 +272,13 @@ class TestNumeric:
         assert 20 == len(result)
         assert int == result.dtype
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.histogram(np.array([range(0, 10)]).astype(num_type), bins=1)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.histogram(pda, bins="1")
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.histogram(np.array([range(0, 10)]).astype(num_type), bins="1")
 
     #   log and exp tests were identical, and so have been combined.
@@ -320,7 +321,7 @@ class TestNumeric:
 
         for npfunc, akfunc in ((np.log, ak.log), (np.exp, ak.exp)):
             assert np.allclose(npfunc(na), akfunc(pda).to_ndarray())
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             akfunc(np.array([range(0, 10)]).astype(num_type))
 
     @pytest.mark.parametrize("num_type", INT_FLOAT)
@@ -335,7 +336,7 @@ class TestNumeric:
             == ak.abs(ak.arange(-5, 0, dtype=num_type)).to_list()
         )
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.abs(np.array([range(0, 10)]).astype(num_type))
 
     @pytest.mark.parametrize("num_type1", NO_BOOL)
@@ -364,7 +365,7 @@ class TestNumeric:
 
         for npfunc, akfunc in ((np.cumsum, ak.cumsum), (np.cumprod, ak.cumprod)):
             assert np.allclose(npfunc(na), akfunc(pda).to_ndarray())
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.cumsum(np.array([range(0, 10)]).astype(num_type))
 
     #   test_trig_and_hyp covers the testing for most trigonometric and hyperbolic
@@ -378,7 +379,7 @@ class TestNumeric:
             _trig_and_hyp_test_helper(npfunc, na, akfunc, pda)
             if (npfunc, akfunc) in INFINITY_EDGE_CASES:
                 _infinity_edge_case_helper(npfunc, akfunc)
-            with pytest.raises(TypeError):
+            with pytest.raises(TypeCheckError):
                 akfunc(np.array([range(0, 10)]).astype(num_type))
 
     @pytest.mark.parametrize("num_type", NO_BOOL)
@@ -476,14 +477,14 @@ class TestNumeric:
         assert np.allclose(np.arctan2(na1, 0), ak.arctan2(pda1, 0).to_ndarray(), equal_nan=True)
         assert np.allclose(np.arctan2(0, na1), ak.arctan2(0, pda1).to_ndarray(), equal_nan=True)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.arctan2(
                 np.array([range(0, 10)]).astype(num_type),
                 np.array([range(10, 20)]).astype(num_type),
             )
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.arctan2(pda_num[0], np.array([range(10, 20)]).astype(num_type))
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.arctan2(np.array([range(0, 10)]).astype(num_type), pda_denom[0])
 
     @pytest.mark.parametrize("num_type", NO_BOOL)
@@ -492,7 +493,7 @@ class TestNumeric:
         pda = ak.array(na, dtype=num_type)
         _trig_and_hyp_test_helper(np.rad2deg, na, ak.rad2deg, pda)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.rad2deg(np.array([range(0, 10)]).astype(num_type))
 
     @pytest.mark.parametrize("num_type", NO_BOOL)
@@ -501,7 +502,7 @@ class TestNumeric:
         pda = ak.array(na, dtype=num_type)
         _trig_and_hyp_test_helper(np.deg2rad, na, ak.deg2rad, pda)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.deg2rad(np.array([range(0, 10)]).astype(num_type))
 
     @pytest.mark.parametrize("num_type", NO_FLOAT)
@@ -515,7 +516,7 @@ class TestNumeric:
     def test_value_counts_error(self):
         pda = ak.linspace(1, 10, 10)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.value_counts([0])
 
     def test_isnan(self):
@@ -533,7 +534,7 @@ class TestNumeric:
         assert ak.isnan(ark_s_int64).to_list() == [False, False, False, False]
 
         ark_s_string = ak.array(["a", "b", "c"])
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.isnan(ark_s_string)
 
     def test_str_cat_cast(self):

--- a/PROTO_tests/tests/pdarray_creation_test.py
+++ b/PROTO_tests/tests/pdarray_creation_test.py
@@ -6,6 +6,7 @@ from collections import deque
 import numpy as np
 import pandas as pd
 import pytest
+from typeguard import TypeCheckError
 
 import arkouda as ak
 
@@ -228,13 +229,13 @@ class TestPdarrayCreation:
         with pytest.raises(ValueError):
             ak.randint(low=1, high=0, size=1, dtype=ak.float64)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.randint(0, 1, "1000")
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.randint("0", 1, 1000)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.randint(0, "1", 1000)
 
     def test_randint_with_seed(self):
@@ -284,13 +285,13 @@ class TestPdarrayCreation:
         u_array = ak.uniform(size=np.int64(3), low=np.int64(0), high=np.int64(5), seed=np.int64(0))
         assert [0.30013431967121934, 0.47383036230759112, 1.0441791878997098] == u_array.to_list()
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.uniform(low="0", high=5, size=size)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.uniform(low=0, high="5", size=size)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.uniform(low=0, high=5, size="100")
 
         # Test that int_scalars covers uint8, uint16, uint32
@@ -433,13 +434,13 @@ class TestPdarrayCreation:
         assert 0.0000 == pda[5]
         assert (pda.to_ndarray() == np.linspace(float(5.0), float(0.0), np.int64(6))).all()
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.linspace(0, "100", 1000)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.linspace("0", 100, 1000)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.linspace(0, 100, "1000")
 
         # Test that int_scalars covers uint8, uint16, uint32
@@ -474,10 +475,10 @@ class TestPdarrayCreation:
         assert npda.tolist() == pda.to_list()
 
     def test_standard_normal_errors(self):
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.standard_normal("100")
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.standard_normal(100.0)
 
         with pytest.raises(ValueError):
@@ -512,13 +513,13 @@ class TestPdarrayCreation:
         with pytest.raises(ValueError):
             ak.random_strings_uniform(maxlen=5, minlen=5, size=10)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.random_strings_uniform(minlen="1", maxlen=5, size=10)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.random_strings_uniform(minlen=1, maxlen="5", size=10)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.random_strings_uniform(minlen=1, maxlen=5, size="10")
 
         # Test that int_scalars covers uint8, uint16, uint32
@@ -558,13 +559,13 @@ class TestPdarrayCreation:
         assert str == pda.dtype
 
     def test_random_strings_lognormal_errors(self):
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.random_strings_lognormal("2", 0.25, 100)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.random_strings_lognormal(2, 0.25, "100")
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.random_strings_lognormal(2, 0.25, 100, 1000000)
 
         # Test that int_scalars covers uint8, uint16, uint32
@@ -655,7 +656,7 @@ class TestPdarrayCreation:
         assert isinstance(p_array, ak.pdarray)
         assert np.int64 == p_array.dtype
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.from_series(np.ones(10))
 
         with pytest.raises(ValueError):

--- a/PROTO_tests/tests/random_test.py
+++ b/PROTO_tests/tests/random_test.py
@@ -5,6 +5,7 @@ from itertools import product
 import numpy as np
 import pytest
 from scipy import stats as sp_stats
+from typeguard import TypeCheckError
 
 import arkouda as ak
 from arkouda.scipy import chisquare as akchisquare
@@ -488,13 +489,13 @@ class TestRandom:
         with pytest.raises(ValueError):
             ak.random.randint(low=1, high=0, size=1, dtype=ak.float64)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.random.randint(0, 1, "1000")
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.random.randint("0", 1, 1000)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.random.randint(0, "1", 1000)
 
         # Test that int_scalars covers uint8, uint16, uint32
@@ -550,13 +551,13 @@ class TestRandom:
             [0.30013431967121934, 0.47383036230759112, 1.0441791878997098], uArray.to_list()
         )
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.random.uniform(low="0", high=5, size=100)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.random.uniform(low=0, high="5", size=100)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.random.uniform(low=0, high=5, size="100")
 
         # Test that int_scalars covers uint8, uint16, uint32
@@ -583,10 +584,10 @@ class TestRandom:
 
         assert np.allclose(npda.tolist(), pda.to_list())
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.random.standard_normal("100")
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.random.standard_normal(100.0)
 
         with pytest.raises(ValueError):

--- a/PROTO_tests/tests/series_test.py
+++ b/PROTO_tests/tests/series_test.py
@@ -352,7 +352,7 @@ class TestSeries:
         assert np.allclose(data_int.isnull().values.to_ndarray(), expected_int.values.to_ndarray())
         assert np.allclose(data_int.notna().values.to_ndarray(), ~expected_int.values.to_ndarray())
         assert np.allclose(data_int.notnull().values.to_ndarray(), ~expected_int.values.to_ndarray())
-        assert ~data_int.hasnans()
+        assert not data_int.hasnans()
 
     def test_isna_float(self):
         # Test case with float data type
@@ -374,7 +374,7 @@ class TestSeries:
         assert np.allclose(
             data_string.notnull().values.to_ndarray(), ~expected_string.values.to_ndarray()
         )
-        assert ~data_string.hasnans()
+        assert not data_string.hasnans()
 
     def test_fillna(self):
         data = ak.Series([1, np.nan, 3, np.nan, 5])

--- a/PROTO_tests/tests/sort_test.py
+++ b/PROTO_tests/tests/sort_test.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from typeguard import TypeCheckError
 
 import arkouda as ak
 from arkouda.sorting import SortingAlgorithm
@@ -77,11 +78,11 @@ class TestSort:
                 ak.sort(arr, algo)
 
         # Test TypeError from sort attempt on non-pdarray
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.sort(list(range(0, 10)), algo)
 
         # Test attempt to sort Strings object, which is unsupported
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.sort(ak.array([f"string {i}" for i in range(10)]), algo)
 
     @pytest.mark.parametrize("algo", SortingAlgorithm)

--- a/PROTO_tests/tests/string_test.py
+++ b/PROTO_tests/tests/string_test.py
@@ -4,6 +4,7 @@ from typing import List
 import numpy as np
 import pandas as pd
 import pytest
+from typeguard import TypeCheckError
 
 import arkouda as ak
 
@@ -275,22 +276,22 @@ class TestString:
         stringsOne = ak.random_strings_uniform(1, 10, size // 4, characters="printable")
         stringsTwo = ak.random_strings_uniform(1, 10, size // 4, characters="printable")
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             stringsOne.lstick(stringsTwo, delimiter=1)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             stringsOne.lstick([1], 1)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             stringsOne.startswith(1)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             stringsOne.endswith(1)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             stringsOne.contains(1)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             stringsOne.peel(1)
 
         with pytest.raises(ValueError):

--- a/PROTO_tests/tests/symbol_table_test.py
+++ b/PROTO_tests/tests/symbol_table_test.py
@@ -1,4 +1,5 @@
 import pytest
+from typeguard import TypeCheckError
 
 import arkouda as ak
 from arkouda.pdarrayclass import RegistrationError
@@ -618,13 +619,13 @@ class TestRegistration:
     def test_error_handling(self, dtype):
         a = self.make_pdarray(dtype, 100)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             a.register(7)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.attach(7)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.is_registered(7)
 
     @pytest.mark.parametrize("dtype", DTYPES)

--- a/PROTO_tests/tests/util_test.py
+++ b/PROTO_tests/tests/util_test.py
@@ -41,7 +41,7 @@ class TestUtil:
             Index(categoricals),
             Series(categoricals),
         ]:
-            assert ~is_numeric(item)
+            assert not is_numeric(item)
 
         for item in [ints, Index(ints), Series(ints), floats, Index(floats), Series(floats)]:
             assert is_numeric(item)
@@ -57,7 +57,7 @@ class TestUtil:
             Index(floats),
             Series(floats),
         ]:
-            assert ~is_int(item)
+            assert not is_int(item)
 
         for item in [ints, Index(ints), Series(ints)]:
             assert is_int(item)
@@ -73,7 +73,7 @@ class TestUtil:
             Index(categoricals),
             Series(categoricals),
         ]:
-            assert ~is_float(item)
+            assert not is_float(item)
 
         for item in [floats, Index(floats), Series(floats)]:
             assert is_float(item)

--- a/PROTO_tests/tests/where_test.py
+++ b/PROTO_tests/tests/where_test.py
@@ -3,6 +3,7 @@ from itertools import product
 
 import numpy as np
 import pytest
+from typeguard import TypeCheckError
 
 import arkouda as ak
 
@@ -40,7 +41,7 @@ class TestWhere:
                 assert np.allclose(akres, npres, equal_nan=True)
 
     def test_error_handling(self):
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.where([0], ak.linspace(1, 10, 10), ak.linspace(1, 10, 10))
 
         with pytest.raises(TypeError):
@@ -141,7 +142,7 @@ class TestWhere:
         )
         # Arkouda does not support multiple where clauses
         cond = a1 > 5, a1 < 8
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeCheckError):
             ak.where(cond, a1, a2)
 
     def test_dtypes(self):

--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python>=3.9,!=3.12.4   # minimum 3.9
+  - python>=3.9   # minimum 3.9
   - numpy>=1.24.1,<2.0
   - pandas>=1.4.0,!=2.2.0
   - pyzmq>=20.0.0
@@ -44,7 +44,7 @@ dependencies:
 
   - pip:
     # Developer dependencies
-    - typeguard==2.10.0
+    - typeguard
     - sphinx-autopackagesummary
     - furo # sphinx theme
     - myst-parser

--- a/arkouda-env.yml
+++ b/arkouda-env.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python>=3.9,!=3.12.4   # minimum 3.9
+  - python>=3.9   # minimum 3.9
   - numpy>=1.24.1,<2.0
   - pandas>=1.4.0,!=2.2.0
   - pyzmq>=20.0.0
@@ -25,4 +25,4 @@ dependencies:
   - pytest-env
 
   - pip:
-      - typeguard==2.10.0
+      - typeguard

--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -1473,7 +1473,6 @@ class Categorical:
         return unregister(user_defined_name)
 
     @staticmethod
-    @typechecked
     def parse_hdf_categoricals(
         d: Mapping[str, Union[pdarray, Strings]]
     ) -> Tuple[List[str], Dict[str, Categorical]]:

--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -11,7 +11,6 @@ from typing import (
     Tuple,
     Union,
     cast,
-    no_type_check,
 )
 
 from arkouda.dtypes import dtype as akdtype
@@ -20,7 +19,7 @@ if TYPE_CHECKING:
     from arkouda.categorical import Categorical
 
 import numpy as np
-from typeguard import typechecked
+from typeguard import typechecked, typeguard_ignore
 
 from arkouda.client import generic_msg
 from arkouda.dtypes import _val_isinstance_of_union, bigint
@@ -2029,7 +2028,7 @@ class GroupBy:
 
         return {piece_name: getattr(self, piece_name) for piece_name in requiredPieces}
 
-    @no_type_check
+    @typeguard_ignore
     def register(self, user_defined_name: str) -> GroupBy:
         """
         Register this GroupBy object and underlying components with the Arkouda server

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -1773,7 +1773,6 @@ def load(
             raise RuntimeError(re)
 
 
-@typechecked
 def load_all(
     path_prefix: str, file_format: str = "INFER", column_delim: str = ",", read_nested=True
 ) -> Mapping[str, Union[pdarray, Strings, SegArray, Categorical]]:

--- a/arkouda/join.py
+++ b/arkouda/join.py
@@ -187,7 +187,6 @@ def compute_join_size(a: pdarray, b: pdarray) -> Tuple[int, int]:
     return nelem, nbytes
 
 
-@typechecked
 def inner_join(
     left: Union[pdarray, Strings, Categorical, Sequence[Union[pdarray, Strings]]],
     right: Union[pdarray, Strings, Categorical, Sequence[Union[pdarray, Strings]]],

--- a/arkouda/numeric.py
+++ b/arkouda/numeric.py
@@ -2,10 +2,9 @@ import json
 from enum import Enum
 from typing import ForwardRef, List, Optional, Sequence, Tuple, Union
 from typing import cast as type_cast
-from typing import no_type_check
 
 import numpy as np
-from typeguard import typechecked
+from typeguard import check_type, typechecked, typeguard_ignore
 
 from arkouda.client import generic_msg
 from arkouda.dtypes import DTypes, bigint
@@ -83,12 +82,11 @@ class ErrorMode(Enum):
     return_validity = "return_validity"
 
 
-@typechecked
 def cast(
-    pda: Union[pdarray, Strings, Categorical],  # type: ignore
+    pda: Union[pdarray, Strings, Categorical],
     dt: Union[np.dtype, type, str, bigint],
     errors: ErrorMode = ErrorMode.strict,
-) -> Union[Union[pdarray, Strings, Categorical], Tuple[pdarray, pdarray]]:  # type: ignore
+) -> Union[Union[pdarray, Strings, Categorical], Tuple[pdarray, pdarray]]:
     """
     Cast an array to another dtype.
 
@@ -1503,13 +1501,13 @@ def _hash_single(pda: pdarray, full: bool = True):
         return create_pdarray(repMsg)
 
 
-@no_type_check
+@typeguard_ignore
 def _str_cat_where(
     condition: pdarray,
     A: Union[str, Strings, Categorical],
     B: Union[str, Strings, Categorical],
 ) -> Union[Strings, Categorical]:
-    # added @no_type_check because mypy can't handle Categorical not being declared
+    # added @typeguard_ignore because mypy can't handle Categorical not being declared
     # sooner, but there are circular dependencies preventing that
     from arkouda.categorical import Categorical
     from arkouda.pdarraysetops import concatenate
@@ -1574,12 +1572,11 @@ def _str_cat_where(
     raise TypeError("ak.where is not supported between Strings and Categorical")
 
 
-@typechecked
 def where(
     condition: pdarray,
-    A: Union[str, numeric_scalars, pdarray, Strings, Categorical],  # type: ignore
-    B: Union[str, numeric_scalars, pdarray, Strings, Categorical],  # type: ignore
-) -> Union[pdarray, Strings, Categorical]:  # type: ignore
+    A: Union[str, numeric_scalars, pdarray, Strings, Categorical],
+    B: Union[str, numeric_scalars, pdarray, Strings, Categorical],
+) -> Union[pdarray, Strings, Categorical]:
     """
     Returns an array with elements chosen from A and B based upon a
     conditioning array. As is the case with numpy.where, the return array
@@ -1650,6 +1647,8 @@ def where(
     is supported e.g., n < 5, n > 1, which is supported in numpy
     is not currently supported in Arkouda
     """
+    check_type(condition, pdarray)
+
     if (not isSupportedNumber(A) and not isinstance(A, pdarray)) or (
         not isSupportedNumber(B) and not isinstance(B, pdarray)
     ):
@@ -2017,8 +2016,8 @@ def value_counts(
 @typechecked
 def clip(
     pda: pdarray,
-    lo: Union[numeric_scalars, pdarray],
-    hi: Union[numeric_scalars, pdarray],
+    lo: Optional[Union[numeric_scalars, pdarray]],
+    hi: Optional[Union[numeric_scalars, pdarray]],
 ) -> pdarray:
     """
     Clip (limit) the values in an array to a given range [lo,hi]

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1239,7 +1239,7 @@ class pdarray:
         return self.size * self.dtype.itemsize
 
     @typechecked
-    def fill(self, value: numeric_scalars) -> None:
+    def fill(self, value: numeric_and_bool_scalars) -> None:
         """
         Fill the array (in place) with a constant value.
 

--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -20,6 +20,7 @@ from arkouda.dtypes import (
     int_scalars,
     isSupportedInt,
     isSupportedNumber,
+    numeric_and_bool_scalars,
     numeric_scalars,
     resolve_scalar_dtype,
 )
@@ -545,7 +546,7 @@ def ones(
 @typechecked
 def full(
     size: Union[int_scalars, str],
-    fill_value: Union[numeric_scalars, str],
+    fill_value: Union[numeric_and_bool_scalars, str],
     dtype: Union[np.dtype, type, str, bigint] = float64,
     max_bits: Optional[int] = None,
 ) -> Union[pdarray, Strings]:
@@ -641,7 +642,7 @@ def scalar_array(
 
 @typechecked
 def _full_string(
-    size: Union[int_scalars, str],
+    size: Union[numeric_and_bool_scalars, str],
     fill_value: str,
 ) -> Strings:
     """

--- a/arkouda/series.py
+++ b/arkouda/series.py
@@ -130,7 +130,6 @@ class Series:
 
     objType = "Series"
 
-    @typechecked
     def __init__(
         self,
         data: Union[Tuple, List, groupable_element_type, Series, SegArray, pd.Series, pd.Categorical],

--- a/arkouda/sorting.py
+++ b/arkouda/sorting.py
@@ -64,7 +64,7 @@ def argsort(
     if axis == -1:
         axis = pda.ndim - 1
 
-    check_type(argname="argsort", value=pda, expected_type=Union[pdarray, Strings, Categorical])
+    check_type(value=pda, expected_type=Union[pdarray, Strings, Categorical])
     if hasattr(pda, "argsort"):
         return cast(Categorical, pda).argsort()
     if pda.size == 0 and hasattr(pda, "dtype"):
@@ -149,7 +149,7 @@ def coargsort(
     from arkouda.numeric import cast as akcast
 
     check_type(
-        argname="coargsort", value=arrays, expected_type=Sequence[Union[pdarray, Strings, Categorical]]
+        value=arrays, expected_type=Sequence[Union[pdarray, Strings, Categorical]]
     )
     size: int_scalars = -1
     anames = []

--- a/pydoc/requirements.txt
+++ b/pydoc/requirements.txt
@@ -1,9 +1,9 @@
 # dependencies
-python>=3.9,!=3.12.4
+python>=3.9
 numpy>=1.24.1,<2.0
 pandas>=1.4.0,!=2.2.0
 pyzmq>=20.0.0
-typeguard==2.10.0
+typeguard
 tabulate
 pyfiglet
 versioneer

--- a/pydoc/setup/REQUIREMENTS.md
+++ b/pydoc/setup/REQUIREMENTS.md
@@ -17,11 +17,11 @@ The installation instructions for the dependencies listed here may vary dependin
 
 The following python packages are required by the Arkouda client package.
 
-- `python>=3.9,!=3.12.4`
+- `python>=3.9`
 - `numpy>=1.24.1,<2.0`
 - `pandas>=1.4.0,!=2.2.0`
 - `pyzmq>=20.0.0`
-- `typeguard==2.10.0`
+- `typeguard`
 - `tabulate`
 - `pyfiglet`
 - `versioneer`

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
     # and refuse to install the project if the version does not match. If you
     # do not support Python 2, you can simplify this to '>=3.5' or similar, see
     # https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
-    python_requires=">=3.9,!=3.12.4",
+    python_requires=">=3.9",
     # This field lists other packages that your project depends on to run.
     # Any package you put here will be installed by pip when your project is
     # installed, so they must be valid existing projects.
@@ -118,7 +118,7 @@ setup(
         "numpy>=1.24.1,<2.0",
         "pandas>=1.4.0,!=2.2.0",
         "pyzmq>=20.0.0",
-        "typeguard==2.10.0",
+        "typeguard",
         "tabulate",
         "pyfiglet",
         "versioneer",


### PR DESCRIPTION
testing if we can add back in 3.12 and 3.x workflows