### PR TITLE
Fix performance regression in array transfer performance

### DIFF
--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -291,16 +291,19 @@ def array(
             raise RuntimeError(
                 "Array exceeds allowed transfer size. Increase ak.client.maxTransferBytes to allow"
             )
-        #   Make a copy to avoid error #3757
-        a = a.copy()
+        if a.flags["F_CONTIGUOUS"] and not a.flags["OWNDATA"]:
+            # Make a copy if the array was shallow-transposed (to avoid error #3757)
+            a_ = a.copy()
+        else:
+            a_ = a
         # Pack binary array data into a bytes object with a command header
         # including the dtype and size. If the server has a different byteorder
         # than our numpy array we need to swap to match since the server expects
         # native endian bytes
-        aview = _array_memview(a)
+        aview = _array_memview(a_)
         rep_msg = generic_msg(
-            cmd=f"array<{a.dtype.name},{ndim}>",
-            args={"dtype": a.dtype.name, "shape": tuple(a.shape), "seg_string": False},
+            cmd=f"array<{a_.dtype.name},{ndim}>",
+            args={"dtype": a_.dtype.name, "shape": tuple(a_.shape), "seg_string": False},
             payload=aview,
             send_binary=True,
         )


### PR DESCRIPTION
Fix a recent [regression](https://chapel-lang.org/perf/arkouda/chapcs/?startdate=2024/09/01&enddate=2024/10/06&graphs=arraytransferperformance) in array transfer performance caused by an extra array copy added [here](https://github.com/Bears-R-Us/arkouda/pull/3761/files).

The copy was included to ensure the array data are properly transposed on the server side following a shallow numpy transpose (where the buffer remains the same and an array-metadata flag is set to indicate that the array was transposed). The change fixed https://github.com/Bears-R-Us/arkouda/issues/3757, but added overhead. This PR only makes the extra copy for the shallow-transpose case, which should restore performance for the common case.