### PR TITLE
Remove xfail from now passing tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,9 @@ log_file = .pytest/pytest.log
 log_file_level = DEBUG
 log_file_format = %(asctime)s [%(levelname)s] %(message)s
 
+; raise an error if an xfail test passes (xpass)
+xfail_strict=true
+
 #   Set the timeout to 30 minutes:
 timeout = 1800
 #   Set timeout_method to 'signal' on Unix

--- a/pytest.opts.ini
+++ b/pytest.opts.ini
@@ -1,5 +1,8 @@
 [pytest]
 
+; raise an error if an xfail test passes (xpass)
+xfail_strict=true
+
 # pytest configuration file for tests/optioned-server
 
 filterwarnings =

--- a/tests/numpy/alignment_verification/char_alignment.py
+++ b/tests/numpy/alignment_verification/char_alignment.py
@@ -37,15 +37,16 @@ class TestArkoudaNumpyCharAlignment:
         with pytest.raises(TypeError, match=r"input to isnumeric must be Strings"):
             ak_char.isnumeric(["1", "2", "3"])
 
-    @pytest.mark.xfail(
-        reason="Known mismatch: empty string treated as numeric in Arkouda "
-        "(should be False like NumPy). Issue #5243"
-    )
     @pytest.mark.parametrize(
         "py_list",
         [
             ["Strings 0", "Strings 1", "Strings 2", "120", "121", "122"],
-            ["", "0", "00", "  ", "3.14", "-1", "+2", "１２３", "٣", "二"],  # noqa: RUF001
+            pytest.param(
+                ["", "0", "00", "  ", "3.14", "-1", "+2", "１２３", "٣", "二"],  # noqa: RUF001
+                marks=pytest.mark.xfail(
+                    reason="Known mismatch: empty string treated as numeric in Arkouda (should be False like NumPy). Issue #5243"
+                ),
+            ),
             ["1e3", "⅕", "²", "₇", "2³₇", "2³x₇", "٣٤٥", "१२३"],
         ],
     )

--- a/tests/numpy/alignment_verification/char_alignment.py
+++ b/tests/numpy/alignment_verification/char_alignment.py
@@ -44,7 +44,8 @@ class TestArkoudaNumpyCharAlignment:
             pytest.param(
                 ["", "0", "00", "  ", "3.14", "-1", "+2", "１２３", "٣", "二"],  # noqa: RUF001
                 marks=pytest.mark.xfail(
-                    reason="Known mismatch: empty string treated as numeric in Arkouda (should be False like NumPy). Issue #5243"
+                    reason="Known mismatch: empty string treated as numeric in Arkouda "
+                    + "(should be False like NumPy). Issue #5243"
                 ),
             ),
             ["1e3", "⅕", "²", "₇", "2³₇", "2³x₇", "٣٤٥", "१२३"],

--- a/tests/numpy/alignment_verification/operators_alignment.py
+++ b/tests/numpy/alignment_verification/operators_alignment.py
@@ -66,9 +66,9 @@ def _rand_array(dtype, nonzero: bool = False, nonneg: bool = False, seed=SEED):
         data = rng.uniform(low, high, size=N)
         if nonzero:
             # push away from zero to avoid div-by-zero in denominator cases
-            data = np.where(np.abs(data) < 1e-6, 1.0, data)
+            data = ak.where(ak.abs(data) < 1e-6, 1.0, data)
         if nonneg:
-            data = np.abs(data)
+            data = ak.abs(data)
         return ak.array(data)
 
     # Integer types
@@ -76,7 +76,7 @@ def _rand_array(dtype, nonzero: bool = False, nonneg: bool = False, seed=SEED):
         low, high = (0, 1 << 31)
         data = rng.integers(low, high, size=N, dtype=np.uint64)
         if nonzero:
-            data = np.where(data == 0, 1, data)
+            data = ak.where(data == 0, 1, data)
         if nonneg:
             # already nonnegative
             pass
@@ -86,9 +86,9 @@ def _rand_array(dtype, nonzero: bool = False, nonneg: bool = False, seed=SEED):
         low, high = (-1 << 31, 1 << 31)
         data = rng.integers(low, high, size=N, dtype=np.int64)
         if nonzero:
