### PR TITLE
Closes #5076:  ArkoudaExtensionArray.copy

### DIFF
--- a/arkouda/pandas/extension/_arkouda_array.py
+++ b/arkouda/pandas/extension/_arkouda_array.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Iterable
 
 import numpy as np
 
@@ -29,7 +29,7 @@ class ArkoudaArray(ArkoudaExtensionArray, ExtensionArray):
     default_fill_value = -1
 
     def __init__(self, data):
-        if isinstance(data, np.ndarray):
+        if isinstance(data, (np.ndarray, Iterable)):
             data = ak_array(data)
         if not isinstance(data, pdarray):
             raise TypeError("Expected an Arkouda pdarray")
@@ -40,6 +40,10 @@ class ArkoudaArray(ArkoudaExtensionArray, ExtensionArray):
         # If pandas passes our own EA dtype, ignore it and infer from data
         if isinstance(dtype, _ArkoudaBaseDtype):
             dtype = dtype.numpy_dtype
+
+        if dtype is not None and hasattr(dtype, "numpy_dtype"):
+            dtype = dtype.numpy_dtype
+
         # If scalars is already a numpy array, we can preserve its dtype
         return cls(ak_array(scalars, dtype=dtype, copy=copy))
 
@@ -114,10 +118,6 @@ class ArkoudaArray(ArkoudaExtensionArray, ExtensionArray):
             return ak_full(self._data.size, False, dtype=bool)
 
         return isnan(self._data)
-
-    #   TODO:  use pdarray.copy()
-    def copy(self):
-        return ArkoudaArray(self._data[:])
 
     @property
     def dtype(self):

--- a/arkouda/pandas/extension/_arkouda_categorical_array.py
+++ b/arkouda/pandas/extension/_arkouda_categorical_array.py
@@ -45,9 +45,6 @@ class ArkoudaCategoricalArray(ArkoudaExtensionArray, ExtensionArray):
     def isna(self):
         return ak.zeros(self._data.size, dtype=ak.bool)
 
-    def copy(self):
-        return ArkoudaCategoricalArray(self._data[:])
-
     @property
     def dtype(self):
         return ArkoudaCategoricalDtype()

--- a/arkouda/pandas/extension/_arkouda_extension_array.py
+++ b/arkouda/pandas/extension/_arkouda_extension_array.py
@@ -91,6 +91,66 @@ class ArkoudaExtensionArray(ExtensionArray):
         """
         return len(self._data)
 
+    def copy(self, deep: bool = True):
+        """
+        Return a copy of the array.
+
+        Parameters
+        ----------
+        deep : bool, default True
+            Whether to make a deep copy of the underlying Arkouda data.
+            - If ``True``, the underlying server-side array is duplicated.
+            - If ``False``, a new ExtensionArray wrapper is created but the
+              underlying data is shared (no server-side copy).
+
+        Returns
+        -------
+        ArkoudaExtensionArray
+            A new instance of the same concrete subclass containing either a
+            deep copy or a shared reference to the underlying data.
+
+        Notes
+        -----
+        Pandas semantics:
+            ``deep=False`` creates a new wrapper but may share memory.
+            ``deep=True`` must create an independent copy of the data.
+
+        Arkouda semantics:
+            Arkouda arrays do not presently support views. Therefore:
+            - ``deep=False`` returns a new wrapper around the *same*
+              server-side array.
+            - ``deep=True`` forces a full server-side copy.
+
+        Examples
+        --------
+        Shallow copy (shared data):
+
+        >>> import arkouda as ak
+        >>> from arkouda.pandas.extension import ArkoudaArray
+        >>> arr = ArkoudaArray(ak.arange(5))
+        >>> c1 = arr.copy(deep=False)
+        >>> c1
+        ArkoudaArray([0 1 2 3 4])
+
+        Underlying data is the same object:
+
+        >>> arr._data is c1._data
+        True
+
+        Deep copy (independent server-side data):
+
+        >>> c2 = arr.copy(deep=True)
+        >>> c2
+        ArkoudaArray([0 1 2 3 4])
+
+        Underlying data is a distinct pdarray on the server:
+
+        >>> arr._data is c2._data
+        False
+        """
+        data = self._data.copy() if deep else self._data
+        return type(self)(data)
+
     @classmethod
     def _concat_same_type(cls, to_concat):
         """

--- a/arkouda/pandas/extension/_arkouda_string_array.py
+++ b/arkouda/pandas/extension/_arkouda_string_array.py
@@ -56,9 +56,6 @@ class ArkoudaStringArray(ArkoudaExtensionArray, ExtensionArray):
 
         return zeros(self._data.size, dtype="bool")
 
-    def copy(self):
-        return ArkoudaStringArray(self._data[:])
-
     def __eq__(self, other):
         return self._data == (other._data if isinstance(other, ArkoudaStringArray) else other)
 

--- a/arkouda/pandas/series.py
+++ b/arkouda/pandas/series.py
@@ -1583,7 +1583,6 @@ class Series:
 
         """
         from arkouda.numpy import isnan, where
-        from arkouda.numpy.segarray import SegArray
 
         value_: Union[supported_scalars, pdarray, Strings, Categorical, SegArray]
 

--- a/tests/pandas/extension/arkouda_array_extension.py
+++ b/tests/pandas/extension/arkouda_array_extension.py
@@ -6,7 +6,7 @@ import arkouda as ak
 
 from arkouda import numeric_and_bool_scalars
 from arkouda.numpy.pdarrayclass import pdarray
-from arkouda.pandas.extension._arkouda_array import ArkoudaArray
+from arkouda.pandas.extension import ArkoudaArray, ArkoudaCategoricalArray, ArkoudaStringArray
 from arkouda.testing import assert_equivalent
 
 


### PR DESCRIPTION
This PR adds the ArkoudaExtensionArray.copy to align with the pandas extension array API and associated unit tests.

Closes #5076:  ArkoudaExtensionArray.copy