### PR TITLE
Closes #4692:  tolist to match numpy

### DIFF
--- a/arkouda/alignment.py
+++ b/arkouda/alignment.py
@@ -232,7 +232,7 @@ def find(query, space, all_occurrences=False, remove_missing=False):
     Set both remove_missing and all_occurrences to True, missing values
     will be empty segments
 
-    >>> ak.find(arr1, arr2, remove_missing=True, all_occurrences=True).to_list()
+    >>> ak.find(arr1, arr2, remove_missing=True, all_occurrences=True).tolist()
     [[],
      [],
      [],

--- a/arkouda/array_api/array_object.py
+++ b/arkouda/array_api/array_object.py
@@ -108,7 +108,7 @@ class Array:
     def tolist(self):
         """
         Convert the array to a Python list or nested lists, using the pdarray
-        method to_list.
+        method tolist.
 
         This involves copying the data from the server to the client, and thus
         will fail if the array is too large (see:
@@ -116,10 +116,10 @@ class Array:
 
         See Also
         --------
-        pdarray.to_list()
+        pdarray.tolist()
 
         """
-        x = self._array.to_list()
+        x = self._array.tolist()
         if self.shape == ():
             # to match numpy, return a scalar for a 0-dimensional array
             return x[0]

--- a/arkouda/client_dtypes.py
+++ b/arkouda/client_dtypes.py
@@ -189,7 +189,7 @@ class BitVector(pdarray):
         """Export data to a numpy array of string-formatted bit vectors."""
         return np.array([self.format(x) for x in self.values.to_ndarray()])
 
-    def to_list(self):
+    def tolist(self):
         """Export data to a list of string-formatted bit vectors."""
         return self.to_ndarray().tolist()
 
@@ -637,7 +637,7 @@ class IPv4(pdarray):
         """Export array as a numpy array of integers."""
         return np.array([self.format(x) for x in self.values.to_ndarray()])
 
-    def to_list(self):
+    def tolist(self):
         """Export array as a list of integers."""
         return self.to_ndarray().tolist()
 

--- a/arkouda/numpy/pdarrayclass.py
+++ b/arkouda/numpy/pdarrayclass.py
@@ -2549,7 +2549,7 @@ class pdarray:
         See Also
         --------
         array()
-        to_list()
+        tolist()
 
         Examples
         --------
@@ -2610,7 +2610,7 @@ class pdarray:
         else:
             return x.reshape(self.shape)
 
-    def to_list(self) -> List[numeric_scalars]:
+    def tolist(self) -> List[numeric_scalars]:
         """
         Convert the array to a list, transferring array data from the
         Arkouda server to client-side Python. Note: if the pdarray size exceeds
@@ -2645,9 +2645,9 @@ class pdarray:
         --------
         >>> import arkouda as ak
         >>> a = ak.arange(0, 5, 1)
-        >>> a.to_list()
+        >>> a.tolist()
         [0, 1, 2, 3, 4]
-        >>> type(a.to_list())
+        >>> type(a.tolist())
         <class 'list'>
         """
         return cast(List[numeric_scalars], self.to_ndarray().tolist())

--- a/arkouda/numpy/segarray.py
+++ b/arkouda/numpy/segarray.py
@@ -681,7 +681,7 @@ class SegArray:
         See Also
         --------
         array()
-        to_list()
+        tolist()
 
         Examples
         --------
@@ -700,7 +700,7 @@ class SegArray:
             arr.append(ndvals[ndsegs[-1] :])
         return np.array(arr, dtype=object)
 
-    def to_list(self):
+    def tolist(self):
         """
         Convert the segarray into a list containing sub-arrays
 
@@ -717,9 +717,9 @@ class SegArray:
         --------
         >>> import arkouda as ak
         >>> segarr = ak.SegArray(ak.array([0, 4, 7]), ak.arange(12))
-        >>> segarr.to_list()
+        >>> segarr.tolist()
         [[0, 1, 2, 3], [4, 5, 6], [7, 8, 9, 10, 11]]
-        >>> type(segarr.to_list())
+        >>> type(segarr.tolist())
         <class 'list'>
         """
         return [arr.tolist() for arr in self.to_ndarray()]

--- a/arkouda/numpy/strings.py
+++ b/arkouda/numpy/strings.py
@@ -2288,7 +2288,7 @@ class Strings:
         See Also
         --------
         array()
-        to_list()
+        tolist()
 
         Examples
         --------
@@ -2313,7 +2313,7 @@ class Strings:
             res[i] = np.str_(codecs.decode(b"".join(npvalues[o : o + ln])))
         return res
 
-    def to_list(self) -> List[str]:
+    def tolist(self) -> List[str]:
         """
         Convert the SegString to a list, transferring data from the
         arkouda server to Python. If the SegString exceeds a built-in size limit,
@@ -2342,9 +2342,9 @@ class Strings:
         --------
         >>> import arkouda as ak
         >>> a = ak.array(["hello", "my", "world"])
-        >>> a.to_list()
+        >>> a.tolist()
         ['hello', 'my', 'world']
-        >>> type(a.to_list())
+        >>> type(a.tolist())
         <class 'list'>
         """
         return cast(List[str], self.to_ndarray().tolist())

--- a/arkouda/numpy/timeclass.py
+++ b/arkouda/numpy/timeclass.py
@@ -220,8 +220,8 @@ class _AbstractBaseTime(pdarray):
             dtype="{}64[ns]".format(self.__class__.__name__.lower()),
         )
 
