### PR TITLE
Closes #5417:  Rename ArkoudaCategoricalArray to ArkoudaCategorical

### DIFF
--- a/arkouda/__init__.py
+++ b/arkouda/__init__.py
@@ -402,7 +402,7 @@ from arkouda.pandas import (
     series,
     ArkoudaArray,
     ArkoudaStringArray,
-    ArkoudaCategoricalArray,
+    ArkoudaCategorical,
     ArkoudaBoolDtype,
     ArkoudaCategoricalDtype,
     ArkoudaInt64Dtype,

--- a/arkouda/pandas/__init__.py
+++ b/arkouda/pandas/__init__.py
@@ -4,7 +4,7 @@ from arkouda.pandas.extension import (
     ArkoudaArray,
     ArkoudaBigintDtype,
     ArkoudaBoolDtype,
-    ArkoudaCategoricalArray,
+    ArkoudaCategorical,
     ArkoudaCategoricalDtype,
     ArkoudaFloat64Dtype,
     ArkoudaInt64Dtype,

--- a/arkouda/pandas/extension/__init__.py
+++ b/arkouda/pandas/extension/__init__.py
@@ -18,7 +18,7 @@ high-performance backend.
    production environments.
 """
 from ._arkouda_array import ArkoudaArray
-from ._arkouda_categorical_array import ArkoudaCategoricalArray
+from ._arkouda_categorical_array import ArkoudaCategorical
 from ._arkouda_extension_array import ArkoudaExtensionArray
 from ._arkouda_string_array import ArkoudaStringArray
 from ._dataframe_accessor import ArkoudaDataFrameAccessor
@@ -47,7 +47,7 @@ __all__ = [
     "ArkoudaCategoricalDtype",
     "ArkoudaArray",
     "ArkoudaStringArray",
-    "ArkoudaCategoricalArray",
+    "ArkoudaCategorical",
     "ArkoudaExtensionArray",
     "ArkoudaIndexAccessor",
     "ArkoudaDataFrameAccessor",

--- a/arkouda/pandas/extension/_arkouda_categorical_array.py
+++ b/arkouda/pandas/extension/_arkouda_categorical_array.py
@@ -28,10 +28,10 @@ else:
     Categorical = TypeVar("Categorical")
 
 
-__all__ = ["ArkoudaCategoricalArray"]
+__all__ = ["ArkoudaCategorical"]
 
 
-class ArkoudaCategoricalArray(ArkoudaExtensionArray, ExtensionArray):
+class ArkoudaCategorical(ArkoudaExtensionArray, ExtensionArray):
     """
     Arkouda-backed categorical pandas ExtensionArray.
 
@@ -40,10 +40,10 @@ class ArkoudaCategoricalArray(ArkoudaExtensionArray, ExtensionArray):
 
     Parameters
     ----------
-    data : Categorical | ArkoudaCategoricalArray | ndarray | Sequence[Any]
+    data : Categorical | ArkoudaCategorical | ndarray | Sequence[Any]
         Input to wrap or convert.
         - If ``Categorical``, used directly.
-        - If another ``ArkoudaCategoricalArray``, its backing object is reused.
+        - If another ``ArkoudaCategorical``, its backing object is reused.
         - If list/tuple/ndarray, converted via ``ak.Categorical(ak.array(data))``.
 
     Raises
@@ -59,11 +59,11 @@ class ArkoudaCategoricalArray(ArkoudaExtensionArray, ExtensionArray):
 
     default_fill_value: str = ""
 
-    def __init__(self, data: Categorical | "ArkoudaCategoricalArray" | ndarray | Sequence[Any]):
+    def __init__(self, data: Categorical | "ArkoudaCategorical" | ndarray | Sequence[Any]):
         from arkouda import Categorical as AkCategorical
         from arkouda import array
 
-        if isinstance(data, ArkoudaCategoricalArray):
+        if isinstance(data, ArkoudaCategorical):
             self._data = data._data
             return
 
@@ -98,7 +98,7 @@ class ArkoudaCategoricalArray(ArkoudaExtensionArray, ExtensionArray):
         -------
         Any
             A Python scalar for scalar access, or a new
-            :class:`ArkoudaCategoricalArray` for non-scalar indexers.
+            :class:`ArkoudaCategorical` for non-scalar indexers.
 
         Raises
         ------
@@ -109,9 +109,9 @@ class ArkoudaCategoricalArray(ArkoudaExtensionArray, ExtensionArray):
         --------
         >>> import numpy as np
         >>> import arkouda as ak
-        >>> from arkouda.pandas.extension import ArkoudaCategoricalArray
+        >>> from arkouda.pandas.extension import ArkoudaCategorical
         >>> data = ak.Categorical(ak.array(["a", "b", "c", "d"]))
-        >>> arr = ArkoudaCategoricalArray(data)
+        >>> arr = ArkoudaCategorical(data)
 
         Scalar access returns a Python string-like scalar:
 
@@ -123,27 +123,27 @@ class ArkoudaCategoricalArray(ArkoudaExtensionArray, ExtensionArray):
         >>> arr[-1]
         np.str_('d')
 
-        Slice indexing returns a new ArkoudaCategoricalArray:
+        Slice indexing returns a new ArkoudaCategorical:
 
         >>> result = arr[1:3]
         >>> type(result)
-        <class 'arkouda.pandas.extension._arkouda_categorical_array.ArkoudaCategoricalArray'>
+        <class 'arkouda.pandas.extension._arkouda_categorical_array.ArkoudaCategorical'>
 
         NumPy integer array indexing:
 
         >>> idx = np.array([0, 2], dtype=np.int64)
         >>> sliced = arr[idx]
-        >>> isinstance(sliced, ArkoudaCategoricalArray)
+        >>> isinstance(sliced, ArkoudaCategorical)
         True
 
         NumPy boolean mask:
 
         >>> mask = np.array([True, False, True, False])
         >>> masked = arr[mask]
-        >>> isinstance(masked, ArkoudaCategoricalArray)
+        >>> isinstance(masked, ArkoudaCategorical)
         True
 
-        Empty integer indexer returns an empty ArkoudaCategoricalArray:
+        Empty integer indexer returns an empty ArkoudaCategorical:
 
         >>> empty_idx = np.array([], dtype=np.int64)
         >>> empty = arr[empty_idx]
@@ -158,7 +158,7 @@ class ArkoudaCategoricalArray(ArkoudaExtensionArray, ExtensionArray):
         # Handle empty indexer (list / tuple / ndarray of length 0)
         if isinstance(key, (list, tuple, np.ndarray)) and len(key) == 0:
             empty_strings = ak_array([], dtype="str_")
-            return ArkoudaCategoricalArray(Categorical(empty_strings))
+            return ArkoudaCategorical(Categorical(empty_strings))
 
         # Scalar integers and slices: delegate directly to the underlying Categorical
         if isinstance(key, (int, np.integer, slice)):
@@ -167,7 +167,7 @@ class ArkoudaCategoricalArray(ArkoudaExtensionArray, ExtensionArray):
             if isinstance(key, (int, np.integer)):
                 return result
             # For slices, underlying arkouda.Categorical returns a Categorical
-            return ArkoudaCategoricalArray(result)
+            return ArkoudaCategorical(result)
 
         # NumPy array indexers: normalize to Arkouda pdarrays
         if isinstance(key, np.ndarray):
@@ -198,13 +198,13 @@ class ArkoudaCategoricalArray(ArkoudaExtensionArray, ExtensionArray):
             # Return a Python scalar string
             return labels[0]
 
-        # Non-scalar: wrap Categorical in ArkoudaCategoricalArray
+        # Non-scalar: wrap Categorical in ArkoudaCategorical
         if isinstance(result, Categorical):
-            return ArkoudaCategoricalArray(result)
+            return ArkoudaCategorical(result)
 
         # Fallback: if Categorical returned something array-like but not Categorical,
         # rebuild a Categorical from it.
-        return ArkoudaCategoricalArray(Categorical(result))
+        return ArkoudaCategorical(Categorical(result))
 
     @classmethod
     def _from_sequence(cls, scalars, dtype=None, copy=False):
@@ -234,7 +234,7 @@ class ArkoudaCategoricalArray(ArkoudaExtensionArray, ExtensionArray):
 
         * If ``dtype`` is categorical (pandas ``category`` / ``CategoricalDtype`` /
           ``ArkoudaCategoricalDtype``), returns an Arkouda-backed
-          ``ArkoudaCategoricalArray`` (optionally copied).
+          ``ArkoudaCategorical`` (optionally copied).
         * If ``dtype`` requests ``object``, returns a NumPy ``ndarray`` of dtype object
           containing the category labels (materialized to the client).
         * If ``dtype`` requests a string dtype, returns an Arkouda-backed
@@ -262,8 +262,8 @@ class ArkoudaCategoricalArray(ArkoudaExtensionArray, ExtensionArray):
         Casting to ``category`` returns an Arkouda-backed categorical array:
 
         >>> import arkouda as ak
-        >>> from arkouda.pandas.extension import ArkoudaCategoricalArray
-        >>> c = ArkoudaCategoricalArray(ak.Categorical(ak.array(["x", "y", "x"])))
+        >>> from arkouda.pandas.extension import ArkoudaCategorical
+        >>> c = ArkoudaCategorical(ak.Categorical(ak.array(["x", "y", "x"])))
         >>> out = c.astype("category")
         >>> out is c
         False
@@ -289,7 +289,7 @@ class ArkoudaCategoricalArray(ArkoudaExtensionArray, ExtensionArray):
 
         Casting to another dtype casts the labels-as-strings and returns an Arkouda-backed array:
 
-        >>> c_num = ArkoudaCategoricalArray(ak.Categorical(ak.array(["1", "2", "3"])))
+        >>> c_num = ArkoudaCategorical(ak.Categorical(ak.array(["1", "2", "3"])))
         >>> a = c_num.astype("int64")
         >>> a.to_ndarray()
         array([1, 2, 3])
@@ -345,13 +345,13 @@ class ArkoudaCategoricalArray(ArkoudaExtensionArray, ExtensionArray):
         return ArkoudaCategoricalDtype()
 
     def __eq__(self, other):
-        """Elementwise equality for ArkoudaCategoricalArray."""
+        """Elementwise equality for ArkoudaCategorical."""
         from arkouda.numpy.pdarrayclass import pdarray
         from arkouda.numpy.pdarraycreation import array as ak_array
         from arkouda.pandas.categorical import Categorical
 
         # Case 1: Categorical vs Categorical
-        if isinstance(other, ArkoudaCategoricalArray):
+        if isinstance(other, ArkoudaCategorical):
             if len(self) != len(other):
                 raise ValueError("Lengths must match for elementwise comparison")
             return ArkoudaArray(self._data == other._data)
@@ -379,7 +379,7 @@ class ArkoudaCategoricalArray(ArkoudaExtensionArray, ExtensionArray):
         return NotImplemented
 
     def __repr__(self):
-        return f"ArkoudaCategoricalArray({self._data})"
+        return f"ArkoudaCategorical({self._data})"
 
     def value_counts(self, dropna: bool = True) -> pd.Series:
         """
@@ -417,9 +417,9 @@ class ArkoudaCategoricalArray(ArkoudaExtensionArray, ExtensionArray):
         Examples
         --------
         >>> import arkouda as ak
-        >>> from arkouda.pandas.extension import ArkoudaCategoricalArray
+        >>> from arkouda.pandas.extension import ArkoudaCategorical
         >>>
-        >>> a = ArkoudaCategoricalArray(["a", "b", "a", "c", "b", "a"])
+        >>> a = ArkoudaCategorical(["a", "b", "a", "c", "b", "a"])
         >>> a.value_counts()
         a    3
         b    2
@@ -459,7 +459,7 @@ class ArkoudaCategoricalArray(ArkoudaExtensionArray, ExtensionArray):
     # ------------------------------------------------------------------
 
     def _categorical_not_implemented(self, name: str):
-        raise NotImplementedError(f"{name} is not yet implemented for ArkoudaCategoricalArray.")
+        raise NotImplementedError(f"{name} is not yet implemented for ArkoudaCategorical.")
 
     def _categories_match_up_to_permutation(self, *args, **kwargs):
         self._categorical_not_implemented("_categories_match_up_to_permutation")
@@ -532,7 +532,7 @@ class ArkoudaCategoricalArray(ArkoudaExtensionArray, ExtensionArray):
 
     @classmethod
     def from_codes(cls, *args, **kwargs):
-        raise NotImplementedError("from_codes is not yet implemented for ArkoudaCategoricalArray.")
+        raise NotImplementedError("from_codes is not yet implemented for ArkoudaCategorical.")
 
     def isnull(self, *args, **kwargs):
         self._categorical_not_implemented("isnull")

--- a/arkouda/pandas/extension/_arkouda_extension_array.py
+++ b/arkouda/pandas/extension/_arkouda_extension_array.py
@@ -274,7 +274,7 @@ class ArkoudaExtensionArray(ExtensionArray):
 
         * :class:`ArkoudaArray` for numeric :class:`pdarray`
         * :class:`ArkoudaStringArray` for :class:`Strings`
-        * :class:`ArkoudaCategoricalArray` for pandas-style
+        * :class:`ArkoudaCategorical` for pandas-style
           :class:`~arkouda.pandas.categorical.Categorical`
 
         This method is the primary construction hook used by pandas when creating
@@ -299,7 +299,7 @@ class ArkoudaExtensionArray(ExtensionArray):
         ArkoudaExtensionArray
             An instance of :class:`ArkoudaArray`,
             :class:`ArkoudaStringArray`, or
-            :class:`ArkoudaCategoricalArray`, depending on the type of the
+            :class:`ArkoudaCategorical`, depending on the type of the
             resulting Arkouda server-side object.
 
         Raises
@@ -343,7 +343,7 @@ class ArkoudaExtensionArray(ExtensionArray):
         from arkouda.numpy.strings import Strings
         from arkouda.pandas.categorical import Categorical as ak_Categorical
         from arkouda.pandas.extension._arkouda_array import ArkoudaArray
-        from arkouda.pandas.extension._arkouda_categorical_array import ArkoudaCategoricalArray
+        from arkouda.pandas.extension._arkouda_categorical_array import ArkoudaCategorical
         from arkouda.pandas.extension._arkouda_string_array import ArkoudaStringArray
         from arkouda.pandas.extension._dtypes import ArkoudaCategoricalDtype, ArkoudaDtype
 
@@ -381,7 +381,7 @@ class ArkoudaExtensionArray(ExtensionArray):
         if isinstance(ak_obj, Strings):
             return ArkoudaStringArray(ak_obj)
         if isinstance(ak_obj, ak_Categorical):
-            return ArkoudaCategoricalArray(ak_obj)
+            return ArkoudaCategorical(ak_obj)
 
         raise TypeError(f"Unsupported Arkouda construction result: {type(ak_obj).__name__}")
 

--- a/arkouda/pandas/extension/_dataframe_accessor.py
+++ b/arkouda/pandas/extension/_dataframe_accessor.py
@@ -234,7 +234,7 @@ class ArkoudaDataFrameAccessor:
         Instead of materializing columns into NumPy arrays, this function
         wraps each underlying Arkouda server-side array in the appropriate
         ``ArkoudaExtensionArray`` subclass (``ArkoudaArray``,
-        ``ArkoudaStringArray``, or ``ArkoudaCategoricalArray``).
+        ``ArkoudaStringArray``, or ``ArkoudaCategorical``).
         The resulting pandas ``DataFrame`` therefore keeps all data on the
         Arkouda server, enabling scalable operations without transferring
         data to the Python client.
@@ -254,7 +254,7 @@ class ArkoudaDataFrameAccessor:
 
             * :class:`ArkoudaArray`
             * :class:`ArkoudaStringArray`
-            * :class:`ArkoudaCategoricalArray`
+            * :class:`ArkoudaCategorical`
 
             No materialization to NumPy occurs.
             All column data remain server-resident.
@@ -314,7 +314,7 @@ class ArkoudaDataFrameAccessor:
         <class 'arkouda.pandas.extension._arkouda_string_array.ArkoudaStringArray'>
 
         >>> type(pdf2["c"].array)
-        <class 'arkouda.pandas.extension._arkouda_categorical_array.ArkoudaCategoricalArray'>
+        <class 'arkouda.pandas.extension._arkouda_categorical_array.ArkoudaCategorical'>
 
         """
         return _akdf_to_pandas_no_copy(akdf)

--- a/arkouda/pandas/extension/_dtypes.py
+++ b/arkouda/pandas/extension/_dtypes.py
@@ -241,7 +241,7 @@ class ArkoudaDtype(ExtensionDtype):
     Generic Arkouda-backed dtype for pandas construction.
 
     Using dtype="ak" triggers ArkoudaExtensionArray._from_sequence, which
-    dispatches to ArkoudaArray / ArkoudaStringArray / ArkoudaCategoricalArray.
+    dispatches to ArkoudaArray / ArkoudaStringArray / ArkoudaCategorical.
     """
 
     name = "ak"
@@ -588,7 +588,7 @@ class ArkoudaCategoricalDtype(_ArkoudaBaseDtype):
     Arkouda-backed categorical dtype.
 
     This dtype integrates Arkouda's distributed ``Categorical`` type with
-    the pandas ExtensionArray interface via :class:`ArkoudaCategoricalArray`.
+    the pandas ExtensionArray interface via :class:`ArkoudaCategorical`.
     It enables pandas objects (Series, DataFrame) to hold categorical data
     stored and processed on the Arkouda server, while exposing familiar
     pandas APIs.
@@ -596,7 +596,7 @@ class ArkoudaCategoricalDtype(_ArkoudaBaseDtype):
     Methods
     -------
     construct_array_type()
-        Returns the :class:`ArkoudaCategoricalArray` used as the storage class.
+        Returns the :class:`ArkoudaCategorical` used as the storage class.
     """
 
     name = "category"
@@ -613,8 +613,8 @@ class ArkoudaCategoricalDtype(_ArkoudaBaseDtype):
         Returns
         -------
         type
-            The :class:`ArkoudaCategoricalArray` class associated with this dtype.
+            The :class:`ArkoudaCategorical` class associated with this dtype.
         """
-        from ._arkouda_categorical_array import ArkoudaCategoricalArray
+        from ._arkouda_categorical_array import ArkoudaCategorical
 
-        return ArkoudaCategoricalArray
+        return ArkoudaCategorical

--- a/tests/pandas/extension/arkouda_array_extension.py
+++ b/tests/pandas/extension/arkouda_array_extension.py
@@ -12,7 +12,7 @@ from arkouda.numpy.pdarraycreation import array as ak_array
 from arkouda.pandas.extension import (
     ArkoudaArray,
     ArkoudaBoolDtype,
-    ArkoudaCategoricalArray,
+    ArkoudaCategorical,
     ArkoudaExtensionArray,
     ArkoudaFloat64Dtype,
     ArkoudaInt64Dtype,
@@ -329,7 +329,7 @@ class TestArkoudaArrayExtension:
 
         - "numeric"      -> ArkoudaArray
         - "strings"      -> ArkoudaStringsArray
-        - "categorical"  -> ArkoudaCategoricalArray
+        - "categorical"  -> ArkoudaCategorical
         """
         kind = request.param
 
@@ -344,7 +344,7 @@ class TestArkoudaArrayExtension:
         elif kind == "categorical":
             base = ak.array(["a", "b", "c", "a", "b"])
             cat = ak.Categorical(base)
-            arr = ArkoudaCategoricalArray(cat)
+            arr = ArkoudaCategorical(cat)
 
         else:  # pragma: no cover - defensive
             raise ValueError(f"Unexpected kind: {kind}")

--- a/tests/pandas/extension/arkouda_array_extension_inherited.py
+++ b/tests/pandas/extension/arkouda_array_extension_inherited.py
@@ -9,7 +9,7 @@ import arkouda as ak
 from arkouda import Categorical
 from arkouda.pandas.extension import (
     ArkoudaArray,
-    ArkoudaCategoricalArray,
+    ArkoudaCategorical,
     ArkoudaStringArray,
 )
 
@@ -38,7 +38,7 @@ class TestArkoudaArrayExplodeInherited:
             # String-backed example
             (ArkoudaStringArray, ["a", "b", "c"]),
             # Categorical-backed example
-            (ArkoudaCategoricalArray, ["red", "blue", "red"]),
+            (ArkoudaCategorical, ["red", "blue", "red"]),
         ],
     )
     def test_explode_scalar_data_roundtrip(self, ea_cls, values):
