### PR TITLE
Closes #4459: Simplify and extend logic in binopvv

### DIFF
--- a/arkouda/numpy/pdarrayclass.py
+++ b/arkouda/numpy/pdarrayclass.py
@@ -26,6 +26,7 @@ from arkouda.numpy.dtypes import (
     numeric_scalars,
     numpy_scalars,
     resolve_scalar_dtype,
+    result_type,
 )
 from arkouda.numpy.dtypes import str_ as akstr_
 from arkouda.numpy.dtypes import uint64 as akuint64
@@ -689,6 +690,16 @@ class pdarray:
             raise ValueError(f"bad operator {op}")
         # pdarray binop pdarray
         if isinstance(other, pdarray):
+            # Not sure why the import is necessary, but it appears to be necessary.
+            from arkouda.numpy.dtypes import float64 as akfloat64
+
+            res_type = result_type(self, other)
+            bit_ops = {"&", "^", "|", ">>", "<<", ">>>", ">>>"}
+            if res_type == akfloat64 and op in bit_ops:
+                raise TypeError(
+                    f"Input types {self.dtype}, {other.dtype} result in array of type "
+                    f"{res_type}, which is not compatible with bitwise operation {op}"
+                )
             try:
                 x1, x2, tmp_x1, tmp_x2 = broadcast_if_needed(self, other)
             except ValueError:

--- a/tests/operator_test.py
+++ b/tests/operator_test.py
@@ -103,6 +103,8 @@ class TestOperator:
                         else:  # arkouda implements with error, np does not implement
                             results["arkouda_minus_numpy"].append((expression, str(e), True))
                         continue
+                    except TypeError as e:
+                        results["neither_implement"].append((expression, str(e)))
                     # arkouda implements but not numpy
                     results["arkouda_minus_numpy"].append((expression, str(akres), False))
                     continue
@@ -386,11 +388,6 @@ class TestOperator:
             # Binopvv case, Same type
             assert (ak_arr << ak_shift).to_list() == (np_arr << np_shift).tolist()
             assert (ak_arr >> ak_shift).to_list() == (np_arr >> np_shift).tolist()
-
-            # Binopvv case, Mixed type
-            ak_shift_other_dtype = ak.cast(ak_shift, "int64" if dtype != "int64" else "uint64")
-            assert (ak_arr << ak_shift_other_dtype).to_list() == (np_arr << np_shift).tolist()
-            assert (ak_arr >> ak_shift_other_dtype).to_list() == (np_arr >> np_shift).tolist()
 
     def test_shift_bool_int64_binop(self):
         # This tests for a missing implementation of bit shifting booleans and ints, Issue #2945
@@ -716,9 +713,11 @@ class TestOperator:
         assert ak.array([1.1, 2.3, 5]).__repr__() in answers
 
         answers = [
-            "array([0 0.52631578947368418 1.0526315789473684 ... 8.9473684210526319 9.473684210526315 10])",
+            "array([0 0.52631578947368418 1.0526315789473684 ..."
+            " 8.9473684210526319 9.473684210526315 10])",
             "array([0 0.5 1.1 ... 8.9 9.5 10])",
-            "array([0.00000000000000000 0.52631578947368418 1.0526315789473684 ... 8.9473684210526319 9.473684210526315 10.00000000000000000])",
+            "array([0.00000000000000000 0.52631578947368418 1.0526315789473684 ..."
+            " 8.9473684210526319 9.473684210526315 10.00000000000000000])",
         ]
         assert ak.linspace(0, 10, 20).__repr__() in answers
         assert "array([False False False])" == ak.isnan(ak.array([1.1, 2.3, 5])).__repr__()


### PR DESCRIPTION
This cleans up the logic in `binopvv` and `doBinOpvv`. Currently, only some types are supported due to the limitations of `@arkouda.instantiateAndRegister`, but once that is changed, the existing logic should more or less support additional sizes of `uint` and `int`. The code will likely require significant refactoring, but the logic should basically stay the same, and it should be much cleaner to do it.

Closes #4459: Simplify and extend logic in binopvv