### PR TITLE
Closes #4096, adding `range` parameter to `histogram` functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Makefile for Arkouda
 ARKOUDA_PROJECT_DIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
+ARKOUDA_PROJECT_DIR := $(patsubst %/,%,$(ARKOUDA_PROJECT_DIR))
 
 PROJECT_NAME := arkouda
 ARKOUDA_SOURCE_DIR := $(ARKOUDA_PROJECT_DIR)/src
@@ -114,7 +115,7 @@ deps-download-source: zmq-download-source hdf5-download-source arrow-download-so
 
 DEP_DIR := dep
 DEP_INSTALL_DIR := $(ARKOUDA_PROJECT_DIR)/$(DEP_DIR)
-DEP_BUILD_DIR := $(ARKOUDA_PROJECT_DIR)$(DEP_DIR)/build
+DEP_BUILD_DIR := $(ARKOUDA_PROJECT_DIR)/$(DEP_DIR)/build
 
 ZMQ_VER := 4.3.5
 ZMQ_NAME_VER := zeromq-$(ZMQ_VER)
@@ -128,8 +129,8 @@ zmq-download-source:
     ifeq (,$(wildcard ${ZMQ_BUILD_DIR}*/.*))
         #   If the tar.gz not found, download it
         ifeq (,$(wildcard ${DEP_BUILD_DIR}/${ZMQ_NAME_VER}*.tar.gz))
-			cd $(DEP_BUILD_DIR) && curl -sL $(ZMQ_LINK) | tar xz		
-		#   Otherwise just unzip it
+			cd $(DEP_BUILD_DIR) && curl -sL $(ZMQ_LINK) | tar xz
+        #   Otherwise just unzip it
         else
 			cd $(DEP_BUILD_DIR) && tar -xzf $(ZMQ_NAME_VER)*.tar.gz
         endif
@@ -166,18 +167,18 @@ hdf5-download-source:
     ifeq (,$(wildcard ${HDF5_BUILD_DIR}*/.*))
         #   If the tar.gz not found, download it
         ifeq (,$(wildcard ${DEP_BUILD_DIR}/$(HDF5_NAME_VER)*tar.gz))
-			cd $(DEP_BUILD_DIR) && curl -sL $(HDF5_LINK) | tar xz		
-		#   Otherwise just unzip it
+			cd $(DEP_BUILD_DIR) && curl -sL $(HDF5_LINK) | tar xz
+        #   Otherwise just unzip it
         else
 			cd $(DEP_BUILD_DIR) && tar -xzf $(HDF5_NAME_VER)*.tar.gz
         endif
-    endif    
+    endif
 
 install-hdf5: hdf5-download-source
 	@echo "Installing HDF5"
 	rm -rf $(HDF5_INSTALL_DIR)
 	mkdir -p $(DEP_INSTALL_DIR) $(DEP_BUILD_DIR)
-	
+
 	cd $(HDF5_BUILD_DIR)* && ./configure --prefix=$(HDF5_INSTALL_DIR) --enable-optimization=high --enable-hl && make && make install
 	echo '$$(eval $$(call add-path,$(HDF5_INSTALL_DIR)))' >> Makefile.paths
 
@@ -218,9 +219,8 @@ arrow-download-source:
 		mkdir -p $(ARROW_DEP_DIR)
 		cd $(ARROW_BUILD_DIR)/cpp/thirdparty/ && ./download_dependencies.sh $(ARROW_DEP_DIR) > $(DEP_BUILD_DIR)/arrow_exports.sh
     endif
-    
+
 	rm -fr $(ARROW_BUILD_DIR)
-    
 
 install-arrow: arrow-download-source
 	@echo "Installing Apache Arrow/Parquet"
@@ -230,16 +230,16 @@ install-arrow: arrow-download-source
 
 	cd $(DEP_BUILD_DIR) && tar -xvf $(ARROW_NAME_VER).tar.gz
 	mkdir -p $(ARROW_BUILD_DIR)/cpp/build-release
