### PR TITLE
Refactor bitwise ops on booleans and remove duplicated `Set` from BinOp

### DIFF
--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -9,6 +9,7 @@ module BinOp
   use Message;
   use BitOps;
   use BigInteger;
+  use Set;
 
 
   private config const logLevel = ServerConfig.logLevel;
@@ -128,18 +129,11 @@ module BinOp
     return res;
   }
 
-  proc isRealOp(op: string): bool {
-    return op == "+" || op == "-" || op == "*" ||
-           op == "//" || op == "%" || op == "**";
-  }
+  const realOps = new set(string, ["+", "-", "*", "//", "%", "**"]);
 
   // All operations that involve one of these operations result in a `bool`
   // symbol table entry.
-  proc isBoolOp(op: string): bool {
-    return op == "<"  || op == "<=" ||
-           op == ">"  || op == ">=" ||
-           op == "==" || op == "!=";
-  }
+  const boolOps = new set(string, ["<", "<=", ">", ">=", "==", "!="]);
 
   proc doBoolBoolBitOp(
     op: string, ref e: [] bool, l: [] bool, r /*: [] bool OR bool*/
@@ -195,7 +189,7 @@ module BinOp
 
     if etype == bool {
 
-      if isBoolOp(op) {
+      if boolOps.contains(op) {
 
         select op {
 
@@ -328,7 +322,7 @@ module BinOp
 
     if etype == bool {
 
-      if isBoolOp(op) {
+      if boolOps.contains(op) {
 
         select op {
 
@@ -453,7 +447,7 @@ module BinOp
 
     if etype == bool {
 
-      if isBoolOp(op) {
+      if boolOps.contains(op) {
 
         select op {
 

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -129,6 +129,32 @@ module BinOp
     return res;
   }
 
+  //
+  // TODO: these checks sets are used only to check if a string matches
+  // i.e. realOps.contains(op) or boolOps.contains(op)
+  // however, a faster way to do this is to write a function that checks
+  // the ascii bytes
+  // for example, the boolOps can be written as:
+  //
+  // return (op.numBytes == 1 && (op.byte[0] == 60 ||
+  //                             op.byte[0] == 62)) ||
+  //        (op.numBytes == 2 && ((op.byte[0] == 60 && op.byte[1] == 61) ||
+  //                              (op.byte[0] == 62 && op.byte[1] == 61) ||
+  //                              (op.byte[0] == 61 && op.byte[1] == 61) ||
+  //                              (op.byte[0] == 33 && op.byte[1] == 61)));
+  //
+  // it should also be possible to use the `toByte` method at compile-time to
+  // improve the readability, although this has not been tested to see how it impacts
+  // compile-time and runtime performance:
+  //
+  // return (op.numBytes == 1 && (op.byte[0] == "<".toByte() ||
+  //                             op.byte[0] == ">".toByte())) ||
+  //        (op.numBytes == 2 && ((op.byte[0] == "<".toByte() && op.byte[1] == "=".toByte()) ||
+  //                              (op.byte[0] == ">".toByte() && op.byte[1] == "=".toByte()) ||
+  //                              (op.byte[0] == "=".toByte() && op.byte[1] == "=".toByte()) ||
+  //                              (op.byte[0] == "!".toByte() && op.byte[1] == "=".toByte())));
+  //
+
   const realOps = new set(string, ["+", "-", "*", "//", "%", "**"]);
 
   // All operations that involve one of these operations result in a `bool`

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -130,17 +130,20 @@ module BinOp
 
 
   proc doBoolBoolBitOp(
-    op:string, ref e: [] bool, l: [] bool, r /*: [] bool OR bool*/
+    op: string, ref e: [] bool, l: [] bool, r /*: [] bool OR bool*/
   ): bool {
-    select op {
-      when "|" { e = l | r; }
-      when "&" { e = l & r; }
-      when "*" { e = l & r; }
-      when "^" { e = l ^ r; }
-      when "+" { e = l | r; }
-      otherwise do return false;
+    var handled = false;
+    if op == "|" || op == "+" {
+      e = l | r;
+      handled = true;
+    } else if op == "&" || op == "*" {
+      e = l & r;
+      handled = true;
+    } else if op == "^" {
+      e = l ^ r;
+      handled = true;
     }
-    return true;
+    return handled;
   }
 
   /*

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -128,6 +128,18 @@ module BinOp
     return res;
   }
 
+  proc isRealOp(op: string): bool {
+    return op == "+" || op == "-" || op == "*" ||
+           op == "//" || op == "%" || op == "**";
+  }
+
+  // All operations that involve one of these operations result in a `bool`
+  // symbol table entry.
+  proc isBoolOp(op: string): bool {
+    return op == "<"  || op == "<=" ||
+           op == ">"  || op == ">=" ||
+           op == "==" || op == "!=";
+  }
 
   proc doBoolBoolBitOp(
     op: string, ref e: [] bool, l: [] bool, r /*: [] bool OR bool*/
@@ -173,15 +185,6 @@ module BinOp
 
     const nie = notImplementedError(pn,l.dtype,op,r.dtype);
 
-    use Set;
-    var boolOps: set(string);
-        boolOps.add("<");
-        boolOps.add("<=");
-        boolOps.add(">");
-        boolOps.add(">=");
-        boolOps.add("==");
-        boolOps.add("!=");
-
     type castType = mySafeCast(lType, rType);
 
     // The compiler complains that maybe etype is bool if it gets down below this
@@ -192,7 +195,7 @@ module BinOp
 
     if etype == bool {
 
-      if boolOps.contains(op) {
+      if isBoolOp(op) {
 
         select op {
 
@@ -315,15 +318,6 @@ module BinOp
 
     const nie = notImplementedError(pn,"%s %s %s".format(type2str(l.a.eltType),op,type2str(val.type)));
 
-    use Set;
-    var boolOps: set(string);
-        boolOps.add("<");
-        boolOps.add("<=");
-        boolOps.add(">");
-        boolOps.add(">=");
-        boolOps.add("==");
-        boolOps.add("!=");
-
     type castType = mySafeCast(lType, rType);
 
     // The compiler complains that maybe etype is bool if it gets down below this
@@ -334,7 +328,7 @@ module BinOp
 
     if etype == bool {
 
-      if boolOps.contains(op) {
+      if isBoolOp(op) {
 
         select op {
 
@@ -449,15 +443,6 @@ module BinOp
     var e = makeDistArray((...r.tupShape), etype);
     const nie = notImplementedError(pn,"%s %s %s".format(type2str(val.type),op,type2str(r.a.eltType)));
 
-    use Set;
-    var boolOps: set(string);
-        boolOps.add("<");
-        boolOps.add("<=");
-        boolOps.add(">");
-        boolOps.add(">=");
-        boolOps.add("==");
-        boolOps.add("!=");
-
     type castType = mySafeCast(lType, rType);
 
     // The compiler complains that maybe etype is bool if it gets down below this
@@ -468,7 +453,7 @@ module BinOp
 
     if etype == bool {
 
-      if boolOps.contains(op) {
+      if isBoolOp(op) {
 
         select op {
 

--- a/src/BinOp.chpl
+++ b/src/BinOp.chpl
@@ -128,6 +128,21 @@ module BinOp
     return res;
   }
 
+
+  proc doBoolBoolBitOp(
+    op:string, ref e: [] bool, l: [] bool, r /*: [] bool OR bool*/
+  ): bool {
+    select op {
+      when "|" { e = l | r; }
+      when "&" { e = l & r; }
+      when "*" { e = l & r; }
+      when "^" { e = l ^ r; }
+      when "+" { e = l | r; }
+      otherwise do return false;
+    }
+    return true;
+  }
+
   /*
   Generic function to execute a binary operation on pdarray entries 
   in the symbol table
@@ -191,13 +206,8 @@ module BinOp
       }
 
       if lType == bool && rType == bool {
-        select op {
-          when "|" { e = l.a | r.a; }
-          when "&" { e = l.a & r.a; }
-          when "*" { e = l.a & r.a; }
-          when "^" { e = l.a ^ r.a; }
-          when "+" { e = l.a | r.a; }
-          otherwise do return MsgTuple.error(nie);
+        if !doBoolBoolBitOp(op, e, l.a, r.a) {
+          return MsgTuple.error(nie);
         }
         return st.insert(new shared SymEntry(e));
       }
@@ -338,13 +348,8 @@ module BinOp
       }
 
       if lType == bool && rType == bool {
-        select op {
-          when "|" { e = l.a | val; }
-          when "&" { e = l.a & val; }
-          when "*" { e = l.a & val; }
-          when "^" { e = l.a ^ val; }
-          when "+" { e = l.a | val; }
-          otherwise do return MsgTuple.error(nie);
+        if !doBoolBoolBitOp(op, e, l.a, val) {
+          return MsgTuple.error(nie);
         }
         return st.insert(new shared SymEntry(e));
       }
@@ -477,13 +482,8 @@ module BinOp
       }
 
       if lType == bool && rType == bool {
-        select op {
-          when "|" { e = val | r.a; }
-          when "&" { e = val & r.a; }
-          when "*" { e = val & r.a; }
-          when "^" { e = val ^ r.a; }
-          when "+" { e = val | r.a; }
-          otherwise do return MsgTuple.error(nie);
+        if !doBoolBoolBitOp(op, e, r.a, val) {
+          return MsgTuple.error(nie);
         }
         return st.insert(new shared SymEntry(e));
       }

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -64,7 +64,7 @@ module OperatorMsg
         if (binop_dtype_a == bigint || binop_dtype_b == bigint) &&
                 !isRealType(binop_dtype_a) && !isRealType(binop_dtype_b)
         {
-          if isBoolOp(op) {
+          if boolOps.contains(op) {
             // call bigint specific func which returns distr bool array
             return st.insert(new shared SymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
           }
@@ -77,7 +77,7 @@ module OperatorMsg
           return new MsgTuple(errorMsg, MsgType.ERROR);
         }
 
-        if isBoolOp(op) {
+        if boolOps.contains(op) {
           return doBinOpvv(l, r, binop_dtype_a, binop_dtype_b, bool, op, pn, st);
         }
 
@@ -93,14 +93,14 @@ module OperatorMsg
 
         type returnType = mySafeCast(binop_dtype_a, binop_dtype_b);
 
-        if (!isRealOp(op)) && (returnType == real(32) || returnType == real(64)) {
+        if (!realOps.contains(op)) && (returnType == real(32) || returnType == real(64)) {
           const errorMsg = unrecognizedTypeError(pn, "("+type2str(binop_dtype_a)+","+type2str(binop_dtype_b)+")");
           omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
           return new MsgTuple(errorMsg, MsgType.ERROR);
         }
 
         if returnType == bool {
-          if op == "+" || op == "*" || (!isRealOp(op)) {
+          if op == "+" || op == "*" || (!realOps.contains(op)) {
             return doBinOpvv(l, r, binop_dtype_a, binop_dtype_b, bool, op, pn, st);
           }
           if op == "-" {
@@ -153,7 +153,7 @@ module OperatorMsg
         if (binop_dtype_a == bigint || binop_dtype_b == bigint) &&
                 !isRealType(binop_dtype_a) && !isRealType(binop_dtype_b)
         {
-          if isBoolOp(op) {
+          if boolOps.contains(op) {
             // call bigint specific func which returns distr bool array
             return st.insert(new shared SymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
           }
@@ -166,7 +166,7 @@ module OperatorMsg
           return new MsgTuple(errorMsg, MsgType.ERROR);
         }
 
-        if isBoolOp(op) {
+        if boolOps.contains(op) {
           return doBinOpvs(l, val, binop_dtype_a, binop_dtype_b, bool, op, pn, st);
         }
 
@@ -182,14 +182,14 @@ module OperatorMsg
 
         type returnType = mySafeCast(binop_dtype_a, binop_dtype_b);
 
-        if (!isRealOp(op)) && (returnType == real(32) || returnType == real(64)) {
+        if (!realOps.contains(op)) && (returnType == real(32) || returnType == real(64)) {
           const errorMsg = unrecognizedTypeError(pn, "("+type2str(binop_dtype_a)+","+type2str(binop_dtype_b)+")");
           omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
           return new MsgTuple(errorMsg, MsgType.ERROR);
         }
 
         if returnType == bool {
-          if op == "+" || op == "*" || (!isRealOp(op)) {
+          if op == "+" || op == "*" || (!realOps.contains(op)) {
             return doBinOpvs(l, val, binop_dtype_a, binop_dtype_b, bool, op, pn, st);
           }
           if op == "-" {
@@ -241,7 +241,7 @@ module OperatorMsg
         if (binop_dtype_a == bigint || binop_dtype_b == bigint) &&
                 !isRealType(binop_dtype_a) && !isRealType(binop_dtype_b)
         {
-          if isBoolOp(op) {
+          if boolOps.contains(op) {
             // call bigint specific func which returns distr bool array
             return st.insert(new shared SymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
           }
@@ -254,7 +254,7 @@ module OperatorMsg
           return new MsgTuple(errorMsg, MsgType.ERROR);
         }
 
-        if isBoolOp(op) {
+        if boolOps.contains(op) {
           return doBinOpsv(val, r, binop_dtype_a, binop_dtype_b, bool, op, pn, st);
         }
 
@@ -270,14 +270,14 @@ module OperatorMsg
 
         type returnType = mySafeCast(binop_dtype_a, binop_dtype_b);
 
-        if (!isRealOp(op)) && (returnType == real(32) || returnType == real(64)) {
+        if (!realOps.contains(op)) && (returnType == real(32) || returnType == real(64)) {
           const errorMsg = unrecognizedTypeError(pn, "("+type2str(binop_dtype_a)+","+type2str(binop_dtype_b)+")");
           omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
           return new MsgTuple(errorMsg, MsgType.ERROR);
         }
 
         if returnType == bool {
-          if op == "+" || op == "*" || (!isRealOp(op)) {
+          if op == "+" || op == "*" || (!realOps.contains(op)) {
             return doBinOpsv(val, r, binop_dtype_a, binop_dtype_b, bool, op, pn, st);
           }
           if op == "-" {

--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -57,19 +57,6 @@ module OperatorMsg
                                           cmd,op,st.attrib(msgArgs['a'].val),
                                           st.attrib(msgArgs['b'].val)));
 
-        use Set;
-
-        // This boolOps set is a filter to determine the output type for the operation.
-        // All operations that involve one of these operations result in a `bool` symbol
-        // table entry.
-        var boolOps: set(string);
-        boolOps.add("<");
-        boolOps.add("<=");
-        boolOps.add(">");
-        boolOps.add(">=");
-        boolOps.add("==");
-        boolOps.add("!=");
-
         // This probably doesn't handle all normal bigint cases, but it handles a decent number.
         // This, at least, can be expanded when BinOp.chpl is cleaned up
         // It will be reasonably straightforward to clean up here.
@@ -77,7 +64,7 @@ module OperatorMsg
         if (binop_dtype_a == bigint || binop_dtype_b == bigint) &&
                 !isRealType(binop_dtype_a) && !isRealType(binop_dtype_b)
         {
-          if boolOps.contains(op) {
+          if isBoolOp(op) {
             // call bigint specific func which returns distr bool array
             return st.insert(new shared SymEntry(doBigIntBinOpvvBoolReturn(l, r, op)));
           }
@@ -90,7 +77,7 @@ module OperatorMsg
           return new MsgTuple(errorMsg, MsgType.ERROR);
         }
 
-        if boolOps.contains(op) {
+        if isBoolOp(op) {
           return doBinOpvv(l, r, binop_dtype_a, binop_dtype_b, bool, op, pn, st);
         }
 
@@ -104,24 +91,16 @@ module OperatorMsg
           return doBinOpvv(l, r, binop_dtype_a, binop_dtype_b, real(64), op, pn, st);
         }
 
-        var realOps: set(string);
-        realOps.add("+");
-        realOps.add("-");
-        realOps.add("*");
-        realOps.add("//");
-        realOps.add("%");
-        realOps.add("**");
-
         type returnType = mySafeCast(binop_dtype_a, binop_dtype_b);
 
-        if (!realOps.contains(op)) && (returnType == real(32) || returnType == real(64)) {
+        if (!isRealOp(op)) && (returnType == real(32) || returnType == real(64)) {
           const errorMsg = unrecognizedTypeError(pn, "("+type2str(binop_dtype_a)+","+type2str(binop_dtype_b)+")");
           omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
           return new MsgTuple(errorMsg, MsgType.ERROR);
         }
 
         if returnType == bool {
-          if op == "+" || op == "*" || (!realOps.contains(op)) {
+          if op == "+" || op == "*" || (!isRealOp(op)) {
             return doBinOpvv(l, r, binop_dtype_a, binop_dtype_b, bool, op, pn, st);
           }
           if op == "-" {
@@ -167,19 +146,6 @@ module OperatorMsg
              "cmd: %? op: %? left pdarray: %? scalar: %?".format(
                                           cmd,op,st.attrib(msgArgs['a'].val), val));
 
-        use Set;
-
-        // This boolOps set is a filter to determine the output type for the operation.
-        // All operations that involve one of these operations result in a `bool` symbol
-        // table entry.
-        var boolOps: set(string);
-        boolOps.add("<");
-        boolOps.add("<=");
-        boolOps.add(">");
-        boolOps.add(">=");
-        boolOps.add("==");
-        boolOps.add("!=");
-
         // This probably doesn't handle all normal bigint cases, but it handles a decent number.
         // This, at least, can be expanded when BinOp.chpl is cleaned up
         // It will be reasonably straightforward to clean up here.
@@ -187,7 +153,7 @@ module OperatorMsg
         if (binop_dtype_a == bigint || binop_dtype_b == bigint) &&
                 !isRealType(binop_dtype_a) && !isRealType(binop_dtype_b)
         {
-          if boolOps.contains(op) {
+          if isBoolOp(op) {
             // call bigint specific func which returns distr bool array
             return st.insert(new shared SymEntry(doBigIntBinOpvsBoolReturn(l, val, op)));
           }
@@ -200,7 +166,7 @@ module OperatorMsg
           return new MsgTuple(errorMsg, MsgType.ERROR);
         }
 
-        if boolOps.contains(op) {
+        if isBoolOp(op) {
           return doBinOpvs(l, val, binop_dtype_a, binop_dtype_b, bool, op, pn, st);
         }
 
@@ -214,24 +180,16 @@ module OperatorMsg
           return doBinOpvs(l, val, binop_dtype_a, binop_dtype_b, real(64), op, pn, st);
         }
 
-        var realOps: set(string);
-        realOps.add("+");
-        realOps.add("-");
-        realOps.add("*");
-        realOps.add("//");
-        realOps.add("%");
-        realOps.add("**");
-
         type returnType = mySafeCast(binop_dtype_a, binop_dtype_b);
 
-        if (!realOps.contains(op)) && (returnType == real(32) || returnType == real(64)) {
+        if (!isRealOp(op)) && (returnType == real(32) || returnType == real(64)) {
           const errorMsg = unrecognizedTypeError(pn, "("+type2str(binop_dtype_a)+","+type2str(binop_dtype_b)+")");
           omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
           return new MsgTuple(errorMsg, MsgType.ERROR);
         }
 
         if returnType == bool {
-          if op == "+" || op == "*" || (!realOps.contains(op)) {
+          if op == "+" || op == "*" || (!isRealOp(op)) {
             return doBinOpvs(l, val, binop_dtype_a, binop_dtype_b, bool, op, pn, st);
           }
           if op == "-" {
@@ -276,19 +234,6 @@ module OperatorMsg
                  "cmd: %? op = %? scalar dtype = %? scalar = %? pdarray = %?".format(
                                    cmd,op,type2str(binop_dtype_b),msgArgs['value'].val,st.attrib(msgArgs['a'].val)));
 
-        use Set;
-
-        // This boolOps set is a filter to determine the output type for the operation.
-        // All operations that involve one of these operations result in a `bool` symbol
-        // table entry.
-        var boolOps: set(string);
-        boolOps.add("<");
-        boolOps.add("<=");
-        boolOps.add(">");
-        boolOps.add(">=");
-        boolOps.add("==");
-        boolOps.add("!=");
-
         // This probably doesn't handle all normal bigint cases, but it handles a decent number.
         // This, at least, can be expanded when BinOp.chpl is cleaned up
         // It will be reasonably straightforward to clean up here.
@@ -296,7 +241,7 @@ module OperatorMsg
         if (binop_dtype_a == bigint || binop_dtype_b == bigint) &&
                 !isRealType(binop_dtype_a) && !isRealType(binop_dtype_b)
         {
-          if boolOps.contains(op) {
+          if isBoolOp(op) {
             // call bigint specific func which returns distr bool array
             return st.insert(new shared SymEntry(doBigIntBinOpsvBoolReturn(val, r, op)));
           }
@@ -309,7 +254,7 @@ module OperatorMsg
           return new MsgTuple(errorMsg, MsgType.ERROR);
         }
 
-        if boolOps.contains(op) {
+        if isBoolOp(op) {
           return doBinOpsv(val, r, binop_dtype_a, binop_dtype_b, bool, op, pn, st);
         }
 
@@ -323,24 +268,16 @@ module OperatorMsg
           return doBinOpsv(val, r, binop_dtype_a, binop_dtype_b, real(64), op, pn, st);
         }
 
-        var realOps: set(string);
-        realOps.add("+");
-        realOps.add("-");
-        realOps.add("*");
-        realOps.add("//");
-        realOps.add("%");
-        realOps.add("**");
-
         type returnType = mySafeCast(binop_dtype_a, binop_dtype_b);
 
-        if (!realOps.contains(op)) && (returnType == real(32) || returnType == real(64)) {
+        if (!isRealOp(op)) && (returnType == real(32) || returnType == real(64)) {
           const errorMsg = unrecognizedTypeError(pn, "("+type2str(binop_dtype_a)+","+type2str(binop_dtype_b)+")");
           omLogger.error(getModuleName(),getRoutineName(),getLineNumber(),errorMsg);
           return new MsgTuple(errorMsg, MsgType.ERROR);
         }
 
         if returnType == bool {
-          if op == "+" || op == "*" || (!realOps.contains(op)) {
+          if op == "+" || op == "*" || (!isRealOp(op)) {
             return doBinOpsv(val, r, binop_dtype_a, binop_dtype_b, bool, op, pn, st);
           }
           if op == "-" {


### PR DESCRIPTION
This PR makes a few changes to how bitwise and boolean ops are computed in the arkouda server. 

- Since the order of operands to bitwise ops does not matter, by using a helper function `doBoolBoolBitOp` and only calling it with operands in the same order (always `vector, scalar` or `vector, vector`) we can save some compilation time
- The same `Set.set` was being recreated all over the place to determine if an op was an operator. This PR refactors that set into a common place so it does not get instantiated for all the generic combinations.
- Makes a similar transformation with `Set.set` for `realOps`

I consider this a general cleanup and consolidation of logic in BinOp/OperatorMsg, it also saves a little bit of time while compiling