### PR TITLE
Fix performance regression in reductions benchmark

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -2740,7 +2740,7 @@ def _reduces_to_single_value(axis, ndim) -> bool:
 # helper function for sum, min, max, prod
 def _comon_reduction(
     pda: pdarray, axis: Optional[Union[int, Tuple[int, ...]]], kind: str
-) -> Union[numeric_and_bool_scalars, pdarray]:
+):
     if kind not in ["sum", "min", "max", "prod"]:
         raise ValueError(f"Unsupported reduction type: {kind}")
 

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -2753,8 +2753,7 @@ def sum(
         args={"x": pda, "axis": axis_, "skipNan": False},
     )
     if axis is None or len(axis_) == 0 or pda.ndim == 1:
-        # TODO: remove call to 'flatten'
-        return create_pdarray(cast(str, repMsg)).flatten()[0]
+        return create_pdarray(cast(str, repMsg))[(0,)*pda.ndim]
     else:
         return create_pdarray(cast(str, repMsg))
 
@@ -2842,7 +2841,7 @@ def prod(pda: pdarray, axis: Optional[Union[int, Tuple[int, ...]]] = None) -> Un
         args={"x": pda, "axis": axis_, "skipNan": False},
     )
     if axis is None or len(axis_) == 0 or pda.ndim == 1:
-        return create_pdarray(cast(str, repMsg)).flatten()[0]
+        return create_pdarray(cast(str, repMsg))[(0,)*pda.ndim]
     else:
         return create_pdarray(cast(str, repMsg))
 
@@ -2879,7 +2878,7 @@ def min(
         args={"x": pda, "axis": axis_, "skipNan": False},
     )
     if axis is None or len(axis_) == 0 or pda.ndim == 1:
-        return create_pdarray(cast(str, repMsg)).flatten()[0]
+        return create_pdarray(cast(str, repMsg))[(0,)*pda.ndim]
     else:
         return create_pdarray(cast(str, repMsg))
 
@@ -2917,7 +2916,7 @@ def max(
         args={"x": pda, "axis": axis_, "skipNan": False},
     )
     if axis is None or len(axis_) == 0 or pda.ndim == 1:
-        return create_pdarray(cast(str, repMsg)).flatten()[0]
+        return create_pdarray(cast(str, repMsg))[(0,)*pda.ndim]
     else:
         return create_pdarray(cast(str, repMsg))
 

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -69,7 +69,9 @@ module ReductionMsg
       where t==int || t==real || t==uint(64) || t==bool
     {
       use SliceReductionOps;
-      return prodSlice(x, x.domain, reductionReturnType(t), skipNan);
+      if skipNan
+        then return prodSlice(x, x.domain, reductionReturnType(t), true);
+        else return * reduce x:reductionReturnType(t);
     }
 
     @arkouda.registerCommand

--- a/src/registry/register_commands.py
+++ b/src/registry/register_commands.py
@@ -974,6 +974,13 @@ def gen_command_proc(name, return_type, formals, mod_name, config):
         )
     ]
 
+    def return_type_fn_name():
+        if isinstance(return_type, chapel.FnCall):
+            if ce := return_type.called_expression():
+                if isinstance(ce, chapel.Identifier):
+                    return ce.name()
+        return None
+
     # assume the returned type is a symbol if it's an identifier that is not a scalar or type-query reference
     # or if it is a type-constructor call for a class that inherits from 'AbstractSymEntry'
     returns_symbol = (
@@ -985,7 +992,8 @@ def gen_command_proc(name, return_type, formals, mod_name, config):
         )
         or (
             # TODO: do resolution to ensure that this is a class type that inherits from 'AbstractSymEntry'
-            isinstance(return_type, chapel.FnCall)
+            return_type_fn_name() is not None
+            and return_type_fn_name() in ["SymEntry",] + list(config["parameter_classes"].keys())
         )
     )
     returns_array = (


### PR DESCRIPTION
Fix a [performance regression](https://chapel-lang.org/perf/arkouda/16-node-xc/?startdate=2024/10/11&enddate=2024/10/25&graphs=reduceperformance) caused by recent refactoring of ReductionMsg.  

The refactor made total reductions (i.e., reducing an array to a single scalar value) return that scalar value via a 1-element array. This resulted in much cleaner code, but also added overhead for the total-reduction case. This PR separates total reductions into separate commands s.t. they can return a scalar directly.

Also fixes a bug in register_commands.py, where any unrecognized return type was being treated as a symbol-table entry. 