### PR TITLE
Closes #4236:  arkouda_benchmark_linux and arkouda_tests_linux to use ubuntu-with-arkouda-deps

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,7 +55,7 @@ jobs:
     env:
       CHPL_HOME: /opt/chapel-2.4.0
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.0
+      image: ajpotts/ubuntu-with-arkouda-deps:1.0.1
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
@@ -75,7 +75,7 @@ jobs:
     env:
       CHPL_HOME: /opt/chapel-2.4.0
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.0
+      image: ajpotts/ubuntu-with-arkouda-deps:1.0.1
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
@@ -100,7 +100,7 @@ jobs:
   flake8:
     runs-on: ubuntu-latest
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.0
+      image: ajpotts/ubuntu-with-arkouda-deps:1.0.1
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
@@ -133,7 +133,7 @@ jobs:
     env:
       CHPL_HOME: /opt/chapel-2.4.0
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.0
+      image: ajpotts/ubuntu-with-arkouda-deps:1.0.1
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
@@ -176,7 +176,7 @@ jobs:
     env:
       CHPL_HOME: /opt/chapel-2.4.0
     container:
-      image: ajpotts/almalinux-with-arkouda-deps:1.0.0
+      image: ajpotts/almalinux-with-arkouda-deps:1.0.1
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
@@ -275,7 +275,7 @@ jobs:
     env:
       CHPL_HOME: /opt/chapel-2.4.0
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.0
+      image: ajpotts/ubuntu-with-arkouda-deps:1.0.1
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4    
@@ -373,7 +373,7 @@ jobs:
     env:
       CHPL_HOME: /opt/chapel-${{ matrix.chpl-version }}
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.0
+      image: ajpotts/ubuntu-with-arkouda-deps:1.0.1
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
@@ -421,7 +421,7 @@ jobs:
     env:
       CHPL_HOME: /opt/chapel-${{ matrix.chpl-version }}
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.0
+      image: ajpotts/ubuntu-with-arkouda-deps:1.0.1
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
@@ -466,48 +466,24 @@ jobs:
 
   arkouda_tests_linux:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - image: chapel
-            threads: 2
-#          - image: chapel-gasnet-smp
-#            threads: 1
     env:
-      CHPL_RT_NUM_THREADS_PER_LOCALE: ${{matrix.threads}}
+      CHPL_RT_NUM_THREADS_PER_LOCALE: 2
+      CHPL_HOME: /opt/chapel-2.4.0
     container:
-      image: chapel/${{matrix.image}}:2.3.0
+      image: ajpotts/ubuntu-with-arkouda-deps:1.0.1
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
-    - name: Install python dependencies
-      uses: nick-fields/retry@v2
-      with:
-        timeout_seconds: 1200  # or use timeout_minutes
-        max_attempts: 2
-        retry_wait_seconds: 60
-        retry_on: error
-        command: |
-          apt-get update
-          apt-get install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libssl-dev libsqlite3-dev libreadline-dev libbz2-dev libffi-dev curl liblzma-dev tk-dev
-          apt-get install -y libhdf5-dev
-
-    # Download and install Python from source (updated URL for Python 3.12)
-    - name: Download Python 3.12 source
+    - name: Set Python version to 3.13
       run: |
-        curl -O https://www.python.org/ftp/python/3.12.0/Python-3.12.0.tgz
-        file Python-3.12.0.tgz  # Check the file type
-
-    - name: Extract Python 3.12 source
+        update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1      
+    - name: Set Chapel version to 2.4
       run: |
-        tar -xvf Python-3.12.0.tgz
-        cd Python-3.12.0 && ./configure --enable-optimizations && make -j$(nproc) && make altinstall && cd ..
-        update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.12 1
-
-    # Install pip for Python from the get-pip.py script
-    - name: Install pip for Python 3.12
+        update-alternatives --install /usr/bin/chpl chpl /opt/chapel-2.4.0/bin/linux64-x86_64/chpl 1
+        update-alternatives --install /usr/bin/chpldoc chpldoc /opt/chapel-2.4.0/bin/linux64-x86_64/chpldoc 1
+    - name: Check Chapel version
       run: |
-        curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3.12 get-pip.py
+        chpl --version
     - name: Install dependencies
       uses: nick-fields/retry@v2
       with:
@@ -516,16 +492,11 @@ jobs:
         retry_wait_seconds: 60
         retry_on: error
         command: |
-          apt-get update && apt-get install -y -V ca-certificates lsb-release wget
-          make install-arrow
-          apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev libcurl4-openssl-dev libidn2-dev libzmq3-dev
-          make install-iconv
-          make install-pytables
+          python3 -m ensurepip --default-pip
+          python3 -m pip install pytest-benchmark==3.2.2 py
           echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" >> Makefile.paths
