### PR TITLE
Closes #4836: --saveUsedModules should only save modules that are not compiled by default

### DIFF
--- a/src/CommandMap.chpl
+++ b/src/CommandMap.chpl
@@ -23,6 +23,7 @@ module CommandMap {
   var moduleMap: map(string, (string, int));  // cmd-name => (module-name, line number)
   use Set;
   var usedModules: set(string);
+  const requiredModules = new set(string, ["GenSymIO", "MsgProcessing"]);
 
   /**
    * Register command->function in the CommandMap
@@ -83,7 +84,10 @@ module CommandMap {
 
   proc executeCommand(cmd: string, msgArgs, st): MsgTuple throws {
     if commandMap.contains(cmd) {
-      if moduleMap.contains(cmd) then usedModules.add(moduleMap[cmd][0]);
+      if moduleMap.contains(cmd) {
+        var m = moduleMap[cmd][0];
+        if !requiredModules.contains(m) then usedModules.add(m);
+      }
       return commandMap[cmd](cmd, msgArgs, st);
     } else {
       return MsgTuple.error("Unrecognized command: %s".format(cmd));

--- a/src/parseServerConfig.py
+++ b/src/parseServerConfig.py
@@ -12,7 +12,10 @@ def getModules(config):
 
 
 def getModuleFiles(mods, src_dir):
-    return " ".join([f"{mod}.chpl" if mod[0] == "/" else f"{src_dir}/{mod}.chpl" for mod in mods])
+    required_modules = {'GenSymIO', 'MsgProcessing', f'{src_dir}/GenSymIO.chpl',
+                       f'{src_dir}/MsgProcessing.chpl'}
+    return " ".join([f"{mod}.chpl" if mod[0] == "/" else f"{src_dir}/{mod}.chpl" for mod in mods
+                      if mod not in required_modules])
 
 
 def parseServerConfig(config_filename, src_dir):


### PR DESCRIPTION
In `CommandMap.chpl` modules are added rather indiscriminately to `usedModules`. The issue arises in that in `src/registry/register_commands.py`, this gets defined: `DEFAULT_MODS = ["MsgProcessing", "GenSymIO"]`. It seems that these automatically come along for the ride and don't need to be included in `UsedModules.cfg`.

Closes #4836: --saveUsedModules should only save modules that are not compiled by default