### PR TITLE
Closes #4659:  add skip_doctest option to tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -772,8 +772,9 @@ print-%:
 	$(info $($*)) @trues
 
 size=100
+skip_doctest="False"
 test-python:
-	python3 -m pytest -c pytest.ini --size=$(size) $(ARKOUDA_PYTEST_OPTIONS)
+	python3 -m pytest -c pytest.ini --size=$(size) $(ARKOUDA_PYTEST_OPTIONS) --skip_doctest=$(skip_doctest)
 	python3 -m pytest -c pytest.opts.ini --size=$(size) $(ARKOUDA_PYTEST_OPTIONS)
 
 CLEAN_TARGETS += test-clean

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,13 @@ def pytest_addoption(parser):
         help="Directory to store temporary files.",
     )
 
+    parser.addoption(
+        "--skip_doctest",
+        action="store",
+        default="False",
+        help="Set to True to skip doctest-related tests",
+    )
+
 
 def pytest_collection_modifyitems(config, items):
     if config.getoption("--optional-parquet"):
@@ -66,6 +73,12 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "optional_parquet" in item.keywords:
             item.add_marker(skip_parquet)
+
+    if config.getoption("--skip_doctest").lower() == "true":
+        skip_marker = pytest.mark.skip(reason="skipped due to --skip_doctest")
+        for item in items:
+            if "docstrings" in item.name.lower():
+                item.add_marker(skip_marker)
 
 
 def _get_test_locales(config):


### PR DESCRIPTION
Adds a `skip_doctest` option to the unit tests.  When `True` the `doctest` unit tests will be skipped.  The default is `False`.  To run, use `make test skip_doctest=True` or `python3 -m pytest -c pytest.ini --size=100  --skip_doctest=True`.

Closes #4659:  add skip_doctest option to tests