### PR TITLE
Fixes handling of size/shape parameter in ak.random.poisson

### DIFF
--- a/arkouda/numpy/random/generator.py
+++ b/arkouda/numpy/random/generator.py
@@ -218,7 +218,7 @@ class Generator:
 
         shape, ndim, full_size = _infer_shape_from_size(size)
         if full_size < 0:
-            raise ValueError("The size parameter must be > 0")
+            raise ValueError("The size parameter must be >= 0")
 
         rep_msg = generic_msg(
             cmd=f"standardExponential<{ndim}>",
@@ -298,7 +298,7 @@ class Generator:
 
         shape, ndim, full_size = _infer_shape_from_size(size)
         if full_size <= 0:
-            raise ValueError("The size parameter must be > 0")
+            raise ValueError("The size parameter must be >= 0")
 
         rep_msg = generic_msg(
             cmd=f"uniformGenerator<{dtype.name},{ndim}>",
@@ -614,7 +614,7 @@ class Generator:
 
         shape, ndim, full_size = _infer_shape_from_size(size)
         if full_size < 0:
-            raise ValueError("The size parameter must be > 0")
+            raise ValueError("The size parameter must be >= 0")
 
         rep_msg = generic_msg(
             cmd=f"standardGamma<{ndim}>",
@@ -678,7 +678,7 @@ class Generator:
 
         shape, ndim, full_size = _infer_shape_from_size(size)
         if full_size < 0:
-            raise ValueError("The size parameter must be > 0")
+            raise ValueError("The size parameter must be >= 0")
 
         rep_msg = generic_msg(
             cmd=f"standardNormalGenerator<{ndim}>",
@@ -944,7 +944,7 @@ class Generator:
 
         shape, ndim, full_size = _infer_shape_from_size(size)
         if full_size < 0:
-            raise ValueError("The size parameter must be > 0")
+            raise ValueError("The size parameter must be >= 0")
 
         is_single_lambda, lam = float_array_or_scalar_helper("poisson", "lam", lam, size)
         if (lam < 0).any() if isinstance(lam, pdarray) else lam < 0:
@@ -1012,7 +1012,7 @@ class Generator:
 
         shape, ndim, full_size = _infer_shape_from_size(size)
         if full_size < 0:
-            raise ValueError("The size parameter must be > 0")
+            raise ValueError("The size parameter must be >= 0")
 
         dt = akdtype("float64")
         rep_msg = generic_msg(

--- a/arkouda/numpy/random/generator.py
+++ b/arkouda/numpy/random/generator.py
@@ -936,10 +936,15 @@ class Generator:
 
         """
         from arkouda.client import generic_msg
+        from arkouda.numpy.util import _infer_shape_from_size
 
         if size is None:
             # delegate to numpy when return size is 1
             return self._np_generator.poisson(lam, size)
+
+        shape, ndim, full_size = _infer_shape_from_size(size)
+        if full_size < 0:
+            raise ValueError("The size parameter must be > 0")
 
         is_single_lambda, lam = float_array_or_scalar_helper("poisson", "lam", lam, size)
         if (lam < 0).any() if isinstance(lam, pdarray) else lam < 0:
@@ -951,14 +956,14 @@ class Generator:
                 "name": self._name_dict[akdtype("float64")],
                 "lam": lam,
                 "is_single_lambda": is_single_lambda,
-                "size": size,
+                "size": full_size,
                 "has_seed": self._seed is not None,
                 "state": self._state,
             },
         )
         # we only generate one val using the generator in the symbol table
         self._state += 1
-        return create_pdarray(rep_msg)
+        return create_pdarray(rep_msg) if ndim == 1 else create_pdarray(rep_msg).reshape(shape)
 
     def uniform(self, low=0.0, high=1.0, size=None):
         """


### PR DESCRIPTION
Closes #4220

This fixes the handling of the size parameter in ak.random.poisson, so that (e.g.) ak.random.poisson(lam=lam,size=(m,n)) will produce an mxn pdarray.

The very simple fix is to generate 1D values, and reshape if needed.

Analyzing this bug report uncovered other issues in the random number generation, so I'll be adding additional issues.