### PR TITLE
Closes 3943 issue with reshape

### DIFF
--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1819,7 +1819,7 @@ class pdarray:
         if len(shape) == 1:
             shape = shape[0]
             lenshape = 1
-        if (not isinstance(shape,int)) and (not isinstance(shape, pdarray)):
+        if (not isinstance(shape, int)) and (not isinstance(shape, pdarray)):
             shape = [i for i in shape]
             lenshape = len(shape)
         return create_pdarray(

--- a/arkouda/pdarrayclass.py
+++ b/arkouda/pdarrayclass.py
@@ -1814,13 +1814,17 @@ class pdarray:
         """
         # allows the elements of the shape parameter to be passed in as separate arguments
         # For example, a.reshape(10, 11) is equivalent to a.reshape((10, 11))
+        # the lenshape variable addresses an error that occurred when a single integer was
+        # passed
         if len(shape) == 1:
             shape = shape[0]
-        elif not isinstance(shape, pdarray):
+            lenshape = 1
+        if (not isinstance(shape,int)) and (not isinstance(shape, pdarray)):
             shape = [i for i in shape]
+            lenshape = len(shape)
         return create_pdarray(
             generic_msg(
-                cmd=f"reshape<{self.dtype},{self.ndim},{len(shape)}>",
+                cmd=f"reshape<{self.dtype},{self.ndim},{lenshape}>",
                 args={
                     "name": self.name,
                     "shape": shape,

--- a/tests/pdarrayclass_test.py
+++ b/tests/pdarrayclass_test.py
@@ -29,6 +29,8 @@ class TestPdarrayClass:
         r = a.reshape((2, 2))
         assert r.shape == (2, 2)
         assert isinstance(r, ak.pdarray)
+        b = r.reshape(4)
+        assert ak.all(a==b)
 
     @pytest.mark.skip_if_max_rank_less_than(3)
     def test_reshape_and_flatten_bug_reproducer(self):


### PR DESCRIPTION
Closes #3943 

Slight changes to reshape to allow for a single integer argument.   Had to make some additional changes so that the use of reshape by slice wouldn't cause problems.  Passes all tests.

Added a test to test_reshape.  Previously it changed a (4) to a (2,2).  Now it changes it back to (4) also.

