### PR TITLE
Closes #3329: hstack to match numpy

### DIFF
--- a/arkouda/numpy/pdarrayclass.py
+++ b/arkouda/numpy/pdarrayclass.py
@@ -5,7 +5,7 @@ import json
 from functools import reduce
 from math import ceil
 from sys import modules
-from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union, cast
 
 import numpy as np
 from typeguard import typechecked
@@ -366,8 +366,8 @@ class pdarray:
         The number of elements in the array
     ndim : int_scalars
         The rank of the array
-    shape : Sequence[int]
-        A list or tuple containing the sizes of each dimension of the array
+    shape : Tuple[int, ...]
+        A tuple containing the sizes of each dimension of the array
     itemsize : int_scalars
         The size in bytes of each element
     """
@@ -407,7 +407,7 @@ class pdarray:
         mydtype: Union[np.dtype, str],
         size: int_scalars,
         ndim: int_scalars,
-        shape: Sequence[int],
+        shape: Tuple[int, ...],
         itemsize: int_scalars,
         max_bits: Optional[int] = None,
     ) -> None:
@@ -2921,10 +2921,10 @@ def create_pdarray(repMsg: str, max_bits=None) -> pdarray:
         ndim = int(fields[4])
 
         if fields[5] == "[]":
-            shape = []
+            shape: Tuple[int, ...] = tuple([])
         else:
             trailing_comma_offset = -2 if fields[5][len(fields[5]) - 2] == "," else -1
-            shape = [int(el) for el in fields[5][1:trailing_comma_offset].split(",")]
+            shape = tuple([int(el) for el in fields[5][1:trailing_comma_offset].split(",")])
 
         itemsize = int(fields[6])
     except Exception as e:

--- a/arkouda/numpy/pdarraymanipulation.py
+++ b/arkouda/numpy/pdarraymanipulation.py
@@ -1,49 +1,68 @@
-from typing import List, Literal, Optional, Sequence, Tuple, Union, cast
+from typing import Literal, Optional, Sequence, Union, cast
 
 import numpy as np
 from typeguard import typechecked
 
 from arkouda.client import generic_msg
+from arkouda.numpy.dtypes import bigint
 from arkouda.numpy.dtypes import dtype as akdtype
 from arkouda.numpy.pdarrayclass import create_pdarray, pdarray
 from arkouda.numpy.pdarraycreation import arange, array
 
-__all__ = ["vstack", "delete"]
+__all__ = ["hstack", "vstack", "delete"]
 
 
 @typechecked
-def vstack(
-    tup: Union[Tuple[pdarray], List[pdarray]],
+def hstack(
+    tup: Sequence[pdarray],
     *,
-    dtype: Optional[Union[type, str]] = None,
+    dtype: Optional[Union[str, type]] = None,
     casting: Literal["no", "equiv", "safe", "same_kind", "unsafe"] = "same_kind",
 ) -> pdarray:
     """
-    Stack a sequence of arrays vertically (row-wise).
+    Stack arrays in sequence horizontally (column wise).
 
-    This is equivalent to concatenation along the first axis after 1-D arrays of
-    shape `(N,)` have been reshaped to `(1,N)`.
+    This is equivalent to concatenation along the second axis, except for 1-D arrays
+    where it concatenates along the first axis. Rebuilds arrays divided by ``hsplit``.
+
+    This function makes most sense for arrays with up to 3 dimensions. For instance, for pixel-data
+    with a height (first axis), width (second axis), and r/g/b channels (third axis). The functions
+    ``concatenate``, ``stack`` and ``block`` provide more general stacking and concatenation operations.
 
     Parameters
     ----------
