### PR TITLE
Add a compatibility module for Time to handle the new totalMicroseconds method

### DIFF
--- a/src/RandUtil.chpl
+++ b/src/RandUtil.chpl
@@ -54,10 +54,7 @@ module RandUtil {
         where D.rank == 1 {
             // use a fixed number of elements per stream instead of relying on number of locales or numTasksPerLoc because these
             // can vary from run to run / machine to mahchine. And it's important for the same seed to give the same results
-            use Time;
-            proc timeDelta.totalMicroseconds(): int{
-                return ((days*(24*60*60) + seconds)*1_000_000 + microseconds): int;
-            }
+            use ArkoudaTimeCompat;
             var next: rng.eltType;
             if hasSeed {
                 next = rng.next();

--- a/src/compat/eq-20/ArkoudaTimeCompat.chpl
+++ b/src/compat/eq-20/ArkoudaTimeCompat.chpl
@@ -1,0 +1,7 @@
+module ArkoudaTimeCompat {
+  public use Time;
+
+  proc timeDelta.totalMicroseconds(): int{
+    return ((days*(24*60*60) + seconds)*1_000_000 + microseconds): int;
+  }  
+}

--- a/src/compat/eq-21/ArkoudaTimeCompat.chpl
+++ b/src/compat/eq-21/ArkoudaTimeCompat.chpl
@@ -1,0 +1,7 @@
+module ArkoudaTimeCompat {
+  public use Time;
+
+  proc timeDelta.totalMicroseconds(): int{
+    return ((days*(24*60*60) + seconds)*1_000_000 + microseconds): int;
+  }  
+}

--- a/src/compat/eq-22/ArkoudaTimeCompat.chpl
+++ b/src/compat/eq-22/ArkoudaTimeCompat.chpl
@@ -1,0 +1,7 @@
+module ArkoudaTimeCompat {
+  public use Time;
+
+  proc timeDelta.totalMicroseconds(): int{
+    return ((days*(24*60*60) + seconds)*1_000_000 + microseconds): int;
+  }  
+}

--- a/src/compat/eq-23/ArkoudaTimeCompat.chpl
+++ b/src/compat/eq-23/ArkoudaTimeCompat.chpl
@@ -1,0 +1,7 @@
+module ArkoudaTimeCompat {
+  public use Time;
+
+  proc timeDelta.totalMicroseconds(): int{
+    return ((days*(24*60*60) + seconds)*1_000_000 + microseconds): int;
+  }  
+}

--- a/src/compat/ge-24/ArkoudaTimeCompat.chpl
+++ b/src/compat/ge-24/ArkoudaTimeCompat.chpl
@@ -1,0 +1,3 @@
+module ArkoudaTimeCompat {
+  public use Time;
+}


### PR DESCRIPTION
Without a compatibility module, the recent addition of totalMicroseconds will result in a resolution conflict with the original solution.

Passed `make check` and `make test-python` locally