### PR TITLE
Closes #5332:  ArkoudaArray arithmetic methods add, sub, mul

### DIFF
--- a/arkouda/pandas/extension/_arkouda_extension_array.py
+++ b/arkouda/pandas/extension/_arkouda_extension_array.py
@@ -53,6 +53,7 @@ import numpy as np
 
 from numpy.typing import NDArray
 from pandas.api.extensions import ExtensionArray
+from pandas.core.arraylike import OpsMixin
 from typing_extensions import Self
 
 from arkouda.numpy.dtypes import all_scalars
@@ -75,7 +76,7 @@ def _ensure_numpy(x):
     return np.asarray(x)
 
 
-class ArkoudaExtensionArray(ExtensionArray):
+class ArkoudaExtensionArray(OpsMixin, ExtensionArray):
     default_fill_value: Optional[Union[all_scalars, str]] = -1
 
     _data: Any

--- a/pytest.ini
+++ b/pytest.ini
@@ -69,6 +69,7 @@ testpaths =
     tests/pandas/categorical_test.py
     tests/pandas/conversion_test.py
     tests/pandas/dataframe_test.py
+    tests/pandas/extension/arithmetic_ops.py
     tests/pandas/extension/arkouda_array_extension.py
     tests/pandas/extension/arkouda_categorical_extension.py
     tests/pandas/extension/arkouda_extension.py

--- a/tests/pandas/extension/arithmetic_ops.py
+++ b/tests/pandas/extension/arithmetic_ops.py
@@ -1,0 +1,137 @@
+import operator
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from arkouda.pandas.extension import ArkoudaArray
+
+
+# ---- helpers ---------------------------------------------------------------
+
+
+def _ea(values, dtype="ak_int64"):
+    # construct the ExtensionArray via pandas dtype resolution
+    return pd.array(values, dtype=dtype)
+
+
+def _np(values, dtype=np.int64):
+    return np.array(values, dtype=dtype)
+
+
+class TestArkoudaArrayExtensionArithmeticOps:
+    # ---- core: dunder dispatch exists ------------------------------------------
+
+    def test_dunder_add_exists_on_ea_type(self):
+        x = _ea([1, 2, 3], dtype="ak_int64")
+        assert hasattr(type(x), "__add__")
+        assert hasattr(type(x), "__radd__")
+
+    @pytest.mark.parametrize(
+        "op, np_op",
+        [
+            (operator.add, operator.add),
+            (operator.sub, operator.sub),
+            (operator.mul, operator.mul),
+            (operator.truediv, operator.truediv),
+            (operator.floordiv, operator.floordiv),
+            (operator.mod, operator.mod),
+            (operator.pow, operator.pow),
+        ],
+    )
+    def test_binary_ops_ea_ea_dispatch_and_values_int64(self, op, np_op):
+        x = _ea([1, 2, 3], dtype="ak_int64")
+        y = _ea([10, 20, 30], dtype="ak_int64")
+
+        # IMPORTANT: exercise Python operator dispatch (dunder), not _arith_method directly
+        out = op(x, y)
+
+        assert isinstance(out, ArkoudaArray)
+
+        expected = np_op(_np([1, 2, 3]), _np([10, 20, 30]))
+        # pandas may produce float for true division; your EA currently converts via to_numpy
+        np.testing.assert_allclose(out.to_numpy(), expected)
+
+    @pytest.mark.parametrize(
+        "op, np_op",
+        [
+            (operator.add, operator.add),
+            (operator.sub, operator.sub),
+            (operator.mul, operator.mul),
+            (operator.truediv, operator.truediv),
+            (operator.floordiv, operator.floordiv),
+            (operator.mod, operator.mod),
+            (operator.pow, operator.pow),
+        ],
+    )
+    def test_binary_ops_ea_scalar_dispatch_and_values_int64(self, op, np_op):
+        x = _ea([1, 2, 3], dtype="ak_int64")
+        s = 5
+
+        out = op(x, s)
+        assert isinstance(out, ArkoudaArray)
+
+        expected = np_op(_np([1, 2, 3]), s)
+        np.testing.assert_allclose(out.to_numpy(), expected)
+
+    @pytest.mark.parametrize(
+        "op, np_op",
+        [
+            (operator.add, operator.add),
+            (operator.sub, operator.sub),
+            (operator.mul, operator.mul),
+            (operator.truediv, operator.truediv),
+            (operator.floordiv, operator.floordiv),
+            (operator.mod, operator.mod),
+            (operator.pow, operator.pow),
+        ],
+    )
+    def test_reflected_ops_scalar_ea_dispatch_and_values_int64(self, op, np_op):
+        x = _ea([1, 2, 3], dtype="ak_int64")
+        s = 5
+
+        # reflected: scalar op EA
+        out = op(s, x)
+        assert isinstance(out, ArkoudaArray)
+
+        expected = np_op(s, _np([1, 2, 3]))
+        np.testing.assert_allclose(out.to_numpy(), expected)
+
+    # ---- dtype coverage: float64 ------------------------------------------------
+
+    def test_add_float64(self):
+        x = _ea([1.5, 2.5, 3.0], dtype="ak_float64")
+        y = _ea([10.0, 20.0, 30.0], dtype="ak_float64")
+
+        out = x + y
+        assert isinstance(out, ArkoudaArray)
+        np.testing.assert_allclose(out.to_numpy(), _np([11.5, 22.5, 33.0], dtype=np.float64))
+
+    def test_truediv_int64_produces_expected_values(self):
+        # This test is intentionally about values; dtype may be float depending on backend behavior.
+        x = _ea([1, 2, 3], dtype="ak_int64")
+        y = _ea([2, 2, 2], dtype="ak_int64")
+
+        out = x / y
+        np.testing.assert_allclose(out.to_numpy(), np.array([0.5, 1.0, 1.5]))
+
+    # ---- error paths ------------------------------------------------------------
+
+    def test_add_incompatible_type_raises_typeerror(self):
+        x = _ea([1, 2, 3], dtype="ak_int64")
+
+        # choose something your _arith_method rejects (non-scalar, non-EA)
+        class Weird:
+            pass
+
+        with pytest.raises(TypeError):
+            _ = x + Weird()
+
+    def test_add_length_mismatch_raises(self):
+        x = _ea([1, 2, 3], dtype="ak_int64")
+        y = _ea([10, 20], dtype="ak_int64")
+
+        # depending on arkouda/pandas behavior, this could be ValueError or something else;
+        # but it should definitely not silently succeed.
+        with pytest.raises(ValueError):
+            _ = x + y


