### PR TITLE
Fix logger usage in benchmark infrastructure

### DIFF
--- a/arkouda/core/logger.py
+++ b/arkouda/core/logger.py
@@ -1,7 +1,7 @@
 """
 Logging utilities for Arkouda client operations.
 
-The `arkouda.logger` module provides an extensible, configurable logging system tailored
+The `arkouda.core.logger` module provides an extensible, configurable logging system tailored
 to Arkouda's Python client. It supports structured logging using the standard `logging`
 module with added conveniences, such as type-safe log level enums, named handlers,
 and global verbosity toggles.

--- a/benchmark_v2/generate_field_lookup_map.py
+++ b/benchmark_v2/generate_field_lookup_map.py
@@ -36,7 +36,7 @@ import re
 # Aggregate operations explicitly defined
 import arkouda as ak
 
-from arkouda.logger import get_arkouda_logger
+from arkouda.core.logger import get_arkouda_logger
 
 
 BENCHMARK_DIR = os.path.dirname(__file__)


### PR DESCRIPTION
Fixes the logger usage in the benchmark infastructure, since arkouda.logger has moved