### PR TITLE
Use CI image with jemalloc for faster build times

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,7 @@ jobs:
     env:
       CHPL_HOME: /opt/chapel-2.4.0
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.2
+      image: ajpotts/ubuntu-with-arkouda-deps:1.0.3
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
@@ -109,7 +109,7 @@ jobs:
     env:
       CHPL_HOME: /opt/chapel-2.4.0
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.2
+      image: ajpotts/ubuntu-with-arkouda-deps:1.0.3
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
@@ -132,7 +132,7 @@ jobs:
     env:
       CHPL_HOME: /opt/chapel-2.4.0
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.2
+      image: ajpotts/ubuntu-with-arkouda-deps:1.0.3
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
@@ -171,7 +171,7 @@ jobs:
   flake8:
     runs-on: ubuntu-latest
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.2
+      image: ajpotts/ubuntu-with-arkouda-deps:1.0.3
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
@@ -204,7 +204,7 @@ jobs:
     env:
       CHPL_HOME: /opt/chapel-2.4.0
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.2
+      image: ajpotts/ubuntu-with-arkouda-deps:1.0.3
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
@@ -346,7 +346,7 @@ jobs:
     env:
       CHPL_HOME: /opt/chapel-2.4.0
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.2
+      image: ajpotts/ubuntu-with-arkouda-deps:1.0.3
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4    
@@ -444,7 +444,7 @@ jobs:
     env:
       CHPL_HOME: /opt/chapel-${{ matrix.chpl-version }}
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.2
+      image: ajpotts/ubuntu-with-arkouda-deps:1.0.3
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
@@ -493,7 +493,7 @@ jobs:
     env:
       CHPL_HOME: /opt/chapel-${{ matrix.chpl-version }}
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.2
+      image: ajpotts/ubuntu-with-arkouda-deps:1.0.3
     steps:
     - name: Show memory available
       run: |
@@ -552,7 +552,7 @@ jobs:
       CHPL_RT_NUM_THREADS_PER_LOCALE: 2
       CHPL_HOME: /opt/chapel-2.4.0
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.2
+      image: ajpotts/ubuntu-with-arkouda-deps:1.0.3
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
@@ -603,7 +603,7 @@ jobs:
     env:
       CHPL_HOME: /opt/chapel-2.4.0
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.2
+      image: ajpotts/ubuntu-with-arkouda-deps:1.0.3
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       CHPL_HOME: /opt/chapel-2.4.0
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.2
+      image: ajpotts/ubuntu-with-arkouda-deps:1.0.3
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4

