### PR TITLE
Fixes #3821: Bug in stridable indexing of Strings in multilocale

### DIFF
--- a/src/SegmentedString.chpl
+++ b/src/SegmentedString.chpl
@@ -207,9 +207,7 @@ module SegmentedString {
 
     proc this(const slice: range(strides=strideKind.any)) throws {
       var aa = makeDistArray(slice.size, int);
-      forall (elt,j) in zip(aa, slice) with (var agg = newSrcAggregator(int)) {
-        agg.copy(elt,j);
-      }
+      aa = slice;
       return this[aa];
     }
 

--- a/tests/numpy/manipulation_functions_test.py
+++ b/tests/numpy/manipulation_functions_test.py
@@ -40,8 +40,6 @@ class TestNumpyManipulationFunctions:
         f2 = ak.broadcast(segments=segs, values=vals2, permutation=perm).reshape(shape)
         assert_equal(f, f2)
 
-    #   Currently there is a bug in the reverse indexing of Strings (#3821) that causes this test to fail.
-    @pytest.mark.skip("Skip until bug fix Ticket #3821 is completed.")
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_flip_string(self, size):
         s = ak.random_strings_uniform(1, 2, size, seed=seed)


### PR DESCRIPTION
This PR fixes #3821 which gave incorrect results for stridable index into segstrings on multilocale