### PR TITLE
Fix mypy errors caused by new version of mypy

### DIFF
--- a/arkouda/numpy/pdarraysetops.py
+++ b/arkouda/numpy/pdarraysetops.py
@@ -515,13 +515,13 @@ def concatenate(
         if dtype_ == bigint:
             max_bit_list = []
             for a in arrays:
-                if a.dtype == bigint and isinstance(a, pdarray):
-                    if a.max_bits > 0:
+                if isinstance(a, pdarray) and a.dtype == bigint:
+                    if a.max_bits is not None and a.max_bits > 0:
                         max_bit_list.append(a.max_bits)
             # Should this be min or max?
             m_bits = -1 if len(max_bit_list) == 0 else min(max_bit_list)
             for a in arrays:
-                if a.dtype == bigint and isinstance(a, pdarray):
+                if isinstance(a, pdarray) and a.dtype == bigint:
                     a.max_bits = m_bits
         offsets = [0 for _ in range(len(arrays))]
         for i in range(1, len(arrays)):


### PR DESCRIPTION
Fixes mypy errors caused by new versions of mypy, which showed up as:

```
arkouda/numpy/pdarraysetops.py:519: error: Item "Strings" of "pdarray | Strings | Categorical" has no attribute "max_bits"  [union-attr]
arkouda/numpy/pdarraysetops.py:519: error: Item "Categorical" of "pdarray | Strings | Categorical" has no attribute "max_bits"  [union-attr]
arkouda/numpy/pdarraysetops.py:520: error: Item "Strings" of "pdarray | Strings | Categorical" has no attribute "max_bits"  [union-attr]
arkouda/numpy/pdarraysetops.py:520: error: Item "Categorical" of "pdarray | Strings | Categorical" has no attribute "max_bits"  [union-attr]
arkouda/numpy/pdarraysetops.py:525: error: Item "Strings" of "pdarray | Strings | Categorical" has no attribute "max_bits"  [union-attr]
arkouda/numpy/pdarraysetops.py:525: error: Item "Categorical" of "pdarray | Strings | Categorical" has no attribute "max_bits"  [union-attr]
```