### PR TITLE
add `ARKOUDA_DEFAULT_TEMP_DIRECTORY` to globally set the default temp directory

### DIFF
--- a/benchmarks/IO.py
+++ b/benchmarks/IO.py
@@ -9,6 +9,9 @@ from glob import glob
 import arkouda as ak
 import numpy as np
 
+from server_util.test.server_test_util import get_default_temp_directory
+
+
 TYPES = (
     "int64",
     "float64",
@@ -237,7 +240,7 @@ def create_parser():
     parser.add_argument(
         "-p",
         "--path",
-        default=os.path.join(os.getcwd(), "ak-io-test"),
+        default=os.path.join(get_default_temp_directory(), "ak-io-test"),
         help="Target path for measuring read/write rates",
     )
     parser.add_argument(

--- a/benchmarks/csvIO.py
+++ b/benchmarks/csvIO.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 
 import argparse
+import os
 
 from IO import *
+from server_util.test.server_test_util import get_default_temp_directory
+
 
 TYPES = (
     "int64",
@@ -34,7 +37,7 @@ def create_parser():
     parser.add_argument(
         "-p",
         "--path",
-        default=os.getcwd() + "ak-io-test",
+        default=os.path.join(get_default_temp_directory(), "ak-io-test"),
         help="Target path for measuring read/write rates",
     )
     parser.add_argument(

--- a/benchmarks/multiIO.py
+++ b/benchmarks/multiIO.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 
 import argparse
+import os
 
 from IO import *
+from server_util.test.server_test_util import get_default_temp_directory
+
 
 TYPES = (
     "int64",
@@ -29,7 +32,7 @@ def create_parser():
     parser.add_argument(
         "-p",
         "--path",
-        default=os.path.join(os.getcwd(), "ak-io-test"),
+        default=os.path.join(get_default_temp_directory(), "ak-io-test"),
         help="Target path for measuring read/write rates",
     )
     parser.add_argument(

--- a/benchmarks/parquet-fixed-strings.py
+++ b/benchmarks/parquet-fixed-strings.py
@@ -5,6 +5,9 @@ import argparse
 import shutil
 import pandas as pd
 
+from server_util.test.server_test_util import get_default_temp_directory
+
+
 str_length = 2
 test_dir = ''
 test_results = {
@@ -121,7 +124,7 @@ def print_performance_table(test_results):
     df = pd.DataFrame(data, columns=["test", "sec"])
     df["sec"] = df["sec"].apply(lambda x: f"{x:.3f}")
     print(df.to_markdown(index=False))
-                
+
 def create_parser():
     parser = argparse.ArgumentParser(
         description="Measure performance of writing and reading random arrays from disk."
@@ -140,7 +143,7 @@ def create_parser():
     parser.add_argument(
         "-p",
         "--path",
-        default=os.path.join(os.getcwd(), "ak-io-test/"),
+        default=os.path.join(get_default_temp_directory(), "ak-io-test"),
         help="Target path for measuring read/write rates",
     )
     return parser
@@ -156,7 +159,7 @@ if __name__ == "__main__":
     size = args.size
 
     write_files()
-        
+
     read_files_fixed()
     read_files()
 

--- a/benchmarks/parquetIO.py
+++ b/benchmarks/parquetIO.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 
 import argparse
+import os
 
 from IO import *
+from server_util.test.server_test_util import get_default_temp_directory
+
 
 TYPES = (
     "int64",
@@ -37,7 +40,7 @@ def create_parser():
     parser.add_argument(
         "-p",
         "--path",
-        default=os.getcwd() + "ak-io-test",
+        default=os.path.join(get_default_temp_directory(), "ak-io-test"),
         help="Target path for measuring read/write rates",
     )
     parser.add_argument(

--- a/benchmarks/parquetMultiIO.py
+++ b/benchmarks/parquetMultiIO.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 
 import argparse
+import os
 
 from multiIO import *
+from server_util.test.server_test_util import get_default_temp_directory
+
 
 TYPES = (
     "int64",
@@ -33,7 +36,7 @@ def create_parser():
     parser.add_argument(
         "-p",
         "--path",
-        default=os.getcwd() + "ak-io-test",
+        default=os.path.join(get_default_temp_directory(), "ak-io-test"),
         help="Target path for measuring read/write rates",
     )
     parser.add_argument(

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -196,9 +196,10 @@ def create_parser():
         help="run each benchmark in its own server instance",
     )
     parser.add_argument(
-        "--within-slrum-alloc",
+        "--within-slurm-alloc",
         default=False,
-        help="whether this script was launched from within a slurm allocation (for use with --isolated only)",
+        help="whether this script was launched from within a slurm allocation "
+        + "(for use with --isolated only)",
     )
     return parser
 

--- a/server_util/test/server_test_util.py
+++ b/server_util/test/server_test_util.py
@@ -127,6 +127,14 @@ def read_server_and_port_from_file(server_connection_info):
             continue
 
 
+def get_default_temp_directory():
+    """
+    Get the default temporary directory for arkouda server and client
+    """
+    dflt = os.getcwd()
+    return os.getenv("ARKOUDA_DEFAULT_TEMP_DIRECTORY", dflt)
+
+
 ####################
 # Server utilities #
 ####################

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ from server_util.test.server_test_util import (
     TestRunningMode,
     start_arkouda_server,
     stop_arkouda_server,
+    get_default_temp_directory,
 )
 
 os.environ["ARKOUDA_CLIENT_MODE"] = "API"
@@ -51,7 +52,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--temp-directory",
         action="store",
-        default=os.getcwd(),
+        default=get_default_temp_directory(),
         help="Directory to store temporary files.",
     )
 


### PR DESCRIPTION
Adds `ARKOUDA_DEFAULT_TEMP_DIRECTORY` to globally set the default temp directory

Followup work to https://github.com/Bears-R-Us/arkouda/pull/4181, this PR makes similar changes to the benchmark infastructure.