### PR TITLE
Add new searchsorted implementation

### DIFF
--- a/arkouda/array_api/searching_functions.py
+++ b/arkouda/array_api/searching_functions.py
@@ -135,7 +135,9 @@ def searchsorted(
         last such index. Default is 'left'.
     sorter : Array, optional
         The indices that would sort `x1` in ascending order. If None, `x1` is assumed to be sorted.
-
+    x2_sorted : bool, default=False
+        If True, assumes that `x2` is already sorted in ascending order. This can improve performance
+        for large, sorted search arrays. If False, no assumption is made about the order of `x2`.
     """
     from arkouda.client import generic_msg
 

--- a/arkouda/array_api/searching_functions.py
+++ b/arkouda/array_api/searching_functions.py
@@ -117,6 +117,7 @@ def searchsorted(
     /,
     *,
     side: Literal["left", "right"] = "left",
+    x2_sorted: bool = False,
     sorter: Optional[Array] = None,
 ) -> Array:
     """
@@ -155,6 +156,7 @@ def searchsorted(
             "x1": _x1._array,
             "x2": x2._array,
             "side": side,
+            "x2Sorted": x2_sorted,
         },
     )
 

--- a/arkouda/numpy/sorting.py
+++ b/arkouda/numpy/sorting.py
@@ -291,7 +291,7 @@ def sort(
 
 @typechecked
 def searchsorted(
-    a: pdarray, v: Union[int_scalars, float64, bigint, pdarray], side: Literal["left", "right"] = "left"
+    a: pdarray, v: Union[int_scalars, float64, bigint, pdarray], side: Literal["left", "right"] = "left", x2_sorted: bool = False
 ) -> Union[int, pdarray]:
     """
     Find indices where elements should be inserted to maintain order.
@@ -361,6 +361,7 @@ def searchsorted(
             "x1": a,
             "x2": v_,
             "side": side,
+            "x2Sorted": x2_sorted,
         },
     )
 

--- a/arkouda/numpy/sorting.py
+++ b/arkouda/numpy/sorting.py
@@ -87,7 +87,11 @@ def argsort(
     if axis == -1:
         axis = int(ndim) - 1
 
-    check_type(argname="argsort", value=pda, expected_type=Union[pdarray, Strings, Categorical])
+    check_type(
+        argname="argsort",
+        value=pda,
+        expected_type=Union[pdarray, Strings, Categorical],
+    )
 
     if isinstance(pda, Categorical):
         return cast(Categorical, pda).argsort()
@@ -161,7 +165,9 @@ def coargsort(
     from arkouda.pandas.categorical import Categorical
 
     check_type(
-        argname="coargsort", value=arrays, expected_type=Sequence[Union[pdarray, Strings, Categorical]]
+        argname="coargsort",
+        value=arrays,
+        expected_type=Sequence[Union[pdarray, Strings, Categorical]],
     )
     size: int_scalars = -1
     anames, atypes, expanded_arrays = [], [], []
@@ -227,7 +233,9 @@ def coargsort(
 
 @typechecked
 def sort(
-    pda: pdarray, algorithm: SortingAlgorithm = SortingAlgorithm.RadixSortLSD, axis: int_scalars = -1
+    pda: pdarray,
+    algorithm: SortingAlgorithm = SortingAlgorithm.RadixSortLSD,
+    axis: int_scalars = -1,
 ) -> pdarray:
     """
     Return a sorted copy of the array. Only sorts numeric arrays;
@@ -291,7 +299,10 @@ def sort(
 
 @typechecked
 def searchsorted(
-    a: pdarray, v: Union[int_scalars, float64, bigint, pdarray], side: Literal["left", "right"] = "left", x2_sorted: bool = False
+    a: pdarray,
+    v: Union[int_scalars, float64, bigint, pdarray],
+    side: Literal["left", "right"] = "left",
+    x2_sorted: bool = False,
 ) -> Union[int, pdarray]:
     """
     Find indices where elements should be inserted to maintain order.

--- a/arkouda/numpy/sorting.py
+++ b/arkouda/numpy/sorting.py
@@ -319,6 +319,9 @@ def searchsorted(
     side : {'left', 'right'}, default='left'
         If 'left', the index of the first suitable location found is given.
         If 'right', return the last such index.
+    x2_sorted : bool, default=False
+        If True, assumes that `v` (x2) is already sorted in ascending order. This can improve performance
+        for large, sorted search arrays. If False, no assumption is made about the order of `v`.
 
     Returns
     -------
@@ -346,6 +349,9 @@ def searchsorted(
     >>> v = ak.array([-10, 20, 12, 13])
     >>> ak.searchsorted(a, v)
     array([0 5 1 2])
+    >>> v_sorted = ak.array([-10, 12, 13, 20])
+    >>> ak.searchsorted(a, v_sorted, x2_sorted=True)
+    array([0 1 2 5])
     """
     from arkouda.client import generic_msg
 

--- a/src/SortMsg.chpl
+++ b/src/SortMsg.chpl
@@ -294,7 +294,7 @@ module SortMsg
           throw new Error("searchSorted side must be a string with value 'left' or 'right'.");
       }
 
-      if x2Sorted && x1.size >= numLocales && d2.rank == 1{
+      if (x2.rank == 1) && x2Sorted && x1.size >= numLocales {
         // If x2 is already sorted, we can use the fast version
         param msg = "Fast searchSorted path taken";
         sortLogger.info(getModuleName(),getRoutineName(),getLineNumber(), msg);

--- a/src/SortMsg.chpl
+++ b/src/SortMsg.chpl
@@ -296,7 +296,7 @@ module SortMsg
 
       if x2Sorted && x1.size >= numLocales {
         // If x2 is already sorted, we can use the fast version
-        writeln("Fast searchSorted path taken");
+        sortLogger.info("Fast searchSorted path taken");
         return searchSortedFast(x1, x2, side);
       }
       return searchSortedSlow(x1, x2, side);

--- a/src/SortMsg.chpl
+++ b/src/SortMsg.chpl
@@ -296,7 +296,8 @@ module SortMsg
 
       if x2Sorted && x1.size >= numLocales {
         // If x2 is already sorted, we can use the fast version
-        sortLogger.info("Fast searchSorted path taken");
+        param msg = "Fast searchSorted path taken";
+        sortLogger.info(getModuleName(),getRoutineName(),getLineNumber(), msg);
         return searchSortedFast(x1, x2, side);
       }
       return searchSortedSlow(x1, x2, side);

--- a/src/SortMsg.chpl
+++ b/src/SortMsg.chpl
@@ -185,8 +185,8 @@ module SortMsg
             // If this value is > myHigh, we can skip the rest since it's not in our range (except for last locale)
             // Or if gtElem is same as eqOrGtElem, then we don't own this either
             if (isLastLocale || gtElem <= myHigh) && gtElem != eqOrGtElem {
-            // We own this value, so we can set myFirst to gtMyLow
-            myFirst = gtMyLow;
+              // We own this value, so we can set myFirst to gtMyLow
+              myFirst = gtMyLow;
             }
           }
         } else {

--- a/src/SortMsg.chpl
+++ b/src/SortMsg.chpl
@@ -99,7 +99,7 @@ module SortMsg
 
 
   proc searchSortedFast(x1: [?d1] ?t, x2: [?d2] t, side: string): [d2] int throws
-    where ((d1.rank == 1) &&
+    where (((d1.rank == 1) && (d2.rank == 1)) &&
             (t == int || t == real || t == uint || t == uint(8) ||
             t == bigint))
   {
@@ -294,7 +294,7 @@ module SortMsg
           throw new Error("searchSorted side must be a string with value 'left' or 'right'.");
       }
 
-      if x2Sorted && x1.size >= numLocales {
+      if x2Sorted && x1.size >= numLocales && d2.rank == 1{
         // If x2 is already sorted, we can use the fast version
         param msg = "Fast searchSorted path taken";
         sortLogger.info(getModuleName(),getRoutineName(),getLineNumber(), msg);

--- a/src/SortMsg.chpl
+++ b/src/SortMsg.chpl
@@ -97,15 +97,216 @@ module SortMsg
       return sorted;
     }
 
+
+  proc searchSortedFast(x1: [?d1] ?t, x2: [?d2] t, side: string): [d2] int throws
+    where ((d1.rank == 1) &&
+            (t == int || t == real || t == uint || t == uint(8) ||
+            t == bigint))
+  {
+    if side != "left" && side != "right" {
+        throw new Error("searchSortedNew side must be a string with value \
+                        'left' or 'right'.");
+    }
+    // This is a distributed version of searchSorted
+    // We will use the local subdomain to find the boundaries for each locale
+    // and then do a binary search on the local subdomain of x1 for each value
+    // in x2 that lies in that locale
+
+    // This version assumes both x1 and x2 are sorted arrays
+
+    // Find the locale boundaries for x1
+    var locBoundariesX1 = blockDist.createArray(0..Locales.size-1, (t, t));
+    coforall loc in Locales do on loc {
+      // Get the local subdomain of x1
+      ref myLocVals = x1[x1.domain.localSubdomain()];
+
+      // Since all arrays are always distributed across all locales in Arkouda
+      // we don't need to worry about the local subdomain being empty
+      // as long as the array size is greater than numLocales
+
+      // Assign to boundaries array
+      // low and high is the same as first and last since x1 is sorted
+      locBoundariesX1[loc.id] = (myLocVals.first, myLocVals.last);
+    }
+
+    // Find the locale boundaries for x2, such that we know which locale
+    // is responsible for which values in x2, aligning with locBoundariesX1
+    // Make locBoundariesX2 a defaultDist array copied on each locale ??
+    var locBoundariesX2 = blockDist.createArray(0..Locales.size-1, (int, int));
+    coforall loc in Locales do on loc {
+      // Get the low and high values for the local subdomain of x1
+      const (myLow, myHigh) = locBoundariesX1[loc.id];
+      const isFirstLocale = here.id == 0;
+      const isLastLocale = here.id == Locales.size - 1;
+
+      const prevLocId = if isFirstLocale then 0 else here.id - 1; // previous locale id, won't be used for locale 0
+      const (_, prevHigh) = if isFirstLocale then (0:t, myLow) else locBoundariesX1[prevLocId];
+      const nextLocId = if isLastLocale then Locales.size - 1 else here.id + 1 ; // next locale id, won't be used for last locale
+      const (nextLow, _) = if isLastLocale then (myHigh, 0:t) else locBoundariesX1[nextLocId];
+
+      // Use binary search to find boundaries efficiently
+      var myFirst = -1;
+      var myLast = -1;
+
+      // Find first index where x2[i] >= myLow
+      const (_, eqOrGtMyLow) = if myLow == prevHigh then
+        Search.binarySearch(x2, myLow, new leftCmp())
+      else
+        Search.binarySearch(x2, prevHigh, new rightCmp())
+      ;
+      // Special case for the 0th Locale, where myLow really doesn't matter,
+      // we need to include all elements < myHigh
+      if isFirstLocale && eqOrGtMyLow > x2.domain.high {
+        myFirst = 0; // We own all elements in x2
+      } else if eqOrGtMyLow <= x2.domain.high { // eqOrGtMyLow can be out of bounds if myLow is > all elements in x2 for other locales
+
+        const eqOrGtElem = x2[eqOrGtMyLow]; // this is the element at the index we found
+
+        // If this value is > myHigh, we can skip the rest since it's not in our range
+        if isLastLocale && eqOrGtElem > myHigh { // special case for last locale, where myHigh really doesn't matter,
+          myFirst = eqOrGtMyLow; // We own this value, so we can set myFirst to eqOrGtMyLow
+        } else if !isFirstLocale && eqOrGtElem == myLow && eqOrGtElem == prevHigh
+          /*&& prevHigh == myLow (implied)*/ && side == "left" {
+
+          // If we are on any locale other than the first one,
+          // AND eqOrGtElem is equal to myLow,
+          // AND eqOrGtElem is equal to the previous locale's high,
+          // AND side is "left", then the previous locale owns this value
+
+          // The next value we could possibly own is the first x2 value that is greater than myLow
+          // Find first index where x2[i] > myLow
+          const (_, gtMyLow) = Search.binarySearch(x2, prevHigh, new rightCmp());
+          // gtMyLow can be out of bounds if myLow is >= all elements in x2
+          if gtMyLow <= x2.domain.high {
+            const gtElem = x2[gtMyLow]; // this is the element at the index we found
+            // If this value is > myHigh, we can skip the rest since it's not in our range (except for last locale)
+            // Or if gtElem is same as eqOrGtElem, then we don't own this either
+            if (isLastLocale || gtElem <= myHigh) && gtElem != eqOrGtElem {
+            // We own this value, so we can set myFirst to gtMyLow
+            myFirst = gtMyLow;
+            }
+          }
+        } else {
+          // We own this value, so we can set myFirst to eqOrGtMyLow
+          myFirst = eqOrGtMyLow;
+        }
+      }
+
+      // Now find myLast using binary search instead of linear search
+      if myFirst != -1 {
+        // Find the last index where x2[i] <= myHigh
+        const (_, eqOrLeMyHighPlusOne) = Search.binarySearch(x2, myHigh, new rightCmp()); // right cmp is correct here always, since we want the last index
+        // The element and index we have is 1 after the last element that is <= myHigh
+        // so we go back one index to get the last element that is <= myHigh
+        const eqOrLeMyHigh = eqOrLeMyHighPlusOne - 1;
+        // eqOrLeMyHigh can also be out of bounds if myHigh is < all elements in x2
+        // Special case for the last Locale, where myHigh really doesn't matter,
+        // we need to include all elements < myHigh
+        if isLastLocale {
+          myLast = x2.domain.high;
+        } else if eqOrLeMyHigh >= x2.domain.low {
+          const eqOrLeElem = x2[eqOrLeMyHigh]; // this is the element at the index we found
+
+          // If we are any locale other than the last one,
+          // AND eqOrLeElem is equal to myHigh,
+          // AND eqOrLeElem is equal to the next locale's low,
+          // AND side is "right", then the next locale owns this value
+          if !isLastLocale && eqOrLeElem == myHigh && eqOrLeElem == nextLow
+            /*&& nextLow == myHigh (implied)*/ && side == "right" {
+            // Find last index where x2[i] < myHigh
+            const (_, ltMyHighPlusOne) = Search.binarySearch(x2, myHigh, new leftCmp());
+            // The element and index we have is 1 after the last element that is < myHigh
+            // so we go back one index to get the last element that is < myHigh
+            const ltMyHigh = ltMyHighPlusOne - 1;
+            // ltMyHigh can be out of bounds if myHigh is <= all elements in x2
+            /// TODOOOOOOO special case last locale ??? (not needed since this will never trigger because of the blanket last locale if statement setting myLast above)
+            if ltMyHigh >= x2.domain.low {
+              const ltElem = x2[ltMyHigh]; // this is the element at the index we found
+              // If this value is < prevHigh, we can skip the rest since it's not in our range
+              // Or if ltElem is same as eqOrLeElem, then we don't own this either
+              if ltElem >= prevHigh && ltElem != eqOrLeElem {
+                // We own this value, so we can set myLast to ltMyHigh
+                myLast = ltMyHigh;
+              }
+            }
+          } else {
+            // We own this value, so we can set myLast to eqOrLeMyHigh
+            myLast = eqOrLeMyHigh;
+          }
+        }
+      }
+
+      // Handle empty ranges
+      if myFirst == -1 {
+        myFirst = 0;
+        myLast = -1; // This creates an empty range [0..-1]
+      }
+
+      // Assign the boundaries for this locale
+      locBoundariesX2[loc.id] = (myFirst, myLast);
+    }
+    // Now we have the boundaries for each locale, we can do a binary search on x1
+    // for each value in my chunk of x2
+    var ret = x2.domain.tryCreateArray(int); // change to makeDistArray
+    coforall loc in Locales do on loc {
+      // Get the local subdomain of x1
+      const myLocalSubdomainX1 = x1.domain.localSubdomain();
+      ref myLocX1 = x1[myLocalSubdomainX1];
+
+      // Get the boundaries for this locale
+      const (myFirst, myLast) = locBoundariesX2[loc.id];
+
+      // Create a local copy subdomain of x2 that this locale is responsible for
+      var myLocX2 : [myFirst..myLast] t;
+      // This seems risky. What if this slice is too big to fit on a single node?
+      // Ex: all the elements in x2 are smaller than x1[0], so the entirety of x2
+      // is assigned to locale 0? I guess this is also a load balancing issue...
+      myLocX2[myFirst..myLast] = x2[myFirst..myLast];
+
+      select side {
+        when "left" do doSearch(myLocX1, myLocX2, new leftCmp());
+        when "right" do doSearch(myLocX1, myLocX2, new rightCmp());
+        otherwise do halt("unreachable");
+       }
+    }
+
+    proc doSearch(const ref a1: [] t, const ref a2: [?d] t, cmp) {
+      var localret : [d] int;
+      forall idx in d {
+        const (_, i) = Search.binarySearch(a1, a2[idx], cmp);
+        // ret[idx] = i;
+        localret[idx] = i;
+      }
+      ret[d] = localret[d];
+    }
+
+    return ret;
+  }
+
+
     // https://data-apis.org/array-api/latest/API_specification/generated/array_api.searchsorted.html#array_api.searchsorted
     @arkouda.registerCommand
-    proc searchSorted(x1: [?d1] ?t, x2: [?d2] t, side: string): [d2] int throws
+    proc searchSorted(x1: [?d1] ?t, x2: [?d2] t, side: string, x2Sorted : bool = false): [d2] int throws
       where ((d1.rank == 1) &&
              (t == int || t == real || t == uint || t == uint(8) || t == bigint))
     {
       if side != "left" && side != "right" {
           throw new Error("searchSorted side must be a string with value 'left' or 'right'.");
       }
+
+      if x2Sorted && x1.size >= numLocales {
+        // If x2 is already sorted, we can use the fast version
+        writeln("Fast searchSorted path taken");
+        return searchSortedFast(x1, x2, side);
+      }
+      return searchSortedSlow(x1, x2, side);
+    }
+
+
+    proc searchSortedSlow(x1: [?d1] ?t, x2: [?d2] t, side: string): [d2] int throws
+      where ((d1.rank == 1) &&
+             (t == int || t == real || t == uint || t == uint(8) || t == bigint))
+    {
 
       var ret = makeDistArray((...x2.shape), int);
 

--- a/tests/numpy/sort_test.py
+++ b/tests/numpy/sort_test.py
@@ -169,3 +169,132 @@ class TestSort:
             assert ak_output == np_output
         else:
             assert_arkouda_array_equivalent(ak_output, np_output)
+
+    @pytest.mark.parametrize("dtype", [ak.float64, ak.int64, ak.bigint, ak.uint64])
+    @pytest.mark.parametrize("side", ["left", "right"])
+    def test_searchsorted_fast_edge_cases(self, dtype, side):
+        # Test edge cases for searchsorted with fast path enabled
+        # This is when x2 is also sorted
+        # List of (x1, x2) edge case pairs
+        edge_cases = [
+            # Test case 1: basic case with small arrays
+            ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], [5, 8, 10, 12]),
+
+            # Test case 2: x2 element equals boundary values (left/right side differences)
+            ([1, 2, 2, 2, 3, 4, 4, 4, 5, 6, 7, 8, 8, 9, 10, 11], [2, 4, 8, 10]),
+
+            # Test case 4: All x2 elements smaller than x1[0] (all assigned to locale 0)
+            ([10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85], [1, 2, 3, 4, 5, 6, 7, 8]),
+
+            # Test case 5: All x2 elements larger than x1[last] (all assigned to last locale)
+            ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], [20, 25, 30, 35, 40, 45, 50, 55]),
+
+            # Test case 6: x2 elements exactly at locale boundary transitions
+            ([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], [3, 4, 7, 8, 11, 12]),
+
+            # Test case 7: Duplicate values spanning multiple locales
+            ([1, 1, 1, 1, 5, 5, 5, 5, 9, 9, 9, 9, 13, 13, 13, 13], [1, 5, 9, 13]),
+
+            # Test case 8: x2 value equal to prevHigh and myLow (left side ownership test)
+            ([2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32], [6, 8, 16, 20]),
+
+            # Test case 9: x2 value equal to myHigh and nextLow (right side ownership test)
+            ([1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31], [7, 9, 11, 15, 19]),
+
+            # Test case 10: Mixed boundary conditions with left/right side differences
+            ([0, 2, 2, 4, 4, 4, 6, 6, 8, 8, 8, 10, 12, 14, 16, 18], [2, 4, 6, 8, 10, 12]),
+
+            # Test case 11: Binary search edge case - value not found, insertion point
+            ([1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31], [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32]),
+
+            # Test case 12: Large duplicates that may create empty ranges
+            ([1, 1, 1, 1, 1, 1, 10, 10, 10, 10, 10, 20, 20, 20, 20, 20], [1, 5, 10, 15, 20, 25]),
+
+            # Test case 13: Arithmetic edge cases (potential overflow/underflow in mid calculation)
+            ([100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600], [150, 350, 550, 750, 950, 1150, 1350, 1550]),
+
+            # Test case 14: First locale special case where myLow doesn't matter
+            ([5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80], [1, 2, 3, 12, 18, 22, 28, 35]),
+
+            # Test case 15: Last locale special case where myHigh doesn't matter
+            ([1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75], [38, 42, 47, 50, 55, 60, 70, 80]),
+
+            # Test case 16: Out of bounds binary search results
+            ([10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160], [5, 15, 25, 95, 105, 125, 145, 165]),
+
+            # Test case 17: The specific case mentioned in the prompt
+            ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], [8, 12, 16, 16]),
+
+            # Test case 18: Sequential boundary values
+            ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], [3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+
+            # Test case 19: Empty ranges created by boundary logic
+            ([1, 1, 1, 1, 10, 10, 10, 10, 20, 20, 20, 20, 30, 30, 30, 30], [5, 15, 25, 35]),
+
+            # Test case 20: Maximum stress test with many duplicates
+            ([1, 1, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, 5, 5], [1, 2, 3, 4, 5, 6]),
+
+            # Algorithmic edge cases
+            # A1: eqOrGtMyLow == x2.domain.high condition for first locale
+            ([5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80], [45]),
+            # A2: eqOrGtMyLow out of bounds condition
+            ([50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200], [10, 20, 30, 40]),
+            # A3: gtMyLow out of bounds when searching for next value
+            ([5, 5, 5, 10, 10, 10, 15, 15, 15, 20, 20, 20, 25, 25, 25, 30], [10, 15, 20, 35]),
+            # A4: eqOrLeMyHigh out of bounds (negative index)
+            ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], [0]),
+            # A5: ltMyHigh out of bounds when searching for previous value
+            ([10, 10, 10, 20, 20, 20, 30, 30, 30, 40, 40, 40, 50, 50, 50, 60], [5, 10, 20, 30]),
+            # A6: Complex boundary value equality across multiple locales
+            ([1, 2, 3, 3, 3, 4, 5, 6, 6, 6, 7, 8, 9, 9, 9, 10], [3, 6, 9]),
+            # A7: Left vs Right side ownership with identical boundary values
+            ([2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32], [8, 16, 24]),
+            # A8: gtElem == eqOrGtElem condition testing
+            ([1, 1, 1, 5, 5, 5, 9, 9, 9, 13, 13, 13, 17, 17, 17, 21], [1, 5, 9, 13, 17]),
+            # A9: ltElem == eqOrLeElem condition testing
+            ([3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45, 48], [6, 15, 24, 33, 42]),
+            # A10: myFirst remains -1 leading to empty range creation
+            ([100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600], [50, 150, 250]),
+            # A11: Last locale with eqOrGtElem > myHigh
+            ([1, 5, 9, 13, 17, 21, 25, 29, 33, 37, 41, 45, 49, 53, 57, 61], [35, 45, 55, 65, 75]),
+            # A12: First locale with all elements in x2 < myHigh
+            ([50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200], [10, 20, 30, 40, 45]),
+            # A13: Boundary search with leftCmp vs rightCmp differences
+            ([2, 2, 2, 6, 6, 6, 10, 10, 10, 14, 14, 14, 18, 18, 18, 22], [2, 6, 10, 14, 18]),
+            # A14: Stress test for boundary index calculations
+            ([1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31], [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32]),
+            # A15: Complex ownership transfer scenarios
+            ([5, 10, 10, 15, 20, 20, 25, 30, 30, 35, 40, 40, 45, 50, 50, 55], [8, 10, 12, 18, 20, 22, 28, 30, 32, 38, 40, 42, 48, 50, 52]),
+            # Specialized cases
+            # S1: Exact boundary value equality for left side ownership
+            ([1, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30], [6, 14, 22]),
+            # S2: Exact boundary value equality for right side ownership
+            ([2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32], [8, 16, 24]),
+            # S3: Binary search returns domain.high exactly
+            ([10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160], [95, 105, 115, 125]),
+            # S4: Empty range handling with myFirst = -1
+            ([20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95], [5, 10, 15]),
+            # S5: gtElem <= myHigh && gtElem != eqOrGtElem condition
+            ([5, 5, 10, 10, 15, 15, 20, 20, 25, 25, 30, 30, 35, 35, 40, 40], [5, 10, 15, 20, 25]),
+            # S6: ltElem >= prevHigh && ltElem != eqOrLeElem condition
+            ([3, 6, 6, 9, 9, 12, 12, 15, 15, 18, 18, 21, 21, 24, 24, 27], [6, 9, 12, 15, 18, 21]),
+            # S7: eqOrLeMyHigh negative index scenario
+            ([100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600], [50]),
+            # S8: All elements equal (extreme duplicate case)
+            ([5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5], [5, 5, 5, 5]),
+            # S9: Interleaved boundaries with first/last locale special cases
+            ([1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150], [0, 5, 35, 75, 125, 160]),
+            # S10: Maximum boundary stress test
+            ([1, 1, 5, 5, 5, 10, 10, 15, 15, 15, 20, 20, 25, 25, 25, 30], [1, 3, 5, 7, 10, 12, 15, 17, 20, 22, 25, 27, 30, 35]),
+            # Uneven blockDist distribution: x1 length 17
+            ([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17], [1,8,16,17]),
+        ]
+        for x1, x2 in edge_cases:
+            np_x1 = np.array(x1, dtype=dtype)
+            np_x2 = np.array(x2, dtype=dtype)
+            ak_x1 = ak.array(np_x1)
+            ak_x2 = ak.array(np_x2)
+            np_output = np.searchsorted(np_x1, np_x2, side)
+            ak_output = ak.searchsorted(ak_x1, ak_x2, side, x2_sorted=True)
+            assert_arkouda_array_equivalent(ak_output, np_output)
+

