### PR TITLE
Closes #3905:  assert_equivalent to compare shapes of pdarrays

### DIFF
--- a/arkouda/testing/_asserters.py
+++ b/arkouda/testing/_asserters.py
@@ -504,8 +504,8 @@ def raise_assert_detail(
 
 
 def assert_arkouda_pdarray_equal(
-    left,
-    right,
+    left: pdarray,
+    right: pdarray,
     check_dtype: bool = True,
     err_msg=None,
     check_same=None,
@@ -538,6 +538,22 @@ def assert_arkouda_pdarray_equal(
     assert_class_equal(left, right, obj=obj)
     # both classes must be an ak.pdarray
     _check_isinstance(left, right, pdarray)
+
+    assert (
+        left.ndim == right.ndim
+    ), f"left dimension {left.ndim} does not match right dimension {right.ndim}."
+    assert left.size == right.size, f"left size {left.size} does not match right size {right.size}."
+    if left.shape:
+        assert (
+            left.shape == right.shape
+        ), f"left shape {left.shape} does not match right shape {right.shape}."
+    else:
+        assert (
+            isinstance(left.shape, tuple)
+            and isinstance(right.shape, tuple)
+            and len(left.shape) == 0
+            and len(right.shape) == 0
+        ), f"left shape {left.shape} does not match right shape {right.shape}."
 
     assert len(left) == len(
         right
@@ -771,7 +787,7 @@ def assert_arkouda_array_equal(
             check_same=check_same,
             obj=obj,
         )
-    else:
+    elif isinstance(left, pdarray) and isinstance(right, pdarray):
         assert_arkouda_pdarray_equal(
             left,
             right,
@@ -780,6 +796,11 @@ def assert_arkouda_array_equal(
             check_same=check_same,
             obj=obj,
             index_values=index_values,
+        )
+    else:
+        raise TypeError(
+            "assert_arkouda_array_equal can only compare arrays of matching type: "
+            "pdarray | Strings | Categorical | SegArray"
         )
 
 

--- a/tests/testing/asserters_test.py
+++ b/tests/testing/asserters_test.py
@@ -1097,6 +1097,18 @@ class TestDataFrame:
         with pytest.raises(AssertionError):
             assert_arkouda_array_equivalent(convert_left(a), convert_right(a2))
 
+    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.parametrize("left_as_arkouda", [True, False])
+    @pytest.mark.parametrize("right_as_arkouda", [True, False])
+    def test_assert_arkouda_array_equal_shape(self, left_as_arkouda, right_as_arkouda):
+        convert_left = self.get_converter(left_as_arkouda)
+        convert_right = self.get_converter(right_as_arkouda)
+
+        a = ak.arange(4).reshape((2, 2))
+        b = ak.arange(4).reshape((1, 4))
+        with pytest.raises(AssertionError):
+            assert_arkouda_array_equivalent(convert_left(a), convert_right(b))
+
     def test_assert_arkouda_segarray_equal(self):
 
         seg = ak.SegArray(ak.array([0, 3, 9]), ak.arange(10))


### PR DESCRIPTION
This adds checks to the `assert_arkouda_pdarray_equal` function to also check that `ndims`, `size`, and `shape` are all equal.

Closes #3905:  assert_equivalent to compare shapes of pdarrays