### PR TITLE
Closes #4779 strip ak connect from examples

### DIFF
--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -81,7 +81,6 @@ Notes
 Examples
 --------
 >>> import arkouda as ak
->>> ak.connect() # doctest: +SKIP
 >>> ak.get_config() # doctest: +SKIP
 {'serverHostname': 'localhost', 'numLocales': 4, ...}
 >>> ak.disconnect() # doctest: +SKIP
@@ -1586,8 +1585,6 @@ def generate_history(
     Examples
     --------
     >>> import arkouda as ak
-    >>> ak.connect()    # doctest: +SKIP
-    connected to arkouda server tcp://*:5555
     >>> ak.get_config()    # doctest: +SKIP
     {'arkoudaVersion': 'v2025.01.13+165.g23ccdfd6c', 'chplVersion': '2.4.0',
         ... 'pythonVersion': '3.13', 'ZMQVersion': '4.3.5', 'HDF5Version': '1.14.4',

--- a/arkouda/comm_diagnostics.py
+++ b/arkouda/comm_diagnostics.py
@@ -38,7 +38,7 @@ Examples
 --------
 >>> import arkouda as ak
 >>> import arkouda.comm_diagnostics as cd
->>> ak.connect()
+
 >>> from arkouda.comm_diagnostics import start_comm_diagnostics, stop_comm_diagnostics, \
 get_comm_diagnostics, print_comm_diagnostics_table
 >>> start_comm_diagnostics()
@@ -59,7 +59,6 @@ Index(['put', 'get', 'put_nb', 'get_nb', 'try_nb', 'amo', 'execute_on', 'execute
 1  170  198
 2  170  198
 3  170  198 (4 rows x 2 columns)
-
 
 >>> print_comm_diagnostics_table()  # doctest: +SKIP
 +----+-------+-------+--------------+-----------------+

--- a/arkouda/numpy/pdarrayclass.py
+++ b/arkouda/numpy/pdarrayclass.py
@@ -4755,7 +4755,6 @@ def power(
     >>> ak.power(a, 3, a % 2 == 0)
     array([0 1 8 3 64])
 
-
     Raises
     ------
     TypeError
@@ -4903,7 +4902,6 @@ def mod(dividend, divisor) -> pdarray:
     >>> b = ak.array([2,2,2,3,3,3,4,4,4,5,5,5,6,6,6,7,7,7,8,8])
     >>> ak.mod(a,b)
     array([1 0 1 1 2 0 3 0 1 0 1 2 1 2 3 2 3 4 3 4])
-
 
     Raises
     ------

--- a/arkouda/pandas/categorical.py
+++ b/arkouda/pandas/categorical.py
@@ -391,7 +391,7 @@ class Categorical:
         Examples
         --------
         >>> import arkouda as ak
-        >>> ak.connect()
+
         >>> c = Categorical(ak.array(["a", "b", "c"]))
         >>> c_cpy = Categorical(ak.array(["a", "b", "c"]))
         >>> c.equals(c_cpy)
@@ -1094,7 +1094,7 @@ class Categorical:
         Examples
         --------
         >>> import arkouda as ak
-        >>> ak.connect()
+
         >>> cat = ak.Categorical(ak.array(['dog', 'cat', 'dog', 'bird']))
         >>> cat.argsort()
         array([3, 1, 0, 2])  # 'bird' < 'cat' < 'dog'

--- a/arkouda/pandas/dataframe.py
+++ b/arkouda/pandas/dataframe.py
@@ -2078,7 +2078,7 @@ class DataFrame(UserDict):
         Examples
         --------
         >>> import arkouda as ak
-        >>> ak.connect()
+
         >>> df = ak.DataFrame({"A": ak.array([1, 2, 3]), "B": ak.array([4, 5, 6])})
         >>> df
            A  B
@@ -2158,7 +2158,7 @@ class DataFrame(UserDict):
         Examples
         --------
         >>> import arkouda as ak
-        >>> ak.connect()
+
         >>> df1 = ak.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
         >>> df1
             col1  col2

--- a/arkouda/pandas/index.py
+++ b/arkouda/pandas/index.py
@@ -988,7 +988,7 @@ class Index:
         Examples
         --------
         >>> import arkouda as ak
-        >>> ak.connect()
+
         >>> idx = ak.Index(ak.array([2, 3, 2, 3, 4]))
         >>> idx
         Index(array([2 3 2 3 4]), dtype='int64')
@@ -1679,7 +1679,7 @@ class MultiIndex(Index):
         Examples
         --------
         >>> import arkouda as ak
-        >>> ak.connect()
+
         >>> m = ak.index.MultiIndex([ak.array([1,2,3]),ak.array([4,5,6])])
         >>> m.memory_usage()
         48

--- a/arkouda/pandas/series.py
+++ b/arkouda/pandas/series.py
@@ -856,7 +856,7 @@ class Series:
         Examples
         --------
         >>> import arkouda as ak
-        >>> ak.connect()
+
         >>> s = ak.Series(["elk", "pig", "dog", "quetzal"], name="animal")
         >>> print(s.to_markdown())
         +----+----------+

--- a/arkouda/scipy/_stats_py.py
+++ b/arkouda/scipy/_stats_py.py
@@ -196,7 +196,6 @@ def chisquare(f_obs, f_exp=None, ddof=0):
     Power_divergenceResult(statistic=np.float64(8.333333333333334),
         pvalue=np.float64(0.03960235520756414))
 
-
     See Also
     --------
     scipy.stats.chisquare

--- a/arkouda/scipy/special/_math.py
+++ b/arkouda/scipy/special/_math.py
@@ -34,7 +34,6 @@ def xlogy(x: Union[pdarray, np.float64], y: pdarray):
     >>> xlogy( 5.0, ak.array([1, 2, 3, 4]))
     array([0.00000000000000000 3.4657359027997265 5.4930614433405491 6.9314718055994531])
 
-
     """
     if not isinstance(x, (np.float64, pdarray)) and np.can_cast(x, np.float64):
         x = np.float64(x)

--- a/arkouda/testing/_asserters.py
+++ b/arkouda/testing/_asserters.py
@@ -237,7 +237,6 @@ def assert_index_equal(
     >>> tm.assert_index_equal(a, b)
 
     """
-
     __tracebackhide__ = not DEBUG
 
     def _check_types(left, right, obj: str = "Index") -> None:
@@ -447,7 +446,6 @@ def assert_categorical_equal(
         Defaults to 'Categorical'.
 
     """
-
     _check_isinstance(left, right, Categorical)
 
     exact = True

--- a/pytest.ini
+++ b/pytest.ini
@@ -80,6 +80,7 @@ testpaths =
     tests/where_test.py
     tests/version_test.py
     tests/pandas/row_test.py
+    tests/test_no_ak_connect_doctest.py
 norecursedirs =
     .git
     dist

--- a/tests/test_no_ak_connect_doctest.py
+++ b/tests/test_no_ak_connect_doctest.py
@@ -1,0 +1,184 @@
+"""Pytest guard that forbids `>>> ak.connect(...)` inside NumPy-style Examples sections.
+
+This test scans all Python files (excluding a small ignore set), parses triple-quoted
+docstrings, finds their "Examples" sections, and flags any doctest prompt lines that
+call ``ak.connect``. Failures report file, line number, and a small context block.
+"""
+
+from pathlib import Path
+import re
+from typing import Generator, List, Tuple
+
+# --- Heuristics that mirror the stripper script ---
+TRIPLE_QUOTE_RE = re.compile(r'(?P<q>"""|\'\'\')(?P<body>.*?)(?P=q)', re.DOTALL)
+SECTION_HEADER_RE = re.compile(
+    r"^[ \t]*([A-Za-z][A-Za-z0-9 _-]*)[ \t]*\n[ \t]*[-=~]{3,}[ \t]*\n", re.MULTILINE
+)
+DOCTEST_CONNECT_RE = re.compile(r"^\s*>{2,}\s*ak\.connect\(", re.MULTILINE)
+
+# Optional: ignore some paths (examples, build outputs, vendored code, etc.)
+IGNORES = {
+    ".git",
+    ".venv",
+    "venv",
+    "build",
+    "dist",
+    "site-packages",
+    "__pycache__",
+    "docs/_build",
+}
+
+
+def should_skip(path: Path) -> bool:
+    """
+    Determine whether a given file path should be skipped based on ignore rules.
+
+    Parameters
+    ----------
+    path : Path
+        Path to the file, **relative** to the repository root.
+
+    Returns
+    -------
+    bool
+        ``True`` if the file lives under any of the ignored directories defined
+        in :data:`IGNORES`, otherwise ``False``.
+    """
+    parts = set(path.parts)
+    return bool(parts & IGNORES)
+
+
+def examples_spans_in_doc(doc: str) -> Generator[tuple[int, int], None, None]:
+    """
+    Yield (start, end) index pairs for "Examples" sections within a docstring body.
+
+    This inspects the given docstring text (without surrounding triple quotes)
+    for NumPy-style section headers. For each section named "Examples",
+    the start and end offsets of the section's content within the docstring
+    are yielded.
+
+    Parameters
+    ----------
+    doc : str
+        The full text of a docstring body (without triple quotes).
+
+    Yields
+    ------
+    int
+        The start and end character indices (relative to ``doc``) of each
+        Examples section found.
+
+    Returns
+    -------
+    None
+        The generator returns ``None`` upon completion.
+    """
+    sections = list(SECTION_HEADER_RE.finditer(doc))
+    if not sections:
+        return None
+    for i, m in enumerate(sections):
+        name = m.group(1).strip().lower()
+        start = m.end()
+        end = sections[i + 1].start() if i + 1 < len(sections) else len(doc)
+        if name == "examples":
+            yield start, end
+
+
+def find_offenses_with_lines(text: str) -> List[Tuple[int, str, str]]:
+    """
+    Find forbidden doctest prompt lines inside Examples sections of docstrings.
+
+    Parameters
+    ----------
+    text : str
+        The full text of a Python source file.
+
+    Returns
+    -------
+    list[tuple[int, str, str]]
+        A list of ``(line_number, matched_line, context_block)`` tuples for each
+        offending line inside an Examples section. ``context_block`` contains the
+        offending line plus one line of context above and below.
+    """
+    offenses: List[Tuple[int, str, str]] = []
+    for m in TRIPLE_QUOTE_RE.finditer(text):
+        doc_start = m.start()
+        body = m.group("body")
+        for s, e in examples_spans_in_doc(body):
+            # Search within this Examples slice
+            slice_ = body[s:e]
+            for bad in DOCTEST_CONNECT_RE.finditer(slice_):
+                # Compute absolute index in file text
+                absolute_idx = doc_start + s + bad.start()
+                # Determine line bounds for matched line
+                line_start = text.rfind("\n", 0, absolute_idx) + 1
+                line_end = text.find("\n", absolute_idx)
+                if line_end == -1:
+                    line_end = len(text)
+                # Compute line number
+                line_no = text.count("\n", 0, line_start) + 1
+                matched_line = text[line_start:line_end].rstrip()
+
+                # Build a small context block: previous, current, next lines
+                # Previous line
+                prev_start = text.rfind("\n", 0, max(0, line_start - 1)) + 1
+                prev_end = line_start - 1 if line_start > 0 else 0
+                prev_line = text[prev_start:prev_end].rstrip() if prev_end > prev_start else ""
+
+                # Next line
+                next_start = line_end + 1 if line_end < len(text) else len(text)
+                next_end = text.find("\n", next_start)
+                if next_end == -1:
+                    next_end = len(text)
+                next_line = text[next_start:next_end].rstrip() if next_end > next_start else ""
+
+                context = "\n".join(
+                    [
+                        f"{line_no - 1:>6}: {prev_line}" if prev_line else "",
+                        f"{line_no:>6}: {matched_line}",
+                        f"{line_no + 1:>6}: {next_line}" if next_line else "",
+                    ]
+                ).strip("\n")
+
+                offenses.append((line_no, matched_line, context))
+    return offenses
+
+
+def test_no_ak_connect_doctest():
+    """
+    Assert no ``>>> ak.connect(...)`` doctest prompts exist inside Examples sections.
+
+    The test walks through all Python files in the repository (excluding ignored
+    paths), parses triple-quoted docstrings, and checks their "Examples" sections
+    for doctest prompt lines calling ``ak.connect``. If any such lines are found,
+    the test fails and reports the file, line number, and a small context block.
+
+    Raises
+    ------
+    AssertionError
+        If one or more offending lines are found inside Examples sections.
+    """
+    repo_root = Path(__file__).resolve().parents[1]
+    offenders: List[Tuple[Path, int, str, str]] = []  # (path, line, matched_line, context)
+
+    for py in repo_root.rglob("*.py"):
+        rel = py.relative_to(repo_root)
+        if should_skip(rel):
+            continue
+        try:
+            text = py.read_text(encoding="utf-8")
+        except Exception:
+            continue
+        hits = find_offenses_with_lines(text)
+        for line_no, matched_line, context in hits:
+            offenders.append((rel, line_no, matched_line, context))
+
+    assert not offenders, (
+        "Forbidden doctest prompts found INSIDE docstring 'Examples' sections "
+        "(remove lines like `>>> ak.connect(...)`).\n\n"
+        + "\n\n".join(
+            f"""{path}:{line}
+{context}"""
+            for path, line, matched_line, context in offenders
+        )
+    )


### PR DESCRIPTION
This PR removes `>>> ak.connect()` from the docstrings which can cause `doctest` to hang.  It also adds a unit tests that will fail if any `>>> ak.connect()` are added to the docstrings in the future.

Closes #4779 strip ak connect from examples