--- a/tests/numpy/sort_test.py
+++ b/tests/numpy/sort_test.py
@@ -183,227 +183,218 @@ class TestSort:
         else:
             assert_arkouda_array_equivalent(ak_output, np_output)
 
+    # List of (x1, x2) edge case pairs for searchsorted fast path
+    edge_cases_searchsorted_fast = [
+        # Test case 1: basic case with small arrays
+        ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], [5, 8, 10, 12]),
+        # Test case 2: x2 element equals boundary values (left/right side differences)
+        ([1, 2, 2, 2, 3, 4, 4, 4, 5, 6, 7, 8, 8, 9, 10, 11], [2, 4, 8, 10]),
+        # Test case 4: All x2 elements smaller than x1[0] (all assigned to locale 0)
+        ([10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85], [1, 2, 3, 4, 5, 6, 7, 8]),
+        # Test case 5: All x2 elements larger than x1[last] (all assigned to last locale)
+        (
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+            [20, 25, 30, 35, 40, 45, 50, 55],
+        ),
+        # Test case 6: x2 elements exactly at locale boundary transitions
+        (
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+            [3, 4, 7, 8, 11, 12],
+        ),
+        # Test case 7: Duplicate values spanning multiple locales
+        (
+            [1, 1, 1, 1, 5, 5, 5, 5, 9, 9, 9, 9, 13, 13, 13, 13],
+            [1, 5, 9, 13],
+        ),
+        # Test case 8: x2 value equal to prevHigh and myLow (left side ownership test)
+        (
+            [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32],
+            [6, 8, 16, 20],
+        ),
+        # Test case 9: x2 value equal to myHigh and nextLow (right side ownership test)
+        (
+            [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31],
+            [7, 9, 11, 15, 19],
+        ),
+        # Test case 10: Mixed boundary conditions with left/right side differences
+        (
+            [0, 2, 2, 4, 4, 4, 6, 6, 8, 8, 8, 10, 12, 14, 16, 18],
+            [2, 4, 6, 8, 10, 12],
+        ),
+        # Test case 11: Binary search edge case - value not found, insertion point
+        (
+            [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31],
+            [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32],
+        ),
+        # Test case 12: Large duplicates that may create empty ranges
+        (
+            [1, 1, 1, 1, 1, 1, 10, 10, 10, 10, 10, 20, 20, 20, 20, 20],
+            [1, 5, 10, 15, 20, 25],
+        ),
+        # Test case 13: Arithmetic edge cases (potential overflow/underflow in mid calculation)
+        (
+            [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600],
+            [150, 350, 550, 750, 950, 1150, 1350, 1550],
+        ),
+        # Test case 14: First locale special case where myLow doesn't matter
+        (
+            [5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80],
+            [1, 2, 3, 12, 18, 22, 28, 35],
+        ),
+        # Test case 15: Last locale special case where myHigh doesn't matter
+        (
+            [1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75],
+            [38, 42, 47, 50, 55, 60, 70, 80],
+        ),
+        # Test case 16: Out of bounds binary search results
+        (
+            [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160],
+            [5, 15, 25, 95, 105, 125, 145, 165],
+        ),
+        # Test case 17: The specific case mentioned in the prompt
+        (
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+            [8, 12, 16, 16],
+        ),
+        # Test case 18: Sequential boundary values
+        (
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+            [3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+        ),
+        # Test case 19: Empty ranges created by boundary logic
+        (
+            [1, 1, 1, 1, 10, 10, 10, 10, 20, 20, 20, 20, 30, 30, 30, 30],
+            [5, 15, 25, 35],
+        ),
+        # Test case 20: Maximum stress test with many duplicates
+        (
+            [1, 1, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, 5, 5],
+            [1, 2, 3, 4, 5, 6],
+        ),
+        # Algorithmic edge cases
+        # A1: eqOrGtMyLow == x2.domain.high condition for first locale
+        ([5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80], [45]),
+        # A2: eqOrGtMyLow out of bounds condition
+        (
+            [50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200],
+            [10, 20, 30, 40],
+        ),
+        # A3: gtMyLow out of bounds when searching for next value
+        (
+            [5, 5, 5, 10, 10, 10, 15, 15, 15, 20, 20, 20, 25, 25, 25, 30],
+            [10, 15, 20, 35],
+        ),
+        # A4: eqOrLeMyHigh out of bounds (negative index)
+        ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], [0]),
+        # A5: ltMyHigh out of bounds when searching for previous value
+        ([10, 10, 10, 20, 20, 20, 30, 30, 30, 40, 40, 40, 50, 50, 50, 60], [5, 10, 20, 30]),
+        # A6: Complex boundary value equality across multiple locales
+        ([1, 2, 3, 3, 3, 4, 5, 6, 6, 6, 7, 8, 9, 9, 9, 10], [3, 6, 9]),
+        # A7: Left vs Right side ownership with identical boundary values
+        (
+            [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32],
+            [8, 16, 24],
+        ),
+        # A8: gtElem == eqOrGtElem condition testing
+        (
+            [1, 1, 1, 5, 5, 5, 9, 9, 9, 13, 13, 13, 17, 17, 17, 21],
+            [1, 5, 9, 13, 17],
+        ),
+        # A9: ltElem == eqOrLeElem condition testing
+        (
+            [3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45, 48],
+            [6, 15, 24, 33, 42],
+        ),
+        # A10: myFirst remains -1 leading to empty range creation
+        (
+            [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600],
+            [50, 150, 250],
+        ),
+        # A11: Last locale with eqOrGtElem > myHigh
+        ([1, 5, 9, 13, 17, 21, 25, 29, 33, 37, 41, 45, 49, 53, 57, 61], [35, 45, 55, 65, 75]),
+        # A12: First locale with all elements in x2 < myHigh
+        (
+            [50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200],
+            [10, 20, 30, 40, 45],
+        ),
+        # A13: Boundary search with leftCmp vs rightCmp differences
+        (
+            [2, 2, 2, 6, 6, 6, 10, 10, 10, 14, 14, 14, 18, 18, 18, 22],
+            [2, 6, 10, 14, 18],
+        ),
+        # A14: Stress test for boundary index calculations
+        (
+            [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31],
+            [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32],
+        ),
+        # A15: Complex ownership transfer scenarios
+        (
+            [5, 10, 10, 15, 20, 20, 25, 30, 30, 35, 40, 40, 45, 50, 50, 55],
+            [8, 10, 12, 18, 20, 22, 28, 30, 32, 38, 40, 42, 48, 50, 52],
+        ),
+        # Specialized cases
+        # S1: Exact boundary value equality for left side ownership
+        (
+            [1, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30],
+            [6, 14, 22],
+        ),
+        # S2: Exact boundary value equality for right side ownership
+        (
+            [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32],
+            [8, 16, 24],
+        ),
+        # S3: Binary search returns domain.high exactly
+        (
+            [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160],
+            [95, 105, 115, 125],
+        ),
+        # S4: Empty range handling with myFirst = -1
+        ([20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95], [5, 10, 15]),
+        # S5: gtElem <= myHigh && gtElem != eqOrGtElem condition
+        ([5, 5, 10, 10, 15, 15, 20, 20, 25, 25, 30, 30, 35, 35, 40, 40], [5, 10, 15, 20, 25]),
+        # S6: ltElem >= prevHigh && ltElem != eqOrLeElem condition
+        (
+            [3, 6, 6, 9, 9, 12, 12, 15, 15, 18, 18, 21, 21, 24, 24, 27],
+            [6, 9, 12, 15, 18, 21],
+        ),
+        # S7: eqOrLeMyHigh negative index scenario
+        (
+            [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600],
+            [50],
+        ),
+        # S8: All elements equal (extreme duplicate case)
+        ([5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5], [5, 5, 5, 5]),
+        # S9: Interleaved boundaries with first/last locale special cases
+        (
+            [1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150],
+            [0, 5, 35, 75, 125, 160],
+        ),
+        # S10: Maximum boundary stress test
+        (
+            [1, 1, 5, 5, 5, 10, 10, 15, 15, 15, 20, 20, 25, 25, 25, 30],
+            [1, 3, 5, 7, 10, 12, 15, 17, 20, 22, 25, 27, 30, 35],
+        ),
+        # Uneven blockDist distribution: x1 length 17
+        (
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17],
+            [1, 8, 16, 17],
+        ),
+    ]
+
     @pytest.mark.parametrize("dtype", [ak.float64, ak.int64, ak.uint64, ak.bigint])
     @pytest.mark.parametrize("side", ["left", "right"])
