### PR TITLE
Closes #3631: refactor-utilMsg-to-remove-registerND-annotation

### DIFF
--- a/arkouda/array_api/utility_functions.py
+++ b/arkouda/array_api/utility_functions.py
@@ -71,9 +71,9 @@ def clip(a: Array, a_min, a_max, /) -> Array:
     return Array._new(
         create_pdarray(
             generic_msg(
-                cmd=f"clip{a.ndim}D",
+                cmd=f"clip<{a.dtype},{a.ndim}>",
                 args={
-                    "name": a._array,
+                    "x": a._array,
                     "min": a_min,
                     "max": a_max,
                 },
@@ -111,9 +111,9 @@ def diff(a: Array, /, n: int = 1, axis: int = -1, prepend=None, append=None) -> 
     return Array._new(
         create_pdarray(
             generic_msg(
-                cmd=f"diff{a.ndim}D",
+                cmd=f"diff<{a.dtype},{a.ndim}>",
                 args={
-                    "name": a_._array,
+                    "x": a_._array,
                     "n": n,
                     "axis": axis,
                 },
@@ -176,7 +176,7 @@ def pad(
     return Array._new(
         create_pdarray(
             generic_msg(
-                cmd=f"pad{array.ndim}D",
+                cmd=f"pad<{array.dtype},{array.ndim}>",
                 args={
                     "name": array._array,
                     "padWidthBefore": tuple(pad_widths_b),

--- a/src/registry/Commands.chpl
+++ b/src/registry/Commands.chpl
@@ -1940,6 +1940,102 @@ proc ark_cumSum_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowe
   return ark_reg_cumSum_generic(cmd, msgArgs, st, array_dtype_0=bigint, array_nd_0=1);
 registerFunction('cumSum<bigint,1>', ark_cumSum_bigint_1, 'StatsMsg', 120);
 
+import UtilMsg;
+
+proc ark_reg_clip_generic(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype_0, param array_nd_0: int): MsgTuple throws {
+  var x_array_sym = st[msgArgs['x']]: SymEntry(array_dtype_0, array_nd_0);
+  ref x = x_array_sym.a;
+  var min = msgArgs['min'].toScalar(real);
+  var max = msgArgs['max'].toScalar(real);
+  var ark_result = UtilMsg.clip(x,min,max);
+  var ark_result_symbol = new shared SymEntry(ark_result);
+
+  return st.insert(ark_result_symbol);
+}
+
+proc ark_clip_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_clip_generic(cmd, msgArgs, st, array_dtype_0=int, array_nd_0=1);
+registerFunction('clip<int64,1>', ark_clip_int_1, 'UtilMsg', 27);
+
+proc ark_clip_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_clip_generic(cmd, msgArgs, st, array_dtype_0=uint, array_nd_0=1);
+registerFunction('clip<uint64,1>', ark_clip_uint_1, 'UtilMsg', 27);
+
+proc ark_clip_uint8_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_clip_generic(cmd, msgArgs, st, array_dtype_0=uint(8), array_nd_0=1);
+registerFunction('clip<uint8,1>', ark_clip_uint8_1, 'UtilMsg', 27);
+
+proc ark_clip_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_clip_generic(cmd, msgArgs, st, array_dtype_0=real, array_nd_0=1);
+registerFunction('clip<float64,1>', ark_clip_real_1, 'UtilMsg', 27);
+
+proc ark_clip_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_clip_generic(cmd, msgArgs, st, array_dtype_0=bool, array_nd_0=1);
+registerFunction('clip<bool,1>', ark_clip_bool_1, 'UtilMsg', 27);
+
+proc ark_clip_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_clip_generic(cmd, msgArgs, st, array_dtype_0=bigint, array_nd_0=1);
+registerFunction('clip<bigint,1>', ark_clip_bigint_1, 'UtilMsg', 27);
+
+proc ark_reg_diff_generic(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype_0, param array_nd_0: int): MsgTuple throws {
+  var x_array_sym = st[msgArgs['x']]: SymEntry(array_dtype_0, array_nd_0);
+  ref x = x_array_sym.a;
+  var n = msgArgs['n'].toScalar(int);
+  var axis = msgArgs['axis'].toScalar(int);
+  var ark_result = UtilMsg.diff(x,n,axis);
+  var ark_result_symbol = new shared SymEntry(ark_result);
+
+  return st.insert(ark_result_symbol);
+}
+
+proc ark_diff_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_diff_generic(cmd, msgArgs, st, array_dtype_0=int, array_nd_0=1);
+registerFunction('diff<int64,1>', ark_diff_int_1, 'UtilMsg', 58);
+
+proc ark_diff_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_diff_generic(cmd, msgArgs, st, array_dtype_0=uint, array_nd_0=1);
+registerFunction('diff<uint64,1>', ark_diff_uint_1, 'UtilMsg', 58);
+
+proc ark_diff_uint8_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_diff_generic(cmd, msgArgs, st, array_dtype_0=uint(8), array_nd_0=1);
+registerFunction('diff<uint8,1>', ark_diff_uint8_1, 'UtilMsg', 58);
+
+proc ark_diff_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_diff_generic(cmd, msgArgs, st, array_dtype_0=real, array_nd_0=1);
+registerFunction('diff<float64,1>', ark_diff_real_1, 'UtilMsg', 58);
+
+proc ark_diff_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_diff_generic(cmd, msgArgs, st, array_dtype_0=bool, array_nd_0=1);
+registerFunction('diff<bool,1>', ark_diff_bool_1, 'UtilMsg', 58);
+
+proc ark_diff_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_diff_generic(cmd, msgArgs, st, array_dtype_0=bigint, array_nd_0=1);
+registerFunction('diff<bigint,1>', ark_diff_bigint_1, 'UtilMsg', 58);
+
+proc ark_pad_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return UtilMsg.pad(cmd, msgArgs, st, array_dtype=int, array_nd=1);
+registerFunction('pad<int64,1>', ark_pad_int_1, 'UtilMsg', 125);
+
+proc ark_pad_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return UtilMsg.pad(cmd, msgArgs, st, array_dtype=uint, array_nd=1);
+registerFunction('pad<uint64,1>', ark_pad_uint_1, 'UtilMsg', 125);
+
+proc ark_pad_uint8_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return UtilMsg.pad(cmd, msgArgs, st, array_dtype=uint(8), array_nd=1);
+registerFunction('pad<uint8,1>', ark_pad_uint8_1, 'UtilMsg', 125);
+
+proc ark_pad_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return UtilMsg.pad(cmd, msgArgs, st, array_dtype=real, array_nd=1);
+registerFunction('pad<float64,1>', ark_pad_real_1, 'UtilMsg', 125);
+
+proc ark_pad_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return UtilMsg.pad(cmd, msgArgs, st, array_dtype=bool, array_nd=1);
+registerFunction('pad<bool,1>', ark_pad_bool_1, 'UtilMsg', 125);
+
+proc ark_pad_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return UtilMsg.pad(cmd, msgArgs, st, array_dtype=bigint, array_nd=1);
+registerFunction('pad<bigint,1>', ark_pad_bigint_1, 'UtilMsg', 125);
+
 import MsgProcessing;
 
 proc ark_create_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do

--- a/tests/array_api/util_functions.py
+++ b/tests/array_api/util_functions.py
@@ -9,17 +9,20 @@ import arkouda.array_api as xp
 SEED = 314159
 s = SEED
 
+DTYPES = [ak.int64, ak.float64, ak.uint64, ak.uint8]
+
 
 def get_server_max_array_dims():
     try:
-        return json.load(open('serverConfig.json', 'r'))['max_array_dims']
+        return json.load(open("serverConfig.json", "r"))["max_array_dims"]
     except (ValueError, FileNotFoundError, TypeError, KeyError):
         return 1
 
-def randArr(shape):
+
+def randArr(shape, dtype):
     global s
     s += 2
-    return xp.asarray(ak.randint(0, 100, shape, dtype=ak.int64, seed=s))
+    return xp.asarray(ak.randint(0, 100, shape, dtype=ak.int64, seed=s), dtype=dtype)
 
 
 class TestUtilFunctions:
@@ -45,9 +48,12 @@ class TestUtilFunctions:
         a[3, 4] = True
         assert xp.any(a)
 
-    @pytest.mark.skipif(get_server_max_array_dims() < 3, reason="test_clip requires server with 'max_array_dims' >= 3")
-    def test_clip(self):
-        a = randArr((5, 6, 7))
+    @pytest.mark.parametrize("dtype", DTYPES)
+    @pytest.mark.skipif(
+        get_server_max_array_dims() < 3, reason="test_clip requires server with 'max_array_dims' >= 3"
+    )
+    def test_clip(self, dtype):
+        a = randArr((5, 6, 7), dtype)
         anp = a.to_ndarray()
 
         a_c = xp.clip(a, 10, 90)
@@ -58,8 +64,33 @@ class TestUtilFunctions:
         get_server_max_array_dims() < 3,
         reason="test_diff requires server with 'max_array_dims' >= 3",
     )
-    def test_diff(self):
-        a = randArr((5, 6, 7))
+    def test_clip_errors(self):
+        # bool
+        a = xp.asarray(ak.randint(0, 100, (5, 6, 7), dtype=ak.bool_, seed=s), dtype=ak.bool_)
+        with pytest.raises(
+            RuntimeError, match="Error executing command: clip does not support dtype bool"
+        ):
+            xp.clip(a, 10, 90)
+
+        # bigint
+        bi_arr = ak.array(
+            [0, 1, 2, 3, 4, 2**64 - 5, 2**64 - 4, 2**64 - 3, 2**64 - 2, 2**64 - 1],
+            dtype=ak.bigint,
+            max_bits=64,
+        )
+        a = xp.asarray(bi_arr, dtype=ak.bool_)
+        with pytest.raises(
+            RuntimeError, match="Error executing command: clip does not support dtype bigint"
+        ):
+            xp.clip(a, 10, 90)
+
+    @pytest.mark.parametrize("dtype", DTYPES)
+    @pytest.mark.skipif(
+        get_server_max_array_dims() < 3,
+        reason="test_diff requires server with 'max_array_dims' >= 3",
+    )
+    def test_diff(self, dtype):
+        a = randArr((5, 6, 7), dtype)
         anp = a.to_ndarray()
 
         a_d = xp.diff(a, n=1, axis=1)
@@ -70,6 +101,30 @@ class TestUtilFunctions:
         anp_d = np.diff(anp, n=2, axis=0)
 
         assert a_d.tolist() == anp_d.tolist()
+
+    @pytest.mark.skipif(
+        get_server_max_array_dims() < 3,
+        reason="test_diff requires server with 'max_array_dims' >= 3",
+    )
+    def test_diff_error(self):
+        # bool
+        a = xp.asarray(ak.randint(0, 100, (5, 6, 7), dtype=ak.bool_, seed=s), dtype=ak.bool_)
+        with pytest.raises(
+            RuntimeError, match="Error executing command: diff does not support dtype bool"
+        ):
+            xp.diff(a, n=2, axis=0)
+
+        # bigint
+        bi_arr = ak.array(
+            [0, 1, 2, 3, 4, 2**64 - 5, 2**64 - 4, 2**64 - 3, 2**64 - 2, 2**64 - 1],
+            dtype=ak.bigint,
+            max_bits=64,
+        )
+        a = xp.asarray(bi_arr, dtype=ak.bool_)
+        with pytest.raises(
+            RuntimeError, match="Error executing command: diff does not support dtype bigint"
+        ):
+            xp.diff(a, n=2, axis=0)
 
     @pytest.mark.skipif(
         get_server_max_array_dims() < 3,
@@ -94,3 +149,19 @@ class TestUtilFunctions:
         a_p = xp.pad(a, 2, constant_values=3)
         anp_p = np.pad(anp, 2, constant_values=3)
         assert a_p.tolist() == anp_p.tolist()
+
+    def test_pad_error(self):
+        # bigint
+        bi_arr = ak.array(
+            [0, 1, 2, 3, 4, 2**64 - 5, 2**64 - 4, 2**64 - 3, 2**64 - 2, 2**64 - 1],
+            dtype=ak.bigint,
+            max_bits=64,
+        )
+        a = xp.asarray(bi_arr, dtype=ak.bool_)
+        with pytest.raises(
+            RuntimeError, match="Error executing command: pad does not support dtype bigint"
+        ):
+            xp.pad(
+                a, ((1, 1)), mode="constant", constant_values=((-1, 1))
+            )
+            xp.diff(a, n=2, axis=0)


### PR DESCRIPTION
Refactored `UtilMsg` to remove `@arkouda.registerND` annotation.  Also added some extra unit tests to verify the unsupported types throw `RuntimeError`s.

Closes #3631: refactor-utilMsg-to-remove-registerND-annotation