### PR TITLE
skip doctest unit tests for string, categorial on hpe systems

### DIFF
--- a/tests/categorical_test.py
+++ b/tests/categorical_test.py
@@ -27,6 +27,14 @@ def df_test_base_tmp(request):
 
 
 class TestCategorical:
+    @pytest.mark.skipif(
+        os.environ.get("CHPL_HOST_PLATFORM") == "hpe-apollo",
+        reason="Test skipped on CHPL_HOST_PLATFORM=hpe-apollo for debugging purposes (hanging test)",
+    )
+    @pytest.mark.skipif(
+        os.environ.get("CHPL_HOST_PLATFORM") == "cray-xc",
+        reason="Test skipped on CHPL_HOST_PLATFORM=cray-xc for debugging purposes (hanging test)",
+    )
     def test_categorical_docstrings(self):
         import doctest
 

--- a/tests/numpy/string_test.py
+++ b/tests/numpy/string_test.py
@@ -16,10 +16,13 @@ UNIQUE = N // 4
 
 
 class TestString:
-    @pytest.mark.skipif(os.environ.get("CHPL_COMM") == "ugni", reason="Test skipped on CHPL_COMM=ugni")
     @pytest.mark.skipif(
         os.environ.get("CHPL_HOST_PLATFORM") == "hpe-apollo",
         reason="Test skipped on CHPL_HOST_PLATFORM=hpe-apollo for debugging purposes (hanging test)",
+    )
+    @pytest.mark.skipif(
+        os.environ.get("CHPL_HOST_PLATFORM") == "cray-xc",
+        reason="Test skipped on CHPL_HOST_PLATFORM=cray-xc for debugging purposes (hanging test)",
     )
     def test_strings_docstrings(self):
         import doctest


### PR DESCRIPTION
Skips doctest unit tests for `string`, `categorial` modules on hpe systems due to hanging tests.