### PR TITLE
Closes #5335:  Bug: pd.array fails on Arkouda-backed Categorical with dtype specified

### DIFF
--- a/tests/pandas/extension/arkouda_categorical_extension.py
+++ b/tests/pandas/extension/arkouda_categorical_extension.py
@@ -185,6 +185,30 @@ class TestArkoudaCategoricalExtension:
             assert np.array_equal(out_isna, expected)
             assert np.array_equal(out_isnull, expected)
 
+    def test_pd_array_with_dtype_on_ak_categorical_should_not_iterate(self):
+        """
+        Reproducer for: #5335 pd.array on an Arkouda-backed Categorical fails when dtype is provided.
+
+        Expected: should succeed (without iterating the Categorical) and produce an ak_int64
+        array representing the categorical codes.
+        """
+        cat = Categorical(ak.array(["a", "a", "b"]))
+
+        expected = cat.codes.to_ndarray()
+
+        result = pd.array(cat, dtype="ak_int64")
+
+        assert len(result) == len(expected)
+
+        if hasattr(result, "to_ndarray"):
+            got = result.to_ndarray()
+        elif hasattr(result, "to_numpy"):
+            got = result.to_numpy()
+        else:
+            got = np.asarray(result)
+
+        assert np.array_equal(got, expected)
+
 
 class TestArkoudaCategoricalAsType:
     def test_categorical_array_astype_category_stays_extension(


### PR DESCRIPTION
## Summary

Fixes an issue where calling `pd.array()` on an Arkouda-backed
`Categorical` with an explicit `dtype` would fail with a
`NotImplementedError`.

The failure occurred because `pd.array()` routed through
`ArkoudaArray._from_sequence`, which ultimately attempted to iterate
over the `Categorical`. Arkouda intentionally disallows iteration on
`Categorical` objects to prevent implicit data transfer from the server.

This change introduces a safe conversion path that: - Detects
Arkouda-backed `Categorical` inputs in `_from_sequence` - Extracts the
server-side categorical `codes` - Casts the codes if a `dtype` is
provided - Constructs the `ArkoudaArray` directly from the server-side
`pdarray`

This avoids iteration entirely and preserves server-side semantics.

------------------------------------------------------------------------

## Root Cause

`pd.array(cat, dtype="ak_int64")` triggered:

1.  `ArkoudaArray._from_sequence`
2.  `ak_array(scalars, ...)`
3.  `list(scalars)` inside `ak_array`
4.  `Categorical.__iter__`, which raises `NotImplementedError`

Since iteration is intentionally blocked for Categoricals, a direct
server-side conversion path was required.

------------------------------------------------------------------------

## Changes

### `_arkouda_array.py`

-   Added special-case handling for Arkouda `Categorical` in
    `_from_sequence`
-   Extract categorical codes directly
-   Cast codes when a dtype is provided
-   Return `cls(codes)` without invoking `ak_array`

### Tests

Added:

``` python
def test_pd_array_with_dtype_on_ak_categorical_should_not_iterate(self):
```

This verifies that:

-   `pd.array(cat, dtype="ak_int64")` succeeds
-   The resulting values match `cat.codes`
-   No iteration occurs

------------------------------------------------------------------------

## Behavioral Impact

Before: - `pd.array(Categorical(...), dtype=...)` raised
`NotImplementedError`

After: - Returns an `ArkoudaArray` backed by categorical codes - No
implicit data transfer - Fully server-side conversion path

------------------------------------------------------------------------

## Example

``` python
import arkouda as ak
import pandas as pd
from arkouda.pandas import Categorical

cat = Categorical(ak.array(["a", "a", "b"]))
arr = pd.array(cat, dtype="ak_int64")

# arr now contains the categorical codes
```




Closes #5335:  Bug: pd.array fails on Arkouda-backed Categorical with dtype specified