### PR TITLE
Fixes #4838:  make doc fails when building with chapel 2.5.0

### DIFF
--- a/src/compat/eq-22/ArkoudaSortCompat.chpl
+++ b/src/compat/eq-22/ArkoudaSortCompat.chpl
@@ -1,5 +1,5 @@
 module ArkoudaSortCompat {
-  public use Sort except defaultComparator, DefaultComparator;
+  public use Sort except defaultComparator;
 
   proc defaultComparator type {
     import Sort;


### PR DESCRIPTION
Fixes this `chpldoc` error found when running `make doc` against chapel 2.5:
```
arkouda/src/compat/eq-22/ArkoudaSortCompat.chpl:2: cannot use 'except' clause with symbol 'DefaultComparator' as it is not defined in 'Sort'
```

Closes #4838:  make doc fails when building with chapel 2.5.0