### PR TITLE
Closes #3815: Disable `client_test` for nightly due to machine issues

### DIFF
--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -5,6 +5,7 @@ from arkouda.client import generic_msg
 from server_util.test.server_test_util import TestRunningMode, start_arkouda_server
 
 
+@pytest.mark.skipif(pytest.host == "horizon", reason="nightly test failures due to machine busyness")
 class TestClient:
     def test_client_connected(self):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import subprocess
 import importlib
 import os
 
@@ -68,6 +69,7 @@ def pytest_configure(config):
     pytest.seed = None if config.getoption("seed") == "" else eval(config.getoption("seed"))
     pytest.prob_size = [eval(x) for x in config.getoption("size").split(",")]
     pytest.test_running_mode = TestRunningMode(os.getenv("ARKOUDA_RUNNING_MODE", "CLASS_SERVER"))
+    pytest.host = subprocess.check_output("hostname").decode("utf-8").strip()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/numpy/numeric_test.py
+++ b/tests/numpy/numeric_test.py
@@ -1,4 +1,3 @@
-import subprocess
 from math import isclose, sqrt
 
 import numpy as np
@@ -310,9 +309,7 @@ class TestNumeric:
 
     #   log and exp tests were identical, and so have been combined.
 
-    host = subprocess.check_output("hostname").decode("utf-8").strip()
-
-    @pytest.mark.skipif(host == "horizon", reason="Fails on horizon")
+    @pytest.mark.skipif(pytest.host == "horizon", reason="Fails on horizon")
     @pytest.mark.skip_if_max_rank_less_than(2)
     @pytest.mark.parametrize("num_type1", NO_BOOL)
     @pytest.mark.parametrize("num_type2", NO_BOOL)


### PR DESCRIPTION
Slight rework of #3816

@bmcdonald3's original description:
> There are currently two issues with the client test in Arkouda that are impacting nightly distributed performance testing on some of our machines. The first test causing this issue follows the following pattern:
> 1. Connect to server
> 2. Shut down the server
> 3. Relaunch the server
> 4. Connect to the new server And, due to machine busyness, the second launched server can get held up in the queue and never granted an allocation, causing a failure.
> The second of the testing issue comes from one of the testing using Python IO to write a file containing server information, but one of our machine is currently dealing with a filesystem migration, causing Python writing to not work as expected due to permission problems.

Closes https://github.com/Bears-R-Us/arkouda/issues/3815