### PR TITLE
Closes #4237 add doctest to the project

### DIFF
--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -24,6 +24,7 @@ dependencies:
   - pytest>=6.0
   - pytest-env
   - cloudpickle
+  - doctest
   # - chapel-py
 
   # Developer dependencies

--- a/arkouda/numpy/dtypes.py
+++ b/arkouda/numpy/dtypes.py
@@ -455,9 +455,10 @@ def isSupportedInt(num):
 
     Examples
     --------
-    >>> ak.isSupportedInt(ak.int64)
+    >>> import arkouda as ak
+    >>> ak.isSupportedInt(79)
     True
-    >>> ak.isSupportedInt(ak.float64)
+    >>> ak.isSupportedInt(54.9)
     False
 
     """
@@ -479,9 +480,10 @@ def isSupportedFloat(num):
 
     Examples
     --------
-    >>> ak.isSupportedFloat(ak.int64)
+    >>> import arkouda as ak
+    >>> ak.isSupportedFloat(56)
     False
-    >>> ak.isSupportedFloat(ak.float64)
+    >>> ak.isSupportedFloat(56.7)
     True
 
     """
@@ -503,9 +505,10 @@ def isSupportedNumber(num):
 
     Examples
     --------
-    >>> ak.isSupportedNumber(ak.int64)
+    >>> import arkouda as ak
+    >>> ak.isSupportedNumber(45.9)
     True
-    >>> ak.isSupportedNumber(ak.str_)
+    >>> ak.isSupportedNumber("string")
     False
 
     """
@@ -527,9 +530,10 @@ def isSupportedBool(num):
 
     Examples
     --------
-    >>> ak.isSupportedBool(ak.int64)
+    >>> import arkouda as ak
+    >>> ak.isSupportedBool("True")
     False
-    >>> ak.isSupportedBool(bool)
+    >>> ak.isSupportedBool(True)
     True
 
     """
@@ -551,7 +555,8 @@ def isSupportedDType(scalar: object) -> bool:
 
     Examples
     --------
-    >>> ak.isSupportedDType(ak.int64)
+    >>> import arkouda as ak
+    >>> ak.isSupportedDType(ak.int64(64))
     True
     >>> ak.isSupportedDType(np.complex128(1+2j))
     False
@@ -576,6 +581,7 @@ def resolve_scalar_dtype(val: object) -> str:
 
     Examples
     --------
+    >>> import arkouda as ak
     >>> ak.resolve_scalar_dtype(1)
     'int64'
     >>> ak.resolve_scalar_dtype(2.0)
@@ -634,6 +640,7 @@ def get_byteorder(dt: np.dtype) -> str:
 
     Examples
     --------
+    >>> import arkouda as ak
     >>> ak.get_byteorder(ak.dtype(ak.int64))
     '<'
 
@@ -665,6 +672,7 @@ def get_server_byteorder() -> str:
 
     Examples
     --------
+    >>> import arkouda as ak
     >>> ak.get_server_byteorder()
     'little'
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ parentdir_prefix = arkouda-
 
 [isort]
 profile = black
-extend_skip_glob = *__init__.py,*deprecated*,*.pyi
+extend_skip_glob = *__init__.py,*deprecated*,*.pyi,dep/*
 
 [flake8]
 max-line-length = 105
@@ -28,3 +28,4 @@ exclude =
     converter/csv2hdf.py
     ./build
     ./.git
+    ./.venv

--- a/tests/numpy/dtypes_test.py
+++ b/tests/numpy/dtypes_test.py
@@ -23,6 +23,12 @@ SUPPORTED_NP_DTYPES = [
 
 
 class TestDTypes:
+    def test_my_module_docstrings(self):
+        import doctest
+
+        result = doctest.testmod(dtypes)
+        assert result.failed == 0, f"Doctest failed: {result.failed} failures"
+
     def test_resolve_scalar_dtype(self):
         for b in True, False:
             assert "bool" == dtypes.resolve_scalar_dtype(b)


### PR DESCRIPTION
This PR adds `doctest` testing to the dtypes module.  `doctest` checks whether the examples in the docstrings give the output as shown in the docstring.  The goal is eventually to add `doctest` testing to every module.  

Closes #4237 add doctest to the project