### PR TITLE
Closes #4343:  add darglint to the project

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,6 +22,20 @@ jobs:
       run: |
         pydocstyle
 
+  darglint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install darglint>=1.8.1
+    - name: Check docstrings with darglint
+      run: |
+        #  darglint is a docstring linter that checks whether docstring sections (arguments, returns, raises, etc.) match the function signature or implementation.
+        darglint -v 2 arkouda
+
   isort:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -694,7 +694,11 @@ format: isort ruff-format
 	#   Run docstring linter
 	pydocstyle
 	#   Run flake8
-	flake8
+	flake8 $(ARKOUDA_PROJECT_DIR)/arkouda
+
+darglint: 
+	#   Check darglint linter for doc strings:
+	darglint -v 2 arkouda
 
 
 #################

--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -45,6 +45,7 @@ dependencies:
   - types-python-dateutil
   - pydocstyle>=6.3.0
   - pre-commit
+  - darglint>=1.8.1
 
   - pip:
     # Developer dependencies

--- a/arkouda-env.yml
+++ b/arkouda-env.yml
@@ -25,6 +25,7 @@ dependencies:
   - pytest-env
   - cloudpickle
   - pre-commit
+  - darglint>=1.8.1
   # - chapel-py
 
   - pip:

--- a/arkouda/array_api/creation_functions.py
+++ b/arkouda/array_api/creation_functions.py
@@ -36,12 +36,13 @@ def asarray(
     - a scalar value (bool, int, float)
     - a sequence of scalar values (not yet implemented)
     - a buffer (not yet implemented)
-    - an arkouda :class:`~arkouda.numpy.pdarrayclass.pdarray`
+    - an arkouda class:`~arkouda.numpy.pdarrayclass.pdarray`
     - a numpy ndarray
 
     Parameters
     ----------
-    obj:
+    obj : Array, bool, int, float, complex,
+          sequence of scalars, buffer, pdarray, or numpy.ndarray
         The object to convert to an Array
     dtype: Optional[Dtype]
         The dtype of the resulting Array. If None, the dtype is inferred from the input object

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -1733,7 +1733,10 @@ def load(
 
 @typechecked
 def load_all(
-    path_prefix: str, file_format: str = "INFER", column_delim: str = ",", read_nested=True
+    path_prefix: str,
+    file_format: str = "INFER",
+    column_delim: str = ",",
+    read_nested: bool = True,
 ) -> Mapping[str, Union[pdarray, Strings, SegArray, Categorical]]:
     """
     Load multiple pdarrays, Strings, SegArrays, or Categoricals previously
@@ -1763,7 +1766,7 @@ def load_all(
 
     Raises
     ------
-    TypeError:
+    TypeError
         Raised if path_prefix is not a str
     ValueError
         Raised if file_format/extension is encountered that is not hdf5 or parquet or

--- a/arkouda/match.py
+++ b/arkouda/match.py
@@ -60,7 +60,7 @@ class Match:
 
         Returns
         -------
-        pdarray, bool
+        pdarray
             True for elements that match, False otherwise
 
         Examples

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ extend_skip_glob = *__init__.py,*deprecated*,*.pyi,dep/*
 
 [flake8]
 max-line-length = 105
-extend-ignore = E203, E712
+extend-ignore = E203,E712,W605
 per-file-ignores =
     tests/operator_test.py: E501
     tests/symbol_table_test.py: F841
@@ -36,6 +36,14 @@ exclude =
 #inherit = false
 #   TODO:  Remove all ignore codes
 ignore = D417,D101,D203,D103,D107,D105,D102,D404,D100,D212,D415,D400,D205
-
 match-dir = arkouda
+
+    
+[darglint]
+# How strictly to enforce: none, short, full
+strictness = full
+# Which docstring style: google, sphinx, or numpy
+docstring_style = numpy
+ignore=DAR402,DAR103,DAR101,DAR202,DAR002,DAR102,DAR201,DAR401,DAR203,
+
 

--- a/setup.py
+++ b/setup.py
@@ -166,6 +166,7 @@ setup(
             "ipython",
             "pydocstyle>=6.3.0",
             "pre-commit",
+            "darglint>=1.8.1",
         ],
     },
     # replace original install command with version that also builds


### PR DESCRIPTION
This PR adds darglint to the project.  Darglint is a functional docstring linter that verifies if a docstring's description matches the actual function/method implementation. It supports Google, Sphinx, and NumPy style guides.  It leaves resolving the discovered errors to separate tickets.