### PR TITLE
Closes #3661 set default size to 10**2 in unit tests

### DIFF
--- a/PROTO_tests/conftest.py
+++ b/PROTO_tests/conftest.py
@@ -26,7 +26,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--size",
         action="store",
-        default="10**8",
+        default="10**2",
         help="Problem size: length of array to use for tests/benchmarks. For some cases, this will "
         "be multiplied by the number of locales.",
     )


### PR DESCRIPTION
This sets the default size parameter to `10**2` in `PROTO_tests/conftest.py`.  This is the most commonly run test size for development purposes.

Closes #3661 set default size to 10**2 in unit tests