### PR TITLE
First attempt at disallowing negatives in bigints

### DIFF
--- a/arkouda/numpy/pdarrayclass.py
+++ b/arkouda/numpy/pdarrayclass.py
@@ -2310,15 +2310,27 @@ class pdarray:
         array([1 0])
 
         Returns
-        _______
+        -------
         ak.pdarray
             An arkouda pdarray with values converted to the specified data type
 
+        Raises
+        ------
+        ValueError
+            Raised if the array contains negative numbers. Arkouda cannot at present
+            handle negative bigints.
+
         Notes
-        _____
+        -----
         This is essentially shorthand for ak.cast(x, '<dtype>') where x is a pdarray.
         """
         from arkouda.numpy import cast as akcast
+
+        # check for negative numbers and bigint, which arkouda doesn't presently handle.
+
+        if dtype == bigint:
+            if (self < 0).any():
+                raise ValueError("arkouda cannot convert negative numbers to bigints.")
 
         return akcast(self, dtype)
 

--- a/arkouda/numpy/pdarrayclass.py
+++ b/arkouda/numpy/pdarrayclass.py
@@ -2311,7 +2311,7 @@ class pdarray:
 
         Returns
         -------
-        ak.pdarray
+        pdarray
             An arkouda pdarray with values converted to the specified data type
 
         Raises

--- a/arkouda/numpy/pdarraycreation.py
+++ b/arkouda/numpy/pdarraycreation.py
@@ -180,7 +180,8 @@ def array(
         or if the product of a size and a.itemsize > maxTransferBytes
     ValueError
         Raised if a has rank is not in get_array_ranks(), or if the returned message is malformed or does
-        not contain the fields required to generate the array.
+        not contain the fields required to generate the array, or if the array contains negative numbers,
+        because arkouda cannot at present handle negative bigints.
 
     See Also
     --------

--- a/tests/bigint_agg_test.py
+++ b/tests/bigint_agg_test.py
@@ -14,13 +14,13 @@ def gather_scatter(a):
 
 
 class TestBigInt:
-    @pytest.mark.parametrize("size", pytest.prob_size)
-    def test_negative(self, size):
-        # test with negative bigint values
-        arr = -1 * ak.randint(0, 2**32, size)
-        bi_neg = ak.cast(arr, ak.bigint)
-        res = gather_scatter(bi_neg)
-        assert bi_neg.to_list() == res.to_list()
+#    at pytest.mark.parametrize("size", pytest.prob_size)
+#    def test_negative(self, size):
+#        # test with negative bigint values
+#        arr = -1 * ak.randint(0, 2**32, size)
+#        bi_neg = ak.cast(arr, ak.bigint)
+#        res = gather_scatter(bi_neg)
+#        assert bi_neg.to_list() == res.to_list()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_large(self, size):

--- a/tests/bigint_agg_test.py
+++ b/tests/bigint_agg_test.py
@@ -14,13 +14,13 @@ def gather_scatter(a):
 
 
 class TestBigInt:
-#    at pytest.mark.parametrize("size", pytest.prob_size)
-#    def test_negative(self, size):
-#        # test with negative bigint values
-#        arr = -1 * ak.randint(0, 2**32, size)
-#        bi_neg = ak.cast(arr, ak.bigint)
-#        res = gather_scatter(bi_neg)
-#        assert bi_neg.to_list() == res.to_list()
+    #    at pytest.mark.parametrize("size", pytest.prob_size)
+    #    def test_negative(self, size):
+    #        # test with negative bigint values
+    #        arr = -1 * ak.randint(0, 2**32, size)
+    #        bi_neg = ak.cast(arr, ak.bigint)
+    #        res = gather_scatter(bi_neg)
+    #        assert bi_neg.to_list() == res.to_list()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_large(self, size):

--- a/tests/coargsort_test.py
+++ b/tests/coargsort_test.py
@@ -20,7 +20,7 @@ def make_ak_arrays(size, dtype, minimum=-(2**32), maximum=2**32, seed=1):
         # Prior to disallowing negative numbers in bigints, the next line was:
         # return ak.cast(ak.randint(minimum, maximum, size=size, seed=seed), dtype) + 2**200
         # But 2**64 is interpreted as a negative number when casting
-        return ak.cast(ak.randint(0, min(maximum,2**63), size=size, seed=seed), dtype) + 2**200
+        return ak.cast(ak.randint(0, min(maximum, 2**63), size=size, seed=seed), dtype) + 2**200
     raise ValueError(f"Unsupported dtype: {dtype}")
 
 

--- a/tests/coargsort_test.py
+++ b/tests/coargsort_test.py
@@ -17,7 +17,10 @@ def make_ak_arrays(size, dtype, minimum=-(2**32), maximum=2**32, seed=1):
     elif dtype == "bool":
         return ak.cast(ak.randint(0, 2, size=size, seed=seed), dtype)
     elif dtype == "bigint":
-        return ak.cast(ak.randint(minimum, maximum, size=size, seed=seed), dtype) + 2**200
+        # Prior to disallowing negative numbers in bigints, the next line was:
+        # return ak.cast(ak.randint(minimum, maximum, size=size, seed=seed), dtype) + 2**200
+        # But 2**64 is interpreted as a negative number when casting
+        return ak.cast(ak.randint(0, min(maximum,2**63), size=size, seed=seed), dtype) + 2**200
     raise ValueError(f"Unsupported dtype: {dtype}")
 
 

--- a/tests/numpy/numeric_test.py
+++ b/tests/numpy/numeric_test.py
@@ -243,6 +243,8 @@ class TestNumeric:
                 # we don't support casting a float to a bigint
                 # we do support str to bool, but it's expected to contain "true/false" not numerics
                 continue
+            if t1 == ak.int64 and cast_to == ak.bigint:
+                orig = ak.abs(orig)  # we can't cast negative ints to bigint
             other = ak.cast(orig, cast_to)
             assert orig.size == other.size
             if (t1, cast_to) in ROUNDTRIP_CAST:


### PR DESCRIPTION
Closes #4594 

I'm not entirely happy with this, but it closes 4594 by disallowing negative numbers in bigints, since arkouda really doesn't seem to be built to handle them.  Enabling them will take some serious analysis and rewriting.  Disabling them turned into a search-and-destroy mission.  I think I got them all, but one can't always be sure in a program this large.

A few notes, with novel numbering:

(0) darglint didn't like the docstring saying that cast returned an ak.pdarray.  Said it should be just pdarray.  Fixed.  There may be more of these.

(1) The use of "new_dt" in the cast function in numeric.py is to keep mypy from complaining that the "dt" doesn't have a .name parameter if dt is a String (which is part of the Union that it can be).

(2) There were three ways negative numbers could work their way into bigint arrays: (a) the array method in pdarraycreation, (b) the .astype method of pdarrayclass, and (c) the cast function in numeric.py.  Those have all been addressed.

(3) There were tests that were inserting negative numbers in bigint arrays: (a) test_coargsort_single_type in coargsort_test.py, (b) test_cast in numeric_test.py, and (c) test_negative in bigint_agg_test that explicitly created bigint pdarrays with negative numbers.  The first two were edited.  The third one was entirely commented out.