-    tup : Tuple[pdarray]
-        The arrays to be stacked
-    dtype : Optional[Union[type, str]], optional
-        The data-type of the output array. If not provided, the output
-        array will be determined using `np.common_type` on the
-        input arrays Defaults to None
-    casting : {"no", "equiv", "safe", "same_kind", "unsafe"], optional
-        Controls what kind of data casting may occur - currently unused
+    tup : sequence of pdarray
+        The arrays must have the same shape along all but the second axis, except 1-D arrays which
+        can be any length. In the case of a single array_like input, it will be treated as a sequence of
+        arrays; i.e., each element along the zeroth axis is treated as a separate array.
+    dtype : str or type, optional
+        If provided, the destination array will have this type.
+    casting : {‘no’, ‘equiv’, ‘safe’, ‘same_kind’, ‘unsafe’}, optional
+        Controls what kind of data casting may occur. Defaults to ‘same_kind’. Currently unused.
 
     Returns
     -------
-
     pdarray
-        The stacked array
+        The array formed by stacking the given arrays.
+
+    See Also
+    --------
+    concatenate, stack, block, vstack, dstack, column_stack, hsplit, unstack
+
+    Examples
+    --------
+    >>> a = ak.array([1, 2, 3])
+    >>> b = ak.array([4, 5, 6])
+    >>> ak.hstack((a, b))
+    array([1 2 3 4 5 6])
+    >>> a = ak.array([[1],[2],[3]])
+    >>> b = ak.array([[4],[5],[6]])
+    >>> ak.hstack((a, b))
+    array([array([1 4]) array([2 5]) array([3 6])])
     """
 
     if casting != "same_kind":
-        # TODO: wasn't clear from the docs what each of the casting options does
+        # TODO: align with https://numpy.org/doc/stable/glossary.html#term-casting
         raise NotImplementedError(f"casting={casting} is not yet supported")
 
     # ensure all arrays have the same number of dimensions
@@ -52,23 +71,177 @@ def vstack(
         if a.ndim != ndim:
             raise ValueError("all input arrays must have the same number of dimensions")
 
+    has_bigint = False
+    m_bits = -1
+
+    for a in tup:
+        if a.dtype == bigint:
+            has_bigint = True
+
+            # I think a.max_bits creates a call to Chapel, so maybe this cuts down
+            # on how many times we bother the server.
+            curr_bits = a.max_bits
+            if curr_bits > 0 and (m_bits == -1 or curr_bits < m_bits):
+                m_bits = curr_bits
+
     # establish the dtype of the output array
+    if has_bigint and dtype is None:
+        dtype = bigint
     if dtype is None:
-        dtype_ = np.common_type(*[np.empty(0, dtype=a.dtype) for a in tup])
+        dtype_ = np.result_type(*[np.dtype(a.dtype) for a in tup])
     else:
         dtype_ = akdtype(dtype)
 
     # cast the input arrays to the output dtype if necessary
     arrays = [a.astype(dtype_) if a.dtype != dtype_ else a for a in tup]
 
+    if has_bigint:
+        for i in range(len(arrays)):
+            arrays[i].max_bits = m_bits
+
+    offsets = [0 for _ in range(len(arrays))]
+
+    if ndim == 1:
+        for i in range(1, len(arrays)):
+            offsets[i] = offsets[i - 1] + arrays[i - 1].shape[0]
+        return create_pdarray(
+            generic_msg(
+                cmd=f"concatenate<{akdtype(dtype_).name},{arrays[0].ndim}>",
+                args={
+                    "names": list(arrays),
+                    "n": len(arrays),
+                    "axis": 0,
+                    "offsets": offsets,
+                },
+            )
+        )
+
+    for i in range(1, len(arrays)):
+        offsets[i] = offsets[i - 1] + arrays[i - 1].shape[1]
+
+    # stack the arrays along the horizontal axis
+    return create_pdarray(
+        generic_msg(
+            cmd=f"concatenate<{akdtype(dtype_).name},{arrays[0].ndim}>",
+            args={
+                "names": list(arrays),
+                "n": len(arrays),
+                "axis": 1,
+                "offsets": offsets,
+            },
+        )
+    )
+
+
+@typechecked
+def vstack(
+    tup: Sequence[pdarray],
+    *,
+    dtype: Optional[Union[str, type]] = None,
+    casting: Literal["no", "equiv", "safe", "same_kind", "unsafe"] = "same_kind",
+) -> pdarray:
+    """
+    Stack arrays in sequence vertically (row wise).
+
+    This is equivalent to concatenation along the first axis after
+    1-D arrays of shape `(N,)` have been reshaped to `(1,N)`. Rebuilds arrays divided by ``vsplit``.
+
+    This function makes most sense for arrays with up to 3 dimensions.
+    For instance, for pixel-data with a height (first axis), width (second axis),
+    and r/g/b channels (third axis). The functions ``concatenate``, ``stack`` and ``block``
+    provide more general stacking and concatenation operations.
+
+    Parameters
+    ----------
+    tup : sequence of pdarray
+        The arrays must have the same shape along all but the first axis. 1-D arrays
+        must have the same length. In the case of a single array_like input, it will be
+        treated as a sequence of arrays; i.e., each element along the zeroth axis is treated
+        as a separate array.
+    dtype : str or type, optional
+        If provided, the destination array will have this dtype.
+    casting : {"no", "equiv", "safe", "same_kind", "unsafe"], optional
+        Controls what kind of data casting may occur. Defaults to ‘same_kind’. Currently unused.
+
+    Returns
+    -------
+    pdarray
+        The array formed by stacking the given arrays, will be at least 2-D.
+
+    See Also
+    --------
+    concatenate, stack, block, hstack, dstack, column_stack, hsplit, unstack
+
+    Examples
+    --------
+    >>> a = ak.array([1, 2, 3])
+    >>> b = ak.array([4, 5, 6])
+    >>> ak.vstack((a, b))
+    array([array([1 2 3]) array([4 5 6])])
+
+    >>> a = ak.array([[1],[2],[3]])
+    >>> b = ak.array([[4],[5],[6]])
+    >>> ak.vstack((a, b))
+    array([array([1]) array([2]) array([3]) array([4]) array([5]) array([6])])
+
+    """
+
+    if casting != "same_kind":
+        # TODO: align with https://numpy.org/doc/stable/glossary.html#term-casting
+        raise NotImplementedError(f"casting={casting} is not yet supported")
+
+    # From docstring: "This is equivalent to concatenation along the first axis after 1-D arrays
+    # of shape (N,) have been reshaped to (1,N)."
+    arrays = [a if a.ndim != 1 else a.reshape((1, len(a))) for a in tup]
+
+    # ensure all arrays have the same number of dimensions
+    ndim = arrays[0].ndim
+    for a in arrays:
+        if a.ndim != ndim:
+            raise ValueError("all input arrays must have the same number of dimensions")
+
+    has_bigint = False
+    m_bits = -1
+
+    for a in tup:
+        if a.dtype == bigint:
+            has_bigint = True
+
+            # I think a.max_bits creates a call to Chapel, so maybe this cuts down
+            # on how many times we bother the server.
+            curr_bits = a.max_bits
+            if curr_bits > 0 and (m_bits == -1 or curr_bits < m_bits):
+                m_bits = curr_bits
+
+    # establish the dtype of the output array
+    if has_bigint and dtype is None:
+        dtype = bigint
+    if dtype is None:
+        dtype_ = np.result_type(*[np.dtype(a.dtype) for a in arrays])
+    else:
+        dtype_ = akdtype(dtype)
+
+    # cast the input arrays to the output dtype if necessary
+    arrays = [a.astype(dtype_) if a.dtype != dtype_ else a for a in arrays]
+
+    if has_bigint:
+        for i in range(len(arrays)):
+            arrays[i].max_bits = m_bits
+
+    offsets = [0 for _ in range(len(arrays))]
+
+    for i in range(1, len(arrays)):
+        offsets[i] = offsets[i - 1] + arrays[i - 1].shape[0]
+
     # stack the arrays along the first axis
     return create_pdarray(
         generic_msg(
-            cmd=f"stack{ndim}D",
+            cmd=f"concatenate<{akdtype(dtype_).name},{arrays[0].ndim}>",
             args={
                 "names": list(arrays),
                 "n": len(arrays),
                 "axis": 0,
+                "offsets": offsets,
             },
         )
     )

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,6 +14,7 @@ testpaths =
     tests/array_api/stats_functions.py
     tests/array_api/util_functions.py
     tests/alignment_test.py
+    tests/array_manipulation_tests.py
     tests/apply_test.py
     tests/bigint_agg_test.py
     tests/bitops_test.py

--- a/tests/numpy/array_manipulation_tests.py
+++ b/tests/numpy/array_manipulation_tests.py
@@ -9,16 +9,187 @@ from arkouda.testing import assert_arkouda_array_equivalent
 class TestManipulationFunctions:
     @pytest.mark.skip_if_rank_not_compiled([2])
     def test_vstack(self):
-        # These tests will be implemented soon, hopefully.
-        """
         a = [ak.random.randint(0, 10, 25) for _ in range(4)]
         n = [x.to_ndarray() for x in a]
 
         n_vstack = np.vstack(n)
         a_vstack = ak.vstack(a)
 
