### PR TITLE
Parquet things

### DIFF
--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -317,6 +317,31 @@ class TestParquet:
             else:
                 assert (np_edge_case == pq_arr.to_ndarray()).all()
 
+    @pytest.mark.parametrize("prob_size", pytest.prob_size)
+    def test_large_parquet_io(self,par_test_base_tmp,prob_size) :
+
+        with tempfile.TemporaryDirectory(dir=par_test_base_tmp) as tmp_dirname:
+            filename = f"{tmp_dirname}/pq_test_large_parquet"
+            size = 2**21 + 8  # A problem had been detected with parquet files of > 2**21 entries
+            bool_array = np.array((size//2)*[True,False]).tolist()
+            flt_array  = np.arange(size).astype(np.float64).tolist()
+            int_array  = np.arange(size).astype(np.int64).tolist()
+            str_array  = np.array(["a"+str(i) for i in np.arange(size)]).tolist()
+            arrays = [bool_array, int_array, flt_array, str_array]
+            tuples = list(zip(*arrays))
+            names = ['first','second','third','fourth']
+            index = pd.MultiIndex.from_tuples(tuples,names=names)
+            s = pd.Series(np.random.randn(size),index=index)
+            df = s.to_frame()
+            df.to_parquet(filename)
+            ak_df = ak.DataFrame(ak.read_parquet(filename)) 
+            #  This check is on all of the random numbers generated in s
+            assert np.all(ak_df.to_pandas().values[:,0] == s.values)
+            #  This check is on all of the elements of the MultiIndex
+            for i in range(len(names)) :
+                assert np.all( df.index.get_level_values(names[i]).to_numpy() == ak_df[names[i]].to_ndarray() )
+                
+
     @pytest.mark.parametrize("dtype", NUMERIC_AND_STR_TYPES)
     def test_get_datasets(self, par_test_base_tmp, dtype):
         ak_arr = make_ak_arrays(10, dtype)

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -323,24 +323,24 @@ class TestParquet:
         with tempfile.TemporaryDirectory(dir=par_test_base_tmp) as tmp_dirname:
             filename = f"{tmp_dirname}/pq_test_large_parquet"
             size = 2**21 + 8  # A problem had been detected with parquet files of > 2**21 entries
-            bool_array = np.array((size//2)*[True,False]).tolist()
-            flt_array  = np.arange(size).astype(np.float64).tolist()
-            int_array  = np.arange(size).astype(np.int64).tolist()
-            str_array  = np.array(["a"+str(i) for i in np.arange(size)]).tolist()
+            bool_array = np.array((size//2)*[True, False]).tolist()
+            flt_array = np.arange(size).astype(np.float64).tolist()
+            int_array = np.arange(size).astype(np.int64).tolist()
+            str_array = np.array(["a"+str(i) for i in np.arange(size)]).tolist()
             arrays = [bool_array, int_array, flt_array, str_array]
             tuples = list(zip(*arrays))
-            names = ['first','second','third','fourth']
-            index = pd.MultiIndex.from_tuples(tuples,names=names)
-            s = pd.Series(np.random.randn(size),index=index)
+            names = ['first', 'second', 'third', 'fourth']
+            index = pd.MultiIndex.from_tuples(tuples, names=names)
+            s = pd.Series(np.random.randn(size), index=index)
             df = s.to_frame()
             df.to_parquet(filename)
-            ak_df = ak.DataFrame(ak.read_parquet(filename)) 
+            ak_df = ak.DataFrame(ak.read_parquet(filename))
             #  This check is on all of the random numbers generated in s
-            assert np.all(ak_df.to_pandas().values[:,0] == s.values)
+            assert np.all(ak_df.to_pandas().values[:, 0] == s.values)
             #  This check is on all of the elements of the MultiIndex
             for i in range(len(names)) :
-                assert np.all( df.index.get_level_values(names[i]).to_numpy() == ak_df[names[i]].to_ndarray() )
-                
+                assert np.all(df.index.get_level_values(names[i]).to_numpy() == ak_df[names[i]].to_ndarray())
+
 
     @pytest.mark.parametrize("dtype", NUMERIC_AND_STR_TYPES)
     def test_get_datasets(self, par_test_base_tmp, dtype):


### PR DESCRIPTION
This addresses the "read multiple row groups in parquet files correctly" issue.  I'd like to keep this at the Draft level while you  guys look it over.  If we're all satisfied with it, I'll rename it and do the "Closes #xxxx" thing.

Recap:

- PR # 3950 noted that in Parquet files of 10**8 entries, the final "many" rows were being read as all zeroes.  That PR fixed the problem for integers by adding a num_read variable to the read ReadColumn proc in ReadParquet.cpp.  The problem persisted for floats.

- I diagnosed that the problem happened in files of more than 2**21 entries.  I added a similar num_read variable to the readColumnDbFl proc, also in ReadParquet.cpp.  This fixed the problem.

- I also added a unit test for this in io_test.py, called test_large_parquet_io.  It took some poking (and thanks for your help, Amanda) to figure out how to compare the columns of the DataFrame en masse, instead of one at a time.