### PR TITLE
Improve CI to automate builds (Part 2)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,8 @@ on: [pull_request, merge_group, workflow_dispatch]
 
 env:
   ARKOUDA_QUICK_COMPILE: true
-  
+  ARKOUDA_SKIP_CHECK_DEPS: true
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -30,27 +31,26 @@ jobs:
 
   chpl-lint:
     runs-on: ubuntu-latest
-    env:
-      CHPL_HOME: /opt/chapel-2.5.0
+    strategy:
+      matrix:
+        chpl-version: ['2.5.0']
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.3
+      image: ghcr.io/bears-r-us/ubuntu-with-arkouda-deps-chpl-${{ matrix.chpl-version }}:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Set Python version to 3.13
       run: |
         update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1
-    - name: Install dependencies
-      run: |
-        (cd $CHPL_HOME && make chplcheck)
-        update-alternatives --install /usr/bin/chplcheck chplcheck /opt/chapel-2.5.0/tools/chplcheck/chplcheck 1
     - name: Ensure ignore file exists
       # .chplcheckignore should live at your repo root
       run: |
         if [ ! -f .chplcheckignore ]; then
           echo "# add paths/globs to ignore, e.g. src/generated/*" > .chplcheckignore
         fi
-
     - name: Run chplcheck (respecting .chplcheckignore)
       run: |
         make chplcheck
@@ -99,17 +99,18 @@ jobs:
           pip install ruff==0.11.2
       # Update output format to enable automatic inline annotations.
       - name: ruff version
-        run: | 
+        run: |
           ruff --version
       - name: Run Ruff
         run: ruff format --check --diff
 
   mypy:
     runs-on: ubuntu-latest
-    env:
-      CHPL_HOME: /opt/chapel-2.5.0
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.3
+      image: ghcr.io/bears-r-us/ubuntu-with-arkouda-deps-chpl-2.5.0:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
@@ -129,23 +130,20 @@ jobs:
 
   docs:
     runs-on: ubuntu-latest
-    env:
-      CHPL_HOME: /opt/chapel-2.5.0
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.3
+      image: ghcr.io/bears-r-us/ubuntu-with-arkouda-deps-chpl-2.5.0:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Set Python version to 3.13
       run: |
-        update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1  
-        python3 -m ensurepip --default-pip    
-    - name: Set Chapel version to 2.5.0
-      run: |
-        update-alternatives --install /usr/bin/chpl chpl /opt/chapel-2.5.0/bin/linux64-x86_64/chpl 1
-        update-alternatives --install /usr/bin/chpldoc chpldoc /opt/chapel-2.5.0/bin/linux64-x86_64/chpldoc 1
+        update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1
+        python3 -m ensurepip --default-pip
     - name: check chpldoc version
-      run: |  
+      run: |
         chpldoc --version
     - name: Install dependencies
       run: |
@@ -171,7 +169,10 @@ jobs:
   flake8:
     runs-on: ubuntu-latest
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.3
+      image: ghcr.io/bears-r-us/ubuntu-with-arkouda-deps-chpl-2.5.0:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
@@ -190,7 +191,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install flake8 pydoclint[flake8]==0.6.10
     - name: flake8 version
-      run: | 
+      run: |
         python3 -m ensurepip --default-pip
         flake8 --version
     - name: Arkouda flake8
@@ -205,18 +206,17 @@ jobs:
     env:
       CHPL_HOME: /opt/chapel-2.5.0
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.3
+      image: ghcr.io/bears-r-us/ubuntu-with-arkouda-deps-chpl-2.5.0:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
     # Check Python version
     - name: Set python version
-      run: |    
-        update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${{ matrix.python-version }} 1    
-    - name: Set Chapel version to 2.5.0
       run: |
-        update-alternatives --install /usr/bin/chpl chpl /opt/chapel-2.5.0/bin/linux64-x86_64/chpl 1
-        update-alternatives --install /usr/bin/chpldoc chpldoc /opt/chapel-2.5.0/bin/linux64-x86_64/chpldoc 1
+        update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${{ matrix.python-version }} 1
     - name: Check python version
       run: |
         python3 --version
@@ -239,16 +239,17 @@ jobs:
     - name: Arkouda unit tests
       run: |
         make test-python size=100
