### PR TITLE
Closes #5146: Update Parquet file reading to use Arrow Result-returning OpenFile API

### DIFF
--- a/src/parquet/UtilParquet.cpp
+++ b/src/parquet/UtilParquet.cpp
@@ -22,7 +22,7 @@
       *errMsg = strdup(result.status().message().c_str());      \
       return ARROWERROR;                                        \
     }                                                           \
-    res = result.ValueOrDie();                                  \
+    res = std::move(result.ValueOrDie());                       \
   }
 
   // The `ARROWSTATUS_OK` macro should be used when calling an
@@ -60,7 +60,7 @@ int64_t cpp_getNumRows(const char* filename, char** errMsg) {
                    infile);
 
     std::unique_ptr<parquet::arrow::FileReader> reader;
-    ARROWSTATUS_OK(parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &reader));
+    ARROWRESULT_OK(parquet::arrow::OpenFile(infile, arrow::default_memory_pool()), reader);
   
     return reader -> parquet_reader() -> metadata() -> num_rows();
   } catch (const std::exception& e) {
@@ -79,9 +79,9 @@ static int getSchema(const char* filename,
                                                infile);
 
   std::unique_ptr<parquet::arrow::FileReader> reader;
-  ARROWSTATUS_OK(parquet::arrow::OpenFile(infile,
-                                          arrow::default_memory_pool(),
-                                          &reader));
+  ARROWRESULT_OK(parquet::arrow::OpenFile(infile,
+                                          arrow::default_memory_pool()),
+                 reader);
   ARROWSTATUS_OK(reader->GetSchema(out));
 
   return 0;
@@ -104,7 +104,7 @@ int cpp_getPrecision(const char* filename, const char* colname, char** errMsg) {
                    infile);
 
     std::unique_ptr<parquet::arrow::FileReader> reader;
-    ARROWSTATUS_OK(parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &reader));
+    ARROWRESULT_OK(parquet::arrow::OpenFile(infile, arrow::default_memory_pool()), reader);
 
     std::shared_ptr<arrow::Schema> sc;
     std::shared_ptr<arrow::Schema>* out = &sc;
@@ -190,7 +190,7 @@ int cpp_getType(const char* filename, const char* colname, char** errMsg) {
                    infile);
 
     std::unique_ptr<parquet::arrow::FileReader> reader;
-    ARROWSTATUS_OK(parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &reader));
+    ARROWRESULT_OK(parquet::arrow::OpenFile(infile, arrow::default_memory_pool()), reader);
 
     std::shared_ptr<arrow::Schema> sc;
     std::shared_ptr<arrow::Schema>* out = &sc;
@@ -253,7 +253,7 @@ int cpp_getListType(const char* filename, const char* colname, char** errMsg) {
                    infile);
 
     std::unique_ptr<parquet::arrow::FileReader> reader;
-    ARROWSTATUS_OK(parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &reader));
+    ARROWRESULT_OK(parquet::arrow::OpenFile(infile, arrow::default_memory_pool()), reader);
 
     std::shared_ptr<arrow::Schema> sc;
     std::shared_ptr<arrow::Schema>* out = &sc;
@@ -550,7 +550,7 @@ int cpp_appendColumnToParquet(const char* filename, void* chpl_arr,
     ARROWRESULT_OK(arrow::io::ReadableFile::Open(filename, arrow::default_memory_pool()),
                    infile);
     std::unique_ptr<parquet::arrow::FileReader> reader;
-    ARROWSTATUS_OK(parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &reader));
+    ARROWRESULT_OK(parquet::arrow::OpenFile(infile, arrow::default_memory_pool()), reader);
     // Use threads for case when reading a table with many columns
     reader->set_use_threads(true);
 
@@ -648,7 +648,7 @@ int cpp_getDatasetNames(const char* filename, char** dsetResult, bool readNested
     ARROWRESULT_OK(arrow::io::ReadableFile::Open(filename, arrow::default_memory_pool()),
                    infile);
     std::unique_ptr<parquet::arrow::FileReader> reader;
-    ARROWSTATUS_OK(parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &reader));
+    ARROWRESULT_OK(parquet::arrow::OpenFile(infile, arrow::default_memory_pool()), reader);
 
     std::shared_ptr<arrow::Schema> sc;
     std::shared_ptr<arrow::Schema>* out = &sc;


### PR DESCRIPTION
### **Modernize Parquet file reading to Arrow’s Result-returning API**

This PR updates all uses of `parquet::arrow::OpenFile` in `UtilParquet.cpp` to the non-deprecated Arrow 19+ API. The old API wrote into a `FileReader*` via an out-parameter, while the new API returns:

```cpp
arrow::Result<std::unique_ptr<parquet::arrow::FileReader>>
```

### **Key changes**

* Replaced all instances of:

  ```cpp
  ARROWSTATUS_OK(parquet::arrow::OpenFile(..., &reader));
  ```

  with:

  ```cpp
  ARROWRESULT_OK(parquet::arrow::OpenFile(...), reader);
  ```

* Updated the `ARROWRESULT_OK` macro to use:

  ```cpp
  res = std::move(result.ValueOrDie());
  ```

  to correctly extract the move-only `unique_ptr` returned by Arrow.

### **Why this change is needed**

* Removes Arrow 19 deprecation warnings from the build.
* Aligns Arkouda’s Parquet integration with the current Arrow API.
* Makes future Arrow upgrades simpler.
* No changes to behavior or performance; this is purely an API modernization.

### **Notes**

* All existing error-handling behavior remains unchanged.
* No impact to downstream Chapel code or server behavior.

---

Closes #5146: Update Parquet file reading to use Arrow Result-returning OpenFile API