### PR TITLE
Closes #3811: Roll back test change to determine impact on testing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,8 +106,6 @@ def manage_connection():
 
     try:
         ak.connect(server=pytest.server, port=pytest.port, timeout=pytest.timeout)
-        if TestRunningMode.CLIENT == pytest.test_running_mode:
-            pytest.nl = get_config()['numLocales']
         pytest.max_rank = get_max_array_rank()
 
     except Exception as e:


### PR DESCRIPTION
A running mode check was added to correctly test with Client mode, which allows developers to view server output when running the test harness, but there have been some nightly testing failures running in Server mode that are difficult to track down, due to the lack of server output. Since this change seems possibly related, we are temporarily reverting it to assess if this was causing those failures.

Closes #3811 