### PR TITLE
Closes #4606 benchmark v2/reformat benchmark results.py to parse all benchmark results

### DIFF
--- a/benchmark_v2/aggregate_benchmark.py
+++ b/benchmark_v2/aggregate_benchmark.py
@@ -65,6 +65,5 @@ def bench_aggregate(benchmark, op):
         f"Measures performance of GroupBy.aggregate using the {op} operator."
     )
     benchmark.extra_info["problem_size"] = N
-    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-        (numBytes / benchmark.stats["mean"]) / 2**30
-    )
+    #   units are GiB/sec:
+    benchmark.extra_info["transfer_rate"] = float((numBytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/argsort_benchmark.py
+++ b/benchmark_v2/argsort_benchmark.py
@@ -41,6 +41,5 @@ def bench_argsort(benchmark, dtype):
 
         benchmark.extra_info["description"] = "Measures the performance of argsort"
         benchmark.extra_info["problem_size"] = N
-        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-            (nbytes / benchmark.stats["mean"]) / 2**30
-        )
+        #   units are GiB/sec:
+        benchmark.extra_info["transfer_rate"] = float((nbytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/array_create_benchmark.py
+++ b/benchmark_v2/array_create_benchmark.py
@@ -63,6 +63,5 @@ def bench_array_create(benchmark, op, dtype):
             f"Measures performance of {'NumPy' if pytest.numpy else 'Arkouda'} array creation"
         )
         benchmark.extra_info["problem_size"] = N
-        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-            (nbytes / benchmark.stats["mean"]) / 2**30
-        )
+        #   units are GiB/sec:
+        benchmark.extra_info["transfer_rate"] = float((nbytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/array_transfer_benchmark.py
+++ b/benchmark_v2/array_transfer_benchmark.py
@@ -33,9 +33,8 @@ def bench_array_transfer_tondarray(benchmark, dtype):
 
         benchmark.extra_info["description"] = "Measures the performance of pdarray.to_ndarray"
         benchmark.extra_info["problem_size"] = N
-        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-            (numBytes / benchmark.stats["mean"]) / 2**30
-        )
+        #   units are GiB/sec:
+        benchmark.extra_info["transfer_rate"] = float((numBytes / benchmark.stats["mean"]) / 2**30)
         benchmark.extra_info["max_bit"] = pytest.max_bits
 
 
@@ -56,7 +55,6 @@ def bench_array_transfer_akarray(benchmark, dtype):
 
         benchmark.extra_info["description"] = "Measures the performance of ak.array"
         benchmark.extra_info["problem_size"] = N
-        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-            (numBytes / benchmark.stats["mean"]) / 2**30
-        )
+        #   units are GiB/sec:
+        benchmark.extra_info["transfer_rate"] = float((numBytes / benchmark.stats["mean"]) / 2**30)
         benchmark.extra_info["max_bit"] = pytest.max_bits

--- a/benchmark_v2/bigint_bitwise_binops_benchmark.py
+++ b/benchmark_v2/bigint_bitwise_binops_benchmark.py
@@ -49,7 +49,6 @@ def bench_bitwise_binops(benchmark, op):
 
     benchmark.extra_info["description"] = "Measures the performance of bigint bitwise binops"
     benchmark.extra_info["problem_size"] = N
-    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-        (result / benchmark.stats["mean"]) / 2**30
-    )
+    #   units are GiB/sec:
+    benchmark.extra_info["transfer_rate"] = float((result / benchmark.stats["mean"]) / 2**30)
     benchmark.extra_info["max_bit"] = pytest.max_bits

--- a/benchmark_v2/bigint_conversion_benchmark.py
+++ b/benchmark_v2/bigint_conversion_benchmark.py
@@ -5,7 +5,7 @@ import arkouda as ak
 
 @pytest.mark.skip_numpy(True)
 @pytest.mark.benchmark(group="BigInt_Conversion")
-@pytest.mark.parametrize("direction", ["to_bigint", "from_bigint"])
+@pytest.mark.parametrize("direction", ["bigint_from_uint_arrays", "bigint_to_uint_arrays"])
 def bench_bigint_conversion(benchmark, direction):
     N = pytest.N
     max_bits = pytest.max_bits
@@ -14,7 +14,7 @@ def bench_bigint_conversion(benchmark, direction):
     b = ak.randint(0, 2**32, N, dtype=ak.uint64, seed=pytest.seed)
     tot_bytes = N * 8 if (0 < max_bits <= 64) else N * 16
 
-    if direction == "to_bigint":
+    if direction == "bigint_from_uint_arrays":
 
         def run():
             ak.bigint_from_uint_arrays([a, b], max_bits=max_bits)
@@ -36,6 +36,5 @@ def bench_bigint_conversion(benchmark, direction):
     benchmark.extra_info["problem_size"] = N
     benchmark.extra_info["backend"] = "Arkouda"
     benchmark.extra_info["max_bits"] = max_bits
