### PR TITLE
Closes #3820:  bug in flip multi-local

### DIFF
--- a/tests/numpy/manipulation_functions_test.py
+++ b/tests/numpy/manipulation_functions_test.py
@@ -40,6 +40,8 @@ class TestNumpyManipulationFunctions:
         f2 = ak.broadcast(segments=segs, values=vals2, permutation=perm).reshape(shape)
         assert_equal(f, f2)
 
+    #   Currently there is a bug in the reverse indexing of Strings (#3821) that causes this test to fail.
+    @pytest.mark.skip("Skip until bug fix Ticket #3821 is completed.")
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_flip_string(self, size):
         s = ak.random_strings_uniform(1, 2, size, seed=seed)


### PR DESCRIPTION
This PR skips the failing test `test_flip_string`, which is actually due to a bug in the reverse indexing of Strings.  See #3821.

Closes #3820:  bug in flip multi-local