### PR TITLE
Closes #4292:  add doctest to array_api/array_object module

### DIFF
--- a/arkouda/array_api/array_object.py
+++ b/arkouda/array_api/array_object.py
@@ -334,8 +334,8 @@ class Array:
         >>> import numpy as np
         >>> a = np.array([1.0], dtype=np.float32)
         >>> b = np.array(1.0, dtype=np.float64)
-        >>> np.add(a, b) # The spec says this should be float64
-        array([2.])
+        >>> np.add(a, b).dtype # The spec says this should be float64
+        dtype('float64')
 
         To fix this, we add a dimension to the 0-dimension array before passing it
         through. This works because a dimension would be added anyway from

--- a/tests/array_api/array_object.py
+++ b/tests/array_api/array_object.py
@@ -4,6 +4,7 @@ import arkouda.array_api as xp
 
 
 class TestArrayObject:
+    @pytest.mark.skip_if_rank_not_compiled([1, 2, 3])
     def test_array_object_docstrings(self):
         import doctest
 


### PR DESCRIPTION
Adds `doctest` unit test for the `array_api/array_object` module.

Closes #4292:  add doctest to array_api/array_object module