### PR TITLE
Closes #5067:  ak.generic_msg overloads for more precise type checking

### DIFF
--- a/arkouda/client.py
+++ b/arkouda/client.py
@@ -67,7 +67,7 @@ from enum import Enum
 import json
 import os
 import sys
-from typing import Dict, List, Mapping, Optional, Tuple, Union, cast
+from typing import Dict, List, Literal, Mapping, Optional, Tuple, Union, cast, overload
 import warnings
 
 import zmq  # for typechecking
@@ -1047,6 +1047,46 @@ def _json_args_to_str(json_obj: Optional[Dict] = None) -> Tuple[int, str]:
         param = ParameterObject.factory(key, val)
         j.append(json.dumps(param.dict))
     return len(j), json.dumps(j)
+
+
+@overload
+def generic_msg(
+    cmd: str,
+    args: Optional[Dict] = ...,
+    payload: None = ...,
+    send_binary: Literal[False] = ...,
+    recv_binary: Literal[False] = ...,
+) -> str: ...
+
+
+@overload
+def generic_msg(
+    cmd: str,
+    args: Optional[Dict] = ...,
+    payload: None = ...,
+    send_binary: Literal[False] = ...,
+    recv_binary: Literal[True] = ...,
+) -> memoryview: ...
+
+
+@overload
+def generic_msg(
+    cmd: str,
+    args: Optional[Dict],
+    payload: memoryview,
+    send_binary: Literal[True],
+    recv_binary: Literal[False] = ...,
+) -> str: ...
+
+
+@overload
+def generic_msg(
+    cmd: str,
+    args: Optional[Dict],
+    payload: memoryview,
+    send_binary: Literal[True],
+    recv_binary: Literal[True],
+) -> memoryview: ...
 
 
 def generic_msg(

--- a/arkouda/client_dtypes.py
+++ b/arkouda/client_dtypes.py
@@ -908,13 +908,10 @@ class IPv4(pdarray):
         file_type: Literal["single", "distribute"] = "distribute",
     ):
         """Override of the pdarray to_hdf to store the special object type."""
-        from typing import cast as type_cast
-
         from arkouda.client import generic_msg
         from arkouda.pandas.io import _file_type_to_int, _mode_str_to_int
 
