### PR TITLE
Fixes ak.full behavior, Closes 4312

### DIFF
--- a/arkouda/numpy/pdarraycreation.py
+++ b/arkouda/numpy/pdarraycreation.py
@@ -628,7 +628,7 @@ def ones(
 def full(
     size: Union[int_scalars, Tuple[int_scalars, ...], str],
     fill_value: Union[numeric_scalars, str],
-    dtype: Union[np.dtype, type, str, bigint] = float64,
+    dtype: Optional[Union[np.dtype, type, str, bigint]] = None,
     max_bits: Optional[int] = None,
 ) -> Union[pdarray, Strings]:
     """
@@ -685,6 +685,8 @@ def full(
         return _full_string(size, fill_value)
     elif ak_dtype(dtype) == str_ or dtype == Strings:
         return _full_string(size, str_(fill_value))
+
+    dtype = dtype if dtype is not None else resolve_scalar_dtype(fill_value)
 
     dtype = akdtype(dtype)  # normalize dtype
     dtype_name = dtype.name if isinstance(dtype, bigint) else cast(np.dtype, dtype).name

--- a/tests/numpy/pdarray_creation_test.py
+++ b/tests/numpy/pdarray_creation_test.py
@@ -746,7 +746,7 @@ class TestPdarrayCreation:
         rank = ak.client.get_max_array_rank() + 1
         shape, local_size = _generate_test_shape(rank, 2**rank)
         with pytest.raises(ValueError):
-            ak.full(shape, dtype)
+            ak.full(shape, 1, dtype)
 
     def test_full_misc(self):
         for arg in -1, False:


### PR DESCRIPTION
This makes the dtype argument optional, defaulting to None.  If it is None, then the function uses the type of the supplied fill_value parameter.

It also fixes an error in test_full_error.  Because its use of ak.full wasn't supplying a fill_value, it was causing an error, but not the one it was supposed to.