@@ -50,10 +50,10 @@ class TestArkoudaArrayExplodeInherited:
         - return lengths as an ndarray of ones with shape (len(arr),).
 
         This should hold for ArkoudaArray, ArkoudaStringsArray, and
-        ArkoudaCategoricalArray when they wrap scalar (non-list-like) data.
+        ArkoudaCategorical when they wrap scalar (non-list-like) data.
         """
         # Construct the underlying Arkouda data depending on EA type
-        if ea_cls is ArkoudaCategoricalArray:
+        if ea_cls is ArkoudaCategorical:
             # Categorical typically wraps an Arkouda Categorical built from values
             ak_data = Categorical(ak.array(values))
         else:
@@ -83,7 +83,7 @@ class TestArkoudaArrayExplodeInherited:
         [
             (ArkoudaArray, [1, 2, 3]),
             (ArkoudaStringArray, ["x", "y", "z"]),
-            (ArkoudaCategoricalArray, ["low", "med", "high"]),
+            (ArkoudaCategorical, ["low", "med", "high"]),
         ],
     )
     def test_explode_does_not_change_series_values(self, ea_cls, values):
@@ -93,7 +93,7 @@ class TestArkoudaArrayExplodeInherited:
         and index. Arkouda-backed Series of all three EA types should
         follow that behavior.
         """
