### PR TITLE
Closes #4743: Create a benchmark for ak.find

### DIFF
--- a/benchmark_v2/find_benchmark.py
+++ b/benchmark_v2/find_benchmark.py
@@ -1,0 +1,51 @@
+import pytest
+
+import arkouda as ak
+
+TYPES = ("int64", "uint64", "float64", "str")
+
+
+@pytest.mark.skip_numpy(True)
+@pytest.mark.benchmark(group="AK_find")
+@pytest.mark.parametrize("dtype", TYPES)
+def bench_find(benchmark, dtype):
+    """
+    Measure ak.find performance with all_occurrences=True.
+    Runs for each dtype in TYPES.
+
+    """
+    cfg = ak.get_config()
+    N = pytest.prob_size * cfg["numLocales"]
+    query_frac = 0.01  # Use 1% of the space as query set
+    qN = max(1, int(query_frac * N))
+
+    if dtype == "int64":
+        space = ak.randint(0, 2**32, N, seed=pytest.seed)
+    elif dtype == "uint64":
+        space = ak.randint(0, 2**32, N, dtype=ak.uint64, seed=pytest.seed)
+    elif dtype == "float64":
+        space = ak.randint(0, 1, N, dtype=ak.float64, seed=pytest.seed)
+    elif dtype == "str":
+        space = ak.random_strings_uniform(1, 16, N, seed=pytest.seed)
+
+    # Select query values from the space to guarantee matches
+    query = space[ak.randint(0, N, qN, seed=pytest.seed + 1)]
+
+    if dtype == "str":
+        nbytes = space.nbytes * space.entry.itemsize + query.nbytes * query.entry.itemsize
+    else:
+        nbytes = (space.size + query.size) * space.itemsize
+
+    benchmark.pedantic(
+        ak.find,
+        args=[query, space],
+        kwargs={"all_occurrences": True},
+        rounds=pytest.trials,
+    )
+
+    benchmark.extra_info["description"] = "Measures the performance of ak.find with all_occurrences=True"
+    benchmark.extra_info["problem_size"] = N
+    benchmark.extra_info["query_size"] = qN
+    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
+        (nbytes / benchmark.stats["mean"]) / 2**30
+    )


### PR DESCRIPTION
This will provide a way to test the upcoming changes to ak.find.

Modeled after the already existing benchmarks.

Closes #4743: Create a benchmark for ak.find