### PR TITLE
Closes #5312:  ExtensionArray.isna return type to match pandas

### DIFF
--- a/arkouda/pandas/extension/_arkouda_array.py
+++ b/arkouda/pandas/extension/_arkouda_array.py
@@ -6,6 +6,7 @@ from typing import cast as type_cast
 import numpy as np
 
 from numpy import ndarray
+from numpy.typing import NDArray
 from pandas.api.extensions import ExtensionArray
 
 from arkouda.numpy.dtypes import dtype as ak_dtype
@@ -188,15 +189,17 @@ class ArkoudaArray(ArkoudaExtensionArray, ExtensionArray):
         # Fallback: local cast
         return self.to_ndarray().astype(npdt, copy=copy)
 
-    def isna(self) -> ExtensionArray | ndarray[Any, Any]:
+    def isna(self) -> NDArray[np.bool_]:
         from arkouda.numpy import isnan
         from arkouda.numpy.pdarraycreation import full as ak_full
         from arkouda.numpy.util import is_float
 
         if not is_float(self._data):
-            return ak_full(self._data.size, False, dtype=bool)
+            return (
+                ak_full(self._data.size, False, dtype=bool).to_ndarray().astype(dtype=bool, copy=False)
+            )
 
-        return isnan(self._data)
+        return isnan(self._data).to_ndarray().astype(dtype=bool, copy=False)
 
     @property
     def dtype(self):

--- a/benchmark_v2/optional/multidim_binop_benchmark.py
+++ b/benchmark_v2/optional/multidim_binop_benchmark.py
@@ -1,8 +1,9 @@
+import functools
 import math
 import operator
 
 import pytest
-import functools
+
 import arkouda as ak
 
 from benchmark_v2.benchmark_utils import calc_num_bytes

--- a/tests/pandas/extension/arkouda_array_extension.py
+++ b/tests/pandas/extension/arkouda_array_extension.py
@@ -168,7 +168,7 @@ class TestArkoudaArrayExtension:
         ak_data = ak.arange(10)
         arr = ArkoudaArray(ak_data)
         na = arr.isna()
-        assert ak.all(na == False)
+        assert np.all(na == False)
 
     def test_isna_with_nan(self):
         from arkouda.testing import assert_equal
@@ -176,7 +176,7 @@ class TestArkoudaArrayExtension:
         ak_data = ak.array([1, np.nan, 2])
         arr = ArkoudaArray(ak_data)
         na = arr.isna()
-        expected = ak.array([False, True, False])
+        expected = np.array([False, True, False])
         assert_equal(na, expected)
 
     def test_copy(self):


### PR DESCRIPTION
# Fix `isna` return type to match pandas ExtensionArray contract

## Summary
This PR fixes a mypy override error in `ArkoudaArray.isna` by aligning its return type with the
`pandas.core.arrays.base.ExtensionArray` API. The method now **always returns a NumPy boolean ndarray**
instead of sometimes returning an Arkouda-backed array.

## Motivation
`ExtensionArray.isna()` is required by pandas to return a NumPy `bool` ndarray. Returning an
`ExtensionArray` violates the base-class contract and causes mypy to emit an override error.

## Changes
- Update the `isna` signature to return `NDArray[np.bool_]`.
- Convert the Arkouda `isnan` result to a NumPy boolean array before returning.
- Update the corresponding test to expect a NumPy array rather than an Arkouda array.

## Impact
- Resolves mypy override error.
- Brings Arkouda’s pandas ExtensionArray implementation into strict compliance with pandas’ API.
- No behavioral change for users beyond the concrete return type of `isna`.

## Testing
- Updated unit test verifies that `isna()` returns a NumPy boolean array with correct values.

Closes #5312:  ExtensionArray.isna return type to match pandas