-          python3 -m pip install scikit-build pytest-benchmark==3.2.2 py
-    - name: Install Chapel frontend bindings
-      run: |
-        (cd $CHPL_HOME/tools/chapel-py && python3 -m pip install .)
+          echo "\$(eval \$(call add-path,$DEP_INSTALL_DIR/arrow-install/))" >> Makefile.paths
+          echo "\$(eval \$(call add-path,$DEP_INSTALL_DIR/libiconv-install/))" >> Makefile.paths
     - name: Build/Install Arkouda
       run: |
         make
@@ -547,48 +518,23 @@ jobs:
         
   arkouda_benchmark_linux:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - image: chapel
-            threads: 2
-#          - image: chapel-gasnet-smp
-#            threads: 1
     env:
-      CHPL_RT_NUM_THREADS_PER_LOCALE: ${{matrix.threads}}
+      CHPL_HOME: /opt/chapel-2.4.0
     container:
-      image: chapel/${{matrix.image}}:2.3.0
+      image: ajpotts/ubuntu-with-arkouda-deps:1.0.1
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
-    - name: Install python dependencies
-      uses: nick-fields/retry@v2
-      with:
-        timeout_seconds: 1200  # or use timeout_minutes
-        max_attempts: 2
-        retry_wait_seconds: 60
-        retry_on: error
-        command: |
-          apt-get update
-          apt-get install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libssl-dev libsqlite3-dev libreadline-dev libbz2-dev libffi-dev curl liblzma-dev tk-dev
-          apt-get install -y libhdf5-dev
-
-    # Download and install Python from source (updated URL for Python 3.12)
-    - name: Download Python 3.12 source
+    - name: Set Python version to 3.13
       run: |
-        curl -O https://www.python.org/ftp/python/3.12.0/Python-3.12.0.tgz
-        file Python-3.12.0.tgz  # Check the file type
-
-    - name: Extract Python 3.12 source
+        update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1      
+    - name: Set Chapel version to 2.4
       run: |
-        tar -xvf Python-3.12.0.tgz
-        cd Python-3.12.0 && ./configure --enable-optimizations && make -j$(nproc) && make altinstall && cd ..
-        update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.12 1
-
-    # Install pip for Python from the get-pip.py script
-    - name: Install pip for Python 3.12
+        update-alternatives --install /usr/bin/chpl chpl /opt/chapel-2.4.0/bin/linux64-x86_64/chpl 1
+        update-alternatives --install /usr/bin/chpldoc chpldoc /opt/chapel-2.4.0/bin/linux64-x86_64/chpldoc 1
+    - name: Check Chapel version
       run: |
-        curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3.12 get-pip.py
+        chpl --version
     - name: Install dependencies
       uses: nick-fields/retry@v2
       with:
@@ -597,23 +543,15 @@ jobs:
         retry_wait_seconds: 60
         retry_on: error
         command: |
-          apt-get update && apt-get install -y -V ca-certificates lsb-release wget
-          make install-arrow
-          apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev libcurl4-openssl-dev libidn2-dev libzmq3-dev
-          make install-iconv
-          make install-pytables
+          python3 -m ensurepip --default-pip
+          python3 -m pip install pytest-benchmark==3.2.2 py
           echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" >> Makefile.paths
-          python3 -m pip install scikit-build pytest-benchmark==3.2.2 py
-    - name: Install Chapel frontend bindings
-      run: |
-        (cd $CHPL_HOME/tools/chapel-py && python3 -m pip install .)
+          echo "\$(eval \$(call add-path,$DEP_INSTALL_DIR/arrow-install/))" >> Makefile.paths
+          echo "\$(eval \$(call add-path,$DEP_INSTALL_DIR/libiconv-install/))" >> Makefile.paths
     - name: Build/Install Arkouda
       run: |
         make
         python3 -m pip install .[dev]
-    - name: Arkouda make check
-      run: |
-        make check
     - name: Arkouda benchmark
       run: |
         make benchmark size_bm=10

--- a/docker/README.txt
+++ b/docker/README.txt
@@ -11,5 +11,5 @@ This script builds and optionally pushes a Docker image for the Arkouda project.
 ## Usage
 
 ```bash
-./build_and_push.sh -v VERSION -i IMAGE_NAME -r REPO_NAME [-p]
+bash docker/build_arkouda_container.sh -v VERSION -i IMAGE_NAME -r REPO_NAME [-p]
 ```

