### PR TITLE
Aligns ak.matmul to numpy

### DIFF
--- a/arkouda/numpy/numeric.py
+++ b/arkouda/numpy/numeric.py
@@ -3063,9 +3063,20 @@ def transpose(pda: pdarray, axes: Optional[Tuple[int_scalars, ...]] = None) -> p
     )
 
 
+@typechecked
 def matmul(pdaLeft: pdarray, pdaRight: pdarray) -> pdarray:
     """
     Compute the product of two matrices.
+
+    Notes
+    -----
+    If both are 1D, this returns a simple dot product.
+    If both are 2D, it returns a conventional matrix multiplication.
+    If only one is 1D, the result matches the "dot" function, so we use that.
+    If neither is 1D and at least one is > 2D, then broadcasting is involved.
+    If pdaLeft's shape is [(leftshape),m,n] and pdaRight's shape is [(rightshape),n,k],
+    then the result will have shape [(common shape),m,k] where common shape is a
+    shape that both leftshape and rightshape can be broadcast to.
 
     Parameters
     ----------
@@ -3091,27 +3102,90 @@ def matmul(pdaLeft: pdarray, pdaRight: pdarray) -> pdarray:
     array([array([1.00000000... 5.00000000... 14.0000000...])
     array([1.10000000... 5.30000000... 14.6000000...])])
 
-    Notes
-    -----
-    Server returns an error if shapes of pdaLeft and pdaRight
-    are incompatible with matrix multiplication.
+    Raises
+    ------
+    ValueError
+        Raised if shapes are incompatible with matrix multiplication.
 
     """
     from arkouda.client import generic_msg
+    from arkouda.numpy.pdarrayclass import dot
+    from arkouda.numpy.util import broadcast_shapes, broadcast_to
 
-    if pdaLeft.ndim != pdaRight.ndim:
-        raise ValueError("matmul requires matrices of matching rank.")
-    cmd = f"matmul<{pdaLeft.dtype},{pdaRight.dtype},{pdaLeft.ndim}>"
-    args = {
-        "x1": pdaLeft,
-        "x2": pdaRight,
-    }
-    return create_pdarray(
-        generic_msg(
-            cmd=cmd,
-            args=args,
-        )
-    )
+    # Disallow scalar arguments.  That's not a matmul thing.
+
+    if pdaLeft.ndim < 1 or pdaRight.ndim < 1:
+        raise ValueError("Scalar arguments not allowed for matmul.")
+
+    # Handle the 1D and 1D case.
+
+    elif pdaLeft.ndim == 1 and pdaRight.ndim == 1:
+        if pdaLeft.size != pdaRight.size:
+            raise ValueError("Mismatch in dimensions of arguments for matmul.")
+        else:
+            return dot(pdaLeft, pdaRight)
+
+    # Handle the 2D and 2D case.
+
+    elif pdaLeft.ndim == 2 and pdaRight.ndim == 2:
+        if pdaLeft.shape[-1] != pdaRight.shape[0]:
+            raise ValueError("Mismatch in dimensions of arguments for matmul.")
+        else:
+            cmd = f"matmul<{pdaLeft.dtype},{pdaRight.dtype},{pdaLeft.ndim}>"
+            args = {
+                "x1": pdaLeft,
+                "x2": pdaRight,
+            }
+            return create_pdarray(
+                generic_msg(
+                    cmd=cmd,
+                    args=args,
+                )
+            )
+
+    # Handle both singleton 1D cases (i.e. either left or right is 1D, but not both)
+
+    elif pdaLeft.ndim == 1:
+        if pdaLeft.size != pdaRight.shape[-2]:
+            raise ValueError("Mismatch in dimensions of arguments for matmul.")
+        else:
+            return dot(pdaLeft, pdaRight)
+    elif pdaRight.ndim == 1:
+        if pdaRight.size != pdaLeft.shape[-1]:
+            raise ValueError("Mismatch in dimensions of arguments for matmul.")
+        else:
+            return dot(pdaLeft, pdaRight)
+
+    # Handle the multi-dim cases.  This involves finding a common shape for broadcast.
+
+    else:
+        left_preshape = pdaLeft.shape[0:-2]  # pull off all but last 2 dims of
+        right_preshape = pdaRight.shape[0:-2]  # both shapes
+        try:
+            tmp_preshape = broadcast_shapes(left_preshape, right_preshape)
+            tmp_pdaLeftshape = list(tmp_preshape)
+            tmp_pdaLeftshape.append(pdaLeft.shape[-2])  # restore the last 2 dims
+            tmp_pdaLeftshape.append(pdaLeft.shape[-1])  # of the left shape
+            new_pdaLeftshape = tuple(tmp_pdaLeftshape)
+            tmp_pdaRightshape = list(tmp_preshape)  # now do the same jiggery-pokery
+            tmp_pdaRightshape.append(pdaRight.shape[-2])  # with the shape of pdaRight
+            tmp_pdaRightshape.append(pdaRight.shape[-1])
+            new_pdaRightshape = tuple(tmp_pdaRightshape)
+            new_pdaLeft = broadcast_to(pdaLeft, new_pdaLeftshape)
+            new_pdaRight = broadcast_to(pdaRight, new_pdaRightshape)  # args are now ready
+            cmd = f"multidimmatmul<{pdaLeft.dtype},{new_pdaLeft.ndim},{pdaRight.dtype}>"
+            args = {
+                "a": new_pdaLeft,
+                "b": new_pdaRight,
+            }
+            return create_pdarray(
+                generic_msg(
+                    cmd=cmd,
+                    args=args,
+                )
+            )
+        except Exception as e:
+            raise ValueError("Mismatch in dimensions of arguments for matmul.") from e
 
 
 @typechecked