-    def to_list(self):
-        __doc__ = super().to_list().__doc__  # noqa
+    def tolist(self):
+        __doc__ = super().tolist().__doc__  # noqa
         return self.to_ndarray().tolist()
 
     def to_hdf(

--- a/arkouda/pandas/categorical.py
+++ b/arkouda/pandas/categorical.py
@@ -502,11 +502,11 @@ class Categorical:
     def to_pandas(self) -> pd_Categorical:
         """Return the equivalent Pandas Categorical."""
         return pd_Categorical.from_codes(
-            codes=type_cast(List[int], self.codes.to_list()),
+            codes=type_cast(List[int], self.codes.tolist()),
             categories=pd_Index(self.categories.to_ndarray()),
         )
 
-    def to_list(self) -> List[str]:
+    def tolist(self) -> List[str]:
         """
         Convert the Categorical to a list.
 

--- a/arkouda/pandas/dataframe.py
+++ b/arkouda/pandas/dataframe.py
@@ -2987,7 +2987,7 @@ class DataFrame(UserDict):
                 # in order for proper pandas functionality, SegArrays must be seen as 1d
                 # and therefore need to be converted to list
                 if isinstance(val, SegArray):
-                    pandas_data[key] = val.to_list()
+                    pandas_data[key] = val.tolist()
                 elif isinstance(val, Categorical):
                     pandas_data[key] = val.to_pandas()
                 else:
@@ -5127,7 +5127,7 @@ class DataFrame(UserDict):
             elif (isinstance(axis, int) and axis == 1) or (isinstance(axis, str) and axis == "columns"):
                 result = DataFrame()
                 if isinstance(mask, Series):
-                    for col, truth in zip(mask.index.values.to_list(), mask.values.to_list()):
+                    for col, truth in zip(mask.index.values.tolist(), mask.values.tolist()):
                         if truth is True:
                             result[col] = self[col][:]
 

--- a/arkouda/pandas/index.py
+++ b/arkouda/pandas/index.py
@@ -456,7 +456,7 @@ class Index:
             val = convert_if_categorical(self.values)
             return val.to_ndarray()
 
-    def to_list(self):
+    def tolist(self):
         if isinstance(self.values, list):
             return self.values
         else:
@@ -1260,7 +1260,7 @@ class MultiIndex(Index):
     def to_ndarray(self):
         return ndarray([convert_if_categorical(val).to_ndarray() for val in self.levels])
 
-    def to_list(self):
+    def tolist(self):
         return self.to_ndarray().tolist()
 
     def register(self, user_defined_name):

--- a/arkouda/pandas/series.py
+++ b/arkouda/pandas/series.py
@@ -805,7 +805,7 @@ class Series:
         elif isinstance(self.values, SegArray):
             # pandas errors when ndarray formatted like a segarray is
             # passed into Series but works when it's just a list of lists
-            val = self.values.to_list()
+            val = self.values.tolist()
         else:
             val = self.values.to_ndarray()
 
@@ -882,9 +882,9 @@ class Series:
         )
 
     @typechecked()
-    def to_list(self) -> list:
+    def tolist(self) -> list:
         p = self.to_pandas()
-        return p.to_list()
+        return p.tolist()
 
     @typechecked
     def value_counts(self, sort: bool = True) -> Series:

--- a/tests/alignment_test.py
+++ b/tests/alignment_test.py
@@ -39,7 +39,7 @@ class TestAlignment:
 
         lower_bound, upper_bound, vals = self.get_interval_info(lb, ub, v, dtype)
         interval_idxs = ak.search_intervals(vals, (lower_bound, upper_bound))
-        assert expected_result == interval_idxs.to_list()
+        assert expected_result == interval_idxs.tolist()
 
     @pytest.mark.parametrize("dtype", DATA_TYPES)
     def test_multi_array_search_interval(self, dtype):
@@ -48,18 +48,18 @@ class TestAlignment:
         ends = (ak.array([4, 14, 24], dtype), ak.array([4, 14, 24], dtype))
         vals = (ak.array([3, 13, 23], dtype), ak.array([23, 13, 3], dtype))
         ans = [-1, 1, -1]
-        assert ans == ak.search_intervals(vals, (starts, ends), hierarchical=False).to_list()
-        assert ans == ak.interval_lookup((starts, ends), ak.arange(3), vals).to_list()
+        assert ans == ak.search_intervals(vals, (starts, ends), hierarchical=False).tolist()
+        assert ans == ak.interval_lookup((starts, ends), ak.arange(3), vals).tolist()
 
         vals = (ak.array([23, 13, 3], dtype), ak.array([23, 13, 3], dtype))
         ans = [2, 1, 0]
-        assert ans == ak.search_intervals(vals, (starts, ends), hierarchical=False).to_list()
-        assert ans == ak.interval_lookup((starts, ends), ak.arange(3), vals).to_list()
+        assert ans == ak.search_intervals(vals, (starts, ends), hierarchical=False).tolist()
+        assert ans == ak.interval_lookup((starts, ends), ak.arange(3), vals).tolist()
 
         vals = (ak.array([23, 13, 33], dtype), ak.array([23, 13, 3], dtype))
         ans = [2, 1, -1]
-        assert ans == ak.search_intervals(vals, (starts, ends), hierarchical=False).to_list()
-        assert ans == ak.interval_lookup((starts, ends), ak.arange(3), vals).to_list()
+        assert ans == ak.search_intervals(vals, (starts, ends), hierarchical=False).tolist()
+        assert ans == ak.interval_lookup((starts, ends), ak.arange(3), vals).tolist()
 
         # test hierarchical flag
         starts = (ak.array([0, 5], dtype), ak.array([0, 11], dtype))
@@ -69,10 +69,10 @@ class TestAlignment:
             ak.array([0, 20, 1, 5, 15, 0, 12, 30], dtype),
         )
 
-        search_intervals = ak.search_intervals(vals, (starts, ends), hierarchical=False).to_list()
+        search_intervals = ak.search_intervals(vals, (starts, ends), hierarchical=False).tolist()
         assert search_intervals == [0, -1, 0, 0, 1, -1, 1, -1]
 
-        search_intervals_hierarchical = ak.search_intervals(vals, (starts, ends)).to_list()
+        search_intervals_hierarchical = ak.search_intervals(vals, (starts, ends)).tolist()
         assert search_intervals_hierarchical == [0, 0, 0, 0, 1, 1, 1, -1]
 
         # bigint is equivalent to hierarchical=True case
@@ -80,7 +80,7 @@ class TestAlignment:
         bi_ends = ak.bigint_from_uint_arrays([ak.cast(a, ak.uint64) for a in ends])
         bi_vals = ak.bigint_from_uint_arrays([ak.cast(a, ak.uint64) for a in vals])
         assert (
-            ak.search_intervals(bi_vals, (bi_starts, bi_ends)).to_list() == search_intervals_hierarchical
+            ak.search_intervals(bi_vals, (bi_starts, bi_ends)).tolist() == search_intervals_hierarchical
         )
 
     @pytest.mark.parametrize("dtype", DATA_TYPES)
@@ -92,7 +92,7 @@ class TestAlignment:
 
         lower_bound, upper_bound, vals = self.get_interval_info(lb, ub, v, dtype)
         interval_idxs = ak.search_intervals(vals, (lower_bound, upper_bound))
-        assert expected_result == interval_idxs.to_list()
+        assert expected_result == interval_idxs.tolist()
 
     def test_error_handling(self):
         lb = [0, 10, 20, 30, 40, 50]
@@ -165,8 +165,8 @@ class TestAlignment:
         first_answer = [-1, -1, 0, 0, -1, 0, 2, 0, -1, 0, 0, 3, -1]
         smallest_answer = [-1, -1, 0, 2, -1, 2, 2, 1, -1, 0, 0, 3, -1]
         first_result = ak.search_intervals(values, intervals, hierarchical=False)
-        assert first_result.to_list() == first_answer
+        assert first_result.tolist() == first_answer
         smallest_result = ak.search_intervals(
             values, intervals, tiebreak=tiebreak_smallest, hierarchical=False
         )
-        assert smallest_result.to_list() == smallest_answer
+        assert smallest_result.tolist() == smallest_answer

--- a/tests/bigint_agg_test.py
+++ b/tests/bigint_agg_test.py
@@ -27,7 +27,7 @@ class TestBigInt:
         arr = -1 * ak.randint(0, 2**32, size)
         bi_neg = ak.cast(arr, ak.bigint)
         res = gather_scatter(bi_neg)
-        assert bi_neg.to_list() == res.to_list()
+        assert bi_neg.tolist() == res.tolist()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_negative_arraycreation(self, size):
@@ -35,7 +35,7 @@ class TestBigInt:
         arr = -1 * ak.randint(0, 2**32, size)
         bi_neg = ak.array(arr, dtype=ak.bigint)
         res = gather_scatter(bi_neg)
-        assert bi_neg.to_list() == res.to_list()
+        assert bi_neg.tolist() == res.tolist()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_negative_astype(self, size):
@@ -43,7 +43,7 @@ class TestBigInt:
         arr = -1 * ak.randint(0, 2**32, size)
         bi_neg = arr.astype(ak.bigint)
         res = gather_scatter(bi_neg)
-        assert bi_neg.to_list() == res.to_list()
+        assert bi_neg.tolist() == res.tolist()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_large(self, size):
@@ -54,14 +54,14 @@ class TestBigInt:
         bot_bits = ak.randint(0, 2**32, size, dtype=ak.uint64)
         bi_arr = ak.bigint_from_uint_arrays([top_bits, mid_bits1, mid_bits2, bot_bits])
         res = gather_scatter(bi_arr)
-        assert bi_arr.to_list() == res.to_list()
+        assert bi_arr.tolist() == res.tolist()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_zero(self, size):
         # test all zero bigint assignments
         all_zero = ak.zeros(size, dtype=ak.bigint)
         res = gather_scatter(all_zero)
-        assert all_zero.to_list() == res.to_list()
+        assert all_zero.tolist() == res.tolist()
 
     def test_variable_sized(self):
         # 5 bigints of differing number of limbs
@@ -72,7 +72,7 @@ class TestBigInt:
         bits5 = ak.array([1, 1, 1, 1, 1], dtype=ak.uint64)
         bi_arr = ak.bigint_from_uint_arrays([bits1, bits2, bits3, bits4, bits5])
         res = gather_scatter(bi_arr)
-        assert bi_arr.to_list() == res.to_list()
+        assert bi_arr.tolist() == res.tolist()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_change_size(self, size):
@@ -81,4 +81,4 @@ class TestBigInt:
         bi_arr = ak.bigint_from_uint_arrays([bits, bits, bits, bits])
         res = ak.ones_like(bi_arr)
         bi_arr[:] = res
-        assert bi_arr.to_list() == res.to_list()
+        assert bi_arr.tolist() == res.tolist()

--- a/tests/bitops_test.py
+++ b/tests/bitops_test.py
@@ -17,31 +17,31 @@ class TestBitOps:
 
     def test_popcount(self):
         for arr in self.int_arr, self.uint_arr, self.bigint_arr:
-            assert arr.popcount().to_list() == [0, 1, 1, 2, 1, 2, 2, 3, 1, 2]
+            assert arr.popcount().tolist() == [0, 1, 1, 2, 1, 2, 2, 3, 1, 2]
 
         for arr in self.edge_cases, self.edge_cases_uint, self.edge_cases_bigint:
-            assert ak.popcount(arr).to_list() == [1, 64, 63]
+            assert ak.popcount(arr).tolist() == [1, 64, 63]
 
     def test_parity(self):
         for arr in self.int_arr, self.uint_arr, self.bigint_arr:
-            assert arr.parity().to_list() == [0, 1, 1, 0, 1, 0, 0, 1, 1, 0]
+            assert arr.parity().tolist() == [0, 1, 1, 0, 1, 0, 0, 1, 1, 0]
 
         for arr in self.edge_cases, self.edge_cases_uint, self.edge_cases_bigint:
-            assert ak.parity(arr).to_list() == [1, 0, 1]
+            assert ak.parity(arr).tolist() == [1, 0, 1]
 
     def test_clz(self):
         for arr in self.int_arr, self.uint_arr, self.bigint_arr:
-            assert arr.clz().to_list() == [64, 63, 62, 62, 61, 61, 61, 61, 60, 60]
+            assert arr.clz().tolist() == [64, 63, 62, 62, 61, 61, 61, 61, 60, 60]
 
         for arr in self.edge_cases, self.edge_cases_uint, self.edge_cases_bigint:
-            assert ak.clz(arr).to_list() == [0, 0, 1]
+            assert ak.clz(arr).tolist() == [0, 0, 1]
 
     def test_ctz(self):
         for arr in self.int_arr, self.uint_arr, self.bigint_arr:
-            assert arr.ctz().to_list() == [0, 0, 1, 0, 2, 0, 1, 0, 3, 0]
+            assert arr.ctz().tolist() == [0, 0, 1, 0, 2, 0, 1, 0, 3, 0]
 
         for arr in self.edge_cases, self.edge_cases_uint, self.edge_cases_bigint:
-            assert ak.ctz(arr).to_list() == [63, 0, 0]
+            assert ak.ctz(arr).tolist() == [63, 0, 0]
 
     def test_bigint_bitops(self):
         # compare against int pdarray with variety of max_bits, should be the same except for clz
@@ -58,10 +58,10 @@ class TestBitOps:
             # base_clz plus the difference between max_bits and the number bits used to store the bigint
             clz_ans = base_clz + (max_bits - 64)
 
-            assert pop_ans.to_list() == bi.popcount().to_list()
-            assert par_ans.to_list() == bi.parity().to_list()
-            assert clz_ans.to_list() == bi.clz().to_list()
-            assert ctz_ans.to_list() == bi.ctz().to_list()
+            assert pop_ans.tolist() == bi.popcount().tolist()
+            assert par_ans.tolist() == bi.parity().tolist()
+            assert clz_ans.tolist() == bi.clz().tolist()
+            assert ctz_ans.tolist() == bi.ctz().tolist()
 
         # set one more bit (the 201st)
         bi += 2**200
@@ -76,10 +76,10 @@ class TestBitOps:
             bi.max_bits = max_bits
             clz_ans = ak.full_like(bi, max_bits - 201)
 
-            assert pop_ans.to_list() == bi.popcount().to_list()
-            assert par_ans.to_list() == bi.parity().to_list()
-            assert clz_ans.to_list() == bi.clz().to_list()
-            assert ctz_ans.to_list() == bi.ctz().to_list()
+            assert pop_ans.tolist() == bi.popcount().tolist()
+            assert par_ans.tolist() == bi.parity().tolist()
+            assert clz_ans.tolist() == bi.clz().tolist()
+            assert ctz_ans.tolist() == bi.ctz().tolist()
 
         # test with lots of trailing zeros
         bi = ak.bigint_from_uint_arrays(
@@ -105,10 +105,10 @@ class TestBitOps:
             # so we want the 128 bits after accounted
             clz_ans[0] += 128
 
-            assert pop_ans.to_list() == bi.popcount().to_list()
-            assert par_ans.to_list() == bi.parity().to_list()
-            assert clz_ans.to_list() == bi.clz().to_list()
-            assert ctz_ans.to_list() == bi.ctz().to_list()
+            assert pop_ans.tolist() == bi.popcount().tolist()
+            assert par_ans.tolist() == bi.parity().tolist()
+            assert clz_ans.tolist() == bi.clz().tolist()
+            assert ctz_ans.tolist() == bi.ctz().tolist()
 
         # test edge cases
         edge_case = ak.cast(ak.array([-(2**63), -1, 2**63 - 1]), ak.uint64)
@@ -126,10 +126,10 @@ class TestBitOps:
             # base_clz plus the amount that max_bits exceeds the bits used to store the bigint
             clz_ans = base_clz + (max_bits - 192)
 
-            assert pop_ans.to_list() == bi.popcount().to_list()
-            assert par_ans.to_list() == bi.parity().to_list()
-            assert clz_ans.to_list() == bi.clz().to_list()
-            assert ctz_ans.to_list() == bi.ctz().to_list()
+            assert pop_ans.tolist() == bi.popcount().tolist()
+            assert par_ans.tolist() == bi.parity().tolist()
+            assert clz_ans.tolist() == bi.clz().tolist()
+            assert ctz_ans.tolist() == bi.ctz().tolist()
 
     @pytest.mark.parametrize("dtype", [bool, str, float])
     def test_dtypes_errors(self, dtype):
@@ -147,41 +147,41 @@ class TestBitOps:
         rotated = self.int_arr.rotl(5)
         shifted = self.int_arr << 5
         # No wraparound, so these should be equal
-        assert rotated.to_list() == shifted.to_list()
+        assert rotated.tolist() == shifted.tolist()
 
-        assert ak.rotl(self.edge_cases, 1).to_list() == [1, -1, -2]
+        assert ak.rotl(self.edge_cases, 1).tolist() == [1, -1, -2]
 
         # vector <<< vector
         rotated = self.int_arr.rotl(self.int_arr)
         shifted = self.int_arr << self.int_arr
         # No wraparound, so these should be equal
-        assert rotated.to_list() == shifted.to_list()
+        assert rotated.tolist() == shifted.tolist()
 
-        assert ak.rotl(self.edge_cases, ak.array([1, 1, 1])).to_list() == [1, -1, -2]
+        assert ak.rotl(self.edge_cases, ak.array([1, 1, 1])).tolist() == [1, -1, -2]
 
         # scalar <<< vector
         rotated = ak.rotl(-(2**63), self.int_arr)
-        assert rotated.to_list() == [-(2**63), 1, 2, 4, 8, 16, 32, 64, 128, 256]
+        assert rotated.tolist() == [-(2**63), 1, 2, 4, 8, 16, 32, 64, 128, 256]
 
     def test_rotr(self):
         # vector <<< scalar
         rotated = (1024 * self.int_arr).rotr(5)
         shifted = (1024 * self.int_arr) >> 5
         # No wraparound, so these should be equal
-        assert rotated.to_list() == shifted.to_list()
+        assert rotated.tolist() == shifted.tolist()
 
-        assert ak.rotr(self.edge_cases, 1).to_list() == [2**62, -1, -(2**62) - 1]
+        assert ak.rotr(self.edge_cases, 1).tolist() == [2**62, -1, -(2**62) - 1]
 
         # vector <<< vector
         rotated = (1024 * self.int_arr).rotr(self.int_arr)
         shifted = (1024 * self.int_arr) >> self.int_arr
         # No wraparound, so these should be equal
-        assert rotated.to_list() == shifted.to_list()
+        assert rotated.tolist() == shifted.tolist()
 
         r = ak.rotr(self.edge_cases, ak.array([1, 1, 1]))
-        assert r.to_list() == [2**62, -1, -(2**62) - 1]
+        assert r.tolist() == [2**62, -1, -(2**62) - 1]
 
         # scalar <<< vector
         rotated = ak.rotr(1, self.int_arr)
         ans = [1, -(2**63), 2**62, 2**61, 2**60, 2**59, 2**58, 2**57, 2**56, 2**55]
-        assert rotated.to_list() == ans
+        assert rotated.tolist() == ans

--- a/tests/client_dtypes_test.py
+++ b/tests/client_dtypes_test.py
@@ -34,14 +34,14 @@ class TestClientDTypes:
         arr = ak.arange(4, dtype=dtype)
         bv = ak.BitVector(arr, width=3)
         assert isinstance(bv, ak.BitVector)
-        assert bv.to_list() == bv_answer
+        assert bv.tolist() == bv_answer
         assert bv.dtype == ak.bitType
 
         # Test reversed
         arr = ak.arange(4, dtype=dtype)
         bv = ak.BitVector(arr, width=3, reverse=True)
         assert isinstance(bv, ak.BitVector)
-        assert bv.to_list() == bv_rev_answer
+        assert bv.tolist() == bv_rev_answer
         assert bv.dtype == ak.bitType
 
         # test use of vectorizer function
@@ -49,7 +49,7 @@ class TestClientDTypes:
         bvectorizer = ak.BitVectorizer(3)
         bv = bvectorizer(arr)
         assert isinstance(bv, ak.BitVector)
-        assert bv.to_list() == bv_answer
+        assert bv.tolist() == bv_answer
         assert bv.dtype == ak.bitType
 
     def test_bit_vector_error_handling(self):
@@ -71,7 +71,7 @@ class TestClientDTypes:
         arr = ak.arange(2**64 - 4, 2**64 - 1, dtype=dtype)
         bv = ak.BitVector(arr, width=64)
         assert isinstance(bv, ak.BitVector)
-        assert bv.to_list() == bv_answer
+        assert bv.tolist() == bv_answer
         assert bv.dtype == ak.bitType
 
     def test_field_creation(self):
@@ -79,7 +79,7 @@ class TestClientDTypes:
         names = ["8", "4", "2", "1"]
         f = ak.Fields(values, names)
         assert isinstance(f, ak.Fields)
-        assert f.to_list() == ["---- (0)", "---1 (1)", "--2- (2)", "--21 (3)"]
+        assert f.tolist() == ["---- (0)", "---1 (1)", "--2- (2)", "--21 (3)"]
         assert f.dtype == ak.bitType
 
         # Named fields with reversed bit order
@@ -93,7 +93,7 @@ class TestClientDTypes:
             "----//----//----//Bit4// (8)",
             "----//----//Bit3//Bit4// (12)",
         ]
-        assert f.to_list() == expected
+        assert f.tolist() == expected
 
         values = ak.arange(8, dtype=ak.uint64)
         names = [f"Bit{x}" for x in range(65)]
@@ -124,10 +124,10 @@ class TestClientDTypes:
         ips = ak.randint(1, 2**32, prob_size)
         ip_list = ak.array(ips, dtype=dtype)
         ipv4 = ak.IPv4(ip_list)
-        py_ips = [ipaddress.IPv4Address(ip).compressed for ip in ips.to_list()]
+        py_ips = [ipaddress.IPv4Address(ip).compressed for ip in ips.tolist()]
 
         assert isinstance(ipv4, ak.IPv4)
-        assert ipv4.to_list() == py_ips
+        assert ipv4.tolist() == py_ips
         assert ipv4.dtype == ak.bitType
 
         with pytest.raises(TypeError):
@@ -138,7 +138,7 @@ class TestClientDTypes:
         # Test handling of python dotted-quad input
         ipv4 = ak.ip_address(py_ips)
         assert isinstance(ipv4, ak.IPv4)
-        assert ipv4.to_list() == py_ips
+        assert ipv4.tolist() == py_ips
         assert ipv4.dtype == ak.bitType
 
     @pytest.mark.parametrize("prob_size", pytest.prob_size)
@@ -146,26 +146,26 @@ class TestClientDTypes:
         ips = ak.randint(1, 2**32, prob_size)
         ip_list = ak.array(ips)
         ipv4 = ak.IPv4(ip_list)
-        ip_as_dot = [ipaddress.IPv4Address(ip) for ip in ips.to_list()]
+        ip_as_dot = [ipaddress.IPv4Address(ip) for ip in ips.tolist()]
         ip_as_int = [ipv4.normalize(ipd) for ipd in ip_as_dot]
-        assert ips.to_list() == ip_as_int
+        assert ips.tolist() == ip_as_int
 
     def test_is_ipv4(self):
         prob_size = 100
         x = [random.getrandbits(32) for _ in range(prob_size)]
 
         ans = ak.is_ipv4(ak.array(x, dtype=ak.uint64))
-        assert ans.to_list() == [True] * prob_size
+        assert ans.tolist() == [True] * prob_size
 
         ipv4 = ak.IPv4(ak.array(x))
-        assert ak.is_ipv4(ipv4).to_list() == [True] * prob_size
+        assert ak.is_ipv4(ipv4).tolist() == [True] * prob_size
 
         x = [
             random.getrandbits(64) if i < prob_size / 2 else random.getrandbits(32)
             for i in range(prob_size)
         ]
         ans = ak.is_ipv4(ak.array(x, ak.uint64))
-        assert ans.to_list() == [i >= prob_size / 2 for i in range(prob_size)]
+        assert ans.tolist() == [i >= prob_size / 2 for i in range(prob_size)]
 
         with pytest.raises(TypeError):
             ak.is_ipv4(ak.array(x, ak.float64))
@@ -179,14 +179,14 @@ class TestClientDTypes:
         low = ak.array([i & (2**64 - 1) for i in x], dtype=ak.uint64)
         high = ak.array([i >> 64 for i in x], dtype=ak.uint64)
 
-        assert ak.is_ipv6(high, low).to_list() == [True] * prob_size
+        assert ak.is_ipv6(high, low).tolist() == [True] * prob_size
 
         x = [
             random.getrandbits(64) if i < prob_size / 2 else random.getrandbits(32)
             for i in range(prob_size)
         ]
         ans = ak.is_ipv6(ak.array(x, ak.uint64))
-        assert ans.to_list() == [i < prob_size / 2 for i in range(prob_size)]
+        assert ans.tolist() == [i < prob_size / 2 for i in range(prob_size)]
 
         with pytest.raises(TypeError):
             ak.is_ipv6(ak.array(x, ak.float64))

--- a/tests/coargsort_test.py
+++ b/tests/coargsort_test.py
@@ -91,19 +91,19 @@ class TestCoargsort:
             *permutations([cat_from_codes, string, cat]),
         ]:
             ans = cat_ans if isinstance(cat_list[0], ak.Categorical) else str_ans
-            assert ans == cat_list[0][ak.coargsort(cat_list, algo)].to_list()
+            assert ans == cat_list[0][ak.coargsort(cat_list, algo)].tolist()
 
     @pytest.mark.parametrize("algo", SortingAlgorithm)
     def test_coargsort_empty_categorical_and_strings(self, algo):
         empty_str = ak.random_strings_uniform(1, 16, 0)
         for empty in [empty_str, ak.Categorical(empty_str)]:
-            assert ak.coargsort([empty], algo).to_list() == []
+            assert ak.coargsort([empty], algo).tolist() == []
 
     def test_coargsort_bool(self):
         args = [ak.arange(5) % 2 == 0, ak.arange(5, 0, -1)]
         perm = ak.coargsort(args)
-        assert args[0][perm].to_list() == [False, False, True, True, True]
-        assert args[1][perm].to_list() == [2, 4, 1, 3, 5]
+        assert args[0][perm].tolist() == [False, False, True, True, True]
+        assert args[1][perm].tolist() == [2, 4, 1, 3, 5]
 
     @pytest.mark.parametrize("algo", SortingAlgorithm)
     def test_error_handling(self, algo):
@@ -154,5 +154,5 @@ class TestCoargsort:
     def test_coargsort_empty_and_singleton(self):
         empty = ak.array([])
         singleton = ak.array([42])
-        assert ak.coargsort([empty]).to_list() == []
-        assert ak.coargsort([singleton]).to_list() == [0]
+        assert ak.coargsort([empty]).tolist() == []
+        assert ak.coargsort([singleton]).tolist() == [0]

--- a/tests/indexing_test.py
+++ b/tests/indexing_test.py
@@ -47,14 +47,14 @@ class TestIndexing:
         ikeys, ukeys = key_arrays(prob_size)
         pda = value_array(dtype, prob_size)
         assert pda[np.uint(2)] == pda[2]
-        assert pda[ukeys].to_list() == pda[ikeys].to_list()
+        assert pda[ukeys].tolist() == pda[ikeys].tolist()
 
     @pytest.mark.parametrize("prob_size", pytest.prob_size)
     def test_bool_indexing(self, prob_size):
         u = value_array(ak.uint64, prob_size)
         b = value_array(ak.bool_, prob_size)
-        assert u[b].to_list() == ak.cast(u, ak.int64)[b].to_list()
-        assert u[b].to_list() == ak.cast(u, ak.bigint)[b].to_list()
+        assert u[b].tolist() == ak.cast(u, ak.int64)[b].tolist()
+        assert u[b].tolist() == ak.cast(u, ak.bigint)[b].tolist()
 
     @pytest.mark.parametrize("prob_size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", NUM_TYPES)
@@ -69,9 +69,9 @@ class TestIndexing:
 
         # set [slice] = scalar/pdarray
         pda[:test_size] = -2
-        assert pda[ukeys].to_list() == pda[ikeys].to_list()
+        assert pda[ukeys].tolist() == pda[ikeys].tolist()
         pda[:test_size] = ak.cast(ak.arange(test_size), dtype)
-        assert pda[ukeys].to_list() == pda[ikeys].to_list()
+        assert pda[ukeys].tolist() == pda[ikeys].tolist()
 
         # set [int] = val with uint key and value
         val = value_scalar(dtype, prob_size)[0]
@@ -80,17 +80,17 @@ class TestIndexing:
 
         # set [slice] = scalar/pdarray
         pda[:prob_size] = val
-        assert pda[:prob_size].to_list() == ak.full(prob_size, val, dtype=dtype).to_list()
+        assert pda[:prob_size].tolist() == ak.full(prob_size, val, dtype=dtype).tolist()
         pda_value_array = value_array(dtype, prob_size)
         pda[:prob_size] = pda_value_array
-        assert pda[:prob_size].to_list() == pda_value_array.to_list()
+        assert pda[:prob_size].tolist() == pda_value_array.tolist()
 
         # set [pdarray] = scalar/pdarray with uint key pdarray
         pda[ak.arange(prob_size, dtype=ak.uint64)] = val
-        assert pda[:prob_size].to_list() == ak.full(prob_size, val, dtype=dtype).to_list()
+        assert pda[:prob_size].tolist() == ak.full(prob_size, val, dtype=dtype).tolist()
         pda_value_array = value_array(dtype, prob_size)
         pda[ak.arange(prob_size)] = pda_value_array
-        assert pda[:prob_size].to_list() == pda_value_array.to_list()
+        assert pda[:prob_size].tolist() == pda_value_array.tolist()
 
     def test_indexing_with_uint(self):
         # verify reproducer from #1210 no longer fails
@@ -107,7 +107,7 @@ class TestIndexing:
     def test_handling_bigint_max_bits(self):
         a = ak.arange(2**200 - 1, 2**200 + 11, max_bits=3)
         a[:] = ak.arange(2**200 - 1, 2**200 + 11)
-        assert [7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2] == a.to_list()
+        assert [7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2] == a.tolist()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_compare_get_slice(self, size):

--- a/tests/numpy/array_manipulation_tests.py
+++ b/tests/numpy/array_manipulation_tests.py
@@ -339,11 +339,11 @@ class TestManipulationFunctions:
                 a_delete = ak.delete(a, delete_inds, axis=i)
                 assert_arkouda_array_equivalent(n_delete, a_delete)
 
-                n_delete = np.delete(n, delete_inds.to_list(), axis=i)
-                a_delete = ak.delete(a, delete_inds.to_list(), axis=i)
+                n_delete = np.delete(n, delete_inds.tolist(), axis=i)
+                a_delete = ak.delete(a, delete_inds.tolist(), axis=i)
                 assert_arkouda_array_equivalent(n_delete, a_delete)
 
-                delete_bounds = sorted(ak.randint(-axis_dim_size, axis_dim_size, 2).to_list())
+                delete_bounds = sorted(ak.randint(-axis_dim_size, axis_dim_size, 2).tolist())
                 if delete_bounds[0] < 0 <= delete_bounds[1] < delete_bounds[0] + a_size:
                     delete_bounds = delete_bounds[::-1]
                 low, high = delete_bounds

--- a/tests/numpy/datetime_test.py
+++ b/tests/numpy/datetime_test.py
@@ -317,10 +317,10 @@ class TestDatetime:
             "dayofyear",
             "is_leap_year",
         ):
-            assert getattr(pd_dt, attr_name).to_list() == getattr(ak_dt, attr_name).to_list()
+            assert getattr(pd_dt, attr_name).tolist() == getattr(ak_dt, attr_name).tolist()
 
-        assert pd_dt.isocalendar().week.to_list() == ak_dt.week.to_list()
-        assert pd_dt.isocalendar().week.to_list() == ak_dt.weekofyear.to_list()
+        assert pd_dt.isocalendar().week.tolist() == ak_dt.week.tolist()
+        assert pd_dt.isocalendar().week.tolist() == ak_dt.weekofyear.tolist()
         assert ((pd_dt.isocalendar() == ak_dt.isocalendar().to_pandas()).all()).all()
 
     def test_date_time_accessors(self):
@@ -341,7 +341,7 @@ class TestDatetime:
         assert ((pd_td.components == ak_td.components.to_pandas()).all()).all()
         assert np.allclose(pd_td.total_seconds(), ak_td.total_seconds().to_ndarray())
         for attr_name in "nanoseconds", "microseconds", "seconds", "days":
-            assert getattr(pd_td, attr_name).to_list() == getattr(ak_td, attr_name).to_list()
+            assert getattr(pd_td, attr_name).tolist() == getattr(ak_td, attr_name).tolist()
 
     def test_time_delta_accessors(self):
         self.time_delta_attribute_helper(
@@ -367,15 +367,11 @@ class TestDatetime:
             "2010-01-01",
             "2010-01-03",
         ):
-            ak_week = ak.Datetime(ak.date_range(date, periods=10, freq="W")).week.to_list()
-            pd_week = (
-                pd.Series(pd.date_range(date, periods=10, freq="W")).dt.isocalendar().week.to_list()
-            )
+            ak_week = ak.Datetime(ak.date_range(date, periods=10, freq="W")).week.tolist()
+            pd_week = pd.Series(pd.date_range(date, periods=10, freq="W")).dt.isocalendar().week.tolist()
             assert ak_week == pd_week
 
         for date in "2000-01-01", "2005-01-01":
-            ak_week = ak.Datetime(ak.date_range(date, periods=10, freq="d")).week.to_list()
-            pd_week = (
-                pd.Series(pd.date_range(date, periods=10, freq="d")).dt.isocalendar().week.to_list()
-            )
+            ak_week = ak.Datetime(ak.date_range(date, periods=10, freq="d")).week.tolist()
+            pd_week = pd.Series(pd.date_range(date, periods=10, freq="d")).dt.isocalendar().week.tolist()
             assert ak_week == pd_week

--- a/tests/numpy/numeric_test.py
+++ b/tests/numpy/numeric_test.py
@@ -150,7 +150,7 @@ def _trig_and_hyp_test_helper(np_func, na, ak_func, pda):
     assert np.allclose(na, ak_func(pda, where=False).to_ndarray(), equal_nan=True)
     assert np.allclose(
         [np_func(na[i]) if truth_np[i] else na[i] for i in range(len(na))],
-        ak_func(pda, where=truth_ak).to_list(),
+        ak_func(pda, where=truth_ak).tolist(),
         equal_nan=True,
     )
     np.seterr(**old_settings)  # restore original settings
@@ -299,7 +299,7 @@ class TestNumeric:
         res = ak.cast(strarr, num_type, errors=ak.ErrorMode.ignore)
         assert np.allclose(ans, res.to_ndarray(), equal_nan=True)
         res, valid = ak.cast(strarr, num_type, errors=ak.ErrorMode.return_validity)
-        assert valid.to_list() == validans.to_list()
+        assert valid.tolist() == validans.tolist()
         assert np.allclose(ans, res.to_ndarray(), equal_nan=True)
 
     @pytest.mark.parametrize("num_type", NO_BOOL)
@@ -324,9 +324,9 @@ class TestNumeric:
 
         # add 'range'
         ak_result, ak_bins = ak.histogram(pda, bins=20, range=(15, 20))
-        np_result, np_bins = np.histogram(np.array(pda.to_list()), bins=20, range=(15, 20))
-        assert np.allclose(ak_result.to_list(), np_result.tolist())
-        assert np.allclose(ak_bins.to_list(), np_bins.tolist())
+        np_result, np_bins = np.histogram(np.array(pda.tolist()), bins=20, range=(15, 20))
+        assert np.allclose(ak_result.tolist(), np_result.tolist())
+        assert np.allclose(ak_bins.tolist(), np_bins.tolist())
 
     #   log and exp tests were identical, and so have been combined.
 
@@ -344,22 +344,22 @@ class TestNumeric:
 
         np_hist, np_x_edges, np_y_edges = np.histogram2d(np_x, np_y)
         ak_hist, ak_x_edges, ak_y_edges = ak.histogram2d(ak_x, ak_y)
-        assert np.allclose(np_hist.tolist(), ak_hist.to_list())
-        assert np.allclose(np_x_edges.tolist(), ak_x_edges.to_list())
-        assert np.allclose(np_y_edges.tolist(), ak_y_edges.to_list())
+        assert np.allclose(np_hist.tolist(), ak_hist.tolist())
+        assert np.allclose(np_x_edges.tolist(), ak_x_edges.tolist())
+        assert np.allclose(np_y_edges.tolist(), ak_y_edges.tolist())
 
         np_hist, np_x_edges, np_y_edges = np.histogram2d(np_x, np_y, bins=(10, 20))
         ak_hist, ak_x_edges, ak_y_edges = ak.histogram2d(ak_x, ak_y, bins=(10, 20))
-        assert np.allclose(np_hist.tolist(), ak_hist.to_list())
-        assert np.allclose(np_x_edges.tolist(), ak_x_edges.to_list())
-        assert np.allclose(np_y_edges.tolist(), ak_y_edges.to_list())
+        assert np.allclose(np_hist.tolist(), ak_hist.tolist())
+        assert np.allclose(np_x_edges.tolist(), ak_x_edges.tolist())
+        assert np.allclose(np_y_edges.tolist(), ak_y_edges.tolist())
 
         # add 'range'
         np_hist, np_x_edges, np_y_edges = np.histogram2d(np_x, np_y, range=((25, 92), (15, 86)))
         ak_hist, ak_x_edges, ak_y_edges = ak.histogram2d(ak_x, ak_y, range=((25, 92), (15, 86)))
-        assert np.allclose(np_hist.tolist(), ak_hist.to_list())
-        assert np.allclose(np_x_edges.tolist(), ak_x_edges.to_list())
-        assert np.allclose(np_y_edges.tolist(), ak_y_edges.to_list())
+        assert np.allclose(np_hist.tolist(), ak_hist.tolist())
+        assert np.allclose(np_x_edges.tolist(), ak_x_edges.tolist())
+        assert np.allclose(np_y_edges.tolist(), ak_y_edges.tolist())
 
         # test arbitrary dimensional histogram
         dim_list = [3, 4, 5]
@@ -371,17 +371,17 @@ class TestNumeric:
 
                 np_hist, np_bin_edges = np.histogramdd(np_arrs, bins=bins)
                 ak_hist, ak_bin_edges = ak.histogramdd(ak_arrs, bins=bins)
-                assert np.allclose(np_hist.tolist(), ak_hist.to_list())
+                assert np.allclose(np_hist.tolist(), ak_hist.tolist())
                 for np_edge, ak_edge in zip(np_bin_edges, ak_bin_edges):
-                    assert np.allclose(np_edge.tolist(), ak_edge.to_list())
+                    assert np.allclose(np_edge.tolist(), ak_edge.tolist())
 
                 # add 'range'
                 range_arg = [(10, 80) for _ in range(dim)]
                 np_hist, np_bin_edges = np.histogramdd(np_arrs, bins=bins, range=range_arg)
                 ak_hist, ak_bin_edges = ak.histogramdd(ak_arrs, bins=bins, range=range_arg)
-                assert np.allclose(np_hist.tolist(), ak_hist.to_list())
+                assert np.allclose(np_hist.tolist(), ak_hist.tolist())
                 for np_edge, ak_edge in zip(np_bin_edges, ak_bin_edges):
-                    assert np.allclose(np_edge.tolist(), ak_edge.to_list())
+                    assert np.allclose(np_edge.tolist(), ak_edge.tolist())
 
     @pytest.mark.parametrize("num_type", NO_BOOL)
     @pytest.mark.parametrize("op", ["exp", "log", "expm1", "log2", "log10", "log1p"])
@@ -405,8 +405,8 @@ class TestNumeric:
         assert np.allclose(np.abs(na), ak.abs(pda).to_ndarray())
 
         assert (
-            ak.arange(5, 0, -1, dtype=num_type).to_list()
-            == ak.abs(ak.arange(-5, 0, dtype=num_type)).to_list()
+            ak.arange(5, 0, -1, dtype=num_type).tolist()
+            == ak.abs(ak.arange(-5, 0, dtype=num_type)).tolist()
         )
 
         with pytest.raises(TypeError):
@@ -491,7 +491,7 @@ class TestNumeric:
 
         assert np.allclose(
             na_num / na_denom,
-            ak.arctan2(pda_num, pda_denom, where=False).to_list(),
+            ak.arctan2(pda_num, pda_denom, where=False).tolist(),
             equal_nan=True,
         )
         assert np.allclose(
@@ -606,7 +606,7 @@ class TestNumeric:
         assert np.array_equal(np.isnan(npa), actual)
 
         ark_s_int64 = ak.array(np.array([1, 2, 3, 4], dtype="int64"))
-        assert ak.isnan(ark_s_int64).to_list() == [False, False, False, False]
+        assert ak.isnan(ark_s_int64).tolist() == [False, False, False, False]
 
         ark_s_string = ak.array(["a", "b", "c"])
         with pytest.raises(TypeError):
@@ -660,12 +660,12 @@ class TestNumeric:
         h1, h2 = ak.hash(ak.arange(10))
         rev = ak.arange(9, -1, -1)
         h3, h4 = ak.hash(rev)
-        assert h1.to_list() == h3[rev].to_list()
-        assert h2.to_list() == h4[rev].to_list()
+        assert h1.tolist() == h3[rev].tolist()
+        assert h2.tolist() == h4[rev].tolist()
 
         h1 = ak.hash(ak.arange(10), full=False)
         h3 = ak.hash(rev, full=False)
-        assert h1.to_list() == h3[rev].to_list()
+        assert h1.tolist() == h3[rev].tolist()
 
         h = ak.hash(ak.linspace(0, 10, 10))
         assert h[0].dtype == ak.uint64
@@ -675,27 +675,27 @@ class TestNumeric:
         s = ak.random_strings_uniform(4, 8, 10)
         h1, h2 = ak.hash(s)
         rh1, rh2 = ak.hash(s[rev])
-        assert h1.to_list() == rh1[rev].to_list()
-        assert h2.to_list() == rh2[rev].to_list()
+        assert h1.tolist() == rh1[rev].tolist()
+        assert h2.tolist() == rh2[rev].tolist()
 
         # verify all the ways to hash strings match
         h3, h4 = ak.hash([s])
-        assert h1.to_list() == h3.to_list()
-        assert h2.to_list() == h4.to_list()
+        assert h1.tolist() == h3.tolist()
+        assert h2.tolist() == h4.tolist()
         h5, h6 = s.hash()
-        assert h1.to_list() == h5.to_list()
-        assert h2.to_list() == h6.to_list()
+        assert h1.tolist() == h5.tolist()
+        assert h2.tolist() == h6.tolist()
 
         # test segarray hash with int and string values
         # along with strings, categorical, and pdarrays
         segs = ak.array([0, 3, 6, 9])
         vals = ak.array([0, 1, 2, 3, 4, 5, 0, 1, 2, 5, 5, 5, 5])
         sa = ak.SegArray(segs, vals)
-        str_vals = ak.array([f"str {i}" for i in vals.to_list()])
+        str_vals = ak.array([f"str {i}" for i in vals.tolist()])
         str_sa = ak.SegArray(segs, str_vals)
         a = ak.array([-10, 4, -10, 17])
         bi = a + 2**200
-        s = ak.array([f"str {i}" for i in a.to_list()])
+        s = ak.array([f"str {i}" for i in a.tolist()])
         c = ak.Categorical(s)
         for h in [
             sa,
@@ -715,11 +715,11 @@ class TestNumeric:
             if isinstance(h, ak.SegArray):
                 # verify all the ways to hash segarrays match
                 h3, h4 = ak.hash([h])
-                assert h1.to_list() == h3.to_list()
-                assert h2.to_list() == h4.to_list()
+                assert h1.tolist() == h3.tolist()
+                assert h2.tolist() == h4.tolist()
                 h5, h6 = h.hash()
-                assert h1.to_list() == h5.to_list()
-                assert h2.to_list() == h6.to_list()
+                assert h1.tolist() == h5.tolist()
+                assert h2.tolist() == h6.tolist()
             # the first and third position are identical and should hash to the same thing
             assert h1[0] == h1[2]
             assert h2[0] == h2[2]
@@ -739,28 +739,28 @@ class TestNumeric:
         h1, h2 = ak.hash(my_cat)
         rev = ak.arange(10**5)[::-1]
         rh1, rh2 = ak.hash(my_cat[rev])
-        assert h1.to_list() == rh1[rev].to_list()
-        assert h2.to_list() == rh2[rev].to_list()
+        assert h1.tolist() == rh1[rev].tolist()
+        assert h2.tolist() == rh2[rev].tolist()
 
         # verify all the ways to hash Categoricals match
         h3, h4 = ak.hash([my_cat])
-        assert h1.to_list() == h3.to_list()
-        assert h2.to_list() == h4.to_list()
+        assert h1.tolist() == h3.tolist()
+        assert h2.tolist() == h4.tolist()
         h5, h6 = my_cat.hash()
-        assert h1.to_list() == h5.to_list()
-        assert h2.to_list() == h6.to_list()
+        assert h1.tolist() == h5.tolist()
+        assert h2.tolist() == h6.tolist()
 
         # verify it matches hashing the categories and then indexing with codes
         sh1, sh2 = my_cat.categories.hash()
         h7, h8 = sh1[my_cat.codes], sh2[my_cat.codes]
-        assert h1.to_list() == h7.to_list()
-        assert h2.to_list() == h8.to_list()
+        assert h1.tolist() == h7.tolist()
+        assert h2.tolist() == h8.tolist()
 
         # verify all the ways to hash bigint pdarrays match
         h1, h2 = ak.hash(bi)
         h3, h4 = ak.hash([bi])
-        assert h1.to_list() == h3.to_list()
-        assert h2.to_list() == h4.to_list()
+        assert h1.tolist() == h3.tolist()
+        assert h2.tolist() == h4.tolist()
 
     # Notes about median:
     #  prob_size is either even or odd, so one of sample_e, sample_o will have an even

--- a/tests/numpy/pdarray_creation_test.py
+++ b/tests/numpy/pdarray_creation_test.py
@@ -271,12 +271,10 @@ class TestPdarrayCreation:
             assert pda[-1] == bi + 10 - 1
 
         # test array and arange infer dtype
-        assert (
-            ak.array([bi, bi + 1, bi + 2, bi + 3, bi + 4]).to_list() == ak.arange(bi, bi + 5).to_list()
-        )
+        assert ak.array([bi, bi + 1, bi + 2, bi + 3, bi + 4]).tolist() == ak.arange(bi, bi + 5).tolist()
 
         # test that max_bits being set results in a mod
-        assert ak.arange(bi, bi + 5, max_bits=200).to_list() == ak.arange(5).to_list()
+        assert ak.arange(bi, bi + 5, max_bits=200).tolist() == ak.arange(5).tolist()
 
         # test ak.bigint_from_uint_arrays
         # top bits are all 1 which should be 2**64
@@ -284,26 +282,26 @@ class TestPdarrayCreation:
         bot_bits = ak.arange(5, dtype=ak.uint64)
         two_arrays = ak.bigint_from_uint_arrays([top_bits, bot_bits])
         assert ak.bigint == two_arrays.dtype
-        assert two_arrays.to_list() == [2**64 + i for i in range(5)]
+        assert two_arrays.tolist() == [2**64 + i for i in range(5)]
         # top bits should represent 2**128
         mid_bits = ak.zeros(5, ak.uint64)
         three_arrays = ak.bigint_from_uint_arrays([top_bits, mid_bits, bot_bits])
-        assert three_arrays.to_list() == [2**128 + i for i in range(5)]
+        assert three_arrays.tolist() == [2**128 + i for i in range(5)]
 
         # test round_trip of ak.bigint_to/from_uint_arrays
         t = ak.arange(bi - 1, bi + 9)
         t_dup = ak.bigint_from_uint_arrays(t.bigint_to_uint_arrays())
-        assert t.to_list() == t_dup.to_list()
+        assert t.tolist() == t_dup.tolist()
         assert t_dup.max_bits == -1
 
         # test setting max_bits after creation still mods
         t_dup.max_bits = 200
-        assert t_dup.to_list() == [bi - 1, 0, 1, 2, 3, 4, 5, 6, 7, 8]
+        assert t_dup.tolist() == [bi - 1, 0, 1, 2, 3, 4, 5, 6, 7, 8]
 
         # test slice_bits along 64 bit boundaries matches return from bigint_to_uint_arrays
         for i, uint_bits in enumerate(t.bigint_to_uint_arrays()):
             slice_bits = t.slice_bits(64 * (4 - (i + 1)), 64 * (4 - i) - 1)
-            assert uint_bits.to_list() == slice_bits.to_list()
+            assert uint_bits.tolist() == slice_bits.tolist()
 
     @pytest.mark.skip_if_max_rank_less_than(2)
     def test_bigint_creation_multi_dim(self):
@@ -337,37 +335,37 @@ class TestPdarrayCreation:
         assert_arkouda_array_equal(a, c[0, :])
 
     def test_arange(self):
-        assert np.arange(0, 10, 1).tolist() == ak.arange(0, 10, 1).to_list()
-        assert np.arange(10, 0, -1).tolist() == ak.arange(10, 0, -1).to_list()
-        assert np.arange(-5, -10, -1).tolist() == ak.arange(-5, -10, -1).to_list()
-        assert np.arange(0, 10, 2).tolist() == ak.arange(0, 10, 2).to_list()
+        assert np.arange(0, 10, 1).tolist() == ak.arange(0, 10, 1).tolist()
+        assert np.arange(10, 0, -1).tolist() == ak.arange(10, 0, -1).tolist()
+        assert np.arange(-5, -10, -1).tolist() == ak.arange(-5, -10, -1).tolist()
+        assert np.arange(0, 10, 2).tolist() == ak.arange(0, 10, 2).tolist()
 
     @pytest.mark.parametrize("dtype", ak.intTypes)
     def test_arange_dtype(self, dtype):
         # test dtype works with optional start/step
         stop = ak.arange(100, dtype=dtype)
-        assert np.arange(100, dtype=dtype).tolist() == stop.to_list()
+        assert np.arange(100, dtype=dtype).tolist() == stop.tolist()
         assert dtype == stop.dtype
 
         start_stop = ak.arange(100, 105, dtype=dtype)
-        assert np.arange(100, 105, dtype=dtype).tolist() == start_stop.to_list()
+        assert np.arange(100, 105, dtype=dtype).tolist() == start_stop.tolist()
         assert dtype == start_stop.dtype
 
         start_stop_step = ak.arange(100, 105, 2, dtype=dtype)
-        assert np.arange(100, 105, 2, dtype=dtype).tolist() == start_stop_step.to_list()
+        assert np.arange(100, 105, 2, dtype=dtype).tolist() == start_stop_step.tolist()
         assert dtype == start_stop_step.dtype
 
         # also test for start/stop/step that cause empty ranges
         start_stop_step = ak.arange(100, 10, 2, dtype=dtype)
-        assert np.arange(100, 10, 2, dtype=dtype).tolist() == start_stop_step.to_list()
+        assert np.arange(100, 10, 2, dtype=dtype).tolist() == start_stop_step.tolist()
         assert dtype == start_stop_step.dtype
 
         start_stop_step = ak.arange(10, 15, -2, dtype=dtype)
-        assert np.arange(10, 15, -2, dtype=dtype).tolist() == start_stop_step.to_list()
+        assert np.arange(10, 15, -2, dtype=dtype).tolist() == start_stop_step.tolist()
         assert dtype == start_stop_step.dtype
 
         start_stop_step = ak.arange(10, 10, -2, dtype=dtype)
-        assert np.arange(10, 10, 2, dtype=dtype).tolist() == start_stop_step.to_list()
+        assert np.arange(10, 10, 2, dtype=dtype).tolist() == start_stop_step.tolist()
         assert dtype == start_stop_step.dtype
 
     def test_arange_misc(self):
@@ -376,25 +374,25 @@ class TestPdarrayCreation:
         ak_arange_uint = ak.arange(-5, -10, -1, dtype=ak.uint64)
         # np_arange_uint = array([18446744073709551611, 18446744073709551610, 18446744073709551609,
         #        18446744073709551608, 18446744073709551607], dtype=uint64)
-        assert np_arange_uint.tolist() == ak_arange_uint.to_list()
+        assert np_arange_uint.tolist() == ak_arange_uint.tolist()
         assert ak.uint64 == ak_arange_uint.dtype
 
         uint_start_stop = ak.arange(2**63 + 3, 2**63 + 7)
         ans = ak.arange(3, 7, dtype=ak.uint64) + 2**63
-        assert ans.to_list() == uint_start_stop.to_list()
+        assert ans.tolist() == uint_start_stop.tolist()
         assert ak.uint64 == uint_start_stop.dtype
 
         # test correct conversion to float64
         np_arange_float = np.arange(-5, -10, -1, dtype=np.float64)
         ak_arange_float = ak.arange(-5, -10, -1, dtype=ak.float64)
         # array([-5., -6., -7., -8., -9.])
-        assert np_arange_float.tolist() == ak_arange_float.to_list()
+        assert np_arange_float.tolist() == ak_arange_float.tolist()
         assert ak.float64 == ak_arange_float.dtype
 
         # test correct conversion to bool
         expected_bool = [False, True, True, True, True]
         ak_arange_bool = ak.arange(0, 10, 2, dtype=ak.bool_)
-        assert expected_bool == ak_arange_bool.to_list()
+        assert expected_bool == ak_arange_bool.tolist()
         assert ak.bool_ == ak_arange_bool.dtype
 
         # test int_scalars covers uint8, uint16, uint32
@@ -496,7 +494,7 @@ class TestPdarrayCreation:
     def test_randint_with_seed(self):
         values = ak.randint(1, 5, 10, seed=2)
 
-        assert [4, 3, 1, 3, 2, 4, 4, 2, 3, 4] == values.to_list()
+        assert [4, 3, 1, 3, 2, 4, 4, 2, 3, 4] == values.tolist()
 
         values = ak.randint(1, 5, 10, dtype=ak.float64, seed=2)
 
@@ -513,14 +511,14 @@ class TestPdarrayCreation:
             4.0337935981006172,
         ]
 
-        assert ans == values.to_list()
+        assert ans == values.tolist()
 
         bools = [False, True, True, True, True, False, True, True, True, True]
         values = ak.randint(1, 5, 10, dtype=ak.bool_, seed=2)
-        assert values.to_list() == bools
+        assert values.tolist() == bools
 
         values = ak.randint(1, 5, 10, dtype=bool, seed=2)
-        assert values.to_list() == bools
+        assert values.tolist() == bools
 
         # Test that int_scalars covers uint8, uint16, uint32
         uint_arr = ak.randint(np.uint8(1), np.uint32(5), np.uint16(10), seed=np.uint8(2))
@@ -539,14 +537,14 @@ class TestPdarrayCreation:
             0.30013431967121934,
             0.47383036230759112,
             1.0441791878997098,
-        ] == u_array.to_list()
+        ] == u_array.tolist()
 
         u_array = ak.uniform(size=np.int64(3), low=np.int64(0), high=np.int64(5), seed=np.int64(0))
         assert [
             0.30013431967121934,
             0.47383036230759112,
             1.0441791878997098,
-        ] == u_array.to_list()
+        ] == u_array.tolist()
 
         with pytest.raises(TypeError):
             ak.uniform(low="0", high=5, size=size)
@@ -760,7 +758,7 @@ class TestPdarrayCreation:
         strings_full = ak.full(5, "test")
         assert isinstance(strings_full, ak.Strings)
         assert 5 == len(strings_full)
-        assert strings_full.to_list() == ["test"] * 5
+        assert strings_full.tolist() == ["test"] * 5
 
         with pytest.raises(TypeError):
             ak.full(5, 1, dtype=ak.uint8)
@@ -867,7 +865,7 @@ class TestPdarrayCreation:
 
         npda = pda.to_ndarray()
         pda = ak.standard_normal(dtype(100), dtype(1))
-        assert npda.tolist() == pda.to_list()
+        assert npda.tolist() == pda.tolist()
 
     def test_standard_normal_errors(self):
         with pytest.raises(TypeError):
@@ -949,7 +947,7 @@ class TestPdarrayCreation:
             "WL",
             "JCSD",
             "DSN",
-        ] == pda.to_list()
+        ] == pda.tolist()
 
         pda = ak.random_strings_uniform(minlen=1, maxlen=5, seed=1, size=10, characters="printable")
         assert [
@@ -963,7 +961,7 @@ class TestPdarrayCreation:
             "}.",
             "b3Yc",
             "Kw,",
-        ] == pda.to_list()
+        ] == pda.tolist()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("num_dtype", NUMERIC_SCALARS)
@@ -1006,10 +1004,10 @@ class TestPdarrayCreation:
         ]
 
         pda = ak.random_strings_lognormal(2, 0.25, 10, seed=1)
-        assert randoms == pda.to_list()
+        assert randoms == pda.tolist()
 
         pda = ak.random_strings_lognormal(float(2), np.float64(0.25), np.int64(10), seed=1)
-        assert randoms == pda.to_list()
+        assert randoms == pda.tolist()
 
         printable_randoms = [
             "eL96<O",
@@ -1025,12 +1023,12 @@ class TestPdarrayCreation:
         ]
 
         pda = ak.random_strings_lognormal(2, 0.25, 10, seed=1, characters="printable")
-        assert printable_randoms == pda.to_list()
+        assert printable_randoms == pda.tolist()
 
         pda = ak.random_strings_lognormal(
             np.int64(2), np.float64(0.25), np.int64(10), seed=1, characters="printable"
         )
-        assert printable_randoms == pda.to_list()
+        assert printable_randoms == pda.tolist()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", [bool, np.float64, np.int64, str])
@@ -1194,7 +1192,7 @@ class TestPdarrayCreation:
         ):
             greedy_pda = ak.array(greedy_list)
             assert greedy_pda.dtype == ak.uint64
-            assert greedy_list == greedy_pda.to_list()
+            assert greedy_list == greedy_pda.tolist()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     def randint_randomness(self, size):
@@ -1256,12 +1254,12 @@ class TestPdarrayCreation:
         ones = ak.ones(10)
         n_ones = ones.to_ndarray()
         new_ones = ak.array(n_ones)
-        assert ones.to_list() == new_ones.to_list()
+        assert ones.tolist() == new_ones.tolist()
 
         empty_ones = ak.ones(0)
         n_empty_ones = empty_ones.to_ndarray()
         new_empty_ones = ak.array(n_empty_ones)
-        assert empty_ones.to_list() == new_empty_ones.to_list()
+        assert empty_ones.tolist() == new_empty_ones.tolist()
 
     @pytest.mark.skip_if_max_rank_less_than(2)
     @pytest.mark.parametrize("size", pytest.prob_size)
@@ -1271,7 +1269,7 @@ class TestPdarrayCreation:
             ones = ak.ones(shape)
             n_ones = ones.to_ndarray()
             new_ones = ak.array(n_ones)
-            assert ones.to_list() == new_ones.to_list()
+            assert ones.tolist() == new_ones.tolist()
 
     @pytest.mark.skip_if_max_rank_less_than(2)
     @pytest.mark.parametrize("size", pytest.prob_size)

--- a/tests/numpy/pdarrayclass_test.py
+++ b/tests/numpy/pdarrayclass_test.py
@@ -476,21 +476,21 @@ class TestPdarrayClass:
     def test_argsort_default(self, data, expected):
         a = ak.array(data)
         result = a.argsort()
-        assert result.to_list() == expected
-        assert a[result].to_list() == sorted(data)
+        assert result.tolist() == expected
+        assert a[result].tolist() == sorted(data)
 
     def test_argsort_descending(self):
         a = ak.array([42, 7, 19])
         result = a.argsort(ascending=False)
-        assert result.to_list() == [0, 2, 1]
-        assert a[result].to_list() == sorted([42, 7, 19], reverse=True)
+        assert result.tolist() == [0, 2, 1]
+        assert a[result].tolist() == sorted([42, 7, 19], reverse=True)
 
     def test_argsort_bigint(self):
         a = ak.array([2**70, 1, 2**69], dtype=ak.bigint)
         result = a.argsort()
         sorted_vals = a[result]
         expected = sorted([2**70, 1, 2**69])
-        assert sorted_vals.to_list() == expected
+        assert sorted_vals.tolist() == expected
 
     def test_argsort_invalid_axis(self):
         a = ak.array([1, 2, 3])
@@ -500,7 +500,7 @@ class TestPdarrayClass:
     def test_argsort_axis_minus1(self):
         a = ak.array([5, 3, 4])
         result = a.argsort(axis=-1)
-        assert a[result].to_list() == [3, 4, 5]
+        assert a[result].tolist() == [3, 4, 5]
 
     def test_argsort_empty_array(self):
         a = ak.array([], dtype=ak.int64)
@@ -518,7 +518,7 @@ class TestPdarrayClass:
 
         a = ak.array([4, 1, 3])
         result = a.argsort(algorithm=SortingAlgorithm.RadixSortLSD)
-        assert a[result].to_list() == sorted([4, 1, 3])
+        assert a[result].tolist() == sorted([4, 1, 3])
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("ascending", [True, False])

--- a/tests/numpy/random_test.py
+++ b/tests/numpy/random_test.py
@@ -25,13 +25,13 @@ class TestRandom:
         rng = ak.random.default_rng(18)
         first = rng.integers(-(2**32), 2**32, 10)
         second = rng.integers(-(2**32), 2**32, 10)
-        assert first.to_list() != second.to_list()
+        assert first.tolist() != second.tolist()
 
         rng = ak.random.default_rng(18)
         same_seed_first = rng.integers(-(2**32), 2**32, 10)
         same_seed_second = rng.integers(-(2**32), 2**32, 10)
-        assert first.to_list() == same_seed_first.to_list()
-        second.to_list() == same_seed_second.to_list()
+        assert first.tolist() == same_seed_first.tolist()
+        second.tolist() == same_seed_second.tolist()
 
         # test endpoint
         rng = ak.random.default_rng()
@@ -54,10 +54,10 @@ class TestRandom:
         same_seed_bool_arr = rng.integers(0, 1, size=20, dtype="bool")
         same_seed_int_arr = rng.integers(-(2**32), 2**32, size=10, dtype="int")
 
-        assert uint_arr.to_list() == same_seed_uint_arr.to_list()
-        assert float_arr.to_list() == same_seed_float_arr.to_list()
-        assert bool_arr.to_list() == same_seed_bool_arr.to_list()
-        assert int_arr.to_list() == same_seed_int_arr.to_list()
+        assert uint_arr.tolist() == same_seed_uint_arr.tolist()
+        assert float_arr.tolist() == same_seed_float_arr.tolist()
+        assert bool_arr.tolist() == same_seed_bool_arr.tolist()
+        assert int_arr.tolist() == same_seed_int_arr.tolist()
 
         # verify within bounds (lower inclusive and upper exclusive)
         rng = ak.random.default_rng()
@@ -70,7 +70,7 @@ class TestRandom:
         # ints are checked for equality; floats are checked for closeness
 
         def check(a, b, t):
-            return (a == b).all() if t is ak.int64 else np.allclose(a.to_list(), b.to_list())
+            return (a == b).all() if t is ak.int64 else np.allclose(a.tolist(), b.tolist())
 
         # verify all the same elements are in the shuffle as in the original
 
@@ -97,7 +97,7 @@ class TestRandom:
         # ints are checked for equality; floats are checked for closeness
 
         def check(a, b, t):
-            return (a == b).all() if t is ak.int64 else np.allclose(a.to_list(), b.to_list())
+            return (a == b).all() if t is ak.int64 else np.allclose(a.tolist(), b.tolist())
 
         # verify all the same elements are in the permutation as in the original
 
@@ -132,13 +132,13 @@ class TestRandom:
         rng = ak.random.default_rng(18)
         first = rng.uniform(-(2**32), 2**32, 10)
         second = rng.uniform(-(2**32), 2**32, 10)
-        assert first.to_list() != second.to_list()
+        assert first.tolist() != second.tolist()
 
         rng = ak.random.default_rng(18)
         same_seed_first = rng.uniform(-(2**32), 2**32, 10)
         same_seed_second = rng.uniform(-(2**32), 2**32, 10)
-        assert np.allclose(first.to_list(), same_seed_first.to_list())
-        assert np.allclose(second.to_list(), same_seed_second.to_list())
+        assert np.allclose(first.tolist(), same_seed_first.tolist())
+        assert np.allclose(second.tolist(), same_seed_second.tolist())
 
         # verify within bounds (lower inclusive and upper exclusive)
         rng = ak.random.default_rng()
@@ -197,7 +197,7 @@ class TestRandom:
                     for p in [None, weights]:
                         previous = choice_arrays.pop(0)
                         current = rng.choice(a, size, replace, p)
-                        assert np.allclose(previous.to_list(), current.to_list())
+                        assert np.allclose(previous.tolist(), current.tolist())
 
     def test_logistic(self):
         scal = 2
@@ -206,10 +206,10 @@ class TestRandom:
         for loc, scale in product([scal, arr], [scal, arr]):
             rng = ak.random.default_rng(17)
             num_samples = 5
-            log_sample = rng.logistic(loc=loc, scale=scale, size=num_samples).to_list()
+            log_sample = rng.logistic(loc=loc, scale=scale, size=num_samples).tolist()
 
             rng = ak.random.default_rng(17)
-            assert rng.logistic(loc=loc, scale=scale, size=num_samples).to_list() == log_sample
+            assert rng.logistic(loc=loc, scale=scale, size=num_samples).tolist() == log_sample
 
     def test_lognormal(self):
         scal = 2
@@ -218,25 +218,25 @@ class TestRandom:
         for mean, sigma in product([scal, arr], [scal, arr]):
             rng = ak.random.default_rng(17)
             num_samples = 5
-            log_sample = rng.lognormal(mean=mean, sigma=sigma, size=num_samples).to_list()
+            log_sample = rng.lognormal(mean=mean, sigma=sigma, size=num_samples).tolist()
 
             rng = ak.random.default_rng(17)
-            assert rng.lognormal(mean=mean, sigma=sigma, size=num_samples).to_list() == log_sample
+            assert rng.lognormal(mean=mean, sigma=sigma, size=num_samples).tolist() == log_sample
 
     def test_normal(self):
         rng = ak.random.default_rng(17)
-        both_scalar = rng.normal(loc=10, scale=2, size=10).to_list()
-        scale_scalar = rng.normal(loc=ak.array([0, 10, 20]), scale=1, size=3).to_list()
-        loc_scalar = rng.normal(loc=10, scale=ak.array([1, 2, 3]), size=3).to_list()
-        both_array = rng.normal(loc=ak.array([0, 10, 20]), scale=ak.array([1, 2, 3]), size=3).to_list()
+        both_scalar = rng.normal(loc=10, scale=2, size=10).tolist()
+        scale_scalar = rng.normal(loc=ak.array([0, 10, 20]), scale=1, size=3).tolist()
+        loc_scalar = rng.normal(loc=10, scale=ak.array([1, 2, 3]), size=3).tolist()
+        both_array = rng.normal(loc=ak.array([0, 10, 20]), scale=ak.array([1, 2, 3]), size=3).tolist()
 
         # redeclare rng with same seed to test reproducibility
         rng = ak.random.default_rng(17)
-        assert rng.normal(loc=10, scale=2, size=10).to_list() == both_scalar
-        assert rng.normal(loc=ak.array([0, 10, 20]), scale=1, size=3).to_list() == scale_scalar
-        assert rng.normal(loc=10, scale=ak.array([1, 2, 3]), size=3).to_list() == loc_scalar
+        assert rng.normal(loc=10, scale=2, size=10).tolist() == both_scalar
+        assert rng.normal(loc=ak.array([0, 10, 20]), scale=1, size=3).tolist() == scale_scalar
+        assert rng.normal(loc=10, scale=ak.array([1, 2, 3]), size=3).tolist() == loc_scalar
         assert (
-            rng.normal(loc=ak.array([0, 10, 20]), scale=ak.array([1, 2, 3]), size=3).to_list()
+            rng.normal(loc=ak.array([0, 10, 20]), scale=ak.array([1, 2, 3]), size=3).tolist()
             == both_array
         )
 
@@ -244,15 +244,15 @@ class TestRandom:
         rng = ak.random.default_rng(12345)
         num_samples = 5
         # scalar shape
-        scal_sample = rng.standard_gamma(2, size=num_samples).to_list()
+        scal_sample = rng.standard_gamma(2, size=num_samples).tolist()
 
         # array shape
-        arr_sample = rng.standard_gamma(ak.arange(5), size=num_samples).to_list()
+        arr_sample = rng.standard_gamma(ak.arange(5), size=num_samples).tolist()
 
         # reset rng with same seed and ensure we get same results
         rng = ak.random.default_rng(12345)
-        assert rng.standard_gamma(2, size=num_samples).to_list() == scal_sample
-        assert rng.standard_gamma(ak.arange(num_samples), size=num_samples).to_list() == arr_sample
+        assert rng.standard_gamma(2, size=num_samples).tolist() == scal_sample
+        assert rng.standard_gamma(ak.arange(num_samples), size=num_samples).tolist() == arr_sample
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_standard_gamma_no_seed(self, size):
@@ -273,7 +273,7 @@ class TestRandom:
 
         k = rng.uniform(0, 10)
         sample = rng.standard_gamma(k, size=num_samples)
-        sample_list = sample.to_list()
+        sample_list = sample.tolist()
 
         # second goodness of fit test against the distribution with proper mean and std
         good_fit_res = sp_stats.goodness_of_fit(sp_stats.gamma, sample_list, known_params={"a": k})
@@ -307,16 +307,16 @@ class TestRandom:
         num_samples = 5
         # scalar lambda
         scal_lam = 2
-        scal_sample = rng.poisson(lam=scal_lam, size=num_samples).to_list()
+        scal_sample = rng.poisson(lam=scal_lam, size=num_samples).tolist()
 
         # array lambda
         arr_lam = ak.arange(5)
-        arr_sample = rng.poisson(lam=arr_lam, size=num_samples).to_list()
+        arr_sample = rng.poisson(lam=arr_lam, size=num_samples).tolist()
 
         # reset rng with same seed and ensure we get same results
         rng = ak.random.default_rng(17)
-        assert rng.poisson(lam=scal_lam, size=num_samples).to_list() == scal_sample
-        assert rng.poisson(lam=arr_lam, size=num_samples).to_list() == arr_sample
+        assert rng.poisson(lam=scal_lam, size=num_samples).tolist() == scal_sample
+        assert rng.poisson(lam=arr_lam, size=num_samples).tolist() == arr_sample
 
     def test_poisson_seed_reproducibility(self):
         # test resolution of issue #3322, same seed gives same result across machines / num locales
@@ -337,16 +337,16 @@ class TestRandom:
         num_samples = 5
         # scalar scale
         scal_scale = 2
-        scal_sample = rng.exponential(scale=scal_scale, size=num_samples).to_list()
+        scal_sample = rng.exponential(scale=scal_scale, size=num_samples).tolist()
 
         # array scale
         arr_scale = ak.arange(5)
-        arr_sample = rng.exponential(scale=arr_scale, size=num_samples).to_list()
+        arr_sample = rng.exponential(scale=arr_scale, size=num_samples).tolist()
 
         # reset rng with same seed and ensure we get same results
         rng = ak.random.default_rng(17)
-        assert rng.exponential(scale=scal_scale, size=num_samples).to_list() == scal_sample
-        assert rng.exponential(scale=arr_scale, size=num_samples).to_list() == arr_sample
+        assert rng.exponential(scale=scal_scale, size=num_samples).tolist() == scal_sample
+        assert rng.exponential(scale=arr_scale, size=num_samples).tolist() == arr_sample
 
     def test_choice_hypothesis_testing(self):
         # perform a weighted sample and use chisquare to test
@@ -382,7 +382,7 @@ class TestRandom:
 
         scale = rng.uniform(0, 10)
         sample = rng.exponential(scale=scale, size=num_samples, method=method)
-        sample_list = sample.to_list()
+        sample_list = sample.tolist()
 
         # do the Kolmogorov-Smirnov test for goodness of fit
         ks_res = sp_stats.kstest(
@@ -402,7 +402,7 @@ class TestRandom:
         mean = rng.uniform(-10, 10)
         deviation = rng.uniform(0, 10)
         sample = rng.normal(loc=mean, scale=deviation, size=num_samples, method=method)
-        sample_list = sample.to_list()
+        sample_list = sample.tolist()
 
         # first test if samples are normal at all
         _, pval = sp_stats.normaltest(sample_list)
@@ -451,7 +451,7 @@ class TestRandom:
         lam = rng.uniform(0, 10)
 
         sample = rng.poisson(lam=lam, size=num_samples)
-        count_dict = Counter(sample.to_list())
+        count_dict = Counter(sample.tolist())
 
         # the sum of exp freq and obs freq must be within 1e-08, so we use
         # the isf (inverse survival function where survival function is 1-cdf) to
@@ -552,7 +552,7 @@ class TestRandom:
     def test_legacy_randint_with_seed(self):
         values = ak.random.randint(1, 5, 10, seed=2)
 
-        assert [4, 3, 1, 3, 2, 4, 4, 2, 3, 4] == values.to_list()
+        assert [4, 3, 1, 3, 2, 4, 4, 2, 3, 4] == values.tolist()
 
         values = ak.random.randint(1, 5, 10, dtype=ak.float64, seed=2)
 
@@ -567,7 +567,7 @@ class TestRandom:
             3.7098921109084522,
             4.5939589352472314,
             4.0337935981006172,
-        ] == values.to_list()
+        ] == values.tolist()
 
         values = ak.random.randint(1, 5, 10, dtype=ak.bool_, seed=2)
         assert [
@@ -581,7 +581,7 @@ class TestRandom:
             True,
             True,
             True,
-        ] == values.to_list()
+        ] == values.tolist()
 
         values = ak.random.randint(1, 5, 10, dtype=bool, seed=2)
         assert [
@@ -595,7 +595,7 @@ class TestRandom:
             True,
             True,
             True,
-        ] == values.to_list()
+        ] == values.tolist()
 
         # Test that int_scalars covers uint8, uint16, uint32
         ak.random.randint(np.uint8(1), np.uint32(5), np.uint16(10), seed=np.uint8(2))
@@ -614,13 +614,13 @@ class TestRandom:
         uArray = ak.random.uniform(size=3, low=0, high=5, seed=0)
         assert np.allclose(
             [0.30013431967121934, 0.47383036230759112, 1.0441791878997098],
-            uArray.to_list(),
+            uArray.tolist(),
         )
 
         uArray = ak.random.uniform(size=np.int64(3), low=np.int64(0), high=np.int64(5), seed=np.int64(0))
         assert np.allclose(
             [0.30013431967121934, 0.47383036230759112, 1.0441791878997098],
-            uArray.to_list(),
+            uArray.tolist(),
         )
 
         with pytest.raises(TypeError):
@@ -654,7 +654,7 @@ class TestRandom:
         npda = pda.to_ndarray()
         pda = ak.random.standard_normal(np.int64(100), np.int64(1))
 
-        assert np.allclose(npda.tolist(), pda.to_list())
+        assert np.allclose(npda.tolist(), pda.tolist())
 
         with pytest.raises(TypeError):
             ak.random.standard_normal("100")

--- a/tests/numpy/segarray_test.py
+++ b/tests/numpy/segarray_test.py
@@ -201,13 +201,13 @@ class TestSegArray:
         sa = ak.SegArray(ak.array(segs_np), ak.array(vals_np))
 
         assert isinstance(sa, ak.SegArray)
-        assert segs_np.tolist() == sa.segments.to_list()
-        assert vals_np.tolist() == sa.values.to_list()
+        assert segs_np.tolist() == sa.segments.tolist()
+        assert vals_np.tolist() == sa.values.tolist()
         assert sa.size == len(segs_np)
         assert sa.dtype == dtype
 
         expected_lens = np.concatenate((segs_np[1:], np.array([size]))) - segs_np
-        assert expected_lens.tolist() == sa.lengths.to_list()
+        assert expected_lens.tolist() == sa.lengths.tolist()
 
         with pytest.raises(TypeError):
             ak.SegArray(segs_np, ak.array(vals_np))
@@ -225,28 +225,28 @@ class TestSegArray:
         segs = ak.array([0, 0, len(b)])
         segarr = ak.SegArray(segs, flat)
         assert isinstance(segarr, ak.SegArray)
-        assert segarr.lengths.to_list() == [0, 3, 1]
+        assert segarr.lengths.tolist() == [0, 3, 1]
 
         # test empty as middle element
         flat = ak.array(a + c)
         segs = ak.array([0, len(a), len(a)])
         segarr = ak.SegArray(segs, flat)
         assert isinstance(segarr, ak.SegArray)
-        assert segarr.lengths.to_list() == [2, 0, 1]
+        assert segarr.lengths.tolist() == [2, 0, 1]
 
         # test empty as last
         flat = ak.array(a + b + c)
         segs = ak.array([0, len(a), len(a) + len(b), len(a) + len(b) + len(c)])
         segarr = ak.SegArray(segs, flat)
         assert isinstance(segarr, ak.SegArray)
-        assert segarr.lengths.to_list() == [2, 3, 1, 0]
+        assert segarr.lengths.tolist() == [2, 3, 1, 0]
 
     def test_empty_creation(self):
         sa = ak.SegArray(ak.array([], dtype=ak.int64), ak.array([]))
 
         assert isinstance(sa, ak.SegArray)
         assert sa.size == 0
-        assert [] == sa.lengths.to_list()
+        assert [] == sa.lengths.tolist()
 
     def test_generic_error_handling(self):
         with pytest.raises(TypeError):
@@ -270,13 +270,13 @@ class TestSegArray:
         sa = ak.SegArray(ak.array(segs_np), ak.array(vals_np))
 
         assert isinstance(sa, ak.SegArray)
-        assert segs_np.tolist() == sa.segments.to_list()
-        assert vals_np.tolist() == sa.values.to_list()
+        assert segs_np.tolist() == sa.segments.tolist()
+        assert vals_np.tolist() == sa.values.tolist()
         assert sa.size == len(segs_np)
         assert sa.dtype == dtype
 
         expected_lens = np.concatenate((segs_np[1:], np.array([10]))) - segs_np
-        assert expected_lens.tolist() == sa.lengths.to_list()
+        assert expected_lens.tolist() == sa.lengths.tolist()
 
         with pytest.raises(TypeError):
             ak.SegArray(segs_np, ak.array(vals_np))
@@ -294,12 +294,12 @@ class TestSegArray:
         sa = ak.SegArray.from_multi_array(ma)
 
         assert isinstance(sa, ak.SegArray)
-        assert [0, 4, 4, 6] == sa.segments.to_list()
-        assert list(range(6)) == sa.values.to_list()
+        assert [0, 4, 4, 6] == sa.segments.tolist()
+        assert list(range(6)) == sa.values.tolist()
         assert sa.size == 4
 
         expected_lens = [4, 0, 2, 0]
-        assert expected_lens == sa.lengths.to_list()
+        assert expected_lens == sa.lengths.tolist()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", DTYPES)
@@ -313,10 +313,10 @@ class TestSegArray:
         result = ak.SegArray.concat([sa, c_sa])
         assert isinstance(result, ak.SegArray)
         assert result.size == (sa.size + c_sa.size)
-        assert result.lengths.to_list() == (sa.lengths.to_list() + c_sa.lengths.to_list())
-        assert result.segments.to_list() == np.concatenate([seg_np, c_seg + val_np.size]).tolist()
-        assert result.values.to_list() == sa.values.to_list() + c_sa.values.to_list()
-        assert result.to_list() == (sa.to_list() + c_sa.to_list())
+        assert result.lengths.tolist() == (sa.lengths.tolist() + c_sa.lengths.tolist())
+        assert result.segments.tolist() == np.concatenate([seg_np, c_seg + val_np.size]).tolist()
+        assert result.values.tolist() == sa.values.tolist() + c_sa.values.tolist()
+        assert result.tolist() == (sa.tolist() + c_sa.tolist())
 
         # test concat with empty segments
         seg_np, val_np = self.make_segarray_edge(dtype)
@@ -326,10 +326,10 @@ class TestSegArray:
         result = ak.SegArray.concat([sa, c_sa])
         assert isinstance(result, ak.SegArray)
         assert result.size == (sa.size + c_sa.size)
-        assert result.lengths.to_list() == (sa.lengths.to_list() + c_sa.lengths.to_list())
-        assert result.segments.to_list() == np.concatenate([seg_np, c_seg + val_np.size]).tolist()
-        assert result.values.to_list() == sa.values.to_list() + c_sa.values.to_list()
-        assert result.to_list() == (sa.to_list() + c_sa.to_list())
+        assert result.lengths.tolist() == (sa.lengths.tolist() + c_sa.lengths.tolist())
+        assert result.segments.tolist() == np.concatenate([seg_np, c_seg + val_np.size]).tolist()
+        assert result.values.tolist() == sa.values.tolist() + c_sa.values.tolist()
+        assert result.tolist() == (sa.tolist() + c_sa.tolist())
 
         # test axis=1
         if dtype != ak.str_:  # TODO - updated to run on strings once #2646 is complete
@@ -340,8 +340,8 @@ class TestSegArray:
             result = ak.SegArray.concat([sa, c_sa], axis=1)
             assert isinstance(result, ak.SegArray)
             assert result.size == sa.size
-            assert result.lengths.to_list() == (sa.lengths + c_sa.lengths).to_list()
-            assert result.to_list() == [x + y for (x, y) in zip(sa.to_list(), c_sa.to_list())]
+            assert result.lengths.tolist() == (sa.lengths + c_sa.lengths).tolist()
+            assert result.tolist() == [x + y for (x, y) in zip(sa.tolist(), c_sa.tolist())]
 
     def test_concat_error_handling(self):
         sa_1 = ak.SegArray(ak.arange(0, 10, 2), ak.arange(10))
@@ -370,19 +370,19 @@ class TestSegArray:
 
         suffix, origin = sa.get_suffixes(1)
         assert origin.all()
-        assert suffix[0].to_list() == [x[-1] for x in sa.to_list()]
+        assert suffix[0].tolist() == [x[-1] for x in sa.tolist()]
 
         seg_np, val_np = self.make_segarray_edge(dtype)
         sa = ak.SegArray(ak.array(seg_np), ak.array(val_np))
         suffix, origin = sa.get_suffixes(2)
-        assert origin.to_list() == [False, True, False, False, True, False, False]
-        expected = [[s[(-2 + i)] for s in sa.to_list() if len(s) > 2] for i in range(2)]
-        assert [x.to_list() for x in suffix] == expected
+        assert origin.tolist() == [False, True, False, False, True, False, False]
+        expected = [[s[(-2 + i)] for s in sa.tolist() if len(s) > 2] for i in range(2)]
+        assert [x.tolist() for x in suffix] == expected
 
         suffix, origin = sa.get_suffixes(2, proper=False)
-        assert origin.to_list() == [False, True, True, False, True, False, False]
-        expected = [[s[(-2 + i)] for s in sa.to_list() if len(s) > 1] for i in range(2)]
-        assert [x.to_list() for x in suffix] == expected
+        assert origin.tolist() == [False, True, True, False, True, False, False]
+        expected = [[s[(-2 + i)] for s in sa.tolist() if len(s) > 1] for i in range(2)]
+        assert [x.tolist() for x in suffix] == expected
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", DTYPES)
@@ -392,20 +392,20 @@ class TestSegArray:
 
         prefix, origin = sa.get_prefixes(1)
         assert origin.all()
-        assert prefix[0].to_list() == [x[0] for x in sa.to_list()]
+        assert prefix[0].tolist() == [x[0] for x in sa.tolist()]
 
         seg_np, val_np = self.make_segarray_edge(dtype)
         sa = ak.SegArray(ak.array(seg_np), ak.array(val_np))
 
         prefix, origin = sa.get_prefixes(2)
-        assert origin.to_list() == [False, True, False, False, True, False, False]
-        expected = [[s[(i)] for s in sa.to_list() if len(s) > 2] for i in range(2)]
-        assert [x.to_list() for x in prefix] == expected
+        assert origin.tolist() == [False, True, False, False, True, False, False]
+        expected = [[s[(i)] for s in sa.tolist() if len(s) > 2] for i in range(2)]
+        assert [x.tolist() for x in prefix] == expected
 
         prefix, origin = sa.get_prefixes(2, proper=False)
-        assert origin.to_list() == [False, True, True, False, True, False, False]
-        expected = [[s[(i)] for s in sa.to_list() if len(s) > 1] for i in range(2)]
-        assert [x.to_list() for x in prefix] == expected
+        assert origin.tolist() == [False, True, True, False, True, False, False]
+        expected = [[s[(i)] for s in sa.tolist() if len(s) > 1] for i in range(2)]
+        assert [x.tolist() for x in prefix] == expected
 
     @pytest.mark.parametrize("dtype", DTYPES)
     def test_ngram(self, dtype):
@@ -413,7 +413,7 @@ class TestSegArray:
         sa = ak.SegArray(ak.array(seg_np), ak.array(val_np))
 
         ngram, origin = sa.get_ngrams(2)
-        ng_list = [x.to_list() for x in ngram]
+        ng_list = [x.tolist() for x in ngram]
         ng_tuple = list(zip(ng_list[0], ng_list[1]))
         exp_list = []
         exp_origin = []
@@ -424,7 +424,7 @@ class TestSegArray:
                     exp_list.append((seg[j], seg[j + 1]))
                     exp_origin.append(i)
         assert ng_tuple == exp_list
-        assert origin.to_list() == exp_origin
+        assert origin.tolist() == exp_origin
 
         with pytest.raises(ValueError):
             sa.get_ngrams(7)
@@ -436,26 +436,26 @@ class TestSegArray:
         sa = ak.SegArray(ak.array(seg_np), ak.array(val_np))
 
         res, origins = sa.get_jth(1)
-        assert res.to_list() == [x[1] for x in sa.to_list() if 1 < len(x)]
-        assert origins.to_list() == [4 < len(x) for x in sa.to_list()]
+        assert res.tolist() == [x[1] for x in sa.tolist() if 1 < len(x)]
+        assert origins.tolist() == [4 < len(x) for x in sa.tolist()]
 
         res, origins = sa.get_jth(4)
         if dtype != ak.str_:
-            assert res.to_list() == [x[4] if 4 < len(x) else 0 for x in sa.to_list()]
+            assert res.tolist() == [x[4] if 4 < len(x) else 0 for x in sa.tolist()]
         else:
-            assert res.to_list() == [x[4] for x in sa.to_list() if 4 < len(x)]
+            assert res.tolist() == [x[4] for x in sa.tolist() if 4 < len(x)]
 
         res, origins = sa.get_jth(4, compressed=True)
-        assert res.to_list() == [x[4] for x in sa.to_list() if 4 < len(x)]
+        assert res.tolist() == [x[4] for x in sa.tolist() if 4 < len(x)]
 
         seg_np, val_np = self.make_segarray_edge(dtype)
         sa = ak.SegArray(ak.array(seg_np), ak.array(val_np))
 
         res, origins = sa.get_jth(2)
         if dtype != ak.str_:
-            assert res.to_list() == [x[2] if 2 < len(x) else 0 for x in sa.to_list()]
+            assert res.tolist() == [x[2] if 2 < len(x) else 0 for x in sa.tolist()]
         else:
-            assert res.to_list() == [x[2] for x in sa.to_list() if 2 < len(x)]
+            assert res.tolist() == [x[2] for x in sa.tolist() if 2 < len(x)]
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", NO_STR)  # Strings arrays are immutable
@@ -466,16 +466,16 @@ class TestSegArray:
         sa.set_jth(0, 1, 99)
         val_np[seg_np[0] + 1] = 99
         test_sa = ak.SegArray(ak.array(seg_np), ak.array(val_np))
-        assert val_np.tolist() == sa.values.to_list()
-        assert test_sa.to_list() == sa.to_list()
+        assert val_np.tolist() == sa.values.tolist()
+        assert test_sa.tolist() == sa.tolist()
 
         sa.set_jth(ak.array([0, 1, 2]), 3, 17)
         val_np[seg_np[0] + 3] = 17
         val_np[seg_np[1] + 3] = 17
         val_np[seg_np[2] + 3] = 17
         test_sa = ak.SegArray(ak.array(seg_np), ak.array(val_np))
-        assert val_np.tolist() == sa.values.to_list()
-        assert test_sa.to_list() == sa.to_list()
+        assert val_np.tolist() == sa.values.tolist()
+        assert test_sa.tolist() == sa.tolist()
 
         seg_np, val_np = self.make_segarray_edge(dtype)
         sa = ak.SegArray(ak.array(seg_np), ak.array(val_np))
@@ -483,15 +483,15 @@ class TestSegArray:
         sa.set_jth(1, 1, 5)
         val_np[seg_np[1] + 1] = 5
         test_sa = ak.SegArray(ak.array(seg_np), ak.array(val_np))
-        assert val_np.tolist() == sa.values.to_list()
-        assert test_sa.to_list() == sa.to_list()
+        assert val_np.tolist() == sa.values.tolist()
+        assert test_sa.tolist() == sa.tolist()
 
         sa.set_jth(ak.array([1, 4]), 1, 11)
         val_np[seg_np[1] + 1] = 11
         val_np[seg_np[4] + 1] = 11
         test_sa = ak.SegArray(ak.array(seg_np), ak.array(val_np))
-        assert val_np.tolist() == sa.values.to_list()
-        assert test_sa.to_list() == sa.to_list()
+        assert val_np.tolist() == sa.values.tolist()
+        assert test_sa.tolist() == sa.tolist()
 
         with pytest.raises(ValueError):
             sa.set_jth(4, 4, 999)
@@ -502,8 +502,8 @@ class TestSegArray:
         sa = ak.SegArray(ak.array(seg_np), ak.array(val_np))
 
         elem, origin = sa.get_length_n(2)
-        assert [x.to_list() for x in elem] == [[sa[2][i]] for i in range(2)]
-        assert origin.to_list() == [True if sa[i].size == 2 else False for i in range(sa.size)]
+        assert [x.tolist() for x in elem] == [[sa[2][i]] for i in range(2)]
+        assert origin.tolist() == [True if sa[i].size == 2 else False for i in range(sa.size)]
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", DTYPES)
@@ -524,18 +524,18 @@ class TestSegArray:
 
         assert isinstance(result, ak.SegArray)
         assert result.size == (sa.size + edge_sa.size)
-        assert result.lengths.to_list() == (sa.lengths.to_list() + edge_sa.lengths.to_list())
-        assert result.segments.to_list() == np.concatenate([seg_np, edge_seg + val_np.size]).tolist()
-        assert result.values.to_list() == sa.values.to_list() + edge_sa.values.to_list()
-        assert result.to_list() == (sa.to_list() + edge_sa.to_list())
+        assert result.lengths.tolist() == (sa.lengths.tolist() + edge_sa.lengths.tolist())
+        assert result.segments.tolist() == np.concatenate([seg_np, edge_seg + val_np.size]).tolist()
+        assert result.values.tolist() == sa.values.tolist() + edge_sa.values.tolist()
+        assert result.tolist() == (sa.tolist() + edge_sa.tolist())
 
         result = edge_sa.append(sa)
         assert isinstance(result, ak.SegArray)
         assert result.size == (edge_sa.size + sa.size)
-        assert result.lengths.to_list() == (edge_sa.lengths.to_list() + sa.lengths.to_list())
-        assert result.segments.to_list() == np.concatenate([edge_seg, seg_np + edge_val.size]).tolist()
-        assert result.values.to_list() == edge_sa.values.to_list() + sa.values.to_list()
-        assert result.to_list() == (edge_sa.to_list() + sa.to_list())
+        assert result.lengths.tolist() == (edge_sa.lengths.tolist() + sa.lengths.tolist())
+        assert result.segments.tolist() == np.concatenate([edge_seg, seg_np + edge_val.size]).tolist()
+        assert result.values.tolist() == edge_sa.values.tolist() + sa.values.tolist()
+        assert result.tolist() == (edge_sa.tolist() + sa.tolist())
 
         # test axis=1
         if dtype != ak.str_:  # TODO - updated to run on strings once #2646 is complete
@@ -545,8 +545,8 @@ class TestSegArray:
             result = sa.append(sa2, axis=1)
             assert isinstance(result, ak.SegArray)
             assert result.size == sa.size
-            assert result.lengths.to_list() == (sa.lengths + sa2.lengths).to_list()
-            assert result.to_list() == [x + y for (x, y) in zip(sa.to_list(), sa2.to_list())]
+            assert result.lengths.tolist() == (sa.lengths + sa2.lengths).tolist()
+            assert result.tolist() == [x + y for (x, y) in zip(sa.tolist(), sa2.tolist())]
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", NO_STR)
@@ -559,21 +559,21 @@ class TestSegArray:
 
         assert isinstance(result, ak.SegArray)
         assert result.size == sa.size
-        assert result.lengths.to_list() == (sa.lengths + 1).to_list()
-        sa_list = sa.to_list()
+        assert result.lengths.tolist() == (sa.lengths + 1).tolist()
+        sa_list = sa.tolist()
         for i, s in enumerate(sa_list):
             s.append(to_append[i])
-        assert result.to_list() == sa_list
+        assert result.tolist() == sa_list
 
         # test single value
         to_append = self.get_append_scalar(dtype)
         result = sa.append_single(to_append)
         assert result.size == sa.size
-        assert result.lengths.to_list() == (sa.lengths + 1).to_list()
-        sa_list = sa.to_list()
+        assert result.lengths.tolist() == (sa.lengths + 1).tolist()
+        sa_list = sa.tolist()
         for s in sa_list:
             s.append(to_append)
-        assert result.to_list() == sa_list
+        assert result.tolist() == sa_list
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", NO_STR)
@@ -587,21 +587,21 @@ class TestSegArray:
 
         assert isinstance(result, ak.SegArray)
         assert result.size == sa.size
-        assert result.lengths.to_list() == (sa.lengths + 1).to_list()
-        sa_list = sa.to_list()
+        assert result.lengths.tolist() == (sa.lengths + 1).tolist()
+        sa_list = sa.tolist()
         for i, s in enumerate(sa_list):
             s.insert(0, to_prepend[i])
-        assert result.to_list() == sa_list
+        assert result.tolist() == sa_list
 
         # test single value
         to_prepend = self.get_append_scalar(dtype)
         result = sa.prepend_single(to_prepend)
         assert result.size == sa.size
-        assert result.lengths.to_list() == (sa.lengths + 1).to_list()
-        sa_list = sa.to_list()
+        assert result.lengths.tolist() == (sa.lengths + 1).tolist()
+        sa_list = sa.tolist()
         for s in sa_list:
             s.insert(0, to_prepend)
-        assert result.to_list() == sa_list
+        assert result.tolist() == sa_list
 
     @pytest.mark.parametrize("dtype", DTYPES)
     def test_remove_repeats(self, dtype):
@@ -618,8 +618,8 @@ class TestSegArray:
         flat = ak.array(a + b)
         sa = ak.SegArray(segments, flat)
         result = sa.remove_repeats()
-        assert [0, len(exp_a)] == result.segments.to_list()
-        assert np.concatenate([exp_a, exp_b]).tolist() == result.values.to_list()
+        assert [0, len(exp_a)] == result.segments.tolist()
+        assert np.concatenate([exp_a, exp_b]).tolist() == result.values.tolist()
 
         # test empty segments
         # TODO - update line below to segments = ak.array([0, 0, len(a), len(a), len(a), len(a)+len(b)])
@@ -634,8 +634,8 @@ class TestSegArray:
             len(exp_a),
             len(exp_a),
             len(exp_a) + len(exp_b),
-        ] == result.segments.to_list()
-        assert np.concatenate([exp_a, exp_b]).tolist() == result.values.to_list()
+        ] == result.segments.tolist()
+        assert np.concatenate([exp_a, exp_b]).tolist() == result.values.tolist()
 
     @pytest.mark.parametrize("dtype", NO_FLOAT_STR)
     @pytest.mark.parametrize("op", SETOPS)
@@ -653,10 +653,10 @@ class TestSegArray:
         np_func = getattr(np, f"{op}1d")
         exp_1 = np_func(np.array(a), np.array(c))
         exp_2 = np_func(np.array(b), np.array(d))
-        assert result.segments.to_list() == [0, len(exp_1)]
-        assert result.values.to_list() == np.concatenate([exp_1, exp_2]).tolist()
+        assert result.segments.tolist() == [0, len(exp_1)]
+        assert result.values.tolist() == np.concatenate([exp_1, exp_2]).tolist()
         exp_sa = ak.SegArray(ak.array([0, len(exp_1)]), ak.array(np.concatenate([exp_1, exp_2])))
-        assert result.to_list() == exp_sa.to_list()
+        assert result.tolist() == exp_sa.tolist()
 
         # TODO - empty segments testing
 
@@ -679,11 +679,11 @@ class TestSegArray:
         segarr = ak.SegArray(segments, akflat)
 
         assert isinstance(segarr, ak.SegArray)
-        assert segarr.lengths.to_list() == [2, 2, 1]
-        assert segarr[0].to_list() == a
-        assert segarr[1].to_list() == b
-        assert segarr[2].to_list() == c
-        assert segarr[ak.array([1, 2])].values.to_list() == b + c
+        assert segarr.lengths.tolist() == [2, 2, 1]
+        assert segarr[0].tolist() == a
+        assert segarr[1].tolist() == b
+        assert segarr[2].tolist() == c
+        assert segarr[ak.array([1, 2])].values.tolist() == b + c
         assert segarr.__eq__(ak.array([1])) == NotImplemented
         assert segarr.__eq__(segarr).all()
         assert segarr._non_empty_count == 3
@@ -728,7 +728,7 @@ class TestSegArray:
         # ensure 2 does not exist in return values
         assert (filter_result.values != f).all()
         for i in range(sa.size):
-            assert sa[i][(sa[i] != f)].to_list() == filter_result[i].to_list()
+            assert sa[i][(sa[i] != f)].tolist() == filter_result[i].tolist()
 
         # test list filter
         fl = self.get_filter_list(dtype)
@@ -740,7 +740,7 @@ class TestSegArray:
         for i in range(sa.size):
             x = ak.in1d(ak.array(sa[i]), ak.array(fl), invert=True)
             v = ak.array(sa[i])[x]
-            assert v.to_list() == filter_result[i].to_list()
+            assert v.tolist() == filter_result[i].tolist()
 
         # test pdarray filter
         filter_result = sa.filter(ak.array(fl), discard_empty=False)
@@ -751,7 +751,7 @@ class TestSegArray:
         for i in range(sa.size):
             x = ak.in1d(ak.array(sa[i]), ak.array(fl), invert=True)
             v = ak.array(sa[i])[x]
-            assert v.to_list() == filter_result[i].to_list()
+            assert v.tolist() == filter_result[i].tolist()
 
         # test dropping empty segments
         fl = list(set(a))
@@ -764,7 +764,7 @@ class TestSegArray:
             x = ak.in1d(ak.array(sa[i]), ak.array(fl), invert=True)
             v = ak.array(sa[i])[x]
             if v.size != 0:
-                assert v.to_list() == filter_result[i - offset].to_list()
+                assert v.tolist() == filter_result[i - offset].tolist()
             else:
                 offset += 1
 
@@ -781,7 +781,7 @@ class TestSegArray:
 
         s1 = ak.SegArray(ak.array([0, 4, 14, 14]), ak.arange(-10, 10))
         s2 = ak.SegArray(ak.array([0, 9, 14, 14]), ak.arange(-10, 10))
-        assert (s1 == s2).to_list() == [False, False, True, True]
+        assert (s1 == s2).tolist() == [False, False, True, True]
 
         # test segarrays with empty segments, multiple types, and edge cases
         df = ak.DataFrame(

--- a/tests/numpy/setops_test.py
+++ b/tests/numpy/setops_test.py
@@ -167,7 +167,7 @@ class TestSetOps:
         lb = list(zip(b, d))
         lr = [x in lb for x in la]
 
-        assert ak_result.to_list() == lr
+        assert ak_result.tolist() == lr
 
     @pytest.mark.parametrize("dtype1", INTEGRAL_TYPES)
     @pytest.mark.parametrize("dtype2", INTEGRAL_TYPES)
@@ -182,7 +182,7 @@ class TestSetOps:
         lb = list(zip(c, d))
         lr = [x in lb for x in la]
 
-        assert ak_result.to_list() == lr
+        assert ak_result.tolist() == lr
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_in1d_multiarray_str(self, size):
@@ -200,14 +200,14 @@ class TestSetOps:
 
         ak_result = ak.in1d(l1, l2)
 
-        la = list(zip(a.to_list(), b.to_list()))
-        lb = list(zip(c.to_list(), d.to_list()))
+        la = list(zip(a.tolist(), b.tolist()))
+        lb = list(zip(c.tolist(), d.tolist()))
         lr = [x in lb for x in la]
-        assert ak_result.to_list() == lr
+        assert ak_result.tolist() == lr
 
         stringsOne = ak.array(["String {}".format(i % 3) for i in range(10)])
         stringsTwo = ak.array(["String {}".format(i % 2) for i in range(10)])
-        assert [(x % 3) < 2 for x in range(10)] == ak.in1d(stringsOne, stringsTwo).to_list()
+        assert [(x % 3) < 2 for x in range(10)] == ak.in1d(stringsOne, stringsTwo).tolist()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_in1d_multiarray_categorical(self, size):
@@ -225,14 +225,14 @@ class TestSetOps:
 
         ak_result = ak.in1d(l1, l2)
 
-        la = list(zip(a.to_list(), b.to_list()))
-        lb = list(zip(c.to_list(), d.to_list()))
+        la = list(zip(a.tolist(), b.tolist()))
+        lb = list(zip(c.tolist(), d.tolist()))
         lr = [x in lb for x in la]
-        assert ak_result.to_list() == lr
+        assert ak_result.tolist() == lr
 
         stringsOne = ak.Categorical(ak.array(["String {}".format(i % 3) for i in range(10)]))
         stringsTwo = ak.Categorical(ak.array(["String {}".format(i % 2) for i in range(10)]))
-        assert [(x % 3) < 2 for x in range(10)] == ak.in1d(stringsOne, stringsTwo).to_list()
+        assert [(x % 3) < 2 for x in range(10)] == ak.in1d(stringsOne, stringsTwo).tolist()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", INTEGRAL_TYPES)
@@ -248,7 +248,7 @@ class TestSetOps:
         la = set(zip(a, c))
         lb = set(zip(b, d))
         lr = sorted(la.intersection(lb))
-        ak_result = [x.to_list() for x in ak_result]
+        ak_result = [x.tolist() for x in ak_result]
         ak_result = list(zip(*ak_result))
         assert ak_result == lr
 
@@ -265,7 +265,7 @@ class TestSetOps:
         lb = set(zip(c, d))
         lr = sorted(la.intersection(lb))
 
-        ak_result = [x.to_list() for x in ak_result]
+        ak_result = [x.tolist() for x in ak_result]
         # sorting applied for bigint case. Numbers are right, but not ordering properly
         ak_result = sorted(list(zip(*ak_result)))
         assert ak_result == lr
@@ -286,10 +286,10 @@ class TestSetOps:
 
         ak_result = ak.intersect1d(l1, l2)
 
-        la = set(zip(a.to_list(), b.to_list()))
-        lb = set(zip(c.to_list(), d.to_list()))
+        la = set(zip(a.tolist(), b.tolist()))
+        lb = set(zip(c.tolist(), d.tolist()))
         lr = sorted(la.intersection(lb))
-        ak_result = [x.to_list() for x in ak_result]
+        ak_result = [x.tolist() for x in ak_result]
         ak_result = sorted(list(zip(*ak_result)))
         assert ak_result == lr
 
@@ -303,8 +303,8 @@ class TestSetOps:
         b1 = ak.array(c)
         b2 = ak.array(d)
         t = ak.intersect1d([a1, a2], [b1, b2])
-        assert ["def"] == t[0].to_list()
-        assert ["456"] == t[1].to_list()
+        assert ["def"] == t[0].tolist()
+        assert ["456"] == t[1].tolist()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_intersect1d_multiarray_categorical(self, size):
@@ -322,10 +322,10 @@ class TestSetOps:
 
         ak_result = ak.intersect1d(l1, l2)
 
-        la = set(zip(a.to_list(), b.to_list()))
-        lb = set(zip(c.to_list(), d.to_list()))
+        la = set(zip(a.tolist(), b.tolist()))
+        lb = set(zip(c.tolist(), d.tolist()))
         lr = sorted(la.intersection(lb))
-        ak_result = [x.to_list() for x in ak_result]
+        ak_result = [x.tolist() for x in ak_result]
         ak_result = list(zip(*ak_result))
         assert ak_result == lr
 
@@ -339,8 +339,8 @@ class TestSetOps:
         b1 = ak.Categorical(ak.array(c))
         b2 = ak.Categorical(ak.array(d))
         t = ak.intersect1d([a1, a2], [b1, b2])
-        assert ["def"] == t[0].to_list()
-        assert ["456"] == t[1].to_list()
+        assert ["def"] == t[0].tolist()
+        assert ["456"] == t[1].tolist()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", NUMERIC_TYPES)
@@ -356,7 +356,7 @@ class TestSetOps:
         la = set(zip(a, c))
         lb = set(zip(b, d))
         lr = sorted(la.union(lb))
-        ak_result = [x.to_list() for x in ak_result]
+        ak_result = [x.tolist() for x in ak_result]
         ak_result = list(zip(*ak_result))
         assert ak_result == lr
 
@@ -373,7 +373,7 @@ class TestSetOps:
         lb = set(zip(c, d))
         lr = sorted(la.union(lb))
 
-        ak_result = [x.to_list() for x in ak_result]
+        ak_result = [x.tolist() for x in ak_result]
         # sorting applied for bigint case. Numbers are right, but not ordering properly
         ak_result = sorted(list(zip(*ak_result)))
         assert ak_result == lr
@@ -392,10 +392,10 @@ class TestSetOps:
 
         ak_result = ak.union1d(l1, l2)
 
-        la = set(zip(a.to_list(), b.to_list()))
-        lb = set(zip(c.to_list(), d.to_list()))
+        la = set(zip(a.tolist(), b.tolist()))
+        lb = set(zip(c.tolist(), d.tolist()))
         lr = sorted(la.union(lb))
-        ak_result = [x.to_list() for x in ak_result]
+        ak_result = [x.tolist() for x in ak_result]
         ak_result = list(zip(*ak_result))
         # because strings are grouped not sorted we are verifying the tuple exists
         for x in ak_result:
@@ -411,8 +411,8 @@ class TestSetOps:
         b1 = ak.array(c)
         b2 = ak.array(d)
         t = ak.union1d([a1, a2], [b1, b2])
-        assert len({"xyz", "def", "abc"}.symmetric_difference(t[0].to_list())) == 0
-        assert len({"0", "456", "123"}.symmetric_difference(t[1].to_list())) == 0
+        assert len({"xyz", "def", "abc"}.symmetric_difference(t[0].tolist())) == 0
+        assert len({"0", "456", "123"}.symmetric_difference(t[1].tolist())) == 0
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_union1d_many_strings(self, size):
@@ -456,10 +456,10 @@ class TestSetOps:
 
         ak_result = ak.union1d(l1, l2)
 
-        la = set(zip(a.to_list(), b.to_list()))
-        lb = set(zip(c.to_list(), d.to_list()))
+        la = set(zip(a.tolist(), b.tolist()))
+        lb = set(zip(c.tolist(), d.tolist()))
         lr = sorted(la.union(lb))
-        ak_result = [x.to_list() for x in ak_result]
+        ak_result = [x.tolist() for x in ak_result]
         ak_result = list(zip(*ak_result))
         # because strings are grouped not sorted we are verifying the tuple exists
         for x in ak_result:
@@ -478,8 +478,8 @@ class TestSetOps:
         cat_b1 = ak.Categorical(b1)
         cat_b2 = ak.Categorical(b2)
         t = ak.union1d([cat_a1, cat_a2], [cat_b1, cat_b2])
-        assert ["abc", "def", "xyz"] == t[0].to_list()
-        assert ["123", "456", "0"] == t[1].to_list()
+        assert ["abc", "def", "xyz"] == t[0].tolist()
+        assert ["123", "456", "0"] == t[1].tolist()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", INTEGRAL_TYPES)
@@ -496,7 +496,7 @@ class TestSetOps:
         lb = set(zip(b, d))
         lr = sorted(la.symmetric_difference(lb))
 
-        ak_result = [x.to_list() for x in ak_result]
+        ak_result = [x.tolist() for x in ak_result]
         ak_result = list(zip(*ak_result))
         assert ak_result == lr
 
@@ -513,7 +513,7 @@ class TestSetOps:
         lb = set(zip(c, d))
         lr = sorted(la.symmetric_difference(lb))
 
-        ak_result = [x.to_list() for x in ak_result]
+        ak_result = [x.tolist() for x in ak_result]
         # sorting applied for bigint case. Numbers are right, but not ordering properly
         ak_result = sorted(list(zip(*ak_result)))
         assert ak_result == lr
@@ -532,10 +532,10 @@ class TestSetOps:
 
         ak_result = ak.setxor1d(l1, l2)
 
-        la = set(zip(a.to_list(), b.to_list()))
-        lb = set(zip(c.to_list(), d.to_list()))
+        la = set(zip(a.tolist(), b.tolist()))
+        lb = set(zip(c.tolist(), d.tolist()))
         lr = sorted(la.symmetric_difference(lb))
-        ak_result = [x.to_list() for x in ak_result]
+        ak_result = [x.tolist() for x in ak_result]
         ak_result = list(zip(*ak_result))
         # because strings are grouped not sorted we are verifying the tuple exists
         for x in ak_result:
@@ -551,8 +551,8 @@ class TestSetOps:
         b1 = ak.array(c)
         b2 = ak.array(d)
         t = ak.setxor1d([a1, a2], [b1, b2])
-        assert ["abc", "abc"] == t[0].to_list()
-        assert ["000", "123"] == t[1].to_list()
+        assert ["abc", "abc"] == t[0].tolist()
+        assert ["000", "123"] == t[1].tolist()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_setxor1d_multiarray_categorical(self, size):
@@ -568,10 +568,10 @@ class TestSetOps:
 
         ak_result = ak.setxor1d(l1, l2)
 
-        la = set(zip(a.to_list(), b.to_list()))
-        lb = set(zip(c.to_list(), d.to_list()))
+        la = set(zip(a.tolist(), b.tolist()))
+        lb = set(zip(c.tolist(), d.tolist()))
         lr = sorted(la.symmetric_difference(lb))
-        ak_result = [x.to_list() for x in ak_result]
+        ak_result = [x.tolist() for x in ak_result]
         ak_result = list(zip(*ak_result))
         # because strings are grouped not sorted we are verifying the tuple exists
         for x in ak_result:
@@ -587,8 +587,8 @@ class TestSetOps:
         b1 = ak.Categorical(ak.array(c))
         b2 = ak.Categorical(ak.array(d))
         t = ak.setxor1d([a1, a2], [b1, b2])
-        assert ["abc", "abc"] == t[0].to_list()
-        assert ["000", "123"] == t[1].to_list()
+        assert ["abc", "abc"] == t[0].tolist()
+        assert ["000", "123"] == t[1].tolist()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", INTEGRAL_TYPES)
@@ -605,7 +605,7 @@ class TestSetOps:
         lb = set(zip(b, d))
         lr = sorted(la.difference(lb))
 
-        ak_result = [x.to_list() for x in ak_result]
+        ak_result = [x.tolist() for x in ak_result]
         ak_result = list(zip(*ak_result))
         assert ak_result == lr
 
@@ -622,7 +622,7 @@ class TestSetOps:
         lb = set(zip(c, d))
         lr = sorted(la.difference(lb))
 
-        ak_result = [x.to_list() for x in ak_result]
+        ak_result = [x.tolist() for x in ak_result]
         # sorting applied for bigint case. Numbers are right, but not ordering properly
         ak_result = sorted(list(zip(*ak_result)))
         assert ak_result == lr
@@ -641,10 +641,10 @@ class TestSetOps:
 
         ak_result = ak.setdiff1d(l1, l2)
 
-        la = set(zip(a.to_list(), b.to_list()))
-        lb = set(zip(c.to_list(), d.to_list()))
+        la = set(zip(a.tolist(), b.tolist()))
+        lb = set(zip(c.tolist(), d.tolist()))
         lr = sorted(la.difference(lb))
-        ak_result = [x.to_list() for x in ak_result]
+        ak_result = [x.tolist() for x in ak_result]
         ak_result = list(zip(*ak_result))
         # because strings are grouped not sorted we are verifying the tuple exists
         for x in ak_result:
@@ -660,8 +660,8 @@ class TestSetOps:
         b1 = ak.array(c)
         b2 = ak.array(d)
         t = ak.setdiff1d([a1, a2], [b1, b2])
-        assert ["abc"] == t[0].to_list()
-        assert ["123"] == t[1].to_list()
+        assert ["abc"] == t[0].tolist()
+        assert ["123"] == t[1].tolist()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_setdiff1d_multiarray_categorical(self, size):
@@ -677,10 +677,10 @@ class TestSetOps:
 
         ak_result = ak.setdiff1d(l1, l2)
 
-        la = set(zip(a.to_list(), b.to_list()))
-        lb = set(zip(c.to_list(), d.to_list()))
+        la = set(zip(a.tolist(), b.tolist()))
+        lb = set(zip(c.tolist(), d.tolist()))
         lr = sorted(la.difference(lb))
-        ak_result = [x.to_list() for x in ak_result]
+        ak_result = [x.tolist() for x in ak_result]
         ak_result = list(zip(*ak_result))
         # because strings are grouped not sorted we are verifying the tuple exists
         for x in ak_result:
@@ -696,8 +696,8 @@ class TestSetOps:
         b1 = ak.Categorical(ak.array(c))
         b2 = ak.Categorical(ak.array(d))
         t = ak.setdiff1d([a1, a2], [b1, b2])
-        assert ["abc"] == t[0].to_list()
-        assert ["123"] == t[1].to_list()
+        assert ["abc"] == t[0].tolist()
+        assert ["123"] == t[1].tolist()
 
     def test_multiarray_validation(self):
         x = [ak.arange(3), ak.arange(3), ak.arange(3)]
@@ -719,7 +719,7 @@ class TestSetOps:
     def test_index_of(self):
         # index of nan (reproducer from #3009)
         s = ak.Series(ak.array([1, 2, 3]), index=ak.array([1, 2, np.nan]))
-        assert ak.indexof1d(ak.array([np.nan]), s.index.values).to_list() == [2]
+        assert ak.indexof1d(ak.array([np.nan]), s.index.values).tolist() == [2]
         rng = np.random.default_rng()
         seeds = [
             rng.choice(2**63),
@@ -781,11 +781,11 @@ class TestSetOps:
             arr2_keys = ak.GroupBy(arr2).unique_keys
             in_both = ak.intersect1d(arr1_keys, arr2_keys)
 
-            for i in in_both.to_list():
+            for i in in_both.tolist():
                 pd_i = pd_s[i]
                 ak_i = ak_s[i]
                 if isinstance(pd_i, pd.Series):
                     assert isinstance(ak_i, ak.Series)
-                    assert pd_i.values.tolist() == ak_i.values.to_list()
+                    assert pd_i.values.tolist() == ak_i.values.tolist()
                 else:
                     assert pd_i == ak_i

--- a/tests/numpy/sort_test.py
+++ b/tests/numpy/sort_test.py
@@ -78,7 +78,7 @@ class TestSort:
             pda_bigint = pda + 2**200
             sorted_pda = ak.sort(pda, algo)
             sorted_bi = ak.sort(pda_bigint, algo)
-            assert (sorted_bi - 2**200).to_list() == sorted_pda.to_list()
+            assert (sorted_bi - 2**200).tolist() == sorted_pda.tolist()
 
     @pytest.mark.parametrize("algo", SortingAlgorithm)
     def test_bit_boundary_hardcode(self, algo):

--- a/tests/numpy/string_test.py
+++ b/tests/numpy/string_test.py
@@ -136,7 +136,7 @@ class TestString:
         # Unique keys should be same result as ak.unique
         assert akset == set(g.unique_keys.to_ndarray())
         assert akset == set(gc.unique_keys.to_ndarray())
-        assert gc.permutation.to_list() == g.permutation.to_list()
+        assert gc.permutation.tolist() == g.permutation.tolist()
         permStrings = strings[g.permutation].to_ndarray()
         # Check each group individually
         lengths = np.diff(np.hstack((g.segments.to_ndarray(), np.array([g.length]))))
@@ -405,8 +405,8 @@ class TestString:
         # Convert Pandas series of strings into a byte array where each string is terminated
         # by a null byte.
         # This mimics what should be stored server-side in the strings.bytes pdarray
-        expected_series_dec = self.convert_to_ord(series.to_list())
-        actual_dec = pda._comp_to_ndarray("values").tolist()  # pda.bytes.to_list()
+        expected_series_dec = self.convert_to_ord(series.tolist())
+        actual_dec = pda._comp_to_ndarray("values").tolist()  # pda.bytes.tolist()
         assert expected_series_dec == actual_dec
 
         # Now perform the peel and verify
@@ -422,15 +422,15 @@ class TestString:
         series = pd.Series([f"abc{d}xyz", f"small{d}dog", f"blue{d}hat", "last"])
         pda = ak.from_series(series)
         a, b = pda.peel(d)
-        assert ["abc", "small", "blue", ""] == a.to_list()
-        assert ["xyz", "dog", "hat", "last"] == b.to_list()
+        assert ["abc", "small", "blue", ""] == a.tolist()
+        assert ["xyz", "dog", "hat", "last"] == b.tolist()
 
         # Try a slight permutation since we were able to get both versions to fail at one point
         series = pd.Series([f"abc{d}xyz", f"small{d}dog", "last"])
         pda = ak.from_series(series)
         a, b = pda.peel(d)
-        assert ["abc", "small", ""] == a.to_list()
-        assert ["xyz", "dog", "last"] == b.to_list()
+        assert ["abc", "small", ""] == a.tolist()
+        assert ["xyz", "dog", "last"] == b.tolist()
 
     @staticmethod
     def _stick_help(strings, test_strings, base_words, delim, size):
@@ -477,51 +477,51 @@ class TestString:
     def test_split(self):
         orig = ak.array(["one|two", "three|four|five", "six"])
         flat, mapping = orig.split("|", return_segments=True)
-        assert flat.to_list() == ["one", "two", "three", "four", "five", "six"]
-        assert mapping.to_list() == [0, 2, 5]
+        assert flat.tolist() == ["one", "two", "three", "four", "five", "six"]
+        assert mapping.tolist() == [0, 2, 5]
         thirds = [ak.cast(ak.arange(i, 99, 3), "str") for i in range(3)]
         thickrange = thirds[0].stick(thirds[1], delimiter=", ").stick(thirds[2], delimiter=", ")
         flatrange = thickrange.split(", ")
-        assert ak.cast(flatrange, "int64").to_list(), np.arange(99).tolist()
+        assert ak.cast(flatrange, "int64").tolist(), np.arange(99).tolist()
 
     def test_get_lengths(self):
         base = ["one", "two", "three", "four", "five"]
         s1 = ak.array(base)
         lengths = s1.get_lengths()
-        assert [len(x) for x in base] == lengths.to_list()
+        assert [len(x) for x in base] == lengths.tolist()
 
     def test_strip(self):
         s = ak.array([" Jim1", "John1   ", "Steve1 2"])
-        assert s.strip(" 12").to_list() == ["Jim", "John", "Steve"]
-        assert s.strip("12 ").to_list() == ["Jim", "John", "Steve"]
-        assert s.strip("1 2").to_list() == ["Jim", "John", "Steve"]
+        assert s.strip(" 12").tolist() == ["Jim", "John", "Steve"]
+        assert s.strip("12 ").tolist() == ["Jim", "John", "Steve"]
+        assert s.strip("1 2").tolist() == ["Jim", "John", "Steve"]
 
         s = ak.array([" Jim", "John 1", "Steve1 2  "])
-        assert s.strip().to_list() == ["Jim", "John 1", "Steve1 2"]
+        assert s.strip().tolist() == ["Jim", "John 1", "Steve1 2"]
 
         s = ak.array(["\nStrings ", " \n StringS \r", "bbabStringS \r\t "])
-        assert s.strip().to_list() == ["Strings", "StringS", "bbabStringS"]
+        assert s.strip().tolist() == ["Strings", "StringS", "bbabStringS"]
 
         s = ak.array(["abcStringsbac", "cabStringScc", "bbabStringS abc"])
-        assert s.strip("abc").to_list() == ["Strings", "StringS", "StringS "]
+        assert s.strip("abc").tolist() == ["Strings", "StringS", "StringS "]
 
         s = ak.array(["\nStrings ", " \n StringS \r", " \t   StringS \r\t "])
-        assert s.strip().to_list() == ["Strings", "StringS", "StringS"]
+        assert s.strip().tolist() == ["Strings", "StringS", "StringS"]
 
     def test_case_change(self):
         mixed = ak.array([f"StrINgS hErE {i}" for i in range(10)])
 
         lower = mixed.lower()
-        assert lower.to_list() == [f"strings here {i}" for i in range(10)]
+        assert lower.tolist() == [f"strings here {i}" for i in range(10)]
 
         upper = mixed.upper()
-        assert upper.to_list() == [f"STRINGS HERE {i}" for i in range(10)]
+        assert upper.tolist() == [f"STRINGS HERE {i}" for i in range(10)]
 
         title = mixed.title()
-        assert title.to_list() == [f"Strings Here {i}" for i in range(10)]
+        assert title.tolist() == [f"Strings Here {i}" for i in range(10)]
 
         capital = mixed.capitalize()
-        assert capital.to_list() == [f"Strings here {i}" for i in range(10)]
+        assert capital.tolist() == [f"Strings here {i}" for i in range(10)]
 
         # first 10 all lower, second 10 mixed case (not lower, upper, or title), third 10 all upper,
         # last 10 all title
@@ -529,27 +529,27 @@ class TestString:
 
         islower = lmut.islower()
         expected = 10 > ak.arange(40)
-        assert islower.to_list() == expected.to_list()
+        assert islower.tolist() == expected.tolist()
 
         isupper = lmut.isupper()
         expected = (30 > ak.arange(40)) & (ak.arange(40) >= 20)
-        assert isupper.to_list() == expected.to_list()
+        assert isupper.tolist() == expected.tolist()
 
         istitle = lmut.istitle()
         expected = ak.arange(40) >= 30
-        assert istitle.to_list() == expected.to_list()
+        assert istitle.tolist() == expected.tolist()
 
     def test_string_isalnum(self):
         not_alnum = ak.array([f"%Strings {i}" for i in range(3)])
         alnum = ak.array([f"Strings{i}" for i in range(3)])
         example = ak.concatenate([not_alnum, alnum])
-        assert example.isalnum().to_list() == [False, False, False, True, True, True]
+        assert example.isalnum().tolist() == [False, False, False, True, True, True]
 
     def test_string_isalpha(self):
         not_alpha = ak.array([f"%Strings {i}" for i in range(3)])
         alpha = ak.array(["StringA", "StringB", "StringC"])
         example = ak.concatenate([not_alpha, alpha])
-        assert example.isalpha().to_list() == [False, False, False, True, True, True]
+        assert example.isalpha().tolist() == [False, False, False, True, True, True]
 
         example2 = ak.array(
             [
@@ -581,13 +581,13 @@ class TestString:
             False,
         ]
 
-        assert example2.isalpha().to_list() == expected
+        assert example2.isalpha().tolist() == expected
 
     def test_string_isdecimal(self):
         not_decimal = ak.array([f"Strings {i}" for i in range(3)])
         decimal = ak.array([f"12{i}" for i in range(3)])
         example = ak.concatenate([not_decimal, decimal])
-        assert example.isdecimal().to_list() == [False, False, False, True, True, True]
+        assert example.isdecimal().tolist() == [False, False, False, True, True, True]
 
         example2 = ak.array(
             [
@@ -623,13 +623,13 @@ class TestString:
             False,
         ]
 
-        assert example2.isdecimal().to_list() == expected
+        assert example2.isdecimal().tolist() == expected
 
     def test_string_isdigit(self):
         not_digit = ak.array([f"Strings {i}" for i in range(3)])
         digit = ak.array([f"12{i}" for i in range(3)])
         example = ak.concatenate([not_digit, digit])
-        assert example.isdigit().to_list() == [False, False, False, True, True, True]
+        assert example.isdigit().tolist() == [False, False, False, True, True, True]
 
         example2 = ak.array(
             [
@@ -665,14 +665,14 @@ class TestString:
             False,
         ]
 
-        assert example2.isdigit().to_list() == expected
+        assert example2.isdigit().tolist() == expected
 
     def test_string_empty(self):
         not_empty = ak.array([f"Strings {i}" for i in range(3)])
         empty = ak.array(["" for i in range(3)])
         example = ak.concatenate([not_empty, empty])
 
-        assert example.isempty().to_list() == [False, False, False, True, True, True]
+        assert example.isempty().tolist() == [False, False, False, True, True, True]
 
         example2 = ak.array(
             [
@@ -704,13 +704,13 @@ class TestString:
             False,
         ]
 
-        assert example2.isempty().to_list() == expected
+        assert example2.isempty().tolist() == expected
 
     def test_string_isspace(self):
         not_space = ak.array([f"Strings {i}" for i in range(3)])
         space = ak.array([" ", "\t", "\n", "\v", "\f", "\r", " \t\n\v\f\r"])
         example = ak.concatenate([not_space, space])
-        assert example.isspace().to_list() == [
+        assert example.isspace().tolist() == [
             False,
             False,
             False,
@@ -753,7 +753,7 @@ class TestString:
             False,
         ]
 
-        assert example2.isspace().to_list() == expected
+        assert example2.isspace().tolist() == expected
 
     def test_where(self):
         revs = ak.arange(10) % 2 == 0
@@ -762,21 +762,21 @@ class TestString:
         # SegString and str literal
         str_lit = "str 1222222"
         ans = ak.where(revs, s1, str_lit)
-        assert s1[revs].to_list() == ans[revs].to_list()
-        for s in ans[~revs].to_list():
+        assert s1[revs].tolist() == ans[revs].tolist()
+        for s in ans[~revs].tolist():
             assert s == str_lit
 
         # str literal first
         ans = ak.where(revs, str_lit, s1)
-        assert s1[~revs].to_list() == ans[~revs].to_list()
-        for s in ans[revs].to_list():
+        assert s1[~revs].tolist() == ans[~revs].tolist()
+        for s in ans[revs].tolist():
             assert s == str_lit
 
         # 2 SegStr
         s2 = ak.array([f"str {i * 2}" for i in range(10)])
         ans = ak.where(revs, s1, s2)
-        assert s1[revs].to_list() == ans[revs].to_list()
-        assert s2[~revs].to_list() == ans[~revs].to_list()
+        assert s1[revs].tolist() == ans[revs].tolist()
+        assert s2[~revs].tolist() == ans[~revs].tolist()
 
     @staticmethod
     def _get_strings(prefix: str = "string", size: int = 11) -> ak.Strings:
@@ -811,7 +811,7 @@ class TestString:
 
         # Ordered concatenation
         s12ord = ak.concatenate([s1, s2], ordered=True)
-        assert expected_result == s12ord.to_list()
+        assert expected_result == s12ord.tolist()
         # Unordered (but still deterministic) concatenation
         # TODO: the unordered concatenation test is disabled per #710 #721
         # s12unord = ak.concatenate([s1, s2], ordered=False)
@@ -821,26 +821,26 @@ class TestString:
         strings = ak.array(a)
         for n in 1, 3:  # test multiple sizes of suffix and prefix
             prefix, origin = strings.get_prefixes(n, return_origins=True, proper=True)
-            assert [x[0:n] for x in a if len(x) > n] == prefix.to_list()
+            assert [x[0:n] for x in a if len(x) > n] == prefix.tolist()
             assert [True if len(x) > n else False for x in a]
 
             prefix, origin = strings.get_prefixes(n, return_origins=True, proper=False)
-            assert [x[0:n] for x in a if len(x) >= n] == prefix.to_list()
+            assert [x[0:n] for x in a if len(x) >= n] == prefix.tolist()
             assert [True if len(x) >= n else False for x in a]
 
             prefix = strings.get_prefixes(n, return_origins=False, proper=False)
-            assert [x[0:n] for x in a if len(x) >= n] == prefix.to_list()
+            assert [x[0:n] for x in a if len(x) >= n] == prefix.tolist()
 
             suffix, origin = strings.get_suffixes(n, return_origins=True, proper=True)
-            assert [x[len(x) - n :] for x in a if len(x) > n] == suffix.to_list()
+            assert [x[len(x) - n :] for x in a if len(x) > n] == suffix.tolist()
             assert [True if len(x) >= n else False for x in a]
 
             suffix, origin = strings.get_suffixes(n, return_origins=True, proper=False)
-            assert [x[len(x) - n :] for x in a if len(x) >= n] == suffix.to_list()
+            assert [x[len(x) - n :] for x in a if len(x) >= n] == suffix.tolist()
             assert [True if len(x) >= n else False for x in a]
 
             suffix = strings.get_suffixes(n, return_origins=False, proper=False)
-            assert [x[len(x) - n :] for x in a if len(x) >= n] == suffix.to_list()
+            assert [x[len(x) - n :] for x in a if len(x) >= n] == suffix.tolist()
 
     def test_encoding(self):
         idna_strings = ak.array(
@@ -860,13 +860,13 @@ class TestString:
         a1 = ["münchen", "zürich"]
         s1 = ak.array(a1)
         result = s1.encode("idna")
-        assert [i.encode("idna").decode("ascii") for i in a1] == result.to_list()
+        assert [i.encode("idna").decode("ascii") for i in a1] == result.tolist()
 
         # validate encoding with empty string
         e = ["", "abc", "", "123"]
         ak_e = ak.array(e)
         result = ak_e.encode("idna")
-        assert [i.encode("idna").decode("ascii") for i in e] == result.to_list()
+        assert [i.encode("idna").decode("ascii") for i in e] == result.tolist()
 
         a2 = [
             "xn--mnchen-3ya",
@@ -878,7 +878,7 @@ class TestString:
         s2 = ak.array(a2)
         result = s2.decode("idna")
         # using the below assertion due to a bug in `Strings.to_ndarray`. See issue #1828
-        assert ["münchen", "zürich", "", "", "example.com"] == result.to_list()
+        assert ["münchen", "zürich", "", "", "example.com"] == result.tolist()
 
         a3 = ak.random_strings_uniform(1, 10, 100 // 4, characters="printable")
         assert (a3 == a3.encode("ascii").decode("ascii")).all()
@@ -892,7 +892,7 @@ class TestString:
 
         # roundtrip to return back to decoded values in UTF-8
         decoded = result.decode(fromEncoding="utf-16", toEncoding="utf-8")
-        assert ["münchen", "zürich", "example.com"] == decoded.to_list()
+        assert ["münchen", "zürich", "example.com"] == decoded.tolist()
 
     def test_tondarray(self):
         v1 = ["münchen", "zürich", "abc", "123", ""]

--- a/tests/numpy/util_test.py
+++ b/tests/numpy/util_test.py
@@ -99,37 +99,35 @@ class TestUtil:
         d = ak.Categorical(a)
 
         result = map(a, {"4": 25, "5": 30, "1": 7})
-        assert result.to_list() == [7, 7, 25, 25, 25]
+        assert result.tolist() == [7, 7, 25, 25, 25]
 
         result = map(a, {"1": 7})
-        assert (
-            result.to_list() == ak.cast(ak.array([7, 7, np.nan, np.nan, np.nan]), dt=ak.int64).to_list()
-        )
+        assert result.tolist() == ak.cast(ak.array([7, 7, np.nan, np.nan, np.nan]), dt=ak.int64).tolist()
 
         result = map(a, {"1": 7.0})
-        assert np.allclose(result.to_list(), [7.0, 7.0, np.nan, np.nan, np.nan], equal_nan=True)
+        assert np.allclose(result.tolist(), [7.0, 7.0, np.nan, np.nan, np.nan], equal_nan=True)
 
         result = map(b, {4: 25.0, 2: 30.0, 1: 7.0, 3: 5.0})
-        assert result.to_list() == [30.0, 5.0, 30.0, 5.0, 25.0]
+        assert result.tolist() == [30.0, 5.0, 30.0, 5.0, 25.0]
 
         result = map(c, {1.0: "a", 2.2: "b", 4.4: "c", 5.0: "d"})
-        assert result.to_list() == ["a", "a", "b", "b", "c"]
+        assert result.tolist() == ["a", "a", "b", "b", "c"]
 
         result = map(c, {1.0: "a"})
-        assert result.to_list() == ["a", "a", "null", "null", "null"]
+        assert result.tolist() == ["a", "a", "null", "null", "null"]
 
         result = map(c, {1.0: "a", 2.2: "b", 4.4: "c", 5.0: "d", 6.0: "e"})
-        assert result.to_list() == ["a", "a", "b", "b", "c"]
+        assert result.tolist() == ["a", "a", "b", "b", "c"]
 
         result = map(d, {"4": 25, "5": 30, "1": 7})
-        assert result.to_list() == [7, 7, 25, 25, 25]
+        assert result.tolist() == [7, 7, 25, 25, 25]
 
         result = map(d, {"1": 7})
         assert np.allclose(
-            result.to_list(),
-            ak.cast(ak.array([7, 7, np.nan, np.nan, np.nan]), dt=ak.int64).to_list(),
+            result.tolist(),
+            ak.cast(ak.array([7, 7, np.nan, np.nan, np.nan]), dt=ak.int64).tolist(),
             equal_nan=True,
         )
 
         result = map(d, {"1": 7.0})
-        assert np.allclose(result.to_list(), [7.0, 7.0, np.nan, np.nan, np.nan], equal_nan=True)
+        assert np.allclose(result.tolist(), [7.0, 7.0, np.nan, np.nan, np.nan], equal_nan=True)

--- a/tests/operator_test.py
+++ b/tests/operator_test.py
@@ -225,7 +225,7 @@ class TestOperator:
         # reproducer for issue #2802
         concatenated = ak.concatenate([ak.arange(5, max_bits=3), ak.arange(2**200 - 1, 2**200 + 4)])
         assert concatenated.max_bits == 3
-        assert [0, 1, 2, 3, 4, 7, 0, 1, 2, 3] == concatenated.to_list()
+        assert [0, 1, 2, 3, 4, 7, 0, 1, 2, 3] == concatenated.tolist()
 
     def test_fixed_concatenate(self):
         for pda1, pda2 in zip(
@@ -233,13 +233,13 @@ class TestOperator:
             (ak.arange(4, 7), ak.linspace(4, 6, 3)),
         ):
             ans = list(range(7))
-            assert ak.concatenate([pda1, pda2]).to_list() == ans
-            assert ak.concatenate([pda2, pda1]).to_list() == (ans[4:] + ans[:4])
+            assert ak.concatenate([pda1, pda2]).tolist() == ans
+            assert ak.concatenate([pda2, pda1]).tolist() == (ans[4:] + ans[:4])
 
     def test_invert(self):
         ak_invert = ~ak.arange(10, dtype=ak.uint64)
         np_invert = ~np.arange(10, dtype=np.uint)
-        assert ak_invert.to_list() == np_invert.tolist()
+        assert ak_invert.tolist() == np_invert.tolist()
 
     def test_bool_bool_addition_binop(self):
         np_x = np.array([True, True, False, False])
@@ -247,13 +247,13 @@ class TestOperator:
         ak_x = ak.array(np_x)
         ak_y = ak.array(np_y)
         # Vector-Vector Case
-        assert (np_x + np_y).tolist() == (ak_x + ak_y).to_list()
+        assert (np_x + np_y).tolist() == (ak_x + ak_y).tolist()
         # Scalar-Vector Case
-        assert (np_x[0] + np_y).tolist() == (ak_x[0] + ak_y).to_list()
-        assert (np_x[-1] + np_y).tolist() == (ak_x[-1] + ak_y).to_list()
+        assert (np_x[0] + np_y).tolist() == (ak_x[0] + ak_y).tolist()
+        assert (np_x[-1] + np_y).tolist() == (ak_x[-1] + ak_y).tolist()
         # Vector-Scalar Case
-        assert (np_x + np_y[0]).tolist() == (ak_x + ak_y[0]).to_list()
-        assert (np_x + np_y[-1]).tolist() == (ak_x + ak_y[-1]).to_list()
+        assert (np_x + np_y[0]).tolist() == (ak_x + ak_y[0]).tolist()
+        assert (np_x + np_y[-1]).tolist() == (ak_x + ak_y[-1]).tolist()
 
     def test_bool_bool_addition_opeq(self):
         np_x = np.array([True, True, False, False])
@@ -263,27 +263,27 @@ class TestOperator:
         np_x += np_y
         ak_x += ak_y
         # Vector-Vector Case
-        assert np_x.tolist() == ak_x.to_list()
+        assert np_x.tolist() == ak_x.tolist()
         # Scalar-Vector Case
         # True
         np_true = np_x[0]
         ak_true = ak_x[0]
         np_true += np_y
         ak_true += ak_y
-        assert np_x.tolist() == ak_x.to_list()
+        assert np_x.tolist() == ak_x.tolist()
         # False
         np_false = np_x[-1]
         ak_false = ak_x[-1]
         np_false += np_y
         ak_false += ak_y
-        assert np_x.tolist() == ak_x.to_list()
+        assert np_x.tolist() == ak_x.tolist()
 
     def test_uint_bool_binops(self):
         # Test fix for issue #1932
         # Adding support to binopvv to correctly handle uint and bool types
         ak_uint = ak.arange(10, dtype=ak.uint64)
         ak_bool = ak_uint % 2 == 0
-        assert (ak_uint + ak_bool).to_list() == (ak.arange(10) + ak_bool).to_list()
+        assert (ak_uint + ak_bool).tolist() == (ak.arange(10) + ak_bool).tolist()
 
     def test_int_uint_binops(self):
         np_int = np.arange(-5, 5)
@@ -382,12 +382,12 @@ class TestOperator:
                 assert np.allclose((ak_arr >> i).to_ndarray(), np_arr >> i)
 
             # Binopsv case
-            assert (max_bits << ak_shift).to_list() == (max_bits << np_shift).tolist()
-            assert (max_bits >> ak_shift).to_list() == (max_bits >> np_shift).tolist()
+            assert (max_bits << ak_shift).tolist() == (max_bits << np_shift).tolist()
+            assert (max_bits >> ak_shift).tolist() == (max_bits >> np_shift).tolist()
 
             # Binopvv case, Same type
-            assert (ak_arr << ak_shift).to_list() == (np_arr << np_shift).tolist()
-            assert (ak_arr >> ak_shift).to_list() == (np_arr >> np_shift).tolist()
+            assert (ak_arr << ak_shift).tolist() == (np_arr << np_shift).tolist()
+            assert (ak_arr >> ak_shift).tolist() == (np_arr >> np_shift).tolist()
 
     def test_shift_bool_int64_binop(self):
         # This tests for a missing implementation of bit shifting booleans and ints, Issue #2945
@@ -428,15 +428,15 @@ class TestOperator:
         ]
 
         for x in shift_scalars:
-            assert ak_vector.to_list() == np_vector.tolist()
+            assert ak_vector.tolist() == np_vector.tolist()
 
             ak_vector <<= x
             np_vector <<= x
-            assert ak_vector.to_list() == np_vector.tolist()
+            assert ak_vector.tolist() == np_vector.tolist()
 
             ak_vector >>= x
             np_vector >>= x
-            assert ak_vector.to_list() == np_vector.tolist()
+            assert ak_vector.tolist() == np_vector.tolist()
 
     def test_shift_equals_vector_binops(self):
         vector_pairs = [
@@ -457,15 +457,15 @@ class TestOperator:
                 if (v[0].dtype.kind != "b") and (ak_vector[0].dtype.kind != v[0].dtype.kind):
                     continue
 
-                assert ak_vector.to_list() == np_vector.tolist()
+                assert ak_vector.tolist() == np_vector.tolist()
 
                 ak_vector <<= v
                 np_vector <<= v.to_ndarray()
-                assert ak_vector.to_list() == np_vector.tolist()
+                assert ak_vector.tolist() == np_vector.tolist()
 
                 ak_vector >>= v
                 np_vector >>= v.to_ndarray()
-                assert ak_vector.to_list() == np_vector.tolist()
+                assert ak_vector.tolist() == np_vector.tolist()
 
     def test_concatenate_type_preservation(self):
         # Test that concatenate preserves special pdarray types (IPv4, Datetime, BitVector, ...)
@@ -478,11 +478,11 @@ class TestOperator:
             special_one, special_two = special_type(pda_one), special_type(pda_two)
             special_concat = ak.concatenate([special_one, special_two])
             assert isinstance(special_concat, special_type)
-            assert special_type(pda_concat).to_list() == special_concat.to_list()
+            assert special_type(pda_concat).tolist() == special_concat.tolist()
 
             # test single and empty
             assert isinstance(ak.concatenate([special_one]), special_type)
-            assert special_one.to_list() == ak.concatenate([special_one]).to_list()
+            assert special_one.tolist() == ak.concatenate([special_one]).tolist()
             assert isinstance(
                 ak.concatenate([special_type(ak.array([], dtype=ak.int64))]),
                 special_type,
@@ -491,7 +491,7 @@ class TestOperator:
             # verify ak.util.concatenate still works
             special_aku_concat = akuconcat([special_one, special_two])
             assert isinstance(special_aku_concat, special_type)
-            assert special_type(pda_concat).to_list() == special_aku_concat.to_list()
+            assert special_type(pda_concat).tolist() == special_aku_concat.tolist()
 
         # Test failure with mixed types
         with pytest.raises(TypeError):
@@ -524,22 +524,22 @@ class TestOperator:
         n = np.array([10, 5, 2])
         a = ak.array(n)
 
-        assert ak.power(a, 2).to_list() == np.power(n, 2).tolist()
-        assert ak.power(a, ak.array([2, 3, 4])).to_list() == np.power(n, [2, 3, 4]).tolist()
+        assert ak.power(a, 2).tolist() == np.power(n, 2).tolist()
+        assert ak.power(a, ak.array([2, 3, 4])).tolist() == np.power(n, [2, 3, 4]).tolist()
 
         # Test a singleton with and without a Boolean argument
         a = ak.array([7])
-        assert ak.power(a, 3, True).to_list() == ak.power(a, 3).to_list()
-        assert ak.power(a, 3, False).to_list() == a.to_list()
+        assert ak.power(a, 3, True).tolist() == ak.power(a, 3).tolist()
+        assert ak.power(a, 3, False).tolist() == a.tolist()
 
         # Test an with and without a Boolean argument, all the same
         a = ak.array([0, 0.0, 1, 7.0, 10])
-        assert ak.power(a, 3, ak.ones(5, bool)).to_list() == ak.power(a, 3).to_list()
-        assert ak.power(a, 3, ak.zeros(5, bool)).to_list() == a.to_list()
+        assert ak.power(a, 3, ak.ones(5, bool)).tolist() == ak.power(a, 3).tolist()
+        assert ak.power(a, 3, ak.zeros(5, bool)).tolist() == a.tolist()
 
         # Test a singleton with a mixed Boolean argument
         a = ak.arange(10)
-        assert [i if i % 2 else i**2 for i in range(10)] == ak.power(a, 2, a % 2 == 0).to_list()
+        assert [i if i % 2 else i**2 for i in range(10)] == ak.power(a, 2, a % 2 == 0).tolist()
 
         # Test invalid input, negative
         n = np.array([-1.0, -3.0])
@@ -557,7 +557,7 @@ class TestOperator:
 
         # Test with a mixed Boolean array
         a = ak.arange(5)
-        assert [i if i % 2 else i**0.5 for i in range(5)] == ak.sqrt(a, a % 2 == 0).to_list()
+        assert [i if i % 2 else i**0.5 for i in range(5)] == ak.sqrt(a, a % 2 == 0).tolist()
 
     def test_uint_and_bigint_operation_equals(self):
         def declare_arrays():
@@ -585,64 +585,64 @@ class TestOperator:
         # test uint opequals uint functionality against numpy
         for arr in u_arr, bi_arr, np_arr:
             arr += u
-        assert u_arr.to_list() == np_arr.tolist()
-        assert bi_arr.to_list() == np_arr.tolist()
+        assert u_arr.tolist() == np_arr.tolist()
+        assert bi_arr.tolist() == np_arr.tolist()
 
         for arr in u_arr, bi_arr, np_arr:
             arr += arr
-        assert u_arr.to_list() == np_arr.tolist()
-        assert bi_arr.to_list() == np_arr.tolist()
+        assert u_arr.tolist() == np_arr.tolist()
+        assert bi_arr.tolist() == np_arr.tolist()
 
         for arr in u_arr, bi_arr, np_arr:
             arr -= u
-        assert u_arr.to_list() == np_arr.tolist()
-        assert bi_arr.to_list() == np_arr.tolist()
+        assert u_arr.tolist() == np_arr.tolist()
+        assert bi_arr.tolist() == np_arr.tolist()
 
         for arr in u_arr, bi_arr, np_arr:
             arr -= arr
-        assert u_arr.to_list() == np_arr.tolist()
-        assert bi_arr.to_list() == np_arr.tolist()
+        assert u_arr.tolist() == np_arr.tolist()
+        assert bi_arr.tolist() == np_arr.tolist()
 
         # redeclare because subtract by self zeroed out
         u_arr, bi_arr, np_arr = declare_arrays()
 
         for arr in u_arr, bi_arr, np_arr:
             arr *= u
-        assert u_arr.to_list() == np_arr.tolist()
-        assert bi_arr.to_list() == np_arr.tolist()
+        assert u_arr.tolist() == np_arr.tolist()
+        assert bi_arr.tolist() == np_arr.tolist()
 
         for arr in u_arr, bi_arr, np_arr:
             arr *= arr
-        assert u_arr.to_list() == np_arr.tolist()
-        assert bi_arr.to_list() == np_arr.tolist()
+        assert u_arr.tolist() == np_arr.tolist()
+        assert bi_arr.tolist() == np_arr.tolist()
 
         for arr in u_arr, bi_arr, np_arr:
             arr **= u
-        assert u_arr.to_list() == np_arr.tolist()
-        assert bi_arr.to_list() == np_arr.tolist()
+        assert u_arr.tolist() == np_arr.tolist()
+        assert bi_arr.tolist() == np_arr.tolist()
 
         for arr in u_arr, bi_arr, np_arr:
             arr **= arr
-        assert u_arr.to_list() == np_arr.tolist()
-        assert bi_arr.to_list() == np_arr.tolist()
+        assert u_arr.tolist() == np_arr.tolist()
+        assert bi_arr.tolist() == np_arr.tolist()
 
         for arr in u_arr, bi_arr, np_arr:
             arr %= u
-        assert u_arr.to_list() == np_arr.tolist()
-        assert bi_arr.to_list() == np_arr.tolist()
+        assert u_arr.tolist() == np_arr.tolist()
+        assert bi_arr.tolist() == np_arr.tolist()
 
         for arr in u_arr, bi_arr, np_arr:
             arr //= u
-        assert u_arr.to_list() == np_arr.tolist()
-        assert bi_arr.to_list() == np_arr.tolist()
+        assert u_arr.tolist() == np_arr.tolist()
+        assert bi_arr.tolist() == np_arr.tolist()
 
         # redeclare because divide zeroed out
         u_arr, bi_arr, np_arr = declare_arrays()
 
         for arr in u_arr, bi_arr, np_arr:
             arr //= arr
-        assert u_arr.to_list() == np_arr.tolist()
-        assert bi_arr.to_list() == np_arr.tolist()
+        assert u_arr.tolist() == np_arr.tolist()
+        assert bi_arr.tolist() == np_arr.tolist()
 
         # the only arrays that can be added in place are uint and bool
         # scalars are cast to same type if possible
@@ -655,8 +655,8 @@ class TestOperator:
             u_tmp += v
             bi_tmp += v
             i_tmp += v
-            assert u_tmp.to_list() == i_tmp.to_list()
-            assert u_tmp.to_list() == bi_tmp.to_list()
+            assert u_tmp.tolist() == i_tmp.tolist()
+            assert u_tmp.tolist() == bi_tmp.tolist()
 
         # adding a float or int inplace could have a result which is not a uint
         for e in [i_arr, f_arr]:
@@ -745,82 +745,82 @@ class TestOperator:
         u_scalar = 10
 
         # logical bit ops: only work if both arguments are bigint
-        assert (u & u_range).to_list() == (bi & bi_range).to_list()
-        assert [(bi[i] & bi_scalar) % mod_by for i in range(bi.size)] == (bi & bi_scalar).to_list()
-        assert [(bi_scalar & bi[i]) % mod_by for i in range(bi.size)] == (bi_scalar & bi).to_list()
+        assert (u & u_range).tolist() == (bi & bi_range).tolist()
+        assert [(bi[i] & bi_scalar) % mod_by for i in range(bi.size)] == (bi & bi_scalar).tolist()
+        assert [(bi_scalar & bi[i]) % mod_by for i in range(bi.size)] == (bi_scalar & bi).tolist()
 
-        assert (u | u_range).to_list() == (bi | bi_range).to_list()
-        assert [(bi[i] | bi_scalar) % mod_by for i in range(bi.size)] == (bi | bi_scalar).to_list()
-        assert [(bi_scalar | bi[i]) % mod_by for i in range(bi.size)] == (bi_scalar | bi).to_list()
+        assert (u | u_range).tolist() == (bi | bi_range).tolist()
+        assert [(bi[i] | bi_scalar) % mod_by for i in range(bi.size)] == (bi | bi_scalar).tolist()
+        assert [(bi_scalar | bi[i]) % mod_by for i in range(bi.size)] == (bi_scalar | bi).tolist()
 
-        assert (u ^ u_range).to_list() == (bi ^ bi_range).to_list()
-        assert [(bi[i] ^ bi_scalar) % mod_by for i in range(bi.size)] == (bi ^ bi_scalar).to_list()
-        assert [(bi_scalar ^ bi[i]) % mod_by for i in range(bi.size)] == (bi_scalar ^ bi).to_list()
+        assert (u ^ u_range).tolist() == (bi ^ bi_range).tolist()
+        assert [(bi[i] ^ bi_scalar) % mod_by for i in range(bi.size)] == (bi ^ bi_scalar).tolist()
+        assert [(bi_scalar ^ bi[i]) % mod_by for i in range(bi.size)] == (bi_scalar ^ bi).tolist()
 
         # bit shifts: left side must be bigint, right side must be int/uint
         ans = u << u_range
-        assert ans.to_list() == (bi << u_range).to_list()
-        assert ans.to_list() == (bi << i_range).to_list()
+        assert ans.tolist() == (bi << u_range).tolist()
+        assert ans.tolist() == (bi << i_range).tolist()
 
         ans = u >> u_range
-        assert ans.to_list() == (bi >> u_range).to_list()
-        assert ans.to_list() == (bi >> i_range).to_list()
+        assert ans.tolist() == (bi >> u_range).tolist()
+        assert ans.tolist() == (bi >> i_range).tolist()
 
         ans = u.rotl(u_range)
-        assert ans.to_list() == bi.rotl(u_range).to_list()
-        assert ans.to_list() == bi.rotl(i_range).to_list()
+        assert ans.tolist() == bi.rotl(u_range).tolist()
+        assert ans.tolist() == bi.rotl(i_range).tolist()
         ans = u.rotr(u_range)
-        assert ans.to_list() == bi.rotr(u_range).to_list()
-        assert ans.to_list() == bi.rotr(i_range).to_list()
+        assert ans.tolist() == bi.rotr(u_range).tolist()
+        assert ans.tolist() == bi.rotr(i_range).tolist()
 
         # ops where left side has to bigint
         ans = u // u_range
         for ran in bi_range, u_range, i_range:
-            assert ans.to_list() == (bi // ran).to_list()
+            assert ans.tolist() == (bi // ran).tolist()
 
         ans = u % u_range
         for ran in bi_range, u_range, i_range:
-            assert ans.to_list() == (bi % ran).to_list()
+            assert ans.tolist() == (bi % ran).tolist()
 
         ans = u**u_range
         for ran in bi_range, u_range, i_range:
-            assert ans.to_list() == (bi**ran).to_list()
+            assert ans.tolist() == (bi**ran).tolist()
 
         # ops where either side can any of bigint, int, uint, bool
         ans = u + u_range
         for ran in bi_range, u_range, i_range:
-            assert ans.to_list() == (bi + ran).to_list()
-            assert ans.to_list() == (ran + bi).to_list()
+            assert ans.tolist() == (bi + ran).tolist()
+            assert ans.tolist() == (ran + bi).tolist()
 
         ans = u + b
-        assert ans.to_list() == (bi + b).to_list()
-        assert ans.to_list() == (b + bi).to_list()
+        assert ans.tolist() == (bi + b).tolist()
+        assert ans.tolist() == (b + bi).tolist()
         for s in [i_scalar, u_scalar, bi_scalar]:
-            assert [(bi[i] + s) % mod_by for i in range(bi.size)] == (bi + s).to_list()
-            assert [(s + bi[i]) % mod_by for i in range(bi.size)] == (s + bi).to_list()
+            assert [(bi[i] + s) % mod_by for i in range(bi.size)] == (bi + s).tolist()
+            assert [(s + bi[i]) % mod_by for i in range(bi.size)] == (s + bi).tolist()
 
         ans = u - u_range
         for ran in bi_range, u_range, i_range:
-            assert ans.to_list() == (bi - ran).to_list()
-        assert (u - b).to_list() == (bi - b).to_list()
-        assert (b - u).to_list() == (b - bi).to_list()
+            assert ans.tolist() == (bi - ran).tolist()
+        assert (u - b).tolist() == (bi - b).tolist()
+        assert (b - u).tolist() == (b - bi).tolist()
 
         for s in [i_scalar, u_scalar, bi_scalar]:
-            assert [(bi[i] - s) % mod_by for i in range(bi.size)] == (bi - s).to_list()
-            assert [(s - bi[i]) % mod_by for i in range(bi.size)] == (s - bi).to_list()
+            assert [(bi[i] - s) % mod_by for i in range(bi.size)] == (bi - s).tolist()
+            assert [(s - bi[i]) % mod_by for i in range(bi.size)] == (s - bi).tolist()
 
-        assert (bi - neg_range).to_list() == (bi + u_range).to_list()
+        assert (bi - neg_range).tolist() == (bi + u_range).tolist()
 
         ans = u * u_range
         for ran in bi_range, u_range, i_range:
-            assert ans.to_list() == (bi * ran).to_list()
+            assert ans.tolist() == (bi * ran).tolist()
         ans = u * b
-        assert ans.to_list() == (bi * b).to_list()
-        assert ans.to_list() == (b * bi).to_list()
+        assert ans.tolist() == (bi * b).tolist()
+        assert ans.tolist() == (b * bi).tolist()
 
         for s in [i_scalar, u_scalar, bi_scalar]:
-            assert [(bi[i] * s) % mod_by for i in range(bi.size)] == (bi * s).to_list()
-            assert [(s * bi[i]) % mod_by for i in range(bi.size)] == (s * bi).to_list()
+            assert [(bi[i] * s) % mod_by for i in range(bi.size)] == (bi * s).tolist()
+            assert [(s * bi[i]) % mod_by for i in range(bi.size)] == (s * bi).tolist()
 
     def test_bigint_rotate(self):
         # see issue #2214
@@ -841,8 +841,8 @@ class TestOperator:
             ak.arange(10)
         )
         ans = [10 if i % 2 == 0 else 5 for i in range(10)]
-        assert left_rot.to_list() == ans
-        assert right_rot.to_list() == ans
+        assert left_rot.tolist() == ans
+        assert right_rot.tolist() == ans
 
     def test_float_mods(self):
         edge_cases = [

--- a/tests/pandas/categorical_test.py
+++ b/tests/pandas/categorical_test.py
@@ -86,8 +86,8 @@ class TestCategorical:
         prefix, size = "string", 10
         cat = self.create_basic_categorical(prefix, size)
 
-        assert list(range(size)) == cat.codes.to_list() == cat.segments.to_list()
-        assert ([f"{prefix} {i}" for i in range(size)] + ["N/A"]) == cat.categories.to_list()
+        assert list(range(size)) == cat.codes.tolist() == cat.segments.tolist()
+        assert ([f"{prefix} {i}" for i in range(size)] + ["N/A"]) == cat.categories.tolist()
         assert size == cat.size
         assert "Categorical" == cat.objType
 
@@ -119,8 +119,8 @@ class TestCategorical:
         categories = ak.array([f"string {i}" for i in range(10)] + ["N/A"])
 
         cat = ak.Categorical.from_codes(codes, categories)
-        assert codes.to_list() == cat.codes.to_list()
-        assert categories.to_list() == cat.categories.to_list()
+        assert codes.tolist() == cat.codes.tolist()
+        assert categories.tolist() == cat.categories.tolist()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_from_pd_categorical(self, size):
@@ -163,7 +163,7 @@ class TestCategorical:
         # to verify we correctly grouped, make sure we never re-encounter
         seen_before = set()
         curr = ""
-        for val in grouped.to_list():
+        for val in grouped.tolist():
             if val != curr:
                 assert val not in seen_before
                 curr = val
@@ -174,7 +174,7 @@ class TestCategorical:
         unique_cat = ak.Categorical(
             ak.array(["string", "string1", "string3", "non-string", "non-string2"])
         )
-        assert non_unique_cat.unique().to_list() == unique_cat.to_list()
+        assert non_unique_cat.unique().tolist() == unique_cat.tolist()
 
     def test_to_ndarray(self):
         cat = self.create_randomized_categorical()
@@ -194,8 +194,8 @@ class TestCategorical:
         )
         assert (cat.to_ndarray() == ndcat).all()
 
-    def test_to_list(self):
-        assert self.non_unique_cat.to_list() == np.array(self.non_unique_strs).tolist()
+    def test_tolist(self):
+        assert self.non_unique_cat.tolist() == np.array(self.non_unique_strs).tolist()
 
     def test_to_strings(self):
         cat = self.non_unique_cat
@@ -212,7 +212,7 @@ class TestCategorical:
             "non-string",
         ]
 
-        assert cat.to_strings().to_list() == cat_list
+        assert cat.to_strings().tolist() == cat_list
         assert isinstance(cat.to_strings(), ak.Strings)
 
     def test_equality(self):
@@ -220,12 +220,12 @@ class TestCategorical:
         cat_dupe = self.create_basic_categorical()
         cat_non_dupe = self.non_unique_cat
 
-        assert cat.to_list() == cat_dupe.to_list()
+        assert cat.tolist() == cat_dupe.tolist()
         assert (cat != cat_non_dupe).all()
 
         c1 = ak.Categorical(ak.array(["a", "b", "c", "a", "b"]))
         c2 = ak.Categorical(ak.array(["a", "x", "c", "y", "b"]))
-        assert (c1 == c2).to_list() == [True, False, True, False, True]
+        assert (c1 == c2).tolist() == [True, False, True, False, True]
 
     def test_binop(self):
         size = 10
@@ -238,9 +238,9 @@ class TestCategorical:
 
         for i in range(size):
             for op in "==", "!=":
-                ans = ak.arange(10)._binop(i, op).to_list()
-                assert ans == cat._binop(f"string {i}", op).to_list()
-                assert ans == cat._binop(np.str_(f"string {i}"), op).to_list()
+                ans = ak.arange(10)._binop(i, op).tolist()
+                assert ans == cat._binop(f"string {i}", op).tolist()
+                assert ans == cat._binop(np.str_(f"string {i}"), op).tolist()
 
         with pytest.raises(NotImplementedError):
             cat._binop("string 1", "===")
@@ -256,8 +256,8 @@ class TestCategorical:
 
         answer = [x < 2 for x in vals]
 
-        assert answer == ak.in1d(cat_one, cat_two).to_list()
-        assert answer == ak.in1d(cat_one, strings_two).to_list()
+        assert answer == ak.in1d(cat_one, cat_two).tolist()
+        assert answer == ak.in1d(cat_one, strings_two).tolist()
 
         with pytest.raises(TypeError):
             ak.in1d(cat_one, ak.randint(0, 5, 5))
@@ -269,13 +269,13 @@ class TestCategorical:
         # test string literal in and not in categories
         for str_lit in "str 1", "str 122222":
             ans = ak.where(revs, cat1, str_lit)
-            assert cat1[revs].to_list() == ans[revs].to_list()
-            for s in ans[~revs].to_list():
+            assert cat1[revs].tolist() == ans[revs].tolist()
+            for s in ans[~revs].tolist():
                 assert s == str_lit
 
             ans = ak.where(revs, str_lit, cat1)
-            assert cat1[~revs].to_list() == ans[~revs].to_list()
-            for s in ans[revs].to_list():
+            assert cat1[~revs].tolist() == ans[~revs].tolist()
+            for s in ans[revs].tolist():
                 assert s == str_lit
 
         # 2 categorical, same and different categories
@@ -284,8 +284,8 @@ class TestCategorical:
             ak.Categorical(ak.array([f"str {i * 2}" for i in range(10)])),
         ):
             ans = ak.where(revs, cat1, cat2)
-            assert cat1[revs].to_list() == ans[revs].to_list()
-            assert cat2[~revs].to_list() == ans[~revs].to_list()
+            assert cat1[revs].tolist() == ans[revs].tolist()
+            assert cat2[~revs].tolist() == ans[~revs].tolist()
 
     def test_concatenate(self):
         cat_one = self.create_basic_categorical("string", 50)
@@ -313,14 +313,14 @@ class TestCategorical:
         for order in True, False:
             str_concat = ak.concatenate([s1, s2], ordered=order)
             cat_concat = ak.concatenate([c1, c2], ordered=order)
-            assert str_concat.to_list() == cat_concat.to_list()
+            assert str_concat.tolist() == cat_concat.tolist()
 
         # Tiny concatenation
         # Used to fail when length of array was less than numLocales
         # CI uses 2 locales, so try with length-1 arrays
         a = ak.Categorical(ak.array(["a"]))
         b = ak.Categorical(ak.array(["b"]))
-        assert ak.concatenate((a, b), ordered=False).to_list() == ak.array(["a", "b"]).to_list()
+        assert ak.concatenate((a, b), ordered=False).tolist() == ak.array(["a", "b"]).tolist()
 
     def test_save_and_load_categorical(self, df_test_base_tmp):
         """
@@ -358,7 +358,7 @@ class TestCategorical:
 
             # Note assertCountEqual asserts a and b have the same elements
             # in the same amount regardless of order
-            assert cat_from_hdf.categories.to_list() == expected_categories
+            assert cat_from_hdf.categories.tolist() == expected_categories
 
             # Asserting the optional components and sizes are correct
             # for both constructors should be sufficient
@@ -385,10 +385,10 @@ class TestCategorical:
             assert len(x.items()) == 4
             # Note assertCountEqual asserts a and b have the same
             # elements in the same amount regardless of order
-            assert x["cat1"].categories.to_list() == c1.categories.to_list()
-            assert x["cat2"].categories.to_list() == c2.categories.to_list()
-            assert x["pda1"].to_list() == pda1.to_list()
-            assert x["strings1"].to_list() == strings1.to_list()
+            assert x["cat1"].categories.tolist() == c1.categories.tolist()
+            assert x["cat2"].categories.tolist() == c2.categories.tolist()
+            assert x["pda1"].tolist() == pda1.tolist()
+            assert x["strings1"].tolist() == strings1.tolist()
 
     def test_hdf_update(self, df_test_base_tmp):
         num_elems = 51  # create_basic_categorical starts counting at 1, so the size is really off by one
@@ -412,11 +412,11 @@ class TestCategorical:
             assert dset_name3 in data
 
             d = data[dset_name2]
-            assert d.codes.to_list() == replace_cat.codes.to_list()
-            assert d.permutation.to_list() == replace_cat.permutation.to_list()
-            assert d.segments.to_list() == replace_cat.segments.to_list()
-            assert d._akNAcode.to_list() == replace_cat._akNAcode.to_list()
-            assert d.categories.to_list() == replace_cat.categories.to_list()
+            assert d.codes.tolist() == replace_cat.codes.tolist()
+            assert d.permutation.tolist() == replace_cat.permutation.tolist()
+            assert d.segments.tolist() == replace_cat.segments.tolist()
+            assert d._akNAcode.tolist() == replace_cat._akNAcode.tolist()
+            assert d.categories.tolist() == replace_cat.categories.tolist()
 
     def test_unused_categories_logic(self):
         # Reproducer for issue #990
@@ -424,12 +424,12 @@ class TestCategorical:
         s12 = s[1:3]
         cat = ak.Categorical(s)
         cat12 = cat[1:3]
-        assert ak.in1d(s, s12).to_list() == ak.in1d(cat, cat12).to_list()
-        assert set(ak.unique(s12).to_list()) == set(ak.unique(cat12).to_list())
+        assert ak.in1d(s, s12).tolist() == ak.in1d(cat, cat12).tolist()
+        assert set(ak.unique(s12).tolist()) == set(ak.unique(cat12).tolist())
 
         cat_from_codes = ak.Categorical.from_codes(ak.array([1, 2]), s)
-        assert ak.in1d(s, s12).to_list() == ak.in1d(cat, cat_from_codes).to_list()
-        assert set(ak.unique(s12).to_list()) == set(ak.unique(cat_from_codes).to_list())
+        assert ak.in1d(s, s12).tolist() == ak.in1d(cat, cat_from_codes).tolist()
+        assert set(ak.unique(s12).tolist()) == set(ak.unique(cat_from_codes).tolist())
 
     def test_na(self):
         s = ak.array(["A", "B", "C", "B", "C"])
@@ -453,7 +453,7 @@ class TestCategorical:
         c1 = ak.Categorical(ak.array(["A", "B", "C"]))
         c2 = ak.Categorical(ak.array(["B", "C", "D"]))
         c3, c4 = ak.Categorical.standardize_categories([c1, c2])
-        assert c3.categories.to_list() == c4.categories.to_list()
+        assert c3.categories.tolist() == c4.categories.tolist()
         assert not c3.isna().any() and not c4.isna().any()
         assert c1.categories.size + 1 == c3.categories.size == c4.categories.size
 
@@ -462,7 +462,7 @@ class TestCategorical:
         values = ak.Categorical(ak.array(["A", "B", "C"]))
         args = ak.array([3, 2, 1, 0])
         ret = ak.lookup(keys, values, args)
-        assert ret.to_list() == ["C", "B", "A", "N/A"]
+        assert ret.tolist() == ["C", "B", "A", "N/A"]
 
     def test_deletion(self):
         cat = ak.Categorical(ak.array(["a", "b", "c"]))
@@ -478,7 +478,7 @@ class TestCategorical:
         rand_codes = ak.randint(0, rand_cats.size, 100)
         cat = ak.Categorical.from_codes(codes=rand_codes, categories=rand_cats)
 
-        assert sorted(cat.to_list()) == cat.sort_values().to_list()
+        assert sorted(cat.tolist()) == cat.sort_values().tolist()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_to_pandas(self, size):

--- a/tests/pandas/dataframe_test.py
+++ b/tests/pandas/dataframe_test.py
@@ -335,13 +335,13 @@ class TestDataFrame:
 
         df_dict = {"fields": f, "ip": ip, "date": d, "bitvector": bv}
         df = ak.DataFrame(df_dict)
-        pd_d = [pd.to_datetime(x, unit="ns") for x in d.to_list()]
+        pd_d = [pd.to_datetime(x, unit="ns") for x in d.tolist()]
         pddf = pd.DataFrame(
             {
-                "fields": f.to_list(),
-                "ip": ip.to_list(),
+                "fields": f.tolist(),
+                "ip": ip.tolist(),
                 "date": pd_d,
-                "bitvector": bv.to_list(),
+                "bitvector": bv.tolist(),
             }
         )
         assert_frame_equal(pddf, df.to_pandas())
@@ -378,14 +378,14 @@ class TestDataFrame:
 
         # index validation
         assert isinstance(df.index, ak.Index)
-        assert df.index.to_list() == ref_df.index.to_list()
+        assert df.index.tolist() == ref_df.index.tolist()
 
         for cname in df.columns.values:
             col, ref_col = getattr(df, cname), getattr(ref_df, cname)
             assert isinstance(col, ak.Series)
-            assert col.to_list() == ref_col.to_list()
+            assert col.tolist() == ref_col.tolist()
             assert isinstance(df[cname], (ak.pdarray, ak.Strings, ak.Categorical))
-            assert df[cname].to_list() == ref_df[cname].to_list()
+            assert df[cname].tolist() == ref_df[cname].tolist()
 
         # check mult-column list
         col_list = ["userName", "amount", "bi"]
@@ -483,18 +483,18 @@ class TestDataFrame:
         df = self.build_ak_df()
 
         slice_df = df[ak.array([1, 3, 5])]
-        assert slice_df.index.to_list() == [1, 3, 5]
+        assert slice_df.index.tolist() == [1, 3, 5]
 
         df_reset = slice_df.reset_index()
-        assert df_reset.index.to_list() == [0, 1, 2]
-        assert slice_df.index.to_list(), [1, 3, 5]
+        assert df_reset.index.tolist() == [0, 1, 2]
+        assert slice_df.index.tolist(), [1, 3, 5]
 
         df_reset2 = slice_df.reset_index(size=3)
-        assert df_reset2.index.to_list() == [0, 1, 2]
-        assert slice_df.index.to_list() == [1, 3, 5]
+        assert df_reset2.index.tolist() == [0, 1, 2]
+        assert slice_df.index.tolist() == [1, 3, 5]
 
         slice_df.reset_index(inplace=True)
-        assert slice_df.index.to_list(), [0, 1, 2]
+        assert slice_df.index.tolist(), [0, 1, 2]
 
     def test_rename(self):
         df = self.build_ak_df()
@@ -528,12 +528,12 @@ class TestDataFrame:
 
         # Test out of Place - index
         df_rename = df.rename(rename_idx)
-        assert df_rename.index.values.to_list() == conf
-        assert df.index.values.to_list() == list(range(6))
+        assert df_rename.index.values.tolist() == conf
+        assert df.index.values.tolist() == list(range(6))
 
         # Test in place - index
         df.rename(index=rename_idx, inplace=True)
-        assert df.index.values.to_list() == conf
+        assert df.index.values.tolist() == conf
 
     def test_append(self):
         df = self.build_ak_df()
@@ -546,7 +546,7 @@ class TestDataFrame:
         assert_frame_equal(ref_df, df.to_pandas())
 
         idx = np.arange(8)
-        assert idx.tolist() == df.index.index.to_list()
+        assert idx.tolist() == df.index.index.tolist()
 
         df_keyerror = self.build_ak_keyerror()
         with pytest.raises(KeyError):
@@ -594,16 +594,16 @@ class TestDataFrame:
         df = self.build_ak_df()
         gb = df.GroupBy("userName")
         keys, count = gb.size()
-        assert keys.to_list() == ["Bob", "Alice", "Carol"]
-        assert count.to_list() == [2, 3, 1]
-        assert gb.permutation.to_list() == [1, 4, 0, 2, 5, 3]
+        assert keys.tolist() == ["Bob", "Alice", "Carol"]
+        assert count.tolist() == [2, 3, 1]
+        assert gb.permutation.tolist() == [1, 4, 0, 2, 5, 3]
 
         gb = df.GroupBy(["userName", "userID"])
         keys, count = gb.size()
         assert len(keys) == 2
-        assert keys[0].to_list() == ["Bob", "Alice", "Carol"]
-        assert keys[1].to_list() == [222, 111, 333]
-        assert count.to_list() == [2, 3, 1]
+        assert keys[0].tolist() == ["Bob", "Alice", "Carol"]
+        assert keys[1].tolist() == [222, 111, 333]
+        assert count.tolist() == [2, 3, 1]
 
         # testing counts with IPv4 column
         s = ak.DataFrame({"a": ak.IPv4(ak.arange(1, 5))}).groupby("a").size()
@@ -631,8 +631,8 @@ class TestDataFrame:
 
         c = gb.size(as_series=True)
         assert isinstance(c, ak.Series)
-        assert c.index.to_list() == ["Alice", "Bob", "Carol"]
-        assert c.values.to_list() == [3, 2, 1]
+        assert c.index.tolist() == ["Alice", "Bob", "Carol"]
+        assert c.values.tolist() == [3, 2, 1]
 
     @pytest.mark.parametrize("agg", ["sum", "first", "count"])
     def test_gb_aggregations(self, agg):
@@ -849,19 +849,19 @@ class TestDataFrame:
         df = self.build_ak_df()
 
         p = df.argsort(key="userName")
-        assert p.to_list() == [0, 2, 5, 1, 4, 3]
+        assert p.tolist() == [0, 2, 5, 1, 4, 3]
 
         p = df.argsort(key="userName", ascending=False)
-        assert p.to_list() == [3, 4, 1, 5, 2, 0]
+        assert p.tolist() == [3, 4, 1, 5, 2, 0]
 
     def test_coargsort(self):
         df = self.build_ak_df()
 
         p = df.coargsort(keys=["userID", "amount"])
-        assert p.to_list() == [0, 5, 2, 1, 4, 3]
+        assert p.tolist() == [0, 5, 2, 1, 4, 3]
 
         p = df.coargsort(keys=["userID", "amount"], ascending=False)
-        assert p.to_list() == [3, 4, 1, 2, 5, 0]
+        assert p.tolist() == [3, 4, 1, 2, 5, 0]
 
     def test_sort_values(self):
         userid = [111, 222, 111, 333, 222, 111]
@@ -949,7 +949,7 @@ class TestDataFrame:
         df_2 = ak.DataFrame({"user_name": username, "user_id": userid})
 
         rows = ak.intx(df_1, df_2)
-        assert rows.to_list() == [False, True, False, False, True, False]
+        assert rows.tolist() == [False, True, False, False, True, False]
 
         df_3 = ak.DataFrame({"user_name": username, "user_number": userid})
         with pytest.raises(ValueError):
@@ -974,7 +974,7 @@ class TestDataFrame:
         df = ak.DataFrame({"userID": userid, "amount": amount})
 
         filtered = df.filter_by_range(keys=["userID"], low=1, high=2)
-        assert filtered.to_list() == [False, True, False, True, True, False]
+        assert filtered.tolist() == [False, True, False, True, True, False]
 
     def test_copy(self):
         username = ak.array(["Alice", "Bob", "Alice", "Carol", "Bob", "Alice"])
@@ -985,7 +985,7 @@ class TestDataFrame:
         assert_frame_equal(df.to_pandas(), df_copy.to_pandas())
 
         df_copy.__setitem__("userID", ak.array([1, 2, 1, 3, 2, 1]))
-        assert df["userID"].to_list() != df_copy["userID"].to_list()
+        assert df["userID"].tolist() != df_copy["userID"].tolist()
 
         df_copy = df.copy(deep=False)
         df_copy.__setitem__("userID", ak.array([1, 2, 1, 3, 2, 1]))
@@ -996,26 +996,26 @@ class TestDataFrame:
 
         # test against pdarray
         test_df = df.isin(ak.array([0, 1]))
-        assert test_df["col_A"].to_list() == [False, False]
-        assert test_df["col_B"].to_list() == [True, False]
+        assert test_df["col_A"].tolist() == [False, False]
+        assert test_df["col_B"].tolist() == [True, False]
 
         # Test against dict
         test_df = df.isin({"col_A": ak.array([0, 3])})
-        assert test_df["col_A"].to_list() == [False, True]
-        assert test_df["col_B"].to_list() == [False, False]
+        assert test_df["col_A"].tolist() == [False, True]
+        assert test_df["col_B"].tolist() == [False, False]
 
         # test against series
         i = ak.Index(ak.arange(2))
         s = ak.Series(data=ak.array([3, 9]), index=i.index)
         test_df = df.isin(s)
-        assert test_df["col_A"].to_list() == [False, False]
-        assert test_df["col_B"].to_list() == [False, True]
+        assert test_df["col_A"].tolist() == [False, False]
+        assert test_df["col_B"].tolist() == [False, True]
 
         # test against another dataframe
         other_df = ak.DataFrame({"col_A": ak.array([7, 3], dtype=ak.bigint), "col_C": ak.array([0, 9])})
         test_df = df.isin(other_df)
-        assert test_df["col_A"].to_list() == [True, True]
-        assert test_df["col_B"].to_list() == [False, False]
+        assert test_df["col_A"].tolist() == [True, True]
+        assert test_df["col_B"].tolist() == [False, False]
 
     def test_count(self):
         akdf = self.build_ak_df_with_nans()
@@ -1066,11 +1066,11 @@ class TestDataFrame:
 
         bool_idx = df[df["cnt"] > 3]
         bool_idx.__repr__()
-        assert bool_idx.index.index.to_list() == list(range(4, 65))
+        assert bool_idx.index.index.tolist() == list(range(4, 65))
 
         slice_idx = df[:]
         slice_idx.__repr__()
-        assert slice_idx.index.index.to_list() == list(range(65))
+        assert slice_idx.index.index.tolist() == list(range(65))
 
         # verify it persists non-int Index
         idx = ak.concatenate([ak.zeros(5, bool), ak.ones(60, bool)])
@@ -1080,11 +1080,11 @@ class TestDataFrame:
         bool_idx.__repr__()
         # the new index is first False and rest True (because we lose first 4),
         # so equivalent to arange(61, bool)
-        assert bool_idx.index.index.to_list() == ak.arange(61, dtype=bool).to_list()
+        assert bool_idx.index.index.tolist() == ak.arange(61, dtype=bool).tolist()
 
         slice_idx = df[:]
         slice_idx.__repr__()
-        assert slice_idx.index.index.to_list() == idx.to_list()
+        assert slice_idx.index.index.tolist() == idx.tolist()
 
     def test_subset(self):
         df = ak.DataFrame(
@@ -1097,9 +1097,9 @@ class TestDataFrame:
         )
         df2 = df[["a", "b"]]
         assert ["a", "b"] == df2.columns.values
-        assert df.index.to_list() == df2.index.to_list()
-        assert df["a"].to_list() == df2["a"].to_list()
-        assert df["b"].to_list() == df2["b"].to_list()
+        assert df.index.tolist() == df2.index.tolist()
+        assert df["a"].tolist() == df2["a"].tolist()
+        assert df["b"].tolist() == df2["b"].tolist()
 
     def test_multi_col_merge(self):
         size = 1000
@@ -1573,9 +1573,9 @@ class TestDataFrame:
                             random_state=rng,
                         )
 
