### PR TITLE
Closes #4872: ak.randint doesn't behave the same for bool as numpy

### DIFF
--- a/arkouda/numpy/numeric.py
+++ b/arkouda/numpy/numeric.py
@@ -959,7 +959,7 @@ def cumsum(pda: pdarray, axis: Optional[Union[int, None]] = None) -> pdarray:
     >>> ak.cumsum(ak.uniform(5,1.0,5.0, seed=1))
     array([4.14859379... 5.48568392... 9.48801240... 13.0780218... 16.8202747...])
 
-    >>> ak.cumsum(ak.randint(0, 1, 5, dtype=ak.bool_, seed=1))
+    >>> ak.cumsum(ak.randint(0, 2, 5, dtype=ak.bool_, seed=1))
     array([1 1 2 3 4])
     """
     from arkouda.client import generic_msg
@@ -1029,7 +1029,7 @@ def cumprod(pda: pdarray, axis: Optional[Union[int, None]] = None) -> pdarray:
     >>> ak.cumprod(ak.uniform(5,1.0,5.0, seed=1))
     array([4.14859379... 5.54704379... 22.20109135... 79.7021268... 298.2655159...])
 
-    >>> ak.cumprod(ak.randint(0, 1, 5, dtype=ak.bool_, seed=1))
+    >>> ak.cumprod(ak.randint(0, 2, 5, dtype=ak.bool_, seed=1))
     array([1 0 0 0 0])
     """
     from arkouda.client import generic_msg

