### PR TITLE
Closes #4445:  add pytest-timeout

### DIFF
--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -47,6 +47,7 @@ dependencies:
   - pre-commit
   - darglint>=1.8.1
   - pytest-subtests
+  - pytest-timeout
 
   - pip:
     # Developer dependencies

--- a/benchmark_v2/conftest.py
+++ b/benchmark_v2/conftest.py
@@ -56,7 +56,7 @@ def pytest_addoption(parser):
 
     default_client_timeout = int(os.getenv("ARKOUDA_CLIENT_TIMEOUT", 0))
     parser.addoption(
-        "--timeout",
+        "--client_timeout",
         action="store",
         type=int,
         default=default_client_timeout,
@@ -206,7 +206,7 @@ def pytest_configure(config):
     pytest.nl = config.getoption("nl")
     pytest.running_mode = TestRunningMode(config.getoption("running_mode"))
     pytest.verbose = config.getoption("verbose")
-    pytest.timeout = config.getoption("timeout")
+    pytest.client_timeout = config.getoption("client_timeout")
     # NOTE:  Commented out argument that is not yet implemented and therefore has no effect.
     # pytest.log_level = config.getoption("log_level")
     pytest.prob_size = eval(config.getoption("size"))
@@ -310,7 +310,7 @@ def _module_server() -> Iterator[None]:
 @pytest.fixture(scope="function", autouse=True)
 def manage_connection():
     try:
-        ak.connect(server=pytest.host, port=pytest.port, timeout=pytest.timeout)
+        ak.connect(server=pytest.host, port=pytest.port, timeout=pytest.client_timeout)
     except Exception as e:
         raise ConnectionError(e)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,9 @@
 [pytest]
+#   Set the timeout to 15 minutes:
+timeout = 900
+#   Set timeout_method to 'signal' on Unix
+timeout_method = thread  
+
 filterwarnings =
     ignore:Version mismatch between client .*
 testpaths =

--- a/setup.py
+++ b/setup.py
@@ -209,6 +209,7 @@ setup(
             "pydoclint[flake8]==0.6.6",
             "pytest-subtests",
             "numba",
+            "pytest-timeout",
         ],
     },
     # replace original install command with version that also builds


### PR DESCRIPTION
This PR adds `pytest-timeout` to the project.  `pytest-timeout` can be used to time out unit tests individually or over the entire project, as listed in the table below.  However, it does not work well with ZMQ in multi-locale mode.  In that scenario, if one test fail all subsequent tests will fail.  Thus, the time out value should be set high enough that it will only be triggered rarely and indicate a serious problem with the tests.

### Summary

| Approach  | Usage                                |
|-----------|--------------------------------------|
| Per test  | `@pytest.mark.timeout(5)`            |
| Global    | `pytest.ini` with `timeout = 5`      |
| CLI       | `pytest --timeout=5`                 |
| Fixture   | Not commonly used; prefer markers or config |

Closes #4445: add pytest-timeout