-                        res = (
-                            np.allclose(previous1["vals"].to_list(), current1["vals"].to_list())
-                        ) and (np.allclose(previous2["vals"].to_list(), current2["vals"].to_list()))
+                        res = (np.allclose(previous1["vals"].tolist(), current1["vals"].tolist())) and (
+                            np.allclose(previous2["vals"].tolist(), current2["vals"].tolist())
+                        )
                         if not res:
                             print(f"\nnum locales: {cfg['numLocales']}")
                             print(f"Failure with seed:\n{seed}")
@@ -1680,4 +1680,4 @@ class TestDataFrame:
 
 
 def pda_to_str_helper(pda):
-    return ak.array([f"str {i}" for i in pda.to_list()])
+    return ak.array([f"str {i}" for i in pda.tolist()])

--- a/tests/pandas/groupby_test.py
+++ b/tests/pandas/groupby_test.py
@@ -227,12 +227,12 @@ class TestGroupBy:
         x = ak.array([True, True, False, True, False, False])
         g = ak.GroupBy(x)
         keys, locs = g.argmin(b)
-        assert keys.to_list() == [False, True]
-        assert locs.to_list() == [4, 1]
+        assert keys.tolist() == [False, True]
+        assert locs.tolist() == [4, 1]
 
         keys, locs = g.argmax(b)
