### PR TITLE
Part 3 of #3933: failing make install-arrow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get update && apt-get install -y -V ca-certificates lsb-release wget
-        make install-arrow
+        make install-arrow-quick
         apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip libarrow-dev libparquet-dev libcurl4-openssl-dev libidn2-dev
         make install-iconv
         echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" >> Makefile.paths
@@ -93,6 +93,46 @@ jobs:
       run: |
         make test-python size=100
 
+  arkouda_makefile_almalinux:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11']
+    container:
+      image: ajpotts/almalinux-with-arkouda-deps:1.0.0
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{matrix.python-version}}
+    - name: Check python version
+      run: |
+        python3 --version
+    - name: Make install-arrow
+      uses: nick-fields/retry@v2
+      with:
+        timeout_seconds: 1200  # or use timeout_minutes
+        max_attempts: 2
+        retry_on: error
+        command: |
+          make install-arrow        
+    - name: Make install-hdf5
+      run: |
+        make install-hdf5
+    - name: Make install-zmq
+      run: |
+        make install-zmq        
+    - name: Make install-iconv
+      run: |
+        make install-iconv
+    - name: Make install-idn2
+      run: |
+        make install-idn2        
+    - name: Make install-blosc
+      run: |
+        make install-blosc     
+
 
   arkouda_makefile:
     runs-on: ubuntu-20.04
@@ -109,22 +149,29 @@ jobs:
         python-version: ${{matrix.python-version}}
     - name: Install dependencies
       run: |
-        apt-get update && apt-get install -y -V ca-certificates lsb-release wget build-essential ninja-build cmake
-        apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip libcurl4-openssl-dev libidn2-dev
-        echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" >> Makefile.paths
+        apt-get update && apt-get install -y -V ca-certificates lsb-release wget build-essential cmake
+        apt-get update && apt-get install -y -V python3-pip libcurl4-openssl-dev
+        apt-get update -y && apt-get -y -V upgrade 
     - name: Check python version
       run: |
         python3 --version
+
     - name: Install Chapel frontend bindings
       run: |
         (cd $CHPL_HOME/tools/chapel-py && python3 -m pip install .)
+    - name: Make install-arrow-quick
+      run: |
+        make install-arrow-quick
     - name: Make install-arrow
-      run: |
-        make install-arrow
-    - name: Make install-arrow OS=unrecognized
-      run: |
-        make arrow-clean
-        make install-arrow OS=unrecognized              
+      uses: nick-fields/retry@v2
+      with:
+        timeout_seconds: 1200  # or use timeout_minutes
+        max_attempts: 2
+        retry_on: error
+        command: |
+            apt-get remove -y apache-arrow-apt-source
+            make arrow-clean
+            make install-arrow    
     - name: Make install-hdf5
       run: |
         make install-hdf5
@@ -155,7 +202,7 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get update && apt-get install -y -V ca-certificates lsb-release wget
-        make install-arrow
+        make install-arrow-quick
         apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip libarrow-dev libparquet-dev libcurl4-openssl-dev libidn2-dev
         make install-iconv
         
@@ -186,7 +233,7 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get update && apt-get install -y -V ca-certificates lsb-release wget
-        make install-arrow
+        make install-arrow-quick
         apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip libarrow-dev libparquet-dev libcurl4-openssl-dev libidn2-dev
         make install-iconv
         echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" >> Makefile.paths
@@ -225,7 +272,7 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get update && apt-get install -y -V ca-certificates lsb-release wget
-        make install-arrow
+        make install-arrow-quick
         apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip libarrow-dev libparquet-dev libcurl4-openssl-dev libidn2-dev
         make install-iconv
         echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" >> Makefile.paths
@@ -270,7 +317,7 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get update && apt-get install -y -V ca-certificates lsb-release wget
-        make install-arrow
+        make install-arrow-quick
         apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip libarrow-dev libparquet-dev libcurl4-openssl-dev libidn2-dev 
         pip install pytest-benchmark==4.0.0
         make install-iconv

--- a/docker/almalinux-with-arkouda-deps/Dockerfile
+++ b/docker/almalinux-with-arkouda-deps/Dockerfile
@@ -1,0 +1,10 @@
+FROM ajpotts/almalinux-chapel:1.0.0
+
+# Set user to root
+USER root
+
+
+RUN git clone https://github.com/Bears-R-Us/arkouda.git && source ~/.bashrc && cd arkouda && make install-deps DEP_BUILD_DIR=/dep/build && python3 -m pip install -e .[dev]
+
+
+ENTRYPOINT ["/bin/bash", "-l"]

