### PR TITLE
Closes #5351:  Normalize pandas Series conversion in from_series 

### DIFF
--- a/arkouda/pandas/conversion.py
+++ b/arkouda/pandas/conversion.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, TypeVar, Union
 
+import numpy as np
 import pandas as pd
 
 from typeguard import typechecked
@@ -23,74 +24,79 @@ def from_series(
     series: pd.Series, dtype: Optional[Union[type, str]] = None
 ) -> Union[pdarray, "Strings"]:
     """
-    Converts a Pandas Series to an Arkouda pdarray or Strings object. If
-    dtype is None, the dtype is inferred from the Pandas Series. Otherwise,
-    the dtype parameter is set if the dtype of the Pandas Series is to be
-    overridden or is  unknown (for example, in situations where the Series
-    dtype is object).
+    Convert a pandas ``Series`` to an Arkouda ``pdarray`` or ``Strings``.
+
+    If ``dtype`` is not provided, the dtype is inferred from the pandas
+    ``Series`` (using pandas' dtype metadata). If ``dtype`` is provided, it
+    is used as an override and normalized via Arkouda's dtype resolution rules.
+
+    In addition to the core numeric/bool types, this function supports
+    datetime and timedelta Series of **any** resolution (``ns``, ``us``, ``ms``,
+    etc.) by converting them to an ``int64`` pdarray of nanoseconds.
 
     Parameters
     ----------
     series : pd.Series
-        The Pandas Series with a dtype of bool, float64, int64, or string
-    dtype : Optional[Union[type, str]]
-        The valid dtype types are np.bool, np.float64, np.int64, and np.str
+        The pandas Series to convert.
+    dtype : Optional[Union[type, str]], optional
+        Optional dtype override. This may be a Python type (e.g. ``bool``),
+        a NumPy scalar type (e.g. ``np.int64``), or a dtype string.
+
+        String-like spellings are normalized to Arkouda string dtype, including:
+        ``"object"``, ``"str"``, ``"string"``, ``"string[python]"``,
+        and ``"string[pyarrow]"``.
 
     Returns
     -------
     Union[pdarray, Strings]
+        An Arkouda ``pdarray`` for numeric/bool/datetime/timedelta inputs, or an
+        Arkouda ``Strings`` for string inputs.
 
     Raises
     ------
     ValueError
-        Raised if the Series dtype is not bool, float64, int64, string, datetime, or timedelta
+        Raised if the dtype cannot be interpreted or is unsupported for conversion.
 
     Examples
     --------
     >>> import arkouda as ak
+    >>> import numpy as np
+    >>> import pandas as pd
+
+    # ints
     >>> np.random.seed(1701)
-    >>> ak.from_series(pd.Series(np.random.randint(0,10,5)))
+    >>> ak.from_series(pd.Series(np.random.randint(0, 10, 5)))
     array([4 3 3 5 0])
 
-    >>> ak.from_series(pd.Series(['1', '2', '3', '4', '5']),dtype=np.int64)
+    >>> ak.from_series(pd.Series(['1', '2', '3', '4', '5']), dtype=np.int64)
     array([1 2 3 4 5])
 
+    # floats
     >>> np.random.seed(1701)
-    >>> ak.from_series(pd.Series(np.random.uniform(low=0.0,high=1.0,size=3)))
+    >>> ak.from_series(pd.Series(np.random.uniform(low=0.0, high=1.0, size=3)))
     array([0.089433234324597599 0.1153776854774361 0.51874393620990389])
 
-    >>> ak.from_series(
-    ...     pd.Series([
-    ...         '0.57600036956445599',
-    ...         '0.41619265571741659',
-    ...         '0.6615356693784662',
-    ...     ]),
-    ...     dtype=np.float64,
-    ... )
-    array([0.57600036956445599 0.41619265571741659 0.6615356693784662])
-
+    # bools
     >>> np.random.seed(1864)
-    >>> ak.from_series(pd.Series(np.random.choice([True, False],size=5)))
+    >>> ak.from_series(pd.Series(np.random.choice([True, False], size=5)))
     array([True True True False False])
 
-    >>> ak.from_series(pd.Series(['True', 'False', 'False', 'True', 'True']), dtype=bool)
-    array([True True True True True])
-
+    # strings: pandas dtype spellings normalized to Arkouda Strings
     >>> ak.from_series(pd.Series(['a', 'b', 'c', 'd', 'e'], dtype="string"))
     array(['a', 'b', 'c', 'd', 'e'])
 
+    >>> ak.from_series(pd.Series(['a', 'b', 'c'], dtype="string[pyarrow]"))
+    array(['a', 'b', 'c'])
+
+    # datetime: any resolution is accepted, returned as int64 nanoseconds
     >>> ak.from_series(pd.Series(pd.to_datetime(['1/1/2018', np.datetime64('2018-01-01')])))
     array([1514764800000000000 1514764800000000000])
 
     Notes
     -----
-    The supported datatypes are bool, float64, int64, string, and datetime64[ns]. The
-    data type is either inferred from the the Series or is set via the dtype parameter.
-
-    Series of datetime or timedelta are converted to Arkouda arrays of dtype int64 (nanoseconds)
-
-    A Pandas Series containing strings has a dtype of object. Arkouda assumes the Series
-    contains strings and sets the dtype to str
+    - Datetime and timedelta Series are converted to ``int64`` nanoseconds.
+    - String-like pandas dtypes (including ``object``) are treated as string and
+      converted to Arkouda ``Strings``.
     """
     from arkouda.numpy.pdarraycreation import array
 
