### PR TITLE
Closes #3849: Add `SortingAlgorithm` enum to `__all__`

### DIFF
--- a/arkouda/sorting.py
+++ b/arkouda/sorting.py
@@ -21,7 +21,7 @@ from arkouda.strings import Strings
 
 numeric_dtypes = {dtype(int64), dtype(uint64), dtype(float64)}
 
-__all__ = ["argsort", "coargsort", "sort"]
+__all__ = ["argsort", "coargsort", "sort", "SortingAlgorithm"]
 
 SortingAlgorithm = Enum("SortingAlgorithm", ["RadixSortLSD", "TwoArrayRadixSort"])
 


### PR DESCRIPTION
Small change to add `SortingAlgorithm` enum to `__all__`. Since `SortingAlgorithm` is an argument to the sorting algorithms, and it would be useful to pass in `ak.SortingAlgorithm.RadixSortLSD` 

Closes #3849