### PR TITLE
Sort module updates for Chapel 2.3

### DIFF
--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -37,7 +37,7 @@ module ArgSortMsg
     private config const logChannel = ServerConfig.logChannel;
     const asLogger = new Logger(logLevel, logChannel);
 
-    proc dynamicTwoArrayRadixSort(ref Data:[], comparator:?rec=new DefaultComparator()) {
+    proc dynamicTwoArrayRadixSort(ref Data:[], comparator:?rec=new defaultComparator()) {
       if Data._instance.isDefaultRectangular() {
         ArkoudaSortCompat.TwoArrayRadixSort.twoArrayRadixSort(Data, comparator);
       } else {
@@ -82,12 +82,12 @@ module ArgSortMsg
         return algorithm;
     }
 
-    // proc DefaultComparator.keyPart(x: _tuple, i:int) where !isHomogeneousTuple(x) &&
+    // proc defaultComparator.keyPart(x: _tuple, i:int) where !isHomogeneousTuple(x) &&
     // (isInt(x(0)) || isUint(x(0)) || isReal(x(0))) {
     
     import Reflection.canResolveMethod;
     record ContrivedComparator: keyPartComparator {
-      const dc = new DefaultComparator();
+      const dc = new defaultComparator();
       proc keyPart(a, i: int) {
         if canResolveMethod(dc, "keyPart", a, 0) {
           return dc.keyPart(a, i);

--- a/src/SegStringSort.chpl
+++ b/src/SegStringSort.chpl
@@ -29,7 +29,7 @@ module SegStringSort {
   record StringIntComparator: keyPartComparator {
     proc keyPart((a0,_): (string, int), in i: int) {
       // Just run the default comparator on the string
-      return (new DefaultComparator()).keyPart(a0, i);
+      return (new defaultComparator()).keyPart(a0, i);
     }
   }
   

--- a/src/compat/eq-20/ArkoudaSortCompat.chpl
+++ b/src/compat/eq-20/ArkoudaSortCompat.chpl
@@ -1,5 +1,5 @@
 module ArkoudaSortCompat {
-  public use Sort;
+  public use Sort except defaultComparator, DefaultComparator;
 
   interface keyComparator {}
   interface keyPartComparator {}
@@ -9,5 +9,10 @@ module ArkoudaSortCompat {
     proc pre param do return -1;
     proc returned param do return 0;
     proc post param do return 1;
+  }
+
+  proc defaultComparator type {
+    import Sort;
+    return Sort.DefaultComparator;
   }
 }

--- a/src/compat/eq-21/ArkoudaSortCompat.chpl
+++ b/src/compat/eq-21/ArkoudaSortCompat.chpl
@@ -1,5 +1,5 @@
 module ArkoudaSortCompat {
-  public use Sort;
+  public use Sort except defaultComparator, DefaultComparator;
 
   interface keyComparator {}
   interface keyPartComparator {}
@@ -9,5 +9,10 @@ module ArkoudaSortCompat {
     proc pre param do return -1;
     proc returned param do return 0;
     proc post param do return 1;
+  }
+
+  proc defaultComparator type {
+    import Sort;
+    return Sort.DefaultComparator;
   }
 }

--- a/src/compat/eq-22/ArkoudaSortCompat.chpl
+++ b/src/compat/eq-22/ArkoudaSortCompat.chpl
@@ -1,3 +1,8 @@
 module ArkoudaSortCompat {
-  public use Sort;
+  public use Sort except defaultComparator, DefaultComparator;
+
+  proc defaultComparator type {
+    import Sort;
+    return Sort.DefaultComparator;
+  }
 }

--- a/toys/argsortDRS.chpl
+++ b/toys/argsortDRS.chpl
@@ -7,12 +7,12 @@ config param debug = false;
 config const timing = true;
 
 module SortModuleStuff {
-  use Sort only DefaultComparator, defaultComparator, chpl_compare, chpl_check_comparator;
+  use Sort only defaultComparator, chpl_compare, chpl_check_comparator;
 
 /* BEGIN STUFF THAT SHOULD BE IN SORT MODULE */
 
 pragma "no doc"
-proc shellSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator,
+proc shellSort(Data: [?Dom] ?eltType, comparator:?rec=new defaultComparator(),
                start=Dom.low, end=Dom.high)
 {
   chpl_check_comparator(comparator, eltType);
@@ -126,7 +126,7 @@ proc binForRecord(a, criterion, startbit:int)
   } else if canResolveMethod(criterion, "key", a) {
     // Try to use the default comparator to get a keyPart.
     return binForRecordKeyPart(criterion.key(a),
-                               defaultComparator,
+                               new defaultComparator(),
                                startbit);
   } else {
     compilerError("Bad comparator for radix sort ", criterion.type:string,
@@ -160,7 +160,7 @@ proc msbRadixSortParamLastStartBit(Data:[], comparator) param {
   // Compute end_bit if it's known
   // Default comparator on integers has fixed width
   const ref element = Data[Data.domain.low];
-  if comparator.type == DefaultComparator && fixedWidth(element.type) > 0 {
+  if comparator.type == defaultComparator && fixedWidth(element.type) > 0 {
     return fixedWidth(element.type) - RADIX_BITS;
   } else if canResolveMethod(comparator, "key", element) {
     type keyType = comparator.key(element).type;
@@ -212,7 +212,7 @@ proc findDataStartBit(startbit:int, min_ubits, max_ubits):int {
 }
 
 pragma "no doc"
-proc msbRadixSort(Data:[], comparator:?rec=defaultComparator) {
+proc msbRadixSort(Data:[], comparator:?rec=new defaultComparator()) {
 
   var endbit:int;
   endbit = msbRadixSortParamLastStartBit(Data, comparator);
@@ -677,7 +677,7 @@ proc simpletestcore(input:[]) {
 
   msbRadixSortWithScratchSpace(blockDom.low, blockDom.high,
                                dst, src,
-                               defaultComparator,
+                               new defaultComparator(),
                                0, max(int));
 
   if debug {
@@ -735,7 +735,7 @@ proc randomtest(n:int) {
   timer.start();
   msbRadixSortWithScratchSpace(0, n-1,
                                dst, src,
-                               defaultComparator,
+                               new defaultComparator(),
                                0, max(int));
   timer.stop();
 

--- a/toys/distributedRadixSort.chpl
+++ b/toys/distributedRadixSort.chpl
@@ -7,12 +7,12 @@ config param debug = false;
 config const timing = true;
 
 module SortModuleStuff {
-  use Sort only DefaultComparator, defaultComparator, chpl_compare, chpl_check_comparator;
+  use Sort only defaultComparator, chpl_compare, chpl_check_comparator;
 
 /* BEGIN STUFF THAT SHOULD BE IN SORT MODULE */
 
 pragma "no doc"
-proc shellSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator,
+proc shellSort(Data: [?Dom] ?eltType, comparator:?rec=new defaultComparator(),
                start=Dom.low, end=Dom.high)
 {
   chpl_check_comparator(comparator, eltType);
@@ -160,7 +160,7 @@ proc msbRadixSortParamLastStartBit(Data:[], comparator) param {
   // Compute end_bit if it's known
   // Default comparator on integers has fixed width
   const ref element = Data[Data.domain.low];
-  if comparator.type == DefaultComparator && fixedWidth(element.type) > 0 {
+  if comparator.type == defaultComparator && fixedWidth(element.type) > 0 {
     return fixedWidth(element.type) - RADIX_BITS;
   } else if canResolveMethod(comparator, "key", element) {
     type keyType = comparator.key(element).type;


### PR DESCRIPTION
Updates the typename of `DefaultComparator` to `defaultComparator`. `DefaultComparator` was a transitional name while stabilizing the module, `defaultComparator` is the final name.

Followup to https://github.com/Bears-R-Us/arkouda/pull/3750