### PR TITLE
Fix the shutdown test by using the correct server

### DIFF
--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -51,7 +51,7 @@ class TestClient:
         Tests the ak.shutdown() method
         """
         ak.shutdown()
-        start_arkouda_server(numlocales=pytest.nl)
+        pytest.server, _, _ = start_arkouda_server(numlocales=pytest.nl)
         # reconnect to server so subsequent tests will pass
         ak.connect(server=pytest.server, port=pytest.port, timeout=pytest.timeout)
 


### PR DESCRIPTION
`test_shutdown` shuts the server down and restarts it. But it just assumes that we'll get the same node as the head node, which is not guaranteed, and almost never happens in a new system we are establishing Arkouda testing on.