### PR TITLE
Fixes bug involving arange and kwargs -- Closes 4321

### DIFF
--- a/arkouda/array_api/creation_functions.py
+++ b/arkouda/array_api/creation_functions.py
@@ -111,9 +111,9 @@ def arange(
         raise ValueError(f"Unsupported device {device!r}")
 
     if stop is None:
-        return Array._new(ak.arange(0, start, step, dtype=dtype))
+        return Array._new(ak.arange(0, start, step, dtype=dtype))  # type: ignore
     else:
-        return Array._new(ak.arange(start, stop, step, dtype=dtype))
+        return Array._new(ak.arange(start, stop, step, dtype=dtype))  # type: ignore
 
 
 def empty(

--- a/tests/array_api/array_manipulation.py
+++ b/tests/array_api/array_manipulation.py
@@ -105,7 +105,7 @@ class TestManipulation:
     @pytest.mark.skip_if_rank_not_compiled([3])
     def test_flip(self):
         # 1D case
-        a = xp.arange(10)
+        a = xp.asarray(ak.arange(10))
         b1 = xp.flip(a)
         b2 = xp.flip(a, axis=0)
 
@@ -201,7 +201,7 @@ class TestManipulation:
     @pytest.mark.skip_if_rank_not_compiled([3])
     def test_roll(self):
         # 1D case
-        a = xp.arange(10)
+        a = xp.asarray(ak.arange(10))
         b1 = xp.roll(a, 3)
         b2 = xp.roll(a, -3)
 

--- a/tests/numpy/pdarray_creation_test.py
+++ b/tests/numpy/pdarray_creation_test.py
@@ -255,7 +255,7 @@ class TestPdarrayCreation:
 
     @pytest.mark.parametrize("dtype", ak.intTypes)
     def test_arange_dtype(self, dtype):
-        # test dtype works with optional start/stride
+        # test dtype works with optional start/step
         stop = ak.arange(100, dtype=dtype)
         assert np.arange(100, dtype=dtype).tolist() == stop.to_list()
         assert dtype == stop.dtype
@@ -264,22 +264,22 @@ class TestPdarrayCreation:
         assert np.arange(100, 105, dtype=dtype).tolist() == start_stop.to_list()
         assert dtype == start_stop.dtype
 
-        start_stop_stride = ak.arange(100, 105, 2, dtype=dtype)
-        assert np.arange(100, 105, 2, dtype=dtype).tolist() == start_stop_stride.to_list()
-        assert dtype == start_stop_stride.dtype
+        start_stop_step = ak.arange(100, 105, 2, dtype=dtype)
+        assert np.arange(100, 105, 2, dtype=dtype).tolist() == start_stop_step.to_list()
+        assert dtype == start_stop_step.dtype
 
-        # also test for start/stop/stride that cause empty ranges
-        start_stop_stride = ak.arange(100, 10, 2, dtype=dtype)
-        assert np.arange(100, 10, 2, dtype=dtype).tolist() == start_stop_stride.to_list()
-        assert dtype == start_stop_stride.dtype
+        # also test for start/stop/step that cause empty ranges
+        start_stop_step = ak.arange(100, 10, 2, dtype=dtype)
+        assert np.arange(100, 10, 2, dtype=dtype).tolist() == start_stop_step.to_list()
+        assert dtype == start_stop_step.dtype
 
-        start_stop_stride = ak.arange(10, 15, -2, dtype=dtype)
-        assert np.arange(10, 15, -2, dtype=dtype).tolist() == start_stop_stride.to_list()
-        assert dtype == start_stop_stride.dtype
+        start_stop_step = ak.arange(10, 15, -2, dtype=dtype)
+        assert np.arange(10, 15, -2, dtype=dtype).tolist() == start_stop_step.to_list()
+        assert dtype == start_stop_step.dtype
 
-        start_stop_stride = ak.arange(10, 10, -2, dtype=dtype)
-        assert np.arange(10, 10, 2, dtype=dtype).tolist() == start_stop_stride.to_list()
-        assert dtype == start_stop_stride.dtype
+        start_stop_step = ak.arange(10, 10, -2, dtype=dtype)
+        assert np.arange(10, 10, 2, dtype=dtype).tolist() == start_stop_step.to_list()
+        assert dtype == start_stop_step.dtype
 
     def test_arange_misc(self):
         # test uint64 handles negatives correctly
@@ -316,12 +316,12 @@ class TestPdarrayCreation:
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", [ak.float64, ak.uint64, ak.float64])
     @pytest.mark.parametrize("start", [0, 2, 5])
-    @pytest.mark.parametrize("stride", [1, 3])
-    def test_compare_arange(self, size, dtype, start, stride):
+    @pytest.mark.parametrize("step", [1, 3])
+    def test_compare_arange(self, size, dtype, start, step):
         # create np version
-        nArange = np.arange(start, size, stride, dtype=dtype)
+        nArange = np.arange(start, size, step, dtype=dtype)
         # create ak version
-        aArange = ak.arange(start, size, stride, dtype=dtype)
+        aArange = ak.arange(start, size, step, dtype=dtype)
         assert np.allclose(nArange, aArange.to_ndarray())
 
     @pytest.mark.parametrize("size", pytest.prob_size)


### PR DESCRIPTION
Closes #4321 

This addresses the bug Engin noted in Issue 4321.  It no longer uses kwargs, and it should behave the same way numpy does.  That is, I've tested it with:

pda = ak.arange(10)         # same as if you said ak.arange(0,10,1)
pda = ak.arange(1,10)     # same as if you said ak.arange(1,10,1)
pda = ak.arange(1,10,2)

and in each case, it treats the numbers the same way numpy does.

There is still some anomalous behavior in here.  It only handles integers (I don't know the history behind that), and removing the **kwarg aspect caused mypy issues because xp.arange calls it with floats.  For that matter, xp.arange claims to return floats, but it doesn't.  In fact, test_flip and test_roll fail if it returns floats.

Anomalous behavior aside (and perhaps that's for another issue), I believe this particular bug is fixed.