--- a/docker/ubuntu-with-arkouda-deps/1.0.3/Dockerfile
+++ b/docker/ubuntu-with-arkouda-deps/1.0.3/Dockerfile
@@ -1,0 +1,130 @@
+FROM ubuntu:24.04
+
+USER root
+
+ENV PATH=/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/venv/bin
+
+ENV CHPL_HOME=/opt/chapel-2.4.0
+ENV CHPL_RE2=bundled
+ENV CHPL_GMP=bundled
+ENV CHPL_COMM=none
+ENV CHPL_TARGET_CPU=native
+ENV MANPATH=/opt/chapel-2.4.0/man
+ENV CHPL_TASKS=qthreads
+ENV CHPL_TARGET_MEM=cstdlib
+# TODO: mimalloc is even faster (added in Chapel 2.5)
+ENV CHPL_HOST_MEM=jemalloc
+ENV CHPL_LLVM=none
+
+#   Set timezone, a prerequisite of the python3.12 install
+RUN ln -snf /usr/share/zoneinfo/$CONTAINER_TIMEZONE /etc/localtime && echo $CONTAINER_TIMEZONE > /etc/timezone
+
+WORKDIR /opt
+
+#   Set up environment variables
+COPY bashrc.local /opt/
+RUN mv /opt/bashrc.local ~/.bashrc.local && echo 'source ~/.bashrc.local' >> ~/.bashrc
+
+RUN apt-get -y update && apt-get -y upgrade
+RUN apt-get install -y software-properties-common && add-apt-repository ppa:deadsnakes/ppa
+RUN apt-get install -y python3.10 python3.10-venv python3.10-dev python3.11 python3.11-venv python3.11-dev python3.12 python3.12-venv python3.12-dev python3.13 python3.13-venv python3.13-dev
+RUN apt-get install -y python3-pip python3-virtualenv
+
+#   Install arkouda dependencies
+RUN apt-get update && apt-get install -y -V ca-certificates lsb-release wget libhdf5-dev
+RUN apt-get update && apt-get install -y libhdf5-dev hdf5-tools libzmq3-dev python3-pip libcurl4-openssl-dev libidn2-dev libzmq3-dev
+
+#   pip installs should use a virtual environment
+RUN python3 -m venv /venv
+RUN python3 -m pip install scikit-build versioneer setuptools wheel pytest-benchmark==3.2.2 py
+
+###############################################################################
+###                                                                         ###
+###     Install Chapel                                                      ###
+###                                                                         ###
+###############################################################################
+
+#  Install dependencies
+RUN apt-get install -y ca-certificates wget curl
+RUN apt-get install -y gcc g++ m4 perl python3-dev bash make mawk git pkg-config cmake
+RUN apt-get install -y llvm-dev llvm clang libclang-dev libclang-cpp-dev libedit-dev
+
+#   Download and install Chapel source
+RUN wget https://github.com/chapel-lang/chapel/releases/download/2.0.0/chapel-2.0.0.tar.gz && tar -xvf chapel-2.0.0.tar.gz && cd /opt/chapel-2.0.0 && CHPL_HOME=/opt/chapel-2.0.0 make
+RUN wget https://github.com/chapel-lang/chapel/releases/download/2.1.0/chapel-2.1.0.tar.gz && tar -xvf chapel-2.1.0.tar.gz && cd /opt/chapel-2.1.0 && CHPL_HOME=/opt/chapel-2.1.0 make
+RUN wget https://github.com/chapel-lang/chapel/releases/download/2.2.0/chapel-2.2.0.tar.gz && tar -xvf chapel-2.2.0.tar.gz && cd /opt/chapel-2.2.0 && CHPL_HOME=/opt/chapel-2.2.0 make
+RUN wget https://github.com/chapel-lang/chapel/releases/download/2.3.0/chapel-2.3.0.tar.gz && tar -xvf chapel-2.3.0.tar.gz && cd /opt/chapel-2.3.0 && CHPL_HOME=/opt/chapel-2.3.0 make
+RUN wget https://github.com/chapel-lang/chapel/releases/download/2.4.0/chapel-2.4.0.tar.gz && tar -xvf chapel-2.4.0.tar.gz && cd /opt/chapel-2.4.0 && CHPL_HOME=/opt/chapel-2.4.0 make
+
+# install chapel-py
+RUN cd  /opt/chapel-2.0.0  && CHPL_HOME=/opt/chapel-2.0.0  make chapel-py-venv
+RUN cd  /opt/chapel-2.1.0  && CHPL_HOME=/opt/chapel-2.1.0  make chapel-py-venv
+RUN cd  /opt/chapel-2.2.0  && CHPL_HOME=/opt/chapel-2.2.0  make chapel-py-venv
+RUN cd  /opt/chapel-2.3.0  && CHPL_HOME=/opt/chapel-2.3.0  make chapel-py-venv
+RUN cd  /opt/chapel-2.4.0  && CHPL_HOME=/opt/chapel-2.4.0  make chapel-py-venv
+
+#Install Chapel frontend bindings
+RUN python3 -m venv /venv
+RUN cd /opt/chapel-2.0.0/tools/chapel-py && CHPL_HOME=/opt/chapel-2.0.0 python3 -m pip install .
+RUN cd /opt/chapel-2.1.0/tools/chapel-py && CHPL_HOME=/opt/chapel-2.1.0 python3 -m pip install .
+RUN cd /opt/chapel-2.2.0/tools/chapel-py && CHPL_HOME=/opt/chapel-2.2.0 python3 -m pip install .
+RUN cd /opt/chapel-2.3.0/tools/chapel-py && CHPL_HOME=/opt/chapel-2.3.0 python3 -m pip install .
+RUN cd /opt/chapel-2.4.0/tools/chapel-py && CHPL_HOME=/opt/chapel-2.4.0 python3 -m pip install .
+
+#Install chpldoc
+RUN cd /opt/chapel-2.0.0 && CHPL_HOME=/opt/chapel-2.0.0 make chpldoc
+RUN cd /opt/chapel-2.1.0 && CHPL_HOME=/opt/chapel-2.1.0 make chpldoc
+RUN cd /opt/chapel-2.2.0 && CHPL_HOME=/opt/chapel-2.2.0 make chpldoc
+RUN cd /opt/chapel-2.3.0 && CHPL_HOME=/opt/chapel-2.3.0 make chpldoc
+RUN cd /opt/chapel-2.4.0 && CHPL_HOME=/opt/chapel-2.4.0 make chpldoc
+
+
+###############################################################################
+###                                                                         ###
+###     Install Arkouda Dependencies                                        ###
+###                                                                         ###
+###############################################################################
+
+
+ENV DEP_DIR=/opt/dep
+ENV DEP_BUILD_DIR=$DEP_DIR/build
+ENV DEP_INSTALL_DIR=$DEP_DIR/install
+ENV ARROW_DEP_DIR=$DEP_BUILD_DIR/arrow_dependencies
+
+RUN  mkdir -p $DEP_DIR && mkdir -p $DEP_BUILD_DIR && mkdir -p $DEP_INSTALL_DIR
+
+#   TODO:  Remove this step when the bzip2 repo is stable.
+#COPY build.tar $DEP_DIR/build.tar
+#RUN cd $DEP_DIR && tar -xvf build.tar
+
+#   Download clone arkouda repo and set to specific commit: https://github.com/Bears-R-Us/arkouda/pull/4342
+RUN cd /opt && git clone https://github.com/Bears-R-Us/arkouda.git && cd arkouda && cd /opt/arkouda && git checkout 33298be6ab0d75125ee6513e1d5375485c70676c
+WORKDIR /opt/arkouda
+
+#   This step will skip the download if the files are already in $DEP_BUILD_DIR
+RUN make deps-download-source DEP_BUILD_DIR=$DEP_BUILD_DIR
+
+RUN make install-arrow DEP_BUILD_DIR=$DEP_BUILD_DIR DEP_INSTALL_DIR=$DEP_INSTALL_DIR
+RUN make install-iconv DEP_BUILD_DIR=$DEP_BUILD_DIR DEP_INSTALL_DIR=$DEP_INSTALL_DIR
+RUN make install-pytables DEP_BUILD_DIR=$DEP_BUILD_DIR
+
+WORKDIR /opt
+RUN rm -fr arkouda
+
+
+###############################################################################
+###                                                                         ###
+###     Set defaults                                                        ###
+###                                                                         ###
+###############################################################################
+
+#   Save build environment to the .bashrc.local
+RUN env >> ~/.bashrc.local
+
+
+ENTRYPOINT ["/bin/bash", "-l"]
+
+
+
+
+

