### PR TITLE
Closes #4231:  Add make format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -690,6 +690,9 @@ isort:
 	#  Verify if it will pass the CI check:
 	isort --check-only --diff .
 
+format: isort ruff-format
+	flake8
+
 #################
 #### Test.mk ####
 #################


### PR DESCRIPTION
Adds a `make format` to the Makefile that calls `make isort`, `make ruff-format`, and `flake8`.
Closes #4231:  Add make format