### PR TITLE
Closes #5060 remove isort

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,22 +51,6 @@ jobs:
       run: |
         make chplcheck
 
-  isort:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install isort==5.13.2
-      - name: Run isort
-        run: |
-          isort --settings-path pyproject.toml --check-only --diff .
-
   ruff-format:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,10 +18,3 @@ repos:
       - id: ruff-format
         files: '\.py$'         # make sure it only hits .py files
 
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2        # or whatever the latest isort version is
-    hooks:
-      - id: isort
-        name: isort (python)
-        args: ["--profile=black"]
-        exclude: ^(tests/deprecated|runs)

--- a/Makefile
+++ b/Makefile
@@ -693,13 +693,9 @@ ruff-format:
 	ruff check $(ARKOUDA_PROJECT_DIR)/arkouda --fix
 	#  Verify if it will pass the CI check:
 	ruff format --check --diff
-	isort --settings-path $(ARKOUDA_PROJECT_DIR)/pyproject.toml  --gitignore --float-to-top .
 
 isort:
-	isort --version-number
-	isort --settings-path $(ARKOUDA_PROJECT_DIR)/pyproject.toml  --gitignore --float-to-top .
-	#  Verify if it will pass the CI check:
-	isort --settings-path $(ARKOUDA_PROJECT_DIR)/pyproject.toml --check-only --diff .
+	ruff check --select I --fix .
 
 
 .PHONY: check-doc-examples

--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -37,7 +37,6 @@ dependencies:
   - flake8
   - mypy>=0.931
   - black==25.1.0
-  - isort==5.13.2
   - pytest-json-report
   - pytest-benchmark
   - mathjax

--- a/arkouda/alignment.py
+++ b/arkouda/alignment.py
@@ -43,6 +43,7 @@ array([100 200 200])
 """
 
 import functools
+
 from typing import TYPE_CHECKING, Sequence, TypeVar
 from warnings import warn
 

--- a/arkouda/apply.py
+++ b/arkouda/apply.py
@@ -53,10 +53,12 @@ See Also
 
 import base64
 import sys
+
 from typing import Callable, Optional, Union, cast
 
 import cloudpickle
 import numpy as np
+
 from typeguard import typechecked
 
 from arkouda.client import get_config

--- a/arkouda/array_api/_dtypes.py
+++ b/arkouda/array_api/_dtypes.py
@@ -1,4 +1,5 @@
 import arkouda as ak
+
 from arkouda import dtype as akdtype
 
 

--- a/arkouda/array_api/array_object.py
+++ b/arkouda/array_api/array_object.py
@@ -19,13 +19,25 @@ of ndarray.
 
 from __future__ import annotations
 
-from enum import IntEnum
 import types
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union, cast
+
+from enum import IntEnum
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
 
 import numpy as np
 
 import arkouda as ak
+
 from arkouda import array_api
 from arkouda.numpy.pdarraycreation import scalar_array
 

--- a/arkouda/array_api/creation_functions.py
+++ b/arkouda/array_api/creation_functions.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, List, Optional, Tuple, Union, cast
 import numpy as np
 
 import arkouda as ak
+
 from arkouda.numpy.dtypes import dtype as akdtype
 from arkouda.numpy.dtypes import resolve_scalar_dtype
 from arkouda.numpy.pdarrayclass import _to_pdarray, pdarray

--- a/arkouda/array_api/manipulation_functions.py
+++ b/arkouda/array_api/manipulation_functions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import List, Optional, Tuple, Union, cast
 
 import numpy as np
+
 from typeguard import typechecked
 
 from arkouda.numpy.dtypes import bool as akbool

--- a/arkouda/array_api/searching_functions.py
+++ b/arkouda/array_api/searching_functions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Literal, Optional, Tuple, cast
 
 import arkouda as ak
+
 from arkouda.numpy import cast as akcast
 from arkouda.numpy.pdarrayclass import create_pdarray, create_pdarrays
 

--- a/arkouda/array_api/statistical_functions.py
+++ b/arkouda/array_api/statistical_functions.py
@@ -10,6 +10,7 @@ from arkouda.numpy.pdarrayclass import create_pdarray
 from arkouda.numpy.util import _axis_validation
 
 from ._dtypes import (
+    _numeric_dtypes,  # _complex_floating_dtypes,; complex128,
     _real_floating_dtypes,
     _real_numeric_dtypes,
     _signed_integer_dtypes,
@@ -17,7 +18,6 @@ from ._dtypes import (
     int64,
     uint64,
 )
-from ._dtypes import _numeric_dtypes  # _complex_floating_dtypes,; complex128,
 from .array_object import Array, implements_numpy
 from .manipulation_functions import squeeze
 

--- a/arkouda/array_api/utility_functions.py
+++ b/arkouda/array_api/utility_functions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Optional, Tuple, Union
 
 import arkouda as ak
+
 from arkouda.numpy.pdarrayclass import create_pdarray
 from arkouda.numpy.pdarraycreation import scalar_array
 

--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -63,18 +63,25 @@ Examples
 
 """
 
-from enum import Enum
 import json
 import os
 import sys
-from typing import Dict, List, Literal, Mapping, Optional, Tuple, Union, cast, overload
 import warnings
+
+from enum import Enum
+from typing import Dict, List, Literal, Mapping, Optional, Tuple, Union, cast, overload
 
 import zmq  # for typechecking
 
 from arkouda import __version__, security
 from arkouda.logger import ArkoudaLogger, LogLevel, getArkoudaLogger
-from arkouda.message import MessageFormat, MessageType, ParameterObject, ReplyMessage, RequestMessage
+from arkouda.message import (
+    MessageFormat,
+    MessageType,
+    ParameterObject,
+    ReplyMessage,
+    RequestMessage,
+)
 from arkouda.pandas import io_util
 
 

--- a/arkouda/client_dtypes.py
+++ b/arkouda/client_dtypes.py
@@ -54,6 +54,7 @@ from ipaddress import ip_address as _ip_address
 from typing import TYPE_CHECKING, Literal, Optional, TypeVar, Union
 
 import numpy as np
+
 from typeguard import typechecked
 
 from arkouda.numpy.dtypes import bitType, intTypes, isSupportedInt
@@ -929,7 +930,12 @@ class IPv4(pdarray):
     def update_hdf(self, prefix_path: str, dataset: str = "array", repack: bool = True):
         """Override the pdarray implementation so that the special object type will be used."""
         from arkouda.client import generic_msg
-        from arkouda.pandas.io import _file_type_to_int, _get_hdf_filetype, _mode_str_to_int, _repack_hdf
+        from arkouda.pandas.io import (
+            _file_type_to_int,
+            _get_hdf_filetype,
+            _mode_str_to_int,
+            _repack_hdf,
+        )
 
         # determine the format (single/distribute) that the file was saved in
         file_type = _get_hdf_filetype(prefix_path + "*")

--- a/arkouda/history.py
+++ b/arkouda/history.py
@@ -43,6 +43,7 @@ arkouda.generate_history : High-level function for retrieving command history.
 """
 
 import readline
+
 from typing import List, Optional
 
 from IPython.core.history import HistoryAccessor

--- a/arkouda/infoclass.py
+++ b/arkouda/infoclass.py
@@ -57,8 +57,9 @@ array([0 1 2 3 4])
 """
 
 import json
-from json import JSONEncoder
 import sys
+
+from json import JSONEncoder
 from typing import TYPE_CHECKING, List, TypeVar, Union, cast
 
 from typeguard import typechecked

--- a/arkouda/logger.py
+++ b/arkouda/logger.py
@@ -56,9 +56,20 @@ See Also
 
 """
 
-from enum import Enum
-from logging import CRITICAL, DEBUG, ERROR, INFO, WARN, Formatter, Handler, Logger, StreamHandler
 import os
+
+from enum import Enum
+from logging import (
+    CRITICAL,
+    DEBUG,
+    ERROR,
+    INFO,
+    WARN,
+    Formatter,
+    Handler,
+    Logger,
+    StreamHandler,
+)
 from typing import List, Optional, cast
 
 from typeguard import typechecked

--- a/arkouda/message.py
+++ b/arkouda/message.py
@@ -62,9 +62,10 @@ See Also
 
 from __future__ import annotations
 
+import json
+
 from dataclasses import dataclass
 from enum import Enum
-import json
 from typing import Dict, Optional
 
 from typeguard import typechecked

--- a/arkouda/numpy/_typing/_typing.py
+++ b/arkouda/numpy/_typing/_typing.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
 import builtins
+
 from typing import Any, Iterable, Literal, TypeAlias, TypeGuard
 from typing import Union as _Union
 
 import numpy as np
 
-from arkouda.numpy.dtypes import bigint
+from arkouda.numpy.dtypes import bigint, str_
 from arkouda.numpy.dtypes import bool_ as ak_bool
 from arkouda.numpy.dtypes import float64 as ak_float64
 from arkouda.numpy.dtypes import int64 as ak_int64
-from arkouda.numpy.dtypes import str_
 from arkouda.numpy.dtypes import uint64 as ak_uint64
 from arkouda.numpy.strings import Strings
 

--- a/arkouda/numpy/dtypes.py
+++ b/arkouda/numpy/dtypes.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import builtins
-from enum import Enum
 import sys
+
+from enum import Enum
 from typing import TYPE_CHECKING, List, Union, cast
 
 import numpy as np
+
 from numpy import (
     bool,
     bool_,

--- a/arkouda/numpy/err.py
+++ b/arkouda/numpy/err.py
@@ -56,10 +56,11 @@ from __future__ import annotations
 
 import contextlib
 import sys
-from typing import Callable, Dict, Iterator, Literal, Optional
 
 # --- add near the top of arkouda/err.py ---
 import warnings
+
+from typing import Callable, Dict, Iterator, Literal, Optional
 
 from arkouda.logger import getArkoudaLogger
 

--- a/arkouda/numpy/numeric.py
+++ b/arkouda/numpy/numeric.py
@@ -1,31 +1,48 @@
 from __future__ import annotations
 
-from enum import Enum
 import json
-from typing import TYPE_CHECKING, Any, Iterable, List, Literal, Optional, Sequence, Tuple, TypeVar
-from typing import Union
+
+from enum import Enum
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Iterable,
+    List,
+    Literal,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+    get_args,
+    no_type_check,
+    overload,
+)
 from typing import Union as _Union
 from typing import cast as type_cast
-from typing import get_args, no_type_check, overload
 
 import numpy as np
+
 from typeguard import typechecked
 
 from arkouda.groupbyclass import GroupBy, groupable
 from arkouda.numpy.dtypes import (
+    ARKOUDA_SUPPORTED_INTS,
+    _datatype_check,
+    bigint,
     int_scalars,
     isSupportedNumber,
     numeric_scalars,
     resolve_scalar_dtype,
     str_,
 )
-from arkouda.numpy.dtypes import ARKOUDA_SUPPORTED_INTS, _datatype_check, bigint
 from arkouda.numpy.dtypes import bool_ as ak_bool
 from arkouda.numpy.dtypes import dtype as akdtype
 from arkouda.numpy.dtypes import float64 as ak_float64
 from arkouda.numpy.dtypes import int64 as ak_int64
 from arkouda.numpy.dtypes import uint64 as ak_uint64
 from arkouda.numpy.pdarrayclass import (
+    _reduces_to_single_value,
     argmax,
     broadcast_if_needed,
     create_pdarray,
@@ -33,7 +50,6 @@ from arkouda.numpy.pdarrayclass import (
     pdarray,
     sum,
 )
-from arkouda.numpy.pdarrayclass import _reduces_to_single_value
 from arkouda.numpy.pdarrayclass import all as ak_all
 from arkouda.numpy.pdarrayclass import any as ak_any
 from arkouda.numpy.pdarraycreation import array, linspace, scalar_array

--- a/arkouda/numpy/pdarrayclass.py
+++ b/arkouda/numpy/pdarrayclass.py
@@ -1,18 +1,27 @@
 from __future__ import annotations
 
 import builtins
-from functools import reduce
 import json
+
+from functools import reduce
 from math import ceil
 from sys import modules
 from typing import TYPE_CHECKING, List, Optional, Tuple, TypeVar, Union, cast, overload
 
 import numpy as np
+
 from typeguard import typechecked
 
 from arkouda.infoclass import information, pretty_print_information
 from arkouda.logger import getArkoudaLogger
 from arkouda.numpy.dtypes import (
+    NUMBER_FORMAT_STRINGS,
+    DTypes,
+    bigint,
+    bool_scalars,
+    dtype,
+    get_byteorder,
+    get_server_byteorder,
     int_scalars,
     isSupportedBool,
     isSupportedInt,
@@ -22,11 +31,8 @@ from arkouda.numpy.dtypes import (
     resolve_scalar_dtype,
     result_type,
 )
-from arkouda.numpy.dtypes import NUMBER_FORMAT_STRINGS, DTypes, bigint
 from arkouda.numpy.dtypes import bool_ as akbool
-from arkouda.numpy.dtypes import bool_scalars, dtype
 from arkouda.numpy.dtypes import float64 as akfloat64
-from arkouda.numpy.dtypes import get_byteorder, get_server_byteorder
 from arkouda.numpy.dtypes import int64 as akint64
 from arkouda.numpy.dtypes import str_ as akstr_
 from arkouda.numpy.dtypes import uint64 as akuint64
@@ -3035,7 +3041,12 @@ class pdarray:
         - If the dataset provided does not exist, it will be added
         """
         from arkouda.client import generic_msg
