### PR TITLE
Part 3 of #3964:  Refactor benchmark handling of running mode

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,9 @@
 import importlib
+import importlib.util
 import os
 import subprocess
 import sys
-from typing import Iterable
+from typing import Iterable, Iterator
 
 import pytest
 import scipy
@@ -91,35 +92,69 @@ def pytest_configure(config):
     pytest.temp_directory = config.getoption("--temp-directory")
 
 
-@pytest.fixture(scope="session", autouse=True)
-def startup_teardown():
-    test_running_mode = pytest.test_running_mode
-
+def _ensure_plugins_installed():
     if not importlib.util.find_spec("pytest") or not importlib.util.find_spec("pytest_env"):
         raise EnvironmentError("pytest and pytest-env must be installed")
-    if TestRunningMode.CLASS_SERVER == test_running_mode:
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _global_server() -> Iterator[None]:
+    """
+    In GLOBAL_SERVER mode, start exactly one Arkouda server for the entire session.
+    No-op in CLASS_SERVER or CLIENT mode.
+
+    Yields
+    ------
+    None
+        Control returns to pytest to execute all tests in the session, then comes
+        back here to tear down the server once the session is complete.
+    """
+    _ensure_plugins_installed()
+
+    if pytest.test_running_mode == TestRunningMode.GLOBAL_SERVER:
+        host, port, proc = start_arkouda_server(numlocales=pytest.nl, port=pytest.port)
+        pytest.server = host
+        print(f"Started arkouda_server in GLOBAL_SERVER mode on {host}:{port} ({pytest.nl} locales)")
+
         try:
-            pytest.server, _, _ = start_arkouda_server(numlocales=pytest.nl, port=pytest.port)
-            print(
-                "Started arkouda_server in TEST_CLASS mode with host: {} port: {} locales: {}".format(
-                    pytest.server, pytest.port, pytest.nl
-                )
-            )
-        except Exception as e:
-            raise RuntimeError(
-                f"in configuring or starting the arkouda_server: {e}, check "
-                + "environment and/or arkouda_server installation"
-            )
+            yield
+        finally:
+            try:
+                stop_arkouda_server()
+            except Exception:
+                pass
     else:
-        print("in client stack test mode with host: {} port: {}".format(pytest.server, pytest.port))
+        # No server in CLASS_SERVER or CLIENT mode
+        yield
 
-    yield
 
-    if TestRunningMode.CLASS_SERVER == test_running_mode:
+@pytest.fixture(scope="module", autouse=True)
+def _module_server() -> Iterator[None]:
+    """
+    In CLASS_SERVER mode, start/stop Arkouda once per module.
+    No-op in GLOBAL_SERVER or CLIENT mode.
+
+    Yields
+    ------
+    None
+        Control returns to pytest to run the module’s tests, then this fixture
+        resumes here to stop the server once the module is complete.
+    """
+    if pytest.test_running_mode == TestRunningMode.CLASS_SERVER:
+        host, port, proc = start_arkouda_server(numlocales=pytest.nl, port=pytest.port)
+        pytest.server = host
+        print(f"Started arkouda_server in CLASS_SERVER mode on {host}:{port} ({pytest.nl} locales)")
+
         try:
-            stop_arkouda_server()
-        except Exception:
-            pass
+            yield
+        finally:
+            try:
+                stop_arkouda_server()
+            except Exception:
+                pass
+    else:
+        # No server in GLOBAL_SERVER or CLIENT mode
+        yield
 
 
 @pytest.fixture(scope="class", autouse=True)


### PR DESCRIPTION
This PR separates out the handling of `CLASS_SERVER` mode and `GLOBAL_SERVER` mode in the `conftest.py` for both the unit tests and the benchmarks.  This corrects an error where the `GLOBAL_SERVER` mode did not start an arkouda server and therefore duplicated the behavior of `CLIENT` mode.

`CLIENT` mode should not start a sever, but assumes arkouda can connect to a pre-existing server.  `GLOBAL_SERVER` mode should start a server once and be used for all tests across all modules.  In `CLASS_SERVER` mode, a new server will start before the tests for each module and stop after the tests for that module are completed.

Part 3 of #3964:  Refactor benchmark handling of running mode