### PR TITLE
Closes #4876 improve extension array api take functions

### DIFF
--- a/arkouda/pandas/extension/_arkouda_categorical_array.py
+++ b/arkouda/pandas/extension/_arkouda_categorical_array.py
@@ -31,6 +31,8 @@ class ArkoudaCategoricalDtype(ExtensionDtype):
 
 
 class ArkoudaCategoricalArray(ArkoudaBaseArray, ExtensionArray):
+    default_fill_value: str = ""
+
     def __init__(self, data):
         if not isinstance(data, ak.Categorical):
             raise TypeError("Expected arkouda Categorical")

--- a/arkouda/plotting.py
+++ b/arkouda/plotting.py
@@ -33,8 +33,10 @@ Examples
 >>> import numpy as np
 >>> from arkouda.plotting import hist_all, plot_dist
 >>> df = ak.DataFrame({'x': ak.array(np.random.randn(100))})
->>> hist_all(df)
 
+Save the figure to disk:
+>>> fig, axes = hist_all(df)
+>>> fig.savefig("hist_all.png")
 >>> b, h = ak.histogram(ak.arange(10), 3)
 >>> plot_dist(b.to_ndarray(), h[:-1].to_ndarray())
 >>> import matplotlib.pyplot as plt
@@ -130,9 +132,14 @@ def hist_all(ak_df: DataFrame, cols: Optional[list[str]] = None):
     ----------
     ak_df : DataFrame
         An Arkouda DataFrame containing the data to visualize.
-    cols : list
-        Optional. A list of column names to plot. If empty or not provided, all
+    cols : list, optional
+        A list of column names to plot. If empty or not provided, all
         columns in the DataFrame are considered.
+
+    Returns
+    -------
+    tuple[matplotlib.figure.Figure, numpy.ndarray]
+        A tuple containing the matplotlib Figure and an array of Axes objects.
 
     Notes
     -----
@@ -142,6 +149,7 @@ def hist_all(ak_df: DataFrame, cols: Optional[list[str]] = None):
 
     Examples
     --------
+    Basic usage with all columns:
     >>> import arkouda as ak
     >>> import numpy as np
     >>> from arkouda.plotting import hist_all
@@ -151,7 +159,11 @@ def hist_all(ak_df: DataFrame, cols: Optional[list[str]] = None):
     ...     "c": ak.array(np.random.randn(100)),
     ...     "d": ak.array(np.random.randn(100))
     ... })
