### PR TITLE
Closes #4706  strip out correctness_only mode from the benchmarks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -638,9 +638,6 @@ jobs:
         make benchmark size_bm=10
     - name: Arkouda benchmark -- Numpy
       run: |
-        python3 -m pytest -c benchmark.ini --size=10 --numpy 
-    - name: Arkouda benchmark -- Correctness Only
-      run: |
-        python3 -m pytest -c benchmark.ini --size=10 --correctness_only     
+        python3 -m pytest -c benchmark.ini --size=10 --numpy   
           
             

--- a/benchmark.ini
+++ b/benchmark.ini
@@ -41,6 +41,5 @@ env =
     D:ARKOUDA_CLIENT_TIMEOUT=0
     D:ARKOUDA_LOG_LEVEL=DEBUG
 markers =
-    skip_correctness_only
     skip_numpy
     skip_if_rank_not_compiled

--- a/benchmark_v2/argsort_benchmark.py
+++ b/benchmark_v2/argsort_benchmark.py
@@ -17,7 +17,7 @@ def bench_argsort(benchmark, dtype):
     str dtype is significantly slower than numerics
     """
     cfg = ak.get_config()
-    N = 10**4 if pytest.correctness_only else pytest.prob_size * cfg["numLocales"]
+    N = pytest.prob_size * cfg["numLocales"]
 
     if dtype in pytest.dtype:
         if dtype == "int64":
@@ -36,14 +36,9 @@ def bench_argsort(benchmark, dtype):
 
         if pytest.numpy:
             a = a.to_ndarray()
-            result = benchmark.pedantic(np.argsort, args=[a], rounds=pytest.trials)
+            benchmark.pedantic(np.argsort, args=[a], rounds=pytest.trials)
         else:
-            result = benchmark.pedantic(ak.argsort, args=[a], rounds=pytest.trials)
-
-        if pytest.correctness_only and not pytest.numpy and dtype != "str":
-            a_np = a.to_ndarray()
-            expected = np.argsort(a_np)
-            np.testing.assert_array_equal(result.to_ndarray(), expected)
+            benchmark.pedantic(ak.argsort, args=[a], rounds=pytest.trials)
 
         benchmark.extra_info["description"] = "Measures the performance of argsort"
         benchmark.extra_info["problem_size"] = N

--- a/benchmark_v2/array_create_benchmark.py
+++ b/benchmark_v2/array_create_benchmark.py
@@ -36,7 +36,6 @@ def _create_np_array(size, op, dtype, seed):
     return a
 
 
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.benchmark(group="Array_Create")
 @pytest.mark.parametrize("op", OPS)
 @pytest.mark.parametrize("dtype", TYPES)
@@ -45,7 +44,7 @@ def bench_array_create(benchmark, op, dtype):
     Measures array creation performance (Arkouda or NumPy based on flags)
     """
     cfg = ak.get_config()
-    size = 10**4 if pytest.correctness_only else pytest.prob_size * cfg["numLocales"]
+    size = pytest.prob_size * cfg["numLocales"]
 
     if dtype in pytest.dtype:
         if pytest.numpy:

--- a/benchmark_v2/array_transfer_benchmark.py
+++ b/benchmark_v2/array_transfer_benchmark.py
@@ -17,12 +17,11 @@ def create_ak_array(N, dtype):
     return a, nb
 
 
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.benchmark(group="ArrayTransfer_tondarray")
 @pytest.mark.parametrize("dtype", TYPES)
 def bench_array_transfer_tondarray(benchmark, dtype):
     if dtype in pytest.dtype:
-        N = 10**4 if pytest.correctness_only else pytest.prob_size * ak.get_config()["numLocales"]
+        N = pytest.prob_size * ak.get_config()["numLocales"]
         a, nb = create_ak_array(N, dtype)
         ak.client.maxTransferBytes = nb
 
@@ -40,12 +39,11 @@ def bench_array_transfer_tondarray(benchmark, dtype):
         benchmark.extra_info["max_bit"] = pytest.max_bits
 
 
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.benchmark(group="ArrayTransfer_ak.array")
 @pytest.mark.parametrize("dtype", TYPES)
 def bench_array_transfer_akarray(benchmark, dtype):
     if dtype in pytest.dtype:
-        N = 10**4 if pytest.correctness_only else pytest.prob_size * ak.get_config()["numLocales"]
+        N = pytest.prob_size * ak.get_config()["numLocales"]
         a, nb = create_ak_array(N, dtype)
         ak.client.maxTransferBytes = nb
         npa = a.to_ndarray()