-        assert keys.to_list() == [False, True]
-        assert locs.to_list() == [2, 0]
+        assert keys.tolist() == [False, True]
+        assert locs.tolist() == [2, 0]
 
     def test_boolean_arrays(self):
         a = ak.array([True, False, True, True, False])
@@ -241,26 +241,26 @@ class TestGroupBy:
         k, ct = g.size()
 
         assert ct[1] == true_ct
-        assert k.to_list() == [False, True]
+        assert k.tolist() == [False, True]
 
         # This test was added since we added the size method for issue #1353
         k, ct = g.size()
 
         assert ct[1] == true_ct
-        assert k.to_list() == [False, True]
+        assert k.tolist() == [False, True]
 
         b = ak.array([False, False, True, False, False])
         g = ak.GroupBy([a, b])
         k, ct = g.size()
-        assert ct.to_list() == [2, 2, 1]
-        assert k[0].to_list() == [False, True, True]
-        assert k[1].to_list() == [False, False, True]
+        assert ct.tolist() == [2, 2, 1]
+        assert k[0].tolist() == [False, True, True]
+        assert k[1].tolist() == [False, False, True]
 
     def test_bitwise_aggregations(self):
         revs = ak.arange(self.igb.length) % 2
-        assert self.igb.OR(revs)[1].to_list() == self.igb.max(revs)[1].to_list()
-        assert self.igb.AND(revs)[1].to_list() == self.igb.min(revs)[1].to_list()
-        assert self.igb.XOR(revs)[1].to_list() == (self.igb.sum(revs)[1] % 2).to_list()
+        assert self.igb.OR(revs)[1].tolist() == self.igb.max(revs)[1].tolist()
+        assert self.igb.AND(revs)[1].tolist() == self.igb.min(revs)[1].tolist()
+        assert self.igb.XOR(revs)[1].tolist() == (self.igb.sum(revs)[1] % 2).tolist()
 
     def test_standalone_broadcast(self):
         segs = ak.arange(10) ** 2
