### PR TITLE
Closes #4372: Doc duplication issue for Reorged modules

### DIFF
--- a/pydoc/conf.py
+++ b/pydoc/conf.py
@@ -106,6 +106,20 @@ autoapi_ignore = [
     "*arkouda/strings/*",
     "*arkouda/timeclass/*",
     "*arkouda/util/*",
+    #   Prevent faux module from generating duplicate docs
+    "*arkouda/categorical/*",
+    "*arkouda/dataframe/*",
+    "*arkouda/groupbyclass/*",
+    "*arkouda/index/*",
+    "*arkouda/io/*",
+    "*arkouda/io_util/*",
+    "*arkouda/join/*",
+    "*arkouda/match/*",
+    "*arkouda/matcher/*",
+    "*arkouda/row/*",
+    "*arkouda/series/*",
+    "*arkouda/sparrayclass/*",
+    "*arkouda/sparsematrix/*",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/pydoc/preprocess/generate_import_stubs.py
+++ b/pydoc/preprocess/generate_import_stubs.py
@@ -149,8 +149,9 @@ def main():
     import arkouda.numpy as aknp
     import arkouda.pandas.dataframe as akDataframe
     import arkouda.pandas.groupbyclass as akGroupbyclass
-    import arkouda.pandas.series as akSeries
     import arkouda.scipy as akscipy
+    import arkouda.scipy.sparrayclass as akscipySparrayclass
+    import arkouda.scipy.sparsematrix as akscipySparsematrix
     import arkouda.scipy.special as akscipySpecial
     import arkouda.scipy.stats as akscipyStats
 
@@ -163,9 +164,10 @@ def main():
     write_stub(akscipy, "arkouda/scipy.pyi", all_only=True, allow_arkouda=True)
     write_stub(akscipyStats, "arkouda/scipy/stats.pyi", all_only=True, allow_arkouda=True)
     write_stub(akscipySpecial, "arkouda/scipy/special.pyi", all_only=True, allow_arkouda=True)
+    write_stub(akscipySparrayclass, "arkouda/scipy/sparrayclass.pyi", all_only=True, allow_arkouda=True)
+    write_stub(akscipySparsematrix, "arkouda/scipy/sparsematrix.pyi", all_only=True, allow_arkouda=True)
     write_stub(akDataframe, "arkouda/pandas/dataframe.pyi", all_only=True, allow_arkouda=True)
     write_stub(akGroupbyclass, "arkouda/pandas/groupbyclass.pyi", all_only=True, allow_arkouda=True)
-    write_stub(akSeries, "arkouda/series.pyi", all_only=True, allow_arkouda=True)
     write_stub(
         aknp.pdarrayclass,
         "arkouda/numpy/pdarrayclass.pyi",


### PR DESCRIPTION
This PR (Closes [#4372](https://github.com/Bears-R-Us/arkouda/issues/4372)) removed the duplicated modules that are generated twice in the docs after the reorg. They now generate correctly and only once in their designated modules.