### PR TITLE
Closes #4984: ak.array with negative numbers still has problems

### DIFF
--- a/tests/numpy/pdarray_creation_test.py
+++ b/tests/numpy/pdarray_creation_test.py
@@ -1392,3 +1392,27 @@ class TestPdarrayCreation:
         assert a.size == 100
         assert ak.all(a == 0)
         assert ak.all(a == ak.array([0] * 100, dtype=ak.bigint).reshape(5, 20))
+
+    def test_bigint_large_negative_values(self):
+        a = ak.array([-(2**200)])
+        b = np.array([2**200])
+        val = 2**200
+        c = [f"{-val}"]
+        ak_c = ak.array(c, dtype=ak.bigint)
+        assert_equivalent(a, -b)
+        assert_equivalent(a, ak_c)
+
+    def test_range_conversion(self):
+        a = ak.array(range(0, 10))
+        b = ak.array(list(range(10)))
+        assert_equivalent(a, b)
+
+    def test_should_be_uint(self):
+        a = ak.array([2**63])
+        assert a.dtype == ak.uint64
+
+    def test_should_not_be_uint(self):
+        a = ak.array([-1, 2**63])
+        b = np.array([-1, 2**63])
+        assert_equivalent(a, b)
+        assert a.dtype == ak.float64


### PR DESCRIPTION
I mainly was trying to fix issues surrounding things like `ak.array([-2**200])`, but while I was messing around in `ak.array` I noticed a few other things that needed fixing.

This is needed for #4593.

**Summary of Changes**

* Added an early `str` check to raise a clear `TypeError` for scalar string inputs.
* Tightened iterable handling to convert only generators/ranges to lists, leaving `np.ndarray` and `pd.Series` intact.
* Refined unsigned integer inference to require non-negative values and include values ≥ 2⁶³.
* Added automatic `bigint` inference for `object` arrays containing only integers.
* Reworked negative bigint handling to properly construct signed bigints using a sign mask.
* Added tests for large negative bigint values, range conversion, unsigned inference, and mixed-sign behavior.

**Purpose:**
Fixes incorrect bigint conversion for large negative numbers and cleans up input normalization and dtype inference logic.


Closes #4984: ak.array with negative numbers still has problems