### PR TITLE
Part 2 of #3933 failing make install arrow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,7 +74,7 @@ jobs:
         python-version: ${{matrix.python-version}}
     - name: Install dependencies
       run: |
-        apt-get update && apt-get install -y -V ca-certificates lsb-release wget gnupg
+        apt-get update && apt-get install -y -V ca-certificates lsb-release wget
         make install-arrow
         apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip libarrow-dev libparquet-dev libcurl4-openssl-dev libidn2-dev
         make install-iconv
@@ -109,7 +109,7 @@ jobs:
         python-version: ${{matrix.python-version}}
     - name: Install dependencies
       run: |
-        apt-get update && apt-get install -y -V ca-certificates lsb-release wget gnupg
+        apt-get update && apt-get install -y -V ca-certificates lsb-release wget build-essential ninja-build cmake
         apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip libcurl4-openssl-dev libidn2-dev
         echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" >> Makefile.paths
     - name: Check python version
@@ -118,6 +118,13 @@ jobs:
     - name: Install Chapel frontend bindings
       run: |
         (cd $CHPL_HOME/tools/chapel-py && python3 -m pip install .)
+    - name: Make install-arrow
+      run: |
+        make install-arrow
+    - name: Make install-arrow OS=unrecognized
+      run: |
+        make arrow-clean
+        make install-arrow OS=unrecognized              
     - name: Make install-hdf5
       run: |
         make install-hdf5
@@ -133,9 +140,8 @@ jobs:
     - name: Make install-blosc
       run: |
         make install-blosc      
-    - name: Make install-arrow
-      run: |
-        make install-arrow
+  
+
 
   arkouda_chpl_portability:
     runs-on: ubuntu-latest
@@ -148,7 +154,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install dependencies
       run: |
-        apt-get update && apt-get install -y -V ca-certificates lsb-release wget gnupg
+        apt-get update && apt-get install -y -V ca-certificates lsb-release wget
         make install-arrow
         apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip libarrow-dev libparquet-dev libcurl4-openssl-dev libidn2-dev
         make install-iconv
@@ -179,7 +185,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install dependencies
       run: |
-        apt-get update && apt-get install -y -V ca-certificates lsb-release wget gnupg
+        apt-get update && apt-get install -y -V ca-certificates lsb-release wget
         make install-arrow
         apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip libarrow-dev libparquet-dev libcurl4-openssl-dev libidn2-dev
         make install-iconv
@@ -218,7 +224,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install dependencies
       run: |
-        apt-get update && apt-get install -y -V ca-certificates lsb-release wget gnupg
+        apt-get update && apt-get install -y -V ca-certificates lsb-release wget
         make install-arrow
         apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip libarrow-dev libparquet-dev libcurl4-openssl-dev libidn2-dev
         make install-iconv
@@ -263,7 +269,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install dependencies
       run: |
-        apt-get update && apt-get install -y -V ca-certificates lsb-release wget gnupg
+        apt-get update && apt-get install -y -V ca-certificates lsb-release wget
         make install-arrow
         apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip libarrow-dev libparquet-dev libcurl4-openssl-dev libidn2-dev 
         pip install pytest-benchmark==4.0.0


### PR DESCRIPTION
This add the ability for `make install-arrow` to install from source code from the git release of arrow.


Part 2 of #3933 failing make install arrow