### PR TITLE
Part 1 of #2528  numeric_scalars in type hint disables our typechecking

### DIFF
--- a/arkouda/accessor.py
+++ b/arkouda/accessor.py
@@ -50,9 +50,15 @@ Users should not instantiate accessors directly — use `.str` and `.dt` instead
 
 """
 
+from typing import TYPE_CHECKING, TypeVar
+
 from arkouda.numpy.strings import Strings
 from arkouda.numpy.timeclass import Datetime
-from arkouda.pandas.categorical import Categorical
+
+if TYPE_CHECKING:
+    from arkouda.categorical import Categorical
+else:
+    Categorical = TypeVar("Categorical")
 
 __all__ = [
     "CachedAccessor",

--- a/arkouda/alignment.py
+++ b/arkouda/alignment.py
@@ -43,7 +43,7 @@ array([100 200 200])
 """
 
 import functools
-from typing import Sequence
+from typing import TYPE_CHECKING, Sequence, TypeVar
 from warnings import warn
 
 import numpy as np
@@ -57,8 +57,14 @@ from arkouda.numpy.pdarraycreation import arange, full, ones, zeros
 from arkouda.numpy.pdarraysetops import concatenate, in1d
 from arkouda.numpy.sorting import argsort, coargsort
 from arkouda.numpy.strings import Strings
-from arkouda.pandas.categorical import Categorical
 from arkouda.pandas.groupbyclass import GroupBy, broadcast, unique
