### PR TITLE
Omit runs folder from pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         args: 
           - --fix        # applies lint‐rule fixes in place
           - --extend-ignore=I,E712,E741,PTH110,PTH118,PTH108,C403,PTH100,PTH109,F841,F401,W291,W293,PT012,D400,PLR2044,B034,PT011,RUF034,N812,D404,PTH202,PLC0206,RUF013,PTH208,PT021,B015,C404,PT006,RUF040,PT017,B011,PT015,PT022,SIM222,SIM210,PT014,SIM113,C414,PLR1730,PLR0124,C405,SIM117,B023,SIM105,PLW1508,PTH103,B018,B008,PTH107,PLW1510,RET502,F821,E721,E731,PT007,D100,D103,D102,D101,D205,D401,D105
-        exclude: ^(tests/deprecated|arkouda/_version\.py|versioneer\.py)$
+        exclude: ^(tests/deprecated|arkouda/_version\.py|versioneer\.py|runs)$
 
       # 2) the formatter hook
       - id: ruff-format
@@ -24,4 +24,4 @@ repos:
       - id: isort
         name: isort (python)
         args: ["--profile=black"]
-        exclude: ^(tests/deprecated)
+        exclude: ^(tests/deprecated|runs)


### PR DESCRIPTION
Omits `runs` folder from `pre-commit` checks.