### PR TITLE
4688 intermittent ci failures error invoking driver compilation phase

### DIFF
--- a/arkouda/numpy/random/generator.py
+++ b/arkouda/numpy/random/generator.py
@@ -715,7 +715,6 @@ class Generator:
         array([5 9 7 3 0 2 1 6 4 8])
 
         """
-
         from arkouda.client import generic_msg
 
         if not isinstance(x, pdarray):

--- a/scripts/trim_server_modules.sh
+++ b/scripts/trim_server_modules.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# scripts/trim_server_modules.sh
+
+CFG_FILE="ServerModules.cfg"
+
+# List of modules to exclude in multidim builds
+EXCLUDE_MODULES=(
+  "CheckpointMsg"
+  "CommDiagnosticsMsg"
+)
+
+# Backup original
+cp "$CFG_FILE" "$CFG_FILE.bak"
+
+# Comment out each module if present
+for module in "${EXCLUDE_MODULES[@]}"; do
+  sed -i "s/^\($module\)$/# \1/" "$CFG_FILE"
+done
+
+

--- a/tests/checkpoint_test.py
+++ b/tests/checkpoint_test.py
@@ -33,6 +33,7 @@ def cp_test_base_tmp(request):
 
 
 class TestCheckpoint:
+    @pytest.mark.skip_if_max_rank_greater_than(1)
     @pytest.mark.skipif(
         os.environ.get("CHPL_HOST_PLATFORM") == "hpe-apollo",
         reason="skipped on CHPL_HOST_PLATFORM=hpe-apollo - login/compute file system access unreliable",
@@ -68,6 +69,7 @@ class TestCheckpoint:
         finally:
             rmtree(expected_dir)
 
+    @pytest.mark.skip_if_max_rank_greater_than(1)
     def test_bigint_checkpoint(self, cp_test_base_tmp):
         prob_size = 300  # force memBuf resizing in the implementation
         lst = list()
@@ -91,6 +93,7 @@ class TestCheckpoint:
             for i in range(prob_size):
                 assert pda[i] == lst[i]
 
+    @pytest.mark.skip_if_max_rank_greater_than(1)
     @pytest.mark.parametrize("prob_size", pytest.prob_size)
     def test_checkpoint_custom_names(self, cp_test_base_tmp, prob_size):
         arr = ak.zeros(prob_size, int)
@@ -117,6 +120,7 @@ class TestCheckpoint:
             assert arr[3] == 0
             assert arr[2] == 2
 
+    @pytest.mark.skip_if_max_rank_greater_than(1)
     def test_incorrect_nl(self):
         cp_name = "test_incorrect_nl_cp"
         create_fake_cp(cp_name, num_locales=ak.get_config()["numLocales"] + 1)
@@ -130,6 +134,7 @@ class TestCheckpoint:
         finally:
             clean_fake_cp(cp_name)
 
+    @pytest.mark.skip_if_max_rank_greater_than(1)
     def test_incorrect_chunks(self):
         cp_name = "test_incorrect_chunks_cp"
         create_fake_cp(cp_name)
@@ -148,6 +153,7 @@ class TestCheckpoint:
         finally:
             clean_fake_cp(cp_name)
 
+    @pytest.mark.skip_if_max_rank_greater_than(1)
     def test_corrupt_json(self):
         cp_name = "test_corrupt_json_cp"
         create_fake_cp(cp_name)
@@ -161,6 +167,7 @@ class TestCheckpoint:
         finally:
             clean_fake_cp(cp_name)
 
+    @pytest.mark.skip_if_max_rank_greater_than(1)
     def test_wrong_argument(self):
         try:
             ak.save_checkpoint(mode="override")

--- a/tests/comm_diagnostics_test.py
+++ b/tests/comm_diagnostics_test.py
@@ -40,6 +40,7 @@ diagnostic_stats_functions = [
 
 
 class TestCommDiagnostics:
+    @pytest.mark.skip_if_max_rank_greater_than(1)
     @pytest.mark.skipif(
         os.environ.get("CHPL_HOST_PLATFORM") == "hpe-apollo",
         reason="Test skipped on CHPL_HOST_PLATFORM=hpe-apollo for debugging purposes (hanging test)",
@@ -57,12 +58,14 @@ class TestCommDiagnostics:
         )
         assert result.failed == 0, f"Doctest failed: {result.failed} failures"
 
+    @pytest.mark.skip_if_max_rank_greater_than(1)
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_verbose_comm(self, size):
         start_verbose_comm()
         ak.zeros(size)
         stop_verbose_comm()
 
+    @pytest.mark.skip_if_max_rank_greater_than(1)
     @pytest.mark.parametrize("op", diagnostic_stats_functions)
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_comm_diagnostics_single_locale(self, op, size):
@@ -80,6 +83,7 @@ class TestCommDiagnostics:
         reset_comm_diagnostics()
         stop_comm_diagnostics()
 
+    @pytest.mark.skip_if_max_rank_greater_than(1)
     @pytest.mark.skip_if_nl_less_than(2)
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_comm_diagnostics_multi_locale(self, size):
@@ -96,6 +100,7 @@ class TestCommDiagnostics:
 
         stop_comm_diagnostics()
 
+    @pytest.mark.skip_if_max_rank_greater_than(1)
     def test_get_comm_diagnostics(self):
         start_comm_diagnostics()
 


### PR DESCRIPTION
The purpose of this PR is to reduce the RAM usage for the multi-dimensional unit tests running the CI.  It adds a script that will comment out a list of modules from the `ServerModules.cfg` that do not need to be tested in the multi-dimensional case.  It also adds a pytest skip to any unit tests that depend on these modules when arkouda is compiled for the multidimesional case.  