### PR TITLE
Closes #4814:  Refactor benchmarks/multiIO.py to new benchmark framework

### DIFF
--- a/benchmark_v2/datdir/configs/field_lookup_map.json
+++ b/benchmark_v2/datdir/configs/field_lookup_map.json
@@ -1180,7 +1180,7 @@
         "extra_info",
         "transfer_rate"
       ],
-      "lookup_regex": null,
+      "lookup_regex": "bench_read_hdf_multi\\[(?:int64|float64|bool|uint64|str)\\]",
       "name": ""
     },
     "read Average time HDF5 =": {
@@ -1189,7 +1189,7 @@
         "stats",
         "mean"
       ],
-      "lookup_regex": null,
+      "lookup_regex": "bench_read_hdf_multi\\[(?:int64|float64|bool|uint64|str)\\]",
       "name": ""
     },
     "write Average rate HDF5 =": {
@@ -1198,7 +1198,7 @@
         "extra_info",
         "transfer_rate"
       ],
-      "lookup_regex": null,
+      "lookup_regex": "bench_write_hdf_multi\\[(?:int64|float64|bool|uint64|str)\\]",
       "name": ""
     },
     "write Average time HDF5 =": {
@@ -1207,7 +1207,7 @@
         "stats",
         "mean"
       ],
-      "lookup_regex": null,
+      "lookup_regex": "bench_write_hdf_multi\\[(?:int64|float64|bool|uint64|str)\\]",
       "name": ""
     }
   },

--- a/benchmark_v2/generate_field_lookup_map.py
+++ b/benchmark_v2/generate_field_lookup_map.py
@@ -91,11 +91,18 @@ def infer_regex(benchmark_name: str, field: str) -> str:
     # CSV Read/Write
     if "csvIO" == benchmark_name:
         m1 = re.search(r"(write|read)", field)
-
         if m1:
             op = m1.group(1)
             dtype = "(?:int64|float64|bool|uint64|str)"
             return f"bench_csv_io\\[{op}-{dtype}\\]"
+
+    # multiIO Read/Write
+    if "multiIO" == benchmark_name:
+        m1 = re.search(r"(write|read)", field)
+        if m1:
+            op = m1.group(1)
+            dtype = "(?:int64|float64|bool|uint64|str)"
+            return f"bench_{op}_hdf_multi\\[{dtype}\\]"
 
     # parquet IO
     if benchmark_name in ["parquetIO", "parquetMultiIO"]:

--- a/benchmark_v2/reformat_benchmark_results.py
+++ b/benchmark_v2/reformat_benchmark_results.py
@@ -54,7 +54,7 @@ BENCHMARKS = [
     "substring_search",
     # "split",
     "sort-cases",
-    # "multiIO",
+    "multiIO",
     "str-locality",
     "dataframe",
     "encode",


### PR DESCRIPTION
Refactors `benchmarks/multiIO.py` to new benchmark framework to align with other benchmarks in `benchmarks_v2`.

Closes #4814:  Refactor benchmarks/multiIO.py to new benchmark framework