### PR TITLE
Closes #3929: Add chapel 2.1, 2.2 to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        chpl-version: ['2.0.0']
+        chpl-version: ['2.0.0','2.1.0','2.2.0']
     container:
       image: chapel/chapel:${{matrix.chpl-version}}
     steps:


### PR DESCRIPTION
This PR adds chapel `2.1.0` and `2.2.0` to the `arkouda_chpl_portability` tests in the CI.

Closes #3929: Add chapel 2.1, 2.2 to CI