### PR TITLE
Closes #4293 add doctest to array api constants module

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,7 @@ filterwarnings =
     ignore:Version mismatch between client .*
 testpaths =
     tests/array_api/typing_test.py
+    tests/array_api/constants.py
     tests/array_api/array_creation.py
     tests/array_api/array_manipulation.py
     tests/array_api/binary_ops.py

--- a/tests/array_api/constants.py
+++ b/tests/array_api/constants.py
@@ -1,0 +1,8 @@
+class TestConstants:
+    def test_constants_docstrings(self):
+        import doctest
+
+        from arkouda.array_api import _constants
+
+        result = doctest.testmod(_constants, optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)
+        assert result.failed == 0, f"Doctest failed: {result.failed} failures"


### PR DESCRIPTION
Adds `doctest` unit test for the `array_api/_constants` module.

Closes #4293 add doctest to array api constants module