### PR TITLE
Closes #4862:  array_transfer.dat not populating with benchmark_v2

### DIFF
--- a/benchmark_v2/array_transfer_benchmark.py
+++ b/benchmark_v2/array_transfer_benchmark.py
@@ -18,7 +18,7 @@ def create_ak_array(N, dtype):
 
 @pytest.mark.benchmark(group="ArrayTransfer_tondarray")
 @pytest.mark.parametrize("dtype", TYPES)
-def bench_array_transfer_tondarray(benchmark, dtype):
+def bench_array_transfer_to_ndarray(benchmark, dtype):
     if dtype in pytest.dtype:
         N = pytest.N
         a = create_ak_array(N, dtype)
@@ -40,7 +40,7 @@ def bench_array_transfer_tondarray(benchmark, dtype):
 
 @pytest.mark.benchmark(group="ArrayTransfer_ak.array")
 @pytest.mark.parametrize("dtype", TYPES)
-def bench_array_transfer_akarray(benchmark, dtype):
+def bench_array_transfer_from_ndarray(benchmark, dtype):
     if dtype in pytest.dtype:
         N = pytest.N
         a = create_ak_array(N, dtype)

--- a/benchmark_v2/datdir/configs/field_lookup_map.json
+++ b/benchmark_v2/datdir/configs/field_lookup_map.json
@@ -482,7 +482,7 @@
         "extra_info",
         "transfer_rate"
       ],
-      "lookup_regex": null,
+      "lookup_regex": "bench_array_transfer_from_ndarray\\[(?:int64|float64|bool|uint64)\\]",
       "name": ""
     },
     "ak.array Average time =": {
@@ -491,7 +491,7 @@
         "stats",
         "mean"
       ],
-      "lookup_regex": null,
+      "lookup_regex": "bench_array_transfer_from_ndarray\\[(?:int64|float64|bool|uint64)\\]",
       "name": ""
     },
     "to_ndarray Average rate =": {
@@ -500,7 +500,7 @@
         "extra_info",
         "transfer_rate"
       ],
-      "lookup_regex": null,
+      "lookup_regex": "bench_array_transfer_to_ndarray\\[(?:int64|float64|bool|uint64)\\]",
       "name": ""
     },
     "to_ndarray Average time =": {
@@ -509,7 +509,7 @@
         "stats",
         "mean"
       ],
-      "lookup_regex": null,
+      "lookup_regex": "bench_array_transfer_to_ndarray\\[(?:int64|float64|bool|uint64)\\]",
       "name": ""
     }
   },
@@ -520,7 +520,7 @@
         "extra_info",
         "transfer_rate"
       ],
-      "lookup_regex": null,
+      "lookup_regex": "bench_array_transfer_from_ndarray\\[(?:int64|float64|bool|uint64)\\]",
       "name": ""
     },
     "ak.array Average time =": {
@@ -529,7 +529,7 @@
         "stats",
         "mean"
       ],
-      "lookup_regex": null,
+      "lookup_regex": "bench_array_transfer_from_ndarray\\[(?:int64|float64|bool|uint64)\\]",
       "name": ""
     },
     "to_ndarray Average rate =": {
@@ -538,7 +538,7 @@
         "extra_info",
         "transfer_rate"
       ],
-      "lookup_regex": null,
+      "lookup_regex": "bench_array_transfer_to_ndarray\\[(?:int64|float64|bool|uint64)\\]",
       "name": ""
     },
     "to_ndarray Average time =": {
@@ -547,7 +547,7 @@
         "stats",
         "mean"
       ],
-      "lookup_regex": null,
+      "lookup_regex": "bench_array_transfer_to_ndarray\\[(?:int64|float64|bool|uint64)\\]",
       "name": ""
     }
   },


### PR DESCRIPTION
Fixes a bug/omission in `benchmark_v2/generate_field_lookup_map.py` causing `array_transfer.dat` and `bigint_array_transfer.dat` to be populated with all `-1` by `make benchmark`.

Closes #4862:  array_transfer.dat not populating with benchmark_v2