-    >>> hist_all(ak_df)
+    >>> fig, axes = hist_all(ak_df)
+
+    Save the figure to disk:
+    >>> fig, axes = hist_all(ak_df, cols=["a", "b"])
+    >>> fig.savefig("hist_all.png")
 
     """
     if not cols or len(cols) == 0:
@@ -163,57 +175,40 @@ def hist_all(ak_df: DataFrame, cols: Optional[list[str]] = None):
     fig.tight_layout(pad=2.0)
 
     if isinstance(axes, plt.Axes):
-        axes = np.array(axes).flatten()
+        axes = np.array([axes])
     elif isinstance(axes, np.ndarray):
         axes = axes.flatten()
     else:
         axes = [axes]
 
-    for col in cols:
+    for idx, col in enumerate(cols):
+        ax = axes[idx]
         try:
-            from typing import List
-
-            cols_idx = cols.index
-            if isinstance(cols_idx, List):
-                ax = axes[cols_idx.index(col)]
-            else:
-                ax = axes[cols_idx(col)]
             x = ak_df[col]
-
             if x.dtype == "float64":
                 x = x[~isnan(x)]
-
             n = len(x)
             g1 = skew(x)
-
         except ValueError:
             GB_df = GroupBy(ak_df[col])
-
             if not isinstance(GB_df.unique_keys, (Strings, Categorical, pdarray)):
                 raise TypeError(
                     f"expected one of (Strings, Categorical, pdarray), "
                     f"got {type(GB_df.unique_keys).__name__!r}"
                 )
-
             new_labels = arange(GB_df.unique_keys.size)
             newcol = GB_df.broadcast(new_labels)
             x = newcol[: ak_df.size]
-
             if x.dtype == "float64":
                 x = x[~isnan(x)]
-
             n = len(x)
             g1 = skew(x)
 
         sigma_g1 = math.sqrt(6 * (n - 2) / ((n + 1) * (n + 3)))
-        # Doane's Formula
         num_bins = int(1 + math.log2(n) + math.log2(1 + abs(g1) / sigma_g1))
 
-        # Compute histogram counts in arkouda
         h = histogram(x, num_bins)
-        # Compute bins in numpy
         if isinstance(x, Datetime):
-            # Matplotlib has trouble plotting np.datetime64 and np.timedelta64
             bins = date_range(x.min(), x.max(), periods=num_bins).to_ndarray().astype("int")
         elif isinstance(x, Timedelta):
             bins = timedelta_range(x.min(), x.max(), periods=num_bins).to_ndarray().astype("int")
@@ -224,3 +219,5 @@ def hist_all(ak_df: DataFrame, cols: Optional[list[str]] = None):
         ax.set_title(col, size=8)
         if x.max() > 100 * x.min():
             ax.set_yscale("log")
+
+    return fig, axes

--- a/arkouda/plotting.py
+++ b/arkouda/plotting.py
@@ -33,10 +33,8 @@ Examples
 >>> import numpy as np
 >>> from arkouda.plotting import hist_all, plot_dist
 >>> df = ak.DataFrame({'x': ak.array(np.random.randn(100))})
+>>> hist_all(df)
 
-Save the figure to disk:
->>> fig, axes = hist_all(df)
->>> fig.savefig("hist_all.png")
 >>> b, h = ak.histogram(ak.arange(10), 3)
 >>> plot_dist(b.to_ndarray(), h[:-1].to_ndarray())
 >>> import matplotlib.pyplot as plt
@@ -132,14 +130,9 @@ def hist_all(ak_df: DataFrame, cols: Optional[list[str]] = None):
     ----------
     ak_df : DataFrame
         An Arkouda DataFrame containing the data to visualize.
-    cols : list, optional
-        A list of column names to plot. If empty or not provided, all
+    cols : list
+        Optional. A list of column names to plot. If empty or not provided, all
         columns in the DataFrame are considered.
-
-    Returns
-    -------
-    tuple[matplotlib.figure.Figure, numpy.ndarray]
-        A tuple containing the matplotlib Figure and an array of Axes objects.
 
     Notes
     -----
@@ -149,7 +142,6 @@ def hist_all(ak_df: DataFrame, cols: Optional[list[str]] = None):
 
     Examples
     --------
-    Basic usage with all columns:
     >>> import arkouda as ak
     >>> import numpy as np
     >>> from arkouda.plotting import hist_all
@@ -159,11 +151,7 @@ def hist_all(ak_df: DataFrame, cols: Optional[list[str]] = None):
     ...     "c": ak.array(np.random.randn(100)),
     ...     "d": ak.array(np.random.randn(100))
     ... })
-    >>> fig, axes = hist_all(ak_df)
-
-    Save the figure to disk:
-    >>> fig, axes = hist_all(ak_df, cols=["a", "b"])
-    >>> fig.savefig("hist_all.png")
+    >>> hist_all(ak_df)
 
     """
     if not cols or len(cols) == 0:
@@ -175,40 +163,57 @@ def hist_all(ak_df: DataFrame, cols: Optional[list[str]] = None):
     fig.tight_layout(pad=2.0)
 
     if isinstance(axes, plt.Axes):
-        axes = np.array([axes])
+        axes = np.array(axes).flatten()
     elif isinstance(axes, np.ndarray):
         axes = axes.flatten()
     else:
         axes = [axes]
 
-    for idx, col in enumerate(cols):
-        ax = axes[idx]
+    for col in cols:
         try:
+            from typing import List
+
+            cols_idx = cols.index
+            if isinstance(cols_idx, List):
+                ax = axes[cols_idx.index(col)]
+            else:
+                ax = axes[cols_idx(col)]
             x = ak_df[col]
+
             if x.dtype == "float64":
                 x = x[~isnan(x)]
