### PR TITLE
Closes #4227: Hitting Chapel's default instantiation limit when compiling for 3 or more dimensions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,6 +371,12 @@ CHPL_FLAGS += -lpython$(shell python3 -c "import sysconfig; print(sysconfig.get_
 # Ignore warnings from the Python headers. This is irrelevant for newer Python versions
 CHPL_FLAGS += --ccflags -Wno-macro-redefined
 
+# Allows the user to set a different instantiation limit
+ifneq ($(instantiate_max),)
+CHPL_USER_FLAGS += --instantiate-max=$(instantiate_max)
+endif
+
+
 PYTHON_VERSION := $(shell python3 -c "import sys; print(*sys.version_info[:2], sep='.')")
 
 
@@ -567,7 +573,7 @@ SERVER_CONFIG_SCRIPT=$(ARKOUDA_SOURCE_DIR)/parseServerConfig.py
 $(ARKOUDA_MAIN_MODULE): check-deps register-commands $(ARROW_UTIL_O) $(ARROW_READ_O) $(ARROW_WRITE_O) $(ARKOUDA_SOURCES) $(ARKOUDA_MAKEFILES)
 	$(eval MOD_GEN_OUT=$(shell python3 $(SERVER_CONFIG_SCRIPT) $(ARKOUDA_CONFIG_FILE) $(ARKOUDA_SOURCE_DIR)))
 
-	$(CHPL) $(CHPL_DEBUG_FLAGS) $(PRINT_PASSES_FLAGS) $(REGEX_MAX_CAPTURES_FLAG) $(OPTIONAL_SERVER_FLAGS) $(CHPL_FLAGS_WITH_VERSION) $(CHPL_COMPAT_FLAGS) $(ARKOUDA_MAIN_SOURCE) $(ARKOUDA_COMPAT_MODULES) $(ARKOUDA_SERVER_USER_MODULES) $(MOD_GEN_OUT) $(ARKOUDA_RW_DEFAULT_FLAG) $(ARKOUDA_KEYPART_FLAG) $(ARKOUDA_REGISTRY_DIR)/Commands.chpl -I$(ARKOUDA_SOURCE_DIR)/parquet -o $@
+	$(CHPL) $(CHPL_DEBUG_FLAGS) $(CHPL_USER_FLAGS) $(PRINT_PASSES_FLAGS) $(REGEX_MAX_CAPTURES_FLAG) $(OPTIONAL_SERVER_FLAGS) $(CHPL_FLAGS_WITH_VERSION) $(CHPL_COMPAT_FLAGS) $(ARKOUDA_MAIN_SOURCE) $(ARKOUDA_COMPAT_MODULES) $(ARKOUDA_SERVER_USER_MODULES) $(MOD_GEN_OUT) $(ARKOUDA_RW_DEFAULT_FLAG) $(ARKOUDA_KEYPART_FLAG) $(ARKOUDA_REGISTRY_DIR)/Commands.chpl -I$(ARKOUDA_SOURCE_DIR)/parquet -o $@
 
 CLEAN_TARGETS += arkouda-clean
 .PHONY: arkouda-clean

--- a/pydoc/setup/BUILD.md
+++ b/pydoc/setup/BUILD.md
@@ -152,6 +152,25 @@ Note:
 This step can require a large amount of RAM, especially when building with multi-locale enabled.
 If you are running in wsl or a container and your build fails, consider increasing the memory allocation. 
 
+### Chapel Instantiation Limit Errors
+
+If you encounter an error similar to the following during the build:
+
+```bash
+$CHPL_HOME/modules/standard/CTypes.chpl:611: error: Function ':' has been instantiated too many times
+note: If this is intentional, try increasing the instantiation limit from 512
+make: *** [Makefile:575: arkouda_server] Error 1
+```
+
+you can resolve it by increasing Chapel’s instantiation limit when invoking `make`:
+
+```bash
+make instantiate_max=1024
+```
+
+You can substitute `1024` with a higher value if needed.
+This flag passes `--instantiate-max=<value>` to the Chapel compiler during the build.
+
 ## Building the Arkouda Documentation
 The Arkouda documentation is [here](https://bears-r-us.github.io/arkouda/). This section is only necessary
 if you're updating the documentation.


### PR DESCRIPTION
This allows users to override Chapel's instantiation limit from the make line.

As it happens, this is not easy to test that it "fixes" anything right now. I think recent PRs have done an outstanding job of fixing this issue from the perspective of not needing such a high instantiation limit (and, I might add, the memory issue). On my laptop with about 30 GB RAM free, I was able to set

```yaml
# Snippet from registration_config.json
"nd": [1, 2, 3, 4, 5],
```

(yes, five dimensions) and while it took a very long time to compile (around 40 minutes) it managed to compile with the default instantiation limit of 512. So how do we know that this works? It's actually not that hard to check that it breaks things. You can run

```bash
make instantiate_max=10
```

and you will see

```bash
$CHPL_HOME/modules/standard/CTypes.chpl:611: error: Function ':' has been instantiated too many times
note:   If this is intentional, try increasing the instantiation limit from 10
make: *** [Makefile:575: arkouda_server] Error 1
```

So clearly this code has an effect! That really ought to mean that if a user wants a higher instantiation limit, they should be able to get it.

Oh, and I updated `BUILD.md` so anyone who greps through our files for the error should be able to find documentation on how to fix it!

Closes #4227: Hitting Chapel's default instantiation limit when compiling for 3 or more dimensions