### PR TITLE
Closes #4623: Errors in multidimensional take testing

### DIFF
--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -933,18 +933,47 @@ module IndexingMsg
         ref xa = x.a;
         ref idxa = idx.a;
 
-        if array_nd == 1 {
-            forall i in idx.a.domain with (var agg = newSrcAggregator(array_dtype_x)) {
-                agg.copy(y[i], xa[idxa[i]:int]);
+        coforall loc in Locales do on loc {
+
+            var myIdxArr = idx.a[0..#idx.a.size];
+            var m = new map(array_dtype_idx, list(int));
+
+            // This is probably not the most efficient way to handle things, but it works
+            // I can probably improve it later.
+
+            // Here is my idea for improvement: do an argsort on the values of myIdxArr
+            // Apply the argsort to the original indices
+            // Shift the sorted array by one and do a comparison to see where idxa[i] != idxa[i + 1]
+            // Now the forall can work with a map because we just point it at the starting index.
+
+            for i in myIdxArr.domain {
+                var idx = myIdxArr[i];
+                if m.contains(idx) {
+                    m[idx].pushBack(i);
+                } else {
+                    m[idx] = new list([i]);
+                }
             }
-        } else {
-            for sliceIdx in domOffAxis(x.a.domain, axis) {
-                forall i in idx.a.domain with (var agg = newSrcAggregator(array_dtype_x)) {
-                    var yIdx = sliceIdx,
-                        xIdx = sliceIdx;
-                    yIdx[axis] = i;
-                    xIdx[axis] = idxa[i]:int;
-                    agg.copy(y[yIdx], xa[xIdx]);
+
+            if array_nd == 1 {
+                forall i in x.a.domain with (var agg = newDstAggregator(array_dtype_x),
+                                             const ref tempMap = m) {
+                    if tempMap.contains(i: array_dtype_idx) {
+                        for j in tempMap[i: array_dtype_idx] {
+                            agg.copy(y[j], xa[i]);
+                        }
+                    }
+                }
+            } else {
+                forall i in x.a.domain with (var agg = newDstAggregator(array_dtype_x),
+                                             const ref tempMap = m) {
+                    if tempMap.contains(i[axis]: array_dtype_idx) {
+                        for j in tempMap[i[axis]: array_dtype_idx] {
+                            var yIdx = i;
+                            yIdx[axis] = j;
+                            agg.copy(y[yIdx], xa[i]);
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Engin pointed out that multidim, multilocale tests were failing on `test_take_multidim`. I think I found the cause of the issue. Previously, `take` required that the indices had to have the same length as the array it was being used on in the given axis. Since numpy has no such restriction, I tossed that out and assumed it would be fine. But it wasn't fine, because the way the source aggregator was being used, it could be the case that source and dest could both be remote to the locale doing the aggregation. This restructures the code so that it should be okay. It passes tests with 16 locales on 3 dimensions.

Currently, there are a few places where the code could be more efficient, but making it faster could be more difficult. So, this is something of a quick fix just to get it working again.

Closes #4623: Errors in multidimensional take testing