### PR TITLE
Remove verbose output from comm diag test

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,7 +5,7 @@ testpaths =
     tests/array_api/array_creation.py
     tests/array_api/array_manipulation.py
     tests/array_api/binary_ops.py
-    tests/array_api/elementwise_functions.py    
+    tests/array_api/elementwise_functions.py
     tests/array_api/indexing.py
     tests/array_api/linalg.py
     tests/array_api/searching_functions.py
@@ -91,4 +91,4 @@ markers =
     skip_if_scipy_version_less_than
     skip_if_scipy_version_eq
     skip_if_scipy_version_neq
-        
+

--- a/tests/comm_diagnostics_test.py
+++ b/tests/comm_diagnostics_test.py
@@ -38,11 +38,16 @@ diagnostic_stats_functions = [
 
 class TestCommDiagnostics:
 
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_verbose_comm(self, size):
+        start_verbose_comm()
+        ak.zeros(size)
+        stop_verbose_comm()
+
     @pytest.mark.parametrize("op", diagnostic_stats_functions)
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_comm_diagnostics_single_locale(self, op, size):
         start_comm_diagnostics()
-        start_verbose_comm()
 
         ak.sort(ak.arange(size) * -1.0)
         comm_diagnostic_function = getattr(ak.comm_diagnostics, op)
@@ -52,7 +57,6 @@ class TestCommDiagnostics:
         if pytest.nl == 1:
             assert result.sum() == 0
 
-        stop_verbose_comm()
         print_comm_diagnostics_table()
         reset_comm_diagnostics()
         stop_comm_diagnostics()


### PR DESCRIPTION
Resolves https://github.com/Bears-R-Us/arkouda/issues/4178

Factor out verbose comm into it's own small test

