### PR TITLE
Closes #4993:  ArkoudaArray.argsort

### DIFF
--- a/arkouda/pandas/extension/_arkouda_array.py
+++ b/arkouda/pandas/extension/_arkouda_array.py
@@ -144,11 +144,6 @@ class ArkoudaArray(ArkoudaExtensionArray, ExtensionArray):
             return False
         return self._data.equals(other._data)
 
-    #   TODO:  add pandas arguments
-    def argsort(self, ascending=True):
-        perm = self._data.argsort(ascending=ascending)
-        return perm
-
     def _reduce(self, name, skipna=True, **kwargs):
         if name == "all":
             return self._data.all()


### PR DESCRIPTION
# Add argsort to ArkoudaExtensionArray

Implements the [ExtensionArray.argsort](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.api.extensions.ExtensionArray.argsort.html)
 API for Arkouda-backed arrays.

##  Summary

- Adds a fully pandas-compatible `argsort` implementation to `ArkoudaBaseArray`.
- Supports `pdarray`, `Strings`, and `Categorical` types.
- Performs sorting on the Arkouda server for efficiency.
- Returns a `pdarray`, and uses a `# type: ignore[override]` to ignore `pandas` and `mypy` type expectations.  Pandas expects a NumPy `ndarray` to be returned.
- Handles `ascending`, `na_position`, and `kind` arguments for API compatibility.

## Implementation Details

- Uses Arkouda’s internal `argsort` to compute the permutation remotely.
- Adjusts NaN placement based on `na_position` ("first" or "last").
- Raises `ValueError` for invalid `na_position` values.
- Raises `TypeError` for unsupported underlying dtypes.
- Returns a `pdarray`, contrary to pandas expectation to return a NumPy `ndarray`.

## Tests Added
test_argsort_extensionarray.py includes:

- Float `pdarray` with NaN handling (ascending / descending, first / last).
- `Strings` and `Categorical` sorting correctness.
- Error handling for invalid `na_position` and unsupported dtypes.
- Ensures `kind` and extra `kwargs` are accepted but ignored.

## Example
```python
>>> import arkouda as ak
>>> from arkouda.pandas.extension import ArkoudaArray

>>> a = ArkoudaArray(ak.array([3.0, float("nan"), 1.0]))
>>> a.argsort()  # NaN last by default
array([2 0 1])

>>> a.argsort(na_position="first")
array([1 2 0])
```
## Why This Matters

This addition brings Arkouda’s pandas integration closer to parity with native `ExtensionArray` behavior.
It enables pandas operations such as sorting and reindexing to function correctly on Arkouda-backed columns,
while keeping heavy data resident on the server for performance and scalability.

Closes #4993: ArkoudaArray.argsort
