### PR TITLE
Improve parquet read implementation and multiple column read performance

### DIFF
--- a/.chplcheckignore
+++ b/.chplcheckignore
@@ -57,6 +57,7 @@ NumPyDType.chpl
 OperatorMsg.chpl
 parquet
 ParquetMsg.chpl
+ParquetSharedEnums.chpl
 parseServerConfig.py
 RadixSortLSD.chpl
 RandArray.chpl

--- a/src/ParquetSharedEnums.chpl
+++ b/src/ParquetSharedEnums.chpl
@@ -1,0 +1,10 @@
+/* WARNING: this file is included in C++ code as if it is a regular C header. So
+ * even though it has chpl extension, the syntax has to be legal both in Chapel
+ * and C++ and the contents should be limited to enum definitions shared between
+ * different layers to ensure consistent signalling.
+ */
+
+enum NullMode { noNulls=0,
+                onlyFloats=1,
+                all=2
+};

--- a/src/parquet/ReadParquet.h
+++ b/src/parquet/ReadParquet.h
@@ -1,5 +1,11 @@
+#ifndef READ_PARQUET_H
+#define READ_PARQUET_H
+
 #include <stdint.h>
 #include <stdbool.h>
+
+#include "UtilParquet.h"
+
 
 // Wrap functions in C extern if compiling C++ object file
 #ifdef __cplusplus
@@ -13,11 +19,48 @@
 #include <parquet/schema.h>
 #include <cmath>
 #include <queue>