-    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-        (bytes_processed / benchmark.stats["mean"]) / 2**30
-    )
+    #   units are GiB/sec:
+    benchmark.extra_info["transfer_rate"] = float((bytes_processed / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/coargsort_benchmark.py
+++ b/benchmark_v2/coargsort_benchmark.py
@@ -45,6 +45,5 @@ def bench_coargsort(benchmark, dtype, numArrays):
 
         benchmark.extra_info["description"] = "Measures the performance of ak.coargsort"
         benchmark.extra_info["problem_size"] = N
-        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-            (nbytes / benchmark.stats["mean"]) / 2**30
-        )
+        #   units are GiB/sec:
+        benchmark.extra_info["transfer_rate"] = float((nbytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/csv_io_benchmark.py
+++ b/benchmark_v2/csv_io_benchmark.py
@@ -65,6 +65,5 @@ def bench_csv_io(benchmark, tmp_path, dtype, op):
     benchmark.extra_info["dtype"] = dtype
     benchmark.extra_info["operation"] = op
     benchmark.extra_info["backend"] = "Arkouda"
-    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-        (num_bytes / benchmark.stats["mean"]) / 2**30
-    )
+    #   units are GiB/sec:
+    benchmark.extra_info["transfer_rate"] = float((num_bytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/dataframe_indexing_benchmark.py
+++ b/benchmark_v2/dataframe_indexing_benchmark.py
@@ -71,6 +71,5 @@ def bench_dataframe(benchmark, op):
 
     benchmark.extra_info["description"] = "Measures the performance of arkouda Dataframe indexing"
     benchmark.extra_info["problem_size"] = N
-    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-        (numBytes / benchmark.stats["mean"]) / 2**30
-    )
+    #   units are GiB/sec:
+    benchmark.extra_info["transfer_rate"] = float((numBytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/datdir/configs/field_lookup_map.json
+++ b/benchmark_v2/datdir/configs/field_lookup_map.json
@@ -1,1 +1,2942 @@
-{"stream": {"Average rate =": {"group": "", "name": "bench_stream", "benchmark_name": "stream", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": "bench_stream\\[[\\w\\d]*\\]"}, "Average time =": {"group": "", "name": "bench_stream", "benchmark_name": "stream", "lookup_path": ["stats", "mean"], "lookup_regex": "bench_stream\\[[\\w\\d]*\\]"}}, "argsort": {"Average rate =": {"group": "", "name": "bench_argsort", "benchmark_name": "argsort", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": "bench_argsort\\[[\\w\\d]*\\]"}, "Average time =": {"group": "", "name": "bench_argsort", "benchmark_name": "argsort", "lookup_path": ["stats", "mean"], "lookup_regex": "bench_argsort\\[[\\w\\d]*\\]"}}, "coargsort": {"Average rate =": {"group": "", "name": "bench_coargsort", "benchmark_name": "coargsort", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": "bench_coargsort\\[[\\w\\d]*\\]"}, "Average time =": {"group": "", "name": "bench_coargsort", "benchmark_name": "coargsort", "lookup_path": ["stats", "mean"], "lookup_regex": "bench_coargsort\\[[\\w\\d]*\\]"}, "1-array Average rate =": {"group": "Arkouda_CoArgSort", "name": "", "benchmark_name": "coargsort", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": "bench_coargsort\\[[\\w\\d]*-1\\]"}, "1-array Average time =": {"group": "Arkouda_CoArgSort", "name": "", "benchmark_name": "coargsort", "lookup_path": ["stats", "mean"], "lookup_regex": "bench_coargsort\\[[\\w\\d]*-1\\]"}, "2-array Average rate =": {"group": "Arkouda_CoArgSort", "name": "", "benchmark_name": "coargsort", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": "bench_coargsort\\[[\\w\\d]*-2\\]"}, "2-array Average time =": {"group": "Arkouda_CoArgSort", "name": "", "benchmark_name": "coargsort", "lookup_path": ["stats", "mean"], "lookup_regex": "bench_coargsort\\[[\\w\\d]*-2\\]"}, "8-array Average rate =": {"group": "Arkouda_CoArgSort", "name": "", "benchmark_name": "coargsort", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": "bench_coargsort\\[[\\w\\d]*-8\\]"}, "8-array Average time =": {"group": "Arkouda_CoArgSort", "name": "", "benchmark_name": "coargsort", "lookup_path": ["stats", "mean"], "lookup_regex": "bench_coargsort\\[[\\w\\d]*-8\\]"}, "16-array Average rate =": {"group": "Arkouda_CoArgSort", "name": "", "benchmark_name": "coargsort", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": "bench_coargsort\\[[\\w\\d]*-16\\]"}, "16-array Average time =": {"group": "Arkouda_CoArgSort", "name": "", "benchmark_name": "coargsort", "lookup_path": ["stats", "mean"], "lookup_regex": "bench_coargsort\\[[\\w\\d]*-16\\]"}}, "aggregate": {"Average rate =": {"group": "", "name": "bench_aggregate", "benchmark_name": "aggregate", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": "bench_aggregate\\[[\\w\\d]*\\]"}, "Average time =": {"group": "", "name": "bench_aggregate", "benchmark_name": "aggregate", "lookup_path": ["stats", "mean"], "lookup_regex": "bench_aggregate\\[[\\w\\d]*\\]"}, "Aggregate prod Average rate =": {"group": "GroupBy.aggregate", "name": "bench_aggregate[prod]", "benchmark_name": "aggregate", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": ""}, "Aggregate prod Average time =": {"group": "GroupBy.aggregate", "name": "bench_aggregate[prod]", "benchmark_name": "aggregate", "lookup_path": ["stats", "mean"], "lookup_regex": ""}, "Aggregate sum Average rate =": {"group": "GroupBy.aggregate", "name": "bench_aggregate[sum]", "benchmark_name": "aggregate", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": ""}, "Aggregate sum Average time =": {"group": "GroupBy.aggregate", "name": "bench_aggregate[sum]", "benchmark_name": "aggregate", "lookup_path": ["stats", "mean"], "lookup_regex": ""}, "Aggregate mean Average rate =": {"group": "GroupBy.aggregate", "name": "bench_aggregate[mean]", "benchmark_name": "aggregate", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": ""}, "Aggregate mean Average time =": {"group": "GroupBy.aggregate", "name": "bench_aggregate[mean]", "benchmark_name": "aggregate", "lookup_path": ["stats", "mean"], "lookup_regex": ""}, "Aggregate min Average rate =": {"group": "GroupBy.aggregate", "name": "bench_aggregate[min]", "benchmark_name": "aggregate", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": ""}, "Aggregate min Average time =": {"group": "GroupBy.aggregate", "name": "bench_aggregate[min]", "benchmark_name": "aggregate", "lookup_path": ["stats", "mean"], "lookup_regex": ""}, "Aggregate max Average rate =": {"group": "GroupBy.aggregate", "name": "bench_aggregate[max]", "benchmark_name": "aggregate", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": ""}, "Aggregate max Average time =": {"group": "GroupBy.aggregate", "name": "bench_aggregate[max]", "benchmark_name": "aggregate", "lookup_path": ["stats", "mean"], "lookup_regex": ""}, "Aggregate argmin Average rate =": {"group": "GroupBy.aggregate", "name": "bench_aggregate[argmin]", "benchmark_name": "aggregate", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": ""}, "Aggregate argmin Average time =": {"group": "GroupBy.aggregate", "name": "bench_aggregate[argmin]", "benchmark_name": "aggregate", "lookup_path": ["stats", "mean"], "lookup_regex": ""}, "Aggregate argmax Average rate =": {"group": "GroupBy.aggregate", "name": "bench_aggregate[argmax]", "benchmark_name": "aggregate", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": ""}, "Aggregate argmax Average time =": {"group": "GroupBy.aggregate", "name": "bench_aggregate[argmax]", "benchmark_name": "aggregate", "lookup_path": ["stats", "mean"], "lookup_regex": ""}, "Aggregate any Average rate =": {"group": "GroupBy.aggregate", "name": "bench_aggregate[any]", "benchmark_name": "aggregate", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": ""}, "Aggregate any Average time =": {"group": "GroupBy.aggregate", "name": "bench_aggregate[any]", "benchmark_name": "aggregate", "lookup_path": ["stats", "mean"], "lookup_regex": ""}, "Aggregate all Average rate =": {"group": "GroupBy.aggregate", "name": "bench_aggregate[all]", "benchmark_name": "aggregate", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": ""}, "Aggregate all Average time =": {"group": "GroupBy.aggregate", "name": "bench_aggregate[all]", "benchmark_name": "aggregate", "lookup_path": ["stats", "mean"], "lookup_regex": ""}, "Aggregate xor Average rate =": {"group": "GroupBy.aggregate", "name": "bench_aggregate[xor]", "benchmark_name": "aggregate", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": ""}, "Aggregate xor Average time =": {"group": "GroupBy.aggregate", "name": "bench_aggregate[xor]", "benchmark_name": "aggregate", "lookup_path": ["stats", "mean"], "lookup_regex": ""}, "Aggregate and Average rate =": {"group": "GroupBy.aggregate", "name": "bench_aggregate[and]", "benchmark_name": "aggregate", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": ""}, "Aggregate and Average time =": {"group": "GroupBy.aggregate", "name": "bench_aggregate[and]", "benchmark_name": "aggregate", "lookup_path": ["stats", "mean"], "lookup_regex": ""}, "Aggregate or Average rate =": {"group": "GroupBy.aggregate", "name": "bench_aggregate[or]", "benchmark_name": "aggregate", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": ""}, "Aggregate or Average time =": {"group": "GroupBy.aggregate", "name": "bench_aggregate[or]", "benchmark_name": "aggregate", "lookup_path": ["stats", "mean"], "lookup_regex": ""}, "Aggregate nunique Average rate =": {"group": "GroupBy.aggregate", "name": "bench_aggregate[nunique]", "benchmark_name": "aggregate", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": ""}, "Aggregate nunique Average time =": {"group": "GroupBy.aggregate", "name": "bench_aggregate[nunique]", "benchmark_name": "aggregate", "lookup_path": ["stats", "mean"], "lookup_regex": ""}}, "gather": {"Average rate =": {"group": "", "name": "bench_gather", "benchmark_name": "gather", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": "bench_gather\\[[\\w\\d]*\\]"}, "Average time =": {"group": "", "name": "bench_gather", "benchmark_name": "gather", "lookup_path": ["stats", "mean"], "lookup_regex": "bench_gather\\[[\\w\\d]*\\]"}}, "scatter": {"Average rate =": {"group": "", "name": "bench_scatter", "benchmark_name": "scatter", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": "bench_scatter\\[[\\w\\d]*\\]"}, "Average time =": {"group": "", "name": "bench_scatter", "benchmark_name": "scatter", "lookup_path": ["stats", "mean"], "lookup_regex": "bench_scatter\\[[\\w\\d]*\\]"}}, "dataframe": {"Average rate =": {"group": "", "name": "bench_dataframe", "benchmark_name": "dataframe", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": "bench_dataframe\\[[\\w\\d]*\\]"}, "Average time =": {"group": "", "name": "bench_dataframe", "benchmark_name": "dataframe", "lookup_path": ["stats", "mean"], "lookup_regex": "bench_dataframe\\[[\\w\\d]*\\]"}, "_get_head_tail_server Average time =": {"group": "Dataframe_Indexing", "name": "bench_dataframe[_get_head_tail_server]", "benchmark_name": "dataframe", "lookup_path": ["stats", "mean"], "lookup_regex": ""}, "_get_head_tail_server Average rate =": {"group": "Dataframe_Indexing", "name": "bench_dataframe[_get_head_tail_server]", "benchmark_name": "dataframe", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": ""}, "_get_head_tail Average time =": {"group": "Dataframe_Indexing", "name": "bench_dataframe[_get_head_tail]", "benchmark_name": "dataframe", "lookup_path": ["stats", "mean"], "lookup_regex": ""}, "_get_head_tail Average rate =": {"group": "Dataframe_Indexing", "name": "bench_dataframe[_get_head_tail]", "benchmark_name": "dataframe", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": ""}}, "bigint_stream": {"Average rate =": {"group": "", "name": "bench_bigint_stream", "benchmark_name": "bigint_stream", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": "bench_bigint_stream\\[[\\w\\d]*\\]"}, "Average time =": {"group": "", "name": "bench_bigint_stream", "benchmark_name": "bigint_stream", "lookup_path": ["stats", "mean"], "lookup_regex": "bench_bigint_stream\\[[\\w\\d]*\\]"}, "Average bigint stream time =": {"group": "", "name": "bench_bigint_stream", "benchmark_name": "bigint_stream", "lookup_path": ["stats", "mean"], "lookup_regex": "bench_bigint_stream\\[[\\w\\d]*\\]"}, "Average bigint stream rate =": {"group": "", "name": "bench_bigint_stream", "benchmark_name": "bigint_stream", "lookup_path": ["extra_info", "transfer_rate"], "lookup_regex": "bench_bigint_stream\\[[\\w\\d]*\\]"}}}
+{
+  "scan": {
+    "cumsum Average time =": {
+      "name": "",
+      "benchmark_name": "scan",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_scan\\[(?:int64|float64|bool|uint64)-cumsum\\]"
+    },
+    "cumsum Average rate =": {
+      "name": "",
+      "benchmark_name": "scan",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_scan\\[(?:int64|float64|bool|uint64)-cumsum\\]"
+    },
+    "cumprod Average time =": {
+      "name": "",
+      "benchmark_name": "scan",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_scan\\[(?:int64|float64|bool|uint64)-cumprod\\]"
+    },
+    "cumprod Average rate =": {
+      "name": "",
+      "benchmark_name": "scan",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_scan\\[(?:int64|float64|bool|uint64)-cumprod\\]"
+    }
+  },
+  "sort-cases": {
+    "uniform int64 16-bit RadixSortLSD average time =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_random_uniform\\[16-bit-(?:int64|float64|bool|uint64|str)-SortingAlgorithm.RadixSortLSD\\]"
+    },
+    "uniform int64 16-bit RadixSortLSD average rate =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_random_uniform\\[16-bit-(?:int64|float64|bool|uint64|str)-SortingAlgorithm.RadixSortLSD\\]"
+    },
+    "uniform int64 16-bit TwoArrayRadixSort average time =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_random_uniform\\[16-bit-(?:int64|float64|bool|uint64|str)-SortingAlgorithm.TwoArrayRadixSort\\]"
+    },
+    "uniform int64 16-bit TwoArrayRadixSort average rate =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_random_uniform\\[16-bit-(?:int64|float64|bool|uint64|str)-SortingAlgorithm.TwoArrayRadixSort\\]"
+    },
+    "uniform int64 32-bit RadixSortLSD average time =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_random_uniform\\[32-bit-(?:int64|float64|bool|uint64|str)-SortingAlgorithm.RadixSortLSD\\]"
+    },
+    "uniform int64 32-bit RadixSortLSD average rate =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_random_uniform\\[32-bit-(?:int64|float64|bool|uint64|str)-SortingAlgorithm.RadixSortLSD\\]"
+    },
+    "uniform int64 32-bit TwoArrayRadixSort average time =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_random_uniform\\[32-bit-(?:int64|float64|bool|uint64|str)-SortingAlgorithm.TwoArrayRadixSort\\]"
+    },
+    "uniform int64 32-bit TwoArrayRadixSort average rate =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_random_uniform\\[32-bit-(?:int64|float64|bool|uint64|str)-SortingAlgorithm.TwoArrayRadixSort\\]"
+    },
+    "uniform int64 64-bit RadixSortLSD average time =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_random_uniform\\[64-bit-(?:int64|float64|bool|uint64|str)-SortingAlgorithm.RadixSortLSD\\]"
+    },
+    "uniform int64 64-bit RadixSortLSD average rate =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_random_uniform\\[64-bit-(?:int64|float64|bool|uint64|str)-SortingAlgorithm.RadixSortLSD\\]"
+    },
+    "uniform int64 64-bit TwoArrayRadixSort average time =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_random_uniform\\[64-bit-(?:int64|float64|bool|uint64|str)-SortingAlgorithm.TwoArrayRadixSort\\]"
+    },
+    "uniform int64 64-bit TwoArrayRadixSort average rate =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_random_uniform\\[64-bit-(?:int64|float64|bool|uint64|str)-SortingAlgorithm.TwoArrayRadixSort\\]"
+    },
+    "uniform float64 RadixSortLSD average time =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_random_uniform\\[64-bit-float64-SortingAlgorithm.RadixSortLSD\\]"
+    },
+    "uniform float64 RadixSortLSD average rate =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_random_uniform\\[64-bit-float64-SortingAlgorithm.RadixSortLSD\\]"
+    },
+    "uniform float64 TwoArrayRadixSort average time =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_random_uniform\\[64-bit-float64-SortingAlgorithm.TwoArrayRadixSort\\]"
+    },
+    "uniform float64 TwoArrayRadixSort average rate =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_random_uniform\\[64-bit-float64-SortingAlgorithm.TwoArrayRadixSort\\]"
+    },
+    "power-law float64 RadixSortLSD average time =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_power_law\\[(?:int64|float64|bool|uint64|str)-SortingAlgorithm.RadixSortLSD\\]"
+    },
+    "power-law float64 RadixSortLSD average rate =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_power_law\\[(?:int64|float64|bool|uint64|str)-SortingAlgorithm.RadixSortLSD\\]"
+    },
+    "power-law float64 TwoArrayRadixSort average time =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_power_law\\[(?:int64|float64|bool|uint64|str)-SortingAlgorithm.TwoArrayRadixSort\\]"
+    },
+    "power-law float64 TwoArrayRadixSort average rate =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_power_law\\[(?:int64|float64|bool|uint64|str)-SortingAlgorithm.TwoArrayRadixSort\\]"
+    },
+    "power-law int64 RadixSortLSD average time =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_power_law\\[(?:int64|float64|bool|uint64|str)-SortingAlgorithm.RadixSortLSD\\]"
+    },
+    "power-law int64 RadixSortLSD average rate =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_power_law\\[(?:int64|float64|bool|uint64|str)-SortingAlgorithm.RadixSortLSD\\]"
+    },
+    "power-law int64 TwoArrayRadixSort average time =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_power_law\\[(?:int64|float64|bool|uint64|str)-SortingAlgorithm.TwoArrayRadixSort\\]"
+    },
+    "power-law int64 TwoArrayRadixSort average rate =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_power_law\\[(?:int64|float64|bool|uint64|str)-SortingAlgorithm.TwoArrayRadixSort\\]"
+    },
+    "RMAT int64 RadixSortLSD average time =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_rmat\\[SortingAlgorithm.RadixSortLSD\\]"
+    },
+    "RMAT int64 RadixSortLSD average rate =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_rmat\\[SortingAlgorithm.RadixSortLSD\\]"
+    },
+    "RMAT int64 TwoArrayRadixSort average time =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_rmat\\[SortingAlgorithm.TwoArrayRadixSort\\]"
+    },
+    "RMAT int64 TwoArrayRadixSort average rate =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_rmat\\[SortingAlgorithm.TwoArrayRadixSort\\]"
+    },
+    "block-sorted concat int64 RadixSortLSD average time =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_block_sorted\\[concat-SortingAlgorithm.RadixSortLSD\\]"
+    },
+    "block-sorted concat int64 RadixSortLSD average rate =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_block_sorted\\[concat-SortingAlgorithm.RadixSortLSD\\]"
+    },
+    "block-sorted concat int64 TwoArrayRadixSort average time =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_block_sorted\\[concat-SortingAlgorithm.TwoArrayRadixSort\\]"
+    },
+    "block-sorted concat int64 TwoArrayRadixSort average rate =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_block_sorted\\[concat-SortingAlgorithm.TwoArrayRadixSort\\]"
+    },
+    "block-sorted interleaved int64 RadixSortLSD average time =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_block_sorted\\[interleaved-SortingAlgorithm.RadixSortLSD\\]"
+    },
+    "block-sorted interleaved int64 RadixSortLSD average rate =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_block_sorted\\[interleaved-SortingAlgorithm.RadixSortLSD\\]"
+    },
+    "block-sorted interleaved int64 TwoArrayRadixSort average time =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_block_sorted\\[interleaved-SortingAlgorithm.TwoArrayRadixSort\\]"
+    },
+    "block-sorted interleaved int64 TwoArrayRadixSort average rate =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_block_sorted\\[interleaved-SortingAlgorithm.TwoArrayRadixSort\\]"
+    },
+    "refinement int64 RadixSortLSD average time =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_refinement\\[SortingAlgorithm.RadixSortLSD\\]"
+    },
+    "refinement int64 RadixSortLSD average rate =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_refinement\\[SortingAlgorithm.RadixSortLSD\\]"
+    },
+    "refinement int64 TwoArrayRadixSort average time =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_refinement\\[SortingAlgorithm.TwoArrayRadixSort\\]"
+    },
+    "refinement int64 TwoArrayRadixSort average rate =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_refinement\\[SortingAlgorithm.TwoArrayRadixSort\\]"
+    },
+    "datetime64[ns] RadixSortLSD average time =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_time_like\\[SortingAlgorithm.RadixSortLSD\\]"
+    },
+    "datetime64[ns] RadixSortLSD average rate =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_time_like\\[SortingAlgorithm.RadixSortLSD\\]"
+    },
+    "datetime64[ns] TwoArrayRadixSort average time =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_time_like\\[SortingAlgorithm.TwoArrayRadixSort\\]"
+    },
+    "datetime64[ns] TwoArrayRadixSort average rate =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_time_like\\[SortingAlgorithm.TwoArrayRadixSort\\]"
+    },
+    "IP-like 2*int64 RadixSortLSD average time =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_ip_like\\[SortingAlgorithm.RadixSortLSD\\]"
+    },
+    "IP-like 2*int64 RadixSortLSD average rate =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_ip_like\\[SortingAlgorithm.RadixSortLSD\\]"
+    },
+    "IP-like 2*int64 TwoArrayRadixSort average time =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_ip_like\\[SortingAlgorithm.TwoArrayRadixSort\\]"
+    },
+    "IP-like 2*int64 TwoArrayRadixSort average rate =": {
+      "name": "",
+      "benchmark_name": "sort_cases",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_ip_like\\[SortingAlgorithm.TwoArrayRadixSort\\]"
+    }
+  },
+  "small-str-groupby": {
+    "small str array Average time =": {
+      "name": "",
+      "benchmark_name": "small_groupby",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_groupby_small_str\\[small\\]"
+    },
+    "small str array Average rate =": {
+      "name": "",
+      "benchmark_name": "small_groupby",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_groupby_small_str\\[small\\]"
+    },
+    "medium str array Average time =": {
+      "name": "",
+      "benchmark_name": "small_groupby",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_groupby_small_str\\[medium\\]"
+    },
+    "medium str array Average rate =": {
+      "name": "",
+      "benchmark_name": "small_groupby",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_groupby_small_str\\[medium\\]"
+    },
+    "big str array Average time =": {
+      "name": "",
+      "benchmark_name": "small_groupby",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_groupby_small_str\\[big\\]"
+    },
+    "big str array Average rate =": {
+      "name": "",
+      "benchmark_name": "small_groupby",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_groupby_small_str\\[big\\]"
+    }
+  },
+  "bigint_stream": {
+    "Average bigint stream time =": {
+      "name": "",
+      "benchmark_name": "bigint_stream",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_bigint_stream\\[bigint\\]"
+    },
+    "Average bigint stream rate =": {
+      "name": "",
+      "benchmark_name": "bigint_stream",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_bigint_stream\\[bigint\\]"
+    }
+  },
+  "comp-time": {
+    "total time :": {
+      "name": "",
+      "benchmark_name": "comp_time",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": null
+    }
+  },
+  "array_create": {
+    "zeros Average time =": {
+      "name": "",
+      "benchmark_name": "array_create",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_array_create\\[(?:int64|float64|bool|uint64)-zeros\\]"
+    },
+    "zeros Average rate =": {
+      "name": "",
+      "benchmark_name": "array_create",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_array_create\\[(?:int64|float64|bool|uint64)-zeros\\]"
+    },
+    "ones Average time =": {
+      "name": "",
+      "benchmark_name": "array_create",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_array_create\\[(?:int64|float64|bool|uint64)-ones\\]"
+    },
+    "ones Average rate =": {
+      "name": "",
+      "benchmark_name": "array_create",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_array_create\\[(?:int64|float64|bool|uint64)-ones\\]"
+    },
+    "randint Average time =": {
+      "name": "",
+      "benchmark_name": "array_create",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_array_create\\[(?:int64|float64|bool|uint64)-randint\\]"
+    },
+    "randint Average rate =": {
+      "name": "",
+      "benchmark_name": "array_create",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_array_create\\[(?:int64|float64|bool|uint64)-randint\\]"
+    }
+  },
+  "IO": {
+    "write Average time HDF5 =": {
+      "name": "",
+      "benchmark_name": "IO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_write_hdf\\[(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "write Average rate HDF5 =": {
+      "name": "",
+      "benchmark_name": "IO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_write_hdf\\[(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average time HDF5 =": {
+      "name": "",
+      "benchmark_name": "IO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_read_hdf\\[(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average rate HDF5 =": {
+      "name": "",
+      "benchmark_name": "IO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_read_hdf\\[(?:int64|float64|bool|uint64|str)\\]"
+    }
+  },
+  "parquetMultiIO": {
+    "write Average time none =": {
+      "name": "",
+      "benchmark_name": "parquetMultiIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_write_parquet_multi\\[None-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "write Average rate none =": {
+      "name": "",
+      "benchmark_name": "parquetMultiIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_write_parquet_multi\\[None-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "write Average time snappy =": {
+      "name": "",
+      "benchmark_name": "parquetMultiIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_write_parquet_multi\\[snappy-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "write Average rate snappy =": {
+      "name": "",
+      "benchmark_name": "parquetMultiIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_write_parquet_multi\\[snappy-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "write Average time gzip =": {
+      "name": "",
+      "benchmark_name": "parquetMultiIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_write_parquet_multi\\[gzip-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "write Average rate gzip =": {
+      "name": "",
+      "benchmark_name": "parquetMultiIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_write_parquet_multi\\[gzip-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "write Average time brotli =": {
+      "name": "",
+      "benchmark_name": "parquetMultiIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_write_parquet_multi\\[brotli-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "write Average rate brotli =": {
+      "name": "",
+      "benchmark_name": "parquetMultiIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_write_parquet_multi\\[brotli-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "write Average time zstd =": {
+      "name": "",
+      "benchmark_name": "parquetMultiIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_write_parquet_multi\\[zstd-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "write Average rate zstd =": {
+      "name": "",
+      "benchmark_name": "parquetMultiIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_write_parquet_multi\\[zstd-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "write Average time lz4 =": {
+      "name": "",
+      "benchmark_name": "parquetMultiIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_write_parquet_multi\\[lz4-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "write Average rate lz4 =": {
+      "name": "",
+      "benchmark_name": "parquetMultiIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_write_parquet_multi\\[lz4-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average time none =": {
+      "name": "",
+      "benchmark_name": "parquetMultiIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_read_parquet_multi\\[None-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average rate none =": {
+      "name": "",
+      "benchmark_name": "parquetMultiIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_read_parquet_multi\\[None-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average time snappy =": {
+      "name": "",
+      "benchmark_name": "parquetMultiIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_read_parquet_multi\\[snappy-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average rate snappy =": {
+      "name": "",
+      "benchmark_name": "parquetMultiIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_read_parquet_multi\\[snappy-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average time gzip =": {
+      "name": "",
+      "benchmark_name": "parquetMultiIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_read_parquet_multi\\[gzip-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average rate gzip =": {
+      "name": "",
+      "benchmark_name": "parquetMultiIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_read_parquet_multi\\[gzip-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average time brotli =": {
+      "name": "",
+      "benchmark_name": "parquetMultiIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_read_parquet_multi\\[brotli-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average rate brotli =": {
+      "name": "",
+      "benchmark_name": "parquetMultiIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_read_parquet_multi\\[brotli-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average time zstd =": {
+      "name": "",
+      "benchmark_name": "parquetMultiIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_read_parquet_multi\\[zstd-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average rate zstd =": {
+      "name": "",
+      "benchmark_name": "parquetMultiIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_read_parquet_multi\\[zstd-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average time lz4 =": {
+      "name": "",
+      "benchmark_name": "parquetMultiIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_read_parquet_multi\\[lz4-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average rate lz4 =": {
+      "name": "",
+      "benchmark_name": "parquetMultiIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_read_parquet_multi\\[lz4-(?:int64|float64|bool|uint64|str)\\]"
+    }
+  },
+  "bigint_conversion": {
+    "bigint_from_uint_arrays Average time =": {
+      "name": "",
+      "benchmark_name": "bigint_conversion",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_bigint_conversion\\[bigint_from_uint_arrays\\]"
+    },
+    "bigint_from_uint_arrays Average rate =": {
+      "name": "",
+      "benchmark_name": "bigint_conversion",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_bigint_conversion\\[bigint_from_uint_arrays\\]"
+    },
+    "bigint_to_uint_arrays Average time =": {
+      "name": "",
+      "benchmark_name": "bigint_conversion",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_bigint_conversion\\[bigint_to_uint_arrays\\]"
+    },
+    "bigint_to_uint_arrays Average rate =": {
+      "name": "",
+      "benchmark_name": "bigint_conversion",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_bigint_conversion\\[bigint_to_uint_arrays\\]"
+    }
+  },
+  "multiIO": {
+    "write Average time HDF5 =": {
+      "name": "",
+      "benchmark_name": "multiIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": null
+    },
+    "write Average rate HDF5 =": {
+      "name": "",
+      "benchmark_name": "multiIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": null
+    },
+    "read Average time HDF5 =": {
+      "name": "",
+      "benchmark_name": "multiIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": null
+    },
+    "read Average rate HDF5 =": {
+      "name": "",
+      "benchmark_name": "multiIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": null
+    }
+  },
+  "encode": {
+    "Average idna encode time =": {
+      "name": "",
+      "benchmark_name": "encode",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_encode\\[idna\\]"
+    },
+    "Average idna encode rate =": {
+      "name": "",
+      "benchmark_name": "encode",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_encode\\[idna\\]"
+    },
+    "Average ascii encode time =": {
+      "name": "",
+      "benchmark_name": "encode",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_encode\\[ascii\\]"
+    },
+    "Average ascii encode rate =": {
+      "name": "",
+      "benchmark_name": "encode",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_encode\\[ascii\\]"
+    },
+    "Average idna decode time =": {
+      "name": "",
+      "benchmark_name": "encode",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_decode\\[idna\\]"
+    },
+    "Average idna decode rate =": {
+      "name": "",
+      "benchmark_name": "encode",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_decode\\[idna\\]"
+    },
+    "Average ascii decode time =": {
+      "name": "",
+      "benchmark_name": "encode",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_decode\\[ascii\\]"
+    },
+    "Average ascii decode rate =": {
+      "name": "",
+      "benchmark_name": "encode",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_decode\\[ascii\\]"
+    }
+  },
+  "reduce": {
+    "sum Average time =": {
+      "name": "",
+      "benchmark_name": "reduce",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_reduce\\[(?:int64|float64|bool|uint64)-sum\\]"
+    },
+    "sum Average rate =": {
+      "name": "",
+      "benchmark_name": "reduce",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_reduce\\[(?:int64|float64|bool|uint64)-sum\\]"
+    },
+    "prod Average time =": {
+      "name": "",
+      "benchmark_name": "reduce",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_reduce\\[(?:int64|float64|bool|uint64)-prod\\]"
+    },
+    "prod Average rate =": {
+      "name": "",
+      "benchmark_name": "reduce",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_reduce\\[(?:int64|float64|bool|uint64)-prod\\]"
+    },
+    "min Average time =": {
+      "name": "",
+      "benchmark_name": "reduce",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_reduce\\[(?:int64|float64|bool|uint64)-min\\]"
+    },
+    "min Average rate =": {
+      "name": "",
+      "benchmark_name": "reduce",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_reduce\\[(?:int64|float64|bool|uint64)-min\\]"
+    },
+    "max Average time =": {
+      "name": "",
+      "benchmark_name": "reduce",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_reduce\\[(?:int64|float64|bool|uint64)-max\\]"
+    },
+    "max Average rate =": {
+      "name": "",
+      "benchmark_name": "reduce",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_reduce\\[(?:int64|float64|bool|uint64)-max\\]"
+    },
+    "Reduce sum Average time =": {
+      "name": "bench_reduce[sum]",
+      "benchmark_name": "reduce",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_reduce\\[[\\w\\d]+-sum\\]"
+    },
+    "Reduce sum Average rate =": {
+      "name": "bench_reduce[sum]",
+      "benchmark_name": "reduce",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_reduce\\[[\\w\\d]+-sum\\]"
+    },
+    "Reduce prod Average time =": {
+      "name": "bench_reduce[prod]",
+      "benchmark_name": "reduce",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_reduce\\[[\\w\\d]+-prod\\]"
+    },
+    "Reduce prod Average rate =": {
+      "name": "bench_reduce[prod]",
+      "benchmark_name": "reduce",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_reduce\\[[\\w\\d]+-prod\\]"
+    },
+    "Reduce min Average time =": {
+      "name": "bench_reduce[min]",
+      "benchmark_name": "reduce",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_reduce\\[[\\w\\d]+-min\\]"
+    },
+    "Reduce min Average rate =": {
+      "name": "bench_reduce[min]",
+      "benchmark_name": "reduce",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_reduce\\[[\\w\\d]+-min\\]"
+    },
+    "Reduce max Average time =": {
+      "name": "bench_reduce[max]",
+      "benchmark_name": "reduce",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_reduce\\[[\\w\\d]+-max\\]"
+    },
+    "Reduce max Average rate =": {
+      "name": "bench_reduce[max]",
+      "benchmark_name": "reduce",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_reduce\\[[\\w\\d]+-max\\]"
+    },
+    "Reduce argmin Average time =": {
+      "name": "bench_reduce[argmin]",
+      "benchmark_name": "reduce",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_reduce\\[[\\w\\d]+-argmin\\]"
+    },
+    "Reduce argmin Average rate =": {
+      "name": "bench_reduce[argmin]",
+      "benchmark_name": "reduce",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_reduce\\[[\\w\\d]+-argmin\\]"
+    },
+    "Reduce argmax Average time =": {
+      "name": "bench_reduce[argmax]",
+      "benchmark_name": "reduce",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_reduce\\[[\\w\\d]+-argmax\\]"
+    },
+    "Reduce argmax Average rate =": {
+      "name": "bench_reduce[argmax]",
+      "benchmark_name": "reduce",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_reduce\\[[\\w\\d]+-argmax\\]"
+    }
+  },
+  "bigint_bitwise_binops": {
+    "Average bigint AND time =": {
+      "name": "",
+      "benchmark_name": "bigint_bitwise_binops",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_bitwise_binops\\[and\\]"
+    },
+    "Average bigint AND rate =": {
+      "name": "",
+      "benchmark_name": "bigint_bitwise_binops",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_bitwise_binops\\[and\\]"
+    },
+    "Average bigint OR time =": {
+      "name": "",
+      "benchmark_name": "bigint_bitwise_binops",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_bitwise_binops\\[or\\]"
+    },
+    "Average bigint OR rate =": {
+      "name": "",
+      "benchmark_name": "bigint_bitwise_binops",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_bitwise_binops\\[or\\]"
+    },
+    "Average bigint SHIFT time =": {
+      "name": "",
+      "benchmark_name": "bigint_bitwise_binops",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_bitwise_binops\\[shift\\]"
+    },
+    "Average bigint SHIFT rate =": {
+      "name": "",
+      "benchmark_name": "bigint_bitwise_binops",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_bitwise_binops\\[shift\\]"
+    }
+  },
+  "in1d": {
+    "Medium average time =": {
+      "name": "",
+      "benchmark_name": "in1d",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_in1d\\[MEDIUM-(?:int64|float64|bool|uint64)\\]"
+    },
+    "Medium average rate =": {
+      "name": "",
+      "benchmark_name": "in1d",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_in1d\\[MEDIUM-(?:int64|float64|bool|uint64)\\]"
+    },
+    "Large average time =": {
+      "name": "",
+      "benchmark_name": "in1d",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_in1d\\[LARGE-(?:int64|float64|bool|uint64)\\]"
+    },
+    "Large average rate =": {
+      "name": "",
+      "benchmark_name": "in1d",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_in1d\\[LARGE-(?:int64|float64|bool|uint64)\\]"
+    }
+  },
+  "groupby": {
+    "1-array Average time =": {
+      "name": "",
+      "benchmark_name": "groupby",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_groupby\\[(?:int64|float64|bool|uint64)-1\\]"
+    },
+    "1-array Average rate =": {
+      "name": "",
+      "benchmark_name": "groupby",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_groupby\\[(?:int64|float64|bool|uint64)-1\\]"
+    },
+    "2-array Average time =": {
+      "name": "",
+      "benchmark_name": "groupby",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_groupby\\[(?:int64|float64|bool|uint64)-2\\]"
+    },
+    "2-array Average rate =": {
+      "name": "",
+      "benchmark_name": "groupby",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_groupby\\[(?:int64|float64|bool|uint64)-2\\]"
+    },
+    "8-array Average time =": {
+      "name": "",
+      "benchmark_name": "groupby",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_groupby\\[(?:int64|float64|bool|uint64)-8\\]"
+    },
+    "8-array Average rate =": {
+      "name": "",
+      "benchmark_name": "groupby",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_groupby\\[(?:int64|float64|bool|uint64)-8\\]"
+    },
+    "16-array Average time =": {
+      "name": "",
+      "benchmark_name": "groupby",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_groupby\\[(?:int64|float64|bool|uint64)-16\\]"
+    },
+    "16-array Average rate =": {
+      "name": "",
+      "benchmark_name": "groupby",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_groupby\\[(?:int64|float64|bool|uint64)-16\\]"
+    }
+  },
+  "array_transfer": {
+    "to_ndarray Average time =": {
+      "name": "",
+      "benchmark_name": "array_transfer",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": null
+    },
+    "to_ndarray Average rate =": {
+      "name": "",
+      "benchmark_name": "array_transfer",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": null
+    },
+    "ak.array Average time =": {
+      "name": "",
+      "benchmark_name": "array_transfer",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": null
+    },
+    "ak.array Average rate =": {
+      "name": "",
+      "benchmark_name": "array_transfer",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": null
+    }
+  },
+  "aggregate": {
+    "Aggregate sum Average rate =": {
+      "name": "bench_aggregate[sum]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "^bench_aggregate\\[sum\\]$"
+    },
+    "Aggregate prod Average rate =": {
+      "name": "bench_aggregate[prod]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "^bench_aggregate\\[prod\\]$"
+    },
+    "Aggregate mean Average rate =": {
+      "name": "bench_aggregate[mean]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "^bench_aggregate\\[mean\\]$"
+    },
+    "Aggregate min Average rate =": {
+      "name": "bench_aggregate[min]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "^bench_aggregate\\[min\\]$"
+    },
+    "Aggregate max Average rate =": {
+      "name": "bench_aggregate[max]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "^bench_aggregate\\[max\\]$"
+    },
+    "Aggregate argmin Average rate =": {
+      "name": "bench_aggregate[argmin]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "^bench_aggregate\\[argmin\\]$"
+    },
+    "Aggregate argmax Average rate =": {
+      "name": "bench_aggregate[argmax]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "^bench_aggregate\\[argmax\\]$"
+    },
+    "Aggregate any Average rate =": {
+      "name": "bench_aggregate[any]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "^bench_aggregate\\[any\\]$"
+    },
+    "Aggregate all Average rate =": {
+      "name": "bench_aggregate[all]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "^bench_aggregate\\[all\\]$"
+    },
+    "Aggregate xor Average rate =": {
+      "name": "bench_aggregate[xor]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "^bench_aggregate\\[xor\\]$"
+    },
+    "Aggregate and Average rate =": {
+      "name": "bench_aggregate[and]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "^bench_aggregate\\[and\\]$"
+    },
+    "Aggregate or Average rate =": {
+      "name": "bench_aggregate[or]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "^bench_aggregate\\[or\\]$"
+    },
+    "Aggregate nunique Average rate =": {
+      "name": "bench_aggregate[nunique]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "^bench_aggregate\\[nunique\\]$"
+    },
+    "Aggregate sum Average time =": {
+      "name": "bench_aggregate[sum]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "^bench_aggregate\\[sum\\]$"
+    },
+    "Aggregate prod Average time =": {
+      "name": "bench_aggregate[prod]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "^bench_aggregate\\[prod\\]$"
+    },
+    "Aggregate min Average time =": {
+      "name": "bench_aggregate[min]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "^bench_aggregate\\[min\\]$"
+    },
+    "Aggregate max Average time =": {
+      "name": "bench_aggregate[max]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "^bench_aggregate\\[max\\]$"
+    },
+    "Aggregate argmin Average time =": {
+      "name": "bench_aggregate[argmin]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "^bench_aggregate\\[argmin\\]$"
+    },
+    "Aggregate argmax Average time =": {
+      "name": "bench_aggregate[argmax]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "^bench_aggregate\\[argmax\\]$"
+    },
+    "Aggregate any Average time =": {
+      "name": "bench_aggregate[any]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "^bench_aggregate\\[any\\]$"
+    },
+    "Aggregate all Average time =": {
+      "name": "bench_aggregate[all]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "^bench_aggregate\\[all\\]$"
+    },
+    "Aggregate xor Average time =": {
+      "name": "bench_aggregate[xor]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "^bench_aggregate\\[xor\\]$"
+    },
+    "Aggregate and Average time =": {
+      "name": "bench_aggregate[and]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "^bench_aggregate\\[and\\]$"
+    },
+    "Aggregate or Average time =": {
+      "name": "bench_aggregate[or]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "^bench_aggregate\\[or\\]$"
+    },
+    "Aggregate nunique Average time =": {
+      "name": "bench_aggregate[nunique]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "^bench_aggregate\\[nunique\\]$"
+    },
+    "Aggregate var Average time =": {
+      "name": "bench_aggregate[var]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "^bench_aggregate\\[var\\]$"
+    },
+    "Aggregate var Average rate =": {
+      "name": "bench_aggregate[var]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "^bench_aggregate\\[var\\]$"
+    },
+    "Aggregate median Average time =": {
+      "name": "bench_aggregate[median]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "^bench_aggregate\\[median\\]$"
+    },
+    "Aggregate median Average rate =": {
+      "name": "bench_aggregate[median]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "^bench_aggregate\\[median\\]$"
+    },
+    "Aggregate mode Average time =": {
+      "name": "bench_aggregate[mode]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "^bench_aggregate\\[mode\\]$"
+    },
+    "Aggregate mode Average rate =": {
+      "name": "bench_aggregate[mode]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "^bench_aggregate\\[mode\\]$"
+    },
+    "Aggregate mean Average time =": {
+      "name": "bench_aggregate[mean]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "^bench_aggregate\\[mean\\]$"
+    },
+    "Aggregate std Average time =": {
+      "name": "bench_aggregate[std]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "^bench_aggregate\\[std\\]$"
+    },
+    "Aggregate std Average rate =": {
+      "name": "bench_aggregate[std]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "^bench_aggregate\\[std\\]$"
+    },
+    "Aggregate unique Average time =": {
+      "name": "bench_aggregate[unique]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "^bench_aggregate\\[unique\\]$"
+    },
+    "Aggregate unique Average rate =": {
+      "name": "bench_aggregate[unique]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "^bench_aggregate\\[unique\\]$"
+    },
+    "Aggregate count Average time =": {
+      "name": "bench_aggregate[count]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "^bench_aggregate\\[count\\]$"
+    },
+    "Aggregate count Average rate =": {
+      "name": "bench_aggregate[count]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "^bench_aggregate\\[count\\]$"
+    },
+    "Aggregate first Average time =": {
+      "name": "bench_aggregate[first]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "^bench_aggregate\\[first\\]$"
+    },
+    "Aggregate first Average rate =": {
+      "name": "bench_aggregate[first]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "^bench_aggregate\\[first\\]$"
+    }
+  },
+  "parquetIO": {
+    "write Average time none =": {
+      "name": "",
+      "benchmark_name": "parquetIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_write_parquet\\[None-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "write Average rate none =": {
+      "name": "",
+      "benchmark_name": "parquetIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_write_parquet\\[None-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "write Average time snappy =": {
+      "name": "",
+      "benchmark_name": "parquetIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_write_parquet\\[snappy-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "write Average rate snappy =": {
+      "name": "",
+      "benchmark_name": "parquetIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_write_parquet\\[snappy-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "write Average time gzip =": {
+      "name": "",
+      "benchmark_name": "parquetIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_write_parquet\\[gzip-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "write Average rate gzip =": {
+      "name": "",
+      "benchmark_name": "parquetIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_write_parquet\\[gzip-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "write Average time brotli =": {
+      "name": "",
+      "benchmark_name": "parquetIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_write_parquet\\[brotli-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "write Average rate brotli =": {
+      "name": "",
+      "benchmark_name": "parquetIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_write_parquet\\[brotli-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "write Average time zstd =": {
+      "name": "",
+      "benchmark_name": "parquetIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_write_parquet\\[zstd-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "write Average rate zstd =": {
+      "name": "",
+      "benchmark_name": "parquetIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_write_parquet\\[zstd-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "write Average time lz4 =": {
+      "name": "",
+      "benchmark_name": "parquetIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_write_parquet\\[lz4-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "write Average rate lz4 =": {
+      "name": "",
+      "benchmark_name": "parquetIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_write_parquet\\[lz4-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average time none =": {
+      "name": "",
+      "benchmark_name": "parquetIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_read_parquet\\[None-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average rate none =": {
+      "name": "",
+      "benchmark_name": "parquetIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_read_parquet\\[None-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average time snappy =": {
+      "name": "",
+      "benchmark_name": "parquetIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_read_parquet\\[snappy-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average rate snappy =": {
+      "name": "",
+      "benchmark_name": "parquetIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_read_parquet\\[snappy-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average time gzip =": {
+      "name": "",
+      "benchmark_name": "parquetIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_read_parquet\\[gzip-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average rate gzip =": {
+      "name": "",
+      "benchmark_name": "parquetIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_read_parquet\\[gzip-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average time brotli =": {
+      "name": "",
+      "benchmark_name": "parquetIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_read_parquet\\[brotli-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average rate brotli =": {
+      "name": "",
+      "benchmark_name": "parquetIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_read_parquet\\[brotli-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average time zstd =": {
+      "name": "",
+      "benchmark_name": "parquetIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_read_parquet\\[zstd-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average rate zstd =": {
+      "name": "",
+      "benchmark_name": "parquetIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_read_parquet\\[zstd-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average time lz4 =": {
+      "name": "",
+      "benchmark_name": "parquetIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_read_parquet\\[lz4-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average rate lz4 =": {
+      "name": "",
+      "benchmark_name": "parquetIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_read_parquet\\[lz4-(?:int64|float64|bool|uint64|str)\\]"
+    }
+  },
+  "str-coargsort": {
+    "1-array Average time =": {
+      "name": "",
+      "benchmark_name": "coargsort",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_coargsort\\[str-1\\]"
+    },
+    "1-array Average rate =": {
+      "name": "",
+      "benchmark_name": "coargsort",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_coargsort\\[str-1\\]"
+    },
+    "2-array Average time =": {
+      "name": "",
+      "benchmark_name": "coargsort",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_coargsort\\[str-2\\]"
+    },
+    "2-array Average rate =": {
+      "name": "",
+      "benchmark_name": "coargsort",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_coargsort\\[str-2\\]"
+    },
+    "8-array Average time =": {
+      "name": "",
+      "benchmark_name": "coargsort",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_coargsort\\[str-8\\]"
+    },
+    "8-array Average rate =": {
+      "name": "",
+      "benchmark_name": "coargsort",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_coargsort\\[str-8\\]"
+    },
+    "16-array Average time =": {
+      "name": "",
+      "benchmark_name": "coargsort",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_coargsort\\[str-16\\]"
+    },
+    "16-array Average rate =": {
+      "name": "",
+      "benchmark_name": "coargsort",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_coargsort\\[str-16\\]"
+    }
+  },
+  "setops": {
+    "intersect1d Average time =": {
+      "name": "",
+      "benchmark_name": "setops",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_setops\\[(?:int64|float64|bool|uint64)-intersect1d\\]"
+    },
+    "intersect1d Average rate =": {
+      "name": "",
+      "benchmark_name": "setops",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_setops\\[(?:int64|float64|bool|uint64)-intersect1d\\]"
+    },
+    "union1d Average time =": {
+      "name": "",
+      "benchmark_name": "setops",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_setops\\[(?:int64|float64|bool|uint64)-union1d\\]"
+    },
+    "union1d Average rate =": {
+      "name": "",
+      "benchmark_name": "setops",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_setops\\[(?:int64|float64|bool|uint64)-union1d\\]"
+    },
+    "setxor1d Average time =": {
+      "name": "",
+      "benchmark_name": "setops",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_setops\\[(?:int64|float64|bool|uint64)-setxor1d\\]"
+    },
+    "setxor1d Average rate =": {
+      "name": "",
+      "benchmark_name": "setops",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_setops\\[(?:int64|float64|bool|uint64)-setxor1d\\]"
+    },
+    "setdiff1d Average time =": {
+      "name": "",
+      "benchmark_name": "setops",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_setops\\[(?:int64|float64|bool|uint64)-setdiff1d\\]"
+    },
+    "setdiff1d Average rate =": {
+      "name": "",
+      "benchmark_name": "setops",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_setops\\[(?:int64|float64|bool|uint64)-setdiff1d\\]"
+    }
+  },
+  "bigint_array_transfer": {
+    "to_ndarray Average time =": {
+      "name": "",
+      "benchmark_name": "bigint_array_transfer",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": null
+    },
+    "to_ndarray Average rate =": {
+      "name": "",
+      "benchmark_name": "bigint_array_transfer",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": null
+    },
+    "ak.array Average time =": {
+      "name": "",
+      "benchmark_name": "bigint_array_transfer",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": null
+    },
+    "ak.array Average rate =": {
+      "name": "",
+      "benchmark_name": "bigint_array_transfer",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": null
+    }
+  },
+  "str-groupby": {
+    "1-array Average time =": {
+      "name": "",
+      "benchmark_name": "groupby",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_groupby\\[str-1\\]"
+    },
+    "1-array Average rate =": {
+      "name": "",
+      "benchmark_name": "groupby",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_groupby\\[str-1\\]"
+    },
+    "2-array Average time =": {
+      "name": "",
+      "benchmark_name": "groupby",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_groupby\\[str-2\\]"
+    },
+    "2-array Average rate =": {
+      "name": "",
+      "benchmark_name": "groupby",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_groupby\\[str-2\\]"
+    },
+    "8-array Average time =": {
+      "name": "",
+      "benchmark_name": "groupby",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_groupby\\[str-8\\]"
+    },
+    "8-array Average rate =": {
+      "name": "",
+      "benchmark_name": "groupby",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_groupby\\[str-8\\]"
+    },
+    "16-array Average time =": {
+      "name": "",
+      "benchmark_name": "groupby",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_groupby\\[str-16\\]"
+    },
+    "16-array Average rate =": {
+      "name": "",
+      "benchmark_name": "groupby",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_groupby\\[str-16\\]"
+    }
+  },
+  "dataframe": {
+    "_get_head_tail_server Average time =": {
+      "name": "",
+      "benchmark_name": "dataframe",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_dataframe\\[_get_head_tail_server\\]"
+    },
+    "_get_head_tail_server Average rate =": {
+      "name": "",
+      "benchmark_name": "dataframe",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_dataframe\\[_get_head_tail_server\\]"
+    },
+    "_get_head_tail Average time =": {
+      "name": "",
+      "benchmark_name": "dataframe",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_dataframe\\[_get_head_tail\\]"
+    },
+    "_get_head_tail Average rate =": {
+      "name": "",
+      "benchmark_name": "dataframe",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_dataframe\\[_get_head_tail\\]"
+    }
+  },
+  "csvIO": {
+    "write Average time CSV =": {
+      "name": "",
+      "benchmark_name": "csvIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_csv_io\\[write-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "write Average rate CSV =": {
+      "name": "",
+      "benchmark_name": "csvIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_csv_io\\[write-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average time CSV =": {
+      "name": "",
+      "benchmark_name": "csvIO",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_csv_io\\[read-(?:int64|float64|bool|uint64|str)\\]"
+    },
+    "read Average rate CSV =": {
+      "name": "",
+      "benchmark_name": "csvIO",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_csv_io\\[read-(?:int64|float64|bool|uint64|str)\\]"
+    }
+  },
+  "substring_search": {
+    "non-regex with literal substring Average time =": {
+      "name": "",
+      "benchmark_name": "substring_search",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_strings_contains\\[Non_Regex\\]"
+    },
+    "non-regex with literal substring Average rate =": {
+      "name": "",
+      "benchmark_name": "substring_search",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_strings_contains\\[Non_Regex\\]"
+    },
+    "regex with literal substring Average time =": {
+      "name": "",
+      "benchmark_name": "substring_search",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_strings_contains\\[Regex_Literal\\]"
+    },
+    "regex with literal substring Average rate =": {
+      "name": "",
+      "benchmark_name": "substring_search",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_strings_contains\\[Regex_Literal\\]"
+    },
+    "regex with pattern Average time =": {
+      "name": "",
+      "benchmark_name": "substring_search",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_strings_contains\\[Regex_Pattern\\]"
+    },
+    "regex with pattern Average rate =": {
+      "name": "",
+      "benchmark_name": "substring_search",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_strings_contains\\[Regex_Pattern\\]"
+    }
+  },
+  "coargsort": {
+    "1-array Average time =": {
+      "name": "",
+      "benchmark_name": "coargsort",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_coargsort\\[(?:int64|float64|bool|uint64)-1\\]"
+    },
+    "1-array Average rate =": {
+      "name": "",
+      "benchmark_name": "coargsort",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_coargsort\\[(?:int64|float64|bool|uint64)-1\\]"
+    },
+    "2-array Average time =": {
+      "name": "",
+      "benchmark_name": "coargsort",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_coargsort\\[(?:int64|float64|bool|uint64)-2\\]"
+    },
+    "2-array Average rate =": {
+      "name": "",
+      "benchmark_name": "coargsort",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_coargsort\\[(?:int64|float64|bool|uint64)-2\\]"
+    },
+    "8-array Average time =": {
+      "name": "",
+      "benchmark_name": "coargsort",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_coargsort\\[(?:int64|float64|bool|uint64)-8\\]"
+    },
+    "8-array Average rate =": {
+      "name": "",
+      "benchmark_name": "coargsort",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_coargsort\\[(?:int64|float64|bool|uint64)-8\\]"
+    },
+    "16-array Average time =": {
+      "name": "",
+      "benchmark_name": "coargsort",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_coargsort\\[(?:int64|float64|bool|uint64)-16\\]"
+    },
+    "16-array Average rate =": {
+      "name": "",
+      "benchmark_name": "coargsort",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_coargsort\\[(?:int64|float64|bool|uint64)-16\\]"
+    }
+  },
+  "bigint_groupby": {
+    "1-array Average time =": {
+      "name": "",
+      "benchmark_name": "bigint_groupby",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_groupby\\[(?:int64|float64|bool|uint64)-1\\]"
+    },
+    "1-array Average rate =": {
+      "name": "",
+      "benchmark_name": "bigint_groupby",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_groupby\\[(?:int64|float64|bool|uint64)-1\\]"
+    },
+    "2-array Average time =": {
+      "name": "",
+      "benchmark_name": "bigint_groupby",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_groupby\\[(?:int64|float64|bool|uint64)-2\\]"
+    },
+    "2-array Average rate =": {
+      "name": "",
+      "benchmark_name": "bigint_groupby",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_groupby\\[(?:int64|float64|bool|uint64)-2\\]"
+    },
+    "8-array Average time =": {
+      "name": "",
+      "benchmark_name": "bigint_groupby",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_groupby\\[(?:int64|float64|bool|uint64)-8\\]"
+    },
+    "8-array Average rate =": {
+      "name": "",
+      "benchmark_name": "bigint_groupby",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_groupby\\[(?:int64|float64|bool|uint64)-8\\]"
+    },
+    "16-array Average time =": {
+      "name": "",
+      "benchmark_name": "bigint_groupby",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_groupby\\[(?:int64|float64|bool|uint64)-16\\]"
+    },
+    "16-array Average rate =": {
+      "name": "",
+      "benchmark_name": "bigint_groupby",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_groupby\\[(?:int64|float64|bool|uint64)-16\\]"
+    }
+  },
+  "str-locality": {
+    "Hashing good locality Average time =": {
+      "name": "",
+      "benchmark_name": "locality",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_str_locality\\[good-Hashing\\]"
+    },
+    "Hashing good locality Average rate =": {
+      "name": "",
+      "benchmark_name": "locality",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_str_locality\\[good-Hashing\\]"
+    },
+    "Hashing poor locality Average time =": {
+      "name": "",
+      "benchmark_name": "locality",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_str_locality\\[poor-Hashing\\]"
+    },
+    "Hashing poor locality Average rate =": {
+      "name": "",
+      "benchmark_name": "locality",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_str_locality\\[poor-Hashing\\]"
+    },
+    "Regex searching good locality Average time =": {
+      "name": "",
+      "benchmark_name": "locality",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_str_locality\\[good-Regex\\]"
+    },
+    "Regex searching good locality Average rate =": {
+      "name": "",
+      "benchmark_name": "locality",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_str_locality\\[good-Regex\\]"
+    },
+    "Regex searching poor locality Average time =": {
+      "name": "",
+      "benchmark_name": "locality",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_str_locality\\[poor-Regex\\]"
+    },
+    "Regex searching poor locality Average rate =": {
+      "name": "",
+      "benchmark_name": "locality",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_str_locality\\[poor-Regex\\]"
+    },
+    "Casting good locality Average time =": {
+      "name": "",
+      "benchmark_name": "locality",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_str_locality\\[good-Casting\\]"
+    },
+    "Casting good locality Average rate =": {
+      "name": "",
+      "benchmark_name": "locality",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_str_locality\\[good-Casting\\]"
+    },
+    "Casting poor locality Average time =": {
+      "name": "",
+      "benchmark_name": "locality",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_str_locality\\[poor-Casting\\]"
+    },
+    "Casting poor locality Average rate =": {
+      "name": "",
+      "benchmark_name": "locality",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_str_locality\\[poor-Casting\\]"
+    },
+    "Comparing to scalar good locality Average time =": {
+      "name": "",
+      "benchmark_name": "locality",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_str_locality\\[good-Comparing\\]"
+    },
+    "Comparing to scalar good locality Average rate =": {
+      "name": "",
+      "benchmark_name": "locality",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_str_locality\\[good-Comparing\\]"
+    },
+    "Comparing to scalar poor locality Average time =": {
+      "name": "",
+      "benchmark_name": "locality",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_str_locality\\[poor-Comparing\\]"
+    },
+    "Comparing to scalar poor locality Average rate =": {
+      "name": "",
+      "benchmark_name": "locality",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_str_locality\\[poor-Comparing\\]"
+    }
+  },
+  "flatten": {
+    "non-regex flatten with literal delimiter Average time =": {
+      "name": "",
+      "benchmark_name": "flatten",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": null
+    },
+    "non-regex flatten with literal delimiter Average rate =": {
+      "name": "",
+      "benchmark_name": "flatten",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": null
+    },
+    "regex flatten with literal delimiter Average time =": {
+      "name": "",
+      "benchmark_name": "flatten",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": null
+    },
+    "regex flatten with literal delimiter Average rate =": {
+      "name": "",
+      "benchmark_name": "flatten",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": null
+    },
+    "regex flatten with pattern delimiter Average time =": {
+      "name": "",
+      "benchmark_name": "flatten",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": null
+    },
+    "regex flatten with pattern delimiter Average rate =": {
+      "name": "",
+      "benchmark_name": "flatten",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": null
+    }
+  },
+  "emitted-code-size": {
+    "Statements emitted:": {
+      "name": "",
+      "benchmark_name": "emitted_code_size",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": null
+    }
+  },
+  "str-in1d": {
+    "Medium average time =": {
+      "name": "",
+      "benchmark_name": "in1d",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_in1d\\[MEDIUM-str\\]"
+    },
+    "Medium average rate =": {
+      "name": "",
+      "benchmark_name": "in1d",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_in1d\\[MEDIUM-str\\]"
+    },
+    "Large average time =": {
+      "name": "",
+      "benchmark_name": "in1d",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_in1d\\[LARGE-str\\]"
+    },
+    "Large average rate =": {
+      "name": "",
+      "benchmark_name": "in1d",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_in1d\\[LARGE-str\\]"
+    }
+  },
+  "stream": {
+    "Average rate =": {
+      "name": "bench_stream",
+      "benchmark_name": "stream",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_stream\\[(?:int64|float64|bool|uint64)\\]"
+    },
+    "Average time =": {
+      "name": "bench_stream",
+      "benchmark_name": "stream",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_stream\\[(?:int64|float64|bool|uint64)\\]"
+    }
+  },
+  "argsort": {
+    "Average rate =": {
+      "name": "bench_argsort",
+      "benchmark_name": "argsort",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_argsort\\[(?:int64|float64|bool|uint64)\\]"
+    },
+    "Average time =": {
+      "name": "bench_argsort",
+      "benchmark_name": "argsort",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_argsort\\[(?:int64|float64|bool|uint64)\\]"
+    }
+  },
+  "str-argsort": {
+    "Average rate =": {
+      "name": "bench_argsort",
+      "benchmark_name": "argsort",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_argsort\\[str\\]"
+    },
+    "Average time =": {
+      "name": "bench_argsort",
+      "benchmark_name": "argsort",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_argsort\\[str\\]"
+    }
+  },
+  "gather": {
+    "Average rate =": {
+      "name": "bench_gather",
+      "benchmark_name": "gather",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_gather\\[(?:int64|float64|bool|uint64)\\]"
+    },
+    "Average time =": {
+      "name": "bench_gather",
+      "benchmark_name": "gather",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_gather\\[(?:int64|float64|bool|uint64)\\]"
+    }
+  },
+  "str-gather": {
+    "Average rate =": {
+      "name": "bench_gather",
+      "benchmark_name": "gather",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_gather\\[str\\]"
+    },
+    "Average time =": {
+      "name": "bench_gather",
+      "benchmark_name": "gather",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_gather\\[str\\]"
+    }
+  },
+  "scatter": {
+    "Average rate =": {
+      "name": "bench_scatter",
+      "benchmark_name": "scatter",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_scatter\\[(?:int64|float64|bool|uint64)\\]"
+    },
+    "Average time =": {
+      "name": "bench_scatter",
+      "benchmark_name": "scatter",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_scatter\\[(?:int64|float64|bool|uint64)\\]"
+    }
+  },
+  "noop": {
+    "Average rate =": {
+      "name": "bench_noop",
+      "benchmark_name": "noop",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "^bench_noop.*$"
+    },
+    "Average time =": {
+      "name": "bench_noop",
+      "benchmark_name": "noop",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "^bench_noop.*$"
+    }
+  },
+  "split": {
+    "Average rate =": {
+      "name": "bench_split",
+      "benchmark_name": "split",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "bench_split\\[(?:int64|float64|bool|uint64)\\]"
+    },
+    "Average time =": {
+      "name": "bench_split",
+      "benchmark_name": "split",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "bench_split\\[(?:int64|float64|bool|uint64)\\]"
+    }
+  }
+}

--- a/benchmark_v2/encoding_benchmark.py
+++ b/benchmark_v2/encoding_benchmark.py
@@ -29,9 +29,8 @@ def bench_encode(benchmark, encoding):
 
     benchmark.extra_info["description"] = f"Measures the performance of Strings.encode with '{encoding}'"
     benchmark.extra_info["problem_size"] = N
-    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-        (numBytes / benchmark.stats["mean"]) / 2**30
-    )
+    #   units are GiB/sec:
+    benchmark.extra_info["transfer_rate"] = float((numBytes / benchmark.stats["mean"]) / 2**30)
 
 
 @pytest.mark.skip_numpy(True)
@@ -51,6 +50,5 @@ def bench_decode(benchmark, encoding):
 
     benchmark.extra_info["description"] = f"Measures the performance of Strings.decode with '{encoding}'"
     benchmark.extra_info["problem_size"] = N
-    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-        (numBytes / benchmark.stats["mean"]) / 2**30
-    )
+    #   units are GiB/sec:
+    benchmark.extra_info["transfer_rate"] = float((numBytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/flatten_benchmark.py
+++ b/benchmark_v2/flatten_benchmark.py
@@ -45,6 +45,7 @@ def bench_ak_flatten_2d(benchmark, dtype, shape_type):
     benchmark.extra_info["description"] = f"Measures ak.flatten (np-style) on dtype={dtype}"
     benchmark.extra_info["problem_size"] = N
     benchmark.extra_info["backend"] = "Arkouda"
-    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
+    #   units are GiB/sec:
+    benchmark.extra_info["transfer_rate"] = float(
         (data.size * data.itemsize / benchmark.stats["mean"]) / 2**30
     )

--- a/benchmark_v2/gather_benchmark.py
+++ b/benchmark_v2/gather_benchmark.py
@@ -70,6 +70,5 @@ def bench_gather(benchmark, dtype):
     benchmark.extra_info["problem_size"] = N
     benchmark.extra_info["index_size"] = isize
     benchmark.extra_info["value_size"] = vsize
-    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-        (numBytes / benchmark.stats["mean"]) / 2**30
-    )
+    #   units are GiB/sec:
+    benchmark.extra_info["transfer_rate"] = float((numBytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/generate_field_lookup_map.py
+++ b/benchmark_v2/generate_field_lookup_map.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""
+Generate a field-to-regex lookup map for benchmark performance keys.
+
+This script parses `.perfkeys` files located in the benchmark graph infrastructure
+directory, infers regular expressions to identify benchmark output keys,
+and maps them to internal data paths used for analysis (e.g., `stats.mean`,
+`extra_info.transfer_rate`). The result is written to a JSON file for use in
+benchmark plotting and evaluation tools.
+
+Main Components:
+----------------
+- `infer_regex`:
+    Infers a benchmark regex pattern based on benchmark and field names.
+- `get_header_fields_from_directory`:
+    Loads header fields from `.perfkeys` files in a given directory.
+- `build_field_lookup_map`:
+    Builds the core mapping from benchmark fields to regex expressions and paths.
+- `add_default_mappings`:
+    Adds standard time/rate mappings for simple benchmarks.
+- `add_aggregate_ops`:
+    Adds entries for GroupBy and reduction-based aggregate operations.
+
+Output:
+-------
+Writes the resulting mapping to `benchmark_v2/datdir/configs/field_lookup_map.json`.
+
+"""
+
+import json
+import logging
+import os
+import re
+
+# Aggregate operations explicitly defined
+import arkouda as ak
+from arkouda.logger import getArkoudaLogger
+
+GRAPH_INFRA_DIR = "benchmark_v2/graph_infra"
+OUTPUT_JSON = "benchmark_v2/datdir/configs/field_lookup_map.json"
+
+# Benchmarks that just need default Average rate/time keys
+DEFAULT_BENCHMARKS = [
+    "stream",
+    "argsort",
+    "str-argsort",
+    "gather",
+    "str-gather",
+    "scatter",
+    "bigint_stream",
+    "flatten",
+    "noop",
+    "split",
+]
+
+
+AGGREGATE_OPS = ak.GroupBy.Reductions
+
+
+def infer_regex(benchmark_name: str, field: str) -> str:
+    """Infer a regex for JSON benchmark names based on perfkey field names."""
+    base_bench = re.sub(r"^(str|bigint)(?:_|-)", "", benchmark_name)
+
+    if "array_transfer" in base_bench:
+        if "to_ndarray" in field:
+            base_bench = base_bench + "_tondarray"
+        elif "ak.array" in field:
+            base_bench = base_bench + "_akarray"
+
+    # Groupby & Coargsort (with array counts)
+    if "array" in field and base_bench in ["groupby", "coargsort"]:
+        m = re.search(r"(\d+)-array", field)
+        if m:
+            num = m.group(1)
+            if benchmark_name.startswith("str-"):
+                dtype = "str"
+            elif benchmark_name.startswith("bigint-"):
+                dtype = "bigint"
+            else:
+                dtype = "(?:int64|float64|bool|uint64)"
+            return f"bench_{base_bench}\\[{dtype}-{num}\\]"
+
+    # IO
+    if "IO" == benchmark_name:
+        m = re.search(r"((?:write|read)) Average", field)
+        if m:
+            op = m.group(1)
+            dtype = "(?:int64|float64|bool|uint64|str)"
+            return f"bench_{op}_hdf\\[{dtype}\\]"
+
+    # CSV Read/Write
+    if "csvIO" == benchmark_name:
+        m1 = re.search(r"(write|read)", field)
+
+        if m1:
+            op = m1.group(1)
+            dtype = "(?:int64|float64|bool|uint64|str)"
+            return f"bench_csv_io\\[{op}-{dtype}\\]"
+
+    # parquet IO
+    if benchmark_name in ["parquetIO", "parquetMultiIO"]:
+        qualifier = "_multi" if "Multi" in benchmark_name else ""
+        m1 = re.search(r"((?:write|read)) Average", field)
+        m2 = re.search(r"(\w+) =", field)
+        if m1 and m2:
+            op = m1.group(1)
+            compression = m2.group(1)
+            compression = "None" if compression == "none" else compression
+            dtype = "(?:int64|float64|bool|uint64|str)"
+            return f"bench_{op}_parquet{qualifier}\\[{compression}-{dtype}\\]"
+
+    # encode
+    if "encode" in benchmark_name:
+        m1 = re.search(r"((?:ascii|idna))", field)
+        m2 = re.search(r"((?:encode|decode))", field)
+        if m1 and m2:
+            encoding = m1.group(1)
+            mode = m2.group(1)
+            return f"bench_{mode}\\[{encoding}\\]"
+
+    # small-str-groupby
+    if "small-str-groupby" in benchmark_name:
+        m = re.search(r"((?:small|medium|big)) str array Average", field)
+        if m:
+            op = m.group(1)
+            return f"bench_groupby_small_str\\[{op}\\]"
+
+    # dataframe
+    if base_bench == "dataframe":
+        m = re.search(r"([_\-\w]+) Average", field)
+        if m:
+            op = m.group(1)
+            return f"bench_{base_bench}\\[{op}\\]"
+
+    #  reduce
+    if benchmark_name in ["reduce", "scan", "setops", "array_create"]:
+        m = re.search(r"(\w+) Average", field)
+        if m:
+            op = m.group(1)
+            dtype = "(?:int64|float64|bool|uint64)"
+            return f"bench_{base_bench}\\[{dtype}-{op}\\]"
+
+    # bigint_conversion
+    if "bigint_conversion" in benchmark_name:
+        m = re.search(r"(\w+) Average", field)
+        if m:
+            op = m.group(1)
+            return f"bench_bigint_conversion\\[{op}\\]"
+
+    # in1d & str-in1d
+    if "in1d" in benchmark_name:
+        m = re.search(r"((?:Medium|Large)) average", field)
+        if m:
+            size = m.group(1).upper()
+            if benchmark_name.startswith("str-"):
+                dtype = "str"
+            elif benchmark_name.startswith("bigint-"):
+                dtype = "bigint"
+            else:
+                dtype = "(?:int64|float64|bool|uint64)"
+            return f"bench_in1d\\[{size}-{dtype}\\]"
+
+    # str_locality
+    if "str-locality" in benchmark_name:
+        m1 = re.search(r"((?:Hashing|Regex|Casting|Comparing))", field)
+        m2 = re.search(r"((?:good|poor))", field)
+        if m1 and m2:
+            op = m1.group(1)
+            locality = m2.group(1)
+            return f"bench_str_locality\\[{locality}-{op}\\]"
+
+    # bigint_bitwise_binops
+    if "bigint_bitwise_binops" in benchmark_name:
+        m1 = re.search(r"((?:AND|OR|SHIFT))", field)
+        if m1:
+            op = m1.group(1).lower()
+            return f"bench_bitwise_binops\\[{op}\\]"
+
+    # sort-cases
+    if benchmark_name == "sort-cases":
+        m1 = re.search(r"((?:RadixSortLSD|TwoArrayRadixSort))", field)
+        if m1:
+            sort = "SortingAlgorithm." + m1.group(1)
+            dtype = "(?:int64|float64|bool|uint64|str)"
+            if "RMAT" in field:
+                return f"bench_rmat\\[{sort}\\]"
+            elif "block-sorted" in field:
+                m2 = re.search(r"(concat|interleaved)", field)
+                if m2:
+                    mode = m2.group(1)
+                    return f"bench_block_sorted\\[{mode}-{sort}\\]"
+            elif "refinement" in field:
+                return f"bench_refinement\\[{sort}\\]"
+            elif "datetime" in field:
+                return f"bench_time_like\\[{sort}\\]"
+            elif "IP" in field:
+                return f"bench_ip_like\\[{sort}\\]"
+            elif "uniform" in field:
+                m2 = re.search(r"(\d+)-bit", field)
+                m3 = re.search(r"float64", field, re.IGNORECASE)
+                if m2:
+                    mode = m2.group(1)
+                    return f"bench_random_uniform\\[{mode}-bit-{dtype}-{sort}\\]"
+                elif m3:
+                    return f"bench_random_uniform\\[64-bit-float64-{sort}\\]"
+            elif "power" in field:
+                return f"bench_power_law\\[{dtype}-{sort}\\]"
+
+    # substring-search
+    if benchmark_name == "substring_search":
+        m1 = re.search(r"(^(?:non-regex|regex))", field)
+        if m1:
+            regex_type = m1.group(1)
+            if regex_type == "regex":
+                m2 = re.search(r"(pattern)", field)
+                if m2:
+                    return "bench_strings_contains\\[Regex_Pattern\\]"
+                else:
+                    return "bench_strings_contains\\[Regex_Literal\\]"
+            elif regex_type == "non-regex":
+                return "bench_strings_contains\\[Non_Regex\\]"
+
+    # Reduce/Scan/Aggregate
+    if benchmark_name in {"reduce", "scan", "aggregate"}:
+        op = field.split()[0]
+        return f"bench_{benchmark_name}\\[{op}\\]"
+
+    # Bigint Stream (special case)
+    if benchmark_name == "bigint_stream":
+        return r"bench_bigint_stream\[bigint\]"
+
+
+def get_header_fields_from_directory(directory_path):
+    """Load perfkeys headers into a dict."""
+    file_contents = {}
+    for filename in os.listdir(directory_path):
+        if filename.endswith(".perfkeys"):
+            with open(os.path.join(directory_path, filename), "r", encoding="utf-8") as f:
+                lines = [line.strip() for line in f if line.strip()]
+                key = re.search(r"([\w\-_]+)\.perfkeys", filename)[1]
+                file_contents[key] = lines
+    return file_contents
+
+
+def build_field_lookup_map():
+    headers = get_header_fields_from_directory(GRAPH_INFRA_DIR)
+    field_lookup_map = {}
+
+    for benchmark_name, fields in headers.items():
+        field_lookup_map[benchmark_name] = {}
+        for field in fields:
+            if field == "# Date":
+                continue
+            regex = infer_regex(benchmark_name, field)
+            lookup_path = ["extra_info", "transfer_rate"] if "rate" in field else ["stats", "mean"]
+
+            field_lookup_map[benchmark_name][field] = {
+                "name": "",
+                "benchmark_name": benchmark_name.replace("str-", "")
+                .replace("bigint-", "")
+                .replace("-", "_"),
+                "lookup_path": lookup_path,
+                "lookup_regex": regex,
+            }
+
+    return field_lookup_map
+
+
+def add_default_mappings(field_lookup_map):
+    for b in DEFAULT_BENCHMARKS:
+        if b not in field_lookup_map:
+            base_bench = b.replace("str-", "").replace("bigint-", "").replace("-", "_")
+            if b.startswith("str-"):
+                dtype = "str"
+            elif b.startswith("bigint-"):
+                dtype = "bigint"
+            else:
+                dtype = "(?:int64|float64|bool|uint64)"
+
+            if base_bench == "noop":
+                regex = rf"^bench_{base_bench}.*$"
+            elif base_bench == "bigint_stream":
+                regex = r"bench_bigint_stream\[bigint\]"
+            else:
+                regex = f"bench_{base_bench}\\[{dtype}\\]"
+
+            field_lookup_map[b] = {
+                "Average rate =": {
+                    "name": f"bench_{base_bench}",
+                    "benchmark_name": base_bench,
+                    "lookup_path": ["extra_info", "transfer_rate"],
+                    "lookup_regex": regex,
+                },
+                "Average time =": {
+                    "name": f"bench_{base_bench}",
+                    "benchmark_name": base_bench,
+                    "lookup_path": ["stats", "mean"],
+                    "lookup_regex": regex,
+                },
+            }
+    return field_lookup_map
+
+
+def add_aggregate_ops(field_lookup_map):
+    if "aggregate" not in field_lookup_map:
+        field_lookup_map["aggregate"] = {}
+    if "reduce" not in field_lookup_map:
+        field_lookup_map["reduce"] = {}
+
+    for op in AGGREGATE_OPS:  # should include all GroupBy.Reductions ops
+        for t in ["time", "rate"]:
+            lookup_path = ["extra_info", "transfer_rate"] if t == "rate" else ["stats", "mean"]
+
+            # Correct mapping for GroupBy.aggregate
+            field_lookup_map["aggregate"][f"Aggregate {op} Average {t} ="] = {
+                "name": f"bench_aggregate[{op}]",
+                "benchmark_name": "aggregate",
+                "lookup_path": lookup_path,
+                "lookup_regex": f"^bench_aggregate\\[{op}\\]$",
+            }
+
+    # Keep reduce ops separate (only numeric ops)
+    for op in ["sum", "prod", "min", "max", "argmin", "argmax"]:
+        for t in ["time", "rate"]:
+            lookup_path = ["extra_info", "transfer_rate"] if t == "rate" else ["stats", "mean"]
+            field_lookup_map["reduce"][f"Reduce {op} Average {t} ="] = {
+                "name": f"bench_reduce[{op}]",
+                "benchmark_name": "reduce",
+                "lookup_path": lookup_path,
+                "lookup_regex": f"bench_reduce\\[[\\w\\d]+-{op}\\]",
+            }
+    return field_lookup_map
+
+
+def main():
+    logger = getArkoudaLogger(name="generate field lookup map")
+
+    field_lookup_map = build_field_lookup_map()
+    field_lookup_map = add_default_mappings(field_lookup_map)
+    field_lookup_map = add_aggregate_ops(field_lookup_map)
+
+    os.makedirs(os.path.dirname(OUTPUT_JSON), exist_ok=True)
+    with open(OUTPUT_JSON, "w", encoding="utf-8") as f:
+        json.dump(field_lookup_map, f, indent=2)
+
+    logger.debug(f"Updated {OUTPUT_JSON} with {len(field_lookup_map)} benchmarks.")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.WARNING)
+    main()

--- a/benchmark_v2/groupby_benchmark.py
+++ b/benchmark_v2/groupby_benchmark.py
@@ -45,6 +45,5 @@ def bench_groupby(benchmark, numArrays, dtype):
             f"Measures the performance of ak.GroupBy creation with {dtype} dtype"
         )
         benchmark.extra_info["problem_size"] = N
-        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-            (numBytes / benchmark.stats["mean"]) / 2**30
-        )
+        #   units are GiB/sec:
+        benchmark.extra_info["transfer_rate"] = float((numBytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/in1d_benchmark.py
+++ b/benchmark_v2/in1d_benchmark.py
@@ -38,6 +38,5 @@ def bench_in1d(benchmark, dtype, size):
         benchmark.extra_info["description"] = "in1d benchmark using Arkouda"
         benchmark.extra_info["backend"] = "Arkouda"
         benchmark.extra_info["problem_size"] = N
-        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-            (nbytes / benchmark.stats["mean"]) / 2**30
-        )
+        #   units are GiB/sec:
+        benchmark.extra_info["transfer_rate"] = float((nbytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/io_benchmark.py
+++ b/benchmark_v2/io_benchmark.py
@@ -104,9 +104,8 @@ def bench_write_hdf(benchmark, dtype):
             f"Measures the performance of IO write {dtype} to HDF5 file"
         )
         benchmark.extra_info["problem_size"] = pytest.prob_size
-        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-            (nbytes / benchmark.stats["mean"]) / 2**30
-        )
+        #   units are GiB/sec:
+        benchmark.extra_info["transfer_rate"] = float((nbytes / benchmark.stats["mean"]) / 2**30)
 
 
 @pytest.mark.skip_numpy(True)
@@ -135,9 +134,8 @@ def bench_write_parquet(benchmark, dtype, comp):
             f"Measures the performance of IO write {dtype} to Parquet file using {comp} compression"
         )
         benchmark.extra_info["problem_size"] = pytest.prob_size
-        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-            (nbytes / benchmark.stats["mean"]) / 2**30
-        )
+        #   units are GiB/sec:
+        benchmark.extra_info["transfer_rate"] = float((nbytes / benchmark.stats["mean"]) / 2**30)
 
 
 @pytest.mark.skip_numpy(True)
@@ -169,9 +167,8 @@ def bench_write_parquet_multi(benchmark, dtype, comp):
             f"Measures the performance of IO write {dtype} to Parquet file using {comp} compression"
         )
         benchmark.extra_info["problem_size"] = pytest.prob_size
-        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-            (nbytes / benchmark.stats["mean"]) / 2**30
-        )
+        #   units are GiB/sec:
+        benchmark.extra_info["transfer_rate"] = float((nbytes / benchmark.stats["mean"]) / 2**30)
 
 
 @pytest.mark.skip_numpy(True)
@@ -202,9 +199,8 @@ def bench_write_parquet_append(benchmark, dtype, comp):
             f"Measures the performance of IO write {dtype} to Parquet file using {comp} compression"
         )
         benchmark.extra_info["problem_size"] = pytest.prob_size
-        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-            (nbytes / benchmark.stats["mean"]) / 2**30
-        )
+        #   units are GiB/sec:
+        benchmark.extra_info["transfer_rate"] = float((nbytes / benchmark.stats["mean"]) / 2**30)
 
 
 @pytest.mark.skip_numpy(True)
@@ -225,9 +221,8 @@ def bench_read_hdf(benchmark, dtype):
 
         benchmark.extra_info["description"] = "Measures the performance of IO read from HDF5 files"
         benchmark.extra_info["problem_size"] = pytest.prob_size
-        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-            (nbytes / benchmark.stats["mean"]) / 2**30
-        )
+        #   units are GiB/sec:
+        benchmark.extra_info["transfer_rate"] = float((nbytes / benchmark.stats["mean"]) / 2**30)
 
 
 @pytest.mark.skip_numpy(True)
@@ -253,16 +248,15 @@ def bench_read_parquet(benchmark, dtype, comp):
 
         benchmark.extra_info["description"] = "Measures the performance of IO read from Parquet files"
         benchmark.extra_info["problem_size"] = pytest.prob_size
-        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-            (nbytes / benchmark.stats["mean"]) / 2**30
-        )
+        #   units are GiB/sec:
+        benchmark.extra_info["transfer_rate"] = float((nbytes / benchmark.stats["mean"]) / 2**30)
 
 
 @pytest.mark.skip_numpy(True)
 @pytest.mark.benchmark(group="Arkouda_IO_Read_Parquet")
 @pytest.mark.parametrize("dtype", TYPES)
 @pytest.mark.parametrize("comp", COMPRESSIONS)
-def bench_read_parquet_multi_column(benchmark, dtype, comp):
+def bench_read_parquet_multi(benchmark, dtype, comp):
     """
     Read files written by parquet multicolumn and parquet append modes
     """
@@ -285,9 +279,8 @@ def bench_read_parquet_multi_column(benchmark, dtype, comp):
 
         benchmark.extra_info["description"] = "Measures the performance of IO read from Parquet files"
         benchmark.extra_info["problem_size"] = pytest.prob_size
-        benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-            (nbytes / benchmark.stats["mean"]) / 2**30
-        )
+        #   units are GiB/sec:
+        benchmark.extra_info["transfer_rate"] = float((nbytes / benchmark.stats["mean"]) / 2**30)
 
 
 @pytest.mark.skip_numpy(True)

--- a/benchmark_v2/no_op_benchmark.py
+++ b/benchmark_v2/no_op_benchmark.py
@@ -26,6 +26,5 @@ def bench_noop(benchmark):
     benchmark.extra_info["description"] = description
     benchmark.extra_info["problem_size"] = "N/A"
     benchmark.extra_info["backend"] = backend
-    benchmark.extra_info["transfer_rate"] = (
-        f"{benchmark.stats['rounds'] / benchmark.stats['total']:.4f} operations per second"
-    )
+    #   units are operations per second:
+    benchmark.extra_info["transfer_rate"] = float(benchmark.stats["rounds"] / benchmark.stats["total"])

--- a/benchmark_v2/parquet-fixed-strings_benchmark.py
+++ b/benchmark_v2/parquet-fixed-strings_benchmark.py
@@ -32,6 +32,5 @@ def bench_parquet_fixed_strings(benchmark, tmp_path, scaling, fixed_len, nfiles)
     benchmark.extra_info["scaling"] = scaling
     benchmark.extra_info["nfiles"] = nfiles
     benchmark.extra_info["backend"] = "Arkouda"
-    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-        (numBytes / benchmark.stats["mean"]) / 2**30
-    )
+    #   units are GiB/sec:
+    benchmark.extra_info["transfer_rate"] = float((numBytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/reduce_benchmark.py
+++ b/benchmark_v2/reduce_benchmark.py
@@ -2,7 +2,7 @@ import pytest
 
 import arkouda as ak
 
-OPS = ("sum", "prod", "min", "max")
+OPS = ("sum", "prod", "min", "max", "argmin", "argmax")
 TYPES = ("int64", "float64")
 
 
@@ -40,6 +40,5 @@ def bench_reduce(benchmark, op, dtype):
     benchmark.extra_info["description"] = f"Reduce: {op} ({backend})"
     benchmark.extra_info["problem_size"] = N
     benchmark.extra_info["backend"] = backend
-    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-        (nbytes / benchmark.stats["mean"]) / 2**30
-    )
+    #   units are GiB/sec:
+    benchmark.extra_info["transfer_rate"] = float((nbytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/scan_benchmark.py
+++ b/benchmark_v2/scan_benchmark.py
@@ -47,6 +47,5 @@ def bench_scan(benchmark, op, dtype):
     benchmark.extra_info["description"] = f"Scan: {op} using {backend}"
     benchmark.extra_info["problem_size"] = N
     benchmark.extra_info["backend"] = backend
-    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-        (nbytes / benchmark.stats["mean"]) / 2**30
-    )
+    #   units are GiB/sec:
+    benchmark.extra_info["transfer_rate"] = float((nbytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/scatter_benchmark.py
+++ b/benchmark_v2/scatter_benchmark.py
@@ -59,6 +59,5 @@ def bench_scatter(benchmark, dtype):
     benchmark.extra_info["problem_size"] = N
     benchmark.extra_info["index_size"] = isize
     benchmark.extra_info["value_size"] = vsize
-    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-        (numBytes / benchmark.stats["mean"]) / 2**30
-    )
+    #   units are GiB/sec:
+    benchmark.extra_info["transfer_rate"] = float((numBytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/setops_benchmark.py
+++ b/benchmark_v2/setops_benchmark.py
@@ -41,9 +41,8 @@ def bench_segarr_setops_small(benchmark, op, dtype):
 
     benchmark.extra_info["description"] = "Measures the performance of SegArray setops (small input)"
     benchmark.extra_info["problem_size"] = N
-    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-        (nbytes / benchmark.stats["mean"]) / 2**30
-    )
+    #   units are GiB/sec:
+    benchmark.extra_info["transfer_rate"] = float((nbytes / benchmark.stats["mean"]) / 2**30)
 
 
 @pytest.mark.benchmark(group="Setops")
@@ -81,6 +80,5 @@ def bench_setops(benchmark, op, dtype):
     benchmark.extra_info["description"] = f"Measures the performance of {backend} {op}"
     benchmark.extra_info["problem_size"] = N
     benchmark.extra_info["backend"] = backend
-    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-        (numBytes / benchmark.stats["mean"]) / 2**30
-    )
+    #   units are GiB/sec:
+    benchmark.extra_info["transfer_rate"] = float((numBytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/setops_multiarray_benchmark.py
+++ b/benchmark_v2/setops_multiarray_benchmark.py
@@ -34,6 +34,5 @@ def bench_setops_multiarray(benchmark, op, dtype):
     benchmark.extra_info["description"] = f"Multiarray set operation: {op} on dtype={dtype}"
     benchmark.extra_info["problem_size"] = N
     benchmark.extra_info["backend"] = "Arkouda"
-    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-        (bytes_processed / benchmark.stats["mean"]) / 2**30
-    )
+    #   units are GiB/sec:
+    benchmark.extra_info["transfer_rate"] = float((bytes_processed / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/small-str-groupby.py
+++ b/benchmark_v2/small-str-groupby.py
@@ -25,6 +25,5 @@ def bench_groupby_small_str(benchmark, strlen_label):
     benchmark.extra_info["problem_size"] = N
     benchmark.extra_info["backend"] = "Arkouda"
     benchmark.extra_info["string_length"] = strlen
-    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-        (bytes_processed / benchmark.stats["mean"]) / 2**30
-    )
+    #   units are GiB/sec:
+    benchmark.extra_info["transfer_rate"] = float((bytes_processed / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/sort_cases_benchmark.py
+++ b/benchmark_v2/sort_cases_benchmark.py
@@ -52,9 +52,8 @@ def run_sort(benchmark, name, data, sort_fn):
     benchmark.extra_info["description"] = f"{name} via {backend}"
     benchmark.extra_info["problem_size"] = data[0].size if isinstance(data, tuple) else data.size
     benchmark.extra_info["backend"] = backend
-    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-        (numBytes / benchmark.stats["mean"]) / 2**30
-    )
+    #   units are GiB/sec:
+    benchmark.extra_info["transfer_rate"] = float((numBytes / benchmark.stats["mean"]) / 2**30)
 
 
 @pytest.mark.benchmark(group="AK_Sort_Cases")

--- a/benchmark_v2/split_benchmark.py
+++ b/benchmark_v2/split_benchmark.py
@@ -28,6 +28,5 @@ def bench_strings_split(benchmark, label, delim, use_regex):
     benchmark.extra_info["description"] = f"Performance of Strings.split (mode: {label})"
     benchmark.extra_info["problem_size"] = N
     benchmark.extra_info["backend"] = "Arkouda"
-    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-        (num_bytes / benchmark.stats["mean"]) / 2**30
-    )
+    #   units are GiB/sec:
+    benchmark.extra_info["transfer_rate"] = float((num_bytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/str_locality_benchmark.py
+++ b/benchmark_v2/str_locality_benchmark.py
@@ -4,12 +4,12 @@ import arkouda as ak
 
 OPS = {
     "Hashing": lambda x: x.hash(),
-    "Regex_Search": lambda x: x.contains(r"\d{3,5}\.\d{5,8}", regex=True),
+    "Regex": lambda x: x.contains(r"\d{3,5}\.\d{5,8}", regex=True),
     "Casting": lambda x: ak.cast(x, ak.float64),
-    "Scalar_Compare": lambda x: (x == "5.5"),
+    "Comparing": lambda x: (x == "5.5"),
 }
 
-LOCALITY = {"Good", "Poor"}
+LOCALITY = {"good", "poor"}
 
 
 def _generate_data(loc):
@@ -26,7 +26,7 @@ def _generate_data(loc):
     )
     random_strings = prefix.stick(suffix, delimiter=".")
 
-    if loc == "Good":
+    if loc == "good":
         return random_strings
     else:
         #   To simulate poor locality, sort by string lengths.
@@ -51,6 +51,5 @@ def bench_str_locality(benchmark, op, loc):
     )
     benchmark.extra_info["problem_size"] = data.size
     benchmark.extra_info["backend"] = "Arkouda"
-    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-        (nbytes / benchmark.stats["mean"]) / 2**30
-    )
+    #   units are GiB/sec:
+    benchmark.extra_info["transfer_rate"] = float((nbytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/stream_benchmark.py
+++ b/benchmark_v2/stream_benchmark.py
@@ -40,9 +40,8 @@ def bench_stream(benchmark, dtype):
 
     benchmark.extra_info["description"] = f"Measures performance of stream using {dtype} types."
     benchmark.extra_info["problem_size"] = N
-    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-        (nBytes / benchmark.stats["mean"]) / 2**30
-    )
+    #   units are GiB/sec:
+    benchmark.extra_info["transfer_rate"] = float((nBytes / benchmark.stats["mean"]) / 2**30)
 
 
 @pytest.mark.benchmark(group="stream")
@@ -70,6 +69,5 @@ def bench_bigint_stream(benchmark, dtype):
     # Can't do numpy comparison for bigint yet
     benchmark.extra_info["description"] = f"Measures performance of stream using {dtype} types."
     benchmark.extra_info["problem_size"] = N
-    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-        (nBytes / benchmark.stats["mean"]) / 2**30
-    )
+    #   units are GiB/sec:
+    benchmark.extra_info["transfer_rate"] = float((nBytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/substring_search_benchmark.py
+++ b/benchmark_v2/substring_search_benchmark.py
@@ -34,6 +34,5 @@ def bench_strings_contains(benchmark, search_string, use_regex):
     benchmark.extra_info["backend"] = "Arkouda"
     benchmark.extra_info["search_string"] = search_string
     benchmark.extra_info["regex"] = use_regex
-    benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-        (num_bytes / benchmark.stats["mean"]) / 2**30
-    )
+    #   units are GiB/sec:
+    benchmark.extra_info["transfer_rate"] = float((num_bytes / benchmark.stats["mean"]) / 2**30)


### PR DESCRIPTION
This PR moves the generation of field lookup map to a separate script `benchmark_v2/generate_field_lookup_map.py`.  This will enable the map to be regenerated only when there are major code changes, rather than with each benchmark run.  

It also adds field parsing for most of the benchmarks.  The few remaining (flatten, split, multiIO) will be handled in a separate PR as they require extra work.  

Additionally, the `tranfer_rate` field was changed to float (rather than string) type in order to match the form expected in the results.

Closes #4606 benchmark v2/reformat benchmark results.py to parse all benchmark results