### PR TITLE
Closes #4365:  Prevent comments in docstring Examples

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,6 +21,8 @@ jobs:
     - name: Run linter (pydocstyle)
       run: |
         pydocstyle
+    - name: Run doc-example check
+      run: make check-doc-examples
 
   darglint:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -690,7 +690,18 @@ isort:
 	#  Verify if it will pass the CI check:
 	isort --check-only --diff .
 
-format: isort ruff-format
+
+.PHONY: check-doc-examples
+check-doc-examples:
+	@# skip binaries, only look in .py files, use extended regex
+	@if grep -R -I -nE '^[[:space:]]*>>>[[:space:]]*#' \
+	     --include="*.py" $(ARKOUDA_PROJECT_DIR)/arkouda; then \
+	  echo "💥 Found comment-only doctest examples (>>> #…); please remove them"; \
+	  exit 1; \
+	fi
+	
+	
+format: isort ruff-format check-doc-examples
 	#   Run docstring linter
 	pydocstyle
 	#   Run flake8

--- a/arkouda/index.py
+++ b/arkouda/index.py
@@ -304,10 +304,9 @@ class Index:
 
     @staticmethod
     def factory(index):
-        t = type(index)
         if isinstance(index, Index):
             return index
-        elif t != list and t != tuple:
+        elif not isinstance(index, List) and not isinstance(index, Tuple):
             return Index(index)
         else:
             return MultiIndex(index)

--- a/arkouda/numpy/pdarrayclass.py
+++ b/arkouda/numpy/pdarrayclass.py
@@ -2642,7 +2642,6 @@ class pdarray:
 
         potentially disconnect from server and reconnect to server
         >>> b = ak.pdarray.attach("my_zeros")
-        >>> # ...other work...
         >>> b.unregister()
         """
         if self.registered_name is not None and self.is_registered():
@@ -2691,7 +2690,6 @@ class pdarray:
 
         # potentially disconnect from server and reconnect to server
         >>> b = ak.pdarray.attach("my_zeros")
-        >>> # ...other work...
         >>> b.unregister()
         """
         from arkouda.numpy.util import unregister


### PR DESCRIPTION
This PR adds `check-doc-examples` to the `Makefile` which checks that there are not Examples of the form `>>> #` in the docstrings, and adds a check for these to the CI.

Closes #4365:  Prevent comments in docstring Examples