### PR TITLE
Tweaks a few files to avoid relying on CHPL_HOME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -380,12 +380,14 @@ CHECK_DEPS = check-chpl check-zmq check-hdf5 check-re2 check-arrow check-iconv c
 endif
 check-deps: $(CHECK_DEPS)
 
-SANITIZER = $(shell $(CHPL_HOME)/util/chplenv/chpl_sanitizers.py --exe 2>/dev/null)
+ARKOUDA_CHPL_HOME=$(shell $(CHPL) --print-chpl-home 2>/dev/null)
+
+SANITIZER = $(shell $(ARKOUDA_CHPL_HOME)/util/chplenv/chpl_sanitizers.py --exe 2>/dev/null)
 ifneq ($(SANITIZER),none)
 ARROW_SANITIZE=-fsanitize=$(SANITIZER)
 endif
 
-CHPL_CXX = $(shell $(CHPL_HOME)/util/config/compileline --compile-c++ 2>/dev/null)
+CHPL_CXX = $(shell $(ARKOUDA_CHPL_HOME)/util/config/compileline --compile-c++ 2>/dev/null)
 ifeq ($(CHPL_CXX),)
 CHPL_CXX=$(CXX)
 endif
@@ -574,7 +576,7 @@ arkouda-clean:
 
 .PHONY: tags
 tags:
-	-@(cd $(ARKOUDA_SOURCE_DIR) && $(CHPL_HOME)/util/chpltags -r . > /dev/null \
+	-@(cd $(ARKOUDA_SOURCE_DIR) && $(ARKOUDA_CHPL_HOME)/util/chpltags -r . > /dev/null \
 		&& echo "Updated $(ARKOUDA_SOURCE_DIR)/TAGS" \
 		|| echo "Tags utility not available.  Skipping tags generation.")
 

--- a/benchmark_v2/reformat_benchmark_results.py
+++ b/benchmark_v2/reformat_benchmark_results.py
@@ -67,7 +67,7 @@ if os.getenv("ARKOUDA_SERVER_PARQUET_SUPPORT"):
 
 def get_chpl_util_dir():
     """Get the Chapel directory that contains graph generation utilities."""
-    CHPL_HOME = os.getenv("CHPL_HOME")
+    CHPL_HOME = subprocess.check_output(["chpl", "--print-chpl-home"]).decode().strip()
     if not CHPL_HOME:
         logging.error("$CHPL_HOME not set")
         sys.exit(1)

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -69,7 +69,7 @@ if os.getenv("ARKOUDA_SERVER_PARQUET_SUPPORT"):
 
 def get_chpl_util_dir():
     """Get the Chapel directory that contains graph generation utilities."""
-    CHPL_HOME = os.getenv("CHPL_HOME")
+    CHPL_HOME = subprocess.check_output(["chpl", "--print-chpl-home"]).decode().strip()
     if not CHPL_HOME:
         logging.error("$CHPL_HOME not set")
         sys.exit(1)

--- a/installers.py
+++ b/installers.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 import sys
-from subprocess import PIPE, Popen, TimeoutExpired
+from subprocess import PIPE, CalledProcessError, Popen, TimeoutExpired, check_call
 
 from setuptools.command.build_py import build_py
 
@@ -13,11 +13,11 @@ class ArkoudaBuildError(Exception):
 def chpl_installed():
     """Check to see if chapel is installed and sourced"""
     try:
-        if os.environ["CHPL_HOME"]:
+        if check_call(["chpl", "--version"], stdout=PIPE, stderr=PIPE) == 0:
             print("Existing Chapel install detected")
             return True
         return False
-    except KeyError:
+    except (KeyError, CalledProcessError):
         return False
 
 


### PR DESCRIPTION
Tweaks a few files to avoid relying on CHPL_HOME to build arkouda, as not all Chapel installs may have a `CHPL_HOME` set. For example, linux package installs do not set CHPL_HOME