### PR TITLE
improve benchmark flags

### DIFF
--- a/benchmark_v2/conftest.py
+++ b/benchmark_v2/conftest.py
@@ -324,13 +324,15 @@ def manage_connection():
 
 @pytest.fixture(autouse=True)
 def skip_correctness_only(request):
-    if request.node.get_closest_marker("skip_correctness_only"):
-        if request.node.get_closest_marker("skip_correctness_only").args[0] == pytest.correctness_only:
-            pytest.skip("this test requires --correctness_only != {}".format(pytest.correctness_only))
+    marker = request.node.get_closest_marker("skip_correctness_only")
+    if marker and marker.args and marker.args[0] == pytest.correctness_only:
+        pytest.skip(
+            f"{request.node.name} skipped: requires --correctness_only != {pytest.correctness_only}"
+        )
 
 
 @pytest.fixture(autouse=True)
 def skip_numpy(request):
-    if request.node.get_closest_marker("skip_numpy"):
-        if request.node.get_closest_marker("skip_numpy").args[0] == pytest.numpy:
-            pytest.skip("this test requires --numpy != {}".format(pytest.numpy))
+    marker = request.node.get_closest_marker("skip_numpy")
+    if marker and marker.args and marker.args[0] == pytest.numpy:
+        pytest.skip(f"{request.node.name} skipped: requires --numpy != {pytest.numpy}")


### PR DESCRIPTION
## PR: Improve Robustness and Clarity of `skip_correctness_only` and `skip_numpy` Fixtures

This PR refines the autouse `pytest` fixtures used to conditionally skip tests based on `--correctness_only` and `--numpy` flags.

### ✅ Improvements

- **Safe Marker Access**
  - Uses a local `marker = ...` variable to avoid redundant calls and potential `NoneType` errors
  - Adds guard clauses to ensure `marker.args` exists before accessing index `[0]`

- **Improved Skip Messages**
  - Includes the test name in the skip message using `request.node.name`
  - Provides a more readable and informative reason for skipping

### 🔧 Before

```python
if request.node.get_closest_marker("skip_correctness_only").args[0] == pytest.correctness_only:
    pytest.skip("this test requires --correctness_only != ...")
