### PR TITLE
Fix sparseMatToPdarray test failures for distributed arrays

### DIFF
--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -727,13 +727,6 @@ module MultiTypeSymEntry
         return new shared SparseSymEntry(a, size, matLayout, eltType);
     }
 
-    proc makeSparseArray(size, type eltType, param matLayout) {
-        const dom = {1..size, 1..size};
-        var spsDom: sparse subdomain(dom) dmapped new dmap(new CS(compressRows=(matLayout==layout.CSR)));
-        var A: [spsDom] eltType;
-        return A;
-    }
-
 
     class GeneratorSymEntry:AbstractSymEntry {
         type etype;

--- a/src/SparseMatrix.chpl
+++ b/src/SparseMatrix.chpl
@@ -108,6 +108,8 @@ module SparseMatrix {
             const iStart = rt * nRowsPerTask + iRange.low,
                   iStop = if rt == nRowTasks-1 then iRange.last else (rt+1) * nRowsPerTask + iRange.low - 1;
 
+            // TODO: try to avoid repeated 'contains' checks here (e.g, by directly querying the
+            //       local subdomain's array of non-zero indices)
             for i in iStart..iStop {
               for j in jRange {
                 if spsMat.domain.contains((i,j))
@@ -142,6 +144,8 @@ module SparseMatrix {
             var idxAgg = newDstAggregator(int),
                 valAgg = newDstAggregator(spsMat.eltType);
 
+            // TODO: try to avoid repeated 'contains' checks here (e.g, by directly iterating
+            //       over the local subdomain's array of non-zero indices)
             for i in iStart..iStop {
               var idx = colBlockStartOffsets.localAccess[i, colBlockIdx];
               for j in jRange {
@@ -195,6 +199,8 @@ module SparseMatrix {
             const jStart = ct * nColsPerTask + jRange.low,
                   jStop = if ct == nColTasks-1 then jRange.last else (ct+1) * nColsPerTask + jRange.low - 1;
 
+            // TODO: try to avoid repeated 'contains' checks here (e.g, by directly querying the
+            //       local subdomain's array of non-zero indices)
             for i in iRange {
               for j in jStart..jStop {
                 if spsMat.domain.contains((i,j))
@@ -229,6 +235,8 @@ module SparseMatrix {
             var idxAgg = newDstAggregator(int),
                 valAgg = newDstAggregator(spsMat.eltType);
 
+            // TODO: try to avoid repeated 'contains' checks here (e.g, by directly iterating
+            //       over the local subdomain's array of non-zero indices)
             for j in jStart..jStop {
               var idx = rowBlockStartOffsets.localAccess[rowBlockIdx, j];
               for i in iRange {

--- a/src/SparseMatrix.chpl
+++ b/src/SparseMatrix.chpl
@@ -175,7 +175,7 @@ module SparseMatrix {
     const (grid, nRowBlocks, nColBlocks) = getGridInfo(spsMat);
 
     // number of non-zeros in each column, for each row-block of the matrix
-    // TODO: make this a sparse array ('spsMat.shape[0]' could be very large)
+    // TODO: make this a sparse array ('spsMat.shape[1]' could be very large)
     const nnzDom = blockDist.createDomain({0..<nRowBlocks, 1..spsMat.shape[1]}, targetLocales=grid);
     var nnzPerRowBlock: [nnzDom] int;
 
@@ -377,7 +377,7 @@ module SparseMatrix {
         const jStart = ct * nColsPerTask + jRange.low,
               jStop = if ct == nColTasks-1 then jRange.last else (ct+1) * nColsPerTask + jRange.low - 1;
 
-        rowBlockStartOffsets[{jStart..jStop, 0..<nColBlocks}] += colBlockIntermediate[ct-1];
+        rowBlockStartOffsets[{0..<nRowBlocks, jStart..jStop}] += colBlockIntermediate[ct-1];
       }
     }
 
@@ -386,7 +386,7 @@ module SparseMatrix {
 
     coforall colBlockIdx in 1..<nColBlocks with (ref rowBlockStartOffsets) do on grid[0,colBlockIdx] {
       const jRange = pdom.localSubdomain().dim(1);
-      rowBlockStartOffsets[{jRange, 0..<nColBlocks}] += intermediate[colBlockIdx-1];
+      rowBlockStartOffsets[{0..<nRowBlocks, jRange}] += intermediate[colBlockIdx-1];
     }
 
     return rowBlockStartOffsets;

--- a/src/SparseMatrixMsg.chpl
+++ b/src/SparseMatrixMsg.chpl
@@ -125,11 +125,11 @@ module SparseMatrixMsg {
         if gEnt.layoutStr=="CSC" {
             // Hardcode for int right now
             var sparrayEntry = gEnt.toSparseSymEntry(int, dimensions=2, layout.CSC);
-            fillSparseMatrix(sparrayEntry.a, vals.a);
+            fillSparseMatrix(sparrayEntry.a, vals.a, layout.CSC);
         } else if gEnt.layoutStr=="CSR" {
             // Hardcode for int right now
             var sparrayEntry = gEnt.toSparseSymEntry(int, dimensions=2, layout.CSR);
-            fillSparseMatrix(sparrayEntry.a, vals.a);
+            fillSparseMatrix(sparrayEntry.a, vals.a, layout.CSR);
         } else {
             throw getErrorWithContext(
                                     msg="unsupported layout for sparse matrix: %s".format(gEnt.layoutStr),

--- a/src/SparseMatrixMsg.chpl
+++ b/src/SparseMatrixMsg.chpl
@@ -20,8 +20,6 @@ module SparseMatrixMsg {
     private config const logChannel = ServerConfig.logChannel;
     const sparseLogger = new Logger(logLevel, logChannel);
 
-    param distributed = true;
-
     proc randomSparseMatrixMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
         var repMsg: string; // response message with the details of the new arr
 
@@ -34,14 +32,14 @@ module SparseMatrixMsg {
 
         select l {
             when "CSR" {
-                var aV = randSparseMatrix(size, density, layout.CSR, distributed, int); // Hardcode int for now and false for distributed
+                var aV = randSparseMatrix(size, density, layout.CSR, int);
                 st.addEntry(vName, createSparseSymEntry(aV, size, layout.CSR, int));
                 repMsg = "created " + st.attrib(vName);
                 sparseLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
                 return new MsgTuple(repMsg, MsgType.NORMAL);
             }
             when "CSC" {
-                var aV = randSparseMatrix(size, density, layout.CSC, distributed, int); // Hardcode int for now and false for distributed
+                var aV = randSparseMatrix(size, density, layout.CSC, int);
                 st.addEntry(vName, createSparseSymEntry(aV, size, layout.CSC, int));
                 repMsg = "created " + st.attrib(vName);
                 sparseLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);

--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -11,13 +11,21 @@ class TestSparse:
         vals_csr = csr.to_pdarray()[2].to_ndarray()
         assert np.all(vals_csc == 0)
         assert np.all(vals_csr == 0)
-        fill_vals_csc = ak.randint(0, 10, csc.nnz)
-        fill_vals_csr = ak.randint(0, 10, csr.nnz)
+
+        fill_vals_csc = ak.array(np.arange(0, csc.nnz))
+        fill_vals_csr = ak.array(np.arange(0, csr.nnz))
+
+        # fill_vals_csc = ak.randint(0, 10, csc.nnz)
+        # fill_vals_csr = ak.randint(0, 10, csr.nnz)
         csc.fill_vals(fill_vals_csc)
         csr.fill_vals(fill_vals_csr)
         vals_csc = csc.to_pdarray()[2].to_ndarray()
         vals_csr = csr.to_pdarray()[2].to_ndarray()
-        assert np.all(vals_csc == fill_vals_csc.to_ndarray())
+
+        print(vals_csr.tolist())
+        print(fill_vals_csr.to_ndarray().tolist())
+
+        # assert np.all(vals_csc == fill_vals_csc.to_ndarray())
         assert np.all(vals_csr == fill_vals_csr.to_ndarray())
 
 

--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -11,21 +11,13 @@ class TestSparse:
         vals_csr = csr.to_pdarray()[2].to_ndarray()
         assert np.all(vals_csc == 0)
         assert np.all(vals_csr == 0)
-
-        fill_vals_csc = ak.array(np.arange(0, csc.nnz))
-        fill_vals_csr = ak.array(np.arange(0, csr.nnz))
-
-        # fill_vals_csc = ak.randint(0, 10, csc.nnz)
-        # fill_vals_csr = ak.randint(0, 10, csr.nnz)
+        fill_vals_csc = ak.randint(0, 10, csc.nnz)
+        fill_vals_csr = ak.randint(0, 10, csr.nnz)
         csc.fill_vals(fill_vals_csc)
         csr.fill_vals(fill_vals_csr)
         vals_csc = csc.to_pdarray()[2].to_ndarray()
         vals_csr = csr.to_pdarray()[2].to_ndarray()
-
-        print(vals_csr.tolist())
-        print(fill_vals_csr.to_ndarray().tolist())
-
-        # assert np.all(vals_csc == fill_vals_csc.to_ndarray())
+        assert np.all(vals_csc == fill_vals_csc.to_ndarray())
         assert np.all(vals_csr == fill_vals_csr.to_ndarray())
 
 


### PR DESCRIPTION
Fixes a couple of bugs with the distributed implementation of sparseMatToPdarray.

Also fixes a few other bugs/issues with the sparse matrix code:
* `ChplConfig.CHPL_COMM` is now used to determine whether sparse matrices are distributed. Matrices created by `randSparseMatrix` were always distributed before.
* The `SparseSymEntry` class now stores a distributed sparse array when the server is configured for multi-locale. It was always storing a non-distributed array before.
* `fillSparseMatrix` now populates matrices in either a row-major (for CSR) or column-major (for CSC) order. For distributed arrays, it was populating values one locale at a time, causing them to appear out of order overall.
   * this hadn't been picked up by testing because `sparseMatToPdarray` was doing the inverse operation, instead of returning values in a global row-major or column-major order