### PR TITLE
Closes #4600:  docstring for the history module 

### DIFF
--- a/arkouda/history.py
+++ b/arkouda/history.py
@@ -1,3 +1,47 @@
+"""
+History retrieval utilities for Arkouda command execution.
+
+This module provides tools for retrieving the history of commands executed
+in Python REPL shells or Jupyter/IPython notebooks. It defines abstract and
+concrete retrievers to access interactive command history for reproducibility,
+debugging, or audit purposes.
+
+Classes
+-------
+HistoryRetriever
+    Abstract base class defining the `retrieve` method and a helper for filtering commands.
+
+ShellHistoryRetriever
+    Retrieves command history from a Python REPL shell using `readline`.
+
+NotebookHistoryRetriever
+    Retrieves command history from a Jupyter notebook or IPython shell via IPython's history database.
+
+Usage
+-----
+Used internally by `arkouda.generate_history()` to provide a user-friendly interface
+for querying and filtering past commands based on optional string filters and count limits.
+
+Examples
+--------
+>>> from arkouda.history import ShellHistoryRetriever, NotebookHistoryRetriever
+
+# REPL mode
+>>> h = ShellHistoryRetriever()
+>>> h.retrieve(command_filter="ak.", num_commands=5)   # doctest: +SKIP
+['ak.array([1,2,3])', 'ak.sum(...)', ...]
+
+# Notebook mode
+>>> h = NotebookHistoryRetriever()
+>>> h.retrieve(num_commands=3)  # doctest: +SKIP
+['ak.connect()', 'df = ak.DataFrame(...)', 'ak.argsort(...)']
+
+See Also
+--------
+arkouda.generate_history : High-level function for retrieving command history.
+
+"""
+
 import readline
 from typing import List, Optional
 


### PR DESCRIPTION
Adds a docstring for the `history` module.

Closes #4600: docstring for the history module