--- a/benchmark_v2/bigint_bitwise_binops_benchmark.py
+++ b/benchmark_v2/bigint_bitwise_binops_benchmark.py
@@ -17,14 +17,13 @@ def compute_nbytes(N):
     return N * 16
 
 
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.benchmark(group="Bigint Bitwise Binops")
 @pytest.mark.parametrize("op", OPS)
 def bench_bitwise_binops(benchmark, op):
     """
     Measures the performance of bigint bitwise binops
     """
-    N = 10**4 if pytest.correctness_only else pytest.prob_size * ak.get_config()["numLocales"]
+    N = pytest.prob_size * ak.get_config()["numLocales"]
     nbytes = compute_nbytes(N)
 
     a = generate_bigint_pair(N)

--- a/benchmark_v2/bigint_conversion_benchmark.py
+++ b/benchmark_v2/bigint_conversion_benchmark.py
@@ -3,7 +3,6 @@ import pytest
 import arkouda as ak
 
 
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.skip_numpy(True)
 @pytest.mark.benchmark(group="BigInt_Conversion")
 @pytest.mark.parametrize("direction", ["to_bigint", "from_bigint"])

--- a/benchmark_v2/coargsort_benchmark.py
+++ b/benchmark_v2/coargsort_benchmark.py
@@ -12,7 +12,7 @@ NUM_ARR = [1, 2, 8, 16]
 @pytest.mark.parametrize("dtype", TYPES)
 def bench_coargsort(benchmark, dtype, numArrays):
     cfg = ak.get_config()
-    N = 10**4 if pytest.correctness_only else pytest.prob_size * cfg["numLocales"]
+    N = pytest.prob_size * cfg["numLocales"]
 
     if dtype in pytest.dtype:
         if pytest.seed is None:
@@ -42,14 +42,7 @@ def bench_coargsort(benchmark, dtype, numArrays):
         else:
             func = ak.coargsort
 
-        result = benchmark.pedantic(func, args=[arrs], rounds=pytest.trials)
-
-        if pytest.correctness_only and not pytest.numpy and dtype != "str":
-            arrs_np = [a.to_ndarray() for a in arrs]
-            #   np.lexsort sorts the arrays in reverse key order from ak.coargsort.
-            arrs_np.reverse()
-            expected = np.lexsort(arrs_np)
-            np.testing.assert_array_equal(result.to_ndarray(), expected)
+        benchmark.pedantic(func, args=[arrs], rounds=pytest.trials)
 
         benchmark.extra_info["description"] = "Measures the performance of ak.coargsort"
         benchmark.extra_info["problem_size"] = N

--- a/benchmark_v2/conftest.py
+++ b/benchmark_v2/conftest.py
@@ -193,12 +193,6 @@ def pytest_addoption(parser):
         default=os.path.join(os.getcwd(), "ak_io_benchmark"),
         help="Benchmark only option. Target path for measuring read/write rates",
     )
-    parser.addoption(
-        "--correctness_only",
-        default=False,
-        action="store_true",
-        help="Only check correctness, not performance.",
-    )
 
 
 def pytest_configure(config):
@@ -236,8 +230,6 @@ def pytest_configure(config):
     pytest.io_path = config.getoption("io_path")
     pytest.io_read = config.getoption("io_only_read")
     pytest.io_write = config.getoption("io_only_write")
-
-    pytest.correctness_only = config.getoption("correctness_only")
 
 
 def _ensure_plugins_installed():
@@ -321,15 +313,6 @@ def manage_connection():
         ak.disconnect()
     except Exception as e:
         raise ConnectionError(e)
-
-
-@pytest.fixture(autouse=True)
-def skip_correctness_only(request):
-    marker = request.node.get_closest_marker("skip_correctness_only")
-    if marker and marker.args and marker.args[0] == pytest.correctness_only:
-        pytest.skip(
-            f"{request.node.name} skipped: requires --correctness_only != {pytest.correctness_only}"
-        )
 
 
 @pytest.fixture(autouse=True)

--- a/benchmark_v2/csv_io_benchmark.py
+++ b/benchmark_v2/csv_io_benchmark.py
@@ -29,7 +29,6 @@ def remove_files(path):
         os.remove(f)
 
 
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.skip_numpy(True)
 @pytest.mark.benchmark(group="CSV_IO")
 @pytest.mark.parametrize("dtype", TYPES)

