### PR TITLE
Closes #5030: concatenate gives unexpected zeros when axis=1

### DIFF
--- a/arkouda/numpy/pdarraysetops.py
+++ b/arkouda/numpy/pdarraysetops.py
@@ -478,7 +478,7 @@ def concatenate(
             prev_arr = arrays[i - 1]
             if isinstance(prev_arr, pdarray):
                 shape1 = prev_arr.shape
-                offsets[i] = offsets[i - 1] + shape1[0]
+                offsets[i] = offsets[i - 1] + shape1[axis]
         valid, axis_ = _integer_axis_validation(axis, arrays[0].ndim)
         if not valid:
             raise IndexError(f"{axis} is not a valid axis for array of rank {arrays[0].ndim}")


### PR DESCRIPTION
Turns out the `offsets` array was being calculated incorrectly, I think. Not sure how this wasn't noticed before.

To check it works, compile with dimensions 1 and 2 and do this:

```python
size = 10

t = ak.array([0.0, 0.111111, 0.222222, 0.333333, 0.444444, 0.555556, 0.666667, 0.777778, 0.888889, 1.0])

s0v = ak.array([0.0,0.0])

s1v = ak.array([4.0, 5.0])

n = 10

M = 2

out_dt = ak.float64

cols = []
for j in range(M):
    col = ((1 - t) * s0v[j] + t * s1v[j]).astype(out_dt)       # (n,)
    cols.append(col.reshape((n, 1)))    # (n,1)


print(cols)

mat = ak.concatenate(cols,axis=1)

print(mat)
```

Output should be
```python
array([array([0.00000000000000000 0.00000000000000000]) array([0.44444400000000001 0.55555500000000002]) array([0.88888800000000001 1.11111]) array([1.333332 1.6666650000000001]) array([1.777776 2.2222200000000001]) array([2.2222240000000002 2.7777800000000004]) array([2.666668 3.3333349999999999]) array([3.1111119999999999 3.88889]) array([3.5555560000000002 4.444445]) array([4.00000000000000000 5.00000000000000000])])
```

I'm honestly not sure how it didn't have an error before - it errored on my computer.

Closes #5030: concatenate gives unexpected zeros when axis=1