### PR TITLE
Closes #4469: gh-pages action seems to need rsync

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -37,6 +37,10 @@ jobs:
     - name: Arkouda make doc
       run: |
         make doc
+    - name: Install rsync (needed by deploy action)
+      run: |
+        apt-get update
+        apt-get install -y rsync
     - name: publish-docs
       uses: JamesIves/github-pages-deploy-action@v4
       with:


### PR DESCRIPTION
I looked at the log for the `gh-pages` action since it's still not working. It said it was missing `rsync`, so this at least should fix that. Possibly more issues to come.

Well, ChatGPT says that you want to do an `apt-get install -y rsync` to fix it, anyways. If this works, then we should maybe consider updating the docker image, but if there are more things needed, maybe it would be best to update the docker image all at once.

Closes #4469: gh-pages action seems to need rsync