--- a/docker/ubuntu-with-arkouda-deps/1.0.1/Dockerfile
+++ b/docker/ubuntu-with-arkouda-deps/1.0.1/Dockerfile
@@ -1,0 +1,130 @@
+FROM ubuntu:24.04
+
+USER root
+
+ENV PATH=/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/venv/bin
+
+ENV CHPL_HOME=/opt/chapel-2.4.0
+ENV CHPL_RE2=bundled 
+ENV CHPL_GMP=bundled 
+ENV CHPL_COMM=none 
+ENV CHPL_TARGET_CPU=native 
+ENV CHPL_LLVM=system
+ENV MANPATH=/opt/chapel-2.4.0/man
+ENV CHPL_TASKS=qthreads
+ENV CHPL_MEM=cstdlib
+ENV CHPL_HOST_MEM=cstdlib
+ENV CHPL_LLVM=none
+
+#   Set timezone, a prerequisite of the python3.12 install
+RUN ln -snf /usr/share/zoneinfo/$CONTAINER_TIMEZONE /etc/localtime && echo $CONTAINER_TIMEZONE > /etc/timezone
+
+WORKDIR /opt
+
+#   Set up environment variables
+COPY bashrc.local /opt/
+RUN mv /opt/bashrc.local ~/.bashrc.local && echo 'source ~/.bashrc.local' >> ~/.bashrc
+
+RUN apt-get -y update && apt-get -y upgrade
+RUN apt-get install -y software-properties-common && add-apt-repository ppa:deadsnakes/ppa
+RUN apt-get install -y python3.10 python3.10-venv python3.10-dev python3.11 python3.11-venv python3.11-dev python3.12 python3.12-venv python3.12-dev python3.13 python3.13-venv python3.13-dev
+RUN apt-get install -y python3-pip python3-virtualenv
+
+#   Install arkouda dependencies
+RUN apt-get update && apt-get install -y -V ca-certificates lsb-release wget libhdf5-dev
+RUN apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip libcurl4-openssl-dev libidn2-dev libzmq3-dev
+
+#   pip installs should use a virtual environment
+RUN python3 -m venv /venv
+RUN python3 -m pip install scikit-build versioneer setuptools wheel pytest-benchmark==3.2.2 py
+
+###############################################################################
+###                                                                         ###
+###     Install Chapel                                                      ###
+###                                                                         ###
+###############################################################################
+
+#  Install dependencies
+RUN apt-get install -y ca-certificates wget curl
+RUN apt-get install -y gcc g++ m4 perl python3-dev bash make mawk git pkg-config cmake
+RUN apt-get install -y llvm-dev llvm clang libclang-dev libclang-cpp-dev libedit-dev
+
+#   Download and install Chapel source
+RUN wget https://github.com/chapel-lang/chapel/releases/download/2.0.0/chapel-2.0.0.tar.gz && tar -xvf chapel-2.0.0.tar.gz && cd /opt/chapel-2.0.0 && CHPL_HOME=/opt/chapel-2.0.0 make
+RUN wget https://github.com/chapel-lang/chapel/releases/download/2.1.0/chapel-2.1.0.tar.gz && tar -xvf chapel-2.1.0.tar.gz && cd /opt/chapel-2.1.0 && CHPL_HOME=/opt/chapel-2.1.0 make
+RUN wget https://github.com/chapel-lang/chapel/releases/download/2.2.0/chapel-2.2.0.tar.gz && tar -xvf chapel-2.2.0.tar.gz && cd /opt/chapel-2.2.0 && CHPL_HOME=/opt/chapel-2.2.0 make
+RUN wget https://github.com/chapel-lang/chapel/releases/download/2.3.0/chapel-2.3.0.tar.gz && tar -xvf chapel-2.3.0.tar.gz && cd /opt/chapel-2.3.0 && CHPL_HOME=/opt/chapel-2.3.0 make
+RUN wget https://github.com/chapel-lang/chapel/releases/download/2.4.0/chapel-2.4.0.tar.gz && tar -xvf chapel-2.4.0.tar.gz && cd /opt/chapel-2.4.0 && CHPL_HOME=/opt/chapel-2.4.0 make
+
+# install chapel-py
+RUN cd  /opt/chapel-2.0.0  && CHPL_HOME=/opt/chapel-2.0.0  make chapel-py-venv
+RUN cd  /opt/chapel-2.1.0  && CHPL_HOME=/opt/chapel-2.1.0  make chapel-py-venv
+RUN cd  /opt/chapel-2.2.0  && CHPL_HOME=/opt/chapel-2.2.0  make chapel-py-venv
+RUN cd  /opt/chapel-2.3.0  && CHPL_HOME=/opt/chapel-2.3.0  make chapel-py-venv
+RUN cd  /opt/chapel-2.4.0  && CHPL_HOME=/opt/chapel-2.4.0  make chapel-py-venv
+
+#Install Chapel frontend bindings
+RUN python3 -m venv /venv
+RUN cd /opt/chapel-2.0.0/tools/chapel-py && CHPL_HOME=/opt/chapel-2.0.0 python3 -m pip install .
+RUN cd /opt/chapel-2.1.0/tools/chapel-py && CHPL_HOME=/opt/chapel-2.1.0 python3 -m pip install .
+RUN cd /opt/chapel-2.2.0/tools/chapel-py && CHPL_HOME=/opt/chapel-2.2.0 python3 -m pip install .
+RUN cd /opt/chapel-2.3.0/tools/chapel-py && CHPL_HOME=/opt/chapel-2.3.0 python3 -m pip install .
+RUN cd /opt/chapel-2.4.0/tools/chapel-py && CHPL_HOME=/opt/chapel-2.4.0 python3 -m pip install .
+
+#Install chpldoc
+RUN cd /opt/chapel-2.0.0 && CHPL_HOME=/opt/chapel-2.0.0 make chpldoc
+RUN cd /opt/chapel-2.1.0 && CHPL_HOME=/opt/chapel-2.1.0 make chpldoc
+RUN cd /opt/chapel-2.2.0 && CHPL_HOME=/opt/chapel-2.2.0 make chpldoc
+RUN cd /opt/chapel-2.3.0 && CHPL_HOME=/opt/chapel-2.3.0 make chpldoc
+RUN cd /opt/chapel-2.4.0 && CHPL_HOME=/opt/chapel-2.4.0 make chpldoc
+
+
+###############################################################################
+###                                                                         ###
+###     Install Arkouda Dependencies                                        ###
+###                                                                         ###
+###############################################################################
+
+
+ENV DEP_DIR=/opt/dep
+ENV DEP_BUILD_DIR=$DEP_DIR/build
+ENV DEP_INSTALL_DIR=$DEP_DIR/install
+ENV ARROW_DEP_DIR=$DEP_BUILD_DIR/arrow_dependencies
+
+RUN  mkdir -p $DEP_DIR && mkdir -p $DEP_BUILD_DIR && mkdir -p $DEP_INSTALL_DIR
+
+#   TODO:  Remove this step when the bzip2 repo is stable.
+#COPY build.tar $DEP_DIR/build.tar
+#RUN cd $DEP_DIR && tar -xvf build.tar
+
+#   Download clone arkouda repo and set to specific commit: Closes #4098 upgrade to numpy 2.0.0 (#4213)
+RUN cd /opt && git clone https://github.com/Bears-R-Us/arkouda.git && cd arkouda && git checkout abfb13bfe7931c07c2dec4e814955c59551a2d98
+WORKDIR /opt/arkouda
+
+#   This step will skip the download if the files are already in $DEP_BUILD_DIR
+RUN make deps-download-source DEP_BUILD_DIR=$DEP_BUILD_DIR
+
+RUN make install-arrow DEP_BUILD_DIR=$DEP_BUILD_DIR DEP_INSTALL_DIR=$DEP_INSTALL_DIR
+RUN make install-iconv DEP_BUILD_DIR=$DEP_BUILD_DIR DEP_INSTALL_DIR=$DEP_INSTALL_DIR
+RUN make install-pytables DEP_BUILD_DIR=$DEP_BUILD_DIR
+
+WORKDIR /opt
+RUN rm -fr arkouda
+
+
+###############################################################################
+###                                                                         ###
+###     Set defaults                                                        ###
+###                                                                         ###
+###############################################################################
+
+#   Save build environment to the .bashrc.local
+RUN env >> ~/.bashrc.local
+
+
+ENTRYPOINT ["/bin/bash", "-l"]
+
+
+
+
+

--- a/docker/ubuntu-with-arkouda-deps/1.0.1/bashrc.local
+++ b/docker/ubuntu-with-arkouda-deps/1.0.1/bashrc.local
@@ -1,0 +1,2 @@
+export ARKOUDA_QUICK_COMPILE=true 
+export ARKOUDA_SKIP_CHECK_DEPS=True


### PR DESCRIPTION
In order to create a version of `ubuntu-with-arkouda-deps` that would run the `arkouda_tests_linux` CI test, I updated the container to have environment variable `CHPL_TASKS=qthreads`, which is required to enable multiple threads per locale.

Closes #4236:  arkouda_benchmark_linux and arkouda_tests_linux to use ubuntu-with-arkouda-deps