+
+if TYPE_CHECKING:
+    from arkouda.categorical import Categorical
+
+else:
+    Categorical = TypeVar("Categorical")
+
 
 __all__ = [
     "NonUniqueError",
@@ -297,6 +303,8 @@ def find(query, space, all_occurrences=False, remove_missing=False):
     """
     from arkouda.client import generic_msg
     from arkouda.numpy import cumsum, where
+    from arkouda.numpy.strings import Strings
+    from arkouda.pandas.categorical import Categorical
 
     # Concatenate the space and query in fast (block interleaved) mode
     if isinstance(query, (pdarray, Strings, Categorical)):
@@ -421,12 +429,14 @@ def lookup(keys, values, arguments, fillvalue=-1):
     >>> revkeys = values
     >>> revindices = ak.arange(values.size)
     >>> revargs = ak.array([24, 21, 22])
-    >>> idx = ak.lookup(revkeys, revindices, revargs)
-    >>> keys1[idx], keys2[idx]
+    >>> indx = ak.lookup(revkeys, revindices, revargs)
+    >>> keys1[indx], keys2[indx]
     (array(['twenty', 'twenty', 'twenty']),
     array(['four', 'one', 'two']))
 
     """
+    from arkouda.pandas.categorical import Categorical
+
     if isinstance(values, Categorical):
         codes = lookup(keys, values.codes, arguments, fillvalue=values._NAcode)
         return Categorical.from_codes(codes, values.categories, NAvalue=values.NAvalue)
@@ -840,6 +850,8 @@ def interval_lookup(keys, values, arguments, fillvalue=-1, tiebreak=None, hierar
         in any interval.
 
     """
+    from arkouda.categorical import Categorical
+
     if isinstance(values, Categorical):
         codes = interval_lookup(keys, values.codes, arguments, fillvalue=values._NAcode)
         return Categorical.from_codes(codes, values.categories, NAvalue=values.NAvalue)

--- a/arkouda/array_api/array_object.py
+++ b/arkouda/array_api/array_object.py
@@ -364,7 +364,7 @@ class Array:
         ak.abs()
 
         """
-        return ak.abs(self._array)
+        return Array._new(ak.abs(self._array))
 
     def __add__(self: Array, other: Union[int, float, Array], /) -> Array:
         """

--- a/arkouda/array_api/creation_functions.py
+++ b/arkouda/array_api/creation_functions.py
@@ -78,18 +78,15 @@ def asarray(
 
     if isinstance(obj, ak.pdarray):
         return Array._new(obj)
-    elif (
-        isinstance(obj, bool)
-        or isinstance(obj, int)
-        or isinstance(obj, float)
-        or isinstance(obj, complex)
-    ):
+    elif isinstance(obj, (bool, int, float)):
         if dtype is None:
             xdtype = akdtype(resolve_scalar_dtype(obj))
         else:
             xdtype = akdtype(dtype)
         res = ak.full(1, obj, xdtype)
         return Array._new(res)
+    elif isinstance(obj, complex):
+        raise TypeError("complex dtype is not supported in Arkouda Arrays")
     elif isinstance(obj, Array):
         return Array._new(ak.array(obj._array))
     elif isinstance(obj, ak.pdarray):

--- a/arkouda/array_api/searching_functions.py
+++ b/arkouda/array_api/searching_functions.py
@@ -92,6 +92,7 @@ def where(condition: Array, x1: Array, x2: Array, /) -> Array:
     from arkouda.client import generic_msg
 
     broadcasted = broadcast_arrays(condition, x1, x2)
+    assert isinstance(broadcasted, list) and all(isinstance(arg, Array) for arg in broadcasted)
 
     a = broadcasted[1]._array
     b = broadcasted[2]._array

--- a/arkouda/array_api/statistical_functions.py
+++ b/arkouda/array_api/statistical_functions.py
@@ -176,17 +176,17 @@ def prod(
     keepdims : bool, optional
         Whether to keep the singleton dimension(s) along `axis` in the result.
     """
+    from arkouda import prod as ak_prod
+    from arkouda.numpy import pdarray
+
     if x.dtype not in _numeric_dtypes:
         raise TypeError("Only numeric dtypes are allowed in prod")
 
-    # cast to the appropriate dtype if necessary
     cast_to = _prod_sum_dtype(x.dtype) if dtype is None else dtype
-    if cast_to != x.dtype:
-        x_op = akcast(x._array, cast_to)
-    else:
-        x_op = x._array
+    x_op = akcast(x._array, cast_to) if cast_to != x.dtype else x._array
 
-    from arkouda import prod as ak_prod
+    if not isinstance(x_op, pdarray):
+        raise TypeError(f"Expected pdarray, got {type(x_op)}")
 
     return Array._new(ak_prod(x_op, axis=axis, keepdims=keepdims))
 
@@ -271,17 +271,17 @@ def sum(
     keepdims : bool, optional
         Whether to keep the singleton dimension(s) along `axis` in the result.
     """
+    from arkouda import sum as ak_sum
+    from arkouda.numpy import pdarray
+
     if x.dtype not in _numeric_dtypes:
         raise TypeError("Only numeric dtypes are allowed in sum")
 
-    # cast to the appropriate dtype if necessary
     cast_to = _prod_sum_dtype(x.dtype) if dtype is None else dtype
-    if cast_to != x.dtype:
-        x_op = akcast(x._array, cast_to)
-    else:
-        x_op = x._array
+    x_op = akcast(x._array, cast_to) if cast_to != x.dtype else x._array
 
-    from arkouda import sum as ak_sum
+    if not isinstance(x_op, pdarray):
+        raise TypeError(f"Expected pdarray, got {type(x_op)}")
 
     return Array._new(ak_sum(x_op, axis=axis, keepdims=keepdims))
 
@@ -385,7 +385,7 @@ def cumulative_sum(
     if dtype is None:
         x_ = x
     else:
-        x_ = akcast(x, dtype)
+        x_ = Array(akcast(x._array, dtype))
 
     resp = generic_msg(
         cmd=f"cumSum<{x_.dtype},{x.ndim}>",

--- a/arkouda/numpy/numeric.py
+++ b/arkouda/numpy/numeric.py
@@ -2560,7 +2560,7 @@ def median(pda: pdarray) -> np.float64:
         )
 
 
-def count_nonzero(pda: pdarray) -> np.int64:
+def count_nonzero(pda: pdarray) -> int_scalars:
     """
     Compute the nonzero count of a given array. 1D case only, for now.
 
@@ -2571,7 +2571,7 @@ def count_nonzero(pda: pdarray) -> np.int64:
 
     Returns
     -------
-    np.int64
+    int_scalars
         The nonzero count of the entire pdarray
 
     Raises
@@ -2928,7 +2928,7 @@ def tril(pda: pdarray, diag: int_scalars = 0) -> pdarray:
 
 
 @typechecked
-def transpose(pda: pdarray, axes: Optional[Tuple[int, ...]] = None) -> pdarray:
+def transpose(pda: pdarray, axes: Optional[Tuple[int_scalars, ...]] = None) -> pdarray:
     """
     Compute the transpose of a matrix.
 
@@ -2969,10 +2969,10 @@ def transpose(pda: pdarray, axes: Optional[Tuple[int, ...]] = None) -> pdarray:
 
     if axes is not None:  # if axes was supplied, check that it's valid
         r = tuple(np.arange(pda.ndim))
-        if not (np.sort(axes) == r).all():
+        if not (np.sort(np.array(axes)) == r).all():
             raise ValueError(f"{axes} is not a valid set of axes for pdarray of rank {pda.ndim}")
     else:  # if axes is None, create a tuple of the axes in reverse order
-        axes = tuple(((pda.ndim - 1) - np.arange(pda.ndim)))
+        axes = tuple(reversed(range(pda.ndim)))
 
     return create_pdarray(
         generic_msg(

--- a/arkouda/numpy/pdarrayclass.py
+++ b/arkouda/numpy/pdarrayclass.py
@@ -1488,7 +1488,7 @@ class pdarray:
         return self.size * self.dtype.itemsize
 
     @typechecked
-    def fill(self, value: numeric_scalars) -> None:
+    def fill(self, value: Union[numeric_scalars, bool_scalars]) -> None:
         """
         Fill the array (in place) with a constant value.
 
@@ -3173,7 +3173,7 @@ class pdarray:
 #       all values have been checked by python module and...
 #       server has created pdarray already before this is called
 @typechecked
-def create_pdarray(repMsg: str, max_bits=None) -> pdarray:
+def create_pdarray(repMsg: Union[str, memoryview], max_bits=None) -> pdarray:
     """
     Return a pdarray instance pointing to an array created by the arkouda server.
     The user should not call this function directly.
@@ -3198,6 +3198,9 @@ def create_pdarray(repMsg: str, max_bits=None) -> pdarray:
         Raised if a server-side error is thrown in the process of creating
         the pdarray instance
     """
+    if isinstance(repMsg, memoryview):
+        repMsg = repMsg.tobytes().decode()
+
     try:
         fields = repMsg.split()
         name = fields[1]
@@ -3284,7 +3287,7 @@ def _make_reduction_func(
         pda: pdarray,
         axis: Optional[Union[int_scalars, Tuple[int_scalars, ...]]] = None,
         keepdims: bool = False,
-    ) -> Union[numeric_scalars, pdarray]:
+    ) -> Union[numeric_scalars, np.bool_, pdarray]:
         return _common_reduction(op, pda, axis, keepdims=keepdims)
 
     op_func.__doc__ = f"""
@@ -3438,7 +3441,7 @@ def _common_reduction(
     pda: pdarray,
     axis: Optional[Union[int_scalars, Tuple[int_scalars, ...], None]] = None,
     keepdims: bool = False,
-) -> Union[numeric_scalars, pdarray]:
+) -> Union[numeric_scalars, np.bool_, pdarray]:
     """
     Return reduction of a pdarray by an operation along an axis.
 
@@ -3845,9 +3848,9 @@ def _compute_dot_result_shape(s1, s2):
 
 @typechecked
 def dot(
-    pda1: Union[np.int64, np.float64, np.uint64, pdarray],
-    pda2: Union[np.int64, np.float64, np.uint64, pdarray],
-) -> Union[numeric_scalars, pdarray]:
+    pda1: Union[int, np.int64, np.float64, np.uint64, pdarray],
+    pda2: Union[int, np.int64, np.float64, np.uint64, pdarray],
+) -> Union[numeric_scalars, np.bool, pdarray]:
     """
     Computes dot product of two arrays.
 

--- a/arkouda/numpy/pdarraycreation.py
+++ b/arkouda/numpy/pdarraycreation.py
@@ -22,6 +22,7 @@ from arkouda.numpy.dtypes import (
     NumericDTypes,
     SeriesDTypes,
     bigint,
+    bool_scalars,
 )
 from arkouda.numpy.dtypes import (
     int_scalars,
@@ -681,8 +682,8 @@ def ones(
 @typechecked
 def full(
     size: Union[int_scalars, Tuple[int_scalars, ...], str],
-    fill_value: Union[numeric_scalars, str],
-    dtype: Optional[Union[np.dtype, type, str, bigint]] = None,
+    fill_value: Union[numeric_scalars, np.bool, str],
+    dtype: Union[np.dtype, type, str, bigint] = float64,
     max_bits: Optional[int] = None,
 ) -> Union[pdarray, Strings]:
     """
@@ -772,7 +773,8 @@ def full(
 
 @typechecked
 def scalar_array(
-    value: numeric_scalars, dtype: Optional[Union[np.dtype, type, str, bigint]] = None
+    value: Union[numeric_scalars, bool_scalars],
+    dtype: Optional[Union[np.dtype, type, str, bigint]] = None,
 ) -> pdarray:
     """
     Create a pdarray from a single scalar value.
@@ -781,6 +783,8 @@ def scalar_array(
     ----------
     value: numeric_scalars
         Value to create pdarray from
+    dtype: np.dtype, type, str, bigint, or None
+        The data type of the created array.
 
     Returns
     -------

--- a/arkouda/numpy/sorting.py
+++ b/arkouda/numpy/sorting.py
@@ -169,6 +169,7 @@ def coargsort(
         value=arrays,
         expected_type=Sequence[Union[pdarray, Strings, Categorical]],
     )
+
     size: int_scalars = -1
     anames, atypes, expanded_arrays = [], [], []
     max_dim = 1

--- a/arkouda/numpy/util.py
+++ b/arkouda/numpy/util.py
@@ -22,7 +22,6 @@ from arkouda.numpy.pdarraysetops import unique
 from arkouda.numpy.sorting import coargsort
 from arkouda.numpy.strings import Strings
 from arkouda.numpy.timeclass import Datetime, Timedelta
-from arkouda.pandas.categorical import Categorical
 from arkouda.pandas.groupbyclass import GroupBy
 
 __all__ = [
@@ -51,11 +50,10 @@ __all__ = [
 
 
 if TYPE_CHECKING:
+    from arkouda.categorical import Categorical
     from arkouda.client import generic_msg, get_config, get_mem_used
-    from arkouda.numpy.segarray import SegArray
     from arkouda.pandas.index import Index
     from arkouda.pandas.series import Series
-
 else:
     Index = TypeVar("Index")
     Series = TypeVar("Series")
@@ -63,6 +61,7 @@ else:
     generic_msg = TypeVar("generic_msg")
     get_config = TypeVar("get_config")
     get_mem_used = TypeVar("get_mem_used")
+    Categorical = TypeVar("Categorical")
 
 
 def identity(x):
@@ -180,6 +179,8 @@ def convert_if_categorical(values):
     >>> print(result)
     [1 2 3]
     """
+    from arkouda.pandas.categorical import Categorical
+
     if isinstance(values, Categorical):
         values = values.categories[values.codes]
     return values
@@ -272,6 +273,7 @@ def attach(name: str):
     from arkouda.client import generic_msg
     from arkouda.numpy.pdarrayclass import pdarray
     from arkouda.numpy.segarray import SegArray
+    from arkouda.pandas.categorical import Categorical
     from arkouda.pandas.dataframe import DataFrame
     from arkouda.pandas.index import Index, MultiIndex
     from arkouda.pandas.series import Series
@@ -838,6 +840,7 @@ def map(
 
     from arkouda import Series, array, broadcast, full
     from arkouda.numpy.pdarraysetops import in1d
+    from arkouda.pandas.categorical import Categorical
 
     keys = values
     gb = GroupBy(keys, dropna=False)

--- a/arkouda/pandas/dataframe.py
+++ b/arkouda/pandas/dataframe.py
@@ -83,12 +83,12 @@ from arkouda.numpy.sorting import argsort, coargsort
 from arkouda.numpy.sorting import sort as aksort
 from arkouda.numpy.strings import Strings
 from arkouda.numpy.timeclass import Datetime, Timedelta
-from arkouda.pandas.categorical import Categorical
 from arkouda.pandas.groupbyclass import GROUPBY_REDUCTION_TYPES, GroupBy, unique
 from arkouda.pandas.join import inner_join
 from arkouda.pandas.row import Row
 
 if TYPE_CHECKING:
+    from arkouda.categorical import Categorical
     from arkouda.numpy import cast as akcast
     from arkouda.numpy import cumsum, where
     from arkouda.numpy.segarray import SegArray
@@ -99,6 +99,8 @@ else:
     akcast = TypeVar("akcast")
     cumsum = TypeVar("cumsum")
     where = TypeVar("where")
+    Categorical = TypeVar("Categorical")
+
 
 # This is necessary for displaying DataFrames with BitVector columns,
 # because pandas _html_repr automatically truncates the number of displayed bits
@@ -798,8 +800,6 @@ class DataFrame(UserDict):
 
     """
 
-    _COLUMN_CLASSES = (pdarray, Strings, Categorical, SegArray)
-
     objType = "DataFrame"
 
     def __init__(self, initialdata=None, index=None, columns=None):
@@ -807,6 +807,7 @@ class DataFrame(UserDict):
         self.registered_name = None
 
         from arkouda.numpy.segarray import SegArray
+        from arkouda.pandas.categorical import Categorical
 
         self._COLUMN_CLASSES = (pdarray, Strings, Categorical, SegArray)
 
@@ -1176,6 +1177,8 @@ class DataFrame(UserDict):
         return "DataFrame([" + keystr + "], {:,}".format(self._nrows) + rows + ", " + str(mem) + ")"
 
     def _get_head_tail(self):
+        from arkouda.pandas.categorical import Categorical
+
         if self._empty:
             return pd.DataFrame()
         self.update_nrows()
@@ -1205,6 +1208,7 @@ class DataFrame(UserDict):
     def _get_head_tail_server(self):
         from arkouda.client import generic_msg
         from arkouda.numpy.segarray import SegArray
+        from arkouda.pandas.categorical import Categorical
 
         if self._empty:
             return pd.DataFrame()
@@ -1655,6 +1659,7 @@ class DataFrame(UserDict):
 
         """
         from arkouda.numpy.segarray import SegArray
+        from arkouda.pandas.categorical import Categorical
 
         dtypes = []
         keys = []
@@ -2631,6 +2636,7 @@ class DataFrame(UserDict):
 
         """
         from arkouda.numpy.segarray import SegArray
+        from arkouda.pandas.categorical import Categorical
 
         # Estimate how much memory would be required for this DataFrame
         nbytes = 0
@@ -3023,6 +3029,7 @@ class DataFrame(UserDict):
         1  4  2 (2 rows x 2 columns)
 
         """
+        from arkouda.pandas.categorical import Categorical
         from arkouda.pandas.io import to_parquet
 
         data = self._prep_data(index=index, columns=columns)
@@ -3955,6 +3962,7 @@ class DataFrame(UserDict):
         col2  -1.0   1.0 (2 rows x 2 columns)
 
         """
+        from arkouda.pandas.categorical import Categorical
 
         def numeric_help(d):
             if isinstance(d, Strings):
@@ -5146,6 +5154,8 @@ def _inner_join_merge(
         Inner-Joined Arkouda DataFrame
 
     """
+    from arkouda.pandas.categorical import Categorical
+
     left_cols, right_cols = left.columns.values.copy(), right.columns.values.copy()
     col_intersect_ = col_intersect.copy() if isinstance(col_intersect, list) else [col_intersect[:]]
     left_on_ = [left_on] if isinstance(left_on, str) else left_on
@@ -5424,6 +5434,8 @@ def __nulls_like(
         ]
     ] = None,
 ):
+    from arkouda.pandas.categorical import Categorical
+
     if size is None:
         size = arry.size
 
@@ -5556,6 +5568,8 @@ def merge(
     6     8     NaN     8.0 (7 rows x 3 columns)
 
     """
+    from arkouda.pandas.categorical import Categorical
+
     col_intersect = list(set(left.columns) & set(right.columns))
     on = on if on is not None else col_intersect
     if left_on is None and right_on is None:

--- a/arkouda/pandas/index.py
+++ b/arkouda/pandas/index.py
@@ -77,7 +77,6 @@ from arkouda.numpy.pdarraysetops import argsort, in1d
 from arkouda.numpy.sorting import coargsort
 from arkouda.numpy.strings import Strings
 from arkouda.numpy.util import convert_if_categorical, generic_concat, get_callback
-from arkouda.pandas.categorical import Categorical
 from arkouda.pandas.groupbyclass import GroupBy, unique
 
 __all__ = [
@@ -85,12 +84,14 @@ __all__ = [
     "MultiIndex",
 ]
 
-
 if TYPE_CHECKING:
-    from arkouda.numpy import cast as akcast
+    from arkouda import cast as akcast
+    from arkouda.categorical import Categorical
     from arkouda.pandas.series import Series
 else:
+    Series = TypeVar("Series")
     akcast = TypeVar("akcast")
+    Categorical = TypeVar("Categorical")
 
 
 class Index:
@@ -144,6 +145,7 @@ class Index:
 
         """
         from arkouda.numpy.dtypes import dtype as ak_dtype
+        from arkouda.pandas.categorical import Categorical
 
         if isinstance(self.values, List):
             # Infer dtype from first element
@@ -163,6 +165,8 @@ class Index:
         allow_list=False,
         max_list_size=1000,
     ):
+        from arkouda.pandas.categorical import Categorical
+
         self.max_list_size = max_list_size
         self.registered_name: Optional[str] = None
 
@@ -483,6 +487,8 @@ class Index:
             The reconstructed Index or MultiIndex instance.
 
         """
+        from arkouda.pandas.categorical import Categorical
+
         data = json.loads(rep_msg)
 
         idx = []
@@ -598,6 +604,8 @@ class Index:
 
     def to_pandas(self):
         """Return the equivalent Pandas Index."""
+        from arkouda.pandas.categorical import Categorical
+
         if isinstance(self.values, list):
             val = ndarray(self.values)
         elif isinstance(self.values, Categorical):
@@ -684,6 +692,8 @@ class Index:
         they are unregistered.
 
         """
+        from arkouda.pandas.categorical import Categorical
+
         if isinstance(self.values, list):
             raise TypeError("Index cannot be registered when values are list type.")
 
@@ -785,6 +795,7 @@ class Index:
 
         """
         from arkouda.numpy.util import is_registered
+        from arkouda.pandas.categorical import Categorical
 
         if self.registered_name is None:
             if not isinstance(self.values, Categorical):
@@ -1402,6 +1413,8 @@ class MultiIndex(Index):
         name: Optional[str] = None,
         names: Optional[list[str]] = None,
     ):
+        from arkouda.pandas.categorical import Categorical
+
         self.registered_name: Optional[str] = None
         if isinstance(data, MultiIndex):
             self.levels = data.levels
@@ -1695,6 +1708,8 @@ class MultiIndex(Index):
         while others are converted to NumPy arrays.
 
         """
+        from arkouda.pandas.categorical import Categorical
+
         mi = pd.MultiIndex.from_arrays(
             [i.to_pandas() if isinstance(i, Categorical) else i.to_ndarray() for i in self.index],
             names=self.names,
@@ -1775,6 +1790,7 @@ class MultiIndex(Index):
 
         """
         from arkouda.client import generic_msg
+        from arkouda.pandas.categorical import Categorical
 
         if self.registered_name is not None and self.is_registered():
             raise RegistrationError(f"This object is already registered as {self.registered_name}")

--- a/arkouda/pandas/io.py
+++ b/arkouda/pandas/io.py
@@ -1844,7 +1844,9 @@ def load_all(
     file_format: str = "INFER",
     column_delim: str = ",",
     read_nested: bool = True,
-) -> Mapping[str, Union[pdarray, Strings, SegArray, Categorical]]:
+) -> Mapping[
+    str, pdarray | Strings | SegArray | Categorical | DataFrame | IPv4 | Datetime | Timedelta | Index
+]:
     """
     Load multiple pdarrays, Strings, SegArrays, or Categoricals previously saved with ``save_all()``.
 

--- a/arkouda/pandas/join.py
+++ b/arkouda/pandas/join.py
@@ -20,7 +20,6 @@ from arkouda.numpy.pdarrayclass import create_pdarray, pdarray
 from arkouda.numpy.pdarraycreation import arange, array, ones, zeros
 from arkouda.numpy.pdarraysetops import concatenate, in1d
 from arkouda.numpy.strings import Strings
-from arkouda.pandas.categorical import Categorical
 from arkouda.pandas.groupbyclass import GroupBy, broadcast
 
 if TYPE_CHECKING:
@@ -29,6 +28,13 @@ if TYPE_CHECKING:
 else:
     generic_msg = TypeVar("generic_msg")
     cumsum = TypeVar("cumsum")
+
+
+if TYPE_CHECKING:
+    from arkouda.categorical import Categorical
+
+else:
+    Categorical = TypeVar("Categorical")
 
 __all__ = ["join_on_eq_with_dt", "gen_ranges", "compute_join_size"]
 
@@ -257,6 +263,7 @@ def inner_join(
     from inspect import signature
 
     from arkouda.numpy import cumsum
+    from arkouda.pandas.categorical import Categorical
 
     is_sequence = isinstance(left, Sequence) and isinstance(right, Sequence)
 

--- a/arkouda/pandas/series.py
+++ b/arkouda/pandas/series.py
@@ -24,20 +24,21 @@ from arkouda.numpy.pdarraycreation import arange, array, full, zeros
 from arkouda.numpy.pdarraysetops import argsort, concatenate, in1d, indexof1d
 from arkouda.numpy.strings import Strings
 from arkouda.numpy.util import get_callback, is_float
-from arkouda.pandas.categorical import Categorical
 import arkouda.pandas.dataframe
 from arkouda.pandas.groupbyclass import GroupBy, groupable_element_type
 from arkouda.pandas.index import Index, MultiIndex
 
 if TYPE_CHECKING:
+    from arkouda.categorical import Categorical
     from arkouda.numpy import cast as akcast
-    from arkouda.numpy import isnan, value_counts
     from arkouda.numpy.segarray import SegArray
 else:
     SegArray = TypeVar("SegArray")
     akcast = TypeVar("akcast")
     isnan = TypeVar("isnan")
     value_counts = TypeVar("value_counts")
+    Categorical = TypeVar("Categorical")
+
 
 # pd.set_option("display.max_colwidth", 65) is being called in DataFrame.py. This will resolve BitVector
 # truncation issues. If issues arise, that's where to look for it.
@@ -154,6 +155,8 @@ class Series:
         name=None,
         index: Optional[Union[pdarray, Strings, Tuple, List, Index]] = None,
     ):
+        from arkouda.pandas.categorical import Categorical
+
         if isinstance(data, pd.Categorical):
             data = Categorical(data)
 
@@ -797,6 +800,7 @@ class Series:
         import copy
 
         from arkouda.numpy.segarray import SegArray
+        from arkouda.pandas.categorical import Categorical
 
         idx = self.index.to_pandas()
 
@@ -998,6 +1002,7 @@ class Series:
 
         """
         from arkouda.client import generic_msg
+        from arkouda.pandas.categorical import Categorical
 
         if self.registered_name is not None and self.is_registered():
             raise RegistrationError(f"This object is already registered as {self.registered_name}")
@@ -1143,6 +1148,8 @@ class Series:
             the Series instance
 
         """
+        from arkouda.pandas.categorical import Categorical
+
         data = json.loads(repMsg)
         val_comps = data["value"].split("+|+")
         if val_comps[0] == Categorical.objType.upper():


### PR DESCRIPTION
This PR resolves a number of type errors where resolution is a prerequisite of upgrading to `typeguard==4.4.2` in order to improve type checking for `Union` types.

Part 1 of #2528  numeric_scalars in type hint disables our typechecking