### PR TITLE
Closes #5307:  Replace _make_aggop with Explicit Aggregation Method Definitions

### DIFF
--- a/arkouda/pandas/dataframe.py
+++ b/arkouda/pandas/dataframe.py
@@ -83,7 +83,7 @@ from arkouda.numpy.pdarraysetops import concatenate, in1d, intersect1d
 from arkouda.numpy.sorting import argsort, coargsort
 from arkouda.numpy.sorting import sort as aksort
 from arkouda.numpy.timeclass import Datetime, Timedelta
-from arkouda.pandas.groupbyclass import GROUPBY_REDUCTION_TYPES, GroupBy, unique
+from arkouda.pandas.groupbyclass import GroupBy, unique
 from arkouda.pandas.index import Index, MultiIndex
 from arkouda.pandas.join import inner_join
 from arkouda.pandas.row import Row
@@ -133,13 +133,6 @@ def apply_if_callable(maybe_callable, obj, **kwargs):
     return maybe_callable
 
 
-def groupby_operators(cls):
-    for name in GROUPBY_REDUCTION_TYPES:
-        setattr(cls, name, cls._make_aggop(name))
-    return cls
-
-
-@groupby_operators
 class DataFrameGroupBy:
     """
     A DataFrame that has been grouped by a subset of columns.
@@ -214,58 +207,114 @@ class DataFrameGroupBy:
         else:
             return self.df.data[c][self.where_not_nan]
 
-    @classmethod
-    def _make_aggop(cls, opname):
+    def _aggregate(self, opname, colnames=None):
+        """
+        Aggregate the operation, with the grouped column(s) values as keys.
+
+        Parameters
+        ----------
+        colnames : (list of) str, default=None
+            Column name or list of column names to compute the aggregation over.
+
+        Returns
+        -------
+        DataFrame
+
+        """
         numerical_dtypes = [akfloat64, akint64, akuint64]
+        if colnames is None:
+            colnames = list(self.df.data.keys())
+        elif isinstance(colnames, str):
+            colnames = [colnames]
+        colnames = [
+            c
+            for c in colnames
+            if ((self.df.data[c].dtype in numerical_dtypes) or self.df.data[c].dtype == bigint)
+            and (
+                (isinstance(self.gb_key_names, str) and (c != self.gb_key_names))
+                or (isinstance(self.gb_key_names, list) and c not in self.gb_key_names)
+            )
+        ]
 
-        def aggop(self, colnames=None):
-            """
-            Aggregate the operation, with the grouped column(s) values as keys.
-
-            Parameters
-            ----------
-            colnames : (list of) str, default=None
-                Column name or list of column names to compute the aggregation over.
-
-            Returns
-            -------
-            DataFrame
-
-            """
-            if colnames is None:
-                colnames = list(self.df.data.keys())
-            elif isinstance(colnames, str):
-                colnames = [colnames]
-            colnames = [
-                c
-                for c in colnames
-                if ((self.df.data[c].dtype in numerical_dtypes) or self.df.data[c].dtype == bigint)
-                and (
-                    (isinstance(self.gb_key_names, str) and (c != self.gb_key_names))
-                    or (isinstance(self.gb_key_names, list) and c not in self.gb_key_names)
+        if isinstance(colnames, List):
+            if isinstance(self.gb_key_names, str):
+                return DataFrame(
+                    {c: self.gb.aggregate(self._get_df_col(c), opname)[1] for c in colnames},
+                    index=Index(self.gb.unique_keys, name=self.gb_key_names),
                 )
-            ]
+            elif isinstance(self.gb_key_names, list) and len(self.gb_key_names) == 1:
+                return DataFrame(
+                    {c: self.gb.aggregate(self._get_df_col(c), opname)[1] for c in colnames},
+                    index=Index(self.gb.unique_keys, name=self.gb_key_names[0]),
+                )
+            elif isinstance(self.gb_key_names, list):
+                column_dict = dict(zip(self.gb_key_names, self.unique_keys))
+                for c in colnames:
+                    column_dict[c] = self.gb.aggregate(self._get_df_col(c), opname)[1]
+                return DataFrame(column_dict)
+            else:
+                return None
 
-            if isinstance(colnames, List):
-                if isinstance(self.gb_key_names, str):
-                    return DataFrame(
-                        {c: self.gb.aggregate(self._get_df_col(c), opname)[1] for c in colnames},
-                        index=Index(self.gb.unique_keys, name=self.gb_key_names),
-                    )
-                elif isinstance(self.gb_key_names, list) and len(self.gb_key_names) == 1:
-                    return DataFrame(
-                        {c: self.gb.aggregate(self._get_df_col(c), opname)[1] for c in colnames},
-                        index=Index(self.gb.unique_keys, name=self.gb_key_names[0]),
-                    )
-                elif isinstance(self.gb_key_names, list):
-                    column_dict = dict(zip(self.gb_key_names, self.unique_keys))
-                    for c in colnames:
-                        column_dict[c] = self.gb.aggregate(self._get_df_col(c), opname)[1]
-                    return DataFrame(column_dict)
-                else:
-                    return None
+    def sum(self, colnames=None):
+        return self._aggregate("sum", colnames=colnames)
 
-        return aggop
+    def count(self, colnames=None):
+        return self._aggregate("count", colnames=colnames)
+
+    def prod(self, colnames=None):
+        return self._aggregate("prod", colnames=colnames)
+
+    def var(self, colnames=None):
+        return self._aggregate("var", colnames=colnames)
+
+    def std(self, colnames=None):
+        return self._aggregate("std", colnames=colnames)
+
+    def mean(self, colnames=None):
+        return self._aggregate("mean", colnames=colnames)
+
+    def median(self, colnames=None):
+        return self._aggregate("median", colnames=colnames)
+
+    def min(self, colnames=None):
+        return self._aggregate("min", colnames=colnames)
+
+    def max(self, colnames=None):
+        return self._aggregate("max", colnames=colnames)
+
+    def argmin(self, colnames=None):
+        return self._aggregate("argmin", colnames=colnames)
+
+    def argmax(self, colnames=None):
+        return self._aggregate("argmax", colnames=colnames)
+
+    def nunique(self, colnames=None):
+        return self._aggregate("nunique", colnames=colnames)
+
+    def any(self, colnames=None):
+        return self._aggregate("any", colnames=colnames)
+
+    def all(self, colnames=None):
+        return self._aggregate("all", colnames=colnames)
+
+    # Keywords: cannot do `def or(self, ...)` / `def and(self, ...)`
+    def or_(self, colnames=None):
+        return self._aggregate("or", colnames=colnames)
+
+    def and_(self, colnames=None):
+        return self._aggregate("and", colnames=colnames)
+
+    def xor(self, colnames=None):
+        return self._aggregate("xor", colnames=colnames)
+
+    def first(self, colnames=None):
+        return self._aggregate("first", colnames=colnames)
+
+    def mode(self, colnames=None):
+        return self._aggregate("mode", colnames=colnames)
+
+    def unique(self, colnames=None):
+        return self._aggregate("unique", colnames=colnames)
 
     def size(self, as_series=None, sort_index=True):
         """
