### PR TITLE
Will eventually close 4092, align ak.transpose to np.transpose

### DIFF
--- a/tests/numpy/numeric_test.py
+++ b/tests/numpy/numeric_test.py
@@ -1036,6 +1036,31 @@ class TestNumeric:
             ppa = ak.transpose(pda).to_ndarray()
             assert check(npa, ppa, data_type)
 
+    @pytest.mark.parametrize("data_type", INT_FLOAT_BOOL)
+    @pytest.mark.parametrize("prob_size", pytest.prob_size)
+    def test_alt_transpose(self, data_type, prob_size):
+        size = 10
+        for n in get_array_ranks() :
+            if n==1 :
+                shape = size
+                array_size = size
+            else :
+                shape = (n-1)*[2]
+                shape.append(size)
+                array_size = (2**(n-1))*size
+
+            nda = np.arange(array_size).reshape(shape)
+            pda = ak.array(nda) 
+
+            if n==1 :   # trivial case
+                assert (np.transpose(nda) == ak.alt_transpose(pda).to_ndarray()).all()
+            else :      # all permutations of 'shape' must be checked 
+                from itertools import permutations
+                perms = set(permutations(np.arange(n).tolist()))
+                for perm in perms :
+                    assert (np.transpose(nda,perm) == ak.alt_transpose(pda,perm).to_ndarray()).all()
+                
+            
     # eye works on ints, floats, or bool
     @pytest.mark.skip_if_rank_not_compiled(2)
     @pytest.mark.parametrize("data_type", INT_FLOAT_BOOL)

--- a/tests/numpy/numeric_test.py
+++ b/tests/numpy/numeric_test.py
@@ -1041,7 +1041,7 @@ class TestNumeric:
     def test_alt_transpose(self, data_type, prob_size):
         size = 10
         for n in get_array_ranks() :
-            if n==1 :
+            if n == 1 :
                 shape = size
                 array_size = size
             else :
@@ -1050,18 +1050,18 @@ class TestNumeric:
                 array_size = (2**(n-1))*size
 
             nda = np.arange(array_size).reshape(shape)
-            pda = ak.array(nda) 
+            pda = ak.array(nda)
 
-            if n==1 :   # trivial case
+            if n == 1 :   # trivial case
                 assert (np.transpose(nda) == ak.alt_transpose(pda).to_ndarray()).all()
-            else :      # all permutations of 'shape' must be checked 
+            else :      # all permutations of 'shape' must be checked
                 from itertools import permutations
                 perms = set(permutations(np.arange(n).tolist()))
                 for perm in perms :
-                    assert (np.transpose(nda,perm) == ak.alt_transpose(pda,perm).to_ndarray()).all()
-                
-            
+                    assert (np.transpose(nda, perm) == ak.alt_transpose(pda, perm).to_ndarray()).all()
+
     # eye works on ints, floats, or bool
+
     @pytest.mark.skip_if_rank_not_compiled(2)
     @pytest.mark.parametrize("data_type", INT_FLOAT_BOOL)
     @pytest.mark.parametrize("prob_size", pytest.prob_size)


### PR DESCRIPTION
This is a draft PR, which adds a function ak.alt_transpose, without removing the existing ak.transpose.

The situation was that ak.transpose didn't cover all the possible uses that np.transpose does.  But there's another transpose function in the array_api that does.

So rather than rewrite anything, I created alt_transpose to use the array_api transpose function (which required converting to and from the Array object).

In addition to ak.alt_transpose, there is also a test_alt_transpose in tests/numpy/numeric_test.py

I'd like to get your feedback before making the drastic move of replacing the existing ak.transpose.