### PR TITLE
Closes 3548 - updates and corrects docstrings in pdarraycreation.py

### DIFF
--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -317,6 +317,31 @@ class TestParquet:
             else:
                 assert (np_edge_case == pq_arr.to_ndarray()).all()
 
+    @pytest.mark.parametrize("prob_size", pytest.prob_size)
+    def test_large_parquet_io(self,par_test_base_tmp,prob_size) :
+
+        with tempfile.TemporaryDirectory(dir=par_test_base_tmp) as tmp_dirname:
+            filename = f"{tmp_dirname}/pq_test_large_parquet"
+            size = max(prob_size,2**21 + 8)  # A problem had been detected with parquet files of > 2**21 entries
+            bool_array = np.array((size//2)*[True, False]).tolist()
+            flt_array = np.arange(size).astype(np.float64).tolist()
+            int_array = np.arange(size).astype(np.int64).tolist()
+            str_array = np.array(["a"+str(i) for i in np.arange(size)]).tolist()
+            arrays = [bool_array, int_array, flt_array, str_array]
+            tuples = list(zip(*arrays))
+            names = ['first', 'second', 'third', 'fourth']
+            index = pd.MultiIndex.from_tuples(tuples, names=names)
+            s = pd.Series(np.random.randn(size), index=index)
+            df = s.to_frame()
+            df.to_parquet(filename)
+            ak_df = ak.DataFrame(ak.read_parquet(filename))
+            #  This check is on all of the random numbers generated in s
+            assert np.all(ak_df.to_pandas().values[:, 0] == s.values)
+            #  This check is on all of the elements of the MultiIndex
+            for i in range(len(names)) :
+                assert np.all(df.index.get_level_values(names[i]).to_numpy() == ak_df[names[i]].to_ndarray())
+
+
     @pytest.mark.parametrize("dtype", NUMERIC_AND_STR_TYPES)
     def test_get_datasets(self, par_test_base_tmp, dtype):
         ak_arr = make_ak_arrays(10, dtype)


### PR DESCRIPTION
This updates the docstrings in pdarraycreation.py.

Summary:

- some Raises entries were outdated.  I fixed them.
- some Examples involved random numbers, so without adding a seed, they weren't reproducible.  I added a seed.
- some Examples gave results as integers when arkouda gives floating point.  I corrected that.
- most Examples had commas between array elements in the output, and arkouda mostly doesn't.  I removed the commas.
- because ones, zeros and full were almost identical code, I removed the code from ones and zeros, and replaced it with a single line call to full, with a fill_value of 1 or 0 as appropriate.
- added @typechecked to promote_to_common_type.

As to Ryan's comment below re ak.standard_normal, I'm puzzled at how the current version got into the code.  When I check it myself, I get what docdoc thinks I should get.  So I updated it.