+
             n = len(x)
             g1 = skew(x)
+
         except ValueError:
             GB_df = GroupBy(ak_df[col])
+
             if not isinstance(GB_df.unique_keys, (Strings, Categorical, pdarray)):
                 raise TypeError(
                     f"expected one of (Strings, Categorical, pdarray), "
                     f"got {type(GB_df.unique_keys).__name__!r}"
                 )
+
             new_labels = arange(GB_df.unique_keys.size)
             newcol = GB_df.broadcast(new_labels)
             x = newcol[: ak_df.size]
+
             if x.dtype == "float64":
                 x = x[~isnan(x)]
+
             n = len(x)
             g1 = skew(x)
 
         sigma_g1 = math.sqrt(6 * (n - 2) / ((n + 1) * (n + 3)))
+        # Doane's Formula
         num_bins = int(1 + math.log2(n) + math.log2(1 + abs(g1) / sigma_g1))
 
+        # Compute histogram counts in arkouda
         h = histogram(x, num_bins)
+        # Compute bins in numpy
         if isinstance(x, Datetime):
+            # Matplotlib has trouble plotting np.datetime64 and np.timedelta64
             bins = date_range(x.min(), x.max(), periods=num_bins).to_ndarray().astype("int")
         elif isinstance(x, Timedelta):
             bins = timedelta_range(x.min(), x.max(), periods=num_bins).to_ndarray().astype("int")
@@ -219,5 +224,3 @@ def hist_all(ak_df: DataFrame, cols: Optional[list[str]] = None):
         ax.set_title(col, size=8)
         if x.max() > 100 * x.min():
             ax.set_yscale("log")
-
-    return fig, axes

--- a/tests/pandas/extension/arkouda_array_extension.py
+++ b/tests/pandas/extension/arkouda_array_extension.py
@@ -1,13 +1,23 @@
 import numpy as np
+import pandas as pd
 import pytest
 
 import arkouda as ak
 from arkouda import numeric_and_bool_scalars
 from arkouda.numpy.pdarrayclass import pdarray
 from arkouda.pandas.extension._arkouda_array import ArkoudaArray, ArkoudaDtype
+from arkouda.testing import assert_equivalent
+
+SUPPORTED_TYPES = [ak.bool_, ak.uint64, ak.int64, ak.bigint, ak.float64]
 
 
 class TestArkoudaArrayExtension:
+    @pytest.fixture
+    def base_arr(self):
+        # Small, distinct values to make indexing obvious
+        data = ak.array([10, 20, 30, 40, 50])
+        return ArkoudaArray(data)
+
     def test_array_extension_docstrings(self):
         import doctest
 
@@ -169,3 +179,86 @@ class TestArkoudaArrayExtension:
         new_arr = ArkoudaArray._from_factorized(values, orig)
         assert isinstance(new_arr, ArkoudaArray)
         assert new_arr.to_numpy().tolist() == values
