### PR TITLE
Closes 4828, fixes some parametrizations

### DIFF
--- a/tests/numpy/pdarray_creation_test.py
+++ b/tests/numpy/pdarray_creation_test.py
@@ -416,7 +416,7 @@ class TestPdarrayCreation:
         assert (uint_array == int_array).all()
 
     @pytest.mark.parametrize("size", pytest.prob_size)
-    @pytest.mark.parametrize("dtype", [ak.float64, ak.uint64, ak.float64])
+    @pytest.mark.parametrize("dtype", [ak.int64, ak.uint64, ak.float64])
     @pytest.mark.parametrize("start", [0, 2, 5])
     @pytest.mark.parametrize("step", [1, 3])
     def test_compare_arange(self, size, dtype, start, step):

--- a/tests/numpy/sort_test.py
+++ b/tests/numpy/sort_test.py
@@ -36,7 +36,7 @@ class TestSort:
         assert result.failed == 0, f"Doctest failed: {result.failed} failures"
 
     @pytest.mark.parametrize("size", pytest.prob_size)
-    @pytest.mark.parametrize("dtype", [ak.float64, ak.uint64, ak.float64])
+    @pytest.mark.parametrize("dtype", [ak.int64, ak.uint64, ak.float64])
     def test_compare_argsort(self, size, dtype):
         # create np version
         a = np.arange(size, dtype=dtype)
@@ -51,7 +51,7 @@ class TestSort:
         assert np.array_equal(a, b.to_ndarray())
 
     @pytest.mark.parametrize("size", pytest.prob_size)
-    @pytest.mark.parametrize("dtype", [ak.float64, ak.uint64, ak.float64])
+    @pytest.mark.parametrize("dtype", [ak.int64, ak.uint64, ak.float64])
     def test_compare_sort(self, size, dtype):
         # create np version
         a = np.arange(size, dtype=dtype)


### PR DESCRIPTION
Closes #4828 

As noted in the issue, pdarray_creation_test.py and sort_test.py both had tests where dtypes was parametrized as [ak.float64, ak.uint64, ak.float64].  The first was clearly intended to be ak.int64, so this has been fixed.