### PR TITLE
Skipif test_checkpoint()

### DIFF
--- a/tests/checkpoint_test.py
+++ b/tests/checkpoint_test.py
@@ -35,7 +35,7 @@ def cp_test_base_tmp(request):
 class TestCheckpoint:
     @pytest.mark.skipif(
         os.environ.get("CHPL_HOST_PLATFORM") == "hpe-apollo",
-        reason="skipped on CHPL_HOST_PLATFORM=hpe-apollo - login/compute file system access unreliable"
+        reason="skipped on CHPL_HOST_PLATFORM=hpe-apollo - login/compute file system access unreliable",
     )
     @pytest.mark.parametrize("prob_size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", ["int64", "float64", "bool"])


### PR DESCRIPTION
One of the testing machines does not support file system accesses across the login node (running the pytest client) and the compute nodes (running the server). Skip `test_checkpoint()` in that case to avoid failures.

While there, refactor slightly `test_checkpoint()` implementation.

P.S. We may need to skipif `auto_checkpoints.py` as well in this case.