### PR TITLE
Adds overloads to ak.full

### DIFF
--- a/arkouda/numpy/numeric.py
+++ b/arkouda/numpy/numeric.py
@@ -3767,7 +3767,7 @@ def minimum(x1: Union[pdarray, numeric_scalars], x2: Union[pdarray, numeric_scal
 
     if np.isscalar(tx1) and isinstance(tx2, pdarray):
         return (
-            full(nan, tx2.size) if np.isnan(tx1) else where(isnan(tx2), tx2, where(tx1 < tx2, tx1, tx2))
+            full(tx2.size, nan) if np.isnan(tx1) else where(isnan(tx2), tx2, where(tx1 < tx2, tx1, tx2))
         )
 
     # if tx2 was a scalar, then tx1 isn't (they can't both be, at this point).
@@ -3855,7 +3855,7 @@ def maximum(x1: Union[pdarray, numeric_scalars], x2: Union[pdarray, numeric_scal
 
     if np.isscalar(tx1) and isinstance(tx2, pdarray):
         return (
-            full(nan, tx2.size) if np.isnan(tx1) else where(isnan(tx2), tx2, where(tx1 > tx2, tx1, tx2))
+            full(tx2.size, nan) if np.isnan(tx1) else where(isnan(tx2), tx2, where(tx1 > tx2, tx1, tx2))
         )
 
     # if tx2 was a scalar, then tx1 isn't (they can't both be, at this point).

--- a/arkouda/numpy/util.py
+++ b/arkouda/numpy/util.py
@@ -710,6 +710,7 @@ def broadcast_to(x: Union[numeric_scalars, pdarray], shape: Union[int, Tuple[int
     from arkouda.numpy.pdarraycreation import full as akfull
 
     if _val_isinstance_of_union(x, numeric_scalars):
+        assert not isinstance(x, pdarray)  # Required for mypy
         return akfull(shape, x, dtype=type(x))
     elif isinstance(x, pdarray) and isinstance(shape, int):
         if x.ndim == 1 and x.size == shape:
@@ -1024,6 +1025,7 @@ def map(
         xtra_keys = gb_keys[in1d(gb_keys, mapping.index.values, invert=True)]
 
         if xtra_keys.size > 0:
+            nans: Union[pdarray, Strings]  # without this, mypy complains
             if not isinstance(mapping.values, (Strings, Categorical)):
                 nans = full(xtra_keys.size, np.nan, mapping.values.dtype)
             else:

--- a/tests/pandas/extension/arkouda_array_extension.py
+++ b/tests/pandas/extension/arkouda_array_extension.py
@@ -168,7 +168,7 @@ class TestArkoudaArrayExtension:
         ak_data = ak.arange(10)
         arr = ArkoudaArray(ak_data)
         na = arr.isna()
-        assert np.all(na == False)
+        assert (na == False).all()
 
     def test_isna_with_nan(self):
         from arkouda.testing import assert_equal


### PR DESCRIPTION
Closes #5173 

This one required a fair amount of work to satisfy mypy once the overloads were written.  I'm going to keep it in draft initially.

Notes:

In addition to the work on the overloads, mypy found an error in the order of calling parameters to full in my recent PR that changed ak.minimum and ak.maximum.  So that's been fixed.

Once the overloads were in place, mypy flagged an error in the use of full in isna function in the recent pandas extensions.  I addressed that by converting the result of ak.full to an ArkoudaArray before returning.
