### PR TITLE
Clean up registerCommands.py script

### DIFF
--- a/src/registry/register_commands.py
+++ b/src/registry/register_commands.py
@@ -858,8 +858,6 @@ def gen_command_proc(name, return_type, formals, mod_name):
         )
     ]
 
-    print(array_etype_queries)
-
     # assume the returned type is a symbol if it's an identifier that is not a scalar or type-query reference
     # or if it is a `SymEntry` type-constructor call
     returns_symbol = (

--- a/src/registry/register_commands.py
+++ b/src/registry/register_commands.py
@@ -1,6 +1,7 @@
 import itertools
 import json
 import sys
+from enum import Enum
 
 import chapel
 
@@ -113,12 +114,47 @@ class FormalQueryRef:
         return self.name
 
 
-class StaticType:
-    def __init__(self, name):
-        self.name = name
+class StaticTypeInfo:
+    def __init__(self, value):
+        self.value = value
 
-    def name(self):
-        return self.name
+    def value(self):
+        return self.value
+
+
+class formalKind(Enum):
+    ARRAY = 1
+    LIST = 2
+    BORROWED_CLASS = 3
+    HOMOG_TUPLE = 4
+    SCALAR = 5
+
+
+class FormalTypeSpec:
+    def __init__(self, kind, name, storage_kind, type_str=None, info=None):
+        self.kind = kind
+        self.name = name
+        self.storage_kind = storage_kind
+        self.type_str = type_str
+        self.info = [] if info is None else (info if isinstance(info, list) else [info,])
+
+    def append_info(self, info):
+        self.info.append(info)
+
+    def info(self):
+        return self.info
+
+    def is_generic(self) -> bool:
+        return self.storage_kind in ["type", "param"]
+
+    def is_untyped(self) -> bool:
+        return self.kind == formalKind.SCALAR and self.type_str is None
+
+    def is_chapel_scalar_type(self) -> bool:
+        return self.kind == formalKind.SCALAR and self.type_str in chapel_scalar_types
+
+    def stringify(self) -> str:
+        return f"{self.storage_kind} {self.name}: {self.type_str}" if self.type_str else f"{self.storage_kind} {self.name}"
 
 
 def get_formals(fn, require_type_annotations):
@@ -130,39 +166,42 @@ def get_formals(fn, require_type_annotations):
     presence of a type-query in a bracket-loop type expression
     """
 
-    def info_tuple(formal):
-        ten = None
-        extra_info = None
+    def get_formal_type_spec(formal):
+        name = formal.name()
+        sk = formal.storage_kind()
         if te := formal.type_expression():
-            if isinstance(te, chapel.BracketLoop):
+            if isinstance(te, chapel.BracketLoop):  # Array types
                 if te.is_maybe_array_type():
-                    ten = "<array>"
-                    extra_info = [None, None]
+                    ft = FormalTypeSpec(formalKind.ARRAY, name, sk)
 
-                    # record domain query name if any
+                    # record domain query name, if any
                     if isinstance(te.iterand(), chapel.TypeQuery):
-                        extra_info[0] = FormalQuery(te.iterand().name())
+                        dom_q = FormalQuery(te.iterand().name())
                     else:
+                        # hack: chapel-py doesn't have a way to get the text/body of a block (I think)
                         block_text = extract_ast_block_text(te.iterand())
-                        extra_info[0] = FormalQueryRef(block_text)
+                        dom_q = FormalQueryRef(block_text)
+                    ft.append_info(dom_q)
 
-                    # record element type query if any
+                    # record element type query, if any
+                    elt_q = None
                     if isinstance(te.body(), chapel.Block):
                         # hack: chapel-py doesn't have a way to get the text/body of a block (I think)
                         block_text = extract_ast_block_text(te.body())
 
                         if block_text[0] == "?":
-                            extra_info[1] = FormalQuery(block_text[1:])
+                            elt_q = FormalQuery(block_text[1:])
                         elif block_text in chapel_scalar_types.keys():
-                            extra_info[1] = StaticType(block_text)
+                            elt_q = StaticTypeInfo(block_text)
                         else:
-                            extra_info[1] = FormalQueryRef(block_text)
+                            elt_q = FormalQueryRef(block_text)
+                    ft.append_info(elt_q)
 
-                    extra_info = tuple(extra_info)
+                    return ft
                 else:
                     # TODO:  `x: []` and `x: [?d]` are currently treated as invalid formal type expressions
                     raise ValueError("invalid formal type expression")
-            elif isinstance(te, chapel.FnCall):
+            elif isinstance(te, chapel.FnCall):  # Composite types (list and borrowed-class)
                 if ce := te.called_expression():
                     if isinstance(ce, chapel.Identifier):
                         call_name = ce.name()
@@ -171,49 +210,67 @@ def get_formals(fn, require_type_annotations):
                             if list_type not in chapel_scalar_types:
                                 error_message(
                                     f"registering '{fn.name()}'",
-                                    f"unsupported formal type for registration {list_type}",
+                                    f"unsupported formal type for registration {list_type}; list element type must be a scalar",
                                 )
                             else:
-                                ten = f"list,{list_type}"
+                                return FormalTypeSpec(formalKind.LIST, name, sk, info=list_type)
                         elif call_name == "borrowed":
                             ten = call_name + " " + list(te.actuals())[0].name()
+                            return FormalTypeSpec(formalKind.BORROWED_CLASS, name, sk, ten)
                         else:
                             error_message(
                                 f"registering '{fn.name()}'",
                                 f"unsupported composite type expression for registration {call_name}",
                             )
-            elif isinstance(te, chapel.OpCall) and te.is_binary_op() and te.op() == "*":
-                ten = "<homog_tuple>"
-                actuals = list(te.actuals())
-
-                # check the tuple element type (must be an identifier - either corresponding to a scalar type or a dtype query)
-                if isinstance(actuals[1], chapel.Identifier):
-                    tuple_elt_type = actuals[1].name()
+                    else:
+                        error_message(
+                            f"registering '{fn.name()}'",
+                            f"unsupported type expression for registration {extract_ast_block_text(te.body())}",
+                        )
                 else:
                     error_message(
                         f"registering '{fn.name()}'",
-                        f"unsupported homog_tuple type expression for registration on formal '{formal.name()}'; "
-                        + f"tuple element type must be an identifier (either a scalar type or a queried dtype)",
+                        f"unsupported type expression for registration {extract_ast_block_text(te.body())}",
                     )
+            elif isinstance(te, chapel.OpCall) and te.is_binary_op() and te.op() == "*":  # Homog. Tuple types
+                ft = FormalTypeSpec(formalKind.HOMOG_TUPLE, name, sk)
+                actuals = list(te.actuals())
 
                 # check the tuple size (should be an int literal or a queried domain's rank)
                 if isinstance(actuals[0], chapel.IntLiteral):
-                    extra_info = (int(actuals[0].text()), tuple_elt_type)
+                    ft.append_info(StaticTypeInfo(int(actuals[0].text())))
                 elif (
                     isinstance(actuals[0], chapel.Dot)
                     and actuals[0].field() == "rank"
                     and isinstance(actuals[0].receiver(), chapel.Identifier)
                 ):
-                    extra_info = (actuals[0].receiver().name(), tuple_elt_type)
+                    ft.append_info(FormalQueryRef(actuals[0].receiver().name()))
                 else:
                     error_message(
                         f"registering '{fn.name()}'",
                         f"unsupported homog_tuple type expression for registration on formal '{formal.name()}'; "
                         + "tuple size must be an int literal or a queried domain's rank",
                     )
-            else:
-                ten = te.name()
-        return (formal.name(), formal.storage_kind(), ten, extra_info)
+
+                # check the tuple element type (must be an identifier - either corresponding to a scalar type or a dtype query)
+                if isinstance(actuals[1], chapel.Identifier):
+                    name = actuals[1].name()
+                    if name in chapel_scalar_types:
+                        ft.append_info(StaticTypeInfo(name))
+                    else:
+                        ft.append_info(FormalQueryRef(name))
+                else:
+                    error_message(
+                        f"registering '{fn.name()}'",
+                        f"unsupported homog_tuple type expression for registration on formal '{formal.name()}'; "
+                        + f"tuple element type must be an identifier (either a Chapel scalar type or a queried dtype)",
+                    )
+
+                return ft
+            else:  # Scalar types
+                return FormalTypeSpec(formalKind.SCALAR, name, sk, te.name())
+        else:  # param and type formals
+            return FormalTypeSpec(formalKind.SCALAR, name, sk)
 
     con_formals = []
     gen_formals = []
@@ -223,17 +280,18 @@ def get_formals(fn, require_type_annotations):
                 "registration of procedures with vararg or tuple-grouped formals are not yet supported."
             )
         elif isinstance(formal, (chapel.Formal, chapel.AnonFormal)):
-            formal_info = info_tuple(formal)
-            if formal_info[2] is None and require_type_annotations:
+            spec = get_formal_type_spec(formal)
+
+            if spec.is_untyped() and require_type_annotations:
                 error_message(
                     f"registering '{fn.name()}'",
-                    f"missing type expression for formal '{formal_info[0]}'",
+                    f"missing type expression for formal '{spec.name}'",
                 )
             else:
-                if formal_info[1] in ["type", "param"]:
-                    gen_formals.append(formal_info)
+                if spec.is_generic():
+                    gen_formals.append(spec)
                 else:
-                    con_formals.append(formal_info)
+                    con_formals.append(spec)
 
     return con_formals, gen_formals
 
@@ -353,12 +411,12 @@ def generic_permutations(config, gen_formals):
     to_permute = {}
     # TODO: check that the type annotations on param formals are scalars and that
     # the values in the config file can be used as literals of that type
-    for formal_name, storage_kind, _, _ in gen_formals:
-        name_components = formal_name.split("_")
+    for formal_spec in gen_formals:
+        name_components = formal_spec.name.split("_")
 
         if len(name_components) < 2:
             raise ValueError(
-                f"invalid generic formal '{formal_name}; "
+                f"invalid generic formal '{formal_spec.name}; "
                 + "generic formals must be in the format '<param-class>_<param-name>[_...]' "
                 + "to be instantiated with values from the configuration file"
             )
@@ -368,7 +426,7 @@ def generic_permutations(config, gen_formals):
 
         if pclass not in config["parameter_classes"].keys():
             raise ValueError(
-                f"generic formal '{formal_name}' is not a valid parameter class; "
+                f"generic formal '{formal_spec.name}' is not a valid parameter class; "
                 + "please check the 'parameter_classes' field in the configuration file"
             )
 
@@ -378,7 +436,7 @@ def generic_permutations(config, gen_formals):
                 + "please check the 'parameter_classes' field in the configuration file"
             )
 
-        to_permute[formal_name] = parse_param_class_value(
+        to_permute[formal_spec.name] = parse_param_class_value(
             config["parameter_classes"][pclass][pname]
         )
 
@@ -393,14 +451,14 @@ def valid_generic_command_signature(fn, con_formals):
     """
     if len(con_formals) == 3:
         if (
-            con_formals[0][0] != "cmd"
-            or con_formals[0][2] != "string"
-            or con_formals[1][0] != ARGS_FORMAL_NAME
-            or con_formals[1][1] != ARGS_FORMAL_INTENT
-            or con_formals[1][2] != ARGS_FORMAL_TYPE
-            or con_formals[2][0] != SYMTAB_FORMAL_NAME
-            or con_formals[2][1] != SYMTAB_FORMAL_INTENT
-            or con_formals[2][2] != SYMTAB_FORMAL_TYPE
+            con_formals[0].name != "cmd"
+            or con_formals[0].type_str != "string"
+            or con_formals[1].name != ARGS_FORMAL_NAME
+            or con_formals[1].storage_kind != ARGS_FORMAL_INTENT
+            or con_formals[1].type_str != ARGS_FORMAL_TYPE
+            or con_formals[2].name != SYMTAB_FORMAL_NAME
+            or con_formals[2].storage_kind != SYMTAB_FORMAL_INTENT
+            or con_formals[2].type_str != SYMTAB_FORMAL_TYPE
         ):
             return False
     else:
@@ -447,12 +505,12 @@ def unpack_array_arg(arg_name, array_count, finfo, domain_queries, dtype_queries
         nd_generic_formal_info = None
     else:
         nd_arg_name = "array_nd_" + str(array_count)
-        nd_generic_formal_info = (nd_arg_name, "param", "int", None)
+        nd_generic_formal_info = FormalTypeSpec(formalKind.SCALAR, nd_arg_name, "param", "int")
 
     # check if the array formal has a static type or a type-query
     # if not, generate a unique name and formal info for the dtype argument
-    if finfo is not None and finfo[1] is not None and isinstance(finfo[1], StaticType):
-        dtype_arg_name = finfo[1].name
+    if finfo is not None and finfo[1] is not None and isinstance(finfo[1], StaticTypeInfo):
+        dtype_arg_name = finfo[1].value
         dtype_generic_formal_info = None
     elif (
         finfo is not None
@@ -464,7 +522,7 @@ def unpack_array_arg(arg_name, array_count, finfo, domain_queries, dtype_queries
         dtype_generic_formal_info = None
     else:
         dtype_arg_name = "array_dtype_" + str(array_count)
-        dtype_generic_formal_info = (dtype_arg_name, "type", None, None)
+        dtype_generic_formal_info = FormalTypeSpec(formalKind.SCALAR, dtype_arg_name, storage_kind="type")
 
     return (
         f"\tvar {arg_name}_array_sym = {SYMTAB_FORMAL_NAME}[{ARGS_FORMAL_NAME}['{arg_name}']]: {ARRAY_ENTRY_CLASS_NAME}({dtype_arg_name}, {nd_arg_name});\n"
@@ -535,7 +593,7 @@ def unpack_tuple_arg(arg_name, tuple_size, scalar_type):
     return f"\tvar {arg_name} = {ARGS_FORMAL_NAME}['{arg_name}'].toScalarTuple({scalar_type}, {tuple_size});"
 
 
-def unpack_list_arg(arg_name, arg_type):
+def unpack_list_arg(arg_name, list_elt_type):
     """
     Generate the code to unpack a list argument
 
@@ -545,7 +603,6 @@ def unpack_list_arg(arg_name, arg_type):
     ```
     """
 
-    list_elt_type = arg_type.split(",")[1]
     return f"\tvar {arg_name} = {ARGS_FORMAL_NAME}['{arg_name}'].toScalarList({list_elt_type});"
 
 
@@ -568,10 +625,7 @@ def gen_signature(user_proc_name, generic_args=None):
     """
     if generic_args:
         name = "ark_reg_" + user_proc_name + "_generic"
-        arg_strings = [
-            f"{kind} {name}: {ft}" if ft else f"{kind} {name}"
-            for name, kind, ft, _ in generic_args
-        ]
+        arg_strings = [formal_spec.stringify() for formal_spec in generic_args]
         proc = f"proc {name}(cmd: string, {ARGS_FORMAL_NAME}: {ARGS_FORMAL_TYPE}, {SYMTAB_FORMAL_NAME}: {SYMTAB_FORMAL_TYPE}, {', '.join(arg_strings)}): {RESPONSE_TYPE_NAME} throws {'{'}"
     else:
         name = "ark_reg_" + user_proc_name
@@ -593,13 +647,15 @@ def gen_arg_unpacking(formals):
     array_domain_queries = {}
     array_dtype_queries = {}
 
-    for fname, fintent, ftype, finfo in formals:
+    for formal_spec in formals:
+        if formal_spec.is_chapel_scalar_type():
+            unpack_lines.append(unpack_scalar_arg(formal_spec.name, formal_spec.type_str))
+        elif formal_spec.kind == formalKind.ARRAY:
+            # finfo[0] is the domain query info, finfo[1] is the dtype query info
+            finfo = formal_spec.info
 
-        if ftype in chapel_scalar_types:
-            unpack_lines.append(unpack_scalar_arg(fname, ftype))
-        elif ftype == "<array>":
             code, gen_dtype_arg, gen_nd_arg = unpack_array_arg(
-                fname,
+                formal_spec.name,
                 array_arg_counter,
                 finfo,
                 array_domain_queries,
@@ -622,50 +678,49 @@ def gen_arg_unpacking(formals):
                     and isinstance(finfo[0], FormalQuery)
                     and gen_nd_arg is not None
                 ):
-                    array_domain_queries[finfo[0].name] = gen_nd_arg[0]
+                    array_domain_queries[finfo[0].name] = gen_nd_arg.name
                 if (
                     finfo[1] is not None
                     and isinstance(finfo[1], FormalQuery)
                     and gen_dtype_arg is not None
                 ):
-                    array_dtype_queries[finfo[1].name] = gen_dtype_arg[0]
+                    array_dtype_queries[finfo[1].name] = gen_dtype_arg.name
 
-        elif "list" in ftype:
-            unpack_lines.append(unpack_list_arg(fname, ftype))
-        elif ftype == "<homog_tuple>":
+        elif formal_spec.kind == formalKind.LIST:
+            unpack_lines.append(unpack_list_arg(formal_spec.name, formal_spec.info[0]))
+        elif formal_spec.kind == formalKind.HOMOG_TUPLE:
+            finfo = formal_spec.info
             tsize = finfo[0]
             ttype = finfo[1]
 
             # if the tuple size is a domain query, use the corresponding generic rank argument
-            if isinstance(tsize, str):
-                tsize = array_domain_queries[tsize]
+            if isinstance(tsize, FormalQueryRef):
+                tsize = array_domain_queries[tsize.name]
+            else:
+                tsize = tsize.value
 
             # if the tuple type is a dtype query, use the corresponding generic dtype argument
-            if ttype in array_dtype_queries:
+            if isinstance(ttype, FormalQueryRef) and ttype.name in array_dtype_queries:
                 ttype = array_dtype_queries[ttype]
-            elif ttype not in chapel_scalar_types:
-                error_message(
-                    f"registering '{fname}'",
-                    f"unsupported homog_tuple type expression for registration on formal '{fname}'; "
-                    + f"tuple element type must be a scalar (one of {chapel_scalar_types.keys()}) or a dtype from a query",
-                )
+            else:
+                ttype = ttype.value
 
-            unpack_lines.append(unpack_tuple_arg(fname, tsize, ttype))
+            unpack_lines.append(unpack_tuple_arg(formal_spec.name, tsize, ttype))
         else:
             # a scalar formal with a generic type
-            if ftype in array_dtype_queries.keys():
-
-                unpack_lines.append(
-                    unpack_scalar_arg(fname, array_dtype_queries[ftype])
-                )
-            else:
-                # TODO: fully handle generic user-defined types
-                code, scalar_args = unpack_scalar_arg_with_generic(
-                    fname, scalar_arg_counter
-                )
-                unpack_lines.append(code)
-                generic_args += scalar_args
-                scalar_arg_counter += 1
+            if formal_spec.type_str is not None:
+                if queried_type := array_dtype_queries[formal_spec.type_str]:
+                    unpack_lines.append(
+                        unpack_scalar_arg(formal_spec.name, queried_type)
+                    )
+                else:
+                    # TODO: fully handle generic user-defined types
+                    code, scalar_args = unpack_scalar_arg_with_generic(
+                        formal_spec.name, scalar_arg_counter
+                    )
+                    unpack_lines.append(code)
+                    generic_args += scalar_args
+                    scalar_arg_counter += 1
 
     return ("\n".join(unpack_lines), generic_args)
 
@@ -757,12 +812,12 @@ def gen_command_proc(name, return_type, formals, mod_name):
     is_generic_command = len(command_formals) > 0
     signature, cmd_name = gen_signature(name, command_formals)
     fn_call, result_name = gen_user_function_call(
-        name, [f[0] for f in formals], mod_name, return_type
+        name, [f.name for f in formals], mod_name, return_type
     )
 
     # get the names of the array-elt-type queries in the formals
     array_etype_queries = [
-        f[3][1].name for f in formals if (f[2] == "<array>" and f[3] is not None)
+        f.info[1].name for f in formals if (f.kind == formalKind.ARRAY and len(f.info) > 0)
     ]
 
     # assume the returned type is a symbol if it's an identifier that is not a scalar or type-query reference

--- a/src/registry/register_commands.py
+++ b/src/registry/register_commands.py
@@ -851,8 +851,14 @@ def gen_command_proc(name, return_type, formals, mod_name):
     array_etype_queries = [
         f.info[1].name
         for f in formals
-        if (f.kind == formalKind.ARRAY and len(f.info) > 0)
+        if (
+            f.kind == formalKind.ARRAY
+            and len(f.info) > 0
+            and isinstance(f.info[1], FormalQuery)
+        )
     ]
+
+    print(array_etype_queries)
 
     # assume the returned type is a symbol if it's an identifier that is not a scalar or type-query reference
     # or if it is a `SymEntry` type-constructor call
@@ -867,7 +873,7 @@ def gen_command_proc(name, return_type, formals, mod_name):
             # TODO: generalize this to any class type identifier or class type-constructor call that
             # inherits from 'AbstractSymEntry'
             isinstance(return_type, chapel.FnCall)
-            and return_type.called_expression().name() == "SymEntry"
+            and return_type.called_expression().name() == ARRAY_ENTRY_CLASS_NAME
         )
     )
     returns_array = (


### PR DESCRIPTION
Add a `FormalTypeSpec` class to `registerCommands.py` to improve readability/maintainability. (Previously, information about formal types was stored in a 4-tuple, and the meaning of each element wasn't always clear).