### PR TITLE
Closes #5460:  Fix comm_diagnostics docstring formatting

### DIFF
--- a/arkouda/comm_diagnostics.py
+++ b/arkouda/comm_diagnostics.py
@@ -1,16 +1,18 @@
 """
 Communication diagnostics and instrumentation utilities for Arkouda.
 
-This module provides tools to collect, reset, and report Chapel communication statistics
-used in Arkouda operations. It is useful for profiling and debugging distributed communication
-patterns in both blocking and non-blocking modes. The diagnostics can be queried at a per-locale
-level and printed as a markdown-formatted summary.
+This module provides tools to collect, reset, and report Chapel communication
+statistics used in Arkouda operations. It is useful for profiling and debugging
+distributed communication patterns in both blocking and non-blocking modes.
+Diagnostics can be queried at a per-locale level and printed as a
+markdown-formatted summary.
 
 Features
 --------
-- Start/stop/reset communication diagnostics tracking
+- Start, stop, and reset communication diagnostics tracking
 - Enable verbose reporting of communication events
-- Retrieve statistics on blocking/non-blocking gets, puts, AMOs, and remote execution
+- Retrieve statistics on blocking and non-blocking gets, puts, AMOs,
+  and remote execution
 - Inspect remote cache usage (hits, misses, prefetch, readahead)
 - Aggregate results into a DataFrame
 - Export markdown summary tables
@@ -18,47 +20,90 @@ Features
 Functions
 ---------
 start_comm_diagnostics()
+    Start communication diagnostics tracking.
+
 stop_comm_diagnostics()
+    Stop communication diagnostics tracking.
+
 reset_comm_diagnostics()
+    Reset all collected diagnostics.
+
 print_comm_diagnostics_table(print_empty_columns=False)
+    Print a markdown-formatted summary table of diagnostics.
+
 start_verbose_comm()
+    Enable verbose communication reporting.
+
 stop_verbose_comm()
+    Disable verbose communication reporting.
 
-Getters for specific metrics:
-- get_comm_diagnostics_{put, get, put_nb, get_nb, try_nb, wait_nb, amo}
-- get_comm_diagnostics_{execute_on, execute_on_fast, execute_on_nb}
-- get_comm_diagnostics_cache_{get_hits, get_misses, put_hits, put_misses,
-  num_prefetches, num_page_readaheads, prefetch_unused, prefetch_waited,
-  readahead_unused, readahead_waited}
+Getters for specific metrics
+----------------------------
+- get_comm_diagnostics_put
+- get_comm_diagnostics_get
+- get_comm_diagnostics_put_nb
+- get_comm_diagnostics_get_nb
+- get_comm_diagnostics_try_nb
+- get_comm_diagnostics_wait_nb
+- get_comm_diagnostics_amo
+- get_comm_diagnostics_execute_on
+- get_comm_diagnostics_execute_on_fast
+- get_comm_diagnostics_execute_on_nb
 
-get_comm_diagnostics() → DataFrame
+Cache diagnostics
+-----------------
+- get_comm_diagnostics_cache_get_hits
+- get_comm_diagnostics_cache_get_misses
+- get_comm_diagnostics_cache_put_hits
+- get_comm_diagnostics_cache_put_misses
+- get_comm_diagnostics_cache_num_prefetches
+- get_comm_diagnostics_cache_num_page_readaheads
+- get_comm_diagnostics_cache_prefetch_unused
+- get_comm_diagnostics_cache_prefetch_waited
+- get_comm_diagnostics_cache_readahead_unused
+- get_comm_diagnostics_cache_readahead_waited
+
+get_comm_diagnostics() -> DataFrame
     Collect all diagnostics into a single DataFrame.
 
 Examples
 --------
 >>> import arkouda as ak
 >>> import arkouda.comm_diagnostics as cd
+>>> from arkouda.comm_diagnostics import (
+...     start_comm_diagnostics,
+...     stop_comm_diagnostics,
+...     get_comm_diagnostics,
+...     print_comm_diagnostics_table,
+... )
 
->>> from arkouda.comm_diagnostics import start_comm_diagnostics, stop_comm_diagnostics, \
-get_comm_diagnostics, print_comm_diagnostics_table
 >>> start_comm_diagnostics()
 'commDiagnostics started.'
+
 >>> a = ak.randint(0, 100, 1_000_000)
 >>> b = ak.sort(a)
+
 >>> stop_comm_diagnostics()
 'commDiagnostics stopped.'
+
 >>> df = get_comm_diagnostics()
->>> df.columns
-Index(['put', 'get', 'put_nb', 'get_nb', 'try_nb', 'amo', 'execute_on', 'execute_on_fast', \
-'execute_on_nb', 'cache_get_hits', 'cache_get_misses', 'cache_put_hits', 'cache_put_misses', \
-'cache_num_prefetches', 'cache_num_page_readaheads', 'cache_prefetch_unused', \
-'cache_prefetch_waited', 'cache_readahead_unused', 'cache_readahead_waited', 'wait_nb'], dtype='<U0')
->>> df[["put","get"]]  # doctest: +SKIP
+
+>>> list(df.columns)
+['put', 'get', 'put_nb', 'get_nb', 'try_nb', 'amo',
+ 'execute_on', 'execute_on_fast', 'execute_on_nb',
+ 'cache_get_hits', 'cache_get_misses',
+ 'cache_put_hits', 'cache_put_misses',
+ 'cache_num_prefetches', 'cache_num_page_readaheads',
+ 'cache_prefetch_unused', 'cache_prefetch_waited',
+ 'cache_readahead_unused', 'cache_readahead_waited',
+ 'wait_nb']
+
+>>> df[["put", "get"]]  # doctest: +SKIP
    put  get
 0  162  118
 1  170  198
 2  170  198
-3  170  198 (4 rows x 2 columns)
+3  170  198  (4 rows x 2 columns)
 
 >>> print_comm_diagnostics_table()  # doctest: +SKIP
 +----+-------+-------+--------------+-----------------+
@@ -82,8 +127,8 @@ Printed tables and verbose messages appear in the server-side Chapel logs.
 
 See Also
 --------
-arkouda.pandas.dataframe.DataFrame, arkouda.core.client.generic_msg
-
+arkouda.pandas.dataframe.DataFrame
+arkouda.core.client.generic_msg
 """
 
 import sys


### PR DESCRIPTION
Fixes formatting errors in the `comm_diagnostics` docstring causing it to render incorrectly.

Closes #5460:  Fix comm_diagnostics docstring formatting