### PR TITLE
Auto checkpoint upon exceeding memory percentage

### DIFF
--- a/src/Message.chpl
+++ b/src/Message.chpl
@@ -492,7 +492,7 @@ module Message {
                 }
             }
 
-            throw new owned ErrorWithContext("JSON argument key Not Found; %s".format(key),
+            throw new owned ErrorWithContext("JSON argument key Not Found: %s".format(key),
                                              getLineNumber(),
                                              getRoutineName(),
                                              getModuleName(),


### PR DESCRIPTION
Initial implementation of automatic checkpointing, performed in the server before waiting for the next zmq message from the client based on a memory percentage threshold. The threshold is controlled by a config argument of the server and is off by default. Automatic checkpointing is not done if the CheckpointMsg module was included in the build.

Minimal intelligence is included that suppresses automatic checkpointing if it has already been performed or a checkpoint has been loaded, unless memory has been below the threshold after these took place.

Essential next steps: report it to the user that the checkpointing is taking place and wait for 5 seconds (for example) idle time so that checkpointing does not occur during intermediate computations. For example, `ak.ones(nnn)` takes two messages and the checkpoint will currently occur between them if threshold is exceeded.

I would also like to move `activityMutex` to a "common header" file like `MultiTypeSymbolTable` so that CheckpointMsg can do locking at a finer granularity than (currently) for the entire `autoCheckpointMsg()`.