### PR TITLE
Closes #5137:  bug in MultiIndex.ak.collect

### DIFF
--- a/arkouda/pandas/extension/_index_accessor.py
+++ b/arkouda/pandas/extension/_index_accessor.py
@@ -392,18 +392,9 @@ class ArkoudaIndexAccessor:
         # MultiIndex
         # --------------------------------------------------------------
         if isinstance(idx, pd.MultiIndex):
-            arrays = []
-            for level in idx.levels:
-                arr = level.array
-                if isinstance(arr, ArkoudaExtensionArray):
-                    akcol = getattr(arr, "_data", None)
-                    if akcol is None:
-                        raise TypeError("Arkouda-backed index level does not expose '_data'")
-                    arrays.append(akcol.to_ndarray())
-                else:
-                    arrays.append(level.to_numpy())
-
-            return pd.MultiIndex.from_arrays(arrays, names=list(idx.names))
+            # Materialize full tuples; works for both Arkouda-backed and plain.
+            tuples = list(idx.to_list())
+            return pd.MultiIndex.from_tuples(tuples, names=list(idx.names))
 
         raise TypeError(f"Unsupported index type for collect(): {type(idx)!r}")
 


### PR DESCRIPTION
# PR Description: Fix `IndexAccessor.collect` for MultiIndex and Add Tests

This pull request improves the behavior of `ArkoudaIndexAccessor.collect()` when
handling `pandas.MultiIndex` objects, especially those with Arkouda‑backed levels.

## Summary of Changes

### 1. **Correct MultiIndex Collection Logic**
Previously, `collect()` attempted to rebuild a MultiIndex by iterating over
`idx.levels`, which fails to preserve row ordering and duplicates and can break
for certain Arkouda‑backed level types.

This PR replaces that logic with:

```python
tuples = list(idx.to_list())
return pd.MultiIndex.from_tuples(tuples, names=list(idx.names))
```

This ensures:
- Correct preservation of all rows, including duplicates.
- Correct ordering semantics.
- Compatibility with both plain pandas and Arkouda‑backed MultiIndex levels.
- No reliance on internal `_data` attributes of extension arrays.

### 2. **New Test: `test_collect_multiindex_preserves_all_rows`**
A parametrized test verifies behavior for both:
- `arkouda_backed = False` (plain pandas MultiIndex)
- `arkouda_backed = True` (Arkouda-backed MultiIndex)

The test asserts:
- Result is always a *plain pandas* MultiIndex.
- Length, names, and row tuples match exactly.
- `.equals()` holds for the plain-pandas case.

### 3. **Minor Test Cleanup**
- Adds missing `pytest` import.
- Uses explicit `.to_list()` comparison for row-level correctness.

## Motivation

The old behavior caused incorrect reconstruction of MultiIndex objects,
particularly losing duplicate rows or failing to preserve row ordering when
levels were Arkouda-backed. This surfaced as failures in new tests validating
faithful round‑trip conversion.

## Impact

- Improves correctness and stability of MultiIndex operations under Arkouda.
- Ensures `.collect()` behaves predictably regardless of backend.
- No API breakage; existing callers receive more correct results.

## File Changes

- `arkouda/pandas/extension/_index_accessor.py`
- `tests/pandas/extension/index_accessor.py`

Closes #5137:  bug in MultiIndex.ak.collect