### PR TITLE
Closes #2689: Value mismatch with numpy on `int(arr) // -float(arr)`

### DIFF
--- a/tests/numpy/numeric_test.py
+++ b/tests/numpy/numeric_test.py
@@ -1704,3 +1704,10 @@ class TestNumeric:
         arr = ak.array([], dtype="str_")
         assert isinstance(arr, ak.Strings)
         assert arr.size == 0
+
+    def test_idiv_edge_case(self):
+        a = ak.array([-1])
+        b = ak.array([1 / 3])
+        assert (a // b)[0] == -4.0
+        a = ak.array([1])
+        assert (a // b)[0] == 3.0


### PR DESCRIPTION
If you want to use integer division to do compute $a$ divided by $b$, then we can break that down into

$$\dfrac{a}{b} = q + \dfrac{r}{b}$$

for some integer $q$ and (possibly non-integer) $r$. When computing $q$, computers can output "incorrect" numbers. This is because of floating point precision problems. For example, `1/3` evaluates to `0.3333333333333333` in Python, but if you pry behind the scenes a little bit, you can do `(1/3).as_integer_ratio()` and get `(6004799503160661, 18014398509481984)`, where `6004799503160661 * 3` is `18014398509481983`, which is one less than `18014398509481984`. This is perfectly fine if you decide to check `1 // (1/3)` because we are integer dividing by a number slightly less than the actual `1/3`.

The problem arises when we try to do `(-1) // (1/3)` because now the reality is that when we floor, we need to round down to `-4` (which might seem silly, but you weren't actually integer dividing by one third, you were integer dividing by whatever your computer says `1/3` is). However, if you want to do the integer division, the first step is to do the float division. It does the float division of `-1` by `1/3` and gets exactly `-3.0`. This is because the difference is so slim that it literally cannot store it in the floating point value.

How do we correct this problem? C offers the `fma` function, where `fma(x, y, z)` is `x * y + z`. It computes with as much precision as possible and only fits it into a 64 bit real value at the very end. So we use that to compute

$$r = -qb + a$$

and since $q$ is an integer, if $r$ and $b$ have different signs, the remainder term $\dfrac{r}{b}$ will be negative and we need to subtract one from $q$, otherwise it is nonnegative and we can just return $q$.

Closes #2689: Value mismatch with numpy on `int(arr) // -float(arr)`