### PR TITLE
Closes #3954: skip_by_rank to handle set containment

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -74,5 +74,6 @@ env =
 markers =
     skip_if_max_rank_less_than
     skip_if_max_rank_greater_than
+    skip_if_rank_not_compiled
     skip_if_nl_greater_than
     skip_if_nl_less_than

--- a/tests/array_api/array_creation.py
+++ b/tests/array_api/array_creation.py
@@ -15,21 +15,21 @@ DIMS = [1, 1, 2, 1, 1, 2, 2]
 
 
 class TestArrayCreation:
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     @pytest.mark.parametrize("shape", SHAPES)
     @pytest.mark.parametrize("dtype", ak.ScalarDTypes)
     def test_zeros(self, shape, dtype):
         a = xp.zeros(shape, dtype=dtype)
         assert_equivalent(a._array, np.zeros(shape, dtype=dtype))
 
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     @pytest.mark.parametrize("shape", SHAPES)
     @pytest.mark.parametrize("dtype", ak.ScalarDTypes)
     def test_ones(self, shape, dtype):
         a = xp.ones(shape, dtype=dtype)
         assert_equivalent(a._array, np.ones(shape, dtype=dtype))
 
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     def test_from_numpy(self):
         # TODO: support 0D (scalar) arrays
         # (need changes to the create0D command from #2967)
@@ -41,7 +41,7 @@ class TestArrayCreation:
             assert b.shape == a.shape
             assert b.tolist() == a.tolist()
 
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     @pytest.mark.parametrize("data_type", [ak.int64, ak.float64, ak.bool_])
     @pytest.mark.parametrize("prob_size", pytest.prob_size)
     def test_triu(self, data_type, prob_size):
@@ -60,7 +60,7 @@ class TestArrayCreation:
                 ak_triu = array_triu(pda, k=diag)._array
                 assert_almost_equivalent(ak_triu, np_triu)
 
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     @pytest.mark.parametrize("data_type", [ak.int64, ak.float64, ak.bool_])
     @pytest.mark.parametrize("prob_size", pytest.prob_size)
     def test_tril(self, data_type, prob_size):
@@ -79,7 +79,7 @@ class TestArrayCreation:
                 ak_tril = array_tril(pda, k=diag)._array
                 assert_almost_equivalent(np_tril, ak_tril)
 
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     @pytest.mark.parametrize("data_type", [ak.int64, ak.float64, ak.bool_])
     @pytest.mark.parametrize("prob_size", pytest.prob_size)
     def test_eye(self, data_type, prob_size):

--- a/tests/array_api/array_manipulation.py
+++ b/tests/array_api/array_manipulation.py
@@ -18,7 +18,7 @@ def randArr(shape):
 
 class TestManipulation:
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     def test_broadcast(self):
         a = xp.ones((1, 6, 1))
         b = xp.ones((5, 1, 10))
@@ -37,7 +37,7 @@ class TestManipulation:
         assert (abcd[2] == 1).all()
         assert (abcd[3] == 1).all()
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     def test_concat(self):
         a = randArr((5, 3, 10))
         b = randArr((5, 3, 2))
@@ -70,7 +70,7 @@ class TestManipulation:
         assert hijConcat.shape == (18,)
         assert hijConcat.tolist() == hijNP.tolist()
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     def test_expand_dims(self):
         a = randArr((5, 3))
         alist = a.tolist()
@@ -105,7 +105,7 @@ class TestManipulation:
         with pytest.raises(IndexError):
             xp.expand_dims(a, axis=-4)
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([3])
     def test_flip(self):
         # 1D case
         a = xp.arange(10)
@@ -145,7 +145,7 @@ class TestManipulation:
         with pytest.raises(IndexError):
             xp.flip(r, axis=-4)
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([3])
     def test_permute_dims(self):
         r = randArr((7, 8, 9))
 
@@ -172,7 +172,7 @@ class TestManipulation:
         with pytest.raises(IndexError):
             xp.permute_dims(r, (0, 1, -4))
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     def test_reshape(self):
         r = randArr((2, 6, 12))
         nr = np.asarray(r.tolist())
