### PR TITLE
Closes #4675:  update bigint_conversion benchmark

### DIFF
--- a/benchmark_v2/bigint_conversion_benchmark.py
+++ b/benchmark_v2/bigint_conversion_benchmark.py
@@ -4,50 +4,40 @@ import arkouda as ak
 
 
 @pytest.mark.skip_correctness_only(True)
+@pytest.mark.skip_numpy(True)
 @pytest.mark.benchmark(group="BigInt_Conversion")
-def bench_to_bigint(benchmark):
+@pytest.mark.parametrize("direction", ["to_bigint", "from_bigint"])
+def bench_bigint_conversion(benchmark, direction):
     cfg = ak.get_config()
     N = pytest.prob_size * cfg["numLocales"]
+    max_bits = pytest.max_bits
 
     a = ak.randint(0, 2**32, N, dtype=ak.uint64, seed=pytest.seed)
     b = ak.randint(0, 2**32, N, dtype=ak.uint64, seed=pytest.seed)
+    tot_bytes = N * 8 if (0 < max_bits <= 64) else N * 16
 
-    # bytes per bigint array (N * 16) since it's made of 2 uint64 arrays
-    # if max_bits in [0, 64] then they're essentially 1 uint64 array
-    tot_bytes = N * 8 if pytest.max_bits != -1 and pytest.max_bits <= 64 else N * 8 * 2
+    if direction == "to_bigint":
 
-    benchmark.pedantic(
-        ak.bigint_from_uint_arrays,
-        args=[[a, b]],
-        kwargs={"max_bits": pytest.max_bits},
-        rounds=pytest.trials,
-    )
-    benchmark.extra_info["description"] = "Measures the performance of ak.bigint_from_uint_arrays"
-    benchmark.extra_info["problem_size"] = pytest.prob_size
+        def run():
+            ak.bigint_from_uint_arrays([a, b], max_bits=max_bits)
+            return tot_bytes
+
+        label = "bigint_from_uint_arrays"
+    else:
+        ba = ak.bigint_from_uint_arrays([a, b], max_bits=max_bits)
+
+        def run():
+            ba.bigint_to_uint_arrays()
+            return tot_bytes
+
+        label = "bigint_to_uint_arrays"
+
+    bytes_processed = benchmark.pedantic(run, rounds=pytest.trials)
+
+    benchmark.extra_info["description"] = f"Measures performance of {label} with max_bits={max_bits}"
+    benchmark.extra_info["problem_size"] = N
+    benchmark.extra_info["backend"] = "Arkouda"
+    benchmark.extra_info["max_bits"] = max_bits
     benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-        (tot_bytes / benchmark.stats["mean"]) / 2**30
+        (bytes_processed / benchmark.stats["mean"]) / 2**30
     )
-    benchmark.extra_info["max_bits"] = pytest.max_bits
-
-
-@pytest.mark.skip_correctness_only(True)
-@pytest.mark.benchmark(group="BigInt_Conversion")
-def bench_from_bigint(benchmark):
-    cfg = ak.get_config()
-    N = pytest.prob_size * cfg["numLocales"]
-
-    # bytes per bigint array (N * 16) since it's made of 2 uint64 arrays
-    # if max_bits in [0, 64] then they're essentially 1 uint64 array
-    tot_bytes = N * 8 if pytest.max_bits != -1 and pytest.max_bits <= 64 else N * 8 * 2
-
-    a = ak.randint(0, 2**32, N, dtype=ak.uint64, seed=pytest.seed)
-    b = ak.randint(0, 2**32, N, dtype=ak.uint64, seed=pytest.seed)
-    ba = ak.bigint_from_uint_arrays([a, b], max_bits=pytest.max_bits)
-
-    benchmark.pedantic(ba.bigint_to_uint_arrays, rounds=pytest.trials)
-    benchmark.extra_info["description"] = "Measures the performance of bigint_to_uint_arrays"
-    benchmark.extra_info["problem_size"] = pytest.prob_size
-    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-        (tot_bytes / benchmark.stats["mean"]) / 2**30
-    )
-    benchmark.extra_info["max_bits"] = pytest.max_bits


### PR DESCRIPTION
## PR: Refactor `bigint_conversion_benchmark.py` to Unified Format

This PR consolidates the bigint conversion benchmarks into a single parameterized function that supports consistent benchmarking and metadata collection.

### ✅ Key Changes

- **Single Benchmark Function**
  - Parameterized by `direction` = `to_bigint` or `from_bigint`
- **Pedantic Timing**
  - Uses `benchmark.pedantic(...)` with Arkouda-standard `--trials`
- **Data Transfer Accounting**
  - Computes bytes based on `max_bits` (1 or 2 uint64s per bigint)
- **Benchmark Metadata**
  - Describes the benchmarked operation and includes transfer rate in GiB/sec
- **Auto-Skip**
  - Skips when `--numpy` or `--correctness_only` are set

This makes the benchmark easier to maintain and more consistent with other performance tests in the suite.




Closes #4675:  update bigint_conversion benchmark