-    def test_searchsorted_fast_edge_cases(self, dtype, side):
-        # Test edge cases for searchsorted with fast path enabled
-        # This is when x2 is also sorted
-        # List of (x1, x2) edge case pairs
-        edge_cases = [
-            # Test case 1: basic case with small arrays
-            (
-                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-                [5, 8, 10, 12],
-            ),
-            # Test case 2: x2 element equals boundary values (left/right side differences)
-            (
-                [1, 2, 2, 2, 3, 4, 4, 4, 5, 6, 7, 8, 8, 9, 10, 11],
-                [2, 4, 8, 10],
-            ),
-            # Test case 4: All x2 elements smaller than x1[0] (all assigned to locale 0)
-            ([10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85], [1, 2, 3, 4, 5, 6, 7, 8]),
-            # Test case 5: All x2 elements larger than x1[last] (all assigned to last locale)
-            (
-                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-                [20, 25, 30, 35, 40, 45, 50, 55],
-            ),
-            # Test case 6: x2 elements exactly at locale boundary transitions
-            (
-                [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
-                [3, 4, 7, 8, 11, 12],
-            ),
-            # Test case 7: Duplicate values spanning multiple locales
-            (
-                [1, 1, 1, 1, 5, 5, 5, 5, 9, 9, 9, 9, 13, 13, 13, 13],
-                [1, 5, 9, 13],
-            ),
-            # Test case 8: x2 value equal to prevHigh and myLow (left side ownership test)
-            (
-                [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32],
-                [6, 8, 16, 20],
-            ),
-            # Test case 9: x2 value equal to myHigh and nextLow (right side ownership test)
-            (
-                [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31],
-                [7, 9, 11, 15, 19],
-            ),
-            # Test case 10: Mixed boundary conditions with left/right side differences
-            (
-                [0, 2, 2, 4, 4, 4, 6, 6, 8, 8, 8, 10, 12, 14, 16, 18],
-                [2, 4, 6, 8, 10, 12],
-            ),
-            # Test case 11: Binary search edge case - value not found, insertion point
-            (
-                [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31],
-                [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32],
-            ),
-            # Test case 12: Large duplicates that may create empty ranges
-            (
-                [1, 1, 1, 1, 1, 1, 10, 10, 10, 10, 10, 20, 20, 20, 20, 20],
-                [1, 5, 10, 15, 20, 25],
-            ),
-            # Test case 13: Arithmetic edge cases (potential overflow/underflow in mid calculation)
-            (
-                [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600],
-                [150, 350, 550, 750, 950, 1150, 1350, 1550],
-            ),
-            # Test case 14: First locale special case where myLow doesn't matter
-            (
-                [5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80],
-                [1, 2, 3, 12, 18, 22, 28, 35],
-            ),
-            # Test case 15: Last locale special case where myHigh doesn't matter
-            (
-                [1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75],
-                [38, 42, 47, 50, 55, 60, 70, 80],
-            ),
-            # Test case 16: Out of bounds binary search results
-            (
-                [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160],
-                [5, 15, 25, 95, 105, 125, 145, 165],
-            ),
-            # Test case 17: The specific case mentioned in the prompt
-            (
-                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-                [8, 12, 16, 16],
-            ),
-            # Test case 18: Sequential boundary values
-            (
-                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-                [3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
-            ),
-            # Test case 19: Empty ranges created by boundary logic
-            (
-                [1, 1, 1, 1, 10, 10, 10, 10, 20, 20, 20, 20, 30, 30, 30, 30],
-                [5, 15, 25, 35],
-            ),
-            # Test case 20: Maximum stress test with many duplicates
-            (
-                [1, 1, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, 5, 5],
-                [1, 2, 3, 4, 5, 6],
-            ),
-            # Algorithmic edge cases
-            # A1: eqOrGtMyLow == x2.domain.high condition for first locale
-            ([5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80], [45]),
-            # A2: eqOrGtMyLow out of bounds condition
-            (
-                [50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200],
-                [10, 20, 30, 40],
-            ),
-            # A3: gtMyLow out of bounds when searching for next value
-            (
-                [5, 5, 5, 10, 10, 10, 15, 15, 15, 20, 20, 20, 25, 25, 25, 30],
-                [10, 15, 20, 35],
-            ),
-            # A4: eqOrLeMyHigh out of bounds (negative index)
-            ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], [0]),
-            # A5: ltMyHigh out of bounds when searching for previous value
-            ([10, 10, 10, 20, 20, 20, 30, 30, 30, 40, 40, 40, 50, 50, 50, 60], [5, 10, 20, 30]),
-            # A6: Complex boundary value equality across multiple locales
-            ([1, 2, 3, 3, 3, 4, 5, 6, 6, 6, 7, 8, 9, 9, 9, 10], [3, 6, 9]),
-            # A7: Left vs Right side ownership with identical boundary values
-            (
-                [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32],
-                [8, 16, 24],
-            ),
-            # A8: gtElem == eqOrGtElem condition testing
-            (
-                [1, 1, 1, 5, 5, 5, 9, 9, 9, 13, 13, 13, 17, 17, 17, 21],
-                [1, 5, 9, 13, 17],
-            ),
-            # A9: ltElem == eqOrLeElem condition testing
-            (
-                [3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45, 48],
-                [6, 15, 24, 33, 42],
-            ),
-            # A10: myFirst remains -1 leading to empty range creation
-            (
-                [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600],
-                [50, 150, 250],
-            ),
-            # A11: Last locale with eqOrGtElem > myHigh
-            ([1, 5, 9, 13, 17, 21, 25, 29, 33, 37, 41, 45, 49, 53, 57, 61], [35, 45, 55, 65, 75]),
-            # A12: First locale with all elements in x2 < myHigh
-            (
-                [50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200],
-                [10, 20, 30, 40, 45],
-            ),
-            # A13: Boundary search with leftCmp vs rightCmp differences
-            (
-                [2, 2, 2, 6, 6, 6, 10, 10, 10, 14, 14, 14, 18, 18, 18, 22],
-                [2, 6, 10, 14, 18],
-            ),
-            # A14: Stress test for boundary index calculations
-            (
-                [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31],
-                [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32],
-            ),
-            # A15: Complex ownership transfer scenarios
-            (
-                [5, 10, 10, 15, 20, 20, 25, 30, 30, 35, 40, 40, 45, 50, 50, 55],
-                [8, 10, 12, 18, 20, 22, 28, 30, 32, 38, 40, 42, 48, 50, 52],
-            ),
-            # Specialized cases
-            # S1: Exact boundary value equality for left side ownership
-            (
-                [1, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30],
-                [6, 14, 22],
-            ),
-            # S2: Exact boundary value equality for right side ownership
-            (
-                [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32],
-                [8, 16, 24],
-            ),
-            # S3: Binary search returns domain.high exactly
-            (
-                [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160],
-                [95, 105, 115, 125],
-            ),
-            # S4: Empty range handling with myFirst = -1
-            ([20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95], [5, 10, 15]),
-            # S5: gtElem <= myHigh && gtElem != eqOrGtElem condition
-            ([5, 5, 10, 10, 15, 15, 20, 20, 25, 25, 30, 30, 35, 35, 40, 40], [5, 10, 15, 20, 25]),
-            # S6: ltElem >= prevHigh && ltElem != eqOrLeElem condition
-            (
-                [3, 6, 6, 9, 9, 12, 12, 15, 15, 18, 18, 21, 21, 24, 24, 27],
-                [6, 9, 12, 15, 18, 21],
-            ),
-            # S7: eqOrLeMyHigh negative index scenario
-            (
-                [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600],
-                [50],
-            ),
-            # S8: All elements equal (extreme duplicate case)
-            ([5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5], [5, 5, 5, 5]),
-            # S9: Interleaved boundaries with first/last locale special cases
-            (
-                [1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150],
-                [0, 5, 35, 75, 125, 160],
-            ),
-            # S10: Maximum boundary stress test
-            (
-                [1, 1, 5, 5, 5, 10, 10, 15, 15, 15, 20, 20, 25, 25, 25, 30],
-                [1, 3, 5, 7, 10, 12, 15, 17, 20, 22, 25, 27, 30, 35],
-            ),
-            # Uneven blockDist distribution: x1 length 17
-            (
-                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17],
-                [1, 8, 16, 17],
-            ),
-        ]
-        for x1, x2 in edge_cases:
-            ak_x1 = ak.array(x1, dtype=dtype)
-            ak_x2 = ak.array(x2, dtype=dtype)
-            if dtype == ak.bigint:
-                ak_x1 = ak_x1 + 2**200
-                ak_x2 = ak_x2 + 2**200
-            np_x1 = ak_x1.to_ndarray()
-            if isinstance(ak_x2, ak.pdarray):
-                np_x2 = ak_x2.to_ndarray()
-            else:
-                np_x2 = x2
-            np_output = np.searchsorted(np_x1, np_x2, side)
-            ak_output = ak.searchsorted(
-                ak_x1, ak_x2, side, x2_sorted=True
-            )  # x2_sorted=True for fast path
-            assert_arkouda_array_equivalent(ak_output, np_output)
+    @pytest.mark.parametrize("x1,x2", edge_cases_searchsorted_fast)
+    def test_searchsorted_fast_edge_cases(self, dtype, side, x1, x2):
+        ak_x1 = ak.array(x1, dtype=dtype)
+        ak_x2 = ak.array(x2, dtype=dtype)
+        if dtype == ak.bigint:
+            ak_x1 = ak_x1 + 2**200
+            ak_x2 = ak_x2 + 2**200
+        np_x1 = ak_x1.to_ndarray()
+        if isinstance(ak_x2, ak.pdarray):
+            np_x2 = ak_x2.to_ndarray()
+        else:
+            np_x2 = x2
+        np_output = np.searchsorted(np_x1, np_x2, side)
+        ak_output = ak.searchsorted(ak_x1, ak_x2, side, x2_sorted=True)  # x2_sorted=True for fast path
+        assert_arkouda_array_equivalent(ak_output, np_output)

