### PR TITLE
Closes #4110:  docstring bug in standard_gamma

### DIFF
--- a/arkouda/numpy/random/_generator.py
+++ b/arkouda/numpy/random/_generator.py
@@ -542,13 +542,14 @@ class Generator:
         Notes
         -----
         The probability density function for the Gamma distribution is
+
         .. math::
             p(x) = x^{k-1}\frac{e^{\frac{-x}{\theta}}}{\theta^k\Gamma(k)}
 
         Examples
         --------
         >>> rng = ak.random.default_rng()
-        >>> rng.rng.standard_gamma(1)
+        >>> rng.standard_gamma(1)
         0.8729704388729135 # random
         >>> rng.standard_gamma(1, size=3)
         array([0.4879818539586227 0.6534654349920751 0.40990997253631162]) # random


### PR DESCRIPTION
Fixes two docstring bugs in standard_gamma.  One that prevents the examples from running, and one that prevents the equation from rendering properly in sphinx.

Closes #4110:  docstring bug in standard_gamma