### PR TITLE
Closes #3579:  Update str_locality_benchmark

### DIFF
--- a/benchmark_v2/str_locality_benchmark.py
+++ b/benchmark_v2/str_locality_benchmark.py
@@ -17,15 +17,16 @@ def _generate_data(loc):
     prefix = ak.random_strings_uniform(
         minlen=1, maxlen=16, size=N, seed=pytest.seed, characters="numeric"
     )
-    if pytest.seed is not None:
-        pytest.seed += 1
     suffix = ak.random_strings_uniform(
-        minlen=1, maxlen=16, size=N, seed=pytest.seed, characters="numeric"
+        minlen=1,
+        maxlen=16,
+        size=N,
+        seed=None if pytest.seed is None else pytest.seed + 1,
+        characters="numeric",
     )
     random_strings = prefix.stick(suffix, delimiter=".")
     perm = ak.argsort(random_strings.get_lengths())
-    sorted_strings = random_strings[perm]
-    return random_strings if loc == "Good" else sorted_strings
+    return random_strings if loc == "Good" else random_strings[perm]
 
 
 @pytest.mark.skip_correctness_only(True)


### PR DESCRIPTION
## PR: Refactor `str_locality_benchmark.py` for Clarity and Consistency

This PR makes minor refinements to the `str_locality_benchmark.py` benchmark while maintaining its original functionality and performance focus.

### ✅ Changes Made
- **Seed Handling**: Avoids mutating `pytest.seed` directly by incrementing a local copy when generating the second string component. This ensures reproducibility without side effects across tests.
- **Consistent Data Size Calculation**: Uses `data.nbytes` consistently for transfer rate calculation.
- **Minor Code Cleanup**: Simplified logic for generating sorted/unsorted string arrays for locality effects.

### 🔍 Behavior
- **No Correctness Mode**: The benchmark remains performance-only, skipping when `--correctness_only` or `--numpy` is set.
- **Parameters**: Benchmarks string locality effects (`Good` vs `Poor`) across four operations (`Hashing`, `Regex_Search`, `Casting`, `Scalar_Compare`).
- **Metadata**: Still reports problem size, backend, and transfer rate.

This refactor improves maintainability and reproducibility while keeping results comparable with previous runs.


Closes #3579:  Update str_locality_benchmark