### PR TITLE
Closes #3960: python interface for CommDiagnostics

### DIFF
--- a/ServerModules.cfg
+++ b/ServerModules.cfg
@@ -6,6 +6,7 @@ ArraySetopsMsg
 AryUtil
 BroadcastMsg
 CastMsg
+CommDiagnosticsMsg
 ConcatenateMsg
 CSVMsg
 DataFrameIndexingMsg

--- a/arkouda/comm_diagnostics.py
+++ b/arkouda/comm_diagnostics.py
@@ -1,0 +1,507 @@
+from typing import cast as typecast
+
+from arkouda.client import generic_msg
+from arkouda.pdarrayclass import create_pdarray
+
+__all__ = [
+    "start_comm_diagnostics",
+    "stop_comm_diagnostics",
+    "reset_comm_diagnostics",
+    "print_comm_diagnostics_table",
+    "start_verbose_comm",
+    "stop_verbose_comm",
+    "get_comm_diagnostics_put",
+    "get_comm_diagnostics_get",
+    "get_comm_diagnostics_put_nb",
+    "get_comm_diagnostics_get_nb",
+    "get_comm_diagnostics_try_nb",
+    "get_comm_diagnostics_amo",
+    "get_comm_diagnostics_execute_on",
+    "get_comm_diagnostics_execute_on_fast",
+    "get_comm_diagnostics_execute_on_nb",
+    "get_comm_diagnostics_cache_get_hits",
+    "get_comm_diagnostics_cache_get_misses",
+    "get_comm_diagnostics_cache_put_hits",
+    "get_comm_diagnostics_cache_put_misses",
+    "get_comm_diagnostics_cache_num_prefetches",
+    "get_comm_diagnostics_cache_num_page_readaheads",
+    "get_comm_diagnostics_cache_prefetch_unused",
+    "get_comm_diagnostics_cache_prefetch_waited",
+    "get_comm_diagnostics_cache_readahead_unused",
+    "get_comm_diagnostics_cache_readahead_waited",
+    "get_comm_diagnostics_wait_nb",
+]
+
+
+def start_comm_diagnostics():
+    """
+    Start counting communication operations across the whole program.
+
+    Returns
+    -------
+    str
+        Completion message.
+    """
+    rep_msg = generic_msg(
+        cmd="startCommDiagnostics",
+        args={},
+    )
+    return typecast(str, rep_msg)
+
+
+def stop_comm_diagnostics():
+    """
+    Stop counting communication operations across the whole program.
+
+    Returns
+    -------
+    str
+        Completion message.
+    """
+    rep_msg = generic_msg(
+        cmd="stopCommDiagnostics",
+        args={},
+    )
+    return typecast(str, rep_msg)
+
+
+def reset_comm_diagnostics():
+    """
+    Reset aggregate communication counts across the whole program.
+
+    Returns
+    -------
+    str
+        Completion message.
+    """
+    rep_msg = generic_msg(
+        cmd="resetCommDiagnostics",
+        args={},
+    )
+    return typecast(str, rep_msg)
+
+
+def print_comm_diagnostics_table(print_empty_columns=False):
+    """
+    Print the current communication counts in a markdown table
+    using a row per locale and a column per operation.
+    By default, operations for which all locales have a count of zero are not displayed in the table,
+    though an argument can be used to reverse that behavior.
+
+    Parameters
+    ----------
+    print_empty_columns : bool=False
+
+    Note
+    ----
+    The table will only be printed to the chapel logs.
+
+    Returns
+    -------
+    str
+        Completion message.
+    """
+    rep_msg = generic_msg(
+        cmd="printCommDiagnosticsTable",
+        args={"printEmptyCols": print_empty_columns},
+    )
+    return typecast(str, rep_msg)
+
+
+def start_verbose_comm():
+    """
+    Start on-the-fly reporting of communication initiated on any locale.
+
+    Note
+    ----
+    Reporting will only be printed to the chapel logs.
+
+    Returns
+    -------
+    str
+        Completion message.
+    """
+    rep_msg = generic_msg(
+        cmd="startVerboseComm",
+        args={},
+    )
+    return typecast(str, rep_msg)
+
+
+def stop_verbose_comm():
+    """
+    Stop on-the-fly reporting of communication initiated on any locale.
+
+    Returns
+    -------
+    str
+        Completion message.
+    """
+    rep_msg = generic_msg(
+        cmd="stopVerboseComm",
+        args={},
+    )
+    return typecast(str, rep_msg)
+
+
+def get_comm_diagnostics_put():
+    """
+    blocking PUTs, in which initiator waits for completion
+
+    Returns
+    -------
+    pdarray
+        A pdarray, where the size is the number of locales,
+        populated with the statistic value from each locale.
+    """
+    rep_msg = generic_msg(
+        cmd="getCommDiagnosticsPut",
+        args={},
+    )
+    return create_pdarray(typecast(str, rep_msg))
+
+
+def get_comm_diagnostics_get():
+    """
+    blocking GETs, in which initiator waits for completion
+
+    Returns
+    -------
+    pdarray
+        A pdarray, where the size is the number of locales,
+        populated with the statistic value from each locale.
+    """
+    rep_msg = generic_msg(
+        cmd="getCommDiagnosticsGet",
+        args={},
+    )
+    return create_pdarray(typecast(str, rep_msg))
+
+
+def get_comm_diagnostics_put_nb():
+    """
+    non-blocking PUTs
+
+    Returns
+    -------
+    pdarray
+        A pdarray, where the size is the number of locales,
+        populated with the statistic value from each locale.
+    """
+    rep_msg = generic_msg(
+        cmd="getCommDiagnosticsPutNb",
+        args={},
+    )
+    return create_pdarray(typecast(str, rep_msg))
+
+
+def get_comm_diagnostics_get_nb():
+    """
+    non-blocking GETs
+
+    Returns
+    -------
+    pdarray
+        A pdarray, where the size is the number of locales,
+        populated with the statistic value from each locale.
+    """
+    rep_msg = generic_msg(
+        cmd="getCommDiagnosticsGetNb",
+        args={},
+    )
+    return create_pdarray(typecast(str, rep_msg))
+
+
+def get_comm_diagnostics_test_nb():
+    """
+    tests for non-blocking GET/PUT completions
+
+    Returns
+    -------
+    pdarray
+        A pdarray, where the size is the number of locales,
+        populated with the statistic value from each locale.
+    """
+    rep_msg = generic_msg(
+        cmd="getCommDiagnosticsTestNb",
+        args={},
+    )
+    return create_pdarray(typecast(str, rep_msg))
+
+
+def get_comm_diagnostics_wait_nb():
+    """
+    blocking waits for non-blocking GET/PUT completions
+
+    Returns
+    -------
+    pdarray
+        A pdarray, where the size is the number of locales,
+        populated with the statistic value from each locale.
+    """
+    rep_msg = generic_msg(
+        cmd="getCommDiagnosticsWaitNb",
+        args={},
+    )
+    return create_pdarray(typecast(str, rep_msg))
+
+
+def get_comm_diagnostics_try_nb():
+    """
+    tests for non-blocking GET/PUT completions
+
+    Returns
+    -------
+    pdarray
+        A pdarray, where the size is the number of locales,
+        populated with the statistic value from each locale.
+    """
+    rep_msg = generic_msg(
+        cmd="getCommDiagnosticsTryNb",
+        args={},
+    )
+    return create_pdarray(typecast(str, rep_msg))
+
+
+def get_comm_diagnostics_amo():
+    """
+    atomic memory operations
+
+    Returns
+    -------
+    pdarray
+        A pdarray, where the size is the number of locales,
+        populated with the statistic value from each locale.
+    """
+    rep_msg = generic_msg(
+        cmd="getCommDiagnosticsAmo",
+        args={},
+    )
+    return create_pdarray(typecast(str, rep_msg))
+
+
+def get_comm_diagnostics_execute_on():
+    """
+    blocking remote executions, in which initiator waits for completion
+
+    Returns
+    -------
+    pdarray
+        A pdarray, where the size is the number of locales,
+        populated with the statistic value from each locale.
+    """
+    rep_msg = generic_msg(
+        cmd="getCommDiagnosticsExecuteOn",
+        args={},
+    )
+    return create_pdarray(typecast(str, rep_msg))
+
+
+def get_comm_diagnostics_execute_on_fast():
+    """
+    blocking remote executions performed by the target locale’s Active Message handler
+
+    Returns
+    -------
+    pdarray
+        A pdarray, where the size is the number of locales,
+        populated with the statistic value from each locale.
+    """
+    rep_msg = generic_msg(
+        cmd="getCommDiagnosticsExecuteOnFast",
+        args={},
+    )
+    return create_pdarray(typecast(str, rep_msg))
+
+
+def get_comm_diagnostics_execute_on_nb():
+    """
+    non-blocking remote executions
+
+    Returns
+    -------
+    pdarray
+        A pdarray, where the size is the number of locales,
+        populated with the statistic value from each locale.
+    """
+    rep_msg = generic_msg(
+        cmd="getCommDiagnosticsExecuteOnNb",
+        args={},
+    )
+    return create_pdarray(typecast(str, rep_msg))
+
+
+def get_comm_diagnostics_cache_get_hits():
+    """
+    GETs that were handled by the cache.
+    GETs counted here did not require the cache to communicate in order to return the result.
+
+    Returns
+    -------
+    pdarray
+        A pdarray, where the size is the number of locales,
+        populated with the statistic value from each locale.
+    """
+    rep_msg = generic_msg(
+        cmd="getCommDiagnosticsCacheGetHits",
+        args={},
+    )
+    return create_pdarray(typecast(str, rep_msg))
+
+
+def get_comm_diagnostics_cache_get_misses():
+    """
+    GETs that were not handled by the cache
+
+    Returns
+    -------
+    pdarray
+        A pdarray, where the size is the number of locales,
+        populated with the statistic value from each locale.
+    """
+    rep_msg = generic_msg(
+        cmd="getCommDiagnosticsCacheGetMisses",
+        args={},
+    )
+    return create_pdarray(typecast(str, rep_msg))
+
+
+def get_comm_diagnostics_cache_put_hits():
+    """
+    PUTs that were stored in cache pages that already existed.
+
+    Returns
+    -------
+    pdarray
+        A pdarray, where the size is the number of locales,
+        populated with the statistic value from each locale.
+    """
+    rep_msg = generic_msg(
+        cmd="getCommDiagnosticsCachePutHits",
+        args={},
+    )
+    return create_pdarray(typecast(str, rep_msg))
+
+
+def get_comm_diagnostics_cache_put_misses():
+    """
+    PUTs that required the cache to create a new page to store them.
+
+    Returns
+    -------
+    pdarray
+        A pdarray, where the size is the number of locales,
+        populated with the statistic value from each locale.
+    """
+    rep_msg = generic_msg(
+        cmd="getCommDiagnosticsCachePutMisses",
+        args={},
+    )
+    return create_pdarray(typecast(str, rep_msg))
+
+
+def get_comm_diagnostics_cache_num_prefetches():
+    """
+    Number of prefetches issued to the remote cache at the granularity of cache pages.
+    This counter is specifically triggered via calls to chpl_comm_remote_prefetch
+
+    Returns
+    -------
+    pdarray
+        A pdarray, where the size is the number of locales,
+        populated with the statistic value from each locale.
+    """
+    rep_msg = generic_msg(
+        cmd="getCommDiagnosticsCacheNumPrefetches",
+        args={},
+    )
+    return create_pdarray(typecast(str, rep_msg))
+
+
+def get_comm_diagnostics_cache_num_page_readaheads():
+    """
+    Number of readaheads issued to the remote cache at the granularity of cache pages.
+
+    Returns
+    -------
+    pdarray
+        A pdarray, where the size is the number of locales,
+        populated with the statistic value from each locale.
+    """
+    rep_msg = generic_msg(
+        cmd="getCommDiagnosticsCacheNumPageReadaheads",
+        args={},
+    )
+    return create_pdarray(typecast(str, rep_msg))
+
+
+def get_comm_diagnostics_cache_prefetch_unused():
+    """
+    Number of cache pages that were prefetched but evicted from the cache before being accessed
+    (i.e., the prefetches were too early).
+
+    Returns
+    -------
+    pdarray
+        A pdarray, where the size is the number of locales,
+        populated with the statistic value from each locale.
+    """
+    rep_msg = generic_msg(
+        cmd="getCommDiagnosticsCachePrefetchUnused",
+        args={},
+    )
+    return create_pdarray(typecast(str, rep_msg))
+
+
+def get_comm_diagnostics_cache_prefetch_waited():
+    """
+    Number of cache pages that were prefetched but did not arrive in the cache before being accessed
+    (i.e., the prefetches were too late).
+
+    Returns
+    -------
+    pdarray
+        A pdarray, where the size is the number of locales,
+        populated with the statistic value from each locale.
+    """
+    rep_msg = generic_msg(
+        cmd="getCommDiagnosticsCachePrefetchWaited",
+        args={},
+    )
+    return create_pdarray(typecast(str, rep_msg))
+
+
+def get_comm_diagnostics_cache_readahead_unused():
+    """
+    Number of cache pages that were read ahead but evicted from the cache before being accessed
+    (i.e., the readaheads were too early).
+
+    Returns
+    -------
+    pdarray
+        A pdarray, where the size is the number of locales,
+        populated with the statistic value from each locale.
+    """
+    rep_msg = generic_msg(
+        cmd="getCommDiagnosticsCacheReadaheadUnused",
+        args={},
+    )
+    return create_pdarray(typecast(str, rep_msg))
+
+
+def get_comm_diagnostics_cache_readahead_waited():
+    """
+    Number of cache pages that were read ahead but did not arrive in the cache before being accessed
+    (i.e., the readaheads were too late).
+
+    Returns
+    -------
+    pdarray
+        A pdarray, where the size is the number of locales,
+        populated with the statistic value from each locale.
+    """
+    rep_msg = generic_msg(
+        cmd="getCommDiagnosticsCacheReadaheadWaited",
+        args={},
+    )
+    return create_pdarray(typecast(str, rep_msg))

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,6 +21,7 @@ testpaths =
     tests/client_dtypes_test.py
     tests/client_test.py
     tests/coargsort_test.py
