### PR TITLE
Closes #4386 add docstr-coverage

### DIFF
--- a/.docstr.yaml
+++ b/.docstr.yaml
@@ -1,0 +1,9 @@
+paths:                # files or directories to analyze
+  - arkouda
+exclude: .*/tests     # regex to skip test files
+skip_magic: True      # ignore __dunder__ methods (except __init__)
+skip_init: True       # ignore __init__ methods
+skip_private: True    # ignore names starting with _
+fail_under: 76.0        # exit non-zero if coverage < 76%
+badge: docs/badge.svg # generate an SVG badge
+

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -120,6 +120,20 @@ jobs:
       run: |
         make doc
 
+  docstr-cov:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with: { python-version: '3.x' }
+      - name: Install dependencies
+        run: pip install docstr-coverage
+      - name: Run docstring coverage
+        run: |
+          mkdir -p docs
+          make docstr-coverage
+
   flake8:
     runs-on: ubuntu-latest
     container:

--- a/Makefile
+++ b/Makefile
@@ -710,6 +710,10 @@ format: isort ruff-format check-doc-examples
 darglint: 
 	#   Check darglint linter for doc strings:
 	darglint -v 2 arkouda
+	
+docstr-coverage:
+	#   Check coverage for doc strings:
+	docstr-coverage arkouda --config .docstr.yaml
 
 
 #################

--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -56,3 +56,4 @@ dependencies:
     - linkify-it-py
     - ruff==0.11.2
     - pydoclint[flake8]==0.6.6
+    - docstr-coverage


### PR DESCRIPTION
This PR adds make `docstr-coverage`, which runs the `docstr-coverage` tool over the `arkouda` directory and computes the percentage of docstring coverage.  It also adds a check to the CI to ensure coverage stays above a certain level.

`docstr-coverage`:  This library measures docstring coverage in Python code, identifying functions, classes, methods, and modules lacking docstrings. It provides statistics on overall docstring coverage for files and projects. 


Closes #4386 add docstr-coverage