### PR TITLE
Checkpoint pdarrays of bigints

### DIFF
--- a/src/BigIntMsg.chpl
+++ b/src/BigIntMsg.chpl
@@ -53,7 +53,6 @@ module BigIntMsg {
 
         var retname = st.nextName();
         st.addEntry(retname, createSymEntry(bigIntArray, max_bits));
-        var syment = st[retname]: SymEntry(array_dtype, array_nd); // Is this line necessary?
         repMsg = "created %s".format(st.attrib(retname));
         biLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
         return new MsgTuple(repMsg, MsgType.NORMAL);


### PR DESCRIPTION
Add support for bigint arrays to checkpointing.

The initial implementation used ULEB128 encoding for saving "count", i.e., the number of bytes needed to store a given bigint. The intention was to use the smallest number of bytes possible for representing the "count", as ULEB128 is variable-length, akin to utf-8. I changed to always using 4 bytes for saving "count" in the second commit to simplify the code. I consider the use of extra 2 bytes for bigints that fit within (2^15-1) bytes (4 bytes vs. ULEB128) to be a reasonable compromise between maintainability and efficiency.

Contributes to #2384.