### PR TITLE
Add `xp.trapz`

### DIFF
--- a/arkouda/array_api/__init__.py
+++ b/arkouda/array_api/__init__.py
@@ -139,7 +139,7 @@ from .sorting_functions import argsort, sort
 
 from .statistical_functions import max, mean, min, prod, std, sum, var, cumulative_sum
 
-from .utility_functions import all, any, clip, diff, pad
+from .utility_functions import all, any, clip, diff, trapz, pad
 
 __array_api_version__ = "2022.12"
 
@@ -282,6 +282,6 @@ __all__ += ["argsort", "sort"]
 
 __all__ += ["max", "mean", "min", "prod", "std", "sum", "var", "cumulative_sum"]
 
-__all__ += ["all", "any", "clip", "diff", "pad"]
+__all__ += ["all", "any", "clip", "diff", "trapz", "pad"]
 
 warnings.warn("The arkouda.array_api submodule is still experimental.")

--- a/arkouda/array_api/__init__.py
+++ b/arkouda/array_api/__init__.py
@@ -139,7 +139,7 @@ from .sorting_functions import argsort, sort
 
 from .statistical_functions import max, mean, min, prod, std, sum, var, cumulative_sum
 
-from .utility_functions import all, any, clip, diff, trapz, pad
+from .utility_functions import all, any, clip, diff, trapz, trapezoid, pad
 
 __array_api_version__ = "2022.12"
 
@@ -282,6 +282,6 @@ __all__ += ["argsort", "sort"]
 
 __all__ += ["max", "mean", "min", "prod", "std", "sum", "var", "cumulative_sum"]
 
-__all__ += ["all", "any", "clip", "diff", "trapz", "pad"]
+__all__ += ["all", "any", "clip", "diff", "trapz", "trapezoid", "pad"]
 
 warnings.warn("The arkouda.array_api submodule is still experimental.")

--- a/arkouda/array_api/utility_functions.py
+++ b/arkouda/array_api/utility_functions.py
@@ -302,6 +302,9 @@ def trapz(y: Array, x: Optional[Array] = None, dx: Optional[float] = 1.0, axis: 
 
     return ret
 
+def trapezoid(y: Array, x: Optional[Array] = None, dx: Optional[float] = 1.0, axis: int = -1) -> Array:
+    return trapz(y, x, dx, axis)
+
 def pad(
     array: Array,
     pad_width,  # Union[int, Tuple[int, int], Tuple[Tuple[int, int], ...]]

--- a/arkouda/array_api/utility_functions.py
+++ b/arkouda/array_api/utility_functions.py
@@ -169,6 +169,7 @@ def diff(a: Array, /, n: int = 1, axis: int = -1, prepend=None, append=None) -> 
         )
     )
 