-        assert n_vstack.tolist() == a_vstack.to_list()
-        """
+        assert_arkouda_array_equivalent(n_vstack, a_vstack)
+
+    @pytest.mark.skip_if_rank_not_compiled([2])
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype", [int, ak.int64, ak.uint64, float, ak.float64, ak.bigint])
+    def test_vstack_with_dtypes(self, size, dtype):
+        if dtype == ak.bigint:
+            a = [ak.arange(2**200 + i * size, 2**200 + (i + 1) * size, dtype=dtype) for i in range(4)]
+            n = [np.arange(2**200 + i * size, 2**200 + (i + 1) * size) for i in range(4)]
+        else:
+            a = [ak.arange(i * size, (i + 1) * size, dtype=dtype) for i in range(4)]
+            n = [x.to_ndarray() for x in a]
+        n_vstack = np.vstack(n)
+        a_vstack = ak.vstack(a)
+
+        assert_arkouda_array_equivalent(n_vstack, a_vstack)
+
+    @pytest.mark.skip_if_rank_not_compiled([2])
+    @pytest.mark.parametrize("dtype", [int, ak.int64, ak.uint64, float, ak.float64, ak.bigint])
+    @pytest.mark.parametrize("shapes", [[(3,), (3,)], [(2, 3), (3,)], [(3, 3), (4, 3)]])
+    def test_vstack2D_with_shapes(self, dtype, shapes):
+        shape1, shape2 = shapes
+
+        shape1_prod = 1
+        for i in shape1:
+            shape1_prod = shape1_prod * i
+
+        shape2_prod = 1
+        for i in shape2:
+            shape2_prod = shape2_prod * i
+
+        if dtype == ak.bigint:
+            ak_a = ak.arange(2**200, 2**200 + shape1_prod, dtype=dtype).reshape(shape1)
+            ak_b = ak.arange(
+                2**200 + shape1_prod, 2**200 + (shape1_prod + shape2_prod), dtype=dtype
+            ).reshape(shape2)
+            ak_vstack = ak.vstack((ak_a, ak_b))
+
+            np_a = np.arange(2**200, 2**200 + shape1_prod).reshape(shape1)
+            np_b = np.arange(2**200 + shape1_prod, 2**200 + (shape1_prod + shape2_prod)).reshape(shape2)
+            np_vstack = np.vstack((np_a, np_b))
+        else:
+            ak_a = ak.arange(shape1_prod, dtype=dtype).reshape(shape1)
+            ak_b = ak.arange(shape1_prod, (shape1_prod + shape2_prod), dtype=dtype).reshape(shape2)
+            ak_vstack = ak.vstack((ak_a, ak_b))
+
+            np_a = np.arange(shape1_prod, dtype=dtype).reshape(shape1)
+            np_b = np.arange(shape1_prod, (shape1_prod + shape2_prod), dtype=dtype).reshape(shape2)
+            np_vstack = np.vstack((np_a, np_b))
+
+        assert_arkouda_array_equivalent(np_vstack, ak_vstack)
+
+    @pytest.mark.skip_if_rank_not_compiled([3])
+    @pytest.mark.parametrize("dtype", [int, ak.int64, ak.uint64, float, ak.float64, ak.bigint])
+    @pytest.mark.parametrize(
+        "shapes", [[(1, 2, 3), (1, 2, 3)], [(1, 2, 3), (2, 2, 3)], [(2, 2, 2), (4, 2, 2)]]
+    )
+    def test_vstack3D_with_shapes(self, dtype, shapes):
+        shape1, shape2 = shapes
+
+        shape1_prod = 1
+        for i in shape1:
+            shape1_prod = shape1_prod * i
+
+        shape2_prod = 1
+        for i in shape2:
+            shape2_prod = shape2_prod * i
+
+        if dtype == ak.bigint:
+            ak_a = ak.arange(2**200, 2**200 + shape1_prod, dtype=dtype).reshape(shape1)
+            ak_b = ak.arange(
+                2**200 + shape1_prod, 2**200 + (shape1_prod + shape2_prod), dtype=dtype
+            ).reshape(shape2)
+            ak_vstack = ak.vstack((ak_a, ak_b))
+
+            np_a = np.arange(2**200, 2**200 + shape1_prod).reshape(shape1)
+            np_b = np.arange(2**200 + shape1_prod, 2**200 + (shape1_prod + shape2_prod)).reshape(shape2)
+            np_vstack = np.vstack((np_a, np_b))
+        else:
+            ak_a = ak.arange(shape1_prod, dtype=dtype).reshape(shape1)
+            ak_b = ak.arange(shape1_prod, (shape1_prod + shape2_prod), dtype=dtype).reshape(shape2)
+            ak_vstack = ak.vstack((ak_a, ak_b))
+
+            np_a = np.arange(shape1_prod, dtype=dtype).reshape(shape1)
+            np_b = np.arange(shape1_prod, (shape1_prod + shape2_prod), dtype=dtype).reshape(shape2)
+            np_vstack = np.vstack((np_a, np_b))
+
+        assert_arkouda_array_equivalent(np_vstack, ak_vstack)
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype", [int, ak.int64, ak.uint64, float, ak.float64, ak.bigint])
+    def test_hstack(self, size, dtype):
+        if dtype == ak.bigint:
+            a = [ak.arange(2**200 + i * size, 2**200 + (i + 1) * size, dtype=dtype) for i in range(4)]
+            n = [np.arange(2**200 + i * size, 2**200 + (i + 1) * size) for i in range(4)]
+        else:
+            a = [ak.arange(i * size, (i + 1) * size, dtype=dtype) for i in range(4)]
+            n = [x.to_ndarray() for x in a]
+
+        n_hstack = np.hstack(n)
+        a_hstack = ak.hstack(a)
+
+        assert_arkouda_array_equivalent(n_hstack, a_hstack)
+
+    @pytest.mark.skip_if_rank_not_compiled([2])
+    @pytest.mark.parametrize("dtype", [int, ak.int64, ak.uint64, float, ak.float64, ak.bigint])
+    @pytest.mark.parametrize("shapes", [[(3, 1), (3, 1)], [(2, 3), (2, 4)], [(3, 5), (3, 2)]])
+    def test_hstack2D_with_shapes(self, dtype, shapes):
+        shape1, shape2 = shapes
+
+        shape1_prod = 1
+        for i in shape1:
+            shape1_prod = shape1_prod * i
+
+        shape2_prod = 1
+        for i in shape2:
+            shape2_prod = shape2_prod * i
+
+        if dtype == ak.bigint:
+            ak_a = ak.arange(2**200, 2**200 + shape1_prod, dtype=dtype).reshape(shape1)
+            ak_b = ak.arange(
+                2**200 + shape1_prod, 2**200 + (shape1_prod + shape2_prod), dtype=dtype
+            ).reshape(shape2)
+            ak_hstack = ak.hstack((ak_a, ak_b))
+
+            np_a = np.arange(2**200, 2**200 + shape1_prod).reshape(shape1)
+            np_b = np.arange(2**200 + shape1_prod, 2**200 + (shape1_prod + shape2_prod)).reshape(shape2)
+            np_hstack = np.hstack((np_a, np_b))
+        else:
+            ak_a = ak.arange(shape1_prod, dtype=dtype).reshape(shape1)
+            ak_b = ak.arange(shape1_prod, (shape1_prod + shape2_prod), dtype=dtype).reshape(shape2)
+            ak_hstack = ak.hstack((ak_a, ak_b))
+
+            np_a = np.arange(shape1_prod, dtype=dtype).reshape(shape1)
+            np_b = np.arange(shape1_prod, (shape1_prod + shape2_prod), dtype=dtype).reshape(shape2)
+            np_hstack = np.hstack((np_a, np_b))
+
+        assert_arkouda_array_equivalent(np_hstack, ak_hstack)
+
+    @pytest.mark.skip_if_rank_not_compiled([3])
+    @pytest.mark.parametrize("dtype", [int, ak.int64, ak.uint64, float, ak.float64, ak.bigint])
+    @pytest.mark.parametrize(
+        "shapes", [[(1, 2, 3), (1, 2, 3)], [(1, 2, 3), (1, 1, 3)], [(2, 2, 2), (2, 4, 2)]]
+    )
+    def test_hstack3D_with_shapes(self, dtype, shapes):
+        shape1, shape2 = shapes
+
+        shape1_prod = 1
+        for i in shape1:
+            shape1_prod = shape1_prod * i
+
+        shape2_prod = 1
+        for i in shape2:
+            shape2_prod = shape2_prod * i
+
+        if dtype == ak.bigint:
+            ak_a = ak.arange(2**200, 2**200 + shape1_prod, dtype=dtype).reshape(shape1)
+            ak_b = ak.arange(
+                2**200 + shape1_prod, 2**200 + (shape1_prod + shape2_prod), dtype=dtype
+            ).reshape(shape2)
+            ak_hstack = ak.hstack((ak_a, ak_b))
+
+            np_a = np.arange(2**200, 2**200 + shape1_prod).reshape(shape1)
+            np_b = np.arange(2**200 + shape1_prod, 2**200 + (shape1_prod + shape2_prod)).reshape(shape2)
+            np_hstack = np.hstack((np_a, np_b))
+        else:
+            ak_a = ak.arange(shape1_prod, dtype=dtype).reshape(shape1)
+            ak_b = ak.arange(shape1_prod, (shape1_prod + shape2_prod), dtype=dtype).reshape(shape2)
+            ak_hstack = ak.hstack((ak_a, ak_b))
+
+            np_a = np.arange(shape1_prod, dtype=dtype).reshape(shape1)
+            np_b = np.arange(shape1_prod, (shape1_prod + shape2_prod), dtype=dtype).reshape(shape2)
+            np_hstack = np.hstack((np_a, np_b))
+
+        assert_arkouda_array_equivalent(np_hstack, ak_hstack)
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", [int, ak.int64, ak.uint64, float, ak.float64, ak.bigint])


### PR DESCRIPTION
Since hstack uses concatenate in numpy, I redid concatenate on server side. It seems to work with normal pdarrays but not Strings or Categorical. I made some modifications on other things that also rely on ConcatenateMsg.chpl.

I also updated vstack because I somewhat doubt that functioned properly before. I noticed that the code where the vstack and delete tests were (tests/array_manipulation_tests.py) was not included in the pytest.ini, so I added it. The tests for delete failed, but I didn't touch it, so I suspect that was ongoing prior to my adding it.

While trying to clean things up a bit, I noticed some interesting behavior. Some things rely on the concatenate with ordered=False (meaning that when concatenating two arrays, the result may have the two arrays mixed together, rather than a whole block where you have the first, followed by everything in the second). Specifically, when comparing two Categorical objects together (i.e. for equality), it would concatenate the Strings of categories and also two aranges (which were, I guess, meant to associate the categories to numbers). Basically, it seemed to rely on the fact that they would get concatenated in the same way. This seems very sketchy to me. At some point we should probably further investigate set_categories in arkouda/categorical.py and the functions it calls. It takes a shockingly long time to test equality on two Categoricals with three things, but different categories. Definitely feels like optimizations are possible. Also ConcatenateMsg.chpl could probably benefit from optimization for Strings.

Closes #3329: hstack to match numpy