-        if ea_cls is ArkoudaCategoricalArray:
+        if ea_cls is ArkoudaCategorical:
             ak_data = Categorical(ak.array(values))
         else:
             ak_data = ak.array(values)
@@ -177,7 +177,7 @@ class TestArkoudaArrayFormatterInherited:
     # NEW: Run the same formatter semantics tests for:
     #   - ArkoudaArray
     #   - ArkoudaStringArray
-    #   - ArkoudaCategoricalArray
+    #   - ArkoudaCategorical
     # ------------------------------------------------------------------
 
     @pytest.mark.parametrize(
@@ -186,7 +186,7 @@ class TestArkoudaArrayFormatterInherited:
             (ArkoudaArray, lambda: ak.arange(3)),
             (ArkoudaStringArray, lambda: ak.array(["a", "b", "c"])),
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "z"])),
             ),
         ],
@@ -211,7 +211,7 @@ class TestArkoudaArrayFormatterInherited:
             (ArkoudaArray, lambda: ak.arange(3)),
             (ArkoudaStringArray, lambda: ak.array(["a", "b", "c"])),
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "z"])),
             ),
         ],
@@ -236,7 +236,7 @@ class TestArkoudaArrayFormatterInherited:
             (ArkoudaArray, lambda: ak.arange(3)),
             (ArkoudaStringArray, lambda: ak.array(["a", "b", "c"])),
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "z"])),
             ),
         ],
