### PR TITLE
Closes #4352:  Remove the DAR102 errors from the docstrings

### DIFF
--- a/arkouda/categorical.py
+++ b/arkouda/categorical.py
@@ -1326,10 +1326,6 @@ class Categorical:
         """
         Return a list of all component names.
 
-        Parameters
-        ----------
-        None
-
         Returns
         -------
         List[str]
@@ -1346,10 +1342,6 @@ class Categorical:
         """
         Return a JSON formatted string containing information about all components of self.
 
-        Parameters
-        ----------
-        None
-
         Returns
         -------
         str
@@ -1359,18 +1351,7 @@ class Categorical:
         return information(self._list_component_names())
 
     def pretty_print_info(self) -> None:
-        """
-        Print information about all components of self in a human-readable format.
-
-        Parameters
-        ----------
-        None
-
-        Returns
-        -------
-        None
-
-        """
+        """Print information about all components of self in a human-readable format."""
         [p.pretty_print_info() for p in Categorical._get_components_dict(self).values()]
 
     @staticmethod

--- a/arkouda/client_dtypes.py
+++ b/arkouda/client_dtypes.py
@@ -751,9 +751,9 @@ def is_ipv4(ip: Union[pdarray, IPv4], ip2: Optional[pdarray] = None) -> pdarray:
     Parameters
     ----------
     ip: pdarray (int64) or ak.IPv4
-    IPv4 value. High Bits of IPv6 if IPv6 is passed in.
+        IPv4 value. High Bits of IPv6 if IPv6 is passed in.
     ip2: pdarray (int64), Optional
-    Low Bits of IPv6. This is added for support when dealing with data that contains IPv6 as well.
+        Low Bits of IPv6. This is added for support when dealing with data that contains IPv6 as well.
 
     Returns
     -------
@@ -790,9 +790,9 @@ def is_ipv6(ip: Union[pdarray, IPv4], ip2: Optional[pdarray] = None) -> pdarray:
     Parameters
     ----------
     ip: pdarray (int64) or ak.IPv4
-    High Bits of IPv6.
+        High Bits of IPv6.
     ip2: pdarray (int64), Optional
-    Low Bits of IPv6
+        Low Bits of IPv6
 
     Returns
     -------

--- a/arkouda/groupbyclass.py
+++ b/arkouda/groupbyclass.py
@@ -551,10 +551,6 @@ class GroupBy:
 
         This counts the total number of rows (including NaN values).
 
-        Parameters
-        ----------
-        none
-
         Returns
         -------
         List[pdarray|Strings], pdarray|int64

--- a/arkouda/infoclass.py
+++ b/arkouda/infoclass.py
@@ -51,9 +51,9 @@ def information(names: Union[List[str], str] = RegisteredSymbols) -> str:
     Parameters
     ----------
     names : Union[List[str], str]
-       names is either the name of an object or list of names of objects to retrieve info
-       if names is ak.AllSymbols, retrieves info for all symbols in the symbol table
-       if names is ak.RegisteredSymbols, retrieves info for all symbols in the registry
+        names is either the name of an object or list of names of objects to retrieve info
+        if names is ak.AllSymbols, retrieves info for all symbols in the symbol table
+        if names is ak.RegisteredSymbols, retrieves info for all symbols in the registry
 
     Returns
     -------
