### PR TITLE
Closes #3970: comm_diagnostics function to return a DataFrame

### DIFF
--- a/tests/comm_diagnostics_test.py
+++ b/tests/comm_diagnostics_test.py
@@ -62,3 +62,12 @@ class TestCommDiagnostics:
         print_comm_diagnostics_table(print_empty_columns=False)
 
         stop_comm_diagnostics()
+
+    def test_get_comm_diagnostics(self):
+        start_comm_diagnostics()
+
+        df = get_comm_diagnostics()
+        assert isinstance(df, ak.DataFrame)
+        assert len(df) == pytest.nl
+
+        stop_comm_diagnostics()


### PR DESCRIPTION
This PR adds a `get_comm_diagnostics()` function that returns a `DataFrame` of diagnostic statistics.  It also modifies `print_comm_diagnostics` to print to the python interpreter in addition to the chapel logs.

Closes #3970: comm_diagnostics function to return a DataFrame