-	
+
 	cd $(DEP_BUILD_DIR) && . ./arrow_exports.sh && cd $(ARROW_BUILD_DIR)/cpp/build-release && cmake -S $(ARROW_BUILD_DIR)/cpp .. -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_INSTALL_PREFIX=$(ARROW_INSTALL_DIR) -DCMAKE_BUILD_TYPE=Release -DARROW_PARQUET=ON -DARROW_WITH_SNAPPY=ON -DARROW_WITH_BROTLI=ON -DARROW_WITH_BZ2=ON -DARROW_WITH_LZ4=ON -DARROW_WITH_ZLIB=ON -DARROW_WITH_ZSTD=ON -DARROW_DEPENDENCY_SOURCE=$(ARROW_DEPENDENCY_SOURCE) $(ARROW_OPTIONS) && make -j$(NUM_CORES)
 
 	cd $(ARROW_BUILD_DIR)/cpp/build-release && make install
-    
-	echo '$$(eval $$(call add-path,$(ARROW_INSTALL_DIR)))' >> Makefile.paths   
+
+	echo '$$(eval $$(call add-path,$(ARROW_INSTALL_DIR)))' >> Makefile.paths
 
 arrow-clean:
 	rm -rf $(DEP_BUILD_DIR)/apache-arrow*
-	rm -rf $(DEP_BUILD_DIR)/arrow-apache-arrow*	
+	rm -rf $(DEP_BUILD_DIR)/arrow-apache-arrow*
 	rm -rf $(ARROW_DEP_DIR)
 	rm -fr $(DEP_BUILD_DIR)/arrow_exports.sh
 
@@ -268,23 +268,23 @@ ICONV_LINK := https://ftp.gnu.org/pub/gnu/libiconv/libiconv-$(ICONV_VER).tar.gz
 
 iconv-download-source:
 	mkdir -p $(DEP_BUILD_DIR)
-	
+
     #If the build directory does not exist,  create it
     ifeq (,$(wildcard ${ICONV_BUILD_DIR}*/.*))
         #   If the tar.gz not found, download it
         ifeq (,$(wildcard ${DEP_BUILD_DIR}/libiconv-${ICONV_VER}.tar.gz))
-			cd $(DEP_BUILD_DIR) && curl -sL $(ICONV_LINK) | tar xz		
-		#   Otherwise just unzip it
+			cd $(DEP_BUILD_DIR) && curl -sL $(ICONV_LINK) | tar xz
+        #   Otherwise just unzip it
         else
 			cd $(DEP_BUILD_DIR) && tar -xzf libiconv-$(ICONV_VER).tar.gz
         endif
-    endif	
-    
+    endif
+
 install-iconv: iconv-download-source
 	@echo "Installing iconv"
 	rm -rf $(ICONV_INSTALL_DIR)
 	mkdir -p $(DEP_INSTALL_DIR) $(DEP_BUILD_DIR)
-	
+
 	cd $(ICONV_BUILD_DIR) && ./configure --prefix=$(ICONV_INSTALL_DIR) && make && make install
 	echo '$$(eval $$(call add-path,$(ICONV_INSTALL_DIR)))' >> Makefile.paths
 
@@ -299,23 +299,23 @@ LIBIDN_LINK := https://ftp.gnu.org/gnu/libidn/libidn2-$(LIBIDN_VER).tar.gz
 
 idn2-download-source:
 	mkdir -p $(DEP_BUILD_DIR)
-	
+
     #If the build directory does not exist,  create it
     ifeq (,$(wildcard $(LIBIDN_BUILD_DIR)*/.*))
-		# If the tar.gz is not found, download it
+        # If the tar.gz is not found, download it
         ifeq (,$(wildcard ${DEP_BUILD_DIR}/libidn2-$(LIBIDN_VER)*.tar.gz))
-			cd $(DEP_BUILD_DIR) && curl -sL $(LIBIDN_LINK) | tar xz		
-		# Otherwise just unzip it
+			cd $(DEP_BUILD_DIR) && curl -sL $(LIBIDN_LINK) | tar xz
+        # Otherwise just unzip it
         else
 			cd $(DEP_BUILD_DIR) && tar -xzf libidn2-$(LIBIDN_VER)*.tar.gz
         endif
-    endif	
+    endif
 
 install-idn2: idn2-download-source
 	@echo "Installing libidn2"
 	rm -rf $(LIBIDN_INSTALL_DIR)
