### PR TITLE
Increase unit test timeout to 30 minutes

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
-#   Set the timeout to 15 minutes:
-timeout = 900
+#   Set the timeout to 30 minutes:
+timeout = 1800
 #   Set timeout_method to 'signal' on Unix
 timeout_method = thread  
 


### PR DESCRIPTION
Increases unit test timeout to 30 minutes to avoid timeouts on HPE's Apollo.