### PR TITLE
Fix paths in new CI image Dockerfile

### DIFF
--- a/docker/ubuntu-with-arkouda-deps/Dockerfile
+++ b/docker/ubuntu-with-arkouda-deps/Dockerfile
@@ -4,7 +4,7 @@ ARG CHPL_VERSION
 
 USER root
 
-ENV PATH=/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/venv/bin
+ENV PATH=/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/chapel-$CHPL_VERSION/bin/linux64-x86_64:/opt/chapel-$CHPL_VERSION/bin/linux64-arm64:/opt/chapel-$CHPL_VERSION/bin/linux64-aarch64
 
 ENV CHPL_HOME=/opt/chapel-$CHPL_VERSION
 ENV CHPL_RE2=bundled
@@ -98,6 +98,7 @@ RUN rm -fr arkouda
 ###############################################################################
 
 #   Save build environment to the .bashrc.local
+# TODO: is this really needed?
 RUN env >> ~/.bashrc.local
 
 


### PR DESCRIPTION
Fix paths in new CI image Dockerfile to actually add `chpl` to the PATH

Future work
- [ ] all of the work done to put stuff in a `~/.bashrc.local` is not being used at all. the CI runs with `/bin/sh -c ...`, so bash files will never be invoked