@@ -271,7 +271,7 @@ class TestArkoudaArrayFromScalarsInherited:
             (ArkoudaStringArray, lambda: ak.array(["a", "b", "c", "d", "e"])),
             # categorical
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "z", "y", "x"])),
             ),
         ],
@@ -301,7 +301,7 @@ class TestArkoudaArrayFromScalarsInherited:
             (ArkoudaArray, lambda: ak.arange(3)),
             (ArkoudaStringArray, lambda: ak.array(["a", "b", "c"])),
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "z"])),
             ),
         ],
@@ -346,7 +346,7 @@ class TestArkoudaArrayGetReprFooterInherited:
             (ArkoudaStringArray, lambda: ak.array(["a", "b", "c", "d", "e"])),
             # categorical
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "z", "y", "x"])),
             ),
         ],
@@ -372,7 +372,7 @@ class TestArkoudaArrayGetReprFooterInherited:
             (ArkoudaStringArray, lambda: ak.array([], dtype=ak.str_)),
             # empty categorical (must supply empty categorical)
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array([], dtype=ak.str_)),
             ),
         ],
@@ -403,9 +403,7 @@ class TestArkoudaArrayHashInherited:
         owner = next(base for base in ArkoudaArray.mro() if "_hash_pandas_object" in base.__dict__)
         assert owner is PandasExtensionArray
 
-    @pytest.mark.xfail(
-        reason=("Fails because Depends on ArkoudaCategoricalArray.to_factorize_view #5101")
-    )
+    @pytest.mark.xfail(reason=("Fails because Depends on ArkoudaCategorical.to_factorize_view #5101"))
     @pytest.mark.parametrize(
         "EA, make_data",
         [
@@ -415,7 +413,7 @@ class TestArkoudaArrayHashInherited:
             (ArkoudaStringArray, lambda: ak.array(["a", "b", "a", "c"])),
             # categorical EA
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "x", "z"])),
             ),
         ],
@@ -449,16 +447,14 @@ class TestArkoudaArrayHashInherited:
             # Each logical value should map to a single hash
             assert len(hset) == 1, f"value {v!r} had multiple hashes: {hset}"
 
