### PR TITLE
Closes #5052:  test_randint_array_dtype_multi_dim fails when size==10

### DIFF
--- a/tests/numpy/pdarray_creation_test.py
+++ b/tests/numpy/pdarray_creation_test.py
@@ -451,7 +451,7 @@ class TestPdarrayCreation:
             high = size if array_type != bool else 2
             test_array = ak.randint(0, high, shape, array_type)
             assert isinstance(test_array, ak.pdarray)
-            assert size == len(test_array)
+            assert local_size == len(test_array)
             assert array_type == test_array.dtype
             assert shape == test_array.shape
             assert ((0 <= test_array) & (test_array <= size)).all()


### PR DESCRIPTION
Fixes unit test `test_randint_array_dtype_multi_dim` failing when `size==10`.

Closes #5052:  test_randint_array_dtype_multi_dim fails when size==10