### PR TITLE
Closes-4045 adds multi-dim tests to scipy_test

### DIFF
--- a/arkouda/testing/_equivalence_asserters.py
+++ b/arkouda/testing/_equivalence_asserters.py
@@ -62,9 +62,12 @@ def _convert_to_arkouda(obj):
         return obj
 
     if not isinstance(
-        obj, (pd.MultiIndex, pd.Index, pd.Series, pd.DataFrame, pd.Categorical, np.ndarray)
+        obj,
+        (pd.MultiIndex, pd.Index, pd.Series, pd.DataFrame, pd.Categorical, np.ndarray),
     ):
-        raise TypeError(f"obj must be an arkouda, numpy or pandas object, but was type: {type(obj)}")
+        raise TypeError(
+            f"obj must be an arkouda, numpy or pandas object, but was type: {type(obj)}"
+        )
 
     if isinstance(obj, pd.MultiIndex):
         return MultiIndex(obj)
@@ -77,7 +80,7 @@ def _convert_to_arkouda(obj):
     elif isinstance(obj, pd.Categorical):
         return Categorical(obj)
     elif isinstance(obj, np.ndarray):
-        return array(obj)
+        return array(np.ascontiguousarray(obj))  # required for some multi-dim cases
     return None
 
 
@@ -181,7 +184,9 @@ def assert_index_equivalent(
     """
     __tracebackhide__ = not DEBUG
 
-    if not isinstance(left, (Index, pd.Index)) or not isinstance(right, (Index, pd.Index)):
+    if not isinstance(left, (Index, pd.Index)) or not isinstance(
+        right, (Index, pd.Index)
+    ):
         raise TypeError(
             f"left and right must be type arkouda.Index, or pandas.Index.  "
             f"Instead types were {type(left)} and {type(right)}"
@@ -242,7 +247,9 @@ def assert_arkouda_array_equivalent(
 
     if not isinstance(
         left, (np.ndarray, pd.Categorical, pdarray, Strings, Categorical, SegArray)
-    ) or not isinstance(right, (np.ndarray, pd.Categorical, pdarray, Strings, Categorical, SegArray)):
+    ) or not isinstance(
+        right, (np.ndarray, pd.Categorical, pdarray, Strings, Categorical, SegArray)
+    ):
         raise TypeError(
             f"left and right must be type np.ndarray, pdarray, Strings, "
             f"Categorical, or SegArray.  "
@@ -329,7 +336,9 @@ def assert_series_equivalent(
     """
     __tracebackhide__ = not DEBUG
 
-    if not isinstance(left, (Series, pd.Series)) or not isinstance(right, (Series, pd.Series)):
+    if not isinstance(left, (Series, pd.Series)) or not isinstance(
+        right, (Series, pd.Series)
+    ):
         raise TypeError(
             f"left and right must be type arkouda.Series or pandas.Series.  "
             f"Instead types were {type(left)} and {type(right)}."
@@ -478,7 +487,9 @@ def assert_equivalent(left, right, **kwargs) -> None:
         assert_series_equivalent(left, right, **kwargs)
     elif isinstance(left, (DataFrame, pd.DataFrame)):
         assert_frame_equivalent(left, right, **kwargs)
-    elif isinstance(left, (pdarray, np.ndarray, Strings, Categorical, pd.Categorical, SegArray)):
+    elif isinstance(
+        left, (pdarray, np.ndarray, Strings, Categorical, pd.Categorical, SegArray)
+    ):
         assert_arkouda_array_equivalent(left, right, **kwargs)
     elif isinstance(left, str):
         assert kwargs == {}

--- a/arkouda/testing/_equivalence_asserters.py
+++ b/arkouda/testing/_equivalence_asserters.py
@@ -80,7 +80,9 @@ def _convert_to_arkouda(obj):
     elif isinstance(obj, pd.Categorical):
         return Categorical(obj)
     elif isinstance(obj, np.ndarray):
-        return array(np.ascontiguousarray(obj))  # required for some multi-dim cases
+        return array(
+            obj if obj.flags.c_contiguous else np.ascontiguousarray(obj)
+        )  # required for some multi-dim cases
     return None
 
 

--- a/tests/scipy/scipy_test.py
+++ b/tests/scipy/scipy_test.py
@@ -7,23 +7,43 @@ import arkouda as ak
 from arkouda.scipy import chisquare as ak_chisquare
 from arkouda.scipy import power_divergence as ak_power_divergence
 
+from arkouda.client import get_max_array_rank, get_array_ranks
+
 DDOF = [0, 1, 2, 3, 4, 5]
 PAIRS = [
     (
-        np.array([10000000, 20000000, 30000000, 40000000, 50000000, 60000000, 70000000]),
-        np.array([10000000, 20000000, 30000000, 40000001, 50000000, 60000000, 70000000]),
+        np.array(
+            [10000000, 20000000, 30000000, 40000000, 50000000, 60000000, 70000000]
+        ),
+        np.array(
+            [10000000, 20000000, 30000000, 40000001, 50000000, 60000000, 70000000]
+        ),
     ),
     (
-        np.array([10000000, 20000000, 30000000, 40000000, 50000000, 60000000, 70000000]),
+        np.array(
+            [10000000, 20000000, 30000000, 40000000, 50000000, 60000000, 70000000]
+        ),
         None,
     ),
     (np.array([44, 24, 29, 3]) / 100 * 189, np.array([43, 52, 54, 40])),
 ]
 
+#  bumpup is useful for multi-dimensional testing.
+#  Given an array of shape(m1,m2,...m), it will broadcast it to shape (2,m1,m2,...,m).
+#  Called iteratively, it will broadcast 1D to 2D to 3D to 4D to ...
+
+
+def bumpup(a):
+    if a.ndim == 1:
+        blob = (2, a.size)
+    else:
+        blob = list(a.shape)
+        blob.insert(0, 2)
+        blob = tuple(blob)
+    return np.broadcast_to(a, blob)
+
 
 class TestStats:
-
-    @pytest.mark.skip_if_scipy_version_greater_than("1.13.1")
     @pytest.mark.parametrize(
         "lambda_",
         [
@@ -43,11 +63,36 @@ class TestStats:
         f_exp = ak.array(np_f_exp) if np_f_exp is not None else None
 
         ak_power_div = ak_power_divergence(f_obs, f_exp, ddof=ddof, lambda_=lambda_)
-        scipy_power_div = scipy_power_divergence(np_f_obs, np_f_exp, ddof=ddof, axis=0, lambda_=lambda_)
+        scipy_power_div = scipy_power_divergence(
+            np_f_obs, np_f_exp, ddof=ddof, axis=0, lambda_=lambda_
+        )
 
         assert np.allclose(ak_power_div, scipy_power_div, equal_nan=True)
 
-    @pytest.mark.skip_if_scipy_version_greater_than("1.13.1")
+        # for the potential multi-dimensional case, create higher dim versions of the above
+        # pairs.
+        if get_max_array_rank() > 1:
+            for n in range(2, get_max_array_rank() + 1):
+                np_f_obs = bumpup(np_f_obs)  #
+                if np_f_exp is not None:  # conversion to pdarray
+                    np_f_exp = bumpup(np_f_exp)
+                # Note the the "bumpup" is done whether or not this rank is in get_array_ranks
+                # so that the rank at each iteration will be correct.
+                # But the test is only applied for ranks that are in get_array_ranks
+                if n in get_array_ranks():
+                    f_obs = ak.array(np_f_obs)
+                    f_exp = ak.array(np_f_exp) if np_f_exp is not None else None
+                    # ak_power_div does not have an axis arg, so the comparison is made
+                    # to scipy_power_div with axis=None
+                    ak_power_div = ak_power_divergence(
+                        f_obs, f_exp, ddof=ddof, lambda_=lambda_
+                    )
+                    scipy_power_div = scipy_power_divergence(
+                        np_f_obs, np_f_exp, ddof=ddof, axis=None, lambda_=lambda_
+                    )
+
+                    assert np.allclose(ak_power_div, scipy_power_div, equal_nan=True)
+
     @pytest.mark.parametrize("ddof", DDOF)
     @pytest.mark.parametrize("pair", PAIRS)
     def test_chisquare(self, ddof, pair):
@@ -59,3 +104,27 @@ class TestStats:
         scipy_chisq = scipy_chisquare(np_f_obs, np_f_exp, ddof=ddof, axis=0)
 
         assert np.allclose(ak_chisq, scipy_chisq, equal_nan=True)
+
+        # for the potential multi-dimensional case, create higher dim versions of the above
+        # pairs.
+        if get_max_array_rank() > 1:
+            for n in range(2, get_max_array_rank() + 1):
+                np_f_obs = np.ascontiguousarray(
+                    bumpup(np_f_obs)
+                )  # contiguous is needed for the conversion to pdarray
+                if np_f_exp is not None:
+                    np_f_exp = np.ascontiguousarray(bumpup(np_f_exp))
+                # Note the the "bumpup" is done whether or not this rank is in get_array_ranks
+                # so that the rank at each iteration will be correct.
+                # But the test is only applied for ranks that are in get_array_ranks
+                if n in get_array_ranks():
+                    f_obs = ak.array(np_f_obs)
+                    f_exp = ak.array(np_f_exp) if np_f_exp is not None else None
+                    # ak_chisq does not have an axis arg, so the comparison is made
+                    # to scipy_chisq with axis=None
+                    ak_chisq = ak_chisquare(f_obs, f_exp, ddof=ddof)
+                    scipy_chisq = scipy_chisquare(
+                        np_f_obs, np_f_exp, ddof=ddof, axis=None
+                    )
+
+                    assert np.allclose(ak_chisq, scipy_chisq, equal_nan=True)

--- a/tests/scipy/scipy_test.py
+++ b/tests/scipy/scipy_test.py
@@ -73,9 +73,9 @@ class TestStats:
         # pairs.
         if get_max_array_rank() > 1:
             for n in range(2, get_max_array_rank() + 1):
-                np_f_obs = bumpup(np_f_obs)  #
+                np_f_obs = np.ascontiguousarray(bumpup(np_f_obs))  #
                 if np_f_exp is not None:  # conversion to pdarray
-                    np_f_exp = bumpup(np_f_exp)
+                    np_f_exp = np.ascontiguousarray(bumpup(np_f_exp))
                 # Note the the "bumpup" is done whether or not this rank is in get_array_ranks
                 # so that the rank at each iteration will be correct.
                 # But the test is only applied for ranks that are in get_array_ranks


### PR DESCRIPTION
Closes #4045 
Closes #4177 

Adds multi-dimensionality testing to scipy_test.  The functions in scipy will allow multidimensional arguments, but at the present are only written to return 1D results.  This may be a thing to update in the future.

This also changes "obj" to "obj if obj.flags.c_contiguous else np.ascontiguousarray(obj)" in _convert_to_arkouda, so that we won't have to do that every time we check a multi-dimensional array (arkouda can only convert contiguous arrays to pdarrays -- so far this has only come up when we have multi-dimensional arrays that were created by enlarging smaller arrays).