### PR TITLE
Closes #3902: truth value of an empty array DeprecationWarning

### DIFF
--- a/arkouda/pdarraycreation.py
+++ b/arkouda/pdarraycreation.py
@@ -444,7 +444,7 @@ def zeros(
 
     Parameters
     ----------
-    size : int_scalars
+    size : int_scalars or tuple of int_scalars
         Size of the array (only rank-1 arrays supported)
     dtype : all_scalars
         Type of resulting array, default float64
@@ -489,8 +489,8 @@ def zeros(
     if ndim > get_max_array_rank():
         raise ValueError(f"array rank {ndim} exceeds maximum of {get_max_array_rank()}")
 
-    if shape == ():
-        return scalar_array(0, dtype=dtype)
+    if isinstance(shape, tuple) and len(shape) == 0:
+        raise ValueError("size () not currently supported in ak.zeros.")
 
     repMsg = generic_msg(cmd=f"create<{dtype_name},{ndim}>", args={"shape": shape})
 
@@ -508,7 +508,7 @@ def ones(
 
     Parameters
     ----------
-    size : int_scalars
+    size : int_scalars or tuple of int_scalars
         Size of the array (only rank-1 arrays supported)
     dtype : Union[float64, int64, bool]
         Resulting array type, default float64
@@ -553,6 +553,9 @@ def ones(
     if ndim > get_max_array_rank():
         raise ValueError(f"array rank {ndim} exceeds maximum of {get_max_array_rank()}")
 
+    if isinstance(shape, tuple) and len(shape) == 0:
+        raise ValueError("size () not currently supported in ak.ones.")
+
     repMsg = generic_msg(cmd=f"create<{dtype_name},{ndim}>", args={"shape": shape})
     a = create_pdarray(repMsg)
     a.fill(1)
@@ -573,7 +576,7 @@ def full(
 
     Parameters
     ----------
-    size: int_scalars
+    size: int_scalars or tuple of int_scalars
         Size of the array (only rank-1 arrays supported)
     fill_value: int_scalars
         Value with which the array will be filled
@@ -622,6 +625,9 @@ def full(
 
     if ndim > get_max_array_rank():
         raise ValueError(f"array rank {ndim} exceeds maximum of {get_max_array_rank()}")
+
+    if isinstance(shape, tuple) and len(shape) == 0:
+        raise ValueError("size () not currently supported in ak.full.")
 
     repMsg = generic_msg(cmd=f"create<{dtype_name},{ndim}>", args={"shape": shape})
 

--- a/tests/array_api/array_creation.py
+++ b/tests/array_api/array_creation.py
@@ -6,41 +6,34 @@ import pytest
 import arkouda as ak
 import arkouda.array_api as xp
 from arkouda.testing import assert_almost_equivalent
+from arkouda.testing import assert_equivalent
 
 # requires the server to be built with 2D array support
-SHAPES = [(), (0,), (0, 0), (1,), (5,), (2, 2), (5, 10)]
-SIZES = [1, 0, 0, 1, 5, 4, 50]
-DIMS = [0, 1, 2, 1, 1, 2, 2]
+SHAPES = [(0,), (0, 0), (1,), (5,), (2, 2), (5, 10)]
+SIZES = [0, 0, 0, 1, 5, 4, 50]
+DIMS = [1, 1, 2, 1, 1, 2, 2]
 
 
 class TestArrayCreation:
     @pytest.mark.skip_if_max_rank_less_than(2)
-    def test_zeros(self):
-        for shape, size, dim in zip(SHAPES, SIZES, DIMS):
-            for dtype in ak.ScalarDTypes:
-                a = xp.zeros(shape, dtype=dtype)
-                assert a.size == size
-                assert a.ndim == dim
-                assert a.shape == shape
-                assert a.dtype == dtype
-                assert a.tolist() == np.zeros(shape, dtype=dtype).tolist()
+    @pytest.mark.parametrize("shape", SHAPES)
+    @pytest.mark.parametrize("dtype", ak.ScalarDTypes)
+    def test_zeros(self, shape, dtype):
+        a = xp.zeros(shape, dtype=dtype)
+        assert_equivalent(a._array, np.zeros(shape, dtype=dtype))
 
     @pytest.mark.skip_if_max_rank_less_than(2)
-    def test_ones(self):
-        for shape, size, dim in zip(SHAPES, SIZES, DIMS):
-            for dtype in ak.ScalarDTypes:
-                a = xp.ones(shape, dtype=dtype)
-                assert a.size == size
-                assert a.ndim == dim
-                assert a.shape == shape
-                assert a.dtype == dtype
-                assert a.tolist() == np.ones(shape, dtype=dtype).tolist()
+    @pytest.mark.parametrize("shape", SHAPES)
+    @pytest.mark.parametrize("dtype", ak.ScalarDTypes)
+    def test_ones(self, shape, dtype):
+        a = xp.ones(shape, dtype=dtype)
+        assert_equivalent(a._array, np.ones(shape, dtype=dtype))
 
     @pytest.mark.skip_if_max_rank_less_than(2)
     def test_from_numpy(self):
         # TODO: support 0D (scalar) arrays
         # (need changes to the create0D command from #2967)
-        for shape in SHAPES[1:]:
+        for shape in SHAPES:
             a = np.random.randint(0, 10, size=shape, dtype=np.int64)
             b = xp.asarray(a)
             assert b.size == a.size

--- a/tests/pdarray_creation_test.py
+++ b/tests/pdarray_creation_test.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pytest
 
 import arkouda as ak
-from arkouda.testing import assert_arkouda_array_equal
+from arkouda.testing import assert_arkouda_array_equal, assert_equivalent
 
 INT_SCALARS = list(ak.dtypes.int_scalars.__args__)
 NUMERIC_SCALARS = list(ak.dtypes.numeric_scalars.__args__)
@@ -364,6 +364,12 @@ class TestPdarrayCreation:
         assert dtype == zeros.dtype
         assert (0 == zeros).all()
 
+    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.parametrize("dtype", [int, ak.int64, float, ak.float64, bool, ak.bool_])
+    @pytest.mark.parametrize("shape", [0, 2, (2, 3)])
+    def test_ones_match_numpy(self, shape, dtype):
+        assert_equivalent(ak.zeros(shape, dtype=dtype), np.zeros(shape, dtype=dtype))
+
     @pytest.mark.skip_if_max_rank_less_than(3)
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", [ak.int64, float, ak.float64, bool, ak.bool_, ak.bigint])
@@ -404,6 +410,12 @@ class TestPdarrayCreation:
         assert isinstance(ones, ak.pdarray)
         assert dtype == ones.dtype
         assert (1 == ones).all()
+
+    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.parametrize("dtype", [int, ak.int64, float, ak.float64, bool, ak.bool_])
+    @pytest.mark.parametrize("shape", [0, 2, (2, 3)])
+    def test_ones_match_numpy(self, shape, dtype):
+        assert_equivalent(ak.ones(shape, dtype=dtype), np.ones(shape, dtype=dtype))
 
     @pytest.mark.parametrize("dtype", [int, ak.int64, float, ak.float64, bool, ak.bool_, ak.bigint])
     @pytest.mark.parametrize("size", pytest.prob_size)
@@ -455,6 +467,14 @@ class TestPdarrayCreation:
         assert isinstance(type_full, ak.pdarray)
         assert dtype == type_full.dtype
         assert (1 == type_full).all()
+
+    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.parametrize("dtype", [int, ak.int64, float, ak.float64, bool, ak.bool_])
+    @pytest.mark.parametrize("shape", [0, 2, (2, 3)])
+    def test_full_match_numpy(self, shape, dtype):
+        assert_equivalent(
+            ak.full(shape, fill_value=2, dtype=dtype), np.full(shape, fill_value=2, dtype=dtype)
+        )
 
     @pytest.mark.skip_if_max_rank_less_than(3)
     @pytest.mark.parametrize("size", pytest.prob_size)


### PR DESCRIPTION
Mitigates the following pytest warning:
```
arkouda/arkouda/pdarraycreation.py:492: DeprecationWarning: The truth value of an empty array is ambiguous. Returning False, but in future this will result in an error. Use `array.size > 0` to check that an array is not empty.
    if shape == ():
```
Closes #3902: truth value of an empty array DeprecationWarning