### PR TITLE
Closes #4489:  trapz instability

### DIFF
--- a/arkouda/array_api/utility_functions.py
+++ b/arkouda/array_api/utility_functions.py
@@ -240,14 +240,14 @@ def trapz(y: Array, x: Optional[Array] = None, dx: Optional[float] = 1.0, axis: 
     >>> x = xp.linspace(0, 1, num=50)
     >>> y = x**2
     >>> xp.trapz(y, x)
-    0.33340274885464394
+    0.3334027488546439...
 
     Or estimate the area of a circle, noting we repeat the sample which closes
     the curve:
 
     >>> theta = xp.linspace(0, 2 * xp.pi, num=1000, endpoint=True)
     >>> xp.trapz(xp.cos(theta), x=xp.sin(theta))
-    3.141571941375841
+    3.14157194137584...
 
     ``np.trapz`` can be applied along a specified axis to do multiple
     computations in one call:

--- a/tests/array_api/util_functions.py
+++ b/tests/array_api/util_functions.py
@@ -156,19 +156,19 @@ class TestUtilFunctions:
         for axis in [-1, 0]:
             t = xp.trapz(y, axis=axis)
             t_np = np.trapz(y_np, axis=axis)
-            assert t == t_np
+            assert np.allclose(t._array, t_np)
 
         # Single array version, specified dx
         for axis in [-1, 0]:
             t = xp.trapz(y, dx=2.5, axis=axis)
             t_np = np.trapz(y_np, dx=2.5, axis=axis)
-            assert t == t_np
+            assert np.allclose(t._array, t_np)
 
         # Two array version
         for axis in [-1, 0]:
             t = xp.trapz(y, x, axis=axis)
             t_np = np.trapz(y_np, x_np, axis=axis)
-            assert t == t_np
+            assert np.allclose(t._array, t_np)
 
     @pytest.mark.parametrize("dtype", DTYPES_WITH_BOOL)
     @pytest.mark.skip_if_rank_not_compiled([2])


### PR DESCRIPTION
My best guess is the minor differences in the `trapz` return values are precision errors on the server.  I added ellipses to the docstring and additional `np.allclose` calls to the unit test to hopefully prevent CI errors from this.

Closes #4489:  trapz instability