### PR TITLE
Update Commands.chpl to reflect recent changes to linalg module

### DIFF
--- a/src/registry/Commands.chpl
+++ b/src/registry/Commands.chpl
@@ -869,6 +869,39 @@ registerFunction('takeAlongAxis<bigint,bigint,1>', ark_takeAlongAxis_bigint_bigi
 
 import LinalgMsg;
 
+proc ark_reg_transpose_generic(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype_0, param array_nd_0: int): MsgTuple throws {
+  var array_array_sym = st[msgArgs['array']]: SymEntry(array_dtype_0, array_nd_0);
+  ref array = array_array_sym.a;
+  var ark_result = LinalgMsg.transpose(array);
+  var ark_result_symbol = new shared SymEntry(ark_result);
+
+  return st.insert(ark_result_symbol);
+}
+
+proc ark_transpose_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_transpose_generic(cmd, msgArgs, st, array_dtype_0=int, array_nd_0=1);
+registerFunction('transpose<int64,1>', ark_transpose_int_1, 'LinalgMsg', 289);
+
+proc ark_transpose_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_transpose_generic(cmd, msgArgs, st, array_dtype_0=uint, array_nd_0=1);
+registerFunction('transpose<uint64,1>', ark_transpose_uint_1, 'LinalgMsg', 289);
+
+proc ark_transpose_uint8_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_transpose_generic(cmd, msgArgs, st, array_dtype_0=uint(8), array_nd_0=1);
+registerFunction('transpose<uint8,1>', ark_transpose_uint8_1, 'LinalgMsg', 289);
+
+proc ark_transpose_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_transpose_generic(cmd, msgArgs, st, array_dtype_0=real, array_nd_0=1);
+registerFunction('transpose<float64,1>', ark_transpose_real_1, 'LinalgMsg', 289);
+
+proc ark_transpose_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_transpose_generic(cmd, msgArgs, st, array_dtype_0=bool, array_nd_0=1);
+registerFunction('transpose<bool,1>', ark_transpose_bool_1, 'LinalgMsg', 289);
+
+proc ark_transpose_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return ark_reg_transpose_generic(cmd, msgArgs, st, array_dtype_0=bigint, array_nd_0=1);
+registerFunction('transpose<bigint,1>', ark_transpose_bigint_1, 'LinalgMsg', 289);
+
 proc ark_eye_int(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.eye(cmd, msgArgs, st, array_dtype=int);
 registerFunction('eye<int64>', ark_eye_int, 'LinalgMsg', 26);
@@ -1085,173 +1118,149 @@ proc ark_matmul_bigint_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: 
   return LinalgMsg.matmul(cmd, msgArgs, st, array_dtype_x1=bigint, array_dtype_x2=bigint, array_nd=1);
 registerFunction('matmul<bigint,bigint,1>', ark_matmul_bigint_bigint_1, 'LinalgMsg', 165);
 
-proc ark_transpose_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return LinalgMsg.transpose(cmd, msgArgs, st, array_dtype=int, array_nd=1);
-registerFunction('transpose<int64,1>', ark_transpose_int_1, 'LinalgMsg', 289);
-
-proc ark_transpose_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return LinalgMsg.transpose(cmd, msgArgs, st, array_dtype=uint, array_nd=1);
-registerFunction('transpose<uint64,1>', ark_transpose_uint_1, 'LinalgMsg', 289);
-
-proc ark_transpose_uint8_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return LinalgMsg.transpose(cmd, msgArgs, st, array_dtype=uint(8), array_nd=1);
-registerFunction('transpose<uint8,1>', ark_transpose_uint8_1, 'LinalgMsg', 289);
-
-proc ark_transpose_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return LinalgMsg.transpose(cmd, msgArgs, st, array_dtype=real, array_nd=1);
-registerFunction('transpose<float64,1>', ark_transpose_real_1, 'LinalgMsg', 289);
-
-proc ark_transpose_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return LinalgMsg.transpose(cmd, msgArgs, st, array_dtype=bool, array_nd=1);
-registerFunction('transpose<bool,1>', ark_transpose_bool_1, 'LinalgMsg', 289);
-
-proc ark_transpose_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return LinalgMsg.transpose(cmd, msgArgs, st, array_dtype=bigint, array_nd=1);
-registerFunction('transpose<bigint,1>', ark_transpose_bigint_1, 'LinalgMsg', 289);
-
 proc ark_vecdot_int_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=int, array_dtype_x2=int, array_nd=1);
-registerFunction('vecdot<int64,int64,1>', ark_vecdot_int_int_1, 'LinalgMsg', 337);
+registerFunction('vecdot<int64,int64,1>', ark_vecdot_int_int_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_int_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=int, array_dtype_x2=uint, array_nd=1);
-registerFunction('vecdot<int64,uint64,1>', ark_vecdot_int_uint_1, 'LinalgMsg', 337);
+registerFunction('vecdot<int64,uint64,1>', ark_vecdot_int_uint_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_int_uint8_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=int, array_dtype_x2=uint(8), array_nd=1);
-registerFunction('vecdot<int64,uint8,1>', ark_vecdot_int_uint8_1, 'LinalgMsg', 337);
+registerFunction('vecdot<int64,uint8,1>', ark_vecdot_int_uint8_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_int_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=int, array_dtype_x2=real, array_nd=1);
-registerFunction('vecdot<int64,float64,1>', ark_vecdot_int_real_1, 'LinalgMsg', 337);
+registerFunction('vecdot<int64,float64,1>', ark_vecdot_int_real_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_int_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=int, array_dtype_x2=bool, array_nd=1);
-registerFunction('vecdot<int64,bool,1>', ark_vecdot_int_bool_1, 'LinalgMsg', 337);
+registerFunction('vecdot<int64,bool,1>', ark_vecdot_int_bool_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_int_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=int, array_dtype_x2=bigint, array_nd=1);
-registerFunction('vecdot<int64,bigint,1>', ark_vecdot_int_bigint_1, 'LinalgMsg', 337);
+registerFunction('vecdot<int64,bigint,1>', ark_vecdot_int_bigint_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_uint_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=uint, array_dtype_x2=int, array_nd=1);
-registerFunction('vecdot<uint64,int64,1>', ark_vecdot_uint_int_1, 'LinalgMsg', 337);
+registerFunction('vecdot<uint64,int64,1>', ark_vecdot_uint_int_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_uint_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=uint, array_dtype_x2=uint, array_nd=1);
-registerFunction('vecdot<uint64,uint64,1>', ark_vecdot_uint_uint_1, 'LinalgMsg', 337);
+registerFunction('vecdot<uint64,uint64,1>', ark_vecdot_uint_uint_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_uint_uint8_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=uint, array_dtype_x2=uint(8), array_nd=1);
-registerFunction('vecdot<uint64,uint8,1>', ark_vecdot_uint_uint8_1, 'LinalgMsg', 337);
+registerFunction('vecdot<uint64,uint8,1>', ark_vecdot_uint_uint8_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_uint_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=uint, array_dtype_x2=real, array_nd=1);
-registerFunction('vecdot<uint64,float64,1>', ark_vecdot_uint_real_1, 'LinalgMsg', 337);
+registerFunction('vecdot<uint64,float64,1>', ark_vecdot_uint_real_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_uint_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=uint, array_dtype_x2=bool, array_nd=1);
-registerFunction('vecdot<uint64,bool,1>', ark_vecdot_uint_bool_1, 'LinalgMsg', 337);
+registerFunction('vecdot<uint64,bool,1>', ark_vecdot_uint_bool_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_uint_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=uint, array_dtype_x2=bigint, array_nd=1);
-registerFunction('vecdot<uint64,bigint,1>', ark_vecdot_uint_bigint_1, 'LinalgMsg', 337);
+registerFunction('vecdot<uint64,bigint,1>', ark_vecdot_uint_bigint_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_uint8_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=uint(8), array_dtype_x2=int, array_nd=1);
-registerFunction('vecdot<uint8,int64,1>', ark_vecdot_uint8_int_1, 'LinalgMsg', 337);
+registerFunction('vecdot<uint8,int64,1>', ark_vecdot_uint8_int_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_uint8_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=uint(8), array_dtype_x2=uint, array_nd=1);
-registerFunction('vecdot<uint8,uint64,1>', ark_vecdot_uint8_uint_1, 'LinalgMsg', 337);
+registerFunction('vecdot<uint8,uint64,1>', ark_vecdot_uint8_uint_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_uint8_uint8_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=uint(8), array_dtype_x2=uint(8), array_nd=1);
-registerFunction('vecdot<uint8,uint8,1>', ark_vecdot_uint8_uint8_1, 'LinalgMsg', 337);
+registerFunction('vecdot<uint8,uint8,1>', ark_vecdot_uint8_uint8_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_uint8_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=uint(8), array_dtype_x2=real, array_nd=1);
-registerFunction('vecdot<uint8,float64,1>', ark_vecdot_uint8_real_1, 'LinalgMsg', 337);
+registerFunction('vecdot<uint8,float64,1>', ark_vecdot_uint8_real_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_uint8_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=uint(8), array_dtype_x2=bool, array_nd=1);
-registerFunction('vecdot<uint8,bool,1>', ark_vecdot_uint8_bool_1, 'LinalgMsg', 337);
+registerFunction('vecdot<uint8,bool,1>', ark_vecdot_uint8_bool_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_uint8_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=uint(8), array_dtype_x2=bigint, array_nd=1);
-registerFunction('vecdot<uint8,bigint,1>', ark_vecdot_uint8_bigint_1, 'LinalgMsg', 337);
+registerFunction('vecdot<uint8,bigint,1>', ark_vecdot_uint8_bigint_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_real_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=real, array_dtype_x2=int, array_nd=1);
-registerFunction('vecdot<float64,int64,1>', ark_vecdot_real_int_1, 'LinalgMsg', 337);
+registerFunction('vecdot<float64,int64,1>', ark_vecdot_real_int_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_real_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=real, array_dtype_x2=uint, array_nd=1);
-registerFunction('vecdot<float64,uint64,1>', ark_vecdot_real_uint_1, 'LinalgMsg', 337);
+registerFunction('vecdot<float64,uint64,1>', ark_vecdot_real_uint_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_real_uint8_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=real, array_dtype_x2=uint(8), array_nd=1);
-registerFunction('vecdot<float64,uint8,1>', ark_vecdot_real_uint8_1, 'LinalgMsg', 337);
+registerFunction('vecdot<float64,uint8,1>', ark_vecdot_real_uint8_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_real_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=real, array_dtype_x2=real, array_nd=1);
-registerFunction('vecdot<float64,float64,1>', ark_vecdot_real_real_1, 'LinalgMsg', 337);
+registerFunction('vecdot<float64,float64,1>', ark_vecdot_real_real_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_real_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=real, array_dtype_x2=bool, array_nd=1);
-registerFunction('vecdot<float64,bool,1>', ark_vecdot_real_bool_1, 'LinalgMsg', 337);
+registerFunction('vecdot<float64,bool,1>', ark_vecdot_real_bool_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_real_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=real, array_dtype_x2=bigint, array_nd=1);
-registerFunction('vecdot<float64,bigint,1>', ark_vecdot_real_bigint_1, 'LinalgMsg', 337);
+registerFunction('vecdot<float64,bigint,1>', ark_vecdot_real_bigint_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_bool_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=bool, array_dtype_x2=int, array_nd=1);
-registerFunction('vecdot<bool,int64,1>', ark_vecdot_bool_int_1, 'LinalgMsg', 337);
+registerFunction('vecdot<bool,int64,1>', ark_vecdot_bool_int_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_bool_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=bool, array_dtype_x2=uint, array_nd=1);
-registerFunction('vecdot<bool,uint64,1>', ark_vecdot_bool_uint_1, 'LinalgMsg', 337);
+registerFunction('vecdot<bool,uint64,1>', ark_vecdot_bool_uint_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_bool_uint8_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=bool, array_dtype_x2=uint(8), array_nd=1);
-registerFunction('vecdot<bool,uint8,1>', ark_vecdot_bool_uint8_1, 'LinalgMsg', 337);
+registerFunction('vecdot<bool,uint8,1>', ark_vecdot_bool_uint8_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_bool_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=bool, array_dtype_x2=real, array_nd=1);
-registerFunction('vecdot<bool,float64,1>', ark_vecdot_bool_real_1, 'LinalgMsg', 337);
+registerFunction('vecdot<bool,float64,1>', ark_vecdot_bool_real_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_bool_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=bool, array_dtype_x2=bool, array_nd=1);
-registerFunction('vecdot<bool,bool,1>', ark_vecdot_bool_bool_1, 'LinalgMsg', 337);
+registerFunction('vecdot<bool,bool,1>', ark_vecdot_bool_bool_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_bool_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=bool, array_dtype_x2=bigint, array_nd=1);
-registerFunction('vecdot<bool,bigint,1>', ark_vecdot_bool_bigint_1, 'LinalgMsg', 337);
+registerFunction('vecdot<bool,bigint,1>', ark_vecdot_bool_bigint_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_bigint_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=bigint, array_dtype_x2=int, array_nd=1);
-registerFunction('vecdot<bigint,int64,1>', ark_vecdot_bigint_int_1, 'LinalgMsg', 337);
+registerFunction('vecdot<bigint,int64,1>', ark_vecdot_bigint_int_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_bigint_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=bigint, array_dtype_x2=uint, array_nd=1);
-registerFunction('vecdot<bigint,uint64,1>', ark_vecdot_bigint_uint_1, 'LinalgMsg', 337);
+registerFunction('vecdot<bigint,uint64,1>', ark_vecdot_bigint_uint_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_bigint_uint8_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=bigint, array_dtype_x2=uint(8), array_nd=1);
-registerFunction('vecdot<bigint,uint8,1>', ark_vecdot_bigint_uint8_1, 'LinalgMsg', 337);
+registerFunction('vecdot<bigint,uint8,1>', ark_vecdot_bigint_uint8_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_bigint_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=bigint, array_dtype_x2=real, array_nd=1);
-registerFunction('vecdot<bigint,float64,1>', ark_vecdot_bigint_real_1, 'LinalgMsg', 337);
+registerFunction('vecdot<bigint,float64,1>', ark_vecdot_bigint_real_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_bigint_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=bigint, array_dtype_x2=bool, array_nd=1);
-registerFunction('vecdot<bigint,bool,1>', ark_vecdot_bigint_bool_1, 'LinalgMsg', 337);
+registerFunction('vecdot<bigint,bool,1>', ark_vecdot_bigint_bool_1, 'LinalgMsg', 318);
 
 proc ark_vecdot_bigint_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return LinalgMsg.vecdot(cmd, msgArgs, st, array_dtype_x1=bigint, array_dtype_x2=bigint, array_nd=1);
-registerFunction('vecdot<bigint,bigint,1>', ark_vecdot_bigint_bigint_1, 'LinalgMsg', 337);
+registerFunction('vecdot<bigint,bigint,1>', ark_vecdot_bigint_bigint_1, 'LinalgMsg', 318);
 
 import ManipulationMsg;
 


### PR DESCRIPTION
Updates `Commands.chpl` (ran `make register-commands` on master) to reflect changes made in https://github.com/Bears-R-Us/arkouda/pull/3693. This fixes a build failure when `chapel-py` is not available and build scripts need to fall back to the tracked `Commands.chpl` file.