### PR TITLE
Refactor `OperatorMsg`

### DIFF
--- a/.configs/registration-config-multi-dim.json
+++ b/.configs/registration-config-multi-dim.json
@@ -10,6 +10,15 @@
                 "bool",
                 "bigint"
             ]
+        },
+        "binop": {
+            "dtype": [
+                "int",
+                "uint",
+                "real",
+                "bool",
+                "bigint"
+            ]
         }
     }
 }

--- a/.configs/registration-config-single-dim.json
+++ b/.configs/registration-config-single-dim.json
@@ -10,6 +10,15 @@
                 "bool",
                 "bigint"
             ]
+        },
+        "binop": {
+            "dtype": [
+                "int",
+                "uint",
+                "real",
+                "bool",
+                "bigint"
+            ]
         }
     }
 }

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -540,8 +540,8 @@ class pdarray:
         if dt not in DTypes:
             raise TypeError(f"Unhandled scalar type: {other} ({type(other)})")
         repMsg = generic_msg(
-            cmd=f"binopvs{self.ndim}D",
-            args={"op": op, "a": self, "dtype": dt, "value": other},
+            cmd=f"binopvsMsg<{self.dtype},{dt},{self.ndim}>",
+            args={"op": op, "a": self, "value": other},
         )
         return create_pdarray(repMsg)
 

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -585,8 +585,8 @@ class pdarray:
         if dt not in DTypes:
             raise TypeError(f"Unhandled scalar type: {other} ({type(other)})")
         repMsg = generic_msg(
-            cmd=f"binopsv{self.ndim}D",
-            args={"op": op, "dtype": dt, "value": other, "a": self},
+            cmd=f"binopsv<{self.dtype},{dt},{self.ndim}>",
+            args={"op": op, "dtype": dt, "a": self, "value": other},
         )
         return create_pdarray(repMsg)
 
@@ -777,7 +777,10 @@ class pdarray:
         if isinstance(other, pdarray):
             if self.shape != other.shape:
                 raise ValueError(f"shape mismatch {self.shape} {other.shape}")
-            generic_msg(cmd=f"opeqvv{self.ndim}D", args={"op": op, "a": self, "b": other})
+            generic_msg(
+                cmd=f"opeqvv<{self.dtype},{other.dtype},{self.ndim}>",
+                args={"op": op, "a": self, "b": other}
+            )
             return self
         # pdarray binop scalar
         # opeq requires scalar to be cast as pdarray dtype
@@ -791,8 +794,9 @@ class pdarray:
             raise TypeError(f"Unhandled scalar type: {other} ({type(other)})")
 
         generic_msg(
-            cmd=f"opeqvs{self.ndim}D",
-            args={"op": op, "a": self, "dtype": self.dtype.name, "value": self.format_other(other)},
+            # TODO: does opeqvs really need to select over pairs of dtypes?
+            cmd=f"opeqvs<{self.dtype},{self.dtype},{self.ndim}>",
+            args={"op": op, "a": self, "value": self.format_other(other)},
         )
         return self
 

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -540,7 +540,7 @@ class pdarray:
         if dt not in DTypes:
             raise TypeError(f"Unhandled scalar type: {other} ({type(other)})")
         repMsg = generic_msg(
-            cmd=f"binopvsMsg<{self.dtype},{dt},{self.ndim}>",
+            cmd=f"binopvs<{self.dtype},{dt},{self.ndim}>",
             args={"op": op, "a": self, "value": other},
         )
         return create_pdarray(repMsg)

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -520,7 +520,10 @@ class pdarray:
                 x1, x2, tmp_x1, tmp_x2 = broadcast_if_needed(self, other)
             except ValueError:
                 raise ValueError(f"shape mismatch {self.shape} {other.shape}")
-            repMsg = generic_msg(cmd=f"binopvv{x1.ndim}D", args={"op": op, "a": x1, "b": x2})
+            repMsg = generic_msg(
+                cmd=f"binopvv<{self.dtype},{other.dtype},{x1.ndim}>",
+                args={"op": op, "a": x1, "b": x2}
+            )
             if tmp_x1:
                 del x1
             if tmp_x2:

--- a/registration-config.json
+++ b/registration-config.json
@@ -10,6 +10,15 @@
                 "bool",
                 "bigint"
             ]
+        },
+        "binop": {
+            "dtype": [
+                "int",
+                "uint",
+                "real",
+                "bool",
+                "bigint"
+            ]
         }
     }
 }

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -190,7 +190,7 @@ module BinOp
             ref ra = r.a;
             [(ei,li,ri) in zip(ea,la,ra)] ei = if ri != 0 then li/ri else 0;
           }
-          when "%" { // " modulo
+          when "%" { // modulo " <- quote is workaround for syntax highlighter bug
             ref ea = e;
             ref la = l.a;
             ref ra = r.a;
@@ -320,7 +320,7 @@ module BinOp
           when "**" { 
             e= l.a**r.a;
           }
-          when "%" { // "
+          when "%" { // modulo " <- quote is workaround for syntax highlighter bug
             ref ea = e;
             ref la = l.a;
             ref ra = r.a;
@@ -352,7 +352,7 @@ module BinOp
           when "**" { 
             e= l.a:real**r.a:real;
           }
-          when "%" { // "
+          when "%" { // modulo " <- quote is workaround for syntax highlighter bug
             ref ea = e;
             ref la = l.a;
             ref ra = r.a;
@@ -552,7 +552,7 @@ module BinOp
             ref la = l.a;
             [(ei,li) in zip(ea,la)] ei = if val != 0 then li/val else 0;
           }
-          when "%" { // modulo "
+          when "%" { // modulo " <- quote is workaround for syntax highlighter bug
             ref ea = e;
             ref la = l.a;
             [(ei,li) in zip(ea,la)] ei = if val != 0 then li%val else 0;
@@ -673,7 +673,7 @@ module BinOp
           when "**" { 
             e= l.a**val;
           }
-          when "%" { // "
+          when "%" { // modulo " <- quote is workaround for syntax highlighter bug
             ref ea = e;
             ref la = l.a;
             [(ei,li) in zip(ea,la)] ei = modHelper(li, val);
@@ -724,7 +724,7 @@ module BinOp
           when "**" { 
             e= l.a: real**val: real;
           }
-          when "%" { // "
+          when "%" { // modulo " <- quote is workaround for syntax highlighter bug
             ref ea = e;
             ref la = l.a;
             [(ei,li) in zip(ea,la)] ei = modHelper(li, val);
@@ -897,7 +897,7 @@ module BinOp
             ref ra = r.a;
             [(ei,ri) in zip(ea,ra)] ei = if ri != 0 then val/ri else 0;
           }
-          when "%" { // modulo "
+          when "%" { // modulo " <- quote is workaround for syntax highlighter bug
             ref ea = e;
             ref ra = r.a;
             [(ei,ri) in zip(ea,ra)] ei = if ri != 0 then val%ri else 0;
@@ -1003,7 +1003,7 @@ module BinOp
           when "**" { 
             e= val**r.a;
           }
-          when "%" { // "
+          when "%" { // modulo " <- quote is workaround for syntax highlighter bug
             ref ea = e;
             ref ra = r.a;
             [(ei,ri) in zip(ea,ra)] ei = modHelper(val:real, ri);
@@ -1054,7 +1054,7 @@ module BinOp
           when "**" { 
             e= val:real**r.a:real;
           }
-          when "%" { // "
+          when "%" { // modulo " <- quote is workaround for syntax highlighter bug
             ref ea = e;
             ref ra = r.a;
             [(ei,ri) in zip(ea,ra)] ei = modHelper(val:real, ri);
@@ -1271,7 +1271,7 @@ module BinOp
           }
           visted = true;
         }
-        when "%" { // modulo
+        when "%" { // modulo " <- quote is workaround for syntax highlighter bug
           // we only do in place mod when ri != 0, tmp will be 0 in other locations
           // we can't use ei = li % ri because this can result in negatives
           forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
@@ -1515,7 +1515,7 @@ module BinOp
           }
           visted = true;
         }
-        when "%" { // modulo
+        when "%" { // modulo " <- quote is workaround for syntax highlighter bug
           // we only do in place mod when val != 0, tmp will be 0 in other locations
           // we can't use ei = li % val because this can result in negatives
           forall t in tmp with (var local_val = val, var local_max_size = max_size) {
@@ -1779,7 +1779,7 @@ module BinOp
           }
           visted = true;
         }
-        when "%" { // modulo
+        when "%" { // modulo " <- quote is workaround for syntax highlighter bug
           forall (t, ri) in zip(tmp, ra) with (var local_max_size = max_size) {
             if ri != 0 {
               mod(t, t, ri);

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -269,7 +269,6 @@ module BinOp
     } else if (l.etype == uint && r.etype == int) ||
               (l.etype == int && r.etype == uint) {
 
-      writeln("correct dispatch... ", op, "  ", l.etype: string, " ", r.etype: string, " ", etype: string);
       select op {
         when "+" {
           e = l.a:real + r.a:real;

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -62,9 +62,6 @@ module BinOp
   :arg op: string representation of binary operation to execute
   :type op: string
 
-  :arg rname: name of the `e` in the symbol table
-  :type rname: string
-
   :arg pn: routine name of callsite function
   :type pn: string
 

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -286,7 +286,6 @@ module BinOp
           [(ei,li,ri) in zip(ea,la,ra)] ei = floorDivisionHelper(li, ri);
         }
         otherwise {
-          writeln("wtf... ", op, "  ", l.etype: string, " ", r.etype: string, " ", etype: string);
           return MsgTuple.error(nie);
         }
       }

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -289,7 +289,6 @@ module BinOp
           return MsgTuple.error(nie);
         }
       }
-      writeln("returning... ", op, "  ", l.etype: string, " ", r.etype: string, " ", etype: string);
       return st.insert(new shared SymEntry(e));
     }
     // If either RHS or LHS type is real, the same operations are supported and the

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -411,22 +411,21 @@ module OperatorMsg
       :returns: (MsgTuple) 
       :throws: `UndefinedSymbolError(name)`
     */
-    @arkouda.registerND
-    proc binopsvMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, param nd: int): MsgTuple throws {
+    @arkouda.instantiateAndRegister
+    proc binopsv(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab,
+      type binop_dtype_a,
+      type binop_dtype_b,
+      param array_nd: int
+    ): MsgTuple throws {
         param pn = Reflection.getRoutineName();
-        var repMsg: string = ""; // response message
 
-        const op = msgArgs.getValueOf("op");
-        const aname = msgArgs.getValueOf("a");
-        const value = msgArgs.get("value");
+        const r = st[msgArgs['a']]: borrowed SymEntry(binop_dtype_a, array_nd),
+              val = msgArgs['value'].toScalar(binop_dtype_b),
+              op = msgArgs['op'].toScalar(string);
 
-        var dtype = str2dtype(msgArgs.getValueOf("dtype"));
-        var rname = st.nextName();
-        var right: borrowed GenSymEntry = getGenericTypedArrayEntry(aname, st);
-        
         omLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                 "command = %? op = %? scalar dtype = %? scalar = %? pdarray = %?".format(
-                                   cmd,op,dtype2str(dtype),value,st.attrib(aname)));
+                 "cmd: %? op = %? scalar dtype = %? scalar = %? pdarray = %?".format(
+                                   cmd,op,type2str(binop_dtype_b),msgArgs['value'].val,st.attrib(msgArgs['a'].val)));
 
         use Set;
         // This boolOps set is a filter to determine the output type for the operation.
@@ -439,314 +438,148 @@ module OperatorMsg
         boolOps.add(">=");
         boolOps.add("==");
         boolOps.add("!=");
-        
+
         var realOps: set(string);
         realOps.add("+");
         realOps.add("-");
         realOps.add("/");
         realOps.add("//");
 
-        select (dtype, right.dtype) {
-          when (DType.Int64, DType.Int64) {
-            var val = value.getIntValue();
-            var r = toSymEntry(right,int, nd);
-            
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, r.tupShape, bool);
-              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
-            } else if op == "/" {
-              // True division is the only case in this int, int case
-              // that results in a `real` symbol table entry.
-              var e = st.addEntry(rname, r.tupShape, real);
-              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
-            }
-            var e = st.addEntry(rname, r.tupShape, int);
-            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+        if binop_dtype_a == int && binop_dtype_b == int {
+          if boolOps.contains(op) {
+            return doBinOpsv(val, r, bool, op, pn, st);
+          } else if op == "/" {
+            // True division is the only case in this int, int case
+            // that results in a `real` symbol table entry.
+            return doBinOpsv(val, r, real, op, pn, st);
           }
-          when (DType.Int64, DType.Float64) {
-            var val = value.getIntValue();
-            var r = toSymEntry(right,real, nd);
-            // Only two possible resultant types are `bool` and `real`
-            // for this case
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, r.tupShape, bool);
-              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
-            }
-            var e = st.addEntry(rname, r.tupShape, real);
-            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          return doBinOpsv(val, r, int, op, pn, st);
+        }
+        else if binop_dtype_a == int && binop_dtype_b == real {
+          // Only two possible resultant types are `bool` and `real`
+          // for this case
+          if boolOps.contains(op) {
+            return doBinOpsv(val, r, bool, op, pn, st);
           }
-          when (DType.Float64, DType.Int64) {
-            var val = value.getRealValue();
-            var r = toSymEntry(right,int, nd);
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, r.tupShape, bool);
-              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
-            }
-            var e = st.addEntry(rname, r.tupShape, real);
-            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          return doBinOpsv(val, r, real, op, pn, st);
+        }
+        else if binop_dtype_a == real && binop_dtype_b == int {
+          if boolOps.contains(op) {
+            return doBinOpsv(val, r, bool, op, pn, st);
           }
-          when (DType.UInt64, DType.Float64) {
-            var val = value.getUIntValue();
-            var r = toSymEntry(right,real, nd);
-            // Only two possible resultant types are `bool` and `real`
-            // for this case
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, r.tupShape, bool);
-              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
-            }
-            var e = st.addEntry(rname, r.tupShape, real);
-            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          return doBinOpsv(val, r, real, op, pn, st);
+        }
+        else if binop_dtype_a == uint && binop_dtype_b == real {
+          // Only two possible resultant types are `bool` and `real`
+          // for this case
+          if boolOps.contains(op) {
+            return doBinOpsv(val, r, bool, op, pn, st);
           }
-          when (DType.Float64, DType.UInt64) {
-            var val = value.getRealValue();
-            var r = toSymEntry(right,uint, nd);
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, r.tupShape, bool);
-              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
-            }
-            var e = st.addEntry(rname, r.tupShape, real);
-            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          return doBinOpsv(val, r, real, op, pn, st);
+        }
+        else if binop_dtype_a == real && binop_dtype_b == uint {
+          if boolOps.contains(op) {
+            return doBinOpsv(val, r, bool, op, pn, st);
           }
-          when (DType.Float64, DType.Float64) {
-            var val = value.getRealValue();
-            var r = toSymEntry(right,real, nd);
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, r.tupShape, bool);
-              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
-            }
-            var e = st.addEntry(rname, r.tupShape, real);
-            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          return doBinOpsv(val, r, real, op, pn, st);
+        }
+        else if binop_dtype_a == real && binop_dtype_b == real {
+          if boolOps.contains(op) {
+            return doBinOpsv(val, r, bool, op, pn, st);
           }
-          // For cases where a boolean operand is involved, the only
-          // possible resultant type is `bool`
-          when (DType.Bool, DType.Bool) {
-            var val = value.getBoolValue();
-            var r = toSymEntry(right,bool, nd);
-            if (op == "<<") || (op == ">>") {
-              var e = st.addEntry(rname, r.tupShape, int);
-              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
-            }
-            var e = st.addEntry(rname, r.tupShape, bool);
-            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          return doBinOpsv(val, r, real, op, pn, st);
+        }
+        // For cases where a boolean operand is involved, the only
+        // possible resultant type is `bool`
+        else if binop_dtype_a == bool && binop_dtype_b == bool {
+          if (op == "<<") || (op == ">>") {
+            return doBinOpsv(val, r, int, op, pn, st);
           }
-          when (DType.Bool, DType.Int64) {
-            var val = value.getBoolValue();
-            var r = toSymEntry(right,int, nd);
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, r.tupShape, bool);
-              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
-            }
-            var e = st.addEntry(rname, r.tupShape, int);
-            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          return doBinOpsv(val, r, bool, op, pn, st);
+        }
+        else if binop_dtype_a == bool && binop_dtype_b == int {
+          if boolOps.contains(op) {
+            return doBinOpsv(val, r, bool, op, pn, st);
           }
-          when (DType.Int64, DType.Bool) {
-            var val = value.getIntValue();
-            var r = toSymEntry(right,bool, nd);
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, r.tupShape, bool);
-              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
-            }
-            var e = st.addEntry(rname, r.tupShape, int);
-            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          return doBinOpsv(val, r, int, op, pn, st);
+        }
+        else if binop_dtype_a == int && binop_dtype_b == bool {
+          if boolOps.contains(op) {
+            return doBinOpsv(val, r, bool, op, pn, st);
           }
-          when (DType.Bool, DType.Float64) {
-            var val = value.getBoolValue();
-            var r = toSymEntry(right,real, nd);
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, r.tupShape, bool);
-              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
-            }
-            var e = st.addEntry(rname, r.tupShape, real);
-            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          return doBinOpsv(val, r, int, op, pn, st);
+        }
+        else if binop_dtype_a == bool && binop_dtype_b == real {
+          if boolOps.contains(op) {
+            return doBinOpsv(val, r, bool, op, pn, st);
           }
-          when (DType.Float64, DType.Bool) {
-            var val = value.getRealValue();
-            var r = toSymEntry(right,bool, nd);
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, r.tupShape, bool);
-              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
-            }
-            var e = st.addEntry(rname, r.tupShape, real);
-            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          return doBinOpsv(val, r, real, op, pn, st);
+        }
+        else if binop_dtype_a == real && binop_dtype_b == bool {
+          if boolOps.contains(op) {
+            return doBinOpsv(val, r, bool, op, pn, st);
           }
-          when (DType.Bool, DType.UInt64) {
-            var val = value.getBoolValue();
-            var r = toSymEntry(right,uint, nd);
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, r.tupShape, bool);
-              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
-            }
-            var e = st.addEntry(rname, r.tupShape, uint);
-            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          return doBinOpsv(val, r, real, op, pn, st);
+        }
+        else if binop_dtype_a == bool && binop_dtype_b == uint {
+          if boolOps.contains(op) {
+            return doBinOpsv(val, r, bool, op, pn, st);
           }
-          when (DType.UInt64, DType.Bool) {
-            var val = value.getUIntValue();
-            var r = toSymEntry(right,bool, nd);
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, r.tupShape, bool);
-              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
-            }
-            var e = st.addEntry(rname, r.tupShape, uint);
-            return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
+          return doBinOpsv(val, r, uint, op, pn, st);
+        }
+        else if binop_dtype_a == uint && binop_dtype_b == bool {
+          if boolOps.contains(op) {
+            return doBinOpsv(val, r, bool, op, pn, st);
           }
-          when (DType.UInt64, DType.UInt64) {
-            var val = value.getUIntValue();
-            var r = toSymEntry(right,uint, nd);
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, r.tupShape, bool);
-              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
-            }
-            if op == "/"{
-              var e = st.addEntry(rname, r.tupShape, real);
-              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
-            } else {
-              var e = st.addEntry(rname, r.tupShape, uint);
-              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
-            }
+          return doBinOpsv(val, r, uint, op, pn, st);
+        }
+        else if binop_dtype_a == uint && binop_dtype_b == uint {
+          if boolOps.contains(op) {
+            return doBinOpsv(val, r, bool, op, pn, st);
           }
-          when (DType.UInt64, DType.Int64) {
-            var val = value.getUIntValue();
-            var r = toSymEntry(right,int, nd);
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, r.tupShape, bool);
-              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
-            }
-            // +, -, /, // both result in real outputs to match NumPy
-            if realOps.contains(op) {
-              var e = st.addEntry(rname, r.tupShape, real);
-              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
-            } else {
-              // isn't +, -, /, // so we can use LHS to determine type
-              var e = st.addEntry(rname, r.tupShape, uint);
-              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
-            }
-          }
-          when (DType.Int64, DType.UInt64) {
-            var val = value.getIntValue();
-            var r = toSymEntry(right,uint, nd);
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, r.tupShape, bool);
-              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
-            }
-            // +, -, /, // both result in real outputs to match NumPy
-            if realOps.contains(op) {
-              var e = st.addEntry(rname, r.tupShape, real);
-              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
-            } else {
-              // isn't +, -, /, // so we can use LHS to determine type
-              var e = st.addEntry(rname, r.tupShape, int);
-              return doBinOpsv(val, r, e, op, dtype, rname, pn, st);
-            }
-          }
-          when (DType.BigInt, DType.BigInt) {
-            var val = value.getBigIntValue();
-            var r = toSymEntry(right,bigint, nd);
-            if boolOps.contains(op) {
-              // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
-              var repMsg = "created %s".format(st.attrib(rname));
-              return new MsgTuple(repMsg, MsgType.NORMAL);
-            }
-            // call bigint specific func which returns dist bigint array
-            var (tmp, max_bits) = doBigIntBinOpsv(val, r, op);
-            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
-            var repMsg = "created %s".format(st.attrib(rname));
-            return new MsgTuple(repMsg, MsgType.NORMAL);
-          }
-          when (DType.BigInt, DType.Int64) {
-            var val = value.getBigIntValue();
-            var r = toSymEntry(right,int, nd);
-            if boolOps.contains(op) {
-              // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
-              var repMsg = "created %s".format(st.attrib(rname));
-              return new MsgTuple(repMsg, MsgType.NORMAL);
-            }
-            // call bigint specific func which returns dist bigint array
-            var (tmp, max_bits) = doBigIntBinOpsv(val, r, op);
-            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
-            var repMsg = "created %s".format(st.attrib(rname));
-            return new MsgTuple(repMsg, MsgType.NORMAL);
-          }
-          when (DType.BigInt, DType.UInt64) {
-            var val = value.getBigIntValue();
-            var r = toSymEntry(right,uint, nd);
-            if boolOps.contains(op) {
-              // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
-              var repMsg = "created %s".format(st.attrib(rname));
-              return new MsgTuple(repMsg, MsgType.NORMAL);
-            }
-            // call bigint specific func which returns dist bigint array
-            var (tmp, max_bits) = doBigIntBinOpsv(val, r, op);
-            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
-            var repMsg = "created %s".format(st.attrib(rname));
-            return new MsgTuple(repMsg, MsgType.NORMAL);
-          }
-          when (DType.BigInt, DType.Bool) {
-            var val = value.getBigIntValue();
-            var r = toSymEntry(right,bool, nd);
-            if boolOps.contains(op) {
-              // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
-              var repMsg = "created %s".format(st.attrib(rname));
-              return new MsgTuple(repMsg, MsgType.NORMAL);
-            }
-            // call bigint specific func which returns dist bigint array
-            var (tmp, max_bits) = doBigIntBinOpsv(val, r, op);
-            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
-            var repMsg = "created %s".format(st.attrib(rname));
-            return new MsgTuple(repMsg, MsgType.NORMAL);
-          }
-          when (DType.Int64, DType.BigInt) {
-            var val = value.getIntValue();
-            var r = toSymEntry(right,bigint, nd);
-            if boolOps.contains(op) {
-              // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
-              var repMsg = "created %s".format(st.attrib(rname));
-              return new MsgTuple(repMsg, MsgType.NORMAL);
-            }
-            // call bigint specific func which returns dist bigint array
-            var (tmp, max_bits) = doBigIntBinOpsv(val, r, op);
-            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
-            var repMsg = "created %s".format(st.attrib(rname));
-            return new MsgTuple(repMsg, MsgType.NORMAL);
-          }
-          when (DType.UInt64, DType.BigInt) {
-            var val = value.getUIntValue();
-            var r = toSymEntry(right,bigint, nd);
-            if boolOps.contains(op) {
-              // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
-              var repMsg = "created %s".format(st.attrib(rname));
-              return new MsgTuple(repMsg, MsgType.NORMAL);
-            }
-            // call bigint specific func which returns dist bigint array
-            var (tmp, max_bits) = doBigIntBinOpsv(val, r, op);
-            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
-            var repMsg = "created %s".format(st.attrib(rname));
-            return new MsgTuple(repMsg, MsgType.NORMAL);
-          }
-          when (DType.Bool, DType.BigInt) {
-            var val = value.getBoolValue();
-            var r = toSymEntry(right,bigint, nd);
-            if boolOps.contains(op) {
-              // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
-              var repMsg = "created %s".format(st.attrib(rname));
-              return new MsgTuple(repMsg, MsgType.NORMAL);
-            }
-            // call bigint specific func which returns dist bigint array
-            var (tmp, max_bits) = doBigIntBinOpsv(val, r, op);
-            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
-            var repMsg = "created %s".format(st.attrib(rname));
-            return new MsgTuple(repMsg, MsgType.NORMAL);
+          if op == "/"{
+            return doBinOpsv(val, r, real, op, pn, st);
+          } else {
+            return doBinOpsv(val, r, uint, op, pn, st);
           }
         }
-        var errorMsg = unrecognizedTypeError(pn, "("+dtype2str(dtype)+","+dtype2str(right.dtype)+")");
-        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-        return new MsgTuple(errorMsg, MsgType.ERROR);
+        else if binop_dtype_a == uint && binop_dtype_b == int {
+          if boolOps.contains(op) {
+            return doBinOpsv(val, r, bool, op, pn, st);
+          }
+          // +, -, /, // both result in real outputs to match NumPy
+          if realOps.contains(op) {
+            return doBinOpsv(val, r, real, op, pn, st);
+          } else {
+            // isn't +, -, /, // so we can use LHS to determine type
+            return doBinOpsv(val, r, uint, op, pn, st);
+          }
+        }
+        else if binop_dtype_a == int && binop_dtype_b == uint {
+          if boolOps.contains(op) {
+            return doBinOpsv(val, r, bool, op, pn, st);
+          }
+          // +, -, /, // both result in real outputs to match NumPy
+          if realOps.contains(op) {
+            return doBinOpsv(val, r, real, op, pn, st);
+          } else {
+            // isn't +, -, /, // so we can use LHS to determine type
+            return doBinOpsv(val, r, int, op, pn, st);
+          }
+        }
+        else if (binop_dtype_a == bigint || binop_dtype_b == bigint) &&
+                !isRealType(binop_dtype_a) && !isRealType(binop_dtype_b) {
+          if boolOps.contains(op) {
+            return st.insert(new shared SymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
+          }
+          // call bigint specific func which returns dist bigint array
+          const (tmp, max_bits) = doBigIntBinOpsv(val, r, op);
+          return st.insert(new shared SymEntry(tmp, max_bits));
+        } else {
+          const errorMsg = unrecognizedTypeError(pn, "("+type2str(binop_dtype_a)+","+type2str(binop_dtype_b)+")");
+          omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+          return MsgTuple.error(errorMsg);
+        }
     }
 
     /*
@@ -762,587 +595,458 @@ module OperatorMsg
       :returns: (MsgTuple)
       :throws: `UndefinedSymbolError(name)`
     */
-    @arkouda.registerND
-    proc opeqvvMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, param nd: int): MsgTuple throws {
+    @arkouda.instantiateAndRegister
+    proc opeqvv(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab,
+      type binop_dtype_a,
+      type binop_dtype_b,
+      param array_nd: int
+    ): MsgTuple throws {
         param pn = Reflection.getRoutineName();
-        var repMsg: string; // response message
 
-        const op = msgArgs.getValueOf("op");
-        const aname = msgArgs.getValueOf("a");
-        const bname = msgArgs.getValueOf("b");
-
-        // retrieve left and right pdarray objects      
-        var left: borrowed GenSymEntry = getGenericTypedArrayEntry(aname, st);
-        var right: borrowed GenSymEntry = getGenericTypedArrayEntry(bname, st);
+        var l = st[msgArgs['a']]: borrowed SymEntry(binop_dtype_a, array_nd);
+        const r = st[msgArgs['b']]: borrowed SymEntry(binop_dtype_b, array_nd),
+              op = msgArgs['op'].toScalar(string),
+              nie = notImplementedError(pn,type2str(binop_dtype_a),op,type2str(binop_dtype_b));
 
         omLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                     "cmd: %s op: %s left pdarray: %s right pdarray: %s".format(cmd,op,
-                                                         st.attrib(aname),st.attrib(bname)));
+                    st.attrib(msgArgs['a'].val),st.attrib(msgArgs['b'].val)));
 
