### PR TITLE
Closes-4481 corrects default dtype of ak.eye

### DIFF
--- a/arkouda/numpy/numeric.py
+++ b/arkouda/numpy/numeric.py
@@ -2713,7 +2713,7 @@ def putmask(
     return
 
 
-def eye(rows: int_scalars, cols: int_scalars, diag: int_scalars = 0, dt: type = ak_int64) -> pdarray:
+def eye(rows: int_scalars, cols: int_scalars, diag: int_scalars = 0, dt: type = ak_float64) -> pdarray:
     """
     Return a pdarray with zeros everywhere except along a diagonal, which is all ones.
     The matrix need not be square.


### PR DESCRIPTION
Very simple change, to one file, to correct the default output type of ak.eye to match np.eye.