--- a/tests/numpy/sort_test.py
+++ b/tests/numpy/sort_test.py
@@ -170,7 +170,7 @@ class TestSort:
         else:
             assert_arkouda_array_equivalent(ak_output, np_output)
 
-    @pytest.mark.parametrize("dtype", [ak.float64, ak.int64, ak.bigint, ak.uint64])
+    @pytest.mark.parametrize("dtype", [ak.float64, ak.int64, ak.uint64, ak.bigint])
     @pytest.mark.parametrize("side", ["left", "right"])
     def test_searchsorted_fast_edge_cases(self, dtype, side):
         # Test edge cases for searchsorted with fast path enabled
@@ -290,11 +290,17 @@ class TestSort:
             ([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17], [1,8,16,17]),
         ]
         for x1, x2 in edge_cases:
-            np_x1 = np.array(x1, dtype=dtype)
-            np_x2 = np.array(x2, dtype=dtype)
-            ak_x1 = ak.array(np_x1)
-            ak_x2 = ak.array(np_x2)
+            ak_x1 = ak.array(x1, dtype=dtype)
+            ak_x2 = ak.array(x2, dtype=dtype)
+            if dtype == ak.bigint:
+                ak_x1 = ak_x1 + 2**200
+                ak_x2 = ak_x2 + 2**200
+            np_x1 = ak_x1.to_ndarray()
+            if isinstance(ak_x2, ak.pdarray):
+                np_x2 = ak_x2.to_ndarray()
+            else:
+                np_x2 = x2
             np_output = np.searchsorted(np_x1, np_x2, side)
