### PR TITLE
Closes 4443, adding unit tests for segarray mean

### DIFF
--- a/arkouda/numpy/pdarrayclass.py
+++ b/arkouda/numpy/pdarrayclass.py
@@ -35,6 +35,36 @@ from arkouda.numpy.dtypes import (
 from arkouda.numpy.dtypes import str_ as akstr_
 from arkouda.numpy.dtypes import uint64 as akuint64
 
+
+def _axis_parser(axis):
+    if axis is None:
+        return None
+    else:
+        axis_ = [axis] if np.isscalar(axis) else list(axis) if isinstance(axis, tuple) else axis
+        return axis_
+
+
+def _axis_validation(axis, rank):
+    if axis is None:
+        return True, None
+    elif isinstance(axis, int):
+        axis = axis if axis > 0 else rank + axis
+        if 0 <= axis and axis < rank:
+            return True, axis
+        else:
+            return False, axis
+    elif isinstance(axis, list):  # it's a list
+        valid = True
+        axis_ = axis.copy()
+        for i in range(len(axis_)):
+            axis_[i] = axis_[i] if axis_[i] >= 0 else rank + axis_[i]
+            if axis_[i] < 0 or axis_[i] >= rank:
+                valid = False
+        return valid, axis_
+    else:
+        return False, axis
+
+
 module = modules[__name__]
 
 if TYPE_CHECKING:
@@ -1822,23 +1852,35 @@ class pdarray:
         #   Function is generated at runtime with _make_index_reduction_func.
         return argmax(self, axis=axis, keepdims=keepdims)
 
-    def mean(self) -> np.float64:
+    def mean(
+        self, axis: Optional[Union[None, int, list, tuple]] = None, keepdims: Optional[bool] = False
+    ) -> Union[np.float64, pdarray]:
         """
         Compute the mean.  See ``arkouda.mean`` for details.
         """
-        return mean(self)
+        return mean(self, axis, keepdims)
 
-    def var(self, ddof: int_scalars = 0) -> np.float64:
+    def var(
+        self,
+        ddof: int_scalars = 0,
+        axis: Optional[Union[None, int, list, tuple]] = None,
+        keepdims: Optional[bool] = False,
+    ) -> Union[np.float64, pdarray]:
         """
         Compute the variance. See ``arkouda.var`` for details.
         """
-        return var(self, ddof=ddof)
+        return var(self, ddof, axis, keepdims)
 
-    def std(self, ddof: int_scalars = 0) -> np.float64:
+    def std(
+        self,
+        ddof: int_scalars = 0,
+        axis: Optional[Union[None, int, list, tuple]] = None,
+        keepdims: Optional[bool] = False,
+    ) -> Union[np.float64, pdarray]:
         """
         Compute the standard deviation. See ``arkouda.std`` for details.
         """
-        return std(self, ddof=ddof)
+        return std(self, ddof, axis, keepdims)
 
     def cov(self, y: pdarray) -> np.float64:
         """
@@ -2957,6 +2999,8 @@ def _make_index_reduction_func(
 # check whether a reduction of the given axes on an 'ndim' dimensional array
 # would result in a single scalar value
 def _reduces_to_single_value(axis, ndim) -> bool:
+    if axis is None:
+        return True
     if len(axis) == 0 or ndim == 1:
         # if no axes are specified or the array is 1D, the result is a scalar
         return True
@@ -3416,7 +3460,9 @@ def dot(
 
 
 @typechecked
-def mean(pda: pdarray) -> np.float64:
+def mean(
+    pda: pdarray, axis: Optional[Union[None, int, list, tuple]] = None, keepdims: Optional[bool] = False
+) -> Union[np.float64, pdarray]:
     """
     Return the mean of the array.
 
@@ -3424,11 +3470,17 @@ def mean(pda: pdarray) -> np.float64:
     ----------
     pda : pdarray
         Values for which to calculate the mean
+    axis : int, Tuple[int, ...], optional, default = None
+        The axis or axes along which to do the operation
+        If None, the computation is done across the entire array.
+    keepdims : bool, optional, default = False
+        Whether to keep the singleton dimension(s) along `axis` in the result.
 
     Returns
     -------
-    np.float64
-        The mean calculated from the pda sum and size
+    Union[np.float64, pdarray]
+        The mean calculated from the pda sum and size, along the axis/axes if
+        those are given.
 
     Examples
     --------
@@ -3438,6 +3490,15 @@ def mean(pda: pdarray) -> np.float64:
     np.float64(4.5)
     >>> a.mean()
     np.float64(4.5)
+    >>> a = ak.arange(10).reshape(2,5)
+    >>> a.mean(axis=0)
+    array([2.5 3.5 4.5 5.5 6.5])
+    >>> ak.mean(a,axis=0)
+    array([2.5 3.5 4.5 5.5 6.5])
+    >>> a.mean(axis=1)
+    array([2.00000000000000000 7.00000000000000000])
+    >>> ak.mean(a,axis=1)
+    array([2.00000000000000000 7.00000000000000000])
 
     Raises
     ------
@@ -3446,16 +3507,41 @@ def mean(pda: pdarray) -> np.float64:
     RuntimeError
         Raised if there's a server-side error thrown
     """
-    return parse_single_value(
-        generic_msg(
-            cmd=f"mean<{pda.dtype},{pda.ndim}>",
-            args={"x": pda, "skipNan": False},
+
+    axis_ = _axis_parser(axis)
+    if _reduces_to_single_value(axis_, pda.ndim):
+        return parse_single_value(
+            generic_msg(
+                cmd=f"mean<{pda.dtype},{pda.ndim}>",
+                args={"x": pda, "skipNan": False},
+            )
         )
-    )
+    else:
+        valid, axis__ = _axis_validation(axis_, pda.ndim)
+        if valid:
+            result = create_pdarray(
+                generic_msg(
+                    cmd=f"meanReduce<{pda.dtype},{pda.ndim}>",
+                    args={"x": pda, "axes": axis__, "skipNan": False},
+                )
+            )
+            if keepdims:
+                return result
+            else:
+                from arkouda.numpy import squeeze
+
+                return squeeze(result, tuple(axis__))
+        else:
+            raise ValueError(f"Invalid axes {axis} for array rank {pda.ndim}")
 
 
 @typechecked
-def var(pda: pdarray, ddof: int_scalars = 0) -> np.float64:
+def var(
+    pda: pdarray,
+    ddof: int_scalars = 0,
+    axis: Optional[Union[None, int, list, tuple]] = None,
+    keepdims: Optional[bool] = False,
+) -> Union[np.float64, pdarray]:
     """
     Return the variance of values in the array.
 
@@ -3465,11 +3551,17 @@ def var(pda: pdarray, ddof: int_scalars = 0) -> np.float64:
         Values for which to calculate the variance
     ddof : int_scalars
         "Delta Degrees of Freedom" used in calculating var
+    axis : int, Tuple[int, ...], optional, default = None
+        The axis or axes along which to do the operation
+        If None, the computation is done across the entire array.
+    keepdims : bool, optional, default = False
+        Whether to keep the singleton dimension(s) along `axis` in the result.
 
     Returns
     -------
-    np.float64
-        The scalar variance of the array
+    Union[np.float64, pdarray]
+        The scalar variance of the array, or the variance along the axis/axes
+        if supplied
 
     Examples
     --------
@@ -3479,6 +3571,15 @@ def var(pda: pdarray, ddof: int_scalars = 0) -> np.float64:
     np.float64(8.25)
     >>> a.var()
     np.float64(8.25)
+    >>> a = ak.arange(10).reshape(2,5)
+    >>> a.var(axis=0)
+    array([6.25 6.25 6.25 6.25 6.25])
+    >>> ak.var(a,axis=0)
+    array([6.25 6.25 6.25 6.25 6.25])
+    >>> a.var(axis=1)
+    array([2.00000000000000000 2.00000000000000000])
+    >>> ak.var(a,axis=1)
+    array([2.00000000000000000 2.00000000000000000])
 
     Raises
     ------
@@ -3505,18 +3606,43 @@ def var(pda: pdarray, ddof: int_scalars = 0) -> np.float64:
     ``ddof=0`` provides a maximum likelihood estimate of the variance for
     normally distributed variables.
     """
-    if ddof >= pda.size:
-        raise ValueError("var: ddof must be less than number of values")
-    return parse_single_value(
-        generic_msg(
-            cmd=f"var<{pda.dtype},{pda.ndim}>",
-            args={"x": pda, "ddof": ddof, "skipNan": False},
+    if ddof < 0 or ddof >= pda.size:
+        raise ValueError("var: ddof must be in range 0 to number of values")
+
+    axis_ = _axis_parser(axis)
+    if _reduces_to_single_value(axis_, pda.ndim):
+        return parse_single_value(
+            generic_msg(
+                cmd=f"var<{pda.dtype},{pda.ndim}>",
+                args={"x": pda, "ddof": ddof, "skipNan": False},
+            )
         )
-    )
+    else:
+        valid, axis__ = _axis_validation(axis_, pda.ndim)
+        if valid:
+            result = create_pdarray(
+                generic_msg(
+                    cmd=f"varReduce<{pda.dtype},{pda.ndim}>",
+                    args={"x": pda, "axes": axis__, "ddof": ddof, "skipNan": False},
+                )
+            )
+            if keepdims:
+                return result
+            else:
+                from arkouda.numpy import squeeze
+
+                return squeeze(result, tuple(axis__))
+        else:
+            raise ValueError(f"Invalid axes {axis} for array rank {pda.ndim}")
 
 
 @typechecked
-def std(pda: pdarray, ddof: int_scalars = 0) -> np.float64:
+def std(
+    pda: pdarray,
+    ddof: int_scalars = 0,
+    axis: Optional[Union[None, int, list, tuple]] = None,
+    keepdims: Optional[bool] = False,
+) -> Union[np.float64, pdarray]:
     """
     Return the standard deviation of values in the array. The standard
     deviation is implemented as the square root of the variance.
@@ -3527,11 +3653,17 @@ def std(pda: pdarray, ddof: int_scalars = 0) -> np.float64:
         values for which to calculate the standard deviation
     ddof : int_scalars
         "Delta Degrees of Freedom" used in calculating std
+    axis : int, Tuple[int, ...], optional, default = None
+        The axis or axes along which to do the operation
+        If None, the computation is done across the entire array.
+    keepdims : bool, optional, default = False
+        Whether to keep the singleton dimension(s) along `axis` in the result.
 
     Returns
     -------
-    np.float64
-        The scalar standard deviation of the array
+    Union[np.float64, pdarray]
+        The scalar standard deviation of the array, or the standard deviation
+         along the axis/axes if supplied
 
     Examples
     --------
@@ -3541,6 +3673,15 @@ def std(pda: pdarray, ddof: int_scalars = 0) -> np.float64:
     np.float64(2.8722813232690143)
     >>> a.std()
     np.float64(2.8722813232690143)
+    >>> a = ak.arange(10).reshape(2,5)
+    >>> a.std(axis=0)
+    array([2.5 2.5 2.5 2.5 2.5])
+    >>> ak.std(a,axis=0)
+    array([2.5 2.5 2.5 2.5 2.5])
+    >>> a.std(axis=1)
+    array([1.4142135623730951 1.4142135623730951])
+    >>> ak.std(a,axis=1)
+    array([1.4142135623730951 1.4142135623730951])
 
     Raises
     ------
@@ -3570,14 +3711,34 @@ def std(pda: pdarray, ddof: int_scalars = 0) -> np.float64:
     the estimated variance, so even with ``ddof=1``, it will not be an
     unbiased estimate of the standard deviation per se.
     """
-    if ddof < 0:
-        raise ValueError("ddof must be an integer 0 or greater")
-    return parse_single_value(
-        generic_msg(
-            cmd=f"std<{pda.dtype},{pda.ndim}>",
-            args={"x": pda, "ddof": ddof, "skipNan": False},
+    if ddof < 0 or ddof >= pda.size:
+        raise ValueError("var: ddof must be in range 0 to number of values")
+
+    axis_ = _axis_parser(axis)
+    if _reduces_to_single_value(axis_, pda.ndim):
+        return parse_single_value(
+            generic_msg(
+                cmd=f"std<{pda.dtype},{pda.ndim}>",
+                args={"x": pda, "ddof": ddof, "skipNan": False},
+            )
         )
-    )
+    else:
+        valid, axis__ = _axis_validation(axis_, pda.ndim)
+        if valid:
+            result = create_pdarray(
+                generic_msg(
+                    cmd=f"stdReduce<{pda.dtype},{pda.ndim}>",
+                    args={"x": pda, "axes": axis__, "ddof": ddof, "skipNan": False},
+                )
+            )
+            if keepdims:
+                return result
+            else:
+                from arkouda.numpy import squeeze
+
+                return squeeze(result, tuple(axis__))
+        else:
+            raise ValueError(f"Invalid axes {axis} for array rank {pda.ndim}")
 
 
 @typechecked

--- a/arkouda/numpy/timeclass.py
+++ b/arkouda/numpy/timeclass.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+from typing import Optional, Union
 
 import numpy as np
 from pandas import Series as pdSeries
@@ -885,11 +886,16 @@ class Timedelta(_AbstractBaseTime):
         """
         return to_timedelta(self.to_ndarray())
 
-    def std(self, ddof: int_scalars = 0):
+    def std(
+        self,
+        ddof: int_scalars = 0,
+        axis: Optional[Union[None, int, list, tuple]] = None,
+        keepdims: Optional[bool] = False,
+    ):
         """
-        Returns the standard deviation as a pd.Timedelta object
+        Returns the standard deviation as a pd.Timedelta object, with args compatible with ak.std
         """
-        return self._scalar_callback(self.values.std(ddof=ddof))
+        return self._scalar_callback(self.values.std(ddof, axis, keepdims))
 
     def sum(self):
         # Sum as a pd.Timedelta

--- a/src/AryUtil.chpl
+++ b/src/AryUtil.chpl
@@ -145,7 +145,6 @@ module AryUtil
 
     proc validateNegativeAxes(axis: int, param nd: int): (bool, int) {
       var ret: int;
-      
       ret = if axis >= 0 then axis else nd + axis;
       if ret >= nd then return (false, ret);
       if ret <0    then return (false, ret);

--- a/src/ManipulationMsg.chpl
+++ b/src/ManipulationMsg.chpl
@@ -834,6 +834,7 @@ module ManipulationMsg {
     const name = msgArgs["name"],
           nAxes = msgArgs["nAxes"].toScalar(int),
           axes = msgArgs["axes"].toScalarArray(int, nAxes);
+
     var eIn = st[name]: borrowed SymEntry(array_dtype, array_nd_in),
         (valid, shape, mapping) = validateSqueeze(eIn.tupShape, axes, array_nd_out);
 

--- a/src/StatsMsg.chpl
+++ b/src/StatsMsg.chpl
@@ -27,13 +27,18 @@ module StatsMsg {
 
     @arkouda.registerCommand()
     proc meanReduce(const ref x: [?d] ?t, skipNan: bool, axes: list(int)): [] real throws {
-      var meanArr = makeDistArray(domOffAxis(d, axes), real);
-      forall (slice, sliceIdx) in axisSlices(d, axes) {
-        if canBeNan(t) && skipNan
-          then meanArr[sliceIdx] = meanSkipNan(x, slice);
-          else meanArr[sliceIdx] = meanOver(x, slice);
+      const (valid, axes_) = validateNegativeAxes (axes, d.rank);
+      if !valid {
+        throw new Error("Invalid axis value(s) '%?' in mean reduction".format(axes));
+      } else {
+        var meanArr = makeDistArray(domOffAxis(d, axes_), real);
+        forall (slice, sliceIdx) in axisSlices(d, axes_) {
+            if canBeNan(t) && skipNan
+            then meanArr[sliceIdx] = meanSkipNan(x, slice);
+            else meanArr[sliceIdx] = meanOver(x, slice);
+        }
+        return meanArr;
       }
-      return meanArr;
     }
 
     @arkouda.registerCommand(name="var")
@@ -45,13 +50,18 @@ module StatsMsg {
 
     @arkouda.registerCommand()
     proc varReduce(const ref x: [?d] ?t, skipNan: bool, ddof: real, axes: list(int)): [] real throws {
-      var varArr = makeDistArray(domOffAxis(d, axes), real);
-      forall (slice, sliceIdx) in axisSlices(d, axes) {
-        if canBeNan(t) && skipNan
-          then varArr[sliceIdx] = varianceSkipNan(x, slice, ddof);
-          else varArr[sliceIdx] = varianceOver(x, slice, ddof);
+      const (valid, axes_) = validateNegativeAxes (axes, d.rank);
+      if !valid {
+        throw new Error("Invalid axis value(s) '%?' in var reduction".format(axes));
+      } else {
+        var varArr = makeDistArray(domOffAxis(d, axes_), real);
+        forall (slice, sliceIdx) in axisSlices(d, axes_) {
+            if canBeNan(t) && skipNan
+              then varArr[sliceIdx] = varianceSkipNan(x, slice, ddof);
+              else varArr[sliceIdx] = varianceOver(x, slice, ddof);
+        }
+        return varArr;
       }
-      return varArr;
     }
 
     @arkouda.registerCommand()
@@ -63,13 +73,18 @@ module StatsMsg {
 
     @arkouda.registerCommand()
     proc stdReduce(const ref x: [?d] ?t, skipNan: bool, ddof: real, axes: list(int)): [] real throws {
-      var stdArr = makeDistArray(domOffAxis(d, axes), real);
-      forall (slice, sliceIdx) in axisSlices(d, axes) {
-        if canBeNan(t) && skipNan
-          then stdArr[sliceIdx] = stdSkipNan(x, slice, ddof);
-          else stdArr[sliceIdx] = stdOver(x, slice, ddof);
+      const (valid, axes_) = validateNegativeAxes (axes, d.rank);
+      if !valid {
+        throw new Error("Invalid axis value(s) '%?' in std reduction".format(axes));
+      } else {
+        var stdArr = makeDistArray(domOffAxis(d, axes_), real);
+        forall (slice, sliceIdx) in axisSlices(d, axes_) {
+            if canBeNan(t) && skipNan
+                then stdArr[sliceIdx] = stdSkipNan(x, slice, ddof);
+                else stdArr[sliceIdx] = stdOver(x, slice, ddof);
+        }
+        return stdArr;
       }
-      return stdArr;
     }
 
     @arkouda.registerCommand()

--- a/tests/array_api/stats_functions.py
+++ b/tests/array_api/stats_functions.py
@@ -49,6 +49,9 @@ class TestStatsFunction:
         assert aMin02Keepdims[0, 6, 0] == -1
 
     @pytest.mark.skip_if_rank_not_compiled([2, 3])
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
+    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     def test_mean(self):
         a = xp.ones((10, 5, 5))
         a[0, 0, 0] = 251

--- a/tests/array_api/stats_functions.py
+++ b/tests/array_api/stats_functions.py
@@ -49,9 +49,6 @@ class TestStatsFunction:
         assert aMin02Keepdims[0, 6, 0] == -1
 
     @pytest.mark.skip_if_rank_not_compiled([2, 3])
-    @pytest.mark.skip_if_rank_not_compiled([2, 3])
-    @pytest.mark.skip_if_rank_not_compiled([2, 3])
-    @pytest.mark.skip_if_rank_not_compiled([2, 3])
     def test_mean(self):
         a = xp.ones((10, 5, 5))
         a[0, 0, 0] = 251

--- a/tests/numpy/pdarrayclass_test.py
+++ b/tests/numpy/pdarrayclass_test.py
@@ -6,6 +6,7 @@ import pytest
 import arkouda as ak
 from arkouda.client import get_array_ranks, get_max_array_rank
 from arkouda.dtypes import bigint
+from arkouda.testing import assert_almost_equivalent as ak_assert_almost_equivalent
 from arkouda.testing import assert_arkouda_array_equivalent
 from arkouda.testing import assert_equal as ak_assert_equal
 from arkouda.testing import assert_equivalent as ak_assert_equivalent
@@ -307,4 +308,121 @@ class TestPdarrayClass:
             pda2 = ak.array(nda2)
             assert_arkouda_array_equivalent(ak.dot(pda1, pda2), np.dot(nda1, nda2))
 
-        #   higher dimension testing may not be feasible at this time
+        #   higher dimension testing of dot may not be feasible at this time
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype", NUMERIC_TYPES_NO_BOOL)
+    def test_mean_1D(self, size, dtype):
+        nda = np.random.randint(0, size, size).astype(dtype)
+        pda = ak.array(nda)
+        ak_assert_almost_equivalent(np.mean(nda), pda.mean())
+        ak.assert_almost_equivalent(np.mean(nda), ak.mean(pda))
+
+    @pytest.mark.skip_if_rank_not_compiled([2])
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype", NUMERIC_TYPES_NO_BOOL)
+    def test_mean_2D(self, size, dtype):
+        nda = np.random.randint(0, size, (2, size // 2)).astype(dtype)
+        pda = ak.array(nda)
+        ak_assert_almost_equivalent(np.mean(nda), pda.mean())
+        ak.assert_almost_equivalent(np.mean(nda), ak.mean(pda))
+        for axis in range(-2, 2):
+            ak_assert_almost_equivalent(np.mean(nda, axis=axis), pda.mean(axis=axis))
+            ak.assert_almost_equivalent(np.mean(nda, axis=axis), ak.mean(pda, axis=axis))
+
+    @pytest.mark.skip_if_rank_not_compiled([3])
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype", NUMERIC_TYPES_NO_BOOL)
+    def test_mean_3D(self, size, dtype):
+        nda = np.random.randint(0, size, (2, 2, size // 4)).astype(dtype)
+        pda = ak.array(nda)
+        ak_assert_almost_equivalent(np.mean(nda), pda.mean())
+        ak.assert_almost_equivalent(np.mean(nda), ak.mean(pda))
+        for axis in range(-3, 3):
+            ak_assert_almost_equivalent(np.mean(nda, axis=axis), pda.mean(axis=axis))
+            ak.assert_almost_equivalent(np.mean(nda, axis=axis), ak.mean(pda, axis=axis))
+        for axis in [(0, 1), (0, 2), (1, 2), (-3, -2), (-3, -1), (-2, -1)]:
+            ak_assert_almost_equivalent(np.mean(nda, axis=axis), pda.mean(axis=axis))
+            ak.assert_almost_equivalent(np.mean(nda, axis=axis), ak.mean(pda, axis=axis))
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype", NUMERIC_TYPES_NO_BOOL)
+    def test_var_1D(self, size, dtype):
+        nda = np.random.randint(0, size, size).astype(dtype)
+        pda = ak.array(nda)
+        ak_assert_almost_equivalent(np.var(nda), pda.var())
+        ak.assert_almost_equivalent(np.var(nda), ak.var(pda))
+        ak_assert_almost_equivalent(np.var(nda, ddof=1), pda.var(ddof=1))
+        ak.assert_almost_equivalent(np.var(nda, ddof=1), ak.var(pda, ddof=1))
+
+    @pytest.mark.skip_if_rank_not_compiled([2])
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype", NUMERIC_TYPES_NO_BOOL)
+    def test_var_2D(self, size, dtype):
+        nda = np.random.randint(0, size, (2, size // 2)).astype(dtype)
+        pda = ak.array(nda)
+        ak.assert_almost_equivalent(np.var(nda), pda.var())
+        ak.assert_almost_equivalent(np.var(nda), ak.var(pda))
+        ak.assert_almost_equivalent(np.var(nda, ddof=1), pda.var(ddof=1))
+        ak.assert_almost_equivalent(np.var(nda, ddof=1), ak.var(pda, ddof=1))
+        for axis in range(2):
+            ak_assert_almost_equivalent(np.var(nda, axis=axis, ddof=1), pda.var(axis=axis, ddof=1))
+            ak.assert_almost_equivalent(np.var(nda, axis=axis, ddof=1), ak.var(pda, axis=axis, ddof=1))
+
+    @pytest.mark.skip_if_rank_not_compiled([3])
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype", NUMERIC_TYPES_NO_BOOL)
+    def test_var_3D(self, size, dtype):
+        nda = np.random.randint(0, size, (2, 2, size // 4)).astype(dtype)
+        pda = ak.array(nda)
+        ak_assert_almost_equivalent(np.var(nda), pda.var())
+        ak.assert_almost_equivalent(np.var(nda), ak.var(pda))
+        ak_assert_almost_equivalent(np.var(nda, ddof=1), pda.var(ddof=1))
+        ak.assert_almost_equivalent(np.var(nda, ddof=1), ak.var(pda, ddof=1))
+        for axis in range(2):
+            ak_assert_almost_equivalent(np.var(nda, axis=axis, ddof=1), pda.var(axis=axis, ddof=1))
+            ak.assert_almost_equivalent(np.var(nda, axis=axis, ddof=1), ak.var(pda, axis=axis, ddof=1))
+        for axis in [(0, 1), (0, 2), (1, 2), (-3, -2), (-3, -1), (-2, -1)]:
+            ak_assert_almost_equivalent(np.var(nda, ddof=1, axis=axis), pda.var(ddof=1, axis=axis))
+            ak.assert_almost_equivalent(np.var(nda, ddof=1, axis=axis), ak.var(pda, ddof=1, axis=axis))
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype", NUMERIC_TYPES_NO_BOOL)
+    def test_std_1D(self, size, dtype):
+        nda = np.random.randint(0, size, size).astype(dtype)
+        pda = ak.array(nda)
+        ak_assert_almost_equivalent(np.std(nda), pda.std())
+        ak.assert_almost_equivalent(np.std(nda), ak.std(pda))
+        ak_assert_almost_equivalent(np.std(nda, ddof=1), pda.std(ddof=1))
+        ak.assert_almost_equivalent(np.std(nda, ddof=1), ak.std(pda, ddof=1))
+
+    @pytest.mark.skip_if_rank_not_compiled([2])
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype", NUMERIC_TYPES_NO_BOOL)
+    def test_std_2D(self, size, dtype):
+        nda = np.random.randint(0, size, (2, size // 2)).astype(dtype)
+        pda = ak.array(nda)
+        ak_assert_almost_equivalent(np.std(nda), pda.std())
+        ak.assert_almost_equivalent(np.std(nda), ak.std(pda))
+        ak_assert_almost_equivalent(np.std(nda, ddof=1), pda.std(ddof=1))
+        ak.assert_almost_equivalent(np.std(nda, ddof=1), ak.std(pda, ddof=1))
+        for axis in range(2):
+            ak_assert_almost_equivalent(np.std(nda, axis=axis, ddof=1), pda.std(axis=axis, ddof=1))
+            ak.assert_almost_equivalent(np.std(nda, axis=axis, ddof=1), ak.std(pda, axis=axis, ddof=1))
+
+    @pytest.mark.skip_if_rank_not_compiled([3])
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype", NUMERIC_TYPES_NO_BOOL)
+    def test_std_3D(self, size, dtype):
+        nda = np.random.randint(0, size, (2, 2, size // 4)).astype(dtype)
+        pda = ak.array(nda)
+        ak_assert_almost_equivalent(np.std(nda), pda.std())
+        ak.assert_almost_equivalent(np.std(nda), ak.std(pda))
+        ak_assert_almost_equivalent(np.std(nda, ddof=1), pda.std(ddof=1))
+        ak.assert_almost_equivalent(np.std(nda, ddof=1), ak.std(pda, ddof=1))
+        for axis in range(2):
+            ak_assert_almost_equivalent(np.std(nda, axis=axis, ddof=1), pda.std(axis=axis, ddof=1))
+            ak.assert_almost_equivalent(np.std(nda, axis=axis, ddof=1), ak.std(pda, axis=axis, ddof=1))
+        for axis in [(0, 1), (0, 2), (1, 2), (-3, -2), (-3, -1), (-2, -1)]:
+            ak_assert_almost_equivalent(np.std(nda, ddof=1, axis=axis), pda.std(ddof=1, axis=axis))
+            ak.assert_almost_equivalent(np.std(nda, ddof=1, axis=axis), ak.std(pda, ddof=1, axis=axis))

--- a/tests/numpy/segarray_test.py
+++ b/tests/numpy/segarray_test.py
@@ -248,15 +248,13 @@ class TestSegArray:
         assert sa.size == 0
         assert [] == sa.lengths.to_list()
 
-
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", NUMERIC_DTYPES)
-    def test_mean(self, size, dtype) :
+    def test_mean(self, size, dtype):
         c_segs, c_vals = self.make_segarray(size, dtype)
         c_sa = ak.SegArray(ak.array(c_segs), ak.array(c_vals))
-        for i in range(len(c_sa)) :
-            assert (c_sa.mean()[i] == c_sa[i].mean())
-
+        for i in range(len(c_sa)):
+            assert c_sa.mean()[i] == c_sa[i].mean()
 
     def test_generic_error_handling(self):
         with pytest.raises(TypeError):

--- a/tests/numpy/segarray_test.py
+++ b/tests/numpy/segarray_test.py
@@ -14,6 +14,7 @@ NO_BOOL = [ak.int64, ak.uint64, ak.bigint, ak.float64, ak.str_]
 NO_STR = [ak.int64, ak.uint64, ak.bigint, ak.float64, ak.bool_]
 NO_FLOAT = [ak.int64, ak.uint64, ak.bigint, ak.str_, ak.bool_]
 NO_FLOAT_STR = [ak.int64, ak.uint64, ak.bigint, ak.bool_]
+NUMERIC_DTYPES = [ak.int64, ak.uint64, ak.float64]
 SETOPS = ["intersect", "union", "setdiff", "setxor"]
 
 
@@ -246,6 +247,16 @@ class TestSegArray:
         assert isinstance(sa, ak.SegArray)
         assert sa.size == 0
         assert [] == sa.lengths.to_list()
+
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype", NUMERIC_DTYPES)
+    def test_mean(self, size, dtype) :
+        c_segs, c_vals = self.make_segarray(size, dtype)
+        c_sa = ak.SegArray(ak.array(c_segs), ak.array(c_vals))
+        for i in range(len(c_sa)) :
+            assert (c_sa.mean()[i] == c_sa[i].mean())
+
 
     def test_generic_error_handling(self):
         with pytest.raises(TypeError):


### PR DESCRIPTION
Closes #4443 

This adds a unit test for the mean function in segarray.  This one doesn't really need axis handling, as individual entries in a segarray are expected to be 1D.  Holding this as a draft until 4425 is approved and merged.