### PR TITLE
Parallel sparseMatrixtoPdarray implementation

### DIFF
--- a/src/SparseMatrix.chpl
+++ b/src/SparseMatrix.chpl
@@ -350,7 +350,7 @@ module SparseMatrix {
 
     // update the column groups with the previous group's sum
     // (the 0'th column group is already correct)
-    coforall cg in 0..<nColGroups with (ref rowBlockStartOffsets) {
+    coforall cg in 1..<nColGroups with (ref rowBlockStartOffsets) {
       const colBlockIdx = cg / nTasksPerColBlock;
       on grid[0, colBlockIdx] {
         const jStart = cg * nColsPerGroup + 1,

--- a/src/SparseMatrixMsg.chpl
+++ b/src/SparseMatrixMsg.chpl
@@ -92,11 +92,11 @@ module SparseMatrixMsg {
         if gEnt.layoutStr=="CSC" {
             // Hardcode for int right now
             var sparrayEntry = gEnt.toSparseSymEntry(int, dimensions=2, layout.CSC);
-            sparseMatToPdarray(sparrayEntry.a, rows, cols, vals);
+            sparseMatToPdarrayCSC(sparrayEntry.a, rows, cols, vals);
         } else if gEnt.layoutStr=="CSR" {
             // Hardcode for int right now
             var sparrayEntry = gEnt.toSparseSymEntry(int, dimensions=2, layout.CSR);
-            sparseMatToPdarray(sparrayEntry.a, rows, cols, vals);
+            sparseMatToPdarrayCSR(sparrayEntry.a, rows, cols, vals);
         } else {
             throw getErrorWithContext(
                                     msg="unsupported layout for sparse matrix: %s".format(gEnt.layoutStr),


### PR DESCRIPTION
Adds a parallel and distributed implementation of the sparse-matrix to pdarray conversion algorithm that creates three pdarrays populated with: rows, columns, and values.

This hasn't been fully tested for distributed sparse arrays yet, but the algorithm should be ready to work with them once `SparseSymEntry` is updated to be distributed.