### PR TITLE
Closes-4092 aligns ak.transpose to numpy transpose

### DIFF
--- a/arkouda/numpy/_numeric.py
+++ b/arkouda/numpy/_numeric.py
@@ -1,6 +1,6 @@
 import json
 from enum import Enum
-from typing import TYPE_CHECKING, List, Sequence, Tuple, TypeVar, Union
+from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple, TypeVar, Union
 from typing import cast as type_cast
 from typing import no_type_check
 
@@ -212,7 +212,9 @@ def cast(
             )
             if errors == ErrorMode.return_validity:
                 a, b = type_cast(str, repMsg).split("+")
-                return create_pdarray(type_cast(str, a)), create_pdarray(type_cast(str, b))
+                return create_pdarray(type_cast(str, a)), create_pdarray(
+                    type_cast(str, b)
+                )
             else:
                 return create_pdarray(type_cast(str, repMsg))
     elif isinstance(pda, Categorical):  # type: ignore
@@ -1075,7 +1077,9 @@ def arctan2(
         | Raised if both num and denom are scalars
         | Raised if where is neither boolean nor a pdarray of boolean
     """
-    if not all(isSupportedNumber(arg) or isinstance(arg, pdarray) for arg in [num, denom]):
+    if not all(
+        isSupportedNumber(arg) or isinstance(arg, pdarray) for arg in [num, denom]
+    ):
         raise TypeError(
             f"Unsupported types {type(num)} and/or {type(denom)}. Supported "
             "types are numeric scalars and pdarrays. At least one argument must be a pdarray."
@@ -1306,7 +1310,9 @@ def arctanh(pda: pdarray, where: Union[bool, pdarray] = True) -> pdarray:
     return _trig_helper(pda, "arctanh", where)
 
 
-def _trig_helper(pda: pdarray, func: str, where: Union[bool, pdarray] = True) -> pdarray:
+def _trig_helper(
+    pda: pdarray, func: str, where: Union[bool, pdarray] = True
+) -> pdarray:
     """
     Returns the result of the input trig function acting element-wise on the array.
 
@@ -1507,7 +1513,10 @@ def hash(
         return _hash_single(pda, full) if isinstance(pda, pdarray) else pda.hash()
     elif isinstance(pda, List):
         if any(
-            wrong_type := [not isinstance(a, (pdarray, Strings, SegArray_, Categorical_)) for a in pda]
+            wrong_type := [
+                not isinstance(a, (pdarray, Strings, SegArray_, Categorical_))
+                for a in pda
+            ]
         ):
             raise TypeError(
                 f"Unsupported type {type(pda[np.argmin(wrong_type)])}. Supported types are pdarray,"
@@ -1590,16 +1599,22 @@ def _str_cat_where(
             new_categories = concatenate([A.categories, array([B])])
             b_code = A.codes.size + 1
         new_codes = where(condition, A.codes, b_code)
-        return Categorical.from_codes(new_codes, new_categories, NAvalue=A.NAvalue).reset_categories()
+        return Categorical.from_codes(
+            new_codes, new_categories, NAvalue=A.NAvalue
+        ).reset_categories()
 
     # both cat
     if isinstance(A, Categorical) and isinstance(B, Categorical):
         if A.codes.size != B.codes.size:
             raise TypeError("Categoricals must be same length")
-        if A.categories.size != B.categories.size or not ak_all(A.categories == B.categories):
+        if A.categories.size != B.categories.size or not ak_all(
+            A.categories == B.categories
+        ):
             A, B = A.standardize_categories([A, B])
         new_codes = where(condition, A.codes, B.codes)
-        return Categorical.from_codes(new_codes, A.categories, NAvalue=A.NAvalue).reset_categories()
+        return Categorical.from_codes(
+            new_codes, A.categories, NAvalue=A.NAvalue
+        ).reset_categories()
 
     # one strings and one str
     if isinstance(A, Strings) and isinstance(B, str):
@@ -1743,14 +1758,18 @@ def where(
             ltr = resolve_scalar_dtype(B)
             cmdstring = "wherevs_" + ltr + f"<{condition.ndim},{A.dtype}>"
         else:  # *should* be impossible because of the IsSupportedNumber check
-            raise TypeError(f"where does not accept scalar type {resolve_scalar_dtype(B)}")
+            raise TypeError(
+                f"where does not accept scalar type {resolve_scalar_dtype(B)}"
+            )
 
     elif isinstance(B, pdarray) and np.isscalar(A):
         if resolve_scalar_dtype(A) in ["float64", "int64", "uint64", "bool"]:
             ltr = resolve_scalar_dtype(A)
             cmdstring = "wheresv_" + ltr + f"<{condition.ndim},{B.dtype}>"
         else:  # *should* be impossible because of the IsSupportedNumber check
-            raise TypeError(f"where does not accept scalar type {resolve_scalar_dtype(A)}")
+            raise TypeError(
+                f"where does not accept scalar type {resolve_scalar_dtype(A)}"
+            )
 
     else:  # both are scalars
         if resolve_scalar_dtype(A) in ["float64", "int64", "uint64", "bool"]:
@@ -1758,9 +1777,13 @@ def where(
             if resolve_scalar_dtype(B) in ["float64", "int64", "uint64", "bool"]:
                 tb = resolve_scalar_dtype(B)
             else:
-                raise TypeError(f"where does not accept scalar type {resolve_scalar_dtype(B)}")
+                raise TypeError(
+                    f"where does not accept scalar type {resolve_scalar_dtype(B)}"
+                )
         else:
-            raise TypeError(f"where does not accept scalar type {resolve_scalar_dtype(A)}")
+            raise TypeError(
+                f"where does not accept scalar type {resolve_scalar_dtype(A)}"
+            )
         cmdstring = "wheress_" + ta + "_" + tb + f"<{condition.ndim}>"
 
     repMsg = generic_msg(
@@ -1910,13 +1933,17 @@ def histogram2d(
         x_bins, y_bins = bins, bins
     else:
         if len(bins) != 2:
-            raise ValueError("Sequences of bins must contain two elements (num_x_bins, num_y_bins)")
+            raise ValueError(
+                "Sequences of bins must contain two elements (num_x_bins, num_y_bins)"
+            )
         x_bins, y_bins = bins
     if x_bins < 1 or y_bins < 1:
         raise ValueError("bins must be 1 or greater")
     x_bin_boundaries = linspace(x.min(), x.max(), x_bins + 1)
     y_bin_boundaries = linspace(y.min(), y.max(), y_bins + 1)
-    repMsg = generic_msg(cmd="histogram2D", args={"x": x, "y": y, "xBins": x_bins, "yBins": y_bins})
+    repMsg = generic_msg(
+        cmd="histogram2D", args={"x": x, "y": y, "xBins": x_bins, "yBins": y_bins}
+    )
     return (
         create_pdarray(type_cast(str, repMsg)).reshape(x_bins, y_bins),
         x_bin_boundaries,
@@ -1995,7 +2022,9 @@ def histogramdd(
         bins = [bins] * num_dims
     else:
         if len(bins) != num_dims:
-            raise ValueError("Sequences of bins must contain same number of elements as the sample")
+            raise ValueError(
+                "Sequences of bins must contain same number of elements as the sample"
+            )
     if any(b < 1 for b in bins):
         raise ValueError("bins must be 1 or greater")
 
@@ -2197,9 +2226,9 @@ def median(pda: pdarray) -> np.float64:
     if len(pda_srtd) % 2 == 1:
         return pda_srtd[len(pda_srtd) // 2].astype(np.float64)
     else:
-        return ((pda_srtd[len(pda_srtd) // 2] + pda_srtd[len(pda_srtd) // 2 - 1]) / 2.0).astype(
-            np.float64
-        )
+        return (
+            (pda_srtd[len(pda_srtd) // 2] + pda_srtd[len(pda_srtd) // 2 - 1]) / 2.0
+        ).astype(np.float64)
 
 
 def count_nonzero(pda: pdarray) -> np.int64:
@@ -2302,7 +2331,9 @@ def array_equal(pda_a: pdarray, pda_b: pdarray, equal_nan: bool = False) -> bool
     >>> ak.array_equal(a,b,True)
     True
     """
-    if (pda_a.shape != pda_b.shape) or ((pda_a.dtype == akstr_) ^ (pda_b.dtype == akstr_)):
+    if (pda_a.shape != pda_b.shape) or (
+        (pda_a.dtype == akstr_) ^ (pda_b.dtype == akstr_)
+    ):
         return False
     elif equal_nan:
         return bool(ak_all(where(isnan(pda_a), isnan(pda_b), pda_a == pda_b)))
@@ -2375,7 +2406,9 @@ def putmask(
     ]
 
     if not ((A.dtype, Values.dtype) in ALLOWED_PUTMASK_PAIRS):
-        raise RuntimeError(f"Types {A.dtype} and {Values.dtype} are not compatible in putmask.")
+        raise RuntimeError(
+            f"Types {A.dtype} and {Values.dtype} are not compatible in putmask."
+        )
     if mask.size != A.size:
         raise RuntimeError("mask and A must be same size in putmask")
     generic_msg(
@@ -2389,7 +2422,9 @@ def putmask(
     return
 
 
-def eye(rows: int_scalars, cols: int_scalars, diag: int_scalars = 0, dt: type = ak_int64) -> pdarray:
+def eye(
+    rows: int_scalars, cols: int_scalars, diag: int_scalars = 0, dt: type = ak_int64
+) -> pdarray:
     """
     Return a pdarray with zeros everywhere except along a diagonal, which is all ones.
     The matrix need not be square.
@@ -2555,39 +2590,60 @@ def tril(pda: pdarray, diag: int_scalars = 0) -> pdarray:
     )
 
 
-def transpose(pda: pdarray) -> pdarray:
+@typechecked
+def transpose(pda: pdarray, axes: Optional[Tuple[int, ...]] = None) -> pdarray:
     """
     Compute the transpose of a matrix.
 
     Parameters
     ----------
     pda : pdarray
+    axes: Tuple[int,...] Optional, defaults to None
+        If specified, must be a tuple which contains a permutation of the axes of pda.
 
     Returns
     -------
     pdarray
         the transpose of the input matrix
+        For a 1-D array, this is the original array.
+        For a 2-D array, this is the standard matrix transpose.
+        For an n-D array, if axes are given, their order indicates how the axes are permuted.
+        If axes is None, the axes are reversed.
 
     Examples
     --------
     >>> a = ak.array([[1,2,3,4,5],[1,2,3,4,5]])
     >>> ak.transpose(a)
     array([array([1 1]) array([2 2]) array([3 3]) array([4 4]) array([5 5])])
+    >>> z = ak.array(np.arange(27).reshape(3,3,3))
+    >>> ak.transpose(z,axes=(1,0,2))
+    array([array([array([0 1 2]) array([9 10 11]) array([18 19 20])]) array([array([3 4 5])
+      array([12 13 14]) array([21 22 23])]) array([array([6 7 8]) array([15 16 17]) array([24 25 26])])])
 
-
-    Notes
-    -----
-    Server returns an error if rank of pda < 2
-
+    Raises
+    ------
+    ValueError
+        Raised if axes is not a legitimate permutation of the axes of pda
+    TypeError
+        Raised if pda is not a pdarray, or if axes is neither a tuple nor None
     """
-    cmd = f"transpose<{pda.dtype},{pda.ndim}>"
-    args = {
-        "array": pda,
-    }
+
+    if axes is not None:  # if axes was supplied, check that it's valid
+        r = tuple(np.arange(pda.ndim))
+        if not (np.sort(axes) == r).all():
+            raise ValueError(
+                f"{axes} is not a valid set of axes for pdarray of rank {pda.ndim}"
+            )
+    else:  # if axes is None, create a tuple of the axes in reverse order
+        axes = tuple(((pda.ndim - 1) - np.arange(pda.ndim)))
+
     return create_pdarray(
         generic_msg(
-            cmd=cmd,
-            args=args,
+            cmd=f"permuteDims<{pda.dtype},{pda.ndim}>",
+            args={
+                "name": pda,
+                "axes": axes,
+            },
         )
     )
 

--- a/tests/numpy/numeric_test.py
+++ b/tests/numpy/numeric_test.py
@@ -9,6 +9,7 @@ from arkouda.client import get_array_ranks, get_max_array_rank
 from arkouda.numpy.dtypes import dtype as akdtype
 from arkouda.numpy.dtypes import str_
 from arkouda.testing import assert_almost_equivalent as ak_assert_almost_equivalent
+from arkouda.testing import assert_arkouda_array_equivalent
 
 ARRAY_TYPES = [ak.int64, ak.float64, ak.bool_, ak.uint64, str_]
 NUMERIC_TYPES = [ak.int64, ak.float64, ak.bool_, ak.uint64]
@@ -125,7 +126,9 @@ def _trig_and_hyp_test_helper(np_func, na, ak_func, pda):
     assert np.allclose(np_func(na), ak_func(pda).to_ndarray(), equal_nan=True)
     truth_np = alternate(True, False, len(na))
     truth_ak = ak.array(truth_np)
-    assert np.allclose(np_func(na, where=True), ak_func(pda, where=True).to_ndarray(), equal_nan=True)
+    assert np.allclose(
+        np_func(na, where=True), ak_func(pda, where=True).to_ndarray(), equal_nan=True
+    )
     assert np.allclose(na, ak_func(pda, where=False).to_ndarray(), equal_nan=True)
     assert np.allclose(
         [np_func(na[i]) if truth_np[i] else na[i] for i in range(len(na))],
@@ -169,17 +172,23 @@ class TestNumeric:
         seed = pytest.seed if pytest.seed is not None else 8675309
         # Uniform
         assert not (ak.uniform(prob_size) == ak.uniform(prob_size)).all()
-        assert (ak.uniform(prob_size, seed=seed) == ak.uniform(prob_size, seed=seed)).all()
+        assert (
+            ak.uniform(prob_size, seed=seed) == ak.uniform(prob_size, seed=seed)
+        ).all()
 
         # Standard Normal
-        assert not (ak.standard_normal(prob_size) == ak.standard_normal(prob_size)).all()
+        assert not (
+            ak.standard_normal(prob_size) == ak.standard_normal(prob_size)
+        ).all()
         assert (
-            ak.standard_normal(prob_size, seed=seed) == ak.standard_normal(prob_size, seed=seed)
+            ak.standard_normal(prob_size, seed=seed)
+            == ak.standard_normal(prob_size, seed=seed)
         ).all()
 
         # Strings (uniformly distributed length)
         assert not (
-            ak.random_strings_uniform(1, 10, prob_size) == ak.random_strings_uniform(1, 10, prob_size)
+            ak.random_strings_uniform(1, 10, prob_size)
+            == ak.random_strings_uniform(1, 10, prob_size)
         ).all()
 
         assert (
@@ -189,7 +198,8 @@ class TestNumeric:
 
         # Strings (log-normally distributed length)
         assert not (
-            ak.random_strings_lognormal(2, 1, prob_size) == ak.random_strings_lognormal(2, 1, prob_size)
+            ak.random_strings_lognormal(2, 1, prob_size)
+            == ak.random_strings_lognormal(2, 1, prob_size)
         ).all()
         assert (
             ak.random_strings_lognormal(2, 1, prob_size, seed=seed)
@@ -210,7 +220,9 @@ class TestNumeric:
         }
 
         for t1, orig in arrays.items():
-            if (t1 == ak.float64 and cast_to == ak.bigint) or (t1 == ak.str_ and cast_to == ak.bool_):
+            if (t1 == ak.float64 and cast_to == ak.bigint) or (
+                t1 == ak.str_ and cast_to == ak.bool_
+            ):
                 # we don't support casting a float to a bigint
                 # we do support str to bool, but it's expected to contain "true/false" not numerics
                 continue
@@ -226,11 +238,15 @@ class TestNumeric:
         ans = None
         if num_type == ak.int64:
             intNAN = -(2**63)
-            strarr = ak.array(["1", "2 ", "3?", "!4", "  5", "-45", "0b101", "0x30", "N/A"])
+            strarr = ak.array(
+                ["1", "2 ", "3?", "!4", "  5", "-45", "0b101", "0x30", "N/A"]
+            )
             ans = np.array([1, 2, intNAN, intNAN, 5, -45, 0b101, 0x30, intNAN])
         elif num_type == ak.uint64:
             uintNAN = 0
-            strarr = ak.array(["1", "2 ", "3?", "-4", "  5", "45", "0b101", "0x30", "N/A"])
+            strarr = ak.array(
+                ["1", "2 ", "3?", "-4", "  5", "45", "0b101", "0x30", "N/A"]
+            )
             ans = np.array([1, 2, uintNAN, uintNAN, 5, 45, 0b101, 0x30, uintNAN])
         elif num_type == ak.float64:
             strarr = ak.array(
@@ -246,7 +262,9 @@ class TestNumeric:
                     "N/A",
                 ]
             )
-            ans = np.array([1.1, 2.2, np.nan, np.nan, 5.5, 6.6e-6, 78.91e4, 6.0, np.nan])
+            ans = np.array(
+                [1.1, 2.2, np.nan, np.nan, 5.5, 6.6e-6, 78.91e4, 6.0, np.nan]
+            )
         elif num_type == ak.bool_:
             strarr = ak.array(
                 [
@@ -466,7 +484,11 @@ class TestNumeric:
 
         assert np.allclose(
             [
-                (np.arctan2(na_num[i], na_denom[i]) if truth_np[i] else na_num[i] / na_denom[i])
+                (
+                    np.arctan2(na_num[i], na_denom[i])
+                    if truth_np[i]
+                    else na_num[i] / na_denom[i]
+                )
                 for i in range(len(na_num))
             ],
             ak.arctan2(pda_num, pda_denom, where=truth_ak).to_ndarray(),
@@ -474,7 +496,11 @@ class TestNumeric:
         )
         assert np.allclose(
             [
-                (np.arctan2(na_num[0], na_denom[i]) if truth_np[i] else na_num[0] / na_denom[i])
+                (
+                    np.arctan2(na_num[0], na_denom[i])
+                    if truth_np[i]
+                    else na_num[0] / na_denom[i]
+                )
                 for i in range(len(na_denom))
             ],
             ak.arctan2(pda_num[0], pda_denom, where=truth_ak).to_ndarray(),
@@ -482,7 +508,11 @@ class TestNumeric:
         )
         assert np.allclose(
             [
-                (np.arctan2(na_num[i], na_denom[0]) if truth_np[i] else na_num[i] / na_denom[0])
+                (
+                    np.arctan2(na_num[i], na_denom[0])
+                    if truth_np[i]
+                    else na_num[i] / na_denom[0]
+                )
                 for i in range(len(na_num))
             ],
             ak.arctan2(pda_num, pda_denom[0], where=truth_ak).to_ndarray(),
@@ -508,10 +538,18 @@ class TestNumeric:
             ak.arctan2(pda2, pda1).to_ndarray(),
             equal_nan=True,
         )
-        assert np.allclose(np.arctan2(na1, 5), ak.arctan2(pda1, 5).to_ndarray(), equal_nan=True)
-        assert np.allclose(np.arctan2(5, na1), ak.arctan2(5, pda1).to_ndarray(), equal_nan=True)
-        assert np.allclose(np.arctan2(na1, 0), ak.arctan2(pda1, 0).to_ndarray(), equal_nan=True)
-        assert np.allclose(np.arctan2(0, na1), ak.arctan2(0, pda1).to_ndarray(), equal_nan=True)
+        assert np.allclose(
+            np.arctan2(na1, 5), ak.arctan2(pda1, 5).to_ndarray(), equal_nan=True
+        )
+        assert np.allclose(
+            np.arctan2(5, na1), ak.arctan2(5, pda1).to_ndarray(), equal_nan=True
+        )
+        assert np.allclose(
+            np.arctan2(na1, 0), ak.arctan2(pda1, 0).to_ndarray(), equal_nan=True
+        )
+        assert np.allclose(
+            np.arctan2(0, na1), ak.arctan2(0, pda1).to_ndarray(), equal_nan=True
+        )
 
         with pytest.raises(TypeError):
             ak.arctan2(
@@ -589,7 +627,9 @@ class TestNumeric:
             ak.array([f"str {i}" for i in range(101)]),
             ak.array([f"str {i % 3}" for i in range(101)]),
         ]
-        for test_str, test_cat in zip(test_strs, [ak.Categorical(s) for s in test_strs]):
+        for test_str, test_cat in zip(
+            test_strs, [ak.Categorical(s) for s in test_strs]
+        ):
             cast_str = ak.cast(test_cat, ak.Strings)
             assert (cast_str == test_str).all()
             cast_cat = ak.cast(test_str, ak.Categorical)
@@ -692,7 +732,9 @@ class TestNumeric:
         assert h2[0] != h2[1]
 
         # test categorical hash
-        categories, codes = ak.array([f"str {i}" for i in range(3)]), ak.randint(0, 3, 10**5)
+        categories, codes = ak.array([f"str {i}" for i in range(3)]), ak.randint(
+            0, 3, 10**5
+        )
         my_cat = ak.Categorical.from_codes(codes=codes, categories=categories)
         h1, h2 = ak.hash(my_cat)
         rev = ak.arange(10**5)[::-1]
@@ -973,7 +1015,9 @@ class TestNumeric:
         # ints and bools are checked for equality; floats are checked for closeness
 
         check = lambda a, b, t: (  # noqa: E731
-            np.allclose(a.tolist(), b.tolist()) if akdtype(t) == "float64" else (a == b).all()
+            np.allclose(a.tolist(), b.tolist())
+            if akdtype(t) == "float64"
+            else (a == b).all()
         )
 
         # test on one square and two non-square matrices
@@ -998,7 +1042,9 @@ class TestNumeric:
         # ints and bools are checked for equality; floats are checked for closeness
 
         check = lambda a, b, t: (  # noqa: E731
-            np.allclose(a.tolist(), b.tolist()) if akdtype(t) == "float64" else (a == b).all()
+            np.allclose(a.tolist(), b.tolist())
+            if akdtype(t) == "float64"
+            else (a == b).all()
         )
 
         # test on one square and two non-square matrices
@@ -1014,27 +1060,33 @@ class TestNumeric:
 
     # transpose works on ints, floats, or bool
 
-    @pytest.mark.skip_if_rank_not_compiled(2)
     @pytest.mark.parametrize("data_type", INT_FLOAT_BOOL)
     @pytest.mark.parametrize("prob_size", pytest.prob_size)
     def test_transpose(self, data_type, prob_size):
+        size = prob_size
+        for n in get_array_ranks():
+            if n == 1:
+                shape = size
+                array_size = size
+            else:
+                shape = (n - 1) * [2]
+                shape.append(size)
+                array_size = (2 ** (n - 1)) * size
 
-        size = int(sqrt(prob_size))
+            nda = np.arange(array_size).reshape(shape)
+            pda = ak.array(nda)
 
-        # ints and bools are checked for equality; floats are checked for closeness
+            if n == 1:  # trivial case
+                assert_arkouda_array_equivalent(np.transpose(nda), ak.transpose(pda))
+            else:  # all permutations of 'shape' must be checked
+                from itertools import permutations
 
-        check = lambda a, b, t: (  # noqa: E731
-            np.allclose(a.tolist(), b.tolist()) if akdtype(t) == "float64" else (a == b).all()
-        )
-
-        # test on one square and two non-square matrices
-
-        for rows, cols in [(size, size), (size + 1, size - 1), (size - 1, size + 1)]:
-            pda = ak.randint(1, 10, (rows, cols))
-            nda = pda.to_ndarray()
-            npa = np.transpose(nda)
-            ppa = ak.transpose(pda).to_ndarray()
-            assert check(npa, ppa, data_type)
+                perms = set(permutations(np.arange(n).tolist()))
+                for perm in perms:  # contiguous array is needed for test
+                    assert_arkouda_array_equivalent(
+                        np.ascontiguousarray(np.transpose(nda, perm)),
+                        ak.transpose(pda, perm),
+                    )
 
     # eye works on ints, floats, or bool
     @pytest.mark.skip_if_rank_not_compiled(2)
@@ -1047,7 +1099,9 @@ class TestNumeric:
         # ints and bools are checked for equality; floats are checked for closeness
 
         check = lambda a, b, t: (  # noqa: E731
-            np.allclose(a.tolist(), b.tolist()) if akdtype(t) == "float64" else (a == b).all()
+            np.allclose(a.tolist(), b.tolist())
+            if akdtype(t) == "float64"
+            else (a == b).all()
         )
 
         # test on one square and two non-square matrices
@@ -1071,7 +1125,9 @@ class TestNumeric:
         # ints and bools are checked for equality; floats are checked for closeness
 
         check = lambda a, b, t: (  # noqa: E731
-            np.allclose(a.tolist(), b.tolist()) if akdtype(t) == "float64" else (a == b).all()
+            np.allclose(a.tolist(), b.tolist())
+            if akdtype(t) == "float64"
+            else (a == b).all()
         )
 
         # test on one square and two non-square products
@@ -1100,7 +1156,9 @@ class TestNumeric:
         # ints and bools are checked for equality; floats are checked for closeness
 
         check = lambda a, b, t: (  # noqa: E731
-            np.allclose(a.tolist(), b.tolist()) if akdtype(t) == "float64" else (a == b).all()
+            np.allclose(a.tolist(), b.tolist())
+            if akdtype(t) == "float64"
+            else (a == b).all()
         )
 
         pda_a = ak.randint(0, 10, (depth, width), dtype=data_type1)
@@ -1134,7 +1192,9 @@ class TestNumeric:
             pda_b = ak.array(temp)
             assert ak.array_equal(pda_a, pda_b)  # matching string arrays
             pda_c = pda_b[:-1]
-            assert not (ak.array_equal(pda_a, pda_c))  # matching except c is shorter by 1
+            assert not (
+                ak.array_equal(pda_a, pda_c)
+            )  # matching except c is shorter by 1
             temp = np.random.choice(VOWELS_AND_SUCH, prob_size)
             pda_b = ak.array(temp)
             assert not (ak.array_equal(pda_a, pda_b))  # mismatching string arrays
@@ -1149,7 +1209,9 @@ class TestNumeric:
             nda_b = nda_a.copy() if matching else np.random.uniform(0, 100, prob_size)
             pda_a = ak.array(nda_a)
             pda_b = ak.array(nda_b) if same_size else ak.array(nda_b[:-1])
-            assert ak.array_equal(pda_a, pda_b, nan_handling) == (matching and same_size)
+            assert ak.array_equal(pda_a, pda_b, nan_handling) == (
+                matching and same_size
+            )
         else:  # other types have simpler tests
             pda_a = ak.random.randint(0, 100, prob_size, dtype=data_type)
             if matching:  # known to match?


### PR DESCRIPTION
Closes #4092 

This replaces the existing ak.transpose with code that calls permuteDims on the server.  In this way, it matches the previous ak.transpose for 2D pdarrays, and also works for 1D and >= 3D cases, matching np.transpose.