### PR TITLE
Incorporates standard for axis validation to array_api/manipulation_functions.py

### DIFF
--- a/arkouda/array_api/manipulation_functions.py
+++ b/arkouda/array_api/manipulation_functions.py
@@ -32,7 +32,20 @@ def broadcast_arrays(*arrays: Array) -> List[Array]:
     """
     Broadcast arrays to a common shape.
 
-    Throws a ValueError if a common shape cannot be determined.
+    Parameters
+    ----------
+    arrays : Array
+        The arrays to broadcast. Must be broadcastable to a common shape.
+
+    Raises
+    ------
+    ValueError
+        Raised by broadcast_dims if a common shape cannot be determined.
+
+    Returns
+    -------
+    List
+        A list whose elements are the given Arrays broadcasted to the common shape.
     """
     shapes = [a.shape for a in arrays]
     bcShape = shapes[0]
@@ -46,6 +59,23 @@ def broadcast_arrays(*arrays: Array) -> List[Array]:
 def broadcast_to(x: Array, /, shape: Tuple[int, ...]) -> Array:
     """
     Broadcast the array to the specified shape.
+
+    Parameters
+    ----------
+    x: Array
+        The array to be broadcast.
+    shape: Tuple[int, ...]
+        The shape to which the array is to be broadcast.
+
+    Raises
+    ------
+    ValueError
+        Raised server-side if the broadcast fails.
+
+    Returns
+    -------
+    Array
+        A new array which is x broadcast to the provided shape.
 
     See: https://data-apis.org/array-api/latest/API_specification/broadcasting.html for details.
     """
