### PR TITLE
Adds additional multi-dim capabilities for random number generation

### DIFF
--- a/arkouda/numpy/pdarraycreation.py
+++ b/arkouda/numpy/pdarraycreation.py
@@ -1460,7 +1460,7 @@ def randint(
 
 @typechecked
 def uniform(
-    size: int_scalars,
+    size: Union[int_scalars, Tuple[int_scalars, ...]],
     low: numeric_scalars = float(0.0),
     high: numeric_scalars = 1.0,
     seed: Union[None, int_scalars] = None,
@@ -1507,7 +1507,17 @@ def uniform(
     >>> ak.uniform(size=3,low=0,high=5,seed=0)
     array([0.30013431967121934 0.47383036230759112 1.0441791878997098])
     """
-    return randint(low=low, high=high, size=size, dtype="float64", seed=seed)
+    from arkouda.numpy.util import _infer_shape_from_size
+
+    shape, ndim, full_size = _infer_shape_from_size(size)
+    if full_size < 0:
+        raise ValueError("The size parameter must be >= 0")
+
+    return (
+        randint(low=low, high=high, size=size, dtype="float64", seed=seed)
+        if ndim == 1
+        else randint(low=low, high=high, size=full_size, dtype="float64", seed=seed).reshape(shape)
+    )
 
 
 @typechecked

--- a/arkouda/numpy/pdarraycreation.py
+++ b/arkouda/numpy/pdarraycreation.py
@@ -1475,8 +1475,8 @@ def uniform(
         The low value (inclusive) of the range, defaults to 0.0
     high : float_scalars
         The high value (inclusive) of the range, defaults to 1.0
-    size : int_scalars
-        The length of the returned array
+    size : Union[int_scalars, Tuple[int_scalars]
+        The length or shape of the returned array
     seed : int_scalars, optional
         Value used to initialize the random number generator
 

--- a/arkouda/numpy/random/generator.py
+++ b/arkouda/numpy/random/generator.py
@@ -987,7 +987,7 @@ class Generator:
             Upper boundary of the output interval. All values generated will be less than high.
             high must be greater than or equal to low. The default value is 1.0.
 
-        size: numeric_scalars, optional
+        size: int, tuple(int), None, optional
             Output shape. Default is None, in which case a single value is returned.
 
         Returns

--- a/arkouda/numpy/random/generator.py
+++ b/arkouda/numpy/random/generator.py
@@ -559,10 +559,15 @@ class Generator:
         array([0.8059711747202466 0.71958748004486961 0.72539618972095954])
 
         """
+        from arkouda.numpy.util import _infer_shape_from_size
+
         if size is None:
             # delegate to numpy when return size is 1
             return self._np_generator.random()
-        return self.uniform(size=size)
+        shape, ndim, full_size = _infer_shape_from_size(size)
+        if full_size < 0:
+            raise ValueError("The size parameter must be >= 0")
+        return self.uniform(size=size) if ndim == 1 else self.uniform(size=full_size).reshape(shape)
 
     def standard_gamma(self, shape, size=None):
         r"""

--- a/arkouda/numpy/random/legacy.py
+++ b/arkouda/numpy/random/legacy.py
@@ -297,8 +297,8 @@ def uniform(
         The low value (inclusive) of the range, defaults to 0.0
     high : float_scalars
         The high value (inclusive) of the range, defaults to 1.0
-    size : int_scalars
-        The length of the returned array
+    size : Union[int_scalars, Tuple[int_scalars]
+        The length or shape of the returned array
     seed : int_scalars, optional
         Value used to initialize the random number generator
 

--- a/tests/numpy/pdarray_creation_test.py
+++ b/tests/numpy/pdarray_creation_test.py
@@ -548,6 +548,8 @@ class TestPdarrayCreation:
         int_arr = ak.randint(1, 5, 10, seed=2)
         assert (uint_arr == int_arr).all()
 
+    #   The next three tests handle the uniform function in pdarraycreation.py
+
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_uniform(self, size):
         test_array = ak.uniform(size)
@@ -581,6 +583,112 @@ class TestPdarrayCreation:
         # Test that int_scalars covers uint8, uint16, uint32
         uint_arr = ak.uniform(low=np.uint8(0), high=np.uint16(5), size=np.uint32(100), seed=np.uint8(1))
         int_arr = ak.uniform(low=0, high=5, size=100, seed=1)
+        assert (uint_arr == int_arr).all()
+
+    @pytest.mark.skip_if_rank_not_compiled(2)
+    def test_uniform_2D(self):
+        test_array = ak.uniform((4, 4))
+        assert isinstance(test_array, ak.pdarray)
+        assert ak.float64 == test_array.dtype
+        assert ((4, 4)) == test_array.shape
+
+        u_array = ak.uniform(size=(3, 3), low=0, high=5, seed=0)
+        assert [
+            0.30013431967121934,
+            0.47383036230759112,
+            1.0441791878997098,
+            4.8614729022647323,
+            3.3350975917391743,
+            1.3542127655612139,
+            0.71961446966809384,
+            1.2128292351934404,
+            1.6304932878138119,
+        ] == u_array.flatten().tolist()
+
+        u_array = ak.uniform(
+            size=(np.int64(3), np.int64(3)), low=np.int64(0), high=np.int64(5), seed=np.int64(0)
+        )
+        assert [
+            0.30013431967121934,
+            0.47383036230759112,
+            1.0441791878997098,
+            4.8614729022647323,
+            3.3350975917391743,
+            1.3542127655612139,
+            0.71961446966809384,
+            1.2128292351934404,
+            1.6304932878138119,
+        ] == u_array.flatten().tolist()
+
+        with pytest.raises(TypeError):
+            ak.uniform(low="0", high=5, size=(3, 3))
+
+        with pytest.raises(TypeError):
+            ak.uniform(low=0, high="5", size=(3, 3))
+
+        with pytest.raises(TypeError):
+            ak.uniform(low=0, high=5, size="(3,3)")
+
+        # Test that int_scalars covers uint8, uint16, uint32
+        uint_arr = ak.uniform(
+            low=np.uint8(0), high=np.uint16(5), size=(np.uint32(10), np.uint32(10)), seed=np.uint8(1)
+        )
+        int_arr = ak.uniform(low=0, high=5, size=(10, 10), seed=1)
+        assert (uint_arr == int_arr).all()
+
+    @pytest.mark.skip_if_rank_not_compiled(3)
+    def test_uniform_3D(self):
+        test_array = ak.uniform((4, 4, 4))
+        assert isinstance(test_array, ak.pdarray)
+        assert ak.float64 == test_array.dtype
+        assert ((4, 4, 4)) == test_array.shape
+
+        u_array = ak.uniform(size=(2, 2, 2), low=0, high=5, seed=0)
+        assert [
+            0.30013431967121934,
+            0.47383036230759112,
+            1.0441791878997098,
+            4.8614729022647323,
+            3.3350975917391743,
+            1.3542127655612139,
+            0.71961446966809384,
+            1.2128292351934404,
+        ] == u_array.flatten().tolist()
+
+        u_array = ak.uniform(
+            size=(np.int64(2), np.int64(2), np.int64(2)),
+            low=np.int64(0),
+            high=np.int64(5),
+            seed=np.int64(0),
+        )
+        assert [
+            0.30013431967121934,
+            0.47383036230759112,
+            1.0441791878997098,
+            4.8614729022647323,
+            3.3350975917391743,
+            1.3542127655612139,
+            0.71961446966809384,
+            1.2128292351934404,
+        ] == u_array.flatten().tolist()
+
+        with pytest.raises(TypeError):
+            ak.uniform(low="0", high=5, size=(2, 2, 2))
+
+        with pytest.raises(TypeError):
+            ak.uniform(low=0, high="5", size=(2, 2, 2))
+
+        with pytest.raises(TypeError):
+            ak.uniform(low=0, high=5, size="(2,2,2)")
+
+        # Test that int_scalars covers uint8, uint16, uint32
+        uint_arr = ak.uniform(
+            low=np.uint8(0),
+            high=np.uint16(5),
+            size=(np.uint32(10), np.uint32(10), np.uint32(10)),
+            seed=np.uint8(1),
+        )
+        int_arr = ak.uniform(low=0, high=5, size=(10, 10, 10), seed=1)
         assert (uint_arr == int_arr).all()
 
     @pytest.mark.parametrize("size", pytest.prob_size)

--- a/tests/numpy/random_test.py
+++ b/tests/numpy/random_test.py
@@ -181,6 +181,8 @@ class TestRandom:
         permuted_p = rng.permutation(pda_p, method=method)
         assert check(ak.sort(pda_p), ak.sort(permuted_p), data_type)
 
+    #   The next three tests handle the uniform function found in legacy.py.
+
     def test_uniform(self):
         # verify same seed gives different but reproducible arrays
         rng = ak.random.default_rng(pytest.seed)
@@ -199,6 +201,46 @@ class TestRandom:
         bounded_arr = rng.uniform(-5, 5, 1000)
         assert all(bounded_arr.to_ndarray() >= -5)
         assert all(bounded_arr.to_ndarray() < 5)
+
+    @pytest.mark.skip_if_rank_not_compiled(2)
+    def test_uniform_2D(self):
+        # verify same seed gives different but reproducible arrays
+        rng = ak.random.default_rng(pytest.seed)
+        first = rng.uniform(-(2**32), 2**32, (5, 2))
+        second = rng.uniform(-(2**32), 2**32, (5, 2))
+        assert first.tolist() != second.tolist()
+
+        rng = ak.random.default_rng(pytest.seed)
+        same_seed_first = rng.uniform(-(2**32), 2**32, (5, 2))
+        same_seed_second = rng.uniform(-(2**32), 2**32, (5, 2))
+        assert np.allclose(first.tolist(), same_seed_first.tolist())
+        assert np.allclose(second.tolist(), same_seed_second.tolist())
+
+        # verify within bounds (lower inclusive and upper exclusive)
+        rng = ak.random.default_rng()
+        bounded_arr = rng.uniform(-5, 5, (10, 10))
+        assert (bounded_arr.to_ndarray() >= -5).all()
+        assert (bounded_arr.to_ndarray() < 5).all()
+
+    @pytest.mark.skip_if_rank_not_compiled(3)
+    def test_uniform_3D(self):
+        # verify same seed gives different but reproducible arrays
+        rng = ak.random.default_rng(pytest.seed)
+        first = rng.uniform(-(2**32), 2**32, (5, 3, 2))
+        second = rng.uniform(-(2**32), 2**32, (5, 3, 2))
+        assert first.tolist() != second.tolist()
+
+        rng = ak.random.default_rng(pytest.seed)
+        same_seed_first = rng.uniform(-(2**32), 2**32, (5, 3, 2))
+        same_seed_second = rng.uniform(-(2**32), 2**32, (5, 3, 2))
+        assert np.allclose(first.tolist(), same_seed_first.tolist())
+        assert np.allclose(second.tolist(), same_seed_second.tolist())
+
+        # verify within bounds (lower inclusive and upper exclusive)
+        rng = ak.random.default_rng()
+        bounded_arr = rng.uniform(-5, 5, (10, 10, 10))
+        assert (bounded_arr.to_ndarray() >= -5).all()
+        assert (bounded_arr.to_ndarray() < 5).all()
 
     def test_choice(self):
         # verify without replacement works
@@ -816,3 +858,38 @@ class TestRandom:
 
         for pda1, pda2 in zip(pda1list, pda2list):
             assert (pda1 != pda2).any()
+
+    def test_random_random(self):
+        ak.random.seed(1701)  # specific seed because we test for specific values
+        pda = ak.random.random(5)
+        expected = np.array(
+            [
+                0.011410423448327005,
+                0.73618171558685619,
+                0.12367222192448891,
+                0.95616789699591898,
+                0.36427886480971333,
+            ]
+        )
+        assert np.allclose(pda.to_ndarray(), expected)
+
+    @pytest.mark.skip_if_rank_not_compiled(2)
+    def test_random_random_2D(self):
+        ak.random.seed(1701)  # specific seed because we test for specific values
+        pda = ak.random.random((2, 2))
+        expected = np.array(
+            [[0.011410423448327005, 0.73618171558685619], [0.12367222192448891, 0.95616789699591898]]
+        )
+        assert np.allclose(pda.to_ndarray(), expected)
+
+    @pytest.mark.skip_if_rank_not_compiled(3)
+    def test_random_random_3D(self):
+        ak.random.seed(1701)  # specific seed because we test for specific values
+        pda = ak.random.random((2, 2, 2))
+        expected = np.array(
+            [
+                [[0.01141042, 0.73618172], [0.12367222, 0.9561679]],
+                [[0.36427886, 0.7148233], [0.66334928, 0.07164771]],
+            ]
+        )
+        assert np.allclose(pda.to_ndarray(), expected)


### PR DESCRIPTION
Closes #4944.  This adds the ability to generate multi-dimensional pdarrays of random numbers to all occurrences of uniform, as well as ak.random.random.  This also includes multi-dim unit tests for uniform and ak.random.random.