### PR TITLE
Closes #4165:  reshape function and max_bits handling

### DIFF
--- a/arkouda/numpy/pdarrayclass.py
+++ b/arkouda/numpy/pdarrayclass.py
@@ -2097,6 +2097,7 @@ class pdarray:
         if (not isinstance(shape, int)) and (not isinstance(shape, pdarray)):
             shape = [i for i in shape]
             lenshape = len(shape)
+
         return create_pdarray(
             generic_msg(
                 cmd=f"reshape<{self.dtype},{self.ndim},{lenshape}>",
@@ -2105,6 +2106,7 @@ class pdarray:
                     "shape": shape,
                 },
             ),
+            max_bits=self.max_bits,
         )
 
     def flatten(self):

--- a/tests/numpy/pdarrayclass_test.py
+++ b/tests/numpy/pdarrayclass_test.py
@@ -5,6 +5,7 @@ import pytest
 
 import arkouda as ak
 from arkouda.client import get_array_ranks, get_max_array_rank
+from arkouda.dtypes import bigint
 from arkouda.testing import assert_arkouda_array_equivalent
 from arkouda.testing import assert_equal as ak_assert_equal
 from arkouda.testing import assert_equivalent as ak_assert_equivalent
@@ -47,6 +48,13 @@ class TestPdarrayClass:
         size = 10
         x = ak.arange(size, dtype=dtype).reshape((1, size, 1))
         ak_assert_equal(x.flatten(), ak.arange(size, dtype=dtype))
+
+    def test_reshape_bigint_bug_4165_reproducer(self):
+        x = ak.arange(10, dtype=bigint)
+        x.max_bits = 64
+        assert x.max_bits == 64
+        y = x.reshape((10,))
+        assert y.max_bits == 64
 
     @pytest.mark.parametrize("dtype", DTYPES)
     def test_shape(self, dtype):


### PR DESCRIPTION
This PR fixes a bug in the `reshape` function so that the returned array will have the same `max_bits` value as the original `pdarray`.  It also adds a reproducer to the unit tests.

Closes #4165:  reshape function and max_bits handling