### PR TITLE
Fix docs build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -128,30 +128,6 @@ jobs:
       run: |
         python3 -m mypy arkouda
 
-  docs:
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/bears-r-us/ubuntu-with-arkouda-deps-chpl-2.5.0:latest
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.github_token }}
-    steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v4
-    - name: Set Python version to 3.13
-      run: |
-        update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1
-        python3 -m ensurepip --default-pip
-    - name: check chpldoc version
-      run: |
-        chpldoc --version
-    - name: Install dependencies
-      run: |
-        python3 -m pip install .[dev]
-    - name: Arkouda make doc
-      run: |
-        make doc
-
   docstr-cov:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -36,6 +36,7 @@ jobs:
       run: |
         make doc
     - name: Install rsync (needed by deploy action)
+      if: github.repository_owner == 'Bears-R-Us' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
       run: |
         apt-get update
         apt-get install -y rsync


### PR DESCRIPTION
Fixes the docs build since its using an incorrect image

Also adjusts the job to run partially on PRs so it can be tested without merging. Only the push step is skipped. This means we can merge the CI/docs and gh-pages/docs jobs to a single job

Resolves https://github.com/Bears-R-Us/arkouda/issues/4996