### PR TITLE
Closes #4597:  implement pandas ExtensionArray for arkouda

### DIFF
--- a/arkouda/__init__.py
+++ b/arkouda/__init__.py
@@ -1,6 +1,7 @@
 # isort: skip_file
 # flake8: noqa
 # isort: skip_file
+# arkouda/__init__.py
 # do not run isort, imports are order dependent
 """
 Arkouda: Exploratory data science at scale.
@@ -121,6 +122,7 @@ from arkouda.numpy import (
     bitType,
     bool,
     bool_,
+    bool,
     bool_scalars,
     broadcast_dims,
     broadcast_to_shape,
@@ -352,6 +354,12 @@ from arkouda.pandas import (
     join_on_eq_with_dt,
     row,
     series,
+    ArkoudaArray,
+    ArkoudaDtype,
+    ArkoudaStringArray,
+    ArkoudaStringDtype,
+    ArkoudaCategoricalArray,
+    ArkoudaCategoricalDtype,
 )
 from arkouda.client import (
     connect,

--- a/arkouda/numpy/__init__.py
+++ b/arkouda/numpy/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 # isort: skip_file
+# arkouda/numpy/__init__.py
 from arkouda.numpy.imports import (
     False_,
     ScalarType,

--- a/arkouda/numpy/pdarrayclass.py
+++ b/arkouda/numpy/pdarrayclass.py
@@ -1105,6 +1105,8 @@ class pdarray:
 
     # overload a[] to treat like list
     def __getitem__(self, key):
+        import numpy as np
+
         from arkouda.client import generic_msg
 
         if self.ndim == 1 and np.isscalar(key) and (resolve_scalar_dtype(key) in ["int64", "uint64"]):
@@ -1230,6 +1232,12 @@ class pdarray:
             else:
                 return ret_array
 
+        # Support NumPy integer array indexing (used in pandas internals)
+        if isinstance(key, np.ndarray) and np.issubdtype(key.dtype, np.integer) and self.ndim == 1:
+            from arkouda.numpy.pdarraycreation import array as ak_array
+
+            key = ak_array(key)
+
         if isinstance(key, pdarray) and self.ndim == 1:
             if key.dtype not in ("bool", "int", "uint"):
                 raise TypeError(f"unsupported pdarray index type {key.dtype}")
@@ -1243,6 +1251,8 @@ class pdarray:
                 },
             )
             return create_pdarray(repMsg)
+
+        import numpy as np
 
         if isinstance(key, slice):
             # handle the arr[:] case

--- a/arkouda/numpy/strings.py
+++ b/arkouda/numpy/strings.py
@@ -401,6 +401,11 @@ class Strings:
                 },
             )
             return Strings.from_return_msg(repMsg)
+        elif isinstance(key, np.ndarray):
+            # convert numpy array to pdarray
+            from arkouda.numpy.pdarraycreation import array as ak_array
+
+            return self[ak_array(key)]
         else:
             raise TypeError(f"unsupported pdarray index type {key.__class__.__name__}")
 

--- a/arkouda/pandas/__init__.py
+++ b/arkouda/pandas/__init__.py
@@ -1,4 +1,8 @@
 # flake8: noqa
+# arkouda/pandas/__init__.py
 from arkouda.pandas.join import compute_join_size, gen_ranges, join_on_eq_with_dt
 from arkouda.pandas.row import Row
 from arkouda.pandas.series import Series
+from arkouda.pandas.extension import ArkoudaArray, ArkoudaDtype
+from arkouda.pandas.extension import ArkoudaCategoricalArray, ArkoudaCategoricalDtype
+from arkouda.pandas.extension import ArkoudaStringArray, ArkoudaStringDtype

--- a/arkouda/pandas/extension/__init__.py
+++ b/arkouda/pandas/extension/__init__.py
@@ -1,0 +1,13 @@
+# arkouda/pandas/extension/__init__.py
+from ._arkouda_array import ArkoudaArray, ArkoudaDtype
+from ._arkouda_categorical_array import ArkoudaCategoricalArray, ArkoudaCategoricalDtype
+from ._arkouda_string_array import ArkoudaStringArray, ArkoudaStringDtype
+
+__all__ = [
+    "ArkoudaArray",
+    "ArkoudaDtype",
+    "ArkoudaStringArray",
+    "ArkoudaStringDtype",
+    "ArkoudaCategoricalArray",
+    "ArkoudaCategoricalDtype",
+]

--- a/arkouda/pandas/extension/_arkouda_array.py
+++ b/arkouda/pandas/extension/_arkouda_array.py
@@ -1,0 +1,213 @@
+from typing import Any
+
+import numpy as np
+from numpy import ndarray
+from pandas.api.extensions import ExtensionArray, ExtensionDtype
+
+from arkouda.numpy.dtypes import dtype as ak_dtype
+from arkouda.numpy.pdarraycreation import array as ak_array
+from arkouda.numpy.pdarraycreation import full as ak_full
+from arkouda.numpy.pdarraycreation import pdarray
+
+from ._arkouda_base_array import ArkoudaBaseArray
+
+__all__ = ["ArkoudaArray", "ArkoudaDtype"]
+
+
+class ArkoudaDtype(ExtensionDtype):
+    # implement required properties/methods here
+    name = "arkouda"
+    type = object  # or the underlying Python type, like int/str
+    kind = "O"
+
+    @classmethod
+    def construct_array_type(cls):
+        from ._arkouda_array import ArkoudaArray
+
+        return ArkoudaArray
+
+    @property
+    def na_value(self):
+        return -1  # or np.nan or None depending on your use case
+
+    #   TODO: Implement numpy_dtype function
+    # @property
+    # def numpy_dtype(self):
+    #     return np.int64  # or whatever underlies this EA
+
+
+class ArkoudaArray(ArkoudaBaseArray, ExtensionArray):
+    default_fill_value = -1
+
+    def __init__(self, data):
+        if isinstance(data, np.ndarray):
+            data = ak_array(data)
+        if not isinstance(data, pdarray):
+            raise TypeError("Expected an Arkouda pdarray")
+        self._data = data
+
+    # in _arkouda_array.py
+
+    @classmethod
+    def _from_sequence(cls, scalars, dtype=None, copy=False):
+        # If pandas passes our own EA dtype, ignore it and infer from data
+        if isinstance(dtype, ArkoudaDtype):
+            dtype = None
+        # If scalars is already a numpy array, we can preserve its dtype
+        return cls(ak_array(scalars, dtype=dtype, copy=copy))
+
+    def __getitem__(self, key):
+        # Convert numpy boolean mask to arkouda pdarray
+        if isinstance(key, np.ndarray):
+            if key.dtype == bool:
+                key = ak_array(key)
+            elif key.dtype.kind in {"i"}:
+                key = ak_array(key, dtype="int64")
+            elif key.dtype.kind in {"u"}:
+                key = ak_array(key, dtype="uint64")
+            else:
+                raise TypeError(f"Unsupported numpy index type {key.dtype}")
+
+        result = self._data[key]
+        if np.isscalar(key):
+            if isinstance(result, pdarray):
+                return result[0]
+            else:
+                return result
+        return self.__class__(result)
+
+    #   TODO:  Simplify to use underlying array setter
+    def __setitem__(self, key, value):
+        from arkouda.numpy.dtypes import isSupportedInt
+
+        # Convert numpy mask to pdarray if necessary
+        if isinstance(key, np.ndarray) and key.dtype == bool:
+            key = ak_array(key)
+        elif isinstance(key, np.ndarray) and isSupportedInt(key.dtype):
+            key = ak_array(key)
+        if isinstance(value, ArkoudaArray):
+            value = value._data
+        elif isinstance(value, pdarray):
+            pass
+        elif isinstance(value, (int, float, bool)):  # Add scalar check
+            self._data[key] = value  # assign scalar to scalar position
+            return
+        else:
+            value = ak_array(value)
+
+        self._data[key] = value
+
+    def __len__(self):
+        return int(self._data.size)
+
+    def astype(self, dtype, copy: bool = False):
+        # Always hand back a real object-dtype ndarray when object is requested
+        if dtype in (object, np.object_, "object", np.dtype("O")):
+            return self.to_ndarray().astype(object, copy=copy)
+
+        if isinstance(dtype, ArkoudaDtype):
+            return self.copy() if copy else self
+
+        # Server-side cast for numeric/bool
+        try:
+            npdt = np.dtype(dtype)
+        except Exception:
+            return self.to_ndarray().astype(dtype, copy=copy)
+
+        from arkouda.numpy.numeric import cast as ak_cast
+
+        if npdt.kind in {"i", "u", "f", "b"}:
+            return type(self)(ak_cast(self._data, ak_dtype(npdt.name)))
+
+        # Fallback: local cast
+        return self.to_ndarray().astype(npdt, copy=copy)
+
+    def isna(self) -> ExtensionArray | ndarray[Any, Any]:
+        from arkouda.numpy import isnan
+        from arkouda.numpy.util import is_float
+
+        if not is_float(self._data):
+            return ak_full(self._data.size, False, dtype=bool)
+
+        return isnan(self._data)
+
+    #   TODO:  use pdarray.copy()
+    def copy(self):
+        return ArkoudaArray(self._data[:])
+
+    @property
+    def dtype(self):
+        return ArkoudaDtype()
+
+    @property
+    def nbytes(self):
+        return self._data.nbytes
+
+    def to_numpy(self, dtype=None, copy=False, na_value=np.nan):
+        return self._data.to_ndarray()
+        # return ak_array(self._data)
+
+    def equals(self, other):
+        if not isinstance(other, ArkoudaArray):
+            return False
+        return self._data.equals(other._data)
+
+    #   TODO:  add pandas arguments
+    def argsort(self, ascending=True):
+        perm = self._data.argsort(ascending=ascending)
+        return perm
+
+    def _reduce(self, name, skipna=True, **kwargs):
+        if name == "all":
+            return self._data.all()
+        elif name == "any":
+            return self._data.any()
+        elif name == "sum":
+            return self._data.sum()
+        elif name == "prod":
+            return self._data.prod()
+        elif name == "min":
+            return self._data.min()
+        elif name == "max":
+            return self._data.max()
+        else:
+            raise TypeError(f"'ArkoudaArray' with dtype arkouda does not support reduction '{name}'")
+
+    def __eq__(self, other):
+        if isinstance(other, ArkoudaArray):
+            return self._data == other._data
+        return self._data == other
+
+    def __repr__(self):
+        return f"ArkoudaArray({self._data})"
+
+    #   TODO:  refine this.
+    def _values_for_factorize(self):
+        """
+        Return (values, na_value) as NumPy for pandas.factorize.
+        Ensure 'values' is 1-D numpy array and 'na_value' is the sentinel to use.
+        """
+        vals = self.to_ndarray()  # materialize to numpy
+        if vals.dtype.kind in {"U", "S", "O"}:
+            na = ""  # strings: empty as sentinel is OK for factorize
+        elif vals.dtype.kind in {"i", "u"}:
+            na = -1
+        else:
+            na = np.nan
+        return vals, na
+
+    @classmethod
+    def _from_factorized(cls, uniques, original):
+        # pandas gives us numpy uniques; preserve dtype by deferring to _from_sequence
+        return cls._from_sequence(uniques)
+
+    def factorize(self, *, sort=False, use_na_sentinel=True, **kwargs):
+        import numpy as np
+        import pandas as pd
+
+        codes, uniques = pd.factorize(
+            np.asarray(self.to_numpy()),
+            sort=sort,
+            use_na_sentinel=use_na_sentinel,
+        )
+        return codes, uniques

--- a/arkouda/pandas/extension/_arkouda_base_array.py
+++ b/arkouda/pandas/extension/_arkouda_base_array.py
@@ -1,0 +1,180 @@
+"""
+Base extension array infrastructure for Arkouda-backed pandas objects.
+
+This module defines :class:`ArkoudaBaseArray`, an abstract base class implementing
+common logic for pandas ``ExtensionArray`` subclasses that store their data in Arkouda
+server-side arrays. It provides core methods like construction from sequences,
+concatenation, conversion to NumPy, and a generalized ``take`` implementation
+supporting missing-value fills.
+
+Classes in this module are not intended to be instantiated directly—subclasses should
+wrap specific Arkouda types such as numeric arrays, strings, or categoricals, and
+must ensure that the internal ``_data`` attribute references the correct Arkouda
+array type.
+
+Classes
+-------
+ArkoudaBaseArray(ExtensionArray)
+    Base class for Arkouda-backed pandas extension arrays, implementing shared
+    behaviors and bridging pandas’ extension array API with Arkouda server arrays.
+
+Notes
+-----
+This module is designed to integrate with pandas' extension array interface. It
+is used internally by Arkouda's pandas extension types and not generally part of
+the public user-facing API. Subclasses must implement certain abstract or
+datatype-specific methods, such as ``_fill_missing``.
+
+Examples
+--------
+>>> import arkouda as ak
+>>> from arkouda.pandas.extension._arkouda_base_array import ArkoudaBaseArray
+>>> arr = ak.array([1, 2, 3])
+>>> class MyArray(ArkoudaBaseArray): pass
+>>> a = MyArray(arr)
+>>> len(a)
+3
+>>> a.to_numpy()
+array([1, 2, 3])
+
+The ``take`` method supports missing values via ``allow_fill=True``:
+
+>>> import numpy as np
+>>> idx = np.array([0, -1, 2])
+>>> a.take(idx, allow_fill=True, fill_value=99).to_numpy()
+array([ 1, 99,  3])
+
+"""
+
+import numpy as np
+from pandas.api.extensions import ExtensionArray
+
+from arkouda.numpy.pdarrayclass import pdarray
+from arkouda.numpy.pdarraycreation import array as ak_array
+from arkouda.numpy.pdarraysetops import concatenate as ak_concat
+from arkouda.numpy.strings import Strings
+
+__all__ = ["_ensure_numpy", "ArkoudaBaseArray"]
+
+
+def _ensure_numpy(x):
+    if hasattr(x, "to_ndarray"):
+        return x.to_ndarray()
+    return np.asarray(x)
+
+
+class ArkoudaBaseArray(ExtensionArray):
+    def __init__(self, data):
+        # Subclasses should ensure this is the correct ak object
+        self._data = data
+
+    def __len__(self):
+        return int(self._data.size)
+
+    @classmethod
+    def _from_sequence(cls, scalars, dtype=None, copy=False):
+        from arkouda.numpy.pdarraycreation import array as ak_array
+
+        # If caller already passed an arkouda array, honor it
+        if isinstance(scalars, pdarray) or isinstance(scalars, Strings):
+            return cls(scalars.copy() if copy else scalars)
+        # Else build in arkouda
+        if dtype is None:
+            return cls(ak_array(scalars))
+
+        return cls(ak_array(scalars, dtype=dtype, copy=copy))
+
+    @classmethod
+    def _concat_same_type(cls, to_concat):
+        return cls(ak_concat([x._data for x in to_concat]))
+
+    def take(self, indexer, fill_value=None, allow_fill=False, axis=None):
+        import numpy as np
+
+        import arkouda as ak
+        from arkouda.numpy.pdarrayclass import pdarray
+        from arkouda.numpy.strings import Strings
+
+        # normalize indexer to ak int64
+        if isinstance(indexer, pdarray):
+            idx_ak = indexer.astype("int64")
+        else:
+            idx_ak = ak.array(np.asarray(indexer, dtype="int64"))
+
+        if not allow_fill:
+            gathered = self._data[idx_ak]
+            return type(self)(gathered)
+
+        # allow_fill=True
+        mask = idx_ak == -1
+        idx_fix = ak.where(mask, 0, idx_ak)  # valid placeholder
+
+        # server-side gather
+        gathered = self._data[idx_fix]
+
+        # choose default fill if needed
+        if fill_value is None:
+            # rely on EA dtype name if you exposed it; fall back to ak dtype
+            from arkouda.dtypes import dtype as ak_dtype
+
+            dtype = ak_dtype(self._data.dtype)
+            if dtype == "str_":
+                fill_value = ""
+            elif dtype in ["int64", "uint64"]:
+                fill_value = -1
+            elif dtype == "bool_":
+                fill_value = False
+            else:
+                # safest: require explicit fill for weird/non-numeric types
+                raise ValueError("Specify fill_value explicitly for this dtype when allow_fill=True")
+
+        # Categorical: pandas returns strings when fill may not be in categories
+        try:
+            from arkouda.pandas.extension._arkouda_categorical_array import (
+                ArkoudaCategoricalArray,
+            )
+        except Exception:
+            ArkoudaCategoricalArray = ()  # not available yet
+
+        if isinstance(self, ArkoudaCategoricalArray):
+            # Convert to strings for mixing category + fill
+            gathered_str = self._data.to_strings()[idx_fix]  # subset as strings
+            if not isinstance(fill_value, str):
+                fill_value = str(fill_value)
+            fill_vec = ak.full(mask.size, fill_value, dtype="str_")
+            out = ak.where(mask, fill_vec, gathered_str)
+            return ArkoudaCategoricalArray(ak.Categorical(out))
+
+        # Strings: use string fill
+        if isinstance(self._data, Strings):
+            if not isinstance(fill_value, str):
+                fill_value = str(fill_value)
+            fill_vec = ak.full(mask.size, fill_value, dtype="str_")
+            out = ak.where(mask, fill_vec, gathered)
+            return type(self)(out)
+
+        # Numeric/bool: scalar fill is fine
+        # Make sure the fill is castable to the underlying dtype
+        from arkouda.numpy.dtypes import can_cast
+
+        fv = (
+            ak.cast(ak_array([fill_value]), dt=self._data.dtype)[0]
+            if can_cast(fill_value, self._data.dtype)
+            else fill_value
+        )
+        out = ak.where(
+            mask, ak.full(mask.size, fv, dtype=str(getattr(self._data, "dtype", "int64"))), gathered
+        )
+        return type(self)(out)
+
+    def _fill_missing(self, mask, fill_value):
+        raise NotImplementedError("Subclasses must implement _fill_missing")
+
+    def to_numpy(self, dtype=None, copy=False):
+        out = self._data.to_ndarray()
+        if dtype is not None:
+            out = out.astype(dtype, copy=False)
+        return out
+
+    def to_ndarray(self):
+        return self._data.to_ndarray()

--- a/arkouda/pandas/extension/_arkouda_categorical_array.py
+++ b/arkouda/pandas/extension/_arkouda_categorical_array.py
@@ -1,0 +1,84 @@
+from typing import TYPE_CHECKING, TypeVar
+
+from pandas.api.extensions import (
+    ExtensionArray,
+    ExtensionDtype,
+    register_extension_dtype,
+)
+
+import arkouda as ak
+
+from ._arkouda_base_array import ArkoudaBaseArray
+
+if TYPE_CHECKING:
+    from arkouda.categorical import Categorical
+else:
+    Categorical = TypeVar("Categorical")
+
+
+__all__ = ["ArkoudaCategoricalDtype", "ArkoudaCategoricalArray"]
+
+
+@register_extension_dtype
+class ArkoudaCategoricalDtype(ExtensionDtype):
+    name = "arkouda_categorical"
+    type = Categorical
+    kind = "O"
+
+    @classmethod
+    def construct_array_type(cls):
+        return ArkoudaCategoricalArray
+
+
+class ArkoudaCategoricalArray(ArkoudaBaseArray, ExtensionArray):
+    def __init__(self, data):
+        if not isinstance(data, ak.Categorical):
+            raise TypeError("Expected arkouda Categorical")
+        self._data = data
+
+    @classmethod
+    def _from_sequence(cls, scalars, dtype=None, copy=False):
+        import arkouda as ak
+
+        # if 'scalars' are raw labels (strings), build ak.Categorical
+        if not isinstance(scalars, ak.Categorical):
+            scalars = ak.Categorical(ak.array(scalars))
+        return cls(scalars)
+
+    def __getitem__(self, idx):
+        if isinstance(idx, int):
+            return self._data[idx]
+        return ArkoudaCategoricalArray(self._data[idx])
+
+    def __len__(self):
+        return int(self._data.size)
+
+    def isna(self):
+        return ak.zeros(self._data.size, dtype=ak.bool)
+
+    def copy(self):
+        return ArkoudaCategoricalArray(self._data[:])
+
+    @property
+    def dtype(self):
+        return ArkoudaCategoricalDtype()
+
+    def to_numpy(self, dtype=None, copy=False, na_value=None):
+        return self._data.to_ndarray()
+
+    def __eq__(self, other):
+        return self._data == (other._data if isinstance(other, ArkoudaCategoricalArray) else other)
+
+    def __repr__(self):
+        return f"ArkoudaCategoricalArray({self._data})"
+
+    def factorize(self, *, sort=False, use_na_sentinel=True, **kwargs):
+        import numpy as np
+        import pandas as pd
+
+        codes, uniques = pd.factorize(
+            np.asarray(self.to_numpy()),
+            sort=sort,
+            use_na_sentinel=use_na_sentinel,
+        )
+        return codes, uniques

--- a/arkouda/pandas/extension/_arkouda_string_array.py
+++ b/arkouda/pandas/extension/_arkouda_string_array.py
@@ -1,0 +1,92 @@
+import numpy as np
+from pandas.api.extensions import (
+    ExtensionArray,
+    ExtensionDtype,
+    register_extension_dtype,
+)
+
+import arkouda as ak
+
+from ._arkouda_base_array import ArkoudaBaseArray
+
+__all__ = ["ArkoudaStringDtype", "ArkoudaStringArray"]
+
+
+@register_extension_dtype
+class ArkoudaStringDtype(ExtensionDtype):
+    name = "string"  # <<< This is what pandas expects
+    type = str
+    kind = "O"
+
+    @property
+    def _is_numeric(self):
+        return False
+
+    @property
+    def _is_boolean(self):
+        return False
+
+    @classmethod
+    def construct_array_type(cls):
+        return ArkoudaStringArray
+
+
+class ArkoudaStringArray(ArkoudaBaseArray, ExtensionArray):
+    default_fill_value = ""
+
+    def __init__(self, data):
+        if not isinstance(data, ak.Strings):
+            raise TypeError("Expected arkouda Strings")
+        self._data = data
+
+    @property
+    def dtype(self):
+        return ArkoudaStringDtype()
+
+    @classmethod
+    def _from_sequence(cls, scalars, dtype=None, copy=False):
+        return cls(ak.array(scalars))
+
+    def __getitem__(self, key):
+        result = self._data[key]
+        if np.isscalar(key):
+            if hasattr(result, "to_ndarray"):
+                return result.to_ndarray()[()]
+            else:
+                return result
+        return ArkoudaStringArray(result)
+
+    def __len__(self):
+        return int(self._data.size)
+
+    def astype(self, dtype, copy: bool = False):
+        if dtype in (object, np.object_, "object", np.dtype("O")):
+            return self.to_ndarray().astype(object, copy=copy)
+        # Let pandas do the rest locally
+        return self.to_ndarray().astype(dtype, copy=copy)
+
+    def isna(self):
+        return ak.zeros(self._data.size, dtype=ak.bool)
+
+    def copy(self):
+        return ArkoudaStringArray(self._data[:])
+
+    def to_numpy(self, dtype=None, copy=False, na_value=None):
+        return self._data.to_ndarray()
+
+    def __eq__(self, other):
+        return self._data == (other._data if isinstance(other, ArkoudaStringArray) else other)
+
+    def __repr__(self):
+        return f"ArkoudaStringArray({self._data})"
+
+    def factorize(self, *, sort=False, use_na_sentinel=True, **kwargs):
+        import numpy as np
+        import pandas as pd
+
+        codes, uniques = pd.factorize(
+            np.asarray(self.to_numpy()),
+            sort=sort,
+            use_na_sentinel=use_na_sentinel,
+        )
+        return codes, uniques

--- a/pytest.ini
+++ b/pytest.ini
@@ -81,6 +81,13 @@ testpaths =
     tests/version_test.py
     tests/pandas/row_test.py
     tests/test_no_ak_connect_doctest.py
+    tests/pandas/extension/arkouda_base_extension.py
+    tests/pandas/extension/arkouda_array_extension.py
+    tests/pandas/extension/arkouda_strings_extension.py
+    tests/pandas/extension/arkouda_categorical_extension.py
+    tests/pandas/extension/series.py
+    tests/pandas/extension/index.py
+    tests/pandas/extension/dataframes.py
 norecursedirs =
     .git
     dist

--- a/tests/pandas/extension/arkouda_array_extension.py
+++ b/tests/pandas/extension/arkouda_array_extension.py
@@ -1,0 +1,171 @@
+import numpy as np
+import pytest
+
+import arkouda as ak
+from arkouda import numeric_and_bool_scalars
+from arkouda.numpy.pdarrayclass import pdarray
+from arkouda.pandas.extension._arkouda_array import ArkoudaArray, ArkoudaDtype
+
+
+class TestArkoudaArrayExtension:
+    def test_array_extension_docstrings(self):
+        import doctest
+
+        from arkouda.pandas.extension import _arkouda_array
+
+        result = doctest.testmod(
+            _arkouda_array, optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE
+        )
+        assert result.failed == 0, f"Doctest failed: {result.failed} failures"
+
+    def test_constructor_from_pdarray(self):
+        arr = ArkoudaArray(ak.arange(5))
+        assert isinstance(arr, ArkoudaArray)
+        assert len(arr) == 5
+
+    def test_constructor_from_numpy(self):
+        arr = ArkoudaArray(np.array([10, 20, 30]))
+        assert isinstance(arr, ArkoudaArray)
+        assert len(arr) == 3
+
+    def test_getitem_scalar(self):
+        ak_data = ak.arange(10)
+        arr = ArkoudaArray(ak_data)
+        assert arr[1] == 1
+
+    def test_getitem_slice(self):
+        ak_data = ak.arange(10)
+        arr = ArkoudaArray(ak_data)
+        sub = arr[2:5]
+        assert isinstance(sub, ArkoudaArray)
+        assert sub.to_numpy().tolist() == [2, 3, 4]
+
+    def test_setitem_scalar(self):
+        ak_data = ak.arange(10)
+        arr = ArkoudaArray(ak_data[:])  # avoid modifying fixture
+        arr[1] = 42
+        assert arr[1] == 42
+
+    def test_setitem_array(self):
+        ak_data = ak.arange(10)
+        arr = ArkoudaArray(ak_data[:])
+        # arr[[0, 2]] = [99, 88]
+        arr[ak.array([0, 2])] = [99, 88]
+        assert arr[0] == 99
+        assert arr[2] == 88
+
+    def test_len(self):
+        ak_data = ak.arange(10)
+        arr = ArkoudaArray(ak_data)
+        assert len(arr) == 10
+
+    def test_isna(self):
+        ak_data = ak.arange(10)
+        arr = ArkoudaArray(ak_data)
+        na = arr.isna()
+        assert ak.all(na == False)
+
+    def test_isna_with_nan(self):
+        from arkouda.testing import assert_equal
+
+        ak_data = ak.array([1, np.nan, 2])
+        arr = ArkoudaArray(ak_data)
+        na = arr.isna()
+        expected = ak.array([False, True, False])
+        assert_equal(na, expected)
+
+    def test_copy(self):
+        ak_data = ak.arange(10)
+        arr = ArkoudaArray(ak_data)
+        cpy = arr.copy()
+        assert arr.equals(cpy)
+        assert arr is not cpy
+
+    def test_dtype(self):
+        arr = ArkoudaArray(ak.array([1]))
+        assert isinstance(arr.dtype, ArkoudaDtype)
+        assert arr.dtype.name == "arkouda"
+
+    def test_nbytes(self):
+        ak_data = ak.arange(10)
+        arr = ArkoudaArray(ak_data)
+        assert isinstance(arr.nbytes, int)
+        assert arr.nbytes == 80
+
+    def test_to_numpy(self):
+        ak_data = ak.arange(5)
+        arr = ArkoudaArray(ak_data)
+        np_arr = arr.to_numpy()
+        assert isinstance(np_arr, np.ndarray)
+        assert np_arr.tolist() == [0, 1, 2, 3, 4]
+
+    def test_astype(self):
+        ak_data = ak.arange(10)
+        arr = ArkoudaArray(ak_data)
+        casted = arr.astype(np.float64)
+        assert isinstance(casted, ArkoudaArray)
+        assert isinstance(casted._data, pdarray)
+        assert casted._data.dtype == np.float64
+
+    def test_equals_true(self):
+        ak_data = ak.arange(10)
+        arr1 = ArkoudaArray(ak_data)
+        arr2 = ArkoudaArray(ak_data[:])
+        assert arr1.equals(arr2)
+
+    def test_equals_false(self):
+        ak_data = ak.arange(10)
+        arr1 = ArkoudaArray(ak_data)
+        arr2 = ArkoudaArray(ak.array([5, 4, 3, 2, 1]))
+        assert not arr1.equals(arr2)
+
+    def test_argsort(self):
+        ak_data = ak.arange(10)
+        arr = ArkoudaArray(ak_data)
+        perm = arr.argsort()
+        sorted_vals = arr._data[perm]
+        assert ak.is_sorted(sorted_vals)
+
+    @pytest.mark.parametrize("reduction", ["all", "any", "sum", "prod", "min", "max"])
+    def test_reduce_ops(self, reduction):
+        ak_data = ak.arange(10)
+        arr = ArkoudaArray(ak_data)
+        result = arr._reduce(reduction)
+        assert isinstance(result, numeric_and_bool_scalars)
+
+    def test_reduce_invalid(self):
+        ak_data = ak.arange(10)
+        arr = ArkoudaArray(ak_data)
+        with pytest.raises(TypeError):
+            arr._reduce("mean")
+
+    def test_concat_same_type(self):
+        a1 = ArkoudaArray(ak.array([1, 2]))
+        a2 = ArkoudaArray(ak.array([3, 4]))
+        out = ArkoudaArray._concat_same_type([a1, a2])
+        assert isinstance(out, ArkoudaArray)
+        assert out.to_numpy().tolist() == [1, 2, 3, 4]
+
+    def test_eq_operator(self):
+        a1 = ArkoudaArray(ak.array([1, 2]))
+        a2 = ArkoudaArray(ak.array([1, 2]))
+        result = a1 == a2
+        assert ak.all(result)
+
+    def test_repr(self):
+        ak_data = ak.arange(10)
+        arr = ArkoudaArray(ak_data)
+        assert "ArkoudaArray" in repr(arr)
+
+    def test_factorize(self):
+        arr = ArkoudaArray(ak.array([1, 2, 1, 3]))
+        codes, uniques = arr.factorize()
+        assert set(codes.tolist()) == {0, 1, 2}
+        assert sorted(uniques.tolist()) == [1, 2, 3]
+
+    def test_from_factorized(self):
+        values = [10, 20, 10]
+        orig = ArkoudaArray(ak.array([10, 20, 10]))
+        new_arr = ArkoudaArray._from_factorized(values, orig)
+        assert isinstance(new_arr, ArkoudaArray)
+        assert new_arr.to_numpy().tolist() == values

--- a/tests/pandas/extension/arkouda_base_extension.py
+++ b/tests/pandas/extension/arkouda_base_extension.py
@@ -1,0 +1,10 @@
+class TestArkoudaBaseExtension:
+    def test_base_extension_docstrings(self):
+        import doctest
+
+        from arkouda.pandas.extension import _arkouda_base_array
+
+        result = doctest.testmod(
+            _arkouda_base_array, optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE
+        )
+        assert result.failed == 0, f"Doctest failed: {result.failed} failures"

--- a/tests/pandas/extension/arkouda_categorical_extension.py
+++ b/tests/pandas/extension/arkouda_categorical_extension.py
@@ -1,0 +1,10 @@
+class TestArkoudaCategoricalExtension:
+    def test_base_categorical_docstrings(self):
+        import doctest
+
+        from arkouda.pandas.extension import _arkouda_categorical_array
+
+        result = doctest.testmod(
+            _arkouda_categorical_array, optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE
+        )
+        assert result.failed == 0, f"Doctest failed: {result.failed} failures"

--- a/tests/pandas/extension/arkouda_strings_extension.py
+++ b/tests/pandas/extension/arkouda_strings_extension.py
@@ -1,0 +1,10 @@
+class TestArkoudaStringsExtension:
+    def test_strings_extension_docstrings(self):
+        import doctest
+
+        from arkouda.pandas.extension import _arkouda_string_array
+
+        result = doctest.testmod(
+            _arkouda_string_array, optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE
+        )
+        assert result.failed == 0, f"Doctest failed: {result.failed} failures"

--- a/tests/pandas/extension/dataframes.py
+++ b/tests/pandas/extension/dataframes.py
@@ -1,0 +1,59 @@
+import pandas as pd
+import pytest
+
+import arkouda as ak
+from arkouda.pandas.extension._arkouda_array import ArkoudaArray
+from arkouda.pandas.extension._arkouda_categorical_array import ArkoudaCategoricalArray
+from arkouda.pandas.extension._arkouda_string_array import ArkoudaStringArray
+
+
+class TestDataFrameExtension:
+    def test_dataframe_with_extensionarrays(self):
+        N = 5
+        df = pd.DataFrame(
+            {
+                "i": ArkoudaArray(ak.arange(N)),
+                "s": ArkoudaStringArray(ak.array(["a", "b", "c", "d", "e"])),
+                "c": ArkoudaCategoricalArray(
+                    ak.Categorical(ak.array(["low", "low", "high", "medium", "low"]))
+                ),
+            }
+        )
+
+        assert df.shape == (5, 3)
+        assert df.iloc[2]["s"] == "c"
+
+    @pytest.mark.parametrize("how", ["inner", "left", "right", "outer"])
+    def test_dataframe_join_with_arkouda_arrays(self, how):
+        # Left table
+        df1 = pd.DataFrame(
+            {
+                "id": ArkoudaArray(ak.array([1, 2, 3])),
+                "name": ArkoudaStringArray(ak.array(["alice", "bob", "carol"])),
+            }
+        )
+
+        # Right table
+        df2 = pd.DataFrame(
+            {
+                "id": ArkoudaArray(ak.array([2, 3, 4])),
+                "score": ArkoudaArray(ak.array([88, 92, 75])),
+            }
+        )
+
+        # Perform join
+        result = df1.merge(df2, on="id", how=how)
+
+        if how == "inner":
+            assert len(result) == 2
+            assert result["id"].tolist() == [2, 3]
+            assert result["score"].tolist() == [88, 92]
+        elif how == "left":
+            assert len(result) == 3
+            assert result["id"].tolist() == [1, 2, 3]
+        elif how == "right":
+            assert len(result) == 3
+            assert result["id"].tolist() == [2, 3, 4]
+        elif how == "outer":
+            assert len(result) == 4
+            assert sorted(result["id"].tolist()) == [1, 2, 3, 4]

--- a/tests/pandas/extension/index.py
+++ b/tests/pandas/extension/index.py
@@ -1,0 +1,50 @@
+import pandas as pd
+
+import arkouda as ak
+from arkouda.pandas.extension._arkouda_array import ArkoudaArray
+from arkouda.pandas.extension._arkouda_string_array import ArkoudaStringArray
+
+
+class TestIndexExtension:
+    def test_index_basic_ops(self):
+        idx = pd.Index(ArkoudaArray(ak.array([10, 20, 30])), name="foo")
+        assert len(idx) == 3
+        assert idx.name == "foo"
+        assert idx[0] == 10
+        # assert list(idx[:2]._data.to_ndarray()) == [10, 20]
+        assert list(idx[:2].to_numpy()) == [10, 20]
+
+    def test_index_equality(self):
+        a = pd.Index(ArkoudaArray(ak.array([1, 2, 3])))
+        b = pd.Index(ArkoudaArray(ak.array([1, 2, 3])))
+        c = pd.Index(ArkoudaArray(ak.array([3, 2, 1])))
+
+        assert a.equals(b)
+        assert not a.equals(c)
+
+    def test_multiindex_construction_and_get_level_values(self):
+        idx1 = ArkoudaArray(ak.array([1, 2, 3]))
+        idx2 = ArkoudaStringArray(ak.array(["a", "b", "c"]))
+
+        mi = pd.MultiIndex.from_arrays([idx1, idx2], names=["num", "letter"])
+
+        assert mi.nlevels == 2
+        assert mi.names == ["num", "letter"]
+
+        lv0 = mi.get_level_values(0)
+        lv1 = mi.get_level_values(1)
+
+        assert lv0.tolist() == [1, 2, 3]
+        assert lv1.tolist() == ["a", "b", "c"]
+
+    def test_multiindex_equals_and_length(self):
+        idx1a = ArkoudaArray(ak.array([1, 2]))
+        idx2a = ArkoudaStringArray(ak.array(["x", "y"]))
+        idx1b = ArkoudaArray(ak.array([1, 2]))
+        idx2b = ArkoudaStringArray(ak.array(["x", "y"]))
+
+        mi1 = pd.MultiIndex.from_arrays([idx1a, idx2a])
+        mi2 = pd.MultiIndex.from_arrays([idx1b, idx2b])
+
+        assert mi1.equals(mi2)
+        assert len(mi1) == 2

--- a/tests/pandas/extension/series.py
+++ b/tests/pandas/extension/series.py
@@ -1,0 +1,110 @@
+import numpy as np
+import pandas as pd
+
+import arkouda as ak
+from arkouda.pandas.extension._arkouda_array import ArkoudaArray
+
+
+class TestSeriesExtension:
+    def test_series_from_strings(self):
+        from arkouda.pandas.extension._arkouda_string_array import ArkoudaStringArray
+
+        s_arr = ArkoudaStringArray(ak.array(["alpha", "beta", "gamma"]))
+        s = pd.Series(s_arr)
+        assert s.iloc[0] == "alpha"
+        assert s.iloc[2] == "gamma"
+
+    def test_string_series_take_with_fill(self):
+        from arkouda.pandas.extension._arkouda_string_array import ArkoudaStringArray
+
+        s_arr = ArkoudaStringArray(ak.array(["a", "b", "c"]))
+        s = pd.Series(s_arr)
+        taken = pd.Series(s.values.take([0, -1, 2], allow_fill=True))
+        assert taken.iloc[1] == ""  # default fill
+        assert taken.iloc[2] == "c"
+
+    def test_series_from_categorical(self):
+        from arkouda.pandas.extension._arkouda_categorical_array import (
+            ArkoudaCategoricalArray,
+        )
+
+        s_arr = ArkoudaCategoricalArray(ak.Categorical(ak.array(["high", "low", "medium", "low"])))
+        s = pd.Series(s_arr)
+        assert s.iloc[1] == "low"
+        assert s.iloc[3] == "low"
+
+    def test_categorical_series_take_with_fill(self):
+        from arkouda.pandas.extension._arkouda_categorical_array import (
+            ArkoudaCategoricalArray,
+        )
+
+        s_arr = ArkoudaCategoricalArray(ak.Categorical(ak.array(["x", "y", "z"])))
+        s = pd.Series(s_arr)
+        taken = pd.Series(s.values.take([1, -1, 0], allow_fill=True, fill_value="x"))
+        assert taken.iloc[0] == "y"
+        assert taken.iloc[1] == "x"
+
+    def test_series_construction(self):
+        a = ArkoudaArray(ak.array([10, 20, 30]))
+        s = pd.Series(a)
+        assert isinstance(s, pd.Series)
+        assert len(s) == 3
+        assert s.iloc[1] == 20
+
+    def test_series_repr(self):
+        a = ArkoudaArray(ak.array([1, 2, 3]))
+        s = pd.Series(a)
+        output = repr(s)
+        assert "arkouda" in output
+        assert "1" in output
+
+    def test_series_indexing(self):
+        a = ArkoudaArray(ak.arange(5))
+        s = pd.Series(a)
+        assert s[0] == 0
+        assert s[4] == 4
+        assert s.iloc[2] == 2
+        assert s.loc[3] == 3
+
+    def test_series_slicing(self):
+        a = ArkoudaArray(ak.arange(10))
+        s = pd.Series(a)
+        sliced = s[2:5]
+        assert list(sliced.values._data.to_ndarray()) == [2, 3, 4]
+
+    def test_series_sum_and_reductions(self):
+        a = ArkoudaArray(ak.array([1, 2, 3]))
+        s = pd.Series(a)
+        assert s.sum() == 6
+        assert s.max() == 3
+        assert s.min() == 1
+        assert s.all()  # nonzero
+        assert pd.Series(ArkoudaArray(ak.array([0, 0, 0]))).any() == False
+
+    def test_series_equality(self):
+        a1 = ArkoudaArray(ak.array([1, 2, 3]))
+        a2 = ArkoudaArray(ak.array([1, 2, 3]))
+        s1 = pd.Series(a1)
+        s2 = pd.Series(a2)
+        assert s1.equals(s2)
+
+    def test_series_take(self):
+        a = ArkoudaArray(ak.array([10, 20, 30]))
+        s = pd.Series(a)
+        taken = s.take([2, 0])
+        assert list(taken.values._data.to_ndarray()) == [30, 10]
+
+    def test_series_copy(self):
+        a = ArkoudaArray(ak.array([5, 6]))
+        s = pd.Series(a)
+        copied = s.copy()
+        assert s.equals(copied)
+        copied.iloc[0] = 999
+        assert s.iloc[0] != copied.iloc[0]
+
+    def test_numpy_boolean_mask_on_series(self):
+        arr = ArkoudaArray(ak.array([1, 2, 3]))
+        s = pd.Series(arr)
+        mask = np.array([False, True, True])
+        result = s[mask]
+        assert list(result.values.to_ndarray()) == [2, 3]


### PR DESCRIPTION
Summary
This PR introduces experimental support for using Arkouda arrays as pandas `ExtensionArray`s, enabling seamless integration with pandas `Series`, `DataFrame`, and `Index` operations.

Key Features
✅ `ArkoudaArray`, `ArkoudaStringArray`, and `ArkoudaCategoricalArray` now implement the `ExtensionArray` interface.

✅ Corresponding `ArkoudaDtype`, `ArkoudaStringDtype`, and `ArkoudaCategoricalDtype` classes added and registered.

✅ Basic support for:

Element-wise operations and reductions

Slicing, indexing, and take

`Series` and `DataFrame` construction

Joins and merges via `_concat_same_type`

`Index` and `MultiIndex` compatibility (partial)

✅ Unit tests for Series behavior and join operations

⚠️ String and categorical fill behavior is still evolving and may require explicit fill_value for correctness.

Implementation Notes
`_concat_same_type` is attached to each Arkouda-backed array class to support join operations.

A shared `BaseArkoudaArray` class factors out common logic for take, slicing, and equality.

Some limitations and fallbacks are documented where full pandas interoperability isn't yet available.

This work brings Arkouda one step closer to being a drop-in backend for pandas workflows at scale. It allows developers to write familiar pandas code while executing at scale on distributed memory systems.



Closes #4597:  implement pandas ExtensionArray for arkouda