-    @pytest.mark.xfail(
-        reason=("Fails because Depends on ArkoudaCategoricalArray.to_factorize_view #5101")
-    )
+    @pytest.mark.xfail(reason=("Fails because Depends on ArkoudaCategorical.to_factorize_view #5101"))
     @pytest.mark.parametrize(
         "EA, make_data",
         [
             (ArkoudaArray, lambda: ak.array([1, 2, 3, 4])),
             (ArkoudaStringArray, lambda: ak.array(["a", "b", "c", "d"])),
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["p", "q", "r", "q"])),
             ),
         ],
@@ -571,7 +567,7 @@ class TestArkoudaArrayPutmask:
 
     def test_putmask_categorical(self):
         """
-        _putmask should update categorical values if ArkoudaCategoricalArray
+        _putmask should update categorical values if ArkoudaCategorical
         implements __setitem__. Otherwise, skip until implemented.
         """
         data = np.array(["x", "y", "x", "z"], dtype=object)
@@ -579,13 +575,13 @@ class TestArkoudaArrayPutmask:
         value = "Q"
 
         ak_cat = ak.Categorical(ak.array(data))
-        arr = ArkoudaCategoricalArray(ak_cat)
+        arr = ArkoudaCategorical(ak_cat)
         result = arr.copy()
 
         try:
             result._putmask(mask, value)
         except NotImplementedError:
-            pytest.skip("ArkoudaCategoricalArray does not yet implement __setitem__.")
+            pytest.skip("ArkoudaCategorical does not yet implement __setitem__.")
 
         expected = data.copy()
         expected[mask] = value
@@ -656,7 +652,7 @@ class TestArkoudaArrayRank:
             (ArkoudaStringArray, lambda: ak.array(["b", "a", "b", "c"])),
             # categorical EA
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "x", "z"])),
             ),
         ],
@@ -721,7 +717,7 @@ class TestArkoudaArrayRepr2D:
         [
             (ArkoudaStringArray, lambda: ak.array(["a", "b", "c", "d", "e"])),
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "z", "y", "x"])),
             ),
         ],
@@ -759,7 +755,7 @@ class TestArkoudaArrayRepr2D:
             ),
             # categorical
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "z", "y", "x"])),
                 ["x", "y", "z"],
             ),
@@ -880,14 +876,14 @@ class TestArkoudaArrayValuesForArgsort:
             (ArkoudaStringArray, lambda: ak.array(["c", "a", "d", "a", "b"])),
             # categorical EA
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["z", "x", "y", "x", "z"])),
             ),
         ],
     )
     def test_values_for_argsort_induces_correct_sort_order_across_eas(self, EA, make_data):
         """
-        For ArkoudaArray, ArkoudaStringArray, and ArkoudaCategoricalArray,
+        For ArkoudaArray, ArkoudaStringArray, and ArkoudaCategorical,
         _values_for_argsort() should return a NumPy array whose argsort order,
         when applied back to the logical Python-level values (tolist()), gives
         the same sorted values as normal Python sorting.
@@ -1016,7 +1012,7 @@ class TestArkoudaArrayDelete:
             (ArkoudaStringArray, lambda: ak.array(["a", "b", "c", "d"]), 1),
             # categorical
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "z", "y"])),
                 3,
             ),
@@ -1047,7 +1043,7 @@ class TestArkoudaArrayDelete:
             (ArkoudaStringArray, lambda: ak.array(["a", "b", "c", "d", "e"]), [0, 4]),
             # categorical
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "z", "y", "x"])),
                 [1, 2],
             ),
@@ -1079,7 +1075,7 @@ class TestArkoudaArrayDelete:
             (ArkoudaStringArray, lambda: ak.array(["a", "b", "c", "d", "e"]), slice(1, 3)),
             # categorical
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "z", "y", "x"])),
                 slice(2, 5),
             ),
@@ -1176,7 +1172,7 @@ class TestArkoudaArrayDropna:
             (ArkoudaStringArray, lambda: ak.array(["a", "b", "c", "d"]), "string[python]"),
             # categorical EA: no missings, dropna should be a no-op
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "z", "y"])),
                 "category",
             ),
@@ -1266,7 +1262,7 @@ class TestArkoudaArrayInsert:
             (ArkoudaStringArray, lambda: ak.array(["a", "b", "c"]), 0, "z", ["z", "a", "b", "c"]),
             # categorical EA (insert a value already in the categories)
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "z"])),
                 0,
                 "y",
@@ -1300,7 +1296,7 @@ class TestArkoudaArrayInsert:
             ),
             # categorical EA
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "z", "y"])),
                 2,
                 "y",
@@ -1328,7 +1324,7 @@ class TestArkoudaArrayInsert:
             (ArkoudaStringArray, lambda: ak.array(["a", "b", "c"]), "z", ["a", "b", "c", "z"]),
             # categorical EA
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "z"])),
                 "x",
                 ["x", "y", "z", "x"],
@@ -1412,9 +1408,9 @@ class TestArkoudaArrayIsin:
                 lambda: ak.array(["a", "b", "c", "b"]),
                 ["b", "c"],
             ),
-            # ArkoudaCategoricalArray
+            # ArkoudaCategorical
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "x", "z"])),
                 ["x", "z"],
             ),
@@ -1422,7 +1418,7 @@ class TestArkoudaArrayIsin:
     )
     def test_isin_basic_for_strings_and_categoricals(self, EA, make_data, test_vals):
         """
-        For ArkoudaStringArray and ArkoudaCategoricalArray, isin() should
+        For ArkoudaStringArray and ArkoudaCategorical, isin() should
         return a NumPy boolean array whose values match numpy.isin applied to
         the Python-level logical values (tolist()).
         """
@@ -1448,7 +1444,7 @@ class TestArkoudaArrayIsin:
                 ["q", "z"],
             ),
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "z"])),
                 ["q"],
             ),
@@ -1474,7 +1470,7 @@ class TestArkoudaArrayIsin:
                 ["x"],
             ),
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["a", "a", "a"])),
                 ["a"],
             ),
@@ -1631,22 +1627,22 @@ class TestArkoudaArrayMap:
 
     @pytest.mark.xfail(
         reason=(
-            "ArkoudaCategoricalArray.map currently fails because "
-            "Index.astype(object, copy=...) calls ArkoudaCategoricalArray.astype "
+            "ArkoudaCategorical.map currently fails because "
+            "Index.astype(object, copy=...) calls ArkoudaCategorical.astype "
             "with an unsupported 'copy' keyword."
         )
     )
     def test_map_dict_categorical_not_supported_yet(self):
         """
