### PR TITLE
Closes #3815: Disable client test due to machine issues

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -17,7 +17,7 @@ testpaths =
     tests/categorical_test.py
     tests/check.py
     tests/client_dtypes_test.py
-    tests/client_test.py
+    #tests/client_test.py
     tests/coargsort_test.py
     tests/dataframe_test.py
     tests/datetime_test.py


### PR DESCRIPTION
There are currently two issues with the client test in Arkouda that are impacting nightly distributed performance testing on some of our machines. The first test causing this issue follows the following pattern:
1. Connect to server
2. Shut down the server
3. Relaunch the server
4. Connect to the new server And, due to machine busyness, the second launched server can get held up in the queue and never granted an allocation, causing a failure.

The second of the testing issue comes from one of the testing using Python IO to write a file containing server information, but one of our machine is currently dealing with a filesystem migration, causing Python writing to not work as expected due to permission problems.

Closes #3815 