### PR TITLE
Skipif testing of auto-checkpoints.py

### DIFF
--- a/tests/optioned-server/auto-checkpoints.py
+++ b/tests/optioned-server/auto-checkpoints.py
@@ -1,9 +1,15 @@
+import os
 from time import sleep
 
 import pytest
 
 import arkouda as ak
 from arkouda.pandas.io_util import delete_directory, directory_exists
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("CHPL_HOST_PLATFORM") == "hpe-apollo",
+    reason="skipped on CHPL_HOST_PLATFORM=hpe-apollo - login/compute file system access unreliable",
+)
 
 autockptPath = ".akdata"
 autockptName = "auto_checkpoint"


### PR DESCRIPTION
One of the testing machines does not support file system accesses across the login node (running the pytest client) and the compute nodes (running the server). Do not test `auto-checkpoints.py` in that case to avoid failures.

This duplicates the solution in #4690 for `auto-checkpoints.py` . 