--- a/docker/almalinux/Dockerfile
+++ b/docker/almalinux/Dockerfile
@@ -1,0 +1,31 @@
+FROM almalinux:9.0
+
+# Set user to root
+USER root
+
+RUN echo 'source ~/.bashrc.chpl' >> ~/.bashrc && printf "export CHPL_HOME=/chapel-2.3.0 \nexport CHPL_RE2=bundled \nexport CHPL_GMP=bundled \nexport CHPL_COMM=none \nexport CHPL_TARGET_COMPILER=gnu \nexport export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/chapel-2.3.0:/chapel-2.3.0/bin/linux64-x86_64 \nexport CHPL_TARGET_CPU=native \nexport CHPL_HOST_MEM=jemalloc \nexport ARKOUDA_QUICK_COMPILE=true \nexport ARKOUDA_SKIP_CHECK_DEPS=True \n" >>  ~/.bashrc.chpl && source ~/.bashrc
+
+#  Install dependencies
+RUN dnf update -y && dnf install -y ca-certificates wget
+RUN dnf update -y && dnf install -y python3-pip 
+RUN dnf update -y && dnf -y upgrade 
+RUN dnf install -y gcc gcc-c++ m4 perl python3.12 python3-devel bash make gawk git cmake which diffutils
+RUN dnf install -y llvm-devel clang clang-devel libcurl-devel
+
+#   Download Chapel source
+RUN wget https://github.com/chapel-lang/chapel/releases/download/2.3.0/chapel-2.3.0.tar.gz
+RUN tar -xvf chapel-2.3.0.tar.gz
+
+#   Set environment variables
+RUN cd /chapel-2.3.0 && source util/quickstart/setchplenv.bash
+
+#   Install Chapel
+RUN source ~/.bashrc && cd $CHPL_HOME && make
+RUN source ~/.bashrc && chpl --version
+
+# install chapel-py
+RUN source ~/.bashrc && cd  $CHPL_HOME  && make chapel-py-venv
+
+WORKDIR /root
+
+ENTRYPOINT ["/bin/bash", "-l"]

--- a/docker/build_almalinux_with_arkouda_deps.sh
+++ b/docker/build_almalinux_with_arkouda_deps.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+
+echo "This script is intended to be run from the arkouda project directory."
+
+VERSION=1.0.0
+IMAGE_NAME=almalinux-with-arkouda-deps
+REPO_NAME=ajpotts
+
+docker build -t $IMAGE_NAME:$VERSION docker/$IMAGE_NAME/
+docker tag $IMAGE_NAME:$VERSION $REPO_NAME/$IMAGE_NAME:$VERSION
+docker push $REPO_NAME/$IMAGE_NAME:$VERSION
+
+

--- a/docker/build_push_almalinux.sh
+++ b/docker/build_push_almalinux.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+VERSION=1.0.0
+
+docker build -t almalinux-chapel:$VERSION almalinux/
+docker tag almalinux-chapel:$VERSION ajpotts/almalinux-chapel:$VERSION
+docker push ajpotts/almalinux-chapel:$VERSION

--- a/scripts/install_arrow_quick.sh
+++ b/scripts/install_arrow_quick.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+DEP_BUILD_DIR=$1
+
+
+# Check the necessary programs are installed
+if ! command -v lsb_release 2>&1 >/dev/null
+then
+    printf "\nExiting.
+    The program lsb_release could not be found.
+    Please install lsb_release and try again, or use 'make install-arrow' instead.\n\n"
+    exit 1
+fi
+
+#   get the OS, ubuntu, etc...
+OS=$(lsb_release --id --short | tr 'A-Z' 'a-z')
+
+#   If pop, replace with ubuntu
+OS_FINAL=$(echo ${OS} | awk '{gsub(/pop/,"ubuntu")}1')
+
+#   System release, such as "jammy" for "ubuntu jammy"
+OS_CODENAME=$(lsb_release --codename --short)
+
+#   System release, for example, 22 extracted from 22.04
+OS_RELEASE=$(lsb_release -rs | cut -d'.' -f1)
+
+if [[ $OS_FINAL == *"ubuntu"* ]] || [[ $OS_FINAL == *"debian"* ]]; then
+	ARROW_LINK="https://apache.jfrog.io/artifactory/arrow/${OS_FINAL}/apache-arrow-apt-source-latest-${OS_CODENAME}.deb"
+elif [[ $OS_FINAL == *"almalinux"* ]]; then
+    ARROW_LINK="https://apache.jfrog.io/ui/native/arrow/${OS_FINAL}/${OS_RELEASE}/apache-arrow-release-latest.rpm"
+elif [[ $OS_FINAL == *"centos-rc"* ]]; then
+    ARROW_LINK="https://apache.jfrog.io/ui/native/arrow/centos-rc/9-stream/apache-arrow-release-latest.rpm"
+fi
+
+echo "Installing Apache Arrow/Parquet"
+echo "from build directory: ${DEP_BUILD_DIR}"
+mkdir -p ${DEP_BUILD_DIR}
+
+#   If the BUILD_DIR does not contain the apache-arrow file, use wget to fetch it
+if ! find ${DEP_BUILD_DIR} -name "apache-arrow*" -type f -print -quit | grep -q .; then
+	cd ${DEP_BUILD_DIR} && wget ${ARROW_LINK}
+fi
+
+#   Now do the installs
+if [[ $OS_FINAL == *"ubuntu"* ]] || [[ $OS_FINAL == *"debian"* ]]; then
+    if [ "$EUID" -ne 0 ]; then
+        cd $DEP_BUILD_DIR && sudo apt install -y -V ./apache-arrow*.deb
+    else 
+        cd $DEP_BUILD_DIR && apt install -y -V ./apache-arrow*.deb
+    fi
+elif [[ $OS_FINAL == *"almalinux"* ]]; then
+    if [ "$EUID" -ne 0]; then
+        cd $DEP_BUILD_DIR && sudo dnf install -y ./apache-arrow*.rpm
+    else 
+        cd $DEP_BUILD_DIR && dnf install -y ./apache-arrow*.rpm
+    fi
+else
+    echo "make install-arrow-quick does not support ${OS}.  Please use make install-arrow instead."
+fi
+
+


### PR DESCRIPTION
This PR separates the arrow install into `make install-arrow` and `make install-arrow-quick`.  `make install-arrow` will build from source, whereas `install-arrow-quick` will build from the `.deb` or `.rpm` file, if available.  

Part 3 of #3933: failing make install-arrow
Closes #3931, #3933 