### PR TITLE
Revert "Temporarily don't timeout pytest for debugging"

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,9 +4,9 @@ log_file_level = DEBUG
 log_file_format = %(asctime)s [%(levelname)s] %(message)s
 
 #   Set the timeout to 30 minutes:
-#timeout = 1800
+timeout = 1800
 #   Set timeout_method to 'signal' on Unix
-#timeout_method = thread  
+timeout_method = thread  
 
 filterwarnings =
     ignore:Version mismatch between client .*


### PR DESCRIPTION
Reverts Bears-R-Us/arkouda#4686

The tests are passing now and on the most recent run, the longest running test was `dataframe_test.py::TestDataFrame::test_multi_col_merge`, which took 18 minutes and was the only test to take more than 5 minutes.