@@ -289,12 +289,12 @@ class TestGroupBy:
             compressed_vals = vals[non_empty_segs]
 
             assert (
-                ak.broadcast(segs, vals, size).to_list()
-                == ak.broadcast(compressed_segs, compressed_vals, size).to_list()
+                ak.broadcast(segs, vals, size).tolist()
+                == ak.broadcast(compressed_segs, compressed_vals, size).tolist()
             )
             assert (
-                ak.broadcast(segs, vals, size, perm).to_list()
-                == ak.broadcast(compressed_segs, compressed_vals, size, perm).to_list()
+                ak.broadcast(segs, vals, size, perm).tolist()
+                == ak.broadcast(compressed_segs, compressed_vals, size, perm).tolist()
             )
 
     def test_nan_broadcast(self):
@@ -310,84 +310,84 @@ class TestGroupBy:
     def test_count(self):
         keys, counts = self.igb.size()
 
-        assert [1, 2, 3, 4, 5] == keys.to_list()
-        assert [1, 4, 2, 1, 2] == counts.to_list()
+        assert [1, 2, 3, 4, 5] == keys.tolist()
+        assert [1, 4, 2, 1, 2] == counts.tolist()
 
     def test_broadcast_ints(self):
         keys, counts = self.igb.size()
 
         results = self.igb.broadcast(1 * (counts > 2), permute=False)
