### PR TITLE
Closes #4272:  add doctest to manipulation_functions module

### DIFF
--- a/arkouda/numpy/manipulation_functions.py
+++ b/arkouda/numpy/manipulation_functions.py
@@ -248,23 +248,15 @@ def squeeze(
     --------
     >>> import arkouda as ak
     >>> x = ak.arange(10).reshape((1, 10, 1))
-    >>> x
-    array([array([array([0]) array([1]) array([2]) array([3])....
-     array([4]) array([5]) array([6]) array([7]) array([8]) array([9])])])
     >>> x.shape
     (1, 10, 1)
-    >>> ak.squeeze(x,axis=None)
-    array([0 1 2 3 4 5 6 7 8 9])
-    >>> ak.squeeze(x,axis=None).shape
+    >>> ak.squeeze(x, axis=None).shape
     (10,)
-    >>> ak.squeeze(x,axis=2)
-    array([array([0 1 2 3 4 5 6 7 8 9])])
-    >>> ak.squeeze(x,axis=2).shape
+    >>> ak.squeeze(x, axis=2).shape
     (1, 10)
-    >>> ak.squeeze(x,axis=(0,2))
-    array([0 1 2 3 4 5 6 7 8 9])
-    >>> ak.squeeze(x,axis=(0,2)).shape
+    >>> ak.squeeze(x, axis=(0, 2)).shape
     (10,)
+
     """
     from arkouda.numpy.dtypes import _val_isinstance_of_union
 

--- a/tests/numpy/manipulation_functions_test.py
+++ b/tests/numpy/manipulation_functions_test.py
@@ -13,15 +13,17 @@ DTYPES = ["uint64", "uint8", "int64", "float64", "bigint", "bool"]
 
 
 class TestNumpyManipulationFunctions:
-    # @pytest.mark.skip_if_rank_not_compiled([1, 2, 3])
-    # def test_manipulation_functions_docstrings(self):
-    #     import doctest
-    #
-    #     result = doctest.testmod(
-    #         manipulation_functions,
-    #         optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE,
-    #     )
-    #     assert result.failed == 0, f"Doctest failed: {result.failed} failures"
+    @pytest.mark.skip_if_rank_not_compiled([1, 2, 3])
+    def test_manipulation_functions_docstrings(self):
+        import doctest
+
+        from arkouda import manipulation_functions
+
+        result = doctest.testmod(
+            manipulation_functions,
+            optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE,
+        )
+        assert result.failed == 0, f"Doctest failed: {result.failed} failures"
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", [int, ak.int64, ak.uint64, float, ak.float64, bool, ak.bool_])


### PR DESCRIPTION
Adds `doctest` unit tests to `manipulation_functions` module.

Closes #4272:  add doctest to manipulation_functions module