### PR TITLE
Fewer 'throws' while logging

### DIFF
--- a/src/ArgSortMsg.chpl
+++ b/src/ArgSortMsg.chpl
@@ -357,8 +357,8 @@ module ArgSortMsg
                   );
         }
       }
-      try! asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                             "argsort time = %i".format(Time.timeSinceEpoch().totalSeconds() - t1));
+      asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                     "argsort time = ", (Time.timeSinceEpoch().totalSeconds() - t1): string);
       return iv;
     }
 
@@ -412,8 +412,8 @@ module ArgSortMsg
                   );
         }
       }
-      try! asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                             "argsort time = %i".format(Time.timeSinceEpoch().totalSeconds() - t1));
+      asLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+                     "argsort time = ", (Time.timeSinceEpoch().totalSeconds() - t1): string);
       return iv;
     }
 

--- a/src/CheckpointMsg.chpl
+++ b/src/CheckpointMsg.chpl
@@ -195,7 +195,7 @@ module CheckpointMsg {
   // returns true if the daemon was started
   proc startAsyncCheckpointDaemon(sd: borrowed DefaultServerDaemon) {
     if checkpointMemPct <= 0 && checkpointIdleTime <= 0 {
-      try! cpLogger.info(M(), R(), L(), "asynchronous checkpointing was not requested");
+      cpLogger.info(M(), R(), L(), "asynchronous checkpointing was not requested");
       return false;
     }
 
@@ -216,7 +216,7 @@ module CheckpointMsg {
     // start the asynchronous task
     begin asyncCheckpointDaemon(sd);
 
-    try! cpLogger.info(M(), R(), L(), "started the asynchronous checkpointing daemon");
+    cpLogger.info(M(), R(), L(), "started the asynchronous checkpointing daemon");
     return true;
   }
 
@@ -256,7 +256,6 @@ module CheckpointMsg {
 
         if idleStart == idleStartForLastCheckpoint {
           // There has been no action on the server since we last checkpointed.
-          try! cpLogger.debug(M(), R(), L(), "no action since last checkpoint");
           delay = minRequestedDelay;
           continue;
         }
@@ -264,7 +263,6 @@ module CheckpointMsg {
         const idleTime = curTime - idleStart;
         if idleTime < minRequestedDelay {
           // The server has not been idle long enough. Check back later.
-          try! cpLogger.debug(M(), R(), L(), "the server has not been idle for long enough");
           delay = minRequestedDelay - idleTime;
           continue;
         }
@@ -292,7 +290,7 @@ module CheckpointMsg {
         delay = checkpointCheckInterval;
 
       } catch err {
-          try! cpLogger.error(M(), R(), L(), err.message());
+          cpLogger.error(M(), R(), L(), err.message());
       }
     }
   }

--- a/src/JoinEqWithDTMsg.chpl
+++ b/src/JoinEqWithDTMsg.chpl
@@ -93,8 +93,8 @@ module JoinEqWithDTMsg
                       t1: [a1D] int, t2: [a2D] int, dt: int, pred: int,
                       resLimitPerLocale: int) throws {
 
-        try! jeLogger.info(getModuleName(),getRoutineName(),getLineNumber(),
-                                            "resLimitPerLocale = %?".format(resLimitPerLocale));
+        jeLogger.info(getModuleName(),getRoutineName(),getLineNumber(),
+                      "resLimitPerLocale = ", resLimitPerLocale: string);
         
         // allocate result arrays per locale
         var locResI: [PrivateSpace] [0..#resLimitPerLocale] int;
@@ -147,7 +147,7 @@ module JoinEqWithDTMsg
                                             addResFlag = true;
                                         }
                                         otherwise {
-                                            try! jeLogger.info(getModuleName(),getRoutineName(),getLineNumber(),
+                                            jeLogger.info(getModuleName(),getRoutineName(),getLineNumber(),
                                                            "OOPS! bad predicate number!"); 
                                         }
                                     }

--- a/src/RadixSortLSD.chpl
+++ b/src/RadixSortLSD.chpl
@@ -76,8 +76,8 @@ module RadixSortLSD
         // loop over digits
         for rshift in {0..#nBits by bitsPerDigit} {
             const last = (rshift + bitsPerDigit) >= nBits;
-            try! rsLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-                                                        "rshift = %?".format(rshift));
+            rsLogger.debug(getModuleName(), getRoutineName(), getLineNumber(),
+                           "rshift = ", rshift: string);
             // count digits
             coforall loc in Locales with (ref globalCounts) {
                 on loc {

--- a/src/ServerDaemon.chpl
+++ b/src/ServerDaemon.chpl
@@ -773,11 +773,8 @@ module ServerDaemon {
             this.port = try! getEnv('METRICS_SERVER_PORT','5556'):int;
 
             try! this.socket.bind("tcp://*:%?".format(this.port));
-            try! sdLogger.debug(getModuleName(), 
-                                getRoutineName(), 
-                                getLineNumber(),
-                                "initialized and listening in port %i".format(
-                                this.port));
+            sdLogger.debug(getModuleName(), getRoutineName(), getLineNumber(),
+                           "initialized and listening in port ", this.port: string);
         }
 
         override proc run() throws {
@@ -877,11 +874,8 @@ module ServerDaemon {
             this.port = try! getEnv('SERVER_STATUS_PORT','5557'):int;
 
             try! this.socket.bind("tcp://*:%?".format(this.port));
-            try! sdLogger.debug(getModuleName(), 
-                                getRoutineName(), 
-                                getLineNumber(),
-                                "initialized and listening in port %i".format(
-                                this.port));
+            sdLogger.debug(getModuleName(), getRoutineName(), getLineNumber(),
+                           "initialized and listening in port ", this.port: string);
         }
 
         override proc run() throws {

--- a/src/Unique.chpl
+++ b/src/Unique.chpl
@@ -45,7 +45,7 @@ module Unique
     */
     proc uniqueSort(a: [?aD] ?eltType, param needCounts = true) throws {
         if (aD.size == 0) {
-            try! uLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"zero size");
+            uLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"zero size");
             var u = makeDistArray(0, eltType);
             if (needCounts) {
                 var c = makeDistArray(0, int);
@@ -61,7 +61,7 @@ module Unique
 
     proc uniqueSortWithInverse(a: [?aD] ?eltType, param needIndices=false) throws {
         if (aD.size == 0) {
-            try! uLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"zero size");
+            uLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"zero size");
             var u = makeDistArray(aD.size, eltType);
             var c = makeDistArray(aD.size, int);
             var inv = makeDistArray(aD.size, int);
@@ -110,7 +110,7 @@ module Unique
         [(t, s, i) in zip(truth, sorted, aD)] if i > aD.low { t = (sorted[i-1] != s); }
         var allUnique: int = + reduce truth;
         if (allUnique == aD.size) {
-           try!  uLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
+            uLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
                                     "early out already unique");
             var u = makeDistArray(aD.size, eltType);
             u = sorted; // array is already unique
@@ -128,7 +128,7 @@ module Unique
         var iv: [truth.domain] int = (+ scan truth);
         // compute how many segments
         var pop = iv[iv.size-1];
-        try! uLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"pop = %?".format(pop));
+        uLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"pop = ",pop:string);
 
         var segs = makeDistArray(pop, int);
         var ukeys = makeDistArray(pop, eltType);


### PR DESCRIPTION
Switch logging methods to be non-throwing, by removing their dependence on the `format()`. This eliminates the need for `try!` when calling them and reduces (slightly) the size of the generated code.

While there, clean up and factor our the implementation; remove logger calls in CheckpointMsg that were added by mistake.