### PR TITLE
Closes #3855:  refactor boolReductionMsg

### DIFF
--- a/ServerModules.cfg
+++ b/ServerModules.cfg
@@ -26,6 +26,7 @@ OperatorMsg
 ParquetMsg
 RandMsg
 ReductionMsg
+ReductionMsgFunctions
 RegistrationMsg
 SegmentedMsg
 SequenceMsg

--- a/arkouda/array_api/statistical_functions.py
+++ b/arkouda/array_api/statistical_functions.py
@@ -50,11 +50,7 @@ def max(
 
     from arkouda import max as ak_max
 
-    arr = Array._new(ak_max(x._array, axis=axis))
-    if keepdims or axis is None or x.ndim == 1:
-        return arr
-    else:
-        return squeeze(arr, axis)
+    return Array._new(ak_max(x._array, axis=axis, keepdims=keepdims))
 
 
 # this is a temporary fix to get mean working with XArray
@@ -138,11 +134,7 @@ def min(
 
     from arkouda import min as ak_min
 
-    arr = Array._new(ak_min(x._array, axis=axis))
-    if keepdims or axis is None or x.ndim == 1:
-        return arr
-    else:
-        return squeeze(arr, axis)
+    return Array._new(ak_min(x._array, axis=axis, keepdims=keepdims))
 
 
 def prod(
@@ -180,11 +172,7 @@ def prod(
 
     from arkouda import prod as ak_prod
 
-    arr = Array._new(ak_prod(x_op, axis=axis))
-    if keepdims or axis is None or x.ndim == 1:
-        return arr
-    else:
-        return squeeze(arr, axis)
+    return Array._new(ak_prod(x_op, axis=axis, keepdims=keepdims))
 
 
 # Not working with XArray yet, pending a fix for:
@@ -277,11 +265,7 @@ def sum(
 
     from arkouda import sum as ak_sum
 
-    arr = Array._new(ak_sum(x_op, axis=axis))
-    if keepdims or axis is None or x.ndim == 1:
-        return arr
-    else:
-        return squeeze(arr, axis)
+    return Array._new(ak_sum(x_op, axis=axis, keepdims=keepdims))
 
 
 # Not working with XArray yet, pending a fix for:

--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -26,6 +26,7 @@ from arkouda.logger import getArkoudaLogger
 from arkouda.numpy import cast as akcast
 from arkouda.numpy import where
 from arkouda.numpy.dtypes import bool_ as akbool
+from arkouda.numpy.dtypes import bool_scalars
 from arkouda.numpy.dtypes import dtype as akdtype
 from arkouda.numpy.dtypes import int64 as akint64
 from arkouda.numpy.dtypes import int_scalars, resolve_scalar_dtype, str_, str_scalars
@@ -290,7 +291,7 @@ class Categorical:
             new_categories = concatenate((new_categories, array([NAvalue])))
         return [arr.set_categories(new_categories, NAvalue=NAvalue) for arr in arrays]
 
-    def equals(self, other) -> bool:
+    def equals(self, other) -> bool_scalars:
         """
         Whether Categoricals are the same size and all entries are equal.
 
@@ -320,9 +321,11 @@ class Categorical:
             if other.size != self.size:
                 return False
             else:
-                return akall(self == other)
-        else:
-            return False
+                result = akall(self == other)
+                if isinstance(result, (bool, np.bool_)):
+                    return result
+
+        return False
 
     def set_categories(self, new_categories, NAvalue=None):
         """

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -4,6 +4,7 @@ import builtins
 import json
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
+import numpy as np
 import pandas as pd
 from numpy import array as ndarray
 from numpy import dtype as npdtype
@@ -13,6 +14,7 @@ from arkouda import Categorical, Strings
 from arkouda.groupbyclass import GroupBy, unique
 from arkouda.numpy import cast as akcast
 from arkouda.numpy.dtypes import bool_ as akbool
+from arkouda.numpy.dtypes import bool_scalars
 from arkouda.numpy.dtypes import float64 as akfloat64
 from arkouda.numpy.dtypes import int64 as akint64
 from arkouda.pdarrayclass import RegistrationError, pdarray
@@ -290,7 +292,7 @@ class Index:
 
         return cls.factory(idx) if len(idx) > 1 else cls.factory(idx[0])
 
-    def equals(self, other: Index) -> bool:
+    def equals(self, other: Index) -> bool_scalars:
         """
         Whether Indexes are the same size, and all entries are equal.
 
@@ -351,7 +353,10 @@ class Index:
 
             return True
         else:
-            return akall(self == other)
+            result = akall(self == other)
+            if isinstance(result, (bool, np.bool_)):
+                return result
+        return False
 
     def memory_usage(self, unit="B"):
         """

--- a/arkouda/numpy/_numeric.py
+++ b/arkouda/numpy/_numeric.py
@@ -8,7 +8,7 @@ import numpy as np
 from typeguard import typechecked
 
 from arkouda.client import generic_msg
-from arkouda.dtypes import str_ as akstr_
+from arkouda.numpy.dtypes import str_ as akstr_
 from arkouda.groupbyclass import GroupBy, groupable
 from arkouda.numpy.dtypes import DTypes, bigint
 from arkouda.numpy.dtypes import bool_ as ak_bool

--- a/arkouda/numpy/dtypes/dtypes.py
+++ b/arkouda/numpy/dtypes/dtypes.py
@@ -56,6 +56,7 @@ __all__ = [
     "int8",
     "intTypes",
     "int_scalars",
+    "isSupportedBool",
     "isSupportedFloat",
     "isSupportedInt",
     "isSupportedNumber",
@@ -245,6 +246,8 @@ class DType(Enum):
         return self.value
 
 
+ARKOUDA_SUPPORTED_BOOLS = (bool, np.bool_)
+
 ARKOUDA_SUPPORTED_INTS = (
     int,
     np.int8,
@@ -311,6 +314,10 @@ def isSupportedFloat(num):
 
 def isSupportedNumber(num):
     return isinstance(num, ARKOUDA_SUPPORTED_NUMBERS)
+
+
+def isSupportedBool(num):
+    return isinstance(num, ARKOUDA_SUPPORTED_BOOLS)
 
 
 def resolve_scalar_dtype(val: object) -> str:

--- a/arkouda/pdarraymanipulation.py
+++ b/arkouda/pdarraymanipulation.py
@@ -3,7 +3,7 @@ from typeguard import typechecked
 
 from arkouda.client import generic_msg
 from arkouda.pdarrayclass import pdarray, create_pdarray
-from arkouda.dtypes import dtype as akdtype
+from arkouda.numpy.dtypes import dtype as akdtype
 
 import numpy as np
 

--- a/arkouda/series.py
+++ b/arkouda/series.py
@@ -16,7 +16,7 @@ from arkouda.groupbyclass import GroupBy, groupable_element_type
 from arkouda.index import Index, MultiIndex
 from arkouda.numpy import cast as akcast
 from arkouda.numpy import isnan, value_counts
-from arkouda.numpy.dtypes import dtype, float64, int64
+from arkouda.numpy.dtypes import bool_scalars, dtype, float64, int64
 from arkouda.pdarrayclass import (
     RegistrationError,
     any,
@@ -1442,7 +1442,7 @@ class Series:
         """
         return self.notna()
 
-    def hasnans(self) -> bool:
+    def hasnans(self) -> bool_scalars:
         """
         Return True if there are any NaNs.
 
@@ -1465,9 +1465,11 @@ class Series:
         True
         """
         if is_float(self.values):
-            return any(isnan(self.values))
-        else:
-            return False
+            result = any(isnan(self.values))
+            if isinstance(result, (bool, np.bool_)):
+                return result
+
+        return False
 
     def fillna(self, value) -> Series:
         """

--- a/arkouda/sparrayclass.py
+++ b/arkouda/sparrayclass.py
@@ -7,7 +7,7 @@ import numpy as np
 from typeguard import typechecked
 
 from arkouda.client import generic_msg
-from arkouda.dtypes import NumericDTypes, dtype, int_scalars
+from arkouda.numpy.dtypes import NumericDTypes, dtype, int_scalars
 from arkouda.logger import getArkoudaLogger
 from arkouda.pdarrayclass import create_pdarrays, pdarray
 

--- a/arkouda/sparsematrix.py
+++ b/arkouda/sparsematrix.py
@@ -6,8 +6,8 @@ import numpy as np
 from typeguard import typechecked
 
 from arkouda.client import generic_msg
-from arkouda.dtypes import dtype as akdtype
-from arkouda.dtypes import int64
+from arkouda.numpy.dtypes import dtype as akdtype
+from arkouda.numpy.dtypes import int64
 from arkouda.logger import getArkoudaLogger
 from arkouda.numpy.dtypes.dtypes import NumericDTypes
 from arkouda.pdarrayclass import pdarray

--- a/arkouda/strings.py
+++ b/arkouda/strings.py
@@ -13,7 +13,7 @@ from arkouda.client import generic_msg
 from arkouda.infoclass import information, list_symbol_table
 from arkouda.logger import getArkoudaLogger
 from arkouda.match import Match, MatchType
-from arkouda.numpy.dtypes import NUMBER_FORMAT_STRINGS
+from arkouda.numpy.dtypes import NUMBER_FORMAT_STRINGS, bool_scalars
 from arkouda.numpy.dtypes import dtype as akdtype
 from arkouda.numpy.dtypes import int_scalars, resolve_scalar_dtype, str_, str_scalars
 from arkouda.pdarrayclass import RegistrationError
@@ -272,10 +272,10 @@ class Strings:
             )
         return create_pdarray(generic_msg(cmd=cmd, args=args))
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other):  # type: ignore
         return self._binop(other, "==")
 
-    def __ne__(self, other) -> bool:
+    def __ne__(self, other):  # type: ignore
         return self._binop(cast(Strings, other), "!=")
 
     def __getitem__(self, key):
@@ -339,7 +339,7 @@ class Strings:
         """
         return "string"
 
-    def equals(self, other) -> bool:
+    def equals(self, other) -> bool_scalars:
         """
         Whether Strings are the same size and all entries are equal.
 
@@ -369,9 +369,10 @@ class Strings:
             if other.size != self.size:
                 return False
             else:
-                return akall(self == other)
-        else:
-            return False
+                result = akall(self == other)
+                if isinstance(result, (bool, np.bool_)):
+                    return result
+        return False
 
     def get_lengths(self) -> pdarray:
         """

--- a/arkouda/testing/_asserters.py
+++ b/arkouda/testing/_asserters.py
@@ -19,7 +19,7 @@ from arkouda import (
     pdarray,
     sort,
 )
-from arkouda import sum as aksum
+from arkouda.pdarrayclass import sum as aksum
 from arkouda.util import is_numeric
 
 DEBUG = True
@@ -310,7 +310,7 @@ def assert_index_equal(
             else:
                 mismatch = left != right
 
-            diff = aksum(mismatch.astype(int)) * 100.0 / len(left)
+            diff = aksum(mismatch.astype(int)).astype(float) * 100.0 / len(left)
             msg = f"{obj} values are different ({np.round(diff, 5)} %)"
             raise_assert_detail(obj, msg, left, right)
     else:
@@ -561,7 +561,7 @@ def assert_arkouda_pdarray_equal(
             if left.shape != right.shape:
                 raise_assert_detail(obj, f"{obj} shapes are different", left.shape, right.shape)
 
-            diff = aksum(left != right)
+            diff = aksum(left != right).astype(float)
 
             diff = diff * 100.0 / left.size
             msg = f"{obj} values are different ({np.round(diff, 5)} %)"
@@ -570,7 +570,7 @@ def assert_arkouda_pdarray_equal(
         raise AssertionError(err_msg)
 
     from arkouda import all as akall
-    from arkouda.dtypes import bigint, dtype
+    from arkouda.numpy.dtypes import bigint, dtype
 
     # compare shape and values
     # @TODO use ak.allclose
@@ -704,7 +704,7 @@ def assert_arkouda_strings_equal(
 
     def _raise(left: Strings, right: Strings, err_msg):
         if err_msg is None:
-            diff = aksum(left != right)
+            diff = aksum(left != right).astype(float)
             diff = diff * 100.0 / left.size
             msg = f"{obj} values are different ({np.round(diff, 5)} %)"
             raise_assert_detail(obj, msg, left, right, index_values=index_values)

--- a/pydoc/preprocess/generate_import_stubs.py
+++ b/pydoc/preprocess/generate_import_stubs.py
@@ -152,6 +152,7 @@ def main():
     import arkouda.scipy.special as akscipySpecial
     import arkouda.scipy.stats as akscipyStats
     import arkouda.series as akSeries
+    import arkouda as ak
 
     write_stub(aknp, "arkouda/numpy.pyi", all_only=False, allow_arkouda=True)
     write_stub(aknp.dtypes, "arkouda/numpy/dtypes.pyi", all_only=False, allow_arkouda=True)
@@ -162,7 +163,7 @@ def main():
     write_stub(akDataframe, "arkouda/dataframe.pyi", all_only=True, allow_arkouda=True)
     write_stub(akGroupbyclass, "arkouda/groupbyclass.pyi", all_only=True, allow_arkouda=True)
     write_stub(akSeries, "arkouda/series.pyi", all_only=True, allow_arkouda=True)
-
+    write_stub(ak.pdarrayclass, "arkouda/pdarrayclass.pyi", all_only=True, allow_arkouda=True)
 
 if __name__ == "__main__":
     main()

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -96,7 +96,7 @@ module AryUtil
       :arg A: array to check
 
     */
-    proc isSorted(A:[?D] ?t): bool {
+    proc isSorted(A:[?D] ?t): bool where D.rank == 1 {
         var sorted: bool;
         sorted = true;
         forall (a,i) in zip(A,D) with (&& reduce sorted) {
@@ -115,7 +115,7 @@ module AryUtil
       :arg slice: a slice domain (only the indices in this domain are checked)
       :arg axisIdx: the axis to check
     */
-    proc isSortedOver(A: [?D] ?t, slice, axisIdx: int) {
+    proc isSortedOver(const ref A: [?D] ?t, const ref slice, axisIdx: int) {
         var sorted = true;
         forall i in slice with (&& reduce sorted, var im1: D.rank*int) {
             if i[axisIdx] > slice.dim(axisIdx).low {

--- a/src/ReductionMsg.chpl
+++ b/src/ReductionMsg.chpl
@@ -34,7 +34,7 @@ module ReductionMsg
     const basicReductionOps = {"sum", "prod", "min", "max"},
           boolReductionOps = {"any", "all", "is_sorted", "is_locally_sorted"},
           idxReductionOps = {"argmin", "argmax"};
-
+    
     proc reductionReturnType(type t) type
       do return if t == bool then int else t;
 
@@ -138,120 +138,6 @@ module ReductionMsg
         forall (sliceDom, sliceIdx) in axisSlices(x.domain, axes)
           do ret[sliceIdx] = getMinSlice(x, sliceDom, skipNan);
         return ret;
-      }
-    }
-
-    /*
-      Compute an array reduction along one or more axes.
-      (where the result has a bool data type)
-
-      Supports: 'any', 'all', is_sorted, is_locally_sorted
-    */
-    @arkouda.registerND(cmd_prefix="reduce->bool")
-    proc boolReductionMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, param nd: int): MsgTuple throws {
-      use SliceReductionOps;
-      param pn = Reflection.getRoutineName();
-      const x = msgArgs.getValueOf("x"),
-            op = msgArgs.getValueOf("op"),
-            nAxes = msgArgs.get("nAxes").getIntValue(),
-            axesRaw = msgArgs.get("axis").toScalarArray(int, nAxes),
-            rname = st.nextName();
-
-      var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(x, st);
-
-      if !boolReductionOps.contains(op) {
-        const errorMsg = notImplementedError(pn,op,gEnt.dtype);
-        rmLogger.error(getModuleName(),pn,getLineNumber(),errorMsg);
-        return new MsgTuple(errorMsg, MsgType.ERROR);
-      }
-
-      if nd > 1 && (op == "is_sorted" || op == "is_locally_sorted") {
-        // TODO: support this for any case where nAxes == 1)
-        const errorMsg = "is_sorted checks are only supported for 1D arrays";
-        rmLogger.error(getModuleName(),pn,getLineNumber(),errorMsg);
-        return new MsgTuple(errorMsg, MsgType.ERROR);
-      }
-
-      proc computeReduction(type t): MsgTuple throws {
-        const eIn = toSymEntry(gEnt, t, nd);
-
-        if nd == 1 || nAxes == 0 {
-          var s: bool;
-          select op {
-            when "any" {
-              s = if t == bool
-                then | reduce eIn.a
-                else (+ reduce (eIn.a != 0)) != 0;
-            }
-            when "all" {
-              s = if t == bool
-                then & reduce eIn.a
-                else (+ reduce (eIn.a != 0)) == eIn.a.size;
-            }
-            when "is_sorted" do s = isSorted(eIn.a);
-            when "is_locally_sorted" {
-              coforall loc in Locales with (&& reduce s) do on loc {
-                ref aLocal = eIn.a[eIn.a.localSubdomain()];
-                s &&= isSorted(aLocal);
-              }
-            }
-            otherwise halt("unreachable");
-          }
-
-          const scalarValue = "bool " + bool2str(s);
-          rmLogger.debug(getModuleName(),pn,getLineNumber(),scalarValue);
-          return new MsgTuple(scalarValue, MsgType.NORMAL);
-        } else {
-          const (valid, axes) = validateNegativeAxes(axesRaw, nd);
-          if !valid {
-            var errorMsg = "Invalid axis value(s) '%?' in slicing reduction".format(axesRaw);
-            rmLogger.error(getModuleName(),pn,getLineNumber(),errorMsg);
-            return new MsgTuple(errorMsg,MsgType.ERROR);
-          } else {
-            const outShape = reducedShape(eIn.a.shape, axes);
-            var eOut = st.addEntry(rname, outShape, bool);
-
-            forall sliceIdx in domOffAxis(eIn.a.domain, axes) {
-              const sliceDom = domOnAxis(eIn.a.domain, sliceIdx, axes);
-              var s: bool = true;
-              select op {
-                when "any" do s = any(eIn.a, sliceDom);
-                when "all" do s = all(eIn.a, sliceDom);
-                when "is_sorted" {
-                  // TODO: maybe it's better to fold this loop outside of the
-                  // domOffAxis loop (check one dimension at a time globally).
-                  for axisIdx in axes do
-                    s &&= isSortedOver(eIn.a, sliceDom, axisIdx);
-                }
-                when "is_locally_sorted" {
-                  coforall loc in Locales with (&& reduce s) do on loc {
-                    const localSliceDom = sliceDom[eIn.a.localSubdomain()];
-                    for axisIdx in axes do
-                      s &&= isSortedOver(eIn.a, localSliceDom, axisIdx);
-                  }
-                }
-                otherwise halt("unreachable");
-              }
-              eOut.a[sliceIdx] = s;
-            }
-
-            const repMsg = "created " + st.attrib(rname);
-            rmLogger.info(getModuleName(),pn,getLineNumber(),repMsg);
-            return new MsgTuple(repMsg, MsgType.NORMAL);
-          }
-        }
-      }
-
-      select gEnt.dtype {
-        when DType.Int64 do return computeReduction(int);
-        when DType.UInt64 do return computeReduction(uint);
-        when DType.Float64 do return computeReduction(real);
-        when DType.Bool do return computeReduction(bool);
-        otherwise {
-          var errorMsg = notImplementedError(pn,dtype2str(gEnt.dtype));
-          rmLogger.error(getModuleName(),pn,getLineNumber(),errorMsg);
-          return new MsgTuple(errorMsg,MsgType.ERROR);
-        }
       }
     }
 
@@ -429,32 +315,77 @@ module ReductionMsg
       return nnzIndices;
     }
 
-    private module SliceReductionOps {
+    module SliceReductionOps {
       private proc isArgandType(type t) param: bool do
         return isRealType(t) || isImagType(t) || isComplexType(t);
 
-      proc any(ref a: [] bool, slice): bool {
+      proc anySlice(const ref a: [] bool, slice): bool {
         var hasAny = false;
         forall i in slice with (|| reduce hasAny) do hasAny ||= a[i];
         return hasAny;
       }
 
-      proc any(ref a: [] ?t, slice): bool {
-        var sum = 0:t;
+      proc anySlice(const ref a: [] ?t, slice): bool {
+        var sum = 0:int;
         forall i in slice with (+ reduce sum) do sum += (a[i] != 0):int;
         return sum != 0;
       }
 
-      proc all(ref a: [] bool, slice): bool {
+      proc allSlice(const ref a: [] bool, slice): bool {
         var hasAll = true;
         forall i in slice with (&& reduce hasAll) do hasAll &&= a[i];
         return hasAll;
       }
 
-      proc all(ref a: [] ?t, slice): bool {
-        var sum = 0:t;
+      proc allSlice(const ref a: [] ?t, slice): bool {
+        var sum = 0:int;
         forall i in slice with (+ reduce sum) do sum += (a[i] != 0):int;
-        return sum == a.size;
+        return sum == slice.size;
+      }
+
+      proc isSortedLocallySlice(const ref A: [?D] ?t, slice) 
+        where D.rank == 1 {
+        var s = true;
+        coforall loc in Locales with (&& reduce s) do on loc {
+
+          const ref localSliceDom = slice.localSubdomain();
+          const ref aLocalSlice = A[localSliceDom];
+
+          s &&= isSortedSlice(aLocalSlice, localSliceDom);
+
+        }
+        return s;
+      }   
+
+      proc isSortedLocallySlice(const ref A: [?D] ?t, slice) 
+        where D.rank != 1 {
+        var s = true;
+        coforall loc in Locales with (&& reduce s) do on loc {
+
+          const ref localSliceDom = slice.localSubdomain();
+          const ref aLocalSlice = A[localSliceDom];
+
+          forall axisIdx in 0..#aLocalSlice.rank  with (&& reduce s){
+            s &&= isSortedOver(aLocalSlice, localSliceDom, axisIdx);
+          }
+        }
+        return s;
+      }
+
+      proc isSortedSlice(const ref A: [?D] ?t, slice) 
+        where D.rank != 1 {
+        const ref aSlice = A[slice];
+        var s = true;
+        forall axisIdx in 0..#slice.rank  with (&& reduce s){
+          s &&= isSortedOver(aSlice, slice, axisIdx);
+        }
+        return s;
+      }
+
+      proc isSortedSlice(const ref A: [?D] ?t, slice) 
+        where D.rank == 1 {
+        const ref aSlice = A[slice];
+        return isSorted(aSlice);
       }
 
       proc sumSlice(const ref a: [?d] ?t, slice, type opType, skipNan: bool): opType {

--- a/src/ReductionMsgFunctions.chpl
+++ b/src/ReductionMsgFunctions.chpl
@@ -1,0 +1,109 @@
+module ReductionMsgFunctions
+{
+    use BigInteger;
+    use List;
+    use AryUtil;
+    use ReductionMsg;
+    use SliceReductionOps;
+
+    @arkouda.registerCommand
+    proc anyAll(const ref x:[?d] ?t): bool throws
+    {
+      use SliceReductionOps;
+      return anySlice(x, x.domain);
+    }
+
+    @arkouda.registerCommand
+    proc any(const ref x:[?d] ?t, axis: list(int)): [] bool throws
+      {
+      use SliceReductionOps;
+      type opType = bool;
+      const (valid, axes) = validateNegativeAxes(axis, x.rank);
+      if !valid {
+        throw new Error("Invalid axis value(s) '%?' in slicing reduction".format(axis));
+      } else {
+        const outShape = reducedShape(x.shape, axes);
+        var ret = makeDistArray((...outShape), opType);
+        forall (sliceDom, sliceIdx) in axisSlices(x.domain, axes)
+          do ret[sliceIdx] = anySlice(x, sliceDom);
+        return ret;
+      }
+    }
+
+
+    @arkouda.registerCommand
+    proc allAll(const ref x:[?d] ?t): bool throws
+    {
+      use SliceReductionOps;
+      return allSlice(x, x.domain);
+    }
+
+    @arkouda.registerCommand
+    proc all(const ref x:[?d] ?t, axis: list(int)): [] bool throws
+      {
+      use SliceReductionOps;
+      type opType = bool;
+      const (valid, axes) = validateNegativeAxes(axis, x.rank);
+      if !valid {
+        throw new Error("Invalid axis value(s) '%?' in slicing reduction".format(axis));
+      } else {
+        const outShape = reducedShape(x.shape, axes);
+        var ret = makeDistArray((...outShape), opType);
+        forall (sliceDom, sliceIdx) in axisSlices(x.domain, axes)
+          do ret[sliceIdx] = allSlice(x, sliceDom);
+        return ret;
+      }
+    }
+
+
+    @arkouda.registerCommand
+    proc isSortedAll(const ref x:[?d] ?t): bool throws
+    {
+      use SliceReductionOps;
+      return isSortedSlice(x, x.domain);
+    }
+
+    @arkouda.registerCommand
+    proc isSorted(const ref x:[?d] ?t, axis: list(int)): [] bool throws
+      {
+      use SliceReductionOps;
+      type opType = bool;
+      const (valid, axes) = validateNegativeAxes(axis, x.rank);
+      if !valid {
+        throw new Error("Invalid axis value(s) '%?' in slicing reduction".format(axis));
+      } else {
+        const outShape = reducedShape(x.shape, axes);
+        var ret = makeDistArray((...outShape), opType);
+        forall (sliceDom, sliceIdx) in axisSlices(x.domain, axes)
+          do ret[sliceIdx] = isSortedSlice(x, sliceDom);
+        return ret;
+      }
+    }
+
+
+    @arkouda.registerCommand
+    proc isSortedLocallyAll(const ref x:[?d] ?t): bool throws
+    {
+      use SliceReductionOps;
+      return isSortedLocallySlice(x, x.domain);
+    }
+
+    @arkouda.registerCommand
+    proc isSortedLocally(const ref x:[?d] ?t, axis: list(int)): [] bool throws
+      {
+      use SliceReductionOps;
+      type opType = bool;
+      const (valid, axes) = validateNegativeAxes(axis, x.rank);
+      if !valid {
+        throw new Error("Invalid axis value(s) '%?' in slicing reduction".format(axis));
+      } else {
+        const outShape = reducedShape(x.shape, axes);
+        var ret = makeDistArray((...outShape), opType);
+        forall (sliceDom, sliceIdx) in axisSlices(x.domain, axes)
+          do ret[sliceIdx] = isSortedLocallySlice(x, sliceDom);
+        return ret;
+      }
+    }
+
+
+}

--- a/src/scripts/generate_reduction_functions.py
+++ b/src/scripts/generate_reduction_functions.py
@@ -1,0 +1,70 @@
+FUNCS = [
+    ["any", "bool", []],
+    ["all", "bool", []],
+    ["isSorted", "bool", []],
+    ["isSortedLocally", "bool", []],
+]
+
+
+def generate_reduction_functions():
+
+    ret = """module ReductionMsgFunctions
+{
+    use BigInteger;
+    use List;
+    use AryUtil;
+    use ReductionMsg;
+    use SliceReductionOps;
+"""
+
+    for func, ret_type, allowed_types in FUNCS:
+
+        where_statement = ""
+
+        if len(allowed_types) > 0:
+            where_statement += "where "
+            where_statement += "||".join([f"(t=={tp})" for tp in allowed_types])
+
+        ret += f"""
+    @arkouda.registerCommand
+    proc {func}All(const ref x:[?d] ?t): {ret_type} throws
+    {where_statement}{{
+      use SliceReductionOps;
+      return {func}Slice(x, x.domain);
+    }}
+
+    @arkouda.registerCommand
+    proc {func}(const ref x:[?d] ?t, axis: list(int)): [] {ret_type} throws
+      {where_statement}{{
+      use SliceReductionOps;
+      type opType = {ret_type};
+      const (valid, axes) = validateNegativeAxes(axis, x.rank);
+      if !valid {{
+        throw new Error("Invalid axis value(s) '%?' in slicing reduction".format(axis));
+      }} else {{
+        const outShape = reducedShape(x.shape, axes);
+        var ret = makeDistArray((...outShape), opType);
+        forall (sliceDom, sliceIdx) in axisSlices(x.domain, axes)
+          do ret[sliceIdx] = {func}Slice(x, sliceDom);
+        return ret;
+      }}
+    }}"""
+        ret += "\n\n"
+
+    ret = ret.replace("\t", "  ")
+    ret = ret
+    ret += "\n}"
+
+    return ret
+
+
+def main():
+
+    outfile = "src/ReductionMsgFunctions.chpl"
+
+    with open(outfile, "w") as text_file:
+        text_file.write(generate_reduction_functions())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,3 +130,14 @@ def skip_by_rank(request):
     if request.node.get_closest_marker("skip_if_max_rank_greater_than"):
         if request.node.get_closest_marker("skip_if_max_rank_greater_than").args[0] < pytest.max_rank:
             pytest.skip("this test requires server with max_array_dims =< {}".format(pytest.max_rank))
+
+
+@pytest.fixture(autouse=True)
+def skip_by_num_locales(request):
+    if request.node.get_closest_marker("skip_if_nl_less_than"):
+        if request.node.get_closest_marker("skip_if_nl_less_than").args[0] > pytest.nl:
+            pytest.skip("this test requires server with nl >= {}".format(pytest.nl))
+
+    if request.node.get_closest_marker("skip_if_nl_greater_than"):
+        if request.node.get_closest_marker("skip_if_nl_greater_than").args[0] < pytest.nl:
+            pytest.skip("this test requires server with nl =< {}".format(pytest.nl))

--- a/tests/deprecated/dtypes_tests.py
+++ b/tests/deprecated/dtypes_tests.py
@@ -115,7 +115,7 @@ class DtypesTest(ArkoudaTest):
         self.assertEqual("<class 'list'>", dtypes.resolve_scalar_dtype([1]))
 
     def test_is_dtype_in_union(self):
-        from arkouda.dtypes import _is_dtype_in_union
+        from arkouda.numpy.dtypes import _is_dtype_in_union
         from typing import Union
 
         float_scalars = Union[float, np.float64, np.float32]
@@ -126,7 +126,7 @@ class DtypesTest(ArkoudaTest):
         self.assertFalse(_is_dtype_in_union(np.float64, float))
 
     def test_nbytes(self):
-        from arkouda.dtypes import BigInt
+        from arkouda.numpy.dtypes import BigInt
 
         a = ak.cast(ak.array([1, 2, 3]), dt="bigint")
         self.assertEqual(a.nbytes, 3 * BigInt.itemsize)

--- a/tests/deprecated/groupby_test.py
+++ b/tests/deprecated/groupby_test.py
@@ -3,7 +3,7 @@ import pandas as pd
 from base_test import ArkoudaTest
 from context import arkouda as ak
 
-from arkouda.dtypes import float64, int64
+from arkouda.numpy.dtypes import float64, int64
 from arkouda.groupbyclass import GroupByReductionType
 from arkouda.scipy import chisquare as akchisquare
 

--- a/tests/deprecated/index_test.py
+++ b/tests/deprecated/index_test.py
@@ -8,7 +8,7 @@ from context import arkouda as ak
 from numpy import dtype as npdtype
 
 from arkouda import io_util
-from arkouda.dtypes import dtype
+from arkouda.numpy.dtypes import dtype
 from arkouda.index import Index
 from arkouda.pdarrayclass import pdarray
 
@@ -269,7 +269,7 @@ class IndexTest(ArkoudaTest):
             m2.get_level_values(-1 * m2.nlevels)
 
     def test_memory_usage(self):
-        from arkouda.dtypes import BigInt
+        from arkouda.numpy.dtypes import BigInt
         from arkouda.index import Index, MultiIndex
 
         idx = Index(ak.cast(ak.array([1, 2, 3]), dt="bigint"))

--- a/tests/deprecated/numeric_test.py
+++ b/tests/deprecated/numeric_test.py
@@ -3,7 +3,7 @@ from math import isclose
 from base_test import ArkoudaTest
 from context import arkouda as ak
 
-from arkouda.dtypes import npstr
+from arkouda.numpy.dtypes import npstr
 
 """
 Encapsulates unit tests for the numeric module with the exception

--- a/tests/index_test.py
+++ b/tests/index_test.py
@@ -316,26 +316,26 @@ class TestIndex:
 
     def test_equal_levels(self):
         m = ak.MultiIndex(
-            [ak.arange(3), ak.arange(3) * -1, ak.array(["a", 'b","c', "d"])],
+            [ak.arange(3), ak.arange(3) * -1, ak.array(["a", "b", "c"])],
             names=["col1", "col2", "col3"],
         )
 
         m2 = ak.MultiIndex(
-            [ak.arange(3), ak.arange(3) * -1, ak.array(["a", 'b","c', "d"])],
+            [ak.arange(3), ak.arange(3) * -1, ak.array(["a", "b", "c"])],
             names=["A", "B", "C"],
         )
 
         assert m.equal_levels(m2)
 
         m3 = ak.MultiIndex(
-            [ak.arange(3), ak.arange(3) * -1, ak.array(["a", 'b","c', "d"]), 2 * ak.arange(3)],
+            [ak.arange(3), ak.arange(3) * -1, ak.array(["a", "b", "c"]), 2 * ak.arange(3)],
             names=["col1", "col2", "col3"],
         )
 
         assert not m.equal_levels(m3)
 
         m4 = ak.MultiIndex(
-            [ak.arange(3), ak.arange(3) * 2, ak.array(["a", 'b","c', "d"])],
+            [ak.arange(3), ak.arange(3) * 2, ak.array(["a", "b", "c"])],
             names=["col1", "col2", "col3"],
         )
 

--- a/tests/numpy/numeric_test.py
+++ b/tests/numpy/numeric_test.py
@@ -5,8 +5,8 @@ import pytest
 
 import arkouda as ak
 from arkouda.client import get_max_array_rank
-from arkouda.dtypes import dtype as akdtype
-from arkouda.dtypes import str_
+from arkouda.numpy.dtypes import dtype as akdtype
+from arkouda.numpy.dtypes import str_
 
 ARRAY_TYPES = [ak.int64, ak.float64, ak.bool_, ak.uint64, str_]
 NUMERIC_TYPES = [ak.int64, ak.float64, ak.bool_, ak.uint64]

--- a/tests/pdarrayclass_test.py
+++ b/tests/pdarrayclass_test.py
@@ -1,3 +1,5 @@
+from typing import Optional, Tuple, Union
+
 import numpy as np
 import pytest
 
@@ -5,6 +7,14 @@ import arkouda as ak
 from arkouda.testing import assert_equal as ak_assert_equal
 
 SEED = 314159
+import numpy
+
+import arkouda.pdarrayclass
+
+REDUCTION_OPS = list(set(ak.pdarrayclass.SUPPORTED_REDUCTION_OPS) - set(["isSorted", "isSortedLocally"]))
+DTYPES = ["int64", "float64", "bool", "uint64"]
+
+#   TODO: add unint8 to DTYPES
 
 
 class TestPdarrayClass:
@@ -42,79 +52,133 @@ class TestPdarrayClass:
         b = a.reshape((2, 2, size / 4))
         ak_assert_equal(b.flatten(), a)
 
-    def test_prod(self):
-        a = ak.arange(10) + 1
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype", DTYPES)
+    @pytest.mark.parametrize("axis", [0, (0,), None])
+    def test_is_sorted(self, size, dtype, axis):
 
-        assert ak.prod(a) == 3628800
+        a = ak.arange(size, dtype=dtype)
+        assert ak.is_sorted(a, axis=axis)
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
-    def test_prod_multidim(self):
-        a = ak.ones((2, 3, 4))
-        a = a + a
+        b = ak.flip(a)
+        assert not ak.is_sorted(b, axis=axis)
 
-        assert ak.prod(a) == 2**24
-
-        aProd0 = ak.prod(a, axis=0)
-        assert aProd0.shape == (1, 3, 4)
-        assert aProd0[0, 0, 0] == 2**2
-
-        aProd02 = ak.prod(a, axis=(1, 2))
-        assert aProd02.shape == (2, 1, 1)
-        assert aProd02[0, 0, 0] == 2**12
-
-    def test_sum(self):
-        a = ak.ones(10)
-
-        assert ak.sum(a) == 10
+        c = ak.randint(0, size // 10, size, seed=SEED)
+        assert not ak.is_sorted(c, axis=axis)
 
     @pytest.mark.skip_if_max_rank_less_than(3)
-    def test_sum_multidim(self):
-        a = ak.ones((2, 3, 4))
+    @pytest.mark.parametrize("dtype", list(set(DTYPES) - set(["bool"])))
+    @pytest.mark.parametrize("axis", [None, 0, 1, (0, 2), (0, 1, 2)])
+    def test_is_sorted_multidim(self, dtype, axis):
 
-        assert ak.sum(a) == 24
+        a = ak.array(ak.randint(0, 100, (5, 7, 4), dtype=dtype, seed=SEED))
+        sorted = ak.is_sorted(a, axis=axis)
+        if isinstance(sorted, np.bool_):
+            assert not sorted
+        else:
+            assert ak.all(sorted == False)
 
-        aSum0 = ak.sum(a, axis=0)
-        assert aSum0.shape == (1, 3, 4)
-        assert aSum0[0, 0, 0] == 2
+        x = ak.arange(40).reshape((2, 10, 2))
+        sorted = ak.is_sorted(x, axis=axis)
+        if isinstance(sorted, np.bool_):
+            assert sorted
+        else:
+            assert ak.all(sorted)
 
-        aSum02 = ak.sum(a, axis=(1, 2))
-        assert aSum02.shape == (2, 1, 1)
-        assert aSum02[0, 0, 0] == 12
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype", DTYPES)
+    @pytest.mark.parametrize("axis", [0, (0,), None])
+    def test_is_locally_sorted(self, size, dtype, axis):
+        from arkouda.pdarrayclass import is_locally_sorted
 
-    def test_max(self):
-        a = ak.arange(10)
-        assert ak.max(a) == 9
+        a = ak.arange(size)
+        assert is_locally_sorted(a, axis=axis)
+
+        assert not is_locally_sorted(ak.flip(a), axis=axis)
+
+        b = ak.randint(0, size // 10, size)
+        assert not is_locally_sorted(b, axis=axis)
+
+    @pytest.mark.skip_if_nl_greater_than(2)
+    @pytest.mark.skip_if_nl_less_than(2)
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_is_locally_sorted_multi_locale(self, size):
+        from arkouda.pdarrayclass import is_locally_sorted, is_sorted
+
+        size = size // 2
+        a = ak.concatenate([ak.arange(size), ak.arange(size)])
+        assert is_locally_sorted(a)
+        assert not is_sorted(a)
 
     @pytest.mark.skip_if_max_rank_less_than(3)
-    def test_max(self):
+    @pytest.mark.parametrize("dtype", DTYPES)
+    @pytest.mark.parametrize("axis", [None, 0, 1, (0, 2), (0, 1, 2)])
+    def test_is_locally_sorted_multidim(self, dtype, axis):
+        from arkouda.pdarrayclass import is_locally_sorted
+
         a = ak.array(ak.randint(0, 100, (5, 7, 4), dtype=ak.int64, seed=SEED))
-        a[3, 6, 2] = 101
+        sorted = is_locally_sorted(a, axis=axis)
+        if isinstance(sorted, np.bool_):
+            assert not sorted
+        else:
+            assert ak.all(sorted == False)
 
-        assert ak.max(a) == 101
+        x = ak.arange(40).reshape((2, 10, 2))
+        sorted = is_locally_sorted(x, axis=axis)
+        if isinstance(sorted, np.bool_):
+            assert sorted
+        else:
+            assert ak.all(sorted)
 
-        aMax0 = ak.max(a, axis=0)
-        assert aMax0.shape == (1, 7, 4)
-        assert aMax0[0, 6, 2] == 101
+    def assert_reduction_ops_match(
+        self, op: str, pda: ak.pdarray, axis: Optional[Union[int, Tuple[int, ...]]] = None
+    ):
+        from arkouda.testing import assert_equivalent as ak_assert_equivalent
 
-        aMax02 = ak.max(a, axis=(0, 2))
-        assert aMax02.shape == (1, 7, 1)
-        assert aMax02[0, 6, 0] == 101
+        ak_op = getattr(arkouda.pdarrayclass, op)
+        np_op = getattr(numpy, op)
+        nda = pda.to_ndarray()
 
-    def test_min(self):
-        a = ak.arange(10) + 2
-        assert ak.min(a) == 2
+        # TODO: remove cast when #3864 is resolved.
+        ak_result = ak_op(pda, axis=axis)
+        if op in ["max", "min"] and pda.dtype == ak.bool_:
+            if isinstance(ak_result, ak.pdarray):
+                ak_result = ak.cast(ak_result, dt=ak.bool_)
+            else:
+                ak_result = np.bool_(ak_result)
+
+        ak_assert_equivalent(ak_result, np_op(nda, axis=axis))
+
+    @pytest.mark.parametrize("op", REDUCTION_OPS)
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype", DTYPES)
+    @pytest.mark.parametrize("arry_gen", [ak.zeros, ak.ones, ak.arange])
+    @pytest.mark.parametrize("axis", [0, (0,), None])
+    def test_reductions_match_numpy_1D(self, op, size, dtype, arry_gen, axis):
+        size = min(size, 1000) if op == "prod" else size
+        pda = arry_gen(size, dtype=dtype)
+        self.assert_reduction_ops_match(op, pda, axis=axis)
 
     @pytest.mark.skip_if_max_rank_less_than(3)
-    def test_min(self):
-        a = ak.array(ak.randint(0, 100, (5, 7, 4), dtype=ak.int64, seed=SEED))
-        a[3, 6, 2] = -1
+    @pytest.mark.parametrize("op", REDUCTION_OPS)
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype", DTYPES)
+    @pytest.mark.parametrize("arry_gen", [ak.zeros, ak.ones])
+    @pytest.mark.parametrize("axis", [None, 0, 1, (0, 2), (0, 1, 2)])
+    def test_reductions_match_numpy_3D_zeros(self, op, size, dtype, arry_gen, axis):
+        size = min(size // 3, 100) if op == "prod" else size // 3
+        pda = arry_gen((size, size, size), dtype=dtype)
+        self.assert_reduction_ops_match(op, pda, axis=axis)
 
-        assert ak.min(a) == -1
+    @pytest.mark.parametrize("op", REDUCTION_OPS)
+    @pytest.mark.parametrize("axis", [0, (0,), None])
+    def test_reductions_match_numpy_1D_TF(self, op, axis):
+        pda = ak.array([True, True, False, True, True, True, True, True])
+        self.assert_reduction_ops_match(op, pda, axis=axis)
 
-        aMin0 = ak.min(a, axis=0)
-        assert aMin0.shape == (1, 7, 4)
-        assert aMin0[0, 6, 2] == -1
-
-        aMin02 = ak.min(a, axis=(0, 2))
-        assert aMin02.shape == (1, 7, 1)
-        assert aMin02[0, 6, 0] == -1
+    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.parametrize("op", REDUCTION_OPS)
+    @pytest.mark.parametrize("axis", [None, 0, 1, (0, 2), (0, 1, 2)])
+    def test_reductions_match_numpy_3D_TF(self, op, axis):
+        pda = ak.array([True, True, False, True, True, True, True, True]).reshape((2, 2, 2))
+        self.assert_reduction_ops_match(op, pda, axis=axis)


### PR DESCRIPTION
This PR refactors boolReductionMsg, splitting it into separate `all`, `any`, `isSorted`, and `isSortedLocally` functions.  It also refactors the reduction functions `pdarrayclass` to add the `axis` and `keepdims` arguments. 

Closes #3855:  refactor boolReductionMsg
Closes #3836: keepdims argument for sum