+    tests/comm_diagnostics_test.py
     tests/dataframe_test.py
     tests/datetime_test.py
     tests/extrema_test.py

--- a/src/CommDiagnosticsMsg.chpl
+++ b/src/CommDiagnosticsMsg.chpl
@@ -1,0 +1,210 @@
+module CommDiagnosticsMsg
+{
+    use CommDiagnostics, Message, CommandMap, MultiTypeSymbolTable, Reflection, MultiTypeSymEntry;
+
+    proc ak_startCommDiagnostics(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        startCommDiagnostics();
+        return new MsgTuple("commDiagnostics started.", MsgType.NORMAL);
+    }
+
+    proc ak_stopCommDiagnostics(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        stopCommDiagnostics();
+        return new MsgTuple("commDiagnostics stopped.", MsgType.NORMAL);
+    }
+
+    proc ak_printCommDiagnosticsTable(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        const printEmptyCols = msgArgs['printEmptyCols'].toScalar(bool);
+        printCommDiagnosticsTable(printEmptyColumns=printEmptyCols);
+        return new MsgTuple("commDiagnostics printed.", MsgType.NORMAL);
+    }
+
+    proc ak_resetCommDiagnostics(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        resetCommDiagnostics();
+        return new MsgTuple("commDiagnostics reset.", MsgType.NORMAL);
+    }
+
+    proc ak_startVerboseComm(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        startVerboseComm();
+        return new MsgTuple("commDiagnostics set verbose.", MsgType.NORMAL);
+    }
+
+    proc ak_stopVerboseComm(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        stopVerboseComm();
+        return new MsgTuple("commDiagnostics unset verbose.", MsgType.NORMAL);
+    }
+
+    proc getCommDiagnosticsPut(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        const commD = getCommDiagnostics();
+        const puts = forall i in 0..#numLocales do commD[i].put;
+        const e = createSymEntry(puts);
+        return st.insert(e);
+    }
+
+    proc getCommDiagnosticsGet(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        const commD = getCommDiagnostics();
+        const gets = forall i in 0..#numLocales do commD[i].get;
+        const e = createSymEntry(gets);
+        return st.insert(e);
+    }
+
+    proc getCommDiagnosticsPutNb(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        const commD = getCommDiagnostics();
+        const puts = forall i in 0..#numLocales do commD[i].put_nb;
+        const e = createSymEntry(puts);
+        return st.insert(e);
+    }
+
+    proc getCommDiagnosticsGetNb(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        const commD = getCommDiagnostics();
+        const gets = forall i in 0..#numLocales do commD[i].get_nb;
+        const e = createSymEntry(gets);
+        return st.insert(e);
+    }
+
+    proc getCommDiagnosticsTestNb(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        const commD = getCommDiagnostics();
+        const ret = forall i in 0..#numLocales do commD[i].test_nb;
+        const e = createSymEntry(ret);
+        return st.insert(e);
+    }
+
+    proc getCommDiagnosticsWaitNb(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        const commD = getCommDiagnostics();
+        const ret = forall i in 0..#numLocales do commD[i].wait_nb;
+        const e = createSymEntry(ret);
+        return st.insert(e);
+    }
+
+    proc getCommDiagnosticsTryNb(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        const commD = getCommDiagnostics();
+        const ret = forall i in 0..#numLocales do commD[i].try_nb;
+        const e = createSymEntry(ret);
+        return st.insert(e);
+    }
+
+    proc getCommDiagnosticsAmo(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        const commD = getCommDiagnostics();
+        const ret = forall i in 0..#numLocales do commD[i].amo;
+        const e = createSymEntry(ret);
+        return st.insert(e);
+    }
+
+    proc getCommDiagnosticsExecuteOn(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        const commD = getCommDiagnostics();
+        const ret = forall i in 0..#numLocales do commD[i].execute_on;
+        const e = createSymEntry(ret);
+        return st.insert(e);
+    }
+
+    proc getCommDiagnosticsExecuteOnFast(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        const commD = getCommDiagnostics();
+        const ret = forall i in 0..#numLocales do commD[i].execute_on_fast;
+        const e = createSymEntry(ret);
+        return st.insert(e);
+    }
+
+    proc getCommDiagnosticsExecuteOnNb(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        const commD = getCommDiagnostics();
+        const ret = forall i in 0..#numLocales do commD[i].execute_on_nb;
+        const e = createSymEntry(ret);
+        return st.insert(e);
+    }
+
+    proc getCommDiagnosticsCacheGetHits(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        const commD = getCommDiagnostics();
+        const ret = forall i in 0..#numLocales do commD[i].cache_get_hits;
+        const e = createSymEntry(ret);
+        return st.insert(e);
+    }
+
+    proc getCommDiagnosticsCacheGetMisses(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        const commD = getCommDiagnostics();
+        const ret = forall i in 0..#numLocales do commD[i].cache_get_misses;
+        const e = createSymEntry(ret);
+        return st.insert(e);
+    }
+
+    proc getCommDiagnosticsCachePutHits(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        const commD = getCommDiagnostics();
+        const ret = forall i in 0..#numLocales do commD[i].cache_put_hits;
+        const e = createSymEntry(ret);
+        return st.insert(e);
+    }
+
+    proc getCommDiagnosticsCachePutMisses(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        const commD = getCommDiagnostics();
+        const ret = forall i in 0..#numLocales do commD[i].cache_put_misses;
+        const e = createSymEntry(ret);
+        return st.insert(e);
+    }
+
+    proc getCommDiagnosticsCacheNumPrefetches(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        const commD = getCommDiagnostics();
+        const ret = forall i in 0..#numLocales do commD[i].cache_num_prefetches;
+        const e = createSymEntry(ret);
+        return st.insert(e);
+    }
+
+    proc getCommDiagnosticsCacheNumPageReadaheads(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        const commD = getCommDiagnostics();
+        const ret = forall i in 0..#numLocales do commD[i].cache_num_page_readaheads;
+        const e = createSymEntry(ret);
+        return st.insert(e);
+    }
+
+    proc getCommDiagnosticsCachePrefetchUnused(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        const commD = getCommDiagnostics();
+        const ret = forall i in 0..#numLocales do commD[i].cache_prefetch_unused;
+        const e = createSymEntry(ret);
+        return st.insert(e);
+    }
+
+    proc getCommDiagnosticsCachePrefetchWaited(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        const commD = getCommDiagnostics();
+        const ret = forall i in 0..#numLocales do commD[i].cache_prefetch_waited;
+        const e = createSymEntry(ret);
+        return st.insert(e);
+    }
+
+    proc getCommDiagnosticsCacheReadaheadUnused(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        const commD = getCommDiagnostics();
+        const ret = forall i in 0..#numLocales do commD[i].cache_readahead_unused;
+        const e = createSymEntry(ret);
+        return st.insert(e);
+    }
+
+    proc getCommDiagnosticsCacheReadaheadWaited(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        const commD = getCommDiagnostics();
+        const ret = forall i in 0..#numLocales do commD[i].cache_readahead_waited;
+        const e = createSymEntry(ret);
+        return st.insert(e);
+    }
+
+    registerFunction('startCommDiagnostics', ak_startCommDiagnostics, getModuleName());
+    registerFunction('stopCommDiagnostics', ak_stopCommDiagnostics, getModuleName());
+    registerFunction('printCommDiagnosticsTable', ak_printCommDiagnosticsTable, getModuleName());
+    registerFunction('resetCommDiagnostics', ak_resetCommDiagnostics, getModuleName());
+    registerFunction('startVerboseComm', ak_startVerboseComm, getModuleName());
+    registerFunction('stopVerboseComm', ak_stopVerboseComm, getModuleName());
+    registerFunction('getCommDiagnosticsPut', getCommDiagnosticsPut, getModuleName());
+    registerFunction('getCommDiagnosticsGet', getCommDiagnosticsGet, getModuleName());
+    registerFunction('getCommDiagnosticsPutNb', getCommDiagnosticsPutNb, getModuleName());
+    registerFunction('getCommDiagnosticsGetNb', getCommDiagnosticsGetNb, getModuleName());
+    registerFunction('getCommDiagnosticsTestNb', getCommDiagnosticsTestNb, getModuleName());
+    registerFunction('getCommDiagnosticsWaitNb', getCommDiagnosticsWaitNb, getModuleName());
+    registerFunction('getCommDiagnosticsTryNb', getCommDiagnosticsTryNb, getModuleName());
+    registerFunction('getCommDiagnosticsAmo', getCommDiagnosticsAmo, getModuleName());
+    registerFunction('getCommDiagnosticsExecuteOn', getCommDiagnosticsExecuteOn, getModuleName());
+    registerFunction('getCommDiagnosticsExecuteOnFast', getCommDiagnosticsExecuteOnFast, getModuleName());
+    registerFunction('getCommDiagnosticsExecuteOnNb', getCommDiagnosticsExecuteOnNb, getModuleName());
+    registerFunction('getCommDiagnosticsCacheGetHits', getCommDiagnosticsCacheGetHits, getModuleName());
+    registerFunction('getCommDiagnosticsCacheGetMisses', getCommDiagnosticsCacheGetMisses, getModuleName());
+    registerFunction('getCommDiagnosticsCachePutHits', getCommDiagnosticsCachePutHits, getModuleName());
+    registerFunction('getCommDiagnosticsCachePutMisses', getCommDiagnosticsCachePutMisses, getModuleName());
+    registerFunction('getCommDiagnosticsCacheNumPrefetches', getCommDiagnosticsCacheNumPrefetches, getModuleName());
+    registerFunction('getCommDiagnosticsCacheNumPageReadaheads', getCommDiagnosticsCacheNumPageReadaheads, getModuleName());
+    registerFunction('getCommDiagnosticsCachePrefetchUnused', getCommDiagnosticsCachePrefetchUnused, getModuleName());
+    registerFunction('getCommDiagnosticsCachePrefetchWaited', getCommDiagnosticsCachePrefetchWaited, getModuleName());
+    registerFunction('getCommDiagnosticsCacheReadaheadUnused', getCommDiagnosticsCacheReadaheadUnused, getModuleName());
+    registerFunction('getCommDiagnosticsCacheReadaheadWaited', getCommDiagnosticsCacheReadaheadWaited, getModuleName());
+}

