### PR TITLE
Fixes #4824:  In io_benchmark.py read Average rate is always zero

### DIFF
--- a/benchmark_v2/aggregate_benchmark.py
+++ b/benchmark_v2/aggregate_benchmark.py
@@ -1,3 +1,4 @@
+from benchmark_utils import calc_num_bytes
 import pytest
 
 import arkouda as ak
@@ -55,15 +56,16 @@ def bench_aggregate(benchmark, op):
             elif op == "count":
                 df.groupby("key")["val"].count()
 
-            return vals_np.size * vals_np.itemsize
-
-        numBytes = benchmark.pedantic(numpy_agg, rounds=pytest.trials)
+        benchmark.pedantic(numpy_agg, rounds=pytest.trials)
+        num_bytes = calc_num_bytes(vals_np)
     else:
-        numBytes = benchmark.pedantic(run_agg, args=(g, vals, op), rounds=pytest.trials)
+        benchmark.pedantic(run_agg, args=(g, vals, op), rounds=pytest.trials)
+        num_bytes = calc_num_bytes(vals)
 
     benchmark.extra_info["description"] = (
         f"Measures performance of GroupBy.aggregate using the {op} operator."
     )
     benchmark.extra_info["problem_size"] = N
+    benchmark.extra_info["num_bytes"] = num_bytes
     #   units are GiB/sec:
-    benchmark.extra_info["transfer_rate"] = float((numBytes / benchmark.stats["mean"]) / 2**30)
+    benchmark.extra_info["transfer_rate"] = float((num_bytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/argsort_benchmark.py
+++ b/benchmark_v2/argsort_benchmark.py
@@ -1,3 +1,4 @@
+from benchmark_utils import calc_num_bytes
 import numpy as np
 import pytest
 
@@ -28,10 +29,7 @@ def bench_argsort(benchmark, dtype):
         elif dtype == "str":
             a = ak.random_strings_uniform(1, 16, N, seed=pytest.seed)
 
-        if dtype == "str":
-            nbytes = a.nbytes * a.entry.itemsize
-        else:
-            nbytes = a.size * a.itemsize
+        num_bytes = calc_num_bytes(a)
 
         if pytest.numpy:
             a = a.to_ndarray()
@@ -41,5 +39,6 @@ def bench_argsort(benchmark, dtype):
 
         benchmark.extra_info["description"] = "Measures the performance of argsort"
         benchmark.extra_info["problem_size"] = N
+        benchmark.extra_info["num_bytes"] = num_bytes
         #   units are GiB/sec:
-        benchmark.extra_info["transfer_rate"] = float((nbytes / benchmark.stats["mean"]) / 2**30)
+        benchmark.extra_info["transfer_rate"] = float((num_bytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/array_create_benchmark.py
+++ b/benchmark_v2/array_create_benchmark.py
@@ -1,3 +1,4 @@
+from benchmark_utils import calc_num_bytes
 import numpy as np
 import pytest
 
@@ -49,19 +50,20 @@ def bench_array_create(benchmark, op, dtype):
         if pytest.numpy:
 
             def create_array():
-                a = _create_np_array(N, op, dtype, pytest.seed)
-                return a.size * a.itemsize
+                return _create_np_array(N, op, dtype, pytest.seed)
+
         else:
 
             def create_array():
-                a = _create_ak_array(N, op, dtype, pytest.seed)
-                return a.size * a.itemsize
+                return _create_ak_array(N, op, dtype, pytest.seed)
 
-        nbytes = benchmark.pedantic(create_array, rounds=pytest.trials)
+        result = benchmark.pedantic(create_array, rounds=pytest.trials)
+        num_bytes = calc_num_bytes(result)
 
         benchmark.extra_info["description"] = (
             f"Measures performance of {'NumPy' if pytest.numpy else 'Arkouda'} array creation"
         )
         benchmark.extra_info["problem_size"] = N
+        benchmark.extra_info["num_bytes"] = num_bytes
         #   units are GiB/sec:
-        benchmark.extra_info["transfer_rate"] = float((nbytes / benchmark.stats["mean"]) / 2**30)
+        benchmark.extra_info["transfer_rate"] = float((num_bytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/array_transfer_benchmark.py
+++ b/benchmark_v2/array_transfer_benchmark.py
@@ -1,3 +1,4 @@
+from benchmark_utils import calc_num_bytes
 import pytest
 
 import arkouda as ak
@@ -10,11 +11,9 @@ def create_ak_array(N, dtype):
         u1 = ak.randint(0, 2**32, N, dtype=ak.uint64, seed=pytest.seed)
         u2 = ak.randint(0, 2**32, N, dtype=ak.uint64, seed=pytest.seed)
         a = ak.bigint_from_uint_arrays([u1, u2], max_bits=pytest.max_bits)
-        nb = a.size * 8 if pytest.max_bits != -1 and pytest.max_bits <= 64 else a.size * 16
     else:
         a = ak.randint(0, 2**32, N, dtype=dtype, seed=pytest.seed)
-        nb = a.size * a.itemsize
-    return a, nb
+    return a
 
 
 @pytest.mark.benchmark(group="ArrayTransfer_tondarray")
@@ -22,19 +21,20 @@ def create_ak_array(N, dtype):
 def bench_array_transfer_tondarray(benchmark, dtype):
     if dtype in pytest.dtype:
         N = pytest.N
-        a, nb = create_ak_array(N, dtype)
-        ak.client.maxTransferBytes = nb
+        a = create_ak_array(N, dtype)
+        num_bytes = calc_num_bytes(a)
+        ak.client.maxTransferBytes = num_bytes
 
         def to_nd():
             a.to_ndarray()
-            return nb
 
-        numBytes = benchmark.pedantic(to_nd, rounds=pytest.trials)
+        benchmark.pedantic(to_nd, rounds=pytest.trials)
 
         benchmark.extra_info["description"] = "Measures the performance of pdarray.to_ndarray"
         benchmark.extra_info["problem_size"] = N
+        benchmark.extra_info["num_bytes"] = num_bytes
         #   units are GiB/sec:
-        benchmark.extra_info["transfer_rate"] = float((numBytes / benchmark.stats["mean"]) / 2**30)
+        benchmark.extra_info["transfer_rate"] = float((num_bytes / benchmark.stats["mean"]) / 2**30)
         benchmark.extra_info["max_bit"] = pytest.max_bits
 
 
@@ -43,18 +43,19 @@ def bench_array_transfer_tondarray(benchmark, dtype):
 def bench_array_transfer_akarray(benchmark, dtype):
     if dtype in pytest.dtype:
         N = pytest.N
-        a, nb = create_ak_array(N, dtype)
-        ak.client.maxTransferBytes = nb
+        a = create_ak_array(N, dtype)
+        num_bytes = calc_num_bytes(a)
+        ak.client.maxTransferBytes = num_bytes
         npa = a.to_ndarray()
 
         def from_np():
             ak.array(npa, max_bits=pytest.max_bits)
-            return nb
 
-        numBytes = benchmark.pedantic(from_np, rounds=pytest.trials)
+        benchmark.pedantic(from_np, rounds=pytest.trials)
 
         benchmark.extra_info["description"] = "Measures the performance of ak.array"
         benchmark.extra_info["problem_size"] = N
+        benchmark.extra_info["num_bytes"] = num_bytes
         #   units are GiB/sec:
-        benchmark.extra_info["transfer_rate"] = float((numBytes / benchmark.stats["mean"]) / 2**30)
+        benchmark.extra_info["transfer_rate"] = float((num_bytes / benchmark.stats["mean"]) / 2**30)
         benchmark.extra_info["max_bit"] = pytest.max_bits

--- a/benchmark_v2/benchmark_utils.py
+++ b/benchmark_v2/benchmark_utils.py
@@ -1,0 +1,59 @@
+from builtins import sum as py_sum
+
+import numpy as np
+import pytest
+
+import arkouda as ak
+
+
+def calc_num_bytes(a) -> int:
+    """
+    Recursively calculate bytes for Arkouda arrays/strings and container types.
+    Handles dicts, lists/tuples, and DataFrame-like objects (duck-typed).
+    """
+    # dict: sum values
+    if isinstance(a, dict):
+        return py_sum(calc_num_bytes(v) for v in a.values())
+
+    # DataFrame-like (duck typing)
+    if hasattr(a, "columns") and hasattr(a, "__getitem__"):
+        try:
+            return py_sum(calc_num_bytes(a[c]) for c in a.columns)
+        except Exception:
+            pass
+
+    # Generic iterables (but not strings/bytes)
+    if hasattr(a, "__iter__") and not isinstance(a, (str, bytes)):
+        try:
+            return py_sum(calc_num_bytes(v) for v in a)
+        except Exception:
+            pass
+
+    # Arkouda arrays
+    if isinstance(a, ak.pdarray):
+        if a.dtype == "bigint":
+            return a.size * 8 if 0 < pytest.max_bits <= 64 else a.size * 16
+        else:
+            return a.nbytes
+    if isinstance(a, ak.Strings):
+        num_bytes = a.get_bytes().nbytes + a.get_offsets().nbytes
+        if hasattr(a, "entry"):
+            num_bytes += a.entry.nbytes
+        return num_bytes
+    if isinstance(a, ak.Categorical):
+        num_bytes = 0
+        if hasattr(a, "codes"):
+            num_bytes += a.codes.nbytes
+        if hasattr(a, "categories"):
+            num_bytes += a.categories.nbytes
+        if hasattr(a, "segments"):
+            num_bytes += a.segments.nbytes
+        if hasattr(a, "permutation"):
+            num_bytes += a.permutation.nbytes
+        return num_bytes
+    if isinstance(a, ak.SegArray):
+        return a.values.nbytes + a.segments.nbytes
+    if isinstance(a, np.ndarray):
+        return a.nbytes
+
+    raise TypeError(f"Unhandled type {type(a)} in calc_nbytes")

--- a/benchmark_v2/bigint_bitwise_binops_benchmark.py
+++ b/benchmark_v2/bigint_bitwise_binops_benchmark.py
@@ -24,7 +24,7 @@ def bench_bitwise_binops(benchmark, op):
     Measures the performance of bigint bitwise binops
     """
     N = pytest.N
-    nbytes = compute_nbytes(N)
+    num_bytes = compute_nbytes(N)
 
     a = generate_bigint_pair(N)
     b = generate_bigint_pair(N)
@@ -33,22 +33,22 @@ def bench_bitwise_binops(benchmark, op):
 
         def do_op():
             _ = a & b
-            return nbytes
+
     elif op == "or":
 
         def do_op():
             _ = a | b
-            return nbytes
+
     elif op == "shift":
 
         def do_op():
             _ = a >> 10
-            return nbytes
 
-    result = benchmark.pedantic(do_op, rounds=pytest.trials)
+    benchmark.pedantic(do_op, rounds=pytest.trials)
 
     benchmark.extra_info["description"] = "Measures the performance of bigint bitwise binops"
     benchmark.extra_info["problem_size"] = N
+    benchmark.extra_info["num_bytes"] = num_bytes
     #   units are GiB/sec:
-    benchmark.extra_info["transfer_rate"] = float((result / benchmark.stats["mean"]) / 2**30)
+    benchmark.extra_info["transfer_rate"] = float((num_bytes / benchmark.stats["mean"]) / 2**30)
     benchmark.extra_info["max_bit"] = pytest.max_bits

--- a/benchmark_v2/coargsort_benchmark.py
+++ b/benchmark_v2/coargsort_benchmark.py
@@ -1,3 +1,4 @@
+from benchmark_utils import calc_num_bytes
 import numpy as np
 import pytest
 
@@ -29,11 +30,7 @@ def bench_coargsort(benchmark, dtype, numArrays):
         elif dtype == "str":
             arrs = [ak.random_strings_uniform(1, 16, N // numArrays, seed=s) for s in seeds]
 
-        nbytes = (
-            sum(a.size * a.itemsize for a in arrs)
-            if dtype != "str"
-            else sum(a.nbytes * a.entry.itemsize for a in arrs)
-        )
+        num_bytes = calc_num_bytes(arrs)
 
         if pytest.numpy:
             arrs = [a.to_ndarray() for a in arrs]
@@ -45,5 +42,6 @@ def bench_coargsort(benchmark, dtype, numArrays):
 
         benchmark.extra_info["description"] = "Measures the performance of ak.coargsort"
         benchmark.extra_info["problem_size"] = N
+        benchmark.extra_info["num_bytes"] = num_bytes
         #   units are GiB/sec:
-        benchmark.extra_info["transfer_rate"] = float((nbytes / benchmark.stats["mean"]) / 2**30)
+        benchmark.extra_info["transfer_rate"] = float((num_bytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/csv_io_benchmark.py
+++ b/benchmark_v2/csv_io_benchmark.py
@@ -4,6 +4,7 @@ import os
 import pytest
 
 import arkouda as ak
+from benchmark_v2.benchmark_utils import calc_num_bytes
 
 TYPES = ("str", "int64", "float64", "uint64")
 
@@ -58,12 +59,13 @@ def bench_csv_io(benchmark, tmp_path, dtype, op):
         benchmark.pedantic(run, rounds=trials)
         remove_files(str(path))
 
-    num_bytes = a.nbytes
+    num_bytes = calc_num_bytes(a)
 
     benchmark.extra_info["description"] = f"CSV {op} benchmark for dtype={dtype}"
     benchmark.extra_info["problem_size"] = N
     benchmark.extra_info["dtype"] = dtype
     benchmark.extra_info["operation"] = op
     benchmark.extra_info["backend"] = "Arkouda"
+    benchmark.extra_info["num_bytes"] = num_bytes
     #   units are GiB/sec:
     benchmark.extra_info["transfer_rate"] = float((num_bytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/encoding_benchmark.py
+++ b/benchmark_v2/encoding_benchmark.py
@@ -19,18 +19,18 @@ def compute_nbytes(a):
 def bench_encode(benchmark, encoding):
     N = pytest.N
     a = generate_string_array(N)
-    nbytes = compute_nbytes(a)
+    num_bytes = compute_nbytes(a)
 
     def encode_op():
         encoded = a.encode(encoding)  # noqa: F841
-        return nbytes
 
-    numBytes = benchmark.pedantic(encode_op, rounds=pytest.trials)
+    benchmark.pedantic(encode_op, rounds=pytest.trials)
 
     benchmark.extra_info["description"] = f"Measures the performance of Strings.encode with '{encoding}'"
     benchmark.extra_info["problem_size"] = N
+    benchmark.extra_info["num_bytes"] = num_bytes
     #   units are GiB/sec:
-    benchmark.extra_info["transfer_rate"] = float((numBytes / benchmark.stats["mean"]) / 2**30)
+    benchmark.extra_info["transfer_rate"] = float((num_bytes / benchmark.stats["mean"]) / 2**30)
 
 
 @pytest.mark.skip_numpy(True)
@@ -40,15 +40,15 @@ def bench_decode(benchmark, encoding):
     N = pytest.N
     a = generate_string_array(N)
     encoded = a.encode(encoding)
-    nbytes = compute_nbytes(a)
+    num_bytes = compute_nbytes(a)
 
     def decode_op():
         decoded = encoded.decode(encoding)  # noqa: F841
-        return nbytes
 
-    numBytes = benchmark.pedantic(decode_op, rounds=pytest.trials)
+    benchmark.pedantic(decode_op, rounds=pytest.trials)
 
     benchmark.extra_info["description"] = f"Measures the performance of Strings.decode with '{encoding}'"
     benchmark.extra_info["problem_size"] = N
+    benchmark.extra_info["num_bytes"] = num_bytes
     #   units are GiB/sec:
-    benchmark.extra_info["transfer_rate"] = float((numBytes / benchmark.stats["mean"]) / 2**30)
+    benchmark.extra_info["transfer_rate"] = float((num_bytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/find_benchmark.py
+++ b/benchmark_v2/find_benchmark.py
@@ -1,3 +1,4 @@
+from benchmark_utils import calc_num_bytes
 import pytest
 
 import arkouda as ak
@@ -32,10 +33,7 @@ def bench_find(benchmark, dtype):
     # Select query values from the space to guarantee matches
     query = space[ak.randint(0, N, qN, seed=seed + 1)]
 
-    if dtype == "str":
-        nbytes = space.nbytes * space.entry.itemsize + query.nbytes * query.entry.itemsize
-    else:
-        nbytes = (space.size + query.size) * space.itemsize
+    num_bytes = calc_num_bytes((space, query))
 
     benchmark.pedantic(
         ak.find,
@@ -47,6 +45,7 @@ def bench_find(benchmark, dtype):
     benchmark.extra_info["description"] = "Measures the performance of ak.find with all_occurrences=True"
     benchmark.extra_info["problem_size"] = N
     benchmark.extra_info["query_size"] = qN
+    benchmark.extra_info["num_bytes"] = num_bytes
     benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-        (nbytes / benchmark.stats["mean"]) / 2**30
+        (num_bytes / benchmark.stats["mean"]) / 2**30
     )

--- a/benchmark_v2/flatten_benchmark.py
+++ b/benchmark_v2/flatten_benchmark.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 import arkouda as ak
+from benchmark_v2.benchmark_utils import calc_num_bytes
 
 DTYPES = ("int64", "float64", "bool")
 
@@ -40,12 +41,12 @@ def bench_ak_flatten_2d(benchmark, dtype, shape_type):
     def flatten_op():
         return arr2d.flatten()
 
-    numBytes = benchmark.pedantic(flatten_op, rounds=pytest.trials)  # noqa: F841
+    benchmark.pedantic(flatten_op, rounds=pytest.trials)
+    num_bytes = calc_num_bytes(data)
 
     benchmark.extra_info["description"] = f"Measures ak.flatten (np-style) on dtype={dtype}"
     benchmark.extra_info["problem_size"] = N
     benchmark.extra_info["backend"] = "Arkouda"
+    benchmark.extra_info["num_bytes"] = num_bytes
     #   units are GiB/sec:
-    benchmark.extra_info["transfer_rate"] = float(
-        (data.size * data.itemsize / benchmark.stats["mean"]) / 2**30
-    )
+    benchmark.extra_info["transfer_rate"] = float((num_bytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/in1d_benchmark.py
+++ b/benchmark_v2/in1d_benchmark.py
@@ -1,3 +1,4 @@
+from benchmark_utils import calc_num_bytes
 import pytest
 
 import arkouda as ak
@@ -25,18 +26,19 @@ def bench_in1d(benchmark, dtype, size):
         if dtype == "str":
             a = ak.random_strings_uniform(1, MAXSTRLEN, N)
             b = ak.random_strings_uniform(1, MAXSTRLEN, s)
-            nbytes = a.size * 8 + a.nbytes + b.size * 8 + b.nbytes
+            num_bytes = calc_num_bytes((a, b))
         else:
             a = ak.arange(N) % SIZES["LARGE"]
             b = ak.arange(s)
             if dtype == "uint64":
                 a = ak.cast(a, ak.uint64)
                 b = ak.cast(b, ak.uint64)
-            nbytes = a.size * a.itemsize + b.size * b.itemsize
+            num_bytes = calc_num_bytes((a, b))
 
         benchmark.pedantic(ak.in1d, args=[a, b], rounds=pytest.trials)
         benchmark.extra_info["description"] = "in1d benchmark using Arkouda"
         benchmark.extra_info["backend"] = "Arkouda"
         benchmark.extra_info["problem_size"] = N
+        benchmark.extra_info["num_bytes"] = num_bytes
         #   units are GiB/sec:
-        benchmark.extra_info["transfer_rate"] = float((nbytes / benchmark.stats["mean"]) / 2**30)
+        benchmark.extra_info["transfer_rate"] = float((num_bytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/parquet-fixed-strings_benchmark.py
+++ b/benchmark_v2/parquet-fixed-strings_benchmark.py
@@ -1,3 +1,4 @@
+from benchmark_utils import calc_num_bytes
 import pytest
 
 import arkouda as ak
@@ -14,7 +15,7 @@ def bench_parquet_fixed_strings(benchmark, tmp_path, scaling, fixed_len, nfiles)
     base_path.mkdir(parents=True, exist_ok=True)
 
     strings = ak.random_strings_uniform(fixed_len, fixed_len + 1, N, seed=pytest.seed)
-    numBytes = strings.nbytes
+    num_bytes = calc_num_bytes(strings)
 
     strings.to_parquet(base_path / "part_0.parquet")
 
@@ -32,5 +33,6 @@ def bench_parquet_fixed_strings(benchmark, tmp_path, scaling, fixed_len, nfiles)
     benchmark.extra_info["scaling"] = scaling
     benchmark.extra_info["nfiles"] = nfiles
     benchmark.extra_info["backend"] = "Arkouda"
+    benchmark.extra_info["num_bytes"] = num_bytes
     #   units are GiB/sec:
-    benchmark.extra_info["transfer_rate"] = float((numBytes / benchmark.stats["mean"]) / 2**30)
+    benchmark.extra_info["transfer_rate"] = float((num_bytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/reduce_benchmark.py
+++ b/benchmark_v2/reduce_benchmark.py
@@ -1,3 +1,4 @@
+from benchmark_utils import calc_num_bytes
 import pytest
 
 import arkouda as ak
@@ -36,9 +37,10 @@ def bench_reduce(benchmark, op, dtype):
         backend = "Arkouda"
 
     benchmark.pedantic(fxn, rounds=pytest.trials)
-    nbytes = a.size * a.itemsize
+    num_bytes = calc_num_bytes(a)
     benchmark.extra_info["description"] = f"Reduce: {op} ({backend})"
     benchmark.extra_info["problem_size"] = N
     benchmark.extra_info["backend"] = backend
+    benchmark.extra_info["num_bytes"] = num_bytes
     #   units are GiB/sec:
-    benchmark.extra_info["transfer_rate"] = float((nbytes / benchmark.stats["mean"]) / 2**30)
+    benchmark.extra_info["transfer_rate"] = float((num_bytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/reformat_benchmark_results.py
+++ b/benchmark_v2/reformat_benchmark_results.py
@@ -32,7 +32,6 @@ BENCHMARKS = [
     "argsort",
     "coargsort",
     "groupby",
-    # "flatten",
     "aggregate",
     "gather",
     "scatter",

--- a/benchmark_v2/scan_benchmark.py
+++ b/benchmark_v2/scan_benchmark.py
@@ -1,3 +1,4 @@
+from benchmark_utils import calc_num_bytes
 import numpy as np
 import pytest
 
@@ -42,10 +43,11 @@ def bench_scan(benchmark, op, dtype):
         backend = "Arkouda"
 
     benchmark.pedantic(fxn, args=[a], rounds=pytest.trials)
-    nbytes = a.size * a.itemsize * 2
+    num_bytes = 2 * calc_num_bytes(a)
 
     benchmark.extra_info["description"] = f"Scan: {op} using {backend}"
     benchmark.extra_info["problem_size"] = N
     benchmark.extra_info["backend"] = backend
+    benchmark.extra_info["num_bytes"] = num_bytes
     #   units are GiB/sec:
-    benchmark.extra_info["transfer_rate"] = float((nbytes / benchmark.stats["mean"]) / 2**30)
+    benchmark.extra_info["transfer_rate"] = float((num_bytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/setops_multiarray_benchmark.py
+++ b/benchmark_v2/setops_multiarray_benchmark.py
@@ -1,3 +1,4 @@
+from benchmark_utils import calc_num_bytes
 import pytest
 
 import arkouda as ak
@@ -29,10 +30,11 @@ def bench_setops_multiarray(benchmark, op, dtype):
 
     fxn = getattr(ak, op)
     benchmark.pedantic(fxn, args=([a, b], [c, d]), rounds=pytest.trials)
-    bytes_processed = 4 * a.size * a.itemsize
+    num_bytes = calc_num_bytes((a, b, c, d))
 
     benchmark.extra_info["description"] = f"Multiarray set operation: {op} on dtype={dtype}"
     benchmark.extra_info["problem_size"] = N
     benchmark.extra_info["backend"] = "Arkouda"
+    benchmark.extra_info["num_bytes"] = num_bytes
     #   units are GiB/sec:
-    benchmark.extra_info["transfer_rate"] = float((bytes_processed / benchmark.stats["mean"]) / 2**30)
+    benchmark.extra_info["transfer_rate"] = float((num_bytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/shuffle_benchmark.py
+++ b/benchmark_v2/shuffle_benchmark.py
@@ -1,3 +1,4 @@
+from benchmark_utils import calc_num_bytes
 import pytest
 
 import arkouda as ak
@@ -31,8 +32,8 @@ def bench_shuffle(benchmark, dtype, method):
     # Create RNG
     rng = ak.random.default_rng(seed)
 
-    # Compute bytes involved (string arrays report nbytes appropriately)
-    nbytes = pda.nbytes
+    # Compute bytes involved (string arrays report num_bytes appropriately)
+    num_bytes = calc_num_bytes(pda)
 
     # Benchmark: shuffle in place
     benchmark.pedantic(
@@ -47,6 +48,7 @@ def bench_shuffle(benchmark, dtype, method):
         f"Shuffles a 1..N array with dtype={dtype} using rng.shuffle(method='{method}')."
     )
     benchmark.extra_info["problem_size"] = N
+    benchmark.extra_info["num_bytes"] = num_bytes
     benchmark.extra_info["transfer_rate"] = "{:.4f} GiB/sec".format(
-        (nbytes / benchmark.stats["mean"]) / 2**30
+        (num_bytes / benchmark.stats["mean"]) / 2**30
     )

--- a/benchmark_v2/small-str-groupby.py
+++ b/benchmark_v2/small-str-groupby.py
@@ -1,3 +1,4 @@
+from benchmark_utils import calc_num_bytes
 import pytest
 
 import arkouda as ak
@@ -13,17 +14,13 @@ def bench_groupby_small_str(benchmark, strlen_label):
     strlen = SIZES[strlen_label]
 
     a = ak.random_strings_uniform(1, strlen, N, seed=pytest.seed)
-    totalbytes = a.nbytes
-
-    def run():
-        _ = ak.GroupBy(a)
-        return totalbytes
-
-    bytes_processed = benchmark.pedantic(run, rounds=pytest.trials)
+    num_bytes = calc_num_bytes(a)
+    benchmark.pedantic(ak.GroupBy, args=[a], rounds=pytest.trials)
 
     benchmark.extra_info["description"] = f"GroupBy construction benchmark with {strlen_label} strings"
     benchmark.extra_info["problem_size"] = N
     benchmark.extra_info["backend"] = "Arkouda"
     benchmark.extra_info["string_length"] = strlen
+    benchmark.extra_info["num_bytes"] = num_bytes
     #   units are GiB/sec:
-    benchmark.extra_info["transfer_rate"] = float((bytes_processed / benchmark.stats["mean"]) / 2**30)
+    benchmark.extra_info["transfer_rate"] = float((num_bytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/split_benchmark.py
+++ b/benchmark_v2/split_benchmark.py
@@ -1,3 +1,4 @@
+from benchmark_utils import calc_num_bytes
 import pytest
 
 import arkouda as ak
@@ -17,16 +18,13 @@ def bench_split(benchmark, label, delim, use_regex):
 
     thirds = [ak.cast(ak.arange(i, N * 3, 3), "str") for i in range(3)]
     thickrange = thirds[0].stick(thirds[1], delimiter="_").stick(thirds[2], delimiter="_")
-    nbytes = thickrange.nbytes
+    num_bytes = calc_num_bytes(thickrange)
 
-    def run():
-        thickrange.split(delim, regex=use_regex)
-        return nbytes
-
-    num_bytes = benchmark.pedantic(run, rounds=pytest.trials)
+    benchmark.pedantic(thickrange.split, args=[delim], kwargs={"regex": use_regex}, rounds=pytest.trials)
 
     benchmark.extra_info["description"] = f"Performance of Strings.split (mode: {label})"
     benchmark.extra_info["problem_size"] = N
     benchmark.extra_info["backend"] = "Arkouda"
+    benchmark.extra_info["num_bytes"] = num_bytes
     #   units are GiB/sec:
     benchmark.extra_info["transfer_rate"] = float((num_bytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/str_locality_benchmark.py
+++ b/benchmark_v2/str_locality_benchmark.py
@@ -1,3 +1,4 @@
+from benchmark_utils import calc_num_bytes
 import pytest
 
 import arkouda as ak
@@ -42,14 +43,15 @@ def bench_str_locality(benchmark, op, loc):
 
     def run():
         OPS[op](data)
-        return data.nbytes
 
-    nbytes = benchmark.pedantic(run, rounds=pytest.trials)
+    benchmark.pedantic(run, rounds=pytest.trials)
+    num_bytes = calc_num_bytes(data)
 
     benchmark.extra_info["description"] = (
         f"Benchmark of String locality effects: operation={op}, locality={loc}"
     )
     benchmark.extra_info["problem_size"] = data.size
     benchmark.extra_info["backend"] = "Arkouda"
+    benchmark.extra_info["num_bytes"] = num_bytes
     #   units are GiB/sec:
-    benchmark.extra_info["transfer_rate"] = float((nbytes / benchmark.stats["mean"]) / 2**30)
+    benchmark.extra_info["transfer_rate"] = float((num_bytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/stream_benchmark.py
+++ b/benchmark_v2/stream_benchmark.py
@@ -1,3 +1,4 @@
+from benchmark_utils import calc_num_bytes
 import numpy as np
 import pytest
 
@@ -20,7 +21,6 @@ def check_numpy_equivalence(a, b, alpha, result):
 @pytest.mark.parametrize("dtype", ["int64", "float64"])
 def bench_stream(benchmark, dtype):
     N = pytest.N
-    nBytes = N * 8 * 3
 
     if pytest.random or pytest.seed is not None:
         if dtype == "int64":
@@ -37,18 +37,20 @@ def bench_stream(benchmark, dtype):
         a, b = a.to_ndarray(), b.to_ndarray()
 
     benchmark.pedantic(run_test, args=(a, b, pytest.alpha), rounds=pytest.trials)
+    num_bytes = 3 * calc_num_bytes(a)
 
     benchmark.extra_info["description"] = f"Measures performance of stream using {dtype} types."
     benchmark.extra_info["problem_size"] = N
+    benchmark.extra_info["num_bytes"] = num_bytes
     #   units are GiB/sec:
-    benchmark.extra_info["transfer_rate"] = float((nBytes / benchmark.stats["mean"]) / 2**30)
+    benchmark.extra_info["transfer_rate"] = float((num_bytes / benchmark.stats["mean"]) / 2**30)
 
 
 @pytest.mark.benchmark(group="stream")
 @pytest.mark.parametrize("dtype", ["bigint"])
 def bench_bigint_stream(benchmark, dtype):
     N = pytest.N
-    nBytes = N * 8 * 3
+    num_bytes = 0
 
     if pytest.random or pytest.seed is not None:
         a1 = ak.randint(0, 2**32, N, dtype=ak.uint64, seed=pytest.seed)
@@ -59,15 +61,17 @@ def bench_bigint_stream(benchmark, dtype):
         b2 = ak.randint(0, 2**32, N, dtype=ak.uint64, seed=pytest.seed)
         b = ak.bigint_from_uint_arrays([b1, b2], max_bits=pytest.max_bits)
 
-        nBytes *= 2
+        num_bytes += calc_num_bytes((b1, b2)) + 2 * calc_num_bytes((b1, b2))
     else:
         a = ak.bigint_from_uint_arrays([ak.ones(N, dtype=ak.uint64)], max_bits=pytest.max_bits)
         b = ak.bigint_from_uint_arrays([ak.ones(N, dtype=ak.uint64)], max_bits=pytest.max_bits)
+        num_bytes += calc_num_bytes(a) + 2 * calc_num_bytes(b)
 
     benchmark.pedantic(run_test, args=(a, b, int(pytest.alpha)), rounds=pytest.trials)
 
     # Can't do numpy comparison for bigint yet
     benchmark.extra_info["description"] = f"Measures performance of stream using {dtype} types."
     benchmark.extra_info["problem_size"] = N
+    benchmark.extra_info["num_bytes"] = num_bytes
     #   units are GiB/sec:
-    benchmark.extra_info["transfer_rate"] = float((nBytes / benchmark.stats["mean"]) / 2**30)
+    benchmark.extra_info["transfer_rate"] = float((num_bytes / benchmark.stats["mean"]) / 2**30)

--- a/benchmark_v2/substring_search_benchmark.py
+++ b/benchmark_v2/substring_search_benchmark.py
@@ -1,3 +1,4 @@
+from benchmark_utils import calc_num_bytes
 import pytest
 
 import arkouda as ak
@@ -22,11 +23,11 @@ def bench_strings_contains(benchmark, search_string, use_regex):
     # each string in test_substring contains '1 string 1' with random strings before and after
     a = start.stick(end, delimiter="1 string 1")
 
-    def run():
-        a.contains(search_string, regex=use_regex)
-        return a.nbytes
+    num_bytes = calc_num_bytes(a)
 
-    num_bytes = benchmark.pedantic(run, rounds=pytest.trials)
+    benchmark.pedantic(
+        a.contains, args=[search_string], kwargs={"regex": use_regex}, rounds=pytest.trials
+    )
     benchmark.extra_info["description"] = (
         f"Benchmark for Strings.contains with regex={use_regex} and search_string={search_string}"
     )
@@ -34,5 +35,6 @@ def bench_strings_contains(benchmark, search_string, use_regex):
     benchmark.extra_info["backend"] = "Arkouda"
     benchmark.extra_info["search_string"] = search_string
     benchmark.extra_info["regex"] = use_regex
+    benchmark.extra_info["num_bytes"] = num_bytes
     #   units are GiB/sec:
     benchmark.extra_info["transfer_rate"] = float((num_bytes / benchmark.stats["mean"]) / 2**30)


### PR DESCRIPTION
This PR creates a `calc_num_bytes` function to unify the calculation of transfer bytes across `benchmarks_v2`.

Closes #4824:  In benchmarks_v2/io_benchmark.py read Average rate is always zero
Closes #4765:  unify handling of num_bytes in benchmarks_v2 