### PR TITLE
ak.get_registration_config() and tweaks

### DIFF
--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -119,6 +119,7 @@ __all__ = [
     "disconnect",
     "shutdown",
     "get_config",
+    "get_registration_config",
     "get_max_array_rank",
     "get_mem_used",
     "get_mem_avail",
@@ -878,7 +879,8 @@ def connect(
     with an existing connection, the socket will be re-initialized.
 
     """
-    global connected, serverConfig, regexMaxCaptures, channel, registrationConfig
+    global channel
+    global connected, serverConfig, regexMaxCaptures, registrationConfig
 
     # send the connect message
     cmd = "connect"
@@ -913,7 +915,7 @@ def connect(
             RuntimeWarning,
         )
     regexMaxCaptures = serverConfig["regexMaxCaptures"]  # type: ignore
-    registrationConfig = _get_registration_config_msg()
+    registrationConfig = _get_registration_config_msg()  # type: ignore
     clientLogger.info(return_message)
 
 
@@ -1028,7 +1030,7 @@ def disconnect() -> None:
         Raised if there's an error disconnecting from the Arkouda server
 
     """
-    global connected, serverConfig
+    global connected, serverConfig, regexMaxCaptures, registrationConfig
 
     if connected:
         # send disconnect message to server
@@ -1042,6 +1044,8 @@ def disconnect() -> None:
             raise ConnectionError(e)
         connected = False
         serverConfig = None
+        regexMaxCaptures = -1
+        registrationConfig = None
         clientLogger.info(return_message)
     else:
         clientLogger.info("not connected; cannot disconnect")
@@ -1065,7 +1069,7 @@ def shutdown() -> None:
         there is an error in disconnecting from the server
 
     """
-    global connected, serverConfig
+    global connected, serverConfig, regexMaxCaptures, registrationConfig
 
     if not connected:
         raise RuntimeError("not connected, cannot shutdown server")
@@ -1082,6 +1086,8 @@ def shutdown() -> None:
         raise RuntimeError(e)
     connected = False
     serverConfig = None
+    regexMaxCaptures = -1
+    registrationConfig = None
 
 
 def _json_args_to_str(json_obj: Optional[Dict] = None) -> Tuple[int, str]:
@@ -1268,9 +1274,34 @@ def get_config() -> Mapping[str, Union[str, int, float]]:
 
     """
     if serverConfig is None:
-        raise RuntimeError("client is not connected to a server")
+        raise RuntimeError("client is not connected to a server, no 'serverConfig'")
 
     return serverConfig
+
+
+def get_registration_config():
+    """
+    Get the registration settings that the server was built with.
+
+    These registration settings are defined in the file `registration-config.json`
+    and snapshot at server build time.
+
+    Returns
+    -------
+    dict
+        A mapping from parameter name to nested mappings,
+        reflecting the structure of the original JSON file.
+
+    Raises
+    ------
+    RuntimeError
+        Raised if the client is not connected to a server
+
+    """
+    if registrationConfig is None:
+        raise RuntimeError("client is not connected to a server, no 'registrationConfig'")
+
+    return registrationConfig
 
 
 def get_max_array_rank() -> int:
@@ -1288,7 +1319,7 @@ def get_max_array_rank() -> int:
 
     """
     if serverConfig is None:
-        raise RuntimeError("client is not connected to a server")
+        raise RuntimeError("client is not connected to a server, no 'serverConfig'")
 
     return max(get_array_ranks())
 
@@ -1308,10 +1339,7 @@ def get_array_ranks() -> list[int]:
 
     """
     if registrationConfig is None:
-        raise RuntimeError(
-            "There was a problem loading registrationConfig."
-            "Make sure the client is connected to a server."
-        )
+        raise RuntimeError("client is not connected to a server, no 'registrationConfig'")
 
     return registrationConfig["parameter_classes"]["array"]["nd"]
 

--- a/arkouda/numpy/dtypes.py
+++ b/arkouda/numpy/dtypes.py
@@ -84,6 +84,7 @@ __all__ = [
     "complex128",
     "complex64",
     "dtype",
+    "dtype_for_chapel",
     "float16",
     "float32",
     "float64",
@@ -202,6 +203,63 @@ def dtype(dtype):
     return np.dtype(dtype)
 
 
+_dtype_for_chapel = dict()  # type: ignore
+
+_dtype_name_for_chapel = {  # see DType
+    "real": "float64",
+    "real(32)": "float32",
+    "real(64)": "float64",
+    "complex": "complex128",
+    "complex(64)": "complex64",
+    "complex(128)": "complex128",
+    "int": "int64",
+    "int(8)": "int8",
+    "int(16)": "int16",
+    "int(32)": "int32",
+    "int(64)": "int64",
+    "uint": "uint64",
+    "uint(8)": "uint8",
+    "uint(16)": "uint16",
+    "uint(32)": "uint32",
+    "uint(64)": "uint64",
+    "bool": "bool",
+    "bigint": "bigint",
+    "string": "str",
+}
+
+
+def dtype_for_chapel(type_name: str):
+    """
+    Returns dtype() for the given Chapel type.
+
+    Parameters
+    ----------
+    type_name : str
+        The name of the Chapel type, with or without the bit width
+
+    Returns
+    -------
+    dtype
+        The corresponding Arkouda dtype object
+
+    Raises
+    ------
+    TypeError
+        Raised if Arkouda does not have a type that corresponds to `type_name`
+
+    """
+    try:
+        return _dtype_for_chapel[type_name]
+    except KeyError:
+        try:
+            dtype_name = _dtype_name_for_chapel[type_name]
+        except KeyError:
+            raise TypeError(f"Arkouda does not have a dtype that corresponds to '{type_name}' in Chapel")
+        result = dtype(dtype_name)
+        _dtype_for_chapel[type_name] = result
+        return result
+
+
 def can_cast(from_, to) -> builtins.bool:
     """
     Returns True if cast between data types can occur according to the casting rule.
@@ -213,8 +271,8 @@ def can_cast(from_, to) -> builtins.bool:
     to: dtype or dtype specifier
         Data type to cast to.
 
-    Return
-    ------
+    Returns
+    -------
     builtins.bool
         True if cast can occur according to the casting rule.
 

--- a/arkouda/numpy/random/generator.py
+++ b/arkouda/numpy/random/generator.py
@@ -1,9 +1,11 @@
 import numpy as np
 import numpy.random as np_random
 
+from arkouda.client import get_registration_config
 from arkouda.numpy.dtypes import _val_isinstance_of_union
 from arkouda.numpy.dtypes import dtype as akdtype
 from arkouda.numpy.dtypes import dtype as to_numpy_dtype
+from arkouda.numpy.dtypes import dtype_for_chapel
 from arkouda.numpy.dtypes import float64 as akfloat64
 from arkouda.numpy.dtypes import float_scalars
 from arkouda.numpy.dtypes import int64 as akint64
@@ -286,7 +288,7 @@ class Generator:
             high = high - 1
 
         shape, ndim, full_size = _infer_shape_from_size(size)
-        if full_size < 0:
+        if full_size <= 0:
             raise ValueError("The size parameter must be > 0")
 
         rep_msg = generic_msg(
@@ -931,6 +933,9 @@ class Generator:
         return create_pdarray(rep_msg)
 
 
+_supported_chapel_types = frozenset(("int", "int(64)", "uint", "uint(64)", "real", "real(64)", "bool"))
+
+
 def default_rng(seed=None):
     """
     Construct a new Generator.
@@ -967,7 +972,10 @@ def default_rng(seed=None):
     # we declare a generator for each type and fast-forward the state
 
     name_dict = dict()
-    for dt in akdtype("int64"), akdtype("uint64"), akdtype("float64"), akdtype("bool"):
+    for chapel_dt in get_registration_config()["parameter_classes"]["array"]["dtype"]:
+        if chapel_dt not in _supported_chapel_types:
+            continue
+        dt = dtype_for_chapel(chapel_dt)
         name_dict[dt] = generic_msg(
             cmd=f"createGenerator<{dt.name}>",
             args={"has_seed": has_seed, "seed": seed, "state": state},

--- a/src/CheckpointMsg.chpl
+++ b/src/CheckpointMsg.chpl
@@ -1,11 +1,12 @@
 module CheckpointMsg {
   use FileSystem;
-  use Types, List;
+  use List, Random;
   use ArkoudaJSONCompat;
   import IO, Path, Time;
   import Reflection.{getModuleName as M,
                      getRoutineName as R,
                      getLineNumber as L};
+  import Reflection.getNumFields;
 
   use ServerErrors, ServerConfig;
   import ServerDaemon.DefaultServerDaemon;
@@ -14,7 +15,7 @@ module CheckpointMsg {
   use ParquetMsg;
   use IOUtils;
   use Logging;
-  use BigInteger, CTypes, GMP;  // for checkpointing of bigint arrays
+  use BigInteger, CTypes, GMP, FileIO;  // for checkpointing of bigint arrays
 
   config param metadataExt = "md";
   config param dataExt = "data";
@@ -76,6 +77,7 @@ module CheckpointMsg {
 
 
   private param SymEntryType = SymbolEntryType.PrimitiveTypedArraySymEntry;
+  private param GenEntryType = SymbolEntryType.GeneratorSymEntry;
 
   private proc removeIt(path) throws do
     if isDir(path) then rmTree(path); else remove(path);
@@ -122,7 +124,7 @@ module CheckpointMsg {
       const mdName = Path.joinPath(cpPath, ".".join(name, metadataExt));
       var mdWriter = IO.open(mdName, ioMode.cw).writer(locking=false);
       writeJson(mdWriter, entryMD, "entry metadata", mdName);
-        
+
       // actual work is done here
       entry.saveEntry(name, cpPath, mdName, mdWriter);
     }
@@ -172,6 +174,8 @@ module CheckpointMsg {
       select entryMD.entryType {
         when SymEntryType:string do
           entry = loadSymEntry(mdName, entryMD, mdReader);
+        when GenEntryType:string do
+          entry = loadGenerator(mdName, entryMD, mdReader);
         otherwise do
           // we should be able to load everything we saved
           throw new NotImplementedError(cpNotImplementedMsg("Loading",
@@ -355,19 +359,24 @@ module CheckpointMsg {
                           name, this.entryType:string, mdName));
   }
 
-  private proc checkSymEntryType(entry: SymEntry(?), direction: string) {
-    if entry.entryType != SymEntryType then
-      cpLogger.error(M(), R(), L(), "unexpected SymEntry.entryType=",
-                     entry.entryType:string, ", expected: ", SymEntryType:string,
+  private proc checkEntryType(entry: borrowed AbstractSymEntry,
+                              expected: SymbolEntryType, direction: string) {
+    if entry.entryType != expected then
+      cpLogger.error(M(), R(), L(), "unexpected entry.entryType=",
+                     entry.entryType:string, ", expected: ", expected:string,
                      " when ", direction, " an entry with name:", entry.name);
   }
+
+  /******************************************************************/
+  /*** SymEntry / PrimitiveTypedArraySymEntry aka SymEntryType ***/
+  /******************************************************************/
 
   private proc hasPrimitiveElements(entry) param do
     return isIntegral(entry.etype) || isReal(entry.etype) || isBool(entry.etype);
 
   override proc SymEntry.saveEntry(name, path, mdName, mdWriter) throws {
     const entry = this;
-    checkSymEntryType(entry, "saving");
+    checkEntryType(entry, SymEntryType, "saving");
 
     // SymEntry.saveEntry() will be instantiated by the compiler for each
     // (etype, dimensions) combination that the program can create.
@@ -418,11 +427,11 @@ module CheckpointMsg {
       writeJson(mdWriter, chunkMD, "chunk metadata", mdName);
     }
 
-    cpLogger.debug(M(), R(), L(), "Metadata created: ", mdName);
+    cpLogger.debug(M(), R(), L(), "SymEntry metadata created in", mdName);
   }
 
-  private proc localeName(baseName, locIdx) do
-    return "".join(baseName, ".loc", locIdx:string, ".bin");
+  private proc localeName(baseName, locIdx) throws do
+    return generateFilename(baseName, ".bin", locIdx);
 
   private proc saveSymEntryBigint(entry, name, path, mdName, mdWriter) throws {
     // Metadata is similar to saveSymEntryPrimitive(), except no "chunks".
@@ -498,7 +507,7 @@ module CheckpointMsg {
     }
 
     cpLogger.debug(M(), R(), L(), "Data loaded %s".format(mdName));
-    checkSymEntryType(entryVal, "loading");
+    checkEntryType(entryVal, SymEntryType, "loading");
     return entryVal;
   }
 
@@ -530,6 +539,93 @@ module CheckpointMsg {
         bigintReadArray(localeName(baseName, locIdx),
                         entry.a.localSlice[entry.a.localSubdomain()]);
     }
+  }
+
+  /******************************************************************/
+  /*** GeneratorSymEntry aka GenEntryType ***/
+  /******************************************************************/
+
+  //
+  // This helper record is binary-serializable "out of the box".
+  // Cf. `randomStream` has a serializer so the compiler is "hands off"
+  // and does not create all the needed methods to de/serialize it properly.
+  // See https://github.com/chapel-lang/chapel/issues/27363
+  //
+  /* private */ record generatorSerializer
+  {
+    type rngsType;    // the type of randomStream.PCGRandomStreamPrivate_rngs
+    var state: int;
+    // fields of randomStream
+    var seed: int;
+    var rngs: rngsType;
+    var count: int(64);
+  }
+
+  private proc rngsTypeForEtype(type eltType) type {
+    var rs = new randomStream(eltType);
+    return rs.PCGRandomStreamPrivate_rngs.type;
+  }
+
+  private proc toSerializable(gen: GeneratorSymEntry(?)) {
+    const ref rs = gen.generator;
+
+    // A failure in the following asserts is a signal to update the code
+    // to changes in `randomStream` and/or `GeneratorSymEntry`.
+    // randomStream: eltType, seed, rngs, count
+    compilerAssert(getNumFields(rs.type) == 4);
+    // GeneratorSymEntry: etype, generator, state
+    compilerAssert(getNumFields(gen.type) == 3);
+
+    return new generatorSerializer(
+      rngsType = rngsTypeForEtype(rs.eltType),
+      state    = gen.state,
+      seed     = rs.seed,
+      rngs     = rs.PCGRandomStreamPrivate_rngs,
+      count    = rs.PCGRandomStreamPrivate_count);
+  }
+
+  override proc GeneratorSymEntry.saveEntry(name, path, mdName, mdWriter) throws {
+    const entry = this;
+    checkEntryType(entry, GenEntryType, "saving");
+    mdWriter.writeln(entry.etype:string);
+    const data = toSerializable(entry);
+    mdWriter.withSerializer(binarySerializer).write(data);
+    mdWriter.writeln();
+    cpLogger.debug(M(), R(), L(), "GeneratorSymEntry metadata and data created in", mdName);
+  }
+
+  // Is it OK to create a randomStream of this type?
+  private proc isOkGeneratorType(type etype) param do
+    return isNumericType(etype) || isBoolType(etype);
+
+  private proc loadGenerator(mdName, entryMD, mdReader) : shared AbstractSymEntry throws {
+    const etypeStr = mdReader.read(string);
+    mdReader.readThrough("\n");
+
+    for param eltyIdx in 0..arrayElementsTy.size-1 {
+      type etype = arrayElementsTy[eltyIdx];
+      if isOkGeneratorType(etype) &&
+         etypeStr == etype:string then
+        return loadHelperGen(mdName, entryMD, mdReader, arrayElementsTy[eltyIdx]);
+    }
+
+    throw new NotImplementedError(cpNotImplementedMsg(" ".join(
+      "Loading a generator with elements of type", etypeStr, "from"),
+      entryMD.entryName, entryMD.entryType, mdName), L(), R(), M());
+  }
+
+  private proc loadHelperGen(mdName, entryMD, mdReader, type etype) throws {
+    type deserType = generatorSerializer(rngsType = rngsTypeForEtype(etype));
+    const data = mdReader.withDeserializer(binaryDeserializer).read(deserType);
+    var rs = new randomStream(etype, data.seed);
+    rs.PCGRandomStreamPrivate_rngs = data.rngs;
+    rs.PCGRandomStreamPrivate_count = data.count;
+
+    const entryVal = new shared GeneratorSymEntry(rs, data.state);
+    entryVal.name = entryMD.entryName;
+    cpLogger.debug(M(), R(), L(), "Generator data loaded from ", mdName);
+    checkEntryType(entryVal, GenEntryType, "loading");
+    return entryVal;
   }
 
   /******************************************************************/

--- a/src/CheckpointMsg.chpl
+++ b/src/CheckpointMsg.chpl
@@ -1,12 +1,11 @@
 module CheckpointMsg {
   use FileSystem;
-  use List, Random;
+  use List;
   use ArkoudaJSONCompat;
   import IO, Path, Time;
   import Reflection.{getModuleName as M,
                      getRoutineName as R,
                      getLineNumber as L};
-  import Reflection.getNumFields;
 
   use ServerErrors, ServerConfig;
   import ServerDaemon.DefaultServerDaemon;
@@ -77,7 +76,6 @@ module CheckpointMsg {
 
 
   private param SymEntryType = SymbolEntryType.PrimitiveTypedArraySymEntry;
-  private param GenEntryType = SymbolEntryType.GeneratorSymEntry;
 
   private proc removeIt(path) throws do
     if isDir(path) then rmTree(path); else remove(path);
@@ -174,8 +172,6 @@ module CheckpointMsg {
       select entryMD.entryType {
         when SymEntryType:string do
           entry = loadSymEntry(mdName, entryMD, mdReader);
-        when GenEntryType:string do
-          entry = loadGenerator(mdName, entryMD, mdReader);
         otherwise do
           // we should be able to load everything we saved
           throw new NotImplementedError(cpNotImplementedMsg("Loading",
@@ -539,93 +535,6 @@ module CheckpointMsg {
         bigintReadArray(localeName(baseName, locIdx),
                         entry.a.localSlice[entry.a.localSubdomain()]);
     }
-  }
-
-  /******************************************************************/
-  /*** GeneratorSymEntry aka GenEntryType ***/
-  /******************************************************************/
-
-  //
-  // This helper record is binary-serializable "out of the box".
-  // Cf. `randomStream` has a serializer so the compiler is "hands off"
-  // and does not create all the needed methods to de/serialize it properly.
-  // See https://github.com/chapel-lang/chapel/issues/27363
-  //
-  /* private */ record generatorSerializer
-  {
-    type rngsType;    // the type of randomStream.PCGRandomStreamPrivate_rngs
-    var state: int;
-    // fields of randomStream
-    var seed: int;
-    var rngs: rngsType;
-    var count: int(64);
-  }
-
-  private proc rngsTypeForEtype(type eltType) type {
-    var rs = new randomStream(eltType);
-    return rs.PCGRandomStreamPrivate_rngs.type;
-  }
-
-  private proc toSerializable(gen: GeneratorSymEntry(?)) {
-    const ref rs = gen.generator;
-
-    // A failure in the following asserts is a signal to update the code
-    // to changes in `randomStream` and/or `GeneratorSymEntry`.
-    // randomStream: eltType, seed, rngs, count
-    compilerAssert(getNumFields(rs.type) == 4);
-    // GeneratorSymEntry: etype, generator, state
-    compilerAssert(getNumFields(gen.type) == 3);
-
-    return new generatorSerializer(
-      rngsType = rngsTypeForEtype(rs.eltType),
-      state    = gen.state,
-      seed     = rs.seed,
-      rngs     = rs.PCGRandomStreamPrivate_rngs,
-      count    = rs.PCGRandomStreamPrivate_count);
-  }
-
-  override proc GeneratorSymEntry.saveEntry(name, path, mdName, mdWriter) throws {
-    const entry = this;
-    checkEntryType(entry, GenEntryType, "saving");
-    mdWriter.writeln(entry.etype:string);
-    const data = toSerializable(entry);
-    mdWriter.withSerializer(binarySerializer).write(data);
-    mdWriter.writeln();
-    cpLogger.debug(M(), R(), L(), "GeneratorSymEntry metadata and data created in", mdName);
-  }
-
-  // Is it OK to create a randomStream of this type?
-  private proc isOkGeneratorType(type etype) param do
-    return isNumericType(etype) || isBoolType(etype);
-
-  private proc loadGenerator(mdName, entryMD, mdReader) : shared AbstractSymEntry throws {
-    const etypeStr = mdReader.read(string);
-    mdReader.readThrough("\n");
-
-    for param eltyIdx in 0..arrayElementsTy.size-1 {
-      type etype = arrayElementsTy[eltyIdx];
-      if isOkGeneratorType(etype) &&
-         etypeStr == etype:string then
-        return loadHelperGen(mdName, entryMD, mdReader, arrayElementsTy[eltyIdx]);
-    }
-
-    throw new NotImplementedError(cpNotImplementedMsg(" ".join(
-      "Loading a generator with elements of type", etypeStr, "from"),
-      entryMD.entryName, entryMD.entryType, mdName), L(), R(), M());
-  }
-
-  private proc loadHelperGen(mdName, entryMD, mdReader, type etype) throws {
-    type deserType = generatorSerializer(rngsType = rngsTypeForEtype(etype));
-    const data = mdReader.withDeserializer(binaryDeserializer).read(deserType);
-    var rs = new randomStream(etype, data.seed);
-    rs.PCGRandomStreamPrivate_rngs = data.rngs;
-    rs.PCGRandomStreamPrivate_count = data.count;
-
-    const entryVal = new shared GeneratorSymEntry(rs, data.state);
-    entryVal.name = entryMD.entryName;
-    cpLogger.debug(M(), R(), L(), "Generator data loaded from ", mdName);
-    checkEntryType(entryVal, GenEntryType, "loading");
-    return entryVal;
   }
 
   /******************************************************************/

--- a/src/registry/register_commands.py
+++ b/src/registry/register_commands.py
@@ -1358,6 +1358,7 @@ def make_reg_config_module(config):
     elts_ty = " ".join(f"{dim}," for dim in arr_elts)
 
     stamps = [
+        "// ./doc-support.chpl is used instead when generating docs for this module\n"
         "module RegistrationConfig {",
         "use BigInteger;",
         watermarkConfig(config),

--- a/tests/accessor_test.py
+++ b/tests/accessor_test.py
@@ -119,7 +119,7 @@ class TestDatetimeAccessor:
             values = "not_datetime"
 
         series = MockSeries()
-        with pytest.raises(AttributeError, match="Can only use \.dt accessor with datetimelike values"):
+        with pytest.raises(AttributeError, match="Can only use \\.dt accessor with datetimelike values"):
             DatetimeAccessor(series)
 
     def test_4524_datetime_reproduer(self):
@@ -151,5 +151,5 @@ class TestStringAccessor:
             values = "not_categorical_or_strings"
 
         series = MockSeries()
-        with pytest.raises(AttributeError, match="Can only use \.str accessor with string like values"):
+        with pytest.raises(AttributeError, match="Can only use \\.str accessor with string like values"):
             StringAccessor(series)

--- a/tests/checkpoint_test.py
+++ b/tests/checkpoint_test.py
@@ -5,7 +5,6 @@ from os import path
 from shutil import rmtree
 import tempfile
 
-import numpy as np
 import pytest
 
 import arkouda as ak
@@ -120,36 +119,6 @@ class TestCheckpoint:
 
             assert arr[3] == 0
             assert arr[2] == 2
-
-    @pytest.mark.skip_if_max_rank_greater_than(1)
-    @pytest.mark.parametrize("prob_size", pytest.prob_size)
-    def test_generators(self, cp_test_base_tmp, prob_size):
-        with tempfile.TemporaryDirectory(dir=cp_test_base_tmp) as tmp_dirname:
-            cp_name = "generators"
-            g1 = ak.numpy.random.default_rng()  # unspecified seed
-            g2 = ak.numpy.random.default_rng(314)  # specified seed
-
-            # We use numpy arrays so they are preserved across checkpointing.
-            # Note that we are testing checkpointing of g1 and g2, not arrays.
-            def rand(g):
-                return g.integers(1, 9, prob_size).to_ndarray()
-
-            rand(g1), rand(g2)  # advance the generators from the initial state
-            ak.save_checkpoint(path=tmp_dirname, name=cp_name)
-
-            i1np = rand(g1)
-            i2np = rand(g2)
-
-            # expect a generator to produce different set of numbers next
-            assert not np.array_equal(i1np, rand(g1))
-            assert not np.array_equal(i2np, rand(g2))
-
-            ak.load_checkpoint(path=tmp_dirname, name=cp_name)
-            # expect generators unwound back to the starting points for i1np, i2np
-            # These currently fail because g1,g2._state are not unwound, see:
-            #   https://github.com/Bears-R-Us/arkouda/issues/4709
-            # assert np.array_equal(i1np, rand(g1))
-            # assert np.array_equal(i2np, rand(g2))
 
     @pytest.mark.skip_if_max_rank_greater_than(1)
     def test_incorrect_nl(self):

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -115,6 +115,18 @@ class TestClient:
 
         assert get_server_max_array_dims() == ak.client.get_max_array_rank()
 
+    def test_client_get_registration_config(self):
+        """
+        Tests that we can call ak.client.get_registration_config()
+        and that the returned result matches the contents of "registration-config.json".
+        """
+        from_server = ak.client.get_registration_config()
+
+        import json
+
+        from_file = json.load(open("registration-config.json", "r"))
+        assert from_server == from_file
+
     def test_get_mem_used(self):
         """
         Tests the ak.get_mem_used and ak.get_mem_avail methods
@@ -175,8 +187,7 @@ class TestClient:
         assert isinstance(availableRanks, list)
         assert len(availableRanks) >= 1
         assert 1 in availableRanks
-        assert ak.client.get_max_array_rank() in availableRanks
-        assert ak.client.get_max_array_rank() + 1 not in availableRanks
+        assert ak.client.get_max_array_rank() == max(availableRanks)
 
     def test_no_op(self):
         """

--- a/tests/numpy/dtypes_test.py
+++ b/tests/numpy/dtypes_test.py
@@ -236,6 +236,34 @@ class TestDTypes:
         assert "{:d}" == dtypes.NUMBER_FORMAT_STRINGS["uint64"]
         assert "{:d}" == dtypes.NUMBER_FORMAT_STRINGS["bigint"]
 
+    def test_dtype_for_chapel(self):
+        dtypes_for_chapel = {  # see DType
+            "real": "float64",
+            "real(32)": "float32",
+            "real(64)": "float64",
+            "complex": "complex128",
+            "complex(64)": "complex64",
+            "complex(128)": "complex128",
+            "int": "int64",
+            "int(8)": "int8",
+            "int(16)": "int16",
+            "int(32)": "int32",
+            "int(64)": "int64",
+            "uint": "uint64",
+            "uint(8)": "uint8",
+            "uint(16)": "uint16",
+            "uint(32)": "uint32",
+            "uint(64)": "uint64",
+            "bool": "bool",
+            "bigint": "bigint",
+            "string": "str",
+        }
+        for chapel_name, dtype_name in dtypes_for_chapel.items():
+            assert dtypes.dtype_for_chapel(chapel_name) == dtypes.dtype(dtype_name)
+        # check caching in the implementation of dtype_for_chapel()
+        for chapel_name, dtype_name in dtypes_for_chapel.items():
+            assert dtypes.dtype_for_chapel(chapel_name) == dtypes.dtype(dtype_name)
+
     @pytest.mark.parametrize("dtype1", [ak.bool_, ak.uint8, ak.uint64, ak.bigint, ak.int64, ak.float64])
     @pytest.mark.parametrize("dtype2", [ak.bool_, ak.uint8, ak.uint64, ak.bigint, ak.int64, ak.float64])
     def test_result_type(self, dtype1, dtype2):


### PR DESCRIPTION
* Add `ak.get_registration_config()`.
* Populate a Generator in the client with GeneratorSymEntry instances on the server only for those types that are requested in `registration-config.json`.
* Minor code improvements I did while working on the following.

While there, redirected the file naming for bigint checkpoint data to the standard-ish `generateFilename()`.

This PR initially added checkpointing of `GeneratorSymEntry`. However during testing I realized that, while checkpointing per se works, restoring from a checkpoint does not "roll back" Arkouda properly. This is because part of the Generator state, specifically its `state` field, is stored in the client and not on the server. Therefore backed out this checkpointing addition in the second commit in this PR.

See #4709 for discussion on this.