@@ -82,13 +112,42 @@ def concat(arrays: Union[Tuple[Array, ...], List[Array]], /, *, axis: Optional[i
         The axis along which to concatenate the arrays. The default is 0. If None, the arrays are
         flattened before concatenation.
 
+    Raises
+    ------
+    IndexError
+        Raised if axis is not a valid axis for the given arrays.
+    ValueError
+        Raised if array shapes are incompatible with concat.
+
+    Returns
+    -------
+    Array
+        A new Array which is the concatention of the given Arrays along the given axis.
+
     """
     from arkouda.client import generic_msg
+    from arkouda.numpy.util import _integer_axis_validation
+
+    # Check array ranks
 
     ndim = arrays[0].ndim
     for a in arrays:
         if a.ndim != ndim:
             raise ValueError("all input arrays must have the same number of dimensions to concatenate")
+
+    # Check axis
+
+    axis_ = axis
+    if axis_ is not None:
+        valid, axis_ = _integer_axis_validation(axis, ndim)
+        if not valid:
+            raise IndexError(f"{axis} is not a valid axis for array of rank {ndim}")
+
+    # Make all arrays a common type
+    # TODO: use a different approach to the common type.  The promotion function
+    # below uses numpy.common_types, which returns float, even when given all ints.
+    # That means this concat function will output a float, even if all arrays are ints.
+    # numpy concat does not do that.
 
     (common_dt, _arrays) = promote_to_common_dtype([a._array for a in arrays])
 
@@ -99,13 +158,13 @@ def concat(arrays: Union[Tuple[Array, ...], List[Array]], /, *, axis: Optional[i
                 generic_msg(
                     cmd=(
                         f"concat<{common_dt},{ndim}>"
-                        if axis is not None
+                        if axis_ is not None
                         else f"concatFlat<{common_dt},{ndim}>"
                     ),
                     args={
                         "n": len(arrays),
                         "names": _arrays,
-                        "axis": axis,
+                        "axis": axis_,
                     },
                 ),
             )
@@ -124,6 +183,16 @@ def expand_dims(x: Array, /, *, axis: int) -> Array:
     axis : int
         The axis at which to insert the new (size one) dimension. Must be in the range
         `[-x.ndim-1, x.ndim]`.
+
+    Raises
+    ------
+    IndexError
+        Raised if axis is not a valid axis for the given result.
+
+    Returns
+    -------
+    Array
+        A new Array with a new dimension equal to 1, inserted at the given axis.
     """
     from arkouda.client import generic_msg
     from arkouda.numpy.util import _integer_axis_validation
@@ -163,12 +232,27 @@ def flip(x: Array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None) -> 
         The array to flip
     axis : int or Tuple[int, ...], optional
         The axis or axes along which to flip the array. If None, flip the array along all axes.
+
+    Raises
+    ------
+    IndexError
+        Raised if the axis/axes is/are invalid for the given array, or if the flip
+        fails server-side.
+
+    Returns
+    -------
+    Array
+        A copy of x with the results reversed along the given axis or axes.
     """
     from arkouda.client import generic_msg
+    from arkouda.numpy.util import _axis_validation
 
     axisList = []
     if axis is not None:
-        axisList = list(axis) if isinstance(axis, tuple) else [axis]
+        valid, axisList = _axis_validation(axis, x.ndim)
+        if not valid:
+            raise IndexError(f"{axis} is not a valid axis/axes for array of rank {x.ndim}")
+
     try:
         return Array._new(
             create_pdarray(
@@ -193,6 +277,22 @@ def flip(x: Array, /, *, axis: Optional[Union[int, Tuple[int, ...]]] = None) -> 
         raise IndexError(f"Failed to flip array: {e}")
 
 
+#   The checking for source and destination axis validity in moveaxis is virtually identical
+#   whether the axes are supplied as integers or tuples, so it's done here.
+
+
+def _check_moveaxis_axes(s, d, nd, check_function):
+    valid_s, s_ = check_function(s, nd)
+    valid_d, d_ = check_function(d, nd)
+    if not (valid_s or valid_d):
+        raise IndexError(f"Neither source {s} nor destination {d} are valid for rank {nd}")
+    elif not valid_s:
+        raise IndexError(f"Source {s} is not valid for rank {nd}")
+    elif not valid_d:
+        raise IndexError(f"Destination {d} is not valid for rank {nd}")
+    return s_, d_
+
+
 def moveaxis(
     x: Array,
     source: Union[int, Tuple[int, ...]],
@@ -212,18 +312,43 @@ def moveaxis(
     destination : int or Tuple[int, ...]
         Destination positions for each of the original axes. Must be the same length as `source`.
         Values must be unique and fall within the range `[-x.ndim, x.ndim)`.
+
+    Raises
+    ------
+    ValueError
+        Raised if source and destination are not the same type (tuple or int).
+    IndexError
+        Raised if source, destination, or both are not valid for x.ndim.
+
+    Returns
+    -------
+    Array
+        A new Array with the axes shifted per the givern source, destination.
     """
+    from arkouda.numpy.util import _axis_validation, _integer_axis_validation
+
     perm = list(range(x.ndim))
-    if isinstance(source, tuple):
-        if isinstance(destination, tuple):
-            for s, d in zip(source, destination):
-                perm[s] = d
-        else:
-            raise ValueError("source and destination must both be tuples if source is a tuple")
-    elif isinstance(destination, int):
-        perm[source] = destination
+
+    # Do axis checking on the "both tuple" case.
+
+    if isinstance(source, tuple) and isinstance(destination, tuple):
+        source_, destination_ = _check_moveaxis_axes(source, destination, x.ndim, _axis_validation)
+        for s, d in zip(source_, destination_):
+            perm[s] = d
+
+    # Do axis checking on the "both integer" case.
+
+    elif isinstance(source, int) and isinstance(destination, int):
+        source_, destination_ = _check_moveaxis_axes(
+            source, destination, x.ndim, _integer_axis_validation
+        )
+        perm.pop(source_)
+        perm.insert(destination_, source_)
+
+    # Raise an error if they're not (both tuples) nor (both integers).
+
     else:
-        raise ValueError("source and destination must both be integers if source is a tuple")
+        raise ValueError("source and destination must both be integers or both be tuples.")
 
     return permute_dims(x, axes=tuple(perm))
 
@@ -238,8 +363,24 @@ def permute_dims(x: Array, /, axes: Tuple[int, ...]) -> Array:
         The array whose dimensions are to be permuted
     axes : Tuple[int, ...]
         The new order of the dimensions. Must be a permutation of the integers from 0 to `x.ndim-1`.
+
+    Raises
+    ------
+    IndexError
+        Raised if the given axes are not a valid reordering of the axes of x.
+
+    Returns
+    -------
+    Array
+        A copy of x with the axes permuted as per the axes argument.
     """
     from arkouda.client import generic_msg
+
+    # Check axes, e.g. if x.ndim = 3, axes must be some permutation of 0,1,2.
+    # If it is, then a sort will turn it into (0,1,2).
+
+    if not (np.sort(axes) == np.arange(x.ndim)).all():
+        raise IndexError(f"{axes} is not a valid permutation of axes for arrays of rank {x.ndim}")
 
     try:
         return Array._new(
@@ -274,7 +415,18 @@ def repeat(x: Array, repeats: Union[int, Array], /, *, axis: Optional[int] = Non
          * If axis is not None, must be an integer, or a 1D array of integers whose size matches the
            number of elements along the specified axis.
     axis : int, optional
-        The axis along which to repeat elements. If None, the array is flattened before repeating.
+        The axis along which to repeat elements. If None, the array is flattened before repeating,
+        and each element is repeated repeats times.
+
+    Raises
+    ------
+    NotYetImplementedError
+        Raised if axis arg is used.
+
+    Returns
+    -------
+    Array
+        A new 1D array with each element of x repeated repeats times.
     """
     from arkouda.client import generic_msg
 
@@ -315,8 +467,41 @@ def reshape(x: Array, /, shape: Tuple[int, ...], *, copy: Optional[bool] = None)
     copy : bool, optional
         Whether to create a copy of the array.
         WARNING: currently always creates a copy, ignoring the value of this parameter.
+
+    Raises
+    ------
+    ValueError
+        Raised if the given shape is invalid, or if more than one unknown dimension is specified.
+
+    Returns
+    -------
+    Array
+        A reshaped version of x, as specified in shape.
+
     """
     from arkouda.client import generic_msg
+
+    # Check the validity of the new shape.  At most one -1 is allowed, as in numpy.
+
+    if shape.count(-1) > 1:
+        raise ValueError("can only specify one unknown dimension")
+
+    # A -1 represents an "unknown shape."  That means "fill in the rest of it here,"
+    # e.g. reshaping (24,1) to (3,2,-1) creates a shape of (3,2,4).
+
+    elif shape.count(-1) == 1:
+        partial_shape = -np.prod(shape)  # figure out what the -1 equates to
+        if x.size % partial_shape != 0:  # raise error if it doesn't make sense (e.g. (12) to (7,-1)
+            raise ValueError(f"cannot reshape array of size {x.size} into shape {shape}")
+        else:  # but if it does make sense, fill it in as appropriate
+            fillin = x.size // partial_shape
+            shape_copy = [fillin if val == -1 else val for val in shape]
+            shape = tuple(int(x) for x in shape_copy)  # avoids mypy "int vs np.int64" error
+
+    # Finally, if there are no unknown shapes, just check the the new size matches the old.
+
+    elif np.prod(shape) != x.size:  # e.g. can't reshape (4,3,2) to (3,3,3)
+        raise ValueError(f"cannot reshape array of size {x.size} into shape {shape}")
 
     # TODO: figure out copying semantics (currently always creates a copy)
     try:
@@ -361,12 +546,30 @@ def roll(
     axis: int or Tuple[int, ...], optional
         The axis or axes along which to roll the array. If None, the array is flattened before
         rolling.
+
+    Raises
+    ------
+    IndexError
+        Raised if the axis/axes aren't valid for the given array, or if axis and shift are both
+        tuples but not of the same length, or if roll fails server-side.
+
+    Returns
+    -------
+    Array
+        An array with the same shape as x, but with elements shifted as per axis and shift.
     """
     from arkouda.client import generic_msg
+    from arkouda.numpy.util import _axis_validation
+
+    if isinstance(shift, tuple) and isinstance(axis, tuple) and (len(axis) != len(shift)):
+        raise IndexError("When shift and axis are both tuples, they must have the same length.")
 
     axisList = []
     if axis is not None:
-        axisList = list(axis) if isinstance(axis, tuple) else [axis]
+        valid, axisList = _axis_validation(axis, x.ndim)
+        if not valid:
+            raise IndexError(f"{axis} is not a valid axis/axes for array of rank {x.ndim}")
+
     try:
         return Array._new(
             create_pdarray(
@@ -403,6 +606,12 @@ def squeeze(x: Array, /, axis: Union[int, Tuple[int, ...]]) -> Array:
         The array to squeeze
     axis : int or Tuple[int, ...]
         The axis or axes to squeeze (must have a size of one).
+
+    Returns
+    -------
+    Array
+        The input array, but with the axes specified in axis (which must be of length 1) removed.
+
     """
     from arkouda.numpy import squeeze
 
@@ -423,20 +632,37 @@ def stack(arrays: Union[Tuple[Array, ...], List[Array]], /, *, axis: int = 0) ->
     axis : int, optional
         The axis along which to stack the arrays. Must be in the range `[-N, N)`, where N is the number
         of dimensions in the input arrays. The default is 0.
+
+    Raises
+    ------
+    ValueError
+        Raised if the arrays aren't all the same shape.
+    IndexError
+        Raised if axis isn't valid for the given arrays.
+
+    Returns
+    -------
+    Array
+        A stacked array with rank 1 greater than the input arrays.
     """
     from arkouda.client import generic_msg
     from arkouda.numpy.util import _integer_axis_validation
 
     ndim = arrays[0].ndim
-    for a in arrays:
-        if a.ndim != ndim:
-            raise ValueError("all input arrays must have the same number of dimensions to stack")
+
+    base_shape = arrays[0].shape
+    for a in arrays[1:]:
+        if a.shape != base_shape:
+            raise ValueError("all input arrays must have the same shape to stack")
 
     # expand_dims and stack test the axis validity against an array of rank ndim+1
 
     valid, axis_ = _integer_axis_validation(axis, ndim + 1)
     if not valid:
         raise IndexError(f"{axis} is not a valid axis for stacking arrays of rank {ndim}")
+
+    # TODO: fix the type promotion here, as in concat above.  This is always producing
+    # floats, even when all inputs are integer.  numpy stack doesn't do that.
 
     (common_dt, _arrays) = promote_to_common_dtype([a._array for a in arrays])
 
@@ -470,7 +696,12 @@ def tile(x: Array, repetitions: Tuple[int, ...], /) -> Array:
         The number of repetitions along each dimension. If there are more repetitions than array
         dimensions, singleton dimensions are prepended to the array to make it match the number of
         repetitions. If there are more array dimensions than repetitions, ones are prepended to the
-        repetitions tuple to make it's length match the number of array dimensions.
+        repetitions tuple to make its length match the number of array dimensions.
+
+    Returns
+    -------
+    Array
+        The tiled output array.
     """
     from arkouda.client import generic_msg
 
@@ -510,6 +741,16 @@ def unstack(x: Array, /, *, axis: int = 0) -> Tuple[Array, ...]:
         The array to unstack
     axis : int, optional
         The axis along which to unstack the array. The default is 0.
+
+    Raises
+    ------
+    IndexError
+        Raised if the axis is not valid for the given Array.
+
+    Returns
+    -------
+    Tuple
+        A Tuple of unstacked Arrays.
     """
     from arkouda.client import generic_msg
     from arkouda.numpy.util import _integer_axis_validation

--- a/arkouda/numpy/util.py
+++ b/arkouda/numpy/util.py
@@ -1134,14 +1134,19 @@ def adjust_negs(axis, rank):
 
 # axis validation can be called in multiple conditions.
 
-# Some functions require the axis to be an integer.  For that, we have
-# _integer_axis_validation, which returns a boolean and an int.
+# Some functions require the axis to be an integer (or None).  For that, we have
+# _integer_axis_validation, which returns a boolean and an int (or None).
 
 
-def _integer_axis_validation(axis: int_scalars, rank):
-    if bounds_check(axis, rank):
-        axis = adjust_negs(axis, rank)
-        return True, axis
+def _integer_axis_validation(axis, rank):
+    if axis is None:
+        return True, None
+    elif isinstance(axis, int):
+        if bounds_check(axis, rank):
+            axis = adjust_negs(axis, rank)
+            return True, axis
+        else:
+            return False, axis
     else:
         return False, axis
 
@@ -1158,9 +1163,9 @@ def _axis_validation(axis, rank):
     elif isinstance(axis, int):
         if bounds_check(axis, rank):
             axis = adjust_negs(axis, rank)
-            return True, list[axis]
+            return True, [axis]
         else:
-            return False, list[axis]
+            return False, [axis]
 
     else:
         if isinstance(axis, list):


### PR DESCRIPTION
Addendum

The existing axis checking in array_api **moveaxis** wasn't correct.  It allowed cases numpy doesn't (for example, moving axes (0,1,2) to (1,1,0)).  This isn't the same issue as the axis validation, but it was an error, and has been fixed.

Closes #4857 

This is part of a series of PRs that will standardize the axis checking (and negative axis handling) in arkouda.  This PR specifically finalizes the _axis_validation function in numpy/util.py, and updates all of the axis handling and checking in array_api/manipulation_functions.py.

This PR also adds several fields to the docstrings, and changes the "must have same rank" check in **stack** to "must have same shape," to match numpy.