### PR TITLE
Temporarily disable pytables installation test in the CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -391,15 +391,15 @@ jobs:
         retry_on: error
         command: |
           make install-hdf5  DEP_BUILD_DIR=$DEP_BUILD_DIR
-    - name: Make install-pytables
-      uses: nick-fields/retry@v2
-      with:
-        timeout_seconds: 1200  # or use timeout_minutes
-        max_attempts: 2
-        retry_wait_seconds: 60
-        retry_on: error
-        command: |
-          HDF5_DIR=$(pwd)/dep/hdf5-install/ make install-pytables DEP_BUILD_DIR=$DEP_BUILD_DIR
+#    - name: Make install-pytables
+#      uses: nick-fields/retry@v2
+#      with:
+#        timeout_seconds: 1200  # or use timeout_minutes
+#        max_attempts: 2
+#        retry_wait_seconds: 60
+#        retry_on: error
+#        command: |
+#          HDF5_DIR=$(pwd)/dep/hdf5-install/ make install-pytables DEP_BUILD_DIR=$DEP_BUILD_DIR
 
 
   arkouda_chpl_portability:


### PR DESCRIPTION
Temporarily disable the test of the `pytables` install in the `Makefile`.  This will give time to investigate the error.  It's also possible that `pip` install is now available for the versions we need, in which case we may not need to install `pytables` via the `Makefile` going forward.

Related to #5033 intermittent arkouda makefile test failures