### PR DESCRIPTION
## Summary
This PR enables native Python arithmetic operators (e.g. `+`, `-`, `*`, `/`) for Arkouda-backed pandas `ExtensionArray`s by integrating pandas’ `OpsMixin` into the shared base class. It also adds a focused test suite to ensure operator dispatch routes through pandas’ ExtensionArray arithmetic protocol rather than relying on direct `_arith_method` calls.

## Key changes
- Add `OpsMixin` to `ArkoudaExtensionArray`, enabling Python dunder operators (`__add__`, `__sub__`, etc.) for all Arkouda-backed ExtensionArrays.
- Add a new test module (`tests/pandas/extension/arithmetic_ops.py`) that:
  - Verifies operator dunder methods exist on Arkouda ExtensionArrays
  - Exercises true Python operator dispatch (`x + y`, `x + scalar`, `scalar + x`)
  - Confirms correct result values and type stability
  - Covers common arithmetic operators and error paths (invalid types, length mismatch)

## Why this matters
Previously, `_arith_method` worked when called directly, but expressions like `x + y` failed because the required dunder methods were not present on the ExtensionArray classes. Integrating `OpsMixin` aligns Arkouda’s pandas extensions with pandas’ expected arithmetic protocol and restores intuitive operator behavior for users.

## Testing
- New unit tests added under `tests/pandas/extension/arithmetic_ops.py`
- Tests fail on `main` and pass with this change
- No changes to existing tests or behavior outside arithmetic dispatch

Closes #5332:  ArkoudaArray arithmetic methods add, sub, mul