### PR TITLE
Part of #2384: Checkpoint numeric arrays; improved framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -650,7 +650,7 @@ doc-server: ${DOC_DIR} $(DOC_SERVER_OUTPUT_DIR)/index.html
 $(DOC_SERVER_OUTPUT_DIR)/index.html: $(ARKOUDA_SOURCES) $(ARKOUDA_MAKEFILES) | $(DOC_SERVER_OUTPUT_DIR)
 	@echo "Building documentation for: Server"
 	@# Build the documentation to the Chapel output directory
-	$(CHPLDOC) $(CHPLDOC_FLAGS) $(ARKOUDA_MAIN_SOURCE) $(ARKOUDA_SOURCE_DIR)/compat/eq-22/* -o $(DOC_SERVER_OUTPUT_DIR)
+	$(CHPLDOC) $(CHPLDOC_FLAGS) $(ARKOUDA_REGISTRY_DIR)/doc-support.chpl $(ARKOUDA_MAIN_SOURCE) $(ARKOUDA_SOURCE_DIR)/compat/eq-22/* -o $(DOC_SERVER_OUTPUT_DIR)
 	@# Create the .nojekyll file needed for github pages in the  Chapel output directory
 	touch $(DOC_SERVER_OUTPUT_DIR)/.nojekyll
 	@echo "Completed building documentation for: Server"

--- a/arkouda/pandas/io.py
+++ b/arkouda/pandas/io.py
@@ -2127,8 +2127,10 @@ def save_checkpoint(name="", path=".akdata", mode: str = "overwrite"):
     """
     from arkouda.client import generic_msg
 
-    if mode not in ("overwrite", "error"):
-        raise ValueError("mode can be 'overwrite' or 'error' not {}".format(mode))
+    legal_modes = ["overwrite", "error", "preserve_previous"]
+    if mode not in legal_modes:
+        allowed = '", "'.join(legal_modes)
+        raise ValueError(f'invalid checkpointing mode "{mode}"; allowed modes are: "{allowed}"')
 
     return cast(str, generic_msg(cmd="save_checkpoint", args={"name": name, "path": path, "mode": mode}))
 

--- a/src/ManipulationMsg.chpl
+++ b/src/ManipulationMsg.chpl
@@ -452,9 +452,9 @@ module ManipulationMsg {
   proc expandDimsMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype, param array_nd: int): MsgTuple throws {
     param pn = Reflection.getRoutineName();
 
-    if array_nd == MaxArrayDims {
+    if ! arrayDimIsSupported(array_nd+1) {
       const errMsg = "Cannot expand arrays with rank %i, as this would result an an array with rank %i".format(array_nd, array_nd+1) +
-                     ", exceeding the server's configured maximum of %i. ".format(MaxArrayDims) +
+                     " that is not included in the server's configured ranks: " + arrayDimensionsStr + "." +
                      "Please update the configuration and recompile to support higher-dimensional arrays.";
       mLogger.error(getModuleName(),pn,getLineNumber(),errMsg);
       return new MsgTuple(errMsg,MsgType.ERROR);
@@ -903,9 +903,9 @@ module ManipulationMsg {
   proc stackMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype, param array_nd: int): MsgTuple throws {
     param pn = Reflection.getRoutineName();
 
-    if array_nd == MaxArrayDims {
+    if ! arrayDimIsSupported(array_nd+1) {
       const errMsg = "Cannot stack arrays with rank %i, as this would result an an array with rank %i".format(array_nd, array_nd+1) +
-                     ", exceeding the server's configured maximum of %i. ".format(MaxArrayDims) +
+                     " that is not included in the server's configured ranks: " + arrayDimensionsStr + "." +
                      "Please update the configuration and recompile to support higher-dimensional arrays.";
       mLogger.error(getModuleName(),pn,getLineNumber(),errMsg);
       return new MsgTuple(errMsg,MsgType.ERROR);

--- a/src/MsgProcessing.chpl
+++ b/src/MsgProcessing.chpl
@@ -148,9 +148,24 @@ module MsgProcessing
     :returns: MsgTuple
      */
     proc getconfigMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
