### PR TITLE
Closes #4565: MaxArrayDims is incorrect - fix or remove it

### DIFF
--- a/src/ServerConfig.chpl
+++ b/src/ServerConfig.chpl
@@ -41,12 +41,6 @@ module ServerConfig
     };
 
     /*
-      maximum array dimensionality supported by the server
-      set in 'registration-config.json'
-    */
-    config param MaxArrayDims: int = 1;
-
-    /*
     Type of deployment, which currently is either STANDARD, meaning
     that Arkouda is deployed bare-metal or within an HPC environment, 
     or on Kubernetes, defaults to Deployment.STANDARD
@@ -208,7 +202,6 @@ module ServerConfig
             const byteorder: string;
             const autoShutdown: bool;
             const serverInfoNoSplash: bool;
-            const maxArrayDims: int;
         }
 
         var (Zmajor, Zminor, Zmicro) = ZMQ.version;
@@ -235,8 +228,7 @@ module ServerConfig
             regexMaxCaptures = regexMaxCaptures,
             byteorder = try! getByteorder(),
             autoShutdown = autoShutdown,
-            serverInfoNoSplash = serverInfoNoSplash,
-            maxArrayDims = MaxArrayDims
+            serverInfoNoSplash = serverInfoNoSplash
         );
         return try! formatJson(cfg);
 


### PR DESCRIPTION
Decided to remove it. It doesn't look like it's actually used anywhere and in `ServerConfig.chpl` there already is a function `proc arrayDimIsSupported(param dim: int) param : bool {` which should continue to be used in place of `MaxArrayDims`.

Closes #4565: MaxArrayDims is incorrect - fix or remove it