### PR TITLE
Closes #3798 benchmark v2/sort cases benchmark.py throws errors

### DIFF
--- a/benchmark.ini
+++ b/benchmark.ini
@@ -24,7 +24,7 @@ testpaths =
     benchmark_v2/substring_search_benchmark.py
     benchmark_v2/no_op_benchmark.py
     benchmark_v2/io_benchmark.py
-#!    benchmark_v2/sort_cases_benchmark.py
+    benchmark_v2/sort_cases_benchmark.py
 python_functions = bench_*
 env =
     D:ARKOUDA_SERVER_HOST=localhost

--- a/benchmark_v2/sort_cases_benchmark.py
+++ b/benchmark_v2/sort_cases_benchmark.py
@@ -4,7 +4,6 @@ import pytest
 from arkouda.sorting import SortingAlgorithm
 
 TYPES = ("int64", "float64")
-POWERLAW_DATA = None
 
 
 def get_nbytes(data):
@@ -63,15 +62,11 @@ def bench_random_uniform(benchmark, algo, dtype, bits):
 
 
 def _generate_power_law_data():
-    global POWERLAW_DATA
+    y = ak.uniform(pytest.prob_size)
+    a = -2.5  # power law exponent, between -2 and -3
+    ub = 2**32  # upper bound
 
-    if POWERLAW_DATA is None:
-        y = ak.uniform(pytest.prob_size)
-        a = -2.5  # power law exponent, between -2 and -3
-        ub = 2 ** 32  # upper bound
-        POWERLAW_DATA = ((ub ** (a + 1) - 1) * y + 1) ** (1 / (a + 1))
-
-    return POWERLAW_DATA
+    return ((ub ** (a + 1) - 1) * y + 1) ** (1 / (a + 1))
 
 
 @pytest.mark.benchmark(group="AK_Sort_Cases")


### PR DESCRIPTION
This removes `POWERLAW_DATA` as a global variable which was causing a logging error.  It seems to be related to the fact that `manage_connection` in `conftest.py` is run with `function` scope and therefore the arkouda server is connected and disconnected for each separate test run.

Closes #3798 benchmark v2/sort cases benchmark.py throws errors