-        Document current failure mode for ArkoudaCategoricalArray.map with dict
-        mapping. Once ArkoudaCategoricalArray.astype supports 'copy=', this
+        Document current failure mode for ArkoudaCategorical.map with dict
+        mapping. Once ArkoudaCategorical.astype supports 'copy=', this
         test should be updated to assert equality with pandas.
         """
         values = ["x", "y", "x", "z"]
         mapping = {"x": 1, "y": 2, "z": 3}
 
         ak_data = ak.Categorical(ak.array(values))
-        arr = ArkoudaCategoricalArray(ak_data)
+        arr = ArkoudaCategorical(ak_data)
 
         # Currently raises TypeError deep in Index.astype(..., copy=False)
         arr.map(mapping)
@@ -1678,13 +1674,13 @@ class TestArkoudaArrayMap:
 
     @pytest.mark.xfail(
         reason=(
-            "ArkoudaCategoricalArray.map with callable is blocked by the same "
+            "ArkoudaCategorical.map with callable is blocked by the same "
             "astype(copy=...) issue as the dict-mapping case."
         )
     )
     def test_map_callable_categorical_not_supported_yet(self):
         """
-        Current behavior: callable mapping on ArkoudaCategoricalArray also
+        Current behavior: callable mapping on ArkoudaCategorical also
         fails due to astype(copy=...) on the categorical index.
         """
         values = ["x", "y", "z"]
@@ -1693,7 +1689,7 @@ class TestArkoudaArrayMap:
             return f"val_{x}"
 
         ak_data = ak.Categorical(ak.array(values))
-        arr = ArkoudaCategoricalArray(ak_data)
+        arr = ArkoudaCategorical(ak_data)
 
         arr.map(f)
 
@@ -1786,7 +1782,7 @@ class TestArkoudaArrayRavel:
         [
             (ArkoudaStringArray, lambda: ak.array(["a", "b", "c", "d"])),
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "z", "y"])),
             ),
         ],
@@ -1804,7 +1800,7 @@ class TestArkoudaArrayRavel:
         [
             (ArkoudaStringArray, lambda: ak.array(["a", "b", "c"])),
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["u", "v", "u"])),
             ),
         ],
@@ -1889,7 +1885,7 @@ class TestArkoudaArrayRepeat:
         [
             (ArkoudaStringArray, lambda: ak.array(["a", "b", "c"]), 2),
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "x"])),
                 3,
             ),
@@ -1920,7 +1916,7 @@ class TestArkoudaArrayRepeat:
                 [1, 0, 2, 1],
             ),
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "z", "y"])),
                 [2, 1, 0, 1],
             ),
@@ -1947,7 +1943,7 @@ class TestArkoudaArrayRepeat:
         [
             (ArkoudaStringArray, lambda: ak.array(["a", "b", "c"])),
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "x"])),
             ),
         ],
@@ -2253,15 +2249,15 @@ class TestArkoudaArrayShift:
 
     def test_shift_categorical_currently_raises_valueerror(self):
         """
-        For ArkoudaCategoricalArray, shift() currently fails when pandas'
+        For ArkoudaCategorical, shift() currently fails when pandas'
         machinery tries to construct a categorical from the fill row
         (e.g. [-1]). We lock in the ValueError as the current behavior.
 
-        If/when shift is properly implemented for ArkoudaCategoricalArray,
+        If/when shift is properly implemented for ArkoudaCategorical,
         this test should be updated to assert the correct semantics instead.
         """
         cat = ak.Categorical(ak.array(["x", "y", "z", "y", "x"]))
-        arr = ArkoudaCategoricalArray(cat)
+        arr = ArkoudaCategorical(cat)
 
         with pytest.raises(ValueError):
             arr.shift(periods=1)
@@ -2383,12 +2379,12 @@ class TestArkoudaArrayToList:
 
     def test_tolist_categorical_roundtrip(self):
         """
-        ArkoudaCategoricalArray.tolist() should return the logical category
+        ArkoudaCategorical.tolist() should return the logical category
         labels, consistent with pandas.Categorical.tolist().
         """
         labels = ["x", "y", "x", "z"]
         ak_cat = ak.Categorical(ak.array(labels))
-        arr = ArkoudaCategoricalArray(ak_cat)
+        arr = ArkoudaCategorical(ak_cat)
 
         result = arr.tolist()
 
@@ -2416,7 +2412,7 @@ class TestArkoudaArrayTranspose:
             (ArkoudaArray, lambda: ak.arange(5)),
             (ArkoudaStringArray, lambda: ak.array(["a", "b", "c", "d", "e"])),
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "z", "y", "x"])),
             ),
         ],
@@ -2439,7 +2435,7 @@ class TestArkoudaArrayTranspose:
             (ArkoudaArray, lambda: ak.arange(5)),
             (ArkoudaStringArray, lambda: ak.array(["a", "b", "c", "d", "e"])),
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "z", "y", "x"])),
             ),
         ],
@@ -2464,7 +2460,7 @@ class TestArkoudaArrayTranspose:
             (ArkoudaArray, lambda: ak.array([10, 20, 30, 40])),
             (ArkoudaStringArray, lambda: ak.array(["u", "v", "w", "x"])),
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["a", "b", "a", "c"])),
             ),
         ],
@@ -2484,7 +2480,7 @@ class TestArkoudaArrayTranspose:
             (ArkoudaArray, lambda: ak.arange(4)),
             (ArkoudaStringArray, lambda: ak.array(["a", "b", "c", "d"])),
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "z", "y"])),
             ),
         ],
@@ -2586,7 +2582,7 @@ class TestArkoudaArrayUnique:
     # String and Categorical examples
     # ------------------------------------------------------------------
 
-    @pytest.mark.xfail(reason=("Fails because ArkoudaCategoricalArray.astype() is not yet implemented."))
+    @pytest.mark.xfail(reason=("Fails because ArkoudaCategorical.astype() is not yet implemented."))
     @pytest.mark.parametrize(
         "EA, make_data, pandas_constructor",
         [
@@ -2598,7 +2594,7 @@ class TestArkoudaArrayUnique:
             ),
             # Categoricals: order-preserving de-duplication on labels
             (
-                ArkoudaCategoricalArray,
+                ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "x", "z", "y"])),
                 lambda vals: pd.Categorical(vals),
             ),
@@ -2606,7 +2602,7 @@ class TestArkoudaArrayUnique:
     )
     def test_unique_strings_and_categoricals_match_pandas(self, EA, make_data, pandas_constructor):
         """
