### PR TITLE
Adds an if to avoid the error in Bug 4594

### DIFF
--- a/arkouda/numpy/dtypes.py
+++ b/arkouda/numpy/dtypes.py
@@ -292,9 +292,10 @@ def result_type(*args: Union[pdarray, np.dtype, type]) -> Union[np.dtype, type]:
             # Fallback for unrecognized types
             np_dtypes.append(np.result_type(dt))
 
+    if has_float:
+        return np.result_type(float64)
+
     if has_bigint:
-        if has_float:
-            return float64
         return bigint
     else:
         return np.result_type(*np_dtypes)

--- a/arkouda/numpy/pdarraycreation.py
+++ b/arkouda/numpy/pdarraycreation.py
@@ -239,6 +239,12 @@ def array(
         except (RuntimeError, TypeError, ValueError):
             raise TypeError("a must be a pdarray, np.ndarray, or convertible to a numpy array")
 
+    #   Special case, to get around error when putting negative numbers in a bigint
+
+    if dtype == bigint:
+        if a.dtype == "int64" and (a < 0).any():
+            return akcast(array(a), bigint)
+
     if a.dtype == bigint or a.dtype.name not in DTypes or dtype == bigint:
         # We need this array whether the number of dimensions is 1 or greater.
         uint_arrays: List[Union[pdarray, Strings]] = []

--- a/tests/bigint_agg_test.py
+++ b/tests/bigint_agg_test.py
@@ -15,10 +15,33 @@ def gather_scatter(a):
 
 class TestBigInt:
     @pytest.mark.parametrize("size", pytest.prob_size)
-    def test_negative(self, size):
-        # test with negative bigint values
+    def test_negative_bug_reproducer(self, size):
+        # test with negative bigint values.
+        arr = ak.array([-1, -2, -3], dtype=ak.bigint)  # if this returns a value, the bug was fixed
+        brr = ak.array([1, 2, 3], dtype=ak.bigint)
+        assert ((arr + brr) == 0).all()
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_negative_cast(self, size):
+        # test with negative bigint values.
         arr = -1 * ak.randint(0, 2**32, size)
         bi_neg = ak.cast(arr, ak.bigint)
+        res = gather_scatter(bi_neg)
+        assert bi_neg.to_list() == res.to_list()
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_negative_arraycreation(self, size):
+        # test with negative bigint values.
+        arr = -1 * ak.randint(0, 2**32, size)
+        bi_neg = ak.array(arr, dtype=ak.bigint)
+        res = gather_scatter(bi_neg)
+        assert bi_neg.to_list() == res.to_list()
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_negative_astype(self, size):
+        # test with negative bigint values.
+        arr = -1 * ak.randint(0, 2**32, size)
+        bi_neg = arr.astype(ak.bigint)
         res = gather_scatter(bi_neg)
         assert bi_neg.to_list() == res.to_list()
 


### PR DESCRIPTION
Closes #4594

Rather than disallow negative numbers in bigint arrays, this adds an if to avoid the logic where negative numbers entered an infinite loop involving bigint_from_uint_arrays.  Instead, an ak.int64 array is created, and then cast to bigint.