### PR TITLE
Closes #5091: Allow the user to change the compiled Arkouda dimensions from make

### DIFF
--- a/pydoc/setup/BUILD.md
+++ b/pydoc/setup/BUILD.md
@@ -171,6 +171,40 @@ make instantiate_max=1024
 You can substitute `1024` with a higher value if needed.
 This flag passes `--instantiate-max=<value>` to the Chapel compiler during the build.
 
+### Overriding Supported Array Dimensions
+
+Arkouda generates its server-side command registry from a JSON configuration that specifies which array dimensionalities (`nd`) are supported.
+
+By default, this value is set to:
+
+```bash
+"nd": [1]
+```
+
+If you want to build Arkouda with support for additional array dimensions, you can override this at build time by specifying the environment variable `ARRAY_ND_MAX` when invoking `make`.
+
+For example, to support 1-, 2-, and 3-dimensional arrays:
+
+```bash
+make ARRAY_ND_MAX=3
+```
+
+Internally, this automatically expands the allowed dimensions to:
+
+```bash
+[1, 2, 3]
+```
+
+This mechanism is intended for developers experimenting with extended dimensionality and is not needed for standard Arkouda builds.
+
+You can combine this with other build-time overrides, such as increasing Chapel’s instantiation limit:
+
+```bash
+make ARRAY_ND_MAX=3 instantiation_max=1024
+```
+
+All such overrides work independently and can be mixed freely.
+
 ## Building the Arkouda Documentation
 The Arkouda documentation is [here](https://bears-r-us.github.io/arkouda/). This section is only necessary
 if you're updating the documentation.

--- a/src/registry/register_commands.py
+++ b/src/registry/register_commands.py
@@ -2,6 +2,7 @@ from enum import Enum
 import itertools
 import json
 import sys
+import os
 
 import chapel
 
@@ -1394,6 +1395,25 @@ def watermarkConfig(config):
 
 def main():
     config = json.load(open(sys.argv[1]))
+
+    # Allow user to override number of dimensions from make
+
+    nd_env = os.environ.get("ARRAY_ND_MAX")
+
+    if nd_env is not None:
+        try:
+            n = int(nd_env)
+            if n < 1:
+                raise ValueError("n must be >= 1")
+
+            old = config["parameter_classes"]["array"]["nd"]
+            new = list(range(1, n + 1))
+            config["parameter_classes"]["array"]["nd"] = new
+            print(f"Overriding compile ranks {old} from registration-config.json with {new}")
+        except ValueError:
+            # Optional: fail loudly or just warn
+            print(f"Warning: invalid n/ARRAY_ND_MAX value {nd_env!r}, ignoring", file=sys.stderr)
+
     source_files = getModuleFiles(sys.argv[2], sys.argv[3])
     (chpl_src, n) = register_commands(config, source_files)
     reg_config = make_reg_config_module(config)


### PR DESCRIPTION
Apparently make takes in variables and puts them in environment variables available in the `os` module in Python. So this just tells Python to look at a new environment variable I created and if it exists, modify the config.

Closes #5091: Allow the user to change the compiled Arkouda dimensions from make