-        For ArkoudaStringArray and ArkoudaCategoricalArray, unique() should
+        For ArkoudaStringArray and ArkoudaCategorical, unique() should
         remove duplicates while preserving the order of first occurrence,
         matching pandas' unique() on the logical values.
         """
@@ -2625,12 +2621,12 @@ class TestArkoudaArrayUnique:
 
         assert result_list == expected_list
 
-    @pytest.mark.xfail(reason=("Fails because ArkoudaCategoricalArray.astype() is not yet implemented."))
+    @pytest.mark.xfail(reason=("Fails because ArkoudaCategorical.astype() is not yet implemented."))
     @pytest.mark.parametrize(
         "EA, values",
         [
             (ArkoudaStringArray, ["foo", "foo", "foo"]),
-            (ArkoudaCategoricalArray, ["cat", "cat", "cat"]),
+            (ArkoudaCategorical, ["cat", "cat", "cat"]),
         ],
     )
     def test_unique_strings_and_categoricals_all_duplicates(self, EA, values):
@@ -2638,7 +2634,7 @@ class TestArkoudaArrayUnique:
         For string and categorical Arkouda EAs, if all elements are the same,
         unique() should return a length-1 array with that value.
         """
-        if EA is ArkoudaCategoricalArray:
+        if EA is ArkoudaCategorical:
             ak_data = ak.Categorical(ak.array(values))
         else:
             ak_data = ak.array(values)
@@ -2649,12 +2645,12 @@ class TestArkoudaArrayUnique:
 
         assert result_list == [values[0]]
 
-    @pytest.mark.xfail(reason=("Fails because ArkoudaCategoricalArray.astype() is not yet implemented."))
+    @pytest.mark.xfail(reason=("Fails because ArkoudaCategorical.astype() is not yet implemented."))
     @pytest.mark.parametrize(
         "EA, values",
         [
             (ArkoudaStringArray, ["a", "b", "c", "d"]),
-            (ArkoudaCategoricalArray, ["x", "y", "z"]),
+            (ArkoudaCategorical, ["x", "y", "z"]),
         ],
     )
     def test_unique_strings_and_categoricals_already_unique(self, EA, values):
@@ -2663,7 +2659,7 @@ class TestArkoudaArrayUnique:
         unique, unique() should return the same logical values in the
         same order.
         """
-        if EA is ArkoudaCategoricalArray:
+        if EA is ArkoudaCategorical:
             ak_data = ak.Categorical(ak.array(values))
         else:
             ak_data = ak.array(values)

--- a/tests/pandas/extension/arkouda_extension.py
+++ b/tests/pandas/extension/arkouda_extension.py
@@ -12,7 +12,7 @@ from arkouda.numpy.strings import Strings
 from arkouda.pandas.categorical import Categorical
 from arkouda.pandas.extension import (
     ArkoudaArray,
-    ArkoudaCategoricalArray,
+    ArkoudaCategorical,
     ArkoudaExtensionArray,
     ArkoudaStringArray,
 )
@@ -38,7 +38,7 @@ class TestArkoudaExtensionArray:
 
         - "numeric"      -> ArkoudaArray
         - "strings"      -> ArkoudaStringsArray
-        - "categorical"  -> ArkoudaCategoricalArray
+        - "categorical"  -> ArkoudaCategorical
         """
         kind = request.param
 
@@ -53,7 +53,7 @@ class TestArkoudaExtensionArray:
         elif kind == "categorical":
             base = ak.array(["a", "b", "c", "a", "b"])
             cat = ak.Categorical(base)
-            arr = ArkoudaCategoricalArray(cat)
+            arr = ArkoudaCategorical(cat)
 
         else:  # pragma: no cover - defensive
             raise ValueError(f"Unexpected kind: {kind}")
@@ -297,7 +297,7 @@ class TestArkoudaExtensionArray:
         for arr in [
             ArkoudaArray(ak.array([1, 2, 3])),
             ArkoudaStringArray(ak.array(["a", "b"])),
-            ArkoudaCategoricalArray(ak.Categorical(ak.array(["a", "b"]))),
+            ArkoudaCategorical(ak.Categorical(ak.array(["a", "b"]))),
         ]:
             out = type(arr)._concat_same_type([arr])
             # Should be the same object (no new allocation)
@@ -329,11 +329,11 @@ class TestArkoudaExtensionArray:
     def test_concat_categorical_happy_path_contents_and_length(self):
         s1 = ak.array(["r", "g", "b"])
         s2 = ak.array(["g", "r"])
-        a = ArkoudaCategoricalArray(ak.Categorical(s1))
-        b = ArkoudaCategoricalArray(ak.Categorical(s2))
+        a = ArkoudaCategorical(ak.Categorical(s1))
+        b = ArkoudaCategorical(ak.Categorical(s2))
 
-        out = ArkoudaCategoricalArray._concat_same_type([a, b])
-        assert isinstance(out, ArkoudaCategoricalArray)
+        out = ArkoudaCategorical._concat_same_type([a, b])
+        assert isinstance(out, ArkoudaCategorical)
         assert len(out) == len(a) + len(b)
         # Compare as numpy arrays of labels
         assert_equal(out._data, ak.Categorical(ak.array(["r", "g", "b", "g", "r"])))
@@ -518,7 +518,7 @@ class TestArkoudaExtensionArray:
         """
         s = ak.array(["red", "blue", "red", "green"])
         cat = ak.Categorical(s)  # construct from Strings
-        a = ArkoudaCategoricalArray(cat)
+        a = ArkoudaCategorical(cat)
         codes, uniques = a.factorize()
 
         # order of first-appearance: ["red", "blue", "green"]
@@ -543,7 +543,7 @@ class TestArkoudaExtensionArray:
         Verify that ArkoudaExtensionArray._from_sequence chooses the right subclass.
         * pdarray          -> ArkoudaArray
         * Strings          -> ArkoudaStringArray
-        * Categorical      -> ArkoudaCategoricalArray
+        * Categorical      -> ArkoudaCategorical
         * Python sequence  -> ArkoudaArray (via ak.array -> pdarray)
         """
         # pdarray -> ArkoudaArray
@@ -560,11 +560,11 @@ class TestArkoudaExtensionArray:
         assert isinstance(ea_str, ArkoudaStringArray)
         assert isinstance(ea_str._data, Strings)
 
-        # Categorical -> ArkoudaCategoricalArray
+        # Categorical -> ArkoudaCategorical
         ak_labels = ak.array(["low", "low", "high"])
         cat = Categorical(ak_labels)
         ea_cat = ArkoudaExtensionArray._from_sequence(cat)
