### PR TITLE
Closes #4811:  parse results for benchmark_v2/split_benchmark.py

### DIFF
--- a/benchmark_v2/datdir/configs/field_lookup_map.json
+++ b/benchmark_v2/datdir/configs/field_lookup_map.json
@@ -1634,23 +1634,14 @@
       ],
       "lookup_regex": "^bench_aggregate\\[nunique\\]$"
     },
-    "Aggregate var Average time =": {
-      "name": "bench_aggregate[var]",
+    "Aggregate mean Average time =": {
+      "name": "bench_aggregate[mean]",
       "benchmark_name": "aggregate",
       "lookup_path": [
         "stats",
         "mean"
       ],
-      "lookup_regex": "^bench_aggregate\\[var\\]$"
-    },
-    "Aggregate var Average rate =": {
-      "name": "bench_aggregate[var]",
-      "benchmark_name": "aggregate",
-      "lookup_path": [
-        "extra_info",
-        "transfer_rate"
-      ],
-      "lookup_regex": "^bench_aggregate\\[var\\]$"
+      "lookup_regex": "^bench_aggregate\\[mean\\]$"
     },
     "Aggregate median Average time =": {
       "name": "bench_aggregate[median]",
@@ -1688,33 +1679,6 @@
       ],
       "lookup_regex": "^bench_aggregate\\[mode\\]$"
     },
-    "Aggregate mean Average time =": {
-      "name": "bench_aggregate[mean]",
-      "benchmark_name": "aggregate",
-      "lookup_path": [
-        "stats",
-        "mean"
-      ],
-      "lookup_regex": "^bench_aggregate\\[mean\\]$"
-    },
-    "Aggregate std Average time =": {
-      "name": "bench_aggregate[std]",
-      "benchmark_name": "aggregate",
-      "lookup_path": [
-        "stats",
-        "mean"
-      ],
-      "lookup_regex": "^bench_aggregate\\[std\\]$"
-    },
-    "Aggregate std Average rate =": {
-      "name": "bench_aggregate[std]",
-      "benchmark_name": "aggregate",
-      "lookup_path": [
-        "extra_info",
-        "transfer_rate"
-      ],
-      "lookup_regex": "^bench_aggregate\\[std\\]$"
-    },
     "Aggregate unique Average time =": {
       "name": "bench_aggregate[unique]",
       "benchmark_name": "aggregate",
@@ -1750,6 +1714,42 @@
         "transfer_rate"
       ],
       "lookup_regex": "^bench_aggregate\\[count\\]$"
+    },
+    "Aggregate std Average time =": {
+      "name": "bench_aggregate[std]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "^bench_aggregate\\[std\\]$"
+    },
+    "Aggregate std Average rate =": {
+      "name": "bench_aggregate[std]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "^bench_aggregate\\[std\\]$"
+    },
+    "Aggregate var Average time =": {
+      "name": "bench_aggregate[var]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "stats",
+        "mean"
+      ],
+      "lookup_regex": "^bench_aggregate\\[var\\]$"
+    },
+    "Aggregate var Average rate =": {
+      "name": "bench_aggregate[var]",
+      "benchmark_name": "aggregate",
+      "lookup_path": [
+        "extra_info",
+        "transfer_rate"
+      ],
+      "lookup_regex": "^bench_aggregate\\[var\\]$"
     },
     "Aggregate first Average time =": {
       "name": "bench_aggregate[first]",
@@ -2927,7 +2927,7 @@
         "extra_info",
         "transfer_rate"
       ],
-      "lookup_regex": "bench_split\\[(?:int64|float64|bool|uint64)\\]"
+      "lookup_regex": "bench_split.*"
     },
     "Average time =": {
       "name": "bench_split",
@@ -2936,7 +2936,7 @@
         "stats",
         "mean"
       ],
-      "lookup_regex": "bench_split\\[(?:int64|float64|bool|uint64)\\]"
+      "lookup_regex": "bench_split.*"
     }
   }
 }

--- a/benchmark_v2/generate_field_lookup_map.py
+++ b/benchmark_v2/generate_field_lookup_map.py
@@ -281,6 +281,8 @@ def add_default_mappings(field_lookup_map):
                 regex = rf"^bench_{base_bench}.*$"
             elif base_bench == "bigint_stream":
                 regex = r"bench_bigint_stream\[bigint\]"
+            elif base_bench == "split":
+                regex = "bench_split.*"
             else:
                 regex = f"bench_{base_bench}\\[{dtype}\\]"
 

--- a/benchmark_v2/reformat_benchmark_results.py
+++ b/benchmark_v2/reformat_benchmark_results.py
@@ -52,7 +52,7 @@ BENCHMARKS = [
     "str-gather",
     "str-in1d",
     "substring_search",
-    # "split",
+    "split",
     "sort-cases",
     # "multiIO",
     "str-locality",

--- a/benchmark_v2/split_benchmark.py
+++ b/benchmark_v2/split_benchmark.py
@@ -12,7 +12,7 @@ SPLIT_MODES = [
 @pytest.mark.skip_numpy(True)
 @pytest.mark.benchmark(group="Arkouda_Strings_Split")
 @pytest.mark.parametrize("label, delim, use_regex", SPLIT_MODES)
-def bench_strings_split(benchmark, label, delim, use_regex):
+def bench_split(benchmark, label, delim, use_regex):
     N = pytest.N
 
     thirds = [ak.cast(ak.arange(i, N * 3, 3), "str") for i in range(3)]


### PR DESCRIPTION
Adds the `split` benchmark handling to the `benchmark_v2/generate_field_lookup_map.py`.

Closes #4811:  parse results for benchmark_v2/split_benchmark.py