### PR TITLE
Fix host-related issues re start_arkouda_server()

### DIFF
--- a/benchmark_v2/conftest.py
+++ b/benchmark_v2/conftest.py
@@ -24,7 +24,7 @@ def pytest_addoption(parser):
         "--host",
         action="store",
         default=default_host,
-        help="arkouda server host",
+        help="arkouda server host for CLIENT running mode",
     )
 
     default_port = int(os.getenv("ARKOUDA_SERVER_PORT", 5555))
@@ -41,8 +41,8 @@ def pytest_addoption(parser):
         "--nl",
         action="store",
         default=default_nl,
-        help="Number of Locales to run Arkouda with."
-        "Defaults ARKOUDA_NUMLOCALES, if set, otherwise 2. "
+        help="Number of Locales to run Arkouda with. "
+        "Defaults to ARKOUDA_NUMLOCALES, if set, otherwise 2. "
         "If Arkouda is not configured for multi_locale, 1 locale is used.",
     )
 
@@ -258,7 +258,8 @@ def _global_server() -> Iterator[None]:
 
     if pytest.running_mode == TestRunningMode.GLOBAL_SERVER:
         nl = pytest.nl
-        host, port, proc = start_arkouda_server(host=pytest.host, numlocales=nl, port=pytest.port)
+        host, port, proc = start_arkouda_server(numlocales=nl, port=pytest.port)
+        pytest.host = host
         print(f"Started arkouda_server in GLOBAL_SERVER mode on {host}:{port} ({nl} locales)")
 
         try:
@@ -288,7 +289,8 @@ def _module_server() -> Iterator[None]:
     """
     if pytest.running_mode == TestRunningMode.CLASS_SERVER:
         nl = pytest.nl
-        host, port, proc = start_arkouda_server(host=pytest.host, numlocales=nl, port=pytest.port)
+        host, port, proc = start_arkouda_server(numlocales=nl, port=pytest.port)
+        pytest.host = host
         print(f"Started arkouda_server in CLASS_SERVER mode on {host}:{port} ({nl} locales)")
 
         try:

--- a/server_util/test/server_test_util.py
+++ b/server_util/test/server_test_util.py
@@ -271,7 +271,7 @@ def start_arkouda_server(
     :param int numlocals: the number of arkouda_server locales
     :param bool trace: indicates whether to start the arkouda_server with tracing
     :param int port: the desired arkouda_server port, defaults to 5555
-    :param str host: the desired arkouda_server host, defaults to None
+    :param str host: the host that arkouda_server is or will run on, if known, None otherwise
     :param list server_args: additional arguments to pass to the server
     :param within_slurm_alloc: whether the current script is running within a slurm allocation.
                                in which case, special care needs to be taken when launching the server.
@@ -318,9 +318,13 @@ def start_arkouda_server(
         If host is None, this means the host and port are to be retrieved
         via the read_server_and_port_from_file method
         """
+        requested_port = port
         host, port, connect_url = read_server_and_port_from_file(
             connection_file, process=process, server_cmd=cmd
         )
+        if port != requested_port:
+            logging.error(f"requested port {requested_port}, got {port}")
+
     server_info = ServerInfo(host, port, process)
     set_server_info(server_info)
     return server_info
@@ -366,7 +370,7 @@ def run_client(client, client_args=None, timeout=get_client_timeout()):
     :rtype: str
     """
     server_info = get_server_info()
-    cmd = ["python3"] + [client] + [server_info.host, str(server_info.port)]
+    cmd = ["python3", client, server_info.host, str(server_info.port)]
     if client_args:
         cmd += client_args
     logging.info('Running client "{}"'.format(cmd))
@@ -384,7 +388,7 @@ def run_client_live(client, client_args=None, timeout=get_client_timeout()):
     :rtype: int
     """
     server_info = get_server_info()
-    cmd = ["python3"] + [client] + [server_info.host, str(server_info.port)]
+    cmd = ["python3", client, server_info.host, str(server_info.port)]
     if client_args:
         cmd += client_args
     logging.info('Running client "{}"'.format(cmd))

