### PR TITLE
Temporarily don't timeout pytest for debugging

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,8 @@
 [pytest]
 #   Set the timeout to 30 minutes:
-timeout = 1800
+#timeout = 1800
 #   Set timeout_method to 'signal' on Unix
-timeout_method = thread  
+#timeout_method = thread  
 
 filterwarnings =
     ignore:Version mismatch between client .*


### PR DESCRIPTION
Temporarily remove pytest timeout to help debug hanging tests on the HPE systems.