### PR TITLE
Closes #5062:  ak.array overloads for more precise type checking

### DIFF
--- a/arkouda/numpy/numeric.py
+++ b/arkouda/numpy/numeric.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from enum import Enum
 import json
-from typing import TYPE_CHECKING, Any, List, Literal, Optional, Sequence, Tuple, TypeVar
+from typing import TYPE_CHECKING, Any, Iterable, List, Literal, Optional, Sequence, Tuple, TypeVar
 from typing import Union
 from typing import Union as _Union
 from typing import cast as type_cast
-from typing import no_type_check, overload
+from typing import get_args, no_type_check, overload
 
 import numpy as np
 from typeguard import typechecked
@@ -3620,7 +3620,9 @@ def percentile(
 
 
 def take(
-    a: Union[pdarray, Strings], indices: Union[numeric_scalars, pdarray], axis: Optional[int] = None
+    a: Union[pdarray, Strings],
+    indices: Union[numeric_scalars, pdarray, Iterable[numeric_scalars]],
+    axis: Optional[int] = None,
 ) -> pdarray:
     """
     Take elements from an array along an axis.
@@ -3631,9 +3633,9 @@ def take(
 
     Parameters
     ----------
-    a : pdarray
+    a : pdarray or Strings
         The array from which to take elements
-    indices : numeric_scalars or pdarray
+    indices : numeric_scalars or pdarray or Iterable[numeric_scalars]
         The indices of the values to extract. Also allow scalars for indices.
     axis : int, optional
         The axis over which to select values. By default, the flattened input array is used.
@@ -3673,11 +3675,12 @@ def take(
     if isinstance(indices, pdarray) and indices.ndim != 1:
         raise ValueError("indices must be 1D")
 
-    if not isinstance(indices, pdarray) and isinstance(indices, list):
-        indices_ = array(indices)
-    elif not isinstance(indices, pdarray):
+    indices_: pdarray
+    if isinstance(indices, Iterable):
+        indices_ = type_cast(pdarray, array(indices))
+    elif isinstance(indices, get_args(numeric_scalars)):
         indices_ = array([indices])
-    else:
+    elif isinstance(indices, pdarray):
         indices_ = indices
 
     result = create_pdarray(

--- a/arkouda/numpy/pdarraycreation.py
+++ b/arkouda/numpy/pdarraycreation.py
@@ -5,9 +5,11 @@ from typing import cast as type_cast
 from typing import overload
 
 import numpy as np
+from numpy.typing import NDArray
 import pandas as pd
 from typeguard import typechecked
 
+from arkouda.numpy._typing._typing import _NumericLikeDType, _StringDType
 from arkouda.numpy.dtypes import (
     NUMBER_FORMAT_STRINGS,
     DTypes,
@@ -165,6 +167,68 @@ def _deepcopy(a: pdarray) -> pdarray:
         args={"x": a},
     )
     return create_pdarray(rep_msg)
+
+
+# ======================
+# Overloads for ak.array
+# ======================
+
+
+@overload
+def array(
+    a: Union[pdarray, Strings, Iterable[Any], NDArray[Any]],
+    dtype: _StringDType = ...,
+    *,
+    copy: bool = ...,
+    max_bits: int = ...,
+) -> Strings: ...
+
+
+@overload
+def array(
+    a: Union[pdarray, Strings, Iterable[Any], NDArray[Any]],
+    dtype: _NumericLikeDType = ...,  # object covers np.dtype, type, int/float/bool dtypes, etc.
+    *,
+    copy: bool = ...,
+    max_bits: int = ...,
+) -> pdarray: ...
+
+
+@overload
+def array(
+    a: Union[pdarray, Strings, Iterable[Any], NDArray[Any]],
+    dtype=None,
+    *,
+    copy: bool = ...,
+    max_bits: int = ...,
+) -> Union[pdarray, Strings]: ...
+
+
+@overload
+def array(
+    a: Union[pdarray, List[_NumericLikeDType]],
+    dtype: Union[_StringDType, _NumericLikeDType, None] = None,
+    copy: bool = False,
+    max_bits: int = -1,
+) -> pdarray: ...
+
+
+@overload
+def array(
+    a: Union[Strings, Iterable[_StringDType]],
+    dtype: Union[_StringDType, _NumericLikeDType, None] = None,
+    copy: bool = False,
+    max_bits: int = -1,
+) -> Strings: ...
+
+
+@overload
+def array(
+    a: Union[pdarray, Strings, Iterable[Any], NDArray[Any]],
+    dtype: Union[_StringDType, _NumericLikeDType, None] = None,
+    copy: bool = False,
+    max_bits: int = -1,
+) -> Union[pdarray, Strings]: ...
 
 
 def array(

--- a/arkouda/pandas/series.py
+++ b/arkouda/pandas/series.py
@@ -364,9 +364,11 @@ class Series:
             Raised if val is not one of the supported types
 
         """
+        from typing import get_args
+
         if isinstance(val, list):
-            val = array(val)
-        if is_supported_scalar(val):
+            return array(val)
+        if isinstance(val, get_args(supported_scalars)):
             if dtype(type(val)) != self.values.dtype:
                 raise TypeError(
                     "Unexpected value type. Received {} but expected {}".format(
@@ -375,6 +377,7 @@ class Series:
                 )
             if isinstance(val, str):
                 raise TypeError("Cannot modify string type dataframes")
+            return val
         elif isinstance(val, Strings):
             raise TypeError("Cannot modify string type dataframes")
         elif isinstance(val, pdarray):
@@ -384,9 +387,9 @@ class Series:
                         dtype(type(val)), self.values.dtype
                     )
                 )
+            return val
         else:
             raise TypeError("cannot set with unsupported value type: {}".format(type(val)))
-        return val
 
     def __setitem__(
         self,


### PR DESCRIPTION
Implements ak.array overloads for more precise type checking.

Closes #5062:  ak.array overloads for more precise type checking