### PR TITLE
Closes #4244: Make an unordered set union of two Strings arrays function

### DIFF
--- a/arkouda/numpy/pdarraymanipulation.py
+++ b/arkouda/numpy/pdarraymanipulation.py
@@ -109,7 +109,6 @@ def hstack(
                 cmd=f"concatenate<{akdtype(dtype_).name},{arrays[0].ndim}>",
                 args={
                     "names": list(arrays),
-                    "n": len(arrays),
                     "axis": 0,
                     "offsets": offsets,
                 },
@@ -125,7 +124,6 @@ def hstack(
             cmd=f"concatenate<{akdtype(dtype_).name},{arrays[0].ndim}>",
             args={
                 "names": list(arrays),
-                "n": len(arrays),
                 "axis": 1,
                 "offsets": offsets,
             },
@@ -239,7 +237,6 @@ def vstack(
             cmd=f"concatenate<{akdtype(dtype_).name},{arrays[0].ndim}>",
             args={
                 "names": list(arrays),
-                "n": len(arrays),
                 "axis": 0,
                 "offsets": offsets,
             },

--- a/arkouda/numpy/pdarraysetops.py
+++ b/arkouda/numpy/pdarraysetops.py
@@ -458,7 +458,6 @@ def concatenate(
         repMsg = generic_msg(
             cmd=f"concatenate<{akdtype(dtype_).name},{arrays[0].ndim}>",
             args={
-                "n": len(arrays),
                 "names": list(arrays),
                 "axis": 0,
                 "offsets": offsets,
@@ -472,7 +471,6 @@ def concatenate(
         repMsg = generic_msg(
             cmd="concatenateStr",
             args={
-                "nstr": len(arrays),
                 "objType": objtype,
                 "names": names,
                 "mode": mode,

--- a/arkouda/numpy/strings.py
+++ b/arkouda/numpy/strings.py
@@ -2183,8 +2183,8 @@ class Strings:
         dt = f"<U{lengths.max() if len(lengths) > 0 else 1}"
         res = np.empty(self.size, dtype=dt)
         # Form a string from each segment and store in numpy array
-        for i, (o, l) in enumerate(zip(npoffsets, lengths)):
-            res[i] = np.str_(codecs.decode(b"".join(npvalues[o : o + l])))
+        for i, (o, ln) in enumerate(zip(npoffsets, lengths)):
+            res[i] = np.str_(codecs.decode(b"".join(npvalues[o : o + ln])))
         return res
 
     def to_list(self) -> Any:
@@ -2789,3 +2789,36 @@ class Strings:
             cmd="sendArray",
             args={"values": self.entry, "hostname": hostname, "port": port, "objType": "strings"},
         )
+
+    @staticmethod
+    def concatenate_uniquely(strings: List[Strings]) -> Strings:
+        """
+        Concatenates a list of Strings into a single Strings object
+        containing only unique strings. Order may not be preserved.
+
+        Parameters
+        ----------
+        strings : List[Strings]
+            List of segmented string objects to concatenate.
+
+        Returns
+        -------
+        Strings
+            A new Strings object containing the unique values.
+        """
+
+        if not strings:
+            raise ValueError("Must provide at least one Strings object")
+
+        # Extract name of each SegmentedString
+        names = [s.name for s in strings]
+
+        # Send the command to the server
+        rep_msg = generic_msg(
+            cmd="concatenateUniquely",
+            args={
+                "names": names,
+            },
+        )
+
+        return Strings.from_return_msg(cast(str, rep_msg))

--- a/tests/numpy/string_test.py
+++ b/tests/numpy/string_test.py
@@ -929,3 +929,31 @@ class TestString:
         strings = self.get_strings(size, base_words)
 
         ak_assert_equal(strings.flatten(), strings)
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_concatenate_uniquely(self, size):
+        import random
+
+        from arkouda import Strings
+
+        base_array = [str(i) for i in range(size)]
+        list_1 = []
+        for i in range(size // 5):
+            val = random.choice(base_array)
+            list_1.append(val)
+            base_array.remove(val)
+
+        base_array = [str(i) for i in range(size)]
+        list_2 = []
+        for i in range(size // 5):
+            val = random.choice(base_array)
+            list_2.append(val)
+            base_array.remove(val)
+
+        ak_arr_1 = ak.array(list_1)
+        ak_arr_2 = ak.array(list_2)
+
+        output = Strings.concatenate_uniquely([ak_arr_1, ak_arr_2])
+        correct = set(list_1).union(set(list_2))
+
+        assert set(output.to_ndarray()) == correct


### PR DESCRIPTION
Previously, `set_categories` was using several groupbys to set categories for a Categorical array to some new set of categories. This was inefficient. I figured out a new way to tackle this - union the categories together (as Strings arrays), get the index of the old categories in the new ones, and then remap. I was told that a `union1d` function already exists, but looking into it, it did not seem to perform very well. I created my own version that ignores order. Here's how it works:

1. Union together the data within each locale across the arrays we're doing the union over
2. Take the hash of each string modulo numLocales to determine which locale to send each string to
3. After every locale sends all of its strings to all the other locales (including itself), look at what everyone else has sent me
4. Each locale creates a new set containing the strings that were sent to it (there are now no duplicates of strings across all locales)
5. Join the data together into a new SegString object

This seems to be the fastest way to do this. Getting incredible performance out of this and major asymptotic improvement over `union1d`.

Closes #4244: Make an unordered set union of two Strings arrays function