### PR TITLE
Closes #5064  ak.cast overloads for more precise type checking

### DIFF
--- a/arkouda/numpy/_typing/__init__.py
+++ b/arkouda/numpy/_typing/__init__.py
@@ -1,0 +1,24 @@
+from ._typing import (
+    ArkoudaNumericTypes,
+    BuiltinNumericTypes,
+    NumericDTypeTypes,
+    StringDTypeTypes,
+    _ArrayLikeNum,
+    _ArrayLikeStr,
+    _NumericLikeDType,
+    _StringDType,
+    is_string_dtype_hint,
+)
+
+
+__all__ = [
+    "BuiltinNumericTypes",
+    "ArkoudaNumericTypes",
+    "NumericDTypeTypes",
+    "StringDTypeTypes",
+    "_ArrayLikeNum",
+    "_ArrayLikeStr",
+    "_StringDType",
+    "_NumericLikeDType",
+    "is_string_dtype_hint",
+]

--- a/arkouda/numpy/_typing/_typing.py
+++ b/arkouda/numpy/_typing/_typing.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import builtins
+from typing import Any, Iterable, Literal, TypeAlias, TypeGuard
+from typing import Union as _Union
+
+import numpy as np
+
+from arkouda.numpy.dtypes import bigint
+from arkouda.numpy.dtypes import bool_ as ak_bool
+from arkouda.numpy.dtypes import float64 as ak_float64
+from arkouda.numpy.dtypes import int64 as ak_int64
+from arkouda.numpy.dtypes import str_
+from arkouda.numpy.dtypes import uint64 as ak_uint64
+from arkouda.numpy.strings import Strings
+
+
+BuiltinNumericTypes: TypeAlias = _Union[type[int], type[float], type[bool]]
+
+ArkoudaNumericTypes: TypeAlias = _Union[type[ak_int64], type[ak_float64], type[ak_uint64], type[ak_bool]]
+
+NumericDTypeTypes: TypeAlias = _Union[
+    Literal["bigint", "float64", "int8", "int64", "uint8", "uint64", "bool", "bool_"],
+    ArkoudaNumericTypes,
+    BuiltinNumericTypes,
+    np.dtype[Any],
+    bigint,
+    None,
+]
+
+StringDTypeTypes: TypeAlias = _Union[Literal["str", "str_"], type[str_], type[str], type[Strings]]
+
+_ArrayLikeNum: TypeAlias = _Union[
+    np.ndarray,  # keeps it simple; or list your NDArray[...]
+    _Union[Iterable[int], Iterable[float], Iterable[bool]],
+]
+
+_ArrayLikeStr: TypeAlias = _Union[
+    np.ndarray,  # or NDArray[np.str_]
+    Iterable[str],
+]
+
+
+_StringDType: TypeAlias = _Union[
+    Literal["str", "str_"],
+    type[str_],
+    type[str],
+    type[Strings],
+]
+
+_NumericLikeDType: TypeAlias = _Union[
+    # string literals for common names
+    Literal[
+        "bigint",
+        "float64",
+        "int8",
+        "int16",
+        "int32",
+        "int64",
+        "uint8",
+        "uint16",
+        "uint32",
+        "uint64",
+        "bool",
+        "bool_",
+    ],
+    type[builtins.bool],
+    type[np.bool_],
+    type[float],
+    type[int],
+    type[np.float64],
+    type[np.float32],
+    type[np.int8],
+    type[np.int16],
+    type[np.int32],
+    type[np.int64],
+    type[np.uint8],
+    type[np.uint16],
+    type[np.uint32],
+    type[np.uint64],
+    type[ak_int64],
+    type[ak_uint64],
+    type[ak_float64],
+    type[ak_bool],
+    type[bigint],
+]
+
+
+def is_string_dtype_hint(x: object) -> TypeGuard["_StringDType"]:
+    # accept the spellings you want to map to Arkouda Strings
+    return x in ("str", "str_") or x is str_ or x is str_ or x is Strings

--- a/arkouda/numpy/sorting.py
+++ b/arkouda/numpy/sorting.py
@@ -197,7 +197,7 @@ def coargsort(
             if a.dtype == bigint:
                 expanded_arrays.extend(a.bigint_to_uint_arrays())
             elif a.dtype == bool:
-                expanded_arrays.append(type_cast(pdarray, akcast(a, "int")))
+                expanded_arrays.append(akcast(a, "int"))
             else:
                 expanded_arrays.append(a)
         else:

--- a/arkouda/numpy/strings.py
+++ b/arkouda/numpy/strings.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import codecs
 import itertools
 import re
-from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple, TypeVar, Union
+from typing import cast
+from typing import cast as type_cast
 
 import numpy as np
 from numpy import dtype as npdtype
@@ -2492,7 +2494,7 @@ class Strings:
             else np.frombuffer(rep_msg, dt).copy()
         )
 
-    def astype(self, dtype: Union[np.dtype, str]) -> pdarray:
+    def astype(self, dtype: Union[np.dtype, str]) -> Union[pdarray, Strings]:
         """
         Cast values of Strings object to provided dtype.
 
@@ -2512,7 +2514,7 @@ class Strings:
         """
         from arkouda.numpy import cast as akcast
 
-        return akcast(self, dtype)
+        return type_cast(Union[pdarray, Strings], akcast(self, dtype))
 
     def to_parquet(
         self,
@@ -3055,7 +3057,7 @@ class Strings:
         sorted_array = create_pdarray(cast(str, repMsg))
         return sorted_array if ascending else flip(sorted_array)
 
-    def take(self, indices: Union[numeric_scalars, pdarray], axis: Optional[int] = None) -> pdarray:
+    def take(self, indices: Union[numeric_scalars, pdarray], axis: Optional[int] = None) -> Strings:
         """
         Take elements from the array along an axis.
 
@@ -3072,8 +3074,8 @@ class Strings:
 
         Returns
         -------
-        pdarray
-            The returned array has the same type as `a`.
+        Strings
+             A Strings containing the selected elements.
 
         Examples
         --------

--- a/arkouda/pandas/categorical.py
+++ b/arkouda/pandas/categorical.py
@@ -215,7 +215,9 @@ class Categorical:
             self.NAvalue = kwargs.get("NAvalue", "N/A")
             findNA = self.categories == self.NAvalue
             if findNA.any():
-                self._NAcode = int(akcast(findNA, akint64).argmax())
+                self._NAcode = int(
+                    type_cast(Union[np.uint, np.integer], akcast(findNA, akint64).argmax())
+                )
             else:
                 # Append NA value
                 self.categories = concatenate((self.categories, array([self.NAvalue])))

--- a/arkouda/scipy/sparsematrix.py
+++ b/arkouda/scipy/sparsematrix.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import Union
-from typing import cast
 from typing import cast as type_cast
 
 import numpy as np
@@ -133,7 +132,7 @@ def create_sparse_matrix(size: int, rows: pdarray, cols: pdarray, vals: pdarray,
     if layout not in ["CSR", "CSC"]:
         raise ValueError("layout must be 'CSR' or 'CSC'")
 
-    vals_dtype_name = cast(np.dtype, vals.dtype).name
+    vals_dtype_name = type_cast(np.dtype, vals.dtype).name
     # check dtype for error
     if vals_dtype_name not in NumericDTypes:
         raise TypeError(f"unsupported dtype {vals.dtype}")


### PR DESCRIPTION
Closes #5064  ak.cast overloads for more precise type checking