@@ -201,7 +201,7 @@ class TestManipulation:
             # more than one dimension can't be inferred
             xp.reshape(r, (2, -1, -1))
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([3])
     def test_roll(self):
         # 1D case
         a = xp.arange(10)
@@ -244,7 +244,7 @@ class TestManipulation:
         with pytest.raises(IndexError):
             xp.roll(r, 3, axis=-4)
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     def test_squeeze(self):
         r1 = randArr((1, 2, 3))
         r2 = randArr((2, 1, 3))
@@ -277,7 +277,7 @@ class TestManipulation:
         with pytest.raises(ValueError):
             xp.squeeze(r4, axis=1)
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     def test_stack_unstack(self):
         a = randArr((5, 4))
         b = randArr((5, 4))
@@ -303,7 +303,7 @@ class TestManipulation:
         assert bp.tolist() == b.tolist()
         assert cp.tolist() == c.tolist()
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     def test_tile(self):
         a = randArr((2, 3))
 
@@ -313,7 +313,7 @@ class TestManipulation:
             assert at.shape == npat.shape
             assert at.tolist() == npat.tolist()
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     def test_repeat(self):
         a = randArr((5, 10))
         r = randArr((50,))

--- a/tests/array_api/array_object.py
+++ b/tests/array_api/array_object.py
@@ -13,7 +13,7 @@ class TestArrayCreation:
         assert chunks == [[0]]
 
     @pytest.mark.skipif(pytest.nl > 1, reason="Multi-local will produce different chunk_info")
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     def test_chunk_info_2dim(self):
 
         a = xp.zeros((2, 2))

--- a/tests/array_api/binary_ops.py
+++ b/tests/array_api/binary_ops.py
@@ -15,7 +15,7 @@ SCALAR_TYPES.remove("bool_")
 
 
 class TestArrayCreation:
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     @pytest.mark.parametrize("op", ["+", "-", "*", "/"])
     @pytest.mark.parametrize("dtype", SCALAR_TYPES)
     def test_binops(self, op, dtype):

--- a/tests/array_api/elementwise_functions.py
+++ b/tests/array_api/elementwise_functions.py
@@ -11,7 +11,7 @@ DIMS = [0, 1, 2, 1, 1, 2, 2]
 
 
 class TestElemenwiseFunctions:
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     def test_logical_not(self):
         a = xp.asarray(ak.array([True, False, True, False]))
         not_a = xp.asarray(ak.array([False, True, False, True]))

--- a/tests/array_api/indexing.py
+++ b/tests/array_api/indexing.py
@@ -17,7 +17,7 @@ def randArr(shape):
 
 
 class TestIndexing:
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     def test_rank_changing_assignment(self):
         a = randArr((5, 6, 7))
         b = randArr((5, 6))
@@ -37,7 +37,7 @@ class TestIndexing:
         a[:, :, :] = e
         assert a.tolist() == e.tolist()
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([3])
     def test_nd_assignment(self):
         a = randArr((5, 6, 7))
         bnp = randArr((5, 6, 7)).to_ndarray()
@@ -51,7 +51,7 @@ class TestIndexing:
         a[:] = 5
         assert (a == 5).all()
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     def test_pdarray_index(self):
         a = randArr((5, 6, 7))
         anp = np.asarray(a.tolist())
@@ -82,7 +82,7 @@ class TestIndexing:
         xnp = anp[:]
         assert x.tolist() == xnp.tolist()
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     def test_none_index(self):
         a = randArr((10, 10))
         anp = np.asarray(a.tolist())

--- a/tests/array_api/linalg.py
+++ b/tests/array_api/linalg.py
@@ -8,7 +8,7 @@ import numpy as np
 
 class TestLinalg:
 
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     @pytest.mark.parametrize("data_type1", [ak.int64, ak.float64, ak.bool_])
     @pytest.mark.parametrize("data_type2", [ak.int64, ak.float64, ak.bool_])
     @pytest.mark.parametrize("prob_size", pytest.prob_size)
