### PR TITLE
Closes 5172 -- adds overloads to hash in numeric.py

### DIFF
--- a/arkouda/numpy/numeric.py
+++ b/arkouda/numpy/numeric.py
@@ -1859,11 +1859,29 @@ def _hash_helper(a):
         return a.name
 
 
-# this is # type: ignored and doesn't actually do any type checking
-# the type hints are there as a reference to show which types are expected
-# type validation is done within the function
+HashableItems = Union[pdarray, Strings, SegArray, Categorical]
+HashableList = List[HashableItems]
+
+
+@overload
+def hash(pda: HashableItems, full: Literal[True] = True) -> Tuple[pdarray, pdarray]: ...
+
+
+@overload
+def hash(pda: HashableItems, full: Literal[False]) -> pdarray: ...
+
+
+@overload
+def hash(pda: HashableList, full: Literal[True] = True) -> Tuple[pdarray, pdarray]: ...
+
+
+@overload
+def hash(pda: HashableList, full: Literal[False]) -> pdarray: ...
+
+
+@typechecked
 def hash(
-    pda: Union[  # type: ignore
+    pda: Union[
         Union[pdarray, Strings, SegArray, Categorical],
         List[Union[pdarray, Strings, SegArray, Categorical]],
     ],


### PR DESCRIPTION
Closes #5172.

This adds overloads to the `hash` function in _numeric.py_, implements typechecking in `hash`, removes the `type: ignore` comment, and removes the comment describing that the function was not being typechecked.

It does not add overloads to the hash functions in _categorical, segarray or strings_, because all of those are of the form `def hash (self)`.

IMHO, the overloads are a bit wordy, but this is what mypy requires.  I did consult chatGPT, which did not recommend breaking out the elements of the Union, since that aspect doesn't affect the output type.  Only the value of `full` does.