### PR TITLE
Build arrow support with c++20

### DIFF
--- a/make/prologue/arrow_shims.mk
+++ b/make/prologue/arrow_shims.mk
@@ -37,15 +37,15 @@ compile-arrow-cpp:
 	$(MAKE) compile-arrow-util
 
 compile-arrow-write:
-	$(CHPL_CXX) -O3 -std=c++17 $(ARROW_PIC) -c $(ARROW_WRITE_CPP) -o $(ARROW_WRITE_O) \
+	$(CHPL_CXX) -O3 -std=c++20 $(ARROW_PIC) -c $(ARROW_WRITE_CPP) -o $(ARROW_WRITE_O) \
 		$(INCLUDE_FLAGS) $(ARROW_SANITIZE)
 
 compile-arrow-read:
-	$(CHPL_CXX) -O3 -std=c++17 $(ARROW_PIC) -c $(ARROW_READ_CPP) -o $(ARROW_READ_O) \
+	$(CHPL_CXX) -O3 -std=c++20 $(ARROW_PIC) -c $(ARROW_READ_CPP) -o $(ARROW_READ_O) \
 		$(INCLUDE_FLAGS) $(ARROW_SANITIZE)
 
 compile-arrow-util:
-	$(CHPL_CXX) -O3 -std=c++17 $(ARROW_PIC) -c $(ARROW_UTIL_CPP) -o $(ARROW_UTIL_O) \
+	$(CHPL_CXX) -O3 -std=c++20 $(ARROW_PIC) -c $(ARROW_UTIL_CPP) -o $(ARROW_UTIL_O) \
 		$(INCLUDE_FLAGS) $(ARROW_SANITIZE)
 
 $(ARROW_UTIL_O): $(ARROW_UTIL_CPP) $(ARROW_UTIL_H)


### PR DESCRIPTION
Switches to using C++20 to build arrow support code, which is required in arrow 22+

Switching to use C++20 works in all versions I tested (19, 20, 21, 22, 23, 24)