@@ -27,7 +27,7 @@ class TestLinalg:
             npProduct = np.matmul(ndaLeft, ndaRight)
             assert_almost_equivalent(akProduct._array, npProduct)
 
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     @pytest.mark.parametrize("data_type", [ak.int64, ak.float64, ak.bool_])
     @pytest.mark.parametrize("prob_size", pytest.prob_size)
     def test_transpose(self, data_type, prob_size):
@@ -43,7 +43,7 @@ class TestLinalg:
             ppa = xp.matrix_transpose(array)._array
             assert np.allclose(ppa.to_ndarray(), npa)
 
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     @pytest.mark.parametrize("data_type1", [ak.int64, ak.float64, ak.bool_])
     @pytest.mark.parametrize("data_type2", [ak.int64, ak.float64])
     @pytest.mark.parametrize("prob_size", pytest.prob_size)

--- a/tests/array_api/searching_functions.py
+++ b/tests/array_api/searching_functions.py
@@ -10,7 +10,7 @@ SEED = 314159
 
 
 class TestSearchingFunctions:
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     def test_argmax(self):
         a = xp.asarray(ak.randint(0, 100, (4, 5, 6), dtype=ak.int64, seed=SEED))
         a[3, 2, 1] = 101
@@ -27,7 +27,7 @@ class TestSearchingFunctions:
         assert aArgmax1Keepdims.shape == (4, 1, 6)
         assert aArgmax1Keepdims[3, 0, 1] == 2
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     def test_argmin(self):
         a = xp.asarray(ak.randint(0, 100, (4, 5, 6), dtype=ak.int64, seed=SEED))
         a[3, 2, 1] = -1
@@ -42,7 +42,7 @@ class TestSearchingFunctions:
         assert aArgmin1Keepdims.shape == (4, 1, 6)
         assert aArgmin1Keepdims[3, 0, 1] == 2
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([3])
     def test_nonzero(self):
         a = xp.zeros((40, 15, 16), dtype=ak.int64)
         a[0, 1, 0] = 1
@@ -75,7 +75,7 @@ class TestSearchingFunctions:
 
         assert nz[0].tolist() == [0, 12, 100, 205, 490]
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([3])
     def test_where(self):
         a = xp.zeros((4, 5, 6), dtype=ak.int64)
         a[1, 2, 3] = 1
@@ -94,7 +94,7 @@ class TestSearchingFunctions:
         assert d[0, 0, 0] == c[0, 0, 0]
         assert d[3, 3, 3] == c[3, 3, 3]
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     def test_search_sorted(self):
         a = xp.asarray(ak.randint(0, 100, 1000, dtype=ak.float64))
         b = xp.asarray(ak.randint(0, 100, (10, 10), dtype=ak.float64))

--- a/tests/array_api/set_functions.py
+++ b/tests/array_api/set_functions.py
@@ -10,9 +10,9 @@ s = SEED
 
 def ret_shapes():
     shapes = [1000]
-    if pytest.max_rank > 1:
+    if 2 in ak.client.get_array_ranks():
         shapes.append((20, 50))
-    if pytest.max_rank > 2:
+    if 3 in ak.client.get_array_ranks():
         shapes.append((2, 10, 50))
     return shapes
 

--- a/tests/array_api/sorting.py
+++ b/tests/array_api/sorting.py
@@ -14,7 +14,7 @@ SCALAR_TYPES.remove("bool_")
 
 class TestArrayCreation:
 
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     def test_argsort(self):
         for shape in SHAPES:
             for dtype in ak.ScalarDTypes:
@@ -46,7 +46,7 @@ class TestArrayCreation:
                                 for j in range(shape[1] - 1):
                                     assert a[i, b[i, j]] <= a[i, b[i, j + 1]]
 
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     @pytest.mark.parametrize("dtype", SCALAR_TYPES)
     @pytest.mark.parametrize("shape", SHAPES)
     def test_sort(self, dtype, shape):

