### PR TITLE
Closes #3646: Config changes for `make test-proto`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -557,7 +557,7 @@ print-%:
 
 size=100
 test-python-proto:
-	python3 -m pytest -c pytest_PROTO.ini PROTO_tests/ --size=$(size) $(ARKOUDA_PYTEST_OPTIONS)
+	python3 -m pytest -c pytest.ini --size=$(size) $(ARKOUDA_PYTEST_OPTIONS)
 
 CLEAN_TARGETS += test-clean
 .PHONY: test-clean

--- a/PROTO_tests/conftest.py
+++ b/PROTO_tests/conftest.py
@@ -63,11 +63,12 @@ def pytest_configure(config):
     pytest.nl = _get_test_locales(config)
     pytest.seed = None if config.getoption("seed") == "" else eval(config.getoption("seed"))
     pytest.prob_size = [eval(x) for x in config.getoption("size").split(",")]
+    pytest.test_running_mode = TestRunningMode(os.getenv("ARKOUDA_RUNNING_MODE", "CLASS_SERVER"))
 
 
 @pytest.fixture(scope="session", autouse=True)
 def startup_teardown():
-    test_running_mode = TestRunningMode(os.getenv("ARKOUDA_RUNNING_MODE", "CLASS_SERVER"))
+    test_running_mode = pytest.test_running_mode
 
     if not importlib.util.find_spec("pytest") or not importlib.util.find_spec("pytest_env"):
         raise EnvironmentError("pytest and pytest-env must be installed")

--- a/PROTO_tests/tests/categorical_test.py
+++ b/PROTO_tests/tests/categorical_test.py
@@ -10,6 +10,7 @@ from arkouda import io, io_util
 from arkouda.categorical import Categorical
 from arkouda.testing import assert_categorical_equal
 
+
 @pytest.fixture
 def df_test_base_tmp(request):
     df_test_base_tmp = "{}/.categorical_test".format(os.getcwd())
@@ -126,7 +127,6 @@ class TestCategorical:
         ak_cat2 = ak.Categorical(ak.Categorical(strings1))
         expected_cat = ak.Categorical(strings1)
         assert_categorical_equal(ak_cat2, expected_cat)
-
 
     def test_substring_search(self):
         cat = self.create_basic_categorical()

--- a/PROTO_tests/tests/client_test.py
+++ b/PROTO_tests/tests/client_test.py
@@ -2,7 +2,7 @@ import pytest
 
 import arkouda as ak
 from arkouda.client import generic_msg
-from server_util.test.server_test_util import start_arkouda_server
+from server_util.test.server_test_util import TestRunningMode, start_arkouda_server
 
 
 class TestClient:
@@ -42,6 +42,10 @@ class TestClient:
         ak.disconnect()
         ak.connect(server=pytest.server, port=pytest.port)
 
+    @pytest.mark.skipif(
+        pytest.test_running_mode == TestRunningMode.CLIENT,
+        reason="start_arkouda_server won't restart if running mode is client",
+    )
     def test_shutdown(self):
         """
         Tests the ak.shutdown() method

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,7 +7,7 @@ testpaths =
     PROTO_tests/tests/bigint_agg_test.py
     PROTO_tests/tests/bitops_test.py
     PROTO_tests/tests/categorical_test.py
-    PROTO_tests/tests/check.py    
+    PROTO_tests/tests/check.py
     PROTO_tests/tests/client_dtypes_test.py
     PROTO_tests/tests/client_test.py
     PROTO_tests/tests/coargsort_test.py


### PR DESCRIPTION
This PR closes #3646. I was digging into the proto tests to see how we fared with a multi-locale server with runtime checks enabled. While investigating this, I found a few small errors and some quality of life changes. These came up because I wanted to use the client running mode to bring my own server (one built with multi-locale and runtime checks) and attempting to skip tests that contained failures to see if the subsequent files had any issues

The changes made:
* `make test-proto` command included `PROTO_tests/` in addition to `pytest_PROTO.ini `. This caused test files to always be run even if they were removed from the `.ini` file
* The environment variables set in `pytest_PROTO.ini ` were being picked up when you run the tests in pycharm. It seems pycharm looks for a file named `pytest.ini` for it's configuration, so I renamed our `ini` to that since we're making the proto tests our main/only testing suite
* There's one test in `client_test`, which shuts down the server and calls `start_arkouda_server` to restart it, but this doesn't work when running mode is client. So I added `pytest.test_running_mode` and created a `skipif` for this test