### PR TITLE
Closes 2999, adds ak.logspace function

### DIFF
--- a/arkouda/__init__.py
+++ b/arkouda/__init__.py
@@ -223,6 +223,7 @@ from arkouda.numpy import (
     log10,
     log1p,
     log2,
+    logspace,
     longdouble,
     longlong,
     ma,

--- a/arkouda/numpy/__init__.py
+++ b/arkouda/numpy/__init__.py
@@ -258,6 +258,7 @@ from arkouda.numpy.pdarraycreation import (
     full,
     full_like,
     linspace,
+    logspace,
     ones,
     ones_like,
     promote_to_common_dtype,

--- a/arkouda/numpy/pdarraycreation.py
+++ b/arkouda/numpy/pdarraycreation.py
@@ -38,6 +38,7 @@ __all__ = [
     "full_like",
     "arange",
     "linspace",
+    "logspace",
     "randint",
     "uniform",
     "standard_normal",
@@ -1074,6 +1075,54 @@ def arange(
         return arr if aktype == akint64 else akcast(arr, dt=aktype)
 
     raise TypeError(f"start, stop, step must be ints; got {args!r}")
+
+
+@typechecked
+def logspace(
+    start: numeric_scalars, stop: numeric_scalars, length: int_scalars, base: numeric_scalars = 10.0
+) -> pdarray:
+    """
+    Create a pdarray of numbers evenly spaced on a log scale.
+
+    Parameters
+    ----------
+    start : numeric_scalars
+        Start of interval (inclusive)
+    stop : numeric_scalars
+        End of interval (inclusive)
+    length : int_scalars
+        Number of points
+    base : the base of the log space
+
+    Returns
+    -------
+    pdarray
+        Array of float values evenly space along the log interval from start**base to stop**base
+
+    Raises
+    ------
+    TypeError
+        Raised if start or stop is not a float or int or if length is not an int
+
+    See Also
+    --------
+    linspace
+
+    Notes
+    -----
+    If start is greater than stop, the pdarray values are generated
+    in descending order.
+
+    Examples
+    --------
+    >>> import arkouda as ak
+    >>> ak.logspace(2, 3, 3, 4)
+    array([16.00000000000000000 32.00000000000000000 64.00000000000000000])
+
+    >>> ak.logspace(10, 5, 3, 4)
+    array([1048576.00000000000000000 32768.00000000000000000 1024.00000000000000000])
+    """
+    return base ** linspace(start, stop, length)
 
 
 @typechecked

--- a/tests/numpy/pdarray_creation_test.py
+++ b/tests/numpy/pdarray_creation_test.py
@@ -797,12 +797,13 @@ class TestPdarrayCreation:
             assert (full_like_arr == 1).all()
             assert full_like_arr.size == ran_arr.size
 
-    def test_linspace(self):
-        pda = ak.linspace(0, 100, 1000)
-        assert 1000 == len(pda)
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_linspace(self, size):
+        pda = ak.linspace(0, 100, size)
+        assert size == len(pda)
         assert float == pda.dtype
         assert isinstance(pda, ak.pdarray)
-        assert (pda.to_ndarray() == np.linspace(0, 100, 1000)).all()
+        assert (pda.to_ndarray() == np.linspace(0, 100, size)).all()
 
         pda = ak.linspace(start=5, stop=0, length=6)
         assert 5.0000 == pda[0]
@@ -820,20 +821,20 @@ class TestPdarrayCreation:
         assert (pda.to_ndarray() == np.linspace(float(5.0), float(0.0), np.int64(6))).all()
 
         with pytest.raises(TypeError):
-            ak.linspace(0, "100", 1000)
+            ak.linspace(0, "100", size)
 
         with pytest.raises(TypeError):
-            ak.linspace("0", 100, 1000)
+            ak.linspace("0", 100, size)
 
         with pytest.raises(TypeError):
-            ak.linspace(0, 100, "1000")
+            ak.linspace(0, 100, "size")
 
         # Test that int_scalars covers uint8, uint16, uint32
-        int_arr = ak.linspace(0, 100, (1000 % 256))
+        int_arr = ak.linspace(0, 100, (size % 256))
         for args in [
-            (np.uint8(0), np.uint16(100), np.uint32(1000 % 256)),
-            (np.uint32(0), np.uint8(100), np.uint16(1000 % 256)),
-            (np.uint16(0), np.uint32(100), np.uint8(1000 % 256)),
+            (np.uint8(0), np.uint16(100), np.uint32(size % 256)),
+            (np.uint32(0), np.uint8(100), np.uint16(size % 256)),
+            (np.uint16(0), np.uint32(100), np.uint8(size % 256)),
         ]:
             assert (int_arr == ak.linspace(*args)).all()
 
@@ -845,7 +846,17 @@ class TestPdarrayCreation:
         a = np.linspace(start, stop, size)
         # create ak version
         b = ak.linspace(start, stop, size)
-        assert np.allclose(a, b.to_ndarray())
+        assert_equivalent(a, b)
+
+    @pytest.mark.parametrize("start", [0, 0.5, 2])
+    @pytest.mark.parametrize("stop", [50, 101])
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    def test_compare_logspace(self, size, start, stop):
+        # create np version
+        a = np.logspace(start, stop, size)
+        # create ak version
+        b = ak.logspace(start, stop, size)
+        assert_equivalent(a, b)
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", INT_SCALARS)


### PR DESCRIPTION
Closes #2999

This adds a logspace function, similar to np.logspace.  Just like np.logspace, it uses the linspace function to generate a sequence of numbers, then raises it to the given power.

There is also a unit test for logspace.

Note that we really need to do some additional work.  My preference is to push this function for now, and then create a new issue to improve the alignment to numpy as described below (but I'm open to discussion).

- Neither ak.logspace nor ak.linspace allow non-scalar start, stop and base.  The numpy versions do.
- ak.logspace and ak.linspace use "length" to refer to the argument that numpy calls "num".
- Neither ak.logspace nor ak.linspace allow a dtype or axis argument.  Numpy does.