-	mkdir -p $(DEP_INSTALL_DIR) $(DEP_BUILD_DIR)	
-	
+	mkdir -p $(DEP_INSTALL_DIR) $(DEP_BUILD_DIR)
+
 	cd $(LIBIDN_BUILD_DIR) && ./configure --prefix=$(LIBIDN_INSTALL_DIR) && make && make install
 	echo '$$(eval $$(call add-path,$(LIBIDN_INSTALL_DIR)))' >> Makefile.paths
 
@@ -327,7 +327,7 @@ BLOSC_INSTALL_DIR := $(DEP_INSTALL_DIR)/c-blosc-install
 
 blosc-download-source:
 	mkdir -p $(DEP_BUILD_DIR)
-	
+
     #If the build directory does not exist,  create it
     ifeq (,$(wildcard $(BLOSC_BUILD_DIR)/.*))
 		cd $(DEP_BUILD_DIR) && git clone https://github.com/Blosc/c-blosc2.git
@@ -759,8 +759,6 @@ benchmark:
 	mkdir -p benchmark_v2/data
 	python3 -m pytest -c benchmark.ini --benchmark-autosave --benchmark-storage=file://benchmark_v2/.benchmarks --size=$(size_bm) --benchmark-json=$(out)
 	python3 benchmark_v2/reformat_benchmark_results.py --benchmark-data $(out)
-
-	
 
 version:
 	@echo $(VERSION);

--- a/src/HistogramMsg.chpl
+++ b/src/HistogramMsg.chpl
@@ -6,18 +6,18 @@ module HistogramMsg
     use ServerErrors;
     use Logging;
     use Message;
-    
+
     use MultiTypeSymbolTable;
     use MultiTypeSymEntry;
     use ServerErrorStrings;
 
     use Histogram;
     use Message;
- 
+
     private config const logLevel = ServerConfig.logLevel;
     private config const logChannel = ServerConfig.logChannel;
     const hgmLogger = new Logger(logLevel, logChannel);
-    
+
     private config const sBound = 2**12;
     private config const mBound = 2**25;
 
@@ -27,7 +27,7 @@ module HistogramMsg
         var repMsg: string; // response message
         const bins = msgArgs.get("bins").getIntValue();
         const name = msgArgs.getValueOf("array");
-        
+
         // get next symbol name
         var rname = st.nextName();
         hgmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
@@ -38,8 +38,8 @@ module HistogramMsg
         // helper nested procedure
         proc histogramHelper(type t) throws {
           var e = toSymEntry(gEnt,t);
-          var aMin = min reduce e.a;
-          var aMax = max reduce e.a;
+          var aMin = msgArgs.get("minVal").toScalar(real);
+          var aMax = msgArgs.get("maxVal").toScalar(real);
           var binWidth:real = (aMax - aMin):real / bins:real;
           hgmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                                            "binWidth %r".format(binWidth));
@@ -70,11 +70,11 @@ module HistogramMsg
             when (DType.Float64) {histogramHelper(real);}
             otherwise {
                 var errorMsg = notImplementedError(pn,gEnt.dtype);
-                hgmLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);  
-                return new MsgTuple(errorMsg, MsgType.ERROR);             
+                hgmLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                return new MsgTuple(errorMsg, MsgType.ERROR);
             }
         }
-        
+
         repMsg = "created " + st.attrib(rname);
         hgmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
         return new MsgTuple(repMsg, MsgType.NORMAL);
