### PR TITLE
Closes 5113, fixing behavior of floor division operator (//)

### DIFF
--- a/src/OperatorMsg.chpl
+++ b/src/OperatorMsg.chpl
@@ -410,7 +410,7 @@ module OperatorMsg
                 when "//=" { //floordiv
                     ref la = l.a;
                     ref ra = r.a;
-                    [(li,ri) in zip(la,ra)] li = floorDivisionHelper(li, ri);
+                    la = floorDivision(la, ra, real);
                 }
                 when "**=" { l.a **= r.a; }
                 when "%=" {
@@ -430,7 +430,7 @@ module OperatorMsg
                 when "//=" { //floordiv
                     ref la = l.a;
                     ref ra = r.a;
-                    [(li,ri) in zip(la,ra)] li = floorDivisionHelper(li, ri);
+                    la = floorDivision(la, ra, real);
                 }
                 when "**=" { l.a **= r.a; }
                 when "%=" {
@@ -450,7 +450,7 @@ module OperatorMsg
                 when "//=" { //floordiv
                     ref la = l.a;
                     ref ra = r.a;
-                    [(li,ri) in zip(la,ra)] li = floorDivisionHelper(li, ri);
+                    la = floorDivision(la, ra, real);
                 }
                 when "**=" { l.a **= r.a; }
                 when "%=" {
@@ -857,7 +857,7 @@ module OperatorMsg
                 when "/=" {l.a /= val;}//truediv
                 when "//=" { //floordiv
                     ref la = l.a;
-                    [li in la] li = floorDivisionHelper(li, val);
+                    la = floorDivision(la, val, real);
                 }
                 when "**=" { l.a **= val; }
                 when "%=" {

--- a/src/TimeClassMsg.chpl
+++ b/src/TimeClassMsg.chpl
@@ -57,7 +57,7 @@ module TimeClassMsg {
 
         forall (v, y, m, d, iso_y, is_ly, woy, doy, dow) in zip(valuesEntry.a, year, month, day, isoYear, is_leap_year, weekOfYear, dayOfYear, dayOfWeek) {
             // convert to seconds and create date
-            var t = dateTime.createUtcFromTimestamp(floorDivisionHelper(v, 10**9):int).getDate();
+            var t = dateTime.createUtcFromTimestamp(floorDivisionHelper(v, 10**9, int):int).getDate();
             (y, m, d, (iso_y, woy, dow)) = (t.year, t.month, t.day, t.isoWeekDate());
             dow -= 1;
             is_ly = isLeapYear(y);
@@ -112,11 +112,16 @@ module TimeClassMsg {
             var retname = st.nextName();
             var e = st.addEntry(retname, aD.size, int);
             if u != "day" {
-                [(ei,vi) in zip(e.a,values)] ei = floorDivisionHelper(vi, denominator):int % f;
+                forall i in e.a.domain {
+                    e.a[i] = floorDivisionHelper(values[i], denominator, int):int % f;
+                }
             }
             else {
                 // "day" is not modded, because it's the last unit
-                [(ei,vi) in zip(e.a,values)] ei = floorDivisionHelper(vi, denominator):int;
+                forall i in e.a.domain {
+                    e.a[i] = floorDivisionHelper(values[i], denominator, int):int;
+                }
+
             }
             attributesDict.add(u, "created %s".format(st.attrib(retname)));
             denominator *= f;  //denominator is product of previous factors


### PR DESCRIPTION
Closes #5113 

**Update** -- after a chat with Ryan, I realized that it wasn't really enough to correct the behavior of // without also distributing it.  So this version does that, with a new function called _floorDivision_, which calls a slightly changed _floorDivisionHelper_.

There are three versions of _floorDivision_, for the vv, vs and sv cases.

All of the calls to _floorDivisionHelper_ in BinOp, which were zippered foralls, now call _floorDivision_.

I also changed the calls to _floorDivisionHelper_ in TimeClassMsg.chpl and OperatorMsg.chpl.

Also at Ryan's suggestion, I removed "inline" from the declaration of _floorDivisionHelper_.  I haven't yet addressed _ModHelper_.  That will be in the PR for the behavior of the % operator.

---------

**Previously** -- I modified _floorDivisionHelper_ to handle more data types, and invoked it in places where chapel had been performing a simple (and incorrect) a/b division.