### PR TITLE
Adds negative axis handling to squeeze

### DIFF
--- a/src/ManipulationMsg.chpl
+++ b/src/ManipulationMsg.chpl
@@ -834,7 +834,6 @@ module ManipulationMsg {
     const name = msgArgs["name"],
           nAxes = msgArgs["nAxes"].toScalar(int),
           axes = msgArgs["axes"].toScalarArray(int, nAxes);
-
     var eIn = st[name]: borrowed SymEntry(array_dtype, array_nd_in),
         (valid, shape, mapping) = validateSqueeze(eIn.tupShape, axes, array_nd_out);
 
@@ -875,8 +874,11 @@ module ManipulationMsg {
     if NOut > NIn then return (false, shapeOut, mapping);
     if d.size >= NIn then return (false, shapeOut, mapping);
 
+    const (valid, axes_) = validateNegativeAxes(axes, NIn);
+    if !valid then return (false, shapeOut, mapping);
+
     var degenAxes: NIn*bool;
-    for axis in axes {
+    for axis in axes_ {
       if shape[axis] != 1 then return (false, shapeOut, mapping);
       degenAxes[axis] = true;
     }

--- a/tests/numpy/manipulation_functions_test.py
+++ b/tests/numpy/manipulation_functions_test.py
@@ -164,6 +164,8 @@ class TestNumpyManipulationFunctions:
 
         x = ak.arange(size, dtype=dtype).reshape((1, size, 1))
         assert_equal(ak.squeeze(x, axis=None), ak.arange(size, dtype=dtype))
+        assert_equal(ak.squeeze(x, axis=-3), ak.arange(size, dtype=dtype).reshape((size, 1)))
+        assert_equal(ak.squeeze(x, axis=-1), ak.arange(size, dtype=dtype).reshape((1, size)))
         assert_equal(ak.squeeze(x, axis=0), ak.arange(size, dtype=dtype).reshape((size, 1)))
         assert_equal(ak.squeeze(x, axis=2), ak.arange(size, dtype=dtype).reshape((1, size)))
         assert_equal(ak.squeeze(x, axis=(0, 2)), ak.arange(size, dtype=dtype))


### PR DESCRIPTION
Closes #4405, a sub-issue of 4125.  Numpy functions allow for negative numbers in the axis argument (e.g. -1 means the last axis, -2 the next-to-last, etc).  Arkouda has such functionality server-side, but it's not used consistently.  This PR is part of a series that aims to correct that.