### PR TITLE
Closes #3720: Update `SetMsg` to use the new message framework

### DIFF
--- a/arkouda/array_api/set_functions.py
+++ b/arkouda/array_api/set_functions.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from .array_object import Array
-
 from typing import NamedTuple, cast
 
 from arkouda.client import generic_msg
-from arkouda.pdarrayclass import create_pdarray
+from arkouda.pdarrayclass import create_pdarray, create_pdarrays
+
+from .array_object import Array
 
 
 class UniqueAllResult(NamedTuple):
@@ -33,21 +33,21 @@ def unique_all(x: Array, /) -> UniqueAllResult:
     - the inverse indices that reconstruct `x` from the unique values
     - the counts of each unique value
     """
-    resp = cast(
-        str,
-        generic_msg(
-            cmd=f"uniqueAll{x.ndim}D",
-            args={"name": x._array},
-        ),
+    arrays = create_pdarrays(
+        cast(
+            str,
+            generic_msg(
+                cmd=f"uniqueAll<{x.dtype},{x.ndim}>",
+                args={"name": x._array},
+            ),
+        )
     )
 
-    arrays = [Array._new(create_pdarray(r)) for r in resp.split("+")]
-
     return UniqueAllResult(
-        values=arrays[0],
-        indices=arrays[1],
-        inverse_indices=arrays[2],
-        counts=arrays[3],
+        values=Array._new(arrays[0]),
+        indices=Array._new(arrays[1]),
+        inverse_indices=Array._new(arrays[2]),
+        counts=Array._new(arrays[3]),
     )
 
 
@@ -57,19 +57,19 @@ def unique_counts(x: Array, /) -> UniqueCountsResult:
     - the unique values in `x`
     - the counts of each unique value
     """
