### PR TITLE
Closes #4247:  Add doctest to accessor module

### DIFF
--- a/tests/accessor_test.py
+++ b/tests/accessor_test.py
@@ -1,0 +1,13 @@
+import pytest
+
+import arkouda as ak
+
+
+class TestAccessor:
+    def test_alignment_docstrings(self):
+        import doctest
+
+        from arkouda import accessor
+
+        result = doctest.testmod(accessor, optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)
+        assert result.failed == 0, f"Doctest failed: {result.failed} failures"


### PR DESCRIPTION
Adds unit doctest unit tests to the `accessor` module.

Closes #4247:  Add doctest to accessor module