### PR TITLE
Add the initial capability to checkpoint partial server state

### DIFF
--- a/ServerModules.cfg
+++ b/ServerModules.cfg
@@ -7,6 +7,7 @@ ArraySetopsMsg
 AryUtil
 BroadcastMsg
 CastMsg
+CheckpointMsg
 CommDiagnosticsMsg
 ConcatenateMsg
 CSVMsg

--- a/pytest.ini
+++ b/pytest.ini
@@ -19,6 +19,7 @@ testpaths =
     tests/bitops_test.py
     tests/categorical_test.py
     tests/check.py
+    tests/checkpoint_test.py
     tests/client_dtypes_test.py
     tests/client_test.py
     tests/coargsort_test.py

--- a/src/CheckpointMsg.chpl
+++ b/src/CheckpointMsg.chpl
@@ -1,0 +1,352 @@
+module CheckpointMsg {
+  use FileSystem;
+  use List;
+  use ArkoudaJSONCompat;
+  import IO, Path;
+  import Reflection.{getModuleName as M,
+                     getRoutineName as R,
+                     getLineNumber as L};
+
+  use ServerErrors, ServerConfig;
+  use MultiTypeSymbolTable, MultiTypeSymEntry;
+  use Message;
+  use ParquetMsg;
+  use IOUtils;
+  use Logging;
+
+  config param metadataExt = "md";
+  config param dataExt = "data";
+  config param mdNameMaxLength = 256;
+  config param serverMetadataName = "server."+metadataExt;
+
+  config const dsetname = "data";
+
+  private config const logLevel = ServerConfig.logLevel;
+  private config const logChannel = ServerConfig.logChannel;
+  const cpLogger = new Logger(logLevel,logChannel);
+
+
+  proc saveCheckpointMsg(cmd: string, msgArgs: borrowed MessageArgs,
+                         st: borrowed SymTab): MsgTuple throws {
+    var basePath = msgArgs.getValueOf("path");
+    const nameArg = msgArgs.getValueOf("name");
+    const mode = msgArgs.getValueOf("mode");
+
+    if !exists(basePath) then
+      mkdir(basePath);
+
+    const cpName = if nameArg.isEmpty() then st.serverid else nameArg;
+    const cpPath = Path.joinPath(basePath, cpName);
+
+    if exists(cpPath) {
+      if mode=="error" {
+        throw new SaveCheckpointError(
+            ("A file already exists in %s. If you want to overwrite, use " +
+             "`mode=\"overwrite\"`, which will delete the file").format(cpPath)
+        );
+      }
+
+      if isDir(cpPath) {
+        rmTree(cpPath);
+      }
+      else {
+        remove(cpPath);
+      }
+    }
+
+    mkdir(cpPath);
+
+    saveServerMetadata(cpPath, st);
+
+    for (name, entry) in zip(st.tab.keys(), st.tab.values()) {
+      try {
+        var gse = toGenSymEntry(entry);
+
+        // TODO we can expand this
+        if gse.ndim != 1 then continue;
+
+        // These types are the only types parquet IO supports right now.
+        select gse.dtype {
+          when DType.UInt64  do saveArr(cpPath, name, gse: getSEType(uint(64)));
+          when DType.Int64   do saveArr(cpPath, name, gse: getSEType(int(64)));
+          when DType.Float64 do saveArr(cpPath, name, gse: getSEType(real(64)));
+          when DType.Bool    do saveArr(cpPath, name, gse: getSEType(bool));
+          otherwise          do continue;
+        }
+        cpLogger.debug(M(), R(), L(), "Saved entry %s".format(name));
+      }
+      catch err: ClassCastError {
+        // we couldn't build a symentry, not saving this entry
+        cpLogger.debug(M(), R(), L(), "Cannot save %s".format(name));
+      }
+    }
+    return Msg.send(cpName);
+  }
+
+  proc loadCheckpointMsg(cmd: string, msgArgs: borrowed MessageArgs,
+                         st: borrowed SymTab): MsgTuple throws {
+    var basePath = msgArgs.getValueOf("path");
+    const nameArg = msgArgs.getValueOf("name");
+
+    if !exists(basePath) {
+      return Msg.error("The base save directory not found: " + basePath);
+    }
+
+    const cpPath = Path.joinPath(basePath, nameArg);
+
+    if !exists(cpPath) {
+      return Msg.error("The Arkouda save directory not found: " + cpPath);
+    }
+
+    cpLogger.debug(M(), R(), L(), "Save directory found: %s".format(cpPath));
+
+    var loadedId: string;
+    try {
+      loadedId = loadServerMetadata(cpPath);
+    }
+    catch e: FileNotFoundError {
+      return Msg.error("Can't find the server metadata in the saved session.");
+    }
+
+    cpLogger.debug(M(), R(), L(), "Metadata loaded");
+
+    var rnames: list((string, ObjType, string));
+
+    // iterate over metadata while loading individual data for each metadata
+    for mdName in glob(cpPath+"/*"+metadataExt) {
+      // skip the server metadata
+      if mdName == Path.joinPath(cpPath, serverMetadataName) then continue;
+
+      cpLogger.debug(M(), R(), L(),
+                     "Loading array with metadata %s".format(mdName));
+      // load the array (data and metadata)
+      var (name, entry) = loadArr(cpPath, mdName, loadedId);
+
+      st.addEntry(name, entry);
+
+      cpLogger.debug(M(), R(), L(),
+                     "Loaded array with metadata %s".format(mdName));
+
+    }
+    return Msg.send(nameArg);
+  }
+
+  private proc getSEType(type t) type {
+    return borrowed SymEntry(t, dimensions=1);
+  }
+
+  private proc saveServerMetadata(path, st: borrowed SymTab) throws {
+    const serverMD = new serverMetadata(st.serverid, numLocales);
+
+    const mdName = Path.joinPath(path, serverMetadataName);
+    var mdFile = IO.open(mdName, ioMode.cw);
+    var mdWriter = mdFile.writer();
+    mdWriter.writeln(toJson(serverMD));
+  }
+
+  private proc saveArr(path, name, entry) throws {
+    const arrMD = new arrayMetadata(name, entry.size,
+                                    entry.a.targetLocales().size);
+
+    // write the array
+    const dataName = Path.joinPath(path, ".".join(name, dataExt));
+    const (warnFlag, filenames, numElems) =
+        write1DDistArrayParquet(filename=dataName,
+                                dsetname=dsetname,
+                                dtype="int64",
+                                compression=0,
+                                mode=TRUNCATE,
+                                A=entry.a);
+
+    cpLogger.debug(M(), R(), L(), "Data created: %s".format(dataName));
+
+    // write the metadata
+    const mdName = Path.joinPath(path, ".".join(name, metadataExt));
+    var mdFile = IO.open(mdName, ioMode.cw);
+    var mdWriter = mdFile.writer();
+    mdWriter.writeln(toJson(arrMD));
+
+    for data in zip(filenames, numElems) {
+      const metadata = new chunkMetadata((...data));
+      mdWriter.writeln(toJson(metadata));
+    }
+
+    mdWriter.close();
+    mdFile.close();
+
+    cpLogger.debug(M(), R(), L(), "Metadata created: %s".format(mdName));
+  }
+
+  private proc loadServerMetadata(path) throws {
+    const mdName = Path.joinPath(path, serverMetadataName);
+
+    var mdFile = IO.open(mdName, ioMode.r);
+    var mdReader = mdFile.reader();
+
+    const metadata: serverMetadata;
+    try {
+      metadata = fromJsonThrow(mdReader.readAll(string), serverMetadata);
+    }
+    catch IllegalArgumentError {
+      throw new owned LoadCheckpointError(
+          "Server metadata has incorrect format (%s) ".format(mdName)
+      );
+    }
+
+    if metadata.numLocales!=numLocales {
+      throw new owned LoadCheckpointError(
+          ("Attempting to load a checkpoint that was made with a different " +
+           "number of locales (%i) then the current execution (%i)" +
+           "").format(metadata.numLocales, numLocales));
+    }
+
+    return metadata.serverid;
+  }
+
+  private proc loadArr(path, mdName, loadedId) throws {
+    cpLogger.debug(M(), R(), L(), "Reading %s".format(mdName));
+
+    var mdFile = IO.open(mdName, ioMode.r);
+    var mdReader = mdFile.reader();
+
+    const metadata: arrayMetadata;
+    try {
+      metadata = fromJsonThrow(mdReader.readThrough("\n"), arrayMetadata);
+    }
+    catch IllegalArgumentError {
+      throw new owned LoadCheckpointError(
+          "Array metadata header has incorrect format (%s) ".format(mdName)
+      );
+    }
+
+    cpLogger.debug(M(), R(), L(), "Metadata read %s".format(mdName));
+
+    const ref name = metadata.name;
+    const ref size = metadata.size;
+    const ref numTargetLocales = metadata.numTargetLocales;
+
+    if numTargetLocales!=numLocales {
+      throw new owned LoadCheckpointError(
+          ("Attempting to load a checkpoint that was made with a different " +
+           "number of locales (%i) then the current execution (%i)" +
+           "").format(numTargetLocales, numLocales));
+    }
+
+    var filenames: [0..#numTargetLocales] string;
+    var numElems: [0..#numTargetLocales] int;
+
+    var line: string;
+    var curChunk = 0;
+    while mdReader.readLine(line) {
+      const metadata: chunkMetadata;
+      try {
+        metadata = fromJsonThrow(line, chunkMetadata);
+      }
+      catch IllegalArgumentError {
+        throw new owned LoadCheckpointError(
+            "Array chunk metadata has incorrect format (%s) ".format(mdName)
+        );
+      }
+
+      filenames[curChunk] = metadata.filename;
+      numElems[curChunk] = metadata.numElems;
+      curChunk += 1;
+    }
+
+    if curChunk != numTargetLocales {
+      cpLogger.debug(M(), R(), L(), "Chunk count mismatch, will throw");
+      throw new owned LoadCheckpointError(
+          ("Array metadata (%s) does not contain correct number of chunks " +
+           "(%i found, %i expected).").format(mdName, curChunk,
+                                              numTargetLocales)
+      );
+    }
+
+    cpLogger.debug(M(), R(), L(), "Filenames loaded %s".format(mdName));
+
+    var entryVal = new shared SymEntry(size, int);
+    readFilesByName(A=entryVal.a,
+                    filenames=filenames,
+                    sizes=numElems,
+                    dsetname=dsetname,
+                    ty=0);
+
+    cpLogger.debug(M(), R(), L(), "Data loaded %s".format(mdName));
+
+    mdReader.close();
+    mdFile.close();
+
+    return (name, entryVal);
+  }
+
+  use CommandMap;
+  registerFunction("save_checkpoint", saveCheckpointMsg, M());
+  registerFunction("load_checkpoint", loadCheckpointMsg, M());
+
+  /* Thrown while loading a checkpoint. The cases for this error type is limited
+     to the logic of checkpointing itself. Other errors related to IO etc can
+     also be thrown during loading. */
+  class LoadCheckpointError: Error {
+    proc init(msg: string) {
+      super.init(msg);
+    }
+  }
+
+  /* Thrown while saving a checkpoint. The cases for this error type is limited
+     to the logic of checkpointing itself. Other errors related to IO etc can
+     also be thrown during saving. */
+  class SaveCheckpointError: Error {
+    proc init(msg: string) {
+      super.init(msg);
+    }
+  }
+
+  /* Representation of server metadata. Created per checkpoint. Will be saved to
+     a metadata file in JSON format.
+  */
+  record serverMetadata {
+    const serverid: string;
+    const numLocales: int;
+  }
+
+  /* Representation of array metadata. Created per array per checkpoint. Will be
+     saved to a metadata file in JSON format along with chunk metadata.
+  */
+  record arrayMetadata {
+    const name: string;
+    const size: int;
+    const numTargetLocales: int;
+  }
+
+  /* Representation of array metadata. Created per locale per array per
+     checkpoint. Each chunk will result in a JSON object being written to the
+     array metadata.
+  */
+  record chunkMetadata {
+    const filename: string;
+    const numElems: int;
+  }
+
+  // this works around an issue in Chapel's standard fromJson, where some errors
+  // cannot be caught. https://github.com/chapel-lang/chapel/pull/26656 will be
+  // the fix for that. This helper can be removed or moved to compatibility
+  // modules when that fix goes in.
+  private proc fromJsonThrow(s: string, type t) throws {
+    var fileReader = openStringReader(s, deserializer=new jsonDeserializer());
+    var ret: t;
+    fileReader.read(ret);
+    return ret;
+  }
+
+  /* Convenience wrapper for sending messages to the client. */
+  module Msg {
+    use Message;
+    inline proc error(msg: string) {
+      return new MsgTuple(msg, MsgType.ERROR);
+    }
+
+    inline proc send(msg) {
+      return new MsgTuple(msg, MsgType.NORMAL);
+    }
+  }
+}

--- a/src/ParquetMsg.chpl
+++ b/src/ParquetMsg.chpl
@@ -143,7 +143,22 @@ module ParquetMsg {
     return (rgSubdomains, offset);
   }
 
-  proc readFilesByName(ref A: [] ?t, ref whereNull: [] bool, filenames: [] string, sizes: [] int, dsetname: string, ty, byteLength=-1, hasNonFloatNulls=false) throws {
+  inline proc readFilesByName(ref A: [] ?t, filenames: [] string, sizes: [] int,
+                              dsetname: string, ty, byteLength=-1,
+                              hasNonFloatNulls=false) throws {
+    var dummy = [false];
+    readFilesByName(A, dummy, filenames, sizes, dsetname, ty, byteLength,
+                    hasNonFloatNulls, hasWhereNull=false);
+  }
+
+  /*
+     whereNull will be populated by the CPP interface, where `true` would mean a
+   0 (null) having been read.
+   */
+  proc readFilesByName(ref A: [] ?t, ref whereNull: [] bool,
+                       filenames: [] string, sizes: [] int, dsetname: string,
+                       ty, byteLength=-1, hasNonFloatNulls=false,
+                       param hasWhereNull=true) throws {
     extern proc c_readColumnByName(filename, arr_chpl, where_null_chpl, colNum, numElems, startIdx, batchSize, byteLength, hasNonFloatNulls, errMsg): int;
 
     var (subdoms, length) = getSubdomains(sizes);
@@ -159,8 +174,14 @@ module ParquetMsg {
           const intersection = domain_intersection(locdom, filedom);
           if intersection.size > 0 {
             var pqErr = new parquetErrorMsg();
-            if c_readColumnByName(filename.localize().c_str(), c_ptrTo(A[intersection.low]), c_ptrTo(whereNull[intersection.low]),
-                                  dsetname.localize().c_str(), intersection.size, intersection.low - off,
+            var whereNullPtr = if hasWhereNull
+                                  then c_ptrTo(whereNull[intersection.low])
+                                  else nil;
+            if c_readColumnByName(filename.localize().c_str(),
+                                  c_ptrTo(A[intersection.low]),
+                                  whereNullPtr,
+                                  dsetname.localize().c_str(),
+                                  intersection.size, intersection.low - off,
                                   batchSize, byteLength, hasNonFloatNulls,
                                   c_ptrTo(pqErr.errMsg)) == ARROWERROR {
               pqErr.parquetError(getLineNumber(), getRoutineName(), getModuleName());
@@ -469,6 +490,7 @@ module ParquetMsg {
 
     // Generate the filenames based upon the number of targetLocales.
     var filenames = generateFilenames(prefix, extension, A.targetLocales().size);
+    var numElemsPerFile: [filenames.domain] int;
 
     //Generate a list of matching filenames to test against. 
     var matchingFilenames = getMatchingFilenames(prefix, extension);
@@ -494,6 +516,9 @@ module ParquetMsg {
 
         var locDom = A.localSubdomain();
         var locArr = A[locDom];
+
+        numElemsPerFile[idx] = locDom.size;
+
         var valPtr: c_ptr(void) = nil;
         if locArr.size != 0 {
           valPtr = c_ptrTo(locArr);
@@ -513,7 +538,7 @@ module ParquetMsg {
         }
       }
     // Only warn when files are being overwritten in truncate mode
-    return filesExist && mode == TRUNCATE;
+    return (filesExist && mode == TRUNCATE, filenames, numElemsPerFile);
   }
 
   proc createEmptyParquetFile(filename: string, dsetname: string, dtype: int, compression: int) throws {
@@ -1147,18 +1172,22 @@ module ParquetMsg {
     select dataType {
       when DType.Int64 {
         var e = toSymEntry(toGenSymEntry(entry), int);
-        warnFlag = write1DDistArrayParquet(filename, dsetname, dtypestr, compression:int, mode, e.a);
+        warnFlag = write1DDistArrayParquet(filename, dsetname, dtypestr,
+                                           compression:int, mode, e.a)[0];
       }
       when DType.UInt64 {
         var e = toSymEntry(toGenSymEntry(entry), uint);
-        warnFlag = write1DDistArrayParquet(filename, dsetname, dtypestr, compression:int, mode, e.a);
+        warnFlag = write1DDistArrayParquet(filename, dsetname, dtypestr,
+                                           compression:int, mode, e.a)[0];
       }
       when DType.Bool {
         var e = toSymEntry(toGenSymEntry(entry), bool);
-        warnFlag = write1DDistArrayParquet(filename, dsetname, dtypestr, compression:int, mode, e.a);
+        warnFlag = write1DDistArrayParquet(filename, dsetname, dtypestr,
+                                           compression:int, mode, e.a)[0];
       } when DType.Float64 {
         var e = toSymEntry(toGenSymEntry(entry), real);
-        warnFlag = write1DDistArrayParquet(filename, dsetname, dtypestr, compression:int, mode, e.a);
+        warnFlag = write1DDistArrayParquet(filename, dsetname, dtypestr,
+                                           compression:int, mode, e.a)[0];
       } otherwise {
         var errorMsg = "Writing Parquet files not supported for %s type".format(msgArgs.getValueOf("dtype"));
         pqLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);

--- a/src/compat/eq-20/ArkoudaJSONCompat.chpl
+++ b/src/compat/eq-20/ArkoudaJSONCompat.chpl
@@ -1,0 +1,13 @@
+module ArkoudaJSONCompat {
+  public use JSON;
+  private use IO;
+
+  proc toJson(arg): string throws {
+    var memWriter = openMemFile();
+    var writer = memWriter.writer(locking=false).withSerializer(jsonSerializer);
+    writer.write(arg);
+    writer.close();
+
+    return memWriter.reader(locking=false).readAll(string);
+  }
+}

--- a/src/compat/eq-21/ArkoudaJSONCompat.chpl
+++ b/src/compat/eq-21/ArkoudaJSONCompat.chpl
@@ -1,0 +1,13 @@
+module ArkoudaJSONCompat {
+  public use JSON;
+  private use IO;
+
+  proc toJson(arg): string throws {
+    var memWriter = openMemFile();
+    var writer = memWriter.writer(locking=false).withSerializer(jsonSerializer);
+    writer.write(arg);
+    writer.close();
+
+    return memWriter.reader(locking=false).readAll(string);
+  }
+}

--- a/src/compat/eq-22/ArkoudaJSONCompat.chpl
+++ b/src/compat/eq-22/ArkoudaJSONCompat.chpl
@@ -1,0 +1,3 @@
+module ArkoudaJSONCompat {
+  public use JSON;
+}

--- a/src/compat/eq-23/ArkoudaJSONCompat.chpl
+++ b/src/compat/eq-23/ArkoudaJSONCompat.chpl
@@ -1,0 +1,3 @@
+module ArkoudaJSONCompat {
+  public use JSON;
+}

--- a/src/compat/ge-24/ArkoudaJSONCompat.chpl
+++ b/src/compat/ge-24/ArkoudaJSONCompat.chpl
@@ -1,0 +1,3 @@
+module ArkoudaJSONCompat {
+  public use JSON;
+}

--- a/tests/checkpoint_test.py
+++ b/tests/checkpoint_test.py
@@ -1,0 +1,177 @@
+import arkouda as ak
+
+import os
+import json
+import pytest
+import tempfile
+from os import path
+from shutil import rmtree
+from datetime import datetime
+
+
+@pytest.fixture
+def cp_test_base_tmp(request):
+    # make sure to create a unique directory
+    timestamp = str(datetime.now()).replace(' ', '_')
+    cp_test_base_tmp = "{}/.cp_test_{}".format(os.getcwd(), timestamp)
+    while path.isdir(cp_test_base_tmp):
+        timestamp = str(datetime.now()).replace(' ', '_')
+        cp_test_base_tmp = "{}/.cp_test_{}".format(os.getcwd(), timestamp)
+
+    ak.io_util.get_directory(cp_test_base_tmp)
+
+    # Define a finalizer function for teardown
+    def finalizer():
+        # Clean up any resources if needed
+        ak.io_util.delete_directory(cp_test_base_tmp)
+
+    # Register the finalizer to ensure cleanup
+    request.addfinalizer(finalizer)
+    return cp_test_base_tmp
+
+
+class TestCheckpoint:
+    @pytest.mark.parametrize("prob_size", pytest.prob_size)
+    def test_checkpoint(self, prob_size):
+        arr = ak.zeros(prob_size, int)
+        arr[2] = 2
+
+        cp_name = ak.save_checkpoint()
+
+        expected_dir = '.akdata/{}'.format(cp_name)
+
+        try:
+            # check basics
+            assert path.isdir(expected_dir)
+            assert path.isfile(path.join(expected_dir, 'server.md'))
+
+            arr[3] = 3
+
+            # should overwrite the value
+            ak.load_checkpoint(cp_name)
+
+            assert arr[3] == 0
+            assert arr[2] == 2
+
+        finally:
+            rmtree(expected_dir)
+
+    @pytest.mark.parametrize("prob_size", pytest.prob_size)
+    def test_checkpoint_custom_names(self, cp_test_base_tmp, prob_size):
+        arr = ak.zeros(prob_size, int)
+        arr[2] = 2
+
+        cp_name = 'test_cp'
+
+        with tempfile.TemporaryDirectory(dir=cp_test_base_tmp) as tmp_dirname:
+            ret = ak.save_checkpoint(path=tmp_dirname, name=cp_name)
+            assert ret == cp_name
+
+            # check basics
+            assert path.isdir(tmp_dirname)
+
+            expected_dir = path.join(tmp_dirname, cp_name)
+            assert path.isdir(expected_dir)
+            assert path.isfile(path.join(expected_dir, 'server.md'))
+
+            arr[3] = 3
+
+            # should overwrite the value
+            ak.load_checkpoint(path=tmp_dirname, name=cp_name)
+
+            assert arr[3] == 0
+            assert arr[2] == 2
+
+    def test_incorrect_nl(self):
+        cp_name = 'test_incorrect_nl_cp'
+        create_fake_cp(cp_name,
+                       num_locales=ak.get_config()['numLocales']+1)
+        try:
+            ak.load_checkpoint(cp_name)
+        except RuntimeError as err:
+            assert ('Attempting to load a checkpoint that was made with a '
+                    'different number of locales') in str(err)
+        finally:
+            clean_fake_cp(cp_name)
+
+    def test_incorrect_chunks(self):
+        cp_name = 'test_incorrect_chunks_cp'
+        create_fake_cp(cp_name)
+
+        metadata_name = create_fake_array(cp_name)
+
+        num_locales = ak.get_config()['numLocales']
+
+        with open(metadata_name, 'a') as f:
+            for i in range(0, num_locales+5):
+                f.write(json.dumps({'filename': 'dummy file',
+                                    'numElems': 100}))
+
+        try:
+            ak.load_checkpoint(cp_name)
+        except RuntimeError as err:
+            assert ('does not contain correct number of chunks') in str(err)
+        finally:
+            clean_fake_cp(cp_name)
+
+    def test_corrupt_json(self):
+        cp_name = 'test_corrupt_json_cp'
+        create_fake_cp(cp_name)
+        create_fake_array(cp_name, corrupt_json=True)
+
+        try:
+            ak.load_checkpoint(cp_name)
+        except RuntimeError as err:
+            assert ('has incorrect format') in str(err)
+        finally:
+            clean_fake_cp(cp_name)
+
+    def test_wrong_argument(self):
+        try:
+            ak.save_checkpoint(mode='override')
+        except ValueError as err:
+            assert ("can be 'overwrite' or 'error'" in str(err))
+
+
+def create_fake_array(cp_name, arr_name='dummy', num_target_locales=-1,
+                      corrupt_json=False):
+    cp_path = get_def_cp_path(cp_name)
+
+    arr_metadata = path.join(cp_path, '{}.md'.format(arr_name))
+
+    if num_target_locales == -1:
+        num_target_locales = ak.get_config()['numLocales']
+
+    name_field = 'name' if not corrupt_json else 'junk'
+
+    with open(arr_metadata, 'w') as f:
+        f.write(json.dumps({name_field: arr_name, 'size': 10,
+                            'numTargetLocales': num_target_locales}))
+
+    return arr_metadata
+
+
+def create_fake_cp(cp_name, serverid='dummy', num_locales=-1):
+    clean_fake_cp(cp_name)
+    cp_path = get_def_cp_path(cp_name)
+
+    os.makedirs(cp_path)
+
+    if num_locales == -1:
+        num_locales = ak.get_config()['numLocales']
+
+    server_metadata = path.join(cp_path, 'server.md')
+
+    # write a server metadata with mismatching number of locales
+    with open(server_metadata, 'w') as f:
+        f.write(json.dumps({'serverid': 'dummy',
+                            'numLocales': num_locales}))
+
+
+def clean_fake_cp(cp_name):
+    rmtree(get_def_cp_path(cp_name), ignore_errors=True)
+
+
+def get_def_cp_path(cp_name):
+    def_cp_root = '.akdata'
+    return path.join(def_cp_root, cp_name)


### PR DESCRIPTION
This PR adds the ability to checkpoint pdarrays on the server side. Core of this implementation is from @bmcdonald3.

Two client-side functions are added:

- `arkouda.save_checkpoint(name='', path='.akdata')`
  - `path` is the directory to store the save instance. It will be created if it doesn't exist.
  - `name` is the name of the save instance, by default this will be the server id
- `arkouda.load_checkpoint(name)`
  - loads the checkpoint with the given name

TODO
- [x] handle merge conflicts
- [x] add test
- [x] test with large number of nodes and arrays
