### PR TITLE
Closes #3337:  Fix can_cast with NumPy 2.0 breaking changes

### DIFF
--- a/arkouda/numpy/dtypes/dtypes.py
+++ b/arkouda/numpy/dtypes/dtypes.py
@@ -42,6 +42,7 @@ __all__ = [
     "bitType",
     "bool_",
     "bool_scalars",
+    "can_cast",
     "complex128",
     "complex64",
     "dtype",
@@ -119,6 +120,36 @@ def dtype(dtype):
         return np.dtype(np.str_)
     else:
         return np.dtype(dtype)
+
+
+def can_cast(from_, to) -> builtins.bool:
+    """
+    Returns True if cast between data types can occur according to the casting rule.
+
+    Parameters
+    __________
+
+    from_: dtype, dtype specifier, NumPy scalar, or pdarray
+        Data type, NumPy scalar, or array to cast from.
+    to: dtype or dtype specifier
+        Data type to cast to.
+
+    Return
+    ------
+    bool
+        True if cast can occur according to the casting rule.
+
+    """
+    if isSupportedInt(from_):
+        if (from_ < 2**64) and (from_ >= 0) and (to == dtype(uint64)):
+            return True
+
+    if (
+        np.isscalar(from_) or _is_dtype_in_union(from_, numeric_scalars)
+    ) and not isinstance(from_, (int, float, complex)):
+        return np.can_cast(from_, to)
+
+    return False
 
 
 def _is_dtype_in_union(dtype, union_type) -> builtins.bool:

--- a/arkouda/numpy/pdarrayclass.py
+++ b/arkouda/numpy/pdarrayclass.py
@@ -601,7 +601,11 @@ class pdarray:
         # If scalar cannot be safely cast, server will infer the return dtype
         dt = resolve_scalar_dtype(other)
 
-        if self.dtype != bigint and np.can_cast(other, self.dtype):
+        from arkouda.numpy.dtypes import can_cast as ak_can_cast
+
+        if self.dtype != bigint and ak_can_cast(other, self.dtype):
+            # If scalar can be losslessly cast to array dtype,
+            # do the cast so that return array will have same dtype
             dt = self.dtype.name
             other = self.dtype.type(other)
 
@@ -646,7 +650,9 @@ class pdarray:
         # If scalar cannot be safely cast, server will infer the return dtype
         dt = resolve_scalar_dtype(other)
 
-        if self.dtype != bigint and np.can_cast(other, self.dtype):
+        from arkouda.numpy.dtypes import can_cast as ak_can_cast
+
+        if self.dtype != bigint and ak_can_cast(other, self.dtype):
             # If scalar can be losslessly cast to array dtype,
             # do the cast so that return array will have same dtype
             dt = self.dtype.name

--- a/tests/numpy/numeric_test.py
+++ b/tests/numpy/numeric_test.py
@@ -1185,3 +1185,14 @@ class TestNumeric:
                 sample = sample.reshape(local_shape)  # reshape only needed if rank > 1
             aksample = ak.array(sample)
             assert np.all(npfunc(sample) == akfunc(aksample).to_ndarray())
+
+    def test_can_cast(self):
+        from arkouda.numpy import can_cast
+
+        assert can_cast(np.int64(5), "uint64")
+        assert can_cast(ak.int64, ak.int64)
+        assert not can_cast(ak.int64, ak.uint64)
+
+        assert can_cast(5, ak.uint64)
+        assert not can_cast(-5, ak.uint64)
+        assert not can_cast(2**200, ak.uint64)


### PR DESCRIPTION
This PR adds a can_cast function to match numpy:
https://numpy.org/devdocs/reference/generated/numpy.can_cast.html

The `casting` argument is left to a separate ticket: https://github.com/Bears-R-Us/arkouda/issues/4107

Closes #3337:  Fix can_cast with NumPy 2.0 breaking changes