### PR TITLE
Closes #5168:  gh-pages set cancel-in-progress=true

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: gh-pages-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   ARKOUDA_QUICK_COMPILE: true
 


### PR DESCRIPTION
Cancel in-progress gh-pages documentation builds when a newer run starts, ensuring only the lated PR update is built and deployed.


Closes #5168:  gh-pages set cancel-in-progress=true