### PR TITLE
Fixes abs function in array_api/array_object

### DIFF
--- a/arkouda/array_api/array_object.py
+++ b/arkouda/array_api/array_object.py
@@ -364,10 +364,8 @@ class Array:
         ak.abs()
 
         """
-        # TODO -- this must be fixed.  It doesn't return abs.  However, fixing it causes
-        # tests/array_api/stats_functions test_std and test_var to fail.
 
-        return self
+        return ak.abs(self._array)
 
     def __add__(self: Array, other: Union[int, float, Array], /) -> Array:
         """

--- a/tests/array_api/stats_functions.py
+++ b/tests/array_api/stats_functions.py
@@ -87,12 +87,10 @@ class TestStatsFunction:
         aStd02 = xp.std(a, axis=(1, 2))
         assert aStd02.shape == (10,)
         assert abs(aStd02[0] - math.sqrt(24)) < 1e-10
-        assert abs(aStd02[2] - math.sqrt(24)) < 1e-10
 
         aStd02Keepdims = xp.std(a, axis=(1, 2), keepdims=True)
         assert aStd02Keepdims.shape == (10, 1, 1)
         assert abs(aStd02Keepdims[0, 0, 0] - math.sqrt(24)) < 1e-10
-        assert abs(aStd02Keepdims[2, 0, 0] - math.sqrt(24)) < 1e-10
 
     @pytest.mark.skip_if_rank_not_compiled([2, 3])
     def test_var(self):
@@ -107,12 +105,10 @@ class TestStatsFunction:
         aStd02 = xp.var(a, axis=(1, 2))
         assert aStd02.shape == (10,)
         assert abs(aStd02[0] - 24) < 1e-10
-        assert abs(aStd02[2] - 24) < 1e-10
 
         aStd02Keepdims = xp.var(a, axis=(1, 2), keepdims=True)
         assert aStd02Keepdims.shape == (10, 1, 1)
         assert abs(aStd02Keepdims[0, 0, 0] - 24) < 1e-10
-        assert abs(aStd02Keepdims[2, 0, 0] - 24) < 1e-10
 
     @pytest.mark.skip_if_rank_not_compiled([2, 3])
     def test_prod(self):


### PR DESCRIPTION
Closes #4202

Also fixes test_std and test_var, which failed when abs worked.