### PR TITLE
Closes #5419:  Bug: DataFrame.ak.to_ak() Does Not Convert Index to Arkouda-Backed Index

### DIFF
--- a/arkouda/pandas/extension/_dataframe_accessor.py
+++ b/arkouda/pandas/extension/_dataframe_accessor.py
@@ -371,11 +371,17 @@ class ArkoudaDataFrameAccessor:
         2  3  c
         """
         from arkouda.numpy.pdarraycreation import array as ak_array
+        from arkouda.pandas.extension import ArkoudaIndexAccessor
+
+        idx = ArkoudaIndexAccessor(self._obj.index).to_ak()
 
         cols = {}
         for name, col in self._obj.items():
-            cols[name] = ArkoudaExtensionArray._from_sequence(ak_array(col.values))
-        return pd_DataFrame(cols)
+            if isinstance(col.array, ArkoudaExtensionArray):
+                cols[name] = col.array
+            else:
+                cols[name] = ArkoudaExtensionArray._from_sequence(ak_array(col.values))
+        return pd_DataFrame(cols, index=idx)
 
     def collect(self) -> pd_DataFrame:
         """


### PR DESCRIPTION
## Summary

This PR fixes an architectural inconsistency in `DataFrame.ak.to_ak()`
where:

-   Columns were correctly converted to Arkouda-backed `ExtensionArray`s
-   The index remained a pandas `RangeIndex`

This broke Arkouda's zero-copy invariants and resulted in mixed backend
state (Arkouda-backed columns with NumPy-backed index).

This PR ensures the index is converted to an Arkouda-backed pandas
`Index` using `ArkoudaIndexAccessor`.

------------------------------------------------------------------------

## Problem

Before this change:

``` python
df = pd.DataFrame({"a": np.arange(5)})
ak_df = df.ak.to_ak()

ak_df["a"].array      # ArkoudaExtensionArray ✅
ak_df.index           # RangeIndex ❌
```

The index was silently replaced with a default `RangeIndex` because
`to_ak()` rebuilt the DataFrame without passing an index:

``` python
return pd_DataFrame(cols)
```

This caused: - Mixed backend state - Violation of Arkouda zero-copy
guarantees - Potential downstream inconsistencies in index-aware
operations

------------------------------------------------------------------------

## Changes

### 1. Convert Index via `ArkoudaIndexAccessor`

``` python
from arkouda.pandas.extension import ArkoudaIndexAccessor

idx = ArkoudaIndexAccessor(self._obj.index).to_ak()
return pd_DataFrame(cols, index=idx)
```

This reuses the existing index conversion infrastructure and keeps
behavior consistent with:

-   `_index_accessor.py`
-   `Series.ak.to_ak()`

------------------------------------------------------------------------

### 2. Avoid Re-materializing Already Arkouda-Backed Columns

If a column is already Arkouda-backed, reuse it instead of calling
`ak.array()` again:

``` python
if isinstance(col.array, ArkoudaExtensionArray):
    cols[name] = col.array
else:
    cols[name] = ArkoudaExtensionArray._from_sequence(ak_array(col.values))
```

This preserves zero-copy behavior and improves performance.

------------------------------------------------------------------------

## New Test

Added regression test:

``` python
def test_dataframe_to_ak_converts_index_to_arkouda_backed():
```

Verifies:

-   Columns are Arkouda-backed
-   Index is Arkouda-backed
-   Values are preserved
-   No NumPy fallback occurs

------------------------------------------------------------------------

## Architectural Impact

This change restores the invariant:

> An Arkouda-backed pandas DataFrame must have both: - Arkouda-backed
> columns - Arkouda-backed index

No behavior changes for users except increased correctness and
consistency.

------------------------------------------------------------------------

## Performance Impact

-   Avoids unnecessary re-materialization for already Arkouda-backed
    columns
-   No additional server transfers introduced

------------------------------------------------------------------------

## Backwards Compatibility

Fully backwards compatible.\
Only fixes inconsistent backend state.


Closes #5419:  Bug: DataFrame.ak.to_ak() Does Not Convert Index to Arkouda-Backed Index