### PR TITLE
Closes #3695: Fix Parquet Fixed-Length Code Path for Incorrect File Size Assumption

### DIFF
--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -1030,7 +1030,7 @@ module ParquetMsg {
           } else {
             entrySeg.a = fixedLen;
             for i in sizes.domain do
-+              byteSizes[i] = fixedLen*sizes[i];
+              byteSizes[i] = fixedLen*sizes[i];
           }
           entrySeg.a = (+ scan entrySeg.a) - entrySeg.a;
 

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -1029,7 +1029,8 @@ module ParquetMsg {
             byteSizes = calcStrSizesAndOffset(entrySeg.a, filenames, sizes, dsetname);
           } else {
             entrySeg.a = fixedLen;
-            byteSizes = fixedLen*len;
+            for i in sizes.domain do
++              byteSizes[i] = fixedLen*sizes[i];
           }
           entrySeg.a = (+ scan entrySeg.a) - entrySeg.a;
 


### PR DESCRIPTION
The current implementation of the fixed-length code path for reading Parquet files incorrectly assumes that all files within a dataset have the same number of strings. This can lead to incorrect results or unexpected behavior when dealing with datasets where files have varying numbers of strings.

Closes #3695