### PR TITLE
Closes #4203: Fix max_bits on multidimensional arrays

### DIFF
--- a/ServerModules.cfg
+++ b/ServerModules.cfg
@@ -5,6 +5,7 @@ ApplyMsg
 ArgSortMsg
 ArraySetopsMsg
 AryUtil
+BigIntMsg
 BroadcastMsg
 CastMsg
 CheckpointMsg

--- a/src/BigIntMsg.chpl
+++ b/src/BigIntMsg.chpl
@@ -16,18 +16,24 @@ module BigIntMsg {
     private config const logChannel = ServerConfig.logChannel;
     const biLogger = new Logger(logLevel, logChannel);
 
-    proc bigIntCreationMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+    @arkouda.instantiateAndRegister("big_int_creation")
+    proc bigIntCreationMsg(cmd: string, msgArgs: borrowed MessageArgs,
+                           st: borrowed SymTab, type array_dtype,
+                           param array_nd: int): MsgTuple throws
+        where (array_dtype == bigint) {
         param pn = Reflection.getRoutineName();
         var repMsg: string;
 
         var num_arrays = msgArgs.get("num_arrays").getIntValue();
-        var len = msgArgs.get("len").getIntValue();
+        var shape = msgArgs.get("shape").toScalarTuple(int, array_nd);
         var arrayNames = msgArgs.get("arrays").getList(num_arrays);
         var max_bits = msgArgs.get("max_bits").getIntValue();
 
-        var bigIntArray = makeDistArray(len, bigint);
+        var bigIntArray = makeDistArray((...shape), bigint);
         for (name, i) in zip(arrayNames, 0..<num_arrays by -1) {
-            ref uintA = toSymEntry(getGenericTypedArrayEntry(name, st), uint).a;
+            // We are creating a bigint array from uint arrays
+            var entry = st[name]: SymEntry(uint, array_nd);
+            ref uintA = entry.a;
             forall (uA, bA) in zip(uintA, bigIntArray) with (var bigUA: bigint) {
               bigUA = uA;
               bigUA <<= (64*i);
@@ -47,106 +53,91 @@ module BigIntMsg {
 
         var retname = st.nextName();
         st.addEntry(retname, createSymEntry(bigIntArray, max_bits));
-        var syment = toSymEntry(getGenericTypedArrayEntry(retname, st), bigint);
+        var syment = st[retname]: SymEntry(array_dtype, array_nd); // Is this line necessary?
         repMsg = "created %s".format(st.attrib(retname));
         biLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 
-    proc bigintToUintArraysMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+    @arkouda.instantiateAndRegister("bigint_to_uint_list")
+    proc bigintToUintArraysMsg(cmd: string, msgArgs: borrowed MessageArgs,
+                               st: borrowed SymTab, type array_dtype,
+                               param array_nd: int): MsgTuple throws
+        where (array_dtype == bigint) {
+
         param pn = Reflection.getRoutineName();
         const name = msgArgs.getValueOf("array");
-        var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(name, st);
+        var entry = st[name]: SymEntry(array_dtype, array_nd);
+        var repMsg: string = "";
 
-        select gEnt.dtype {
-            when DType.BigInt {
-                var e = toSymEntry(gEnt, bigint);
-                var tmp = e.a;
-                // take in a bigint sym entry and return list of uint64 symentries
-                var retList: list(string);
-                // default to false because we want to do first loop whether or not tmp is all_zero
-                var all_zero = false;
-                var low = makeDistArray(tmp.domain, uint);
-                const ushift = 64:uint;
-                while !all_zero {
-                  low = tmp:uint;
-                  var retname = st.nextName();
-                  st.addEntry(retname, createSymEntry(low));
-                  retList.pushBack("created %s".format(st.attrib(retname)));
+        var tmp = entry.a;
+        // take in a bigint sym entry and return list of uint64 symentries
+        var retList: list(string);
+        // default to false because we want to do first loop whether or not tmp is all_zero
+        var all_zero = false;
+        var low = makeDistArray(tmp.domain, uint);
+        const ushift = 64:uint;
+        while !all_zero {
+            low = tmp:uint;
+            var retname = st.nextName();
+            st.addEntry(retname, createSymEntry(low));
+            retList.pushBack("created %s".format(st.attrib(retname)));
 
-                  all_zero = true;
-                  forall t in tmp with (&& reduce all_zero) {
-                    t >>= ushift;
-                    all_zero &&= (t == 0 || t == -1);
-                  }
-                }
-                var repMsg = formatJson(retList);
-                biLogger.debug(getModuleName(), getRoutineName(), getLineNumber(), repMsg);
-                return new MsgTuple(repMsg, MsgType.NORMAL);
-            }
-            otherwise {
-                var errorMsg = notImplementedError(pn, "("+dtype2str(gEnt.dtype)+")");
-                biLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg, MsgType.ERROR);
+            all_zero = true;
+            forall t in tmp with (&& reduce all_zero) {
+                t >>= ushift;
+                all_zero &&= (t == 0 || t == -1);
             }
         }
+        repMsg = formatJson(retList);
+
+        biLogger.debug(getModuleName(), getRoutineName(), getLineNumber(), repMsg);
+        return new MsgTuple(repMsg, MsgType.NORMAL);
+
     }
 
-    proc getMaxBitsMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+    @arkouda.instantiateAndRegister("get_max_bits")
+    proc getMaxBitsMsg(cmd: string, msgArgs: borrowed MessageArgs,
+                       st: borrowed SymTab, type array_dtype,
+                       param array_nd: int): MsgTuple throws
+        where (array_dtype == bigint) {
+
         param pn = Reflection.getRoutineName();
         const name = msgArgs.getValueOf("array");
-        var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(name, st);
 
-        select gEnt.dtype {
-            when DType.BigInt {
-                var repMsg = formatJson(toSymEntry(gEnt, bigint).max_bits);
-                biLogger.debug(getModuleName(), getRoutineName(), getLineNumber(), repMsg);
-                return new MsgTuple(repMsg, MsgType.NORMAL);
-            }
-            otherwise {
-                var errorMsg = notImplementedError(pn, "("+dtype2str(gEnt.dtype)+")");
-                biLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg, MsgType.ERROR);
-            }
-        }
+        var entry = st[name]: SymEntry(array_dtype, array_nd);
+        var repMsg = formatJson(entry.max_bits);
+        biLogger.debug(getModuleName(), getRoutineName(), getLineNumber(), repMsg);
+        return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 
-    proc setMaxBitsMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+    @arkouda.instantiateAndRegister("set_max_bits")
+    proc setMaxBitsMsg(cmd: string, msgArgs: borrowed MessageArgs,
+                       st: borrowed SymTab, type array_dtype,
+                       param array_nd: int): MsgTuple throws
+        where (array_dtype == bigint) {
+
         param pn = Reflection.getRoutineName();
         const name = msgArgs.getValueOf("array");
         var max_bits = msgArgs.get("max_bits").getIntValue();
-        var gEnt: borrowed GenSymEntry = getGenericTypedArrayEntry(name, st);
-
-        select gEnt.dtype {
-            when DType.BigInt {
-                var e = toSymEntry(gEnt, bigint);
-                ref ea = e.a;
-
-                if max_bits != -1 {
-                    // modBy should always be non-zero since we start at 1 and left shift
-                    var max_size = 1:bigint;
-                    max_size <<= max_bits;
-                    max_size -= 1;
-                    forall ei in ea with (var local_max_size = max_size) {
-                      ei &= local_max_size;
-                    }
-                }
-                e.max_bits = max_bits;
-                var repMsg = "Sucessfully set max_bits";
-                biLogger.debug(getModuleName(), getRoutineName(), getLineNumber(), repMsg);
-                return new MsgTuple(repMsg, MsgType.NORMAL);
-            }
-            otherwise {
-                var errorMsg = notImplementedError(pn, "("+dtype2str(gEnt.dtype)+")");
-                biLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-                return new MsgTuple(errorMsg, MsgType.ERROR);
+        var entry = st[name]: SymEntry(array_dtype, array_nd);
+        var repMsg: string = "";
+        ref ea = entry.a;
+        if max_bits != -1 {
+            // modBy should always be non-zero since we start at 1 and left shift
+            var max_size = 1:bigint;
+            max_size <<= max_bits;
+            max_size -= 1;
+            forall ei in ea with (var local_max_size = max_size) {
+                ei &= local_max_size;
             }
         }
+        entry.max_bits = max_bits;
+        repMsg = "Sucessfully set max_bits";
+
+        biLogger.debug(getModuleName(), getRoutineName(), getLineNumber(), repMsg);
+        return new MsgTuple(repMsg, MsgType.NORMAL);
+
     }
 
-    use CommandMap;
-    registerFunction("big_int_creation", bigIntCreationMsg, getModuleName());
-    registerFunction("bigint_to_uint_list", bigintToUintArraysMsg, getModuleName());
-    registerFunction("get_max_bits", getMaxBitsMsg, getModuleName());
-    registerFunction("set_max_bits", setMaxBitsMsg, getModuleName());
 }


### PR DESCRIPTION
For some reason, `toSymEntry` has an input `param dimensions = 1`, but no call (that I've seen) ever changes that. Trying to rework it so that it doesn't need that and will just automatically convert it to whatever dimension is in ndim (an attribute of `GenSymEntry`) seems impossible (I tried, which is maybe not saying much). It seems to need to know at compile time what kind of `SymEntry` it is returning. Engin pointed out that this is solved by `instantiateAndRegister` (or just `registerCommand` if that's all that's necessary).

This can probably be applied to many other instances where a call to `toSymEntry` exists (e.g. I saw some in casting). This may not fix all of them, but this alone should fix most of them and some further tweaking should be possible on the others.

Since fixing all the ones in `BigIntMsg.chpl`, this also fixes the issue from before where converting multidimensional bigint arrays to and from numpy caused errors without so much reshaping.

Closes #4203: Fix max_bits on multidimensional arrays