### PR TITLE
Closes #3677: Occasional failures of `test_string_broadcast`

### DIFF
--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -877,6 +877,10 @@ class TestString:
 
     def test_string_broadcast(self):
         keys = ak.randint(0, 10, 100, int)
+        while ak.unique(keys).size != 10:
+            # keep generating until every element appears at least once
+            keys = ak.randint(0, 10, 100, int)
+
         g = ak.GroupBy(keys)
         str_vals = ak.random_strings_uniform(0, 3, 10, characters="printable")
         str_broadcast_ans = str_vals[keys]


### PR DESCRIPTION
This PR fixes #3677 by regenerating `keys` if not all elements appear at least once

This should be pretty rare but it caused a CI failure last week