### PR TITLE
Closes #4282:  add doctest to strings module

### DIFF
--- a/arkouda/numpy/numeric.py
+++ b/arkouda/numpy/numeric.py
@@ -2964,6 +2964,7 @@ def quantile(
 
     Examples
     --------
+    >>> import arkouda as ak
     >>> a = ak.array([[1,2,3,4,5],[1,2,3,4,5]])
     >>> q = 0.7
     >>> ak.quantile(a,q,axis=None,method="linear")
@@ -3012,7 +3013,7 @@ def quantile(
         if (q_ < 0.0).any() or (q_ > 1.0).any():  # type: ignore
             raise ValueError("Values of q in quantile must be in range [0,1].")
 
-    if not (method in ALLOWED_PERQUANT_METHODS):
+    if method not in ALLOWED_PERQUANT_METHODS:
         raise ValueError(f"Method {method} is not supported in quantile.")
 
     # scalar q, no axis slicing
@@ -3137,6 +3138,7 @@ def percentile(
 
     Examples
     --------
+    >>> import arkouda as ak
     >>> a = ak.array([[1,2,3,4,5],[1,2,3,4,5]])
     >>> q = 70
     >>> ak.percentile(a,q,axis=None,method="linear")

--- a/arkouda/numpy/strings.py
+++ b/arkouda/numpy/strings.py
@@ -402,10 +402,10 @@ class Strings:
         >>> s = ak.array(["a", "b", "c"])
         >>> s_cpy = ak.array(["a", "b", "c"])
         >>> s.equals(s_cpy)
-        True
+        np.True_
         >>> s2 = ak.array(["a", "x", "c"])
         >>> s.equals(s2)
-        False
+        np.False_
         """
         if isinstance(other, Strings):
             if other.size != self.size:
@@ -445,9 +445,10 @@ class Strings:
 
         Example
         -------
+        >>> import arkouda as ak
         >>> x = ak.array(['one', 'two', 'three'])
         >>> x.get_bytes()
-        [111 110 101 0 116 119 111 0 116 104 114 101 101 0]
+        array([111 110 101 0 116 119 111 0 116 104 114 101 101 0])
         """
         if self._bytes is None or self._bytes.name not in list_symbol_table():
             self._bytes = create_pdarray(
@@ -470,9 +471,10 @@ class Strings:
 
         Example
         -------
+        >>> import arkouda as ak
         >>> x = ak.array(['one', 'two', 'three'])
         >>> x.get_offsets()
-        [0 4 8]
+        array([0 4 8])
         """
         if self._offsets is None or self._offsets.name not in list_symbol_table():
             self._offsets = create_pdarray(

--- a/tests/numpy/string_test.py
+++ b/tests/numpy/string_test.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 
 import arkouda as ak
+from arkouda.numpy import strings
 from arkouda.testing import assert_equal as ak_assert_equal
 
 ak.verbose = False
@@ -14,11 +15,11 @@ UNIQUE = N // 4
 
 
 class TestString:
-    # def test_strings_docstrings(self):
-    #     import doctest
-    #
-    #     result = doctest.testmod(strings, optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)
-    #     assert result.failed == 0, f"Doctest failed: {result.failed} failures"
+    def test_strings_docstrings(self):
+        import doctest
+
+        result = doctest.testmod(strings, optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)
+        assert result.failed == 0, f"Doctest failed: {result.failed} failures"
 
     Gremlins = namedtuple(
         "Gremlins",


### PR DESCRIPTION
This PR adds a doctest unit tests to `strings_test.py` and corrects the discovered errors in the examples from the `strings` module.

Closes #4282:  add doctest to strings module
