### PR TITLE
Fix array transfer performance regression

### DIFF
--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -291,7 +291,7 @@ def array(
             raise RuntimeError(
                 "Array exceeds allowed transfer size. Increase ak.client.maxTransferBytes to allow"
             )
-        if a.flags["F_CONTIGUOUS"] and not a.flags["OWNDATA"]:
+        if a.ndim > 1 and a.flags["F_CONTIGUOUS"] and not a.flags["OWNDATA"]:
             # Make a copy if the array was shallow-transposed (to avoid error #3757)
             a_ = a.copy()
         else:


### PR DESCRIPTION
https://github.com/Bears-R-Us/arkouda/pull/3814 didn't actually fix the [performance regression](https://chapel-lang.org/perf/arkouda/chapcs/?startdate=2024/09/25&enddate=2024/10/09&graphs=arraytransferperformance) it was intended to because the extra array copy was always firing for 1D arrays. This is because 1D numpy arrays are marked with `C_CONTIGUOUS` and `F_CONTIGUOUS` (they can be either).

This PR adjusts `ak.array` to only copy the numpy array if it's rank is greater than 1, and it's `F_CONTIGUOUS` (and non-owned).