### PR TITLE
skips string module doctest unit test on apollo

### DIFF
--- a/tests/numpy/string_test.py
+++ b/tests/numpy/string_test.py
@@ -17,6 +17,10 @@ UNIQUE = N // 4
 
 class TestString:
     @pytest.mark.skipif(os.environ.get("CHPL_COMM") == "ugni", reason="Test skipped on CHPL_COMM=ugni")
+    @pytest.mark.skipif(
+        os.environ.get("CHPL_HOST_PLATFORM") == "hpe-apollo",
+        reason="Test skipped on CHPL_HOST_PLATFORM=hpe-apollo for debugging purposes (hanging test)",
+    )
     def test_strings_docstrings(self):
         import doctest
 


### PR DESCRIPTION
Skips string module doctest unit test on `hpe-apollo`.  The test has been hanging on that and other systems.