-            data = np.where(data == 0, 1, data)
+            data = ak.where(data == 0, 1, data)
         if nonneg:
-            data = np.abs(data)
+            data = ak.abs(data)
         return ak.array(data)
 
     raise NotImplementedError(f"Unhandled dtype {dtype}")
@@ -102,10 +102,11 @@ def _numpy_equivalent(a: ak.pdarray):
 
 
 # --- Parametrized binary op tests (array ⊗ array) ---
-@pytest.mark.xfail(reason="Requires ak.minimum (#5118) and bug fix for rshift (#5115)")
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("name,fn", BINARY_OPS)
 def test_binary_ops_array_array_alignment(dtype, name, fn):
+    if name in {"mod", "rshift"}:
+        pytest.xfail(reason="Requires bug fix for mod (#5118) and bug fix for rshift (#5115)")
     if dtype is ak.bool_ and name in {"add", "sub", "mul", "truediv", "floordiv", "mod", "pow"}:
         pytest.skip(f"NumPy does not support {name} for boolean dtype")
     # Skip invalid dtype/op combinations
@@ -146,10 +147,12 @@ def test_binary_ops_array_array_alignment(dtype, name, fn):
 
 
 # --- Scalar broadcasting (array ⊗ scalar and scalar ⊗ array) ---
-@pytest.mark.xfail(reason="Requires bug fixes for floordiv, mod, pow (#5113, #5112, #5114)")
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("name,fn", BINARY_OPS)
 def test_binary_ops_array_scalar_alignment(dtype, name, fn):
+    if name in {"mod", "pow"}:
+        pytest.xfail(reason="Requires bug fixes for mod and pow (#5112, #5114)")
+
     # Arithmetic on booleans is not supported by NumPy
     if dtype is ak.bool_ and name in {"add", "sub", "mul", "truediv", "floordiv", "mod", "pow"}:
         pytest.skip(f"NumPy does not support {name} for boolean dtype")
@@ -211,7 +214,6 @@ def test_comparison_ops_alignment(dtype, name, fn):
 
 
 # --- Unary operator alignment ---
-@pytest.mark.xfail(reason="Requires pdarray.__pos__ (#5116) and bug fixes in __neg__ (#5117, #5119)")
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("name,fn", UNARY_OPS)
 def test_unary_ops_alignment(dtype, name, fn):

--- a/tests/numpy/alignment_verification/operators_alignment.py
+++ b/tests/numpy/alignment_verification/operators_alignment.py
@@ -107,6 +107,8 @@ def _numpy_equivalent(a: ak.pdarray):
 def test_binary_ops_array_array_alignment(dtype, name, fn):
     if name in {"mod", "rshift"}:
         pytest.xfail(reason="Requires bug fix for mod (#5118) and bug fix for rshift (#5115)")
+    if name in {"pow"}:
+        pytest.xfail(reason="pow can be innacurate in CI")
     if dtype is ak.bool_ and name in {"add", "sub", "mul", "truediv", "floordiv", "mod", "pow"}:
         pytest.skip(f"NumPy does not support {name} for boolean dtype")
     # Skip invalid dtype/op combinations

--- a/tests/numpy/alignment_verification/random_generator_alignment_test.py
+++ b/tests/numpy/alignment_verification/random_generator_alignment_test.py
@@ -98,10 +98,6 @@ def test_integers_dtype_and_bounds(dtype):
     assert (out <= 19).all()
 
 
-@pytest.mark.xfail(
-    reason="Bug: integers dtype guard uses `is` after dtype normalization; "
-    "float dtypes not rejected. Issue #5298."
-)
 def test_integers_rejects_float64_dtype():
     rng = ak.random.default_rng(SEED)
     with pytest.raises(TypeError):

--- a/tests/pandas/extension/arkouda_array_extension_inherited.py
+++ b/tests/pandas/extension/arkouda_array_extension_inherited.py
@@ -403,18 +403,26 @@ class TestArkoudaArrayHashInherited:
         owner = next(base for base in ArkoudaArray.mro() if "_hash_pandas_object" in base.__dict__)
         assert owner is PandasExtensionArray
 