-            ak_output = ak.searchsorted(ak_x1, ak_x2, side, x2_sorted=True)
+            ak_output = ak.searchsorted(ak_x1, ak_x2, side, x2_sorted=True) # x2_sorted=True for fast path
             assert_arkouda_array_equivalent(ak_output, np_output)
 

--- a/tests/numpy/sort_test.py
+++ b/tests/numpy/sort_test.py
@@ -29,7 +29,10 @@ class TestSort:
 
         from arkouda.numpy import sorting
 
-        result = doctest.testmod(sorting, optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)
+        result = doctest.testmod(
+            sorting,
+            optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE,
+        )
         assert result.failed == 0, f"Doctest failed: {result.failed} failures"
 
     @pytest.mark.parametrize("size", pytest.prob_size)
@@ -128,7 +131,11 @@ class TestSort:
         neg_arr = np.array([-3.14, np.inf, np.nan, -np.inf, 3.14, 0.0, 3.14, -8])
         pos_arr = np.array([3.14, np.inf, np.nan, np.inf, 7.7, 0.0, 3.14, 8])
         for npa in neg_arr, pos_arr:
-            assert np.allclose(np.sort(npa), ak.sort(ak.array(npa), algo).to_ndarray(), equal_nan=True)
+            assert np.allclose(
+                np.sort(npa),
+                ak.sort(ak.array(npa), algo).to_ndarray(),
+                equal_nan=True,
+            )
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", [ak.float64, ak.int64, ak.bigint, ak.uint64])
@@ -153,7 +160,13 @@ class TestSort:
             if len(v_shape) not in get_array_ranks():
                 pytest.skip(f"Server not compiled for rank {len(v_shape)}")
             else:
-                v = ak.randint(low=low, high=high, size=v_shape, dtype=dtype_, seed=pytest.seed)
+                v = ak.randint(
+                    low=low,
+                    high=high,
+                    size=v_shape,
+                    dtype=dtype_,
+                    seed=pytest.seed,
+                )
                 v = ak.array(v, dtype) + shift
         a = ak.randint(low=low, high=high, size=size, dtype=dtype_, seed=pytest.seed)
         a = ak.sort(a)
@@ -178,69 +191,110 @@ class TestSort:
         # List of (x1, x2) edge case pairs
         edge_cases = [
             # Test case 1: basic case with small arrays
-            ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], [5, 8, 10, 12]),
-
+            (
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+                [5, 8, 10, 12],
+            ),
             # Test case 2: x2 element equals boundary values (left/right side differences)
-            ([1, 2, 2, 2, 3, 4, 4, 4, 5, 6, 7, 8, 8, 9, 10, 11], [2, 4, 8, 10]),
-
+            (
+                [1, 2, 2, 2, 3, 4, 4, 4, 5, 6, 7, 8, 8, 9, 10, 11],
+                [2, 4, 8, 10],
+            ),
             # Test case 4: All x2 elements smaller than x1[0] (all assigned to locale 0)
             ([10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85], [1, 2, 3, 4, 5, 6, 7, 8]),
