### PR TITLE
Closes #5144: Clean up linking warning in make

### DIFF
--- a/make/Prologue.mk
+++ b/make/Prologue.mk
@@ -71,12 +71,19 @@ endif
 
 # add-path: Append custom paths for non-system software.
 define add-path
+# Always add headers for both C compilation and Chapel-generated C compilation
+INCLUDE_FLAGS += -I$(1)/include
+CHPL_FLAGS    += -I$(1)/include
+
+# Add lib64 if present (independent of lib)
 ifneq ("$(wildcard $(1)/lib64)","")
-  INCLUDE_FLAGS += -I$(1)/include -L$(1)/lib64
-  CHPL_FLAGS    += -I$(1)/include -L$(1)/lib64 --ldflags="-Wl,-rpath,$(1)/lib64"
+CHPL_FLAGS += -L$(1)/lib64 --ldflags="-Wl,-rpath,$(1)/lib64"
 endif
-INCLUDE_FLAGS += -I$(1)/include -L$(1)/lib
-CHPL_FLAGS    += -I$(1)/include -L$(1)/lib --ldflags="-Wl,-rpath,$(1)/lib"
+
+# Add lib if present
+ifneq ("$(wildcard $(1)/lib)","")
+CHPL_FLAGS += -L$(1)/lib --ldflags="-Wl,-rpath,$(1)/lib"
+endif
 endef
 # Usage: $(eval $(call add-path,/home/user/anaconda3/envs/arkouda))
 #                               ^ no space after comma


### PR DESCRIPTION
### **Fixed unused `-L` warnings during C++ compilation by separating compile and link flags**

This PR updates the `add-path` macro in the Makefile to avoid passing `-L` (library search paths) to compilation steps. Previously, `INCLUDE_FLAGS` contained both `-I` and `-L` paths, but `INCLUDE_FLAGS` is used for *compilation* (`clang++ -c`). Since the `-L` flag is only meaningful at *link* time, Clang emitted warnings like:

```
warning: argument unused during compilation: '-L<path>' [-Wunused-command-line-argument]
```

### **What changed**

* `INCLUDE_FLAGS` now contains only `-I` include paths.
* `CHPL_FLAGS` now contains the `-L` paths and corresponding `--ldflags="-Wl,-rpath,..."`.
* No functional changes to linked libraries; linking behavior remains the same.

### **Why this matters**

* Eliminates noisy compiler warnings during the Arrow helper builds.
* Cleans up the build system so compile/link flags are used correctly.
* Makes it easier to spot *actual* warnings in CI.

---

Closes #5144: Clean up linking warning in make