-    @pytest.mark.xfail(reason=("Fails because Depends on ArkoudaCategorical.to_factorize_view #5101"))
     @pytest.mark.parametrize(
         "EA, make_data",
         [
             # numeric EA
             (ArkoudaArray, lambda: ak.array([10, 20, 10, 30])),
             # string EA
-            (ArkoudaStringArray, lambda: ak.array(["a", "b", "a", "c"])),
+            pytest.param(
+                ArkoudaStringArray,
+                lambda: ak.array(["a", "b", "a", "c"]),
+                marks=pytest.mark.xfail(
+                    reason="Fails because ArkoudaCategorical.to_factorize_view #5101"
+                ),
+            ),
             # categorical EA
-            (
+            pytest.param(
                 ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["x", "y", "x", "z"])),
+                marks=pytest.mark.xfail(
+                    reason="Fails because ArkoudaCategorical.to_factorize_view #5101"
+                ),
             ),
         ],
     )
@@ -447,15 +455,23 @@ class TestArkoudaArrayHashInherited:
             # Each logical value should map to a single hash
             assert len(hset) == 1, f"value {v!r} had multiple hashes: {hset}"
 
-    @pytest.mark.xfail(reason=("Fails because Depends on ArkoudaCategorical.to_factorize_view #5101"))
     @pytest.mark.parametrize(
         "EA, make_data",
         [
             (ArkoudaArray, lambda: ak.array([1, 2, 3, 4])),
-            (ArkoudaStringArray, lambda: ak.array(["a", "b", "c", "d"])),
-            (
+            pytest.param(
+                ArkoudaStringArray,
+                lambda: ak.array(["a", "b", "c", "d"]),
+                marks=pytest.mark.xfail(
+                    reason="Fails because ArkoudaCategorical.to_factorize_view #5101"
+                ),
+            ),
+            pytest.param(
                 ArkoudaCategorical,
                 lambda: ak.Categorical(ak.array(["p", "q", "r", "q"])),
+                marks=pytest.mark.xfail(
+                    reason="Fails because ArkoudaCategorical.to_factorize_view #5101"
+                ),
             ),
         ],
     )
@@ -1625,13 +1641,6 @@ class TestArkoudaArrayMap:
             np.asarray(expected),
         )
 
-    @pytest.mark.xfail(
-        reason=(
-            "ArkoudaCategorical.map currently fails because "
-            "Index.astype(object, copy=...) calls ArkoudaCategorical.astype "
-            "with an unsupported 'copy' keyword."
-        )
-    )
     def test_map_dict_categorical_not_supported_yet(self):
         """
         Document current failure mode for ArkoudaCategorical.map with dict
@@ -1672,12 +1681,6 @@ class TestArkoudaArrayMap:
             np.asarray(expected),
         )
 
-    @pytest.mark.xfail(
-        reason=(
-            "ArkoudaCategorical.map with callable is blocked by the same "
-            "astype(copy=...) issue as the dict-mapping case."
-        )
-    )
     def test_map_callable_categorical_not_supported_yet(self):
         """
         Current behavior: callable mapping on ArkoudaCategorical also
@@ -2582,7 +2585,6 @@ class TestArkoudaArrayUnique:
     # String and Categorical examples
     # ------------------------------------------------------------------
 
-    @pytest.mark.xfail(reason=("Fails because ArkoudaCategorical.astype() is not yet implemented."))
     @pytest.mark.parametrize(
         "EA, make_data, pandas_constructor",
         [
@@ -2621,7 +2623,6 @@ class TestArkoudaArrayUnique:
 
         assert result_list == expected_list
 
-    @pytest.mark.xfail(reason=("Fails because ArkoudaCategorical.astype() is not yet implemented."))
     @pytest.mark.parametrize(
         "EA, values",
         [
@@ -2645,7 +2646,6 @@ class TestArkoudaArrayUnique:
 
         assert result_list == [values[0]]
 
-    @pytest.mark.xfail(reason=("Fails because ArkoudaCategorical.astype() is not yet implemented."))
     @pytest.mark.parametrize(
         "EA, values",
         [


### PR DESCRIPTION
It was recently noticed that the arkouda server runs with many tests that are marked as `xfail` but those tests actually do pass now. This PR removes the xfail markers for them