### PR TITLE
Fix auto-checkpointing failure

### DIFF
--- a/tests/optioned-server/auto-checkpoints.py
+++ b/tests/optioned-server/auto-checkpoints.py
@@ -97,8 +97,8 @@ class TestIdleAndInterval:
         assert not directory_exists(autockptPrevDir)
         sleep(1)
         assert directory_exists_delayed(autockptPrevDir, 10)
-        assert directory_exists(autockptDir)
         ak.client.wait_for_async_activity()
+        assert directory_exists(autockptDir)
         # verify that these checkpoints were created successfully
         ak.load_checkpoint(autockptName)
         ak.load_checkpoint(autockptPrevName)


### PR DESCRIPTION
Fix an unlikely, yet possible failing scenario in auto-checkpoint testing, which we have seen fail occasionally in github CI checks.

#### Details

In this scenario, the test code in `auto-checkpoints.py`(Process 1) does the following:

```python
... wait for ".akdata/auto_checkpoint.prev" to be created ...
assert(directory_exists(".akdata/auto_checkpoint.prev"))
assert(directory_exists(".akdata/auto_checkpoint"))
```

Meanwhile the server code in `CheckpointMsg.chpl` (Process 2) does the following:

```chpl
...
rename(".akdata/auto_checkpoint", ".akdata/auto_checkpoint.prev")
mkdir(".akdata/auto_checkpoint")
```

While these run concurrently, it is possible that the server (Process 2) is pre-empted between the two statements while the test (Process 1) continues execution. In this case, the test observes the ".prev" directory, passes the first assertion, however arrives at the second assertion before the server is given its chance to create that directory, causing the second assertion to fail.

The solution implemented in this PR is for the test to wait for the auto-checkpoint to complete on the server before running the second assert.