### PR TITLE
Closes #4793:  Temporarily add ignore codes to .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,8 @@ repos:
       - id: ruff
         args: 
           - --fix        # applies lint‐rule fixes in place
-          - --extend-ignore=E712,E741
+          - --extend-ignore=E712,E741,PTH110,PTH118,PTH108,C403,PTH100,PTH109,F841,F401,W291,W293,PT012,D400,PLR2044,B034,PT011,RUF034,N812,D404,PTH202,PLC0206,RUF013,PTH208,PT021,B015,C404,PT006,RUF040,PT017,B011,PT015,PT022,SIM222,SIM210,PT014,SIM113,C414,PLR1730,PLR0124,C405,SIM117,B023,SIM105,PLW1508,PTH103,B018,B008,PTH107,PLW1510,RET502,F821,E721,E731,PT007,PT003
+        exclude: ^(tests/deprecated)
 
       # 2) the formatter hook
       - id: ruff-format
@@ -18,4 +19,4 @@ repos:
       - id: isort
         name: isort (python)
         args: ["--profile=black"]
-
+        exclude: ^(tests/deprecated)

--- a/arkouda/numpy/pdarraycreation.py
+++ b/arkouda/numpy/pdarraycreation.py
@@ -1232,7 +1232,6 @@ def logspace(
         array([4.00000000000000000 16.00000000000000000])
         array([16.00000000000000000 64.00000000000000000])])
     """
-
     if dtype not in (None, float64):
         raise TypeError("dtype must be None or float64")
     if base <= 0:
@@ -1318,7 +1317,6 @@ def linspace(
         array([1.00000000000000000 2.00000000000000000])
         array([2.00000000000000000 3.00000000000000000])])
     """
-
     from arkouda import newaxis
     from arkouda.numeric import transpose
     from arkouda.numpy.manipulation_functions import tile

--- a/arkouda/sorting/__init__.py
+++ b/arkouda/sorting/__init__.py
@@ -1,3 +1,9 @@
 # flake8: noqa
 
-from arkouda.numpy.sorting import SortingAlgorithm, argsort, coargsort, searchsorted, sort
+from arkouda.numpy.sorting import (
+    SortingAlgorithm,
+    argsort,
+    coargsort,
+    searchsorted,
+    sort,
+)

--- a/benchmark_v2/reformat_benchmark_results.py
+++ b/benchmark_v2/reformat_benchmark_results.py
@@ -207,8 +207,9 @@ def get_nested_value(data: dict, keys: list):
 
 
 def get_value(field: str, benchmark_name: str, field_lookup_map: dict, benchmark_data):
-    """get the value of a field in a benchmark using the field_lookup_map
-    and the benchmark_data in pytest json format."""
+    """Get the value of a field in a benchmark using the field_lookup_map
+    and the benchmark_data in pytest json format.
+    """
     regex_str = None
     if (
         field_lookup_map.get(benchmark_name).get(field) is not None
@@ -243,7 +244,8 @@ def get_value(field: str, benchmark_name: str, field_lookup_map: dict, benchmark
 
 def compute_average(benchmark_name_regex: str, keys: list, benchmark_data):
     """Compute the average value of a statistic, using a regex on
-    the benchmark name to determine which values to use."""
+    the benchmark name to determine which values to use.
+    """
     total = 0.0
     count = 0
     try:

--- a/converter/hdflow.py
+++ b/converter/hdflow.py
@@ -58,7 +58,8 @@ def write_strings(f, group, packed, offsets):
 def col2dset(name, col, f, dtype=None, compression="gzip"):
     """Write a pandas Series <col> to dataset <name> in HDF5 file <f>.
     Optionally, specify a dtype to convert to before writing. Compression
-    with gzip is also supported."""
+    with gzip is also supported.
+    """
     normdtype = _normalize_dtype(col, dtype)
     data = _cast_values(col, dtype)
     try:
@@ -75,7 +76,8 @@ def col2dset(name, col, f, dtype=None, compression="gzip"):
 
 def df2hdf(filename, df, dtypes={}, compression="gzip"):
     """Write a pandas DataFrame <df> to a HDF5 file <filename>. Optionally,
-    specify dtypes for converting the columns and a compression to use."""
+    specify dtypes for converting the columns and a compression to use.
+    """
     with h5py.File(filename, "w") as f:
         for colname in df.columns:
             col2dset(

--- a/ruff.toml
+++ b/ruff.toml
@@ -46,7 +46,7 @@ quote-style = "double"
 # UP    - pyupgrade: recommend modern Python syntax (e.g., f-strings, `|` for union)
 # YTT   - flake8-2020: flag outdated or fragile Python version checks
 # E501  - enforces maximum line length
-select = ["E", "F", "I", "D", "W", "A", "B", "C4", "EM", "ERA", "N", "PGH", "PIE", "PL", "PT", "PTH", "RET","RUF", "SIM", "SLF", "T20", "UP", "YTT", "E501"] 
+select = ["E", "F", "D", "W", "A", "B", "C4", "EM", "ERA", "N", "PGH", "PIE", "PL", "PT", "PTH", "RET","RUF", "SIM", "SLF", "T20", "UP", "YTT", "E501"] 
 fixable = ["I","D"]
 ignore = ["D401","D104","D205","D100","D102","D105","D103","D200","D101",
 "A004","A002","A001",

--- a/tests/nan_test.py
+++ b/tests/nan_test.py
@@ -59,7 +59,6 @@ def run_test(verbose=True):
 
     :return:
     """
-
     d = make_arrays()
     df = pd.DataFrame(d)
     akdf = {k: ak.array(v) for k, v in d.items()}

--- a/tests/optioned-server/auto-checkpoints.py
+++ b/tests/optioned-server/auto-checkpoints.py
@@ -77,7 +77,6 @@ class TestIdleAndInterval:
           3.0 [more than checkpointInterval]
           verify existence of an auto-checkpoint and a previous auto-checkpoint
         """
-
         delete_directory(autockptDir)  # start with a clean slate
         delete_directory(autockptPrevDir)
         a = ak.ones(pytest.prob_size[0])

--- a/tests/pandas/parquet_edge_test.py
+++ b/tests/pandas/parquet_edge_test.py
@@ -127,10 +127,12 @@ def get_test_parquet_files() -> List[Path]:
     """
     Discover parquet test files, excluding those known to crash the server.
 
-    Returns:
+    Returns
+    -------
         List of Path objects for parquet files to test (empty list if env var not set)
 
-    Raises:
+    Raises
+    ------
         FileNotFoundError: If test data directory doesn't exist
         ValueError: If no parquet files found in valid directory
     """
@@ -178,7 +180,8 @@ def read_parquet_with_arkouda(
     """
     Read a parquet file with Arkouda and optionally compare with pandas.
 
-    Returns:
+    Returns
+    -------
         ParquetTestResult object with test outcomes
     """
     filename = Path(filepath).name

--- a/tests/scipy/sparse_test.py
+++ b/tests/scipy/sparse_test.py
@@ -42,6 +42,7 @@ class TestSparse:
             Perform matrix-matrix multiplication of two sparse matrices represented by
             3 arrays of rows, cols, and vals.
             A . B
+
             Parameters
             ----------
             rowsA : list or array-like


### PR DESCRIPTION
Temporarily adds ignore codes to .pre-commit-config.yaml to mitigate them until they can be addressed.  Also removes "I" mode from `ruff` linter to prevent conflicts with `isort`. 

Closes #4793:  Temporarily add ignore codes to .pre-commit-config.yaml