### PR TITLE
Remove unnecessary @pytest.mark.skip_if_max_rank_greater_than(1)

### DIFF
--- a/tests/comm_diagnostics_test.py
+++ b/tests/comm_diagnostics_test.py
@@ -41,7 +41,6 @@ diagnostic_stats_functions = [
 
 @pytest.mark.requires_chapel_module("CommDiagnosticsMsg")
 class TestCommDiagnostics:
-    @pytest.mark.skip_if_max_rank_greater_than(1)
     def test_comm_diagnostics_docstrings(self):
         import doctest
 
@@ -51,14 +50,12 @@ class TestCommDiagnostics:
         )
         assert result.failed == 0, f"Doctest failed: {result.failed} failures"
 
-    @pytest.mark.skip_if_max_rank_greater_than(1)
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_verbose_comm(self, size):
         start_verbose_comm()
         ak.zeros(size)
         stop_verbose_comm()
 
-    @pytest.mark.skip_if_max_rank_greater_than(1)
     @pytest.mark.parametrize("op", diagnostic_stats_functions)
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_comm_diagnostics_single_locale(self, op, size):
@@ -76,7 +73,6 @@ class TestCommDiagnostics:
         reset_comm_diagnostics()
         stop_comm_diagnostics()
 
-    @pytest.mark.skip_if_max_rank_greater_than(1)
     @pytest.mark.skip_if_nl_less_than(2)
     @pytest.mark.parametrize("size", pytest.prob_size)
     def test_comm_diagnostics_multi_locale(self, size):
@@ -93,7 +89,6 @@ class TestCommDiagnostics:
 
         stop_comm_diagnostics()
 
-    @pytest.mark.skip_if_max_rank_greater_than(1)
     def test_get_comm_diagnostics(self):
         start_comm_diagnostics()
 


### PR DESCRIPTION
Removes unnecessary `@pytest.mark.skip_if_max_rank_greater_than(1)` markings.