--- a/tests/comm_diagnostics_test.py
+++ b/tests/comm_diagnostics_test.py
@@ -1,0 +1,64 @@
+import pytest
+import arkouda as ak
+from arkouda.comm_diagnostics import *
+
+
+diagnostic_stats_functions = [
+    "get_comm_diagnostics_put",
+    "get_comm_diagnostics_get",
+    "get_comm_diagnostics_put_nb",
+    "get_comm_diagnostics_get_nb",
+    "get_comm_diagnostics_try_nb",
+    "get_comm_diagnostics_amo",
+    "get_comm_diagnostics_execute_on",
+    "get_comm_diagnostics_execute_on_fast",
+    "get_comm_diagnostics_execute_on_nb",
+    "get_comm_diagnostics_cache_get_hits",
+    "get_comm_diagnostics_cache_get_misses",
+    "get_comm_diagnostics_cache_put_hits",
+    "get_comm_diagnostics_cache_put_misses",
+    "get_comm_diagnostics_cache_num_prefetches",
+    "get_comm_diagnostics_cache_num_page_readaheads",
+    "get_comm_diagnostics_cache_prefetch_unused",
+    "get_comm_diagnostics_cache_prefetch_waited",
+    "get_comm_diagnostics_cache_readahead_unused",
+    "get_comm_diagnostics_cache_readahead_waited",
+]
+
+
+class TestCommDiagnostics:
+
+    @pytest.mark.parametrize("op", diagnostic_stats_functions)
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_comm_diagnostics_single_locale(self, op, size):
+        start_comm_diagnostics()
+        start_verbose_comm()
+
+        ak.sort(ak.arange(size) * -1.0)
+        comm_diagnostic_function = getattr(ak.comm_diagnostics, op)
+        result = comm_diagnostic_function()
+        assert isinstance(result, ak.pdarray)
+        assert result.size == pytest.nl
+        if pytest.nl == 1:
+            assert result.sum() == 0
+
+        stop_verbose_comm()
+        print_comm_diagnostics_table()
+        reset_comm_diagnostics()
+        stop_comm_diagnostics()
+
+    @pytest.mark.skip_if_nl_less_than(2)
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_comm_diagnostics_multi_locale(self, size):
+        start_comm_diagnostics()
+
+        ak.sort(ak.arange(size) * -1.0)
+        result = get_comm_diagnostics_get() + get_comm_diagnostics_put()
+        assert isinstance(result, ak.pdarray)
+        assert result.size == pytest.nl
+        assert ak.all(result > (size ** (1 / 2)))
+
+        print_comm_diagnostics_table(print_empty_columns=True)
+        print_comm_diagnostics_table(print_empty_columns=False)
+
+        stop_comm_diagnostics()


### PR DESCRIPTION
This PR adds a `comm_diagnostics` module with the functions `start_comm_diagnostics`, `stop_comm_diagnostics`, `reset_comm_diagnostics`,  `print_comm_diagnostics_table` and other communication diagnostics statistical functions.  These functions act as a python interface to the chapel functions `startCommDiagnostics`, `stopCommDiagnostics`, `resetCommDiagnostics`, `printCommDiagnosticsTable`, and `getCommDiagnostics.`


Closes #3960: python interface for CommDiagnostics