### PR TITLE
Change some nested foralls to for/foralls in HistogramMsg

### DIFF
--- a/src/HistogramMsg.chpl
+++ b/src/HistogramMsg.chpl
@@ -190,7 +190,7 @@ module HistogramMsg
                 // each task gets it's own copy of the histogram and they're reduced
                 hgmLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                                             "%? <= %?".format(bins,sBound));
-                forall (gEnt, stride, bin) in zip(gEnts, dimProd.a, bins) with (+ reduce indices) {
+                for (gEnt, stride, bin) in zip(gEnts, dimProd.a, bins) {
                     var e = toSymEntry(gEnt,t);
                     var aMin = min reduce e.a;
                     var aMax = max reduce e.a;
@@ -220,7 +220,7 @@ module HistogramMsg
                 use PrivateDist;
                 var atomicIdx: [PrivateSpace] [0..#numSamples] atomic int;
 
-                forall (gEnt, stride, bin) in zip(gEnts, dimProd.a, bins) {
+                for (gEnt, stride, bin) in zip(gEnts, dimProd.a, bins) {
                     var e = toSymEntry(gEnt,t);
                     var aMin = min reduce e.a;
                     var aMax = max reduce e.a;
@@ -264,7 +264,7 @@ module HistogramMsg
                 use PrivateDist;
                 var atomicIdx: [makeDistDom(numSamples)] atomic int;
 
-                forall (gEnt, stride, bin) in zip(gEnts, dimProd.a, bins) {
+                for (gEnt, stride, bin) in zip(gEnts, dimProd.a, bins) {
                     var e = toSymEntry(gEnt,t);
                     var aMin = min reduce e.a;
                     var aMax = max reduce e.a;


### PR DESCRIPTION
This PR is to assist https://github.com/Bears-R-Us/arkouda/pull/4176.

That PR makes `toSymEntry` a throwing function. Unfortunately, in the histogram code, there are some nested foralls which are subject to [an existing bug in the Chapel compiler](https://github.com/chapel-lang/chapel/issues/26912) that gets exposed by making `toSymEntry` a throwing function. This PR adjusts the histogram code to avoid that bug.

In general, the change here shouldn't be seen as a workaround, although the implementation could still be less than ideal. When you have nested `forall`s, in almost all cases, the outer one will grab all the cores in the system, forcing the inner one to be sequential one. Where this PR makes changes, it feels way more important for the inner loop to execute in parallel compared to the outer one. Therefore, I expect the change here to be an improvement for performance as well.