### PR TITLE
Closes #4402:  resolve DOC602 pydoclint errors

### DIFF
--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import Dict, List, Mapping, Optional, Tuple, Union, cast
 
 from arkouda import __version__, io_util, security
-from arkouda.logger import LogLevel, getArkoudaLogger
+from arkouda.logger import ArkoudaLogger, LogLevel, getArkoudaLogger
 from arkouda.message import (
     MessageFormat,
     MessageType,
@@ -225,12 +225,17 @@ class Channel:
         to the connect_url or generated from supplied server and port values
     user : str
         Arkouda user who will use the Channel to connect to the arkouda_server
-    token : str, optional
+    token : Union[str, None]
         Token used to connect to the arkouda_server if authentication is enabled
     logger : ArkoudaLogger
         ArkoudaLogger used for logging
 
     """
+
+    url: str
+    user: str
+    token: Union[str, None]
+    logger: ArkoudaLogger
 
     __slots__ = ("url", "user", "token", "logger")
 

--- a/arkouda/numpy/pdarraysetops.py
+++ b/arkouda/numpy/pdarraysetops.py
@@ -207,6 +207,9 @@ def in1d(
     from arkouda.alignment import NonUniqueError
     from arkouda.categorical import Categorical as Categorical_
 
+    ua: groupable
+    ub: groupable
+
     if isinstance(A, (pdarray, Strings, Categorical_)):
         if isinstance(A, (Strings, Categorical_)) and not isinstance(B, (Strings, Categorical_)):
             raise TypeError("Arguments must have compatible types, Strings/Categorical")
@@ -648,6 +651,9 @@ def intersect1d(A: groupable, B: groupable, assume_unique: bool = False) -> Unio
     """
     from arkouda.categorical import Categorical as Categorical_
 
+    ua: groupable
+    ub: groupable
+
     if (
         isinstance(A, (pdarray, Strings, Categorical_))
         and isinstance(B, (pdarray, Strings, Categorical_))
@@ -761,6 +767,9 @@ def setdiff1d(A: groupable, B: groupable, assume_unique: bool = False) -> Union[
     """
     from arkouda.categorical import Categorical as Categorical_
 
+    ua: groupable
+    ub: groupable
+
     if (
         isinstance(A, (pdarray, Strings, Categorical_))
         and isinstance(B, (pdarray, Strings, Categorical_))
@@ -864,6 +873,9 @@ def setxor1d(A: groupable, B: groupable, assume_unique: bool = False) -> Union[p
     [array([2 2 4 4 5 5]), array([2 5 2 4 4 5]), array([2 4 5 4 2 5])]
     """
     from arkouda.categorical import Categorical as Categorical_
+
+    ua: groupable
+    ub: groupable
 
     if (
         isinstance(A, (pdarray, Strings, Categorical_))

--- a/arkouda/numpy/strings.py
+++ b/arkouda/numpy/strings.py
@@ -12,7 +12,7 @@ from typeguard import typechecked
 import arkouda.numpy.dtypes
 from arkouda.client import generic_msg
 from arkouda.infoclass import information, list_symbol_table
-from arkouda.logger import getArkoudaLogger
+from arkouda.logger import ArkoudaLogger, getArkoudaLogger
 from arkouda.match import Match, MatchType
 from arkouda.numpy.dtypes import (
     NUMBER_FORMAT_STRINGS,
@@ -53,8 +53,8 @@ class Strings:
         The rank of the array (currently only rank 1 arrays supported)
     shape : tuple
         The sizes of each dimension of the array
-    dtype : dtype
-        The dtype is ak.str
+    dtype : type
+        The dtype is ak.str_
     logger : ArkoudaLogger
         Used for all logging operations
 
@@ -65,10 +65,15 @@ class Strings:
     raw bytes of all strings, delimited by nulls.
     """
 
+    entry: pdarray
+    size: int_scalars
+    nbytes: int_scalars
+    ndim: int_scalars
+    shape: Tuple[int]
+    logger: ArkoudaLogger
+
     BinOps = frozenset(["==", "!="])
     objType = "Strings"
-    size: int_scalars
-    shape: Tuple[int]
 
     @staticmethod
     def from_return_msg(rep_msg: str) -> Strings:

--- a/arkouda/pandas/join.py
+++ b/arkouda/pandas/join.py
@@ -302,11 +302,14 @@ def inner_join(
         keep12 = keep
     else:
         if whereargs is not None:
-            if not is_sequence:
+            right = whereargs[1]
+
+            left = whereargs[0]
+            if not isinstance(right, Sequence) and not isinstance(left, Sequence):
                 # Gather right whereargs
-                rightWhere = whereargs[1][byRight.permutation][ranges]
+                rightWhere = right[byRight.permutation][ranges]
                 # Expand left whereargs
-                keep_where = whereargs[0][keep]
+                keep_where = left[keep]
                 keep_where = keep_where.codes if isinstance(keep_where, Categorical) else keep_where
                 leftWhere = broadcast(fullSegs, keep_where, ranges.size)
             else:

--- a/arkouda/plotting.py
+++ b/arkouda/plotting.py
@@ -3,11 +3,13 @@ import math
 import numpy as np
 from matplotlib import pyplot as plt
 
+from arkouda.categorical import Categorical
 from arkouda.dataframe import DataFrame
 from arkouda.groupbyclass import GroupBy
 from arkouda.numpy import histogram, isnan
-from arkouda.numpy.pdarrayclass import skew
+from arkouda.numpy.pdarrayclass import pdarray, skew
 from arkouda.numpy.pdarraycreation import arange
+from arkouda.numpy.strings import Strings
 from arkouda.numpy.timeclass import Datetime, Timedelta, date_range, timedelta_range
 
 __all__ = [
@@ -132,6 +134,13 @@ def hist_all(ak_df: DataFrame, cols: list = []):
 
         except ValueError:
             GB_df = GroupBy(ak_df[col])
+
+            if not isinstance(GB_df.unique_keys, (Strings, Categorical, pdarray)):
+                raise TypeError(
+                    f"expected one of (Strings, Categorical, pdarray), "
+                    f"got {type(GB_df.unique_keys).__name__!r}"
+                )
+
             new_labels = arange(GB_df.unique_keys.size)
             newcol = GB_df.broadcast(new_labels)
             x = newcol[: ak_df.size]

--- a/arkouda/scipy/_stats_py.py
+++ b/arkouda/scipy/_stats_py.py
@@ -5,6 +5,7 @@ from numpy import asarray
 from scipy.stats import chi2  # type: ignore
 
 import arkouda as ak
+from arkouda.numpy import float64
 from arkouda.numpy.dtypes import float64 as akfloat64
 from arkouda.scipy.special import xlogy
 
@@ -17,9 +18,12 @@ class Power_divergenceResult(namedtuple("Power_divergenceResult", ("statistic", 
 
     Attributes
     ----------
-    statistic :    numpy.float64
-    pvalue :    numpy.float64
+    statistic :    float64
+    pvalue :    float64
     """
+
+    statistic: float64
+    pvalue: float64
 
 
 # Map from names to lambda_ values used in power_divergence().

--- a/arkouda/scipy/sparrayclass.py
+++ b/arkouda/scipy/sparrayclass.py
@@ -32,8 +32,8 @@ class sparray:
     ----------
     name : str
         The server-side identifier for the array
-    dtype : dtype
-        The element type of the array
+    dtype : type
+        The element dtype of the array
     size : int_scalars
         The size of any one dimension of the array (all dimensions are assumed to be equal sized for now)
     nnz: int_scalars
@@ -47,6 +47,15 @@ class sparray:
     itemsize : int_scalars
         The size in bytes of each element
     """
+
+    name: str
+    dtype: type
+    size: int_scalars
+    nnz: int_scalars
+    ndim: int_scalars
+    shape: Sequence[int]
+    layout: str
+    itemsize: int_scalars
 
     def __init__(
         self,

--- a/arkouda/testing/_asserters.py
+++ b/arkouda/testing/_asserters.py
@@ -316,7 +316,7 @@ def assert_index_equal(
             else:
                 mismatch = left != right
 
-            diff = aksum(mismatch.astype(int)).astype(float) * 100.0 / len(left)
+            diff = aksum(mismatch) * 100.0 / len(left)
             msg = f"{obj} values are different ({np.round(diff, 5)} %)"
             raise_assert_detail(obj, msg, left, right)
     else:
@@ -584,9 +584,9 @@ def assert_arkouda_pdarray_equal(
             if left.shape != right.shape:
                 raise_assert_detail(obj, f"{obj} shapes are different", left.shape, right.shape)
 
-            diff = aksum(left != right).astype(float)
+            diff = aksum(left != right)
 
-            diff = diff * 100.0 / left.size
+            diff = diff * 100.0 / float(left.size)
             msg = f"{obj} values are different ({np.round(diff, 5)} %)"
             raise_assert_detail(obj, msg, left, right, index_values=index_values)
 
@@ -727,8 +727,8 @@ def assert_arkouda_strings_equal(
 
     def _raise(left: Strings, right: Strings, err_msg):
         if err_msg is None:
-            diff = aksum(left != right).astype(float)
-            diff = diff * 100.0 / left.size
+            diff = aksum(left != right)
+            diff = diff * 100.0 / float(left.size)
             msg = f"{obj} values are different ({np.round(diff, 5)} %)"
             raise_assert_detail(obj, msg, left, right, index_values=index_values)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ extend_skip_glob = *__init__.py,*deprecated*,*.pyi,dep/*
 max-line-length = 105
 # keep all the default checks, plus F403 for "import *"
 extend-select = F403
-extend-ignore = E203,E712,W605,DOC107,DOC201,DOC101,DOC106,DOC103,DOC501,DOC503,DOC203,DOC105,DOC110,DOC502,DOC601,DOC603,DOC109,DOC102,DOC001,DOC301,DOC302,DOC602
+extend-ignore = E203,E712,W605,DOC107,DOC201,DOC101,DOC106,DOC103,DOC501,DOC503,DOC203,DOC105,DOC110,DOC502,DOC601,DOC603,DOC109,DOC102,DOC001,DOC301,DOC302,
 per-file-ignores =
     tests/operator_test.py: E501
     tests/symbol_table_test.py: F841


### PR DESCRIPTION
Resolves the `DOC606` `pydoclint` errors and removes the error code from the ignore field in the `setup.cfg`.

Closes #4402:  resolve DOC602 pydoclint errors