-        
+
   arkouda_makefile_almalinux:
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ['3.13']
-    env:
-      CHPL_HOME: /chapel-2.5.0
     container:
-      image: ajpotts/almalinux-with-arkouda-deps:1.0.3
+      image: ghcr.io/bears-r-us/almalinux-with-arkouda-deps:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
@@ -259,6 +260,8 @@ jobs:
         dnf update -y
         dnf install -y zlib-devel gcc gcc-c++ make zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel openssl openssl-devel libffi-devel xz-devel zlib-devel
 
+    # TODO: why does this need to build its own Python when the container has its own?
+    # almalinux's python is old, so we build from source. But can we move this into the container build?
     # Download and install Python from source (updated URL for Python 3.13)
     - name: Download Python ${matrix.python-version} source
       run: |
@@ -294,7 +297,7 @@ jobs:
         max_attempts: 2
         retry_wait_seconds: 60
         retry_on: error
-        command: | 
+        command: |
           make install-zmq DEP_BUILD_DIR=/dep/build
     - name: Make install-iconv
       uses: nick-fields/retry@v2
@@ -303,7 +306,7 @@ jobs:
         max_attempts: 2
         retry_wait_seconds: 60
         retry_on: error
-        command: | 
+        command: |
           make install-iconv DEP_BUILD_DIR=/dep/build
     - name: Make install-idn2
       uses: nick-fields/retry@v2
@@ -330,7 +333,7 @@ jobs:
         max_attempts: 2
         retry_wait_seconds: 60
         retry_on: error
-        command: |  
+        command: |
           make install-hdf5 DEP_BUILD_DIR=/dep/build
     - name: Make install-pytables
       uses: nick-fields/retry@v2
@@ -344,21 +347,21 @@ jobs:
 
   arkouda_makefile:
     runs-on: ubuntu-latest
-    env:
-      CHPL_HOME: /opt/chapel-2.5.0
+    strategy:
+      matrix:
+        chpl-version: ['2.5.0']
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.3
+      image: ghcr.io/bears-r-us/ubuntu-with-arkouda-deps-chpl-${{ matrix.chpl-version }}:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4    
+      uses: actions/checkout@v4
     - name: Set Python version to 3.13
       run: |
-        update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1 
-        python3 -m ensurepip --default-pip     
-    - name: Set Chapel version to 2.5.0
-      run: |
-        update-alternatives --install /usr/bin/chpl chpl /opt/chapel-2.5.0/bin/linux64-x86_64/chpl 1
-        update-alternatives --install /usr/bin/chpldoc chpldoc /opt/chapel-2.5.0/bin/linux64-x86_64/chpldoc 1
+        update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1
+        python3 -m ensurepip --default-pip
     - name: Check python version
       run: |
         python3 --version
@@ -370,7 +373,7 @@ jobs:
         retry_wait_seconds: 60
         retry_on: error
         command: |
-          make install-arrow-quick 
+          make install-arrow-quick
     - name: Make install-arrow
       uses: nick-fields/retry@v2
       with:
@@ -397,7 +400,7 @@ jobs:
         max_attempts: 2
         retry_wait_seconds: 60
         retry_on: error
-        command: | 
+        command: |
           make install-iconv  DEP_BUILD_DIR=$DEP_BUILD_DIR
     - name: Make install-idn2
       uses: nick-fields/retry@v2
@@ -407,7 +410,7 @@ jobs:
         retry_wait_seconds: 60
         retry_on: error
         command: |
-          make install-idn2  DEP_BUILD_DIR=$DEP_BUILD_DIR   
+          make install-idn2  DEP_BUILD_DIR=$DEP_BUILD_DIR
     - name: Make install-blosc
       uses: nick-fields/retry@v2
       with:
@@ -441,21 +444,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        chpl-version: ['2.0.0','2.1.0','2.2.0','2.3.0','2.4.0','2.5.0']
-    env:
-      CHPL_HOME: /opt/chapel-${{ matrix.chpl-version }}
+        chpl-version: ['2.4.0','2.5.0']
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.3
+      image: ghcr.io/bears-r-us/ubuntu-with-arkouda-deps-chpl-${{ matrix.chpl-version }}:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Set Python version to 3.13
       run: |
