### PR TITLE
Closes #4288:  add doctest to sparsematrix module

### DIFF
--- a/arkouda/numpy/sorting.py
+++ b/arkouda/numpy/sorting.py
@@ -71,16 +71,19 @@ def argsort(
     Examples
     --------
     >>> import arkouda as ak
-    >>> a = ak.randint(0, 10, 10)
+    >>> a = ak.randint(0, 10, 10, seed=1)
+    >>> a
+    array([7 9 5 1 4 1 8 5 5 0])
+
     >>> perm = ak.argsort(a)
     >>> a[perm]
-    array([0 1 3 3 5 5 5 6 6 6])
+    array([0 1 1 4 5 5 5 7 8 9])
 
     >>> ak.argsort(a, ak.sorting.SortingAlgorithm["RadixSortLSD"])
-    array([0 2 9 6 8 1 3 5 7 4])
+    array([9 3 5 4 2 7 8 0 6 1])
 
     >>> ak.argsort(a, ak.sorting.SortingAlgorithm["TwoArrayRadixSort"])
-    array([0 2 9 6 8 1 3 5 7 4])
+    array([9 3 5 4 2 7 8 0 6 1])
     """
     from arkouda.categorical import Categorical
 
@@ -269,10 +272,12 @@ def sort(
     Examples
     --------
     >>> import arkouda as ak
-    >>> a = ak.randint(0, 10, 10)
+    >>> a = ak.randint(0, 10, 10, seed=1)
+    >>> a
+    array([7 9 5 1 4 1 8 5 5 0])
     >>> sorted = ak.sort(a)
     >>> sorted
-    array([0 1 1 3 4 5 7 8 8 9])
+    array([0 1 1 4 5 5 5 7 8 9])
     """
     if pda.dtype == bigint:
         return pda[coargsort(pda.bigint_to_uint_arrays(), algorithm)]

--- a/tests/numpy/sort_test.py
+++ b/tests/numpy/sort_test.py
@@ -24,11 +24,13 @@ def np_is_sorted(arr):
 
 
 class TestSort:
-    # def test_sort_docstrings(self):
-    #     import doctest
-    #
-    #     result = doctest.testmod(sort, optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)
-    #     assert result.failed == 0, f"Doctest failed: {result.failed} failures"
+    def test_sorting_docstrings(self):
+        import doctest
+
+        from arkouda.numpy import sorting
+
+        result = doctest.testmod(sorting, optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)
+        assert result.failed == 0, f"Doctest failed: {result.failed} failures"
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", [ak.float64, ak.uint64, ak.float64])

--- a/tests/scipy/sparse_test.py
+++ b/tests/scipy/sparse_test.py
@@ -9,6 +9,16 @@ from arkouda.scipy.sparsematrix import (
 
 
 class TestSparse:
+    def test_sparrayclass_docstrings(self):
+        import doctest
+
+        from arkouda.scipy import sparrayclass
+
+        result = doctest.testmod(
+            sparrayclass, optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE
+        )
+        assert result.failed == 0, f"Doctest failed: {result.failed} failures"
+
     def test_utils(self):
         csc = random_sparse_matrix(10, 0.2, "CSC")
         csr = random_sparse_matrix(10, 0.2, "CSR")


### PR DESCRIPTION
This PR adds a doctest unit test for the `sparrayclass` and `sorting` modules.

Closes #4288:  add doctest to sparsematrix module
Closes #4281:  add doctest to sorting module