### PR TITLE
Closes #4863:  16-array Average rate always returns zero under benchm…

### DIFF
--- a/benchmark_v2/coargsort_benchmark.py
+++ b/benchmark_v2/coargsort_benchmark.py
@@ -13,6 +13,7 @@ NUM_ARR = [1, 2, 8, 16]
 @pytest.mark.parametrize("dtype", TYPES)
 def bench_coargsort(benchmark, dtype, numArrays):
     N = pytest.N
+    size = max(1, N // numArrays)
 
     if dtype in pytest.dtype:
         if pytest.seed is None:
@@ -22,13 +23,13 @@ def bench_coargsort(benchmark, dtype, numArrays):
 
         # Generate Arkouda arrays
         if dtype == "int64":
-            arrs = [ak.randint(0, 2**32, N // numArrays, seed=s) for s in seeds]
+            arrs = [ak.randint(0, 2**32, size, seed=s) for s in seeds]
         elif dtype == "uint64":
-            arrs = [ak.randint(0, 2**32, N // numArrays, dtype=ak.uint64, seed=s) for s in seeds]
+            arrs = [ak.randint(0, 2**32, size, dtype=ak.uint64, seed=s) for s in seeds]
         elif dtype == "float64":
-            arrs = [ak.randint(0, 1, N // numArrays, dtype=ak.float64, seed=s) for s in seeds]
+            arrs = [ak.randint(0, 1, size, dtype=ak.float64, seed=s) for s in seeds]
         elif dtype == "str":
-            arrs = [ak.random_strings_uniform(1, 16, N // numArrays, seed=s) for s in seeds]
+            arrs = [ak.random_strings_uniform(1, 16, size, seed=s) for s in seeds]
 
         num_bytes = calc_num_bytes(arrs)
 

--- a/benchmark_v2/groupby_benchmark.py
+++ b/benchmark_v2/groupby_benchmark.py
@@ -9,17 +9,18 @@ NUM_ARR = [1, 2, 8, 16]
 
 def generate_arrays(dtype, numArrays, N):
     arrays = []
+    size = max(1, N // numArrays)
     for i in range(numArrays):
         if dtype == ak.bigint.name:
-            a = ak.randint(0, 2**32, N // numArrays, dtype=ak.uint64, seed=pytest.seed)
-            b = ak.randint(0, 2**32, N // numArrays, dtype=ak.uint64, seed=pytest.seed)
+            a = ak.randint(0, 2**32, size, dtype=ak.uint64, seed=pytest.seed)
+            b = ak.randint(0, 2**32, size, dtype=ak.uint64, seed=pytest.seed)
             ba = ak.bigint_from_uint_arrays([a, b], max_bits=pytest.max_bits)
             arrays.append(ba)
         elif dtype == "int64" or (i % 2 == 0 and dtype == "mixed"):
-            a = ak.randint(0, 2**32, N // numArrays, seed=pytest.seed)
+            a = ak.randint(0, 2**32, size, seed=pytest.seed)
             arrays.append(a)
         else:
-            a = ak.random_strings_uniform(1, 16, N // numArrays, seed=pytest.seed)
+            a = ak.random_strings_uniform(1, 16, size, seed=pytest.seed)
             arrays.append(a)
         if pytest.seed is not None:
             pytest.seed += 1
@@ -40,7 +41,7 @@ def bench_groupby(benchmark, numArrays, dtype):
         benchmark.pedantic(ak.GroupBy, args=[arrays], rounds=pytest.trials)
 
         benchmark.extra_info["description"] = (
-            f"Measures the performance of ak.GroupBy creation with {dtype} dtype"
+            f"Measures the performance of ak.GroupBy creation of {numArrays} array(s) with {dtype} dtype"
         )
         benchmark.extra_info["problem_size"] = N
         benchmark.extra_info["num_bytes"] = num_bytes


### PR DESCRIPTION
This PR fixes a minor issue where the Average rate for `groupby.dat` and `coargsort.dat` was always zero when the number of arrays was `16` and the benchmark size was `10`.  This was due to integer division used to determine the individual array sizes, which will be zero when the number of arrays is smaller than the size (`pytest.N`) of the benchmark.

Closes #4863:  16-array Average rate always returns zero under benchmark_v2 groupby