### PR TITLE
Add CI for Chapel 2.9.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        chpl-version: ['2.8.0']
+        chpl-version: ['2.9.0']
     container:
       image: ghcr.io/bears-r-us/ubuntu-with-arkouda-deps-chpl-${{ matrix.chpl-version }}:latest
       credentials:
@@ -79,7 +79,7 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/bears-r-us/ubuntu-with-arkouda-deps-chpl-2.8.0:latest
+      image: ghcr.io/bears-r-us/ubuntu-with-arkouda-deps-chpl-2.9.0:latest
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
@@ -117,7 +117,7 @@ jobs:
   flake8:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/bears-r-us/ubuntu-with-arkouda-deps-chpl-2.8.0:latest
+      image: ghcr.io/bears-r-us/ubuntu-with-arkouda-deps-chpl-2.9.0:latest
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
@@ -152,9 +152,9 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     env:
-      CHPL_HOME: /opt/chapel-2.8.0
+      CHPL_HOME: /opt/chapel-2.9.0
     container:
-      image: ghcr.io/bears-r-us/ubuntu-with-arkouda-deps-chpl-2.8.0:latest
+      image: ghcr.io/bears-r-us/ubuntu-with-arkouda-deps-chpl-2.9.0:latest
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        chpl-version: ['2.8.0']
+        chpl-version: ['2.9.0']
     container:
       image: ghcr.io/bears-r-us/ubuntu-with-arkouda-deps-chpl-${{ matrix.chpl-version }}:latest
       credentials:
@@ -396,7 +396,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        chpl-version: ['2.5.0','2.6.0','2.7.0','2.8.0']
+        chpl-version: ['2.5.0','2.6.0','2.7.0','2.8.0','2.9.0']
     container:
       image: ghcr.io/bears-r-us/ubuntu-with-arkouda-deps-chpl-${{ matrix.chpl-version }}:latest
       credentials:
@@ -437,7 +437,7 @@ jobs:
       ARKOUDA_CONFIG_FILE: .configs/MultiDimTestServerModules.cfg
     strategy:
       matrix:
-        chpl-version: ['2.8.0']
+        chpl-version: ['2.9.0']
       max-parallel: 3
     container:
       image: ghcr.io/bears-r-us/ubuntu-with-arkouda-deps-chpl-${{ matrix.chpl-version }}:latest
@@ -487,7 +487,7 @@ jobs:
 #    runs-on: ubuntu-latest
 #    strategy:
 #      matrix:
-#        chpl-version: ['2.8.0']
+#        chpl-version: ['2.9.0']
 #      max-parallel: 3
 #    container:
 #      image: ghcr.io/bears-r-us/ubuntu-with-arkouda-deps-chpl-${{ matrix.chpl-version }}:latest
@@ -571,7 +571,7 @@ jobs:
       CHPL_RT_NUM_THREADS_PER_LOCALE: 2
     strategy:
       matrix:
-        chpl-version: ['2.8.0']
+        chpl-version: ['2.9.0']
     container:
       image: ghcr.io/bears-r-us/ubuntu-with-arkouda-deps-chpl-${{ matrix.chpl-version }}:latest
       credentials:
@@ -620,7 +620,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        chpl-version: ['2.8.0']
+        chpl-version: ['2.9.0']
     container:
       image: ghcr.io/bears-r-us/ubuntu-with-arkouda-deps-chpl-${{ matrix.chpl-version }}:latest
       credentials:


### PR DESCRIPTION
Adds CI for Chapel 2.9.0. 

Requires https://github.com/Bears-R-Us/arkouda/pull/5499