### PR TITLE
Closes #4555, aligns ak.sign output type to np.sign output type

### DIFF
--- a/src/EfuncMsg.chpl
+++ b/src/EfuncMsg.chpl
@@ -338,7 +338,7 @@ module EfuncMsg
     // sgn is a special case.  It is the only thing that returns int(8).
 
     @arkouda.registerCommand(name="sgn")
-    proc ak_sgn (pda : [?d] ?t) : [d] int(8) throws
+    proc ak_sgn (pda : [?d] ?t) : [d] t throws
         where (t==int || t==real)
     {
         return (sgn(pda));

--- a/tests/numpy/numeric_test.py
+++ b/tests/numpy/numeric_test.py
@@ -426,6 +426,13 @@ class TestNumeric:
         with pytest.raises(TypeError):
             ak.square(np.array([range(-10, 10)]).astype(ak.bool_))
 
+    @pytest.mark.parametrize("num_type", INT_FLOAT)
+    @pytest.mark.parametrize("prob_size", pytest.prob_size)
+    def test_sign(self, prob_size, num_type):
+        nda = np.arange(prob_size).astype(num_type) - prob_size // 2
+        pda = ak.array(nda)
+        assert_arkouda_array_equivalent(np.sign(nda), ak.sign(pda))
+
     #   cumsum and cumprod tests were identical, and so have been combined.
 
     @pytest.mark.parametrize("num_type", NUMERIC_TYPES)


### PR DESCRIPTION
Closes #4555 

The output of ak.sign has been hardcoded to int(8).  This changes it to match the input data type.