-
             # Test case 5: All x2 elements larger than x1[last] (all assigned to last locale)
-            ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], [20, 25, 30, 35, 40, 45, 50, 55]),
-
+            (
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+                [20, 25, 30, 35, 40, 45, 50, 55],
+            ),
             # Test case 6: x2 elements exactly at locale boundary transitions
-            ([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], [3, 4, 7, 8, 11, 12]),
-
+            (
+                [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+                [3, 4, 7, 8, 11, 12],
+            ),
             # Test case 7: Duplicate values spanning multiple locales
-            ([1, 1, 1, 1, 5, 5, 5, 5, 9, 9, 9, 9, 13, 13, 13, 13], [1, 5, 9, 13]),
-
+            (
+                [1, 1, 1, 1, 5, 5, 5, 5, 9, 9, 9, 9, 13, 13, 13, 13],
+                [1, 5, 9, 13],
+            ),
             # Test case 8: x2 value equal to prevHigh and myLow (left side ownership test)
-            ([2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32], [6, 8, 16, 20]),
-
+            (
+                [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32],
+                [6, 8, 16, 20],
+            ),
             # Test case 9: x2 value equal to myHigh and nextLow (right side ownership test)
-            ([1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31], [7, 9, 11, 15, 19]),
-
+            (
+                [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31],
+                [7, 9, 11, 15, 19],
+            ),
             # Test case 10: Mixed boundary conditions with left/right side differences
-            ([0, 2, 2, 4, 4, 4, 6, 6, 8, 8, 8, 10, 12, 14, 16, 18], [2, 4, 6, 8, 10, 12]),
-
+            (
+                [0, 2, 2, 4, 4, 4, 6, 6, 8, 8, 8, 10, 12, 14, 16, 18],
+                [2, 4, 6, 8, 10, 12],
+            ),
             # Test case 11: Binary search edge case - value not found, insertion point
-            ([1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31], [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32]),
-
+            (
+                [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31],
+                [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32],
+            ),
             # Test case 12: Large duplicates that may create empty ranges
-            ([1, 1, 1, 1, 1, 1, 10, 10, 10, 10, 10, 20, 20, 20, 20, 20], [1, 5, 10, 15, 20, 25]),
-
+            (
+                [1, 1, 1, 1, 1, 1, 10, 10, 10, 10, 10, 20, 20, 20, 20, 20],
+                [1, 5, 10, 15, 20, 25],
+            ),
             # Test case 13: Arithmetic edge cases (potential overflow/underflow in mid calculation)
-            ([100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600], [150, 350, 550, 750, 950, 1150, 1350, 1550]),
-
+            (
+                [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600],
+                [150, 350, 550, 750, 950, 1150, 1350, 1550],
+            ),
             # Test case 14: First locale special case where myLow doesn't matter
-            ([5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80], [1, 2, 3, 12, 18, 22, 28, 35]),
-
+            (
+                [5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80],
+                [1, 2, 3, 12, 18, 22, 28, 35],
+            ),
             # Test case 15: Last locale special case where myHigh doesn't matter
-            ([1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75], [38, 42, 47, 50, 55, 60, 70, 80]),
-
+            (
+                [1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75],
+                [38, 42, 47, 50, 55, 60, 70, 80],
+            ),
             # Test case 16: Out of bounds binary search results
-            ([10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160], [5, 15, 25, 95, 105, 125, 145, 165]),
-
+            (
+                [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160],
+                [5, 15, 25, 95, 105, 125, 145, 165],
+            ),
             # Test case 17: The specific case mentioned in the prompt
-            ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], [8, 12, 16, 16]),
-
+            (
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+                [8, 12, 16, 16],
+            ),
             # Test case 18: Sequential boundary values
