### PR TITLE
Fix pytest.ini outdated name for pdarraymanipulation_tests.py

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -57,7 +57,7 @@ testpaths =
     tests/numpy/char_test.py
     tests/numpy/dtypes_test.py
     tests/numpy/manipulation_functions_test.py
-    tests/numpy/array_manipulation_tests.py
+    tests/numpy/pdarraymanipulation_tests.py
     tests/numpy/numeric_test.py
     tests/numpy/numpy_test.py
     tests/numpy/random_test.py


### PR DESCRIPTION
Fixes `pytest.ini` outdated name for `pdarraymanipulation_tests.py`.