### PR TITLE
Closes #3755: take function

### DIFF
--- a/arkouda/array_api/indexing_functions.py
+++ b/arkouda/array_api/indexing_functions.py
@@ -2,9 +2,6 @@ from __future__ import annotations
 
 from typing import Optional
 
-from arkouda.client import generic_msg
-from arkouda.numpy.pdarrayclass import create_pdarray
-
 from .array_object import Array
 
 
@@ -23,22 +20,9 @@ def take(x: Array, indices: Array, /, *, axis: Optional[int] = None) -> Array:
         The axis along which to take elements. If None, `x` must be 1D.
     """
 
+    from arkouda.numpy.numeric import take
+
     if axis is None and x.ndim != 1:
         raise ValueError("axis must be specified for multidimensional arrays")
 
-    if indices.ndim != 1:
-        raise ValueError("indices must be 1D")
-
-    if axis is None:
-        axis = 0
-
-    repMsg = generic_msg(
-        cmd=f"takeAlongAxis<{x.dtype},{indices.dtype},{x.ndim}>",
-        args={
-            "x": x._array,
-            "indices": indices._array,
-            "axis": axis,
-        },
-    )
-
-    return Array._new(create_pdarray(repMsg))
+    return Array._new(take(x._array, indices._array, axis))

--- a/arkouda/numpy/numeric.py
+++ b/arkouda/numpy/numeric.py
@@ -118,6 +118,7 @@ __all__ = [
     "ErrorMode",
     "quantile",
     "percentile",
+    "take",
 ]
 
 
@@ -3172,3 +3173,49 @@ def percentile(
             raise ValueError("Values of q in percentile must be in range [0,100].")
 
     return quantile(a, q_ / 100.0, axis, method, keepdims)  # type: ignore
+
+
+def take(a: pdarray, indices: Union[numeric_scalars, pdarray], axis: Optional[int] = None) -> pdarray:
+    """
+    Take elements from an array along an axis.
+
+    When axis is not None, this function does the same thing as “fancy” indexing (indexing arrays
+    using arrays); however, it can be easier to use if you need elements along a given axis.
+    A call such as ``np.take(arr, indices, axis=3)`` is equivalent to ``arr[:,:,:,indices,...]``.
+
+    Parameters
+    ----------
+    a : pdarray
+        The array from which to take elements
+    indices : numeric_scalars or pdarray
+        The indices of the values to extract. Also allow scalars for indices.
+    axis : int, optional
+        The axis over which to select values. By default, the flattened input array is used.
+
+    Returns
+    -------
+    pdarray
+        The returned array has the same type as `a`.
+    """
+
+    if axis is None and a.ndim != 1:
+        a = a.flatten()
+
+    if isinstance(indices, pdarray) and indices.ndim != 1:
+        raise ValueError("indices must be 1D")
+
+    if axis is None:
+        axis = 0
+
+    result = create_pdarray(
+        generic_msg(
+            cmd=f"takeAlongAxis<{a.dtype},{indices.dtype},{a.ndim}>",
+            args={
+                "x": a,
+                "indices": indices,
+                "axis": axis,
+            },
+        )
+    )
+
+    return result

--- a/tests/numpy/numeric_test.py
+++ b/tests/numpy/numeric_test.py
@@ -1521,3 +1521,51 @@ class TestNumeric:
             )
             ak_assert_almost_equivalent(pr, nr)
             keepdims = not keepdims  # switch this each time through the loop
+
+
+@pytest.mark.parametrize("dtype", NUMERIC_TYPES)
+@pytest.mark.parametrize("size", pytest.prob_size)
+def test_take_1d(dtype, size):
+    seed = pytest.seed if pytest.seed is not None else 8675309
+    if dtype == "bool":
+        a = ak.randint(0, 2, size, dtype=dtype, seed=seed)
+    else:
+        a = ak.randint(0, 100, size, dtype=dtype, seed=seed)
+    anp = a.to_ndarray()
+
+    indices = ak.randint(0, size, size // 2, dtype="int64", seed=seed)
+    indices_np = indices.to_ndarray()
+
+    a_taken = ak.take(a, indices)
+    anp_taken = np.take(anp, indices_np)
+
+    assert np.array_equal(a_taken.to_ndarray(), anp_taken)
+
+
+@pytest.mark.parametrize("dtype", NUMERIC_TYPES)
+@pytest.mark.skip_if_rank_not_compiled([3])
+def test_take_multidim(dtype):
+    seed = pytest.seed if pytest.seed is not None else 8675309
+    if dtype == "bool":
+        a = ak.randint(0, 2, (5, 6, 7), dtype=dtype, seed=seed)
+    else:
+        a = ak.randint(0, 100, (5, 6, 7), dtype=dtype, seed=seed)
+    anp = a.to_ndarray()
+
+    indices = ak.randint(0, 6, 3, dtype="int64", seed=seed)
+    indices_np = indices.to_ndarray()
+
+    a_taken = ak.take(a, indices, axis=1)
+    anp_taken = np.take(anp, indices_np, axis=1)
+
+    assert np.array_equal(a_taken.to_ndarray(), anp_taken)
+
+    a_taken = ak.take(a, indices, axis=0)
+    anp_taken = np.take(anp, indices_np, axis=0)
+
+    assert np.array_equal(a_taken.to_ndarray(), anp_taken)
+
+    a_taken = ak.take(a, indices)
+    anp_taken = np.take(anp, indices_np)
+
+    assert np.array_equal(a_taken.to_ndarray(), anp_taken)


### PR DESCRIPTION
Moved the code for the `take` function from `array_api` to `numeric`. There is a discrepancy between what the Array API standard says to do and what `numpy` does, so I tried to keep both in line with what they should be.

Closes #3755: take function