### PR TITLE
Closes #4291:  add doctest to _stats_py module

### DIFF
--- a/arkouda/scipy/_stats_py.py
+++ b/arkouda/scipy/_stats_py.py
@@ -73,14 +73,15 @@ def power_divergence(f_obs, f_exp=None, ddof=0, lambda_=None):
     --------
 
     >>> import arkouda as ak
-    >>> ak.connect()
-    >>> from arkouda.stats import power_divergence
+    >>> from arkouda.scipy import power_divergence
     >>> x = ak.array([10, 20, 30, 10])
     >>> y = ak.array([10, 30, 20, 10])
     >>> power_divergence(x, y, lambda_="pearson")
-    Power_divergenceResult(statistic=8.333333333333334, pvalue=0.03960235520756414)
+    Power_divergenceResult(statistic=np.float64(8.333333333333334),
+        pvalue=np.float64(0.03960235520756414))
     >>> power_divergence(x, y, lambda_="log-likelihood")
-    Power_divergenceResult(statistic=8.109302162163285, pvalue=0.04380595350226197)
+    Power_divergenceResult(statistic=np.float64(8.109302162163285),
+        pvalue=np.float64(0.04380595350226197))
 
     See Also
     -------
@@ -190,10 +191,10 @@ def chisquare(f_obs, f_exp=None, ddof=0):
     --------
 
     >>> import arkouda as ak
-    >>> ak.connect()
-    >>> from arkouda.stats import chisquare
+    >>> from arkouda.scipy import chisquare
     >>> chisquare(ak.array([10, 20, 30, 10]), ak.array([10, 30, 20, 10]))
-    Power_divergenceResult(statistic=8.333333333333334, pvalue=0.03960235520756414)
+    Power_divergenceResult(statistic=np.float64(8.333333333333334),
+        pvalue=np.float64(0.03960235520756414))
 
 
     See Also

--- a/tests/scipy/scipy_test.py
+++ b/tests/scipy/scipy_test.py
@@ -37,6 +37,16 @@ def bumpup(a):
 
 
 class TestStats:
+    from arkouda.scipy import _stats_py as stats
+
+    def test_scipy_stats_py_docstrings(self):
+        import doctest
+
+        from arkouda.scipy import _stats_py as stats
+
+        result = doctest.testmod(stats, optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)
+        assert result.failed == 0, f"Doctest failed: {result.failed} failures"
+
     @pytest.mark.skip_if_scipy_version_greater_than("1.13.1")
     @pytest.mark.parametrize(
         "lambda_",

--- a/tests/scipy/special_tests.py
+++ b/tests/scipy/special_tests.py
@@ -7,9 +7,18 @@ from arkouda.scipy.special import xlogy
 
 
 class TestStats:
+    def test_scipy_special_docstrings(self):
+        import doctest
+
+        from arkouda.scipy import special
+
+        result = doctest.testmod(special, optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)
+        assert result.failed == 0, f"Doctest failed: {result.failed} failures"
+
     @pytest.mark.parametrize("np_x", [3, 5, np.float64(6), np.array([1.0, 2.0, 4.5])])
     @pytest.mark.parametrize(
-        "np_y", [np.array([1, 2, 3]), np.array([10, 100, 100]), np.array([-1, 0, np.nan])]
+        "np_y",
+        [np.array([1, 2, 3]), np.array([10, 100, 100]), np.array([-1, 0, np.nan])],
     )
     def test_xlogy(self, np_x, np_y):
         x = ak.array(np_x) if isinstance(np_x, np.ndarray) else np_x


### PR DESCRIPTION
This PR adds a doctest unit tests to `scipy_test.py` and corrects the discovered errors in the examples from the `arkouda.scipy._stats_py` module.

Closes #4291:  add doctest to _stats_py module
Closes #4289:  add doctest to scipy/special module