### PR TITLE
Closes #4460: Simplify and extend logic in binopvs

### DIFF
--- a/arkouda/numpy/dtypes.py
+++ b/arkouda/numpy/dtypes.py
@@ -219,8 +219,13 @@ def can_cast(from_, to) -> builtins.bool:
 
     """
     if isSupportedInt(from_):
-        if (from_ < 2**64) and (from_ >= 0) and (to == dtype(uint64)):
-            return True
+        if isinstance(from_, int):
+            if (from_ < 2**64) and (from_ >= 0) and (to == dtype(uint64)):
+                return True
+            elif (from_ < 2**63) and (from_ >= -(2**63)) and (to == dtype(int64)):
+                return True
+    elif isSupportedFloat(from_):
+        return _is_dtype_in_union(to, float_scalars)
 
     if (np.isscalar(from_) or _is_dtype_in_union(from_, numeric_scalars)) and not isinstance(
         from_, (int, float, complex)
@@ -255,7 +260,7 @@ def result_type(*args: Union[pdarray, np.dtype, type]) -> Union[np.dtype, type]:
     Notes
     -----
     This function is meant to be a drop-in replacement for numpy.result_type
-    but includes logic to support Arkouda's bigint types.
+    but includes logic to support Arkouda's bigint type.
     """
     from numpy.typing import DTypeLike
 

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -225,7 +225,7 @@ module BinOp
         when "*" { e = (l.a: etype * r.a: etype): etype; }
         when "+" { e = (l.a: etype + r.a: etype): etype; }
         when "-" { e = (l.a: etype - r.a: etype): etype; }
-        when "/" { e = ((l.a: etype) / (r.a: etype)): etype; }
+        when "/" { e = (l.a: etype / r.a: etype): etype; }
         when "%" {
           ref ea = e;
           ref la = l.a;
@@ -297,695 +297,283 @@ module BinOp
 
   }
 
