### PR TITLE
Closes #3569:  Update gather_benchmark

### DIFF
--- a/benchmark_v2/gather_benchmark.py
+++ b/benchmark_v2/gather_benchmark.py
@@ -7,84 +7,79 @@ TYPES = ("int64", "float64", "bool", "str")
 
 
 def _run_gather(a, i):
-    """
-    Helper function allowing for the gather to be benchmarked
-    """
     return a[i]
 
 
-@pytest.mark.skip_correctness_only(True)
-@pytest.mark.benchmark(group="AK_Gather")
+def compute_transfer_bytes(result, dtype):
+    if dtype == "str":
+        offsets = 3 * result.size * 8
+        buffers = (result.size * 8) + (2 * result.nbytes)
+        return offsets + buffers
+    else:
+        return result.size * result.itemsize * 3
+
+
+@pytest.mark.benchmark(group="Gather")
 @pytest.mark.parametrize("dtype", TYPES)
 def bench_gather(benchmark, dtype):
     cfg = ak.get_config()
-    isize = pytest.prob_size if pytest.idx_size is None else pytest.idx_size
-    vsize = pytest.prob_size if pytest.val_size is None else pytest.val_size
+    N = 10**4 if pytest.correctness_only else pytest.prob_size
+    isize = N if pytest.idx_size is None else pytest.idx_size
+    vsize = N if pytest.val_size is None else pytest.val_size
     Ni = isize * cfg["numLocales"]
     Nv = vsize * cfg["numLocales"]
 
-    if dtype in pytest.dtype:
-        i = ak.randint(0, Nv, Ni, seed=pytest.seed)
-        if pytest.seed is not None:
-            pytest.seed += 1
-        if pytest.random or pytest.seed is not None:
-            if dtype == "int64":
-                v = ak.randint(0, 2**32, Nv, seed=pytest.seed)
-            elif dtype == "float64":
-                v = ak.randint(0, 1, Nv, dtype=ak.float64, seed=pytest.seed)
-            elif dtype == "bool":
-                v = ak.randint(0, 1, Nv, dtype=ak.bool, seed=pytest.seed)
-            elif dtype == "str":
-                v = ak.random_strings_uniform(1, 16, Nv, seed=pytest.seed)
-        else:
-            if dtype == "str":
-                v = ak.cast(ak.arange(Nv), "str")
-            else:
-                v = ak.ones(Nv, dtype=dtype)
+    i_ak = ak.randint(0, Nv, Ni, seed=pytest.seed)
+    if pytest.seed is not None:
+        pytest.seed += 1
 
-        c = benchmark.pedantic(_run_gather, args=[v, i], rounds=pytest.trials)
-
+    if pytest.random or pytest.seed is not None:
+        if dtype == "int64":
+            v_ak = ak.randint(0, 2**32, Nv, seed=pytest.seed)
+        elif dtype == "float64":
+            v_ak = ak.randint(0, 1, Nv, dtype=ak.float64, seed=pytest.seed)
+        elif dtype == "bool":
+            v_ak = ak.randint(0, 2, Nv, dtype=ak.bool, seed=pytest.seed)
+        elif dtype == "str":
+            v_ak = ak.random_strings_uniform(1, 16, Nv, seed=pytest.seed)
+    else:
         if dtype == "str":
-            offsets_transferred = 3 * c.size * 8
-            bytes_transferred = (c.size * 8) + (2 * c.nbytes)
-            bytes_per_sec = (offsets_transferred + bytes_transferred) / benchmark.stats["mean"]
+            v_ak = ak.cast(ak.arange(Nv), "str")
         else:
-            bytes_per_sec = (c.size * c.itemsize * 3) / benchmark.stats["mean"]
+            v_ak = ak.ones(Nv, dtype=dtype)
 
-        benchmark.extra_info["description"] = "Measures the performance of Arkouda gather"
-        benchmark.extra_info["problem_size"] = pytest.prob_size
-        benchmark.extra_info["index_size"] = isize
-        benchmark.extra_info["value_size"] = vsize
-        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format((bytes_per_sec / 2**30))
-
-
-@pytest.mark.skip_correctness_only(True)
-@pytest.mark.benchmark(group="NumPy_Gather")
-@pytest.mark.parametrize("dtype", TYPES)
-def bench_np_gather(benchmark, dtype):
     if pytest.numpy:
-        Ni = pytest.prob_size if pytest.idx_size is None else pytest.idx_size
-        Nv = pytest.prob_size if pytest.val_size is None else pytest.val_size
-        if pytest.seed is not None:
-            np.random.seed(pytest.seed)
-        i = np.random.randint(0, Nv, Ni)
+        i = i_ak.to_ndarray()
+        v = v_ak.to_ndarray()
 
-        if pytest.random or pytest.seed is not None:
-            if dtype == "int64":
-                v = np.random.randint(0, 2**32, Nv)
-            elif dtype == "float64":
-                v = np.random.random(Nv)
-            elif dtype == "bool":
-                v = np.random.randint(0, 1, Nv, dtype=np.bool)
-            elif dtype == "str":
-                v = np.array(np.random.randint(0, 2**32, Nv), dtype="str")
-        else:
-            v = np.ones(Nv, dtype=dtype)
+        def gather_np_op():
+            c = _run_gather(v, i)
+            return compute_transfer_bytes(c, dtype)
 
-        c = benchmark.pedantic(_run_gather, args=[v, i], rounds=pytest.trials)
-        bytes_per_sec = (c.size * c.itemsize * 3) / benchmark.stats["mean"]
-        benchmark.extra_info["description"] = "Measures the performance of NumPy gather"
-        benchmark.extra_info["problem_size"] = pytest.prob_size
-        benchmark.extra_info["index_size"] = Ni
-        benchmark.extra_info["value_size"] = Nv
-        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format((bytes_per_sec / 2**30))
+        numBytes = benchmark.pedantic(gather_np_op, rounds=pytest.trials)
+        backend = "NumPy"
+    else:
+
+        def gather_ak_op():
+            c = _run_gather(v_ak, i_ak)
+            return compute_transfer_bytes(c, dtype)
+
+        numBytes = benchmark.pedantic(gather_ak_op, rounds=pytest.trials)
+        backend = "Arkouda"
+
+        # Correctness check: compare against NumPy if enabled
+        if pytest.correctness_only:
+            i_np = i_ak.to_ndarray()
+            v_np = v_ak.to_ndarray()
+            expected = v_np[i_np]
+            result = _run_gather(v_ak, i_ak).to_ndarray()
+            np.testing.assert_array_equal(result, expected)
+
+    benchmark.extra_info["description"] = f"Measures the performance of {backend} gather"
+    benchmark.extra_info["backend"] = backend
+    benchmark.extra_info["problem_size"] = N
+    benchmark.extra_info["index_size"] = isize
+    benchmark.extra_info["value_size"] = vsize
+    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
+        (numBytes / benchmark.stats["mean"]) / 2**30
+    )


### PR DESCRIPTION
## PR: Unify `gather_benchmark.py` with NumPy and Correctness Support

This PR refactors `gather_benchmark.py` to consolidate separate Arkouda and NumPy benchmarks into a single function, and adds correctness checking functionality.

### ✅ Key Enhancements

- **Single Benchmark Function**
  - Combines Arkouda and NumPy gather logic using `.to_ndarray()` conversion
  - Simplifies maintenance and improves clarity

- **Correctness-Only Mode (`--correctness_only`)**
  - Reduces problem size to `10**4`
  - Performs a NumPy-based validation of Arkouda’s gather results

- **NumPy Mode (`--numpy`)**
  - Enables side-by-side performance comparison by switching execution to NumPy
  - Uses the same Arkouda-generated inputs (via `.to_ndarray()`)

- **Consistent Transfer Rate Measurement**
  - All runs return the number of bytes processed to standardize throughput reporting
  - Supports both string and numeric dtype accounting

### 🧹 Structural Improvements

- Centralized data generation
- Unified variable naming (`i_ak`, `v_ak`, `backend`, etc.)
- Reduced duplicated logic across execution modes

This refactor significantly simplifies the gather benchmark while improving flexibility, accuracy, and test coverage.


Closes #3569:  Update gather_benchmark
