### PR TITLE
Closes #5412:  ArkoudaSeriesAccessor.locate materializes to pandas

### DIFF
--- a/arkouda/pandas/extension/_series_accessor.py
+++ b/arkouda/pandas/extension/_series_accessor.py
@@ -44,6 +44,8 @@ from arkouda.pandas.extension import ArkoudaExtensionArray, ArkoudaIndexAccessor
 from arkouda.pandas.groupbyclass import GroupBy
 from arkouda.pandas.series import Series as ak_Series
 
+from ._index_accessor import _ak_index_to_pandas_no_copy
+
 
 # ---------------------------------------------------------------------------
 # Helpers: wrapping and unwrapping
@@ -454,9 +456,7 @@ class ArkoudaSeriesAccessor:
 
         out_ak = aks.locate(key)
 
-        # Wrap result into an Arkouda-backed pandas Series
-        # (keep the returned index/name from the legacy result).
-        idx = ArkoudaIndexAccessor(out_ak.index.to_pandas()).to_ak()  # preserve names/levels
+        idx = _ak_index_to_pandas_no_copy(out_ak.index)
         return _ak_array_to_pandas_series(out_ak.values, name=out_ak.name).set_axis(idx)
 
     @staticmethod


### PR DESCRIPTION
## Summary
This PR improves the efficiency of the Arkouda pandas extension `Series` accessor by avoiding an unnecessary round‑trip conversion when preserving the index returned from `locate`.

Previously, the implementation converted the Arkouda index to pandas and then wrapped it back into an Arkouda-backed index through `ArkoudaIndexAccessor`. This introduced redundant work and potential copies.

The new implementation replaces this logic with a direct helper that converts the Arkouda index to a pandas index **without copying**, preserving names and levels while reducing overhead.

## Change
Replace the following code:

```python
# Wrap result into an Arkouda-backed pandas Series
# (keep the returned index/name from the legacy result).
idx = ArkoudaIndexAccessor(out_ak.index.to_pandas()).to_ak()  # preserve names/levels
```

with:

```python
idx = _ak_index_to_pandas_no_copy(out_ak.index)
```

## Implementation Details
- Added import:
  ```python
  from ._index_accessor import _ak_index_to_pandas_no_copy
  ```
- Replaced the previous `ArkoudaIndexAccessor` conversion with the new helper function.
- The helper returns a pandas index view of the Arkouda index without forcing a copy.

## Benefits
- Eliminates unnecessary conversions.
- Reduces overhead in Series accessor operations.
- Simplifies the code path.
- Maintains index metadata (names and levels).

## Files Changed
- `arkouda/pandas/extension/_series_accessor.py`

Closes #5412:  ArkoudaSeriesAccessor.locate materializes to pandas