### PR TITLE
fix a typo in pytest.ini causing groupby tests to be skipped

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -31,7 +31,7 @@ testpaths =
     tests/pandas/dataframe_test.py
     tests/numpy/datetime_test.py
     tests/extrema_test.py
-    tests/pandas/xgroupby_test.py
+    tests/pandas/groupby_test.py
     tests/indexing_test.py
     tests/pandas/index_test.py
     tests/pandas/io_test.py


### PR DESCRIPTION
Fixes a typo in pytest.ini causing groupby tests to be skipped.