--- a/benchmark_v2/dataframe_indexing_benchmark.py
+++ b/benchmark_v2/dataframe_indexing_benchmark.py
@@ -7,14 +7,13 @@ import arkouda as ak
 OPS = ["_get_head_tail_server", "_get_head_tail"]
 
 
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.benchmark(group="Dataframe_Indexing")
 @pytest.mark.parametrize("op", OPS)
 def bench_dataframe(benchmark, op):
     """
     Measures the performance of arkouda Dataframe indexing
     """
-    N = 10**4 if pytest.correctness_only else pytest.prob_size * ak.get_config()["numLocales"]
+    N = pytest.prob_size * ak.get_config()["numLocales"]
 
     types = [ak.Categorical, ak.pdarray, ak.Strings, ak.SegArray]
     df_dict = {}

--- a/benchmark_v2/encoding_benchmark.py
+++ b/benchmark_v2/encoding_benchmark.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 
 import arkouda as ak
@@ -14,12 +13,11 @@ def compute_nbytes(a):
     return a.nbytes * a.entry.itemsize
 
 
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.skip_numpy(True)
 @pytest.mark.benchmark(group="Strings_EncodeDecode")
 @pytest.mark.parametrize("encoding", ENCODINGS)
 def bench_encode(benchmark, encoding):
-    N = 10**4 if pytest.correctness_only else pytest.prob_size * ak.get_config()["numLocales"]
+    N = pytest.prob_size * ak.get_config()["numLocales"]
     a = generate_string_array(N)
     nbytes = compute_nbytes(a)
 
@@ -29,11 +27,6 @@ def bench_encode(benchmark, encoding):
 
     numBytes = benchmark.pedantic(encode_op, rounds=pytest.trials)
 
-    if pytest.correctness_only:
-        input_strs = a.to_ndarray()
-        expected = np.array([s.encode(encoding) for s in input_strs])
-        np.testing.assert_array_equal(a.encode(encoding).to_ndarray(), expected)
-
     benchmark.extra_info["description"] = f"Measures the performance of Strings.encode with '{encoding}'"
     benchmark.extra_info["problem_size"] = N
     benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
@@ -41,12 +34,11 @@ def bench_encode(benchmark, encoding):
     )
 
 
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.skip_numpy(True)
 @pytest.mark.benchmark(group="Strings_EncodeDecode")
 @pytest.mark.parametrize("encoding", ENCODINGS)
 def bench_decode(benchmark, encoding):
-    N = 10**4 if pytest.correctness_only else pytest.prob_size * ak.get_config()["numLocales"]
+    N = pytest.prob_size * ak.get_config()["numLocales"]
     a = generate_string_array(N)
     encoded = a.encode(encoding)
     nbytes = compute_nbytes(a)
@@ -56,11 +48,6 @@ def bench_decode(benchmark, encoding):
         return nbytes
 
     numBytes = benchmark.pedantic(decode_op, rounds=pytest.trials)
-
-    if pytest.correctness_only:
-        expected = np.array([s for s in a.to_ndarray()])
-        result = encoded.decode(encoding).to_ndarray()
-        np.testing.assert_array_equal(result, expected)
 
     benchmark.extra_info["description"] = f"Measures the performance of Strings.decode with '{encoding}'"
     benchmark.extra_info["problem_size"] = N

--- a/benchmark_v2/flatten_benchmark.py
+++ b/benchmark_v2/flatten_benchmark.py
@@ -13,7 +13,7 @@ DTYPES = ("int64", "float64", "bool")
 @pytest.mark.parametrize("shape_type", ["square", "wide", "tall"])
 def bench_ak_flatten_2d(benchmark, dtype, shape_type):
     cfg = ak.get_config()
-    N = 10**4 if pytest.correctness_only else pytest.prob_size * cfg["numLocales"]
+    N = pytest.prob_size * cfg["numLocales"]
 
     if shape_type == "square":
         #   Ensure N has an integer square root:
@@ -49,8 +49,3 @@ def bench_ak_flatten_2d(benchmark, dtype, shape_type):
     benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
         (data.size * data.itemsize / benchmark.stats["mean"]) / 2**30
     )
-
-    if pytest.correctness_only:
-        np_expected = data.to_ndarray().reshape(shape).flatten()
-        np_actual = flatten_op().to_ndarray()
-        np.testing.assert_array_equal(np_expected, np_actual)

--- a/benchmark_v2/gather_benchmark.py
+++ b/benchmark_v2/gather_benchmark.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 
 import arkouda as ak