-        var repMsg: string; // response message
         mpLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"cmd: %s".format(cmd));
         return new MsgTuple(getConfig(), MsgType.NORMAL);
+    }
+    
+    /* 
+    query server registration config - registration-config.json
+    
+    :arg reqMsg: request containing (cmd)
+    :type reqMsg: string 
+
+    :arg st: SymTab to act on
+    :type st: borrowed SymTab 
+
+    :returns: MsgTuple
+     */
+    proc getRegistrationConfig(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        mpLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),"cmd: ", cmd);
+        return new MsgTuple(ServerConfig.registrationConfigSpec, MsgType.NORMAL);
     }
 
     /* 

--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -6,6 +6,8 @@ module ServerConfig
     use SymArrayDmap only makeDistDomType;
 
     public use IO;
+    public use RegistrationConfig;
+
     use ServerErrorStrings;
     use Reflection;
     use ServerErrors;
@@ -376,6 +378,22 @@ module ServerConfig
                 }
             }
         }
+    }
+
+    // use this arrayDimIsSupported() instead of MaxArrayDims
+    // could clone it for a non-param argument
+    proc arrayDimIsSupported(param dim: int) param : bool {
+      for param idx in 0..arrayDimensionsTy.size-1 do
+        if dim == arrayDimensionsTy[idx].size then
+          return true;
+      return false;
+    }
+
+    proc arrayElmTypeIsSupported(type eltType) param : bool {
+      for param idx in 0..arrayElementsTy.size-1 do
+        if eltType == arrayElementsTy[idx] then
+          return true;
+      return false;
     }
 
     proc string.splitMsgToTuple(param numChunks: int) {

--- a/src/ServerDaemon.chpl
+++ b/src/ServerDaemon.chpl
@@ -356,6 +356,7 @@ module ServerDaemon {
             registerFunction("str", strMsg);
             registerFunction("repr", reprMsg);
             registerFunction("getconfig", getconfigMsg);
+            registerFunction('getRegistrationConfig', getRegistrationConfig);
             registerFunction("getmemused", getmemusedMsg);
             registerFunction("getavailmem", getmemavailMsg);
             registerFunction("getmemstatus", getMemoryStatusMsg);
@@ -687,7 +688,7 @@ module ServerDaemon {
 
                     (response, wasError) = sendRepMsg(repMsg, user);
                 } catch e {
-                    (response, wasError) = sendRepMsg(MsgTuple.error("Error executing command: %s".format(e.message())), user);
+                    (response, wasError) = sendRepMsg(MsgTuple.error("Error executing command %s: %s".format(cmd, e.message())), user);
                 }
 
                 var elapsedTime = timeSinceEpoch().totalSeconds() - s0;

--- a/src/ServerErrors.chpl
+++ b/src/ServerErrors.chpl
@@ -1,6 +1,6 @@
 module ServerErrors {
 
-    private use IO; // for string.format
+    private use IO;
 
     class OutOfBoundsError: Error {}
 
@@ -23,10 +23,9 @@ module ServerErrors {
          */
         proc init(msg : string, lineNumber: int, routineName: string, 
                       moduleName: string, errorClass: string='ErrorWithContext') {
-            try! super.init("%s Line %? In %s.%s: %s".format(errorClass,lineNumber,
-                                                          moduleName,
-                                                          routineName,
-                                                          msg));
+            super.init(generateErrorContext(msg=msg, lineNumber=lineNumber,
+              moduleName=moduleName, routineName=routineName, errorClass=errorClass));
+
             this.lineNumber = lineNumber;
             this.routineName = routineName;
             this.moduleName = moduleName;
@@ -44,7 +43,7 @@ module ServerErrors {
          * understandable to front-end developers as well as users.
          */
         proc publish() : string {
-            return try! "Error: %s".format(publishMsg);
+            return "Error: " + publishMsg;
         }
     }
     
@@ -96,7 +95,7 @@ module ServerErrors {
 
         proc init(msg : string, lineNumber: int, routineName: string, 
                                                            moduleName: string) { 
-           super.init(msg,lineNumber,routineName,moduleName,errorClass='NotHDF5FileError'); 
+           super.init(msg,lineNumber,routineName,moduleName,errorClass='HDF5FileFormatError'); 
         } 
 
         proc init(){ super.init(); }
@@ -220,7 +219,7 @@ module ServerErrors {
 
         proc init(msg : string, lineNumber: int, routineName: string,
                                                            moduleName: string) {
-           super.init(msg,lineNumber,routineName,moduleName,errorClass='IOError');
+           super.init(msg,lineNumber,routineName,moduleName,errorClass='ConfigurationError');
         }
 
         proc init(){ super.init(); }
@@ -233,7 +232,8 @@ module ServerErrors {
      */
     proc generateErrorContext(msg: string, lineNumber: int, moduleName: string, routineName: string, 
                                         errorClass: string="ErrorWithContext") : string {
-        return try! "%s %? %s:%s %s".format(errorClass,lineNumber,moduleName,routineName,msg);
+        return "".join(errorClass, " Line ", lineNumber:string, " In ",
+                       moduleName, ".", routineName, ": ", msg);
     }
  
     /*

--- a/src/registry/doc-support.chpl
+++ b/src/registry/doc-support.chpl
@@ -1,0 +1,24 @@
+// This file is used only when generating docs -
+// to satisfy `use RegistrationConfig` in ServerConfig.chpl.
+// When building Arkouda, this module is found in `src/registry/Commands.chpl`.
+module RegistrationConfig {
+
+  /* This param contains verbatim the contents of `registration-config.json`
+     that were used when building Arkouda. */
+  param registrationConfigSpec: string;
+
+  /* This param string contains a list of array dimensions requested in
+     `registration-config.json`. For example: "1," or "1,2,3,". */
+  param arrayDimensionsStr: string;
+
+  /* This type indicates, implicitly, what array ranks were requensted in
+     `registration-config.json`. For example: `(1*nothing,)` if just rank=1
+     or `(1*nothing, 2*nothing, 3*nothing)` if it requested ranks 1, 2, and 3. */
+  type arrayDimensionsTy;
+
+  /* This is a tuple type each component of which is an array element type
+     requested in `registration-config.json`. For example: `(int, bigint, real)`
+     if `int`, `bigint`, and `real` were requested. */
+  type arrayElementsTy;
+
+}  // module RegistrationConfig


### PR DESCRIPTION
Add the ability for checkpointing to save and load 1-d arrays of any integer or real or bool types specified in `registration-config.json`.

Implementation-wise, set up a framework for checkpointing of any subclasses of AbstractSymEntry, by using dynamic dispatch and starting the entry metadata file with a line that is consistent across all entry kinds.

Furthermore, set up a framework in the server code that allows `param` for-loops over all `param` dimensions and all element types specified in `"parameter_classes"["array"]` in `registration-config.json`.

In more implementation detail, the list of `"parameter_classes"["array"]["nd"]` is now available through `arrayDimensionsTy`; `"parameter_classes"["array"]["dtype"]` through `arrayElementsTy`. These are generated into `src/registry/Commands.chpl` by `src/registry/register_commands.py`, which handles `@arkouda.instantiateAndRegister` and similar attributes. Their use is exemplified by the implementations of `arrayDimIsSupported()`, `arrayElmTypeIsSupported()` or `loadSymEntry()`.

This framework will be leveraged to implement checkpointing of the remaining types of SymTab entries. The type-tuple-based approach is a workaround for Chapel's lack of iterators that yield `param` or `type`.

Other implementation changes:

Restricted `addEntry()` to handle only those types that are requested in `registration-config.json`. This reduces the amount of generated code because the compiler no longer needs to instantiate `SymEntry` for some of the unintended types, such as `[u]int`16 and 32.

Extended `SymTab.insert()` to set the new entry's name, which would otherwise be left empty.

Replaced uses of `MaxArrayDims` with `arrayDimIsSupported()`, except for one in getConfig().

Moved `getRegistrationConfig()` from `register_commands.py` to `MsgProcessing.chpl` for easier maintenance, and simplified it.
