### PR TITLE
Closes #3714: pdarray.shape should be a tuple

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -364,7 +364,7 @@ class pdarray:
         self.dtype = dtype(mydtype)
         self.size = size
         self.ndim = ndim
-        self.shape = shape
+        self._shape = tuple(shape)
         self.itemsize = itemsize
         if max_bits:
             self.max_bits = max_bits
@@ -398,6 +398,18 @@ class pdarray:
         from arkouda.client import pdarrayIterThresh
 
         return generic_msg(cmd="repr", args={"array": self, "printThresh": pdarrayIterThresh})
+
+    @property
+    def shape(self):
+        """
+        Return the shape of an array.
+
+        Returns
+        -------
+        tuple of int
+            The elements of the shape tuple give the lengths of the corresponding array dimensions.
+        """
+        return tuple(self._shape)
 
     @property
     def max_bits(self):
@@ -962,7 +974,7 @@ class pdarray:
 
                 # use 'None' values in the original key to expand the dimensions
                 shape = []
-                rs = ret_array.shape
+                rs = list(ret_array.shape)
                 for k in key_with_none:
                     if k is None:
                         shape.append(1)

--- a/tests/pdarray_creation_test.py
+++ b/tests/pdarray_creation_test.py
@@ -53,7 +53,7 @@ class TestPdarrayCreation:
             ak.array(np.ones(shape), dtype),
         ]:
             assert isinstance(pda, ak.pdarray)
-            assert pda.shape == list(shape)
+            assert pda.shape == shape
             assert dtype == pda.dtype
 
     @pytest.mark.skip_if_max_rank_greater_than(3)
@@ -248,7 +248,7 @@ class TestPdarrayCreation:
         assert isinstance(test_array, ak.pdarray)
         assert size == len(test_array)
         assert array_type == test_array.dtype
-        assert [size] == test_array.shape
+        assert (size,) == test_array.shape
         assert ((0 <= test_array) & (test_array <= size)).all()
 
     # (The above function tests randint with various ARRAY dtypes; the function below
@@ -259,7 +259,7 @@ class TestPdarrayCreation:
             assert isinstance(test_array, ak.pdarray)
             assert 1000 == len(test_array)
             assert ak.int64 == test_array.dtype
-            assert [1000] == test_array.shape
+            assert (1000,) == test_array.shape
             assert ((0 <= test_array) & (test_array <= 1000)).all()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
@@ -334,7 +334,7 @@ class TestPdarrayCreation:
         test_array = ak.uniform(size)
         assert isinstance(test_array, ak.pdarray)
         assert ak.float64 == test_array.dtype
-        assert [size] == test_array.shape
+        assert (size,) == test_array.shape
 
         u_array = ak.uniform(size=3, low=0, high=5, seed=0)
         assert [0.30013431967121934, 0.47383036230759112, 1.0441791878997098] == u_array.to_list()
@@ -372,7 +372,7 @@ class TestPdarrayCreation:
         zeros = ak.zeros(shape, dtype)
         assert isinstance(zeros, ak.pdarray)
         assert dtype == zeros.dtype
-        assert zeros.shape == list(shape)
+        assert zeros.shape == shape
         assert (0 == zeros).all()
 
     @pytest.mark.skip_if_max_rank_greater_than(3)
@@ -412,7 +412,7 @@ class TestPdarrayCreation:
         shape = (2, 2, size)
         ones = ak.ones(shape, dtype)
         assert isinstance(ones, ak.pdarray)
-        assert ones.shape == list(shape)
+        assert ones.shape == shape
         assert dtype == ones.dtype
         assert (1 == ones).all()
 
@@ -464,7 +464,7 @@ class TestPdarrayCreation:
         type_full = ak.full(shape, 1, dtype)
         assert isinstance(type_full, ak.pdarray)
         assert dtype == type_full.dtype
-        assert type_full.shape == list(shape)
+        assert type_full.shape == shape
         assert (1 == type_full).all()
 
     @pytest.mark.skip_if_max_rank_greater_than(3)
@@ -737,7 +737,7 @@ class TestPdarrayCreation:
     def test_mulitdimensional_array_creation(self):
         a = ak.array([[0, 0], [0, 1], [1, 1]])
         assert isinstance(a, ak.pdarray)
-        assert a.shape == [3, 2]
+        assert a.shape == (3, 2)
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", [bool, np.float64, np.int64, str])

--- a/tests/pdarrayclass_test.py
+++ b/tests/pdarrayclass_test.py
@@ -1,13 +1,27 @@
 import pytest
 
 import arkouda as ak
+import numpy as np
 
 
 class TestPdarrayClass:
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_max_rank_less_than(2)
     def test_reshape(self):
         a = ak.arange(4)
         r = a.reshape((2, 2))
-        assert r.shape == [2, 2]
+        assert r.shape == (2, 2)
         assert isinstance(r, ak.pdarray)
+
+    def test_shape(self):
+        a = ak.arange(4)
+        np_a = np.arange(4)
+        assert isinstance(a.shape, tuple)
+        assert a.shape == np_a.shape
+
+    @pytest.mark.skip_if_max_rank_less_than(2)
+    def test_shape_multidim(self):
+        a = ak.arange(4).reshape((2,2))
+        np_a = np.arange(4).reshape((2,2))
+        assert isinstance(a.shape, tuple)
+        assert a.shape == np_a.shape


### PR DESCRIPTION
This PR changes pdarray.shape to be a tuple to  match numpy better:
https://numpy.org/doc/2.1/reference/generated/numpy.shape.html

Closes #3714: pdarray.shape should be a tuple