### PR TITLE
Bundle of performance improvements

### DIFF
--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -130,22 +130,56 @@ module IndexingMsg
     }
 
     @arkouda.registerCommand("[slice]")
-    proc sliceIndex(const ref array: [?d] ?t, starts: d.rank*int, stops: d.rank*int, strides: d.rank*int, max_bits: int): SymEntry(t, d.rank) throws {
-        var rngs: d.rank*range(strides=strideKind.any),
-            outSizes: d.rank*int;
-        for param dim in 0..<d.rank {
-            rngs[dim] = convertSlice(starts[dim], stops[dim], strides[dim]);
-            outSizes[dim] = rngs[dim].size;
+    proc sliceIndex(const ref array: [?d] ?t,
+                    starts: d.rank*int, stops: d.rank*int, strides: d.rank*int,
+                    max_bits: int): SymEntry(t, d.rank) throws {
+        inline proc allEq(x, ys) {
+            var r = true;
+            for param i in 0..<x.size do r &= x[i] == ys;
+            return r;
         }
+        if allEq(strides, 1) {
+            // If all strides are 1, we can use strideKind.one, which is more efficient.
+            // we can also use whole-array ops, which when not strided are faster
+            var rngs: d.rank*range(strides=strideKind.one),
+                outSizes: d.rank*int;
+            for param dim in 0..<d.rank {
+                rngs[dim] = starts[dim]..stops[dim]-1;
+                outSizes[dim] = rngs[dim].size;
+            }
 
-        const sliceDom = makeDistDom({(...rngs)});
-        var arraySlice = makeDistArray((...outSizes), t);
+            const sliceDom = {(...rngs)}; // we don't need a distributed dom for this
+            var arraySlice = makeDistArray((...outSizes), t);
+            arraySlice = array[{(...rngs)}];
+            return new shared SymEntry(arraySlice, max_bits=max_bits);
+        } else if allEq(strides, -1) {
+            // same as above but with strideKind.negOne
+            var rngs: d.rank*range(strides=strideKind.negOne),
+                outSizes: d.rank*int;
+            for param dim in 0..<d.rank {
+                rngs[dim] = stops[dim]-1..starts[dim] by -1;
+                outSizes[dim] = rngs[dim].size;
+            }
 
-        forall (elt,j) in zip(arraySlice, sliceDom) with (var agg = newSrcAggregator(t)) {
-            agg.copy(elt,array[j]);
+            const sliceDom = {(...rngs)}; // we don't need a distributed dom for this
+            var arraySlice = makeDistArray((...outSizes), t);
+            arraySlice = array[{(...rngs)}];
+            return new shared SymEntry(arraySlice, max_bits=max_bits);
+        } else {
+            var rngs: d.rank*range(strides=strideKind.any),
+                outSizes: d.rank*int;
+            for param dim in 0..<d.rank {
+                rngs[dim] = convertSlice(starts[dim], stops[dim], strides[dim]);
+                outSizes[dim] = rngs[dim].size;
+            }
+
+            const sliceDom = {(...rngs)}; // we don't need a distributed dom for this
+            var arraySlice = makeDistArray((...outSizes), t);
+            forall (elt,j) in zip(arraySlice, sliceDom) with (var agg = newSrcAggregator(t)) {
+                agg.copy(elt,array[j]);
+            }
+            return new shared SymEntry(arraySlice, max_bits=max_bits);
         }
-
-        return new shared SymEntry(arraySlice, max_bits=max_bits);
     }
 
     /*

--- a/src/IndexingMsg.chpl
+++ b/src/IndexingMsg.chpl
@@ -157,7 +157,7 @@ module IndexingMsg
             var rngs: d.rank*range(strides=strideKind.negOne),
                 outSizes: d.rank*int;
             for param dim in 0..<d.rank {
-                rngs[dim] = stops[dim]-1..starts[dim] by -1;
+                rngs[dim] = stops[dim]+1..starts[dim] by -1;
                 outSizes[dim] = rngs[dim].size;
             }
 

--- a/src/UtilMsg.chpl
+++ b/src/UtilMsg.chpl
@@ -59,7 +59,7 @@ module UtilMsg {
       var y = makeDistArray(outDom, t);
       for axisSliceIdx in domOffAxis(d, axis) {
         const slice = domOnAxis(outDom, tuplify(axisSliceIdx), axis);
-        for i in slice {
+        forall i in slice {
           var idxp = tuplify(i);
           idxp[axis] += 1;
           y[i] = (x[idxp] - x[i]): t;
@@ -75,10 +75,9 @@ module UtilMsg {
           d1 <=> d2;
           const diffSubDom = subDomain(x.shape, axis, m);
 
-          forall axisSliceIdx in domOffAxis(d, axis) {
+          for axisSliceIdx in domOffAxis(d, axis) {
             const slice = domOnAxis(diffSubDom, tuplify(axisSliceIdx), axis);
-
-            for i in slice {
+            forall i in slice {
               var idxp = tuplify(i);
               idxp[axis] += 1;
               d1[i] = (d2[idxp] - d2[i]): t;


### PR DESCRIPTION
A bundle of performance improvements motivated by analytics workflow

* improved the parallelization of `diff`, 1.5x speedup on micro benchmark using a COMM=none server on my mac.
    * it looks like previous refactors accidentally removed the parallelization, so I added it back
    * I also found that the outer loop is usually a single trip count, so that being parallel is not very useful. the inner loop being parallel is much faster (at least in my benchmarks)
* improved the performance of array slices, up to a 2x speedup on a micro benchmark using a COMM=none server on my mac
    * by specializing for non-strided ranges and using whole-array operations, we take advantage of builtin chapel optimizations for slicing