--- a/docker/ubuntu-with-arkouda-deps/1.0.3/bashrc.local
+++ b/docker/ubuntu-with-arkouda-deps/1.0.3/bashrc.local
@@ -1,0 +1,2 @@
+export ARKOUDA_QUICK_COMPILE=true 
+export ARKOUDA_SKIP_CHECK_DEPS=True


### PR DESCRIPTION
I noticed that the CI image is using CHPL_HOST_MEM=cstdlib. Chapel offers CHPL_HOST_MEM=jemalloc for improvement compiler performance.

I tested using Chapel main with the CI multi-dim array build and got the following build time results with ARKOUDA_QUICK_COMPILE=1

```bash
$ grep 'total time' build_cstdlib.log
     total time                         1025.550    4.665   60.767  1090.981
     total time                         1025.550    4.665   60.767  1090.981
     total time                         131.206    0.000    0.000  131.207
     total time                           0.560    0.000    0.000    0.560
          total time (front end) : 744.541 seconds
         total time (middle end) : 178.412 seconds
           total time (back end) : 299.235 seconds
                      total time :1222.748 seconds
$ grep 'total time' build_jemalloc.log
     total time                         809.735    3.098   28.300  841.133
     total time                         809.735    3.098   28.300  841.133
     total time                         128.679    0.032    0.000  128.711
     total time                           0.543    0.000    0.000    0.543
          total time (front end) : 644.966 seconds
         total time (middle end) : 119.373 seconds
           total time (back end) : 205.504 seconds
                      total time : 970.386 seconds
$ grep 'total time' build_mimalloc.log
     total time                         729.304    2.955   21.332  753.592
     total time                         729.304    2.955   21.332  753.592
     total time                         123.736    0.000    0.000  123.736
     total time                           0.529    0.000    0.000    0.529
          total time (front end) : 570.396 seconds
         total time (middle end) : 109.592 seconds
           total time (back end) : 197.340 seconds
                      total time : 877.857 seconds
```

Note that just switching to CHPL_HOST_MEM=jemalloc gives a 25% boost in performance when building Arkouda.

I will note that switching to CHPL_HOST_MEM=mimalloc is even faster (40% faster than baseline), but it was only added in Chapel 2.5 and so is not useful for all the versions of Chapel the CI supports.