### PR TITLE
Fix push for `build-CI-container`

### DIFF
--- a/.github/workflows/build-CI-container.yml
+++ b/.github/workflows/build-CI-container.yml
@@ -36,13 +36,13 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3.5.0
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build Docker Image
-        uses: docker/build-push-action@v6.18.0
+        uses: docker/build-push-action@v6
         with:
           file: ${{ inputs.DOCKERFILE }}
           push: false
@@ -52,8 +52,11 @@ jobs:
             CHPL_VERSION=${{ inputs.CHPL_VERSION }}
       - name: Push Docker Image if on main
         if: github.repository_owner == 'Bears-R-Us' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
-        uses: docker/build-push-action@v6.18.0
+        uses: docker/build-push-action@v6
         with:
           file: ${{ inputs.DOCKERFILE }}
           push: true
           tags: ghcr.io/bears-r-us/${{ inputs.IMAGE_NAME }}:${{ inputs.VERSION }}
+          context: ${{ inputs.CONTEXTPATH }}
+          build-args: |
+            CHPL_VERSION=${{ inputs.CHPL_VERSION }}


### PR DESCRIPTION
Fixes the push step for `build-CI-container`, it needs to have the same args as the build step