--- a/arkouda/numpy/pdarraycreation.py
+++ b/arkouda/numpy/pdarraycreation.py
@@ -1448,7 +1448,7 @@ def randint(
     >>> ak.randint(0, 1, 3, seed=1701, dtype=ak.float64)
     array([0.011410423448327005 0.73618171558685619 0.12367222192448891])
 
-    >>> ak.randint(0, 1, 5, seed=1701, dtype=ak.bool_)
+    >>> ak.randint(0, 2, 5, seed=1701, dtype=ak.bool_)
     array([False True False True False])
     """
     from arkouda.numpy.random import randint

--- a/tests/array_api/linalg.py
+++ b/tests/array_api/linalg.py
@@ -23,13 +23,15 @@ class TestLinalg:
     @pytest.mark.parametrize("prob_size", pytest.prob_size)
     def test_matmul(self, data_type1, data_type2, prob_size):
         size = int(sqrt(prob_size))
+        high1 = 10 if data_type1 != ak.bool_ else 2
+        high2 = 10 if data_type2 != ak.bool_ else 2
 
         # test on one square and two non-square products
 
         for rows, cols in [(size, size), (size + 1, size - 1), (size - 1, size + 1)]:
-            arrayLeft = xp.asarray(ak.randint(0, 10, (rows, size), dtype=data_type1))
+            arrayLeft = xp.asarray(ak.randint(0, high1, (rows, size), dtype=data_type1))
             ndaLeft = arrayLeft.to_ndarray()
-            arrayRight = xp.asarray(ak.randint(0, 10, (size, cols), dtype=data_type2))
+            arrayRight = xp.asarray(ak.randint(0, high2, (size, cols), dtype=data_type2))
             ndaRight = arrayRight.to_ndarray()
             akProduct = xp.matmul(arrayLeft, arrayRight)
             npProduct = np.matmul(ndaLeft, ndaRight)
@@ -57,8 +59,9 @@ class TestLinalg:
     def test_vecdot(self, data_type1, data_type2, prob_size):
         depth = np.random.randint(2, 10)
         width = prob_size // depth
+        high = 10 if data_type1 != ak.bool_ else 2
 
-        pda_a = xp.asarray(ak.randint(0, 10, (depth, width), dtype=data_type1))
+        pda_a = xp.asarray(ak.randint(0, high, (depth, width), dtype=data_type1))
         nda_a = pda_a.to_ndarray()
         pda_b = xp.asarray(ak.randint(0, 10, (depth, width), dtype=data_type2))
         nda_b = pda_b.to_ndarray()

--- a/tests/array_api/sorting.py
+++ b/tests/array_api/sorting.py
@@ -27,8 +27,9 @@ class TestSortingFunctions:
     @pytest.mark.parametrize("dtype", ak.ScalarDTypes)
     @pytest.mark.parametrize("descending", [True, False])
     def test_argsort(self, shape, dtype, descending):
+        high = 100 if dtype != "bool_" else 2
         for axis in range(len(shape)):
-            a = xp.asarray(ak.randint(0, 100, shape, dtype=dtype, seed=pytest.seed))
+            a = xp.asarray(ak.randint(0, high, shape, dtype=dtype, seed=pytest.seed))
             b = xp.argsort(a, axis=axis, descending=descending)
             np_b = a.to_ndarray().argsort(axis=axis, stable=True)
             np_b = np.flip(np_b, axis=axis) if descending else np_b

--- a/tests/array_api/utility_functions.py
+++ b/tests/array_api/utility_functions.py
@@ -58,7 +58,7 @@ class TestUtilFunctions:
     @pytest.mark.skip_if_rank_not_compiled([3])
     def test_clip_errors(self):
         # bool
-        a = xp.asarray(ak.randint(0, 100, (5, 6, 7), dtype=ak.bool_, seed=seed), dtype=ak.bool_)
+        a = xp.asarray(ak.randint(0, 2, (5, 6, 7), dtype=ak.bool_, seed=seed), dtype=ak.bool_)
         with pytest.raises(
             RuntimeError,
             match="Error executing command: clip does not support dtype bool",

--- a/tests/numpy/pdarray_creation_test.py
+++ b/tests/numpy/pdarray_creation_test.py
@@ -433,7 +433,8 @@ class TestPdarrayCreation:
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("array_type", [ak.int64, ak.float64, bool])
     def test_randint_array_dtype(self, size, array_type):
-        test_array = ak.randint(0, size, size, array_type)
+        high = size if array_type != bool else 2
+        test_array = ak.randint(0, high, size, array_type)
         assert isinstance(test_array, ak.pdarray)
         assert size == len(test_array)
         assert array_type == test_array.dtype
@@ -446,7 +447,8 @@ class TestPdarrayCreation:
     def test_randint_array_dtype_multi_dim(self, size, array_type):
         for rank in multi_dim_ranks():
             shape, local_size = _generate_test_shape(rank, size)
-            test_array = ak.randint(0, size, shape, array_type)
+            high = size if array_type != bool else 2
+            test_array = ak.randint(0, high, shape, array_type)
             assert isinstance(test_array, ak.pdarray)
             assert size == len(test_array)
             assert array_type == test_array.dtype
@@ -535,10 +537,10 @@ class TestPdarrayCreation:
         assert ans == values.tolist()
 
         bools = [False, True, True, True, True, False, True, True, True, True]
-        values = ak.randint(1, 5, 10, dtype=ak.bool_, seed=2)
+        values = ak.randint(0, 2, 10, dtype=ak.bool_, seed=2)
         assert values.tolist() == bools
 
-        values = ak.randint(1, 5, 10, dtype=bool, seed=2)
+        values = ak.randint(0, 2, 10, dtype=bool, seed=2)
         assert values.tolist() == bools
 
         # Test that int_scalars covers uint8, uint16, uint32

--- a/tests/numpy/pdarrayclass_test.py
+++ b/tests/numpy/pdarrayclass_test.py
@@ -206,7 +206,9 @@ class TestPdarrayClass:
     def test_is_locally_sorted_multidim(self, dtype, axis):
         from arkouda.numpy.pdarrayclass import is_locally_sorted
 
-        a = ak.array(ak.randint(0, 100, (20, 20, 20), dtype=dtype, seed=seed))
+        high = 100 if dtype != "bool" else 2
+
+        a = ak.array(ak.randint(0, high, (20, 20, 20), dtype=dtype, seed=seed))
         sorted = is_locally_sorted(a, axis=axis)
         if isinstance(sorted, np.bool_):
             assert not sorted
@@ -572,7 +574,8 @@ class TestPdarrayClass:
     @pytest.mark.parametrize("ascending", [True, False])
     @pytest.mark.parametrize("dtype", [ak.int64, ak.float64, ak.bool_, ak.uint64, ak.bigint])
     def test_argsort_random(self, size, ascending, dtype):
-        a = ak.randint(0, 1_000_000, size, dtype=dtype if dtype != ak.bigint else ak.int64, seed=seed)
+        high = 1_000_000 if dtype != ak.bool_ else 2
+        a = ak.randint(0, high, size, dtype=dtype if dtype != ak.bigint else ak.int64, seed=seed)
         if dtype == ak.bigint:
             a = a + 2**70
         perm = a.argsort(ascending=ascending)
@@ -588,8 +591,9 @@ class TestPdarrayClass:
     @pytest.mark.parametrize("dtype", ak.ScalarDTypes)
     @pytest.mark.parametrize("ascending", [True, False])
     def test_argsort_numpy_alignment(self, shape, dtype, ascending):
+        high = 100 if dtype != "bool_" else 2
         for axis in range(len(shape)):
-            a = ak.randint(0, 100, shape, dtype=dtype, seed=seed)
+            a = ak.randint(0, high, shape, dtype=dtype, seed=seed)
             b = a.argsort(axis=axis, ascending=ascending)
             np_b = a.to_ndarray().argsort(axis=axis, stable=True)
             np_b = np.flip(np_b, axis=axis) if not ascending else np_b

--- a/tests/numpy/random_test.py
+++ b/tests/numpy/random_test.py
@@ -627,11 +627,23 @@ class TestRandom:
         with pytest.raises(TypeError):
             ak.random.randint()
 
-        with pytest.raises(ValueError, match="size must be >= 0, ndim >= 1, and high >= low"):
+        with pytest.raises(ValueError, match="size must be >= 0, ndim >= 1"):
             ak.random.randint(low=0, high=1, size=-1, dtype=ak.float64)
 
-        with pytest.raises(ValueError, match="size must be >= 0, ndim >= 1, and high >= low"):
+        with pytest.raises(ValueError, match="low >= high"):
             ak.random.randint(low=1, high=0, size=1, dtype=ak.float64)
+
+        with pytest.raises(ValueError, match="high <= 0"):
+            ak.random.randint(low=0, high=0, size=10, dtype=ak.bool_)
+
+        with pytest.raises(ValueError, match="low < 0"):
+            ak.random.randint(low=-1, high=1, size=10, dtype=ak.bool_)
+
+        with pytest.raises(ValueError, match="high is out of bounds for bool"):
+            ak.random.randint(low=1, high=3, size=10, dtype=ak.bool_)
+
+        with pytest.raises(ValueError, match="low >= high"):
+            ak.random.randint(low=1, high=1, size=10, dtype=ak.bool_)
 
         with pytest.raises(TypeError):
             ak.random.randint(0, 1, "1000")
@@ -666,7 +678,7 @@ class TestRandom:
             4.0337935981006172,
         ] == values.tolist()
 
-        values = ak.random.randint(1, 5, 10, dtype=ak.bool_, seed=2)
+        values = ak.random.randint(0, 2, 10, dtype=ak.bool_, seed=2)
         assert [
             False,
             True,
@@ -680,7 +692,7 @@ class TestRandom:
             True,
         ] == values.tolist()
 
-        values = ak.random.randint(1, 5, 10, dtype=bool, seed=2)
+        values = ak.random.randint(0, 2, 10, dtype=bool, seed=2)
         assert [
             False,
             True,


### PR DESCRIPTION
Fixed up the Chapel code for randint, and then also updated how it's handled in the Python-side. Then tests failed so updated several of them.

Closes #4872: ak.randint doesn't behave the same for bool as numpy