-        return type_cast(
-            str,
+        return (
             generic_msg(
                 cmd="tohdf",
                 args={

--- a/arkouda/comm_diagnostics.py
+++ b/arkouda/comm_diagnostics.py
@@ -87,7 +87,6 @@ arkouda.DataFrame, arkouda.client.generic_msg
 """
 
 import sys
-from typing import cast as type_cast
 
 from arkouda.numpy.pdarrayclass import create_pdarray
 from arkouda.pandas.dataframe import DataFrame
@@ -140,7 +139,7 @@ def start_comm_diagnostics():
         cmd="startCommDiagnostics",
         args={},
     )
-    return type_cast(str, rep_msg)
+    return rep_msg
 
 
 def stop_comm_diagnostics():
@@ -159,7 +158,7 @@ def stop_comm_diagnostics():
         cmd="stopCommDiagnostics",
         args={},
     )
-    return type_cast(str, rep_msg)
+    return rep_msg
 
 
 def reset_comm_diagnostics():
@@ -178,7 +177,7 @@ def reset_comm_diagnostics():
         cmd="resetCommDiagnostics",
         args={},
     )
-    return type_cast(str, rep_msg)
+    return rep_msg
 
 
 def print_comm_diagnostics_table(print_empty_columns=False):
@@ -217,7 +216,7 @@ def print_comm_diagnostics_table(print_empty_columns=False):
     else:
         sys.stdout.write(df[[col for col in df.columns if ak_sum(df[col]) != 0]].to_markdown())
 
-    return type_cast(str, rep_msg)
+    return rep_msg
 
 
 def start_verbose_comm():
@@ -240,7 +239,7 @@ def start_verbose_comm():
         cmd="startVerboseComm",
         args={},
     )
-    return type_cast(str, rep_msg)
+    return rep_msg
 
 
 def stop_verbose_comm():
@@ -259,7 +258,7 @@ def stop_verbose_comm():
         cmd="stopVerboseComm",
         args={},
     )
-    return type_cast(str, rep_msg)
+    return rep_msg
 
 
 def get_comm_diagnostics_put():
@@ -279,7 +278,7 @@ def get_comm_diagnostics_put():
         cmd="getCommDiagnosticsPut",
         args={},
     )
-    return create_pdarray(type_cast(str, rep_msg))
+    return create_pdarray(rep_msg)
 
 
 def get_comm_diagnostics_get():
@@ -299,7 +298,7 @@ def get_comm_diagnostics_get():
         cmd="getCommDiagnosticsGet",
         args={},
     )
-    return create_pdarray(type_cast(str, rep_msg))
+    return create_pdarray(rep_msg)
 
 
 def get_comm_diagnostics_put_nb():
@@ -319,7 +318,7 @@ def get_comm_diagnostics_put_nb():
         cmd="getCommDiagnosticsPutNb",
         args={},
     )
-    return create_pdarray(type_cast(str, rep_msg))
+    return create_pdarray(rep_msg)
 
 
 def get_comm_diagnostics_get_nb():
@@ -339,7 +338,7 @@ def get_comm_diagnostics_get_nb():
         cmd="getCommDiagnosticsGetNb",
         args={},
     )
-    return create_pdarray(type_cast(str, rep_msg))
+    return create_pdarray(rep_msg)
 
 
 def get_comm_diagnostics_test_nb():
@@ -359,7 +358,7 @@ def get_comm_diagnostics_test_nb():
         cmd="getCommDiagnosticsTestNb",
         args={},
     )
-    return create_pdarray(type_cast(str, rep_msg))
+    return create_pdarray(rep_msg)
 
 
 def get_comm_diagnostics_wait_nb():
@@ -379,7 +378,7 @@ def get_comm_diagnostics_wait_nb():
         cmd="getCommDiagnosticsWaitNb",
         args={},
     )
-    return create_pdarray(type_cast(str, rep_msg))
+    return create_pdarray(rep_msg)
 
 
 def get_comm_diagnostics_try_nb():
@@ -399,7 +398,7 @@ def get_comm_diagnostics_try_nb():
         cmd="getCommDiagnosticsTryNb",
         args={},
     )
-    return create_pdarray(type_cast(str, rep_msg))
+    return create_pdarray(rep_msg)
 
 
 def get_comm_diagnostics_amo():
@@ -419,7 +418,7 @@ def get_comm_diagnostics_amo():
         cmd="getCommDiagnosticsAmo",
         args={},
     )
-    return create_pdarray(type_cast(str, rep_msg))
+    return create_pdarray(rep_msg)
 
 
 def get_comm_diagnostics_execute_on():
@@ -439,7 +438,7 @@ def get_comm_diagnostics_execute_on():
         cmd="getCommDiagnosticsExecuteOn",
         args={},
     )
-    return create_pdarray(type_cast(str, rep_msg))
+    return create_pdarray(rep_msg)
 
 
 def get_comm_diagnostics_execute_on_fast():
@@ -459,7 +458,7 @@ def get_comm_diagnostics_execute_on_fast():
         cmd="getCommDiagnosticsExecuteOnFast",
         args={},
     )
-    return create_pdarray(type_cast(str, rep_msg))
+    return create_pdarray(rep_msg)
 
 
 def get_comm_diagnostics_execute_on_nb():
@@ -479,7 +478,7 @@ def get_comm_diagnostics_execute_on_nb():
         cmd="getCommDiagnosticsExecuteOnNb",
         args={},
     )
-    return create_pdarray(type_cast(str, rep_msg))
+    return create_pdarray(rep_msg)
 
 
 def get_comm_diagnostics_cache_get_hits():
@@ -501,7 +500,7 @@ def get_comm_diagnostics_cache_get_hits():
         cmd="getCommDiagnosticsCacheGetHits",
         args={},
     )
-    return create_pdarray(type_cast(str, rep_msg))
+    return create_pdarray(rep_msg)
 
 
 def get_comm_diagnostics_cache_get_misses():
@@ -521,7 +520,7 @@ def get_comm_diagnostics_cache_get_misses():
         cmd="getCommDiagnosticsCacheGetMisses",
         args={},
     )
-    return create_pdarray(type_cast(str, rep_msg))
+    return create_pdarray(rep_msg)
 
 
 def get_comm_diagnostics_cache_put_hits():
@@ -541,7 +540,7 @@ def get_comm_diagnostics_cache_put_hits():
         cmd="getCommDiagnosticsCachePutHits",
         args={},
     )
-    return create_pdarray(type_cast(str, rep_msg))
+    return create_pdarray(rep_msg)
 
 
 def get_comm_diagnostics_cache_put_misses():
@@ -561,7 +560,7 @@ def get_comm_diagnostics_cache_put_misses():
         cmd="getCommDiagnosticsCachePutMisses",
         args={},
     )
-    return create_pdarray(type_cast(str, rep_msg))
+    return create_pdarray(rep_msg)
 
 
 def get_comm_diagnostics_cache_num_prefetches():
@@ -583,7 +582,7 @@ def get_comm_diagnostics_cache_num_prefetches():
         cmd="getCommDiagnosticsCacheNumPrefetches",
         args={},
     )
-    return create_pdarray(type_cast(str, rep_msg))
+    return create_pdarray(rep_msg)
 
 
 def get_comm_diagnostics_cache_num_page_readaheads():
@@ -603,7 +602,7 @@ def get_comm_diagnostics_cache_num_page_readaheads():
         cmd="getCommDiagnosticsCacheNumPageReadaheads",
         args={},
     )
-    return create_pdarray(type_cast(str, rep_msg))
+    return create_pdarray(rep_msg)
 
 
 def get_comm_diagnostics_cache_prefetch_unused():
@@ -626,7 +625,7 @@ def get_comm_diagnostics_cache_prefetch_unused():
         cmd="getCommDiagnosticsCachePrefetchUnused",
         args={},
     )
-    return create_pdarray(type_cast(str, rep_msg))
+    return create_pdarray(rep_msg)
 
 
 def get_comm_diagnostics_cache_prefetch_waited():
@@ -649,7 +648,7 @@ def get_comm_diagnostics_cache_prefetch_waited():
         cmd="getCommDiagnosticsCachePrefetchWaited",
         args={},
     )
-    return create_pdarray(type_cast(str, rep_msg))
+    return create_pdarray(rep_msg)
 
 
 def get_comm_diagnostics_cache_readahead_unused():
@@ -672,7 +671,7 @@ def get_comm_diagnostics_cache_readahead_unused():
         cmd="getCommDiagnosticsCacheReadaheadUnused",
         args={},
     )
-    return create_pdarray(type_cast(str, rep_msg))
+    return create_pdarray(rep_msg)
 
 
 def get_comm_diagnostics_cache_readahead_waited():
@@ -696,7 +695,7 @@ def get_comm_diagnostics_cache_readahead_waited():
         cmd="getCommDiagnosticsCacheReadaheadWaited",
         args={},
     )
-    return create_pdarray(type_cast(str, rep_msg))
+    return create_pdarray(rep_msg)
 
 
 def get_comm_diagnostics() -> DataFrame:

--- a/arkouda/numpy/numeric.py
+++ b/arkouda/numpy/numeric.py
@@ -312,10 +312,10 @@ def cast(
                 },
             )
             if errors == ErrorMode.return_validity:
-                a, b = type_cast(str, repMsg).split("+")
+                a, b = repMsg.split("+")
                 return create_pdarray(type_cast(str, a)), create_pdarray(type_cast(str, b))
             else:
-                return create_pdarray(type_cast(str, repMsg))
+                return create_pdarray(repMsg)
     elif isinstance(pda, Categorical):  # type: ignore
         if dt is Strings or dt in ["Strings", "str"] or dt == str_:
             return pda.categories[pda.codes]
@@ -362,7 +362,7 @@ def abs(pda: pdarray) -> pdarray:
             "pda": pda,
         },
     )
-    return create_pdarray(type_cast(str, repMsg))
+    return create_pdarray(repMsg)
 
 
 @typechecked
@@ -571,7 +571,7 @@ def sign(pda: pdarray) -> pdarray:
             "pda": pda,
         },
     )
-    return create_pdarray(type_cast(str, repMsg))
+    return create_pdarray(repMsg)
 
 
 @typechecked
@@ -610,7 +610,7 @@ def isfinite(pda: pdarray) -> pdarray:
             "pda": pda,
         },
     )
-    return create_pdarray(type_cast(str, repMsg))
+    return create_pdarray(repMsg)
 
 
 @typechecked
@@ -649,7 +649,7 @@ def isinf(pda: pdarray) -> pdarray:
             "pda": pda,
         },
     )
-    return create_pdarray(type_cast(str, repMsg))
+    return create_pdarray(repMsg)
 
 
 @typechecked
@@ -696,7 +696,7 @@ def isnan(pda: pdarray) -> pdarray:
             "pda": pda,
         },
     )
-    return create_pdarray(type_cast(str, repMsg))
+    return create_pdarray(repMsg)
 
 
 @typechecked
@@ -748,7 +748,7 @@ def log(pda: pdarray) -> pdarray:
             "pda": pda,
         },
     )
-    return create_pdarray(type_cast(str, repMsg))
+    return create_pdarray(repMsg)
 
 
 @typechecked
@@ -781,7 +781,7 @@ def log10(pda: pdarray) -> pdarray:
             "pda": pda,
         },
     )
-    return create_pdarray(type_cast(str, repMsg))
+    return create_pdarray(repMsg)
 
 
 @typechecked
@@ -814,7 +814,7 @@ def log2(pda: pdarray) -> pdarray:
             "pda": pda,
         },
     )
-    return create_pdarray(type_cast(str, repMsg))
+    return create_pdarray(repMsg)
 
 
 @typechecked
@@ -959,7 +959,7 @@ def exp(pda: pdarray) -> pdarray:
             "pda": pda,
         },
     )
-    return create_pdarray(type_cast(str, repMsg))
+    return create_pdarray(repMsg)
 
 
 @typechecked
@@ -1000,7 +1000,7 @@ def expm1(pda: pdarray) -> pdarray:
             "pda": pda,
         },
     )
-    return create_pdarray(type_cast(str, repMsg))
+    return create_pdarray(repMsg)
 
 
 @typechecked
@@ -1103,7 +1103,7 @@ def cumsum(pda: pdarray, axis: Optional[Union[int, None]] = None) -> pdarray:
             "includeInitial": False,
         },
     )
-    return create_pdarray(type_cast(str, repMsg))
+    return create_pdarray(repMsg)
 
 
 @typechecked
@@ -1173,7 +1173,7 @@ def cumprod(pda: pdarray, axis: Optional[Union[int, None]] = None) -> pdarray:
             "includeInitial": False,
         },
     )
-    return create_pdarray(type_cast(str, repMsg))
+    return create_pdarray(repMsg)
 
 
 @typechecked
@@ -1482,10 +1482,7 @@ def arctan2(
                 raise TypeError(f"{ts} is not an allowed num type for arctan2")
             argdict = {"a": num, "b": denom if where is True else denom[where]}  # type: ignore
 
-        repMsg = type_cast(
-            str,
-            generic_msg(cmd=cmdstring, args=argdict),
-        )
+        repMsg = generic_msg(cmd=cmdstring, args=argdict)
         ret = create_pdarray(repMsg)
         if where is True:
             return ret
@@ -1730,14 +1727,11 @@ def _general_helper(pda: pdarray, func: str, where: Union[bool, pdarray] = True)
 
     _datatype_check(pda.dtype, [ak_float64, ak_int64, ak_uint64], func)
     if where is True:
-        repMsg = type_cast(
-            str,
-            generic_msg(
-                cmd=f"{func}<{pda.dtype},{pda.ndim}>",
-                args={
-                    "x": pda,
-                },
-            ),
+        repMsg = generic_msg(
+            cmd=f"{func}<{pda.dtype},{pda.ndim}>",
+            args={
+                "x": pda,
+            },
         )
         return create_pdarray(repMsg)
     elif where is False:
@@ -1745,14 +1739,11 @@ def _general_helper(pda: pdarray, func: str, where: Union[bool, pdarray] = True)
     else:
         if where.dtype != bool:
             raise TypeError(f"where must have dtype bool, got {where.dtype} instead")
-        repMsg = type_cast(
-            str,
-            generic_msg(
-                cmd=f"{func}<{pda.dtype},{pda.ndim}>",
-                args={
-                    "x": pda[where],
-                },
-            ),
+        repMsg = generic_msg(
+            cmd=f"{func}<{pda.dtype},{pda.ndim}>",
+            args={
+                "x": pda[where],
+            },
         )
         return _merge_where(pda[:], where, create_pdarray(repMsg))
 
@@ -1945,17 +1936,14 @@ def hash(
                 expanded_pda.append(a)
         types_list = [a.objType for a in expanded_pda]
         names_list = [_hash_helper(a) for a in expanded_pda]
-        rep_msg = type_cast(
-            str,
-            generic_msg(
-                cmd="hashList",
-                args={
-                    "nameslist": names_list,
-                    "typeslist": types_list,
-                    "length": len(expanded_pda),
-                    "size": len(expanded_pda[0]),
-                },
-            ),
+        rep_msg = generic_msg(
+            cmd="hashList",
+            args={
+                "nameslist": names_list,
+                "typeslist": types_list,
+                "length": len(expanded_pda),
+                "size": len(expanded_pda[0]),
+            },
         )
         hashes = json.loads(rep_msg)
         return create_pdarray(hashes["upperHash"]), create_pdarray(hashes["lowerHash"])
@@ -1974,14 +1962,11 @@ def _hash_single(pda: pdarray, full: bool = True):
         return hash(pda.bigint_to_uint_arrays())
     _datatype_check(pda.dtype, [float, int, ak_uint64], "hash")
     hname = "hash128" if full else "hash64"
-    repMsg = type_cast(
-        str,
-        generic_msg(
-            cmd=f"{hname}<{pda.dtype},{pda.ndim}>",
-            args={
-                "x": pda,
-            },
-        ),
+    repMsg = generic_msg(
+        cmd=f"{hname}<{pda.dtype},{pda.ndim}>",
+        args={
+            "x": pda,
+        },
     )
     if full:
         a, b = repMsg.split("+")
@@ -2530,7 +2515,7 @@ def histogramdd(
             "num_samples": sample[0].size,
         },
     )
-    return create_pdarray(type_cast(str, repMsg)).reshape(bins), bin_boundaries
+    return create_pdarray(repMsg).reshape(bins), bin_boundaries
 
 
 @typechecked

--- a/arkouda/numpy/segarray.py
+++ b/arkouda/numpy/segarray.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 from typing import TYPE_CHECKING, Literal, Optional, Sequence, Tuple, TypeVar
-from typing import cast as type_cast
 
 import numpy as np
 
@@ -824,17 +823,14 @@ class SegArray:
         """
         from arkouda.client import generic_msg
 
-        repMsg = type_cast(
-            str,
-            generic_msg(
-                cmd="segmentedHash",
-                args={
-                    "objType": self.objType,
-                    "values": self.values,
-                    "segments": self.segments,
-                    "valObjType": self.values.objType,
-                },
-            ),
+        repMsg = generic_msg(
+            cmd="segmentedHash",
+            args={
+                "objType": self.objType,
+                "values": self.values,
+                "segments": self.segments,
+                "valObjType": self.values.objType,
+            },
         )
         h1, h2 = repMsg.split("+")
         return create_pdarray(h1), create_pdarray(h2)
@@ -876,21 +872,18 @@ class SegArray:
         from arkouda.client import generic_msg
         from arkouda.pandas.io import _file_type_to_int, _mode_str_to_int
 
-        return type_cast(
-            str,
-            generic_msg(
-                cmd="tohdf",
-                args={
-                    "values": self.values.name,
-                    "segments": self.segments.name,
-                    "dset": dataset,
-                    "write_mode": _mode_str_to_int(mode),
-                    "filename": prefix_path,
-                    "dtype": self.dtype,
-                    "objType": self.objType,
-                    "file_format": _file_type_to_int(file_type),
-                },
-            ),
+        return generic_msg(
+            cmd="tohdf",
+            args={
+                "values": self.values.name,
+                "segments": self.segments.name,
+                "dset": dataset,
+                "write_mode": _mode_str_to_int(mode),
+                "filename": prefix_path,
+                "dtype": self.dtype,
+                "objType": self.objType,
+                "file_format": _file_type_to_int(file_type),
+            },
         )
 
     def update_hdf(
@@ -1017,20 +1010,17 @@ class SegArray:
         if mode.lower() == "append":
             raise ValueError("Append mode is not supported for SegArray.")
 
-        return type_cast(
-            str,
-            generic_msg(
-                "writeParquet",
-                {
-                    "values": self.values.name,
-                    "segments": self.segments.name,
-                    "dset": dataset,
-                    "mode": _mode_str_to_int(mode),
-                    "prefix": prefix_path,
-                    "objType": self.objType,
-                    "compression": compression,
-                },
-            ),
+        return generic_msg(
+            "writeParquet",
+            {
+                "values": self.values.name,
+                "segments": self.segments.name,
+                "dset": dataset,
+                "mode": _mode_str_to_int(mode),
+                "prefix": prefix_path,
+                "objType": self.objType,
+                "compression": compression,
+            },
         )
 
     @classmethod

--- a/arkouda/numpy/timeclass.py
+++ b/arkouda/numpy/timeclass.py
@@ -233,25 +233,20 @@ class _AbstractBaseTime(pdarray):
         file_type: str = "distribute",
     ):
         """Override of the pdarray to_hdf to store the special dtype."""
-        from typing import cast as type_cast
-
         from arkouda.client import generic_msg
         from arkouda.pandas.io import _file_type_to_int, _mode_str_to_int
 
-        return type_cast(
-            str,
-            generic_msg(
-                cmd="tohdf",
-                args={
-                    "values": self,
-                    "dset": dataset,
-                    "write_mode": _mode_str_to_int(mode),
-                    "filename": prefix_path,
-                    "dtype": self.dtype,
-                    "objType": self.special_objType,
-                    "file_format": _file_type_to_int(file_type),
-                },
-            ),
+        return generic_msg(
+            cmd="tohdf",
+            args={
+                "values": self,
+                "dset": dataset,
+                "write_mode": _mode_str_to_int(mode),
+                "filename": prefix_path,
+                "dtype": self.dtype,
+                "objType": self.special_objType,
+                "file_format": _file_type_to_int(file_type),
+            },
         )
 
     def update_hdf(self, prefix_path: str, dataset: str = "array", repack: bool = True):

--- a/arkouda/pandas/index.py
+++ b/arkouda/pandas/index.py
@@ -1259,8 +1259,6 @@ class Index:
         determine the file format.
 
         """
-        from typing import cast as type_cast
-
         from arkouda.client import generic_msg
         from arkouda.pandas.categorical import Categorical as Categorical_
         from arkouda.pandas.io import _file_type_to_int, _mode_str_to_int
@@ -1291,22 +1289,19 @@ class Index:
                 )
             )
         ]
-        return type_cast(
-            str,
-            generic_msg(
-                cmd="tohdf",
-                args={
-                    "filename": prefix_path,
-                    "dset": dataset,
-                    "file_format": _file_type_to_int(file_type),
-                    "write_mode": _mode_str_to_int(mode),
-                    "objType": self.objType,
-                    "num_idx": 1,
-                    "idx": index_data,
-                    "idx_objTypes": [self.values.objType],  # this will be pdarray, strings, or cat
-                    "idx_dtypes": [str(self.values.dtype)],
-                },
-            ),
+        return generic_msg(
+            cmd="tohdf",
+            args={
+                "filename": prefix_path,
+                "dset": dataset,
+                "file_format": _file_type_to_int(file_type),
+                "write_mode": _mode_str_to_int(mode),
+                "objType": self.objType,
+                "num_idx": 1,
+                "idx": index_data,
+                "idx_objTypes": [self.values.objType],  # this will be pdarray, strings, or cat
+                "idx_dtypes": [str(self.values.dtype)],
+            },
         )
 
     def update_hdf(
@@ -2206,8 +2201,6 @@ class MultiIndex(Index):
         determine the file format.
 
         """
-        from typing import cast as type_cast
-
         from arkouda.client import generic_msg
         from arkouda.pandas.categorical import Categorical as Categorical_
         from arkouda.pandas.io import _file_type_to_int, _mode_str_to_int
@@ -2228,22 +2221,19 @@ class MultiIndex(Index):
             )
             for obj in self.levels
         ]
-        return type_cast(
-            str,
-            generic_msg(
-                cmd="tohdf",
-                args={
-                    "filename": prefix_path,
-                    "dset": dataset,
-                    "file_format": _file_type_to_int(file_type),
-                    "write_mode": _mode_str_to_int(mode),
-                    "objType": self.objType,
-                    "num_idx": len(self.levels),
-                    "idx": index_data,
-                    "idx_objTypes": [obj.objType for obj in self.levels],
-                    "idx_dtypes": [str(obj.dtype) for obj in self.levels],
-                },
-            ),
+        return generic_msg(
+            cmd="tohdf",
+            args={
+                "filename": prefix_path,
+                "dset": dataset,
+                "file_format": _file_type_to_int(file_type),
+                "write_mode": _mode_str_to_int(mode),
+                "objType": self.objType,
+                "num_idx": len(self.levels),
+                "idx": index_data,
+                "idx_objTypes": [obj.objType for obj in self.levels],
+                "idx_dtypes": [str(obj.dtype) for obj in self.levels],
+            },
         )
 
     def update_hdf(

--- a/arkouda/scipy/sparsematrix.py
+++ b/arkouda/scipy/sparsematrix.py
@@ -65,7 +65,7 @@ def random_sparse_matrix(
         },
     )
 
-    return create_sparray(type_cast(str, repMsg))
+    return create_sparray(repMsg)
 
 
 @typechecked
@@ -96,7 +96,7 @@ def sparse_matrix_matrix_mult(A, B: sparray) -> sparray:
         args={"arg1": A.name, "arg2": B.name},
     )
 
-    return create_sparray(type_cast(str, repMsg))
+    return create_sparray(repMsg)
 
 
 def create_sparse_matrix(size: int, rows: pdarray, cols: pdarray, vals: pdarray, layout: str) -> sparray:
@@ -143,4 +143,4 @@ def create_sparse_matrix(size: int, rows: pdarray, cols: pdarray, vals: pdarray,
         args={"rows": rows.name, "cols": cols.name, "vals": vals.name, "shape": shape},
     )
 
-    return create_sparray(type_cast(str, repMsg))
+    return create_sparray(repMsg)


### PR DESCRIPTION
Adds overloads for the `ak.generic_msg`, which improves type checking throughout the project.

Closes #5067:  ak.generic_msg overloads for more precise type checking