+
+namespace akcpp {
+  // Engin: We could consider exposing this struct to Chapel. Note that in
+  // ParquetMsg.chpl there is a somewhat similar type. However, this one is for a
+  // single column read
+  // Based on what we decide, the implementation of this struct can be mode more
+  // C++-like or could stay more C-like.
+  struct ColReadOp {
+    void* chpl_arr;
+    int64_t *startIdx;
+    std::shared_ptr<parquet::ColumnReader> column_reader;
+    bool hasNonFloatNulls;
+    chplEnum_t nullMode;
+    int64_t row_idx;
+    int64_t numElems;
+    int64_t batchSize;
+    bool* where_null_chpl;
+    const parquet::ColumnDescriptor* col_info;
+
+    template<typename ArrowType>
+    int64_t read();
+
+    template<typename Types>
+    int64_t _readShortIntegral();
+  };
+
+  int readAllCols(const char* filename, void** chpl_arrs, int* types,
+                  bool* where_null_chpl, int64_t numElems, int64_t startIdx,
+                  int64_t batchSize, chplEnum_t nullMode, char** errMsg);
+}
+
+
 extern "C" {
 #endif
   int c_readStrColumnByName(const char* filename, void* chpl_arr, const char* colname, int64_t numElems, int64_t batchSize, char** errMsg);
   
   int cpp_readStrColumnByName(const char* filename, void* chpl_arr, const char* colname, int64_t numElems, int64_t batchSize, char** errMsg);
+
+  int c_readAllCols(const char* filename, void** chpl_arrs, int* types,
+                         bool* where_null_chpl, int64_t numElems,
+                         int64_t startIdx, int64_t batchSize,
+                         chplEnum_t nullMode, char** errMsg);
 
   int c_readColumnByName(const char* filename, void* chpl_arr, bool* where_null_chpl,
                          const char* colname, int64_t numElems, int64_t startIdx,
@@ -49,3 +92,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+#endif //READ_PARQUET_H

--- a/src/parquet/SharedEnums.h
+++ b/src/parquet/SharedEnums.h
@@ -1,0 +1,6 @@
+#ifndef SHARED_ENUMS_H
+#define SHARED_ENUMS_H
+
+#include "../ParquetSharedEnums.chpl"
+
+#endif // SHARED_ENUMS_H

--- a/src/parquet/UtilParquet.h
+++ b/src/parquet/UtilParquet.h
@@ -1,5 +1,11 @@
+#ifndef UTIL_PARQUET_H
+#define UTIL_PARQUET_H
+
 #include <stdint.h>
 #include <stdbool.h>
+#include "SharedEnums.h"
+
+#define chplEnum_t int64_t
 
 // Wrap functions in C extern if compiling C++ object file
 #ifdef __cplusplus
@@ -14,7 +20,9 @@
 #include <cmath>
 #include <queue>
 
+
 std::shared_ptr<parquet::schema::GroupNode> SetupSchema(void* column_names, void * objTypes, void* datatypes, int64_t colnum);
+
 
 extern "C" {
 #endif
@@ -44,6 +52,7 @@ extern "C" {
 #define ZSTD_COMP 4
 #define LZ4_COMP 5
 
+
   typedef struct {
     uint32_t len;
     const uint8_t* ptr;
@@ -67,6 +76,11 @@ extern "C" {
   // is no C++ interoperability supported in Chapel today.
   int64_t c_getNumRows(const char*, char** errMsg);
   int64_t cpp_getNumRows(const char*, char** errMsg);
+
+  int64_t c_getNumCols(const char* filename, char** errMsg);
+  int64_t cpp_getNumCols(const char* filename, char** errMsg);
+
+  int c_getAllTypes(const char* filename, int* types_out, char** errMsg);
   
   int64_t c_getStringColumnNullIndices(const char* filename, const char* colname, void* chpl_nulls, char** errMsg);
   int64_t cpp_getStringColumnNullIndices(const char* filename, const char* colname, void* chpl_nulls, char** errMsg);
@@ -148,3 +162,4 @@ extern "C" {
   bool check_status_ok(arrow::Status status, char** errMsg);
 }
 #endif
+#endif //UTIL_PARQUET_H


### PR DESCRIPTION
This PR has two main goals:

- improve the performance of parquet reads, particularly when all the columns of the file(s) are read
- start improving the implementation on C++ and Chapel sides

### User-facing Change:

- This PR deprecates `has_non_float_nulls: Bool`, in favor of `null_handling: {"none", "only floats", "all"}`
  - We need a 3-way switch to enable fast floating point reads when the user knows their data contains no nulls. Old boolean-based switch cannot capture that. The new `null_handling` formal to `read_parquet` defaults to "only floats" to match with the older behavior.
  - Right now, `null_handling` is effective only when reading all columns. `has_non_float_nulls` is used when only a subset of columns are read. It is a TODO to phase out `has_non_float_nulls`, among other things.

### Why do we need a new implementation for performance?

Parquet is a columnar format. However, that doesn't mean that all data for a column is stored consecutively. For large files (512M by default, I think), Parquet files will be written in consecutive _row groups_ instead of storing large columns one after another. Therefore, a more natural way of reading a parquet file is to read row-group-by-row-group while going through all the columns. Considering reading all columns as a common use case, it is important to read parquet files in that way for performance. Right now, if you have 10 columns, you open and read the entire file(s) 10 times, one for each column, skipping 9 columns during each read.

#### A small optimization along the way

With the new `null_handling` control flag, we can also enable batch reads of floating point types where prior to this PR we were reading them one-by-one to be able to catch nulls. I think even with nulls at play, we should be able to do better than that, but that's a post-merge TODO.



#### Performance Improvements

This is using ~400GBs of data in 5 columns partitioned into 128 files, read by 16 locales:

|           | `main` (s) | branch (s) | improvement (x)
|---------|-----------------|---------------|--------
| min    | 11.43           | 7.60          | 1.50
| max   | 22.58          | 14.96        | 1.51
| ave    |  16.69         | 9.38          | 1.78

This is using ~30GBs of data in 1000 columns partitioned into 128 files, read by 16 locales:

|           | `master` (s) | branch (s) | improvement (x)
|---------|-----------------|---------------|--------
| min    | 335.97           | 9.02          | 37.24
| max   | 335.97          | 15.64        | 21.48
| ave    | 335.97         | 9.98          | 33.67



### Implementation details:

- If the user doesn't pass any dataset names to `read_parquet`, we read all columns. This PR makes that case take an entirely new codepath with no modifications to the subset-of-columns code path. I intend to remove this old code path in favor of the new one even for subset-of columns. That's a post-merge TODO.
- This new code path introduces the following on the C++ side:
  - `namespace akcpp` on the C++ side. I want more code to live in this namespace going forward. Within that namespace:
  - `struct AkReadColOp` on the C++ side to represent type-agnostic information for reading a single column.
  - This type has a template `read()` function for reading a column with specific dynamic type
  - `read()` has some template specializations for handling some specific cases like short integrals that are not represented on the Chapel side and need to be cast to bigger ones
  - The `read()` family of functions has _a lot of code redundancy_ that I inherited from the earlier implementation. Refactoring those redundancies into helpers is an obvious TODO.  
  - `readAllCols` function to handle the operation. This is the function that selects the correct `read()` instantiation based on the dynamic type.
- This new code path introduces the following on the Chapel side:
  - `readAllColsParquetMsg` which is the main message handler here. The implementation is too much of a Frakenstein experiment where old style/structure is mixed with the new. Going forward, I want this function to be the general parquet read function, so it needs more improvements.
  - The implementation of this stores read metadata in `pqReadColOp`. This is deceptively similar to `AkReadColOp`. But it actually stores information for the whole read operation and it is not per-column. I want to consider whether we can have single metadata shared between C++ and Chapel.
  - This `pqReadColOp` determines whether we can read all columns at the same time based on the dynamic types of the columns. If we can't it will fall back to the old implementation. Currently that fallback is a bit rough as we call the message handler. I think that's a bad practice and the core logic of the read has to be available without the message handling. We'll need to reconcile the two different reads in any case, so that's part of post-merge TODOs.
  - I used this type to do column-per-column reads, too. That's the only change in the existing code path. I started off thinking that I can do all the refactoring in one go, but decided against it. Nevertheless, I left that part in. Currently that causes `pqReadColOp` to be more generic than I'd like. It will be fixed in the next refactor wave.
  - Simplified error location reporting
  - Several new small helpers and simplified helpers 

### Test Status:
- [x] local parquet unit testing
- [x] oversubscribed parquet unit testing

### Post-Merge TODO
- [ ] Refactor `read()` functions into having more helpers
  - [ ] Consider handling per-batch post-processing differently, maybe with functors.
- [ ] use the `akcpp::readAllCols` function for reading subset of columns, too and remove the old read implementation completely. Similarly for `readAllColsParquetMsg` on Chapel side
  - [ ] Fall back to col-per-col read in a more graceful way 
  - [ ] completely deprecate `has_non_float_nulls`
- [ ] Can we read floating point columns with nulls in them in batches and process nulls differently? 
- [ ] Can we use a single metadata type for C++ and Chapel?
- [ ] Use message registration attributes for Parquet message handlers
- [ ] Short integer and float reads use a temporary buffer. We can get rid of that by reading into the larger Chapel buffer and spacing things out in reverse order.
- [ ] Handle `ARROWERROR` and error messages populated by the C level better and more consistently
- [ ] https://github.com/Bears-R-Us/arkouda/issues/4925