### PR TITLE
Removed deprecated functions

### DIFF
--- a/arkouda/numpy/timeclass.py
+++ b/arkouda/numpy/timeclass.py
@@ -1,6 +1,5 @@
 import datetime
 import json
-from warnings import warn
 
 import numpy as np
 from pandas import Series as pdSeries
@@ -1008,7 +1007,6 @@ def date_range(
     tz=None,
     normalize=False,
     name=None,
-    closed=None,
     inclusive="both",
     **kwargs,
 ):
@@ -1037,10 +1035,6 @@ def date_range(
         Normalize start/end dates to midnight before generating date range.
     name : str, default None
         Name of the resulting DatetimeIndex.
-    closed : {None, 'left', 'right'}, optional
-        Make the interval closed with respect to the given frequency to
-        the 'left', 'right', or both sides (None, the default).
-        *Deprecated*
     inclusive : {"both", "neither", "left", "right"}, default "both"
         Include boundaries. Whether to set each bound as closed or open.
     **kwargs
@@ -1061,12 +1055,6 @@ def date_range(
     <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases>`__.
 
     """
-    if closed is not None:
-        warn(
-            "closed has been deprecated. Please use the inclusive parameter instead.",
-            DeprecationWarning,
-        )
-        inclusive = closed
 
     return Datetime(
         pd_date_range(

--- a/arkouda/pandas/series.py
+++ b/arkouda/pandas/series.py
@@ -1074,44 +1074,6 @@ class Series:
         unregister(self.registered_name)
         self.registered_name = None
 
-    @staticmethod
-    @typechecked
-    def attach(label: str, nkeys: int = 1) -> Series:
-        """
-        Retrieve a Series previously registered in Arkouda.
-
-        Deprecated
-        ----------
-        Use `ak.attach(label)` instead.
-
-        Parameters
-        ----------
-        label : str
-            The name under which the Series was registered.
-        nkeys : int, optional
-            The number of index keys if a MultiIndex was registered. Default is 1.
-
-        Returns
-        -------
-        Series
-            The Series object associated with the given label.
-
-        Raises
-        ------
-        KeyError
-            If no Series is registered under `label`.
-
-        """
-        import warnings
-
-        from arkouda.numpy.util import attach
-
-        warnings.warn(
-            "ak.Series.attach() is deprecated. Please use ak.attach() instead.",
-            DeprecationWarning,
-        )
-        return attach(label)
-
     @typechecked
     def is_registered(self) -> bool:
         """


### PR DESCRIPTION
This PR removes the `Series.attach` function, as well as the `closed` argument from `timeclass.date_time`, both of which have been deprecated.