-            ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], [3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
-
+            (
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+                [3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+            ),
             # Test case 19: Empty ranges created by boundary logic
-            ([1, 1, 1, 1, 10, 10, 10, 10, 20, 20, 20, 20, 30, 30, 30, 30], [5, 15, 25, 35]),
-
+            (
+                [1, 1, 1, 1, 10, 10, 10, 10, 20, 20, 20, 20, 30, 30, 30, 30],
+                [5, 15, 25, 35],
+            ),
             # Test case 20: Maximum stress test with many duplicates
-            ([1, 1, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, 5, 5], [1, 2, 3, 4, 5, 6]),
-
+            (
+                [1, 1, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, 5, 5],
+                [1, 2, 3, 4, 5, 6],
+            ),
             # Algorithmic edge cases
             # A1: eqOrGtMyLow == x2.domain.high condition for first locale
             ([5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80], [45]),
             # A2: eqOrGtMyLow out of bounds condition
-            ([50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200], [10, 20, 30, 40]),
+            (
+                [50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200],
+                [10, 20, 30, 40],
+            ),
             # A3: gtMyLow out of bounds when searching for next value
-            ([5, 5, 5, 10, 10, 10, 15, 15, 15, 20, 20, 20, 25, 25, 25, 30], [10, 15, 20, 35]),
+            (
+                [5, 5, 5, 10, 10, 10, 15, 15, 15, 20, 20, 20, 25, 25, 25, 30],
+                [10, 15, 20, 35],
+            ),
             # A4: eqOrLeMyHigh out of bounds (negative index)
             ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], [0]),
             # A5: ltMyHigh out of bounds when searching for previous value
@@ -248,46 +302,94 @@ class TestSort:
             # A6: Complex boundary value equality across multiple locales
             ([1, 2, 3, 3, 3, 4, 5, 6, 6, 6, 7, 8, 9, 9, 9, 10], [3, 6, 9]),
             # A7: Left vs Right side ownership with identical boundary values
-            ([2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32], [8, 16, 24]),
+            (
+                [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32],
+                [8, 16, 24],
+            ),
             # A8: gtElem == eqOrGtElem condition testing
-            ([1, 1, 1, 5, 5, 5, 9, 9, 9, 13, 13, 13, 17, 17, 17, 21], [1, 5, 9, 13, 17]),
+            (
+                [1, 1, 1, 5, 5, 5, 9, 9, 9, 13, 13, 13, 17, 17, 17, 21],
+                [1, 5, 9, 13, 17],
+            ),
             # A9: ltElem == eqOrLeElem condition testing
-            ([3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45, 48], [6, 15, 24, 33, 42]),
+            (
+                [3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45, 48],
+                [6, 15, 24, 33, 42],
+            ),
             # A10: myFirst remains -1 leading to empty range creation
-            ([100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600], [50, 150, 250]),
+            (
+                [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600],
+                [50, 150, 250],
+            ),
             # A11: Last locale with eqOrGtElem > myHigh
             ([1, 5, 9, 13, 17, 21, 25, 29, 33, 37, 41, 45, 49, 53, 57, 61], [35, 45, 55, 65, 75]),
             # A12: First locale with all elements in x2 < myHigh
-            ([50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200], [10, 20, 30, 40, 45]),
+            (
+                [50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200],
+                [10, 20, 30, 40, 45],
+            ),
             # A13: Boundary search with leftCmp vs rightCmp differences
-            ([2, 2, 2, 6, 6, 6, 10, 10, 10, 14, 14, 14, 18, 18, 18, 22], [2, 6, 10, 14, 18]),
+            (
+                [2, 2, 2, 6, 6, 6, 10, 10, 10, 14, 14, 14, 18, 18, 18, 22],
+                [2, 6, 10, 14, 18],
+            ),
             # A14: Stress test for boundary index calculations
-            ([1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31], [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32]),
+            (
+                [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31],
+                [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32],
+            ),
             # A15: Complex ownership transfer scenarios
-            ([5, 10, 10, 15, 20, 20, 25, 30, 30, 35, 40, 40, 45, 50, 50, 55], [8, 10, 12, 18, 20, 22, 28, 30, 32, 38, 40, 42, 48, 50, 52]),
+            (
+                [5, 10, 10, 15, 20, 20, 25, 30, 30, 35, 40, 40, 45, 50, 50, 55],
+                [8, 10, 12, 18, 20, 22, 28, 30, 32, 38, 40, 42, 48, 50, 52],
+            ),
             # Specialized cases
             # S1: Exact boundary value equality for left side ownership
-            ([1, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30], [6, 14, 22]),
+            (
+                [1, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30],
+                [6, 14, 22],
+            ),
             # S2: Exact boundary value equality for right side ownership
-            ([2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32], [8, 16, 24]),
+            (
+                [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32],
+                [8, 16, 24],
+            ),
             # S3: Binary search returns domain.high exactly
-            ([10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160], [95, 105, 115, 125]),
+            (
+                [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160],
+                [95, 105, 115, 125],
+            ),
             # S4: Empty range handling with myFirst = -1
             ([20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95], [5, 10, 15]),
             # S5: gtElem <= myHigh && gtElem != eqOrGtElem condition
             ([5, 5, 10, 10, 15, 15, 20, 20, 25, 25, 30, 30, 35, 35, 40, 40], [5, 10, 15, 20, 25]),
             # S6: ltElem >= prevHigh && ltElem != eqOrLeElem condition
-            ([3, 6, 6, 9, 9, 12, 12, 15, 15, 18, 18, 21, 21, 24, 24, 27], [6, 9, 12, 15, 18, 21]),
+            (
+                [3, 6, 6, 9, 9, 12, 12, 15, 15, 18, 18, 21, 21, 24, 24, 27],
+                [6, 9, 12, 15, 18, 21],
+            ),
             # S7: eqOrLeMyHigh negative index scenario
-            ([100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600], [50]),
+            (
+                [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600],
+                [50],
+            ),
             # S8: All elements equal (extreme duplicate case)
             ([5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5], [5, 5, 5, 5]),
             # S9: Interleaved boundaries with first/last locale special cases
-            ([1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150], [0, 5, 35, 75, 125, 160]),
+            (
+                [1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150],
+                [0, 5, 35, 75, 125, 160],
+            ),
             # S10: Maximum boundary stress test
-            ([1, 1, 5, 5, 5, 10, 10, 15, 15, 15, 20, 20, 25, 25, 25, 30], [1, 3, 5, 7, 10, 12, 15, 17, 20, 22, 25, 27, 30, 35]),
+            (
+                [1, 1, 5, 5, 5, 10, 10, 15, 15, 15, 20, 20, 25, 25, 25, 30],
+                [1, 3, 5, 7, 10, 12, 15, 17, 20, 22, 25, 27, 30, 35],
+            ),
             # Uneven blockDist distribution: x1 length 17
-            ([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17], [1,8,16,17]),
+            (
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17],
+                [1, 8, 16, 17],
+            ),
         ]
         for x1, x2 in edge_cases:
             ak_x1 = ak.array(x1, dtype=dtype)
@@ -301,6 +403,7 @@ class TestSort:
             else:
                 np_x2 = x2
             np_output = np.searchsorted(np_x1, np_x2, side)
-            ak_output = ak.searchsorted(ak_x1, ak_x2, side, x2_sorted=True) # x2_sorted=True for fast path
+            ak_output = ak.searchsorted(
+                ak_x1, ak_x2, side, x2_sorted=True
+            )  # x2_sorted=True for fast path
             assert_arkouda_array_equivalent(ak_output, np_output)
-


### PR DESCRIPTION
This adds a new implementation for searchsorted that performs much better in the distributed case.
Currently it only kicks in when `x2` is also sorted.

This demonstrates much better weak scaling than the older implementation