### PR TITLE
Closes #4853: Problem in shuffle docstring

### DIFF
--- a/tests/numpy/random_test.py
+++ b/tests/numpy/random_test.py
@@ -22,6 +22,7 @@ class TestRandom:
         result = doctest.testmod(random, optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)
         assert result.failed == 0, f"Doctest failed: {result.failed} failures"
 
+    @pytest.mark.skip_if_nl_neq(1)
     def test_random_generator_docstrings(self):
         import doctest
 


### PR DESCRIPTION
This just uses the annotation to skip the doctest if the number of locales is not 1.

Closes #4853: Problem in shuffle docstring