### PR TITLE
Part of #2384: Auto checkpoint upon exceeding memory percentage or idle time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -768,6 +768,7 @@ print-%:
 size=100
 test-python:
 	python3 -m pytest -c pytest.ini --size=$(size) $(ARKOUDA_PYTEST_OPTIONS)
+	python3 -m pytest -c pytest.opts.ini --size=$(size) $(ARKOUDA_PYTEST_OPTIONS)
 
 CLEAN_TARGETS += test-clean
 .PHONY: test-clean

--- a/arkouda/io_util.py
+++ b/arkouda/io_util.py
@@ -66,6 +66,7 @@ def delimited_file_to_dict(path: str, delimiter: str = ",") -> Dict[str, str]:
     Return a dictionary populated by lines from a file where
     the first delimited element of each line is the key and
     the second delimited element is the value.
+    If the file does not exist, return an empty dictionary.
 
     Parameters
     ----------
@@ -84,16 +85,21 @@ def delimited_file_to_dict(path: str, delimiter: str = ",") -> Dict[str, str]:
     ------
     UnsupportedOperation
         Raised if there's an error in reading the file
+    ValueError
+        Raised if a line has more or fewer than two delimited elements
 
     """
     values: Dict[str, str] = {}
 
-    with open(path, "a+") as f:
-        f.seek(0)
-        for line in f:
-            line = line.rstrip()
-            key, value = line.split(delimiter)
-            values[key] = value
+    try:
+        with open(path, "r") as f:
+            for line in f:
+                line = line.rstrip()
+                key, value = line.split(delimiter)
+                values[key] = value
+    except FileNotFoundError:
+        pass  # return an empty dictionary
+
     return values
 
 
@@ -152,3 +158,20 @@ def delete_directory(dir: str) -> None:
             shutil.rmtree(dir)
         except OSError as e:
             print("Error: %s - %s." % (e.filename, e.strerror))
+
+
+def directory_exists(dir: str) -> bool:
+    """
+    Return True if the directory exists.
+
+    Parameters
+    ----------
+    dir : str
+        The path to the directory
+
+    Returns
+    -------
+    True if the directory exists, False otherwise.
+
+    """
+    return isdir(dir)

--- a/pytest.ini
+++ b/pytest.ini
@@ -65,6 +65,7 @@ norecursedirs =
     build
     *egg*
     tests/deprecated
+    tests/optioned-server
     benchmark*
 python_functions =
     test_*

--- a/pytest.opts.ini
+++ b/pytest.opts.ini
@@ -1,0 +1,25 @@
+[pytest]
+
+# pytest configuration file for tests/optioned-server
+
+filterwarnings =
+    ignore:Version mismatch between client .*
+
+testpaths =
+    tests/optioned-server/auto-checkpoints.py
+
+#norecursedirs =
+#    .git
+
+python_functions =
+    test_*
+
+env =
+    D:ARKOUDA_SERVER_HOST=localhost
+    D:ARKOUDA_SERVER_PORT=5555
+    D:ARKOUDA_RUNNING_MODE=CLASS_SERVER
+    D:ARKOUDA_VERBOSE=True
+    D:ARKOUDA_CLIENT_TIMEOUT=0
+    D:ARKOUDA_LOG_LEVEL=DEBUG
+
+# markers =

--- a/src/CommandMap.chpl
+++ b/src/CommandMap.chpl
@@ -1,6 +1,7 @@
 module CommandMap {
   use Message;
   use MultiTypeSymbolTable;
+  import ServerDaemon;
 
   use JSON;
   use IO;
@@ -38,6 +39,12 @@ module CommandMap {
         moduleMap.add(cmd, (modName, line));
     }
   }
+
+  /* Support for asynchronous checkpointing. */
+  proc emptyStartAsyncCheckpointDaemon(sd: borrowed ServerDaemon.DefaultServerDaemon) {
+    return false;
+  }
+  var funStartAsyncCheckpointDaemon = emptyStartAsyncCheckpointDaemon;
 
   proc writeUsedModulesJson(ref mods: set(string)) {
     const cfgFile = try! open("UsedModules.json", ioMode.cw),

--- a/src/Logging.chpl
+++ b/src/Logging.chpl
@@ -149,19 +149,19 @@ module Logging {
             }
         }
         
-        proc critical(moduleName, routineName, lineNumber, msg: string) throws {
+        proc error(moduleName, routineName, lineNumber, msg: string) throws {
             try {
                 this.outputHandler.write(generateLogMessage(moduleName, routineName, lineNumber, 
-                                            msg, "CRITICAL"));
+                                            msg, "ERROR"));
             } catch (e: Error) {
                 writeln(generateErrorMsg(moduleName, routineName, lineNumber, e));
             }            
         }
         
-        proc error(moduleName, routineName, lineNumber, msg: string) throws {
+        proc critical(moduleName, routineName, lineNumber, msg: string) throws {
             try {
                 this.outputHandler.write(generateLogMessage(moduleName, routineName, lineNumber, 
-                                            msg, "ERROR"));
+                                            msg, "CRITICAL"));
             } catch (e: Error) {
                 writeln(generateErrorMsg(moduleName, routineName, lineNumber, e));
             }

--- a/src/Message.chpl
+++ b/src/Message.chpl
@@ -71,6 +71,24 @@ module Message {
         );
     }
 
+    proc type MsgTuple.warning(msg: string): MsgTuple {
+        return new MsgTuple(
+            msg = msg,
+            msgType = MsgType.WARNING,
+            msgFormat = MsgFormat.STRING,
+            payload = b""
+        );
+    }
+
+    proc type MsgTuple.error(msg: string): MsgTuple {
+        return new MsgTuple(
+            msg = msg,
+            msgType = MsgType.ERROR,
+            msgFormat = MsgFormat.STRING,
+            payload = b""
+        );
+    }
+
     /*
         Create a MsgTuple indicating to the client that a new symbol was created
     */
@@ -126,15 +144,6 @@ module Message {
         return new MsgTuple(
             msg = "%s %s".format(dTypeName, NumPyDType.type2fmt(t)).format(scalar),
             msgType = MsgType.NORMAL,
-            msgFormat = MsgFormat.STRING,
-            payload = b""
-        );
-    }
-
-    proc type MsgTuple.error(msg: string): MsgTuple {
-        return new MsgTuple(
-            msg = msg,
-            msgType = MsgType.ERROR,
             msgFormat = MsgFormat.STRING,
             payload = b""
         );
@@ -492,7 +501,7 @@ module Message {
                 }
             }
 
-            throw new owned ErrorWithContext("JSON argument key Not Found; %s".format(key),
+            throw new owned ErrorWithContext("JSON argument key Not Found: %s".format(key),
                                              getLineNumber(),
                                              getRoutineName(),
                                              getModuleName(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,7 +123,7 @@ def startup_teardown():
 
 
 @pytest.fixture(scope="class", autouse=True)
-def manage_connection():
+def manage_connection(_class_server):
     import arkouda as ak
 
     try:
@@ -140,6 +140,12 @@ def manage_connection():
         ak.disconnect()
     except Exception as e:
         raise ConnectionError(e)
+
+
+# subdirectories can override this, for example to start per-class server
+@pytest.fixture(scope="class", autouse=True)
+def _class_server(request):
+    yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/io_util_test.py
+++ b/tests/io_util_test.py
@@ -20,20 +20,21 @@ class TestIOUtil:
 
     def test_write_line_to_file(self):
         with tempfile.TemporaryDirectory(dir=self.io_test_dir_base) as tmp_dirname:
-            io_util.write_line_to_file(
-                path=f"{tmp_dirname}/testfile.txt", line="localhost:5555,9ty4h6olr4"
-            )
-            assert os.path.exists(f"{tmp_dirname}/testfile.txt")
+            test_file = f"{tmp_dirname}/testfile.txt"
+            test_line = "localhost:5555,9ty4h6olr4"
+            io_util.write_line_to_file(path=test_file, line=test_line)
+            assert os.path.exists(test_file)
+            assert open(test_file).read() == f"{test_line}\n"
+            io_util.write_line_to_file(test_file, "line2")
+            assert open(test_file).read() == f"{test_line}\nline2\n"
 
     def test_delimited_file_to_dict(self):
         with tempfile.TemporaryDirectory(dir=self.io_test_dir_base) as tmp_dirname:
             file_name = f"{tmp_dirname}/testfile.txt"
-            io_util.write_line_to_file(path=file_name, line="localhost:5555,9ty4h6olr4")
-            io_util.write_line_to_file(path=file_name, line="127.0.0.1:5556,6ky3i91l17")
-            values = io_util.delimited_file_to_dict(path=file_name, delimiter=",")
-            assert values
-            assert "9ty4h6olr4" == values["localhost:5555"]
-            assert "6ky3i91l17" == values["127.0.0.1:5556"]
+            values = {"localhost:5555": "9ty4h6olr4", "127.0.0.1:5556": "6ky3i91l17"}
+            io_util.dict_to_delimited_file(file_name, values, ",")
+            values_read = io_util.delimited_file_to_dict(path=file_name, delimiter=",")
+            assert values_read == values
 
     def test_delete_directory(self):
         path = f"{pytest.temp_directory}/test_dir"
@@ -48,3 +49,8 @@ class TestIOUtil:
 
         # Check no error when run on non-existant directory:
         io_util.delete_directory(path)
+
+    def test_directory_exists(self):
+        with tempfile.TemporaryDirectory(dir=self.io_test_dir_base) as tmp_dirname:
+            assert io_util.directory_exists(tmp_dirname)
+            assert not io_util.directory_exists(f"{tmp_dirname}/xyz")

--- a/tests/optioned-server/auto-checkpoints.py
+++ b/tests/optioned-server/auto-checkpoints.py
@@ -1,0 +1,113 @@
+from time import sleep
+
+import pytest
+
+import arkouda as ak
+from arkouda.io_util import delete_directory, directory_exists
+
+autockptPath = ".akdata"
+autockptName = "auto_checkpoint"
+autockptDir = f"{autockptPath}/{autockptName}"
+
+
+def directory_exists_delayed(path, num_delays, delay=0.1):
+    """
+    Repeats directory_exists() query num_delays times,
+    each after a delay of `delay` seconds.
+    This allows us to adjust for the server that can delay
+    the detection of a condition by --checkpointCheckInterval, if set,
+    otherwise by min(--checkpointIdleTime, --checkpointMemPctDelay).
+    """
+    for _ in range(num_delays):
+        if directory_exists(path):
+            return True
+        sleep(delay)
+    return directory_exists(path)
+
+
+class TestIdleAndInterval:
+    class_server_args = [
+        "--checkpointIdleTime=1",
+        "--checkpointInterval=3",
+    ]
+
+    def test_idletime_and_interval(self):
+        """
+        Check the following sequence of events, numbers indicating wait seconds:
+          perform server activity
+          0.5 [less than checkpointIdleTime since activity]
+          verify no auto-checkpoint
+          1.0 [more than checkpointIdleTime since activity]
+          veryfy an auto-checkpoint exists
+          another server activity
+          2.0 [more than checkpointIdleTime since latest activity,
+               less than checkpointInterval since latest checkpoint]
+          verify no new auto-checkpoint
+          1.0 [more than checkpointIdleTime since latest activity,
+               more than checkpointInterval since latest checkpoint]
+          verify a new auto-checkpoint exists
+        """
+
+        delete_directory(autockptDir)  # start with a clean slate
+        a = ak.ones(pytest.prob_size[0])
+        sleep(0.5)
+        assert not directory_exists(autockptDir)
+        sleep(1)
+        assert directory_exists_delayed(autockptDir, 10)
+        delete_directory(autockptDir)
+        b = ak.ones(pytest.prob_size[0])
+        sleep(2)
+        assert not directory_exists(autockptDir)
+        sleep(1)
+        assert directory_exists_delayed(autockptDir, 10)
+        delete_directory(autockptDir)
+        del a, b  # avoid flake8 errors about unused a,b
+
+
+class TestMemPct:
+    class_server_args = [
+        "--checkpointMemPct=5",
+        "--checkpointMemPctDelay=1",
+        "--checkpointInterval=1",
+    ]
+
+    def test_memory_percentage(self):
+        """
+        Check the following sequence of events. While class_server_args sets
+        checkpointMemPctDelay and checkpointInterval to 1 second, we pad it.
+        First, directory_exists_delayed() allows the CP daemon to wake up
+        the first time in just under 1 second after server activity, realize that
+        the waiting time of 1 second has not passed, then sleep for another
+        1 second before taking action. We add 0.5 seconds on top of that
+        to ensure the server completes whatever action it takes.
+
+        Here is the expected sequence:
+          allocate small memory
+          2.5 [more than checkpointMemPctDelay since activity]
+          verify no auto-checkpoint
+          allocate "big" memory, i.e., over checkpointMemPct
+          2.5 [more than checkpointMemPctDelay since activity]
+          verify an auto-checkpoint exists
+          2.5 [more than checkpointInterval since last checkpoint]
+          verify no new auto-checkpoint, since no server activity since last A-CP
+          perform server activity
+          2.5 [more than checkpointMemPctDelay since activity]
+          verify a new auto-checkpoint exists
+        """
+
+        delete_directory(autockptDir)  # start with a clean slate
+        avail_mem = ak.get_mem_avail()
+        small_array = ak.zeros(100)  # below memory threshold
+        sleep(2.5)
+        assert not directory_exists(autockptDir)
+        big_array = ak.zeros(int(avail_mem / 140))  # over 5% of avail_mem
+        sleep(1.5)
+        assert directory_exists_delayed(autockptDir, 10)
+        delete_directory(autockptDir)
+        sleep(2.5)
+        assert not directory_exists(autockptDir)
+        del small_array
+        sleep(1.5)
+        assert directory_exists_delayed(autockptDir, 10)
+        delete_directory(autockptDir)
+        del big_array  # avoid flake8 errors about unused big_array

--- a/tests/optioned-server/conftest.py
+++ b/tests/optioned-server/conftest.py
@@ -1,0 +1,104 @@
+# Tests in this directory use the server started with added custom options.
+#
+# server launched PER MODULE:
+#   define the global `module_server_args`
+#
+# server launched PER CLASS:
+#   define the class variable `class_server_args` in each class
+#
+# Each module must do one or the other, not both.
+# These "server_args" variables, when defined, must be lists of strings.
+# `test_running_mode` and `ARKOUDA_RUNNING_MODE` are ignored.
+#
+# `<parent dir>/conftest.py` still applies - except for the fixtures
+# overriden by this conftest.
+#
+# `ARKOUDA_HOME/pytest.opts.ini` configures pytest for this directory.
+
+import importlib
+from typing import Iterator
+
+import pytest
+
+from server_util.test.server_test_util import start_arkouda_server, stop_arkouda_server
+
+
+def _ensure_plugins_installed():
+    if not importlib.util.find_spec("pytest") or not importlib.util.find_spec("pytest_env"):
+        raise EnvironmentError("pytest and pytest-env must be installed")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def startup_teardown():
+    _ensure_plugins_installed()
+    yield
+
+
+# convenience shortcuts #
+
+
+def _module_args(req):
+    return req.module.__name__ + ".module_server_args "
+
+
+def _class_args(req):
+    return req.module.__name__ + "." + req.cls.__name__ + ".class_server_args "
+
+
+def _module_error_msg(req, args):
+    return _module_args(req) + "is not a list: " + str(args)
+
+
+def _class_error_msg(req, args):
+    return _class_args(req) + "is not a list: " + str(args)
+
+
+# returns ServerInfo(host, port, process)
+def _my_start_server(server_args):
+    return start_arkouda_server(numlocales=pytest.nl, port=pytest.port, server_args=server_args)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _module_server(request) -> Iterator[None]:
+    module_server_args = getattr(request.module, "module_server_args", None)
+    if module_server_args is not None:
+        if type(module_server_args) is not list:
+            raise TypeError(_module_error_msg(request, module_server_args))
+        _my_start_server(module_server_args)
+        pytest.module_server_launched = True
+
+        yield
+
+        stop_arkouda_server()
+        pytest.module_server_launched = False
+    else:
+        # arkouda server will start for each class
+        pytest.module_server_launched = False
+
+        yield
+
+
+@pytest.fixture(scope="class", autouse=True)
+def _class_server(request) -> Iterator[None]:
+    r = request
+    class_server_args = getattr(r.cls, "class_server_args", None)
+    if class_server_args is not None:
+        if pytest.module_server_launched:
+            raise RuntimeError("both " + _module_args(r) + "and " + _class_args(r) + "are given")
+        if type(class_server_args) is not list:
+            raise TypeError(_class_error_msg(r, class_server_args))
+        _my_start_server(class_server_args)
+
+        yield
+
+        stop_arkouda_server()
+    else:
+        if not pytest.module_server_launched:
+            raise RuntimeError("neither " + _module_args(r) + "nor " + _class_args(r) + "is given")
+
+        yield
+
+
+# NB ak.connect() and ak.disconnect() are invoked in the parent conftest.py, see:
+#  @pytest.fixture(scope="class", autouse=True)
+#  def manage_connection(_class_server):


### PR DESCRIPTION
Address part of #2384. Replaces #4378.

The server now automatically saves a checkpoint if memory usage exceeded a threshold or if the server has been idle for a bit. This is disabled by default, see below. Requires `CheckpointMsg` module. Arkouda still builds without this module.

The following server options in `CheckpointMsg` module control the behavior:

* `checkpointMemPct` : Perform checkpointing automatically when memory usage exceeds this many percent of available memory. By default / if <=0, auto-checkpointing is not triggered by memory usage.

* `checkpointMemPctDelay` : When memory exceeds the `checkpointMemPct` threhsold, wait for this many seconds of idle time before checkpointing. By default / if <=0, uses 5 seconds.

* `checkpointIdleTime` : Perform checkpointing automatically when the server is idle for this many seconds. By default / if <=0, auto-checkpointing is not triggered by idle time.

* `checkpointCheckInterval` : The auto-checkpoint implementation will wake up every this many seconds to check if a checkpoint needs to be saved due to memory usage or idle time. By default / if <=0, uses min( checkpointMemPctDelay, checkpointIdleTime ).

* `checkpointInterval` : Automatic checkpointing due to memory use or idle time will wait for at least this many seconds after any completed checkpoint save or load operations, whether automatic or client-initiated. By default / if <=0, uses 3600 (one hour). This avoids overly-frequent auto-checkpointing. The server does not need not be idle during this interval. Checkpoint operations requested by the client are not subject to this delay. 

If the server receives a message from the client while auto-checkpointing is in progress, it locks until auto-checkpointing completes.

This PR also introduces a framework for client testing with customer server options and invokes it as a sibling `pytest` command in `Makefile`. Such testing is configured using `pytest.opts.ini` and `tests/optioned-server/conftest.py` . It is used to test the functionality added in this PR.

While there: switch the order of error() and critical() in `src/Logging.chpl` to match the order in the enum; an analogous change in `src/Message.chpl`; open the file in read mode, not append, in `io_util.delimited_file_to_dict()`; added `io_util.directory_exists()`.

Next features to implement:
* The previous checkpoint is saved until the new checkpoint has successfully completed.
* The server informs the client that it is auto-saving a checkpoint.
* Tune the default thresholds, esp. `checkpointInterval` .
* Do not checkpoint until the first client connects to the server and has some activity.

The module-level variable `lastCkptCompletion` in CheckpointMsg.chpl should be specific to each `DefaultServerDaemon` instance rather than be a global. This is OK for now that we have only a single instance.