### PR TITLE
Argsort performance fix for float64

### DIFF
--- a/arkouda/sorting.py
+++ b/arkouda/sorting.py
@@ -94,7 +94,6 @@ def argsort(
             args={
                 "name": pda.name,
                 "algoName": algorithm.name,
-                "objType": pda.objType,
                 "axis": axis,
             },
         )

--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -432,10 +432,15 @@ module ArgSortMsg
               algoName = msgArgs["algoName"].toScalar(string),
               algorithm = getSortingAlgoritm(algoName),
               axis =  msgArgs["axis"].toScalar(int),
-              symEntry = st[msgArgs["name"]]: SymEntry(array_dtype, array_nd),
-              vals = if (array_dtype == bool) then (symEntry.a:int) else (symEntry.a: array_dtype);
-    
-        const iv = argsortDefault(vals, algorithm=algorithm, axis);
+              symEntry = st[msgArgs["name"]]: SymEntry(array_dtype, array_nd);
+
+        const iv;
+        if array_dtype == bool {
+          var int_vals = makeDistArray(symEntry.a:int);
+          iv = argsortDefault(int_vals, algorithm=algorithm, axis);
+        } else {
+          iv = argsortDefault(symEntry.a, algorithm=algorithm, axis);
+        }
         return st.insert(new shared SymEntry(iv));
     }
 

--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -430,17 +430,12 @@ module ArgSortMsg
     {
         const name = msgArgs["name"],
               algoName = msgArgs["algoName"].toScalar(string),
-              algorithm = getSortingAlgoritm(algoName),
+              algorithm = if array_dtype == real then defaultSortAlgorithm else getSortingAlgoritm(algoName),
               axis =  msgArgs["axis"].toScalar(int),
-              symEntry = st[msgArgs["name"]]: SymEntry(array_dtype, array_nd);
+              symEntry = st[msgArgs["name"]]: borrowed SymEntry(array_dtype, array_nd),
+              vals = if (array_dtype == bool) then (symEntry.a:int) else (symEntry.a: array_dtype);
 
-        const iv;
-        if array_dtype == bool {
-          var int_vals = makeDistArray(symEntry.a:int);
-          iv = argsortDefault(int_vals, algorithm=algorithm, axis);
-        } else {
-          iv = argsortDefault(symEntry.a, algorithm=algorithm, axis);
-        }
+        const iv = argsortDefault(vals, algorithm=algorithm, axis);
         return st.insert(new shared SymEntry(iv));
     }
 


### PR DESCRIPTION
Fixes the drop in float64 MSD radix sort performance observed [here](https://chapel-lang.org/perf/arkouda/16-node-xc/?startdate=2024/07/20&enddate=2024/08/22&configs=release&graphs=uniformlydistributeddata,powerlawdistributeddata).