### PR TITLE
Set longer timeout for `test_multi_col_merge` when running with ASAN

### DIFF
--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -63,7 +63,7 @@ class TestClient:
         ak.shutdown()
         pytest.server, _, _ = start_arkouda_server(numlocales=pytest.nl, port=pytest.port)
         # reconnect to server so subsequent tests will pass
-        ak.connect(server=pytest.server, port=pytest.port, timeout=pytest.timeout)
+        ak.connect(server=pytest.server, port=pytest.port, timeout=pytest.client_timeout)
 
     def test_client_get_config(self):
         """

--- a/tests/pandas/dataframe_test.py
+++ b/tests/pandas/dataframe_test.py
@@ -1101,6 +1101,7 @@ class TestDataFrame:
         assert df["a"].tolist() == df2["a"].tolist()
         assert df["b"].tolist() == df2["b"].tolist()
 
+    @pytest.mark.timeout(9000 if pytest.asan else 1800)
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_multi_col_merge(self, size):
         size = min(size, 1000)


### PR DESCRIPTION
Sets a longer timeout for `test_multi_col_merge` when running with ASAN to ensure the test actually finishes