### PR TITLE
Use the Chapel standard sort for distributed sorting

### DIFF
--- a/src/DynamicSort.chpl
+++ b/src/DynamicSort.chpl
@@ -5,7 +5,7 @@ module DynamicSort {
       if Data._instance.isDefaultRectangular() {
         ArkoudaSortCompat.TwoArrayRadixSort.twoArrayRadixSort(Data, comparator);
       } else {
-        ArkoudaSortCompat.TwoArrayDistributedRadixSort.twoArrayDistributedRadixSort(Data, comparator);
+        ArkoudaSortCompat.sort(Data, comparator);
       }
     }
 


### PR DESCRIPTION
As of https://github.com/chapel-lang/chapel/pull/27277, Chapel's standard library distributed sort is faster than the undocumented one that Arkouda uses. This PR makes the switch to the new sort. In anecdotal runs, I see it to be much faster than the existing ones.