@@ -101,11 +101,11 @@ module HistogramMsg
         // helper nested procedure
         proc histogramHelper(type t1, type t2) throws {
             var x = toSymEntry(xGenEnt,t1);
-            var y = toSymEntry(yGenEnt,t2);            
-            var xMin = min reduce x.a;
-            var xMax = max reduce x.a;
-            var yMin = min reduce y.a;
-            var yMax = max reduce y.a;
+            var y = toSymEntry(yGenEnt,t2);
+            var xMin = msgArgs.get("xMin").toScalar(real);
+            var xMax = msgArgs.get("xMax").toScalar(real);
+            var yMin = msgArgs.get("yMin").toScalar(real);
+            var yMax = msgArgs.get("yMax").toScalar(real);
             var xBinWidth:real = (xMax - xMin):real / xBins:real;
             var yBinWidth:real = (yMax - yMin):real / yBins:real;
             hgmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
@@ -162,87 +162,80 @@ module HistogramMsg
         const binsStrs = msgArgs.get("bins").getList(numDims);
         const bins = try! [b in binsStrs] b:int;
         const names = msgArgs.get("sample").getList(numDims);
-        const dimProdName = msgArgs.getValueOf("dim_prod");
+        const dimProd = msgArgs.get("dim_prod").toScalarArray(int, numDims);
         const totNumBins = * reduce bins;
-        
+
         // get next symbol name
         var rname = st.nextName();
         hgmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                       "cmd: %s name: %? bins: %? rname: %s".format(cmd, names, bins, rname));
 
         var gEnts = try! [name in names] getGenericTypedArrayEntry(name, st);
-        var dimProdGenEnt = getGenericTypedArrayEntry(dimProdName, st);
-        var dimProd = toSymEntry(dimProdGenEnt,int);
 
         // helper nested procedure
         proc histogramHelper(type t) throws {
+            var rangeMin = msgArgs.get("rangeMin").toScalarArray(real, numDims);
+            var rangeMax = msgArgs.get("rangeMax").toScalarArray(real, numDims);
             var indices = makeDistArray(numSamples, int);
-            // 3 different implementations depending on size of histogram
-            // this is due to the time memory tradeoff between creating one/few atomic arrays
-            // or many non-atomic arrays and reducing them
 
             // compute index into flattened array:
             // for each dimension calculate which bin that value falls into in parallel
             // we can then scale by the product of the previous dimensions to get that dimensions impact on the flattened index
             // summing all these together gives the index into the flattened array
+            hgmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(), "compute indices");
+            for (gEnt, stride, bin, aMin, aMax) in zip(gEnts, dimProd, bins, rangeMin, rangeMax) {
+                var e = toSymEntry(gEnt,t);
+                var binWidth:real = (aMax - aMin):real / bin:real;
+                forall (v, idx) in zip(e.a, indices) {
+                  if idx < 0 {
+                    // value for this index was out of bounds in a previous sample, skip
+                  } else if ! histValWithinRange(v, aMin, aMax) {
+                    idx = -1;
+                  } else {
+                    const vBin = histValToBin(v, aMin, aMax, bin, binWidth);
+                    idx += (vBin * stride):int;
+                  }
+                }
+            }
+
+            // The result will be here.
+            const histSE = createSymEntry(totNumBins, real);
+            st.addEntry(rname, histSE);
+            ref hist = histSE.a;
+
+            // 3 different implementations depending on size of histogram
+            // this is due to the time memory tradeoff between creating one/few atomic arrays
+            // or many non-atomic arrays and reducing them
             if (totNumBins <= sBound) {
+                // "histogramReduceIntent"
                 // small number of buckets (so histogram is relatively small):
                 // each task gets it's own copy of the histogram and they're reduced
                 hgmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                                             "%? <= %?".format(bins,sBound));
-                for (gEnt, stride, bin) in zip(gEnts, dimProd.a, bins) {
-                    var e = toSymEntry(gEnt,t);
-                    var aMin = min reduce e.a;
-                    var aMax = max reduce e.a;
-                    var binWidth:real = (aMax - aMin):real / bin:real;
-                    forall (v, idx) in zip(e.a, indices) {
-                        var vBin = ((v - aMin) / binWidth):int;
-                        if v == aMax {vBin = bin-1;}
-                        idx += (vBin * stride):int;
-                    }
-                }
                 var gHist: [0..#totNumBins] int;
-                
+
                 // count into per-task/per-locale histogram and then reduce as tasks complete
                 forall idx in indices with (+ reduce gHist) {
+                    if idx<0 then continue;
                     gHist[idx] += 1;
                 }
 
-                var hist = makeDistArray(totNumBins,int);        
                 hist = gHist;
-                st.addEntry(rname, createSymEntry(hist));
             }
             else if (totNumBins <= mBound) {
+                // "histogramLocalAtomic"
                 // medium number of buckets:
                 // each locale gets it's own atomic copy of the histogram and these are reduced together
                 hgmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                                             "%? <= %?".format(bins,mBound));
                 use PrivateDist;