+
+    @pytest.mark.parametrize(
+        "indexer_factory",
+        [
+            lambda: [0, 2, 4],  # Python list
+            lambda: np.array([0, 2, 4], dtype=np.int64),  # NumPy int64
+            lambda: np.array([0, 2, 4], dtype=np.int32),  # NumPy int32 (upcast to int64)
+            lambda: ak.array(np.array([0, 2, 4], dtype=np.int64)),  # Arkouda pdarray
+        ],
+    )
+    def test_take_no_allow_fill_various_indexers(self, base_arr, indexer_factory):
+        indexer = indexer_factory()
+        out = base_arr.take(indexer, allow_fill=False)
+        assert isinstance(out, ArkoudaArray)
+        assert out.to_numpy().tolist() == [10, 30, 50]
+
+    #   TODO: Implement this test after Issue #4878 is resolved
+    # def test_take_negative_indices_no_allow_fill(self,base_arr):
+    #     # Negative indices are valid when allow_fill=False (wrap from end)
+    #     indexer = [-1, -2, 0]  # 50, 30, 10
+    #     out = base_arr.take(indexer, allow_fill=False)
+    #     assert out.to_numpy().tolist() == [50, 30, 10]
+
+    def test_take_allow_fill_replaces_minus_one_with_fill_value(self, base_arr):
+        indexer = [0, -1, 2, -1]
+        out = base_arr.take(indexer, allow_fill=True, fill_value=999)
+        # indices: 0 -> 10, -1 -> fill, 2 -> 30, -1 -> fill
+        assert out.to_numpy().tolist() == [10, 999, 30, 999]
+
+    def test_take_allow_fill_uses_default_fill_when_none(self, base_arr, monkeypatch):
+        # Ensure class default is used when fill_value=None
+        # If you've changed default_fill_value, update expectation accordingly.
+        monkeypatch.setattr(ArkoudaArray, "default_fill_value", -1, raising=False)
+
+        indexer = [1, -1, 3]
+        out = base_arr.take(indexer, allow_fill=True, fill_value=None)
+        assert out.to_numpy().tolist() == [20, -1, 40]
+
+    def test_take_allow_fill_invalid_negative_raises(self, base_arr):
+        # Pandas semantics: when allow_fill=True, only -1 is allowed as sentinel
+        indexer = [0, -2, 1]
+        with pytest.raises(ValueError):
+            base_arr.take(indexer, allow_fill=True, fill_value=0)
+
+    def test_take_preserves_dtype_and_length(self, base_arr):
+        indexer = [4, 3, 2, 1, 0]
+        out = base_arr.take(indexer, allow_fill=False)
+        assert isinstance(out, ArkoudaArray)
+        assert len(out) == len(indexer)
+        # round-trip dtype through numpy for a quick check
+        assert out._data.dtype == base_arr._data.dtype
+
+    def test_take_with_pdarray_indexer(self, base_arr):
+        idx_pd = ak.array(np.array([0, 4, 1], dtype=np.int64))
+        assert isinstance(idx_pd, pdarray)
+        out = base_arr.take(idx_pd, allow_fill=False)
+        assert out.to_numpy().tolist() == [10, 50, 20]
+
+    def test_take_allow_fill_large_mask_sparse_fill(self, base_arr):
+        # Mixed valid and -1 entries; checks that only masked positions are filled
+        indexer = [0, 1, -1, 2, -1]
+        out = base_arr.take(indexer, allow_fill=True, fill_value=777)
+        assert out.to_numpy().tolist() == [10, 20, 777, 30, 777]
+
+    @pytest.mark.parametrize("fill_value", [0, 123, -5])
+    def test_take_allow_fill_explicit_fill_castable(self, base_arr, fill_value):
+        indexer = [-1, 0, -1]
+        out = base_arr.take(indexer, allow_fill=True, fill_value=fill_value)
+        assert out.to_numpy().tolist() == [fill_value, 10, fill_value]
+
+    def test_take_allow_fill_all_filled(self, base_arr):
+        indexer = [-1, -1, -1]
+        out = base_arr.take(indexer, allow_fill=True, fill_value=42)
+        assert out.to_numpy().tolist() == [42, 42, 42]
+
+    @pytest.mark.parametrize("dtype", SUPPORTED_TYPES)
+    @pytest.mark.parametrize("prob_size", pytest.prob_size)
+    def test_take_numeric_scaling(self, dtype, prob_size):
+        pda = ak.arange(prob_size, dtype=dtype)
+        arr = ArkoudaArray(pda)
+        s = pd.Series(pda.to_ndarray())
+        idx1 = ak.arange(prob_size, dtype=ak.int64) // 2
+        assert_equivalent(arr.take(idx1)._data, s.take(idx1.to_ndarray()).to_numpy())

--- a/tests/pandas/extension/arkouda_categorical_extension.py
+++ b/tests/pandas/extension/arkouda_categorical_extension.py
@@ -1,3 +1,11 @@
+import pandas as pd
+import pytest
+
+import arkouda as ak
+from arkouda.pandas.extension import ArkoudaCategoricalArray
+from arkouda.testing import assert_equivalent
+
+
 class TestArkoudaCategoricalExtension:
     def test_base_categorical_docstrings(self):
         import doctest