@@ -23,7 +22,7 @@ def compute_transfer_bytes(result, dtype):
 @pytest.mark.parametrize("dtype", TYPES)
 def bench_gather(benchmark, dtype):
     cfg = ak.get_config()
-    N = 10**4 if pytest.correctness_only else pytest.prob_size
+    N = pytest.prob_size
     isize = N if pytest.idx_size is None else pytest.idx_size
     vsize = N if pytest.val_size is None else pytest.val_size
     Ni = isize * cfg["numLocales"]
@@ -66,14 +65,6 @@ def bench_gather(benchmark, dtype):
 
         numBytes = benchmark.pedantic(gather_ak_op, rounds=pytest.trials)
         backend = "Arkouda"
-
-        # Correctness check: compare against NumPy if enabled
-        if pytest.correctness_only:
-            i_np = i_ak.to_ndarray()
-            v_np = v_ak.to_ndarray()
-            expected = v_np[i_np]
-            result = _run_gather(v_ak, i_ak).to_ndarray()
-            np.testing.assert_array_equal(result, expected)
 
     benchmark.extra_info["description"] = f"Measures the performance of {backend} gather"
     benchmark.extra_info["backend"] = backend

--- a/benchmark_v2/groupby_benchmark.py
+++ b/benchmark_v2/groupby_benchmark.py
@@ -31,7 +31,6 @@ def generate_arrays(dtype, numArrays, N):
     return arrays, totalbytes
 
 
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.benchmark(group="GroupBy_Creation")
 @pytest.mark.parametrize("numArrays", NUM_ARR)
 @pytest.mark.parametrize("dtype", TYPES)

--- a/benchmark_v2/io_benchmark.py
+++ b/benchmark_v2/io_benchmark.py
@@ -84,7 +84,6 @@ def _build_prefix(ftype: str, dtype: str, compression=None, multi=False, append=
     return base + f"par_{compression}_{dtype}"
 
 
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.skip_numpy(True)
 @pytest.mark.benchmark(group="Arkouda_IO_Write_HDF5")
 @pytest.mark.parametrize("dtype", TYPES)
@@ -111,7 +110,6 @@ def bench_write_hdf(benchmark, dtype):
         )
 
 
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.skip_numpy(True)
 @pytest.mark.benchmark(group="Arkouda_IO_Write_Parquet")
 @pytest.mark.parametrize("dtype", TYPES)
@@ -144,7 +142,6 @@ def bench_write_parquet(benchmark, dtype, comp):
         )
 
 
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.skip_numpy(True)
 @pytest.mark.benchmark(group="Arkouda_IO_Write_Parquet")
 @pytest.mark.parametrize("dtype", TYPES)
@@ -180,7 +177,6 @@ def bench_write_parquet_multi(benchmark, dtype, comp):
         )
 
 
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.skip_numpy(True)
 @pytest.mark.benchmark(group="Arkouda_IO_Write_Parquet")
 @pytest.mark.parametrize("dtype", TYPES)
@@ -215,7 +211,6 @@ def bench_write_parquet_append(benchmark, dtype, comp):
         )
 
 
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.skip_numpy(True)
 @pytest.mark.benchmark(group="Arkouda_IO_Read_HDF5")
 @pytest.mark.parametrize("dtype", TYPES)
@@ -239,7 +234,6 @@ def bench_read_hdf(benchmark, dtype):
         )
 
 
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.skip_numpy(True)
 @pytest.mark.benchmark(group="Arkouda_IO_Read_Parquet")
 @pytest.mark.parametrize("dtype", TYPES)
@@ -268,7 +262,6 @@ def bench_read_parquet(benchmark, dtype, comp):
         )
 
 
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.skip_numpy(True)
 @pytest.mark.benchmark(group="Arkouda_IO_Read_Parquet")
 @pytest.mark.parametrize("dtype", TYPES)
@@ -301,7 +294,6 @@ def bench_read_parquet_multi_column(benchmark, dtype, comp):
         )
 
 
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.skip_numpy(True)
 @pytest.mark.benchmark(group="Arkouda_IO_Delete")
 def bench_delete(benchmark):

--- a/benchmark_v2/no_op_benchmark.py
+++ b/benchmark_v2/no_op_benchmark.py
@@ -4,7 +4,6 @@ import pytest
 import arkouda as ak
 
 
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.benchmark(group="Arkouda_No_Op")
 def bench_noop(benchmark):
     if pytest.numpy:

--- a/benchmark_v2/parquet-fixed-strings_benchmark.py
+++ b/benchmark_v2/parquet-fixed-strings_benchmark.py
@@ -4,7 +4,6 @@ import arkouda as ak
 
 
 @pytest.mark.skip_numpy(True)
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.benchmark(group="Parquet_Fixed_Strings")
 @pytest.mark.parametrize("scaling", [False, True])
 @pytest.mark.parametrize("fixed_len", [1, 8])

--- a/benchmark_v2/scatter_benchmark.py
+++ b/benchmark_v2/scatter_benchmark.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 
 import arkouda as ak
@@ -15,7 +14,7 @@ def _run_scatter(a, i, v):
 @pytest.mark.parametrize("dtype", TYPES)
 def bench_scatter(benchmark, dtype):
     cfg = ak.get_config()
-    N = 10**4 if pytest.correctness_only else pytest.prob_size
+    N = pytest.prob_size
     isize = N if pytest.idx_size is None else pytest.idx_size
     vsize = N if pytest.val_size is None else pytest.val_size
     Ni = isize * cfg["numLocales"]
@@ -55,14 +54,6 @@ def bench_scatter(benchmark, dtype):
 
         numBytes = benchmark.pedantic(scatter_ak_op, rounds=pytest.trials)
         backend = "Arkouda"
-
-        # Correctness check: compare with NumPy reference
-        if pytest.correctness_only:
-            i_np = i_ak.to_ndarray()
-            v_np = v_ak.to_ndarray()
-            c_np = np.zeros(Nv, dtype=v_np.dtype)
-            c_np[i_np] = v_np
-            np.testing.assert_array_equal(c_ak.to_ndarray(), c_np)
 
     benchmark.extra_info["description"] = f"Measures the performance of {backend} scatter"
     benchmark.extra_info["backend"] = backend

--- a/benchmark_v2/setops_benchmark.py
+++ b/benchmark_v2/setops_benchmark.py
@@ -8,7 +8,6 @@ OPS1D = ("intersect1d", "union1d", "setxor1d", "setdiff1d")
 TYPES = ("int64", "uint64")
 
 
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.skip_numpy(True)
 @pytest.mark.benchmark(group="Segarray_Setops_Small")
 @pytest.mark.parametrize("op", OPS)
@@ -48,7 +47,6 @@ def bench_segarr_setops_small(benchmark, op, dtype):
     )
 
 
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.benchmark(group="Setops")
 @pytest.mark.parametrize("op", OPS1D)
 @pytest.mark.parametrize("dtype", TYPES)

--- a/benchmark_v2/setops_multiarray_benchmark.py
+++ b/benchmark_v2/setops_multiarray_benchmark.py
@@ -7,13 +7,12 @@ DTYPES = ("int64", "uint64")
 
 
 @pytest.mark.skip_numpy(True)
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.benchmark(group="SetOps_MultiArray")
 @pytest.mark.parametrize("op", OPS)
 @pytest.mark.parametrize("dtype", DTYPES)
 def bench_setops_multiarray(benchmark, op, dtype):
     cfg = ak.get_config()
-    N = 10**4 if pytest.correctness_only else pytest.prob_size * cfg["numLocales"]
+    N = pytest.prob_size * cfg["numLocales"]
 
     seed = pytest.seed or 0
     if dtype == "int64":

--- a/benchmark_v2/small-str-groupby.py
+++ b/benchmark_v2/small-str-groupby.py
@@ -6,11 +6,10 @@ SIZES = {"small": 6, "medium": 12, "big": 24}
 
 
 @pytest.mark.skip_numpy(True)
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.benchmark(group="GroupBySmallStrings")
 @pytest.mark.parametrize("strlen_label", SIZES)
 def bench_groupby_small_str(benchmark, strlen_label):
-    N = 10**4 if pytest.correctness_only else pytest.prob_size * ak.get_config()["numLocales"]
+    N = pytest.prob_size * ak.get_config()["numLocales"]
     strlen = SIZES[strlen_label]
 
     a = ak.random_strings_uniform(1, strlen, N, seed=pytest.seed)

--- a/benchmark_v2/sort_cases_benchmark.py
+++ b/benchmark_v2/sort_cases_benchmark.py
@@ -42,13 +42,7 @@ def run_sort(benchmark, name, data, sort_fn):
     else:
 
         def sort_op():
-            p = sort_fn(data)
-            if pytest.correctness_only:
-                if isinstance(data, tuple):
-                    sorted_data = [d[p] for d in data]  # noqa: F841
-                    # Assume lexsorted comparison is hard to check; skip for now
-                else:
-                    assert ak.is_sorted(data[p])
+            p = sort_fn(data)  # noqa: F841
             return get_nbytes(data)
 
         backend = "Arkouda"