--- a/tests/array_api/stats_functions.py
+++ b/tests/array_api/stats_functions.py
@@ -12,7 +12,7 @@ SEED = 314159
 
 class TestStatsFunction:
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     def test_max(self):
         a = xp.asarray(ak.randint(0, 100, (5, 7, 4), dtype=ak.int64, seed=SEED))
         a[3, 6, 2] = 101
@@ -31,7 +31,7 @@ class TestStatsFunction:
         assert aMax02Keepdims.shape == (1, 7, 1)
         assert aMax02Keepdims[0, 6, 0] == 101
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     def test_min(self):
         a = xp.asarray(ak.randint(0, 100, (5, 7, 4), dtype=ak.int64, seed=SEED))
         a[3, 6, 2] = -1
@@ -50,7 +50,7 @@ class TestStatsFunction:
         assert aMin02Keepdims.shape == (1, 7, 1)
         assert aMin02Keepdims[0, 6, 0] == -1
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     def test_mean(self):
         a = xp.ones((10, 5, 5))
         a[0, 0, 0] = 251
@@ -76,7 +76,7 @@ class TestStatsFunction:
         assert aMean02Keepdims[0, 0, 0] == 2
         assert aMean02Keepdims[2, 0, 0] == 2
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     def test_std(self):
         a = xp.ones((10, 5, 5), dtype=ak.float64)
         a[0, 0, 0] = 26
@@ -96,7 +96,7 @@ class TestStatsFunction:
         assert abs(aStd02Keepdims[0, 0, 0] - math.sqrt(24)) < 1e-10
         assert abs(aStd02Keepdims[2, 0, 0] - math.sqrt(24)) < 1e-10
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     def test_var(self):
         a = xp.ones((10, 5, 5), dtype=ak.float64)
         a[0, 0, 0] = 26
@@ -116,7 +116,7 @@ class TestStatsFunction:
         assert abs(aStd02Keepdims[0, 0, 0] - 24) < 1e-10
         assert abs(aStd02Keepdims[2, 0, 0] - 24) < 1e-10
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     def test_prod(self):
         a = xp.ones((2, 3, 4))
         a = a + a
@@ -135,7 +135,7 @@ class TestStatsFunction:
         assert aProd02Keepdims.shape == (2, 1, 1)
         assert aProd02Keepdims[0, 0, 0] == 2**12
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     def test_sum(self):
         a = xp.ones((2, 3, 4))
 
@@ -153,7 +153,7 @@ class TestStatsFunction:
         assert aSum02Keepdims.shape == (2, 1, 1)
         assert aSum02Keepdims[0, 0, 0] == 12
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([3])
     def test_cumsum(self):
         a = xp.asarray(ak.randint(0, 100, (5, 6, 7), seed=SEED))
 

--- a/tests/array_api/util_functions.py
+++ b/tests/array_api/util_functions.py
@@ -21,7 +21,7 @@ def randArr(shape, dtype):
 
 class TestUtilFunctions:
 
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     def test_all(self):
         a = xp.ones((10, 10), dtype=ak.bool_)
         assert xp.all(a)
@@ -29,7 +29,7 @@ class TestUtilFunctions:
         a[3, 4] = False
         assert not xp.all(a)
 
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     def test_any(self):
         a = xp.zeros((10, 10), dtype=ak.bool_)
         assert not xp.any(a)
@@ -38,7 +38,7 @@ class TestUtilFunctions:
         assert xp.any(a)
 
     @pytest.mark.parametrize("dtype", DTYPES)
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([3])
     def test_clip(self, dtype):
         a = randArr((5, 6, 7), dtype)
 
@@ -48,7 +48,7 @@ class TestUtilFunctions:
         anp_c = np.clip(anp, 10, 90)
         assert a_c.tolist() == anp_c.tolist()
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([3])
     def test_clip_errors(self):
         # bool
         a = xp.asarray(ak.randint(0, 100, (5, 6, 7), dtype=ak.bool_, seed=s), dtype=ak.bool_)
