### PR TITLE
Refactor `SparseMatrixMsg` to use automated registration

### DIFF
--- a/arkouda/sparrayclass.py
+++ b/arkouda/sparrayclass.py
@@ -122,14 +122,19 @@ class sparray:
         # check dtype for error
         if dtype_name not in NumericDTypes:
             raise TypeError(f"unsupported dtype {dtype}")
-        responseArrays = generic_msg(cmd="sparse_to_pdarrays", args={"matrix": self})
+        responseArrays = generic_msg(
+            cmd=f"sparse_to_pdarrays<{self.dtype},{self.layout}>", args={"matrix": self}
+        )
         array_list = create_pdarrays(responseArrays)
         return array_list
 
     """"""
 
     def fill_vals(self, a: pdarray):
-        generic_msg(cmd="fill_sparse_vals", args={"matrix": self, "vals": a})
+        generic_msg(
+            cmd=f"fill_sparse_vals<{self.dtype},{self.layout}>",
+            args={"matrix": self, "vals": a}
+        )
 
 
 # creates sparray object

--- a/registration-config.json
+++ b/registration-config.json
@@ -11,6 +11,13 @@
                 "bigint"
             ]
         },
+        "sparse": {
+            "dtype": ["int"],
+            "layout": {
+                "__enum__": "SparseMatrix.Layout",
+                "__variants__": ["CSR", "CSC"]
+            }
+        },
         "binop": {
             "dtype": [
                 "int",

--- a/src/Message.chpl
+++ b/src/Message.chpl
@@ -81,6 +81,8 @@ module Message {
             msg += (sym: borrowed GenSymEntry).attrib();
         } else if sym.isAssignableTo(SymbolEntryType.CompositeSymEntry) {
             msg += (sym: borrowed CompositeSymEntry).attrib();
+        } else if sym.isAssignableTo(SymbolEntryType.SparseSymEntry) {
+            msg += (sym: borrowed GenSparseSymEntry).attrib();
         }
 
         return new MsgTuple(

--- a/src/SparseMatrix.chpl
+++ b/src/SparseMatrix.chpl
@@ -6,7 +6,7 @@ module SparseMatrix {
   use CommAggregation;
 
   // Quick and dirty, not permanent
-  proc fillSparseMatrix(ref spsMat, const A: [?D] ?eltType, param l: layout) throws {
+  proc fillSparseMatrix(ref spsMat, const A: [?D] ?eltType, param l: Layout) throws {
     if A.rank != 1 then
         throw getErrorWithContext(
                         msg="fill vals requires a 1D array; got a %iD array".format(A.rank),
@@ -40,7 +40,7 @@ module SparseMatrix {
     //   spsMat[i,j] = A[idx];
     // }
 
-    if l == layout.CSR {
+    if l == Layout.CSR {
       var idx = 0;
       for i in spsMat.domain.parentDom.dim(0) {
         for j in spsMat.domain.parentDom.dim(1) {
@@ -95,7 +95,9 @@ module SparseMatrix {
     Fill the rows, cols, and vals arrays with the non-zero indices and values
     from the sparse matrix in row-major order.
   */
-  proc sparseMatToPdarrayCSR(const ref spsMat, ref rows, ref cols, ref vals) {
+  proc sparseMatToPdarray(const ref spsMat, ref rows, ref cols, ref vals, param layout: Layout)
+    where layout == Layout.CSR
+  {
     // // serial algorithm (for reference):
     // var idx = 0;
     // for i in spsMat.domain.parentDom.dim(0) {
@@ -156,7 +158,9 @@ module SparseMatrix {
   //   Fill the rows, cols, and vals arrays with the non-zero indices and values
   //   from the sparse matrix in col-major order.
   // */
-  proc sparseMatToPdarrayCSC(const ref spsMat, ref rows, ref cols, ref vals) {
+  proc sparseMatToPdarray(const ref spsMat, ref rows, ref cols, ref vals, param layout: Layout)
+    where layout == Layout.CSC
+  {
     // // serial algorithm (for reference):
     // var idx = 0;
     // for j in spsMat.domain.parentDom.dim(1) {
@@ -450,9 +454,9 @@ module SparseMatrix {
     return C;
   }
 
-  proc randSparseMatrix(size, density, param layout, type eltType) {
+  proc randSparseMatrix(shape: 2*int, density, param layout, type eltType) {
     import SymArrayDmap.makeSparseDomain;
-    var (SD, dense) = makeSparseDomain(size, layout);
+    var (SD, dense) = makeSparseDomain(shape, layout);
 
     // randomly include index pairs based on provided density
     for (i,j) in dense do
@@ -471,7 +475,7 @@ module SparseMatrix {
 
     use BlockDist, LayoutCS, Map, Random;
 
-    enum layout {
+    enum Layout {
       CSR,
       CSC
     };

--- a/src/SparseMatrixMsg.chpl
+++ b/src/SparseMatrixMsg.chpl
@@ -20,135 +20,60 @@ module SparseMatrixMsg {
     private config const logChannel = ServerConfig.logChannel;
     const sparseLogger = new Logger(logLevel, logChannel);
 
-    proc randomSparseMatrixMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
-        var repMsg: string; // response message with the details of the new arr
+    @arkouda.instantiateAndRegister("random_sparse_matrix")
+    proc randomSparseMatrix(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab,
+                            type sparse_dtype, param sparse_layout: Layout
+    ): MsgTuple throws {
+        const shape = msgArgs["shape"].toScalarTuple(int, 2), // Hardcode 2D for now
+              density = msgArgs["density"].toScalar(real);
 
-        var vName = st.nextName(); // symbol table key for resulting sparse arr
-
-        var size: int = msgArgs.get("size").getIntValue();
-        var density: real = msgArgs.get("density").getRealValue();
-        var l: string = msgArgs.getValueOf("layout");
-
-
-        select l {
-            when "CSR" {
-                var aV = randSparseMatrix(size, density, layout.CSR, int);
-                st.addEntry(vName, createSparseSymEntry(aV, size, layout.CSR, int));
-                repMsg = "created " + st.attrib(vName);
-                sparseLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-                return new MsgTuple(repMsg, MsgType.NORMAL);
-            }
-            when "CSC" {
-                var aV = randSparseMatrix(size, density, layout.CSC, int);
-                st.addEntry(vName, createSparseSymEntry(aV, size, layout.CSC, int));
-                repMsg = "created " + st.attrib(vName);
-                sparseLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-                return new MsgTuple(repMsg, MsgType.NORMAL);
-            }
-            otherwise {
-                var errorMsg = notImplementedError("unsupported layout for sparse matrix",l);
-                sparseLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg, MsgType.ERROR);
-            }
-        }
+        const aV = randSparseMatrix(shape, density, sparse_layout, sparse_dtype);
+        return st.insert(new shared SparseSymEntry(aV, sparse_layout));
     }
 
+    @arkouda.instantiateAndRegister("sparse_matrix_matrix_mult")
+    proc sparseMatrixMatrixMultMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab,
+                                   type sparse_dtype
+    ): MsgTuple throws {
+        const e1 = st[msgArgs["arg1"]]: borrowed SparseSymEntry(sparse_dtype, 2, Layout.CSC),
+              e2 = st[msgArgs["arg2"]]: borrowed SparseSymEntry(sparse_dtype, 2, Layout.CSR);
 
-
-    proc sparseMatrixMatrixMultMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
-        var repMsg: string; // response message with the details of the new arr
-
-        var vName = st.nextName(); // symbol table key for resulting sparse arr
-
-        var gEnt1 = getGenericSparseArrayEntry(msgArgs.getValueOf("arg1"), st);
-        var gEnt2 = getGenericSparseArrayEntry(msgArgs.getValueOf("arg2"), st);
-
-        // Hardcode for int right now
-        var e1 = gEnt1.toSparseSymEntry(int, dimensions=2, layout.CSC);
-        var e2 = gEnt2.toSparseSymEntry(int, dimensions=2, layout.CSR);
-
-        var size = gEnt2.size;
-
-        var aV = sparseMatMatMult(e1.a, e2.a);
-        st.addEntry(vName, createSparseSymEntry(aV, size, layout.CSR, int));
-        repMsg = "created " + st.attrib(vName);
-        sparseLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
-        return new MsgTuple(repMsg, MsgType.NORMAL);
+        const aV = sparseMatMatMult(e1.a, e2.a);
+        return st.insert(new shared SparseSymEntry(aV, Layout.CSR));
     }
 
+    @arkouda.instantiateAndRegister("sparse_to_pdarrays")
+    proc sparseMatrixtoPdarray(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab,
+                               type sparse_dtype, param sparse_layout: Layout
+    ): MsgTuple throws {
+        const e = st[msgArgs["matrix"]]: borrowed SparseSymEntry(sparse_dtype, 2, sparse_layout);
 
-    proc sparseMatrixtoPdarray(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
-        var repMsg: string; // response message with the details of the new arr
+        const size = e.nnz;
+        var rows = makeDistArray(size, int),
+            cols = makeDistArray(size, int),
+            vals = makeDistArray(size, sparse_dtype);
 
-        var gEnt = getGenericSparseArrayEntry(msgArgs.getValueOf("matrix"), st);
-
-        var size = gEnt.nnz;
-        var rows = makeDistArray(size, int);
-        var cols = makeDistArray(size, int);
-        var vals = makeDistArray(size, int);
-
-        if gEnt.layoutStr=="CSC" {
-            // Hardcode for int right now
-            var sparrayEntry = gEnt.toSparseSymEntry(int, dimensions=2, layout.CSC);
-            sparseMatToPdarrayCSC(sparrayEntry.a, rows, cols, vals);
-        } else if gEnt.layoutStr=="CSR" {
-            // Hardcode for int right now
-            var sparrayEntry = gEnt.toSparseSymEntry(int, dimensions=2, layout.CSR);
-            sparseMatToPdarrayCSR(sparrayEntry.a, rows, cols, vals);
-        } else {
-            throw getErrorWithContext(
-                                    msg="unsupported layout for sparse matrix: %s".format(gEnt.layoutStr),
-                                    lineNumber=getLineNumber(),
-                                    routineName=getRoutineName(),
-                                    moduleName=getModuleName(),
-                                    errorClass="NotImplementedError"
-                                    );
-        }
+        sparseMatToPdarray(e.a, rows, cols, vals, sparse_layout);
 
         var responses: [0..2] MsgTuple;
-        responses[0] = st.insert(createSymEntry(rows));
-        responses[1] = st.insert(createSymEntry(cols));
-        responses[2] = st.insert(createSymEntry(vals));
+        responses[0] = st.insert(new shared SymEntry(rows));
+        responses[1] = st.insert(new shared SymEntry(cols));
+        responses[2] = st.insert(new shared SymEntry(vals));
         sparseLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "Converted sparse matrix to pdarray");
         return MsgTuple.fromResponses(responses);
     }
 
+    @arkouda.instantiateAndRegister("fill_sparse_vals")
+    proc fillSparseMatrixMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab,
+                             type sparse_dtype, param sparse_layout: Layout
+    ): MsgTuple throws {
+        const e = st[msgArgs["matrix"]]: borrowed SparseSymEntry(sparse_dtype, 2, sparse_layout),
+              vals = st[msgArgs["vals"]]: borrowed SymEntry(sparse_dtype, 1);
 
-    proc fillSparseMatrixMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
-        var repMsg: string; // response message with the details of the new arr
+        fillSparseMatrix(e.a, vals.a, sparse_layout);
 
-        var gEnt = getGenericSparseArrayEntry(msgArgs.getValueOf("matrix"), st);
-        var gEntVals: borrowed GenSymEntry = getGenericTypedArrayEntry(msgArgs.getValueOf("vals"), st);
-
-        //Hardcode int for now
-        var vals = toSymEntry(gEntVals,int);
-        if gEnt.layoutStr=="CSC" {
-            // Hardcode for int right now
-            var sparrayEntry = gEnt.toSparseSymEntry(int, dimensions=2, layout.CSC);
-            fillSparseMatrix(sparrayEntry.a, vals.a, layout.CSC);
-        } else if gEnt.layoutStr=="CSR" {
-            // Hardcode for int right now
-            var sparrayEntry = gEnt.toSparseSymEntry(int, dimensions=2, layout.CSR);
-            fillSparseMatrix(sparrayEntry.a, vals.a, layout.CSR);
-        } else {
-            throw getErrorWithContext(
-                                    msg="unsupported layout for sparse matrix: %s".format(gEnt.layoutStr),
-                                    lineNumber=getLineNumber(),
-                                    routineName=getRoutineName(),
-                                    moduleName=getModuleName(),
-                                    errorClass="NotImplementedError"
-                                    );
-        }
         sparseLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "Filled sparse Array with values");
         return MsgTuple.success();
     }
-
-
-
-    use CommandMap;
-    registerFunction("random_sparse_matrix", randomSparseMatrixMsg, getModuleName());
-    registerFunction("sparse_matrix_matrix_mult", sparseMatrixMatrixMultMsg, getModuleName());
-    registerFunction("sparse_to_pdarrays", sparseMatrixtoPdarray, getModuleName());
-    registerFunction("fill_sparse_vals", fillSparseMatrixMsg, getModuleName());
 
 }

--- a/src/SymArrayDmap.chpl
+++ b/src/SymArrayDmap.chpl
@@ -1,6 +1,6 @@
 module SymArrayDmap {
     import ChplConfig;
-    import SparseMatrix.layout;
+    import SparseMatrix.Layout;
     public use BlockDist;
     use LayoutCS;
 
@@ -130,12 +130,11 @@ module SymArrayDmap {
         return makeDistDom(size).type;
     }
 
-    proc makeSparseDomain(size: int, param matLayout) {
-      const dom = {1..size, 1..size}; // TODO: only supporting square matrices for now?
-                                      // TODO: change domain to be zero based?
+    proc makeSparseDomain(shape: 2*int, param matLayout: Layout) {
+      const dom = {1..shape[0], 1..shape[1]}; // TODO: change domain to be zero based?
       select MyDmap {
         when Dmap.defaultRectangular {
-          var spsDom: sparse subdomain(dom) dmapped new dmap(new CS(compressRows=(matLayout==layout.CSR)));
+          var spsDom: sparse subdomain(dom) dmapped new dmap(new CS(compressRows=(matLayout==Layout.CSR)));
           return (spsDom, dom);
         }
         when Dmap.blockDist {
@@ -143,7 +142,7 @@ module SymArrayDmap {
                 grid = {0..<locsPerDim, 0..<locsPerDim},
                 localeGrid = reshape(Locales[0..<grid.size], grid);
 
-          type layoutType = CS(compressRows=(matLayout==layout.CSR));
+          type layoutType = CS(compressRows=(matLayout==Layout.CSR));
           const DenseBlkDom = dom dmapped new blockDist(boundingBox=dom,
                                                         targetLocales=localeGrid,
                                                         sparseLayoutType=layoutType);
@@ -154,8 +153,8 @@ module SymArrayDmap {
       }
     }
 
-    proc makeSparseArray(size: int, type eltType, param matLayout) {
-      const (sd, _) = makeSparseDomain(size, matLayout);
+    proc makeSparseArray(shape: 2*int, type eltType, param matLayout: Layout) {
+      const (sd, _) = makeSparseDomain(shape, matLayout);
       var arr: [sd] eltType;
       return arr;
     }

--- a/training/AUTO_REGISTRATION_OVERVIEW.md
+++ b/training/AUTO_REGISTRATION_OVERVIEW.md
@@ -158,6 +158,32 @@ result = create_pdarray(
 
 Other parameter classes can also be added to the configuration file and used in a similar manner (both to instantiate array-related arguments, or for a completely different set of generic arguments). Note that `"array"` is a special parameter-class because the `registerCommand` annotation uses it to instantiate array arguments.
 
+**Note about `param` Enum formals:**
+
+In order to make a (group of) procedures generic over an enum, it's values can be specified in
+the configuration file in the following format:
+
+```json
+{
+  "group": {
+    "field": {
+      "__enum__": "ModuleName.EnumName",
+      "__variants__": ["V1", "V2", "V3"]
+    }
+  }
+}
+```
+
+The `__enum__` field is used to add an import statement to `Commands.chpl`, so the module name where the enum is defined must be provided.
+
+The `__variants__` field specifies which variants of the enum the procedure should be instantiated for. For example, procedures with arguments in the form:
+
+```chapel
+param group_field[_...]: EnumName
+```
+
+will be instantiated with `EnumName.V1`, `EnumName.V2`, and `EnumName.V3`.
+
 <a id="iar-opt-out"></a>
 ### opting out of some instantiations
 


### PR DESCRIPTION
Refactor `SparseMatrixMsg` to use `instantiateAndRegister`.

In the process:
* rename `layout` enum to `Layout`
* add support for generic enum params to `instantiateAndRegister` (useful for `Layout` enum)
* add `SparseSymEntry` support to `st.insert` 
* simplify `SparseSymEntry`'s initializer

TODO: add special support for `SparseSymEntry` in register_commands.py s.t. argument parsing and response code can be generated automatically. Then switch to using `registerCommand` where possible in `SparseMatrixMsg`. (try to do this in a general manner s.t. any child class of `AbstractSymEntry` works with `registerCommand`).