### PR TITLE
Fix test `size`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -568,10 +568,10 @@ CLEAN_TARGETS += test-clean
 test-clean:
 	$(RM) $(TEST_TARGETS) $(addsuffix _real,$(TEST_TARGETS))
 
-size = 10**8
+size_bm = 10**8
 .PHONY: benchmark
 benchmark:
-	python3 -m pytest -c benchmark.ini --benchmark-autosave --benchmark-storage=file://benchmark_v2/.benchmarks --size=$(size)
+	python3 -m pytest -c benchmark.ini --benchmark-autosave --benchmark-storage=file://benchmark_v2/.benchmarks --size=$(size_bm)
 
 version:
 	@echo $(VERSION);


### PR DESCRIPTION
https://github.com/Bears-R-Us/arkouda/pull/3794 modified the makefile to increased the `size` argument when running `make benchmark` to 10**8.

This had the indirect effect of causing the regular tests to run with the same size. This PR uses different variable names for the benchmark and test sizes s.t. the test suite runs with the previous size of 100 by default.