### PR TITLE
Switch pydocstyle to numpy convention

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,9 +46,9 @@ require-return-section-when-returning-nothing = True
     
 [pydocstyle]
 #inherit = false
-#   TODO:  Remove all ignore codes
-ignore = D417,D101,D203,D103,D107,D105,D102,D404,D100,D212,D415,D400
+convention = numpy
 match-dir = arkouda
+
 
     
 [darglint]


### PR DESCRIPTION
Switches pydocstyle to numpy convention instead of using an ignore field.