### PR TITLE
Closes #4199:  add isort to Makefile

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,15 @@ jobs:
       run: |
         ! git --no-pager grep -n $'\t' -- '*.chpl'
         
+  isort:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - uses: isort/isort-action@master 
+        
   mypy:
     runs-on: ubuntu-latest
     container:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,16 +60,18 @@ Our Continuous Integration workflow has a linter (`flake8`) to verify all our py
 
 We use `isort`, `black`, and `flake8` (typically in that order) to ensure our code is consistent.
 We utilize a line length of 105. When running `black`, be sure to to use the `--line-length 105` parameter.
+Please use `make isort` to ensure consistency across contributors.
 
 ```bash
-$ isort arkouda/example_feature.py
-Fixing arkouda/example_feature.py
+$ make isort
+isort --gitignore --float-to-top arkouda
+Skipped 34 files
+isort --gitignore --float-to-top tests
+Skipped 1 files
 
 $ black --line-length 105 arkouda/example_feature.py
-reformatted arkouda/example_feature.py
-
-All done!
-1 file reformatted.
+All done! ✨ 🍰 ✨
+27 files reformatted, 67 files left unchanged.
 
 $ flake8 arkouda/example_feature.py
 ```

--- a/Makefile
+++ b/Makefile
@@ -679,6 +679,9 @@ doc-clean: stub-clean
 
 check:
 	@$(ARKOUDA_PROJECT_DIR)/server_util/test/checkInstall
+	
+isort:
+	isort --gitignore --float-to-top .
 
 #################
 #### Test.mk ####

--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -35,8 +35,8 @@ dependencies:
   - sphinx-autodoc-typehints
   - flake8
   - mypy>=0.931
-  - black
-  - isort
+  - black==25.1.0
+  - isort==5.13.2
   - pytest-json-report
   - pytest-benchmark
   - mathjax

--- a/arkouda/array_api/_typing.py
+++ b/arkouda/array_api/_typing.py
@@ -8,15 +8,6 @@ valid for inputs that match the given type annotations.
 
 from __future__ import annotations
 
