### PR TITLE
Closes #3896 PytestUnknownMarkWarning for pytest.mark.skip_if_nl_grea…

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -74,3 +74,5 @@ env =
 markers =
     skip_if_max_rank_less_than
     skip_if_max_rank_greater_than
+    skip_if_nl_greater_than
+    skip_if_nl_less_than


### PR DESCRIPTION
This fixes a bug where pytest was throwing a warning due to undeclared pytest markers.

Closes #3896 PytestUnknownMarkWarning for pytest.mark.skip_if_nl_greater_than and pytest.mark.skip_if_nl_less_than