### PR TITLE
Closes #5321:  Fix Codecov “missing BASE report” by enabling coverage uploads on main

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [pull_request, merge_group, workflow_dispatch]
+on:
+  push:
+    branches: [main]
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
 
 env:
   ARKOUDA_QUICK_COMPILE: true
@@ -551,7 +557,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}   # not needed for public repos
         files: coverage.xml
-        flags: ${{ matrix.python-version }}
+        flags: python-coverage
         fail_ci_if_error: true
 
 


### PR DESCRIPTION
# Fix Codecov “missing BASE report” by uploading coverage on `main`

Codecov reports a persistent warning on PRs:

> ⚠️ Please upload report for BASE (main@…)

Even when all modified lines are fully covered.

## Root cause
- CI did **not run on pushes to `main`**, so Codecov never received a base coverage report.
- The Codecov upload step used an **invalid flag** (`matrix.python-version`) in a job without that matrix.

## Changes
- Add a `push` trigger for the `main` branch so coverage is uploaded for the base commit.
- Replace the invalid Codecov flag with a stable constant flag (`python-coverage`).

## Result
- Codecov can compute correct base-vs-PR coverage.
- Removes “missing BASE report” warnings.
- Restores reliable coverage regression detection.

Closes #5321:  Fix Codecov “missing BASE report” by enabling coverage uploads on main