### PR TITLE
Closes 4831, standardizes axis checking for cases where axis can only be an integer

### DIFF
--- a/arkouda/array_api/linalg.py
+++ b/arkouda/array_api/linalg.py
@@ -42,4 +42,4 @@ def vecdot(x1: Array, x2: Array, /, *, axis: int = -1) -> Array:
 
     from .array_object import Array
 
-    return Array._new(ak_vecdot(x1._array, x2._array))
+    return Array._new(ak_vecdot(x1._array, x2._array, axis))

--- a/arkouda/array_api/sorting_functions.py
+++ b/arkouda/array_api/sorting_functions.py
@@ -54,9 +54,6 @@ def sort(x: Array, /, *, axis: int = -1, descending: bool = False, stable: bool 
         Whether to use a stable sorting algorithm. Note: arkouda's sorting algorithm is always stable so
         this argument is ignored.
     """
-    if axis == -1:
-        axis = x.ndim - 1
-
     if x.dtype not in _real_numeric_dtypes:
         raise TypeError("Only real numeric dtypes are allowed in sort")
 

--- a/arkouda/numpy/pdarraycreation.py
+++ b/arkouda/numpy/pdarraycreation.py
@@ -36,12 +36,7 @@ from arkouda.numpy.dtypes import dtype as akdtype
 from arkouda.numpy.dtypes import float64, get_byteorder, get_server_byteorder
 from arkouda.numpy.dtypes import int64 as akint64
 from arkouda.numpy.dtypes import uint64 as akuint64
-from arkouda.numpy.pdarrayclass import (
-    _axis_validation,
-    broadcast_to_shape,
-    create_pdarray,
-    pdarray,
-)
+from arkouda.numpy.pdarrayclass import broadcast_to_shape, create_pdarray, pdarray
 from arkouda.numpy.strings import Strings
 
 if TYPE_CHECKING:
@@ -1320,7 +1315,7 @@ def linspace(
     from arkouda import newaxis
     from arkouda.numeric import transpose
     from arkouda.numpy.manipulation_functions import tile
-    from arkouda.numpy.util import broadcast_dims
+    from arkouda.numpy.util import _integer_axis_validation, broadcast_dims
 
     if dtype not in (None, float64):
         raise TypeError("dtype must be None or float64")
@@ -1377,9 +1372,9 @@ def linspace(
         # Handle the axis parameter if needed
 
         if axis != 0:
-            good, axis_ = _axis_validation(axis, result.ndim)
-            if not good:
-                raise ValueError(f"{axis} is not a valid axis for the result of linspace.")
+            valid, axis_ = _integer_axis_validation(axis, result.ndim)
+            if not valid:
+                raise IndexError(f"{axis} is not a valid axis for the result of linspace.")
             axes = list(range(result.ndim))
             axes[axis_] = 0
             axes[0] = axis_

--- a/arkouda/numpy/pdarraysetops.py
+++ b/arkouda/numpy/pdarraysetops.py
@@ -400,7 +400,7 @@ def concatenate(
     """
     from arkouda.client import generic_msg
     from arkouda.numpy.dtypes import int_scalars
-    from arkouda.numpy.util import get_callback
+    from arkouda.numpy.util import _integer_axis_validation, get_callback
     from arkouda.pandas.categorical import Categorical as Categorical_
     size: int_scalars = 0
     objtype = None
@@ -483,11 +483,14 @@ def concatenate(
             if isinstance(prev_arr, pdarray):
                 shape1 = prev_arr.shape
                 offsets[i] = offsets[i - 1] + shape1[0]
+        valid, axis_ = _integer_axis_validation(axis, arrays[0].ndim)
+        if not valid :
+            raise IndexError(f"{axis} is not a valid axis for array of rank {arrays[0].ndim}")
         repMsg = generic_msg(
             cmd=f"concatenate<{akdtype(dtype_).name},{arrays[0].ndim}>",
             args={
                 "names": list(arrays),
-                "axis": axis,
+                "axis": axis_,
                 "offsets": offsets,
             })
         if dtype_ == bigint:

--- a/tests/numpy/pdarrayclass_test.py
+++ b/tests/numpy/pdarrayclass_test.py
@@ -493,7 +493,7 @@ class TestPdarrayClass:
 
     def test_argsort_invalid_axis(self):
         a = ak.array([1, 2, 3])
-        with pytest.raises(ValueError, match="axis=2 is invalid for array with ndim=1"):
+        with pytest.raises(IndexError):
             a.argsort(axis=2)
 
     def test_argsort_axis_minus1(self):


### PR DESCRIPTION
Closes #4831, which is a subset of #4800

This covers the cases where the axis parameter can only be an integer.  This only applies to array_api and numpy functions, and not the pandas functions (where axis can be 0 or 1, "index" or "columns").

It doesn't cover the cases where the axis parameter can be a tuple.

Quick summary:

There is now a function in numpy/util.py called _integer_axis_validation.  It returns a bool and an int.  If the bool is false, the given axis wasn't valid, and in (I think) every case, an IndexError is raised.

There are several functions in array_api that just pass their parameters to arkouda/numpy functions with the same name.  In those cases, I don't bother to check at the array_api level.

Note that array_api's vecdot accepted an axis parameter, but didn't use it.  I changed that so that it passes the axis argument to the numpy function.  Also note that vecdot handles the axis validation differently than other functions, so it doesn't use the standard validation.

Also also note that expand_dims and stack are unique in that they check the validity against a rank 1 greater than the given input.