-        from arkouda.pandas.io import _file_type_to_int, _get_hdf_filetype, _mode_str_to_int, _repack_hdf
+        from arkouda.pandas.io import (
+            _file_type_to_int,
+            _get_hdf_filetype,
+            _mode_str_to_int,
+            _repack_hdf,
+        )
 
         # determine the format (single/distribute) that the file was saved in
         file_type = _get_hdf_filetype(prefix_path + "*")

--- a/arkouda/numpy/pdarraycreation.py
+++ b/arkouda/numpy/pdarraycreation.py
@@ -1,12 +1,23 @@
 import itertools
-from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Tuple, TypeVar, Union
-from typing import cast
+
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+)
 from typing import cast as type_cast
-from typing import overload
 
 import numpy as np
-from numpy.typing import NDArray
 import pandas as pd
+
+from numpy.typing import NDArray
 from typeguard import typechecked
 
 from arkouda.numpy._typing._typing import _NumericLikeDType, _StringDType
@@ -17,8 +28,9 @@ from arkouda.numpy.dtypes import (
     SeriesDTypes,
     bigint,
     bool_scalars,
-)
-from arkouda.numpy.dtypes import (
+    float64,
+    get_byteorder,
+    get_server_byteorder,
     int_scalars,
     isSupportedInt,
     isSupportedNumber,
@@ -27,7 +39,6 @@ from arkouda.numpy.dtypes import (
     str_,
 )
 from arkouda.numpy.dtypes import dtype as akdtype
-from arkouda.numpy.dtypes import float64, get_byteorder, get_server_byteorder
 from arkouda.numpy.dtypes import int64 as akint64
 from arkouda.numpy.dtypes import uint64 as akuint64
 from arkouda.numpy.pdarrayclass import create_pdarray, pdarray
@@ -696,7 +707,9 @@ def zeros(
     if dtype_name not in NumericDTypes:
         raise TypeError(f"unsupported dtype {dtype}")
 
-    from arkouda.numpy.util import _infer_shape_from_size  # placed here to avoid circ import
+    from arkouda.numpy.util import (
+        _infer_shape_from_size,  # placed here to avoid circ import
+    )
 
     shape, ndim, full_size = _infer_shape_from_size(size)
 
@@ -841,7 +854,9 @@ def full(
     # check dtype for error
     if dtype_name not in NumericDTypes:
         raise TypeError(f"unsupported dtype {dtype}")
-    from arkouda.numpy.util import _infer_shape_from_size  # placed here to avoid circ import
+    from arkouda.numpy.util import (
+        _infer_shape_from_size,  # placed here to avoid circ import
+    )
 
     shape, ndim, full_size = _infer_shape_from_size(size)
 
@@ -1405,7 +1420,11 @@ def linspace(
     from arkouda import newaxis
     from arkouda.numeric import transpose
     from arkouda.numpy.manipulation_functions import tile
-    from arkouda.numpy.util import _integer_axis_validation, broadcast_shapes, broadcast_to
+    from arkouda.numpy.util import (
+        _integer_axis_validation,
+        broadcast_shapes,
+        broadcast_to,
+    )
 
     if dtype not in (None, float64):
         raise TypeError("dtype must be None or float64")

--- a/arkouda/numpy/pdarraymanipulation.py
+++ b/arkouda/numpy/pdarraymanipulation.py
@@ -2,6 +2,7 @@ from typing import Literal, Optional, Sequence, Tuple, Union, cast
 from warnings import warn
 
 import numpy as np
+
 from typeguard import typechecked
 
 from arkouda.numpy.dtypes import bigint

--- a/arkouda/numpy/pdarraysetops.py
+++ b/arkouda/numpy/pdarraysetops.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Sequence, TypeVar, Union, cast
 
 import numpy as np
+
 from typeguard import typechecked
 
 from arkouda.client_dtypes import BitVector
@@ -16,7 +17,12 @@ from arkouda.numpy.pdarrayclass import create_pdarray, pdarray
 from arkouda.numpy.pdarraycreation import array, ones, zeros, zeros_like
 from arkouda.numpy.sorting import argsort
 from arkouda.numpy.strings import Strings
-from arkouda.pandas.groupbyclass import GroupBy, groupable, groupable_element_type, unique
+from arkouda.pandas.groupbyclass import (
+    GroupBy,
+    groupable,
+    groupable_element_type,
+    unique,
+)
 
 
 if TYPE_CHECKING:

--- a/arkouda/numpy/random/generator.py
+++ b/arkouda/numpy/random/generator.py
@@ -2,14 +2,17 @@ import numpy as np
 import numpy.random as np_random
 
 from arkouda.client import get_registration_config
-from arkouda.numpy.dtypes import _val_isinstance_of_union
+from arkouda.numpy.dtypes import (
+    _val_isinstance_of_union,
+    dtype_for_chapel,
+    float_scalars,
+    int_scalars,
+    numeric_scalars,
+)
 from arkouda.numpy.dtypes import dtype as akdtype
 from arkouda.numpy.dtypes import dtype as to_numpy_dtype
-from arkouda.numpy.dtypes import dtype_for_chapel
 from arkouda.numpy.dtypes import float64 as akfloat64
-from arkouda.numpy.dtypes import float_scalars
 from arkouda.numpy.dtypes import int64 as akint64
-from arkouda.numpy.dtypes import int_scalars, numeric_scalars
 from arkouda.numpy.pdarrayclass import create_pdarray, pdarray
 
 

--- a/arkouda/numpy/random/legacy.py
+++ b/arkouda/numpy/random/legacy.py
@@ -2,11 +2,10 @@ from typing import Optional, Tuple, Union, cast
 
 from typeguard import typechecked
 
-from arkouda.numpy.dtypes import NUMBER_FORMAT_STRINGS, DTypes
+from arkouda.numpy.dtypes import NUMBER_FORMAT_STRINGS, DTypes, int_scalars, numeric_scalars
 from arkouda.numpy.dtypes import dtype as akdtype
 from arkouda.numpy.dtypes import float64 as akfloat64
 from arkouda.numpy.dtypes import int64 as akint64
-from arkouda.numpy.dtypes import int_scalars, numeric_scalars
 from arkouda.numpy.pdarrayclass import create_pdarray, pdarray
 from arkouda.numpy.random.generator import Generator, default_rng
 

--- a/arkouda/numpy/segarray.py
+++ b/arkouda/numpy/segarray.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+
 from typing import TYPE_CHECKING, Literal, Optional, Sequence, Tuple, TypeVar
 
 import numpy as np
@@ -10,7 +11,12 @@ from arkouda.numpy.dtypes import bool_ as akbool
 from arkouda.numpy.dtypes import int64 as akint64
 from arkouda.numpy.dtypes import int_scalars, isSupportedInt, str_
 from arkouda.numpy.dtypes import uint64 as akuint64
-from arkouda.numpy.pdarrayclass import RegistrationError, create_pdarray, is_sorted, pdarray
+from arkouda.numpy.pdarrayclass import (
+    RegistrationError,
+    create_pdarray,
+    is_sorted,
+    pdarray,
+)
 from arkouda.numpy.pdarraycreation import arange, array, ones, zeros
 from arkouda.numpy.pdarraysetops import concatenate
 from arkouda.numpy.strings import Strings
@@ -923,7 +929,12 @@ class SegArray:
           file with the new data
         """
         from arkouda.client import generic_msg
-        from arkouda.pandas.io import _file_type_to_int, _get_hdf_filetype, _mode_str_to_int, _repack_hdf
+        from arkouda.pandas.io import (
+            _file_type_to_int,
+            _get_hdf_filetype,
+            _mode_str_to_int,
+            _repack_hdf,
+        )
 
         if self.dtype == str_:
             # Support will be added by Issue #2443

--- a/arkouda/numpy/sorting.py
+++ b/arkouda/numpy/sorting.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import TYPE_CHECKING, Literal, Sequence, TypeVar, Union
-from typing import cast
+from typing import TYPE_CHECKING, Literal, Sequence, TypeVar, Union, cast
 from typing import cast as type_cast
 
 from typeguard import check_type, typechecked

--- a/arkouda/numpy/strings.py
+++ b/arkouda/numpy/strings.py
@@ -3,23 +3,40 @@ from __future__ import annotations
 import codecs
 import itertools
 import re
-from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple, TypeVar, Union
-from typing import cast
+
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+)
 from typing import cast as type_cast
 
 import numpy as np
+
 from numpy import dtype as npdtype
 from typeguard import typechecked
 
+import arkouda.numpy.dtypes
+
 from arkouda.infoclass import information, list_symbol_table
 from arkouda.logger import ArkoudaLogger, getArkoudaLogger
-import arkouda.numpy.dtypes
-from arkouda.numpy.dtypes import NUMBER_FORMAT_STRINGS, bool_scalars
+from arkouda.numpy.dtypes import (
+    NUMBER_FORMAT_STRINGS,
+    bool_scalars,
+    int_scalars,
+    numeric_scalars,
+    resolve_scalar_dtype,
+    str_scalars,
+)
 from arkouda.numpy.dtypes import int64 as akint64
-from arkouda.numpy.dtypes import int_scalars, numeric_scalars, resolve_scalar_dtype, str_scalars
-from arkouda.numpy.pdarrayclass import RegistrationError
+from arkouda.numpy.pdarrayclass import RegistrationError, create_pdarray, parse_single_value, pdarray
 from arkouda.numpy.pdarrayclass import all as akall
-from arkouda.numpy.pdarrayclass import create_pdarray, parse_single_value, pdarray
 from arkouda.pandas.match import Match, MatchType
 
 
@@ -2713,7 +2730,12 @@ class Strings:
         - If the dataset provided does not exist, it will be added
         """
         from arkouda.client import generic_msg
-        from arkouda.pandas.io import _file_type_to_int, _get_hdf_filetype, _mode_str_to_int, _repack_hdf
+        from arkouda.pandas.io import (
+            _file_type_to_int,
+            _get_hdf_filetype,
+            _mode_str_to_int,
+            _repack_hdf,
+        )
 
         # determine the format (single/distribute) that the file was saved in
         file_type = _get_hdf_filetype(prefix_path + "*")

--- a/arkouda/numpy/timeclass.py
+++ b/arkouda/numpy/timeclass.py
@@ -1,8 +1,10 @@
 import datetime
 import json
+
 from typing import TYPE_CHECKING, Optional, TypeVar, Union
 
 import numpy as np
+
 from pandas import Series as pdSeries
 from pandas import Timedelta as pdTimedelta
 from pandas import Timestamp as pdTimestamp
@@ -252,7 +254,12 @@ class _AbstractBaseTime(pdarray):
     def update_hdf(self, prefix_path: str, dataset: str = "array", repack: bool = True):
         """Override the pdarray implementation so that the special object type will be used."""
         from arkouda.client import generic_msg
-        from arkouda.pandas.io import _file_type_to_int, _get_hdf_filetype, _mode_str_to_int, _repack_hdf
+        from arkouda.pandas.io import (
+            _file_type_to_int,
+            _get_hdf_filetype,
+            _mode_str_to_int,
+            _repack_hdf,
+        )
 
         # determine the format (single/distribute) that the file was saved in
         file_type = _get_hdf_filetype(prefix_path + "*")

--- a/arkouda/numpy/util.py
+++ b/arkouda/numpy/util.py
@@ -2,15 +2,22 @@ from __future__ import annotations
 
 import builtins
 import json
-from math import prod as maprod
 import sys
+
+from math import prod as maprod
 from typing import TYPE_CHECKING, List, Literal, Sequence, Tuple, TypeVar, Union, cast
 
 from typeguard import typechecked
 
 from arkouda.client_dtypes import BitVector, BitVectorizer, IPv4
 from arkouda.infoclass import list_registry
-from arkouda.numpy.dtypes import _is_dtype_in_union, dtype, float_scalars, int_scalars, numeric_scalars
+from arkouda.numpy.dtypes import (
+    _is_dtype_in_union,
+    dtype,
+    float_scalars,
+    int_scalars,
+    numeric_scalars,
+)
 from arkouda.numpy.pdarrayclass import create_pdarray, pdarray
 from arkouda.numpy.pdarraycreation import arange
 from arkouda.numpy.pdarraysetops import unique

--- a/arkouda/pandas/categorical.py
+++ b/arkouda/pandas/categorical.py
@@ -47,13 +47,25 @@ See Also
 
 from __future__ import annotations
 
-from collections import defaultdict
 import itertools
 import json
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, TypeVar, Union
+
+from collections import defaultdict
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+)
 from typing import cast as type_cast
 
 import numpy as np
+
 from pandas import Categorical as pd_Categorical
 from pandas import Index as pd_Index
 from typeguard import typechecked
@@ -61,13 +73,11 @@ from typeguard import typechecked
 from arkouda.infoclass import information
 from arkouda.logger import getArkoudaLogger
 from arkouda.numpy.dtypes import bool_ as akbool
-from arkouda.numpy.dtypes import bool_scalars
+from arkouda.numpy.dtypes import bool_scalars, int_scalars, resolve_scalar_dtype, str_, str_scalars
 from arkouda.numpy.dtypes import dtype as akdtype
 from arkouda.numpy.dtypes import int64 as akint64
-from arkouda.numpy.dtypes import int_scalars, resolve_scalar_dtype, str_, str_scalars
-from arkouda.numpy.pdarrayclass import RegistrationError
+from arkouda.numpy.pdarrayclass import RegistrationError, create_pdarray, pdarray
 from arkouda.numpy.pdarrayclass import all as akall
-from arkouda.numpy.pdarrayclass import create_pdarray, pdarray
 from arkouda.numpy.pdarraycreation import arange, array, ones, zeros, zeros_like
 from arkouda.numpy.pdarraysetops import concatenate, in1d
 from arkouda.numpy.sorting import argsort
@@ -1294,7 +1304,12 @@ class Categorical:
 
         """
         from arkouda.client import generic_msg
-        from arkouda.pandas.io import _file_type_to_int, _get_hdf_filetype, _mode_str_to_int, _repack_hdf
+        from arkouda.pandas.io import (
+            _file_type_to_int,
+            _get_hdf_filetype,
+            _mode_str_to_int,
+            _repack_hdf,
+        )
 
         # determine the format (single/distribute) that the file was saved in
         file_type = _get_hdf_filetype(prefix_path + "*")

--- a/arkouda/pandas/dataframe.py
+++ b/arkouda/pandas/dataframe.py
@@ -43,29 +43,40 @@ Examples
 
 from __future__ import annotations
 
-from collections import UserDict
-from functools import reduce
 import json
 import os
 import random
 import sys
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, TypeVar, Union, cast
+
+from collections import UserDict
+from functools import reduce
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+)
 from warnings import warn
 
 import numpy as np  # type: ignore
+import pandas as pd  # type: ignore
+
 from numpy import ndarray
 from numpy._typing import _8Bit, _16Bit, _32Bit, _64Bit
-import pandas as pd  # type: ignore
 from typeguard import typechecked
 
 from arkouda.client import maxTransferBytes
 from arkouda.client_dtypes import BitVector, Fields, IPv4
 from arkouda.index import Index, MultiIndex
-from arkouda.numpy.dtypes import _is_dtype_in_union, bigint
+from arkouda.numpy.dtypes import _is_dtype_in_union, bigint, numeric_scalars
 from arkouda.numpy.dtypes import bool_ as akbool
 from arkouda.numpy.dtypes import float64 as akfloat64
 from arkouda.numpy.dtypes import int64 as akint64
-from arkouda.numpy.dtypes import numeric_scalars
 from arkouda.numpy.dtypes import uint64 as akuint64
 from arkouda.numpy.pdarrayclass import RegistrationError, pdarray
 from arkouda.numpy.pdarraycreation import arange, array, create_pdarray, full, zeros
@@ -3226,7 +3237,11 @@ class DataFrame(UserDict):
         4 -4  4 (5 rows x 2 columns)
 
         """
-        from arkouda.pandas.io import _dict_recombine_segarrays_categoricals, get_filetype, load_all
+        from arkouda.pandas.io import (
+            _dict_recombine_segarrays_categoricals,
+            get_filetype,
+            load_all,
+        )
 
         prefix, extension = os.path.splitext(prefix_path)
         first_file = f"{prefix}_LOCALE0000{extension}"

--- a/arkouda/pandas/extension/_arkouda_array.py
+++ b/arkouda/pandas/extension/_arkouda_array.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import numpy as np
+
 from numpy import ndarray
 from pandas.api.extensions import ExtensionArray
 

--- a/arkouda/pandas/extension/_arkouda_extension_array.py
+++ b/arkouda/pandas/extension/_arkouda_extension_array.py
@@ -47,6 +47,7 @@ array([ 1, 99,  3])
 from typing import Optional, Tuple, Union
 
 import numpy as np
+
 from pandas.api.extensions import ExtensionArray
 
 from arkouda.numpy.dtypes import all_scalars
@@ -137,6 +138,7 @@ class ArkoudaExtensionArray(ExtensionArray):
           * gathers once, then fills masked positions in a single pass.
         """
         import arkouda as ak
+
         from arkouda.numpy.pdarrayclass import pdarray
 
         # Normalize indexer to ak int64

--- a/arkouda/pandas/extension/_arkouda_string_array.py
+++ b/arkouda/pandas/extension/_arkouda_string_array.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from pandas.api.extensions import ExtensionArray
 
 from arkouda.numpy.pdarraycreation import array as ak_array

--- a/arkouda/pandas/extension/_dtypes.py
+++ b/arkouda/pandas/extension/_dtypes.py
@@ -44,13 +44,13 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+
 from numpy import dtype as np_dtype
 from pandas.api.extensions import ExtensionDtype
 
-from arkouda.numpy.dtypes import bigint
+from arkouda.numpy.dtypes import bigint, float64, int64, str_, uint8, uint64
 from arkouda.numpy.dtypes import bool as ak_bool
 from arkouda.numpy.dtypes import dtype as ak_dtype
-from arkouda.numpy.dtypes import float64, int64, str_, uint8, uint64
 
 
 # ---- Base dtype -------------------------------------------------------------

--- a/arkouda/pandas/groupbyclass.py
+++ b/arkouda/pandas/groupbyclass.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 
 import enum
 import json
+
 from typing import (
     TYPE_CHECKING,
     Dict,
@@ -59,17 +60,21 @@ from typing import (
 )
 
 import numpy as np
+
 from typeguard import typechecked
 
 from arkouda.logger import ArkoudaLogger, getArkoudaLogger
-from arkouda.numpy.dtypes import _val_isinstance_of_union, bigint
+from arkouda.numpy.dtypes import _val_isinstance_of_union, bigint, float_scalars, int_scalars
 from arkouda.numpy.dtypes import dtype as akdtype
 from arkouda.numpy.dtypes import float64 as akfloat64
-from arkouda.numpy.dtypes import float_scalars
 from arkouda.numpy.dtypes import int64 as akint64
-from arkouda.numpy.dtypes import int_scalars
 from arkouda.numpy.dtypes import uint64 as akuint64
-from arkouda.numpy.pdarrayclass import RegistrationError, create_pdarray, is_sorted, pdarray
+from arkouda.numpy.pdarrayclass import (
+    RegistrationError,
+    create_pdarray,
+    is_sorted,
+    pdarray,
+)
 from arkouda.numpy.pdarraycreation import arange, full
 from arkouda.numpy.random import default_rng
 from arkouda.numpy.sorting import argsort, sort
@@ -571,7 +576,12 @@ class GroupBy:
 
         """
         from arkouda.client import generic_msg
-        from arkouda.pandas.io import _file_type_to_int, _get_hdf_filetype, _mode_str_to_int, _repack_hdf
+        from arkouda.pandas.io import (
+            _file_type_to_int,
+            _get_hdf_filetype,
+            _mode_str_to_int,
+            _repack_hdf,
+        )
 
         # determine the format (single/distribute) that the file was saved in
         file_type = _get_hdf_filetype(prefix_path + "*")

--- a/arkouda/pandas/index.py
+++ b/arkouda/pandas/index.py
@@ -59,13 +59,15 @@ from __future__ import annotations
 
 import builtins
 import json
+
 from typing import TYPE_CHECKING, List, Literal, Optional, Tuple, TypeVar, Union
 from typing import cast as type_cast
 
 import numpy as np
+import pandas as pd
+
 from numpy import array as ndarray
 from numpy import dtype as npdtype
-import pandas as pd
 from typeguard import typechecked
 
 from arkouda.numpy.dtypes import bool_ as akbool
@@ -665,6 +667,7 @@ class Index:
 
         """
         import numpy as np
+
         from numpy import argsort as np_argsort
         from numpy import flip as np_flip
         from numpy import isnan as np_isnan
@@ -1344,7 +1347,12 @@ class Index:
         """
         from arkouda.client import generic_msg
         from arkouda.pandas.categorical import Categorical as Categorical_
-        from arkouda.pandas.io import _file_type_to_int, _get_hdf_filetype, _mode_str_to_int, _repack_hdf
+        from arkouda.pandas.io import (
+            _file_type_to_int,
+            _get_hdf_filetype,
+            _mode_str_to_int,
+            _repack_hdf,
+        )
 
         # determine the format (single/distribute) that the file was saved in
         file_type = _get_hdf_filetype(prefix_path + "*")
@@ -2278,7 +2286,12 @@ class MultiIndex(Index):
         """
         from arkouda.client import generic_msg
         from arkouda.pandas.categorical import Categorical as Categorical_
-        from arkouda.pandas.io import _file_type_to_int, _get_hdf_filetype, _mode_str_to_int, _repack_hdf
+        from arkouda.pandas.io import (
+            _file_type_to_int,
+            _get_hdf_filetype,
+            _mode_str_to_int,
+            _repack_hdf,
+        )
 
         if isinstance(self.levels, list):
             raise TypeError("Unable update hdf when Index levels are a list.")

--- a/arkouda/pandas/io.py
+++ b/arkouda/pandas/io.py
@@ -66,10 +66,22 @@ arkouda.categorical.Categorical, arkouda.index.Index, arkouda.index.MultiIndex
 import glob
 import json
 import os
-from typing import TYPE_CHECKING, Dict, List, Literal, Mapping, Optional, TypeVar, Union, cast
+
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    List,
+    Literal,
+    Mapping,
+    Optional,
+    TypeVar,
+    Union,
+    cast,
+)
 from warnings import warn
 
 import pandas as pd
+
 from typeguard import typechecked
 
 from arkouda.client_dtypes import IPv4
@@ -2397,6 +2409,7 @@ def snapshot(filename):
 
     """
     import inspect
+
     from types import ModuleType
 
     from arkouda.numpy.segarray import SegArray

--- a/arkouda/pandas/io_util.py
+++ b/arkouda/pandas/io_util.py
@@ -38,9 +38,10 @@ Examples
 
 """
 
+import shutil
+
 from os.path import isdir
 from pathlib import Path
-import shutil
 from typing import Any, Dict, Mapping
 
 from arkouda.logger import getArkoudaLogger

--- a/arkouda/pandas/join.py
+++ b/arkouda/pandas/join.py
@@ -1,12 +1,21 @@
-from typing import TYPE_CHECKING, Callable, Optional, Sequence, Tuple, TypeVar, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+)
 
 import numpy as np
+
 from typeguard import typechecked
 
 from arkouda.alignment import right_align
-from arkouda.numpy.dtypes import NUMBER_FORMAT_STRINGS
+from arkouda.numpy.dtypes import NUMBER_FORMAT_STRINGS, resolve_scalar_dtype
 from arkouda.numpy.dtypes import int64 as akint64
-from arkouda.numpy.dtypes import resolve_scalar_dtype
 from arkouda.numpy.pdarrayclass import create_pdarray, pdarray
 from arkouda.numpy.pdarraycreation import arange, array, ones, zeros
 from arkouda.numpy.pdarraysetops import concatenate, in1d

--- a/arkouda/pandas/match.py
+++ b/arkouda/pandas/match.py
@@ -40,8 +40,9 @@ arkouda.client.regexMaxCaptures
 
 """
 
-from enum import Enum
 import json
+
+from enum import Enum
 from typing import TYPE_CHECKING, TypeVar, cast
 
 from arkouda.numpy.pdarrayclass import create_pdarray, pdarray

--- a/arkouda/pandas/matcher.py
+++ b/arkouda/pandas/matcher.py
@@ -41,6 +41,7 @@ See Also
 
 import json
 import re
+
 from typing import TYPE_CHECKING, TypeVar, cast
 
 from arkouda.infoclass import list_symbol_table

--- a/arkouda/pandas/series.py
+++ b/arkouda/pandas/series.py
@@ -1,24 +1,33 @@
 from __future__ import annotations
 
-from builtins import str as builtin_str
 import json
 import operator
+
+from builtins import str as builtin_str
 from typing import TYPE_CHECKING, List, Literal, Optional, Tuple, TypeVar, Union, cast
 
 import numpy as np
 import pandas as pd
+
 from pandas._config import get_option
 from typeguard import typechecked
+
+import arkouda.pandas.dataframe
 
 from arkouda.accessor import CachedAccessor, DatetimeAccessor, StringAccessor
 from arkouda.alignment import lookup
 from arkouda.numpy.dtypes import bool_scalars, dtype, float64, int64
-from arkouda.numpy.pdarrayclass import RegistrationError, any, argmaxk, create_pdarray, pdarray
+from arkouda.numpy.pdarrayclass import (
+    RegistrationError,
+    any,
+    argmaxk,
+    create_pdarray,
+    pdarray,
+)
 from arkouda.numpy.pdarraycreation import arange, array, full, zeros
 from arkouda.numpy.pdarraysetops import argsort, concatenate, in1d, indexof1d
 from arkouda.numpy.strings import Strings
 from arkouda.numpy.util import get_callback, is_float
-import arkouda.pandas.dataframe
 from arkouda.pandas.groupbyclass import GroupBy, groupable_element_type
 from arkouda.pandas.index import Index, MultiIndex
 

--- a/arkouda/plotting.py
+++ b/arkouda/plotting.py
@@ -55,14 +55,17 @@ See Also
 from __future__ import annotations
 
 import math
+
 from typing import Optional, Tuple
 
-from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
 import numpy as np
+
+from matplotlib.figure import Figure
 from numpy.typing import NDArray
 
 import arkouda as ak
+
 from arkouda.categorical import Categorical
 from arkouda.dataframe import DataFrame
 from arkouda.groupbyclass import GroupBy

--- a/arkouda/scipy/_stats_py.py
+++ b/arkouda/scipy/_stats_py.py
@@ -1,10 +1,12 @@
 from collections import namedtuple
 
 import numpy as np
+
 from numpy import asarray
 from scipy.stats import chi2  # type: ignore
 
 import arkouda as ak
+
 from arkouda.numpy import float64
 from arkouda.numpy.dtypes import float64 as akfloat64
 from arkouda.scipy.special import xlogy

--- a/arkouda/scipy/sparrayclass.py
+++ b/arkouda/scipy/sparrayclass.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import builtins
-from typing import List, Optional, Sequence, Union
-from typing import cast
+
+from typing import List, Optional, Sequence, Union, cast
 from typing import cast as type_cast
 
 import numpy as np
+
 from typeguard import typechecked
 
 from arkouda.logger import getArkoudaLogger

--- a/arkouda/scipy/sparsematrix.py
+++ b/arkouda/scipy/sparsematrix.py
@@ -4,12 +4,12 @@ from typing import Union
 from typing import cast as type_cast
 
 import numpy as np
+
 from typeguard import typechecked
 
 from arkouda.logger import getArkoudaLogger
-from arkouda.numpy.dtypes import NumericDTypes
+from arkouda.numpy.dtypes import NumericDTypes, int64
 from arkouda.numpy.dtypes import dtype as akdtype
-from arkouda.numpy.dtypes import int64
 from arkouda.numpy.pdarrayclass import pdarray
 from arkouda.scipy.sparrayclass import create_sparray, sparray
 

--- a/arkouda/security.py
+++ b/arkouda/security.py
@@ -51,13 +51,14 @@ Examples
 
 """
 
-from collections import defaultdict
 import json
 import os
-from os.path import expanduser
-from pathlib import Path
 import platform
 import secrets
+
+from collections import defaultdict
+from os.path import expanduser
+from pathlib import Path
 
 from typeguard import typechecked
 

--- a/arkouda/testing/_asserters.py
+++ b/arkouda/testing/_asserters.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Literal, NoReturn, cast
 
 import numpy as np
+
 from pandas.api.types import is_bool, is_number
 from pandas.io.formats.printing import pprint_thing  # type: ignore
 

--- a/arkouda/testing/_equivalence_asserters.py
+++ b/arkouda/testing/_equivalence_asserters.py
@@ -2,11 +2,22 @@ from __future__ import annotations
 
 # Third Party
 import numpy as np
-from numpy import bool_, floating, integer, str_
 import pandas as pd
 
+from numpy import bool_, floating, integer, str_
+
 # First Party
-from arkouda import Categorical, DataFrame, Index, MultiIndex, SegArray, Series, Strings, array, pdarray
+from arkouda import (
+    Categorical,
+    DataFrame,
+    Index,
+    MultiIndex,
+    SegArray,
+    Series,
+    Strings,
+    array,
+    pdarray,
+)
 from arkouda.testing import (
     assert_almost_equal,
     assert_arkouda_array_equal,

--- a/benchmark_v2/aggregate_benchmark.py
+++ b/benchmark_v2/aggregate_benchmark.py
@@ -1,5 +1,6 @@
-from benchmark_utils import calc_num_bytes
 import pytest
+
+from benchmark_utils import calc_num_bytes
 
 import arkouda as ak
 

--- a/benchmark_v2/argsort_benchmark.py
+++ b/benchmark_v2/argsort_benchmark.py
@@ -1,6 +1,7 @@
-from benchmark_utils import calc_num_bytes
 import numpy as np
 import pytest
+
+from benchmark_utils import calc_num_bytes
 
 import arkouda as ak
 

--- a/benchmark_v2/array_create_benchmark.py
+++ b/benchmark_v2/array_create_benchmark.py
@@ -1,6 +1,7 @@
-from benchmark_utils import calc_num_bytes
 import numpy as np
 import pytest
+
+from benchmark_utils import calc_num_bytes
 
 import arkouda as ak
 

--- a/benchmark_v2/array_transfer_benchmark.py
+++ b/benchmark_v2/array_transfer_benchmark.py
@@ -1,5 +1,6 @@
-from benchmark_utils import calc_num_bytes
 import pytest
+
+from benchmark_utils import calc_num_bytes
 
 import arkouda as ak
 

--- a/benchmark_v2/bigint_conversion_benchmark.py
+++ b/benchmark_v2/bigint_conversion_benchmark.py
@@ -1,5 +1,6 @@
-from benchmark_utils import calc_num_bytes
 import pytest
+
+from benchmark_utils import calc_num_bytes
 
 import arkouda as ak
 

--- a/benchmark_v2/coargsort_benchmark.py
+++ b/benchmark_v2/coargsort_benchmark.py
@@ -1,6 +1,7 @@
-from benchmark_utils import calc_num_bytes
 import numpy as np
 import pytest
+
+from benchmark_utils import calc_num_bytes
 
 import arkouda as ak
 

--- a/benchmark_v2/conftest.py
+++ b/benchmark_v2/conftest.py
@@ -2,11 +2,13 @@ import importlib
 import importlib.util
 import os
 import sys
+
 from typing import Iterable, Iterator
 
 import pytest
 
 import arkouda as ak
+
 from arkouda.client import get_array_ranks
 from server_util.test.server_test_util import (
     TestRunningMode,

--- a/benchmark_v2/csv_io_benchmark.py
+++ b/benchmark_v2/csv_io_benchmark.py
@@ -1,9 +1,11 @@
-from glob import glob
 import os
+
+from glob import glob
 
 import pytest
 
 import arkouda as ak
+
 from benchmark_v2.benchmark_utils import calc_num_bytes
 
 

--- a/benchmark_v2/dataframe_indexing_benchmark.py
+++ b/benchmark_v2/dataframe_indexing_benchmark.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
-from benchmark_utils import calc_num_bytes
 import numpy as np
 import pytest
+
+from benchmark_utils import calc_num_bytes
 
 import arkouda as ak
 

--- a/benchmark_v2/find_benchmark.py
+++ b/benchmark_v2/find_benchmark.py
@@ -1,5 +1,6 @@
-from benchmark_utils import calc_num_bytes
 import pytest
+
+from benchmark_utils import calc_num_bytes
 
 import arkouda as ak
 

--- a/benchmark_v2/gather_benchmark.py
+++ b/benchmark_v2/gather_benchmark.py
@@ -1,5 +1,6 @@
-from benchmark_utils import calc_num_bytes
 import pytest
+
+from benchmark_utils import calc_num_bytes
 
 import arkouda as ak
 

--- a/benchmark_v2/generate_field_lookup_map.py
+++ b/benchmark_v2/generate_field_lookup_map.py
@@ -34,6 +34,7 @@ import re
 
 # Aggregate operations explicitly defined
 import arkouda as ak
+
 from arkouda.logger import getArkoudaLogger
 
 

--- a/benchmark_v2/groupby_benchmark.py
+++ b/benchmark_v2/groupby_benchmark.py
@@ -1,5 +1,6 @@
-from benchmark_utils import calc_num_bytes
 import pytest
+
+from benchmark_utils import calc_num_bytes
 
 import arkouda as ak
 

--- a/benchmark_v2/in1d_benchmark.py
+++ b/benchmark_v2/in1d_benchmark.py
@@ -1,5 +1,6 @@
-from benchmark_utils import calc_num_bytes
 import pytest
+
+from benchmark_utils import calc_num_bytes
 
 import arkouda as ak
 

--- a/benchmark_v2/io_benchmark.py
+++ b/benchmark_v2/io_benchmark.py
@@ -1,11 +1,14 @@
-from glob import glob
 import os
 import shutil
 
-from benchmark_utils import calc_num_bytes
+from glob import glob
+
 import pytest
 
+from benchmark_utils import calc_num_bytes
+
 import arkouda as ak
+
 from arkouda.pandas.io import to_parquet
 
 

--- a/benchmark_v2/optional/flatten_benchmark.py
+++ b/benchmark_v2/optional/flatten_benchmark.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 import arkouda as ak
+
 from benchmark_v2.benchmark_utils import calc_num_bytes
 
 

--- a/benchmark_v2/optional/index_benchmark.py
+++ b/benchmark_v2/optional/index_benchmark.py
@@ -1,6 +1,7 @@
 import pytest
 
 import arkouda as ak
+
 from benchmark_v2.benchmark_utils import calc_num_bytes
 
 

--- a/benchmark_v2/optional/shuffle_benchmark.py
+++ b/benchmark_v2/optional/shuffle_benchmark.py
@@ -1,6 +1,7 @@
 import pytest
 
 import arkouda as ak
+
 from benchmark_v2.benchmark_utils import calc_num_bytes
 
 

--- a/benchmark_v2/parquet-fixed-strings_benchmark.py
+++ b/benchmark_v2/parquet-fixed-strings_benchmark.py
@@ -1,5 +1,6 @@
-from benchmark_utils import calc_num_bytes
 import pytest
+
+from benchmark_utils import calc_num_bytes
 
 import arkouda as ak
 

--- a/benchmark_v2/reduce_benchmark.py
+++ b/benchmark_v2/reduce_benchmark.py
@@ -1,5 +1,6 @@
-from benchmark_utils import calc_num_bytes
 import pytest
+
+from benchmark_utils import calc_num_bytes
 
 import arkouda as ak
 

--- a/benchmark_v2/reformat_benchmark_results.py
+++ b/benchmark_v2/reformat_benchmark_results.py
@@ -8,13 +8,14 @@ automatically.
 
 import argparse
 import csv
-from datetime import datetime
 import json
 import logging
 import os
 import re
 import subprocess
 import sys
+
+from datetime import datetime
 from typing import Union
 
 

--- a/benchmark_v2/scan_benchmark.py
+++ b/benchmark_v2/scan_benchmark.py
@@ -1,6 +1,7 @@
-from benchmark_utils import calc_num_bytes
 import numpy as np
 import pytest
+
+from benchmark_utils import calc_num_bytes
 
 import arkouda as ak
 

--- a/benchmark_v2/scatter_benchmark.py
+++ b/benchmark_v2/scatter_benchmark.py
@@ -1,5 +1,6 @@
-from benchmark_utils import calc_num_bytes
 import pytest
+
+from benchmark_utils import calc_num_bytes
 
 import arkouda as ak
 

--- a/benchmark_v2/setops_benchmark.py
+++ b/benchmark_v2/setops_benchmark.py
@@ -1,6 +1,7 @@
-from benchmark_utils import calc_num_bytes
 import numpy as np
 import pytest
+
+from benchmark_utils import calc_num_bytes
 
 import arkouda as ak
 

--- a/benchmark_v2/setops_multiarray_benchmark.py
+++ b/benchmark_v2/setops_multiarray_benchmark.py
@@ -1,5 +1,6 @@
-from benchmark_utils import calc_num_bytes
 import pytest
+
+from benchmark_utils import calc_num_bytes
 
 import arkouda as ak
 

--- a/benchmark_v2/small-str-groupby.py
+++ b/benchmark_v2/small-str-groupby.py
@@ -1,5 +1,6 @@
-from benchmark_utils import calc_num_bytes
 import pytest
+
+from benchmark_utils import calc_num_bytes
 
 import arkouda as ak
 

--- a/benchmark_v2/sort_cases_benchmark.py
+++ b/benchmark_v2/sort_cases_benchmark.py
@@ -1,8 +1,10 @@
-from benchmark_utils import calc_num_bytes
 import numpy as np
 import pytest
 
+from benchmark_utils import calc_num_bytes
+
 import arkouda as ak
+
 from arkouda.numpy.sorting import SortingAlgorithm
 
 

--- a/benchmark_v2/split_benchmark.py
+++ b/benchmark_v2/split_benchmark.py
@@ -1,5 +1,6 @@
-from benchmark_utils import calc_num_bytes
 import pytest
+
+from benchmark_utils import calc_num_bytes
 
 import arkouda as ak
 

--- a/benchmark_v2/str_locality_benchmark.py
+++ b/benchmark_v2/str_locality_benchmark.py
@@ -1,5 +1,6 @@
-from benchmark_utils import calc_num_bytes
 import pytest
+
+from benchmark_utils import calc_num_bytes
 
 import arkouda as ak
 

--- a/benchmark_v2/stream_benchmark.py
+++ b/benchmark_v2/stream_benchmark.py
@@ -1,6 +1,7 @@
-from benchmark_utils import calc_num_bytes
 import numpy as np
 import pytest
+
+from benchmark_utils import calc_num_bytes
 
 import arkouda as ak
 

--- a/benchmark_v2/substring_search_benchmark.py
+++ b/benchmark_v2/substring_search_benchmark.py
@@ -1,5 +1,6 @@
-from benchmark_utils import calc_num_bytes
 import pytest
+
+from benchmark_utils import calc_num_bytes
 
 import arkouda as ak
 

--- a/benchmarks/IO.py
+++ b/benchmarks/IO.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 
 import argparse
-from enum import Enum
-from glob import glob
 import os
 import time
+
+from enum import Enum
+from glob import glob
 
 import numpy as np
 
 import arkouda as ak
+
 from server_util.test.server_test_util import get_default_temp_directory
 
 

--- a/benchmarks/csvIO.py
+++ b/benchmarks/csvIO.py
@@ -3,9 +3,17 @@
 import argparse
 import os
 
-from IO import COMPRESSIONS, FileFormat, check_correctness, remove_files, time_ak_read, time_ak_write
+from IO import (
+    COMPRESSIONS,
+    FileFormat,
+    check_correctness,
+    remove_files,
+    time_ak_read,
+    time_ak_write,
+)
 
 import arkouda as ak
+
 from server_util.test.server_test_util import get_default_temp_directory
 
 

--- a/benchmarks/multiIO.py
+++ b/benchmarks/multiIO.py
@@ -6,6 +6,7 @@ import os
 from IO import FileFormat, check_correctness, remove_files, time_ak_read, time_ak_write
 
 import arkouda as ak
+
 from server_util.test.server_test_util import get_default_temp_directory
 
 

--- a/benchmarks/parquet-fixed-strings.py
+++ b/benchmarks/parquet-fixed-strings.py
@@ -6,6 +6,7 @@ import time
 import pandas as pd
 
 import arkouda as ak
+
 from server_util.test.server_test_util import get_default_temp_directory
 
 

--- a/benchmarks/parquetIO.py
+++ b/benchmarks/parquetIO.py
@@ -3,9 +3,17 @@
 import argparse
 import os
 
-from IO import COMPRESSIONS, FileFormat, check_correctness, remove_files, time_ak_read, time_ak_write
+from IO import (
+    COMPRESSIONS,
+    FileFormat,
+    check_correctness,
+    remove_files,
+    time_ak_read,
+    time_ak_write,
+)
 
 import arkouda as ak
+
 from server_util.test.server_test_util import get_default_temp_directory
 
 

--- a/benchmarks/parquetMultiIO.py
+++ b/benchmarks/parquetMultiIO.py
@@ -7,6 +7,7 @@ from IO import COMPRESSIONS, FileFormat, remove_files
 from multiIO import check_correctness, time_ak_read, time_ak_write
 
 import arkouda as ak
+
 from server_util.test.server_test_util import get_default_temp_directory
 
 

--- a/benchmarks/sort-cases.py
+++ b/benchmarks/sort-cases.py
@@ -6,6 +6,7 @@ import time
 import numpy as np
 
 import arkouda as ak
+
 from arkouda.numpy.sorting import SortingAlgorithm
 
 

--- a/benchmarks/stream.py
+++ b/benchmarks/stream.py
@@ -6,6 +6,7 @@ import time
 import numpy as np
 
 import arkouda as ak
+
 from arkouda.numpy.dtypes import dtype as akdtype
 
 

--- a/converter/csv2hdf.py
+++ b/converter/csv2hdf.py
@@ -17,6 +17,7 @@ def import_local(path):
 
 if __name__ == "__main__":
     import argparse
+
     from multiprocessing import cpu_count
 
     import hdflow

--- a/converter/hdflow.py
+++ b/converter/hdflow.py
@@ -1,10 +1,12 @@
-from itertools import repeat
 import multiprocessing as mp
 import os
+
+from itertools import repeat
 
 import h5py
 import numpy as np
 import pandas as pd
+
 from tqdm import tqdm
 
 

--- a/examples/cos_dist.py
+++ b/examples/cos_dist.py
@@ -37,6 +37,7 @@ if __name__ == "__main__":
     import time
 
     import numpy as np
+
     from scipy.spatial import distance
 
     parser = argparse.ArgumentParser(description="Example of cosine distance/similarity in arkouda")

--- a/installers.py
+++ b/installers.py
@@ -44,8 +44,9 @@ installed via pip or setuptools.
 
 import os
 import shutil
-from subprocess import PIPE, CalledProcessError, Popen, TimeoutExpired, check_call
 import sys
+
+from subprocess import PIPE, CalledProcessError, Popen, TimeoutExpired, check_call
 
 from setuptools.command.build_py import build_py
 

--- a/pydoc/requirements.txt
+++ b/pydoc/requirements.txt
@@ -37,7 +37,6 @@ linkify-it-py
 flake8
 mypy>=0.931
 black
-isort
 pytest-json-report
 pytest-benchmark
 mathjax

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ dev = [
   "mypy>=0.931",
   "black==25.1.0",
   "ruff==0.11.2",
-  "isort==5.13.2",
   "flake8",
   "furo",
   "myst-parser",
@@ -88,63 +87,4 @@ versionfile_build  = "arkouda/_version.py"
 tag_prefix = "v"                     # "" if your tags look like v1.2.3 or 1.2.3; set "v" if needed
 parentdir_prefix = "arkouda-"
 
-
-[tool.isort]
-profile = "black"
-line_length = 105
-known_first_party = ["arkouda"]
-
-force_sort_within_sections = true
-lines_after_imports = 2
-#force_single_line = true
-lines_between_types = 1
-
-# Prefer stable one-per-line *only when there are several names*
-multi_line_output = 3            # vertical hanging indent
-#use_parentheses = true
-#include_trailing_comma = true
-#force_grid_wrap = 0     #   Force wrapping at N imports, N=0 means do not force
-
-# Keep these always on a single line
-single_line_exclusions = [
-  "__future__",
-  "typing",
-  "typing_extensions",
-]
-
-skip = [
-  "build",
-  ".bzr",
-  "node_modules",
-  "buck-out",
-  ".pytype",
-  "__pypackages__",
-  ".svn",
-  ".tox",
-  ".mypy_cache",
-  ".git",
-  ".hg",
-  ".direnv",
-  ".pants.d",
-  ".venv",
-  ".nox",
-  "dist",
-  ".eggs",
-  "venv",
-  "_build",
-  "runs",
-  "toys",
-  "versioneer.py",
-]
-extend_skip_glob = [
-  ".venv/*",
-  "*.pyi",
-  "dep/*",
-  "*__init__.py",
-  "*deprecated*",
-  "arkouda/versioneer.py",
-  "arkouda/toys/*",
-  "arkouda/benchmark_v2/*",
-  "arkouda/server_util/test/*",
-]
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -75,9 +75,9 @@ ignore = ["D100","D101","D102","D103","D105","D205","D401",
 
 [lint.isort]
 known-first-party = ["arkouda"]
-force-sort-within-sections = true
 combine-as-imports = false
 lines-after-imports = 2
+lines-between-types = 1
 force-single-line = false
 
 

--- a/server_util/test/generation.py
+++ b/server_util/test/generation.py
@@ -1,10 +1,12 @@
 import random
+
 from string import ascii_lowercase, ascii_uppercase, digits
 from typing import Mapping
 
-from context import arkouda as ak
 import h5py
 import numpy as np
+
+from context import arkouda as ak
 
 
 ALPHABET = ascii_lowercase

--- a/server_util/test/server_test_util.py
+++ b/server_util/test/server_test_util.py
@@ -14,14 +14,15 @@ stopped atexit or with a call to stop_arkouda_server().
 """
 
 import atexit
-from collections import namedtuple
 import contextlib
-from enum import Enum
 import logging
 import os
 import socket
 import subprocess
 import time
+
+from collections import namedtuple
+from enum import Enum
 
 
 class TestRunningMode(Enum):

--- a/tests/accessor_test.py
+++ b/tests/accessor_test.py
@@ -3,6 +3,7 @@ import importlib
 import pytest
 
 import arkouda as ak
+
 from arkouda import Series
 from arkouda.accessor import (
     CachedAccessor,

--- a/tests/array_api/array_creation.py
+++ b/tests/array_api/array_creation.py
@@ -5,6 +5,7 @@ import pytest
 
 import arkouda as ak
 import arkouda.array_api as xp
+
 from arkouda.testing import assert_almost_equivalent, assert_equivalent
 
 

--- a/tests/array_api/elementwise_functions.py
+++ b/tests/array_api/elementwise_functions.py
@@ -2,6 +2,7 @@ import pytest
 
 import arkouda as ak
 import arkouda.array_api as xp
+
 from arkouda.testing import assert_equal
 
 

--- a/tests/array_api/linalg.py
+++ b/tests/array_api/linalg.py
@@ -5,6 +5,7 @@ import pytest
 
 import arkouda as ak
 import arkouda.array_api as xp
+
 from arkouda.testing import assert_almost_equivalent
 
 

--- a/tests/array_api/sorting.py
+++ b/tests/array_api/sorting.py
@@ -3,6 +3,7 @@ import pytest
 
 import arkouda as ak
 import arkouda.array_api as xp
+
 from arkouda.testing import assert_equivalent
 
 

--- a/tests/checkpoint_test.py
+++ b/tests/checkpoint_test.py
@@ -1,13 +1,15 @@
-from datetime import datetime
 import json
 import os
+import tempfile
+
+from datetime import datetime
 from os import path
 from shutil import rmtree
-import tempfile
 
 import pytest
 
 import arkouda as ak
+
 from arkouda.pandas import io_util
 
 

--- a/tests/client_dtypes_test.py
+++ b/tests/client_dtypes_test.py
@@ -4,6 +4,7 @@ import random
 import pytest
 
 import arkouda as ak
+
 from arkouda import client_dtypes
 
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -3,6 +3,7 @@ import time
 import pytest
 
 import arkouda as ak
+
 from server_util.test.server_test_util import TestRunningMode, start_arkouda_server
 
 

--- a/tests/coargsort_test.py
+++ b/tests/coargsort_test.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 import arkouda as ak
+
 from arkouda.numpy.sorting import SortingAlgorithm
 
 

--- a/tests/comm_diagnostics_test.py
+++ b/tests/comm_diagnostics_test.py
@@ -1,6 +1,7 @@
 import pytest
 
 import arkouda as ak
+
 from arkouda import comm_diagnostics
 from arkouda.comm_diagnostics import (
     get_comm_diagnostics,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,19 +3,21 @@ import importlib.util
 import os
 import subprocess
 import sys
+
 from typing import Iterable, Iterator
 
 import pytest
 import scipy
 
 import arkouda as ak
+
 from server_util.test.server_test_util import (
     TestRunningMode,
     get_default_temp_directory,
+    is_multilocale_arkouda,  # TODO probably not needed
     start_arkouda_server,
     stop_arkouda_server,
 )
-from server_util.test.server_test_util import is_multilocale_arkouda  # TODO probably not needed
 
 
 os.environ["ARKOUDA_CLIENT_MODE"] = "API"

--- a/tests/extrema_test.py
+++ b/tests/extrema_test.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 import arkouda as ak
+
 from arkouda.testing import assert_arkouda_array_equivalent
 
 

--- a/tests/logger_test.py
+++ b/tests/logger_test.py
@@ -1,9 +1,11 @@
-from logging import DEBUG, INFO, WARN, FileHandler, StreamHandler
 import tempfile
+
+from logging import DEBUG, INFO, WARN, FileHandler, StreamHandler
 
 import pytest
 
 import arkouda as ak
+
 from arkouda import logger
 from arkouda.logger import LogLevel, getArkoudaClientLogger, getArkoudaLogger
 from arkouda.pandas import io_util

--- a/tests/message_test.py
+++ b/tests/message_test.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 import arkouda as ak
+
 from arkouda import message
 from arkouda.client import _json_args_to_str
 from arkouda.message import MessageFormat, MessageType, ReplyMessage, RequestMessage

--- a/tests/numpy/char_test.py
+++ b/tests/numpy/char_test.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 import arkouda as ak
+
 from arkouda.numpy import char
 from arkouda.testing import assert_arkouda_array_equivalent
 

--- a/tests/numpy/datetime_test.py
+++ b/tests/numpy/datetime_test.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 
 import arkouda as ak
+
 from arkouda.numpy import timeclass
 
 

--- a/tests/numpy/dtypes_test.py
+++ b/tests/numpy/dtypes_test.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 import arkouda as ak
+
 from arkouda.numpy import dtypes
 
 

--- a/tests/numpy/err_test.py
+++ b/tests/numpy/err_test.py
@@ -1,10 +1,12 @@
-from collections.abc import Iterator  # or: from typing import Iterator
 import logging
+
+from collections.abc import Iterator  # or: from typing import Iterator
 from typing import Literal
 
 import pytest
 
 import arkouda as ak
+
 from arkouda.numpy import err as akerr
 
 
@@ -162,7 +164,9 @@ class TestErr:
         from arkouda.numpy import err as akerr
 
         # Use the exact logger the module uses
-        from arkouda.numpy.err import _logger as module_logger  # test-only import of private symbol
+        from arkouda.numpy.err import (
+            _logger as module_logger,  # test-only import of private symbol
+        )
 
         class ListHandler(logging.Handler):
             def __init__(self, level=logging.ERROR):

--- a/tests/numpy/manipulation_functions_test.py
+++ b/tests/numpy/manipulation_functions_test.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 import arkouda as ak
+
 from arkouda.pandas.categorical import Categorical
 from arkouda.testing import assert_arkouda_array_equivalent, assert_equal
 

--- a/tests/numpy/numeric_test.py
+++ b/tests/numpy/numeric_test.py
@@ -1,17 +1,18 @@
-from math import isclose, prod, sqrt
 import random
 import warnings
+
+from math import isclose, prod, sqrt
 
 import numpy as np
 import pytest
 
 import arkouda as ak
+
 from arkouda.client import get_array_ranks, get_max_array_rank
 from arkouda.numpy.dtypes import dtype as akdtype
 from arkouda.numpy.dtypes import str_
-from arkouda.testing import assert_almost_equal
+from arkouda.testing import assert_almost_equal, assert_arkouda_array_equivalent
 from arkouda.testing import assert_almost_equivalent as ak_assert_almost_equivalent
-from arkouda.testing import assert_arkouda_array_equivalent
 
 
 ARRAY_TYPES = [ak.int64, ak.float64, ak.bool_, ak.uint64, str_]

--- a/tests/numpy/pdarray_creation_test.py
+++ b/tests/numpy/pdarray_creation_test.py
@@ -1,18 +1,19 @@
-from collections import deque
 import datetime as dt
 import math
 import statistics
+
+from collections import deque
 
 import numpy as np
 import pandas as pd
 import pytest
 
 import arkouda as ak
+
 from arkouda.numpy import newaxis, pdarraycreation
 from arkouda.numpy.util import _generate_test_shape, _infer_shape_from_size
-from arkouda.testing import assert_almost_equivalent, assert_arkouda_array_equal
+from arkouda.testing import assert_almost_equivalent, assert_arkouda_array_equal, assert_equivalent
 from arkouda.testing import assert_equal as ak_assert_equal
-from arkouda.testing import assert_equivalent
 
 
 INT_SCALARS = list(ak.numpy.dtypes.int_scalars.__args__)

--- a/tests/numpy/pdarrayclass_test.py
+++ b/tests/numpy/pdarrayclass_test.py
@@ -4,12 +4,12 @@ import numpy as np
 import pytest
 
 import arkouda as ak
+
 from arkouda.client import get_array_ranks, get_max_array_rank
 from arkouda.dtypes import bigint
 from arkouda.testing import assert_almost_equivalent as ak_assert_almost_equivalent
-from arkouda.testing import assert_arkouda_array_equivalent
+from arkouda.testing import assert_arkouda_array_equivalent, assert_equivalent
 from arkouda.testing import assert_equal as ak_assert_equal
-from arkouda.testing import assert_equivalent
 from arkouda.testing import assert_equivalent as ak_assert_equivalent
 
 

--- a/tests/numpy/pdarraymanipulation_tests.py
+++ b/tests/numpy/pdarraymanipulation_tests.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 import arkouda as ak
+
 from arkouda.client import get_array_ranks
 from arkouda.numpy import pdarraymanipulation
 from arkouda.testing import assert_arkouda_array_equivalent

--- a/tests/numpy/random_test.py
+++ b/tests/numpy/random_test.py
@@ -1,13 +1,16 @@
-from collections import Counter
-from itertools import product
 import math
 import os
 
+from collections import Counter
+from itertools import product
+
 import numpy as np
 import pytest
+
 from scipy import stats as sp_stats
 
 import arkouda as ak
+
 from arkouda.numpy import random
 from arkouda.scipy import chisquare as akchisquare
 from arkouda.testing import assert_almost_equivalent, assert_arkouda_array_equal

--- a/tests/numpy/segarray_test.py
+++ b/tests/numpy/segarray_test.py
@@ -1,12 +1,14 @@
 import math
 import os
-from string import ascii_letters, digits
 import tempfile
+
+from string import ascii_letters, digits
 
 import numpy as np
 import pytest
 
 import arkouda as ak
+
 from arkouda.pandas import io_util
 
 

--- a/tests/numpy/setops_test.py
+++ b/tests/numpy/setops_test.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 
 import arkouda as ak
+
 from arkouda.testing import assert_arkouda_array_equivalent
 
 

--- a/tests/numpy/sort_test.py
+++ b/tests/numpy/sort_test.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 import arkouda as ak
+
 from arkouda.client import get_array_ranks
 from arkouda.numpy.sorting import SortingAlgorithm
 from arkouda.testing import assert_arkouda_array_equivalent

--- a/tests/numpy/string_test.py
+++ b/tests/numpy/string_test.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 
 import arkouda as ak
+
 from arkouda import Strings
 from arkouda.numpy import strings
 from arkouda.testing import assert_equal as ak_assert_equal

--- a/tests/numpy/util_test.py
+++ b/tests/numpy/util_test.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 import arkouda as ak
+
 from arkouda.numpy import util
 from arkouda.numpy.util import may_share_memory, shares_memory
 from arkouda.testing import assert_arkouda_array_equivalent

--- a/tests/operator_test.py
+++ b/tests/operator_test.py
@@ -1,11 +1,13 @@
-from itertools import product
 import operator as op_
 import warnings
+
+from itertools import product
 
 import numpy as np
 import pytest
 
 import arkouda as ak
+
 from arkouda.testing import assert_almost_equivalent, assert_arkouda_array_equivalent
 
 

--- a/tests/optioned-server/auto-checkpoints.py
+++ b/tests/optioned-server/auto-checkpoints.py
@@ -1,9 +1,11 @@
 import os
+
 from time import sleep
 
 import pytest
 
 import arkouda as ak
+
 from arkouda.pandas.io_util import delete_directory, directory_exists
 
 

--- a/tests/optioned-server/conftest.py
+++ b/tests/optioned-server/conftest.py
@@ -18,11 +18,13 @@
 import importlib
 import re
 import subprocess
+
 from typing import Iterator
 
 import pytest
 
 import arkouda as ak
+
 from server_util.test.server_test_util import start_arkouda_server, stop_arkouda_server
 
 

--- a/tests/optioned-server/heartbeat.py
+++ b/tests/optioned-server/heartbeat.py
@@ -4,6 +4,7 @@ import time
 import pytest
 
 import arkouda as ak
+
 from server_util.test.server_test_util import get_server_info
 
 

--- a/tests/pandas/categorical_test.py
+++ b/tests/pandas/categorical_test.py
@@ -2,10 +2,12 @@ import os
 import tempfile
 
 import numpy as np
-from pandas import Categorical as pd_Categorical
 import pytest
 
+from pandas import Categorical as pd_Categorical
+
 import arkouda as ak
+
 from arkouda.numpy.pdarraycreation import array
 from arkouda.pandas import io, io_util
 from arkouda.pandas.categorical import Categorical

--- a/tests/pandas/dataframe_test.py
+++ b/tests/pandas/dataframe_test.py
@@ -4,12 +4,13 @@ import tempfile
 
 import numpy as np
 import pandas as pd
-from pandas.testing import assert_frame_equal
-from pandas.testing import assert_frame_equal as pd_assert_frame_equal
-from pandas.testing import assert_series_equal
 import pytest
 
+from pandas.testing import assert_frame_equal, assert_series_equal
+from pandas.testing import assert_frame_equal as pd_assert_frame_equal
+
 import arkouda as ak
+
 from arkouda.pandas import io_util
 from arkouda.scipy import chisquare as akchisquare
 from arkouda.testing import assert_frame_equal as ak_assert_frame_equal

--- a/tests/pandas/extension/arkouda_array_extension.py
+++ b/tests/pandas/extension/arkouda_array_extension.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 
 import arkouda as ak
+
 from arkouda import numeric_and_bool_scalars
 from arkouda.numpy.pdarrayclass import pdarray
 from arkouda.pandas.extension._arkouda_array import ArkoudaArray

--- a/tests/pandas/extension/arkouda_categorical_extension.py
+++ b/tests/pandas/extension/arkouda_categorical_extension.py
@@ -2,6 +2,7 @@ import pandas as pd
 import pytest
 
 import arkouda as ak
+
 from arkouda.pandas.extension import ArkoudaCategoricalArray
 from arkouda.testing import assert_equivalent
 

--- a/tests/pandas/extension/arkouda_extension.py
+++ b/tests/pandas/extension/arkouda_extension.py
@@ -2,7 +2,12 @@ import numpy as np
 import pytest
 
 import arkouda as ak
-from arkouda.pandas.extension import ArkoudaArray, ArkoudaCategoricalArray, ArkoudaStringArray
+
+from arkouda.pandas.extension import (
+    ArkoudaArray,
+    ArkoudaCategoricalArray,
+    ArkoudaStringArray,
+)
 from arkouda.pandas.extension._arkouda_extension_array import ArkoudaExtensionArray
 from arkouda.pdarrayclass import pdarray
 from arkouda.testing import assert_arkouda_array_equal, assert_equal

--- a/tests/pandas/extension/arkouda_strings_extension.py
+++ b/tests/pandas/extension/arkouda_strings_extension.py
@@ -2,6 +2,7 @@ import pandas as pd
 import pytest
 
 import arkouda as ak
+
 from arkouda.pandas.extension import ArkoudaStringArray
 from arkouda.testing import assert_equivalent
 

--- a/tests/pandas/extension/dataframes.py
+++ b/tests/pandas/extension/dataframes.py
@@ -2,6 +2,7 @@ import pandas as pd
 import pytest
 
 import arkouda as ak
+
 from arkouda.pandas.extension._arkouda_array import ArkoudaArray
 from arkouda.pandas.extension._arkouda_categorical_array import ArkoudaCategoricalArray
 from arkouda.pandas.extension._arkouda_string_array import ArkoudaStringArray

--- a/tests/pandas/extension/dtypes_extension.py
+++ b/tests/pandas/extension/dtypes_extension.py
@@ -175,6 +175,7 @@ class TestArkoudaDtypesExtension:
         import pandas.testing as pdt
 
         import arkouda as ak
+
         from arkouda.pandas.extension._arkouda_array import ArkoudaArray
 
         ak_arr = ak.array(data, dtype=dtype_cls().name)
@@ -189,6 +190,7 @@ class TestArkoudaDtypesExtension:
 
     def test_series_with_strings_dtype(self):
         import arkouda as ak
+
         from arkouda.pandas.extension._arkouda_string_array import ArkoudaStringArray
 
         a = ak.array(["a", "b", ""])
@@ -200,7 +202,10 @@ class TestArkoudaDtypesExtension:
 
     def test_series_with_categorical_dtype(self):
         import arkouda as ak
-        from arkouda.pandas.extension._arkouda_categorical_array import ArkoudaCategoricalArray
+
+        from arkouda.pandas.extension._arkouda_categorical_array import (
+            ArkoudaCategoricalArray,
+        )
 
         a = ak.Categorical(ak.array(["x", "y", "x"]))
         cea = ArkoudaCategoricalArray(a)

--- a/tests/pandas/extension/index.py
+++ b/tests/pandas/extension/index.py
@@ -1,6 +1,7 @@
 import pandas as pd
 
 import arkouda as ak
+
 from arkouda.pandas.extension._arkouda_array import ArkoudaArray
 from arkouda.pandas.extension._arkouda_string_array import ArkoudaStringArray
 

--- a/tests/pandas/extension/series.py
+++ b/tests/pandas/extension/series.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 
 import arkouda as ak
+
 from arkouda.pandas.extension._arkouda_array import ArkoudaArray
 
 
@@ -24,7 +25,9 @@ class TestSeriesExtension:
         assert taken.iloc[2] == "c"
 
     def test_series_from_categorical(self):
-        from arkouda.pandas.extension._arkouda_categorical_array import ArkoudaCategoricalArray
+        from arkouda.pandas.extension._arkouda_categorical_array import (
+            ArkoudaCategoricalArray,
+        )
 
         s_arr = ArkoudaCategoricalArray(ak.Categorical(ak.array(["high", "low", "medium", "low"])))
         s = pd.Series(s_arr)
@@ -32,7 +35,9 @@ class TestSeriesExtension:
         assert s.iloc[3] == "low"
 
     def test_categorical_series_take_with_fill(self):
-        from arkouda.pandas.extension._arkouda_categorical_array import ArkoudaCategoricalArray
+        from arkouda.pandas.extension._arkouda_categorical_array import (
+            ArkoudaCategoricalArray,
+        )
 
         s_arr = ArkoudaCategoricalArray(ak.Categorical(ak.array(["x", "y", "z"])))
         s = pd.Series(s_arr)

--- a/tests/pandas/groupby_test.py
+++ b/tests/pandas/groupby_test.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 
 import arkouda as ak
+
 from arkouda import GroupBy, concatenate
 from arkouda import sort as aksort
 from arkouda import sum as aksum

--- a/tests/pandas/index_test.py
+++ b/tests/pandas/index_test.py
@@ -3,20 +3,21 @@ import os
 import tempfile
 
 import numpy as np
-from numpy import dtype as npdtype
 import pandas as pd
+import pytest
+
+from numpy import dtype as npdtype
 from pandas import Categorical as pd_Categorical
 from pandas import Index as pd_Index
 from pandas.testing import assert_index_equal as pd_assert_index_equal
-import pytest
 
 import arkouda as ak
+
 from arkouda.numpy.dtypes import dtype
 from arkouda.numpy.pdarrayclass import pdarray
 from arkouda.pandas import io_util
 from arkouda.pandas.index import Index
-from arkouda.testing import assert_equal, assert_equivalent
-from arkouda.testing import assert_index_equal
+from arkouda.testing import assert_equal, assert_equivalent, assert_index_equal
 from arkouda.testing import assert_index_equal as ak_assert_index_equal
 
 

--- a/tests/pandas/io_test.py
+++ b/tests/pandas/io_test.py
@@ -3,17 +3,20 @@ import glob
 import os
 import shutil
 import tempfile
+
 from typing import List, Mapping, Union
 
 import h5py
 import numpy as np
 import pandas as pd
-from pandas.testing import assert_series_equal
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 
+from pandas.testing import assert_series_equal
+
 import arkouda as ak
+
 from arkouda import read_zarr, to_zarr
 from arkouda.pandas import io_util
 from arkouda.testing import assert_frame_equal

--- a/tests/pandas/join_test.py
+++ b/tests/pandas/join_test.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 import arkouda as ak
+
 from arkouda.pandas import join
 
 

--- a/tests/pandas/parquet_edge_test.py
+++ b/tests/pandas/parquet_edge_test.py
@@ -23,6 +23,7 @@ Environment Variables:
 
 import logging
 import os
+
 from pathlib import Path
 from typing import List, Optional, Union
 

--- a/tests/pandas/series_test.py
+++ b/tests/pandas/series_test.py
@@ -1,10 +1,12 @@
 import numpy as np
 import pandas as pd
-from pandas.testing import assert_frame_equal as pd_assert_frame_equal
-from pandas.testing import assert_series_equal as pd_assert_series_equal
 import pytest
 
+from pandas.testing import assert_frame_equal as pd_assert_frame_equal
+from pandas.testing import assert_series_equal as pd_assert_series_equal
+
 import arkouda as ak
+
 from arkouda.pandas.series import Series
 from arkouda.testing import assert_series_equal as ak_assert_series_equal
 

--- a/tests/plotting_test.py
+++ b/tests/plotting_test.py
@@ -9,6 +9,7 @@ import pytest
 
 import arkouda as ak
 
+
 # Import targets under test
 from arkouda.plotting import plot_dist
 

--- a/tests/regex_test.py
+++ b/tests/regex_test.py
@@ -1,10 +1,12 @@
-from itertools import chain
 import re
+
+from itertools import chain
 
 import numpy as np
 import pytest
 
 import arkouda as ak
+
 from arkouda.pandas import match, matcher
 
 

--- a/tests/scipy/scipy_test.py
+++ b/tests/scipy/scipy_test.py
@@ -1,9 +1,11 @@
 import numpy as np
 import pytest
+
 from scipy.stats import chisquare as scipy_chisquare
 from scipy.stats import power_divergence as scipy_power_divergence
 
 import arkouda as ak
+
 from arkouda.client import get_array_ranks, get_max_array_rank
 from arkouda.scipy import chisquare as ak_chisquare
 from arkouda.scipy import power_divergence as ak_power_divergence

--- a/tests/scipy/sparse_test.py
+++ b/tests/scipy/sparse_test.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 import arkouda as ak
+
 from arkouda.scipy.sparsematrix import (
     create_sparse_matrix,
     random_sparse_matrix,

--- a/tests/scipy/special_tests.py
+++ b/tests/scipy/special_tests.py
@@ -1,8 +1,10 @@
 import numpy as np
 import pytest
+
 from scipy.special import xlogy as scipy_xlogy
 
 import arkouda as ak
+
 from arkouda.scipy.special import xlogy
 
 

--- a/tests/security_test.py
+++ b/tests/security_test.py
@@ -1,5 +1,6 @@
-from os.path import expanduser
 import platform
+
+from os.path import expanduser
 
 from arkouda import security
 

--- a/tests/stats_test.py
+++ b/tests/stats_test.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 
 import arkouda as ak
+
 from arkouda.numpy.dtypes import bigint
 
 

--- a/tests/symbol_table_test.py
+++ b/tests/symbol_table_test.py
@@ -1,6 +1,7 @@
 import pytest
 
 import arkouda as ak
+
 from arkouda.numpy.pdarrayclass import RegistrationError
 
 

--- a/tests/test_no_ak_connect_doctest.py
+++ b/tests/test_no_ak_connect_doctest.py
@@ -5,8 +5,9 @@ docstrings, finds their "Examples" sections, and flags any doctest prompt lines 
 call ``ak.connect``. Failures report file, line number, and a small context block.
 """
 
-from pathlib import Path
 import re
+
+from pathlib import Path
 from typing import Generator, List, Tuple
 
 

--- a/tests/testing/asserters_test.py
+++ b/tests/testing/asserters_test.py
@@ -1,6 +1,7 @@
 import pytest
 
 import arkouda as ak
+
 from arkouda import Categorical, DataFrame, Index, MultiIndex, Series, cast
 from arkouda.testing import (
     assert_almost_equal,

--- a/toys/genops.py
+++ b/toys/genops.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+
 from string import Template
 
 

--- a/versioneer.py
+++ b/versioneer.py
@@ -312,10 +312,11 @@ import errno
 import functools
 import json
 import os
-from pathlib import Path
 import re
 import subprocess
 import sys
+
+from pathlib import Path
 from typing import Any, Callable, Dict, List, NoReturn, Optional, Tuple, Union, cast
 
 


### PR DESCRIPTION
This PR removes `isort` from the project as import sorting is handled by `ruff`.

Closes #5060 remove isort