### PR TITLE
Simplify `deepcopy` for potential performance improvements

### DIFF
--- a/src/GenSymIO.chpl
+++ b/src/GenSymIO.chpl
@@ -34,15 +34,7 @@
     proc deepcopy(x : [?d] ?t) : [d] t throws
         where (t==int || t==real || t==uint || t==bigint || t==bool) {
         var retVal = makeDistArray(d, t);
-        if numLocales == 1 {
-            forall (x_, r_) in zip (x, retVal) { r_ = x_ ; }
-            return retVal;
-        } else {
-            coforall loc in Locales do on loc {
-                var xLD = x.localSubdomain() ;
-                retVal[xLD] = x[xLD];
-            }
-        }
+        retVal = x;
         return retVal;
     }
 


### PR DESCRIPTION
Simplifies the `deepcopy` implementation to just use array assignment.

The previous implementation in the 1-node cases would result in fine-grained array accesses and in the multi-node case would do manual slicing/bulk copies. However, the builtin array assignment operator is already optimized for this. In the single node case for a trivial array it will result in a single `memcpy` and in the multi-node case it will result in a single memcpy per locale (assuming the same distribution).