@@ -70,7 +70,7 @@ class TestUtilFunctions:
             xp.clip(a, 10, 90)
 
     @pytest.mark.parametrize("dtype", DTYPES)
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([3])
     def test_diff(self, dtype):
         a = randArr((5, 6, 7), dtype)
         anp = a.to_ndarray()
@@ -84,7 +84,7 @@ class TestUtilFunctions:
 
         assert a_d.tolist() == anp_d.tolist()
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([3])
     def test_diff_error(self):
         # bool
         a = xp.asarray(ak.randint(0, 100, (5, 6, 7), dtype=ak.bool_, seed=s), dtype=ak.bool_)
@@ -105,7 +105,7 @@ class TestUtilFunctions:
         ):
             xp.diff(a, n=2, axis=0)
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([3])
     def test_pad(self):
         a = xp.ones((5, 6, 7))
         anp = np.ones((5, 6, 7))

--- a/tests/array_manipulation_tests.py
+++ b/tests/array_manipulation_tests.py
@@ -8,7 +8,7 @@ import arkouda as ak
 
 class TestManipulationFunctions:
 
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     def test_vstack(self):
         a = [ak.random.randint(0, 10, 25) for _ in range(4)]
         n = [x.to_ndarray() for x in a]
@@ -18,7 +18,7 @@ class TestManipulationFunctions:
 
         assert n_vstack.tolist() == a_vstack.to_list()
 
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     def test_delete(self):
         a = ak.randint(0, 100, (10, 10))
         n = a.to_ndarray()

--- a/tests/numpy/manipulation_functions_test.py
+++ b/tests/numpy/manipulation_functions_test.py
@@ -19,7 +19,7 @@ class TestNumpyManipulationFunctions:
         f = ak.flip(a)
         assert_equal(f, a[::-1])
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([3])
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", [ak.int64, ak.uint64, ak.float64])
     def test_flip_multi_dim(self, size, dtype):
@@ -27,7 +27,7 @@ class TestNumpyManipulationFunctions:
         f = ak.flip(a)
         assert_equal(f, (size * 4 - 1) - a)
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_flip_multi_dim_bool(self, size):
         shape = (size, 2)
@@ -69,7 +69,7 @@ class TestNumpyManipulationFunctions:
         z = ak.array([1])
         assert_equal(ak.squeeze(z), ak.array([1]))
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", DTYPES)
     def test_squeeze(self, size, dtype):

--- a/tests/numpy/numeric_test.py
+++ b/tests/numpy/numeric_test.py
@@ -312,7 +312,7 @@ class TestNumeric:
     #   log and exp tests were identical, and so have been combined.
 
     @pytest.mark.skipif(pytest.host == "horizon", reason="Fails on horizon")
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     @pytest.mark.parametrize("num_type1", NO_BOOL)
     @pytest.mark.parametrize("num_type2", NO_BOOL)
     def test_histogram_multidim(self, num_type1, num_type2):
@@ -591,7 +591,8 @@ class TestNumeric:
         """
         Test isinf and isfinite.  These return pdarrays of T/F values as appropriate.
         """
-        def isinf_isfin_check(nda, pda) :
+
+        def isinf_isfin_check(nda, pda):
             warnings.filterwarnings("ignore")
             nda_blowup = np.exp(nda)
             warnings.filterwarnings("default")
@@ -599,12 +600,12 @@ class TestNumeric:
             assert (np.isinf(nda_blowup) == ak.isinf(pda_blowup).to_ndarray()).all()
             assert (np.isfinite(nda_blowup) == ak.isfinite(pda_blowup).to_ndarray()).all()
 
-        def derive_multi_shape(r) :
+        def derive_multi_shape(r):
             i = 1
-            while i**r < prob_size :
+            while i**r < prob_size:
                 i += 1
-            i = i if i**r <= prob_size else i-1
-            return i**r, r*[i]
+            i = i if i**r <= prob_size else i - 1
+            return i**r, r * [i]
 
         # first the 1D case, then the max rank case
 
