### PR TITLE
Closes #3827:  rename flatten to split

### DIFF
--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -1224,7 +1224,7 @@ class Strings:
         return self._get_matcher(pattern).get_match(MatchType.FULLMATCH, self)
 
     @typechecked()
-    def split(
+    def regex_split(
         self, pattern: Union[bytes, str_scalars], maxsplit: int = 0, return_segments: bool = False
     ) -> Union[Strings, Tuple]:
         """
@@ -1560,7 +1560,7 @@ class Strings:
         self._empty_pattern_verification(substr)
         return self.contains(substr + "$", regex=True)
 
-    def flatten(
+    def split(
         self, delimiter: str, return_segments: bool = False, regex: bool = False
     ) -> Union[Strings, Tuple]:
         """Unpack delimiter-joined substrings into a flat array.
@@ -1609,7 +1609,7 @@ class Strings:
                 re.compile(delimiter)
             except Exception as e:
                 raise ValueError(e)
-            return self.split(delimiter, return_segments=return_segments)
+            return self.regex_split(delimiter, return_segments=return_segments)
         else:
             cmd = "segmentedFlatten"
             repMsg = cast(

--- a/benchmark.ini
+++ b/benchmark.ini
@@ -11,7 +11,7 @@ testpaths =
     benchmark_v2/array_create_benchmark.py
     benchmark_v2/groupby_benchmark.py
     benchmark_v2/coargsort_benchmark.py
-    benchmark_v2/flatten_benchmark.py
+    benchmark_v2/split_benchmark.py
     benchmark_v2/encoding_benchmark.py
     benchmark_v2/reduce_benchmark.py
     benchmark_v2/gather_benchmark.py

--- a/benchmark_v2/split_benchmark.py
+++ b/benchmark_v2/split_benchmark.py
@@ -14,11 +14,11 @@ def _generate_test_data():
 
 
 @pytest.mark.benchmark(group="AK_Flatten")
-def bench_flatten_nonregex(benchmark):
+def bench_split_nonregex(benchmark):
     thickrange, nbytes = _generate_test_data()
 
-    benchmark.pedantic(thickrange.flatten, args=["_"], rounds=pytest.trials)
-    benchmark.extra_info["description"] = "Measures the performance of Strings.flatten"
+    benchmark.pedantic(thickrange.split, args=["_"], rounds=pytest.trials)
+    benchmark.extra_info["description"] = "Measures the performance of Strings.split"
     benchmark.extra_info["problem_size"] = pytest.prob_size
     benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
         (nbytes / benchmark.stats["mean"]) / 2**30
@@ -26,11 +26,11 @@ def bench_flatten_nonregex(benchmark):
 
 
 @pytest.mark.benchmark(group="AK_Flatten")
-def bench_flatten_regexliteral(benchmark):
+def bench_split_regexliteral(benchmark):
     thickrange, nbytes = _generate_test_data()
 
-    benchmark.pedantic(thickrange.flatten, args=["_"], kwargs={"regex": True}, rounds=pytest.trials)
-    benchmark.extra_info["description"] = "Measures the performance of Strings.flatten"
+    benchmark.pedantic(thickrange.split, args=["_"], kwargs={"regex": True}, rounds=pytest.trials)
+    benchmark.extra_info["description"] = "Measures the performance of Strings.split"
     benchmark.extra_info["problem_size"] = pytest.prob_size
     benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
         (nbytes / benchmark.stats["mean"]) / 2**30
@@ -38,11 +38,11 @@ def bench_flatten_regexliteral(benchmark):
 
 
 @pytest.mark.benchmark(group="AK_Flatten")
-def bench_flatten_regexpattern(benchmark):
+def bench_split_regexpattern(benchmark):
     thickrange, nbytes = _generate_test_data()
 
-    benchmark.pedantic(thickrange.flatten, args=["_+"], kwargs={"regex": True}, rounds=pytest.trials)
-    benchmark.extra_info["description"] = "Measures the performance of Strings.flatten"
+    benchmark.pedantic(thickrange.split, args=["_+"], kwargs={"regex": True}, rounds=pytest.trials)
+    benchmark.extra_info["description"] = "Measures the performance of Strings.split"
     benchmark.extra_info["problem_size"] = pytest.prob_size
     benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
         (nbytes / benchmark.stats["mean"]) / 2**30

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -48,7 +48,7 @@ BENCHMARKS = [
     "str-gather",
     "str-in1d",
     "substring_search",
-    "flatten",
+    "split",
     "sort-cases",
     "multiIO",
     "str-locality",

--- a/benchmarks/split.py
+++ b/benchmarks/split.py
@@ -6,8 +6,8 @@ import time
 import arkouda as ak
 
 
-def time_flatten(N_per_locale, trials):
-    print(">>> arkouda flatten")
+def time_split(N_per_locale, trials):
+    print(">>> arkouda split")
     cfg = ak.get_config()
     N = N_per_locale * cfg["numLocales"]
     print("numLocales = {}, N = {:,}".format(cfg["numLocales"], N))
@@ -21,17 +21,17 @@ def time_flatten(N_per_locale, trials):
     regex_pattern_times = []
     for i in range(trials):
         start = time.time()
-        non_regex = thickrange.flatten("_")
+        non_regex = thickrange.split("_")
         end = time.time()
         non_regex_times.append(end - start)
 
         start = time.time()
-        regex_literal = thickrange.flatten("_", regex=True)
+        regex_literal = thickrange.split("_", regex=True)
         end = time.time()
         regex_literal_times.append(end - start)
 
         start = time.time()
-        regex_pattern = thickrange.flatten("_+", regex=True)
+        regex_pattern = thickrange.split("_+", regex=True)
         end = time.time()
         regex_pattern_times.append(end - start)
 
@@ -44,22 +44,22 @@ def time_flatten(N_per_locale, trials):
     assert (regex_literal == answer).all()
     assert (regex_pattern == answer).all()
 
-    print("non-regex flatten with literal delimiter Average time = {:.4f} sec".format(avg_non_regex))
-    print("regex flatten with literal delimiter Average time = {:.4f} sec".format(avg_regex_literal))
-    print("regex flatten with pattern delimiter Average time = {:.4f} sec".format(avg_regex_pattern))
+    print("non-regex split with literal delimiter Average time = {:.4f} sec".format(avg_non_regex))
+    print("regex split with literal delimiter Average time = {:.4f} sec".format(avg_regex_literal))
+    print("regex split with pattern delimiter Average time = {:.4f} sec".format(avg_regex_pattern))
 
     print(
-        "non-regex flatten with literal delimiter Average rate = {:.4f} GiB/sec".format(
+        "non-regex split with literal delimiter Average rate = {:.4f} GiB/sec".format(
             nbytes / 2**30 / avg_non_regex
         )
     )
     print(
-        "regex flatten with literal delimiter Average rate = {:.4f} GiB/sec".format(
+        "regex split with literal delimiter Average rate = {:.4f} GiB/sec".format(
             nbytes / 2**30 / avg_regex_literal
         )
     )
     print(
-        "regex flatten with pattern delimiter Average rate = {:.4f} GiB/sec".format(
+        "regex split with pattern delimiter Average rate = {:.4f} GiB/sec".format(
             nbytes / 2**30 / avg_regex_pattern
         )
     )
@@ -72,19 +72,19 @@ def check_correctness():
     thickrange = thirds[0].stick(thirds[1], delimiter="_").stick(thirds[2], delimiter="_")
 
     answer = ak.cast(ak.arange(N * 3), "str")
-    assert (thickrange.flatten("_") == answer).all()
-    assert (thickrange.flatten("_", regex=True) == answer).all()
-    assert (thickrange.flatten("_+", regex=True) == answer).all()
+    assert (thickrange.split("_") == answer).all()
+    assert (thickrange.split("_", regex=True) == answer).all()
+    assert (thickrange.split("_+", regex=True) == answer).all()
 
 
 def create_parser():
     parser = argparse.ArgumentParser(
-        description="Measure the performance of regex and non-regex flatten on Strings."
+        description="Measure the performance of regex and non-regex split on Strings."
     )
     parser.add_argument("hostname", help="Hostname of arkouda server")
     parser.add_argument("port", type=int, help="Port of arkouda server")
     parser.add_argument(
-        "-n", "--size", type=int, default=10**5, help="Problem size: Number of Strings to flatten"
+        "-n", "--size", type=int, default=10**5, help="Problem size: Number of Strings to split"
     )
     parser.add_argument(
         "-t", "--trials", type=int, default=1, help="Number of times to run the benchmark"
@@ -112,5 +112,5 @@ if __name__ == "__main__":
 
     print("array size = {:,}".format(args.size))
     print("number of trials = ", args.trials)
-    time_flatten(args.size, args.trials)
+    time_split(args.size, args.trials)
     sys.exit(0)

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -565,7 +565,7 @@ class TestParquet:
 
     def test_segarray_string(self, par_test_base_tmp):
         words = ak.array(["one,two,three", "uno,dos,tres"])
-        strs, segs = words.split(",", return_segments=True)
+        strs, segs = words.regex_split(",", return_segments=True)
         x = ak.SegArray(segs, strs)
 
         with tempfile.TemporaryDirectory(dir=par_test_base_tmp) as tmp_dirname:
@@ -1865,7 +1865,7 @@ class TestHDF5:
 
     def test_segarray_str_hdf5(self, hdf_test_base_tmp):
         words = ak.array(["one,two,three", "uno,dos,tres"])
-        strs, segs = words.split(",", return_segments=True)
+        strs, segs = words.regex_split(",", return_segments=True)
 
         x = ak.SegArray(segs, strs)
         with tempfile.TemporaryDirectory(dir=hdf_test_base_tmp) as tmp_dirname:

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -451,14 +451,14 @@ class TestString:
         str_ans = "['string 0', 'string 1', 'string 2', ... , 'string 98', 'string 99', 'string 100']"
         assert str_ans == str(strings)
 
-    def test_flatten(self):
+    def test_split(self):
         orig = ak.array(["one|two", "three|four|five", "six"])
-        flat, mapping = orig.flatten("|", return_segments=True)
+        flat, mapping = orig.split("|", return_segments=True)
         assert flat.to_list() == ["one", "two", "three", "four", "five", "six"]
         assert mapping.to_list() == [0, 2, 5]
         thirds = [ak.cast(ak.arange(i, 99, 3), "str") for i in range(3)]
         thickrange = thirds[0].stick(thirds[1], delimiter=", ").stick(thirds[2], delimiter=", ")
-        flatrange = thickrange.flatten(", ")
+        flatrange = thickrange.split(", ")
         assert ak.cast(flatrange, "int64").to_list(), np.arange(99).tolist()
 
     def test_get_lengths(self):


### PR DESCRIPTION
This pr renames `flatten` to `split` and `split` to `regex_split`.

Closes #3827:  rename flatten to split