### PR TITLE
Closes #3664: streamline get_max_array_rank checks in unit testing

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -69,3 +69,6 @@ env =
     D:ARKOUDA_VERBOSE=True
     D:ARKOUDA_CLIENT_TIMEOUT=0
     D:ARKOUDA_LOG_LEVEL=DEBUG
+markers =
+    skip_if_max_rank_less_than
+    skip_if_max_rank_greater_than

--- a/tests/array_api/array_creation.py
+++ b/tests/array_api/array_creation.py
@@ -11,14 +11,9 @@ SHAPES = [(), (0,), (0, 0), (1,), (5,), (2, 2), (5, 10)]
 SIZES = [1, 0, 0, 1, 5, 4, 50]
 DIMS = [0, 1, 2, 1, 1, 2, 2]
 
-def get_server_max_array_dims():
-    try:
-        return json.load(open('serverConfig.json', 'r'))['max_array_dims']
-    except (ValueError, FileNotFoundError, TypeError, KeyError):
-        return 1
 
 class TestArrayCreation:
-    @pytest.mark.skipif(get_server_max_array_dims() < 2, reason="test_zeros requires server with 'max_array_dims' >= 2")
+    @pytest.mark.skip_if_max_rank_less_than(2)
     def test_zeros(self):
         for shape, size, dim in zip(SHAPES, SIZES, DIMS):
             for dtype in ak.ScalarDTypes:
@@ -29,7 +24,7 @@ class TestArrayCreation:
                 assert a.dtype == dtype
                 assert a.tolist() == np.zeros(shape, dtype=dtype).tolist()
 
-    @pytest.mark.skipif(get_server_max_array_dims() < 2, reason="test_ones requires server with 'max_array_dims' >= 2")
+    @pytest.mark.skip_if_max_rank_less_than(2)
     def test_ones(self):
         for shape, size, dim in zip(SHAPES, SIZES, DIMS):
             for dtype in ak.ScalarDTypes:
@@ -40,7 +35,7 @@ class TestArrayCreation:
                 assert a.dtype == dtype
                 assert a.tolist() == np.ones(shape, dtype=dtype).tolist()
 
-    @pytest.mark.skipif(get_server_max_array_dims() < 2, reason="test_from_numpy requires server with 'max_array_dims' >= 2")
+    @pytest.mark.skip_if_max_rank_less_than(2)
     def test_from_numpy(self):
         # TODO: support 0D (scalar) arrays
         # (need changes to the create0D command from #2967)

--- a/tests/array_api/array_manipulation.py
+++ b/tests/array_api/array_manipulation.py
@@ -10,13 +10,6 @@ SEED = 12345
 s = SEED
 
 
-def get_server_max_array_dims():
-    try:
-        return json.load(open("serverConfig.json", "r"))["max_array_dims"]
-    except (ValueError, FileNotFoundError, TypeError, KeyError):
-        return 1
-
-
 def randArr(shape):
     global s
     s += 2
@@ -25,10 +18,7 @@ def randArr(shape):
 
 class TestManipulation:
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_broadcast requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_broadcast(self):
         a = xp.ones((1, 6, 1))
         b = xp.ones((5, 1, 10))
@@ -47,10 +37,7 @@ class TestManipulation:
         assert (abcd[2] == 1).all()
         assert (abcd[3] == 1).all()
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_concat requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_concat(self):
         a = randArr((5, 3, 10))
         b = randArr((5, 3, 2))
@@ -83,10 +70,7 @@ class TestManipulation:
         assert hijConcat.shape == (18,)
         assert hijConcat.tolist() == hijNP.tolist()
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_expand_dims requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_expand_dims(self):
         a = randArr((5, 3))
         alist = a.tolist()
@@ -121,10 +105,7 @@ class TestManipulation:
         with pytest.raises(IndexError):
             xp.expand_dims(a, axis=-4)
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_flip requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_flip(self):
         # 1D case
         a = xp.arange(10)
@@ -164,10 +145,7 @@ class TestManipulation:
         with pytest.raises(IndexError):
             xp.flip(r, axis=-4)
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_permute_dims requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_permute_dims(self):
         r = randArr((7, 8, 9))
 
