### PR TITLE
Fixes common type promotion in array_api concat and stack

### DIFF
--- a/arkouda/array_api/manipulation_functions.py
+++ b/arkouda/array_api/manipulation_functions.py
@@ -130,7 +130,7 @@ def _resolve_common_dtype(pdarrayList):
     elif _has_type(akbool, pdarrayList):
         dt = akbool
     else:
-        raise TypeError("All arrays in concat must be float, int, uint, or bool.")
+        raise TypeError("All arrays in operation must be float, int, uint, or bool.")
 
     dt = akdtype(dt)
     return dt, [array.astype(dt) for array in pdarrayList]

--- a/arkouda/array_api/manipulation_functions.py
+++ b/arkouda/array_api/manipulation_functions.py
@@ -4,10 +4,10 @@ from typing import List, Optional, Tuple, Union, cast
 
 import numpy as np
 
-from arkouda.numpy.dtypes import dtype as akdtype
 from arkouda.numpy.dtypes import bool as akbool
-from arkouda.numpy.dtypes import int64 as akint64
+from arkouda.numpy.dtypes import dtype as akdtype
 from arkouda.numpy.dtypes import float64 as akfloat64
+from arkouda.numpy.dtypes import int64 as akint64
 from arkouda.numpy.dtypes import uint64 as akuint64
 from arkouda.numpy.pdarrayclass import create_pdarray, create_pdarrays
 from arkouda.numpy.pdarraycreation import scalar_array

--- a/arkouda/array_api/manipulation_functions.py
+++ b/arkouda/array_api/manipulation_functions.py
@@ -114,18 +114,20 @@ def broadcast_to(x: Array, /, shape: Tuple[int, ...]) -> Array:
 #   else if there are any bools     -> result is bool
 
 
+def _has_type(aktype, pdarrayList):
+    return True in [array.dtype == aktype for array in pdarrayList]
+
+
 def _resolve_common_dtype(pdarrayList):
-    if True in [array.dtype == akfloat64 for array in pdarrayList]:
+    if _has_type(akfloat64, pdarrayList):
         dt = akfloat64
-    elif True in [array.dtype == akint64 for array in pdarrayList] and True in [
-        array.dtype == akuint64 for array in pdarrayList
-    ]:
+    elif _has_type(akint64, pdarrayList) and _has_type(akuint64, pdarrayList):
         dt = akfloat64
-    elif True in [array.dtype == akint64 for array in pdarrayList]:
+    elif _has_type(akint64, pdarrayList):
         dt = akint64
-    elif True in [array.dtype == akuint64 for array in pdarrayList]:
+    elif _has_type(akuint64, pdarrayList):
         dt = akuint64
-    elif True in [array.dtype == akbool for array in pdarrayList]:
+    elif _has_type(akbool, pdarrayList):
         dt = akbool
     else:
         raise TypeError("All arrays in concat must be float, int, uint, or bool.")

--- a/arkouda/array_api/manipulation_functions.py
+++ b/arkouda/array_api/manipulation_functions.py
@@ -4,8 +4,13 @@ from typing import List, Optional, Tuple, Union, cast
 
 import numpy as np
 
+from arkouda.numpy.dtypes import dtype as akdtype
+from arkouda.numpy.dtypes import bool as akbool
+from arkouda.numpy.dtypes import int64 as akint64
+from arkouda.numpy.dtypes import float64 as akfloat64
+from arkouda.numpy.dtypes import uint64 as akuint64
 from arkouda.numpy.pdarrayclass import create_pdarray, create_pdarrays
-from arkouda.numpy.pdarraycreation import promote_to_common_dtype, scalar_array
+from arkouda.numpy.pdarraycreation import scalar_array
 from arkouda.numpy.util import broadcast_dims
 
 from .array_object import Array, implements_numpy
@@ -100,6 +105,35 @@ def broadcast_to(x: Array, /, shape: Tuple[int, ...]) -> Array:
         raise ValueError(f"Failed to broadcast array: {e}")
 
 
+#   Dtype resolution in concat and stack both follow conventional numpy rules of:
+
+#   if there are any floats OR (there are any ints AND there are any uints)
+#                                   -> result is float
+#   else if there are any ints      -> result is int
+#   else if there are any uints     -> result is uint
+#   else if there are any bools     -> result is bool
+
+
+def _resolve_common_dtype(pdarrayList):
+    if True in [array.dtype == akfloat64 for array in pdarrayList]:
+        dt = akfloat64
+    elif True in [array.dtype == akint64 for array in pdarrayList] and True in [
+        array.dtype == akuint64 for array in pdarrayList
+    ]:
+        dt = akfloat64
+    elif True in [array.dtype == akint64 for array in pdarrayList]:
+        dt = akint64
+    elif True in [array.dtype == akuint64 for array in pdarrayList]:
+        dt = akuint64
+    elif True in [array.dtype == akbool for array in pdarrayList]:
+        dt = akbool
+    else:
+        raise TypeError("All arrays in concat must be float, int, uint, or bool.")
+
+    dt = akdtype(dt)
+    return dt, [array.astype(dt) for array in pdarrayList]
+
+
 def concat(arrays: Union[Tuple[Array, ...], List[Array]], /, *, axis: Optional[int] = 0) -> Array:
     """
     Concatenate arrays along an axis.
@@ -149,7 +183,7 @@ def concat(arrays: Union[Tuple[Array, ...], List[Array]], /, *, axis: Optional[i
     # That means this concat function will output a float, even if all arrays are ints.
     # numpy concat does not do that.
 
-    (common_dt, _arrays) = promote_to_common_dtype([a._array for a in arrays])
+    (common_dt, _arrays) = _resolve_common_dtype([a._array for a in arrays])
 
     return Array._new(
         create_pdarray(
@@ -661,12 +695,8 @@ def stack(arrays: Union[Tuple[Array, ...], List[Array]], /, *, axis: int = 0) ->
     if not valid:
         raise IndexError(f"{axis} is not a valid axis for stacking arrays of rank {ndim}")
 
-    # TODO: fix the type promotion here, as in concat above.  This is always producing
-    # floats, even when all inputs are integer.  numpy stack doesn't do that.
+    (common_dt, _arrays) = _resolve_common_dtype([a._array for a in arrays])
 
-    (common_dt, _arrays) = promote_to_common_dtype([a._array for a in arrays])
-
-    # TODO: type promotion across input arrays
     return Array._new(
         create_pdarray(
             cast(


### PR DESCRIPTION
Addendum

I neatened this a bit, with a function _has_type, so that the check against all  types would be a bit more readable and concise.


Closes #4880 

Both concat and stack were using numpy's promote_to_common_dtype to compute the result type.  But numpy's concat and stack don't use that.  They use the conventional numpy rule of:

any float -> output = float, else
any int AND any uint -> output = float, else
any int -> output = int, else
any uint -> output = uint, else
any bool -> output = bool, else
error

This PR implements the correct type promotion.

**Possible point of discussion**:

I've done the check (and type conversion) python-side.  The "where" function, implemented in EfuncMsg.chpl, does the same check chapel-side.  On the one hand, I would prefer to be consistent.  On the other hand, that would create multiple instantiations of the chapel-side proc, and we've recently been running up against instantiation limits.

I am entirely open to discussion on whether to move this chapel-side.
