### PR TITLE
4295 add doctest to array api data type functions module

### DIFF
--- a/arkouda/array_api/array_object.py
+++ b/arkouda/array_api/array_object.py
@@ -334,8 +334,8 @@ class Array:
         >>> import numpy as np
         >>> a = np.array([1.0], dtype=np.float32)
         >>> b = np.array(1.0, dtype=np.float64)
-        >>> np.add(a, b) # The spec says this should be float64
-        array([2.])
+        >>> np.add(a, b).dtype # The spec says this should be float64
+        dtype('float64')
 
         To fix this, we add a dimension to the 0-dimension array before passing it
         through. This works because a dimension would be added anyway from

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,7 @@ filterwarnings =
 testpaths =
     tests/array_api/typing_test.py
     tests/array_api/constants.py
+    tests/array_api/data_type_functions.py
     tests/array_api/array_creation.py
     tests/array_api/array_manipulation.py
     tests/array_api/binary_ops.py

--- a/tests/array_api/data_type_functions.py
+++ b/tests/array_api/data_type_functions.py
@@ -1,0 +1,18 @@
+class TestDataTypeFunctions:
+    def test_dtypes_docstrings(self):
+        import doctest
+
+        from arkouda.array_api import _dtypes
+
+        result = doctest.testmod(_dtypes, optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)
+        assert result.failed == 0, f"Doctest failed: {result.failed} failures"
+
+    def test_data_type_functions_docstrings(self):
+        import doctest
+
+        from arkouda.array_api import data_type_functions
+
+        result = doctest.testmod(
+            data_type_functions, optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE
+        )
+        assert result.failed == 0, f"Doctest failed: {result.failed} failures"


### PR DESCRIPTION
Adds a `doctest` unit test to the `array_api/data_type` and `array_api/_dtypes` modules.

Closes #4295 add doctest to array api data type functions module
Closes #4296: add doctest to array_api/_dtypes module 