### PR TITLE
Closes #3574:  Update reduce_benchmark

### DIFF
--- a/benchmark_v2/reduce_benchmark.py
+++ b/benchmark_v2/reduce_benchmark.py
@@ -7,61 +7,51 @@ OPS = ("sum", "prod", "min", "max")
 TYPES = ("int64", "float64")
 
 
-@pytest.mark.skip_correctness_only(True)
-@pytest.mark.benchmark(group="Arkouda_Reduce")
+@pytest.mark.benchmark(group="Reduce")
 @pytest.mark.parametrize("op", OPS)
 @pytest.mark.parametrize("dtype", TYPES)
 def bench_reduce(benchmark, op, dtype):
-    if dtype in pytest.dtype:
-        cfg = ak.get_config()
-        N = pytest.prob_size * cfg["numLocales"]
-        if pytest.random or pytest.seed is not None:
-            if dtype == "int64":
-                a = ak.randint(1, N, N, seed=pytest.seed)
-            elif dtype == "float64":
-                a = ak.uniform(N, seed=pytest.seed) + 0.5
-        else:
-            a = ak.arange(1, N, 1)
-            if dtype == "float64":
-                a = 1.0 * a
+    if dtype not in pytest.dtype:
+        pytest.skip(f"{dtype} not in selected dtypes")
 
+    cfg = ak.get_config()
+    N = 10**4 if pytest.correctness_only else pytest.prob_size * cfg["numLocales"]
+
+    # Create test array
+    if pytest.random or pytest.seed is not None:
+        if dtype == "int64":
+            a = ak.randint(1, N, N, seed=pytest.seed)
+        elif dtype == "float64":
+            a = ak.uniform(N, seed=pytest.seed) + 0.5
+    else:
+        a = ak.arange(1, N, 1)
+        if dtype == "float64":
+            a = 1.0 * a
+
+    # Choose backend
+    if pytest.numpy:
+        a_np = a.to_ndarray()
+        fxn = getattr(a_np, op)
+        backend = "NumPy"
+    else:
         fxn = getattr(a, op)
-        benchmark.pedantic(fxn, rounds=pytest.trials)
+        backend = "Arkouda"
 
-        nbytes = a.size * a.itemsize
-        benchmark.extra_info["description"] = "Measures performance of ak reduce functions."
-        benchmark.extra_info["problem_size"] = pytest.prob_size
-        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-            (nbytes / benchmark.stats["mean"]) / 2**30
-        )
+    def run():
+        result = fxn()
+        if pytest.correctness_only:
+            expected = getattr(a.to_ndarray(), op)()
+            if op == "prod":
+                np.testing.assert_allclose(result, expected, rtol=1e-10)
+            else:
+                assert result == expected
+        return a.size * a.itemsize
 
+    bytes_processed = benchmark.pedantic(run, rounds=pytest.trials)
 
-@pytest.mark.skip_correctness_only(True)
-@pytest.mark.benchmark(group="Numpy_Reduce")
-@pytest.mark.parametrize("op", OPS)
-@pytest.mark.parametrize("dtype", TYPES)
-def bench_np_reduce(benchmark, op, dtype):
-    if pytest.numpy and dtype in pytest.dtype:
-        N = pytest.prob_size
-        if pytest.seed is not None:
-            np.random.seed(pytest.seed)
-
-        if pytest.random or pytest.seed is not None:
-            if dtype == "int64":
-                a = np.random.randint(1, N, N)
-            elif dtype == "float64":
-                a = np.random.random(N) + 0.5
-        else:
-            a = np.arange(1, N, 1, dtype=dtype)
-
-        fxn = getattr(a, op)
-        benchmark.pedantic(fxn, rounds=pytest.trials)
-
-        nbytes = a.size * a.itemsize
-        benchmark.extra_info["description"] = (
-            "Measures performance of numpy reduce functions for comparison"
-        )
-        benchmark.extra_info["problem_size"] = pytest.prob_size
-        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-            (nbytes / benchmark.stats["mean"]) / 2**30
-        )
+    benchmark.extra_info["description"] = f"Reduce: {op} ({backend})"
+    benchmark.extra_info["problem_size"] = N
+    benchmark.extra_info["backend"] = backend
+    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
+        (bytes_processed / benchmark.stats["mean"]) / 2**30
+    )


### PR DESCRIPTION
## PR: Refactor `reduce_benchmark.py` to Support --numpy and --correctness_only

This PR updates the `reduce_benchmark.py` module to align with Arkouda's standardized benchmarking framework.

### ✅ Key Enhancements

- **`--numpy` support**
  - Benchmarks are executed using NumPy when `--numpy` is passed
  - Uses `.to_ndarray()` and NumPy reduction methods

- **`--correctness_only` validation**
  - Compares Arkouda results to NumPy equivalents
  - Ensures correctness across all operations

- **Unified Test Logic**
  - Combines all backends into a single parameterized benchmark
  - Uses `benchmark.pedantic` for consistent trial-based timing

- **Benchmark Metadata**
  - Annotates output with problem size, backend name, and transfer rate

### 🧪 Coverage

- Operations: `sum`, `prod`, `min`, `max`
- Dtypes: `int64`, `float64`

This ensures reproducible performance tracking with correctness validation for key reduction operations.



Closes #3574:  Update reduce_benchmark