@@ -109,10 +109,6 @@ def list_symbol_table() -> List[str]:
     """
     Return a list containing the names of all objects in the symbol table
 
-    Parameters
-    ----------
-    None
-
     Returns
     -------
     list
@@ -134,7 +130,7 @@ def _parse_json(names: Union[List[str], str]) -> List[InfoEntry]:
     Parameters
     ----------
     names : Union[List[str], str]
-    Names to pass to information
+        Names to pass to information
 
     Returns
     -------
@@ -157,13 +153,9 @@ def pretty_print_information(names: Union[List[str], str] = RegisteredSymbols) -
     Parameters
     ----------
     names : Union[List[str], str]
-       names is either the name of an object or list of names of objects to retrieve info
-       if names is ak.AllSymbols, retrieves info for all symbols in the symbol table
-       if names is ak.RegisteredSymbols, retrieves info for all symbols in the registry
-
-    Returns
-    -------
-    None
+        names is either the name of an object or list of names of objects to retrieve info
+        if names is ak.AllSymbols, retrieves info for all symbols in the symbol table
+        if names is ak.RegisteredSymbols, retrieves info for all symbols in the registry
 
     Raises
     ------

--- a/arkouda/io.py
+++ b/arkouda/io.py
@@ -658,7 +658,7 @@ def read_hdf(
         Default False, if True this will tell the server to calculate the
         offsets/segments array on the server versus loading them from HDF5 files.
         In the future this option may be set to True as the default.
-    tagData: bool
+    tag_data: bool
         Default False, if True tag the data with the code associated with the filename
         that the data was pulled from.
 
@@ -793,7 +793,7 @@ def read_parquet(
         Default False, if True will allow files with read errors to be skipped
         instead of failing.  A warning will be included in the return containing
         the total number of files skipped due to failure and up to 10 filenames.
-    tagData: bool
+    tag_data: bool
         Default False, if True tag the data with the code associated with the filename
         that the data was pulled from.
     read_nested: bool
@@ -2209,7 +2209,7 @@ def snapshot(filename):
     Parameters
     ----------
     filename: str
-    Name to use when storing file
+        Name to use when storing file
 
     See Also
     --------
@@ -2243,7 +2243,7 @@ def restore(filename):
     Parameters
     ----------
     filename: str
-    Name used to create snapshot to be read
+        Name used to create snapshot to be read
 
     Returns
     -------

--- a/arkouda/numpy/dtypes.py
+++ b/arkouda/numpy/dtypes.py
@@ -513,7 +513,8 @@ def isSupportedInt(num):
 
     Parameters
     ----------
-    scalar: object
+    num: object
+        A scalar.
 
     Returns
     -------
@@ -538,7 +539,8 @@ def isSupportedFloat(num):
 
     Parameters
     ----------
-    scalar: object
+    num: object
+        A scalar.
 
     Returns
     -------
@@ -563,7 +565,8 @@ def isSupportedNumber(num):
 
     Parameters
     ----------
-    scalar: object
+    num: object
+        A scalar.
 
     Returns
     -------
@@ -588,7 +591,8 @@ def isSupportedBool(num):
 
     Parameters
     ----------
-    scalar: object
+    num: object
+        A scalar.
 
     Returns
     -------

--- a/arkouda/numpy/pdarrayclass.py
+++ b/arkouda/numpy/pdarrayclass.py
@@ -1559,10 +1559,6 @@ class pdarray:
         """
         Return True iff the object is contained in the registry
 
-        Parameters
-        ----------
-        None
-
         Returns
         -------
         bool
@@ -1588,10 +1584,6 @@ class pdarray:
         """
         Return a list of all component names
 
-        Parameters
-        ----------
-        None
-
         Returns
         -------
         List[str]
@@ -1601,11 +1593,7 @@ class pdarray:
 
     def info(self) -> str:
         """
-        Return a JSON formatted string containing information about all components of self
-
-        Parameters
-        ----------
-        None
+        Return a JSON formatted string containing information about all components of self.
 
         Returns
         -------
@@ -1615,17 +1603,7 @@ class pdarray:
         return information(self._list_component_names())
 
     def pretty_print_info(self) -> None:
-        """
-        Print information about all components of self in a human readable format
-
-        Parameters
-        ----------
-        None
-
-        Returns
-        -------
-        None
-        """
+        """Print information about all components of self in a human-readable format."""
         pretty_print_information(self._list_component_names())
 
     def is_sorted(
@@ -1952,8 +1930,6 @@ class pdarray:
 
         Parameters
         ----------
-        pda : pdarray
-            Values for which to calculate the mean
         axis : int, Tuple[int, ...], optional, default = None
             The axis or axes along which to do the operation
             If None, the computation is done across the entire array.
@@ -2003,8 +1979,6 @@ class pdarray:
 
         Parameters
         ----------
-        pda : pdarray
-            Values for which to calculate the variance
         ddof : int_scalars
             "Delta Degrees of Freedom" used in calculating var
         axis : int, Tuple[int, ...], optional, default = None
@@ -2077,8 +2051,6 @@ class pdarray:
 
         Parameters
         ----------
-        pda : pdarray
-            values for which to calculate the standard deviation
         ddof : int_scalars
             "Delta Degrees of Freedom" used in calculating std
         axis : int, Tuple[int, ...], optional, default = None

--- a/arkouda/numpy/pdarraycreation.py
+++ b/arkouda/numpy/pdarraycreation.py
@@ -957,7 +957,7 @@ def arange(
     dtype: Optional[Union[np.dtype, type, bigint]] = None,
     max_bits: Optional[int] = None,
 ) -> pdarray:
-    """
+    """# noqa: DAR102
     arange([start,] stop[, step,] dtype=int64)
 
     Create a pdarray of consecutive integers within the interval [start, stop).

--- a/arkouda/numpy/strings.py
+++ b/arkouda/numpy/strings.py
@@ -2660,10 +2660,6 @@ class Strings:
         """
         Return a list of all component names
 
-        Parameters
-        ----------
-        None
-
         Returns
         -------
         List[str]
@@ -2675,10 +2671,6 @@ class Strings:
         """
         Return a JSON formatted string containing information about all components of self
 
-        Parameters
-        ----------
-        None
-
         Returns
         -------
         str
@@ -2687,18 +2679,7 @@ class Strings:
         return information(self._list_component_names())
 
     def pretty_print_info(self) -> None:
-        """
-        Print information about all components of self in a human readable format
-
-        Parameters
-        ----------
-        None
-
-        Returns
-        -------
-        None
-
-        """
+        """Print information about all components of self in a human readable format."""
         self.entry.pretty_print_info()
 
     @typechecked
@@ -2760,13 +2741,6 @@ class Strings:
         Unregister a Strings object in the arkouda server which was previously
         registered using register() and/or attached to using attach()
 
-        Parameters
-        ----------
-
-        Returns
-        -------
-        None
-
         Raises
         ------
         RuntimeError
@@ -2780,6 +2754,7 @@ class Strings:
         -----
         Registered names/Strings objects in the server are immune to deletion until
         they are unregistered.
+
         """
         from arkouda.numpy.util import unregister
 
@@ -2791,10 +2766,6 @@ class Strings:
     def is_registered(self) -> np.bool_:
         """
         Return True iff the object is contained in the registry
-
-        Parameters
-        ----------
-        None
 
         Returns
         -------

--- a/arkouda/testing/_asserters.py
+++ b/arkouda/testing/_asserters.py
@@ -755,8 +755,7 @@ def assert_arkouda_array_equal(
 
     Parameters
     ----------
-    left, right : arkouda.pdarray or arkouda.numpy.Strings or arkouda.Categorical or
-    arkouda.numpy.SegArray
+    left, right : pdarray or Strings or Categorical or SegArray
         The two arrays to be compared.
     check_dtype : bool, default True
         Check dtype if both a and b are ak.pdarray.
@@ -769,6 +768,7 @@ def assert_arkouda_array_equal(
         assertion message.
     index_values : Index | arkouda.pdarray, default None
         optional index (shared by both left and right), used in output.
+
     """
     assert_class_equal(left, right)
 

--- a/arkouda/testing/_equivalence_asserters.py
+++ b/arkouda/testing/_equivalence_asserters.py
@@ -223,7 +223,7 @@ def assert_arkouda_array_equivalent(
 
     Parameters
     ----------
-    left, right : np.ndarray, pd.Categorical, arkouda.pdarray or arkouda.numpy.Strings or
+    left, right : np.ndarray, pd.Categorical, arkouda.pdarray or arkouda.numpy.Strings or \
     arkouda.Categorical
         The two arrays to be compared.
     check_dtype : bool, default True
@@ -470,11 +470,17 @@ def assert_equivalent(left, right, **kwargs) -> None:
 
     Parameters
     ----------
-    left, right : Index, pd.Index, Series, pd.Series, DataFrame, pd.DataFrame,
-    Strings, Categorical, pd.Categorical, SegArray, pdarray, np.ndarray,
-        The two items to be compared.
+    left : Index, pd.Index, Series, pd.Series, DataFrame, pd.DataFrame, \
+Strings, Categorical, pd.Categorical, SegArray, pdarray, np.ndarray
+        The first item to be compared.
+
+    right : Index, pd.Index, Series, pd.Series, DataFrame, pd.DataFrame, \
+Strings, Categorical, pd.Categorical, SegArray, pdarray, np.ndarray
+        The second item to be compared.
+
     **kwargs
         All keyword arguments are passed through to the underlying assert method.
+
     """
     __tracebackhide__ = not DEBUG
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,6 @@ match-dir = arkouda
 strictness = full
 # Which docstring style: google, sphinx, or numpy
 docstring_style = numpy
-ignore=DAR402,DAR103,DAR101,DAR202,DAR002,DAR102,DAR201,DAR401
+ignore=DAR402,DAR103,DAR101,DAR202,DAR002,DAR201,DAR401
 
 


### PR DESCRIPTION
Fixes the `DAR102` errors from the docstrings throughout the project.

Closes #4352:  Remove the DAR102 errors from the docstrings