@@ -662,7 +711,11 @@ class DataFrameGroupBy:
         return Series(data=data, index=self.df.index)
 
 
-@groupby_operators
+# Create keyword aliases so users can call gb.or(...) / gb.and(...)
+setattr(DataFrameGroupBy, "or", DataFrameGroupBy.or_)
+setattr(DataFrameGroupBy, "and", DataFrameGroupBy.and_)
+
+
 class DiffAggregate:
     """
     A column in a GroupBy that has been differenced.
@@ -673,13 +726,13 @@ class DiffAggregate:
     ----------
     gb : GroupBy
         GroupBy object, where the aggregation keys are values of column(s) of a dataframe.
-    values : Series
+    values : pdarray
         A column to compute the difference on.
 
     """
 
     gb: GroupBy
-    values: Series
+    values: pdarray
 
     def __init__(self, gb, series):
         from arkouda.numpy.pdarraycreation import zeros
@@ -695,13 +748,75 @@ class DiffAggregate:
         values[gb.segments] = np.nan
         self.values = values
 
-    @classmethod
-    def _make_aggop(cls, opname):
-        def aggop(self):
-            return Series(self.gb.aggregate(self.values, opname))
+    def _agg(self, opname: str):
+        """Apply a groupby aggregation to the diff values."""
+        return Series(self.gb.aggregate(self.values, opname))
 
-        return aggop
+    def sum(self):
+        return self._agg("sum")
 
