### PR TITLE
3917 copy function to match numpy

### DIFF
--- a/arkouda/__init__.py
+++ b/arkouda/__init__.py
@@ -140,6 +140,7 @@ from arkouda.numpy import (
     complex128,
     complex64,
     concatenate,
+    copy,
     corr,
     cos,
     cosh,

--- a/arkouda/numpy/__init__.py
+++ b/arkouda/numpy/__init__.py
@@ -292,4 +292,5 @@ from arkouda.numpy.util import (
     register_all,
     is_registered,
     broadcast_dims,
+    copy,
 )

--- a/arkouda/numpy/pdarrayclass.py
+++ b/arkouda/numpy/pdarrayclass.py
@@ -619,6 +619,23 @@ class pdarray:
             generic_msg(cmd=cmd, args={"array": self, "max_bits": max_bits})
             self._max_bits = max_bits
 
+    def copy(self) -> pdarray:
+        """
+        Return an array copy of the given object.
+
+        Returns
+        -------
+        pdarray
+            A deep copy of the pdarray.
+        """
+        from arkouda.pdarraycreation import array
+
+        ret = array(self, copy=True)
+        if isinstance(ret, pdarray):
+            return ret
+        else:
+            raise RuntimeError("Could not copy pdarray.")
+
     def equals(self, other) -> bool_scalars:
         """
         Whether pdarrays are the same size and all entries are equal.

--- a/arkouda/numpy/strings.py
+++ b/arkouda/numpy/strings.py
@@ -5,7 +5,6 @@ import itertools
 import re
 from typing import (
     TYPE_CHECKING,
-    Any,
     Dict,
     List,
     Literal,
@@ -409,7 +408,24 @@ class Strings:
         """
         return "string"
 
-    def equals(self, other: Any) -> bool_scalars:
+    def copy(self) -> Strings:
+        """
+        Return a deep copy of the Strings object.
+
+        Returns
+        -------
+        Strings
+            A deep copy of the Strings.
+        """
+        from arkouda.pdarraycreation import array
+
+        ret = array(self, copy=True)
+        if isinstance(ret, Strings):
+            return ret
+        else:
+            raise RuntimeError("Could not copy Strings object.")
+
+    def equals(self, other) -> bool_scalars:
         """
         Whether Strings are the same size and all entries are equal.
 

--- a/arkouda/numpy/util.py
+++ b/arkouda/numpy/util.py
@@ -31,6 +31,7 @@ __all__ = [
     "broadcast_dims",
     "convert_bytes",
     "convert_if_categorical",
+    "copy",
     "generic_concat",
     "get_callback",
     "identity",
@@ -958,3 +959,27 @@ def _generate_test_shape(rank, size):
     shape = tuple(shape)  # multiple steps because .append doesn't
     local_size = maprod(shape)  # have a return value
     return shape, local_size
+
+
+def copy(a: Union[Strings, pdarray]) -> Union[Strings, pdarray]:
+    """
+    Return a deep copy of the given Arkouda object.
+
+    Parameters
+    ----------
+    a : Union[Strings, pdarray]
+        The object to copy.
+
+    Returns
+    -------
+    Union[Strings, pdarray]
+        A deep copy of the pdarray or Strings object.
+
+    Raises
+    ------
+    TypeError
+        If the input is not a Strings or pdarray instance.
+    """
+    if isinstance(a, (Strings, pdarray)):
+        return a.copy()
+    raise TypeError(f"Unsupported type for copy: {type(a)}")

--- a/tests/numpy/pdarray_creation_test.py
+++ b/tests/numpy/pdarray_creation_test.py
@@ -10,7 +10,9 @@ import pytest
 import arkouda as ak
 from arkouda.numpy import newaxis, pdarraycreation
 from arkouda.numpy.util import _generate_test_shape, _infer_shape_from_size
-from arkouda.testing import assert_arkouda_array_equal, assert_equivalent
+from arkouda.testing import assert_arkouda_array_equal
+from arkouda.testing import assert_equal as ak_assert_equal
+from arkouda.testing import assert_equivalent
 
 INT_SCALARS = list(ak.numpy.dtypes.int_scalars.__args__)
 NUMERIC_SCALARS = list(ak.numpy.dtypes.numeric_scalars.__args__)
@@ -148,6 +150,18 @@ class TestPdarrayCreation:
                 expected_type = ak.Strings if pda.dtype == str else ak.pdarray
                 assert isinstance(pda, expected_type), f"{name}: Type mismatch"
                 assert len(pda) == size, f"{name}: Size mismatch: {len(pda)} != {size}"
+
+    @pytest.mark.parametrize("dtype", [ak.int64, ak.float64, ak.bool_, ak.bigint])
+    def test_array_copy(self, dtype):
+        a = ak.arange(100, dtype=dtype)
+
+        b = ak.array(a, copy=True)
+        assert a is not b
+        ak_assert_equal(a, b)
+
+        c = ak.array(a, copy=False)
+        assert a is c
+        ak_assert_equal(a, c)
 
     @pytest.mark.skip_if_max_rank_less_than(2)
     @pytest.mark.parametrize("size", pytest.prob_size)

--- a/tests/numpy/pdarrayclass_test.py
+++ b/tests/numpy/pdarrayclass_test.py
@@ -310,8 +310,6 @@ class TestPdarrayClass:
             pda2 = ak.array(nda2)
             assert_arkouda_array_equivalent(ak.dot(pda1, pda2), np.dot(nda1, nda2))
 
-        #   higher dimension testing of dot may not be feasible at this time
-
     @pytest.mark.parametrize("dtype", DTYPES)
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_diff_1d(self, dtype, size):
@@ -551,3 +549,21 @@ class TestPdarrayClass:
             assert b.shape == a.shape
 
             assert_equivalent(b, np_b)
+
+    @pytest.mark.parametrize("dtype", DTYPES)
+    def test_copy(self, dtype):
+        fixed_size = 100
+        a = ak.arange(fixed_size, dtype=dtype)
+        a_cpy = a.copy()
+
+        assert a_cpy is not a
+        ak_assert_equal(a, a_cpy)
+
+    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.parametrize("dtype", DTYPES)
+    def test_copy_multidim(self, dtype):
+        a = ak.arange(1000, dtype=dtype).reshape((10, 10, 10))
+        a_cpy = a.copy()
+
+        assert a_cpy is not a
+        ak_assert_equal(a, a_cpy)

--- a/tests/numpy/string_test.py
+++ b/tests/numpy/string_test.py
@@ -1011,3 +1011,11 @@ class TestString:
         result = strings.argsort()
         sorted_values = strings[result].tolist()
         assert sorted_values == sorted(strings.tolist())
+
+    def test_copy(self):
+        fixed_size = 100
+        a = ak.arange(fixed_size, dtype=ak.str_)
+        a_cpy = a.copy()
+
+        assert a_cpy is not a
+        ak_assert_equal(a, a_cpy)

--- a/tests/numpy/util_test.py
+++ b/tests/numpy/util_test.py
@@ -1,8 +1,9 @@
 import numpy as np
+import pytest
 
 import arkouda as ak
 from arkouda.numpy import util
-from arkouda.numpy.util import is_float, is_int, is_numeric, map
+from arkouda.util import is_float, is_int, is_numeric, map
 
 
 class TestUtil:
@@ -131,3 +132,14 @@ class TestUtil:
 
         result = map(d, {"1": 7.0})
         assert np.allclose(result.tolist(), [7.0, 7.0, np.nan, np.nan, np.nan], equal_nan=True)
+
+    @pytest.mark.parametrize("dtype", [ak.int64, ak.float64, ak.bool_, ak.bigint, ak.str_])
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_copy(self, dtype, size):
+        a = ak.arange(size, dtype=dtype)
+        b = ak.numpy.util.copy(a)
+
+        from arkouda import assert_equal as ak_assert_equal
+
+        assert a is not b
+        ak_assert_equal(a, b)


### PR DESCRIPTION
Creates a copy function to match numpy:
https://numpy.org/doc/2.1/reference/generated/numpy.copy.html

Also modifies the `array` function to operate on `Strings`, and to have a copy argument.  When `copy=False`, the original array will be returned, rather than a copy, if possible.

Closes #3917 copy function to match numpy