-                var atomicIdx: [PrivateSpace] [0..#numSamples] atomic int;
 
-                for (gEnt, stride, bin) in zip(gEnts, dimProd.a, bins) {
-                    var e = toSymEntry(gEnt,t);
-                    var aMin = min reduce e.a;
-                    var aMax = max reduce e.a;
-                    var binWidth:real = (aMax - aMin):real / bin:real;
-                    forall (v, i) in zip(e.a, 0..) {
-                        var vBin = ((v - aMin) / binWidth):int;
-                        if v == aMax {vBin = bin-1;}
-                        atomicIdx[here.id][i].add((vBin * stride):int);
-                    }
-                }
-
-                var lIdx: [0..#numSamples] int;
-                forall i in PrivateSpace with (+ reduce lIdx) {
-                    lIdx reduce= atomicIdx[i].read();
-                }
-
-                indices = lIdx;
                 // allocate per-locale atomic histogram
                 var atomicHist: [PrivateSpace] [0..#totNumBins] atomic int;
 
                 // count into per-locale private atomic histogram
                 forall idx in indices {
+                    if idx<0 then continue;
                     atomicHist[here.id][idx].add(1);
                 }
 
@@ -252,43 +245,26 @@ module HistogramMsg
                     lHist reduce= atomicHist[i].read();
                 }
 
-                var hist = makeDistArray(totNumBins,int);        
                 hist = lHist;
-                st.addEntry(rname, createSymEntry(hist));
             }
             else {
+
+                // "histogramGlobalAtomic"
                 // large number of buckets:
                 // one global atomic histogram
                 hgmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                                                 "%? > %?".format(bins,mBound));
-                use PrivateDist;
-                var atomicIdx: [makeDistDom(numSamples)] atomic int;
-
-                for (gEnt, stride, bin) in zip(gEnts, dimProd.a, bins) {
-                    var e = toSymEntry(gEnt,t);
-                    var aMin = min reduce e.a;
-                    var aMax = max reduce e.a;
-                    var binWidth:real = (aMax - aMin):real / bin:real;
-                    forall (v, i) in zip(e.a, 0..) {
-                        var vBin = ((v - aMin) / binWidth):int;
-                        if v == aMax {vBin = bin-1;}
-                        atomicIdx[i].add((vBin * stride):int);
-                    }
-                }
-
-                [(i,ai) in zip(indices, atomicIdx)] i = ai.read();
                 // allocate single global atomic histogram
                 var atomicHist: [makeDistDom(totNumBins)] atomic int;
 
                 // count into atomic histogram
                 forall idx in indices {
+                    if idx<0 then continue;
                     atomicHist[idx].add(1);
                 }
 
-                var hist = makeDistArray(totNumBins,int);
                 // copy from atomic histogram to normal histogram
                 [(e,ae) in zip(hist, atomicHist)] e = ae.read();
-                st.addEntry(rname, createSymEntry(hist));
             }
         }
 
@@ -298,11 +274,11 @@ module HistogramMsg
             when (DType.Float64) {histogramHelper(real);}
             otherwise {
                 var errorMsg = notImplementedError(pn,gEnts[0].dtype);
-                hgmLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);  
-                return new MsgTuple(errorMsg, MsgType.ERROR);             
+                hgmLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+                return new MsgTuple(errorMsg, MsgType.ERROR);
             }
         }
-        
+
         repMsg = "created " + st.attrib(rname);
         hgmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
         return new MsgTuple(repMsg, MsgType.NORMAL);


### PR DESCRIPTION
Closes #4096. Required by https://github.com/Bears-R-Us/arkouda-contrib/pull/179

Adds `numpy`-style optional `range` parameter to client histogram functions:
* `histogram()`
* `histogram2d()`
* `histogramdd()`

Switches the histograms produced by `histogramdd()` to contain `float` counts instead of integer counts, to match `numpy`.

While there:

* Makes `histogramdDMsg()` more efficient.
* Factors out some histogram server code.
* Removes the dependence of `histogramdd()` on `cumprod()`.
* Cleans up Makefile to remove an extraneous `/` and trailing whitespace.