### PR TITLE
Closes #4235: searchsorted to work with uint type

### DIFF
--- a/arkouda/numpy/sorting.py
+++ b/arkouda/numpy/sorting.py
@@ -324,6 +324,7 @@ def searchsorted(
         If `a` has more than one dimension.
     TypeError
         If `a` has an unsupported dtype (i.e., not int64, uint64, bigint, or float64).
+        If the dtype of `a` and `v` does not match
 
 
     Examples
@@ -352,6 +353,9 @@ def searchsorted(
     else:
         scalar_input = True
         v_ = cast(pdarray, array([v]))
+
+    if a.dtype != v_.dtype:
+        raise TypeError(f"The dtype of a ({a.dtype}) and v ({v_.dtype}) must match.")
 
     repMsg = generic_msg(
         cmd=f"searchSorted<{a.dtype},{a.ndim},{v_.ndim}>",

--- a/tests/numpy/sort_test.py
+++ b/tests/numpy/sort_test.py
@@ -131,7 +131,7 @@ class TestSort:
             assert np.allclose(np.sort(npa), ak.sort(ak.array(npa), algo).to_ndarray(), equal_nan=True)
 
     @pytest.mark.parametrize("size", pytest.prob_size)
-    @pytest.mark.parametrize("dtype", [ak.float64, ak.int64, ak.bigint])
+    @pytest.mark.parametrize("dtype", [ak.float64, ak.int64, ak.bigint, ak.uint64])
     @pytest.mark.parametrize("v_shape", [(), (10,), (4, 5), (2, 2, 3)])
     @pytest.mark.parametrize("side", ["left", "right"])
     def test_searchsorted(self, size, dtype, v_shape, side):
@@ -154,10 +154,10 @@ class TestSort:
                 pytest.skip(f"Server not compiled for rank {len(v_shape)}")
             else:
                 v = ak.randint(low=low, high=high, size=v_shape, dtype=dtype_, seed=pytest.seed)
-                v = ak.array(v, dtype) + shift
+                v = ak.array(ak.array(v, dtype) + shift, dtype)
         a = ak.randint(low=low, high=high, size=size, dtype=dtype_, seed=pytest.seed)
         a = ak.sort(a)
-        a = ak.array(a, dtype) + shift
+        a = ak.array(ak.array(a, dtype) + shift, dtype)
         np_a = a.to_ndarray()
         if isinstance(v, ak.pdarray):
             np_v = v.to_ndarray()


### PR DESCRIPTION
I think `searchsorted` should work with uint types now. The problem was that somehow, `v = ak.array(v, dtype) + shift` would turn `v` into an array of `float64` if `v` was originally `uint64` and `shift` was 0. I changed it to be `v = ak.array(ak.array(v, dtype) + shift, dtype)` (and similarly where we do the same thing to `a`) and now tests pass. This should probably be fixed in `binopvs` or wherever it is as well, I imagine this is probably not intended behavior.

I also added a check that the data types match in `searchsorted`.

Closes #4235: searchsorted to work with uint type