--- a/server_util/test/server_test_util.py
+++ b/server_util/test/server_test_util.py
@@ -271,7 +271,7 @@ def start_arkouda_server(
     :param int numlocals: the number of arkouda_server locales
     :param bool trace: indicates whether to start the arkouda_server with tracing
     :param int port: the desired arkouda_server port, defaults to 5555
-    :param str host: the host that arkouda_server is or will run on, if known, None otherwise
+    :param str host: the host that arkouda_server will run on, if known, None (default) otherwise
     :param list server_args: additional arguments to pass to the server
     :param within_slurm_alloc: whether the current script is running within a slurm allocation.
                                in which case, special care needs to be taken when launching the server.

--- a/src/CheckpointMsg.chpl
+++ b/src/CheckpointMsg.chpl
@@ -267,6 +267,12 @@ module CheckpointMsg {
           continue;
         }
 
+        if ! sd.seenNotableActivity.read() {
+          // There has been no action on the server since it started.
+          delay = minRequestedDelay;
+          continue;
+        }
+
         const ckptReason = needToCheckpoint(idleTime, idleStart, idleStartForLastMemCheck);
         if ! ckptReason.isEmpty() {
           // Save a checkpoint.

--- a/src/ServerDaemon.chpl
+++ b/src/ServerDaemon.chpl
@@ -666,6 +666,7 @@ module ServerDaemon {
                             if commandMap.contains(cmd) {
                                 activityMutex.writeEF("server");
                                 defer { activityMutex.readFE(); }
+                                serverActivityMark();
 
                                 repMsg = executeCommand(cmd, msgArgs, st);
                             } else {
@@ -741,6 +742,9 @@ module ServerDaemon {
         // 0 if it is currently not idle.
         var idlePeriodStart: atomic real;
 
+        // Has the server received non-trivial commands?
+        var seenNotableActivity: atomic bool;
+
         /* Starts a task for asynchronous checkpointing. */
         proc startAsyncCheckpointTask() {
           numAsyncTasks.add(1);
@@ -755,6 +759,10 @@ module ServerDaemon {
 
         proc serverIdleStop() {
           idlePeriodStart.write(0);
+        }
+
+        proc serverActivityMark() {
+          seenNotableActivity.write(true);
         }
     }
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -4,7 +4,9 @@ import arkouda as ak
 from server_util.test.server_test_util import TestRunningMode, start_arkouda_server
 
 
-@pytest.mark.skipif(pytest.host == "horizon", reason="nightly test failures due to machine busyness")
+@pytest.mark.skipif(
+    pytest.client_host == "horizon", reason="nightly test failures due to machine busyness"
+)
 class TestClient:
     # def test_client_docstrings(self):
     #     import doctest
@@ -52,14 +54,14 @@ class TestClient:
 
     @pytest.mark.skipif(
         pytest.test_running_mode == TestRunningMode.CLIENT,
-        reason="start_arkouda_server won't restart if running mode is client",
+        reason="should not stop/start the server in the CLIENT mode",
     )
     def test_shutdown(self):
         """
         Tests the ak.shutdown() method
         """
         ak.shutdown()
-        pytest.server, _, _ = start_arkouda_server(numlocales=pytest.nl)
+        pytest.server, _, _ = start_arkouda_server(numlocales=pytest.nl, port=pytest.port)
         # reconnect to server so subsequent tests will pass
         ak.connect(server=pytest.server, port=pytest.port, timeout=pytest.timeout)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,7 +87,7 @@ def pytest_configure(config):
     pytest.seed = None if config.getoption("seed") == "" else eval(config.getoption("seed"))
     pytest.prob_size = [eval(x) for x in config.getoption("size").split(",")]
     pytest.test_running_mode = TestRunningMode(os.getenv("ARKOUDA_RUNNING_MODE", "CLASS_SERVER"))
-    pytest.host = subprocess.check_output("hostname").decode("utf-8").strip()
+    pytest.client_host = subprocess.check_output("hostname").decode("utf-8").strip()
 
     pytest.temp_directory = config.getoption("--temp-directory")
 

--- a/tests/numpy/numeric_test.py
+++ b/tests/numpy/numeric_test.py
@@ -332,7 +332,7 @@ class TestNumeric:
 
     #   log and exp tests were identical, and so have been combined.
 
-    @pytest.mark.skipif(pytest.host == "horizon", reason="Fails on horizon")
+    @pytest.mark.skipif(pytest.client_host == "horizon", reason="Fails on horizon")
     @pytest.mark.skip_if_rank_not_compiled([2, 3])
     @pytest.mark.parametrize("num_type1", NO_BOOL)
     @pytest.mark.parametrize("num_type2", NO_BOOL)

--- a/tests/optioned-server/auto-checkpoints.py
+++ b/tests/optioned-server/auto-checkpoints.py
@@ -14,15 +14,21 @@ def directory_exists_delayed(path, num_delays, delay=0.1):
     """
     Repeats directory_exists() query num_delays times,
     each after a delay of `delay` seconds.
+
     This allows us to adjust for the server that can delay
-    the detection of a condition by --checkpointCheckInterval, if set,
-    otherwise by min(--checkpointIdleTime, --checkpointMemPctDelay).
+    the detection of a condition by up to `checkpointCheckInterval`,
+    which defaults to min(`checkpointIdleTime`, `checkpointMemPctDelay`).
+
+    The final sleep() is needed to wait for server checkpointing to complete,
+    once the directory is created. Otherwise delete_directory() executed
+    by the tests may interfer with checkpointing.
     """
     for _ in range(num_delays):
         if directory_exists(path):
+            sleep(0.3)  # conservative estimate
             return True
         sleep(delay)
-    return directory_exists(path)
+    return False
 
 
 class TestIdleAndInterval:


### PR DESCRIPTION
Fix a bug that prevents `tests/optioned-server/conftest.py` added in #4391 from connecting to the server that's not on "localhost".

While there, clarify the handling of the server host and port in the test suites:
* "Host" that comes from a command-line argument or environment variable and defaults to `localhost` is used only in the CLIENT running mode.
* "Host" is obtained from `start_arkouda_server()`, which reads it from `ak-server-info` that's created by the server, in GLOBAL_SERVER and CLASS_SERVER modes.
* "Port" comes from a command-line argument or environment variable and defaults to 5555; the port produced by `start_arkouda_server()` is expected to be the same.

The testing frameworks store the host and the port for use in `ak.connect()` as follows:

| suite | tests/ | benchmarks/ | benchmark_v2/ |
| :-- | :-- | :-- | :-- |
| host | `pytest.server` | `get_server_info()` | `pytest.host` |
| port | `pytest.port` | `get_server_info()` | `pytest.port` | 
| file | conftest.py | run_benchmarks.py | conftest.py |

The `host` argument of `start_arkouda_server()` has not been used for its [intended purpose](https://github.com/Bears-R-Us/arkouda/pull/374/files#r427210331) since it was added in #374. I propose to remove it, which will increase the clarity of code.