@@ -98,16 +104,27 @@ def from_series(
         dt = series.dtype.name
     else:
         dt = str(dtype)
+
+    # normalize pandas string dtype spellings
+    if dt in {"object", "str", "string[python]", "string[pyarrow]"}:
+        dt = "string"
+
     try:
         """
         If the Series has a object dtype, set dtype to string to comply with method
         signature that does not require a dtype; this is required because Pandas can infer
         non-str dtypes from the input np or Python array.
         """
-        if dt == "object":
-            dt = "string"
+        # handle datetime/timedelta with any resolution (us, ms, ns, ...)
+        if series.dtype.kind in ("M", "m"):
+            # normalize to ns then convert to int64 nanoseconds
+            if series.dtype.kind == "M":
+                n_array = series.to_numpy(dtype="datetime64[ns]").astype("int64")
+            else:
+                n_array = series.to_numpy(dtype="timedelta64[ns]").astype("int64")
+            return array(n_array, dtype=np.int64)
 
-        n_array = series.to_numpy(dtype=SeriesDTypes[dt])  # type: ignore
+        n_array = series.to_numpy(dtype=SeriesDTypes[dt])
     except KeyError:
         raise ValueError(
             f"dtype {dt} is unsupported. Supported dtypes are bool, float64, int64, string, "

--- a/tests/pandas/conversion_test.py
+++ b/tests/pandas/conversion_test.py
@@ -8,6 +8,14 @@ import arkouda as ak
 
 
 class TestPandasConversion:
+    def test_conversion_docstrings(self):
+        import doctest
+
+        from arkouda.pandas import conversion
+
+        result = doctest.testmod(conversion, optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)
+        assert result.failed == 0, f"Doctest failed: {result.failed} failures"
+
     @pytest.mark.parametrize("size", pytest.prob_size)
     @pytest.mark.parametrize("dtype", [bool, np.float64, np.int64, str])
     def test_from_series_dtypes(self, size, dtype):
@@ -21,6 +29,21 @@ class TestPandasConversion:
         assert isinstance(p_objects_array, ak.pdarray if dtype is not str else ak.Strings)
         assert dtype == p_objects_array.dtype
 
+    @pytest.mark.parametrize("size", pytest.prob_size)
+    @pytest.mark.parametrize(
+        "string_dtype", ["object", "str", "string", "string[python]", "string[pyarrow]"]
+    )
+    def test_from_series_string_spellings(self, size, string_dtype):
+        # When dtype is one of these spellings, from_series should produce Strings.
+        s = pd.Series([f"x{i}" for i in range(size)], dtype=string_dtype)
+        a = ak.from_series(s)
+
+        assert isinstance(a, ak.Strings)
+
+        # Also works when passed as dtype override
+        b = ak.from_series(pd.Series([f"x{i}" for i in range(size)]), dtype=string_dtype)
+        assert isinstance(b, ak.Strings)
+
     def test_from_series_misc(self):
         p_array = ak.from_series(pd.Series(["a", "b", "c", "d", "e"]))
         assert isinstance(p_array, ak.Strings)
@@ -31,25 +54,54 @@ class TestPandasConversion:
         assert isinstance(p_array, ak.pdarray)
         assert bool == p_array.dtype
 
+        # Python datetime objects -> int64 ns
         p_array = ak.from_series(pd.Series([dt.datetime(2016, 1, 1, 0, 0, 1)]))
-
         assert isinstance(p_array, ak.pdarray)
         assert np.int64 == p_array.dtype
 
+        # numpy datetime64 -> int64 ns
         p_array = ak.from_series(pd.Series([np.datetime64("2018-01-01")]))
-
         assert isinstance(p_array, ak.pdarray)
         assert np.int64 == p_array.dtype
 
+        # Mixed datetime inputs -> int64 ns
         p_array = ak.from_series(
             pd.Series(pd.to_datetime(["1/1/2018", np.datetime64("2018-01-01"), dt.datetime(2018, 1, 1)]))
         )
+        assert isinstance(p_array, ak.pdarray)
+        assert np.int64 == p_array.dtype
 
+        # Datetime resolution variants should be accepted
+        p_array = ak.from_series(pd.Series([np.datetime64("2018-01-01", "ms")]))
+        assert isinstance(p_array, ak.pdarray)
+        assert np.int64 == p_array.dtype
+
+        # Timedelta with non-ns resolution should be accepted
+        p_array = ak.from_series(pd.Series([np.timedelta64(123, "ms")]))
         assert isinstance(p_array, ak.pdarray)
         assert np.int64 == p_array.dtype
 
         with pytest.raises(TypeError):
             ak.from_series(np.ones(10))
 
+        # Unsupported dtype override (via ak_dtype) should raise ValueError
+        with pytest.raises(ValueError):
+            ak.from_series(pd.Series(np.random.randint(0, 10, 10)), dtype=np.int8)
+
+        # If the Series dtype itself is unsupported and no override is given, also ValueError
         with pytest.raises(ValueError):
             ak.from_series(pd.Series(np.random.randint(0, 10, 10), dtype=np.int8))
+
+    def test_from_series_object_dtype_normalized_to_string(self):
+        # Force dt == "object" from series.dtype.name and ensure it is treated as string.
+        s = pd.Series(["a", None, "b"], dtype="object")
+
+        a = ak.from_series(s)
+
+        assert isinstance(a, ak.Strings)
+
+        # dtype can surface as `str` or as a NumPy unicode dtype depending on implementation details.
+        assert (a.dtype == str) or (isinstance(a.dtype, np.dtype) and a.dtype.kind in ("U", "S"))
+
+        # Most importantly: object inputs are stringified and preserved as strings
+        assert a.tolist() == ["a", "None", "b"]


### PR DESCRIPTION
## Summary

This PR improves `ak.from_series` to better align with pandas expectations and real-world usage by:

1. Supporting **datetime and timedelta Series at any resolution** (`ns`, `us`, `ms`, etc.)
2. Normalizing **pandas string dtype spellings** to Arkouda `Strings`
3. Clarifying and expanding the function **docstring**, with executable examples
4. Adding **doctest coverage** and targeted unit tests for new behavior

---

## Motivation

Previously, `from_series` only reliably handled `datetime64[ns]` and a narrow set of string dtype spellings. In practice, pandas Series often contain:

- Datetime or timedelta data with non-nanosecond resolutions
- Multiple equivalent string dtype spellings (`object`, `string[pyarrow]`, etc.)

This PR makes `from_series` more robust, more pandas-compatible, and easier to understand and validate.

---

## Behavior Changes

### Datetime / Timedelta Handling

- Any pandas datetime or timedelta Series is now accepted regardless of resolution
- Values are normalized to **int64 nanoseconds**, consistent with Arkouda conventions

Examples:
```python
ak.from_series(pd.Series([np.datetime64("2018-01-01", "ms")]))
ak.from_series(pd.Series([np.timedelta64(123, "ms")]))
```

Closes #5351:  Normalize pandas Series conversion in from_series 