### PR TITLE
Closes #4808:  Expand pytest.N usage in benchmarks_v2

### DIFF
--- a/benchmark_v2/array_transfer_benchmark.py
+++ b/benchmark_v2/array_transfer_benchmark.py
@@ -21,7 +21,7 @@ def create_ak_array(N, dtype):
 @pytest.mark.parametrize("dtype", TYPES)
 def bench_array_transfer_tondarray(benchmark, dtype):
     if dtype in pytest.dtype:
-        N = pytest.prob_size * ak.get_config()["numLocales"]
+        N = pytest.N
         a, nb = create_ak_array(N, dtype)
         ak.client.maxTransferBytes = nb
 
@@ -42,7 +42,7 @@ def bench_array_transfer_tondarray(benchmark, dtype):
 @pytest.mark.parametrize("dtype", TYPES)
 def bench_array_transfer_akarray(benchmark, dtype):
     if dtype in pytest.dtype:
-        N = pytest.prob_size * ak.get_config()["numLocales"]
+        N = pytest.N
         a, nb = create_ak_array(N, dtype)
         ak.client.maxTransferBytes = nb
         npa = a.to_ndarray()

--- a/benchmark_v2/bigint_bitwise_binops_benchmark.py
+++ b/benchmark_v2/bigint_bitwise_binops_benchmark.py
@@ -23,7 +23,7 @@ def bench_bitwise_binops(benchmark, op):
     """
     Measures the performance of bigint bitwise binops
     """
-    N = pytest.prob_size * ak.get_config()["numLocales"]
+    N = pytest.N
     nbytes = compute_nbytes(N)
 
     a = generate_bigint_pair(N)

--- a/benchmark_v2/dataframe_indexing_benchmark.py
+++ b/benchmark_v2/dataframe_indexing_benchmark.py
@@ -13,7 +13,7 @@ def bench_dataframe(benchmark, op):
     """
     Measures the performance of arkouda Dataframe indexing
     """
-    N = pytest.prob_size * ak.get_config()["numLocales"]
+    N = pytest.N
 
     types = [ak.Categorical, ak.pdarray, ak.Strings, ak.SegArray]
     df_dict = {}

--- a/benchmark_v2/encoding_benchmark.py
+++ b/benchmark_v2/encoding_benchmark.py
@@ -17,7 +17,7 @@ def compute_nbytes(a):
 @pytest.mark.benchmark(group="Strings_EncodeDecode")
 @pytest.mark.parametrize("encoding", ENCODINGS)
 def bench_encode(benchmark, encoding):
-    N = pytest.prob_size * ak.get_config()["numLocales"]
+    N = pytest.N
     a = generate_string_array(N)
     nbytes = compute_nbytes(a)
 
@@ -37,7 +37,7 @@ def bench_encode(benchmark, encoding):
 @pytest.mark.benchmark(group="Strings_EncodeDecode")
 @pytest.mark.parametrize("encoding", ENCODINGS)
 def bench_decode(benchmark, encoding):
-    N = pytest.prob_size * ak.get_config()["numLocales"]
+    N = pytest.N
     a = generate_string_array(N)
     encoded = a.encode(encoding)
     nbytes = compute_nbytes(a)

--- a/benchmark_v2/find_benchmark.py
+++ b/benchmark_v2/find_benchmark.py
@@ -14,8 +14,7 @@ def bench_find(benchmark, dtype):
     Runs for each dtype in TYPES.
 
     """
-    cfg = ak.get_config()
-    N = pytest.prob_size * cfg["numLocales"]
+    N = pytest.N
     query_frac = 0.01  # Use 1% of the space as query set
     qN = max(1, int(query_frac * N))
 

--- a/benchmark_v2/groupby_benchmark.py
+++ b/benchmark_v2/groupby_benchmark.py
@@ -36,7 +36,7 @@ def generate_arrays(dtype, numArrays, N):
 @pytest.mark.parametrize("dtype", TYPES)
 def bench_groupby(benchmark, numArrays, dtype):
     if dtype in pytest.dtype:
-        N = pytest.prob_size * ak.get_config()["numLocales"]
+        N = pytest.N
         arrays, numBytes = generate_arrays(dtype, numArrays, N)
 
         benchmark.pedantic(ak.GroupBy, args=[arrays], rounds=pytest.trials)

--- a/benchmark_v2/small-str-groupby.py
+++ b/benchmark_v2/small-str-groupby.py
@@ -9,7 +9,7 @@ SIZES = {"small": 6, "medium": 12, "big": 24}
 @pytest.mark.benchmark(group="GroupBySmallStrings")
 @pytest.mark.parametrize("strlen_label", SIZES)
 def bench_groupby_small_str(benchmark, strlen_label):
-    N = pytest.prob_size * ak.get_config()["numLocales"]
+    N = pytest.N
     strlen = SIZES[strlen_label]
 
     a = ak.random_strings_uniform(1, strlen, N, seed=pytest.seed)

--- a/benchmark_v2/str_locality_benchmark.py
+++ b/benchmark_v2/str_locality_benchmark.py
@@ -13,7 +13,7 @@ LOCALITY = {"good", "poor"}
 
 
 def _generate_data(loc):
-    N = pytest.prob_size * ak.get_config()["numLocales"]
+    N = pytest.N
     prefix = ak.random_strings_uniform(
         minlen=1, maxlen=16, size=N, seed=pytest.seed, characters="numeric"
     )

--- a/benchmark_v2/substring_search_benchmark.py
+++ b/benchmark_v2/substring_search_benchmark.py
@@ -13,7 +13,7 @@ SEARCHES = {
 @pytest.mark.benchmark(group="Arkouda_Strings_SubstringSearch")
 @pytest.mark.parametrize("search_string,use_regex", SEARCHES.values(), ids=list(SEARCHES.keys()))
 def bench_strings_contains(benchmark, search_string, use_regex):
-    N = pytest.prob_size * ak.get_config()["numLocales"]
+    N = pytest.N
     seed = pytest.seed
 
     start = ak.random_strings_uniform(minlen=1, maxlen=8, size=N, seed=seed)


### PR DESCRIPTION
This PR expands `pytest.N` usage in `benchmarks_v2` to a few remaining cases.

Closes #4808:  Expand pytest.N usage in benchmarks_v2