### PR TITLE
Closes #4698:  add cancel-in-progress to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,6 +4,10 @@ on: [pull_request, merge_group, workflow_dispatch]
 
 env:
   ARKOUDA_QUICK_COMPILE: true
+  
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:


### PR DESCRIPTION
This PR adds a concurrency block to the top-level of the GitHub Actions workflow to prevent duplicate or overlapping runs for the same branch or pull request.

Introduced:

```
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```
This ensures that only one workflow run per branch or PR is active at a time.

Closes #4698:  add cancel-in-progress to CI