### PR TITLE
Do not allow using pandas 3.0.4

### DIFF
--- a/arkouda-env-dev.yml
+++ b/arkouda-env-dev.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python>=3.10
   - numpy>=2.0
-  - pandas>=1.4.0,!=2.2.0
+  - pandas>=1.4.0,!=2.2.0,!=3.0.4
   - pyzmq>=20.0.0
   - tabulate
   - pyfiglet

--- a/arkouda-env.yml
+++ b/arkouda-env.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python>=3.10
   - numpy>=2.0
-  - pandas>=1.4.0,!=2.2.0
+  - pandas>=1.4.0,!=2.2.0,!=3.0.4
   - pyzmq>=20.0.0
   - tabulate
   - pyfiglet

--- a/docker/almalinux-with-arkouda-deps/requirements.txt
+++ b/docker/almalinux-with-arkouda-deps/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.24.1,<2.0
-pandas>=1.4.0,!=2.2.0
+pandas>=1.4.0,!=2.2.0,!=3.0.4
 pyzmq>=20.0.0
 typeguard==2.10.0
 tabulate

--- a/pydoc/requirements.txt
+++ b/pydoc/requirements.txt
@@ -1,7 +1,7 @@
 # dependencies
 python>=3.10
 numpy>=2.0
-pandas>=1.4.0,!=2.2.0
+pandas>=1.4.0,!=2.2.0,!=3.0.4
 pyzmq>=20.0.0
 typeguard==2.10.0
 tabulate

--- a/pydoc/setup/REQUIREMENTS.md
+++ b/pydoc/setup/REQUIREMENTS.md
@@ -19,7 +19,7 @@ The following python packages are required by the Arkouda client package.
 
 - `python>=3.10`
 - `numpy>=1.24.1,<2.0`
-- `pandas>=1.4.0,!=2.2.0`
+- `pandas>=1.4.0,!=2.2.0,!=3.0.4`
 - `pyzmq>=20.0.0`
 - `typeguard==2.10.0`
 - `tabulate`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ keywords = ["HPC","workflow","exploratory","analysis","parallel","distribute","a
 
 dependencies = [
   "numpy>=2.0",
-  "pandas>=1.4.0,!=2.2.0",
+  "pandas>=1.4.0,!=2.2.0,!=3.0.4",
   "pyzmq>=20.0.0",
   "typeguard==2.10.0",
   "tabulate",


### PR DESCRIPTION
Prevents pandas 3.0.4 from being used at all, since it can segfault with dates

Possibly related pandas issues
[BUG: Segfault constructing pd.Timedelta with numpy 2.3.x/2.4.x on Python 3.14 (pandas 3.0.4) · Issue #66083 · pandas-dev/pandas · GitHub](https://github.com/pandas-dev/pandas/issues/66083)
[BUG: pd.to_datetime segfaults on Series of duplicated ISO8601 strings (regression in 3.0.4) · Issue #66085 · pandas-dev/pandas · GitHub](https://github.com/pandas-dev/pandas/issues/66085)
[BUG: Segfault constructing pd.Timedelta on Python 3.14 (pandas 3.0.4, regression from 3.0.3) · Issue #66086 · pandas-dev/pandas · GitHub](https://github.com/pandas-dev/pandas/issues/66086)