-  proc doBinOpvs(l, val, type etype, op: string, pn, st): MsgTuple throws {
+  proc doBinOpvs(l, val, type lType, type rType, type etype, op: string, pn, st): MsgTuple throws {
     var e = makeDistArray((...l.tupShape), etype);
 
     const nie = notImplementedError(pn,"%s %s %s".format(type2str(l.a.eltType),op,type2str(val.type)));
 
+    use Set;
+    var boolOps: set(string);
+        boolOps.add("<");
+        boolOps.add("<=");
+        boolOps.add(">");
+        boolOps.add(">=");
+        boolOps.add("==");
+        boolOps.add("!=");
+
+    type castType = mySafeCast(lType, rType);
+
+    // The compiler complains that maybe etype is bool if it gets down below this
+    // without returning, so we have to kind of chunk this next piece off.
+
+    // For similar reasons, everything else is kinda split off into its own thing.
+    // The compiler has no common sense about things (and that's not really its fault)
+
     if etype == bool {
-      // Since we know that the result type is a boolean, we know
-      // that it either (1) is an operation between bools or (2) uses
-      // a boolean operator (<, <=, etc.)
-      if l.etype == bool && val.type == bool {
+
+      if boolOps.contains(op) {
+
         select op {
-          when "|" {
-            e = l.a | val;
-          }
-          when "&" {
-            e = l.a & val;
-          }
-          when "^" {
-            e = l.a ^ val;
-          }
-          when "==" {
-            e = l.a == val;
-          }
-          when "!=" {
-            e = l.a != val;
-          }
-          when "<" {
-            e = l.a:int < val:int;
-          }
-          when ">" {
-            e = l.a:int > val:int;
-          }
-          when "<=" {
-            e = l.a:int <= val:int;
-          }
-          when ">=" {
-            e = l.a:int >= val:int;
-          }
-          when "+" {
-            e = l.a | val;
-          }
+
+          when "<" { e = (l.a: castType) < (val: castType); }
+          when "<=" { e = (l.a: castType) <= (val: castType); }
+          when ">" { e = (l.a: castType) > (val: castType); }
+          when ">=" { e = (l.a: castType) >= (val: castType); }
+          when "==" { e = (l.a: castType) == (val: castType); }
+          when "!=" { e = (l.a: castType) != (val: castType); }
+          otherwise do return MsgTuple.error(nie); // Shouldn't happen
+
+        }
+        return st.insert(new shared SymEntry(e));
+      }
+
+      if lType == bool && rType == bool {
+        select op {
+          when "|" { e = l.a | val; }
+          when "&" { e = l.a & val; }
+          when "*" { e = l.a & val; }
+          when "^" { e = l.a ^ val; }
+          when "+" { e = l.a | val; }
           otherwise do return MsgTuple.error(nie);
         }
+        return st.insert(new shared SymEntry(e));
       }
-      // All types support the same binary operations when the resultant
-      // type is bool and `l` and `r` are not both boolean, so this does
-      // not need to be specialized for each case.
-      else {
-        if ((l.etype == real && val.type == bool) || (l.etype == bool && val.type == real)) {
-          select op {
-            when "<" {
-              e = l.a:real < val:real;
-            }
-            when ">" {
-              e = l.a:real > val:real;
-            }
-            when "<=" {
-              e = l.a:real <= val:real;
-            }
-            when ">=" {
-              e = l.a:real >= val:real;
-            }
-            when "==" {
-              e = l.a:real == val:real;
-            }
-            when "!=" {
-              e = l.a:real != val:real;
-            }
-            otherwise do return MsgTuple.error(nie);
-          }
-        }
-        else {
-          select op {
-            when "<" {
-              e = l.a < val;
-            }
-            when ">" {
-              e = l.a > val;
-            }
-            when "<=" {
-              e = l.a <= val;
-            }
-            when ">=" {
-              e = l.a >= val;
-            }
-            when "==" {
-              e = l.a == val;
-            }
-            when "!=" {
-              e = l.a != val;
-            }
-            otherwise do return MsgTuple.error(nie);
-          }
-        }
-      }
-      return st.insert(new shared SymEntry(e));
+
+      return MsgTuple.error(nie);
+
     }
-    // Since we know that both `l` and `r` are of type `int` and that
-    // the resultant type is not bool (checked in first `if`), we know
-    // what operations are supported based on the resultant type
-    else if (l.etype == int && val.type == int) ||
-            (l.etype == uint && val.type == uint) {
-      if etype == int || etype == uint {
-        select op {
-          when "+" {
-            e = l.a + val;
-          }
-          when "-" {
-            e = l.a - val;
-          }
-          when "*" {
-            e = l.a * val;
-          }
-          when "//" { // floordiv
-            ref ea = e;
-            ref la = l.a;
-            [(ei,li) in zip(ea,la)] ei = if val != 0 then li/val else 0;
-          }
-          when "%" { // modulo " <- quote is workaround for syntax highlighter bug
-            ref ea = e;
-            ref la = l.a;
-            [(ei,li) in zip(ea,la)] ei = if val != 0 then li%val else 0;
-          }
-          when "<<" {
-            if 0 <= val && val < 64 {
-              e = l.a << val;
-            }
-          }
-          when ">>" {
-            if 0 <= val && val < 64 {
-              e = l.a >> val;
-            }
-          }
-          when "<<<" {
-            e = rotl(l.a, val);
-          }
-          when ">>>" {
-            e = rotr(l.a, val);
-          }
-          when "&" {
-            e = l.a & val;
-          }                    
-          when "|" {
-            e = l.a | val;
-          }                    
-          when "^" {
-            e = l.a ^ val;
-          }
-          when "**" { 
-            e= l.a**val;
-          }     
-          otherwise do return MsgTuple.error(nie);
-        }
-      } else if etype == real {
-        select op {
-          // True division is the only integer type that would result in a
-          // resultant type of `real`
-          when "/" {
-            e = l.a:real / val:real;
-          }
-          otherwise do return MsgTuple.error(nie);
-        }
-      }
-      return st.insert(new shared SymEntry(e));
-    }
-    else if (etype == int && val.type == uint) ||
-            (etype == uint && val.type == int) {
+
+    else if lType == bool && rType == bool && etype == uint(8) { // Both bools is kinda weird
       select op {
-        when ">>" {
-          if 0 <= val && val < 64 {
-            e = l.a >> val:l.etype;
-          }
+        when "%" { e = (0: uint(8)); } // numpy has these as int(8), but Arkouda doesn't really support that type.
+        when "//" { e = (l.a & val): uint(8); }
+        when "**" { e = (!l.a & val): uint(8); }
+        when "<<" { e = (l.a: uint(8)) << (val: uint(8)); }
+        when ">>" { e = (l.a: uint(8)) >> (val: uint(8)); }
+        otherwise do return MsgTuple.error(nie);
+        // >>> and <<< could probably be implemented as int(8) or uint(8) things
+      }
+      return st.insert(new shared SymEntry(e));
+    }
+
+    else if etype == real(32) || etype == real(64) {
+
+      select op {
+        when "*" { e = (l.a: etype * val: etype): etype; }
+        when "+" { e = (l.a: etype + val: etype): etype; }
+        when "-" { e = (l.a: etype - val: etype): etype; }
+        when "/" { e = (l.a: etype / val: etype): etype; }
+        when "%" {
+          ref ea = e;
+          ref la = l.a;
+          [(ei,li) in zip(ea,la)] ei = modHelper(li: etype, val: etype): etype;
         }
-        when "<<" {
-          if 0 <= val && val < 64 {
-            e = l.a << val:l.etype;
-          }
+        when "//" {
+          ref ea = e;
+          ref la = l.a;
+          [(ei,li) in zip(ea,la)] ei = floorDivisionHelper(li: etype, val: etype): etype;
         }
-        when ">>>" {
-          e = rotr(l.a, val:l.etype);
-        }
-        when "<<<" {
-          e = rotl(l.a, val:l.etype);
-        }
-        when "+" {
-          e = l.a + val:l.etype;
-        }
-        when "-" {
-          e = l.a - val:l.etype;
+        when "**" {
+          e = ((l.a: etype) ** (val: etype)): etype;
         }
         otherwise do return MsgTuple.error(nie);
       }
       return st.insert(new shared SymEntry(e));
+
     }
-    else if (l.etype == bool && val.type == bool) {
+
+    else {
+
       select op {
-        when ">>" {
-          if(val){
-            e = l.a:int >> val:int;
-          }else{
-            e = l.a:int;
-          }
+        when "|" { e = (l.a | val): etype; }
+        when "&" { e = (l.a & val): etype; }
+        when "*" { e = (l.a * val): etype; }
+        when "^" { e = (l.a ^ val): etype; }
+        when "+" { e = (l.a + val): etype; }
+        when "-" { e = (l.a - val): etype; }
+        when "/" { e = (l.a: etype) / (val: etype); }
+        when "%" {
+          ref ea = e;
+          ref la = l.a;
+          [(ei,li) in zip(ea,la)] ei = if val != 0 then li%val else 0;
+        }
+        when "//" {
+          ref ea = e;
+          ref la = l.a;
+          [(ei,li) in zip(ea,la)] ei = if val != 0 then (li/val): etype else 0: etype;
+        }
+        when "**" {
+          if val < 0
+            then return MsgTuple.error("Attempt to exponentiate base of type Int or UInt to negative exponent");
+          e = (l.a: etype) ** (val: etype);
         }
         when "<<" {
-          if(val){
-            e = l.a:int << val:int;
-          }else{
-            e = l.a:int;
-          }
+          ref ea = e;
+          ref la = l.a;
+          [(ei,li) in zip(ea,la)] if (0 <= val && val < numBits(etype)) then ei = ((li: etype) << (val: etype)): etype;
         }
+        when ">>" {
+          ref ea = e;
+          ref la = l.a;
+          [(ei,li) in zip(ea,la)] if (0 <= val && val < numBits(etype)) then ei = ((li: etype) >> (val: etype)): etype;
+        }
+        when "<<<" { e = rotl(l.a: etype, val: etype); }
+        when ">>>" { e = rotr(l.a: etype, val: etype); }
         otherwise do return MsgTuple.error(nie);
       }
       return st.insert(new shared SymEntry(e));
     }
-    // If either RHS or LHS type is real, the same operations are supported and the
-    // result will always be a `real`, so all 3 of these cases can be shared.
-    else if ((l.etype == real && val.type == real) || (l.etype == int && val.type == real)
-             || (l.etype == real && val.type == int)) {
-      select op {
-          when "+" {
-            e = l.a + val;
-          }
-          when "-" {
-            e = l.a - val;
-          }
-          when "*" {
-            e = l.a * val;
-          }
-          when "/" { // truediv
-            e = l.a / val;
-          }
-          when "//" { // floordiv
-            ref ea = e;
-            ref la = l.a;
-            [(ei,li) in zip(ea,la)] ei = floorDivisionHelper(li, val);
-          }
-          when "**" { 
-            e= l.a**val;
-          }
-          when "%" { // modulo " <- quote is workaround for syntax highlighter bug
-            ref ea = e;
-            ref la = l.a;
-            [(ei,li) in zip(ea,la)] ei = modHelper(li, val);
-          }
-          otherwise do return MsgTuple.error(nie);
-        }
-      return st.insert(new shared SymEntry(e));
-    }
-    else if etype == real && ((l.etype == uint && val.type == int) || (l.etype == int && val.type == uint)) {
-      select op {
-          when "+" {
-            e = l.a: real + val: real;
-          }
-          when "-" {
-            e = l.a: real - val: real;
-          }
-          when "/" { // truediv
-            e = l.a: real / val: real;
-          }
-          when "//" { // floordiv
-            ref ea = e;
-            var la = l.a;
-            [(ei,li) in zip(ea,la)] ei = floorDivisionHelper(li, val:real);
-          }
-          otherwise do return MsgTuple.error(nie);
-        }
-      return st.insert(new shared SymEntry(e));
-    }
-    else if ((l.etype == uint && val.type == real) || (l.etype == real && val.type == uint)) {
-      select op {
-          when "+" {
-            e = l.a: real + val: real;
-          }
-          when "-" {
-            e = l.a: real - val: real;
-          }
-          when "*" {
-            e = l.a: real * val: real;
-          }
-          when "/" { // truediv
-            e = l.a: real / val: real;
-          } 
-          when "//" { // floordiv
-            ref ea = e;
-            ref la = l.a;
-            [(ei,li) in zip(ea,la)] ei = floorDivisionHelper(li, val);
-          }
-          when "**" { 
-            e= l.a: real**val: real;
-          }
-          when "%" { // modulo " <- quote is workaround for syntax highlighter bug
-            ref ea = e;
-            ref la = l.a;
-            [(ei,li) in zip(ea,la)] ei = modHelper(li, val);
-          }
-          otherwise do return MsgTuple.error(nie);
-        }
-      return st.insert(new shared SymEntry(e));
-    } else if ((l.etype == int && val.type == bool) || (l.etype == bool && val.type == int)) {
-      select op {
-          when "+" {
-            // Since we don't know which of `l` or `r` is the int and which is the `bool`,
-            // we can just cast both to int, which will be a noop for the vector that is
-            // already `int`
-            e = l.a:int + val:int;
-          }
-          when "-" {
-            e = l.a:int - val:int;
-          }
-          when "*" {
-            e = l.a:int * val:int;
-          }
-          when ">>" {
-            if 0 <= val:int && val:int < 64 {
-              e = l.a:int >> val:int;
-            }
-          }
-          when "<<" {
-            if 0 <= val:int && val:int < 64 {
-              e = l.a:int << val:int;
-            }
-          }
-          otherwise do return MsgTuple.error(nie);
-        }
-      return st.insert(new shared SymEntry(e));
-    } else if ((l.etype == real && val.type == bool) || (l.etype == bool && val.type == real)) {
-      select op {
-          when "+" {
-            e = l.a:real + val:real;
-          }
-          when "-" {
-            e = l.a:real - val:real;
-          }
-          when "*" {
-            e = l.a:real * val:real;
-          }
-          otherwise do return MsgTuple.error(nie);
-        }
-      return st.insert(new shared SymEntry(e));
-    } else {
-      const errorMsg = unrecognizedTypeError(pn, "("+dtype2str(l.dtype)+","+type2str(val.type)+")");
-      omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-      return MsgTuple.error(errorMsg);
-    }
+
+    return MsgTuple.error(nie);
   }
 
-  proc doBinOpsv(val, r, type etype, op: string, pn, st) throws {
+  proc doBinOpsv(val, r, type lType, type rType, type etype, op: string, pn, st) throws {
     var e = makeDistArray((...r.tupShape), etype);
     const nie = notImplementedError(pn,"%s %s %s".format(type2str(val.type),op,type2str(r.a.eltType)));
 
+    use Set;
+    var boolOps: set(string);
+        boolOps.add("<");
+        boolOps.add("<=");
+        boolOps.add(">");
+        boolOps.add(">=");
+        boolOps.add("==");
+        boolOps.add("!=");
+
+    type castType = mySafeCast(lType, rType);
+
+    // The compiler complains that maybe etype is bool if it gets down below this
+    // without returning, so we have to kind of chunk this next piece off.
+
+    // For similar reasons, everything else is kinda split off into its own thing.
+    // The compiler has no common sense about things (and that's not really its fault)
+
     if etype == bool {
-      // Since we know that the result type is a boolean, we know
-      // that it either (1) is an operation between bools or (2) uses
-      // a boolean operator (<, <=, etc.)
-      if r.etype == bool && val.type == bool {
+
+      if boolOps.contains(op) {
+
         select op {
-          when "|" {
-            e = val | r.a;
-          }
-          when "&" {
-            e = val & r.a;
-          }
-          when "^" {
-            e = val ^ r.a;
-          }
-          when "==" {
-            e = val == r.a;
-          }
-          when "!=" {
-            e = val != r.a;
-          }
-          when "<" {
-            e = val:int < r.a:int;
-          }
-          when ">" {
-            e = val:int > r.a:int;
-          }
-          when "<=" {
-            e = val:int <= r.a:int;
-          }
-          when ">=" {
-            e = val:int >= r.a:int;
-          }
-          when "+" {
-            e = val | r.a;
-          }
+
+          when "<" { e = (val: castType) < (r.a: castType); }
+          when "<=" { e = (val: castType) <= (r.a: castType); }
+          when ">" { e = (val: castType) > (r.a: castType); }
+          when ">=" { e = (val: castType) >= (r.a: castType); }
+          when "==" { e = (val: castType) == (r.a: castType); }
+          when "!=" { e = (val: castType) != (r.a: castType); }
+          otherwise do return MsgTuple.error(nie); // Shouldn't happen
+
+        }
+        return st.insert(new shared SymEntry(e));
+      }
+
+      if lType == bool && rType == bool {
+        select op {
+          when "|" { e = val | r.a; }
+          when "&" { e = val & r.a; }
+          when "*" { e = val & r.a; }
+          when "^" { e = val ^ r.a; }
+          when "+" { e = val | r.a; }
           otherwise do return MsgTuple.error(nie);
         }
+        return st.insert(new shared SymEntry(e));
       }
-      // All types support the same binary operations when the resultant
-      // type is bool and `l` and `r` are not both boolean, so this does
-      // not need to be specialized for each case.
-      else {
-        if ((r.etype == real && val.type == bool) || (r.etype == bool && val.type == real)) {
-          select op {
-            when "<" {
-              e = val:real < r.a:real;
-            }
-            when ">" {
-              e = val:real > r.a:real;
-            }
-            when "<=" {
-              e = val:real <= r.a:real;
-            }
-            when ">=" {
-              e = val:real >= r.a:real;
-            }
-            when "==" {
-              e = val:real == r.a:real;
-            }
-            when "!=" {
-              e = val:real != r.a:real;
-            }
-            otherwise do return MsgTuple.error(nie);
-          }
-        }
-        else {
-          select op {
-            when "<" {
-              e = val < r.a;
-            }
-            when ">" {
-              e = val > r.a;
-            }
-            when "<=" {
-              e = val <= r.a;
-            }
-            when ">=" {
-              e = val >= r.a;
-            }
-            when "==" {
-              e = val == r.a;
-            }
-            when "!=" {
-              e = val != r.a;
-            }
-            otherwise do return MsgTuple.error(nie);
-          }
-        }
-      }
-      return st.insert(new shared SymEntry(e));
+
+      return MsgTuple.error(nie);
+
     }
-    // Since we know that both `l` and `r` are of type `int` and that
-    // the resultant type is not bool (checked in first `if`), we know
-    // what operations are supported based on the resultant type
-    else if (r.etype == int && val.type == int) ||
-            (r.etype == uint && val.type == uint) {
-      if etype == int || etype == uint {
-        select op {
-          when "+" {
-            e = val + r.a;
-          }
-          when "-" {
-            e = val - r.a;
-          }
-          when "*" {
-            e = val * r.a;
-          }
-          when "//" { // floordiv
-            ref ea = e;
-            ref ra = r.a;
-            [(ei,ri) in zip(ea,ra)] ei = if ri != 0 then val/ri else 0;
-          }
-          when "%" { // modulo " <- quote is workaround for syntax highlighter bug
-            ref ea = e;
-            ref ra = r.a;
-            [(ei,ri) in zip(ea,ra)] ei = if ri != 0 then val%ri else 0;
-          }
-          when "<<" {
-            ref ea = e;
-            ref ra = r.a;
-            [(ei,ri) in zip(ea,ra)] if (0 <= ri && ri < 64) then ei = val << ri;
-          }                    
-          when ">>" {
-            ref ea = e;
-            ref ra = r.a;
-            [(ei,ri) in zip(ea,ra)] if (0 <= ri && ri < 64) then ei = val >> ri;
-          }
-          when "<<<" {
-            e = rotl(val, r.a);
-          }
-          when ">>>" {
-            e = rotr(val, r.a);
-          }
-          when "&" {
-            e = val & r.a;
-          }                    
-          when "|" {
-            e = val | r.a;
-          }                    
-          when "^" {
-            e = val ^ r.a;
-          }
-          when "**" {
-            if || reduce (r.a<0){
-              var errorMsg = "Attempt to exponentiate base of type Int64 to negative exponent";
-              omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-              return new MsgTuple(errorMsg, MsgType.ERROR); 
-            }
-            e= val**r.a;
-          }
-          otherwise do return MsgTuple.error(nie);
-        }
-      } else if etype == real {
-        select op {
-          // True division is the only integer type that would result in a
-          // resultant type of `real`
-          when "/" {
-            e = val:real / r.a:real;
-          }
-          otherwise do return MsgTuple.error(nie);
-        }
-      }
-      return st.insert(new shared SymEntry(e));
-    }
-    else if (etype == int && val.type == uint) ||
-            (etype == uint && val.type == int) {
+
+    else if lType == bool && rType == bool && etype == uint(8) { // Both bools is kinda weird
       select op {
-        when ">>" {
+        when "%" { e = (0: uint(8)); } // numpy has these as int(8), but Arkouda doesn't really support that type.
+        when "//" { e = (val & r.a): uint(8); }
+        when "**" { e = (!val & r.a): uint(8); }
+        when "<<" { e = (val: uint(8)) << (r.a: uint(8)); }
+        when ">>" { e = (val: uint(8)) >> (r.a: uint(8)); }
+        otherwise do return MsgTuple.error(nie);
+        // >>> and <<< could probably be implemented as int(8) or uint(8) things
+      }
+      return st.insert(new shared SymEntry(e));
+    }
+
+    else if etype == real(32) || etype == real(64) {
+
+      select op {
+        when "*" { e = (val: etype * r.a: etype): etype; }
+        when "+" { e = (val: etype + r.a: etype): etype; }
+        when "-" { e = (val: etype - r.a: etype): etype; }
+        when "/" { e = (val: etype / r.a: etype): etype; }
+        when "%" {
           ref ea = e;
           ref ra = r.a;
-          [(ei,ri) in zip(ea,ra)] if ri:uint < 64 then ei = val:r.etype >> ri;
+          [(ei,ri) in zip(ea,ra)] ei = modHelper(val: etype, ri: etype): etype;
         }
-        when "<<" {
+        when "//" {
           ref ea = e;
           ref ra = r.a;
-          [(ei,ri) in zip(ea,ra)] if ri:uint < 64 then ei = val:r.etype << ri;
+          [(ei,ri) in zip(ea,ra)] ei = floorDivisionHelper(val: etype, ri: etype): etype;
         }
-        when ">>>" {
-          e = rotr(val:r.etype, r.a);
-        }
-        when "<<<" {
-          e = rotl(val:r.etype, r.a);
-        }
-        when "+" {
-          e = val:r.etype + r.a;
-        }
-        when "-" {
-          e = val:r.etype - r.a;
+        when "**" {
+          e = ((val: etype) ** (r.a: etype)): etype;
         }
         otherwise do return MsgTuple.error(nie);
       }
       return st.insert(new shared SymEntry(e));
+
     }
-    // If either RHS or LHS type is real, the same operations are supported and the
-    // result will always be a `real`, so all 3 of these cases can be shared.
-    else if ((r.etype == real && val.type == real) || (r.etype == int && val.type == real)
-             || (r.etype == real && val.type == int)) {
+
+    else {
+
       select op {
-          when "+" {
-            e = val + r.a;
-          }
-          when "-" {
-            e = val - r.a;
-          }
-          when "*" {
-            e = val * r.a;
-          }
-          when "/" { // truediv
-            e = val:real / r.a:real;
-          } 
-          when "//" { // floordiv
-            ref ea = e;
-            ref ra = r.a;
-            [(ei,ri) in zip(ea,ra)] ei = floorDivisionHelper(val:real, ri);
-          }
-          when "**" { 
-            e= val**r.a;
-          }
-          when "%" { // modulo " <- quote is workaround for syntax highlighter bug
-            ref ea = e;
-            ref ra = r.a;
-            [(ei,ri) in zip(ea,ra)] ei = modHelper(val:real, ri);
-          }
-          otherwise do return MsgTuple.error(nie);
+        when "|" { e = (val | r.a): etype; }
+        when "&" { e = (val & r.a): etype; }
+        when "*" { e = (val * r.a): etype; }
+        when "^" { e = (val ^ r.a): etype; }
+        when "+" { e = (val + r.a): etype; }
+        when "-" { e = (val - r.a): etype; }
+        when "/" { e = (val: etype) / (r.a: etype); }
+        when "%" {
+          ref ea = e;
+          ref ra = r.a;
+          [(ei,ri) in zip(ea,ra)] ei = if ri != 0 then val%ri else 0;
         }
-      return st.insert(new shared SymEntry(e));
-    }
-    else if etype == real && ((r.etype == uint && val.type == int) || (r.etype == int && val.type == uint)) {
-      select op {
-          when "+" {
-            e = val:real + r.a:real;
-          }
-          when "-" {
-            e = val:real - r.a:real;
-          }
-          when "/" { // truediv
-            e = val:real / r.a:real;
-          }
-          when "//" { // floordiv
-            ref ea = e;
-            var ra = r.a;
-            [(ei,ri) in zip(ea,ra)] ei = floorDivisionHelper(val:real, ri);
-          }
-          otherwise do return MsgTuple.error(nie);
+        when "//" {
+          ref ea = e;
+          ref ra = r.a;
+          [(ei,ri) in zip(ea,ra)] ei = if ri != 0 then (val/ri): etype else 0: etype;
         }
+        when "**" {
+          if || reduce (r.a<0)
+            then return MsgTuple.error("Attempt to exponentiate base of type Int or UInt to negative exponent");
+          e = (val: etype) ** (r.a: etype);
+        }
+        when "<<" {
+          ref ea = e;
+          ref ra = r.a;
+          [(ei,ri) in zip(ea,ra)] if (0 <= ri && ri < numBits(etype)) then ei = ((val: etype) << (ri: etype)): etype;
+        }
+        when ">>" {
+          ref ea = e;
+          ref ra = r.a;
+          [(ei,ri) in zip(ea,ra)] if (0 <= ri && ri < numBits(etype)) then ei = ((val: etype) >> (ri: etype)): etype;
+        }
+        when "<<<" { e = rotl(val: etype, r.a: etype); }
+        when ">>>" { e = rotr(val: etype, r.a: etype); }
+        otherwise do return MsgTuple.error(nie);
+      }
       return st.insert(new shared SymEntry(e));
     }
-    else if ((r.etype == uint && val.type == real) || (r.etype == real && val.type == uint)) {
-      select op {
-          when "+" {
-            e = val:real + r.a:real;
-          }
-          when "-" {
-            e = val:real - r.a:real;
-          }
-          when "*" {
-            e = val:real * r.a:real;
-          }
-          when "/" { // truediv
-            e = val:real / r.a:real;
-          } 
-          when "//" { // floordiv
-            ref ea = e;
-            ref ra = r.a;
-            [(ei,ri) in zip(ea,ra)] ei = floorDivisionHelper(val:real, ri);
-          }
-          when "**" { 
-            e= val:real**r.a:real;
-          }
-          when "%" { // modulo " <- quote is workaround for syntax highlighter bug
-            ref ea = e;
-            ref ra = r.a;
-            [(ei,ri) in zip(ea,ra)] ei = modHelper(val:real, ri);
-          }
-          otherwise do return MsgTuple.error(nie);
-        }
-      return st.insert(new shared SymEntry(e));
-    } else if ((r.etype == int && val.type == bool) || (r.etype == bool && val.type == int)) {
-      select op {
-          when "+" {
-            // Since we don't know which of `l` or `r` is the int and which is the `bool`,
-            // we can just cast both to int, which will be a noop for the vector that is
-            // already `int`
-            e = val:int + r.a:int;
-          }
-          when "-" {
-            e = val:int - r.a:int;
-          }
-          when "*" {
-            e = val:int * r.a:int;
-          }
-          when ">>" {
-            ref ea = e;
-            ref ra = r.a;
-            [(ei,ri) in zip(ea,ra)] if (0 <= ri && ri < 64) then ei = val:int >> ri:int;
-          }
-          when "<<" {
-            ref ea = e;
-            ref ra = r.a;
-            [(ei,ri) in zip(ea,ra)] if (0 <= ri && ri < 64) then ei = val:int << ri:int;
-          }
-          otherwise do return MsgTuple.error(nie);
-        }
-      return st.insert(new shared SymEntry(e));
-    } else if ((r.etype == real && val.type == bool) || (r.etype == bool && val.type == real)) {
-      select op {
-          when "+" {
-            e = val:real + r.a:real;
-          }
-          when "-" {
-            e = val:real - r.a:real;
-          }
-          when "*" {
-            e = val:real * r.a:real;
-          }
-          otherwise do return MsgTuple.error(nie);
-        }
-      return st.insert(new shared SymEntry(e));
-    } else if (r.etype == bool && val.type == bool)  {
-      select op {
-          when "<<" {
-            if(val){
-              e = val:int << r.a:int;
-            }
-          }
-          when ">>" {
-            if(val){
-              e = val:int >> r.a:int;
-            }
-          }
-          otherwise do return MsgTuple.error(nie);
-        }
-      return st.insert(new shared SymEntry(e));
-    } else {
-      const errorMsg = unrecognizedTypeError(pn, "("+type2str(val.type)+","+type2str(r.a.eltType)+")");
-      omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-      return new MsgTuple(errorMsg, MsgType.ERROR);
-    }
+
+    return MsgTuple.error(nie);
   }
 
   proc doBigIntBinOpvv(l, r, op: string) throws {

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -168,6 +168,7 @@ module OperatorMsg
                                           cmd,op,st.attrib(msgArgs['a'].val), val));
 
         use Set;
+
         // This boolOps set is a filter to determine the output type for the operation.
         // All operations that involve one of these operations result in a `bool` symbol
         // table entry.
@@ -179,135 +180,11 @@ module OperatorMsg
         boolOps.add("==");
         boolOps.add("!=");
 
-        var realOps: set(string);
-        realOps.add("+");
-        realOps.add("-");
-        realOps.add("*");
-        realOps.add("/");
-        realOps.add("//");
+        // This probably doesn't handle all normal bigint cases, but it handles a decent number.
+        // This, at least, can be expanded when BinOp.chpl is cleaned up
+        // It will be reasonably straightforward to clean up here.
 
-        if binop_dtype_a == int && binop_dtype_b == int {
-          if boolOps.contains(op) {
-            return doBinOpvs(l, val, bool, op, pn, st);
-          } else if op == "/" {
-            // True division is the only case in this int, int case
-            // that results in a `real` symbol table entry.
-            return doBinOpvs(l, val, real, op, pn, st);
-          }
-          return doBinOpvs(l, val, int, op, pn, st);
-        } else if binop_dtype_a == int && binop_dtype_b == real {
-          // Only two possible resultant types are `bool` and `real`
-          // for this case
-          if boolOps.contains(op) {
-            return doBinOpvs(l, val, bool, op, pn, st);
-          }
-          return doBinOpvs(l, val, real, op, pn, st);
-        }
-        else if binop_dtype_a == real && binop_dtype_b == int {
-          if boolOps.contains(op) {
-            return doBinOpvs(l, val, bool, op, pn, st);
-          }
-          return doBinOpvs(l, val, real, op, pn, st);
-        }
-        else if binop_dtype_a == uint && binop_dtype_b == real {
-          // Only two possible resultant types are `bool` and `real`
-          // for this case
-          if boolOps.contains(op) {
-            return doBinOpvs(l, val, bool, op, pn, st);
-          }
-          return doBinOpvs(l, val, real, op, pn, st);
-        }
-        else if binop_dtype_a == real && binop_dtype_b == uint {
-          if boolOps.contains(op) {
-            return doBinOpvs(l, val, bool, op, pn, st);
-          }
-          return doBinOpvs(l, val, real, op, pn, st);
-        }
-        else if binop_dtype_a == real && binop_dtype_b == real {
-          if boolOps.contains(op) {
-            return doBinOpvs(l, val, bool, op, pn, st);
-          }
-          return doBinOpvs(l, val, real, op, pn, st);
-        }
-        // For cases where a boolean operand is involved, the only
-        // possible resultant type is `bool`
-        else if binop_dtype_a == bool && binop_dtype_b == bool {
-          if (op == "<<") || (op == ">>") {
-            return doBinOpvs(l, val, int, op, pn, st);
-          }
-          return doBinOpvs(l, val, bool, op, pn, st);
-        }
-        else if binop_dtype_a == bool && binop_dtype_b == int {
-          if boolOps.contains(op) {
-            return doBinOpvs(l, val, bool, op, pn, st);
-          }
-          return doBinOpvs(l, val, int, op, pn, st);
-        }
-        else if binop_dtype_a == int && binop_dtype_b == bool {
-          if boolOps.contains(op) {
-            return doBinOpvs(l, val, bool, op, pn, st);
-          }
-          return doBinOpvs(l, val, int, op, pn, st);
-        }
-        else if binop_dtype_a == bool && binop_dtype_b == real {
-          if boolOps.contains(op) {
-            return doBinOpvs(l, val, bool, op, pn, st);
-          }
-          return doBinOpvs(l, val, real, op, pn, st);
-        }
-        else if binop_dtype_a == real && binop_dtype_b == bool {
-          if boolOps.contains(op) {
-            return doBinOpvs(l, val, bool, op, pn, st);
-          }
-          return doBinOpvs(l, val, real, op, pn, st);
-        }
-        else if binop_dtype_a == bool && binop_dtype_b == uint {
-          if boolOps.contains(op) {
-            return doBinOpvs(l, val, bool, op, pn, st);
-          }
-          return doBinOpvs(l, val, uint, op, pn, st);
-        }
-        else if binop_dtype_a == uint && binop_dtype_b == bool {
-          if boolOps.contains(op) {
-            return doBinOpvs(l, val, bool, op, pn, st);
-          }
-          return doBinOpvs(l, val, uint, op, pn, st);
-        }
-        else if binop_dtype_a == uint && binop_dtype_b == uint {
-          if boolOps.contains(op) {
-            return doBinOpvs(l, val, bool, op, pn, st);
-          }
-          if op == "/"{
-            return doBinOpvs(l, val, real, op, pn, st);
-          } else {
-            return doBinOpvs(l, val, uint, op, pn, st);
-          }
-        }
-        else if binop_dtype_a == uint && binop_dtype_b == int {
-          if boolOps.contains(op) {
-            return doBinOpvs(l, val, bool, op, pn, st);
-          }
-          // +, -, /, // both result in real outputs to match NumPy
-          if realOps.contains(op) {
-            return doBinOpvs(l, val, real, op, pn, st);
-          } else {
-            // isn't +, -, /, // so we can use LHS to determine type
-            return doBinOpvs(l, val, uint, op, pn, st);
-          }
-        }
-        else if binop_dtype_a == int && binop_dtype_b == uint {
-          if boolOps.contains(op) {
-            return doBinOpvs(l, val, bool, op, pn, st);
-          }
-          // +, -, /, // both result in real outputs to match NumPy
-          if realOps.contains(op) {
-            return doBinOpvs(l, val, real, op, pn, st);
-          } else {
-            // isn't +, -, /, // so we can use LHS to determine type
-            return doBinOpvs(l, val, int, op, pn, st);
-          }
-        }
-        else if (binop_dtype_a == bigint || binop_dtype_b == bigint) &&
+        if (binop_dtype_a == bigint || binop_dtype_b == bigint) &&
                 !isRealType(binop_dtype_a) && !isRealType(binop_dtype_b)
         {
           if boolOps.contains(op) {
@@ -317,11 +194,57 @@ module OperatorMsg
           // call bigint specific func which returns dist bigint array
           const (tmp, max_bits) = doBigIntBinOpvs(l, val, op);
           return st.insert(new shared SymEntry(tmp, max_bits));
-        } else {
+        } else if (binop_dtype_a == bigint || binop_dtype_b == bigint) {
           const errorMsg = unrecognizedTypeError(pn, "("+type2str(binop_dtype_a)+","+type2str(binop_dtype_b)+")");
           omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-          return MsgTuple.error(errorMsg);
+          return new MsgTuple(errorMsg, MsgType.ERROR);
         }
+
+        if boolOps.contains(op) {
+          return doBinOpvs(l, val, binop_dtype_a, binop_dtype_b, bool, op, pn, st);
+        }
+
+        if op == "/" {
+          if binop_dtype_a == real(32) && isSmallType(binop_dtype_b) {
+            return doBinOpvs(l, val, binop_dtype_a, binop_dtype_b, real(32), op, pn, st);
+          }
+          if binop_dtype_b == real(32) && isSmallType(binop_dtype_a) {
+            return doBinOpvs(l, val, binop_dtype_a, binop_dtype_b, real(32), op, pn, st);
+          }
+          return doBinOpvs(l, val, binop_dtype_a, binop_dtype_b, real(64), op, pn, st);
+        }
+
+        var realOps: set(string);
+        realOps.add("+");
+        realOps.add("-");
+        realOps.add("*");
+        realOps.add("//");
+        realOps.add("%");
+        realOps.add("**");
+
+        type returnType = mySafeCast(binop_dtype_a, binop_dtype_b);
+
+        if (!realOps.contains(op)) && (returnType == real(32) || returnType == real(64)) {
+          const errorMsg = unrecognizedTypeError(pn, "("+type2str(binop_dtype_a)+","+type2str(binop_dtype_b)+")");
+          omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+          return new MsgTuple(errorMsg, MsgType.ERROR);
+        }
+
+        if returnType == bool {
+          if op == "+" || op == "*" || (!realOps.contains(op)) {
+            return doBinOpvs(l, val, binop_dtype_a, binop_dtype_b, bool, op, pn, st);
+          }
+          if op == "-" {
+            const errorMsg = unrecognizedTypeError(pn, "("+type2str(binop_dtype_a)+","+type2str(binop_dtype_b)+")");
+            omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+          }
+          if op == "//" || op == "%" || op == "**" {
+            return doBinOpvs(l, val, binop_dtype_a, binop_dtype_b, uint(8), op, pn, st);
+          }
+        }
+
+        return doBinOpvs(l, val, binop_dtype_a, binop_dtype_b, returnType, op, pn, st);
     }
 
     /*
@@ -354,6 +277,7 @@ module OperatorMsg
                                    cmd,op,type2str(binop_dtype_b),msgArgs['value'].val,st.attrib(msgArgs['a'].val)));
 
         use Set;
+
         // This boolOps set is a filter to determine the output type for the operation.
         // All operations that involve one of these operations result in a `bool` symbol
         // table entry.
@@ -365,147 +289,71 @@ module OperatorMsg
         boolOps.add("==");
         boolOps.add("!=");
 
-        var realOps: set(string);
-        realOps.add("+");
-        realOps.add("-");
-        realOps.add("/");
-        realOps.add("//");
+        // This probably doesn't handle all normal bigint cases, but it handles a decent number.
+        // This, at least, can be expanded when BinOp.chpl is cleaned up
+        // It will be reasonably straightforward to clean up here.
 
-        if binop_dtype_a == int && binop_dtype_b == int {
+        if (binop_dtype_a == bigint || binop_dtype_b == bigint) &&
+                !isRealType(binop_dtype_a) && !isRealType(binop_dtype_b)
+        {
           if boolOps.contains(op) {
-            return doBinOpsv(val, r, bool, op, pn, st);
-          } else if op == "/" {
-            // True division is the only case in this int, int case
-            // that results in a `real` symbol table entry.
-            return doBinOpsv(val, r, real, op, pn, st);
-          }
-          return doBinOpsv(val, r, int, op, pn, st);
-        }
-        else if binop_dtype_a == int && binop_dtype_b == real {
-          // Only two possible resultant types are `bool` and `real`
-          // for this case
-          if boolOps.contains(op) {
-            return doBinOpsv(val, r, bool, op, pn, st);
-          }
-          return doBinOpsv(val, r, real, op, pn, st);
-        }
-        else if binop_dtype_a == real && binop_dtype_b == int {
-          if boolOps.contains(op) {
-            return doBinOpsv(val, r, bool, op, pn, st);
-          }
-          return doBinOpsv(val, r, real, op, pn, st);
-        }
-        else if binop_dtype_a == uint && binop_dtype_b == real {
-          // Only two possible resultant types are `bool` and `real`
-          // for this case
-          if boolOps.contains(op) {
-            return doBinOpsv(val, r, bool, op, pn, st);
-          }
-          return doBinOpsv(val, r, real, op, pn, st);
-        }
-        else if binop_dtype_a == real && binop_dtype_b == uint {
-          if boolOps.contains(op) {
-            return doBinOpsv(val, r, bool, op, pn, st);
-          }
-          return doBinOpsv(val, r, real, op, pn, st);
-        }
-        else if binop_dtype_a == real && binop_dtype_b == real {
-          if boolOps.contains(op) {
-            return doBinOpsv(val, r, bool, op, pn, st);
-          }
-          return doBinOpsv(val, r, real, op, pn, st);
-        }
-        // For cases where a boolean operand is involved, the only
-        // possible resultant type is `bool`
-        else if binop_dtype_a == bool && binop_dtype_b == bool {
-          if (op == "<<") || (op == ">>") {
-            return doBinOpsv(val, r, int, op, pn, st);
-          }
-          return doBinOpsv(val, r, bool, op, pn, st);
-        }
-        else if binop_dtype_a == bool && binop_dtype_b == int {
-          if boolOps.contains(op) {
-            return doBinOpsv(val, r, bool, op, pn, st);
-          }
-          return doBinOpsv(val, r, int, op, pn, st);
-        }
-        else if binop_dtype_a == int && binop_dtype_b == bool {
-          if boolOps.contains(op) {
-            return doBinOpsv(val, r, bool, op, pn, st);
-          }
-          return doBinOpsv(val, r, int, op, pn, st);
-        }
-        else if binop_dtype_a == bool && binop_dtype_b == real {
-          if boolOps.contains(op) {
-            return doBinOpsv(val, r, bool, op, pn, st);
-          }
-          return doBinOpsv(val, r, real, op, pn, st);
-        }
-        else if binop_dtype_a == real && binop_dtype_b == bool {
-          if boolOps.contains(op) {
-            return doBinOpsv(val, r, bool, op, pn, st);
-          }
-          return doBinOpsv(val, r, real, op, pn, st);
-        }
-        else if binop_dtype_a == bool && binop_dtype_b == uint {
-          if boolOps.contains(op) {
-            return doBinOpsv(val, r, bool, op, pn, st);
-          }
-          return doBinOpsv(val, r, uint, op, pn, st);
-        }
-        else if binop_dtype_a == uint && binop_dtype_b == bool {
-          if boolOps.contains(op) {
-            return doBinOpsv(val, r, bool, op, pn, st);
-          }
-          return doBinOpsv(val, r, uint, op, pn, st);
-        }
-        else if binop_dtype_a == uint && binop_dtype_b == uint {
-          if boolOps.contains(op) {
-            return doBinOpsv(val, r, bool, op, pn, st);
-          }
-          if op == "/"{
-            return doBinOpsv(val, r, real, op, pn, st);
-          } else {
-            return doBinOpsv(val, r, uint, op, pn, st);
-          }
-        }
-        else if binop_dtype_a == uint && binop_dtype_b == int {
-          if boolOps.contains(op) {
-            return doBinOpsv(val, r, bool, op, pn, st);
-          }
-          // +, -, /, // both result in real outputs to match NumPy
-          if realOps.contains(op) {
-            return doBinOpsv(val, r, real, op, pn, st);
-          } else {
-            // isn't +, -, /, // so we can use LHS to determine type
-            return doBinOpsv(val, r, uint, op, pn, st);
-          }
-        }
-        else if binop_dtype_a == int && binop_dtype_b == uint {
-          if boolOps.contains(op) {
-            return doBinOpsv(val, r, bool, op, pn, st);
-          }
-          // +, -, /, // both result in real outputs to match NumPy
-          if realOps.contains(op) {
-            return doBinOpsv(val, r, real, op, pn, st);
-          } else {
-            // isn't +, -, /, // so we can use LHS to determine type
-            return doBinOpsv(val, r, int, op, pn, st);
-          }
-        }
-        else if (binop_dtype_a == bigint || binop_dtype_b == bigint) &&
-                !isRealType(binop_dtype_a) && !isRealType(binop_dtype_b) {
-          if boolOps.contains(op) {
+            // call bigint specific func which returns distr bool array
             return st.insert(new shared SymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
           }
           // call bigint specific func which returns dist bigint array
           const (tmp, max_bits) = doBigIntBinOpsv(val, r, op);
           return st.insert(new shared SymEntry(tmp, max_bits));
-        } else {
+        } else if (binop_dtype_a == bigint || binop_dtype_b == bigint) {
           const errorMsg = unrecognizedTypeError(pn, "("+type2str(binop_dtype_a)+","+type2str(binop_dtype_b)+")");
           omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
-          return MsgTuple.error(errorMsg);
+          return new MsgTuple(errorMsg, MsgType.ERROR);
         }
+
+        if boolOps.contains(op) {
+          return doBinOpsv(val, r, binop_dtype_a, binop_dtype_b, bool, op, pn, st);
+        }
+
+        if op == "/" {
+          if binop_dtype_a == real(32) && isSmallType(binop_dtype_b) {
+            return doBinOpsv(val, r, binop_dtype_a, binop_dtype_b, real(32), op, pn, st);
+          }
+          if binop_dtype_b == real(32) && isSmallType(binop_dtype_a) {
+            return doBinOpsv(val, r, binop_dtype_a, binop_dtype_b, real(32), op, pn, st);
+          }
+          return doBinOpsv(val, r, binop_dtype_a, binop_dtype_b, real(64), op, pn, st);
+        }
+
+        var realOps: set(string);
+        realOps.add("+");
+        realOps.add("-");
+        realOps.add("*");
+        realOps.add("//");
+        realOps.add("%");
+        realOps.add("**");
+
+        type returnType = mySafeCast(binop_dtype_a, binop_dtype_b);
+
+        if (!realOps.contains(op)) && (returnType == real(32) || returnType == real(64)) {
+          const errorMsg = unrecognizedTypeError(pn, "("+type2str(binop_dtype_a)+","+type2str(binop_dtype_b)+")");
+          omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+          return new MsgTuple(errorMsg, MsgType.ERROR);
+        }
+
+        if returnType == bool {
+          if op == "+" || op == "*" || (!realOps.contains(op)) {
+            return doBinOpsv(val, r, binop_dtype_a, binop_dtype_b, bool, op, pn, st);
+          }
+          if op == "-" {
+            const errorMsg = unrecognizedTypeError(pn, "("+type2str(binop_dtype_a)+","+type2str(binop_dtype_b)+")");
+            omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
+            return new MsgTuple(errorMsg, MsgType.ERROR);
+          }
+          if op == "//" || op == "%" || op == "**" {
+            return doBinOpsv(val, r, binop_dtype_a, binop_dtype_b, uint(8), op, pn, st);
+          }
+        }
+
+        return doBinOpsv(val, r, binop_dtype_a, binop_dtype_b, returnType, op, pn, st);
     }
 
     /*

--- a/tests/numpy/numeric_test.py
+++ b/tests/numpy/numeric_test.py
@@ -1198,7 +1198,6 @@ class TestNumeric:
     def test_can_cast(self):
         from arkouda.numpy.dtypes import can_cast
 
-        assert can_cast(np.int64(5), "uint64")
         assert can_cast(ak.int64, ak.int64)
         assert not can_cast(ak.int64, ak.uint64)
 

--- a/tests/numpy/sort_test.py
+++ b/tests/numpy/sort_test.py
@@ -154,10 +154,10 @@ class TestSort:
                 pytest.skip(f"Server not compiled for rank {len(v_shape)}")
             else:
                 v = ak.randint(low=low, high=high, size=v_shape, dtype=dtype_, seed=pytest.seed)
-                v = ak.array(ak.array(v, dtype) + shift, dtype)
+                v = ak.array(v, dtype) + shift
         a = ak.randint(low=low, high=high, size=size, dtype=dtype_, seed=pytest.seed)
         a = ak.sort(a)
-        a = ak.array(ak.array(a, dtype) + shift, dtype)
+        a = ak.array(a, dtype) + shift
         np_a = a.to_ndarray()
         if isinstance(v, ak.pdarray):
             np_v = v.to_ndarray()


### PR DESCRIPTION
Applied mostly the same changes to `binopvs` and `binopsv` from `binopvv`. This could possibly benefit from being collapsed into one function that works regardless of vector or scalar.

Closes #4460: Simplify and extend logic in binopvs
Closes #4461: Simplify and extend logic in binopsv