### PR TITLE
Closes #4884: Converting numpy array of bigint zeros to Arkouda yields empty array

### DIFF
--- a/arkouda/numpy/pdarraycreation.py
+++ b/arkouda/numpy/pdarraycreation.py
@@ -355,6 +355,8 @@ def array(
             # attempt to break bigint into multiple uint64 arrays
             # early out if we would have more uint arrays than can fit in max_bits
             early_out = (max_bits // 64) + (max_bits % 64 != 0) if max_bits != -1 else float("inf")
+            if all(a == 0):
+                return zeros(a.shape, dtype=bigint, max_bits=max_bits)
             while any(a != 0) and len(uint_arrays) < early_out:
                 if isinstance(a, np.ndarray):
                     low, a = a.astype("O") % 2**64, a.astype("O") // 2**64

--- a/tests/numpy/pdarray_creation_test.py
+++ b/tests/numpy/pdarray_creation_test.py
@@ -1376,3 +1376,16 @@ class TestPdarrayCreation:
             ones = ak.ones(shape, ak.bigint)
             n_ones = ones.to_ndarray()
             assert_arkouda_array_equal(ones, ak.array(n_ones))
+
+    def test_np_bigint_zeros_conversion(self):
+        a = ak.array(np.array([2**200] * 100) * 0)
+        assert a.size == 100
+        assert ak.all(a == 0)
+        assert ak.all(a == ak.array([0] * 100, dtype=ak.bigint))
+
+    @pytest.mark.skip_if_max_rank_less_than(2)
+    def test_np_bigint_zeros_conversion_multidim(self):
+        a = ak.array((np.array([2**200] * 100) * 0).reshape(5, 20))
+        assert a.size == 100
+        assert ak.all(a == 0)
+        assert ak.all(a == ak.array([0] * 100, dtype=ak.bigint).reshape(5, 20))


### PR DESCRIPTION
For some reason, converting an ndarray of zeros from numpy to Arkouda (when the zeros are bigint type) comes out all zeros. This isn't right.

Closes #4884: Converting numpy array of bigint zeros to Arkouda yields empty array