### PR TITLE
Part of #2384: Preserve previous auto-checkpoint

### DIFF
--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -1999,8 +1999,11 @@ def save_checkpoint(name="", path=".akdata", mode: str = "overwrite"):
         The directory to save the checkpoint. If the directory doesn't exist, it
         will be created. If it exists, a new directory for the checkpoint
         instance will be created inside this directory.
-    mode : {'overwrite' | 'error'}
+    mode : {'overwrite' | 'preserve_previous' | 'error'}
         By default, overwrite the checkpoint files if they exist.
+        If 'preserve_previous', an existing checkpoint with 'name' will be
+        renamed to 'name.prev', overwriting 'name.prev' if it existed,
+        before creating a new checkpoint with 'name'.
         If 'error', an error will be raised if a checkpoint with the same name
         exists.
 

--- a/src/ServerDaemon.chpl
+++ b/src/ServerDaemon.chpl
@@ -532,7 +532,6 @@ module ServerDaemon {
                  * remaining payload.
                  */
                 var (rawRequest, _) = reqMsgRaw.splitMsgToTuple(b"BINARY_PAYLOAD",2);
-                var user, token, cmd: string;
 
                 // parse requests, execute requests, format responses
                 /*
@@ -552,12 +551,12 @@ module ServerDaemon {
                 }
 
                 // deserialize the decoded, JSON-formatted cmdStr into a RequestMsg
-                var msg: RequestMsg  = extractRequest(request);
-                user   = msg.user;
-                token  = msg.token;
-                cmd    = msg.cmd;
-                var format = msg.format;
-                var args   = msg.args;
+                const msg: RequestMsg = extractRequest(request);
+                const user   = msg.user;
+                const token  = msg.token;
+                const cmd    = msg.cmd;
+                const format = msg.format;
+                const args   = msg.args;
                 var size: int;
                 try {
                         size = msg.size: int;
@@ -581,7 +580,7 @@ module ServerDaemon {
                 sdLogger.info(getModuleName(),
                                 getRoutineName(),
                                 getLineNumber(),
-                                "MessageArgs: %?".format(msgArgs));
+                                "Command: %s MessageArgs: %?".format(cmd, msgArgs));
 
                 /*
                 * If authentication is enabled with the --authenticate flag, authenticate


### PR DESCRIPTION
Add the ability for `ak.save_checkpoint()` to preserve a checkpoint that is about to be overwritten, by passing to it `mode='preserve_previous'`.

Switch automatic checkpointing to this mode by default instead of `overwrite`. Add the server config `checkpointMode` to control this setting.

While there, touch up ServerDaemon.chpl.