@@ -194,10 +172,7 @@ class TestManipulation:
         with pytest.raises(IndexError):
             xp.permute_dims(r, (0, 1, -4))
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_reshape requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_reshape(self):
         r = randArr((2, 6, 12))
         nr = np.asarray(r.tolist())
@@ -226,10 +201,7 @@ class TestManipulation:
             # more than one dimension can't be inferred
             xp.reshape(r, (2, -1, -1))
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_roll requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_roll(self):
         # 1D case
         a = xp.arange(10)
@@ -272,10 +244,7 @@ class TestManipulation:
         with pytest.raises(IndexError):
             xp.roll(r, 3, axis=-4)
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_squeeze requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_squeeze(self):
         r1 = randArr((1, 2, 3))
         r2 = randArr((2, 1, 3))
@@ -308,10 +277,7 @@ class TestManipulation:
         with pytest.raises(ValueError):
             xp.squeeze(r4, axis=1)
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_stack_unstack requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_stack_unstack(self):
         a = randArr((5, 4))
         b = randArr((5, 4))
@@ -337,10 +303,7 @@ class TestManipulation:
         assert bp.tolist() == b.tolist()
         assert cp.tolist() == c.tolist()
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_tile requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(2)
     def test_tile(self):
         a = randArr((2, 3))
 
@@ -350,10 +313,7 @@ class TestManipulation:
             assert at.shape == npat.shape
             assert at.tolist() == npat.tolist()
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_repeat requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_repeat(self):
         a = randArr((5, 10))
         r = randArr((50,))

--- a/tests/array_api/binary_ops.py
+++ b/tests/array_api/binary_ops.py
@@ -14,18 +14,8 @@ SCALAR_TYPES = list(ak.ScalarDTypes)
 SCALAR_TYPES.remove("bool_")
 
 
-def get_server_max_array_dims():
-    try:
-        return json.load(open("serverConfig.json", "r"))["max_array_dims"]
-    except (ValueError, FileNotFoundError, TypeError, KeyError):
-        return 1
-
-
 class TestArrayCreation:
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 2,
-        reason="test_binops requires server with 'max_array_dims' >= 2",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(2)
     @pytest.mark.parametrize("op", ["+", "-", "*", "/"])
     @pytest.mark.parametrize("dtype", SCALAR_TYPES)
     def test_binops(self, op, dtype):

--- a/tests/array_api/indexing.py
+++ b/tests/array_api/indexing.py
@@ -10,13 +10,6 @@ SEED = 12345
 s = SEED
 
 
-def get_server_max_array_dims():
-    try:
-        return json.load(open("serverConfig.json", "r"))["max_array_dims"]
-    except (ValueError, FileNotFoundError, TypeError, KeyError):
-        return 1
-
-
 def randArr(shape):
     global s
     s += 2
@@ -24,10 +17,7 @@ def randArr(shape):
 
 
 class TestIndexing:
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_rank_changing_assignment requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_rank_changing_assignment(self):
         a = randArr((5, 6, 7))
         b = randArr((5, 6))
@@ -47,10 +37,7 @@ class TestIndexing:
         a[:, :, :] = e
         assert a.tolist() == e.tolist()
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_nd_assignment requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_nd_assignment(self):
         a = randArr((5, 6, 7))
         bnp = randArr((5, 6, 7)).to_ndarray()
@@ -64,10 +51,7 @@ class TestIndexing:
         a[:] = 5
         assert (a == 5).all()
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_pdarray_index requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_pdarray_index(self):
         a = randArr((5, 6, 7))
         anp = np.asarray(a.tolist())
@@ -98,10 +82,7 @@ class TestIndexing:
         xnp = anp[:]
         assert x.tolist() == xnp.tolist()
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_none_index requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_none_index(self):
         a = randArr((10, 10))
         anp = np.asarray(a.tolist())

--- a/tests/array_api/searching_functions.py
+++ b/tests/array_api/searching_functions.py
@@ -9,18 +9,8 @@ import arkouda.array_api as xp
 SEED = 314159
 
 
-def get_server_max_array_dims():
-    try:
-        return json.load(open("serverConfig.json", "r"))["max_array_dims"]
-    except (ValueError, FileNotFoundError, TypeError, KeyError):
-        return 1
-
-
 class TestSearchingFunctions:
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_argmax requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_argmax(self):
         a = xp.asarray(ak.randint(0, 100, (4, 5, 6), dtype=ak.int64, seed=SEED))
         a[3, 2, 1] = 101