-        assert [0, 1, 1, 1, 1, 0, 0, 0, 0, 0] == results.to_list()
+        assert [0, 1, 1, 1, 1, 0, 0, 0, 0, 0] == results.tolist()
 
         results = self.igb.broadcast(1 * (counts == 2), permute=False)
-        assert [0, 0, 0, 0, 0, 1, 1, 0, 1, 1] == results.to_list()
+        assert [0, 0, 0, 0, 0, 1, 1, 0, 1, 1] == results.tolist()
 
         results = self.igb.broadcast(1 * (counts < 4), permute=False)
-        assert [1, 0, 0, 0, 0, 1, 1, 1, 1, 1] == results.to_list()
+        assert [1, 0, 0, 0, 0, 1, 1, 1, 1, 1] == results.tolist()
 
         results = self.igb.broadcast(1 * (counts > 2))
-        assert [0, 0, 0, 1, 1, 1, 0, 0, 1, 0] == results.to_list()
+        assert [0, 0, 0, 1, 1, 1, 0, 0, 1, 0] == results.tolist()
 
         results = self.igb.broadcast(1 * (counts == 2))
-        assert [0, 0, 1, 0, 0, 0, 1, 1, 0, 1] == results.to_list()
+        assert [0, 0, 1, 0, 0, 0, 1, 1, 0, 1] == results.tolist()
 
         results = self.igb.broadcast(1 * (counts < 4))
-        assert [1, 1, 1, 0, 0, 0, 1, 1, 0, 1] == results.to_list()
+        assert [1, 1, 1, 0, 0, 0, 1, 1, 0, 1] == results.tolist()
 
     def test_broadcast_uints(self):
         keys, counts = self.ugb.size()
-        assert [1, 4, 2, 1, 2] == counts.to_list()
-        assert [1, 2, 3, 4, 5] == keys.to_list()
+        assert [1, 4, 2, 1, 2] == counts.tolist()
+        assert [1, 2, 3, 4, 5] == keys.tolist()
 
         u_results = self.ugb.broadcast(1 * (counts > 2))
         i_results = self.igb.broadcast(1 * (counts > 2))
-        assert i_results.to_list() == u_results.to_list()
+        assert i_results.tolist() == u_results.tolist()
 
         u_results = self.ugb.broadcast(1 * (counts == 2))
         i_results = self.igb.broadcast(1 * (counts == 2))
-        assert i_results.to_list() == u_results.to_list()
+        assert i_results.tolist() == u_results.tolist()
 
         u_results = self.ugb.broadcast(1 * (counts < 4))
         i_results = self.igb.broadcast(1 * (counts < 4))
-        assert i_results.to_list() == u_results.to_list()
+        assert i_results.tolist() == u_results.tolist()
 
         # test uint Groupby.broadcast with and without permute
         u_results = self.ugb.broadcast(ak.array([1, 2, 6, 8, 9], dtype=ak.uint64), permute=False)
         i_results = self.igb.broadcast(ak.array([1, 2, 6, 8, 9], dtype=ak.uint64), permute=False)
-        assert i_results.to_list() == u_results.to_list()
+        assert i_results.tolist() == u_results.tolist()
         u_results = self.ugb.broadcast(ak.array([1, 2, 6, 8, 9], dtype=ak.uint64))
         i_results = self.igb.broadcast(ak.array([1, 2, 6, 8, 9], dtype=ak.uint64))
-        assert i_results.to_list() == u_results.to_list()
+        assert i_results.tolist() == u_results.tolist()
 
         # test uint broadcast
         u_results = ak.broadcast(ak.array([0]), ak.array([1], dtype=ak.uint64), 1)
         i_results = ak.broadcast(ak.array([0]), ak.array([1]), 1)
-        assert i_results.to_list() == u_results.to_list()
+        assert i_results.tolist() == u_results.tolist()
 
     def test_broadcast_strings(self):
         keys, counts = self.sgb.size()
-        assert [1, 4, 2, 1, 2] == counts.to_list()
-        assert ["1", "2", "3", "4", "5"] == keys.to_list()
+        assert [1, 4, 2, 1, 2] == counts.tolist()
+        assert ["1", "2", "3", "4", "5"] == keys.tolist()
 
         s_results = self.sgb.broadcast(1 * (counts > 2))
         i_results = self.igb.broadcast(1 * (counts > 2))
-        assert i_results.to_list() == s_results.to_list()
+        assert i_results.tolist() == s_results.tolist()
 
         s_results = self.sgb.broadcast(1 * (counts == 2))
         i_results = self.igb.broadcast(1 * (counts == 2))
-        assert i_results.to_list() == s_results.to_list()
+        assert i_results.tolist() == s_results.tolist()
 
         s_results = self.sgb.broadcast(1 * (counts < 4))
         i_results = self.igb.broadcast(1 * (counts < 4))
-        assert i_results.to_list() == s_results.to_list()
+        assert i_results.tolist() == s_results.tolist()
 
         # test str Groupby.broadcast with and without permute
         s_results = self.sgb.broadcast(ak.array(["1", "2", "6", "8", "9"]), permute=False)
         i_results = self.igb.broadcast(ak.array(["1", "2", "6", "8", "9"]), permute=False)
-        assert i_results.to_list() == s_results.to_list()
+        assert i_results.tolist() == s_results.tolist()
         s_results = self.sgb.broadcast(ak.array(["1", "2", "6", "8", "9"]))
         i_results = self.igb.broadcast(ak.array(["1", "2", "6", "8", "9"]))
-        assert i_results.to_list() == s_results.to_list()
+        assert i_results.tolist() == s_results.tolist()
 
     def test_broadcast_bigints(self):
         # use reproducer to verify >64 bits work
@@ -396,67 +396,67 @@ class TestGroupBy:
         segs = ak.array([0, 2, 5])
         bi_broad = ak.groupbyclass.broadcast(segs, a, 8)
         indices = ak.broadcast(segs, ak.arange(3), 8)
-        assert bi_broad.to_list() == a[indices].to_list()
+        assert bi_broad.tolist() == a[indices].tolist()
         assert bi_broad.max_bits == a.max_bits
 
         # verify max_bits is preserved by broadcast
         a.max_bits = 201
         bi_broad = ak.broadcast(segs, a, 8)
-        assert bi_broad.to_list() == a[indices].to_list()
+        assert bi_broad.tolist() == a[indices].tolist()
         assert bi_broad.max_bits == a.max_bits
 
         # do the same tests as uint and compare the results
         keys, counts = self.bigb.size()
-        assert [1, 4, 2, 1, 2] == counts.to_list()
-        assert [1, 2, 3, 4, 5] == keys.to_list()
+        assert [1, 4, 2, 1, 2] == counts.tolist()
+        assert [1, 2, 3, 4, 5] == keys.tolist()
 
         u_results = self.ugb.broadcast(1 * (counts > 2))
         bi_results = self.bigb.broadcast(1 * (counts > 2))
-        assert bi_results.to_list() == u_results.to_list()
+        assert bi_results.tolist() == u_results.tolist()
 
         u_results = self.ugb.broadcast(1 * (counts == 2))
         bi_results = self.bigb.broadcast(1 * (counts == 2))
-        assert bi_results.to_list() == u_results.to_list()
+        assert bi_results.tolist() == u_results.tolist()
 
         u_results = self.ugb.broadcast(1 * (counts < 4))
         bi_results = self.bigb.broadcast(1 * (counts < 4))
-        assert bi_results.to_list() == u_results.to_list()
+        assert bi_results.tolist() == u_results.tolist()
 
         # test bigint Groupby.broadcast with and without permute with > 64 bit values
         u_results = self.ugb.broadcast(ak.array([1, 2, 6, 8, 9], dtype=ak.uint64), permute=False)
         bi_results = self.bigb.broadcast(
             ak.array([1, 2, 6, 8, 9], dtype=ak.bigint) + 2**200, permute=False
         )
-        assert (bi_results - 2**200).to_list() == u_results.to_list()
+        assert (bi_results - 2**200).tolist() == u_results.tolist()
         u_results = self.ugb.broadcast(ak.array([1, 2, 6, 8, 9], dtype=ak.uint64))
         bi_results = self.bigb.broadcast(ak.array([1, 2, 6, 8, 9], dtype=ak.bigint) + 2**200)
-        assert (bi_results - 2**200).to_list() == u_results.to_list()
+        assert (bi_results - 2**200).tolist() == u_results.tolist()
 
         # test bigint broadcast
         u_results = ak.broadcast(ak.array([0]), ak.array([1], dtype=ak.uint64), 1)
         bi_results = ak.broadcast(ak.array([0]), ak.array([1], dtype=ak.bigint), 1)
-        assert bi_results.to_list() == u_results.to_list()
+        assert bi_results.tolist() == u_results.tolist()
 
     def test_broadcast_booleans(self):
         keys, counts = self.igb.size()
 
         results = self.igb.broadcast(counts > 2, permute=False)
-        assert [0, 1, 1, 1, 1, 0, 0, 0, 0, 0] == results.to_list()
+        assert [0, 1, 1, 1, 1, 0, 0, 0, 0, 0] == results.tolist()
 
         results = self.igb.broadcast(counts == 2, permute=False)
-        assert [0, 0, 0, 0, 0, 1, 1, 0, 1, 1] == results.to_list()
+        assert [0, 0, 0, 0, 0, 1, 1, 0, 1, 1] == results.tolist()
 
         results = self.igb.broadcast(counts < 4, permute=False)
-        assert [1, 0, 0, 0, 0, 1, 1, 1, 1, 1] == results.to_list()
+        assert [1, 0, 0, 0, 0, 1, 1, 1, 1, 1] == results.tolist()
 
         results = self.igb.broadcast(counts > 2)
-        assert [0, 0, 0, 1, 1, 1, 0, 0, 1, 0] == results.to_list()
+        assert [0, 0, 0, 1, 1, 1, 0, 0, 1, 0] == results.tolist()
 
         results = self.igb.broadcast(counts == 2)
-        assert [0, 0, 1, 0, 0, 0, 1, 1, 0, 1] == results.to_list()
+        assert [0, 0, 1, 0, 0, 0, 1, 1, 0, 1] == results.tolist()
 
         results = self.igb.broadcast(counts < 4)
-        assert [1, 1, 1, 0, 0, 0, 1, 1, 0, 1] == results.to_list()
+        assert [1, 1, 1, 0, 0, 0, 1, 1, 0, 1] == results.tolist()
 
     def test_groupby_reduction_type(self):
         assert "any" == str(GroupByReductionType.ANY)
@@ -548,7 +548,7 @@ class TestGroupBy:
             g = ak.GroupBy(key)
             for val in keys:
                 k, n = g.nunique(val)
-                assert n.to_list() == [1, 1, 1]
+                assert n.tolist() == [1, 1, 1]
 
     def test_type_failure_multilevel_groupby_aggregate(self):
         # just checking no error occurs with hotfix for Issue 858
@@ -565,8 +565,8 @@ class TestGroupBy:
         u_keys, u_group_sums = gu.sum(u)
         i_keys, i_group_sums = gi.sum(i)
 
-        assert u_keys.to_list() == i_keys.to_list()
-        assert u_group_sums.to_list() == i_group_sums.to_list()
+        assert u_keys.tolist() == i_keys.tolist()
+        assert u_group_sums.tolist() == i_group_sums.tolist()
 
         # verify the multidim unsigned version doesnt break
         ak.GroupBy([u, u])
@@ -577,8 +577,8 @@ class TestGroupBy:
         g = ak.GroupBy(labels)
         u_unique_keys, u_group_nunique = g.nunique(u_data)
         i_unique_keys, i_group_nunique = g.nunique(i_data)
-        assert u_unique_keys.to_list() == i_unique_keys.to_list()
-        assert u_group_nunique.to_list() == i_group_nunique.to_list()
+        assert u_unique_keys.tolist() == i_unique_keys.tolist()
+        assert u_group_nunique.tolist() == i_group_nunique.tolist()
 
     def test_groupby_count(self):
         a = ak.array([1, 0, -1, 1, -1, -1])
@@ -621,8 +621,8 @@ class TestGroupBy:
             # order isn't guaranteed so argsort and permute
             i_perm = ak.argsort(i_unique)
             bi_perm = ak.argsort(shift_down)
-            assert i_counts[i_perm].to_list() == bi_counts[bi_perm].to_list()
-            assert i_unique[i_perm].to_list() == shift_down[bi_perm].to_list()
+            assert i_counts[i_perm].tolist() == bi_counts[bi_perm].tolist()
+            assert i_unique[i_perm].tolist() == shift_down[bi_perm].tolist()
 
         # multilevel groupby
         (i1_unique, i2_unique), i_counts = ak.GroupBy(int_arrays).size()
@@ -632,9 +632,9 @@ class TestGroupBy:
         # order isn't guaranteed so argsort and permute
         i_perm = ak.coargsort((i1_unique, i2_unique))
         bi_perm = ak.coargsort((shift_down1, shift_down2))
-        assert i_counts[i_perm].to_list() == bi_counts[bi_perm].to_list()
-        assert i1_unique[i_perm].to_list() == shift_down1[bi_perm].to_list()
-        assert i2_unique[i_perm].to_list() == shift_down2[bi_perm].to_list()
+        assert i_counts[i_perm].tolist() == bi_counts[bi_perm].tolist()
+        assert i1_unique[i_perm].tolist() == shift_down1[bi_perm].tolist()
+        assert i2_unique[i_perm].tolist() == shift_down2[bi_perm].tolist()
 
         # verify we can groupby bigint with other typed arrays
         mixted_types_arrays = [[bi_a, b], [a, bi_b], [bi_b, a], [b, bi_a]]
@@ -665,13 +665,13 @@ class TestGroupBy:
         for agg in aggregations:
             u_res = u_gb.aggregate(vals, agg)
             bi_res = bi_gb.aggregate(vals, agg)
-            assert u_res[0].to_list() == bi_res[0].to_list()
-            assert u_res[1].to_list() == bi_res[1].to_list()
+            assert u_res[0].tolist() == bi_res[0].tolist()
+            assert u_res[1].tolist() == bi_res[1].tolist()
 
             u_res = u_gb.aggregate(bi, agg)
             bi_res = bi_gb.aggregate(bi, agg)
-            assert u_res[0].to_list() == bi_res[0].to_list()
-            assert u_res[1].to_list() == bi_res[1].to_list()
+            assert u_res[0].tolist() == bi_res[0].tolist()
+            assert u_res[1].tolist() == bi_res[1].tolist()
 
         # test aggregations with > 64 bits and scale back down
         i = ak.arange(10)
@@ -682,8 +682,8 @@ class TestGroupBy:
         for agg in other_aggs:
             i_res = gb.aggregate(i, agg)
             bi_res = gb.aggregate(bi, agg)
-            assert i_res[0].to_list() == bi_res[0].to_list()
-            assert i_res[1].to_list() == (bi_res[1] - 2**200).to_list()
+            assert i_res[0].tolist() == bi_res[0].tolist()
+            assert i_res[1].tolist() == (bi_res[1] - 2**200).tolist()
 
     def test_zero_length_groupby(self):
         """
@@ -739,7 +739,7 @@ class TestGroupBy:
         if dtype == ak.bool_:
             assert aksum(values) == aksum(expected_values)
         else:
-            assert set(values.to_list()) == set(expected_values.to_list())
+            assert set(values.tolist()) == set(expected_values.tolist())
 
     @pytest.mark.parametrize("dtype", ["bool", "str_", "int64", "float64"])
     @pytest.mark.parametrize("size", pytest.prob_size)
@@ -788,7 +788,7 @@ class TestGroupBy:
         if dtype == ak.bool_:
             assert aksum(values) == aksum(expected_values)
         else:
-            assert set(values.to_list()) == set(expected_values.to_list())
+            assert set(values.tolist()) == set(expected_values.tolist())
 
     def test_first_aggregation(self):
         keys = ak.array([0, 1, 0, 1, 0, 1])
@@ -796,7 +796,7 @@ class TestGroupBy:
         ans = [9, 8]
         g = ak.GroupBy(keys)
         _, res = g.first(vals)
-        assert ans == res.to_list()
+        assert ans == res.tolist()
 
     def test_mode_aggregation(self):
         keys = ak.array([0, 1, 0, 1, 0, 1, 0, 1])
@@ -804,11 +804,11 @@ class TestGroupBy:
         ans = [5, 3]
         g = ak.GroupBy(keys)
         _, res = g.mode(vals)
-        assert ans == res.to_list()
+        assert ans == res.tolist()
         # Test with multi-array values
         _, res2 = g.mode([vals, vals])
-        assert ans == res2[0].to_list()
-        assert ans == res2[1].to_list()
+        assert ans == res2[0].tolist()
+        assert ans == res2[1].tolist()
 
     def test_large_mean_aggregation(self):
         # reproducer for integer overflow in groupby.mean
@@ -816,7 +816,7 @@ class TestGroupBy:
 
         # since all values of a are the same, all means should be 2**63 - 1
         _, means = ak.GroupBy(ak.arange(10) % 3).mean(a)
-        for m in means.to_list():
+        for m in means.tolist():
             assert np.isclose(float(a[0]), m)
 
     #   ak.unique takes 1 pda argument and 3 booleans
@@ -894,13 +894,13 @@ class TestGroupBy:
         ans = [[4, 5, 6], [2, 3]]
         g = ak.GroupBy(keys)
         _, res = g.unique(vals)
-        for a, r in zip(ans, res.to_list()):
+        for a, r in zip(ans, res.tolist()):
             assert a == r
         # Test with multi-array values
         _, res2 = g.unique([vals, vals])
-        for a, r in zip(ans, res2[0].to_list()):
+        for a, r in zip(ans, res2[0].tolist()):
             assert a == r
-        for a, r in zip(ans, res2[1].to_list()):
+        for a, r in zip(ans, res2[1].tolist()):
             assert a == r
 
     def test_sample_hypothesis_testing(self):
@@ -992,8 +992,8 @@ class TestGroupBy:
                             random_state=rng,
                         )
 
-                        res = np.allclose(previous1.to_list(), current1.to_list()) and np.allclose(
-                            previous2.to_list(), current2.to_list()
+                        res = np.allclose(previous1.tolist(), current1.tolist()) and np.allclose(
+                            previous2.tolist(), current2.tolist()
                         )
                         if not res:
                             print(f"\nnum locales: {cfg['numLocales']}")
@@ -1007,5 +1007,5 @@ class TestGroupBy:
         unique_keys, nuniq = g.nunique(vals)
         expected_unique_keys = ["1", "2"]
         expected_nuniq = [8, 3]
-        assert expected_unique_keys == unique_keys.to_list()
-        assert expected_nuniq == nuniq.to_list()
+        assert expected_unique_keys == unique_keys.tolist()
+        assert expected_nuniq == nuniq.tolist()

--- a/tests/pandas/index_test.py
+++ b/tests/pandas/index_test.py
@@ -48,7 +48,7 @@ class TestIndex:
 
         assert isinstance(idx, ak.Index)
         assert idx.size == size
-        assert idx.to_list() == list(range(size))
+        assert idx.tolist() == list(range(size))
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_index_creation_strings(self, size):
@@ -57,7 +57,7 @@ class TestIndex:
 
         assert isinstance(idx, ak.Index)
         assert idx.size == size
-        assert idx.to_list() == strings1.to_list()
+        assert idx.tolist() == strings1.tolist()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_index_creation_from_index(self, size):
@@ -437,16 +437,16 @@ class TestIndex:
     def test_argsort(self):
         idx = ak.Index.factory(ak.arange(5))
         i = idx.argsort(False)
-        assert i.to_list() == [4, 3, 2, 1, 0]
+        assert i.tolist() == [4, 3, 2, 1, 0]
 
         idx = ak.Index(ak.array([1, 0, 4, 2, 5, 3]))
         i = idx.argsort()
         # values should be the indexes in the array of idx
-        assert i.to_list() == [1, 0, 3, 5, 2, 4]
+        assert i.tolist() == [1, 0, 3, 5, 2, 4]
 
         i = ak.Index([1, 2, 3])
-        assert i.argsort(ascending=True).to_list() == [0, 1, 2]
-        assert i.argsort(ascending=False).to_list() == [2, 1, 0]
+        assert i.argsort(ascending=True).tolist() == [0, 1, 2]
+        assert i.argsort(ascending=False).tolist() == [2, 1, 0]
 
         i2 = ak.Index([1, 2, 3], allow_list=True)
         assert i2.argsort(ascending=True) == [0, 1, 2]
@@ -457,14 +457,14 @@ class TestIndex:
         assert i3.argsort(ascending=False) == [2, 1, 0]
 
         i4 = ak.Index(ak.array(["a", "b", "c"]))
-        assert i4.argsort(ascending=True).to_list() == [0, 1, 2]
-        assert i4.argsort(ascending=False).to_list() == [2, 1, 0]
+        assert i4.argsort(ascending=True).tolist() == [0, 1, 2]
+        assert i4.argsort(ascending=False).tolist() == [2, 1, 0]
 
     def test_map(self):
         idx = ak.Index(ak.array([2, 3, 2, 3, 4]))
 
         result = idx.map({4: 25.0, 2: 30.0, 1: 7.0, 3: 5.0})
-        assert result.values.to_list() == [30.0, 5.0, 30.0, 5.0, 25.0]
+        assert result.values.tolist() == [30.0, 5.0, 30.0, 5.0, 25.0]
 
     def test_concat(self):
         idx_1 = ak.Index.factory(ak.arange(5))
@@ -472,27 +472,27 @@ class TestIndex:
         idx_2 = ak.Index(ak.array([2, 4, 1, 3, 0]))
 
         idx_full = idx_1.concat(idx_2)
-        assert idx_full.to_list() == [0, 1, 2, 3, 4, 2, 4, 1, 3, 0]
+        assert idx_full.tolist() == [0, 1, 2, 3, 4, 2, 4, 1, 3, 0]
 
         i = ak.Index([1, 2, 3], allow_list=True)
         i2 = ak.Index(["a", "b", "c"], allow_list=True)
-        assert i.concat(i2).to_list() == ["1", "2", "3", "a", "b", "c"]
+        assert i.concat(i2).tolist() == ["1", "2", "3", "a", "b", "c"]
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_lookup(self, size):
         idx = ak.Index.factory(ak.arange(size))
         lk = idx.lookup(ak.array([0, size - 1]))
 
-        assert lk.to_list() == [i in [0, size - 1] for i in range(size)]
+        assert lk.tolist() == [i in [0, size - 1] for i in range(size)]
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_multi_argsort(self, size):
         idx = ak.Index.factory([ak.arange(size), ak.arange(size)])
         s = idx.argsort(False)
-        assert s.to_list() == list(reversed(range(size)))
+        assert s.tolist() == list(reversed(range(size)))
 
         s = idx.argsort()
-        assert s.to_list() == list(range(size))
+        assert s.tolist() == list(range(size))
 
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_multi_concat(self, size):
@@ -512,7 +512,7 @@ class TestIndex:
         lk = ak.array(truth)
         result = idx.lookup([lk, lk])
 
-        assert result.to_list() == [i in truth for i in range(size)]
+        assert result.tolist() == [i in truth for i in range(size)]
 
     def test_save(self, df_test_base_tmp):
         locale_count = ak.get_config()["numLocales"]
@@ -577,18 +577,18 @@ class TestIndex:
         i4 = ak.Index(ak.array(["a", "b", "c"]))
         assert array_equal(i4.to_ndarray(), ndarray(["a", "b", "c"]))
 
-    def test_to_list(self):
+    def test_tolist(self):
         i = ak.Index([1, 2, 3])
-        assert i.to_list() == [1, 2, 3]
+        assert i.tolist() == [1, 2, 3]
 
         i2 = ak.Index([1, 2, 3], allow_list=True)
-        assert i2.to_list() == [1, 2, 3]
+        assert i2.tolist() == [1, 2, 3]
 
         i3 = ak.Index(["a", "b", "c"], allow_list=True)
-        assert i3.to_list() == ["a", "b", "c"]
+        assert i3.tolist() == ["a", "b", "c"]
 
         i4 = ak.Index(ak.array(["a", "b", "c"]))
-        assert i4.to_list() == ["a", "b", "c"]
+        assert i4.tolist() == ["a", "b", "c"]
 
     def test_register_list_values(self):
         i = ak.Index([1, 2, 3], allow_list=True)

--- a/tests/pandas/io_test.py
+++ b/tests/pandas/io_test.py
@@ -367,7 +367,7 @@ class TestParquet:
             ak_vals = ak.read_parquet(f"{file_name}*")
 
             for key in ak_dict:
-                assert ak_vals[key].to_list() == ak_dict[key].to_list()
+                assert ak_vals[key].tolist() == ak_dict[key].tolist()
 
     @pytest.mark.parametrize("dtype", NUMERIC_AND_STR_TYPES)
     def test_append_empty(self, par_test_base_tmp, dtype):
@@ -377,7 +377,7 @@ class TestParquet:
             ak_arr.to_parquet(f"{tmp_dirname}/pq_test_correct", "my-dset", mode="append")
             pq_arr = ak.read_parquet(f"{tmp_dirname}/pq_test_correct*", "my-dset")["my-dset"]
 
-            assert ak_arr.to_list() == pq_arr.to_list()
+            assert ak_arr.tolist() == pq_arr.tolist()
 
     @pytest.mark.parametrize("comp", COMPRESSIONS)
     def test_null_strings(self, par_test_base_tmp, comp):
@@ -391,7 +391,7 @@ class TestParquet:
 
             # datasets must be specified for get_null_indices
             res = ak.get_null_indices(f"{file_name}*", datasets="strings_array").popitem()[1]
-            assert [0, 1, 0, 1, 0, 1, 1] == res.to_list()
+            assert [0, 1, 0, 1, 0, 1, 1] == res.tolist()
 
     def test_null_indices(self):
         datadir = "resources/parquet-testing"
@@ -400,7 +400,7 @@ class TestParquet:
         filename = os.path.join(datadir, basename)
         res = ak.get_null_indices(filename, datasets="col1")["col1"]
 
-        assert [0, 1, 0, 1, 0, 1, 1] == res.to_list()
+        assert [0, 1, 0, 1, 0, 1, 1] == res.tolist()
 
     @pytest.mark.parametrize("comp", COMPRESSIONS)
     def test_compression(self, par_test_base_tmp, comp):
@@ -414,7 +414,7 @@ class TestParquet:
             rd_arr = ak.read_parquet(f"{tmp_dirname}/compress_test*", "array")["array"]
 
             # validate the list read out matches the array used to write
-            assert rd_arr.to_list() == a.to_list()
+            assert rd_arr.tolist() == a.tolist()
 
         b = ak.randint(0, 2, 150, dtype=ak.bool_)
 
@@ -426,7 +426,7 @@ class TestParquet:
             rd_arr = ak.read_parquet(f"{tmp_dirname}/compress_test*", "array")["array"]
 
             # validate the list read out matches the array used to write
-            assert rd_arr.to_list() == b.to_list()
+            assert rd_arr.tolist() == b.tolist()
 
     @pytest.mark.parametrize("comp", COMPRESSIONS)
     def test_nan_compressions(self, par_test_base_tmp, comp):
@@ -500,7 +500,7 @@ class TestParquet:
             ak_data = ak.read_parquet(f"{file_name}*")
             for k, v in ak_data.items():
                 assert isinstance(v, ak.SegArray)
-                for x, y in zip(df[k].tolist(), v.to_list()):
+                for x, y in zip(df[k].tolist(), v.tolist()):
                     if isinstance(x, np.ndarray):
                         x = x.tolist()
                     assert x == y if k != "FloatList" else np.allclose(x, y, equal_nan=True)
@@ -509,7 +509,7 @@ class TestParquet:
             for k, v in df.items():
                 ak_data = ak.read_parquet(f"{file_name}*", datasets=k)[k]
                 assert isinstance(ak_data, ak.SegArray)
-                for x, y in zip(v.tolist(), ak_data.to_list()):
+                for x, y in zip(v.tolist(), ak_data.tolist()):
                     if isinstance(x, np.ndarray):
                         x = x.tolist()
                     assert x == y if k != "FloatList" else np.allclose(x, y, equal_nan=True)
@@ -524,7 +524,7 @@ class TestParquet:
             assert isinstance(ak_data, ak.SegArray)
             assert ak_data.size == 5
             for i in range(5):
-                assert df["ListCol"][i] == ak_data[i].to_list()
+                assert df["ListCol"][i] == ak_data[i].tolist()
 
         df = pd.DataFrame(
             {
@@ -540,15 +540,15 @@ class TestParquet:
             # read full file
             ak_data = ak.read_parquet(f"{file_name}*")
             for k, v in ak_data.items():
-                assert df[k].tolist() == v.to_list()
+                assert df[k].tolist() == v.tolist()
 
             # read individual datasets
             ak_data = ak.read_parquet(f"{file_name}*", datasets="IntCol")["IntCol"]
             assert isinstance(ak_data, ak.pdarray)
-            assert df["IntCol"].to_list() == ak_data.to_list()
+            assert df["IntCol"].tolist() == ak_data.tolist()
             ak_data = ak.read_parquet(f"{file_name}*", datasets="ListCol")["ListCol"]
             assert isinstance(ak_data, ak.SegArray)
-            assert df["ListCol"].to_list() == ak_data.to_list()
+            assert df["ListCol"].tolist() == ak_data.tolist()
 
         # test for multi-file with and without empty segs
         is_multi_loc = pytest.nl != 1
@@ -592,7 +592,7 @@ class TestParquet:
                 assert isinstance(ak_data, ak.SegArray)
                 assert ak_data.size == len(lists[0]) * NUM_FILES
                 for i in range(ak_data.size):
-                    assert combo["ListCol"][i] == ak_data[i].to_list()
+                    assert combo["ListCol"][i] == ak_data[i].tolist()
 
     def test_segarray_string(self, par_test_base_tmp):
         words = ak.array(["one,two,three", "uno,dos,tres"])
@@ -604,9 +604,9 @@ class TestParquet:
 
             rd = ak.read_parquet(f"{tmp_dirname}/segarr_str_*").popitem()[1]
             assert isinstance(rd, ak.SegArray)
-            assert x.segments.to_list() == rd.segments.to_list()
-            assert x.values.to_list() == rd.values.to_list()
-            assert x.to_list() == rd.to_list()
+            assert x.segments.tolist() == rd.segments.tolist()
+            assert x.values.tolist() == rd.values.tolist()
+            assert x.tolist() == rd.tolist()
 
         # additional testing for empty segments. See Issue #2560
         a, c = (
@@ -617,7 +617,7 @@ class TestParquet:
         with tempfile.TemporaryDirectory(dir=par_test_base_tmp) as tmp_dirname:
             s.to_parquet(f"{tmp_dirname}/segarray_test_empty")
             rd_data = ak.read_parquet(f"{tmp_dirname}/segarray_test_empty_*").popitem()[1]
-            assert s.to_list() == rd_data.to_list()
+            assert s.tolist() == rd_data.tolist()
 
     @pytest.mark.parametrize("dtype", NUMERIC_AND_STR_TYPES)
     @pytest.mark.parametrize("segarray_create", [segarray_setup, edge_case_segarray_setup])
@@ -629,7 +629,7 @@ class TestParquet:
 
             rd_data = ak.read_parquet(f"{tmp_dirname}/segarray_test*").popitem()[1]
             for i in range(3):
-                x, y = s[i].to_list(), rd_data[i].to_list()
+                x, y = s[i].tolist(), rd_data[i].tolist()
                 assert x == y if dtype != "float64" else np.allclose(x, y, equal_nan=True)
 
         s = ak.SegArray(ak.array([0, 0, len(a), len(a), len(a), len(a) + len(c)]), ak.array(a + c))
@@ -638,7 +638,7 @@ class TestParquet:
 
             rd_data = ak.read_parquet(f"{tmp_dirname}/segarray_test_empty*").popitem()[1]
             for i in range(6):
-                x, y = s[i].to_list(), rd_data[i].to_list()
+                x, y = s[i].tolist(), rd_data[i].tolist()
                 assert x == y if dtype != "float64" else np.allclose(x, y, equal_nan=True)
 
     @pytest.mark.parametrize("comp", COMPRESSIONS)
@@ -673,7 +673,7 @@ class TestParquet:
             df_pd.to_parquet(file_name)
             df_ak = ak.DataFrame(ak.read_parquet(f"{file_name}*"))
             for c in df_ak.columns.values:
-                assert df_ak[c].to_list() == df_pd[c].to_list()
+                assert df_ak[c].tolist() == df_pd[c].tolist()
 
     def test_read_nested(self, par_test_base_tmp):
         df = ak.DataFrame(
@@ -690,20 +690,20 @@ class TestParquet:
             data = ak.read_parquet(f"{file_name}*")
             assert "idx" in data
             assert "seg" in data
-            assert df["idx"].to_list() == data["idx"].to_list()
-            assert df["seg"].to_list() == data["seg"].to_list()
+            assert df["idx"].tolist() == data["idx"].tolist()
+            assert df["seg"].tolist() == data["seg"].tolist()
 
             # test read with read_nested=false and no supplied datasets
             data = ak.read_parquet(f"{file_name}*", read_nested=False)["idx"]
             assert isinstance(data, ak.pdarray)
-            assert df["idx"].to_list() == data.to_list()
+            assert df["idx"].tolist() == data.tolist()
 
             # test read with read_nested=false and user supplied datasets. Should ignore read_nested
             data = ak.read_parquet(f"{file_name}*", datasets=["idx", "seg"], read_nested=False)
             assert "idx" in data
             assert "seg" in data
-            assert df["idx"].to_list() == data["idx"].to_list()
-            assert df["seg"].to_list() == data["seg"].to_list()
+            assert df["idx"].tolist() == data["idx"].tolist()
+            assert df["seg"].tolist() == data["seg"].tolist()
 
     @pytest.mark.parametrize("comp", COMPRESSIONS)
     def test_ipv4_columns(self, par_test_base_tmp, comp):
@@ -733,7 +733,7 @@ class TestParquet:
         # test replacement of IPv4 with uint representation
         df = ak.DataFrame({"a": ak.IPv4(ak.arange(10))})
         df["a"] = df["a"].export_uint()
-        assert ak.arange(10).to_list() == df["a"].to_list()
+        assert ak.arange(10).tolist() == df["a"].tolist()
 
     def test_decimal_reads(self, par_test_base_tmp):
         cols = []
@@ -784,7 +784,7 @@ class TestParquet:
                     ak.sort(ak.randint(0, val_size, val_size - 1, seed=seed)),
                 ]
             )
-            df_dict["rand"] = ak.SegArray(segs, vals).to_list()
+            df_dict["rand"] = ak.SegArray(segs, vals).tolist()
 
             pddf = pd.DataFrame(df_dict)
             with tempfile.TemporaryDirectory(dir=par_test_base_tmp) as tmp_dirname:
@@ -792,9 +792,9 @@ class TestParquet:
                 pddf.to_parquet(file_path)
                 akdf = ak.DataFrame(ak.read_parquet(file_path))
 
-                to_pd = pd.Series(akdf["rand"].to_list())
+                to_pd = pd.Series(akdf["rand"].tolist())
                 # raises an error if the two series aren't equal
-                # we can't use np.allclose(pddf['rand'].to_list, akdf['rand'].to_list) since these
+                # we can't use np.allclose(pddf['rand'].tolist, akdf['rand'].tolist) since these
                 # are lists of lists. assert_series_equal handles this and properly handles nans.
                 # we pass the same absolute and relative tolerances as the numpy default in allclose
                 # to ensure float point differences don't cause errors
@@ -806,7 +806,7 @@ class TestParquet:
                 vals.to_parquet(file_path, dataset="my_vals")
                 read = ak.read_parquet(file_path + "*")["my_vals"]
                 if isinstance(vals, ak.pdarray) and vals.dtype == ak.float64:
-                    assert np.allclose(read.to_list(), vals.to_list(), equal_nan=True)
+                    assert np.allclose(read.tolist(), vals.tolist(), equal_nan=True)
                 else:
                     assert (read == vals).all()
 
@@ -1362,7 +1362,7 @@ class TestHDF5:
             for col_name in akdf.columns.values:
                 gen_arr = ak.read_hdf(f"{file_name}*", datasets=[col_name])[col_name]
                 if akdf[col_name].dtype != ak.float64:
-                    assert akdf[col_name].to_list() == gen_arr.to_list()
+                    assert akdf[col_name].tolist() == gen_arr.tolist()
                 else:
                     a = akdf[col_name].to_ndarray()
                     b = gen_arr.to_ndarray()
@@ -1402,7 +1402,7 @@ class TestHDF5:
                 # verify generic load works
                 gen_arr = ak.load(path_prefix=file_name, dataset=col_name)[col_name]
                 if akdf[col_name].dtype != ak.float64:
-                    assert akdf[col_name].to_list() == gen_arr.to_list()
+                    assert akdf[col_name].tolist() == gen_arr.tolist()
                 else:
                     a = akdf[col_name].to_ndarray()
                     b = gen_arr.to_ndarray()
@@ -1414,7 +1414,7 @@ class TestHDF5:
                 # verify generic load works with file_format parameter
                 gen_arr = ak.load(path_prefix=file_name, dataset=col_name, file_format="HDF5")[col_name]
                 if akdf[col_name].dtype != ak.float64:
-                    assert akdf[col_name].to_list() == gen_arr.to_list()
+                    assert akdf[col_name].tolist() == gen_arr.tolist()
                 else:
                     a = akdf[col_name].to_ndarray()
                     b = gen_arr.to_ndarray()
@@ -1623,12 +1623,12 @@ class TestHDF5:
         r_floats = ak.sort(
             ak.load("{}/multi-type-test".format(hdf_test_base_tmp), dataset="m_floats")["m_floats"]
         )
-        assert m_floats.to_list() == r_floats.to_list()
+        assert m_floats.tolist() == r_floats.tolist()
 
         r_ints = ak.sort(
             ak.load("{}/multi-type-test".format(hdf_test_base_tmp), dataset="m_ints")["m_ints"]
         )
-        assert m_ints.to_list() == r_ints.to_list()
+        assert m_ints.tolist() == r_ints.tolist()
 
         strings = strings_array.to_ndarray()
         strings.sort()
@@ -1654,7 +1654,7 @@ class TestHDF5:
         r_strings_dupe = ak.load(
             "{}/append-strings-test".format(hdf_test_base_tmp), dataset="strings-dupe"
         )["strings-dupe"]
-        assert r_strings.to_list() == r_strings_dupe.to_list()
+        assert r_strings.tolist() == r_strings_dupe.tolist()
 
     def testAppendMixedStringsDataset(self, hdf_test_base_tmp):
         strings_array = ak.array(["string {}".format(num) for num in list(range(0, 25))])
@@ -1680,8 +1680,8 @@ class TestHDF5:
         r_ints = ak.sort(
             ak.load("{}/append-multi-type-test".format(hdf_test_base_tmp), dataset="m_ints")["m_ints"]
         )
-        assert m_floats.to_list() == r_floats.to_list()
-        assert m_ints.to_list() == r_ints.to_list()
+        assert m_floats.tolist() == r_floats.tolist()
+        assert m_ints.tolist() == r_ints.tolist()
 
         strings = strings_array.to_ndarray()
         strings.sort()
@@ -1709,7 +1709,7 @@ class TestHDF5:
                 loaded = ak.load(file_name, dataset=col_name)[col_name]
                 for arr in [loaded, r_mixed[col_name]]:
                     if df_dict[col_name].dtype != ak.float64:
-                        assert df_dict[col_name].to_list() == arr.to_list()
+                        assert df_dict[col_name].tolist() == arr.tolist()
                     else:
                         a = df_dict[col_name].to_ndarray()
                         b = arr.to_ndarray()
@@ -1733,7 +1733,7 @@ class TestHDF5:
                 loaded = ak.load(file_name, dataset=col_name)[col_name]
                 for arr in [loaded, r_mixed[col_name]]:
                     if df_dict[col_name].dtype != ak.float64:
-                        assert df_dict[col_name].to_list() == arr.to_list()
+                        assert df_dict[col_name].tolist() == arr.tolist()
                     else:
                         a = df_dict[col_name].to_ndarray()
                         b = arr.to_ndarray()
@@ -1760,7 +1760,7 @@ class TestHDF5:
                 ak.read_hdf(f"{prefix}*")
 
             a = ak.read_hdf(f"{prefix}*", strict_types=False)
-            assert a["integers"].to_list() == np.arange(len(int_types) * N).tolist()
+            assert a["integers"].tolist() == np.arange(len(int_types) * N).tolist()
             assert np.allclose(
                 a["floats"].to_ndarray(),
                 np.arange(len(float_types) * N, dtype=np.float64),
@@ -1788,7 +1788,7 @@ class TestHDF5:
             pda2 = ak.load(f"{tmp_dirname}/small_numeric", dataset="pda1")["pda1"]
             assert str(pda1) == str(pda2)
             assert 18446744073709551500 == pda2[0]
-            assert pda2.to_list() == npa1.tolist()
+            assert pda2.tolist() == npa1.tolist()
 
     def test_uint64_to_from_array(self, hdf_test_base_tmp):
         """
