### PR TITLE
Closes #3705: Add annotations to skip tests based on rank.

### DIFF
--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1,7 +1,7 @@
 import pytest
 
 import arkouda as ak
-from arkouda.client import generic_msg
+from arkouda.client import generic_msg, get_max_array_rank
 from server_util.test.server_test_util import TestRunningMode, start_arkouda_server
 
 
@@ -156,6 +156,7 @@ class TestClient:
         for cmd in ["connect", "info", "str"]:
             assert cmd in cmds
 
+    @pytest.mark.skip_if_max_rank_greater_than(9)
     def test_client_array_dim_cmd_error(self):
         """
         Tests that a user will get a helpful error message if they attempt to

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -287,6 +287,7 @@ class TestNumeric:
     host = subprocess.check_output("hostname").decode("utf-8").strip()
 
     @pytest.mark.skipif(host == "horizon", reason="Fails on horizon")
+    @pytest.mark.skip_if_max_rank_less_than(2)
     def test_histogram_multidim(self):
         # test 2d histogram
         seed = 1


### PR DESCRIPTION
Add annotations to skip tests based on rank.  The relevant tests are: `test_histogram_multidim` and `test_clienlient_array_dim_cmd_error`.

Closes #3705: Add annotations to skip tests based on rank.

co-authored with @drculhane 