-        update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1      
-    - name: Set Chapel version to ${matrix.chpl-version}
-      run: |
-        update-alternatives --install /usr/bin/chpl chpl /opt/chapel-${{ matrix.chpl-version }}/bin/linux64-x86_64/chpl 1
-        update-alternatives --install /usr/bin/chpldoc chpldoc /opt/chapel-${{ matrix.chpl-version }}/bin/linux64-x86_64/chpldoc 1
+        update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1
     - name: Check Chapel version
       run: |
         chpl --version
@@ -471,12 +471,6 @@ jobs:
           echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" >> Makefile.paths
           echo "\$(eval \$(call add-path,$DEP_INSTALL_DIR/arrow-install/))" >> Makefile.paths
           echo "\$(eval \$(call add-path,$DEP_INSTALL_DIR/libiconv-install/))" >> Makefile.paths
-    - name: Check chpl version
-      run: |
-        chpl --version
-    - name: Install Chapel frontend bindings
-      run: |
-        (cd $CHPL_HOME/tools/chapel-py && python3 -m pip install .)
     - name: Build/Install Arkouda
       run: |
         make
@@ -489,12 +483,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        chpl-version: ['2.0.0','2.1.0','2.2.0','2.3.0','2.4.0','2.5.0']
+        chpl-version: ['2.4.0','2.5.0']
       max-parallel: 3
-    env:
-      CHPL_HOME: /opt/chapel-${{ matrix.chpl-version }}
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.3
+      image: ghcr.io/bears-r-us/ubuntu-with-arkouda-deps-chpl-${{ matrix.chpl-version }}:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
     steps:
     - name: Show memory available
       run: |
@@ -506,11 +501,7 @@ jobs:
       uses: actions/checkout@v4
     - name: Set Python version to 3.13
       run: |
-        update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1      
-    - name: Set Chapel version to ${matrix.chpl-version}
-      run: |
-        update-alternatives --install /usr/bin/chpl chpl /opt/chapel-${{ matrix.chpl-version }}/bin/linux64-x86_64/chpl 1
-        update-alternatives --install /usr/bin/chpldoc chpldoc /opt/chapel-${{ matrix.chpl-version }}/bin/linux64-x86_64/chpldoc 1
+        update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1
     - name: Check Chapel version
       run: |
         chpl --version
@@ -527,12 +518,6 @@ jobs:
           echo "\$(eval \$(call add-path,/usr/lib/x86_64-linux-gnu/hdf5/serial/))" >> Makefile.paths
           echo "\$(eval \$(call add-path,$DEP_INSTALL_DIR/arrow-install/))" >> Makefile.paths
           echo "\$(eval \$(call add-path,$DEP_INSTALL_DIR/libiconv-install/))" >> Makefile.paths
-    - name: Check chpl version
-      run: |
-        chpl --version
-    - name: Install Chapel frontend bindings
-      run: |
-        (cd $CHPL_HOME/tools/chapel-py && python3 -m pip install .)    
     - name: Use MultiDim Configs
       run: |
         cp .configs/registration-config-multi-dim.json registration-config.json
@@ -551,19 +536,20 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CHPL_RT_NUM_THREADS_PER_LOCALE: 2
-      CHPL_HOME: /opt/chapel-2.5.0
+    strategy:
+      matrix:
+        chpl-version: ['2.5.0']
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.3
+      image: ghcr.io/bears-r-us/ubuntu-with-arkouda-deps-chpl-${{ matrix.chpl-version }}:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Set Python version to 3.13
       run: |
-        update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1      
-    - name: Set Chapel version to 2.5
-      run: |
-        update-alternatives --install /usr/bin/chpl chpl /opt/chapel-2.5.0/bin/linux64-x86_64/chpl 1
-        update-alternatives --install /usr/bin/chpldoc chpldoc /opt/chapel-2.5.0/bin/linux64-x86_64/chpldoc 1
+        update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1
     - name: Check Chapel version
       run: |
         chpl --version
@@ -588,33 +574,31 @@ jobs:
       run: |
         make check
     - name: Arkouda unit tests
-      if: matrix.image != 'chapel-gasnet-smp'
       env:
         ARKOUDA_PYTEST_OPTIONS: "--durations=0 --durations-min=5.0"
       run: |
         make test-python size=100
     - name: Arkouda benchmark --correctness-only
-      if: matrix.image != 'chapel-gasnet-smp'
       run: |
         ARKOUDA_HOME=$(pwd) ./benchmarks/run_benchmarks.py --correctness-only
         ARKOUDA_HOME=$(pwd) ./benchmarks/run_benchmarks.py --size=100 --gen-graphs
