### PR TITLE
Support where-clause evaluation in registration annotations

### DIFF
--- a/arkouda/array_api/utility_functions.py
+++ b/arkouda/array_api/utility_functions.py
@@ -69,7 +69,7 @@ def clip(a: Array, a_min, a_max, /) -> Array:
         The maximum value
     """
     if a.dtype == ak.bigint or a.dtype == ak.bool_:
-        raise RuntimeError(f"Error executing command: diff clip not support dtype {a.dtype}")
+        raise RuntimeError(f"Error executing command: clip does not support dtype {a.dtype}")
 
     return Array._new(
         create_pdarray(

--- a/arkouda/array_api/utility_functions.py
+++ b/arkouda/array_api/utility_functions.py
@@ -69,7 +69,7 @@ def clip(a: Array, a_min, a_max, /) -> Array:
         The maximum value
     """
     if a.dtype == ak.bigint or a.dtype == ak.bool_:
-        raise RuntimeError(f"Error executing command: diff does not support dtype {a.dtype}")
+        raise RuntimeError(f"Error executing command: diff clip not support dtype {a.dtype}")
 
     return Array._new(
         create_pdarray(

--- a/arkouda/array_api/utility_functions.py
+++ b/arkouda/array_api/utility_functions.py
@@ -68,6 +68,9 @@ def clip(a: Array, a_min, a_max, /) -> Array:
     a_max : scalar
         The maximum value
     """
+    if a.dtype == ak.bigint or a.dtype == ak.bool_:
+        raise RuntimeError(f"Error executing command: diff does not support dtype {a.dtype}")
+
     return Array._new(
         create_pdarray(
             generic_msg(
@@ -99,6 +102,9 @@ def diff(a: Array, /, n: int = 1, axis: int = -1, prepend=None, append=None) -> 
     append : Array, optional
         Array to append to `a` along `axis` before calculating the difference.
     """
+    if a.dtype == ak.bigint or a.dtype == ak.bool_:
+        raise RuntimeError(f"Error executing command: diff does not support dtype {a.dtype}")
+
     if prepend is not None and append is not None:
         a_ = concat((prepend, a, append), axis=axis)
     elif prepend is not None:

--- a/arkouda/array_api/utility_functions.py
+++ b/arkouda/array_api/utility_functions.py
@@ -146,6 +146,9 @@ def pad(
     if mode != "constant":
         raise NotImplementedError(f"pad mode '{mode}' is not supported")
 
+    if array.dtype == ak.bigint:
+        raise RuntimeError("Error executing command: pad does not support dtype bigint")
+
     if "constant_values" not in kwargs:
         cvals = 0
     else:

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -2750,7 +2750,7 @@ def sum(
     axis_ = [] if axis is None else ([axis,] if isinstance(axis, int) else list(axis))
     repMsg = generic_msg(
         cmd=f"sum<{pda.dtype.name},{pda.ndim}>",
-        args={"x": pda, "axis": axis, "skipNan": False},
+        args={"x": pda, "axis": axis_, "skipNan": False},
     )
     if axis is None or len(axis_) == 0 or pda.ndim == 1:
         # TODO: remove call to 'flatten'

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -2757,12 +2757,11 @@ def sum(
     RuntimeError
         Raised if there's a server-side error thrown
     """
-    axis_arry = _get_axis_pdarray(axis)
     repMsg = generic_msg(
-        cmd=f"sum<{pda.dtype.name},{pda.ndim},{axis_arry.ndim}>",
-        args={"x": pda, "axis": axis_arry, "skipNan": False},
+        cmd=f"sum<{pda.dtype.name},{pda.ndim}>",
+        args={"x": pda, "axis": axis, "skipNan": False},
     )
-    if axis is None or len(axis_arry) == 0 or pda.ndim == 1:
+    if axis is None or len(axis) == 0 or pda.ndim == 1:
         return create_pdarray(cast(str, repMsg)).flatten()[0]
     else:
         return create_pdarray(cast(str, repMsg))

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -2747,7 +2747,7 @@ def sum(
     RuntimeError
         Raised if there's a server-side error thrown
     """
-    axis_ = tuple(axis) if axis is not None else ()
+    axis_ = [] if axis is None else ([axis,] if isinstance(axis, int) else list(axis))
     repMsg = generic_msg(
         cmd=f"sum<{pda.dtype.name},{pda.ndim}>",
         args={"x": pda, "axis": axis, "skipNan": False},
@@ -2836,7 +2836,7 @@ def prod(pda: pdarray, axis: Optional[Union[int, Tuple[int, ...]]] = None) -> Un
     RuntimeError
         Raised if there's a server-side error thrown
     """
-    axis_ = tuple(axis) if axis is not None else ()
+    axis_ = [] if axis is None else ([axis,] if isinstance(axis, int) else list(axis))
     repMsg = generic_msg(
         cmd=f"prod<{pda.dtype.name},{pda.ndim}>",
         args={"x": pda, "axis": axis_, "skipNan": False},
@@ -2873,7 +2873,7 @@ def min(
     RuntimeError
         Raised if there's a server-side error thrown
     """
-    axis_ = tuple(axis) if axis is not None else ()
+    axis_ = [] if axis is None else ([axis,] if isinstance(axis, int) else list(axis))
     repMsg = generic_msg(
         cmd=f"min<{pda.dtype.name},{pda.ndim}>",
         args={"x": pda, "axis": axis_, "skipNan": False},
@@ -2911,7 +2911,7 @@ def max(
     RuntimeError
         Raised if there's a server-side error thrown
     """
-    axis_ = tuple(axis) if axis is not None else ()
+    axis_ = [] if axis is None else ([axis,] if isinstance(axis, int) else list(axis))
     repMsg = generic_msg(
         cmd=f"max<{pda.dtype.name},{pda.ndim}>",
         args={"x": pda, "axis": axis_, "skipNan": False},

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -2720,16 +2720,6 @@ def is_sorted(pda: pdarray) -> np.bool_:
     )
 
 
-def _get_axis_pdarray(axis: Optional[Union[int, Tuple[int, ...]]] = None):
-    from arkouda import array as ak_array
-
-    axis_list = []
-    if axis is not None:
-        axis_list = list(axis) if isinstance(axis, tuple) else [axis]
-
-    return ak_array(axis_list, dtype="int64")
-
-
 @typechecked
 def sum(
     pda: pdarray, axis: Optional[Union[int, Tuple[int, ...]]] = None
@@ -2757,11 +2747,13 @@ def sum(
     RuntimeError
         Raised if there's a server-side error thrown
     """
+    axis_ = tuple(axis) if axis is not None else ()
     repMsg = generic_msg(
         cmd=f"sum<{pda.dtype.name},{pda.ndim}>",
         args={"x": pda, "axis": axis, "skipNan": False},
     )
-    if axis is None or len(axis) == 0 or pda.ndim == 1:
+    if axis is None or len(axis_) == 0 or pda.ndim == 1:
+        # TODO: remove call to 'flatten'
         return create_pdarray(cast(str, repMsg)).flatten()[0]
     else:
         return create_pdarray(cast(str, repMsg))
@@ -2844,12 +2836,12 @@ def prod(pda: pdarray, axis: Optional[Union[int, Tuple[int, ...]]] = None) -> Un
     RuntimeError
         Raised if there's a server-side error thrown
     """
-    axis_arry = _get_axis_pdarray(axis)
+    axis_ = tuple(axis) if axis is not None else ()
     repMsg = generic_msg(
-        cmd=f"prod<{pda.dtype.name},{pda.ndim},{axis_arry.ndim}>",
-        args={"x": pda, "axis": axis_arry, "skipNan": False},
+        cmd=f"prod<{pda.dtype.name},{pda.ndim}>",
+        args={"x": pda, "axis": axis_, "skipNan": False},
     )
-    if axis is None or len(axis_arry) == 0 or pda.ndim == 1:
+    if axis is None or len(axis_) == 0 or pda.ndim == 1:
         return create_pdarray(cast(str, repMsg)).flatten()[0]
     else:
         return create_pdarray(cast(str, repMsg))
@@ -2881,12 +2873,12 @@ def min(
     RuntimeError
         Raised if there's a server-side error thrown
     """
-    axis_arry = _get_axis_pdarray(axis)
+    axis_ = tuple(axis) if axis is not None else ()
     repMsg = generic_msg(
-        cmd=f"min<{pda.dtype.name},{pda.ndim},{axis_arry.ndim}>",
-        args={"x": pda, "axis": axis_arry, "skipNan": False},
+        cmd=f"min<{pda.dtype.name},{pda.ndim}>",
+        args={"x": pda, "axis": axis_, "skipNan": False},
     )
-    if axis is None or len(axis_arry) == 0 or pda.ndim == 1:
+    if axis is None or len(axis_) == 0 or pda.ndim == 1:
         return create_pdarray(cast(str, repMsg)).flatten()[0]
     else:
         return create_pdarray(cast(str, repMsg))
@@ -2919,12 +2911,12 @@ def max(
     RuntimeError
         Raised if there's a server-side error thrown
     """
-    axis_arry = _get_axis_pdarray(axis)
+    axis_ = tuple(axis) if axis is not None else ()
     repMsg = generic_msg(
-        cmd=f"max<{pda.dtype.name},{pda.ndim},{axis_arry.ndim}>",
-        args={"x": pda, "axis": axis_arry, "skipNan": False},
+        cmd=f"max<{pda.dtype.name},{pda.ndim}>",
+        args={"x": pda, "axis": axis_, "skipNan": False},
     )
-    if axis is None or len(axis_arry) == 0 or pda.ndim == 1:
+    if axis is None or len(axis_) == 0 or pda.ndim == 1:
         return create_pdarray(cast(str, repMsg)).flatten()[0]
     else:
         return create_pdarray(cast(str, repMsg))

--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -434,15 +434,9 @@ module ArgSortMsg
               axis =  msgArgs["axis"].toScalar(int),
               symEntry = st[msgArgs["name"]]: SymEntry(array_dtype, array_nd),
               vals = if (array_dtype == bool) then (symEntry.a:int) else (symEntry.a: array_dtype);
-    
+
         const iv = argsortDefault(vals, algorithm=algorithm, axis);
         return st.insert(new shared SymEntry(iv));
-    }
-
-    proc argsort(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype, param array_nd: int): MsgTuple throws 
-      where (array_dtype == BigInteger.bigint) || (array_dtype == uint(8)) 
-    {
-        return MsgTuple.error("argsort does not support the %s dtype".format(array_dtype:string));
     }
 
     proc argsortStrings(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -945,9 +945,9 @@ module AryUtil
       flatten a multi-dimensional array into a 1D array
     */
     @arkouda.registerCommand
-    proc flatten(const ref a: [?d] ?t): [] t throws
-      where a.rank > 1
-    {
+    proc flatten(const ref a: [?d] ?t): [] t throws {
+      if a.rank == 1 then return a;
+
       var flat = makeDistArray(d.size, t);
 
       // ranges of flat indices owned by each locale
@@ -1002,12 +1002,6 @@ module AryUtil
       }
 
       return flat;
-    }
-
-    proc flatten(const ref a: [?d] ?t): [] t throws
-      where a.rank == 1
-    {
-      return a;
     }
 
     // helper for computing an array element's index from its order

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -157,8 +157,17 @@ module AryUtil
     }
 
     proc validateNegativeAxes(axes: list(int), param nd: int): (bool, list(int)) {
-      const (valid, ret) = validateNegativeAxes(axes.toArray(), nd);
-      return (valid, new list(ret));
+      var ret = new list(int);
+      for a in axes {
+        if a >= 0 && a < nd {
+          ret.pushBack(a);
+        } else if a < 0 && a >= -nd {
+          ret.pushBack(nd + a);
+        } else {
+          return (false, ret);
+        }
+      }
+      return (true, ret);
     }
 
     /*
@@ -334,7 +343,13 @@ module AryUtil
     }
 
     proc reducedShape(shape: ?N*int, axes: list(int)): N*int {
-      return reducedShape(shape, axes.toArray());
+      var ret: N*int;
+      for param i in 0..<N {
+        if N == 1 || axes.contains(i)
+          then ret[i] = 1;
+          else ret[i] = shape[i];
+      }
+      return ret;
     }
 
     /*

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -156,6 +156,10 @@ module AryUtil
       return (true, ret);
     }
 
+    proc validateNegativeAxes(axes: list(int), param nd: int): (bool, list(int)) {
+      return new list(validateNegativeAxes(axes.toArray(), nd));
+    }
+
     /*
       Get a domain that selects out the idx'th set of indices along the specified axes
 
@@ -326,6 +330,10 @@ module AryUtil
       var ret = shape;
       ret[axis] = 1;
       return ret;
+    }
+
+    proc reducedShape(shape: ?N*int, axes: list(int)): N*int {
+      return reducedShape(shape, axes.toArray());
     }
 
     /*

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -157,7 +157,8 @@ module AryUtil
     }
 
     proc validateNegativeAxes(axes: list(int), param nd: int): (bool, list(int)) {
-      return new list(validateNegativeAxes(axes.toArray(), nd));
+      const (valid, ret) = validateNegativeAxes(axes.toArray(), nd);
+      return (valid, new list(ret));
     }
 
     /*

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -345,7 +345,7 @@ module AryUtil
     proc reducedShape(shape: ?N*int, axes: list(int)): N*int {
       var ret: N*int;
       for param i in 0..<N {
-        if N == 1 || axes.contains(i)
+        if N == 1 || axes.size == 0 || axes.contains(i)
           then ret[i] = 1;
           else ret[i] = shape[i];
       }

--- a/src/CastMsg.chpl
+++ b/src/CastMsg.chpl
@@ -25,7 +25,8 @@ module CastMsg {
     type array_dtype_to,
     param array_nd: int
   ): MsgTuple throws
-    where !(isFloatingType(array_dtype_from) && array_dtype_to == bigint) &&
+    where !((isRealType(array_dtype_from) || isImagType(array_dtype_from) || isComplexType(array_dtype_from))
+            && array_dtype_to == bigint) &&
           !(array_dtype_from == bigint && array_dtype_to == bool)
   {
     const a = st[msgArgs["name"]]: SymEntry(array_dtype_from, array_nd);

--- a/src/CastMsg.chpl
+++ b/src/CastMsg.chpl
@@ -15,10 +15,6 @@ module CastMsg {
   private config const logChannel = ServerConfig.logChannel;
   const castLogger = new Logger(logLevel, logChannel);
 
-  proc isFloatingType(type t) param : bool {
-    return isRealType(t) || isImagType(t) || isComplexType(t);
-  }
-
   @arkouda.instantiateAndRegister(prefix="cast")
   proc castArray(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab,
     type array_dtype_from,
@@ -39,22 +35,6 @@ module CastMsg {
         type2str(array_dtype_to)
       ));
     }
-  }
-
-  // cannot cast float types to bigint, cannot cast bigint to bool
-  proc castArray(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab,
-    type array_dtype_from,
-    type array_dtype_to,
-    param array_nd: int
-  ): MsgTuple throws
-    where (isFloatingType(array_dtype_from) && array_dtype_to == bigint) ||
-          (array_dtype_from == bigint && array_dtype_to == bool)
-  {
-    return MsgTuple.error(
-      "cannot cast array of type %s to %s".format(
-      type2str(array_dtype_from),
-      type2str(array_dtype_to)
-    ));
   }
 
   @arkouda.instantiateAndRegister(prefix="castToStrings")

--- a/src/CastMsg.chpl
+++ b/src/CastMsg.chpl
@@ -21,8 +21,7 @@ module CastMsg {
     type array_dtype_to,
     param array_nd: int
   ): MsgTuple throws
-    where !((isRealType(array_dtype_from) || isImagType(array_dtype_from) || isComplexType(array_dtype_from))
-            && array_dtype_to == bigint) &&
+    where !((isRealType(array_dtype_from) || isImagType(array_dtype_from) || isComplexType(array_dtype_from)) && array_dtype_to == bigint) &&
           !(array_dtype_from == bigint && array_dtype_to == bool)
   {
     const a = st[msgArgs["name"]]: SymEntry(array_dtype_from, array_nd);

--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -43,12 +43,6 @@ module GenSymIO {
         return st.insert(new shared SymEntry(makeArrayFromBytes(msgArgs.payload, shape, array_dtype)));
     }
 
-    proc array(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype, param array_nd: int): MsgTuple throws
-        where array_dtype == bigint
-    {
-        return MsgTuple.error("Array creation from binary payload is not supported for bigint arrays");
-    }
-
     proc makeArrayFromBytes(ref payload: bytes, shape: ?N*int, type t): [] t throws {
         var size = 1;
         for s in shape do size *= s;
@@ -136,12 +130,6 @@ module GenSymIO {
         }
         const size = array.size*c_sizeof(array_dtype):int;
         return MsgTuple.payload(bytes.createAdoptingBuffer(ptr:c_ptr(uint(8)), size, size));
-    }
-
-    proc tondarray(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype, param array_nd: int): MsgTuple throws
-        where array_dtype == bigint
-    {
-        return MsgTuple.error("cannot create ndarray from bigint array");
     }
 
     /*

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -206,12 +206,6 @@ module IndexingMsg
         }
     }
 
-    proc multiPDArrayIndex(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype_a, type array_dtype_idx, param array_nd: int): MsgTuple throws
-        where array_dtype_idx != int && array_dtype_idx != uint
-    {
-        return MsgTuple.error("Invalid index type: %s; must be 'int' or 'uint'".format(type2str(array_dtype_idx)));
-    }
-
     private proc multiIndexShape(inShape: ?N*int, idxDims: [?d] int, outSize: int): (bool, int, N*int) {
         var minShape: N*int = inShape,
             firstRank = -1;
@@ -958,14 +952,6 @@ module IndexingMsg
         }
 
         return st.insert(new shared SymEntry(y, x.max_bits));
-    }
-
-    proc takeAlongAxis(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab,
-        type array_dtype_x,
-        type array_dtype_idx,
-        param array_nd: int
-    ): MsgTuple throws {
-        return MsgTuple.error("Cannot take along axis with non-integer index array");
     }
 
     use CommandMap;

--- a/src/LinalgMsg.chpl
+++ b/src/LinalgMsg.chpl
@@ -61,13 +61,6 @@ module LinalgMsg {
         return st.insert(e);
     }
 
-
-    proc eye(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype): MsgTuple throws 
-       where array_dtype == BigInteger.bigint
-    {
-        return MsgTuple.error("eye does not support the bigint dtype");
-    }
-
     //  tril and triu are identical except for the argument they pass to triluHandler (true for upper, false for lower)
     //  The zeros are written into the upper (or lower) triangle of the array, offset by the value of diag.
 
@@ -79,11 +72,6 @@ module LinalgMsg {
         return triluHandler(cmd, msgArgs, st, array_dtype, array_nd, false);
     }
 
-    proc tril(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype, param array_nd: int): MsgTuple throws 
-    where array_nd < 2 {
-        return MsgTuple.error("Array must be at least 2 dimensional for 'tril'");
-    }
-
     //  Create an array from an existing array with its lower triangle zeroed out
 
     @arkouda.instantiateAndRegister
@@ -92,13 +80,9 @@ module LinalgMsg {
         return triluHandler(cmd, msgArgs, st, array_dtype, array_nd, true);
     }
 
-    proc triu(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype, param array_nd: int): MsgTuple throws 
-    where array_nd < 2 {
-        return MsgTuple.error("Array must be at least 2 dimensional for 'triu'");
-    }
-
-    //  Fetch the arguments, call zeroTri, return result. 
-
+    //  Fetch the arguments, call zeroTri, return result.
+    // TODO: support instantiating param bools with 'true' and 'false' s.t. we'd have 'triluHandler<true>' and 'triluHandler<false>'
+    //       cmds if this procedure were annotated instead of the two above.
     proc triluHandler(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab,
                       type array_dtype, param array_nd: int, param upper: bool
     ): MsgTuple throws {
@@ -193,16 +177,6 @@ module LinalgMsg {
 
         return st.insert(eOut);
 
-    }
-
-    proc matmul(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype_x1, type array_dtype_x2, param array_nd: int): MsgTuple throws
-        where (array_nd < 2) && (array_dtype_x1 != BigInteger.bigint) && (array_dtype_x2 != BigInteger.bigint) {
-            return MsgTuple.error("Matrix multiplication with arrays of dimension < 2 is not supported");
-    }
-
-    proc matmul(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype_x1, type array_dtype_x2, param array_nd: int): MsgTuple throws
-        where (array_dtype_x1 == BigInteger.bigint) || (array_dtype_x2 == BigInteger.bigint) {
-            return MsgTuple.error("Matrix multiplication with arrays of bigint type is not supported");
     }
 
     proc compute_result_type_matmul(type t1, type t2) type {
@@ -364,22 +338,6 @@ module LinalgMsg {
         if t1 == uint(8) || t2 == uint(8) then return uint(8);
         if t1 == uint(64) || t2 == uint(64) then return uint(64);
         return bool;
-    }
-
-    proc vecdot(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype_x1, type array_dtype_x2, param array_nd: int): MsgTuple throws
-        where (array_nd < 2)  && ((array_dtype_x1 != bool) || (array_dtype_x2 != bool)) 
-            && (array_dtype_x1 != BigInteger.bigint) && (array_dtype_x2 != BigInteger.bigint)  {
-            return MsgTuple.error("VecDot with arrays of dimension < 2 is not supported");
-    }
-
-    proc vecdot(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype_x1, type array_dtype_x2, param array_nd: int): MsgTuple throws
-        where (array_dtype_x1 == bool) && (array_dtype_x2 == bool) {
-            return MsgTuple.error("VecDot with arrays both of type bool is not supported");
-    }
-
-    proc vecdot(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype_x1, type array_dtype_x2, param array_nd: int): MsgTuple throws
-        where (array_dtype_x1 == BigInteger.bigint) || (array_dtype_x2 == BigInteger.bigint) {
-            return MsgTuple.error("VecDot with arrays of type bigint is not supported");
     }
 
     // @arkouda.registerND(???)

--- a/src/LinalgMsg.chpl
+++ b/src/LinalgMsg.chpl
@@ -276,11 +276,6 @@ module LinalgMsg {
         return ret;
     }
 
-    proc transpose(array: [?d] ?t): [d] t throws
-    where d.rank < 2 {
-      throw new Error("Matrix transpose with arrays of dimension < 2 is not supported");
-    }
-
     /*
         Compute the generalized dot product of two tensors along the specified axis.
 

--- a/src/Message.chpl
+++ b/src/Message.chpl
@@ -120,8 +120,11 @@ module Message {
 
     proc type MsgTuple.fromScalar(scalar: ?t): MsgTuple throws {
         import NumPyDType;
+        const dTypeName = type2str(t);
+        if dTypeName == "undef"
+            then throw new Error("Unknown scalar type '%s' in MsgTuple.fromScalar".format(t:string));
         return new MsgTuple(
-            msg = "%s %s".format(type2str(t), NumPyDType.type2fmt(t)).format(scalar),
+            msg = "%s %s".format(dTypeName, NumPyDType.type2fmt(t)).format(scalar),
             msgType = MsgType.NORMAL,
             msgFormat = MsgFormat.STRING,
             payload = b""

--- a/src/MsgProcessing.chpl
+++ b/src/MsgProcessing.chpl
@@ -339,11 +339,6 @@ module MsgProcessing
         return msg;
     }
 
-    proc chunkInfoAsString(array: [?d] ?t): string throws 
-        where (t != bool) && (t != int(64)) && (t != uint(64)) && (t != uint(8)) && (t != real){
-        throw new Error("chunkInfo does not support dtype %s".format(t:string));
-    }
-
     @arkouda.registerCommand
     proc chunkInfoAsArray(array: [?d] ?t):[] int throws
     where (t == bool) || (t == int(64)) || (t == uint(64)) || (t == uint(8)) ||(t == real) {
@@ -356,10 +351,5 @@ module MsgProcessing
                 blockSizes[i,loc.id] = locDom.dim(i).low;
         }
         return blockSizes;
-    }
-
-    proc chunkInfoAsArray(array: [?d] ?t): [d] int throws 
-        where (t != bool) && (t != int(64)) && (t != uint(64)) && (t != uint(8)) && (t != real){
-        throw new Error("chunkInfo does not support dtype %s".format(t:string));
     }
 }

--- a/src/RandMsg.chpl
+++ b/src/RandMsg.chpl
@@ -75,12 +75,6 @@ module RandMsg
         return st.insert(e);
     }
 
-    proc randint(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype, param array_nd: int): MsgTuple throws
-        where array_dtype == BigInteger.bigint
-    {
-        return MsgTuple.error("randint does not support the bigint dtype");
-    }
-
     @arkouda.instantiateAndRegister
     proc randomNormal(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, param array_nd: int): MsgTuple throws {
         const shape = msgArgs["shape"].toScalarTuple(int, array_nd),
@@ -117,12 +111,6 @@ module RandMsg
         return st.insert(new shared GeneratorSymEntry(generator, state));
     }
 
-    proc createGenerator(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype): MsgTuple throws
-        where array_dtype == BigInteger.bigint
-    {
-        return MsgTuple.error("createGenerator does not support the bigint dtype");
-    }
-
     @arkouda.instantiateAndRegister
     proc uniformGenerator(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype, param array_nd: int): MsgTuple throws
         where array_dtype != BigInteger.bigint
@@ -149,12 +137,6 @@ module RandMsg
             rng.fill(uniformEntry.a, low, high);
         }
         return st.insert(uniformEntry);
-    }
-
-    proc uniformGenerator(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype, param array_nd: int): MsgTuple throws
-        where array_dtype == BigInteger.bigint
-    {
-        return MsgTuple.error("uniformGenerator does not support the bigint dtype");
     }
 
 
@@ -252,6 +234,9 @@ module RandMsg
 
     @arkouda.instantiateAndRegister
     proc standardNormalGenerator(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, param array_nd): MsgTuple throws
+        do return standardNormalGeneratorHelp(cmd, msgArgs, st, array_nd);
+
+    proc standardNormalGeneratorHelp(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, param array_nd): MsgTuple throws
         where array_nd == 1
     {
         const name = msgArgs["name"],                           // generator name
@@ -287,7 +272,7 @@ module RandMsg
     }
 
 
-    proc standardNormalGenerator(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, param array_nd): MsgTuple throws
+    proc standardNormalGeneratorHelp(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, param array_nd): MsgTuple throws
         where array_nd > 1
     {
         const name = msgArgs["name"],                           // generator name
@@ -387,6 +372,9 @@ module RandMsg
 
     @arkouda.instantiateAndRegister
     proc standardExponential(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, param array_nd): MsgTuple throws
+        do return standardExponentialHelp(cmd, msgArgs, st, array_nd);
+
+    proc standardExponentialHelp(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, param array_nd): MsgTuple throws
         where array_nd == 1
     {
         const name = msgArgs["name"],                                   // generator name
@@ -421,7 +409,7 @@ module RandMsg
         }
     }
 
-    proc standardExponential(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, param array_nd): MsgTuple throws
+    proc standardExponentialHelp(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, param array_nd): MsgTuple throws
         where array_nd > 1
     {
         const name = msgArgs["name"],                                   // generator name
@@ -567,12 +555,6 @@ module RandMsg
         }
     }
 
-    proc choice(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype): MsgTuple throws
-        where array_dtype == BigInteger.bigint
-    {
-        return MsgTuple.error("choice does not support the bigint dtype");
-    }
-
     inline proc logisticGenerator(mu: real, scale: real, ref rs) {
         var U = rs.next(0, 1);
 
@@ -693,7 +675,10 @@ module RandMsg
     }
 
     @arkouda.instantiateAndRegister
-    proc shuffle(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype, param array_nd: int): MsgTuple throws 
+    proc shuffle(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype, param array_nd: int): MsgTuple throws
+        do return shuffleHelp(cmd, msgArgs, st, array_dtype, array_nd);
+
+    proc shuffleHelp(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype, param array_nd: int): MsgTuple throws 
         where array_nd == 1
     {
         const name = msgArgs["name"],
@@ -715,7 +700,7 @@ module RandMsg
         return MsgTuple.success();
     }
 
-    proc shuffle(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype, param array_nd: int): MsgTuple throws 
+    proc shuffleHelp(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype, param array_nd: int): MsgTuple throws 
         where array_nd != 1
     {
         const name = msgArgs["name"],

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -380,16 +380,6 @@ module ReductionMsg
 
 
     // simple and efficient 'nonzero' implementation for 1D arrays
-    proc nonzero(
-      cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab,
-      type array_dtype,
-      param array_nd: int
-    ): MsgTuple throws
-      where array_dtype == bigint
-    {
-      return MsgTuple.error("nonzero is not supported for bigint arrays");
-    }
-
     proc nonzero1D(x: [?d] ?t): [] int throws {
       const nTasksPerLoc = here.maxTaskPar;
       var nnzPerTask: [0..<numLocales] [0..<nTasksPerLoc] int;

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -129,8 +129,9 @@ module ReductionMsg
       where t==int || t==real || t==uint(64) || t==bool
     {
       use SliceReductionOps;
+
       type opType = if t == bool then int else t;
-      if d.rank == 1 then return (+ reduce x:opType);
+      if d.rank == 1 then return makeDistArray([(+ reduce x:opType)]);
 
       const (valid, axes) = validateNegativeAxes(axis, x.rank);
       if !valid {
@@ -151,21 +152,12 @@ module ReductionMsg
     }
 
     @arkouda.registerCommand
-    proc prod(ref x:[?d] ?t, axis: [?d2] int, skipNan: bool): [] t throws 
-      where (t==int || t==real || t==uint(64)) && (x.rank == 1) && (axis.rank == 1)  {
-        return makeDistArray([(* reduce x)]);
-    }
-
-    proc prod(ref x:[?d] ?t, axis: [?d2] int, skipNan: bool): [] int throws 
-      where (t==bool) && (x.rank == 1) && (axis.rank == 1)  {
-      return makeDistArray([(* reduce x:int)]);
-    }
-
-    proc prod(ref x:[?d] ?t, axis: [?d2] int, skipNan: bool): [] throws 
-      where (t==int || t==real || t==uint(64) || t==bool) && (x.rank != 1) && (axis.rank == 1) {
+    proc prod(ref x:[?d] ?t, axis: list(int), skipNan: bool): [] throws
+      where t==int || t==real || t==uint(64) || t==bool {
       use SliceReductionOps;
 
       type opType = if t == bool then int else t;
+      if d.rank == 1 then return makeDistArray([(* reduce x:opType)]);
 
       const (valid, axes) = validateNegativeAxes(axis, x.rank);
       if !valid {
@@ -183,35 +175,15 @@ module ReductionMsg
         }
         return ret;
       }
-    }   
-
-    proc prod(ref x:[?d] ?t, axis: [?d2] int, skipNan: bool): [d2] t throws 
-    where (t==int || t==real || t==uint(64) || t==bool) && (axis.rank != 1) {
-      throw new Error("prod only accepts axis of rank 1.");
     }
-
-    proc prod(ref x:[?d] ?t, axis: [?d2] int, skipNan: bool): [d2] t throws 
-    where (t!=int && t!=real && t!=uint(64) && t!=bool) {
-      throw new Error("prod does not support type %s".format(type2str(t)));
-    }
-
 
     @arkouda.registerCommand
-    proc max(ref x:[?d] ?t, axis: [?d2] int, skipNan: bool): [] t throws 
-      where (t==int || t==real || t==uint(64)) && (x.rank == 1) && (axis.rank == 1)  {
-        return makeDistArray([(max reduce x)]);
-    }
-
-    proc max(ref x:[?d] ?t, axis: [?d2] int, skipNan: bool): [] int throws 
-      where (t==bool) && (x.rank == 1) && (axis.rank == 1)  {
-      return makeDistArray([(max reduce x:int)]);
-    }
-
-    proc max(ref x:[?d] ?t, axis: [?d2] int, skipNan: bool): [] throws 
-      where (t==int || t==real || t==uint(64) || t==bool) && (x.rank != 1) && (axis.rank == 1) {
+    proc max(ref x:[?d] ?t, axis: list(int), skipNan: bool): [] throws
+      where t==int || t==real || t==uint(64) || t==bool {
       use SliceReductionOps;
 
       type opType = if t == bool then int else t;
+      if d.rank == 1 then return makeDistArray([(max reduce x:opType)]);
 
       const (valid, axes) = validateNegativeAxes(axis, x.rank);
       if !valid {
@@ -229,34 +201,15 @@ module ReductionMsg
         }
         return ret;
       }
-    }   
-
-    proc max(ref x:[?d] ?t, axis: [?d2] int, skipNan: bool): [d2] t throws 
-    where (t==int || t==real || t==uint(64) || t==bool) && (axis.rank != 1) {
-      throw new Error("max only accepts axis of rank 1.");
-    }
-
-    proc max(ref x:[?d] ?t, axis: [?d2] int, skipNan: bool): [d2] t throws 
-    where (t!=int && t!=real && t!=uint(64) && t!=bool) {
-      throw new Error("max does not support type %s".format(type2str(t)));
     }
 
     @arkouda.registerCommand
-    proc min(ref x:[?d] ?t, axis: [?d2] int, skipNan: bool): [] t throws 
-      where (t==int || t==real || t==uint(64)) && (x.rank == 1) && (axis.rank == 1)  {
-        return makeDistArray([(min reduce x)]);
-    }
-
-    proc min(ref x:[?d] ?t, axis: [?d2] int, skipNan: bool): [] int throws 
-      where (t==bool) && (x.rank == 1) && (axis.rank == 1)  {
-      return makeDistArray([(min reduce x:int)]);
-    }
-
-    proc min(ref x:[?d] ?t, axis: [?d2] int, skipNan: bool): [] throws 
-      where (t==int || t==real || t==uint(64) || t==bool) && (x.rank != 1) && (axis.rank == 1) {
+    proc min(ref x:[?d] ?t, axis: list(int), skipNan: bool): [] throws
+      where t==int || t==real || t==uint(64) || t==bool {
       use SliceReductionOps;
 
       type opType = if t == bool then int else t;
+      if d.rank == 1 then return makeDistArray([(min reduce x:opType)]);
 
       const (valid, axes) = validateNegativeAxes(axis, x.rank);
       if !valid {
@@ -274,16 +227,6 @@ module ReductionMsg
         }
         return ret;
       }
-    }   
-
-    proc min(ref x:[?d] ?t, axis: [?d2] int, skipNan: bool): [d2] t throws 
-    where (t==int || t==real || t==uint(64) || t==bool) && (axis.rank != 1) {
-      throw new Error("min only accepts axis of rank 1.");
-    }
-
-    proc min(ref x:[?d] ?t, axis: [?d2] int, skipNan: bool): [d2] t throws 
-    where (t!=int && t!=real && t!=uint(64) && t!=bool) {
-      throw new Error("min does not support type %s".format(type2str(t)));
     }
 
     /*

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -124,13 +124,16 @@ module ReductionMsg
       }
     }
 
+    proc reductionReturnType(type t) type
+      do return if t == bool then int else t;
+
     @arkouda.registerCommand
-    proc sum(ref x:[?d] ?t, axis: list(int), skipNan: bool): [] throws
+    proc sum(ref x:[?d] ?t, axis: list(int), skipNan: bool): [] reductionReturnType(t) throws
       where t==int || t==real || t==uint(64) || t==bool
     {
       use SliceReductionOps;
 
-      type opType = if t == bool then int else t;
+      type opType = reductionReturnType(t);
       if d.rank == 1 then return makeDistArray([(+ reduce x:opType)]);
 
       const (valid, axes) = validateNegativeAxes(axis, x.rank);
@@ -152,11 +155,11 @@ module ReductionMsg
     }
 
     @arkouda.registerCommand
-    proc prod(ref x:[?d] ?t, axis: list(int), skipNan: bool): [] throws
+    proc prod(ref x:[?d] ?t, axis: list(int), skipNan: bool): [] reductionReturnType(t) throws
       where t==int || t==real || t==uint(64) || t==bool {
       use SliceReductionOps;
 
-      type opType = if t == bool then int else t;
+      type opType = reductionReturnType(t);
       if d.rank == 1 then return makeDistArray([(* reduce x:opType)]);
 
       const (valid, axes) = validateNegativeAxes(axis, x.rank);
@@ -178,11 +181,11 @@ module ReductionMsg
     }
 
     @arkouda.registerCommand
-    proc max(ref x:[?d] ?t, axis: list(int), skipNan: bool): [] throws
+    proc max(ref x:[?d] ?t, axis: list(int), skipNan: bool): [] reductionReturnType(t) throws
       where t==int || t==real || t==uint(64) || t==bool {
       use SliceReductionOps;
 
-      type opType = if t == bool then int else t;
+      type opType = reductionReturnType(t);
       if d.rank == 1 then return makeDistArray([(max reduce x:opType)]);
 
       const (valid, axes) = validateNegativeAxes(axis, x.rank);
@@ -204,11 +207,11 @@ module ReductionMsg
     }
 
     @arkouda.registerCommand
-    proc min(ref x:[?d] ?t, axis: list(int), skipNan: bool): [] throws
+    proc min(ref x:[?d] ?t, axis: list(int), skipNan: bool): [] reductionReturnType(t) throws
       where t==int || t==real || t==uint(64) || t==bool {
       use SliceReductionOps;
 
-      type opType = if t == bool then int else t;
+      type opType = reductionReturnType(t);
       if d.rank == 1 then return makeDistArray([(min reduce x:opType)]);
 
       const (valid, axes) = validateNegativeAxes(axis, x.rank);

--- a/src/SetMsg.chpl
+++ b/src/SetMsg.chpl
@@ -27,12 +27,6 @@ module SetMsg {
     return st.insert(new shared SymEntry(eUnique));
   }
 
-  proc uniqueValues(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype, param array_nd: int): MsgTuple throws
-    where (array_dtype == BigInteger.bigint) || (array_dtype == uint(8))
-  {
-      return MsgTuple.error("unique_values does not support the %s dtype".format(array_dtype:string));
-  }
-
   @arkouda.instantiateAndRegister
   proc uniqueCounts(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype, param array_nd: int): MsgTuple throws {
     const name = msgArgs.getValueOf("name"),

--- a/src/SortMsg.chpl
+++ b/src/SortMsg.chpl
@@ -31,9 +31,13 @@ module SortMsg
 
     /* sort takes pdarray and returns a sorted copy of the array */
     @arkouda.registerCommand
-    proc sort(array: [?d] ?t, alg: string, axis: int): [d] t throws 
-    where ((t == real) || (t == int) || (t == uint(64))) && (d.rank == 1) {
+    proc sort(array: [?d] ?t, alg: string, axis: int): [d] t throws
+      where ((t == real) || (t == int) || (t == uint(64)))
+        do return sortHelp(array, alg, axis);
 
+    proc sortHelp(array: [?d] ?t, alg: string, axis: int): [d] t throws
+      where d.rank == 1
+    {
       var algorithm: SortingAlgorithm = ArgSortMsg.getSortingAlgorithm(alg);
       const itemsize = dtypeSize(whichDtype(t));
       overMemLimit(radixSortLSD_keys_memEst(d.size, itemsize));
@@ -48,9 +52,9 @@ module SortMsg
       }
     }
 
-    proc sort(array: [?d] ?t, alg: string, axis: int): [d] t throws 
-    where ((t == real) || (t==int) || (t==uint(64))) && (d.rank > 1) {
-
+    proc sortHelp(array: [?d] ?t, alg: string, axis: int): [d] t throws
+      where d.rank > 1
+    {
       var algorithm: SortingAlgorithm = ArgSortMsg.getSortingAlgorithm(alg);
       const itemsize = dtypeSize(whichDtype(t));
       overMemLimit(radixSortLSD_keys_memEst(d.size, itemsize));
@@ -91,16 +95,11 @@ module SortMsg
       return sorted;
     }
 
-    proc sort(array: [?d] ?t, alg: string, axis: int): [d] t throws 
-    where ((t != real) && (t!=int) && (t!=uint(64))) {
-      throw new Error("sort does not support type %s".format(type2str(t)));
-    }
-
     // https://data-apis.org/array-api/latest/API_specification/generated/array_api.searchsorted.html#array_api.searchsorted
     @arkouda.registerCommand
     proc searchSorted(x1: [?d1] real, x2: [?d2] real, side: string): [d2] int throws
-    where (d1.rank == 1) {
-
+      where d1.rank == 1
+    {
       if side != "left" && side != "right" {
           throw new Error("searchSorted side must be a string with value 'left' or 'right'.");
       }
@@ -121,11 +120,6 @@ module SortMsg
       }
 
       return ret;
-    }
-
-    proc searchSorted(x1: [?d1] real, x2: [?d2] real, side: string): [d2] int throws
-    where (d1.rank != 1){
-      throw new Error("searchSorted only arrays x1 of dimension 1.");
     }
 
     record leftCmp: relativeComparator {

--- a/src/SparseMatrixMsg.chpl
+++ b/src/SparseMatrixMsg.chpl
@@ -63,7 +63,7 @@ module SparseMatrixMsg {
         return MsgTuple.fromResponses(responses);
     }
 
-    @arkouda.registerCommand("fill_sparse_vals")
+    @arkouda.registerCommand("fill_sparse_vals", ignoreWhereClause=true)
     proc fillSparseMatrixMsg(matrix: borrowed SparseSymEntry(?), vals: [?d] ?t /* matrix.etype */) throws
         where t == matrix.etype && d.rank == 1
             do fillSparseMatrix(matrix.a, vals, matrix.matLayout);

--- a/src/StatsMsg.chpl
+++ b/src/StatsMsg.chpl
@@ -85,15 +85,6 @@ module StatsMsg {
       return (+ reduce ((x:real - mx) * (y:real - my))) / (dx.size - 1):real;
     }
 
-    // above registration will instantiate `cov` for all combinations of array ranks
-    // even though it is only valid when the ranks are the same
-    // (respecting the where clause in the signature is future work for 'registerCommand')
-    proc cov(const ref x: [?dx], const ref y: [?dy]): real throws
-      where dx.rank != dy.rank
-    {
-      throw new Error("x and y must have the same rank");
-    }
-
     @arkouda.registerCommand()
     proc corr(const ref x: [?dx] ?tx, const ref y: [?dy] ?ty): real throws
       where dx.rank == dy.rank
@@ -105,15 +96,6 @@ module StatsMsg {
             my = mean(y);
 
       return cov(x, y) / (std(x, 1) * std(y, 1));
-    }
-
-    // above registration will instantiate `corr` for all combinations of array ranks
-    // even though it is only valid when the ranks are the same
-    // (respecting the where clause in the signature is future work for 'registerCommand')
-    proc corr(const ref x: [?dx], const ref y: [?dy]): real throws
-      where dx.rank != dy.rank
-    {
-      throw new Error("x and y must have the same rank");
     }
 
     @arkouda.registerCommand()

--- a/src/UtilMsg.chpl
+++ b/src/UtilMsg.chpl
@@ -43,11 +43,6 @@ module UtilMsg {
       return y;
   }
 
-  proc clip(const ref x: [?d] ?t, min: real, max: real): [d] t throws 
-    where (t != int) && (t != real) && (t != uint(8)) && (t != uint(64)){
-      throw new Error("clip does not support dtype %s".format(t:string));
-  }
-
   /*
     Compute the n'th order discrete difference along a given axis
 
@@ -93,11 +88,6 @@ module UtilMsg {
       } // d2 deinit here
       return d1[outDom];
     }
-  }
-
-  proc diff(x: [?d] ?t, n: int, axis: int): [d] t throws 
-    where (t != real) && (t != int) && (t != uint(8)) && (t != uint(64)){
-      throw new Error("diff does not support dtype %s".format(t:string));
   }
 
   // helper to create a domain that's 'n' elements smaller in the 'axis' dimension

--- a/src/UtilMsg.chpl
+++ b/src/UtilMsg.chpl
@@ -164,9 +164,4 @@ module UtilMsg {
     return st.insert(new shared SymEntry(paddedArray));
   }
 
-  proc pad(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype, param array_nd: int): MsgTuple throws 
-    where (array_dtype != int) && (array_dtype != uint(8)) && (array_dtype != uint(64)) && (array_dtype != real) && (array_dtype != bool) {
-      throw new Error("pad does not support dtype %s".format(array_dtype:string));
-  }
-
 }

--- a/src/registry/register_commands.py
+++ b/src/registry/register_commands.py
@@ -1164,7 +1164,6 @@ def stamp_out_command(
 
     if iar_annotation and wc is not None:
         wc_node = WCNode(wc)
-        print(name, wc_node)
     else:
         wc_node = None
 

--- a/src/registry/register_commands.py
+++ b/src/registry/register_commands.py
@@ -1031,23 +1031,29 @@ class WCBinOP(WCNode):
     def eval(self, args):
         lhse = self.lhs.eval(args)
         rhse = self.rhs.eval(args)
-        match self.op:
-            case "==":
-                return lhse == rhse
-            case "!=":
-                return lhse != rhse
-            case "<":
-                return int(lhse) < int(rhse)
-            case "<=":
-                return int(lhse) <= int(rhse)
-            case ">":
-                return int(lhse) > int(rhse)
-            case ">=":
-                return int(lhse) >= int(rhse)
-            case "&&":
-                return bool(lhse) and bool(rhse)
-            case "||":
-                return bool(lhse) or bool(rhse)
+
+        if self.op == "==":
+            return lhse == rhse
+        elif self.op == "!=":
+            return lhse != rhse
+        elif self.op == "<":
+            return int(lhse) < int(rhse)
+        elif self.op == "<=":
+            return int(lhse) <= int(rhse)
+        elif self.op == ">":
+            return int(lhse) > int(rhse)
+        elif self.op == ">=":
+            return int(lhse) >= int(rhse)
+        elif self.op == "&&":
+            return bool(lhse) and bool(rhse)
+        elif self.op == "||":
+            return bool(lhse) or bool(rhse)
+        else:
+            error_message(
+                "evaluating where-clause",
+                f"binary operator '{self.op}' not yet supported in where-clauses",
+            )
+            return True
 
     def __str__(self):
         return f"({self.lhs} {self.op} {self.rhs})"
@@ -1059,11 +1065,16 @@ class WCUnaryOP(WCNode):
         self.operand = WCNode(list(ast.actuals())[0])
 
     def eval(self, args):
-        match self.op:
-            case "!":
-                return not bool(self.operand.eval(args))
-            case "-":
-                return -int(self.operand.eval(args))
+        if self.op == "!":
+            return not bool(self.operand.eval(args))
+        elif self.op == "-":
+            return -int(self.operand.eval(args))
+        else:
+            error_message(
+                "evaluating where-clause",
+                f"unary operator '{self.op}' not yet supported in where-clauses",
+            )
+            return True
 
     def __str__(self):
         return f"{self.op}{self.operand}"


### PR DESCRIPTION
Add (primitive) support for where-clause evaluation to `registerCommand` and `instantiateAndRegister`. Both annotations now evaluate the procedure's where-clause and will only generate instantiations for sets of generic parameters where the where-clause would evaluate to `true`.

The primary goal of this change is to be able to remove extraneous overloads of command procedures that simply return an error message indicating that some set of types and/or array ranks are not supported for that command. For example, in the following code snippet, the second overload of `asdf` can now be removed because the build system won't attempt to generate an instantiation for it:

```chapel
@arkouda.registerCommand
proc asdf(x: [?d] ?t): [d] t throws
  where t != bigint
{
  // ...
}

proc asdf(x: [?d] ?t): [d] t throws
  where t == bigint
    do throw new Error("'asdf' does not support 'bigint'");
```

This feature is not totally general-purpose yet. **Current limitations:**
* only some `param`-function calls are currently supported. Specifically, support for`isIntegralType` and other related procedures from Chapel's Types module is hard-coded in, but any other function calls within a where-clause will not work
* references to queried array types and queried domains are supported; however:
  * only the rank of a queried domain can be referenced (as in the code example below), none of the domain's other `param` or `type` methods/fields are accessible
  * referencing an array's `etype` or `rank` directly is not yet supported (ex: `where x.etype != bool && x.rank < 3`)
 * referencing `param` or `type` fields of a non-array argument is not yet supported (ex: `where mySparseSym.matLayout == Layout.CSR`)

Eventually, `registerCommands.py` should be modified to use the Compiler's resolver to speculatively evaluate where-clauses in a much more robust manner. This would in principle remove the above limitations, but is likely a more significant development effort than the solution in this PR.

Limitations aside, this PR allows most of the extraneous procedures currently in Arkouda to be removed.

Note: one can opt out of this feature by setting the `ignoreWhereClause` argument in the annotation call. This could be useful in an example like the one below, or to get around one of the limitations listed above.

```chapel
@arkouda.registerCommand(ignoreWhereClause=true)
proc jkl(x: [?d] ?t): [d] t throws
  where d.rank == 1 {
    // special 1D implementation ... 
}

proc jkl(x: [?d] ?t): [d] t throws
  where d.rank > 1 {
    // general ND implementation ... 
}
```

(resolves: https://github.com/Bears-R-Us/arkouda/issues/3837)