@@ -8,3 +16,87 @@ class TestArkoudaCategoricalExtension:
             _arkouda_categorical_array, optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE
         )
         assert result.failed == 0, f"Doctest failed: {result.failed} failures"
+
+    @pytest.fixture
+    def cat_arr(self):
+        """
+        Construct a small categorical EA with categories ['a','b','c'] and values:
+        ['a','b','a','c','b']
+        """
+        values = ["a", "b", "a", "c", "b"]
+        # Prefer a `_from_sequence` constructor if your EA supports it.
+        # Otherwise, adapt to your categorical EA's builder API (e.g., from_codes).
+        return ArkoudaCategoricalArray._from_sequence(values)
+
+    def test_take_categorical_no_allow_fill(self, cat_arr):
+        out = cat_arr.take([0, 2, 4], allow_fill=False)
+        # Expect original values at those positions
+        np_out = out.to_numpy().tolist()
+        assert np_out == ["a", "a", "b"]
+
+    # TODO: Implement this test after Issue #4878 is resolved
+    # def test_take_categorical_negative_indices_no_allow_fill(self, cat_arr):
+    #     out = cat_arr.take([-1, -3, 0], allow_fill=False)
+    #     np_out = np.asarray(out.to_numpy()).tolist()
+    #     assert np_out == ["b", "a", "a"]
+
+    #   TODO:  Include this test when Issue #4881 is resolved
+    # def test_take_categorical_allow_fill_default_is_na(self, cat_arr):
+    #     """
+    #     When allow_fill=True and fill_value=None, categorical EAs should fill with NA.
+    #     We'll assert that isna() reflects the masked positions.
+    #     """
+    #     out = cat_arr.take([0, -1, 2, -1], allow_fill=True, fill_value=None)
+    #     # Positions 1 and 3 should be NA
+    #     isna = out.isna()
+    #     # Try Arkouda boolean -> numpy for assertion
+    #     try:
+    #         isna_np = isna.to_ndarray()
+    #     except Exception:
+    #         isna_np = np.asarray(isna)
+    #     assert isna_np.tolist() == [False, True, False, True]
+
+    def test_take_categorical_allow_fill_with_existing_category(self, cat_arr):
+        """
+        Fill with a known category value ('b').
+        """
+        out = cat_arr.take([0, -1, 3, -1], allow_fill=True, fill_value="b")
+        np_out = out.to_numpy().tolist()
+        assert np_out == ["a", "b", "c", "b"]
+
+    def test_take_categorical_allow_fill_invalid_negative_raises(self, cat_arr):
+        with pytest.raises(ValueError):
+            cat_arr.take([0, -2, 1], allow_fill=True, fill_value="a")
+
+    def test_take_categorical_preserves_dtype_and_categories(self, cat_arr):
+        """
+        Ensure categories are preserved after take (common categorical EA invariant).
+        We try to check categories either on `dtype.categories` or on the instance.
+        """
+        from arkouda import Categorical
+
+        # Snapshot categories before
+        cats_before = None
+        if hasattr(cat_arr, "categories"):
+            cats_before = cat_arr.categories.tolist()
+
+        out = cat_arr.take([4, 3, 2, 1, 0], allow_fill=False)
+
+        # Same categories after (order preserved)
+        cats_after = None
+        if hasattr(out, "categories"):
+            cats_after = out.categories.tolist()
+
+        assert cats_before == cats_after
+        assert len(out.to_numpy()) == 5
+        assert isinstance(out, ArkoudaCategoricalArray)
+        assert isinstance(out._data, Categorical)
+
+    @pytest.mark.parametrize("prob_size", pytest.prob_size)
+    def test_take_categorical_scaling(self, prob_size):
+        strings = ak.array(["a", "b"])
+        pda = ak.Categorical(strings[ak.tile(ak.array([0, 1]), prob_size // 2)])
+        arr = ArkoudaCategoricalArray(pda)
+        s = pd.Series(pda.to_ndarray())
+        idx1 = ak.arange(prob_size, dtype=ak.int64) // 2
+        assert_equivalent(arr.take(idx1)._data.to_strings(), s.take(idx1.to_ndarray()).to_numpy())

--- a/tests/pandas/extension/arkouda_strings_extension.py
+++ b/tests/pandas/extension/arkouda_strings_extension.py
@@ -1,3 +1,11 @@
+import pandas as pd
+import pytest
+
+import arkouda as ak
+from arkouda.pandas.extension import ArkoudaStringArray
+from arkouda.testing import assert_equivalent
+
+
 class TestArkoudaStringsExtension:
     def test_strings_extension_docstrings(self):
         import doctest
@@ -8,3 +16,61 @@ class TestArkoudaStringsExtension:
             _arkouda_string_array, optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE
         )
         assert result.failed == 0, f"Doctest failed: {result.failed} failures"
+
+    @pytest.fixture
+    def str_arr(self):
+        data = ak.array(["a", "b", "c", "d", "e"])
+        return ArkoudaStringArray(data)
+
+    def test_take_strings_no_allow_fill(self, str_arr):
+        out = str_arr.take([0, 2, 4], allow_fill=False)
+        assert isinstance(out, ArkoudaStringArray)
+        assert out.to_numpy().tolist() == ["a", "c", "e"]
+
+    # TODO: Implement this test after Issue #4878 is resolved
+    # def test_take_strings_negative_indices_no_allow_fill(self,str_arr):
+    #     # negative indexes wrap when allow_fill=False
+    #     out = str_arr.take([-1, -3, 0], allow_fill=False)
+    #     assert out.to_numpy().tolist() == ["e", "c", "a"]
+
+    def test_take_strings_allow_fill_explicit_fill(self, str_arr):
+        # -1 becomes fill_value when allow_fill=True
+        out = str_arr.take([0, -1, 2, -1], allow_fill=True, fill_value="MISSING")
+        assert out.to_numpy().tolist() == ["a", "MISSING", "c", "MISSING"]
+
+    def test_take_strings_allow_fill_default_fill_none(self, str_arr, monkeypatch):
+        """
+        When fill_value=None and allow_fill=True, expect the string default.
+        Most implementations use "" (empty string) for string dtype sentinel fill.
+        """
+        # If your EA uses a class attr for default, ensure it's "" for strings,
+        # or your take() detects dtype "str" and chooses "".
+        indexer = [1, -1, 3]
+        out = str_arr.take(indexer, allow_fill=True, fill_value=None)
+        assert out.to_numpy().tolist() == ["b", "", "d"]
+
+    def test_take_strings_allow_fill_invalid_negative_raises(self, str_arr):
+        with pytest.raises(ValueError):
+            str_arr.take([0, -2, 1], allow_fill=True, fill_value="X")
+
+    def test_take_strings_preserves_dtype_and_length(self, str_arr):
+        idx = [4, 3, 2, 1, 0]
+        out = str_arr.take(idx, allow_fill=False)
+        assert isinstance(out, ArkoudaStringArray)
+        assert len(out) == len(idx)
+        # kind should be 'U' (unicode) for numpy strings in most builds
+        assert out.to_numpy().dtype.kind in ("U", "S", "O")
+
+    def test_take_strings_sparse_fill_only_masks(self, str_arr):
+        indexer = [0, 1, -1, 2, -1]
+        out = str_arr.take(indexer, allow_fill=True, fill_value="FILL")
+        assert out.to_numpy().tolist() == ["a", "b", "FILL", "c", "FILL"]
+
+    @pytest.mark.parametrize("prob_size", pytest.prob_size)
+    def test_take_strings_scaling(self, prob_size):
+        strings = ak.array(["a", "b"])
+        pda = strings[ak.tile(ak.array([0, 1]), prob_size // 2)]
+        arr = ArkoudaStringArray(pda)
+        s = pd.Series(pda.to_ndarray())
+        idx1 = ak.arange(prob_size, dtype=ak.int64) // 2
+        assert_equivalent(arr.take(idx1)._data, s.take(idx1.to_ndarray()).to_numpy())


### PR DESCRIPTION
This PR simplifies the logic for the `take` function in `arkouda/pandas/extension/_arkouda_base_array.py` and adds unit tests.

Closes #4876 improve extension array api take functions