### PR TITLE
Closes #5108: Remove output file that is created in `io_util` docstring

### DIFF
--- a/arkouda/pandas/io_util.py
+++ b/arkouda/pandas/io_util.py
@@ -32,9 +32,10 @@ Notes
 
 Examples
 --------
->>> from arkouda.io_util import get_directory, write_line_to_file
+>>> from arkouda.io_util import delete_directory, get_directory, write_line_to_file
 >>> path = get_directory("tmp/output")
 >>> write_line_to_file(path / "log.txt", "Computation completed")
+>>> delete_directory(path)
 
 """
 


### PR DESCRIPTION
This PR (Closes #5108) removes a untracked file directory that is created in the `io_util` docstring.