@@ -619,7 +620,7 @@ class TestNumeric:
         # only the max rank case is done, because only rank 1 and max_array_rank are
         # guaranteed to be covered by the arkouda interface.  In-between ranks may not be.
 
-        newsize, newshape = derive_multi_shape (get_max_array_rank())
+        newsize, newshape = derive_multi_shape(get_max_array_rank())
         nda = nda[0:newsize].reshape(newshape)
         pda = ak.array(nda)
         isinf_isfin_check(nda, pda)
@@ -931,7 +932,7 @@ class TestNumeric:
     # the resulting matrices are on the order of size*size.
 
     # tril works on ints, floats, or bool
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled(2)
     @pytest.mark.parametrize("data_type", INT_FLOAT_BOOL)
     @pytest.mark.parametrize("prob_size", pytest.prob_size)
     def test_tril(self, data_type, prob_size):
@@ -959,7 +960,7 @@ class TestNumeric:
 
     @pytest.mark.parametrize("data_type", INT_FLOAT_BOOL)
     @pytest.mark.parametrize("prob_size", pytest.prob_size)
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     def test_triu(self, data_type, prob_size):
         size = int(sqrt(prob_size))
 
@@ -982,7 +983,7 @@ class TestNumeric:
 
     # transpose works on ints, floats, or bool
 
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     @pytest.mark.parametrize("data_type", INT_FLOAT_BOOL)
     @pytest.mark.parametrize("prob_size", pytest.prob_size)
     def test_transpose(self, data_type, prob_size):
@@ -1005,7 +1006,7 @@ class TestNumeric:
             assert check(npa, ppa, data_type)
 
     # eye works on ints, floats, or bool
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     @pytest.mark.parametrize("data_type", INT_FLOAT_BOOL)
     @pytest.mark.parametrize("prob_size", pytest.prob_size)
     def test_eye(self, data_type, prob_size):
@@ -1028,7 +1029,7 @@ class TestNumeric:
                 assert check(nda, pda, data_type)
 
     # matmul works on ints, floats, or bool
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     @pytest.mark.parametrize("data_type1", INT_FLOAT_BOOL)
     @pytest.mark.parametrize("data_type2", INT_FLOAT_BOOL)
     @pytest.mark.parametrize("prob_size", pytest.prob_size)
@@ -1056,7 +1057,7 @@ class TestNumeric:
     # vecdot works on ints, floats, or bool, with the limitation that both inputs can't
     # be bool
 
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     @pytest.mark.parametrize("data_type1", INT_FLOAT_BOOL)
     @pytest.mark.parametrize("data_type2", INT_FLOAT)
     @pytest.mark.parametrize("prob_size", pytest.prob_size)

--- a/tests/numpy/utils_test.py
+++ b/tests/numpy/utils_test.py
@@ -18,6 +18,6 @@ class TestFromNumericFunctions:
         a = ak.array(["a", "b", "c"])
         assert ak.shape(a) == np.shape(a.to_ndarray())
 
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     def test_shape_multidim_pdarray(self):
         assert ak.shape(ak.eye(3, 2)) == (3, 2)

--- a/tests/pdarray_creation_test.py
+++ b/tests/pdarray_creation_test.py
@@ -43,7 +43,7 @@ class TestPdarrayCreation:
             assert len(pda) == fixed_size
             assert dtype == pda.dtype
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([3])
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", [int, ak.int64, ak.uint64, float, ak.float64, bool, ak.bool_])
     def test_array_creation_multi_dim(self, size, dtype):
@@ -91,7 +91,7 @@ class TestPdarrayCreation:
             assert isinstance(pda, ak.pdarray if pda.dtype != str else ak.Strings)
             assert len(pda) == size
 
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     def test_array_creation_misc(self):
         av = ak.array(np.array([[0, 1], [0, 1]]))
         assert isinstance(av, ak.pdarray)
