### PR TITLE
Closes #3771:  register_commands.py to handle generic scalar type

### DIFF
--- a/registration-config.json
+++ b/registration-config.json
@@ -10,6 +10,16 @@
                 "bool",
                 "bigint"
             ]
+        },
+        "scalar": {
+            "dtype": [
+                "int",
+                "uint",
+                "uint(8)",
+                "real",
+                "bool",
+                "bigint"
+            ]
         }
     }
 }

--- a/src/registry/Commands.chpl
+++ b/src/registry/Commands.chpl
@@ -19,6 +19,16 @@ param regConfig = """
         "bool",
         "bigint"
       ]
+    },
+    "scalar": {
+      "dtype": [
+        "int",
+        "uint",
+        "uint(8)",
+        "real",
+        "bool",
+        "bigint"
+      ]
     }
   }
 }


### PR DESCRIPTION
Closes #3771:  register_commands.py to handle generic scalar type

This PR modifies register_commands.py to handle arguments that have a generic scalar type.  The following example demonstrates the new functionality.

When the following is compiled within arkouda:
```
    //  TEST Function
    @arkouda.registerCommand
    proc testFunc(x: ?t, x2: ?t2, array: [?D] ?t3): [D] t3 throws
    where (t == int) && (t2 == int) && (t3 == int){
        const ret = array + x + x2;
        return ret;
    }

    proc testFunc(x: ?t, x2: ?t2, array: [?D] ?t3): [D] t3 throws
    where (t != int) || (t2 != int) || (t3 != int) {
      throw new Error("Case not supported.");
    }
```

The following will work in arkouda:
```
from arkouda import *
from typing import cast

pda = ak.arange(10).reshape((2,5))
 
repMsg = generic_msg(
    cmd=f"testFunc<int64,int64,int64,2>",
    args={
        "array": pda.name,
         "x": 1,
         "x2": 7,
    },
)

create_pdarray(cast(str, repMsg))

```
```
In [2]: from arkouda import *
   ...: from typing import cast
   ...: 
   ...: pda = ak.arange(10).reshape((2,5))
   ...: 
   ...: repMsg = generic_msg(
   ...:     cmd=f"testFunc<int64,int64,int64,2>",
   ...:     args={
   ...:         "array": pda.name,
   ...:          "x": 1,
   ...:          "x2": 7,
   ...:     },
   ...: )
   ...: 
   ...: create_pdarray(cast(str, repMsg))
   ...: 
Out[2]: array([array([8 9 10 11 12]) array([13 14 15 16 17])])
```