### PR TITLE
Implements destructors for chapel-side and python-side rngs

### DIFF
--- a/arkouda/numpy/random/legacy.py
+++ b/arkouda/numpy/random/legacy.py
@@ -339,14 +339,15 @@ def seed(seed=None):
     Notes
     -----
     Reseeding always causes the destruction of an existing generator, because
-    there is no way to reseed a chapel randomStream.
-    The existing generator is deleted, though python doesn't require that.
-    Python-side, it suffices to create a new generator with the new seed.
+    there is no way to reseed a chapel randomStream.  The existing generator
+    is deleted, and the python destructor invokes the chapel-side delGenerator
+    which removes the generator from the symbol table, deleting it and its
+    RandomStream.
     """
     global theGenerator
 
     if globalGeneratorExists():
-        del theGenerator
+        theGenerator.destructor()
 
     theGenerator = default_rng(seed)
 
@@ -822,6 +823,10 @@ def shuffle(
     >>> pda
     array([2 3 6 9 8 5 1 4 7 0])
     """
+    # It is worth noting that shuffle is unique among the rng functions, in that
+    # it does not return a value.  The elements of x are shuffled in place.  That's
+    # why this function has no return statement.
+
     getGlobalGenerator().shuffle(
         x, method=method, feistel_rounds=feistel_rounds, feistel_key=feistel_key
     )

--- a/src/RandMsg.chpl
+++ b/src/RandMsg.chpl
@@ -32,11 +32,29 @@ module RandMsg
     const randLogger = new Logger(logLevel, logChannel);
 
     /*
+        The delGeneratorMsg allows the deletion of random number generator objects.
+        This was implemented so that in the event that the global rng is reseeded
+        multiple times, we won't build up a never-ending set of generatorEntrys and
+        RandomStreams.
+     */
+
+    @chplcheck.ignore("UnusedFormal")
+    proc delGeneratorMsg(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab): MsgTuple throws {
+        const name = msgArgs.getValueOf("name");
+        var generatorEntry = st(name);
+        st.deleteEntry(generatorEntry.name);
+        var repMsg = "deleted " +  generatorEntry.name;
+        randLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+        return MsgTuple.success();
+    }
+
+    /*
     parse, execute, and respond to randint message
     uniform int in half-open interval [min,max)
 
     :arg reqMsg: message to process (contains cmd,aMin,aMax,len,dtype)
     */
+
     @arkouda.instantiateAndRegister
     proc randint(cmd: string, msgArgs: borrowed MessageArgs, st: borrowed SymTab, type array_dtype, param array_nd: int): MsgTuple throws
         where array_dtype != BigInteger.bigint
@@ -1854,4 +1872,5 @@ module RandMsg
     registerFunction("logisticGenerator", logisticGeneratorMsg, getModuleName());
     registerFunction("segmentedSample", segmentedSampleMsg, getModuleName());
     registerFunction("poissonGenerator", poissonGeneratorMsg, getModuleName());
+    registerFunction("delGenerator", delGeneratorMsg, getModuleName());
 }


### PR DESCRIPTION
Closes #4869 

This is an addendum to the global seed generator which implements destructors for the random number generators on both chapel-side and python-side.  Prior to this, generators were never destroyed in either place, which resulted in an upward creep of memory usage if the global generator was reseeded thousands of times.

In not-perfectly-accurate tests using htop, I've confirmed that in this version, 100000 reseeds will add 0.01GB to the memory usage, whereas the previous version added 0.3GB to 0.4GB of memory usage.