-    resp = cast(
-        str,
-        generic_msg(
-            cmd=f"uniqueCounts{x.ndim}D",
-            args={"name": x._array},
-        ),
+    arrays = create_pdarrays(
+        cast(
+            str,
+            generic_msg(
+                cmd=f"uniqueCounts<{x.dtype},{x.ndim}>",
+                args={"name": x._array},
+            ),
+        )
     )
 
-    arrays = [Array._new(create_pdarray(r)) for r in resp.split("+")]
-
     return UniqueCountsResult(
-        values=arrays[0],
-        counts=arrays[1],
+        values=Array._new(arrays[0]),
+        counts=Array._new(arrays[1]),
     )
 
 
@@ -79,19 +79,19 @@ def unique_inverse(x: Array, /) -> UniqueInverseResult:
     - the unique values in `x`
     - the inverse indices that reconstruct `x` from the unique values
     """
-    resp = cast(
-        str,
-        generic_msg(
-            cmd=f"uniqueInverse{x.ndim}D",
-            args={"name": x._array},
-        ),
+    arrays = create_pdarrays(
+        cast(
+            str,
+            generic_msg(
+                cmd=f"uniqueInverse<{x.dtype},{x.ndim}>",
+                args={"name": x._array},
+            ),
+        )
     )
 
-    arrays = [Array._new(create_pdarray(r)) for r in resp.split("+")]
-
     return UniqueInverseResult(
-        values=arrays[0],
-        inverse_indices=arrays[1],
+        values=Array._new(arrays[0]),
+        inverse_indices=Array._new(arrays[1]),
     )
 
 
@@ -104,7 +104,7 @@ def unique_values(x: Array, /) -> Array:
             cast(
                 str,
                 generic_msg(
-                    cmd=f"uniqueValues{x.ndim}D",
+                    cmd=f"uniqueValues<{x.dtype},{x.ndim}>",
                     args={"name": x._array},
                 ),
             )

--- a/src/registry/Commands.chpl
+++ b/src/registry/Commands.chpl
@@ -1760,6 +1760,104 @@ proc ark_nonzero_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrow
   return ReductionMsg.nonzero(cmd, msgArgs, st, array_dtype=bigint, array_nd=1);
 registerFunction('nonzero<bigint,1>', ark_nonzero_bigint_1, 'ReductionMsg', 325);
 
+import SetMsg;
+
+proc ark_uniqueValues_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return SetMsg.uniqueValues(cmd, msgArgs, st, array_dtype=int, array_nd=1);
+registerFunction('uniqueValues<int64,1>', ark_uniqueValues_int_1, 'SetMsg', 17);
+
+proc ark_uniqueValues_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return SetMsg.uniqueValues(cmd, msgArgs, st, array_dtype=uint, array_nd=1);
+registerFunction('uniqueValues<uint64,1>', ark_uniqueValues_uint_1, 'SetMsg', 17);
+
+proc ark_uniqueValues_uint8_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return SetMsg.uniqueValues(cmd, msgArgs, st, array_dtype=uint(8), array_nd=1);
+registerFunction('uniqueValues<uint8,1>', ark_uniqueValues_uint8_1, 'SetMsg', 17);
+
+proc ark_uniqueValues_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return SetMsg.uniqueValues(cmd, msgArgs, st, array_dtype=real, array_nd=1);
+registerFunction('uniqueValues<float64,1>', ark_uniqueValues_real_1, 'SetMsg', 17);
+
+proc ark_uniqueValues_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return SetMsg.uniqueValues(cmd, msgArgs, st, array_dtype=bool, array_nd=1);
+registerFunction('uniqueValues<bool,1>', ark_uniqueValues_bool_1, 'SetMsg', 17);
+
+proc ark_uniqueValues_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return SetMsg.uniqueValues(cmd, msgArgs, st, array_dtype=bigint, array_nd=1);
+registerFunction('uniqueValues<bigint,1>', ark_uniqueValues_bigint_1, 'SetMsg', 17);
+
+proc ark_uniqueCounts_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return SetMsg.uniqueCounts(cmd, msgArgs, st, array_dtype=int, array_nd=1);
+registerFunction('uniqueCounts<int64,1>', ark_uniqueCounts_int_1, 'SetMsg', 37);
+
+proc ark_uniqueCounts_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return SetMsg.uniqueCounts(cmd, msgArgs, st, array_dtype=uint, array_nd=1);
+registerFunction('uniqueCounts<uint64,1>', ark_uniqueCounts_uint_1, 'SetMsg', 37);
+
+proc ark_uniqueCounts_uint8_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return SetMsg.uniqueCounts(cmd, msgArgs, st, array_dtype=uint(8), array_nd=1);
+registerFunction('uniqueCounts<uint8,1>', ark_uniqueCounts_uint8_1, 'SetMsg', 37);
+
+proc ark_uniqueCounts_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return SetMsg.uniqueCounts(cmd, msgArgs, st, array_dtype=real, array_nd=1);
+registerFunction('uniqueCounts<float64,1>', ark_uniqueCounts_real_1, 'SetMsg', 37);
+
+proc ark_uniqueCounts_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return SetMsg.uniqueCounts(cmd, msgArgs, st, array_dtype=bool, array_nd=1);
+registerFunction('uniqueCounts<bool,1>', ark_uniqueCounts_bool_1, 'SetMsg', 37);
+
+proc ark_uniqueCounts_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return SetMsg.uniqueCounts(cmd, msgArgs, st, array_dtype=bigint, array_nd=1);
+registerFunction('uniqueCounts<bigint,1>', ark_uniqueCounts_bigint_1, 'SetMsg', 37);
+
+proc ark_uniqueInverse_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return SetMsg.uniqueInverse(cmd, msgArgs, st, array_dtype=int, array_nd=1);
+registerFunction('uniqueInverse<int64,1>', ark_uniqueInverse_int_1, 'SetMsg', 58);
+
+proc ark_uniqueInverse_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return SetMsg.uniqueInverse(cmd, msgArgs, st, array_dtype=uint, array_nd=1);
+registerFunction('uniqueInverse<uint64,1>', ark_uniqueInverse_uint_1, 'SetMsg', 58);
+
+proc ark_uniqueInverse_uint8_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return SetMsg.uniqueInverse(cmd, msgArgs, st, array_dtype=uint(8), array_nd=1);
+registerFunction('uniqueInverse<uint8,1>', ark_uniqueInverse_uint8_1, 'SetMsg', 58);
+
+proc ark_uniqueInverse_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return SetMsg.uniqueInverse(cmd, msgArgs, st, array_dtype=real, array_nd=1);
+registerFunction('uniqueInverse<float64,1>', ark_uniqueInverse_real_1, 'SetMsg', 58);
+
+proc ark_uniqueInverse_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return SetMsg.uniqueInverse(cmd, msgArgs, st, array_dtype=bool, array_nd=1);
+registerFunction('uniqueInverse<bool,1>', ark_uniqueInverse_bool_1, 'SetMsg', 58);
+
+proc ark_uniqueInverse_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return SetMsg.uniqueInverse(cmd, msgArgs, st, array_dtype=bigint, array_nd=1);
+registerFunction('uniqueInverse<bigint,1>', ark_uniqueInverse_bigint_1, 'SetMsg', 58);
+
+proc ark_uniqueAll_int_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return SetMsg.uniqueAll(cmd, msgArgs, st, array_dtype=int, array_nd=1);
+registerFunction('uniqueAll<int64,1>', ark_uniqueAll_int_1, 'SetMsg', 78);
+
+proc ark_uniqueAll_uint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return SetMsg.uniqueAll(cmd, msgArgs, st, array_dtype=uint, array_nd=1);
+registerFunction('uniqueAll<uint64,1>', ark_uniqueAll_uint_1, 'SetMsg', 78);
+
+proc ark_uniqueAll_uint8_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return SetMsg.uniqueAll(cmd, msgArgs, st, array_dtype=uint(8), array_nd=1);
+registerFunction('uniqueAll<uint8,1>', ark_uniqueAll_uint8_1, 'SetMsg', 78);
+
+proc ark_uniqueAll_real_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return SetMsg.uniqueAll(cmd, msgArgs, st, array_dtype=real, array_nd=1);
+registerFunction('uniqueAll<float64,1>', ark_uniqueAll_real_1, 'SetMsg', 78);
+
+proc ark_uniqueAll_bool_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return SetMsg.uniqueAll(cmd, msgArgs, st, array_dtype=bool, array_nd=1);
+registerFunction('uniqueAll<bool,1>', ark_uniqueAll_bool_1, 'SetMsg', 78);
+
+proc ark_uniqueAll_bigint_1(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws do
+  return SetMsg.uniqueAll(cmd, msgArgs, st, array_dtype=bigint, array_nd=1);
+registerFunction('uniqueAll<bigint,1>', ark_uniqueAll_bigint_1, 'SetMsg', 78);
+
 import StatsMsg;
 
 proc ark_reg_mean_generic(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype_0, param array_nd_0: int): MsgTuple throws {

--- a/tests/array_api/set_functions.py
+++ b/tests/array_api/set_functions.py
@@ -1,5 +1,3 @@
-import json
-
 import numpy as np
 import pytest
 
@@ -10,7 +8,16 @@ SEED = 314159
 s = SEED
 
 
-def randArr(shape):
+def ret_shapes():
+    shapes = [1000]
+    if pytest.max_rank > 1:
+        shapes.append((20, 50))
+    if pytest.max_rank > 2:
+        shapes.append((2, 10, 50))
+    return shapes
+
+
+def rand_arr(shape):
     global s
     s += 2
     return xp.asarray(ak.randint(0, 100, shape, dtype=ak.int64, seed=s))
@@ -18,11 +25,9 @@ def randArr(shape):
 
 class TestSetFunction:
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
     def test_set_functions(self):
-
-        for shape in [(1000), (20, 50), (2, 10, 50)]:
-            r = randArr(shape)
+        for shape in ret_shapes():
+            r = rand_arr(shape)
 
             ua = xp.unique_all(r)
             uc = xp.unique_counts(r)


### PR DESCRIPTION
This PR (Closes #3720) updates `SetMsg` to use the new message framework and modifies the test to run with less than 3 dims