### PR TITLE
Closes #3561:  Update array_create_benchmark

### DIFF
--- a/benchmark_v2/array_create_benchmark.py
+++ b/benchmark_v2/array_create_benchmark.py
@@ -37,47 +37,34 @@ def _create_np_array(size, op, dtype, seed):
 
 
 @pytest.mark.skip_correctness_only(True)
-@pytest.mark.benchmark(group="AK Array Create")
+@pytest.mark.benchmark(group="Array_Create")
 @pytest.mark.parametrize("op", OPS)
 @pytest.mark.parametrize("dtype", TYPES)
 def bench_array_create(benchmark, op, dtype):
     """
-    Measures Arkouda array creation performance
+    Measures array creation performance (Arkouda or NumPy based on flags)
     """
     cfg = ak.get_config()
-    size = pytest.prob_size * cfg["numLocales"]
+    size = 10**4 if pytest.correctness_only else pytest.prob_size * cfg["numLocales"]
 
     if dtype in pytest.dtype:
-        a = benchmark.pedantic(
-            _create_ak_array, args=(size, op, dtype, pytest.seed), rounds=pytest.trials
+        if pytest.numpy:
+
+            def create_array():
+                a = _create_np_array(size, op, dtype, pytest.seed)
+                return a.size * a.itemsize
+        else:
+
+            def create_array():
+                a = _create_ak_array(size, op, dtype, pytest.seed)
+                return a.size * a.itemsize
+
+        nbytes = benchmark.pedantic(create_array, rounds=pytest.trials)
+
+        benchmark.extra_info["description"] = (
+            f"Measures performance of {'NumPy' if pytest.numpy else 'Arkouda'} array creation"
         )
-
-        nbytes = a.size * a.itemsize
-        benchmark.extra_info["description"] = "Measures the performance of Arkouda array creation"
-        benchmark.extra_info["problem_size"] = pytest.prob_size
-        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-            (nbytes / benchmark.stats["mean"]) / 2**30
-        )
-
-
-@pytest.mark.skip_correctness_only(True)
-@pytest.mark.benchmark(group="NP Array Create")
-@pytest.mark.parametrize("op", OPS)
-@pytest.mark.parametrize("dtype", TYPES)
-def bench_np_array_create(benchmark, op, dtype):
-    """
-    Measures Numpy array creation performance
-    """
-    size = pytest.prob_size
-
-    if pytest.numpy and dtype in pytest.dtype:
-        a = benchmark.pedantic(
-            _create_np_array, args=(size, op, dtype, pytest.seed), rounds=pytest.trials
-        )
-
-        nbytes = a.size * a.itemsize
-        benchmark.extra_info["description"] = "Measures the performance of numpy array creation"
-        benchmark.extra_info["problem_size"] = pytest.prob_size
+        benchmark.extra_info["problem_size"] = size
         benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
             (nbytes / benchmark.stats["mean"]) / 2**30
         )


### PR DESCRIPTION
## PR: Refactor `array_create_benchmark.py` for NumPy and Correctness-Only Modes

This PR updates the `array_create_benchmark.py` benchmark to support two configurable testing modes:

- ✅ **NumPy Mode (`pytest.numpy=True`)**  
  Uses NumPy array creation functions instead of Arkouda for performance comparison.

- ✅ **Correctness-Only Mode (`pytest.correctness_only=True`)**  
  Reduces the problem size to `10**4` to enable faster correctness validation.

### 🔧 Changes
- Unified Arkouda and NumPy benchmarking logic into a single `bench_array_create` function
- Moved `nbytes` calculation into the benchmarked function to support consistent throughput reporting
- Removed the now-redundant `bench_np_array_create` function

This refactor streamlines the benchmark, eliminates duplication, and aligns it with the updated design patterns used in the rest of the benchmarking suite.



Closes #3561:  Update array_create_benchmark