### PR TITLE
Part 1 of #3933: failing make install-arrow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,9 +74,8 @@ jobs:
         python-version: ${{matrix.python-version}}
     - name: Install dependencies
       run: |
-        apt-get update && apt-get install -y -V ca-certificates lsb-release wget
-        wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-        apt-get install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+        apt-get update && apt-get install -y -V ca-certificates lsb-release wget gnupg
+        make install-arrow
         apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip libarrow-dev libparquet-dev libcurl4-openssl-dev libidn2-dev
         make install-iconv
         echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" >> Makefile.paths
@@ -110,10 +109,8 @@ jobs:
         python-version: ${{matrix.python-version}}
     - name: Install dependencies
       run: |
-        apt-get update && apt-get install -y -V ca-certificates lsb-release wget
-        wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-        apt-get install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-        apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip libarrow-dev libparquet-dev libcurl4-openssl-dev libidn2-dev
+        apt-get update && apt-get install -y -V ca-certificates lsb-release wget gnupg
+        apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip libcurl4-openssl-dev libidn2-dev
         echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" >> Makefile.paths
     - name: Check python version
       run: |
@@ -136,6 +133,9 @@ jobs:
     - name: Make install-blosc
       run: |
         make install-blosc      
+    - name: Make install-arrow
+      run: |
+        make install-arrow
 
   arkouda_chpl_portability:
     runs-on: ubuntu-latest
@@ -148,11 +148,11 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install dependencies
       run: |
-        apt-get update && apt-get install -y -V ca-certificates lsb-release wget
-        wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-        apt-get install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+        apt-get update && apt-get install -y -V ca-certificates lsb-release wget gnupg
+        make install-arrow
         apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip libarrow-dev libparquet-dev libcurl4-openssl-dev libidn2-dev
         make install-iconv
+        
         echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" >> Makefile.paths
     - name: Check chpl version
       run: |
@@ -179,9 +179,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install dependencies
       run: |
-        apt-get update && apt-get install -y -V ca-certificates lsb-release wget
-        wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-        apt-get install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+        apt-get update && apt-get install -y -V ca-certificates lsb-release wget gnupg
+        make install-arrow
         apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip libarrow-dev libparquet-dev libcurl4-openssl-dev libidn2-dev
         make install-iconv
         echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" >> Makefile.paths
@@ -219,9 +218,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install dependencies
       run: |
-        apt-get update && apt-get install -y -V ca-certificates lsb-release wget
-        wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-        apt-get install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+        apt-get update && apt-get install -y -V ca-certificates lsb-release wget gnupg
+        make install-arrow
         apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip libarrow-dev libparquet-dev libcurl4-openssl-dev libidn2-dev
         make install-iconv
         echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" >> Makefile.paths
@@ -265,9 +263,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install dependencies
       run: |
-        apt-get update && apt-get install -y -V ca-certificates lsb-release wget
-        wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-        apt-get install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+        apt-get update && apt-get install -y -V ca-certificates lsb-release wget gnupg
+        make install-arrow
         apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip libarrow-dev libparquet-dev libcurl4-openssl-dev libidn2-dev 
         pip install pytest-benchmark==4.0.0
         make install-iconv


### PR DESCRIPTION
This PR refactors `make install-arrow` section of the Makefile.  The previous version was failing to build arrow.  This version should successfully build.  It also allows the addition of the `DEP_BUILD_DIR` option, which allows the user to specify a build directory.  It can be called as follows:
```
make install-arrow DEP_BUILD_DIR=<dependencies_directory>
```
If this directory contains a file of the form `apache-arrow-apt-source*.deb`, it will use that file instead of fetching the file with `wget`.  This will be useful for offline builds.



The downsides are that it automatically selects the latest arrow version (unless using the `DEP_BUILD_DIR` option), and it requires either to be run with root, or it will make a `sudo` call which will require the user to enter a password.

Part of #3933: failing make install-arrow