### PR TITLE
Closes #5428:  BUG: Pandas Series with dtype=ak Returns NumPy Index Values

### DIFF
--- a/arkouda/pandas/extension/_series_accessor.py
+++ b/arkouda/pandas/extension/_series_accessor.py
@@ -354,14 +354,18 @@ class ArkoudaSeriesAccessor:
     @property
     def is_arkouda(self) -> bool:
         """
-        Return whether the underlying Series is Arkouda-backed.
+        Return True if this Series is fully Arkouda-backed.
 
-        A Series is Arkouda-backed if its underlying storage uses
-        :class:`ArkoudaExtensionArray`.
+        A Series is considered Arkouda-backed when both:
+
+        1. Its values are stored in an ``ArkoudaExtensionArray``.
+        2. Its index (including each level of a MultiIndex) is
+           backed by ``ArkoudaExtensionArray``.
 
         Returns
         -------
         bool
+            True if both data and index are Arkouda-backed, otherwise False.
 
         Examples
         --------
@@ -373,9 +377,21 @@ class ArkoudaSeriesAccessor:
         >>> ak_s.ak.is_arkouda
         True
         """
-        arr = getattr(self._obj, "array", None)
-        idx_arr = self._obj.index.values
-        return isinstance(arr, ArkoudaExtensionArray) and isinstance(idx_arr, ArkoudaExtensionArray)
+        # Check values
+        values = getattr(self._obj, "array", None)
+        if not isinstance(values, ArkoudaExtensionArray):
+            return False
+
+        idx = self._obj.index
+
+        # MultiIndex: require every level to be Arkouda-backed
+        if isinstance(idx, pd.MultiIndex):
+            return all(
+                isinstance(getattr(level, "array", None), ArkoudaExtensionArray) for level in idx.levels
+            )
+
+        # Single-level Index
+        return isinstance(getattr(idx, "array", None), ArkoudaExtensionArray)
 
     # ------------------------------------------------------------------
     # Legacy delegation: thin wrappers over ak.Series

--- a/tests/pandas/extension/index_accessor.py
+++ b/tests/pandas/extension/index_accessor.py
@@ -201,6 +201,54 @@ class TestArkoudaIndexAccessor:
         assert not idx_local.ak.is_arkouda
         assert not midx_local.ak.is_arkouda
 
+    def test_pandas_index_to_ak_rangeindex_default_roundtrips(self):
+        """
+        RangeIndex(start=0, step=1) should convert to an ak.Index without materializing
+        on the client, and the values should round-trip back to the same RangeIndex.
+        """
+        idx = pd.RangeIndex(0, 10, 1, name="r")
+        ak_idx = _pandas_index_to_ak(idx)
+
+        assert isinstance(ak_idx, ak_Index)
+        assert ak_idx.name == "r"
+
+        pd_back = ak_idx.to_pandas()
+        assert isinstance(pd_back, pd.Index)
+        assert pd_back.equals(pd.RangeIndex(0, 10, 1, name="r"))
+
+    def test_pandas_index_to_ak_rangeindex_nontrivial_roundtrips(self):
+        """
+        RangeIndex(start!=0 or step!=1) should convert to an ak.Index and round-trip
+        back to an equivalent RangeIndex.
+        """
+        idx = pd.RangeIndex(5, 20, 3, name="r2")
+        ak_idx = _pandas_index_to_ak(idx)
+
+        assert isinstance(ak_idx, ak_Index)
+        assert ak_idx.name == "r2"
+
+        pd_back = ak_idx.to_pandas()
+        assert pd_back.equals(pd.RangeIndex(5, 20, 3, name="r2"))
+
+    def test_pandas_index_to_ak_rangeindex_negative_step_roundtrips_or_errors(self):
+        """
+        Descending RangeIndex is valid in pandas. If Arkouda supports negative-step arange,
+        it should round-trip; otherwise the conversion should raise a clear error.
+
+        This test allows either outcome to avoid being over-prescriptive about backend support.
+        """
+        idx = pd.RangeIndex(10, 0, -2, name="desc")
+
+        try:
+            ak_idx = _pandas_index_to_ak(idx)
+        except Exception as e:
+            # If unsupported, at least ensure we fail loudly (not silently wrong).
+            assert isinstance(e, (ValueError, NotImplementedError, RuntimeError))
+            return
+
+        pd_back = ak_idx.to_pandas()
+        assert pd_back.equals(pd.RangeIndex(10, 0, -2, name="desc"))
+
     def test_from_ak_legacy_roundtrip_index(self):
         """Round-trip using to_ak_legacy() + from_ak_legacy()."""
         idx = pd.Index([7, 8, 9], name="nums")