@@ -105,7 +105,7 @@ class TestPdarrayCreation:
         with pytest.raises(TypeError):
             ak.array(list(list(0)))
 
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     def test_array_creation_transpose_bug_reproducer(self):
 
         import numpy as np
@@ -364,13 +364,13 @@ class TestPdarrayCreation:
         assert dtype == zeros.dtype
         assert (0 == zeros).all()
 
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     @pytest.mark.parametrize("dtype", [int, ak.int64, float, ak.float64, bool, ak.bool_])
     @pytest.mark.parametrize("shape", [0, 2, (2, 3)])
     def test_ones_match_numpy(self, shape, dtype):
         assert_equivalent(ak.zeros(shape, dtype=dtype), np.zeros(shape, dtype=dtype))
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([3])
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", [ak.int64, float, ak.float64, bool, ak.bool_, ak.bigint])
     def test_zeros_dtype_mult_dim(self, size, dtype):
@@ -411,7 +411,7 @@ class TestPdarrayCreation:
         assert dtype == ones.dtype
         assert (1 == ones).all()
 
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     @pytest.mark.parametrize("dtype", [int, ak.int64, float, ak.float64, bool, ak.bool_])
     @pytest.mark.parametrize("shape", [0, 2, (2, 3)])
     def test_ones_match_numpy(self, shape, dtype):
@@ -419,7 +419,7 @@ class TestPdarrayCreation:
 
     @pytest.mark.parametrize("dtype", [int, ak.int64, float, ak.float64, bool, ak.bool_, ak.bigint])
     @pytest.mark.parametrize("size", pytest.prob_size)
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([3])
     def test_ones_dtype_multi_dim(self, size, dtype):
         shape = (2, 2, size)
         ones = ak.ones(shape, dtype)
@@ -468,7 +468,7 @@ class TestPdarrayCreation:
         assert dtype == type_full.dtype
         assert (1 == type_full).all()
 
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     @pytest.mark.parametrize("dtype", [int, ak.int64, float, ak.float64, bool, ak.bool_])
     @pytest.mark.parametrize("shape", [0, 2, (2, 3)])
     def test_full_match_numpy(self, shape, dtype):
@@ -476,7 +476,7 @@ class TestPdarrayCreation:
             ak.full(shape, fill_value=2, dtype=dtype), np.full(shape, fill_value=2, dtype=dtype)
         )
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([3])
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", [int, ak.int64, ak.uint64, float, ak.float64, bool, ak.bool_])
     def test_full_dtype_multi_dim(self, size, dtype):
@@ -753,7 +753,7 @@ class TestPdarrayCreation:
         )
         assert printable_randoms == pda.to_list()
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     def test_mulitdimensional_array_creation(self):
         a = ak.array([[0, 0], [0, 1], [1, 1]])
         assert isinstance(a, ak.pdarray)

--- a/tests/pdarrayclass_test.py
+++ b/tests/pdarrayclass_test.py
@@ -22,7 +22,7 @@ DTYPES = ["int64", "float64", "bool", "uint64"]
 
 class TestPdarrayClass:
 
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     @pytest.mark.parametrize("dtype", DTYPES)
     def test_reshape(self, dtype):
         a = ak.arange(4, dtype=dtype)
@@ -30,7 +30,7 @@ class TestPdarrayClass:
         assert r.shape == (2, 2)
         assert isinstance(r, ak.pdarray)
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([3])
     def test_reshape_and_flatten_bug_reproducer(self):
         dtype = "bigint"
         size = 10
@@ -44,7 +44,7 @@ class TestPdarrayClass:
         assert isinstance(a.shape, tuple)
         assert a.shape == np_a.shape
 
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     @pytest.mark.parametrize("dtype", list(set(DTYPES) - set(["bool"])))
     def test_shape_multidim(self, dtype):
         a = ak.arange(4, dtype=dtype).reshape((2, 2))