-__all__ = [
-    "Array",
-    "Device",
-    "Dtype",
-    "SupportsDLPack",
-    "SupportsBufferProtocol",
-    "PyCapsule",
-]
-
 from typing import (
     Any,
     Literal,
@@ -40,6 +31,16 @@ from numpy import (
 )
 
 from .array_object import Array
+
+__all__ = [
+    "Array",
+    "Device",
+    "Dtype",
+    "SupportsDLPack",
+    "SupportsBufferProtocol",
+    "PyCapsule",
+]
+
 
 _T_co = TypeVar("_T_co", covariant=True)
 

--- a/arkouda/array_api/array_object.py
+++ b/arkouda/array_api/array_object.py
@@ -29,6 +29,12 @@ from typing import (
     cast,
 )
 
+import numpy as np
+
+import arkouda as ak
+from arkouda import array_api
+from arkouda.numpy.pdarraycreation import scalar_array
+
 from ._dtypes import (  # _all_dtypes,; _integer_or_boolean_dtypes,; _numeric_dtypes,
     _boolean_dtypes,
     _complex_floating_dtypes,
@@ -42,11 +48,6 @@ from .creation_functions import asarray
 if TYPE_CHECKING:
     from ._typing import Device, Dtype
 
-import numpy as np
-
-import arkouda as ak
-from arkouda import array_api
-from arkouda.numpy.pdarraycreation import scalar_array
 
 HANDLED_FUNCTIONS: Dict[str, Callable] = {}
 

--- a/arkouda/array_api/creation_functions.py
+++ b/arkouda/array_api/creation_functions.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, List, Optional, Tuple, Union, cast
 
 import numpy as np
 
+import arkouda as ak
 from arkouda.numpy.dtypes import dtype as akdtype
 from arkouda.numpy.dtypes import resolve_scalar_dtype
 from arkouda.numpy.pdarrayclass import _to_pdarray, pdarray
@@ -16,8 +17,6 @@ if TYPE_CHECKING:
         NestedSequence,
         SupportsBufferProtocol,
     )
-
-import arkouda as ak
 
 
 def asarray(

--- a/arkouda/array_api/data_type_functions.py
+++ b/arkouda/array_api/data_type_functions.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Tuple, Union
 
+import numpy as np
+
+import arkouda as ak
+
 from ._dtypes import (
     _all_dtypes,
     _boolean_dtypes,
@@ -18,10 +22,6 @@ from .array_object import Array, implements_numpy
 
 if TYPE_CHECKING:
     from ._typing import Dtype
-
-import numpy as np
-
-import arkouda as ak
 
 
 def astype(x: Array, dtype: Dtype, /, *, copy: bool = True) -> Array:

--- a/arkouda/array_api/statistical_functions.py
+++ b/arkouda/array_api/statistical_functions.py
@@ -2,6 +2,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, Tuple, Union
 
+import numpy as np
+
+from arkouda.client import generic_msg
+from arkouda.numpy import cast as akcast
+from arkouda.numpy.dtypes import dtype as akdtype
+from arkouda.numpy.pdarrayclass import create_pdarray
+
 from ._dtypes import (  # _complex_floating_dtypes,; complex128,
     _numeric_dtypes,
     _real_floating_dtypes,
@@ -16,13 +23,6 @@ from .manipulation_functions import squeeze
 
 if TYPE_CHECKING:
     from ._typing import Dtype
-
-import numpy as np
-
-from arkouda.client import generic_msg
-from arkouda.numpy import cast as akcast
-from arkouda.numpy.dtypes import dtype as akdtype
-from arkouda.numpy.pdarrayclass import create_pdarray
 
 
 def max(

--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -34,12 +34,12 @@ from arkouda.numpy.dtypes import uint64 as akuint64
 from arkouda.numpy.pdarrayclass import RegistrationError, pdarray
 from arkouda.numpy.pdarraycreation import arange, array, create_pdarray, full, zeros
 from arkouda.numpy.pdarraysetops import concatenate, in1d, intersect1d
-from arkouda.row import Row
 from arkouda.numpy.segarray import SegArray
-from arkouda.series import Series
 from arkouda.numpy.sorting import argsort, coargsort
 from arkouda.numpy.strings import Strings
 from arkouda.numpy.timeclass import Datetime, Timedelta
+from arkouda.row import Row
+from arkouda.series import Series
 
 # This is necessary for displaying DataFrames with BitVector columns,
 # because pandas _html_repr automatically truncates the number of displayed bits

--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -14,27 +14,32 @@ from typing import (
     no_type_check,
 )
 
-from arkouda.numpy.dtypes import dtype as akdtype
-
-if TYPE_CHECKING:
-    from arkouda.categorical import Categorical
-
 import numpy as np
 from typeguard import typechecked
 
 from arkouda.client import generic_msg
 from arkouda.logger import getArkoudaLogger
 from arkouda.numpy.dtypes import _val_isinstance_of_union, bigint
+from arkouda.numpy.dtypes import dtype as akdtype
 from arkouda.numpy.dtypes import float64 as akfloat64
 from arkouda.numpy.dtypes import float_scalars
 from arkouda.numpy.dtypes import int64 as akint64
 from arkouda.numpy.dtypes import int_scalars
 from arkouda.numpy.dtypes import uint64 as akuint64
-from arkouda.numpy.random import default_rng
-from arkouda.numpy.pdarrayclass import RegistrationError, create_pdarray, is_sorted, pdarray
+from arkouda.numpy.pdarrayclass import (
+    RegistrationError,
+    create_pdarray,
+    is_sorted,
+    pdarray,
+)
 from arkouda.numpy.pdarraycreation import arange, full
+from arkouda.numpy.random import default_rng
 from arkouda.numpy.sorting import argsort, sort
 from arkouda.numpy.strings import Strings
+
+if TYPE_CHECKING:
+    from arkouda.categorical import Categorical
+
 
 __all__ = ["unique", "GroupBy", "broadcast", "GROUPBY_REDUCTION_TYPES"]
 

--- a/arkouda/numpy/dtypes.py
+++ b/arkouda/numpy/dtypes.py
@@ -23,7 +23,6 @@ from numpy import (
     uint32,
     uint64,
 )
-
 from numpy.dtypes import (
     BoolDType,
     ByteDType,

--- a/arkouda/numpy/pdarraycreation.py
+++ b/arkouda/numpy/pdarraycreation.py
@@ -14,7 +14,11 @@ from arkouda.numpy.dtypes import (
     bigint,
 )
 from arkouda.numpy.dtypes import dtype as akdtype
-from arkouda.numpy.dtypes import float64, get_byteorder, get_server_byteorder
+from arkouda.numpy.dtypes import (
+    float64,
+    get_byteorder,
+    get_server_byteorder,
+)
 from arkouda.numpy.dtypes import int64 as akint64
 from arkouda.numpy.dtypes import (
     int_scalars,

--- a/arkouda/numpy/pdarraysetops.py
+++ b/arkouda/numpy/pdarraysetops.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from typing import Sequence, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Sequence, TypeVar, Union, cast
 
 import numpy as np
 from typeguard import typechecked
-
 
 from arkouda.client import generic_msg
 from arkouda.client_dtypes import BitVector
@@ -18,7 +17,6 @@ from arkouda.numpy.pdarrayclass import create_pdarray, pdarray
 from arkouda.numpy.pdarraycreation import array, ones, zeros, zeros_like
 from arkouda.numpy.sorting import argsort
 from arkouda.numpy.strings import Strings
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from arkouda.categorical import Categorical

--- a/arkouda/numpy/segarray.py
+++ b/arkouda/numpy/segarray.py
@@ -17,7 +17,12 @@ from arkouda.numpy.dtypes import bool_ as akbool
 from arkouda.numpy.dtypes import int64 as akint64
 from arkouda.numpy.dtypes import int_scalars, isSupportedInt, str_
 from arkouda.numpy.dtypes import uint64 as akuint64
-from arkouda.numpy.pdarrayclass import RegistrationError, create_pdarray, is_sorted, pdarray
+from arkouda.numpy.pdarrayclass import (
+    RegistrationError,
+    create_pdarray,
+    is_sorted,
+    pdarray,
+)
 from arkouda.numpy.pdarraycreation import arange, array, ones, zeros
 from arkouda.numpy.pdarraysetops import concatenate
 from arkouda.numpy.strings import Strings

--- a/arkouda/scipy/sparsematrix.py
+++ b/arkouda/scipy/sparsematrix.py
@@ -7,9 +7,9 @@ from typeguard import typechecked
 
 from arkouda.client import generic_msg
 from arkouda.logger import getArkoudaLogger
+from arkouda.numpy.dtypes import NumericDTypes
 from arkouda.numpy.dtypes import dtype as akdtype
 from arkouda.numpy.dtypes import int64
-from arkouda.numpy.dtypes import NumericDTypes
 from arkouda.numpy.pdarrayclass import pdarray
 from arkouda.scipy.sparrayclass import create_sparray, sparray
 

--- a/arkouda/series.py
+++ b/arkouda/series.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import operator
 from typing import List, Optional, Tuple, Union, cast
 
 import numpy as np
@@ -37,7 +38,6 @@ __all__ = [
     "Series",
 ]
 
-import operator
 
 supported_scalars = Union[int, float, bool, str, np.int64, np.float64, np.bool_, np.str_]
 

--- a/benchmarks/IO.py
+++ b/benchmarks/IO.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python3
 
 import argparse
-from enum import Enum
 import os
 import time
+from enum import Enum
 from glob import glob
 
-import arkouda as ak
 import numpy as np
 
+import arkouda as ak
 from server_util.test.server_test_util import get_default_temp_directory
-
 
 TYPES = (
     "int64",

--- a/benchmarks/bigint_conversion.py
+++ b/benchmarks/bigint_conversion.py
@@ -1,6 +1,7 @@
 import argparse
-import arkouda as ak
 import time
+
+import arkouda as ak
 
 
 def time_bigint_conversion(N_per_locale, trials, seed, max_bits):

--- a/benchmarks/csvIO.py
+++ b/benchmarks/csvIO.py
@@ -4,8 +4,8 @@ import argparse
 import os
 
 from IO import *
-from server_util.test.server_test_util import get_default_temp_directory
 
+from server_util.test.server_test_util import get_default_temp_directory
 
 TYPES = (
     "int64",

--- a/benchmarks/multiIO.py
+++ b/benchmarks/multiIO.py
@@ -4,8 +4,8 @@ import argparse
 import os
 
 from IO import *
-from server_util.test.server_test_util import get_default_temp_directory
 
+from server_util.test.server_test_util import get_default_temp_directory
 
 TYPES = (
     "int64",

--- a/benchmarks/parquet-fixed-strings.py
+++ b/benchmarks/parquet-fixed-strings.py
@@ -1,12 +1,12 @@
-import time
-import arkouda as ak
-import os
 import argparse
+import os
 import shutil
+import time
+
 import pandas as pd
 
+import arkouda as ak
 from server_util.test.server_test_util import get_default_temp_directory
-
 
 str_length = 2
 test_dir = ''
@@ -166,5 +166,3 @@ if __name__ == "__main__":
     delete_folder_contents(test_dir)
 
     print_performance_table(test_results)
-
-import pandas as pd

--- a/benchmarks/parquetIO.py
+++ b/benchmarks/parquetIO.py
@@ -4,8 +4,8 @@ import argparse
 import os
 
 from IO import *
-from server_util.test.server_test_util import get_default_temp_directory
 
+from server_util.test.server_test_util import get_default_temp_directory
 
 TYPES = (
     "int64",

--- a/benchmarks/parquetMultiIO.py
+++ b/benchmarks/parquetMultiIO.py
@@ -4,8 +4,8 @@ import argparse
 import os
 
 from multiIO import *
-from server_util.test.server_test_util import get_default_temp_directory
 
+from server_util.test.server_test_util import get_default_temp_directory
 
 TYPES = (
     "int64",

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -11,10 +11,11 @@ import logging
 import os
 import subprocess
 import sys
+
 from server_util.test.server_test_util import (
     get_arkouda_numlocales,
-    start_arkouda_server,
     run_client,
+    start_arkouda_server,
     stop_arkouda_server,
 )
 

--- a/examples/ak_bfs_conn_comp.py
+++ b/examples/ak_bfs_conn_comp.py
@@ -10,6 +10,7 @@
 
 import arkouda as ak
 
+
 def gen_rmat_edges(lgNv, Ne_per_v, p, perm=False):
     # number of vertices
     Nv = 2**lgNv
@@ -94,8 +95,13 @@ def conn_comp(src, dst, printCComp=False, printLayers=False):
     return components
 
 if __name__ == "__main__":
+    import argparse
+    import gc
+    import math
+    import sys
+    import time
+
     import matplotlib.pyplot as plt
-    import argparse, sys, gc, math, time
     
     parser = argparse.ArgumentParser(description="Generates an rmat structured spare matrix as tuples(ii,jj)")
     parser.add_argument('hostname', help='Hostname of arkouda server')

--- a/examples/ak_rmat.py
+++ b/examples/ak_rmat.py
@@ -2,6 +2,7 @@
 
 import arkouda as ak
 
+
 def gen_rmat_edges(lgNv, Ne_per_v, p, perm=False):
     # number of vertices
     Nv = 2**lgNv
@@ -46,8 +47,13 @@ def gen_rmat_edges(lgNv, Ne_per_v, p, perm=False):
 
 
 if __name__ == "__main__":
+    import argparse
+    import gc
+    import math
+    import sys
+    import time
+
     import matplotlib.pyplot as plt
-    import argparse, sys, gc, math, time
     
     parser = argparse.ArgumentParser(description="Generates an rmat structured spare matrix as tuples(ii,jj)")
     parser.add_argument('hostname', help='Hostname of arkouda server')

--- a/examples/cos_dist.py
+++ b/examples/cos_dist.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
-import arkouda as ak
 import math
+
+import arkouda as ak
+
 
 # dot product or two arkouda pdarrays
 def ak_dot(u, v):
@@ -27,9 +29,13 @@ def ak_cos_dist(u, v):
 
 
 if __name__ == "__main__":
-    from scipy.spatial import distance
+    import argparse
+    import gc
+    import sys
+    import time
+
     import numpy as np
-    import argparse, sys, gc, time
+    from scipy.spatial import distance
 
     parser = argparse.ArgumentParser(description="Example of cosine distance/similarity in arkouda")
     parser.add_argument('--server', default="localhost", help='server/Hostname of arkouda server')
@@ -59,5 +65,3 @@ if __name__ == "__main__":
     assert (np.allclose(d3, distance.cosine(u3,v1)))
 
     ak.disconnect()
-    
-    

--- a/examples/lanl_netflow_example.py
+++ b/examples/lanl_netflow_example.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 
-import sys, time, argparse
+import argparse
+import sys
+import time
+
 import arkouda as ak
 
 if __name__ == '__main__':
@@ -79,4 +82,3 @@ if __name__ == '__main__':
 
     ak.shutdown()
     #ak.disconnect()
-    

--- a/pydoc/conf.py
+++ b/pydoc/conf.py
@@ -13,7 +13,6 @@
 import os
 import sys
 
-
 sys.path.insert(0, os.path.abspath("../benchmarks"))
 sys.path.insert(0, os.path.abspath(".."))
 

--- a/pydoc/setup/EXTERNAL_TOOLS.md
+++ b/pydoc/setup/EXTERNAL_TOOLS.md
@@ -19,9 +19,9 @@ Using `pip install`, the following applications can be downloaded to your arkoud
 cd <path_to_arkouda>/arkouda
 
 # Download each of the following applications
-pip install black
+pip install black==25.1.0
 pip install flake8
-pip install isort
+pip install isort==5.13.2
 ```
 
 ### Add a local external tool 

--- a/pydoc/setup/REQUIREMENTS.md
+++ b/pydoc/setup/REQUIREMENTS.md
@@ -56,8 +56,8 @@ The dependencies listed here are only required if you will be doing development 
 - `linkify-it-py`
 - `flake8`
 - `mypy>=0.931`
-- `black`
-- `isort`
+- `black==25.1.0`
+- `isort==5.13.2`
 - `pytest-json-report`
 - `pytest-benchmark`
 - `mathjax`

--- a/scripts/exclude_np.py
+++ b/scripts/exclude_np.py
@@ -6,11 +6,7 @@ import inspect
 
 
 def exclude(name, obj) -> bool:
-    if (
-        hasattr(obj, "__doc__")
-        and not name.startswith("__")
-        and obj.__doc__ is not None
-    ):
+    if hasattr(obj, "__doc__") and not name.startswith("__") and obj.__doc__ is not None:
         if "array" in obj.__doc__:
             return True
     return False

--- a/server_util/test/checkInstall
+++ b/server_util/test/checkInstall
@@ -5,8 +5,8 @@ Run check.py, automatically starting/stopping the server.
 """
 
 import logging
-import sys
 import os
+import sys
 
 from server_test_util import *
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,8 @@ parentdir_prefix = arkouda-
 
 [isort]
 profile = black
+extend_skip_glob = *__init__.py,*deprecated*
+#,*versioneer.py,*toys*,*examples*,*server_util*,*tests*,*benchmarks*,*converter*,*pydoc*,*scripts*,*src*
 
 [flake8]
 max-line-length = 105

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ setup(
         "pyarrow",
         "scipy<=1.13.1; python_version<='3.12'",
         "scipy; python_version>'3.12'",
-        "cloudpickle"
+        "cloudpickle",
         # chapel-py
     ],
     # List additional groups of dependencies here (e.g. development
@@ -151,8 +151,8 @@ setup(
             "sphinx-argparse",
             "sphinx-autoapi",
             "mypy>=0.931",
-            "black",
-            "isort",
+            "black==25.1.0",
+            "isort==5.13.2",
             "flake8",
             "furo",
             "myst-parser",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,9 +14,9 @@ from server_util.test.server_test_util import (
 )
 from server_util.test.server_test_util import (
     TestRunningMode,
+    get_default_temp_directory,
     start_arkouda_server,
     stop_arkouda_server,
-    get_default_temp_directory,
 )
 
 os.environ["ARKOUDA_CLIENT_MODE"] = "API"

--- a/tests/io_util_test.py
+++ b/tests/io_util_test.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+
 import pytest
 
 from arkouda import io_util

--- a/tests/numpy/pdarrayclass_test.py
+++ b/tests/numpy/pdarrayclass_test.py
@@ -4,10 +4,9 @@ import numpy as np
 import pytest
 
 import arkouda as ak
+from arkouda.client import get_array_ranks, get_max_array_rank
 from arkouda.testing import assert_equal as ak_assert_equal
 from arkouda.testing import assert_equivalent as ak_assert_equivalent
-
-from arkouda.client import get_max_array_rank, get_array_ranks
 
 SEED = 314159
 

--- a/tests/scipy/scipy_test.py
+++ b/tests/scipy/scipy_test.py
@@ -4,10 +4,9 @@ from scipy.stats import chisquare as scipy_chisquare
 from scipy.stats import power_divergence as scipy_power_divergence
 
 import arkouda as ak
+from arkouda.client import get_array_ranks, get_max_array_rank
 from arkouda.scipy import chisquare as ak_chisquare
 from arkouda.scipy import power_divergence as ak_power_divergence
-
-from arkouda.client import get_max_array_rank, get_array_ranks
 
 DDOF = [0, 1, 2, 3, 4, 5]
 PAIRS = [

--- a/tests/scipy/sparse_test.py
+++ b/tests/scipy/sparse_test.py
@@ -2,9 +2,9 @@ import numpy as np
 
 import arkouda as ak
 from arkouda.scipy.sparsematrix import (
+    create_sparse_matrix,
     random_sparse_matrix,
     sparse_matrix_matrix_mult,
-    create_sparse_matrix,
 )
 
 

--- a/toys/connected_components.py
+++ b/toys/connected_components.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import arkouda as ak
 
+
 # generate rmat graph edge-list as two pdarrays
 def gen_rmat_edges(lgNv, Ne_per_v, p, perm=False):
     # number of vertices

--- a/toys/genops.py
+++ b/toys/genops.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-from string import Template
 import os
+from string import Template
 
 OPEQUAL = ['+=', '-=', '*=', '/=']
 BINOP = ['+', '-', '*', '/']

--- a/toys/np_rmat.py
+++ b/toys/np_rmat.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
+import gc
+import math
+import sys
+
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import math
-import gc
-import sys
-import matplotlib.pyplot as plt
+
 
 def gen_rmat_edges(lgNv, Ne_per_v, p):
     # number of vertices

--- a/toys/python_hash_rate.py
+++ b/toys/python_hash_rate.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 
-import random
-import sys
-import string
-import time
 import argparse
+import random
+import string
+import sys
+import time
 
 NINPUTS = 1_000_000
 INPUTSIZE = 8

--- a/versioneer.py
+++ b/versioneer.py
@@ -1595,6 +1595,7 @@ def get_cmdclass(cmdclass=None):
 
     if "cx_Freeze" in sys.modules:  # cx_freeze enabled?
         from cx_Freeze.dist import build_exe as _build_exe
+
         # nczeczulin reports that py2exe won't like the pep440-style string
         # as FILEVERSION, but it can be used for PRODUCTVERSION, e.g.
         # setup(console=[{


### PR DESCRIPTION
Adds `make isort` to the Makefile to standardize contributions.  Also fixes the `isort` and `black` versions.

Closes #4199:  add isort to Makefile