### PR TITLE
Avoid 0 in test with unsigned numbers

### DIFF
--- a/tests/apply_test.py
+++ b/tests/apply_test.py
@@ -66,7 +66,7 @@ class TestApply:
         for r in ak.client.get_array_ranks():
             size = int(prob_size**(1/r))
             shape = (size,) * r
-            a = ak.randint(0, 100, shape, dtype)
+            a = ak.randint(1, 100, shape, dtype)
             b = ak.apply(a, lambda x: x**4 - 1)
             assert ak.all(b == a**4 - 1)
             assert b.dtype == dtype


### PR DESCRIPTION
Adjusts a test to avoid accidentally trying to convert a -1 to an unsigned number.

This test creates an array with random numbers between 0 and 100. But if a number is 0, then the result after doing `0**4-1` is a negative number, which causes exceptions when trying to cast the value to an unsigned int.