### PR TITLE
Standardizes axis validation and handling in array_api/statistical_functions.py

### DIFF
--- a/tests/array_api/stats_functions.py
+++ b/tests/array_api/stats_functions.py
@@ -8,6 +8,7 @@ import arkouda.array_api as xp
 
 
 class TestStatsFunction:
+    @pytest.mark.skip_if_rank_not_compiled([2])
     def test_statistical_functions_docstrings(self):
         import doctest
 
@@ -65,7 +66,7 @@ class TestStatsFunction:
 
         a[:, 0, 0] = 26
 
-        print(a.tolist())
+        assert int(xp.mean(a)) == 2
 
         aMean0 = xp.mean(a, axis=0)
         assert aMean0.shape == (5, 5)


### PR DESCRIPTION
Closes #4905 

The primary intent of this PR was to add the new standard axis validation & handling to array_api/statistical_functions.py.  Along the way, I noted other issues.

- The docstrings were very incomplete.  I have attempted to fix that.
- The unit test for array_api's mean had a print statement where there should have been an assert.  Fixed.
- There are two comments in statistical_functions.py that I believe are out of date:  lines 298 and 449, if my notes are correct.  I'm inclined to delete them (holding off on that for a later revision).

NOTE: some of the functions are just pass-throughs (i.e. no code except for calling another function).  In those cases, I've chosen not to check the axis parameter (since the other function has to), nor to include the corresponding errors in the Raises section, even though I may have included Examples.  This is purely a judgment call, and I'm open to discussion.