+    def count(self):
+        return self._agg("count")
+
+    def prod(self):
+        return self._agg("prod")
+
+    def var(self):
+        return self._agg("var")
+
+    def std(self):
+        return self._agg("std")
+
+    def mean(self):
+        return self._agg("mean")
+
+    def median(self):
+        return self._agg("median")
+
+    def min(self):
+        return self._agg("min")
+
+    def max(self):
+        return self._agg("max")
+
+    def argmin(self):
+        return self._agg("argmin")
+
+    def argmax(self):
+        return self._agg("argmax")
+
+    def nunique(self):
+        return self._agg("nunique")
+
+    def any(self):
+        return self._agg("any")
+
+    def all(self):
+        return self._agg("all")
+
+    def xor(self):
+        return self._agg("xor")
+
+    def first(self):
+        return self._agg("first")
+
+    def mode(self):
+        return self._agg("mode")
+
+    def unique(self):
+        return self._agg("unique")
+
+    # Python keyword-safe definitions
+    def or_(self):
+        return self._agg("or")
+
+    def and_(self):
+        return self._agg("and")
+
+
+# Add keyword aliases so gb.diff(...).or() works
+setattr(DiffAggregate, "or", DiffAggregate.or_)
+setattr(DiffAggregate, "and", DiffAggregate.and_)
 
 """
 DataFrame structure based on Arkouda arrays.

--- a/arkouda/pandas/series.py
+++ b/arkouda/pandas/series.py
@@ -86,14 +86,7 @@ def unary_operators(cls) -> type:
     return cls
 
 
-def aggregation_operators(cls) -> type:
-    for name in ["max", "min", "mean", "sum", "std", "var", "argmax", "argmin", "prod"]:
-        setattr(cls, name, cls._make_aggop(name))
-    return cls
-
-
 @unary_operators
-@aggregation_operators
 @natural_binary_operators
 class Series:
     """
@@ -814,12 +807,32 @@ class Series:
 
         return unaryop
 
-    @classmethod
-    def _make_aggop(cls, name):
-        def aggop(self) -> Series:
-            return getattr(self.values, name)()
+    def max(self):
+        return self.values.max()
 
-        return aggop
+    def min(self):
+        return self.values.min()
+
+    def mean(self):
+        return self.values.mean()
+
+    def sum(self):
+        return self.values.sum()
+
+    def std(self):
+        return self.values.std()
+
+    def var(self):
+        return self.values.var()
+
+    def argmax(self):
+        return self.values.argmax()
+
+    def argmin(self):
+        return self.values.argmin()
+
+    def prod(self):
+        return self.values.prod()
 
     @typechecked
     def add(self, b: Series) -> Series:


### PR DESCRIPTION
# Refactor GroupBy and Series Aggregation to Explicit Methods

## Summary

This PR removes dynamic method generation for aggregation operations in:

-   `DataFrameGroupBy`
-   `DiffAggregate`
-   `Series`

and replaces them with explicitly defined methods.

The goal is to eliminate runtime method injection via decorators and
`_make_aggop` closures, resulting in:

-   Clearer API surface
-   Improved static analysis and IDE support
-   Easier reasoning about supported operations
-   Reduced metaprogramming complexity

------------------------------------------------------------------------

## Key Changes

### 1. Removed Dynamic GroupBy Operator Injection

Deleted:

-   `groupby_operators` decorator
-   `GROUPBY_REDUCTION_TYPES` dependency in `dataframe.py`
-   `_make_aggop` classmethod in `DataFrameGroupBy`
-   `_make_aggop` classmethod in `DiffAggregate`

Aggregation methods are now explicitly defined on both classes.

------------------------------------------------------------------------

### 2. Introduced `_aggregate` in `DataFrameGroupBy`

A shared `_aggregate(opname, colnames=None)` method now handles
aggregation logic, including:

-   Filtering numeric and bigint columns
-   Excluding groupby key columns
-   Returning correctly indexed `DataFrame` results

Explicit aggregation methods now include:

    sum, count, prod, var, std, mean, median,
    min, max, argmin, argmax, nunique,
    any, all, xor, first, mode, unique

Special handling is provided for keyword conflicts:

-   `or_()` → aliased to `or`
-   `and_()` → aliased to `and`

------------------------------------------------------------------------

### 3. Explicit Aggregations in `DiffAggregate`

Replaced closure-based `_make_aggop` with:

-   `_agg(opname)` helper
-   Explicit reduction methods for all supported groupby operations
-   Keyword-safe aliases for `or` and `and`

This makes the class fully declarative and avoids dynamic method
construction.

------------------------------------------------------------------------

### 4. Removed `aggregation_operators` Decorator from `Series`

Deleted:

-   `aggregation_operators` decorator
-   `_make_aggop` classmethod in `Series`

Explicitly implemented the following methods:

    max, min, mean, sum, std, var, argmax, argmin, prod

Each now directly delegates to `self.values.<op>()`.

------------------------------------------------------------------------

## Behavioral Impact

-   No functional change to supported operations
-   No change to public API names
-   Improved maintainability and readability
-   Eliminates closure-based runtime method injection

------------------------------------------------------------------------

## Why This Change?

Dynamic method injection made the API surface harder to:

-   Inspect
-   Debug
-   Statistically analyze
-   Navigate in IDEs

Explicit definitions make supported reductions obvious and future
modifications safer.

------------------------------------------------------------------------

## Testing

Existing groupby and series aggregation tests pass without modification.

No behavioral regressions expected.

Closes #5307:  Replace _make_aggop with Explicit Aggregation Method Definitions