### PR TITLE
Closes #2956: Implement `allclose` function

### DIFF
--- a/arkouda/__init__.py
+++ b/arkouda/__init__.py
@@ -95,6 +95,7 @@ from arkouda.numpy import (
     add_docstring,
     add_newdoc,
     all,
+    allclose,
     all_scalars,
     any,
     append,

--- a/arkouda/numpy/__init__.py
+++ b/arkouda/numpy/__init__.py
@@ -209,6 +209,7 @@ from arkouda.numpy.pdarrayclass import (
     RegistrationError,
     _to_pdarray,
     all,
+    allclose,
     any,
     argmax,
     argmaxk,

--- a/arkouda/numpy/pdarrayclass.py
+++ b/arkouda/numpy/pdarrayclass.py
@@ -194,6 +194,7 @@ __all__ = [
     "rotl",
     "rotr",
     "cov",
+    "allclose",
     "corr",
     "divmod",
     "sqrt",
@@ -4088,6 +4089,70 @@ def cov(x: pdarray, y: pdarray) -> np.float64:
 
     return parse_single_value(
         generic_msg(cmd=f"cov<{x.dtype},{x.ndim},{y.dtype},{y.ndim}>", args={"x": x, "y": y})
+    )
+
+
+@typechecked
+def allclose(
+    a: pdarray, b: pdarray, rtol: float = 1e-5, atol: float = 1e-8, equal_nan: bool = False
+) -> bool:
+    """
+    Returns True if all elements of ``a`` and ``b`` are equal within a tolerance.
+
+    This function compares two arrays elementwise and returns True if they are
+    equal within the tolerance defined by the parameters ``rtol`` and ``atol``.
+    The comparison uses the formula: absolute(a - b) <= (atol + rtol * absolute(b))
+
+    Parameters
+    ----------
+    a : pdarray
+        First array to compare.
+    b : pdarray
+        Second array to compare.
+    rtol : float, optional
+        Relative tolerance. Default is 1e-5.
+    atol : float, optional
+        Absolute tolerance. Default is 1e-8.
+    equal_nan : bool, optional
+        Whether to consider NaNs in corresponding positions as equal.
+        Default is False.
+
+    Returns
+    -------
+    bool
+        True if all elements are equal within the specified tolerance,
+        False otherwise.
+
+    Raises
+    ------
+    TypeError
+        If either ``a`` or ``b`` is not a ``pdarray``.
+    TypeError
+        If either array has dtype ``bigint``, which is not supported.
+    ValueError
+        If ``a`` and ``b`` have different shapes.
+
+    Examples
+    --------
+    >>> import arkouda as ak
+    >>> x = ak.array([1.0, 2.0, 3.0])
+    >>> y = ak.array([1.0, 2.00001, 2.99999])
+    >>> ak.allclose(x, y)
+    True
+    """
+    from arkouda.client import generic_msg
+
+    if not isinstance(a, pdarray) or not isinstance(b, pdarray):
+        raise TypeError("a and b must be pdarray instances")
+    if (a.dtype in [bigint]) or (b.dtype in [bigint]):
+        raise TypeError("bigint is not supported for allclose")
+    return bool(
+        parse_single_value(
+            generic_msg(
+                cmd=f"allclose<{a.dtype},{a.ndim},{b.dtype},{b.ndim}>",
+                args={"a": a, "b": b, "rtol": rtol, "atol": atol, "equal_nan": equal_nan},
+            )
+        )
     )
 
 

--- a/arkouda/pdarrayclass/__init__.py
+++ b/arkouda/pdarrayclass/__init__.py
@@ -11,6 +11,7 @@ from arkouda.numpy.pdarrayclass import (
     clear,
     clz,
     corr,
+    allclose,
     cov,
     ctz,
     divmod,

--- a/tests/stats_test.py
+++ b/tests/stats_test.py
@@ -3,6 +3,10 @@ import pandas as pd
 import pytest
 
 import arkouda as ak
+from arkouda.numpy.dtypes import bigint
+
+
+NUMERIC_TYPES = ["int64", "uint64", "float64", "bool"]
 
 
 class TestStats:
@@ -60,6 +64,50 @@ class TestStats:
                 assert getattr(self.b, fn)(ark) == pytest.approx(getattr(self.pdb, fn)(pand))
                 assert getattr(self.f, fn)(ark) == pytest.approx(getattr(self.pdf, fn)(pand))
                 assert getattr(self.u, fn)(ark) == pytest.approx(getattr(self.pdu, fn)(pand))
+
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize("dtype1", NUMERIC_TYPES)
+    @pytest.mark.parametrize("dtype2", NUMERIC_TYPES)
+    def test_allclose(self, size, dtype1, dtype2):
+        if dtype1 == "bool" or dtype2 == "bool":
+            size = 2
+
+        a = ak.arange(size, dtype=dtype1)
+        b = ak.arange(size, dtype=dtype2)
+        assert ak.allclose(a, b)
+
+    def test_allclose_edge_cases(self):
+        # Tolerance tests
+        a = ak.array([1.0, 2.0, 3.0])
+        b_close = ak.array([1.0, 2.00001, 2.99999])
+        b_far = ak.array([1.0, 2.1, 3.1])
+        assert ak.allclose(a, b_close, rtol=1e-5, atol=1e-8)
+        assert not ak.allclose(a, b_far, rtol=1e-5, atol=1e-8)
+
+        # Edge cases: zeros and infinities
+        a_zero = ak.array([0.0, 0.0, 0.0])
+        b_zero = ak.array([1e-9, -1e-9, 0.0])
+        assert ak.allclose(a_zero, b_zero, atol=1e-8)
+
+        a_inf = ak.array([np.inf, -np.inf, 1.0])
+        b_inf = ak.array([np.inf, -np.inf, 1.0])
+        b_inf_diff = ak.array([np.inf, np.inf, 1.0])
+        assert ak.allclose(a_inf, b_inf)
+        assert not ak.allclose(a_inf, b_inf_diff)
+
+        # Test bigint is not supported
+        a_big = ak.array([1, 2, 3], dtype=bigint)
+        b_big = ak.array([1, 2, 3], dtype=bigint)
+        with pytest.raises(TypeError, match="bigint is not supported"):
+            ak.allclose(a_big, b_big)
+
+        # Test nan_equal argument
+        a_nan = ak.array([1.0, np.nan, 3.0])
+        assert not ak.allclose(a_nan, a_nan)
+        assert ak.allclose(a_nan, a_nan, equal_nan=True)
+        a_mixed = ak.array([np.nan, 2.0, 3.0])
+        b_mixed = ak.array([1.0, np.nan, 3.0])
+        assert not ak.allclose(a_mixed, b_mixed, equal_nan=True)
 
     def test_corr_matrix(self):
         ak_df = ak.DataFrame({"x": self.x, "y": self.y, "u": self.u, "b": self.b, "f": self.f}).corr()


### PR DESCRIPTION
This PR (Closes #2956) implements the `allclose` function and adds testing for multiple types supported to match numpy.