### PR TITLE
Closes #4175:  remove try! in toSymEntry

### DIFF
--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -677,7 +677,7 @@ module AryUtil
       var curDigit = numDigits - totalDigits;
       for (name, nBits, neg) in zip(names, bitWidths, negs) {
         var g: borrowed GenSymEntry = getGenericTypedArrayEntry(name, st);
-        proc mergeArray(type t) {
+        proc mergeArray(type t) throws {
           var e = toSymEntry(g, t);
           ref A = e.a;
 

--- a/src/MultiTypeSymEntry.chpl
+++ b/src/MultiTypeSymEntry.chpl
@@ -123,7 +123,7 @@ module MultiTypeSymEntry
         :arg etype: type for gse to be cast to
         :type etype: type
        */
-    inline proc toSymEntry(gse: borrowed GenSymEntry, type etype, param dimensions=1) {
+    inline proc toSymEntry(gse: borrowed GenSymEntry, type etype, param dimensions=1) throws {
         return gse.toSymEntry(etype, dimensions);
     }
 
@@ -173,8 +173,13 @@ module MultiTypeSymEntry
            :arg etype: `SymEntry` type parameter
            :type etype: type
          */
-        inline proc toSymEntry(type etype, param dimensions=1) {
-            return try! this :borrowed SymEntry(etype, dimensions);
+        inline proc toSymEntry(type etype, param dimensions=1) throws {
+            try {
+                return this :borrowed SymEntry(etype, dimensions);
+            } catch e {
+                    const errorMsg = "Could not cast this `GenSymEntry` to `borrowed SymEntry(%s)".format(type2str(etype));
+                    throw new Error(errorMsg);
+            }
         }
 
         /* 


### PR DESCRIPTION
Remove `try!` in `toSymEntry` because it kills the server instead of throwing an Error.

Closes #4175:  remove try! in toSymEntry