--- a/arkouda/numpy/pdarrayclass.py
+++ b/arkouda/numpy/pdarrayclass.py
@@ -3993,11 +3993,11 @@ def dot(
         elif pda1.ndim == 2 and pda2.ndim == 2:  # matmul will do the shape check
             return ship(akmatmul(pda1, pda2), specialCase)  # type: ignore
 
-        #   Third and fourth cases involve a left argument of N-dimensions, and a right argument
-        #   of 1 or more.  The 1-D right argument is handled by reshaping it to 2-D and then
-        #   reshaping the answer to remove the extra dimension.
+        #   Third and fourth cases involve left or right argument of N-dimensions, and right
+        #   or left argument of 1 or more.  The 1-D  argument is handled by reshaping it to 2-D,
+        #   and squeezing the answer to remove the extra dimension.
 
-        elif pda1.ndim > 1 and pda2.ndim >= 1:
+        elif pda1.ndim >= 1 and pda2.ndim >= 1:  # trying something
             s3 = _compute_dot_result_shape(pda1.shape, pda2.shape)
             if len(s3) not in get_array_ranks():
                 raise ValueError(
@@ -4005,18 +4005,27 @@ def dot(
                 )
             else:
                 d1_case = pda2.ndim == 1
+                d2_case = pda1.ndim == 1  # trying something
                 temp_pda2 = pda2.reshape(pda2.size, 1) if d1_case else pda2  # type: ignore
+                temp_pda1 = pda1.reshape(1, pda1.size) if d2_case else pda1  # trying something
                 repMsg = generic_msg(
-                    cmd=f"dot<{pda1.dtype},{pda1.ndim},{pda2.dtype},{temp_pda2.ndim}>",
+                    cmd=f"dot<{pda1.dtype},{temp_pda1.ndim},{pda2.dtype},{temp_pda2.ndim}>",
                     args={
-                        "a": pda1,
+                        "a": temp_pda1,
                         "b": temp_pda2,
                     },
                 )
+
                 if d1_case:
                     temp_ans = create_pdarray(repMsg)
-                    newshape = list(temp_ans.shape)  # these steps remove
-                    del newshape[-1]  # the padded 1 from
+                    newshape = list(temp_ans.shape)               # these steps remove
+                    del newshape[-1]                              # the padded 1 from
+                    temp_ans = temp_ans.reshape(tuple(newshape))  # the shape of result
+                    return ship(temp_ans, specialCase)
+                elif d2_case:
+                    temp_ans = create_pdarray(repMsg)
+                    newshape = list(temp_ans.shape)               # these steps remove
+                    del newshape[0]                               # the padded 1 from
                     temp_ans = temp_ans.reshape(tuple(newshape))  # the shape of result
                     return ship(temp_ans, specialCase)
                 else:

--- a/src/LinalgMsg.chpl
+++ b/src/LinalgMsg.chpl
@@ -214,6 +214,9 @@ module LinalgMsg {
         return (true, outDims);
     }
 
+    //  batchedMatMult is now OBE with the addition of multidimmatmul, and will
+    //  probably be removed in a future update.
+
     proc batchedMatMult(in A: [?D], in B, ref C) throws {
         const BatchDom = domOffAxis(D, D.rank-2, D.rank-1);
 
@@ -386,7 +389,7 @@ module LinalgMsg {
 
     // In general, if aShape is ( (front dims), k) and
     //            and bShape is ( (back dims), k, m), then
-    //         then shapeOut is ( (front dims), (back dims), m)
+    //                shapeOut is ( (front dims), (back dims), m)
 
     proc dotShape(aShape: ?N*int, bShape: ?N2*int): (N+N2-2)*int
         where N > 1 && N2 > 1 {
@@ -397,6 +400,65 @@ module LinalgMsg {
         return shapeOut;
     }
 
+    // matmulShape is similar, but for multi-dimensional matmul
+
+    // If aShape is ( (front dims), m, n) and
+    //    bShape is ( (front dims), n, k), then
+    //    shapeOut is ( (front dims), m, k)
+
+    // Note that aShape and bShape were created python-side, and all the error
+    // checking was done there.
+
+    proc matmulShape(aShape: ?N*int, bShape: N*int) : N*int
+        where N > 1 {
+        var shapeOut: N*int;
+        for i in 0..<(N-1) do shapeOut[i] = aShape[i];
+        shapeOut[N-1] = bShape[N-1];
+        return shapeOut;
+    }
+
+
+    // Multidimensional matmul has the same functionality as in numpy.  We expect
+    // the shapes to have been managed (and broadcast if need be) client-side before
+    // this proc is invoked.
+    // That is, the shapes of a and b must be identical except for the last 2 dims.
+    // Those 2 dims must be compatible with regular 2D matrix multiplication (i.e.
+    // m,n and n,k, giving a product of m,k).
+
+    @arkouda.registerCommand(name="multidimmatmul")
+    proc multidimmatmul(a: [?d] ?ta, b: [d] ?tb): [] np_ret_type(ta,tb) throws
+    where ( (d.rank >=2)
+        && (ta == int || ta == real || ta == bool || ta == uint )
+        && (tb == int || tb == real || tb == bool || tb == uint )
+           ) {
+        param pn = Reflection.getRoutineName();
+
+        // make an array of the appropriate shape and type to hold the output
+
+        var eOut = makeDistArray((...matmulShape(a.shape, b.shape)), np_ret_type(ta,tb));
+
+        // loop over all output elements
+
+        forall outIdx in eOut.domain {
+
+            var aIdx = outIdx;
+            var bIdx = outIdx;
+
+            var total: np_ret_type(ta,tb) = 0:np_ret_type(ta,tb);
+            for i in 0..<a.shape(d.rank-1) {
+                aIdx = outIdx; aIdx[d.rank-1] = i; // aIdx = ( (front dims), m, loop variable)
+                bIdx = outIdx; bIdx[d.rank-2] = i; // bIdx = ( (front dims), loop variable, k)
+                if np_ret_type(ta,tb) == bool {
+                    total |= a[aIdx]:bool && b[bIdx]:bool;
+                } else {
+                    total += a[aIdx]:np_ret_type(ta,tb) * b[bIdx]:np_ret_type(ta,tb);
+                }
+            }
+            eOut[outIdx] = total;
+        }
+
+        return eOut;
+    }
 
     /*
         Compute the generalized dot product of two tensors along the specified axis.

--- a/tests/numpy/numeric_test.py
+++ b/tests/numpy/numeric_test.py
@@ -1188,6 +1188,42 @@ class TestNumeric:
             npProduct = np.matmul(ndaLeft, ndaRight)
             assert check(npProduct, akProduct.to_ndarray(), akProduct.dtype)
 
+    @pytest.mark.skip_if_rank_not_compiled((2, 3))
+    @pytest.mark.parametrize("data_type1", INT_FLOAT_BOOL)
+    @pytest.mark.parametrize("data_type2", INT_FLOAT_BOOL)
+    def test_matmulmultidim(self, data_type1, data_type2):
+        check = lambda a, b, t: (  # noqa: E731
+            np.allclose(a.tolist(), b.tolist()) if akdtype(t) == "float64" else (a == b).all()
+        )
+
+        # In the pdarray generations below, using .astype avoids a TypeError when the
+        # type is bool.
+        # Note that the left argument is always data_type1, and the right data_type2.
+
+        nda_1d = np.arange(10).astype(data_type2)
+        pda_1d = ak.array(nda_1d)
+        nda_nd = np.arange(60).reshape(2, 3, 10).astype(data_type1)
+        pda_nd = ak.array(nda_nd)
+        akProduct = ak.matmul(pda_nd, pda_1d)
+        npProduct = np.matmul(nda_nd, nda_1d)
+        assert check(npProduct, akProduct.to_ndarray(), akProduct.dtype)
+
+        nda_1d = np.arange(10).astype(data_type1)
+        nda_nd = np.arange(60).reshape(2, 10, 3).astype(data_type2)
+        pda_1d = ak.array(nda_1d)
+        pda_nd = ak.array(nda_nd)
+        akProduct = ak.matmul(pda_1d, pda_nd)
+        npProduct = np.matmul(nda_1d, nda_nd)
+        assert check(npProduct, akProduct.to_ndarray(), akProduct.dtype)
+
+        nda_nd = np.arange(60).reshape(2, 10, 3).astype(data_type1)
+        pda_nd = ak.array(nda_nd)
+        nda_md = np.arange(15).astype(data_type2).reshape(1, 3, 5)
+        pda_md = ak.array(nda_md)
+        akProduct = ak.matmul(pda_nd, pda_md)
+        npProduct = np.matmul(nda_nd, nda_md)
+        assert check(npProduct, akProduct.to_ndarray(), akProduct.dtype)
+
     # Notes about array_equal:
     #   Strings compared to non-strings are always not equal.
     #   nan handling is (of course) unique to floating point


### PR DESCRIPTION
NOPE.  Still draft.  Leftover comments in pdarrayclass.py

Closes #4961

Adds multi-dim behavior to _ak.matmul_ to match _numpy_.

As noted in comments in the _matmul_ function, there are multiple cases:

- If either of both arguments is/are 1-D, then _matmul_ matches _dot_, so the args are sent there.
- If both arrays are 2-D, the computation is handled as a conventional matrix-matrix multiplication.  The shapes must be compatible.
- if one array is  > 2-D and the other is >= 2-D, the numpy rules for broadcasting shapes are followed, e.g.
- given argument shapes of [m,n,k,p] * [1,n,p,q], the second argument is first broadcast to shape [m,n,p,q]
- next [m,n] sub-results of shape [k,q] are calculated
- giving a final result of shape [m,n,k,q].

The python _matmul_ function has been significantly rewritten.

There are new chapel functions to handle the multi-dim case.

There are unit tests that check the multi-dim case up to 3-D.

**Notes about _dot_:**

In the course of sending things to _dot_, I amended _dot_ to cover the case where the 1st argument is 1-D and the 2nd isn't.  This is allowed in _np.dot_, although the online documentation doesn't mention that.