-        select (left.dtype, right.dtype) {
-            when (DType.Int64, DType.Int64) {
-                var l = toSymEntry(left,int, nd);
-                var r = toSymEntry(right,int, nd);
-                select op {
-                    when "+=" { l.a += r.a; }
-                    when "-=" { l.a -= r.a; }
-                    when "*=" { l.a *= r.a; }
-                    when ">>=" { l.a >>= r.a;}
-                    when "<<=" { l.a <<= r.a;}
-                    when "//=" {
-                        //l.a /= r.a;
-                        ref la = l.a;
-                        ref ra = r.a;
-                        [(li,ri) in zip(la,ra)] li = if ri != 0 then li/ri else 0;
-                    }//floordiv
-                    when "%=" {
-                        //l.a /= r.a;
-                        ref la = l.a;
-                        ref ra = r.a;
-                        [(li,ri) in zip(la,ra)] li = if ri != 0 then li%ri else 0;
-                    }
-                    when "**=" { 
-                        if || reduce (r.a<0){
-                            var errorMsg =  "Attempt to exponentiate base of type Int64 to negative exponent";
-                            return new MsgTuple(errorMsg, MsgType.ERROR);
-                        }
-                        else{ l.a **= r.a; }
-                    }
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+        if binop_dtype_a == int && binop_dtype_b == int  {
+            select op {
+                when "+=" { l.a += r.a; }
+                when "-=" { l.a -= r.a; }
+                when "*=" { l.a *= r.a; }
+                when ">>=" { l.a >>= r.a;}
+                when "<<=" { l.a <<= r.a;}
+                when "//=" {
+                    //l.a /= r.a;
+                    ref la = l.a;
+                    ref ra = r.a;
+                    [(li,ri) in zip(la,ra)] li = if ri != 0 then li/ri else 0;
+                }//floordiv
+                when "%=" {
+                    //l.a /= r.a;
+                    ref la = l.a;
+                    ref ra = r.a;
+                    [(li,ri) in zip(la,ra)] li = if ri != 0 then li%ri else 0;
+                }
+                when "**=" {
+                    if || reduce (r.a<0){
+                        var errorMsg =  "Attempt to exponentiate base of type Int64 to negative exponent";
                         return new MsgTuple(errorMsg, MsgType.ERROR);
                     }
+                    else{ l.a **= r.a; }
                 }
-            }
-            when (DType.Int64, DType.UInt64) {
-                // The result of operations between int and uint are float by default which doesn't fit in either type
-                var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
-                omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg, MsgType.ERROR);
-            }
-            when (DType.Int64, DType.Float64) {
-                var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
-                omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg, MsgType.ERROR);
-            }
-            when (DType.Int64, DType.Bool) {
-                var l = toSymEntry(left, int, nd);
-                var r = toSymEntry(right, bool, nd);
-                select op {
-                    when "+=" {l.a += r.a:int;}
-                    when "-=" {l.a -= r.a:int;}
-                    when "*=" {l.a *= r.a:int;}
-                    when ">>=" { l.a >>= r.a:int;}
-                    when "<<=" { l.a <<= r.a:int;}
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);
-                    }
-                }
-            }
-            when (DType.Int64, DType.BigInt) {
-                var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
-                omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg, MsgType.ERROR);
-            }
-            when (DType.UInt64, DType.Int64) {
-                // The result of operations between int and uint are float by default which doesn't fit in either type
-                var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
-                omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg, MsgType.ERROR);
-            }
-            when (DType.UInt64, DType.UInt64) {
-                var l = toSymEntry(left,uint, nd);
-                var r = toSymEntry(right,uint, nd);
-                select op {
-                    when "+=" { l.a += r.a; }
-                    when "-=" {
-                        l.a -= r.a;
-                    }
-                    when "*=" { l.a *= r.a; }
-                    when "//=" {
-                        //l.a /= r.a;
-                        ref la = l.a;
-                        ref ra = r.a;
-                        [(li,ri) in zip(la,ra)] li = if ri != 0 then li/ri else 0;
-                    }//floordiv
-                    when "%=" {
-                        //l.a /= r.a;
-                        ref la = l.a;
-                        ref ra = r.a;
-                        [(li,ri) in zip(la,ra)] li = if ri != 0 then li%ri else 0;
-                    }
-                    when "**=" {
-                        l.a **= r.a;
-                    }
-                    when ">>=" { l.a >>= r.a;}
-                    when "<<=" { l.a <<= r.a;}
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);
-                    }
-                }
-            }
-            when (DType.UInt64, DType.Float64) {
-                var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
-                omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg, MsgType.ERROR);
-            }
-            when (DType.UInt64, DType.Bool) {
-                var l = toSymEntry(left, uint, nd);
-                var r = toSymEntry(right, bool, nd);
-                select op {
-                    when "+=" {l.a += r.a:uint;}
-                    when "-=" {l.a -= r.a:uint;}
-                    when "*=" {l.a *= r.a:uint;}
-                    when ">>=" { l.a >>= r.a:uint;}
-                    when "<<=" { l.a <<= r.a:uint;}
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);
-                    }
-                }
-            }
-            when (DType.UInt64, DType.BigInt) {
-                var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
-                omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg, MsgType.ERROR);
-            }
-            when (DType.Float64, DType.Int64) {
-                var l = toSymEntry(left,real, nd);
-                var r = toSymEntry(right,int, nd);
-
-                select op {
-                    when "+=" {l.a += r.a;}
-                    when "-=" {l.a -= r.a;}
-                    when "*=" {l.a *= r.a;}
-                    when "/=" {l.a /= r.a:real;} //truediv
-                    when "//=" { //floordiv
-                        ref la = l.a;
-                        ref ra = r.a;
-                        [(li,ri) in zip(la,ra)] li = floorDivisionHelper(li, ri);
-                    }
-                    when "**=" { l.a **= r.a; }
-                    when "%=" {
-                        ref la = l.a;
-                        ref ra = r.a;
-                        [(li,ri) in zip(la,ra)] li = modHelper(li, ri);
-                    }
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);
-                    }
-                }
-            }
-            when (DType.Float64, DType.UInt64) {
-                var l = toSymEntry(left,real, nd);
-                var r = toSymEntry(right,uint, nd);
-
-                select op {
-                    when "+=" {l.a += r.a;}
-                    when "-=" {l.a -= r.a;}
-                    when "*=" {l.a *= r.a;}
-                    when "/=" {l.a /= r.a:real;} //truediv
-                    when "//=" { //floordiv
-                        ref la = l.a;
-                        ref ra = r.a;
-                        [(li,ri) in zip(la,ra)] li = floorDivisionHelper(li, ri);
-                    }
-                    when "**=" { l.a **= r.a; }
-                    when "%=" {
-                        ref la = l.a;
-                        ref ra = r.a;
-                        [(li,ri) in zip(la,ra)] li = modHelper(li, ri);
-                    }
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);
-                    }
-                }
-            }
-            when (DType.Float64, DType.Float64) {
-                var l = toSymEntry(left,real, nd);
-                var r = toSymEntry(right,real, nd);
-                select op {
-                    when "+=" {l.a += r.a;}
-                    when "-=" {l.a -= r.a;}
-                    when "*=" {l.a *= r.a;}
-                    when "/=" {l.a /= r.a;}//truediv
-                    when "//=" { //floordiv
-                        ref la = l.a;
-                        ref ra = r.a;
-                        [(li,ri) in zip(la,ra)] li = floorDivisionHelper(li, ri);
-                    }
-                    when "**=" { l.a **= r.a; }
-                    when "%=" {
-                        ref la = l.a;
-                        ref ra = r.a;
-                        [(li,ri) in zip(la,ra)] li = modHelper(li, ri);
-                    }
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);
-                    }
-                }
-            }
-            when (DType.Float64, DType.Bool) {
-                var l = toSymEntry(left, real, nd);
-                var r = toSymEntry(right, bool, nd);
-                select op {
-                    when "+=" {l.a += r.a:real;}
-                    when "-=" {l.a -= r.a:real;}
-                    when "*=" {l.a *= r.a:real;}
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);
-                    }
-                }
-            }
-            when (DType.Float64, DType.BigInt) {
-                var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
-                omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg, MsgType.ERROR);
-            }
-            when (DType.Bool, DType.Bool) {
-                var l = toSymEntry(left, bool, nd);
-                var r = toSymEntry(right, bool, nd);
-                select op {
-                    when "|=" {l.a |= r.a;}
-                    when "&=" {l.a &= r.a;}
-                    when "^=" {l.a ^= r.a;}
-                    when "+=" {l.a |= r.a;}
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);
-                    }
-                }
-            }
-            when (DType.BigInt, DType.Int64) {
-                var l = toSymEntry(left,bigint, nd);
-                var r = toSymEntry(right,int, nd);
-                ref la = l.a;
-                ref ra = r.a;
-                var max_bits = l.max_bits;
-                var max_size = 1:bigint;
-                var has_max_bits = max_bits != -1;
-                if has_max_bits {
-                  max_size <<= max_bits;
-                  max_size -= 1;
-                }
-                select op {
-                  when "+=" {
-                    forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
-                      li += ri;
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "-=" {
-                    forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
-                      li -= ri;
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "*=" {
-                    forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
-                      li *= ri;
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "//=" {
-                    forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
-                      if ri != 0 {
-                        li /= ri;
-                      }
-                      else {
-                        li = 0:bigint;
-                      }
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "%=" {
-                    // we can't use li %= ri because this can result in negatives
-                    forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
-                      if ri != 0 {
-                        mod(li, li, ri);
-                      }
-                      else {
-                        li = 0:bigint;
-                      }
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "**=" {
-                    if || reduce (ra<0) {
-                      throw new Error("Attempt to exponentiate base of type BigInt to negative exponent");
-                    }
-                    if has_max_bits {
-                      forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
-                        powMod(li, li, ri, local_max_size + 1);
-                      }
-                    }
-                    else {
-                      forall (li, ri) in zip(la, ra) {
-                        li **= ri:uint;
-                      }
-                    }
-                  }
-                  otherwise {
-                    var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
-                    omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                    return new MsgTuple(errorMsg, MsgType.ERROR);
-                  }
-                }
-            }
-            when (DType.BigInt, DType.UInt64) {
-                var l = toSymEntry(left,bigint, nd);
-                var r = toSymEntry(right,uint, nd);
-                ref la = l.a;
-                ref ra = r.a;
-                var max_bits = l.max_bits;
-                var max_size = 1:bigint;
-                var has_max_bits = max_bits != -1;
-                if has_max_bits {
-                  max_size <<= max_bits;
-                  max_size -= 1;
-                }
-                select op {
-                  when "+=" {
-                    forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
-                      li += ri;
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "-=" {
-                    forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
-                      li -= ri;
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "*=" {
-                    forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
-                      li *= ri;
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "//=" {
-                    forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
-                      if ri != 0 {
-                        li /= ri;
-                      }
-                      else {
-                        li = 0:bigint;
-                      }
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "%=" {
-                    // we can't use li %= ri because this can result in negatives
-                    forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
-                      if ri != 0 {
-                        mod(li, li, ri);
-                      }
-                      else {
-                        li = 0:bigint;
-                      }
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "**=" {
-                    if || reduce (ra<0) {
-                      throw new Error("Attempt to exponentiate base of type BigInt to negative exponent");
-                    }
-                    if has_max_bits {
-                      forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
-                        powMod(li, li, ri, local_max_size + 1);
-                      }
-                    }
-                    else {
-                      forall (li, ri) in zip(la, ra) {
-                        li **= ri:uint;
-                      }
-                    }
-                  }
-                  otherwise {
-                    var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
-                    omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                    return new MsgTuple(errorMsg, MsgType.ERROR);
-                  }
-                }
-            }
-            when (DType.BigInt, DType.Float64) {
-                var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
-                omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg, MsgType.ERROR);
-            }
-            when (DType.BigInt, DType.Bool) {
-                var l = toSymEntry(left,bigint, nd);
-                var r = toSymEntry(right,bool, nd);
-                ref la = l.a;
-                var ra = r.a:bigint;
-                var max_bits = l.max_bits;
-                var max_size = 1:bigint;
-                var has_max_bits = max_bits != -1;
-                if has_max_bits {
-                  max_size <<= max_bits;
-                  max_size -= 1;
-                }
-                select op {
-                  when "+=" {
-                    forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
-                      li += ri;
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "-=" {
-                    forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
-                      li -= ri;
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "*=" {
-                    forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
-                      li *= ri;
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  otherwise {
-                    var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
-                    omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                    return new MsgTuple(errorMsg, MsgType.ERROR);
-                  }
-                }
-            }
-            when (DType.BigInt, DType.BigInt) {
-                var l = toSymEntry(left,bigint, nd);
-                var r = toSymEntry(right,bigint, nd);
-                ref la = l.a;
-                ref ra = r.a;
-                var max_bits = l.max_bits;
-                var max_size = 1:bigint;
-                var has_max_bits = max_bits != -1;
-                if has_max_bits {
-                  max_size <<= max_bits;
-                  max_size -= 1;
-                }
-                select op {
-                  when "+=" {
-                    forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
-                      li += ri;
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "-=" {
-                    forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
-                      li -= ri;
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "*=" {
-                    forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
-                      li *= ri;
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "//=" {
-                    forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
-                      if ri != 0 {
-                        li /= ri;
-                      }
-                      else {
-                        li = 0:bigint;
-                      }
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "%=" {
-                    // we can't use li %= ri because this can result in negatives
-                    forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
-                      if ri != 0 {
-                        mod(li, li, ri);
-                      }
-                      else {
-                        li = 0:bigint;
-                      }
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "**=" {
-                    if || reduce (ra<0) {
-                      throw new Error("Attempt to exponentiate base of type BigInt to negative exponent");
-                    }
-                    if has_max_bits {
-                      forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
-                        powMod(li, li, ri, local_max_size + 1);
-                      }
-                    }
-                    else {
-                      forall (li, ri) in zip(la, ra) {
-                        li **= ri:uint;
-                      }
-                    }
-                  }
-                  otherwise {
-                    var errorMsg = notImplementedError(pn,left.dtype,op,right.dtype);
-                    omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                    return new MsgTuple(errorMsg, MsgType.ERROR);
-                  }
-                }
-            }
-            otherwise {
-                var errorMsg = unrecognizedTypeError(pn,
-                                  "("+dtype2str(left.dtype)+","+dtype2str(right.dtype)+")");
-                omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg, MsgType.ERROR);
+                otherwise do return MsgTuple.error(nie);
             }
         }
-        repMsg = "opeqvv success";
-        omLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-        return new MsgTuple(repMsg, MsgType.NORMAL);
+        else if binop_dtype_a == int && binop_dtype_b == bool  {
+            select op {
+                when "+=" {l.a += r.a:int;}
+                when "-=" {l.a -= r.a:int;}
+                when "*=" {l.a *= r.a:int;}
+                when ">>=" { l.a >>= r.a:int;}
+                when "<<=" { l.a <<= r.a:int;}
+                otherwise do return MsgTuple.error(nie);
+            }
+        }
+        else if binop_dtype_a == uint && binop_dtype_b == uint  {
+            select op {
+                when "+=" { l.a += r.a; }
+                when "-=" {
+                    l.a -= r.a;
+                }
+                when "*=" { l.a *= r.a; }
+                when "//=" {
+                    //l.a /= r.a;
+                    ref la = l.a;
+                    ref ra = r.a;
+                    [(li,ri) in zip(la,ra)] li = if ri != 0 then li/ri else 0;
+                }//floordiv
+                when "%=" {
+                    //l.a /= r.a;
+                    ref la = l.a;
+                    ref ra = r.a;
+                    [(li,ri) in zip(la,ra)] li = if ri != 0 then li%ri else 0;
+                }
+                when "**=" {
+                    l.a **= r.a;
+                }
+                when ">>=" { l.a >>= r.a;}
+                when "<<=" { l.a <<= r.a;}
+                otherwise do return MsgTuple.error(nie);
+            }
+        }
+        else if binop_dtype_a == uint && binop_dtype_b == bool  {
+            select op {
+                when "+=" {l.a += r.a:uint;}
+                when "-=" {l.a -= r.a:uint;}
+                when "*=" {l.a *= r.a:uint;}
+                when ">>=" { l.a >>= r.a:uint;}
+                when "<<=" { l.a <<= r.a:uint;}
+                otherwise do return MsgTuple.error(nie);
+            }
+        }
+        else if binop_dtype_a == real && binop_dtype_b == int  {
+            select op {
+                when "+=" {l.a += r.a;}
+                when "-=" {l.a -= r.a;}
+                when "*=" {l.a *= r.a;}
+                when "/=" {l.a /= r.a:real;} //truediv
+                when "//=" { //floordiv
+                    ref la = l.a;
+                    ref ra = r.a;
+                    [(li,ri) in zip(la,ra)] li = floorDivisionHelper(li, ri);
+                }
+                when "**=" { l.a **= r.a; }
+                when "%=" {
+                    ref la = l.a;
+                    ref ra = r.a;
+                    [(li,ri) in zip(la,ra)] li = modHelper(li, ri);
+                }
+                otherwise do return MsgTuple.error(nie);
+            }
+        }
+        else if binop_dtype_a == real && binop_dtype_b == uint  {
+            select op {
+                when "+=" {l.a += r.a;}
+                when "-=" {l.a -= r.a;}
+                when "*=" {l.a *= r.a;}
+                when "/=" {l.a /= r.a:real;} //truediv
+                when "//=" { //floordiv
+                    ref la = l.a;
+                    ref ra = r.a;
+                    [(li,ri) in zip(la,ra)] li = floorDivisionHelper(li, ri);
+                }
+                when "**=" { l.a **= r.a; }
+                when "%=" {
+                    ref la = l.a;
+                    ref ra = r.a;
+                    [(li,ri) in zip(la,ra)] li = modHelper(li, ri);
+                }
+                otherwise do return MsgTuple.error(nie);
+            }
+        }
+        else if binop_dtype_a == real && binop_dtype_b == real  {
+            select op {
+                when "+=" {l.a += r.a;}
+                when "-=" {l.a -= r.a;}
+                when "*=" {l.a *= r.a;}
+                when "/=" {l.a /= r.a;}//truediv
+                when "//=" { //floordiv
+                    ref la = l.a;
+                    ref ra = r.a;
+                    [(li,ri) in zip(la,ra)] li = floorDivisionHelper(li, ri);
+                }
+                when "**=" { l.a **= r.a; }
+                when "%=" {
+                    ref la = l.a;
+                    ref ra = r.a;
+                    [(li,ri) in zip(la,ra)] li = modHelper(li, ri);
+                }
+                otherwise do return MsgTuple.error(nie);
+            }
+        }
+        else if binop_dtype_a == real && binop_dtype_b == bool  {
+            select op {
+                when "+=" {l.a += r.a:real;}
+                when "-=" {l.a -= r.a:real;}
+                when "*=" {l.a *= r.a:real;}
+                otherwise do return MsgTuple.error(nie);
+            }
+        }
+        else if binop_dtype_a == bool && binop_dtype_b == bool  {
+            select op {
+                when "|=" {l.a |= r.a;}
+                when "&=" {l.a &= r.a;}
+                when "^=" {l.a ^= r.a;}
+                when "+=" {l.a |= r.a;}
+                otherwise do return MsgTuple.error(nie);
+            }
+        }
+        else if binop_dtype_a == bigint && binop_dtype_b == int  {
+            ref la = l.a;
+            ref ra = r.a;
+            var max_bits = l.max_bits;
+            var max_size = 1:bigint;
+            var has_max_bits = max_bits != -1;
+            if has_max_bits {
+              max_size <<= max_bits;
+              max_size -= 1;
+            }
+            select op {
+              when "+=" {
+                forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
+                  li += ri;
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "-=" {
+                forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
+                  li -= ri;
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "*=" {
+                forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
+                  li *= ri;
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "//=" {
+                forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
+                  if ri != 0 {
+                    li /= ri;
+                  }
+                  else {
+                    li = 0:bigint;
+                  }
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "%=" {
+                // we can't use li %= ri because this can result in negatives
+                forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
+                  if ri != 0 {
+                    mod(li, li, ri);
+                  }
+                  else {
+                    li = 0:bigint;
+                  }
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "**=" {
+                if || reduce (ra<0) {
+                  throw new Error("Attempt to exponentiate base of type BigInt to negative exponent");
+                }
+                if has_max_bits {
+                  forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
+                    powMod(li, li, ri, local_max_size + 1);
+                  }
+                }
+                else {
+                  forall (li, ri) in zip(la, ra) {
+                    li **= ri:uint;
+                  }
+                }
+              }
+              otherwise do return MsgTuple.error(nie);
+            }
+        }
+        else if binop_dtype_a == bigint && binop_dtype_b == uint  {
+            ref la = l.a;
+            ref ra = r.a;
+            var max_bits = l.max_bits;
+            var max_size = 1:bigint;
+            var has_max_bits = max_bits != -1;
+            if has_max_bits {
+              max_size <<= max_bits;
+              max_size -= 1;
+            }
+            select op {
+              when "+=" {
+                forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
+                  li += ri;
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "-=" {
+                forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
+                  li -= ri;
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "*=" {
+                forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
+                  li *= ri;
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "//=" {
+                forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
+                  if ri != 0 {
+                    li /= ri;
+                  }
+                  else {
+                    li = 0:bigint;
+                  }
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "%=" {
+                // we can't use li %= ri because this can result in negatives
+                forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
+                  if ri != 0 {
+                    mod(li, li, ri);
+                  }
+                  else {
+                    li = 0:bigint;
+                  }
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "**=" {
+                if || reduce (ra<0) {
+                  throw new Error("Attempt to exponentiate base of type BigInt to negative exponent");
+                }
+                if has_max_bits {
+                  forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
+                    powMod(li, li, ri, local_max_size + 1);
+                  }
+                }
+                else {
+                  forall (li, ri) in zip(la, ra) {
+                    li **= ri:uint;
+                  }
+                }
+              }
+              otherwise do return MsgTuple.error(nie);
+            }
+        }
+        else if binop_dtype_a == bigint && binop_dtype_b == bool  {
+            ref la = l.a;
+            var ra = r.a:bigint;
+            var max_bits = l.max_bits;
+            var max_size = 1:bigint;
+            var has_max_bits = max_bits != -1;
+            if has_max_bits {
+              max_size <<= max_bits;
+              max_size -= 1;
+            }
+            select op {
+              when "+=" {
+                forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
+                  li += ri;
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "-=" {
+                forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
+                  li -= ri;
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "*=" {
+                forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
+                  li *= ri;
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              otherwise do return MsgTuple.error(nie);
+            }
+        }
+        else if binop_dtype_a == bigint && binop_dtype_b == bigint  {
+            ref la = l.a;
+            ref ra = r.a;
+            var max_bits = l.max_bits;
+            var max_size = 1:bigint;
+            var has_max_bits = max_bits != -1;
+            if has_max_bits {
+              max_size <<= max_bits;
+              max_size -= 1;
+            }
+            select op {
+              when "+=" {
+                forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
+                  li += ri;
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "-=" {
+                forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
+                  li -= ri;
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "*=" {
+                forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
+                  li *= ri;
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "//=" {
+                forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
+                  if ri != 0 {
+                    li /= ri;
+                  }
+                  else {
+                    li = 0:bigint;
+                  }
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "%=" {
+                // we can't use li %= ri because this can result in negatives
+                forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
+                  if ri != 0 {
+                    mod(li, li, ri);
+                  }
+                  else {
+                    li = 0:bigint;
+                  }
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "**=" {
+                if || reduce (ra<0) {
+                  throw new Error("Attempt to exponentiate base of type BigInt to negative exponent");
+                }
+                if has_max_bits {
+                  forall (li, ri) in zip(la, ra) with (var local_max_size = max_size) {
+                    powMod(li, li, ri, local_max_size + 1);
+                  }
+                }
+                else {
+                  forall (li, ri) in zip(la, ra) {
+                    li **= ri:uint;
+                  }
+                }
+              }
+              otherwise do return MsgTuple.error(nie);
+            }
+          } else {
+            return MsgTuple.error(nie);
+          }
+
+        return MsgTuple.success();
     }
 
     /*
@@ -1358,581 +1062,450 @@ module OperatorMsg
       :returns: (MsgTuple)
       :throws: `UndefinedSymbolError(name)`
     */
-    @arkouda.registerND
-    proc opeqvsMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, param nd: int): MsgTuple throws {
+    @arkouda.instantiateAndRegister
+    proc opeqvs(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab,
+      type binop_dtype_a,
+      type binop_dtype_b,
+      param array_nd: int
+    ): MsgTuple throws {
         param pn = Reflection.getRoutineName();
-        var repMsg: string; // response message
 
-        const op = msgArgs.getValueOf("op");
-        const aname = msgArgs.getValueOf("a");
-        const value = msgArgs.get("value");
-        var dtype = str2dtype(msgArgs.getValueOf("dtype"));
+        var l = st[msgArgs['a']]: borrowed SymEntry(binop_dtype_a, array_nd);
+        const val = msgArgs['value'].toScalar(binop_dtype_b),
+              op = msgArgs['op'].toScalar(string),
+              nie = notImplementedError(pn,type2str(binop_dtype_a),op,type2str(binop_dtype_b));
 
         omLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                        "cmd: %s op: %s aname: %s dtype: %s scalar: %s".format(
-                                                 cmd,op,aname,dtype2str(dtype),value.getValue()));
+                         "op: %? pdarray: %? scalar: %?".format(op,st.attrib(msgArgs['a'].val),val));
 
-        var left: borrowed GenSymEntry = getGenericTypedArrayEntry(aname, st);
- 
-        omLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                         "op: %? pdarray: %? scalar: %?".format(op,st.attrib(aname),value.getValue()));
-        select (left.dtype, dtype) {
-            when (DType.Int64, DType.Int64) {
-                var l = toSymEntry(left,int, nd);
-                var val = value.getIntValue();
-                select op {
-                    when "+=" { l.a += val; }
-                    when "-=" { l.a -= val; }
-                    when "*=" { l.a *= val; }
-                    when ">>=" { l.a >>= val; }
-                    when "<<=" { l.a <<= val; }
-                    when "//=" {
-                        if val != 0 {l.a /= val;} else {l.a = 0;}
-                    }//floordiv
-                    when "%=" {
-                        if val != 0 {l.a %= val;} else {l.a = 0;}
+        if binop_dtype_a == int && binop_dtype_b == int  {
+            select op {
+                when "+=" { l.a += val; }
+                when "-=" { l.a -= val; }
+                when "*=" { l.a *= val; }
+                when ">>=" { l.a >>= val; }
+                when "<<=" { l.a <<= val; }
+                when "//=" {
+                    if val != 0 {l.a /= val;} else {l.a = 0;}
+                }//floordiv
+                when "%=" {
+                    if val != 0 {l.a %= val;} else {l.a = 0;}
+                }
+                when "**=" {
+                    if val<0 {
+                        var errorMsg = "Attempt to exponentiate base of type int64 to negative exponent";
+                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),
+                                                                          errorMsg);
+                        return new MsgTuple(errorMsg, MsgType.ERROR);
                     }
-                    when "**=" {
-                        if val<0 {
-                            var errorMsg = "Attempt to exponentiate base of type Int64 to negative exponent";
-                            omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),
-                                                                              errorMsg);
-                            return new MsgTuple(errorMsg, MsgType.ERROR);
-                        }
-                        else{ l.a **= val; }
+                    else{ l.a **= val; }
 
-                    }
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);                         
-                    }
                 }
-            }
-            when (DType.Int64, DType.UInt64) {
-                var l = toSymEntry(left,int, nd);
-                var val = value.getUIntValue();
-                select op {
-                    when ">>=" { l.a >>= val; }
-                    when "<<=" { l.a <<= val; }
-                    otherwise {
-                        // The result of operations between int and uint are float by default which doesn't fit in either type
-                        var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);
-                    }
-                }
-            }
-            when (DType.Int64, DType.Float64) {
-                var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
-                omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg, MsgType.ERROR);
-            }
-            when (DType.Int64, DType.Bool) {
-                var l = toSymEntry(left, int, nd);
-                var val = value.getBoolValue();
-                select op {
-                    when "+=" {l.a += val:int;}
-                    when "-=" {l.a -= val:int;}
-                    when "*=" {l.a *= val:int;}
-                    when ">>=" {l.a >>= val:int; }
-                    when "<<=" {l.a <<= val:int; }
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);
-                    }
-                }
-            }
-            when (DType.Int64, DType.BigInt) {
-                var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
-                omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg, MsgType.ERROR);
-            }
-            when (DType.UInt64, DType.Int64) {
-            var l = toSymEntry(left, uint, nd);
-                var val = value.getIntValue();
-                select op {
-                    when ">>=" { l.a >>= val; }
-                    when "<<=" { l.a <<= val; }
-                    otherwise {
-                        // The result of operations between int and uint are float by default which doesn't fit in either type
-                        var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);
-                    }
-                }
-            }
-            when (DType.UInt64, DType.UInt64) {
-                var l = toSymEntry(left,uint, nd);
-                var val = value.getUIntValue();
-                select op {
-                    when "+=" { l.a += val; }
-                    when "-=" {
-                        l.a -= val;
-                    }
-                    when "*=" { l.a *= val; }
-                    when "//=" {
-                        if val != 0 {l.a /= val;} else {l.a = 0;}
-                    }//floordiv
-                    when "%=" {
-                        if val != 0 {l.a %= val;} else {l.a = 0;}
-                    }
-                    when "**=" {
-                        l.a **= val;
-                    }
-                    when ">>=" { l.a >>= val; }
-                    when "<<=" { l.a <<= val; }
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);
-                    }
-                }
-            }
-            when (DType.UInt64, DType.Float64) {
-                var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
-                omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg, MsgType.ERROR);
-            }
-            when (DType.UInt64, DType.Bool) {
-                var l = toSymEntry(left, uint, nd);
-                var val = value.getBoolValue();
-                select op {
-                    when "+=" {l.a += val:uint;}
-                    when "-=" {l.a -= val:uint;}
-                    when "*=" {l.a *= val:uint;}
-                    when ">>=" { l.a >>= val:uint;}
-                    when "<<=" { l.a <<= val:uint;}
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);
-                    }
-                }
-            }
-            when (DType.Bool, DType.Bool) {
-                var l = toSymEntry(left, bool, nd);
-                var val = value.getBoolValue();
-                select op {
-                    when "+=" {l.a |= val;}
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);
-                    }
-                }
-            }
-            when (DType.UInt64, DType.BigInt) {
-                var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
-                omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg, MsgType.ERROR);
-            }
-            when (DType.Float64, DType.Int64) {
-                var l = toSymEntry(left,real, nd);
-                var val = value.getIntValue();
-                select op {
-                    when "+=" {l.a += val;}
-                    when "-=" {l.a -= val;}
-                    when "*=" {l.a *= val;}
-                    when "/=" {l.a /= val:real;} //truediv
-                    when "//=" { //floordiv
-                        ref la = l.a;
-                        [li in la] li = floorDivisionHelper(li, val);
-                    }
-                    when "**=" { l.a **= val; }
-                    when "%=" {
-                        ref la = l.a;
-                        [li in la] li = modHelper(li, val);
-                    }
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);
-                    }
-                }
-            }
-            when (DType.Float64, DType.UInt64) {
-                var l = toSymEntry(left,real, nd);
-                var val = value.getUIntValue();
-                select op {
-                    when "+=" { l.a += val; }
-                    when "-=" { l.a -= val; }
-                    when "*=" { l.a *= val; }
-                    when "//=" {
-                        ref la = l.a;
-                        [li in la] li = floorDivisionHelper(li, val);
-                    }//floordiv
-                    when "**=" {
-                        l.a **= val;
-                    }
-                    when "%=" {
-                        ref la = l.a;
-                        [li in la] li = modHelper(li, val);
-                    }
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);
-                    }
-                }
-            }
-            when (DType.Float64, DType.Float64) {
-                var l = toSymEntry(left,real, nd);
-                var val = value.getRealValue();
-                select op {
-                    when "+=" {l.a += val;}
-                    when "-=" {l.a -= val;}
-                    when "*=" {l.a *= val;}
-                    when "/=" {l.a /= val;}//truediv
-                    when "//=" { //floordiv
-                        ref la = l.a;
-                        [li in la] li = floorDivisionHelper(li, val);
-                    }
-                    when "**=" { l.a **= val; }
-                    when "%=" {
-                        ref la = l.a;
-                        [li in la] li = modHelper(li, val);
-                    }
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);
-                    }
-                }
-            }
-            when (DType.Float64, DType.Bool) {
-                var l = toSymEntry(left, real, nd);
-                var val = value.getBoolValue();
-                select op {
-                    when "+=" {l.a += val:real;}
-                    when "-=" {l.a -= val:real;}
-                    when "*=" {l.a *= val:real;}
-                    otherwise {
-                        var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
-                        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                        return new MsgTuple(errorMsg, MsgType.ERROR);
-                    }
-                }
-            }
-            when (DType.Float64, DType.BigInt) {
-                var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
-                omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg, MsgType.ERROR);
-            }
-            when (DType.BigInt, DType.Int64) {
-                var l = toSymEntry(left,bigint, nd);
-                var val = value.getIntValue();
-                ref la = l.a;
-                var max_bits = l.max_bits;
-                var max_size = 1:bigint;
-                var has_max_bits = max_bits != -1;
-                if has_max_bits {
-                  max_size <<= max_bits;
-                  max_size -= 1;
-                }
-                select op {
-                  when "+=" {
-                    forall li in la with (var local_val = val, var local_max_size = max_size) {
-                      li += local_val;
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "-=" {
-                    forall li in la with (var local_val = val, var local_max_size = max_size) {
-                      li -= local_val;
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "*=" {
-                    forall li in la with (var local_val = val, var local_max_size = max_size) {
-                      li *= local_val;
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "//=" {
-                    forall li in la with (var local_val = val, var local_max_size = max_size) {
-                      if local_val != 0 {
-                        li /= local_val;
-                      }
-                      else {
-                        li = 0:bigint;
-                      }
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "%=" {
-                    // we can't use li %= val because this can result in negatives
-                    forall li in la with (var local_val = val, var local_max_size = max_size) {
-                      if local_val != 0 {
-                        mod(li, li, local_val);
-                      }
-                      else {
-                        li = 0:bigint;
-                      }
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "**=" {
-                    if val<0 {
-                      throw new Error("Attempt to exponentiate base of type BigInt to negative exponent");
-                    }
-                    if has_max_bits {
-                      forall li in la with (var local_val = val, var local_max_size = max_size) {
-                        powMod(li, li, local_val, local_max_size + 1);
-                      }
-                    }
-                    else {
-                      forall li in la with (var local_val = val) {
-                        li **= local_val:uint;
-                      }
-                    }
-                  }
-                  otherwise {
-                    var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
-                    omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                    return new MsgTuple(errorMsg, MsgType.ERROR);
-                  }
-                }
-            }
-            when (DType.BigInt, DType.UInt64) {
-                var l = toSymEntry(left,bigint, nd);
-                var val = value.getUIntValue();
-                ref la = l.a;
-                var max_bits = l.max_bits;
-                var max_size = 1:bigint;
-                var has_max_bits = max_bits != -1;
-                if has_max_bits {
-                  max_size <<= max_bits;
-                  max_size -= 1;
-                }
-                select op {
-                  when "+=" {
-                    forall li in la with (var local_val = val, var local_max_size = max_size) {
-                      li += local_val;
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "-=" {
-                    forall li in la with (var local_val = val, var local_max_size = max_size) {
-                      li -= local_val;
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "*=" {
-                    forall li in la with (var local_val = val, var local_max_size = max_size) {
-                      li *= local_val;
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "//=" {
-                    forall li in la with (var local_val = val, var local_max_size = max_size) {
-                      if local_val != 0 {
-                        li /= local_val;
-                      }
-                      else {
-                        li = 0:bigint;
-                      }
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "%=" {
-                    // we can't use li %= val because this can result in negatives
-                    forall li in la with (var local_val = val, var local_max_size = max_size) {
-                      if local_val != 0 {
-                        mod(li, li, local_val);
-                      }
-                      else {
-                        li = 0:bigint;
-                      }
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "**=" {
-                    if val<0 {
-                      throw new Error("Attempt to exponentiate base of type BigInt to negative exponent");
-                    }
-                    if has_max_bits {
-                      forall li in la with (var local_val = val, var local_max_size = max_size) {
-                        powMod(li, li, local_val, local_max_size + 1);
-                      }
-                    }
-                    else {
-                      forall li in la with (var local_val = val) {
-                        li **= local_val:uint;
-                      }
-                    }
-                  }
-                  otherwise {
-                    var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
-                    omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                    return new MsgTuple(errorMsg, MsgType.ERROR);
-                  }
-                }
-            }
-            when (DType.BigInt, DType.Float64) {
-                var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
-                omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg, MsgType.ERROR);
-            }
-            when (DType.BigInt, DType.Bool) {
-                var l = toSymEntry(left, bigint, nd);
-                var val = value.getBoolValue();
-                ref la = l.a;
-                var max_bits = l.max_bits;
-                var max_size = 1:bigint;
-                var has_max_bits = max_bits != -1;
-                if has_max_bits {
-                  max_size <<= max_bits;
-                  max_size -= 1;
-                }
-                select op {
-                  // TODO change once we can cast directly from bool to bigint
-                  when "+=" {
-                    forall li in la with (var local_val = val:int:bigint, var local_max_size = max_size) {
-                      li += local_val;
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "-=" {
-                    forall li in la with (var local_val = val:int:bigint, var local_max_size = max_size) {
-                      li -= local_val;
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "*=" {
-                    forall li in la with (var local_val = val:int:bigint, var local_max_size = max_size) {
-                      li *= local_val;
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  otherwise {
-                    var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
-                    omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                    return new MsgTuple(errorMsg, MsgType.ERROR);
-                  }
-                }
-            }
-            when (DType.BigInt, DType.BigInt) {
-                var l = toSymEntry(left,bigint, nd);
-                var val = value.getBigIntValue();
-                ref la = l.a;
-                var max_bits = l.max_bits;
-                var max_size = 1:bigint;
-                var has_max_bits = max_bits != -1;
-                if has_max_bits {
-                  max_size <<= max_bits;
-                  max_size -= 1;
-                }
-                select op {
-                  when "+=" {
-                    forall li in la with (var local_val = val, var local_max_size = max_size) {
-                      li += local_val;
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "-=" {
-                    forall li in la with (var local_val = val, var local_max_size = max_size) {
-                      li -= local_val;
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "*=" {
-                    forall li in la with (var local_val = val, var local_max_size = max_size) {
-                      li *= local_val;
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "//=" {
-                    forall li in la with (var local_val = val, var local_max_size = max_size) {
-                      if local_val != 0 {
-                        li /= local_val;
-                      }
-                      else {
-                        li = 0:bigint;
-                      }
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "%=" {
-                    // we can't use li %= val because this can result in negatives
-                    forall li in la with (var local_val = val, var local_max_size = max_size) {
-                      if local_val != 0 {
-                        mod(li, li, local_val);
-                      }
-                      else {
-                        li = 0:bigint;
-                      }
-                      if has_max_bits {
-                        li &= local_max_size;
-                      }
-                    }
-                  }
-                  when "**=" {
-                    if val<0 {
-                      throw new Error("Attempt to exponentiate base of type BigInt to negative exponent");
-                    }
-                    if has_max_bits {
-                      forall li in la with (var local_val = val, var local_max_size = max_size) {
-                        powMod(li, li, local_val, local_max_size + 1);
-                      }
-                    }
-                    else {
-                      forall li in la with (var local_val = val) {
-                        li **= local_val:uint;
-                      }
-                    }
-                  }
-                  otherwise {
-                    var errorMsg = notImplementedError(pn,left.dtype,op,dtype);
-                    omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                    return new MsgTuple(errorMsg, MsgType.ERROR);
-                  }
-                }
-            }
-            otherwise {
-              var errorMsg = unrecognizedTypeError(pn,
-                                  "("+dtype2str(left.dtype)+","+dtype2str(dtype)+")");
-              omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-              return new MsgTuple(errorMsg, MsgType.ERROR);
+                otherwise do return MsgTuple.error(nie);
             }
         }
-        repMsg = "opeqvs success";
-        omLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-        return new MsgTuple(repMsg, MsgType.NORMAL);
+        else if binop_dtype_a == int && binop_dtype_b == uint  {
+            select op {
+                when ">>=" { l.a >>= val; }
+                when "<<=" { l.a <<= val; }
+                otherwise do return MsgTuple.error(nie);
+            }
+        }
+        else if binop_dtype_a == int && binop_dtype_b == bool  {
+            select op {
+                when "+=" {l.a += val:int;}
+                when "-=" {l.a -= val:int;}
+                when "*=" {l.a *= val:int;}
+                when ">>=" {l.a >>= val:int; }
+                when "<<=" {l.a <<= val:int; }
+                otherwise do return MsgTuple.error(nie);
+            }
+        }
+        else if binop_dtype_a == uint && binop_dtype_b == int  {
+            select op {
+                when ">>=" { l.a >>= val; }
+                when "<<=" { l.a <<= val; }
+                otherwise do return MsgTuple.error(nie);
+            }
+        }
+        else if binop_dtype_a == uint && binop_dtype_b == uint  {
+            select op {
+                when "+=" { l.a += val; }
+                when "-=" {
+                    l.a -= val;
+                }
+                when "*=" { l.a *= val; }
+                when "//=" {
+                    if val != 0 {l.a /= val;} else {l.a = 0;}
+                }//floordiv
+                when "%=" {
+                    if val != 0 {l.a %= val;} else {l.a = 0;}
+                }
+                when "**=" {
+                    l.a **= val;
+                }
+                when ">>=" { l.a >>= val; }
+                when "<<=" { l.a <<= val; }
+                otherwise do return MsgTuple.error(nie);
+            }
+        }
+        else if binop_dtype_a == uint && binop_dtype_b == bool  {
+            select op {
+                when "+=" {l.a += val:uint;}
+                when "-=" {l.a -= val:uint;}
+                when "*=" {l.a *= val:uint;}
+                when ">>=" { l.a >>= val:uint;}
+                when "<<=" { l.a <<= val:uint;}
+                otherwise do return MsgTuple.error(nie);
+            }
+        }
+        else if binop_dtype_a == bool && binop_dtype_b == bool  {
+            select op {
+                when "+=" {l.a |= val;}
+                otherwise do return MsgTuple.error(nie);
+            }
+        }
+        else if binop_dtype_a == real && binop_dtype_b == int  {
+            select op {
+                when "+=" {l.a += val;}
+                when "-=" {l.a -= val;}
+                when "*=" {l.a *= val;}
+                when "/=" {l.a /= val:real;} //truediv
+                when "//=" { //floordiv
+                    ref la = l.a;
+                    [li in la] li = floorDivisionHelper(li, val);
+                }
+                when "**=" { l.a **= val; }
+                when "%=" {
+                    ref la = l.a;
+                    [li in la] li = modHelper(li, val);
+                }
+                otherwise do return MsgTuple.error(nie);
+            }
+        }
+        else if binop_dtype_a == real && binop_dtype_b == uint  {
+            select op {
+                when "+=" { l.a += val; }
+                when "-=" { l.a -= val; }
+                when "*=" { l.a *= val; }
+                when "//=" {
+                    ref la = l.a;
+                    [li in la] li = floorDivisionHelper(li, val);
+                }//floordiv
+                when "**=" {
+                    l.a **= val;
+                }
+                when "%=" {
+                    ref la = l.a;
+                    [li in la] li = modHelper(li, val);
+                }
+                otherwise do return MsgTuple.error(nie);
+            }
+        }
+        else if binop_dtype_a == real && binop_dtype_b == real  {
+            select op {
+                when "+=" {l.a += val;}
+                when "-=" {l.a -= val;}
+                when "*=" {l.a *= val;}
+                when "/=" {l.a /= val;}//truediv
+                when "//=" { //floordiv
+                    ref la = l.a;
+                    [li in la] li = floorDivisionHelper(li, val);
+                }
+                when "**=" { l.a **= val; }
+                when "%=" {
+                    ref la = l.a;
+                    [li in la] li = modHelper(li, val);
+                }
+                otherwise do return MsgTuple.error(nie);
+            }
+        }
+        else if binop_dtype_a == real && binop_dtype_b == bool  {
+            select op {
+                when "+=" {l.a += val:real;}
+                when "-=" {l.a -= val:real;}
+                when "*=" {l.a *= val:real;}
+                otherwise do return MsgTuple.error(nie);
+            }
+        }
+        else if binop_dtype_a == bigint && binop_dtype_b == int  {
+            ref la = l.a;
+            var max_bits = l.max_bits;
+            var max_size = 1:bigint;
+            var has_max_bits = max_bits != -1;
+            if has_max_bits {
+              max_size <<= max_bits;
+              max_size -= 1;
+            }
+            select op {
+              when "+=" {
+                forall li in la with (var local_val = val, var local_max_size = max_size) {
+                  li += local_val;
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "-=" {
+                forall li in la with (var local_val = val, var local_max_size = max_size) {
+                  li -= local_val;
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "*=" {
+                forall li in la with (var local_val = val, var local_max_size = max_size) {
+                  li *= local_val;
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "//=" {
+                forall li in la with (var local_val = val, var local_max_size = max_size) {
+                  if local_val != 0 {
+                    li /= local_val;
+                  }
+                  else {
+                    li = 0:bigint;
+                  }
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "%=" {
+                // we can't use li %= val because this can result in negatives
+                forall li in la with (var local_val = val, var local_max_size = max_size) {
+                  if local_val != 0 {
+                    mod(li, li, local_val);
+                  }
+                  else {
+                    li = 0:bigint;
+                  }
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "**=" {
+                if val<0 {
+                  throw new Error("Attempt to exponentiate base of type BigInt to negative exponent");
+                }
+                if has_max_bits {
+                  forall li in la with (var local_val = val, var local_max_size = max_size) {
+                    powMod(li, li, local_val, local_max_size + 1);
+                  }
+                }
+                else {
+                  forall li in la with (var local_val = val) {
+                    li **= local_val:uint;
+                  }
+                }
+              }
+              otherwise do return MsgTuple.error(nie);
+            }
+        }
+        else if binop_dtype_a == bigint && binop_dtype_b == uint  {
+            ref la = l.a;
+            var max_bits = l.max_bits;
+            var max_size = 1:bigint;
+            var has_max_bits = max_bits != -1;
+            if has_max_bits {
+              max_size <<= max_bits;
+              max_size -= 1;
+            }
+            select op {
+              when "+=" {
+                forall li in la with (var local_val = val, var local_max_size = max_size) {
+                  li += local_val;
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "-=" {
+                forall li in la with (var local_val = val, var local_max_size = max_size) {
+                  li -= local_val;
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "*=" {
+                forall li in la with (var local_val = val, var local_max_size = max_size) {
+                  li *= local_val;
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "//=" {
+                forall li in la with (var local_val = val, var local_max_size = max_size) {
+                  if local_val != 0 {
+                    li /= local_val;
+                  }
+                  else {
+                    li = 0:bigint;
+                  }
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "%=" {
+                // we can't use li %= val because this can result in negatives
+                forall li in la with (var local_val = val, var local_max_size = max_size) {
+                  if local_val != 0 {
+                    mod(li, li, local_val);
+                  }
+                  else {
+                    li = 0:bigint;
+                  }
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "**=" {
+                if val<0 {
+                  throw new Error("Attempt to exponentiate base of type BigInt to negative exponent");
+                }
+                if has_max_bits {
+                  forall li in la with (var local_val = val, var local_max_size = max_size) {
+                    powMod(li, li, local_val, local_max_size + 1);
+                  }
+                }
+                else {
+                  forall li in la with (var local_val = val) {
+                    li **= local_val:uint;
+                  }
+                }
+              }
+              otherwise do return MsgTuple.error(nie);
+            }
+        }
+        else if binop_dtype_a == bigint && binop_dtype_b == bool  {
+            ref la = l.a;
+            var max_bits = l.max_bits;
+            var max_size = 1:bigint;
+            var has_max_bits = max_bits != -1;
+            if has_max_bits {
+              max_size <<= max_bits;
+              max_size -= 1;
+            }
+            select op {
+              // TODO change once we can cast directly from bool to bigint
+              when "+=" {
+                forall li in la with (var local_val = val:int:bigint, var local_max_size = max_size) {
+                  li += local_val;
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "-=" {
+                forall li in la with (var local_val = val:int:bigint, var local_max_size = max_size) {
+                  li -= local_val;
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "*=" {
+                forall li in la with (var local_val = val:int:bigint, var local_max_size = max_size) {
+                  li *= local_val;
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              otherwise do return MsgTuple.error(nie);
+            }
+        }
+        else if binop_dtype_a == bigint && binop_dtype_b == bigint  {
+            ref la = l.a;
+            var max_bits = l.max_bits;
+            var max_size = 1:bigint;
+            var has_max_bits = max_bits != -1;
+            if has_max_bits {
+              max_size <<= max_bits;
+              max_size -= 1;
+            }
+            select op {
+              when "+=" {
+                forall li in la with (var local_val = val, var local_max_size = max_size) {
+                  li += local_val;
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "-=" {
+                forall li in la with (var local_val = val, var local_max_size = max_size) {
+                  li -= local_val;
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "*=" {
+                forall li in la with (var local_val = val, var local_max_size = max_size) {
+                  li *= local_val;
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "//=" {
+                forall li in la with (var local_val = val, var local_max_size = max_size) {
+                  if local_val != 0 {
+                    li /= local_val;
+                  }
+                  else {
+                    li = 0:bigint;
+                  }
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "%=" {
+                // we can't use li %= val because this can result in negatives
+                forall li in la with (var local_val = val, var local_max_size = max_size) {
+                  if local_val != 0 {
+                    mod(li, li, local_val);
+                  }
+                  else {
+                    li = 0:bigint;
+                  }
+                  if has_max_bits {
+                    li &= local_max_size;
+                  }
+                }
+              }
+              when "**=" {
+                if val<0 {
+                  throw new Error("Attempt to exponentiate base of type BigInt to negative exponent");
+                }
+                if has_max_bits {
+                  forall li in la with (var local_val = val, var local_max_size = max_size) {
+                    powMod(li, li, local_val, local_max_size + 1);
+                  }
+                }
+                else {
+                  forall li in la with (var local_val = val) {
+                    li **= local_val:uint;
+                  }
+                }
+              }
+              otherwise do return MsgTuple.error(nie);
+            }
+        }
+        else {
+          return MsgTuple.error(nie);
+        }
+        return MsgTuple.success();
     }
 }

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -27,7 +27,7 @@ module OperatorMsg
       Parse and respond to binopvv message.
       vv == vector op vector
 
-      :arg reqMsg: request containing (cmd,op,aname,bname,rname)
+      :arg reqMsg: request containing (cmd,op,aname,bname)
       :type reqMsg: string 
 
       :arg st: SymTab to act on
@@ -70,8 +70,6 @@ module OperatorMsg
         realOps.add("-");
         realOps.add("/");
         realOps.add("//");
-
-        const rname = st.nextName();
 
         if binop_dtype_a == int && binop_dtype_b == int {
           if boolOps.contains(op) {
@@ -239,8 +237,6 @@ module OperatorMsg
         omLogger.debug(getModuleName(), getRoutineName(), getLineNumber(),
              "cmd: %? op: %? left pdarray: %? scalar: %?".format(
                                           cmd,op,st.attrib(msgArgs['a'].val), val));
-
-        const rname = st.nextName();
 
         use Set;
         // This boolOps set is a filter to determine the output type for the operation.
@@ -1053,7 +1049,7 @@ module OperatorMsg
       Parse and respond to opeqvs message.
       vector op= scalar
 
-      :arg reqMsg: request containing (cmd,op,aname,bname,rname)
+      :arg reqMsg: request containing (cmd,op,aname,bname)
       :type reqMsg: string
 
       :arg st: SymTab to act on

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -194,104 +194,21 @@ module OperatorMsg
             return doBinOpvv(l, r, int, op, pn, st);
           }
         }
-        else if binop_dtype_a == bigint && binop_dtype_b == bigint {
+        else if binop_dtype_a == bigint || binop_dtype_b == bigint {
           if boolOps.contains(op) {
             // call bigint specific func which returns distr bool array
-            var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
-            var repMsg = "created %s".format(st.attrib(rname));
-            return new MsgTuple(repMsg, MsgType.NORMAL);
+            return st.insert(new shared SymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
           }
           // call bigint specific func which returns dist bigint array
-          var (tmp, max_bits) = doBigIntBinOpvv(l, r, op);
-          var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
-          var repMsg = "created %s".format(st.attrib(rname));
-          return new MsgTuple(repMsg, MsgType.NORMAL);
-        }
-        else if binop_dtype_a == bigint && binop_dtype_b == int {
-          if boolOps.contains(op) {
-            // call bigint specific func which returns distr bool array
-            var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
-            var repMsg = "created %s".format(st.attrib(rname));
-            return new MsgTuple(repMsg, MsgType.NORMAL);
-          }
-          // call bigint specific func which returns dist bigint array
-          var (tmp, max_bits) = doBigIntBinOpvv(l, r, op);
-          var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
-          var repMsg = "created %s".format(st.attrib(rname));
-          return new MsgTuple(repMsg, MsgType.NORMAL);
-        }
-        else if binop_dtype_a == bigint && binop_dtype_b == uint {
-          if boolOps.contains(op) {
-            // call bigint specific func which returns distr bool array
-            var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
-            var repMsg = "created %s".format(st.attrib(rname));
-            return new MsgTuple(repMsg, MsgType.NORMAL);
-          }
-          // call bigint specific func which returns dist bigint array
-          var (tmp, max_bits) = doBigIntBinOpvv(l, r, op);
-          var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
-          var repMsg = "created %s".format(st.attrib(rname));
-          return new MsgTuple(repMsg, MsgType.NORMAL);
-        }
-        else if binop_dtype_a == bigint && binop_dtype_b == bool {
-          if boolOps.contains(op) {
-            // call bigint specific func which returns distr bool array
-            var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
-            var repMsg = "created %s".format(st.attrib(rname));
-            return new MsgTuple(repMsg, MsgType.NORMAL);
-          }
-          // call bigint specific func which returns dist bigint array
-          var (tmp, max_bits) = doBigIntBinOpvv(l, r, op);
-          var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
-          var repMsg = "created %s".format(st.attrib(rname));
-          return new MsgTuple(repMsg, MsgType.NORMAL);
-        }
-        else if binop_dtype_a == int && binop_dtype_b == bigint {
-          if boolOps.contains(op) {
-            // call bigint specific func which returns distr bool array
-            var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
-            var repMsg = "created %s".format(st.attrib(rname));
-            return new MsgTuple(repMsg, MsgType.NORMAL);
-          }
-          // call bigint specific func which returns dist bigint array
-          var (tmp, max_bits) = doBigIntBinOpvv(l, r, op);
-          var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
-          var repMsg = "created %s".format(st.attrib(rname));
-          return new MsgTuple(repMsg, MsgType.NORMAL);
-        }
-        else if binop_dtype_a == uint && binop_dtype_b == bigint {
-          if boolOps.contains(op) {
-            // call bigint specific func which returns distr bool array
-            var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
-            var repMsg = "created %s".format(st.attrib(rname));
-            return new MsgTuple(repMsg, MsgType.NORMAL);
-          }
-          // call bigint specific func which returns dist bigint array
-          var (tmp, max_bits) = doBigIntBinOpvv(l, r, op);
-          var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
-          var repMsg = "created %s".format(st.attrib(rname));
-          return new MsgTuple(repMsg, MsgType.NORMAL);
-        }
-        else if binop_dtype_a == bool && binop_dtype_b == bigint {
-          if boolOps.contains(op) {
-            // call bigint specific func which returns distr bool array
-            var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
-            var repMsg = "created %s".format(st.attrib(rname));
-            return new MsgTuple(repMsg, MsgType.NORMAL);
-          }
-          // call bigint specific func which returns dist bigint array
-          var (tmp, max_bits) = doBigIntBinOpvv(l, r, op);
-          var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
-          var repMsg = "created %s".format(st.attrib(rname));
-          return new MsgTuple(repMsg, MsgType.NORMAL);
+          const (tmp, max_bits) = doBigIntBinOpvv(l, r, op);
+          return st.insert(new shared SymEntry(tmp, max_bits));
         } else {
-          writeln("unreachable???");
-          var errorMsg = unrecognizedTypeError(pn, "("+type2str(binop_dtype_a)+","+type2str(binop_dtype_b)+")");
+          const errorMsg = unrecognizedTypeError(pn, "("+type2str(binop_dtype_a)+","+type2str(binop_dtype_b)+")");
           omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
           return new MsgTuple(errorMsg, MsgType.ERROR);
         }
     }
-    
+
     /*
       Parse and respond to binopvs message.
       vs == vector op scalar
@@ -305,22 +222,23 @@ module OperatorMsg
       :returns: (MsgTuple)
       :throws: `UndefinedSymbolError(name)`
     */
-    @arkouda.registerND
-    proc binopvsMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, param nd: int): MsgTuple throws {
+    @arkouda.instantiateAndRegister
+    proc binopvs(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab,
+      type binop_dtype_a,
+      type binop_dtype_b,
+      param array_nd: int
+    ): MsgTuple throws {
         param pn = Reflection.getRoutineName();
-        var repMsg: string = ""; // response message
 
-        const aname = msgArgs.getValueOf("a");
-        const op = msgArgs.getValueOf("op");
-        const value = msgArgs.get("value");
+        const l = st[msgArgs['a']]: borrowed SymEntry(binop_dtype_a, array_nd),
+              val = msgArgs['value'].toScalar(binop_dtype_b),
+              op = msgArgs['op'].toScalar(string);
 
-        const dtype = str2dtype(msgArgs.getValueOf("dtype"));
-        var rname = st.nextName();
-        var left: borrowed GenSymEntry = getGenericTypedArrayEntry(aname, st);
+        omLogger.debug(getModuleName(), getRoutineName(), getLineNumber(),
+             "cmd: %? op: %? left pdarray: %? scalar: %?".format(
+                                          cmd,op,st.attrib(msgArgs['a'].val), val));
 
-        omLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                           "op: %s dtype: %? pdarray: %? scalar: %?".format(
-                                                     op,dtype,st.attrib(aname),value.getValue()));
+        const rname = st.nextName();
 
         use Set;
         // This boolOps set is a filter to determine the output type for the operation.
@@ -340,307 +258,140 @@ module OperatorMsg
         realOps.add("/");
         realOps.add("//");
 
-        select (left.dtype, dtype) {
-          when (DType.Int64, DType.Int64) {
-            var l = toSymEntry(left,int, nd);
-            var val = value.getIntValue();
-            
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, l.tupShape, bool);
-              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
-            } else if op == "/" {
-              // True division is the only case in this int, int case
-              // that results in a `real` symbol table entry.
-              var e = st.addEntry(rname, l.tupShape, real);
-              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
-            }
-            var e = st.addEntry(rname, l.tupShape, int);
-            return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+        if binop_dtype_a == int && binop_dtype_b == int {
+          if boolOps.contains(op) {
+            return doBinOpvs(l, val, bool, op, pn, st);
+          } else if op == "/" {
+            // True division is the only case in this int, int case
+            // that results in a `real` symbol table entry.
+            return doBinOpvs(l, val, real, op, pn, st);
           }
-          when (DType.Int64, DType.Float64) {
-            var l = toSymEntry(left,int, nd);
-            var val = value.getRealValue();
-            // Only two possible resultant types are `bool` and `real`
-            // for this case
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, l.tupShape, bool);
-              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
-            }
-            var e = st.addEntry(rname, l.tupShape, real);
-            return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+          return doBinOpvs(l, val, int, op, pn, st);
+        } else if binop_dtype_a == int && binop_dtype_b == real {
+          // Only two possible resultant types are `bool` and `real`
+          // for this case
+          if boolOps.contains(op) {
+            return doBinOpvs(l, val, bool, op, pn, st);
           }
-          when (DType.Float64, DType.Int64) {
-            var l = toSymEntry(left,real, nd);
-            var val = value.getIntValue();
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, l.tupShape, bool);
-              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
-            }
-            var e = st.addEntry(rname, l.tupShape, real);
-            return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+          return doBinOpvs(l, val, real, op, pn, st);
+        }
+        else if binop_dtype_a == real && binop_dtype_b == int {
+          if boolOps.contains(op) {
+            return doBinOpvs(l, val, bool, op, pn, st);
           }
-          when (DType.UInt64, DType.Float64) {
-            var l = toSymEntry(left,uint, nd);
-            var val = value.getRealValue();
-            // Only two possible resultant types are `bool` and `real`
-            // for this case
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, l.tupShape, bool);
-              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
-            }
-            var e = st.addEntry(rname, l.tupShape, real);
-            return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+          return doBinOpvs(l, val, real, op, pn, st);
+        }
+        else if binop_dtype_a == uint && binop_dtype_b == real {
+          // Only two possible resultant types are `bool` and `real`
+          // for this case
+          if boolOps.contains(op) {
+            return doBinOpvs(l, val, bool, op, pn, st);
           }
-          when (DType.Float64, DType.UInt64) {
-            var l = toSymEntry(left,real, nd);
-            var val = value.getUIntValue();
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, l.tupShape, bool);
-              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
-            }
-            var e = st.addEntry(rname, l.tupShape, real);
-            return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+          return doBinOpvs(l, val, real, op, pn, st);
+        }
+        else if binop_dtype_a == real && binop_dtype_b == uint {
+          if boolOps.contains(op) {
+            return doBinOpvs(l, val, bool, op, pn, st);
           }
-          when (DType.Float64, DType.Float64) {
-            var l = toSymEntry(left,real, nd);
-            var val = value.getRealValue();
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, l.tupShape, bool);
-              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
-            }
-            var e = st.addEntry(rname, l.tupShape, real);
-            return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+          return doBinOpvs(l, val, real, op, pn, st);
+        }
+        else if binop_dtype_a == real && binop_dtype_b == real {
+          if boolOps.contains(op) {
+            return doBinOpvs(l, val, bool, op, pn, st);
           }
-          // For cases where a boolean operand is involved, the only
-          // possible resultant type is `bool`
-          when (DType.Bool, DType.Bool) {
-            var l = toSymEntry(left,bool, nd);
-            var val = value.getBoolValue();
-            if (op == "<<") || (op == ">>") {
-              var e = st.addEntry(rname, l.tupShape, int);
-              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
-            }
-            var e = st.addEntry(rname, l.tupShape, bool);
-            return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+          return doBinOpvs(l, val, real, op, pn, st);
+        }
+        // For cases where a boolean operand is involved, the only
+        // possible resultant type is `bool`
+        else if binop_dtype_a == bool && binop_dtype_b == bool {
+          if (op == "<<") || (op == ">>") {
+            return doBinOpvs(l, val, int, op, pn, st);
           }
-          when (DType.Bool, DType.Int64) {
-            var l = toSymEntry(left,bool, nd);
-            var val = value.getIntValue();
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, l.tupShape, bool);
-              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
-            }
-            var e = st.addEntry(rname, l.tupShape, int);
-            return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+          return doBinOpvs(l, val, bool, op, pn, st);
+        }
+        else if binop_dtype_a == bool && binop_dtype_b == int {
+          if boolOps.contains(op) {
+            return doBinOpvs(l, val, bool, op, pn, st);
           }
-          when (DType.Int64, DType.Bool) {
-            var l = toSymEntry(left,int, nd);
-            var val = value.getBoolValue();
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, l.tupShape, bool);
-              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
-            }
-            var e = st.addEntry(rname, l.tupShape, int);
-            return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+          return doBinOpvs(l, val, int, op, pn, st);
+        }
+        else if binop_dtype_a == int && binop_dtype_b == bool {
+          if boolOps.contains(op) {
+            return doBinOpvs(l, val, bool, op, pn, st);
           }
-          when (DType.Bool, DType.Float64) {
-            var l = toSymEntry(left,bool, nd);
-            var val = value.getRealValue();
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, l.tupShape, bool);
-              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
-            }
-            var e = st.addEntry(rname, l.tupShape, real);
-            return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+          return doBinOpvs(l, val, int, op, pn, st);
+        }
+        else if binop_dtype_a == bool && binop_dtype_b == real {
+          if boolOps.contains(op) {
+            return doBinOpvs(l, val, bool, op, pn, st);
           }
-          when (DType.Float64, DType.Bool) {
-            var l = toSymEntry(left,real, nd);
-            var val = value.getBoolValue();
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, l.tupShape, bool);
-              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
-            }
-            var e = st.addEntry(rname, l.tupShape, real);
-            return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+          return doBinOpvs(l, val, real, op, pn, st);
+        }
+        else if binop_dtype_a == real && binop_dtype_b == bool {
+          if boolOps.contains(op) {
+            return doBinOpvs(l, val, bool, op, pn, st);
           }
-          when (DType.Bool, DType.UInt64) {
-            var l = toSymEntry(left,bool, nd);
-            var val = value.getUIntValue();
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, l.tupShape, bool);
-              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
-            }
-            var e = st.addEntry(rname, l.tupShape, uint);
-            return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+          return doBinOpvs(l, val, real, op, pn, st);
+        }
+        else if binop_dtype_a == bool && binop_dtype_b == uint {
+          if boolOps.contains(op) {
+            return doBinOpvs(l, val, bool, op, pn, st);
           }
-          when (DType.UInt64, DType.Bool) {
-            var l = toSymEntry(left,uint, nd);
-            var val = value.getBoolValue();
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, l.tupShape, bool);
-              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
-            }
-            var e = st.addEntry(rname, l.tupShape, uint);
-            return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
+          return doBinOpvs(l, val, uint, op, pn, st);
+        }
+        else if binop_dtype_a == uint && binop_dtype_b == bool {
+          if boolOps.contains(op) {
+            return doBinOpvs(l, val, bool, op, pn, st);
           }
-          when (DType.UInt64, DType.UInt64) {
-            var l = toSymEntry(left,uint, nd);
-            var val = value.getUIntValue();
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, l.tupShape, bool);
-              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
-            }
-            if op == "/"{
-              var e = st.addEntry(rname, l.tupShape, real);
-              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
-            } else {
-              var e = st.addEntry(rname, l.tupShape, uint);
-              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
-            }
+          return doBinOpvs(l, val, uint, op, pn, st);
+        }
+        else if binop_dtype_a == uint && binop_dtype_b == uint {
+          if boolOps.contains(op) {
+            return doBinOpvs(l, val, bool, op, pn, st);
           }
-          when (DType.UInt64, DType.Int64) {
-            var l = toSymEntry(left,uint, nd);
-            var val = value.getIntValue();
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, l.tupShape, bool);
-              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
-            }
-            // +, -, /, // both result in real outputs to match NumPy
-            if realOps.contains(op) {
-              var e = st.addEntry(rname, l.tupShape, real);
-              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
-            } else {
-              // isn't +, -, /, // so we can use LHS to determine type
-              var e = st.addEntry(rname, l.tupShape, uint);
-              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
-            }
-          }
-          when (DType.Int64, DType.UInt64) {
-            var l = toSymEntry(left,int, nd);
-            var val = value.getUIntValue();
-            if boolOps.contains(op) {
-              var e = st.addEntry(rname, l.tupShape, bool);
-              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
-            }
-            // +, -, /, // both result in real outputs to match NumPy
-            if realOps.contains(op) {
-              var e = st.addEntry(rname, l.tupShape, real);
-              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
-            } else {
-              // isn't +, -, /, // so we can use LHS to determine type
-              var e = st.addEntry(rname, l.tupShape, int);
-              return doBinOpvs(l, val, e, op, dtype, rname, pn, st);
-            }
-          }
-          when (DType.BigInt, DType.BigInt) {
-            var l = toSymEntry(left,bigint, nd);
-            var val = value.getBigIntValue();
-            if boolOps.contains(op) {
-              // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
-              var repMsg = "created %s".format(st.attrib(rname));
-              return new MsgTuple(repMsg, MsgType.NORMAL);
-            }
-            // call bigint specific func which returns dist bigint array
-            var (tmp, max_bits) = doBigIntBinOpvs(l, val, op);
-            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
-            var repMsg = "created %s".format(st.attrib(rname));
-            return new MsgTuple(repMsg, MsgType.NORMAL);
-          }
-          when (DType.BigInt, DType.Int64) {
-            var l = toSymEntry(left,bigint, nd);
-            var val = value.getIntValue();
-            if boolOps.contains(op) {
-              // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
-              var repMsg = "created %s".format(st.attrib(rname));
-              return new MsgTuple(repMsg, MsgType.NORMAL);
-            }
-            // call bigint specific func which returns dist bigint array
-            var (tmp, max_bits) = doBigIntBinOpvs(l, val, op);
-            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
-            var repMsg = "created %s".format(st.attrib(rname));
-            return new MsgTuple(repMsg, MsgType.NORMAL);
-          }
-          when (DType.BigInt, DType.UInt64) {
-            var l = toSymEntry(left,bigint, nd);
-            var val = value.getUIntValue();
-            if boolOps.contains(op) {
-              // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
-              var repMsg = "created %s".format(st.attrib(rname));
-              return new MsgTuple(repMsg, MsgType.NORMAL);
-            }
-            // call bigint specific func which returns dist bigint array
-            var (tmp, max_bits) = doBigIntBinOpvs(l, val, op);
-            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
-            var repMsg = "created %s".format(st.attrib(rname));
-            return new MsgTuple(repMsg, MsgType.NORMAL);
-          }
-          when (DType.BigInt, DType.Bool) {
-            var l = toSymEntry(left,bigint, nd);
-            var val = value.getBoolValue();
-            if boolOps.contains(op) {
-              // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
-              var repMsg = "created %s".format(st.attrib(rname));
-              return new MsgTuple(repMsg, MsgType.NORMAL);
-            }
-            // call bigint specific func which returns dist bigint array
-            var (tmp, max_bits) = doBigIntBinOpvs(l, val, op);
-            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
-            var repMsg = "created %s".format(st.attrib(rname));
-            return new MsgTuple(repMsg, MsgType.NORMAL);
-          }
-          when (DType.Int64, DType.BigInt) {
-            var l = toSymEntry(left,int, nd);
-            var val = value.getBigIntValue();
-            if boolOps.contains(op) {
-              // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
-              var repMsg = "created %s".format(st.attrib(rname));
-              return new MsgTuple(repMsg, MsgType.NORMAL);
-            }
-            // call bigint specific func which returns dist bigint array
-            var (tmp, max_bits) = doBigIntBinOpvs(l, val, op);
-            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
-            var repMsg = "created %s".format(st.attrib(rname));
-            return new MsgTuple(repMsg, MsgType.NORMAL);
-          }
-          when (DType.UInt64, DType.BigInt) {
-            var l = toSymEntry(left,uint, nd);
-            var val = value.getBigIntValue();
-            if boolOps.contains(op) {
-              // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
-              var repMsg = "created %s".format(st.attrib(rname));
-              return new MsgTuple(repMsg, MsgType.NORMAL);
-            }
-            // call bigint specific func which returns dist bigint array
-            var (tmp, max_bits) = doBigIntBinOpvs(l, val, op);
-            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
-            var repMsg = "created %s".format(st.attrib(rname));
-            return new MsgTuple(repMsg, MsgType.NORMAL);
-          }
-          when (DType.Bool, DType.BigInt) {
-            var l = toSymEntry(left,bool, nd);
-            var val = value.getBigIntValue();
-            if boolOps.contains(op) {
-              // call bigint specific func which returns distr bool array
-              var e = st.addEntry(rname, createSymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
-              var repMsg = "created %s".format(st.attrib(rname));
-              return new MsgTuple(repMsg, MsgType.NORMAL);
-            }
-            // call bigint specific func which returns dist bigint array
-            var (tmp, max_bits) = doBigIntBinOpvs(l, val, op);
-            var e = st.addEntry(rname, createSymEntry(tmp, max_bits));
-            var repMsg = "created %s".format(st.attrib(rname));
-            return new MsgTuple(repMsg, MsgType.NORMAL);
+          if op == "/"{
+            return doBinOpvs(l, val, real, op, pn, st);
+          } else {
+            return doBinOpvs(l, val, uint, op, pn, st);
           }
         }
-        var errorMsg = unrecognizedTypeError(pn, "("+dtype2str(left.dtype)+","+dtype2str(dtype)+")");
-        omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-        return new MsgTuple(errorMsg, MsgType.ERROR);
+        else if binop_dtype_a == uint && binop_dtype_b == int {
+          if boolOps.contains(op) {
+            return doBinOpvs(l, val, bool, op, pn, st);
+          }
+          // +, -, /, // both result in real outputs to match NumPy
+          if realOps.contains(op) {
+            return doBinOpvs(l, val, real, op, pn, st);
+          } else {
+            // isn't +, -, /, // so we can use LHS to determine type
+            return doBinOpvs(l, val, uint, op, pn, st);
+          }
+        }
+        else if binop_dtype_a == int && binop_dtype_b == uint {
+          if boolOps.contains(op) {
+            return doBinOpvs(l, val, bool, op, pn, st);
+          }
+          // +, -, /, // both result in real outputs to match NumPy
+          if realOps.contains(op) {
+            return doBinOpvs(l, val, real, op, pn, st);
+          } else {
+            // isn't +, -, /, // so we can use LHS to determine type
+            return doBinOpvs(l, val, int, op, pn, st);
+          }
+        }
+        else if binop_dtype_a == bigint || binop_dtype_b == bigint {
+          if boolOps.contains(op) {
+            // call bigint specific func which returns distr bool array
+            return st.insert(new shared SymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
+          }
+          // call bigint specific func which returns dist bigint array
+          const (tmp, max_bits) = doBigIntBinOpvs(l, val, op);
+          return st.insert(new shared SymEntry(tmp, max_bits));
+        } else {
+          const errorMsg = unrecognizedTypeError(pn, "("+type2str(binop_dtype_a)+","+type2str(binop_dtype_b)+")");
+          omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+          return MsgTuple.error(errorMsg);
+        }
     }
 
     /*

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -194,7 +194,9 @@ module OperatorMsg
             return doBinOpvv(l, r, int, op, pn, st);
           }
         }
-        else if binop_dtype_a == bigint || binop_dtype_b == bigint {
+        else if (binop_dtype_a == bigint || binop_dtype_b == bigint) &&
+                !isRealType(binop_dtype_a) && !isRealType(binop_dtype_b)
+        {
           if boolOps.contains(op) {
             // call bigint specific func which returns distr bool array
             return st.insert(new shared SymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
@@ -379,7 +381,9 @@ module OperatorMsg
             return doBinOpvs(l, val, int, op, pn, st);
           }
         }
-        else if binop_dtype_a == bigint || binop_dtype_b == bigint {
+        else if (binop_dtype_a == bigint || binop_dtype_b == bigint) &&
+                !isRealType(binop_dtype_a) && !isRealType(binop_dtype_b)
+        {
           if boolOps.contains(op) {
             // call bigint specific func which returns distr bool array
             return st.insert(new shared SymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));

--- a/src/registry/Commands.chpl
+++ b/src/registry/Commands.chpl
@@ -1787,6 +1787,306 @@ proc ark_binopvs_bigint_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st:
   return OperatorMsg.binopvs(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=bigint, array_nd=1);
 registerFunction('binopvs<bigint,bigint,1>', ark_binopvs_bigint_bigint_1, 'OperatorMsg', 228);
 
+proc ark_binopsv_int_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopsv(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=int, array_nd=1);
+registerFunction('binopsv<int64,int64,1>', ark_binopsv_int_int_1, 'OperatorMsg', 415);
+
+proc ark_binopsv_int_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopsv(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=uint, array_nd=1);
+registerFunction('binopsv<int64,uint64,1>', ark_binopsv_int_uint_1, 'OperatorMsg', 415);
+
+proc ark_binopsv_int_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopsv(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=real, array_nd=1);
+registerFunction('binopsv<int64,float64,1>', ark_binopsv_int_real_1, 'OperatorMsg', 415);
+
+proc ark_binopsv_int_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopsv(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=bool, array_nd=1);
+registerFunction('binopsv<int64,bool,1>', ark_binopsv_int_bool_1, 'OperatorMsg', 415);
+
+proc ark_binopsv_int_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopsv(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=bigint, array_nd=1);
+registerFunction('binopsv<int64,bigint,1>', ark_binopsv_int_bigint_1, 'OperatorMsg', 415);
+
+proc ark_binopsv_uint_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopsv(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=int, array_nd=1);
+registerFunction('binopsv<uint64,int64,1>', ark_binopsv_uint_int_1, 'OperatorMsg', 415);
+
+proc ark_binopsv_uint_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopsv(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=uint, array_nd=1);
+registerFunction('binopsv<uint64,uint64,1>', ark_binopsv_uint_uint_1, 'OperatorMsg', 415);
+
+proc ark_binopsv_uint_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopsv(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=real, array_nd=1);
+registerFunction('binopsv<uint64,float64,1>', ark_binopsv_uint_real_1, 'OperatorMsg', 415);
+
+proc ark_binopsv_uint_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopsv(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=bool, array_nd=1);
+registerFunction('binopsv<uint64,bool,1>', ark_binopsv_uint_bool_1, 'OperatorMsg', 415);
+
+proc ark_binopsv_uint_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopsv(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=bigint, array_nd=1);
+registerFunction('binopsv<uint64,bigint,1>', ark_binopsv_uint_bigint_1, 'OperatorMsg', 415);
+
+proc ark_binopsv_real_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopsv(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=int, array_nd=1);
+registerFunction('binopsv<float64,int64,1>', ark_binopsv_real_int_1, 'OperatorMsg', 415);
+
+proc ark_binopsv_real_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopsv(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=uint, array_nd=1);
+registerFunction('binopsv<float64,uint64,1>', ark_binopsv_real_uint_1, 'OperatorMsg', 415);
+
+proc ark_binopsv_real_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopsv(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=real, array_nd=1);
+registerFunction('binopsv<float64,float64,1>', ark_binopsv_real_real_1, 'OperatorMsg', 415);
+
+proc ark_binopsv_real_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopsv(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=bool, array_nd=1);
+registerFunction('binopsv<float64,bool,1>', ark_binopsv_real_bool_1, 'OperatorMsg', 415);
+
+proc ark_binopsv_real_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopsv(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=bigint, array_nd=1);
+registerFunction('binopsv<float64,bigint,1>', ark_binopsv_real_bigint_1, 'OperatorMsg', 415);
+
+proc ark_binopsv_bool_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopsv(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=int, array_nd=1);
+registerFunction('binopsv<bool,int64,1>', ark_binopsv_bool_int_1, 'OperatorMsg', 415);
+
+proc ark_binopsv_bool_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopsv(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=uint, array_nd=1);
+registerFunction('binopsv<bool,uint64,1>', ark_binopsv_bool_uint_1, 'OperatorMsg', 415);
+
+proc ark_binopsv_bool_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopsv(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=real, array_nd=1);
+registerFunction('binopsv<bool,float64,1>', ark_binopsv_bool_real_1, 'OperatorMsg', 415);
+
+proc ark_binopsv_bool_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopsv(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=bool, array_nd=1);
+registerFunction('binopsv<bool,bool,1>', ark_binopsv_bool_bool_1, 'OperatorMsg', 415);
+
+proc ark_binopsv_bool_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopsv(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=bigint, array_nd=1);
+registerFunction('binopsv<bool,bigint,1>', ark_binopsv_bool_bigint_1, 'OperatorMsg', 415);
+
+proc ark_binopsv_bigint_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopsv(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=int, array_nd=1);
+registerFunction('binopsv<bigint,int64,1>', ark_binopsv_bigint_int_1, 'OperatorMsg', 415);
+
+proc ark_binopsv_bigint_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopsv(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=uint, array_nd=1);
+registerFunction('binopsv<bigint,uint64,1>', ark_binopsv_bigint_uint_1, 'OperatorMsg', 415);
+
+proc ark_binopsv_bigint_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopsv(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=real, array_nd=1);
+registerFunction('binopsv<bigint,float64,1>', ark_binopsv_bigint_real_1, 'OperatorMsg', 415);
+
+proc ark_binopsv_bigint_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopsv(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=bool, array_nd=1);
+registerFunction('binopsv<bigint,bool,1>', ark_binopsv_bigint_bool_1, 'OperatorMsg', 415);
+
+proc ark_binopsv_bigint_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopsv(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=bigint, array_nd=1);
+registerFunction('binopsv<bigint,bigint,1>', ark_binopsv_bigint_bigint_1, 'OperatorMsg', 415);
+
+proc ark_opeqvv_int_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvv(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=int, array_nd=1);
+registerFunction('opeqvv<int64,int64,1>', ark_opeqvv_int_int_1, 'OperatorMsg', 599);
+
+proc ark_opeqvv_int_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvv(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=uint, array_nd=1);
+registerFunction('opeqvv<int64,uint64,1>', ark_opeqvv_int_uint_1, 'OperatorMsg', 599);
+
+proc ark_opeqvv_int_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvv(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=real, array_nd=1);
+registerFunction('opeqvv<int64,float64,1>', ark_opeqvv_int_real_1, 'OperatorMsg', 599);
+
+proc ark_opeqvv_int_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvv(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=bool, array_nd=1);
+registerFunction('opeqvv<int64,bool,1>', ark_opeqvv_int_bool_1, 'OperatorMsg', 599);
+
+proc ark_opeqvv_int_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvv(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=bigint, array_nd=1);
+registerFunction('opeqvv<int64,bigint,1>', ark_opeqvv_int_bigint_1, 'OperatorMsg', 599);
+
+proc ark_opeqvv_uint_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvv(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=int, array_nd=1);
+registerFunction('opeqvv<uint64,int64,1>', ark_opeqvv_uint_int_1, 'OperatorMsg', 599);
+
+proc ark_opeqvv_uint_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvv(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=uint, array_nd=1);
+registerFunction('opeqvv<uint64,uint64,1>', ark_opeqvv_uint_uint_1, 'OperatorMsg', 599);
+
+proc ark_opeqvv_uint_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvv(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=real, array_nd=1);
+registerFunction('opeqvv<uint64,float64,1>', ark_opeqvv_uint_real_1, 'OperatorMsg', 599);
+
+proc ark_opeqvv_uint_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvv(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=bool, array_nd=1);
+registerFunction('opeqvv<uint64,bool,1>', ark_opeqvv_uint_bool_1, 'OperatorMsg', 599);
+
+proc ark_opeqvv_uint_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvv(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=bigint, array_nd=1);
+registerFunction('opeqvv<uint64,bigint,1>', ark_opeqvv_uint_bigint_1, 'OperatorMsg', 599);
+
+proc ark_opeqvv_real_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvv(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=int, array_nd=1);
+registerFunction('opeqvv<float64,int64,1>', ark_opeqvv_real_int_1, 'OperatorMsg', 599);
+
+proc ark_opeqvv_real_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvv(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=uint, array_nd=1);
+registerFunction('opeqvv<float64,uint64,1>', ark_opeqvv_real_uint_1, 'OperatorMsg', 599);
+
+proc ark_opeqvv_real_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvv(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=real, array_nd=1);
+registerFunction('opeqvv<float64,float64,1>', ark_opeqvv_real_real_1, 'OperatorMsg', 599);
+
+proc ark_opeqvv_real_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvv(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=bool, array_nd=1);
+registerFunction('opeqvv<float64,bool,1>', ark_opeqvv_real_bool_1, 'OperatorMsg', 599);
+
+proc ark_opeqvv_real_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvv(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=bigint, array_nd=1);
+registerFunction('opeqvv<float64,bigint,1>', ark_opeqvv_real_bigint_1, 'OperatorMsg', 599);
+
+proc ark_opeqvv_bool_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvv(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=int, array_nd=1);
+registerFunction('opeqvv<bool,int64,1>', ark_opeqvv_bool_int_1, 'OperatorMsg', 599);
+
+proc ark_opeqvv_bool_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvv(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=uint, array_nd=1);
+registerFunction('opeqvv<bool,uint64,1>', ark_opeqvv_bool_uint_1, 'OperatorMsg', 599);
+
+proc ark_opeqvv_bool_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvv(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=real, array_nd=1);
+registerFunction('opeqvv<bool,float64,1>', ark_opeqvv_bool_real_1, 'OperatorMsg', 599);
+
+proc ark_opeqvv_bool_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvv(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=bool, array_nd=1);
+registerFunction('opeqvv<bool,bool,1>', ark_opeqvv_bool_bool_1, 'OperatorMsg', 599);
+
+proc ark_opeqvv_bool_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvv(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=bigint, array_nd=1);
+registerFunction('opeqvv<bool,bigint,1>', ark_opeqvv_bool_bigint_1, 'OperatorMsg', 599);
+
+proc ark_opeqvv_bigint_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvv(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=int, array_nd=1);
+registerFunction('opeqvv<bigint,int64,1>', ark_opeqvv_bigint_int_1, 'OperatorMsg', 599);
+
+proc ark_opeqvv_bigint_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvv(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=uint, array_nd=1);
+registerFunction('opeqvv<bigint,uint64,1>', ark_opeqvv_bigint_uint_1, 'OperatorMsg', 599);
+
+proc ark_opeqvv_bigint_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvv(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=real, array_nd=1);
+registerFunction('opeqvv<bigint,float64,1>', ark_opeqvv_bigint_real_1, 'OperatorMsg', 599);
+
+proc ark_opeqvv_bigint_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvv(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=bool, array_nd=1);
+registerFunction('opeqvv<bigint,bool,1>', ark_opeqvv_bigint_bool_1, 'OperatorMsg', 599);
+
+proc ark_opeqvv_bigint_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvv(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=bigint, array_nd=1);
+registerFunction('opeqvv<bigint,bigint,1>', ark_opeqvv_bigint_bigint_1, 'OperatorMsg', 599);
+
+proc ark_opeqvs_int_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvs(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=int, array_nd=1);
+registerFunction('opeqvs<int64,int64,1>', ark_opeqvs_int_int_1, 'OperatorMsg', 1066);
+
+proc ark_opeqvs_int_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvs(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=uint, array_nd=1);
+registerFunction('opeqvs<int64,uint64,1>', ark_opeqvs_int_uint_1, 'OperatorMsg', 1066);
+
+proc ark_opeqvs_int_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvs(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=real, array_nd=1);
+registerFunction('opeqvs<int64,float64,1>', ark_opeqvs_int_real_1, 'OperatorMsg', 1066);
+
+proc ark_opeqvs_int_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvs(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=bool, array_nd=1);
+registerFunction('opeqvs<int64,bool,1>', ark_opeqvs_int_bool_1, 'OperatorMsg', 1066);
+
+proc ark_opeqvs_int_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvs(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=bigint, array_nd=1);
+registerFunction('opeqvs<int64,bigint,1>', ark_opeqvs_int_bigint_1, 'OperatorMsg', 1066);
+
+proc ark_opeqvs_uint_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvs(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=int, array_nd=1);
+registerFunction('opeqvs<uint64,int64,1>', ark_opeqvs_uint_int_1, 'OperatorMsg', 1066);
+
+proc ark_opeqvs_uint_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvs(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=uint, array_nd=1);
+registerFunction('opeqvs<uint64,uint64,1>', ark_opeqvs_uint_uint_1, 'OperatorMsg', 1066);
+
+proc ark_opeqvs_uint_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvs(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=real, array_nd=1);
+registerFunction('opeqvs<uint64,float64,1>', ark_opeqvs_uint_real_1, 'OperatorMsg', 1066);
+
+proc ark_opeqvs_uint_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvs(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=bool, array_nd=1);
+registerFunction('opeqvs<uint64,bool,1>', ark_opeqvs_uint_bool_1, 'OperatorMsg', 1066);
+
+proc ark_opeqvs_uint_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvs(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=bigint, array_nd=1);
+registerFunction('opeqvs<uint64,bigint,1>', ark_opeqvs_uint_bigint_1, 'OperatorMsg', 1066);
+
+proc ark_opeqvs_real_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvs(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=int, array_nd=1);
+registerFunction('opeqvs<float64,int64,1>', ark_opeqvs_real_int_1, 'OperatorMsg', 1066);
+
+proc ark_opeqvs_real_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvs(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=uint, array_nd=1);
+registerFunction('opeqvs<float64,uint64,1>', ark_opeqvs_real_uint_1, 'OperatorMsg', 1066);
+
+proc ark_opeqvs_real_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvs(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=real, array_nd=1);
+registerFunction('opeqvs<float64,float64,1>', ark_opeqvs_real_real_1, 'OperatorMsg', 1066);
+
+proc ark_opeqvs_real_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvs(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=bool, array_nd=1);
+registerFunction('opeqvs<float64,bool,1>', ark_opeqvs_real_bool_1, 'OperatorMsg', 1066);
+
+proc ark_opeqvs_real_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvs(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=bigint, array_nd=1);
+registerFunction('opeqvs<float64,bigint,1>', ark_opeqvs_real_bigint_1, 'OperatorMsg', 1066);
+
+proc ark_opeqvs_bool_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvs(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=int, array_nd=1);
+registerFunction('opeqvs<bool,int64,1>', ark_opeqvs_bool_int_1, 'OperatorMsg', 1066);
+
+proc ark_opeqvs_bool_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvs(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=uint, array_nd=1);
+registerFunction('opeqvs<bool,uint64,1>', ark_opeqvs_bool_uint_1, 'OperatorMsg', 1066);
+
+proc ark_opeqvs_bool_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvs(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=real, array_nd=1);
+registerFunction('opeqvs<bool,float64,1>', ark_opeqvs_bool_real_1, 'OperatorMsg', 1066);
+
+proc ark_opeqvs_bool_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvs(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=bool, array_nd=1);
+registerFunction('opeqvs<bool,bool,1>', ark_opeqvs_bool_bool_1, 'OperatorMsg', 1066);
+
+proc ark_opeqvs_bool_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvs(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=bigint, array_nd=1);
+registerFunction('opeqvs<bool,bigint,1>', ark_opeqvs_bool_bigint_1, 'OperatorMsg', 1066);
+
+proc ark_opeqvs_bigint_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvs(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=int, array_nd=1);
+registerFunction('opeqvs<bigint,int64,1>', ark_opeqvs_bigint_int_1, 'OperatorMsg', 1066);
+
+proc ark_opeqvs_bigint_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvs(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=uint, array_nd=1);
+registerFunction('opeqvs<bigint,uint64,1>', ark_opeqvs_bigint_uint_1, 'OperatorMsg', 1066);
+
+proc ark_opeqvs_bigint_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvs(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=real, array_nd=1);
+registerFunction('opeqvs<bigint,float64,1>', ark_opeqvs_bigint_real_1, 'OperatorMsg', 1066);
+
+proc ark_opeqvs_bigint_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvs(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=bool, array_nd=1);
+registerFunction('opeqvs<bigint,bool,1>', ark_opeqvs_bigint_bool_1, 'OperatorMsg', 1066);
+
+proc ark_opeqvs_bigint_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.opeqvs(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=bigint, array_nd=1);
+registerFunction('opeqvs<bigint,bigint,1>', ark_opeqvs_bigint_bigint_1, 'OperatorMsg', 1066);
+
 import RandMsg;
 
 proc ark_randint_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do

--- a/src/registry/Commands.chpl
+++ b/src/registry/Commands.chpl
@@ -1687,6 +1687,106 @@ proc ark_binopvv_bigint_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st:
   return OperatorMsg.binopvv(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=bigint, array_nd=1);
 registerFunction('binopvv<bigint,bigint,1>', ark_binopvv_bigint_bigint_1, 'OperatorMsg', 40);
 
+proc ark_binopvsMsg_int_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=int, array_nd=1);
+registerFunction('binopvsMsg<int64,int64,1>', ark_binopvsMsg_int_int_1, 'OperatorMsg', 280);
+
+proc ark_binopvsMsg_int_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=uint, array_nd=1);
+registerFunction('binopvsMsg<int64,uint64,1>', ark_binopvsMsg_int_uint_1, 'OperatorMsg', 280);
+
+proc ark_binopvsMsg_int_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=real, array_nd=1);
+registerFunction('binopvsMsg<int64,float64,1>', ark_binopvsMsg_int_real_1, 'OperatorMsg', 280);
+
+proc ark_binopvsMsg_int_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=bool, array_nd=1);
+registerFunction('binopvsMsg<int64,bool,1>', ark_binopvsMsg_int_bool_1, 'OperatorMsg', 280);
+
+proc ark_binopvsMsg_int_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=bigint, array_nd=1);
+registerFunction('binopvsMsg<int64,bigint,1>', ark_binopvsMsg_int_bigint_1, 'OperatorMsg', 280);
+
+proc ark_binopvsMsg_uint_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=int, array_nd=1);
+registerFunction('binopvsMsg<uint64,int64,1>', ark_binopvsMsg_uint_int_1, 'OperatorMsg', 280);
+
+proc ark_binopvsMsg_uint_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=uint, array_nd=1);
+registerFunction('binopvsMsg<uint64,uint64,1>', ark_binopvsMsg_uint_uint_1, 'OperatorMsg', 280);
+
+proc ark_binopvsMsg_uint_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=real, array_nd=1);
+registerFunction('binopvsMsg<uint64,float64,1>', ark_binopvsMsg_uint_real_1, 'OperatorMsg', 280);
+
+proc ark_binopvsMsg_uint_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=bool, array_nd=1);
+registerFunction('binopvsMsg<uint64,bool,1>', ark_binopvsMsg_uint_bool_1, 'OperatorMsg', 280);
+
+proc ark_binopvsMsg_uint_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=bigint, array_nd=1);
+registerFunction('binopvsMsg<uint64,bigint,1>', ark_binopvsMsg_uint_bigint_1, 'OperatorMsg', 280);
+
+proc ark_binopvsMsg_real_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=int, array_nd=1);
+registerFunction('binopvsMsg<float64,int64,1>', ark_binopvsMsg_real_int_1, 'OperatorMsg', 280);
+
+proc ark_binopvsMsg_real_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=uint, array_nd=1);
+registerFunction('binopvsMsg<float64,uint64,1>', ark_binopvsMsg_real_uint_1, 'OperatorMsg', 280);
+
+proc ark_binopvsMsg_real_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=real, array_nd=1);
+registerFunction('binopvsMsg<float64,float64,1>', ark_binopvsMsg_real_real_1, 'OperatorMsg', 280);
+
+proc ark_binopvsMsg_real_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=bool, array_nd=1);
+registerFunction('binopvsMsg<float64,bool,1>', ark_binopvsMsg_real_bool_1, 'OperatorMsg', 280);
+
+proc ark_binopvsMsg_real_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=bigint, array_nd=1);
+registerFunction('binopvsMsg<float64,bigint,1>', ark_binopvsMsg_real_bigint_1, 'OperatorMsg', 280);
+
+proc ark_binopvsMsg_bool_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=int, array_nd=1);
+registerFunction('binopvsMsg<bool,int64,1>', ark_binopvsMsg_bool_int_1, 'OperatorMsg', 280);
+
+proc ark_binopvsMsg_bool_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=uint, array_nd=1);
+registerFunction('binopvsMsg<bool,uint64,1>', ark_binopvsMsg_bool_uint_1, 'OperatorMsg', 280);
+
+proc ark_binopvsMsg_bool_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=real, array_nd=1);
+registerFunction('binopvsMsg<bool,float64,1>', ark_binopvsMsg_bool_real_1, 'OperatorMsg', 280);
+
+proc ark_binopvsMsg_bool_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=bool, array_nd=1);
+registerFunction('binopvsMsg<bool,bool,1>', ark_binopvsMsg_bool_bool_1, 'OperatorMsg', 280);
+
+proc ark_binopvsMsg_bool_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=bigint, array_nd=1);
+registerFunction('binopvsMsg<bool,bigint,1>', ark_binopvsMsg_bool_bigint_1, 'OperatorMsg', 280);
+
+proc ark_binopvsMsg_bigint_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=int, array_nd=1);
+registerFunction('binopvsMsg<bigint,int64,1>', ark_binopvsMsg_bigint_int_1, 'OperatorMsg', 280);
+
+proc ark_binopvsMsg_bigint_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=uint, array_nd=1);
+registerFunction('binopvsMsg<bigint,uint64,1>', ark_binopvsMsg_bigint_uint_1, 'OperatorMsg', 280);
+
+proc ark_binopvsMsg_bigint_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=real, array_nd=1);
+registerFunction('binopvsMsg<bigint,float64,1>', ark_binopvsMsg_bigint_real_1, 'OperatorMsg', 280);
+
+proc ark_binopvsMsg_bigint_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=bool, array_nd=1);
+registerFunction('binopvsMsg<bigint,bool,1>', ark_binopvsMsg_bigint_bool_1, 'OperatorMsg', 280);
+
+proc ark_binopvsMsg_bigint_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=bigint, array_nd=1);
+registerFunction('binopvsMsg<bigint,bigint,1>', ark_binopvsMsg_bigint_bigint_1, 'OperatorMsg', 280);
+
 import RandMsg;
 
 proc ark_randint_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do

--- a/src/registry/Commands.chpl
+++ b/src/registry/Commands.chpl
@@ -19,6 +19,15 @@ param regConfig = """
         "bool",
         "bigint"
       ]
+    },
+    "binop": {
+      "dtype": [
+        "int",
+        "uint",
+        "real",
+        "bool",
+        "bigint"
+      ]
     }
   }
 }
@@ -1575,6 +1584,108 @@ registerFunction('repeatFlat<bool,1>', ark_repeatFlat_bool_1, 'ManipulationMsg',
 proc ark_repeatFlat_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
   return ManipulationMsg.repeatFlatMsg(cmd, msgArgs, st, array_dtype=bigint, array_nd=1);
 registerFunction('repeatFlat<bigint,1>', ark_repeatFlat_bigint_1, 'ManipulationMsg', 902);
+
+import OperatorMsg;
+
+proc ark_binopvv_int_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvv(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=int, array_nd=1);
+registerFunction('binopvv<int64,int64,1>', ark_binopvv_int_int_1, 'OperatorMsg', 40);
+
+proc ark_binopvv_int_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvv(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=uint, array_nd=1);
+registerFunction('binopvv<int64,uint64,1>', ark_binopvv_int_uint_1, 'OperatorMsg', 40);
+
+proc ark_binopvv_int_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvv(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=real, array_nd=1);
+registerFunction('binopvv<int64,float64,1>', ark_binopvv_int_real_1, 'OperatorMsg', 40);
+
+proc ark_binopvv_int_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvv(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=bool, array_nd=1);
+registerFunction('binopvv<int64,bool,1>', ark_binopvv_int_bool_1, 'OperatorMsg', 40);
+
+proc ark_binopvv_int_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvv(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=bigint, array_nd=1);
+registerFunction('binopvv<int64,bigint,1>', ark_binopvv_int_bigint_1, 'OperatorMsg', 40);
+
+proc ark_binopvv_uint_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvv(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=int, array_nd=1);
+registerFunction('binopvv<uint64,int64,1>', ark_binopvv_uint_int_1, 'OperatorMsg', 40);
+
+proc ark_binopvv_uint_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvv(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=uint, array_nd=1);
+registerFunction('binopvv<uint64,uint64,1>', ark_binopvv_uint_uint_1, 'OperatorMsg', 40);
+
+proc ark_binopvv_uint_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvv(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=real, array_nd=1);
+registerFunction('binopvv<uint64,float64,1>', ark_binopvv_uint_real_1, 'OperatorMsg', 40);
+
+proc ark_binopvv_uint_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvv(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=bool, array_nd=1);
+registerFunction('binopvv<uint64,bool,1>', ark_binopvv_uint_bool_1, 'OperatorMsg', 40);
+
+proc ark_binopvv_uint_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvv(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=bigint, array_nd=1);
+registerFunction('binopvv<uint64,bigint,1>', ark_binopvv_uint_bigint_1, 'OperatorMsg', 40);
+
+proc ark_binopvv_real_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvv(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=int, array_nd=1);
+registerFunction('binopvv<float64,int64,1>', ark_binopvv_real_int_1, 'OperatorMsg', 40);
+
+proc ark_binopvv_real_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvv(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=uint, array_nd=1);
+registerFunction('binopvv<float64,uint64,1>', ark_binopvv_real_uint_1, 'OperatorMsg', 40);
+
+proc ark_binopvv_real_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvv(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=real, array_nd=1);
+registerFunction('binopvv<float64,float64,1>', ark_binopvv_real_real_1, 'OperatorMsg', 40);
+
+proc ark_binopvv_real_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvv(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=bool, array_nd=1);
+registerFunction('binopvv<float64,bool,1>', ark_binopvv_real_bool_1, 'OperatorMsg', 40);
+
+proc ark_binopvv_real_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvv(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=bigint, array_nd=1);
+registerFunction('binopvv<float64,bigint,1>', ark_binopvv_real_bigint_1, 'OperatorMsg', 40);
+
+proc ark_binopvv_bool_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvv(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=int, array_nd=1);
+registerFunction('binopvv<bool,int64,1>', ark_binopvv_bool_int_1, 'OperatorMsg', 40);
+
+proc ark_binopvv_bool_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvv(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=uint, array_nd=1);
+registerFunction('binopvv<bool,uint64,1>', ark_binopvv_bool_uint_1, 'OperatorMsg', 40);
+
+proc ark_binopvv_bool_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvv(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=real, array_nd=1);
+registerFunction('binopvv<bool,float64,1>', ark_binopvv_bool_real_1, 'OperatorMsg', 40);
+
+proc ark_binopvv_bool_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvv(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=bool, array_nd=1);
+registerFunction('binopvv<bool,bool,1>', ark_binopvv_bool_bool_1, 'OperatorMsg', 40);
+
+proc ark_binopvv_bool_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvv(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=bigint, array_nd=1);
+registerFunction('binopvv<bool,bigint,1>', ark_binopvv_bool_bigint_1, 'OperatorMsg', 40);
+
+proc ark_binopvv_bigint_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvv(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=int, array_nd=1);
+registerFunction('binopvv<bigint,int64,1>', ark_binopvv_bigint_int_1, 'OperatorMsg', 40);
+
+proc ark_binopvv_bigint_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvv(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=uint, array_nd=1);
+registerFunction('binopvv<bigint,uint64,1>', ark_binopvv_bigint_uint_1, 'OperatorMsg', 40);
+
+proc ark_binopvv_bigint_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvv(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=real, array_nd=1);
+registerFunction('binopvv<bigint,float64,1>', ark_binopvv_bigint_real_1, 'OperatorMsg', 40);
+
+proc ark_binopvv_bigint_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvv(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=bool, array_nd=1);
+registerFunction('binopvv<bigint,bool,1>', ark_binopvv_bigint_bool_1, 'OperatorMsg', 40);
+
+proc ark_binopvv_bigint_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvv(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=bigint, array_nd=1);
+registerFunction('binopvv<bigint,bigint,1>', ark_binopvv_bigint_bigint_1, 'OperatorMsg', 40);
 
 import RandMsg;
 

--- a/src/registry/Commands.chpl
+++ b/src/registry/Commands.chpl
@@ -1687,105 +1687,105 @@ proc ark_binopvv_bigint_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st:
   return OperatorMsg.binopvv(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=bigint, array_nd=1);
 registerFunction('binopvv<bigint,bigint,1>', ark_binopvv_bigint_bigint_1, 'OperatorMsg', 40);
 
-proc ark_binopvsMsg_int_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=int, array_nd=1);
-registerFunction('binopvsMsg<int64,int64,1>', ark_binopvsMsg_int_int_1, 'OperatorMsg', 280);
+proc ark_binopvs_int_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvs(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=int, array_nd=1);
+registerFunction('binopvs<int64,int64,1>', ark_binopvs_int_int_1, 'OperatorMsg', 228);
 
-proc ark_binopvsMsg_int_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=uint, array_nd=1);
-registerFunction('binopvsMsg<int64,uint64,1>', ark_binopvsMsg_int_uint_1, 'OperatorMsg', 280);
+proc ark_binopvs_int_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvs(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=uint, array_nd=1);
+registerFunction('binopvs<int64,uint64,1>', ark_binopvs_int_uint_1, 'OperatorMsg', 228);
 
-proc ark_binopvsMsg_int_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=real, array_nd=1);
-registerFunction('binopvsMsg<int64,float64,1>', ark_binopvsMsg_int_real_1, 'OperatorMsg', 280);
+proc ark_binopvs_int_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvs(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=real, array_nd=1);
+registerFunction('binopvs<int64,float64,1>', ark_binopvs_int_real_1, 'OperatorMsg', 228);
 
-proc ark_binopvsMsg_int_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=bool, array_nd=1);
-registerFunction('binopvsMsg<int64,bool,1>', ark_binopvsMsg_int_bool_1, 'OperatorMsg', 280);
+proc ark_binopvs_int_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvs(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=bool, array_nd=1);
+registerFunction('binopvs<int64,bool,1>', ark_binopvs_int_bool_1, 'OperatorMsg', 228);
 
-proc ark_binopvsMsg_int_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=bigint, array_nd=1);
-registerFunction('binopvsMsg<int64,bigint,1>', ark_binopvsMsg_int_bigint_1, 'OperatorMsg', 280);
+proc ark_binopvs_int_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvs(cmd, msgArgs, st, binop_dtype_a=int, binop_dtype_b=bigint, array_nd=1);
+registerFunction('binopvs<int64,bigint,1>', ark_binopvs_int_bigint_1, 'OperatorMsg', 228);
 
-proc ark_binopvsMsg_uint_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=int, array_nd=1);
-registerFunction('binopvsMsg<uint64,int64,1>', ark_binopvsMsg_uint_int_1, 'OperatorMsg', 280);
+proc ark_binopvs_uint_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvs(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=int, array_nd=1);
+registerFunction('binopvs<uint64,int64,1>', ark_binopvs_uint_int_1, 'OperatorMsg', 228);
 
-proc ark_binopvsMsg_uint_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=uint, array_nd=1);
-registerFunction('binopvsMsg<uint64,uint64,1>', ark_binopvsMsg_uint_uint_1, 'OperatorMsg', 280);
+proc ark_binopvs_uint_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvs(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=uint, array_nd=1);
+registerFunction('binopvs<uint64,uint64,1>', ark_binopvs_uint_uint_1, 'OperatorMsg', 228);
 
-proc ark_binopvsMsg_uint_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=real, array_nd=1);
-registerFunction('binopvsMsg<uint64,float64,1>', ark_binopvsMsg_uint_real_1, 'OperatorMsg', 280);
+proc ark_binopvs_uint_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvs(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=real, array_nd=1);
+registerFunction('binopvs<uint64,float64,1>', ark_binopvs_uint_real_1, 'OperatorMsg', 228);
 
-proc ark_binopvsMsg_uint_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=bool, array_nd=1);
-registerFunction('binopvsMsg<uint64,bool,1>', ark_binopvsMsg_uint_bool_1, 'OperatorMsg', 280);
+proc ark_binopvs_uint_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvs(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=bool, array_nd=1);
+registerFunction('binopvs<uint64,bool,1>', ark_binopvs_uint_bool_1, 'OperatorMsg', 228);
 
-proc ark_binopvsMsg_uint_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=bigint, array_nd=1);
-registerFunction('binopvsMsg<uint64,bigint,1>', ark_binopvsMsg_uint_bigint_1, 'OperatorMsg', 280);
+proc ark_binopvs_uint_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvs(cmd, msgArgs, st, binop_dtype_a=uint, binop_dtype_b=bigint, array_nd=1);
+registerFunction('binopvs<uint64,bigint,1>', ark_binopvs_uint_bigint_1, 'OperatorMsg', 228);
 
-proc ark_binopvsMsg_real_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=int, array_nd=1);
-registerFunction('binopvsMsg<float64,int64,1>', ark_binopvsMsg_real_int_1, 'OperatorMsg', 280);
+proc ark_binopvs_real_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvs(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=int, array_nd=1);
+registerFunction('binopvs<float64,int64,1>', ark_binopvs_real_int_1, 'OperatorMsg', 228);
 
-proc ark_binopvsMsg_real_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=uint, array_nd=1);
-registerFunction('binopvsMsg<float64,uint64,1>', ark_binopvsMsg_real_uint_1, 'OperatorMsg', 280);
+proc ark_binopvs_real_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvs(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=uint, array_nd=1);
+registerFunction('binopvs<float64,uint64,1>', ark_binopvs_real_uint_1, 'OperatorMsg', 228);
 
-proc ark_binopvsMsg_real_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=real, array_nd=1);
-registerFunction('binopvsMsg<float64,float64,1>', ark_binopvsMsg_real_real_1, 'OperatorMsg', 280);
+proc ark_binopvs_real_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvs(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=real, array_nd=1);
+registerFunction('binopvs<float64,float64,1>', ark_binopvs_real_real_1, 'OperatorMsg', 228);
 
-proc ark_binopvsMsg_real_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=bool, array_nd=1);
-registerFunction('binopvsMsg<float64,bool,1>', ark_binopvsMsg_real_bool_1, 'OperatorMsg', 280);
+proc ark_binopvs_real_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvs(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=bool, array_nd=1);
+registerFunction('binopvs<float64,bool,1>', ark_binopvs_real_bool_1, 'OperatorMsg', 228);
 
-proc ark_binopvsMsg_real_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=bigint, array_nd=1);
-registerFunction('binopvsMsg<float64,bigint,1>', ark_binopvsMsg_real_bigint_1, 'OperatorMsg', 280);
+proc ark_binopvs_real_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvs(cmd, msgArgs, st, binop_dtype_a=real, binop_dtype_b=bigint, array_nd=1);
+registerFunction('binopvs<float64,bigint,1>', ark_binopvs_real_bigint_1, 'OperatorMsg', 228);
 
-proc ark_binopvsMsg_bool_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=int, array_nd=1);
-registerFunction('binopvsMsg<bool,int64,1>', ark_binopvsMsg_bool_int_1, 'OperatorMsg', 280);
+proc ark_binopvs_bool_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvs(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=int, array_nd=1);
+registerFunction('binopvs<bool,int64,1>', ark_binopvs_bool_int_1, 'OperatorMsg', 228);
 
-proc ark_binopvsMsg_bool_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=uint, array_nd=1);
-registerFunction('binopvsMsg<bool,uint64,1>', ark_binopvsMsg_bool_uint_1, 'OperatorMsg', 280);
+proc ark_binopvs_bool_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvs(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=uint, array_nd=1);
+registerFunction('binopvs<bool,uint64,1>', ark_binopvs_bool_uint_1, 'OperatorMsg', 228);
 
-proc ark_binopvsMsg_bool_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=real, array_nd=1);
-registerFunction('binopvsMsg<bool,float64,1>', ark_binopvsMsg_bool_real_1, 'OperatorMsg', 280);
+proc ark_binopvs_bool_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvs(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=real, array_nd=1);
+registerFunction('binopvs<bool,float64,1>', ark_binopvs_bool_real_1, 'OperatorMsg', 228);
 
-proc ark_binopvsMsg_bool_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=bool, array_nd=1);
-registerFunction('binopvsMsg<bool,bool,1>', ark_binopvsMsg_bool_bool_1, 'OperatorMsg', 280);
+proc ark_binopvs_bool_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvs(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=bool, array_nd=1);
+registerFunction('binopvs<bool,bool,1>', ark_binopvs_bool_bool_1, 'OperatorMsg', 228);
 
-proc ark_binopvsMsg_bool_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=bigint, array_nd=1);
-registerFunction('binopvsMsg<bool,bigint,1>', ark_binopvsMsg_bool_bigint_1, 'OperatorMsg', 280);
+proc ark_binopvs_bool_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvs(cmd, msgArgs, st, binop_dtype_a=bool, binop_dtype_b=bigint, array_nd=1);
+registerFunction('binopvs<bool,bigint,1>', ark_binopvs_bool_bigint_1, 'OperatorMsg', 228);
 
-proc ark_binopvsMsg_bigint_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=int, array_nd=1);
-registerFunction('binopvsMsg<bigint,int64,1>', ark_binopvsMsg_bigint_int_1, 'OperatorMsg', 280);
+proc ark_binopvs_bigint_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvs(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=int, array_nd=1);
+registerFunction('binopvs<bigint,int64,1>', ark_binopvs_bigint_int_1, 'OperatorMsg', 228);
 
-proc ark_binopvsMsg_bigint_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=uint, array_nd=1);
-registerFunction('binopvsMsg<bigint,uint64,1>', ark_binopvsMsg_bigint_uint_1, 'OperatorMsg', 280);
+proc ark_binopvs_bigint_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvs(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=uint, array_nd=1);
+registerFunction('binopvs<bigint,uint64,1>', ark_binopvs_bigint_uint_1, 'OperatorMsg', 228);
 
-proc ark_binopvsMsg_bigint_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=real, array_nd=1);
-registerFunction('binopvsMsg<bigint,float64,1>', ark_binopvsMsg_bigint_real_1, 'OperatorMsg', 280);
+proc ark_binopvs_bigint_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvs(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=real, array_nd=1);
+registerFunction('binopvs<bigint,float64,1>', ark_binopvs_bigint_real_1, 'OperatorMsg', 228);
 
-proc ark_binopvsMsg_bigint_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=bool, array_nd=1);
-registerFunction('binopvsMsg<bigint,bool,1>', ark_binopvsMsg_bigint_bool_1, 'OperatorMsg', 280);
+proc ark_binopvs_bigint_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvs(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=bool, array_nd=1);
+registerFunction('binopvs<bigint,bool,1>', ark_binopvs_bigint_bool_1, 'OperatorMsg', 228);
 
-proc ark_binopvsMsg_bigint_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
-  return OperatorMsg.binopvsMsg(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=bigint, array_nd=1);
-registerFunction('binopvsMsg<bigint,bigint,1>', ark_binopvsMsg_bigint_bigint_1, 'OperatorMsg', 280);
+proc ark_binopvs_bigint_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return OperatorMsg.binopvs(cmd, msgArgs, st, binop_dtype_a=bigint, binop_dtype_b=bigint, array_nd=1);
+registerFunction('binopvs<bigint,bigint,1>', ark_binopvs_bigint_bigint_1, 'OperatorMsg', 228);
 
 import RandMsg;
 


### PR DESCRIPTION
Refactor `operatorMsg` to use `instantiateAndRegister`.

Because binary operations have traditionally not supported `uint(8)`, a separate parameter-class is added with all the scalar types except `uint(8)`. 