-        assert isinstance(ea_cat, ArkoudaCategoricalArray)
+        assert isinstance(ea_cat, ArkoudaCategorical)
         assert isinstance(ea_cat._data, Categorical)
 
         # Plain Python sequence -> ArkoudaArray via ak.array -> pdarray

--- a/tests/pandas/extension/dataframe_accessor.py
+++ b/tests/pandas/extension/dataframe_accessor.py
@@ -14,7 +14,7 @@ from arkouda.pandas.categorical import Categorical as ak_Categorical
 from arkouda.pandas.dataframe import DataFrame as ak_DataFrame
 from arkouda.pandas.extension import (
     ArkoudaArray,
-    ArkoudaCategoricalArray,
+    ArkoudaCategorical,
     ArkoudaExtensionArray,
     ArkoudaIndexAccessor,
     ArkoudaStringArray,
@@ -89,7 +89,7 @@ class TestDataFrameConversion:
             {
                 "i": ArkoudaArray(ak_arange(5)),
                 "s": ArkoudaStringArray(ak_array(["a", "b", "c", "d", "e"])),
-                "c": ArkoudaCategoricalArray(
+                "c": ArkoudaCategorical(
                     ak_Categorical(ak_array(["low", "low", "high", "medium", "low"]))
                 ),
             }

--- a/tests/pandas/extension/dataframes.py
+++ b/tests/pandas/extension/dataframes.py
@@ -4,7 +4,7 @@ import pytest
 import arkouda as ak
 
 from arkouda.pandas.extension._arkouda_array import ArkoudaArray
-from arkouda.pandas.extension._arkouda_categorical_array import ArkoudaCategoricalArray
+from arkouda.pandas.extension._arkouda_categorical_array import ArkoudaCategorical
 from arkouda.pandas.extension._arkouda_string_array import ArkoudaStringArray
 
 
@@ -15,7 +15,7 @@ class TestDataFrameExtension:
             {
                 "i": ArkoudaArray(ak.arange(N)),
                 "s": ArkoudaStringArray(ak.array(["a", "b", "c", "d", "e"])),
-                "c": ArkoudaCategoricalArray(
+                "c": ArkoudaCategorical(
                     ak.Categorical(ak.array(["low", "low", "high", "medium", "low"]))
                 ),
             }

--- a/tests/pandas/extension/dtypes_extension.py
+++ b/tests/pandas/extension/dtypes_extension.py
@@ -6,7 +6,7 @@ import pytest
 
 import arkouda as ak
 
-from arkouda.pandas.extension import ArkoudaArray, ArkoudaCategoricalArray, ArkoudaStringArray
+from arkouda.pandas.extension import ArkoudaArray, ArkoudaCategorical, ArkoudaStringArray
 
 # Module under test
 from arkouda.pandas.extension._dtypes import (
@@ -175,8 +175,8 @@ class TestArkoudaDtypesExtension:
             ("ak.bigint", ArkoudaBigintDtype, ArkoudaArray, [1, 3, 4]),
             # string -> ArkoudaStringArray
             ("ak.string", ArkoudaStringDtype, ArkoudaStringArray, ["a", "b", "c"]),
-            # category -> ArkoudaCategoricalArray
-            ("ak.category", ArkoudaCategoricalDtype, ArkoudaCategoricalArray, ["a", "b", "a"]),
+            # category -> ArkoudaCategorical
+            ("ak.category", ArkoudaCategoricalDtype, ArkoudaCategorical, ["a", "b", "a"]),
         ],
     )
     def test_pd_array_with_arkouda_aliases_is_arkouda(
@@ -325,11 +325,11 @@ class TestArkoudaDtypesExtension:
 
     def test_series_with_categorical_dtype(self):
         from arkouda.pandas.extension._arkouda_categorical_array import (
-            ArkoudaCategoricalArray,
+            ArkoudaCategorical,
         )
 
         a = ak.Categorical(ak.array(["x", "y", "x"]))
-        cea = ArkoudaCategoricalArray(a)
+        cea = ArkoudaCategorical(a)
         s = pd.Series(cea)
         assert isinstance(s.dtype, ArkoudaCategoricalDtype)
         # categories round-trip to Python scalars on materialization
@@ -361,7 +361,7 @@ class TestArkoudaGenericDtypesExtension:
         cat = PandasCategorical(ak.array(["a", "b", "a", "c"]))
         arr = pd.array(cat, dtype="ak")
 
-        assert isinstance(arr, ArkoudaCategoricalArray)
+        assert isinstance(arr, ArkoudaCategorical)
         assert isinstance(arr.dtype, ArkoudaCategoricalDtype)
 
     def test_series_dtype_ak_dispatches_numeric(self):
@@ -383,5 +383,5 @@ class TestArkoudaGenericDtypesExtension:
         arr = pd.array(cat, dtype="ak")
         s = pd.Series(arr)
 
-        assert isinstance(s.array, ArkoudaCategoricalArray)
+        assert isinstance(s.array, ArkoudaCategorical)
         assert isinstance(s.dtype, ArkoudaCategoricalDtype)

--- a/tests/pandas/extension/series.py
+++ b/tests/pandas/extension/series.py
@@ -26,20 +26,20 @@ class TestSeriesExtension:
 
     def test_series_from_categorical(self):
         from arkouda.pandas.extension._arkouda_categorical_array import (
-            ArkoudaCategoricalArray,
+            ArkoudaCategorical,
         )
 
-        s_arr = ArkoudaCategoricalArray(ak.Categorical(ak.array(["high", "low", "medium", "low"])))
+        s_arr = ArkoudaCategorical(ak.Categorical(ak.array(["high", "low", "medium", "low"])))
         s = pd.Series(s_arr)
         assert s.iloc[1] == "low"
         assert s.iloc[3] == "low"
 
     def test_categorical_series_take_with_fill(self):
         from arkouda.pandas.extension._arkouda_categorical_array import (
-            ArkoudaCategoricalArray,
+            ArkoudaCategorical,
         )
 
-        s_arr = ArkoudaCategoricalArray(ak.Categorical(ak.array(["x", "y", "z"])))
+        s_arr = ArkoudaCategorical(ak.Categorical(ak.array(["x", "y", "z"])))
         s = pd.Series(s_arr)
         taken = pd.Series(s.values.take([1, -1, 0], allow_fill=True, fill_value="x"))
         assert taken.iloc[0] == "y"


### PR DESCRIPTION
Changes the name `ArkoudaCategoricalArray` to `ArkoudaCategorical` to match pandas naming.

Closes #5417:  Rename ArkoudaCategoricalArray to ArkoudaCategorical