@@ -37,10 +27,7 @@ class TestSearchingFunctions:
         assert aArgmax1Keepdims.shape == (4, 1, 6)
         assert aArgmax1Keepdims[3, 0, 1] == 2
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_argmin requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_argmin(self):
         a = xp.asarray(ak.randint(0, 100, (4, 5, 6), dtype=ak.int64, seed=SEED))
         a[3, 2, 1] = -1
@@ -55,10 +42,7 @@ class TestSearchingFunctions:
         assert aArgmin1Keepdims.shape == (4, 1, 6)
         assert aArgmin1Keepdims[3, 0, 1] == 2
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_nonzero requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_nonzero(self):
         a = xp.zeros((4, 5, 6), dtype=ak.int64)
         a[0, 1, 0] = 1
@@ -74,10 +58,7 @@ class TestSearchingFunctions:
         assert sorted(nz[1].tolist()) == sorted([1, 2, 2, 2])
         assert sorted(nz[2].tolist()) == sorted([0, 3, 2, 1])
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_where requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_where(self):
         a = xp.zeros((4, 5, 6), dtype=ak.int64)
         a[1, 2, 3] = 1
@@ -96,10 +77,7 @@ class TestSearchingFunctions:
         assert d[0, 0, 0] == c[0, 0, 0]
         assert d[3, 3, 3] == c[3, 3, 3]
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_search_sorted requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_search_sorted(self):
         a = xp.asarray(ak.randint(0, 100, 1000, dtype=ak.float64))
         b = xp.asarray(ak.randint(0, 100, (10, 10), dtype=ak.float64))

--- a/tests/array_api/set_functions.py
+++ b/tests/array_api/set_functions.py
@@ -10,13 +10,6 @@ SEED = 314159
 s = SEED
 
 
-def get_server_max_array_dims():
-    try:
-        return json.load(open("serverConfig.json", "r"))["max_array_dims"]
-    except (ValueError, FileNotFoundError, TypeError, KeyError):
-        return 1
-
-
 def randArr(shape):
     global s
     s += 2
@@ -25,10 +18,7 @@ def randArr(shape):
 
 class TestSetFunction:
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_set_functions requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_set_functions(self):
 
         for shape in [(1000), (20, 50), (2, 10, 50)]:

--- a/tests/array_api/sorting.py
+++ b/tests/array_api/sorting.py
@@ -9,16 +9,12 @@ import arkouda.array_api as xp
 SHAPES = [(1,), (25,), (5, 10), (10, 5)]
 SEED = 12345
 SCALAR_TYPES = list(ak.ScalarDTypes)
-SCALAR_TYPES.remove('bool_')
+SCALAR_TYPES.remove("bool_")
 
-def get_server_max_array_dims():
-    try:
-        return json.load(open('serverConfig.json', 'r'))['max_array_dims']
-    except (ValueError, FileNotFoundError, TypeError, KeyError):
-        return 1
+
 class TestArrayCreation:
 
-    @pytest.mark.skipif(get_server_max_array_dims() < 2, reason="test_argsort requires server with 'max_array_dims' >= 2")
+    @pytest.mark.skip_if_max_rank_less_than(2)
     def test_argsort(self):
         for shape in SHAPES:
             for dtype in ak.ScalarDTypes:
@@ -50,7 +46,7 @@ class TestArrayCreation:
                                 for j in range(shape[1] - 1):
                                     assert a[i, b[i, j]] <= a[i, b[i, j + 1]]
 
-    @pytest.mark.skipif(get_server_max_array_dims() < 2, reason="test_sort requires server with 'max_array_dims' >= 2")
+    @pytest.mark.skip_if_max_rank_less_than(2)
     @pytest.mark.parametrize("dtype", SCALAR_TYPES)
     @pytest.mark.parametrize("shape", SHAPES)
     def test_sort(self, dtype, shape):

--- a/tests/array_api/stats_functions.py
+++ b/tests/array_api/stats_functions.py
@@ -9,18 +9,10 @@ import arkouda.array_api as xp
 
 SEED = 314159
 
