### PR TITLE
Closes 4657 aligns linspace and logspace to numpy

### DIFF
--- a/arkouda/__init__.py
+++ b/arkouda/__init__.py
@@ -222,6 +222,7 @@ from arkouda.numpy import (
     issubdtype,
     lib,
     linspace,
+    logspace,
     log,
     log10,
     log1p,

--- a/arkouda/numpy/__init__.py
+++ b/arkouda/numpy/__init__.py
@@ -259,6 +259,7 @@ from arkouda.numpy.pdarraycreation import (
     full,
     full_like,
     linspace,
+    logspace,
     ones,
     ones_like,
     promote_to_common_dtype,

--- a/arkouda/numpy/pdarrayclass.py
+++ b/arkouda/numpy/pdarrayclass.py
@@ -558,9 +558,9 @@ class pdarray:
 
     def __del__(self):
         try:
+            logger.debug(f"deleting pdarray with name {self.name}")
             from arkouda.client import generic_msg
 
-            logger.debug(f"deleting pdarray with name {self.name}")
             generic_msg(cmd="delete", args={"name": self.name})
         except (RuntimeError, AttributeError):
             pass

--- a/arkouda/numpy/pdarraycreation.py
+++ b/arkouda/numpy/pdarraycreation.py
@@ -35,7 +35,12 @@ from arkouda.numpy.dtypes import (
     str_,
 )
 from arkouda.numpy.dtypes import uint64 as akuint64
-from arkouda.numpy.pdarrayclass import create_pdarray, pdarray
+from arkouda.numpy.pdarrayclass import (
+    _axis_validation,
+    broadcast_to_shape,
+    create_pdarray,
+    pdarray,
+)
 from arkouda.numpy.strings import Strings
 
 if TYPE_CHECKING:
@@ -54,6 +59,7 @@ __all__ = [
     "full_like",
     "arange",
     "linspace",
+    "logspace",
     "randint",
     "uniform",
     "standard_normal",
@@ -1108,58 +1114,239 @@ def arange(
 
 
 @typechecked
-def linspace(start: numeric_scalars, stop: numeric_scalars, length: int_scalars) -> pdarray:
+def logspace(
+    start: Union[numeric_scalars, pdarray],
+    stop: Union[numeric_scalars, pdarray],
+    num: int_scalars = 50,
+    base: numeric_scalars = 10.0,
+    endpoint: Union[None, bool] = True,
+    dtype: Union[None, float64] = None,
+    axis: Union[None, int_scalars] = 0,
+) -> pdarray:
     """
-    Create a pdarray of linearly-spaced floats in a closed interval.
+    Create a pdarray of numbers evenly spaced on a log scale.
 
     Parameters
     ----------
-    start : numeric_scalars
-        Start of interval (inclusive)
-    stop : numeric_scalars
-        End of interval (inclusive)
-    length : int_scalars
-        Number of points
+    start : Union[float_scalars, pdarray]
+        The starting value of the sequence.
+    stop : Union[float_scalars, pdarray]
+        The end value of the sequence, unless `endpoint` is set to False.
+        In that case, the sequence consists of all but the last of ``num + 1``
+        evenly spaced samples, so that `stop` is excluded.  Note that the step
+        size changes when `endpoint` is False.
+    num : int, optional
+        Number of samples to generate. Default is 50. Must be non-negative.
+    base : numeric_scalars, optional
+        the base of the log space, defaults to 10.0.
+    endpoint : bool, optional
+    dtype : Union[None, float64]
+        allowed for compatibility with numpy, but ignored.  Outputs are always float
+    axis : int, optional
+        The axis in the result to store the samples.  Relevant only if start
+        or stop are array-like.  By default (0), the samples will be along a
+        new axis inserted at the beginning. Use -1 to get an axis at the end.
 
     Returns
     -------
     pdarray
-        Array of evenly spaced float values along the interval
+        There are `num` equally spaced (logarithmically) samples in the closed interval
+        base**``[start, stop]`` or the half-open interval base**``[start, stop)``
+        (depending on whether `endpoint` is True or False).
 
     Raises
     ------
     TypeError
-        Raised if start or stop is not a float or int or if length is not an int
+        Raised if start or stop is not a float or a pdarray, or if num
+        is not an int, or if endpoint is not a bool, or if dtype is anything
+        other than None or float64, or axis is not an integer.
+    ValueError
+        Raised if axis is not a valid axis for the given data.
 
     See Also
     --------
-    arange
+    linspace
 
     Notes
     -----
-    If that start is greater than stop, the pdarray values are generated
+    If start is greater than stop, the pdarray values are generated
     in descending order.
 
     Examples
     --------
     >>> import arkouda as ak
-    >>> ak.linspace(0, 1, 5)
-    array([0.00000000000000000 0.25 0.5 0.75 1.00000000000000000])
-
-    >>> ak.linspace(start=1, stop=0, length=5)
-    array([1.00000000000000000 0.75 0.5 0.25 0.00000000000000000])
-
-    >>> ak.linspace(start=-5, stop=0, length=5)
-    array([-5.00000000000000000 -3.75 -2.5 -1.25 0.00000000000000000])
+    >>> ak.logspace(2,3,3,4)
+    array([16.00000000000000000 32.00000000000000000 64.00000000000000000])
+    >>> ak.logspace(2,3,3,4,endpoint=False)
+    array([16.00000000000000000 25.398416831491197 40.317473596635935])
+    >>> ak.logspace(0,1,3,4)
+    array([1.00000000000000000 2.00000000000000000 4.00000000000000000])
+    >>> ak.logspace(1,0,3,4)
+    array([4.00000000000000000 2.00000000000000000 1.00000000000000000])
+    >>> ak.logspace(0,1,3,endpoint=False)
+    array([1.00000000000000000 2.1544346900318838 4.6415888336127784])
+    >>> ak.logspace(0,ak.array([2,3]),3,base=2)
+    array([array([1.00000000000000000 1.00000000000000000])
+        array([2.00000000000000000 2.8284271247461903])
+        array([4.00000000000000000 8.00000000000000000])])
+    >>> ak.logspace(ak.array([0,1]),3,3,base=3)
+    array([array([1.00000000000000000 3.00000000000000000])
+        array([5.196152422706632 9.00000000000000000])
+        array([27.00000000000000000 27.00000000000000000])])
+    >>> ak.logspace(ak.array([0,1]),ak.array([2,3]),3,base=4)
+    array([array([1.00000000000000000 4.00000000000000000])
+        array([4.00000000000000000 16.00000000000000000])
+        array([16.00000000000000000 64.00000000000000000])])
     """
-    from arkouda.client import generic_msg
 
-    if not isSupportedNumber(start) or not isSupportedNumber(stop):
-        raise TypeError("both start and stop must be an int, np.int64, float, or np.float64")
-    if not isSupportedNumber(length):
-        raise TypeError("length must be an int or int64")
-    repMsg = generic_msg(cmd="linspace", args={"start": start, "stop": stop, "len": length})
-    return create_pdarray(repMsg)
+    return base ** linspace(start, stop, num, endpoint=endpoint, dtype=None, axis=axis)
+
+
+@typechecked
+def linspace(
+    start: Union[numeric_scalars, pdarray],
+    stop: Union[numeric_scalars, pdarray],
+    num: int_scalars = 50,
+    endpoint: Union[None, bool] = True,
+    dtype: Union[None, float64] = None,
+    axis: Union[None, int_scalars] = 0,
+) -> pdarray:
+    """
+    Return evenly spaced numbers over a specified interval.
+
+    Returns `num` evenly spaced samples, calculated over the
+    interval [`start`, `stop`].
+
+    The endpoint of the interval can optionally be excluded.
+
+    Parameters
+    ----------
+    start : Union[float_scalars, pdarray]
+        The starting value of the sequence.
+    stop : Union[float_scalars, pdarray]
+        The end value of the sequence, unless `endpoint` is set to False.
+        In that case, the sequence consists of all but the last of ``num + 1``
+        evenly spaced samples, so that `stop` is excluded.  Note that the step
+        size changes when `endpoint` is False.
+    num : int, optional
+        Number of samples to generate. Default is 50. Must be non-negative.
+    endpoint : bool, optional
+        If True, `stop` is the last sample. Otherwise, it is not included.
+        Default is True.
+    dtype : dtype, optional
+        Allowed for compatibility with numpy linspace, but anything entered
+        is ignored.  The output is always ak.float64.
+    axis : int, optional
+        The axis in the result to store the samples.  Relevant only if start
+        or stop are array-like.  By default (0), the samples will be along a
+        new axis inserted at the beginning. Use -1 to get an axis at the end.
+
+    Returns
+    -------
+    pdarray
+        There are `num` equally spaced samples in the closed interval
+        ``[start, stop]`` or the half-open interval ``[start, stop)``
+        (depending on whether `endpoint` is True or False).
+
+    Raises
+    ------
+    TypeError
+        Raised if start or stop is not a float or a pdarray, or if num
+        is not an int, or if endpoint is not a bool, or if dtype is anything
+        other than None or float64, or axis is not an integer.
+    ValueError
+        Raised if axis is not a valid axis for the given data.
+
+    Examples
+    --------
+    >>> import arkouda as ak
+    >>> ak.linspace(0,1,3)
+    array([0.00000000000000000 0.5 1.00000000000000000])
+    >>> ak.linspace(1,0,3)
+    array([1.00000000000000000 0.5 0.00000000000000000])
+    >>> ak.linspace(0,1,3,endpoint=False)
+    array([0.00000000000000000 0.33333333333333331 0.66666666666666663])
+    >>> ak.linspace(0,ak.array([2,3]),3)
+    array([array([0.00000000000000000 0.00000000000000000])
+        array([1.00000000000000000 1.5]) array([2.00000000000000000 3.00000000000000000])])
+    >>> ak.linspace(ak.array([0,1]),3,3)
+    array([array([0.00000000000000000 1.00000000000000000])
+        array([1.5 2.00000000000000000]) array([3.00000000000000000 3.00000000000000000])])
+    >>> ak.linspace(ak.array([0,1]),ak.array([2,3]),3)
+    array([array([0.00000000000000000 1.00000000000000000])
+        array([1.00000000000000000 2.00000000000000000])
+        array([2.00000000000000000 3.00000000000000000])])
+    """
+
+    from arkouda.client import generic_msg
+    from arkouda.numeric import transpose
+    from arkouda.numpy.util import broadcast_dims
+
+    #   The code below creates a command string for linspace_vv, linspace_vs,
+    #   linspace_sv or linspace_ss, based on start and stop.
+    #   start and stop are also converted to floats, and broadcast to a common shape if
+    #   necessary.
+
+    start_ = start
+    stop_ = stop
+
+    #   Make sure everything's a float.
+
+    if isinstance(start_, pdarray):
+        start_ = start_.astype(float64)
+    elif isinstance(start_, int):
+        start_ = float(start_)
+
+    if isinstance(stop_, pdarray):
+        stop_ = stop_.astype(float64)
+    elif isinstance(stop_, int):
+        stop_ = float(stop_)
+
+    #   Determine which of vector-vector, vector-scalar, scalar-vector or scalar-scalar
+    #   we're dealing with.
+
+    if isinstance(start_, pdarray) and isinstance(stop_, pdarray):
+        #  they must be broadcast to a matching shape
+        if start_.shape != stop_.shape:
+            newshape = broadcast_dims(start_.shape, stop_.shape)
+            start_ = broadcast_to_shape(start_, newshape)
+            stop_ = broadcast_to_shape(stop_, newshape)
+            cmdstring = f"linspace_vv<{len(newshape)}>"
+        else:
+            cmdstring = f"linspace_vv<{start_.ndim}>"
+
+    #   If one is a scalar and other a vector, we use ak.full to "promote" the scalar one,
+    #   and use the chapel-side vector-vector proc.
+
+    else:
+        if isinstance(start_, pdarray) and np.isscalar(stop_):
+            stop_ = full_like(start_, stop_)
+            cmdstring = f"linspace_vv<{start_.ndim}>"
+
+        elif isinstance(stop_, pdarray) and np.isscalar(start_):
+            start_ = full_like(stop_, start_)
+            cmdstring = f"linspace_vv<{stop_.ndim}>"
+
+        else:  # both are scalars
+            cmdstring = "linspace_ss"
+
+    repMsg = generic_msg(
+        cmd=cmdstring, args={"start": start_, "stop": stop_, "num": num, "endpoint": endpoint}
+    )
+
+    # Handle the axis parameter if needed
+
+    result = create_pdarray(repMsg)
+    if axis != 0:
+        good, axis_ = _axis_validation(axis, result.ndim)
+        if not good:
+            raise ValueError(f"{axis} is not a valid axis for the result of linspace.")
+        axes = list(range(result.ndim))
+        axes[axis_] = 0
+        axes[0] = axis_
+        result = transpose(result, tuple(axes))
+
+    return result
 
 
 @typechecked

--- a/arkouda/numpy/pdarraycreation.py
+++ b/arkouda/numpy/pdarraycreation.py
@@ -1315,7 +1315,7 @@ def linspace(
         else:
             cmdstring = f"linspace_vv<{start_.ndim}>"
 
-    #   If one is a scalar and other a vector, we use ak.full to "promote" the scalar one,
+    #   If one is a scalar and other a vector, we use full_like to "promote" the scalar one,
     #   and use the chapel-side vector-vector proc.
 
     else:

--- a/src/SequenceMsg.chpl
+++ b/src/SequenceMsg.chpl
@@ -64,16 +64,6 @@ module SequenceMsg {
         return result;
     }
 
-    // This proc returns a shape that is an_int prepended to a_shape.
-    // e.g., if a_shape is (2,3) and an_int is 4, it will return (4,2,3).
-
-    proc linspace_shape(a_shape : ?N*int, an_int : int) : (N + 1) * int {
-        var shapeOut : (N+1)*int ;
-        shapeOut[0] = an_int;
-        for i in 0..<N do shapeOut[i+1] = a_shape[i];
-        return shapeOut;
-    }
-
     //  in the vv (vector-vector) case, both start and stop will have already been broadcast to a
     //  compatible shape before the chapel code is invoked.
 
@@ -87,7 +77,14 @@ module SequenceMsg {
         }
         overMemLimit(8*num*start.size);
 
-        var result = makeDistArray((...linspace_shape(start.shape,num)),real);
+        // The line below is chapel-speak for making a new tuple from existing ones.
+        // In this case, resultShape is num followed by the elements of start.shape,
+        // effectively prepending num to start.shape.
+        // The same thing is done below with rdx. 
+
+        var resultShape = ((num),(...start.shape));
+        var result = makeDistArray((...resultShape),real);
+
         if d.rank == 1 {    // if rank of start and stop is 1, then
             for idx in d {  // idx is an integer.
                 for j in 0..#num {
@@ -102,6 +99,7 @@ module SequenceMsg {
                 }
             }
         }
+
         return result;
     }
 


### PR DESCRIPTION
Closing because of the memory issue, and because I've posted an alternate python-only solution.

----------

Closes #4657 and #2999

----------

Still having issues with the memory usage.  In the meantime, I've done the simplifications I talked about (reducing the cases to scalar-scalar and vector-vector), and also simplified the calculation of the result shape (it no longer requires a separate proc).

----------

Update : reworked the for loops chapel-side into foralls, as Ryan suggested.

----------

Ready for review.  This supercedes PR #4637, which I've closed.  That PR added a logspace function, but it didn't include all the parameters of numpy logspace.  This one does.

Quick summary:

There's a lot of code here, but half of it (maybe more) is docstrings and tests.

adds logspace to the __ init __.py files, and to the __ all __ of pdarraycreation.py.
rewrites linspace python-side to use the same parameters and parameter names as numpy
adds logspace, which (just like numpy) computes base ** (results from linspace)
for both linspace and logspace, I've include a dtype parameter for compatibility with numpy, but I ignore it, because these are fundamentally float functions.  I'm open to discussion about that.
eliminates linspaceMsg from SequenceMsg.chpl, and instead has linspace_ss, linspace_sv, linspace_vs, linspace_vv, and a helper function linspace_shape.
includes unit tests for 1D, 2D and 3D versions.  The previous unit tests have been removed.

There is no logspace function chapel-side since it's not needed.

One topic for discussion: I didn't include multi-dim examples in the docstrings, because that made the upstream tests fail.  I could include them, and have numpy/pdarray_creation_test.py skip the docstring tests if the higher ranks aren't compiled (this is how numpy/numeric_test.py handles it).  I'm open to suggestions.