### PR TITLE
Add prototype support for an `ak.apply` function

### DIFF
--- a/ServerModules.cfg
+++ b/ServerModules.cfg
@@ -1,6 +1,7 @@
 # Comment out modules using a `#` to exclude
 # a module from a build
 
+ApplyMsgFunctions
 ArgSortMsg
 ArraySetopsMsg
 AryUtil

--- a/arkouda/__init__.py
+++ b/arkouda/__init__.py
@@ -43,3 +43,4 @@ from arkouda.util import (
 from arkouda.scipy.special import *
 from arkouda.scipy import *
 from arkouda.testing import *
+from arkouda.apply import *

--- a/arkouda/apply.py
+++ b/arkouda/apply.py
@@ -1,0 +1,38 @@
+from typeguard import typechecked
+
+from arkouda.client import generic_msg
+from arkouda.pdarrayclass import pdarray
+from arkouda.pdarraycreation import create_pdarray
+
+__all__ = [
+    "apply",
+]
+
+@typechecked
+def apply(arr: pdarray, func: str) -> pdarray:
+    """
+    Apply a lambda function to a pdarray. The lambda function should be a string
+
+    For example,
+    >>> apply(ak.array([1, 2, 3]), "lambda x,: x+1")
+
+    Parameters
+    ----------
+    arr : pdarray
+        The pdarray to which the function is applied
+
+    func : str
+
+        The lambda function to apply to the array. This should be a string that
+        has the following format: "lambda: x,: ...", where the "..." can be a
+        valid python expression.
+
+    Returns
+    -------
+    pdarray
+        The pdarray resulting from applying the lambda function to the input array
+    """
+
+    repMsg = generic_msg(cmd=f"apply<{arr.dtype},{arr.ndim}>",
+                            args={"x" : arr, "funcStr" : func})
+    return create_pdarray(repMsg)

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,6 +14,7 @@ testpaths =
     tests/array_api/stats_functions.py
     tests/array_api/util_functions.py
     tests/alignment_test.py
+    tests/apply_test.py
     tests/bigint_agg_test.py
     tests/bitops_test.py
     tests/categorical_test.py

--- a/src/ApplyMsgFunctions.chpl
+++ b/src/ApplyMsgFunctions.chpl
@@ -1,0 +1,21 @@
+module ApplyMsgFunctions {
+
+  use Python;
+
+  @arkouda.registerCommand
+  proc apply(const ref x: [?d] ?t, funcStr: string): [] t throws {
+    var ret = makeDistArray(d, t);
+    coforall l in d.targetLocales() do on l {
+      var interp = new Interpreter();
+      var func = new Function(interp, funcStr);
+      for sd in d.localSubdomains() {
+        for i in sd {
+          ret[i] = func(t, x[i]);
+        }
+      }
+    }
+    return ret;
+  }
+
+
+}

--- a/tests/apply_test.py
+++ b/tests/apply_test.py
@@ -1,0 +1,29 @@
+import pytest
+
+import arkouda as ak
+
+"""
+Encapsulates a variety of arkouda apply test cases.
+"""
+
+
+class TestApply:
+
+    @classmethod
+    def setup_class(cls):
+        cls.size = 1000
+
+    @pytest.mark.parametrize("dtype", [ak.int64, ak.uint64])
+    def test_apply_inc(self, dtype):
+        a = ak.arange(TestApply.size, dtype=dtype)
+        b = ak.apply(a, "lambda x,: x+1")
+        assert ak.all(b == a + 1)
+        assert b.dtype == dtype
+
+    @pytest.mark.parametrize("dtype", [ak.int64, ak.uint64])
+    def test_apply_cube(self, dtype):
+        a = ak.arange(TestApply.size, dtype=dtype)
+        b = ak.apply(a, "lambda x,: x*x*x")
+        assert ak.all(b == a * a * a)
+        assert b.dtype == dtype
+


### PR DESCRIPTION
Adds prototypical support for calling an arbitrary python function on a distributed Arkouda array.

For example:

```python
import arkouda as ak
ak.connect()
arr = ak.array([1,2,3])
res = ak.apply(arr, "lambda x,: x+1")
# res is now [2, 3, 4]
``` 

This is a work in progress, and the usage of a string rather than a python function is a temporary limitation.