-def get_server_max_array_dims():
-    try:
-        return json.load(open('serverConfig.json', 'r'))['max_array_dims']
-    except (ValueError, FileNotFoundError, TypeError, KeyError):
-        return 1
 
 class TestStatsFunction:
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_max requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_max(self):
         a = xp.asarray(ak.randint(0, 100, (5, 7, 4), dtype=ak.int64, seed=SEED))
         a[3, 6, 2] = 101
@@ -39,10 +31,7 @@ class TestStatsFunction:
         assert aMax02Keepdims.shape == (1, 7, 1)
         assert aMax02Keepdims[0, 6, 0] == 101
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_min requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_min(self):
         a = xp.asarray(ak.randint(0, 100, (5, 7, 4), dtype=ak.int64, seed=SEED))
         a[3, 6, 2] = -1
@@ -61,10 +50,7 @@ class TestStatsFunction:
         assert aMin02Keepdims.shape == (1, 7, 1)
         assert aMin02Keepdims[0, 6, 0] == -1
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_mean requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_mean(self):
         a = xp.ones((10, 5, 5))
         a[0, 0, 0] = 251
@@ -90,10 +76,7 @@ class TestStatsFunction:
         assert aMean02Keepdims[0, 0, 0] == 2
         assert aMean02Keepdims[2, 0, 0] == 2
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_std requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_std(self):
         a = xp.ones((10, 5, 5), dtype=ak.float64)
         a[0, 0, 0] = 26
@@ -113,10 +96,7 @@ class TestStatsFunction:
         assert abs(aStd02Keepdims[0, 0, 0] - math.sqrt(24)) < 1e-10
         assert abs(aStd02Keepdims[2, 0, 0] - math.sqrt(24)) < 1e-10
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_var requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_var(self):
         a = xp.ones((10, 5, 5), dtype=ak.float64)
         a[0, 0, 0] = 26
@@ -136,10 +116,7 @@ class TestStatsFunction:
         assert abs(aStd02Keepdims[0, 0, 0] - 24) < 1e-10
         assert abs(aStd02Keepdims[2, 0, 0] - 24) < 1e-10
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_prod requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_prod(self):
         a = xp.ones((2, 3, 4))
         a = a + a
@@ -158,10 +135,7 @@ class TestStatsFunction:
         assert aProd02Keepdims.shape == (2, 1, 1)
         assert aProd02Keepdims[0, 0, 0] == 2**12
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_sum requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_sum(self):
         a = xp.ones((2, 3, 4))
 
@@ -179,10 +153,7 @@ class TestStatsFunction:
         assert aSum02Keepdims.shape == (2, 1, 1)
         assert aSum02Keepdims[0, 0, 0] == 12
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_cumsum requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_cumsum(self):
         a = xp.asarray(ak.randint(0, 100, (5, 6, 7), seed=SEED))
 

--- a/tests/array_api/util_functions.py
+++ b/tests/array_api/util_functions.py
@@ -12,24 +12,16 @@ s = SEED
 DTYPES = [ak.int64, ak.float64, ak.uint64, ak.uint8]
 
 
-def get_server_max_array_dims():
-    try:
-        return json.load(open("serverConfig.json", "r"))["max_array_dims"]
-    except (ValueError, FileNotFoundError, TypeError, KeyError):
-        return 1
-
-
 def randArr(shape, dtype):
+
     global s
     s += 2
     return xp.asarray(ak.randint(0, 100, shape, dtype=ak.int64, seed=s), dtype=dtype)
 
 
 class TestUtilFunctions:
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 2,
-        reason="test_all requires server with 'max_array_dims' >= 2",
-    )
+
+    @pytest.mark.skip_if_max_rank_less_than(2)
     def test_all(self):
         a = xp.ones((10, 10), dtype=ak.bool_)
         assert xp.all(a)
@@ -37,10 +29,7 @@ class TestUtilFunctions:
         a[3, 4] = False
         assert ~xp.all(a)
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 2,
-        reason="test_any requires server with 'max_array_dims' >= 2",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(2)
     def test_any(self):
         a = xp.zeros((10, 10), dtype=ak.bool_)
         assert ~xp.any(a)
