### PR TITLE
Closes #4256:  add doctest to history module

### DIFF
--- a/arkouda/history.py
+++ b/arkouda/history.py
@@ -32,7 +32,7 @@ Examples
 ['ak.array([1,2,3])', 'ak.sum(...)', ...]
 
 # Notebook mode
->>> h = NotebookHistoryRetriever()
+>>> h = NotebookHistoryRetriever()  # doctest: +SKIP
 >>> h.retrieve(num_commands=3)  # doctest: +SKIP
 ['ak.connect()', 'df = ak.DataFrame(...)', 'ak.argsort(...)']
 
@@ -128,7 +128,7 @@ class ShellHistoryRetriever(HistoryRetriever):
         >>> readline.clear_history()
         >>> 1 + 2
         3
-        >>> h.retrieve()
+        >>> h.retrieve() # doctest: +SKIP
         [' 1 + 2', 'h.retrieve()']
 
         """
@@ -175,11 +175,14 @@ class NotebookHistoryRetriever(HistoryAccessor, HistoryRetriever):
         --------
         >>> import arkouda as ak
         >>> from arkouda.history import NotebookHistoryRetriever
-        >>> h = NotebookHistoryRetriever()
+        >>> h = NotebookHistoryRetriever()  # doctest: +SKIP
         >>> 1+2
+        3
         >>> 4*6
+        24
         >>> 2**3
-        >>> h.retrieve(num_commands=3)
+        8
+        >>> h.retrieve(num_commands=3)  # doctest: +SKIP
         ['1+2', '4*6', '2**3']
 
         """

--- a/pytest.ini
+++ b/pytest.ini
@@ -37,6 +37,7 @@ testpaths =
     tests/numpy/datetime_test.py
     tests/extrema_test.py
     tests/pandas/groupby_test.py
+    tests/history_test.py
     tests/indexing_test.py
     tests/pandas/index_test.py
     tests/pandas/io_test.py

--- a/tests/history_test.py
+++ b/tests/history_test.py
@@ -1,0 +1,8 @@
+class TestHistory:
+    def test_history_docstrings(self):
+        import doctest
+
+        from arkouda import history
+
+        result = doctest.testmod(history, optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)
+        assert result.failed == 0, f"Doctest failed: {result.failed} failures"


### PR DESCRIPTION
Adds `doctest` unit tests for the `history` module.

Closes #4256:  add doctest to history module