### PR TITLE
Adds multi-dim capability to the uniform random number generator

### DIFF
--- a/arkouda/numpy/pdarraycreation.py
+++ b/arkouda/numpy/pdarraycreation.py
@@ -1451,7 +1451,7 @@ def randint(
 
 @typechecked
 def uniform(
-    size: int_scalars,
+    size: Union[int_scalars, Tuple[int_scalars, ...]],
     low: numeric_scalars = float(0.0),
     high: numeric_scalars = 1.0,
     seed: Union[None, int_scalars] = None,
@@ -1462,8 +1462,8 @@ def uniform(
 
     Parameters
     ----------
-    size : int_scalars
-        The length of the returned array
+    size : Union[int_scalars, Tuple[int_scalars]
+        The length or shape of the returned array
     low : float_scalars
         The low value (inclusive) of the range, defaults to 0.0
     high : float_scalars
@@ -1498,7 +1498,17 @@ def uniform(
     >>> ak.uniform(size=3,low=0,high=5,seed=0)
     array([0.30013431967121934 0.47383036230759112 1.0441791878997098])
     """
-    return randint(low=low, high=high, size=size, dtype="float64", seed=seed)
+    from arkouda.numpy.util import _infer_shape_from_size
+
+    shape, ndim, full_size = _infer_shape_from_size(size)
+    if full_size < 0:
+        raise ValueError("The size parameter must be >= 0")
+
+    return (
+        randint(low=low, high=high, size=size, dtype="float64", seed=seed)
+        if ndim == 1
+        else randint(low=low, high=high, size=full_size, dtype="float64", seed=seed).reshape(shape)
+    )
 
 
 @typechecked

--- a/arkouda/numpy/random/generator.py
+++ b/arkouda/numpy/random/generator.py
@@ -981,8 +981,8 @@ class Generator:
             Upper boundary of the output interval. All values generated will be less than high.
             high must be greater than or equal to low. The default value is 1.0.
 
-        size: numeric_scalars, optional
-            Output shape. Default is None, in which case a single value is returned.
+        size: int, tuple(int), None, optional
+            Output size or shape. Default is None, in which case a single value is returned.
 
         Returns
         -------

--- a/arkouda/numpy/random/legacy.py
+++ b/arkouda/numpy/random/legacy.py
@@ -284,7 +284,7 @@ def standard_normal(
 
 @typechecked
 def uniform(
-    size: int_scalars,
+    size: Union[int_scalars, Tuple[int_scalars, ...]],
     low: numeric_scalars = float(0.0),
     high: numeric_scalars = 1.0,
     seed: Union[None, int_scalars] = None,
@@ -295,8 +295,8 @@ def uniform(
 
     Parameters
     ----------
-    size : int_scalars
-        The length of the returned array
+    size : Union[int_scalars, Tuple[int_scalars]
+        The length or shape of the returned array
     low : float_scalars
         The low value (inclusive) of the range, defaults to 0.0
     high : float_scalars
@@ -331,7 +331,17 @@ def uniform(
     >>> ak.uniform(size=3,low=0,high=5,seed=0)
     array([0.30013431967121934, 0.47383036230759112, 1.0441791878997098])
     """
-    return randint(low=low, high=high, size=size, dtype="float64", seed=seed)
+    from arkouda.numpy.util import _infer_shape_from_size
+
+    shape, ndim, full_size = _infer_shape_from_size(size)
+    if full_size < 0:
+        raise ValueError("The size parameter must be >= 0")
+
+    return (
+        randint(low=low, high=high, size=size, dtype="float64", seed=seed)
+        if ndim == 1
+        else randint(low=low, high=high, size=full_size, dtype="float64", seed=seed).reshape(shape)
+    )
 
 
 def globalGeneratorExists():


### PR DESCRIPTION
Closes #4944

"uniform" appears in three places: pdarraycreation.py, generator.py, and legacy.py.  This updates all three to allow generation of multi-dim pdarrays.  It also updates the docstrings.