@@ -1800,7 +1800,7 @@ class TestHDF5:
         )
         pda1 = ak.array(npa1)
         assert 18446744073709551500 == pda1[0]
-        assert pda1.to_list() == npa1.tolist()
+        assert pda1.tolist() == npa1.tolist()
 
     def test_bigint(self, hdf_test_base_tmp):
         df_dict = {
@@ -1817,24 +1817,24 @@ class TestHDF5:
             a = df_dict["pdarray"]
             for rd_a in [ret_dict["pdarray"], pda_loaded]:
                 assert isinstance(rd_a, ak.pdarray)
-                assert a.to_list() == rd_a.to_list()
+                assert a.tolist() == rd_a.tolist()
                 assert a.max_bits == rd_a.max_bits
 
             g_loaded = ak.read_hdf(f"{tmp_dirname}/bigint_test*", datasets="groupby")["groupby"]
             g = df_dict["groupby"]
             for rd_g in [ret_dict["groupby"], g_loaded]:
                 assert isinstance(rd_g, ak.GroupBy)
-                assert g.keys.to_list() == rd_g.keys.to_list()
-                assert g.unique_keys.to_list() == rd_g.unique_keys.to_list()
-                assert g.permutation.to_list() == rd_g.permutation.to_list()
-                assert g.segments.to_list() == rd_g.segments.to_list()
+                assert g.keys.tolist() == rd_g.keys.tolist()
+                assert g.unique_keys.tolist() == rd_g.unique_keys.tolist()
+                assert g.permutation.tolist() == rd_g.permutation.tolist()
+                assert g.segments.tolist() == rd_g.segments.tolist()
 
             sa_loaded = ak.read_hdf(f"{tmp_dirname}/bigint_test*", datasets="segarray")["segarray"]
             sa = df_dict["segarray"]
             for rd_sa in [ret_dict["segarray"], sa_loaded]:
                 assert isinstance(rd_sa, ak.SegArray)
-                assert sa.values.to_list() == rd_sa.values.to_list()
-                assert sa.segments.to_list() == rd_sa.segments.to_list()
+                assert sa.values.tolist() == rd_sa.values.tolist()
+                assert sa.segments.tolist() == rd_sa.segments.tolist()
 
     def test_unsanitized_dataset_names(self, hdf_test_base_tmp):
         # Test when quotes are part of the dataset name
@@ -1861,14 +1861,14 @@ class TestHDF5:
                 g.to_hdf(f"{tmp_dirname}/groupby_test")
                 g_load = ak.read(f"{tmp_dirname}/groupby_test*").popitem()[1]
                 assert len(g_load.keys) == len(g.keys)
-                assert g_load.permutation.to_list() == g.permutation.to_list()
-                assert g_load.segments.to_list() == g.segments.to_list()
-                assert g_load._uki.to_list() == g._uki.to_list()
+                assert g_load.permutation.tolist() == g.permutation.tolist()
+                assert g_load.segments.tolist() == g.segments.tolist()
+                assert g_load._uki.tolist() == g._uki.tolist()
                 if isinstance(g.keys[0], ak.Categorical):
                     for k, kload in zip(g.keys, g_load.keys):
-                        assert k.to_list() == kload.to_list()
+                        assert k.tolist() == kload.tolist()
                 else:
-                    assert g_load.keys.to_list() == g.keys.to_list()
+                    assert g_load.keys.tolist() == g.keys.tolist()
 
     def test_hdf_categorical(self, hdf_test_base_tmp):
         cat = ak.Categorical(ak.array(["a", "b", "a", "b", "c"]))
@@ -1880,10 +1880,10 @@ class TestHDF5:
                 c.to_hdf(f"{tmp_dirname}/categorical_test")
                 c_load = ak.read(f"{tmp_dirname}/categorical_test*").popitem()[1]
 
-                assert c_load.categories.to_list() == (["a", "b", "c", "N/A"])
+                assert c_load.categories.tolist() == (["a", "b", "c", "N/A"])
                 if c.segments is not None:
-                    assert c.segments.to_list() == c_load.segments.to_list()
-                    assert c.permutation.to_list() == c_load.permutation.to_list()
+                    assert c.segments.tolist() == c_load.segments.tolist()
+                    assert c.permutation.tolist() == c_load.permutation.tolist()
 
     def test_segarray_hdf(self, hdf_test_base_tmp):
         a = [0, 1, 2, 3]
@@ -1901,8 +1901,8 @@ class TestHDF5:
             segarr.to_hdf(f"{tmp_dirname}/segarray_int")
             # Now load it back in
             seg2 = ak.load(f"{tmp_dirname}/segarray_int", dataset="segarray")["segarray"]
-            assert segarr.segments.to_list() == seg2.segments.to_list()
-            assert segarr.values.to_list() == seg2.values.to_list()
+            assert segarr.segments.tolist() == seg2.segments.tolist()
+            assert segarr.values.tolist() == seg2.values.tolist()
 
         # uint64 test
         dtype = ak.numpy.dtypes.uint64
@@ -1913,8 +1913,8 @@ class TestHDF5:
             segarr.to_hdf(f"{tmp_dirname}/segarray_uint")
             # Now load it back in
             seg2 = ak.load(f"{tmp_dirname}/segarray_uint", dataset="segarray")["segarray"]
-            assert segarr.segments.to_list() == seg2.segments.to_list()
-            assert segarr.values.to_list() == seg2.values.to_list()
+            assert segarr.segments.tolist() == seg2.segments.tolist()
+            assert segarr.values.tolist() == seg2.values.tolist()
 
         # float64 test
         dtype = ak.numpy.dtypes.float64
@@ -1925,8 +1925,8 @@ class TestHDF5:
             segarr.to_hdf(f"{tmp_dirname}/segarray_float")
             # Now load it back in
             seg2 = ak.load(f"{tmp_dirname}/segarray_float", dataset="segarray")["segarray"]
-            assert segarr.segments.to_list() == seg2.segments.to_list()
-            assert segarr.values.to_list() == seg2.values.to_list()
+            assert segarr.segments.tolist() == seg2.segments.tolist()
+            assert segarr.values.tolist() == seg2.values.tolist()
 
         # bool test
         dtype = ak.numpy.dtypes.bool_
@@ -1937,8 +1937,8 @@ class TestHDF5:
             segarr.to_hdf(f"{tmp_dirname}/segarray_bool")
             # Now load it back in
             seg2 = ak.load(f"{tmp_dirname}/segarray_bool", dataset="segarray")["segarray"]
-            assert segarr.segments.to_list() == seg2.segments.to_list()
-            assert segarr.values.to_list() == seg2.values.to_list()
+            assert segarr.segments.tolist() == seg2.segments.tolist()
+            assert segarr.values.tolist() == seg2.values.tolist()
 
     def test_dataframe_segarr(self, hdf_test_base_tmp):
         a = [0, 1, 2, 3]
@@ -1968,8 +1968,8 @@ class TestHDF5:
             x.to_hdf(f"{tmp_dirname}/test_file")
             rd = ak.read_hdf(f"{tmp_dirname}/test_file*").popitem()[1]
             assert isinstance(rd, ak.SegArray)
-            assert x.segments.to_list() == rd.segments.to_list()
-            assert x.values.to_list() == rd.values.to_list()
+            assert x.segments.tolist() == rd.segments.tolist()
+            assert x.values.tolist() == rd.values.tolist()
 
     def test_hdf_overwrite_pdarray(self, hdf_test_base_tmp):
         # test repack with a single object
@@ -1992,7 +1992,7 @@ class TestHDF5:
                 # test that repack on/off the file gets smaller/larger respectively
                 assert new_size < orig_size if repack else new_size >= orig_size
                 data = ak.read_hdf(f"{file_name}*")
-                assert data["array"].to_list() == c.to_list()
+                assert data["array"].tolist() == c.tolist()
 
         # test overwrites with different types
         with tempfile.TemporaryDirectory(dir=hdf_test_base_tmp) as tmp_dirname:
@@ -2002,7 +2002,7 @@ class TestHDF5:
                 b = ak.arange(size, dtype=dtype)
                 b.update_hdf(file_name)
                 data = ak.read_hdf(f"{file_name}*").popitem()[1]
-                assert data.to_list() == b.to_list()
+                assert data.tolist() == b.tolist()
 
     def test_hdf_overwrite_strings(self, hdf_test_base_tmp):
         # test repack with a single object
@@ -2025,7 +2025,7 @@ class TestHDF5:
                 # test that repack on/off the file gets smaller/larger respectively
                 assert new_size < orig_size if repack else new_size >= orig_size
                 data = ak.read_hdf(f"{file_name}*")
-                assert data["test_str"].to_list() == c.to_list()
+                assert data["test_str"].tolist() == c.tolist()
 
     def test_overwrite_categorical(self, hdf_test_base_tmp):
         a = ak.Categorical(ak.array([f"cat_{i % 3}" for i in range(100)]))
@@ -2061,7 +2061,7 @@ class TestHDF5:
             assert all(name in data for name in (dset_name, dset_name2, dset_name3))
             d = data[dset_name2]
             for attr in "categories", "codes", "permutation", "segments", "_akNAcode":
-                assert getattr(d, attr).to_list() == getattr(a, attr).to_list()
+                assert getattr(d, attr).tolist() == getattr(a, attr).tolist()
 
     def test_hdf_overwrite_dataframe(self, hdf_test_base_tmp):
         df = ak.DataFrame(
@@ -2158,8 +2158,8 @@ class TestHDF5:
             # ensure that the column was actually overwritten
             assert new_size < orig_size
             data = ak.read_hdf(f"{tmp_dirname}/overwrite_test_*")
-            assert data["b"].to_list() == replace["b"].to_list()
-            assert data["c"].to_list() == replace["c"].to_list()
+            assert data["b"].tolist() == replace["b"].tolist()
+            assert data["c"].tolist() == replace["c"].tolist()
 
         with tempfile.TemporaryDirectory(dir=hdf_test_base_tmp) as tmp_dirname:
             df.to_hdf(f"{tmp_dirname}/overwrite_test")
@@ -2172,8 +2172,8 @@ class TestHDF5:
             # ensure that the column was actually overwritten
             assert new_size >= orig_size
             data = ak.read_hdf(f"{tmp_dirname}/overwrite_test_*")
-            assert data["b"].to_list() == replace["b"].to_list()
-            assert data["c"].to_list() == replace["c"].to_list()
+            assert data["b"].tolist() == replace["b"].tolist()
+            assert data["c"].tolist() == replace["c"].tolist()
 
     def test_snapshot(self, hdf_test_base_tmp):
         df = ak.DataFrame(make_multi_dtype_dict())
@@ -2228,7 +2228,7 @@ class TestHDF5:
 
             assert isinstance(rd_idx, ak.Index)
             assert type(rd_idx.values) is type(idx.values)
-            assert idx.to_list() == rd_idx.to_list()
+            assert idx.tolist() == rd_idx.tolist()
 
         if dtype == ak.str_:
             # if strings we need to also test Categorical
@@ -2239,7 +2239,7 @@ class TestHDF5:
 
                 assert isinstance(rd_idx, ak.Index)
                 assert type(rd_idx.values) is type(idx.values)
-                assert idx.to_list() == rd_idx.to_list()
+                assert idx.tolist() == rd_idx.tolist()
 
     @pytest.mark.parametrize("dtype1", NUMERIC_AND_STR_TYPES)
     @pytest.mark.parametrize("dtype2", NUMERIC_AND_STR_TYPES)
@@ -2253,7 +2253,7 @@ class TestHDF5:
             rd_idx = ak.read_hdf(f"{tmp_dirname}/idx_test*").popitem()[1]
 
             assert isinstance(rd_idx, ak.MultiIndex)
-            assert idx.to_list() == rd_idx.to_list()
+            assert idx.tolist() == rd_idx.tolist()
 
         # handle categorical cases as well
         if ak.str_ in [dtype1, dtype2]:
@@ -2267,7 +2267,7 @@ class TestHDF5:
                 rd_idx = ak.read_hdf(f"{tmp_dirname}/idx_test*").popitem()[1]
 
                 assert isinstance(rd_idx, ak.MultiIndex)
-                assert idx.to_list() == rd_idx.to_list()
+                assert idx.tolist() == rd_idx.tolist()
 
     def test_hdf_overwrite_index(self, hdf_test_base_tmp):
         # test repack with a single object
@@ -2291,7 +2291,7 @@ class TestHDF5:
                 assert new_size < orig_size if repack else new_size >= orig_size
                 data = ak.read_hdf(f"{file_name}*")
                 assert isinstance(data["index"], ak.Index)
-                assert data["index"].to_list() == c.to_list()
+                assert data["index"].tolist() == c.tolist()
 
     def test_special_objtype(self, hdf_test_base_tmp):
         """
@@ -2308,17 +2308,17 @@ class TestHDF5:
             ip.to_hdf(f"{tmp_dirname}/ip_test")
             rd_ip = ak.read_hdf(f"{tmp_dirname}/ip_test*").popitem()[1]
             assert isinstance(rd_ip, ak.IPv4)
-            assert ip.to_list() == rd_ip.to_list()
+            assert ip.tolist() == rd_ip.tolist()
 
             dt.to_hdf(f"{tmp_dirname}/dt_test")
             rd_dt = ak.read_hdf(f"{tmp_dirname}/dt_test*").popitem()[1]
             assert isinstance(rd_dt, ak.Datetime)
-            assert dt.to_list() == rd_dt.to_list()
+            assert dt.tolist() == rd_dt.tolist()
 
             td.to_hdf(f"{tmp_dirname}/td_test")
             rd_td = ak.read_hdf(f"{tmp_dirname}/td_test*").popitem()[1]
             assert isinstance(rd_td, ak.Timedelta)
-            assert td.to_list() == rd_td.to_list()
+            assert td.tolist() == rd_td.tolist()
 
             df.to_hdf(f"{tmp_dirname}/df_test")
             rd_df = ak.read_hdf(f"{tmp_dirname}/df_test*")
@@ -2326,9 +2326,9 @@ class TestHDF5:
             assert isinstance(rd_df["ip"], ak.IPv4)
             assert isinstance(rd_df["datetime"], ak.Datetime)
             assert isinstance(rd_df["timedelta"], ak.Timedelta)
-            assert df["ip"].to_list() == rd_df["ip"].to_list()
-            assert df["datetime"].to_list() == rd_df["datetime"].to_list()
-            assert df["timedelta"].to_list() == rd_df["timedelta"].to_list()
+            assert df["ip"].tolist() == rd_df["ip"].tolist()
+            assert df["datetime"].tolist() == rd_df["datetime"].tolist()
+            assert df["timedelta"].tolist() == rd_df["timedelta"].tolist()
 
 
 class TestCSV:
@@ -2347,13 +2347,13 @@ class TestCSV:
 
             data = ak.read_csv(file_name)
             assert list(data.keys()) == cols
-            assert data["ColA"].to_list() == a
-            assert data["ColB"].to_list() == b
-            assert data["ColC"].to_list() == c
+            assert data["ColA"].tolist() == a
+            assert data["ColB"].tolist() == b
+            assert data["ColC"].tolist() == c
 
             data = ak.read_csv(file_name, datasets="ColB")["ColB"]
             assert isinstance(data, ak.Strings)
-            assert data.to_list() == b
+            assert data.tolist() == b
 
         d = {
             cols[0]: ak.array(a),
@@ -2381,14 +2381,14 @@ class TestCSV:
             ]:
                 data = ak.read_csv(file_name, column_delim=delim)
                 assert list(data.keys()) == cols
-                assert data["ColA"].to_list() == a
-                assert data["ColB"].to_list() == [int(x) for x in b]
-                assert data["ColC"].to_list() == [round(float(x), 2) for x in c]
+                assert data["ColA"].tolist() == a
+                assert data["ColB"].tolist() == [int(x) for x in b]
+                assert data["ColC"].tolist() == [round(float(x), 2) for x in c]
 
                 # test reading subset of columns
                 data = ak.read_csv(file_name, datasets="ColB", column_delim=delim)["ColB"]
                 assert isinstance(data, ak.pdarray)
-                assert data.to_list() == [int(x) for x in b]
+                assert data.tolist() == [int(x) for x in b]
 
         # larger data set testing
         d = {
@@ -2399,9 +2399,9 @@ class TestCSV:
         with tempfile.TemporaryDirectory(dir=csv_test_base_tmp) as tmp_dirname:
             ak.to_csv(d, f"{tmp_dirname}/non_equal_set.csv")
             data = ak.read_csv(f"{tmp_dirname}/non_equal_set*")
-            assert data["ColA"].to_list() == d["ColA"].to_list()
-            assert data["ColB"].to_list() == d["ColB"].to_list()
-            assert data["ColC"].to_list() == d["ColC"].to_list()
+            assert data["ColA"].tolist() == d["ColA"].tolist()
+            assert data["ColB"].tolist() == d["ColB"].tolist()
+            assert data["ColC"].tolist() == d["ColC"].tolist()
 
 
 class TestImportExport:

--- a/tests/pandas/join_test.py
+++ b/tests/pandas/join_test.py
@@ -65,8 +65,8 @@ class TestJoin:
         end = ak.array([10, 20, 30])
 
         segs, ranges = ak.join.gen_ranges(start, end)
-        assert segs.to_list() == [0, 10, 20]
-        assert ranges.to_list() == list(range(30))
+        assert segs.tolist() == [0, 10, 20]
+        assert ranges.tolist() == list(range(30))
 
         with pytest.raises(ValueError):
             segs, ranges = ak.join.gen_ranges(ak.array([11, 12, 41]), end)
@@ -76,10 +76,10 @@ class TestJoin:
         right = ak.array([0, 5, 3, 3, 4, 6, 7, 9, 8, 1])
 
         l, r = ak.join.inner_join(left, right)
-        assert left[l].to_list() == right[r].to_list()
+        assert left[l].tolist() == right[r].tolist()
 
         l, r = ak.join.inner_join(left, right, wherefunc=join_where, whereargs=(left, right))
-        assert left[l].to_list() == right[r].to_list()
+        assert left[l].tolist() == right[r].tolist()
 
         for where_func in ak.unique, ak.intersect1d:
             with pytest.raises(ValueError):
@@ -133,25 +133,25 @@ class TestJoin:
     def test_str_inner_join(self):
         int_left = ak.arange(50)
         int_right = ak.randint(0, 50, 50)
-        str_left = ak.array([f"str {i}" for i in int_left.to_list()])
-        str_right = ak.array([f"str {i}" for i in int_right.to_list()])
+        str_left = ak.array([f"str {i}" for i in int_left.tolist()])
+        str_right = ak.array([f"str {i}" for i in int_right.tolist()])
 
         str_l, str_r = ak.join.inner_join(str_left, str_right)
-        assert str_left[str_l].to_list() == str_right[str_r].to_list()
+        assert str_left[str_l].tolist() == str_right[str_r].tolist()
 
         str_l_where, str_r_where = ak.join.inner_join(
             str_left, str_right, wherefunc=join_where, whereargs=(str_left, str_right)
         )
-        assert str_left[str_l_where].to_list() == str_right[str_r_where].to_list()
+        assert str_left[str_l_where].tolist() == str_right[str_r_where].tolist()
 
         # reproducer from PR
         int_left = ak.arange(10)
         int_right = ak.array([0, 5, 3, 3, 4, 6, 7, 9, 8, 1])
-        str_left = ak.array([f"str {i}" for i in int_left.to_list()])
-        str_right = ak.array([f"str {i}" for i in int_right.to_list()])
+        str_left = ak.array([f"str {i}" for i in int_left.tolist()])
+        str_right = ak.array([f"str {i}" for i in int_right.tolist()])
 
         sl, sr = ak.join.inner_join(str_left, str_right)
-        assert str_left[sl].to_list() == str_right[sr].to_list()
+        assert str_left[sl].tolist() == str_right[sr].tolist()
 
         def where_func(x, y):
             return x % 2 == 0
@@ -162,48 +162,48 @@ class TestJoin:
         sl, sr = ak.join.inner_join(
             str_left, str_right, wherefunc=where_func, whereargs=(int_left, int_right)
         )
-        assert sl.to_list() == il.to_list()
-        assert sr.to_list() == ir.to_list()
+        assert sl.tolist() == il.tolist()
+        assert sr.tolist() == ir.tolist()
 
     def test_cat_inner_join(self):
         int_left = ak.arange(50)
         int_right = ak.randint(0, 50, 50)
-        str_left = ak.array([f"str {i}" for i in int_left.to_list()])
-        str_right = ak.array([f"str {i}" for i in int_right.to_list()])
+        str_left = ak.array([f"str {i}" for i in int_left.tolist()])
+        str_right = ak.array([f"str {i}" for i in int_right.tolist()])
         cat_left = ak.Categorical(str_left)
         cat_right = ak.Categorical(str_right)
 
         # Base Case
         cat_l, cat_r = ak.join.inner_join(cat_left, cat_right)
-        assert cat_left[cat_l].to_list() == cat_right[cat_r].to_list()
+        assert cat_left[cat_l].tolist() == cat_right[cat_r].tolist()
 
         cat_l_where, cat_r_where = ak.join.inner_join(
             cat_left, cat_right, wherefunc=join_where, whereargs=(cat_left, cat_right)
         )
-        assert cat_left[cat_l_where].to_list() == cat_right[cat_r_where].to_list()
+        assert cat_left[cat_l_where].tolist() == cat_right[cat_r_where].tolist()
 
     def test_mixed_inner_join_where(self):
         int_left = ak.arange(50)
         int_right = ak.randint(0, 50, 50)
-        str_left = ak.array([f"str {i}" for i in int_left.to_list()])
-        str_right = ak.array([f"str {i}" for i in int_right.to_list()])
+        str_left = ak.array([f"str {i}" for i in int_left.tolist()])
+        str_right = ak.array([f"str {i}" for i in int_right.tolist()])
         cat_left = ak.Categorical(str_left)
         cat_right = ak.Categorical(str_right)
 
         left, right = ak.join.inner_join(
             int_left, int_right, wherefunc=join_where, whereargs=(cat_left, str_right)
         )
-        assert cat_left[left].to_list() == cat_right[right].to_list()
+        assert cat_left[left].tolist() == cat_right[right].tolist()
 
         left, right = ak.join.inner_join(
             str_left, str_right, wherefunc=join_where, whereargs=(cat_left, int_right)
         )
-        assert cat_left[left].to_list() == cat_right[right].to_list()
+        assert cat_left[left].tolist() == cat_right[right].tolist()
 
         left, right = ak.join.inner_join(
             cat_left, cat_right, wherefunc=join_where, whereargs=(str_left, int_right)
         )
-        assert cat_left[left].to_list() == cat_right[right].to_list()
+        assert cat_left[left].tolist() == cat_right[right].tolist()
 
     def test_lookup(self):
         keys = ak.arange(5)
@@ -213,7 +213,7 @@ class TestJoin:
         # Simple lookup with int keys
         # Also test shortcut for unique-ordered keys
         res = ak.lookup(keys, values, args, fillvalue=-1)
-        assert res.to_list() == ans
+        assert res.tolist() == ans
         # Compound lookup with (str, int) keys
         res2 = ak.lookup(
             (ak.cast(keys, ak.str_), keys),
@@ -221,10 +221,10 @@ class TestJoin:
             (ak.cast(args, ak.str_), args),
             fillvalue=-1,
         )
-        assert res2.to_list() == ans
+        assert res2.tolist() == ans
         # Keys not in uniqued order
         res3 = ak.lookup(keys[::-1], values[::-1], args, fillvalue=-1)
-        assert res3.to_list() == ans
+        assert res3.tolist() == ans
         # Non-unique keys should raise error
         with pytest.warns(UserWarning):
             keys = ak.arange(10) % 5
@@ -256,4 +256,4 @@ def join_where(left, right):
 
 
 def pda_to_str_helper(pda):
-    return ak.array([f"str {i}" for i in pda.to_list()])
+    return ak.array([f"str {i}" for i in pda.tolist()])

--- a/tests/pandas/series_test.py
+++ b/tests/pandas/series_test.py
@@ -27,7 +27,7 @@ class TestSeries:
     def test_series_creation(self, dtype):
         idx = ak.arange(3, dtype=dtype)
         for val in idx, ak.array(["A", "B", "C"]):
-            ans = ak.Series(data=val, index=idx).to_list()
+            ans = ak.Series(data=val, index=idx).tolist()
             for series in (
                 ak.Series(data=val, index=idx),
                 ak.Series(data=val),
@@ -37,7 +37,7 @@ class TestSeries:
             ):
                 assert isinstance(series, ak.Series)
                 assert isinstance(series.index, ak.Index)
-                assert series.to_list() == ans
+                assert series.tolist() == ans
 
         with pytest.raises(TypeError):
             ak.Series(index=idx)
@@ -132,7 +132,7 @@ class TestSeries:
         )
         assert (added.index == ak.arange(size)).all()
         if dtype != ak.bool_:
-            assert all(i in added.values.to_list() for i in range(size))
+            assert all(i in added.values.tolist() for i in range(size))
         else:
             # we have exactly one False
             assert added.values.sum() == 99
@@ -140,8 +140,8 @@ class TestSeries:
     @pytest.mark.parametrize("dtype", [ak.int64, ak.uint64, ak.float64])
     def test_topn(self, dtype):
         top = ak.Series(ak.arange(100, dtype=dtype)).topn(50)
-        assert top.values.to_list() == list(range(99, 49, -1))
-        assert top.index.to_list() == list(range(99, 49, -1))
+        assert top.values.tolist() == list(range(99, 49, -1))
+        assert top.index.tolist() == list(range(99, 49, -1))
 
     @pytest.mark.parametrize("dtype", NUMERICAL_TYPES)
     @pytest.mark.parametrize("dtype_index", NUMERICAL_TYPES)
@@ -162,12 +162,12 @@ class TestSeries:
         perm = ak.array(gen_perm(100), dtype=dtype_index)
 
         idx_sort = ak.Series(data=ordered, index=perm).sort_index()
-        assert idx_sort.index.to_list() == ordered.to_list()
-        assert idx_sort.values.to_list() == perm.to_list()
+        assert idx_sort.index.tolist() == ordered.tolist()
+        assert idx_sort.values.tolist() == perm.tolist()
 
         val_sort = ak.Series(data=perm, index=ordered).sort_values()
-        assert val_sort.index.to_pandas().tolist() == perm.to_list()
-        assert val_sort.values.to_list() == ordered.to_list()
+        assert val_sort.index.to_pandas().tolist() == perm.tolist()
+        assert val_sort.values.tolist() == ordered.tolist()
 
     @pytest.mark.parametrize("dtype", DTYPES)
     def test_head_tail(self, dtype):
@@ -175,23 +175,23 @@ class TestSeries:
         s = ak.Series(ak.arange(n, dtype=dtype))
         for i in range(n):
             head = s.head(i)
-            assert head.index.to_list() == list(range(i))
-            assert head.values.to_list() == ak.arange(i, dtype=dtype).to_list()
+            assert head.index.tolist() == list(range(i))
+            assert head.values.tolist() == ak.arange(i, dtype=dtype).tolist()
 
             tail = s.tail(i)
-            assert tail.index.to_list() == ak.arange(n)[-i:n].to_list()
-            assert tail.values.to_list() == ak.arange(n, dtype=dtype)[-i:n].to_list()
+            assert tail.index.tolist() == ak.arange(n)[-i:n].tolist()
+            assert tail.values.tolist() == ak.arange(n, dtype=dtype)[-i:n].tolist()
 
     def test_value_counts(self):
         s = ak.Series(ak.array([1, 2, 0, 2, 0]))
 
         c = s.value_counts()
-        assert c.index.to_list() == [0, 2, 1]
-        assert c.values.to_list() == [2, 2, 1]
+        assert c.index.tolist() == [0, 2, 1]
+        assert c.values.tolist() == [2, 2, 1]
 
         c = s.value_counts(sort=False)
-        assert c.index.to_list() == list(range(3))
-        assert c.values.to_list() == [2, 1, 2]
+        assert c.index.tolist() == list(range(3))
+        assert c.values.tolist() == [2, 1, 2]
 
     def test_concat(self):
         s = ak.Series(ak.arange(5))
@@ -213,7 +213,7 @@ class TestSeries:
         pd_assert_frame_equal(ref_df, df.to_pandas())
 
         def list_helper(arr):
-            return arr.to_list() if isinstance(arr, (ak.pdarray, ak.Index)) else arr.tolist()
+            return arr.tolist() if isinstance(arr, (ak.pdarray, ak.Index)) else arr.tolist()
 
         for fname in "concat", "pdconcat":
             func = getattr(ak.Series, fname)
@@ -265,35 +265,35 @@ class TestSeries:
         c = ak.Series(ak.array([1.0, 1.0, 2.2, 2.2, 4.4]), index=ak.array([5, 4, 2, 3, 1]))
 
         result = a.map({"4": 25, "5": 30, "1": 7})
-        assert result.index.values.to_list() == [0, 1, 2, 3, 4]
-        assert result.values.to_list() == [7, 7, 25, 25, 25]
+        assert result.index.values.tolist() == [0, 1, 2, 3, 4]
+        assert result.values.tolist() == [7, 7, 25, 25, 25]
 
         result = a.map({"1": 7})
-        assert result.index.values.to_list() == [0, 1, 2, 3, 4]
+        assert result.index.values.tolist() == [0, 1, 2, 3, 4]
         assert (
-            result.values.to_list()
-            == ak.cast(ak.array([7, 7, np.nan, np.nan, np.nan]), dt=ak.int64).to_list()
+            result.values.tolist()
+            == ak.cast(ak.array([7, 7, np.nan, np.nan, np.nan]), dt=ak.int64).tolist()
         )
 
         result = a.map({"1": 7.0})
-        assert result.index.values.to_list() == [0, 1, 2, 3, 4]
-        assert np.allclose(result.values.to_list(), [7.0, 7.0, np.nan, np.nan, np.nan], equal_nan=True)
+        assert result.index.values.tolist() == [0, 1, 2, 3, 4]
+        assert np.allclose(result.values.tolist(), [7.0, 7.0, np.nan, np.nan, np.nan], equal_nan=True)
 
         result = b.map({4: 25.0, 2: 30.0, 1: 7.0, 3: 5.0})
-        assert result.index.values.to_list() == [0, 1, 2, 3, 4]
-        assert result.values.to_list() == [30.0, 5.0, 30.0, 5.0, 25.0]
+        assert result.index.values.tolist() == [0, 1, 2, 3, 4]
+        assert result.values.tolist() == [30.0, 5.0, 30.0, 5.0, 25.0]
 
         result = c.map({1.0: "a", 2.2: "b", 4.4: "c", 5.0: "d"})
-        assert result.index.values.to_list() == [5, 4, 2, 3, 1]
-        assert result.values.to_list() == ["a", "a", "b", "b", "c"]
+        assert result.index.values.tolist() == [5, 4, 2, 3, 1]
+        assert result.values.tolist() == ["a", "a", "b", "b", "c"]
 
         result = c.map({1.0: "a"})
-        assert result.index.values.to_list() == [5, 4, 2, 3, 1]
-        assert result.values.to_list() == ["a", "a", "null", "null", "null"]
+        assert result.index.values.tolist() == [5, 4, 2, 3, 1]
+        assert result.values.tolist() == ["a", "a", "null", "null", "null"]
 
         result = c.map({1.0: "a", 2.2: "b", 4.4: "c", 5.0: "d", 6.0: "e"})
-        assert result.index.values.to_list() == [5, 4, 2, 3, 1]
-        assert result.values.to_list() == ["a", "a", "b", "b", "c"]
+        assert result.index.values.tolist() == [5, 4, 2, 3, 1]
+        assert result.values.tolist() == ["a", "a", "b", "b", "c"]
 
     def test_to_markdown(self):
         s = ak.Series(["elk", "pig", "dog", "quetzal"], name="animal")
@@ -402,19 +402,19 @@ class TestSeries:
         data = ak.Series([1, np.nan, 3, np.nan, 5])
 
         fill_values1 = ak.ones(5)
-        assert data.fillna(fill_values1).to_list() == [1.0, 1.0, 3.0, 1.0, 5.0]
+        assert data.fillna(fill_values1).tolist() == [1.0, 1.0, 3.0, 1.0, 5.0]
 
         fill_values2 = Series(2 * ak.ones(5))
-        assert data.fillna(fill_values2).to_list() == [1.0, 2.0, 3.0, 2.0, 5.0]
+        assert data.fillna(fill_values2).tolist() == [1.0, 2.0, 3.0, 2.0, 5.0]
 
         fill_values3 = 100.0
-        assert data.fillna(fill_values3).to_list() == [1.0, 100.0, 3.0, 100.0, 5.0]
+        assert data.fillna(fill_values3).tolist() == [1.0, 100.0, 3.0, 100.0, 5.0]
 
     def test_series_segarray_to_pandas(self):
         # reproducer for issue #3222
         sa = ak.SegArray(ak.arange(0, 30, 3), ak.arange(30))
         akdf = ak.DataFrame({"test": sa})
-        pddf = pd.DataFrame({"test": sa.to_list()})
+        pddf = pd.DataFrame({"test": sa.tolist()})
 
         pd_assert_frame_equal(akdf.to_pandas(), pddf)
         pd_assert_series_equal(akdf.to_pandas()["test"], pddf["test"], check_names=False)
@@ -440,8 +440,8 @@ class TestSeries:
         s1_a2 = s1["C"]
         assert isinstance(_s1_a2, pd.Series)
         assert isinstance(s1_a2, ak.Series)
-        assert s1_a2.index.to_list() == _s1_a2.index.tolist()
-        assert s1_a2.values.to_list() == _s1_a2.values.tolist()
+        assert s1_a2.index.tolist() == _s1_a2.index.tolist()
+        assert s1_a2.values.tolist() == _s1_a2.values.tolist()
 
         _s2 = pd.Series(index=np.array(ints), data=np.array(strings))
         s2 = ak.Series(index=ak.array(ints), data=ak.array(strings))
@@ -459,8 +459,8 @@ class TestSeries:
         s2_a2 = s2[3]
         assert isinstance(_s2_a2, pd.Series)
         assert isinstance(s2_a2, ak.Series)
-        assert s2_a2.index.to_list() == _s2_a2.index.tolist()
-        assert s2_a2.values.to_list() == _s2_a2.values.tolist()
+        assert s2_a2.index.tolist() == _s2_a2.index.tolist()
+        assert s2_a2.values.tolist() == _s2_a2.values.tolist()
 
         _s3 = pd.Series(index=np.array(floats), data=np.array(ints))
         s3 = ak.Series(index=ak.array(floats), data=ak.array(ints))
@@ -477,8 +477,8 @@ class TestSeries:
         s3_a2 = s3[1.5]
         assert isinstance(_s3_a2, pd.Series)
         assert isinstance(s3_a2, ak.Series)
-        assert s3_a2.index.to_list() == _s3_a2.index.tolist()
-        assert s3_a2.values.to_list() == _s3_a2.values.tolist()
+        assert s3_a2.index.tolist() == _s3_a2.index.tolist()
+        assert s3_a2.values.tolist() == _s3_a2.values.tolist()
 
     def test_getitem_vectors(self):
         ints = [0, 1, 3, 7, 3]
@@ -501,20 +501,20 @@ class TestSeries:
         _s1_a1 = _s1[np.array(["A", "Z"])]
         s1_a1 = s1[ak.array(["A", "Z"])]
         assert isinstance(s1_a1, ak.Series)
-        assert s1_a1.index.to_list() == _s1_a1.index.tolist()
-        assert s1_a1.values.to_list() == _s1_a1.values.tolist()
+        assert s1_a1.index.tolist() == _s1_a1.index.tolist()
+        assert s1_a1.values.tolist() == _s1_a1.values.tolist()
 
         _s1_a2 = _s1[["C", "DE"]]
         s1_a2 = s1[["C", "DE"]]
         assert isinstance(s1_a2, ak.Series)
-        assert s1_a2.index.to_list() == _s1_a2.index.tolist()
-        assert s1_a2.values.to_list() == _s1_a2.values.tolist()
+        assert s1_a2.index.tolist() == _s1_a2.index.tolist()
+        assert s1_a2.values.tolist() == _s1_a2.values.tolist()
 
         _s1_a3 = _s1[[True, False, True, False, False]]
         s1_a3 = s1[[True, False, True, False, False]]
         assert isinstance(s1_a3, ak.Series)
-        assert s1_a3.index.to_list() == _s1_a3.index.tolist()
-        assert s1_a3.values.to_list() == _s1_a3.values.tolist()
+        assert s1_a3.index.tolist() == _s1_a3.index.tolist()
+        assert s1_a3.values.tolist() == _s1_a3.values.tolist()
 
         with pytest.raises(IndexError):
             _s1[[True, False, True]]
@@ -539,14 +539,14 @@ class TestSeries:
         _s2_a1 = _s2[[0.5, 0.0]]
         s2_a1 = s2[[0.5, 0.0]]
         assert isinstance(s1_a2, ak.Series)
-        assert s2_a1.index.to_list() == _s2_a1.index.tolist()
-        assert s2_a1.values.to_list() == _s2_a1.values.tolist()
+        assert s2_a1.index.tolist() == _s2_a1.index.tolist()
+        assert s2_a1.values.tolist() == _s2_a1.values.tolist()
 
         _s2_a2 = _s2[np.array([0.5, 0.0])]
         s2_a2 = s2[ak.array([0.5, 0.0])]
         assert isinstance(s1_a2, ak.Series)
-        assert s2_a2.index.to_list() == _s2_a2.index.tolist()
-        assert s2_a2.values.to_list() == _s2_a2.values.tolist()
+        assert s2_a2.index.tolist() == _s2_a2.index.tolist()
+        assert s2_a2.values.tolist() == _s2_a2.values.tolist()
 
         with pytest.raises(KeyError):
             _s2_a3 = _s2[[1.5, 1.2]]
@@ -556,8 +556,8 @@ class TestSeries:
         _s2_a3 = _s2[[1.5, 0.0]]
         s2_a3 = s2[[1.5, 0.0]]
         assert isinstance(s2_a2, ak.Series)
-        assert s2_a3.index.to_list() == _s2_a3.index.tolist()
-        assert s2_a3.values.to_list() == _s2_a3.values.tolist()
+        assert s2_a3.index.tolist() == _s2_a3.index.tolist()
+        assert s2_a3.values.tolist() == _s2_a3.values.tolist()
 
     def test_setitem_scalars(self):
         ints = [0, 1, 3, 7, 3]
@@ -578,17 +578,17 @@ class TestSeries:
 
         s1["A"] = 0.2
         _s1["A"] = 0.2
-        assert s1.values.to_list() == _s1.values.tolist()
+        assert s1.values.tolist() == _s1.values.tolist()
         s1["C"] = 1.2
         _s1["C"] = 1.2
-        assert s1.values.to_list() == _s1.values.tolist()
+        assert s1.values.tolist() == _s1.values.tolist()
         s1["X"] = 0.0
         _s1["X"] = 0.0
-        assert s1.index.to_list() == _s1.index.tolist()
-        assert s1.values.to_list() == _s1.values.tolist()
+        assert s1.index.tolist() == _s1.index.tolist()
+        assert s1.values.tolist() == _s1.values.tolist()
         s1["C"] = [0.3, 0.4]
         _s1["C"] = [0.3, 0.4]
-        assert s1.values.to_list() == _s1.values.tolist()
+        assert s1.values.tolist() == _s1.values.tolist()
 
         with pytest.raises(ValueError):
             s1["C"] = [0.4, 0.3, 0.2]
@@ -610,32 +610,32 @@ class TestSeries:
 
         s3 = ak.Series(index=ak.array(floats), data=ak.array(ints))
         _s3 = pd.Series(index=np.array(floats), data=np.array(ints))
-        assert s3.values.to_list() == [0, 1, 3, 7, 3]
-        assert s3.index.to_list() == [0.0, 1.5, 0.5, 1.5, -1.0]
-        assert s3.values.to_list() == _s3.values.tolist()
-        assert s3.index.to_list() == _s3.index.tolist()
+        assert s3.values.tolist() == [0, 1, 3, 7, 3]
+        assert s3.index.tolist() == [0.0, 1.5, 0.5, 1.5, -1.0]
+        assert s3.values.tolist() == _s3.values.tolist()
+        assert s3.index.tolist() == _s3.index.tolist()
         s3[0.0] = 2
         _s3[0.0] = 2
-        assert s3.values.to_list() == _s3.values.tolist()
+        assert s3.values.tolist() == _s3.values.tolist()
         _s3[1.5] = 8
         s3[1.5] = 8
-        assert s3.values.to_list() == _s3.values.tolist()
+        assert s3.values.tolist() == _s3.values.tolist()
         _s3[2.0] = 9
         s3[2.0] = 9
-        assert s3.index.to_list() == _s3.index.tolist()
-        assert s3.values.to_list() == _s3.values.tolist()
+        assert s3.index.tolist() == _s3.index.tolist()
+        assert s3.values.tolist() == _s3.values.tolist()
         _s3[1.5] = [4, 5]
         s3[1.5] = [4, 5]
-        assert s3.values.to_list() == _s3.values.tolist()
+        assert s3.values.tolist() == _s3.values.tolist()
         _s3[1.5] = np.array([6, 7])
         s3[1.5] = ak.array([6, 7])
-        assert s3.values.to_list() == _s3.values.tolist()
+        assert s3.values.tolist() == _s3.values.tolist()
         _s3[1.5] = [8]
         s3[1.5] = [8]
-        assert s3.values.to_list() == _s3.values.tolist()
+        assert s3.values.tolist() == _s3.values.tolist()
         _s3[1.5] = np.array([2])
         s3[1.5] = ak.array([2])
-        assert s3.values.to_list() == _s3.values.tolist()
+        assert s3.values.tolist() == _s3.values.tolist()
         with pytest.raises(ValueError):
             s3[1.5] = [9, 10, 11]
         with pytest.raises(ValueError):
@@ -644,8 +644,8 @@ class TestSeries:
         # adding new entries
         _s3[-1.0] = 14
         s3[-1.0] = 14
-        assert s3.values.to_list() == _s3.values.tolist()
-        assert s3.index.to_list() == _s3.index.tolist()
+        assert s3.values.tolist() == _s3.values.tolist()
+        assert s3.index.tolist() == _s3.index.tolist()
 
         # pandas makes the entry a list, which is not what we want.
         with pytest.raises(ValueError):
@@ -684,10 +684,10 @@ class TestSeries:
         _s2 = pd.Series(index=pd.array(["A", "C", "DE", "F", "Z"]), data=pd.array(ints))
         s2[["A", "Z"]] = 2
         _s2[["A", "Z"]] = 2
-        assert s2.values.to_list() == _s2.values.tolist()
+        assert s2.values.tolist() == _s2.values.tolist()
         s2[ak.array(["A", "Z"])] = 3
         _s2[np.array(["A", "Z"])] = 3
-        assert s2.values.to_list() == _s2.values.tolist()
+        assert s2.values.tolist() == _s2.values.tolist()
         with pytest.raises(ValueError):
             _s2[np.array(["A", "Z"])] = [3]
         with pytest.raises(ValueError):
@@ -705,12 +705,12 @@ class TestSeries:
             _s2[["B"]] = 0
         with pytest.raises(KeyError):
             s2[["B"]] = 0
-        assert s2.values.to_list() == _s2.values.tolist()
-        assert s2.index.to_list() == _s2.index.tolist()
+        assert s2.values.tolist() == _s2.values.tolist()
+        assert s2.index.tolist() == _s2.index.tolist()
 
         _s2[np.array(["A", "C", "F"])] = [10, 11, 12]
         s2[ak.array(["A", "C", "F"])] = [10, 11, 12]
-        assert s2.values.to_list() == _s2.values.tolist()
+        assert s2.values.tolist() == _s2.values.tolist()
 
     def test_iloc(self):
         floats = [0.0, 1.5, 0.5, 1.5, -1.0]
@@ -727,11 +727,11 @@ class TestSeries:
 
         s1_a1 = s1.iloc[0]
         assert isinstance(s1_a1, ak.Series)
-        assert s1_a1.index.to_list() == ["A"]
-        assert s1_a1.values.to_list() == [0.0]
+        assert s1_a1.index.tolist() == ["A"]
+        assert s1_a1.values.tolist() == [0.0]
         _s1.iloc[0] = 1.0
         s1.iloc[0] = 1.0
-        assert s1.values.to_list() == _s1.values.tolist()
+        assert s1.values.tolist() == _s1.values.tolist()
 
         with pytest.raises(pd.errors.IndexingError):
             _s1_a2 = _s1.iloc[1, 3]
@@ -744,11 +744,11 @@ class TestSeries:
 
         _s1_a2 = _s1.iloc[[1, 2]]
         s1_a2 = s1.iloc[[1, 2]]
-        assert s1_a2.index.to_list() == _s1_a2.index.tolist()
-        assert s1_a2.values.to_list() == _s1_a2.values.tolist()
+        assert s1_a2.index.tolist() == _s1_a2.index.tolist()
+        assert s1_a2.values.tolist() == _s1_a2.values.tolist()
         _s1.iloc[[1, 2]] = 0.2
         s1.iloc[[1, 2]] = 0.2
-        assert s1.values.to_list() == _s1.values.tolist()
+        assert s1.values.tolist() == _s1.values.tolist()
 
         with pytest.raises(ValueError):
             _s1.iloc[[3, 4]] = [0.3]
@@ -757,7 +757,7 @@ class TestSeries:
 
         _s1.iloc[[3, 4]] = [0.4, 0.5]
         s1.iloc[[3, 4]] = [0.4, 0.5]
-        assert s1.values.to_list() == _s1.values.tolist()
+        assert s1.values.tolist() == _s1.values.tolist()
 
         with pytest.raises(TypeError):
             # in pandas this hits a NotImplementedError
@@ -783,11 +783,11 @@ class TestSeries:
         # can also take boolean array
         _b = _s1.iloc[[True, False, True, True, False]]
         b = s1.iloc[[True, False, True, True, False]]
-        assert b.values.to_list() == _b.values.tolist()
+        assert b.values.tolist() == _b.values.tolist()
 
         _s1.iloc[[True, False, False, True, False]] = [0.5, 0.6]
         s1.iloc[[True, False, False, True, False]] = [0.5, 0.6]
-        assert b.values.to_list() == _b.values.tolist()
+        assert b.values.tolist() == _b.values.tolist()
 
         with pytest.raises(IndexError):
             _s1.iloc[[True, False, True]]

--- a/tests/regex_test.py
+++ b/tests/regex_test.py
@@ -44,14 +44,14 @@ class TestRegex:
             re_non_none = [m for m in re_match_obj if m is not None]
             is_non_none = [m is not None for m in re_match_obj]
 
-            assert ak_match_obj.matched().to_list() == is_non_none
-            assert ak_match_obj.start().to_list() == [m.start() for m in re_non_none]
-            assert ak_match_obj.end().to_list() == [m.end() for m in re_non_none]
+            assert ak_match_obj.matched().tolist() == is_non_none
+            assert ak_match_obj.start().tolist() == [m.start() for m in re_non_none]
+            assert ak_match_obj.end().tolist() == [m.end() for m in re_non_none]
             assert ak_match_obj.match_type() == match_type.upper()
 
             matches, origins = ak_match_obj.find_matches(return_match_origins=True)
 
-            assert matches.to_list() == [m.string[m.start() : m.end()] for m in re_non_none]
+            assert matches.tolist() == [m.string[m.start() : m.end()] for m in re_non_none]
             assert all(origins.to_ndarray() == np.arange(len(re_match_obj))[is_non_none])
 
     @classmethod
@@ -77,8 +77,8 @@ class TestRegex:
             *(re.subn(pattern, repl, strings[i], count) for i in range(strings.size))
         )
 
-        assert ak_sub.to_list() == list(re_sub)
-        assert ak_sub_counts.to_list() == list(re_sub_counts)
+        assert ak_sub.tolist() == list(re_sub)
+        assert ak_sub_counts.tolist() == list(re_sub_counts)
 
     def test_empty_string_patterns(self):
         lit_str = ["0 String 0", "^", " "]
@@ -90,15 +90,15 @@ class TestRegex:
             TestRegex.sub_helper(pattern, lit_str, " +||+ ", 100)
 
             assert ak_str.contains(pattern, regex=True).all()
-            assert ak_str.startswith(pattern, regex=True).to_list() == [
+            assert ak_str.startswith(pattern, regex=True).tolist() == [
                 re.search("^" + pattern, si) is not None for si in lit_str
             ]
             if pattern != "":
-                assert ak_str.endswith(pattern, regex=True).to_list() == [
+                assert ak_str.endswith(pattern, regex=True).tolist() == [
                     re.search(pattern + "$", si) is not None for si in lit_str
                 ]
 
-            assert ak_str.findall(pattern).to_list() == list(
+            assert ak_str.findall(pattern).tolist() == list(
                 chain(*(re.findall(pattern, si) for si in lit_str))
             )
 
@@ -154,10 +154,10 @@ class TestRegex:
         ak_captures = tug_of_war.search(pattern)
         re_captures = [re.search(pattern, tug_of_war[i]) for i in range(tug_of_war.size)]
         for i in range(3):
-            assert ak_captures.group(i).to_list() == [m.group(i) for m in re_captures if m is not None]
+            assert ak_captures.group(i).tolist() == [m.group(i) for m in re_captures if m is not None]
 
         group, group_origins = ak_captures.group(1, return_group_origins=True)
-        assert group_origins.to_list() == [
+        assert group_origins.tolist() == [
             i for i in range(len(re_captures)) if re_captures[i] is not None
         ]
 
@@ -191,7 +191,7 @@ class TestRegex:
                 if i == strings.size - 1
                 else split[split_map[i] : split_map[i + 1]]
             )
-            assert re_split == ak_split.to_list()
+            assert re_split == ak_split.tolist()
 
     def test_regex_substr_search(self):
         digit_strings = ak.array([f"{i} string {i}" for i in range(6)])
@@ -216,38 +216,38 @@ class TestRegex:
         strings = ak.array([f"{i} string {i}" for i in range(5)])
 
         actual_num_matches, actual_starts, actual_lens = strings.find_locations("\\d")
-        assert [2, 2, 2, 2, 2] == actual_num_matches.to_list()
-        assert [0, 9, 0, 9, 0, 9, 0, 9, 0, 9] == actual_starts.to_list()
-        assert [1, 1, 1, 1, 1, 1, 1, 1, 1, 1] == actual_lens.to_list()
+        assert [2, 2, 2, 2, 2] == actual_num_matches.tolist()
+        assert [0, 9, 0, 9, 0, 9, 0, 9, 0, 9] == actual_starts.tolist()
+        assert [1, 1, 1, 1, 1, 1, 1, 1, 1, 1] == actual_lens.tolist()
 
         actual_num_matches, actual_starts, actual_lens = strings.find_locations("string \\d")
-        assert [1, 1, 1, 1, 1] == actual_num_matches.to_list()
-        assert [2, 2, 2, 2, 2] == actual_starts.to_list()
-        assert [8, 8, 8, 8, 8] == actual_lens.to_list()
+        assert [1, 1, 1, 1, 1] == actual_num_matches.tolist()
+        assert [2, 2, 2, 2, 2] == actual_starts.tolist()
+        assert [8, 8, 8, 8, 8] == actual_lens.tolist()
 
     def test_regex_findall(self):
         strings = ak.array([f"{i} string {i}" for i in range(1, 6)])
         expected_matches = ["1", "1", "2", "2", "3", "3", "4", "4", "5", "5"]
         expected_match_origins = [0, 0, 1, 1, 2, 2, 3, 3, 4, 4]
         actual_matches, actual_match_origins = strings.findall("\\d", return_match_origins=True)
-        assert expected_matches == actual_matches.to_list()
-        assert expected_match_origins == actual_match_origins.to_list()
+        assert expected_matches == actual_matches.tolist()
+        assert expected_match_origins == actual_match_origins.tolist()
 
         actual_matches = strings.findall("\\d")
-        assert expected_matches == actual_matches.to_list()
+        assert expected_matches == actual_matches.tolist()
 
         expected_matches = ["string 1", "string 2", "string 3", "string 4", "string 5"]
         expected_match_origins = [0, 1, 2, 3, 4]
         actual_matches, actual_match_origins = strings.findall("string \\d", return_match_origins=True)
-        assert expected_matches == actual_matches.to_list()
-        assert expected_match_origins == actual_match_origins.to_list()
+        assert expected_matches == actual_matches.tolist()
+        assert expected_match_origins == actual_match_origins.tolist()
 
         under = ak.array(["", "____", "_1_2", "3___4___", "5"])
         expected_matches = ["____", "_", "_", "___", "___"]
         expected_match_origins = [1, 2, 2, 3, 3]
         actual_matches, actual_match_origins = under.findall("_+", return_match_origins=True)
-        assert expected_matches == actual_matches.to_list()
-        assert expected_match_origins == actual_match_origins.to_list()
+        assert expected_matches == actual_matches.tolist()
+        assert expected_match_origins == actual_match_origins.tolist()
 
     def test_regex_peel(self):
         orig = ak.array(["a.b", "c.d", "e.f.g"])
@@ -257,43 +257,43 @@ class TestRegex:
         o_left, o_right = orig.peel(".")
         d_left, d_right = digit.peel("\\d", regex=True)
         u_left, u_right = under.peel("_+", regex=True)
-        assert ["a", "c", "e"] == o_left.to_list()
-        assert ["a", "c", "e"] == d_left.to_list()
-        assert ["a", "c", "e"] == u_left.to_list()
-        assert ["b", "d", "f.g"] == o_right.to_list()
-        assert ["b", "d", "f2g"] == d_right.to_list()
-        assert ["b", "d", "f____g"] == u_right.to_list()
+        assert ["a", "c", "e"] == o_left.tolist()
+        assert ["a", "c", "e"] == d_left.tolist()
+        assert ["a", "c", "e"] == u_left.tolist()
+        assert ["b", "d", "f.g"] == o_right.tolist()
+        assert ["b", "d", "f2g"] == d_right.tolist()
+        assert ["b", "d", "f____g"] == u_right.tolist()
 
         o_left, o_right = orig.peel(".", includeDelimiter=True)
         d_left, d_right = digit.peel("\\d", includeDelimiter=True, regex=True)
         u_left, u_right = under.peel("_+", includeDelimiter=True, regex=True)
-        assert ["a.", "c.", "e."] == o_left.to_list()
-        assert ["a1", "c1", "e1"] == d_left.to_list()
-        assert ["a_", "c___", "e__"] == u_left.to_list()
-        assert ["b", "d", "f.g"] == o_right.to_list()
-        assert ["b", "d", "f2g"] == d_right.to_list()
-        assert ["b", "d", "f____g"] == u_right.to_list()
+        assert ["a.", "c.", "e."] == o_left.tolist()
+        assert ["a1", "c1", "e1"] == d_left.tolist()
+        assert ["a_", "c___", "e__"] == u_left.tolist()
+        assert ["b", "d", "f.g"] == o_right.tolist()
+        assert ["b", "d", "f2g"] == d_right.tolist()
+        assert ["b", "d", "f____g"] == u_right.tolist()
 
         o_left, o_right = orig.peel(".", times=2, keepPartial=True)
         d_left, d_right = digit.peel("\\d", times=2, keepPartial=True, regex=True)
         u_left, u_right = under.peel("_+", times=2, keepPartial=True, regex=True)
-        assert ["a.b", "c.d", "e.f"] == o_left.to_list()
-        assert ["a1b", "c1d", "e1f"] == d_left.to_list()
-        assert ["a_b", "c___d", "e__f"] == u_left.to_list()
-        assert ["", "", "g"] == o_right.to_list()
-        assert ["", "", "g"] == d_right.to_list()
-        assert ["", "", "g"] == u_right.to_list()
+        assert ["a.b", "c.d", "e.f"] == o_left.tolist()
+        assert ["a1b", "c1d", "e1f"] == d_left.tolist()
+        assert ["a_b", "c___d", "e__f"] == u_left.tolist()
+        assert ["", "", "g"] == o_right.tolist()
+        assert ["", "", "g"] == d_right.tolist()
+        assert ["", "", "g"] == u_right.tolist()
 
         # rpeel / fromRight: digit is testing fromRight and under is testing rpeel
         o_left, o_right = orig.peel(".", times=2, includeDelimiter=True, fromRight=True)
         d_left, d_right = digit.peel("\\d", times=2, includeDelimiter=True, fromRight=True, regex=True)
         u_left, u_right = under.rpeel("_+", times=2, includeDelimiter=True, regex=True)
-        assert ["a.b", "c.d", "e"] == o_left.to_list()
-        assert ["a1b", "c1d", "e"] == d_left.to_list()
-        assert ["a_b", "c___d", "e"] == u_left.to_list()
-        assert ["", "", ".f.g"] == o_right.to_list()
-        assert ["", "", "1f2g"] == d_right.to_list()
-        assert ["", "", "__f____g"] == u_right.to_list()
+        assert ["a.b", "c.d", "e"] == o_left.tolist()
+        assert ["a1b", "c1d", "e"] == d_left.tolist()
+        assert ["a_b", "c___d", "e"] == u_left.tolist()
+        assert ["", "", ".f.g"] == o_right.tolist()
+        assert ["", "", "1f2g"] == d_right.tolist()
+        assert ["", "", "__f____g"] == u_right.tolist()
 
     def test_regex_on_split(self):
         orig = ak.array(["one|two", "three|four|five", "six", "seven|eight|nine|ten|", "eleven"])
@@ -325,8 +325,8 @@ class TestRegex:
         answer_map = [0, 2, 5, 6, 11]
         for pattern, strings in zip(["|", "\\d", "_+"], [orig, digit, under]):
             ak_flat, ak_map = strings.split(pattern, return_segments=True, regex=pattern != "|")
-            assert answer_flat == ak_flat.to_list()
-            assert answer_map == ak_map.to_list()
+            assert answer_flat == ak_flat.tolist()
+            assert answer_map == ak_map.tolist()
 
         # empty string, start with delim, end with delim, and only delim cases
         orig = ak.array(["", "|", "|1|2", "3|4|", "5"])
@@ -338,7 +338,7 @@ class TestRegex:
         orig_flat, orig_map = orig.split("|", return_segments=True)
         regex_flat, regex_map = regex.split("_+", return_segments=True, regex=True)
 
-        assert answer_flat == orig_flat.to_list()
-        assert answer_flat == regex_flat.to_list()
-        assert answer_map == orig_map.to_list()
-        assert answer_map == regex_map.to_list()
+        assert answer_flat == orig_flat.tolist()
+        assert answer_flat == regex_flat.tolist()
+        assert answer_map == orig_map.tolist()
+        assert answer_map == regex_map.tolist()

--- a/tests/stats_test.py
+++ b/tests/stats_test.py
@@ -69,7 +69,7 @@ class TestStats:
 
         # is there a better way to compare to pandas dataframe when the index doesn't match
         for c in ak_df.columns:
-            assert np.allclose(ak_df[c].to_list(), pd_df[c].to_list())
+            assert np.allclose(ak_df[c].tolist(), pd_df[c].tolist())
 
         # verify this doesn't have scoping issues with numeric conversion
         ak.DataFrame(
@@ -142,16 +142,16 @@ class TestStats:
         for ak_args, np_args in all_args:
             ak_div, ak_mod = ak.divmod(*ak_args)
             np_div, np_mod = np.divmod(*np_args)
-            assert ak_div.to_list() == np_div.tolist()
-            assert ak_mod.to_list() == np_mod.tolist()
+            assert ak_div.tolist() == np_div.tolist()
+            assert ak_mod.tolist() == np_mod.tolist()
 
         # Boolean where argument
         truth = ak.arange(10) % 2 == 0
         ak_div_truth, ak_mod_truth = ak.divmod(self.x, self.y, where=truth)
         div_ans = [(self.x[i] // self.y[i]) if truth[i] else self.x[i] for i in range(10)]
         mod_ans = [(self.x[i] % self.y[i]) if truth[i] else self.x[i] for i in range(10)]
-        assert ak_div_truth.to_list() == div_ans
-        assert ak_mod_truth.to_list() == mod_ans
+        assert ak_div_truth.tolist() == div_ans
+        assert ak_mod_truth.tolist() == mod_ans
 
         # Edge cases in the numerator
         edge_case = [-np.inf, -7.0, -0.0, np.nan, 0.0, 7.0, np.inf]

--- a/tests/symbol_table_test.py
+++ b/tests/symbol_table_test.py
@@ -59,7 +59,7 @@ class TestRegistration:
         attach_pda = ak.attach(reg_name)
         assert attach_pda.is_registered()
         assert pda.registered_name == attach_pda.registered_name
-        assert pda.to_list() == attach_pda.to_list()
+        assert pda.tolist() == attach_pda.tolist()
         if dtype == ak.str_:
             assert isinstance(attach_pda, ak.Strings)
         else:
@@ -100,7 +100,7 @@ class TestRegistration:
         attach_ip = ak.attach(reg_name)
         assert attach_ip.is_registered()
         assert ip.registered_name == attach_ip.registered_name
-        assert ip.to_list() == attach_ip.to_list()
+        assert ip.tolist() == attach_ip.tolist()
         assert isinstance(attach_ip, ak.IPv4)
 
         # validate error handling for double registration
@@ -138,7 +138,7 @@ class TestRegistration:
         attach_dt = ak.attach(reg_name)
         assert attach_dt.is_registered()
         assert dt.registered_name == attach_dt.registered_name
-        assert dt.to_list() == attach_dt.to_list()
+        assert dt.tolist() == attach_dt.tolist()
         assert isinstance(attach_dt, ak.Datetime)
 
         # validate error handling for double registration
@@ -176,7 +176,7 @@ class TestRegistration:
         attach_td = ak.attach(reg_name)
         assert attach_td.is_registered()
         assert td.registered_name == attach_td.registered_name
-        assert td.to_list() == attach_td.to_list()
+        assert td.tolist() == attach_td.tolist()
         assert isinstance(attach_td, ak.Timedelta)
 
         # validate error handling for double registration
@@ -218,7 +218,7 @@ class TestRegistration:
         attach_sa = ak.attach(reg_name)
         assert attach_sa.is_registered()
         assert sa.registered_name == attach_sa.registered_name
-        assert sa.to_list() == attach_sa.to_list()
+        assert sa.tolist() == attach_sa.tolist()
         assert isinstance(attach_sa, ak.SegArray)
 
         # validate error handling for double registration
@@ -343,11 +343,11 @@ class TestRegistration:
         assert attach_g.is_registered()
         assert g.registered_name == attach_g.registered_name
         # need to index the attached to ensure same columns order
-        assert g.segments.to_list() == attach_g.segments.to_list()
-        assert g.permutation.to_list() == attach_g.permutation.to_list()
-        assert g._uki.to_list() == attach_g._uki.to_list()
+        assert g.segments.tolist() == attach_g.segments.tolist()
+        assert g.permutation.tolist() == attach_g.permutation.tolist()
+        assert g._uki.tolist() == attach_g._uki.tolist()
         for k, attach_k in zip(g.keys, attach_g.keys):
-            assert k.to_list() == attach_k.to_list()
+            assert k.tolist() == attach_k.tolist()
         assert isinstance(attach_g, ak.GroupBy)
 
         # validate error handling for double registration
@@ -391,12 +391,12 @@ class TestRegistration:
         assert attach_cat.is_registered()
         assert cat.registered_name == attach_cat.registered_name
         # need to index the attached to ensure same columns order
-        assert cat.codes.to_list() == attach_cat.codes.to_list()
-        assert cat.categories.to_list() == attach_cat.categories.to_list()
-        assert cat._akNAcode.to_list() == attach_cat._akNAcode.to_list()
+        assert cat.codes.tolist() == attach_cat.codes.tolist()
+        assert cat.categories.tolist() == attach_cat.categories.tolist()
+        assert cat._akNAcode.tolist() == attach_cat._akNAcode.tolist()
         if cat.segments is not None and cat.permutation is not None:
-            assert cat.segments.to_list() == attach_cat.segments.to_list()
-            assert cat.permutation.to_list() == attach_cat.permutation.to_list()
+            assert cat.segments.tolist() == attach_cat.segments.tolist()
+            assert cat.permutation.tolist() == attach_cat.permutation.tolist()
         assert isinstance(attach_cat, ak.Categorical)
 
         # validate error handling for double registration
@@ -436,7 +436,7 @@ class TestRegistration:
         attach_i = ak.attach(reg_name)
         assert attach_i.is_registered()
         assert i.registered_name == attach_i.registered_name
-        assert i.to_list() == attach_i.to_list()
+        assert i.tolist() == attach_i.tolist()
         assert isinstance(attach_i, ak.Index)
 
         # validate error handling for double registration
@@ -490,7 +490,7 @@ class TestRegistration:
         attach_i = ak.attach(reg_name)
         assert attach_i.is_registered()
         assert i.registered_name == attach_i.registered_name
-        assert i.to_list() == attach_i.to_list()
+        assert i.tolist() == attach_i.tolist()
         assert isinstance(attach_i, ak.MultiIndex)
 
         # validate error handling for double registration
@@ -531,7 +531,7 @@ class TestRegistration:
         attach_s = ak.attach(reg_name)
         assert attach_s.is_registered()
         assert s.registered_name == attach_s.registered_name
-        assert s.to_list() == attach_s.to_list()
+        assert s.tolist() == attach_s.tolist()
         assert isinstance(attach_s, ak.Series)
 
         # validate error handling for double registration
@@ -570,7 +570,7 @@ class TestRegistration:
         attach_b = ak.attach(reg_name)
         assert attach_b.is_registered()
         assert b.registered_name, attach_b.registered_name
-        assert b.to_list() == attach_b.to_list()
+        assert b.tolist() == attach_b.tolist()
         assert isinstance(attach_b, ak.BitVector)
 
         # validate error handling for double registration
@@ -695,8 +695,8 @@ class TestRegistration:
         assert "MyCat" in att
         assert isinstance(att["MyArray"], ak.pdarray)
         assert isinstance(att["MyCat"], ak.Categorical)
-        assert att["MyArray"].to_list() == a.to_list()
-        assert att["MyCat"].to_list() == c.to_list()
+        assert att["MyArray"].tolist() == a.tolist()
+        assert att["MyCat"].tolist() == c.tolist()
 
         # validate all objects are unregistered
         ak.unregister_all(["MyStrings", "MyArray"])

--- a/tests/where_test.py
+++ b/tests/where_test.py
@@ -56,7 +56,7 @@ class TestWhere:
 
         cond = a1 < 5
         result = ak.where(cond, a1, a2)
-        assert np_result.tolist() == result.to_list()
+        assert np_result.tolist() == result.tolist()
 
     def test_greater_than_where_clause(self):
         n1 = np.arange(1, 10)
@@ -69,7 +69,7 @@ class TestWhere:
 
         cond = a1 > 5
         result = ak.where(cond, a1, a2)
-        assert np_result.tolist() == result.to_list()
+        assert np_result.tolist() == result.tolist()
 
     def test_greater_than_where_clause_with_scalars(self):
         n1 = np.arange(1, 10)
@@ -80,12 +80,12 @@ class TestWhere:
 
         condA = a1 > 5
         result = ak.where(condA, a1, 1)
-        assert np_result.tolist() == result.to_list()
+        assert np_result.tolist() == result.tolist()
 
         np_result = np.where(condN, 1, n1)
 
         result = ak.where(condA, 1, a1)
-        assert np_result.tolist() == result.to_list()
+        assert np_result.tolist() == result.tolist()
 
     def test_not_equal_where_clause(self):
         n1 = np.arange(1, 10)
@@ -98,7 +98,7 @@ class TestWhere:
 
         cond = a1 != 5
         result = ak.where(cond, a1, a2)
-        assert np_result.tolist() == result.to_list()
+        assert np_result.tolist() == result.tolist()
 
     def test_equals_where_clause(self):
         n1 = np.arange(1, 10)
@@ -111,7 +111,7 @@ class TestWhere:
 
         cond = a1 == 5
         result = ak.where(cond, a1, a2)
-        assert np_result.tolist() == result.to_list()
+        assert np_result.tolist() == result.tolist()
 
     def test_where_filter(self):
         n1 = np.arange(1, 10)
@@ -120,8 +120,8 @@ class TestWhere:
         a2 = ak.array(n2)
 
         assert n2.tolist() == n1[n1 > 5].tolist()
-        assert a2.to_list() == a1[a1 > 5].to_list()
-        assert n1[n1 > 5].tolist() == a1[a1 > 5].to_list()
+        assert a2.tolist() == a1[a1 > 5].tolist()
+        assert n1[n1 > 5].tolist() == a1[a1 > 5].tolist()
 
     def test_multiple_where_clauses(self):
         n1 = np.arange(1, 10)
@@ -145,6 +145,6 @@ class TestWhere:
         for dt in (ak.int64, ak.uint64, ak.float64, ak.bool_):
             a = ak.ones(10, dtype=dt)
             b = ak.ones(10, dtype=dt)
-            assert ak.where(cond, a, b).to_list() == a.to_list()
-            assert ak.where(cond, 1, b).to_list() == a.to_list()
-            assert ak.where(cond, a, 1).to_list() == a.to_list()
+            assert ak.where(cond, a, b).tolist() == a.tolist()
+            assert ak.where(cond, 1, b).tolist() == a.tolist()
+            assert ak.where(cond, a, 1).tolist() == a.tolist()


### PR DESCRIPTION
This PR renames the `to_list` function to `tolist` to match numpy.

Closes #4692:  tolist to match numpy