@@ -58,7 +58,7 @@ class TestPdarrayClass:
         a = ak.arange(size, dtype=dtype)
         ak_assert_equal(a.flatten(), a)
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([3])
     @pytest.mark.parametrize("dtype", DTYPES)
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_flatten(self, size, dtype):
@@ -81,7 +81,7 @@ class TestPdarrayClass:
         c = ak.randint(0, size // 10, size, seed=SEED)
         assert not ak.is_sorted(c, axis=axis)
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     @pytest.mark.parametrize("dtype", list(set(DTYPES) - set(["bool"])))
     @pytest.mark.parametrize("axis", [None, 0, 1, (0, 2), (0, 1, 2)])
     def test_is_sorted_multidim(self, dtype, axis):
@@ -126,7 +126,7 @@ class TestPdarrayClass:
         assert is_locally_sorted(a)
         assert not is_sorted(a)
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     @pytest.mark.skip_if_nl_greater_than(2)
     @pytest.mark.parametrize("dtype", DTYPES)
     @pytest.mark.parametrize("axis", [None, 0, 1, (0, 2), (0, 1, 2)])
@@ -171,7 +171,7 @@ class TestPdarrayClass:
         ak_result = ak_op(pda, axis=axis)
         ak_assert_equivalent(ak_result, np_op(nda, axis=axis))
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     @pytest.mark.parametrize("op", INDEX_REDUCTION_OPS)
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", DTYPES)
@@ -196,7 +196,7 @@ class TestPdarrayClass:
         pda = arry_gen(size, dtype=dtype)
         self.assert_reduction_ops_match(op, pda, axis=axis)
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     @pytest.mark.parametrize("op", REDUCTION_OPS)
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", DTYPES)
@@ -213,7 +213,7 @@ class TestPdarrayClass:
         pda = ak.array([True, True, False, True, True, True, True, True])
         self.assert_reduction_ops_match(op, pda, axis=axis)
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     @pytest.mark.parametrize("op", REDUCTION_OPS)
     @pytest.mark.parametrize("axis", [None, 0, 1, (0, 2), (0, 1, 2)])
     def test_reductions_match_numpy_3D_TF(self, op, axis):

--- a/tests/testing/asserters_test.py
+++ b/tests/testing/asserters_test.py
@@ -170,7 +170,7 @@ class TestDataFrame:
         with pytest.raises(AssertionError):
             assert_almost_equivalent(convert_left(df), convert_right(df3), atol=atol, rtol=rtol)
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([3])
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("left_as_arkouda", [True, False])
     @pytest.mark.parametrize("right_as_arkouda", [True, False])
@@ -957,7 +957,7 @@ class TestDataFrame:
         with pytest.raises(AssertionError):
             assert_equivalent(convert_left(df), convert_right(df2))
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([3])
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("left_as_arkouda", [True, False])
     @pytest.mark.parametrize("right_as_arkouda", [True, False])
@@ -1076,7 +1076,7 @@ class TestDataFrame:
         with pytest.raises(AssertionError):
             assert_arkouda_array_equivalent(convert_left(s), convert_right(c))
 
-    @pytest.mark.skip_if_max_rank_less_than(3)
+    @pytest.mark.skip_if_rank_not_compiled([3])
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("left_as_arkouda", [True, False])
     @pytest.mark.parametrize("right_as_arkouda", [True, False])
@@ -1097,7 +1097,7 @@ class TestDataFrame:
         with pytest.raises(AssertionError):
             assert_arkouda_array_equivalent(convert_left(a), convert_right(a2))
 
-    @pytest.mark.skip_if_max_rank_less_than(2)
+    @pytest.mark.skip_if_rank_not_compiled([2])
     @pytest.mark.parametrize("left_as_arkouda", [True, False])
     @pytest.mark.parametrize("right_as_arkouda", [True, False])
     def test_assert_arkouda_array_equal_shape(self, left_as_arkouda, right_as_arkouda):


### PR DESCRIPTION
This adds a `skip_if_rank_not_compiled` pytest marker that skips test if a specific rank or lists of  ranks is not included in the compiled dimensions.  It also updates the markers for the relevant unit tests.

Closes #3954: skip_by_rank to handle set containment