### PR TITLE
Closes #4696:  set max-parallel for multi-dim tests in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -485,6 +485,7 @@ jobs:
     strategy:
       matrix:
         chpl-version: ['2.0.0','2.1.0','2.2.0','2.3.0','2.4.0']
+      max-parallel: 3
     env:
       CHPL_HOME: /opt/chapel-${{ matrix.chpl-version }}
     container:


### PR DESCRIPTION
Sets the `max-parallel` constraint for multi-dim tests in CI. This will limit the number of runners in that group that can kick off at the same time and may reduce the chance of out-of-memory errors.

Closes #4696:  set max-parallel for multi-dim tests in CI