### PR TITLE
Closes #4300:  add doctest to array_api/manipulation_functions module

### DIFF
--- a/arkouda/array_api/manipulation_functions.py
+++ b/arkouda/array_api/manipulation_functions.py
@@ -81,6 +81,7 @@ def concat(arrays: Union[Tuple[Array, ...], List[Array]], /, *, axis: Optional[i
     axis : int, optional
         The axis along which to concatenate the arrays. The default is 0. If None, the arrays are
         flattened before concatenation.
+
     """
 
     ndim = arrays[0].ndim

--- a/tests/array_api/array_manipulation.py
+++ b/tests/array_api/array_manipulation.py
@@ -15,6 +15,17 @@ def randArr(shape):
 
 
 class TestManipulation:
+    @pytest.mark.skip_if_rank_not_compiled([1, 2, 3])
+    def test_manipulation_functions_docstrings(self):
+        import doctest
+
+        from arkouda.array_api import manipulation_functions
+
+        result = doctest.testmod(
+            manipulation_functions, optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE
+        )
+        assert result.failed == 0, f"Doctest failed: {result.failed} failures"
+
     @pytest.mark.skip_if_rank_not_compiled([2, 3])
     def test_broadcast(self):
         a = xp.ones((1, 6, 1))


### PR DESCRIPTION
Adds `doctest` unit test to `array_api/manipulation_functions` module.

Closes #4300:  add doctest to array_api/manipulation_functions module