### PR TITLE
Closes #5043: Investigate performance loss from negative bigint changes

### DIFF
--- a/src/BigIntMsg.chpl
+++ b/src/BigIntMsg.chpl
@@ -55,6 +55,223 @@ module BigIntMsg {
         return new MsgTuple(repMsg, MsgType.NORMAL);
     }
 
+    @arkouda.instantiateAndRegister("big_int_creation_one_limb")
+    proc bigIntCreationOneLimbMsg(cmd: string, msgArgs: borrowed MessageArgs,
+                           st: borrowed SymTab, type array_dtype,
+                           param array_nd: int): MsgTuple throws
+        where (array_dtype == int(64) || array_dtype == uint(64)) {
+        param pn = Reflection.getRoutineName();
+        var repMsg: string;
+
+        var shape = msgArgs.get("shape").toScalarTuple(int, array_nd);
+        var arrayName = msgArgs.get("array");
+        var max_bits = msgArgs.get("max_bits").getIntValue();
+
+        var bigIntArray = makeDistArray((...shape), bigint);
+
+        // We are creating a bigint array from uint arrays
+        var entry = st[arrayName]: SymEntry(array_dtype, array_nd);
+        ref uintA = entry.a;
+        forall (uA, bA) in zip(uintA, bigIntArray) {
+            bA = uA;
+        }
+
+        if max_bits != -1 {
+            // modBy should always be non-zero since we start at 1 and left shift
+            var max_size = 1:bigint;
+            max_size <<= max_bits;
+            max_size -= 1;
+            forall bA in bigIntArray with (var local_max_size = max_size) {
+              bA &= local_max_size;
+            }
+        }
+
+        var retname = st.nextName();
+        st.addEntry(retname, createSymEntry(bigIntArray, max_bits));
+        repMsg = "created %s".format(st.attrib(retname));
+        biLogger.debug(getModuleName(),getRoutineName(),getLineNumber(),repMsg);
+        return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+
+    @arkouda.instantiateAndRegister("big_int_creation_one_limb")
+    proc bigIntCreationOneLimbMsg(cmd: string, msgArgs: borrowed MessageArgs,
+                                st: borrowed SymTab, type array_dtype,
+                                param array_nd: int): MsgTuple throws
+    where array_dtype == real(64)
+    {
+        param pn = Reflection.getRoutineName();
+        var repMsg: string;
+
+        // Same shape / args handling as the int/uint version
+        var shape    = msgArgs.get("shape").toScalarTuple(int, array_nd);
+        var arrayName = msgArgs.get("array");
+        var max_bits  = msgArgs.get("max_bits").getIntValue();
+
+        // Target bigint array
+        var bigIntArray = makeDistArray((...shape), bigint);
+
+        // Source Chapel array of real(64)
+        var entry = st[arrayName]: SymEntry(array_dtype, array_nd);
+        ref realA = entry.a;
+
+        // Convert each real(64) to bigint
+        //
+        // Convention: trunc toward zero
+        //   r: real(64)
+        //   ri = trunc(r)        // real(64) but integer-valued
+        //   bA.set(ri)           // bigint from integer-valued real
+        //
+        // Handle NaN/Inf by throwing errors.
+
+        var problem = false;
+        forall (r, bA) in zip(realA, bigIntArray) with (|| reduce problem) {
+
+            if !isFinite(r) {
+
+                problem = true;
+
+            } else {
+
+                const ri = trunc(r);  // real(64), integral-valued
+                bA.set(ri);
+
+            }
+
+        }
+
+        if problem {
+            const errMsg = "Non-finite real values detected";
+            biLogger.error(getModuleName(), pn, getLineNumber(), errMsg);
+            return MsgTuple.error(errMsg);
+        }
+
+        // Apply max_bits mask if requested (same as int/uint version)
+        if max_bits != -1 {
+            var max_size = 1:bigint;
+            max_size <<= max_bits;
+            max_size -= 1;
+            forall bA in bigIntArray with (var local_max_size = max_size) {
+                bA &= local_max_size;
+            }
+        }
+
+        var retname = st.nextName();
+        st.addEntry(retname, createSymEntry(bigIntArray, max_bits));
+        repMsg = "created %s".format(st.attrib(retname));
+        biLogger.debug(getModuleName(), getRoutineName(), getLineNumber(), repMsg);
+        return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+
+
+    @arkouda.instantiateAndRegister("big_int_creation_multi_limb")
+    proc bigIntCreationMultiLimbMsg(cmd: string,
+                                    msgArgs: borrowed MessageArgs,
+                                    st: borrowed SymTab,
+                                    type array_dtype,
+                                    param array_nd: int): MsgTuple throws
+    where ((array_dtype == int(64) || array_dtype == uint(64)) && array_nd == 1)
+    {
+        var repMsg: string;
+
+        const num_arrays = msgArgs.get("num_arrays").getIntValue();
+        const shape      = msgArgs.get("shape").toScalarTuple(int, array_nd);
+        const arrayNames = msgArgs.get("arrays").getList(num_arrays);
+        const max_bits   = msgArgs.get("max_bits").getIntValue();
+        const signed  = msgArgs.get("signed").toScalar(bool);
+
+        var bigIntArray = makeDistArray((...shape), bigint);
+        var signs = makeDistArray((...shape), bool);
+
+        // --------------------------------------------------------------------------
+        // (1) Horner-fold limbs into bigIntArray
+        //     limb order: arrayNames[0] = least-significant; fold from MS limb down.
+        // --------------------------------------------------------------------------
+        // Precompute mask (if any) to cap growth during folding.
+        const doMask = (max_bits != -1);
+        var mask: bigint;
+        if doMask {
+            mask = 1:bigint;
+            mask <<= max_bits;
+            mask -= 1;
+        }
+
+        if signed {
+            var i = num_arrays - 1;
+            const name  = arrayNames[i];
+            const entry = st[name]: SymEntry(array_dtype, array_nd);
+            ref   limbA = entry.a;
+
+            // Per-element fold; keep everything local
+            if doMask {
+                forall (u, b, s) in zip(limbA, bigIntArray, signs) {
+                    s = (u >> 63): bool;
+                    b += (u & ((1 << 63) - 1));
+                }
+            } else {
+                forall (u, b, s) in zip(limbA, bigIntArray, signs) {
+                    s = (u >> 63): bool;
+                    b += (u & ((1 << 63) - 1));
+                }
+            }
+        }
+
+
+        // Fold from highest index to 0: b = (b << 64) + limb[i]
+        if num_arrays-(1 + (signed: int)) >= 0 {
+            for i in 0..num_arrays-(1 + (signed: int)) by -1 {
+                const name  = arrayNames[i];
+                const entry = st[name]: SymEntry(array_dtype, array_nd);
+                ref   limbA = entry.a;
+
+                // Per-element fold; keep everything local
+                if doMask {
+                    forall (u, b) in zip(limbA, bigIntArray) with (var tmp: bigint, const localMask = mask) {
+                        b <<= 64;
+                        tmp = (u: uint(64)): bigint;  // treat limb as magnitude
+                        b  += tmp;
+                        b  &= localMask;
+                    }
+                } else {
+                    forall (u, b) in zip(limbA, bigIntArray) with (var tmp: bigint) {
+                        b <<= 64;
+                        tmp = (u: uint(64)): bigint;
+                        b  += tmp;
+                    }
+                }
+            }
+        }
+
+        // --------------------------------------------------------------------------
+        // (2) Apply signs with per-locale bulk fetch of sign words
+        // --------------------------------------------------------------------------
+
+        if signed {
+
+            const negAmount = (1: bigint) << (64 * num_arrays - 1);
+
+            forall (b, s) in zip(bigIntArray, signs) {
+                if s {
+                    if doMask {
+                        b = b - negAmount;
+                        b &= mask;
+                    } else {
+                        b = b - negAmount;
+                    }
+                }
+            }
+        }
+
+        // --------------------------------------------------------------------------
+        // (3) Return the created array
+        // --------------------------------------------------------------------------
+        const retname = st.nextName();
+        st.addEntry(retname, createSymEntry(bigIntArray, max_bits));
+        repMsg = "created %s".format(st.attrib(retname));
+        biLogger.debug(getModuleName(), getRoutineName(), getLineNumber(), repMsg);
+        return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+
+
     @arkouda.instantiateAndRegister("big_int_creation")
     proc bigIntCreationMsg(cmd: string, msgArgs: borrowed MessageArgs,
                            st: borrowed SymTab, type array_dtype,


### PR DESCRIPTION
While PR #4985 technically fixed the issue of general negative bigint problems, it caused a performance regression. I believe this is primarily due to the overhead of creating the sign array. Instead, here's basically what happens in the code:

```python
    any_neg = np.any(flat < 0)
    req_bits: int
    if any_neg:
        req_bits = max(flat.max().bit_length(), (-flat.min()).bit_length()) + 1
    else:
        req_bits = flat.max().bit_length()
```
Then the code figures out how many times to pull off `uint64` limbs, rather than waiting until everything is zero (which doesn't happen in the negative case, it just continues to be -1).

The code runs out to ~~two~~ three separate Chapel functions depending on the case. If the input is just an `int64` or `uint64` array, it converts it directly to bigint (similar for `float64` or some other kind of floating point input). If the input is numpy's version of a bigint array, it goes to the multi-limb version (unfortunately, this is the case even if everything comes out to just one limb, but I think the performance loss here is not that bad). If the input data had any negative values, it treats the limbs as signed (all bits are positive and the top bit is negative). However, it's hard to create a bigint like this (AFAIK). So Chapel-side, it creates a signs array, strips off the top bit of every limb and treats it as a bool to reference later. Either way, it goes to the "Horner fold" step, which, as ChatGPT tells me, is possibly a faster way to create the bigints. Previously the code was bit shifting the limbs into the right spot and then adding them to the bigint value. The idea here is that you start with the highest limb of the data, then you bitshift it and add in the next limb, bitshift what you have and add in the next limb, and so on. You can read more about the generic version of this [here](https://en.wikipedia.org/wiki/Horner%27s_method) (take x = `2**64`). Then it adds in the signed bit as necessary.

It also handles the case where `max_bits` is not -1.

Hopefully any loss in performance is made up by a few factors:

1. Previously the Python code was stripping the limbs off by modding by `2**64` and then integer dividing by the same value. I think it could speed the code up to do a bitmask by `2**64 - 1` and then bitshift by 64.
2. Supposedly the Horner fold has better performance.
3. If the input is only one limb of `int64` or `uint64` data, it should go to the single limb version and that should run quicker.

~~This also handles all cases of numeric data to bigint output in a single function, so if the performance is back up, then I can cut out some code in the array function.~~

I went ahead and cut the old bigint code out.

Closes #5043: Investigate performance loss from negative bigint changes