### PR TITLE
skip strings module doctest when CHPL_COMM=ugni

### DIFF
--- a/tests/numpy/string_test.py
+++ b/tests/numpy/string_test.py
@@ -1,3 +1,4 @@
+import os
 from collections import Counter, namedtuple
 from typing import List
 
@@ -15,6 +16,7 @@ UNIQUE = N // 4
 
 
 class TestString:
+    @pytest.mark.skipif(os.environ.get("CHPL_COMM") == "ugni", reason="Test skipped on CHPL_COMM=ugni")
     def test_strings_docstrings(self):
         import doctest
 


### PR DESCRIPTION
This PR has `pytest` skip the `doctest` unit test in `strings` module when `CHPL_COMM=ugni`.

This is a work around for a reported issue where this particular test is hanging on multi-locale when `CHPL_COMM=ugni`.

@lydia-duncan 