### PR TITLE
Closes 4804, fixing a "cumsum" vs "cumulative_sum" typo that was in PR 4755

### DIFF
--- a/tests/array_api/stats_functions.py
+++ b/tests/array_api/stats_functions.py
@@ -162,7 +162,7 @@ class TestStatsFunction:
         a = xp.asarray(ak.randint(0, 100, (5, 6, 7), seed=SEED))
 
         a_sum_0 = xp.cumulative_sum(a, axis=0)
-        a_sum_0_np = np.cumsum(a.to_ndarray(), axis=0)
+        a_sum_0_np = np.cumulative_sum(a.to_ndarray(), axis=0)
         assert a_sum_0.shape == (5, 6, 7)
         assert a_sum_0.tolist() == a_sum_0_np.tolist()
 


### PR DESCRIPTION
Closes #4804, as described in the title.  The test should have compared to np.cumulative_sum, not np.cumsum.