### PR TITLE
Fix broken error reporting for Chapel 2.0 in `register-commands.py`

### DIFF
--- a/src/registry/register_commands.py
+++ b/src/registry/register_commands.py
@@ -49,8 +49,7 @@ RESPONSE_TYPE_NAME = "MsgTuple"
 
 def error_message(message, details, loc=None):
     if loc:
-        info = str(loc).split(":")
-        print(" [", info[0], ":", info[1], "] ", file=sys.stderr, end="")
+        print(" [", loc.path(), ":", loc.start()[0], "] ", file=sys.stderr, end="")
 
     print("Error ", message, ": ", details, file=sys.stderr)
 


### PR DESCRIPTION
Fix a bug in `register-commands.py`'s error reporting, where the code was only working with versions of chpl >=2.1. Errors should now be reported correctly for versions 2.0 - 2.2.