### PR TITLE
Closes #4791:  trim down multi-dim build

### DIFF
--- a/scripts/trim_server_modules.sh
+++ b/scripts/trim_server_modules.sh
@@ -7,6 +7,13 @@ CFG_FILE="ServerModules.cfg"
 EXCLUDE_MODULES=(
   "CheckpointMsg"
   "CommDiagnosticsMsg"
+  "ArraySetops"
+  "ArraySetopsMsg"
+  "DataFrameIndexingMsg" 
+  "EncodingMsg"
+  "Codecs"
+  "CSVMsg"
+  "ExternalIntegration"
 )
 
 # Backup original

--- a/tests/numpy/string_test.py
+++ b/tests/numpy/string_test.py
@@ -18,6 +18,7 @@ UNIQUE = N // 4
 SEED = 12345
 
 
+@pytest.mark.skip_if_max_rank_greater_than(1)
 class TestString:
     @pytest.mark.skipif(
         os.environ.get("CHPL_HOST_PLATFORM") == "hpe-apollo",

--- a/tests/pandas/dataframe_test.py
+++ b/tests/pandas/dataframe_test.py
@@ -37,6 +37,7 @@ def df_test_base_tmp(request):
     return df_test_base_tmp
 
 
+@pytest.mark.skip_if_max_rank_greater_than(1)
 class TestDataFrame:
     def test_dataframe_docstrings(self, df_test_base_tmp):
         import doctest

--- a/tests/pandas/io_test.py
+++ b/tests/pandas/io_test.py
@@ -2338,6 +2338,7 @@ class TestHDF5:
             assert df["timedelta"].tolist() == rd_df["timedelta"].tolist()
 
 
+@pytest.mark.skip_if_max_rank_greater_than(1)
 class TestCSV:
     def test_csv_read_write(self, csv_test_base_tmp):
         # first test that can read csv with no header not written by Arkouda


### PR DESCRIPTION
This PR adds some modules to `scripts/trim_server_modules.sh` which are not necessary to compile during multi-dimensional testing.

Closes #4791:  trim down multi-dim build