### PR TITLE
Temporarily skip scipy testing for Python 3.13+

### DIFF
--- a/tests/scipy/scipy_test.py
+++ b/tests/scipy/scipy_test.py
@@ -19,6 +19,14 @@ PAIRS = [
 
 
 class TestStats:
+
+    @classmethod
+    def setup_class(cls):
+        import sys
+        # skip tests with 3.13+
+        if sys.version_info >= (3, 13):
+            pytest.skip("scipy tests do not work yet with Python 3.13+")
+
     @pytest.mark.parametrize(
         "lambda_",
         [


### PR DESCRIPTION
scipy tests fail with python 3.13+ due to https://github.com/Bears-R-Us/arkouda/issues/3355. This skips them temporarily to allow full testing to pass with Python 3.13