+
 def trapz(y: Array, x: Optional[Array] = None, dx: Optional[float] = 1.0, axis: int = -1) -> Array:
     r"""
     Integrate along the given axis using the composite trapezoidal rule.
@@ -302,8 +303,10 @@ def trapz(y: Array, x: Optional[Array] = None, dx: Optional[float] = 1.0, axis: 
 
     return ret
 
+
 def trapezoid(y: Array, x: Optional[Array] = None, dx: Optional[float] = 1.0, axis: int = -1) -> Array:
     return trapz(y, x, dx, axis)
+
 
 def pad(
     array: Array,

--- a/tests/array_api/util_functions.py
+++ b/tests/array_api/util_functions.py
@@ -145,3 +145,82 @@ class TestUtilFunctions:
         ):
             xp.pad(a, ((1, 1)), mode="constant", constant_values=((-1, 1)))
             xp.diff(a, n=2, axis=0)
+
+    @pytest.mark.parametrize("dtype", DTYPES_WITH_BOOL)
+    def test_trapz_1D(self, dtype):
+        # 1D array test
+        x = randArr((10), dtype)
+        y = randArr((10), dtype)
+        x_np = x.to_ndarray()
+        y_np = y.to_ndarray()
+
+        # Single array version, default dx
+        for axis in [-1, 0]:
+            t = xp.trapz(y, axis=axis)
+            t_np = np.trapz(y_np, axis=axis)
+            assert(t == t_np)
+
+        # Single array version, specified dx
+        for axis in [-1, 0]:
+            t = xp.trapz(y, dx=2.5, axis=axis)
+            t_np = np.trapz(y_np, dx=2.5, axis=axis)
+            assert(t == t_np)
+
+        # Two array version
+        for axis in [-1, 0]:
+            t = xp.trapz(y, x, axis=axis)
+            t_np = np.trapz(y_np, x_np, axis=axis)
+            assert(t == t_np)
+
+    @pytest.mark.parametrize("dtype", DTYPES_WITH_BOOL)
+    @pytest.mark.skip_if_rank_not_compiled([2])
+    def test_trapz_2D(self, dtype):
+        # 2D array test
+        x = randArr((10, 12), dtype)
+        y = randArr((10, 12), dtype)
+        x_np = x.to_ndarray()
+        y_np = y.to_ndarray()
+
+        # Single array version, default dx
+        for axis in [-1, 0, 1]:
+            t = xp.trapz(y, axis=axis)
+            t_np = np.trapz(y_np, axis=axis)
+            assert np.allclose(t.to_ndarray(), t_np)
+
+        # Single array version, specified dx
+        for axis in [-1, 0, 1]:
+            t = xp.trapz(y, dx=2.5, axis=axis)
+            t_np = np.trapz(y_np, dx=2.5, axis=axis)
+            assert np.allclose(t.to_ndarray(), t_np)
+
+        # Two array version
+        for axis in [-1, 0, 1]:
+            t = xp.trapz(y, x, axis=axis)
+            t_np = np.trapz(y_np, x_np, axis=axis)
+            assert np.allclose(t.to_ndarray(), t_np)
+
+    @pytest.mark.parametrize("dtype", DTYPES_WITH_BOOL)
+    @pytest.mark.skip_if_rank_not_compiled([3])
+    def test_trapz_3D(self, dtype):
+        x = randArr((10, 11, 12), dtype)
+        y = randArr((10, 11, 12), dtype)
+        x_np = x.to_ndarray()
+        y_np = y.to_ndarray()
+        # Single array version, default dx
+        for axis in [-1, 0, 1, 2]:
+            t = xp.trapz(y, axis=axis)
+            t_np = np.trapz(y_np, axis=axis)
+            assert np.allclose(t.to_ndarray(), t_np)
+
+        # Single array version, specified dx
+        for axis in [-1, 0, 1, 2]:
+            t = xp.trapz(y, dx=2.5, axis=axis)
+            t_np = np.trapz(y_np, dx=2.5, axis=axis)
+            assert np.allclose(t.to_ndarray(), t_np)
+
+        # Two array version
+        for axis in [-1, 0, 1, 2]:
+            t = xp.trapz(y, x, axis=axis)
+            t_np = np.trapz(y_np, x_np, axis=axis)
+            assert np.allclose(t.to_ndarray(), t_np)
+

--- a/tests/array_api/util_functions.py
+++ b/tests/array_api/util_functions.py
@@ -158,19 +158,19 @@ class TestUtilFunctions:
         for axis in [-1, 0]:
             t = xp.trapz(y, axis=axis)
             t_np = np.trapz(y_np, axis=axis)
-            assert(t == t_np)
+            assert (t == t_np)
 
         # Single array version, specified dx
         for axis in [-1, 0]:
             t = xp.trapz(y, dx=2.5, axis=axis)
             t_np = np.trapz(y_np, dx=2.5, axis=axis)
-            assert(t == t_np)
+            assert (t == t_np)
 
         # Two array version
         for axis in [-1, 0]:
             t = xp.trapz(y, x, axis=axis)
             t_np = np.trapz(y_np, x_np, axis=axis)
-            assert(t == t_np)
+            assert (t == t_np)
 
     @pytest.mark.parametrize("dtype", DTYPES_WITH_BOOL)
     @pytest.mark.skip_if_rank_not_compiled([2])
@@ -223,4 +223,3 @@ class TestUtilFunctions:
             t = xp.trapz(y, x, axis=axis)
             t_np = np.trapz(y_np, x_np, axis=axis)
             assert np.allclose(t.to_ndarray(), t_np)
-

--- a/tests/array_api/util_functions.py
+++ b/tests/array_api/util_functions.py
@@ -223,3 +223,43 @@ class TestUtilFunctions:
             t = xp.trapz(y, x, axis=axis)
             t_np = np.trapz(y_np, x_np, axis=axis)
             assert np.allclose(t.to_ndarray(), t_np)
+
+    @pytest.mark.parametrize("dtype", DTYPES_WITH_BOOL)
+    def test_trapezoid(self, dtype):
+        # 1D array test
+        x = randArr((10), dtype)
+        y = randArr((10), dtype)
+        # Single array version, specified dx
+        for axis in [-1, 0]:
+            t1 = xp.trapz(y, dx=2.5, axis=axis)
+            t2 = xp.trapezoid(y, dx=2.5, axis=axis)
+            assert (t1 == t2)
+
+        # Two array version
+        for axis in [-1, 0]:
+            t1 = xp.trapz(y, x, axis=axis)
+            t2 = xp.trapezoid(y, x, axis=axis)
+            assert (t1 == t2)
+
+    @pytest.mark.parametrize("dtype", DTYPES_WITH_BOOL)
+    def test_trapz_error(self, dtype):
+        # bigint y
+        bi_arr = ak.array(
+            [0, 1, 2, 3, 4, 2**64 - 5, 2**64 - 4, 2**64 - 3, 2**64 - 2, 2**64 - 1],
+            dtype=ak.bigint,
+            max_bits=64,
+        )
+        y = xp.asarray(bi_arr, dtype=ak.bigint)
+        with pytest.raises(
+            RuntimeError,
+            match="Error executing command: trapz does not support dtype bigint",
+        ):
+            xp.trapz(y)
+        # bigint x
+        y = randArr((10), dtype)
+        x = xp.asarray(bi_arr, dtype=ak.bigint)
+        with pytest.raises(
+            RuntimeError,
+            match="Error executing command: trapz does not support dtype bigint",
+        ):
+            xp.trapz(y, x)


### PR DESCRIPTION
Resolves: https://github.com/Bears-R-Us/arkouda/issues/4129

Add `trapz` (or `trapezoid`) function in Arkouda using the functionality from the array API.
   
In the future the entirity of this function may be implemented purely in Chapel.

See https://numpy.org/doc/1.26/reference/generated/numpy.trapz.html#numpy.trapz for reference.

Technically, `trapz` is deprecated in numpy `2.0` onwards, but Arkouda still uses numpy `1.26`. I've added both overloads. 

Also added tests.