### PR TITLE
Restore scipy skipifs removed in #4172

### DIFF
--- a/tests/scipy/scipy_test.py
+++ b/tests/scipy/scipy_test.py
@@ -44,6 +44,7 @@ def bumpup(a):
 
 
 class TestStats:
+    @pytest.mark.skip_if_scipy_version_greater_than("1.13.1")
     @pytest.mark.parametrize(
         "lambda_",
         [
@@ -93,6 +94,7 @@ class TestStats:
 
                     assert np.allclose(ak_power_div, scipy_power_div, equal_nan=True)
 
+    @pytest.mark.skip_if_scipy_version_greater_than("1.13.1")
     @pytest.mark.parametrize("ddof", DDOF)
     @pytest.mark.parametrize("pair", PAIRS)
     def test_chisquare(self, ddof, pair):


### PR DESCRIPTION
Restores the scipy skipifs that were removed in #4172, as they are still needed.