### PR TITLE
Closes #5301:  make 3d

### DIFF
--- a/make/Arkouda.mk
+++ b/make/Arkouda.mk
@@ -66,4 +66,13 @@ CLEANALL_TARGETS += tags-clean
 .PHONY: tags-clean
 tags-clean:
 	$(RM) $(ARKOUDA_SOURCE_DIR)/TAGS
+	
+.PHONY: 2d 3d
+
+2d:
+	$(MAKE) ARRAY_ND_MAX=2 $(DEFAULT_TARGET)
+
+3d:
+	$(MAKE) ARRAY_ND_MAX=3 $(DEFAULT_TARGET)
+
 


### PR DESCRIPTION
## Summary
This PR adds two convenience Makefile targets, `make 2d` and `make 3d`, which rebuild the Arkouda server with a specific maximum array dimensionality by setting `ARRAY_ND_MAX` at compile time.

## Motivation
A common development and testing workflow involves building Arkouda with different maximum supported array dimensions. Previously, this required manually passing `ARRAY_ND_MAX` on the command line. These new targets provide a simple, discoverable, and standardized way to build 2D- or 3D-limited servers.

## Changes
- Add `.PHONY` targets `2d` and `3d` to `make/Arkouda.mk`
- Each target re-invokes `make` with:
  - `ARRAY_ND_MAX=2` for `make 2d`
  - `ARRAY_ND_MAX=3` for `make 3d`
- No changes to the core build logic; existing flag propagation is reused

## Usage
```bash
make 2d
make 3d
```

These targets support normal Make overrides, for example:
```bash
make 3d -j8
```

## Notes
Changing `ARRAY_ND_MAX` affects compile-time specialization and should be treated as producing incompatible binaries. Users may wish to clean between builds when switching dimensions.

Closes #5301:  make 3d