### PR TITLE
Closes-4501, aligns parameter names of ak.eye to those of np.eye

### DIFF
--- a/arkouda/array_api/creation_functions.py
+++ b/arkouda/array_api/creation_functions.py
@@ -193,8 +193,8 @@ def empty_like(x: Array, /, *, dtype: Optional[Dtype] = None, device: Optional[D
 
 
 def eye(
-    n_rows: int,
-    n_cols: Optional[int] = None,
+    N: int,
+    M: Optional[int] = None,
     /,
     *,
     k: int = 0,
@@ -206,11 +206,10 @@ def eye(
 
     Parameters
     ----------
-
-    n_rows: int
+    N: int
         Number of rows in the output.
-    n_cols: Optional[int]
-        Number of columns in the output. If None, defaults to `n_rows`.
+    M: Optional[int]
+        Number of columns in the output. If None, defaults to N.
     k: int
         Index of the diagonal: 0 (the default) refers to the main diagonal, a
         positive value refers to an upper diagonal, and a negative value to a
@@ -223,13 +222,12 @@ def eye(
     if device not in ["cpu", None]:
         raise ValueError(f"Unsupported device {device!r}")
 
-    cols = n_rows
-    if n_cols is not None:
-        cols = n_cols
+    if M is None:
+        M = N
 
     from arkouda import dtype as akdtype
 
-    return Array._new(ak.eye(rows=n_rows, cols=cols, diag=k, dt=akdtype(dtype)))
+    return Array._new(ak.eye(N=N, M=M, k=k, dt=akdtype(dtype)))
 
 
 def from_dlpack(x: object, /) -> Array:

--- a/arkouda/numpy/numeric.py
+++ b/arkouda/numpy/numeric.py
@@ -2713,22 +2713,21 @@ def putmask(
     return
 
 
-def eye(rows: int_scalars, cols: int_scalars, diag: int_scalars = 0, dt: type = ak_float64) -> pdarray:
+def eye(N: int_scalars, M: int_scalars, k: int_scalars = 0, dt: type = ak_float64) -> pdarray:
     """
     Return a pdarray with zeros everywhere except along a diagonal, which is all ones.
     The matrix need not be square.
 
     Parameters
     ----------
-    rows : int_scalars
-    cols : int_scalars
-    diag : int_scalars, default=0
-        | if diag = 0, zeros start at element [0,0] and proceed along diagonal
-        | if diag > 0, zeros start at element [0,diag] and proceed along diagonal
-        | if diag < 0, zeros start at element [diag,0] and proceed along diagonal
-        | etc. Default set to 0.
-    dt : type, default=ak_int64
-        The data type of the elements in the matrix being returned. Default set to ak_int64
+    N : int_scalars
+    M : int_scalars
+    k : int_scalars, default=0
+        | if k = 0, zeros start at element [0,0] and proceed along diagonal
+        | if k > 0, zeros start at element [0,k] and proceed along diagonal
+        | if k < 0, zeros start at element [k,0] and proceed along diagonal
+    dt : type, default=ak_float64
+        The data type of the elements in the matrix being returned. Default set to ak_float64
 
     Returns
     -------
@@ -2738,28 +2737,28 @@ def eye(rows: int_scalars, cols: int_scalars, diag: int_scalars = 0, dt: type = 
     Examples
     --------
     >>> import arkouda as ak
-    >>> ak.eye(rows=4,cols=4,diag=0,dt=ak.int64)
+    >>> ak.eye(N=4,M=4,k=0,dt=ak.int64)
     array([array([1 0 0 0]) array([0 1 0 0]) array([0 0 1 0]) array([0 0 0 1])])
-    >>> ak.eye(rows=3,cols=3,diag=1,dt=ak.float64)
+    >>> ak.eye(N=3,M=3,k=1,dt=ak.float64)
     array([array([0.00000000000000000 1.00000000000000000 0.00000000000000000])
     array([0.00000000000000000 0.00000000000000000 1.00000000000000000])
     array([0.00000000000000000 0.00000000000000000 0.00000000000000000])])
-    >>> ak.eye(rows=4,cols=4,diag=-1,dt=ak.bool_)
+    >>> ak.eye(N=4,M=4,k=-1,dt=ak.bool_)
     array([array([False False False False]) array([True False False False])
     array([False True False False]) array([False False True False])])
 
     Notes
     -----
-    if rows = cols and diag = 0, the result is an identity matrix
+    if N = M and k = 0, the result is an identity matrix
     Server returns an error if rank of pda < 2
 
     """
 
     cmd = f"eye<{akdtype(dt).name}>"
     args = {
-        "rows": rows,
-        "cols": cols,
-        "diag": diag,
+        "N": N,
+        "M": M,
+        "k": k,
     }
     return create_pdarray(
         generic_msg(

--- a/src/LinalgMsg.chpl
+++ b/src/LinalgMsg.chpl
@@ -29,35 +29,35 @@ module LinalgMsg {
     where array_dtype != BigInteger.bigint
     {
 
-        const rows = msgArgs["rows"].toScalar(int),
-              cols = msgArgs["cols"].toScalar(int),
-              diag = msgArgs["diag"].toScalar(int),
-              shape = (rows, cols);
+        const N = msgArgs["N"].toScalar(int),
+              M = msgArgs["M"].toScalar(int),
+              k = msgArgs["k"].toScalar(int),
+              shape = (N, M);
 
-        // rows, cols = dimensions of 2 dimensional matrix.
-        // diag = 0 gives ones along center diagonal
-        // diag = nonzero moves the diagonal up/right for diag > 0, and down/left for diag < 0
+        // N, M = dimensions of 2 dimensional matrix.
+        // k = 0 gives ones along center diagonal
+        // k = nonzero moves the diagonal up/right for diag > 0, and down/left for diag < 0
         //        See comment below
 
         linalgLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),
-            "cmd: %s dtype: %s aRows: %i: aCols: %i aDiag: %i".format(
-            cmd,type2str(array_dtype),rows,cols,diag));
+            "cmd: %s dtype: %s aN: %i: aM: %i ak: %i".format(
+            cmd,type2str(array_dtype),N,M,k));
 
         var e = createSymEntry((...shape), array_dtype);
 
-        // Now put the ones where they go, on the main diagonal if diag == 0, otherise
-        // up-and-right by 'diag' spaces) if diag > 0,
-        // or down-and-left by abs(diag) spaces if diag < 0
+        // Now put the ones where they go, on the main diagonal if k == 0, otherise
+        // up-and-right by 'k' spaces) if k > 0,
+        // or down-and-left by abs(k) spaces if k < 0
 
-        if diag == 0 {
-            forall ij in 0..<min(rows, cols) do
+        if k == 0 {
+            forall ij in 0..<min(N, M) do
                 e.a[ij, ij] = 1 : array_dtype;
-        } else if diag > 0 {
-            forall i in 0..<min(rows, cols-diag) do
-                e.a[i, i+diag] = 1 : array_dtype;
-        } else if diag < 0 {
-            forall j in 0..<min(rows+diag, cols) do
-                e.a[j-diag, j] = 1 : array_dtype;
+        } else if k > 0 {
+            forall i in 0..<min(N, M-k) do
+                e.a[i, i+k] = 1 : array_dtype;
+        } else if k < 0 {
+            forall j in 0..<min(N+k, M) do
+                e.a[j-k, j] = 1 : array_dtype;
         }
 
         return st.insert(e);

--- a/tests/numpy/numeric_test.py
+++ b/tests/numpy/numeric_test.py
@@ -1086,11 +1086,11 @@ class TestNumeric:
 
         # test on one square and two non-square matrices
 
-        for rows, cols in [(size, size), (size + 1, size - 1), (size - 1, size + 1)]:
-            sweep = range(-(cols - 1), rows)  # sweeps the diagonal from LL to UR
-            for diag in sweep:
-                nda = np.eye(rows, cols, diag, dtype=data_type)
-                pda = ak.eye(rows, cols, diag, dt=data_type).to_ndarray()
+        for N, M in [(size, size), (size + 1, size - 1), (size - 1, size + 1)]:
+            sweep = range(-(M - 1), N)  # sweeps the diagonal from LL to UR
+            for k in sweep:
+                nda = np.eye(N, M, k, dtype=data_type)
+                pda = ak.eye(N, M, k, dt=data_type).to_ndarray()
                 assert check(nda, pda, data_type)
 
     # matmul works on ints, floats, or bool


### PR DESCRIPTION
Closes #4501 

Update -- had to make the same change in the array_api version of eye.

This changes the parameter names of ak.eye to match those of np.eye.