--- a/benchmark_v2/split_benchmark.py
+++ b/benchmark_v2/split_benchmark.py
@@ -9,7 +9,6 @@ SPLIT_MODES = [
 ]
 
 
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.skip_numpy(True)
 @pytest.mark.benchmark(group="Arkouda_Strings_Split")
 @pytest.mark.parametrize("label, delim, use_regex", SPLIT_MODES)

--- a/benchmark_v2/str_locality_benchmark.py
+++ b/benchmark_v2/str_locality_benchmark.py
@@ -13,7 +13,7 @@ LOCALITY = {"Good", "Poor"}
 
 
 def _generate_data(loc):
-    N = 10**4 if pytest.correctness_only else pytest.prob_size * ak.get_config()["numLocales"]
+    N = pytest.prob_size * ak.get_config()["numLocales"]
     prefix = ak.random_strings_uniform(
         minlen=1, maxlen=16, size=N, seed=pytest.seed, characters="numeric"
     )
@@ -28,7 +28,6 @@ def _generate_data(loc):
     return random_strings if loc == "Good" else sorted_strings
 
 
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.skip_numpy(True)
 @pytest.mark.benchmark(group="String_Locality")
 @pytest.mark.parametrize("op", OPS)

--- a/benchmark_v2/stream_benchmark.py
+++ b/benchmark_v2/stream_benchmark.py
@@ -20,7 +20,7 @@ def check_numpy_equivalence(a, b, alpha, result):
 @pytest.mark.parametrize("dtype", ["int64", "float64"])
 def bench_stream(benchmark, dtype):
     cfg = ak.get_config()
-    N = 10**4 if pytest.correctness_only else pytest.prob_size * cfg["numLocales"]
+    N = pytest.prob_size * cfg["numLocales"]
     nBytes = N * 8 * 3
 
     if pytest.random or pytest.seed is not None:
@@ -37,10 +37,7 @@ def bench_stream(benchmark, dtype):
     if pytest.numpy:
         a, b = a.to_ndarray(), b.to_ndarray()
 
-    result = benchmark.pedantic(run_test, args=(a, b, pytest.alpha), rounds=pytest.trials)
-
-    if pytest.correctness_only and not pytest.numpy:
-        check_numpy_equivalence(a, b, pytest.alpha, result)
+    benchmark.pedantic(run_test, args=(a, b, pytest.alpha), rounds=pytest.trials)
 
     benchmark.extra_info["description"] = f"Measures performance of stream using {dtype} types."
     benchmark.extra_info["problem_size"] = N
@@ -53,7 +50,7 @@ def bench_stream(benchmark, dtype):
 @pytest.mark.parametrize("dtype", ["bigint"])
 def bench_bigint_stream(benchmark, dtype):
     cfg = ak.get_config()
-    N = 10**4 if pytest.correctness_only else pytest.prob_size * cfg["numLocales"]
+    N = pytest.prob_size * cfg["numLocales"]
     nBytes = N * 8 * 3
 
     if pytest.random or pytest.seed is not None:

--- a/benchmark_v2/substring_search_benchmark.py
+++ b/benchmark_v2/substring_search_benchmark.py
@@ -9,7 +9,6 @@ SEARCHES = {
 }
 
 
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.skip_numpy(True)
 @pytest.mark.benchmark(group="Arkouda_Strings_SubstringSearch")
 @pytest.mark.parametrize("search_string,use_regex", SEARCHES.values(), ids=list(SEARCHES.keys()))

--- a/benchmark_v2/where_benchmark.py
+++ b/benchmark_v2/where_benchmark.py
@@ -13,7 +13,6 @@ def alternate(L, R, n):
     return v
 
 
-@pytest.mark.skip_correctness_only(True)
 @pytest.mark.benchmark(group="Numpy_Scan")
 @pytest.mark.parametrize("dtype", TYPES)
 @pytest.mark.parametrize("v_or_s", STYLES)


### PR DESCRIPTION
Strips out correctness_only mode from the benchmark_V2 benchmarks due to redundancy with the unit tests.
This includes:
- Removing `--correctness_only` mode testing in the CI.
- Removing the `skip_correctness_only` pytest marker.
- The value of `N` no longer depends on the `correctness_only` mode.

Closes #4706  strip out correctness_only mode from the benchmarks