@@ -49,21 +38,17 @@ class TestUtilFunctions:
         assert xp.any(a)
 
     @pytest.mark.parametrize("dtype", DTYPES)
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3, reason="test_clip requires server with 'max_array_dims' >= 3"
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_clip(self, dtype):
         a = randArr((5, 6, 7), dtype)
+
         anp = a.to_ndarray()
 
         a_c = xp.clip(a, 10, 90)
         anp_c = np.clip(anp, 10, 90)
         assert a_c.tolist() == anp_c.tolist()
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_diff requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_clip_errors(self):
         # bool
         a = xp.asarray(ak.randint(0, 100, (5, 6, 7), dtype=ak.bool_, seed=s), dtype=ak.bool_)
@@ -85,10 +70,7 @@ class TestUtilFunctions:
             xp.clip(a, 10, 90)
 
     @pytest.mark.parametrize("dtype", DTYPES)
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_diff requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_diff(self, dtype):
         a = randArr((5, 6, 7), dtype)
         anp = a.to_ndarray()
@@ -102,10 +84,7 @@ class TestUtilFunctions:
 
         assert a_d.tolist() == anp_d.tolist()
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_diff requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_diff_error(self):
         # bool
         a = xp.asarray(ak.randint(0, 100, (5, 6, 7), dtype=ak.bool_, seed=s), dtype=ak.bool_)
@@ -126,10 +105,7 @@ class TestUtilFunctions:
         ):
             xp.diff(a, n=2, axis=0)
 
-    @pytest.mark.skipif(
-        get_server_max_array_dims() < 3,
-        reason="test_pad requires server with 'max_array_dims' >= 3",
-    )
+    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_pad(self):
         a = xp.ones((5, 6, 7))
         anp = np.ones((5, 6, 7))
@@ -161,7 +137,5 @@ class TestUtilFunctions:
         with pytest.raises(
             RuntimeError, match="Error executing command: pad does not support dtype bigint"
         ):
-            xp.pad(
-                a, ((1, 1)), mode="constant", constant_values=((-1, 1))
-            )
+            xp.pad(a, ((1, 1)), mode="constant", constant_values=((-1, 1)))
             xp.diff(a, n=2, axis=0)

--- a/tests/array_manipulation_tests.py
+++ b/tests/array_manipulation_tests.py
@@ -1,19 +1,14 @@
-import arkouda as ak
-import numpy as np
-
-import pytest
 import json
 
+import numpy as np
+import pytest
 
-def get_server_max_array_dims():
-    try:
-        return json.load(open('serverConfig.json', 'r'))['max_array_dims']
-    except (ValueError, FileNotFoundError, TypeError, KeyError):
-        return 1
+import arkouda as ak
 
 
 class TestManipulationFunctions:
-    @pytest.mark.skipif(get_server_max_array_dims() < 2, reason="vstack requires server with 'max_array_dims' >= 2")
+
+    @pytest.mark.skip_if_max_rank_less_than(2)
     def test_vstack(self):
         a = [ak.random.randint(0, 10, 25) for _ in range(4)]
         n = [x.to_ndarray() for x in a]
@@ -23,7 +18,7 @@ class TestManipulationFunctions:
 
         assert n_vstack.tolist() == a_vstack.to_list()
 
-    @pytest.mark.skipif(get_server_max_array_dims() < 2, reason="delete requires server with 'max_array_dims' >= 2")
+    @pytest.mark.skip_if_max_rank_less_than(2)
     def test_delete(self):
         a = ak.randint(0, 100, (10, 10))
         n = a.to_ndarray()

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -867,10 +867,8 @@ class TestNumeric:
 
     @pytest.mark.parametrize("data_type", INT_FLOAT_BOOL)
     @pytest.mark.parametrize("prob_size", pytest.prob_size)
+    @pytest.mark.skip_if_max_rank_less_than(2)
     def test_triu(self, data_type, prob_size):
-        if get_max_array_rank() < 2:
-            pytest.skip()
-
         size = int(sqrt(prob_size))
 
         # ints and bools are checked for equality; floats are checked for closeness


### PR DESCRIPTION
This creates a new pytest fixture allowing unit tests to be skipped with `@pytest.mark.skip_if_max_rank_less_than` or `@pytest.mark.skip_if_max_rank_greater_than`.

Closes #3664: streamline get_max_array_rank checks in unit testing