### PR TITLE
Fixes #3851: Error when running string `flip`

### DIFF
--- a/src/SegmentedMsg.chpl
+++ b/src/SegmentedMsg.chpl
@@ -1204,14 +1204,13 @@ module SegmentedMsg {
     retOffs = (+ scan retOffs) - retOffs;
 
     var flippedVals = makeDistArray(strings.values.a.domain, uint(8));
-    forall (off, len, j) in zip(offs, lengths, ..#offs.size) with (var valAgg = newDstAggregator(uint(8))) {
+    forall (off, len, j) in zip(offs, lengths, 0..) with (var valAgg = newDstAggregator(uint(8))) {
       var i = 0;
       for b in interpretAsBytes(origVals, off..#len, borrow=true) {
         valAgg.copy(flippedVals[retOffs[lengths.domain.high - j] + i], b:uint(8));
         i += 1;
       }
     }
-
     var retString = getSegString(retOffs, flippedVals, st);
     var repMsg = "created " + st.attrib(retString.name) + "+created bytes.size %?".format(retString.nBytes);
     smLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);


### PR DESCRIPTION
When running with multidim, multiloc, and runtime checks, I was seeing the server crash with the following error when running the `ak.flip(string)` test:
```
$CHPL_HOME/modules/internal/ChapelRange.chpl:2772: error: halt reached - With a positive count, the range must have a first index.
```

It ended up being a fairly easy fix once I ran it down... which took a second because this was a new error to me. This PR fixes #3851