### PR TITLE
Closes #4113: flake8 errors in master

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,3 +25,4 @@ exclude =
     benchmarks
     pydoc/_ext/generic_linkcode_resolve_for_sphinx.py
     converter/csv2hdf.py
+    ./build


### PR DESCRIPTION
Excludes `./build` from flake8 checks.


Closes #4113: flake8 errors in master