### PR TITLE
Closes #4313: ak.merge does not support Categorical

### DIFF
--- a/arkouda/dataframe.py
+++ b/arkouda/dataframe.py
@@ -42,7 +42,10 @@ from arkouda.numpy.dtypes import uint64 as akuint64
 from arkouda.numpy.pdarrayclass import RegistrationError, pdarray
 from arkouda.numpy.pdarraycreation import arange, array, create_pdarray, full, zeros
 from arkouda.numpy.pdarraysetops import concatenate, in1d, intersect1d
+from arkouda.numpy.sorting import argsort, coargsort
 from arkouda.numpy.sorting import sort as aksort
+from arkouda.numpy.strings import Strings
+from arkouda.numpy.timeclass import Datetime, Timedelta
 from arkouda.pandas.join import inner_join
 from arkouda.pandas.row import Row
 
@@ -52,9 +55,6 @@ if TYPE_CHECKING:
 else:
     Series = TypeVar("Series")
     SegArray = TypeVar("SegArray")
-from arkouda.numpy.sorting import argsort, coargsort
-from arkouda.numpy.strings import Strings
-from arkouda.numpy.timeclass import Datetime, Timedelta
 
 # This is necessary for displaying DataFrames with BitVector columns,
 # because pandas _html_repr automatically truncates the number of displayed bits
@@ -5800,8 +5800,19 @@ def _inner_join_merge(
     col_intersect_ = col_intersect.copy() if isinstance(col_intersect, list) else [col_intersect[:]]
     left_on_ = [left_on] if isinstance(left_on, str) else left_on
     right_on_ = [right_on] if isinstance(right_on, str) else right_on
+    tmp_left = {col: left[col] for col in left_cols}
+    tmp_right = {col: right[col] for col in right_cols}
+    for lcol, rcol in zip(left_on_, right_on_):
+        if isinstance(left[lcol], Categorical) and isinstance(right[rcol], Categorical):
+            new_categoricals = Categorical.standardize_categories([left[lcol], right[rcol]])
+            tmp_left[lcol] = new_categoricals[0]
+            tmp_right[rcol] = new_categoricals[1]
     left_inds, right_inds = inner_join(
-        [left[col] for col in left_on_], [right[col] for col in right_on_]
+        [tmp_left[col].codes if isinstance(left[col], Categorical) else left[col] for col in left_on_],
+        [
+            tmp_right[col].codes if isinstance(right[col], Categorical) else right[col]
+            for col in right_on_
+        ],
     )
     new_dict = {}
     for lcol, rcol in zip(left_on_, right_on_):
@@ -5811,10 +5822,10 @@ def _inner_join_merge(
 
     for col in left_cols:
         new_col = col + left_suffix if col in col_intersect_ else col
-        new_dict[new_col] = left[col][left_inds]
+        new_dict[new_col] = tmp_left[col][left_inds]
     for col in right_cols:
         new_col = col + right_suffix if col in col_intersect_ else col
-        new_dict[new_col] = right[col][right_inds]
+        new_dict[new_col] = tmp_right[col][right_inds]
 
     ret_df = DataFrame(new_dict)
     sort_keys = [left_on] if isinstance(left_on, str) else left_on
@@ -6055,8 +6066,12 @@ def __nulls_like(
     if size is None:
         size = arry.size
 
-    if isinstance(arry, (Strings, Categorical)):
+    if isinstance(arry, Strings):
         return full(size, "nan")
+    elif isinstance(arry, Categorical):
+        return Categorical.from_codes(
+            categories=arry.categories, codes=full(size, len(arry.categories) - 1, dtype=akint64)
+        )
     else:
         return full(size, np.nan, arry.dtype)
 
@@ -6251,8 +6266,8 @@ def merge(
         raise ValueError("Cannot merge with more columns from one DataFrame than the other")
 
     if not all(
-        isinstance(left[left_col], (pdarray, Strings))
-        and isinstance(right[right_col], (pdarray, Strings))
+        isinstance(left[left_col], (pdarray, Strings, Categorical))
+        and isinstance(right[right_col], (pdarray, Strings, Categorical))
         for left_col, right_col in zip(left_on_, right_on_)
     ):
         raise ValueError("All columns of a multi-column merge must be pdarrays")

--- a/arkouda/pandas/series.py
+++ b/arkouda/pandas/series.py
@@ -27,13 +27,13 @@ from arkouda.numpy.pdarrayclass import (
 )
 from arkouda.numpy.pdarraycreation import arange, array, full, zeros
 from arkouda.numpy.pdarraysetops import argsort, concatenate, in1d, indexof1d
+from arkouda.numpy.strings import Strings
+from arkouda.numpy.util import get_callback, is_float
 
 if TYPE_CHECKING:
     from arkouda.numpy.segarray import SegArray
 else:
     SegArray = TypeVar("SegArray")
-from arkouda.numpy.strings import Strings
-from arkouda.numpy.util import get_callback, is_float
 
 # pd.set_option("display.max_colwidth", 65) is being called in DataFrame.py. This will resolve BitVector
 # truncation issues. If issues arise, that's where to look for it.

--- a/tests/dataframe_test.py
+++ b/tests/dataframe_test.py
@@ -1190,14 +1190,13 @@ class TestDataFrame:
                     else:
                         assert (np.sort(from_ak) == np.sort(from_pd.astype(str))).all()
 
-    """
     @pytest.mark.parametrize("how", ["inner", "left", "right"])
     @pytest.mark.parametrize(
         ("left_on", "right_on"),
         [
             ("a", "x"),
             ("c", "z"),
-            (["a",  "c"], ["x", "z"]),
+            (["a", "c"], ["x", "z"]),
         ],
     )
     def test_merge_categoricals_left_on_right_on(self, how, left_on, right_on):
@@ -1227,17 +1226,11 @@ class TestDataFrame:
 
         ak_merge = ak.merge(left_df, right_df, left_on=left_on, right_on=right_on, how=how, sort=True)
         pd_merge = pd.merge(
-            l_pd,
-            r_pd,
-            left_on=left_on,
-            right_on=right_on,
-            how=how,
-            copy=True,
-            sort=True
+            l_pd, r_pd, left_on=left_on, right_on=right_on, how=how, copy=True, sort=True
         )
 
         # Numeric sorting works okay when floats aren't involved
-        if True:
+        if not ak_merge.isna().any():
             assert_frame_equivalent(ak_merge, pd_merge)
 
         # If there are strings involved, do it this way
@@ -1251,9 +1244,15 @@ class TestDataFrame:
 
                 if isinstance(ak_merge[col], ak.pdarray):
                     assert np.allclose(np.sort(from_ak), np.sort(from_pd), equal_nan=True)
+                elif isinstance(ak_merge[col], ak.Categorical):
+                    na = ak_merge[col].NAvalue
+                    from_ak = np.where(from_ak == na, "nan", from_ak)
+                    from_ak = np.sort(from_ak)
+                    from_pd = np.sort(from_pd.astype(str))
+
+                    assert (from_ak == from_pd).all()
                 else:
                     assert (np.sort(from_ak) == np.sort(from_pd.astype(str))).all()
-    """
 
     def test_isna_notna(self):
         df = ak.DataFrame(


### PR DESCRIPTION
Categorical support didn't take that much reworking. Includes unit test.

Closes #4313: `ak.merge` does not support `Categorical`