--- a/tests/pandas/extension/series_accessor.py
+++ b/tests/pandas/extension/series_accessor.py
@@ -121,6 +121,26 @@ class TestArkoudaSeriesAccessor:
         s_local = s_ak.ak.collect()
         assert not s_local.ak.is_arkouda
 
+    def test_is_arkouda_true_for_to_ak_series_with_default_rangeindex(self):
+        s = pd.Series([1, 2, 3])  # default RangeIndex
+        ak_s = s.ak.to_ak()
+
+        assert isinstance(getattr(ak_s, "array", None), ArkoudaExtensionArray)
+        assert ak_s.ak.is_arkouda is True
+
+    def test_is_arkouda_true_for_to_ak_series_with_nontrivial_index(self):
+        s = pd.Series([10, 20, 30], index=pd.Index([100, 200, 300], name="i"))
+        ak_s = s.ak.to_ak()
+
+        assert ak_s.ak.is_arkouda is True
+
+    def test_is_arkouda_true_for_to_ak_series_with_multiindex(self):
+        mi = pd.MultiIndex.from_product([["a", "b"], [1, 2]], names=["l0", "l1"])
+        s = pd.Series([0, 1, 2, 3], index=mi)
+
+        ak_s = s.ak.to_ak()
+        assert ak_s.ak.is_arkouda is True
+
     def test_to_ak_preserves_index_and_name(self):
         idx = pd.Index([100, 200, 300], name="id")
         s = pd.Series([10, 20, 30], index=idx, name="values")


### PR DESCRIPTION
## Summary

This PR improves Arkouda’s pandas-extension interoperability in two areas:

1. **RangeIndex conversion is now server-side.**  
   `_pandas_index_to_ak` detects `pandas.RangeIndex` and constructs the corresponding index directly on the Arkouda server via `ak_arange`, avoiding client-side materialization for very large ranges.

2. **`Series.ak.is_arkouda` is now “fully Arkouda-backed”.**  
   The predicate now returns `True` only when **both**:
   - the Series values are stored in an `ArkoudaExtensionArray`, and
   - the Series index is Arkouda-backed (and for a `MultiIndex`, **all levels** are Arkouda-backed).

## Motivation

- **Scalability / safety:** `RangeIndex` is “virtual” (start/stop/step). Any conversion path that materializes its values on the client can blow up memory for huge ranges. Creating the range directly on the server avoids this footgun.
- **Correctness / clarity:** Previously, `Series.ak.is_arkouda` could return misleading results by relying on `.index.values`, which is frequently a NumPy array even when the index is conceptually virtual or otherwise not truly Arkouda-backed. The updated logic checks `idx.array` (and MultiIndex levels) and better matches the meaning of “Arkouda-backed.”

## User-visible behavior changes

### `_pandas_index_to_ak`
- `pd.RangeIndex` is converted via server-side `ak_arange(...)` and wrapped in `ak.Index`.
- Defensive check: a `RangeIndex` with `step == 0` raises `ValueError`.

### `Series.ak.is_arkouda`
- Now returns `True` only when both data and index are Arkouda-backed.
- For `pd.MultiIndex`, requires each level to be Arkouda-backed.

## Implementation notes

- `_pandas_index_to_ak`:
  - handles `pd.MultiIndex` as before (delegates to `ak.MultiIndex`).
  - special-cases `pd.RangeIndex` to build values server-side using `ak_arange(stop)` for the common `(start=0, step=1)` case, otherwise `ak_arange(start, stop, step)`.

- `Series.ak.is_arkouda`:
  - early-exits `False` if the Series values are not an `ArkoudaExtensionArray`.
  - checks index backing via `.array` (and each MultiIndex level `.array`) using a defensive `getattr(..., None)`.

## Tests added

### Index accessor tests (`tests/pandas/extension/index_accessor.py`)
- `test_pandas_index_to_ak_rangeindex_default_roundtrips`
- `test_pandas_index_to_ak_rangeindex_nontrivial_roundtrips`
- `test_pandas_index_to_ak_rangeindex_negative_step_roundtrips_or_errors`

### Series accessor tests (`tests/pandas/extension/series_accessor.py`)
- `test_is_arkouda_true_for_to_ak_series_with_default_rangeindex`
- `test_is_arkouda_true_for_to_ak_series_with_nontrivial_index`
- `test_is_arkouda_true_for_to_ak_series_with_multiindex`

## How to validate

- Run the pandas-extension test suite (or at least the two modified test modules):
  - `pytest -q tests/pandas/extension/index_accessor.py`
  - `pytest -q tests/pandas/extension/series_accessor.py`

## Notes / follow-ups

- The negative-step RangeIndex test is intentionally permissive: if the backend does not support negative-step `arange`, the test accepts a clear exception. If negative steps *should* be supported, we can tighten the expectation to require round-tripping.

Closes #5428:  BUG: Pandas Series with dtype=ak Returns NumPy Index Values