-        
+
   arkouda_benchmark_linux:
     runs-on: ubuntu-latest
-    env:
-      CHPL_HOME: /opt/chapel-2.5.0
+    strategy:
+      matrix:
+        chpl-version: ['2.5.0']
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.3
+      image: ghcr.io/bears-r-us/ubuntu-with-arkouda-deps-chpl-${{ matrix.chpl-version }}:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Set Python version to 3.13
       run: |
-        update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1      
-    - name: Set Chapel version to 2.5
-      run: |
-        update-alternatives --install /usr/bin/chpl chpl /opt/chapel-2.5.0/bin/linux64-x86_64/chpl 1
-        update-alternatives --install /usr/bin/chpldoc chpldoc /opt/chapel-2.5.0/bin/linux64-x86_64/chpldoc 1
+        update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1
     - name: Check Chapel version
       run: |
         chpl --version
@@ -640,6 +624,4 @@ jobs:
         make benchmark size_bm=10
     - name: Arkouda benchmark -- Numpy
       run: |
-        python3 -m pytest -c benchmark.ini --size=10 --numpy   
-          
-            
+        python3 -m pytest -c benchmark.ini --size=10 --numpy

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,7 +4,7 @@ name: docs
 on:
   push:
     branches:
-      - master
+      - main
 
 env:
   ARKOUDA_QUICK_COMPILE: true
@@ -16,20 +16,23 @@ jobs:
     env:
       CHPL_HOME: /opt/chapel-2.5.0
     container:
-      image: ajpotts/ubuntu-with-arkouda-deps:1.0.3
+      image: ghcr.io/bears-r-us/ubuntu-with-arkouda-deps:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Set Python version to 3.13
       run: |
-        update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1  
-        python3 -m ensurepip --default-pip    
+        update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1
+        python3 -m ensurepip --default-pip
     - name: Set Chapel version to 2.5.0
       run: |
         update-alternatives --install /usr/bin/chpl chpl /opt/chapel-2.5.0/bin/linux64-x86_64/chpl 1
         update-alternatives --install /usr/bin/chpldoc chpldoc /opt/chapel-2.5.0/bin/linux64-x86_64/chpldoc 1
     - name: check chpldoc version
-      run: |  
+      run: |
         chpldoc --version
     - name: Install dependencies
       run: |

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,27 @@
+# docker CI images
+
+Each folder in this directory contains a Dockerfile for building a container used in CI.
+
+## Updating the images
+
+To update the CI images, all you need to do is edit the relevant Dockerfile(s) and create a PR. The CI images are built automatically by `.github/workflows/build-CI-container-jobs.yml`. If the Dockerfiles are changed, the images will be rebuilt on a PR, and then again when the PR is merged to main. When the PR is merged, the updated images will be pushed to GitHub Container Registry (GHCR) under the Bears-R-Us organization.
+
+## Making CI changes that require image updates
+
+When making changes to the CI that require updates to the images, please follow these steps:
+
+1. Edit the relevant Dockerfile(s) in this directory.
+2. Open a PR with the changes to the Dockerfile(s).
+3. Once the PR is open, the CI images will be rebuilt automatically. You can check the progress of the builds in the "Actions" tab of the repository.
+4. Once the PR is approved and merged, the updated images will be pushed to GHCR automatically.
+5. Make any additional changes to the CI workflows as needed, and open a new PR for those changes.
+
+## Adding a new image
+
+To add a new CI image, follow these steps:
+
+1. Create a new directory in this `docker/` directory for the new image.
+2. Add a Dockerfile to the new directory that defines the image.
+3. Update `.github/workflows/build-CI-container-jobs.yml` to include jobs for building and pushing the new image. You can copy and modify the existing jobs for the other images as needed.
+4. Open a PR with the new directory, Dockerfile, and workflow changes. The new image will be built and pushed automatically when the PR is merged.
+5. Make any additional changes to the CI workflows as needed, and open a new PR for those changes.


### PR DESCRIPTION
Improves the CI by switching it to use the new auto-built images from https://github.com/Bears-R-Us/arkouda/pull/4891

This PR also drops Chapel versions 2.0-2.3 from the CI. A later PR will add 2.6