### PR TITLE
Add `pytest.temp_directory`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,12 @@ def pytest_addoption(parser):
         default="",
         help="Value to initialize random number generator.",
     )
+    parser.addoption(
+        "--temp-directory",
+        action="store",
+        default=os.getcwd(),
+        help="Directory to store temporary files.",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -80,6 +86,8 @@ def pytest_configure(config):
     pytest.prob_size = [eval(x) for x in config.getoption("size").split(",")]
     pytest.test_running_mode = TestRunningMode(os.getenv("ARKOUDA_RUNNING_MODE", "CLASS_SERVER"))
     pytest.host = subprocess.check_output("hostname").decode("utf-8").strip()
+
+    pytest.temp_directory = config.getoption("--temp-directory")
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -23,7 +23,7 @@ NUMERIC_AND_STR_TYPES = NUMERIC_TYPES + ["str"]
 
 @pytest.fixture
 def par_test_base_tmp(request):
-    par_test_base_tmp = "{}/.par_io_test".format(os.getcwd())
+    par_test_base_tmp = "{}/.par_io_test".format(pytest.temp_directory)
     io_util.get_directory(par_test_base_tmp)
 
     # Define a finalizer function for teardown
@@ -38,7 +38,7 @@ def par_test_base_tmp(request):
 
 @pytest.fixture
 def hdf_test_base_tmp(request):
-    hdf_test_base_tmp = "{}/.hdf_test".format(os.getcwd())
+    hdf_test_base_tmp = "{}/.hdf_test".format(pytest.temp_directory)
     io_util.get_directory(hdf_test_base_tmp)
 
     with open("{}/not-a-file_LOCALE0000".format(hdf_test_base_tmp), "w"):
@@ -56,7 +56,7 @@ def hdf_test_base_tmp(request):
 
 @pytest.fixture
 def csv_test_base_tmp(request):
-    csv_test_base_tmp = "{}/.csv_test".format(os.getcwd())
+    csv_test_base_tmp = "{}/.csv_test".format(pytest.temp_directory)
     io_util.get_directory(csv_test_base_tmp)
 
     # Define a finalizer function for teardown
@@ -71,7 +71,7 @@ def csv_test_base_tmp(request):
 
 @pytest.fixture
 def zarr_test_base_tmp(request):
-    zarr_test_base_tmp = "{}/.zarr_test".format(os.getcwd())
+    zarr_test_base_tmp = "{}/.zarr_test".format(pytest.temp_directory)
     io_util.get_directory(zarr_test_base_tmp)
 
     # Define a finalizer function for teardown
@@ -86,7 +86,7 @@ def zarr_test_base_tmp(request):
 
 @pytest.fixture
 def import_export_base_tmp(request):
-    import_export_base_tmp = "{}/import_export_test".format(os.getcwd())
+    import_export_base_tmp = "{}/import_export_test".format(pytest.temp_directory)
     io_util.get_directory(import_export_base_tmp)
 
     # Define a finalizer function for teardown

--- a/tests/io_util_test.py
+++ b/tests/io_util_test.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import pytest
 
 from arkouda import io_util
 
@@ -7,7 +8,7 @@ from arkouda import io_util
 class TestIOUtil:
     @classmethod
     def setup_class(cls):
-        cls.io_test_dir_base = f"{os.getcwd()}/io_test_dir"
+        cls.io_test_dir_base = f"{pytest.temp_directory}/io_test_dir"
         io_util.get_directory(cls.io_test_dir_base)
 
     def test_write_line_to_file(self):
@@ -28,7 +29,7 @@ class TestIOUtil:
             assert "6ky3i91l17" == values["127.0.0.1:5556"]
 
     def test_delete_directory(self):
-        path = "{}/test_dir".format(os.getcwd())
+        path = f"{pytest.temp_directory}/test_dir"
         io_util.get_directory(path)
 
         from os.path import isdir

--- a/tests/logger_test.py
+++ b/tests/logger_test.py
@@ -10,7 +10,7 @@ from arkouda.logger import LogLevel, getArkoudaClientLogger, getArkoudaLogger
 
 
 class TestLogger:
-    logger_test_base_tmp = f"{os.getcwd()}/logger_io_test"
+    logger_test_base_tmp = f"{pytest.temp_directory}/logger_io_test"
     io_util.get_directory(logger_test_base_tmp)
 
     def test_log_level(self):

--- a/tests/logger_test.py
+++ b/tests/logger_test.py
@@ -1,4 +1,3 @@
-import os
 import tempfile
 from logging import DEBUG, INFO, WARN, FileHandler, StreamHandler
 


### PR DESCRIPTION
Adds `pytest.temp_directory`, which allows overriding the default directory for temporary files for IO related tests